### PR TITLE
refactor(analytics): replace the useTrack hook

### DIFF
--- a/.changeset/lucky-hooks-retire.md
+++ b/.changeset/lucky-hooks-retire.md
@@ -1,0 +1,8 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Replace the useTrack hook with the module-level track function
+
+Internal refactor ahead of the analytics package migration. Every event keeps the properties it emits today: desktop reads the `drawer` name from the drawer context (or passes the custom-lock-screen constant directly) at each call site, and mobile's swap entry point rebuilds its router-derived `page` with `usePageNameFromRoute`.

--- a/apps/ledger-live-desktop/src/renderer/analytics/__mocks__/segment.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/__mocks__/segment.ts
@@ -1,5 +1,3 @@
 import { fn, Mock } from "@storybook/test";
 
 export const track: Mock = fn(() => {});
-
-export const useTrack: Mock = fn(() => {});

--- a/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
@@ -13,7 +13,6 @@ import type { AccountLike } from "@ledgerhq/types-live";
 import { idsToLanguage } from "@ledgerhq/types-live";
 import type { Feature, FeatureId, Features } from "@shared/feature-flags";
 import invariant from "invariant";
-import { useCallback, useContext } from "react";
 import type * as Redux from "redux";
 import { ReplaySubject } from "rxjs";
 import { v4 as uuid } from "uuid";
@@ -39,7 +38,6 @@ import {
   sidebarCollapsedSelector,
   trackingEnabledSelector,
 } from "~/renderer/reducers/settings";
-import { analyticsDrawerContext } from "../drawers/Provider";
 import { accountsSelector } from "../reducers/accounts";
 import { currentRouteNameRef, previousRouteNameRef } from "./screenRefs";
 import {
@@ -558,33 +556,6 @@ export const track = (
     date: new Date(),
   });
 };
-
-/**
- * Returns an enriched track function that uses the context to add contextual
- * props to events.
- *
- * For now it's only adding the "drawer" property if it's defined.
- * */
-export function useTrack() {
-  const { analyticsDrawerName } = useContext(analyticsDrawerContext);
-  return useCallback(
-    (
-      eventName: string,
-      properties?: Record<string, unknown> | null,
-      mandatory?: boolean | null,
-    ) => {
-      track(
-        eventName,
-        {
-          ...(analyticsDrawerName ? { drawer: analyticsDrawerName } : {}),
-          ...(properties ?? {}),
-        },
-        mandatory,
-      );
-    },
-    [analyticsDrawerName],
-  );
-}
 
 /**
  * Track an event which will have the name `Page ${category}${name ? " " + name : ""}`.

--- a/apps/ledger-live-desktop/src/renderer/components/ButtonV3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ButtonV3.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useContext } from "react";
 import { Button as BaseButton, InvertTheme } from "@ledgerhq/react-ui";
 import { ButtonProps as BaseButtonProps } from "@ledgerhq/react-ui/components/cta/Button/index";
-import { useTrack } from "~/renderer/analytics/segment";
+import { track } from "~/renderer/analytics/segment";
+import { analyticsDrawerContext } from "~/renderer/drawers/Provider";
 import styled from "styled-components";
 
 export const Base = styled(BaseButton)<{ big?: boolean }>`
@@ -34,12 +35,15 @@ function Button({
   buttonTestId,
   ...rest
 }: Props) {
-  const track = useTrack();
+  const { analyticsDrawerName } = useContext(analyticsDrawerContext);
   const isClickDisabled = disabled || isLoading;
   const onClickHandler = (e: React.SyntheticEvent<HTMLButtonElement, Event>) => {
     if (onClick) {
       if (event) {
-        track(event, eventProperties || {});
+        track(event, {
+          ...(analyticsDrawerName ? { drawer: analyticsDrawerName } : {}),
+          ...(eventProperties || {}),
+        });
       }
       onClick(e);
     }

--- a/apps/ledger-live-desktop/src/renderer/components/CustomImage/ImageCropper.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/CustomImage/ImageCropper.tsx
@@ -1,11 +1,12 @@
-import React, { SyntheticEvent, useCallback, useEffect, useRef, useState } from "react";
+import React, { SyntheticEvent, useCallback, useContext, useEffect, useRef, useState } from "react";
 import { ImageBase64Data, ImageDimensions } from "./types";
 import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
 import { Button, Flex, IconsLegacy } from "@ledgerhq/react-ui";
 import Cropper, { Area, CropperProps } from "react-easy-crop";
 import { createCanvas, getRadianAngle, rotateSize } from "./imageUtils";
 import { ImageCropError } from "@ledgerhq/live-common/customImage/errors";
-import { useTrack } from "~/renderer/analytics/segment";
+import { track } from "~/renderer/analytics/segment";
+import { analyticsDrawerContext } from "~/renderer/drawers/Provider";
 import { useTranslation } from "react-i18next";
 
 export type CropResult = ImageDimensions & ImageBase64Data;
@@ -141,7 +142,7 @@ const ImageCropper: React.FC<Props> = props => {
     children,
   } = props;
 
-  const track = useTrack();
+  const { analyticsDrawerName } = useContext(analyticsDrawerContext);
 
   const [crop, setCrop] = useState<CropState>({ x: 0, y: 0 });
   const [completeCropPixel, setCompleteCropPixel] = useState<Crop>();
@@ -189,11 +190,14 @@ const ImageCropper: React.FC<Props> = props => {
   }, [debouncedCompleteCropPixel, targetDimensions, onResult, setLoading]);
 
   const rotateCounterClockwise: () => void = useCallback(() => {
-    track("button_clicked2", { button: "Rotate" });
+    track("button_clicked2", {
+      ...(analyticsDrawerName ? { drawer: analyticsDrawerName } : {}),
+      button: "Rotate",
+    });
     setLoading(true);
     /** the increments are of 90° so 360°/4 */
     setRotationIncrements((rotationIncrements - 1) % 4);
-  }, [track, setLoading, rotationIncrements]);
+  }, [analyticsDrawerName, setLoading, rotationIncrements]);
 
   const handleCropChange = useCallback(
     (crop: CropState) => {

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/HardwareUpdate.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/HardwareUpdate.test.tsx
@@ -7,7 +7,6 @@ import { openURL } from "~/renderer/linking";
 jest.mock("~/renderer/analytics/segment", () => ({
   track: jest.fn(),
   trackPage: jest.fn(),
-  useTrack: () => jest.fn(),
 }));
 
 jest.mock("~/renderer/linking", () => ({

--- a/apps/ledger-live-desktop/src/renderer/drawers/Drawer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/Drawer.tsx
@@ -1,9 +1,9 @@
 import React, { useContext, useCallback, useEffect, useState, useRef, Suspense } from "react";
-import { context, State } from "./Provider";
+import { analyticsDrawerContext, context, State } from "./Provider";
 import { SideDrawer } from "~/renderer/components/SideDrawer";
 import styled from "styled-components";
 import { Transition, TransitionGroup, TransitionStatus } from "react-transition-group";
-import { useTrack } from "../analytics/segment";
+import { track } from "../analytics/segment";
 const transitionStyles = {
   entering: {},
   entered: {
@@ -70,14 +70,17 @@ const Drawer = () => {
       if (t) clearTimeout(t);
     };
   }, [queue]);
-  const track = useTrack();
+  const { analyticsDrawerName } = useContext(analyticsDrawerContext);
   const onRequestClose = useCallback(() => {
-    track("button_clicked2", { button: "Close" });
+    track("button_clicked2", {
+      ...(analyticsDrawerName ? { drawer: analyticsDrawerName } : {}),
+      button: "Close",
+    });
     if (state?.props?.onRequestClose) {
       onRequestClose();
     }
     setDrawer();
-  }, [setDrawer, state?.props?.onRequestClose, track]);
+  }, [analyticsDrawerName, setDrawer, state?.props?.onRequestClose]);
 
   const refsMapRef = useRef<Map<string, React.RefObject<HTMLDivElement | null>>>(new Map());
 

--- a/apps/ledger-live-desktop/src/renderer/screens/customImage/Step1ChooseImage.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/customImage/Step1ChooseImage.tsx
@@ -6,8 +6,8 @@ import { StepProps } from "./types";
 import StepContainer from "./StepContainer";
 import { Flex, IconsLegacy, InfiniteLoader, Link, Text } from "@ledgerhq/react-ui";
 import TrackPage from "~/renderer/analytics/TrackPage";
-import { analyticsPageNames, analyticsFlowName } from "./shared";
-import { useTrack } from "~/renderer/analytics/segment";
+import { analyticsPageNames, analyticsFlowName, analyticsDrawerName } from "./shared";
+import { track } from "~/renderer/analytics/segment";
 import STAX_CLS_PREVIEW from "~/renderer/animations/customLockScreen/stax.json";
 import FLEX_CLS_PREVIEW from "~/renderer/animations/customLockScreen/flex.json";
 import APEX_CLS_PREVIEW from "~/renderer/animations/customLockScreen/apex.json";
@@ -35,7 +35,6 @@ const StepChooseImage: React.FC<Props> = props => {
     onClickRemoveCustomImage,
   } = props;
   const { t } = useTranslation();
-  const track = useTrack();
 
   const animationSource = useMemo(() => {
     switch (deviceModelId) {
@@ -89,6 +88,7 @@ const StepChooseImage: React.FC<Props> = props => {
             onError={onError}
             onClick={() =>
               track("button_clicked2", {
+                drawer: analyticsDrawerName,
                 button: "Choose from my picture gallery",
               })
             }

--- a/apps/ledger-live-desktop/src/renderer/screens/customImage/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/customImage/index.tsx
@@ -33,7 +33,7 @@ import { analyticsDrawerContext, setDrawer } from "~/renderer/drawers/Provider";
 import { useNavigateToPostOnboardingHubCallback } from "~/renderer/components/PostOnboardingHub/logic/useNavigateToPostOnboardingHubCallback";
 import { analyticsPageNames, analyticsFlowName, analyticsDrawerName } from "./shared";
 import TrackPage, { setTrackingSource } from "~/renderer/analytics/TrackPage";
-import { useTrack } from "~/renderer/analytics/segment";
+import { track } from "~/renderer/analytics/segment";
 import DeviceModelPicker from "~/renderer/components/CustomImage/DeviceModelPicker";
 import { useCompleteActionCallback } from "~/renderer/components/PostOnboardingHub/logic/useCompleteAction";
 import RemoveCustomImage from "../manager/DeviceDashboard/DeviceInformationSummary/RemoveCustomImage";
@@ -67,7 +67,6 @@ const CustomImage: React.FC<Props> = props => {
     setHasCustomLockScreen,
   } = props;
   const { t } = useTranslation();
-  const track = useTrack();
   const { setAnalyticsDrawerName } = useContext(analyticsDrawerContext);
 
   const isDeviceModelIdUndefined =
@@ -185,9 +184,13 @@ const CustomImage: React.FC<Props> = props => {
   const error = stepError[step];
 
   const handleErrorRetryClicked = useCallback(() => {
-    if (error?.name) track("button_clicked2", { button: "Retry" });
+    if (error?.name)
+      track("button_clicked2", {
+        drawer: analyticsDrawerName,
+        button: "Retry",
+      });
     setStepWrapper(Step.chooseImage);
-  }, [error?.name, setStepWrapper, track]);
+  }, [error?.name, setStepWrapper]);
 
   const previousStep: Step | undefined = orderedSteps[orderedSteps.findIndex(s => s === step) - 1];
 

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FeesDrawerLiveApp/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FeesDrawerLiveApp/index.tsx
@@ -7,7 +7,7 @@ import { Account, AccountLike, FeeStrategy } from "@ledgerhq/types-live";
 import { t } from "i18next";
 import isEqual from "lodash/isEqual";
 import React, { useCallback, useRef, useState } from "react";
-import { useTrack } from "~/renderer/analytics/segment";
+import { track } from "~/renderer/analytics/segment";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Alert from "~/renderer/components/Alert";
 import Box from "~/renderer/components/Box";
@@ -39,7 +39,6 @@ export default function FeesDrawerLiveApp({
   disableSlowStrategy = false,
 }: Props) {
   const swapDefaultTrack = useGetSwapTrackingProperties();
-  const track = useTrack();
 
   const [isOpen, setIsOpen] = useState(true);
   const [transaction, setTransactionState] = useState(initialTransaction);
@@ -115,7 +114,7 @@ export default function FeesDrawerLiveApp({
           isPreparingRef.current = false;
         });
     },
-    [bridge, mainAccount, swapDefaultTrack, track, transaction],
+    [bridge, mainAccount, swapDefaultTrack, transaction],
   );
 
   const mapStrategies = useCallback(

--- a/apps/ledger-live-desktop/src/renderer/screens/platform/LiveApp.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/platform/LiveApp.tsx
@@ -6,7 +6,7 @@ import WebPlatformPlayer from "~/renderer/components/WebPlatformPlayer";
 import { languageSelector } from "~/renderer/reducers/settings";
 import { useSelector } from "LLD/hooks/redux";
 import { useLiveAppManifest } from "@ledgerhq/live-common/wallet-api/useLiveAppManifest";
-import { useTrack } from "~/renderer/analytics/segment";
+import { track } from "~/renderer/analytics/segment";
 import { useGetSwapTrackingProperties } from "../exchange/Swap2/utils";
 
 export type LiveAppProps = {
@@ -17,7 +17,6 @@ export function LiveApp({ appId: propsAppId }: LiveAppProps) {
   const navigate = useNavigate();
   const location = useLocation();
   const routeParams = useParams<{ appId: string }>();
-  const track = useTrack();
   const swapTrackingProperties = useGetSwapTrackingProperties();
   const { search } = location;
   const internalParams =
@@ -58,7 +57,7 @@ export function LiveApp({ appId: propsAppId }: LiveAppProps) {
     }
 
     navigate(returnTo || `/platform`);
-  }, [navigate, returnTo, appId, swapTrackingProperties, track]);
+  }, [navigate, returnTo, appId, swapTrackingProperties]);
   const themeType = useTheme().theme;
   const lang = useSelector(languageSelector);
   const params = {

--- a/apps/ledger-live-desktop/tests/jestSetup.js
+++ b/apps/ledger-live-desktop/tests/jestSetup.js
@@ -130,7 +130,6 @@ jest.mock("src/renderer/analytics/segment", () => ({
   start: jest.fn(),
   track: jest.fn(),
   trackPage: jest.fn(),
-  useTrack: jest.fn(),
   updateIdentify: jest.fn().mockResolvedValue(undefined),
 }));
 

--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -14,7 +14,7 @@ import {
   useRoute,
 } from "@react-navigation/native";
 import snakeCase from "lodash/snakeCase";
-import React, { type RefObject, useCallback } from "react";
+import React, { type RefObject } from "react";
 import { idsToLanguage } from "@ledgerhq/types-live";
 import type { FeatureId, Features } from "@shared/feature-flags";
 
@@ -754,15 +754,6 @@ export const flush = async () => {
   await segmentClient.flush();
 };
 
-export const useTrack = () => {
-  const route = useRoute();
-  const track = useCallback(
-    (event: EventType, properties?: Record<string, unknown> | null, mandatory?: boolean | null) =>
-      trackWithRoute(event, route, properties, mandatory),
-    [route],
-  );
-  return track;
-};
 export const usePageNameFromRoute = () => {
   const route = useRoute();
   return getPageNameFromRoute(route);

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -28,7 +28,7 @@ import { TokenCurrency } from "@domain/entity-currency-token";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import type { DeviceModelInfo } from "@ledgerhq/types-live";
 
-import { TrackScreen, track, useTrack } from "~/analytics";
+import { TrackScreen, track } from "~/analytics";
 import { NavigatorName, ScreenName } from "~/const";
 import { MANAGER_TABS } from "~/const/manager";
 import { getDeviceAnimation, getDeviceAnimationStyles } from "~/helpers/getDeviceAnimation";
@@ -790,7 +790,6 @@ export function RequiredFirmwareUpdate({
   device: Device;
 }) {
   const { t } = useTranslation();
-  const track = useTrack();
   const lastSeenDevice: DeviceModelInfo | null | undefined = useSelector(lastSeenDeviceSelector);
   const { shouldDisplayMyWallet } = useWalletFeaturesConfig("mobile");
 

--- a/apps/ledger-live-mobile/src/components/DeviceAction/requiredFirmwareUpdate.test.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/requiredFirmwareUpdate.test.tsx
@@ -7,7 +7,6 @@ import type { State } from "~/reducers/types";
 
 jest.mock("~/analytics", () => ({
   TrackScreen: () => null,
-  useTrack: () => jest.fn(),
   track: jest.fn(),
 }));
 

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SwapNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SwapNavigator.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "~/context/Locale";
 import SwapHistory from "~/screens/Swap/History";
 
 import { useTheme } from "styled-components/native";
-import { useTrack } from "~/analytics";
+import { track, usePageNameFromRoute } from "~/analytics";
 import { NavigatorName, ScreenName } from "~/const";
 import { useNoNanoBuyNanoWallScreenOptions } from "~/context/NoNanoBuyNanoWall";
 import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
@@ -53,20 +53,21 @@ export default function SwapNavigator(
   const { colors } = useTheme();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   const noNanoBuyNanoWallScreenOptions = useNoNanoBuyNanoWallScreenOptions();
-  const track = useTrack();
+  const page = usePageNameFromRoute();
   const navigation = useNavigation<StackNavigatorNavigation<SwapNavigatorParamList>>();
   const { notifyFlowCompleted } = useNotificationsContext();
 
   const trackButtonClick = useCallback(
     (source: string) => {
       track("button_clicked", {
+        page,
         button: "swap",
         source,
         flow: "swap",
         swapVersion: SWAP_VERSION,
       });
     },
-    [track],
+    [page],
   );
 
   useEffect(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptDAppCompleteFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptDAppCompleteFlow.test.tsx
@@ -22,7 +22,6 @@ jest.mock("~/analytics", () => {
 
   return {
     track,
-    useTrack: () => track,
     TrackScreen: () => null,
     updateIdentify: jest.fn(),
   };

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptSwapFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptSwapFlow.test.tsx
@@ -28,7 +28,6 @@ jest.mock("~/analytics", () => {
 
   return {
     track,
-    useTrack: () => track,
     TrackScreen: () => null,
     updateIdentify: jest.fn(),
   };

--- a/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/__integrations__/SeedCompanionStep.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/__integrations__/SeedCompanionStep.integration.test.tsx
@@ -3,14 +3,14 @@ import { Linking } from "react-native";
 import { CharonStatus } from "@ledgerhq/live-common/hw/extractOnboardingState";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { render, screen } from "@tests/test-renderer";
+import { track } from "~/analytics";
 import SeedCompanionStep from "../components/SeedCompanionStep";
 
-const mockTrack = jest.fn();
 jest.mock("~/analytics", () => {
   const actual = jest.requireActual("~/analytics");
   return {
     ...actual,
-    useTrack: () => mockTrack,
+    track: jest.fn(),
   };
 });
 
@@ -79,7 +79,7 @@ describe("SeedCompanionStep", () => {
     const learnMore = await screen.findByText("Learn more or buy");
     await user.press(learnMore);
 
-    expect(mockTrack).toHaveBeenCalledWith("button_clicked", {
+    expect(track).toHaveBeenCalledWith("button_clicked", {
       button: "Learn More",
       page: "Charon Start",
       flow: "onboarding",

--- a/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/__integrations__/TwoStepSyncOnboardingCompanion.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/__integrations__/TwoStepSyncOnboardingCompanion.integration.test.tsx
@@ -30,7 +30,7 @@ jest.mock("~/analytics", () => {
   const actual = jest.requireActual("~/analytics");
   return {
     ...actual,
-    useTrack: () => jest.fn(),
+    track: jest.fn(),
   };
 });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/components/SeedCompanionStep/useSeedCompanionStepViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/components/SeedCompanionStep/useSeedCompanionStepViewModel.test.ts
@@ -1,10 +1,10 @@
 import { Linking } from "react-native";
 import { act, renderHook } from "@tests/test-renderer";
+import { track } from "~/analytics";
 import { useSeedCompanionStepViewModel } from "./useSeedCompanionStepViewModel";
 
-const mockTrack = jest.fn();
 jest.mock("~/analytics", () => ({
-  useTrack: () => mockTrack,
+  track: jest.fn(),
 }));
 
 describe("useSeedCompanionStepViewModel", () => {
@@ -20,8 +20,8 @@ describe("useSeedCompanionStepViewModel", () => {
       result.current.handleLearnMoreClick();
     });
 
-    expect(mockTrack).toHaveBeenCalledTimes(1);
-    expect(mockTrack).toHaveBeenCalledWith("button_clicked", {
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(track).toHaveBeenCalledWith("button_clicked", {
       button: "Learn More",
       page: "Charon Start",
       flow: "onboarding",

--- a/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/components/SeedCompanionStep/useSeedCompanionStepViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/components/SeedCompanionStep/useSeedCompanionStepViewModel.ts
@@ -1,12 +1,10 @@
 import { useCallback } from "react";
 import { Linking } from "react-native";
-import { useTrack } from "~/analytics";
+import { track } from "~/analytics";
 
 const CHARON_LEARN_MORE_URL = "https://shop.ledger.com/products/ledger-recovery-key";
 
 export const useSeedCompanionStepViewModel = () => {
-  const track = useTrack();
-
   const handleLearnMoreClick = useCallback(() => {
     track("button_clicked", {
       button: "Learn More",
@@ -14,7 +12,7 @@ export const useSeedCompanionStepViewModel = () => {
       flow: "onboarding",
     });
     Linking.openURL(CHARON_LEARN_MORE_URL);
-  }, [track]);
+  }, []);
 
   return { handleLearnMoreClick };
 };


### PR DESCRIPTION
### 📝 Description

Replace the `useTrack` hook with the module-level track function

Internal refactor ahead of the analytics package migration. Every event keeps the properties it emits today: desktop reads the `drawer` name from the drawer context (or passes the custom-lock-screen constant directly) at each call site, and mobile's swap entry point rebuilds its router-derived `page` with `usePageNameFromRoute`.

### 🔗 Context

- **JIRA**: [LIVE-35841](https://ledgerhq.atlassian.net/browse/LIVE-35841)


[LIVE-35841]: https://ledgerhq.atlassian.net/browse/LIVE-35841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ