### PR TITLE
chore(llc): parse A4 asset path to `AssetInfo`

### DIFF
--- a/.changeset/fast-crabs-knock.md
+++ b/.changeset/fast-crabs-knock.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+chore(llc): parse A4 asset path to `AssetInfo`

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -393,6 +393,7 @@
     "src/bridge/descriptor/send/memo.ts",
     "src/bridge/descriptor/stake/features.ts",
     "src/bridge/descriptor/types.ts",
+    "src/bridge/generic-coin-framework/a4/client/operations.ts",
     "src/bridge/jsHelpers.ts",
     "src/bridge/mockHelpers.ts",
     "src/bridge/setup.ts",

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/a4/client/operations.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/a4/client/operations.test.ts
@@ -1,0 +1,43 @@
+import { parseA4Asset } from "./operations";
+
+describe("parseA4Asset", () => {
+  it("returns native for 'native'", () => {
+    expect(parseA4Asset("native", "0xowner")).toEqual({ type: "native" });
+  });
+
+  it("returns type only for an unknown single-segment path", () => {
+    expect(parseA4Asset("foo", "0xowner")).toEqual({ type: "foo" });
+  });
+
+  it("parses EVM ERC20 2-segment path", () => {
+    expect(parseA4Asset("erc20.0xcontract", "0xowner")).toEqual({
+      type: "erc20",
+      assetReference: "0xcontract",
+      assetOwner: "0xowner",
+    });
+  });
+
+  it("parses Tron TRC20 3-segment token-standard path", () => {
+    expect(parseA4Asset("token.trc20.Tcontract", "Towner")).toEqual({
+      type: "trc20",
+      assetReference: "Tcontract",
+      assetOwner: "Towner",
+    });
+  });
+
+  it("parses Tron TRC10 3-segment token-standard path", () => {
+    expect(parseA4Asset("token.trc10.1002000", "Towner")).toEqual({
+      type: "trc10",
+      assetReference: "1002000",
+      assetOwner: "Towner",
+    });
+  });
+
+  it("parses Stellar 2-segment token path (issuer not in path)", () => {
+    expect(parseA4Asset("token.USDC", "Gowner")).toEqual({
+      type: "token",
+      assetReference: "USDC",
+      assetOwner: "Gowner",
+    });
+  });
+});

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/a4/client/operations.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/a4/client/operations.ts
@@ -1,0 +1,17 @@
+import type { AssetInfo } from "@ledgerhq/coin-module-framework/api/types";
+
+export function parseA4Asset(assetPath: string, owner: string): AssetInfo {
+  if (assetPath === "native") return { type: "native" };
+
+  const [type, second, third] = assetPath.split(".");
+
+  if (type === "token" && second && third) {
+    return { type: second, assetReference: third, assetOwner: owner };
+  }
+
+  if (second) {
+    return { type, assetReference: second, assetOwner: owner };
+  }
+
+  return { type };
+}


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

A4 asset path is encoding data needed to build the `AssetInfo`. This does the parsing.

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-35929
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
