### PR TITLE
refactor(pay-card): read the session token asynchronously

### DIFF
--- a/.changeset/eager-tokens-await.md
+++ b/.changeset/eager-tokens-await.md
@@ -8,3 +8,6 @@ Read the Pay Card session token asynchronously (LIVE-34742)
 `cardApiExtra.getCardSessionToken` now returns a promise, and the Card base query awaits it. The
 session is about to live in OS secure storage, which only reads asynchronously. Behaviour does not
 change yet: the accessor still answers from memory.
+
+An await can reject, and `BaseQueryFn` must always answer with a result. A session port that rejects
+now gives a `CUSTOM_ERROR` result, so every caller still reads an `error.status`.

--- a/.changeset/eager-tokens-await.md
+++ b/.changeset/eager-tokens-await.md
@@ -1,0 +1,10 @@
+---
+"@shared/api-services": minor
+"@features/platform-card": minor
+---
+
+Read the Pay Card session token asynchronously (LIVE-34742)
+
+`cardApiExtra.getCardSessionToken` now returns a promise, and the Card base query awaits it. The
+session is about to live in OS secure storage, which only reads asynchronously. Behaviour does not
+change yet: the accessor still answers from memory.

--- a/domain/api/card-management/src/api.test.ts
+++ b/domain/api/card-management/src/api.test.ts
@@ -28,7 +28,9 @@ const session = {
 };
 
 // Wired the way the apps wire it: the store registers the service api, never this package.
-const makeStore = (getCardSessionToken: () => string | null = () => null) =>
+const makeStore = (
+  getCardSessionToken: () => Promise<string | null> = () => Promise.resolve(null),
+) =>
   configureStore({
     reducer: {
       [cardApi.reducerPath]: cardApi.reducer,
@@ -191,7 +193,7 @@ describe("cardManagementApi requests", () => {
     it("sends the session bearer token alongside the client key", async () => {
       fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ success: true }));
 
-      const store = makeStore(() => "session-token");
+      const store = makeStore(async () => "session-token");
       const result = await store.dispatch(cardManagementApi.endpoints.logout.initiate());
 
       expect(request(fetchSpy).url).toBe("https://card.test/v1/auth/logout");
@@ -220,7 +222,7 @@ describe("cardManagementApi requests", () => {
         }),
       );
 
-      const store = makeStore(() => "session-token");
+      const store = makeStore(async () => "session-token");
       const result = await store.dispatch(cardManagementApi.endpoints.getUser.initiate());
 
       expect(request(fetchSpy).url).toBe("https://card.test/v1/user");

--- a/features/platform/card/src/session/cardSession.test.ts
+++ b/features/platform/card/src/session/cardSession.test.ts
@@ -5,15 +5,15 @@ describe("cardSession", () => {
     cardSession.clear();
   });
 
-  it("starts empty", () => {
+  it("starts empty", async () => {
     expect(cardSession.getToken()).toBeNull();
-    expect(getCardSessionToken()).toBeNull();
+    await expect(getCardSessionToken()).resolves.toBeNull();
   });
 
-  it("stores and reads the session token", () => {
+  it("stores and reads the session token", async () => {
     cardSession.set("session-token");
     expect(cardSession.getToken()).toBe("session-token");
-    expect(getCardSessionToken()).toBe("session-token");
+    await expect(getCardSessionToken()).resolves.toBe("session-token");
   });
 
   it("treats a nullish token as cleared", () => {

--- a/features/platform/card/src/session/cardSession.ts
+++ b/features/platform/card/src/session/cardSession.ts
@@ -13,7 +13,11 @@ export const cardSession = {
   },
 };
 
-export function getCardSessionToken(): string | null | undefined {
+/**
+ * Async because the store behind it is about to become OS secure storage, which only reads
+ * asynchronously. The Card base query awaits this value on every request.
+ */
+export async function getCardSessionToken(): Promise<string | null | undefined> {
   return cardSession.getToken();
 }
 

--- a/shared/api-services/src/services/card/api.test.ts
+++ b/shared/api-services/src/services/card/api.test.ts
@@ -127,6 +127,38 @@ describe("cardBaseQuery", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(result.error).toMatchObject({ status: 401 });
   });
+
+  it("reports a structured error and sends nothing when the token read rejects", async () => {
+    fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({}));
+
+    const { api, store } = probeStore(
+      cardApiExtra(
+        buildExtra({
+          getCardSessionToken: async () => {
+            throw new Error("keychain unavailable");
+          },
+        }),
+      ),
+    );
+    const result = await store.dispatch(api.endpoints.probe.initiate());
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.error).toEqual({ status: "CUSTOM_ERROR", error: "keychain unavailable" });
+  });
+
+  it("returns the 401 when the refresh rejects", async () => {
+    fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({}, 401));
+    const refreshCardSession = jest.fn(async () => {
+      throw new Error("keychain unavailable");
+    });
+
+    const { api, store } = probeStore(cardApiExtra(buildExtra({ refreshCardSession })));
+    const result = await store.dispatch(api.endpoints.probe.initiate());
+
+    expect(refreshCardSession).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(result.error).toMatchObject({ status: 401 });
+  });
 });
 
 function jsonResponse(body: unknown, status = 200): Response {

--- a/shared/api-services/src/services/card/api.test.ts
+++ b/shared/api-services/src/services/card/api.test.ts
@@ -6,7 +6,7 @@ function buildExtra(overrides: Partial<CardApiExtra> = {}): CardApiExtra {
   return {
     cardApiBaseUrl: "https://card.test",
     cardBaanxClientKey: "test-client-key",
-    getCardSessionToken: () => "session-token",
+    getCardSessionToken: async () => "session-token",
     refreshCardSession: async () => "refreshed-token",
     ...overrides,
   };
@@ -90,7 +90,7 @@ describe("cardBaseQuery", () => {
     fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({}));
 
     const { api, store } = probeStore(
-      cardApiExtra(buildExtra({ getCardSessionToken: () => null })),
+      cardApiExtra(buildExtra({ getCardSessionToken: async () => null })),
     );
     await store.dispatch(api.endpoints.probe.initiate());
 

--- a/shared/api-services/src/services/card/api.ts
+++ b/shared/api-services/src/services/card/api.ts
@@ -20,6 +20,21 @@ export function getCardExtra(api: { extra: unknown }): CardApiExtra {
 
 const UNAUTHORIZED_STATUS = 401;
 
+/**
+ * `BaseQueryFn` promises a result, and RTK Query has no branch for a rejection: it logs the error,
+ * throws it again, and stores a `SerializedError` that carries no `status`. Every caller that reads
+ * `error.status` then reads `undefined`. The app owns both session ports, so this file cannot
+ * promise they resolve. It gives a rejection the shape the signature declares.
+ */
+function sessionError(error: unknown): { error: FetchBaseQueryError } {
+  return {
+    error: {
+      status: "CUSTOM_ERROR",
+      error: error instanceof Error ? error.message : String(error),
+    },
+  };
+}
+
 const cardBaseQuery: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError> = async (
   args,
   api,
@@ -40,7 +55,16 @@ const cardBaseQuery: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryErro
       },
     })(args, api, extraOptions);
 
-  const result = await runWithToken(await extra.getCardSessionToken());
+  let token: string | null | undefined;
+  try {
+    token = await extra.getCardSessionToken();
+  } catch (error) {
+    // A request without the token answers 401. The refresh below cannot help, and that answer would
+    // hide the read failure. Report the failure instead.
+    return sessionError(error);
+  }
+
+  const result = await runWithToken(token);
 
   const isUnauthorized =
     !!result.error &&
@@ -51,7 +75,14 @@ const cardBaseQuery: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryErro
     return result;
   }
 
-  const refreshedToken = await extra.refreshCardSession();
+  let refreshedToken: string | null | undefined;
+  try {
+    refreshedToken = await extra.refreshCardSession();
+  } catch {
+    // The 401 tells the caller more than a failed refresh does.
+    return result;
+  }
+
   if (!refreshedToken) {
     return result;
   }

--- a/shared/api-services/src/services/card/api.ts
+++ b/shared/api-services/src/services/card/api.ts
@@ -40,7 +40,7 @@ const cardBaseQuery: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryErro
       },
     })(args, api, extraOptions);
 
-  const result = await runWithToken(extra.getCardSessionToken());
+  const result = await runWithToken(await extra.getCardSessionToken());
 
   const isUnauthorized =
     !!result.error &&

--- a/shared/api-services/src/services/card/schema.ts
+++ b/shared/api-services/src/services/card/schema.ts
@@ -3,7 +3,8 @@ import { z } from "zod";
 export const CardApiExtraSchema = z.object({
   cardApiBaseUrl: z.string().min(1),
   cardBaanxClientKey: z.string(),
-  getCardSessionToken: z.custom<() => string | null | undefined>(
+  /** Async: the owner reads the session from OS secure storage on every call. */
+  getCardSessionToken: z.custom<() => Promise<string | null | undefined>>(
     value => typeof value === "function",
     { message: "getCardSessionToken must be a function" },
   ),


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

`cardApiExtra.getCardSessionToken` now returns a promise, and the Card base query awaits it.

**Why it is required.** The Card session is about to live in the OS keychain, and
`react-native-keychain` only reads asynchronously (`getGenericPassword`). The base query reads the
token synchronously today and hands it to a synchronous `prepareHeaders`, so the value has to be a
plain string by the time the headers are built. A keychain read cannot be. The accessor has to become
async before anything can persist the session.

Three files change, because the contract and its one caller and its one implementation must move
together:

| File | Change |
| --- | --- |
| `shared/api-services/…/card/schema.ts` | the `CardApiExtra` contract becomes `() => Promise<string \| null \| undefined>` |
| `shared/api-services/…/card/api.ts` | the base query awaits the token, and answers a result when a port rejects |
| `features/platform/card/…/cardSession.ts` | the implementation becomes `async` |

**No behaviour changes.** The accessor still answers from memory. It only returns a promise now.

**An await can reject.** `BaseQueryFn` declares a result, and RTK Query has no branch for a rejection:
it logs the error, throws it again, and stores a `SerializedError` that carries no `status`. Every
caller that reads `error.status` then reads `undefined`. The app owns both session ports, so the base
query guards them. A token read that rejects answers `{ status: "CUSTOM_ERROR", error }` and sends no
request. A refresh that rejects answers the original 401. No port rejects today, so this guard protects
the layers above.

**The `await` on the token is the load-bearing part.** Without it the token is a `Promise`, `if (token)` is
true, and every Card request carries the header `Authorization: Bearer [object Promise]` — a 401 that
looks like a backend fault. The base query is the only caller, so that single line is the whole runtime
risk of this PR.

Both apps' `configureStore.ts` need no edit: they pass the function by reference. They are the
typecheck surface that proves the new signature lines up.

**How it fits the bigger picture.** This is the first of four layers that complete the Pay Card login.
Each one is green on its own:

1. **This PR** — the accessor becomes async. Contract only, no behaviour change.
2. #20809 — `@features/platform-card` persists the session with `react-native-keychain`, and reads the
   access token on every request. This is what needs the async accessor.
3. #20810 — the XState login machine: verify the redirect, exchange the code, store the session, read
   `GET /v1/user`.
4. #20816 — show the signed-in card holder, and let them log out.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34742](https://ledgerhq.atlassian.net/browse/LIVE-34742)
- **ADR** (if any): —


[LIVE-34742]: https://ledgerhq.atlassian.net/browse/LIVE-34742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
