### PR TITLE
fix(e2e/desktop): fall back to max sellable balance in Sell test

### DIFF
--- a/e2e/desktop/tests/page/buyAndSell.page.ts
+++ b/e2e/desktop/tests/page/buyAndSell.page.ts
@@ -248,18 +248,25 @@ export class BuyAndSellPage extends WebViewAppPage {
     );
     await this.verifyElementIsNotEnabled(this.formCta);
 
-    try {
-      await this.verifyElementIsVisible(this.paymentSelector);
-    } catch (error) {
-      if (operation !== OperationType.Sell) throw error;
-      await this.verifyElementIsVisible(this.amountInputError);
+    let balanceTooLow = false;
+    if (operation === OperationType.Sell) {
+      try {
+        await this.verifyElementIsVisible(this.amountInputError, 2000);
+        balanceTooLow = true;
+      } catch {
+        // No error shown — balance covers the requested amount.
+      }
+    }
+    if (balanceTooLow) {
       await this.clickElement(this.maxAmountButton);
-      amount = await (await this.getWebViewElementByTestId(this.amountInputSection)).inputValue();
-      await this.verifyElementIsVisible(this.paymentSelector);
     }
 
+    await this.verifyElementIsVisible(this.paymentSelector);
+    const finalAmount = await (
+      await this.getWebViewElementByTestId(this.amountInputSection)
+    ).inputValue();
     await this.verifyElementIsVisible(this.providersList);
-    return amount;
+    return finalAmount;
   }
 
   @step("Select provider quote")

--- a/e2e/desktop/tests/page/buyAndSell.page.ts
+++ b/e2e/desktop/tests/page/buyAndSell.page.ts
@@ -42,6 +42,8 @@ export class BuyAndSellPage extends WebViewAppPage {
   private fiatDrawerInput = "fiat-drawer-search-input";
   private saveRegionFiatOptionsSelector = "save-region-and-fiat-options";
   private showMoreQuotes = "SHOW MORE QUOTES";
+  private amountInputError = "amount-input-section-error";
+  private maxAmountButton = "max";
   private providerTitleCssSelector =
     "[data-testid^='provider_title_'][data-testid$='_title_container']";
 
@@ -235,8 +237,9 @@ export class BuyAndSellPage extends WebViewAppPage {
     await this.verifyElementText(this.infoBox, "Sell securely with Ledger");
   }
 
+  // Falls back to the max sellable balance if the requested amount exceeds it.
   @step("Enter amount to pay $0")
-  async setAmountToPay(amount: string, operation: string) {
+  async setAmountToPay(amount: string, operation: string): Promise<string> {
     await this.setValue(this.amountInputSection, amount);
 
     await this.verifyElementText(
@@ -244,8 +247,19 @@ export class BuyAndSellPage extends WebViewAppPage {
       operation === OperationType.Buy ? "Select quote to continue" : "Set an amount to get quotes",
     );
     await this.verifyElementIsNotEnabled(this.formCta);
-    await this.verifyElementIsVisible(this.paymentSelector);
+
+    try {
+      await this.verifyElementIsVisible(this.paymentSelector);
+    } catch (error) {
+      if (operation !== OperationType.Sell) throw error;
+      await this.verifyElementIsVisible(this.amountInputError);
+      await this.clickElement(this.maxAmountButton);
+      amount = await (await this.getWebViewElementByTestId(this.amountInputSection)).inputValue();
+      await this.verifyElementIsVisible(this.paymentSelector);
+    }
+
     await this.verifyElementIsVisible(this.providersList);
+    return amount;
   }
 
   @step("Select provider quote")

--- a/e2e/desktop/tests/page/buyAndSell.page.ts
+++ b/e2e/desktop/tests/page/buyAndSell.page.ts
@@ -265,6 +265,10 @@ export class BuyAndSellPage extends WebViewAppPage {
     const finalAmount = await (
       await this.getWebViewElementByTestId(this.amountInputSection)
     ).inputValue();
+    // Max must have lowered the amount; guards against a click that silently did nothing.
+    if (balanceTooLow) {
+      expect(Number(finalAmount)).toBeLessThan(Number(amount));
+    }
     await this.verifyElementIsVisible(this.providersList);
     return finalAmount;
   }

--- a/e2e/desktop/tests/page/webViewApp.page.ts
+++ b/e2e/desktop/tests/page/webViewApp.page.ts
@@ -81,9 +81,9 @@ export abstract class WebViewAppPage extends AppPage {
   }
 
   @step("Verify element is visible in WebView")
-  protected async verifyElementIsVisible(testId: string) {
+  protected async verifyElementIsVisible(testId: string, timeout?: number) {
     const webview = await this.getWebView();
-    await expect(webview.getByTestId(testId)).toBeVisible();
+    await expect(webview.getByTestId(testId)).toBeVisible(timeout ? { timeout } : undefined);
   }
 
   @step("Verify element is not visible in WebView")

--- a/e2e/desktop/tests/specs/buySell.spec.ts
+++ b/e2e/desktop/tests/specs/buySell.spec.ts
@@ -217,8 +217,8 @@ for (const sellAsset of sellAssets) {
         await app.buyAndSell.changeRegionAndCurrency(fiat);
         await app.buyAndSell.verifyFiatAssetSelector(fiat.currencyTicker);
         const amount = await getMinimumSellAmount(crypto.currency.id);
-        const buySell = { ...sellAsset.buySell, amount };
-        await app.buyAndSell.setAmountToPay(amount, operation);
+        const actualAmount = await app.buyAndSell.setAmountToPay(amount, operation);
+        const buySell = { ...sellAsset.buySell, amount: actualAmount };
         const provider = await app.buyAndSell.selectRotatingProvider(operation);
         await app.buyAndSell.selectQuote();
         await app.buyAndSell.verifyProviderUrl(provider, buySell, userdataDestinationPath);


### PR DESCRIPTION
## Summary
- `getMinimumSellAmount()` computes a provider-driven minimum sell amount (via `maxOfMin` from the Buy/Sell `cryptoLimitations` API), independent of the shared test wallet's real-time balance.
- That wallet (e.g. `TokenAccount.ETH_USDT_1`) is a real, live-blockchain account shared and concurrently drawn down by other Buy/Sell/Swap e2e tests in the same CI run, so the computed minimum can end up exceeding the account's actual balance.
- When that happens, the app shows "Not enough balance" instead of the payment/provider selector, and the Sell test previously just timed out waiting for `payment_selector`.
- `setAmountToPay()` now detects that specific balance-insufficient state (via the `amount-input-section-error` testid) and falls back to tapping `max` to use the account's actual live spendable balance, returning the amount actually used so downstream URL verification checks against the real value.

Investigated from CI run: https://github.com/LedgerHQ/ledger-live/actions/runs/31761092448 (`[USDT (Ethereum)] - Sell` failure — entered amount 31.707599 USDT vs. live balance 24.088397 USDT).

Mobile e2e was checked too: its Sell flow taps a `"75%"` balance-percentage button rather than typing the computed minimum, so it isn't exposed to this failure mode — no changes needed there.

## Test plan
- [x] [CI: Desktop E2E `buySell.spec.ts` Sell suite passes for BTC / ETH / USDT (Ethereum)](https://github.com/LedgerHQ/ledger-live/actions/runs/32013246766)
- [x] Manually verify `setAmountToPay` still behaves normally on the happy path (sufficient balance) for both Buy and Sell