### PR TITLE
[LWDM] feat(aleo): framework craftTransaction

### DIFF
--- a/.changeset/nervous-drinks-clap.md
+++ b/.changeset/nervous-drinks-clap.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+feat: implement `craftTransaction` on the framework API for Aleo
+

--- a/libs/coin-modules/coin-aleo/src/__tests__/fixtures/api.fixture.ts
+++ b/libs/coin-modules/coin-aleo/src/__tests__/fixtures/api.fixture.ts
@@ -365,6 +365,13 @@ export const testnetInboundPrivateToPublicTx: AleoPublicTransaction = {
 
 export const TEST_TOKEN_PROGRAM_ID = "test_usad_stablecoin.aleo";
 
+export const testnetSpentTokenRecord: AleoDecryptedRecordResponse = {
+  owner: `${testnetAddress}.private`,
+  data: { amount: "1u128.private" },
+  nonce: "1344917106254048670972991786623247617474892323390373138993206886249401722645group",
+  version: 1,
+};
+
 // Outgoing transfer_private_to_public (credits) — testnetAddress converts a private record to
 // a THIRD PARTY's public balance (not itself). Exercises getTokenOutDetails's PRIVATE_TO_PUBLIC
 // branch, which is program-agnostic (reads plaintext public inputs, no token-argument offset).

--- a/libs/coin-modules/coin-aleo/src/__tests__/fixtures/transaction.fixture.ts
+++ b/libs/coin-modules/coin-aleo/src/__tests__/fixtures/transaction.fixture.ts
@@ -17,6 +17,7 @@ import {
   mockUnspentTokenRecord2,
 } from "./account.fixture";
 import { MOCK_TOKEN_PROGRAM_ID } from "./currency.fixture";
+import { TEST_TOKEN_PROGRAM_ID, testnetSpentTokenRecord } from "./api.fixture";
 
 export const getMockedTransaction = (overrides?: Partial<Transaction>): Transaction => {
   return {
@@ -49,6 +50,13 @@ const baseTxIntentFields = {
   recipient: "aleo172yejeypnffsdft3nrlpwnu964sn83p7ga6dm5zj7ucmqfqjk5rq3pmx6f",
 } as const satisfies Partial<AleoTransactionIntent>;
 
+// must match SDK backend validation (top byte capped at 01/02/03 so each value stays below the curve's field modulus)
+export const MOCK_MULTI_RECORD_TVKS = [
+  "aa".repeat(31) + "01",
+  "bb".repeat(31) + "02",
+  "cc".repeat(31) + "03",
+];
+
 export const mockTxIntentTransferPublic: AleoTransactionIntent = {
   ...baseTxIntentFields,
   amount: 100n,
@@ -62,6 +70,7 @@ export const mockTxIntentTransferPrivate: AleoTransactionIntent = {
   data: {
     type: TRANSACTION_TYPE.TRANSFER_PRIVATE,
     records: [mockUnspentRecord1.decryptedData],
+    tvks: [],
   },
 };
 
@@ -72,6 +81,7 @@ export const mockTxIntentTransferPrivate2: AleoTransactionIntent = {
   data: {
     type: TRANSACTION_TYPE.TRANSFER_PRIVATE,
     records: [mockUnspentRecord1.decryptedData, mockUnspentRecord2.decryptedData],
+    tvks: MOCK_MULTI_RECORD_TVKS,
   },
 };
 
@@ -88,6 +98,7 @@ export const mockTxIntentSelfTransferToPublic: AleoTransactionIntent = {
   data: {
     type: TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC,
     records: [mockUnspentRecord1.decryptedData],
+    tvks: [],
   },
 };
 
@@ -98,6 +109,7 @@ export const mockTxIntentSelfTransferToPublic2: AleoTransactionIntent = {
   data: {
     type: TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC,
     records: [mockUnspentRecord1.decryptedData, mockUnspentRecord2.decryptedData],
+    tvks: MOCK_MULTI_RECORD_TVKS,
   },
 };
 
@@ -154,6 +166,7 @@ export const mockTxIntentTransferTokenPrivate: AleoTransactionIntent = {
     type: TRANSACTION_TYPE.TRANSFER_TOKEN_PRIVATE,
     programId: MOCK_TOKEN_PROGRAM_ID,
     records: [mockUnspentTokenRecord1.decryptedData],
+    tvks: [],
   },
 };
 
@@ -165,6 +178,7 @@ export const mockTxIntentTransferTokenPrivate2: AleoTransactionIntent = {
     type: TRANSACTION_TYPE.TRANSFER_TOKEN_PRIVATE,
     programId: MOCK_TOKEN_PROGRAM_ID,
     records: [mockUnspentTokenRecord1.decryptedData, mockUnspentTokenRecord2.decryptedData],
+    tvks: MOCK_MULTI_RECORD_TVKS,
   },
 };
 
@@ -176,6 +190,31 @@ export const mockTxIntentConvertTokenPrivateToPublic: AleoTransactionIntent = {
     type: TRANSACTION_TYPE.CONVERT_TOKEN_PRIVATE_TO_PUBLIC,
     programId: MOCK_TOKEN_PROGRAM_ID,
     records: [mockUnspentTokenRecord1.decryptedData],
+    tvks: [],
+  },
+};
+
+export const mockTxIntentTransferTokenPrivateReal: AleoTransactionIntent = {
+  ...baseTxIntentFields,
+  amount: 1n,
+  type: TRANSACTION_TYPE.TRANSFER_TOKEN_PRIVATE,
+  data: {
+    type: TRANSACTION_TYPE.TRANSFER_TOKEN_PRIVATE,
+    programId: TEST_TOKEN_PROGRAM_ID,
+    records: [testnetSpentTokenRecord],
+    tvks: [],
+  },
+};
+
+export const mockTxIntentConvertTokenPrivateToPublicReal: AleoTransactionIntent = {
+  ...baseTxIntentFields,
+  amount: 1n,
+  type: TRANSACTION_TYPE.CONVERT_TOKEN_PRIVATE_TO_PUBLIC,
+  data: {
+    type: TRANSACTION_TYPE.CONVERT_TOKEN_PRIVATE_TO_PUBLIC,
+    programId: TEST_TOKEN_PROGRAM_ID,
+    records: [testnetSpentTokenRecord],
+    tvks: [],
   },
 };
 
@@ -187,6 +226,7 @@ export const mockTxIntentConvertTokenPrivateToPublic2: AleoTransactionIntent = {
     type: TRANSACTION_TYPE.CONVERT_TOKEN_PRIVATE_TO_PUBLIC,
     programId: MOCK_TOKEN_PROGRAM_ID,
     records: [mockUnspentTokenRecord1.decryptedData, mockUnspentTokenRecord2.decryptedData],
+    tvks: MOCK_MULTI_RECORD_TVKS,
   },
 };
 

--- a/libs/coin-modules/coin-aleo/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.integ.test.ts
@@ -2,6 +2,7 @@ import invariant from "invariant";
 import { createApi } from "../api";
 import { TRANSACTION_TYPE } from "../constants";
 import { AleoApiConfigurationResetError } from "../errors";
+import { fromHex } from "../logic/utils";
 import { accessProvableApi } from "../network/utils";
 import { getTestnetIntegConfig } from "../__tests__/fixtures/config.fixture";
 import {
@@ -12,7 +13,11 @@ import {
 } from "../__tests__/fixtures/api.fixture";
 import { setupCalStore } from "../__tests__/helpers/cal";
 import { getPristineAccount } from "../__tests__/helpers/account";
-import type { AleoAccountInfo, AleoContext } from "../types";
+import type { AleoAccountInfo, AleoContext, PreparedRequestResponse } from "../types";
+import {
+  mockTxIntentTransferPrivate,
+  mockTxIntentTransferPublic,
+} from "../__tests__/fixtures/transaction.fixture";
 
 type AleoApi = ReturnType<typeof createApi>;
 
@@ -53,6 +58,28 @@ describe("createApi", () => {
     privacyContext = await withPrivacyContext(context, testnetViewKey);
     emptyAddress = pristineAccount.address;
     emptyAddressViewKey = pristineAccount.viewKey;
+  });
+
+  describe("craftTransaction", () => {
+    it("crafts a prepared request for a public root intent", async () => {
+      const result = await api.craftTransaction(context, mockTxIntentTransferPublic);
+
+      const preparedRequest = fromHex<PreparedRequestResponse>(result.transaction);
+      expect(preparedRequest.function_name.toLowerCase()).toContain(
+        Buffer.from("transfer_public").toString("hex"),
+      );
+    });
+
+    it("crafts a prepared request for a private root intent when a viewKey is present", async () => {
+      const contextWithPrivacy = await withPrivacyContext(context, testnetViewKey);
+
+      const result = await api.craftTransaction(contextWithPrivacy, mockTxIntentTransferPrivate);
+
+      const preparedRequest = fromHex<PreparedRequestResponse>(result.transaction);
+      expect(preparedRequest.function_name.toLowerCase()).toContain(
+        Buffer.from("transfer_private").toString("hex"),
+      );
+    });
   });
 
   describe("estimateFees", () => {

--- a/libs/coin-modules/coin-aleo/src/api/index.test.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.test.ts
@@ -1,7 +1,13 @@
 import type { BalanceOptions } from "@ledgerhq/coin-module-framework/api/types";
 import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
 import { getMockedCoinFrameworkOperation } from "../__tests__/fixtures/operation.fixture";
-import { createMockTransactionIntent } from "../__tests__/fixtures/transaction.fixture";
+import {
+  createMockTransactionIntent,
+  mockTxIntentFeePrivate,
+  mockTxIntentFeePublic,
+  mockTxIntentTransferPrivate,
+  mockTxIntentTransferPublic,
+} from "../__tests__/fixtures/transaction.fixture";
 import {
   craftTransaction,
   estimateFees,
@@ -10,7 +16,7 @@ import {
   lastBlock,
   listOperations,
 } from "../logic";
-import { getTransactionType } from "../logic/utils";
+import { buildFeeConfigurationForRootIntent, getTransactionType } from "../logic/utils";
 import type { AleoContext } from "../types";
 import { createApi } from "./index";
 
@@ -32,6 +38,7 @@ describe("createApi", () => {
   const mockedLastBlock = jest.mocked(lastBlock);
   const mockedListOperations = jest.mocked(listOperations);
   const mockedGetTransactionType = jest.mocked(getTransactionType);
+  const mockedBuildFeeConfigurationForRootIntent = jest.mocked(buildFeeConfigurationForRootIntent);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -47,6 +54,11 @@ describe("createApi", () => {
       nextCursor: "next-cursor",
     });
     mockedGetTransactionType.mockReturnValue("transfer_public");
+    mockedBuildFeeConfigurationForRootIntent.mockReturnValue({
+      function_name: "fee_public",
+      max_base_fee: "1234",
+      max_priority_fee: "0",
+    });
   });
 
   it("should return an API object with coin module api methods", () => {
@@ -115,10 +127,170 @@ describe("createApi", () => {
   });
 
   describe("craftTransaction", () => {
-    it("should throw unsupported error", async () => {
-      // @ts-expect-error - it should throw no matter what the input is
-      expect(() => api.craftTransaction(context, {})).toThrow("craftTransaction is not supported");
+    it("throws for an intent with useAllAmount set, before resolving config or crafting", async () => {
+      await expect(
+        api.craftTransaction(context, { ...mockTxIntentTransferPublic, useAllAmount: true }),
+      ).rejects.toThrow("useAllAmount is not supported");
+
+      expect(mockedCraftTransaction).not.toHaveBeenCalled();
+      expect(mockedBuildFeeConfigurationForRootIntent).not.toHaveBeenCalled();
     });
+
+    it("omits viewKey from the craft call when a fee intent's context.viewKey is null", async () => {
+      const nullViewKeyContext = {
+        ...context,
+        config: async () => ({ ...mockConfig, isFeeSponsored: false }),
+        viewKey: null,
+      } as unknown as AleoContext;
+
+      await api.craftTransaction(nullViewKeyContext, mockTxIntentFeePublic);
+
+      expect(mockedCraftTransaction).toHaveBeenCalledWith({
+        config: { ...mockConfig, isFeeSponsored: false },
+        txIntent: mockTxIntentFeePublic,
+        feeConfiguration: null,
+      });
+    });
+
+    it("delegates a public root intent to logic/craftTransaction with a built FeeConfiguration", async () => {
+      const result = await api.craftTransaction(context, mockTxIntentTransferPublic);
+
+      expect(mockedGetTransactionType).toHaveBeenCalledWith(mockTxIntentTransferPublic);
+      expect(mockedEstimateFees).toHaveBeenCalledWith({
+        configOrCurrencyId: mockConfig,
+        transactionType: "transfer_public",
+      });
+      expect(mockedBuildFeeConfigurationForRootIntent).toHaveBeenCalledWith({
+        isPrivate: false,
+        maxBaseFee: BigInt(1234),
+        maxPriorityFee: 0n,
+      });
+      expect(mockedCraftTransaction).toHaveBeenCalledWith({
+        config: mockConfig,
+        txIntent: mockTxIntentTransferPublic,
+        feeConfiguration: {
+          function_name: "fee_public",
+          max_base_fee: "1234",
+          max_priority_fee: "0",
+        },
+      });
+      expect(result).toEqual({ transaction: "crafted_tx" });
+    });
+
+    it("uses options.customFees for max_base_fee instead of calling estimateFees", async () => {
+      await api.craftTransaction(context, mockTxIntentTransferPublic, {
+        customFees: { value: 9999n },
+      });
+
+      expect(mockedEstimateFees).not.toHaveBeenCalled();
+      expect(mockedBuildFeeConfigurationForRootIntent).toHaveBeenCalledWith({
+        isPrivate: false,
+        maxBaseFee: 9999n,
+        maxPriorityFee: 0n,
+      });
+    });
+
+    it.each([
+      ["fee_public", mockTxIntentFeePublic, undefined],
+      ["fee_private", mockTxIntentFeePrivate, "mock-view-key"],
+    ])(
+      "delegates a %s intent to logic/craftTransaction with feeConfiguration: null, without building one or fetching records",
+      async (_label, feeIntent, viewKey) => {
+        const sponsorshipDisabledContext: AleoContext = {
+          ...context,
+          config: async () => ({ ...mockConfig, isFeeSponsored: false }),
+          ...(viewKey !== undefined && { viewKey }),
+        };
+
+        const result = await api.craftTransaction(sponsorshipDisabledContext, feeIntent);
+
+        expect(mockedCraftTransaction).toHaveBeenCalledWith({
+          config: { ...mockConfig, isFeeSponsored: false },
+          txIntent: feeIntent,
+          feeConfiguration: null,
+          ...(viewKey !== undefined && { viewKey }),
+        });
+        expect(mockedBuildFeeConfigurationForRootIntent).not.toHaveBeenCalled();
+        expect(mockedEstimateFees).not.toHaveBeenCalled();
+        expect(mockedGetBalance).not.toHaveBeenCalled();
+        expect(result).toEqual({ transaction: "crafted_tx" });
+      },
+    );
+
+    it.each([
+      ["fee_public", mockTxIntentFeePublic],
+      ["fee_private", mockTxIntentFeePrivate],
+    ])(
+      "throws for a %s intent when fees are sponsored, before any craft",
+      async (_label, feeIntent) => {
+        await expect(api.craftTransaction(context, feeIntent)).rejects.toThrow(
+          "fee craft is not needed when fees are sponsored",
+        );
+
+        expect(mockedCraftTransaction).not.toHaveBeenCalled();
+        expect(mockedBuildFeeConfigurationForRootIntent).not.toHaveBeenCalled();
+      },
+    );
+
+    it.each([
+      ["fee_public", mockTxIntentFeePublic],
+      ["fee_private", mockTxIntentFeePrivate],
+    ])("throws for a %s intent when customFees is passed", async (_label, feeIntent) => {
+      const sponsorshipDisabledContext: AleoContext = {
+        ...context,
+        config: async () => ({ ...mockConfig, isFeeSponsored: false }),
+      };
+
+      await expect(
+        api.craftTransaction(sponsorshipDisabledContext, feeIntent, {
+          customFees: { value: 9999n },
+        }),
+      ).rejects.toThrow("customFees is not supported for fee intents");
+
+      expect(mockedCraftTransaction).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ["undefined", undefined],
+      ["null", null],
+      ["empty string", ""],
+    ])(
+      "throws AleoIncompletePrivacyContextError for a private root intent when viewKey is %s",
+      async (_label, viewKey) => {
+        const privateContext = {
+          ...context,
+          ...(viewKey !== undefined && { viewKey }),
+        } as AleoContext;
+
+        await expect(
+          api.craftTransaction(privateContext, mockTxIntentTransferPrivate),
+        ).rejects.toThrow("aleo: viewKey is missing");
+
+        expect(mockedCraftTransaction).not.toHaveBeenCalled();
+        expect(mockedBuildFeeConfigurationForRootIntent).not.toHaveBeenCalled();
+      },
+    );
+
+    it.each([
+      ["undefined", undefined],
+      ["null", null],
+      ["empty string", ""],
+    ])(
+      "throws AleoIncompletePrivacyContextError for a fee_private intent when viewKey is %s",
+      async (_label, viewKey) => {
+        const privateFeeContext = {
+          ...context,
+          config: async () => ({ ...mockConfig, isFeeSponsored: false }),
+          ...(viewKey !== undefined && { viewKey }),
+        } as AleoContext;
+
+        await expect(
+          api.craftTransaction(privateFeeContext, mockTxIntentFeePrivate),
+        ).rejects.toThrow("aleo: viewKey is missing");
+
+        expect(mockedCraftTransaction).not.toHaveBeenCalled();
+      },
+    );
   });
 
   describe("craftRawTransaction", () => {

--- a/libs/coin-modules/coin-aleo/src/api/index.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.ts
@@ -1,3 +1,4 @@
+import invariant from "invariant";
 import type {
   AccountInfo,
   CoinModuleApi,
@@ -18,7 +19,9 @@ import type {
 } from "@ledgerhq/coin-module-framework/api/index";
 import { craftTransactionData } from "@ledgerhq/coin-module-framework/logic/craftTransactionData";
 import { rejectBalanceOptions } from "@ledgerhq/coin-module-framework/api/getBalance/rejectBalanceOptions";
+import { FEE_INTENT_TYPES } from "../constants";
 import {
+  craftTransaction,
   estimateFees,
   getAccountInfo,
   getBalance,
@@ -26,7 +29,7 @@ import {
   listOperations,
   validateAddress,
 } from "../logic";
-import { getTransactionType } from "../logic/utils";
+import { buildFeeConfigurationForRootIntent, getTransactionType } from "../logic/utils";
 import type { AleoContext, AleoCoinConfig, AleoTransactionIntentData } from "../types";
 
 // currencyId is captured here (it can't live on the Context). The logic functions are shared with
@@ -53,12 +56,65 @@ export function createApi(
     ): string => {
       throw new Error("combine is not supported");
     },
-    craftTransaction: (
-      _context: AleoContext,
-      _txIntent: TransactionIntent<MemoNotSupported, AleoTransactionIntentData>,
-      _options?: { customFees?: FeeEstimation },
+    craftTransaction: async (
+      context: AleoContext,
+      txIntent: TransactionIntent<MemoNotSupported, AleoTransactionIntentData>,
+      options?: { customFees?: FeeEstimation },
     ): Promise<CraftedTransaction> => {
-      throw new Error("craftTransaction is not supported");
+      invariant(!txIntent.useAllAmount, "aleo: useAllAmount is not supported");
+
+      const config = await context.config();
+      const isFeeIntent = FEE_INTENT_TYPES.has(txIntent.type);
+      const isPrivateIntent = "data" in txIntent && "records" in txIntent.data;
+      const isPrivateFeeIntent = txIntent.type === "fee_private";
+
+      if (isFeeIntent) {
+        invariant(!config.isFeeSponsored, "aleo: fee craft is not needed when fees are sponsored");
+        invariant(!options?.customFees, "aleo: customFees is not supported for fee intents");
+
+        if (isPrivateFeeIntent) {
+          invariant(context.viewKey, "aleo: viewKey is missing");
+        }
+
+        // txIntent.amount -> base fee
+        // txIntent.data.priorityFee -> priority fee (defaults to 0)
+        // both should match max_base_fee/max_priority_fee from the FeeConfiguration of the root intent
+        return craftTransaction({
+          config,
+          txIntent,
+          feeConfiguration: null,
+          ...(context.viewKey && { viewKey: context.viewKey }),
+        });
+      }
+
+      if (isPrivateIntent) {
+        invariant(context.viewKey, "aleo: viewKey is missing");
+      }
+
+      const maxBaseFee = options?.customFees
+        ? options.customFees.value
+        : estimateFees({
+            configOrCurrencyId: config,
+            transactionType: getTransactionType(txIntent),
+          }).value;
+
+      const maxPriorityFee =
+        ("data" in txIntent && "priorityFee" in txIntent.data
+          ? txIntent.data.priorityFee
+          : undefined) ?? 0n;
+
+      const feeConfiguration = buildFeeConfigurationForRootIntent({
+        isPrivate: isPrivateIntent,
+        maxBaseFee,
+        maxPriorityFee,
+      });
+
+      return craftTransaction({
+        config,
+        txIntent,
+        feeConfiguration,
+        ...(context.viewKey && { viewKey: context.viewKey }),
+      });
     },
     craftRawTransaction: (
       _context: AleoContext,

--- a/libs/coin-modules/coin-aleo/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/signOperation.test.ts
@@ -504,7 +504,11 @@ describe("buildSignOperation", () => {
 
     expect(mockedCraftTransaction).toHaveBeenCalledWith(
       expect.objectContaining({
-        tvks: ["aa", "aa", "aa"],
+        txIntent: expect.objectContaining({
+          data: expect.objectContaining({
+            tvks: ["aa", "aa", "aa"],
+          }),
+        }),
       }),
     );
   });
@@ -528,8 +532,10 @@ describe("buildSignOperation", () => {
 
     expect(mockSigner.getTvk).not.toHaveBeenCalled();
     expect(mockedCraftTransaction).toHaveBeenCalledWith(
-      expect.not.objectContaining({
-        tvks: expect.anything(),
+      expect.objectContaining({
+        txIntent: expect.objectContaining({
+          data: expect.objectContaining({ tvks: [] }),
+        }),
       }),
     );
   });

--- a/libs/coin-modules/coin-aleo/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/signOperation.ts
@@ -11,7 +11,6 @@ import {
   type AleoSigner,
   type AleoAccount,
   type SignedAleoTransaction,
-  type FeeConfiguration,
   PreparedRequestResponse,
   type AleoCoinConfig,
   AleoTransactionIntentData,
@@ -19,6 +18,7 @@ import {
 import { sdkClient } from "../network/sdk";
 import { craftTransaction } from "../logic";
 import {
+  buildFeeConfigurationForRootIntent,
   createFeeTransactionIntent,
   createTransactionIntent,
   extractViewKey,
@@ -232,11 +232,11 @@ export const buildSignOperation =
           const baseFee = transaction.fees;
           const priorityFee = new BigNumber(0);
 
-          const feeConfiguration: FeeConfiguration = {
-            function_name: isPrivateTransaction(transaction) ? "fee_private" : "fee_public",
-            max_base_fee: baseFee.toString(),
-            max_priority_fee: priorityFee.toString(),
-          };
+          const feeConfiguration = buildFeeConfigurationForRootIntent({
+            isPrivate: isPrivateTransaction(transaction),
+            maxBaseFee: BigInt(baseFee.toFixed(0)),
+            maxPriorityFee: BigInt(priorityFee.toFixed(0)),
+          });
 
           const signature = await signerContext(deviceId, async signer => {
             const tvks = await getTvks({
@@ -260,8 +260,11 @@ export const buildSignOperation =
               config,
               viewKey,
               feeConfiguration,
-              txIntent,
-              ...(tvks && { tvks: [tvks.rootTvk, ...tvks.nestedTvks] }),
+              txIntent: createTransactionIntent({
+                account,
+                transaction,
+                tvks: tvks ? [tvks.rootTvk, ...tvks.nestedTvks] : [],
+              }),
             });
 
             const request = fromHex<PreparedRequestResponse>(craftedRequest.transaction);

--- a/libs/coin-modules/coin-aleo/src/constants.ts
+++ b/libs/coin-modules/coin-aleo/src/constants.ts
@@ -24,6 +24,8 @@ export const TRANSACTION_TYPE = {
   CONVERT_TOKEN_PUBLIC_TO_PRIVATE: "convert_token_public_to_private",
 } as const;
 
+export const FEE_INTENT_TYPES = new Set(["fee_public", "fee_private"]);
+
 // Function names that represent actual private token transfers between parties.
 // Used to exclude internal operations (split, join, fee_private, etc.) from history.
 export const PRIVATE_TRANSFER_FUNCTIONS = new Set([

--- a/libs/coin-modules/coin-aleo/src/logic/craftTransaction.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/craftTransaction.integ.test.ts
@@ -1,12 +1,17 @@
 import aleoConfig from "../config";
 import { testnetViewKey } from "../__tests__/fixtures/api.fixture";
 import {
+  mockTxIntentConvertTokenPrivateToPublicReal,
+  mockTxIntentConvertTokenPublicToPrivate,
   mockTxIntentFeePrivate,
   mockTxIntentFeePublic,
   mockTxIntentSelfTransferToPrivate,
   mockTxIntentSelfTransferToPublic,
   mockTxIntentTransferPrivate,
+  mockTxIntentTransferPrivate2,
   mockTxIntentTransferPublic,
+  mockTxIntentTransferTokenPrivateReal,
+  mockTxIntentTransferTokenPublic,
 } from "../__tests__/fixtures/transaction.fixture";
 import type { FeeConfiguration, PreparedRequestResponse } from "../types";
 import { getTestnetIntegConfig } from "../__tests__/fixtures/config.fixture";
@@ -69,6 +74,39 @@ describe("craftTransaction", () => {
       expectedFunctionName: "fee_private",
       feeConfiguration: null,
       txIntent: mockTxIntentFeePrivate,
+      viewKey: testnetViewKey,
+    },
+    {
+      name: "transfer_token_public",
+      expectedFunctionName: "transfer_public",
+      feeConfiguration: publicFeeConfiguration,
+      txIntent: mockTxIntentTransferTokenPublic,
+    },
+    {
+      name: "transfer_token_private",
+      expectedFunctionName: "transfer_private",
+      feeConfiguration: privateFeeConfiguration,
+      txIntent: mockTxIntentTransferTokenPrivateReal,
+      viewKey: testnetViewKey,
+    },
+    {
+      name: "convert_token_public_to_private",
+      expectedFunctionName: "transfer_public_to_private",
+      feeConfiguration: publicFeeConfiguration,
+      txIntent: mockTxIntentConvertTokenPublicToPrivate,
+    },
+    {
+      name: "convert_token_private_to_public",
+      expectedFunctionName: "transfer_private_to_public",
+      feeConfiguration: privateFeeConfiguration,
+      txIntent: mockTxIntentConvertTokenPrivateToPublicReal,
+      viewKey: testnetViewKey,
+    },
+    {
+      name: "transfer_private (multi-record, 2 records)",
+      expectedFunctionName: "transfer_private_2",
+      feeConfiguration: privateFeeConfiguration,
+      txIntent: mockTxIntentTransferPrivate2,
       viewKey: testnetViewKey,
     },
   ])(

--- a/libs/coin-modules/coin-aleo/src/logic/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/craftTransaction.test.ts
@@ -2,12 +2,15 @@ import { sdkClient } from "../network/sdk";
 import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
 import { getMockedPreparedRequestResponse } from "../__tests__/fixtures/sdk.fixture";
 import {
+  MOCK_MULTI_RECORD_TVKS,
   mockTxIntentFeePrivate,
+  mockTxIntentTransferPrivate,
   mockTxIntentTransferPrivate2,
   mockTxIntentTransferPublic,
 } from "../__tests__/fixtures/transaction.fixture";
 import { mockUnspentRecord1, mockUnspentRecord2 } from "../__tests__/fixtures/account.fixture";
-import type { FeeConfiguration, Intent } from "../types";
+import { TRANSACTION_TYPE } from "../constants";
+import type { AleoTransactionIntent, FeeConfiguration, Intent } from "../types";
 import { craftTransaction } from "./craftTransaction";
 import { mapTransactionIntentToSdkIntent, toHex } from "./utils";
 
@@ -26,6 +29,12 @@ const mockMultiRecordSdkIntent: Intent = {
   amount: "200",
   to: "aleo1recipient",
   records: [mockUnspentRecord1.decryptedData, mockUnspentRecord2.decryptedData],
+};
+const mockSingleRecordSdkIntent: Intent = {
+  type: "transfer_private",
+  amount: "200",
+  to: "aleo1recipient",
+  record: mockUnspentRecord1.decryptedData,
 };
 const mockSdkResponse = getMockedPreparedRequestResponse({
   network_id: 0,
@@ -110,9 +119,7 @@ describe("craftTransaction", () => {
     expect(toHex).toHaveBeenCalledTimes(1);
   });
 
-  it("should pass tvks to SDK for multi-record intents", async () => {
-    const tvks = ["root-tvk", "nested-tvk-1", "nested-tvk-2"];
-
+  it("should pass tvks read from txIntent.data to SDK for multi-record intents", async () => {
     jest.mocked(mapTransactionIntentToSdkIntent).mockReturnValue(mockMultiRecordSdkIntent);
 
     await craftTransaction({
@@ -120,7 +127,6 @@ describe("craftTransaction", () => {
       txIntent: mockTxIntentTransferPrivate2,
       feeConfiguration: mockFeeConfiguration,
       viewKey: mockViewKey,
-      tvks,
     });
 
     expect(sdkClient.createRequestFromIntent).toHaveBeenCalledTimes(1);
@@ -129,20 +135,53 @@ describe("craftTransaction", () => {
       intent: mockMultiRecordSdkIntent,
       feeConfiguration: mockFeeConfiguration,
       viewKey: mockViewKey,
-      tvks,
+      tvks: MOCK_MULTI_RECORD_TVKS,
     });
   });
 
-  it("should require tvks for multi-record intents", async () => {
+  it("should require a non-empty txIntent.data.tvks for multi-record intents before calling the SDK", async () => {
     jest.mocked(mapTransactionIntentToSdkIntent).mockReturnValue(mockMultiRecordSdkIntent);
+    const txIntentWithEmptyTvks: AleoTransactionIntent = {
+      ...mockTxIntentTransferPrivate2,
+      data: {
+        type: TRANSACTION_TYPE.TRANSFER_PRIVATE,
+        records: [mockUnspentRecord1.decryptedData, mockUnspentRecord2.decryptedData],
+        tvks: [],
+      },
+    };
 
     await expect(
       craftTransaction({
         config: mockConfig,
-        txIntent: mockTxIntentTransferPrivate2,
+        txIntent: txIntentWithEmptyTvks,
         feeConfiguration: mockFeeConfiguration,
         viewKey: mockViewKey,
       }),
     ).rejects.toThrow("aleo: tvks are required for transactions with nested calls");
+
+    expect(sdkClient.createRequestFromIntent).not.toHaveBeenCalled();
+  });
+
+  it("should craft successfully with an empty tvks array for a single-record intent, omitting tvks from the SDK call", async () => {
+    jest.mocked(mapTransactionIntentToSdkIntent).mockReturnValue(mockSingleRecordSdkIntent);
+
+    const result = await craftTransaction({
+      config: mockConfig,
+      txIntent: mockTxIntentTransferPrivate,
+      feeConfiguration: mockFeeConfiguration,
+      viewKey: mockViewKey,
+    });
+
+    expect(result).toEqual({ transaction: mockSerializedTx });
+    expect(sdkClient.createRequestFromIntent).toHaveBeenCalledTimes(1);
+    expect(sdkClient.createRequestFromIntent).toHaveBeenCalledWith({
+      config: mockConfig,
+      intent: mockSingleRecordSdkIntent,
+      feeConfiguration: mockFeeConfiguration,
+      viewKey: mockViewKey,
+    });
+    expect(sdkClient.createRequestFromIntent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ tvks: expect.anything() }),
+    );
   });
 });

--- a/libs/coin-modules/coin-aleo/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/craftTransaction.ts
@@ -13,18 +13,20 @@ export async function craftTransaction({
   txIntent,
   feeConfiguration,
   viewKey,
-  tvks,
 }: {
   config: AleoCoinConfig;
   txIntent: TransactionIntent<MemoNotSupported, AleoTransactionIntentData>;
   feeConfiguration: FeeConfiguration | null;
   viewKey?: string;
-  tvks?: string[];
 }): Promise<CraftedTransaction> {
+  const tvks = "data" in txIntent && "records" in txIntent.data ? txIntent.data.tvks : undefined;
   const intent = mapTransactionIntentToSdkIntent(txIntent);
 
   if ("records" in intent && intent.records.length > 1) {
-    invariant(tvks, "aleo: tvks are required for transactions with nested calls");
+    invariant(
+      tvks && tvks.length > 0,
+      "aleo: tvks are required for transactions with nested calls",
+    );
   }
 
   const response = await sdkClient.createRequestFromIntent({
@@ -32,7 +34,7 @@ export async function craftTransaction({
     intent,
     feeConfiguration,
     ...(viewKey !== undefined && { viewKey }),
-    ...(tvks !== undefined && { tvks }),
+    ...(tvks && tvks.length > 0 && { tvks }),
   });
 
   const transaction = toHex(response);

--- a/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
@@ -65,6 +65,7 @@ import {
   toPrivateBridgeOperation,
   resolveConfig,
   getTransactionType,
+  buildFeeConfigurationForRootIntent,
   getAleoSubAccount,
   calculateAmount,
   isProvableApiConfigured,
@@ -546,6 +547,39 @@ describe("getTransactionType", () => {
     const mockTx: TransactionIntent = {};
 
     expect(() => getTransactionType(mockTx)).toThrow();
+  });
+});
+
+describe("buildFeeConfigurationForRootIntent", () => {
+  it("returns function_name fee_public when isPrivate is false", () => {
+    const result = buildFeeConfigurationForRootIntent({
+      isPrivate: false,
+      maxBaseFee: 1234n,
+      maxPriorityFee: 0n,
+    });
+
+    expect(result.function_name).toBe("fee_public");
+  });
+
+  it("returns function_name fee_private when isPrivate is true", () => {
+    const result = buildFeeConfigurationForRootIntent({
+      isPrivate: true,
+      maxBaseFee: 1234n,
+      maxPriorityFee: 0n,
+    });
+
+    expect(result.function_name).toBe("fee_private");
+  });
+
+  it("stringifies maxBaseFee and maxPriorityFee", () => {
+    const result = buildFeeConfigurationForRootIntent({
+      isPrivate: false,
+      maxBaseFee: 4242n,
+      maxPriorityFee: 10n,
+    });
+
+    expect(result.max_base_fee).toBe("4242");
+    expect(result.max_priority_fee).toBe("10");
   });
 });
 

--- a/libs/coin-modules/coin-aleo/src/logic/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.ts
@@ -54,6 +54,7 @@ import type {
   TransactionPrivate,
   AleoCoinConfig,
   AleoPrivateRecord,
+  FeeConfiguration,
   AleoUnspentRecord,
   AleoTransactionIntent,
   SigningStrategy,
@@ -320,6 +321,22 @@ export function getTransactionType(intent: TransactionIntent): TransactionType {
   invariant(transactionType, `aleo: unsupported transaction intent type: ${intent.type}`);
 
   return transactionType;
+}
+
+export function buildFeeConfigurationForRootIntent({
+  isPrivate,
+  maxBaseFee,
+  maxPriorityFee,
+}: {
+  isPrivate: boolean;
+  maxBaseFee: bigint;
+  maxPriorityFee: bigint;
+}): FeeConfiguration {
+  return {
+    function_name: isPrivate ? "fee_private" : "fee_public",
+    max_base_fee: maxBaseFee.toString(),
+    max_priority_fee: maxPriorityFee.toString(),
+  };
 }
 
 export function getAleoSubAccount(
@@ -873,9 +890,11 @@ function buildTransactionIntentBase(
 export function createTransactionIntent({
   account,
   transaction,
+  tvks = [],
 }: {
   account: AleoAccount;
   transaction: Transaction;
+  tvks?: string[];
 }): AleoTransactionIntent {
   const tokenAccount = isTokenTransaction(transaction)
     ? getAleoSubAccount(account, transaction.subAccountId)
@@ -899,6 +918,7 @@ export function createTransactionIntent({
             maxRecords: MAX_PRIVATE_RECORDS_PER_TRANSACTION,
             findRecord: commitment => getRecordByCommitment({ account, commitment }),
           }),
+          tvks,
         },
       };
 
@@ -929,6 +949,7 @@ export function createTransactionIntent({
             maxRecords: MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION,
             findRecord: commitment => getRecordByCommitment({ account, commitment, tokenAccount }),
           }),
+          tvks,
         },
       };
     }

--- a/libs/coin-modules/coin-aleo/src/types/logic.ts
+++ b/libs/coin-modules/coin-aleo/src/types/logic.ts
@@ -57,20 +57,24 @@ export type AleoTransactionIntentData =
   | {
       type: typeof TRANSACTION_TYPE.TRANSFER_PRIVATE;
       records: AleoDecryptedRecordResponse[];
+      tvks: string[];
     }
   | {
       type: typeof TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC;
       records: AleoDecryptedRecordResponse[];
+      tvks: string[];
     }
   | {
       type: typeof TRANSACTION_TYPE.TRANSFER_TOKEN_PRIVATE;
       programId: string;
       records: AleoDecryptedRecordResponse[];
+      tvks: string[];
     }
   | {
       type: typeof TRANSACTION_TYPE.CONVERT_TOKEN_PRIVATE_TO_PUBLIC;
       programId: string;
       records: AleoDecryptedRecordResponse[];
+      tvks: string[];
     }
   | {
       type: "fee_public";


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR implements the framework's `Api.craftTransaction` for Aleo, replacing its "not supported" placeholder. It branches on intent shape: fee intents (`fee_public`/`fee_private`) reject sponsored-fee configs and `customFees`, private intents require a `viewKey` on the context, and root (non-fee) intents build a `FeeConfiguration` from either `customFees` or `estimateFees`. As part of this, `tvks` (nested-call view keys needed for multi-record private transactions) move from a separate `craftTransaction` parameter into `AleoTransactionIntentData` itself, so the intent carries everything needed to craft it and the framework caller doesn't need Aleo-specific knowledge of tvks.

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- https://ledgerhq.atlassian.net/browse/LIVE-33470
