### PR TITLE
[LWM] feat(pay-card): add LWM Pay action tiles view and mount (LIVE-34906)

### DIFF
--- a/.changeset/silent-tiles-mount.md
+++ b/.changeset/silent-tiles-mount.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@features/flow-pay-card-balance": minor
+---
+
+Add Deposit and Request action tiles to the mobile Pay screen hero

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10023,6 +10023,10 @@
         "dialogBanner": "Manage all other assets in your home",
         "confirm": "Confirm"
       }
+    },
+    "actions": {
+      "deposit": "Add stablecoin",
+      "request": "Request"
     }
   },
   "syncIndicator": {

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTabBalance.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTabBalance.integration.test.tsx
@@ -82,6 +82,8 @@ describe("PayTab balance integration", () => {
     expect(screen.getByText(EMPTY_TITLE)).toBeVisible();
     expect(screen.getByText(EMPTY_DESCRIPTION)).toBeVisible();
     expect(screen.queryByTestId("pay-card-balance-funded-state")).toBeNull();
+    expect(screen.queryByTestId("action-tile-deposit")).toBeNull();
+    expect(screen.queryByTestId("action-tile-request")).toBeNull();
   });
 
   it("should render the aggregated stablecoin balance when the user holds stablecoins", async () => {
@@ -91,6 +93,39 @@ describe("PayTab balance integration", () => {
 
     expect(await screen.findByTestId("pay-card-balance-funded-state")).toBeVisible();
     expect(screen.queryByTestId("pay-card-balance-empty-state")).toBeNull();
+  });
+
+  it("should render Deposit and Request action tiles when the hero is funded", async () => {
+    mockStablecoins({ stablecoins: [heldUsdc(1000)] });
+
+    render(<PayTabScreen />, { overrideInitialState: tourSeen });
+
+    expect(await screen.findByTestId("action-tile-deposit")).toBeVisible();
+    expect(screen.getByTestId("action-tile-request")).toBeVisible();
+    expect(screen.getByText("Add stablecoin")).toBeVisible();
+    expect(screen.getByText("Request")).toBeVisible();
+  });
+
+  it("should track button_clicked with quick_action location when an action tile is pressed", async () => {
+    mockStablecoins({ stablecoins: [heldUsdc(1000)] });
+
+    const { user } = render(<PayTabScreen />, { overrideInitialState: tourSeen });
+
+    await user.press(await screen.findByTestId("action-tile-deposit"));
+
+    expect(mockTrack).toHaveBeenCalledWith("button_clicked", {
+      button: "deposit",
+      buttonLocation: "quick_action",
+      page: "Pay",
+    });
+
+    await user.press(screen.getByTestId("action-tile-request"));
+
+    expect(mockTrack).toHaveBeenCalledWith("button_clicked", {
+      button: "request",
+      buttonLocation: "quick_action",
+      page: "Pay",
+    });
   });
 
   it("should track the Pay page with the active balance filter on view", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabActionTiles.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabActionTiles.ts
@@ -1,0 +1,23 @@
+import { useMemo } from "react";
+import { useTranslation } from "~/context/Locale";
+import type { ActionTilesProps } from "@features/flow-pay-card-balance";
+
+const noop = () => {};
+
+export function usePayTabActionTiles(
+  onTrackEvent: ActionTilesProps["onTrackEvent"],
+): ActionTilesProps {
+  const { t } = useTranslation();
+
+  return useMemo(
+    () => ({
+      tiles: [
+        { id: "deposit", label: t("payTab.actions.deposit"), onPress: noop },
+        { id: "request", label: t("payTab.actions.request"), onPress: noop },
+      ],
+      page: "Pay",
+      onTrackEvent,
+    }),
+    [t, onTrackEvent],
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/PayTabView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/PayTabView.tsx
@@ -3,6 +3,7 @@ import { CardLogin, type OpenHostedLogin } from "@features/flow-pay-card-auth";
 import { FeatureTour, type FeatureTourProps } from "@features/flow-pay-card-feature-tour";
 import {
   PayCardBalance,
+  type ActionTilesProps,
   type PayCardBalanceData,
   type PayCardBalanceLabels,
 } from "@features/flow-pay-card-balance";
@@ -15,6 +16,7 @@ type PayTabViewProps = {
   readonly featureTour: FeatureTourProps;
   readonly balance: PayCardBalanceData;
   readonly balanceLabels: PayCardBalanceLabels;
+  readonly actionTiles: ActionTilesProps;
 };
 
 export function PayTabView({
@@ -23,6 +25,7 @@ export function PayTabView({
   featureTour,
   balance,
   balanceLabels,
+  actionTiles,
 }: PayTabViewProps) {
   return (
     <Box
@@ -31,7 +34,7 @@ export function PayTabView({
       testID="paytab-screen"
     >
       <TrackScreen category="Pay" balance_filter={balance.filter} />
-      <PayCardBalance {...balance} labels={balanceLabels} />
+      <PayCardBalance {...balance} labels={balanceLabels} actionTiles={actionTiles} />
       <CardLogin openHostedLogin={openHostedLogin} />
       <FeatureTour {...featureTour} />
     </Box>

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
@@ -6,6 +6,7 @@ import type { FeatureTourProps } from "@features/flow-pay-card-feature-tour";
 import type { PayCardBalanceLabels } from "@features/flow-pay-card-balance";
 import { useNavigationBarHeights } from "LLM/hooks/useNavigationBarHeights";
 import { usePayCardBalance } from "LLM/features/PayTab/hooks/usePayCardBalance";
+import { usePayTabActionTiles } from "LLM/features/PayTab/hooks/usePayTabActionTiles";
 import { track } from "~/analytics";
 
 export function usePayTabViewModel() {
@@ -13,6 +14,7 @@ export function usePayTabViewModel() {
   const { t } = useTranslation();
 
   const balance = usePayCardBalance();
+  const actionTiles = usePayTabActionTiles(balance.onTrackEvent);
 
   const balanceLabels: PayCardBalanceLabels = useMemo(
     () => ({
@@ -60,5 +62,5 @@ export function usePayTabViewModel() {
     [t],
   );
 
-  return { top, openHostedLogin, featureTour, balance, balanceLabels };
+  return { top, openHostedLogin, featureTour, balance, balanceLabels, actionTiles };
 }

--- a/features/flow/pay-card-balance/src/components/ActionTiles/__tests__/ActionTilesView.native.test.tsx
+++ b/features/flow/pay-card-balance/src/components/ActionTiles/__tests__/ActionTilesView.native.test.tsx
@@ -5,8 +5,8 @@ import type { ActionTilesViewProps } from "../types";
 
 const defaultProps: ActionTilesViewProps = {
   tiles: [
-    { id: "deposit", label: "Deposit", onPress: jest.fn(), appearance: "base" },
-    { id: "request", label: "Request", onPress: jest.fn(), appearance: "transparent" },
+    { id: "deposit", label: "Deposit", onPress: jest.fn() },
+    { id: "request", label: "Request", onPress: jest.fn() },
   ],
 };
 
@@ -20,11 +20,7 @@ describe("ActionTilesView (Native)", () => {
 
   it("should call onPress when a tile is pressed", () => {
     const onPress = jest.fn();
-    render(
-      <ActionTilesView
-        tiles={[{ id: "deposit", label: "Deposit", onPress, appearance: "base" }]}
-      />,
-    );
+    render(<ActionTilesView tiles={[{ id: "deposit", label: "Deposit", onPress }]} />);
 
     screen.getByTestId("action-tile-deposit").props.onPress();
 

--- a/features/flow/pay-card-balance/src/components/ActionTiles/types.ts
+++ b/features/flow/pay-card-balance/src/components/ActionTiles/types.ts
@@ -4,7 +4,7 @@ export type ActionTile = Readonly<{
   id: ActionTileId;
   label: string;
   onPress: () => void;
-  appearance: "base" | "transparent";
+  appearance?: "base" | "transparent";
 }>;
 
 export type ActionTilesProps = Readonly<{

--- a/features/flow/pay-card-balance/src/components/Hero/PayCardBalanceFundedState.native.tsx
+++ b/features/flow/pay-card-balance/src/components/Hero/PayCardBalanceFundedState.native.tsx
@@ -41,7 +41,9 @@ export function PayCardBalanceFundedState({
         selectedOption={selectedOption}
         onOpenFilter={onOpenFilter}
       />
-      {actionTiles && <ActionTiles {...actionTiles} />}
+      <Box lx={{ marginTop: "s40", alignItems: "center", justifyContent: "center" }}>
+        {actionTiles && <ActionTiles {...actionTiles} />}
+      </Box>
     </Box>
   );
 }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

**Problem**: The LWM Pay screen had no action tiles under the balance hero, so users could not trigger the core Pay actions from there.

**Solution**: Mount the shared `ActionTiles` view-model under the balance hero on the mobile Pay screen, rendering two Lumen buttons — **Add stablecoin** and **Request** (press → noop + tracking for now, per the ticket scope). **New** stays in the Pay strip, not here.

Changes:
- `@features/flow-pay-card-balance`: `appearance` on `ActionTile` is now optional so native tiles can use the default Lumen button style.
- LWM PayTab: wire the action tiles under the hero (view props only), and extract the composition into `usePayTabActionTiles(onTrackEvent)`.
- i18n: add `payTab.actions.deposit` / `payTab.actions.request` labels.

**Validation**
- `@features/flow-pay-card-balance` ActionTiles native tests ✅

### 🖼️ Screenshots
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-14 at 15 30 10" src="https://github.com/user-attachments/assets/786105a3-5605-4aa3-b005-bb9ddf07c242" />



### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34906](https://ledgerhq.atlassian.net/browse/LIVE-34906)
- **Figma**: [Mobile home](https://www.figma.com/design/WYQQwem0QyG2fTuaAKAe3Y/Pay-%E2%80%A2-Production?node-id=7141-35392&m=dev)

[LIVE-34906]: https://ledgerhq.atlassian.net/browse/LIVE-34906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ