### PR TITLE
feat(pay-card): scaffold @features/flow-pay-card-request (LIVE-36094)

### DIFF
--- a/.changeset/pay-card-request-scaffold.md
+++ b/.changeset/pay-card-request-scaffold.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-pay-card-request": minor
+---
+
+Scaffold the @features/flow-pay-card-request dual-platform flow package (empty public API) so the Pay tab Request receive-screen component and view-model can be added in follow-up tickets.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -129,6 +129,11 @@ features/flow/flow-contacts-list/                         @ledgerhq/wallet-xp
 features/flow/pay-card-balance/                          @ledgerhq/wallet-xp
 features/flow/pay-card-deposit/                          @ledgerhq/wallet-xp
 features/flow/pay-card-feature-tour/                     @ledgerhq/wallet-xp
+features/flow/pay-card-request/                          @ledgerhq/wallet-xp
+
+features/platform/card/                                  @ledgerhq/wallet-xp
+domain/api/card-management/                              @ledgerhq/wallet-xp
+/shared/api-services/src/services/card/                  @ledgerhq/wallet-xp
 
 # Wallet — shared UI
 /shared/ui-queued-bottom-sheet/                          @ledgerhq/wallet-xp

--- a/features/flow/pay-card-request/.eslintrc.tailwind.js
+++ b/features/flow/pay-card-request/.eslintrc.tailwind.js
@@ -1,0 +1,34 @@
+/**
+ * ESLint config for better-tailwindcss only (no oxlint equivalent).
+ * Run via: pnpm lint:tailwind
+ * Applies to *.web.{ts,tsx} files only.
+ */
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+const path = require("path");
+
+module.exports = {
+  root: true,
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: "module",
+    ecmaFeatures: { jsx: true },
+  },
+  plugins: ["better-tailwindcss"],
+  extends: ["plugin:better-tailwindcss/recommended"],
+  ignorePatterns: ["*.js", "*.cjs", "*.mjs", "node_modules"],
+  rules: {
+    "better-tailwindcss/enforce-consistent-line-wrapping": "off",
+  },
+  settings: {
+    "better-tailwindcss": {
+      entryPoint: path.join(__dirname, "../../../apps/ledger-live-desktop/src/renderer/global.css"),
+      callees: ["cn"],
+    },
+  },
+  overrides: [
+    {
+      files: ["**/*.web.{ts,tsx}"],
+    },
+  ],
+};

--- a/features/flow/pay-card-request/.oxfmtrc.json
+++ b/features/flow/pay-card-request/.oxfmtrc.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "printWidth": 100,
+  "trailingComma": "all",
+  "arrowParens": "avoid",
+  "sortPackageJson": false,
+  "ignorePatterns": [
+    "**/*.md",
+    "**/*.json"
+  ]
+}

--- a/features/flow/pay-card-request/.oxlintrc.json
+++ b/features/flow/pay-card-request/.oxlintrc.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "env": {
+    "browser": true,
+    "es6": true,
+    "node": true
+  },
+  "plugins": [
+    "eslint",
+    "import",
+    "oxc",
+    "unicorn",
+    "typescript",
+    "react",
+    "jest",
+    "jsx-a11y"
+  ],
+  "ignorePatterns": ["*.js", "*.cjs", "*.mjs", "node_modules"],
+  "categories": {
+    "correctness": "error",
+    "suspicious": "warn",
+    "pedantic": "off"
+  },
+  "rules": {
+    "eslint/no-unused-vars": "warn",
+    "eslint/no-empty-pattern": "warn",
+    "eslint/no-constant-binary-expression": "warn",
+    "eslint/no-shadow": "off",
+    "eslint/no-unused-expressions": "warn",
+    "eslint/no-unsafe-optional-chaining": "off",
+    "eslint/no-useless-rename": "warn",
+    "eslint/no-console": ["error", { "allow": ["warn", "error"] }],
+    "eslint/no-restricted-imports": [
+      "error",
+      {
+        "paths": ["lodash"],
+        "patterns": [
+          {
+            "group": [
+              "@ledgerhq/live-common/lib/**",
+              "@ledgerhq/live-common/lib-es/**"
+            ],
+            "message": "Please remove the /lib import from live-common import."
+          }
+        ]
+      }
+    ],
+    "import/no-duplicates": "error",
+    "import/no-named-as-default": "off",
+    "typescript/no-explicit-any": "error",
+    "typescript/no-non-null-assertion": "off",
+    "typescript/no-deprecated": "error",
+    "react/no-did-mount-set-state": "warn",
+    "react/jsx-key": "warn",
+    "react/display-name": "off",
+    "react/prop-types": "off",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": [
+      "error",
+      {
+        "additionalHooks": "(useInViewContext|useAnimatedStyle|useDerivedValue|useAnimatedProps)"
+      }
+    ],
+    "unicorn/no-useless-fallback-in-spread": "off",
+    "unicorn/no-useless-spread": "off",
+    "unicorn/no-new-array": "off",
+    "unicorn/no-array-sort": "off",
+    "jest/no-conditional-expect": "warn",
+    "jest/expect-expect": "warn",
+    "jest/require-to-throw-message": "warn",
+    "jest/valid-title": "warn",
+    "jest/no-disabled-tests": "warn",
+    "oxc/const-comparisons": "warn",
+    "jsx-a11y/no-autofocus": "off",
+    "jsx-a11y/anchor-is-valid": "off"
+  },
+  "overrides": [
+    {
+      "files": ["**/*.test.{ts,tsx}", "**/__tests__/**"],
+      "env": { "jest": true },
+      "plugins": ["jest"],
+      "rules": {
+        "typescript/no-explicit-any": "warn"
+      }
+    }
+  ]
+}

--- a/features/flow/pay-card-request/README.md
+++ b/features/flow/pay-card-request/README.md
@@ -1,0 +1,34 @@
+# Pay Card Request
+
+> [!CAUTION]
+> **Status: UNSTABLE** — Scaffold only; public API is still being designed.
+
+Dual-platform flow package that will host the Pay tab **Request receive-screen** experience for
+Ledger Wallet: a shared view-model and receive-screen component (QR, truncated address, action
+slot, shareable card) consumed by the platform presentations on desktop and mobile.
+
+## Scope
+
+This package is currently an **empty scaffold** created in
+[LIVE-36094](https://ledgerhq.atlassian.net/browse/LIVE-36094). The receive-screen view-model and
+component land in [LIVE-35187](https://ledgerhq.atlassian.net/browse/LIVE-35187) and its platform
+tickets (LIVE-35188 / LIVE-35189). Until then the barrels only expose a compile-only placeholder.
+
+## Platform resolution
+
+Only views will carry a platform suffix (`.web` / `.native`). The container, view-model, and types
+stay platform-agnostic and import without a suffix; TypeScript `moduleSuffixes`, the bundlers
+(Rspack / Metro) and the jest preset resolve the right side.
+
+## Structure
+
+Every `index.*` is a pure barrel (`export *` only).
+
+```text
+pay-card-request/
+├── package.json
+└── src/
+    ├── index.ts          # Public API barrel (web/default)
+    ├── index.native.ts   # Public API barrel (native)
+    └── placeholder.ts    # Compile-only placeholder (removed once real exports land)
+```

--- a/features/flow/pay-card-request/jest.config.js
+++ b/features/flow/pay-card-request/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = require("@support/jest-features-flow").createFlowJestConfig({
+  passWithNoTests: true,
+});

--- a/features/flow/pay-card-request/package.json
+++ b/features/flow/pay-card-request/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@features/flow-pay-card-request",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Pay Card request flow for Ledger Wallet (scaffold)",
+  "main": "src/index.ts",
+  "react-native": "src/index.native.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "react-native": "./src/index.native.ts",
+      "default": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "format": "oxfmt src",
+    "format:check": "oxfmt src --check",
+    "lint": "oxlint src && pnpm lint:tailwind",
+    "lint:ci": "oxlint src --quiet && pnpm lint:tailwind",
+    "lint:fix": "oxfmt src && oxlint src --fix --quiet && pnpm lint:tailwind",
+    "lint:tailwind": "eslint --no-eslintrc --no-error-on-unmatched-pattern -c .eslintrc.tailwind.js --ext .ts,.tsx 'src/**/*.web.{ts,tsx}'",
+    "typecheck": "tsc --noEmit -p tsconfig.web.json && tsc --noEmit -p tsconfig.native.json",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../../.. -W features/flow/pay-card-request"
+  },
+  "devDependencies": {
+    "@support/jest-features-flow": "workspace:*",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@testing-library/jest-dom": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "@typescript-eslint/parser": "catalog:",
+    "eslint": "8.57.0",
+    "eslint-plugin-better-tailwindcss": "catalog:",
+    "jest": "catalog:",
+    "jest-environment-jsdom": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
+    "tailwindcss": "catalog:",
+    "typescript": "catalog:"
+  },
+  "optionalDependencies": {
+    "@oxlint/binding-darwin-arm64": "1.51.0",
+    "@oxlint/binding-darwin-x64": "1.51.0",
+    "@oxlint/binding-linux-x64-gnu": "1.51.0",
+    "@oxlint/binding-win32-x64-msvc": "1.51.0"
+  }
+}

--- a/features/flow/pay-card-request/project.json
+++ b/features/flow/pay-card-request/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@features/flow-pay-card-request",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/features/flow/pay-card-request/src/index.native.ts
+++ b/features/flow/pay-card-request/src/index.native.ts
@@ -1,0 +1,1 @@
+export * from "./placeholder";

--- a/features/flow/pay-card-request/src/index.ts
+++ b/features/flow/pay-card-request/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./placeholder";

--- a/features/flow/pay-card-request/src/placeholder.ts
+++ b/features/flow/pay-card-request/src/placeholder.ts
@@ -1,0 +1,1 @@
+export const FLOW_PAY_CARD_REQUEST_PACKAGE = "@features/flow-pay-card-request";

--- a/features/flow/pay-card-request/tsconfig.json
+++ b/features/flow/pay-card-request/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "types": ["jest", "node", "@testing-library/jest-dom"]
+  },
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.web.json" },
+    { "path": "./tsconfig.native.json" }
+  ]
+}

--- a/features/flow/pay-card-request/tsconfig.native.json
+++ b/features/flow/pay-card-request/tsconfig.native.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleSuffixes": [".native", ""]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "src/**/*.web.*"]
+}

--- a/features/flow/pay-card-request/tsconfig.test.json
+++ b/features/flow/pay-card-request/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.web.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "src/**/*.native.*"]
+}

--- a/features/flow/pay-card-request/tsconfig.web.json
+++ b/features/flow/pay-card-request/tsconfig.web.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleSuffixes": [".web", ""]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "src/**/*.native.*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5988,6 +5988,67 @@ importers:
         specifier: 1.51.0
         version: 1.51.0
 
+  features/flow/pay-card-request:
+    devDependencies:
+      '@support/jest-features-flow':
+        specifier: workspace:*
+        version: link:../../../support/jest-features-flow
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@testing-library/jest-dom':
+        specifier: 'catalog:'
+        version: 6.9.1
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      '@typescript-eslint/parser':
+        specifier: 'catalog:'
+        version: 8.48.1(@typescript/typescript6@6.0.2)(eslint@8.57.0)
+      eslint:
+        specifier: 8.57.0
+        version: 8.57.0
+      eslint-plugin-better-tailwindcss:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.3(@typescript/typescript6@6.0.2)(eslint@8.57.0)(tailwindcss@4.1.18)
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0(@types/node@24.12.0)
+      jest-environment-jsdom:
+        specifier: 'catalog:'
+        version: 30.2.0
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.36.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.51.0
+      tailwindcss:
+        specifier: 'catalog:'
+        version: 4.1.18
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+    optionalDependencies:
+      '@oxlint/binding-darwin-arm64':
+        specifier: 1.51.0
+        version: 1.51.0
+      '@oxlint/binding-darwin-x64':
+        specifier: 1.51.0
+        version: 1.51.0
+      '@oxlint/binding-linux-x64-gnu':
+        specifier: 1.51.0
+        version: 1.51.0
+      '@oxlint/binding-win32-x64-msvc':
+        specifier: 1.51.0
+        version: 1.51.0
+
   features/platform/aggregated-assets:
     dependencies:
       '@domain/api-aggregated-assets':


### PR DESCRIPTION
### 📝 Description

Scaffolds the new dual-platform flow package `@features/flow-pay-card-request` with an empty, barrels-only public API. This gives the Pay tab **Request receive-screen** work a package to import before any UI lands.

**Problem**: The Request receive-screen view-model and component (LIVE-35187) need a home package. Landing package setup together with the UI made the change hard to review, so the package init was split out (mirroring the `@features/flow-pay-card-deposit` scaffold: LIVE-36004 → LIVE-34910).

**Solution**: Clone the empty deposit scaffold into `features/flow/pay-card-request/`:

- `package.json` (private, `sideEffects: false`, dual `exports`, scaffold-only tooling deps — no React/Lumen/bottom-sheet), `project.json`, `tsconfig.*`, `jest.config.js` (`passWithNoTests`), oxlint/oxfmt/eslint-tailwind configs.
- Barrels-only `src/index.ts` / `src/index.native.ts` re-exporting a compile-only `placeholder.ts` so typecheck/knip pass on an otherwise empty package.
- `README.md` with the UNSTABLE status marker, CODEOWNERS entry (`@ledgerhq/wallet-xp`), and a minor changeset.

Out of scope (stays on LIVE-35187 and its platform tickets): the receive-screen VM, QR, shareable card, verify-on-device callback, and wiring the package into desktop/mobile.

Validation: typecheck, lint (+ tailwind), test (no tests), and knip all pass.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36094](https://ledgerhq.atlassian.net/browse/LIVE-36094)
- Follow-up: [LIVE-35187](https://ledgerhq.atlassian.net/browse/LIVE-35187)

[LIVE-36094]: https://ledgerhq.atlassian.net/browse/LIVE-36094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ