### PR TITLE
[LWDM] refactor(aleo): support for arc-20 tokens

### DIFF
--- a/.changeset/nine-mirrors-reply.md
+++ b/.changeset/nine-mirrors-reply.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+refactor: aleo listOperations with arc-20 tokens support

--- a/libs/coin-modules/coin-aleo/src/constants.ts
+++ b/libs/coin-modules/coin-aleo/src/constants.ts
@@ -45,11 +45,6 @@ export const SEMI_PUBLIC_TOKEN_FUNCTIONS = new Set([
 // Each record with this value in `record_name` field is a token record.
 export const TOKEN_RECORD_NAME = "Token";
 
-// Indexes based on aleo credits program args
-// ref: https://developer.aleo.org/concepts/fundamentals/credits/#transfer_public
-export const RECIPIENT_ARG_INDEX = 1;
-export const AMOUNT_ARG_INDEX = 2;
-
 // The maximum amount of records to fetch in a single API call when fetching owned records.
 // This is not a limit on the total number of records that can be fetched, but rather a pagination parameter for the API calls.
 export const DEFAULT_RECORDS_PAGE_SIZE = 1000;

--- a/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.test.ts
@@ -380,6 +380,69 @@ describe("listPrivateOperations", () => {
     expect(result.consumedRecordTags).toEqual(new Set(["consumed-tag-1"]));
   });
 
+  it("should collect consumed record tags from ARC-20 record_with_dynamic_id inputs", async () => {
+    const record = getMockedRecord({
+      program_name: "arc20_eth.aleo",
+      function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
+    });
+    const mockEnriched = getMockedEnrichedPrivateRecord({
+      rawRecord: { sender: mockAddress },
+      details: {
+        execution: {
+          transitions: [
+            {
+              id: "au1",
+              scm: "s",
+              tcm: "t",
+              tpk: "tpk1",
+              inputs: [
+                {
+                  id: "in0",
+                  type: "record_with_dynamic_id",
+                  tag: "consumed-token-tag",
+                  dynamic_id: "dynamic-id-0",
+                },
+                { id: "in1", type: "private", value: "cipher_recipient" },
+                { id: "in2", type: "private", value: "cipher_amount" },
+              ],
+              outputs: [],
+              program: "arc20_eth.aleo",
+              function: "transfer_private",
+            },
+            {
+              id: "au2",
+              scm: "s",
+              tcm: "t",
+              tpk: "tpk2",
+              inputs: [
+                { id: "in0", type: "private", value: "cipher_token_id" },
+                { id: "in1", type: "record_dynamic" },
+                { id: "in2", type: "private", value: "cipher_recipient" },
+                { id: "in3", type: "private", value: "cipher_amount" },
+              ],
+              outputs: [],
+              program: "mm1_ldg_arc20_p_28.aleo",
+              function: "transfer_private_1",
+            },
+          ],
+        },
+      },
+    });
+
+    mockEnrichPrivateRecord.mockResolvedValue(mockEnriched);
+    mockToPrivateBridgeOperation.mockReturnValue(mockOp);
+
+    const result = await listPrivateOperations({
+      config: mockConfig,
+      viewKey: mockViewKey,
+      address: mockAddress,
+      ledgerAccountId: mockLedgerAccountId,
+      privateRecords: [record],
+    });
+
+    expect(result.consumedRecordTags).toEqual(new Set(["consumed-token-tag"]));
+  });
+
   it("should not collect tags from incoming transactions where sender is not this address", async () => {
     const record = getMockedRecord({
       program_name: PROGRAM_ID.CREDITS,

--- a/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.ts
@@ -9,10 +9,11 @@ import type {
 import { enrichPrivateRecord } from "../network/utils";
 import { toPrivateBridgeOperation } from "./utils";
 
-function onlyRecordValue(
+// Records forwarded to another program carry no tag; the callee's transition holds it.
+function onlyTaggedRecordValue(
   value: AleoTransitionValue,
-): value is Extract<AleoTransitionValue, { type: "record" }> {
-  return value.type === "record";
+): value is Extract<AleoTransitionValue, { tag: string }> {
+  return "tag" in value;
 }
 
 // Build the set of record tags consumed as inputs in outgoing transactions.
@@ -31,7 +32,9 @@ export function buildConsumedRecordTags(
       enriched.details.fee.transition,
     ];
 
-    const inputRecords = txTransitions.flatMap(({ inputs }) => inputs.filter(onlyRecordValue));
+    const inputRecords = txTransitions.flatMap(({ inputs }) =>
+      inputs.filter(onlyTaggedRecordValue),
+    );
 
     for (const input of inputRecords) {
       tags.add(input.tag);

--- a/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
@@ -58,6 +58,8 @@ import {
   normalizeAleoPlaintext,
   isAleoAddressPlaintext,
   isAleoAmountPlaintext,
+  isParsableTransferFunction,
+  findTransferArguments,
   determineTransactionType,
   patchAccountWithViewKey,
   toCoinFrameworkOperation,
@@ -217,6 +219,75 @@ describe("isAleoAmountPlaintext", () => {
     ["", false],
   ])("(%j) → %s", (input, expected) => {
     expect(isAleoAmountPlaintext(input)).toBe(expected);
+  });
+});
+
+describe("isParsableTransferFunction", () => {
+  it.each([
+    ["transfer_private", true],
+    ["transfer_private_to_public", true],
+    ["transfer_public_to_private", true],
+    ["transfer_private_2", true],
+    ["transfer_private_13", true],
+    ["transfer_private_to_public_4", true],
+    ["transfer_public_to_private_3", true],
+    ["transfer_from_public", false],
+    ["transfer_from_public_to_private", false],
+    ["transfer_public", false],
+    ["transfer_public_as_signer", false],
+    ["mint_private", false],
+    ["burn_private", false],
+    ["join", false],
+    ["join_5", false],
+    ["split", false],
+    ["fee_private", false],
+    ["", false],
+  ])("(%j) → %s", (input, expected) => {
+    expect(isParsableTransferFunction(input)).toBe(expected);
+  });
+});
+
+describe("findTransferArguments", () => {
+  const to = "aleo1recipient123";
+
+  it.each([
+    [
+      "credits.aleo / ARC-20 (record, recipient, amount)",
+      [null, to, "150000u64"],
+      { recipient: to, amount: "150000u64" },
+    ],
+    [
+      "ARC-21 / ARC-22 (recipient, amount, record)",
+      [to, "700u64", null],
+      { recipient: to, amount: "700u64" },
+    ],
+    [
+      "token_registry.aleo (token_id, recipient, amount, flag)",
+      ["1field", to, "500u128", "true"],
+      { recipient: to, amount: "500u128" },
+    ],
+    [
+      "batcher wrapper (external records, recipient, amount, proof)",
+      [null, null, to, "250000u64", "proof"],
+      { recipient: to, amount: "250000u64" },
+    ],
+    [
+      "trailing amount-shaped merkle proof is ignored",
+      [null, to, "42u64", "9999u64"],
+      { recipient: to, amount: "42u64" },
+    ],
+    [
+      "visibility suffixes are stripped",
+      [`${to}.private`, "42u64.public"],
+      { recipient: to, amount: "42u64" },
+    ],
+    ["undecryptable amount", [null, to, null], null],
+    ["no amount-shaped argument after the recipient", [null, to, null, "notanamount"], null],
+    ["no address-shaped argument (join)", [null, null], null],
+    ["amount before the recipient", ["42u64", to], null],
+    ["no arguments", [], null],
+  ])("%s", (_label, plaintexts, expected) => {
+    expect(findTransferArguments(plaintexts)).toEqual(expected);
   });
 });
 
@@ -385,6 +456,15 @@ describe("toCoinFrameworkOperation", () => {
     expect(result.tx.block.hash).toBe(rawTx.block_hash);
   });
 
+  it("should use amount_u128 over amount when provided, including values beyond JS safe integer range", () => {
+    const amountU128 = "123456789012345678901234567890";
+    const rawTx = getMockedPublicTransaction({ amount: 10000000, amount_u128: amountU128 });
+
+    const result = toCoinFrameworkOperation(rawTx, recipientAddress);
+
+    expect(result.value).toBe(BigInt(amountU128));
+  });
+
   it("should set failed to true when transaction_status is not Accepted", () => {
     const rawTx = getMockedPublicTransaction({ transaction_status: "Rejected" });
 
@@ -440,6 +520,15 @@ describe("toBridgeOperation", () => {
     expect(result.hasFailed).toBe(false);
   });
 
+  it("should use amount_u128 over amount when provided, including values beyond JS safe integer range", () => {
+    const amountU128 = "123456789012345678901234567890";
+    const rawTx = getMockedPublicTransaction({ amount: 10000000, amount_u128: amountU128 });
+
+    const result = toBridgeOperation(ledgerAccountId, rawTx, recipientAddress);
+
+    expect(result.value).toEqual(new BigNumber(amountU128));
+  });
+
   it("should generate different ids for different account ids", () => {
     const rawTx = getMockedPublicTransaction();
     const otherId = "js:2:aleo:aleo1other:";
@@ -473,7 +562,6 @@ describe("toBridgeOperation", () => {
 
   it.each([
     ["NaN amount", { amount: NaN as number }],
-    ["zero amount", { amount: 0 }],
     ["negative amount", { amount: -1 }],
   ])("should log invalid raw transaction details for %s", (_label, amountOverride) => {
     const rawTx = getMockedPublicTransaction(amountOverride);
@@ -486,6 +574,19 @@ describe("toBridgeOperation", () => {
       rawTx,
     );
     expect(result.value).toEqual(new BigNumber(rawTx.amount));
+  });
+
+  it("should log a zero amount apart from invalid details for transfer functions", () => {
+    const rawTx = getMockedPublicTransaction({ amount: 0, function_id: "transfer_private" });
+
+    toBridgeOperation(ledgerAccountId, rawTx, recipientAddress);
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenCalledWith(
+      "aleo/toBridgeOperation",
+      `Zero value transaction for ${recipientAddress}`,
+      rawTx,
+    );
   });
 
   it("should not log when amount is valid", () => {

--- a/libs/coin-modules/coin-aleo/src/logic/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.ts
@@ -30,6 +30,7 @@ import {
   FAST_PRIVATE_RECORDS_PER_TRANSACTION,
   MAX_PRIVATE_RECORDS_PER_TRANSACTION,
   MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION,
+  PRIVATE_TRANSFER_FUNCTIONS,
   PROGRAM_ID,
   SINGLE_CALL_SIGNING_TIME,
   TOKEN_RECORD_NAME,
@@ -189,6 +190,10 @@ export const determineTransactionType = (
   return "public";
 };
 
+function resolveTransactionAmount(rawTx: AleoPublicTransaction): BigNumber {
+  return new BigNumber(rawTx.amount_u128 ?? rawTx.amount);
+}
+
 function parseTransactionFields(rawTx: AleoPublicTransaction, address: string) {
   const date = new Date(Number(rawTx.block_timestamp) * 1000);
   const hasFailed = rawTx.transaction_status !== "Accepted";
@@ -218,7 +223,7 @@ export const toCoinFrameworkOperation = (
     type,
     recipients: [rawTx.recipient_address],
     senders: [rawTx.sender_address],
-    value: BigInt(rawTx.amount.toFixed(0)),
+    value: BigInt(resolveTransactionAmount(rawTx).toFixed(0)),
     asset: { type: "native" },
     details: {
       functionId: rawTx.function_id,
@@ -245,14 +250,18 @@ export const toBridgeOperation = (
   address: string,
   isTokenTx?: boolean,
 ): AleoOperation => {
-  const value = new BigNumber(rawTx.amount);
+  const value = resolveTransactionAmount(rawTx);
   const { type, fee, blockHash, transactionType, date, hasFailed } = parseTransactionFields(
     rawTx,
     address,
   );
 
-  if (value.isNaN() || value.lte(0)) {
+  if (value.isNaN() || value.isNegative()) {
     log("aleo/toBridgeOperation", `Invalid raw transaction details for ${address}`, rawTx);
+  }
+
+  if (value.isZero() && rawTx.function_id.includes("transfer")) {
+    log("aleo/toBridgeOperation", `Zero value transaction for ${address}`, rawTx);
   }
 
   return {
@@ -1224,4 +1233,54 @@ export function isAleoAddressPlaintext(v: string): boolean {
 
 export function isAleoAmountPlaintext(v: string): boolean {
   return /^\d+u\d+$/.test(normalizeAleoPlaintext(v));
+}
+
+/**
+ * Whether a transition's (recipient, amount) arguments can be located by scanning for the first
+ * address-shaped argument. Ledger's batching wrappers suffix the function with the record count
+ * (transfer_private_4) but keep the wrapped function's argument order.
+ *
+ * Excludes transfer_from_*, whose first address argument is the sender, not the recipient.
+ */
+export function isParsableTransferFunction(functionName: string): boolean {
+  return PRIVATE_TRANSFER_FUNCTIONS.has(functionName.replace(/_\d+$/, ""));
+}
+
+/**
+ * Takes a transfer transition's arguments in order (null where undecryptable or not a value) and
+ * returns the first address-shaped one plus the first amount-shaped one after it.
+ *
+ * No fixed offset works — all three argument layouts are deployed:
+ *   credits.aleo, ARC-20   (record, recipient, amount)
+ *   ARC-21, ARC-22         (recipient, amount, record, …)
+ *   token_registry.aleo    (token_id, recipient, amount, flag) for transfer_public_to_private
+ */
+export function findTransferArguments(plaintexts: (string | null)[]): {
+  recipient: string;
+  amount: string;
+} | null {
+  let recipient: string | null = null;
+
+  for (const plaintext of plaintexts) {
+    if (!plaintext) {
+      continue;
+    }
+
+    if (!recipient) {
+      if (isAleoAddressPlaintext(plaintext)) {
+        recipient = normalizeAleoPlaintext(plaintext);
+      }
+
+      continue;
+    }
+
+    if (isAleoAmountPlaintext(plaintext)) {
+      return {
+        recipient,
+        amount: normalizeAleoPlaintext(plaintext),
+      };
+    }
+  }
+
+  return null;
 }

--- a/libs/coin-modules/coin-aleo/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.test.ts
@@ -1,4 +1,5 @@
 import BigNumber from "bignumber.js";
+import { log } from "@ledgerhq/logs";
 import { LedgerAPI4xx, LedgerAPI5xx } from "@ledgerhq/live-network/errors";
 import { AleoApiConfigurationResetError } from "../errors";
 import {
@@ -7,8 +8,6 @@ import {
   DEFAULT_TOKENS_PAGE_SIZE,
   PROGRAM_ID,
   TOKEN_RECORD_NAME,
-  RECIPIENT_ARG_INDEX,
-  AMOUNT_ARG_INDEX,
 } from "../constants";
 import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
 import { sdkClient } from "../network/sdk";
@@ -38,6 +37,9 @@ import {
 
 jest.mock("./api");
 jest.mock("./sdk");
+jest.mock("@ledgerhq/logs", () => ({
+  log: jest.fn(),
+}));
 jest.mock("../logic/utils", () => ({
   ...jest.requireActual("../logic/utils"),
   generateUniqueUsername: jest.fn(),
@@ -750,45 +752,7 @@ describe("network/utils", () => {
       expect(mockDecryptRecord).not.toHaveBeenCalled();
     });
 
-    it("should return null when sender is this address and transition has fewer inputs than expected", async () => {
-      const rawRecord = getMockedRecord({
-        function_name: EXPLORER_TRANSFER_TYPES.PRIVATE_TO_PUBLIC,
-        sender: mockEnrichAddress,
-        transition_index: 0,
-      });
-      mockGetTransactionById.mockResolvedValueOnce(
-        getMockedTransactionDetails(rawRecord.transaction_id, {
-          execution: {
-            transitions: [
-              {
-                id: "au1",
-                scm: "s",
-                tcm: "t",
-                tpk: "tpk1",
-                inputs: [{ id: "in0", type: "public", value: "only_one_input" }], // only 1 input, needs 3 (indices 0, 1, 2)
-                outputs: [],
-                program: "credits.aleo",
-                function: "transfer_private_to_public",
-              },
-            ],
-          },
-        }),
-      );
-
-      const result = await enrichPrivateRecord({
-        config: mockConfig,
-        rawRecord,
-        address: mockEnrichAddress,
-        viewKey: mockViewKey,
-      });
-
-      expect(result).toBeNull();
-      expect(mockGetTransactionById).toHaveBeenCalledTimes(1);
-      expect(mockDecryptCiphertext).not.toHaveBeenCalled();
-      expect(mockDecryptRecord).not.toHaveBeenCalled();
-    });
-
-    it("should return null when sender is this address and transition inputs at recipient/amount indices have no value field (record type)", async () => {
+    it("should return null when no amount-shaped argument follows the recipient", async () => {
       const rawRecord = getMockedRecord({
         function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
         sender: mockEnrichAddress,
@@ -804,9 +768,9 @@ describe("network/utils", () => {
                 tcm: "t",
                 tpk: "tpk1",
                 inputs: [
-                  { id: "in0", type: "record", tag: "record_tag_0" }, // index 0
-                  { id: "in1", type: "record", tag: "record_tag_1" }, // RECIPIENT_ARG_INDEX = 1, no value field
-                  { id: "in2", type: "private", value: "ciphertext_amount" }, // AMOUNT_ARG_INDEX = 2
+                  { id: "in0", type: "record", tag: "record_tag_0" },
+                  { id: "in1", type: "private", value: "ciphertext_recipient" },
+                  { id: "in2", type: "record", tag: "record_tag_2" },
                 ],
                 outputs: [],
                 program: "credits.aleo",
@@ -816,6 +780,7 @@ describe("network/utils", () => {
           },
         }),
       );
+      mockDecryptCiphertext.mockResolvedValueOnce({ plaintext: "aleo1recipientnoamount" });
 
       const result = await enrichPrivateRecord({
         config: mockConfig,
@@ -826,8 +791,13 @@ describe("network/utils", () => {
 
       expect(result).toBeNull();
       expect(mockGetTransactionById).toHaveBeenCalledTimes(1);
-      expect(mockDecryptCiphertext).not.toHaveBeenCalled();
+      expect(mockDecryptCiphertext).toHaveBeenCalledTimes(1);
       expect(mockDecryptRecord).not.toHaveBeenCalled();
+      expect(log).toHaveBeenCalledTimes(1);
+      expect(log).toHaveBeenCalledWith(
+        "aleo/sync",
+        `resolveTransferArguments: no recipient/amount arguments found in credits.aleo/transfer_private for tx ${rawRecord.transaction_id}`,
+      );
     });
 
     it("should return null when PRIVATE_TO_PUBLIC and recipient is own address", async () => {
@@ -846,9 +816,9 @@ describe("network/utils", () => {
                 tcm: "t",
                 tpk: "tpk1",
                 inputs: [
-                  { id: "in0", type: "public", value: "record_cipher" },
-                  { id: "in1", type: "public", value: mockEnrichAddress }, // RECIPIENT_ARG_INDEX = 1, self
-                  { id: "in2", type: "public", value: "500000u64" }, // AMOUNT_ARG_INDEX = 2
+                  { id: "in0", type: "record", tag: "record_tag_0" }, // leading spent record
+                  { id: "in1", type: "public", value: mockEnrichAddress }, // recipient, self
+                  { id: "in2", type: "public", value: "500000u64" }, // amount
                 ],
                 outputs: [],
                 program: "credits.aleo",
@@ -888,9 +858,9 @@ describe("network/utils", () => {
               tcm: "t",
               tpk: "tpk1",
               inputs: [
-                { id: "in0", type: "public", value: "record_cipher" },
-                { id: "in1", type: "public", value: recipientAddress }, // RECIPIENT_ARG_INDEX = 1
-                { id: "in2", type: "public", value: "500000u64" }, // AMOUNT_ARG_INDEX = 2
+                { id: "in0", type: "record", tag: "record_tag_0" }, // leading spent record
+                { id: "in1", type: "public", value: recipientAddress }, // recipient
+                { id: "in2", type: "public", value: "500000u64" }, // amount
               ],
               outputs: [],
               program: "credits.aleo",
@@ -936,9 +906,9 @@ describe("network/utils", () => {
               tcm: "t",
               tpk: "tpk_private",
               inputs: [
-                { id: "in0", type: "private", value: "ciphertext_record" },
-                { id: "in1", type: "private", value: "ciphertext_recipient" }, // RECIPIENT_ARG_INDEX = 1
-                { id: "in2", type: "private", value: "ciphertext_amount" }, // AMOUNT_ARG_INDEX = 2
+                { id: "in0", type: "record", tag: "record_tag_0" }, // leading spent record
+                { id: "in1", type: "private", value: "ciphertext_recipient" }, // recipient index = 1
+                { id: "in2", type: "private", value: "ciphertext_amount" }, // amount index = 2
               ],
               outputs: [],
               program: "credits.aleo",
@@ -973,7 +943,7 @@ describe("network/utils", () => {
         viewKey: mockViewKey,
         programId: rawRecord.program_name,
         functionName: rawRecord.function_name,
-        outputIndex: RECIPIENT_ARG_INDEX,
+        outputIndex: 1,
       });
       expect(mockDecryptCiphertext).toHaveBeenCalledWith({
         config: mockConfig,
@@ -982,7 +952,7 @@ describe("network/utils", () => {
         viewKey: mockViewKey,
         programId: rawRecord.program_name,
         functionName: rawRecord.function_name,
-        outputIndex: AMOUNT_ARG_INDEX,
+        outputIndex: 2,
       });
     });
 
@@ -1172,55 +1142,13 @@ describe("network/utils", () => {
       expect(mockDecryptCiphertext).not.toHaveBeenCalled();
     });
 
-    it("should use token input layout (index 0 = recipient, 1 = amount) for outgoing PRIVATE_TO_PUBLIC token record", async () => {
-      const recipientAddress = "aleo1tokenrecipient123";
+    it("should decrypt with the batcher transition's program/function, not the owned record's", async () => {
+      const recipientAddress = "aleo1batcherrecipient789";
       const rawRecord = getMockedRecord({
-        function_name: EXPLORER_TRANSFER_TYPES.PRIVATE_TO_PUBLIC,
-        sender: mockEnrichAddress,
-        record_name: TOKEN_RECORD_NAME,
-        transition_index: 0,
-      });
-      mockGetTransactionById.mockResolvedValueOnce(
-        getMockedTransactionDetails(rawRecord.transaction_id, {
-          execution: {
-            transitions: [
-              {
-                id: "au1",
-                scm: "s",
-                tcm: "t",
-                tpk: "tpk1",
-                inputs: [
-                  { id: "in0", type: "public", value: recipientAddress }, // index 0 = recipient for token
-                  { id: "in1", type: "public", value: "500000u64" }, // index 1 = amount for token
-                ],
-                outputs: [],
-                program: "token_program.aleo",
-                function: "transfer_private_to_public",
-              },
-            ],
-          },
-        }),
-      );
-
-      const result = await enrichPrivateRecord({
-        config: mockConfig,
-        rawRecord,
-        address: mockEnrichAddress,
-        viewKey: mockViewKey,
-      });
-
-      expect(result).not.toBeNull();
-      expect(result?.recipient).toBe(recipientAddress);
-      expect(result?.value).toEqual(new BigNumber(500000));
-      expect(mockDecryptCiphertext).not.toHaveBeenCalled();
-    });
-
-    it("should decrypt ciphertexts from token input indices (0 and 1) for outgoing PRIVATE token record", async () => {
-      const recipientAddress = "aleo1tokenrecipient456";
-      const rawRecord = getMockedRecord({
+        // the record belongs to the inner token program, the transition to Ledger's batching wrapper
         function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
         sender: mockEnrichAddress,
-        program_name: "token_program.aleo",
+        program_name: "usdcx_stablecoin.aleo",
         record_name: TOKEN_RECORD_NAME,
         transition_index: 0,
       });
@@ -1231,14 +1159,17 @@ describe("network/utils", () => {
               id: "au1",
               scm: "s",
               tcm: "t",
-              tpk: "tpk_token",
+              tpk: "tpk_batcher",
               inputs: [
-                { id: "in0", type: "private", value: "ciphertext_recipient" }, // index 0 = recipient for token
-                { id: "in1", type: "private", value: "ciphertext_amount" }, // index 1 = amount for token
+                { id: "in0", type: "external_record" }, // consumed record #1, no tag
+                { id: "in1", type: "external_record" }, // consumed record #2, no tag
+                { id: "in2", type: "private", value: "ciphertext_recipient" }, // recipient index = 2
+                { id: "in3", type: "private", value: "ciphertext_amount" }, // amount index = 3
+                { id: "in4", type: "private", value: "ciphertext_exclusion_proof" },
               ],
               outputs: [],
-              program: "token_program.aleo",
-              function: "transfer_private",
+              program: "ldg_usdcx_p_28.aleo",
+              function: "transfer_private_2",
             },
           ],
         },
@@ -1246,7 +1177,8 @@ describe("network/utils", () => {
       mockGetTransactionById.mockResolvedValueOnce(mockDetails);
       mockDecryptCiphertext
         .mockResolvedValueOnce({ plaintext: recipientAddress })
-        .mockResolvedValueOnce({ plaintext: "800000u64" });
+        .mockResolvedValueOnce({ plaintext: "250000u64" })
+        .mockResolvedValueOnce({ plaintext: "exclusion_proof_plaintext" });
 
       const result = await enrichPrivateRecord({
         config: mockConfig,
@@ -1255,34 +1187,73 @@ describe("network/utils", () => {
         viewKey: mockViewKey,
       });
 
-      expect(result).not.toBeNull();
       expect(result?.recipient).toBe(recipientAddress);
-      expect(result?.value).toEqual(new BigNumber(800000));
-      expect(mockDecryptCiphertext).toHaveBeenCalledTimes(2);
+      expect(result?.value).toEqual(new BigNumber(250000));
       expect(mockDecryptCiphertext).toHaveBeenCalledWith({
         config: mockConfig,
         ciphertext: "ciphertext_recipient",
-        tpk: "tpk_token",
+        tpk: "tpk_batcher",
         viewKey: mockViewKey,
-        programId: "token_program.aleo",
-        functionName: EXPLORER_TRANSFER_TYPES.PRIVATE,
-        outputIndex: RECIPIENT_ARG_INDEX - 1,
+        programId: "ldg_usdcx_p_28.aleo",
+        functionName: "transfer_private_2",
+        outputIndex: 2,
       });
-      expect(mockDecryptCiphertext).toHaveBeenCalledWith({
-        config: mockConfig,
-        ciphertext: "ciphertext_amount",
-        tpk: "tpk_token",
-        viewKey: mockViewKey,
-        programId: "token_program.aleo",
-        functionName: EXPLORER_TRANSFER_TYPES.PRIVATE,
-        outputIndex: AMOUNT_ARG_INDEX - 1,
-      });
+      expect(mockDecryptCiphertext).toHaveBeenCalledWith(
+        expect.objectContaining({ ciphertext: "ciphertext_amount", outputIndex: 3 }),
+      );
     });
 
-    it("should return null when token record has no value field at input index 0", async () => {
+    it.each(["join", "split"])(
+      "should return null for a record-management transition (%s) without decrypting or logging",
+      async functionName => {
+        const rawRecord = getMockedRecord({
+          function_name: functionName,
+          sender: mockEnrichAddress,
+          program_name: "usdcx_stablecoin.aleo",
+          record_name: TOKEN_RECORD_NAME,
+          transition_index: 0,
+        });
+        mockGetTransactionById.mockResolvedValueOnce(
+          getMockedTransactionDetails(rawRecord.transaction_id, {
+            execution: {
+              transitions: [
+                {
+                  id: "au1",
+                  scm: "s",
+                  tcm: "t",
+                  tpk: "tpk1",
+                  inputs: [
+                    { id: "in0", type: "record", tag: "record_tag_0" },
+                    { id: "in1", type: "private", value: "ciphertext_split_amount" },
+                  ],
+                  outputs: [],
+                  program: "usdcx_stablecoin.aleo",
+                  function: functionName,
+                },
+              ],
+            },
+          }),
+        );
+
+        const result = await enrichPrivateRecord({
+          config: mockConfig,
+          rawRecord,
+          address: mockEnrichAddress,
+          viewKey: mockViewKey,
+        });
+
+        expect(result).toBeNull();
+        expect(mockDecryptCiphertext).not.toHaveBeenCalled();
+        expect(log).not.toHaveBeenCalled();
+      },
+    );
+
+    it("should decrypt private-argument transfer_private_to_public (ARC-20 private flavour)", async () => {
+      const recipientAddress = "aleo1arc20privflavour99";
       const rawRecord = getMockedRecord({
-        function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
+        function_name: EXPLORER_TRANSFER_TYPES.PRIVATE_TO_PUBLIC,
         sender: mockEnrichAddress,
+        program_name: "btcx_8e1ed4.aleo",
         record_name: TOKEN_RECORD_NAME,
         transition_index: 0,
       });
@@ -1294,19 +1265,23 @@ describe("network/utils", () => {
                 id: "au1",
                 scm: "s",
                 tcm: "t",
-                tpk: "tpk1",
+                tpk: "tpk_arc20_priv",
                 inputs: [
-                  { id: "in0", type: "record", tag: "record_tag_0" }, // index 0 = no value field (recipient for token)
-                  { id: "in1", type: "private", value: "ciphertext_amount" }, // index 1 = amount for token
+                  { id: "in0", type: "record", tag: "record_tag_0" },
+                  { id: "in1", type: "private", value: "ciphertext_recipient" },
+                  { id: "in2", type: "private", value: "ciphertext_amount" },
                 ],
                 outputs: [],
-                program: "token_program.aleo",
-                function: "transfer_private",
+                program: "btcx_8e1ed4.aleo",
+                function: "transfer_private_to_public",
               },
             ],
           },
         }),
       );
+      mockDecryptCiphertext
+        .mockResolvedValueOnce({ plaintext: recipientAddress })
+        .mockResolvedValueOnce({ plaintext: "25000u128" });
 
       const result = await enrichPrivateRecord({
         config: mockConfig,
@@ -1315,8 +1290,8 @@ describe("network/utils", () => {
         viewKey: mockViewKey,
       });
 
-      expect(result).toBeNull();
-      expect(mockDecryptCiphertext).not.toHaveBeenCalled();
+      expect(result?.recipient).toBe(recipientAddress);
+      expect(result?.value).toEqual(new BigNumber(25000));
     });
   });
 
@@ -1486,7 +1461,10 @@ describe("network/utils", () => {
               scm: "s",
               tcm: "t",
               tpk: "tpk_fee",
-              inputs: [{ id: "in0", type: "public", value: "cipher_recipient" }],
+              inputs: [
+                { id: "in0", type: "private", value: "cipher_recipient" },
+                { id: "in1", type: "public", value: "40000u64" },
+              ],
               outputs: [],
               program: "credits.aleo",
               function: "transfer_public_to_private",
@@ -1532,7 +1510,10 @@ describe("network/utils", () => {
               scm: "s",
               tcm: "t",
               tpk: "tpk1",
-              inputs: [{ id: "in0", type: "public", value: "cipher_addr" }],
+              inputs: [
+                { id: "in0", type: "private", value: "cipher_addr" },
+                { id: "in1", type: "public", value: "40000u64" },
+              ],
               outputs: [],
               program: "credits.aleo",
               function: "transfer_public_to_private",
@@ -1590,7 +1571,10 @@ describe("network/utils", () => {
               scm: "s",
               tcm: "t",
               tpk: "tpk1",
-              inputs: [{ id: "in0", type: "public", value: "cipher_addr" }],
+              inputs: [
+                { id: "in0", type: "private", value: "cipher_addr" },
+                { id: "in1", type: "public", value: "40000u64" },
+              ],
               outputs: [],
               program: "credits.aleo",
               function: "transfer_public_to_private",
@@ -1748,7 +1732,10 @@ describe("network/utils", () => {
               scm: "s",
               tcm: "t",
               tpk: "tpk1",
-              inputs: [{ id: "in0", type: "public", value: "cipher_addr" }],
+              inputs: [
+                { id: "in0", type: "private", value: "cipher_addr" },
+                { id: "in1", type: "public", value: "40000u64" },
+              ],
               outputs: [],
               program: "credits.aleo",
               function: "transfer_public_to_private",
@@ -2302,9 +2289,10 @@ describe("network/utils", () => {
                 tcm: "t",
                 tpk: "tpk1",
                 inputs: [
-                  { id: "in0", type: "public", value: "record_cipher" },
+                  { id: "in0", type: "public", value: recipientAddress },
                   { id: "in1", type: "public", value: "750000u128.public" },
-                  { id: "in2", type: "public", value: recipientAddress },
+                  { id: "in2", type: "record", tag: "record_tag_2" },
+                  { id: "in3", type: "private", value: "ciphertext_merkle_proof" },
                 ],
                 outputs: [],
                 program: "token_program.aleo",
@@ -2329,73 +2317,7 @@ describe("network/utils", () => {
       expect(mockDecryptCiphertext).not.toHaveBeenCalled();
     });
 
-    it("should decrypt recipient and amount for fully private transfers", async () => {
-      const recipientAddress = "aleo1privaterecipient789";
-      const record = getMockedRecord({
-        function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
-        transaction_id: "tx_private",
-        transition_index: 0,
-        program_name: "token_program.aleo",
-      });
-      mockGetTransactionById.mockResolvedValueOnce(
-        getMockedTransactionDetails(record.transaction_id, {
-          fee_value: 9000,
-          execution: {
-            transitions: [
-              {
-                id: "au1",
-                scm: "s",
-                tcm: "t",
-                tpk: "tpk_private",
-                inputs: [
-                  { id: "in1", type: "private", value: "ciphertext_recipient" },
-                  { id: "in2", type: "private", value: "ciphertext_amount" },
-                ],
-                outputs: [],
-                program: record.program_name,
-                function: "transfer_private",
-              },
-            ],
-          },
-        }),
-      );
-      mockDecryptCiphertext
-        .mockResolvedValueOnce({ plaintext: recipientAddress })
-        .mockResolvedValueOnce({ plaintext: "300000u64" });
-
-      const result = await getTokenOutDetails({
-        config: mockConfig,
-        record,
-        viewKey: mockViewKey,
-      });
-
-      expect(result).toEqual({
-        amount: new BigNumber(300000),
-        recipient: recipientAddress,
-        fee: new BigNumber(9000),
-      });
-      expect(mockDecryptCiphertext).toHaveBeenCalledTimes(2);
-      expect(mockDecryptCiphertext).toHaveBeenCalledWith({
-        config: mockConfig,
-        ciphertext: "ciphertext_recipient",
-        tpk: "tpk_private",
-        viewKey: mockViewKey,
-        programId: record.program_name,
-        functionName: EXPLORER_TRANSFER_TYPES.PRIVATE,
-        outputIndex: RECIPIENT_ARG_INDEX - 1,
-      });
-      expect(mockDecryptCiphertext).toHaveBeenCalledWith({
-        config: mockConfig,
-        ciphertext: "ciphertext_amount",
-        tpk: "tpk_private",
-        viewKey: mockViewKey,
-        programId: record.program_name,
-        functionName: EXPLORER_TRANSFER_TYPES.PRIVATE,
-        outputIndex: AMOUNT_ARG_INDEX - 1,
-      });
-    });
-
-    it("should return null amount when private transfer has too few inputs", async () => {
+    it("should return null fields when no amount-shaped argument follows the recipient", async () => {
       const recipientAddress = "aleo1plaintextrecipient";
       const record = getMockedRecord({
         function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
@@ -2430,13 +2352,109 @@ describe("network/utils", () => {
 
       expect(result).toEqual({
         amount: null,
-        recipient: recipientAddress,
+        recipient: null,
         fee: new BigNumber(1000),
       });
       expect(mockDecryptCiphertext).not.toHaveBeenCalled();
     });
 
-    it("should return null fields when decryption fails", async () => {
+    it("should decrypt private arguments and return the sent amount, recipient and fee", async () => {
+      const recipientAddress = "aleo1privaterecipient789";
+      const record = getMockedRecord({
+        function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
+        transaction_id: "tx_private",
+        transition_index: 0,
+        program_name: "arc20_token.aleo",
+      });
+      mockGetTransactionById.mockResolvedValueOnce(
+        getMockedTransactionDetails(record.transaction_id, {
+          fee_value: 9000,
+          execution: {
+            transitions: [
+              {
+                id: "au1",
+                scm: "s",
+                tcm: "t",
+                tpk: "tpk_private",
+                inputs: [
+                  { id: "in0", type: "record", tag: "record_tag_0" },
+                  { id: "in1", type: "private", value: "ciphertext_recipient" },
+                  { id: "in2", type: "private", value: "ciphertext_amount" },
+                ],
+                outputs: [],
+                program: record.program_name,
+                function: EXPLORER_TRANSFER_TYPES.PRIVATE,
+              },
+            ],
+          },
+        }),
+      );
+      mockDecryptCiphertext
+        .mockResolvedValueOnce({ plaintext: recipientAddress })
+        .mockResolvedValueOnce({ plaintext: "300000u128" });
+
+      const result = await getTokenOutDetails({
+        config: mockConfig,
+        record,
+        viewKey: mockViewKey,
+      });
+
+      expect(result).toEqual({
+        amount: new BigNumber(300000),
+        recipient: recipientAddress,
+        fee: new BigNumber(9000),
+      });
+    });
+
+    it("should tolerate a decryption failure on an argument it did not need", async () => {
+      const recipientAddress = "aleo1proofrecipient";
+      const record = getMockedRecord({
+        function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
+        transaction_id: "tx_trailing_proof",
+        transition_index: 0,
+      });
+      mockGetTransactionById.mockResolvedValueOnce(
+        getMockedTransactionDetails("tx_trailing_proof", {
+          fee_value: 3000,
+          execution: {
+            transitions: [
+              {
+                id: "au1",
+                scm: "s",
+                tcm: "t",
+                tpk: "tpk1",
+                inputs: [
+                  { id: "in0", type: "private", value: "cipher_recipient" },
+                  { id: "in1", type: "private", value: "cipher_amount" },
+                  { id: "in2", type: "private", value: "cipher_merkle_proof" },
+                ],
+                outputs: [],
+                program: "usdcx_stablecoin.aleo",
+                function: EXPLORER_TRANSFER_TYPES.PRIVATE,
+              },
+            ],
+          },
+        }),
+      );
+      mockDecryptCiphertext
+        .mockResolvedValueOnce({ plaintext: recipientAddress })
+        .mockResolvedValueOnce({ plaintext: "4200u64" })
+        .mockRejectedValueOnce(new Error("decrypt failed"));
+
+      const result = await getTokenOutDetails({
+        config: mockConfig,
+        record,
+        viewKey: mockViewKey,
+      });
+
+      expect(result).toEqual({
+        amount: new BigNumber(4200),
+        recipient: recipientAddress,
+        fee: new BigNumber(3000),
+      });
+    });
+
+    it("should propagate a decryption failure instead of reporting a zero-amount transfer", async () => {
       const record = getMockedRecord({
         function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
         transaction_id: "tx_decrypt_fail",
@@ -2453,7 +2471,7 @@ describe("network/utils", () => {
                 tcm: "t",
                 tpk: "tpk1",
                 inputs: [
-                  { id: "in0", type: "private", value: "cipher_record" },
+                  { id: "in0", type: "record", tag: "record_tag_0" },
                   { id: "in1", type: "private", value: "cipher_recipient" },
                   { id: "in2", type: "private", value: "cipher_amount" },
                 ],
@@ -2467,17 +2485,9 @@ describe("network/utils", () => {
       );
       mockDecryptCiphertext.mockRejectedValue(new Error("decrypt failed"));
 
-      const result = await getTokenOutDetails({
-        config: mockConfig,
-        record,
-        viewKey: mockViewKey,
-      });
-
-      expect(result).toEqual({
-        amount: null,
-        recipient: null,
-        fee: new BigNumber(2000),
-      });
+      await expect(
+        getTokenOutDetails({ config: mockConfig, record, viewKey: mockViewKey }),
+      ).rejects.toThrow("decrypt failed");
     });
 
     it("should trim transaction_id whitespace before fetching details", async () => {

--- a/libs/coin-modules/coin-aleo/src/network/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.ts
@@ -4,13 +4,10 @@ import { promiseAllBatched } from "@ledgerhq/coin-module-framework/promises";
 import { AleoApiConfigurationResetError } from "../errors";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import {
-  AMOUNT_ARG_INDEX,
   DEFAULT_RECORDS_PAGE_SIZE,
   DEFAULT_TOKENS_PAGE_SIZE,
   EXPLORER_TRANSFER_TYPES,
   PROGRAM_ID,
-  RECIPIENT_ARG_INDEX,
-  TOKEN_RECORD_NAME,
 } from "../constants";
 import { sdkClient } from "../network/sdk";
 import type {
@@ -26,9 +23,8 @@ import type {
   AleoTokenDetails,
 } from "../types";
 import {
-  isAleoAddressPlaintext,
-  isAleoAmountPlaintext,
-  normalizeAleoPlaintext,
+  findTransferArguments,
+  isParsableTransferFunction,
   parseAmount,
   parseMicrocredits,
 } from "../logic/utils";
@@ -361,7 +357,6 @@ export async function accessProvableApi({
 }
 
 type EnrichedRecordData = Pick<EnrichedPrivateRecord, "sender" | "recipient" | "value">;
-type AleoTransitionInputWithValue = AleoTransition["inputs"][number] & { value: string };
 
 // PUBLIC_TO_PRIVATE where sender is this address is already captured as a public OUT op.
 function shouldSkipPublicToPrivateRecord(rawRecord: AleoPrivateRecord, address: string): boolean {
@@ -389,50 +384,87 @@ function getRecordTransition(
   return recordTransition;
 }
 
-function hasValueField(
-  input: AleoTransition["inputs"][number] | null,
-): input is AleoTransitionInputWithValue {
-  return Boolean(input && "value" in input);
+function getInputValue(input: AleoTransition["inputs"][number]): string | null {
+  return "value" in input && input.value ? input.value : null;
 }
 
-function getTransferArguments(
-  isTokenRecord: boolean,
-  recordTransition: AleoTransition,
-  transactionId: string,
-): {
-  recipientArgument: AleoTransitionInputWithValue;
-  amountArgument: AleoTransitionInputWithValue;
-  recipientOutputIndex: number;
-  amountOutputIndex: number;
-} | null {
-  const recipientOutputIndex = isTokenRecord ? RECIPIENT_ARG_INDEX - 1 : RECIPIENT_ARG_INDEX;
-  const amountOutputIndex = isTokenRecord ? AMOUNT_ARG_INDEX - 1 : AMOUNT_ARG_INDEX;
-
-  if (recordTransition.inputs.length <= amountOutputIndex) {
-    log(
-      "aleo/sync",
-      `enrichPrivateRecord: transition has only ${recordTransition.inputs.length} inputs, expected at least ${amountOutputIndex + 1} for tx ${transactionId}`,
-    );
+/**
+ * Reads a transfer transition's recipient and amount, decrypting its private arguments only when
+ * the public ones are not enough.
+ *
+ * Returns null silently for non-transfer functions such as join/split.
+ */
+async function resolveTransferArguments({
+  config,
+  transition,
+  transactionId,
+  viewKey,
+}: {
+  config: AleoCoinConfig;
+  transition: AleoTransition;
+  transactionId: string;
+  viewKey: string;
+}): Promise<{ recipient: string; amount: string } | null> {
+  if (!isParsableTransferFunction(transition.function)) {
     return null;
   }
 
-  // Recipient and amount are contract function arguments, so their inputs must have a `value` field.
-  // Other input (missing `value` field) would indicate unexpected API data.
-  // In that case we skip processing rather than crash.
-  const recipientInput = recordTransition.inputs[recipientOutputIndex] ?? null;
-  const amountInput = recordTransition.inputs[amountOutputIndex] ?? null;
+  const inputValues = transition.inputs.map(input =>
+    input.type === "private" ? null : getInputValue(input),
+  );
+  const publicArguments = findTransferArguments(inputValues);
 
-  if (!hasValueField(recipientInput) || !hasValueField(amountInput)) {
-    log("aleo/sync", `enrichPrivateRecord: invalid transition arguments for tx ${transactionId}`);
-    return null;
+  if (publicArguments) {
+    return publicArguments;
   }
 
-  return {
-    recipientArgument: recipientInput,
-    amountArgument: amountInput,
-    recipientOutputIndex,
-    amountOutputIndex,
-  };
+  const decryptionErrors: unknown[] = [];
+
+  const plaintexts = await Promise.all(
+    transition.inputs.map((input, index) => {
+      const value = getInputValue(input);
+      if (!value) return null;
+      if (input.type !== "private") return value;
+
+      // The owning record's program/function cannot decrypt a batching wrapper's inputs.
+      return sdkClient
+        .decryptCiphertext({
+          config,
+          ciphertext: value,
+          tpk: transition.tpk,
+          viewKey,
+          programId: transition.program,
+          functionName: transition.function,
+          outputIndex: index,
+        })
+        .then(
+          result => result.plaintext,
+          (error: unknown) => {
+            decryptionErrors.push(error);
+            return null;
+          },
+        );
+    }),
+  );
+
+  const transferArguments = findTransferArguments(plaintexts);
+
+  if (transferArguments) {
+    return transferArguments;
+  }
+
+  // Arguments we never needed (trailing merkle proofs) may fail to decrypt; a failure only matters
+  // when it leaves the transfer unreadable, where reporting a zero amount would be worse.
+  if (decryptionErrors.length > 0) {
+    throw decryptionErrors[0];
+  }
+
+  log(
+    "aleo/sync",
+    `resolveTransferArguments: no recipient/amount arguments found in ${transition.program}/${transition.function} for tx ${transactionId}`,
+  );
+
+  return null;
 }
 
 async function enrichOutgoingRecord({
@@ -450,54 +482,29 @@ async function enrichOutgoingRecord({
   viewKey: string;
   address: string;
 }): Promise<EnrichedRecordData | null> {
-  const isTokenRecord = rawRecord.record_name.toLowerCase() === TOKEN_RECORD_NAME.toLowerCase();
-  const transferArguments = getTransferArguments(isTokenRecord, recordTransition, transactionId);
+  const transferArguments = await resolveTransferArguments({
+    config,
+    transition: recordTransition,
+    transactionId,
+    viewKey,
+  });
+
   if (!transferArguments) {
     return null;
   }
 
-  const { recipientArgument, amountArgument, recipientOutputIndex, amountOutputIndex } =
-    transferArguments;
-
-  if (rawRecord.function_name === EXPLORER_TRANSFER_TYPES.PRIVATE_TO_PUBLIC) {
-    // The recipient and amount stay public for private-to-public transfers,
-    // so we can build the outgoing operation directly from the transition inputs.
-    if (recipientArgument.value === address) {
-      return null;
-    }
-
-    return {
-      sender: address,
-      recipient: recipientArgument.value,
-      value: new BigNumber(parseMicrocredits(amountArgument.value)),
-    };
+  // A private-to-public transfer to our own public balance is already the public side of this op.
+  if (
+    rawRecord.function_name === EXPLORER_TRANSFER_TYPES.PRIVATE_TO_PUBLIC &&
+    transferArguments.recipient === address
+  ) {
+    return null;
   }
-
-  const [recipientData, amountData] = await Promise.all([
-    sdkClient.decryptCiphertext({
-      config,
-      ciphertext: recipientArgument.value,
-      tpk: recordTransition.tpk,
-      viewKey,
-      programId: rawRecord.program_name,
-      functionName: rawRecord.function_name,
-      outputIndex: recipientOutputIndex,
-    }),
-    sdkClient.decryptCiphertext({
-      config,
-      ciphertext: amountArgument.value,
-      tpk: recordTransition.tpk,
-      viewKey,
-      programId: rawRecord.program_name,
-      functionName: rawRecord.function_name,
-      outputIndex: amountOutputIndex,
-    }),
-  ]);
 
   return {
     sender: address,
-    recipient: recipientData.plaintext,
-    value: new BigNumber(parseMicrocredits(amountData.plaintext)),
+    recipient: transferArguments.recipient,
+    value: new BigNumber(parseMicrocredits(transferArguments.amount)),
   };
 }
 
@@ -705,32 +712,24 @@ export const patchPublicOperations = async ({
     else {
       const txDetails = await apiClient.getTransactionById(config, operation.hash);
       const recordTransition = txDetails.execution.transitions[0] ?? null;
-      const recipientInput = recordTransition?.inputs[0] ?? {};
-      const recipientArgument = "value" in recipientInput ? recipientInput : null;
 
       // if this is public to private, our account is sender, so it's possible to decrypt the recipient address
-      // arguments of transfer_public_to_private function are (address_ciphertext, amount)
-      if (
-        recipientArgument &&
-        operation.extra.functionId === EXPLORER_TRANSFER_TYPES.PUBLIC_TO_PRIVATE
-      ) {
-        const shouldMarkAsPatched = latestPrivateRecordBlockHeight >= txDetails.block_height;
-        const programId =
-          operation.extra.programId ?? recordTransition.program ?? PROGRAM_ID.CREDITS;
+      const transferArguments =
+        recordTransition && operation.extra.functionId === EXPLORER_TRANSFER_TYPES.PUBLIC_TO_PRIVATE
+          ? await resolveTransferArguments({
+              config,
+              transition: recordTransition,
+              transactionId: operation.hash,
+              viewKey,
+            })
+          : null;
 
-        const recipientData = await sdkClient.decryptCiphertext({
-          config,
-          ciphertext: recipientArgument.value,
-          tpk: recordTransition.tpk,
-          viewKey,
-          programId,
-          functionName: EXPLORER_TRANSFER_TYPES.PUBLIC_TO_PRIVATE,
-          outputIndex: 0,
-        });
+      if (transferArguments) {
+        const shouldMarkAsPatched = latestPrivateRecordBlockHeight >= txDetails.block_height;
 
         patchedOperations.push({
           ...operation,
-          recipients: [recipientData.plaintext],
+          recipients: [transferArguments.recipient],
           extra: {
             ...operation.extra,
             // record scanner may be delayed, so we can consider the operation as patched only when
@@ -768,7 +767,8 @@ export async function getTokenOutDetails({
   record: AleoPrivateRecord;
   viewKey: string;
 }): Promise<{ amount: BigNumber | null; recipient: string | null; fee: BigNumber }> {
-  const txDetails = await apiClient.getTransactionById(config, record.transaction_id.trim());
+  const transactionId = record.transaction_id.trim();
+  const txDetails = await apiClient.getTransactionById(config, transactionId);
   const fee = new BigNumber(txDetails.fee_value);
   const transition = txDetails.execution?.transitions[record.transition_index];
 
@@ -779,68 +779,20 @@ export async function getTokenOutDetails({
       fee,
     };
 
-  // token programs have different argument indices
-  const recipientOutputIndex = RECIPIENT_ARG_INDEX - 1;
-  const amountOutputIndex = AMOUNT_ARG_INDEX - 1;
+  const transferArguments = await resolveTransferArguments({
+    config,
+    transition,
+    transactionId,
+    viewKey,
+  });
 
-  const plaintexts = transition.inputs.flatMap(inp =>
-    inp.type === "public" ? [normalizeAleoPlaintext(inp.value)] : [],
-  );
-  const recipient = plaintexts.find(isAleoAddressPlaintext) ?? null;
-
-  // For private_to_public the amount argument is already in plaintext at AMOUNT_ARG_INDEX.
-  if (record.function_name === EXPLORER_TRANSFER_TYPES.PRIVATE_TO_PUBLIC) {
-    // Amount is already in plaintext — scan inputs by pattern instead of assuming a
-    // fixed argument index (token programs may differ from credits.aleo).
-    const amountStr = plaintexts.find(isAleoAmountPlaintext) ?? null;
-    return { amount: amountStr ? parseAmount(amountStr) : null, recipient, fee };
+  if (!transferArguments) {
+    return { amount: null, recipient: null, fee };
   }
-
-  // Fully private transfer: decrypt recipient and amount arguments using the token program's
-  // argument indices (recipientOutputIndex/amountOutputIndex already account for layout differences).
-  if (transition.inputs.length <= amountOutputIndex) {
-    return { amount: null, recipient, fee };
-  }
-
-  const decryptTransitionArgument = async (argumentIndex: number): Promise<string | null> => {
-    const input = transition.inputs[argumentIndex];
-    if (!input || !("value" in input) || !input.value) return null;
-
-    try {
-      const dec = await sdkClient.decryptCiphertext({
-        config,
-        ciphertext: input.value,
-        tpk: transition.tpk,
-        viewKey,
-        programId: record.program_name,
-        functionName: record.function_name,
-        outputIndex: argumentIndex,
-      });
-      return dec.plaintext;
-    } catch {
-      return null;
-    }
-  };
-
-  const [recipientPlaintext, amountPlaintext] = await Promise.all([
-    decryptTransitionArgument(recipientOutputIndex),
-    decryptTransitionArgument(amountOutputIndex),
-  ]);
-
-  const resolvedRecipient =
-    recipient ??
-    (recipientPlaintext && isAleoAddressPlaintext(recipientPlaintext)
-      ? normalizeAleoPlaintext(recipientPlaintext)
-      : null);
-
-  const amount =
-    amountPlaintext && isAleoAmountPlaintext(amountPlaintext)
-      ? normalizeAleoPlaintext(amountPlaintext)
-      : null;
 
   return {
-    amount: amount ? parseAmount(amount) : null,
-    recipient: resolvedRecipient,
+    amount: parseAmount(transferArguments.amount),
+    recipient: transferArguments.recipient,
     fee,
   };
 }

--- a/libs/coin-modules/coin-aleo/src/types/api.ts
+++ b/libs/coin-modules/coin-aleo/src/types/api.ts
@@ -10,6 +10,16 @@ export type AleoTransitionValue =
       id: string;
       type: "record";
       tag: string;
+    }
+  | {
+      id: string;
+      type: "record_with_dynamic_id";
+      tag: string;
+      dynamic_id: string;
+    }
+  | {
+      id: string;
+      type: "external_record" | "record_dynamic";
     };
 
 export interface AleoTransition {
@@ -43,6 +53,7 @@ export interface AleoPublicTransaction {
   block_timestamp: string;
   function_id: string;
   amount: number;
+  amount_u128?: string;
   sender_address: string;
   recipient_address: string;
   program_id: string;


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR extends Aleo's private-operation parsing to support ARC-20 tokens:

- fixed `getTransferArguments`/`getTokenOutDetails` to locate the recipient/amount arguments dynamically by scanning for the first input carrying a `value` field instead of assuming fixed indices
- added support for new transition input shapes (`record_with_dynamic_id`, `external_record`, `record_dynamic`).
- explicitly excluded record-consolidation functions (`join`, `split`, `fee_private`) from transfer parsing since their transitions carry no recipient/amount. 
- fixed native-token amount parsing to prefer `amount_u128` (a string) over the `amount` number field, since large ARC-20 balances can exceed JS's safe integer range
- stopped flagging zero-value transactions as invalid (zero is a valid on-chain amount).


|  <img width="1800" height="1169" alt="arc20-list-operations" src="https://github.com/user-attachments/assets/8a9d158a-fe37-4d09-8ca6-bb51bf392aa5" /> | <img width="1800" height="1169" alt="arc20-list-operations-2" src="https://github.com/user-attachments/assets/4cd0d79b-ba53-44dc-be0a-2bb66c9dc977" /> |
|---|--|

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- https://ledgerhq.atlassian.net/browse/LIVE-35549