### PR TITLE
feat(pay-card): add deposit options component and views (LIVE-34910)

### DIFF
--- a/.changeset/LIVE-34910-pay-card-deposit-options.md
+++ b/.changeset/LIVE-34910-pay-card-deposit-options.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-pay-card-deposit": minor
+---
+
+Add the shared Pay Card Deposit options component and view-model to `@features/flow-pay-card-deposit`: a Lumen dialog on desktop and a bottom sheet on mobile listing the four deposit options (bank transfer, swap, receive, buy), emitting host-owned navigation intents via `onSelect` and tracking via the injected `onTrackEvent`.

--- a/features/flow/pay-card-deposit/README.md
+++ b/features/flow/pay-card-deposit/README.md
@@ -1,36 +1,70 @@
 # Pay Card Deposit
 
 > [!CAUTION]
-> **Status: UNSTABLE** — Scaffold only; public API is still being designed.
+> **Status: UNSTABLE** — In active development; API may change.
 
-Dual-platform flow package that will host the Pay tab **Deposit options** experience for Ledger
-Wallet (bottom sheet on mobile, dialog on desktop).
+Dual-platform flow package for the Pay tab **Deposit options** experience for Ledger Wallet:
+a Lumen `Dialog` on desktop and a `QueuedBottomSheet` on mobile, both listing the same four
+deposit options (Bank transfer, Swap, Receive, Buy).
 
-## Scope
+## Usage
 
-This package is currently an **empty scaffold** created in
-[LIVE-36004](https://ledgerhq.atlassian.net/browse/LIVE-36004) so it can be reviewed on its own and
-imported by the follow-up UI tickets.
+```tsx
+import { DepositOptions } from "@features/flow-pay-card-deposit";
 
-The Deposit options list (Bank transfer, Swap, Receive, Buy), its view-model, Lumen rows, host
-navigation intents and tracking are added in
-[LIVE-34910](https://ledgerhq.atlassian.net/browse/LIVE-34910) and its platform tickets. Until then
-the barrels only expose a compile-only placeholder.
+<DepositOptions
+  isOpen={isDepositOpen}
+  page="Pay"
+  labels={{
+    title: t("payTab.deposit.title"),
+    options: {
+      bankTransfer: { title: t("..."), description: t("...") },
+      swap: { title: t("..."), description: t("...") },
+      receive: { title: t("..."), description: t("...") },
+      buy: { title: t("..."), description: t("...") },
+    },
+  }}
+  onClose={closeDeposit}
+  onSelect={handleDepositOption}
+  onTrackEvent={track}
+/>;
+```
+
+The overlay is opened by the host (the Pay tab Deposit / "add stablecoins" action tile) via a local
+`isOpen` boolean. The view stays props-only: it emits `onSelect(id)` and the host owns navigation
+(Swap tab, Receive filtered to stablecoins, Buy live app, Bank transfer flow). i18n and analytics
+resolution stay in the app; this package stays i18n-agnostic.
+
+### Tracking
+
+On press the view-model emits `button_clicked { button, buttonLocation: "deposit", page }` via the
+injected `onTrackEvent`, where `button` is `bank transfer` | `swap` | `receive via crypto address` |
+`buy` (per the
+[Pay Tracking Plan](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7331315855/Pay+-+Tracking+Plan)).
 
 ## Platform resolution
 
-The package follows the dual-platform flow template: `package.json` resolves `.` through a
-`react-native` condition (`src/index.native.ts`) and a `default` condition (`src/index.ts`), and
-platform-specific views will use `.web.tsx` / `.native.tsx` suffixes resolved by the bundlers and
-`tsconfig.{web,native}.json`.
+Only the view carries a platform suffix (`.web` / `.native`). The container, view-model, and
+`types.ts` are platform-agnostic and import without a suffix; TypeScript `moduleSuffixes`, the
+bundlers (Rspack / Metro) and the jest preset resolve the right side. Each view has a test importing
+it through its full platform filename.
 
 ## Structure
+
+Every `index.*` is a pure barrel (`export *` only).
 
 ```text
 pay-card-deposit/
 ├── package.json
 └── src/
-    ├── index.ts              # Public API (default)
-    ├── index.native.ts       # Public API (react-native condition)
-    └── placeholder.ts        # Compile-only placeholder (removed once real exports land)
+    ├── components/DepositOptions/
+    │   ├── DepositOptions.tsx                 # Container (platform-agnostic)
+    │   ├── useDepositOptionsViewModel.ts      # options + tracking + close
+    │   ├── DepositOptionsView.web.tsx         # Lumen Dialog
+    │   ├── DepositOptionsView.native.tsx      # QueuedBottomSheet
+    │   └── __tests__/
+    ├── types.ts                               # Component + option contracts
+    ├── exports.ts                             # Public surface (container + types)
+    ├── index.ts                               # Public API barrel → ./exports
+    └── index.native.ts                        # Native public API barrel → ./exports
 ```

--- a/features/flow/pay-card-deposit/package.json
+++ b/features/flow/pay-card-deposit/package.json
@@ -2,7 +2,7 @@
   "name": "@features/flow-pay-card-deposit",
   "version": "0.1.0",
   "private": true,
-  "description": "Pay Card deposit flow for Ledger Wallet (scaffold)",
+  "description": "Pay Card deposit options flow for Ledger Wallet",
   "main": "src/index.ts",
   "react-native": "src/index.native.ts",
   "types": "src/index.ts",
@@ -27,13 +27,25 @@
     "coverage": "jest --coverage",
     "unimported": "pnpm knip --directory ../../.. -W features/flow/pay-card-deposit"
   },
+  "dependencies": {
+    "@shared/ui-queued-bottom-sheet": "workspace:*"
+  },
   "devDependencies": {
+    "@features/platform-style": "workspace:*",
+    "@ledgerhq/lumen-design-core": "catalog:",
+    "@ledgerhq/lumen-ui-react": "catalog:",
+    "@ledgerhq/lumen-ui-rnative": "catalog:",
     "@support/jest-features-flow": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
+    "@testing-library/dom": "catalog:",
     "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
+    "@testing-library/react-native": "catalog:",
+    "@testing-library/user-event": "catalog:",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",
+    "@types/react": "catalog:",
     "@typescript-eslint/parser": "catalog:",
     "eslint": "8.57.0",
     "eslint-plugin-better-tailwindcss": "catalog:",
@@ -41,6 +53,10 @@
     "jest-environment-jsdom": "catalog:",
     "oxfmt": "catalog:",
     "oxlint": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "react-native": "catalog:",
+    "react-test-renderer": "catalog:",
     "tailwindcss": "catalog:",
     "typescript": "catalog:"
   },
@@ -49,5 +65,26 @@
     "@oxlint/binding-darwin-x64": "1.51.0",
     "@oxlint/binding-linux-x64-gnu": "1.51.0",
     "@oxlint/binding-win32-x64-msvc": "1.51.0"
+  },
+  "peerDependencies": {
+    "@ledgerhq/lumen-design-core": "catalog:",
+    "@ledgerhq/lumen-ui-react": "catalog:",
+    "@ledgerhq/lumen-ui-rnative": "catalog:",
+    "react": "catalog:",
+    "react-native": "catalog:"
+  },
+  "peerDependenciesMeta": {
+    "react-native": {
+      "optional": true
+    },
+    "@ledgerhq/lumen-ui-react": {
+      "optional": true
+    },
+    "@ledgerhq/lumen-ui-rnative": {
+      "optional": true
+    },
+    "@ledgerhq/lumen-design-core": {
+      "optional": true
+    }
   }
 }

--- a/features/flow/pay-card-deposit/src/components/DepositOptions/DepositOptionParts.native.tsx
+++ b/features/flow/pay-card-deposit/src/components/DepositOptions/DepositOptionParts.native.tsx
@@ -1,0 +1,43 @@
+import React, { useCallback } from "react";
+import { Card, Spot } from "@ledgerhq/lumen-ui-rnative";
+import { ArrowDown, Bank, Cart, Exchange } from "@ledgerhq/lumen-ui-rnative/symbols";
+import type { DepositOptionId } from "../../types";
+
+export {
+  CardContent,
+  CardContentDescription,
+  CardContentTitle,
+  CardHeader,
+  CardLeading,
+} from "@ledgerhq/lumen-ui-rnative";
+
+type SpotIcon = typeof Bank;
+
+const OPTION_ICONS: Readonly<Record<DepositOptionId, SpotIcon>> = {
+  bankTransfer: Bank,
+  swap: Exchange,
+  receive: ArrowDown,
+  buy: Cart,
+};
+
+type DepositOptionCardProps = Readonly<{
+  optionId: DepositOptionId;
+  onSelect: (id: DepositOptionId) => void;
+  children: React.ReactNode;
+}>;
+
+export function DepositOptionCard({ optionId, onSelect, children }: DepositOptionCardProps) {
+  const handlePress = useCallback(() => {
+    onSelect(optionId);
+  }, [onSelect, optionId]);
+
+  return (
+    <Card type="interactive" onPress={handlePress} testID={`pay-card-deposit-option-${optionId}`}>
+      {children}
+    </Card>
+  );
+}
+
+export function DepositOptionIcon({ optionId }: Readonly<{ optionId: DepositOptionId }>) {
+  return <Spot appearance="icon" icon={OPTION_ICONS[optionId]} size={48} />;
+}

--- a/features/flow/pay-card-deposit/src/components/DepositOptions/DepositOptionParts.web.tsx
+++ b/features/flow/pay-card-deposit/src/components/DepositOptions/DepositOptionParts.web.tsx
@@ -1,0 +1,47 @@
+import React, { useCallback } from "react";
+import { Card, Spot } from "@ledgerhq/lumen-ui-react";
+import { ArrowDown, Bank, Cart, Exchange } from "@ledgerhq/lumen-ui-react/symbols";
+import type { DepositOptionId } from "../../types";
+
+export {
+  CardContent,
+  CardContentDescription,
+  CardContentTitle,
+  CardHeader,
+  CardLeading,
+} from "@ledgerhq/lumen-ui-react";
+
+type SpotIcon = typeof Bank;
+
+const OPTION_ICONS: Readonly<Record<DepositOptionId, SpotIcon>> = {
+  bankTransfer: Bank,
+  swap: Exchange,
+  receive: ArrowDown,
+  buy: Cart,
+};
+
+type DepositOptionCardProps = Readonly<{
+  optionId: DepositOptionId;
+  onSelect: (id: DepositOptionId) => void;
+  children: React.ReactNode;
+}>;
+
+export function DepositOptionCard({ optionId, onSelect, children }: DepositOptionCardProps) {
+  const handlePress = useCallback(() => {
+    onSelect(optionId);
+  }, [onSelect, optionId]);
+
+  return (
+    <Card
+      type="interactive"
+      onClick={handlePress}
+      data-testid={`pay-card-deposit-option-${optionId}`}
+    >
+      {children}
+    </Card>
+  );
+}
+
+export function DepositOptionIcon({ optionId }: Readonly<{ optionId: DepositOptionId }>) {
+  return <Spot appearance="icon" icon={OPTION_ICONS[optionId]} size={48} />;
+}

--- a/features/flow/pay-card-deposit/src/components/DepositOptions/DepositOptionRow.tsx
+++ b/features/flow/pay-card-deposit/src/components/DepositOptions/DepositOptionRow.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import {
+  CardContent,
+  CardContentDescription,
+  CardContentTitle,
+  CardHeader,
+  CardLeading,
+  DepositOptionCard,
+  DepositOptionIcon,
+} from "./DepositOptionParts";
+import type { DepositOption, DepositOptionId } from "../../types";
+
+type DepositOptionRowProps = Readonly<{
+  option: DepositOption;
+  onSelect: (id: DepositOptionId) => void;
+}>;
+
+export function DepositOptionRow({ option, onSelect }: DepositOptionRowProps) {
+  return (
+    <DepositOptionCard optionId={option.id} onSelect={onSelect}>
+      <CardHeader>
+        <CardLeading>
+          <DepositOptionIcon optionId={option.id} />
+          <CardContent>
+            <CardContentTitle>{option.title}</CardContentTitle>
+            <CardContentDescription>{option.description}</CardContentDescription>
+          </CardContent>
+        </CardLeading>
+      </CardHeader>
+    </DepositOptionCard>
+  );
+}

--- a/features/flow/pay-card-deposit/src/components/DepositOptions/DepositOptions.tsx
+++ b/features/flow/pay-card-deposit/src/components/DepositOptions/DepositOptions.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { DepositOptionsView } from "./DepositOptionsView";
+import type { DepositOptionsProps } from "../../types";
+import { useDepositOptionsViewModel } from "./useDepositOptionsViewModel";
+
+export function DepositOptions(props: DepositOptionsProps) {
+  const { options, onSelectOption } = useDepositOptionsViewModel(props);
+
+  return (
+    <DepositOptionsView
+      isOpen={props.isOpen}
+      title={props.labels.title}
+      options={options}
+      onClose={props.onClose}
+      onSelectOption={onSelectOption}
+    />
+  );
+}

--- a/features/flow/pay-card-deposit/src/components/DepositOptions/DepositOptionsView.native.tsx
+++ b/features/flow/pay-card-deposit/src/components/DepositOptions/DepositOptionsView.native.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { BottomSheetHeader, BottomSheetScrollView, Box } from "@ledgerhq/lumen-ui-rnative";
+import { QueuedBottomSheet } from "@shared/ui-queued-bottom-sheet";
+import type { DepositOptionsViewProps } from "../../types";
+import { DepositOptionRow } from "./DepositOptionRow";
+
+export function DepositOptionsView({
+  isOpen,
+  title,
+  options,
+  onClose,
+  onSelectOption,
+}: DepositOptionsViewProps) {
+  return (
+    <QueuedBottomSheet
+      isRequestingToBeOpened={isOpen}
+      onClose={onClose}
+      enableDynamicSizing
+      maxDynamicContentSize="fullWithOffset"
+      testID="pay-card-deposit-sheet"
+    >
+      {isOpen ? (
+        <>
+          <BottomSheetHeader spacing density="expanded" title={title} />
+          <BottomSheetScrollView>
+            <Box
+              lx={{ flexDirection: "column", gap: "s8", paddingBottom: "s16" }}
+              testID="pay-card-deposit-options"
+            >
+              {options.map(option => (
+                <DepositOptionRow key={option.id} option={option} onSelect={onSelectOption} />
+              ))}
+            </Box>
+          </BottomSheetScrollView>
+        </>
+      ) : null}
+    </QueuedBottomSheet>
+  );
+}

--- a/features/flow/pay-card-deposit/src/components/DepositOptions/DepositOptionsView.web.tsx
+++ b/features/flow/pay-card-deposit/src/components/DepositOptions/DepositOptionsView.web.tsx
@@ -1,0 +1,40 @@
+import React, { useCallback } from "react";
+import { Dialog, DialogBody, DialogContent, DialogHeader } from "@ledgerhq/lumen-ui-react";
+import type { DepositOptionsViewProps } from "../../types";
+import { DepositOptionRow } from "./DepositOptionRow";
+
+export function DepositOptionsView({
+  isOpen,
+  title,
+  options,
+  onClose,
+  onSelectOption,
+}: DepositOptionsViewProps) {
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <Dialog open onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader density="expanded" title={title} onClose={onClose} />
+        <DialogBody className="flex flex-col gap-8">
+          <div className="flex flex-col gap-8" data-testid="pay-card-deposit-options">
+            {options.map(option => (
+              <DepositOptionRow key={option.id} option={option} onSelect={onSelectOption} />
+            ))}
+          </div>
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/flow/pay-card-deposit/src/components/DepositOptions/__tests__/DepositOptionParts.native.test.tsx
+++ b/features/flow/pay-card-deposit/src/components/DepositOptions/__tests__/DepositOptionParts.native.test.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { cleanup, render, screen, userEvent } from "@testing-library/react-native";
+import { DepositOptionCard, DepositOptionIcon } from "../DepositOptionParts.native";
+
+describe("DepositOptionParts (Native)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("selects the option when the card is pressed", async () => {
+    const user = userEvent.setup();
+    const onSelect = jest.fn();
+    render(
+      <DepositOptionCard optionId="swap" onSelect={onSelect}>
+        <DepositOptionIcon optionId="swap" />
+      </DepositOptionCard>,
+    );
+
+    await user.press(screen.getByTestId("pay-card-deposit-option-swap"));
+
+    expect(onSelect).toHaveBeenCalledWith("swap");
+  });
+});

--- a/features/flow/pay-card-deposit/src/components/DepositOptions/__tests__/DepositOptionParts.web.test.tsx
+++ b/features/flow/pay-card-deposit/src/components/DepositOptions/__tests__/DepositOptionParts.web.test.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DepositOptionCard, DepositOptionIcon } from "../DepositOptionParts.web";
+
+describe("DepositOptionParts (Web)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("selects the option when the card is clicked", async () => {
+    const user = userEvent.setup();
+    const onSelect = jest.fn();
+    render(
+      <DepositOptionCard optionId="swap" onSelect={onSelect}>
+        <DepositOptionIcon optionId="swap" />
+      </DepositOptionCard>,
+    );
+
+    await user.click(screen.getByTestId("pay-card-deposit-option-swap"));
+
+    expect(onSelect).toHaveBeenCalledWith("swap");
+  });
+});

--- a/features/flow/pay-card-deposit/src/components/DepositOptions/__tests__/DepositOptions.web.test.tsx
+++ b/features/flow/pay-card-deposit/src/components/DepositOptions/__tests__/DepositOptions.web.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DepositOptions } from "../DepositOptions";
+import type { DepositOptionsProps } from "../../../types";
+
+const LABELS: DepositOptionsProps["labels"] = {
+  title: "Deposit stablecoin",
+  options: {
+    bankTransfer: { title: "Bank transfer", description: "From your bank account" },
+    swap: { title: "Swap", description: "From your crypto" },
+    receive: { title: "Receive", description: "From another wallet" },
+    buy: { title: "Buy", description: "With card or bank" },
+  },
+};
+
+function renderDeposit(overrides: Partial<DepositOptionsProps> = {}) {
+  const props: DepositOptionsProps = {
+    isOpen: true,
+    labels: LABELS,
+    page: "Pay",
+    onClose: jest.fn(),
+    onSelect: jest.fn(),
+    onTrackEvent: jest.fn(),
+    ...overrides,
+  };
+  return { props, ...render(<DepositOptions {...props} />) };
+}
+
+describe("DepositOptions (Web)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("wires the view-model: tracks, selects and closes on option press", async () => {
+    const user = userEvent.setup();
+    const { props } = renderDeposit();
+
+    await user.click(screen.getByTestId("pay-card-deposit-option-swap"));
+
+    expect(props.onTrackEvent).toHaveBeenCalledWith("button_clicked", {
+      button: "swap",
+      buttonLocation: "deposit",
+      page: "Pay",
+    });
+    expect(props.onSelect).toHaveBeenCalledWith("swap");
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/flow/pay-card-deposit/src/components/DepositOptions/__tests__/DepositOptionsView.native.test.tsx
+++ b/features/flow/pay-card-deposit/src/components/DepositOptions/__tests__/DepositOptionsView.native.test.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { View } from "react-native";
+import { cleanup, render, screen, userEvent } from "@testing-library/react-native";
+import { DepositOptionsView } from "../DepositOptionsView.native";
+
+jest.mock("@shared/ui-queued-bottom-sheet", () => ({
+  QueuedBottomSheet: ({
+    children,
+    isRequestingToBeOpened,
+    testID,
+  }: {
+    children: React.ReactNode;
+    isRequestingToBeOpened?: boolean;
+    testID?: string;
+  }) => (
+    <View testID={testID} accessibilityState={{ expanded: !!isRequestingToBeOpened }}>
+      {children}
+    </View>
+  ),
+}));
+
+const defaultProps: React.ComponentProps<typeof DepositOptionsView> = {
+  isOpen: true,
+  title: "Deposit stablecoin",
+  options: [
+    { id: "bankTransfer", title: "Bank transfer", description: "From your bank account" },
+    { id: "swap", title: "Swap", description: "From your crypto" },
+    { id: "receive", title: "Receive", description: "From another wallet" },
+    { id: "buy", title: "Buy", description: "With card or bank" },
+  ],
+  onClose: jest.fn(),
+  onSelectOption: jest.fn(),
+};
+
+describe("DepositOptionsView (Native)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("keeps the sheet mounted but hides its content while closed", () => {
+    render(<DepositOptionsView {...defaultProps} isOpen={false} />);
+
+    const sheet = screen.getByTestId("pay-card-deposit-sheet");
+    expect(sheet.props.accessibilityState.expanded).toBe(false);
+    expect(screen.queryByTestId("pay-card-deposit-options")).toBeNull();
+  });
+
+  it("requests the sheet to open and renders its options when open", () => {
+    render(<DepositOptionsView {...defaultProps} />);
+
+    const sheet = screen.getByTestId("pay-card-deposit-sheet");
+    expect(sheet.props.accessibilityState.expanded).toBe(true);
+    expect(screen.getByTestId("pay-card-deposit-options")).toBeVisible();
+    expect(screen.getByTestId("pay-card-deposit-option-swap")).toBeVisible();
+  });
+
+  it("emits the pressed option id", async () => {
+    const user = userEvent.setup();
+    const onSelectOption = jest.fn();
+    render(<DepositOptionsView {...defaultProps} onSelectOption={onSelectOption} />);
+
+    await user.press(screen.getByTestId("pay-card-deposit-option-receive"));
+
+    expect(onSelectOption).toHaveBeenCalledWith("receive");
+  });
+});

--- a/features/flow/pay-card-deposit/src/components/DepositOptions/__tests__/DepositOptionsView.web.test.tsx
+++ b/features/flow/pay-card-deposit/src/components/DepositOptions/__tests__/DepositOptionsView.web.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DepositOptionsView } from "../DepositOptionsView.web";
+
+const defaultProps: React.ComponentProps<typeof DepositOptionsView> = {
+  isOpen: true,
+  title: "Deposit stablecoin",
+  options: [
+    { id: "bankTransfer", title: "Bank transfer", description: "From your bank account" },
+    { id: "swap", title: "Swap", description: "From your crypto" },
+    { id: "receive", title: "Receive", description: "From another wallet" },
+    { id: "buy", title: "Buy", description: "With card or bank" },
+  ],
+  onClose: jest.fn(),
+  onSelectOption: jest.fn(),
+};
+
+describe("DepositOptionsView (Web)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the four options when open", () => {
+    render(<DepositOptionsView {...defaultProps} />);
+
+    expect(screen.getByTestId("pay-card-deposit-options")).toBeVisible();
+    expect(screen.getByTestId("pay-card-deposit-option-bankTransfer")).toBeVisible();
+    expect(screen.getByTestId("pay-card-deposit-option-swap")).toBeVisible();
+    expect(screen.getByTestId("pay-card-deposit-option-receive")).toBeVisible();
+    expect(screen.getByTestId("pay-card-deposit-option-buy")).toBeVisible();
+  });
+
+  it("renders nothing when closed", () => {
+    render(<DepositOptionsView {...defaultProps} isOpen={false} />);
+
+    expect(screen.queryByTestId("pay-card-deposit-options")).toBeNull();
+  });
+
+  it("emits the pressed option id", async () => {
+    const user = userEvent.setup();
+    const onSelectOption = jest.fn();
+    render(<DepositOptionsView {...defaultProps} onSelectOption={onSelectOption} />);
+
+    await user.click(screen.getByTestId("pay-card-deposit-option-buy"));
+
+    expect(onSelectOption).toHaveBeenCalledWith("buy");
+  });
+});

--- a/features/flow/pay-card-deposit/src/components/DepositOptions/__tests__/useDepositOptionsViewModel.web.test.ts
+++ b/features/flow/pay-card-deposit/src/components/DepositOptions/__tests__/useDepositOptionsViewModel.web.test.ts
@@ -1,0 +1,66 @@
+import { renderHook } from "@testing-library/react";
+import { useDepositOptionsViewModel } from "../useDepositOptionsViewModel";
+import type { DepositOptionsProps } from "../../../types";
+
+const LABELS: DepositOptionsProps["labels"] = {
+  title: "Deposit stablecoin",
+  options: {
+    bankTransfer: { title: "Bank transfer", description: "From your bank account" },
+    swap: { title: "Swap", description: "From your crypto" },
+    receive: { title: "Receive", description: "From another wallet" },
+    buy: { title: "Buy", description: "With card or bank" },
+  },
+};
+
+function setup(overrides: Partial<DepositOptionsProps> = {}) {
+  const props: DepositOptionsProps = {
+    isOpen: true,
+    labels: LABELS,
+    page: "Pay",
+    onClose: jest.fn(),
+    onSelect: jest.fn(),
+    onTrackEvent: jest.fn(),
+    ...overrides,
+  };
+  const { result } = renderHook(() => useDepositOptionsViewModel(props));
+  return { props, result };
+}
+
+describe("useDepositOptionsViewModel", () => {
+  it("builds the four options in a fixed order", () => {
+    const { result } = setup();
+
+    expect(result.current.options.map(option => option.id)).toEqual([
+      "bankTransfer",
+      "swap",
+      "receive",
+      "buy",
+    ]);
+    expect(result.current.options[0]).toEqual({
+      id: "bankTransfer",
+      title: "Bank transfer",
+      description: "From your bank account",
+    });
+  });
+
+  it("tracks, selects, then closes when an option is picked", () => {
+    const { props, result } = setup();
+
+    result.current.onSelectOption("receive");
+
+    expect(props.onTrackEvent).toHaveBeenCalledWith("button_clicked", {
+      button: "receive via crypto address",
+      buttonLocation: "deposit",
+      page: "Pay",
+    });
+    expect(props.onSelect).toHaveBeenCalledWith("receive");
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not throw when no tracker is provided", () => {
+    const { props, result } = setup({ onTrackEvent: undefined });
+
+    expect(() => result.current.onSelectOption("swap")).not.toThrow();
+    expect(props.onSelect).toHaveBeenCalledWith("swap");
+  });
+});

--- a/features/flow/pay-card-deposit/src/components/DepositOptions/useDepositOptionsViewModel.ts
+++ b/features/flow/pay-card-deposit/src/components/DepositOptions/useDepositOptionsViewModel.ts
@@ -1,0 +1,36 @@
+import { useCallback, useMemo } from "react";
+import type { DepositOptionId, DepositOptionsProps, DepositOptionsViewModel } from "../../types";
+
+const OPTION_ORDER: readonly DepositOptionId[] = ["bankTransfer", "swap", "receive", "buy"];
+
+const TRACK_BUTTON: Readonly<Record<DepositOptionId, string>> = {
+  bankTransfer: "bank transfer",
+  swap: "swap",
+  receive: "receive via crypto address",
+  buy: "buy",
+};
+
+export function useDepositOptionsViewModel({
+  labels,
+  page,
+  onSelect,
+  onClose,
+  onTrackEvent,
+}: DepositOptionsProps): DepositOptionsViewModel {
+  const options = useMemo(() => OPTION_ORDER.map(id => ({ id, ...labels.options[id] })), [labels]);
+
+  const onSelectOption = useCallback(
+    (id: DepositOptionId) => {
+      onTrackEvent?.("button_clicked", {
+        button: TRACK_BUTTON[id],
+        buttonLocation: "deposit",
+        page,
+      });
+      onSelect(id);
+      onClose();
+    },
+    [onSelect, onClose, onTrackEvent, page],
+  );
+
+  return { options, onSelectOption };
+}

--- a/features/flow/pay-card-deposit/src/exports.ts
+++ b/features/flow/pay-card-deposit/src/exports.ts
@@ -1,0 +1,2 @@
+export * from "./components/DepositOptions/DepositOptions";
+export * from "./types";

--- a/features/flow/pay-card-deposit/src/index.native.ts
+++ b/features/flow/pay-card-deposit/src/index.native.ts
@@ -1,1 +1,1 @@
-export * from "./placeholder";
+export * from "./exports";

--- a/features/flow/pay-card-deposit/src/index.ts
+++ b/features/flow/pay-card-deposit/src/index.ts
@@ -1,1 +1,1 @@
-export * from "./placeholder";
+export * from "./exports";

--- a/features/flow/pay-card-deposit/src/placeholder.ts
+++ b/features/flow/pay-card-deposit/src/placeholder.ts
@@ -1,3 +1,0 @@
-// Compile-only placeholder so the package has a non-empty public surface until the Deposit
-// options component and view-model land in LIVE-34910. Remove once real exports exist.
-export const FLOW_PAY_CARD_DEPOSIT_PACKAGE = "@features/flow-pay-card-deposit";

--- a/features/flow/pay-card-deposit/src/types.ts
+++ b/features/flow/pay-card-deposit/src/types.ts
@@ -1,0 +1,42 @@
+export type DepositOptionId = "bankTransfer" | "swap" | "receive" | "buy";
+
+export type PayCardTrackEvent = (event: string, params: Record<string, unknown>) => void;
+
+export type DepositOptionContent = Readonly<{
+  title: string;
+  description: string;
+}>;
+
+/**
+ * User-facing copy injected by the host app. This package stays i18n-agnostic: the app
+ * resolves translations and passes the strings in.
+ */
+export type DepositOptionsLabels = Readonly<{
+  title: string;
+  options: Readonly<Record<DepositOptionId, DepositOptionContent>>;
+}>;
+
+export type DepositOptionsProps = Readonly<{
+  isOpen: boolean;
+  labels: DepositOptionsLabels;
+  page: string;
+  onClose: () => void;
+  /** Host-owned navigation intent for the pressed option. Navigation stays in the app. */
+  onSelect: (id: DepositOptionId) => void;
+  onTrackEvent?: PayCardTrackEvent;
+}>;
+
+export type DepositOption = DepositOptionContent & Readonly<{ id: DepositOptionId }>;
+
+export type DepositOptionsViewModel = Readonly<{
+  options: readonly DepositOption[];
+  onSelectOption: (id: DepositOptionId) => void;
+}>;
+
+export type DepositOptionsViewProps = Readonly<{
+  isOpen: boolean;
+  title: string;
+  options: readonly DepositOption[];
+  onClose: () => void;
+  onSelectOption: (id: DepositOptionId) => void;
+}>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5772,7 +5772,23 @@ importers:
         version: 1.51.0
 
   features/flow/pay-card-deposit:
+    dependencies:
+      '@shared/ui-queued-bottom-sheet':
+        specifier: workspace:*
+        version: link:../../../shared/ui-queued-bottom-sheet
     devDependencies:
+      '@features/platform-style':
+        specifier: workspace:*
+        version: link:../../platform/style
+      '@ledgerhq/lumen-design-core':
+        specifier: 'catalog:'
+        version: 0.1.24
+      '@ledgerhq/lumen-ui-react':
+        specifier: 'catalog:'
+        version: 0.1.51(@ledgerhq/lumen-design-core@0.1.24)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@ledgerhq/lumen-ui-rnative':
+        specifier: 'catalog:'
+        version: 0.1.54(@ledgerhq/lumen-design-core@0.1.24)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@support/jest-features-flow':
         specifier: workspace:*
         version: link:../../../support/jest-features-flow
@@ -5782,15 +5798,30 @@ importers:
       '@swc/jest':
         specifier: 'catalog:'
         version: 0.2.39(@swc/core@1.15.11)
+      '@testing-library/dom':
+        specifier: 'catalog:'
+        version: 10.4.1
       '@testing-library/jest-dom':
         specifier: 'catalog:'
         version: 6.9.1
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@testing-library/react-native':
+        specifier: 'catalog:'
+        version: 13.3.3(patch_hash=4f93e75372e62b6dc0f0b2635b62a322b37a3727637bd94a38df1ed8648e2e76)(jest@30.2.0(@types/node@24.12.0))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react-test-renderer@19.1.4(react@19.1.4))(react@19.1.4)
+      '@testing-library/user-event':
+        specifier: 'catalog:'
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/jest':
         specifier: 'catalog:'
         version: 30.0.0
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.0
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.0.14
       '@typescript-eslint/parser':
         specifier: 'catalog:'
         version: 8.48.1(@typescript/typescript6@6.0.2)(eslint@8.57.0)
@@ -5812,6 +5843,18 @@ importers:
       oxlint:
         specifier: 'catalog:'
         version: 1.51.0
+      react:
+        specifier: 19.1.4
+        version: 19.1.4
+      react-dom:
+        specifier: 19.1.4
+        version: 19.1.4(react@19.1.4)
+      react-native:
+        specifier: 'catalog:'
+        version: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
+      react-test-renderer:
+        specifier: 'catalog:'
+        version: 19.1.4(react@19.1.4)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.1.18


### PR DESCRIPTION
### 📝 Description

Fills the `@features/flow-pay-card-deposit` package public API with the shared **Deposit options** component + view-model and its two platform presentations (web `Dialog`, native `QueuedBottomSheet`).

**Problem**: Pay needs a "Deposit stablecoins" entry point offering four funding paths — Bank transfer, Swap, Receive, Buy — shared across Ledger Wallet Desktop and Mobile.

**Solution**: A props-only, i18n-agnostic feature package following the `pay-card-balance` pattern:

- `DepositOptions` container wiring the view-model to the platform view.
- `useDepositOptionsViewModel` — deterministic option ordering, `onTrackEvent` tracking (`button_clicked { button, buttonLocation: "deposit", page }`), and `onSelect` + `onClose` on press.
- Shared `DepositOptionRow` composed from platform-specific `DepositOptionParts` (`.web` / `.native`), resolved via module suffixes.
- Web `Dialog` presentation and native `QueuedBottomSheet` presentation.
- Host apps own navigation and translations; the package only emits intents (`bankTransfer` | `swap` | `receive` | `buy`).

Usage:

```tsx
import { DepositOptions } from "@features/flow-pay-card-deposit";

<DepositOptions
  isOpen={isDepositOpen}
  page="Pay"
  labels={labels}
  onClose={close}
  onSelect={handleSelect}
  onTrackEvent={track}
/>
```

Screen composition / navigation wiring stays in LIVE-34912 (LWD) and LIVE-34911 (LWM).

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34910](https://ledgerhq.atlassian.net/browse/LIVE-34910)
- **Figma**: https://www.figma.com/design/WYQQwem0QyG2fTuaAKAe3Y/Pay-%E2%80%A2-Production?node-id=7141-82456&m=dev

[LIVE-34910]: https://ledgerhq.atlassian.net/browse/LIVE-34910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ