### PR TITLE
[LWDM] feat(coin-aleo): implement register method (LIVE-34144)

### DIFF
--- a/.changeset/lucky-icons-matter.md
+++ b/.changeset/lucky-icons-matter.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+Add the `register` method to the coin-aleo framework API: it seals the account view key to the Provable record scanner and returns the `{ type: "aleo", provableId }` handle, sharing the seal-and-enroll sequence with the bridge's `accessProvableApi`.

--- a/libs/coin-modules/coin-aleo/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.integ.test.ts
@@ -303,4 +303,20 @@ describe("createApi", () => {
       expect(balance).toEqual([{ value: 0n, asset: { type: "native" } }]);
     });
   });
+
+  describe("register", () => {
+    it("reads the view key off the context and enrolls it into the testnet scanner", async () => {
+      const contextWithViewKey: AleoContext = { ...context, viewKey: testnetViewKey };
+
+      const result = await api.register(contextWithViewKey, testnetAddress);
+
+      invariant(result.type === "aleo", "guard: expected an aleo registration handle");
+      expect(typeof result.provableId).toBe("string");
+      expect(result.provableId.length).toBeGreaterThan(0);
+    });
+
+    it("rejects before any network call when the context carries no view key", async () => {
+      await expect(api.register(context, testnetAddress)).rejects.toThrow(/view key is required/);
+    });
+  });
 });

--- a/libs/coin-modules/coin-aleo/src/api/index.test.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.test.ts
@@ -15,6 +15,7 @@ import {
   getBalance,
   lastBlock,
   listOperations,
+  register,
 } from "../logic";
 import { buildFeeConfigurationForRootIntent, getTransactionType } from "../logic/utils";
 import type { AleoContext } from "../types";
@@ -37,6 +38,7 @@ describe("createApi", () => {
   const mockedGetBalance = jest.mocked(getBalance);
   const mockedLastBlock = jest.mocked(lastBlock);
   const mockedListOperations = jest.mocked(listOperations);
+  const mockedRegister = jest.mocked(register);
   const mockedGetTransactionType = jest.mocked(getTransactionType);
   const mockedBuildFeeConfigurationForRootIntent = jest.mocked(buildFeeConfigurationForRootIntent);
 
@@ -59,6 +61,7 @@ describe("createApi", () => {
       max_base_fee: "1234",
       max_priority_fee: "0",
     });
+    mockedRegister.mockResolvedValue({ type: "aleo", provableId: "scan-uuid-123" });
   });
 
   it("should return an API object with coin module api methods", () => {
@@ -73,6 +76,7 @@ describe("createApi", () => {
     expect(api.listOperations).toBeInstanceOf(Function);
     expect(api.craftTransactionData).toBeInstanceOf(Function);
     expect(api.getAccountInfo).toBeInstanceOf(Function);
+    expect(api.register).toBeInstanceOf(Function);
   });
 
   describe("getAccountInfo", () => {
@@ -423,10 +427,38 @@ describe("createApi", () => {
   });
 
   describe("register", () => {
-    it("should throw unsupported error", async () => {
+    it("reads the view key off the context and delegates to logic register, returning the handle", async () => {
+      const api = createApi("aleo");
+      const enrolledContext: AleoContext = { ...context, viewKey: "AViewKey1mockviewkey" };
+
+      const result = await api.register(enrolledContext, "aleo1test");
+
+      expect(mockedRegister).toHaveBeenCalledTimes(1);
+      expect(mockedRegister).toHaveBeenCalledWith(mockConfig, "AViewKey1mockviewkey");
+      expect(result).toEqual({ type: "aleo", provableId: "scan-uuid-123" });
+    });
+
+    it("rejects before any network call when the context carries no view key", async () => {
       const api = createApi("aleo");
 
-      await expect(api.register(context, "aleo1test")).rejects.toThrow("register is not supported");
+      await expect(api.register(context, "aleo1test")).rejects.toThrow(/view key is required/);
+      expect(mockedRegister).not.toHaveBeenCalled();
+    });
+
+    it("rejects before any network call when the view key is empty", async () => {
+      const api = createApi("aleo");
+      const emptyContext: AleoContext = { ...context, viewKey: "" };
+
+      await expect(api.register(emptyContext, "aleo1test")).rejects.toThrow(/view key is required/);
+      expect(mockedRegister).not.toHaveBeenCalled();
+    });
+
+    it("keeps the raw view key out of the rejection message", async () => {
+      const api = createApi("aleo");
+
+      await expect(api.register(context, "aleo1test")).rejects.toThrow(
+        expect.objectContaining({ message: expect.not.stringContaining("AViewKey") }),
+      );
     });
   });
 });

--- a/libs/coin-modules/coin-aleo/src/api/index.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.ts
@@ -27,23 +27,26 @@ import {
   getBalance,
   lastBlock,
   listOperations,
+  register,
   validateAddress,
 } from "../logic";
 import { buildFeeConfigurationForRootIntent, getTransactionType } from "../logic/utils";
-import type { AleoContext, AleoCoinConfig, AleoTransactionIntentData } from "../types";
+import type {
+  AleoContext,
+  AleoCoinConfig,
+  AleoRegistration,
+  AleoTransactionIntentData,
+} from "../types";
+
+type AleoCoinModuleApi = CoinModuleApi<AleoCoinConfig, MemoNotSupported, AleoTransactionIntentData>;
 
 // currencyId is captured here (it can't live on the Context). The logic functions are shared with
 // the classic bridge (config-based), so each method resolves config via context.config() and passes
 // it down — no context-first wrappers.
-export function createApi(
-  currencyId: string,
-): CoinModuleApi<AleoCoinConfig, MemoNotSupported, AleoTransactionIntentData> {
+export function createApi(currencyId: string): AleoCoinModuleApi {
   return {
     async call() {
       throw new Error("call is not supported");
-    },
-    async register() {
-      throw new Error("register is not supported");
     },
     broadcast: (_context: AleoContext, _signature: string): Promise<string> => {
       throw new Error("broadcast is not supported");
@@ -191,5 +194,15 @@ export function createApi(
     validateAddress: (_context: AleoContext, address, parameters) =>
       validateAddress(address, parameters),
     craftTransactionData: (_context, intent) => craftTransactionData(intent),
+    // `address` is unused: enrollment is keyed by the view key, not the address.
+    register: async (context: AleoContext, _address: string): Promise<AleoRegistration> => {
+      const viewKey = context.viewKey;
+      invariant(
+        typeof viewKey === "string" && viewKey.length > 0,
+        "aleo/register: a view key is required on the context to register with the Provable scanner",
+      );
+      const config = await context.config();
+      return register(config, viewKey);
+    },
   };
 }

--- a/libs/coin-modules/coin-aleo/src/constants.ts
+++ b/libs/coin-modules/coin-aleo/src/constants.ts
@@ -34,6 +34,14 @@ export const PRIVATE_TRANSFER_FUNCTIONS = new Set([
   EXPLORER_TRANSFER_TYPES.PUBLIC_TO_PRIVATE,
 ]);
 
+// Functions that produce owned records without transferring anything,
+// so their transition holds no recipient and no amount.
+export const NON_TRANSFER_FUNCTIONS = new Set([
+  "join",
+  "split",
+  EXPLORER_TRANSFER_TYPES.FEE_PRIVATE,
+]);
+
 // Semi-public function names that cross the public/private boundary.
 // These appear in public token operations AND have matching private records,
 // so they need to be patched during private sync (analogous to coin ops patching).

--- a/libs/coin-modules/coin-aleo/src/logic/index.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/index.ts
@@ -6,5 +6,6 @@ export { getAccountInfo } from "./getAccountInfo";
 export { getBalance } from "./getBalance";
 export { lastBlock } from "./lastBlock";
 export { listOperations } from "./listOperations";
+export { register } from "./register";
 export { validateIntent } from "./validateIntent";
 export { validateAddress } from "./validateAddress";

--- a/libs/coin-modules/coin-aleo/src/logic/register.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/register.integ.test.ts
@@ -1,0 +1,48 @@
+import aleoConfig from "../config";
+import { testnetViewKey } from "../__tests__/fixtures/api.fixture";
+import { getTestnetIntegConfig } from "../__tests__/fixtures/config.fixture";
+import { getPristineAccount } from "../__tests__/helpers/account";
+import { register } from "./register";
+
+describe("register", () => {
+  const config = getTestnetIntegConfig();
+
+  beforeAll(() => {
+    aleoConfig.setCoinConfig(() => config);
+  });
+
+  it("enrolls a view key into the testnet scanner and returns an aleo handle", async () => {
+    const result = await register(config, testnetViewKey);
+
+    expect(result.type).toBe("aleo");
+    expect(typeof result.provableId).toBe("string");
+    expect(result.provableId.length).toBeGreaterThan(0);
+  });
+
+  it("can register the same view key twice and returns an aleo handle for both calls", async () => {
+    const first = await register(config, testnetViewKey);
+    const second = await register(config, testnetViewKey);
+
+    expect(first.type).toBe("aleo");
+    expect(typeof first.provableId).toBe("string");
+    expect(first.provableId.length).toBeGreaterThan(0);
+    expect(second.type).toBe("aleo");
+    expect(typeof second.provableId).toBe("string");
+    expect(second.provableId.length).toBeGreaterThan(0);
+  });
+
+  it("gives distinct view keys distinct handles", async () => {
+    const pristine = await getPristineAccount();
+
+    const [known, fresh] = await Promise.all([
+      register(config, testnetViewKey),
+      register(config, pristine.viewKey),
+    ]);
+
+    expect(fresh.provableId).not.toBe(known.provableId);
+  });
+
+  it("rejects an empty view key before hitting the network", async () => {
+    await expect(register(config, "")).rejects.toThrow(/view key is required/);
+  });
+});

--- a/libs/coin-modules/coin-aleo/src/logic/register.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/register.test.ts
@@ -1,0 +1,101 @@
+import { log } from "@ledgerhq/logs";
+import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
+import { apiClient } from "../network/api";
+import { sdkClient } from "../network/sdk";
+import { register } from "./register";
+
+jest.mock("../network/api");
+jest.mock("../network/sdk");
+jest.mock("@ledgerhq/logs", () => ({ log: jest.fn() }));
+
+const mockGetScannerPublicKey = jest.mocked(apiClient.getScannerPublicKey);
+const mockEncryptRegistrationPayload = jest.mocked(sdkClient.encryptRegistrationPayload);
+const mockRegisterForScanning = jest.mocked(apiClient.registerForScanningAccountRecordsEncrypted);
+const mockGetRecordScannerStatus = jest.mocked(apiClient.getRecordScannerStatus);
+const mockLog = jest.mocked(log);
+
+describe("register", () => {
+  const config = getMockedConfig("mainnet");
+  const viewKey = "AViewKey1mockviewkey";
+  const publicKey = "aleo1publickey";
+  const keyId = "key-id-123";
+  const encryptedData = "encrypted-data-xyz";
+  const provableId = "uuid-abc-def";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetScannerPublicKey.mockResolvedValue({ public_key: publicKey, key_id: keyId });
+    mockEncryptRegistrationPayload.mockResolvedValue({ encrypted: encryptedData });
+    mockRegisterForScanning.mockResolvedValue({ uuid: provableId });
+  });
+
+  it("performs exactly the three seal-and-enroll calls, in order, and returns the handle", async () => {
+    const result = await register(config, viewKey);
+
+    expect(result).toEqual({ type: "aleo", provableId });
+
+    expect(mockGetScannerPublicKey).toHaveBeenCalledTimes(1);
+    expect(mockEncryptRegistrationPayload).toHaveBeenCalledTimes(1);
+    expect(mockRegisterForScanning).toHaveBeenCalledTimes(1);
+
+    const pubkeyOrder = mockGetScannerPublicKey.mock.invocationCallOrder[0];
+    const encryptOrder = mockEncryptRegistrationPayload.mock.invocationCallOrder[0];
+    const registerOrder = mockRegisterForScanning.mock.invocationCallOrder[0];
+    expect(pubkeyOrder).toBeLessThan(encryptOrder);
+    expect(encryptOrder).toBeLessThan(registerOrder);
+  });
+
+  it("passes the scanner public key and view key to encrypt_registration with start=0", async () => {
+    await register(config, viewKey);
+
+    expect(mockGetScannerPublicKey).toHaveBeenCalledWith(config);
+    expect(mockEncryptRegistrationPayload).toHaveBeenCalledWith({
+      config,
+      publicKey,
+      viewKey,
+      start: 0,
+    });
+  });
+
+  it("hands the scanner only key_id + ciphertext — never the raw view key", async () => {
+    await register(config, viewKey);
+
+    expect(mockRegisterForScanning).toHaveBeenCalledWith({
+      config,
+      encryptedData,
+      keyId,
+    });
+
+    const scannerCallArgs = mockRegisterForScanning.mock.calls[0][0];
+    expect(JSON.stringify(scannerCallArgs)).not.toContain(viewKey);
+  });
+
+  it("never reads the scanner /status endpoint", async () => {
+    await register(config, viewKey);
+
+    expect(mockGetRecordScannerStatus).not.toHaveBeenCalled();
+  });
+
+  it("never logs the view key, the sealed ciphertext or the provableId", async () => {
+    await register(config, viewKey);
+
+    const loggedText = mockLog.mock.calls.map(call => JSON.stringify(call)).join(" ");
+    expect(loggedText).not.toContain(viewKey);
+    expect(loggedText).not.toContain(encryptedData);
+    expect(loggedText).not.toContain(provableId);
+  });
+
+  it("fails the view-key invariant before any network call when the view key is empty", async () => {
+    await expect(register(config, "")).rejects.toThrow(/view key is required/);
+
+    expect(mockGetScannerPublicKey).not.toHaveBeenCalled();
+    expect(mockEncryptRegistrationPayload).not.toHaveBeenCalled();
+    expect(mockRegisterForScanning).not.toHaveBeenCalled();
+  });
+
+  it("keeps the raw view key out of the invariant message", async () => {
+    await expect(register(config, "")).rejects.toThrow(
+      expect.objectContaining({ message: expect.not.stringContaining("AViewKey") }),
+    );
+  });
+});

--- a/libs/coin-modules/coin-aleo/src/logic/register.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/register.ts
@@ -1,0 +1,31 @@
+import invariant from "invariant";
+import { apiClient } from "../network/api";
+import { sdkClient } from "../network/sdk";
+import type { AleoCoinConfig, AleoRegistration } from "../types";
+
+/**
+ * Enrolls a view key into the Provable record scanner and returns its `provableId` handle.
+ *
+ * Not idempotent: each call enrolls again, so the caller persists the `provableId` and only
+ * registers when it is missing.
+ */
+export async function register(config: AleoCoinConfig, viewKey: string): Promise<AleoRegistration> {
+  invariant(viewKey, "aleo/register: a view key is required to register with the Provable scanner");
+
+  const { public_key, key_id } = await apiClient.getScannerPublicKey(config);
+
+  const { encrypted: encryptedData } = await sdkClient.encryptRegistrationPayload({
+    config,
+    publicKey: public_key,
+    viewKey,
+    start: 0,
+  });
+
+  const { uuid } = await apiClient.registerForScanningAccountRecordsEncrypted({
+    config,
+    encryptedData,
+    keyId: key_id,
+  });
+
+  return { type: "aleo", provableId: uuid };
+}

--- a/libs/coin-modules/coin-aleo/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.test.ts
@@ -1293,6 +1293,353 @@ describe("network/utils", () => {
       expect(result?.recipient).toBe(recipientAddress);
       expect(result?.value).toEqual(new BigNumber(25000));
     });
+
+    it("should return null without logging for a record-splitting transition (split)", async () => {
+      const rawRecord = getMockedRecord({
+        function_name: "split",
+        sender: mockEnrichAddress,
+        program_name: "usdcx_stablecoin.aleo",
+        record_name: TOKEN_RECORD_NAME,
+        transition_index: 0,
+      });
+      mockGetTransactionById.mockResolvedValueOnce(
+        getMockedTransactionDetails(rawRecord.transaction_id, {
+          execution: {
+            transitions: [
+              {
+                id: "au1",
+                scm: "s",
+                tcm: "t",
+                tpk: "tpk1",
+                inputs: [
+                  { id: "in0", type: "record", tag: "record_tag_0" },
+                  { id: "in1", type: "private", value: "ciphertext_split_amount" },
+                ],
+                outputs: [],
+                program: "usdcx_stablecoin.aleo",
+                function: "split",
+              },
+            ],
+          },
+        }),
+      );
+
+      const result = await enrichPrivateRecord({
+        config: mockConfig,
+        rawRecord,
+        address: mockEnrichAddress,
+        viewKey: mockViewKey,
+      });
+
+      expect(result).toBeNull();
+      expect(mockDecryptCiphertext).not.toHaveBeenCalled();
+      expect(log).not.toHaveBeenCalled();
+    });
+
+    it("should locate recipient/amount after a leading record_with_dynamic_id input (ARC-20 token)", async () => {
+      const recipientAddress = "aleo1arc20dynamicid456";
+      const rawRecord = getMockedRecord({
+        function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
+        sender: mockEnrichAddress,
+        program_name: "arc20_eth.aleo",
+        record_name: TOKEN_RECORD_NAME,
+        transition_index: 0,
+      });
+      mockGetTransactionById.mockResolvedValueOnce(
+        getMockedTransactionDetails(rawRecord.transaction_id, {
+          execution: {
+            transitions: [
+              {
+                id: "au1",
+                scm: "s",
+                tcm: "t",
+                tpk: "tpk_arc20_dynamic",
+                inputs: [
+                  {
+                    id: "in0",
+                    type: "record_with_dynamic_id",
+                    tag: "record_tag_0",
+                    dynamic_id: "dynamic_id_0",
+                  },
+                  { id: "in1", type: "private", value: "ciphertext_recipient" },
+                  { id: "in2", type: "private", value: "ciphertext_amount" },
+                ],
+                outputs: [],
+                program: "arc20_eth.aleo",
+                function: "transfer_private",
+              },
+            ],
+          },
+        }),
+      );
+      mockDecryptCiphertext
+        .mockResolvedValueOnce({ plaintext: recipientAddress })
+        .mockResolvedValueOnce({ plaintext: "200000000000u128" });
+
+      const result = await enrichPrivateRecord({
+        config: mockConfig,
+        rawRecord,
+        address: mockEnrichAddress,
+        viewKey: mockViewKey,
+      });
+
+      expect(result?.recipient).toBe(recipientAddress);
+      expect(result?.value).toEqual(new BigNumber("200000000000"));
+      expect(mockDecryptCiphertext).toHaveBeenCalledWith(
+        expect.objectContaining({ ciphertext: "ciphertext_recipient", outputIndex: 1 }),
+      );
+      expect(mockDecryptCiphertext).toHaveBeenCalledWith(
+        expect.objectContaining({ ciphertext: "ciphertext_amount", outputIndex: 2 }),
+      );
+    });
+
+    it("should read the ARC-21 token_registry.aleo transfer_private layout (recipient, amount, record)", async () => {
+      const recipientAddress = "aleo1registryrecipient321";
+      const rawRecord = getMockedRecord({
+        function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
+        sender: mockEnrichAddress,
+        program_name: PROGRAM_ID.TOKEN_REGISTRY,
+        record_name: TOKEN_RECORD_NAME,
+        transition_index: 0,
+      });
+      mockGetTransactionById.mockResolvedValueOnce(
+        getMockedTransactionDetails(rawRecord.transaction_id, {
+          execution: {
+            transitions: [
+              {
+                id: "au1",
+                scm: "s",
+                tcm: "t",
+                tpk: "tpk_registry",
+                inputs: [
+                  { id: "in0", type: "private", value: "ciphertext_recipient" },
+                  { id: "in1", type: "private", value: "ciphertext_amount" },
+                  { id: "in2", type: "record", tag: "record_tag_2" },
+                ],
+                outputs: [],
+                program: PROGRAM_ID.TOKEN_REGISTRY,
+                function: "transfer_private",
+              },
+            ],
+          },
+        }),
+      );
+      mockDecryptCiphertext
+        .mockResolvedValueOnce({ plaintext: recipientAddress })
+        .mockResolvedValueOnce({ plaintext: "4500u128" });
+
+      const result = await enrichPrivateRecord({
+        config: mockConfig,
+        rawRecord,
+        address: mockEnrichAddress,
+        viewKey: mockViewKey,
+      });
+
+      expect(result?.recipient).toBe(recipientAddress);
+      expect(result?.value).toEqual(new BigNumber(4500));
+      expect(mockDecryptCiphertext).toHaveBeenCalledTimes(2);
+    });
+
+    it("should read the mainnet ARC-20 transfer_private_to_public layout without any decryption", async () => {
+      // real mainnet arc20_eth.aleo transition, tx at14yqq5na8e4j5eftaptylx6qgggvux5tz20fz6wwt0e2g9vv63sxq3khswj
+      const recipientAddress = "aleo1wha60jq3fw6j3spcdm88798f8s6a5pn57xa0j3yrnl86tflevvxs7jt2y7";
+      const rawRecord = getMockedRecord({
+        function_name: EXPLORER_TRANSFER_TYPES.PRIVATE_TO_PUBLIC,
+        sender: mockEnrichAddress,
+        program_name: "arc20_eth.aleo",
+        record_name: TOKEN_RECORD_NAME,
+        transition_index: 0,
+      });
+      mockGetTransactionById.mockResolvedValueOnce(
+        getMockedTransactionDetails(rawRecord.transaction_id, {
+          execution: {
+            transitions: [
+              {
+                id: "au1",
+                scm: "s",
+                tcm: "t",
+                tpk: "tpk_arc20_mainnet",
+                inputs: [
+                  {
+                    id: "in0",
+                    type: "record_with_dynamic_id",
+                    tag: "record_tag_0",
+                    dynamic_id:
+                      "5187684512444170691509259038386389946045003282669141330013325607829823143029field",
+                  },
+                  { id: "in1", type: "public", value: recipientAddress },
+                  { id: "in2", type: "public", value: "489473792514000772u128" },
+                ],
+                outputs: [],
+                program: "arc20_eth.aleo",
+                function: "transfer_private_to_public",
+              },
+            ],
+          },
+        }),
+      );
+
+      const result = await enrichPrivateRecord({
+        config: mockConfig,
+        rawRecord,
+        address: mockEnrichAddress,
+        viewKey: mockViewKey,
+      });
+
+      expect(result?.recipient).toBe(recipientAddress);
+      expect(result?.value).toEqual(new BigNumber("489473792514000772"));
+      expect(mockDecryptCiphertext).not.toHaveBeenCalled();
+    });
+
+    it("should skip a leading token_id ciphertext before the recipient ciphertext", async () => {
+      const recipientAddress = "aleo1wrappedarc20recipient";
+      const rawRecord = getMockedRecord({
+        function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
+        sender: mockEnrichAddress,
+        program_name: "arc20_wrapper.aleo",
+        record_name: TOKEN_RECORD_NAME,
+        transition_index: 0,
+      });
+      mockGetTransactionById.mockResolvedValueOnce(
+        getMockedTransactionDetails(rawRecord.transaction_id, {
+          execution: {
+            transitions: [
+              {
+                id: "au1",
+                scm: "s",
+                tcm: "t",
+                tpk: "tpk_wrapper",
+                inputs: [
+                  { id: "in0", type: "private", value: "ciphertext_token_id" },
+                  { id: "in1", type: "record_dynamic" },
+                  { id: "in2", type: "private", value: "ciphertext_recipient" },
+                  { id: "in3", type: "private", value: "ciphertext_amount" },
+                ],
+                outputs: [],
+                program: "arc20_wrapper.aleo",
+                function: "transfer_private_1",
+              },
+            ],
+          },
+        }),
+      );
+      mockDecryptCiphertext
+        .mockResolvedValueOnce({ plaintext: "1751493913335802797273486270field" })
+        .mockResolvedValueOnce({ plaintext: recipientAddress })
+        .mockResolvedValueOnce({ plaintext: "900u128" });
+
+      const result = await enrichPrivateRecord({
+        config: mockConfig,
+        rawRecord,
+        address: mockEnrichAddress,
+        viewKey: mockViewKey,
+      });
+
+      expect(result?.recipient).toBe(recipientAddress);
+      expect(result?.value).toEqual(new BigNumber(900));
+      expect(mockDecryptCiphertext).toHaveBeenCalledTimes(3);
+      expect(mockDecryptCiphertext).toHaveBeenCalledWith(
+        expect.objectContaining({ ciphertext: "ciphertext_recipient", outputIndex: 2 }),
+      );
+      expect(mockDecryptCiphertext).toHaveBeenCalledWith(
+        expect.objectContaining({ ciphertext: "ciphertext_amount", outputIndex: 3 }),
+      );
+    });
+
+    it("should ignore the trailing merkle proof argument (real ARC-22 layout)", async () => {
+      const recipientAddress = "aleo1arc22recipient777";
+      const rawRecord = getMockedRecord({
+        function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
+        sender: mockEnrichAddress,
+        program_name: "test_usad_stablecoin.aleo",
+        record_name: TOKEN_RECORD_NAME,
+        transition_index: 0,
+      });
+      mockGetTransactionById.mockResolvedValueOnce(
+        getMockedTransactionDetails(rawRecord.transaction_id, {
+          execution: {
+            transitions: [
+              {
+                id: "au1",
+                scm: "s",
+                tcm: "t",
+                tpk: "tpk_arc22",
+                inputs: [
+                  { id: "in0", type: "private", value: "ciphertext_recipient" },
+                  { id: "in1", type: "private", value: "ciphertext_amount" },
+                  { id: "in2", type: "record", tag: "record_tag_2" },
+                  { id: "in3", type: "private", value: "ciphertext_merkle_proof" },
+                ],
+                outputs: [],
+                program: "test_usad_stablecoin.aleo",
+                function: "transfer_private",
+              },
+            ],
+          },
+        }),
+      );
+      mockDecryptCiphertext
+        .mockResolvedValueOnce({ plaintext: recipientAddress })
+        .mockResolvedValueOnce({ plaintext: "1u128" })
+        .mockResolvedValueOnce({ plaintext: "{ siblings: [ 123field, 456field ] }" });
+
+      const result = await enrichPrivateRecord({
+        config: mockConfig,
+        rawRecord,
+        address: mockEnrichAddress,
+        viewKey: mockViewKey,
+      });
+
+      expect(result?.recipient).toBe(recipientAddress);
+      expect(result?.value).toEqual(new BigNumber(1));
+      expect(mockDecryptCiphertext).toHaveBeenCalledTimes(3);
+    });
+
+    it("should decrypt private-argument transfer_private_to_public (ARC-20 private flavour)", async () => {
+      const recipientAddress = "aleo1arc20privflavour99";
+      const rawRecord = getMockedRecord({
+        function_name: EXPLORER_TRANSFER_TYPES.PRIVATE_TO_PUBLIC,
+        sender: mockEnrichAddress,
+        program_name: "btcx_8e1ed4.aleo",
+        record_name: TOKEN_RECORD_NAME,
+        transition_index: 0,
+      });
+      mockGetTransactionById.mockResolvedValueOnce(
+        getMockedTransactionDetails(rawRecord.transaction_id, {
+          execution: {
+            transitions: [
+              {
+                id: "au1",
+                scm: "s",
+                tcm: "t",
+                tpk: "tpk_arc20_priv",
+                inputs: [
+                  { id: "in0", type: "record", tag: "record_tag_0" },
+                  { id: "in1", type: "private", value: "ciphertext_recipient" },
+                  { id: "in2", type: "private", value: "ciphertext_amount" },
+                ],
+                outputs: [],
+                program: "btcx_8e1ed4.aleo",
+                function: "transfer_private_to_public",
+              },
+            ],
+          },
+        }),
+      );
+      mockDecryptCiphertext
+        .mockResolvedValueOnce({ plaintext: recipientAddress })
+        .mockResolvedValueOnce({ plaintext: "25000u128" });
+
+      const result = await enrichPrivateRecord({
+        config: mockConfig,
+        rawRecord,
+        address: mockEnrichAddress,
+        viewKey: mockViewKey,
+      });
+
+      expect(result?.recipient).toBe(recipientAddress);
+      expect(result?.value).toEqual(new BigNumber(25000));
+    });
   });
 
   describe("patchPublicOperations", () => {
@@ -1409,6 +1756,64 @@ describe("network/utils", () => {
             extra: expect.objectContaining({ patched: true }),
           }),
         ]),
+      );
+    });
+
+    it("should skip the leading token_id when decrypting a token_registry.aleo recipient", async () => {
+      // real mainnet token_registry.aleo transition, tx at1zlma4d7xdhaxnrv2hhnc6arpp959sj29y66vvhcsk50mrfsrm5gqmmpt2z
+      const txHash = "at1zlma4d7xdhaxnrv2hhnc6arpp959sj29y66vvhcsk50mrfsrm5gqmmpt2z";
+      const tokenId =
+        "6088188135219746443092391282916151282477828391085949070550825603498725268775field";
+      const publicOp = getMockedOperation({
+        hash: txHash,
+        type: "OUT",
+        extra: {
+          functionId: "transfer_public_to_private",
+          transactionType: "public",
+          programId: PROGRAM_ID.TOKEN_REGISTRY,
+        },
+      });
+      mockGetTransactionById.mockResolvedValueOnce(
+        getMockedTransactionDetails(txHash, {
+          block_height: 21152368,
+          execution: {
+            transitions: [
+              {
+                id: "au1",
+                scm: "s",
+                tcm: "t",
+                tpk: "tpk_registry_mainnet",
+                inputs: [
+                  { id: "in0", type: "public", value: tokenId },
+                  { id: "in1", type: "private", value: "ciphertext_recipient" },
+                  { id: "in2", type: "public", value: "730000u128" },
+                  { id: "in3", type: "public", value: "false" },
+                ],
+                outputs: [],
+                program: PROGRAM_ID.TOKEN_REGISTRY,
+                function: "transfer_public_to_private",
+              },
+            ],
+          },
+        }),
+      );
+      mockDecryptCiphertext.mockResolvedValueOnce({ plaintext: "aleo1registrytokenrecipient" });
+
+      const result = await patchPublicOperations({
+        config: mockConfig,
+        publicOperations: [publicOp],
+        privateRecords: [],
+        address: patchAddress,
+        ledgerAccountId,
+        viewKey: patchViewKey,
+      });
+
+      expect(result).toEqual([
+        expect.objectContaining({ recipients: ["aleo1registrytokenrecipient"] }),
+      ]);
+      expect(mockDecryptCiphertext).toHaveBeenCalledTimes(1);
+      expect(mockDecryptCiphertext).toHaveBeenCalledWith(
+        expect.objectContaining({ ciphertext: "ciphertext_recipient", outputIndex: 1 }),
       );
     });
 
@@ -2525,6 +2930,66 @@ describe("network/utils", () => {
       });
 
       expect(mockGetTransactionById).toHaveBeenCalledWith(mockConfig, "tx_with_spaces");
+    });
+
+    it("should decrypt recipient and amount at indices 1/2 when there is one leading record input", async () => {
+      const recipientAddress = "aleo1arc20outrecipient";
+      const record = getMockedRecord({
+        function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
+        transaction_id: "tx_arc20_out",
+        transition_index: 0,
+        program_name: "arc20_token.aleo",
+      });
+      mockGetTransactionById.mockResolvedValueOnce(
+        getMockedTransactionDetails(record.transaction_id, {
+          fee_value: 7000,
+          execution: {
+            transitions: [
+              {
+                id: "au1",
+                scm: "s",
+                tcm: "t",
+                tpk: "tpk_arc20",
+                inputs: [
+                  { id: "in0", type: "record", tag: "record_tag_0" },
+                  { id: "in1", type: "private", value: "ciphertext_recipient" },
+                  { id: "in2", type: "private", value: "ciphertext_amount" },
+                ],
+                outputs: [],
+                program: record.program_name,
+                function: "transfer_private",
+              },
+            ],
+          },
+        }),
+      );
+      mockDecryptCiphertext
+        .mockResolvedValueOnce({ plaintext: recipientAddress })
+        .mockResolvedValueOnce({ plaintext: "600000u64" });
+
+      const result = await getTokenOutDetails({
+        config: mockConfig,
+        record,
+        viewKey: mockViewKey,
+      });
+
+      expect(result).toEqual({
+        amount: new BigNumber(600000),
+        recipient: recipientAddress,
+        fee: new BigNumber(7000),
+      });
+      expect(mockDecryptCiphertext).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ciphertext: "ciphertext_recipient",
+          outputIndex: 1,
+        }),
+      );
+      expect(mockDecryptCiphertext).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ciphertext: "ciphertext_amount",
+          outputIndex: 2,
+        }),
+      );
     });
   });
 });

--- a/libs/coin-modules/coin-aleo/src/network/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.ts
@@ -28,6 +28,7 @@ import {
   parseAmount,
   parseMicrocredits,
 } from "../logic/utils";
+import { register } from "../logic/register";
 import { apiClient } from "./api";
 
 export async function decryptRecordAmount(
@@ -325,22 +326,8 @@ export async function accessProvableApi({
   let status;
 
   if (!uuid) {
-    const { public_key, key_id } = await apiClient.getScannerPublicKey(config);
-
-    const { encrypted: encryptedData } = await sdkClient.encryptRegistrationPayload({
-      config,
-      publicKey: public_key,
-      viewKey,
-      start: 0,
-    });
-
-    const { uuid: accountUuid } = await apiClient.registerForScanningAccountRecordsEncrypted({
-      config,
-      encryptedData,
-      keyId: key_id,
-    });
-
-    uuid = accountUuid;
+    const { provableId } = await register(config, viewKey);
+    uuid = provableId;
   }
 
   status = await getRecordScannerStatusOrThrow(config, uuid);

--- a/libs/coin-modules/coin-aleo/src/types/logic.ts
+++ b/libs/coin-modules/coin-aleo/src/types/logic.ts
@@ -12,6 +12,8 @@ import type {
 } from "./api";
 import type { AleoDecryptedRecordResponse } from "./sdk";
 
+export type AleoRegistration = { type: "aleo"; provableId: string };
+
 export interface AleoUnspentRecord extends AleoPrivateRecord {
   microcredits: string;
   decryptedData: AleoDecryptedRecordResponse;


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Add the `register` method to the coin-aleo framework API: it seals the account view key to the Provable record scanner and returns the `{ type: "aleo", provableId }` handle, sharing the seal-and-enroll sequence with the bridge's `accessProvableApi`.

### 🔗 Context

https://ledgerhq.atlassian.net/browse/LIVE-34144