### PR TITLE
docs(agents): add expected github code review skill

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
 # Copilot Automated Reviewer Instructions
 
-- Use [`.agents/agents/code-reviewer.md`](../.agents/agents/code-reviewer.md) to review the PR
 - See [`AGENTS.md`](../AGENTS.md) for general repo context
+- Use [`.agents/agents/code-reviewer.md`](../.agents/agents/code-reviewer.md) to review the PR

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: gh-code-review
+description: Follow these instructions when reviewing PRs
+---
+
+- See the rules for the code review sub-agent [`.agents/agents/code-reviewer.md`](../../../.agents/agents/code-reviewer.md)
+- See [`AGENTS.md`](../../../AGENTS.md) for general repo context


### PR DESCRIPTION
### 📝 Description

GitHub Copilot's automated reviewer expects a specific skill file (`.github/skills/code-review/SKILL.md`) and triggers messaging when the file is not present.

These changes add the file and point to the same documentation described in `.github/copilot-instructions.md`, albeit in a slightly different lense.

<details><summary>Quick research results</summary>
<p>

<img width="618" height="1043" alt="Screenshot 2026-08-17 at 15 18 24" src="https://github.com/user-attachments/assets/cea01feb-5393-436c-b507-395e1a254d2a" />


</p>
</details> 

### 🔗 Context

- **JIRA / GitHub issue**: No Jira but behaviour observed on recent PRs