### PR TITLE
[LWDM] feat(coin-aleo): implement combine and wire broadcast (LIVE-34145)

### DIFF
--- a/.changeset/nervous-books-trade.md
+++ b/.changeset/nervous-books-trade.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+Implement the `combine` method and wire `broadcast` in the coin-aleo framework API: `combine` validates the ordered signature list (root first, then nested calls), reads the view key off the `Context`, and returns the hex-encoded SDK authorization.

--- a/libs/coin-modules/coin-aleo/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.integ.test.ts
@@ -82,6 +82,23 @@ describe("createApi", () => {
     });
   });
 
+  describe("combine", () => {
+    it("rejects an invalid signature with an HTTP error from the backend", async () => {
+      const contextWithViewKey: AleoContext = { ...context, viewKey: testnetViewKey };
+      const crafted = await api.craftTransaction(context, mockTxIntentTransferPublic);
+
+      await expect(
+        api.combine(contextWithViewKey, crafted.transaction, ["sign1invalidsignatureplaceholder"]),
+      ).rejects.toMatchObject({ status: expect.any(Number) });
+    });
+
+    it("rejects before any network call when the context carries no view key", async () => {
+      await expect(api.combine(context, "crafted-tx", ["root-sig"])).rejects.toThrow(
+        /view key is required/,
+      );
+    });
+  });
+
   describe("estimateFees", () => {
     it("returns fee for coin transfer transaction", async () => {
       const fees = await api.estimateFees(context, {

--- a/libs/coin-modules/coin-aleo/src/api/index.test.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.test.ts
@@ -9,6 +9,8 @@ import {
   mockTxIntentTransferPublic,
 } from "../__tests__/fixtures/transaction.fixture";
 import {
+  broadcast,
+  combine,
   craftTransaction,
   estimateFees,
   getAccountInfo,
@@ -32,6 +34,8 @@ describe("createApi", () => {
     logger: () => {},
   };
   const mockOperation = getMockedCoinFrameworkOperation();
+  const mockedBroadcast = jest.mocked(broadcast);
+  const mockedCombine = jest.mocked(combine);
   const mockedCraftTransaction = jest.mocked(craftTransaction);
   const mockedEstimateFees = jest.mocked(estimateFees);
   const mockedGetAccountInfo = jest.mocked(getAccountInfo);
@@ -45,6 +49,8 @@ describe("createApi", () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
+    mockedBroadcast.mockResolvedValue("tx-hash");
+    mockedCombine.mockResolvedValue("combined-hex");
     mockedCraftTransaction.mockResolvedValue({ transaction: "crafted_tx" });
     mockedEstimateFees.mockReturnValue({ value: BigInt(1234) });
     mockedGetBalance.mockResolvedValue([{ value: BigInt(10), asset: { type: "native" } }]);
@@ -117,16 +123,39 @@ describe("createApi", () => {
   });
 
   describe("broadcast", () => {
-    it("should throw unsupported error", () => {
-      expect(() => api.broadcast(context, "test-signature")).toThrow("broadcast is not supported");
+    it("should resolve config from the context and delegate to logic broadcast", async () => {
+      const result = await api.broadcast(context, "signed-tx-hex");
+
+      expect(mockedBroadcast).toHaveBeenCalledTimes(1);
+      expect(mockedBroadcast).toHaveBeenCalledWith({
+        configOrCurrencyId: mockConfig,
+        signedTx: "signed-tx-hex",
+      });
+      expect(result).toBe("tx-hash");
     });
   });
 
   describe("combine", () => {
-    it("should throw unsupported error", () => {
-      expect(() =>
-        api.combine(context, "transaction", ["signature"], { pubkey: "publicKey" }),
-      ).toThrow("combine is not supported");
+    const contextWithViewKey: AleoContext = { ...context, viewKey: "AViewKey1test" };
+
+    it("resolves config and view key from the context and delegates to logic combine", async () => {
+      const result = await api.combine(contextWithViewKey, "crafted-tx", ["root-sig"]);
+
+      expect(mockedCombine).toHaveBeenCalledTimes(1);
+      expect(mockedCombine).toHaveBeenCalledWith({
+        config: mockConfig,
+        transaction: "crafted-tx",
+        signatures: ["root-sig"],
+        viewKey: "AViewKey1test",
+      });
+      expect(result).toBe("combined-hex");
+    });
+
+    it("throws error and skips combine when the view key is absent", async () => {
+      await expect(api.combine(context, "crafted-tx", ["root-sig"])).rejects.toThrow(
+        "aleo: a view key is required to combine a transaction",
+      );
+      expect(mockedCombine).not.toHaveBeenCalled();
     });
   });
 
@@ -258,43 +287,37 @@ describe("createApi", () => {
       ["undefined", undefined],
       ["null", null],
       ["empty string", ""],
-    ])(
-      "throws AleoIncompletePrivacyContextError for a private root intent when viewKey is %s",
-      async (_label, viewKey) => {
-        const privateContext = {
-          ...context,
-          ...(viewKey !== undefined && { viewKey }),
-        } as AleoContext;
+    ])("throws error for a private root intent when viewKey is %s", async (_label, viewKey) => {
+      const privateContext = {
+        ...context,
+        ...(viewKey !== undefined && { viewKey }),
+      } as AleoContext;
 
-        await expect(
-          api.craftTransaction(privateContext, mockTxIntentTransferPrivate),
-        ).rejects.toThrow("aleo: viewKey is missing");
+      await expect(
+        api.craftTransaction(privateContext, mockTxIntentTransferPrivate),
+      ).rejects.toThrow("aleo: a view key is required to craft a private transaction");
 
-        expect(mockedCraftTransaction).not.toHaveBeenCalled();
-        expect(mockedBuildFeeConfigurationForRootIntent).not.toHaveBeenCalled();
-      },
-    );
+      expect(mockedCraftTransaction).not.toHaveBeenCalled();
+      expect(mockedBuildFeeConfigurationForRootIntent).not.toHaveBeenCalled();
+    });
 
     it.each([
       ["undefined", undefined],
       ["null", null],
       ["empty string", ""],
-    ])(
-      "throws AleoIncompletePrivacyContextError for a fee_private intent when viewKey is %s",
-      async (_label, viewKey) => {
-        const privateFeeContext = {
-          ...context,
-          config: async () => ({ ...mockConfig, isFeeSponsored: false }),
-          ...(viewKey !== undefined && { viewKey }),
-        } as AleoContext;
+    ])("throws error for a fee_private intent when viewKey is %s", async (_label, viewKey) => {
+      const privateFeeContext = {
+        ...context,
+        config: async () => ({ ...mockConfig, isFeeSponsored: false }),
+        ...(viewKey !== undefined && { viewKey }),
+      } as AleoContext;
 
-        await expect(
-          api.craftTransaction(privateFeeContext, mockTxIntentFeePrivate),
-        ).rejects.toThrow("aleo: viewKey is missing");
+      await expect(api.craftTransaction(privateFeeContext, mockTxIntentFeePrivate)).rejects.toThrow(
+        "aleo: a view key is required to craft a private fee transaction",
+      );
 
-        expect(mockedCraftTransaction).not.toHaveBeenCalled();
-      },
-    );
+      expect(mockedCraftTransaction).not.toHaveBeenCalled();
+    });
   });
 
   describe("craftRawTransaction", () => {
@@ -428,7 +451,6 @@ describe("createApi", () => {
 
   describe("register", () => {
     it("reads the view key off the context and delegates to logic register, returning the handle", async () => {
-      const api = createApi("aleo");
       const enrolledContext: AleoContext = { ...context, viewKey: "AViewKey1mockviewkey" };
 
       const result = await api.register(enrolledContext, "aleo1test");
@@ -439,14 +461,11 @@ describe("createApi", () => {
     });
 
     it("rejects before any network call when the context carries no view key", async () => {
-      const api = createApi("aleo");
-
       await expect(api.register(context, "aleo1test")).rejects.toThrow(/view key is required/);
       expect(mockedRegister).not.toHaveBeenCalled();
     });
 
     it("rejects before any network call when the view key is empty", async () => {
-      const api = createApi("aleo");
       const emptyContext: AleoContext = { ...context, viewKey: "" };
 
       await expect(api.register(emptyContext, "aleo1test")).rejects.toThrow(/view key is required/);
@@ -454,8 +473,6 @@ describe("createApi", () => {
     });
 
     it("keeps the raw view key out of the rejection message", async () => {
-      const api = createApi("aleo");
-
       await expect(api.register(context, "aleo1test")).rejects.toThrow(
         expect.objectContaining({ message: expect.not.stringContaining("AViewKey") }),
       );

--- a/libs/coin-modules/coin-aleo/src/api/index.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.ts
@@ -21,6 +21,8 @@ import { craftTransactionData } from "@ledgerhq/coin-module-framework/logic/craf
 import { rejectBalanceOptions } from "@ledgerhq/coin-module-framework/api/getBalance/rejectBalanceOptions";
 import { FEE_INTENT_TYPES } from "../constants";
 import {
+  broadcast,
+  combine,
   craftTransaction,
   estimateFees,
   getAccountInfo,
@@ -40,6 +42,14 @@ import type {
 
 type AleoCoinModuleApi = CoinModuleApi<AleoCoinConfig, MemoNotSupported, AleoTransactionIntentData>;
 
+function requireViewKey(context: AleoContext, action: string): string {
+  const { viewKey } = context;
+  if (typeof viewKey !== "string" || viewKey.length === 0) {
+    throw new Error(`aleo: a view key is required to ${action}`);
+  }
+  return viewKey;
+}
+
 // currencyId is captured here (it can't live on the Context). The logic functions are shared with
 // the classic bridge (config-based), so each method resolves config via context.config() and passes
 // it down — no context-first wrappers.
@@ -48,16 +58,21 @@ export function createApi(currencyId: string): AleoCoinModuleApi {
     async call() {
       throw new Error("call is not supported");
     },
-    broadcast: (_context: AleoContext, _signature: string): Promise<string> => {
-      throw new Error("broadcast is not supported");
+    broadcast: async (context: AleoContext, signedTransaction: string): Promise<string> => {
+      const config = await context.config();
+      return broadcast({
+        configOrCurrencyId: config,
+        signedTx: signedTransaction,
+      });
     },
-    combine: (
-      _context: AleoContext,
-      _transaction: string,
-      _signature: string[],
-      _options?: { pubkey?: string },
-    ): string => {
-      throw new Error("combine is not supported");
+    combine: async (
+      context: AleoContext,
+      transaction: string,
+      signatures: string[],
+    ): Promise<string> => {
+      const config = await context.config();
+      const viewKey = requireViewKey(context, "combine a transaction");
+      return combine({ config, transaction, signatures, viewKey });
     },
     craftTransaction: async (
       context: AleoContext,
@@ -76,7 +91,7 @@ export function createApi(currencyId: string): AleoCoinModuleApi {
         invariant(!options?.customFees, "aleo: customFees is not supported for fee intents");
 
         if (isPrivateFeeIntent) {
-          invariant(context.viewKey, "aleo: viewKey is missing");
+          requireViewKey(context, "craft a private fee transaction");
         }
 
         // txIntent.amount -> base fee
@@ -91,7 +106,7 @@ export function createApi(currencyId: string): AleoCoinModuleApi {
       }
 
       if (isPrivateIntent) {
-        invariant(context.viewKey, "aleo: viewKey is missing");
+        requireViewKey(context, "craft a private transaction");
       }
 
       const maxBaseFee = options?.customFees
@@ -196,11 +211,7 @@ export function createApi(currencyId: string): AleoCoinModuleApi {
     craftTransactionData: (_context, intent) => craftTransactionData(intent),
     // `address` is unused: enrollment is keyed by the view key, not the address.
     register: async (context: AleoContext, _address: string): Promise<AleoRegistration> => {
-      const viewKey = context.viewKey;
-      invariant(
-        typeof viewKey === "string" && viewKey.length > 0,
-        "aleo/register: a view key is required on the context to register with the Provable scanner",
-      );
+      const viewKey = requireViewKey(context, "register with the Provable scanner");
       const config = await context.config();
       return register(config, viewKey);
     },

--- a/libs/coin-modules/coin-aleo/src/constants.ts
+++ b/libs/coin-modules/coin-aleo/src/constants.ts
@@ -74,6 +74,9 @@ export const PROGRESS_AFTER_PARSING_RECORDS = 30; // 65 → 95
 export const PROGRESS_DONE = 100;
 export const PROGRESS_THROTTLE_MIN_STEP = 5;
 
+// Root transition + up to 30 nested calls, within the device limit of n < 32 per signing session.
+export const MAX_SIGNATURES_PER_TRANSACTION = 31;
+
 // The maximum number of private records that can be included in a single transaction.
 export const MAX_PRIVATE_RECORDS_PER_TRANSACTION = 14;
 

--- a/libs/coin-modules/coin-aleo/src/logic/combine.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/combine.test.ts
@@ -1,0 +1,156 @@
+import { sdkClient } from "../network/sdk";
+import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
+import { getMockedPreparedRequestResponse } from "../__tests__/fixtures/sdk.fixture";
+import type { AuthorizationResponse } from "../types/sdk";
+import { combine } from "./combine";
+import { fromHex, toHex } from "./utils";
+
+jest.mock("../network/sdk");
+
+const mockedCreateAuthorization = jest.mocked(sdkClient.createAuthorization);
+
+describe("combine", () => {
+  const config = getMockedConfig("testnet");
+  const viewKey = "AViewKey1test000000000000000000000000000000000000000";
+  const authorizationResponse: AuthorizationResponse = {
+    authorization: "tx-auth",
+    execution_id: "exec-id",
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedCreateAuthorization.mockResolvedValue(authorizationResponse);
+  });
+
+  it("forwards the crafted request, signatures and view key to createAuthorization", async () => {
+    const request = getMockedPreparedRequestResponse();
+
+    await combine({
+      config,
+      transaction: toHex(request),
+      signatures: ["root-sig"],
+      viewKey,
+    });
+
+    expect(mockedCreateAuthorization).toHaveBeenCalledTimes(1);
+    expect(mockedCreateAuthorization).toHaveBeenCalledWith({
+      config,
+      request,
+      signatures: ["root-sig"],
+      viewKey,
+    });
+  });
+
+  it("returns hex(AuthorizationResponse) exposing both authorization and execution_id", async () => {
+    const request = getMockedPreparedRequestResponse();
+
+    const result = await combine({
+      config,
+      transaction: toHex(request),
+      signatures: ["root-sig"],
+      viewKey,
+    });
+
+    expect(fromHex<AuthorizationResponse>(result)).toEqual(authorizationResponse);
+  });
+
+  it("forwards root + nested signatures in the given order, root first", async () => {
+    const request = getMockedPreparedRequestResponse({
+      nested_calls: [
+        getMockedPreparedRequestResponse({ is_root: false, tlv: "aabb" }),
+        getMockedPreparedRequestResponse({ is_root: false, tlv: "ccdd" }),
+      ],
+    });
+
+    await combine({
+      config,
+      transaction: toHex(request),
+      signatures: ["root-sig", "nested-sig-1", "nested-sig-2"],
+      viewKey,
+    });
+
+    expect(mockedCreateAuthorization).toHaveBeenCalledWith(
+      expect.objectContaining({
+        signatures: ["root-sig", "nested-sig-1", "nested-sig-2"],
+      }),
+    );
+  });
+
+  it("counts deeply nested calls when validating the signature count", async () => {
+    const request = getMockedPreparedRequestResponse({
+      nested_calls: [
+        getMockedPreparedRequestResponse({
+          is_root: false,
+          nested_calls: [getMockedPreparedRequestResponse({ is_root: false })],
+        }),
+      ],
+    });
+
+    await combine({
+      config,
+      transaction: toHex(request),
+      signatures: ["root-sig", "nested-sig-1", "nested-sig-2"],
+      viewKey,
+    });
+
+    expect(mockedCreateAuthorization).toHaveBeenCalledTimes(1);
+  });
+
+  describe("signature-list validation (rejects before any network call)", () => {
+    it("rejects an empty signature list", async () => {
+      const request = getMockedPreparedRequestResponse();
+
+      await expect(
+        combine({
+          config,
+          transaction: toHex(request),
+          signatures: [],
+          viewKey,
+        }),
+      ).rejects.toThrow("aleo: combine requires at least one signature");
+      expect(mockedCreateAuthorization).not.toHaveBeenCalled();
+    });
+
+    it("rejects more than 31 signatures on a root cycle", async () => {
+      const request = getMockedPreparedRequestResponse();
+      const signatures = Array.from({ length: 32 }, (_, i) => `sig-${i}`);
+
+      await expect(
+        combine({ config, transaction: toHex(request), signatures, viewKey }),
+      ).rejects.toThrow("aleo: too many signatures for a single transaction (max 31)");
+      expect(mockedCreateAuthorization).not.toHaveBeenCalled();
+    });
+
+    it("rejects a fee-cycle craft (no nested calls) combined with more than one signature", async () => {
+      const feeRequest = getMockedPreparedRequestResponse({
+        function_name: "fee_public",
+      });
+
+      await expect(
+        combine({
+          config,
+          transaction: toHex(feeRequest),
+          signatures: ["fee-sig", "extra-sig"],
+          viewKey,
+        }),
+      ).rejects.toThrow("aleo: expected 1 signature(s) but received 2");
+      expect(mockedCreateAuthorization).not.toHaveBeenCalled();
+    });
+
+    it("rejects a signature count that does not match the transition count", async () => {
+      const request = getMockedPreparedRequestResponse({
+        nested_calls: [getMockedPreparedRequestResponse({ is_root: false })],
+      });
+
+      await expect(
+        combine({
+          config,
+          transaction: toHex(request),
+          signatures: ["root-sig"],
+          viewKey,
+        }),
+      ).rejects.toThrow("aleo: expected 2 signature(s) but received 1");
+      expect(mockedCreateAuthorization).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/libs/coin-modules/coin-aleo/src/logic/combine.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/combine.ts
@@ -1,7 +1,56 @@
-export function combine(
-  _transaction: string,
-  _signature: string,
-  _publicKey: string | undefined,
-): string {
-  throw new Error("combine is not supported");
+import invariant from "invariant";
+import { sdkClient } from "../network/sdk";
+import { MAX_SIGNATURES_PER_TRANSACTION } from "../constants";
+import type { AleoCoinConfig, PreparedRequestResponse } from "../types";
+import { fromHex, toHex } from "./utils";
+
+function validateSignatures(request: PreparedRequestResponse, signatures: string[]): void {
+  // One signature per transition: the root plus every flattened nested call.
+  let expected = 1;
+  let level = request.nested_calls ?? [];
+  while (level.length > 0) {
+    expected += level.length;
+    level = level.flatMap(call => call.nested_calls ?? []);
+  }
+
+  invariant(signatures.length > 0, "aleo: combine requires at least one signature");
+  invariant(
+    signatures.length <= MAX_SIGNATURES_PER_TRANSACTION,
+    `aleo: too many signatures for a single transaction (max ${MAX_SIGNATURES_PER_TRANSACTION})`,
+  );
+  invariant(
+    signatures.length === expected,
+    `aleo: expected ${expected} signature(s) but received ${signatures.length}`,
+  );
+}
+
+/**
+ * Combines a crafted request with its ordered signatures (root first, then nested calls).
+ *
+ * Returns hex(AuthorizationResponse) rather than the bare authorization so the fee cycle can reuse
+ * the root cycle's `execution_id`; the caller assembles the final envelope.
+ */
+export async function combine({
+  config,
+  transaction,
+  signatures,
+  viewKey,
+}: {
+  config: AleoCoinConfig;
+  transaction: string;
+  signatures: string[];
+  viewKey: string;
+}): Promise<string> {
+  const request = fromHex<PreparedRequestResponse>(transaction);
+
+  validateSignatures(request, signatures);
+
+  const authorization = await sdkClient.createAuthorization({
+    config,
+    request,
+    signatures,
+    viewKey,
+  });
+
+  return toHex(authorization);
 }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Implement the Alpaca `combine` method and wire `broadcast` (ADR-047 §3): `combine` wraps the SDK `createAuthorization`, validates the ordered signature list, and returns the authorization; the view key is read from the `Context` and never logged.

### 🔗 Context

https://ledgerhq.atlassian.net/browse/LIVE-34145
