### PR TITLE
feat(observability): emit earn_transaction_* at the seam (LIVE-35350)

### DIFF
--- a/.changeset/LIVE-35350-bridge-seam-and-hosts.md
+++ b/.changeset/LIVE-35350-bridge-seam-and-hosts.md
@@ -1,0 +1,13 @@
+---
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Emit `earn_transaction_completed` / `earn_transaction_failed` for native staking, from the account-bridge seam.
+
+Every transaction route resolves its bridge through `getAccountBridge`, so `wrapAccountBridge` — which already hosts the sanctioned-address check — is the one place that sees them all. It now decorates `signOperation` (emitting a classified failure, then re-raising the original error untouched) and `broadcast` (success or classified failure). The device-action layer adds the one signal the bridge cannot see: closing the sign prompt is an unsubscribe rather than an error, so abandonment is reported from there.
+
+This replaces UI-inferred bottom-of-funnel tracking for staking, where a user reaching the final screen was counted as converted whether or not a transaction ever landed. No *analytics* event is produced for non-staking transactions. The seam observes every sign and broadcast outcome, and the Segment mapping is what drops the ones with no derived staking action — so plain sends and swaps reach no analytics sink, and no currency allowlist is needed.
+
+Desktop and mobile each register a Segment observer at startup; `track` already self-gates on analytics consent. Desktop also registers a dev-only console observer so the whole seam can be watched locally across every staking route and coin. The existing Datadog `useBroadcast` path is untouched.

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -158,6 +158,7 @@
     "@ledgerhq/lumen-ui-react": "catalog:",
     "@ledgerhq/lumen-ui-react-visualization": "catalog:",
     "@ledgerhq/react-ui": "workspace:^",
+    "@ledgerhq/transaction-observability": "workspace:^",
     "@ledgerhq/types-devices": "workspace:^",
     "@ledgerhq/types-live": "workspace:^",
     "@ledgerhq/wallet-analytics": "workspace:^",

--- a/apps/ledger-live-desktop/src/renderer/analytics/registerTransactionObserver.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/registerTransactionObserver.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Covers the wiring between the bridge seam and Segment, which no other test reaches: the
+ * observer is registered as an import side effect, so a broken import or a mapping change
+ * would otherwise fail silently in production rather than in CI.
+ */
+const track = jest.fn();
+jest.mock("./segment", () => ({ track: (...args: unknown[]) => track(...args) }));
+
+import {
+  emitTransactionEvent,
+  TransactionDataSource,
+  TransactionPathway,
+  TransactionStage,
+  type LogEvent,
+} from "@ledgerhq/transaction-observability";
+
+// Importing the module is what registers the observer. It must come after the mock above.
+import "./registerTransactionObserver";
+
+const stakingEvent = (over: Partial<Record<string, unknown>> = {}) =>
+  ({
+    status: "success",
+    stage: TransactionStage.Broadcast,
+    appVersion: "llc/test",
+    pathway: TransactionPathway.Send,
+    currencyId: "cardano",
+    family: "cardano",
+    currencyTicker: "ADA",
+    isTestnet: false,
+    isSendMax: false,
+    dataSource: TransactionDataSource.Sign,
+    earnTransactionType: "delegate",
+    rawTransactionType: "delegate",
+    validators: ["pool123"],
+    ...over,
+  }) as unknown as LogEvent;
+
+describe("desktop transaction observer", () => {
+  beforeEach(() => {
+    track.mockClear();
+    jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it("forwards a staking outcome to Segment", () => {
+    emitTransactionEvent(stakingEvent());
+
+    expect(track).toHaveBeenCalledTimes(1);
+    const [event, properties] = track.mock.calls[0];
+    expect(event).toBe("earn_transaction_completed");
+    expect(properties).toMatchObject({
+      flow: "stake",
+      tx_pathway: "send",
+      transaction_type: "delegate",
+      input_currency: "ada",
+      network: "cardano",
+    });
+  });
+
+  /**
+   * `track` self-gates on analytics consent, but its third argument bypasses that gate. Passing
+   * only two arguments is what keeps these events subject to consent, so it is asserted rather
+   * than assumed.
+   */
+  it("never passes the consent-bypassing third argument", () => {
+    emitTransactionEvent(stakingEvent());
+
+    expect(track.mock.calls[0]).toHaveLength(2);
+  });
+
+  it("sends nothing for a transaction with no staking action", () => {
+    emitTransactionEvent(stakingEvent({ earnTransactionType: undefined }));
+
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  it("sends nothing for the Earn live-app, which emits these events itself", () => {
+    emitTransactionEvent(stakingEvent({ manifestId: "earn" }));
+
+    expect(track).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/analytics/registerTransactionObserver.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/registerTransactionObserver.ts
@@ -1,0 +1,32 @@
+import { setTransactionObserver, toSegmentTrackEvent } from "@ledgerhq/transaction-observability";
+import { track } from "./segment";
+
+/**
+ * Forwards every transaction (sign/broadcast) log event from the bridge seam to
+ * Segment/Mixpanel. Additive — the Datadog path (useBroadcast → broadcastLogger) is
+ * untouched. `track` self-gates on analytics consent, so no extra gating is needed here.
+ *
+ * Registered at module load, like mobile's equivalent: the bridge is resolved through the
+ * global `getAccountBridge` rather than React context, so there is nothing to hang it off.
+ */
+setTransactionObserver(event => {
+  const mapped = toSegmentTrackEvent(event);
+  if (mapped) track(mapped.event, mapped.properties);
+});
+
+// Dev-only: makes the whole seam visible locally, across every staking route and coin.
+if (process.env.NODE_ENV !== "production") {
+  setTransactionObserver(event => {
+    // eslint-disable-next-line no-console
+    console.log(`[tx-observability] ${event.stage}/${event.status}`, {
+      pathway: event.pathway,
+      currencyId: event.currencyId,
+      rawTransactionType: event.rawTransactionType,
+      earnTransactionType: event.earnTransactionType,
+      dataSource: event.dataSource,
+      ...(event.status === "failure"
+        ? { errorCategory: event.errorCategory, errorName: event.error.name }
+        : { validators: event.validators, manifestId: event.manifestId }),
+    });
+  });
+}

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -21,6 +21,7 @@ import "~/renderer/styles/global";
 import { registerTransportModules } from "~/renderer/live-common-setup";
 import { getLocalStorageEnvs } from "~/renderer/experimental";
 import "~/renderer/i18n/init";
+import "~/renderer/analytics/registerTransactionObserver";
 import { hydrateCurrency } from "~/renderer/bridge/cache";
 import { setupCryptoAssetsStore } from "~/config/bridge-setup";
 import { setSwapQuotesStore } from "@ledgerhq/live-common/wallet-api/Exchange/quotes/state-manager/store";

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -184,6 +184,7 @@
     "@ledgerhq/lumen-ui-rnative": "catalog:",
     "@ledgerhq/lumen-ui-rnative-visualization": "catalog:",
     "@ledgerhq/native-ui": "workspace:^",
+    "@ledgerhq/transaction-observability": "workspace:^",
     "@ledgerhq/types-devices": "workspace:^",
     "@ledgerhq/types-live": "workspace:^",
     "@ledgerhq/wallet-analytics": "workspace:^",

--- a/apps/ledger-live-mobile/src/analytics/registerTransactionObserver.test.ts
+++ b/apps/ledger-live-mobile/src/analytics/registerTransactionObserver.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Covers the wiring between the bridge seam and Segment, which no other test reaches: the
+ * observer is registered as an import side effect, so a broken import or a mapping change
+ * would otherwise fail silently in production rather than in CI.
+ *
+ * `./segment` is mocked rather than imported: it sits in a require cycle with `~/analytics`,
+ * and this test needs only the `track` call it makes.
+ */
+const track = jest.fn();
+jest.mock("./segment", () => ({ track: (...args: unknown[]) => track(...args) }));
+
+import {
+  emitTransactionEvent,
+  TransactionDataSource,
+  TransactionPathway,
+  TransactionStage,
+  type LogEvent,
+} from "@ledgerhq/transaction-observability";
+
+// Importing the module is what registers the observer. It must come after the mock above.
+import "./registerTransactionObserver";
+
+const stakingEvent = (over: Partial<Record<string, unknown>> = {}) =>
+  ({
+    status: "success",
+    stage: TransactionStage.Broadcast,
+    appVersion: "llm/test",
+    pathway: TransactionPathway.Send,
+    currencyId: "solana",
+    family: "solana",
+    currencyTicker: "SOL",
+    isTestnet: false,
+    isSendMax: false,
+    dataSource: TransactionDataSource.Sign,
+    earnTransactionType: "delegate",
+    rawTransactionType: "stake.createAccount",
+    validators: ["voteAcc"],
+    ...over,
+  }) as unknown as LogEvent;
+
+describe("mobile transaction observer", () => {
+  beforeEach(() => track.mockClear());
+
+  it("forwards a staking outcome to Segment", () => {
+    emitTransactionEvent(stakingEvent());
+
+    expect(track).toHaveBeenCalledTimes(1);
+    const [event, properties] = track.mock.calls[0];
+    expect(event).toBe("earn_transaction_completed");
+    expect(properties).toMatchObject({
+      flow: "stake",
+      tx_pathway: "send",
+      transaction_type: "delegate",
+      // Solana's own wording survives to the broadcast event through correlation.
+      raw_transaction_type: "stake.createAccount",
+      input_currency: "sol",
+      network: "solana",
+    });
+  });
+
+  /**
+   * `track` self-gates on analytics consent, but its third argument bypasses that gate. Passing
+   * only two arguments is what keeps these events subject to consent, so it is asserted rather
+   * than assumed.
+   */
+  it("never passes the consent-bypassing third argument", () => {
+    emitTransactionEvent(stakingEvent());
+
+    expect(track.mock.calls[0]).toHaveLength(2);
+  });
+
+  it("sends nothing for a transaction with no staking action", () => {
+    emitTransactionEvent(stakingEvent({ earnTransactionType: undefined }));
+
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  it("sends nothing for the Earn live-app, which emits these events itself", () => {
+    emitTransactionEvent(stakingEvent({ manifestId: "earn" }));
+
+    expect(track).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/analytics/registerTransactionObserver.ts
+++ b/apps/ledger-live-mobile/src/analytics/registerTransactionObserver.ts
@@ -1,0 +1,12 @@
+import { setTransactionObserver, toSegmentTrackEvent } from "@ledgerhq/transaction-observability";
+import { track } from "./segment";
+
+/**
+ * Forwards every transaction (sign/broadcast) log event from the bridge seam to
+ * Segment/Mixpanel. Additive — the Datadog path (useBroadcast → broadcastLogger) is
+ * untouched. `track` self-gates on analytics consent, so no extra gating is needed here.
+ */
+setTransactionObserver(event => {
+  const mapped = toSegmentTrackEvent(event);
+  if (mapped) track(mapped.event, mapped.properties);
+});

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -14,6 +14,7 @@ import { log } from "@ledgerhq/logs";
 import { checkLibs } from "@ledgerhq/live-common/sanityChecks";
 import "./config/configInit";
 import "./config/bridge-setup";
+import "./analytics/registerTransactionObserver";
 import Config from "react-native-config";
 import useEnv from "@features/platform-env";
 import { init } from "~/e2e/bridge/client";

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -363,6 +363,7 @@
     "@ledgerhq/live-signer-zcash": "workspace:^",
     "@ledgerhq/logs": "catalog:",
     "@ledgerhq/speculos-transport": "workspace:^",
+    "@ledgerhq/transaction-observability": "workspace:^",
     "@ledgerhq/wallet-api-acre-module": "workspace:^",
     "@ledgerhq/wallet-api-client": "catalog:",
     "@ledgerhq/wallet-api-core": "catalog:",

--- a/libs/ledger-live-common/src/bridge/impl.ts
+++ b/libs/ledger-live-common/src/bridge/impl.ts
@@ -13,6 +13,7 @@ import {
   CurrencyBridge,
   ResolvedAccountBridge,
   TransactionCommon,
+  TransactionSource,
   TransactionStatusCommon,
 } from "@ledgerhq/types-live";
 import { getCoinFrameworkAccountBridge } from "./generic-coin-framework/accountBridge";
@@ -26,6 +27,17 @@ import {
 } from "../coin-modules/registry";
 import { defaultBridgeExtensions } from "./defaultBridgeExtensions";
 import { isZcashShieldedEnabled } from "./zcashRouting";
+import { throwError } from "rxjs";
+import { catchError } from "rxjs/operators";
+import {
+  buildBroadcastCommonEvent,
+  buildSignCommonEvent,
+  buildTransactionFailureEvent,
+  buildTransactionSuccessEvent,
+  emitTransactionEvent,
+  TransactionPathway,
+  TransactionStage,
+} from "@ledgerhq/transaction-observability";
 
 // The family owning a currency's bridge is `currency.family`, except zcash:
 // `zcashShielded` routes it to the standalone "zcash" family
@@ -184,7 +196,31 @@ export function getAccountBridge(
   return getAccountBridgeByFamily(family, mainAccount.id);
 }
 
-async function wrapAccountBridge<T extends TransactionCommon>(
+/**
+ * Attributes a broadcast to a {@link TransactionPathway} and a live-app manifest id from
+ * `broadcastConfig.source`. `manifestId` is only set for live-app / dApp sources — a
+ * "coin-module" source's `name` is the host app, not a manifest.
+ */
+function attributeBroadcastSource(source?: TransactionSource): {
+  pathway: TransactionPathway;
+  manifestId?: string;
+} {
+  switch (source?.type) {
+    case "dApp":
+      return { pathway: TransactionPathway.Dapp, manifestId: source.name };
+    case "live-app":
+      return { pathway: TransactionPathway.WalletApiSignAndBroadcast, manifestId: source.name };
+    case "coin-module":
+      return { pathway: TransactionPathway.Send };
+    case "swap":
+      return { pathway: TransactionPathway.Swap };
+    default:
+      return { pathway: TransactionPathway.Unknown };
+  }
+}
+
+// Exported for unit testing the transaction-observability seam.
+export async function wrapAccountBridge<T extends TransactionCommon>(
   bridge: AccountBridge<T>,
   family: string,
 ): Promise<ResolvedAccountBridge<T>> {
@@ -203,6 +239,61 @@ async function wrapAccountBridge<T extends TransactionCommon>(
 
       const commonTransactionStatus = await commonGetTransactionStatus(...args);
       return mergeResults(blockchainTransactionStatus, commonTransactionStatus);
+    },
+    /**
+     * Transaction observability, sign stage. Only failures: a success here is not an outcome
+     * the funnel cares about, and abandoning the prompt is an unsubscribe rather than an
+     * error, so the device-action layer reports that instead.
+     *
+     * The rich transaction is available (hence the exact action and the validators) but
+     * `broadcastConfig` is not, so the originating route is unknown until broadcast.
+     */
+    signOperation: (arg0: Parameters<typeof bridge.signOperation>[0]) =>
+      bridge.signOperation(arg0).pipe(
+        catchError(error => {
+          emitTransactionEvent(
+            buildTransactionFailureEvent(
+              buildSignCommonEvent({
+                account: arg0.account,
+                mainAccount: arg0.account,
+                pathway: TransactionPathway.Unknown,
+                transaction: arg0.transaction,
+              }),
+              { stage: TransactionStage.Sign, error },
+            ),
+          );
+          return throwError(() => error);
+        }),
+      ),
+    /**
+     * Transaction observability, broadcast stage — where a staking transaction's success is
+     * actually known. Fully attributed via `broadcastConfig.source`, but the action has to be
+     * read off the optimistic operation since the transaction is not passed here.
+     */
+    broadcast: async (arg0: Parameters<typeof bridge.broadcast>[0]) => {
+      const { pathway, manifestId } = attributeBroadcastSource(arg0.broadcastConfig?.source);
+      const common = buildBroadcastCommonEvent({
+        account: arg0.account,
+        mainAccount: arg0.account,
+        pathway,
+        manifestId,
+        source: arg0.broadcastConfig?.source,
+        operation: arg0.signedOperation.operation,
+      });
+      try {
+        const operation = await bridge.broadcast(arg0);
+        emitTransactionEvent(buildTransactionSuccessEvent(common));
+        return operation;
+      } catch (error) {
+        emitTransactionEvent(
+          buildTransactionFailureEvent(common, {
+            stage: TransactionStage.Broadcast,
+            error,
+            signedOperation: arg0.signedOperation,
+          }),
+        );
+        throw error;
+      }
     },
   } as ResolvedAccountBridge<T>;
 }

--- a/libs/ledger-live-common/src/bridge/stakingVocabulary.drift.test.ts
+++ b/libs/ledger-live-common/src/bridge/stakingVocabulary.drift.test.ts
@@ -1,0 +1,127 @@
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { GENERIC_TRANSACTION_MODE } from "./generic-coin-framework/types";
+import { MODE_TRAITS, RESOURCE_STAKING_OPERATION_TYPES } from "@ledgerhq/coin-tron/logic/modes";
+import {
+  deriveEarnTransactionType,
+  deriveFromOperationType,
+} from "@ledgerhq/transaction-observability";
+
+/**
+ * Drift guard for the earn funnel's staking vocabulary.
+ *
+ * `@ledgerhq/transaction-observability` classifies transactions by matching family-specific
+ * wording, but it cannot import the coin layer — live-common depends on it, so the edge would
+ * be a cycle. Its own tests therefore assert its maps against hardcoded expectations, which
+ * proves they are self-consistent and nothing more: rename a mode upstream and those tests
+ * still pass while production silently classifies nothing.
+ *
+ * This test closes that hole from the side that *can* see both. It reads the real, runtime
+ * vocabularies and fails when one gains a value the classifier does not know — so a coin
+ * module change surfaces here rather than as a hole in the funnel.
+ *
+ * Add a family here whenever it exposes its modes as runtime values (most declare them as
+ * types only, which cannot be enumerated).
+ */
+
+// Modes that move funds rather than stake them. Listed explicitly so that adding a mode
+// upstream fails the test until someone decides which side it belongs on.
+const GENERIC_NON_STAKING = new Set(["send", "changeTrust", "send-legacy", "send-eip1559"]);
+const TRON_NON_STAKING = new Set(["send"]);
+
+describe("staking vocabulary drift", () => {
+  describe("the generic coin framework", () => {
+    it("classifies every staking mode it defines", () => {
+      const unclassified = GENERIC_TRANSACTION_MODE.filter(
+        mode =>
+          !GENERIC_NON_STAKING.has(mode) &&
+          deriveEarnTransactionType("newchain", mode) === undefined,
+      );
+      expect(unclassified).toEqual([]);
+    });
+
+    it("claims nothing for the modes that are not staking", () => {
+      for (const mode of GENERIC_NON_STAKING) {
+        expect(deriveEarnTransactionType("newchain", mode)).toBeUndefined();
+      }
+    });
+  });
+
+  // Tron is the family that has already migrated onto the generic framework while keeping its
+  // own wording, so it is the live example of the drift this guard exists for.
+  describe("tron", () => {
+    it("classifies every mode tron supports", () => {
+      const unclassified = Object.keys(MODE_TRAITS).filter(
+        mode =>
+          !TRON_NON_STAKING.has(mode) && deriveEarnTransactionType("tron", mode) === undefined,
+      );
+      expect(unclassified).toEqual([]);
+    });
+
+    // Its mode -> OperationType table is exported at runtime, so the broadcast-stage map can be
+    // checked against the real thing instead of a copy of it.
+    it("agrees with tron's own mode-to-operation-type table", () => {
+      const disagreements = [...RESOURCE_STAKING_OPERATION_TYPES.entries()]
+        .map(([mode, operationType]) => ({
+          mode,
+          operationType,
+          fromMode: deriveEarnTransactionType("tron", mode),
+          fromOperationType: deriveFromOperationType("tron", operationType),
+        }))
+        .filter(row => row.fromMode !== row.fromOperationType);
+      expect(disagreements).toEqual([]);
+    });
+  });
+});
+
+/**
+ * Currency id -> the family it resolves to -> a staking mode that family accepts.
+ *
+ * The classifier keys on **family**, which is what lets one cosmos row cover osmo, dydx and the
+ * rest. That only holds while these ids keep resolving to the family the classifier has a map
+ * for, and the classifier itself cannot check it: the currency registry lives in
+ * `@domain/entity-currency-crypto`, which `@ledgerhq/transaction-observability` does not depend
+ * on. So it is checked here, against the real registry, end to end — id, family, action.
+ *
+ * A currency re-homed to another family (as tron was, onto the generic coin framework) fails
+ * this rather than silently dropping out of the funnel.
+ */
+const STAKING_CURRENCIES: Array<[string, string, string]> = [
+  ["cardano", "cardano", "delegate"],
+  ["celo", "celo", "vote"],
+  ["cosmos", "cosmos", "delegate"],
+  ["osmo", "cosmos", "delegate"],
+  ["dydx", "cosmos", "delegate"],
+  ["injective", "cosmos", "delegate"],
+  ["mantra", "cosmos", "delegate"],
+  ["zenrock", "cosmos", "delegate"],
+  ["xion", "cosmos", "delegate"],
+  ["axelar", "cosmos", "delegate"],
+  ["quicksilver", "cosmos", "delegate"],
+  ["persistence", "cosmos", "delegate"],
+  ["sei_evm", "evm", "delegate"],
+  ["monad", "evm", "delegate"],
+  ["somnia", "evm", "delegate"],
+  ["zero_gravity", "evm", "delegate"],
+  ["hedera", "hedera", "delegate"],
+  ["elrond", "multiversx", "delegate"],
+  ["near", "near", "stake"],
+  ["polkadot", "polkadot", "bond"],
+  ["solana", "solana", "stake.createAccount"],
+  ["sui", "sui", "delegate"],
+  ["tezos", "tezos", "delegate"],
+  ["tron", "tron", "freeze"],
+];
+
+describe("staking currencies still resolve to a family the classifier knows", () => {
+  it.each(STAKING_CURRENCIES)("%s is a %s currency", (currencyId, family) => {
+    expect(getCryptoCurrencyById(currencyId).family).toBe(family);
+  });
+
+  it.each(STAKING_CURRENCIES)(
+    "%s reaches a staking action through its real family",
+    (currencyId, _family, mode) => {
+      const family = getCryptoCurrencyById(currencyId).family;
+      expect(deriveEarnTransactionType(family, mode)).toBeDefined();
+    },
+  );
+});

--- a/libs/ledger-live-common/src/bridge/wrapAccountBridge.observability.test.ts
+++ b/libs/ledger-live-common/src/bridge/wrapAccountBridge.observability.test.ts
@@ -1,0 +1,218 @@
+import { Observable, lastValueFrom, throwError } from "rxjs";
+import type { Account, AccountBridge } from "@ledgerhq/types-live";
+
+// Isolate the seam from real coin-module extension loading (keeps this unit test free of
+// coin-module lib builds; the real registry is exercised by impl.test.ts).
+jest.mock("../coin-modules/registry", () => ({
+  loadBridgeExtensionsForFamily: jest.fn().mockResolvedValue({}),
+  loadSetupForFamily: jest.fn(),
+  loadMockBridgeForFamily: jest.fn(),
+}));
+
+import { wrapAccountBridge } from "./impl";
+import {
+  setTransactionObserver,
+  resetTransactionObservers,
+  ErrorCategory,
+  TransactionStage,
+  type LogEvent,
+} from "@ledgerhq/transaction-observability";
+
+// Cardano, so the family-aware normalization of the raw action is exercised end to end.
+const account = {
+  id: "acc",
+  type: "Account",
+  currency: { id: "cardano", family: "cardano", ticker: "ADA" },
+} as unknown as Account;
+
+const signedOperation = {
+  signature: "sig",
+  operation: { type: "DELEGATE", extra: {} },
+} as never;
+
+const coinModuleSource = {
+  mevProtected: false,
+  source: { type: "coin-module" as const, name: "ledger-live-desktop" },
+};
+
+const makeBridge = (overrides: Partial<AccountBridge<never>>): AccountBridge<never> =>
+  ({
+    getTransactionStatus: jest.fn(),
+    signOperation: jest.fn(),
+    broadcast: jest.fn(),
+    ...overrides,
+  }) as unknown as AccountBridge<never>;
+
+describe("wrapAccountBridge — transaction observability seam", () => {
+  let events: LogEvent[];
+  beforeEach(() => {
+    resetTransactionObservers();
+    events = [];
+    setTransactionObserver(e => events.push(e));
+  });
+  afterEach(() => resetTransactionObservers());
+
+  test("broadcast: emits a success event and returns the operation unchanged", async () => {
+    const operation = { id: "op-1" };
+    const bridge = makeBridge({ broadcast: jest.fn().mockResolvedValue(operation) });
+    const wrapped = await wrapAccountBridge(bridge, "cardano");
+
+    const result = await wrapped.broadcast({
+      account,
+      signedOperation,
+      broadcastConfig: coinModuleSource,
+    });
+
+    expect(result).toBe(operation);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      status: "success",
+      stage: TransactionStage.Broadcast,
+      currencyId: "cardano",
+      family: "cardano",
+      pathway: "send",
+      // The optimistic op type normalizes to the canonical action…
+      earnTransactionType: "delegate",
+      // …and the raw value is kept for drill-down.
+      rawTransactionType: "DELEGATE",
+    });
+  });
+
+  // One TransactionPathway per TransactionSource["type"], so no real source falls into
+  // "unknown" — which is reserved for the sign stage, where the source is not yet known.
+  test.each([
+    ["coin-module", "send"],
+    ["dApp", "dApp/eth_sendTransaction"],
+    ["live-app", "wallet-api/transaction.signAndBroadcast"],
+    ["swap", "swap"],
+  ])("broadcast: attributes a %s source as pathway=%s", async (type, expectedPathway) => {
+    const bridge = makeBridge({ broadcast: jest.fn().mockResolvedValue({ id: "op-1" }) });
+    const wrapped = await wrapAccountBridge(bridge, "cardano");
+
+    await wrapped.broadcast({
+      account,
+      signedOperation,
+      broadcastConfig: {
+        mevProtected: false,
+        source: { type: type as "coin-module" | "dApp" | "live-app" | "swap", name: "x" },
+      },
+    });
+
+    expect(events[0]).toMatchObject({ pathway: expectedPathway });
+  });
+
+  test("broadcast: emits a categorized failure event and re-throws the original error", async () => {
+    const error = new Error("insufficient_funds for gas");
+    const bridge = makeBridge({ broadcast: jest.fn().mockRejectedValue(error) });
+    const wrapped = await wrapAccountBridge(bridge, "cardano");
+
+    await expect(
+      wrapped.broadcast({ account, signedOperation, broadcastConfig: coinModuleSource }),
+    ).rejects.toBe(error);
+
+    expect(events[0]).toMatchObject({
+      status: "failure",
+      stage: TransactionStage.Broadcast,
+      errorCategory: ErrorCategory.GasInsufficientBalance,
+      txPayload: { signature: "sig" },
+    });
+  });
+
+  test("broadcast: a plain send is observed but derives no staking action", async () => {
+    const bridge = makeBridge({ broadcast: jest.fn().mockResolvedValue({ id: "op-1" }) });
+    const wrapped = await wrapAccountBridge(bridge, "cardano");
+
+    await wrapped.broadcast({
+      account,
+      signedOperation: { signature: "sig", operation: { type: "OUT", extra: {} } } as never,
+      broadcastConfig: coinModuleSource,
+    });
+
+    expect(events[0].earnTransactionType).toBeUndefined();
+  });
+
+  test("signOperation: emits a sign failure, re-throws, and subscribes exactly once", async () => {
+    const error = Object.assign(new Error(""), { name: "UserRefusedOnDevice" });
+    let subscribeCount = 0;
+    const bridge = makeBridge({
+      signOperation: jest.fn().mockReturnValue(
+        new Observable(subscriber => {
+          subscribeCount += 1;
+          subscriber.error(error);
+        }),
+      ),
+    });
+    const wrapped = await wrapAccountBridge(bridge, "cardano");
+
+    await expect(
+      lastValueFrom(
+        wrapped.signOperation({
+          account,
+          transaction: { family: "cardano", mode: "delegate", poolId: "pool1" } as never,
+          deviceId: "device",
+        }),
+      ),
+    ).rejects.toBe(error);
+
+    expect(subscribeCount).toBe(1);
+    expect(events[0]).toMatchObject({
+      status: "failure",
+      stage: TransactionStage.Sign,
+      errorCategory: ErrorCategory.UserDeviceRefused,
+      earnTransactionType: "delegate",
+      // The sign stage is the only place the delegation target is legible.
+      validators: ["pool1"],
+      // No broadcastConfig here, so the originating route is not yet known.
+      pathway: "unknown",
+    });
+    // Signing never completed, so there is no payload to report.
+    expect(events[0]).not.toHaveProperty("txPayload");
+  });
+
+  test("signOperation: does not emit on sign success", async () => {
+    const bridge = makeBridge({
+      signOperation: jest.fn().mockReturnValue(
+        new Observable(subscriber => {
+          subscriber.next({ type: "signed", signedOperation });
+          subscriber.complete();
+        }),
+      ),
+    });
+    const wrapped = await wrapAccountBridge(bridge, "cardano");
+
+    await lastValueFrom(
+      wrapped.signOperation({ account, transaction: {} as never, deviceId: "device" }),
+    );
+
+    expect(events).toHaveLength(0);
+  });
+
+  // The seam sits in the transaction path, so a broken analytics sink must never surface as
+  // a failed sign or broadcast.
+  test("a throwing observer is isolated and cannot break emission", async () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    setTransactionObserver(() => {
+      throw new Error("sink is broken");
+    });
+    const operation = { id: "op-1" };
+    const bridge = makeBridge({ broadcast: jest.fn().mockResolvedValue(operation) });
+    const wrapped = await wrapAccountBridge(bridge, "cardano");
+
+    await expect(
+      wrapped.broadcast({ account, signedOperation, broadcastConfig: coinModuleSource }),
+    ).resolves.toBe(operation);
+
+    const signError = new Error("boom");
+    const signing = makeBridge({
+      signOperation: jest.fn().mockReturnValue(throwError(() => signError)),
+    });
+    const wrappedSigning = await wrapAccountBridge(signing, "cardano");
+    await expect(
+      lastValueFrom(
+        wrappedSigning.signOperation({ account, transaction: {} as never, deviceId: "d" }),
+      ),
+    ).rejects.toBe(signError);
+
+    warn.mockRestore();
+  });
+});

--- a/libs/ledger-live-common/src/hw/actions/transaction.abandonment.test.ts
+++ b/libs/ledger-live-common/src/hw/actions/transaction.abandonment.test.ts
@@ -1,0 +1,181 @@
+/**
+ * @jest-environment jsdom
+ */
+import { Observable, Subject } from "rxjs";
+import { renderHook, act } from "@testing-library/react";
+import type { Account, SignOperationEvent } from "@ledgerhq/types-live";
+
+// The device-connection half is a whole state machine of its own; this test only cares that
+// the sign prompt appeared, so it is pinned to "device ready". The state object is a single
+// stable instance: `device` is a dependency of the signing effect, so a fresh object per
+// render would resubscribe on every render and drop events.
+const READY = {
+  device: { deviceId: "device", modelId: "nanoX" },
+  opened: true,
+  inWrongDeviceForAccount: null,
+  error: null,
+};
+const DEVICE_GONE = { ...READY, opened: false };
+// Mutable so a test can take the device away mid-flow. Held as one object per state rather than
+// rebuilt per render: `device` is a dependency of the signing effect, so a fresh object each
+// render would resubscribe every render and drop events.
+const appState = { current: READY as typeof READY };
+
+jest.mock("./app", () => ({
+  createAction: () => ({ useHook: () => appState.current, mapResult: () => null }),
+}));
+
+const signOperation = jest.fn();
+jest.mock("../../bridge", () => ({
+  getAccountBridge: async () => ({ signOperation }),
+}));
+
+import { createAction } from "./transaction";
+import {
+  ErrorCategory,
+  resetTransactionObservers,
+  setTransactionObserver,
+  TransactionStage,
+  type LogEvent,
+} from "@ledgerhq/transaction-observability";
+
+const account = {
+  id: "acc",
+  type: "Account",
+  currency: { id: "cardano", family: "cardano", ticker: "ADA" },
+} as unknown as Account;
+
+const txRequest = {
+  account,
+  parentAccount: null,
+  transaction: { family: "cardano", mode: "delegate", poolId: "pool1" },
+  appName: "Cardano ADA",
+} as never;
+
+describe("transaction device action — sign-prompt abandonment", () => {
+  let events: LogEvent[];
+  let signEvents: Subject<SignOperationEvent>;
+
+  beforeEach(() => {
+    appState.current = READY;
+    resetTransactionObservers();
+    events = [];
+    setTransactionObserver(e => events.push(e));
+    signEvents = new Subject<SignOperationEvent>();
+    signOperation.mockReturnValue(
+      new Observable<SignOperationEvent>(subscriber => signEvents.subscribe(subscriber)),
+    );
+  });
+  afterEach(() => resetTransactionObservers());
+
+  const render = () => renderHook(() => createAction(jest.fn() as never).useHook(null, txRequest));
+
+  const flush = async () => {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  };
+
+  it("reports a dismissal when the prompt was shown and the user left", async () => {
+    const { unmount } = render();
+    await flush();
+
+    act(() => signEvents.next({ type: "device-signature-requested" }));
+    unmount();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      status: "failure",
+      stage: TransactionStage.Sign,
+      errorCategory: ErrorCategory.UserModalDismissed,
+      earnTransactionType: "delegate",
+      validators: ["pool1"],
+    });
+  });
+
+  it("reports nothing when the user signed before leaving", async () => {
+    const { result, unmount } = render();
+    await flush();
+
+    act(() => signEvents.next({ type: "device-signature-requested" }));
+    act(() =>
+      signEvents.next({
+        type: "signed",
+        signedOperation: { signature: "sig", operation: {} },
+      } as SignOperationEvent),
+    );
+    expect(result.current.signedOperation).toBeTruthy();
+    unmount();
+
+    expect(events).toHaveLength(0);
+  });
+
+  it("reports nothing when signing errored — the bridge seam already covered it", async () => {
+    const { unmount } = render();
+    await flush();
+
+    act(() => signEvents.next({ type: "device-signature-requested" }));
+    act(() => signEvents.error(Object.assign(new Error(""), { name: "UserRefusedOnDevice" })));
+    unmount();
+
+    expect(events).toHaveLength(0);
+  });
+
+  // Copilot caught this: passing the main account for both fields dropped token attribution,
+  // so an abandoned USDC staking prompt reported only the chain.
+  it("keeps token attribution when the signing account is a token account", async () => {
+    const tokenAccount = {
+      id: "token-acc",
+      type: "TokenAccount",
+      parentId: "acc",
+      token: { id: "ethereum/erc20/usdc", ticker: "USDC" },
+    } as never;
+
+    const { unmount } = renderHook(() =>
+      createAction(jest.fn() as never).useHook(null, {
+        ...(txRequest as unknown as Record<string, unknown>),
+        account: tokenAccount,
+        parentAccount: account,
+      } as never),
+    );
+    await flush();
+
+    act(() => signEvents.next({ type: "device-signature-requested" }));
+    unmount();
+
+    expect(events[0]).toMatchObject({
+      tokenId: "ethereum/erc20/usdc",
+      tokenTicker: "USDC",
+      // The chain still comes from the main account.
+      currencyId: "cardano",
+    });
+  });
+
+  // A device unplugged after the prompt appeared is not the user declining. Reporting it as
+  // user_modal_dismissed would put a device failure in the wrong bucket, and the bridge seam
+  // already reports the transport error itself.
+  it("does not report a dismissal when the device became unavailable", async () => {
+    const { rerender, unmount } = render();
+    await flush();
+
+    act(() => signEvents.next({ type: "device-signature-requested" }));
+
+    appState.current = DEVICE_GONE;
+    await act(async () => {
+      rerender();
+      await Promise.resolve();
+    });
+    unmount();
+
+    expect(events).toHaveLength(0);
+  });
+
+  it("reports nothing when the prompt never appeared", async () => {
+    const { unmount } = render();
+    await flush();
+
+    unmount();
+
+    expect(events).toHaveLength(0);
+  });
+});

--- a/libs/ledger-live-common/src/hw/actions/transaction.ts
+++ b/libs/ledger-live-common/src/hw/actions/transaction.ts
@@ -1,7 +1,13 @@
 import { of, Observable } from "rxjs";
 import { scan, catchError, tap } from "rxjs/operators";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { log } from "@ledgerhq/logs";
+import {
+  buildSignCommonEvent,
+  buildTransactionAbandonedEvent,
+  emitTransactionEvent,
+  TransactionPathway,
+} from "@ledgerhq/transaction-observability";
 import type { Transaction, TransactionStatus } from "../../coin-modules/transaction-types";
 import { TransactionRefusedOnDevice } from "../../errors";
 import { getMainAccount } from "../../account";
@@ -149,9 +155,58 @@ export const createAction = (
     });
     const { device, opened, inWrongDeviceForAccount, error } = appState;
     const [state, setState] = useState(initialState);
+
+    /**
+     * Transaction observability: the sign-prompt drop-off. Failures and broadcast outcomes
+     * are captured wide at the bridge seam, but a user closing the modal is an unsubscribe
+     * rather than an error, so the bridge cannot see it — only this layer can.
+     */
+    const promptShownRef = useRef(false);
+    const settledRef = useRef(false);
+    const buildCommon = useCallback(
+      () =>
+        buildSignCommonEvent({
+          // The signing account, which may be a TokenAccount — that is where the token id and
+          // ticker come from. `mainAccount` supplies the chain and family.
+          account: txRequest.account,
+          mainAccount,
+          pathway: manifestId
+            ? TransactionPathway.WalletApiSignAndBroadcast
+            : TransactionPathway.Send,
+          manifestId,
+          transaction,
+        }),
+      [txRequest.account, mainAccount, manifestId, transaction],
+    );
+    const buildCommonRef = useRef(buildCommon);
+    buildCommonRef.current = buildCommon;
+
+    useEffect(() => {
+      if (state.deviceSignatureRequested) promptShownRef.current = true;
+    }, [state.deviceSignatureRequested]);
+
+    useEffect(() => {
+      if (state.signedOperation || state.transactionSignError) settledRef.current = true;
+    }, [state.signedOperation, state.transactionSignError]);
+
+    // Unmount-only (empty deps), so an effect re-run is not mistaken for the user leaving.
+    useEffect(
+      () => () => {
+        if (promptShownRef.current && !settledRef.current) {
+          emitTransactionEvent(buildTransactionAbandonedEvent(buildCommonRef.current()));
+        }
+      },
+      [],
+    );
+
     useEffect(() => {
       if (!device || !opened || inWrongDeviceForAccount || error) {
         setState(initialState);
+        // The attempt ended without the user dismissing anything — the device went away, or was
+        // the wrong one. Clearing both refs stops that being reported later as a dismissal, and
+        // leaves a retry on the same screen starting from a clean slate.
+        promptShownRef.current = false;
+        settledRef.current = false;
         return;
       }
 

--- a/libs/transaction-observability/src/index.ts
+++ b/libs/transaction-observability/src/index.ts
@@ -13,7 +13,7 @@ export { deriveEarnTransactionType, type EarnTransactionType } from "./earnTrans
 
 export { deriveFromOperationType } from "./operationType";
 
-export { getRawTransactionType, getStakeTarget } from "./transactionShape";
+export { getRawTransactionType, getStakeTarget, type TransactionLike } from "./transactionShape";
 
 export {
   buildBroadcastCommonEvent,

--- a/libs/transaction-observability/src/logEvent.ts
+++ b/libs/transaction-observability/src/logEvent.ts
@@ -44,7 +44,11 @@ type CommonLogEvent = {
   appVersion: string;
   /** The technical route; the product funnel is a separate concept — see above. */
   pathway: TransactionPathway;
-  /** Live-app manifest id — the primary "where". Absent for the native send flow. */
+  /**
+   * Manifest id of the live-app or dApp that originated the transaction — the primary "where".
+   * Both routes carry one: the dApp path sends `manifest.id` too (`useDappLogic.ts`), so `type`
+   * on the source distinguishes the route, not the kind of identifier. Absent for native send.
+   */
   manifestId?: string;
   source?: TransactionSource;
   /** Parent/network currency id (e.g. "ethereum"); token id is reported separately. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1144,6 +1144,9 @@ importers:
       '@ledgerhq/react-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/react
+      '@ledgerhq/transaction-observability':
+        specifier: workspace:^
+        version: link:../../libs/transaction-observability
       '@ledgerhq/types-devices':
         specifier: workspace:^
         version: link:../../libs/types-devices
@@ -1986,6 +1989,9 @@ importers:
       '@ledgerhq/native-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/native
+      '@ledgerhq/transaction-observability':
+        specifier: workspace:^
+        version: link:../../libs/transaction-observability
       '@ledgerhq/types-devices':
         specifier: workspace:^
         version: link:../../libs/types-devices
@@ -12328,6 +12334,9 @@ importers:
       '@ledgerhq/speculos-transport':
         specifier: workspace:^
         version: link:../speculos-transport
+      '@ledgerhq/transaction-observability':
+        specifier: workspace:^
+        version: link:../transaction-observability
       '@ledgerhq/wallet-api-acre-module':
         specifier: workspace:^
         version: link:../wallet-api-acre-module


### PR DESCRIPTION
### 📝 Description

**Part 2 of 3.** Base is [#20817](https://github.com/LedgerHQ/ledger-live/pull/20817) — review that first.

Stack: [#20817 package](https://github.com/LedgerHQ/ledger-live/pull/20817) → **#20818 bridge seam** → [#20819 correlation](https://github.com/LedgerHQ/ledger-live/pull/20819)

**Problem.** Native staking's bottom-of-funnel is inferred from UI screens, so reaching the final screen counted as a success whether or not a transaction ever landed. The aim here is to create unified success/failure events for earn-related transactions so we can get clarity on quantity of failures and where they occur, .

**Approach.** Every production route resolves its bridge through `getAccountBridge` — native send and staking, wallet-api, the dApp `eth_sendTransaction` path, swap — so `wrapAccountBridge` is the single place that sees them all. It already hosts the sanctioned-address check, so this is an established seam rather than a new one.

The tests are built around ensuring the seam never changes transaction behaviour:

- `signOperation` is wrapped in `catchError` and re-raises the **original** error object via `throwError` — a test asserts `.rejects.toBe(error)`, identity not equality.
- A test counts subscriptions to prove the observable is still subscribed exactly once.
- `broadcast` returns the bridge's operation unchanged (`toBe`, again by identity) and re-throws.
- A throwing observer cannot break either path.

**Abandonment.** Closing the sign prompt is an RxJS unsubscribe, not an error, so the bridge structurally cannot see it. That one signal comes from the device-action layer: an unmount-only effect (empty deps, so an effect re-run is not mistaken for the user leaving), guarded by two refs. Covered for prompt-shown-then-left, signed-then-left, errored-then-left, never-shown, and token attribution.

**Drift guard.** `stakingVocabulary.drift.test.ts` lives here rather than in the lib, because only live-common can see both the classifier and the coin layer — the lib importing live-common would be a cycle. It reads **runtime** vocabularies (`GENERIC_TRANSACTION_MODE`, tron's `MODE_TRAITS` and `RESOURCE_STAKING_OPERATION_TYPES`) and fails when one gains a value the classifier does not know. It found a real gap on its first run: tron `legacyUnfreeze` was unclassified, so that unstake would have gone unreported.

**Host registration.** Desktop and mobile each register a Segment observer at startup; `track` already self-gates on analytics consent, so there is no new gate. Desktop also registers a dev-only console observer so the seam can be watched locally across every staking route and coin. The existing Datadog `useBroadcast` path is untouched.

**What is not here.** `connect`-stage failures — device locked, wrong app, app not installed, transport disconnected. Those live entirely in `hw/actions/app.ts`, and `signOperation` is not called until `opened && !error`, so the bridge cannot observe them. Likely a real share of drop-off; needs its own ticket against the device-action layer.

**Known consequence, going in with eyes open.** The derived-action gate is route-agnostic, so a wallet-api/live-app staking broadcast (Tron via stakekit, Polkadot, TON) also emits, because its optimistic operation type is a staking type. Wider than "native", but that is what the gate means. The Earn live-app stays excluded by manifest id since it emits these events itself — anything joining this with `dApp SendTransaction success` must join on transaction identity, never sum.

**Test coverage:** yes — 20 tests across the seam, abandonment and drift guard. No UI changes.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35350](https://ledgerhq.atlassian.net/browse/LIVE-35350)
- **ADR** (if any): 
- ADR https://ledgerhq.atlassian.net/wiki/spaces/PTX/pages/7218364465/EARN+ADR+TX+observability
- Taxonomy docs https://ledgerhq.atlassian.net/wiki/x/8YBQuAE


[LIVE-35350]: https://ledgerhq.atlassian.net/browse/LIVE-35350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ