### PR TITLE
[LWD] test(concordium): drop flaky SIGN screen assertions from onboard tests

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.integ.test.tsx
@@ -209,7 +209,8 @@ describe("OnboardModal Integration", () => {
 
     // Real bridge flows: getPublicKey → getSession → requestCreateAccount → sign.
     // SIGN screen not asserted: the success emit cancels its still pending
-    // setStateWithTimeout transition (see LIVE-34490). MSW intercepts submitCredential.
+    // setStateWithTimeout transition — a wider waitFor budget (LIVE-34490) does not
+    // help. MSW intercepts submitCredential.
     await waitFor(
       () => {
         expect(

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.integ.test.tsx
@@ -184,7 +184,7 @@ describe("OnboardModal Integration", () => {
     await new Promise(r => setTimeout(r, 0));
   });
 
-  it("should complete pairing and reach sign step with real bridge", async () => {
+  it("should complete pairing and account creation with real bridge", async () => {
     setupSuccessfulPairing();
     setupSuccessfulAccountCreation();
 
@@ -207,12 +207,9 @@ describe("OnboardModal Integration", () => {
     });
     expect(screen.getByRole("group", { name: /confirmation code/i })).toBeVisible();
 
-    // Real bridge flows: getPublicKey → getSession → requestCreateAccount → sign
-    await waitFor(() => {
-      expect(screen.getByText(/sign transaction on your ledger device/i)).toBeVisible();
-    }, WAIT_OPTS);
-
-    // MSW intercepts submitCredential; full success depends on network/axios interception
+    // Real bridge flows: getPublicKey → getSession → requestCreateAccount → sign.
+    // SIGN screen not asserted: the success emit cancels its still pending
+    // setStateWithTimeout transition (see LIVE-34490). MSW intercepts submitCredential.
     await waitFor(
       () => {
         expect(

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.test.tsx
@@ -179,10 +179,9 @@ describe("OnboardModal", () => {
     });
     expect(screen.getByRole("group", { name: /confirmation code/i })).toBeVisible();
 
-    await waitFor(() => {
-      expect(screen.getByText(/sign transaction on your ledger device/i)).toBeVisible();
-    }, WAIT_OPTS);
-
+    // SIGN step intentionally not asserted here: the account emit cancels the still
+    // pending setStateWithTimeout transition, so the screen may never render (see
+    // LIVE-34490). Covered by components/__tests__/StepCreate.test.tsx.
     await waitFor(() => {
       expect(
         screen.getByText(/your concordium account has been created successfully/i),

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.test.tsx
@@ -180,8 +180,9 @@ describe("OnboardModal", () => {
     expect(screen.getByRole("group", { name: /confirmation code/i })).toBeVisible();
 
     // SIGN step intentionally not asserted here: the account emit cancels the still
-    // pending setStateWithTimeout transition, so the screen may never render (see
-    // LIVE-34490). Covered by components/__tests__/StepCreate.test.tsx.
+    // pending setStateWithTimeout transition, so the screen may never render — a wider
+    // waitFor budget (LIVE-34490) does not help. Covered by
+    // ../components/__tests__/StepCreate.test.tsx.
     await waitFor(() => {
       expect(
         screen.getByText(/your concordium account has been created successfully/i),


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

The Concordium `OnboardModal › should complete the full onboarding happy path` test fails intermittently on CI while waiting for the "Sign transaction on your Ledger Device" screen ([failing run](https://github.com/LedgerHQ/ledger-live/actions/runs/31702202816/job/94454325467)). At timeout the DOM already shows the success screen: the SIGN screen was skipped, not late.

`setStateWithTimeout` clears the pending step transition before scheduling a new one, so an account emit that lands while the SIGN transition is still pending cancels it — the mocks leave ~200 ms of slack against the 1500 ms transition timer. No `waitFor` budget fixes that, which makes this distinct from LIVE-34490, where the awaited state merely arrived late.

Both onboard tests now stop asserting that transient screen, matching the convention in other LLD family tests and the QR-step precedent in the same file. SIGN → `TransactionConfirm` stays covered by `StepCreate.test.tsx`.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34490](https://ledgerhq.atlassian.net/browse/LIVE-34490?atlOrigin=eyJpIjoiZDhjOWEzOGMyZWIxNDc2OTkzNzVkNzZlYmYyMzJmMzMiLCJwIjoiaiJ9)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-34490]: https://ledgerhq.atlassian.net/browse/LIVE-34490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ