### PR TITLE
[LWDM] feat(observability): correlate sign and broadcast stages (LIVE-35350)

### DIFF
--- a/.changeset/LIVE-35350-manifest-id-property.md
+++ b/.changeset/LIVE-35350-manifest-id-property.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/transaction-observability": minor
+---
+
+Report the originating live-app or dApp as `manifest_id` rather than `provider` on `earn_transaction_completed` / `earn_transaction_failed`.
+
+The value was always a manifest id, and `provider` means something else in Ledger Wallet's analytics: the staking or swap partner behind a flow. `manifest_id` is also the name the rest of the codebase already uses for this identifier, including the feature-flag params that supply it.
+
+No consumer is affected. The host apps only register the observer in the bridge-seam change, so no event has carried either property in production yet.

--- a/.changeset/LIVE-35350-sign-broadcast-correlation.md
+++ b/.changeset/LIVE-35350-sign-broadcast-correlation.md
@@ -1,0 +1,12 @@
+---
+"@ledgerhq/transaction-observability": minor
+"@ledgerhq/live-common": minor
+---
+
+Correlate the sign and broadcast stages, so a broadcast event carries the transaction's own data rather than what survives on the optimistic operation.
+
+`signOperation` emits a `SignedOperation` and that same object is later handed to `broadcast`, so object identity is the correlation key — nothing to invent, nothing to reconcile. A `WeakMap` means no TTL, no eviction policy and no size cap to get wrong, and no signature is retained: a transaction signed but never broadcast simply becomes garbage.
+
+Without this, the broadcast stage is uneven in ways a data consumer cannot predict. Cosmos copies its validators into the optimistic operation and Solana does not; Hedera's `claim-rewards` and Algorand's `claimReward` are crafted as plain transfers and so report `OUT`, and Solana's `stake.withdraw` reports `IN` — indistinguishable from an incoming transfer. Correlation recovers the exact action, the delegation target and send-max for all of them.
+
+Correlation legitimately misses when a signed operation is serialised and rehydrated (the wallet-api `transaction.sign` route, or one persisted and broadcast later) and for ACRE, which signs outside the wrapper. Those fall back to the operation type. `tx_data_source` on every event records which path produced it, so the hit rate is measurable rather than assumed. Route attribution still comes from the broadcast stage, which is the only stage that knows it.

--- a/libs/ledger-live-common/src/bridge/impl.ts
+++ b/libs/ledger-live-common/src/bridge/impl.ts
@@ -28,13 +28,14 @@ import {
 import { defaultBridgeExtensions } from "./defaultBridgeExtensions";
 import { isZcashShieldedEnabled } from "./zcashRouting";
 import { throwError } from "rxjs";
-import { catchError } from "rxjs/operators";
+import { catchError, tap } from "rxjs/operators";
 import {
   buildBroadcastCommonEvent,
   buildSignCommonEvent,
   buildTransactionFailureEvent,
   buildTransactionSuccessEvent,
   emitTransactionEvent,
+  rememberSignContext,
   TransactionPathway,
   TransactionStage,
 } from "@ledgerhq/transaction-observability";
@@ -250,6 +251,17 @@ export async function wrapAccountBridge<T extends TransactionCommon>(
      */
     signOperation: (arg0: Parameters<typeof bridge.signOperation>[0]) =>
       bridge.signOperation(arg0).pipe(
+        // The signed operation is the same object `broadcast` is handed later, so remembering
+        // against it carries the transaction's own wording and target across the stages.
+        tap(event => {
+          if (event.type === "signed") {
+            rememberSignContext(
+              event.signedOperation,
+              arg0.account.currency.family,
+              arg0.transaction,
+            );
+          }
+        }),
         catchError(error => {
           emitTransactionEvent(
             buildTransactionFailureEvent(
@@ -278,7 +290,7 @@ export async function wrapAccountBridge<T extends TransactionCommon>(
         pathway,
         manifestId,
         source: arg0.broadcastConfig?.source,
-        operation: arg0.signedOperation.operation,
+        signedOperation: arg0.signedOperation,
       });
       try {
         const operation = await bridge.broadcast(arg0);

--- a/libs/ledger-live-common/src/bridge/wrapAccountBridge.observability.test.ts
+++ b/libs/ledger-live-common/src/bridge/wrapAccountBridge.observability.test.ts
@@ -169,6 +169,58 @@ describe("wrapAccountBridge — transaction observability seam", () => {
     expect(events[0]).not.toHaveProperty("txPayload");
   });
 
+  // Solana is the case that only works because of correlation: its stake actions become a
+  // DELEGATE/IN/OUT operation, and it copies no validator into the optimistic operation.
+  test("a sign followed by a broadcast reports the transaction's own action and target", async () => {
+    const solanaAccount = {
+      id: "acc",
+      type: "Account",
+      currency: { id: "solana", family: "solana", ticker: "SOL" },
+    } as unknown as Account;
+    const solanaSignedOperation = {
+      signature: "sig",
+      operation: { type: "DELEGATE", extra: {} },
+    } as never;
+
+    const bridge = makeBridge({
+      signOperation: jest.fn().mockReturnValue(
+        new Observable(subscriber => {
+          subscriber.next({ type: "signed", signedOperation: solanaSignedOperation });
+          subscriber.complete();
+        }),
+      ),
+      broadcast: jest.fn().mockResolvedValue({ id: "op-1" }),
+    });
+    const wrapped = await wrapAccountBridge(bridge, "solana");
+
+    await lastValueFrom(
+      wrapped.signOperation({
+        account: solanaAccount,
+        transaction: {
+          family: "solana",
+          model: { kind: "stake.createAccount", uiState: { voteAccAddr: "voteAcc" } },
+        } as never,
+        deviceId: "device",
+      }),
+    );
+    await wrapped.broadcast({
+      account: solanaAccount,
+      signedOperation: solanaSignedOperation,
+      broadcastConfig: coinModuleSource,
+    });
+
+    expect(events[0]).toMatchObject({
+      status: "success",
+      earnTransactionType: "delegate",
+      // The family's own wording, not the operation type it was flattened to.
+      rawTransactionType: "stake.createAccount",
+      validators: ["voteAcc"],
+      dataSource: "sign",
+      // Attribution still comes from the broadcast, which is the only stage that knows it.
+      pathway: "send",
+    });
+  });
+
   test("signOperation: does not emit on sign success", async () => {
     const bridge = makeBridge({
       signOperation: jest.fn().mockReturnValue(

--- a/libs/transaction-observability/src/eventBuilders.test.ts
+++ b/libs/transaction-observability/src/eventBuilders.test.ts
@@ -1,4 +1,4 @@
-import type { Account, AccountLike, Operation, SignedOperation } from "@ledgerhq/types-live";
+import type { Account, AccountLike, SignedOperation } from "@ledgerhq/types-live";
 import { setEnv } from "@shared/env";
 import {
   buildBroadcastCommonEvent,
@@ -19,7 +19,8 @@ const cosmos = account({ id: "cosmos", family: "cosmos", ticker: "ATOM" });
 const sei = account({ id: "sei_evm", family: "evm", ticker: "SEI" });
 
 const tx = (fields: Record<string, unknown>): TransactionLike => fields;
-const operation = (fields: Record<string, unknown>) => fields as unknown as Operation;
+const signed = (op: Record<string, unknown>) =>
+  ({ signature: "0xsig", operation: op }) as unknown as SignedOperation;
 
 const attribution = (mainAccount: Account, over: Partial<{ account: AccountLike }> = {}) => ({
   account: over.account ?? mainAccount,
@@ -86,7 +87,7 @@ describe("buildBroadcastCommonEvent", () => {
   it("derives the action from the optimistic operation type", () => {
     const common = buildBroadcastCommonEvent({
       ...attribution(cosmos),
-      operation: operation({ type: "DELEGATE", extra: {} }),
+      signedOperation: signed({ type: "DELEGATE", extra: {} }),
     });
 
     expect(common).toMatchObject({
@@ -99,7 +100,7 @@ describe("buildBroadcastCommonEvent", () => {
   it("reads the validators cosmos copies into the operation extra", () => {
     const common = buildBroadcastCommonEvent({
       ...attribution(cosmos),
-      operation: operation({
+      signedOperation: signed({
         type: "DELEGATE",
         extra: { validators: [{ address: "cosmosvaloper1" }] },
       }),
@@ -111,7 +112,7 @@ describe("buildBroadcastCommonEvent", () => {
   it("reports no validators for a family that does not copy them across", () => {
     const common = buildBroadcastCommonEvent({
       ...attribution(cardano),
-      operation: operation({ type: "DELEGATE", extra: {} }),
+      signedOperation: signed({ type: "DELEGATE", extra: {} }),
     });
 
     expect(common.validators).toBeUndefined();
@@ -122,7 +123,7 @@ describe("buildBroadcastCommonEvent", () => {
   it("prefers the exact mode off transactionRaw where it survives", () => {
     const common = buildBroadcastCommonEvent({
       ...attribution(sei),
-      operation: operation({
+      signedOperation: signed({
         type: "REWARD",
         extra: {},
         transactionRaw: { mode: "compoundReward", valAddress: "0xval" },
@@ -139,7 +140,7 @@ describe("buildBroadcastCommonEvent", () => {
   it("falls back to the operation type when transactionRaw carries no usable mode", () => {
     const common = buildBroadcastCommonEvent({
       ...attribution(sei),
-      operation: operation({ type: "REWARD", extra: {}, transactionRaw: { mode: "send" } }),
+      signedOperation: signed({ type: "REWARD", extra: {}, transactionRaw: { mode: "send" } }),
     });
 
     expect(common).toMatchObject({
@@ -151,7 +152,7 @@ describe("buildBroadcastCommonEvent", () => {
   it("derives nothing from a plain send, so it never enters the funnel", () => {
     const common = buildBroadcastCommonEvent({
       ...attribution(cosmos),
-      operation: operation({ type: "OUT", extra: {} }),
+      signedOperation: signed({ type: "OUT", extra: {} }),
     });
 
     expect(common.earnTransactionType).toBeUndefined();

--- a/libs/transaction-observability/src/eventBuilders.ts
+++ b/libs/transaction-observability/src/eventBuilders.ts
@@ -18,6 +18,7 @@ import {
 import { deriveEarnTransactionType, type EarnTransactionType } from "./earnTransactionType";
 import { deriveFromOperationType } from "./operationType";
 import { getRawTransactionType, getStakeTarget, type TransactionLike } from "./transactionShape";
+import { recallSignContext } from "./signContext";
 import { classifyTransactionError, ErrorCategory, toError, unwrapRpcError } from "./errorCategory";
 
 type Attribution = {
@@ -116,10 +117,27 @@ function stakeTargetFromOperation(operation: Operation): string[] | undefined {
  * `compoundReward`, since both become `REWARD`.
  */
 export function buildBroadcastCommonEvent(
-  attribution: Attribution & { operation: Operation },
+  attribution: Attribution & { signedOperation: SignedOperation },
 ): CommonLogEvent {
-  const { operation, mainAccount } = attribution;
+  const { signedOperation, mainAccount } = attribution;
+  const { operation } = signedOperation;
   const family = mainAccount.currency.family;
+
+  // The sign stage saw the real transaction. Where that correlates, its data is strictly
+  // better than anything recoverable here — and for the families that report a generic
+  // operation type it is the only thing that makes the action legible at all.
+  const signed = recallSignContext(signedOperation);
+  if (signed?.earnTransactionType) {
+    return buildCommon(attribution, {
+      ...signed,
+      // Celo and tron put the target only on the optimistic operation (`celoSourceValidator`,
+      // `extra.votes`), where the sign stage cannot see it — so take whichever stage has one
+      // rather than letting a correlation hit throw the other away.
+      validators: signed.validators ?? stakeTargetFromOperation(operation),
+      dataSource: TransactionDataSource.Sign,
+    });
+  }
+
   const rawMode = (operation.transactionRaw as { mode?: string } | undefined)?.mode;
   const fromRawMode = deriveEarnTransactionType(family, rawMode);
 

--- a/libs/transaction-observability/src/index.ts
+++ b/libs/transaction-observability/src/index.ts
@@ -15,6 +15,8 @@ export { deriveFromOperationType } from "./operationType";
 
 export { getRawTransactionType, getStakeTarget, type TransactionLike } from "./transactionShape";
 
+export { rememberSignContext, type SignContext } from "./signContext";
+
 export {
   buildBroadcastCommonEvent,
   buildSignCommonEvent,

--- a/libs/transaction-observability/src/segmentEvent.test.ts
+++ b/libs/transaction-observability/src/segmentEvent.test.ts
@@ -120,7 +120,7 @@ describe("toSegmentTrackEvent", () => {
     });
   });
 
-  it("exposes the manifest id as provider", () => {
+  it("exposes the manifest id as manifest_id", () => {
     const result = toSegmentTrackEvent({
       status: "success",
       stage: TransactionStage.Broadcast,
@@ -128,7 +128,7 @@ describe("toSegmentTrackEvent", () => {
       manifestId: "kiln",
     } as LogEvent);
 
-    expect(result!.properties.provider).toBe("kiln");
+    expect(result!.properties.manifest_id).toBe("kiln");
   });
 
   describe("does not emit", () => {

--- a/libs/transaction-observability/src/segmentEvent.ts
+++ b/libs/transaction-observability/src/segmentEvent.ts
@@ -53,7 +53,9 @@ export function toSegmentTrackEvent(event: LogEvent): SegmentTrackEvent | null {
     tx_data_source: event.dataSource,
     is_testnet: event.isTestnet,
     is_send_max: event.isSendMax,
-    ...(event.manifestId ? { provider: event.manifestId } : {}),
+    // The live-app or dApp that originated the transaction. Named `manifest_id` rather than
+    // `provider` because a manifest id is the app, not the staking provider behind it.
+    ...(event.manifestId ? { manifest_id: event.manifestId } : {}),
     ...(event.validators?.length ? { validators: event.validators } : {}),
   };
 

--- a/libs/transaction-observability/src/signContext.test.ts
+++ b/libs/transaction-observability/src/signContext.test.ts
@@ -1,0 +1,151 @@
+import type { Account, SignedOperation } from "@ledgerhq/types-live";
+import { setEnv } from "@shared/env";
+import { hasSignContext, recallSignContext, rememberSignContext } from "./signContext";
+import { buildBroadcastCommonEvent } from "./eventBuilders";
+import { TransactionDataSource, TransactionPathway } from "./logEvent";
+
+const account = (id: string, family: string, ticker: string) =>
+  ({ id: "acc", type: "Account", currency: { id, family, ticker } }) as unknown as Account;
+
+const signed = (op: Record<string, unknown>) =>
+  ({ signature: "0xsig", operation: op }) as unknown as SignedOperation;
+
+const attribution = (mainAccount: Account) => ({
+  account: mainAccount,
+  mainAccount,
+  pathway: TransactionPathway.Send,
+});
+
+beforeEach(() => setEnv("LEDGER_CLIENT_VERSION", "llc/test"));
+
+describe("rememberSignContext / recallSignContext", () => {
+  it("carries the exact action and the delegation target across the stages", () => {
+    const signedOperation = signed({ type: "DELEGATE", extra: {} });
+    rememberSignContext(signedOperation, "solana", {
+      family: "solana",
+      model: { kind: "stake.createAccount", uiState: { voteAccAddr: "voteAcc" } },
+    });
+
+    expect(recallSignContext(signedOperation)).toEqual({
+      earnTransactionType: "delegate",
+      rawTransactionType: "stake.createAccount",
+      validators: ["voteAcc"],
+      isSendMax: false,
+    });
+  });
+
+  it("does not correlate a different signed operation", () => {
+    rememberSignContext(signed({ type: "DELEGATE" }), "cosmos", {
+      family: "cosmos",
+      mode: "delegate",
+    });
+
+    expect(recallSignContext(signed({ type: "DELEGATE" }))).toBeUndefined();
+    expect(recallSignContext(undefined)).toBeUndefined();
+  });
+
+  it("stores nothing for a non-staking transaction", () => {
+    const signedOperation = signed({ type: "OUT" });
+    rememberSignContext(signedOperation, "cosmos", { family: "cosmos", mode: "send" });
+
+    expect(recallSignContext(signedOperation)?.earnTransactionType).toBeUndefined();
+  });
+
+  it("survives a read, so a rebroadcast still correlates", () => {
+    const signedOperation = signed({ type: "DELEGATE" });
+    rememberSignContext(signedOperation, "cosmos", { family: "cosmos", mode: "delegate" });
+
+    recallSignContext(signedOperation);
+    expect(hasSignContext(signedOperation)).toBe(true);
+  });
+});
+
+describe("buildBroadcastCommonEvent with a sign context", () => {
+  // Solana's stake.withdraw becomes an `IN` operation, indistinguishable from an incoming
+  // transfer — correlation is the only thing that makes it reportable at all.
+  it("recovers an action the operation type cannot express", () => {
+    const solana = account("solana", "solana", "SOL");
+    const signedOperation = signed({ type: "IN", extra: {} });
+    rememberSignContext(signedOperation, "solana", {
+      family: "solana",
+      model: { kind: "stake.withdraw" },
+    });
+
+    expect(buildBroadcastCommonEvent({ ...attribution(solana), signedOperation })).toMatchObject({
+      earnTransactionType: "withdraw",
+      rawTransactionType: "stake.withdraw",
+      dataSource: TransactionDataSource.Sign,
+    });
+  });
+
+  it("recovers the validator for a family that drops it from the operation", () => {
+    const cardano = account("cardano", "cardano", "ADA");
+    const signedOperation = signed({ type: "DELEGATE", extra: {} });
+    rememberSignContext(signedOperation, "cardano", {
+      family: "cardano",
+      mode: "delegate",
+      poolId: "pool123",
+    });
+
+    expect(
+      buildBroadcastCommonEvent({ ...attribution(cardano), signedOperation }).validators,
+    ).toEqual(["pool123"]);
+  });
+
+  // The sign stage has no broadcastConfig, so it must never win on attribution.
+  it("keeps the broadcast stage's route attribution", () => {
+    const cosmos = account("cosmos", "cosmos", "ATOM");
+    const signedOperation = signed({ type: "DELEGATE", extra: {} });
+    rememberSignContext(signedOperation, "cosmos", { family: "cosmos", mode: "delegate" });
+
+    const common = buildBroadcastCommonEvent({
+      account: cosmos,
+      mainAccount: cosmos,
+      pathway: TransactionPathway.Dapp,
+      manifestId: "kiln",
+      signedOperation,
+    });
+
+    expect(common).toMatchObject({ pathway: TransactionPathway.Dapp, manifestId: "kiln" });
+  });
+
+  // Celo and tron only expose the target on the optimistic operation, so a correlation hit
+  // must not discard it just because the sign stage had none.
+  it("keeps an operation-only validator when the sign stage had none", () => {
+    const celo = account("celo", "celo", "CELO");
+    const signedOperation = signed({ type: "VOTE", extra: { celoSourceValidator: "0xgroup" } });
+    rememberSignContext(signedOperation, "celo", { family: "celo", mode: "vote" });
+
+    const common = buildBroadcastCommonEvent({ ...attribution(celo), signedOperation });
+    expect(common).toMatchObject({
+      earnTransactionType: "delegate",
+      dataSource: TransactionDataSource.Sign,
+      validators: ["0xgroup"],
+    });
+  });
+
+  it("falls back to the operation type when nothing correlates", () => {
+    const cosmos = account("cosmos", "cosmos", "ATOM");
+
+    expect(
+      buildBroadcastCommonEvent({
+        ...attribution(cosmos),
+        signedOperation: signed({ type: "DELEGATE", extra: {} }),
+      }),
+    ).toMatchObject({
+      earnTransactionType: "delegate",
+      rawTransactionType: "DELEGATE",
+      dataSource: TransactionDataSource.Broadcast,
+    });
+  });
+
+  it("falls back when the sign stage saw no staking action", () => {
+    const cosmos = account("cosmos", "cosmos", "ATOM");
+    const signedOperation = signed({ type: "DELEGATE", extra: {} });
+    rememberSignContext(signedOperation, "cosmos", { family: "cosmos", mode: "send" });
+
+    expect(buildBroadcastCommonEvent({ ...attribution(cosmos), signedOperation })).toMatchObject({
+      dataSource: TransactionDataSource.Broadcast,
+    });
+  });
+});

--- a/libs/transaction-observability/src/signContext.test.ts
+++ b/libs/transaction-observability/src/signContext.test.ts
@@ -48,7 +48,8 @@ describe("rememberSignContext / recallSignContext", () => {
     const signedOperation = signed({ type: "OUT" });
     rememberSignContext(signedOperation, "cosmos", { family: "cosmos", mode: "send" });
 
-    expect(recallSignContext(signedOperation)?.earnTransactionType).toBeUndefined();
+    expect(hasSignContext(signedOperation)).toBe(false);
+    expect(recallSignContext(signedOperation)).toBeUndefined();
   });
 
   it("survives a read, so a rebroadcast still correlates", () => {

--- a/libs/transaction-observability/src/signContext.ts
+++ b/libs/transaction-observability/src/signContext.ts
@@ -7,7 +7,7 @@ import { getRawTransactionType, getStakeTarget, type TransactionLike } from "./t
  * wording, the delegation target, and send-max.
  */
 export type SignContext = {
-  earnTransactionType?: EarnTransactionType;
+  earnTransactionType: EarnTransactionType;
   rawTransactionType?: string;
   validators?: string[];
   isSendMax: boolean;
@@ -37,8 +37,12 @@ export function rememberSignContext(
 ): void {
   if (!signedOperation || typeof signedOperation !== "object") return;
   const rawTransactionType = getRawTransactionType(transaction);
+  const earnTransactionType = deriveEarnTransactionType(family, rawTransactionType);
+  // Only a staking action is ever recalled, so storing anything else is churn the broadcast
+  // stage never reads — it falls back to the operation type whenever the action is absent.
+  if (!earnTransactionType) return;
   contexts.set(signedOperation, {
-    earnTransactionType: deriveEarnTransactionType(family, rawTransactionType),
+    earnTransactionType,
     rawTransactionType,
     validators: getStakeTarget(transaction),
     isSendMax: Boolean(transaction?.useAllAmount),

--- a/libs/transaction-observability/src/signContext.ts
+++ b/libs/transaction-observability/src/signContext.ts
@@ -1,0 +1,58 @@
+import type { SignedOperation } from "@ledgerhq/types-live";
+import { deriveEarnTransactionType, type EarnTransactionType } from "./earnTransactionType";
+import { getRawTransactionType, getStakeTarget, type TransactionLike } from "./transactionShape";
+
+/**
+ * What the sign stage knows and the broadcast stage does not: the family's own action
+ * wording, the delegation target, and send-max.
+ */
+export type SignContext = {
+  earnTransactionType?: EarnTransactionType;
+  rawTransactionType?: string;
+  validators?: string[];
+  isSendMax: boolean;
+};
+
+/**
+ * Correlates the two lifecycle stages.
+ *
+ * `signOperation` emits a `SignedOperation` and that same object is later handed to
+ * `broadcast`, so object identity is the correlation key — no id to invent, nothing to
+ * reconcile. A `WeakMap` rather than a keyed cache means there is no TTL, no eviction policy
+ * and no size cap to get wrong, and no signature is retained: a transaction that is signed
+ * and never broadcast simply becomes garbage. Entries survive a read, so a rebroadcast or a
+ * speed-up still correlates.
+ *
+ * Identity is lost when a signed operation is serialised and rehydrated — the wallet-api
+ * `transaction.sign` route across the webview boundary, or one persisted and broadcast later
+ * — and ACRE signs outside the wrapper entirely. Those miss and fall back to the operation
+ * type, which is why {@link deriveFromOperationType} is still load-bearing.
+ */
+const contexts = new WeakMap<object, SignContext>();
+
+export function rememberSignContext(
+  signedOperation: SignedOperation,
+  family: string,
+  transaction: TransactionLike | undefined | null,
+): void {
+  if (!signedOperation || typeof signedOperation !== "object") return;
+  const rawTransactionType = getRawTransactionType(transaction);
+  contexts.set(signedOperation, {
+    earnTransactionType: deriveEarnTransactionType(family, rawTransactionType),
+    rawTransactionType,
+    validators: getStakeTarget(transaction),
+    isSendMax: Boolean(transaction?.useAllAmount),
+  });
+}
+
+export function recallSignContext(
+  signedOperation: SignedOperation | undefined | null,
+): SignContext | undefined {
+  if (!signedOperation || typeof signedOperation !== "object") return undefined;
+  return contexts.get(signedOperation);
+}
+
+/** Test-only: the map is otherwise invisible, so a leak assertion needs a way in. */
+export function hasSignContext(signedOperation: SignedOperation): boolean {
+  return contexts.has(signedOperation);
+}


### PR DESCRIPTION
### 📝 Description

**Part 3 of 3.** Base is [#20818](https://github.com/LedgerHQ/ledger-live/pull/20818) — review that first.

Stack: [#20817 package](https://github.com/LedgerHQ/ledger-live/pull/20817) → [#20818 bridge seam](https://github.com/LedgerHQ/ledger-live/pull/20818) → **#20819 correlation**

**Problem.** After #20818, a broadcast event carries only what survives on the optimistic operation, and that is uneven in ways a data consumer cannot predict:

- **Validators**: cosmos copies them into `Operation.extra`; solana, cardano, sui, near and multiversx do not. Present for some chains and absent for others with no rule to explain it — worse than uniformly missing, because it looks present.
- **Action**: hedera `claim-rewards` and algorand `claimReward` are crafted as plain self-transfers, so they report `OUT`; solana `stake.withdraw` reports `IN`. Those successes are simply unreportable.
- Cosmos `claimReward` vs `claimRewardCompound` collapse onto `REWARD`.

**Approach.** The correlation key already exists and needed no invention: `signOperation` emits a `SignedOperation`, and **that same object** is later handed to `broadcast`. Object identity is the key.

```ts
const signContext = new WeakMap<SignedOperation, SignContext>();
```

A `WeakMap` rather than a keyed cache is the load-bearing choice — no TTL, no eviction policy and no size cap to get wrong, and no signature is retained: a transaction signed but never broadcast just becomes garbage. Entries survive a read, so a rebroadcast or speed-up still correlates.

**Where it misses — all fall back, none break:**

- A `SignedOperation` that was serialised and rehydrated — the wallet-api `transaction.sign` route across the webview boundary, or one persisted and broadcast later, which the type explicitly supports.
- ACRE, which signs outside the wrapper entirely.

Those fall back to the `OperationType` map from #20817, which is why that map is still load-bearing rather than dead weight.

**`tx_data_source` on every event records which path produced it**, so the correlation hit-rate is measurable in production instead of assumed. If it turns out to be low, that is a number we can see rather than a surprise.

**Also in this PR: the Segment property `provider` becomes `manifest_id`.**

The value was always a manifest id. `provider` means something else in Ledger Wallet's analytics — the staking or swap partner behind a flow — and `manifest_id` is the name the rest of the codebase already uses for this identifier, including the feature-flag params that supply it.

Done now rather than later on purpose: the host apps only register the observer in #20818, which is not merged, so no event has carried either property in production yet. After #20818 ships this becomes a Mixpanel schema break instead of a rename.

**Review notes**

- The sign stage has no `broadcastConfig`, so it must never win on attribution — a test asserts `flow` and `manifestId` still come from the broadcast stage.
- Only the action fields are carried across (action, raw wording, validators, send-max), not a whole event, so sign-stage attribution cannot leak.
- The seam now `tap`s the `signed` event. The subscribe-once test from #20818 still holds.

**Test coverage:** yes. No UI changes.

<img width="806" height="685" alt="image" src="https://github.com/user-attachments/assets/6c871824-6cb1-489b-a795-c4690e2bd86e" />


### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35350](https://ledgerhq.atlassian.net/browse/LIVE-35350)
- **ADR** (if any): 
- ADR https://ledgerhq.atlassian.net/wiki/spaces/PTX/pages/7218364465/EARN+ADR+TX+observability
- Taxonomy docs https://ledgerhq.atlassian.net/wiki/x/8YBQuAE


[LIVE-35350]: https://ledgerhq.atlassian.net/browse/LIVE-35350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
