### PR TITLE
fix(pay-card): use Bundle icon for balance filter fallback

### DIFF
--- a/.changeset/pay-card-balance-filter-bundle-icon.md
+++ b/.changeset/pay-card-balance-filter-bundle-icon.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-pay-card-balance": patch
+---
+
+Use the Bundle symbol instead of Placeholder for the balance filter option fallback icon (web and native).

--- a/features/flow/pay-card-balance/src/components/Filter/BalanceFilterOptionParts.native.tsx
+++ b/features/flow/pay-card-balance/src/components/Filter/BalanceFilterOptionParts.native.tsx
@@ -7,7 +7,7 @@ import {
   CardContentTitle,
   Spot,
 } from "@ledgerhq/lumen-ui-rnative";
-import { Placeholder } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { Bundle } from "@ledgerhq/lumen-ui-rnative/symbols";
 import type { BalanceFilter } from "../../state";
 
 export {
@@ -57,7 +57,7 @@ type FilterOptionIconProps = Readonly<{
 
 export function FilterOptionIcon({ ledgerId, ticker }: FilterOptionIconProps) {
   if (ledgerId == null) {
-    return <Spot appearance="icon" icon={Placeholder} size={48} />;
+    return <Spot appearance="icon" icon={Bundle} size={48} />;
   }
   return <CryptoIcon ledgerId={ledgerId} ticker={ticker ?? ""} size={48} />;
 }

--- a/features/flow/pay-card-balance/src/components/Filter/BalanceFilterOptionParts.web.tsx
+++ b/features/flow/pay-card-balance/src/components/Filter/BalanceFilterOptionParts.web.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 import { CryptoIcon } from "@ledgerhq/crypto-icons";
 import { Card, Spot } from "@ledgerhq/lumen-ui-react";
-import { Placeholder } from "@ledgerhq/lumen-ui-react/symbols";
+import { Bundle } from "@ledgerhq/lumen-ui-react/symbols";
 import type { BalanceFilter } from "../../state";
 
 export {
@@ -51,7 +51,7 @@ type FilterOptionIconProps = Readonly<{
 
 export function FilterOptionIcon({ ledgerId, ticker }: FilterOptionIconProps) {
   if (ledgerId == null) {
-    return <Spot appearance="icon" icon={Placeholder} size={48} />;
+    return <Spot appearance="icon" icon={Bundle} size={48} />;
   }
   return <CryptoIcon ledgerId={ledgerId} ticker={ticker ?? ""} size={48} />;
 }


### PR DESCRIPTION
### 📝 Description

The balance filter option fallback icon in `@features/flow-pay-card-balance` was using the generic `Placeholder` Lumen symbol.

This replaces it with the `Bundle` symbol on both the web (`@ledgerhq/lumen-ui-react/symbols`) and native (`@ledgerhq/lumen-ui-rnative/symbols`) variants of `BalanceFilterOptionParts`, so the "all balances" filter option shows the intended icon.


### 🔗 Context

- **JIRA / GitHub issue**: n/a