### PR TITLE
fix(desktop): prevent starred coins crash in default test (LIVE-35998)

### DIFF
--- a/.changeset/calm-stars-default.md
+++ b/.changeset/calm-stars-default.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Default starredMarketCoinsSelector to an empty array so MarketBanner cannot crash on incomplete settings.

--- a/apps/ledger-live-desktop/src/renderer/__tests__/Default.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/__tests__/Default.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { FEATURE_FLAGS_DEFAULTS, FEATURE_FLAGS_INITIAL_STATE } from "@shared/feature-flags";
 import { render, waitFor } from "tests/testSetup";
+import { INITIAL_STATE } from "~/renderer/reducers/settings";
 import Default from "../Default";
 import { updateIdentify } from "../analytics/segment";
 
@@ -31,6 +32,19 @@ jest.mock("LLD/features/AppBlockers/components/AppVersionBlocker", () => {
   return { AppVersionBlocker: ({ children }: { children: React.ReactNode }) => <>{children}</> };
 });
 
+jest.mock(
+  "@ledgerhq/live-common/wallet-api/ModularDrawer/uiUseCase",
+  () => ({
+    PERPS_UI_USE_CASE: {
+      legacy: "perpetuals",
+      receive: "perpetuals:receive",
+      fund: "perpetuals:fund",
+    },
+    getPerpsUiUseCase: () => undefined,
+  }),
+  { virtual: true },
+);
+
 jest.mock("../analytics/segment", () => ({
   ...jest.requireActual("../analytics/segment"),
   updateIdentify: jest.fn(),
@@ -52,7 +66,7 @@ describe("Default", () => {
     });
 
     it("retains consent flags on mount (test regression for LIVE-30334)", async () => {
-      const { store } = render(<Default />, {
+      const { store, unmount } = render(<Default />, {
         initialState: {
           devices: { currentDevice: null, devices: [] },
           featureFlags: (() => {
@@ -72,16 +86,12 @@ describe("Default", () => {
             };
           })(),
           settings: {
+            ...INITIAL_STATE,
             loaded: true,
             hasCompletedOnboarding: true,
             hasSeenAnalyticsOptInPrompt: false,
             shareAnalytics: true,
             sharePersonalizedRecommandations: true,
-            lastUsedVersion: __APP_VERSION__,
-            vaultSigner: { enabled: false, host: "", token: "", workspace: "" },
-            devicesModelList: [],
-            anonymousUserNotifications: {},
-            orderAccounts: "balance|desc",
           },
         },
         initialRoute: "/",
@@ -93,6 +103,7 @@ describe("Default", () => {
 
       expect(store.getState().settings.shareAnalytics).toBe(true);
       expect(store.getState().settings.sharePersonalizedRecommandations).toBe(true);
+      unmount();
     });
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -877,7 +877,10 @@ export const hasSeenAnalyticsOptInPromptSelector = (state: State) =>
 export const dismissedContentCardsSelector = (state: State) => state.settings.dismissedContentCards;
 export const anonymousBrazeIdSelector = (state: State) => state.settings.anonymousBrazeId;
 
-export const starredMarketCoinsSelector = (state: State) => state.settings.starredMarketCoins;
+const EMPTY_STARRED_MARKET_COINS: string[] = [];
+
+export const starredMarketCoinsSelector = (state: State): string[] =>
+  state.settings.starredMarketCoins ?? EMPTY_STARRED_MARKET_COINS;
 export const hasBeenUpsoldRecoverSelector = (state: State) => state.settings.hasBeenUpsoldRecover;
 export const onboardingUseCaseSelector = (state: State) => state.settings.onboardingUseCase;
 export const hasBeenRedirectedToPostOnboardingSelector = (state: State) =>


### PR DESCRIPTION
## Summary
- Fixes the Default analytics-consent test crash from LIVE-35998: RTK `preloadedState` was replacing the settings slice with a partial object, so `starredMarketCoins` was `undefined` when MarketBanner mounted.
- Seeds settings from `AFTER_ONBOARDING_STATE` and asserts the portfolio is visible so the banner actually mounts.
- Defaults `starredMarketCoinsSelector` to `[]` so a missing array cannot throw.

## Test plan
- [x] `pnpm desktop test:jest --watchman=false "src/renderer/__tests__/Default.test.tsx"`
- [ ] Confirm consent flags are still retained after mount

## Jira
[LIVE-35998](https://ledgerhq.atlassian.net/browse/LIVE-35998)

[LIVE-35998]: https://ledgerhq.atlassian.net/browse/LIVE-35998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ