### PR TITLE
ci(allure): drop tj-actions/branch-names third-party action

### DIFF
--- a/tools/actions/composites/upload-allure-report/action.yml
+++ b/tools/actions/composites/upload-allure-report/action.yml
@@ -28,22 +28,20 @@ runs:
   using: composite
 
   steps:
-    - id: branch-name
-      uses: tj-actions/branch-names@6c999acf206f5561e19f46301bb310e9e70d8815 # v6
     - name: Set report path
       id: report-path
       shell: bash
       run: |
-        REPO_NAME=$(echo "${{ github.repository }}" | cut -d'/' -f2)
-        BRANCH="${{ steps.branch-name.outputs.current_branch }}"
+        REPO_NAME="${GITHUB_REPOSITORY#*/}"
         SUFFIX="${INPUTS_REPORT_PATH_SUFFIX:-$INPUTS_PLATFORM}"
-        if [ "${{ github.repository }}" != "LedgerHQ/ledger-live" ]; then
+        if [ "$GITHUB_REPOSITORY" != "LedgerHQ/ledger-live" ]; then
           PATH_VALUE="${REPO_NAME}-${BRANCH}-${SUFFIX}"
         else
           PATH_VALUE="${BRANCH}-${SUFFIX}"
         fi
         echo "path=${PATH_VALUE}" >> "$GITHUB_OUTPUT"
       env:
+        BRANCH: ${{ github.head_ref || github.ref_name }}
         INPUTS_REPORT_PATH_SUFFIX: ${{ inputs.report_path_suffix }}
         INPUTS_PLATFORM: ${{ inputs.platform }}
     - name: Compress PNG files


### PR DESCRIPTION
### 📝 Description

The `upload-allure-report` composite action relied on the third-party `tj-actions/branch-names` action solely to obtain the current branch name. This PR removes that dependency and computes the branch name natively.

**Problem**: Depending on a third-party action for something GitHub already exposes adds supply-chain risk (the `tj-actions` org was the target of a supply-chain attack in early 2025) and an extra step, for no benefit.

**Solution**:
- Replaced `steps.branch-name.outputs.current_branch` with the native `${{ github.head_ref || github.ref_name }}`:
  - `github.head_ref` -> PR source branch on `pull_request` events.
  - `github.ref_name` -> branch short name (already without `refs/heads/`) otherwise.
- Hardened the `run` block against template injection (flagged by `zizmor`): the branch name is now passed via `env:` and referenced as a shell variable instead of being interpolated directly, and `$GITHUB_REPOSITORY` is used instead of interpolating `github.repository`.

No behavioural change to the generated report path.

### 🔗 Context

- **JIRA / GitHub issue**: _n/a - CI maintenance / dependency hardening_
- **ADR** (if any): _n/a_

