### PR TITLE
[LWDM] feat(aleo): framework getBalance

### DIFF
--- a/.changeset/curvy-chicken-drum.md
+++ b/.changeset/curvy-chicken-drum.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+feat: aleo framework `getBalance`

--- a/libs/coin-modules/coin-aleo/src/__tests__/fixtures/api.fixture.ts
+++ b/libs/coin-modules/coin-aleo/src/__tests__/fixtures/api.fixture.ts
@@ -3,11 +3,13 @@ import { PROGRAM_ID } from "../../constants";
 import type { DelegatedProvingResponse } from "../../types";
 import {
   AleoDecryptedRecordResponse,
+  AleoGetTokensResponse,
   AleoPrivateRecord,
   AleoPublicTransaction,
   AleoPublicTransactionDetailsResponse,
   AleoPublicTransactionsResponse,
   AleoRecordScannerStatusResponse,
+  AleoTokenDetails,
   EnrichedPrivateRecord,
 } from "../../types";
 
@@ -469,6 +471,39 @@ export const getMockedRecordScannerStatus = (
   percentage: 100,
   sync_start_height: 0,
   synced_up_to: 20985061,
+  ...overrides,
+});
+
+export const getMockedTokenDetails = (overrides?: Partial<AleoTokenDetails>): AleoTokenDetails => ({
+  token_id: "token123field",
+  token_id_datatype: null,
+  token_standard: null,
+  symbol: "TKN",
+  display: "Token",
+  program_name: "token_b.aleo",
+  decimals: 6,
+  total_supply: "1000000000000",
+  verified: true,
+  token_icon_url: "https://example.com/token.png",
+  price: "1.23",
+  price_change_percentage_24h: "0.5",
+  fully_diluted_value: null,
+  total_market_cap: "1230000000",
+  volume_24h: "45000",
+  ...overrides,
+});
+
+export const getMockedGetTokensResponse = (
+  overrides?: Partial<AleoGetTokensResponse>,
+): AleoGetTokensResponse => ({
+  pagination: {
+    limit: 20,
+    offset: 0,
+    total_count: 1,
+    has_next: false,
+    has_previous: false,
+  },
+  data: [getMockedTokenDetails()],
   ...overrides,
 });
 

--- a/libs/coin-modules/coin-aleo/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.integ.test.ts
@@ -45,12 +45,14 @@ describe("createApi", () => {
   };
   let emptyAddress: string;
   let privacyContext: AleoContext;
+  let emptyAddressViewKey: string;
 
   beforeAll(async () => {
     setupCalStore();
     const pristineAccount = await getPristineAccount();
-    emptyAddress = pristineAccount.address;
     privacyContext = await withPrivacyContext(context, testnetViewKey);
+    emptyAddress = pristineAccount.address;
+    emptyAddressViewKey = pristineAccount.viewKey;
   });
 
   describe("estimateFees", () => {
@@ -238,6 +240,40 @@ describe("createApi", () => {
       await expect(
         getAccountInfo(contextWithUnknownProvableId, testnetAddress),
       ).rejects.toBeInstanceOf(AleoApiConfigurationResetError);
+    });
+  });
+
+  describe("getBalance", () => {
+    it("throws when no privacy context is given", async () => {
+      await expect(api.getBalance(context, testnetAddress)).rejects.toThrow(
+        "aleo: provableId is missing",
+      );
+    });
+
+    it("throws an error for an invalid address", async () => {
+      const invalidAddress = "invalid_address";
+
+      await expect(api.getBalance(privacyContext, invalidAddress)).rejects.toMatchObject({
+        name: "LedgerAPI4xx",
+        status: 404,
+      });
+    });
+
+    it("combines public and private balances for a native + token account", async () => {
+      const balance = await api.getBalance(privacyContext, testnetAddress);
+      const native = balance.find(entry => entry.asset.type === "native");
+      const tokens = balance.filter(entry => entry.asset.type === "arc22");
+
+      expect(native?.value).toBeGreaterThan(0n);
+      expect(tokens.length).toBeGreaterThan(0);
+    });
+
+    it("returns a zero native entry for a non-existing valid address", async () => {
+      const emptyPrivacyContext = await withPrivacyContext(context, emptyAddressViewKey);
+
+      const balance = await api.getBalance(emptyPrivacyContext, emptyAddress);
+
+      expect(balance).toEqual([{ value: 0n, asset: { type: "native" } }]);
     });
   });
 });

--- a/libs/coin-modules/coin-aleo/src/api/index.test.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.test.ts
@@ -1,3 +1,4 @@
+import type { BalanceOptions } from "@ledgerhq/coin-module-framework/api/types";
 import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
 import { getMockedCoinFrameworkOperation } from "../__tests__/fixtures/operation.fixture";
 import { createMockTransactionIntent } from "../__tests__/fixtures/transaction.fixture";
@@ -5,6 +6,7 @@ import {
   craftTransaction,
   estimateFees,
   getAccountInfo,
+  getBalance,
   lastBlock,
   listOperations,
 } from "../logic";
@@ -26,6 +28,7 @@ describe("createApi", () => {
   const mockedCraftTransaction = jest.mocked(craftTransaction);
   const mockedEstimateFees = jest.mocked(estimateFees);
   const mockedGetAccountInfo = jest.mocked(getAccountInfo);
+  const mockedGetBalance = jest.mocked(getBalance);
   const mockedLastBlock = jest.mocked(lastBlock);
   const mockedListOperations = jest.mocked(listOperations);
   const mockedGetTransactionType = jest.mocked(getTransactionType);
@@ -35,6 +38,7 @@ describe("createApi", () => {
 
     mockedCraftTransaction.mockResolvedValue({ transaction: "crafted_tx" });
     mockedEstimateFees.mockReturnValue({ value: BigInt(1234) });
+    mockedGetBalance.mockResolvedValue([{ value: BigInt(10), asset: { type: "native" } }]);
     mockedLastBlock.mockResolvedValue({ hash: "blockHash", height: 42, time: new Date() });
     mockedListOperations.mockResolvedValue({
       operations: [mockOperation],
@@ -50,6 +54,7 @@ describe("createApi", () => {
     expect(api.combine).toBeInstanceOf(Function);
     expect(api.craftTransaction).toBeInstanceOf(Function);
     expect(api.estimateFees).toBeInstanceOf(Function);
+    expect(api.getBalance).toBeInstanceOf(Function);
     expect(api.getBlock).toBeInstanceOf(Function);
     expect(api.getBlockInfo).toBeInstanceOf(Function);
     expect(api.lastBlock).toBeInstanceOf(Function);
@@ -137,6 +142,24 @@ describe("createApi", () => {
         transactionType: "transfer_public",
       });
       expect(result).toEqual({ value: BigInt(1234) });
+    });
+  });
+
+  describe("getBalance", () => {
+    it("should call getBalance and return balances", async () => {
+      const result = await api.getBalance(context, "aleo1test");
+
+      expect(mockedGetBalance).toHaveBeenCalledTimes(1);
+      expect(mockedGetBalance).toHaveBeenCalledWith(expect.any(Object), "aleo1test");
+      expect(result).toEqual([{ value: BigInt(10), asset: { type: "native" } }]);
+    });
+
+    it("should throw an exception when options is provided", async () => {
+      await expect(
+        api.getBalance(context, "", {} as unknown as BalanceOptions),
+      ).rejects.toMatchObject({
+        name: "InvalidParameterError",
+      });
     });
   });
 

--- a/libs/coin-modules/coin-aleo/src/api/index.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.ts
@@ -17,7 +17,15 @@ import type {
   BalanceOptions,
 } from "@ledgerhq/coin-module-framework/api/index";
 import { craftTransactionData } from "@ledgerhq/coin-module-framework/logic/craftTransactionData";
-import { estimateFees, getAccountInfo, lastBlock, listOperations, validateAddress } from "../logic";
+import { rejectBalanceOptions } from "@ledgerhq/coin-module-framework/api/getBalance/rejectBalanceOptions";
+import {
+  estimateFees,
+  getAccountInfo,
+  getBalance,
+  lastBlock,
+  listOperations,
+  validateAddress,
+} from "../logic";
 import { getTransactionType } from "../logic/utils";
 import type { AleoContext, AleoCoinConfig, AleoTransactionIntentData } from "../types";
 
@@ -77,11 +85,11 @@ export function createApi(
       return getAccountInfo(config, provableId);
     },
     getBalance: async (
-      _context: AleoContext,
-      _address: string,
-      _options?: BalanceOptions,
+      context: AleoContext,
+      address: string,
+      options?: BalanceOptions,
     ): Promise<Balance[]> => {
-      throw new Error("getBalance is not supported");
+      return rejectBalanceOptions(() => getBalance(context, address), options);
     },
     lastBlock: async (context: AleoContext): Promise<BlockInfo> => {
       const config = await context.config();

--- a/libs/coin-modules/coin-aleo/src/constants.ts
+++ b/libs/coin-modules/coin-aleo/src/constants.ts
@@ -2,6 +2,7 @@ export const ALEO_DUMMY_ADDRESS = "aleo14pfq40wgltv8wrhsxqe5tlme4pkp448rfejfvqhd
 
 export const PROGRAM_ID = {
   CREDITS: "credits.aleo",
+  TOKEN_REGISTRY: "token_registry.aleo",
 };
 
 export const EXPLORER_TRANSFER_TYPES = {
@@ -50,6 +51,9 @@ export const AMOUNT_ARG_INDEX = 2;
 // The maximum amount of records to fetch in a single API call when fetching owned records.
 // This is not a limit on the total number of records that can be fetched, but rather a pagination parameter for the API calls.
 export const DEFAULT_RECORDS_PAGE_SIZE = 1000;
+
+// Pagination parameter for GET /tokens calls when fetching the full token registry.
+export const DEFAULT_TOKENS_PAGE_SIZE = 1000;
 
 /**
  * Progress phase boundaries for private sync.

--- a/libs/coin-modules/coin-aleo/src/logic/getBalance.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getBalance.test.ts
@@ -1,0 +1,364 @@
+import { apiClient } from "../network/api";
+import { sdkClient } from "../network/sdk";
+import { fetchAccountTransactionsFromHeight, fetchAllOwnedRecords } from "../network/utils";
+import { PROGRAM_ID } from "../constants";
+import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
+import { getMockedAccount } from "../__tests__/fixtures/account.fixture";
+import {
+  getMockedDecryptedRecord,
+  getMockedGetTokensResponse,
+  getMockedRecord,
+  getMockedRecordScannerStatus,
+  getMockedTokenDetails,
+  getMockedTransaction,
+} from "../__tests__/fixtures/api.fixture";
+import type { AleoContext } from "../types";
+import { getBalance } from "./getBalance";
+
+jest.mock("../network/api");
+jest.mock("../network/sdk");
+jest.mock("../network/utils", () => ({
+  ...jest.requireActual("../network/utils"),
+  fetchAccountTransactionsFromHeight: jest.fn(),
+  fetchAllOwnedRecords: jest.fn(),
+}));
+
+const mockGetAccountBalance = jest.mocked(apiClient.getAccountBalance);
+const mockGetTokenBalance = jest.mocked(apiClient.getTokenBalance);
+const mockGetTokens = jest.mocked(apiClient.getTokens);
+const mockGetRecordScannerStatus = jest.mocked(apiClient.getRecordScannerStatus);
+const mockDecryptRecord = jest.mocked(sdkClient.decryptRecord);
+const mockFetchAccountTransactionsFromHeight = jest.mocked(fetchAccountTransactionsFromHeight);
+const mockFetchAllOwnedRecords = jest.mocked(fetchAllOwnedRecords);
+
+describe("getBalance", () => {
+  const mockConfig = getMockedConfig("mainnet");
+  const address = getMockedAccount().freshAddress;
+  const provableId = "provable-id-1";
+  const viewKey = "AViewKey1mock";
+  const context: AleoContext = {
+    config: async () => mockConfig,
+    logger: () => {},
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAccountBalance.mockResolvedValue("5000000u64");
+    mockGetTokenBalance.mockResolvedValue(null);
+    mockGetTokens.mockResolvedValue(
+      getMockedGetTokensResponse({
+        data: [
+          getMockedTokenDetails({ program_name: "token_b.aleo" }),
+          getMockedTokenDetails({ program_name: "token_pub.aleo" }),
+          getMockedTokenDetails({ program_name: "token_priv.aleo" }),
+        ],
+        pagination: { limit: 100, offset: 0, total_count: 3, has_next: false, has_previous: false },
+      }),
+    );
+    mockFetchAccountTransactionsFromHeight.mockResolvedValue({
+      transactions: [],
+      nextCursor: null,
+    });
+    mockFetchAllOwnedRecords.mockResolvedValue([]);
+  });
+
+  it("no provableId/viewKey — throws before any network call", async () => {
+    await expect(getBalance(context, address)).rejects.toThrow("aleo: provableId is missing");
+
+    expect(mockGetAccountBalance).not.toHaveBeenCalled();
+    expect(mockGetRecordScannerStatus).not.toHaveBeenCalled();
+    expect(mockFetchAllOwnedRecords).not.toHaveBeenCalled();
+    expect(mockDecryptRecord).not.toHaveBeenCalled();
+  });
+
+  it("address never indexed, no private funds or tokens — still returns a zero native entry", async () => {
+    mockGetAccountBalance.mockResolvedValue(null);
+    mockGetRecordScannerStatus.mockResolvedValue(getMockedRecordScannerStatus());
+
+    const result = await getBalance({ ...context, provableId, viewKey }, address);
+
+    expect(result).toEqual([{ value: 0n, asset: { type: "native" } }]);
+  });
+
+  it("both present — native = public + sum of decrypted unspent credits.aleo records (<= synced_up_to)", async () => {
+    mockGetRecordScannerStatus.mockResolvedValue(
+      getMockedRecordScannerStatus({ synced_up_to: 100 }),
+    );
+    mockFetchAllOwnedRecords.mockResolvedValue([
+      getMockedRecord({ program_name: PROGRAM_ID.CREDITS, block_height: 50, spent: false }),
+    ]);
+    mockDecryptRecord.mockResolvedValue(
+      getMockedDecryptedRecord({ data: { microcredits: "300000u64.private" } }),
+    );
+
+    const result = await getBalance({ ...context, provableId, viewKey }, address);
+
+    expect(result[0]).toEqual({ value: BigInt(5300000), asset: { type: "native" } });
+    expect(mockFetchAllOwnedRecords).toHaveBeenCalledWith({
+      config: mockConfig,
+      uuid: provableId,
+      unspent: true,
+      programs: [],
+      functions: [],
+    });
+    expect(mockDecryptRecord).toHaveBeenCalledWith({
+      config: mockConfig,
+      viewKey,
+      ciphertext: getMockedRecord().record_ciphertext,
+    });
+  });
+
+  it("one entry per token, public getTokenBalance + summed unspent token records (<= synced_up_to)", async () => {
+    mockFetchAccountTransactionsFromHeight.mockResolvedValue({
+      transactions: [getMockedTransaction({ program_id: "token_b.aleo" })],
+      nextCursor: null,
+    });
+    mockGetTokenBalance.mockResolvedValue("500u128");
+    mockGetRecordScannerStatus.mockResolvedValue(
+      getMockedRecordScannerStatus({ synced_up_to: 100 }),
+    );
+    mockFetchAllOwnedRecords.mockResolvedValue([
+      getMockedRecord({
+        program_name: "token_b.aleo",
+        record_name: "Token",
+        block_height: 50,
+        spent: false,
+      }),
+    ]);
+    mockDecryptRecord.mockResolvedValue(
+      getMockedDecryptedRecord({ data: { amount: "250u128.private" } }),
+    );
+
+    const result = await getBalance({ ...context, provableId, viewKey }, address);
+
+    expect(result).toContainEqual({
+      value: BigInt(750),
+      asset: { type: "unknown", assetReference: "token_b.aleo" },
+    });
+    expect(mockGetTokenBalance).toHaveBeenCalledWith(mockConfig, "token_b.aleo", address);
+  });
+
+  it("classifies token balances by asset type: arc20 (token_standard), arc21 (token_registry.aleo), arc22 (fallback)", async () => {
+    mockGetTokens.mockResolvedValue(
+      getMockedGetTokensResponse({
+        data: [
+          getMockedTokenDetails({ program_name: "arc20_program.aleo", token_standard: "ARC-20" }),
+          getMockedTokenDetails({ program_name: PROGRAM_ID.TOKEN_REGISTRY }),
+          getMockedTokenDetails({ program_name: "usdcx_stablecoin.aleo" }),
+        ],
+        pagination: { limit: 100, offset: 0, total_count: 3, has_next: false, has_previous: false },
+      }),
+    );
+    mockFetchAccountTransactionsFromHeight.mockResolvedValue({
+      transactions: [
+        getMockedTransaction({ program_id: "arc20_program.aleo" }),
+        getMockedTransaction({ program_id: PROGRAM_ID.TOKEN_REGISTRY }),
+        getMockedTransaction({ program_id: "usdcx_stablecoin.aleo" }),
+      ],
+      nextCursor: null,
+    });
+    mockGetTokenBalance.mockResolvedValue(null);
+    mockGetRecordScannerStatus.mockResolvedValue(
+      getMockedRecordScannerStatus({ synced_up_to: 100 }),
+    );
+
+    const result = await getBalance({ ...context, provableId, viewKey }, address);
+
+    const tokenBalances = result.filter(balance => balance.asset.type !== "native");
+    expect(tokenBalances).toContainEqual({
+      value: 0n,
+      asset: { type: "arc20", assetReference: "arc20_program.aleo" },
+    });
+    expect(tokenBalances).toContainEqual({
+      value: 0n,
+      asset: { type: "arc21", assetReference: PROGRAM_ID.TOKEN_REGISTRY },
+    });
+    expect(tokenBalances).toContainEqual({
+      value: 0n,
+      asset: { type: "arc22", assetReference: "usdcx_stablecoin.aleo" },
+    });
+  });
+
+  it("token discovery = union of public + private programs, minus credits.aleo", async () => {
+    mockFetchAccountTransactionsFromHeight.mockResolvedValue({
+      transactions: [getMockedTransaction({ program_id: "token_pub.aleo" })],
+      nextCursor: null,
+    });
+    mockGetTokenBalance.mockResolvedValue(null);
+    mockGetRecordScannerStatus.mockResolvedValue(
+      getMockedRecordScannerStatus({ synced_up_to: 100 }),
+    );
+    mockFetchAllOwnedRecords.mockResolvedValue([
+      getMockedRecord({ program_name: PROGRAM_ID.CREDITS, block_height: 50, spent: false }),
+      getMockedRecord({
+        program_name: "token_priv.aleo",
+        record_name: "Token",
+        block_height: 50,
+        spent: false,
+        commitment: "priv-commitment",
+      }),
+    ]);
+    mockDecryptRecord.mockResolvedValue(
+      getMockedDecryptedRecord({ data: { microcredits: "0u64.private" } }),
+    );
+
+    const result = await getBalance({ ...context, provableId, viewKey }, address);
+
+    const tokenAssetReferences = result
+      .filter(balance => balance.asset.type !== "native")
+      .map(balance => (balance.asset as { assetReference: string }).assetReference);
+
+    expect(tokenAssetReferences.sort()).toEqual(["token_priv.aleo", "token_pub.aleo"]);
+    expect(tokenAssetReferences).not.toContain(PROGRAM_ID.CREDITS);
+  });
+
+  it("a non-credits program_id absent from the token registry is not treated as a token", async () => {
+    mockFetchAccountTransactionsFromHeight.mockResolvedValue({
+      transactions: [getMockedTransaction({ program_id: "not_a_token.aleo" })],
+      nextCursor: null,
+    });
+    mockGetRecordScannerStatus.mockResolvedValue(
+      getMockedRecordScannerStatus({ synced_up_to: 100 }),
+    );
+
+    const result = await getBalance({ ...context, provableId, viewKey }, address);
+
+    expect(result.filter(balance => balance.asset.type !== "native")).toEqual([]);
+    expect(mockGetTokenBalance).not.toHaveBeenCalled();
+  });
+
+  it("a record above synced_up_to is excluded from both native and token sums", async () => {
+    mockGetRecordScannerStatus.mockResolvedValue(
+      getMockedRecordScannerStatus({ synced_up_to: 100 }),
+    );
+    mockFetchAllOwnedRecords.mockResolvedValue([
+      getMockedRecord({
+        program_name: PROGRAM_ID.CREDITS,
+        block_height: 100,
+        spent: false,
+        commitment: "eligible",
+      }),
+      getMockedRecord({
+        program_name: PROGRAM_ID.CREDITS,
+        block_height: 101,
+        spent: false,
+        commitment: "over-height",
+      }),
+    ]);
+    mockDecryptRecord.mockResolvedValue(
+      getMockedDecryptedRecord({ data: { microcredits: "100u64.private" } }),
+    );
+
+    const result = await getBalance({ ...context, provableId, viewKey }, address);
+
+    expect(result[0]).toEqual({ value: BigInt(5000100), asset: { type: "native" } });
+    expect(mockDecryptRecord).toHaveBeenCalledTimes(1);
+  });
+
+  it("synced_up_to: null — sums every unspent record with no height ceiling", async () => {
+    mockGetRecordScannerStatus.mockResolvedValue(
+      getMockedRecordScannerStatus({ synced_up_to: null }),
+    );
+    mockFetchAllOwnedRecords.mockResolvedValue([
+      getMockedRecord({
+        program_name: PROGRAM_ID.CREDITS,
+        block_height: 1_000_000,
+        spent: false,
+      }),
+    ]);
+    mockDecryptRecord.mockResolvedValue(
+      getMockedDecryptedRecord({ data: { microcredits: "100u64.private" } }),
+    );
+
+    const result = await getBalance({ ...context, provableId, viewKey }, address);
+
+    expect(result[0]).toEqual({ value: BigInt(5000100), asset: { type: "native" } });
+    expect(mockDecryptRecord).toHaveBeenCalledTimes(1);
+  });
+
+  it("synced:false still returns computed partial sums, no thrown error, no public-only fallback", async () => {
+    mockGetRecordScannerStatus.mockResolvedValue(
+      getMockedRecordScannerStatus({ synced: false, percentage: 40, synced_up_to: 90 }),
+    );
+    mockFetchAllOwnedRecords.mockResolvedValue([
+      getMockedRecord({ program_name: PROGRAM_ID.CREDITS, block_height: 90, spent: false }),
+    ]);
+    mockDecryptRecord.mockResolvedValue(
+      getMockedDecryptedRecord({ data: { microcredits: "42u64.private" } }),
+    );
+
+    const result = await getBalance({ ...context, provableId, viewKey }, address);
+
+    expect(result[0]).toEqual({ value: BigInt(5000042), asset: { type: "native" } });
+  });
+
+  it("provableId without viewKey throws before any scanner call", async () => {
+    await expect(getBalance({ ...context, provableId }, address)).rejects.toThrow(
+      "aleo: viewKey is missing",
+    );
+    expect(mockGetRecordScannerStatus).not.toHaveBeenCalled();
+  });
+
+  it("viewKey without provableId throws before any scanner call", async () => {
+    await expect(getBalance({ ...context, viewKey }, address)).rejects.toThrow(
+      "aleo: provableId is missing",
+    );
+    expect(mockGetRecordScannerStatus).not.toHaveBeenCalled();
+  });
+
+  it("AleoRecordScannerStatusResponse's new fields (sync_start_height/synced_up_to) drive the height filter", async () => {
+    const scannerStatus = getMockedRecordScannerStatus();
+    expect(scannerStatus.sync_start_height).toBe(0);
+    expect(scannerStatus.synced_up_to).toBe(20985061);
+    const syncedUpTo = scannerStatus.synced_up_to as number;
+
+    mockGetRecordScannerStatus.mockResolvedValue(scannerStatus);
+    mockFetchAllOwnedRecords.mockResolvedValue([
+      getMockedRecord({
+        program_name: PROGRAM_ID.CREDITS,
+        block_height: syncedUpTo,
+        spent: false,
+      }),
+      getMockedRecord({
+        program_name: PROGRAM_ID.CREDITS,
+        block_height: syncedUpTo + 1,
+        spent: false,
+        commitment: "past-synced-up-to",
+      }),
+    ]);
+    mockDecryptRecord.mockResolvedValue(
+      getMockedDecryptedRecord({ data: { microcredits: "1u64.private" } }),
+    );
+
+    await getBalance({ ...context, provableId, viewKey }, address);
+
+    expect(mockDecryptRecord).toHaveBeenCalledTimes(1);
+  });
+
+  it("the incomplete-privacy-context error never carries provableId or viewKey", async () => {
+    const secretProvableId = "secret-provable-id";
+    const secretViewKey = "secret-view-key";
+
+    let thrown: unknown;
+    try {
+      await getBalance({ ...context, provableId: secretProvableId }, address);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).not.toContain(secretProvableId);
+    expect(Object.keys(thrown as Error)).not.toContain("provableId");
+
+    let thrownForViewKey: unknown;
+    try {
+      await getBalance({ ...context, viewKey: secretViewKey }, address);
+    } catch (error) {
+      thrownForViewKey = error;
+    }
+
+    expect(thrownForViewKey).toBeInstanceOf(Error);
+    expect((thrownForViewKey as Error).message).not.toContain(secretViewKey);
+    expect(Object.keys(thrownForViewKey as Error)).not.toContain("viewKey");
+  });
+});

--- a/libs/coin-modules/coin-aleo/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getBalance.ts
@@ -1,0 +1,93 @@
+import invariant from "invariant";
+import BigNumber from "bignumber.js";
+import type { Balance } from "@ledgerhq/coin-module-framework/api/types";
+import { promiseAllBatched } from "@ledgerhq/coin-module-framework/promises";
+import { PROGRAM_ID } from "../constants";
+import { apiClient } from "../network/api";
+import {
+  fetchAccountTransactionsFromHeight,
+  fetchAllOwnedRecords,
+  fetchAllTokens,
+  getRecordScannerStatusOrThrow,
+  sumUnspentRecords,
+} from "../network/utils";
+import type { AleoContext, AleoPrivateRecord, AleoTokenType } from "../types";
+import { getPublicBalance } from "./getPublicBalance";
+import { classifyAleoTokenType, isTokenRecord, parseAmount, resolvePrivacyContext } from "./utils";
+
+export async function getBalance(context: AleoContext, address: string): Promise<Balance[]> {
+  const config = await context.config();
+  const privacyContext = resolvePrivacyContext(context);
+
+  const [publicBalance, publicDetails, status, allUnspentRecords, allTokens] = await Promise.all([
+    getPublicBalance(config, address),
+    fetchAccountTransactionsFromHeight({
+      config,
+      address,
+      fetchAllPages: true,
+      minBlockHeight: 0,
+    }),
+    getRecordScannerStatusOrThrow(config, privacyContext.provableId),
+    fetchAllOwnedRecords({
+      config,
+      uuid: privacyContext.provableId,
+      unspent: true,
+      // empty arrays opt out of the credits.aleo-only filter, returning records for all programs
+      programs: [],
+      functions: [],
+    }),
+    fetchAllTokens({ config }),
+  ]);
+
+  const tokenTypeByProgramName = new Map<string, AleoTokenType>(
+    allTokens.map(token => [token.program_name, classifyAleoTokenType(token)]),
+  );
+
+  const publicTokenProgramIds = new Set(
+    publicDetails.transactions
+      .map(tx => tx.program_id)
+      .filter(programId => programId !== PROGRAM_ID.CREDITS),
+  );
+  const maxSyncedBlockHeight = status.synced_up_to;
+
+  const privateNativeRecords = allUnspentRecords.filter(
+    record => record.program_name === PROGRAM_ID.CREDITS,
+  );
+  const privateTokenRecords = allUnspentRecords.filter(isTokenRecord);
+
+  const sumPrivate = (records: AleoPrivateRecord[]): Promise<BigNumber> =>
+    sumUnspentRecords({
+      config,
+      viewKey: privacyContext.viewKey,
+      records,
+      ...(typeof maxSyncedBlockHeight === "number" && { maxBlockHeight: maxSyncedBlockHeight }),
+    });
+
+  const privateNativeSum = await sumPrivate(privateNativeRecords);
+
+  const tokenProgramIds = [
+    ...new Set([
+      ...publicTokenProgramIds,
+      ...privateTokenRecords.map(record => record.program_name),
+    ]),
+  ].filter(programId => tokenTypeByProgramName.has(programId));
+
+  const tokenBalances: Balance[] = await promiseAllBatched(4, tokenProgramIds, async programId => {
+    const publicPart = parseAmount(await apiClient.getTokenBalance(config, programId, address));
+    const privatePart = await sumPrivate(
+      privateTokenRecords.filter(record => record.program_name === programId),
+    );
+    const type = tokenTypeByProgramName.get(programId);
+    invariant(typeof type === "string", "aleo: guard for token type");
+
+    return {
+      value: BigInt(publicPart.plus(privatePart).toFixed(0)),
+      asset: { type, assetReference: programId },
+    };
+  });
+
+  const publicNativeValue = publicBalance[0]?.value ?? 0n;
+  const nativeValue = publicNativeValue + BigInt(privateNativeSum.toFixed(0));
+
+  return [{ value: nativeValue, asset: { type: "native" } }, ...tokenBalances];
+}

--- a/libs/coin-modules/coin-aleo/src/logic/index.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/index.ts
@@ -3,6 +3,7 @@ export { combine } from "./combine";
 export { craftTransaction } from "./craftTransaction";
 export { estimateFees } from "./estimateFees";
 export { getAccountInfo } from "./getAccountInfo";
+export { getBalance } from "./getBalance";
 export { lastBlock } from "./lastBlock";
 export { listOperations } from "./listOperations";
 export { validateIntent } from "./validateIntent";

--- a/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
@@ -8,6 +8,7 @@ import {
   EXPLORER_TRANSFER_TYPES,
   MAX_PRIVATE_RECORDS_PER_TRANSACTION,
   MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION,
+  PROGRAM_ID,
   TRANSACTION_TYPE,
 } from "../constants";
 import {
@@ -28,6 +29,8 @@ import {
 import {
   getMockedTransaction as getMockedPublicTransaction,
   getMockedEnrichedPrivateRecord,
+  getMockedRecord,
+  getMockedTokenDetails,
 } from "../__tests__/fixtures/api.fixture";
 import { getMockedOperation } from "../__tests__/fixtures/operation.fixture";
 import { getMockedPreparedRequestResponse } from "../__tests__/fixtures/sdk.fixture";
@@ -48,7 +51,7 @@ import {
   mockTxIntentConvertTokenPrivateToPublic,
   mockTxIntentConvertTokenPrivateToPublic2,
 } from "../__tests__/fixtures/transaction.fixture";
-import type { AleoOperationExtra, ProvableApi } from "../types";
+import type { AleoContext, AleoOperationExtra, ProvableApi } from "../types";
 import {
   parseMicrocredits,
   parseAmount,
@@ -96,6 +99,9 @@ import {
   getStrategyConfig,
   isAleoAccount,
   isAleoTransaction,
+  isTokenRecord,
+  classifyAleoTokenType,
+  resolvePrivacyContext,
 } from "./utils";
 
 jest.mock("../config");
@@ -2624,5 +2630,120 @@ describe("getCalTokens", () => {
 
     expect(result.size).toBe(1);
     expect(result.get(MOCK_TOKEN_PROGRAM_ID)).toEqual(mockTokenCurrency);
+  });
+});
+
+describe("isTokenRecord", () => {
+  it("returns true for a Token record on a non-credits program", () => {
+    const record = getMockedRecord({
+      record_name: "Token",
+      program_name: "token_a.aleo",
+    });
+
+    expect(isTokenRecord(record)).toBe(true);
+  });
+
+  it("is case-insensitive on record_name", () => {
+    const record = getMockedRecord({
+      record_name: "TOKEN",
+      program_name: "token_a.aleo",
+    });
+
+    expect(isTokenRecord(record)).toBe(true);
+  });
+
+  it("returns false for a Token record on credits.aleo", () => {
+    const record = getMockedRecord({
+      record_name: "Token",
+      program_name: PROGRAM_ID.CREDITS,
+    });
+
+    expect(isTokenRecord(record)).toBe(false);
+  });
+
+  it("returns false for a non-Token record", () => {
+    const record = getMockedRecord({
+      record_name: "credits",
+      program_name: "token_a.aleo",
+    });
+
+    expect(isTokenRecord(record)).toBe(false);
+  });
+});
+
+describe("classifyAleoTokenType", () => {
+  it.each([
+    [
+      "token_standard is ARC-20",
+      { token_standard: "ARC-20", program_name: "arc20_program.aleo" },
+      "arc20",
+    ],
+    [
+      "token_standard is lowercase arc-20",
+      { token_standard: "arc-20", program_name: "arc20_program.aleo" },
+      "arc20",
+    ],
+    [
+      "program_name is the shared token_registry.aleo program",
+      { token_standard: null, program_name: PROGRAM_ID.TOKEN_REGISTRY },
+      "arc21",
+    ],
+    [
+      "token_standard wins over a token_registry.aleo program match",
+      { token_standard: "ARC-20", program_name: PROGRAM_ID.TOKEN_REGISTRY },
+      "arc20",
+    ],
+    [
+      "program_name contains stablecoin",
+      { token_standard: null, program_name: "usdcx_stablecoin.aleo" },
+      "arc22",
+    ],
+    [
+      "no rule matches",
+      { token_standard: null, program_name: "some_random_program.aleo" },
+      "unknown",
+    ],
+  ] as const)("%s → %s", (_description, overrides, expected) => {
+    const token = getMockedTokenDetails(overrides);
+
+    expect(classifyAleoTokenType(token)).toBe(expected);
+  });
+});
+
+describe("resolvePrivacyContext", () => {
+  const mockConfigFn = async () => getMockedConfig("mainnet");
+
+  it("returns provableId and viewKey when both are present", () => {
+    const context: AleoContext = {
+      config: mockConfigFn,
+      logger: () => {},
+      provableId: "provable-id-1",
+      viewKey: "AViewKey1mock",
+    };
+
+    expect(resolvePrivacyContext(context)).toEqual({
+      provableId: "provable-id-1",
+      viewKey: "AViewKey1mock",
+    });
+  });
+
+  it("throws when provableId is missing", () => {
+    const context: AleoContext = {
+      config: mockConfigFn,
+      logger: () => {},
+      viewKey: "AViewKey1mock",
+    };
+
+    expect(() => resolvePrivacyContext(context)).toThrow("aleo: provableId is missing");
+  });
+
+  it("throws when viewKey is missing", () => {
+    const context: AleoContext = {
+      config: mockConfigFn,
+      logger: () => {},
+      provableId: "provable-id-1",
+    };
+
+    expect(() => resolvePrivacyContext(context)).toThrow("aleo: viewKey is missing");
   });
 });

--- a/libs/coin-modules/coin-aleo/src/logic/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.ts
@@ -32,6 +32,7 @@ import {
   MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION,
   PROGRAM_ID,
   SINGLE_CALL_SIGNING_TIME,
+  TOKEN_RECORD_NAME,
   TRANSACTION_TYPE,
 } from "../constants";
 import type {
@@ -52,10 +53,14 @@ import type {
   TransactionPublic,
   TransactionPrivate,
   AleoCoinConfig,
+  AleoPrivateRecord,
   AleoUnspentRecord,
   AleoTransactionIntent,
   SigningStrategy,
   StrategyConfig,
+  AleoContext,
+  AleoTokenDetails,
+  AleoTokenType,
 } from "../types";
 
 const MICROCREDITS_REGEX = /^(\d+)u\d+$/;
@@ -78,6 +83,33 @@ export function parseMicrocredits(microcredits: string): string {
 export function parseAmount(raw: string | null): BigNumber {
   if (!raw) return new BigNumber(0);
   return new BigNumber(matchAleoPlaintextAmount(raw) ?? 0);
+}
+
+export function isTokenRecord(record: AleoPrivateRecord): boolean {
+  return (
+    record.record_name.toLowerCase() === TOKEN_RECORD_NAME.toLowerCase() &&
+    record.program_name !== PROGRAM_ID.CREDITS
+  );
+}
+
+export function classifyAleoTokenType(token: AleoTokenDetails): AleoTokenType {
+  if (token.token_standard?.toLowerCase() === "arc-20") return "arc20";
+  if (token.program_name === PROGRAM_ID.TOKEN_REGISTRY) return "arc21";
+  if (token.program_name.includes("stablecoin")) return "arc22";
+  return "unknown";
+}
+
+export function resolvePrivacyContext(context: AleoContext): {
+  provableId: string;
+  viewKey: string;
+} {
+  invariant(typeof context.provableId === "string", "aleo: provableId is missing");
+  invariant(typeof context.viewKey === "string", "aleo: viewKey is missing");
+
+  return {
+    provableId: context.provableId,
+    viewKey: context.viewKey,
+  };
 }
 
 export function patchAccountWithViewKey(account: Account, viewKey: string): Account {

--- a/libs/coin-modules/coin-aleo/src/network/api.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/api.test.ts
@@ -10,6 +10,7 @@ import {
   getMockedAuthorization,
   getMockedFeeAuthorization,
   getMockedDelegatedProvingResponse,
+  getMockedGetTokensResponse,
 } from "../__tests__/fixtures/api.fixture";
 import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
 import { apiClient } from "./api";
@@ -361,6 +362,60 @@ describe("apiClient", () => {
         method: "GET",
         url: `${testnetConfig.apiUrls.node}/v2/${testnetConfig.networkType}/program/credits.aleo/mapping/account/${MOCK_ALEO_ADDRESS}`,
       });
+    });
+  });
+
+  describe("getTokens", () => {
+    it("should fetch the token registry with no params by default", async () => {
+      const mockResponse = getMockedGetTokensResponse();
+      jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
+
+      const result = await apiClient.getTokens({ config: mockConfig });
+
+      expect(network).toHaveBeenCalledTimes(1);
+      expect(network).toHaveBeenCalledWith({
+        method: "GET",
+        url: `${mockConfig.apiUrls.node}/v2/${mockConfig.networkType}/tokens?`,
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it("should forward limit and offset as query params", async () => {
+      const mockResponse = getMockedGetTokensResponse();
+      jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
+
+      await apiClient.getTokens({
+        config: mockConfig,
+        options: { limit: 100, offset: 200 },
+      });
+
+      expect(network).toHaveBeenCalledTimes(1);
+      expect(network).toHaveBeenCalledWith({
+        method: "GET",
+        url: `${mockConfig.apiUrls.node}/v2/${mockConfig.networkType}/tokens?limit=100&offset=200`,
+      });
+    });
+
+    it("should forward verified and symbol as query params", async () => {
+      const mockResponse = getMockedGetTokensResponse();
+      jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
+
+      await apiClient.getTokens({
+        config: mockConfig,
+        options: { verified: true, symbol: "usdc" },
+      });
+
+      expect(network).toHaveBeenCalledTimes(1);
+      expect(network).toHaveBeenCalledWith({
+        method: "GET",
+        url: `${mockConfig.apiUrls.node}/v2/${mockConfig.networkType}/tokens?symbol=usdc&verified=true`,
+      });
+    });
+
+    it("should throw an error when network request fails", async () => {
+      jest.mocked(network).mockRejectedValue(new Error("Network error"));
+
+      await expect(apiClient.getTokens({ config: mockConfig })).rejects.toThrow("Network error");
     });
   });
 

--- a/libs/coin-modules/coin-aleo/src/network/api.ts
+++ b/libs/coin-modules/coin-aleo/src/network/api.ts
@@ -8,6 +8,7 @@ import type {
   AleoRegisterForRecordsResponse,
   AleoGetScannerPublicKeyResponse,
   AleoGetProvePublicKeyResponse,
+  AleoGetTokensResponse,
   AleoPrivateRecord,
   DelegatedProvingResponse,
 } from "../types/api";
@@ -55,6 +56,41 @@ async function getTokenBalance(
   const res = await network<string | null>({
     method: "GET",
     url: `${apiUrls.node}/v2/${networkType}/program/${programId}/mapping/balances/${address}`,
+  });
+
+  return res.data;
+}
+
+/**
+ * Fetches the registry of known tokens on the network (ARC-20, ARC-21 and ARC-22 alike).
+ *
+ * @param config - The Aleo coin config
+ * @param params.limit - Max items to return (server default: 20)
+ * @param params.offset - Number of items to skip (server default: 0)
+ */
+async function getTokens({
+  config,
+  options = {},
+}: {
+  config: AleoCoinConfig;
+  options?: {
+    verified?: boolean;
+    symbol?: string;
+    limit?: number;
+    offset?: number;
+  };
+}): Promise<AleoGetTokensResponse> {
+  const { apiUrls, networkType } = config;
+  const params = new URLSearchParams({
+    ...(options.symbol && { symbol: options.symbol }),
+    ...(typeof options.verified === "boolean" && { verified: options.verified.toString() }),
+    ...(typeof options.limit === "number" && { limit: options.limit.toString() }),
+    ...(typeof options.offset === "number" && { offset: options.offset.toString() }),
+  });
+
+  const res = await network<AleoGetTokensResponse>({
+    method: "GET",
+    url: `${apiUrls.node}/v2/${networkType}/tokens?${params.toString()}`,
   });
 
   return res.data;
@@ -283,6 +319,7 @@ export const apiClient = {
   getLatestBlock,
   getAccountBalance,
   getTokenBalance,
+  getTokens,
   getTransactionById,
   getAccountPublicTransactions,
   getRecordScannerStatus,

--- a/libs/coin-modules/coin-aleo/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.test.ts
@@ -4,6 +4,7 @@ import { AleoApiConfigurationResetError } from "../errors";
 import {
   EXPLORER_TRANSFER_TYPES,
   DEFAULT_RECORDS_PAGE_SIZE,
+  DEFAULT_TOKENS_PAGE_SIZE,
   PROGRAM_ID,
   TOKEN_RECORD_NAME,
   RECIPIENT_ARG_INDEX,
@@ -17,18 +18,22 @@ import {
   getMockedPublicTransaction,
   getMockedTransactionDetails,
   getMockedDecryptedRecord,
+  getMockedTokenDetails,
+  getMockedGetTokensResponse,
 } from "../__tests__/fixtures/api.fixture";
 import { getMockedOperation } from "../__tests__/fixtures/operation.fixture";
 import { apiClient } from "./api";
 import {
   fetchAccountTransactionsFromHeight,
   fetchAllOwnedRecords,
+  fetchAllTokens,
   enrichPrivateRecord,
   patchPublicOperations,
   getTokenOutDetails,
   getRecordScannerStatusOrThrow,
   accessProvableApi,
   decryptRecordAmount,
+  sumUnspentRecords,
 } from "./utils";
 
 jest.mock("./api");
@@ -2074,6 +2079,177 @@ describe("network/utils", () => {
       ).rejects.toMatchObject({ name: "AbortError" });
 
       expect(mockGetAccountOwnedRecords).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("fetchAllTokens", () => {
+    const mockGetTokens = jest.mocked(apiClient.getTokens);
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("should return every token when they fit in a single page", async () => {
+      const tokenA = getMockedTokenDetails({ program_name: "token_a.aleo" });
+      const tokenB = getMockedTokenDetails({ program_name: "token_b.aleo" });
+      mockGetTokens.mockResolvedValueOnce(
+        getMockedGetTokensResponse({
+          data: [tokenA, tokenB],
+          pagination: {
+            limit: 100,
+            offset: 0,
+            total_count: 2,
+            has_next: false,
+            has_previous: false,
+          },
+        }),
+      );
+
+      const result = await fetchAllTokens({ config: mockConfig });
+
+      expect(mockGetTokens).toHaveBeenCalledTimes(1);
+      expect(mockGetTokens).toHaveBeenCalledWith({
+        config: mockConfig,
+        options: { limit: DEFAULT_TOKENS_PAGE_SIZE, offset: 0 },
+      });
+      expect(result).toEqual([tokenA, tokenB]);
+    });
+
+    it("should paginate using offset until has_next is false", async () => {
+      const pageSize = 2;
+      const tokenA = getMockedTokenDetails({ program_name: "token_a.aleo" });
+      const tokenB = getMockedTokenDetails({ program_name: "token_b.aleo" });
+      const tokenC = getMockedTokenDetails({ program_name: "token_c.aleo" });
+      mockGetTokens
+        .mockResolvedValueOnce(
+          getMockedGetTokensResponse({
+            data: [tokenA, tokenB],
+            pagination: {
+              limit: pageSize,
+              offset: 0,
+              total_count: 3,
+              has_next: true,
+              has_previous: false,
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          getMockedGetTokensResponse({
+            data: [tokenC],
+            pagination: {
+              limit: pageSize,
+              offset: pageSize,
+              total_count: 3,
+              has_next: false,
+              has_previous: true,
+            },
+          }),
+        );
+
+      const result = await fetchAllTokens({ config: mockConfig, resultsPerPage: pageSize });
+
+      expect(mockGetTokens).toHaveBeenCalledTimes(2);
+      expect(mockGetTokens).toHaveBeenNthCalledWith(1, {
+        config: mockConfig,
+        options: { limit: pageSize, offset: 0 },
+      });
+      expect(mockGetTokens).toHaveBeenNthCalledWith(2, {
+        config: mockConfig,
+        options: { limit: pageSize, offset: pageSize },
+      });
+      expect(result).toEqual([tokenA, tokenB, tokenC]);
+    });
+
+    it("should return an empty array when the registry has no tokens", async () => {
+      mockGetTokens.mockResolvedValueOnce(getMockedGetTokensResponse({ data: [] }));
+
+      const result = await fetchAllTokens({ config: mockConfig });
+
+      expect(result).toEqual([]);
+    });
+
+    it("should propagate errors thrown by the underlying API call", async () => {
+      mockGetTokens.mockRejectedValueOnce(new Error("Tokens endpoint unavailable"));
+
+      await expect(fetchAllTokens({ config: mockConfig })).rejects.toThrow(
+        "Tokens endpoint unavailable",
+      );
+    });
+  });
+
+  describe("sumUnspentRecords", () => {
+    const mockViewKey = "AViewKey1sumtest";
+
+    it("returns zero without calling decryptRecord when there are no records", async () => {
+      const result = await sumUnspentRecords({
+        config: mockConfig,
+        viewKey: mockViewKey,
+        records: [],
+      });
+
+      expect(result.toFixed(0)).toBe("0");
+      expect(mockDecryptRecord).not.toHaveBeenCalled();
+    });
+
+    it("sums the decrypted amount of every unspent record", async () => {
+      const records = [
+        getMockedRecord({ commitment: "a", record_ciphertext: "cipher-a" }),
+        getMockedRecord({ commitment: "b", record_ciphertext: "cipher-b" }),
+      ];
+      mockDecryptRecord
+        .mockResolvedValueOnce(
+          getMockedDecryptedRecord({ data: { microcredits: "100u64.private" } }),
+        )
+        .mockResolvedValueOnce(
+          getMockedDecryptedRecord({ data: { microcredits: "250u64.private" } }),
+        );
+
+      const result = await sumUnspentRecords({
+        config: mockConfig,
+        viewKey: mockViewKey,
+        records,
+      });
+
+      expect(result.toFixed(0)).toBe("350");
+    });
+
+    it("excludes records scanned past maxBlockHeight", async () => {
+      const records = [
+        getMockedRecord({ commitment: "eligible", block_height: 100 }),
+        getMockedRecord({ commitment: "over-height", block_height: 101 }),
+      ];
+      mockDecryptRecord.mockResolvedValue(
+        getMockedDecryptedRecord({ data: { microcredits: "100u64.private" } }),
+      );
+
+      const result = await sumUnspentRecords({
+        config: mockConfig,
+        viewKey: mockViewKey,
+        records,
+        maxBlockHeight: 100,
+      });
+
+      expect(result.toFixed(0)).toBe("100");
+      expect(mockDecryptRecord).toHaveBeenCalledTimes(1);
+    });
+
+    it("sums every record when maxBlockHeight is omitted", async () => {
+      const records = [
+        getMockedRecord({ commitment: "a", block_height: 100 }),
+        getMockedRecord({ commitment: "b", block_height: 1_000_000 }),
+      ];
+      mockDecryptRecord.mockResolvedValue(
+        getMockedDecryptedRecord({ data: { microcredits: "50u64.private" } }),
+      );
+
+      const result = await sumUnspentRecords({
+        config: mockConfig,
+        viewKey: mockViewKey,
+        records,
+      });
+
+      expect(result.toFixed(0)).toBe("100");
+      expect(mockDecryptRecord).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/libs/coin-modules/coin-aleo/src/network/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.ts
@@ -1,10 +1,12 @@
 import BigNumber from "bignumber.js";
 import { log } from "@ledgerhq/logs";
+import { promiseAllBatched } from "@ledgerhq/coin-module-framework/promises";
 import { AleoApiConfigurationResetError } from "../errors";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import {
   AMOUNT_ARG_INDEX,
   DEFAULT_RECORDS_PAGE_SIZE,
+  DEFAULT_TOKENS_PAGE_SIZE,
   EXPLORER_TRANSFER_TYPES,
   PROGRAM_ID,
   RECIPIENT_ARG_INDEX,
@@ -21,6 +23,7 @@ import type {
   AleoCoinConfig,
   AleoRecordScannerStatusResponse,
   AleoDecryptedRecordResponse,
+  AleoTokenDetails,
 } from "../types";
 import {
   isAleoAddressPlaintext,
@@ -47,6 +50,35 @@ export async function decryptRecordAmount(
     amount: parseAmount(raw ?? null),
     details,
   };
+}
+
+/**
+ * Sums the decrypted amount of every unspent record.
+ *
+ * @param maxBlockHeight - Excludes records scanned past this height. Omit to sum all records.
+ */
+export async function sumUnspentRecords({
+  config,
+  viewKey,
+  records,
+  maxBlockHeight,
+}: {
+  config: AleoCoinConfig;
+  viewKey: string;
+  records: AleoPrivateRecord[];
+  maxBlockHeight?: number;
+}): Promise<BigNumber> {
+  const filteredRecords = records.filter(record => {
+    if (typeof maxBlockHeight !== "number") return true;
+    return record.block_height <= maxBlockHeight;
+  });
+
+  const amounts = await promiseAllBatched(4, filteredRecords, async record => {
+    const decryptedRecord = await decryptRecordAmount(config, viewKey, record);
+    return decryptedRecord.amount;
+  });
+
+  return amounts.reduce((sum, amount) => sum.plus(amount), new BigNumber(0));
 }
 
 function limitTransactions(
@@ -213,6 +245,40 @@ export async function fetchAllOwnedRecords({
   }
 
   return allRecords;
+}
+
+/**
+ * Fetches the full token registry (ARC-20, ARC-21 and ARC-22 alike).
+ *
+ * The `/tokens` endpoint has no program-name filter, so identifying whether a given
+ * program is a known token requires the full registry rather than a per-program lookup.
+ */
+export async function fetchAllTokens({
+  config,
+  resultsPerPage = DEFAULT_TOKENS_PAGE_SIZE,
+}: {
+  config: AleoCoinConfig;
+  resultsPerPage?: number;
+}): Promise<AleoTokenDetails[]> {
+  const tokens: AleoTokenDetails[] = [];
+  let offset = 0;
+  let hasNext = true;
+
+  while (hasNext) {
+    const { data, pagination } = await apiClient.getTokens({
+      config,
+      options: {
+        limit: resultsPerPage,
+        offset,
+      },
+    });
+
+    tokens.push(...data);
+    hasNext = pagination.has_next;
+    offset += resultsPerPage;
+  }
+
+  return tokens;
 }
 
 export async function getRecordScannerStatusOrThrow(

--- a/libs/coin-modules/coin-aleo/src/types/api.ts
+++ b/libs/coin-modules/coin-aleo/src/types/api.ts
@@ -124,6 +124,35 @@ export interface AleoDecryptedCiphertextResponse {
   plaintext: string;
 }
 
+export interface AleoTokenDetails {
+  token_id: string;
+  token_id_datatype: string | null;
+  token_standard: string | null;
+  symbol: string;
+  display: string;
+  program_name: string;
+  decimals: number;
+  total_supply: string | null;
+  verified: boolean;
+  token_icon_url: string;
+  price: string | null;
+  price_change_percentage_24h: string;
+  fully_diluted_value: null;
+  total_market_cap: string | null;
+  volume_24h: string | null;
+}
+
+export interface AleoGetTokensResponse {
+  data: AleoTokenDetails[];
+  pagination: {
+    limit: number;
+    offset: number;
+    total_count: number;
+    has_next: boolean;
+    has_previous: boolean;
+  };
+}
+
 interface DelegatedProvingTransitionResponse {
   id: string;
   program: string;

--- a/libs/coin-modules/coin-aleo/src/types/config.ts
+++ b/libs/coin-modules/coin-aleo/src/types/config.ts
@@ -22,4 +22,7 @@ export type AleoCoinConfig = CurrencyConfig & AleoConfig;
  *
  * The free-form `Record` part carries a `currencyId` needed by some methods (e.g. listOperations).
  */
-export type AleoContext = Context<AleoCoinConfig>;
+export type AleoContext = Context<AleoCoinConfig> & {
+  provableId?: string;
+  viewKey?: string;
+};

--- a/libs/coin-modules/coin-aleo/src/types/logic.ts
+++ b/libs/coin-modules/coin-aleo/src/types/logic.ts
@@ -48,6 +48,8 @@ export type AleoAccountInfo = {
 
 export type RecordPickingStrategy = "manual" | "auto";
 
+export type AleoTokenType = "arc20" | "arc21" | "arc22" | "unknown";
+
 export type TransactionType = (typeof TRANSACTION_TYPE)[keyof typeof TRANSACTION_TYPE];
 
 export type AleoTransactionIntentData =


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR implements the framework's `Api.getBalance` for Aleo, replacing the "not supported" placeholder left by part 1. It combines the public on-chain balance with private (shielded) balances by decrypting the caller's unspent records, and reports per-token balances alongside the native one. Token programs are discovered from both public transaction history and private records, then classified as `arc20`/`arc21`/`arc22`/`unknown` against a newly fetched token registry (`GET /tokens`, paginated via `fetchAllTokens`). Private balances require a `provableId` + `viewKey` on the context (`resolvePrivacyContext`); record sums are capped at the scanner's `synced_up_to` height to avoid counting not-yet-indexed funds, and errors intentionally never leak the caller's `provableId`/`viewKey`.

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- https://ledgerhq.atlassian.net/browse/LIVE-34091
