### PR TITLE
[LWDM] fix(coin-sui): map device 0x8 on address-balance send to clear error

### DIFF
--- a/.changeset/sour-hotels-greet.md
+++ b/.changeset/sour-hotels-greet.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-sui": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+fix(coin-sui): map device 0x8 on address-balance send to clear error

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7924,6 +7924,10 @@
     "SomeSuiForUnstake": {
       "title": "Please ensure you reserve at least 0.1 SUI in your wallet to cover future network fees and undelegate your stake"
     },
+    "SuiAddressBalanceAppUpdateRequired": {
+      "title": "Update your Sui app",
+      "description": "Your Ledger Sui app can't sign a transfer from your SUI address balance. Update the Sui app on your Ledger device and try again."
+    },
     "NotEnoughBalanceForUnstaking": {
       "message": "Your available (non-staked) balance is currently {{currentBalance}} which is insufficient to pay for the network fees to unstake your {{assetName}}.",
       "oneCta": "<cta1>{{cta1Label}}</cta1> {{assetName}} into your account.",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -760,6 +760,10 @@
     "SuiUnstakeExceedsStake": {
       "title": "Amount exceeds the selected stake"
     },
+    "SuiAddressBalanceAppUpdateRequired": {
+      "title": "Update your Sui app",
+      "description": "Your Ledger Sui app can't sign a transfer from your SUI address balance. Update the Sui app on your Ledger device and try again."
+    },
     "PasswordIncorrect": {
       "title": "Incorrect password",
       "description": "Please try again."

--- a/libs/coin-modules/coin-sui/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/signOperation.test.ts
@@ -8,12 +8,29 @@ import { verifyTransactionSignature as mockVerifyTransactionSignature } from "@m
 import { BigNumber } from "bignumber.js";
 import { take } from "rxjs/operators";
 import coinConfig from "../config";
+import { SuiAddressBalanceAppUpdateRequired } from "../errors";
 import type { SuiAccount, SuiSigner, Transaction, SuiSignedOperation } from "../types";
 import { ensureAddressFormat as mockEnsureAddressFormat } from "../utils";
 import { buildOptimisticOperation as mockBuildOptimisticOperation } from "./buildOptimisticOperation";
 import { buildTransaction as mockBuildTransaction } from "./buildTransaction";
 import buildSignOperation from "./signOperation";
 import { calculateAmount as mockCalculateAmount } from "./utils";
+
+// Real `tx.build()` bytes (no intent prefix). Address-balance send: `coin::redeem_funds`
+// (a FundsWithdrawal input) + transferObjects — the shape older Sui apps reject with 0x8.
+const ADDRESS_BALANCE_TX_B64 =
+  "AAACACBvsh/urQJ9pIcyla/1sTzYY/hdvovvz57de8dlGOzHiAIAAMqaOwAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACA3N1aQNTVUkAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIEY29pbgxyZWRlZW1fZnVuZHMBBwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACA3N1aQNTVUkAAQEBAAEBAwAAAAABAADXgJJ9qOf/ltsDmfFnOLvOll7vkz1IfwRlxTK9Hu2w0wDXgJJ9qOf/ltsDmfFnOLvOll7vkz1IfwRlxTK9Hu2w0+gDAAAAAAAAAOH1BQAAAAAA";
+// Classic coin-object send: splitCoins(tx.gas) + transferObjects — no FundsWithdrawal input.
+const COIN_OBJECT_TX_B64 =
+  "AAACAAgAypo7AAAAAAAgb7If7q0CfaSHMpWv9bE82GP4Xb6L78+e3XvHZRjsx4gCAgABAQAAAQEDAAAAAAEBANeAkn2o5/+W2wOZ8Wc4u86WXu+TPUh/BGXFMr0e7bDTARERERERERERERERERERERERERERERERERERERERERERCgAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADXgJJ9qOf/ltsDmfFnOLvOll7vkz1IfwRlxTK9Hu2w0+gDAAAAAAAAAOH1BQAAAAAA";
+
+/** Mimics the transport's TransportStatusError for SW 0x0008 (UNKNOWN_ERROR (0x8)). */
+function makeUnknownDeviceError(): Error {
+  return Object.assign(new Error("Ledger device: UNKNOWN_ERROR (0x8)"), {
+    name: "TransportStatusError",
+    statusCode: 0x0008,
+  });
+}
 
 // Mock dependencies
 jest.mock("../config", () => ({
@@ -355,6 +372,72 @@ describe("buildSignOperation", () => {
       signOperation({ account: mockAccount, deviceId, transaction: mockTransaction }).subscribe({
         error: error => {
           expect(error).toBe(calculateError);
+          done();
+        },
+      });
+    });
+  });
+
+  describe("SIP-58 address-balance error mapping", () => {
+    it("maps UNKNOWN_ERROR (0x8) on an address-balance send to SuiAddressBalanceAppUpdateRequired", done => {
+      (mockBuildTransaction as unknown as jest.Mock).mockResolvedValue({
+        unsigned: Buffer.from(ADDRESS_BALANCE_TX_B64, "base64"),
+      });
+      mockLedgerSigner.signTransaction.mockRejectedValue(makeUnknownDeviceError());
+
+      signOperation({ account: mockAccount, deviceId, transaction: mockTransaction }).subscribe({
+        error: error => {
+          expect(error).toBeInstanceOf(SuiAddressBalanceAppUpdateRequired);
+          done();
+        },
+      });
+    });
+
+    it("propagates UNKNOWN_ERROR (0x8) unchanged for a classic coin-object send", done => {
+      const unknownError = makeUnknownDeviceError();
+      (mockBuildTransaction as unknown as jest.Mock).mockResolvedValue({
+        unsigned: Buffer.from(COIN_OBJECT_TX_B64, "base64"),
+      });
+      mockLedgerSigner.signTransaction.mockRejectedValue(unknownError);
+
+      signOperation({ account: mockAccount, deviceId, transaction: mockTransaction }).subscribe({
+        error: error => {
+          expect(error).toBe(unknownError);
+          done();
+        },
+      });
+    });
+
+    it("propagates non-0x8 device errors unchanged even on an address-balance send", done => {
+      const otherError = Object.assign(new Error("Ledger device: DENIED_BY_USER (0x6985)"), {
+        name: "TransportStatusError",
+        statusCode: 0x6985,
+      });
+      (mockBuildTransaction as unknown as jest.Mock).mockResolvedValue({
+        unsigned: Buffer.from(ADDRESS_BALANCE_TX_B64, "base64"),
+      });
+      mockLedgerSigner.signTransaction.mockRejectedValue(otherError);
+
+      signOperation({ account: mockAccount, deviceId, transaction: mockTransaction }).subscribe({
+        error: error => {
+          expect(error).toBe(otherError);
+          done();
+        },
+      });
+    });
+
+    it("propagates the original 0x8 device error when the unsigned tx bytes can't be parsed", done => {
+      const unknownError = makeUnknownDeviceError();
+      // Not valid BCS transaction bytes: the address-balance probe can't parse them, so it can't
+      // confirm the spend and the original device error must propagate rather than a parse error.
+      (mockBuildTransaction as unknown as jest.Mock).mockResolvedValue({
+        unsigned: new Uint8Array([1, 2, 3, 4, 5]),
+      });
+      mockLedgerSigner.signTransaction.mockRejectedValue(unknownError);
+
+      signOperation({ account: mockAccount, deviceId, transaction: mockTransaction }).subscribe({
+        error: error => {
+          expect(error).toBe(unknownError);
           done();
         },
       });

--- a/libs/coin-modules/coin-sui/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/signOperation.ts
@@ -3,9 +3,11 @@ import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import type { AccountBridge } from "@ledgerhq/types-live";
 import { LedgerSigner } from "@mysten/signers/ledger";
 import type { ClientWithCoreApi } from "@mysten/sui/client";
+import { Transaction as SuiTransaction } from "@mysten/sui/transactions";
 import { BigNumber } from "bignumber.js";
 import { Observable } from "rxjs";
 import suiConfig from "../config";
+import { SuiAddressBalanceAppUpdateRequired } from "../errors";
 import { withCoreApi } from "../network/sdk";
 import type { SuiAccount, SuiSigner, Transaction } from "../types";
 import { buildOptimisticOperation } from "./buildOptimisticOperation";
@@ -36,6 +38,35 @@ const signWithDevice = (
       return ledgerSigner.signTransaction(unsigned, objects, resolution);
     },
   );
+
+/** Device status word for a transaction the Sui app rejects as unrecognized/unsupported. */
+const SUI_APP_UNKNOWN_ERROR = 0x0008;
+
+/**
+ * True when the built transaction spends from the SIP-58 address balance via a `FundsWithdrawal`
+ * input (`0x2::coin::redeem_funds`). Sui apps that predate that parser reject such transfers with
+ * an opaque UNKNOWN_ERROR (0x8), which we translate into an actionable error.
+ */
+function drawsFromAddressBalance(unsigned: Uint8Array): boolean {
+  try {
+    return SuiTransaction.from(unsigned)
+      .getData()
+      .inputs.some(input => input.$kind === "FundsWithdrawal");
+  } catch {
+    // If the bytes can't be parsed we can't confirm an address-balance spend, so treat it as
+    // not one and let the original device error propagate rather than masking it with a parse error.
+    return false;
+  }
+}
+
+/** The Sui app returned SW 0x0008 (surfaced by the transport as UNKNOWN_ERROR (0x8)). */
+function isSuiAppUnknownError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.name === "TransportStatusError" &&
+    (error as { statusCode?: number }).statusCode === SUI_APP_UNKNOWN_ERROR
+  );
+}
 
 /**
  * Sign Transaction with Ledger hardware
@@ -73,7 +104,14 @@ export const buildSignOperation = (
 
         const signed = await signerContext(deviceId, suiSigner =>
           signWithDevice(account, suiSigner, built),
-        );
+        ).catch(error => {
+          // An address-balance transfer that the Sui app can't parse surfaces as UNKNOWN_ERROR
+          // (0x8). Replace it with an actionable error telling the user to update the Sui app.
+          if (isSuiAppUnknownError(error) && drawsFromAddressBalance(built.unsigned)) {
+            throw new SuiAddressBalanceAppUpdateRequired();
+          }
+          throw error;
+        });
 
         subscriber.next({
           type: "device-signature-granted",

--- a/libs/coin-modules/coin-sui/src/errors.ts
+++ b/libs/coin-modules/coin-sui/src/errors.ts
@@ -65,3 +65,19 @@ export class SuiUnstakeExceedsStake extends Error {
     if (fields) Object.assign(this, fields);
   }
 }
+
+/*
+ * The installed Sui app rejected a transfer drawn from the SIP-58 address balance because it
+ * doesn't recognize the `0x2::coin::redeem_funds` withdrawal. Older apps return an opaque
+ * UNKNOWN_ERROR (0x8); we raise this instead so the user knows to update the Sui app.
+ */
+export class SuiAddressBalanceAppUpdateRequired extends Error {
+  override name = "SuiAddressBalanceAppUpdateRequired";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(
+      message ||
+        "Your Ledger Sui app can't sign a transfer from your SUI address balance. Update the Sui app on your Ledger device and try again.",
+    );
+    if (fields) Object.assign(this, fields);
+  }
+}


### PR DESCRIPTION
### 📝 Description

SUI sends, unstakes and swaps drawn from a SIP-58 **address balance** failed on-device at signing with an opaque `UNKNOWN_ERROR (0x8)`, giving the user no hint that it was an app-version problem.

When the built transaction spends from the address balance (a `FundsWithdrawal` input — `0x2::coin::redeem_funds`) and the device returns `0x8`, we now map it to an actionable `SuiAddressBalanceAppUpdateRequired` error ("update your Sui app"), with English copy for desktop and mobile. The transaction is built exactly as before; this only translates the device error, and only for that input shape — any other `0x8` propagates unchanged. It's the field fallback for devices still on the old app; the durable parser fix ships in [LedgerHQ/app-sui#67](https://github.com/LedgerHQ/app-sui/pull/67).

`signOperation.test.ts` guards it: the mapping fires only for an address-balance transfer and passes the original device error through otherwise.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35798](https://ledgerhq.atlassian.net/browse/LIVE-35798) / [TSD-11433](https://ledgerhq.atlassian.net/browse/TSD-11433)
- **ADR** (if any): n/a

[LIVE-35798]: https://ledgerhq.atlassian.net/browse/LIVE-35798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ