### PR TITLE
fix(ci-sast): update permissions in build-and-test-push

### DIFF
--- a/.github/workflows/build-and-test-push.yml
+++ b/.github/workflows/build-and-test-push.yml
@@ -260,13 +260,14 @@ jobs:
   test-additional:
     name: "Test Additional"
     uses: LedgerHQ/ledger-live/.github/workflows/test-additional.yml@develop
+    permissions: 
+      security-events: write
 
   test-mobile-e2e-lint:
     name: "Mobile E2E Lint & Typecheck"
     permissions:
       id-token: write
       contents: read
-      security-events: write
     uses: LedgerHQ/ledger-live/.github/workflows/test-mobile-e2e-lint-reusable.yml@develop
     secrets:
       AWS_ACCOUNT_ID_PROD: ${{ secrets.AWS_ACCOUNT_ID_PROD }}


### PR DESCRIPTION
Added permissions for security events in test-additional job.

<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

U;date ci sast perms on push

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
