### PR TITLE
feat(observability): add transaction-observability lib (LIVE-35350)

### DIFF
--- a/.changeset/LIVE-35350-transaction-observability-package.md
+++ b/.changeset/LIVE-35350-transaction-observability-package.md
@@ -1,0 +1,11 @@
+---
+"@ledgerhq/transaction-observability": minor
+---
+
+Add `@ledgerhq/transaction-observability`: the sign/broadcast log-event model, a global observer registry, error classification, staking-action derivation and the Segment mapping behind `earn_transaction_completed` / `earn_transaction_failed`. Nothing consumes it yet — the account-bridge seam and the host registrations follow.
+
+It lives in a dedicated `libs/*` package rather than `@ledgerhq/live-common` (which no longer accepts new top-level modules), and deliberately does not depend on live-common, since live-common depends on it.
+
+The two lifecycle stages see different things, and that drives the design: `signOperation` gets the rich transaction (the family's own `mode`, the delegation target), while `broadcast` gets only the optimistic operation and so has to read a coarser `OperationType`. There are therefore two derivations — `deriveEarnTransactionType` and `deriveFromOperationType` — and a per-family matrix test asserts they agree. Without the second one a successful Solana stake derives no action at all and is dropped, because its sign-stage `stake.createAccount` becomes a `DELEGATE` operation at broadcast.
+
+Emission is gated on having derived a staking action, so plain sends and swaps are ignored without needing a currency allowlist, and generic operation types (`OUT`, `IN`, `NONE`, `FEES`) are never mapped. Transactions originating from the Earn live-app are skipped because that app emits these events itself. Events carry `stage`, `transaction_type`, `raw_transaction_type`, `input_currency`, `network`, `validators`, `error_category` + `error_reason` on failure, and `tx_data_source` so the sign-vs-broadcast provenance is measurable — never a raw error message or signature.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -265,6 +265,7 @@ libs/coin-modules/coin-ton/                                              @ledger
 libs/concordium-core/                                                    @ledgerhq/ledger-partner-hoodies
 
 # PTX team
+libs/transaction-observability/                                           @ledgerhq/ptx
 features/flow/pay-card-auth/                                             @ledgerhq/ptx
 features/platform/card/                                                  @ledgerhq/ptx
 domain/api/card-management/                                              @ledgerhq/ptx

--- a/libs/transaction-observability/README.md
+++ b/libs/transaction-observability/README.md
@@ -1,0 +1,104 @@
+# `@ledgerhq/transaction-observability`
+
+Normalized sign/broadcast transaction log events, a global observer registry, and the
+classification that turns raw errors and family-specific transaction wording into a stable
+analytics vocabulary.
+
+Consumed by `@ledgerhq/live-common`'s account-bridge seam, and by the desktop and mobile apps
+which each register an observer at startup.
+
+## What this is for
+
+One event shape per outcome, per stage, across every earn flow — so that failures are countable
+two ways: **how many** at each stage, and **of what kind**. Both halves have to hold for the
+numbers to mean anything, which is why so much of this package is classification rather than
+plumbing:
+
+- an outcome that cannot be attributed to a stage inflates or deflates a step of the funnel
+- an outcome whose cause collapses into `unknown` is counted but not actionable
+
+So `unknown` rates are themselves tracked signals, not tolerated noise: `error_category:
+unknown` says the error taxonomy has fallen behind, and `raw_transaction_type` present with no
+`transaction_type` says the staking-action mapping has. Both are visible in the data rather than
+silent.
+
+## Why this lives in `libs/`
+
+The DDD guide treats `libs/*` as legacy and directs new packages to `shared/`, `domain/` or
+`features/`. This one cannot go there: its whole job is to read `Account`, `Operation`,
+`SignedOperation`, `TransactionSource` and `OperationType`, and those types exist only in
+`libs/types-live` — which the new-architecture layers are forbidden to import. There is no
+`domain/entity/account` or `domain/entity/operation` yet.
+
+So `libs/` is forced rather than chosen, and this package should move once those types have a
+non-legacy home.
+
+## Why a package rather than a module in `live-common`
+
+`live-common` no longer accepts new top-level modules, and this code is deliberately free of
+coin-module imports so it stays cheap to load. It must **not** depend on `live-common` —
+`live-common` depends on it, so that edge would be a cycle.
+
+For the same reason a transaction is read through the structural `TransactionLike` rather
+than any family's `Transaction` union: the seam hands over whichever shape the route
+produced, and reading two fields off it should not pull in a family layer.
+
+## The two stages, and why they see different things
+
+`signOperation` receives the rich transaction; `broadcast` receives only the signed
+operation. That asymmetry drives the whole design:
+
+| | sign | broadcast |
+|---|---|---|
+| action wording | the family's own `mode` / `model.kind` | an `OperationType` |
+| delegation target | read from the transaction | only if the family copies it into `Operation.extra` |
+| originating route | not known (no `broadcastConfig`) | attributed from `broadcastConfig.source` |
+
+So there are two derivations, `deriveEarnTransactionType` (sign) and
+`deriveFromOperationType` (broadcast), and a test asserts they agree per family. Without the
+second one a successful Solana stake would derive no action at all and be dropped, because
+its sign-stage `stake.createAccount` becomes a `DELEGATE` operation at broadcast.
+
+`dataSource` on every event records which of the two produced it.
+
+## Emission policy
+
+An event is only forwarded to analytics when a **staking action was derived**. Plain sends
+and swaps derive nothing and are silently ignored, so no currency allowlist is needed and a
+newly-enabled staking currency is covered automatically. Transactions originating from the
+Earn live-app are skipped as well — that app emits `earn_transaction_*` itself with richer
+context, and counting both would double-count.
+
+## Consent is the sink's job, not this package's
+
+`emitTransactionEvent` fires from the bridge seam **unconditionally**. This package has no
+access to the host's settings — it cannot read Redux — so it does not and cannot decide whether
+a user agreed to be measured. Every registered observer gates itself.
+
+That is deliberate rather than an oversight, because there is no single gate to inherit:
+
+| Sink | Governed by |
+|---|---|
+| Segment / Mixpanel | the analytics opt-in (`trackingEnabled`) |
+| Datadog | the crash/error-reporting opt-in, plus its own feature flag |
+| a dev console logger | nothing — it never leaves the process |
+
+Those are **different user choices**. Someone can accept crash reporting and decline analytics,
+or the reverse, so a Datadog sink must not assume the Segment sink's gate.
+
+Today both transmitting observers forward through their host's `track`, whose first statement is
+the analytics-consent check, so consent is enforced without either observer implementing it.
+A future sink that talks to a service directly has to do its own check.
+
+One thing to know if you ever reach for it: the hosts' `track(event, properties, mandatory)`
+takes a third argument that bypasses the consent check and swaps in a reduced property set. It
+exists for recording the consent change itself and is not a general-purpose escape hatch —
+using it for funnel data is a privacy decision, not an engineering one.
+
+## Adding a family
+
+1. Add its staking `mode` values to `FAMILY_ACTIONS` in `earnTransactionType.ts`.
+2. Add the `OperationType`s its optimistic operations carry to `operationType.ts`, read from
+   the coin module's `buildOptimisticOperation` — not guessed.
+3. Add a row to the matrix in `stakingMatrix.test.ts`. The consistency test will fail if the
+   two derivations disagree.

--- a/libs/transaction-observability/jest.config.js
+++ b/libs/transaction-observability/jest.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  transform: {
+    "^.+\\.(ts|tsx)?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+        },
+      },
+    ],
+  },
+  testEnvironment: "node",
+  testPathIgnorePatterns: ["lib/", "lib-es/"],
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../" }], "text"],
+  reporters: [
+    "default",
+    ...(process.env.CI ? ["github-actions"] : []),
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/libs/transaction-observability/package.json
+++ b/libs/transaction-observability/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@ledgerhq/transaction-observability",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Sign/broadcast transaction observability: normalized log events, a global observer registry, and error/staking-action classification, shared across all Ledger Live transaction routes",
+  "keywords": [
+    "Ledger"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LedgerHQ/ledger-live.git"
+  },
+  "bugs": {
+    "url": "https://github.com/LedgerHQ/ledger-live/issues"
+  },
+  "homepage": "https://github.com/LedgerHQ/ledger-live/tree/develop/libs/transaction-observability",
+  "sideEffects": false,
+  "main": "lib/index.js",
+  "module": "lib-es/index.js",
+  "types": "lib/index.d.ts",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@ledgerhq/types-live": "workspace:^",
+    "@shared/env": "workspace:*"
+  },
+  "devDependencies": {
+    "@ledgerhq/coin-module-framework": "catalog:",
+    "@types/node": "catalog:",
+    "@types/jest": "catalog:",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "jest": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:"
+  },
+  "scripts": {
+    "clean": "rimraf lib lib-es",
+    "build": "tsc --project tsconfig.build.json && tsc --project tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es",
+    "prewatch": "pnpm build",
+    "watch": "tsc --watch --project tsconfig.build.json",
+    "watch:es": "tsc --watch --project tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es",
+    "lint": "oxlint -c ../oxc-live-libs/.oxlintrc.json ./src",
+    "lint:fix": "pnpm exec oxfmt -c ../../.oxfmtrc.json ./src && oxlint -c ../oxc-live-libs/.oxlintrc.json ./src --fix --quiet",
+    "format": "pnpm exec oxfmt -c ../../.oxfmtrc.json ./src",
+    "format:check": "pnpm exec oxfmt -c ../../.oxfmtrc.json ./src --check",
+    "typecheck": "tsc --noEmit --customConditions node",
+    "test": "jest",
+    "coverage": "jest --coverage"
+  },
+  "exports": {
+    ".": {
+      "@ledgerhq/source": "./src/index.ts",
+      "import": "./lib-es/index.js",
+      "require": "./lib/index.js",
+      "default": "./lib/index.js"
+    },
+    "./lib-es/*": "./lib-es/*.js",
+    "./lib/*": "./lib/*.js",
+    "./package.json": "./package.json"
+  }
+}

--- a/libs/transaction-observability/src/earnTransactionType.ts
+++ b/libs/transaction-observability/src/earnTransactionType.ts
@@ -1,0 +1,181 @@
+import type { StakingOperation } from "@ledgerhq/coin-module-framework/api/types";
+
+/**
+ * Normalized staking action, for cross-flow funnel analytics.
+ *
+ * Written out rather than derived from `StakingOperation`: this is an analytics contract, so
+ * it must widen by deliberate edit, never on a dependency bump. `approve` and `redeem` are
+ * deliberately absent until the dApp/live-app parts land; `deposit` is already needed natively,
+ * because Celo splits staking into a lock leg and a vote leg.
+ */
+export type EarnTransactionType =
+  // StakingOperation
+  | "delegate"
+  | "undelegate"
+  | "redelegate"
+  | "claimReward"
+  | "compoundReward"
+  | "withdraw"
+  | "deposit";
+
+// Fails the build if upstream StakingOperation drifts out of EarnTransactionType.
+type Extends<Narrow extends Wide, Wide> = Narrow;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _StakingOperationIsCovered = Extends<StakingOperation, EarnTransactionType>;
+
+/**
+ * Family-aware, because the same word means different things per family: Celo `vote` and
+ * Tron `freeze` both start staking, and a flat verb list misses Solana entirely since its
+ * actions are dotted. Keys are lower-cased.
+ */
+const FAMILY_ACTIONS: Record<string, Record<string, EarnTransactionType>> = {
+  // model.kind
+  solana: {
+    "stake.createaccount": "delegate",
+    // First delegation vs re-delegation needs prior account state, absent from the tx.
+    "stake.delegate": "delegate",
+    "stake.undelegate": "undelegate",
+    "stake.withdraw": "withdraw",
+    // Split = partial unstake.
+    "stake.split": "undelegate",
+  },
+  // mode — shared by every cosmos-SDK currency (osmo, dydx, injective, axelar, …)
+  cosmos: {
+    delegate: "delegate",
+    undelegate: "undelegate",
+    redelegate: "redelegate",
+    claimreward: "claimReward",
+    claimrewardcompound: "compoundReward",
+  },
+  cardano: { delegate: "delegate", undelegate: "undelegate" },
+  polkadot: {
+    bond: "delegate",
+    nominate: "delegate",
+    unbond: "undelegate",
+    // Stops nominating without unbonding.
+    chill: "undelegate",
+    rebond: "redelegate",
+    withdrawunbonded: "withdraw",
+    claimreward: "claimReward",
+  },
+  tezos: {
+    delegate: "delegate",
+    stake: "delegate",
+    undelegate: "undelegate",
+    unstake: "undelegate",
+    finalize_unstake: "withdraw",
+  },
+  near: { stake: "delegate", unstake: "undelegate", withdraw: "withdraw" },
+  multiversx: {
+    delegate: "delegate",
+    undelegate: "undelegate",
+    redelegaterewards: "compoundReward",
+    claimrewards: "claimReward",
+    withdraw: "withdraw",
+  },
+  // Celo splits staking across two txs (lock + vote), so one tx is only ever one leg.
+  celo: {
+    lock: "deposit",
+    vote: "delegate",
+    activate: "delegate",
+    revoke: "undelegate",
+    unlock: "undelegate",
+    withdraw: "withdraw",
+  },
+  // Tron likewise splits freeze + vote.
+  tron: {
+    freeze: "delegate",
+    vote: "delegate",
+    unfreeze: "undelegate",
+    // The pre-Stake2.0 unfreeze, still reachable on old frozen balances.
+    legacyunfreeze: "undelegate",
+    undelegateresource: "undelegate",
+    claimreward: "claimReward",
+    withdrawexpireunfreeze: "withdraw",
+  },
+  hedera: {
+    delegate: "delegate",
+    undelegate: "undelegate",
+    redelegate: "redelegate",
+    "claim-rewards": "claimReward",
+  },
+  // optIn is an asset opt-in, not staking.
+  algorand: { claimreward: "claimReward" },
+  sui: { delegate: "delegate", undelegate: "undelegate" },
+  aptos: {
+    stake: "delegate",
+    restake: "redelegate",
+    unstake: "undelegate",
+    withdraw: "withdraw",
+  },
+  /**
+   * EVM native staking (sei_evm, monad, somnia, zero_gravity) is a precompile call, but the
+   * transaction still carries a `mode` from GENERIC_TRANSACTION_MODE — the flows set it
+   * alongside `valAddress`. So no call-data parsing is needed here; the dApp selector route
+   * belongs to the partner work.
+   */
+  evm: {
+    delegate: "delegate",
+    redelegate: "redelegate",
+    undelegate: "undelegate",
+    stake: "delegate",
+    unstake: "undelegate",
+    withdraw: "withdraw",
+    claimreward: "claimReward",
+    compoundreward: "compoundReward",
+  },
+};
+
+/**
+ * The generic coin framework's own vocabulary (`GENERIC_TRANSACTION_MODE`), used as a
+ * fallback for any family not named above.
+ *
+ * Families migrating onto that framework keep their own words where they have them — tron
+ * still says `freeze`/`vote`, and its hooks are typed `mode: string`, not the generic union —
+ * so this is a safety net, not a replacement. It means a family that migrates and adopts the
+ * generic words is classified correctly with no change here.
+ *
+ * Consulted *after* the family map, never before: where a family defines a word that also
+ * exists generically, the family's meaning is the authoritative one.
+ */
+const GENERIC_ACTIONS: Record<string, EarnTransactionType> = {
+  delegate: "delegate",
+  redelegate: "redelegate",
+  undelegate: "undelegate",
+  stake: "delegate",
+  unstake: "undelegate",
+  finalize_unstake: "withdraw",
+  withdraw: "withdraw",
+  claimreward: "claimReward",
+  compoundreward: "compoundReward",
+};
+
+// The wallet-api tx family is "ethereum" while the account family is "evm"; elrond is the
+// currency id for the multiversx family.
+const FAMILY_ALIASES: Record<string, string> = {
+  ethereum: "evm",
+  elrond: "multiversx",
+};
+
+const resolveFamily = (family: string): string => {
+  const key = family.toLowerCase();
+  return FAMILY_ALIASES[key] ?? key;
+};
+
+/**
+ * Map a family-specific raw action (a family `mode` or Solana `model.kind`) to an
+ * {@link EarnTransactionType}.
+ *
+ * `undefined` means "not a staking action" (plain send, swap) — a first-class outcome, so
+ * callers never have to guess.
+ */
+export function deriveEarnTransactionType(
+  family: string | undefined,
+  rawTransactionType: string | undefined,
+): EarnTransactionType | undefined {
+  if (!family || !rawTransactionType) return undefined;
+  const action = rawTransactionType.toLowerCase();
+  return FAMILY_ACTIONS[resolveFamily(family)]?.[action] ?? GENERIC_ACTIONS[action];
+}
+
+export { resolveFamily };

--- a/libs/transaction-observability/src/errorCategory.test.ts
+++ b/libs/transaction-observability/src/errorCategory.test.ts
@@ -1,0 +1,157 @@
+import { classifyTransactionError, ErrorCategory, toError, unwrapRpcError } from "./errorCategory";
+
+const classify = (error: unknown) => classifyTransactionError(toError(unwrapRpcError(error)));
+
+describe("classifyTransactionError", () => {
+  it.each([
+    // device / user (sign stage)
+    ["DisconnectedDevice", { name: "DisconnectedDevice" }, ErrorCategory.DeviceDisconnected],
+    [
+      "DisconnectedDeviceDuringOperation",
+      { name: "DisconnectedDeviceDuringOperation" },
+      ErrorCategory.DeviceDisconnected,
+    ],
+    ["WrongDeviceForAccount", { name: "WrongDeviceForAccount" }, ErrorCategory.DeviceWrongAccount],
+    ["UserRefusedOnDevice", { name: "UserRefusedOnDevice" }, ErrorCategory.UserDeviceRefused],
+    [
+      "TransactionRefusedOnDevice",
+      { name: "TransactionRefusedOnDevice" },
+      ErrorCategory.UserDeviceRefused,
+    ],
+    [
+      "DeviceStatusError user-decline (0x6985)",
+      { name: "DeviceStatusError", statusCode: 0x6985 },
+      ErrorCategory.UserDeviceRefused,
+    ],
+    [
+      "DeviceStatusError other status",
+      { name: "DeviceStatusError", statusCode: 0x6a80 },
+      ErrorCategory.DeviceDisconnected,
+    ],
+    [
+      "Signature interrupted (message)",
+      { message: "Signature interrupted by user" },
+      ErrorCategory.UserModalDismissed,
+    ],
+    [
+      "Canceled by user (message)",
+      { message: "Canceled by user" },
+      ErrorCategory.UserModalDismissed,
+    ],
+    // gas / blockchain (broadcast stage)
+    ["InsufficientFunds", { name: "InsufficientFunds" }, ErrorCategory.GasInsufficientBalance],
+    ["NotEnoughBalance", { name: "NotEnoughBalance" }, ErrorCategory.GasInsufficientBalance],
+    [
+      "REPLACEMENT_UNDERPRICED (message)",
+      { message: "replacement_underpriced" },
+      ErrorCategory.GasFeeTooLow,
+    ],
+    ["SequenceNumberError", { name: "SequenceNumberError" }, ErrorCategory.Blockchain],
+    ["NetworkError", { name: "NetworkError" }, ErrorCategory.Blockchain],
+    ["NONCE_EXPIRED (message)", { message: "nonce_expired: foo" }, ErrorCategory.Blockchain],
+    ["unknown", { name: "Error", message: "something weird" }, ErrorCategory.Unknown],
+  ])("maps %s", (_label, partial, expected) => {
+    expect(classifyTransactionError(Object.assign(new Error(), partial) as Error)).toBe(expected);
+  });
+});
+
+// Neither the Wallet API's RpcError/ServerError nor Ledger Wallet's dApp-path RpcError sets
+// `name`, so without unwrapping every RPC failure would classify as unknown.
+describe("unwrapRpcError", () => {
+  it("unwraps a dApp provider rejection (EIP-1193 4001) as a dismissal", () => {
+    const error = toError(
+      unwrapRpcError({ isRpcError: true, code: 4001, reason: "User rejected" }),
+    );
+    expect(error.name).toBe("UserRejectedRequest");
+    expect(classifyTransactionError(error)).toBe(ErrorCategory.UserModalDismissed);
+  });
+
+  it("keeps the rpc code as the reported name for other provider errors", () => {
+    expect(
+      toError(unwrapRpcError({ isRpcError: true, code: 4900, reason: "Disconnected" })).name,
+    ).toBe("rpc_4900");
+  });
+
+  it("unwraps the original error forwarded inside a Wallet API envelope", () => {
+    const error = toError(
+      unwrapRpcError({
+        getCode: () => -32000,
+        getData: () => ({
+          code: "UNKNOWN_ERROR",
+          data: { name: "UserRefusedOnDevice", message: "declined" },
+        }),
+      }),
+    );
+    expect(error.name).toBe("UserRefusedOnDevice");
+    expect(classifyTransactionError(error)).toBe(ErrorCategory.UserDeviceRefused);
+  });
+
+  it("preserves a nested device status code so it can still be categorised", () => {
+    expect(
+      classify({
+        getCode: () => -32000,
+        getData: () => ({
+          code: "UNKNOWN_ERROR",
+          data: { name: "DeviceStatusError", message: "", statusCode: 0x6985 },
+        }),
+      }),
+    ).toBe(ErrorCategory.UserDeviceRefused);
+  });
+
+  it("falls back to the protocol code as the reported name", () => {
+    const error = toError(
+      unwrapRpcError({ getCode: () => -32000, getData: () => ({ code: "ACCOUNT_NOT_FOUND" }) }),
+    );
+    expect(error.name).toBe("ACCOUNT_NOT_FOUND");
+    expect(classifyTransactionError(error)).toBe(ErrorCategory.Unknown);
+  });
+
+  // `code` is `unknown` on both paths, so String(code) could have reported
+  // "rpc_[object Object]". rpc_unknown keeps this countable as its own case.
+  it.each([
+    ["a provider error", { isRpcError: true, code: { nested: true }, reason: "weird" }, "weird"],
+    ["a wallet-api envelope", { getCode: () => ({ nested: true }), getData: () => undefined }, ""],
+  ])("reports an unreadable code from %s as rpc_unknown", (_label, raw, message) => {
+    const error = toError(unwrapRpcError(raw));
+    expect(error.name).toBe("rpc_unknown");
+    expect(error.message).toBe(message);
+    expect(classifyTransactionError(error)).toBe(ErrorCategory.Unknown);
+  });
+
+  // The envelope shapes are tried in order; this pins that a serialised error still wins over
+  // the protocol code sitting beside it, rather than depending on extractor ordering by luck.
+  it("prefers a serialised error over the protocol code beside it", () => {
+    const error = toError(
+      unwrapRpcError({
+        getCode: () => -32000,
+        getData: () => ({ code: "ACCOUNT_NOT_FOUND", data: { name: "NotEnoughBalance" } }),
+      }),
+    );
+    expect(error.name).toBe("NotEnoughBalance");
+  });
+
+  it("leaves an object with no recognised envelope shape untouched", () => {
+    const raw = { getCode: () => 1 };
+    expect(unwrapRpcError(raw)).toBe(raw);
+  });
+
+  it("leaves a plain error untouched", () => {
+    const original = Object.assign(new Error("x"), { name: "NotEnoughBalance" });
+    expect(unwrapRpcError(original)).toBe(original);
+  });
+});
+
+describe("toError", () => {
+  it("passes an Error through unchanged", () => {
+    const error = new Error("boom");
+    expect(toError(error)).toBe(error);
+  });
+
+  it("coerces a string, an object and a circular value without throwing", () => {
+    expect(toError("boom").message).toBe("boom");
+    expect(toError({ a: 1 }).message).toBe('{"a":1}');
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(() => toError(circular)).not.toThrow();
+  });
+});

--- a/libs/transaction-observability/src/errorCategory.ts
+++ b/libs/transaction-observability/src/errorCategory.ts
@@ -1,0 +1,185 @@
+/**
+ * Normalized, countable error categories spanning the sign and broadcast stages.
+ *
+ * Shared taxonomy with the Earn live app's classifier (LIVE-34203). Ledger Wallet can only
+ * classify what it observes (device / user / gas / blockchain); `validation`, `partner` and
+ * `geolocation` originate in the app and are classified app-side using the same values.
+ *
+ * `Unknown` is a measurement of this list, not a resting place: a rising `unknown` share means
+ * the taxonomy has fallen behind the errors users actually hit, and is a signal to extend it.
+ */
+export enum ErrorCategory {
+  DeviceDisconnected = "device_disconnected",
+  DeviceWrongAccount = "device_wrong_account",
+  UserModalDismissed = "user_modal_dismissed",
+  UserDeviceRefused = "user_device_refused",
+  GasInsufficientBalance = "gas_insufficient_balance",
+  GasFeeTooLow = "gas_fee_too_low",
+  Geolocation = "geolocation",
+  Partner = "partner",
+  Blockchain = "blockchain",
+  /** Pre-sign checks (mostly app-side). */
+  Validation = "validation",
+  Unknown = "unknown",
+}
+
+const namedError = (name: string, message = ""): Error =>
+  Object.assign(new Error(message), { name });
+
+/**
+ * Only a primitive makes a usable code — an object would stringify as "[object Object]".
+ * `rpc_unknown` rather than passing the error through, so "no envelope was recognised" stays
+ * countable separately from "an envelope was recognised but its code was unreadable".
+ */
+const rpcCodeName = (code: unknown): string =>
+  typeof code === "number" || typeof code === "string" ? `rpc_${code}` : "rpc_unknown";
+
+/** Ledger Wallet's EIP-1193 provider error, on the dApp path: a code and a reason, no name. */
+function fromProviderError(error: object): Error | undefined {
+  const provider = error as { isRpcError?: unknown; code?: unknown; reason?: unknown };
+  if (provider.isRpcError !== true) return undefined;
+
+  const message = typeof provider.reason === "string" ? provider.reason : "";
+  // EIP-1193: 4001 is the user declining the request.
+  return provider.code === 4001
+    ? namedError("UserRejectedRequest", message)
+    : namedError(rpcCodeName(provider.code), message);
+}
+
+/**
+ * A real error forwarded verbatim through the envelope: it kept its `name`, and possibly a
+ * device `statusCode` — both of which {@link classifyTransactionError} depends on.
+ */
+function serialisedError(data: object): Error | undefined {
+  const nested = ((data as { data?: unknown }).data ?? data) as {
+    name?: unknown;
+    message?: unknown;
+    statusCode?: unknown;
+  };
+  if (typeof nested.name !== "string") return undefined;
+
+  const unwrapped = namedError(
+    nested.name,
+    typeof nested.message === "string" ? nested.message : "",
+  );
+  return typeof nested.statusCode === "number"
+    ? Object.assign(unwrapped, { statusCode: nested.statusCode })
+    : unwrapped;
+}
+
+/** The wallet-api's own protocol code, for when no inner error survived the trip. */
+function protocolCodeError(data: object): Error | undefined {
+  const { code, message } = data as { code?: unknown; message?: unknown };
+  return typeof code === "string"
+    ? namedError(code, typeof message === "string" ? message : "")
+    : undefined;
+}
+
+/** A Wallet API envelope, whose cause sits behind `getData()` / `getCode()`. */
+function fromWalletApiEnvelope(error: object): Error | undefined {
+  const envelope = error as { getData?: () => unknown; getCode?: () => unknown };
+  if (typeof envelope.getData !== "function") return undefined;
+
+  const data = envelope.getData();
+  if (data && typeof data === "object") {
+    const inner = serialisedError(data) ?? protocolCodeError(data);
+    if (inner) return inner;
+  }
+
+  const code = envelope.getCode?.();
+  return code === undefined ? undefined : namedError(rpcCodeName(code));
+}
+
+/**
+ * Unwrap an RPC failure envelope so the real cause is what gets classified and reported.
+ *
+ * Without this, every RPC-wrapped failure lands in the same `unknown` bucket: neither the
+ * Wallet API's `RpcError`/`ServerError` nor Ledger Wallet's dApp-path `RpcError` sets `name`
+ * — it stays the default "Error" — and the cause sits behind accessors. That would leave the
+ * funnel able to count failures but not tell them apart, which is half the point of measuring
+ * them. Device and coin errors need no unwrapping: the RPC layer round-trips those through
+ * `@ledgerhq/errors`, so their `name` survives.
+ *
+ * One extractor per envelope shape, tried in order of how much they preserve. An error that
+ * matches none is returned untouched.
+ */
+export function unwrapRpcError(error: unknown): unknown {
+  if (!error || typeof error !== "object") return error;
+  return fromProviderError(error) ?? fromWalletApiEnvelope(error) ?? error;
+}
+
+export function toError(err: unknown): Error {
+  if (err instanceof Error) return err;
+  if (typeof err === "string") return new Error(err);
+  try {
+    return new Error(JSON.stringify(err));
+  } catch {
+    return new Error(String(err));
+  }
+}
+
+/**
+ * Maps an arbitrary sign/broadcast error to a normalized {@link ErrorCategory}.
+ *
+ * Pure string-matching (no coin-module imports): stable error `name`s first (Ledger custom
+ * errors plus device/transport errors), then stable substrings in `error.message`. App-only
+ * categories fall through to `Unknown` here and are classified app-side.
+ */
+export function classifyTransactionError(error: Error): ErrorCategory {
+  const name = error.name ?? "";
+  const message = (error.message ?? "").toUpperCase();
+
+  switch (name) {
+    case "WrongDeviceForAccount":
+      return ErrorCategory.DeviceWrongAccount;
+    case "UserRefusedOnDevice":
+    case "UserRefusedAllowManager":
+    case "TransactionRefusedOnDevice":
+      return ErrorCategory.UserDeviceRefused;
+    // EIP-1193 4001, unwrapped from a dApp provider error: declined in the UI, not on device.
+    case "UserRejectedRequest":
+      return ErrorCategory.UserModalDismissed;
+    case "InsufficientFunds":
+    case "NotEnoughBalance":
+      return ErrorCategory.GasInsufficientBalance;
+    case "InvalidTransactionError":
+    case "GasEstimationError":
+    case "SequenceNumberError":
+    case "TronTransactionExpired":
+    case "UnsupportedRpcMethodError":
+    case "NetworkError":
+    case "NetworkDown":
+    case "SendTransactionError":
+      return ErrorCategory.Blockchain;
+  }
+
+  // The status code distinguishes a user decline (CONDITIONS_OF_USE_NOT_SATISFIED) from
+  // other device faults.
+  if (name === "DeviceStatusError" || name === "TransportStatusError") {
+    const statusCode = (error as { statusCode?: number }).statusCode;
+    if (statusCode === 0x6985 || statusCode === 0x5501) return ErrorCategory.UserDeviceRefused;
+    return ErrorCategory.DeviceDisconnected;
+  }
+  if (
+    name.startsWith("DisconnectedDevice") ||
+    name === "CantOpenDevice" ||
+    name === "TransportError" ||
+    name === "TransportRaceCondition"
+  ) {
+    return ErrorCategory.DeviceDisconnected;
+  }
+
+  if (message.includes("SIGNATURE INTERRUPTED BY USER") || message.includes("CANCELED BY USER"))
+    return ErrorCategory.UserModalDismissed;
+  if (message.includes("INSUFFICIENT_FUNDS")) return ErrorCategory.GasInsufficientBalance;
+  if (message.includes("REPLACEMENT_UNDERPRICED") || message.includes("TRANSACTION_UNDERPRICED"))
+    return ErrorCategory.GasFeeTooLow;
+  if (
+    message.includes("NONCE_EXPIRED") ||
+    message.includes("NONCE TOO LOW") ||
+    message.includes("UNPREDICTABLE_GAS_LIMIT")
+  )
+    return ErrorCategory.Blockchain;
+
+  return ErrorCategory.Unknown;
+}

--- a/libs/transaction-observability/src/eventBuilders.test.ts
+++ b/libs/transaction-observability/src/eventBuilders.test.ts
@@ -1,0 +1,228 @@
+import type { Account, AccountLike, Operation, SignedOperation } from "@ledgerhq/types-live";
+import { setEnv } from "@shared/env";
+import {
+  buildBroadcastCommonEvent,
+  buildSignCommonEvent,
+  buildTransactionAbandonedEvent,
+  buildTransactionFailureEvent,
+  buildTransactionSuccessEvent,
+} from "./eventBuilders";
+import { TransactionDataSource, TransactionPathway, TransactionStage } from "./logEvent";
+import { ErrorCategory } from "./errorCategory";
+import type { TransactionLike } from "./transactionShape";
+
+const account = (currency: { id: string; family: string; ticker: string }) =>
+  ({ id: "account-id", type: "Account", currency }) as unknown as Account;
+
+const cardano = account({ id: "cardano", family: "cardano", ticker: "ADA" });
+const cosmos = account({ id: "cosmos", family: "cosmos", ticker: "ATOM" });
+const sei = account({ id: "sei_evm", family: "evm", ticker: "SEI" });
+
+const tx = (fields: Record<string, unknown>): TransactionLike => fields;
+const operation = (fields: Record<string, unknown>) => fields as unknown as Operation;
+
+const attribution = (mainAccount: Account, over: Partial<{ account: AccountLike }> = {}) => ({
+  account: over.account ?? mainAccount,
+  mainAccount,
+  pathway: TransactionPathway.Send,
+});
+
+beforeEach(() => setEnv("LEDGER_CLIENT_VERSION", "llc/test"));
+
+describe("buildSignCommonEvent", () => {
+  it("derives the action and the delegation target from the transaction", () => {
+    const common = buildSignCommonEvent({
+      ...attribution(cardano),
+      transaction: tx({ family: "cardano", mode: "delegate", poolId: "pool123" }),
+    });
+
+    expect(common).toMatchObject({
+      appVersion: "llc/test",
+      currencyId: "cardano",
+      family: "cardano",
+      currencyTicker: "ADA",
+      earnTransactionType: "delegate",
+      rawTransactionType: "delegate",
+      validators: ["pool123"],
+      dataSource: TransactionDataSource.Sign,
+      isSendMax: false,
+    });
+  });
+
+  it("leaves the action undefined for a non-staking transaction", () => {
+    const common = buildSignCommonEvent({
+      ...attribution(cardano),
+      transaction: tx({ family: "cardano", mode: "send" }),
+    });
+
+    expect(common.earnTransactionType).toBeUndefined();
+    expect(common.rawTransactionType).toBe("send");
+  });
+
+  it("reports the token's own id and ticker for a token account", () => {
+    const tokenAccount = {
+      type: "TokenAccount",
+      token: { id: "ethereum/erc20/usdc", ticker: "USDC" },
+    } as unknown as AccountLike;
+
+    const common = buildSignCommonEvent({
+      ...attribution(sei, { account: tokenAccount }),
+      transaction: tx({ family: "ethereum", mode: "delegate" }),
+    });
+
+    expect(common).toMatchObject({ tokenId: "ethereum/erc20/usdc", tokenTicker: "USDC" });
+  });
+
+  it("carries send-max through", () => {
+    const common = buildSignCommonEvent({
+      ...attribution(cosmos),
+      transaction: tx({ family: "cosmos", mode: "delegate", useAllAmount: true }),
+    });
+    expect(common.isSendMax).toBe(true);
+  });
+});
+
+describe("buildBroadcastCommonEvent", () => {
+  it("derives the action from the optimistic operation type", () => {
+    const common = buildBroadcastCommonEvent({
+      ...attribution(cosmos),
+      operation: operation({ type: "DELEGATE", extra: {} }),
+    });
+
+    expect(common).toMatchObject({
+      earnTransactionType: "delegate",
+      rawTransactionType: "DELEGATE",
+      dataSource: TransactionDataSource.Broadcast,
+    });
+  });
+
+  it("reads the validators cosmos copies into the operation extra", () => {
+    const common = buildBroadcastCommonEvent({
+      ...attribution(cosmos),
+      operation: operation({
+        type: "DELEGATE",
+        extra: { validators: [{ address: "cosmosvaloper1" }] },
+      }),
+    });
+
+    expect(common.validators).toEqual(["cosmosvaloper1"]);
+  });
+
+  it("reports no validators for a family that does not copy them across", () => {
+    const common = buildBroadcastCommonEvent({
+      ...attribution(cardano),
+      operation: operation({ type: "DELEGATE", extra: {} }),
+    });
+
+    expect(common.validators).toBeUndefined();
+  });
+
+  // Both claimReward and compoundReward become REWARD, so transactionRaw is the only way to
+  // tell them apart on the generic-coin-framework families.
+  it("prefers the exact mode off transactionRaw where it survives", () => {
+    const common = buildBroadcastCommonEvent({
+      ...attribution(sei),
+      operation: operation({
+        type: "REWARD",
+        extra: {},
+        transactionRaw: { mode: "compoundReward", valAddress: "0xval" },
+      }),
+    });
+
+    expect(common).toMatchObject({
+      earnTransactionType: "compoundReward",
+      rawTransactionType: "compoundReward",
+      validators: ["0xval"],
+    });
+  });
+
+  it("falls back to the operation type when transactionRaw carries no usable mode", () => {
+    const common = buildBroadcastCommonEvent({
+      ...attribution(sei),
+      operation: operation({ type: "REWARD", extra: {}, transactionRaw: { mode: "send" } }),
+    });
+
+    expect(common).toMatchObject({
+      earnTransactionType: "claimReward",
+      rawTransactionType: "REWARD",
+    });
+  });
+
+  it("derives nothing from a plain send, so it never enters the funnel", () => {
+    const common = buildBroadcastCommonEvent({
+      ...attribution(cosmos),
+      operation: operation({ type: "OUT", extra: {} }),
+    });
+
+    expect(common.earnTransactionType).toBeUndefined();
+  });
+});
+
+describe("outcome events", () => {
+  const common = buildSignCommonEvent({
+    ...attribution(cosmos),
+    transaction: tx({ family: "cosmos", mode: "delegate" }),
+  });
+
+  it("tags a success as a broadcast-stage success", () => {
+    expect(buildTransactionSuccessEvent(common)).toMatchObject({
+      status: "success",
+      stage: TransactionStage.Broadcast,
+      earnTransactionType: "delegate",
+    });
+  });
+
+  it("classifies a failure and keeps the signed payload for broadcast-stage failures", () => {
+    const signedOperation = { signature: "0xsig", rawData: { a: 1 } } as unknown as SignedOperation;
+    const event = buildTransactionFailureEvent(common, {
+      stage: TransactionStage.Broadcast,
+      error: Object.assign(new Error("nope"), { name: "NotEnoughBalance" }),
+      signedOperation,
+    });
+
+    expect(event).toMatchObject({
+      status: "failure",
+      stage: TransactionStage.Broadcast,
+      errorCategory: ErrorCategory.GasInsufficientBalance,
+    });
+    expect(event.txPayload).toEqual({ signature: "0xsig", rawData: { a: 1 } });
+  });
+
+  it("has no signed payload at the sign stage, since signing never completed", () => {
+    const event = buildTransactionFailureEvent(common, {
+      stage: TransactionStage.Sign,
+      error: Object.assign(new Error(""), { name: "UserRefusedOnDevice" }),
+    });
+
+    expect(event.txPayload).toBeUndefined();
+    expect(event.errorCategory).toBe(ErrorCategory.UserDeviceRefused);
+  });
+
+  it("unwraps an RPC envelope so the reported name is the real cause", () => {
+    const event = buildTransactionFailureEvent(common, {
+      stage: TransactionStage.Sign,
+      error: { isRpcError: true, code: 4001, reason: "User rejected" },
+    });
+
+    expect(event.error.name).toBe("UserRejectedRequest");
+    expect(event.errorCategory).toBe(ErrorCategory.UserModalDismissed);
+  });
+
+  it("coerces a non-Error throwable", () => {
+    const event = buildTransactionFailureEvent(common, {
+      stage: TransactionStage.Sign,
+      error: "just a string",
+    });
+
+    expect(event.error.message).toBe("just a string");
+    expect(event.errorCategory).toBe(ErrorCategory.Unknown);
+  });
+
+  it("reports an abandoned sign prompt as a dismissal", () => {
+    expect(buildTransactionAbandonedEvent(common)).toMatchObject({
+      status: "failure",
+      stage: TransactionStage.Sign,
+      errorCategory: ErrorCategory.UserModalDismissed,
+    });
+  });
+});

--- a/libs/transaction-observability/src/eventBuilders.ts
+++ b/libs/transaction-observability/src/eventBuilders.ts
@@ -1,0 +1,183 @@
+import type {
+  Account,
+  AccountLike,
+  Operation,
+  SignedOperation,
+  TransactionSource,
+} from "@ledgerhq/types-live";
+// @shared/env (not @ledgerhq/live-env) so the env definitions are guaranteed injected.
+import { getEnv } from "@shared/env";
+import {
+  TransactionDataSource,
+  TransactionStage,
+  type CommonLogEvent,
+  type FailureLogEvent,
+  type SuccessLogEvent,
+  type TransactionPathway,
+} from "./logEvent";
+import { deriveEarnTransactionType, type EarnTransactionType } from "./earnTransactionType";
+import { deriveFromOperationType } from "./operationType";
+import { getRawTransactionType, getStakeTarget, type TransactionLike } from "./transactionShape";
+import { classifyTransactionError, ErrorCategory, toError, unwrapRpcError } from "./errorCategory";
+
+type Attribution = {
+  /** The signing account — read for the token id/ticker. */
+  account: AccountLike;
+  /** The resolved main account — read for currency, family and testnet. */
+  mainAccount: Account;
+  pathway: TransactionPathway;
+  manifestId?: string;
+  source?: TransactionSource;
+};
+
+type ActionFields = {
+  earnTransactionType?: EarnTransactionType;
+  rawTransactionType?: string;
+  validators?: string[];
+  isSendMax: boolean;
+  dataSource: TransactionDataSource;
+};
+
+function buildCommon(attribution: Attribution, action: ActionFields): CommonLogEvent {
+  const { account, mainAccount, pathway, manifestId, source } = attribution;
+  return {
+    appVersion: getEnv("LEDGER_CLIENT_VERSION"),
+    pathway,
+    currencyId: mainAccount.currency.id,
+    family: mainAccount.currency.family,
+    currencyTicker: mainAccount.currency.ticker,
+    isTestnet: Boolean(mainAccount.currency.isTestnetFor),
+    isSendMax: action.isSendMax,
+    dataSource: action.dataSource,
+    ...(manifestId ? { manifestId } : {}),
+    ...(source ? { source } : {}),
+    ...(action.earnTransactionType ? { earnTransactionType: action.earnTransactionType } : {}),
+    ...(action.rawTransactionType ? { rawTransactionType: action.rawTransactionType } : {}),
+    ...(action.validators?.length ? { validators: action.validators } : {}),
+    ...(account.type === "TokenAccount"
+      ? { tokenId: account.token.id, tokenTicker: account.token.ticker }
+      : {}),
+  };
+}
+
+/**
+ * Sign-stage event data, built from the rich transaction: the family's own action wording
+ * and the delegation target, neither of which survives to broadcast.
+ */
+export function buildSignCommonEvent(
+  attribution: Attribution & { transaction?: TransactionLike | null },
+): CommonLogEvent {
+  const { transaction } = attribution;
+  const rawTransactionType = getRawTransactionType(transaction);
+  return buildCommon(attribution, {
+    earnTransactionType: deriveEarnTransactionType(
+      attribution.mainAccount.currency.family,
+      rawTransactionType,
+    ),
+    rawTransactionType,
+    validators: getStakeTarget(transaction),
+    isSendMax: Boolean(transaction?.useAllAmount),
+    dataSource: TransactionDataSource.Sign,
+  });
+}
+
+type OperationExtra = {
+  validators?: Array<{ address?: string } | string>;
+  votes?: Array<{ address?: string }>;
+  targetStakingNodeId?: number | string | null;
+  celoSourceValidator?: string;
+};
+
+/**
+ * Reads the delegation target off the optimistic operation. Only some families copy it
+ * across: cosmos and hedera always, celo/polkadot/tron for a subset of their actions, and
+ * cardano / solana / sui / near / multiversx not at all. That unevenness is precisely why
+ * sign↔broadcast correlation is worth having.
+ */
+function stakeTargetFromOperation(operation: Operation): string[] | undefined {
+  const extra = (operation.extra ?? {}) as OperationExtra;
+  const raw = operation.transactionRaw as { valAddress?: string } | undefined;
+  const candidates = [
+    ...(extra.validators ?? []).map(v => (typeof v === "string" ? v : v?.address)),
+    ...(extra.votes ?? []).map(v => v?.address),
+    extra.celoSourceValidator,
+    extra.targetStakingNodeId != null ? String(extra.targetStakingNodeId) : undefined,
+    raw?.valAddress,
+  ].filter((a): a is string => Boolean(a));
+  return candidates.length ? candidates : undefined;
+}
+
+/**
+ * Broadcast-stage event data. There is no transaction here, only the optimistic operation.
+ *
+ * `Operation.type` is a coarser vocabulary than the sign stage's, so for the generic-coin
+ * -framework families (evm, tezos) the exact original mode is preferred where it survives on
+ * `transactionRaw` — that is the only way to tell an EVM `claimReward` from a
+ * `compoundReward`, since both become `REWARD`.
+ */
+export function buildBroadcastCommonEvent(
+  attribution: Attribution & { operation: Operation },
+): CommonLogEvent {
+  const { operation, mainAccount } = attribution;
+  const family = mainAccount.currency.family;
+  const rawMode = (operation.transactionRaw as { mode?: string } | undefined)?.mode;
+  const fromRawMode = deriveEarnTransactionType(family, rawMode);
+
+  return buildCommon(attribution, {
+    earnTransactionType: fromRawMode ?? deriveFromOperationType(family, operation.type),
+    rawTransactionType: fromRawMode ? rawMode : operation.type,
+    validators: stakeTargetFromOperation(operation),
+    isSendMax: false,
+    dataSource: TransactionDataSource.Broadcast,
+  });
+}
+
+export function buildTransactionSuccessEvent(common: CommonLogEvent): SuccessLogEvent {
+  return { status: "success", stage: TransactionStage.Broadcast, ...common };
+}
+
+/**
+ * Drop-off event: the user dismissed the sign prompt without confirming or erroring. That is
+ * an unsubscribe rather than an error, so it is invisible to the bridge and comes from the
+ * device-action layer.
+ */
+export function buildTransactionAbandonedEvent(common: CommonLogEvent): FailureLogEvent {
+  return {
+    status: "failure",
+    stage: TransactionStage.Sign,
+    error: Object.assign(new Error("Sign prompt dismissed"), { name: "UserModalDismissed" }),
+    errorCategory: ErrorCategory.UserModalDismissed,
+    ...common,
+  };
+}
+
+export type BuildTransactionFailureParams = {
+  stage: TransactionStage;
+  error: unknown;
+  /** Only available when signing succeeded (broadcast-stage failures). */
+  signedOperation?: SignedOperation;
+};
+
+export function buildTransactionFailureEvent(
+  common: CommonLogEvent,
+  { stage, error, signedOperation }: BuildTransactionFailureParams,
+): FailureLogEvent {
+  // Unwrapped once, here, so both the category and the reported `error.name` describe the
+  // real cause rather than an RPC envelope.
+  const err = toError(unwrapRpcError(error));
+  return {
+    status: "failure",
+    stage,
+    error: err,
+    errorCategory: classifyTransactionError(err),
+    ...(signedOperation
+      ? {
+          txPayload: {
+            signature: signedOperation.signature,
+            ...(signedOperation.rawData ? { rawData: signedOperation.rawData } : {}),
+          },
+        }
+      : {}),
+    ...common,
+  };
+}

--- a/libs/transaction-observability/src/index.ts
+++ b/libs/transaction-observability/src/index.ts
@@ -1,0 +1,33 @@
+export {
+  TransactionDataSource,
+  TransactionPathway,
+  TransactionStage,
+  type CommonLogEvent,
+  type LogEvent,
+  type TransactionLogger,
+} from "./logEvent";
+
+export { classifyTransactionError, ErrorCategory, toError, unwrapRpcError } from "./errorCategory";
+
+export { deriveEarnTransactionType, type EarnTransactionType } from "./earnTransactionType";
+
+export { deriveFromOperationType } from "./operationType";
+
+export { getRawTransactionType, getStakeTarget } from "./transactionShape";
+
+export {
+  buildBroadcastCommonEvent,
+  buildSignCommonEvent,
+  buildTransactionAbandonedEvent,
+  buildTransactionFailureEvent,
+  buildTransactionSuccessEvent,
+  type BuildTransactionFailureParams,
+} from "./eventBuilders";
+
+export {
+  emitTransactionEvent,
+  resetTransactionObservers,
+  setTransactionObserver,
+} from "./observer";
+
+export { toSegmentTrackEvent, type SegmentTrackEvent } from "./segmentEvent";

--- a/libs/transaction-observability/src/logEvent.ts
+++ b/libs/transaction-observability/src/logEvent.ts
@@ -1,0 +1,102 @@
+import type { TransactionSource } from "@ledgerhq/types-live";
+import type { ErrorCategory } from "./errorCategory";
+import type { EarnTransactionType } from "./earnTransactionType";
+
+/**
+ * The technical route a transaction took — the granular "where", complementing the live-app
+ * `manifestId`.
+ *
+ * Deliberately *not* called `flow`: the analytics payload uses `flow` for the product funnel,
+ * which is always `"stake"` here, and reaches Mixpanel as `tx_pathway`. Two different things.
+ *
+ * Deliberately finer-grained than the `TransactionSource["type"]` it is attributed from
+ * (`"dApp" | "live-app" | "coin-module" | "swap"`, `libs/types-live/src/transaction.ts`): the
+ * values name the concrete entry point, so a future per-route tap can add one without
+ * changing the source union. Every source type maps onto exactly one value today, and a test
+ * in the seam pins that mapping. `Unknown` belongs to the sign stage, where no
+ * `broadcastConfig` exists yet and the route is genuinely not known.
+ */
+export enum TransactionPathway {
+  Send = "send",
+  WalletApiSignAndBroadcast = "wallet-api/transaction.signAndBroadcast",
+  Dapp = "dApp/eth_sendTransaction",
+  Swap = "swap",
+  Unknown = "unknown",
+}
+
+/** Which stage of the transaction lifecycle produced the event. */
+export enum TransactionStage {
+  Sign = "sign",
+  Broadcast = "broadcast",
+}
+
+/**
+ * Where the event's transaction data came from. Broadcast has no transaction of its own, so
+ * it either reuses the sign stage's (richer) data or falls back to the optimistic operation.
+ * Reported so the correlation hit-rate is measurable rather than assumed.
+ */
+export enum TransactionDataSource {
+  Sign = "sign",
+  Broadcast = "broadcast",
+}
+
+type CommonLogEvent = {
+  appVersion: string;
+  /** The technical route; the product funnel is a separate concept — see above. */
+  pathway: TransactionPathway;
+  /** Live-app manifest id — the primary "where". Absent for the native send flow. */
+  manifestId?: string;
+  source?: TransactionSource;
+  /** Parent/network currency id (e.g. "ethereum"); token id is reported separately. */
+  currencyId: string;
+  family: string;
+  tokenId?: string;
+  /** Tickers, so analytics can report the asset the user recognises ("ETH", "USDC"). */
+  currencyTicker: string;
+  tokenTicker?: string;
+  /**
+   * Normalized staking action, derived per family. Distinct from `pathway` (the technical
+   * origin). Undefined when the transaction is not a recognised staking action — e.g. a
+   * plain send or a swap — which is what keeps those out of the earn funnel.
+   */
+  earnTransactionType?: EarnTransactionType;
+  /**
+   * The family-specific value `earnTransactionType` was derived from — a family `mode`,
+   * Solana `model.kind`, or (at broadcast) an `OperationType`. Kept for drill-down and to
+   * measure how often the normalization misses.
+   */
+  rawTransactionType?: string;
+  /**
+   * Delegation target(s) — validator addresses / staking pool id(s). Public ids, not the
+   * human-readable pool name. Read from the transaction at the sign stage; at broadcast only
+   * available for families that copy it into the optimistic operation's `extra`.
+   */
+  validators?: string[];
+  isTestnet: boolean;
+  isSendMax: boolean;
+  dataSource: TransactionDataSource;
+};
+
+type FailureLogEvent = {
+  status: "failure";
+  stage: TransactionStage;
+  error: Error;
+  errorCategory: ErrorCategory;
+  /** Present only when signing succeeded (i.e. broadcast-stage failures). */
+  txPayload?: {
+    signature: string;
+    rawData?: Record<string, unknown>;
+  };
+} & CommonLogEvent;
+
+type SuccessLogEvent = {
+  status: "success";
+  stage: TransactionStage.Broadcast;
+} & CommonLogEvent;
+
+export type LogEvent = SuccessLogEvent | FailureLogEvent;
+
+/** Injected by each host app to forward events to its analytics sink. */
+export type TransactionLogger = (event: LogEvent) => void;
+
+export type { CommonLogEvent, FailureLogEvent, SuccessLogEvent };

--- a/libs/transaction-observability/src/observer.test.ts
+++ b/libs/transaction-observability/src/observer.test.ts
@@ -1,0 +1,86 @@
+import {
+  emitTransactionEvent,
+  resetTransactionObservers,
+  setTransactionObserver,
+} from "./observer";
+import {
+  TransactionDataSource,
+  TransactionPathway,
+  TransactionStage,
+  type LogEvent,
+} from "./logEvent";
+
+const event = {
+  status: "success",
+  stage: TransactionStage.Broadcast,
+  appVersion: "t",
+  pathway: TransactionPathway.Send,
+  currencyId: "cardano",
+  family: "cardano",
+  currencyTicker: "ADA",
+  isTestnet: false,
+  isSendMax: false,
+  dataSource: TransactionDataSource.Broadcast,
+} as LogEvent;
+
+describe("transaction observer registry", () => {
+  afterEach(() => {
+    resetTransactionObservers();
+    jest.restoreAllMocks();
+  });
+
+  it("delivers an event to every registered observer", () => {
+    const first = jest.fn();
+    const second = jest.fn();
+    setTransactionObserver(first);
+    setTransactionObserver(second);
+
+    emitTransactionEvent(event);
+
+    expect(first).toHaveBeenCalledWith(event);
+    expect(second).toHaveBeenCalledWith(event);
+  });
+
+  it("stops delivering once unsubscribed, leaving the others registered", () => {
+    const kept = jest.fn();
+    const removed = jest.fn();
+    setTransactionObserver(kept);
+    const unsubscribe = setTransactionObserver(removed);
+
+    unsubscribe();
+    emitTransactionEvent(event);
+
+    expect(removed).not.toHaveBeenCalled();
+    expect(kept).toHaveBeenCalledTimes(1);
+  });
+
+  it("is idempotent when unsubscribing twice", () => {
+    const kept = jest.fn();
+    const unsubscribe = setTransactionObserver(() => {});
+    setTransactionObserver(kept);
+
+    unsubscribe();
+    unsubscribe();
+    emitTransactionEvent(event);
+
+    expect(kept).toHaveBeenCalledTimes(1);
+  });
+
+  // The load-bearing guarantee: this registry sits in the sign/broadcast path, so a broken
+  // analytics sink must never surface as a failed transaction.
+  it("isolates a throwing observer from the emitter and from its peers", () => {
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+    const after = jest.fn();
+    setTransactionObserver(() => {
+      throw new Error("sink is broken");
+    });
+    setTransactionObserver(after);
+
+    expect(() => emitTransactionEvent(event)).not.toThrow();
+    expect(after).toHaveBeenCalledWith(event);
+  });
+
+  it("emits to nobody when no observer is registered", () => {
+    expect(() => emitTransactionEvent(event)).not.toThrow();
+  });
+});

--- a/libs/transaction-observability/src/observer.ts
+++ b/libs/transaction-observability/src/observer.ts
@@ -1,0 +1,62 @@
+import type { LogEvent, TransactionLogger } from "./logEvent";
+
+/**
+ * Global registry of transaction log-event observers.
+ *
+ * The account bridge is resolved through the global `getAccountBridge`, not React context,
+ * so host apps cannot pass a sink down as a prop. Instead each host registers an observer
+ * once at startup and the bridge emits into it — the same fire-and-forget pattern as
+ * `@ledgerhq/logs` `listen`/`dispatch`.
+ *
+ * Multiple observers can coexist (e.g. a Segment sink plus a dev console sink), and each one
+ * owns its own consent gate — see {@link setTransactionObserver}.
+ */
+const observers: TransactionLogger[] = [];
+
+/**
+ * Register a transaction observer. Returns an unsubscribe function.
+ *
+ * **An observer is responsible for its own user consent.** Events are emitted from the bridge
+ * seam unconditionally, because this package cannot read the host's settings — so nothing here
+ * checks whether the user agreed to anything, and a sink that transmits without gating would
+ * leak data.
+ *
+ * There is no single gate to inherit, because sinks answer to different consents: Segment and
+ * Mixpanel are governed by the analytics opt-in, while Datadog is governed by the separate
+ * crash/error-reporting opt-in (plus its own feature flag). A user may accept one and decline
+ * the other, so a Datadog sink must not assume the Segment sink's gate — and vice versa.
+ *
+ * In practice: forward through the host's own `track` (which self-gates) or read the relevant
+ * consent selector before transmitting. Sinks that never leave the process — a dev console
+ * logger — need no gate.
+ */
+export function setTransactionObserver(observer: TransactionLogger): () => void {
+  observers.push(observer);
+  return () => {
+    const index = observers.indexOf(observer);
+    if (index !== -1) observers.splice(index, 1);
+  };
+}
+
+/** Remove all observers. Intended for tests. */
+export function resetTransactionObservers(): void {
+  observers.length = 0;
+}
+
+/**
+ * Emit a transaction log event to every registered observer.
+ *
+ * Each observer is isolated in a `try/catch`: a throwing sink must never break the
+ * transaction it is observing.
+ */
+export function emitTransactionEvent(event: LogEvent): void {
+  for (const observer of observers) {
+    try {
+      observer(event);
+    } catch (error) {
+      // warn, not error: a throwing sink is the recoverable case this registry exists to
+      // absorb, and console.error is forwarded to monitoring as an error event.
+      console.warn("transaction observer threw", error);
+    }
+  }
+}

--- a/libs/transaction-observability/src/operationType.ts
+++ b/libs/transaction-observability/src/operationType.ts
@@ -1,0 +1,135 @@
+import type { OperationType } from "@ledgerhq/types-live";
+import type { EarnTransactionType } from "./earnTransactionType";
+import { resolveFamily } from "./earnTransactionType";
+
+/**
+ * Broadcast-stage action derivation.
+ *
+ * `broadcast` receives no transaction, only the optimistic `Operation`, so the action has to
+ * come from its `OperationType`. That is a coarser and partly overloaded vocabulary — the
+ * same word means different things per family (`WITHDRAW` is Celo's unlock-withdraw;
+ * `WITHDRAW_UNBONDED` is EVM's and Polkadot's) — hence the per-family maps.
+ *
+ * Every entry below was read from the family's own `buildOptimisticOperation`. Generic types
+ * (`OUT`, `IN`, `NONE`, `FEES`, `UNKNOWN`) are deliberately never mapped: they are what a
+ * plain send produces, so claiming them would misreport ordinary transfers as staking.
+ */
+const FAMILY_OPERATION_TYPES: Record<
+  string,
+  Partial<Record<OperationType, EarnTransactionType>>
+> = {
+  cardano: { DELEGATE: "delegate", UNDELEGATE: "undelegate" },
+  celo: {
+    LOCK: "deposit",
+    VOTE: "delegate",
+    ACTIVATE: "delegate",
+    REVOKE: "undelegate",
+    UNLOCK: "undelegate",
+    WITHDRAW: "withdraw",
+  },
+  // REWARD covers claimReward and claimRewardCompound alike — see COLLAPSES.
+  cosmos: {
+    DELEGATE: "delegate",
+    UNDELEGATE: "undelegate",
+    REDELEGATE: "redelegate",
+    REWARD: "claimReward",
+  },
+  evm: {
+    DELEGATE: "delegate",
+    UNDELEGATE: "undelegate",
+    REDELEGATE: "redelegate",
+    WITHDRAW_UNBONDED: "withdraw",
+    REWARD: "claimReward",
+  },
+  hedera: { DELEGATE: "delegate", UNDELEGATE: "undelegate", REDELEGATE: "redelegate" },
+  multiversx: {
+    DELEGATE: "delegate",
+    UNDELEGATE: "undelegate",
+    WITHDRAW_UNBONDED: "withdraw",
+    REWARD: "claimReward",
+  },
+  near: { STAKE: "delegate", UNSTAKE: "undelegate", WITHDRAW_UNSTAKED: "withdraw" },
+  polkadot: {
+    BOND: "delegate",
+    NOMINATE: "delegate",
+    UNBOND: "undelegate",
+    CHILL: "undelegate",
+    WITHDRAW_UNBONDED: "withdraw",
+    REWARD_PAYOUT: "claimReward",
+  },
+  solana: { DELEGATE: "delegate", UNDELEGATE: "undelegate" },
+  sui: { DELEGATE: "delegate", UNDELEGATE: "undelegate" },
+  tezos: {
+    DELEGATE: "delegate",
+    UNDELEGATE: "undelegate",
+    STAKE: "delegate",
+    UNSTAKE: "undelegate",
+    FINALIZE_UNSTAKE: "withdraw",
+  },
+  tron: {
+    FREEZE: "delegate",
+    VOTE: "delegate",
+    UNFREEZE: "undelegate",
+    LEGACY_UNFREEZE: "undelegate",
+    UNDELEGATE_RESOURCE: "undelegate",
+    WITHDRAW_EXPIRE_UNFREEZE: "withdraw",
+    REWARD: "claimReward",
+  },
+};
+
+/**
+ * The generic coin framework's `defaultOperationType` mapping, inverted — the fallback for a
+ * family not named above.
+ *
+ * A family that migrates onto that framework without supplying `describeOptimisticOperation`
+ * lands on exactly these types, so covering them here means such a migration is classified
+ * correctly without a change to this file. Consulted after the family map, for the same
+ * reason as on the sign stage.
+ *
+ * `OUT` / `IN` / `NONE` / `FEES` are absent here too: that is where a family with no mapping
+ * lands, and claiming them would sweep ordinary transfers into the funnel.
+ */
+const GENERIC_OPERATION_TYPES: Partial<Record<OperationType, EarnTransactionType>> = {
+  DELEGATE: "delegate",
+  REDELEGATE: "redelegate",
+  UNDELEGATE: "undelegate",
+  STAKE: "delegate",
+  UNSTAKE: "undelegate",
+  FINALIZE_UNSTAKE: "withdraw",
+  WITHDRAW_UNBONDED: "withdraw",
+  REWARD: "claimReward",
+};
+
+/**
+ * Staking actions that produce a generic `OperationType`, and so cannot be recovered at the
+ * broadcast stage at all. Documented as data because the matrix test asserts it: these are
+ * the flows whose success is only reportable once sign↔broadcast correlation is in place.
+ */
+export const UNRECOVERABLE_AT_BROADCAST: Record<string, string[]> = {
+  // Crafted as a plain self-transfer that triggers the claim, so it is literally an `OUT`.
+  hedera: ["claim-rewards"],
+  algorand: ["claimReward"],
+  // `stake.withdraw` is an `IN`, `stake.split` an `OUT`.
+  solana: ["stake.withdraw", "stake.split"],
+};
+
+/**
+ * Distinct sign-stage actions that share one `OperationType`, so the broadcast stage reports
+ * the first of them. Asserted by the matrix test so a silent widening is caught.
+ */
+export const COLLAPSES: Record<string, Array<[string, string]>> = {
+  cosmos: [["claimReward", "claimRewardCompound"]],
+  evm: [["claimReward", "compoundReward"]],
+  multiversx: [["delegate", "reDelegateRewards"]],
+  polkadot: [["bond", "rebond"]],
+  solana: [["stake.createAccount", "stake.delegate"]],
+};
+
+export function deriveFromOperationType(
+  family: string | undefined,
+  operationType: OperationType | string | undefined,
+): EarnTransactionType | undefined {
+  if (!family || !operationType) return undefined;
+  const type = operationType as OperationType;
+  return FAMILY_OPERATION_TYPES[resolveFamily(family)]?.[type] ?? GENERIC_OPERATION_TYPES[type];
+}

--- a/libs/transaction-observability/src/segmentEvent.test.ts
+++ b/libs/transaction-observability/src/segmentEvent.test.ts
@@ -1,0 +1,159 @@
+import { toSegmentTrackEvent } from "./segmentEvent";
+import {
+  TransactionDataSource,
+  TransactionPathway,
+  TransactionStage,
+  type LogEvent,
+} from "./logEvent";
+import { ErrorCategory } from "./errorCategory";
+
+const common = {
+  appVersion: "t",
+  pathway: TransactionPathway.Send,
+  currencyId: "cardano",
+  family: "cardano",
+  currencyTicker: "ADA",
+  isTestnet: false,
+  isSendMax: false,
+  dataSource: TransactionDataSource.Sign,
+  earnTransactionType: "delegate" as const,
+  rawTransactionType: "delegate",
+  validators: ["pool123"],
+};
+
+// A distinctive marker, so the leak assertion below cannot pass or fail by colliding with a
+// legitimate value like `user_device_refused`.
+const refused = Object.assign(new Error("declined for 0xSENSITIVE_ADDR"), {
+  name: "UserRefusedOnDevice",
+});
+
+describe("toSegmentTrackEvent", () => {
+  // The analytics `flow` is the product funnel and is always "stake" — Ledger Wallet's word,
+  // not the Earn live-app's. The route travels separately as `tx_pathway`. Pinned so a change
+  // has to be intentional.
+  it.each([TransactionPathway.Send, TransactionPathway.Dapp, TransactionPathway.Swap])(
+    "always reports flow=stake, whatever the route (%s)",
+    pathway => {
+      const result = toSegmentTrackEvent({
+        status: "success",
+        stage: TransactionStage.Broadcast,
+        ...common,
+        pathway,
+      } as LogEvent);
+
+      expect(result!.properties).toMatchObject({ flow: "stake", tx_pathway: pathway });
+    },
+  );
+
+  it("maps a broadcast success to earn_transaction_completed", () => {
+    const result = toSegmentTrackEvent({
+      status: "success",
+      stage: TransactionStage.Broadcast,
+      ...common,
+    } as LogEvent);
+
+    expect(result!.event).toBe("earn_transaction_completed");
+    expect(result!.properties).toMatchObject({
+      flow: "stake",
+      stage: "broadcast",
+      status: "success",
+      transaction_type: "delegate",
+      raw_transaction_type: "delegate",
+      input_currency: "ada",
+      network: "cardano",
+      validators: ["pool123"],
+      tx_data_source: "sign",
+    });
+    expect(result!.properties).not.toHaveProperty("txPayload");
+    expect(result!.properties).not.toHaveProperty("error");
+  });
+
+  it("maps a failure to earn_transaction_failed with the classified reason", () => {
+    const result = toSegmentTrackEvent({
+      status: "failure",
+      stage: TransactionStage.Sign,
+      error: refused,
+      errorCategory: ErrorCategory.UserDeviceRefused,
+      ...common,
+    } as LogEvent);
+
+    expect(result!.event).toBe("earn_transaction_failed");
+    expect(result!.properties).toMatchObject({
+      stage: "sign",
+      status: "failed",
+      error_category: ErrorCategory.UserDeviceRefused,
+      error_reason: "UserRefusedOnDevice",
+    });
+    // Raw error objects and messages must never reach analytics.
+    expect(result!.properties).not.toHaveProperty("error");
+    expect(JSON.stringify(result!.properties)).not.toContain("0xSENSITIVE_ADDR");
+  });
+
+  it("reports a token's own ticker as input_currency, with the network alongside", () => {
+    const result = toSegmentTrackEvent({
+      status: "success",
+      stage: TransactionStage.Broadcast,
+      ...common,
+      currencyId: "ethereum",
+      family: "evm",
+      currencyTicker: "ETH",
+      tokenTicker: "USDC",
+      tokenId: "ethereum/erc20/usdc",
+    } as LogEvent);
+
+    expect(result!.properties).toMatchObject({ input_currency: "usdc", network: "ethereum" });
+  });
+
+  it("reports the broadcast fallback as tx_data_source=broadcast", () => {
+    const result = toSegmentTrackEvent({
+      status: "success",
+      stage: TransactionStage.Broadcast,
+      ...common,
+      dataSource: TransactionDataSource.Broadcast,
+      rawTransactionType: "DELEGATE",
+    } as LogEvent);
+
+    expect(result!.properties).toMatchObject({
+      tx_data_source: "broadcast",
+      raw_transaction_type: "DELEGATE",
+      transaction_type: "delegate",
+    });
+  });
+
+  it("exposes the manifest id as provider", () => {
+    const result = toSegmentTrackEvent({
+      status: "success",
+      stage: TransactionStage.Broadcast,
+      ...common,
+      manifestId: "kiln",
+    } as LogEvent);
+
+    expect(result!.properties.provider).toBe("kiln");
+  });
+
+  describe("does not emit", () => {
+    it("for a non-staking transaction (plain send / swap)", () => {
+      const result = toSegmentTrackEvent({
+        status: "success",
+        stage: TransactionStage.Broadcast,
+        ...common,
+        earnTransactionType: undefined,
+        rawTransactionType: "send",
+      } as unknown as LogEvent);
+      expect(result).toBeNull();
+    });
+
+    it.each(["earn", "earn-stg", "earn-prd-eks"])(
+      "for the %s live-app, which emits earn_transaction_* itself",
+      manifestId => {
+        const result = toSegmentTrackEvent({
+          status: "success",
+          stage: TransactionStage.Broadcast,
+          ...common,
+          manifestId,
+        } as LogEvent);
+        expect(result).toBeNull();
+      },
+    );
+  });
+});

--- a/libs/transaction-observability/src/segmentEvent.ts
+++ b/libs/transaction-observability/src/segmentEvent.ts
@@ -1,0 +1,69 @@
+import type { LogEvent } from "./logEvent";
+
+export type SegmentTrackEvent = {
+  event: string;
+  properties: Record<string, unknown>;
+};
+
+// Same names and vocabulary as the Earn live-app emits, so both sides of the funnel join in
+// Mixpanel. `stage` carries where in the lifecycle the outcome happened.
+const EARN_TRANSACTION_COMPLETED = "earn_transaction_completed";
+const EARN_TRANSACTION_FAILED = "earn_transaction_failed";
+
+// The Earn live-app emits earn_transaction_* for its own wallet-api flows with richer
+// context (protocol, receipt token). Emitting here too would double-count.
+const APP_OWNED_MANIFEST_IDS = new Set(["earn", "earn-stg", "earn-prd-eks"]);
+
+/**
+ * Maps a transaction {@link LogEvent} to a Segment/Mixpanel `track` call, or `null` when the
+ * event does not belong in the earn funnel.
+ *
+ * Deliberately omits the raw `error` object and `txPayload.signature` — no raw signatures or
+ * error messages in product analytics; the failure reason is carried by `error_category` and
+ * `error_reason`.
+ */
+export function toSegmentTrackEvent(event: LogEvent): SegmentTrackEvent | null {
+  // The bridge seam sees every transaction, including plain sends and swaps. Only a
+  // recognised staking action belongs in the earn funnel.
+  if (!event.earnTransactionType) return null;
+  if (event.manifestId && APP_OWNED_MANIFEST_IDS.has(event.manifestId)) return null;
+
+  const isSuccess = event.status === "success";
+  const properties: Record<string, unknown> = {
+    // Ledger Wallet's own staking events already say "stake" (screens/stake/constants, the
+    // family StepConfirmations), so the seam speaks its host's vocabulary rather than the
+    // Earn live-app's "earn". The two halves of the funnel join on the event name.
+    //
+    // Unreliable on mobile until LIVE-35904: `segment.ts` spreads its extra properties after
+    // the event's, and those set flow=onboarding|post-onboarding while those selectors are true.
+    flow: "stake",
+    stage: event.stage,
+    status: isSuccess ? "success" : "failed",
+    transaction_type: event.earnTransactionType,
+    raw_transaction_type: event.rawTransactionType,
+    // The asset the user recognises, plus the chain it settles on.
+    input_currency: (event.tokenTicker ?? event.currencyTicker).toLowerCase(),
+    network: event.currencyId,
+    family: event.family,
+    // Technical route (native send, wallet-api, dApp) — distinct from the `flow` above,
+    // which is the product funnel.
+    tx_pathway: event.pathway,
+    // Whether the broadcast event reused the sign stage's richer data. Reported so the
+    // correlation hit-rate is measurable rather than assumed.
+    tx_data_source: event.dataSource,
+    is_testnet: event.isTestnet,
+    is_send_max: event.isSendMax,
+    ...(event.manifestId ? { provider: event.manifestId } : {}),
+    ...(event.validators?.length ? { validators: event.validators } : {}),
+  };
+
+  if (!isSuccess) {
+    properties.error_category = event.errorCategory;
+    properties.error_reason = event.error.name;
+  }
+
+  return {
+    event: isSuccess ? EARN_TRANSACTION_COMPLETED : EARN_TRANSACTION_FAILED,
+    properties,
+  };
+}

--- a/libs/transaction-observability/src/stakingMatrix.test.ts
+++ b/libs/transaction-observability/src/stakingMatrix.test.ts
@@ -1,0 +1,269 @@
+import { deriveEarnTransactionType, type EarnTransactionType } from "./earnTransactionType";
+import { COLLAPSES, deriveFromOperationType, UNRECOVERABLE_AT_BROADCAST } from "./operationType";
+
+/**
+ * The source of truth for what this package must classify: every in-app staking flow
+ * (Ledger Live builds the transaction, the device signs it), keyed by family because family
+ * is what determines the vocabulary.
+ *
+ * `mode` is the sign-stage word (a family `mode`, or Solana's `model.kind`); `operationType`
+ * is what the family's own `buildOptimisticOperation` puts on the optimistic operation, which
+ * is all the broadcast stage gets.
+ *
+ * `operationType: null` means **the broadcast stage cannot report this action**, which happens
+ * two different ways: the family emits a generic type there (hedera `claim-rewards` is an
+ * `OUT`), or the action collapses onto another action's type (cosmos `claimRewardCompound`
+ * produces a `REWARD`, which derives `claimReward`). `UNRECOVERABLE_AT_BROADCAST` and
+ * `COLLAPSES` say which, and the "known precision losses" block asserts every `null` row is
+ * accounted for by one of them.
+ *
+ * Cosmos is one row for every cosmos-SDK currency: they share a single `Transaction` type and
+ * mode union, so only the currency-id → family mapping differs.
+ */
+type Row = {
+  mode: string;
+  operationType: string | null;
+  expected: EarnTransactionType;
+};
+
+const MATRIX: Record<string, Row[]> = {
+  cardano: [
+    { mode: "delegate", operationType: "DELEGATE", expected: "delegate" },
+    { mode: "undelegate", operationType: "UNDELEGATE", expected: "undelegate" },
+  ],
+  celo: [
+    { mode: "lock", operationType: "LOCK", expected: "deposit" },
+    { mode: "vote", operationType: "VOTE", expected: "delegate" },
+    { mode: "activate", operationType: "ACTIVATE", expected: "delegate" },
+    { mode: "revoke", operationType: "REVOKE", expected: "undelegate" },
+    { mode: "unlock", operationType: "UNLOCK", expected: "undelegate" },
+    { mode: "withdraw", operationType: "WITHDRAW", expected: "withdraw" },
+  ],
+  cosmos: [
+    { mode: "delegate", operationType: "DELEGATE", expected: "delegate" },
+    { mode: "undelegate", operationType: "UNDELEGATE", expected: "undelegate" },
+    { mode: "redelegate", operationType: "REDELEGATE", expected: "redelegate" },
+    { mode: "claimReward", operationType: "REWARD", expected: "claimReward" },
+    // Collapsed onto REWARD at broadcast — see COLLAPSES.
+    { mode: "claimRewardCompound", operationType: null, expected: "compoundReward" },
+  ],
+  evm: [
+    { mode: "delegate", operationType: "DELEGATE", expected: "delegate" },
+    { mode: "redelegate", operationType: "REDELEGATE", expected: "redelegate" },
+    { mode: "undelegate", operationType: "UNDELEGATE", expected: "undelegate" },
+    { mode: "withdraw", operationType: "WITHDRAW_UNBONDED", expected: "withdraw" },
+    { mode: "claimReward", operationType: "REWARD", expected: "claimReward" },
+    { mode: "compoundReward", operationType: null, expected: "compoundReward" },
+  ],
+  hedera: [
+    { mode: "delegate", operationType: "DELEGATE", expected: "delegate" },
+    { mode: "undelegate", operationType: "UNDELEGATE", expected: "undelegate" },
+    { mode: "redelegate", operationType: "REDELEGATE", expected: "redelegate" },
+    { mode: "claim-rewards", operationType: null, expected: "claimReward" },
+  ],
+  multiversx: [
+    { mode: "delegate", operationType: "DELEGATE", expected: "delegate" },
+    { mode: "unDelegate", operationType: "UNDELEGATE", expected: "undelegate" },
+    { mode: "withdraw", operationType: "WITHDRAW_UNBONDED", expected: "withdraw" },
+    { mode: "claimRewards", operationType: "REWARD", expected: "claimReward" },
+    { mode: "reDelegateRewards", operationType: null, expected: "compoundReward" },
+  ],
+  near: [
+    { mode: "stake", operationType: "STAKE", expected: "delegate" },
+    { mode: "unstake", operationType: "UNSTAKE", expected: "undelegate" },
+    { mode: "withdraw", operationType: "WITHDRAW_UNSTAKED", expected: "withdraw" },
+  ],
+  polkadot: [
+    { mode: "bond", operationType: "BOND", expected: "delegate" },
+    { mode: "nominate", operationType: "NOMINATE", expected: "delegate" },
+    { mode: "unbond", operationType: "UNBOND", expected: "undelegate" },
+    { mode: "chill", operationType: "CHILL", expected: "undelegate" },
+    { mode: "withdrawUnbonded", operationType: "WITHDRAW_UNBONDED", expected: "withdraw" },
+    { mode: "claimReward", operationType: "REWARD_PAYOUT", expected: "claimReward" },
+    // Collapsed onto BOND at broadcast, so it reads as a fresh delegation there.
+    { mode: "rebond", operationType: null, expected: "redelegate" },
+  ],
+  solana: [
+    { mode: "stake.createAccount", operationType: "DELEGATE", expected: "delegate" },
+    { mode: "stake.delegate", operationType: "DELEGATE", expected: "delegate" },
+    { mode: "stake.undelegate", operationType: "UNDELEGATE", expected: "undelegate" },
+    // `IN` and `OUT` respectively — indistinguishable from ordinary transfers.
+    { mode: "stake.withdraw", operationType: null, expected: "withdraw" },
+    { mode: "stake.split", operationType: null, expected: "undelegate" },
+  ],
+  sui: [
+    { mode: "delegate", operationType: "DELEGATE", expected: "delegate" },
+    { mode: "undelegate", operationType: "UNDELEGATE", expected: "undelegate" },
+  ],
+  tezos: [
+    { mode: "delegate", operationType: "DELEGATE", expected: "delegate" },
+    { mode: "undelegate", operationType: "UNDELEGATE", expected: "undelegate" },
+    { mode: "stake", operationType: "STAKE", expected: "delegate" },
+    { mode: "unstake", operationType: "UNSTAKE", expected: "undelegate" },
+    { mode: "finalize_unstake", operationType: "FINALIZE_UNSTAKE", expected: "withdraw" },
+  ],
+  tron: [
+    { mode: "freeze", operationType: "FREEZE", expected: "delegate" },
+    { mode: "vote", operationType: "VOTE", expected: "delegate" },
+    { mode: "unfreeze", operationType: "UNFREEZE", expected: "undelegate" },
+    { mode: "legacyUnfreeze", operationType: "LEGACY_UNFREEZE", expected: "undelegate" },
+    { mode: "unDelegateResource", operationType: "UNDELEGATE_RESOURCE", expected: "undelegate" },
+    { mode: "claimReward", operationType: "REWARD", expected: "claimReward" },
+    {
+      mode: "withdrawExpireUnfreeze",
+      operationType: "WITHDRAW_EXPIRE_UNFREEZE",
+      expected: "withdraw",
+    },
+  ],
+  algorand: [{ mode: "claimReward", operationType: null, expected: "claimReward" }],
+};
+
+const rows = Object.entries(MATRIX).flatMap(([family, familyRows]) =>
+  familyRows.map(row => ({ family, ...row })),
+);
+
+describe("staking action derivation", () => {
+  describe("sign stage", () => {
+    it.each(rows)("$family $mode -> $expected", ({ family, mode, expected }) => {
+      expect(deriveEarnTransactionType(family, mode)).toBe(expected);
+    });
+
+    it.each(["send", "token.send", "changeTrust", "optIn", "register"])(
+      "derives nothing for the non-staking mode %s",
+      mode => {
+        for (const family of Object.keys(MATRIX)) {
+          expect(deriveEarnTransactionType(family, mode)).toBeUndefined();
+        }
+      },
+    );
+  });
+
+  describe("broadcast stage", () => {
+    const recoverable = rows.filter(row => row.operationType !== null);
+
+    it.each(recoverable)(
+      "$family $operationType -> $expected",
+      ({ family, operationType, expected }) => {
+        expect(deriveFromOperationType(family, operationType!)).toBe(expected);
+      },
+    );
+
+    // These are what a plain send, an incoming transfer or a fee-only operation produce. If
+    // any of them ever mapped to an action, every ordinary transfer would enter the funnel.
+    it.each(["OUT", "IN", "NONE", "FEES", "UNKNOWN", "NFT_OUT"])(
+      "never claims the generic operation type %s",
+      operationType => {
+        for (const family of Object.keys(MATRIX)) {
+          expect(deriveFromOperationType(family, operationType)).toBeUndefined();
+        }
+      },
+    );
+  });
+
+  /**
+   * The regression net. Success is only knowable at broadcast, so a family whose two stages
+   * disagree silently drops its completed events — which is exactly what happened to Solana
+   * before `deriveFromOperationType` existed.
+   */
+  describe("the two stages agree", () => {
+    const recoverable = rows.filter(row => row.operationType !== null);
+
+    it.each(recoverable)(
+      "$family: $mode and $operationType derive the same action",
+      ({ family, mode, operationType }) => {
+        expect(deriveFromOperationType(family, operationType!)).toBe(
+          deriveEarnTransactionType(family, mode),
+        );
+      },
+    );
+
+    it("has a broadcast-stage mapping for every recoverable staking mode", () => {
+      const missing = recoverable.filter(
+        row => deriveFromOperationType(row.family, row.operationType!) === undefined,
+      );
+      expect(missing).toEqual([]);
+    });
+  });
+
+  /**
+   * Documented losses. Asserted rather than described so that a coin module fixing one of
+   * them (or a map widening that quietly papers over it) fails here and forces a decision.
+   */
+  describe("known precision losses", () => {
+    it.each(rows.filter(row => row.operationType === null))(
+      "$family $mode is not recoverable at the broadcast stage",
+      ({ family, mode, expected }) => {
+        expect(deriveEarnTransactionType(family, mode)).toBe(expected);
+        const collapsedOnto = COLLAPSES[family]?.find(pair => pair[1] === mode)?.[0];
+        const isUnrecoverable = UNRECOVERABLE_AT_BROADCAST[family]?.includes(mode);
+        expect(Boolean(collapsedOnto) || Boolean(isUnrecoverable)).toBe(true);
+      },
+    );
+
+    it("collapses list only names modes the matrix knows", () => {
+      for (const [family, pairs] of Object.entries(COLLAPSES)) {
+        const known = MATRIX[family].map(row => row.mode);
+        for (const [kept, lost] of pairs) {
+          expect(known).toContain(kept);
+          expect(known).toContain(lost);
+        }
+      }
+    });
+  });
+});
+
+/**
+ * A family that migrates onto the generic coin framework and adopts its vocabulary must be
+ * classified without anyone editing this package. "newchain" stands in for that family: it
+ * appears in neither map, so every assertion here goes through the generic fallback.
+ */
+describe("a family the maps have never seen", () => {
+  it.each([
+    ["delegate", "delegate"],
+    ["redelegate", "redelegate"],
+    ["undelegate", "undelegate"],
+    ["stake", "delegate"],
+    ["unstake", "undelegate"],
+    ["finalize_unstake", "withdraw"],
+    ["withdraw", "withdraw"],
+    ["claimReward", "claimReward"],
+    ["compoundReward", "compoundReward"],
+  ])("derives the generic mode %s as %s", (mode, expected) => {
+    expect(deriveEarnTransactionType("newchain", mode)).toBe(expected);
+  });
+
+  it.each([
+    ["DELEGATE", "delegate"],
+    ["REDELEGATE", "redelegate"],
+    ["UNDELEGATE", "undelegate"],
+    ["STAKE", "delegate"],
+    ["UNSTAKE", "undelegate"],
+    ["FINALIZE_UNSTAKE", "withdraw"],
+    ["WITHDRAW_UNBONDED", "withdraw"],
+    ["REWARD", "claimReward"],
+  ])("derives the generic operation type %s as %s", (operationType, expected) => {
+    expect(deriveFromOperationType("newchain", operationType)).toBe(expected);
+  });
+
+  it.each(["send", "changeTrust", "send-legacy", "send-eip1559"])(
+    "still derives nothing for the non-staking generic mode %s",
+    mode => {
+      expect(deriveEarnTransactionType("newchain", mode)).toBeUndefined();
+    },
+  );
+
+  it.each(["OUT", "IN", "NONE", "FEES", "OPT_IN"])(
+    "still derives nothing for the generic operation type %s",
+    operationType => {
+      expect(deriveFromOperationType("newchain", operationType)).toBeUndefined();
+    },
+  );
+
+  // A family's own word outranks the generic one, so migration can never silently change
+  // what an existing family reports.
+  it("lets a family override a word the generic map also defines", () => {
+    expect(deriveEarnTransactionType("celo", "withdraw")).toBe("withdraw");
+    expect(deriveEarnTransactionType("tezos", "stake")).toBe("delegate");
+    expect(deriveEarnTransactionType("tron", "vote")).toBe("delegate");
+  });
+});

--- a/libs/transaction-observability/src/transactionShape.test.ts
+++ b/libs/transaction-observability/src/transactionShape.test.ts
@@ -1,0 +1,94 @@
+import { getRawTransactionType, getStakeTarget, type TransactionLike } from "./transactionShape";
+
+const tx = (fields: Record<string, unknown>): TransactionLike => fields;
+
+describe("getRawTransactionType", () => {
+  it("returns undefined without a transaction", () => {
+    expect(getRawTransactionType(undefined)).toBeUndefined();
+    expect(getRawTransactionType(null)).toBeUndefined();
+  });
+
+  it("reads mode for families that expose one", () => {
+    expect(getRawTransactionType(tx({ family: "cosmos", mode: "delegate" }))).toBe("delegate");
+    expect(getRawTransactionType(tx({ family: "celo", mode: "lock" }))).toBe("lock");
+  });
+
+  it("reads solana's dotted model.kind", () => {
+    expect(getRawTransactionType(tx({ family: "solana", model: { kind: "stake.delegate" } }))).toBe(
+      "stake.delegate",
+    );
+  });
+
+  // EVM native staking sets a mode; a plain send and a dApp call do not. That is what scopes
+  // this to in-app staking without inspecting call data.
+  it("reads mode for EVM native staking and nothing for other EVM transactions", () => {
+    expect(getRawTransactionType(tx({ family: "ethereum", mode: "delegate" }))).toBe("delegate");
+    expect(getRawTransactionType(tx({ family: "ethereum", data: "0x095ea7b3" }))).toBeUndefined();
+  });
+
+  it("returns undefined for families with no action discriminator", () => {
+    expect(getRawTransactionType(tx({ family: "bitcoin" }))).toBeUndefined();
+  });
+});
+
+describe("getStakeTarget", () => {
+  it("reads Cardano poolId as a single-element list", () => {
+    expect(getStakeTarget(tx({ family: "cardano", mode: "delegate", poolId: "pool123" }))).toEqual([
+      "pool123",
+    ]);
+  });
+
+  it("reads cosmos validators[].address", () => {
+    expect(
+      getStakeTarget(
+        tx({ family: "cosmos", validators: [{ address: "cosmosvaloper1" }, { address: "v2" }] }),
+      ),
+    ).toEqual(["cosmosvaloper1", "v2"]);
+  });
+
+  // Tron's votes moved into familySpecificData when it joined the generic coin framework.
+  it("reads tron votes from familySpecificData", () => {
+    expect(
+      getStakeTarget(
+        tx({
+          family: "tron",
+          mode: "vote",
+          familySpecificData: { votes: [{ address: "TVote2" }] },
+        }),
+      ),
+    ).toEqual(["TVote2"]);
+  });
+
+  it("reads polkadot validators[] and tron votes[].address", () => {
+    expect(getStakeTarget(tx({ family: "polkadot", validators: ["addr1"] }))).toEqual(["addr1"]);
+    expect(getStakeTarget(tx({ family: "tron", votes: [{ address: "TVote" }] }))).toEqual([
+      "TVote",
+    ]);
+  });
+
+  it("reads the solana vote account and the hedera staking node id", () => {
+    expect(
+      getStakeTarget(tx({ family: "solana", model: { uiState: { voteAccAddr: "voteAcc" } } })),
+    ).toEqual(["voteAcc"]);
+    expect(getStakeTarget(tx({ family: "hedera", stakingNodeId: 7 }))).toEqual(["7"]);
+  });
+
+  it("reads valAddress for EVM native staking", () => {
+    expect(
+      getStakeTarget(tx({ family: "ethereum", mode: "delegate", valAddress: "0xval" })),
+    ).toEqual(["0xval"]);
+  });
+
+  // These families put the validator in `recipient`, so reading it would report a plain
+  // send's payee as a delegation target.
+  it("returns undefined for recipient-overloading families and non-staking transactions", () => {
+    expect(
+      getStakeTarget(tx({ family: "tezos", mode: "delegate", recipient: "tz1" })),
+    ).toBeUndefined();
+    expect(
+      getStakeTarget(tx({ family: "sui", mode: "delegate", recipient: "0xval" })),
+    ).toBeUndefined();
+    expect(getStakeTarget(tx({ family: "cosmos", mode: "send" }))).toBeUndefined();
+    expect(getStakeTarget(undefined)).toBeUndefined();
+  });
+});

--- a/libs/transaction-observability/src/transactionShape.ts
+++ b/libs/transaction-observability/src/transactionShape.ts
@@ -1,0 +1,76 @@
+/**
+ * Structural view of a transaction — enough to read the staking action and its target.
+ *
+ * Deliberately not the coin-module `Transaction` union nor the wallet-api one: the bridge
+ * seam hands over whichever of those the route produced, and this package must not depend on
+ * either family layer to read two fields off them.
+ */
+export type TransactionLike = { family?: string } & Record<string, unknown>;
+
+/**
+ * Reads the family-specific staking action off a transaction, at the sign stage.
+ *
+ * Almost every family exposes it as `mode`; Solana is the exception and uses a dotted
+ * `model.kind`. EVM is deliberately *not* special-cased: its native staking flows set a
+ * `mode` alongside `valAddress`, while a plain send or a dApp call has none — so falling
+ * through to `mode` scopes this to in-app staking without inspecting call data.
+ *
+ * `undefined` when the transaction carries no action, or when there is no rich transaction
+ * at all (signRaw / signPsbt / ACRE).
+ */
+export function getRawTransactionType(tx: TransactionLike | undefined | null): string | undefined {
+  if (!tx) return undefined;
+  if (tx.family === "solana") return (tx.model as { kind?: string } | undefined)?.kind;
+  return tx.mode as string | undefined;
+}
+
+function nonEmptyStrings(list?: (string | undefined | null)[]): string[] | undefined {
+  const filtered = (list ?? []).filter((a): a is string => Boolean(a));
+  return filtered.length ? filtered : undefined;
+}
+
+/**
+ * Extracts the delegation target(s) — validator address(es) or staking pool id — from a
+ * transaction.
+ *
+ * Only families with an unambiguous, dedicated target field are handled. Families that
+ * overload the generic `recipient` (near, tezos, multiversx, celo, sui) are intentionally
+ * skipped, so a plain send's payee can never be reported as a validator.
+ */
+export function getStakeTarget(tx: TransactionLike | undefined | null): string[] | undefined {
+  if (!tx) return undefined;
+  const t = tx as {
+    poolId?: string;
+    valAddress?: string;
+    validators?: Array<{ address?: string } | string>;
+    votes?: Array<{ address?: string }>;
+    familySpecificData?: { votes?: Array<{ address?: string }> };
+    stakingNodeId?: number | null;
+    model?: { uiState?: { voteAccAddr?: string; delegate?: { voteAccAddress?: string } } };
+  };
+  switch (tx.family) {
+    case "cardano":
+      return t.poolId ? [t.poolId] : undefined;
+    case "cosmos":
+      return nonEmptyStrings(t.validators?.map(v => (typeof v === "string" ? v : v?.address)));
+    case "polkadot":
+      return nonEmptyStrings(t.validators as (string | undefined)[] | undefined);
+    // Since tron moved onto the generic coin framework its votes travel in
+    // `familySpecificData`; the top-level field is still read for anything predating that.
+    case "tron":
+      return nonEmptyStrings(
+        (t.familySpecificData?.votes ?? t.votes)?.map(v =>
+          typeof v === "string" ? v : v?.address,
+        ),
+      );
+    case "hedera":
+      return t.stakingNodeId != null ? [String(t.stakingNodeId)] : undefined;
+    case "solana": {
+      const addr = t.model?.uiState?.voteAccAddr ?? t.model?.uiState?.delegate?.voteAccAddress;
+      return addr ? [addr] : undefined;
+    }
+    default:
+      // EVM native staking carries the validator on the generic transaction.
+      return t.valAddress ? [t.valAddress] : undefined;
+  }
+}

--- a/libs/transaction-observability/tsconfig.build.json
+++ b/libs/transaction-observability/tsconfig.build.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "customConditions": [],
+    "types": []
+  },
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/__tests__/**/*",
+    "**/tests/**/*",
+    "**/__mocks__/**/*",
+    "**/*.test.js",
+    "**/*.test.jsx",
+    "**/*.spec.js",
+    "**/*.spec.jsx"
+  ]
+}

--- a/libs/transaction-observability/tsconfig.json
+++ b/libs/transaction-observability/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "outDir": "lib",
+    "rootDir": "src",
+    "types": ["node", "jest"]
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15436,6 +15436,40 @@ importers:
         specifier: ^6.1.1
         version: 6.1.4
 
+  libs/transaction-observability:
+    dependencies:
+      '@ledgerhq/types-live':
+        specifier: workspace:^
+        version: link:../types-live
+      '@shared/env':
+        specifier: workspace:*
+        version: link:../../shared/env
+    devDependencies:
+      '@ledgerhq/coin-module-framework':
+        specifier: 'catalog:'
+        version: 8.1.0
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0(@types/node@24.12.0)
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.64.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.79.0
+
   libs/types-devices:
     devDependencies:
       '@ledgerhq/test-quarantine':
@@ -69536,7 +69570,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3
+      metro: 0.83.3(metro-transform-worker@0.83.3)
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -69660,6 +69694,54 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.83.3(metro-transform-worker@0.83.3):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.28.5
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 1.3.8
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.32.0
+      image-size: 1.1.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0(metro@0.83.3)
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.3
+      metro-cache: 0.83.3
+      metro-cache-key: 0.83.3
+      metro-config: 0.83.3(metro-transform-worker@0.83.3)
+      metro-core: 0.83.3
+      metro-file-map: 0.83.3(metro@0.83.3)
+      metro-resolver: 0.83.3
+      metro-runtime: 0.83.3
+      metro-source-map: 0.83.3
+      metro-symbolicate: 0.83.3
+      metro-transform-plugins: 0.83.3
+      metro-transform-worker: 0.83.3
+      mime-types: 2.1.35
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
### 📝 Description

**Part 1 of 3.** Nothing imports this package, so nothing can change behaviour. The reviewer's only question is whether the schema and the classification are right.

Stack: **#20817 package** → [#20818 bridge seam](https://github.com/LedgerHQ/ledger-live/pull/20818) → [#20819 correlation](https://github.com/LedgerHQ/ledger-live/pull/20819)

**Problem.** The Earn bottom-of-funnel is inferred from UI screens for native staking — a `staking_completed` fired on a confirmation screen — so a user who reaches the final screen and never lands a transaction counts as converted. This package is the vocabulary that fixes it: it maps a sign or broadcast outcome onto a stable `{event, properties}` pair for the host to send.

**Approach.** `signOperation` receives the rich transaction; `broadcast` receives only the signed operation. They speak different languages, and that asymmetry drives the whole design:

| | sign | broadcast |
|---|---|---|
| action wording | the family's own `mode` / `model.kind` | an `OperationType` |
| delegation target | read off the transaction | only if the family copies it into `Operation.extra` |
| originating route | unknown (no `broadcastConfig`) | attributed from `broadcastConfig.source` |

So there are two derivations — `deriveEarnTransactionType` (sign) and `deriveFromOperationType` (broadcast) — and `stakingMatrix.test.ts` asserts they agree per family.

```ts
// what a host does with it
setTransactionObserver(event => {
  const mapped = toSegmentTrackEvent(event);
  if (mapped) track(mapped.event, mapped.properties); // track() self-gates on consent
});
```

**Why the matrix test is the point of the PR.** Without the broadcast derivation, a successful Solana stake derives no action at all and is silently dropped, because `stake.createAccount` becomes a `DELEGATE` operation at broadcast. Every row was read from the family's own `buildOptimisticOperation`, not guessed.

**Emission policy.** An event only reaches analytics when a staking action was derived. Plain sends and swaps derive nothing, so no currency allowlist is needed and a newly-enabled staking currency is covered for free. Generic operation types (`OUT`, `IN`, `NONE`, `FEES`) are never mapped — claiming them would sweep ordinary transfers into the funnel.

**Generic coin framework.** A family that migrates onto it and adopts its vocabulary is classified with no change here: the family maps are consulted first, then a generic fallback. A test using a fictional `"newchain"` family proves it. Family-first precedence is deliberate — where a family defines a word that also exists generically, the family's meaning is authoritative (tron kept `freeze`/`vote` while migrating).

**Documented precision losses.** `operationType.ts` records these as data and the matrix test asserts them, so a coin module fixing one forces a decision rather than quietly changing the numbers:

- *Unrecoverable at broadcast*: hedera `claim-rewards` and algorand `claimReward` are crafted as plain transfers (`OUT`); solana `stake.withdraw` is an `IN`, `stake.split` an `OUT`.
- *Collapsed*: cosmos `claimReward`/`claimRewardCompound` and evm `claimReward`/`compoundReward` both become `REWARD`; multiversx `delegate`/`reDelegateRewards` both `DELEGATE`; polkadot `bond`/`rebond` both `BOND`.

#20819 recovers all of these by correlating the two stages.

**Notes for review**

- No dependency on `@ledgerhq/live-common` — live-common depends on this, so that edge would be a cycle nx fails on. A transaction is read through a structural `TransactionLike` for the same reason.
- The README explains why the package sits in `libs/` despite the DDD guide treating it as legacy: it needs `Account` / `Operation` / `SignedOperation` / `TransactionSource` / `OperationType`, which exist only in `libs/types-live`, and the new-architecture layers may not import that. It should move once those types have a non-legacy home.
- `setTransactionObserver` documents that **each sink owns its consent gate** — Segment answers to the analytics opt-in, Datadog to the separate crash-reporting opt-in, so there is no single gate to inherit.
- `observer.ts` has the test it never had in the earlier draft: a throwing analytics sink must never break the transaction it observes.
- The EVM staking chains (`sei_evm`, `monad`, `somnia`, `zero_gravity`) are in scope and need **no** call-data parsing — their in-app flows set a `mode`. dApp selector matching is deliberately absent and returns with the partner work.

**Test coverage:** yes — 307 tests. No UI changes.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35350](https://ledgerhq.atlassian.net/browse/LIVE-35350)
- **ADR** (if any): 
- ADR https://ledgerhq.atlassian.net/wiki/spaces/PTX/pages/7218364465/EARN+ADR+TX+observability
- Taxonomy docs https://ledgerhq.atlassian.net/wiki/x/8YBQuAE


[LIVE-35350]: https://ledgerhq.atlassian.net/browse/LIVE-35350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ