### PR TITLE
ci(test-additional): add workflow SAST and lint checks

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -345,6 +345,9 @@ jobs:
     name: "Test Additional"
     if: ${{!github.event.pull_request.head.repo.fork}}
     uses: LedgerHQ/ledger-live/.github/workflows/test-additional.yml@develop
+    permissions:
+      security-events: write
+      contents: read
 
   test-mobile-e2e-lint:
     name: "Mobile E2E Lint & Typecheck"

--- a/.github/workflows/test-additional.yml
+++ b/.github/workflows/test-additional.yml
@@ -35,3 +35,59 @@ jobs:
 
       - name: Validate Changesets
         uses: LedgerHQ/ledger-live/tools/actions/composites/validate-changesets@develop
+
+  changes:
+    name: Detect Workflow File Changes
+    runs-on: ubuntu-24.04
+    outputs:
+      workflow-files: ${{ steps.filter.outputs.workflow-files }}
+    steps:
+      - id: filter
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            if (!context.payload.pull_request) {
+              core.setOutput('workflow-files', 'false');
+              core.info('Not a pull request — skipping diff');
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            }).then(fs => fs.map(f => f.filename));
+
+            const affected = files.some(f => /^(\.github\/|tools\/actions\/)/.test(f));
+            core.setOutput('workflow-files', String(affected));
+            core.info(affected ? 'Workflow files changed' : 'No workflow files changed');
+
+  ci-sast:
+    name: Test CI Scripts
+    runs-on: ubuntu-24.04
+    needs: changes
+    if: needs.changes.outputs.workflow-files == 'true'
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Setup mise
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        with:
+          use-mise: true
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          min-severity: high
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run actionlint
+        run: actionlint -color -shellcheck ''


### PR DESCRIPTION
## What

Adds two jobs to the "Test Additional" workflow that run only when
`.github/` or `tools/actions/` files are touched:

- **changes** — queries the GitHub API for PR file changes (no checkout) and sets a `workflow-files` output flag, following the same pattern as the `live-common-affected` composite.
- **ci-sast** — runs [zizmor](https://github.com/zizmorcore/zizmor-action) at `min-severity=high` (results uploaded to the Security tab via SARIF) and [actionlint](https://github.com/rhysd/actionlint) (sourced from mise). Both tools cover `.github/workflows/` and `tools/actions/` composites per the existing `.github/actionlint.yml` path config.

## Why

Workflow files are a high-value attack surface and currently have no automated CI gate. Running these checks only on PRs that touch CI files keeps noise low on unrelated work.

## Testing

This PR touches `.github/`, so the `ci-sast` job will run against itself on CI.

### 🔗 Context

Test run: https://github.com/LedgerHQ/ledger-live/actions/runs/31704457255/job/94461410823
Ticket: https://ledgerhq.atlassian.net/browse/LIVE-35006
