### PR TITLE
[LWDM] fix(contacts): align intro and add-contact padding (LIVE-35850)

### DIFF
--- a/.changeset/calm-contacts-align.md
+++ b/.changeset/calm-contacts-align.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-contacts-add-contact": minor
+"@features/flow-contacts-introduction": minor
+---
+
+Remove the Contacts introduction secondary action and align the native add-contact form padding.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -355,21 +355,6 @@ describe("Contacts integration", () => {
     expect(screen.getByTestId("contacts-list")).toBeVisible();
   });
 
-  it("should defer the feature introduction on Maybe later without persisting dismissal", async () => {
-    mockNavigate.mockClear();
-
-    const { user, store } = renderContactsScreen({
-      settings: { hasDismissedContactsFeatureIntroduction: false },
-    });
-
-    expect(screen.getByTestId("contacts-feature-introduction-dialog")).toBeVisible();
-
-    await user.click(screen.getByTestId("contacts-feature-introduction-secondary"));
-
-    expect(mockNavigate).toHaveBeenCalledWith(-1);
-    expect(store.getState().settings.hasDismissedContactsFeatureIntroduction).toBe(false);
-  });
-
   it("should render populated Me detail on load when populated contacts are persisted", () => {
     renderContactsScreen(populatedContactsPageState);
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -317,7 +317,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
   const onCompleteFeatureIntroduction = useCallback(() => {
     featureIntroductionState.dismiss();
   }, [featureIntroductionState]);
-  const onDeferFeatureIntroduction = useCallback(() => {
+  const onCloseFeatureIntroduction = useCallback(() => {
     navigate(-1);
   }, [navigate]);
 
@@ -343,9 +343,8 @@ export function useContactsViewModel(): ContactsPageViewModel {
       description: t("contacts.featureIntroduction.description"),
       highlights: featureIntroductionHighlights,
       primaryActionLabel: t("contacts.featureIntroduction.primaryAction"),
-      secondaryActionLabel: t("contacts.featureIntroduction.secondaryAction"),
       onComplete: onCompleteFeatureIntroduction,
-      onDefer: onDeferFeatureIntroduction,
+      onClose: onCloseFeatureIntroduction,
     },
     ledgerSyncIntroduction: {
       isOpen: isLedgerSyncIntroductionOpen,

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9446,7 +9446,6 @@
       "title": "Introducing Contacts",
       "description": "Your address book for crypto — save the wallets you send to, all in one place.",
       "primaryAction": "Try contacts",
-      "secondaryAction": "Maybe later",
       "highlights": {
         "saveAddresses": {
           "title": "Save addresses once",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10360,7 +10360,6 @@
       "title": "Introducing Contacts",
       "description": "Your address book for crypto — save the wallets you send to, all in one place.",
       "primaryAction": "Try contacts",
-      "secondaryAction": "Maybe later",
       "highlights": {
         "saveAddresses": {
           "title": "Save addresses once",

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/ContactsFeatureIntroduction.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/ContactsFeatureIntroduction.integration.test.tsx
@@ -84,26 +84,6 @@ describe("Contacts feature introduction integration", () => {
     });
   });
 
-  it("should defer the introduction from Maybe later without persisting dismissal", async () => {
-    const { user, store } = render(<ContactsFeatureIntroductionTestApp />, {
-      navigationInitialState: contactsNavigationState,
-      overrideInitialState: withFlagOverrides(
-        { lwmContacts: { enabled: true, params: { newBadge: false } } },
-        state => ({
-          ...state,
-          settings: { ...state.settings, hasDismissedContactsFeatureIntroduction: false },
-        }),
-      ),
-    });
-
-    await user.press(screen.getByTestId("contacts-feature-introduction-secondary"));
-
-    await waitFor(() => {
-      expect(store.getState().settings.hasDismissedContactsFeatureIntroduction).toBe(false);
-      expect(screen.getByTestId("my-wallet-home")).toBeVisible();
-    });
-  });
-
   it("should navigate to the introduction from My Wallet when the feature flag is enabled", async () => {
     const { user } = render(<MyWalletNavigator />, {
       overrideInitialState: withFlagOverrides(

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/ContactsAddContactDrawerSheet.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/ContactsAddContactDrawerSheet.test.tsx
@@ -76,6 +76,9 @@ describe("ContactsAddContactDrawerSheet", () => {
     expect(screen.getByText("0/32")).toBeVisible();
     expect(screen.getByRole("button", { name: "Confirm name" })).toBeDisabled();
     expect(screen.getByTestId("contacts-add-contact-name-input")).toHaveProp("autoFocus", true);
+    expect(screen.getByTestId("contacts-add-contact-form")).not.toHaveStyle({
+      paddingHorizontal: 16,
+    });
   });
 
   it("should cap the contact name at 32 characters", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsFeatureIntroductionSheet/ContactsFeatureIntroductionSheet.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsFeatureIntroductionSheet/ContactsFeatureIntroductionSheet.test.tsx
@@ -12,7 +12,7 @@ const highlights = CONTACTS_FEATURE_INTRODUCTION_HIGHLIGHTS.map(({ icon, transla
 describe("ContactsFeatureIntroductionSheet", () => {
   it("should call onComplete once from Try contacts", async () => {
     const onComplete = jest.fn();
-    const onDefer = jest.fn();
+    const onClose = jest.fn();
     const { user } = render(
       <ContactsFeatureIntroductionSheet
         isOpen
@@ -20,9 +20,8 @@ describe("ContactsFeatureIntroductionSheet", () => {
         description="Your address book for crypto."
         highlights={highlights}
         primaryActionLabel="Try contacts"
-        secondaryActionLabel="Maybe later"
         onComplete={onComplete}
-        onDefer={onDefer}
+        onClose={onClose}
       />,
     );
 
@@ -31,12 +30,13 @@ describe("ContactsFeatureIntroductionSheet", () => {
     await user.press(screen.getByTestId("contacts-feature-introduction-primary"));
 
     expect(onComplete).toHaveBeenCalledTimes(1);
-    expect(onDefer).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("contacts-feature-introduction-secondary")).toBeNull();
   });
 
-  it("should call onDefer once from Maybe later", async () => {
+  it("should call onClose once from the sheet header", async () => {
     const onComplete = jest.fn();
-    const onDefer = jest.fn();
+    const onClose = jest.fn();
     const { user } = render(
       <ContactsFeatureIntroductionSheet
         isOpen
@@ -44,15 +44,14 @@ describe("ContactsFeatureIntroductionSheet", () => {
         description="Your address book for crypto."
         highlights={highlights}
         primaryActionLabel="Try contacts"
-        secondaryActionLabel="Maybe later"
         onComplete={onComplete}
-        onDefer={onDefer}
+        onClose={onClose}
       />,
     );
 
-    await user.press(screen.getByTestId("contacts-feature-introduction-secondary"));
+    await user.press(screen.getByTestId("bottom-sheet-header-close-button"));
 
-    expect(onDefer).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
     expect(onComplete).not.toHaveBeenCalled();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsFeatureIntroductionSheet/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsFeatureIntroductionSheet/index.tsx
@@ -13,22 +13,22 @@ export type ContactsFeatureIntroductionSheetProps = ContactsFeatureIntroduction;
 export function ContactsFeatureIntroductionSheet({
   isOpen,
   onComplete,
-  onDefer,
+  onClose: onCloseCallback,
   ...contentProps
 }: ContactsFeatureIntroductionSheetProps): React.JSX.Element {
   const { bottom: bottomInset } = useSafeAreaInsets();
-  const { complete, defer, onClose } = useContactsFeatureIntroductionActions({
+  const { complete, onClose } = useContactsFeatureIntroductionActions({
     isOpen,
     onComplete,
-    onDefer,
+    onClose: onCloseCallback,
   });
 
   return (
     <QueuedBottomSheet
       isRequestingToBeOpened={isOpen}
       onClose={onClose}
-      onHeaderClosePressed={defer}
-      onBackdropPress={defer}
+      onHeaderClosePressed={onClose}
+      onBackdropPress={onClose}
       testID="contacts-feature-introduction-drawer"
       enableDynamicSizing
       // iOS: allow the sheet to grow with content; uncapped on Android to avoid excess empty space.
@@ -37,7 +37,6 @@ export function ContactsFeatureIntroductionSheet({
       <ContactsFeatureIntroductionContent
         isOpen={isOpen}
         onComplete={complete}
-        onDefer={defer}
         bottomInset={bottomInset}
         {...contentProps}
       />

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsPageContent/ContactsPageContent.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsPageContent/ContactsPageContent.test.tsx
@@ -48,9 +48,8 @@ function createViewModel({
           description: "Your address book for crypto.",
           highlights: [],
           primaryActionLabel: "Try contacts",
-          secondaryActionLabel: "Maybe later",
           onComplete: jest.fn(),
-          onDefer: jest.fn(),
+          onClose: jest.fn(),
         }
       : createClosedContactsFeatureIntroduction(),
     ledgerSyncIntroduction: {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageViewModel.ts
@@ -69,7 +69,7 @@ export function useContactsPageViewModel(): ContactsPageViewModel {
   const onCompleteFeatureIntroduction = useCallback(() => {
     featureIntroductionState.dismiss();
   }, [featureIntroductionState]);
-  const onDeferFeatureIntroduction = useCallback(() => {
+  const onCloseFeatureIntroduction = useCallback(() => {
     navigation.goBack();
   }, [navigation]);
 
@@ -99,9 +99,8 @@ export function useContactsPageViewModel(): ContactsPageViewModel {
       description: t("contacts.featureIntroduction.description"),
       highlights: featureIntroductionHighlights,
       primaryActionLabel: t("contacts.featureIntroduction.primaryAction"),
-      secondaryActionLabel: t("contacts.featureIntroduction.secondaryAction"),
       onComplete: onCompleteFeatureIntroduction,
-      onDefer: onDeferFeatureIntroduction,
+      onClose: onCloseFeatureIntroduction,
     },
     ledgerSyncIntroduction: {
       isOpen: isLedgerSyncIntroductionOpen,

--- a/features/flow/flow-contacts-add-contact/src/components/ContactsContactNameDrawer/ContactsContactNameDrawerContent.native.tsx
+++ b/features/flow/flow-contacts-add-contact/src/components/ContactsContactNameDrawer/ContactsContactNameDrawerContent.native.tsx
@@ -54,7 +54,7 @@ export function ContactsContactNameDrawerContent({
       {isOpen ? (
         <Box lx={{ gap: "s24" }}>
           <BottomSheetHeader />
-          <Box lx={{ gap: "s16", paddingHorizontal: "s16" }}>
+          <Box testID="contacts-add-contact-form" lx={{ gap: "s16" }}>
             <Text typography="heading3SemiBold" lx={{ color: "base" }}>
               {labels.title}
             </Text>

--- a/features/flow/flow-contacts-introduction/src/screens/FeatureIntroduction/ContactsFeatureIntroductionContent.native.test.tsx
+++ b/features/flow/flow-contacts-introduction/src/screens/FeatureIntroduction/ContactsFeatureIntroductionContent.native.test.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react-native";
+import { CONTACTS_FEATURE_INTRODUCTION_HERO_IMAGE } from "./assets";
 import { ContactsFeatureIntroductionContent } from "./ContactsFeatureIntroductionContent";
 
 function renderContent(isOpen = true) {
   const onComplete = jest.fn();
-  const onDefer = jest.fn();
 
   render(
     <ContactsFeatureIntroductionContent
@@ -15,29 +15,29 @@ function renderContent(isOpen = true) {
         { icon: "Contact", title: "Save recipients", description: "Reuse an address safely." },
       ]}
       primaryActionLabel="Get started"
-      secondaryActionLabel="Not now"
-      heroImageSrc="https://example.com/contacts.webp"
       bottomInset={12}
       onComplete={onComplete}
-      onDefer={onDefer}
     />,
   );
 
-  return { onComplete, onDefer };
+  return { onComplete };
 }
 
 describe("ContactsFeatureIntroductionContent", () => {
-  it("should render the native introduction and dispatch its actions", () => {
-    const { onComplete, onDefer } = renderContent();
+  it("should render the native introduction with its bundled hero and complete it", () => {
+    const { onComplete } = renderContent();
 
     expect(screen.getByTestId("contacts-feature-introduction-hero")).toBeVisible();
+    expect(screen.getByTestId("contacts-feature-introduction-hero-image")).toHaveProp(
+      "source",
+      CONTACTS_FEATURE_INTRODUCTION_HERO_IMAGE,
+    );
     expect(screen.getByText("Save recipients")).toBeVisible();
+    expect(screen.queryByTestId("contacts-feature-introduction-secondary")).toBeNull();
 
     fireEvent.press(screen.getByTestId("contacts-feature-introduction-primary"));
-    fireEvent.press(screen.getByTestId("contacts-feature-introduction-secondary"));
 
     expect(onComplete).toHaveBeenCalledTimes(1);
-    expect(onDefer).toHaveBeenCalledTimes(1);
   });
 
   it("should hide the introduction content when it is closed", () => {

--- a/features/flow/flow-contacts-introduction/src/screens/FeatureIntroduction/ContactsFeatureIntroductionContent.native.tsx
+++ b/features/flow/flow-contacts-introduction/src/screens/FeatureIntroduction/ContactsFeatureIntroductionContent.native.tsx
@@ -11,11 +11,9 @@ export function ContactsFeatureIntroductionContent({
   description,
   highlights,
   primaryActionLabel,
-  secondaryActionLabel,
   heroImageSrc,
   bottomInset,
   onComplete,
-  onDefer,
 }: ContactsFeatureIntroductionContentProps): React.JSX.Element {
   const heroImage = heroImageSrc ?? CONTACTS_FEATURE_INTRODUCTION_HERO_IMAGE;
 
@@ -41,6 +39,7 @@ export function ContactsFeatureIntroductionContent({
               lx={{ backgroundColor: "muted" }}
             >
               <Image
+                testID="contacts-feature-introduction-hero-image"
                 source={heroImage as ImageSourcePropType}
                 accessibilityIgnoresInvertColors
                 style={{ width: "100%", height: "100%" }}
@@ -72,7 +71,7 @@ export function ContactsFeatureIntroductionContent({
                 </Box>
               );
             })}
-            <Box lx={{ gap: "s12", paddingTop: "s8" }}>
+            <Box lx={{ paddingTop: "s8" }}>
               <Button
                 appearance="base"
                 size="lg"
@@ -81,15 +80,6 @@ export function ContactsFeatureIntroductionContent({
                 testID="contacts-feature-introduction-primary"
               >
                 {primaryActionLabel}
-              </Button>
-              <Button
-                appearance="gray"
-                size="lg"
-                isFull
-                onPress={onDefer}
-                testID="contacts-feature-introduction-secondary"
-              >
-                {secondaryActionLabel}
               </Button>
             </Box>
           </Box>

--- a/features/flow/flow-contacts-introduction/src/screens/FeatureIntroduction/ContactsFeatureIntroductionDialog.web.test.tsx
+++ b/features/flow/flow-contacts-introduction/src/screens/FeatureIntroduction/ContactsFeatureIntroductionDialog.web.test.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { CONTACTS_FEATURE_INTRODUCTION_HERO_IMAGE } from "./assets";
 import { ContactsFeatureIntroductionDialog } from "./ContactsFeatureIntroductionDialog";
 
 function renderDialog() {
   const onComplete = jest.fn();
-  const onDefer = jest.fn();
+  const onClose = jest.fn();
 
   render(
     <ContactsFeatureIntroductionDialog
@@ -16,39 +17,31 @@ function renderDialog() {
         { icon: "Contact", title: "Save recipients", description: "Reuse an address safely." },
       ]}
       primaryActionLabel="Get started"
-      secondaryActionLabel="Not now"
-      heroImageSrc="https://example.com/contacts.webp"
       onComplete={onComplete}
-      onDefer={onDefer}
+      onClose={onClose}
     />,
   );
 
-  return { onComplete, onDefer };
+  return { onComplete, onClose };
 }
 
 describe("ContactsFeatureIntroductionDialog", () => {
   it("should render the feature content and complete the introduction", async () => {
-    const { onComplete, onDefer } = renderDialog();
+    const { onComplete, onClose } = renderDialog();
     const user = userEvent.setup();
 
     expect(screen.getByTestId("contacts-feature-introduction-dialog")).toBeVisible();
     expect(screen.getByTestId("contacts-feature-introduction-hero")).toBeVisible();
+    expect(
+      screen.getByTestId("contacts-feature-introduction-hero").querySelector("img"),
+    ).toHaveAttribute("src", CONTACTS_FEATURE_INTRODUCTION_HERO_IMAGE);
     expect(screen.getByText("Save recipients")).toBeVisible();
+    expect(screen.queryByTestId("contacts-feature-introduction-secondary")).toBeNull();
 
     await user.click(screen.getByTestId("contacts-feature-introduction-primary"));
     await user.click(screen.getByTestId("contacts-feature-introduction-primary"));
 
     expect(onComplete).toHaveBeenCalledTimes(1);
-    expect(onDefer).not.toHaveBeenCalled();
-  });
-
-  it("should defer the introduction from the secondary action", async () => {
-    const { onComplete, onDefer } = renderDialog();
-    const user = userEvent.setup();
-
-    await user.click(screen.getByTestId("contacts-feature-introduction-secondary"));
-
-    expect(onDefer).toHaveBeenCalledTimes(1);
-    expect(onComplete).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/features/flow/flow-contacts-introduction/src/screens/FeatureIntroduction/ContactsFeatureIntroductionDialog.web.tsx
+++ b/features/flow/flow-contacts-introduction/src/screens/FeatureIntroduction/ContactsFeatureIntroductionDialog.web.tsx
@@ -11,15 +11,14 @@ export function ContactsFeatureIntroductionDialog({
   description,
   highlights,
   primaryActionLabel,
-  secondaryActionLabel,
   heroImageSrc,
   onComplete,
-  onDefer,
+  onClose: onCloseCallback,
 }: ContactsFeatureIntroduction): React.ReactNode {
-  const { complete, defer, onClose } = useContactsFeatureIntroductionActions({
+  const { complete, onClose } = useContactsFeatureIntroductionActions({
     isOpen,
     onComplete,
-    onDefer,
+    onClose: onCloseCallback,
   });
   const heroImage = heroImageSrc ?? CONTACTS_FEATURE_INTRODUCTION_HERO_IMAGE;
 
@@ -36,7 +35,7 @@ export function ContactsFeatureIntroductionDialog({
         className="max-h-[90vh] w-[480px] bg-canvas-sheet p-0"
         data-testid="contacts-feature-introduction-dialog"
       >
-        <DialogHeader density="expanded" onClose={defer} />
+        <DialogHeader density="expanded" onClose={onClose} />
         <DialogBody className="flex min-h-0 flex-1 flex-col gap-24 overflow-hidden px-24 pb-24">
           <ContactsFeatureIntroductionDialogContent
             title={title}
@@ -44,7 +43,7 @@ export function ContactsFeatureIntroductionDialog({
             highlights={highlights}
             heroImage={heroImage}
           />
-          <div className="flex w-full shrink-0 flex-col items-center gap-16">
+          <div className="flex w-full shrink-0 flex-col items-center">
             <Button
               appearance="base"
               size="lg"
@@ -53,15 +52,6 @@ export function ContactsFeatureIntroductionDialog({
               data-testid="contacts-feature-introduction-primary"
             >
               {primaryActionLabel}
-            </Button>
-            <Button
-              appearance="gray"
-              size="lg"
-              onClick={defer}
-              className="w-full"
-              data-testid="contacts-feature-introduction-secondary"
-            >
-              {secondaryActionLabel}
             </Button>
           </div>
         </DialogBody>

--- a/features/flow/flow-contacts-introduction/src/screens/FeatureIntroduction/types.ts
+++ b/features/flow/flow-contacts-introduction/src/screens/FeatureIntroduction/types.ts
@@ -1,6 +1,6 @@
 import type { ContactsFeatureIntroduction } from "../../state/types";
 
-export type ContactsFeatureIntroductionContentProps = ContactsFeatureIntroduction &
+export type ContactsFeatureIntroductionContentProps = Omit<ContactsFeatureIntroduction, "onClose"> &
   Readonly<{
     bottomInset: number;
   }>;

--- a/features/flow/flow-contacts-introduction/src/screens/FeatureIntroduction/useContactsFeatureIntroductionActions.ts
+++ b/features/flow/flow-contacts-introduction/src/screens/FeatureIntroduction/useContactsFeatureIntroductionActions.ts
@@ -3,27 +3,26 @@ import { useCallback, useEffect, useRef } from "react";
 export type UseContactsFeatureIntroductionActionsInput = Readonly<{
   isOpen: boolean;
   onComplete: () => void;
-  onDefer: () => void;
+  onClose: () => void;
 }>;
 
 export type ContactsFeatureIntroductionActions = Readonly<{
   complete: () => void;
-  defer: () => void;
   onClose: () => void;
 }>;
 
 export function useContactsFeatureIntroductionActions({
   isOpen,
   onComplete,
-  onDefer,
+  onClose: onCloseCallback,
 }: UseContactsFeatureIntroductionActionsInput): ContactsFeatureIntroductionActions {
   const hasCompleted = useRef(false);
-  const hasDeferred = useRef(false);
+  const hasClosed = useRef(false);
 
   useEffect(() => {
     if (isOpen) {
       hasCompleted.current = false;
-      hasDeferred.current = false;
+      hasClosed.current = false;
     }
   }, [isOpen]);
 
@@ -36,20 +35,14 @@ export function useContactsFeatureIntroductionActions({
     onComplete();
   }, [onComplete]);
 
-  const defer = useCallback(() => {
-    if (hasDeferred.current) {
+  const onClose = useCallback(() => {
+    if (hasCompleted.current || hasClosed.current) {
       return;
     }
 
-    hasDeferred.current = true;
-    onDefer();
-  }, [onDefer]);
+    hasClosed.current = true;
+    onCloseCallback();
+  }, [onCloseCallback]);
 
-  const onClose = useCallback(() => {
-    if (!hasCompleted.current) {
-      defer();
-    }
-  }, [defer]);
-
-  return { complete, defer, onClose };
+  return { complete, onClose };
 }

--- a/features/flow/flow-contacts-introduction/src/screens/FeatureIntroduction/useContactsFeatureIntroductionActions.web.test.tsx
+++ b/features/flow/flow-contacts-introduction/src/screens/FeatureIntroduction/useContactsFeatureIntroductionActions.web.test.tsx
@@ -2,11 +2,11 @@ import { act, renderHook } from "@testing-library/react";
 import { useContactsFeatureIntroductionActions } from "./useContactsFeatureIntroductionActions";
 
 describe("useContactsFeatureIntroductionActions", () => {
-  it("should call complete once and not defer when the introduction closes after completion", () => {
+  it("should call complete once and not close when the introduction closes after completion", () => {
     const onComplete = jest.fn();
-    const onDefer = jest.fn();
+    const onClose = jest.fn();
     const { result } = renderHook(() =>
-      useContactsFeatureIntroductionActions({ isOpen: true, onComplete, onDefer }),
+      useContactsFeatureIntroductionActions({ isOpen: true, onComplete, onClose }),
     );
 
     act(() => {
@@ -16,29 +16,29 @@ describe("useContactsFeatureIntroductionActions", () => {
     });
 
     expect(onComplete).toHaveBeenCalledTimes(1);
-    expect(onDefer).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
   });
 
-  it("should defer once and reset its actions when the introduction reopens", () => {
+  it("should close once and reset its actions when the introduction reopens", () => {
     const onComplete = jest.fn();
-    const onDefer = jest.fn();
+    const onClose = jest.fn();
     const { result, rerender } = renderHook(
-      ({ isOpen }) => useContactsFeatureIntroductionActions({ isOpen, onComplete, onDefer }),
+      ({ isOpen }) => useContactsFeatureIntroductionActions({ isOpen, onComplete, onClose }),
       { initialProps: { isOpen: true } },
     );
 
     act(() => {
-      result.current.defer();
+      result.current.onClose();
       result.current.onClose();
     });
-    expect(onDefer).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
 
     rerender({ isOpen: false });
     rerender({ isOpen: true });
     act(() => {
-      result.current.defer();
+      result.current.onClose();
     });
 
-    expect(onDefer).toHaveBeenCalledTimes(2);
+    expect(onClose).toHaveBeenCalledTimes(2);
   });
 });

--- a/features/flow/flow-contacts-introduction/src/state/createClosedContactsFeatureIntroduction.ts
+++ b/features/flow/flow-contacts-introduction/src/state/createClosedContactsFeatureIntroduction.ts
@@ -2,7 +2,7 @@ import type { ContactsFeatureIntroduction } from "./types";
 
 export function createClosedContactsFeatureIntroduction(
   onComplete: () => void = () => undefined,
-  onDefer: () => void = () => undefined,
+  onClose: () => void = () => undefined,
 ): ContactsFeatureIntroduction {
   return {
     isOpen: false,
@@ -10,8 +10,7 @@ export function createClosedContactsFeatureIntroduction(
     description: "",
     highlights: [],
     primaryActionLabel: "",
-    secondaryActionLabel: "",
     onComplete,
-    onDefer,
+    onClose,
   };
 }

--- a/features/flow/flow-contacts-introduction/src/state/types.ts
+++ b/features/flow/flow-contacts-introduction/src/state/types.ts
@@ -21,8 +21,7 @@ export type ContactsFeatureIntroduction = Readonly<{
   description: string;
   highlights: readonly ContactsFeatureIntroductionHighlight[];
   primaryActionLabel: string;
-  secondaryActionLabel: string;
   heroImageSrc?: string;
   onComplete: () => void;
-  onDefer: () => void;
+  onClose: () => void;
 }>;

--- a/features/flow/flow-contacts-list/src/ContactsListView.web.test.tsx
+++ b/features/flow/flow-contacts-list/src/ContactsListView.web.test.tsx
@@ -24,7 +24,6 @@ type RenderContactsPageOptions = Readonly<{
   isLedgerSyncChecking?: boolean;
   isFeatureIntroductionOpen?: boolean;
   onCompleteFeatureIntroduction?: () => void;
-  onDeferFeatureIntroduction?: () => void;
   isIntroductionOpen?: boolean;
   onDismissIntroduction?: () => void;
   onOpenMe?: (contactId: ContactId) => void;
@@ -39,7 +38,6 @@ function renderContactsPage({
   isLedgerSyncChecking = false,
   isFeatureIntroductionOpen = false,
   onCompleteFeatureIntroduction = jest.fn(),
-  onDeferFeatureIntroduction = jest.fn(),
   isIntroductionOpen = false,
   onDismissIntroduction = jest.fn(),
   onOpenMe = jest.fn(),
@@ -64,7 +62,6 @@ function renderContactsPage({
           <div>
             <p>Introducing Contacts</p>
             <button onClick={onCompleteFeatureIntroduction}>Try contacts</button>
-            <button onClick={onDeferFeatureIntroduction}>Maybe later</button>
           </div>
         ) : undefined
       }
@@ -84,7 +81,6 @@ function renderContactsPage({
 
   return {
     onCompleteFeatureIntroduction,
-    onDeferFeatureIntroduction,
     onDismissIntroduction,
     onOpenMe,
     onOpenContact,
@@ -183,22 +179,6 @@ describe("ContactsPage", () => {
     fireEvent.click(screen.getByText("Try contacts"));
 
     expect(onCompleteFeatureIntroduction).toHaveBeenCalledTimes(1);
-  });
-
-  it("calls onDefer when Maybe later is pressed", () => {
-    const onDeferFeatureIntroduction = jest.fn();
-
-    renderContactsPage({
-      isFeatureIntroductionOpen: true,
-      onDeferFeatureIntroduction,
-    });
-
-    expect(screen.getByTestId("contacts-list")).toBeVisible();
-    expect(screen.getByText("Introducing Contacts")).toBeVisible();
-
-    fireEvent.click(screen.getByText("Maybe later"));
-
-    expect(onDeferFeatureIntroduction).toHaveBeenCalledTimes(1);
   });
 
   it("shows the Ledger Sync introduction over the Contacts page and dismisses it", () => {


### PR DESCRIPTION
### ✅ Checklist

- [x] A changeset was attached.
- [x] **Covered by automatic tests.** Focused Flow and Mobile tests pass; Desktop integration test is blocked before assertions by an existing Jest module-resolution issue.
- [x] **Impact of the changes:**
      QA should verify that Contacts introduction has only Try contacts on Desktop and Mobile, the close control still exits without persisting completion, the hero image is visible on both platforms, and the Add contact mobile form has 16 px side padding.

### 📝 Description

Fixes LIVE-35850 and LIVE-35882 for Contacts.

The Contacts feature introduction now presents only its primary action on both Desktop and Mobile while preserving the close behavior. The bundled hero asset is covered in both platform tests. The native Add contact form no longer applies a duplicate horizontal inset, so it relies on the bottom sheet’s 16 px padding.

| Before | After |
|--------|-------|
| Secondary Maybe later action and 32 px form inset | One Try contacts action and 16 px form inset |

### ❓ Context

- **JIRA**: https://ledgerhq.atlassian.net/browse/LIVE-35850
- **JIRA**: https://ledgerhq.atlassian.net/browse/LIVE-35882

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA issues.
- **The PR description clearly documents the changes** made and explains the technical decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and potential edge cases have been considered.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.