### PR TITLE
[LWDM] feat(coin-aleo): implement getAccountInfo returning scan status

### DIFF
--- a/.changeset/smooth-knives-whisper.md
+++ b/.changeset/smooth-knives-whisper.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+Aleo now exposes its record-scanner scan status through `getAccountInfo`, so consumers can read sync progress from the shared API instead of digging into coin-module internals. Returns `{ type: "none" }` when the account isn't enrolled yet.

--- a/libs/coin-modules/coin-aleo/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.integ.test.ts
@@ -14,6 +14,16 @@ import { setupCalStore } from "../__tests__/helpers/cal";
 import { getPristineAccount } from "../__tests__/helpers/account";
 import type { AleoAccountInfo, AleoContext } from "../types";
 
+type AleoApi = ReturnType<typeof createApi>;
+
+function requireGetAccountInfo(api: AleoApi): NonNullable<AleoApi["getAccountInfo"]> {
+  const { getAccountInfo } = api;
+  if (!getAccountInfo) {
+    throw new Error("guard: api.getAccountInfo is not implemented");
+  }
+  return getAccountInfo;
+}
+
 async function withPrivacyContext(context: AleoContext, viewKey: string): Promise<AleoContext> {
   const config = await context.config();
   const provableApi = await accessProvableApi({
@@ -34,11 +44,13 @@ describe("createApi", () => {
     logger: () => {},
   };
   let emptyAddress: string;
+  let privacyContext: AleoContext;
 
   beforeAll(async () => {
     setupCalStore();
     const pristineAccount = await getPristineAccount();
     emptyAddress = pristineAccount.address;
+    privacyContext = await withPrivacyContext(context, testnetViewKey);
   });
 
   describe("estimateFees", () => {
@@ -230,13 +242,9 @@ describe("createApi", () => {
 
   describe("getAccountInfo", () => {
     it("returns the aleo scan status for a registered provableId", async () => {
-      // getAccountInfo never registers; withPrivacyContext mints a provableId to exercise the read side.
-      const contextWithPrivacy = await withPrivacyContext(context, testnetViewKey);
+      const getAccountInfo = requireGetAccountInfo(api);
 
-      const info = (await api.getAccountInfo!(
-        contextWithPrivacy,
-        testnetAddress,
-      )) as AleoAccountInfo;
+      const info = (await getAccountInfo(privacyContext, testnetAddress)) as AleoAccountInfo;
 
       expect(info.type).toBe("aleo");
       expect(typeof info.synced).toBe("boolean");
@@ -247,13 +255,14 @@ describe("createApi", () => {
     });
 
     it("throws AleoApiConfigurationResetError for an unknown provableId", async () => {
+      const getAccountInfo = requireGetAccountInfo(api);
       const contextWithUnknownProvableId: AleoContext = {
         ...context,
         provableId: "00000000-0000-0000-0000-000000000000",
       };
 
       await expect(
-        api.getAccountInfo!(contextWithUnknownProvableId, testnetAddress),
+        getAccountInfo(contextWithUnknownProvableId, testnetAddress),
       ).rejects.toBeInstanceOf(AleoApiConfigurationResetError);
     });
   });

--- a/libs/coin-modules/coin-aleo/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.integ.test.ts
@@ -1,15 +1,31 @@
 import invariant from "invariant";
 import { createApi } from "../api";
 import { TRANSACTION_TYPE } from "../constants";
+import { AleoApiConfigurationResetError } from "../errors";
+import { accessProvableApi } from "../network/utils";
 import { getTestnetIntegConfig } from "../__tests__/fixtures/config.fixture";
 import {
   referenceFailedTransferPublicTx,
   referenceTransferPublicTx,
   testnetAddress,
+  testnetViewKey,
 } from "../__tests__/fixtures/api.fixture";
 import { setupCalStore } from "../__tests__/helpers/cal";
 import { getPristineAccount } from "../__tests__/helpers/account";
-import type { AleoContext } from "../types";
+import type { AleoAccountInfo, AleoContext } from "../types";
+
+async function withPrivacyContext(context: AleoContext, viewKey: string): Promise<AleoContext> {
+  const config = await context.config();
+  const provableApi = await accessProvableApi({
+    config,
+    viewKey,
+    provableApi: null,
+  });
+
+  invariant(provableApi.uuid, "guard: missing provableApi.uuid");
+
+  return { ...context, provableId: provableApi.uuid, viewKey };
+}
 
 describe("createApi", () => {
   const api = createApi("aleo_testnet");
@@ -209,6 +225,36 @@ describe("createApi", () => {
         name: "LedgerAPI4xx",
         status: 404,
       });
+    });
+  });
+
+  describe("getAccountInfo", () => {
+    it("returns the aleo scan status for a registered provableId", async () => {
+      // getAccountInfo never registers; withPrivacyContext mints a provableId to exercise the read side.
+      const contextWithPrivacy = await withPrivacyContext(context, testnetViewKey);
+
+      const info = (await api.getAccountInfo!(
+        contextWithPrivacy,
+        testnetAddress,
+      )) as AleoAccountInfo;
+
+      expect(info.type).toBe("aleo");
+      expect(typeof info.synced).toBe("boolean");
+      expect(typeof info.percentage).toBe("number");
+      expect(typeof info.startHeight).toBe("number");
+      expect(typeof info.scannedHeight).toBe("number");
+      expect(info.scannedHeight).toBeGreaterThanOrEqual(info.startHeight);
+    });
+
+    it("throws AleoApiConfigurationResetError for an unknown provableId", async () => {
+      const contextWithUnknownProvableId: AleoContext = {
+        ...context,
+        provableId: "00000000-0000-0000-0000-000000000000",
+      };
+
+      await expect(
+        api.getAccountInfo!(contextWithUnknownProvableId, testnetAddress),
+      ).rejects.toBeInstanceOf(AleoApiConfigurationResetError);
     });
   });
 });

--- a/libs/coin-modules/coin-aleo/src/api/index.test.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.test.ts
@@ -5,7 +5,14 @@ import type {
 } from "@ledgerhq/coin-module-framework/api/types";
 import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
 import { getMockedCoinFrameworkOperation } from "../__tests__/fixtures/operation.fixture";
-import { craftTransaction, estimateFees, getBalance, lastBlock, listOperations } from "../logic";
+import {
+  craftTransaction,
+  estimateFees,
+  getAccountInfo,
+  getBalance,
+  lastBlock,
+  listOperations,
+} from "../logic";
 import { getTransactionType } from "../logic/utils";
 import type { AleoContext, AleoTransactionIntentData } from "../types";
 import { createApi } from "./index";
@@ -22,6 +29,7 @@ describe("createApi", () => {
   const mockOperation = getMockedCoinFrameworkOperation();
   const mockedCraftTransaction = jest.mocked(craftTransaction);
   const mockedEstimateFees = jest.mocked(estimateFees);
+  const mockedGetAccountInfo = jest.mocked(getAccountInfo);
   const mockedGetBalance = jest.mocked(getBalance);
   const mockedLastBlock = jest.mocked(lastBlock);
   const mockedListOperations = jest.mocked(listOperations);
@@ -69,6 +77,48 @@ describe("createApi", () => {
     expect(api.lastBlock).toBeInstanceOf(Function);
     expect(api.listOperations).toBeInstanceOf(Function);
     expect(api.craftTransactionData).toBeInstanceOf(Function);
+    expect(api.getAccountInfo).toBeInstanceOf(Function);
+  });
+
+  describe("getAccountInfo", () => {
+    const accountInfo = {
+      type: "aleo" as const,
+      synced: true,
+      percentage: 100,
+      startHeight: 0,
+      scannedHeight: 20985061,
+    };
+
+    it("reads the provableId off the context and returns the scan status", async () => {
+      mockedGetAccountInfo.mockResolvedValue(accountInfo);
+      const api = createApi("aleo");
+      const enrolledContext: AleoContext = { ...context, provableId: "scan-uuid-123" };
+
+      const result = await api.getAccountInfo!(enrolledContext, "aleo1test");
+
+      expect(mockedGetAccountInfo).toHaveBeenCalledTimes(1);
+      expect(mockedGetAccountInfo).toHaveBeenCalledWith(mockConfig, "scan-uuid-123");
+      expect(result).toEqual(accountInfo);
+    });
+
+    it("returns { type: 'none' } and makes no scanner call when no provableId is on the context", async () => {
+      const api = createApi("aleo");
+
+      const result = await api.getAccountInfo!(context, "aleo1test");
+
+      expect(result).toEqual({ type: "none" });
+      expect(mockedGetAccountInfo).not.toHaveBeenCalled();
+    });
+
+    it("returns { type: 'none' } when provableId is present but empty", async () => {
+      const api = createApi("aleo");
+      const emptyContext: AleoContext = { ...context, provableId: "" };
+
+      const result = await api.getAccountInfo!(emptyContext, "aleo1test");
+
+      expect(result).toEqual({ type: "none" });
+      expect(mockedGetAccountInfo).not.toHaveBeenCalled();
+    });
   });
 
   describe("broadcast", () => {

--- a/libs/coin-modules/coin-aleo/src/api/index.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.ts
@@ -1,4 +1,5 @@
 import type {
+  AccountInfo,
   CoinModuleApi,
   Balance,
   Block,
@@ -17,7 +18,14 @@ import type {
 } from "@ledgerhq/coin-module-framework/api/index";
 import { craftTransactionData } from "@ledgerhq/coin-module-framework/logic/craftTransactionData";
 import { rejectBalanceOptions } from "@ledgerhq/coin-module-framework/api/getBalance/rejectBalanceOptions";
-import { estimateFees, getBalance, lastBlock, listOperations, validateAddress } from "../logic";
+import {
+  estimateFees,
+  getAccountInfo,
+  getBalance,
+  lastBlock,
+  listOperations,
+  validateAddress,
+} from "../logic";
 import { getTransactionType } from "../logic/utils";
 import type { AleoContext, AleoCoinConfig, AleoTransactionIntentData } from "../types";
 
@@ -64,6 +72,14 @@ export function createApi(
         configOrCurrencyId: config,
         transactionType: getTransactionType(intent),
       });
+    },
+    getAccountInfo: async (context: AleoContext, _address: string): Promise<AccountInfo> => {
+      const provableId = context.provableId;
+      if (typeof provableId !== "string" || provableId.length === 0) {
+        return { type: "none" };
+      }
+      const config = await context.config();
+      return getAccountInfo(config, provableId);
     },
     getBalance: async (
       context: AleoContext,

--- a/libs/coin-modules/coin-aleo/src/logic/getAccountInfo.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getAccountInfo.test.ts
@@ -36,7 +36,6 @@ describe("getAccountInfo", () => {
       startHeight: 0,
       scannedHeight: 20985061,
     });
-    // ADR-042 sketched synced as a number; the live scanner returns a boolean.
     expect(typeof info.synced).toBe("boolean");
   });
 
@@ -56,6 +55,25 @@ describe("getAccountInfo", () => {
       percentage: 42,
       startHeight: 100,
       scannedHeight: 5000,
+    });
+  });
+
+  it("falls back to the start height when synced_up_to is null", async () => {
+    mockGetRecordScannerStatus.mockResolvedValue({
+      synced: false,
+      percentage: 0,
+      sync_start_height: 100,
+      synced_up_to: null,
+    });
+
+    const info = (await getAccountInfo(config, provableId)) as AleoAccountInfo;
+
+    expect(info).toEqual({
+      type: "aleo",
+      synced: false,
+      percentage: 0,
+      startHeight: 100,
+      scannedHeight: 100,
     });
   });
 

--- a/libs/coin-modules/coin-aleo/src/logic/getAccountInfo.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getAccountInfo.test.ts
@@ -1,0 +1,81 @@
+import { LedgerAPI4xx, LedgerAPI5xx } from "@ledgerhq/live-network/errors";
+import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
+import { AleoApiConfigurationResetError } from "../errors";
+import { apiClient } from "../network/api";
+import type { AleoAccountInfo } from "../types";
+import { getAccountInfo } from "./getAccountInfo";
+
+jest.mock("../network/api");
+
+const mockGetRecordScannerStatus = jest.mocked(apiClient.getRecordScannerStatus);
+
+describe("getAccountInfo", () => {
+  const config = getMockedConfig("mainnet");
+  const provableId = "scan-uuid-123";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("maps the scanner status to AleoAccountInfo in a single scanner call", async () => {
+    mockGetRecordScannerStatus.mockResolvedValue({
+      synced: true,
+      percentage: 100,
+      sync_start_height: 0,
+      synced_up_to: 20985061,
+    });
+
+    const info = (await getAccountInfo(config, provableId)) as AleoAccountInfo;
+
+    expect(mockGetRecordScannerStatus).toHaveBeenCalledTimes(1);
+    expect(mockGetRecordScannerStatus).toHaveBeenCalledWith(config, provableId);
+    expect(info).toEqual({
+      type: "aleo",
+      synced: true,
+      percentage: 100,
+      startHeight: 0,
+      scannedHeight: 20985061,
+    });
+    // ADR-042 sketched synced as a number; the live scanner returns a boolean.
+    expect(typeof info.synced).toBe("boolean");
+  });
+
+  it("maps a partially-synced status field by field", async () => {
+    mockGetRecordScannerStatus.mockResolvedValue({
+      synced: false,
+      percentage: 42,
+      sync_start_height: 100,
+      synced_up_to: 5000,
+    });
+
+    const info = (await getAccountInfo(config, provableId)) as AleoAccountInfo;
+
+    expect(info).toEqual({
+      type: "aleo",
+      synced: false,
+      percentage: 42,
+      startHeight: 100,
+      scannedHeight: 5000,
+    });
+  });
+
+  it("surfaces a 422 (stale/unknown uuid) as AleoApiConfigurationResetError", async () => {
+    const error422 = new LedgerAPI4xx("Unprocessable Entity", {
+      status: 422,
+      url: undefined,
+      method: "POST",
+    });
+    mockGetRecordScannerStatus.mockRejectedValue(error422);
+
+    await expect(getAccountInfo(config, provableId)).rejects.toBeInstanceOf(
+      AleoApiConfigurationResetError,
+    );
+  });
+
+  it("propagates non-422 errors unchanged", async () => {
+    const serverError = new LedgerAPI5xx("Internal Server Error");
+    mockGetRecordScannerStatus.mockRejectedValue(serverError);
+
+    await expect(getAccountInfo(config, provableId)).rejects.toBeInstanceOf(LedgerAPI5xx);
+  });
+});

--- a/libs/coin-modules/coin-aleo/src/logic/getAccountInfo.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getAccountInfo.ts
@@ -2,7 +2,6 @@ import type { AccountInfo } from "@ledgerhq/coin-module-framework/api/types";
 import { getRecordScannerStatusOrThrow } from "../network/utils";
 import type { AleoAccountInfo, AleoCoinConfig } from "../types";
 
-/** One `POST /scanner/{network}/status` call for a live `provableId`. Never registers (ADR-046). */
 export async function getAccountInfo(
   config: AleoCoinConfig,
   provableId: string,
@@ -14,7 +13,8 @@ export async function getAccountInfo(
     synced: status.synced,
     percentage: status.percentage,
     startHeight: status.sync_start_height,
-    scannedHeight: status.synced_up_to,
+    // synced_up_to is null until the scanner has made progress past sync_start_height
+    scannedHeight: status.synced_up_to ?? status.sync_start_height,
   };
   return accountInfo;
 }

--- a/libs/coin-modules/coin-aleo/src/logic/getAccountInfo.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getAccountInfo.ts
@@ -1,0 +1,20 @@
+import type { AccountInfo } from "@ledgerhq/coin-module-framework/api/types";
+import { getRecordScannerStatusOrThrow } from "../network/utils";
+import type { AleoAccountInfo, AleoCoinConfig } from "../types";
+
+/** One `POST /scanner/{network}/status` call for a live `provableId`. Never registers (ADR-046). */
+export async function getAccountInfo(
+  config: AleoCoinConfig,
+  provableId: string,
+): Promise<AccountInfo> {
+  const status = await getRecordScannerStatusOrThrow(config, provableId);
+
+  const accountInfo: AleoAccountInfo = {
+    type: "aleo",
+    synced: status.synced,
+    percentage: status.percentage,
+    startHeight: status.sync_start_height,
+    scannedHeight: status.synced_up_to,
+  };
+  return accountInfo;
+}

--- a/libs/coin-modules/coin-aleo/src/logic/index.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/index.ts
@@ -2,6 +2,7 @@ export { broadcast } from "./broadcast";
 export { combine } from "./combine";
 export { craftTransaction } from "./craftTransaction";
 export { estimateFees } from "./estimateFees";
+export { getAccountInfo } from "./getAccountInfo";
 export { getBalance } from "./getBalance";
 export { lastBlock } from "./lastBlock";
 export { listOperations } from "./listOperations";

--- a/libs/coin-modules/coin-aleo/src/network/api.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/api.test.ts
@@ -496,6 +496,20 @@ describe("apiClient", () => {
       expect(result.percentage).toBe(42);
     });
 
+    it("should return a status with a null synced_up_to", async () => {
+      const mockResponse = {
+        synced: false,
+        percentage: 0,
+        sync_start_height: 100,
+        synced_up_to: null,
+      };
+      jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
+
+      const result = await apiClient.getRecordScannerStatus(mockConfig, mockUuid);
+
+      expect(result).toEqual(mockResponse);
+    });
+
     it("should use the correct network type in the URL", async () => {
       jest.mocked(network).mockResolvedValue({
         data: { synced: true, percentage: 100, sync_start_height: 0, synced_up_to: 20985061 },

--- a/libs/coin-modules/coin-aleo/src/network/api.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/api.test.ts
@@ -461,7 +461,12 @@ describe("apiClient", () => {
     const mockUuid = "scan-uuid-789";
 
     it("should fetch the record scanner status successfully", async () => {
-      const mockResponse = { synced: true, percentage: 100 };
+      const mockResponse = {
+        synced: true,
+        percentage: 100,
+        sync_start_height: 0,
+        synced_up_to: 20985061,
+      };
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       const result = await apiClient.getRecordScannerStatus(mockConfig, mockUuid);
@@ -477,7 +482,12 @@ describe("apiClient", () => {
     });
 
     it("should return partial sync status", async () => {
-      const mockResponse = { synced: false, percentage: 42 };
+      const mockResponse = {
+        synced: false,
+        percentage: 42,
+        sync_start_height: 100,
+        synced_up_to: 5000,
+      };
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       const result = await apiClient.getRecordScannerStatus(mockConfig, mockUuid);
@@ -487,9 +497,10 @@ describe("apiClient", () => {
     });
 
     it("should use the correct network type in the URL", async () => {
-      jest
-        .mocked(network)
-        .mockResolvedValue({ data: { synced: true, percentage: 100 }, status: 200 });
+      jest.mocked(network).mockResolvedValue({
+        data: { synced: true, percentage: 100, sync_start_height: 0, synced_up_to: 20985061 },
+        status: 200,
+      });
 
       await apiClient.getRecordScannerStatus(testnetConfig, mockUuid);
 

--- a/libs/coin-modules/coin-aleo/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.test.ts
@@ -26,6 +26,7 @@ import {
   enrichPrivateRecord,
   patchPublicOperations,
   getTokenOutDetails,
+  getRecordScannerStatusOrThrow,
 } from "./utils";
 
 jest.mock("./api");
@@ -395,6 +396,52 @@ describe("network/utils", () => {
     });
   });
 
+  describe("getRecordScannerStatusOrThrow", () => {
+    const mockUUID = "uuid-abc-def";
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("should return the scanner status", async () => {
+      const status = {
+        synced: true,
+        percentage: 100,
+        sync_start_height: 0,
+        synced_up_to: 20985061,
+      };
+      mockGetRecordScannerStatus.mockResolvedValue(status);
+
+      const result = await getRecordScannerStatusOrThrow(mockConfig, mockUUID);
+
+      expect(mockGetRecordScannerStatus).toHaveBeenCalledTimes(1);
+      expect(mockGetRecordScannerStatus).toHaveBeenCalledWith(mockConfig, mockUUID);
+      expect(result).toEqual(status);
+    });
+
+    it("should throw AleoApiConfigurationResetError on a 422 error", async () => {
+      const error422 = new LedgerAPI4xx("Unprocessable Entity", {
+        status: 422,
+        url: undefined,
+        method: "POST",
+      });
+      mockGetRecordScannerStatus.mockRejectedValue(error422);
+
+      await expect(getRecordScannerStatusOrThrow(mockConfig, mockUUID)).rejects.toThrow(
+        AleoApiConfigurationResetError,
+      );
+    });
+
+    it("should rethrow a non-422 error unchanged", async () => {
+      const networkError = new LedgerAPI5xx("Internal Server Error");
+      mockGetRecordScannerStatus.mockRejectedValue(networkError);
+
+      await expect(getRecordScannerStatusOrThrow(mockConfig, mockUUID)).rejects.toThrow(
+        LedgerAPI5xx,
+      );
+    });
+  });
+
   describe("accessProvableApi", () => {
     const mockViewKey = "AViewKey1mockviewkey";
     const mockUUID = "uuid-abc-def";
@@ -415,7 +462,12 @@ describe("network/utils", () => {
         };
 
         mockRegisterForScanningAccountRecords.mockResolvedValue({ uuid: mockUUID });
-        mockGetRecordScannerStatus.mockResolvedValue({ synced: false, percentage: 5 });
+        mockGetRecordScannerStatus.mockResolvedValue({
+          synced: false,
+          percentage: 5,
+          sync_start_height: 0,
+          synced_up_to: 0,
+        });
 
         const result = await accessProvableApi({
           config: mockConfig,
@@ -447,7 +499,12 @@ describe("network/utils", () => {
           scannerStatus: { synced: false, percentage: 50 },
         };
 
-        mockGetRecordScannerStatus.mockResolvedValue({ synced: false, percentage: 60 });
+        mockGetRecordScannerStatus.mockResolvedValue({
+          synced: false,
+          percentage: 60,
+          sync_start_height: 0,
+          synced_up_to: 0,
+        });
 
         const result = await accessProvableApi({
           config: mockConfig,
@@ -467,7 +524,12 @@ describe("network/utils", () => {
           scannerStatus: { synced: false, percentage: 50 },
         };
 
-        mockGetRecordScannerStatus.mockResolvedValue({ synced: true, percentage: 100 });
+        mockGetRecordScannerStatus.mockResolvedValue({
+          synced: true,
+          percentage: 100,
+          sync_start_height: 0,
+          synced_up_to: 20985061,
+        });
 
         const result = await accessProvableApi({
           config: mockConfig,
@@ -539,7 +601,12 @@ describe("network/utils", () => {
 
       it("should initialize scanner status with defaults when provableApi is null", async () => {
         mockRegisterForScanningAccountRecords.mockResolvedValue({ uuid: mockUUID });
-        mockGetRecordScannerStatus.mockResolvedValue({ synced: false, percentage: 0 });
+        mockGetRecordScannerStatus.mockResolvedValue({
+          synced: false,
+          percentage: 0,
+          sync_start_height: 0,
+          synced_up_to: 0,
+        });
 
         const result = await accessProvableApi({
           config: mockConfig,

--- a/libs/coin-modules/coin-aleo/src/network/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.ts
@@ -196,10 +196,6 @@ export async function fetchAllOwnedRecords({
   return allRecords;
 }
 
-/**
- * Fetches the record scanner status, translating a 422 (stale/unknown UUID) into
- * {@link AleoApiConfigurationResetError} so every caller reacts to it the same way.
- */
 export async function getRecordScannerStatusOrThrow(
   config: AleoCoinConfig,
   uuid: string,

--- a/libs/coin-modules/coin-aleo/src/network/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.ts
@@ -19,6 +19,7 @@ import type {
   AleoOperation,
   AleoTransition,
   AleoCoinConfig,
+  AleoRecordScannerStatusResponse,
 } from "../types";
 import {
   isAleoAddressPlaintext,
@@ -196,6 +197,25 @@ export async function fetchAllOwnedRecords({
 }
 
 /**
+ * Fetches the record scanner status, translating a 422 (stale/unknown UUID) into
+ * {@link AleoApiConfigurationResetError} so every caller reacts to it the same way.
+ */
+export async function getRecordScannerStatusOrThrow(
+  config: AleoCoinConfig,
+  uuid: string,
+): Promise<AleoRecordScannerStatusResponse> {
+  try {
+    return await apiClient.getRecordScannerStatus(config, uuid);
+  } catch (error) {
+    const err = error as { name?: string; status?: number } | null | undefined;
+    if (err?.name === "LedgerAPI4xx" && err?.status === 422) {
+      throw new AleoApiConfigurationResetError();
+    }
+    throw error;
+  }
+}
+
+/**
  * Manages access to the Provable API by handling authentication and account registration.
  *
  * This function ensures valid API credentials are available and up-to-date. It handles:
@@ -246,15 +266,7 @@ export async function accessProvableApi({
     uuid = accountUuid;
   }
 
-  try {
-    status = await apiClient.getRecordScannerStatus(config, uuid);
-  } catch (error) {
-    const err = error as { name?: string; status?: number } | null | undefined;
-    if (err?.name === "LedgerAPI4xx" && err?.status === 422) {
-      throw new AleoApiConfigurationResetError();
-    }
-    throw error;
-  }
+  status = await getRecordScannerStatusOrThrow(config, uuid);
 
   if (status) {
     synced = status.synced;

--- a/libs/coin-modules/coin-aleo/src/types/api.ts
+++ b/libs/coin-modules/coin-aleo/src/types/api.ts
@@ -97,6 +97,8 @@ export interface AleoGetProvePublicKeyResponse {
 export interface AleoRecordScannerStatusResponse {
   synced: boolean;
   percentage: number;
+  sync_start_height: number;
+  synced_up_to: number;
 }
 
 export interface AleoPrivateRecord {

--- a/libs/coin-modules/coin-aleo/src/types/api.ts
+++ b/libs/coin-modules/coin-aleo/src/types/api.ts
@@ -98,7 +98,7 @@ export interface AleoRecordScannerStatusResponse {
   synced: boolean;
   percentage: number;
   sync_start_height: number;
-  synced_up_to: number;
+  synced_up_to: number | null;
 }
 
 export interface AleoPrivateRecord {

--- a/libs/coin-modules/coin-aleo/src/types/logic.ts
+++ b/libs/coin-modules/coin-aleo/src/types/logic.ts
@@ -34,8 +34,17 @@ export type EnrichedPrivateRecord = {
 
 export interface ProvableApi {
   uuid?: string;
-  scannerStatus?: AleoRecordScannerStatusResponse;
+  // Bridge persists only the sync flags; the height fields are read live via getAccountInfo.
+  scannerStatus?: Pick<AleoRecordScannerStatusResponse, "synced" | "percentage">;
 }
+
+export type AleoAccountInfo = {
+  type: "aleo";
+  synced: boolean;
+  percentage: number;
+  startHeight: number;
+  scannedHeight: number;
+};
 
 export type RecordPickingStrategy = "manual" | "auto";
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Aleo now exposes its record-scanner scan status through `getAccountInfo`, so consumers can read sync progress from the shared API instead of digging into coin-module internals. Returns `{ type: "none" }` when the account isn't enrolled yet.

### 🔗 Context

https://ledgerhq.atlassian.net/browse/LIVE-34092
