### PR TITLE
fix(contacts): remove entry point press padding (LIVE-35852)

### DIFF
--- a/.changeset/calm-lobsters-press.md
+++ b/.changeset/calm-lobsters-press.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": minor
+---
+
+Fix the pressed-state spacing of the mobile Contacts entry point.

--- a/features/flow/contacts/src/components/ContactsButton/ContactsButton.native.tsx
+++ b/features/flow/contacts/src/components/ContactsButton/ContactsButton.native.tsx
@@ -28,7 +28,7 @@ export function ContactsButton({
     <ListItem
       onPress={onPress}
       testID="my-wallet-contacts-button"
-      lx={{ backgroundColor: "surface", borderRadius: "md", paddingVertical: "s4" }}
+      lx={{ backgroundColor: "surface", borderRadius: "md" }}
     >
       <ListItemLeading>
         <Spot appearance="icon" icon={BookOpen} size={48} />


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** The targeted Mobile integration suite is blocked before test execution by the pre-existing missing module `@features/flow-pay-card-balance/state`.
- [x] **Impact of the changes:**
      Press the Contacts entry point in My Wallet and verify no dark vertical frame surrounds the pressed row.

### 📝 Description

The Mobile Contacts entry point kept vertical wrapper padding visible when its ListItem press feedback rendered, which appeared as extra padding around the pressed row.

This removes only that wrapper vertical padding while preserving the existing surface background and corner radius.

<img width="394" height="459" alt="image" src="https://github.com/user-attachments/assets/cb7d528c-8d32-4c5f-9885-22a5fa463a5f" />

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-35852

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)