### PR TITLE
[LWM] chore(analytics): replace useAnalytics hook (LIVE-35840)

### DIFF
--- a/.changeset/quiet-badgers-refactor.md
+++ b/.changeset/quiet-badgers-refactor.md
@@ -1,0 +1,7 @@
+---
+"live-mobile": patch
+---
+
+Replace the useAnalytics hook with the module-level track function
+
+Internal refactor ahead of the analytics package migration. Event property values are unchanged; duplicate `send_modal` "step review device" emissions caused by the hook's route-keyed callback identity no longer fire, so counts for that event may fall slightly.

--- a/apps/ledger-live-mobile/__tests__/jest-setup.js
+++ b/apps/ledger-live-mobile/__tests__/jest-setup.js
@@ -207,14 +207,7 @@ jest.mock("~/analytics/segment", () => ({
   track: jest.fn(),
   setAnalyticsFeatureFlagMethod: jest.fn(),
   screen: jest.fn(),
-  useAnalytics: jest.fn(() => ({
-    track: jest.fn(),
-    screen: jest.fn(),
-    identify: jest.fn(),
-    group: jest.fn(),
-    alias: jest.fn(),
-    reset: jest.fn(),
-  })),
+  usePageNameFromRoute: jest.fn(() => "portfolio_navigator"),
 }));
 
 // Mock of Native Modules

--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -767,14 +767,6 @@ export const usePageNameFromRoute = () => {
   const route = useRoute();
   return getPageNameFromRoute(route);
 };
-export const useAnalytics = () => {
-  const track = useTrack();
-  const page = usePageNameFromRoute();
-  return {
-    track,
-    page,
-  };
-};
 
 const lastScreenEventName: RefObject<string | null | undefined> = React.createRef();
 

--- a/apps/ledger-live-mobile/src/components/FabActions/index.tsx
+++ b/apps/ledger-live-mobile/src/components/FabActions/index.tsx
@@ -9,7 +9,7 @@ import { ButtonProps } from "@ledgerhq/native-ui/components/cta/Button/index";
 import { IconType } from "@ledgerhq/native-ui/components/Icon/type";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import InfoModal from "../InfoModal";
-import { useAnalytics } from "~/analytics";
+import { track } from "~/analytics";
 import { WrappedButtonProps } from "../wrappedUi/Button";
 import { setOriginFlow } from "~/analytics/originFlow";
 import { NavigatorName } from "~/const";
@@ -90,7 +90,6 @@ export const FabButtonBarProvider = ({
   eventProperties?: { [key: string]: unknown };
   children: (value: { quickActions: ActionButtonProps[] }) => ReactNode;
 }) => {
-  const { track } = useAnalytics();
   const [pressedDisabledAction, setPressedDisabledAction] = useState<ActionButtonEvent | undefined>(
     undefined,
   );
@@ -192,7 +191,6 @@ export const FabButtonBarProvider = ({
       readOnlyModeEnabled,
       hasOrderedNano,
       navigateToRebornFlow,
-      track,
       router.name,
       globalEventProperties,
       onNavigate,

--- a/apps/ledger-live-mobile/src/components/NoFunds/NoFunds.tsx
+++ b/apps/ledger-live-mobile/src/components/NoFunds/NoFunds.tsx
@@ -9,7 +9,7 @@ import { StyleProp, ViewStyle } from "react-native";
 import CoinsIcon from "./CoinsIcon";
 import TransferButton from "../TransferButton";
 import { NavigatorName, ScreenName } from "~/const";
-import { TrackScreen, useAnalytics, track } from "~/analytics";
+import { TrackScreen, track, usePageNameFromRoute } from "~/analytics";
 import type { NoFundsNavigatorParamList } from "../RootNavigator/types/NoFundsNavigator";
 import { StackNavigatorProps } from "../RootNavigator/types/helpers";
 import { Currency } from "@domain/entity-currency";
@@ -80,7 +80,7 @@ export default function NoFunds({ route }: Readonly<Props>) {
     return currency && swapAvailableIds.includes(currency.id);
   }, [currency, swapAvailableIds]);
 
-  const { page, track } = useAnalytics();
+  const page = usePageNameFromRoute();
   const onNavigate = useCallback(
     (name: string, options?: object) => {
       (navigation as NativeStackNavigationProp<{ [key: string]: object | undefined }>).navigate(
@@ -111,7 +111,7 @@ export default function NoFunds({ route }: Readonly<Props>) {
         createTokenAccount: shouldCreateTokenAccount,
       },
     });
-  }, [account, currency, onNavigate, page, parentAccount, track]);
+  }, [account, currency, onNavigate, page, parentAccount]);
 
   const onSwap = useCallback(() => {
     track("button_clicked", {
@@ -121,7 +121,7 @@ export default function NoFunds({ route }: Readonly<Props>) {
     navigateToSwapTab({
       navigation: navigation as unknown as NativeStackNavigationProp<BaseNavigatorStackParamList>,
     });
-  }, [navigation, page, track]);
+  }, [navigation, page]);
 
   const onBuy = useCallback(() => {
     track("button_clicked", {
@@ -135,7 +135,7 @@ export default function NoFunds({ route }: Readonly<Props>) {
         defaultCurrencyId: currency.id,
       },
     });
-  }, [track, page, onNavigate, account, parentAccount, currency.id]);
+  }, [page, onNavigate, account, parentAccount, currency.id]);
 
   const buttonsList: ButtonItem[] = [
     {

--- a/apps/ledger-live-mobile/src/components/SelectFeesStrategy.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectFeesStrategy.tsx
@@ -29,7 +29,7 @@ import TachometerSlow from "~/icons/TachometerSlow";
 import TachometerMedium from "~/icons/TachometerMedium";
 import TachometerFast from "~/icons/TachometerFast";
 import NetworkFeeInfo from "./NetworkFeeInfo";
-import { useAnalytics } from "~/analytics";
+import { track } from "~/analytics";
 import { sharedSwapTracking } from "~/screens/Swap/utils";
 import Alert from "./Alert";
 import TranslatedError from "./TranslatedError";
@@ -75,7 +75,6 @@ export default function SelectFeesStrategy({
   onCustomFeesPress,
   status,
 }: Props) {
-  const { track } = useAnalytics();
   const { t } = useTranslation();
   const { colors } = useTheme();
   const mainAccount = getMainAccount(account, parentAccount);
@@ -111,7 +110,7 @@ export default function SelectFeesStrategy({
         extra: item.extra,
       });
     },
-    [onStrategySelect, track],
+    [onStrategySelect],
   );
 
   const onBuy = useCallback(

--- a/apps/ledger-live-mobile/src/families/evm/SelectFeesStrategy.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/SelectFeesStrategy.tsx
@@ -18,7 +18,7 @@ import {
   TouchableOpacityProps,
   View,
 } from "react-native";
-import { useAnalytics } from "~/analytics";
+import { track } from "~/analytics";
 import CounterValue from "~/components/CounterValue";
 import CurrencyUnitValue from "~/components/CurrencyUnitValue";
 import LText from "~/components/LText";
@@ -75,7 +75,6 @@ export default function SelectFeesStrategy({
   transactionToUpdate,
   status,
 }: Props) {
-  const { track } = useAnalytics();
   const { t } = useTranslation();
   const { colors } = useTheme();
   const mainAccount = getMainAccount(account, parentAccount);
@@ -104,7 +103,7 @@ export default function SelectFeesStrategy({
       });
       onStrategySelect({ feesStrategy: strategy });
     },
-    [onStrategySelect, track],
+    [onStrategySelect],
   );
 
   const onBuy = useCallback(

--- a/apps/ledger-live-mobile/src/families/evm/StakingDrawer/EvmStakingDrawerBody.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/StakingDrawer/EvmStakingDrawerBody.tsx
@@ -5,7 +5,7 @@ import { Flex } from "@ledgerhq/native-ui";
 import { ParamListBase, useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import React, { useCallback } from "react";
-import { useAnalytics } from "~/analytics";
+import { track, usePageNameFromRoute } from "~/analytics";
 import { NavigatorName, ScreenName } from "~/const";
 import { EvmStakingDrawerProvider } from "./EvmStakingDrawerProvider";
 import { ListProvider } from "./types";
@@ -26,7 +26,7 @@ export function EvmStakingDrawerBody({
   const navigation =
     useNavigation<NativeStackNavigationProp<ParamListBase, string, NavigatorName>>();
 
-  const { track, page } = useAnalytics();
+  const page = usePageNameFromRoute();
 
   const onProviderPress = useCallback(
     ({ manifest, provider }: { manifest: LiveAppManifest; provider: ListProvider }) => {
@@ -62,7 +62,7 @@ export function EvmStakingDrawerBody({
         });
       }
     },
-    [walletApiAccountId, track, page, onClose, navigation, accountId],
+    [walletApiAccountId, page, onClose, navigation, accountId],
   );
 
   return (

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/NetworkFeesRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/NetworkFeesRow.tsx
@@ -16,7 +16,7 @@ import { BottomSheetInfoGradient } from "LLM/components/BottomSheetGradient";
 import { InfoState } from "LLM/components/InfoState";
 import type { FeeSelectorOptionKind, NetworkFeesViewModel } from "../types";
 import { useSendFlowData } from "../context/SendFlowContext";
-import { useAnalytics } from "~/analytics";
+import { track } from "~/analytics";
 import { getSendFlowTrackingProperties } from "@ledgerhq/ledger-wallet-framework/tracking/send";
 
 type NetworkFeesRowProps = Readonly<{
@@ -80,7 +80,6 @@ export function NetworkFeesRow({ viewModel }: NetworkFeesRowProps) {
   const { state } = useSendFlowData();
   const { account, parentAccount } = state.account;
 
-  const { track } = useAnalytics();
   const trackingProperties = useMemo(() => {
     return {
       ...getSendFlowTrackingProperties(account, parentAccount),
@@ -113,7 +112,7 @@ export function NetworkFeesRow({ viewModel }: NetworkFeesRowProps) {
       option.onSelect();
       selectorBottomSheetRef.current?.dismiss();
     },
-    [selectorBottomSheetRef, track, trackingProperties],
+    [selectorBottomSheetRef, trackingProperties],
   );
 
   const handleCloseInfo = useCallback(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/SendHeader.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/SendHeader.tsx
@@ -18,7 +18,7 @@ import { useTranslation } from "~/context/Locale";
 import { AddressDisclaimer } from "./AddressDisclaimer";
 import { useSendHeaderViewModel } from "../hooks/useSendHeaderViewModel";
 import { useSendFlowData } from "../context/SendFlowContext";
-import { useAnalytics } from "~/analytics";
+import { track, usePageNameFromRoute } from "~/analytics";
 import { getSendFlowTrackingProperties } from "@ledgerhq/ledger-wallet-framework/tracking/send";
 
 type SendHeaderProps = Readonly<{
@@ -56,10 +56,11 @@ export function SendHeader({ headerRight }: SendHeaderProps) {
   const { state } = useSendFlowData();
   const { account, parentAccount } = state.account;
 
-  const { track } = useAnalytics();
   const trackingProperties = useMemo(() => {
     return getSendFlowTrackingProperties(account ?? null, parentAccount);
   }, [account, parentAccount]);
+
+  const page = usePageNameFromRoute();
 
   useEffect(() => {
     if (!viewModel.isRecipientStep) {
@@ -69,9 +70,10 @@ export function SendHeader({ headerRight }: SendHeaderProps) {
     track("send_modal", {
       ...trackingProperties,
       name: "step recipient",
+      page,
       flow: "send",
     });
-  }, [track, trackingProperties, viewModel.isRecipientStep]);
+  }, [page, trackingProperties, viewModel.isRecipientStep]);
 
   return (
     <>

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/__tests__/NetworkFeesRow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/__tests__/NetworkFeesRow.test.tsx
@@ -60,7 +60,7 @@ jest.mock("../../context/SendFlowContext", () => ({
   }),
 }));
 jest.mock("~/analytics", () => ({
-  useAnalytics: () => ({ track: jest.fn() }),
+  track: jest.fn(),
 }));
 jest.mock("@ledgerhq/ledger-wallet-framework/tracking/send", () => ({
   getSendFlowTrackingProperties: () => ({}),

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/__tests__/NetworkFeesRow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/__tests__/NetworkFeesRow.test.tsx
@@ -59,9 +59,6 @@ jest.mock("../../context/SendFlowContext", () => ({
     state: { account: { account: null, parentAccount: null } },
   }),
 }));
-jest.mock("~/analytics", () => ({
-  track: jest.fn(),
-}));
 jest.mock("@ledgerhq/ledger-wallet-framework/tracking/send", () => ({
   getSendFlowTrackingProperties: () => ({}),
 }));

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/AmountScreen.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/AmountScreen.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo } from "react";
 import { SendFlowLayout } from "../../components/SendFlowLayout";
 import { AmountScreenInner } from "./components/AmountScreenInner";
 import { useAmountScreen } from "./hooks/useAmountScreen";
-import { useAnalytics } from "~/analytics";
+import { track, usePageNameFromRoute } from "~/analytics";
 import { getSendFlowTrackingProperties } from "@ledgerhq/ledger-wallet-framework/tracking/send";
 import { useSendFlowData } from "../../context/SendFlowContext";
 
@@ -10,18 +10,20 @@ export function AmountScreen() {
   const { state } = useSendFlowData();
   const { account, parentAccount } = state.account;
 
-  const { track } = useAnalytics();
   const trackingProperties = useMemo(() => {
     return getSendFlowTrackingProperties(account, parentAccount);
   }, [account, parentAccount]);
+
+  const page = usePageNameFromRoute();
 
   useEffect(() => {
     track("send_modal", {
       ...trackingProperties,
       name: "step amount",
+      page,
       flow: "send",
     });
-  }, [track, trackingProperties]);
+  }, [page, trackingProperties]);
 
   const viewModel = useAmountScreen();
   if (!viewModel.ready) {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/QuickActionsRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/QuickActionsRow.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo } from "react";
 import { Box, Button } from "@ledgerhq/lumen-ui-rnative";
 import type { AmountScreenQuickAction } from "../types";
-import { useAnalytics } from "~/analytics";
+import { track } from "~/analytics";
 import { getSendFlowTrackingProperties } from "@ledgerhq/ledger-wallet-framework/tracking/send";
 import { useSendFlowData } from "../../../context/SendFlowContext";
 
@@ -26,7 +26,6 @@ export function QuickActionsRow({ actions }: QuickActionsRowProps) {
   const { state } = useSendFlowData();
   const { account, parentAccount } = state.account;
 
-  const { track } = useAnalytics();
   const trackingProperties = useMemo(() => {
     return getSendFlowTrackingProperties(account, parentAccount);
   }, [account, parentAccount]);
@@ -46,7 +45,7 @@ export function QuickActionsRow({ actions }: QuickActionsRowProps) {
       });
       onPress();
     },
-    [track, trackingProperties],
+    [trackingProperties],
   );
 
   return (

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/hooks/useAmountScreen.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/hooks/useAmountScreen.ts
@@ -11,7 +11,7 @@ import { ScreenName } from "~/const";
 import type { SendFlowNavigationProp } from "../../../types";
 import { useSendSignature } from "../../../context/SendSignatureContext";
 import { getSendFlowTrackingProperties } from "@ledgerhq/ledger-wallet-framework/tracking/send";
-import { useAnalytics } from "~/analytics";
+import { track } from "~/analytics";
 import { useSendAmountDisplayMode } from "@ledgerhq/live-common/flows/send/amount/SendAmountDisplayModeContext";
 
 type AmountScreenViewModelBase = Readonly<{
@@ -49,7 +49,6 @@ export function useAmountScreen(): AmountScreenViewModel {
     close();
   }, [close]);
 
-  const { track } = useAnalytics();
   const trackingProperties = useMemo(() => {
     return getSendFlowTrackingProperties(account, parentAccount);
   }, [account, parentAccount]);
@@ -63,7 +62,7 @@ export function useAmountScreen(): AmountScreenViewModel {
       input_mode: inputMode,
     });
     startSigning(() => navigation.navigate(ScreenName.SendFlowConfirmation));
-  }, [startSigning, navigation, track, trackingProperties, inputMode]);
+  }, [startSigning, navigation, trackingProperties, inputMode]);
 
   const onSelectCoinControl = useCallback(() => {
     navigation.navigate(ScreenName.SendFlowCoinControl);

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Confirmation/components/ConfirmationScreenView/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Confirmation/components/ConfirmationScreenView/index.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo } from "react";
 import { Button } from "@ledgerhq/lumen-ui-rnative";
 import { ConfirmationStatusLayout } from "../ConfirmationStatusLayout";
-import { useAnalytics } from "~/analytics";
+import { track, usePageNameFromRoute } from "~/analytics";
 import { getSendFlowTrackingProperties } from "@ledgerhq/ledger-wallet-framework/tracking/send";
 import { useSendFlowData } from "../../../../context/SendFlowContext";
 
@@ -27,18 +27,20 @@ export function ConfirmationScreenView({
   const { state } = useSendFlowData();
   const { account, parentAccount } = state.account;
 
-  const { track } = useAnalytics();
   const trackingProperties = useMemo(() => {
     return getSendFlowTrackingProperties(account ?? null, parentAccount);
   }, [account, parentAccount]);
+
+  const page = usePageNameFromRoute();
 
   useEffect(() => {
     track("transaction_drawer", {
       ...trackingProperties,
       name: "transaction details",
+      page,
       flow: "send",
     });
-  }, [track, trackingProperties]);
+  }, [page, trackingProperties]);
 
   const handleViewTransaction = useCallback(() => {
     track("button_clicked", {
@@ -48,7 +50,7 @@ export function ConfirmationScreenView({
       flow: "send",
     });
     onViewTransaction();
-  }, [track, trackingProperties, onViewTransaction]);
+  }, [trackingProperties, onViewTransaction]);
 
   const handleClose = useCallback(() => {
     track("button_clicked", {
@@ -58,11 +60,11 @@ export function ConfirmationScreenView({
       flow: "send",
     });
     onClose();
-  }, [track, trackingProperties, onClose]);
+  }, [trackingProperties, onClose]);
 
   useEffect(() => {
-    track("send_modal", { ...trackingProperties, name: "step confirmation" });
-  }, [track, trackingProperties]);
+    track("send_modal", { ...trackingProperties, name: "step confirmation", page });
+  }, [page, trackingProperties]);
 
   return (
     <ConfirmationStatusLayout

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenContentViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenContentViewModel.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react-native";
-import { useAnalytics } from "~/analytics";
+import { track } from "~/analytics";
 import { useMemoViewModel } from "../../../../components/Memo/hooks/useMemoViewModel";
 import { useSendFlowData } from "../../../../context/SendFlowContext";
 import { useRecipientScreenView } from "../useRecipientScreenView";
@@ -17,13 +17,12 @@ jest.mock("~/logic/keyboardVisible", () => ({
   shouldUseKeyboardAvoidance: jest.fn(() => true),
 }));
 
-const mockedUseAnalytics = jest.mocked(useAnalytics);
+const mockedTrack = jest.mocked(track);
 const mockedUseMemoViewModel = jest.mocked(useMemoViewModel);
 const mockedUseSendFlowData = jest.mocked(useSendFlowData);
 const mockedUseRecipientScreenView = jest.mocked(useRecipientScreenView);
 
 const account = createMockAccount({ id: "account_1" });
-const track = jest.fn();
 const handleAddressSelect = jest.fn();
 const onMemoProceed = jest.fn();
 
@@ -67,7 +66,6 @@ const memoViewModel = {
 describe("useRecipientScreenContentViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedUseAnalytics.mockReturnValue({ track } as never);
     mockedUseSendFlowData.mockReturnValue({
       uiConfig: { hasMemo: true },
     } as never);
@@ -93,13 +91,13 @@ describe("useRecipientScreenContentViewModel", () => {
     expect(result.current.showMemo).toBe(true);
     expect(result.current.showMatched).toBe(true);
     expect(result.current.keyboardBehavior).toBe("padding");
-    expect(track).toHaveBeenCalledTimes(2);
-    expect(track).toHaveBeenNthCalledWith(
+    expect(mockedTrack).toHaveBeenCalledTimes(2);
+    expect(mockedTrack).toHaveBeenNthCalledWith(
       1,
       "send_modal",
       expect.objectContaining({ name: "step memo" }),
     );
-    expect(track).toHaveBeenNthCalledWith(
+    expect(mockedTrack).toHaveBeenNthCalledWith(
       2,
       "send_modal",
       expect.objectContaining({ name: "step memo", button: "skip" }),
@@ -117,7 +115,7 @@ describe("useRecipientScreenContentViewModel", () => {
       result.current.handleMatchedAddress("destination", "name.eth");
     });
 
-    expect(track).toHaveBeenCalledWith(
+    expect(mockedTrack).toHaveBeenCalledWith(
       "button_clicked",
       expect.objectContaining({ button: "my accounts", page: "step recipient" }),
     );
@@ -132,7 +130,7 @@ describe("useRecipientScreenContentViewModel", () => {
       onSkip();
     });
 
-    expect(track).toHaveBeenCalledWith(
+    expect(mockedTrack).toHaveBeenCalledWith(
       "button_clicked",
       expect.objectContaining({ button: "skip", page: "step memo" }),
     );

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenContentViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenContentViewModel.ts
@@ -5,7 +5,7 @@ import type { Account, AccountLike } from "@ledgerhq/types-live";
 import { useCallback, useEffect, useMemo } from "react";
 import type { KeyboardAvoidingViewProps } from "react-native";
 import { Platform } from "react-native";
-import { useAnalytics } from "~/analytics";
+import { track } from "~/analytics";
 import { getSendFlowTrackingProperties } from "@ledgerhq/ledger-wallet-framework/tracking/send";
 import { shouldUseKeyboardAvoidance } from "~/logic/keyboardVisible";
 import { useMemoViewModel } from "../../../components/Memo/hooks/useMemoViewModel";
@@ -40,7 +40,6 @@ export function useRecipientScreenContentViewModel({
     recipientSupportsDomain,
   });
   const { uiConfig } = useSendFlowData();
-  const { track } = useAnalytics();
   const trackingProperties = useMemo(
     () => ({
       ...getSendFlowTrackingProperties(account, parentAccount),
@@ -57,7 +56,7 @@ export function useRecipientScreenContentViewModel({
       page: "step memo",
     });
     onMemoProceed();
-  }, [track, onMemoProceed, trackingProperties]);
+  }, [onMemoProceed, trackingProperties]);
 
   const resolvedAddress = recipient.result.resolvedAddress ?? recipient.searchValue;
   const showMemo = uiConfig.hasMemo && recipient.isAddressValid;
@@ -78,14 +77,14 @@ export function useRecipientScreenContentViewModel({
       track("button_clicked", trackingProperties);
       handleAddressSelect(address, ensName);
     },
-    [track, trackingProperties, handleAddressSelect],
+    [trackingProperties, handleAddressSelect],
   );
 
   useEffect(() => {
     if (showMemo) {
       track("send_modal", { ...trackingProperties, name: "step memo" });
     }
-  }, [showMemo, track, trackingProperties]);
+  }, [showMemo, trackingProperties]);
 
   useEffect(() => {
     if (uiConfig.hasMemo && memo.hasFilledMemo && !memo.memoError) {
@@ -95,7 +94,7 @@ export function useRecipientScreenContentViewModel({
         name: "step memo",
       });
     }
-  }, [track, trackingProperties, uiConfig.hasMemo, memo.hasFilledMemo, memo.memoError]);
+  }, [trackingProperties, uiConfig.hasMemo, memo.hasFilledMemo, memo.memoError]);
 
   const shouldShowErrorBanner =
     !recipient.isLoading &&

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/components/SignatureDeviceActionView/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/components/SignatureDeviceActionView/index.tsx
@@ -5,7 +5,7 @@ import { BottomSheetView } from "@ledgerhq/lumen-ui-rnative";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { QueuedBottomSheet } from "@shared/ui-queued-bottom-sheet";
 import SelectDevice2, { type SetHeaderOptionsRequest } from "~/components/SelectDevice2";
-import { useAnalytics } from "~/analytics";
+import { track, usePageNameFromRoute } from "~/analytics";
 import { getSendFlowTrackingProperties } from "@ledgerhq/ledger-wallet-framework/tracking/send";
 import { SigningBody } from "./components/SigningBody";
 
@@ -41,20 +41,22 @@ export function SignatureDeviceActionView({
   onUserCancel,
 }: SignatureDeviceActionViewProps) {
   const { bottom: bottomInset } = useSafeAreaInsets();
-  const { track } = useAnalytics();
 
   const trackingProperties = useMemo(
     () => getSendFlowTrackingProperties(account, parentAccount ?? undefined),
     [account, parentAccount],
   );
 
+  const page = usePageNameFromRoute();
+
   useEffect(() => {
     track("send_modal", {
       ...trackingProperties,
       name: "step review device",
+      page,
       flow: "send",
     });
-  }, [track, trackingProperties]);
+  }, [page, trackingProperties]);
 
   return (
     <View style={{ flex: 1 }} testID="send-signature-step">

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/components/SignatureScreenView/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/components/SignatureScreenView/index.tsx
@@ -9,7 +9,7 @@ import type {
   SignTransactionIntentJobState,
 } from "@ledgerhq/live-common/intents/signTransactionIntent";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
-import { useAnalytics } from "~/analytics";
+import { track, usePageNameFromRoute } from "~/analytics";
 import { getSendFlowTrackingProperties } from "@ledgerhq/ledger-wallet-framework/tracking/send";
 
 const deviceConnectionParams = { acceptedDeviceModelIds: [] };
@@ -34,18 +34,20 @@ export function SignatureScreenView({
   account,
   parentAccount,
 }: SignatureScreenViewProps) {
-  const { track } = useAnalytics();
   const trackingProperties = useMemo(() => {
     return getSendFlowTrackingProperties(account ?? null, parentAccount);
   }, [account, parentAccount]);
+
+  const page = usePageNameFromRoute();
 
   useEffect(() => {
     track("send_modal", {
       ...trackingProperties,
       name: "step review device",
+      page,
       flow: "send",
     });
-  }, [track, trackingProperties]);
+  }, [page, trackingProperties]);
 
   return (
     <View style={{ flex: 1 }} testID="send-signature-step">

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/shared/__tests__/usePortfolioSectionActions.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/shared/__tests__/usePortfolioSectionActions.test.ts
@@ -5,19 +5,16 @@ import {
   mockEthCryptoCurrency,
 } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
 import { NavigatorName, ScreenName } from "~/const";
+import { track } from "~/analytics";
 import { Asset } from "~/types/asset";
 import { usePortfolioSectionActions } from "../usePortfolioSectionActions";
 
 const mockNavigate = jest.fn();
-const mockTrack = jest.fn();
+const mockedTrack = jest.mocked(track);
 
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
   useNavigation: () => ({ navigate: mockNavigate }),
-}));
-
-jest.mock("~/analytics", () => ({
-  track: (...args: unknown[]) => mockTrack(...args),
 }));
 
 const btcAsset: Asset = {
@@ -122,7 +119,7 @@ describe("usePortfolioSectionActions", () => {
         result.current.onItemPress(btcAsset);
       });
 
-      expect(mockTrack).toHaveBeenCalledWith("asset_clicked", {
+      expect(mockedTrack).toHaveBeenCalledWith("asset_clicked", {
         asset: mockBtcCryptoCurrency.name,
         page: "Wallet",
       });
@@ -186,7 +183,7 @@ describe("usePortfolioSectionActions", () => {
         result.current.onPressShowAll();
       });
 
-      expect(mockTrack).toHaveBeenCalledWith("button_clicked", {
+      expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
         button: "asset_list",
         type: "stable",
         page: "Wallet",
@@ -200,7 +197,7 @@ describe("usePortfolioSectionActions", () => {
         result.current.onPressShowAll();
       });
 
-      expect(mockTrack).toHaveBeenCalledWith("button_clicked", {
+      expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
         button: "asset_list",
         type: "crypto",
         page: "Wallet",

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/shared/__tests__/usePortfolioSectionActions.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/shared/__tests__/usePortfolioSectionActions.test.ts
@@ -17,7 +17,7 @@ jest.mock("@react-navigation/native", () => ({
 }));
 
 jest.mock("~/analytics", () => ({
-  useAnalytics: () => ({ track: mockTrack }),
+  track: (...args: unknown[]) => mockTrack(...args),
 }));
 
 const btcAsset: Asset = {

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/shared/usePortfolioSectionActions.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/shared/usePortfolioSectionActions.ts
@@ -5,7 +5,7 @@ import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { NavigatorName, ScreenName } from "~/const";
 import { Asset } from "~/types/asset";
-import { useAnalytics } from "~/analytics";
+import { track } from "~/analytics";
 import { useAssetDetailNavigation } from "LLM/features/AssetDetail/hooks/useAssetDetailNavigation";
 
 interface PortfolioSectionActions {
@@ -28,7 +28,6 @@ export function usePortfolioSectionActions(
 ): PortfolioSectionActions {
   const { shouldDisplayAssetSection } = useWalletFeaturesConfig("mobile");
   const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
-  const { track } = useAnalytics();
   const { openFromAsset } = useAssetDetailNavigation();
 
   const onPressShowAll = useCallback(() => {
@@ -50,7 +49,7 @@ export function usePortfolioSectionActions(
         screen: ScreenName.Assets,
       });
     }
-  }, [navigation, shouldDisplayAssetSection, isReadOnly, variant, track]);
+  }, [navigation, shouldDisplayAssetSection, isReadOnly, variant]);
 
   const onItemPress = useCallback(
     (asset: Asset) => {
@@ -65,7 +64,7 @@ export function usePortfolioSectionActions(
         marketId: asset.marketId,
       });
     },
-    [openFromAsset, track],
+    [openFromAsset],
   );
 
   return { onPressShowAll, onItemPress };

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/useStocksDiscoverySectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/StocksSection/useStocksDiscoverySectionViewModel.ts
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { StockSuggestion } from "@features/platform-aggregated-assets";
-import { useAnalytics } from "~/analytics";
+import { track } from "~/analytics";
 import { ScreenName } from "~/const";
 import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { useAssetDetailNavigation } from "LLM/features/AssetDetail/hooks/useAssetDetailNavigation";
@@ -19,14 +19,13 @@ export interface StocksDiscoverySectionViewModelResult {
 
 export function useStocksDiscoverySectionViewModel(): StocksDiscoverySectionViewModelResult {
   const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
-  const { track } = useAnalytics();
   const { openFromMarket } = useAssetDetailNavigation();
   const { stocks, isLoading, isError } = useDefaultStocksAssets(true, MAX_DISCOVERY_STOCKS);
 
   const onPressExploreAll = useCallback(() => {
     track("button_clicked", { button: "explore_all", type: "stocks", page: "Wallet" });
     navigation.navigate(ScreenName.MarketList, { category: "stocks" });
-  }, [navigation, track]);
+  }, [navigation]);
 
   const onItemPress = useCallback(
     (stock: StockSuggestion) => {
@@ -37,7 +36,7 @@ export function useStocksDiscoverySectionViewModel(): StocksDiscoverySectionView
         source: "portfolio",
       });
     },
-    [openFromMarket, track],
+    [openFromMarket],
   );
 
   return { stocks, isLoading, isError, onPressExploreAll, onItemPress };


### PR DESCRIPTION
### 📝 Description

This PR refactors Ledger Wallet Mobile analytics by removing the `useAnalytics` hook and switching all call sites to the module-level `track` export (and `usePageNameFromRoute` where the hook previously provided page). This supports the ongoing migration of analytics into a dedicated package while keeping emitted event properties stable and reducing hook-driven duplicate emissions in the Send flow.

#### Changes:

- Replaced `useAnalytics()` usages with module `track` across WalletAssets, Send flow, fees strategy components, and other UI entry points.
- Updated the handful of call sites that relied on the hook-provided page to use `usePageNameFromRoute()` explicitly.
- Adjusted Jest mocks/setup and updated impacted unit tests.

### Context

**Jira:** [LIVE-35840](https://ledgerhq.atlassian.net/browse/LIVE-35840)


[LIVE-35840]: https://ledgerhq.atlassian.net/browse/LIVE-35840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ