### PR TITLE
feat(mobile): add Contacts intro debug toggle

### DIFF
--- a/.changeset/bright-contacts-intro.md
+++ b/.changeset/bright-contacts-intro.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add a Contacts feature introduction toggle to Mobile Debug settings.

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/__tests__/useContactsDevToolViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/__tests__/useContactsDevToolViewModel.test.ts
@@ -97,4 +97,21 @@ describe("useContactsDevToolViewModel", () => {
       expect.objectContaining({ id: "contact-me", isMe: true, name: "Me" }),
     ]);
   });
+
+  it("should toggle the Contacts feature introduction dismissed state", () => {
+    const { result, store } = renderHook(() => useContactsDevToolViewModel(), {
+      overrideInitialState: state => ({
+        ...state,
+        settings: { ...state.settings, hasDismissedContactsFeatureIntroduction: true },
+      }),
+    });
+
+    expect(result.current.hasDismissedFeatureIntroduction).toBe(true);
+
+    act(() => {
+      result.current.handleToggleFeatureIntroductionDismissed();
+    });
+
+    expect(store.getState().settings.hasDismissedContactsFeatureIntroduction).toBe(false);
+  });
 });

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/index.tsx
@@ -18,8 +18,10 @@ export default function DebugContacts() {
     isEnabled,
     newBadge,
     eligibleAddressFamilies,
+    hasDismissedFeatureIntroduction,
     handleToggleEnabled,
     handleToggleNewBadge,
+    handleToggleFeatureIntroductionDismissed,
     handleSetEligibleAddressFamilies,
     handleRestoreDefaults,
     handleLoadSamples,
@@ -74,6 +76,25 @@ export default function DebugContacts() {
             isEnabled={isEnabled}
             families={eligibleAddressFamilies}
             onPresetSelect={handleSetEligibleAddressFamilies}
+          />
+        </Box>
+
+        <SectionHeader title="FEATURE INTRODUCTION" />
+
+        <Box
+          lx={{
+            backgroundColor: "surface",
+            borderRadius: "md",
+            padding: "s8",
+            marginBottom: "s24",
+          }}
+        >
+          <FeatureParamRow
+            label="Show introduction"
+            isFeatureEnabled
+            value={!hasDismissedFeatureIntroduction}
+            onToggle={handleToggleFeatureIntroductionDismissed}
+            testID="debug-contacts-feature-introduction-switch"
           />
         </Box>
 

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/useContactsDevToolViewModel.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/useContactsDevToolViewModel.ts
@@ -1,5 +1,4 @@
 import { useCallback, useMemo } from "react";
-import { useDispatch } from "react-redux";
 import { setContacts } from "@domain/entity-contact";
 import { useFeature } from "@features/platform-feature-flags";
 import {
@@ -8,12 +7,18 @@ import {
   type ContactsFeatureValuePatch,
 } from "@features/flow-contacts";
 import { setOverride } from "@shared/feature-flags";
+import { setHasDismissedContactsFeatureIntroduction } from "~/actions/settings";
+import { useDispatch, useSelector } from "~/context/hooks";
+import { hasDismissedContactsFeatureIntroductionSelector } from "~/reducers/settings";
 import { CONTACTS_FLAG } from "./constants";
 import { createContactsDebugSamples } from "./mockContacts";
 
 export function useContactsDevToolViewModel() {
   const dispatch = useDispatch();
   const featureFlag = useFeature(CONTACTS_FLAG);
+  const hasDismissedFeatureIntroduction = useSelector(
+    hasDismissedContactsFeatureIntroductionSelector,
+  );
   const isEnabled = featureFlag?.enabled === true;
   const params = useMemo(
     () => resolveContactsFeatureParams(featureFlag?.params),
@@ -59,13 +64,19 @@ export function useContactsDevToolViewModel() {
     dispatch(setContacts([]));
   }, [dispatch]);
 
+  const handleToggleFeatureIntroductionDismissed = useCallback(() => {
+    dispatch(setHasDismissedContactsFeatureIntroduction(!hasDismissedFeatureIntroduction));
+  }, [dispatch, hasDismissedFeatureIntroduction]);
+
   return {
     featureFlag,
     isEnabled,
     newBadge: params.newBadge,
     eligibleAddressFamilies: params.eligibleAddressFamilies,
+    hasDismissedFeatureIntroduction,
     handleToggleEnabled,
     handleToggleNewBadge,
+    handleToggleFeatureIntroductionDismissed,
     handleSetEligibleAddressFamilies,
     handleRestoreDefaults,
     handleLoadSamples,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** The Contacts Debug ViewModel test verifies the toggle resets the dismissed preference.
- [x] **Impact of the changes:**
      In Settings > Debug > Contacts, enable Show introduction, then open Contacts to replay it.

### 📝 Description

Mobile testers could not replay the Contacts feature introduction after dismissing it, despite an existing Contacts Debug panel.

This PR adds a Show introduction toggle to that existing panel, matching the Desktop Contacts Debug behavior. When enabled, it resets the existing Redux preference so the real introduction appears on the next Contacts visit.
<img width="304" height="308" alt="image" src="https://github.com/user-attachments/assets/2770aac7-8e2e-4d58-8857-a0110392334f" />

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-35862

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)