### PR TITLE
fix(zcash): name ironwood operations and hide shielded self transfers

### DIFF
--- a/.changeset/zcash-ironwood-operation-labels.md
+++ b/.changeset/zcash-ironwood-operation-labels.md
@@ -1,0 +1,10 @@
+---
+"@ledgerhq/coin-zcash": patch
+"ledger-live-desktop": patch
+---
+
+Name the Ironwood shielded operations and stop listing Zcash self-transfers.
+
+The Ironwood operation types were declared and given icons but never labelled, so a received or sent Ironwood transaction rendered its raw key in the history. They now carry the same labels, address cells and "Private (Ironwood)" transaction-type detail as the Sapling and Orchard ones.
+
+A shielded transaction that moved no value across the wallet boundary — every note landing on the account's own internal address — was also emitted as a history row of its own: no counterparty, a value of 0, and, when it was the shielded leg of a transparent-funded sweep, a duplicate of the transparent operation already listing that transaction. Such a transaction now produces an operation typed `NONE`, which keeps it in the account data while leaving it out of the lists. Its classification is unchanged, so the fee and balance logic that reads it is unaffected.

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/operationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/operationDetails.tsx
@@ -27,10 +27,12 @@ class AddressCell extends PureComponent<AddressCellProps<Operation>> {
     switch (operation.type) {
       case "SHIELDED_TX_SAPLING_IN":
       case "SHIELDED_TX_ORCHARD_IN":
+      case "SHIELDED_TX_IRONWOOD_IN":
         value = operation.senders[0];
         break;
       case "SHIELDED_TX_SAPLING_OUT":
       case "SHIELDED_TX_ORCHARD_OUT":
+      case "SHIELDED_TX_IRONWOOD_OUT":
         value = operation.recipients[0];
         break;
     }
@@ -59,6 +61,9 @@ const getI18nKey = (type: string) => {
     case "SHIELDED_TX_ORCHARD_IN":
     case "SHIELDED_TX_ORCHARD_OUT":
       return "zcash.operationDetails.shieldedOrchardTx";
+    case "SHIELDED_TX_IRONWOOD_IN":
+    case "SHIELDED_TX_IRONWOOD_OUT":
+      return "zcash.operationDetails.shieldedIronwoodTx";
     default:
       return null;
   }
@@ -105,6 +110,8 @@ export default {
     SHIELDED_TX_SAPLING_OUT: AddressCell,
     SHIELDED_TX_ORCHARD_IN: AddressCell,
     SHIELDED_TX_ORCHARD_OUT: AddressCell,
+    SHIELDED_TX_IRONWOOD_IN: AddressCell,
+    SHIELDED_TX_IRONWOOD_OUT: AddressCell,
   },
   OperationDetailsExtra,
   splitAddress: {
@@ -112,5 +119,7 @@ export default {
     SHIELDED_TX_SAPLING_OUT: SplitAddressComponent,
     SHIELDED_TX_ORCHARD_IN: SplitAddressComponent,
     SHIELDED_TX_ORCHARD_OUT: SplitAddressComponent,
+    SHIELDED_TX_IRONWOOD_IN: SplitAddressComponent,
+    SHIELDED_TX_IRONWOOD_OUT: SplitAddressComponent,
   },
 };

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -215,7 +215,9 @@
       "SHIELDED_TX_SAPLING_IN": "Received",
       "SHIELDED_TX_SAPLING_OUT": "Sent",
       "SHIELDED_TX_ORCHARD_IN": "Received",
-      "SHIELDED_TX_ORCHARD_OUT": "Sent"
+      "SHIELDED_TX_ORCHARD_OUT": "Sent",
+      "SHIELDED_TX_IRONWOOD_IN": "Received",
+      "SHIELDED_TX_IRONWOOD_OUT": "Sent"
     },
     "edit": {
       "title": "Speed up or Cancel",
@@ -9037,7 +9039,8 @@
       "txType": "Transaction type",
       "transparentTx": "Transparent",
       "shieldedSaplingTx": "🛡 Private (Sapling)",
-      "shieldedOrchardTx": "🛡 Private (Orchard)"
+      "shieldedOrchardTx": "🛡 Private (Orchard)",
+      "shieldedIronwoodTx": "🛡 Private (Ironwood)"
     }
   },
   "aleo": {

--- a/libs/coin-modules/coin-zcash/src/bridge/operations.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/operations.test.ts
@@ -453,7 +453,7 @@ describe("convertShieldedTransactionsToOperations", () => {
 
     expect(result).toHaveLength(3);
     expect(result[0].type).toBe("SHIELDED_TX_ORCHARD_OUT");
-    expect(result[1].type).toBe("SHIELDED_TX_INTERNAL");
+    expect(result[1].type).toBe("NONE");
     expect(result[2].type).toBe("UNKNOWN");
   });
 
@@ -555,7 +555,10 @@ describe("convertShieldedTransactionsToOperations", () => {
     expect(op.value).toEqual(new BigNumber(1_000_000));
   });
 
-  it("op.value for internal tx is 0", () => {
+  // A self-transfer keeps its `SHIELDED_TX_INTERNAL` classification — the fee and
+  // balance logic read it — but the operation it produces is typed `NONE`, which
+  // the platform leaves out of the history lists.
+  it("op.value for internal tx is 0 and the operation is typed NONE", () => {
     const tx: ShieldedTransaction = {
       id: "tx-internal",
       hex: "00",
@@ -569,8 +572,37 @@ describe("convertShieldedTransactionsToOperations", () => {
         ironwood_outputs: [{ amount: new BigNumber(5000), memo: "", transfer_type: "internal" }],
       },
     };
+    expect(getTxType(tx)).toBe("SHIELDED_TX_INTERNAL");
+
     const [op] = convertShieldedTransactionsToOperations([tx], "acc-1");
-    expect(op.type).toBe("SHIELDED_TX_INTERNAL");
+    expect(op.type).toBe("NONE");
+    expect(op.value).toEqual(new BigNumber(0));
+    expect(op.id).toContain("-NONE");
+  });
+
+  // The shielded leg of a t→z sweep whose whole amount landed on the internal
+  // address: the transparent operation already reports this transaction, so the
+  // shielded one must not add a second row for it.
+  it("types the shielded leg of a transparent-funded self-transfer NONE", () => {
+    const tx: ShieldedTransaction = {
+      id: "81d8cc46d43817a62a9cb18def6fbfc840d4e6f29f4097e49e3e726086517c23",
+      hex: "00",
+      blockHeight: 3_430_137,
+      blockHash: "hash",
+      timestamp: 1_785_396_985,
+      fee: new BigNumber(0),
+      transparentOut: new BigNumber(0),
+      hasTransparentInputs: true,
+      decryptedData: {
+        orchard_outputs: [],
+        sapling_outputs: [],
+        ironwood_outputs: [
+          { amount: new BigNumber(1_079_834), memo: "", transfer_type: "internal" },
+        ],
+      },
+    };
+    const [op] = convertShieldedTransactionsToOperations([tx], "acc-1");
+    expect(op.type).toBe("NONE");
     expect(op.value).toEqual(new BigNumber(0));
   });
 

--- a/libs/coin-modules/coin-zcash/src/bridge/operations.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/operations.ts
@@ -75,6 +75,21 @@ export const getTxType = (tx: ShieldedTransaction): OperationType => {
   return "SHIELDED_TX_INTERNAL";
 };
 
+/**
+ * The type the operation carries, which is not always the type the transaction
+ * has.
+ *
+ * A self-transfer moved no value across the wallet boundary, so it has nothing to
+ * report in a history list: it names no counterparty, its value is 0, and when it
+ * is the shielded leg of a transparent-funded send — a t→z sweep whose whole
+ * amount landed on the internal address — the transparent operation already lists
+ * the same transaction. `NONE` is how the platform keeps such a transaction in the
+ * account data while leaving it out of the lists it would only clutter (see
+ * `flattenOperationWithInternalsAndNfts`).
+ */
+const toOperationType = (txType: OperationType): OperationType =>
+  txType === "SHIELDED_TX_INTERNAL" ? "NONE" : txType;
+
 export function applyOutputDelta(
   balance: BigNumber,
   outputs: { transfer_type: string; amount: BigNumber }[],
@@ -238,13 +253,14 @@ export function convertShieldedTransactionsToOperations(
       value = sumNotes("outgoing").plus(deshieldedValue(tx)).plus(fee);
     }
 
+    const operationType = toOperationType(txType);
     const operation: BtcOperation = {
-      id: encodeOperationId(accountId, tx.id, txType),
+      id: encodeOperationId(accountId, tx.id, operationType),
       hash: tx.id,
       accountId,
       blockHash: tx.blockHash,
       blockHeight: tx.blockHeight,
-      type: txType,
+      type: operationType,
       senders: [],
       recipients: [],
       date: new Date(tx.timestamp * 1000), // zcash shielded transaction timestamps are Unix seconds.


### PR DESCRIPTION
### 📝 Description

Two problems seen on the account history of a mainnet account with the shielded feature flag enabled, both surfacing as `i18next::translator: missingKey` warnings.

**The Ironwood operation types were declared but never named.** `SHIELDED_TX_IRONWOOD_IN` / `_OUT` exist in the operation-type union, are classified correctly by the coin module, sit in the IN and OUT families and even have icons — but the desktop app had no label for them, no address cell and no transaction-type detail, so a received or sent Ironwood transaction rendered its raw key where Sapling and Orchard render "Received" / "Sent" and "🛡 Private (Orchard)". They now get the same treatment as the other two pools.

**A shielded self-transfer was emitted as a history row of its own.** `getTxType` returns `SHIELDED_TX_INTERNAL` when no note crossed the wallet boundary and no value reached the transparent bundle — every note landed on the account's own internal address. The classification is right; emitting an operation for it was not. Such an operation cannot be displayed: value 0, no sender, no recipient, no label, and membership in neither the IN nor the OUT family, so no direction and no sign. In the transparent-funded case it was also a duplicate — the transparent sync already lists that transaction, fee included.

It now produces an operation typed `NONE`, the platform's way of keeping a transaction in the account data while leaving it out of the history and the CSV export (`flattenOperationWithInternalsAndNfts`). The classification itself is untouched, so the outgoing-fee and balance computations that read it are unaffected.

Two transactions of that shape, mined at height 3 430 137 on a mainnet account, motivated the change: a t→z sweep whose whole amount landed on the internal address, already listed as a transparent `OUT` of its value plus fee; and a purely shielded self-transfer. No user-facing flow can produce this type today — a z→t send keeps its internal change note but is typed `_OUT` through the transparent bundle, and a z→z send always carries an outgoing note recovered through the external outgoing viewing key.

**Regression cover** — `libs/coin-modules/coin-zcash/src/bridge/operations.test.ts`: a self-transfer keeps its classification but yields an operation typed `NONE` whose id encodes that type, and the shielded leg of a transparent-funded sweep is typed `NONE` (that case built from the transaction observed in the field). Full coin-zcash suite: 696 passed, 40 suites. Desktop typecheck and oxlint clean.

**Note for reviewers**: the operation id encodes the operation type, so rows already stored under the previous type survive until the account is resynced from a cleared cache. A purely shielded self-transfer also pays a fee that no longer appears anywhere in the history, although the balance reflects it — accepted, since such a transaction has no counterparty and no amount to report, and the alternative is a permanent empty row.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35997](https://ledgerhq.atlassian.net/browse/LIVE-35997)
- **ADR** (if any): —


[LIVE-35997]: https://ledgerhq.atlassian.net/browse/LIVE-35997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ