### PR TITLE
feat(icp): add llm staking and neuron management actions (LIVE-29097)

### DIFF
--- a/.changeset/icp-lwm-staking-actions.md
+++ b/.changeset/icp-lwm-staking-actions.md
@@ -1,0 +1,8 @@
+---
+"live-mobile": minor
+"@ledgerhq/types-live": minor
+---
+
+Surface ICP neuron staking entry points on mobile: Stake and Manage Neurons account-header actions,
+gated behind the new `llmIcpStaking` feature flag. The StakingFlow and NeuronManageFlow navigators
+are registered as stubs and their screens land separately.

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
@@ -54,6 +54,8 @@ import type { StellarAddAssetFlowParamList } from "../../../families/stellar/Add
 import type { TezosDelegationFlowParamList } from "../../../families/tezos/DelegationFlow/types";
 import type { TezosStakeFlowParamList } from "../../../families/tezos/StakeFlow/types";
 import type { TezosUnstakeFlowParamList } from "../../../families/tezos/UnstakeFlow/types";
+import type { InternetComputerStakingFlowParamList } from "../../../families/internet_computer/StakingFlow/types";
+import type { InternetComputerNeuronManageFlowParamList } from "../../../families/internet_computer/NeuronManageFlow/types";
 import type { TronVoteFlowParamList } from "../../../families/tron/VoteFlow/types";
 import type { HederaAssociateTokenFlowParamList } from "../../../families/hedera/AssociateTokenFlow/types";
 import type { CantonOnboardAccountParamList } from "../../../families/canton/Onboard/types";
@@ -318,6 +320,10 @@ export type BaseNavigatorStackParamList = {
   [NavigatorName.TezosDelegationFlow]: NavigatorScreenParams<TezosDelegationFlowParamList>;
   [NavigatorName.TezosStakeFlow]: NavigatorScreenParams<TezosStakeFlowParamList>;
   [NavigatorName.TezosUnstakeFlow]: NavigatorScreenParams<TezosUnstakeFlowParamList>;
+
+  // Internet Computer
+  [NavigatorName.InternetComputerStakingFlow]: NavigatorScreenParams<InternetComputerStakingFlowParamList>;
+  [NavigatorName.InternetComputerNeuronManageFlow]: NavigatorScreenParams<InternetComputerNeuronManageFlowParamList>;
 
   // Tron
   [NavigatorName.TronVoteFlow]: NavigatorScreenParams<TronVoteFlowParamList>;

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -351,6 +351,9 @@ export enum ScreenName {
 
   // internet_computer
   InternetComputerEditMemo = "InternetComputerEditMemo",
+  // ICP staking — entry screens reserved by LIVE-29097; the full flows land with LIVE-29098
+  InternetComputerStakingStarted = "InternetComputerStakingStarted",
+  InternetComputerNeuronList = "InternetComputerNeuronList",
 
   // ton
   TonEditComment = "TonEditComment",
@@ -723,6 +726,10 @@ export enum NavigatorName {
   TezosDelegationFlow = "TezosDelegationFlow",
   TezosStakeFlow = "TezosStakeFlow",
   TezosUnstakeFlow = "TezosUnstakeFlow",
+
+  // Internet Computer
+  InternetComputerStakingFlow = "InternetComputerStakingFlow",
+  InternetComputerNeuronManageFlow = "InternetComputerNeuronManageFlow",
 
   // Evm
   EvmEditTransaction = "EvmEditTransaction",

--- a/apps/ledger-live-mobile/src/families/internet_computer/NeuronManageFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/internet_computer/NeuronManageFlow/index.tsx
@@ -7,7 +7,7 @@ import type { InternetComputerNeuronManageFlowParamList } from "./types";
 // Stub navigator reserved for LIVE-29098 (the "NeuronManageFlow"). Registered now so the
 // "Manage Neurons" account action wired in LIVE-29097 has a navigation target. LIVE-29098 replaces
 // the placeholder screen with the neuron list and per-action screens, reusing these names.
-const PlaceholderScreen = () => <View />;
+const PlaceholderScreen = () => <View style={{ flex: 1 }} />;
 
 function NeuronManageFlow() {
   return (

--- a/apps/ledger-live-mobile/src/families/internet_computer/NeuronManageFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/internet_computer/NeuronManageFlow/index.tsx
@@ -1,0 +1,24 @@
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import React from "react";
+import { View } from "react-native";
+import { ScreenName } from "~/const";
+import type { InternetComputerNeuronManageFlowParamList } from "./types";
+
+// Stub navigator reserved for LIVE-29098 (the "NeuronManageFlow"). Registered now so the
+// "Manage Neurons" account action wired in LIVE-29097 has a navigation target. LIVE-29098 replaces
+// the placeholder screen with the neuron list and per-action screens, reusing these names.
+const PlaceholderScreen = () => <View />;
+
+function NeuronManageFlow() {
+  return (
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
+      <Stack.Screen name={ScreenName.InternetComputerNeuronList} component={PlaceholderScreen} />
+    </Stack.Navigator>
+  );
+}
+
+const options = { headerShown: false };
+
+export { NeuronManageFlow as component, options };
+
+const Stack = createNativeStackNavigator<InternetComputerNeuronManageFlowParamList>();

--- a/apps/ledger-live-mobile/src/families/internet_computer/NeuronManageFlow/types.ts
+++ b/apps/ledger-live-mobile/src/families/internet_computer/NeuronManageFlow/types.ts
@@ -1,0 +1,12 @@
+import { ParamListBase, RouteProp } from "@react-navigation/native";
+import { ScreenName } from "~/const";
+
+// Reserved for LIVE-29098 (neuron management flow). LIVE-29097 only registers the entry screen so
+// the account "Manage Neurons" action has a navigation target; LIVE-29098 extends this param list.
+export type InternetComputerNeuronManageFlowParamList = {
+  [ScreenName.InternetComputerNeuronList]: {
+    accountId: string;
+    parentId?: string;
+    source?: RouteProp<ParamListBase, ScreenName>;
+  };
+};

--- a/apps/ledger-live-mobile/src/families/internet_computer/StakingFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/internet_computer/StakingFlow/index.tsx
@@ -1,0 +1,24 @@
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import React from "react";
+import { View } from "react-native";
+import { ScreenName } from "~/const";
+import type { InternetComputerStakingFlowParamList } from "./types";
+
+// Stub navigator reserved for LIVE-29098 (the create-neuron "StakingFlow"). Registered now so the
+// "Stake" account action wired in LIVE-29097 has a navigation target. LIVE-29098 replaces the
+// placeholder screen with the real intro/amount/device/success steps, reusing these names.
+const PlaceholderScreen = () => <View />;
+
+function StakingFlow() {
+  return (
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
+      <Stack.Screen name={ScreenName.InternetComputerStakingStarted} component={PlaceholderScreen} />
+    </Stack.Navigator>
+  );
+}
+
+const options = { headerShown: false };
+
+export { StakingFlow as component, options };
+
+const Stack = createNativeStackNavigator<InternetComputerStakingFlowParamList>();

--- a/apps/ledger-live-mobile/src/families/internet_computer/StakingFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/internet_computer/StakingFlow/index.tsx
@@ -7,12 +7,15 @@ import type { InternetComputerStakingFlowParamList } from "./types";
 // Stub navigator reserved for LIVE-29098 (the create-neuron "StakingFlow"). Registered now so the
 // "Stake" account action wired in LIVE-29097 has a navigation target. LIVE-29098 replaces the
 // placeholder screen with the real intro/amount/device/success steps, reusing these names.
-const PlaceholderScreen = () => <View />;
+const PlaceholderScreen = () => <View style={{ flex: 1 }} />;
 
 function StakingFlow() {
   return (
     <Stack.Navigator screenOptions={{ headerShown: false }}>
-      <Stack.Screen name={ScreenName.InternetComputerStakingStarted} component={PlaceholderScreen} />
+      <Stack.Screen
+        name={ScreenName.InternetComputerStakingStarted}
+        component={PlaceholderScreen}
+      />
     </Stack.Navigator>
   );
 }

--- a/apps/ledger-live-mobile/src/families/internet_computer/StakingFlow/types.ts
+++ b/apps/ledger-live-mobile/src/families/internet_computer/StakingFlow/types.ts
@@ -1,0 +1,12 @@
+import { ParamListBase, RouteProp } from "@react-navigation/native";
+import { ScreenName } from "~/const";
+
+// Reserved for LIVE-29098 (create-neuron flow). LIVE-29097 only registers the entry screen so
+// the account "Stake" action has a navigation target; LIVE-29098 extends this param list.
+export type InternetComputerStakingFlowParamList = {
+  [ScreenName.InternetComputerStakingStarted]: {
+    accountId: string;
+    parentId?: string;
+    source?: RouteProp<ParamListBase, ScreenName>;
+  };
+};

--- a/apps/ledger-live-mobile/src/families/internet_computer/__tests__/accountActions.test.tsx
+++ b/apps/ledger-live-mobile/src/families/internet_computer/__tests__/accountActions.test.tsx
@@ -49,10 +49,9 @@ describe("internet_computer accountActions.getMainActions", () => {
   });
 
   it("routes Stake into the staking flow when the balance can afford a neuron", () => {
-    const [stake, ...rest] = callMainActions(
-      makeAccount({ spendableBalance: ENOUGH_TO_STAKE }),
-      { enabled: true },
-    );
+    const [stake, ...rest] = callMainActions(makeAccount({ spendableBalance: ENOUGH_TO_STAKE }), {
+      enabled: true,
+    });
 
     expect(stake.id).toBe("stake");
     expect(rest).toHaveLength(0);

--- a/apps/ledger-live-mobile/src/families/internet_computer/__tests__/accountActions.test.tsx
+++ b/apps/ledger-live-mobile/src/families/internet_computer/__tests__/accountActions.test.tsx
@@ -1,0 +1,118 @@
+import BigNumber from "bignumber.js";
+import type { ICPAccount } from "@ledgerhq/live-common/families/internet_computer/types";
+import { NavigatorName, ScreenName } from "~/const";
+import accountActions from "../accountActions";
+
+// canStakeICP is exercised by live-common's own tests; here we only need its branching, so mock
+// it to the same `spendableBalance >= MIN_NEURON_STAKE + ICP_FEES` rule (100_000_000 + 10_000).
+jest.mock("@ledgerhq/live-common/families/internet_computer/react", () => ({
+  canStakeICP: (account: { spendableBalance: BigNumber }) =>
+    account.spendableBalance.gte(100_010_000),
+}));
+
+jest.mock("~/context/Locale", () => ({
+  Trans: ({ i18nKey }: { i18nKey: string }) => i18nKey,
+}));
+
+jest.mock("~/helpers/getStakeLabelLocaleBased", () => ({
+  getStakeLabelLocaleBased: () => "account.stake",
+}));
+
+const ENOUGH_TO_STAKE = new BigNumber(100_010_000);
+const NOT_ENOUGH_TO_STAKE = new BigNumber(100_009_999);
+
+const makeAccount = (over: Record<string, unknown> = {}): ICPAccount =>
+  ({
+    type: "Account",
+    id: "icp-1",
+    spendableBalance: ENOUGH_TO_STAKE,
+    neurons: { fullNeurons: [], lastUpdatedMSecs: 0 },
+    ...over,
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  }) as unknown as ICPAccount;
+
+const callMainActions = (account: ICPAccount, flag?: { enabled?: boolean } | null) =>
+  accountActions.getMainActions({ account, llmIcpStaking: flag });
+
+const screenOf = (action: { navigationParams?: readonly [string, object] }) =>
+  (action.navigationParams?.[1] as { screen: string }).screen;
+
+describe("internet_computer accountActions.getMainActions", () => {
+  it("returns no actions when the feature flag is disabled or absent", () => {
+    expect(callMainActions(makeAccount(), { enabled: false })).toEqual([]);
+    expect(callMainActions(makeAccount(), null)).toEqual([]);
+  });
+
+  it("returns no actions for a non-Account (token) account", () => {
+    const tokenAccount = { ...makeAccount(), type: "TokenAccount" } as unknown as ICPAccount;
+    expect(callMainActions(tokenAccount, { enabled: true })).toEqual([]);
+  });
+
+  it("routes Stake into the staking flow when the balance can afford a neuron", () => {
+    const [stake, ...rest] = callMainActions(
+      makeAccount({ spendableBalance: ENOUGH_TO_STAKE }),
+      { enabled: true },
+    );
+
+    expect(stake.id).toBe("stake");
+    expect(rest).toHaveLength(0);
+    expect(stake.navigationParams?.[0]).toBe(NavigatorName.InternetComputerStakingFlow);
+    expect(screenOf(stake)).toBe(ScreenName.InternetComputerStakingStarted);
+  });
+
+  it("routes Stake to NoFundsFlow when the balance is below the minimum", () => {
+    const [stake, ...rest] = callMainActions(
+      makeAccount({ spendableBalance: NOT_ENOUGH_TO_STAKE }),
+      { enabled: true },
+    );
+
+    expect(stake.id).toBe("stake");
+    expect(rest).toHaveLength(0);
+    expect(stake.navigationParams?.[0]).toBe(NavigatorName.NoFundsFlow);
+    expect(screenOf(stake)).toBe(ScreenName.NoFunds);
+  });
+
+  it("adds Manage Neurons once the account has neurons (Stake still first)", () => {
+    const actions = callMainActions(
+      makeAccount({
+        spendableBalance: ENOUGH_TO_STAKE,
+        neurons: { fullNeurons: [{}], lastUpdatedMSecs: 0 },
+      }),
+      { enabled: true },
+    );
+
+    expect(actions.map(a => a.id)).toEqual(["stake", "manage-neurons"]);
+    expect(actions[1].navigationParams?.[0]).toBe(NavigatorName.InternetComputerNeuronManageFlow);
+    expect(screenOf(actions[1])).toBe(ScreenName.InternetComputerNeuronList);
+  });
+
+  it("shows Manage alongside a NoFunds-routed Stake when neurons exist but balance is too low", () => {
+    const actions = callMainActions(
+      makeAccount({
+        spendableBalance: NOT_ENOUGH_TO_STAKE,
+        neurons: { fullNeurons: [{}], lastUpdatedMSecs: 0 },
+      }),
+      { enabled: true },
+    );
+
+    expect(actions.map(a => a.id)).toEqual(["stake", "manage-neurons"]);
+    expect(actions[0].navigationParams?.[0]).toBe(NavigatorName.NoFundsFlow);
+  });
+
+  it("threads accountId and source route into the stake nav params", () => {
+    const source = { name: "Portfolio" } as unknown as Parameters<
+      typeof accountActions.getMainActions
+    >[0]["parentRoute"];
+
+    const [stake] = accountActions.getMainActions({
+      account: makeAccount({ id: "icp-42" }),
+      parentRoute: source,
+      llmIcpStaking: { enabled: true },
+    });
+
+    expect((stake.navigationParams?.[1] as { params: object }).params).toEqual({
+      accountId: "icp-42",
+      source,
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/families/internet_computer/accountActions.tsx
+++ b/apps/ledger-live-mobile/src/families/internet_computer/accountActions.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { Trans } from "~/context/Locale";
+import { ParamListBase, RouteProp } from "@react-navigation/native";
+import { canStakeICP } from "@ledgerhq/live-common/families/internet_computer/react";
+import type { ICPAccount } from "@ledgerhq/live-common/families/internet_computer/types";
+import type { Account } from "@ledgerhq/types-live";
+import { IconsLegacy } from "@ledgerhq/native-ui";
+import { NavigatorName, ScreenName } from "~/const";
+import { ActionButtonEvent, NavigationParamsType } from "~/components/FabActions";
+import { getStakeLabelLocaleBased } from "~/helpers/getStakeLabelLocaleBased";
+
+// ICP staking entry points (LIVE-29097), gated behind the `llmIcpStaking` feature flag.
+// Follows the mobile idiom (near/solana/cosmos): the Stake action is always present and routes to
+// NoFundsFlow when the account can't afford a neuron. Manage Neurons appears only once neurons
+// exist (matching desktop LIVE-29095). Both staking flows are stubs until LIVE-29098.
+const getMainActions = ({
+  account,
+  parentAccount,
+  parentRoute,
+  llmIcpStaking,
+}: {
+  account: ICPAccount;
+  parentAccount?: Account;
+  parentRoute?: RouteProp<ParamListBase, ScreenName>;
+  llmIcpStaking?: { enabled?: boolean } | null;
+}): ActionButtonEvent[] => {
+  if (!llmIcpStaking?.enabled || account.type !== "Account") return [];
+
+  const label = getStakeLabelLocaleBased();
+
+  const stakeNavigationParams: NavigationParamsType = canStakeICP(account)
+    ? [
+        NavigatorName.InternetComputerStakingFlow,
+        {
+          screen: ScreenName.InternetComputerStakingStarted,
+          params: { accountId: account.id, source: parentRoute },
+        },
+      ]
+    : [
+        NavigatorName.NoFundsFlow,
+        {
+          screen: ScreenName.NoFunds,
+          params: { account, parentAccount },
+        },
+      ];
+
+  const actions: ActionButtonEvent[] = [
+    {
+      id: "stake",
+      navigationParams: stakeNavigationParams,
+      label: <Trans i18nKey={label} />,
+      Icon: IconsLegacy.CoinsMedium,
+      eventProperties: { currency: "INTERNET_COMPUTER" },
+    },
+  ];
+
+  if (account.neurons?.fullNeurons.length) {
+    actions.push({
+      id: "manage-neurons",
+      navigationParams: [
+        NavigatorName.InternetComputerNeuronManageFlow,
+        {
+          screen: ScreenName.InternetComputerNeuronList,
+          params: { accountId: account.id, source: parentRoute },
+        },
+      ],
+      label: <Trans i18nKey="internetComputer.headerManageActions.manageNeurons.title" />,
+      Icon: IconsLegacy.CoinsMedium,
+      eventProperties: { currency: "INTERNET_COMPUTER" },
+    });
+  }
+
+  return actions;
+};
+
+export default {
+  getMainActions,
+};

--- a/apps/ledger-live-mobile/src/families/internet_computer/accountActions.tsx
+++ b/apps/ledger-live-mobile/src/families/internet_computer/accountActions.tsx
@@ -50,7 +50,7 @@ const getMainActions = ({
       navigationParams: stakeNavigationParams,
       label: <Trans i18nKey={label} />,
       Icon: IconsLegacy.CoinsMedium,
-      eventProperties: { currency: "INTERNET_COMPUTER" },
+      eventProperties: { currency: "ICP" },
     },
   ];
 
@@ -66,7 +66,7 @@ const getMainActions = ({
       ],
       label: <Trans i18nKey="internetComputer.headerManageActions.manageNeurons.title" />,
       Icon: IconsLegacy.CoinsMedium,
-      eventProperties: { currency: "INTERNET_COMPUTER" },
+      eventProperties: { currency: "ICP" },
     });
   }
 

--- a/apps/ledger-live-mobile/src/families/internet_computer/index.ts
+++ b/apps/ledger-live-mobile/src/families/internet_computer/index.ts
@@ -1,3 +1,8 @@
 import * as InternetComputerEditMemo from "./ScreenEditMemo";
 
 export { InternetComputerEditMemo };
+
+// Export names MUST equal their NavigatorName enum string values so BaseNavigator's family loop
+// registers them automatically. StakingFlow / NeuronManageFlow are stubs until LIVE-29098.
+export * as InternetComputerStakingFlow from "./StakingFlow";
+export * as InternetComputerNeuronManageFlow from "./NeuronManageFlow";

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -1,4 +1,24 @@
 {
+  "internetComputer": {
+    "stakeBanner": {
+      "stakeICP": {
+        "title": "Stake ICP",
+        "description": "Stake ICP and gain rewards by participating in its governance.",
+        "cta": "Stake ICP"
+      }
+    },
+    "headerManageActions": {
+      "manageNeurons": {
+        "title": "Manage Neurons"
+      }
+    },
+    "summaryFooter": {
+      "stakedBalance": "Staked Balance",
+      "stakedBalanceTooltip": "The total amount of ICP tokens currently staked in neurons. Staked ICP earns voting rewards and can be used for governance.",
+      "totalMaturity": "Total Maturity",
+      "totalMaturityTooltip": "The total accumulated rewards from staking, including both staked and liquid maturity. These rewards can be either staked again or claimed as liquid ICP."
+    }
+  },
   "buyCurrency": {
     "buyCTA": "Buy {{ currencyNameOrTicker }}"
   },

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/stakePromptFamilyFlows.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/stakePromptFamilyFlows.ts
@@ -23,7 +23,12 @@ const familyModuleNameByAccountKey: Record<StakePromptCase["accountKey"], string
 const stakePromptFlowNamePattern =
   /(Activate|Bond|ClaimRewards|Delegation|Lock|Nominate|Rebond|Redelegation|Registration|Revoke|SimpleOperation|Staking|Unbond|Undelegation|Undelegate|Unlock|Unstaking|Vote|Withdraw|Withdrawing)Flow$/;
 
-const nonStakePromptFlowExports = new Set<MobileFamilyFlowExport>(["TronVoteFlow"]);
+// InternetComputerStakingFlow is a stub registered in LIVE-29097; the real screens (and
+// NotificationsPrompt integration) land in LIVE-29098. Exclude until then.
+const nonStakePromptFlowExports = new Set<MobileFamilyFlowExport>([
+  "TronVoteFlow",
+  "InternetComputerStakingFlow",
+]);
 
 const hasComponent = (familyExport: unknown): familyExport is MobileFamilyFlow => {
   const component = (familyExport as { component?: unknown } | null)?.component;

--- a/apps/ledger-live-mobile/src/screens/Account/hooks/useAccountActions.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/hooks/useAccountActions.tsx
@@ -51,6 +51,7 @@ export default function useAccountActions({ account, parentAccount, colors }: Pr
   const ptxServiceCtaScreens = useFeature("ptxServiceCtaScreens");
   const evmNativeStakingFeature = useFeature("evmNativeStaking");
   const llmTezosStaking = useFeature("llmTezosStaking");
+  const llmIcpStaking = useFeature("llmIcpStaking");
 
   const isPtxServiceCtaScreensDisabled = useMemo(
     () => !(ptxServiceCtaScreens?.enabled ?? true),
@@ -279,6 +280,7 @@ export default function useAccountActions({ account, parentAccount, colors }: Pr
         parentRoute: route,
         evmNativeStakingFeature,
         llmTezosStaking,
+        llmIcpStaking,
         bridge,
       }) ?? [],
     [
@@ -290,6 +292,7 @@ export default function useAccountActions({ account, parentAccount, colors }: Pr
       decorators,
       evmNativeStakingFeature,
       llmTezosStaking,
+      llmIcpStaking,
       bridge,
     ],
   );

--- a/libs/types-live/src/feature.ts
+++ b/libs/types-live/src/feature.ts
@@ -331,6 +331,7 @@ export type Features = CurrencyFeatures & {
   llmTransferButtonCopyVariant: Feature_LlmTransferButtonCopyVariant;
   lldTezosStaking: DefaultFeature;
   llmTezosStaking: DefaultFeature;
+  llmIcpStaking: DefaultFeature;
   swapToEarn: DefaultFeature;
 };
 

--- a/shared/feature-flags/src/flags/team-coin-integration/index.ts
+++ b/shared/feature-flags/src/flags/team-coin-integration/index.ts
@@ -105,6 +105,7 @@ export * from "./lldTezosStaking";
 export * from "./lldWebviewManifestDomainCheck";
 export * from "./lwdDeeplinkOpenHardening";
 export * from "./lwmDeeplinkOpenHardening";
+export * from "./llmIcpStaking";
 export * from "./llmMemoTag";
 export * from "./llmTezosStaking";
 export * from "./llmWebviewManifestDomainCheck";

--- a/shared/feature-flags/src/flags/team-coin-integration/llmIcpStaking.ts
+++ b/shared/feature-flags/src/flags/team-coin-integration/llmIcpStaking.ts
@@ -1,0 +1,3 @@
+import { flag } from "../../define";
+
+export const llmIcpStaking = flag();


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->
First slice of mobile ICP neuron staking — **LIVE-29097**, the mobile mirror of desktop **LIVE-29095** (#20703). Adds the account-page **entry points**, gated behind a new `llmIcpStaking` feature flag (defaults **off**):

- **Stake** and **Manage Neurons** account-header actions (`families/internet_computer/accountActions.tsx`), registered via the `generated/accountActions.ts` codegen.
  - Follows the mobile idiom (near/solana/cosmos): **Stake** is always shown and routes to `NoFundsFlow` when the account can't afford a neuron (< `MIN_NEURON_STAKE + ICP_FEES`).
  - **Manage Neurons** appears only once the account has neurons (matching desktop LIVE-29095).
- New `llmIcpStaking` feature flag (`@shared/feature-flags` registry + `@ledgerhq/types-live`), consumed in `useAccountActions`.
- Reserved `InternetComputerStakingFlow` / `InternetComputerNeuronManageFlow` navigators, registered as **stubs** (placeholder screen) — real screens land in LIVE-29098.
- `internetComputer` translation block (en).

Consumes the existing LIVE-29094 live-common hooks (`canStakeICP`); **no coin-module or live-common changes**.

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 --> [LIVE-29097](https://ledgerhq.atlassian.net/browse/LIVE-29097)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
