### PR TITLE
fix(ci-sast): correct permissions on push workflow for sast scan

### DIFF
--- a/.github/workflows/build-and-test-push.yml
+++ b/.github/workflows/build-and-test-push.yml
@@ -266,6 +266,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      security-events: write
     uses: LedgerHQ/ledger-live/.github/workflows/test-mobile-e2e-lint-reusable.yml@develop
     secrets:
       AWS_ACCOUNT_ID_PROD: ${{ secrets.AWS_ACCOUNT_ID_PROD }}


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Elevate permissions for ci sast scanning

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
