### PR TITLE
feat(pay-card-balance): add ActionTiles component (LIVE-34905)

### DIFF
--- a/.changeset/LIVE-34905-action-tiles.md
+++ b/.changeset/LIVE-34905-action-tiles.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-pay-card-balance": minor
+---
+
+Add ActionTiles component with MVVM view-model to the pay-card-balance feature

--- a/features/flow/pay-card-balance/src/components/ActionTiles/ActionTiles.tsx
+++ b/features/flow/pay-card-balance/src/components/ActionTiles/ActionTiles.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { ActionTilesView } from "./ActionTilesView";
+import type { ActionTilesProps } from "./types";
+import { useActionTilesViewModel } from "./useActionTilesViewModel";
+
+export function ActionTiles(props: ActionTilesProps) {
+  return <ActionTilesView {...useActionTilesViewModel(props)} />;
+}

--- a/features/flow/pay-card-balance/src/components/ActionTiles/ActionTilesView.native.tsx
+++ b/features/flow/pay-card-balance/src/components/ActionTiles/ActionTilesView.native.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Box, TileButton } from "@ledgerhq/lumen-ui-rnative";
+import { Link, Plus } from "@ledgerhq/lumen-ui-rnative/symbols";
+import type { ComponentProps } from "react";
+import type { ActionTileId, ActionTilesViewProps } from "./types";
+
+type TileIcon = ComponentProps<typeof TileButton>["icon"];
+
+const ICONS: Partial<Record<ActionTileId, TileIcon>> = {
+  deposit: Plus,
+  request: Link,
+};
+
+export function ActionTilesView({ tiles }: ActionTilesViewProps) {
+  return (
+    <Box lx={{ flexDirection: "row", gap: "s8" }} testID="action-tiles">
+      {tiles.map(tile => (
+        <TileButton
+          key={tile.id}
+          lx={{ flex: 1 }}
+          icon={ICONS[tile.id] ?? Plus}
+          onPress={tile.onPress}
+          testID={`action-tile-${tile.id}`}
+          accessibilityLabel={tile.label}
+          isFull
+        >
+          {tile.label}
+        </TileButton>
+      ))}
+    </Box>
+  );
+}

--- a/features/flow/pay-card-balance/src/components/ActionTiles/ActionTilesView.web.tsx
+++ b/features/flow/pay-card-balance/src/components/ActionTiles/ActionTilesView.web.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { Button } from "@ledgerhq/lumen-ui-react";
+import { Link, Telegram, Plus } from "@ledgerhq/lumen-ui-react/symbols";
+import type { ComponentProps } from "react";
+import type { ActionTileId, ActionTilesViewProps } from "./types";
+
+type TileIcon = ComponentProps<typeof Button>["icon"];
+
+const ICONS: Record<ActionTileId, TileIcon> = {
+  deposit: Plus,
+  request: Link,
+  pay: Telegram,
+};
+
+export function ActionTilesView({ tiles }: ActionTilesViewProps) {
+  return (
+    <div className="flex gap-8" data-testid="action-tiles">
+      {tiles.map(tile => (
+        <Button
+          key={tile.id}
+          icon={ICONS[tile.id]}
+          onClick={tile.onPress}
+          data-testid={`action-tile-${tile.id}`}
+          isFull
+        >
+          {tile.label}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/features/flow/pay-card-balance/src/components/ActionTiles/__tests__/ActionTiles.web.test.tsx
+++ b/features/flow/pay-card-balance/src/components/ActionTiles/__tests__/ActionTiles.web.test.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { StyleProvider } from "@features/platform-style";
+import { ActionTiles } from "../ActionTiles";
+import type { ActionTilesProps } from "../types";
+
+function renderWithStyle(ui: React.ReactElement) {
+  return render(<StyleProvider colorScheme="dark">{ui}</StyleProvider>);
+}
+
+function buildProps(overrides: Partial<ActionTilesProps> = {}): ActionTilesProps {
+  return {
+    tiles: [
+      { id: "deposit", label: "Deposit", onPress: jest.fn() },
+      { id: "request", label: "Request", onPress: jest.fn() },
+    ],
+    page: "Pay",
+    ...overrides,
+  };
+}
+
+describe("ActionTiles (Web)", () => {
+  it("should render a button for each tile", () => {
+    renderWithStyle(<ActionTiles {...buildProps()} />);
+
+    expect(screen.getByTestId("action-tile-deposit")).toBeVisible();
+    expect(screen.getByTestId("action-tile-request")).toBeVisible();
+  });
+
+  it("should fire tracking then the tile handler on press", () => {
+    const onTrackEvent = jest.fn();
+    const onPress = jest.fn();
+    renderWithStyle(
+      <ActionTiles
+        {...buildProps({ tiles: [{ id: "deposit", label: "Deposit", onPress }], onTrackEvent })}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("action-tile-deposit"));
+
+    expect(onTrackEvent).toHaveBeenCalledWith("button_clicked", {
+      button: "deposit",
+      buttonLocation: "quick_action",
+      page: "Pay",
+    });
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/flow/pay-card-balance/src/components/ActionTiles/__tests__/ActionTilesView.native.test.tsx
+++ b/features/flow/pay-card-balance/src/components/ActionTiles/__tests__/ActionTilesView.native.test.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { render, screen } from "@testing-library/react-native";
+import { ActionTilesView } from "../ActionTilesView.native";
+import type { ActionTilesViewProps } from "../types";
+
+const defaultProps: ActionTilesViewProps = {
+  tiles: [
+    { id: "deposit", label: "Deposit", onPress: jest.fn() },
+    { id: "request", label: "Request", onPress: jest.fn() },
+  ],
+};
+
+describe("ActionTilesView (Native)", () => {
+  it("should render a button for each tile", () => {
+    render(<ActionTilesView {...defaultProps} />);
+
+    expect(screen.getByTestId("action-tile-deposit")).toBeTruthy();
+    expect(screen.getByTestId("action-tile-request")).toBeTruthy();
+  });
+
+  it("should call onPress when a tile is pressed", () => {
+    const onPress = jest.fn();
+    render(<ActionTilesView tiles={[{ id: "deposit", label: "Deposit", onPress }]} />);
+
+    screen.getByTestId("action-tile-deposit").props.onPress();
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/flow/pay-card-balance/src/components/ActionTiles/__tests__/ActionTilesView.web.test.tsx
+++ b/features/flow/pay-card-balance/src/components/ActionTiles/__tests__/ActionTilesView.web.test.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { StyleProvider } from "@features/platform-style";
+import { ActionTilesView } from "../ActionTilesView.web";
+import type { ActionTilesViewProps } from "../types";
+
+function renderWithStyle(ui: React.ReactElement) {
+  return render(<StyleProvider colorScheme="dark">{ui}</StyleProvider>);
+}
+
+const defaultProps: ActionTilesViewProps = {
+  tiles: [
+    { id: "deposit", label: "Deposit", onPress: jest.fn() },
+    { id: "request", label: "Request", onPress: jest.fn() },
+    { id: "pay", label: "New payment", onPress: jest.fn() },
+  ],
+};
+
+describe("ActionTilesView (Web)", () => {
+  it("should render a button for each tile", () => {
+    renderWithStyle(<ActionTilesView {...defaultProps} />);
+
+    expect(screen.getByTestId("action-tile-deposit")).toBeVisible();
+    expect(screen.getByTestId("action-tile-request")).toBeVisible();
+    expect(screen.getByTestId("action-tile-pay")).toBeVisible();
+  });
+
+  it("should call onPress when a tile is clicked", () => {
+    const onPress = jest.fn();
+    renderWithStyle(<ActionTilesView tiles={[{ id: "deposit", label: "Deposit", onPress }]} />);
+
+    fireEvent.click(screen.getByTestId("action-tile-deposit"));
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("should render tile labels", () => {
+    renderWithStyle(<ActionTilesView {...defaultProps} />);
+
+    expect(screen.getByText("Deposit")).toBeVisible();
+    expect(screen.getByText("Request")).toBeVisible();
+    expect(screen.getByText("New payment")).toBeVisible();
+  });
+});

--- a/features/flow/pay-card-balance/src/components/ActionTiles/__tests__/useActionTilesViewModel.web.test.ts
+++ b/features/flow/pay-card-balance/src/components/ActionTiles/__tests__/useActionTilesViewModel.web.test.ts
@@ -1,0 +1,61 @@
+import { renderHook } from "@testing-library/react";
+import { useActionTilesViewModel } from "../useActionTilesViewModel";
+import type { ActionTile, ActionTilesProps } from "../types";
+
+const deposit: ActionTile = { id: "deposit", label: "Deposit", onPress: jest.fn() };
+const request: ActionTile = { id: "request", label: "Request", onPress: jest.fn() };
+
+function buildProps(overrides: Partial<ActionTilesProps> = {}): ActionTilesProps {
+  return { tiles: [deposit, request], page: "Pay", ...overrides };
+}
+
+describe("useActionTilesViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should fire tracking then call the original handler on press", () => {
+    const onTrackEvent = jest.fn();
+    const { result } = renderHook(() => useActionTilesViewModel(buildProps({ onTrackEvent })));
+
+    result.current.tiles[0].onPress();
+
+    expect(onTrackEvent).toHaveBeenCalledTimes(1);
+    expect(onTrackEvent).toHaveBeenCalledWith("button_clicked", {
+      button: "deposit",
+      buttonLocation: "quick_action",
+      page: "Pay",
+    });
+    expect(deposit.onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("should fire tracking with the correct button id per tile", () => {
+    const onTrackEvent = jest.fn();
+    const { result } = renderHook(() => useActionTilesViewModel(buildProps({ onTrackEvent })));
+
+    result.current.tiles[1].onPress();
+
+    expect(onTrackEvent).toHaveBeenCalledWith("button_clicked", {
+      button: "request",
+      buttonLocation: "quick_action",
+      page: "Pay",
+    });
+  });
+
+  it("should not throw when onTrackEvent is absent", () => {
+    const { result } = renderHook(() => useActionTilesViewModel(buildProps()));
+
+    expect(() => result.current.tiles[0].onPress()).not.toThrow();
+    expect(deposit.onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("should expose all input tiles in the output", () => {
+    const pay: ActionTile = { id: "pay", label: "New payment", onPress: jest.fn() };
+    const { result } = renderHook(() =>
+      useActionTilesViewModel(buildProps({ tiles: [deposit, request, pay] })),
+    );
+
+    expect(result.current.tiles).toHaveLength(3);
+    expect(result.current.tiles.map(t => t.id)).toEqual(["deposit", "request", "pay"]);
+  });
+});

--- a/features/flow/pay-card-balance/src/components/ActionTiles/index.ts
+++ b/features/flow/pay-card-balance/src/components/ActionTiles/index.ts
@@ -1,0 +1,2 @@
+export * from "./ActionTiles";
+export * from "./types";

--- a/features/flow/pay-card-balance/src/components/ActionTiles/types.ts
+++ b/features/flow/pay-card-balance/src/components/ActionTiles/types.ts
@@ -1,0 +1,17 @@
+export type ActionTileId = "deposit" | "request" | "pay";
+
+export type ActionTile = Readonly<{
+  id: ActionTileId;
+  label: string;
+  onPress: () => void;
+}>;
+
+export type ActionTilesProps = Readonly<{
+  tiles: readonly ActionTile[];
+  page: string;
+  onTrackEvent?: (event: string, params: Record<string, unknown>) => void;
+}>;
+
+export type ActionTilesViewProps = Readonly<{
+  tiles: readonly ActionTile[];
+}>;

--- a/features/flow/pay-card-balance/src/components/ActionTiles/useActionTilesViewModel.ts
+++ b/features/flow/pay-card-balance/src/components/ActionTiles/useActionTilesViewModel.ts
@@ -1,0 +1,26 @@
+import { useMemo } from "react";
+import type { ActionTilesProps, ActionTilesViewProps } from "./types";
+
+export function useActionTilesViewModel({
+  tiles,
+  page,
+  onTrackEvent,
+}: ActionTilesProps): ActionTilesViewProps {
+  const trackedTiles = useMemo(
+    () =>
+      tiles.map(tile => ({
+        ...tile,
+        onPress: () => {
+          onTrackEvent?.("button_clicked", {
+            button: tile.id,
+            buttonLocation: "quick_action",
+            page,
+          });
+          tile.onPress();
+        },
+      })),
+    [tiles, page, onTrackEvent],
+  );
+
+  return { tiles: trackedTiles };
+}

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/PayCardBalanceFundedState.native.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/PayCardBalanceFundedState.native.tsx
@@ -1,30 +1,34 @@
 import React from "react";
 import { AmountDisplay, Box } from "@ledgerhq/lumen-ui-rnative";
 import type { FormattedValue } from "./types";
+import { ActionTiles } from "../ActionTiles";
+import type { ActionTilesProps } from "../ActionTiles";
 
 type PayCardBalanceFundedStateProps = Readonly<{
   balance: number;
   formatCountervalue: (value: number) => FormattedValue;
   isLoading: boolean;
+  actionTiles?: ActionTilesProps;
 }>;
 
 export function PayCardBalanceFundedState({
   balance,
   formatCountervalue,
   isLoading,
+  actionTiles,
 }: PayCardBalanceFundedStateProps) {
   return (
-    <Box
-      lx={{ alignItems: "center", justifyContent: "center", paddingVertical: "s32" }}
-      testID="pay-card-balance-funded-state"
-    >
-      <AmountDisplay
-        value={balance}
-        formatter={formatCountervalue}
-        loading={isLoading}
-        size="md"
-        testID="pay-card-balance-amount"
-      />
+    <Box lx={{ paddingVertical: "s32", gap: "s16" }} testID="pay-card-balance-funded-state">
+      <Box lx={{ alignItems: "center", justifyContent: "center" }}>
+        <AmountDisplay
+          value={balance}
+          formatter={formatCountervalue}
+          loading={isLoading}
+          size="md"
+          testID="pay-card-balance-amount"
+        />
+      </Box>
+      {actionTiles && <ActionTiles {...actionTiles} />}
     </Box>
   );
 }

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/PayCardBalanceFundedState.web.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/PayCardBalanceFundedState.web.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { AmountDisplay } from "@ledgerhq/lumen-ui-react";
 import type { FormattedValue, PayCardBalanceFilterOption } from "./types";
 import { BalanceFilterPill } from "./BalanceFilterPill";
+import { ActionTiles } from "../ActionTiles";
+import type { ActionTilesProps } from "../ActionTiles";
 
 type PayCardBalanceFundedStateProps = Readonly<{
   balance: number;
@@ -10,6 +12,7 @@ type PayCardBalanceFundedStateProps = Readonly<{
   allStablecoinsLabel: string;
   selectedOption?: PayCardBalanceFilterOption;
   onOpenFilter: () => void;
+  actionTiles?: ActionTilesProps;
 }>;
 
 export function PayCardBalanceFundedState({
@@ -19,20 +22,24 @@ export function PayCardBalanceFundedState({
   allStablecoinsLabel,
   selectedOption,
   onOpenFilter,
+  actionTiles,
 }: PayCardBalanceFundedStateProps) {
   return (
-    <div className="flex items-end gap-12" data-testid="pay-card-balance-funded-state">
-      <AmountDisplay
-        value={balance}
-        formatter={formatCountervalue}
-        loading={isLoading}
-        data-testid="pay-card-balance-amount"
-      />
-      <BalanceFilterPill
-        allStablecoinsLabel={allStablecoinsLabel}
-        selectedOption={selectedOption}
-        onClick={onOpenFilter}
-      />
+    <div className="flex flex-col gap-24" data-testid="pay-card-balance-funded-state">
+      <div className="flex items-end gap-12">
+        <AmountDisplay
+          value={balance}
+          formatter={formatCountervalue}
+          loading={isLoading}
+          data-testid="pay-card-balance-amount"
+        />
+        <BalanceFilterPill
+          allStablecoinsLabel={allStablecoinsLabel}
+          selectedOption={selectedOption}
+          onClick={onOpenFilter}
+        />
+      </div>
+      {actionTiles && <ActionTiles {...actionTiles} />}
     </div>
   );
 }

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/PayCardBalanceView.native.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/PayCardBalanceView.native.tsx
@@ -12,6 +12,7 @@ export function PayCardBalanceView(props: PayCardBalanceViewProps) {
           balance={props.balance}
           formatCountervalue={props.formatCountervalue}
           isLoading={props.isLoading}
+          actionTiles={props.actionTiles}
         />
       ) : (
         <PayCardBalanceEmptyState labels={props.labels} />

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/PayCardBalanceView.web.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/PayCardBalanceView.web.tsx
@@ -17,6 +17,7 @@ export function PayCardBalanceView(props: PayCardBalanceViewProps) {
             allStablecoinsLabel={props.labels.allStablecoins}
             selectedOption={props.selectedOption}
             onOpenFilter={props.onOpenFilter}
+            actionTiles={props.actionTiles}
           />
           <BalanceFilterDialog
             isOpen={props.isFilterOpen}

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/PayCardBalanceFundedState.native.test.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/PayCardBalanceFundedState.native.test.tsx
@@ -24,4 +24,20 @@ describe("PayCardBalanceFundedState (Native)", () => {
     expect(screen.getByTestId("pay-card-balance-funded-state")).toBeTruthy();
     expect(screen.getByTestId("pay-card-balance-amount")).toBeTruthy();
   });
+
+  it("should render the action tiles when provided", () => {
+    render(
+      <PayCardBalanceFundedState
+        balance={1000}
+        formatCountervalue={formatCountervalue}
+        isLoading={false}
+        actionTiles={{
+          page: "Pay",
+          tiles: [{ id: "deposit", label: "Deposit", onPress: jest.fn() }],
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("action-tile-deposit")).toBeTruthy();
+  });
 });

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/PayCardBalanceFundedState.web.test.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/PayCardBalanceFundedState.web.test.tsx
@@ -52,4 +52,22 @@ describe("PayCardBalanceFundedState (Web)", () => {
 
     expect(onOpenFilter).toHaveBeenCalledTimes(1);
   });
+
+  it("should render the action tiles when provided", () => {
+    renderWithStyle(
+      <PayCardBalanceFundedState
+        balance={1000}
+        formatCountervalue={formatCountervalue}
+        isLoading={false}
+        allStablecoinsLabel="All stablecoins"
+        onOpenFilter={jest.fn()}
+        actionTiles={{
+          page: "Pay",
+          tiles: [{ id: "deposit", label: "Deposit", onPress: jest.fn() }],
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("action-tile-deposit")).toBeVisible();
+  });
 });

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/types.ts
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/types.ts
@@ -1,5 +1,6 @@
 import type { PayCardBalanceFilter } from "@domain/entity-pay-card";
 import type { FormattedValue } from "@ledgerhq/lumen-utils-shared";
+import type { ActionTilesProps } from "../ActionTiles/types";
 
 // Shared by both platforms (`AmountDisplay`);
 export type { FormattedValue };
@@ -76,6 +77,7 @@ export type PayCardBalanceData = PayCardBalanceAggregate &
 export type PayCardBalanceProps = PayCardBalanceData &
   Readonly<{
     labels: PayCardBalanceLabels;
+    actionTiles?: ActionTilesProps;
   }>;
 
 export type PayCardBalanceViewProps =
@@ -98,6 +100,7 @@ export type PayCardBalanceViewProps =
       onCloseFilter: () => void;
       onConfirmFilter: (filter: PayCardBalanceFilter) => void;
       onTrackEvent?: (event: string, params: Record<string, unknown>) => void;
+      actionTiles?: ActionTilesProps;
     }>;
 
 export type BalanceFilterDialogViewModelParams = Readonly<{

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/usePayCardBalanceViewModel.ts
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/usePayCardBalanceViewModel.ts
@@ -12,6 +12,7 @@ export function usePayCardBalanceViewModel({
   formatCountervalue,
   onConfirmFilter,
   onTrackEvent,
+  actionTiles,
   labels,
 }: PayCardBalanceProps): PayCardBalanceViewProps {
   const isLoading = status === "loading";
@@ -57,5 +58,6 @@ export function usePayCardBalanceViewModel({
     onCloseFilter,
     onConfirmFilter,
     onTrackEvent,
+    actionTiles,
   };
 }

--- a/features/flow/pay-card-balance/src/index.native.ts
+++ b/features/flow/pay-card-balance/src/index.native.ts
@@ -1,1 +1,2 @@
 export * from "./components/PayCardBalance";
+export * from "./components/ActionTiles";

--- a/features/flow/pay-card-balance/src/index.ts
+++ b/features/flow/pay-card-balance/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./components/PayCardBalance";
+export * from "./components/ActionTiles";


### PR DESCRIPTION
### 📝 Description

Adds the `ActionTiles` MVVM component to `@features/flow-pay-card-balance`. The component renders quick-action buttons below the balance hero in the Pay tab funded state. Handlers are noop pending navigation; tracking fires via injected `onTrackEvent`.

Platform split: desktop (3 tiles: deposit, request, pay) and mobile (2 tiles: deposit, request).

**Usage**

Pass `actionTiles` to `PayCardBalance` from the platform hook

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34905](https://ledgerhq.atlassian.net/browse/LIVE-34905)

[LIVE-34905]: https://ledgerhq.atlassian.net/browse/LIVE-34905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ