### PR TITLE
fix(evm): drop superseded pending token operation (LIVE-35844)

### DIFF
--- a/.changeset/proud-pandas-vanish.md
+++ b/.changeset/proud-pandas-vanish.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/live-common": patch
+"@ledgerhq/coin-evm": patch
+"@ledgerhq/ledger-wallet-framework": patch
+---
+
+Fix an ERC-20 operation staying stuck on "Sending..." after a speed up or a cancel, which also kept
+its amount locked out of the token spendable balance. A replaced transaction can only be retired by
+its nonce, and token operations were not carrying one.

--- a/libs/coin-modules/coin-evm/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/listOperations.test.ts
@@ -889,6 +889,58 @@ describe("listOperations", () => {
     expect(sameTxFees).toEqual([parentFee, parentFee]);
   });
 
+  it("inherits the parent nonce on token ops, whose fees-only native op is dropped", async () => {
+    // LIVE-35844: the Ledger explorer only reports the nonce on the native op
+    const testContext = ctxWithExplorer({ type: "ledger" });
+
+    const address = "0xb69b37a4fb4a18b3258f974ff6e9f529ad2647b1";
+    const txHash = "0xf034ecf17ad61bc29bab12fc303296428d6c7c8a285bd92b2e30a92b1dd5f3bc";
+    const block = { height: 25745506, hash: "0xblock", time: new Date("2026-08-13T10:29:00.000Z") };
+    const tx = { hash: txHash, block, fees: 41826029222736n, date: block.time, failed: false };
+
+    jest.spyOn(ledgerExplorer, "getOperations").mockResolvedValue({
+      lastCoinOperations: [
+        {
+          id: "coin-fees",
+          type: "FEES",
+          senders: [address],
+          recipients: ["0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"],
+          value: 0n,
+          asset: { type: "native" as const },
+          tx: { ...tx, feesPayer: address },
+          details: { sequence: 316 },
+        },
+      ],
+      lastTokenOperations: [
+        {
+          id: "token-out",
+          type: "OUT",
+          senders: [address],
+          recipients: [address],
+          value: 0n,
+          asset: {
+            type: "erc20" as const,
+            assetReference: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            assetOwner: address,
+          },
+          tx,
+          details: { ledgerOpType: "OUT", assetAmount: "0" },
+        },
+      ],
+      lastNftOperations: [],
+      lastInternalOperations: [],
+      nextPagingToken: "",
+    });
+
+    const { items } = await listOperations(testContext, "", address, {
+      minHeight: 0,
+      order: "asc",
+    });
+
+    // a cancel is a self transfer of 0, so the explorer reports both sides
+    expect(items.map(op => op.details?.sequence)).toEqual([316, 316]);
+  });
+
   it("should emit both native and token operations when tx has native value > 0 and token transfers", async () => {
     const testContext = ctxWithExplorer({ type: "ledger" });
 

--- a/libs/coin-modules/coin-evm/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-evm/src/logic/listOperations.ts
@@ -125,6 +125,7 @@ export async function listOperations(
       },
       details: {
         ...(op.details ?? {}),
+        sequence: op.details?.sequence ?? parent.details?.sequence,
         parentSenders: parent.senders,
         parentRecipients: parent.recipients,
         ...parentContractDetails,

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/postSync.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/postSync.test.ts
@@ -1,28 +1,46 @@
-import type { Account } from "@ledgerhq/types-live";
+import type { Account, Operation, OperationType, TokenAccount } from "@ledgerhq/types-live";
+import { getEnvDefault, setEnv } from "@shared/env";
 import { postSync } from "./postSync";
 import BigNumber from "bignumber.js";
 
+const SENDER = "0xsender";
+
+function op(
+  hash: string,
+  sequence: number | undefined,
+  type: OperationType,
+  date: Date = new Date(),
+): Operation {
+  return {
+    hash,
+    type,
+    date,
+    senders: [SENDER],
+    transactionSequenceNumber: sequence === undefined ? undefined : new BigNumber(sequence),
+  } as Operation;
+}
+
+// postSync only reads operations and pending pools, so sub accounts stay partial too
+type AccountShape = Partial<Omit<Account, "subAccounts">> & {
+  subAccounts?: Partial<TokenAccount>[];
+};
+
+const account = (shape: AccountShape) => shape as Account;
+
 describe("postSync", () => {
+  afterEach(() => {
+    setEnv("OPERATION_OPTIMISTIC_RETENTION", getEnvDefault("OPERATION_OPTIMISTIC_RETENTION"));
+  });
+
   it("removes confirmed and outdated native operations from the pending pool", () => {
-    const initialAccount = {
-      operations: [{ hash: "hash0", transactionSequenceNumber: new BigNumber(4), type: "OUT" }],
-      pendingOperations: [
-        { hash: "outdated", transactionSequenceNumber: new BigNumber(3), type: "IN" },
-        { hash: "hash1", transactionSequenceNumber: new BigNumber(5), type: "OUT" },
-        { hash: "hash2", transactionSequenceNumber: new BigNumber(6), type: "IN" },
-      ],
-    } as Account;
-    const synced = {
-      operations: [
-        { hash: "hash1", transactionSequenceNumber: new BigNumber(5), type: "OUT" },
-        { hash: "hash0", transactionSequenceNumber: new BigNumber(4), type: "OUT" },
-      ],
-      pendingOperations: [
-        { hash: "outdated", transactionSequenceNumber: new BigNumber(3), type: "IN" },
-        { hash: "hash1", transactionSequenceNumber: new BigNumber(5), type: "OUT" },
-        { hash: "hash2", transactionSequenceNumber: new BigNumber(6), type: "IN" },
-      ],
-    } as Account;
+    const initialAccount = account({
+      operations: [op("hash0", 4, "OUT")],
+      pendingOperations: [op("outdated", 3, "IN"), op("hash1", 5, "OUT"), op("hash2", 6, "IN")],
+    });
+    const synced = account({
+      operations: [op("hash1", 5, "OUT"), op("hash0", 4, "OUT")],
+      pendingOperations: [op("outdated", 3, "IN"), op("hash1", 5, "OUT"), op("hash2", 6, "IN")],
+    });
 
     expect(postSync(initialAccount, synced)).toMatchObject({
       operations: [
@@ -36,41 +54,25 @@ describe("postSync", () => {
   });
 
   it("removes confirmed and outdated token operations from the pending pool", () => {
-    const initialAccount = {
-      operations: [{ hash: "hash0", transactionSequenceNumber: new BigNumber(4), type: "OUT" }],
-      pendingOperations: [
-        { hash: "outdated", transactionSequenceNumber: new BigNumber(3), type: "NONE" },
-        { hash: "hash1", transactionSequenceNumber: new BigNumber(5), type: "FEES" },
-        { hash: "hash2", transactionSequenceNumber: new BigNumber(6), type: "IN" },
-      ],
+    const initialAccount = account({
+      operations: [op("hash0", 4, "OUT")],
+      pendingOperations: [op("outdated", 3, "NONE"), op("hash1", 5, "FEES"), op("hash2", 6, "IN")],
       subAccounts: [
         {
-          pendingOperations: [
-            { hash: "outdated", transactionSequenceNumber: new BigNumber(3), type: "IN" },
-            { hash: "hash1", transactionSequenceNumber: new BigNumber(5), type: "FEES" },
-          ],
+          pendingOperations: [op("outdated", 3, "IN"), op("hash1", 5, "FEES")],
         },
       ],
-    } as Account;
-    const synced = {
-      operations: [
-        { hash: "hash1", transactionSequenceNumber: new BigNumber(5), type: "FEES" },
-        { hash: "hash0", transactionSequenceNumber: new BigNumber(4), type: "OUT" },
-      ],
-      pendingOperations: [
-        { hash: "outdated", transactionSequenceNumber: new BigNumber(3), type: "NONE" },
-        { hash: "hash1", transactionSequenceNumber: new BigNumber(5), type: "FEES" },
-        { hash: "hash2", transactionSequenceNumber: new BigNumber(6), type: "IN" },
-      ],
+    });
+    const synced = account({
+      operations: [op("hash1", 5, "FEES"), op("hash0", 4, "OUT")],
+      pendingOperations: [op("outdated", 3, "NONE"), op("hash1", 5, "FEES"), op("hash2", 6, "IN")],
       subAccounts: [
         {
-          operations: [{ hash: "hash1", transactionSequenceNumber: new BigNumber(5), type: "OUT" }],
-          pendingOperations: [
-            { hash: "outdated", transactionSequenceNumber: new BigNumber(3), type: "IN" },
-          ],
+          operations: [op("hash1", 5, "OUT")],
+          pendingOperations: [op("outdated", 3, "IN")],
         },
       ],
-    } as Account;
+    });
 
     expect(postSync(initialAccount, synced)).toMatchObject({
       operations: [
@@ -93,5 +95,62 @@ describe("postSync", () => {
         },
       ],
     });
+  });
+
+  it("removes a superseded token operation once the replacement confirms with the same nonce", () => {
+    // the replacement reuses the nonce but has a different hash, so only the nonce can release it
+    const initialAccount = account({
+      operations: [op("hash0", 4, "OUT")],
+      pendingOperations: [op("superseded", 5, "FEES")],
+      subAccounts: [{ operations: [], pendingOperations: [op("superseded", 5, "OUT")] }],
+    });
+    const synced = account({
+      operations: [op("replacement", 5, "FEES"), op("hash0", 4, "OUT")],
+      pendingOperations: [op("superseded", 5, "FEES")],
+      subAccounts: [{ operations: [], pendingOperations: [op("superseded", 5, "OUT")] }],
+    });
+
+    const result = postSync(initialAccount, synced);
+    expect(result.pendingOperations).toEqual([]);
+    expect(result.subAccounts?.[0].pendingOperations).toEqual([]);
+  });
+
+  it("keeps a pending token operation whose nonce is still ahead of the confirmed ones", () => {
+    const shape = {
+      operations: [op("hash0", 4, "OUT")],
+      pendingOperations: [op("pending", 5, "FEES")],
+      subAccounts: [{ operations: [], pendingOperations: [op("pending", 5, "OUT")] }],
+    };
+
+    const result = postSync(account(shape), account(shape));
+    expect(result.pendingOperations).toMatchObject([{ hash: "pending" }]);
+    expect(result.subAccounts?.[0].pendingOperations).toMatchObject([{ hash: "pending" }]);
+  });
+
+  it("removes pending operations that have been optimistic for longer than the retention window", () => {
+    setEnv("OPERATION_OPTIMISTIC_RETENTION", 1000);
+    const stale = new Date(Date.now() - 60_000);
+    const shape = {
+      operations: [],
+      pendingOperations: [op("stale", 5, "FEES", stale)],
+      subAccounts: [{ operations: [], pendingOperations: [op("stale", 5, "OUT", stale)] }],
+    };
+
+    const result = postSync(account(shape), account(shape));
+    expect(result.pendingOperations).toEqual([]);
+    expect(result.subAccounts?.[0].pendingOperations).toEqual([]);
+  });
+
+  it("uses a confirmed nonce of 0 as the comparison baseline", () => {
+    const initialAccount = account({
+      operations: [op("hash0", 0, "OUT")],
+      pendingOperations: [op("pending", 0, "OUT")],
+    });
+    const synced = account({
+      operations: [op("noSequence", undefined, "OUT"), op("hash0", 0, "OUT")],
+      pendingOperations: [op("pending", 0, "OUT")],
+    });
+
+    expect(postSync(initialAccount, synced).pendingOperations).toEqual([]);
   });
 });

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/postSync.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/postSync.ts
@@ -1,12 +1,14 @@
 import type { Account, AccountLike, Operation } from "@ledgerhq/types-live";
+import { shouldRetainPendingOperation } from "@ledgerhq/ledger-wallet-framework/account/pending";
 import BigNumber from "bignumber.js";
 
 /**
  * After each sync or scan, remove operations from the pending pools if necessary
  * Operations stay pending if and only if
- *  - they are confirmed, i.e. their hash appear in the operation list
+ *  - they are not confirmed, i.e. their hash does not appear in the operation list
  *  - they are not outdated, i.e. their sequence number is at least greater than the
  *    sequence number of the latest transaction
+ *  - they are still within the optimistic retention window
  * NOTE Compared to the default behaviour
  *  - pending operations of token accounts are cleaned up, so we don't see both pending and completed
  *    sub operations in the operation details drawer
@@ -15,8 +17,11 @@ import BigNumber from "bignumber.js";
  *    it only contains the OUT sub operation)
  */
 export function postSync(initial: Account, synced: Account): Account {
-  const lastOperation = synced.operations.find(op => ["OUT", "FEES"].includes(op.type));
-  const latestSequence = lastOperation?.transactionSequenceNumber || new BigNumber(-1);
+  // an operation without a sequence number must not collapse the baseline back to -1
+  const lastOperation = synced.operations.find(
+    op => ["OUT", "FEES"].includes(op.type) && op.transactionSequenceNumber !== undefined,
+  );
+  const latestSequence = lastOperation?.transactionSequenceNumber ?? new BigNumber(-1);
 
   function isPending(account: AccountLike, op: Operation): boolean {
     return (
@@ -24,7 +29,9 @@ export function postSync(initial: Account, synced: Account): Account {
       !account.operations.some(o => o.hash === op.hash) &&
       // Operation is not outdated
       op.transactionSequenceNumber !== undefined &&
-      op.transactionSequenceNumber.gt(latestSequence)
+      op.transactionSequenceNumber.gt(latestSequence) &&
+      // Operation is still optimistic. Checked against the parent, which owns the nonce space.
+      shouldRetainPendingOperation(synced, op)
     );
   }
 

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
@@ -1482,6 +1482,18 @@ describe("coin-framework utils", () => {
         fee: new BigNumber(25),
       });
     });
+
+    it.each([
+      [0, new BigNumber(0)],
+      [3, new BigNumber(3)],
+      [undefined, undefined],
+    ])("adapts a sequence of %s", (sequence, expected) => {
+      const op = { ...baseOp, details: { sequence } };
+
+      const result = adaptCoreOperationToLiveOperation(accountId, op);
+
+      expect(result.transactionSequenceNumber).toEqual(expected);
+    });
   });
 
   describe("nextSequenceWithPending", () => {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
@@ -601,9 +601,8 @@ export function adaptCoreOperationToLiveOperation(accountId: string, op: CoreOpe
     senders: extra.parentSenders ?? op.senders,
     recipients: extra.parentRecipients ?? op.recipients,
     date: op.tx.date,
-    transactionSequenceNumber: op.details?.sequence
-      ? new BigNumber(op.details?.sequence.toString())
-      : undefined,
+    transactionSequenceNumber:
+      op.details?.sequence != null ? new BigNumber(op.details.sequence.toString()) : undefined,
     hasFailed,
     extra,
   };

--- a/libs/ledger-wallet-framework/package.json
+++ b/libs/ledger-wallet-framework/package.json
@@ -124,6 +124,7 @@
     "@types/imurmurhash": "^0.1.4",
     "@types/node": "catalog:",
     "@ledgerhq/live-dmk-speculos": "workspace:^",
+    "@ledgerhq/wallet-framework-test-setup": "workspace:^",
     "@types/invariant": "^2.2.2",
     "@types/jest": "catalog:",
     "@types/lodash": "catalog:",

--- a/libs/ledger-wallet-framework/src/bridge/jsHelpers.test.ts
+++ b/libs/ledger-wallet-framework/src/bridge/jsHelpers.test.ts
@@ -14,6 +14,7 @@ import {
   bip32asBuffer,
   makeScanAccounts,
   makeSync,
+  mergeOps,
   updateTransaction,
 } from "./jsHelpers";
 import { createEmptyHistoryCache } from "../account/balanceHistoryCache";
@@ -969,6 +970,40 @@ describe("makeScanAccounts", () => {
     });
     await new Promise(r => setImmediate(r));
     expect(completeSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("mergeOps", () => {
+  const op = (transactionSequenceNumber?: BigNumber) =>
+    ({
+      id: "op-1",
+      hash: "0xhash",
+      type: "FEES",
+      value: new BigNumber(1),
+      fee: new BigNumber(1),
+      blockHeight: 42,
+      date: new Date("2026-08-13T09:34:00Z"),
+      senders: ["0xfrom"],
+      recipients: ["0xto"],
+      transactionSequenceNumber,
+    }) as Operation;
+
+  it("backfills an operation stored without a sequence number", () => {
+    const [merged] = mergeOps([op(undefined)], [op(new BigNumber(313))]);
+
+    expect(merged.transactionSequenceNumber).toEqual(new BigNumber(313));
+  });
+
+  it("does not erase a stored sequence number with a fetch that reports none", () => {
+    const existing = [op(new BigNumber(313))];
+
+    expect(mergeOps(existing, [op(undefined)])).toBe(existing);
+  });
+
+  it("keeps the stored operation when the sequence number is unchanged", () => {
+    const existing = [op(new BigNumber(313))];
+
+    expect(mergeOps(existing, [op(new BigNumber(313))])).toBe(existing);
   });
 });
 

--- a/libs/ledger-wallet-framework/src/bridge/jsHelpers.ts
+++ b/libs/ledger-wallet-framework/src/bridge/jsHelpers.ts
@@ -122,7 +122,17 @@ function normalizeToObservable<T>(value: Promise<T> | Observable<T>): Observable
 // compare that two dates are roughly the same date in order to update the case it would have drastically changed
 const sameDate = (a: Date, b: Date) => Math.abs(a.getTime() - b.getTime()) < 1000 * 60 * 30;
 
+// a later sync can report a sequence number the stored operation is missing, but a fetch that
+// reports none must never erase one: `mergeOps` replaces `stored` by `fetched` when they differ
+const sameSequenceNumber = (stored: Operation, fetched: Operation) => {
+  const next = fetched.transactionSequenceNumber;
+  if (next === undefined) return true;
+  const current = stored.transactionSequenceNumber;
+  return current !== undefined && current.isEqualTo(next);
+};
+
 // an operation is relatively immutable, however we saw that sometimes it can temporarily change due to reorg,..
+// NOTE not symmetrical: `a` is the stored operation, `b` the freshly fetched one
 export const sameOp = (a: Operation, b: Operation): boolean =>
   a === b ||
   (a.id === b.id && // hash, accountId, type are in id
@@ -131,6 +141,7 @@ export const sameOp = (a: Operation, b: Operation): boolean =>
     a.nftOperations?.length === b.nftOperations?.length &&
     sameDate(a.date, b.date) &&
     a.blockHeight === b.blockHeight &&
+    sameSequenceNumber(a, b) &&
     isEqual(a.senders, b.senders) &&
     isEqual(a.recipients, b.recipients));
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11461,6 +11461,9 @@ importers:
       '@ledgerhq/live-dmk-speculos':
         specifier: workspace:^
         version: link:../live-dmk-speculos
+      '@ledgerhq/wallet-framework-test-setup':
+        specifier: workspace:^
+        version: link:../wallet-framework-test-setup
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11


### PR DESCRIPTION
### 📝 Description

Speeding up or cancelling an ERC-20 send left the superseded operation stuck as `Sending…` forever, and kept its amount locked out of the token spendable balance.

**Why.** A replacement transaction reuses the nonce it replaces and carries a different hash, so the superseded pending operation can only be retired by comparing nonces, never by hash. But for a token send, `listOperations` drops the fees-only native operation to avoid a duplicate row, and that dropped operation was the only one carrying the nonce. The parent `FEES` operation ended up with no `transactionSequenceNumber`, `postSync` fell back to `-1`, and every pending operation looked current on every sync.

Confirmed on a real account: a USDC cancel mined under nonce 316 while the superseded send stayed pending, and the stored parent operation reported no nonce although the explorer returns `nonce_value: 316`. Etherscan-backed chains were unaffected, that adapter already sets the nonce on token operations.

**Fix.**

- `coin-evm/logic/listOperations.ts`: token operations inherit the parent nonce, next to the fees and senders they already inherited. In `enrichTokenWithParent`, so ERC-20/721/1155 and both explorers are covered at once.
- `ledger-wallet-framework/bridge/jsHelpers.ts`: `sameOp` compares `transactionSequenceNumber`, so an operation stored without a nonce is corrected on refetch instead of keeping the gap forever. The check is deliberately asymmetrical (`a` is the stored operation, `b` the fetched one): a fetch reporting no nonce must never erase a stored one, which `enrichTokenWithParent` can produce when pagination splits a transaction's native and token operations across pages.
- `generic-coin-framework/postSync.ts`: the comparison baseline skips operations reporting no nonce instead of collapsing to `-1`, and the optimistic retention window (computed in `jsHelpers`, but discarded here) now applies to token accounts as a backstop.
- `generic-coin-framework/utils.ts`: a confirmed nonce of `0` is no longer read as absent.

Covered by unit tests on all four: nonce inheritance, backfill on refetch, no erasure by a nonce-less fetch, retirement by a same-nonce replacement, the retention window on token accounts, and `0` as a valid baseline.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35844](https://ledgerhq.atlassian.net/browse/LIVE-35844)
- **ADR** (if any):

### DEMO 

https://github.com/user-attachments/assets/3165a5fc-3510-4745-b782-64be68e21966

The video demonstrates the cancellation of a USDC transfer on Ethereum mainnet. The first transaction is canceled by a self-transfer.

The pending transaction that we cancel disappears from the list of operations in the USDC Ethereum account, and the cancel operation appears in the Ethereum transaction list because no USDC is moved (self-transfer of 0 USDC) — only fees are paid in ETH for the transaction gas.

### 🧪 Notes for QA

- `sameOp` is generic: an operation whose nonce changes between syncs is now treated as updated, for every family. Worth a look at history and pending operations outside EVM.
- A slow but valid token send now leaves `Sending…` after `OPERATION_OPTIMISTIC_RETENTION` (30 min) and returns as confirmed once mined, same as native sends today.
- Already-stuck operations are only cleared by that window, since `minHeight` stops their parent operations from being refetched with the nonce.

[LIVE-35844]: https://ledgerhq.atlassian.net/browse/LIVE-35844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
