### PR TITLE
[LWD] feat(pay-card): wire deposit options into desktop pay tab (LIVE-34912)

### DIFF
--- a/.changeset/LIVE-34912-desktop-deposit-options.md
+++ b/.changeset/LIVE-34912-desktop-deposit-options.md
@@ -1,0 +1,8 @@
+---
+"ledger-live-desktop": minor
+"@features/flow-pay-card-deposit": patch
+---
+
+Wire the desktop Pay tab "Add stablecoin" tile to the shared Deposit options dialog: pressing it opens the dialog and each option routes to its desktop flow (bank transfer, swap, buy) or the receive asset flow filtered to stablecoins.
+
+Render the deposit options as Lumen `ListItem` rows.

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -97,6 +97,7 @@
     "@features/flow-large-screen-upsell": "workspace:^",
     "@features/flow-pay-card-auth": "workspace:^",
     "@features/flow-pay-card-balance": "workspace:^",
+    "@features/flow-pay-card-deposit": "workspace:^",
     "@features/flow-pay-card-feature-tour": "workspace:^",
     "@features/platform-aggregated-assets": "workspace:*",
     "@features/platform-card": "workspace:*",

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
@@ -182,6 +182,20 @@ describe("PayTab", () => {
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", { button: "balance_filter" });
   });
 
+  it("should open the deposit options dialog from the deposit action tile", async () => {
+    mockFundedPayStablecoins();
+
+    renderWithMockedCounterValuesProvider(<PayTab />, {
+      initialState: fundedState,
+    });
+
+    const depositTile = await screen.findByRole("button", { name: "Add stablecoin" });
+    fireEvent.click(depositTile);
+
+    expect(await screen.findByTestId("pay-card-deposit-options")).toBeVisible();
+    expect(screen.getByTestId("pay-card-deposit-option-swap")).toBeVisible();
+  });
+
   it("should persist the selected stablecoin, update the hero pill and track the confirmation", async () => {
     mockFundedPayStablecoins();
 

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayTabDepositOptions.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayTabDepositOptions.test.tsx
@@ -1,0 +1,105 @@
+import { act, renderHook } from "@testing-library/react";
+import { useNavigate } from "react-router";
+import { useOpenAssetFlow } from "../../../ModularDialog/hooks/useOpenAssetFlow";
+import { usePayTabDepositOptions } from "../usePayTabDepositOptions";
+
+const mockNavigate = jest.fn();
+const mockOpenAssetFlow = jest.fn();
+
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
+  useNavigate: jest.fn(() => mockNavigate),
+}));
+
+jest.mock("../../../ModularDialog/hooks/useOpenAssetFlow", () => ({
+  useOpenAssetFlow: jest.fn(() => ({
+    openAssetFlow: mockOpenAssetFlow,
+    openAddAccountFlow: jest.fn(),
+  })),
+}));
+
+const mockedUseNavigate = jest.mocked(useNavigate);
+const mockedUseOpenAssetFlow = jest.mocked(useOpenAssetFlow);
+
+const STABLECOIN_IDS = ["ethereum/erc20/usd__coin", "ethereum/erc20/usd_tether__erc20_"];
+
+function render(onTrackEvent = jest.fn()) {
+  return renderHook(() => usePayTabDepositOptions(onTrackEvent, STABLECOIN_IDS));
+}
+
+describe("usePayTabDepositOptions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseNavigate.mockReturnValue(mockNavigate);
+    mockedUseOpenAssetFlow.mockReturnValue({
+      openAssetFlow: mockOpenAssetFlow,
+      openAddAccountFlow: jest.fn(),
+    });
+  });
+
+  it("builds i18n labels for the title and the four options", () => {
+    const { result } = render();
+
+    const { labels, page } = result.current.depositOptions;
+    expect(page).toBe("Pay");
+    expect(labels.title).toBeTruthy();
+    (["bankTransfer", "swap", "receive", "buy"] as const).forEach(id => {
+      expect(labels.options[id].title).toBeTruthy();
+      expect(labels.options[id].description).toBeTruthy();
+    });
+  });
+
+  it("passes the host tracking callback through", () => {
+    const onTrackEvent = jest.fn();
+    const { result } = render(onTrackEvent);
+
+    expect(result.current.depositOptions.onTrackEvent).toBe(onTrackEvent);
+  });
+
+  it("toggles isOpen via open and onClose", () => {
+    const { result } = render();
+
+    expect(result.current.depositOptions.isOpen).toBe(false);
+
+    act(() => result.current.open());
+    expect(result.current.depositOptions.isOpen).toBe(true);
+
+    act(() => result.current.depositOptions.onClose());
+    expect(result.current.depositOptions.isOpen).toBe(false);
+  });
+
+  it("navigates to the bank flow for bankTransfer", () => {
+    const { result } = render();
+
+    act(() => result.current.depositOptions.onSelect("bankTransfer"));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/bank");
+  });
+
+  it("navigates to the swap tab for swap", () => {
+    const { result } = render();
+
+    act(() => result.current.depositOptions.onSelect("swap"));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/swap");
+  });
+
+  it("navigates to the buy live app for buy", () => {
+    const { result } = render();
+
+    act(() => result.current.depositOptions.onSelect("buy"));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/exchange", {
+      state: { mode: "buy", returnTo: "/paytab" },
+    });
+  });
+
+  it("opens the asset flow filtered to stablecoins for receive", () => {
+    const { result } = render();
+
+    act(() => result.current.depositOptions.onSelect("receive"));
+
+    expect(mockOpenAssetFlow).toHaveBeenCalledWith(undefined, STABLECOIN_IDS);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabActionTiles.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabActionTiles.ts
@@ -6,13 +6,19 @@ const noop = () => {};
 
 export function usePayTabActionTiles(
   onTrackEvent: ActionTilesProps["onTrackEvent"],
+  onDeposit: () => void,
 ): ActionTilesProps {
   const { t } = useTranslation();
 
   return useMemo(
     () => ({
       tiles: [
-        { id: "deposit", label: t("payTab.actions.deposit"), onPress: noop, appearance: "base" },
+        {
+          id: "deposit",
+          label: t("payTab.actions.deposit"),
+          onPress: onDeposit,
+          appearance: "base",
+        },
         {
           id: "request",
           label: t("payTab.actions.request"),
@@ -24,6 +30,6 @@ export function usePayTabActionTiles(
       page: "Pay",
       onTrackEvent,
     }),
-    [t, onTrackEvent],
+    [t, onTrackEvent, onDeposit],
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabDepositOptions.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabDepositOptions.ts
@@ -1,0 +1,90 @@
+import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router";
+import { ModularDrawerLocation } from "@ledgerhq/live-common/modularDrawer/enums";
+import type {
+  DepositOptionId,
+  DepositOptionsLabels,
+  DepositOptionsProps,
+  PayCardTrackEvent,
+} from "@features/flow-pay-card-deposit";
+import { useOpenAssetFlow } from "../../ModularDialog/hooks/useOpenAssetFlow";
+
+const DEPOSIT_PAGE = "Pay";
+
+export type UsePayTabDepositOptions = Readonly<{
+  open: () => void;
+  depositOptions: DepositOptionsProps;
+}>;
+
+export function usePayTabDepositOptions(
+  onTrackEvent: PayCardTrackEvent | undefined,
+  stablecoinCurrencyIds: string[],
+): UsePayTabDepositOptions {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const { openAssetFlow } = useOpenAssetFlow(
+    { location: ModularDrawerLocation.ADD_ACCOUNT },
+    DEPOSIT_PAGE,
+    "MODAL_RECEIVE",
+  );
+
+  const onClose = useCallback(() => setIsOpen(false), []);
+  const open = useCallback(() => setIsOpen(true), []);
+
+  const onSelect = useCallback(
+    (id: DepositOptionId) => {
+      switch (id) {
+        case "bankTransfer":
+          navigate("/bank");
+          break;
+        case "swap":
+          navigate("/swap");
+          break;
+        case "buy":
+          navigate("/exchange", { state: { mode: "buy", returnTo: "/paytab" } });
+          break;
+        case "receive":
+          openAssetFlow(undefined, stablecoinCurrencyIds);
+          break;
+      }
+    },
+    [navigate, openAssetFlow, stablecoinCurrencyIds],
+  );
+
+  const labels: DepositOptionsLabels = {
+    title: t("payTab.deposit.title"),
+    options: {
+      bankTransfer: {
+        title: t("payTab.deposit.options.bankTransfer.title"),
+        description: t("payTab.deposit.options.bankTransfer.description"),
+      },
+      swap: {
+        title: t("payTab.deposit.options.swap.title"),
+        description: t("payTab.deposit.options.swap.description"),
+      },
+      receive: {
+        title: t("payTab.deposit.options.receive.title"),
+        description: t("payTab.deposit.options.receive.description"),
+      },
+      buy: {
+        title: t("payTab.deposit.options.buy.title"),
+        description: t("payTab.deposit.options.buy.description"),
+      },
+    },
+  };
+
+  return {
+    open,
+    depositOptions: {
+      isOpen,
+      page: DEPOSIT_PAGE,
+      labels,
+      onClose,
+      onSelect,
+      onTrackEvent,
+    },
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { CardLogin } from "@features/flow-pay-card-auth";
 import { Balance } from "@features/flow-pay-card-balance";
+import { DepositOptions } from "@features/flow-pay-card-deposit";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import { openURL } from "~/renderer/linking";
 import PayTabHeader from "./components/PayTabHeader";
@@ -8,19 +9,27 @@ import { usePayCardBalance } from "./hooks/usePayCardBalance";
 import { FeatureTour } from "@features/flow-pay-card-feature-tour";
 import { usePayTabFeatureTour } from "./hooks/usePayTabFeatureTour";
 import { usePayTabActionTiles } from "./hooks/usePayTabActionTiles";
+import { usePayTabDepositOptions } from "./hooks/usePayTabDepositOptions";
+import { usePayStablecoins } from "./hooks/usePayStablecoins";
 
 const openHostedLogin = (loginUrl: string) => openURL(loginUrl, "");
 
 const PayTab = () => {
   const balance = usePayCardBalance();
   const featureTour = usePayTabFeatureTour();
-  const actionTiles = usePayTabActionTiles(balance.onTrackEvent);
+  const { defaultStablecoins } = usePayStablecoins();
+  const deposit = usePayTabDepositOptions(
+    balance.onTrackEvent,
+    defaultStablecoins.map(stablecoin => stablecoin.id),
+  );
+  const actionTiles = usePayTabActionTiles(balance.onTrackEvent, deposit.open);
 
   return (
     <div className="flex flex-col gap-24">
       <TrackPage category="Pay" balance_filter={balance.filter} />
       <PayTabHeader />
       <Balance {...balance} actionTiles={actionTiles} />
+      <DepositOptions {...deposit.depositOptions} />
       <CardLogin openHostedLogin={openHostedLogin} />
       <FeatureTour {...featureTour} />
     </div>

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -905,6 +905,27 @@
       "deposit": "Add stablecoin",
       "request": "Request",
       "pay": "New payment"
+    },
+    "deposit": {
+      "title": "Add stablecoins",
+      "options": {
+        "bankTransfer": {
+          "title": "Bank transfer",
+          "description": "Transfer USD or EUR to receive stablecoins."
+        },
+        "swap": {
+          "title": "Swap from crypto",
+          "description": "Swap your crypto for stablecoins."
+        },
+        "receive": {
+          "title": "Crypto address",
+          "description": "Receive stablecoins from another wallet."
+        },
+        "buy": {
+          "title": "Buy",
+          "description": "Buy stablecoins with credit card."
+        }
+      }
     }
   },
   "lend": {

--- a/features/flow/pay-card-deposit/src/components/DepositOptions/DepositOptionParts.native.tsx
+++ b/features/flow/pay-card-deposit/src/components/DepositOptions/DepositOptionParts.native.tsx
@@ -1,14 +1,13 @@
 import React, { useCallback } from "react";
-import { Card, Spot } from "@ledgerhq/lumen-ui-rnative";
+import { ListItem, Spot } from "@ledgerhq/lumen-ui-rnative";
 import { ArrowDown, Bank, Cart, Exchange } from "@ledgerhq/lumen-ui-rnative/symbols";
 import type { DepositOptionId } from "../../types";
 
 export {
-  CardContent,
-  CardContentDescription,
-  CardContentTitle,
-  CardHeader,
-  CardLeading,
+  ListItemContent,
+  ListItemDescription,
+  ListItemLeading,
+  ListItemTitle,
 } from "@ledgerhq/lumen-ui-rnative";
 
 type SpotIcon = typeof Bank;
@@ -20,21 +19,25 @@ const OPTION_ICONS: Readonly<Record<DepositOptionId, SpotIcon>> = {
   buy: Cart,
 };
 
-type DepositOptionCardProps = Readonly<{
+type DepositOptionListItemProps = Readonly<{
   optionId: DepositOptionId;
   onSelect: (id: DepositOptionId) => void;
   children: React.ReactNode;
 }>;
 
-export function DepositOptionCard({ optionId, onSelect, children }: DepositOptionCardProps) {
+export function DepositOptionListItem({
+  optionId,
+  onSelect,
+  children,
+}: DepositOptionListItemProps) {
   const handlePress = useCallback(() => {
     onSelect(optionId);
   }, [onSelect, optionId]);
 
   return (
-    <Card type="interactive" onPress={handlePress} testID={`pay-card-deposit-option-${optionId}`}>
+    <ListItem onPress={handlePress} testID={`pay-card-deposit-option-${optionId}`}>
       {children}
-    </Card>
+    </ListItem>
   );
 }
 

--- a/features/flow/pay-card-deposit/src/components/DepositOptions/DepositOptionParts.web.tsx
+++ b/features/flow/pay-card-deposit/src/components/DepositOptions/DepositOptionParts.web.tsx
@@ -1,14 +1,13 @@
 import React, { useCallback } from "react";
-import { Card, Spot } from "@ledgerhq/lumen-ui-react";
+import { ListItem, Spot } from "@ledgerhq/lumen-ui-react";
 import { ArrowDown, Bank, Cart, Exchange } from "@ledgerhq/lumen-ui-react/symbols";
 import type { DepositOptionId } from "../../types";
 
 export {
-  CardContent,
-  CardContentDescription,
-  CardContentTitle,
-  CardHeader,
-  CardLeading,
+  ListItemContent,
+  ListItemDescription,
+  ListItemLeading,
+  ListItemTitle,
 } from "@ledgerhq/lumen-ui-react";
 
 type SpotIcon = typeof Bank;
@@ -20,25 +19,25 @@ const OPTION_ICONS: Readonly<Record<DepositOptionId, SpotIcon>> = {
   buy: Cart,
 };
 
-type DepositOptionCardProps = Readonly<{
+type DepositOptionListItemProps = Readonly<{
   optionId: DepositOptionId;
   onSelect: (id: DepositOptionId) => void;
   children: React.ReactNode;
 }>;
 
-export function DepositOptionCard({ optionId, onSelect, children }: DepositOptionCardProps) {
+export function DepositOptionListItem({
+  optionId,
+  onSelect,
+  children,
+}: DepositOptionListItemProps) {
   const handlePress = useCallback(() => {
     onSelect(optionId);
   }, [onSelect, optionId]);
 
   return (
-    <Card
-      type="interactive"
-      onClick={handlePress}
-      data-testid={`pay-card-deposit-option-${optionId}`}
-    >
+    <ListItem onClick={handlePress} data-testid={`pay-card-deposit-option-${optionId}`}>
       {children}
-    </Card>
+    </ListItem>
   );
 }
 

--- a/features/flow/pay-card-deposit/src/components/DepositOptions/DepositOptionRow.tsx
+++ b/features/flow/pay-card-deposit/src/components/DepositOptions/DepositOptionRow.tsx
@@ -1,12 +1,11 @@
 import React from "react";
 import {
-  CardContent,
-  CardContentDescription,
-  CardContentTitle,
-  CardHeader,
-  CardLeading,
-  DepositOptionCard,
   DepositOptionIcon,
+  DepositOptionListItem,
+  ListItemContent,
+  ListItemDescription,
+  ListItemLeading,
+  ListItemTitle,
 } from "./DepositOptionParts";
 import type { DepositOption, DepositOptionId } from "../../types";
 
@@ -17,16 +16,14 @@ type DepositOptionRowProps = Readonly<{
 
 export function DepositOptionRow({ option, onSelect }: DepositOptionRowProps) {
   return (
-    <DepositOptionCard optionId={option.id} onSelect={onSelect}>
-      <CardHeader>
-        <CardLeading>
-          <DepositOptionIcon optionId={option.id} />
-          <CardContent>
-            <CardContentTitle>{option.title}</CardContentTitle>
-            <CardContentDescription>{option.description}</CardContentDescription>
-          </CardContent>
-        </CardLeading>
-      </CardHeader>
-    </DepositOptionCard>
+    <DepositOptionListItem optionId={option.id} onSelect={onSelect}>
+      <ListItemLeading>
+        <DepositOptionIcon optionId={option.id} />
+        <ListItemContent>
+          <ListItemTitle>{option.title}</ListItemTitle>
+          <ListItemDescription>{option.description}</ListItemDescription>
+        </ListItemContent>
+      </ListItemLeading>
+    </DepositOptionListItem>
   );
 }

--- a/features/flow/pay-card-deposit/src/components/DepositOptions/__tests__/DepositOptionParts.native.test.tsx
+++ b/features/flow/pay-card-deposit/src/components/DepositOptions/__tests__/DepositOptionParts.native.test.tsx
@@ -1,19 +1,19 @@
 import React from "react";
 import { cleanup, render, screen, userEvent } from "@testing-library/react-native";
-import { DepositOptionCard, DepositOptionIcon } from "../DepositOptionParts.native";
+import { DepositOptionIcon, DepositOptionListItem } from "../DepositOptionParts.native";
 
 describe("DepositOptionParts (Native)", () => {
   afterEach(() => {
     cleanup();
   });
 
-  it("selects the option when the card is pressed", async () => {
+  it("selects the option when the list item is pressed", async () => {
     const user = userEvent.setup();
     const onSelect = jest.fn();
     render(
-      <DepositOptionCard optionId="swap" onSelect={onSelect}>
+      <DepositOptionListItem optionId="swap" onSelect={onSelect}>
         <DepositOptionIcon optionId="swap" />
-      </DepositOptionCard>,
+      </DepositOptionListItem>,
     );
 
     await user.press(screen.getByTestId("pay-card-deposit-option-swap"));

--- a/features/flow/pay-card-deposit/src/components/DepositOptions/__tests__/DepositOptionParts.web.test.tsx
+++ b/features/flow/pay-card-deposit/src/components/DepositOptions/__tests__/DepositOptionParts.web.test.tsx
@@ -1,20 +1,20 @@
 import React from "react";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { DepositOptionCard, DepositOptionIcon } from "../DepositOptionParts.web";
+import { DepositOptionIcon, DepositOptionListItem } from "../DepositOptionParts.web";
 
 describe("DepositOptionParts (Web)", () => {
   afterEach(() => {
     cleanup();
   });
 
-  it("selects the option when the card is clicked", async () => {
+  it("selects the option when the list item is clicked", async () => {
     const user = userEvent.setup();
     const onSelect = jest.fn();
     render(
-      <DepositOptionCard optionId="swap" onSelect={onSelect}>
+      <DepositOptionListItem optionId="swap" onSelect={onSelect}>
         <DepositOptionIcon optionId="swap" />
-      </DepositOptionCard>,
+      </DepositOptionListItem>,
     );
 
     await user.click(screen.getByTestId("pay-card-deposit-option-swap"));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -949,6 +949,9 @@ importers:
       '@features/flow-pay-card-balance':
         specifier: workspace:^
         version: link:../../features/flow/pay-card-balance
+      '@features/flow-pay-card-deposit':
+        specifier: workspace:^
+        version: link:../../features/flow/pay-card-deposit
       '@features/flow-pay-card-feature-tour':
         specifier: workspace:^
         version: link:../../features/flow/pay-card-feature-tour


### PR DESCRIPTION
### 📝 Description

Wires the shared `DepositOptions` dialog into the desktop Pay tab. The "Add stablecoin" tile previously did nothing (`onPress: noop`); it now opens the shared `@features/flow-pay-card-deposit` dialog, and each option routes to its desktop flow.

A new host hook `usePayTabDepositOptions` owns the open/close state, builds the i18n `labels`, and routes `onSelect`: `bankTransfer` -> `/bank` (Noah), `swap` -> `/swap`, `buy` -> `/exchange` (buy mode), `receive` -> the modular asset flow filtered to stablecoin currency IDs (reopening `MODAL_RECEIVE`). Tracking stays in the shared view-model (`button_clicked { button, buttonLocation: "deposit", page }`). The shared option rows are also rendered as Lumen `ListItem`.


https://github.com/user-attachments/assets/f35dbae7-ebaf-4880-baf8-ae62f7fec40c


### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34912](https://ledgerhq.atlassian.net/browse/LIVE-34912)
- **ADR** (if any): N/A

[LIVE-34912]: https://ledgerhq.atlassian.net/browse/LIVE-34912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ