### PR TITLE
[LWD] feat(profile): add My Wallet large-screen upsell banner (LIVE-35481)

### DIFF
--- a/.changeset/live-35481-profile-upsell-banner.md
+++ b/.changeset/live-35481-profile-upsell-banner.md
@@ -1,0 +1,7 @@
+---
+"@shared/feature-flags": minor
+"@features/flow-large-screen-upsell": major
+"ledger-live-desktop": minor
+---
+
+Add a My Wallet Profile LNS upsell banner gated by `largeScreenUpsell.banners.profile` (LIVE-35481). Require `utmContent` on `buildLargeScreenUpsellCtaLink` and export `LARGE_SCREEN_UPSELL_UTM`.

--- a/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/LNSUpsellBanner.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/LNSUpsellBanner.test.tsx
@@ -3,7 +3,6 @@
  */
 
 import { FEATURE_FLAGS_DEFAULTS } from "@shared/feature-flags";
-import { t } from "i18next";
 import React from "react";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { render, screen, fireEvent, withFlagOverrides } from "tests/testSetup";
@@ -44,17 +43,17 @@ describe("LNSUpsellBanner", () => {
   ] as const)("on the $page page", ({ location, page }) => {
     it("should not render if the feature flag is disabled", () => {
       renderBanner({ ffEnabled: false });
-      expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
+      expect(screen.queryByText("Upgrade my Ledger")).toBeNull();
     });
 
     it("should not render if the location param is disabled on the feature flag", () => {
       renderBanner({ ffLocationEnabled: false });
-      expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
+      expect(screen.queryByText("Upgrade my Ledger")).toBeNull();
     });
 
     it("should not render if the tracking CTA is disabled on the feature flag", () => {
       renderBanner({ ffCtaEnabled: false });
-      expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
+      expect(screen.queryByText("Upgrade my Ledger")).toBeNull();
     });
 
     it.each([DeviceModelId.nanoSP, DeviceModelId.nanoX])(
@@ -64,7 +63,7 @@ describe("LNSUpsellBanner", () => {
           devicesModelList: [deviceModelId],
           onboardingDate: daysAgoIso(1),
         });
-        expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
+        expect(screen.queryByText("Upgrade my Ledger")).toBeNull();
       },
     );
 
@@ -78,7 +77,7 @@ describe("LNSUpsellBanner", () => {
           devicesModelList: [deviceModelId],
           onboardingDate: daysAgoIso(30),
         });
-        fireEvent.click(screen.getByText(t(`lnsUpsell.opted_in.cta`)));
+        fireEvent.click(screen.getByText("Upgrade my Ledger"));
 
         expect(track).toHaveBeenCalledWith("button_clicked", {
           button: "Level up wallet",
@@ -91,19 +90,19 @@ describe("LNSUpsellBanner", () => {
 
     it("should not render if the user's Nano model is outside the audience", () => {
       renderBanner({ audienceModels: { nanoS: false, nanoSP: true, nanoX: true } });
-      expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
+      expect(screen.queryByText("Upgrade my Ledger")).toBeNull();
     });
 
     it("should not render if the user also owns a large-screen device", () => {
       renderBanner({ devicesModelList: [DeviceModelId.nanoS, DeviceModelId.stax] });
-      expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
+      expect(screen.queryByText("Upgrade my Ledger")).toBeNull();
     });
 
     it("should not render when a longer-cooldown nano is still in cooldown", () => {
       renderBanner({
         devicesModelList: [DeviceModelId.nanoS, DeviceModelId.nanoX],
       });
-      expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
+      expect(screen.queryByText("Upgrade my Ledger")).toBeNull();
     });
 
     it("should render the longest-cooldown nano once that cooldown has elapsed", () => {
@@ -111,7 +110,7 @@ describe("LNSUpsellBanner", () => {
         devicesModelList: [DeviceModelId.nanoS, DeviceModelId.nanoX],
         onboardingDate: daysAgoIso(30),
       });
-      fireEvent.click(screen.getByText(t(`lnsUpsell.opted_in.cta`)));
+      fireEvent.click(screen.getByText("Upgrade my Ledger"));
 
       expect(track).toHaveBeenCalledWith("button_clicked", {
         button: "Level up wallet",
@@ -123,17 +122,17 @@ describe("LNSUpsellBanner", () => {
 
     it("should not render if the user has no devices", () => {
       renderBanner({ devicesModelList: [] });
-      expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
+      expect(screen.queryByText("Upgrade my Ledger")).toBeNull();
     });
 
     it("should not render if the user (opted in) is targeted by a higher tier upsell campaign", () => {
       renderBanner({ targetedByHighTierUpsell: true });
-      expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
+      expect(screen.queryByText("Upgrade my Ledger")).toBeNull();
     });
 
     it("should track click on the cta", () => {
       renderBanner({});
-      fireEvent.click(screen.getByText(t(`lnsUpsell.opted_in.cta`)));
+      fireEvent.click(screen.getByText("Upgrade my Ledger"));
 
       expect(openURL).toHaveBeenCalledTimes(1);
       expect(openURL).toHaveBeenCalledWith("https://example.com/optInCta");
@@ -149,12 +148,8 @@ describe("LNSUpsellBanner", () => {
     it("should render Lumen MediaBanner and track click when lwdWallet40 brazePlacement is on", () => {
       renderBanner({ brazePlacement: true });
 
-      expect(screen.getByText(t(`lnsUpsell.opted_in.title`))).toBeVisible();
-      expect(
-        screen.getByText(
-          t(`lnsUpsell.opted_in.description`, { discount: DEFAULT_DISCOUNT_PERCENT }),
-        ),
-      ).toBeVisible();
+      expect(screen.getByText("See more. Sign safer")).toBeVisible();
+      expect(screen.getByText(`Upgrade and get ${DEFAULT_DISCOUNT_PERCENT}% off.`)).toBeVisible();
 
       fireEvent.click(screen.getByTestId("lns-upsell-media-banner"));
 
@@ -171,13 +166,13 @@ describe("LNSUpsellBanner", () => {
     it("should render opted-out MediaBanner copy when lwdWallet40 brazePlacement is on", () => {
       renderBanner({ brazePlacement: true, isOptIn: false });
 
-      expect(screen.getByText(t(`lnsUpsell.opted_out.title`))).toBeVisible();
-      expect(screen.getByText(t(`lnsUpsell.opted_out.description`))).toBeVisible();
+      expect(screen.getByText("More security. More control")).toBeVisible();
+      expect(screen.getByText("Learn more about security features.")).toBeVisible();
     });
 
     it("should render the banner for opted out users", () => {
       renderBanner({ isOptIn: false });
-      fireEvent.click(screen.getByText(t(`lnsUpsell.opted_out.cta`)));
+      fireEvent.click(screen.getByText("Learn more"));
 
       expect(openURL).toHaveBeenCalledTimes(1);
       expect(openURL).toHaveBeenCalledWith("https://example.com/optOutCta");
@@ -192,7 +187,7 @@ describe("LNSUpsellBanner", () => {
 
     it("should render for opted out users regardless of content cards state", () => {
       renderBanner({ isOptIn: false, targetedByHighTierUpsell: true });
-      fireEvent.click(screen.getByText(t(`lnsUpsell.opted_out.cta`)));
+      fireEvent.click(screen.getByText("Learn more"));
 
       expect(openURL).toHaveBeenCalledTimes(1);
       expect(openURL).toHaveBeenCalledWith("https://example.com/optOutCta");

--- a/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/index.tsx
@@ -11,6 +11,8 @@ import type { LNSBannerModel } from "./types";
 
 type Props = FlexBoxProps & { location: LNSBannerLocation };
 
+const FULL_WIDTH_BANNER_LOCATIONS = new Set<LNSBannerLocation>(["notification_center"]);
+
 export function LNSUpsellBanner({ location, ...boxProps }: Props) {
   return <View {...useLNSUpsellBannerModel(location)} {...boxProps} />;
 }
@@ -30,11 +32,11 @@ function View({
   if (variant.type === "none") return null;
 
   if (shouldUseLumenMediaBanner) {
-    const isNotificationCenter = location === "notification_center";
+    const isFullWidth = FULL_WIDTH_BANNER_LOCATIONS.has(location);
     return (
       <Flex
-        width={isNotificationCenter ? "100%" : "50%"}
-        maxWidth={isNotificationCenter ? "100%" : "50%"}
+        width={isFullWidth ? "100%" : "50%"}
+        maxWidth={isFullWidth ? "100%" : "50%"}
         minWidth={0}
         alignSelf="flex-start"
         {...boxProps}

--- a/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/useLNSUpsellBannerModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/useLNSUpsellBannerModel.ts
@@ -1,4 +1,8 @@
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
+import {
+  LARGE_SCREEN_UPSELL_UTM,
+  buildLargeScreenUpsellCtaLink,
+} from "@features/flow-large-screen-upsell";
 import { useLNSUpsellBannerState } from "LLD/features/LNSUpsell/hooks/useLNSUpsellBannerState";
 import type { LNSBannerLocation, LNSBannerState } from "LLD/features/LNSUpsell/types";
 import { toLargeScreenUpsellDeviceModelAnalyticsValue } from "LLD/features/LargeScreenUpsell/analytics";
@@ -9,36 +13,61 @@ import lnsUpsellManagerImageUrl from "~/renderer/images/lns-upsell-banner-manage
 import lnsUpsellNotificationCenterImageUrl from "~/renderer/images/lns-upsell-banner-notification-center.webp";
 import type { LNSBannerModel } from "./types";
 
-// Accounts reuses the Notification Center illustration (same audience, no dedicated asset).
+// Accounts and profile reuse the Notification Center illustration (no dedicated asset).
 const lnsUpsellImageByLocation: Record<LNSBannerLocation, string> = {
   portfolio: lnsUpsellPortfolioImageUrl,
   manager: lnsUpsellManagerImageUrl,
   notification_center: lnsUpsellNotificationCenterImageUrl,
   accounts: lnsUpsellNotificationCenterImageUrl,
+  profile: lnsUpsellNotificationCenterImageUrl,
 };
 
 export function useLNSUpsellBannerModel(location: LNSBannerLocation): LNSBannerModel {
   const state = useLNSUpsellBannerState(location);
   const { shouldDisplayBrazePlacement } = useWalletFeaturesConfig("desktop");
 
-  const { ctaLink, discountPercent: discount, deviceModelId } = state;
+  const { ctaLink, discountPercent: discount, deviceModelId, tracking } = state;
   const analyticsPage = AnalyticsPageMap[location];
   const imageUrl = lnsUpsellImageByLocation[location];
   const deviceModel = deviceModelId
     ? toLargeScreenUpsellDeviceModelAnalyticsValue(deviceModelId)
     : undefined;
+  const resolvedCtaLink = resolveCtaLink(location, ctaLink);
 
   const handleCTAClick = () => {
-    track("button_clicked", {
-      button: ANALYTICS_BUTTON_CLICK,
-      ...(deviceModel ? { deviceModel } : {}),
-      link: ctaLink,
-      page: analyticsPage,
-    });
-    if (ctaLink) openURL(ctaLink);
+    if (location === "profile") {
+      const personalRecoOptIn = tracking === "opted_in";
+      const sharedProps = {
+        ...(deviceModel ? { deviceModel } : {}),
+        personalRecoOptIn,
+        offerType: personalRecoOptIn ? ("discount" as const) : ("none" as const),
+        platform: "lwd" as const,
+      };
+
+      track("button_clicked", {
+        button: PROFILE_ANALYTICS_BUTTON,
+        page: analyticsPage,
+        ...sharedProps,
+      });
+      track("deeplink_clicked", {
+        page: analyticsPage,
+        deeplinkSource: LARGE_SCREEN_UPSELL_UTM.sourceByPlatform.desktop,
+        deeplinkMedium: LARGE_SCREEN_UPSELL_UTM.medium,
+        deeplinkCampaign: LARGE_SCREEN_UPSELL_UTM.campaign,
+        ...sharedProps,
+      });
+    } else {
+      track("button_clicked", {
+        button: ANALYTICS_BUTTON_CLICK,
+        ...(deviceModel ? { deviceModel } : {}),
+        link: resolvedCtaLink,
+        page: analyticsPage,
+      });
+    }
+
+    if (resolvedCtaLink) openURL(resolvedCtaLink);
   };
 
-  const tracking = state.tracking;
   const variant = getVariant(location, state);
 
   return {
@@ -53,13 +82,26 @@ export function useLNSUpsellBannerModel(location: LNSBannerLocation): LNSBannerM
 }
 
 const ANALYTICS_BUTTON_CLICK = "Level up wallet";
+const PROFILE_ANALYTICS_BUTTON = "upgrade";
 
 const AnalyticsPageMap = {
   manager: "Manager",
   accounts: "Accounts",
   portfolio: "Portfolio",
   notification_center: "NotificationPanel",
+  profile: "Profile",
 } as const satisfies Record<LNSBannerLocation, unknown>;
+
+function resolveCtaLink(location: LNSBannerLocation, ctaLink?: string): string | undefined {
+  if (!ctaLink) return undefined;
+  if (location !== "profile") return ctaLink;
+
+  return buildLargeScreenUpsellCtaLink(
+    ctaLink,
+    "desktop",
+    LARGE_SCREEN_UPSELL_UTM.content.profile_cta,
+  );
+}
 
 function getVariant(location: LNSBannerLocation, state: LNSBannerState): LNSBannerModel["variant"] {
   if (!state.isShown) return { type: "none" };

--- a/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/hooks/useLNSUpsellBannerState.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/hooks/useLNSUpsellBannerState.ts
@@ -4,6 +4,7 @@ import {
   getLargeScreenUpsellEligibility,
   mapDevicesModelListToUpsellInputs,
 } from "@features/flow-large-screen-upsell";
+import { FEATURE_FLAGS_DEFAULTS } from "@shared/feature-flags";
 import { onboardingDateSelector } from "@ledgerhq/live-common/postOnboarding/reducer";
 import { desktopContentCardSelector } from "~/renderer/reducers/dynamicContent";
 import {
@@ -17,17 +18,25 @@ import {
 } from "../types";
 
 const LNS_UPSELL_HIGH_TIER = "LNS_UPSELL_HIGH_TIER";
+const DEFAULT_UPGRADE_LINK =
+  FEATURE_FLAGS_DEFAULTS.largeScreenUpsell.params?.opted_in.link ??
+  "https://shop.ledger.com/pages/ledger-nano-upgrade-program";
 
 export function useLNSUpsellBannerState(location: LNSBannerLocation): LNSBannerState {
   const isOptIn = useSelector(sharePersonalizedRecommendationsSelector);
   const largeScreenUpsell = useFeature("largeScreenUpsell");
   const tracking = isOptIn ? "opted_in" : "opted_out";
+  const isProfile = location === "profile";
 
   const placement = BANNER_PLACEMENT_BY_LOCATION[location];
   const isPlacementEnabled = largeScreenUpsell?.params?.banners?.[placement] ?? false;
   const ctaConfig = largeScreenUpsell?.params?.[tracking];
-  const isCTAEnabled = ctaConfig?.enabled ?? false;
-  const ctaLink = ctaConfig?.link?.trim() || undefined;
+  const isCTAEnabled = isProfile || (ctaConfig?.enabled ?? false);
+  const ctaLink =
+    ctaConfig?.link?.trim() ||
+    (isProfile
+      ? largeScreenUpsell?.params?.opted_in.link?.trim() || DEFAULT_UPGRADE_LINK
+      : undefined);
   const discountPercent = Math.round((largeScreenUpsell?.params?.discount ?? 0) * 100);
 
   const devicesModelList = useSelector(devicesModelListSelector);

--- a/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/index.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/index.ts
@@ -1,2 +1,3 @@
 export * from "./components/LNSUpsellBanner";
+export * from "./components/LNSUpsellBanner/useLNSUpsellBannerModel";
 export * from "./hooks/useLNSUpsellBannerState";

--- a/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/types/index.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/types/index.ts
@@ -1,7 +1,12 @@
 import type { NanoDeviceModelId } from "@features/flow-large-screen-upsell";
 import type { Features } from "@shared/feature-flags";
 
-export type LNSBannerLocation = "manager" | "accounts" | "notification_center" | "portfolio";
+export type LNSBannerLocation =
+  | "manager"
+  | "accounts"
+  | "notification_center"
+  | "portfolio"
+  | "profile";
 
 export type LNSBannerState = {
   isShown: boolean;
@@ -19,4 +24,5 @@ export const BANNER_PLACEMENT_BY_LOCATION = {
   accounts: "accounts",
   notification_center: "notification-center",
   portfolio: "homepage",
+  profile: "profile",
 } as const satisfies Record<LNSBannerLocation, LargeScreenUpsellBannerPlacement>;

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/__integrations__/LNSUpsellProfileBanner.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/__integrations__/LNSUpsellProfileBanner.integration.test.tsx
@@ -1,0 +1,217 @@
+import React from "react";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { FEATURE_FLAGS_DEFAULTS } from "@shared/feature-flags";
+import { LARGE_SCREEN_UPSELL_UTM } from "@features/flow-large-screen-upsell";
+import { render, screen, waitFor, withFlagOverrides } from "tests/testSetup";
+import { track } from "~/renderer/analytics/segment";
+import { openURL } from "~/renderer/linking";
+import { ContextMenu } from "../components/ContextMenu";
+
+jest.mock("~/renderer/store", () => ({
+  getStoreValue: jest.fn(),
+  setStoreValue: jest.fn(),
+  resetStore: jest.fn(),
+}));
+
+jest.mock("~/renderer/linking", () => ({
+  ...jest.requireActual("~/renderer/linking"),
+  openURL: jest.fn(),
+}));
+
+function daysAgoIso(days: number): string {
+  const date = new Date();
+  date.setDate(date.getDate() - days);
+  return date.toISOString();
+}
+
+async function renderMyWalletProfile({
+  ffEnabled = true,
+  profileBannerEnabled = true,
+  isOptIn = true,
+  optedOutLink,
+  devicesModelList = [DeviceModelId.nanoS],
+}: {
+  ffEnabled?: boolean;
+  profileBannerEnabled?: boolean;
+  isOptIn?: boolean;
+  optedOutLink?: string;
+  devicesModelList?: DeviceModelId[];
+} = {}) {
+  const defaultParams = FEATURE_FLAGS_DEFAULTS.largeScreenUpsell.params;
+
+  if (!defaultParams) {
+    throw new Error("Expected large-screen upsell default params");
+  }
+
+  const utils = render(<ContextMenu />, {
+    initialState: {
+      ...withFlagOverrides({
+        largeScreenUpsell: {
+          enabled: ffEnabled,
+          params: {
+            ...defaultParams,
+            banners: {
+              ...defaultParams.banners,
+              profile: profileBannerEnabled,
+            },
+            opted_in: {
+              ...defaultParams.opted_in,
+              enabled: true,
+              link: "https://example.com/optInCta",
+            },
+            opted_out: {
+              ...defaultParams.opted_out,
+              link: optedOutLink ?? "https://example.com/optOutCta",
+            },
+          },
+        },
+      }),
+      settings: {
+        shareAnalytics: true,
+        sharePersonalizedRecommandations: isOptIn,
+        devicesModelList,
+        anonymousUserNotifications: {},
+      },
+      postOnboarding: {
+        onboardingDate: daysAgoIso(0),
+      },
+    },
+  });
+  await utils.user.click(screen.getByRole("button", { name: "My Wallet" }));
+  await waitFor(() => {
+    expect(screen.getByTestId("topbar-action-button-settings")).toBeVisible();
+  });
+  return utils;
+}
+
+function openedCtaUrl(): URL {
+  return new URL(String(jest.mocked(openURL).mock.calls[0][0]));
+}
+
+describe("My Wallet LNS upsell profile banner", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should replace Explore with the compact banner for nanoS when the profile placement is enabled", async () => {
+    await renderMyWalletProfile();
+
+    expect(screen.getByText("Upgrade your Device")).toBeVisible();
+    expect(screen.getByText("Bigger screen, better security. Enjoy 20%.")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Explore" })).toBeVisible();
+    expect(screen.queryByText("Explore all Ledger devices")).toBeNull();
+  });
+
+  it("should keep Explore for stax", async () => {
+    await renderMyWalletProfile({ devicesModelList: [DeviceModelId.stax] });
+
+    expect(screen.getByText("Explore all Ledger devices")).toBeVisible();
+    expect(screen.queryByText("Upgrade your Device")).toBeNull();
+  });
+
+  it("should keep Explore when a nanoS is paired with a large-screen device", async () => {
+    await renderMyWalletProfile({ devicesModelList: [DeviceModelId.nanoS, DeviceModelId.stax] });
+
+    expect(screen.getByText("Explore all Ledger devices")).toBeVisible();
+    expect(screen.queryByText("Upgrade your Device")).toBeNull();
+  });
+
+  it("should keep Explore when the feature flag is off", async () => {
+    await renderMyWalletProfile({ ffEnabled: false });
+
+    expect(screen.getByText("Explore all Ledger devices")).toBeVisible();
+    expect(screen.queryByText("Upgrade your Device")).toBeNull();
+  });
+
+  it("should keep Explore when banners.profile is off", async () => {
+    await renderMyWalletProfile({ profileBannerEnabled: false });
+
+    expect(screen.getByText("Explore all Ledger devices")).toBeVisible();
+    expect(screen.queryByText("Upgrade your Device")).toBeNull();
+  });
+
+  it("should show the compact banner when personalized recommendations are off", async () => {
+    await renderMyWalletProfile({ isOptIn: false });
+
+    expect(screen.getByText("More security. More control")).toBeVisible();
+    expect(screen.getByText("Learn more about security features.")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Explore" })).toBeVisible();
+    expect(screen.queryByText("Explore all Ledger devices")).toBeNull();
+  });
+
+  it("should open the opted_out URL and fire opted-out tracking when personalized recommendations are off", async () => {
+    const { user } = await renderMyWalletProfile({ isOptIn: false });
+
+    await user.click(screen.getByRole("button", { name: "Explore" }));
+
+    const openedUrl = openedCtaUrl();
+    expect(openedUrl.origin + openedUrl.pathname).toBe("https://example.com/optOutCta");
+    expect(openedUrl.searchParams.get("utm_content")).toBe(
+      LARGE_SCREEN_UPSELL_UTM.content.profile_cta,
+    );
+
+    const sharedProps = {
+      deviceModel: "lns",
+      personalRecoOptIn: false,
+      offerType: "none",
+      platform: "lwd",
+    };
+
+    expect(track).toHaveBeenCalledWith("button_clicked", {
+      button: "upgrade",
+      page: "Profile",
+      ...sharedProps,
+    });
+    expect(track).toHaveBeenCalledWith("deeplink_clicked", {
+      page: "Profile",
+      deeplinkSource: LARGE_SCREEN_UPSELL_UTM.sourceByPlatform.desktop,
+      deeplinkMedium: LARGE_SCREEN_UPSELL_UTM.medium,
+      deeplinkCampaign: LARGE_SCREEN_UPSELL_UTM.campaign,
+      ...sharedProps,
+    });
+  });
+
+  it("should fall back to the opted_in shop link when opted_out has no link", async () => {
+    const { user } = await renderMyWalletProfile({
+      isOptIn: false,
+      optedOutLink: "   ",
+    });
+
+    await user.click(screen.getByRole("button", { name: "Explore" }));
+
+    const openedUrl = openedCtaUrl();
+    expect(openedUrl.origin + openedUrl.pathname).toBe("https://example.com/optInCta");
+  });
+
+  it("should open the profile_cta URL and fire button_clicked plus deeplink_clicked", async () => {
+    const { user } = await renderMyWalletProfile();
+
+    await user.click(screen.getByRole("button", { name: "Explore" }));
+
+    const openedUrl = openedCtaUrl();
+    expect(openedUrl.origin + openedUrl.pathname).toBe("https://example.com/optInCta");
+    expect(openedUrl.searchParams.get("utm_content")).toBe(
+      LARGE_SCREEN_UPSELL_UTM.content.profile_cta,
+    );
+
+    const sharedProps = {
+      deviceModel: "lns",
+      personalRecoOptIn: true,
+      offerType: "discount",
+      platform: "lwd",
+    };
+
+    expect(track).toHaveBeenCalledWith("button_clicked", {
+      button: "upgrade",
+      page: "Profile",
+      ...sharedProps,
+    });
+    expect(track).toHaveBeenCalledWith("deeplink_clicked", {
+      page: "Profile",
+      deeplinkSource: LARGE_SCREEN_UPSELL_UTM.sourceByPlatform.desktop,
+      deeplinkMedium: LARGE_SCREEN_UPSELL_UTM.medium,
+      deeplinkCampaign: LARGE_SCREEN_UPSELL_UTM.campaign,
+      ...sharedProps,
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/Explore/ExploreView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/Explore/ExploreView.tsx
@@ -10,7 +10,7 @@ import { ExternalLink } from "@ledgerhq/lumen-ui-react/symbols";
 import Image from "~/renderer/components/Image";
 import ExploreImage from "./explore.webp";
 
-export type ExploreViewProps = {
+type ExploreViewProps = {
   title: string;
   onClick: () => void;
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/Explore/ProfileUpsellView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/Explore/ProfileUpsellView.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import {
+  Button,
+  ListItem,
+  ListItemContent,
+  ListItemDescription,
+  ListItemLeading,
+  ListItemTitle,
+  ListItemTrailing,
+} from "@ledgerhq/lumen-ui-react";
+import Image from "~/renderer/components/Image";
+import ExploreImage from "./explore.webp";
+
+type ProfileUpsellViewProps = {
+  title: string;
+  description: string;
+  cta: string;
+  onClick: () => void;
+};
+
+export function ProfileUpsellView({ title, description, cta, onClick }: ProfileUpsellViewProps) {
+  return (
+    <ListItem
+      onClick={onClick}
+      className="bg-surface h-auto min-h-64 overflow-visible"
+      data-testid="my-wallet-profile-upsell"
+    >
+      <ListItemLeading>
+        <Image resource={ExploreImage} alt="" className="w-48 h-48" />
+        <ListItemContent>
+          <ListItemTitle>{title}</ListItemTitle>
+          <ListItemDescription className="whitespace-normal line-clamp-2">
+            {description}
+          </ListItemDescription>
+        </ListItemContent>
+      </ListItemLeading>
+      <ListItemTrailing>
+        <Button appearance="base" size="sm">
+          {cta}
+        </Button>
+      </ListItemTrailing>
+    </ListItem>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/Explore/hooks/useExploreViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/Explore/hooks/useExploreViewModel.ts
@@ -1,18 +1,28 @@
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
+import { useLNSUpsellBannerModel } from "LLD/features/LNSUpsell";
 import { urls } from "~/config/urls";
 import { useLocalizedUrl } from "~/renderer/hooks/useLocalizedUrls";
 import { openURL } from "~/renderer/linking";
 import { MY_WALLET_TRACKING_BUTTON, MY_WALLET_TRACKING_PAGE_NAME } from "../../../constants";
 
-export type ExploreViewModel = {
+type ProfileUpsell = {
+  title: string;
+  description: string;
+  cta: string;
+  onClick: () => void;
+};
+
+type ExploreViewModel = {
   title: string;
   handleClick: () => void;
+  upsell: ProfileUpsell | null;
 };
 
 export function useExploreViewModel(): ExploreViewModel {
   const { t } = useTranslation();
   const url = useLocalizedUrl(urls.exploreLedgerDevices);
+  const { variant, discount, handleCTAClick, tracking } = useLNSUpsellBannerModel("profile");
 
   const handleClick = useCallback(() => {
     openURL(url, "button_clicked", {
@@ -21,8 +31,20 @@ export function useExploreViewModel(): ExploreViewModel {
     });
   }, [url]);
 
+  const copyKey = tracking === "opted_out" ? "lnsUpsell.opted_out" : "lnsUpsell.profile";
+  const upsell: ProfileUpsell | null =
+    variant.type === "none"
+      ? null
+      : {
+          title: t(`${copyKey}.title`),
+          description: t(`${copyKey}.description`, { discount }),
+          cta: t("lnsUpsell.profile.cta"),
+          onClick: handleCTAClick,
+        };
+
   return {
     title: t("myWallet.explore"),
     handleClick,
+    upsell,
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/Explore/index.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/Explore/index.test.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { t } from "i18next";
 import { render, screen } from "tests/testSetup";
 import { openURL } from "~/renderer/linking";
 import { urls } from "~/config/urls";
@@ -22,13 +21,13 @@ describe("Explore", () => {
   it("should display the explore item", () => {
     render(<Explore />);
 
-    expect(screen.getByText(t("myWallet.explore"))).toBeVisible();
+    expect(screen.getByText("Explore all Ledger devices")).toBeVisible();
   });
 
   it("should open the buy new url when clicked", async () => {
     const { user } = render(<Explore />);
 
-    await user.click(screen.getByText(t("myWallet.explore")));
+    await user.click(screen.getByText("Explore all Ledger devices"));
 
     expect(openURL).toHaveBeenCalledTimes(1);
     expect(openURL).toHaveBeenCalledWith(urls.exploreLedgerDevices, "button_clicked", {

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/Explore/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/Explore/index.tsx
@@ -1,9 +1,14 @@
 import React from "react";
 import { ExploreView } from "./ExploreView";
+import { ProfileUpsellView } from "./ProfileUpsellView";
 import { useExploreViewModel } from "./hooks/useExploreViewModel";
 
 export function Explore() {
-  const { title, handleClick } = useExploreViewModel();
+  const { title, handleClick, upsell } = useExploreViewModel();
+
+  if (upsell) {
+    return <ProfileUpsellView {...upsell} />;
+  }
 
   return <ExploreView title={title} onClick={handleClick} />;
 }

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8668,6 +8668,11 @@
       "title": "More security. More control",
       "description": "Learn more about security features.",
       "cta": "Learn more"
+    },
+    "profile": {
+      "title": "Upgrade your Device",
+      "description": "Bigger screen, better security. Enjoy {{discount}}%.",
+      "cta": "Explore"
     }
   },
   "largeScreenUpsellModal": {

--- a/features/flow/large-screen-upsell/README.md
+++ b/features/flow/large-screen-upsell/README.md
@@ -12,6 +12,7 @@ state (schema, slice, selectors).
 - `getLargeScreenUpsellDecision` / `useLargeScreenUpsellDecision` — audience + cooldown + frequency
 - `mapDevicesModelListToUpsellInputs` — `DeviceModelId[]` → decision inputs
 - `buildLargeScreenUpsellCtaLink` / `buildLargeScreenUpsellContent` — pure helpers
+- `LARGE_SCREEN_UPSELL_UTM` — campaign / medium / source / content values for CTA links
 - `LargeScreenUpsellModal` — Lumen Dialog (web) with mobile-matched copy/assets
 - `LARGE_SCREEN_UPSELL_IMAGES` — light/dark hero webps
 - `LargeScreenUpsellModalAnalyticsPorts` — optional viewed / CTA / dismiss callbacks for app-owned Segment

--- a/features/flow/large-screen-upsell/src/utils/upsellContent.ts
+++ b/features/flow/large-screen-upsell/src/utils/upsellContent.ts
@@ -1,4 +1,4 @@
-import { LARGE_SCREEN_UPSELL_MODAL_UTM_CONTENT, buildLargeScreenUpsellCtaLink } from "./upsellCta";
+import { LARGE_SCREEN_UPSELL_UTM, buildLargeScreenUpsellCtaLink } from "./upsellCta";
 
 export type LargeScreenUpsellVariant = "opted_in" | "opted_out";
 
@@ -39,7 +39,7 @@ export function buildLargeScreenUpsellContent({
   const primaryButtonLink = buildLargeScreenUpsellCtaLink(
     variant === "opted_in" ? optedInLink : optedOutLink,
     medium,
-    LARGE_SCREEN_UPSELL_MODAL_UTM_CONTENT,
+    LARGE_SCREEN_UPSELL_UTM.content.app_start_modal,
   );
 
   const titleKey =

--- a/features/flow/large-screen-upsell/src/utils/upsellCta.test.ts
+++ b/features/flow/large-screen-upsell/src/utils/upsellCta.test.ts
@@ -1,6 +1,7 @@
 import {
   LARGE_SCREEN_UPSELL_BACKUPS_UTM_CONTENT,
   LARGE_SCREEN_UPSELL_MODAL_UTM_CONTENT,
+  LARGE_SCREEN_UPSELL_UTM,
   LARGE_SCREEN_UPSELL_UTM_CAMPAIGN,
   LARGE_SCREEN_UPSELL_UTM_MEDIUM,
   LARGE_SCREEN_UPSELL_UTM_SOURCE_BY_PLATFORM,
@@ -12,26 +13,28 @@ describe("buildLargeScreenUpsellCtaLink", () => {
     const result = buildLargeScreenUpsellCtaLink(
       "https://example.com/offer",
       "mobile",
-      LARGE_SCREEN_UPSELL_MODAL_UTM_CONTENT,
+      LARGE_SCREEN_UPSELL_UTM.content.app_start_modal,
     );
     const url = new URL(result);
 
     expect(url.searchParams.get("utm_source")).toBe(
-      LARGE_SCREEN_UPSELL_UTM_SOURCE_BY_PLATFORM.mobile,
+      LARGE_SCREEN_UPSELL_UTM.sourceByPlatform.mobile,
     );
-    expect(url.searchParams.get("utm_medium")).toBe(LARGE_SCREEN_UPSELL_UTM_MEDIUM);
-    expect(url.searchParams.get("utm_campaign")).toBe(LARGE_SCREEN_UPSELL_UTM_CAMPAIGN);
-    expect(url.searchParams.get("utm_content")).toBe(LARGE_SCREEN_UPSELL_MODAL_UTM_CONTENT);
+    expect(url.searchParams.get("utm_medium")).toBe(LARGE_SCREEN_UPSELL_UTM.medium);
+    expect(url.searchParams.get("utm_campaign")).toBe(LARGE_SCREEN_UPSELL_UTM.campaign);
+    expect(url.searchParams.get("utm_content")).toBe(
+      LARGE_SCREEN_UPSELL_UTM.content.app_start_modal,
+    );
   });
 
   it("should use desktop source when requested", () => {
     const result = buildLargeScreenUpsellCtaLink(
       "https://example.com/offer",
       "desktop",
-      LARGE_SCREEN_UPSELL_MODAL_UTM_CONTENT,
+      LARGE_SCREEN_UPSELL_UTM.content.app_start_modal,
     );
     expect(new URL(result).searchParams.get("utm_source")).toBe(
-      LARGE_SCREEN_UPSELL_UTM_SOURCE_BY_PLATFORM.desktop,
+      LARGE_SCREEN_UPSELL_UTM.sourceByPlatform.desktop,
     );
   });
 
@@ -39,35 +42,69 @@ describe("buildLargeScreenUpsellCtaLink", () => {
     const result = buildLargeScreenUpsellCtaLink(
       "https://example.com/offer",
       "desktop",
-      LARGE_SCREEN_UPSELL_BACKUPS_UTM_CONTENT,
+      LARGE_SCREEN_UPSELL_UTM.content.backups_cta,
     );
     const url = new URL(result);
 
     expect(url.searchParams.get("utm_source")).toBe(
-      LARGE_SCREEN_UPSELL_UTM_SOURCE_BY_PLATFORM.desktop,
+      LARGE_SCREEN_UPSELL_UTM.sourceByPlatform.desktop,
     );
-    expect(url.searchParams.get("utm_medium")).toBe(LARGE_SCREEN_UPSELL_UTM_MEDIUM);
-    expect(url.searchParams.get("utm_campaign")).toBe(LARGE_SCREEN_UPSELL_UTM_CAMPAIGN);
-    expect(url.searchParams.get("utm_content")).toBe(LARGE_SCREEN_UPSELL_BACKUPS_UTM_CONTENT);
+    expect(url.searchParams.get("utm_medium")).toBe(LARGE_SCREEN_UPSELL_UTM.medium);
+    expect(url.searchParams.get("utm_campaign")).toBe(LARGE_SCREEN_UPSELL_UTM.campaign);
+    expect(url.searchParams.get("utm_content")).toBe(LARGE_SCREEN_UPSELL_UTM.content.backups_cta);
+  });
+
+  it("should support legacy individual constants", () => {
+    expect(LARGE_SCREEN_UPSELL_MODAL_UTM_CONTENT).toBe(
+      LARGE_SCREEN_UPSELL_UTM.content.app_start_modal,
+    );
+    expect(LARGE_SCREEN_UPSELL_BACKUPS_UTM_CONTENT).toBe(
+      LARGE_SCREEN_UPSELL_UTM.content.backups_cta,
+    );
+    expect(LARGE_SCREEN_UPSELL_UTM_MEDIUM).toBe(LARGE_SCREEN_UPSELL_UTM.medium);
+    expect(LARGE_SCREEN_UPSELL_UTM_CAMPAIGN).toBe(LARGE_SCREEN_UPSELL_UTM.campaign);
+    expect(LARGE_SCREEN_UPSELL_UTM_SOURCE_BY_PLATFORM).toBe(
+      LARGE_SCREEN_UPSELL_UTM.sourceByPlatform,
+    );
+  });
+
+  it("should set profile_cta utm_content", () => {
+    const result = buildLargeScreenUpsellCtaLink(
+      "https://example.com/offer",
+      "desktop",
+      LARGE_SCREEN_UPSELL_UTM.content.profile_cta,
+    );
+    const url = new URL(result);
+
+    expect(url.searchParams.get("utm_source")).toBe(
+      LARGE_SCREEN_UPSELL_UTM.sourceByPlatform.desktop,
+    );
+    expect(url.searchParams.get("utm_medium")).toBe(LARGE_SCREEN_UPSELL_UTM.medium);
+    expect(url.searchParams.get("utm_campaign")).toBe(LARGE_SCREEN_UPSELL_UTM.campaign);
+    expect(url.searchParams.get("utm_content")).toBe(LARGE_SCREEN_UPSELL_UTM.content.profile_cta);
   });
 
   it("should preserve existing query params while setting UTM values", () => {
     const result = buildLargeScreenUpsellCtaLink(
       "https://example.com/offer?foo=bar",
       "mobile",
-      LARGE_SCREEN_UPSELL_MODAL_UTM_CONTENT,
+      LARGE_SCREEN_UPSELL_UTM.content.app_start_modal,
     );
     const url = new URL(result);
 
     expect(url.searchParams.get("foo")).toBe("bar");
     expect(url.searchParams.get("utm_source")).toBe(
-      LARGE_SCREEN_UPSELL_UTM_SOURCE_BY_PLATFORM.mobile,
+      LARGE_SCREEN_UPSELL_UTM.sourceByPlatform.mobile,
     );
   });
 
   it("should return the trimmed input when URL parsing fails", () => {
     expect(
-      buildLargeScreenUpsellCtaLink(" not a url ", "mobile", LARGE_SCREEN_UPSELL_MODAL_UTM_CONTENT),
+      buildLargeScreenUpsellCtaLink(
+        " not a url ",
+        "mobile",
+        LARGE_SCREEN_UPSELL_UTM.content.app_start_modal,
+      ),
     ).toBe("not a url");
   });
 });

--- a/features/flow/large-screen-upsell/src/utils/upsellCta.ts
+++ b/features/flow/large-screen-upsell/src/utils/upsellCta.ts
@@ -1,17 +1,28 @@
-export const LARGE_SCREEN_UPSELL_MODAL_UTM_CONTENT = "app_start_modal";
-export const LARGE_SCREEN_UPSELL_BACKUPS_UTM_CONTENT = "backups_cta";
+export const LARGE_SCREEN_UPSELL_UTM = {
+  medium: "ledger_live",
+  campaign: "nano_upgrade_program",
+  sourceByPlatform: {
+    mobile: "ledger_wallet_mobile",
+    desktop: "ledger_wallet_desktop",
+  },
+  content: {
+    app_start_modal: "app_start_modal",
+    backups_cta: "backups_cta",
+    profile_cta: "profile_cta",
+  },
+} as const;
+
+export const LARGE_SCREEN_UPSELL_MODAL_UTM_CONTENT =
+  LARGE_SCREEN_UPSELL_UTM.content.app_start_modal;
+export const LARGE_SCREEN_UPSELL_BACKUPS_UTM_CONTENT =
+  LARGE_SCREEN_UPSELL_UTM.content.backups_cta;
+export const LARGE_SCREEN_UPSELL_UTM_MEDIUM = LARGE_SCREEN_UPSELL_UTM.medium;
+export const LARGE_SCREEN_UPSELL_UTM_CAMPAIGN = LARGE_SCREEN_UPSELL_UTM.campaign;
+export const LARGE_SCREEN_UPSELL_UTM_SOURCE_BY_PLATFORM =
+  LARGE_SCREEN_UPSELL_UTM.sourceByPlatform;
 
 export type LargeScreenUpsellUtmContent =
-  | typeof LARGE_SCREEN_UPSELL_MODAL_UTM_CONTENT
-  | typeof LARGE_SCREEN_UPSELL_BACKUPS_UTM_CONTENT;
-
-export const LARGE_SCREEN_UPSELL_UTM_MEDIUM = "ledger_live";
-export const LARGE_SCREEN_UPSELL_UTM_CAMPAIGN = "nano_upgrade_program";
-
-export const LARGE_SCREEN_UPSELL_UTM_SOURCE_BY_PLATFORM = {
-  mobile: "ledger_wallet_mobile",
-  desktop: "ledger_wallet_desktop",
-} as const;
+  (typeof LARGE_SCREEN_UPSELL_UTM.content)[keyof typeof LARGE_SCREEN_UPSELL_UTM.content];
 
 export function buildLargeScreenUpsellCtaLink(
   link: string,
@@ -25,9 +36,9 @@ export function buildLargeScreenUpsellCtaLink(
 
   try {
     const url = new URL(trimmedLink);
-    url.searchParams.set("utm_source", LARGE_SCREEN_UPSELL_UTM_SOURCE_BY_PLATFORM[platform]);
-    url.searchParams.set("utm_medium", LARGE_SCREEN_UPSELL_UTM_MEDIUM);
-    url.searchParams.set("utm_campaign", LARGE_SCREEN_UPSELL_UTM_CAMPAIGN);
+    url.searchParams.set("utm_source", LARGE_SCREEN_UPSELL_UTM.sourceByPlatform[platform]);
+    url.searchParams.set("utm_medium", LARGE_SCREEN_UPSELL_UTM.medium);
+    url.searchParams.set("utm_campaign", LARGE_SCREEN_UPSELL_UTM.campaign);
     url.searchParams.set("utm_content", utmContent);
     return url.toString();
   } catch {

--- a/shared/feature-flags/src/flags/team-engagement/largeScreenUpsell.test.ts
+++ b/shared/feature-flags/src/flags/team-engagement/largeScreenUpsell.test.ts
@@ -9,6 +9,7 @@ describe("largeScreenUpsell", () => {
       "notification-center": true,
       accounts: true,
       homepage: true,
+      profile: true,
     });
   });
 
@@ -32,6 +33,7 @@ describe("largeScreenUpsell", () => {
       "notification-center": true,
       accounts: true,
       homepage: false,
+      profile: true,
     });
   });
 
@@ -50,6 +52,7 @@ describe("largeScreenUpsell", () => {
       "notification-center": true,
       accounts: true,
       homepage: true,
+      profile: true,
     });
   });
 

--- a/shared/feature-flags/src/flags/team-engagement/largeScreenUpsell.ts
+++ b/shared/feature-flags/src/flags/team-engagement/largeScreenUpsell.ts
@@ -32,6 +32,7 @@ const DEFAULT_BANNERS = {
   "notification-center": true,
   accounts: true,
   homepage: true,
+  profile: true,
 } as const;
 
 const bannersSchema = z
@@ -40,6 +41,7 @@ const bannersSchema = z
     "notification-center": z.boolean().default(true),
     accounts: z.boolean().default(true),
     homepage: z.boolean().default(true),
+    profile: z.boolean().default(true),
   })
   .default(DEFAULT_BANNERS);
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Nano S / SP / X users currently see the generic “Explore all Ledger devices” row in My Wallet. This PR replaces that row with a compact large-screen upsell banner when they are eligible.

**Problem**: Profile had no placement for the nano upgrade program. Backup Hub upsell already shipped separately.

**Solution**:
- Gate the banner with `largeScreenUpsell.banners.profile`
- Show it for nano-only wallets even when personalized recommendations are off
- Opt-in copy: `lnsUpsell.profile` (“Upgrade your Device”)
- Opt-out copy: `lnsUpsell.opted_out` title/description; CTA stays **Explore**
- CTA uses `buildLargeScreenUpsellCtaLink` with `utm_content=profile_cta`
- Tracking: `page: Profile`, `button: upgrade`, plus `deeplink_clicked`

**Breaking** (`@features/flow-large-screen-upsell` major): `buildLargeScreenUpsellCtaLink` now requires `utmContent`. UTM values live in `LARGE_SCREEN_UPSELL_UTM`. Mobile still uses its local helper and does not need a change.

```ts
buildLargeScreenUpsellCtaLink(link, "desktop", LARGE_SCREEN_UPSELL_UTM.content.profile_cta);
```

https://github.com/user-attachments/assets/2a15e69b-1c33-4999-9fba-1bd324d28142



### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35481](https://ledgerhq.atlassian.net/browse/LIVE-35481)
- **ADR** (if any):

[LIVE-35481]: https://ledgerhq.atlassian.net/browse/LIVE-35481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ