### PR TITLE
feat(engagement): extend banners to Nano SP and Nano X

### DIFF
--- a/.changeset/live-35397-extend-banner-audience.md
+++ b/.changeset/live-35397-extend-banner-audience.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@features/flow-large-screen-upsell": minor
+---
+
+Extend desktop always-on upsell banners to Nano SP and Nano X using the shared largeScreenUpsell audience and cooldown (LIVE-35397).

--- a/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/LNSUpsellBanner.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/LNSUpsellBanner.test.tsx
@@ -24,9 +24,16 @@ const DEFAULT_DISCOUNT_PERCENT = Math.round(
   (FEATURE_FLAGS_DEFAULTS.largeScreenUpsell.params?.discount ?? 0) * 100,
 );
 
+function daysAgoIso(days: number): string {
+  const date = new Date();
+  date.setDate(date.getDate() - days);
+  return date.toISOString();
+}
+
 describe("LNSUpsellBanner", () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.mocked(openURL).mockClear();
+    jest.mocked(track).mockClear();
   });
 
   describe.each([
@@ -50,9 +57,68 @@ describe("LNSUpsellBanner", () => {
       expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
     });
 
-    it("should not render if the user uses another device", () => {
-      renderBanner({ devicesModelList: [DeviceModelId.nanoSP] });
+    it.each([DeviceModelId.nanoSP, DeviceModelId.nanoX])(
+      "should not render for %s before the cooldown elapses",
+      deviceModelId => {
+        renderBanner({
+          devicesModelList: [deviceModelId],
+          onboardingDate: daysAgoIso(1),
+        });
+        expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
+      },
+    );
+
+    it.each([
+      { deviceModelId: DeviceModelId.nanoSP, analyticsValue: "lnsp" },
+      { deviceModelId: DeviceModelId.nanoX, analyticsValue: "lnx" },
+    ])(
+      "should render for $deviceModelId once its cooldown has elapsed",
+      ({ deviceModelId, analyticsValue }) => {
+        renderBanner({
+          devicesModelList: [deviceModelId],
+          onboardingDate: daysAgoIso(30),
+        });
+        fireEvent.click(screen.getByText(t(`lnsUpsell.opted_in.cta`)));
+
+        expect(track).toHaveBeenCalledWith("button_clicked", {
+          button: "Level up wallet",
+          deviceModel: analyticsValue,
+          link: "https://example.com/optInCta",
+          page,
+        });
+      },
+    );
+
+    it("should not render if the user's Nano model is outside the audience", () => {
+      renderBanner({ audienceModels: { nanoS: false, nanoSP: true, nanoX: true } });
       expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
+    });
+
+    it("should not render if the user also owns a large-screen device", () => {
+      renderBanner({ devicesModelList: [DeviceModelId.nanoS, DeviceModelId.stax] });
+      expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
+    });
+
+    it("should not render when a longer-cooldown nano is still in cooldown", () => {
+      renderBanner({
+        devicesModelList: [DeviceModelId.nanoS, DeviceModelId.nanoX],
+      });
+      expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
+    });
+
+    it("should render the longest-cooldown nano once that cooldown has elapsed", () => {
+      renderBanner({
+        devicesModelList: [DeviceModelId.nanoS, DeviceModelId.nanoX],
+        onboardingDate: daysAgoIso(30),
+      });
+      fireEvent.click(screen.getByText(t(`lnsUpsell.opted_in.cta`)));
+
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "Level up wallet",
+        deviceModel: "lnx",
+        link: "https://example.com/optInCta",
+        page,
+      });
     });
 
     it("should not render if the user has no devices", () => {
@@ -74,6 +140,7 @@ describe("LNSUpsellBanner", () => {
       expect(track).toHaveBeenCalledTimes(1);
       expect(track).toHaveBeenCalledWith("button_clicked", {
         button: "Level up wallet",
+        deviceModel: "lns",
         link: "https://example.com/optInCta",
         page,
       });
@@ -82,12 +149,12 @@ describe("LNSUpsellBanner", () => {
     it("should render Lumen MediaBanner and track click when lwdWallet40 brazePlacement is on", () => {
       renderBanner({ brazePlacement: true });
 
-      expect(screen.getByText(t(`lnsUpsell.opted_in.title`))).toBeTruthy();
+      expect(screen.getByText(t(`lnsUpsell.opted_in.title`))).toBeVisible();
       expect(
         screen.getByText(
           t(`lnsUpsell.opted_in.description`, { discount: DEFAULT_DISCOUNT_PERCENT }),
         ),
-      ).toBeTruthy();
+      ).toBeVisible();
 
       fireEvent.click(screen.getByTestId("lns-upsell-media-banner"));
 
@@ -95,6 +162,7 @@ describe("LNSUpsellBanner", () => {
       expect(openURL).toHaveBeenCalledWith("https://example.com/optInCta");
       expect(track).toHaveBeenCalledWith("button_clicked", {
         button: "Level up wallet",
+        deviceModel: "lns",
         link: "https://example.com/optInCta",
         page,
       });
@@ -103,8 +171,8 @@ describe("LNSUpsellBanner", () => {
     it("should render opted-out MediaBanner copy when lwdWallet40 brazePlacement is on", () => {
       renderBanner({ brazePlacement: true, isOptIn: false });
 
-      expect(screen.getByText(t(`lnsUpsell.opted_out.title`))).toBeTruthy();
-      expect(screen.getByText(t(`lnsUpsell.opted_out.description`))).toBeTruthy();
+      expect(screen.getByText(t(`lnsUpsell.opted_out.title`))).toBeVisible();
+      expect(screen.getByText(t(`lnsUpsell.opted_out.description`))).toBeVisible();
     });
 
     it("should render the banner for opted out users", () => {
@@ -116,6 +184,7 @@ describe("LNSUpsellBanner", () => {
       expect(track).toHaveBeenCalledTimes(1);
       expect(track).toHaveBeenCalledWith("button_clicked", {
         button: "Level up wallet",
+        deviceModel: "lns",
         link: "https://example.com/optOutCta",
         page,
       });
@@ -130,6 +199,7 @@ describe("LNSUpsellBanner", () => {
       expect(track).toHaveBeenCalledTimes(1);
       expect(track).toHaveBeenCalledWith("button_clicked", {
         button: "Level up wallet",
+        deviceModel: "lns",
         link: "https://example.com/optOutCta",
         page,
       });
@@ -141,8 +211,20 @@ describe("LNSUpsellBanner", () => {
       ffCtaEnabled = true,
       isOptIn = true,
       devicesModelList = [DeviceModelId.nanoS],
+      onboardingDate = daysAgoIso(0),
+      audienceModels = {},
       targetedByHighTierUpsell = false,
       brazePlacement = false,
+    }: {
+      ffEnabled?: boolean;
+      ffLocationEnabled?: boolean;
+      ffCtaEnabled?: boolean;
+      isOptIn?: boolean;
+      devicesModelList?: DeviceModelId[];
+      onboardingDate?: string;
+      audienceModels?: Partial<{ nanoS: boolean; nanoSP: boolean; nanoX: boolean }>;
+      targetedByHighTierUpsell?: boolean;
+      brazePlacement?: boolean;
     }) {
       const defaultParams = FEATURE_FLAGS_DEFAULTS.largeScreenUpsell.params;
 
@@ -159,6 +241,12 @@ describe("LNSUpsellBanner", () => {
               enabled: ffEnabled,
               params: {
                 ...defaultParams,
+                audience: {
+                  models: {
+                    ...defaultParams.audience.models,
+                    ...audienceModels,
+                  },
+                },
                 banners: {
                   ...defaultParams.banners,
                   [placement]: ffLocationEnabled,
@@ -182,6 +270,9 @@ describe("LNSUpsellBanner", () => {
             sharePersonalizedRecommandations: isOptIn,
             devicesModelList,
             anonymousUserNotifications: {},
+          },
+          postOnboarding: {
+            onboardingDate,
           },
           dynamicContent: {
             desktopCards: [
@@ -224,6 +315,9 @@ describe("LNSUpsellBanner", () => {
           sharePersonalizedRecommandations: true,
           devicesModelList: [DeviceModelId.nanoS],
           anonymousUserNotifications: {},
+        },
+        postOnboarding: {
+          onboardingDate: daysAgoIso(0),
         },
         dynamicContent: {
           desktopCards: [],

--- a/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/useLNSUpsellBannerModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/useLNSUpsellBannerModel.ts
@@ -1,6 +1,7 @@
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import { useLNSUpsellBannerState } from "LLD/features/LNSUpsell/hooks/useLNSUpsellBannerState";
 import type { LNSBannerLocation, LNSBannerState } from "LLD/features/LNSUpsell/types";
+import { toLargeScreenUpsellDeviceModelAnalyticsValue } from "LLD/features/LargeScreenUpsell/analytics";
 import { track } from "~/renderer/analytics/segment";
 import { openURL } from "~/renderer/linking";
 import lnsUpsellPortfolioImageUrl from "~/renderer/images/lns-upsell-banner-portfolio.webp";
@@ -20,13 +21,17 @@ export function useLNSUpsellBannerModel(location: LNSBannerLocation): LNSBannerM
   const state = useLNSUpsellBannerState(location);
   const { shouldDisplayBrazePlacement } = useWalletFeaturesConfig("desktop");
 
-  const { ctaLink, discountPercent: discount } = state;
+  const { ctaLink, discountPercent: discount, deviceModelId } = state;
   const analyticsPage = AnalyticsPageMap[location];
   const imageUrl = lnsUpsellImageByLocation[location];
+  const deviceModel = deviceModelId
+    ? toLargeScreenUpsellDeviceModelAnalyticsValue(deviceModelId)
+    : undefined;
 
   const handleCTAClick = () => {
     track("button_clicked", {
       button: ANALYTICS_BUTTON_CLICK,
+      ...(deviceModel ? { deviceModel } : {}),
       link: ctaLink,
       page: analyticsPage,
     });

--- a/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/hooks/useLNSUpsellBannerState.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/hooks/useLNSUpsellBannerState.ts
@@ -1,6 +1,10 @@
 import { useSelector } from "LLD/hooks/redux";
 import { useFeature } from "@features/platform-feature-flags";
-import { DeviceModelId } from "@ledgerhq/types-devices";
+import {
+  getLargeScreenUpsellEligibility,
+  mapDevicesModelListToUpsellInputs,
+} from "@features/flow-large-screen-upsell";
+import { onboardingDateSelector } from "@ledgerhq/live-common/postOnboarding/reducer";
 import { desktopContentCardSelector } from "~/renderer/reducers/dynamicContent";
 import {
   devicesModelListSelector,
@@ -27,8 +31,22 @@ export function useLNSUpsellBannerState(location: LNSBannerLocation): LNSBannerS
   const discountPercent = Math.round((largeScreenUpsell?.params?.discount ?? 0) * 100);
 
   const devicesModelList = useSelector(devicesModelListSelector);
-  const hasOnlySeenLNS =
-    devicesModelList.length === 1 && devicesModelList[0] === DeviceModelId.nanoS;
+  const onboardingDate = useSelector(onboardingDateSelector);
+  const eligibility = getLargeScreenUpsellEligibility(
+    {
+      ...mapDevicesModelListToUpsellInputs(devicesModelList),
+      onboardingDate,
+    },
+    {
+      audienceModels: largeScreenUpsell?.params?.audience?.models ?? {
+        nanoS: false,
+        nanoSP: false,
+        nanoX: false,
+      },
+      cooldownDays: largeScreenUpsell?.params?.cooldownDays ?? { default: Infinity },
+      now: new Date(),
+    },
+  );
 
   const desktopCards = useSelector(desktopContentCardSelector);
   const isExcluded = isOptIn && desktopCards.some(c => c.extras.campaign === LNS_UPSELL_HIGH_TIER);
@@ -36,7 +54,8 @@ export function useLNSUpsellBannerState(location: LNSBannerLocation): LNSBannerS
   const isEnabled = Boolean(
     largeScreenUpsell?.enabled && isCTAEnabled && isPlacementEnabled && ctaLink,
   );
-  const isShown = isEnabled && hasOnlySeenLNS && !isExcluded;
+  const isShown = isEnabled && eligibility.isEligible && !isExcluded;
+  const deviceModelId = eligibility.isEligible ? eligibility.deviceModelId : undefined;
 
-  return { isShown, tracking, ctaLink, discountPercent };
+  return { isShown, tracking, ctaLink, discountPercent, deviceModelId };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/types/index.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/types/index.ts
@@ -1,3 +1,4 @@
+import type { NanoDeviceModelId } from "@features/flow-large-screen-upsell";
 import type { Features } from "@shared/feature-flags";
 
 export type LNSBannerLocation = "manager" | "accounts" | "notification_center" | "portfolio";
@@ -7,6 +8,7 @@ export type LNSBannerState = {
   tracking: "opted_in" | "opted_out";
   ctaLink?: string;
   discountPercent?: number;
+  deviceModelId?: NanoDeviceModelId;
 };
 
 type LargeScreenUpsellParams = NonNullable<Features["largeScreenUpsell"]["params"]>;

--- a/features/flow/large-screen-upsell/src/decision/getLargeScreenUpsellDecision.ts
+++ b/features/flow/large-screen-upsell/src/decision/getLargeScreenUpsellDecision.ts
@@ -1,37 +1,10 @@
 import { isCooldownElapsed } from "../internal/isCooldownElapsed";
-import { resolveOnboardingDateForUpsell } from "../internal/legacyOnboardingDate";
+import { getLargeScreenUpsellEligibility } from "./getLargeScreenUpsellEligibility";
 import type {
   LargeScreenUpsellContext,
   LargeScreenUpsellDecision,
   LargeScreenUpsellUserState,
-  NanoDeviceModelId,
 } from "../types";
-
-// Canonical order (same as mobile) so longest-cooldown ties are order-independent.
-const NANO_DEVICE_MODEL_IDS = [
-  "nanoS",
-  "nanoSP",
-  "nanoX",
-] as const satisfies readonly NanoDeviceModelId[];
-
-function selectDeviceModelWithLongestCooldown(
-  deviceModelIds: NanoDeviceModelId[],
-  cooldownDays: LargeScreenUpsellContext["cooldownDays"],
-): { deviceModelId: NanoDeviceModelId; days: number } {
-  const resolveDays = (deviceModelId: NanoDeviceModelId) =>
-    cooldownDays[deviceModelId] ?? cooldownDays.default;
-
-  const seenIds = new Set(deviceModelIds);
-  const orderedDeviceModelIds = NANO_DEVICE_MODEL_IDS.filter(deviceModelId =>
-    seenIds.has(deviceModelId),
-  );
-
-  const deviceModelId = orderedDeviceModelIds.reduce((longestId, candidateId) =>
-    resolveDays(candidateId) > resolveDays(longestId) ? candidateId : longestId,
-  );
-
-  return { deviceModelId, days: resolveDays(deviceModelId) };
-}
 
 export function getLargeScreenUpsellDecision(
   {
@@ -58,36 +31,17 @@ export function getLargeScreenUpsellDecision(
     return { shouldShow: false, reason: "modal_disabled" };
   }
 
-  if (hasSeenTouchscreenDevice) {
-    return { shouldShow: false, reason: "touchscreen_seen" };
-  }
-
-  if (seenNanoModelIds.length === 0) {
-    return { shouldShow: false, reason: "no_nano" };
-  }
-
-  const enabledSeenNanoModelIds = seenNanoModelIds.filter(
-    deviceModelId => audienceModels[deviceModelId],
+  const eligibility = getLargeScreenUpsellEligibility(
+    { seenNanoModelIds, hasSeenTouchscreenDevice, onboardingDate },
+    { audienceModels, cooldownDays, now },
   );
 
-  if (enabledSeenNanoModelIds.length === 0) {
-    return { shouldShow: false, reason: "model_disabled" };
-  }
+  if (!eligibility.isEligible) {
+    if (eligibility.reason === "cooldown") {
+      return { shouldShow: false, reason: "cooldown", deviceModelId: eligibility.deviceModelId };
+    }
 
-  const { deviceModelId, days: resolvedCooldownDays } = selectDeviceModelWithLongestCooldown(
-    enabledSeenNanoModelIds,
-    cooldownDays,
-  );
-  const onboardingDateForEligibility = resolveOnboardingDateForUpsell(onboardingDate);
-
-  if (
-    !isCooldownElapsed({
-      elapsedSinceDate: onboardingDateForEligibility,
-      minimumDays: resolvedCooldownDays,
-      now,
-    })
-  ) {
-    return { shouldShow: false, reason: "cooldown", deviceModelId };
+    return { shouldShow: false, reason: eligibility.reason };
   }
 
   if (
@@ -99,8 +53,8 @@ export function getLargeScreenUpsellDecision(
       now,
     })
   ) {
-    return { shouldShow: false, reason: "throttled", deviceModelId };
+    return { shouldShow: false, reason: "throttled", deviceModelId: eligibility.deviceModelId };
   }
 
-  return { shouldShow: true, deviceModelId };
+  return { shouldShow: true, deviceModelId: eligibility.deviceModelId };
 }

--- a/features/flow/large-screen-upsell/src/decision/getLargeScreenUpsellEligibility.test.ts
+++ b/features/flow/large-screen-upsell/src/decision/getLargeScreenUpsellEligibility.test.ts
@@ -1,0 +1,80 @@
+import { getLargeScreenUpsellEligibility } from "./getLargeScreenUpsellEligibility";
+import type {
+  LargeScreenUpsellEligibilityContext,
+  LargeScreenUpsellEligibilityUserState,
+} from "../types";
+
+const now = new Date("2026-07-15T12:00:00.000Z");
+
+const baseUserState: LargeScreenUpsellEligibilityUserState = {
+  seenNanoModelIds: ["nanoX"],
+  hasSeenTouchscreenDevice: false,
+  onboardingDate: new Date("2026-06-01T12:00:00.000Z"),
+};
+
+const baseContext: LargeScreenUpsellEligibilityContext = {
+  audienceModels: { nanoS: true, nanoSP: true, nanoX: true },
+  cooldownDays: { default: 30, nanoS: 0 },
+  now,
+};
+
+describe("getLargeScreenUpsellEligibility", () => {
+  it.each<{
+    description: string;
+    userState?: Partial<LargeScreenUpsellEligibilityUserState>;
+    context?: Partial<LargeScreenUpsellEligibilityContext>;
+    expected: ReturnType<typeof getLargeScreenUpsellEligibility>;
+  }>([
+    {
+      description: "a touchscreen device has been seen",
+      userState: { hasSeenTouchscreenDevice: true },
+      expected: { isEligible: false, reason: "touchscreen_seen" },
+    },
+    {
+      description: "no nano has been seen",
+      userState: { seenNanoModelIds: [] },
+      expected: { isEligible: false, reason: "no_nano" },
+    },
+    {
+      description: "the only seen nano is disabled for the audience",
+      userState: { seenNanoModelIds: ["nanoS"] },
+      context: { audienceModels: { nanoS: false, nanoSP: true, nanoX: true } },
+      expected: { isEligible: false, reason: "model_disabled" },
+    },
+    {
+      description: "the only seen nano is nanoSP",
+      userState: { seenNanoModelIds: ["nanoSP"] },
+      expected: { isEligible: true, deviceModelId: "nanoSP" },
+    },
+    {
+      description: "the only seen nano is nanoS",
+      userState: { seenNanoModelIds: ["nanoS"] },
+      expected: { isEligible: true, deviceModelId: "nanoS" },
+    },
+    {
+      description: "several nanos are seen, the one with the longest cooldown is selected",
+      userState: { seenNanoModelIds: ["nanoS", "nanoSP", "nanoX"] },
+      expected: { isEligible: true, deviceModelId: "nanoSP" },
+    },
+    {
+      description: "the cooldown hasn't elapsed",
+      userState: {
+        seenNanoModelIds: ["nanoS", "nanoX"],
+        onboardingDate: new Date("2026-07-14T12:00:00.000Z"),
+      },
+      expected: { isEligible: false, reason: "cooldown", deviceModelId: "nanoX" },
+    },
+    {
+      description: "the onboarding date is null",
+      userState: { onboardingDate: null },
+      expected: { isEligible: true, deviceModelId: "nanoX" },
+    },
+  ])("resolves as expected when $description", ({ userState, context, expected }) => {
+    expect(
+      getLargeScreenUpsellEligibility(
+        { ...baseUserState, ...userState },
+        { ...baseContext, ...context },
+      ),
+    ).toEqual(expected);
+  });
+});

--- a/features/flow/large-screen-upsell/src/decision/getLargeScreenUpsellEligibility.ts
+++ b/features/flow/large-screen-upsell/src/decision/getLargeScreenUpsellEligibility.ts
@@ -21,12 +21,14 @@ function selectDeviceModelWithLongestCooldown(
     cooldownDays[deviceModelId] ?? cooldownDays.default;
 
   const seenIds = new Set(deviceModelIds);
-  const orderedDeviceModelIds = NANO_DEVICE_MODEL_IDS.filter(deviceModelId =>
+  const [firstDeviceModelId, ...restDeviceModelIds] = NANO_DEVICE_MODEL_IDS.filter(deviceModelId =>
     seenIds.has(deviceModelId),
   );
 
-  const deviceModelId = orderedDeviceModelIds.reduce((longestId, candidateId) =>
-    resolveDays(candidateId) > resolveDays(longestId) ? candidateId : longestId,
+  const deviceModelId = restDeviceModelIds.reduce(
+    (longestId, candidateId) =>
+      resolveDays(candidateId) > resolveDays(longestId) ? candidateId : longestId,
+    firstDeviceModelId,
   );
 
   return { deviceModelId, days: resolveDays(deviceModelId) };

--- a/features/flow/large-screen-upsell/src/decision/getLargeScreenUpsellEligibility.ts
+++ b/features/flow/large-screen-upsell/src/decision/getLargeScreenUpsellEligibility.ts
@@ -1,0 +1,76 @@
+import { isCooldownElapsed } from "../internal/isCooldownElapsed";
+import { resolveOnboardingDateForUpsell } from "../internal/legacyOnboardingDate";
+import type {
+  LargeScreenUpsellEligibility,
+  LargeScreenUpsellEligibilityContext,
+  LargeScreenUpsellEligibilityUserState,
+  NanoDeviceModelId,
+} from "../types";
+
+const NANO_DEVICE_MODEL_IDS = [
+  "nanoS",
+  "nanoSP",
+  "nanoX",
+] as const satisfies readonly NanoDeviceModelId[];
+
+function selectDeviceModelWithLongestCooldown(
+  deviceModelIds: NanoDeviceModelId[],
+  cooldownDays: LargeScreenUpsellEligibilityContext["cooldownDays"],
+): { deviceModelId: NanoDeviceModelId; days: number } {
+  const resolveDays = (deviceModelId: NanoDeviceModelId) =>
+    cooldownDays[deviceModelId] ?? cooldownDays.default;
+
+  const seenIds = new Set(deviceModelIds);
+  const orderedDeviceModelIds = NANO_DEVICE_MODEL_IDS.filter(deviceModelId =>
+    seenIds.has(deviceModelId),
+  );
+
+  const deviceModelId = orderedDeviceModelIds.reduce((longestId, candidateId) =>
+    resolveDays(candidateId) > resolveDays(longestId) ? candidateId : longestId,
+  );
+
+  return { deviceModelId, days: resolveDays(deviceModelId) };
+}
+
+export function getLargeScreenUpsellEligibility(
+  {
+    seenNanoModelIds,
+    hasSeenTouchscreenDevice,
+    onboardingDate,
+  }: LargeScreenUpsellEligibilityUserState,
+  { audienceModels, cooldownDays, now }: LargeScreenUpsellEligibilityContext,
+): LargeScreenUpsellEligibility {
+  if (hasSeenTouchscreenDevice) {
+    return { isEligible: false, reason: "touchscreen_seen" };
+  }
+
+  if (seenNanoModelIds.length === 0) {
+    return { isEligible: false, reason: "no_nano" };
+  }
+
+  const enabledSeenNanoModelIds = seenNanoModelIds.filter(
+    deviceModelId => audienceModels[deviceModelId],
+  );
+
+  if (enabledSeenNanoModelIds.length === 0) {
+    return { isEligible: false, reason: "model_disabled" };
+  }
+
+  const { deviceModelId, days: resolvedCooldownDays } = selectDeviceModelWithLongestCooldown(
+    enabledSeenNanoModelIds,
+    cooldownDays,
+  );
+  const onboardingDateForEligibility = resolveOnboardingDateForUpsell(onboardingDate);
+
+  if (
+    !isCooldownElapsed({
+      elapsedSinceDate: onboardingDateForEligibility,
+      minimumDays: resolvedCooldownDays,
+      now,
+    })
+  ) {
+    return { isEligible: false, reason: "cooldown", deviceModelId };
+  }
+
+  return { isEligible: true, deviceModelId };
+}

--- a/features/flow/large-screen-upsell/src/index.ts
+++ b/features/flow/large-screen-upsell/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./state";
 export * from "./types";
 export * from "./decision/getLargeScreenUpsellDecision";
+export * from "./decision/getLargeScreenUpsellEligibility";
 export * from "./hooks/useLargeScreenUpsellDecision";
 export * from "./utils/upsellCta";
 export * from "./utils/upsellContent";

--- a/features/flow/large-screen-upsell/src/types.ts
+++ b/features/flow/large-screen-upsell/src/types.ts
@@ -40,3 +40,25 @@ export type LargeScreenUpsellContext = {
   cadenceDays: number;
   now: Date;
 };
+
+export type LargeScreenUpsellEligibilityUserState = Pick<
+  LargeScreenUpsellUserState,
+  "seenNanoModelIds" | "hasSeenTouchscreenDevice" | "onboardingDate"
+>;
+
+export type LargeScreenUpsellEligibilityContext = Pick<
+  LargeScreenUpsellContext,
+  "audienceModels" | "cooldownDays" | "now"
+>;
+
+export type LargeScreenUpsellEligibility =
+  | { isEligible: true; deviceModelId: NanoDeviceModelId }
+  | {
+      isEligible: false;
+      reason: "no_nano" | "touchscreen_seen" | "model_disabled";
+    }
+  | {
+      isEligible: false;
+      reason: "cooldown";
+      deviceModelId: NanoDeviceModelId;
+    };


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Desktop always-on upsell banners were limited to Nano S (`hasOnlySeenLNS`). This PR widens them to Nano SP and Nano X using `largeScreenUpsell.params.audience.models`, and applies the same onboarding cooldown as the large-screen upsell modal.

**Approach**: extract `getLargeScreenUpsellEligibility` from the modal decision engine (audience, touchscreen exclusion, longest per-model `cooldownDays`) and reuse it in `useLNSUpsellBannerState`. Banner-only gates stay in the hook (placement, CTA, Braze high-tier). Modal kill/cadence is not applied to banners.

With default flag params (`cooldownDays.default = 30`, `nanoS = 0`):

- Nano S: banner from day 0
- Nano SP / Nano X: banner after 30 calendar days
- Mixed nanos: longest cooldown wins
- Stax / Flex / Apex: never shown

Banner CTA analytics now include `deviceModel` (`lns` / `lnsp` / `lnx`).

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35397](https://ledgerhq.atlassian.net/browse/LIVE-35397)
- **Story**: [LIVE-32104](https://ledgerhq.atlassian.net/browse/LIVE-32104)
- **ADR** (if any): n/a

### 🧪 Test plan

- [ ] Nano S user sees banners on Home, Notification Center, My Ledger and Accounts from day 0
- [ ] Nano SP / Nano X user does **not** see banners during the cooldown (`cooldownDays.default`, 30)
- [ ] Nano SP / Nano X user sees banners after the cooldown elapses
- [ ] Large-screen owners (Stax / Flex / Apex) never see the banners
- [ ] `audience.models.nanoX: false` hides banners for Nano X
- [ ] Opt-in vs opt-out copy still matches `personalRecoOptIn`
- [ ] Banner click events include `deviceModel`: `lns` / `lnsp` / `lnx`

### 📸 Screenshots

| Before | After |
| --- | --- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |


Made with [Cursor](https://cursor.com)

[LIVE-35397]: https://ledgerhq.atlassian.net/browse/LIVE-35397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ