### PR TITLE
feat(feature-flags): add lwmPasswordRevamp (LIVE-36076)

### DIFF
--- a/.changeset/add-lwm-password-revamp-flag.md
+++ b/.changeset/add-lwm-password-revamp-flag.md
@@ -1,0 +1,5 @@
+---
+"@shared/feature-flags": minor
+---
+
+Add the `lwmPasswordRevamp` feature flag, gating the User App Authentication epic on Ledger Wallet Mobile. Boolean gate with no params, disabled by default; its Remote Config key is derived as `feature_lwm_password_revamp`. Nothing reads it yet.

--- a/shared/feature-flags/src/flags/team-wallet-xp/index.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/index.ts
@@ -19,6 +19,7 @@ export * from "./lwdDustFiltering";
 export * from "./lwdWallet40";
 export * from "./lwmContacts";
 export * from "./lwmDustFiltering";
+export * from "./lwmPasswordRevamp";
 export * from "./lwmWallet40";
 export * from "./lwmQuickActionsCtasVariant";
 export * from "./llmTransferButtonCopyVariant";

--- a/shared/feature-flags/src/flags/team-wallet-xp/lwmPasswordRevamp.ts
+++ b/shared/feature-flags/src/flags/team-wallet-xp/lwmPasswordRevamp.ts
@@ -1,0 +1,3 @@
+import { flag } from "../../define";
+
+export const lwmPasswordRevamp = flag();


### PR DESCRIPTION
### 📝 Description

Declares the feature flag that gates the **User App Authentication** epic, so every follow-up ticket can hide its work behind it from the first commit.

**Problem**: the epic reworks how the app password is stored and verified. That has to ship dark, and the flag needs to exist before any of the four implementation tickets can reference it.

**Solution**: a boolean gate, disabled by default.

```ts
// shared/feature-flags/src/flags/team-wallet-xp/lwmPasswordRevamp.ts
import { flag } from "../../define";

export const lwmPasswordRevamp = flag();
```

Two files: the flag and one line in the team barrel. Nothing else — the registry is `import * as flags from "../flags"`, so `flagRegistry`, `FeatureId`, `Features` and `FeatureIdSchema` all widen from the export alone, and the developer settings screen picks it up with no extra registration.

The Remote Config key is derived rather than declared: `remoteConfig.ts` builds it as `feature_${snakeCase(id)}`, so this resolves to **`feature_lwm_password_revamp`**, matching the Feature Flag field on the epic. No mapping table to edit.

`lwm` and no `lwd` counterpart because the epic is mobile only — desktop is out of scope in the product spec.

**No params.** The candidates are real but undecided: the minimum password length (the spec says 6, the PoC used 8, still unresolved) and whether the migration off short passwords is forced or deferred. Both belong to the tickets that implement them, where the value can be chosen alongside the behaviour it drives. `flag()` → `flagWith({ ... })` is a one-line change later.

### 🧪 Tests

No new test — bare `flag()` declarations don't carry one here (cf. `llRobinhoodDisclaimer`), and the behaviour is entirely the shared `flag()` helper's, which is already covered.

Verified locally instead: the existing 104 tests in `@shared/feature-flags` pass, `typecheck` is green, and a throwaway probe confirmed the flag lands in `FeatureIdSchema.options`, appears in `flagRegistry`, and parses to `{ enabled: false }` by default. The mobile `remoteConfig` test derives its keys from `FeatureIdSchema.options`, so it needs no update.

### 👀 QA

**Nothing to test.** No code reads the flag. It should appear in the developer feature-flags settings screen, switched off.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36076](https://ledgerhq.atlassian.net/browse/LIVE-36076) (epic: [LIVE-35505](https://ledgerhq.atlassian.net/browse/LIVE-35505))
- **Related**: #20847 adds the packages the epic builds on. Independent of this PR — no shared files, either can merge first.

[LIVE-36076]: https://ledgerhq.atlassian.net/browse/LIVE-36076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ