### PR TITLE
feat(app-lock): add verifier and protection state packages (LIVE-35917)

### DIFF
--- a/.changeset/app-lock-packages-scaffold.md
+++ b/.changeset/app-lock-packages-scaffold.md
@@ -1,0 +1,9 @@
+---
+"@features/platform-app-lock": minor
+"@shared/password-verifier": minor
+"live-mobile": patch
+---
+
+Add the two app lock packages the User App Authentication tickets build on: `@shared/password-verifier` (the verifier record and its constant-time comparison) and `@features/platform-app-lock` (protection state schemas, biometrics status unions and errors).
+
+No functional change to Ledger Wallet Mobile: `react-native-keychain` now resolves through the pnpm catalog instead of a direct pin, so the app and `@features/platform-app-lock` cannot drift apart. It still resolves to 10.0.0.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -131,6 +131,10 @@ features/flow/pay-card-deposit/                          @ledgerhq/wallet-xp
 features/flow/pay-card-feature-tour/                     @ledgerhq/wallet-xp
 features/flow/pay-card-request/                          @ledgerhq/wallet-xp
 
+# Wallet — App lock
+features/platform/app-lock/                              @ledgerhq/wallet-xp
+/shared/password-verifier/                               @ledgerhq/wallet-xp
+
 # Wallet — shared UI
 /shared/ui-queued-bottom-sheet/                          @ledgerhq/wallet-xp
 

--- a/features/platform/app-lock/README.md
+++ b/features/platform/app-lock/README.md
@@ -1,0 +1,61 @@
+# @features/platform-app-lock
+
+> [!CAUTION]
+> **Status: UNSTABLE** — Scaffold created in [LIVE-35917](https://ledgerhq.atlassian.net/browse/LIVE-35917); the public API is still being designed.
+
+App lock protection state — whether a password exists, whether biometrics is enabled, and whether
+the app is currently locked — plus the biometrics status unions and the errors the unlock path
+raises. It says _what state the lock is in_, never _how a digest is compared_ (that lives in
+[`@shared/password-verifier`](../../../shared/password-verifier/README.md)) and never _what the user sees_ (that lives
+in [`@features/flow-app-lock`](../../flow/app-lock/README.md)).
+
+## Why platform and not domain/entity
+
+App authentication is a Non-Functional Requirement: invisible to users, no screens, no global
+routing, but required for the app to deliver its features safely. That is the definition of
+`features/platform` in the [architecture guideline](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/6111232117),
+alongside `feature-flags` and `coin-loader`.
+
+It is deliberately **not** a `domain/entity`. The guideline restricts entities to business objects —
+accounts, currencies, contacts — and states that feature-scoped state is not a domain entity.
+`{ hasPassword, biometricsEnabled, isLocked }` is security and session configuration, not a wallet
+business concept.
+
+It is also not flow-local, because more than one flow reads it: the unlock flow reads `isLocked`,
+Settings reads the two protection flags, and the boot sequence decides the initial lock state.
+That combination — cross-flow, domain-adjacent, invisible — is what this layer is for.
+
+## Scope
+
+This is currently a **scaffold**:
+
+- `AppLockStateSchema` / `AppLockState` — `hasPassword`, `biometricsEnabled`, `isLocked`.
+- `AuthenticationTypeSchema` / `AuthenticationType` — `"none" | "password" | "biometrics" | "passwordAndBiometrics"`.
+- `BiometricsAvailability`, `BiometricsPromptResult`, `BiometricsKind`.
+- `AppLockError` and its members `WrongPassword`, `PasswordNotSet`. The `name` string is the
+  contract; catch `AppLockError` to catch the family.
+
+`AuthenticationType` is meant to be **derived** from the two protection flags, not stored: the spec
+allows password-only, biometrics-only and both, so the flags stay the single source of truth and the
+union cannot drift out of sync with them.
+
+The biometrics types are unions rather than booleans because each case needs a different screen:
+`unavailable` (no hardware — never offer it), `notEnrolled` (offer to open system settings) and
+`lockedOut` (the OS decides when to relent). Likewise `cancelled` must stay distinguishable from
+`failed`, so a dismissed sheet is not counted as a failed attempt. These are product requirements
+encoded in the type system; the app's biometrics adapter returns them and the flow switches on them.
+
+**Known gap to decide later:** with nothing stored in a biometric-gated keystore item, there is no
+way to detect that the user's biometric enrolment has changed. If that matters, it needs a canary
+item and a follow-up decision.
+
+The slice, selectors, React hooks and the unlock orchestration (which is what raises the errors) land
+with the tickets that consume them — biometrics/password logic, unlock flow, migration.
+
+## Validation
+
+```sh
+pnpm test
+pnpm typecheck
+pnpm unimported
+```

--- a/features/platform/app-lock/jest.config.js
+++ b/features/platform/app-lock/jest.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  testEnvironment: "node",
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.(t|j)sx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+        },
+      },
+    ],
+  },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/features/platform/app-lock/package.json
+++ b/features/platform/app-lock/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@features/platform-app-lock",
+  "version": "0.1.0",
+  "private": true,
+  "description": "App lock protection state: schemas, types and selectors shared by the flows that read it",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "format": "oxfmt src",
+    "format:check": "oxfmt src --check",
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../../.. -W features/platform/app-lock"
+  },
+  "dependencies": {
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "jest": "catalog:",
+    "oxfmt": "catalog:",
+    "react-native-keychain": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/features/platform/app-lock/project.json
+++ b/features/platform/app-lock/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@features/platform-app-lock",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/features/platform/app-lock/src/biometrics.ts
+++ b/features/platform/app-lock/src/biometrics.ts
@@ -1,0 +1,18 @@
+import type { BIOMETRY_TYPE } from "react-native-keychain";
+
+export type BiometricsKind = `${BIOMETRY_TYPE}`;
+
+export type BiometricsAvailability =
+  | Readonly<{ status: "available"; kind: BiometricsKind }>
+  /** No hardware. */
+  | Readonly<{ status: "unavailable" }>
+  /** Hardware present, nothing enrolled. */
+  | Readonly<{ status: "notEnrolled" }>
+  | Readonly<{ status: "lockedOut" }>;
+
+export type BiometricsPromptResult =
+  | Readonly<{ status: "succeeded" }>
+  /** Dismissed — must not count as a failed attempt. */
+  | Readonly<{ status: "cancelled" }>
+  | Readonly<{ status: "failed" }>
+  | Readonly<{ status: "lockedOut" }>;

--- a/features/platform/app-lock/src/errors.test.ts
+++ b/features/platform/app-lock/src/errors.test.ts
@@ -1,0 +1,16 @@
+import { AppLockError, PasswordNotSet, WrongPassword } from "./errors";
+
+describe("app lock errors", () => {
+  it.each([
+    [new WrongPassword(), "WrongPassword"],
+    [new PasswordNotSet(), "PasswordNotSet"],
+  ])("exposes a stable name and a message", (error, name) => {
+    expect(error.name).toBe(name);
+    expect(error.message).not.toBe("");
+  });
+
+  it("groups the family so callers can catch it at once", () => {
+    expect(new WrongPassword()).toBeInstanceOf(AppLockError);
+    expect(new PasswordNotSet()).toBeInstanceOf(AppLockError);
+  });
+});

--- a/features/platform/app-lock/src/errors.ts
+++ b/features/platform/app-lock/src/errors.ts
@@ -1,0 +1,19 @@
+export class AppLockError extends Error {
+  override name: string = "AppLockError";
+}
+
+export class WrongPassword extends AppLockError {
+  override name = "WrongPassword" as const;
+
+  constructor() {
+    super("The supplied password does not match the stored verifier");
+  }
+}
+
+export class PasswordNotSet extends AppLockError {
+  override name = "PasswordNotSet" as const;
+
+  constructor() {
+    super("No password verifier has been stored yet");
+  }
+}

--- a/features/platform/app-lock/src/index.ts
+++ b/features/platform/app-lock/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./state/schema";
+export * from "./state/types";
+export * from "./biometrics";
+export * from "./errors";

--- a/features/platform/app-lock/src/state/schema.test.ts
+++ b/features/platform/app-lock/src/state/schema.test.ts
@@ -1,0 +1,23 @@
+import { AppLockStateSchema, AuthenticationTypeSchema } from "./schema";
+
+describe("AuthenticationTypeSchema", () => {
+  it.each(["none", "password", "biometrics", "passwordAndBiometrics"])("accepts %s", value => {
+    expect(AuthenticationTypeSchema.parse(value)).toBe(value);
+  });
+
+  it("rejects an unknown authentication type", () => {
+    expect(AuthenticationTypeSchema.safeParse("pin").success).toBe(false);
+  });
+});
+
+describe("AppLockStateSchema", () => {
+  it("parses a complete protection state", () => {
+    const state = { hasPassword: true, biometricsEnabled: false, isLocked: true };
+
+    expect(AppLockStateSchema.parse(state)).toEqual(state);
+  });
+
+  it("rejects a partial state rather than defaulting the missing flags", () => {
+    expect(AppLockStateSchema.safeParse({ hasPassword: true }).success).toBe(false);
+  });
+});

--- a/features/platform/app-lock/src/state/schema.ts
+++ b/features/platform/app-lock/src/state/schema.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const AuthenticationTypeSchema = z.enum([
+  "none",
+  "password",
+  "biometrics",
+  "passwordAndBiometrics",
+]);
+
+export const AppLockStateSchema = z.object({
+  hasPassword: z.boolean(),
+  biometricsEnabled: z.boolean(),
+  isLocked: z.boolean(),
+});

--- a/features/platform/app-lock/src/state/types.ts
+++ b/features/platform/app-lock/src/state/types.ts
@@ -1,0 +1,5 @@
+import type { z } from "zod";
+import type { AppLockStateSchema, AuthenticationTypeSchema } from "./schema";
+
+export type AuthenticationType = z.infer<typeof AuthenticationTypeSchema>;
+export type AppLockState = z.infer<typeof AppLockStateSchema>;

--- a/features/platform/app-lock/tsconfig.json
+++ b/features/platform/app-lock/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["jest"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6271,6 +6271,34 @@ importers:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
 
+  features/platform/app-lock:
+    dependencies:
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+    devDependencies:
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.36.0
+      react-native-keychain:
+        specifier: 'catalog:'
+        version: 10.0.0
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
   features/platform/card:
     dependencies:
       '@domain/api-card-management':
@@ -15722,6 +15750,27 @@ importers:
       jest:
         specifier: 'catalog:'
         version: 30.2.0
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
+  shared/password-verifier:
+    devDependencies:
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.36.0
       typescript:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
@@ -27274,7 +27323,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: '*'
+      rxjs: ^5.5.10
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -36520,6 +36569,7 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qrcode-terminal@0.11.0:

--- a/shared/password-verifier/README.md
+++ b/shared/password-verifier/README.md
@@ -1,0 +1,102 @@
+# @shared/password-verifier
+
+> [!CAUTION]
+> **Status: UNSTABLE** — Created in [LIVE-35917](https://ledgerhq.atlassian.net/browse/LIVE-35917) as part of the User App Authentication epic.
+
+Store a password so it can be checked later without keeping the password itself: the **verifier
+record** and the **constant-time comparison** that checks it.
+
+Pure functions over `Uint8Array`. No dependencies, no ports, no platform access.
+
+Deliberately named for what it does, not for who asked for it. The app lock is its first caller, but
+nothing here knows that — anything needing to verify a password can use it.
+
+## Scope, and why it is this small
+
+Everything else a password screen needs — scrypt, a CSPRNG, the Keychain, the biometric prompt — is a
+thin call into a React Native module. Callers do that directly; wrapping each behind a port bought
+indirection without buying anything, since mocking `react-native-keychain` in a test is one line.
+
+What genuinely benefits from living in one reviewed, exhaustively tested place is the comparison. It
+is three lines, it is easy to write wrongly, and writing it wrongly is silent. So that is what this
+package is, and nothing more.
+
+## Why it is its own package
+
+Small enough to look like it should be folded into its caller, so: it should not be.
+
+The rule is to use the lowest layer that can own the concern. This code needs nothing from
+`domain/` or `features/` — no state, no React, no platform — so `shared/` is the lowest layer that
+can hold it, and putting it a layer up would misplace it. `feature-flags` is split the same way:
+`@shared/feature-flags` owns the primitive, `@features/platform-feature-flags` owns the app-aware
+glue on top.
+
+Its only consumer today is `@features/platform-app-lock`, which depends on `react-native-keychain`.
+Keeping the verifier separate is what makes the security-critical comparison testable in plain Node
+with zero dependencies and no React Native context — and it carries its own CODEOWNERS line, so the
+one file where a casual edit is silently dangerous is reviewed by the people who own it.
+
+The config-to-code ratio is normal for this layer, not a smell: `shared/qr-code` is 12 lines of
+source and `shared/schema-primitives` is 50, against 48 here.
+
+The app lock's own state (`hasPassword`, `biometricsEnabled`, `isLocked`), its biometrics status
+unions and its errors live in
+[`@features/platform-app-lock`](../../features/platform/app-lock/README.md). Its screens live in
+[`@features/flow-app-lock`](../../features/flow/app-lock/README.md).
+
+## What this protects
+
+The verifier stores `scrypt(password, salt)`, never the password. **No field of it is secret** — an
+attacker who reads the device reads the salt, the parameters and the digest. What protects the
+password is the *cost* of scrypt, nothing else, which is why it must stay slow and why a 6-character
+password remains weak however it is stored.
+
+Note what the digest is **not**: it is never used as a key. Nothing is derived from the password to
+encrypt with — the digest exists only to be compared against the stored one. scrypt is used here as
+a password hash, not as a key derivation function, which is why the field is `digest` and the
+parameter is `digestLength` rather than `keyLength`.
+
+Even so, scrypt rather than a fast hash matters for a reason beyond this app: people reuse
+passwords. A fast hash on a readable device would hand an attacker the *user's password*, which may
+open their mail, not merely access to this wallet.
+
+The lock as a whole is an **opportunistic-access control**: it defends against someone picking up the
+phone. It is not data protection and must not be described as "encrypted at rest" — nothing is
+encrypted. Anyone who can read the app's files reads the stored data without going through the
+prompt, and can overwrite the verifier outright.
+
+## API
+
+```ts
+createPasswordVerifier({ digest, salt, scrypt }): PasswordVerifier
+matchesPasswordVerifier(verifier, digest): boolean
+```
+
+The caller derives `digest` with the platform's scrypt and generates `salt` with its CSPRNG.
+`createPasswordVerifier` copies both, so mutating the caller's arrays afterwards cannot alter a
+stored verifier. The `scrypt` parameters travel with the verifier, so an existing one still opens
+after the defaults are raised — hard-coding them would lock out every user the day the cost changes.
+
+`version` is a **policy** version, not an algorithm version: the migration off short passwords needs
+to know which rules a verifier was created under.
+
+`matchesPasswordVerifier` folds every byte into one accumulator and never returns early on a
+mismatch. Replacing it with `===` (which compares references on a `Uint8Array` and is always false),
+`every`, or any early-exit loop would leak how many leading bytes were correct and turn an offline
+brute force into a byte-by-byte one. The length check is safe to short-circuit: `scrypt.digestLength`
+sits in plaintext next to the verifier, so the length is not secret — Node's `timingSafeEqual`
+likewise refuses unequal lengths outright.
+
+## Left to the implementing ticket
+
+No default `ScryptParams` is exported on purpose. Choosing scrypt's `N` (`cost`), `r` (`blockSize`)
+and `p` (`parallelization`) is a real decision that needs measuring on low-end Android — shipping a
+default here would invite adopting it unmeasured.
+
+## Validation
+
+```sh
+pnpm test
+pnpm typecheck
+pnpm unimported
+```

--- a/shared/password-verifier/jest.config.js
+++ b/shared/password-verifier/jest.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  testEnvironment: "node",
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.(t|j)sx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+        },
+      },
+    ],
+  },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/shared/password-verifier/package.json
+++ b/shared/password-verifier/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@shared/password-verifier",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Password verifier record and its constant-time comparison",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "format": "oxfmt src",
+    "format:check": "oxfmt src --check",
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../.. -W shared/password-verifier"
+  },
+  "devDependencies": {
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "jest": "catalog:",
+    "oxfmt": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/shared/password-verifier/project.json
+++ b/shared/password-verifier/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@shared/password-verifier",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/shared/password-verifier/src/index.ts
+++ b/shared/password-verifier/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./types";
+export * from "./verifier";

--- a/shared/password-verifier/src/types.ts
+++ b/shared/password-verifier/src/types.ts
@@ -1,0 +1,13 @@
+export type ScryptParams = Readonly<{
+  cost: number;
+  blockSize: number;
+  parallelization: number;
+  digestLength: number;
+}>;
+
+export type PasswordVerifier = Readonly<{
+  version: number;
+  scrypt: ScryptParams;
+  salt: Uint8Array;
+  digest: Uint8Array;
+}>;

--- a/shared/password-verifier/src/verifier.test.ts
+++ b/shared/password-verifier/src/verifier.test.ts
@@ -1,0 +1,90 @@
+import type { ScryptParams } from "./types";
+import {
+  PASSWORD_VERIFIER_VERSION,
+  createPasswordVerifier,
+  matchesPasswordVerifier,
+} from "./verifier";
+
+const scrypt: ScryptParams = {
+  cost: 16384,
+  blockSize: 8,
+  parallelization: 1,
+  digestLength: 4,
+};
+
+const digest = Uint8Array.from([10, 20, 30, 40]);
+const salt = Uint8Array.from([1, 2, 3, 4]);
+
+describe("createPasswordVerifier", () => {
+  it("stamps the current version and keeps the scrypt parameters", () => {
+    const verifier = createPasswordVerifier({ digest, salt, scrypt });
+
+    expect(verifier.version).toBe(PASSWORD_VERIFIER_VERSION);
+    expect(verifier.scrypt).toEqual(scrypt);
+    expect(verifier.digest).toEqual(digest);
+    expect(verifier.salt).toEqual(salt);
+  });
+
+  it("copies the bytes so mutating the caller's arrays cannot alter the verifier", () => {
+    const mutableDigest = Uint8Array.from(digest);
+    const mutableSalt = Uint8Array.from(salt);
+    const verifier = createPasswordVerifier({
+      digest: mutableDigest,
+      salt: mutableSalt,
+      scrypt,
+    });
+
+    mutableDigest[0] = 99;
+    mutableSalt[0] = 99;
+
+    expect(verifier.digest).toEqual(digest);
+    expect(verifier.salt).toEqual(salt);
+  });
+});
+
+describe("matchesPasswordVerifier", () => {
+  const verifier = createPasswordVerifier({ digest, salt, scrypt });
+
+  it("accepts the identical digest", () => {
+    expect(matchesPasswordVerifier(verifier, Uint8Array.from(digest))).toBe(true);
+  });
+
+  it("rejects a digest differing in the last byte", () => {
+    expect(matchesPasswordVerifier(verifier, Uint8Array.from([10, 20, 30, 41]))).toBe(false);
+  });
+
+  it("rejects a digest differing in the first byte", () => {
+    expect(matchesPasswordVerifier(verifier, Uint8Array.from([11, 20, 30, 40]))).toBe(false);
+  });
+
+  it("rejects a digest differing in a single bit", () => {
+    expect(matchesPasswordVerifier(verifier, Uint8Array.from([10, 20, 30, 41]))).toBe(false);
+    expect(matchesPasswordVerifier(verifier, Uint8Array.from([10, 20, 30, 42]))).toBe(false);
+  });
+
+  it("rejects a shorter and a longer digest", () => {
+    expect(matchesPasswordVerifier(verifier, Uint8Array.from([10, 20, 30]))).toBe(false);
+    expect(matchesPasswordVerifier(verifier, Uint8Array.from([10, 20, 30, 40, 50]))).toBe(false);
+  });
+
+  it("rejects an empty digest", () => {
+    expect(matchesPasswordVerifier(verifier, new Uint8Array())).toBe(false);
+  });
+
+  it("does not accept a prefix of the stored digest", () => {
+    const truncated = createPasswordVerifier({
+      digest: Uint8Array.from([10, 20]),
+      salt,
+      scrypt: { ...scrypt, digestLength: 2 },
+    });
+
+    expect(matchesPasswordVerifier(truncated, Uint8Array.from(digest))).toBe(false);
+  });
+
+  it("compares content, not identity", () => {
+    const equalByValue = Uint8Array.from([10, 20, 30, 40]);
+
+    expect(equalByValue === verifier.digest).toBe(false);
+    expect(matchesPasswordVerifier(verifier, equalByValue)).toBe(true);
+  });
+});

--- a/shared/password-verifier/src/verifier.ts
+++ b/shared/password-verifier/src/verifier.ts
@@ -1,0 +1,29 @@
+import type { PasswordVerifier, ScryptParams } from "./types";
+
+export const PASSWORD_VERIFIER_VERSION = 1;
+
+export function createPasswordVerifier(
+  input: Readonly<{ digest: Uint8Array; salt: Uint8Array; scrypt: ScryptParams }>,
+): PasswordVerifier {
+  return {
+    version: PASSWORD_VERIFIER_VERSION,
+    scrypt: input.scrypt,
+    salt: Uint8Array.from(input.salt),
+    digest: Uint8Array.from(input.digest),
+  };
+}
+
+/** Compares in constant time: no `===`, no early exit, or the timing leaks the digest. */
+export function matchesPasswordVerifier(verifier: PasswordVerifier, digest: Uint8Array): boolean {
+  if (digest.length !== verifier.digest.length) {
+    return false;
+  }
+
+  let difference = 0;
+
+  for (let index = 0; index < digest.length; index += 1) {
+    difference |= digest[index] ^ verifier.digest[index];
+  }
+
+  return difference === 0;
+}

--- a/shared/password-verifier/tsconfig.json
+++ b/shared/password-verifier/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["jest"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}


### PR DESCRIPTION
### 📝 Description

Scaffolds the packages the **User App Authentication** epic builds on. No screens, no orchestration, nothing wired into the app yet — this lands on its own so the layering can be reviewed before the rest of the epic builds on it. #20905 carries the whole epic if you want to see what these packages end up holding — this is its first commit, unchanged.

**Problem**: today's password protects nothing. It is written to the Keychain in plaintext and verified with `credentials.password === password`, so anyone who can read the app's files reads the password itself.

**Solution**: two packages, each owning one concern.

| Package | Owns |
|---|---|
| `@shared/password-verifier` | The `PasswordVerifier` record and its **constant-time** comparison. Zero dependencies, pure functions over `Uint8Array`. |
| `@features/platform-app-lock` | Protection state schemas (`hasPassword`, `biometricsEnabled`, `isLocked`, `AuthenticationType`), the biometrics status unions, and the errors. |

```ts
import { createPasswordVerifier, matchesPasswordVerifier } from "@shared/password-verifier";

const verifier = createPasswordVerifier({ digest, salt, scrypt });
const ok = matchesPasswordVerifier(verifier, freshDigest);
```

Nothing is encrypted: the lock stores `scrypt(password, salt)`, never the password. Each package README records the reasoning behind its shape, including why the verifier is its own package and why the flow will use `screens/<Name>/`.

### 🧪 Tests

20 unit tests. `matchesPasswordVerifier` is covered for first-byte, last-byte, single-bit, length, empty-digest and prefix mismatches, plus reference-vs-value equality; `createPasswordVerifier` for its defensive copy. `@features/flow-app-lock` deliberately does not land here: a package whose public API is empty has no barrel to check, which `enforce-package-structure` rejects outright. It arrives with its first screens, in the next commit of the epic.

Verified locally: `typecheck`, `test`, `format:check`, `lint`, `unimported`, `enforce-boundaries:lint:boundaries` and `enforce-package-structure` all green on both packages, and `pnpm install --frozen-lockfile` on this commit alone.

### 👀 QA

**Nothing to test.** No user-facing change and no app wiring — none of these packages is imported anywhere yet. The only change outside them is `react-native-keychain` moving to the pnpm catalog, which still resolves to 10.0.0 for Ledger Wallet Mobile.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35917](https://ledgerhq.atlassian.net/browse/LIVE-35917) (epic: [LIVE-35505](https://ledgerhq.atlassian.net/browse/LIVE-35505))
- **Guideline**: [Monorepo DDD Re-architecture: Structure & Flow](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/6111232117)
- **Related**: #20848 adds the `lwmPasswordRevamp` flag that gates the epic. Independent — no shared files.

[LIVE-35917]: https://ledgerhq.atlassian.net/browse/LIVE-35917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ