### PR TITLE
fix(coin-zcash): exclude immature ironwood notes from the spendable pool

### DIFF
--- a/.changeset/LIVE-35995-ironwood-note-maturity.md
+++ b/.changeset/LIVE-35995-ironwood-note-maturity.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-zcash": patch
+"ledger-live-desktop": patch
+---
+
+Exclude immature Ironwood notes from the spendable pool. A shielded note is only spendable once its transaction is buried deep enough to have a witness at the builder's anchor, so a freshly scanned change note is no longer selected while a second send is prepared within the same confirmation window. The rule is applied wherever the spendable pool is derived — note selection, max-spendable and amount validation — and the send flow now reports insufficient spendable funds instead of failing when the transaction is built. Funds held by maturing notes stay part of the account's total balance.

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/AccountBalanceSummaryFooter.tsx
@@ -29,6 +29,11 @@ import {
   getPrivateBalance,
   getTransparentBalance,
 } from "@ledgerhq/coin-zcash/logic/account/balance";
+import {
+  getSpendableIronwoodBalance,
+  hasMaturingIronwoodNotes,
+} from "@ledgerhq/coin-zcash/logic/account/spendability";
+import { getReservedNullifiers } from "@ledgerhq/coin-zcash/bridge/note-reservation";
 import { selectShieldedSubscriptions } from "~/renderer/reducers/shieldedSyncSubscriptions";
 import { useZcashShieldedSync } from "./useZcashShieldedSync";
 
@@ -95,6 +100,13 @@ const AmountValue = styled(Text).attrs(() => ({
 }))<{ paddingRight?: number }>`
   ${p => p.paddingRight && `padding-right: ${p.paddingRight}px`};
 `;
+
+const MaturingAmount = styled(Text).attrs(() => ({
+  fontSize: 2,
+  ff: "Inter|Regular",
+  color: "neutral.c70",
+  mt: 1,
+}))``;
 
 const ActionButton = ({
   t,
@@ -339,12 +351,27 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
   // flag-ON no longer yields an under-reported or negative transparent balance.
   const bitcoinResources = "bitcoinResources" in account ? account.bitcoinResources : undefined;
   const _transparentBalance = getTransparentBalance(bitcoinResources?.utxos);
+  // The account page reports holdings, so this stays the account's total
+  // private balance -- funds held by an immature note remain part of it and
+  // stay visible, never made to look like they vanished.
   const _privateBalance = getPrivateBalance(privateInfo);
   const _availableBalance = balance ?? BigNumber(0);
+
+  const zcashAccount = account as ZcashAccount;
+  const hasMaturingFunds = hasMaturingIronwoodNotes(zcashAccount);
+  // The maturing amount is what the total holds beyond what selection could
+  // currently spend -- derived from the same filter as the send flow, so it
+  // can never disagree with it.
+  const _maturingAmount = hasMaturingFunds
+    ? _privateBalance.minus(
+        getSpendableIronwoodBalance(zcashAccount, getReservedNullifiers(zcashAccount)),
+      )
+    : BigNumber(0);
 
   const transparentBalanceLabel = formatCurrencyUnit(unit, _transparentBalance, formatConfig);
   const privateBalanceLabel = formatCurrencyUnit(unit, _privateBalance, formatConfig);
   const availableBalanceLabel = formatCurrencyUnit(unit, _availableBalance, formatConfig);
+  const maturingAmountLabel = formatCurrencyUnit(unit, _maturingAmount, formatConfig);
 
   return (
     <Container>
@@ -387,6 +414,16 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
           <AmountValue>
             <Discreet>{privateBalanceLabel}</Discreet>
           </AmountValue>
+          {hasMaturingFunds ? (
+            <MaturingAmount data-testid="zcash-private-maturing-amount">
+              <Discreet>
+                <Trans
+                  i18nKey="zcash.account.privateBalanceMaturing"
+                  values={{ amount: maturingAmountLabel }}
+                />
+              </Discreet>
+            </MaturingAmount>
+          ) : null}
         </BalanceDetail>
         <BalanceDetail>
           <div

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/AccountBalanceSummaryFooter.tsx
@@ -30,6 +30,7 @@ import {
   getTransparentBalance,
 } from "@ledgerhq/coin-zcash/logic/account/balance";
 import {
+  getMaturingIronwoodBalance,
   getSpendableIronwoodBalance,
   hasMaturingIronwoodNotes,
 } from "@ledgerhq/coin-zcash/logic/account/spendability";
@@ -359,19 +360,24 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
 
   const zcashAccount = account as ZcashAccount;
   const hasMaturingFunds = hasMaturingIronwoodNotes(zcashAccount);
-  // The maturing amount is what the total holds beyond what selection could
-  // currently spend -- derived from the same filter as the send flow, so it
-  // can never disagree with it.
-  const _maturingAmount = hasMaturingFunds
-    ? _privateBalance.minus(
-        getSpendableIronwoodBalance(zcashAccount, getReservedNullifiers(zcashAccount)),
-      )
-    : BigNumber(0);
+  // Spending one note returns its whole remainder as a single fresh note, so
+  // right after a send nearly the entire private balance is maturing. Leading
+  // with what is still spendable is what keeps that from reading as "all your
+  // funds are locked", and it is the figure the send flow will actually offer.
+  const _spendableBalance = getSpendableIronwoodBalance(
+    zcashAccount,
+    getReservedNullifiers(zcashAccount),
+  );
+  // Counted from immaturity alone, not as `total - spendable`: that difference
+  // also swallows the notes an in-flight spend has reserved, which would label
+  // a pending transaction of the user's own as "maturing".
+  const _maturingAmount = getMaturingIronwoodBalance(zcashAccount);
 
   const transparentBalanceLabel = formatCurrencyUnit(unit, _transparentBalance, formatConfig);
   const privateBalanceLabel = formatCurrencyUnit(unit, _privateBalance, formatConfig);
   const availableBalanceLabel = formatCurrencyUnit(unit, _availableBalance, formatConfig);
   const maturingAmountLabel = formatCurrencyUnit(unit, _maturingAmount, formatConfig);
+  const spendableBalanceLabel = formatCurrencyUnit(unit, _spendableBalance, formatConfig);
 
   return (
     <Container>
@@ -419,7 +425,7 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
               <Discreet>
                 <Trans
                   i18nKey="zcash.account.privateBalanceMaturing"
-                  values={{ amount: maturingAmountLabel }}
+                  values={{ spendable: spendableBalanceLabel, maturing: maturingAmountLabel }}
                 />
               </Discreet>
             </MaturingAmount>

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZcashTransferFromSelector.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZcashTransferFromSelector.tsx
@@ -7,11 +7,12 @@ import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import type { Account } from "@ledgerhq/types-live";
 import type { Transaction, ZcashAccount } from "@ledgerhq/live-common/families/bitcoin/types";
 import type { Transaction as ZcashTransaction } from "@ledgerhq/coin-zcash/types";
+import { getTransparentBalance } from "@ledgerhq/coin-zcash/logic/account/balance";
 import {
-  getPrivateBalance,
-  getTransparentBalance,
-  hasRecentlyShieldedFunds,
-} from "@ledgerhq/coin-zcash/logic/account/balance";
+  getSpendableIronwoodBalance,
+  hasMaturingIronwoodNotes,
+} from "@ledgerhq/coin-zcash/logic/account/spendability";
+import { getReservedNullifiers } from "@ledgerhq/coin-zcash/bridge/note-reservation";
 import { useSelector } from "LLD/hooks/redux";
 import { localeSelector } from "~/renderer/reducers/settings";
 import Box from "~/renderer/components/Box/Box";
@@ -102,15 +103,19 @@ const ZcashTransferFromSelector = ({ account, transaction, onChange }: Props) =>
   const zcashAccount = account as ZcashAccount;
   const privateInfo = zcashAccount.privateInfo;
   const fvkAvailable = Boolean(privateInfo?.ufvk);
-  // Same helpers as AccountBalanceSummaryFooter: private = Ironwood only
-  // (deprecated Orchard/Sapling send flows are gone), transparent = own UTXOs
-  // (not balance − private, which diverges across flag/module provenance).
-  const privateBalance = getPrivateBalance(privateInfo);
+  // Unlike AccountBalanceSummaryFooter's total, this figure is what the send
+  // flow can actually select from: mature, unreserved Ironwood notes.
+  // transparent = own UTXOs (not balance − private, which diverges across
+  // flag/module provenance).
+  const privateBalance = getSpendableIronwoodBalance(
+    zcashAccount,
+    getReservedNullifiers(zcashAccount),
+  );
   const transparentBalance = getTransparentBalance(zcashAccount.bitcoinResources?.utxos);
-  // Only warn while a freshly shielded note may still be maturing (until its
-  // transaction has enough confirmations); once everything is spendable the
-  // private balance no longer trails the total.
-  const showSpendableWarning = sender === "private" && hasRecentlyShieldedFunds(privateInfo);
+  // Only warn while a freshly shielded or changed note may still be maturing
+  // (until its transaction has enough confirmations); once everything is
+  // spendable the private balance no longer trails the total.
+  const showSpendableWarning = sender === "private" && hasMaturingIronwoodNotes(zcashAccount);
 
   const formatConfig = { showCode: true, discreet, locale };
   const transparentLabel = formatCurrencyUnit(unit, transparentBalance, formatConfig);

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/ZcashTransferFromSelector.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/ZcashTransferFromSelector.test.tsx
@@ -36,6 +36,45 @@ const makeUtxo = (value: number) => ({
   isChange: false,
 });
 
+// Reference height for note maturity: the spendable-balance figure and the
+// maturing-funds warning are both derived from real Ironwood notes, mature
+// once buried at least ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS below
+// `lastProcessedBlock`. `collectIronwoodSpendableNotes` (and so the maturity
+// filter) only ever admits "incoming"/"internal" notes carrying every
+// spending field, which is what this note fixture provides.
+const TIP = 1_000_000; // latest scanned block height
+const MATURE_BLOCK = TIP - ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS;
+const ironwoodNote = (
+  amount: number,
+  index: number,
+  transferType: "incoming" | "internal" = "incoming",
+) => ({
+  amount: new BigNumber(amount),
+  transfer_type: transferType,
+  memo: "",
+  nullifier: index.toString(16).padStart(2, "0").repeat(32),
+  rho: "ee".repeat(32),
+  rseed: "ff".repeat(32),
+  cmx: "11".repeat(32),
+  position: String(index),
+  recipient: "22".repeat(43),
+  isSpent: false,
+});
+const shieldedTx = (
+  blockHeight: number,
+  notes: ReturnType<typeof ironwoodNote>[],
+): ShieldedTransaction =>
+  ({
+    blockHeight,
+    decryptedData: {
+      orchard_outputs: [],
+      sapling_outputs: [],
+      ironwood_outputs: notes,
+    },
+  }) as unknown as ShieldedTransaction;
+const recentShieldedTx = () => shieldedTx(TIP - 1, [ironwoodNote(5000, 0)]);
+const oldShieldedTx = () => shieldedTx(MATURE_BLOCK, [ironwoodNote(5000, 0)]);
+
 const buildAccount = (overrides: Partial<typeof DEFAULT_ZCASH_PRIVATE_INFO> = {}, isZcash = true) =>
   ({
     ...baseAccount,
@@ -129,6 +168,8 @@ describe("ZcashTransferFromSelector", () => {
         orchardBalance: new BigNumber(0),
         saplingBalance: new BigNumber(0),
         ufvk: "uview-test",
+        lastProcessedBlock: TIP,
+        transactions: [shieldedTx(MATURE_BLOCK, [ironwoodNote(50_000_000, 0)])],
       }),
       {},
     );
@@ -176,6 +217,8 @@ describe("ZcashTransferFromSelector", () => {
         ...buildAccount({
           ironwoodBalance: new BigNumber(50_000_000),
           ufvk: "uview-test",
+          lastProcessedBlock: TIP,
+          transactions: [shieldedTx(MATURE_BLOCK, [ironwoodNote(50_000_000, 0)])],
         }),
         // Stale provenance: balance − ironwood would wrongly yield 0.4 ZEC;
         // UTXOs keep Public correct at 0.1 ZEC.
@@ -189,19 +232,6 @@ describe("ZcashTransferFromSelector", () => {
     expect(screen.getByTestId("transfer-from-public")).not.toHaveTextContent(/0\.4 ZEC/);
     expect(screen.getByTestId("transfer-from-private")).toHaveTextContent(/0\.5 ZEC/);
   });
-
-  const TIP = 1_000_000; // latest scanned block height
-  const outgoingShieldedTx = (blockHeight: number) =>
-    ({
-      blockHeight,
-      decryptedData: {
-        orchard_outputs: [],
-        sapling_outputs: [],
-        ironwood_outputs: [{ amount: new BigNumber(5000), memo: "", transfer_type: "outgoing" }],
-      },
-    }) as unknown as ShieldedTransaction;
-  const recentShieldedTx = () => outgoingShieldedTx(TIP - 1);
-  const oldShieldedTx = () => outgoingShieldedTx(TIP - ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS);
 
   it(`shows the spendable-balance warning when Private is selected and funds were shielded within the last ${ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS} blocks`, () => {
     renderSelector(

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8938,7 +8938,8 @@
       "transparentBalanceTooltip": "Balance that is visible to the public",
       "privateBalance": "Private balance",
       "privateBalanceTooltip": "Balance that is hidden from the public",
-      "privateBalanceWarning": "Private balance excludes Sapling and Orchard shielded funds"
+      "privateBalanceWarning": "Private balance excludes Sapling and Orchard shielded funds",
+      "privateBalanceMaturing": "{{amount}} maturing, spendable in a few minutes"
     },
     "shielded": {
       "send": {

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8939,7 +8939,7 @@
       "privateBalance": "Private balance",
       "privateBalanceTooltip": "Balance that is hidden from the public",
       "privateBalanceWarning": "Private balance excludes Sapling and Orchard shielded funds",
-      "privateBalanceMaturing": "{{amount}} maturing, spendable in a few minutes"
+      "privateBalanceMaturing": "{{spendable}} spendable · {{maturing}} maturing"
     },
     "shielded": {
       "send": {

--- a/libs/coin-modules/coin-zcash/src/bridge/estimateMaxSpendable.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/estimateMaxSpendable.test.ts
@@ -2,12 +2,12 @@ import { BigNumber } from "bignumber.js";
 import { estimateMaxSpendable } from "./estimateMaxSpendable";
 import { computeShieldedSpendFee } from "../logic/coin-selection";
 import type { Transaction, ZcashAccount } from "../types/bridge";
+import { ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS } from "../constants";
 
 const U_ADDRESS =
   "u1u2h4ce7e2cn3z4nzur95muq2dl4da9x8h8kdp2l80gm9nl9raj8zzpx79ycjnfvar4v5exea5pqr5y9qsnlp0cdunwf9yjjx5c4q7ar9";
 const REFERENCE_HEIGHT = 3_450_000;
-const MATURE_DELAY = 12; // mirrors ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS
-const MATURE_BLOCK = REFERENCE_HEIGHT - MATURE_DELAY;
+const MATURE_BLOCK = REFERENCE_HEIGHT - ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS;
 const IMMATURE_BLOCK = REFERENCE_HEIGHT - 3;
 
 const nullifierAt = (index: number) => index.toString(16).padStart(2, "0").repeat(32);

--- a/libs/coin-modules/coin-zcash/src/bridge/estimateMaxSpendable.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/estimateMaxSpendable.test.ts
@@ -1,0 +1,112 @@
+import { BigNumber } from "bignumber.js";
+import { estimateMaxSpendable } from "./estimateMaxSpendable";
+import { computeShieldedSpendFee } from "../logic/coin-selection";
+import type { Transaction, ZcashAccount } from "../types/bridge";
+
+const U_ADDRESS =
+  "u1u2h4ce7e2cn3z4nzur95muq2dl4da9x8h8kdp2l80gm9nl9raj8zzpx79ycjnfvar4v5exea5pqr5y9qsnlp0cdunwf9yjjx5c4q7ar9";
+const REFERENCE_HEIGHT = 3_450_000;
+const MATURE_DELAY = 12; // mirrors ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS
+const MATURE_BLOCK = REFERENCE_HEIGHT - MATURE_DELAY;
+const IMMATURE_BLOCK = REFERENCE_HEIGHT - 3;
+
+const nullifierAt = (index: number) => index.toString(16).padStart(2, "0").repeat(32);
+
+const note = (amount: number, index: number) => ({
+  amount: new BigNumber(amount),
+  transfer_type: "incoming",
+  memo: "",
+  nullifier: nullifierAt(index),
+  rho: "ee".repeat(32),
+  rseed: "ff".repeat(32),
+  cmx: "11".repeat(32),
+  position: String(index),
+  recipient: "22".repeat(43),
+  isSpent: false,
+});
+
+/** One Ironwood note per transaction, so each can carry its own block height. */
+function accountWithIronwoodNotes(
+  specs: Array<{ amount: number; blockHeight: number }>,
+): ZcashAccount {
+  return {
+    type: "Account",
+    id: "js:2:zcash:xpub6D:",
+    currency: { id: "zcash", name: "Zcash" },
+    bitcoinResources: { utxos: [] },
+    privateInfo: {
+      lastProcessedBlock: REFERENCE_HEIGHT,
+      transactions: specs.map((spec, i) => ({
+        id: `tx-${i}`,
+        hex: "00",
+        blockHeight: spec.blockHeight,
+        blockHash: "cc".repeat(32),
+        timestamp: 1_700_000_000,
+        fee: new BigNumber(0),
+        decryptedData: {
+          orchard_outputs: [],
+          sapling_outputs: [],
+          ironwood_outputs: [note(spec.amount, i)],
+        },
+      })),
+    },
+  } as unknown as ZcashAccount;
+}
+
+const shieldedTransaction: Transaction = {
+  family: "zcash",
+  transferType: "shielded",
+  amount: new BigNumber(0),
+  recipient: U_ADDRESS,
+  useAllAmount: true,
+} as Transaction;
+
+const max = (acc: ZcashAccount) =>
+  estimateMaxSpendable({
+    account: acc,
+    transaction: shieldedTransaction,
+  } as never);
+
+describe("estimateMaxSpendable, note maturity", () => {
+  it("excludes immature notes from the figure it computes", async () => {
+    const acc = accountWithIronwoodNotes([
+      { amount: 30_000, blockHeight: MATURE_BLOCK },
+      { amount: 50_000, blockHeight: IMMATURE_BLOCK },
+    ]);
+
+    // Only the 30k mature note counts: total 30k minus the 1-spend fee.
+    const fee = computeShieldedSpendFee(1, false, "shielded");
+    expect(await max(acc)).toEqual(BigNumber.max(new BigNumber(30_000).minus(fee), 0));
+  });
+
+  it("equals the mature-only total minus the fee for spending all of it", async () => {
+    const acc = accountWithIronwoodNotes([
+      { amount: 20_000, blockHeight: MATURE_BLOCK },
+      { amount: 30_000, blockHeight: MATURE_BLOCK },
+      { amount: 50_000, blockHeight: IMMATURE_BLOCK },
+    ]);
+
+    // Two mature notes, spent whole: 50k minus the 2-spend fee.
+    const fee = computeShieldedSpendFee(2, false, "shielded");
+    expect(await max(acc)).toEqual(BigNumber.max(new BigNumber(50_000).minus(fee), 0));
+  });
+
+  it("returns 0 when every note is immature", async () => {
+    const acc = accountWithIronwoodNotes([
+      { amount: 30_000, blockHeight: IMMATURE_BLOCK },
+      { amount: 50_000, blockHeight: IMMATURE_BLOCK },
+    ]);
+
+    expect(await max(acc)).toEqual(new BigNumber(0));
+  });
+
+  it("returns the full total when every note is mature", async () => {
+    const acc = accountWithIronwoodNotes([
+      { amount: 30_000, blockHeight: MATURE_BLOCK },
+      { amount: 20_000, blockHeight: MATURE_BLOCK },
+    ]);
+
+    const fee = computeShieldedSpendFee(2, false, "shielded");
+    expect(await max(acc)).toEqual(BigNumber.max(new BigNumber(50_000).minus(fee), 0));
+  });
+});

--- a/libs/coin-modules/coin-zcash/src/bridge/estimateMaxSpendable.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/estimateMaxSpendable.ts
@@ -1,13 +1,13 @@
 import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account/index";
 import type { AccountBridge } from "@ledgerhq/types-live";
 import type { Transaction, ZcashAccount } from "../types/bridge";
-import { collectIronwoodSpendableNotes } from "./operations";
 import {
   estimateMaxSpendableAmount,
   estimateMaxSpendableTransparent,
 } from "../logic/coin-selection";
 import { isTransparentInputTransfer, resolveTransparentUtxos } from "./statusHelpers";
 import { getReservedNullifiers } from "./note-reservation";
+import { collectSelectableIronwoodNotes } from "../logic/account/spendability";
 
 export const estimateMaxSpendable: AccountBridge<
   Transaction,
@@ -28,9 +28,6 @@ export const estimateMaxSpendable: AccountBridge<
     return estimateMaxSpendableTransparent(utxoValues, "transparent");
   }
 
-  const transactions = mainAccount.privateInfo?.transactions ?? [];
-  const allNotes = collectIronwoodSpendableNotes(transactions);
-  const reserved = getReservedNullifiers(mainAccount);
-  const notes = reserved.size > 0 ? allNotes.filter(n => !reserved.has(n.nullifier)) : allNotes;
+  const notes = collectSelectableIronwoodNotes(mainAccount, getReservedNullifiers(mainAccount));
   return estimateMaxSpendableAmount(notes, transferType);
 };

--- a/libs/coin-modules/coin-zcash/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/getTransactionStatus.test.ts
@@ -15,6 +15,10 @@ const U_ADDRESS =
   "u1u2h4ce7e2cn3z4nzur95muq2dl4da9x8h8kdp2l80gm9nl9raj8zzpx79ycjnfvar4v5exea5pqr5y9qsnlp0cdunwf9yjjx5c4q7ar9";
 const ZS_ADDRESS = "zs1z7rejlpsa98s2rrrfkwmaxu53e4ue0ulcrw0h4x5g8jl04tak0d3mm47vdtahatqrlkngh9slya";
 
+const REFERENCE_HEIGHT = 3_450_000;
+const MATURE_BLOCK = REFERENCE_HEIGHT - 12; // mirrors ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS
+const FRESH_BLOCK = REFERENCE_HEIGHT - 3; // still maturing
+
 const note = (amount: number, index = 1): SpendableNote =>
   ({
     amount: new BigNumber(amount),
@@ -26,6 +30,20 @@ const note = (amount: number, index = 1): SpendableNote =>
     recipient: "22".repeat(43),
     isSpent: false,
   }) as unknown as SpendableNote;
+
+/** A raw pool note, as scanned into `ShieldedTransaction.decryptedData.ironwood_outputs`. */
+const poolNote = (amount: number, index: number) => ({
+  amount: new BigNumber(amount),
+  transfer_type: "incoming",
+  memo: "",
+  nullifier: index.toString(16).padStart(2, "0").repeat(32),
+  rho: "ee".repeat(32),
+  rseed: "ff".repeat(32),
+  cmx: "11".repeat(32),
+  position: String(index),
+  recipient: "22".repeat(43),
+  isSpent: false,
+});
 
 const utxo = (value: number, outputIndex = 0): BitcoinOutput => ({
   hash: "aa".repeat(32),
@@ -40,14 +58,58 @@ const utxo = (value: number, outputIndex = 0): BitcoinOutput => ({
 function account({
   utxos = [100_000, 25_000],
   orchardBalance = 50_000,
-  ironwoodBalance = 50_000,
+  ironwoodNotes = [50_000],
+  freshIronwoodNotes = [],
   synced = true,
+  lastProcessedBlock = REFERENCE_HEIGHT,
 }: {
   utxos?: number[];
   orchardBalance?: number;
-  ironwoodBalance?: number;
+  /** Mature Ironwood notes -- scanned deep enough below `lastProcessedBlock`. */
+  ironwoodNotes?: number[];
+  /** Ironwood notes scanned only a few blocks ago -- still maturing. */
+  freshIronwoodNotes?: number[];
   synced?: boolean;
+  lastProcessedBlock?: number | null;
 } = {}): ZcashAccount {
+  const ironwoodBalance = [...ironwoodNotes, ...freshIronwoodNotes].reduce((s, v) => s + v, 0);
+  const transactions = [
+    ...(ironwoodNotes.length
+      ? [
+          {
+            id: "mature-tx",
+            hex: "00",
+            blockHeight: MATURE_BLOCK,
+            blockHash: "cc".repeat(32),
+            timestamp: 1_700_000_000,
+            fee: new BigNumber(0),
+            decryptedData: {
+              orchard_outputs: [],
+              sapling_outputs: [],
+              ironwood_outputs: ironwoodNotes.map((amount, i) => poolNote(amount, i)),
+            },
+          },
+        ]
+      : []),
+    ...(freshIronwoodNotes.length
+      ? [
+          {
+            id: "fresh-tx",
+            hex: "00",
+            blockHeight: FRESH_BLOCK,
+            blockHash: "dd".repeat(32),
+            timestamp: 1_700_000_100,
+            fee: new BigNumber(0),
+            decryptedData: {
+              orchard_outputs: [],
+              sapling_outputs: [],
+              ironwood_outputs: freshIronwoodNotes.map((amount, i) => poolNote(amount, i + 100)),
+            },
+          },
+        ]
+      : []),
+  ];
+
   return {
     type: "Account",
     id: "js:2:zcash:xpub6D:",
@@ -58,6 +120,8 @@ function account({
           orchardBalance: new BigNumber(orchardBalance),
           ironwoodBalance: new BigNumber(ironwoodBalance),
           saplingBalance: new BigNumber(0),
+          lastProcessedBlock,
+          transactions,
         }
       : undefined,
   } as unknown as ZcashAccount;
@@ -360,7 +424,7 @@ describe("getTransactionStatus, note-spending flows", () => {
   ] as [ZcashTransferType, string][])(
     "bounds %s by the ironwood balance",
     async (transferType, recipient) => {
-      const acc = account({ orchardBalance: 10_000_000, ironwoodBalance: 20_000 });
+      const acc = account({ orchardBalance: 10_000_000, ironwoodNotes: [20_000] });
       const tx = transaction({
         transferType,
         recipient,
@@ -382,6 +446,36 @@ describe("getTransactionStatus, note-spending flows", () => {
       expect((await getTransactionStatus(acc, withinPool)).errors).toEqual({});
     },
   );
+
+  // The amount validated must be the same figure selection draws from, or the
+  // status can green-light a send the builder cannot satisfy.
+  it("rejects an amount the raw pool covers but the mature figure does not", async () => {
+    const acc = account({ ironwoodNotes: [10_000], freshIronwoodNotes: [40_000] });
+    const tx = transaction({
+      transferType: "shielded",
+      recipient: U_ADDRESS,
+      amount: new BigNumber(30_000),
+      selectedNotes: [note(30_000)],
+      zcashFee: new BigNumber(10_000),
+    });
+
+    expect((await getTransactionStatus(acc, tx)).errors.amount).toEqual(
+      new Error("Insufficient shielded balance"),
+    );
+  });
+
+  it("accepts an amount within the mature figure", async () => {
+    const acc = account({ ironwoodNotes: [10_000], freshIronwoodNotes: [40_000] });
+    const tx = transaction({
+      transferType: "shielded",
+      recipient: U_ADDRESS,
+      amount: new BigNumber(5_000),
+      selectedNotes: [note(10_000)],
+      zcashFee: new BigNumber(5_000),
+    });
+
+    expect((await getTransactionStatus(acc, tx)).errors).toEqual({});
+  });
 
   it("refuses a shielded send that selected no note, however full the pool", async () => {
     const status = await getTransactionStatus(

--- a/libs/coin-modules/coin-zcash/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/getTransactionStatus.test.ts
@@ -9,6 +9,7 @@ import {
 import { ZIP317_MINIMUM_FEE } from "../logic/coin-selection";
 import type { BitcoinOutput, Transaction, ZcashAccount, ZcashTransferType } from "../types/bridge";
 import type { SpendableNote } from "../network/types";
+import { ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS } from "../constants";
 
 const T_ADDRESS = "t1b1Rbw2shhJkP6MCnCyxCPuyFedHrwKty8";
 const U_ADDRESS =
@@ -16,7 +17,7 @@ const U_ADDRESS =
 const ZS_ADDRESS = "zs1z7rejlpsa98s2rrrfkwmaxu53e4ue0ulcrw0h4x5g8jl04tak0d3mm47vdtahatqrlkngh9slya";
 
 const REFERENCE_HEIGHT = 3_450_000;
-const MATURE_BLOCK = REFERENCE_HEIGHT - 12; // mirrors ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS
+const MATURE_BLOCK = REFERENCE_HEIGHT - ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS;
 const FRESH_BLOCK = REFERENCE_HEIGHT - 3; // still maturing
 
 const note = (amount: number, index = 1): SpendableNote =>

--- a/libs/coin-modules/coin-zcash/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/getTransactionStatus.ts
@@ -9,6 +9,8 @@ import {
   isTransparentInputTransfer,
   resolveTransparentUtxos,
 } from "./statusHelpers";
+import { getReservedNullifiers } from "./note-reservation";
+import { getSpendableIronwoodBalance } from "../logic/account/spendability";
 
 /**
  * Transaction status for a transparent-input (Public→*) send: the recipient
@@ -75,8 +77,10 @@ export const getTransactionStatus: AccountBridge<
     };
   }
 
-  // Shielded sends spend the Ironwood pool, so validate the amount against it.
-  const poolBalance = privateInfo.ironwoodBalance ?? new BigNumber(0);
+  // Shielded sends spend the Ironwood pool, so validate the amount against the
+  // mature, unreserved figure -- the same one selection draws from, so the
+  // status can never accept an amount selection cannot cover.
+  const poolBalance = getSpendableIronwoodBalance(account, getReservedNullifiers(account));
   const fee = transaction.zcashFee ?? new BigNumber(ZIP317_MINIMUM_FEE);
   const totalSpent = transaction.amount.plus(fee);
 

--- a/libs/coin-modules/coin-zcash/src/bridge/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/prepareTransaction.test.ts
@@ -3,6 +3,7 @@ import { prepareTransaction } from "./prepareTransaction";
 import { estimateMaxSpendable } from "./estimateMaxSpendable";
 import { reserveNotes, _resetReservationsForTest } from "./note-reservation";
 import { ZIP317_MINIMUM_FEE } from "../logic/coin-selection";
+import { ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS } from "../constants";
 import type { BitcoinOutput, Transaction, ZcashAccount, ZcashTransferType } from "../types/bridge";
 
 const T_ADDRESS = "t1b1Rbw2shhJkP6MCnCyxCPuyFedHrwKty8";
@@ -14,6 +15,9 @@ const IN_FLIGHT_TX = "76ec3b38";
 // The account fixture offsets the Ironwood pool by this much so the two pools
 // never share a nullifier or a position.
 const IRONWOOD_INDEX_OFFSET = 100;
+// Comfortably past every fixture note's block height, so the default account
+// carries only mature notes unless a test overrides it to probe maturity.
+const DEFAULT_LAST_PROCESSED_BLOCK = 3_500_000;
 
 const nullifierAt = (index: number) => index.toString(16).padStart(2, "0").repeat(32);
 
@@ -47,13 +51,20 @@ function account({
   utxos = [100_000, 25_000],
   notes = [40_000, 10_000],
   ironwoodNotes = [30_000, 20_000],
-}: { utxos?: number[]; notes?: number[]; ironwoodNotes?: number[] } = {}): ZcashAccount {
+  lastProcessedBlock = DEFAULT_LAST_PROCESSED_BLOCK,
+}: {
+  utxos?: number[];
+  notes?: number[];
+  ironwoodNotes?: number[];
+  lastProcessedBlock?: number | null;
+} = {}): ZcashAccount {
   return {
     type: "Account",
     id: ACCOUNT_ID,
     currency: { id: "zcash", name: "Zcash" },
     bitcoinResources: { utxos: utxos.map((value, i) => utxo(value, i)) },
     privateInfo: {
+      lastProcessedBlock,
       transactions: [
         {
           id: "932c99c7",
@@ -451,5 +462,114 @@ describe("reserved notes", () => {
         new BigNumber(20_000),
       );
     });
+  });
+});
+
+// Reproduces the field failure: a change note is scanned back into the pool a
+// few blocks after the send that created it, and a second send prepared
+// before it matures must not select it.
+describe("prepareTransaction, note maturity", () => {
+  const REFERENCE_HEIGHT = 3_450_000;
+  const MATURE_BLOCK = REFERENCE_HEIGHT - ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS;
+  const FRESH_CHANGE_BLOCK = REFERENCE_HEIGHT - 3;
+
+  function accountWithChangeNote({
+    matureAmount,
+    freshChangeAmount,
+    lastProcessedBlock = REFERENCE_HEIGHT,
+  }: {
+    matureAmount: number;
+    freshChangeAmount: number;
+    lastProcessedBlock?: number;
+  }): ZcashAccount {
+    return {
+      type: "Account",
+      id: ACCOUNT_ID,
+      currency: { id: "zcash", name: "Zcash" },
+      bitcoinResources: { utxos: [] },
+      privateInfo: {
+        lastProcessedBlock,
+        transactions: [
+          {
+            id: "confirmed-send",
+            hex: "00",
+            blockHeight: MATURE_BLOCK,
+            blockHash: "cc".repeat(32),
+            timestamp: 1_700_000_000,
+            fee: new BigNumber(15_000),
+            decryptedData: {
+              orchard_outputs: [],
+              sapling_outputs: [],
+              ironwood_outputs: [note(matureAmount, IRONWOOD_INDEX_OFFSET)],
+            },
+          },
+          {
+            id: "fresh-change",
+            hex: "00",
+            blockHeight: FRESH_CHANGE_BLOCK,
+            blockHash: "dd".repeat(32),
+            timestamp: 1_700_000_100,
+            fee: new BigNumber(10_000),
+            decryptedData: {
+              orchard_outputs: [],
+              sapling_outputs: [],
+              ironwood_outputs: [note(freshChangeAmount, IRONWOOD_INDEX_OFFSET + 1)],
+            },
+          },
+        ],
+      },
+    } as unknown as ZcashAccount;
+  }
+
+  // Largest-first would otherwise pick the 50k fresh change note over the 30k
+  // mature one; the maturity filter must keep it out of the selection.
+  it("excludes the fresh change note even though it is largest, selecting the mature one instead", async () => {
+    const acc = accountWithChangeNote({ matureAmount: 30_000, freshChangeAmount: 50_000 });
+
+    const prepared = await prepareTransaction(
+      acc,
+      transaction({
+        transferType: "shielded",
+        recipient: U_ADDRESS,
+        amount: new BigNumber(15_000),
+      }),
+    );
+
+    expect(prepared.selectedNotes?.map(n => n.amount.toNumber())).toEqual([30_000]);
+  });
+
+  it("reports a reset (no selection) when only the fresh change note could cover the amount", async () => {
+    const acc = accountWithChangeNote({ matureAmount: 10_000, freshChangeAmount: 50_000 });
+
+    const prepared = await prepareTransaction(
+      acc,
+      transaction({
+        transferType: "shielded",
+        recipient: U_ADDRESS,
+        amount: new BigNumber(25_000),
+      }),
+    );
+
+    expect(prepared.selectedNotes).toEqual([]);
+    expect(prepared).not.toHaveProperty("zcashFee");
+  });
+
+  it("makes the change note selectable once the reference height advances past the threshold", async () => {
+    const matured = accountWithChangeNote({
+      matureAmount: 10_000,
+      freshChangeAmount: 50_000,
+      lastProcessedBlock: FRESH_CHANGE_BLOCK + ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS,
+    });
+
+    const prepared = await prepareTransaction(
+      matured,
+      transaction({
+        transferType: "shielded",
+        recipient: U_ADDRESS,
+        amount: new BigNumber(25_000),
+      }),
+    );
+
+    expect(prepared.selectedNotes?.map(n => n.amount.toNumber())).toEqual([50_000]);
   });
 });

--- a/libs/coin-modules/coin-zcash/src/bridge/prepareTransaction.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/prepareTransaction.ts
@@ -2,7 +2,6 @@ import type { BigNumber } from "bignumber.js";
 import type { AccountBridge } from "@ledgerhq/types-live";
 import type { Transaction, ZcashAccount } from "../types/bridge";
 import type { SpendableNote } from "../network/types";
-import { collectIronwoodSpendableNotes } from "./operations";
 import {
   estimateMaxSpendableAmount,
   estimateMaxSpendableTransparent,
@@ -11,6 +10,7 @@ import {
 } from "../logic/coin-selection";
 import { isTransparentInputTransfer, resolveTransparentUtxos } from "./statusHelpers";
 import { getReservedNullifiers } from "./note-reservation";
+import { collectSelectableIronwoodNotes } from "../logic/account/spendability";
 
 // Strip any stale fee/change from a prior prepare and reset the amount so the UI
 // never shows a spendable amount without a matching fee.
@@ -79,9 +79,6 @@ export const prepareTransaction: AccountBridge<
     return prepareTransparentTransaction(account, tx);
   }
 
-  const transactions = account.privateInfo?.transactions ?? [];
-  const allNotes = collectIronwoodSpendableNotes(transactions);
-  const reserved = getReservedNullifiers(account);
-  const notes = reserved.size > 0 ? allNotes.filter(n => !reserved.has(n.nullifier)) : allNotes;
+  const notes = collectSelectableIronwoodNotes(account, getReservedNullifiers(account));
   return prepareNoteTransaction(notes, tx);
 };

--- a/libs/coin-modules/coin-zcash/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/signOperation.test.ts
@@ -21,6 +21,7 @@ import {
 import type { SpendableNote } from "../network/types";
 import type { SignerContext } from "../types/signer";
 import type { Transaction, ZcashAccount } from "../types/bridge";
+import { ZcashNotesNotYetSpendable } from "../types/errors";
 
 jest.mock("../logic/transaction/craftTransaction");
 jest.mock("../logic/transaction/combine");
@@ -381,6 +382,29 @@ describe("bridge/signOperation", () => {
         } as never),
       ),
     ).rejects.toThrow("V6 (Ironwood)");
+  });
+
+  // The maturity filter (logic/account/spendability) is meant to make this
+  // unreachable; this is the safety net for backend drift between the zaino
+  // instance the scan used and the one the builder queries.
+  it("surfaces a note-position-past-anchor build failure as the typed domain error", async () => {
+    mockCraftIronwoodTransaction.mockRejectedValue(
+      new Error(
+        "Error invoking remote method 'zcash:buildIronwoodTransaction': " +
+          "compute_ironwood_witnesses: note position 55985 is at or past anchor_total_leaves 55976 at anchor height 3447474",
+      ),
+    );
+    const signOp = buildSignOperation(makeSignerContext());
+
+    await expect(
+      lastValueFrom(
+        signOp({
+          account: makeAccount(),
+          deviceId: "device-1",
+          transaction: makeTx("shielded"),
+        } as never),
+      ),
+    ).rejects.toThrow(ZcashNotesNotYetSpendable);
   });
 
   it("rejects when the signer does not expose signPcztTransaction", async () => {

--- a/libs/coin-modules/coin-zcash/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/signOperation.ts
@@ -9,7 +9,11 @@ import type {
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import type { Transaction, ZcashAccount, BtcInputRef, ZcashOperationExtra } from "../types/bridge";
 import type { SignerContext } from "../types/signer";
-import { ZcashSignerNotSupported, ZcashSigningCancelled } from "../types/errors";
+import {
+  ZcashNotesNotYetSpendable,
+  ZcashSignerNotSupported,
+  ZcashSigningCancelled,
+} from "../types/errors";
 import { assertCanSend } from "../logic/engineClient";
 import { craftIronwoodTransaction, craftTransaction } from "../logic/transaction/craftTransaction";
 import { combine } from "../logic/transaction/combine";
@@ -30,6 +34,19 @@ const IRONWOOD_BUNDLE_TRANSFER_TYPES = new Set<Transaction["transferType"]>([
   "shielded-to-transparent",
   "transparent-to-shielded",
 ]);
+
+/**
+ * The builder's stable marker for a note whose leaf position is at or past the
+ * number of leaves the Ironwood tree held at its anchor -- the position-range
+ * rejection the maturity filter is meant to make unreachable (see
+ * `types/errors.ts`'s `ZcashNotesNotYetSpendable`). Matched on the message
+ * because the IPC wrapper carries the Rust error through verbatim, with no
+ * structured code.
+ */
+function isNotePositionPastAnchor(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("compute_ironwood_witnesses") && message.includes("anchor_total_leaves");
+}
 
 /**
  * The only bespoke residue of this bridge (kaspa-style): builds the PCZT
@@ -93,7 +110,10 @@ export const buildSignOperation =
 
         const useIronwood = IRONWOOD_BUNDLE_TRANSFER_TYPES.has(transaction.transferType);
         const buildResult = useIronwood
-          ? await craftIronwoodTransaction(plan)
+          ? await craftIronwoodTransaction(plan).catch(err => {
+              if (isNotePositionPastAnchor(err)) throw new ZcashNotesNotYetSpendable();
+              throw err;
+            })
           : await craftTransaction(plan);
 
         const { pcztTransaction } = buildResult;

--- a/libs/coin-modules/coin-zcash/src/logic/account/balance.ts
+++ b/libs/coin-modules/coin-zcash/src/logic/account/balance.ts
@@ -1,8 +1,6 @@
 import { BigNumber } from "bignumber.js";
 import type { BitcoinOutput } from "../../types/bridge";
 import type { ZcashPrivateInfo } from "../../network/types";
-import { ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS } from "../../constants";
-import { getTxType } from "../../bridge/operations";
 
 type PrivateBalances = Pick<
   ZcashPrivateInfo,
@@ -23,13 +21,20 @@ export function getTransparentBalance(
 }
 
 /**
- * Private (shielded) balance = the Ironwood pool only.
+ * Private (shielded) balance = the whole Ironwood pool, mature and immature
+ * notes alike.
  *
  * Ironwood is the only shielded pool that can be spent from the send flow; the
  * Orchard and Sapling pools are deprecated and their send flows are gone. They
- * are deliberately excluded so this value matches the spendable "Private
- * balance" shown in the send modal (see ZcashTransferFromSelector) instead of
- * exceeding it by any residual Orchard/Sapling notes.
+ * are deliberately excluded so this value stays close to the account's
+ * spendable Private funds, without exceeding them by any residual
+ * Orchard/Sapling notes.
+ *
+ * This is the account's **total** private balance, not what the send modal
+ * offers as spendable -- a note fresh enough to still be maturing counts here
+ * but is excluded from selection (see `getSpendableIronwoodBalance` in
+ * `logic/account/spendability`), which is the figure the send flow shows as
+ * spendable.
  *
  * Operations are not restricted the same way: they carry the real amount moved
  * in every pool (see `convertShieldedTransactionsToOperations`), so for an
@@ -38,33 +43,6 @@ export function getTransparentBalance(
 export function getPrivateBalance(privateInfo: PrivateBalances | undefined | null): BigNumber {
   if (!privateInfo) return new BigNumber(0);
   return privateInfo.ironwoodBalance ?? new BigNumber(0);
-}
-
-/**
- * Whether the account made an outgoing shielded transaction that has not yet
- * gained {@link ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS} confirmations.
- *
- * The change note of an outgoing shielded send is summed back into the spendable
- * Ironwood balance as soon as it is scanned, but it cannot be spent again until
- * its transaction has enough blocks mined on top of it. Confirmations are counted
- * against the latest scanned block (`lastProcessedBlock`): an outgoing transaction
- * is still maturing while `lastProcessedBlock - tx.blockHeight` is below the delay.
- * Returns true when any such transaction exists, so the send flow can warn that
- * the spendable balance may temporarily trail the total. Incoming transactions are
- * ignored — they do not gate spendability the same way.
- */
-export function hasRecentlyShieldedFunds(
-  privateInfo: Pick<ZcashPrivateInfo, "transactions" | "lastProcessedBlock"> | undefined | null,
-): boolean {
-  const transactions = privateInfo?.transactions;
-  const lastProcessedBlock = privateInfo?.lastProcessedBlock;
-  if (!transactions?.length || lastProcessedBlock === null || lastProcessedBlock === undefined)
-    return false;
-  return transactions.some(
-    tx =>
-      getTxType(tx).endsWith("_OUT") &&
-      lastProcessedBlock - tx.blockHeight < ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS,
-  );
 }
 
 /** Total balance shown to the user = transparent + private. */

--- a/libs/coin-modules/coin-zcash/src/logic/account/balance.unit.test.ts
+++ b/libs/coin-modules/coin-zcash/src/logic/account/balance.unit.test.ts
@@ -1,12 +1,5 @@
 import { BigNumber } from "bignumber.js";
-import {
-  computeZcashBalance,
-  getPrivateBalance,
-  getTransparentBalance,
-  hasRecentlyShieldedFunds,
-} from "./balance";
-import type { ShieldedTransaction } from "../../network/types";
-import { ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS } from "../../constants";
+import { computeZcashBalance, getPrivateBalance, getTransparentBalance } from "./balance";
 
 describe("getTransparentBalance", () => {
   it("returns 0 when there are no utxos", () => {
@@ -52,6 +45,32 @@ describe("getPrivateBalance", () => {
     } as Parameters<typeof getPrivateBalance>[0];
     expect(getPrivateBalance(privateInfo)).toEqual(new BigNumber(0));
   });
+
+  // The maturity filter (logic/account/spendability) narrows what selection can
+  // spend; it must never narrow this total. A note still maturing stays part
+  // of it.
+  it("returns the whole ironwood balance even when every note behind it is still maturing", () => {
+    const privateInfo = {
+      orchardBalance: new BigNumber(0),
+      saplingBalance: new BigNumber(0),
+      ironwoodBalance: new BigNumber(4000),
+      lastProcessedBlock: 1_000_000,
+      transactions: [
+        {
+          blockHeight: 999_998, // 2 blocks deep -- far short of the maturity delay
+          decryptedData: {
+            orchard_outputs: [],
+            sapling_outputs: [],
+            ironwood_outputs: [
+              { amount: new BigNumber(4000), memo: "", transfer_type: "incoming" },
+            ],
+          },
+        },
+      ],
+    } as unknown as Parameters<typeof getPrivateBalance>[0];
+
+    expect(getPrivateBalance(privateInfo)).toEqual(new BigNumber(4000));
+  });
 });
 
 describe("computeZcashBalance", () => {
@@ -76,84 +95,27 @@ describe("computeZcashBalance", () => {
     };
     expect(computeZcashBalance(new BigNumber(10000), privateInfo)).toEqual(new BigNumber(10000));
   });
-});
 
-describe("hasRecentlyShieldedFunds", () => {
-  const TIP = 1_000_000; // fixed latest scanned block height
+  it("is unaffected by note maturity: a maturing note still counts in the total", () => {
+    const privateInfo = {
+      orchardBalance: new BigNumber(0),
+      saplingBalance: new BigNumber(0),
+      ironwoodBalance: new BigNumber(4000),
+      lastProcessedBlock: 1_000_000,
+      transactions: [
+        {
+          blockHeight: 999_998,
+          decryptedData: {
+            orchard_outputs: [],
+            sapling_outputs: [],
+            ironwood_outputs: [
+              { amount: new BigNumber(4000), memo: "", transfer_type: "incoming" },
+            ],
+          },
+        },
+      ],
+    } as unknown as Parameters<typeof computeZcashBalance>[1];
 
-  // An outgoing shielded transaction: a net-negative Ironwood delta.
-  const outgoingTx = (blockHeight: number) =>
-    ({
-      blockHeight,
-      decryptedData: {
-        orchard_outputs: [],
-        sapling_outputs: [],
-        ironwood_outputs: [{ amount: new BigNumber(5000), memo: "", transfer_type: "outgoing" }],
-      },
-    }) as unknown as ShieldedTransaction;
-
-  // An incoming shielded transaction: a net-positive Ironwood delta.
-  const incomingTx = (blockHeight: number) =>
-    ({
-      blockHeight,
-      decryptedData: {
-        orchard_outputs: [],
-        sapling_outputs: [],
-        ironwood_outputs: [{ amount: new BigNumber(5000), memo: "", transfer_type: "incoming" }],
-      },
-    }) as unknown as ShieldedTransaction;
-
-  it("returns false when privateInfo is missing or empty", () => {
-    expect(hasRecentlyShieldedFunds(undefined)).toBe(false);
-    expect(hasRecentlyShieldedFunds(null)).toBe(false);
-    expect(hasRecentlyShieldedFunds({ transactions: [], lastProcessedBlock: TIP })).toBe(false);
-  });
-
-  it("returns false when the latest scanned block is unknown", () => {
-    expect(
-      hasRecentlyShieldedFunds({ transactions: [outgoingTx(TIP)], lastProcessedBlock: null }),
-    ).toBe(false);
-  });
-
-  it(`returns true when an outgoing shielded transaction is within the last ${ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS} blocks`, () => {
-    expect(
-      hasRecentlyShieldedFunds({
-        transactions: [outgoingTx(TIP - ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS + 1)],
-        lastProcessedBlock: TIP,
-      }),
-    ).toBe(true);
-  });
-
-  it(`returns false when all outgoing shielded transactions have ${ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS}+ confirmations`, () => {
-    expect(
-      hasRecentlyShieldedFunds({
-        transactions: [outgoingTx(TIP - ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS)],
-        lastProcessedBlock: TIP,
-      }),
-    ).toBe(false);
-  });
-
-  it("ignores recent incoming transactions", () => {
-    expect(
-      hasRecentlyShieldedFunds({ transactions: [incomingTx(TIP - 1)], lastProcessedBlock: TIP }),
-    ).toBe(false);
-  });
-
-  it("returns true when at least one of several transactions is a recent outgoing tx", () => {
-    expect(
-      hasRecentlyShieldedFunds({
-        transactions: [outgoingTx(TIP - 20), outgoingTx(TIP - 1)],
-        lastProcessedBlock: TIP,
-      }),
-    ).toBe(true);
-  });
-
-  it(`treats an outgoing transaction just under the ${ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS}-block delay as recent`, () => {
-    expect(
-      hasRecentlyShieldedFunds({
-        transactions: [outgoingTx(TIP - ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS + 1)],
-        lastProcessedBlock: TIP,
-      }),
-    ).toBe(true);
+    expect(computeZcashBalance(new BigNumber(1000), privateInfo)).toEqual(new BigNumber(5000));
   });
 });

--- a/libs/coin-modules/coin-zcash/src/logic/account/spendability.test.ts
+++ b/libs/coin-modules/coin-zcash/src/logic/account/spendability.test.ts
@@ -1,0 +1,275 @@
+import { BigNumber } from "bignumber.js";
+import {
+  collectSelectableIronwoodNotes,
+  getSpendableIronwoodBalance,
+  hasMaturingIronwoodNotes,
+  isMatureAtHeight,
+  resolveReferenceHeight,
+} from "./spendability";
+import { ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS } from "../../constants";
+import type { ZcashAccount } from "../../types/bridge";
+
+const REFERENCE_HEIGHT = 3_450_000;
+
+const nullifierAt = (index: number) => index.toString(16).padStart(2, "0").repeat(32);
+
+const ironwoodNote = (
+  amount: number,
+  index: number,
+  overrides: { transfer_type?: string; isSpent?: boolean } = {},
+) => ({
+  amount: new BigNumber(amount),
+  transfer_type: overrides.transfer_type ?? "incoming",
+  memo: "",
+  nullifier: nullifierAt(index),
+  rho: "ee".repeat(32),
+  rseed: "ff".repeat(32),
+  cmx: "11".repeat(32),
+  position: String(index),
+  recipient: "22".repeat(43),
+  isSpent: overrides.isSpent ?? false,
+});
+
+type NoteSpec = {
+  amount: number;
+  blockHeight: number;
+  transfer_type?: string;
+};
+
+function account({
+  notes,
+  lastProcessedBlock = REFERENCE_HEIGHT,
+  accountBlockHeight,
+}: {
+  notes: NoteSpec[];
+  lastProcessedBlock?: number | null;
+  accountBlockHeight?: number | null;
+}): ZcashAccount {
+  return {
+    blockHeight: accountBlockHeight,
+    privateInfo: {
+      lastProcessedBlock,
+      transactions: notes.map((spec, i) => ({
+        id: `tx-${i}`,
+        hex: "00",
+        blockHeight: spec.blockHeight,
+        blockHash: "cc".repeat(32),
+        timestamp: 1_700_000_000,
+        fee: new BigNumber(0),
+        decryptedData: {
+          orchard_outputs: [],
+          sapling_outputs: [],
+          ironwood_outputs: [
+            ironwoodNote(
+              spec.amount,
+              i,
+              spec.transfer_type ? { transfer_type: spec.transfer_type } : {},
+            ),
+          ],
+        },
+      })),
+    },
+  } as unknown as ZcashAccount;
+}
+
+const noReservations = new Set<string>();
+
+describe("resolveReferenceHeight", () => {
+  it("prefers lastProcessedBlock when it is present", () => {
+    expect(resolveReferenceHeight({ lastProcessedBlock: 100 }, 50)).toBe(100);
+  });
+
+  it("falls back to the account block height when the shielded scan has none", () => {
+    expect(resolveReferenceHeight({ lastProcessedBlock: null }, 50)).toBe(50);
+    expect(resolveReferenceHeight(undefined, 50)).toBe(50);
+  });
+
+  it("treats no note as mature when neither height is known (fail-closed)", () => {
+    expect(resolveReferenceHeight({ lastProcessedBlock: null }, null)).toBeNull();
+    expect(resolveReferenceHeight(undefined, undefined)).toBeNull();
+    expect(resolveReferenceHeight(null, null)).toBeNull();
+  });
+});
+
+describe("isMatureAtHeight", () => {
+  it("excludes a note one block short of the delay", () => {
+    const reference = 1_000;
+    const txBlockHeight = reference - (ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS - 1);
+
+    expect(isMatureAtHeight(txBlockHeight, reference)).toBe(false);
+  });
+
+  it("includes a note exactly at the delay", () => {
+    const reference = 1_000;
+    const txBlockHeight = reference - ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS;
+
+    expect(isMatureAtHeight(txBlockHeight, reference)).toBe(true);
+  });
+
+  it("never grants maturity with an unknown reference height", () => {
+    expect(isMatureAtHeight(0, null)).toBe(false);
+  });
+});
+
+describe("collectSelectableIronwoodNotes", () => {
+  it("excludes a note that has not yet cleared the delay, includes one that has", () => {
+    const acc = account({
+      notes: [
+        {
+          amount: 10_000,
+          blockHeight: REFERENCE_HEIGHT - (ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS - 1),
+        },
+        {
+          amount: 20_000,
+          blockHeight: REFERENCE_HEIGHT - ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS,
+        },
+      ],
+    });
+
+    const selectable = collectSelectableIronwoodNotes(acc, noReservations);
+
+    expect(selectable.map(n => n.amount.toNumber())).toEqual([20_000]);
+  });
+
+  it("becomes selectable once the reference height advances past the threshold", () => {
+    const notes = [{ amount: 10_000, blockHeight: REFERENCE_HEIGHT - 3 }];
+
+    expect(collectSelectableIronwoodNotes(account({ notes }), noReservations)).toEqual([]);
+
+    const later = account({
+      notes,
+      lastProcessedBlock: REFERENCE_HEIGHT - 3 + ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS,
+    });
+    expect(
+      collectSelectableIronwoodNotes(later, noReservations).map(n => n.amount.toNumber()),
+    ).toEqual([10_000]);
+  });
+
+  it("excludes an immature incoming note, not only a change/outgoing one", () => {
+    const acc = account({
+      notes: [
+        {
+          amount: 10_000,
+          blockHeight: REFERENCE_HEIGHT - 3,
+          transfer_type: "incoming",
+        },
+        {
+          amount: 20_000,
+          blockHeight: REFERENCE_HEIGHT - 3,
+          transfer_type: "internal",
+        },
+      ],
+    });
+
+    expect(collectSelectableIronwoodNotes(acc, noReservations)).toEqual([]);
+  });
+
+  it("treats no note as mature when the reference height is unknown", () => {
+    const acc = account({
+      notes: [{ amount: 10_000, blockHeight: 0 }],
+      lastProcessedBlock: null,
+      accountBlockHeight: null,
+    });
+
+    expect(collectSelectableIronwoodNotes(acc, noReservations)).toEqual([]);
+  });
+
+  it("composes maturity with reservation: only mature and unreserved notes are returned", () => {
+    const acc = account({
+      notes: [
+        // mature, reserved
+        {
+          amount: 10_000,
+          blockHeight: REFERENCE_HEIGHT - ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS,
+        },
+        // immature, unreserved
+        { amount: 20_000, blockHeight: REFERENCE_HEIGHT - 3 },
+        // mature, unreserved
+        {
+          amount: 30_000,
+          blockHeight: REFERENCE_HEIGHT - ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS,
+        },
+      ],
+    });
+    const reserved = new Set([nullifierAt(0)]);
+
+    const selectable = collectSelectableIronwoodNotes(acc, reserved);
+
+    expect(selectable.map(n => n.amount.toNumber())).toEqual([30_000]);
+  });
+});
+
+describe("getSpendableIronwoodBalance", () => {
+  it("sums exactly the notes the filter selects", () => {
+    const acc = account({
+      notes: [
+        { amount: 10_000, blockHeight: REFERENCE_HEIGHT - 3 }, // immature
+        {
+          amount: 20_000,
+          blockHeight: REFERENCE_HEIGHT - ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS,
+        },
+        {
+          amount: 30_000,
+          blockHeight: REFERENCE_HEIGHT - ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS,
+        },
+      ],
+    });
+
+    expect(getSpendableIronwoodBalance(acc, noReservations)).toEqual(new BigNumber(50_000));
+  });
+
+  it("answers zero when nothing is mature", () => {
+    const acc = account({
+      notes: [{ amount: 10_000, blockHeight: REFERENCE_HEIGHT - 1 }],
+    });
+
+    expect(getSpendableIronwoodBalance(acc, noReservations)).toEqual(new BigNumber(0));
+  });
+});
+
+describe("hasMaturingIronwoodNotes", () => {
+  it("fires for an immature incoming note", () => {
+    const acc = account({
+      notes: [
+        {
+          amount: 10_000,
+          blockHeight: REFERENCE_HEIGHT - 3,
+          transfer_type: "incoming",
+        },
+      ],
+    });
+
+    expect(hasMaturingIronwoodNotes(acc)).toBe(true);
+  });
+
+  it("fires for an immature change (internal) note", () => {
+    const acc = account({
+      notes: [
+        {
+          amount: 10_000,
+          blockHeight: REFERENCE_HEIGHT - 3,
+          transfer_type: "internal",
+        },
+      ],
+    });
+
+    expect(hasMaturingIronwoodNotes(acc)).toBe(true);
+  });
+
+  it("stays false once every note is mature", () => {
+    const acc = account({
+      notes: [
+        {
+          amount: 10_000,
+          blockHeight: REFERENCE_HEIGHT - ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS,
+        },
+      ],
+    });
+
+    expect(hasMaturingIronwoodNotes(acc)).toBe(false);
+  });
+
+  it("stays false when there are no notes at all", () => {
+    expect(hasMaturingIronwoodNotes(account({ notes: [] }))).toBe(false);
+  });
+});

--- a/libs/coin-modules/coin-zcash/src/logic/account/spendability.ts
+++ b/libs/coin-modules/coin-zcash/src/logic/account/spendability.ts
@@ -104,3 +104,18 @@ export function getSpendableIronwoodBalance(
 export function hasMaturingIronwoodNotes(account: SpendabilityAccount): boolean {
   return collectIronwoodNotesWithMaturity(account).some(({ mature }) => !mature);
 }
+
+/**
+ * Value held by notes that are merely too young to spend.
+ *
+ * Deliberately **not** `total - spendable`: that difference also swallows the
+ * notes an in-flight spend has reserved, and reporting those as "maturing"
+ * would tell the user to wait for a confirmation depth when what they are
+ * actually waiting on is their own pending transaction. This counts immaturity
+ * and nothing else, so the figure always matches the word next to it.
+ */
+export function getMaturingIronwoodBalance(account: SpendabilityAccount): BigNumber {
+  return collectIronwoodNotesWithMaturity(account)
+    .filter(({ mature }) => !mature)
+    .reduce((sum, { note }) => sum.plus(note.amount), new BigNumber(0));
+}

--- a/libs/coin-modules/coin-zcash/src/logic/account/spendability.ts
+++ b/libs/coin-modules/coin-zcash/src/logic/account/spendability.ts
@@ -1,0 +1,106 @@
+import { BigNumber } from "bignumber.js";
+import type { ZcashAccount } from "../../types/bridge";
+import type { SpendableNote, ZcashPrivateInfo } from "../../network/types";
+import { ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS } from "../../constants";
+import { collectIronwoodSpendableNotes } from "../../bridge/operations";
+
+/**
+ * The single funnel every consumer of "what can be spent from the Ironwood
+ * pool" goes through: note selection (`prepareTransaction`), max-spendable
+ * (`estimateMaxSpendable`), amount validation (`getTransactionStatus`), and the
+ * two renderer surfaces that show the spendable Private balance and its
+ * maturing-funds warning. Keeping the maturity rule here, once, is what
+ * guarantees selection and the presented balance can never disagree.
+ */
+
+type SpendabilityAccount = Pick<ZcashAccount, "privateInfo" | "blockHeight">;
+
+/**
+ * The height confirmations are counted against: the latest block the shielded
+ * scan has processed, falling back to the account's (transparent-sync) block
+ * height when the shielded scan has not reported one yet. `null` when neither
+ * is known -- callers must then treat no note as mature (fail-closed).
+ */
+export function resolveReferenceHeight(
+  privateInfo: Pick<ZcashPrivateInfo, "lastProcessedBlock"> | undefined | null,
+  accountBlockHeight: number | undefined | null,
+): number | null {
+  return privateInfo?.lastProcessedBlock ?? accountBlockHeight ?? null;
+}
+
+/**
+ * Whether a note mined at `txBlockHeight` is buried deep enough below
+ * `referenceHeight` to have a witness at the builder's anchor (`tip - 10`,
+ * `ledger-zcash-utils`). The wallet's delay is two blocks deeper than that
+ * anchor lag, which is what keeps a note the wallet calls mature inside the
+ * tree at build time even though the anchor is resolved later, at signing.
+ *
+ * An unknown reference height never grants maturity: the fail-closed case
+ * excludes every note rather than guessing.
+ */
+export function isMatureAtHeight(txBlockHeight: number, referenceHeight: number | null): boolean {
+  if (referenceHeight === null) return false;
+  return referenceHeight - txBlockHeight >= ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS;
+}
+
+type IronwoodNoteMaturity = {
+  note: SpendableNote;
+  mature: boolean;
+};
+
+/**
+ * Every raw Ironwood note (`collectIronwoodSpendableNotes`, unfiltered by
+ * reservation) paired with whether its enclosing transaction is mature. One
+ * pass, shared by every export below, so the maturity filter and the
+ * maturing-funds signal can never drift apart.
+ */
+function collectIronwoodNotesWithMaturity(account: SpendabilityAccount): IronwoodNoteMaturity[] {
+  const transactions = account.privateInfo?.transactions ?? [];
+  const referenceHeight = resolveReferenceHeight(account.privateInfo, account.blockHeight);
+  const blockHeightByTxid = new Map(transactions.map(tx => [tx.id, tx.blockHeight]));
+
+  return collectIronwoodSpendableNotes(transactions).map(note => {
+    const txBlockHeight = blockHeightByTxid.get(note.txid);
+    return {
+      note,
+      mature: txBlockHeight !== undefined && isMatureAtHeight(txBlockHeight, referenceHeight),
+    };
+  });
+}
+
+/**
+ * The spendable pool: mature, unreserved Ironwood notes. Note selection
+ * (`prepareTransaction`) and max-spendable (`estimateMaxSpendable`) both go
+ * through this so a selection and the figure offered as "Max" can never
+ * disagree.
+ */
+export function collectSelectableIronwoodNotes(
+  account: SpendabilityAccount,
+  reserved: ReadonlySet<string>,
+): SpendableNote[] {
+  return collectIronwoodNotesWithMaturity(account)
+    .filter(({ note, mature }) => mature && !reserved.has(note.nullifier))
+    .map(({ note }) => note);
+}
+
+/** Sum of the spendable pool -- the figure presented as spendable. */
+export function getSpendableIronwoodBalance(
+  account: SpendabilityAccount,
+  reserved: ReadonlySet<string>,
+): BigNumber {
+  return collectSelectableIronwoodNotes(account, reserved).reduce(
+    (sum, note) => sum.plus(note.amount),
+    new BigNumber(0),
+  );
+}
+
+/**
+ * True once the filter has excluded at least one note for immaturity --
+ * incoming notes count exactly as much as change notes. Drives the send-flow
+ * warning that spendable may trail total; because it is computed from the
+ * same pass as the filter, it can never fire without a note actually having
+ * been excluded, nor stay silent while one is.
+ */
+export function hasMaturingIronwoodNotes(account: SpendabilityAccount): boolean {
+  return collectIronwoodNotesWithMaturity(account).some(({ mature }) => !mature);
+}

--- a/libs/coin-modules/coin-zcash/src/types/errors.test.ts
+++ b/libs/coin-modules/coin-zcash/src/types/errors.test.ts
@@ -1,4 +1,5 @@
 import {
+  ZcashNotesNotYetSpendable,
   ZcashSaplingRecipientNotSupported,
   ZcashSignerNotSupported,
   ZcashSigningCancelled,
@@ -12,6 +13,7 @@ describe("zcash errors", () => {
     [ZcashSaplingRecipientNotSupported, "Sapling recipients are not supported"],
     [ZcashSignerNotSupported, "Signer does not support Zcash PCZT signing"],
     [ZcashSigningCancelled, "Zcash signing was cancelled"],
+    [ZcashNotesNotYetSpendable, "These funds are not spendable yet, try again in a few minutes"],
   ])("names %p and gives it a readable default message", (Err, message) => {
     const error = new Err();
 

--- a/libs/coin-modules/coin-zcash/src/types/errors.ts
+++ b/libs/coin-modules/coin-zcash/src/types/errors.ts
@@ -43,3 +43,18 @@ export class ZcashUtxoNotInAccount extends Error {
     }
   }
 }
+
+/**
+ * Raised when the builder rejects a selected note because its leaf position is
+ * at or past the number of leaves the Ironwood tree held at its anchor -- the
+ * note exists on-chain but is not yet inside the tree the transaction is built
+ * against. The maturity filter (`logic/account/spendability`) makes this
+ * unreachable in the normal case; this is the safety net for a backend drift
+ * between the zaino instance the scan used and the one the builder queries.
+ */
+export class ZcashNotesNotYetSpendable extends Error {
+  constructor(message = "These funds are not spendable yet, try again in a few minutes") {
+    super(message);
+    this.name = "ZcashNotesNotYetSpendable";
+  }
+}


### PR DESCRIPTION
### 📝 Description

**Previous behaviour.** Two shielded sends issued back-to-back failed on the second one, at build time:

```
compute_ironwood_witnesses: note position 55985 is at or past anchor_total_leaves 55976 at anchor height 3447474
```

A shielded spend needs a Merkle witness against an anchor, which `@ledgerhq/zcash-utils` resolves to `tip − 10`. A note mined inside that lag is on-chain but not yet in the tree the transaction is built against. Note selection admitted a note on `isSpent` and field presence alone and consulted no height, so the first send's change note was picked largest-first as soon as the scan reported it — two to four blocks later. The twelve-block delay constant already in the module fed a UI warning and nothing else.

This is not a note-reservation failure: the reservation correctly selected a *different* note, which simply had no witness yet.

**The fix.** A single maturity rule, in `logic/account/spendability.ts`, applied everywhere the spendable pool is derived so the parts can never disagree:

- note selection (`prepareTransaction`) and max-spendable (`estimateMaxSpendable`) go through `collectSelectableIronwoodNotes` — mature **and** unreserved;
- `getTransactionStatus` validates the amount against the mature total instead of the raw `ironwoodBalance`, so an over-large amount surfaces as `NotEnoughBalance` rather than failing at build time;
- confirmations are counted against the shielded scan's `lastProcessedBlock`, falling back to the account block height, and fail closed when neither is known;
- the send modal shows the spendable figure and the account page keeps the total, with the maturing amount surfaced alongside it;
- the maturity warning is derived from the same pass as the filter, so it now covers incoming notes and cannot drift from what selection actually excluded;
- a residual position-range build failure surfaces as `ZcashNotesNotYetSpendable` instead of the raw builder string.

**Regression guard.** `prepareTransaction.test.ts` reproduces the field scenario: a confirmed send whose change note was scanned in three blocks below the reference, with a second send prepared before it matures. The test asserts the fresh note is skipped in favour of a mature smaller one — the largest-first behaviour that caused the bug — that a reset is returned when no mature note covers the amount, and that the note becomes selectable once the reference height advances.

**Why the anchor is not pinned.** Considered and rejected. The failure is a note too *recent* for the anchor, and the anchor tracks the tip, which only advances: from `blockHeight ≤ reference − 12` and `reference ≤ tip` follows `blockHeight < tip − 10`. A rising tip can only enlarge the tree and heal a selection, never invalidate one. Pinning would buy nothing here and would start the expiry clock at selection time, the builder deriving `target_height = anchor + 40`.

No change to `@ledgerhq/zcash-utils` — the position check it already performs is what surfaced the defect; the fix is entirely in what the wallet offers it.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35995](https://ledgerhq.atlassian.net/browse/LIVE-35995)
- **ADR** (if any): none — no accepted ADR covers note-maturity or spendable-balance semantics

### ✅ Validation

| Check | Result |
|---|---|
| `nx build @ledgerhq/coin-zcash` | pass |
| `nx lint @ledgerhq/coin-zcash` | 0 errors (38 pre-existing warnings, none in touched files) |
| `nx typecheck @ledgerhq/coin-zcash` | pass |
| `nx test @ledgerhq/coin-zcash` | 718 passed, 1 todo, 0 failed (42 suites) |
| `nx typecheck ledger-live-desktop` | pass |
| `nx unimported @ledgerhq/coin-zcash` | pass |

Line coverage on modified files, measured: `spendability.ts`, `prepareTransaction.ts`, `estimateMaxSpendable.ts`, `getTransactionStatus.ts`, `balance.ts`, `errors.ts` at 100%; `signOperation.ts` at 91.66%, the uncovered lines being pre-existing branches untouched by this change.

### ⚠️ Notes for reviewers

- **Not covered by automated tests**: the two-back-to-back-sends check on a physical device, which needs a funded Ironwood account. The unit tests cover the selection logic; the device run confirms the end-to-end effect.
- **Copy**: the account-page "maturing" string is a neutral placeholder pending Design input.
- `bridge/operations.ts` is deliberately untouched to avoid colliding with the in-flight ironwood operation-labels branch.


[LIVE-35995]: https://ledgerhq.atlassian.net/browse/LIVE-35995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ