### PR TITLE
fix(contacts): align add-contact padding (LIVE-35882)

### DIFF
--- a/.changeset/clear-contact-padding.md
+++ b/.changeset/clear-contact-padding.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts-add-contact": minor
+---
+
+Align the native add-contact form with the bottom sheet horizontal padding.

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/ContactsAddContactDrawerSheet.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/ContactsAddContactDrawerSheet.test.tsx
@@ -76,9 +76,6 @@ describe("ContactsAddContactDrawerSheet", () => {
     expect(screen.getByText("0/32")).toBeVisible();
     expect(screen.getByRole("button", { name: "Confirm name" })).toBeDisabled();
     expect(screen.getByTestId("contacts-add-contact-name-input")).toHaveProp("autoFocus", true);
-    expect(screen.getByTestId("contacts-add-contact-form")).not.toHaveStyle({
-      paddingHorizontal: 16,
-    });
   });
 
   it("should cap the contact name at 32 characters", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/ContactsAddContactDrawerSheet.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/ContactsAddContactDrawerSheet.test.tsx
@@ -76,6 +76,9 @@ describe("ContactsAddContactDrawerSheet", () => {
     expect(screen.getByText("0/32")).toBeVisible();
     expect(screen.getByRole("button", { name: "Confirm name" })).toBeDisabled();
     expect(screen.getByTestId("contacts-add-contact-name-input")).toHaveProp("autoFocus", true);
+    expect(screen.getByTestId("contacts-add-contact-form")).not.toHaveStyle({
+      paddingHorizontal: 16,
+    });
   });
 
   it("should cap the contact name at 32 characters", async () => {

--- a/features/flow/flow-contacts-add-contact/src/components/ContactsContactNameDrawer/ContactsContactNameDrawerContent.native.tsx
+++ b/features/flow/flow-contacts-add-contact/src/components/ContactsContactNameDrawer/ContactsContactNameDrawerContent.native.tsx
@@ -54,7 +54,7 @@ export function ContactsContactNameDrawerContent({
       {isOpen ? (
         <Box lx={{ gap: "s24" }}>
           <BottomSheetHeader />
-          <Box lx={{ gap: "s16", paddingHorizontal: "s16" }}>
+          <Box testID="contacts-add-contact-form" lx={{ gap: "s16" }}>
             <Text typography="heading3SemiBold" lx={{ color: "base" }}>
               {labels.title}
             </Text>

--- a/features/flow/flow-contacts-add-contact/src/components/ContactsContactNameDrawer/ContactsContactNameDrawerContent.native.tsx
+++ b/features/flow/flow-contacts-add-contact/src/components/ContactsContactNameDrawer/ContactsContactNameDrawerContent.native.tsx
@@ -54,7 +54,7 @@ export function ContactsContactNameDrawerContent({
       {isOpen ? (
         <Box lx={{ gap: "s24" }}>
           <BottomSheetHeader />
-          <Box testID="contacts-add-contact-form" lx={{ gap: "s16" }}>
+          <Box lx={{ gap: "s16" }}>
             <Text typography="heading3SemiBold" lx={{ color: "base" }}>
               {labels.title}
             </Text>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Flow add-contact: 5 suites / 21 tests; mobile drawer: 1 suite / 8 tests.
- [x] **Impact of the changes:**
      The Add Contact form now keeps the 16px horizontal padding provided by the bottom sheet.

### 📝 Description

Removes the duplicate inner horizontal padding from the native Add Contact form, which previously resulted in a 32px side inset.

<img width="1206" height="2622" alt="Simulator Screenshot - iOS Simulator - 2026-08-17 at 11 13 47" src="https://github.com/user-attachments/assets/07ff5639-6119-4d72-bb41-6d2884099eaa" />

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-35882

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)