### PR TITLE
feat(device-model): add domain device model entity

### DIFF
--- a/domain/entity/device-model/README.md
+++ b/domain/entity/device-model/README.md
@@ -1,0 +1,22 @@
+# @domain/entity-device-model
+
+> [!CAUTION]
+> **Status: UNSTABLE** — Canonical device-model vocabulary introduced for the DDD migration.
+
+Defines the canonical `DeviceModelId` schema and type used by new-architecture packages.
+
+## Why this is a domain entity
+
+A Ledger device model is central product vocabulary, not a transport implementation detail. Its
+identity drives UI choices such as device animations and illustrations, and UX behaviour such as
+available features, onboarding paths, and device-flow steps. The concept is shared by multiple
+features and remains meaningful independently of any specific connection transport, so it belongs
+in the canonical domain layer.
+
+## Usage
+
+```ts
+import { DeviceModelId, DeviceModelIdSchema } from "@domain/entity-device-model";
+
+DeviceModelIdSchema.parse(DeviceModelId.nanoX);
+```

--- a/domain/entity/device-model/jest.config.js
+++ b/domain/entity/device-model/jest.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  testEnvironment: "node",
+  moduleNameMapper: {
+    "^(\\.\\.?/.*)\\.js$": "$1",
+  },
+  transform: {
+    "^.+\\.(t|j)sx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+        },
+      },
+    ],
+  },
+  testPathIgnorePatterns: ["lib/"],
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/domain/entity/device-model/package.json
+++ b/domain/entity/device-model/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@domain/entity-device-model",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Canonical device model identifier entity",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "coverage": "jest --coverage"
+  },
+  "dependencies": {
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "jest": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/domain/entity/device-model/project.json
+++ b/domain/entity/device-model/project.json
@@ -1,0 +1,7 @@
+{
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/domain/entity/device-model/src/index.ts
+++ b/domain/entity/device-model/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./schema";

--- a/domain/entity/device-model/src/schema.mock.ts
+++ b/domain/entity/device-model/src/schema.mock.ts
@@ -1,0 +1,5 @@
+import { DeviceModelId, type DeviceModelId as DeviceModelIdType } from "./schema";
+
+export const mockDeviceModelId = (
+  deviceModelId: DeviceModelIdType = DeviceModelId.nanoX,
+): DeviceModelIdType => deviceModelId;

--- a/domain/entity/device-model/src/schema.test.ts
+++ b/domain/entity/device-model/src/schema.test.ts
@@ -1,0 +1,11 @@
+import { DeviceModelId, DeviceModelIdSchema } from "./schema";
+
+describe("DeviceModelIdSchema", () => {
+  it("accepts every declared device model ID", () => {
+    expect(DeviceModelIdSchema.options).toEqual(Object.values(DeviceModelId));
+  });
+
+  it("rejects unknown device model IDs", () => {
+    expect(DeviceModelIdSchema.safeParse("unknown").success).toBe(false);
+  });
+});

--- a/domain/entity/device-model/src/schema.ts
+++ b/domain/entity/device-model/src/schema.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+export const DeviceModelId = {
+  blue: "blue",
+  nanoS: "nanoS",
+  nanoSP: "nanoSP",
+  nanoX: "nanoX",
+  stax: "stax",
+  europa: "europa",
+  apex: "apex",
+} as const;
+
+export type DeviceModelId = (typeof DeviceModelId)[keyof typeof DeviceModelId];
+
+export const DeviceModelIdSchema = z.enum([
+  DeviceModelId.blue,
+  DeviceModelId.nanoS,
+  DeviceModelId.nanoSP,
+  DeviceModelId.nanoX,
+  DeviceModelId.stax,
+  DeviceModelId.europa,
+  DeviceModelId.apex,
+]);

--- a/domain/entity/device-model/tsconfig.json
+++ b/domain/entity/device-model/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "paths": { "*": ["./*"] },
+    "noEmit": true,
+    "types": ["jest"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4485,6 +4485,31 @@ importers:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
 
+  domain/entity/device-model:
+    dependencies:
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+    devDependencies:
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0(@types/node@24.12.0)
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
   domain/entity/interest-rate:
     dependencies:
       zod:


### PR DESCRIPTION
### 📝 Description

This PR introduces the private `@domain/entity-device-model` package, establishing a canonical domain representation for Ledger hardware-wallet model IDs.

#### Why

`libs/device-intent` needs to move to `features/platform/`, but feature packages cannot depend on legacy packages under `libs/`. It currently imports `DeviceModelId` from `@ledgerhq/types-devices`, which blocks that move.

A Ledger device model is product vocabulary, not a transport implementation detail. It determines device animations and illustrations, supported capabilities, onboarding paths, and device-flow steps. The concept is shared across features and remains meaningful independently of a connection transport, so it belongs in the domain layer.

#### Solution

- Add `@domain/entity-device-model` with a canonical `DeviceModelId` const map, structural string-union type, and Zod schema.
- Provide a mock factory and schema tests covering every declared model and rejection of unknown IDs.
- Keep `@ledgerhq/types-devices` and `@ledgerhq/devices` unchanged. Their public enums remain the compatibility boundary for legacy consumers and external packages.

A later `device-intent` migration can adapt between the domain identifier and legacy enum at its explicit boundary. This avoids a public enum API change while keeping new-architecture code independent from legacy libraries.

### ✅ Testing

- `pnpm --filter @domain/entity-device-model test`
- `pnpm --filter @domain/entity-device-model typecheck`

### 🔗 Context

- **JIRA / GitHub issue**: N/A
- **ADR**: N/A