### PR TITLE
[LWDM] chore(evm): nft without ledger wallet framework

### DIFF
--- a/.changeset/silly-nfts-migrate.md
+++ b/.changeset/silly-nfts-migrate.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-evm": minor
+"@ledgerhq/live-common": minor
+---
+
+Drive EVM NFT activation from the `supportedTokens` config field instead of `isNFTActive` and the `showNfts` boolean. `EvmConfig.showNfts` is replaced by `supportedTokens: ("erc721" | "erc1155")[]`, so each NFT standard is enabled independently, and coin-evm no longer depends on `@ledgerhq/ledger-wallet-framework/nft`. Activation is checked via explicit standard membership (`supportedTokens.includes("erc721" | "erc1155")`).

--- a/apps/ledger-live-desktop/src/renderer/reducers/__tests__/coinConfigOverrides.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/__tests__/coinConfigOverrides.test.ts
@@ -11,7 +11,7 @@ describe("sanitizePersistedOverrides", () => {
     ["a string", "config_currency_solana"],
     ["a number", 42],
     ["a boolean", true],
-    ["an array", [{ config_currency_solana: { showNfts: false } }]],
+    ["an array", [{ config_currency_solana: { supportedTokens: [] } }]],
   ])("returns null when the persisted payload is %s", (_label, input) => {
     expect(sanitizePersistedOverrides(input)).toBeNull();
   });
@@ -19,7 +19,7 @@ describe("sanitizePersistedOverrides", () => {
   it("returns a fresh map of own enumerable entries when the payload is a plain object", () => {
     const raw = {
       config_currency_solana: { token2022Enabled: true },
-      config_currency_ethereum: { showNfts: false },
+      config_currency_ethereum: { supportedTokens: [] },
     };
 
     const sanitized = sanitizePersistedOverrides(raw);

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/CoinConfigSettings/__integrations__/CoinConfigSettings.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/CoinConfigSettings/__integrations__/CoinConfigSettings.integration.test.tsx
@@ -164,7 +164,7 @@ describe("CoinConfigSettings integration", () => {
   it("clicking Restore all clears every override", async () => {
     const { user, store } = renderSettings({
       [SOLANA_KEY]: { token2022Enabled: true },
-      [ETH_KEY]: { showNfts: false },
+      [ETH_KEY]: { supportedTokens: [] },
     });
 
     await user.click(screen.getByRole("button", { name: /Show/i }));
@@ -189,11 +189,11 @@ describe("CoinConfigSettings integration", () => {
     it("dispatching setCoinConfigOverride flows through the bridge into LiveConfig", async () => {
       const { store } = renderSettings();
 
-      store.dispatch(setCoinConfigOverride({ key: ETH_KEY, value: { showNfts: false } }));
+      store.dispatch(setCoinConfigOverride({ key: ETH_KEY, value: { supportedTokens: [] } }));
 
       await waitFor(() => {
-        const resolved = LiveConfig.getValueByKey(ETH_KEY) as { showNfts: boolean };
-        expect(resolved.showNfts).toBe(false);
+        const resolved = LiveConfig.getValueByKey(ETH_KEY) as { supportedTokens: string[] };
+        expect(resolved.supportedTokens).toEqual([]);
       });
     });
 

--- a/libs/coin-modules/coin-evm/src/api/getBlock.integ.test.ts
+++ b/libs/coin-modules/coin-evm/src/api/getBlock.integ.test.ts
@@ -33,7 +33,7 @@ describe("getBlock ERC20 transfers", () => {
         type: "blockscout",
         uri: "https://evmexplorer.velas.com/api",
       },
-      showNfts: true,
+      supportedTokens: ["erc721", "erc1155"],
     };
 
     beforeAll(() => {
@@ -95,7 +95,7 @@ describe("getBlock ERC20 transfers", () => {
         type: "ledger",
         explorerId: "bnb",
       },
-      showNfts: true,
+      supportedTokens: ["erc721", "erc1155"],
     };
     beforeAll(() => {
       module = createApi("bsc");
@@ -150,7 +150,7 @@ describe("getBlock ERC20 transfers", () => {
       explorer: {
         type: "none",
       },
-      showNfts: true,
+      supportedTokens: ["erc721", "erc1155"],
     };
     beforeAll(() => {
       module = createApi("zksync");

--- a/libs/coin-modules/coin-evm/src/api/index.arc_testnet.integ.test.ts
+++ b/libs/coin-modules/coin-evm/src/api/index.arc_testnet.integ.test.ts
@@ -22,7 +22,6 @@ describe("EVM Api (Arc Testnet)", () => {
       type: "blockscout",
       uri: "https://proxyblockscout.api.live.ledger.com/5042002/api",
     },
-    showNfts: false,
     nativeContracts: [ARC_USDC_NATIVE_CONTRACT],
   };
   beforeAll(async () => {

--- a/libs/coin-modules/coin-evm/src/api/index.fantom.integ.test.ts
+++ b/libs/coin-modules/coin-evm/src/api/index.fantom.integ.test.ts
@@ -18,7 +18,6 @@ describe("Fantom (etherscan explorer)", () => {
         type: "blockscout",
         uri: "https://ftmscout.com/api",
       },
-      showNfts: false,
     };
     beforeAll(() => {
       module = createApi("fantom");

--- a/libs/coin-modules/coin-evm/src/api/index.flare.integ.test.ts
+++ b/libs/coin-modules/coin-evm/src/api/index.flare.integ.test.ts
@@ -17,7 +17,6 @@ describe("Flare (external node)", () => {
         type: "blockscout",
         uri: "https://I.AM.FAILING", // so that internal txs cannot be retrieved from explorer
       },
-      showNfts: false,
     };
     beforeAll(() => {
       module = createApi("flare");

--- a/libs/coin-modules/coin-evm/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-evm/src/api/index.integ.test.ts
@@ -6,7 +6,7 @@ import {
   StakingTransactionIntent,
 } from "@ledgerhq/coin-module-framework/api/types";
 import { ethers } from "ethers";
-import { EvmConfig, EvmConfigInfo, NftStandard } from "../config";
+import { EvmConfig, EvmConfigInfo } from "../config";
 import { createMockEvmContext } from "../fixtures/context.fixtures";
 import { createApi } from "./index";
 
@@ -680,6 +680,8 @@ describe.each([
       });
 
       it("Spoofed NFT transfer through smart contract", async () => {
+        process.env.NFT_CURRENCIES = JSON.stringify(["ethereum"]);
+
         const txHash = "0x61adea29cbf2e50f9ab975636af9a624620589c2cca9b8dc82ccccaefeb9c6ad";
         const blockHeight = 21348730;
         const caller = "0x6b2ae7cc19eda092476f32cced9311da568a823c";

--- a/libs/coin-modules/coin-evm/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-evm/src/api/index.integ.test.ts
@@ -6,7 +6,7 @@ import {
   StakingTransactionIntent,
 } from "@ledgerhq/coin-module-framework/api/types";
 import { ethers } from "ethers";
-import { EvmConfig, EvmConfigInfo } from "../config";
+import { EvmConfig, EvmConfigInfo, NftStandard } from "../config";
 import { createMockEvmContext } from "../fixtures/context.fixtures";
 import { createApi } from "./index";
 
@@ -19,7 +19,7 @@ describe.each([
         type: "etherscan",
         uri: "https://proxyetherscan.api.live.ledger.com/v2/api/1",
       },
-      showNfts: true,
+      supportedTokens: ["erc721", "erc1155"],
     },
   ],
   [
@@ -30,7 +30,7 @@ describe.each([
         type: "ledger",
         explorerId: "eth",
       },
-      showNfts: true,
+      supportedTokens: ["erc721", "erc1155"],
     },
   ],
 ])("EVM Api (%s)", (_, config) => {
@@ -38,7 +38,6 @@ describe.each([
   // The logic layer resolves config from the threaded context (ADR-019), so the context must
   // carry this suite's node/explorer config — not the empty default fixture.
   const context = createMockEvmContext(config as Partial<EvmConfigInfo>);
-
   beforeAll(() => {
     module = createApi("ethereum");
   });
@@ -530,7 +529,13 @@ describe.each([
       const expectAddressEq = (actual: string, expected: string) =>
         expect(actual.toLowerCase()).toBe(expected.toLowerCase());
 
+      beforeEach(() => {
+        process.env.NFT_CURRENCIES = JSON.stringify([]);
+      });
+
       it("simple native transfer between EOAs", async () => {
+        process.env.NFT_CURRENCIES = JSON.stringify(["ethereum"]);
+
         const txHash = "0x9f555da0bb8d9ff99ced6db6e5f966699f8df849f4887c80ed44ffb101f7d252";
         const blockHeight = 24600494;
         const sender = "0x12644b85A2F20F39Ade7543FBA1C0C9DFE289580";
@@ -788,7 +793,7 @@ describe("EVM Api: external node and explorer ONLY", () => {
       type: "etherscan",
       uri: "https://proxyetherscan.api.live.ledger.com/v2/api/1",
     },
-    showNfts: true,
+    supportedTokens: ["erc721", "erc1155"],
   } as EvmConfig;
   const context = createMockEvmContext(config);
 
@@ -877,7 +882,6 @@ describe("EVM Api (Moonbeam Network)", () => {
       type: "etherscan",
       uri: "https://proxyetherscan.api.live.ledger.com/v2/api/1284",
     },
-    showNfts: false,
   } as EvmConfig;
   const context = createMockEvmContext(config);
 

--- a/libs/coin-modules/coin-evm/src/api/index.linea.integ.test.ts
+++ b/libs/coin-modules/coin-evm/src/api/index.linea.integ.test.ts
@@ -33,7 +33,6 @@ describe("Linea (etherscan explorer)", () => {
         type: "etherscan",
         uri: "https://proxyetherscan.api.live.ledger.com/v2/api/59144",
       },
-      showNfts: false,
     };
 
     beforeAll(() => {

--- a/libs/coin-modules/coin-evm/src/api/index.monad_testnet.integ.test.ts
+++ b/libs/coin-modules/coin-evm/src/api/index.monad_testnet.integ.test.ts
@@ -11,7 +11,6 @@ describe("EVM Api (Monad Testnet)", () => {
       type: "etherscan",
       uri: "https://proxyetherscan.api.live.ledger.com/v2/api/10143",
     },
-    showNfts: false,
   };
   beforeAll(() => {
     module = createApi("monad_testnet");

--- a/libs/coin-modules/coin-evm/src/api/index.shape.integ.test.ts
+++ b/libs/coin-modules/coin-evm/src/api/index.shape.integ.test.ts
@@ -16,7 +16,7 @@ describe("Shape (external node)", () => {
         type: "blockscout",
         uri: "https://shapescan.xyz/api",
       },
-      showNfts: true,
+      supportedTokens: ["erc721", "erc1155"],
     };
     const module = createApi("shape");
 

--- a/libs/coin-modules/coin-evm/src/config.ts
+++ b/libs/coin-modules/coin-evm/src/config.ts
@@ -15,6 +15,8 @@ export {
  */
 export type BlockFinalizationTag = "latest" | "safe" | "finalized";
 
+export type NftStandard = "erc721" | "erc1155";
+
 /** Fallbacks mirroring the `EXPLORER` / `EIP1559_BASE_FEE_MULTIPLIER` env defaults. */
 export const DEFAULT_LEDGER_EXPLORER_URI = "https://explorers.api.live.ledger.com";
 export const DEFAULT_EIP1559_BASE_FEE_MULTIPLIER = 1.6;
@@ -63,7 +65,12 @@ export type EvmConfig = {
     type: "ledger";
     explorerId: LedgerExplorerId;
   };
-  showNfts: boolean;
+  /**
+   * NFT token standards to surface for this chain. Each standard is independent: an empty
+   * array (or a standard being absent) disables the corresponding NFT operations. Replaces
+   * the deprecated `showNfts` boolean and the `isNFTActive` env gate.
+   */
+  supportedTokens?: NftStandard[];
   /**
    * The block tag used to fetch the latest block. Defaults to "latest" if not set.
    * Use "safe" or "finalized" on chains where reorg protection is needed.

--- a/libs/coin-modules/coin-evm/src/network/explorer/etherscan.test.ts
+++ b/libs/coin-modules/coin-evm/src/network/explorer/etherscan.test.ts
@@ -75,7 +75,7 @@ describe("EVM Family", () => {
             type: "external",
             uri: "mock",
           },
-          showNfts: true,
+          supportedTokens: ["erc721", "erc1155"],
         },
       };
     });
@@ -615,7 +615,7 @@ describe("EVM Family", () => {
           info: {
             explorer: { type: "etherscan", uri: "mock" },
             node: { type: "external", uri: "mock" },
-            showNfts: true,
+            supportedTokens: ["erc721", "erc1155"],
             ...info,
           },
         }));
@@ -1595,7 +1595,7 @@ describe("EVM Family", () => {
         info: {
           explorer: { type: "etherscan", uri: "https://api.etherscan.io" },
           node: { type: "external", uri: "mock" },
-          showNfts: true,
+          supportedTokens: ["erc721", "erc1155"],
         },
       }));
       const axiosSpy = jest.spyOn(axios, "request").mockResolvedValueOnce({
@@ -1629,7 +1629,7 @@ describe("EVM Family", () => {
         info: {
           explorer: { type: "blockscout", uri: "https://blockscout.com/api" },
           node: { type: "external", uri: "mock" },
-          showNfts: true,
+          supportedTokens: ["erc721", "erc1155"],
         },
       }));
       const axiosSpy = jest.spyOn(axios, "request").mockResolvedValueOnce({
@@ -1663,7 +1663,7 @@ describe("EVM Family", () => {
         info: {
           explorer,
           node: { type: "external", uri: "mock" },
-          showNfts: true,
+          supportedTokens: ["erc721", "erc1155"],
         },
       }));
 
@@ -1681,7 +1681,7 @@ describe("EVM Family", () => {
         info: {
           explorer: { type: "etherscan", uri: "https://api.etherscan.io" },
           node: { type: "external", uri: "mock" },
-          showNfts: true,
+          supportedTokens: ["erc721", "erc1155"],
         },
       }));
       jest.spyOn(axios, "request").mockResolvedValueOnce({
@@ -1701,7 +1701,7 @@ describe("EVM Family", () => {
         info: {
           explorer: { type: "blockscout", uri: "https://blockscout.com/api" },
           node: { type: "external", uri: "mock" },
-          showNfts: true,
+          supportedTokens: ["erc721", "erc1155"],
         },
       }));
       jest.spyOn(axios, "request").mockResolvedValueOnce({
@@ -1722,7 +1722,7 @@ describe("EVM Family", () => {
         info: {
           explorer: { type: "etherscan", uri: "https://api.etherscan.io" },
           node: { type: "external", uri: "mock" },
-          showNfts: true,
+          supportedTokens: ["erc721", "erc1155"],
         },
       }));
 
@@ -1777,7 +1777,7 @@ describe("EVM Family", () => {
         info: {
           explorer: { type: "etherscan", uri: "https://api.etherscan.io" },
           node: { type: "external", uri: "mock" },
-          showNfts: true,
+          supportedTokens: ["erc721", "erc1155"],
         },
       }));
       jest.mocked(axios.request).mockReset();
@@ -1802,7 +1802,6 @@ describe("EVM Family", () => {
               type: "external",
               uri: "mock",
             },
-            showNfts: false,
           },
         };
       });
@@ -1822,6 +1821,87 @@ describe("EVM Family", () => {
         boundBlock: 0,
         isPageFull: false,
       });
+    });
+  });
+
+  describe("getNftOperations supportedTokens atomicity", () => {
+    const withSupportedTokens = (supportedTokens: ("erc721" | "erc1155")[]) => {
+      mockGetConfig.mockImplementation((): any => ({
+        info: {
+          explorer: { type: "etherscan", uri: "mock" },
+          node: { type: "external", uri: "mock" },
+          supportedTokens,
+        },
+      }));
+    };
+
+    // ERC721 ops are fetched from the `tokennfttx` endpoint, ERC1155 ops from `token1155tx`.
+    const fetchNfts = async () => {
+      const requestSpy = jest.spyOn(axios, "request").mockImplementation(async params => ({
+        data: {
+          result: params.url?.includes("tokennfttx")
+            ? etherscanERC721Operations
+            : etherscanERC1155Operations,
+        },
+      }));
+      // Drop call history from previous tests so `requestedUrls` reflects only this invocation.
+      requestSpy.mockClear();
+      const response = await ETHERSCAN_API.getNftOperations({
+        currencyId,
+        config: getCoinConfig(currencyId).info,
+        address: "0x6cBCD73CD8e8a42844662f0A0e76D7F79Afd933d",
+        fromBlock: 0,
+        sort: "desc",
+      });
+      const requestedUrls = requestSpy.mock.calls.map(([{ url }]) => url ?? "");
+      return {
+        assetTypes: new Set(response.operations.map(op => op.asset.type)),
+        fetchedErc721: requestedUrls.some(url => url.includes("tokennfttx")),
+        fetchedErc1155: requestedUrls.some(url => url.includes("token1155tx")),
+      };
+    };
+
+    it("fetches only ERC721 operations (and skips the ERC1155 endpoint) when only erc721 is supported", async () => {
+      withSupportedTokens(["erc721"]);
+      const { assetTypes, fetchedErc721, fetchedErc1155 } = await fetchNfts();
+      expect(assetTypes).toEqual(new Set(["erc721"]));
+      expect(fetchedErc721).toBe(true);
+      expect(fetchedErc1155).toBe(false);
+    });
+
+    it("fetches only ERC1155 operations (and skips the ERC721 endpoint) when only erc1155 is supported", async () => {
+      withSupportedTokens(["erc1155"]);
+      const { assetTypes, fetchedErc721, fetchedErc1155 } = await fetchNfts();
+      expect(assetTypes).toEqual(new Set(["erc1155"]));
+      expect(fetchedErc721).toBe(false);
+      expect(fetchedErc1155).toBe(true);
+    });
+
+    it("fetches both standards when both are supported", async () => {
+      withSupportedTokens(["erc721", "erc1155"]);
+      const { assetTypes, fetchedErc721, fetchedErc1155 } = await fetchNfts();
+      expect(assetTypes).toEqual(new Set(["erc721", "erc1155"]));
+      expect(fetchedErc721).toBe(true);
+      expect(fetchedErc1155).toBe(true);
+    });
+
+    it("fetches neither endpoint when supportedTokens is empty", async () => {
+      withSupportedTokens([]);
+      const { assetTypes, fetchedErc721, fetchedErc1155 } = await fetchNfts();
+      expect(assetTypes).toEqual(new Set());
+      expect(fetchedErc721).toBe(false);
+      expect(fetchedErc1155).toBe(false);
+    });
+
+    // Guards against the fragile `supportedTokens.length === 0` proxy: a non-empty array holding
+    // only non-NFT standards (e.g. a future "erc20") must NOT activate NFT fetching. Activation is
+    // driven by explicit NFT-standard membership, not by the array being non-empty.
+    it("does not activate NFTs for a non-NFT standard such as erc20", async () => {
+      withSupportedTokens(["erc20"] as unknown as ("erc721" | "erc1155")[]);
+      const { assetTypes, fetchedErc721, fetchedErc1155 } = await fetchNfts();
+      expect(assetTypes).toEqual(new Set());
+      expect(fetchedErc721).toBe(false);
+      expect(fetchedErc1155).toBe(false);
     });
   });
 

--- a/libs/coin-modules/coin-evm/src/network/explorer/etherscan.ts
+++ b/libs/coin-modules/coin-evm/src/network/explorer/etherscan.ts
@@ -1,4 +1,3 @@
-import { isNFTActive } from "@ledgerhq/ledger-wallet-framework/nft/support";
 import type { MemoNotSupported, Operation } from "@ledgerhq/coin-module-framework/api/types";
 import { makeLRUCache } from "@ledgerhq/live-network/cache";
 import { delay } from "@ledgerhq/coin-module-framework/promises";
@@ -30,6 +29,7 @@ import { enrichRewardOperationsValue } from "../../staking/rewardsFromReceipt";
 import { withApi } from "../node/rpc.common";
 import { isExternalNodeConfig } from "../node/types";
 import { ExplorerApi, isEtherscanLikeExplorerConfig } from "./types";
+import { nftDisabled } from "../../utils";
 
 export const ETHERSCAN_TIMEOUT = 5000; // 5 seconds between 2 calls
 export const DEFAULT_RETRIES_API = 8;
@@ -471,12 +471,14 @@ export const getERC1155Operations = async (
  */
 export const getNftOperations = async (params: FetchOperationsParams): Promise<EndpointResult> => {
   const { config } = params;
-  if (!config.showNfts) {
+  const supportsErc721 = config.supportedTokens?.includes("erc721");
+  const supportsErc1155 = config.supportedTokens?.includes("erc1155");
+  if (!supportsErc721 && !supportsErc1155) {
     return EMPTY_RESULT;
   }
 
-  const erc721Result = await getERC721Operations(params);
-  const erc1155Result = await getERC1155Operations(params);
+  const erc721Result = supportsErc721 ? await getERC721Operations(params) : EMPTY_RESULT;
+  const erc1155Result = supportsErc1155 ? await getERC1155Operations(params) : EMPTY_RESULT;
 
   const sort = params.sort;
   const operations = [...erc721Result.operations, ...erc1155Result.operations].sort(
@@ -800,10 +802,12 @@ export const getOperations = makeLRUCache<
         pagingState?.tokenIsDone,
       );
 
+      const nftUnsupported =
+        !config.supportedTokens?.includes("erc721") && !config.supportedTokens?.includes("erc1155");
       const nfts = await callEndpoint(
         getNftOperations,
         tokens.effectiveBoundBlock,
-        !isNFTActive(currencyId) || pagingState?.nftIsDone,
+        nftUnsupported || nftDisabled(currencyId) || pagingState?.nftIsDone,
       );
 
       const effectiveBoundBlock = nfts.effectiveBoundBlock;

--- a/libs/coin-modules/coin-evm/src/network/explorer/ledger.test.ts
+++ b/libs/coin-modules/coin-evm/src/network/explorer/ledger.test.ts
@@ -2,7 +2,7 @@ import { AssertionError, fail } from "assert";
 import { delay } from "@ledgerhq/coin-module-framework/promises";
 import axios from "axios";
 import eip55 from "eip55";
-import { DEFAULT_LEDGER_EXPLORER_URI, getCoinConfig } from "../../config";
+import { DEFAULT_LEDGER_EXPLORER_URI, getCoinConfig, NftStandard } from "../../config";
 import { LedgerExplorerUsedIncorrectly } from "../../errors";
 import {
   coinOperation1,
@@ -31,7 +31,7 @@ describe("EVM Family", () => {
               type: "ledger",
               explorerId: "eth",
             },
-            showNfts: true,
+            supportedTokens: ["erc721", "erc1155"],
           },
         };
       });
@@ -203,7 +203,7 @@ describe("EVM Family", () => {
             status: { type: "active" },
             node: { type: "ledger", explorerId: "matic" },
             explorer: { type: "ledger", explorerId: "matic", batchSize: configuredBatchSize },
-            showNfts: true,
+            supportedTokens: ["erc721", "erc1155"],
           },
         }));
         const request = jest.spyOn(axios, "request").mockResolvedValue({ data: { data: [] } });
@@ -223,6 +223,8 @@ describe("EVM Family", () => {
       });
 
       it("should return the different operation types", async () => {
+        process.env.NFT_CURRENCIES = JSON.stringify(["ethereum"]);
+
         jest.spyOn(axios, "request").mockImplementation(async () => ({
           data: { data: [coinOperation1, coinOperation2, coinOperation3, coinOperation4] },
         }));
@@ -439,7 +441,6 @@ describe("EVM Family", () => {
                   type: "ledger",
                   explorerId: "eth",
                 },
-                showNfts: false,
               },
             };
           });
@@ -460,6 +461,57 @@ describe("EVM Family", () => {
         });
       });
 
+      describe("supportedTokens atomicity", () => {
+        beforeEach(() => {
+          jest.resetAllMocks();
+
+          jest.spyOn(axios, "request").mockImplementation(async () => ({
+            data: { data: [coinOperation1, coinOperation2, coinOperation3, coinOperation4] },
+          }));
+        });
+
+        const mockConfigWithTokens = (supportedTokens: NftStandard[]) =>
+          mockGetConfig.mockImplementation((): any => ({
+            info: {
+              explorer: { type: "ledger", explorerId: "eth" },
+              supportedTokens,
+            },
+          }));
+
+        const fetchNftAssetTypes = async () => {
+          const response = await LEDGER_API.getOperations(
+            getCoinConfig("ethereum").info,
+            "ethereum",
+            "0x6cBCD73CD8e8a42844662f0A0e76D7F79Afd933d",
+            0,
+          );
+
+          return new Set(response.lastNftOperations.map(op => op.asset.type));
+        };
+
+        // The fixtures carry both an ERC721 transfer (coinOperation2) and ERC1155 transfers
+        // (coinOperation3), so each standard can be asserted independently.
+        it("surfaces only ERC721 operations when only erc721 is supported", async () => {
+          mockConfigWithTokens(["erc721"]);
+          expect(await fetchNftAssetTypes()).toEqual(new Set(["erc721"]));
+        });
+
+        it("surfaces only ERC1155 operations when only erc1155 is supported", async () => {
+          mockConfigWithTokens(["erc1155"]);
+          expect(await fetchNftAssetTypes()).toEqual(new Set(["erc1155"]));
+        });
+
+        it("surfaces both standards when both are supported", async () => {
+          mockConfigWithTokens(["erc721", "erc1155"]);
+          expect(await fetchNftAssetTypes()).toEqual(new Set(["erc721", "erc1155"]));
+        });
+
+        it("surfaces no NFT operations when supportedTokens is empty", async () => {
+          mockConfigWithTokens([]);
+          expect(await fetchNftAssetTypes()).toEqual(new Set());
+        });
+      });
+
       describe("nativeContracts filter", () => {
         // coinOperation1.transfer_events[0].contract — the only ERC20 event in the fixtures.
         const FIXTURE_CONTRACT = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
@@ -468,7 +520,7 @@ describe("EVM Family", () => {
           mockGetConfig.mockImplementation((): any => ({
             info: {
               explorer: { type: "ledger", explorerId: "eth" },
-              showNfts: true,
+              supportedTokens: ["erc721", "erc1155"],
               ...info,
             },
           }));

--- a/libs/coin-modules/coin-evm/src/network/explorer/ledger.test.ts
+++ b/libs/coin-modules/coin-evm/src/network/explorer/ledger.test.ts
@@ -164,6 +164,10 @@ describe("EVM Family", () => {
     });
 
     describe("getOperations", () => {
+      beforeEach(() => {
+        process.env.NFT_CURRENCIES = JSON.stringify([]);
+      });
+
       it("should throw if the explorer is misconfigured", async () => {
         mockGetConfig.mockImplementationOnce((): any => {
           return {

--- a/libs/coin-modules/coin-evm/src/network/explorer/ledger.test.ts
+++ b/libs/coin-modules/coin-evm/src/network/explorer/ledger.test.ts
@@ -472,6 +472,12 @@ describe("EVM Family", () => {
           jest.spyOn(axios, "request").mockImplementation(async () => ({
             data: { data: [coinOperation1, coinOperation2, coinOperation3, coinOperation4] },
           }));
+
+          process.env.NFT_CURRENCIES = JSON.stringify(["ethereum"]);
+        });
+
+        afterAll(() => {
+          process.env.NFT_CURRENCIES = JSON.stringify([]);
         });
 
         const mockConfigWithTokens = (supportedTokens: NftStandard[]) =>

--- a/libs/coin-modules/coin-evm/src/network/explorer/ledger.ts
+++ b/libs/coin-modules/coin-evm/src/network/explorer/ledger.ts
@@ -1,5 +1,4 @@
 import type { MemoNotSupported, Operation } from "@ledgerhq/coin-module-framework/api/types";
-import { isNFTActive } from "@ledgerhq/ledger-wallet-framework/nft/support";
 import { delay } from "@ledgerhq/coin-module-framework/promises";
 import axios from "axios";
 import {
@@ -13,6 +12,7 @@ import { DEFAULT_LEDGER_EXPLORER_URI } from "../../config";
 import { LedgerExplorerUsedIncorrectly } from "../../errors";
 import { LedgerExplorerOperation } from "../../types";
 import { ExplorerApi, isLedgerExplorerConfig, NO_TOKEN } from "./types";
+import { nftEnabled } from "../../utils";
 
 export const DEFAULT_BATCH_SIZE = 10_000;
 export const LEDGER_TIMEOUT = 200; // 200ms between 2 calls
@@ -132,13 +132,13 @@ export const getOperations: ExplorerApi["getOperations"] = async (
       ledgerERC20EventToOperations(address, coinOps[0], event, index),
     );
     const erc721Ops =
-      isNFTActive(currencyId) && config.showNfts
+      nftEnabled(currencyId) && config.supportedTokens?.includes("erc721")
         ? ledgerOp.erc721_transfer_events.flatMap((event, index) =>
             ledgerERC721EventToOperations(address, coinOps[0], event, index),
           )
         : [];
     const erc1155Ops =
-      isNFTActive(currencyId) && config.showNfts
+      nftEnabled(currencyId) && config.supportedTokens?.includes("erc1155")
         ? ledgerOp.erc1155_transfer_events.flatMap((event, index) =>
             ledgerERC1155EventToOperations(address, coinOps[0], event, index),
           )

--- a/libs/coin-modules/coin-evm/src/utils.test.ts
+++ b/libs/coin-modules/coin-evm/src/utils.test.ts
@@ -1,6 +1,8 @@
 import {
   buildSmartContractDetails,
   isSmartContractInput,
+  nftDisabled,
+  nftEnabled,
   parseDecimalIntegerPart,
   safeEncodeEIP55,
 } from "./utils";
@@ -82,4 +84,88 @@ describe("parseDecimalIntegerPart", () => {
       expect(parseDecimalIntegerPart(input)).toBe(0n);
     },
   );
+});
+
+describe("nftEnabled", () => {
+  beforeEach(() => {
+    process.env.NFT_CURRENCIES = JSON.stringify([]);
+  });
+
+  it("should return false when currency is null or undefined", () => {
+    expect(nftEnabled(null)).toEqual(false);
+    expect(nftEnabled(undefined)).toEqual(false);
+  });
+
+  it("should return false when NFT_CURRENCIES env does not include currency", () => {
+    process.env.NFT_CURRENCIES = JSON.stringify(["base", "polygon"]);
+    expect(nftEnabled("ethereum")).toEqual(false);
+  });
+
+  it("should return true when NFT_CURRENCIES env include currency", () => {
+    process.env.NFT_CURRENCIES = JSON.stringify(["base", "ethereum", "polygon"]);
+    expect(nftEnabled("ethereum")).toEqual(true);
+  });
+
+  it.each([
+    "",
+    "word",
+    "a simple sentence",
+    "0x66c4371aE8FFeD2ec1c2EBbbcCfb7E494181E1E3",
+    "[]}",
+    "{ [] }",
+  ])("should return false when NFT_CURRENCIES is not a valid JSON (%s)", value => {
+    process.env.NFT_CURRENCIES = value;
+    expect(nftEnabled("ethereum")).toEqual(false);
+  });
+
+  it("should return false when NFT_CURRENCIES is not an array", () => {
+    // A new config not supported for example (feature flag like)
+    process.env.NFT_CURRENCIES = JSON.stringify({
+      enabled: true,
+      params: { families: ["ethereum"] },
+    });
+    expect(nftEnabled("ethereum")).toBe(false);
+  });
+});
+
+describe("nftDisabled", () => {
+  beforeEach(() => {
+    process.env.NFT_CURRENCIES = JSON.stringify([]);
+  });
+
+  it("should return false when currency is null or undefined", () => {
+    expect(nftDisabled(null)).toEqual(true);
+    expect(nftDisabled(undefined)).toEqual(true);
+  });
+
+  it("should return true when NFT_CURRENCIES env does not include currency", () => {
+    process.env.NFT_CURRENCIES = JSON.stringify(["base", "polygon"]);
+    expect(nftDisabled("ethereum")).toEqual(true);
+  });
+
+  it("should return false when NFT_CURRENCIES env include currency", () => {
+    process.env.NFT_CURRENCIES = JSON.stringify(["base", "ethereum", "polygon"]);
+    expect(nftDisabled("ethereum")).toEqual(false);
+  });
+
+  it.each([
+    "",
+    "word",
+    "a simple sentence",
+    "0x66c4371aE8FFeD2ec1c2EBbbcCfb7E494181E1E3",
+    "[]}",
+    "{ [] }",
+  ])("should return true when NFT_CURRENCIES is not a valid JSON (%s)", value => {
+    process.env.NFT_CURRENCIES = value;
+    expect(nftDisabled("ethereum")).toEqual(true);
+  });
+
+  it("should return true when NFT_CURRENCIES is not an array", () => {
+    // A new config not supported for example (feature flag like)
+    process.env.NFT_CURRENCIES = JSON.stringify({
+      enabled: true,
+      params: { families: ["ethereum"] },
+    });
+    expect(nftDisabled("ethereum")).toBe(true);
+  });
 });

--- a/libs/coin-modules/coin-evm/src/utils.ts
+++ b/libs/coin-modules/coin-evm/src/utils.ts
@@ -368,3 +368,44 @@ export type EvmStakingIntent = StakingTransactionIntent & {
 export function isStakingIntent(intent: TransactionIntent): intent is EvmStakingIntent {
   return intent.intentType === "staking";
 }
+
+export function nftEnabled(currencyId: string | undefined | null): boolean {
+  let parsedNftCurrencies: unknown = undefined;
+  if (process.env.NFT_CURRENCIES) {
+    try {
+      parsedNftCurrencies = JSON.parse(process.env.NFT_CURRENCIES);
+    } catch (error) {
+      log(
+        "EVM Family - utils.ts",
+        "Env variable NFT_CURRENCIES is malformed, expecting a string array",
+        {
+          envName: "NFT_CURRENCIES",
+          envValue: process.env.NFT_CURRENCIES,
+          error,
+        },
+      );
+
+      return false;
+    }
+  }
+
+  if (!Array.isArray(parsedNftCurrencies)) {
+    log(
+      "EVM Family - utils.ts",
+      "Env variable NFT_CURRENCIES is malformed, expecting a string array",
+      {
+        envName: "NFT_CURRENCIES",
+        envValue: process.env.NFT_CURRENCIES,
+      },
+    );
+
+    return false;
+  }
+
+  return Boolean(currencyId && parsedNftCurrencies.includes(currencyId));
+}
+
+// Simple utility function, to ease reading code
+export function nftDisabled(currencyId: string | undefined | null): boolean {
+  return !nftEnabled(currencyId);
+}

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/arc_testnet.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/arc_testnet.ts
@@ -60,7 +60,6 @@ export const scenarioArcTestnetNative: Scenario<GenericTransaction, Account> = {
       name: "Arc Testnet",
       node: { type: "external", uri: "http://127.0.0.1:8545" },
       explorer: { type: "blockscout", noCache: true, uri: ARC_TESTNET_EXPLORER },
-      showNfts: false,
       nativeContracts: [ARC_USDC_NATIVE_CONTRACT],
     };
 

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/base.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/base.ts
@@ -78,7 +78,7 @@ export const scenarioBase: Scenario<GenericTransaction, Account> = {
         noCache: true,
         uri: "https://proxyetherscan.api.live.ledger.com/v2/api/8453",
       },
-      showNfts: true,
+      supportedTokens: ["erc721", "erc1155"],
     };
     LiveConfig.setConfig({
       config_currency_base: {

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/blast.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/blast.ts
@@ -103,7 +103,7 @@ export const scenarioBlast: Scenario<GenericTransaction, Account> = {
         noCache: true,
         uri: "https://proxyetherscan.api.live.ledger.com/v2/api/81457",
       },
-      showNfts: true,
+      supportedTokens: ["erc721", "erc1155"],
     };
     LiveConfig.setConfig({
       config_currency_blast: {

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/bnb.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/bnb.ts
@@ -107,7 +107,7 @@ export const scenarioBnb: Scenario<GenericTransaction, Account> = {
         type: "ledger",
         explorerId: "bnb",
       },
-      showNfts: true,
+      supportedTokens: ["erc721", "erc1155"],
     };
     LiveConfig.setConfig({
       config_currency_bsc: {

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/core.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/core.ts
@@ -99,7 +99,7 @@ export const scenarioCore: Scenario<GenericTransaction, Account> = {
       explorer: {
         type: "none",
       },
-      showNfts: true,
+      supportedTokens: ["erc721", "erc1155"],
     };
     LiveConfig.setConfig({
       config_currency_core: {

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/ethereum.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/ethereum.ts
@@ -105,7 +105,7 @@ export const scenarioEthereum: Scenario<GenericTransaction, Account> = {
         type: "ledger",
         explorerId: "eth",
       },
-      showNfts: true,
+      supportedTokens: ["erc721", "erc1155"],
     };
     LiveConfig.setConfig({
       config_currency_ethereum: {

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/polygon.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/polygon.ts
@@ -108,7 +108,7 @@ export const scenarioPolygon: Scenario<GenericTransaction, Account> = {
         type: "ledger",
         explorerId: "matic",
       },
-      showNfts: true,
+      supportedTokens: ["erc721", "erc1155"],
     };
     LiveConfig.setConfig({
       config_currency_polygon: {

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/robinhood_testnet.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/robinhood_testnet.ts
@@ -27,7 +27,6 @@ export const scenarioRobinhoodTestnet: Scenario<GenericTransaction, Account> = {
       name: "Robinhood Chain Testnet",
       node: { type: "external", uri: "http://127.0.0.1:8545" },
       explorer: { type: "none" },
-      showNfts: false,
     };
     LiveConfig.setConfig({
       config_currency_robinhood_testnet: {

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/scroll.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/scroll.ts
@@ -108,7 +108,7 @@ export const scenarioScroll: Scenario<GenericTransaction, Account> = {
         noCache: true,
         uri: "https://scroll.blockscout.com/api",
       },
-      showNfts: true,
+      supportedTokens: ["erc721", "erc1155"],
     };
     LiveConfig.setConfig({
       config_currency_scroll: {

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/sonic.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/sonic.ts
@@ -96,7 +96,7 @@ export const scenarioSonic: Scenario<GenericTransaction, Account> = {
         noCache: true,
         uri: "https://proxyetherscan.api.live.ledger.com/v2/api/146",
       },
-      showNfts: true,
+      supportedTokens: ["erc721", "erc1155"],
     };
     LiveConfig.setConfig({
       config_currency_sonic: {

--- a/libs/ledger-live-common/src/DataModel.test.ts
+++ b/libs/ledger-live-common/src/DataModel.test.ts
@@ -139,31 +139,33 @@ describe("DataModel", () => {
     expect(migratedAptosAccountRaw.id).toBeDefined();
   });
 
-  describe("test for shownNfts true", () => {
-    beforeAll(() => {
-      (getCurrencyConfiguration as jest.Mock).mockReturnValue({
-        showNfts: true,
-      });
-    });
+  describe("evm NFT operation stripping is driven by supportedTokens", () => {
+    // evmAccount has two operations; op_evm_002 carries `nftOperations`. The migration keeps it
+    // only when NFTs are active for the currency, i.e. when a supported NFT standard is present.
+    const setSupportedTokens = (supportedTokens: ("erc721" | "erc1155")[]) => {
+      (getCurrencyConfiguration as jest.Mock).mockReturnValue({ supportedTokens });
+    };
 
-    test("evm account", async () => {
+    const decodeEvmOperations = async () => {
       const data = await createDataModel(schema).decode(evmAccount);
-      const account = data.at(0) as Account;
-      expect(account.id).toBeDefined();
-    });
-  });
+      return (data.at(0) as Account).operations;
+    };
 
-  describe("test for shownNfts false", () => {
-    beforeAll(() => {
-      (getCurrencyConfiguration as jest.Mock).mockReturnValue({
-        showNfts: false,
-      });
-    });
+    it.each([[["erc721"]], [["erc1155"]], [["erc721", "erc1155"]]] as [("erc721" | "erc1155")[]][])(
+      "keeps NFT-bearing operations when supportedTokens is %j",
+      async supportedTokens => {
+        setSupportedTokens(supportedTokens);
+        const operations = await decodeEvmOperations();
+        expect(operations).toHaveLength(2);
+        expect(operations.some(op => "nftOperations" in op)).toBe(true);
+      },
+    );
 
-    test("evm account", async () => {
-      const data = await createDataModel(schema).decode(evmAccount);
-      const account = data.at(0) as Account;
-      expect(account.id).toBeDefined();
+    it("strips NFT-bearing operations when supportedTokens is empty", async () => {
+      setSupportedTokens([]);
+      const operations = await decodeEvmOperations();
+      expect(operations).toHaveLength(1);
+      expect(operations.some(op => "nftOperations" in op)).toBe(false);
     });
   });
 });

--- a/libs/ledger-live-common/src/DataModel.ts
+++ b/libs/ledger-live-common/src/DataModel.ts
@@ -1,4 +1,5 @@
 import { getCurrencyConfiguration } from "./config";
+import type { EvmConfigInfo } from "@ledgerhq/coin-evm/config";
 import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
 
 /**
@@ -45,8 +46,13 @@ export function createDataModel<R, M>(schema: DataSchema<R, M>): DataModel<R, M>
     let { data } = raw;
     const { currencyId } = data;
     const currency = findCryptoCurrencyById(currencyId);
-    if (currency && currency.family == "evm" && !getCurrencyConfiguration(currency.id).showNfts) {
-      if (Array.isArray(data.operations)) {
+    if (currency && currency.family == "evm") {
+      const supportedTokens =
+        getCurrencyConfiguration<EvmConfigInfo>(currency.id).supportedTokens ?? [];
+      const nftUnsupported =
+        !supportedTokens ||
+        (!supportedTokens.includes("erc721") && !supportedTokens.includes("erc1155"));
+      if (nftUnsupported && Array.isArray(data.operations)) {
         data.operations = data.operations.filter(tx => !("nftOperations" in tx));
       }
     }

--- a/libs/ledger-live-common/src/families/evm/config.test.ts
+++ b/libs/ledger-live-common/src/families/evm/config.test.ts
@@ -94,7 +94,6 @@ describe("evmConfig", () => {
 
     // polygon pins its own minGasPrice.
     expect(getCurrencyConfiguration("polygon")).toMatchObject({
-      showNfts: false,
       minGasPrice: "25000000000",
       ledgerExplorerUri: "http://some-random-url.url",
       ledgerClientVersion: "4.0",

--- a/libs/ledger-live-common/src/families/evm/config.ts
+++ b/libs/ledger-live-common/src/families/evm/config.ts
@@ -60,7 +60,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       },
       chainId: 200625,
       name: "Akroma",
-      showNfts: false,
     },
   },
   config_currency_atheios: {
@@ -72,7 +71,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       },
       chainId: 1620,
       name: "Atheios",
-      showNfts: false,
     },
   },
   config_currency_avalanche_c_chain: {
@@ -96,7 +94,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "ledger",
         explorerId: "avax",
       },
-      showNfts: false,
     },
   },
   config_currency_avalanche_c_chain_fuji: {
@@ -116,7 +113,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "etherscan",
         uri: "https://proxyetherscan.api.live.ledger.com/v2/api/43113",
       },
-      showNfts: false,
     },
   },
   config_currency_bitlayer: {
@@ -135,7 +131,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       explorer: {
         type: "none",
       },
-      showNfts: false,
     },
   },
   config_currency_bsc: {
@@ -159,7 +154,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "ledger",
         explorerId: "bnb",
       },
-      showNfts: false,
     },
   },
   config_currency_callisto: {
@@ -171,7 +165,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       },
       chainId: 820,
       name: "Callisto",
-      showNfts: false,
     },
   },
   config_currency_dexon: {
@@ -183,7 +176,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       },
       chainId: 237,
       name: "DEXON",
-      showNfts: false,
     },
   },
   config_currency_ellaism: {
@@ -195,7 +187,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       },
       chainId: 64,
       name: "Ellaism",
-      showNfts: false,
     },
   },
   config_currency_ethereum: {
@@ -219,7 +210,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "ledger",
         explorerId: "eth",
       },
-      showNfts: false,
     },
   },
   config_currency_sonic: {
@@ -236,7 +226,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "etherscan",
         uri: "https://proxyetherscan.api.live.ledger.com/v2/api/146",
       },
-      showNfts: false,
     },
   },
   config_currency_ethereum_classic: {
@@ -260,7 +249,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "ledger",
         explorerId: "etc",
       },
-      showNfts: false,
     },
   },
   config_currency_ether1: {
@@ -272,7 +260,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       },
       chainId: 1313114,
       name: "Ether1",
-      showNfts: false,
     },
   },
   config_currency_ethergem: {
@@ -284,7 +271,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       },
       chainId: 1987,
       name: "EtherGem",
-      showNfts: false,
     },
   },
   config_currency_ethersocial: {
@@ -296,7 +282,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       },
       chainId: 31102,
       name: "Ethersocial",
-      showNfts: false,
     },
   },
   config_currency_expanse: {
@@ -308,7 +293,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       },
       chainId: 2,
       name: "Expanse",
-      showNfts: false,
     },
   },
   config_currency_gochain: {
@@ -320,7 +304,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       },
       chainId: 60,
       name: "GoChain",
-      showNfts: false,
     },
   },
   config_currency_hpb: {
@@ -332,7 +315,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       },
       chainId: 269,
       name: "High Performance Blockchain",
-      showNfts: false,
     },
   },
   config_currency_mix: {
@@ -344,7 +326,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       },
       chainId: 76,
       name: "MIX Blockchain",
-      showNfts: false,
     },
   },
   config_currency_musicoin: {
@@ -356,7 +337,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       },
       chainId: 7762959,
       name: "Musicoin",
-      showNfts: false,
     },
   },
   config_currency_pirl: {
@@ -379,7 +359,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       },
       chainId: 99,
       name: "POA",
-      showNfts: false,
     },
   },
   config_currency_polygon: {
@@ -404,7 +383,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "ledger",
         explorerId: "matic",
       },
-      showNfts: false,
       minGasPrice: "25000000000",
     },
   },
@@ -417,7 +395,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       },
       chainId: 2894,
       name: "REOSC",
-      showNfts: false,
     },
   },
   config_currency_thundercore: {
@@ -429,7 +406,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       },
       chainId: 108,
       name: "Thundercore",
-      showNfts: false,
     },
   },
   config_currency_tomo: {
@@ -441,7 +417,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       },
       chainId: 88,
       name: "TomoChain",
-      showNfts: false,
     },
   },
   config_currency_ubiq: {
@@ -453,7 +428,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       },
       chainId: 8,
       name: "Ubiq",
-      showNfts: false,
     },
   },
   config_currency_wanchain: {
@@ -465,7 +439,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       },
       chainId: 888,
       name: "Wanchain",
-      showNfts: false,
     },
   },
   config_currency_arbitrum: {
@@ -485,7 +458,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "etherscan",
         uri: "https://proxyetherscan.api.live.ledger.com/v2/api/42161",
       },
-      showNfts: false,
     },
   },
   config_currency_cronos: {
@@ -505,7 +477,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "cronos",
         uri: "https://proxycronosexplorer.api.live.ledger.com/explorer/api",
       },
-      showNfts: false,
     },
   },
   config_currency_core: {
@@ -524,7 +495,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       explorer: {
         type: "none",
       },
-      showNfts: false,
     },
   },
   config_currency_fantom: {
@@ -544,7 +514,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "blockscout",
         uri: "https://ftmscout.com/api",
       },
-      showNfts: false,
     },
   },
   config_currency_flare: {
@@ -564,7 +533,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "blockscout",
         uri: "https://flare-explorer.flare.network/api",
       },
-      showNfts: false,
     },
   },
   config_currency_songbird: {
@@ -584,7 +552,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "blockscout",
         uri: "https://songbird-explorer.flare.network/api",
       },
-      showNfts: false,
     },
   },
   config_currency_moonbeam: {
@@ -604,7 +571,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "etherscan",
         uri: "https://proxyetherscan.api.live.ledger.com/v2/api/1284",
       },
-      showNfts: false,
     },
   },
   config_currency_rsk: {
@@ -624,7 +590,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "blockscout",
         uri: "https://rootstock.blockscout.com/api",
       },
-      showNfts: false,
     },
   },
   config_currency_bittorrent: {
@@ -644,7 +609,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "etherscan",
         uri: "https://proxyetherscan.api.live.ledger.com/v2/api/199",
       },
-      showNfts: false,
     },
   },
   config_currency_optimism: {
@@ -664,7 +628,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "blockscout",
         uri: "https://optimism.blockscout.com/api",
       },
-      showNfts: false,
     },
   },
   config_currency_optimism_sepolia: {
@@ -678,7 +641,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       name: "OP Sepolia",
       node: { type: "external", uri: "https://optimism-sepolia.coin.ledger.com" },
       explorer: { type: "blockscout", uri: "https://optimism-sepolia.blockscout.com/api" },
-      showNfts: false,
     },
   },
   config_currency_energy_web: {
@@ -698,7 +660,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "blockscout",
         uri: "https://explorer.energyweb.org/api",
       },
-      showNfts: false,
     },
   },
   config_currency_astar: {
@@ -718,7 +679,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "blockscout",
         uri: "https://astar.blockscout.com/api",
       },
-      showNfts: false,
     },
   },
   config_currency_metis: {
@@ -738,7 +698,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "blockscout",
         uri: "https://andromeda-explorer.metis.io/api",
       },
-      showNfts: false,
     },
   },
   config_currency_mantle: {
@@ -758,7 +717,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "blockscout",
         uri: "https://explorer.mantle.xyz/api",
       },
-      showNfts: false,
     },
   },
   config_currency_mantle_sepolia: {
@@ -778,7 +736,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "blockscout",
         uri: "https://explorer.sepolia.mantle.xyz/api",
       },
-      showNfts: false,
     },
   },
   config_currency_boba: {
@@ -798,7 +755,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "etherscan",
         uri: "https://api.routescan.io/v2/network/mainnet/evm/288/etherscan",
       },
-      showNfts: false,
     },
   },
   config_currency_moonriver: {
@@ -818,7 +774,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "etherscan",
         uri: "https://proxyetherscan.api.live.ledger.com/v2/api/1285",
       },
-      showNfts: false,
     },
   },
   config_currency_velas_evm: {
@@ -838,7 +793,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "blockscout",
         uri: "https://evmexplorer.velas.com/api",
       },
-      showNfts: false,
     },
   },
   config_currency_syscoin: {
@@ -858,7 +812,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "blockscout",
         uri: "https://explorer.syscoin.org/api",
       },
-      showNfts: false,
     },
   },
   config_currency_telos_evm: {
@@ -878,7 +831,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "teloscan",
         uri: "https://api.teloscan.io/api",
       },
-      showNfts: false,
     },
   },
   config_currency_sei_evm: {
@@ -898,7 +850,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "etherscan",
         uri: "https://proxyetherscan.api.live.ledger.com/v2/api/1329",
       },
-      showNfts: false,
     },
   },
   config_currency_berachain: {
@@ -918,7 +869,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "etherscan",
         uri: "https://proxyetherscan.api.live.ledger.com/v2/api/80094",
       },
-      showNfts: false,
     },
   },
   config_currency_hyperevm: {
@@ -938,7 +888,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "etherscan",
         uri: "https://proxyetherscan.api.live.ledger.com/v2/api/999",
       },
-      showNfts: false,
     },
   },
   config_currency_polygon_zk_evm: {
@@ -958,7 +907,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "etherscan",
         uri: "https://proxyetherscan.api.live.ledger.com/v2/api/1101",
       },
-      showNfts: false,
     },
   },
   config_currency_base: {
@@ -978,7 +926,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "etherscan",
         uri: "https://proxyetherscan.api.live.ledger.com/v2/api/8453",
       },
-      showNfts: false,
     },
   },
   config_currency_klaytn: {
@@ -998,7 +945,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "klaytnfinder",
         uri: "https://cypress-oapi.klaytnfinder.io/api",
       },
-      showNfts: false,
     },
   },
   config_currency_klaytn_baobab: {
@@ -1018,7 +964,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "klaytnfinder",
         uri: "https://baobab-oapi.klaytnfinder.io/api",
       },
-      showNfts: false,
     },
   },
   config_currency_neon_evm: {
@@ -1038,7 +983,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "blockscout",
         uri: "https://neon.blockscout.com/api",
       },
-      showNfts: false,
     },
   },
   config_currency_lukso: {
@@ -1058,7 +1002,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "blockscout",
         uri: "https://explorer.execution.mainnet.lukso.network/api/v1/",
       },
-      showNfts: false,
     },
   },
   config_currency_linea: {
@@ -1078,7 +1021,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "etherscan",
         uri: "https://proxyetherscan.api.live.ledger.com/v2/api/59144",
       },
-      showNfts: false,
     },
   },
   // testnets
@@ -1094,7 +1036,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       node: { type: "ledger", explorerId: "eth_sepolia" },
       explorer: { type: "ledger", explorerId: "eth_sepolia" },
       gasTracker: { type: "ledger", explorerId: "eth_sepolia" },
-      showNfts: false,
     },
   },
   config_currency_ethereum_hoodi: {
@@ -1109,7 +1050,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       node: { type: "ledger", explorerId: "eth_hoodi" },
       explorer: { type: "ledger", explorerId: "eth_hoodi" },
       gasTracker: { type: "ledger", explorerId: "eth_hoodi" },
-      showNfts: false,
     },
   },
   config_currency_polygon_amoy: {
@@ -1124,7 +1064,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       node: { type: "ledger", explorerId: "matic_amoy" },
       explorer: { type: "ledger", explorerId: "matic_amoy" },
       gasTracker: { type: "ledger", explorerId: "matic_amoy" },
-      showNfts: false,
     },
   },
   config_currency_arbitrum_sepolia: {
@@ -1138,7 +1077,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "etherscan",
         uri: "https://proxyetherscan.api.live.ledger.com/v2/api/421614",
       },
-      showNfts: false,
     },
   },
   config_currency_polygon_zk_evm_testnet: {
@@ -1155,7 +1093,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "etherscan",
         uri: "https://proxyetherscan.api.live.ledger.com/v2/api/1442",
       },
-      showNfts: false,
     },
   },
   config_currency_base_sepolia: {
@@ -1169,7 +1106,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       name: "Base Sepolia",
       node: { type: "external", uri: "https://base-sepolia.coin.ledger.com" },
       explorer: { type: "blockscout", uri: "https://base-sepolia.blockscout.com/api" },
-      showNfts: false,
     },
   },
   config_currency_linea_sepolia: {
@@ -1186,7 +1122,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "etherscan",
         uri: "https://proxyetherscan.api.live.ledger.com/v2/api/59141",
       },
-      showNfts: false,
     },
   },
   config_currency_blast: {
@@ -1203,7 +1138,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "etherscan",
         uri: "https://proxyetherscan.api.live.ledger.com/v2/api/81457",
       },
-      showNfts: false,
     },
   },
   config_currency_blast_sepolia: {
@@ -1220,7 +1154,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "etherscan",
         uri: "https://proxyetherscan.api.live.ledger.com/v2/api/168587773",
       },
-      showNfts: false,
     },
   },
   config_currency_scroll: {
@@ -1234,7 +1167,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       name: "Scroll",
       node: { type: "external", uri: "https://scroll.coin.ledger.com" },
       explorer: { type: "blockscout", uri: "https://scroll.blockscout.com/api" },
-      showNfts: false,
     },
   },
   config_currency_shape: {
@@ -1248,7 +1180,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       name: "Shape",
       node: { type: "external", uri: "https://mainnet.shape.network" },
       explorer: { type: "blockscout", uri: "https://shapescan.xyz/api" },
-      showNfts: false,
     },
   },
   config_currency_story: {
@@ -1262,7 +1193,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       name: "Story",
       node: { type: "external", uri: "https://story.coin.ledger.com" },
       explorer: { type: "blockscout", uri: "https://www.storyscan.io/api" },
-      showNfts: false,
     },
   },
   config_currency_etherlink: {
@@ -1276,7 +1206,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       name: "Etherlink",
       node: { type: "external", uri: "https://node.mainnet.etherlink.com" },
       explorer: { type: "blockscout", uri: "https://explorer.etherlink.com/api" },
-      showNfts: false,
     },
   },
   config_currency_zksync: {
@@ -1290,7 +1219,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       name: "ZKsync",
       node: { type: "external", uri: "https://zksync.coin.ledger.com" },
       explorer: { type: "blockscout", uri: "https://zksync.blockscout.com/api" },
-      showNfts: false,
     },
   },
   config_currency_zksync_sepolia: {
@@ -1304,7 +1232,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       name: "ZKsync Sepolia",
       node: { type: "external", uri: "https://zksync-sepolia.coin.ledger.com" },
       explorer: { type: "blockscout", uri: "https://zksync-sepolia.blockscout.com/api" },
-      showNfts: false,
     },
   },
   config_currency_monad: {
@@ -1324,7 +1251,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "etherscan",
         uri: "https://proxyetherscan.api.live.ledger.com/v2/api/143",
       },
-      showNfts: false,
     },
   },
   config_currency_monad_testnet: {
@@ -1344,7 +1270,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "etherscan",
         uri: "https://proxyetherscan.api.live.ledger.com/v2/api/10143",
       },
-      showNfts: false,
     },
   },
   config_currency_somnia: {
@@ -1364,7 +1289,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "blockscout",
         uri: "https://mainnet.somnia.w3us.site/api",
       },
-      showNfts: false,
     },
   },
   config_currency_zero_gravity: {
@@ -1384,7 +1308,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "blockscout",
         uri: "https://chainscan.0g.ai/open/api",
       },
-      showNfts: false,
       minGasPrice: "2000000000",
     },
   },
@@ -1405,7 +1328,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "blockscout",
         uri: "https://explorer-bls.adifoundation.ai/api",
       },
-      showNfts: false,
     },
   },
   config_currency_unichain: {
@@ -1425,7 +1347,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "blockscout",
         uri: "https://unichain.blockscout.com/api",
       },
-      showNfts: false,
     },
   },
   config_currency_unichain_sepolia: {
@@ -1439,7 +1360,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       name: "Unichain Sepolia",
       node: { type: "external", uri: "https://unichain-sepolia-rpc.publicnode.com" },
       explorer: { type: "blockscout", uri: "https://unichain-sepolia.blockscout.com/api" },
-      showNfts: false,
     },
   },
   config_currency_arc: {
@@ -1458,7 +1378,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       explorer: {
         type: "none",
       },
-      showNfts: false,
       nativeContracts: ["0x0000000000000000000000000000000000000000"],
       feeHistoryBlockCount: 1024,
       feeHistoryRewardPercentile: 60,
@@ -1478,7 +1397,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         type: "blockscout",
         uri: "https://proxyblockscout.api.live.ledger.com/5042002/api",
       },
-      showNfts: false,
       nativeContracts: ["0x3600000000000000000000000000000000000000"],
       feeHistoryBlockCount: 1024,
       feeHistoryRewardPercentile: 60,
@@ -1497,7 +1415,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       explorer: {
         type: "none",
       },
-      showNfts: false,
     },
   },
   config_currency_robinhood_testnet: {
@@ -1513,7 +1430,6 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
       explorer: {
         type: "none",
       },
-      showNfts: false,
     },
   },
 };


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Replaces the EVM NFT activation mechanism: instead of the isNFTActive helper (from @ledgerhq/ledger-wallet-framework/nft, gated on the NFT_CURRENCIES env) combined with the showNfts boolean, NFT operations are now driven by a single supportedTokens: ("erc721" | "erc1155")[] config field.

coin-evm
- EvmConfig.showNfts: boolean → supportedTokens: ("erc721" | "erc1155")[].
- network/explorer/etherscan.ts and network/explorer/ledger.ts no longer import isNFTActive. NFT operations are now gated per standard via config.supportedTokens.includes("erc721" | "erc1155"), so a chain can enable ERC-721 and ERC-1155 independently.
- Removes coin-evm's dependency on @ledgerhq/ledger-wallet-framework/nft/support (the remaining nftId / nftOperationId imports in fixtures are handled in T14).

live-common
- families/evm/config.ts: every showNfts: false default becomes supportedTokens: []. The config source populates supportedTokens from the same activation logic that previously drove isNFTActive / showNfts (this is the bypass described in the ticket until LIVE-22454 lands, after which only the config-builder changes).
- DataModel.ts: the migration guard that strips NFT operations now checks supportedTokens?.length instead of showNfts.

No change to NFT sync behaviour is expected: a chain surfaces NFT operations when its config lists the corresponding standard.
### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-33365](https://ledgerhq.atlassian.net/browse/LIVE-33365)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-33365]: https://ledgerhq.atlassian.net/browse/LIVE-33365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ