### PR TITLE
fix(splash-screen): darken the android system splash (LIVE-35905)

### DIFF
--- a/.changeset/LIVE-35905-android-system-splash-dark.md
+++ b/.changeset/LIVE-35905-android-system-splash-dark.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Force a dark background on the Android 12+ system splash screen shown between the launcher tap and the splash screen. It followed the device theme, showing a white background in light mode, because the `windowSplashScreenBackground` it was configured with belongs to `core-splashscreen` and never reached the platform.

--- a/apps/ledger-live-mobile/android/app/src/main/res/values-v31/styles.xml
+++ b/apps/ledger-live-mobile/android/app/src/main/res/values-v31/styles.xml
@@ -3,6 +3,7 @@
     <style name="AppTheme.Splash" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="windowSplashScreenBackground">#000000</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/splash_logo</item>
+        <item name="android:windowSplashScreenBackground">#000000</item>
         <item name="android:windowActionBar">false</item>
         <item name="postSplashScreenTheme">@style/AppTheme</item>
     </style>


### PR DESCRIPTION
Implements a reduced scope of [LIVE-35905](https://ledgerhq.atlassian.net/browse/LIVE-35905).

## Scope

The wordmark splash screen was **descoped**: the logo and its position stay exactly as they are, on every surface and every platform.

The only change is on the **Android 12+ system splash** — the screen shown between tapping the launcher icon and the splash screen. It rendered **white in light mode**, following the device theme. It is now black.

**The icon is deliberately left alone**, so the platform keeps drawing the launcher icon there.

## The bug

`values-v31/styles.xml` configured the splash through `windowSplashScreenBackground` — but unprefixed, that attribute belongs to `androidx.core:core-splashscreen`, not to the platform. It only reaches the platform through the library's `Theme.SplashScreen`, whose own `values-v31` variant maps it across:

```xml
<style name="Theme.SplashScreen" parent="Base.Theme.SplashScreen.DayNight">
    <item name="android:windowSplashScreenBackground">?windowSplashScreenBackground</item>
```

Our style inherits from `Theme.AppCompat.DayNight.NoActionBar` instead, so nothing performed that mapping and the platform fell back to its default — the device theme background.

A second factor compounded it: a resource qualifier **replaces** a style rather than merging it, so the `android:windowBackground` of `#000000` defined in `values/styles.xml` is not inherited by the `values-v31` variant either.

## The fix

One functional line — the prefixed platform attribute, which is the one the system splash actually reads:

```xml
<item name="android:windowSplashScreenBackground">#000000</item>
```

The theme parent and the unprefixed attributes are untouched, keeping the change contained.

## Why the icon is not touched

`windowSplashScreenAnimatedIcon` is unprefixed too, so it is equally unread and the platform falls back to the launcher icon — a bolder, squarer drawing of the bracket than the splash screen shows.

Making it match was attempted and reverted. Two reasons it is not worth pursuing here:

1. **The two surfaces size the logo on incompatible bases.** The platform draws the icon in a fixed **160dp** canvas (`starting_surface_icon_size`), while `launch_screen.xml` scales the logo to the **screen width**. The splash bracket is therefore proportional (~73–95dp depending on device) and the system one absolute, so they cannot match on every device — any scaling factor is a compromise tuned to one screen size.
2. It could not be validated. The system splash frame is too short-lived to capture reliably with `adb screencap` sampling, so changes to it were being made without seeing the result.

If this is picked up later, it needs a proper capture method (`screenrecord` at a usable resolution, or a device) before touching the drawable.

## Verification

- `aapt2 compile` accepts the resource.
- The platform attribute list was checked against `attrs.xml` in the android-36 SDK, and the `Theme.SplashScreen` mapping read from the `core-splashscreen` 1.0.1 AAR rather than recalled.

**The background is not verified on device.** It needs a release or staging build; expect black in both light and dark mode.

Worth checking in the same pass: the status bar icons are currently dark, consistent with the AppCompat light parent. Against a black background they may become unreadable, in which case the fix is `<item name="android:windowLightStatusBar">false</item>`.

## Not changed

**Pre-Android 12** (`values/styles.xml`) is untouched: still a plain black screen with no icon.


## before

https://github.com/user-attachments/assets/25198395-f67d-45aa-9892-8b1e4e25145a


## after


https://github.com/user-attachments/assets/d4dce3d9-0c74-4087-9bb9-365a42e41d15



[LIVE-35905]: https://ledgerhq.atlassian.net/browse/LIVE-35905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ