### PR TITLE
[LWDM] refactor(aleo): preparation for incoming framework getBalance

### DIFF
--- a/.changeset/shy-dots-battle.md
+++ b/.changeset/shy-dots-battle.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+refactor: prepare aleo utils and fixtures for framework getBalance

--- a/libs/coin-modules/coin-aleo/src/__tests__/fixtures/account.fixture.ts
+++ b/libs/coin-modules/coin-aleo/src/__tests__/fixtures/account.fixture.ts
@@ -11,7 +11,7 @@ import type {
   AleoUnspentRecord,
 } from "../../types";
 import { getMockedCurrency, getMockedTokenCurrency } from "./currency.fixture";
-import { getMockedRecord } from "./api.fixture";
+import { getMockedDecryptedRecord, getMockedRecord } from "./api.fixture";
 
 const defaultMockedCurrency = getMockedCurrency();
 const defaultBalance = new BigNumber(100000);
@@ -44,24 +44,16 @@ export const mockUnspentRecord1: AleoUnspentRecord = {
   ...getMockedRecord(),
   commitment: "record-1-commitment",
   microcredits: "800000",
-  decryptedData: {
-    owner: "aleo1zcwqycj02lccfuu57dzjhva7w5dpzc7pngl0sxjhp58t6vlnnqxs6lnp6f.private",
-    data: { microcredits: "800000u64.private" },
-    nonce: "7349790946519678882609199286010273702044020144797298963772495833343454197352group",
-    version: 1,
-  },
+  decryptedData: getMockedDecryptedRecord(),
 };
 
 export const mockUnspentRecord2: AleoUnspentRecord = {
   ...getMockedRecord(),
   commitment: "record-2-commitment",
   microcredits: "600000",
-  decryptedData: {
-    owner: "aleo1zcwqycj02lccfuu57dzjhva7w5dpzc7pngl0sxjhp58t6vlnnqxs6lnp6f.private",
+  decryptedData: getMockedDecryptedRecord({
     data: { microcredits: "600000u64.private" },
-    nonce: "7349790946519678882609199286010273702044020144797298963772495833343454197352group",
-    version: 1,
-  },
+  }),
 };
 
 export const mockUnspentTokenRecord1: AleoUnspentRecord = {

--- a/libs/coin-modules/coin-aleo/src/__tests__/fixtures/api.fixture.ts
+++ b/libs/coin-modules/coin-aleo/src/__tests__/fixtures/api.fixture.ts
@@ -2,10 +2,12 @@ import BigNumber from "bignumber.js";
 import { PROGRAM_ID } from "../../constants";
 import type { DelegatedProvingResponse } from "../../types";
 import {
+  AleoDecryptedRecordResponse,
   AleoPrivateRecord,
   AleoPublicTransaction,
   AleoPublicTransactionDetailsResponse,
   AleoPublicTransactionsResponse,
+  AleoRecordScannerStatusResponse,
   EnrichedPrivateRecord,
 } from "../../types";
 
@@ -447,6 +449,26 @@ export const getMockedRecord = (overrides?: Partial<AleoPrivateRecord>): AleoPri
   tag: "tag123",
   transition_id: "transition123",
   transaction_index: 0,
+  ...overrides,
+});
+
+export const getMockedDecryptedRecord = (
+  overrides?: Partial<AleoDecryptedRecordResponse>,
+): AleoDecryptedRecordResponse => ({
+  owner: "aleo1zcwqycj02lccfuu57dzjhva7w5dpzc7pngl0sxjhp58t6vlnnqxs6lnp6f.private",
+  data: { microcredits: "800000u64.private" },
+  nonce: "7349790946519678882609199286010273702044020144797298963772495833343454197352group",
+  version: 1,
+  ...overrides,
+});
+
+export const getMockedRecordScannerStatus = (
+  overrides?: Partial<AleoRecordScannerStatusResponse>,
+): AleoRecordScannerStatusResponse => ({
+  synced: true,
+  percentage: 100,
+  sync_start_height: 0,
+  synced_up_to: 20985061,
   ...overrides,
 });
 

--- a/libs/coin-modules/coin-aleo/src/__tests__/fixtures/transaction.fixture.ts
+++ b/libs/coin-modules/coin-aleo/src/__tests__/fixtures/transaction.fixture.ts
@@ -1,6 +1,15 @@
 import BigNumber from "bignumber.js";
+import type {
+  MemoNotSupported,
+  TransactionIntent,
+} from "@ledgerhq/coin-module-framework/api/types";
 import { TRANSACTION_TYPE } from "../../constants";
-import type { AleoTransactionIntent, Transaction, TransactionRaw } from "../../types";
+import type {
+  AleoTransactionIntent,
+  AleoTransactionIntentData,
+  Transaction,
+  TransactionRaw,
+} from "../../types";
 import {
   mockUnspentRecord1,
   mockUnspentRecord2,
@@ -179,4 +188,25 @@ export const mockTxIntentConvertTokenPrivateToPublic2: AleoTransactionIntent = {
     programId: MOCK_TOKEN_PROGRAM_ID,
     records: [mockUnspentTokenRecord1.decryptedData, mockUnspentTokenRecord2.decryptedData],
   },
+};
+
+export const createMockTransactionIntent = (): TransactionIntent<
+  MemoNotSupported,
+  AleoTransactionIntentData
+> => {
+  return {
+    intentType: "transaction",
+    asset: {
+      type: "native",
+    },
+    type: "fee_public",
+    amount: BigInt(1000),
+    sender: "aleo1sender1234567890123456789012345678901234567",
+    recipient: "aleo1recipient123456789012345678901234567890",
+    data: {
+      type: "fee_public",
+      priorityFee: 1040n,
+      executionId: "ex1test",
+    },
+  };
 };

--- a/libs/coin-modules/coin-aleo/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.integ.test.ts
@@ -214,32 +214,6 @@ describe("createApi", () => {
     });
   });
 
-  describe("getBalance", () => {
-    it("returns the balance for a valid address", async () => {
-      // not an exact value: testnetAddress's public balance shifts as the team runs more
-      // transactions against it, so only shape + non-negativity are checked here.
-      const balance = await api.getBalance(context, testnetAddress);
-
-      expect(balance).toEqual([expect.objectContaining({ asset: { type: "native" } })]);
-      expect(balance[0].value).toBeGreaterThanOrEqual(0n);
-    });
-
-    it("returns an empty array for a non-existing valid address", async () => {
-      const balance = await api.getBalance(context, emptyAddress);
-
-      expect(balance).toEqual([]);
-    });
-
-    it("throws an error for an invalid address", async () => {
-      const invalidAddress = "invalid_address";
-
-      await expect(api.getBalance(context, invalidAddress)).rejects.toMatchObject({
-        name: "LedgerAPI4xx",
-        status: 404,
-      });
-    });
-  });
-
   describe("getAccountInfo", () => {
     it("returns the aleo scan status for a registered provableId", async () => {
       const getAccountInfo = requireGetAccountInfo(api);

--- a/libs/coin-modules/coin-aleo/src/api/index.test.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.test.ts
@@ -1,26 +1,22 @@
-import type {
-  BalanceOptions,
-  MemoNotSupported,
-  TransactionIntent,
-} from "@ledgerhq/coin-module-framework/api/types";
 import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
 import { getMockedCoinFrameworkOperation } from "../__tests__/fixtures/operation.fixture";
+import { createMockTransactionIntent } from "../__tests__/fixtures/transaction.fixture";
 import {
   craftTransaction,
   estimateFees,
   getAccountInfo,
-  getBalance,
   lastBlock,
   listOperations,
 } from "../logic";
 import { getTransactionType } from "../logic/utils";
-import type { AleoContext, AleoTransactionIntentData } from "../types";
+import type { AleoContext } from "../types";
 import { createApi } from "./index";
 
 jest.mock("../logic");
 jest.mock("../logic/utils");
 
 describe("createApi", () => {
+  const api = createApi("aleo");
   const mockConfig = getMockedConfig("testnet");
   const context: AleoContext = {
     config: async () => mockConfig,
@@ -30,7 +26,6 @@ describe("createApi", () => {
   const mockedCraftTransaction = jest.mocked(craftTransaction);
   const mockedEstimateFees = jest.mocked(estimateFees);
   const mockedGetAccountInfo = jest.mocked(getAccountInfo);
-  const mockedGetBalance = jest.mocked(getBalance);
   const mockedLastBlock = jest.mocked(lastBlock);
   const mockedListOperations = jest.mocked(listOperations);
   const mockedGetTransactionType = jest.mocked(getTransactionType);
@@ -40,7 +35,6 @@ describe("createApi", () => {
 
     mockedCraftTransaction.mockResolvedValue({ transaction: "crafted_tx" });
     mockedEstimateFees.mockReturnValue({ value: BigInt(1234) });
-    mockedGetBalance.mockResolvedValue([{ value: BigInt(10), asset: { type: "native" } }]);
     mockedLastBlock.mockResolvedValue({ hash: "blockHash", height: 42, time: new Date() });
     mockedListOperations.mockResolvedValue({
       operations: [mockOperation],
@@ -51,27 +45,11 @@ describe("createApi", () => {
     mockedGetTransactionType.mockReturnValue("transfer_public");
   });
 
-  const createMockTransactionIntent = (): TransactionIntent<
-    MemoNotSupported,
-    AleoTransactionIntentData
-  > => ({
-    intentType: "transaction",
-    asset: { type: "native" },
-    type: "fee_public",
-    amount: BigInt(1000),
-    sender: "aleo1sender1234567890123456789012345678901234567",
-    recipient: "aleo1recipient123456789012345678901234567890",
-    data: { type: "fee_public", priorityFee: 1040n, executionId: "ex1test" },
-  });
-
   it("should return an API object with coin module api methods", () => {
-    const api = createApi("aleo");
-
     expect(api.broadcast).toBeInstanceOf(Function);
     expect(api.combine).toBeInstanceOf(Function);
     expect(api.craftTransaction).toBeInstanceOf(Function);
     expect(api.estimateFees).toBeInstanceOf(Function);
-    expect(api.getBalance).toBeInstanceOf(Function);
     expect(api.getBlock).toBeInstanceOf(Function);
     expect(api.getBlockInfo).toBeInstanceOf(Function);
     expect(api.lastBlock).toBeInstanceOf(Function);
@@ -91,7 +69,6 @@ describe("createApi", () => {
 
     it("reads the provableId off the context and returns the scan status", async () => {
       mockedGetAccountInfo.mockResolvedValue(accountInfo);
-      const api = createApi("aleo");
       const enrolledContext: AleoContext = { ...context, provableId: "scan-uuid-123" };
 
       const result = await api.getAccountInfo!(enrolledContext, "aleo1test");
@@ -102,8 +79,6 @@ describe("createApi", () => {
     });
 
     it("returns { type: 'none' } and makes no scanner call when no provableId is on the context", async () => {
-      const api = createApi("aleo");
-
       const result = await api.getAccountInfo!(context, "aleo1test");
 
       expect(result).toEqual({ type: "none" });
@@ -111,7 +86,6 @@ describe("createApi", () => {
     });
 
     it("returns { type: 'none' } when provableId is present but empty", async () => {
-      const api = createApi("aleo");
       const emptyContext: AleoContext = { ...context, provableId: "" };
 
       const result = await api.getAccountInfo!(emptyContext, "aleo1test");
@@ -123,16 +97,12 @@ describe("createApi", () => {
 
   describe("broadcast", () => {
     it("should throw unsupported error", () => {
-      const api = createApi("aleo");
-
       expect(() => api.broadcast(context, "test-signature")).toThrow("broadcast is not supported");
     });
   });
 
   describe("combine", () => {
     it("should throw unsupported error", () => {
-      const api = createApi("aleo");
-
       expect(() =>
         api.combine(context, "transaction", ["signature"], { pubkey: "publicKey" }),
       ).toThrow("combine is not supported");
@@ -141,8 +111,6 @@ describe("createApi", () => {
 
   describe("craftTransaction", () => {
     it("should throw unsupported error", async () => {
-      const api = createApi("aleo");
-
       // @ts-expect-error - it should throw no matter what the input is
       expect(() => api.craftTransaction(context, {})).toThrow("craftTransaction is not supported");
     });
@@ -150,8 +118,6 @@ describe("createApi", () => {
 
   describe("craftRawTransaction", () => {
     it("should throw unsupported error", () => {
-      const api = createApi("aleo");
-
       expect(() =>
         api.craftRawTransaction(context, "transaction", "sender", "publicKey", BigInt(1)),
       ).toThrow("craftRawTransaction is not supported");
@@ -160,7 +126,6 @@ describe("createApi", () => {
 
   describe("estimateFees", () => {
     it("should call estimateFees and return fee estimation", async () => {
-      const api = createApi("aleo");
       const txIntent = createMockTransactionIntent();
       const result = await api.estimateFees(context, txIntent);
 
@@ -175,54 +140,26 @@ describe("createApi", () => {
     });
   });
 
-  describe("getBalance", () => {
-    it("should call getBalance and return balances", async () => {
-      const api = createApi("aleo");
-      const result = await api.getBalance(context, "aleo1test");
-
-      expect(mockedGetBalance).toHaveBeenCalledTimes(1);
-      expect(mockedGetBalance).toHaveBeenCalledWith(expect.any(Object), "aleo1test");
-      expect(result).toEqual([{ value: BigInt(10), asset: { type: "native" } }]);
-    });
-
-    it("should throw an exception when options is provided", async () => {
-      const api = createApi("aleo");
-      await expect(
-        api.getBalance(context, "", {} as unknown as BalanceOptions),
-      ).rejects.toMatchObject({
-        name: "InvalidParameterError",
-      });
-    });
-  });
-
   describe("getBlock", () => {
     it("should throw unsupported error", () => {
-      const api = createApi("aleo");
-
       expect(() => api.getBlock(context, 123)).toThrow("getBlock is not supported");
     });
   });
 
   describe("getBlockInfo", () => {
     it("should throw unsupported error", () => {
-      const api = createApi("aleo");
-
       expect(() => api.getBlockInfo(context, 123)).toThrow("getBlockInfo is not supported");
     });
   });
 
   describe("getRewards", () => {
     it("should throw unsupported error", () => {
-      const api = createApi("aleo");
-
       expect(() => api.getRewards(context, "aleo1test")).toThrow("getRewards is not supported");
     });
   });
 
   describe("getNextSequence", () => {
     it("should throw unsupported error", async () => {
-      const api = createApi("aleo");
-
       expect(() => api.getNextSequence(context, "aleo1test")).toThrow(
         "getNextSequence is not supported",
       );
@@ -231,23 +168,18 @@ describe("createApi", () => {
 
   describe("getStakes", () => {
     it("should throw unsupported error", () => {
-      const api = createApi("aleo");
-
       expect(() => api.getStakes(context, "aleo1test")).toThrow("getStakes is not supported");
     });
   });
 
   describe("getValidators", () => {
     it("should throw unsupported error", () => {
-      const api = createApi("aleo");
-
       expect(() => api.getValidators(context)).toThrow("getValidators is not supported");
     });
   });
 
   describe("lastBlock", () => {
     it("should call lastBlock and return block info", async () => {
-      const api = createApi("aleo");
       const result = await api.lastBlock(context);
 
       expect(mockedLastBlock).toHaveBeenCalledTimes(1);
@@ -258,7 +190,6 @@ describe("createApi", () => {
 
   describe("listOperations", () => {
     it("should call listOperations and return operations with proper structure", async () => {
-      const api = createApi("aleo");
       const options = { minHeight: 10, limit: 5 };
       const result = await api.listOperations(context, "aleo1test", options);
 
@@ -274,7 +205,6 @@ describe("createApi", () => {
     });
 
     it("should return undefined next when listOperations has no next cursor", async () => {
-      const api = createApi("aleo");
       mockedListOperations.mockResolvedValueOnce({
         operations: [mockOperation],
         tokenOperations: [],
@@ -289,7 +219,6 @@ describe("createApi", () => {
 
   describe("validateIntent", () => {
     it("should throw unsupported error", async () => {
-      const api = createApi("aleo");
       const txIntent = createMockTransactionIntent();
 
       expect(() => api.validateIntent(context, txIntent, [])).toThrow(

--- a/libs/coin-modules/coin-aleo/src/api/index.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.ts
@@ -17,15 +17,7 @@ import type {
   BalanceOptions,
 } from "@ledgerhq/coin-module-framework/api/index";
 import { craftTransactionData } from "@ledgerhq/coin-module-framework/logic/craftTransactionData";
-import { rejectBalanceOptions } from "@ledgerhq/coin-module-framework/api/getBalance/rejectBalanceOptions";
-import {
-  estimateFees,
-  getAccountInfo,
-  getBalance,
-  lastBlock,
-  listOperations,
-  validateAddress,
-} from "../logic";
+import { estimateFees, getAccountInfo, lastBlock, listOperations, validateAddress } from "../logic";
 import { getTransactionType } from "../logic/utils";
 import type { AleoContext, AleoCoinConfig, AleoTransactionIntentData } from "../types";
 
@@ -85,12 +77,11 @@ export function createApi(
       return getAccountInfo(config, provableId);
     },
     getBalance: async (
-      context: AleoContext,
-      address: string,
-      options?: BalanceOptions,
+      _context: AleoContext,
+      _address: string,
+      _options?: BalanceOptions,
     ): Promise<Balance[]> => {
-      const config = await context.config();
-      return rejectBalanceOptions(() => getBalance(config, address), options);
+      throw new Error("getBalance is not supported");
     },
     lastBlock: async (context: AleoContext): Promise<BlockInfo> => {
       const config = await context.config();

--- a/libs/coin-modules/coin-aleo/src/bridge/sync.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/sync.test.ts
@@ -5,7 +5,8 @@ import { log } from "@ledgerhq/logs";
 import { SyncConfig, DerivationMode } from "@ledgerhq/types-live";
 import { firstValueFrom, toArray, type Observable } from "rxjs";
 import { SYNC_TYPE_TRANSPARENT, SYNC_TYPE_SHIELDED } from "@ledgerhq/types-live";
-import { getBalance, lastBlock, listOperations } from "../logic";
+import { lastBlock, listOperations } from "../logic";
+import { getPublicBalance } from "../logic/getPublicBalance";
 import {
   getMockedCurrency,
   getMockedTokenCurrency,
@@ -43,10 +44,16 @@ jest.mock("@ledgerhq/ledger-wallet-framework/account", () => ({
   getSyncHash: jest.fn(),
 }));
 jest.mock("../logic");
-jest.mock("../network/utils");
+jest.mock("../network/utils", () => ({
+  ...jest.requireActual("../network/utils"),
+  accessProvableApi: jest.fn(),
+  fetchAllOwnedRecords: jest.fn(),
+  patchPublicOperations: jest.fn(),
+}));
 jest.mock("../network/api");
 jest.mock("../logic/listPrivateOperations");
 jest.mock("../logic/getPrivateBalance");
+jest.mock("../logic/getPublicBalance");
 jest.mock("../network/sdk");
 
 jest.mock("@ledgerhq/logs", () => ({
@@ -54,7 +61,7 @@ jest.mock("@ledgerhq/logs", () => ({
 }));
 
 const mockGetSyncHash = jest.mocked(getSyncHash);
-const mockGetBalance = jest.mocked(getBalance);
+const mockGetPublicBalance = jest.mocked(getPublicBalance);
 const mockLastBlock = jest.mocked(lastBlock);
 const mockListOperations = jest.mocked(listOperations);
 const mockAccessProvableApi = jest.mocked(accessProvableApi);
@@ -104,7 +111,7 @@ describe("sync.ts", () => {
     mockGetSyncHash.mockResolvedValue(mockSyncHash);
     coinConfig.setCoinConfig(() => mockConfig);
 
-    mockGetBalance.mockResolvedValue([
+    mockGetPublicBalance.mockResolvedValue([
       {
         asset: { type: "native" as const },
         value: BigInt(mockAccount.balance.toString()),
@@ -186,7 +193,7 @@ describe("sync.ts", () => {
     });
 
     it("should handle empty balance array", async () => {
-      mockGetBalance.mockResolvedValue([]);
+      mockGetPublicBalance.mockResolvedValue([]);
 
       const result = await performPublicSync(
         {
@@ -206,7 +213,7 @@ describe("sync.ts", () => {
 
     it("should update balance when it changes", async () => {
       const mockUpdatedBalance = 10;
-      mockGetBalance.mockResolvedValue([
+      mockGetPublicBalance.mockResolvedValue([
         {
           asset: { type: "native" as const },
           value: BigInt(mockUpdatedBalance),
@@ -330,7 +337,7 @@ describe("sync.ts", () => {
         operations: [oldOperation],
       };
 
-      mockGetBalance.mockResolvedValue([
+      mockGetPublicBalance.mockResolvedValue([
         {
           asset: { type: "native" as const },
           value: BigInt(1000),
@@ -364,7 +371,7 @@ describe("sync.ts", () => {
     });
 
     it("should propagate errors", async () => {
-      mockGetBalance.mockRejectedValue(new Error("Network timeout"));
+      mockGetPublicBalance.mockRejectedValue(new Error("Network timeout"));
 
       await expect(
         performPublicSync(
@@ -1681,7 +1688,7 @@ describe("sync.ts", () => {
     });
 
     it("createPublicSyncObservable errors when performPublicSync throws", async () => {
-      mockGetBalance.mockRejectedValue(new Error("rpc down"));
+      mockGetPublicBalance.mockRejectedValue(new Error("rpc down"));
       const shape$ = createPublicSyncObservable(baseInfo, mockSyncConfig);
       await expect(firstValueFrom(shape$)).rejects.toThrow("rpc down");
     });
@@ -1923,7 +1930,7 @@ describe("sync.ts", () => {
     });
 
     it("makeGetAccountShape errors the outer observable when public sync throws", async () => {
-      mockGetBalance.mockRejectedValue(new Error("Network failure"));
+      mockGetPublicBalance.mockRejectedValue(new Error("Network failure"));
 
       const shape$ = makeGetAccountShape()(baseInfo, { paginationConfig: {} });
 

--- a/libs/coin-modules/coin-aleo/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/sync.ts
@@ -15,7 +15,8 @@ import { SyncConfig, SYNC_TYPE_SHIELDED, SYNC_TYPE_TRANSPARENT } from "@ledgerhq
 import type { TokenAccount } from "@ledgerhq/types-live";
 import invariant from "invariant";
 import { AleoApiConfigurationResetError } from "../errors";
-import { getBalance, lastBlock, listOperations } from "../logic";
+import { lastBlock, listOperations } from "../logic";
+import { getPublicBalance } from "../logic/getPublicBalance";
 import {
   extractViewKey,
   isProvableApiConfigured,
@@ -76,7 +77,7 @@ export async function performPublicSync(
   const config = resolveConfig(currency.id);
 
   const [balances, latestBlock] = await Promise.all([
-    getBalance(config, address),
+    getPublicBalance(config, address),
     lastBlock(config),
   ]);
 

--- a/libs/coin-modules/coin-aleo/src/bridge/tokens.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/tokens.ts
@@ -13,14 +13,12 @@ import {
 } from "../constants";
 import { parseAmount } from "../logic/utils";
 import { apiClient } from "../network/api";
-import { sdkClient } from "../network/sdk";
-import { getTokenOutDetails } from "../network/utils";
+import { decryptRecordAmount, getTokenOutDetails } from "../network/utils";
 import type {
   AleoOperation,
   AleoTokenAccount,
   AleoPrivateRecord,
   AleoPrivateTokenBalance,
-  AleoDecryptedRecordResponse,
   AleoCoinConfig,
 } from "../types";
 
@@ -712,11 +710,6 @@ export async function buildSubAccountsFromPrivateRecords({
   const existingSubAccountIds = new Set(baseSubAccounts.map(sa => sa.id));
   const balanceEntriesById = new Map<string, AleoPrivateTokenBalance>();
 
-  const extractAmount = (decrypted: AleoDecryptedRecordResponse): BigNumber => {
-    const raw = decrypted.data?.amount ?? decrypted.data?.balance ?? decrypted.data?.microcredits;
-    return parseAmount(raw ?? null);
-  };
-
   // ── Phase 1: private balances from unspent records ───────────────────────────
 
   if (unspentPrivateRecords.length > 0) {
@@ -724,21 +717,15 @@ export async function buildSubAccountsFromPrivateRecords({
       const tokenCurrency = calTokens.get(record.program_name);
       if (!tokenCurrency) return;
 
-      const decrypted = await sdkClient.decryptRecord({
-        config,
-        ciphertext: record.record_ciphertext,
-        viewKey,
-      });
-
-      const amount = extractAmount(decrypted);
+      const decryptedRecord = await decryptRecordAmount(config, viewKey, record);
 
       const id = encodeTokenAccountId(ledgerAccountId, tokenCurrency);
       const entry = getOrCreateBalanceEntry(balanceEntriesById, id, tokenCurrency.contractAddress);
-      entry.balance = entry.balance.plus(amount);
+      entry.balance = entry.balance.plus(decryptedRecord.amount);
       entry.unspentRecords.push({
         ...record,
-        microcredits: amount.toString(),
-        decryptedData: decrypted,
+        microcredits: decryptedRecord.amount.toString(),
+        decryptedData: decryptedRecord.details,
       });
     });
   }
@@ -793,12 +780,8 @@ export async function buildSubAccountsFromPrivateRecords({
       fee = outDetails.fee;
     } else {
       // IN (or Private self-transfer): the record itself contains the correct received amount.
-      const decrypted = await sdkClient.decryptRecord({
-        config,
-        ciphertext: record.record_ciphertext,
-        viewKey,
-      });
-      amount = extractAmount(decrypted);
+      const decryptedRecord = await decryptRecordAmount(config, viewKey, record);
+      amount = decryptedRecord.amount;
     }
 
     const tokenAccountId = encodeTokenAccountId(ledgerAccountId, tokenCurrency);

--- a/libs/coin-modules/coin-aleo/src/logic/getPublicBalance.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getPublicBalance.test.ts
@@ -1,13 +1,13 @@
 import { apiClient } from "../network/api";
 import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
 import { getMockedAccount } from "../__tests__/fixtures/account.fixture";
-import { getBalance } from "./getBalance";
+import { getPublicBalance } from "./getPublicBalance";
 
 jest.mock("../network/api");
 
 const mockGetAccountBalance = jest.mocked(apiClient.getAccountBalance);
 
-describe("getBalance", () => {
+describe("getPublicBalance", () => {
   const mockConfig = getMockedConfig("mainnet");
   const mockAccount = getMockedAccount();
 
@@ -18,7 +18,7 @@ describe("getBalance", () => {
   it("should return balance when account has funds", async () => {
     mockGetAccountBalance.mockResolvedValue("1000000u64");
 
-    const result = await getBalance(mockConfig, mockAccount.freshAddress);
+    const result = await getPublicBalance(mockConfig, mockAccount.freshAddress);
 
     expect(result).toEqual([
       {
@@ -33,7 +33,7 @@ describe("getBalance", () => {
   it("should handle zero balance", async () => {
     mockGetAccountBalance.mockResolvedValue("0u64");
 
-    const result = await getBalance(mockConfig, mockAccount.freshAddress);
+    const result = await getPublicBalance(mockConfig, mockAccount.freshAddress);
 
     expect(result).toEqual([
       {
@@ -46,7 +46,7 @@ describe("getBalance", () => {
   it("should handle large balance values", async () => {
     mockGetAccountBalance.mockResolvedValue("999999999999999999u64");
 
-    const result = await getBalance(mockConfig, mockAccount.freshAddress);
+    const result = await getPublicBalance(mockConfig, mockAccount.freshAddress);
 
     expect(result).toEqual([
       {
@@ -59,7 +59,7 @@ describe("getBalance", () => {
   it("should parse balance correctly by removing last 3 characters (u64)", async () => {
     mockGetAccountBalance.mockResolvedValue("123456789u64");
 
-    const result = await getBalance(mockConfig, mockAccount.freshAddress);
+    const result = await getPublicBalance(mockConfig, mockAccount.freshAddress);
 
     expect(result).toEqual([
       {
@@ -72,7 +72,7 @@ describe("getBalance", () => {
   it("should return empty array when API returns null", async () => {
     mockGetAccountBalance.mockResolvedValue(null);
 
-    const result = await getBalance(mockConfig, mockAccount.freshAddress);
+    const result = await getPublicBalance(mockConfig, mockAccount.freshAddress);
 
     expect(result).toEqual([]);
   });
@@ -80,13 +80,13 @@ describe("getBalance", () => {
   it("should throw error when balance format is invalid (missing u64)", async () => {
     mockGetAccountBalance.mockResolvedValue("1000000");
 
-    await expect(getBalance(mockConfig, mockAccount.freshAddress)).rejects.toThrow();
+    await expect(getPublicBalance(mockConfig, mockAccount.freshAddress)).rejects.toThrow();
   });
 
   it("should parse balance with u32 suffix", async () => {
     mockGetAccountBalance.mockResolvedValue("1000000u32");
 
-    const result = await getBalance(mockConfig, mockAccount.freshAddress);
+    const result = await getPublicBalance(mockConfig, mockAccount.freshAddress);
 
     expect(result).toEqual([
       {
@@ -99,12 +99,12 @@ describe("getBalance", () => {
   it("should throw error when balance format has incomplete unit suffix", async () => {
     mockGetAccountBalance.mockResolvedValue("1000000u");
 
-    await expect(getBalance(mockConfig, mockAccount.freshAddress)).rejects.toThrow();
+    await expect(getPublicBalance(mockConfig, mockAccount.freshAddress)).rejects.toThrow();
   });
 
   it("should throw error when balance format is completely invalid", async () => {
     mockGetAccountBalance.mockResolvedValue("invalid");
 
-    await expect(getBalance(mockConfig, mockAccount.freshAddress)).rejects.toThrow();
+    await expect(getPublicBalance(mockConfig, mockAccount.freshAddress)).rejects.toThrow();
   });
 });

--- a/libs/coin-modules/coin-aleo/src/logic/getPublicBalance.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getPublicBalance.ts
@@ -3,7 +3,10 @@ import type { AleoCoinConfig } from "../types";
 import { apiClient } from "../network/api";
 import { parseMicrocredits } from "./utils";
 
-export async function getBalance(config: AleoCoinConfig, address: string): Promise<Balance[]> {
+export async function getPublicBalance(
+  config: AleoCoinConfig,
+  address: string,
+): Promise<Balance[]> {
   const microcreditsU64 = await apiClient.getAccountBalance(config, address);
 
   if (!microcreditsU64) {

--- a/libs/coin-modules/coin-aleo/src/logic/index.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/index.ts
@@ -3,7 +3,6 @@ export { combine } from "./combine";
 export { craftTransaction } from "./craftTransaction";
 export { estimateFees } from "./estimateFees";
 export { getAccountInfo } from "./getAccountInfo";
-export { getBalance } from "./getBalance";
 export { lastBlock } from "./lastBlock";
 export { listOperations } from "./listOperations";
 export { validateIntent } from "./validateIntent";

--- a/libs/coin-modules/coin-aleo/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.test.ts
@@ -16,9 +16,9 @@ import {
   getMockedRecord,
   getMockedPublicTransaction,
   getMockedTransactionDetails,
+  getMockedDecryptedRecord,
 } from "../__tests__/fixtures/api.fixture";
 import { getMockedOperation } from "../__tests__/fixtures/operation.fixture";
-import { accessProvableApi } from "./utils";
 import { apiClient } from "./api";
 import {
   fetchAccountTransactionsFromHeight,
@@ -27,6 +27,8 @@ import {
   patchPublicOperations,
   getTokenOutDetails,
   getRecordScannerStatusOrThrow,
+  accessProvableApi,
+  decryptRecordAmount,
 } from "./utils";
 
 jest.mock("./api");
@@ -393,6 +395,45 @@ describe("network/utils", () => {
         expect(result.transactions).toContainEqual(initializeTx);
         expect(result.transactions).not.toContainEqual(batcherOuterCall);
       });
+    });
+  });
+
+  describe("decryptRecordAmount", () => {
+    const mockViewKey = "AViewKey1abc";
+
+    it("should decrypt the record and parse the amount", async () => {
+      const record = getMockedRecord({ record_ciphertext: "ciphertext123" });
+      const details = getMockedDecryptedRecord({ data: { amount: "500000u64.private" } });
+      mockDecryptRecord.mockResolvedValueOnce(details);
+
+      const result = await decryptRecordAmount(mockConfig, mockViewKey, record);
+
+      expect(mockDecryptRecord).toHaveBeenCalledWith({
+        config: mockConfig,
+        viewKey: mockViewKey,
+        ciphertext: "ciphertext123",
+      });
+      expect(result.amount).toEqual(new BigNumber(500000));
+      expect(result.details).toEqual(details);
+    });
+
+    it.each([
+      ["balance", { balance: "200000u64.private" }],
+      ["microcredits", { microcredits: "100000u64.private" }],
+    ])("should fall back to %s when amount is missing", async (_label, data) => {
+      mockDecryptRecord.mockResolvedValueOnce(getMockedDecryptedRecord({ data }));
+
+      const result = await decryptRecordAmount(mockConfig, mockViewKey, getMockedRecord());
+
+      expect(result.amount).toEqual(new BigNumber(Object.values(data)[0].replace(/u64.*/, "")));
+    });
+
+    it("should return zero when no known amount field is present", async () => {
+      mockDecryptRecord.mockResolvedValueOnce(getMockedDecryptedRecord({ data: {} }));
+
+      const result = await decryptRecordAmount(mockConfig, mockViewKey, getMockedRecord());
+
+      expect(result.amount).toEqual(new BigNumber(0));
     });
   });
 

--- a/libs/coin-modules/coin-aleo/src/network/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.ts
@@ -20,6 +20,7 @@ import type {
   AleoTransition,
   AleoCoinConfig,
   AleoRecordScannerStatusResponse,
+  AleoDecryptedRecordResponse,
 } from "../types";
 import {
   isAleoAddressPlaintext,
@@ -29,6 +30,24 @@ import {
   parseMicrocredits,
 } from "../logic/utils";
 import { apiClient } from "./api";
+
+export async function decryptRecordAmount(
+  config: AleoCoinConfig,
+  viewKey: string,
+  record: AleoPrivateRecord,
+): Promise<{ amount: BigNumber; details: AleoDecryptedRecordResponse }> {
+  const details = await sdkClient.decryptRecord({
+    config,
+    viewKey,
+    ciphertext: record.record_ciphertext,
+  });
+  const raw = details.data?.amount ?? details.data?.balance ?? details.data?.microcredits;
+
+  return {
+    amount: parseAmount(raw ?? null),
+    details,
+  };
+}
 
 function limitTransactions(
   transactions: AleoPublicTransaction[],


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR is a prep work for the coin-aleo module framework ahead of a native `getBalance` implementation:

- logic-layer `getBalance` (which computes the on-chain public balance) is renamed to `getPublicBalance` to free up the name for the framework's `Api.getBalance`, whose implementation now throws `"getBalance is not supported"` as a placeholder until the framework version lands in next PR.
- record decryption used for private token balances is extracted into a shared `decryptRecordAmount` helper in `network/utils.ts`, replacing duplicated inline logic in `bridge/tokens.ts`.
- test fixtures were extended to reduce duplication across test files.

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- https://ledgerhq.atlassian.net/browse/LIVE-34091