### PR TITLE
[LWDM] fix(lwd): new send flow keep recipient after skip memo

### DIFF
--- a/.changeset/sixty-crews-accept.md
+++ b/.changeset/sixty-crews-accept.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+---
+
+fix(lwd): new send flow keeping the previous recipient after skip memo and edit

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendHeader.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendHeader.tsx
@@ -4,54 +4,37 @@ import { AddressInput, DialogHeader } from "@ledgerhq/lumen-ui-react";
 import { useFlowWizard } from "../../FlowWizard/FlowWizardContext";
 import { useSendFlowData, useSendFlowActions } from "../context/SendFlowContext";
 import { useSendAmountDisplayMode } from "@ledgerhq/live-common/flows/send/amount/SendAmountDisplayModeContext";
-import { track } from "~/renderer/analytics/segment";
-import { getSendFlowTrackingProperties } from "../utils/tracking";
-import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import {
   SEND_FLOW_STEP,
   type SendFlowBusinessContext,
   type SendFlowStep,
 } from "@ledgerhq/live-common/flows/send/types";
-import { getMemoFamilyCurrencyId } from "@ledgerhq/live-common/flows/send/utils/memoFamilyCurrencyId";
 import { useAvailableBalance } from "../hooks/useAvailableBalance";
+import { useSendHeaderMemo } from "../hooks/useSendHeaderMemo";
 import { useSendHeaderModel } from "../hooks/useSendHeaderModel";
 import { AddressDisclaimer } from "./AddressDisclaimer";
 import { MemoTypeSelect } from "../screens/Recipient/components/Memo/MemoTypeSelect";
 import { MemoValueInput } from "../screens/Recipient/components/Memo/MemoValueInput";
 import { SkipMemoSection } from "../screens/Recipient/components/Memo/SkipMemoSection";
-import { useRecipientMemo } from "../screens/Recipient/hooks/useRecipientMemo";
 import { RecipientQrScanner } from "../screens/Recipient/components/RecipientQrScanner";
 import type { SendStepConfig } from "../types";
 
 export function SendHeader() {
   const wizard = useFlowWizard<SendFlowStep, SendFlowBusinessContext, SendStepConfig>();
   const { state, uiConfig, recipientSearch } = useSendFlowData();
-  const { close, transaction } = useSendFlowActions();
+  const { close } = useSendFlowActions();
   const { displayMode } = useSendAmountDisplayMode();
   const { t } = useTranslation();
-  const { navigation, currentStep } = wizard;
+  const { currentStep } = wizard;
 
   const headerDisplayMode = currentStep === SEND_FLOW_STEP.COIN_CONTROL ? "crypto" : displayMode;
   const availableText = useAvailableBalance(state.account.account, headerDisplayMode);
 
-  const currencyId = getMemoFamilyCurrencyId(state.account.currency);
-
-  const sendFlowTrackingProperties = useMemo(
-    () => getSendFlowTrackingProperties(state.account.account, state.account.parentAccount),
-    [state.account.account, state.account.parentAccount],
-  );
-
-  const memoDefaultOption = useMemo(() => {
-    return sendFeatures.getMemoDefaultOption(state.account.currency ?? undefined);
-  }, [state.account.currency]);
-
-  const memoTypeOptions = useMemo(() => {
-    return uiConfig.memoOptions ?? [];
-  }, [uiConfig]);
-
   const {
+    currencyId,
     hasMemoTypeOptions,
     memo,
+    memoTypeOptions,
     onMemoTypeChange,
     showMemoValueInput,
     onMemoValueChange,
@@ -61,27 +44,7 @@ export function SendHeader() {
     onSkipMemoCancelConfirm,
     onSkipMemoConfirm,
     resetViewState,
-  } = useRecipientMemo({
-    hasMemo: uiConfig.hasMemo,
-    memoDefaultOption,
-    memoType: uiConfig.memoType,
-    memoTypeOptions,
-    onMemoChange: memo => {
-      const address = state.recipient?.address ?? recipientSearch.value;
-      transaction.setRecipient({ ...state.recipient, address, memo });
-    },
-    onMemoSkip: () => {
-      track("button_clicked", {
-        button: "skip memo",
-        page: "step recipient",
-        ...sendFlowTrackingProperties,
-      });
-      navigation.goToNextStep();
-    },
-    resetKey: `${state.account.account?.id ?? ""}|${currencyId ?? ""}|${
-      recipientSearch.value.length === 0 ? "empty" : "filled"
-    }`,
-  });
+  } = useSendHeaderMemo();
 
   const {
     addressInputValue,

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useSendHeaderMemo.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useSendHeaderMemo.test.ts
@@ -1,0 +1,167 @@
+import { act, renderHook } from "@testing-library/react";
+import type { Memo } from "@ledgerhq/live-common/flows/send/types";
+import { useRecipientMemo } from "../../screens/Recipient/hooks/useRecipientMemo";
+import { useSendHeaderMemo } from "../useSendHeaderMemo";
+
+jest.mock("../../../FlowWizard/FlowWizardContext", () => ({ useFlowWizard: jest.fn() }));
+jest.mock("../../context/SendFlowContext", () => ({
+  useSendFlowData: jest.fn(),
+  useSendFlowActions: jest.fn(),
+}));
+jest.mock("../../screens/Recipient/hooks/useRecipientMemo", () => ({
+  useRecipientMemo: jest.fn(),
+}));
+jest.mock("~/renderer/analytics/segment", () => ({
+  track: jest.fn(),
+}));
+jest.mock("@ledgerhq/live-common/bridge/descriptor/send/features", () => ({
+  sendFeatures: {
+    getMemoDefaultOption: jest.fn(() => undefined),
+  },
+}));
+jest.mock("@ledgerhq/live-common/flows/send/utils/memoFamilyCurrencyId", () => ({
+  getMemoFamilyCurrencyId: jest.fn(() => "ripple"),
+}));
+
+import { useFlowWizard } from "../../../FlowWizard/FlowWizardContext";
+import { useSendFlowData, useSendFlowActions } from "../../context/SendFlowContext";
+import { track } from "~/renderer/analytics/segment";
+
+const mockedUseFlowWizard = jest.mocked(useFlowWizard);
+const mockedUseSendFlowData = jest.mocked(useSendFlowData);
+const mockedUseSendFlowActions = jest.mocked(useSendFlowActions);
+const mockedUseRecipientMemo = jest.mocked(useRecipientMemo);
+
+const setRecipient = jest.fn();
+const goToNextStep = jest.fn();
+
+function mockFlow({
+  searchValue,
+  recipient,
+  isRecipientAddressComplete = true,
+}: {
+  searchValue: string;
+  recipient: { address: string } | null;
+  isRecipientAddressComplete?: boolean;
+}) {
+  mockedUseSendFlowData.mockReturnValue({
+    state: {
+      account: {
+        account: { id: "ripple-account" },
+        parentAccount: null,
+        currency: { id: "ripple" },
+      },
+      recipient,
+    } as never,
+    uiConfig: { hasMemo: true, memoType: "text", memoOptions: [] } as never,
+    recipientSearch: { value: searchValue, setValue: jest.fn(), clear: jest.fn() },
+    isRecipientAddressComplete,
+  });
+  mockedUseSendFlowActions.mockReturnValue({
+    transaction: { setRecipient },
+  } as never);
+  mockedUseFlowWizard.mockReturnValue({
+    navigation: { goToNextStep },
+  } as never);
+}
+
+describe("useSendHeaderMemo", () => {
+  let onMemoChange: ((memo: Memo) => void) | undefined;
+  let onMemoSkip: (() => void) | undefined;
+  let resetKey: string | undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    onMemoChange = undefined;
+    onMemoSkip = undefined;
+    resetKey = undefined;
+    mockedUseRecipientMemo.mockImplementation(props => {
+      onMemoChange = props.onMemoChange;
+      onMemoSkip = props.onMemoSkip;
+      resetKey = props.resetKey;
+      return {
+        hasMemoTypeOptions: false,
+        memo: { value: "", type: undefined },
+        onMemoTypeChange: jest.fn(),
+        showMemoValueInput: true,
+        onMemoValueChange: jest.fn(),
+        showSkipMemo: true,
+        skipMemoState: "propose",
+        hasFilledMemo: false,
+        onSkipMemoRequestConfirm: jest.fn(),
+        onSkipMemoCancelConfirm: jest.fn(),
+        onSkipMemoConfirm: jest.fn(),
+        resetViewState: jest.fn(),
+      };
+    });
+  });
+
+  it("should persist the current search recipient when skipping memo after editing", () => {
+    mockFlow({
+      searchValue: "rNewRecipient",
+      recipient: { address: "rOldRecipient" },
+    });
+
+    renderHook(() => useSendHeaderMemo());
+
+    act(() => {
+      onMemoChange?.({ value: "", type: "NO_MEMO" });
+    });
+
+    expect(setRecipient).toHaveBeenCalledWith({
+      address: "rNewRecipient",
+      ensName: undefined,
+      memo: { value: "", type: "NO_MEMO" },
+    });
+  });
+
+  it("should keep the committed recipient when the search still matches it", () => {
+    mockFlow({
+      searchValue: "rOldRecipient",
+      recipient: { address: "rOldRecipient" },
+    });
+
+    renderHook(() => useSendHeaderMemo());
+
+    act(() => {
+      onMemoChange?.({ value: "123", type: undefined });
+    });
+
+    expect(setRecipient).toHaveBeenCalledWith({
+      address: "rOldRecipient",
+      ensName: undefined,
+      memo: { value: "123", type: undefined },
+    });
+  });
+
+  it("should include the complete search address in the memo reset key", () => {
+    mockFlow({
+      searchValue: "rNewRecipient",
+      recipient: { address: "rOldRecipient" },
+      isRecipientAddressComplete: true,
+    });
+
+    renderHook(() => useSendHeaderMemo());
+
+    expect(resetKey).toBe("ripple-account|ripple|rNewRecipient");
+  });
+
+  it("should go to the next step when skipping memo", () => {
+    mockFlow({
+      searchValue: "rNewRecipient",
+      recipient: { address: "rOldRecipient" },
+    });
+
+    renderHook(() => useSendHeaderMemo());
+
+    act(() => {
+      onMemoSkip?.();
+    });
+
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({ button: "skip memo", page: "step recipient" }),
+    );
+    expect(goToNextStep).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendHeaderMemo.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendHeaderMemo.ts
@@ -1,0 +1,73 @@
+import { useCallback, useMemo, useRef } from "react";
+import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
+import type { Memo } from "@ledgerhq/live-common/flows/send/types";
+import { buildRecipientForMemoChange } from "@ledgerhq/live-common/flows/send/utils";
+import { getMemoFamilyCurrencyId } from "@ledgerhq/live-common/flows/send/utils/memoFamilyCurrencyId";
+import { useFlowWizard } from "../../FlowWizard/FlowWizardContext";
+import { useSendFlowActions, useSendFlowData } from "../context/SendFlowContext";
+import { useRecipientMemo } from "../screens/Recipient/hooks/useRecipientMemo";
+import { track } from "~/renderer/analytics/segment";
+import { getSendFlowTrackingProperties } from "../utils/tracking";
+
+export function useSendHeaderMemo() {
+  const { state, uiConfig, recipientSearch, isRecipientAddressComplete } = useSendFlowData();
+  const { transaction } = useSendFlowActions();
+  const { navigation } = useFlowWizard();
+
+  const currencyId = getMemoFamilyCurrencyId(state.account.currency);
+  const sendFlowTrackingProperties = useMemo(
+    () => getSendFlowTrackingProperties(state.account.account, state.account.parentAccount),
+    [state.account.account, state.account.parentAccount],
+  );
+
+  const memoDefaultOption = useMemo(() => {
+    return sendFeatures.getMemoDefaultOption(state.account.currency ?? undefined);
+  }, [state.account.currency]);
+
+  const memoTypeOptions = useMemo(() => {
+    return uiConfig.memoOptions ?? [];
+  }, [uiConfig]);
+
+  const recipientRef = useRef(state.recipient);
+  recipientRef.current = state.recipient;
+  const searchValueRef = useRef(recipientSearch.value);
+  searchValueRef.current = recipientSearch.value;
+
+  const handleMemoChange = useCallback(
+    (memo: Memo) => {
+      transaction.setRecipient(
+        buildRecipientForMemoChange(searchValueRef.current, recipientRef.current, memo),
+      );
+    },
+    [transaction],
+  );
+
+  const handleMemoSkip = useCallback(() => {
+    track("button_clicked", {
+      button: "skip memo",
+      page: "step recipient",
+      ...sendFlowTrackingProperties,
+    });
+    navigation.goToNextStep();
+  }, [navigation, sendFlowTrackingProperties]);
+
+  const resetKey = `${state.account.account?.id ?? ""}|${currencyId ?? ""}|${
+    isRecipientAddressComplete ? recipientSearch.value : ""
+  }`;
+
+  const memo = useRecipientMemo({
+    hasMemo: uiConfig.hasMemo,
+    memoDefaultOption,
+    memoType: uiConfig.memoType,
+    memoTypeOptions,
+    onMemoChange: handleMemoChange,
+    onMemoSkip: handleMemoSkip,
+    resetKey,
+  });
+
+  return {
+    ...memo,
+    currencyId,
+    memoTypeOptions,
+  };
+}

--- a/libs/ledger-live-common/src/flows/send/__tests__/utils.test.ts
+++ b/libs/ledger-live-common/src/flows/send/__tests__/utils.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildRecipientForMemoChange,
   getRecipientDisplayValue,
   getRecipientSearchPrefillValue,
   saveRecentSendRecipient,
@@ -104,5 +105,59 @@ describe("getRecipientSearchPrefillValue", () => {
     expect(
       getRecipientSearchPrefillValue({ address: "0x1234567890abcdef", ensName: "vitalik.eth" }),
     ).toBe("vitalik.eth");
+  });
+});
+
+describe("buildRecipientForMemoChange", () => {
+  const memo = { value: "", type: "NO_MEMO" };
+
+  it("should use the search value when there is no committed recipient", () => {
+    expect(buildRecipientForMemoChange("rNewRecipient", null, memo)).toEqual({
+      address: "rNewRecipient",
+      ensName: undefined,
+      memo,
+    });
+  });
+
+  it("should use the new search value after the recipient is edited", () => {
+    expect(
+      buildRecipientForMemoChange(
+        "rNewRecipient",
+        { address: "rOldRecipient", memo: { value: "", type: "NO_MEMO" } },
+        memo,
+      ),
+    ).toEqual({
+      address: "rNewRecipient",
+      ensName: undefined,
+      memo,
+    });
+  });
+
+  it("should keep the committed address and ENS when the search still matches", () => {
+    expect(
+      buildRecipientForMemoChange(
+        "vitalik.eth",
+        { address: ADDRESS, ensName: "vitalik.eth" },
+        memo,
+      ),
+    ).toEqual({
+      address: ADDRESS,
+      ensName: "vitalik.eth",
+      memo,
+    });
+  });
+
+  it("should drop the previous ENS when the search no longer matches", () => {
+    expect(
+      buildRecipientForMemoChange(
+        "rNewRecipient",
+        { address: ADDRESS, ensName: "vitalik.eth" },
+        memo,
+      ),
+    ).toEqual({
+      address: "rNewRecipient",
+      ensName: undefined,
+      memo,
+    });
   });
 });

--- a/libs/ledger-live-common/src/flows/send/utils.ts
+++ b/libs/ledger-live-common/src/flows/send/utils.ts
@@ -2,7 +2,7 @@ import { getMainAccount, getRecentAddressesStore } from "../../account/index";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import type { Transaction } from "../../coin-modules/transaction-types";
 import { formatAddress } from "../../utils/addressUtils";
-import type { RecipientData } from "./types";
+import type { Memo, RecipientData } from "./types";
 
 function getEnsNameFromTransaction(transaction: Transaction): string | undefined {
   if (!("recipientDomain" in transaction)) return undefined;
@@ -60,4 +60,32 @@ export function getRecipientSearchPrefillValue(
 ): string | undefined {
   if (!recipient) return "";
   return recipient.ensName?.trim() ? recipient.ensName : recipient.address;
+}
+
+/**
+ * Resolves which recipient to persist when the memo changes.
+ */
+export function buildRecipientForMemoChange(
+  searchValue: string,
+  previousRecipient: RecipientData | null,
+  memo: Memo,
+): RecipientData {
+  const previousAddress = previousRecipient?.address;
+  const previousEnsName = previousRecipient?.ensName;
+  const searchMatchesPrevious =
+    searchValue.length > 0 && (searchValue === previousAddress || searchValue === previousEnsName);
+
+  if (searchMatchesPrevious) {
+    return {
+      address: previousAddress ?? searchValue,
+      ensName: previousEnsName,
+      memo,
+    };
+  }
+
+  return {
+    address: searchValue,
+    ensName: undefined,
+    memo,
+  };
 }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Fixes a LWD bug in the new send flow on memo chains, after skipping memo, going back from amount, changing the recipient, and skipping memo again, the flow kept the first recipient instead of the new one. 
LWD was falling back to the filled recipient when persisting memo changes; it now resolves the recipient from the current search value.

https://github.com/user-attachments/assets/0fe605b3-7695-456b-903c-3ab33e2a4c0f


### 🔗 Context

- **[JIRA / GitHub issue](https://ledgerhq.atlassian.net/browse/LIVE-35991)**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
