### PR TITLE
fix(wallet-framework): declare test-setup devDependency

### DIFF
--- a/.changeset/wet-bobcats-melt.md
+++ b/.changeset/wet-bobcats-melt.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/ledger-wallet-framework": minor
+---
+
+Declare `@ledgerhq/wallet-framework-test-setup` as a devDependency of `@ledgerhq/ledger-wallet-framework`. Its `jest.integ.config.js` already lists the package in `setupFilesAfterEnv`, but it was never a declared dependency, so the `test-integration-pr` workflow's scoped install (`pnpm i --filter="@ledgerhq/ledger-wallet-framework"`) did not link it and the wallet-framework integration tests failed at jest bootstrap with `Module @ledgerhq/wallet-framework-test-setup in the setupFilesAfterEnv option was not found`. Declaring the dependency makes the scoped install include it.

--- a/libs/ledger-wallet-framework/package.json
+++ b/libs/ledger-wallet-framework/package.json
@@ -124,6 +124,7 @@
     "@types/imurmurhash": "^0.1.4",
     "@types/node": "catalog:",
     "@ledgerhq/live-dmk-speculos": "workspace:^",
+    "@ledgerhq/wallet-framework-test-setup": "workspace:^",
     "@types/invariant": "^2.2.2",
     "@types/jest": "catalog:",
     "@types/lodash": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11400,6 +11400,9 @@ importers:
       '@ledgerhq/live-dmk-speculos':
         specifier: workspace:^
         version: link:../live-dmk-speculos
+      '@ledgerhq/wallet-framework-test-setup':
+        specifier: workspace:^
+        version: link:../wallet-framework-test-setup
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11


### PR DESCRIPTION
### 📝 Description

`libs/ledger-wallet-framework`'s `jest.integ.config.js` lists `@ledgerhq/wallet-framework-test-setup` in `setupFilesAfterEnv` by package name, but the package was never a declared dependency. The `test-integration-pr` workflow installs scoped (`pnpm i --filter="@ledgerhq/ledger-wallet-framework"`), so the test-setup package wasn't linked and the wallet-framework integration tests crashed at jest bootstrap with `Module @ledgerhq/wallet-framework-test-setup in the setupFilesAfterEnv option was not found`.

Fix: declare `@ledgerhq/wallet-framework-test-setup` as a `devDependency` (`workspace:^`) so the scoped install links it. The `test-integration-pr` job (`pnpm --filter @ledgerhq/ledger-wallet-framework test-integ`) is the regression guard — it now resolves the setup file and runs the suite instead of failing at bootstrap.

### 🔗 Context

- **JIRA / GitHub issue**: n/a
- **ADR** (if any): n/a