### PR TITLE
chore(release): prune changelogs when cutting a release branch

### DIFF
--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -48,6 +48,8 @@ jobs:
         run: pnpm install -D --ignore-scripts
       - name: enter prerelease mode
         run: pnpm changeset pre enter next
+      - name: Prune changelogs
+        run: node tools/prune-changelogs/bin/prune-changelogs.mjs --keep=20
       - name: Add changed files
         run: |
           git add .

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15822,6 +15822,21 @@ importers:
 
   tools/pnpm-utils: {}
 
+  tools/prune-changelogs:
+    devDependencies:
+      '@manypkg/get-packages':
+        specifier: 1.1.3
+        version: 1.1.3
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      prettier:
+        specifier: 2.8.8
+        version: 2.8.8
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
 packages:
 
   7zip-bin@5.2.0:
@@ -67673,7 +67688,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3
+      metro: 0.83.3(metro-transform-worker@0.83.3)
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -67797,6 +67812,54 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.83.3(metro-transform-worker@0.83.3):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.28.5
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 1.3.8
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.32.0
+      image-size: 1.1.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0(metro@0.83.3)
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.3
+      metro-cache: 0.83.3
+      metro-cache-key: 0.83.3
+      metro-config: 0.83.3(metro-transform-worker@0.83.3)
+      metro-core: 0.83.3
+      metro-file-map: 0.83.3(metro@0.83.3)
+      metro-resolver: 0.83.3
+      metro-runtime: 0.83.3
+      metro-source-map: 0.83.3
+      metro-symbolicate: 0.83.3
+      metro-transform-plugins: 0.83.3
+      metro-transform-worker: 0.83.3
+      mime-types: 2.1.35
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - metro-transform-worker
       - supports-color
       - utf-8-validate
 

--- a/tools/prune-changelogs/README.md
+++ b/tools/prune-changelogs/README.md
@@ -1,0 +1,65 @@
+# prune-changelogs
+
+Trims old entries from every workspace `CHANGELOG.md`, keeping the newest N.
+
+## Why
+
+The release workflows commit through `planetscale/ghcommit-action`, which uses the
+GitHub GraphQL `createCommitOnBranch` mutation. That mutation takes **whole file
+contents, not diffs**, so a one-line version bump prepended to a 2.9 MB changelog
+ships all 2.9 MB.
+
+A release bumping ~146 packages sent ~21 MB raw / 28 MB base64 in a single request
+and intermittently died with `502 Bad Gateway`. Entries had accumulated to 500–700
+per changelog. Pruning to 20 takes the whole set from 22.4 MB to 4.1 MB and leaves
+no single file above ~440 KB base64.
+
+Old entries are deleted, not archived: an archive file would be re-sent in full on
+every commit that appends to it, recreating the problem. History stays available in
+`git log -p CHANGELOG.md` and in the GitHub release for each version.
+
+## Usage
+
+```sh
+node tools/prune-changelogs/bin/prune-changelogs.mjs --dry-run
+node tools/prune-changelogs/bin/prune-changelogs.mjs --keep=20
+```
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--keep=<n>` | `20` | Newest version entries to retain |
+| `--dry-run` | off | Report what would change without writing |
+| `--cwd=<dir>` | `process.cwd()` | Workspace root to scan |
+
+Requires Node ≥ 23.6 for TypeScript type stripping; the repo pins 24.14.0 in
+`mise.toml`.
+
+## Where it runs
+
+`Prune changelogs` in [release-create.yml](../../.github/workflows/release-create.yml),
+after `changeset pre enter` and before the files are staged.
+
+**Only ever prune the release branch cut from develop.** `release-create` cuts
+`release` from `develop`, so the prune reaches `main` through the normal
+release→main merge and `develop` through the backmerge PR. Pruning two branches
+independently produces differently-bounded deletions of the same lines, which
+conflicts on every subsequent merge.
+
+## Invariants
+
+`pruneChangelog` throws rather than write a changelog that would break releases:
+
+- the `# <package name>` header must survive byte-exactly
+- the newest entry must survive byte-exactly
+
+Both matter because `changeset version` inserts new entries directly below the
+header. If a prune altered that region, its diff would overlap the region releases
+edit and every develop/main merge would conflict.
+
+Files are skipped, not rewritten, when they have no `# name` header, are already
+within the limit, or are so short that the footer would outweigh the entries
+removed.
+
+Pruned output is already prettier-clean, so the tool does not run prettier —
+`test/prettier-stability.test.ts` pins that property, since `changeset version`
+reformats these files on every release.

--- a/tools/prune-changelogs/bin/prune-changelogs.mjs
+++ b/tools/prune-changelogs/bin/prune-changelogs.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+/**
+ * Bin shim for the `prune-changelogs` CLI.
+ *
+ * The `.ts` entry is resolved relative to this package, so it works whether
+ * this bin is invoked from the package's own `node_modules` or linked into the
+ * workspace root `node_modules/.bin`.
+ */
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const { run } = await import(resolve(here, "../src/cli.ts"));
+const { UsageError } = await import(resolve(here, "../src/args.ts"));
+
+try {
+  process.exitCode = await run(process.argv.slice(2));
+} catch (error) {
+  if (error instanceof UsageError) {
+    const help = error.message === "help requested";
+    console[help ? "log" : "error"](help ? error.usage : `${error.message}\n\n${error.usage}`);
+    process.exitCode = help ? 0 : 2;
+  } else {
+    console.error(error instanceof Error ? (error.stack ?? error.message) : error);
+    process.exitCode = 1;
+  }
+}

--- a/tools/prune-changelogs/package.json
+++ b/tools/prune-changelogs/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@ledgerhq/prune-changelogs",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Trims old entries from workspace CHANGELOG.md files so release commits stay small.",
+  "type": "module",
+  "bin": {
+    "prune-changelogs": "./bin/prune-changelogs.mjs"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "node --test \"test/**/*.test.ts\"",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint ./",
+    "lint:fix": "oxlint ./ --fix --quiet"
+  },
+  "devDependencies": {
+    "@manypkg/get-packages": "1.1.3",
+    "@types/node": "catalog:",
+    "prettier": "2.8.8",
+    "typescript": "catalog:"
+  }
+}

--- a/tools/prune-changelogs/src/args.ts
+++ b/tools/prune-changelogs/src/args.ts
@@ -1,0 +1,49 @@
+export type Options = {
+  keep: number;
+  dryRun: boolean;
+  cwd: string;
+};
+
+export const DEFAULT_KEEP = 20;
+
+const USAGE = `Usage: prune-changelogs [options]
+
+  --keep=<n>    number of newest version entries to retain (default ${DEFAULT_KEEP})
+  --dry-run     report what would change without writing
+  --cwd=<dir>   workspace root to scan (default: process.cwd())
+  -h, --help    show this message`;
+
+export class UsageError extends Error {
+  readonly usage = USAGE;
+}
+
+export function parseArgs(argv: string[]): Options {
+  const options: Options = { keep: DEFAULT_KEEP, dryRun: false, cwd: process.cwd() };
+
+  for (const arg of argv) {
+    if (arg === "--help" || arg === "-h") throw new UsageError("help requested");
+
+    if (arg === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+
+    const match = /^--(keep|cwd)=(.+)$/.exec(arg);
+    if (!match) throw new UsageError(`unknown argument: ${arg}`);
+
+    if (match[1] === "cwd") {
+      options.cwd = match[2];
+      continue;
+    }
+
+    const keep = Number(match[2]);
+    if (!Number.isInteger(keep) || keep < 1) {
+      throw new UsageError(`--keep must be a positive integer, received "${match[2]}"`);
+    }
+    options.keep = keep;
+  }
+
+  return options;
+}
+
+export { USAGE };

--- a/tools/prune-changelogs/src/cli.ts
+++ b/tools/prune-changelogs/src/cli.ts
@@ -1,0 +1,100 @@
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { parseArgs } from "./args.ts";
+import { findChangelogTargets } from "./packages.ts";
+import { pruneChangelog } from "./prune.ts";
+
+const mb = (bytes: number) => `${(bytes / 1024 / 1024).toFixed(2)} MB`;
+const kb = (bytes: number) => `${Math.round(bytes / 1024)} KB`;
+
+export async function run(argv: string[]): Promise<number> {
+  const options = parseArgs(argv);
+  const targets = await findChangelogTargets(options.cwd);
+
+  const pruned: { path: string; before: number; after: number; dropped: number }[] = [];
+  let bytesBefore = 0;
+  let bytesAfter = 0;
+  let untouched = 0;
+  let tooSmall = 0;
+  let malformed = 0;
+
+  for (const target of targets) {
+    const text = await readFile(target.path, "utf8");
+    bytesBefore += text.length;
+
+    const outcome = pruneChangelog(text, options.keep);
+
+    if (!outcome.changed) {
+      bytesAfter += text.length;
+      if (outcome.reason === "malformed-header") {
+        malformed += 1;
+        console.warn(`skipped (no "# name" header): ${target.path}`);
+      } else if (outcome.reason === "no-saving") {
+        tooSmall += 1;
+      } else {
+        untouched += 1;
+      }
+      continue;
+    }
+
+    bytesAfter += outcome.bytesAfter;
+    pruned.push({
+      path: path.relative(options.cwd, target.path),
+      before: outcome.bytesBefore,
+      after: outcome.bytesAfter,
+      dropped: outcome.dropped,
+    });
+
+    if (!options.dryRun) await writeFile(target.path, outcome.text);
+  }
+
+  report({
+    options,
+    targets: targets.length,
+    pruned,
+    untouched,
+    tooSmall,
+    malformed,
+    bytesBefore,
+    bytesAfter,
+  });
+  return 0;
+}
+
+function report({
+  options,
+  targets,
+  pruned,
+  untouched,
+  tooSmall,
+  malformed,
+  bytesBefore,
+  bytesAfter,
+}: {
+  options: { keep: number; dryRun: boolean };
+  targets: number;
+  pruned: { path: string; before: number; after: number; dropped: number }[];
+  untouched: number;
+  tooSmall: number;
+  malformed: number;
+  bytesBefore: number;
+  bytesAfter: number;
+}): void {
+  const mode = options.dryRun ? "dry run" : "write";
+  console.log(`\nprune-changelogs (${mode}, keep=${options.keep})`);
+  console.log(`  scanned ${targets} workspace changelogs`);
+
+  for (const entry of [...pruned]
+    .sort((a, b) => b.before - b.after - (a.before - a.after))
+    .slice(0, 10)) {
+    console.log(
+      `  ${kb(entry.before).padStart(8)} -> ${kb(entry.after).padStart(7)}  (-${entry.dropped} entries)  ${entry.path}`,
+    );
+  }
+  if (pruned.length > 10) console.log(`  ... and ${pruned.length - 10} more`);
+
+  console.log(
+    `  pruned ${pruned.length}, within limit ${untouched}, too small to benefit ${tooSmall}, skipped ${malformed}`,
+  );
+  console.log(`  total ${mb(bytesBefore)} -> ${mb(bytesAfter)}\n`);
+}

--- a/tools/prune-changelogs/src/index.ts
+++ b/tools/prune-changelogs/src/index.ts
@@ -1,0 +1,11 @@
+export { DEFAULT_KEEP, parseArgs, USAGE, UsageError, type Options } from "./args.ts";
+export { run } from "./cli.ts";
+export { findChangelogTargets, type ChangelogTarget } from "./packages.ts";
+export { FOOTER, FOOTER_TOKEN, pruneChangelog, stripFooter, type PruneOutcome } from "./prune.ts";
+export {
+  hasValidHeader,
+  joinChangelog,
+  splitChangelog,
+  VERSION_HEADING,
+  type SplitChangelog,
+} from "./split.ts";

--- a/tools/prune-changelogs/src/packages.ts
+++ b/tools/prune-changelogs/src/packages.ts
@@ -1,0 +1,24 @@
+import { getPackages } from "@manypkg/get-packages";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+export type ChangelogTarget = { name: string; dir: string; path: string };
+
+/**
+ * Resolves targets through the workspace definition rather than a glob, so
+ * build output and vendored copies (`apps/cli/dist/CHANGELOG.md`,
+ * `apps/ledger-live-mobile/vendor/**\/CHANGELOG.md`) are unreachable by
+ * construction instead of relying on an exclusion list.
+ */
+export async function findChangelogTargets(cwd: string): Promise<ChangelogTarget[]> {
+  const { packages } = await getPackages(cwd);
+
+  return packages
+    .map(pkg => ({
+      name: pkg.packageJson.name,
+      dir: pkg.dir,
+      path: path.join(pkg.dir, "CHANGELOG.md"),
+    }))
+    .filter(target => existsSync(target.path))
+    .sort((a, b) => a.path.localeCompare(b.path));
+}

--- a/tools/prune-changelogs/src/prune.ts
+++ b/tools/prune-changelogs/src/prune.ts
@@ -1,0 +1,83 @@
+import { hasValidHeader, joinChangelog, splitChangelog } from "./split.ts";
+
+/** Stable token so the footer stays strippable even if its wording changes. */
+export const FOOTER_TOKEN = "changelog-pruned";
+
+export const FOOTER =
+  `<!-- ${FOOTER_TOKEN}: older entries were removed to keep this file small. ` +
+  "Full history is in `git log -p CHANGELOG.md` and in the GitHub release for each version. -->";
+
+export type PruneOutcome =
+  | {
+      changed: false;
+      reason: "under-limit" | "malformed-header" | "no-saving";
+      text: string;
+      sections: number;
+    }
+  | {
+      changed: true;
+      text: string;
+      kept: number;
+      dropped: number;
+      bytesBefore: number;
+      bytesAfter: number;
+      /** Byte-exact regions that must survive formatting, or merges will conflict. */
+      header: string;
+      newestSection: string;
+    };
+
+export function stripFooter(text: string): string {
+  return text
+    .split("\n")
+    .filter(line => !(line.trimStart().startsWith("<!--") && line.includes(FOOTER_TOKEN)))
+    .join("\n");
+}
+
+/**
+ * Keeps the newest `keep` version sections and drops the rest.
+ *
+ * Old entries are deleted rather than archived: an archive file would be
+ * re-sent in full on every commit that appends to it, which is the problem
+ * this exists to solve.
+ */
+export function pruneChangelog(text: string, keep: number): PruneOutcome {
+  if (!Number.isInteger(keep) || keep < 1) {
+    throw new RangeError(`keep must be a positive integer, received ${keep}`);
+  }
+
+  const split = splitChangelog(stripFooter(text));
+
+  if (!hasValidHeader(split.header)) {
+    return { changed: false, reason: "malformed-header", text, sections: split.sections.length };
+  }
+  if (split.sections.length <= keep) {
+    return { changed: false, reason: "under-limit", text, sections: split.sections.length };
+  }
+
+  const kept = split.sections.slice(0, keep);
+  const body = joinChangelog({ header: split.header, sections: kept }).trimEnd();
+  const next = `${body}\n\n${FOOTER}\n`;
+
+  if (!next.startsWith(split.header)) {
+    throw new Error("prune dropped the changelog header");
+  }
+  if (!next.includes(kept[0].trimEnd())) {
+    throw new Error("prune altered the newest changelog entry");
+  }
+
+  // Skip on short changelogs
+  if (next.length >= text.length) {
+    return { changed: false, reason: "no-saving", text, sections: split.sections.length };
+  }
+
+  return {
+    changed: true,
+    text: next,
+    kept: kept.length,
+    dropped: split.sections.length - kept.length,
+    bytesBefore: text.length,
+    bytesAfter: next.length,
+    header: split.header,
+    newestSection: kept[0].trimEnd(),
+  };
+}

--- a/tools/prune-changelogs/src/split.ts
+++ b/tools/prune-changelogs/src/split.ts
@@ -1,0 +1,51 @@
+/**
+ * Entry bodies are free-form markdown lifted from changeset files and PR
+ * descriptions, so a `## ` line can legitimately appear inside a fenced code
+ * block. Splitting tracks fences and only treats a semver `## ` heading at
+ * column 0 as a section boundary.
+ */
+
+export const VERSION_HEADING = /^## \d+\.\d+\.\d+(?:[-+][0-9A-Za-z.\-+]+)?\s*$/;
+
+const FENCE = /^(`{3,}|~{3,})/;
+
+export type SplitChangelog = {
+  /** Everything before the first version section, e.g. `# @ledgerhq/foo`. */
+  header: string;
+  /** Version sections, newest first. Each starts with its own `## <version>` line. */
+  sections: string[];
+};
+
+export function splitChangelog(text: string): SplitChangelog {
+  const headerLines: string[] = [];
+  const sections: string[][] = [];
+  let current: string[] | null = null;
+  let fence: string | null = null;
+
+  for (const line of text.split("\n")) {
+    const fenceMatch = FENCE.exec(line);
+    if (fenceMatch) {
+      if (fence === null) fence = fenceMatch[1];
+      else if (line.startsWith(fence)) fence = null;
+    } else if (fence === null && VERSION_HEADING.test(line)) {
+      if (current) sections.push(current);
+      current = [];
+    }
+    (current ?? headerLines).push(line);
+  }
+  if (current) sections.push(current);
+
+  return {
+    header: headerLines.join("\n"),
+    sections: sections.map(lines => lines.join("\n")),
+  };
+}
+
+/** Inverse of {@link splitChangelog} for any changelog with a `# name` header. */
+export function joinChangelog({ header, sections }: SplitChangelog): string {
+  return [header, ...sections].join("\n");
+}
+
+export function hasValidHeader(header: string): boolean {
+  return header.startsWith("# ");
+}

--- a/tools/prune-changelogs/test/args.test.ts
+++ b/tools/prune-changelogs/test/args.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { DEFAULT_KEEP, parseArgs, UsageError } from "../src/args.ts";
+
+test("defaults to writing with DEFAULT_KEEP", () => {
+  const options = parseArgs([]);
+  assert.equal(options.keep, DEFAULT_KEEP);
+  assert.equal(options.dryRun, false);
+});
+
+test("parses --keep, --dry-run and --cwd", () => {
+  const options = parseArgs(["--keep=5", "--dry-run", "--cwd=/tmp/workspace"]);
+  assert.deepEqual(options, { keep: 5, dryRun: true, cwd: "/tmp/workspace" });
+});
+
+test("rejects a non-positive or non-numeric --keep", () => {
+  for (const arg of ["--keep=0", "--keep=-3", "--keep=abc", "--keep=2.5"]) {
+    assert.throws(() => parseArgs([arg]), UsageError, `expected ${arg} to be rejected`);
+  }
+});
+
+test("rejects unknown arguments rather than ignoring them", () => {
+  assert.throws(() => parseArgs(["--keeep=20"]), UsageError);
+  assert.throws(() => parseArgs(["prune"]), UsageError);
+});
+
+test("--help is surfaced as a UsageError carrying the usage text", () => {
+  for (const flag of ["--help", "-h"]) {
+    assert.throws(
+      () => parseArgs([flag]),
+      (error: unknown) => error instanceof UsageError && error.usage.includes("--keep"),
+    );
+  }
+});

--- a/tools/prune-changelogs/test/fixtures.ts
+++ b/tools/prune-changelogs/test/fixtures.ts
@@ -1,0 +1,14 @@
+export const HEADER = "# @ledgerhq/example";
+
+export function section(version: string, body = `- abc1234: change for ${version}`): string {
+  return `## ${version}\n\n### Patch Changes\n\n${body}\n`;
+}
+
+/** Builds a file in exactly the shape `@changesets/apply-release-plan` writes. */
+export function changelog(versions: string[]): string {
+  return [`${HEADER}\n`, ...versions.map(version => section(version))].join("\n");
+}
+
+export function versions(count: number, minor = 0): string[] {
+  return Array.from({ length: count }, (_, index) => `1.${minor}.${count - index - 1}`);
+}

--- a/tools/prune-changelogs/test/prettier-stability.test.ts
+++ b/tools/prune-changelogs/test/prettier-stability.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+import prettier from "prettier";
+import { pruneChangelog } from "../src/prune.ts";
+import { changelog, versions } from "./fixtures.ts";
+
+/**
+ * `changeset version` rewrites these files through prettier on every release.
+ * If pruned output were not already prettier-clean, the next release would
+ * reformat it — and that reformatting would touch the top of the file, where
+ * changesets inserts, turning every develop/main merge into a conflict.
+ *
+ * These tests pin that property so the tool can safely skip formatting.
+ */
+
+const filePath = path.join(import.meta.dirname, "CHANGELOG.md");
+
+async function formatMarkdown(content: string): Promise<string> {
+  const config = await prettier.resolveConfig(filePath);
+  return prettier.format(content, { ...config, filepath: filePath, parser: "markdown" });
+}
+
+test("prettier leaves pruned output byte-identical", async () => {
+  const original = await formatMarkdown(changelog(versions(40)));
+  const outcome = pruneChangelog(original, 10);
+  assert.ok(outcome.changed);
+
+  assert.equal(await formatMarkdown(outcome.text), outcome.text);
+});
+
+test("the header and newest entry survive a prettier round-trip", async () => {
+  const original = await formatMarkdown(changelog(versions(40)));
+  const outcome = pruneChangelog(original, 10);
+  assert.ok(outcome.changed);
+
+  const formatted = await formatMarkdown(outcome.text);
+  assert.ok(formatted.startsWith(outcome.header));
+  assert.ok(formatted.includes(outcome.newestSection));
+});
+
+test("pruning stays idempotent through prettier", async () => {
+  const original = await formatMarkdown(changelog(versions(40)));
+  const once = pruneChangelog(original, 10);
+  assert.ok(once.changed);
+
+  assert.equal(pruneChangelog(await formatMarkdown(once.text), 10).changed, false);
+});
+
+test("prettier-clean input with a fenced `## ` line stays intact", async () => {
+  const body = ["- abc1234: shows a heading", "", "```md", "## 9.9.9", "```"].join("\n");
+  const withFence = changelog(versions(30)).replace("- abc1234: change for 1.0.29", body);
+
+  const original = await formatMarkdown(withFence);
+  const outcome = pruneChangelog(original, 10);
+  assert.ok(outcome.changed);
+
+  assert.ok(outcome.text.includes("## 9.9.9"), "fenced heading must not be treated as a section");
+  assert.equal(await formatMarkdown(outcome.text), outcome.text);
+});

--- a/tools/prune-changelogs/test/prettier.d.ts
+++ b/tools/prune-changelogs/test/prettier.d.ts
@@ -1,0 +1,15 @@
+/**
+ * prettier@2 ships no types and `@types/prettier` is not used in this repo.
+ * Only the surface these tests need is declared, and only for the tests —
+ * the tool itself does not depend on prettier at runtime.
+ */
+declare module "prettier" {
+  type Options = Record<string, unknown>;
+
+  const prettier: {
+    resolveConfig(filePath: string): Promise<Options | null>;
+    format(source: string, options?: Options): string;
+  };
+
+  export default prettier;
+}

--- a/tools/prune-changelogs/test/prune.test.ts
+++ b/tools/prune-changelogs/test/prune.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { FOOTER, FOOTER_TOKEN, pruneChangelog, stripFooter } from "../src/prune.ts";
+import { splitChangelog } from "../src/split.ts";
+import { changelog, HEADER, versions } from "./fixtures.ts";
+
+const pruned = (text: string, keep: number) => {
+  const outcome = pruneChangelog(text, keep);
+  assert.ok(outcome.changed, "expected the changelog to be pruned");
+  return outcome;
+};
+
+test("keeps exactly `keep` newest sections and reports the rest as dropped", () => {
+  const outcome = pruned(changelog(versions(50)), 20);
+
+  assert.equal(outcome.kept, 20);
+  assert.equal(outcome.dropped, 30);
+  assert.equal(splitChangelog(outcome.text).sections.length, 20);
+});
+
+test("retains the newest sections, not the oldest", () => {
+  const outcome = pruned(changelog(["9.0.0", "8.0.0", ...versions(20)]), 2);
+  const { sections } = splitChangelog(outcome.text);
+
+  assert.equal(sections.length, 2);
+  assert.ok(sections[0].startsWith("## 9.0.0"));
+  assert.ok(sections[1].startsWith("## 8.0.0"));
+  assert.ok(!outcome.text.includes("## 1.0.0"));
+});
+
+test("skips a changelog too short for the footer to pay for itself", () => {
+  const outcome = pruneChangelog(changelog(["3.0.0", "2.0.0", "1.0.0"]), 2);
+
+  assert.equal(outcome.changed, false);
+  if (!outcome.changed) assert.equal(outcome.reason, "no-saving");
+  assert.equal(outcome.text, changelog(["3.0.0", "2.0.0", "1.0.0"]));
+});
+
+test("leaves a changelog already within the limit byte-identical", () => {
+  const original = changelog(versions(5));
+  const outcome = pruneChangelog(original, 20);
+
+  assert.equal(outcome.changed, false);
+  assert.equal(outcome.text, original);
+  if (!outcome.changed) assert.equal(outcome.reason, "under-limit");
+});
+
+test("is a no-op at exactly the limit", () => {
+  const original = changelog(versions(20));
+  assert.equal(pruneChangelog(original, 20).changed, false);
+});
+
+test("is idempotent: pruning the output again changes nothing", () => {
+  const once = pruned(changelog(versions(50)), 20).text;
+  const twice = pruneChangelog(once, 20);
+
+  assert.equal(twice.changed, false);
+  assert.equal(twice.text, once);
+});
+
+test("preserves the header byte-exactly", () => {
+  const outcome = pruned(changelog(versions(30)), 10);
+  assert.ok(outcome.text.startsWith(`${HEADER}\n`));
+  assert.equal(outcome.header, `${HEADER}\n`);
+});
+
+test("preserves the newest entry byte-exactly", () => {
+  const original = changelog(versions(30));
+  const newest = splitChangelog(original).sections[0];
+
+  const outcome = pruned(original, 10);
+  assert.ok(outcome.text.includes(newest.trimEnd()));
+  assert.equal(outcome.newestSection, newest.trimEnd());
+});
+
+test("appends the footer exactly once, ending with a single newline", () => {
+  const outcome = pruned(changelog(versions(30)), 10);
+  const occurrences = outcome.text.split(FOOTER_TOKEN).length - 1;
+
+  assert.equal(occurrences, 1);
+  assert.ok(outcome.text.endsWith(`${FOOTER}\n`));
+  assert.ok(!outcome.text.endsWith("\n\n"));
+});
+
+test("re-pruning does not accumulate footers", () => {
+  const once = pruned(changelog(versions(50)), 20).text;
+  const twice = pruned(once, 5).text;
+
+  assert.equal(twice.split(FOOTER_TOKEN).length - 1, 1);
+});
+
+test("always shrinks the file", () => {
+  const original = changelog(versions(40));
+  const outcome = pruned(original, 5);
+
+  assert.ok(outcome.bytesAfter < outcome.bytesBefore);
+  assert.equal(outcome.bytesBefore, original.length);
+  assert.equal(outcome.bytesAfter, outcome.text.length);
+});
+
+test("refuses a changelog without an h1 header", () => {
+  const outcome = pruneChangelog(changelog(versions(30)).replace(`${HEADER}\n`, ""), 10);
+
+  assert.equal(outcome.changed, false);
+  if (!outcome.changed) assert.equal(outcome.reason, "malformed-header");
+});
+
+test("rejects a non-positive or fractional keep", () => {
+  for (const keep of [0, -1, 1.5, Number.NaN]) {
+    assert.throws(() => pruneChangelog(changelog(versions(5)), keep), RangeError);
+  }
+});
+
+test("stripFooter removes only the generated footer line", () => {
+  const body = `${HEADER}\n\n## 1.0.0\n\n- abc1234: a real <!-- comment --> in an entry\n\n${FOOTER}\n`;
+  const stripped = stripFooter(body);
+
+  assert.ok(!stripped.includes(FOOTER_TOKEN));
+  assert.ok(stripped.includes("a real <!-- comment --> in an entry"));
+});

--- a/tools/prune-changelogs/test/split.test.ts
+++ b/tools/prune-changelogs/test/split.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { hasValidHeader, joinChangelog, splitChangelog } from "../src/split.ts";
+import { changelog, HEADER, section } from "./fixtures.ts";
+
+test("splits a canonical changelog into header and newest-first sections", () => {
+  const { header, sections } = splitChangelog(changelog(["1.2.0", "1.1.0", "1.0.0"]));
+
+  assert.equal(header, `${HEADER}\n`);
+  assert.equal(sections.length, 3);
+  assert.ok(sections[0].startsWith("## 1.2.0"));
+  assert.ok(sections[2].startsWith("## 1.0.0"));
+});
+
+test("split then join is an identity", () => {
+  const original = changelog(["2.0.0", "1.9.1", "1.9.0"]);
+  assert.equal(joinChangelog(splitChangelog(original)), original);
+});
+
+test("identity holds for a single-section changelog", () => {
+  const original = changelog(["1.0.0"]);
+  assert.equal(joinChangelog(splitChangelog(original)), original);
+});
+
+test("a `## ` line inside a backtick fence is not a section boundary", () => {
+  const body = ["- abc1234: documented a heading", "", "  ```md", "  ## 9.9.9", "  ```"].join("\n");
+  const text = [`${HEADER}\n`, section("1.1.0", body), section("1.0.0")].join("\n");
+
+  const { sections } = splitChangelog(text);
+  assert.equal(sections.length, 2);
+  assert.ok(sections[0].includes("## 9.9.9"), "fenced heading stays inside its section");
+});
+
+test("a `## ` line inside a tilde fence is not a section boundary", () => {
+  const body = ["- abc1234: tilde fence", "", "~~~md", "## 9.9.9", "~~~"].join("\n");
+  const text = [`${HEADER}\n`, section("1.1.0", body), section("1.0.0")].join("\n");
+
+  assert.equal(splitChangelog(text).sections.length, 2);
+});
+
+test("a longer closing fence still closes the block", () => {
+  const body = ["- abc1234: nested fences", "", "````md", "```", "## 9.9.9", "````"].join("\n");
+  const text = [`${HEADER}\n`, section("1.1.0", body), section("1.0.0")].join("\n");
+
+  assert.equal(splitChangelog(text).sections.length, 2);
+});
+
+test("non-semver `## ` headings are not section boundaries", () => {
+  const body = ["- abc1234: notes", "", "## Unreleased", "", "## Notes"].join("\n");
+  const text = [`${HEADER}\n`, section("1.1.0", body), section("1.0.0")].join("\n");
+
+  assert.equal(splitChangelog(text).sections.length, 2);
+});
+
+test("prerelease and build-metadata versions are recognised", () => {
+  const { sections } = splitChangelog(
+    changelog(["2.0.0-next.4", "2.0.0-nightly.20260814", "1.0.0+build.1"]),
+  );
+  assert.equal(sections.length, 3);
+});
+
+test("a header-only changelog yields no sections", () => {
+  const { header, sections } = splitChangelog(`${HEADER}\n`);
+  assert.equal(sections.length, 0);
+  assert.equal(header, `${HEADER}\n`);
+});
+
+test("hasValidHeader distinguishes h1 headers from anything else", () => {
+  assert.ok(hasValidHeader(`${HEADER}\n`));
+  assert.ok(!hasValidHeader(""));
+  assert.ok(!hasValidHeader("## 1.0.0"));
+  assert.ok(!hasValidHeader("no heading at all"));
+});

--- a/tools/prune-changelogs/tsconfig.json
+++ b/tools/prune-changelogs/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base",
+  "compilerOptions": {
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "types": ["node"],
+    "lib": ["ESNext"],
+    "customConditions": []
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "test/**/*.d.ts"]
+}


### PR DESCRIPTION
Release commits go through createCommitOnBranch, which sends whole file contents rather than diffs. Entries had accumulated to 500-700 per changelog, so a release bumping ~146 packages sent ~28 MB base64 in one request and intermittently returned 502 Bad Gateway.

Prune to the newest 20 entries when release-create cuts the release branch from develop: 22.4 MB -> 4.1 MB across 203 changelogs, with no single file above ~440 KB base64.

Old entries are deleted rather than archived, since an archive file would be re-sent in full whenever it is appended to. History remains in git and in the GitHub release for each version.

This is intentionally only done on release and not hotfix to prevent back-merge issues.

Test run: https://github.com/LedgerHQ/ledger-live/actions/runs/32020372065/job/95358613216
Ticket: https://ledgerhq.atlassian.net/browse/LIVE-36075