### PR TITLE
[LWDM] refactor(device-model): make device model IDs compatible

### DIFF
--- a/.changeset/silent-devices-union.md
+++ b/.changeset/silent-devices-union.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/devices": major
+"@ledgerhq/types-devices": major
+---
+
+Replace the `DeviceModelId` enum with a const map and compatible string-union type.

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceActionContent/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceActionContent/types.ts
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import type { DeviceModelId } from "@ledgerhq/types-devices";
+import { DeviceModelId } from "@ledgerhq/types-devices";
 
 /** Device-side action illustrated by the content animation. */
 export type DeviceActionContentAction = "continue" | "power-and-unlock";
@@ -11,7 +11,7 @@ export type DeviceActionAnimationTheme = "light" | "dark";
 export type DeviceActionAnimationSource = unknown;
 
 /** Device models supported by DeviceActionContent animations. */
-export type SupportedDeviceActionModelId = Exclude<DeviceModelId, DeviceModelId.blue>;
+export type SupportedDeviceActionModelId = Exclude<DeviceModelId, (typeof DeviceModelId)["blue"]>;
 
 /** Lumen banner displayed below the main device instructions. */
 export type DeviceActionContentBanner = Readonly<{

--- a/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/LNSUpsellBanner.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/LNSUpsellBanner.test.tsx
@@ -19,6 +19,8 @@ jest.mock("~/renderer/analytics/segment", () => ({
 }));
 
 describe("LNSUpsellBanner", () => {
+  const defaultDevicesModelList: DeviceModelId[] = [DeviceModelId.nanoS];
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -124,7 +126,7 @@ describe("LNSUpsellBanner", () => {
       ffEnabled = true,
       ffLocationEnabled = true,
       isOptIn = true,
-      devicesModelList = [DeviceModelId.nanoS] as DeviceModelId[],
+      devicesModelList = defaultDevicesModelList,
       targetedByHighTierUpsell = false,
       brazePlacement = false,
     }) {

--- a/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/LNSUpsellBanner.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/LNSUpsellBanner.test.tsx
@@ -124,7 +124,7 @@ describe("LNSUpsellBanner", () => {
       ffEnabled = true,
       ffLocationEnabled = true,
       isOptIn = true,
-      devicesModelList = [DeviceModelId.nanoS],
+      devicesModelList = [DeviceModelId.nanoS] as DeviceModelId[],
       targetedByHighTierUpsell = false,
       brazePlacement = false,
     }) {

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/PostOnboardingHubBanner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/PostOnboardingHubBanner.tsx
@@ -16,7 +16,7 @@ const Wrapper = styled(Card)`
   margin: 20px 0px;
 `;
 
-const illustrations: Record<DeviceModelId, React.ReactNode> = {
+const illustrations: Record<string, React.ReactNode> = {
   stax: <StaxBannerIllustration />,
   europa: <EuropaBannerIllustration />,
   nanoS: undefined,
@@ -24,7 +24,7 @@ const illustrations: Record<DeviceModelId, React.ReactNode> = {
   nanoX: undefined,
   blue: undefined,
   apex: undefined,
-};
+} satisfies Record<DeviceModelId, React.ReactNode>;
 
 const PostOnboardingHubBanner = () => {
   const { t } = useTranslation();
@@ -39,7 +39,7 @@ const PostOnboardingHubBanner = () => {
   return (
     <Wrapper>
       <ActionCard
-        leftContent={deviceModelId ? illustrations[deviceModelId as DeviceModelId] : undefined}
+        leftContent={deviceModelId ? illustrations[deviceModelId] : undefined}
         title={t("postOnboarding.postOnboardingBanner.title", {
           productName: getDeviceModel(deviceModelId ?? DeviceModelId.stax).productName,
         })}

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/PostOnboardingHubBanner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/PostOnboardingHubBanner.tsx
@@ -16,7 +16,7 @@ const Wrapper = styled(Card)`
   margin: 20px 0px;
 `;
 
-const illustrations = {
+const illustrations: Record<DeviceModelId, React.ReactNode> = {
   stax: <StaxBannerIllustration />,
   europa: <EuropaBannerIllustration />,
   nanoS: undefined,
@@ -39,7 +39,7 @@ const PostOnboardingHubBanner = () => {
   return (
     <Wrapper>
       <ActionCard
-        leftContent={deviceModelId ? illustrations[deviceModelId] : undefined}
+        leftContent={deviceModelId ? illustrations[deviceModelId as DeviceModelId] : undefined}
         title={t("postOnboarding.postOnboardingBanner.title", {
           productName: getDeviceModel(deviceModelId ?? DeviceModelId.stax).productName,
         })}

--- a/apps/ledger-live-desktop/src/renderer/hooks/useAutoRedirectToPostOnboarding/useOpenRecoverCallback.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useAutoRedirectToPostOnboarding/useOpenRecoverCallback.ts
@@ -39,9 +39,9 @@ export function useOpenRecoverCallback() {
         fallbackRedirection();
       } else if (
         lastOnboardedDevice &&
-        (
-          [DeviceModelId.stax, DeviceModelId.europa, DeviceModelId.apex] as DeviceModelId[]
-        ).includes(lastOnboardedDevice.modelId) &&
+        new Set<DeviceModelId>([DeviceModelId.stax, DeviceModelId.europa, DeviceModelId.apex]).has(
+          lastOnboardedDevice.modelId,
+        ) &&
         touchScreenPath
       ) {
         redirect(touchScreenPath);

--- a/apps/ledger-live-desktop/src/renderer/hooks/useAutoRedirectToPostOnboarding/useOpenRecoverCallback.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useAutoRedirectToPostOnboarding/useOpenRecoverCallback.ts
@@ -39,9 +39,9 @@ export function useOpenRecoverCallback() {
         fallbackRedirection();
       } else if (
         lastOnboardedDevice &&
-        [DeviceModelId.stax, DeviceModelId.europa, DeviceModelId.apex].includes(
-          lastOnboardedDevice.modelId,
-        ) &&
+        (
+          [DeviceModelId.stax, DeviceModelId.europa, DeviceModelId.apex] as DeviceModelId[]
+        ).includes(lastOnboardedDevice.modelId) &&
         touchScreenPath
       ) {
         redirect(touchScreenPath);

--- a/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/index.tsx
@@ -145,7 +145,7 @@ const UpdateModal = ({
     confirmedPrompt,
     setConfirmedPrompt,
     deviceHasPin: !(
-      ([DeviceModelId.stax, DeviceModelId.europa] as DeviceModelId[]).includes(deviceModelId) &&
+      new Set<DeviceModelId>([DeviceModelId.stax, DeviceModelId.europa]).has(deviceModelId) &&
       !props.deviceInfo?.onboarded
     ),
   };

--- a/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/index.tsx
@@ -145,7 +145,7 @@ const UpdateModal = ({
     confirmedPrompt,
     setConfirmedPrompt,
     deviceHasPin: !(
-      [DeviceModelId.stax, DeviceModelId.europa].includes(deviceModelId) &&
+      ([DeviceModelId.stax, DeviceModelId.europa] as DeviceModelId[]).includes(deviceModelId) &&
       !props.deviceInfo?.onboarded
     ),
   };

--- a/apps/ledger-live-mobile/src/hooks/useAutoRedirectToPostOnboarding/useOpenRecoverUpsellCallback.ts
+++ b/apps/ledger-live-mobile/src/hooks/useAutoRedirectToPostOnboarding/useOpenRecoverUpsellCallback.ts
@@ -50,7 +50,9 @@ export function useOpenRecoverUpsellCallback() {
       if (
         lastConnectedDevice &&
         touchScreenURI &&
-        [DeviceModelId.stax, DeviceModelId.europa].includes(lastConnectedDevice.modelId)
+        ([DeviceModelId.stax, DeviceModelId.europa] as DeviceModelId[]).includes(
+          lastConnectedDevice.modelId,
+        )
       ) {
         redirect(touchScreenURI);
       } else if (recoverPostOnboardingURI && onboardingType === OnboardingType.restore) {

--- a/apps/ledger-live-mobile/src/hooks/useAutoRedirectToPostOnboarding/useOpenRecoverUpsellCallback.ts
+++ b/apps/ledger-live-mobile/src/hooks/useAutoRedirectToPostOnboarding/useOpenRecoverUpsellCallback.ts
@@ -50,7 +50,7 @@ export function useOpenRecoverUpsellCallback() {
       if (
         lastConnectedDevice &&
         touchScreenURI &&
-        ([DeviceModelId.stax, DeviceModelId.europa] as DeviceModelId[]).includes(
+        new Set<DeviceModelId>([DeviceModelId.stax, DeviceModelId.europa]).has(
           lastConnectedDevice.modelId,
         )
       ) {

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceActionContent/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceActionContent/types.ts
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import type { DeviceModelId } from "@ledgerhq/types-devices";
+import { DeviceModelId } from "@ledgerhq/types-devices";
 import type { LottieViewProps } from "lottie-react-native";
 
 /** Device-side action illustrated by the content animation. */
@@ -12,7 +12,7 @@ export type DeviceActionAnimationTheme = "light" | "dark";
 export type DeviceActionAnimationSource = LottieViewProps["source"] | undefined;
 
 /** Device models supported by DeviceActionContent animations. */
-export type SupportedDeviceActionModelId = Exclude<DeviceModelId, DeviceModelId.blue>;
+export type SupportedDeviceActionModelId = Exclude<DeviceModelId, (typeof DeviceModelId)["blue"]>;
 
 /** Lumen banner displayed below the main device instructions. */
 export type DeviceActionContentBanner = Readonly<{

--- a/apps/ledger-live-mobile/src/mvvm/features/LNUpsell/components/LNUpsellBanner/LNUpsellBanner.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LNUpsell/components/LNUpsellBanner/LNUpsellBanner.test.tsx
@@ -186,7 +186,7 @@ describe("LNUpsellBanner", () => {
     function renderBanner({
       largeScreenUpsellEnabled = true,
       isOptIn = true,
-      devicesModelList = [DeviceModelId.nanoS],
+      devicesModelList = [DeviceModelId.nanoS] as DeviceModelId[],
       onboardingDate = now.toISOString(),
       audienceModels = {},
       targetedByHighTierUpsell = false,

--- a/apps/ledger-live-mobile/src/mvvm/features/LNUpsell/components/LNUpsellBanner/LNUpsellBanner.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LNUpsell/components/LNUpsellBanner/LNUpsellBanner.test.tsx
@@ -10,6 +10,7 @@ import { LNUpsellBanner } from ".";
 
 describe("LNUpsellBanner", () => {
   const now = new Date("2026-07-06T12:00:00.000Z");
+  const defaultDevicesModelList: DeviceModelId[] = [DeviceModelId.nanoS];
   let t: ReturnType<typeof useTranslation>["t"];
 
   beforeEach(() => {
@@ -186,7 +187,7 @@ describe("LNUpsellBanner", () => {
     function renderBanner({
       largeScreenUpsellEnabled = true,
       isOptIn = true,
-      devicesModelList = [DeviceModelId.nanoS] as DeviceModelId[],
+      devicesModelList = defaultDevicesModelList,
       onboardingDate = now.toISOString(),
       audienceModels = {},
       targetedByHighTierUpsell = false,

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/analytics.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/analytics.ts
@@ -6,9 +6,9 @@ export const LARGE_SCREEN_UPSELL_MODAL_PAGE_NAME = "Modal - Upgrade";
 export type LargeScreenUpsellDismissMethod = "close button" | "outside tap";
 
 export type LargeScreenUpsellNanoDeviceModelId =
-  | DeviceModelId.nanoS
-  | DeviceModelId.nanoSP
-  | DeviceModelId.nanoX;
+  | (typeof DeviceModelId)["nanoS"]
+  | (typeof DeviceModelId)["nanoSP"]
+  | (typeof DeviceModelId)["nanoX"];
 
 export type LargeScreenUpsellDeviceModelAnalyticsValue = "lns" | "lnsp" | "lnx";
 

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/hooks/__tests__/useLargeScreenUpsellEligibility.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/hooks/__tests__/useLargeScreenUpsellEligibility.test.ts
@@ -5,7 +5,10 @@ import type { State } from "~/reducers/types";
 
 const NOW = new Date("2026-07-06T12:00:00.000Z");
 
-type NanoDeviceModelId = DeviceModelId.nanoS | DeviceModelId.nanoSP | DeviceModelId.nanoX;
+type NanoDeviceModelId =
+  | (typeof DeviceModelId)["nanoS"]
+  | (typeof DeviceModelId)["nanoSP"]
+  | (typeof DeviceModelId)["nanoX"];
 
 type RenderOptions = {
   enabled?: boolean;

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/components/FollowInstructions/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/components/FollowInstructions/index.tsx
@@ -15,7 +15,7 @@ type Props = {
 };
 
 const animationStyles = (modelId: DeviceModelId) =>
-  ([DeviceModelId.stax, DeviceModelId.europa] as DeviceModelId[]).includes(modelId)
+  new Set<DeviceModelId>([DeviceModelId.stax, DeviceModelId.europa]).has(modelId)
     ? { height: 210 }
     : {};
 

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/components/FollowInstructions/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/components/FollowInstructions/index.tsx
@@ -15,7 +15,9 @@ type Props = {
 };
 
 const animationStyles = (modelId: DeviceModelId) =>
-  [DeviceModelId.stax, DeviceModelId.europa].includes(modelId) ? { height: 210 } : {};
+  ([DeviceModelId.stax, DeviceModelId.europa] as DeviceModelId[]).includes(modelId)
+    ? { height: 210 }
+    : {};
 
 const FollowInstructions: React.FC<Props> = ({ device }) => {
   const { theme } = useTheme();

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/deviceSelection.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/deviceSelection.tsx
@@ -56,7 +56,7 @@ export const devices = {
   },
 };
 
-const NOT_SUPPORTED_DEVICES_IOS = [DeviceModelId.nanoS, DeviceModelId.nanoSP];
+const NOT_SUPPORTED_DEVICES_IOS: DeviceModelId[] = [DeviceModelId.nanoS, DeviceModelId.nanoSP];
 
 function OnboardingStepDeviceSelection() {
   const navigation = useNavigation<NavigationProp>();

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Connectivity/DebugHttpTransport.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Connectivity/DebugHttpTransport.tsx
@@ -13,7 +13,7 @@ import NavigationScrollView from "~/components/NavigationScrollView";
 import { NavigatorName, ScreenName } from "~/const";
 
 const DebugHttpTransport = () => {
-  const models = [
+  const models: DeviceModelId[] = [
     DeviceModelId.nanoX,
     DeviceModelId.nanoSP,
     DeviceModelId.stax,
@@ -23,7 +23,7 @@ const DebugHttpTransport = () => {
   const dispatch = useDispatch();
   const [address, setAddress] = useState("");
   const [name, setName] = useState("");
-  const [model, setModelId] = useState(DeviceModelId.nanoX);
+  const [model, setModelId] = useState<DeviceModelId>(DeviceModelId.nanoX);
 
   const onAdd = useCallback(() => {
     const m = address.trim().match(/^((?:[0-9]{1,3}\.){3}[0-9]{1,3})(:([0-9]+))?/);

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/Lottie.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/Lottie.tsx
@@ -26,12 +26,12 @@ function usePrevious<T>(val: T): T {
 }
 
 type EnabledDeviceModelIds =
-  | DeviceModelId.nanoS
-  | DeviceModelId.nanoSP
-  | DeviceModelId.nanoX
-  | DeviceModelId.stax
-  | DeviceModelId.europa
-  | DeviceModelId.apex;
+  | (typeof DeviceModelId)["nanoS"]
+  | (typeof DeviceModelId)["nanoSP"]
+  | (typeof DeviceModelId)["nanoX"]
+  | (typeof DeviceModelId)["stax"]
+  | (typeof DeviceModelId)["europa"]
+  | (typeof DeviceModelId)["apex"];
 
 const deviceModelIds: Array<EnabledDeviceModelIds> = [
   DeviceModelId.nanoS,

--- a/domain/entity/device-model/README.md
+++ b/domain/entity/device-model/README.md
@@ -1,0 +1,22 @@
+# @domain/entity-device-model
+
+> [!CAUTION]
+> **Status: UNSTABLE** — Canonical device-model vocabulary introduced for the DDD migration.
+
+Defines the canonical `DeviceModelId` schema and type used by new-architecture packages.
+
+## Why this is a domain entity
+
+A Ledger device model is central product vocabulary, not a transport implementation detail. Its
+identity drives UI choices such as device animations and illustrations, and UX behaviour such as
+available features, onboarding paths, and device-flow steps. The concept is shared by multiple
+features and remains meaningful independently of any specific connection transport, so it belongs
+in the canonical domain layer.
+
+## Usage
+
+```ts
+import { DeviceModelId, DeviceModelIdSchema } from "@domain/entity-device-model";
+
+DeviceModelIdSchema.parse(DeviceModelId.nanoX);
+```

--- a/domain/entity/device-model/jest.config.js
+++ b/domain/entity/device-model/jest.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  testEnvironment: "node",
+  moduleNameMapper: {
+    "^(\\.\\.?/.*)\\.js$": "$1",
+  },
+  transform: {
+    "^.+\\.(t|j)sx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+        },
+      },
+    ],
+  },
+  testPathIgnorePatterns: ["lib/"],
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/domain/entity/device-model/package.json
+++ b/domain/entity/device-model/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@domain/entity-device-model",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Canonical device model identifier entity",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "coverage": "jest --coverage"
+  },
+  "dependencies": {
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "jest": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/domain/entity/device-model/project.json
+++ b/domain/entity/device-model/project.json
@@ -1,0 +1,7 @@
+{
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/domain/entity/device-model/src/index.ts
+++ b/domain/entity/device-model/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./schema";

--- a/domain/entity/device-model/src/schema.mock.ts
+++ b/domain/entity/device-model/src/schema.mock.ts
@@ -1,0 +1,5 @@
+import { DeviceModelId, type DeviceModelId as DeviceModelIdType } from "./schema";
+
+export const mockDeviceModelId = (
+  deviceModelId: DeviceModelIdType = DeviceModelId.nanoX,
+): DeviceModelIdType => deviceModelId;

--- a/domain/entity/device-model/src/schema.test.ts
+++ b/domain/entity/device-model/src/schema.test.ts
@@ -1,0 +1,11 @@
+import { DeviceModelId, DeviceModelIdSchema } from "./schema";
+
+describe("DeviceModelIdSchema", () => {
+  it("accepts every declared device model ID", () => {
+    expect(DeviceModelIdSchema.options).toEqual(Object.values(DeviceModelId));
+  });
+
+  it("rejects unknown device model IDs", () => {
+    expect(DeviceModelIdSchema.safeParse("unknown").success).toBe(false);
+  });
+});

--- a/domain/entity/device-model/src/schema.ts
+++ b/domain/entity/device-model/src/schema.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+export const DeviceModelId = {
+  blue: "blue",
+  nanoS: "nanoS",
+  nanoSP: "nanoSP",
+  nanoX: "nanoX",
+  stax: "stax",
+  europa: "europa",
+  apex: "apex",
+} as const;
+
+export type DeviceModelId = (typeof DeviceModelId)[keyof typeof DeviceModelId];
+
+export const DeviceModelIdSchema = z.enum([
+  DeviceModelId.blue,
+  DeviceModelId.nanoS,
+  DeviceModelId.nanoSP,
+  DeviceModelId.nanoX,
+  DeviceModelId.stax,
+  DeviceModelId.europa,
+  DeviceModelId.apex,
+]);

--- a/domain/entity/device-model/tsconfig.json
+++ b/domain/entity/device-model/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "paths": { "*": ["./*"] },
+    "noEmit": true,
+    "types": ["jest"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/libs/device-core/src/capabilities/isSyncOnboardingSupported.ts
+++ b/libs/device-core/src/capabilities/isSyncOnboardingSupported.ts
@@ -1,5 +1,11 @@
 import { DeviceModelId } from "@ledgerhq/devices";
 
+const SYNC_ONBOARDING_SUPPORTED_DEVICE_MODELS = new Set<DeviceModelId>([
+  DeviceModelId.stax,
+  DeviceModelId.europa,
+  DeviceModelId.apex,
+]);
+
 export function isSyncOnboardingSupported(deviceModelId: DeviceModelId) {
-  return [DeviceModelId.stax, DeviceModelId.europa, DeviceModelId.apex].includes(deviceModelId);
+  return SYNC_ONBOARDING_SUPPORTED_DEVICE_MODELS.has(deviceModelId);
 }

--- a/libs/ledger-live-common/src/device/use-cases/appDataBackup/types.ts
+++ b/libs/ledger-live-common/src/device/use-cases/appDataBackup/types.ts
@@ -16,7 +16,7 @@ export type AppName = string;
  * The key used to store the application data in the device storage, is a combination of the device model ID and the application name.
  */
 export type AppStorageKey =
-  `${Exclude<DeviceModelId, DeviceModelId.blue | DeviceModelId.nanoS>}-${AppName}`;
+  `${Exclude<DeviceModelId, (typeof DeviceModelId)["blue" | "nanoS"]>}-${AppName}`;
 
 export type AppStorageType = {
   appDataInfo: AppStorageInfo;

--- a/libs/ledgerjs/packages/devices/README.md
+++ b/libs/ledgerjs/packages/devices/README.md
@@ -58,43 +58,29 @@ Type: [number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Globa
 
 Ledger Blue
 
-Type: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)
-
 ### nanoS
 
 Ledger Nano S
-
-Type: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)
 
 ### nanoSP
 
 Ledger Nano S Plus
 
-Type: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)
-
 ### nanoX
 
 Ledger Nano X
-
-Type: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)
 
 ### stax
 
 Ledger Stax
 
-Type: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)
-
 ### europa
 
 Ledger Flex ("europa" is the internal name)
 
-Type: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)
-
 ### apex
 
 Apex
-
-Type: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)
 
 ### ledgerUSBVendorId
 

--- a/libs/ledgerjs/packages/devices/README.md
+++ b/libs/ledgerjs/packages/devices/README.md
@@ -80,7 +80,7 @@ Ledger Flex ("europa" is the internal name)
 
 ### apex
 
-Apex
+Ledger Nano Gen5  (Apex)
 
 ### ledgerUSBVendorId
 

--- a/libs/ledgerjs/packages/devices/src/index.ts
+++ b/libs/ledgerjs/packages/devices/src/index.ts
@@ -34,8 +34,8 @@ export const DeviceModelId = {
   stax: "stax",
   /** Ledger Flex ("europa" is the internal name) */
   europa: "europa", // DO NOT CHANGE TO FLEX or handle all migration issues, things will break
-  /** Apex */
-  apex: "apex",
+  /** Ledger Nano Gen5  (Apex) */
+  apex: "apex", // DO NOT CHANGE TO A NEW VALUE or handle all migration issues, things will break
 } as const;
 
 export type DeviceModelId = (typeof DeviceModelId)[keyof typeof DeviceModelId];
@@ -253,7 +253,6 @@ export interface DeviceModel {
   usbOnly: boolean;
   memorySize: number;
   masks: number[];
-  // blockSize: number, // THIS FIELD IS DEPRECATED, use getBlockSize
   getBlockSize: (firmwareVersion: string) => number;
   bluetoothSpec?: {
     serviceUuid: string;

--- a/libs/ledgerjs/packages/devices/src/index.ts
+++ b/libs/ledgerjs/packages/devices/src/index.ts
@@ -21,22 +21,24 @@ export const IIU2F = 0x04;
 export const IICCID = 0x08;
 export const IIWebUSB = 0x10;
 
-export enum DeviceModelId {
+export const DeviceModelId = {
   /** Ledger Blue */
-  blue = "blue",
+  blue: "blue",
   /** Ledger Nano S */
-  nanoS = "nanoS",
+  nanoS: "nanoS",
   /** Ledger Nano S Plus */
-  nanoSP = "nanoSP",
+  nanoSP: "nanoSP",
   /** Ledger Nano X */
-  nanoX = "nanoX",
+  nanoX: "nanoX",
   /** Ledger Stax */
-  stax = "stax",
+  stax: "stax",
   /** Ledger Flex ("europa" is the internal name) */
-  europa = "europa", // DO NOT CHANGE TO FLEX or handle all migration issues, things will break
+  europa: "europa", // DO NOT CHANGE TO FLEX or handle all migration issues, things will break
   /** Apex */
-  apex = "apex",
-}
+  apex: "apex",
+} as const;
+
+export type DeviceModelId = (typeof DeviceModelId)[keyof typeof DeviceModelId];
 
 const devices: { [key in DeviceModelId]: DeviceModel } = {
   [DeviceModelId.blue]: {

--- a/libs/types-devices/README.md
+++ b/libs/types-devices/README.md
@@ -14,12 +14,47 @@ Ledger types for devices and transport.
 #### Table of Contents
 
 *   [DeviceModelId](#devicemodelid)
+    *   [blue](#blue)
+    *   [nanoS](#nanos)
+    *   [nanoSP](#nanosp)
+    *   [nanoX](#nanox)
+    *   [stax](#stax)
+    *   [europa](#europa)
+    *   [apex](#apex)
 *   [DeviceModel](#devicemodel)
 *   [Device](#device)
 
 ### DeviceModelId
 
 DeviceModelId is a unique identifier to identify the model of a Ledger hardware wallet.
+
+#### blue
+
+Ledger Blue
+
+#### nanoS
+
+Ledger Nano S
+
+#### nanoSP
+
+Ledger Nano S Plus
+
+#### nanoX
+
+Ledger Nano X
+
+#### stax
+
+Ledger Stax
+
+#### europa
+
+Ledger Flex ("europa" is the internal name)
+
+#### apex
+
+Ledger Nano Gen5  (Apex)
 
 ### DeviceModel
 

--- a/libs/types-devices/src/index.ts
+++ b/libs/types-devices/src/index.ts
@@ -2,13 +2,20 @@
  * DeviceModelId is a unique identifier to identify the model of a Ledger hardware wallet.
  */
 export const DeviceModelId = {
+  /** Ledger Blue */
   blue: "blue",
+  /** Ledger Nano S */
   nanoS: "nanoS",
+  /** Ledger Nano S Plus */
   nanoSP: "nanoSP",
+  /** Ledger Nano X */
   nanoX: "nanoX",
+  /** Ledger Stax */
   stax: "stax",
-  europa: "europa",
-  apex: "apex",
+  /** Ledger Flex ("europa" is the internal name) */
+  europa: "europa", // DO NOT CHANGE TO FLEX or handle all migration issues, things will break
+  /** Ledger Nano Gen5  (Apex) */
+  apex: "apex", // DO NOT CHANGE TO A NEW VALUE or handle all migration issues, things will break
 } as const;
 
 export type DeviceModelId = (typeof DeviceModelId)[keyof typeof DeviceModelId];

--- a/libs/types-devices/src/index.ts
+++ b/libs/types-devices/src/index.ts
@@ -1,15 +1,17 @@
 /**
  * DeviceModelId is a unique identifier to identify the model of a Ledger hardware wallet.
  */
-export enum DeviceModelId {
-  blue = "blue",
-  nanoS = "nanoS",
-  nanoSP = "nanoSP",
-  nanoX = "nanoX",
-  stax = "stax",
-  europa = "europa",
-  apex = "apex",
-}
+export const DeviceModelId = {
+  blue: "blue",
+  nanoS: "nanoS",
+  nanoSP: "nanoSP",
+  nanoX: "nanoX",
+  stax: "stax",
+  europa: "europa",
+  apex: "apex",
+} as const;
+
+export type DeviceModelId = (typeof DeviceModelId)[keyof typeof DeviceModelId];
 
 /**
  * a DeviceModel contains all the information of a specific Ledger hardware wallet model.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4485,6 +4485,31 @@ importers:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
 
+  domain/entity/device-model:
+    dependencies:
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+    devDependencies:
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0(@types/node@24.12.0)
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
   domain/entity/interest-rate:
     dependencies:
       zod:


### PR DESCRIPTION
### 📝 Description

This PR prepares `DeviceModelId` for the new monorepo architecture without making new-architecture packages depend on legacy public libraries.

#### Why

`libs/device-intent` needs to move to `features/platform/`, but feature packages cannot depend on legacy packages under `libs/`. Today, it imports `DeviceModelId` from `@ledgerhq/types-devices`, which blocks that move.

A Ledger device model is product vocabulary, rather than a transport implementation detail: it drives device animations and illustrations, supported capabilities, onboarding paths, and device-flow steps. It therefore belongs in the canonical domain layer.

#### Solution

1. Add the private `@domain/entity-device-model` package, defining the canonical domain `DeviceModelId` const map, structural string-union type, and Zod schema.
2. Replace the public `DeviceModelId` enums in `@ledgerhq/types-devices` and `@ledgerhq/devices` with equivalent const maps and string-union types.
3. Preserve member access for consumers:

```ts
const modelId: DeviceModelId = DeviceModelId.nanoX;
```

4. The public and domain identifiers are now string unions with the same members, so values are structurally compatible across the legacy/new-architecture boundary. This removes the nominal incompatibility of independently declared TypeScript enums.

#### Why the public API change is safe

`@ledgerhq/types-devices` and `@ledgerhq/devices` are legacy/deprecated APIs; external integrations built on LedgerJS should use DMK instead.

The runtime representation is preserved: `DeviceModelId.nanoX` is still `"nanoX"`, and the object has the same keys and values. `Object.values(DeviceModelId)` and member access therefore keep their previous behavior.

The type-level enum behavior does change. This PR updates all internal usages that relied on it:

- enum-member types such as `DeviceModelId.nanoX` and `Exclude<DeviceModelId, DeviceModelId.blue>` now use indexed-access types from the const map;
- model-ID collections used for membership checks are constructed as `new Set<DeviceModelId>([…])`, so every declared value is checked while `.has()` accepts the complete union;
- test defaults are explicitly declared as `DeviceModelId[]`, rather than relying on the narrow literal type inferred from a const-map member;
- records keyed by a device model ID are explicitly typed where the enum previously provided broader inference.

Internal usages do not rely on enum reverse mappings, `z.nativeEnum`, mutation, or reflection. The remaining key lookup and membership checks work with the const map because its keys and values are unchanged.

This is intentionally released as a breaking change for both public packages. Their generated documentation has been refreshed.

### ✅ Testing

- `pnpm desktop typecheck`
- `pnpm mobile typecheck`
- `pnpm --filter @ledgerhq/live-common typecheck`
- `pnpm --filter @ledgerhq/devices build`
- `pnpm --filter @ledgerhq/types-devices build`
- `pnpm --filter @ledgerhq/devices test`

### 🔗 Context

- **JIRA / GitHub issue**: N/A
- **ADR**: N/A