### PR TITLE
fix(e2e/mobile): retry buy/sell deeplink on "App not found" race

### DIFF
--- a/e2e/mobile/page/trade/buySell.page.ts
+++ b/e2e/mobile/page/trade/buySell.page.ts
@@ -35,8 +35,21 @@ export default class BuySellPage {
 
   @Step("Open page via deeplink")
   async openViaDeeplink(page: "Buy" | "Sell") {
-    await openDeeplink(page.toLowerCase());
-    await waitForElementById(app.common.walletApiWebview, 60000, { checkVisibility: false });
+    const maxAttempts = 3;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      await openDeeplink(page.toLowerCase());
+      try {
+        // Can show "generic-error-modal" ("App not found") right after boot if
+        // the live-app catalog isn't ready yet - fail fast and retry instead.
+        await waitForElementById(app.common.walletApiWebview, 5000, {
+          checkVisibility: false,
+          errorElementId: "generic-error-modal",
+        });
+        return;
+      } catch (error) {
+        if (attempt === maxAttempts) throw error;
+      }
+    }
   }
 
   @Step("Expect Buy screen to be visible")


### PR DESCRIPTION
## Summary
- Android mobile e2e Buy/Sell tests intermittently fail right after the `ledgerlive://buy` / `ledgerlive://sell` deeplink fires, hitting a false "App not found" (`generic-error-modal`) screen instead of the expected webview.
- Root cause: `RemoteLiveAppProvider`'s `isLoading` starts as `false` and only flips to `true` inside a `useEffect`, so there's a window right after boot where the live-app catalog hasn't been fetched yet but the app can't tell "not loaded yet" apart from "genuinely not found". Fixing that properly is an app-side change and out of scope for this test-only PR.
- This PR works around it entirely on the e2e side: `openViaDeeplink` now fails fast on the pre-existing `generic-error-modal` testID (via `waitForElementById`'s `errorElementId` option) and retries the deeplink up to 3 times instead of waiting out a long fixed timeout.

## Test plan
- [x] `npx tsc --noEmit` in `e2e/mobile` — no new errors
- [ ] Run mobile Android e2e Buy/Sell suite in CI to confirm the flake is gone