### PR TITLE
[LWD] fix(large-screen-upsell): skip retries when blocked

### DIFF
--- a/.changeset/large-screen-upsell-competing-modal.md
+++ b/.changeset/large-screen-upsell-competing-modal.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"@features/flow-large-screen-upsell": patch
+---
+
+Fix Large Screen Upsell competing-modal handling on desktop: do not consume retriesModal when blocked/preempted, rename persisted retries to retriesModal (legacy reset on LWD only), and track modal_blocked.

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/LargeScreenUpsellModalMount.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/LargeScreenUpsellModalMount.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { onboardingDateSelector } from "@ledgerhq/live-common/postOnboarding/reducer";
-import { useFeature } from "@features/platform-feature-flags";
+import { useFeature, useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import {
   LargeScreenUpsellModal,
   mapDevicesModelListToUpsellInputs,
@@ -19,14 +19,18 @@ import { useShouldShowDeferredModals } from "~/renderer/hooks/useShouldShowDefer
 import { selectIsGenericAwarenessModalOpen } from "LLD/features/GenericAwarenessModal/genericAwarenessModalDialog";
 import {
   devicesModelListSelector,
+  hasSeenQ2TourSelector,
+  hasSeenWalletV4TourSelector,
   sharePersonalizedRecommendationsSelector,
 } from "~/renderer/reducers/settings";
 import { openURL } from "~/renderer/linking";
 import {
   toLargeScreenUpsellDeviceModelAnalyticsValue,
+  trackLargeScreenUpsellModalBlockedByCompeting,
   trackLargeScreenUpsellModalCtaClicked,
   trackLargeScreenUpsellModalDismissed,
   trackLargeScreenUpsellModalViewed,
+  type LargeScreenUpsellBlockedCompetitor,
   type LargeScreenUpsellSharedAnalyticsProps,
 } from "./analytics";
 
@@ -51,6 +55,27 @@ function buildSharedAnalyticsProps({
   };
 }
 
+function resolveCompetingAppStartModal({
+  isWalletV4TourCompeting,
+  isQ2TourCompeting,
+  isGenericAwarenessModalOpen,
+}: {
+  isWalletV4TourCompeting: boolean;
+  isQ2TourCompeting: boolean;
+  isGenericAwarenessModalOpen: boolean;
+}): LargeScreenUpsellBlockedCompetitor | null {
+  if (isWalletV4TourCompeting) {
+    return "wallet_v4_tour";
+  }
+  if (isQ2TourCompeting) {
+    return "q2_tour";
+  }
+  if (isGenericAwarenessModalOpen) {
+    return "generic_awareness";
+  }
+  return null;
+}
+
 export function LargeScreenUpsellModalMount() {
   const dispatch = useDispatch();
   const { t } = useTranslation();
@@ -62,15 +87,33 @@ export function LargeScreenUpsellModalMount() {
   const session = useSelector(sessionSelector);
   const feature = useFeature("largeScreenUpsell");
   const shouldShowDeferredModals = useShouldShowDeferredModals();
+  const hasSeenWalletV4Tour = useSelector(hasSeenWalletV4TourSelector);
+  const hasSeenQ2Tour = useSelector(hasSeenQ2TourSelector);
+  const { shouldDisplayTour, shouldDisplayQ2Tour } = useWalletFeaturesConfig("desktop");
   const isGenericAwarenessModalOpen = useSelector(selectIsGenericAwarenessModalOpen);
 
+  // Gate with the same deferred-tour freeze as Terms/Release Notes.
   const hasCompetingAppStartModal = !shouldShowDeferredModals || isGenericAwarenessModalOpen;
 
+  // Competitor identity is only for analytics (`modal_blocked`).
+  const competingModal = resolveCompetingAppStartModal({
+    isWalletV4TourCompeting: shouldDisplayTour && !hasSeenWalletV4Tour,
+    isQ2TourCompeting: shouldDisplayQ2Tour && !hasSeenQ2Tour,
+    isGenericAwarenessModalOpen,
+  });
+
+  const hasTrackedBlockRef = useRef(false);
+
   useEffect(() => {
-    if (hasCompetingAppStartModal && session === "ready") {
-      dispatch(markBlockedByCompeting());
+    if (!hasCompetingAppStartModal || session !== "ready") {
+      return;
     }
-  }, [dispatch, hasCompetingAppStartModal, session]);
+    if (!hasTrackedBlockRef.current && competingModal !== null) {
+      hasTrackedBlockRef.current = true;
+      trackLargeScreenUpsellModalBlockedByCompeting(competingModal);
+    }
+    dispatch(markBlockedByCompeting());
+  }, [competingModal, dispatch, hasCompetingAppStartModal, session]);
 
   const currentModalAnalyticsPropsRef = useRef<LargeScreenUpsellSharedAnalyticsProps | null>(null);
 

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/LargeScreenUpsellModalMount.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/LargeScreenUpsellModalMount.tsx
@@ -8,6 +8,7 @@ import {
   markBlockedByCompeting,
   retriesUpsellModalSelector,
   sessionSelector,
+  useLargeScreenUpsellDecision,
   type LargeScreenUpsellDismissMethod,
   type LargeScreenUpsellModalAnalyticsPorts,
   type LargeScreenUpsellModalViewedContext,
@@ -92,6 +93,18 @@ export function LargeScreenUpsellModalMount() {
   const { shouldDisplayTour, shouldDisplayQ2Tour } = useWalletFeaturesConfig("desktop");
   const isGenericAwarenessModalOpen = useSelector(selectIsGenericAwarenessModalOpen);
 
+  const variant = personalizedRecommendationsEnabled ? "opted_in" : "opted_out";
+  const { seenNanoModelIds, hasSeenTouchscreenDevice } = useMemo(
+    () => mapDevicesModelListToUpsellInputs(devicesModelList),
+    [devicesModelList],
+  );
+  const decision = useLargeScreenUpsellDecision({
+    seenNanoModelIds,
+    hasSeenTouchscreenDevice,
+    onboardingDate,
+    variant,
+  });
+
   // Gate with the same deferred-tour freeze as Terms/Release Notes.
   const hasCompetingAppStartModal = !shouldShowDeferredModals || isGenericAwarenessModalOpen;
 
@@ -105,7 +118,7 @@ export function LargeScreenUpsellModalMount() {
   const hasTrackedBlockRef = useRef(false);
 
   useEffect(() => {
-    if (!hasCompetingAppStartModal || session !== "ready") {
+    if (!hasCompetingAppStartModal || session !== "ready" || !decision.shouldShow) {
       return;
     }
     if (!hasTrackedBlockRef.current && competingModal !== null) {
@@ -113,7 +126,7 @@ export function LargeScreenUpsellModalMount() {
       trackLargeScreenUpsellModalBlockedByCompeting(competingModal);
     }
     dispatch(markBlockedByCompeting());
-  }, [competingModal, dispatch, hasCompetingAppStartModal, session]);
+  }, [competingModal, decision.shouldShow, dispatch, hasCompetingAppStartModal, session]);
 
   const currentModalAnalyticsPropsRef = useRef<LargeScreenUpsellSharedAnalyticsProps | null>(null);
 
@@ -163,9 +176,6 @@ export function LargeScreenUpsellModalMount() {
     return null;
   }
 
-  const { seenNanoModelIds, hasSeenTouchscreenDevice } =
-    mapDevicesModelListToUpsellInputs(devicesModelList);
-
   return (
     <LargeScreenUpsellModal
       seenNanoModelIds={seenNanoModelIds}
@@ -173,7 +183,7 @@ export function LargeScreenUpsellModalMount() {
       onboardingDate={onboardingDate}
       medium="desktop"
       theme={theme === "dark" ? "dark" : "light"}
-      variant={personalizedRecommendationsEnabled ? "opted_in" : "opted_out"}
+      variant={variant}
       t={t}
       openUrl={openURL}
       analytics={analytics}

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/LargeScreenUpsellModalMount.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/LargeScreenUpsellModalMount.tsx
@@ -113,8 +113,10 @@ export function LargeScreenUpsellModalMount() {
     [getAnalyticsPropsForDevice],
   );
 
-  // session becomes "dismissed" on close — while visible it stays "ready" so Mount stays mounted.
-  if (session !== "ready" || hasCompetingAppStartModal) {
+  // session becomes "dismissed" / "blockedByCompeting" — while visible it stays "ready".
+  // Competing modals gate `isAllowedToDisplay` so a visible upsell can roll back its
+  // impression before the session flips to blockedByCompeting.
+  if (session !== "ready") {
     return null;
   }
 
@@ -132,6 +134,7 @@ export function LargeScreenUpsellModalMount() {
       t={t}
       openUrl={openURL}
       analytics={analytics}
+      isAllowedToDisplay={!hasCompetingAppStartModal}
     />
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
@@ -13,6 +13,7 @@ import type { State } from "~/renderer/reducers";
 import { closeDialog, openDialog } from "~/renderer/reducers/dialogs";
 import { openURL } from "~/renderer/linking";
 import { track, trackPage } from "~/renderer/analytics/segment";
+import { setHasSeenWalletV4Tour } from "~/renderer/actions/settings";
 import { LargeScreenUpsellModalMount } from "..";
 
 /** Mimics Portfolio scoping: Mount unmounts when leaving portfolio. */
@@ -79,7 +80,7 @@ function eligibleState(settingsOverrides: Partial<State["settings"]> = {}): Deep
       onboardingDate: "2026-01-01T00:00:00.000Z",
     },
     largeScreenUpsellModal: {
-      retries: 0,
+      retriesModal: 0,
       lastSeenAt: null,
       session: "ready",
     },
@@ -264,7 +265,7 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     expect(openedUrl.searchParams.get("utm_medium")).toBe("ledger_live");
     expect(openedUrl.searchParams.get("utm_campaign")).toBe("nano_upgrade_program");
     expect(openedUrl.searchParams.get("utm_content")).toBe("app_start_modal");
-    expect(store.getState().largeScreenUpsellModal.retries).toBe(0);
+    expect(store.getState().largeScreenUpsellModal.retriesModal).toBe(0);
     expect(track).toHaveBeenCalledWith("button_clicked", {
       button: "explore large screen devices",
       page: "Modal - Upgrade",
@@ -330,7 +331,7 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     });
 
     await waitFor(() => {
-      expect(store.getState().largeScreenUpsellModal.retries).toBe(1);
+      expect(store.getState().largeScreenUpsellModal.retriesModal).toBe(1);
       expect(store.getState().largeScreenUpsellModal.lastSeenAt).not.toBeNull();
     });
     expect(store.getState().largeScreenUpsellModal.session).toBe("ready");
@@ -344,7 +345,7 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     });
 
     await waitFor(() => {
-      expect(store.getState().largeScreenUpsellModal.retries).toBe(1);
+      expect(store.getState().largeScreenUpsellModal.retriesModal).toBe(1);
     });
     expect(store.getState().largeScreenUpsellModal.session).toBe("ready");
 
@@ -355,7 +356,7 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     });
 
     expect(openURL).not.toHaveBeenCalled();
-    expect(store.getState().largeScreenUpsellModal.retries).toBe(1);
+    expect(store.getState().largeScreenUpsellModal.retriesModal).toBe(1);
     expect(store.getState().largeScreenUpsellModal.session).toBe("dismissed");
     expect(screen.queryByTestId("large-screen-upsell-modal")).not.toBeInTheDocument();
     expect(track).toHaveBeenCalledWith("modal_dismissed", {
@@ -388,7 +389,7 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     });
 
     await waitFor(() => {
-      expect(store.getState().largeScreenUpsellModal.retries).toBe(1);
+      expect(store.getState().largeScreenUpsellModal.retriesModal).toBe(1);
     });
 
     await user.click(screen.getByRole("button", { name: "Learn more" }));
@@ -398,7 +399,7 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     });
 
     expect(openURL).not.toHaveBeenCalled();
-    expect(store.getState().largeScreenUpsellModal.retries).toBe(0);
+    expect(store.getState().largeScreenUpsellModal.retriesModal).toBe(0);
   });
 
   it("should open for nanoS even when onboarding was recent because nanoS cooldown is 0", async () => {
@@ -433,7 +434,7 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
         lwdWallet40: { enabled: true, params: { tour: false } },
       }),
       largeScreenUpsellModal: {
-        retries: 2,
+        retriesModal: 2,
         lastSeenAt: Date.parse("2026-07-14T12:00:00.000Z"),
         session: "ready",
       },
@@ -554,7 +555,7 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
 
     await expectModalNotOpen();
 
-    expect(store.getState().largeScreenUpsellModal.retries).toBe(0);
+    expect(store.getState().largeScreenUpsellModal.retriesModal).toBe(0);
     expect(trackPage).not.toHaveBeenCalled();
   });
 
@@ -577,7 +578,7 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
 
     await expectModalNotOpen();
 
-    expect(store.getState().largeScreenUpsellModal.retries).toBe(0);
+    expect(store.getState().largeScreenUpsellModal.retriesModal).toBe(0);
     expect(trackPage).not.toHaveBeenCalled();
   });
 
@@ -643,7 +644,7 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
         lwdWallet40: { enabled: true, params: { tour: false } },
       }),
       largeScreenUpsellModal: {
-        retries: 3,
+        retriesModal: 3,
         lastSeenAt: Date.parse("2026-07-14T12:00:00.000Z"),
         session: "ready",
       },
@@ -669,7 +670,7 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
         lwdWallet40: { enabled: true, params: { tour: false } },
       }),
       largeScreenUpsellModal: {
-        retries: 3,
+        retriesModal: 3,
         lastSeenAt: Date.parse("2026-05-01T12:00:00.000Z"),
         session: "ready",
       },
@@ -708,7 +709,7 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
         onboardingDate: "2026-01-01T00:00:00.000Z",
       },
       largeScreenUpsellModal: {
-        retries: 0,
+        retriesModal: 0,
         lastSeenAt: null,
         session: "ready",
       },
@@ -734,7 +735,7 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
         onboardingDate: "2026-01-01T00:00:00.000Z",
       },
       largeScreenUpsellModal: {
-        retries: 0,
+        retriesModal: 0,
         lastSeenAt: null,
         session: "ready",
       },
@@ -754,7 +755,7 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     await expectModalNotOpen();
   });
 
-  it("should not open later in the same session after a competing modal closes", async () => {
+  it("should stay blocked for the session after a competing modal closes", async () => {
     const { store } = renderMount({
       ...eligibleState(),
       dialogs: {
@@ -763,6 +764,10 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     });
 
     await expectModalNotOpen();
+    await waitFor(() => {
+      expect(store.getState().largeScreenUpsellModal.session).toBe("blockedByCompeting");
+    });
+    expect(store.getState().largeScreenUpsellModal.retriesModal).toBe(0);
 
     act(() => {
       store.dispatch(closeDialog("GENERIC_AWARENESS_MODAL"));
@@ -770,13 +775,52 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
 
     expect(store.getState().dialogs.GENERIC_AWARENESS_MODAL).toBe(false);
     await expectModalNotOpen();
+    expect(store.getState().largeScreenUpsellModal.session).toBe("blockedByCompeting");
+    expect(store.getState().largeScreenUpsellModal.retriesModal).toBe(0);
   });
 
-  it("should unmount when a competing modal opens after the upsell is already visible", async () => {
+  it("should stay blocked after the Wallet V4 tour is completed in the same session", async () => {
+    const { store } = renderMount({
+      ...eligibleState({
+        hasSeenWalletV4Tour: false,
+      }),
+      ...withFlagOverrides({
+        largeScreenUpsell: {
+          enabled: true,
+          params: {
+            opted_out: {
+              enabled: true,
+              link: "https://shop.ledger.com/pages/ledger-nano-upgrade-program",
+            },
+          },
+        },
+        lwdWallet40: { enabled: true, params: { tour: true } },
+      }),
+    });
+
+    await expectModalNotOpen();
+    await waitFor(() => {
+      expect(store.getState().largeScreenUpsellModal.session).toBe("blockedByCompeting");
+    });
+    expect(store.getState().largeScreenUpsellModal.retriesModal).toBe(0);
+
+    act(() => {
+      store.dispatch(setHasSeenWalletV4Tour(true));
+    });
+
+    await expectModalNotOpen();
+    expect(store.getState().largeScreenUpsellModal.session).toBe("blockedByCompeting");
+    expect(store.getState().largeScreenUpsellModal.retriesModal).toBe(0);
+  });
+
+  it("should roll back retries when a competing modal preempts a visible upsell", async () => {
     const { store } = renderMount();
 
     await waitFor(() => {
       expect(screen.getByTestId("large-screen-upsell-modal")).toBeVisible();
+    });
+    await waitFor(() => {
+      expect(store.getState().largeScreenUpsellModal.retriesModal).toBe(1);
     });
 
     act(() => {
@@ -786,7 +830,8 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     await waitFor(() => {
       expect(screen.queryByTestId("large-screen-upsell-modal")).not.toBeInTheDocument();
     });
-    expect(store.getState().largeScreenUpsellModal.retries).toBe(1);
+    expect(store.getState().largeScreenUpsellModal.retriesModal).toBe(0);
+    expect(store.getState().largeScreenUpsellModal.session).toBe("blockedByCompeting");
   });
 
   it("should dismiss via Escape with dismissMethod escape key down", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
@@ -695,7 +695,15 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
   it("should not open when a product tour is competing", async () => {
     renderMount({
       ...withFlagOverrides({
-        largeScreenUpsell: { enabled: true },
+        largeScreenUpsell: {
+          enabled: true,
+          params: {
+            opted_out: {
+              enabled: true,
+              link: "https://shop.ledger.com/pages/ledger-nano-upgrade-program",
+            },
+          },
+        },
         lwdWallet40: { enabled: true, params: { tour: true } },
       }),
       settings: {
@@ -713,6 +721,9 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
         lastSeenAt: null,
         session: "ready",
       },
+      dialogs: {
+        GENERIC_AWARENESS_MODAL: false,
+      },
     });
 
     await expectModalNotOpen();
@@ -728,7 +739,15 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
   it("should not open when a Q2 tour is competing", async () => {
     renderMount({
       ...withFlagOverrides({
-        largeScreenUpsell: { enabled: true },
+        largeScreenUpsell: {
+          enabled: true,
+          params: {
+            opted_out: {
+              enabled: true,
+              link: "https://shop.ledger.com/pages/ledger-nano-upgrade-program",
+            },
+          },
+        },
         lwdWallet40: { enabled: true, params: { tour: false, q2Tour: true } },
       }),
       settings: {
@@ -745,6 +764,9 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
         retriesModal: 0,
         lastSeenAt: null,
         session: "ready",
+      },
+      dialogs: {
+        GENERIC_AWARENESS_MODAL: false,
       },
     });
 
@@ -774,6 +796,26 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
         competitor: "generic_awareness",
       }),
     );
+  });
+
+  it("should not track modal_blocked when the upsell is not eligible", async () => {
+    renderMount({
+      ...eligibleState(),
+      ...withFlagOverrides({
+        largeScreenUpsell: { enabled: false },
+        lwdWallet40: { enabled: true, params: { tour: true } },
+      }),
+      settings: {
+        hasCompletedOnboarding: true,
+        hasSeenWalletV4Tour: false,
+        hasSeenQ2Tour: true,
+        sharePersonalizedRecommandations: false,
+        devicesModelList: [DeviceModelId.nanoS],
+      },
+    });
+
+    await expectModalNotOpen();
+    expect(track).not.toHaveBeenCalledWith("modal_blocked", expect.anything());
   });
 
   it("should stay blocked for the session after a competing modal closes", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
@@ -716,6 +716,13 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     });
 
     await expectModalNotOpen();
+    expect(track).toHaveBeenCalledWith(
+      "modal_blocked",
+      expect.objectContaining({
+        reason: "competing_app_start_modal",
+        competitor: "wallet_v4_tour",
+      }),
+    );
   });
 
   it("should not open when a Q2 tour is competing", async () => {
@@ -742,6 +749,13 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     });
 
     await expectModalNotOpen();
+    expect(track).toHaveBeenCalledWith(
+      "modal_blocked",
+      expect.objectContaining({
+        reason: "competing_app_start_modal",
+        competitor: "q2_tour",
+      }),
+    );
   });
 
   it("should not open when Generic Awareness modal is open", async () => {
@@ -753,6 +767,13 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     });
 
     await expectModalNotOpen();
+    expect(track).toHaveBeenCalledWith(
+      "modal_blocked",
+      expect.objectContaining({
+        reason: "competing_app_start_modal",
+        competitor: "generic_awareness",
+      }),
+    );
   });
 
   it("should stay blocked for the session after a competing modal closes", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/__tests__/analytics.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/__tests__/analytics.test.ts
@@ -2,6 +2,7 @@ import { track, trackPage } from "~/renderer/analytics/segment";
 import {
   LARGE_SCREEN_UPSELL_MODAL_PAGE_NAME,
   toLargeScreenUpsellDeviceModelAnalyticsValue,
+  trackLargeScreenUpsellModalBlockedByCompeting,
   trackLargeScreenUpsellModalCtaClicked,
   trackLargeScreenUpsellModalDismissed,
   trackLargeScreenUpsellModalViewed,
@@ -53,6 +54,19 @@ describe("LargeScreenUpsell analytics", () => {
       page: LARGE_SCREEN_UPSELL_MODAL_PAGE_NAME,
       dismissMethod: "escape key down",
       ...SHARED_PROPS,
+    });
+  });
+
+  it("should emit modal_blocked when a competing app-start modal has preference", () => {
+    trackLargeScreenUpsellModalBlockedByCompeting("wallet_v4_tour");
+
+    expect(track).toHaveBeenCalledWith("modal_blocked", {
+      modal: "upgrade modal",
+      page: LARGE_SCREEN_UPSELL_MODAL_PAGE_NAME,
+      reason: "competing_app_start_modal",
+      competitor: "wallet_v4_tour",
+      platform: "lwd",
+      sourceFlow: "app start",
     });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/analytics.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/analytics.ts
@@ -70,3 +70,18 @@ export function trackLargeScreenUpsellModalDismissed(
     ...sharedProps,
   });
 }
+
+export type LargeScreenUpsellBlockedCompetitor = "wallet_v4_tour" | "q2_tour" | "generic_awareness";
+
+export function trackLargeScreenUpsellModalBlockedByCompeting(
+  competitor: LargeScreenUpsellBlockedCompetitor,
+) {
+  track("modal_blocked", {
+    modal: "upgrade modal",
+    page: LARGE_SCREEN_UPSELL_MODAL_PAGE_NAME,
+    reason: "competing_app_start_modal",
+    competitor,
+    platform: "lwd",
+    sourceFlow: "app start",
+  });
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/screens/LargeScreenUpsellQa/useLargeScreenUpsellQaViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/screens/LargeScreenUpsellQa/useLargeScreenUpsellQaViewModel.ts
@@ -148,7 +148,7 @@ export function useLargeScreenUpsellQaViewModel() {
           seenNanoModelIds,
           hasSeenTouchscreenDevice,
           onboardingDate,
-          frequency: { retries, lastSeenAt },
+          frequency: { retriesModal: retries, lastSeenAt },
         },
         {
           isFeatureEnabled,

--- a/apps/ledger-live-desktop/src/renderer/middlewares/__tests__/db.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/__tests__/db.test.ts
@@ -73,7 +73,7 @@ type FakeState = {
   history: unknown;
   featureFlags: { overrides: unknown; bannerVisible: unknown; remoteFlagsReady?: unknown };
   coinConfigOverrides: { overrides: Record<string, unknown> };
-  largeScreenUpsellModal: { retries: number; lastSeenAt: number | null };
+  largeScreenUpsellModal: { retriesModal: number; lastSeenAt: number | null };
   payCardBalance: {
     balanceFilter: string;
   };
@@ -93,7 +93,7 @@ const baseState = (): FakeState => ({
   history: {},
   featureFlags: { overrides: {}, bannerVisible: false },
   coinConfigOverrides: { overrides: {} },
-  largeScreenUpsellModal: { retries: 0, lastSeenAt: null },
+  largeScreenUpsellModal: { retriesModal: 0, lastSeenAt: null },
   payCardBalance: { balanceFilter: "all" },
   payCardFeatureTour: { hasSeenFeatureTour: false },
 });
@@ -218,7 +218,7 @@ describe("DBMiddleware - largeScreenUpsellModal branch", () => {
   it("persists largeScreenUpsellModal under app/largeScreenUpsellModal on largeScreenUpsellModal/* actions", () => {
     const state: FakeState = {
       ...baseState(),
-      largeScreenUpsellModal: { retries: 2, lastSeenAt: 1_720_000_000_000 },
+      largeScreenUpsellModal: { retriesModal: 2, lastSeenAt: 1_720_000_000_000 },
     };
 
     runMiddleware([state, state], {
@@ -228,7 +228,7 @@ describe("DBMiddleware - largeScreenUpsellModal branch", () => {
 
     expect(mockedSetKey).toHaveBeenCalledTimes(1);
     expect(mockedSetKey).toHaveBeenCalledWith("app", LARGE_SCREEN_UPSELL_MODAL, {
-      retries: 2,
+      retriesModal: 2,
       lastSeenAt: 1_720_000_000_000,
     });
   });

--- a/features/flow/large-screen-upsell/README.md
+++ b/features/flow/large-screen-upsell/README.md
@@ -8,7 +8,7 @@ state (schema, slice, selectors).
 
 ## Exports
 
-- `largeScreenUpsellModalSlice` / selectors / actions — display-frequency state (`retries`, `lastSeenAt`, `session`)
+- `largeScreenUpsellModalSlice` / selectors / actions — display-frequency state (`retriesModal`, `lastSeenAt`, `session`)
 - `getLargeScreenUpsellDecision` / `useLargeScreenUpsellDecision` — audience + cooldown + frequency
 - `mapDevicesModelListToUpsellInputs` — `DeviceModelId[]` → decision inputs
 - `buildLargeScreenUpsellCtaLink` / `buildLargeScreenUpsellContent` — pure helpers

--- a/features/flow/large-screen-upsell/src/decision/getLargeScreenUpsellDecision.test.ts
+++ b/features/flow/large-screen-upsell/src/decision/getLargeScreenUpsellDecision.test.ts
@@ -7,7 +7,7 @@ const baseUserState: LargeScreenUpsellUserState = {
   seenNanoModelIds: ["nanoX"],
   hasSeenTouchscreenDevice: false,
   onboardingDate: new Date("2026-06-01T12:00:00.000Z"),
-  frequency: { retries: 0, lastSeenAt: null },
+  frequency: { retriesModal: 0, lastSeenAt: null },
 };
 
 const baseContext: LargeScreenUpsellContext = {
@@ -93,17 +93,23 @@ describe("getLargeScreenUpsellDecision", () => {
     },
     {
       description: "under the kill threshold regardless of last display",
-      userState: { frequency: { retries: 2, lastSeenAt: Date.parse("2026-07-14T12:00:00.000Z") } },
+      userState: {
+        frequency: { retriesModal: 2, lastSeenAt: Date.parse("2026-07-14T12:00:00.000Z") },
+      },
       expected: { shouldShow: true, deviceModelId: "nanoX" },
     },
     {
       description: "past the kill threshold and within the cadence window",
-      userState: { frequency: { retries: 3, lastSeenAt: Date.parse("2026-07-14T12:00:00.000Z") } },
+      userState: {
+        frequency: { retriesModal: 3, lastSeenAt: Date.parse("2026-07-14T12:00:00.000Z") },
+      },
       expected: { shouldShow: false, reason: "throttled", deviceModelId: "nanoX" },
     },
     {
       description: "past the kill threshold but the cadence window has elapsed",
-      userState: { frequency: { retries: 3, lastSeenAt: Date.parse("2026-05-01T12:00:00.000Z") } },
+      userState: {
+        frequency: { retriesModal: 3, lastSeenAt: Date.parse("2026-05-01T12:00:00.000Z") },
+      },
       expected: { shouldShow: true, deviceModelId: "nanoX" },
     },
   ])("resolves as expected when $description", ({ userState, context, expected }) => {

--- a/features/flow/large-screen-upsell/src/decision/getLargeScreenUpsellDecision.ts
+++ b/features/flow/large-screen-upsell/src/decision/getLargeScreenUpsellDecision.ts
@@ -91,7 +91,7 @@ export function getLargeScreenUpsellDecision(
   }
 
   if (
-    frequency.retries >= killThreshold &&
+    frequency.retriesModal >= killThreshold &&
     frequency.lastSeenAt !== null &&
     !isCooldownElapsed({
       elapsedSinceDate: new Date(frequency.lastSeenAt),

--- a/features/flow/large-screen-upsell/src/hooks/useLargeScreenUpsellDecision.ts
+++ b/features/flow/large-screen-upsell/src/hooks/useLargeScreenUpsellDecision.ts
@@ -17,7 +17,7 @@ export function useLargeScreenUpsellDecision(
   input: UseLargeScreenUpsellDecisionInput,
 ): LargeScreenUpsellDecision {
   const feature = useFeature("largeScreenUpsell");
-  const retries = useSelector(retriesUpsellModalSelector);
+  const retriesModal = useSelector(retriesUpsellModalSelector);
   const lastSeenAt = useSelector(lastSeenUpsellModalSelector);
   const params = feature?.params;
 
@@ -26,7 +26,7 @@ export function useLargeScreenUpsellDecision(
       seenNanoModelIds: input.seenNanoModelIds,
       hasSeenTouchscreenDevice: input.hasSeenTouchscreenDevice,
       onboardingDate: input.onboardingDate,
-      frequency: { retries, lastSeenAt },
+      frequency: { retriesModal, lastSeenAt },
     },
     {
       isFeatureEnabled: Boolean(feature?.enabled && params?.[input.variant].enabled),

--- a/features/flow/large-screen-upsell/src/screens/LargeScreenUpsellModal/useLargeScreenUpsellModalViewModel.ts
+++ b/features/flow/large-screen-upsell/src/screens/LargeScreenUpsellModal/useLargeScreenUpsellModalViewModel.ts
@@ -1,8 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { useFeature } from "@features/platform-feature-flags";
 import { LARGE_SCREEN_UPSELL_IMAGES } from "../../assets";
-import { markDismissed, recordUpsellModalDisplay, resetUpsellModalRetries } from "../../state";
+import {
+  lastSeenUpsellModalSelector,
+  markDismissed,
+  recordUpsellModalDisplay,
+  resetUpsellModalRetries,
+  rollbackUpsellModalDisplay,
+} from "../../state";
 import {
   useLargeScreenUpsellDecision,
   type UseLargeScreenUpsellDecisionInput,
@@ -27,6 +33,11 @@ export type UseLargeScreenUpsellModalViewModelInput = UseLargeScreenUpsellDecisi
   t: BuildLargeScreenUpsellContentInput["t"];
   openUrl: (url: string) => void;
   analytics?: LargeScreenUpsellModalAnalyticsPorts;
+  /**
+   * When false, close without counting a retry (e.g. another app-start modal has preference).
+   * The host still marks the session blocked so the upsell does not reopen later.
+   */
+  isAllowedToDisplay?: boolean;
 };
 
 export function useLargeScreenUpsellModalViewModel({
@@ -40,8 +51,10 @@ export function useLargeScreenUpsellModalViewModel({
   t,
   openUrl,
   analytics,
+  isAllowedToDisplay = true,
 }: UseLargeScreenUpsellModalViewModelInput): LargeScreenUpsellModalViewModel {
   const dispatch = useDispatch();
+  const lastSeenAt = useSelector(lastSeenUpsellModalSelector);
   const feature = useFeature("largeScreenUpsell");
   const decision = useLargeScreenUpsellDecision({
     seenNanoModelIds,
@@ -53,6 +66,7 @@ export function useLargeScreenUpsellModalViewModel({
   const [isOpen, setIsOpen] = useState(false);
   const hasOpenedRef = useRef(false);
   const hasHandledCurrentModalInteractionRef = useRef(false);
+  const lastSeenAtBeforeOpenRef = useRef<number | null>(null);
 
   const params = feature?.params;
   const content = useMemo(() => {
@@ -77,16 +91,30 @@ export function useLargeScreenUpsellModalViewModel({
   const viewedDeviceModelId = decision.shouldShow ? decision.deviceModelId : undefined;
 
   useEffect(() => {
+    if (!isAllowedToDisplay) {
+      if (!hasOpenedRef.current || hasHandledCurrentModalInteractionRef.current) {
+        return;
+      }
+
+      // Competing modal preempted a visible upsell — do not consume an impression.
+      hasOpenedRef.current = false;
+      hasHandledCurrentModalInteractionRef.current = false;
+      setIsOpen(false);
+      dispatch(rollbackUpsellModalDisplay({ previousLastSeenAt: lastSeenAtBeforeOpenRef.current }));
+      return;
+    }
+
     if (viewedDeviceModelId === undefined || !hasContent || hasOpenedRef.current) {
       return;
     }
 
     hasOpenedRef.current = true;
     hasHandledCurrentModalInteractionRef.current = false;
+    lastSeenAtBeforeOpenRef.current = lastSeenAt;
     analytics?.onModalViewed({ deviceModelId: viewedDeviceModelId });
     setIsOpen(true);
     dispatch(recordUpsellModalDisplay());
-  }, [viewedDeviceModelId, dispatch, hasContent, analytics]);
+  }, [isAllowedToDisplay, viewedDeviceModelId, dispatch, hasContent, analytics, lastSeenAt]);
 
   const onDismiss = useCallback(
     (method: LargeScreenUpsellDismissMethod) => {

--- a/features/flow/large-screen-upsell/src/state/schema.mock.ts
+++ b/features/flow/large-screen-upsell/src/state/schema.mock.ts
@@ -4,7 +4,7 @@ export function mockLargeScreenUpsellModalState(
   overrides?: Partial<LargeScreenUpsellModalState>,
 ): LargeScreenUpsellModalState {
   return {
-    retries: 0,
+    retriesModal: 0,
     lastSeenAt: null,
     session: "ready",
     ...overrides,
@@ -15,7 +15,7 @@ export function mockSeenLargeScreenUpsellModalState(
   overrides?: Partial<LargeScreenUpsellModalState>,
 ): LargeScreenUpsellModalState {
   return mockLargeScreenUpsellModalState({
-    retries: 1,
+    retriesModal: 1,
     lastSeenAt: Date.parse("2026-07-01T12:00:00.000Z"),
     session: "dismissed",
     ...overrides,

--- a/features/flow/large-screen-upsell/src/state/schema.test.ts
+++ b/features/flow/large-screen-upsell/src/state/schema.test.ts
@@ -6,32 +6,32 @@ import {
 } from "./schema";
 
 const restorableDefaults = {
-  retries: defaultLargeScreenUpsellModalState.retries,
+  retriesModal: defaultLargeScreenUpsellModalState.retriesModal,
   lastSeenAt: defaultLargeScreenUpsellModalState.lastSeenAt,
 };
 
 describe("LargeScreenUpsellModalStateSchema", () => {
   it.each([
-    { retries: 0, lastSeenAt: null, session: "ready" as const },
+    { retriesModal: 0, lastSeenAt: null, session: "ready" as const },
     {
-      retries: 3,
+      retriesModal: 3,
       lastSeenAt: Date.parse("2026-07-01T12:00:00.000Z"),
       session: "dismissed" as const,
     },
     {
-      retries: Number.MAX_SAFE_INTEGER,
+      retriesModal: Number.MAX_SAFE_INTEGER,
       lastSeenAt: MAX_DATE_MS,
       session: "blockedByCompeting" as const,
     },
-  ])("accepts $retries retries with lastSeenAt $lastSeenAt", state => {
+  ])("accepts $retriesModal retries with lastSeenAt $lastSeenAt", state => {
     expect(LargeScreenUpsellModalStateSchema.parse(state)).toEqual(state);
   });
 
   it.each([
-    { field: "retries", value: -1 },
-    { field: "retries", value: 1.5 },
-    { field: "retries", value: Number.MAX_SAFE_INTEGER + 1 },
-    { field: "retries", value: "2" },
+    { field: "retriesModal", value: -1 },
+    { field: "retriesModal", value: 1.5 },
+    { field: "retriesModal", value: Number.MAX_SAFE_INTEGER + 1 },
+    { field: "retriesModal", value: "2" },
     { field: "lastSeenAt", value: -1 },
     { field: "lastSeenAt", value: 1.5 },
     { field: "lastSeenAt", value: MAX_DATE_MS + 1 },
@@ -42,7 +42,7 @@ describe("LargeScreenUpsellModalStateSchema", () => {
     { field: "session", value: true },
   ])("rejects $field of $value", ({ field, value }) => {
     const state = {
-      retries: 0,
+      retriesModal: 0,
       lastSeenAt: null,
       session: "ready" as const,
       [field]: value,
@@ -69,12 +69,24 @@ describe("RestorableLargeScreenUpsellModalStateSchema", () => {
   it("strips ephemeral session from a persisted payload", () => {
     expect(
       RestorableLargeScreenUpsellModalStateSchema.parse({
-        retries: 2,
+        retriesModal: 2,
         lastSeenAt: Date.parse("2026-07-01T12:00:00.000Z"),
         session: "dismissed",
       }),
     ).toEqual({
-      retries: 2,
+      retriesModal: 2,
+      lastSeenAt: Date.parse("2026-07-01T12:00:00.000Z"),
+    });
+  });
+
+  it("ignores legacy retries and defaults retriesModal to 0", () => {
+    expect(
+      RestorableLargeScreenUpsellModalStateSchema.parse({
+        retries: 3,
+        lastSeenAt: Date.parse("2026-07-01T12:00:00.000Z"),
+      }),
+    ).toEqual({
+      retriesModal: 0,
       lastSeenAt: Date.parse("2026-07-01T12:00:00.000Z"),
     });
   });

--- a/features/flow/large-screen-upsell/src/state/schema.ts
+++ b/features/flow/large-screen-upsell/src/state/schema.ts
@@ -12,14 +12,14 @@ export const LargeScreenUpsellModalSessionSchema = z.enum([
 export type LargeScreenUpsellModalSession = z.infer<typeof LargeScreenUpsellModalSessionSchema>;
 
 export const LargeScreenUpsellModalStateSchema = z.object({
-  retries: z.number().int().nonnegative().safe(),
+  retriesModal: z.number().int().nonnegative().safe(),
   lastSeenAt: z.number().int().nonnegative().max(MAX_DATE_MS).safe().nullable(),
   session: LargeScreenUpsellModalSessionSchema,
 });
 
 export const defaultLargeScreenUpsellModalState: z.infer<typeof LargeScreenUpsellModalStateSchema> =
   {
-    retries: 0,
+    retriesModal: 0,
     lastSeenAt: null,
     session: "ready",
   };
@@ -27,19 +27,19 @@ export const defaultLargeScreenUpsellModalState: z.infer<typeof LargeScreenUpsel
 /** Persisted fields only — session is ephemeral. */
 export const RestorableLargeScreenUpsellModalStateSchema = z
   .object({
-    retries: LargeScreenUpsellModalStateSchema.shape.retries.catch(
-      defaultLargeScreenUpsellModalState.retries,
+    retriesModal: LargeScreenUpsellModalStateSchema.shape.retriesModal.catch(
+      defaultLargeScreenUpsellModalState.retriesModal,
     ),
     lastSeenAt: LargeScreenUpsellModalStateSchema.shape.lastSeenAt.catch(
       defaultLargeScreenUpsellModalState.lastSeenAt,
     ),
   })
   .catch({
-    retries: defaultLargeScreenUpsellModalState.retries,
+    retriesModal: defaultLargeScreenUpsellModalState.retriesModal,
     lastSeenAt: defaultLargeScreenUpsellModalState.lastSeenAt,
   });
 
 export type RestorableLargeScreenUpsellModalState = Pick<
   z.infer<typeof LargeScreenUpsellModalStateSchema>,
-  "retries" | "lastSeenAt"
+  "retriesModal" | "lastSeenAt"
 >;

--- a/features/flow/large-screen-upsell/src/state/slice.test.ts
+++ b/features/flow/large-screen-upsell/src/state/slice.test.ts
@@ -10,6 +10,7 @@ import {
   restoreLargeScreenUpsellModalState,
   resetUpsellModalRetries,
   retriesUpsellModalSelector,
+  rollbackUpsellModalDisplay,
   sessionSelector,
   setLastSeenUpsellModal,
   setUpsellModalRetries,
@@ -21,7 +22,7 @@ const reducer = largeScreenUpsellModalSlice.reducer;
 const lastSeenAt = Date.parse("2026-07-01T12:00:00.000Z");
 
 const withSession = (
-  state: Pick<LargeScreenUpsellModalState, "retries" | "lastSeenAt">,
+  state: Pick<LargeScreenUpsellModalState, "retriesModal" | "lastSeenAt">,
   session: LargeScreenUpsellModalState["session"] = "ready",
 ): LargeScreenUpsellModalState => ({
   ...state,
@@ -45,52 +46,52 @@ describe("largeScreenUpsellModal", () => {
     }>([
       {
         description: "a valid persisted state",
-        payload: { retries: 2, lastSeenAt },
-        expected: withSession({ retries: 2, lastSeenAt }),
+        payload: { retriesModal: 2, lastSeenAt },
+        expected: withSession({ retriesModal: 2, lastSeenAt }),
       },
       {
         description: "a missing lastSeenAt",
-        payload: { retries: 2 },
-        expected: withSession({ retries: 2, lastSeenAt: null }),
+        payload: { retriesModal: 2 },
+        expected: withSession({ retriesModal: 2, lastSeenAt: null }),
       },
       {
         description: "a non-integer retries count",
-        payload: { retries: 2.7, lastSeenAt },
-        expected: withSession({ retries: 0, lastSeenAt }),
+        payload: { retriesModal: 2.7, lastSeenAt },
+        expected: withSession({ retriesModal: 0, lastSeenAt }),
       },
       {
         description: "a negative retries count",
-        payload: { retries: -1, lastSeenAt },
-        expected: withSession({ retries: 0, lastSeenAt }),
+        payload: { retriesModal: -1, lastSeenAt },
+        expected: withSession({ retriesModal: 0, lastSeenAt }),
       },
       {
         description: "an unsafe integer retries count",
-        payload: { retries: Number.MAX_SAFE_INTEGER + 1, lastSeenAt },
-        expected: withSession({ retries: 0, lastSeenAt }),
+        payload: { retriesModal: Number.MAX_SAFE_INTEGER + 1, lastSeenAt },
+        expected: withSession({ retriesModal: 0, lastSeenAt }),
       },
       {
         description: "a non-integer lastSeenAt",
-        payload: { retries: 2, lastSeenAt: 2.7 },
-        expected: withSession({ retries: 2, lastSeenAt: null }),
+        payload: { retriesModal: 2, lastSeenAt: 2.7 },
+        expected: withSession({ retriesModal: 2, lastSeenAt: null }),
       },
       {
         description: "a negative lastSeenAt",
-        payload: { retries: 2, lastSeenAt: -1 },
-        expected: withSession({ retries: 2, lastSeenAt: null }),
+        payload: { retriesModal: 2, lastSeenAt: -1 },
+        expected: withSession({ retriesModal: 2, lastSeenAt: null }),
       },
       {
         description: "a lastSeenAt above the JS Date range",
-        payload: { retries: 2, lastSeenAt: Number.MAX_SAFE_INTEGER },
-        expected: withSession({ retries: 2, lastSeenAt: null }),
+        payload: { retriesModal: 2, lastSeenAt: Number.MAX_SAFE_INTEGER },
+        expected: withSession({ retriesModal: 2, lastSeenAt: null }),
       },
       {
         description: "an unsafe integer lastSeenAt",
-        payload: { retries: 2, lastSeenAt: Number.MAX_SAFE_INTEGER + 1 },
-        expected: withSession({ retries: 2, lastSeenAt: null }),
+        payload: { retriesModal: 2, lastSeenAt: Number.MAX_SAFE_INTEGER + 1 },
+        expected: withSession({ retriesModal: 2, lastSeenAt: null }),
       },
       {
         description: "an entirely malformed payload",
-        payload: { retries: NaN, lastSeenAt: NaN },
+        payload: { retriesModal: NaN, lastSeenAt: NaN },
         expected: initialState,
       },
     ])("falls back to defaults given $description", ({ payload, expected }) => {
@@ -102,12 +103,12 @@ describe("largeScreenUpsellModal", () => {
         reducer(
           undefined,
           restoreLargeScreenUpsellModalState({
-            retries: 2,
+            retriesModal: 2,
             lastSeenAt,
             session: "dismissed",
           }),
         ),
-      ).toEqual(withSession({ retries: 2, lastSeenAt }));
+      ).toEqual(withSession({ retriesModal: 2, lastSeenAt }));
     });
   });
 
@@ -120,11 +121,11 @@ describe("largeScreenUpsellModal", () => {
       recordUpsellModalDisplay(firstDisplayTimestamp),
     );
     expect(firstDisplayState).toEqual(
-      withSession({ retries: 1, lastSeenAt: firstDisplayTimestamp }),
+      withSession({ retriesModal: 1, lastSeenAt: firstDisplayTimestamp }),
     );
 
     expect(reducer(firstDisplayState, recordUpsellModalDisplay(secondDisplayTimestamp))).toEqual(
-      withSession({ retries: 2, lastSeenAt: secondDisplayTimestamp }),
+      withSession({ retriesModal: 2, lastSeenAt: secondDisplayTimestamp }),
     );
   });
 
@@ -132,40 +133,60 @@ describe("largeScreenUpsellModal", () => {
     jest.useFakeTimers().setSystemTime(new Date("2026-07-01T12:00:00.000Z"));
 
     expect(reducer(initialState, recordUpsellModalDisplay())).toEqual(
-      withSession({ retries: 1, lastSeenAt }),
+      withSession({ retriesModal: 1, lastSeenAt }),
     );
   });
 
   it("marks session as dismissed", () => {
     expect(reducer(initialState, markDismissed())).toEqual(
-      withSession({ retries: 0, lastSeenAt: null }, "dismissed"),
+      withSession({ retriesModal: 0, lastSeenAt: null }, "dismissed"),
     );
   });
 
   it("marks session as blockedByCompeting only while ready", () => {
     expect(reducer(initialState, markBlockedByCompeting())).toEqual(
-      withSession({ retries: 0, lastSeenAt: null }, "blockedByCompeting"),
+      withSession({ retriesModal: 0, lastSeenAt: null }, "blockedByCompeting"),
     );
 
     expect(
-      reducer(withSession({ retries: 0, lastSeenAt: null }, "dismissed"), markBlockedByCompeting()),
-    ).toEqual(withSession({ retries: 0, lastSeenAt: null }, "dismissed"));
+      reducer(
+        withSession({ retriesModal: 0, lastSeenAt: null }, "dismissed"),
+        markBlockedByCompeting(),
+      ),
+    ).toEqual(withSession({ retriesModal: 0, lastSeenAt: null }, "dismissed"));
+  });
+
+  it("rolls back a preempted display to the previous lastSeenAt", () => {
+    const afterDisplay = reducer(initialState, recordUpsellModalDisplay(lastSeenAt));
+
+    expect(reducer(afterDisplay, rollbackUpsellModalDisplay({ previousLastSeenAt: null }))).toEqual(
+      withSession({ retriesModal: 0, lastSeenAt: null }),
+    );
+
+    const afterSecondDisplay = reducer(
+      withSession({ retriesModal: 1, lastSeenAt: 1_000 }),
+      recordUpsellModalDisplay(lastSeenAt),
+    );
+
+    expect(
+      reducer(afterSecondDisplay, rollbackUpsellModalDisplay({ previousLastSeenAt: 1_000 })),
+    ).toEqual(withSession({ retriesModal: 1, lastSeenAt: 1_000 }));
   });
 
   it("resets retries without clearing the last display timestamp or session", () => {
     expect(
-      reducer(withSession({ retries: 3, lastSeenAt }, "dismissed"), resetUpsellModalRetries()),
-    ).toEqual(withSession({ retries: 0, lastSeenAt }, "dismissed"));
+      reducer(withSession({ retriesModal: 3, lastSeenAt }, "dismissed"), resetUpsellModalRetries()),
+    ).toEqual(withSession({ retriesModal: 0, lastSeenAt }, "dismissed"));
   });
 
   it("sets the retry count to an arbitrary non-negative integer", () => {
-    expect(reducer(withSession({ retries: 0, lastSeenAt }), setUpsellModalRetries(5))).toEqual(
-      withSession({ retries: 5, lastSeenAt }),
+    expect(reducer(withSession({ retriesModal: 0, lastSeenAt }), setUpsellModalRetries(5))).toEqual(
+      withSession({ retriesModal: 5, lastSeenAt }),
     );
   });
 
   it("ignores invalid retry counts", () => {
-    const state = withSession({ retries: 3, lastSeenAt: null });
+    const state = withSession({ retriesModal: 3, lastSeenAt: null });
 
     for (const invalid of [-1, 2.7, NaN]) {
       expect(reducer(state, setUpsellModalRetries(invalid))).toEqual(state);
@@ -174,16 +195,19 @@ describe("largeScreenUpsellModal", () => {
 
   it("sets the last display timestamp to an arbitrary value or null", () => {
     expect(
-      reducer(withSession({ retries: 1, lastSeenAt: null }), setLastSeenUpsellModal(lastSeenAt)),
-    ).toEqual(withSession({ retries: 1, lastSeenAt }));
+      reducer(
+        withSession({ retriesModal: 1, lastSeenAt: null }),
+        setLastSeenUpsellModal(lastSeenAt),
+      ),
+    ).toEqual(withSession({ retriesModal: 1, lastSeenAt }));
 
-    expect(reducer(withSession({ retries: 1, lastSeenAt }), setLastSeenUpsellModal(null))).toEqual(
-      withSession({ retries: 1, lastSeenAt: null }),
-    );
+    expect(
+      reducer(withSession({ retriesModal: 1, lastSeenAt }), setLastSeenUpsellModal(null)),
+    ).toEqual(withSession({ retriesModal: 1, lastSeenAt: null }));
   });
 
   it("ignores invalid last display timestamps", () => {
-    const state = withSession({ retries: 1, lastSeenAt });
+    const state = withSession({ retriesModal: 1, lastSeenAt });
 
     for (const invalid of [-1, 2.7, NaN, Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER + 1]) {
       expect(reducer(state, setLastSeenUpsellModal(invalid))).toEqual(state);
@@ -209,14 +233,14 @@ describe("largeScreenUpsellModal", () => {
 
   it("selects raw values from root state", () => {
     const state = {
-      largeScreenUpsellModal: withSession({ retries: 3, lastSeenAt }, "dismissed"),
+      largeScreenUpsellModal: withSession({ retriesModal: 3, lastSeenAt }, "dismissed"),
     };
 
     expect(retriesUpsellModalSelector(state)).toBe(3);
     expect(lastSeenUpsellModalSelector(state)).toBe(lastSeenAt);
     expect(sessionSelector(state)).toBe("dismissed");
     expect(persistedLargeScreenUpsellModalSelector(state)).toEqual({
-      retries: 3,
+      retriesModal: 3,
       lastSeenAt,
     });
   });

--- a/features/flow/large-screen-upsell/src/state/slice.ts
+++ b/features/flow/large-screen-upsell/src/state/slice.ts
@@ -46,7 +46,14 @@ export const largeScreenUpsellModalSlice = createSlice({
       if (state.retriesModal > 0) {
         state.retriesModal -= 1;
       }
-      state.lastSeenAt = action.payload.previousLastSeenAt;
+      const { previousLastSeenAt } = action.payload;
+      if (previousLastSeenAt === null) {
+        state.lastSeenAt = null;
+        return;
+      }
+      if (isStorableTimestamp(previousLastSeenAt)) {
+        state.lastSeenAt = previousLastSeenAt;
+      }
     },
     markDismissed: state => {
       state.session = "dismissed";

--- a/features/flow/large-screen-upsell/src/state/slice.ts
+++ b/features/flow/large-screen-upsell/src/state/slice.ts
@@ -23,17 +23,30 @@ export const largeScreenUpsellModalSlice = createSlice({
     ) => {
       const restored = RestorableLargeScreenUpsellModalStateSchema.parse(action.payload);
 
-      state.retries = restored.retries;
+      state.retriesModal = restored.retriesModal;
       state.lastSeenAt = restored.lastSeenAt;
     },
     recordUpsellModalDisplay: {
       reducer: (state, action: PayloadAction<number>) => {
-        state.retries += 1;
+        state.retriesModal += 1;
         state.lastSeenAt = action.payload;
       },
       prepare: (timestamp: number = Date.now()) => ({
         payload: timestamp,
       }),
+    },
+    /**
+     * Undo a display that was recorded but preempted by a competing app-start modal
+     * before the user could interact with the upsell.
+     */
+    rollbackUpsellModalDisplay: (
+      state,
+      action: PayloadAction<{ previousLastSeenAt: number | null }>,
+    ) => {
+      if (state.retriesModal > 0) {
+        state.retriesModal -= 1;
+      }
+      state.lastSeenAt = action.payload.previousLastSeenAt;
     },
     markDismissed: state => {
       state.session = "dismissed";
@@ -44,12 +57,12 @@ export const largeScreenUpsellModalSlice = createSlice({
       }
     },
     resetUpsellModalRetries: state => {
-      state.retries = initialState.retries;
+      state.retriesModal = initialState.retriesModal;
     },
     setUpsellModalRetries: (state, action: PayloadAction<number>) => {
       const retries = action.payload;
       if (Number.isSafeInteger(retries) && retries >= 0) {
-        state.retries = retries;
+        state.retriesModal = retries;
       }
     },
     setLastSeenUpsellModal: (state, action: PayloadAction<number | null>) => {
@@ -66,10 +79,10 @@ export const largeScreenUpsellModalSlice = createSlice({
   selectors: {
     largeScreenUpsellModalSelector: state => state,
     persistedLargeScreenUpsellModalSelector: (state): RestorableLargeScreenUpsellModalState => ({
-      retries: state.retries,
+      retriesModal: state.retriesModal,
       lastSeenAt: state.lastSeenAt,
     }),
-    retriesUpsellModalSelector: state => state.retries,
+    retriesUpsellModalSelector: state => state.retriesModal,
     lastSeenUpsellModalSelector: state => state.lastSeenAt,
     sessionSelector: state => state.session,
   },
@@ -78,6 +91,7 @@ export const largeScreenUpsellModalSlice = createSlice({
 export const {
   restoreLargeScreenUpsellModalState,
   recordUpsellModalDisplay,
+  rollbackUpsellModalDisplay,
   markDismissed,
   markBlockedByCompeting,
   resetUpsellModalRetries,


### PR DESCRIPTION
## Summary

Desktop-only fix for [LIVE-35893](https://ledgerhq.atlassian.net/browse/LIVE-35893).

When a competing app-start modal (Wallet V4 tour, Q2 tour, or Generic Awareness) blocks or preempts the Large Screen Upsell on **LWD**:

- Do **not** consume frequency: roll back any preempted impression via `rollbackUpsellModalDisplay`
- Keep the session `blockedByCompeting` for the rest of the session (upsell does not reopen after the competitor closes)
- Track `modal_blocked` with the competing surface (`wallet_v4_tour` | `q2_tour` | `generic_awareness`)

Rename the persisted counter `retries` → `retriesModal` in `@features/flow-large-screen-upsell` so legacy false impressions reset to `0` on **LWD upgrade**.

## Commits

1. `fix(large-screen-upsell): skip retries when blocked by competing modals` — rollback, session block, `retriesModal` rename (LWD only)
2. `feat(large-screen-upsell): track modal blocked by competitor` — `modal_blocked` analytics

## Test plan

- [ ] Competing tour/GA at LWD start: upsell does not show, `retriesModal` stays `0`, session is `blockedByCompeting`, and it does not reopen after the competitor closes
- [ ] Upsell visible then GA opens: upsell closes, `retriesModal` rolls back, session becomes `blockedByCompeting`
- [ ] After LWD upgrade from a build that had `retries: 3`, storage restores as `retriesModal: 0`
- [ ] `modal_blocked` fires once per block episode with the correct `competitor`
- [ ] Unit: `@features/flow-large-screen-upsell` slice/schema tests; desktop analytics tests
- [ ] Integration: desktop `LargeScreenUpsellModal` competing-modal cases

[LIVE-35893]: https://ledgerhq.atlassian.net/browse/LIVE-35893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ