### PR TITLE
[LWD] fix(contacts): disable ineligible assets (LIVE-35855)

### DIFF
--- a/.changeset/grey-assets-stay.md
+++ b/.changeset/grey-assets-stay.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Show unavailable Contacts asset and network options as disabled in the asset drawer.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -406,14 +406,14 @@ describe("Contacts integration", () => {
     expect(screen.getByTestId("contacts-detail-add-address")).toBeVisible();
   });
 
-  it("should open MAD from the real Add Address CTA with the eligible network ids", async () => {
+  it("should open MAD from the real Add Address CTA with the eligible selectable network ids", async () => {
     const { store, user } = renderContactsScreen();
 
     await user.click(screen.getByTestId("contacts-me-row"));
     await user.click(screen.getByTestId("contacts-detail-add-address"));
 
     expect(store.getState().modularDialog.isOpen).toBe(true);
-    expect(store.getState().modularDialog.dialogParams?.networkIds).toEqual(
+    expect(store.getState().modularDialog.dialogParams?.selectableNetworkIds).toEqual(
       resolveEligibleAddressCurrencyIds(["evm"]),
     );
     expect(store.getState().modularDialog.dialogParams?.presentation).toBe("embedded");

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/ModularDialogFlow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/ModularDialogFlow.tsx
@@ -99,7 +99,9 @@ export function ModularDialogFlow({
     refetch,
     loadingStatus,
     assetsToDisplay,
+    disabledAssetIds,
     networksToDisplay,
+    selectableNetworkIds,
     selectedAsset,
     selectedNetwork,
     handleAssetSelected,
@@ -132,6 +134,7 @@ export function ModularDialogFlow({
             errorInfo={errorInfo}
             refetch={refetch}
             assetsSorted={assetsSorted}
+            disabledAssetIds={disabledAssetIds}
           />
         );
       case MODULAR_DIALOG_STEP.NETWORK_SELECTION:
@@ -141,6 +144,7 @@ export function ModularDialogFlow({
             networksConfiguration={networkConfiguration}
             onNetworkSelected={handleNetworkSelected}
             selectedAssetId={selectedAsset?.id}
+            selectableNetworkIds={selectableNetworkIds}
           />
         );
       case MODULAR_DIALOG_STEP.ACCOUNT_SELECTION:

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/__tests__/selectNetworkFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/__tests__/selectNetworkFlow.test.tsx
@@ -44,6 +44,14 @@ const dialogParamsMixedCurrencies = {
   },
 };
 
+const dialogParamsWithSelectableNetworks = {
+  isOpen: true,
+  dialogParams: {
+    selectableNetworkIds: [ethereumCurrency.id],
+    onAssetSelected: mockOnAssetSelected,
+  },
+};
+
 const waitForSkeletonToBeRemoved = async () => {
   // Wait for the asset list to be rendered (skeletons are replaced with actual content)
   await waitFor(() => {
@@ -79,6 +87,42 @@ describe("ModularDialogFlowManager - Select Network Flow", () => {
     await user.click(bitcoinAsset);
 
     expect(mockOnAssetSelected).toHaveBeenCalledWith(bitcoinCurrency);
+  });
+
+  it("should render ineligible assets as disabled and prevent their selection", async () => {
+    const { user } = render(<ModularDialogFlowManager />, {
+      initialState: { modularDialog: dialogParamsWithSelectableNetworks },
+    });
+
+    await waitForSkeletonToBeRemoved();
+
+    const bitcoinAsset = screen.getByTestId("asset-item-ticker-btc");
+    expect(bitcoinAsset).toHaveAttribute("aria-disabled", "true");
+
+    await user.click(bitcoinAsset);
+
+    expect(mockOnAssetSelected).not.toHaveBeenCalled();
+  });
+
+  it("should allow eligible assets to reach the full network list", async () => {
+    const { user } = render(<ModularDialogFlowManager />, {
+      initialState: { modularDialog: dialogParamsWithSelectableNetworks },
+    });
+
+    await waitForSkeletonToBeRemoved();
+
+    const ethereumAsset = screen.getByTestId("asset-item-ticker-eth");
+    expect(ethereumAsset).not.toHaveAttribute("aria-disabled", "true");
+
+    await user.click(ethereumAsset);
+
+    const ethereumNetwork = screen.getByTestId("network-item-name-Ethereum");
+    const arbitrumNetwork = screen.getByTestId("network-item-name-Arbitrum");
+    expect(arbitrumNetwork).toHaveAttribute("aria-disabled", "true");
+
+    await user.click(ethereumNetwork);
+
+    expect(mockOnAssetSelected).toHaveBeenCalledWith(ethereumCurrency);
   });
 
   it("should navigate to NetworkSelection step after asset selection", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/__tests__/useAssetSelection.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/__tests__/useAssetSelection.test.ts
@@ -1,11 +1,19 @@
 import { renderHook } from "tests/testSetup";
 import { useAssetSelection } from "../useAssetSelection";
 import { CryptoOrTokenCurrency } from "@domain/entity-currency";
+import { AssetData } from "@ledgerhq/live-common/modularDrawer/utils/type";
+import { usdcToken } from "../../../__mocks__/useSelectAssetFlow.mock";
 
 // Mock useAcceptedCurrency to return a function that checks if currency is in supported list
 jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency", () => ({
   useAcceptedCurrency: jest.fn(() => {
-    const supported = new Set(["cardano", "bitcoin", "ethereum", "neo"]);
+    const supported = new Set([
+      "cardano",
+      "bitcoin",
+      "ethereum",
+      "neo",
+      "ethereum/erc20/usd__coin",
+    ]);
     return (currency: CryptoOrTokenCurrency) => supported.has(currency.id);
   }),
 }));
@@ -44,5 +52,45 @@ describe("useAssetSelection", () => {
     const mockSorted = [mockEthereum, mockBitcoin, mockCardano];
     const { result } = renderHook(() => useAssetSelection(mockSorted));
     expect(result.current.assetsToDisplay).toEqual([mockEthereum, mockBitcoin, mockCardano]);
+  });
+
+  it("should derive disabled assets from the selectable network IDs", () => {
+    const assetsSorted: AssetData[] = [
+      {
+        asset: {
+          id: mockEthereum.id,
+          ticker: "ETH",
+          name: mockEthereum.name,
+          assetsIds: { ethereum: "ethereum" },
+        },
+        networks: [mockEthereum, usdcToken],
+      },
+      {
+        asset: {
+          id: mockBitcoin.id,
+          ticker: "BTC",
+          name: mockBitcoin.name,
+          assetsIds: { bitcoin: "bitcoin" },
+        },
+        networks: [mockBitcoin],
+      },
+    ];
+
+    const { result: unrestricted } = renderHook(() =>
+      useAssetSelection([mockEthereum, mockBitcoin], assetsSorted),
+    );
+    expect(unrestricted.current.disabledAssetIds).toEqual(new Set());
+
+    const { result: evmOnly } = renderHook(() =>
+      useAssetSelection([mockEthereum, mockBitcoin], assetsSorted, [mockEthereum.id]),
+    );
+    expect(evmOnly.current.disabledAssetIds).toEqual(new Set([mockBitcoin.id]));
+
+    const { result: noneSelectable } = renderHook(() =>
+      useAssetSelection([mockEthereum, mockBitcoin], assetsSorted, []),
+    );
+    expect(noneSelectable.current.disabledAssetIds).toEqual(
+      new Set([mockEthereum.id, mockBitcoin.id]),
+    );
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/__tests__/useModularDialogFlowState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/__tests__/useModularDialogFlowState.test.tsx
@@ -1,6 +1,15 @@
 import { act, renderHook } from "tests/testSetup";
-import { bitcoinCurrency, ethereumCurrency } from "../../../__mocks__/useSelectAssetFlow.mock";
+import {
+  arbitrumCurrency,
+  bitcoinCurrency,
+  ethereumCurrency,
+} from "../../../__mocks__/useSelectAssetFlow.mock";
 import { useModularDialogFlowState } from "../useModularDialogFlowState";
+import { AssetData } from "@ledgerhq/live-common/modularDrawer/utils/type";
+
+jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency", () => ({
+  useAcceptedCurrency: () => () => true,
+}));
 
 const mockGoToStep = jest.fn();
 const mockSetNetworksToDisplay = jest.fn();
@@ -12,6 +21,30 @@ const defaultProps = {
   setNetworksToDisplay: mockSetNetworksToDisplay,
   goToStep: mockGoToStep,
 };
+
+const assetsWithNetworks: AssetData[] = [
+  {
+    asset: {
+      id: ethereumCurrency.id,
+      ticker: ethereumCurrency.ticker,
+      name: ethereumCurrency.name,
+      assetsIds: {
+        [ethereumCurrency.id]: ethereumCurrency.id,
+        [arbitrumCurrency.id]: arbitrumCurrency.id,
+      },
+    },
+    networks: [ethereumCurrency, arbitrumCurrency],
+  },
+  {
+    asset: {
+      id: bitcoinCurrency.id,
+      ticker: bitcoinCurrency.ticker,
+      name: bitcoinCurrency.name,
+      assetsIds: { [bitcoinCurrency.id]: bitcoinCurrency.id },
+    },
+    networks: [bitcoinCurrency],
+  },
+];
 
 describe("useModularDialogFlowState", () => {
   beforeEach(() => {
@@ -55,5 +88,40 @@ describe("useModularDialogFlowState", () => {
     });
     expect(mockSetNetworksToDisplay).toHaveBeenCalledWith(filtered);
     expect(mockGoToStep).toHaveBeenCalledWith("NETWORK_SELECTION");
+  });
+
+  it("should reject ineligible selections while allowing an eligible network", () => {
+    const { result } = renderHook(
+      () =>
+        useModularDialogFlowState({
+          ...defaultProps,
+          assets: assetsWithNetworks,
+        }),
+      {
+        initialState: {
+          modularDialog: {
+            isOpen: true,
+            dialogParams: {
+              onAssetSelected: mockOnAssetSelected,
+              selectableNetworkIds: [ethereumCurrency.id],
+            },
+          },
+        },
+      },
+    );
+
+    act(() => result.current.handleAssetSelected(bitcoinCurrency));
+    expect(mockOnAssetSelected).not.toHaveBeenCalled();
+    expect(mockGoToStep).not.toHaveBeenCalled();
+
+    act(() => result.current.handleAssetSelected(ethereumCurrency));
+    expect(mockSetNetworksToDisplay).toHaveBeenCalledWith([ethereumCurrency, arbitrumCurrency]);
+    expect(mockGoToStep).toHaveBeenCalledWith("NETWORK_SELECTION");
+
+    act(() => result.current.handleNetworkSelected(arbitrumCurrency));
+    expect(mockOnAssetSelected).not.toHaveBeenCalled();
+
+    act(() => result.current.handleNetworkSelected(ethereumCurrency));
+    expect(mockOnAssetSelected).toHaveBeenCalledWith(ethereumCurrency);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/__tests__/useOpenCurrencyFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/__tests__/useOpenCurrencyFlow.test.tsx
@@ -6,15 +6,16 @@ describe("useOpenCurrencyFlow", () => {
   const ethereum = getCryptoCurrencyById("ethereum");
   const bitcoin = getCryptoCurrencyById("bitcoin");
 
-  it("should open the terminal currency flow with the exact network ids", () => {
+  it("should open the terminal currency flow with the exact selectable network ids", () => {
     const { result, store } = renderHook(() => useOpenCurrencyFlow());
 
     void result.current.openCurrencyFlow([ethereum.id, bitcoin.id]);
 
     expect(store.getState().modularDialog.dialogParams).toMatchObject({
-      networkIds: [ethereum.id, bitcoin.id],
+      selectableNetworkIds: [ethereum.id, bitcoin.id],
       presentation: "dialog",
     });
+    expect(store.getState().modularDialog.dialogParams?.networkIds).toBeUndefined();
     expect(store.getState().modularDialog.dialogParams?.currencies).toBeUndefined();
     expect(store.getState().modularDialog.dialogParams?.onAccountSelected).toBeUndefined();
   });
@@ -27,7 +28,7 @@ describe("useOpenCurrencyFlow", () => {
     });
 
     expect(store.getState().modularDialog.dialogParams).toMatchObject({
-      networkIds: [ethereum.id],
+      selectableNetworkIds: [ethereum.id],
       presentation: "embedded",
     });
 
@@ -93,7 +94,9 @@ describe("useOpenCurrencyFlow", () => {
     });
 
     expect(store.getState().modularDialog.isOpen).toBe(true);
-    expect(store.getState().modularDialog.dialogParams?.networkIds).toEqual([ethereum.id]);
+    expect(store.getState().modularDialog.dialogParams?.selectableNetworkIds).toEqual([
+      ethereum.id,
+    ]);
 
     act(() => {
       store.getState().modularDialog.dialogParams?.onAssetSelected?.(ethereum);

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useAssetSelection.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useAssetSelection.ts
@@ -1,16 +1,43 @@
 import { useMemo } from "react";
 import { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import { useAcceptedCurrency } from "@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency";
+import type { AssetData } from "@ledgerhq/live-common/modularDrawer/utils/type";
 
-export function useAssetSelection(sortedCryptoCurrencies: CryptoOrTokenCurrency[]) {
+function getNetworkId(currency: CryptoOrTokenCurrency): string {
+  return currency.type === "CryptoCurrency" ? currency.id : currency.parentCurrencyId;
+}
+
+export function useAssetSelection(
+  sortedCryptoCurrencies: CryptoOrTokenCurrency[],
+  assetsSorted: AssetData[] | undefined = [],
+  selectableNetworkIds: readonly string[] | undefined = undefined,
+) {
   const isAcceptedCurrency = useAcceptedCurrency();
 
   const assetsToDisplay = useMemo(
     () => sortedCryptoCurrencies.filter(isAcceptedCurrency),
     [sortedCryptoCurrencies, isAcceptedCurrency],
   );
+  const disabledAssetIds = useMemo(() => {
+    if (selectableNetworkIds === undefined) {
+      return new Set<string>();
+    }
+
+    const selectableIds = new Set(selectableNetworkIds);
+    return new Set(
+      assetsSorted
+        ?.filter(
+          asset =>
+            !asset.networks.some(
+              network => isAcceptedCurrency(network) && selectableIds.has(getNetworkId(network)),
+            ),
+        )
+        .map(asset => asset.asset.id),
+    );
+  }, [assetsSorted, isAcceptedCurrency, selectableNetworkIds]);
 
   return {
     assetsToDisplay,
+    disabledAssetIds,
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useModularDialogFlowState.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useModularDialogFlowState.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { getAssetByCurrency } from "../utils/getAssetByCurrency";
 import { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import { ModularDialogStep } from "../types";
@@ -13,6 +13,7 @@ import {
   modularDialogOnAccountSelectedSelector,
   modularDialogOnAssetSelectedSelector,
   modularDialogSearchedSelector,
+  modularDialogSelectableNetworkIdsSelector,
 } from "~/renderer/reducers/modularDialog";
 import { AssetData } from "@ledgerhq/live-common/modularDrawer/utils/type";
 import { useAcceptedCurrency } from "@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency";
@@ -34,12 +35,27 @@ export function useModularDialogFlowState({
   const { trackModularDialogEvent } = useModularDialogAnalytics();
   const searchedValue = useSelector(modularDialogSearchedSelector);
   const currencyIds = useSelector(modularDialogCurrenciesSelector);
+  const selectableNetworkIds = useSelector(modularDialogSelectableNetworkIdsSelector);
   const onAssetSelected = useSelector(modularDialogOnAssetSelectedSelector);
   const onAccountSelected = useSelector(modularDialogOnAccountSelectedSelector);
 
   const [selectedAsset, setSelectedAsset] = useState<CryptoOrTokenCurrency>();
   const [selectedNetwork, setSelectedNetwork] = useState<CryptoOrTokenCurrency>();
   const [providers, setProviders] = useState<AssetData>();
+  const selectableNetworkIdSet = useMemo(
+    () => (selectableNetworkIds === undefined ? undefined : new Set(selectableNetworkIds)),
+    [selectableNetworkIds],
+  );
+
+  const isSelectableNetwork = useCallback(
+    (network: CryptoOrTokenCurrency) => {
+      if (selectableNetworkIdSet === undefined) return true;
+
+      const networkId = network.type === "CryptoCurrency" ? network.id : network.parentCurrencyId;
+      return selectableNetworkIdSet.has(networkId);
+    },
+    [selectableNetworkIdSet],
+  );
 
   const goBackToAssetSelection = useCallback(() => {
     setSelectedAsset(undefined);
@@ -78,6 +94,7 @@ export function useModularDialogFlowState({
   const handleNetworkSelected = useCallback(
     (network: CryptoOrTokenCurrency) => {
       if (!providers) return;
+      if (!isSelectableNetwork(network)) return;
       const correspondingCurrency =
         providers.networks.find(elem => belongsToSameNetwork(elem, network)) ?? network;
 
@@ -87,19 +104,22 @@ export function useModularDialogFlowState({
         onAssetSelected?.(correspondingCurrency);
       }
     },
-    [goToAccountSelection, onAccountSelected, onAssetSelected, providers],
+    [goToAccountSelection, isSelectableNetwork, onAccountSelected, onAssetSelected, providers],
   );
 
   const getNetworksFromProvider = useCallback(
     (provider: AssetData) => {
       return provider.networks.filter(elem => {
-        const isAllowedByFilter =
-          !currencyIds || currencyIds.length === 0 || currencyIds.includes(elem.id);
+        const isAllowedByCurrencyFilter =
+          selectableNetworkIds !== undefined ||
+          !currencyIds ||
+          currencyIds.length === 0 ||
+          currencyIds.includes(elem.id);
 
-        return isAcceptedCurrency(elem) && isAllowedByFilter;
+        return isAcceptedCurrency(elem) && isAllowedByCurrencyFilter;
       });
     },
-    [isAcceptedCurrency, currencyIds],
+    [currencyIds, isAcceptedCurrency, selectableNetworkIds],
   );
 
   const handleNoProvider = useCallback(
@@ -134,6 +154,15 @@ export function useModularDialogFlowState({
   const handleAssetSelected = useCallback(
     (currency: CryptoOrTokenCurrency) => {
       const currentProvider = getAssetByCurrency(currency, assets);
+      if (
+        currentProvider
+          ? !currentProvider.networks.some(
+              network => isAcceptedCurrency(network) && isSelectableNetwork(network),
+            )
+          : !isSelectableNetwork(currency)
+      ) {
+        return;
+      }
       setProviders(currentProvider);
 
       if (!currentProvider) {
@@ -155,6 +184,8 @@ export function useModularDialogFlowState({
       getNetworksFromProvider,
       handleMultipleNetworks,
       handleSingleNetwork,
+      isAcceptedCurrency,
+      isSelectableNetwork,
     ],
   );
 

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useModularDialogRemoteData.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useModularDialogRemoteData.ts
@@ -5,6 +5,8 @@ import { useModularDialogBackButton } from "./useModularDialogBackButton";
 import { useMemo, useState } from "react";
 import { useAssetSelection } from "./useAssetSelection";
 import { CryptoOrTokenCurrency } from "@domain/entity-currency";
+import { useSelector } from "LLD/hooks/redux";
+import { modularDialogSelectableNetworkIdsSelector } from "~/renderer/reducers/modularDialog";
 
 interface UseModularDialogRemoteDataProps {
   currentStep: ModularDialogStep;
@@ -27,7 +29,12 @@ export function useModularDialogRemoteData({
     assetsSorted,
   } = useModularDialogData();
 
-  const { assetsToDisplay } = useAssetSelection(sortedCryptoCurrencies);
+  const selectableNetworkIds = useSelector(modularDialogSelectableNetworkIdsSelector);
+  const { assetsToDisplay, disabledAssetIds } = useAssetSelection(
+    sortedCryptoCurrencies,
+    assetsSorted,
+    selectableNetworkIds,
+  );
 
   const {
     selectedAsset,
@@ -59,6 +66,8 @@ export function useModularDialogRemoteData({
     refetch,
     loadingStatus,
     assetsToDisplay,
+    disabledAssetIds,
+    selectableNetworkIds,
     networksToDisplay,
     selectedAsset,
     selectedNetwork,

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useOpenCurrencyFlow.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useOpenCurrencyFlow.ts
@@ -17,7 +17,7 @@ type PendingCurrencySelection = Readonly<{
 }>;
 
 export type OpenCurrencyFlow = (
-  networkIds: readonly CryptoCurrency["id"][],
+  selectableNetworkIds: readonly CryptoCurrency["id"][],
   options?: Readonly<{
     presentation?: ModularDialogPresentation;
   }>,
@@ -38,7 +38,7 @@ export function useOpenCurrencyFlow(): Readonly<{
   }, [dispatch]);
 
   const openCurrencyFlow = useCallback<OpenCurrencyFlow>(
-    (networkIds, options) => {
+    (selectableNetworkIds, options) => {
       cancelCurrencyFlow();
 
       return new Promise(resolve => {
@@ -65,7 +65,7 @@ export function useOpenCurrencyFlow(): Readonly<{
 
         dispatch(
           openDialog({
-            networkIds: [...networkIds],
+            selectableNetworkIds: [...selectableNetworkIds],
             presentation: options?.presentation,
             onAssetSelected,
             onClose: () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AssetSelector/components/AssetListItem/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AssetSelector/components/AssetListItem/index.tsx
@@ -58,14 +58,17 @@ export const AssetListItem = ({
   numberOfNetworks,
   assetId,
   shouldDisplayId,
+  disabled,
 }: AssetListItemProps) => {
   const handleClick = () => {
+    if (disabled) return;
     onClick({ name, ticker, id });
   };
 
   return (
     <ListItem
       className="-outline-offset-2"
+      disabled={disabled}
       onClick={handleClick}
       data-testid={`asset-item-ticker-${ticker.toLowerCase()}`}
     >

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AssetSelector/components/AssetSelectorContent/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AssetSelector/components/AssetSelectorContent/index.tsx
@@ -27,6 +27,7 @@ export type AssetSelectorContentProps = {
   onScrolledToTop?: () => void;
   loadNext?: () => void;
   assetsSorted?: AssetData[];
+  disabledAssetIds?: ReadonlySet<string>;
 };
 
 const CURRENT_PAGE = "Modular Asset Selection";
@@ -41,6 +42,7 @@ export const AssetSelectorContent = ({
   onScrolledToTop,
   loadNext,
   assetsSorted,
+  disabledAssetIds,
 }: AssetSelectorContentProps) => {
   const assetsMap = groupCurrenciesByAsset(assetsSorted || []);
 
@@ -61,11 +63,12 @@ export const AssetSelectorContent = ({
 
       return {
         ...asset,
+        disabled: disabledAssetIds?.has(asset.id),
         numberOfNetworks: assetWithNetworks?.networks?.length,
         assetId: assetWithNetworks?.asset.metaCurrencyId,
       };
     });
-  }, [assetsTransformed, assetsSorted]);
+  }, [assetsTransformed, assetsSorted, disabledAssetIds]);
 
   const isLoading = [LoadingStatus.Pending, LoadingStatus.Idle].includes(providersLoadingStatus);
   const shouldDisplayEmptyState =
@@ -74,6 +77,7 @@ export const AssetSelectorContent = ({
 
   const onClick = useCallback(
     (asset: AssetType) => {
+      if (asset.disabled) return;
       const selectedAsset = assetsToDisplay.find(({ id }) => id === asset.id);
       if (!selectedAsset) return;
 

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AssetSelector/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AssetSelector/index.tsx
@@ -22,6 +22,7 @@ export type AssetSelectorProps = {
   errorInfo?: ErrorInfo;
   refetch?: () => void;
   assetsSorted?: AssetData[];
+  disabledAssetIds?: ReadonlySet<string>;
 };
 
 const AssetSelector = ({
@@ -34,6 +35,7 @@ const AssetSelector = ({
   errorInfo,
   refetch,
   assetsSorted,
+  disabledAssetIds,
 }: Readonly<AssetSelectorProps>) => {
   const searchedValue = useSelector(modularDialogSearchedSelector);
 
@@ -74,6 +76,7 @@ const AssetSelector = ({
           onScrolledToTop={() => setShouldScrollToTop(false)}
           loadNext={loadNext}
           assetsSorted={assetsSorted}
+          disabledAssetIds={disabledAssetIds}
         />
       )}
     </>

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/components/NetworkListItem/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/components/NetworkListItem/index.tsx
@@ -20,6 +20,7 @@ export type NetworkListItemData = {
 
 type NetworkListItemProps = NetworkListItemData & {
   onClick: () => void;
+  disabled?: boolean;
 };
 
 export const NetworkListItem = ({
@@ -28,10 +29,13 @@ export const NetworkListItem = ({
   rightElement,
   apy,
   onClick,
+  disabled,
 }: NetworkListItemProps) => {
   return (
     <ListItem
-      onClick={onClick}
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
+      aria-disabled={disabled || undefined}
       data-testid={`network-item-name-${currency.name}`}
       className="-outline-offset-2"
     >

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/components/NetworkSelectorContent/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/components/NetworkSelectorContent/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import { useModularDialogAnalytics } from "../../../../analytics/useModularDialogAnalytics";
 import { MODULAR_DIALOG_PAGE_NAME } from "../../../../analytics/modularDialog.types";
@@ -17,6 +17,7 @@ type NetworkSelectorContentProps = {
   onNetworkSelected: (network: CryptoOrTokenCurrency) => void;
   networksConfig: EnhancedModularDrawerConfiguration["networks"];
   selectedAssetId?: string;
+  selectableNetworkIds?: readonly string[];
 };
 
 export const NetworkSelectorContent = ({
@@ -24,8 +25,13 @@ export const NetworkSelectorContent = ({
   onNetworkSelected,
   networksConfig,
   selectedAssetId,
+  selectableNetworkIds,
 }: NetworkSelectorContentProps) => {
   const { trackModularDialogEvent } = useModularDialogAnalytics();
+  const selectableNetworkIdSet = useMemo(
+    () => (selectableNetworkIds === undefined ? undefined : new Set(selectableNetworkIds)),
+    [selectableNetworkIds],
+  );
 
   const formattedNetworks = useNetworkConfiguration(networks ?? [], {
     useAccountData,
@@ -42,6 +48,7 @@ export const NetworkSelectorContent = ({
   }
 
   const onClick = (networkId: string) => {
+    if (selectableNetworkIdSet !== undefined && !selectableNetworkIdSet.has(networkId)) return;
     const network = formattedNetworks.find(network =>
       network.type === "CryptoCurrency"
         ? network.id === networkId
@@ -65,5 +72,11 @@ export const NetworkSelectorContent = ({
     onNetworkSelected(network);
   };
 
-  return <NetworkVirtualList networks={formattedNetworks} onClick={onClick} />;
+  return (
+    <NetworkVirtualList
+      networks={formattedNetworks}
+      onClick={onClick}
+      selectableNetworkIdSet={selectableNetworkIdSet}
+    />
+  );
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/components/NetworkVirtualList/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/components/NetworkVirtualList/index.tsx
@@ -13,9 +13,14 @@ type NetworkWithUI = CryptoOrTokenCurrency & {
 type NetworkVirtualListProps = {
   networks: NetworkWithUI[];
   onClick: (networkId: string) => void;
+  selectableNetworkIdSet?: ReadonlySet<string>;
 };
 
-export const NetworkVirtualList = ({ networks, onClick }: NetworkVirtualListProps) => {
+export const NetworkVirtualList = ({
+  networks,
+  onClick,
+  selectableNetworkIdSet,
+}: NetworkVirtualListProps) => {
   const renderNetworkItem = useCallback(
     (network: NetworkWithUI) => {
       const networkId = network.type === "CryptoCurrency" ? network.id : network.parentCurrencyId;
@@ -25,11 +30,12 @@ export const NetworkVirtualList = ({ networks, onClick }: NetworkVirtualListProp
           description={network.description}
           rightElement={network.rightElement}
           apy={network.apy}
+          disabled={selectableNetworkIdSet ? !selectableNetworkIdSet.has(networkId) : undefined}
           onClick={() => onClick(networkId)}
         />
       );
     },
-    [onClick],
+    [onClick, selectableNetworkIdSet],
   );
 
   return (

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/components/__tests__/SelectNetwork.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/components/__tests__/SelectNetwork.test.tsx
@@ -189,6 +189,30 @@ describe("SelectNetwork Integration Test", () => {
     });
   });
 
+  it("should render ineligible networks as disabled and prevent their selection", async () => {
+    const { user } = render(
+      <NetworkSelectorContent
+        {...defaultProps}
+        selectableNetworkIds={[ethereumCurrency.id]}
+        networks={[bscCurrency, ethereumCurrency]}
+      />,
+    );
+
+    const bscNetwork = screen.getByTestId("network-item-name-BNB Chain");
+    const ethereumNetwork = screen.getByTestId("network-item-name-Ethereum");
+
+    expect(bscNetwork).toHaveAttribute("aria-disabled", "true");
+    expect(ethereumNetwork).not.toHaveAttribute("aria-disabled");
+
+    await user.click(bscNetwork);
+
+    expect(mockOnNetworkSelected).not.toHaveBeenCalled();
+
+    await user.click(ethereumNetwork);
+
+    expect(mockOnNetworkSelected).toHaveBeenCalledWith(expect.objectContaining(ethereumCurrency));
+  });
+
   describe("Network Ordering", () => {
     it("should order networks by balance when balance element is configured", () => {
       const balanceOnlyConfig = {

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/index.tsx
@@ -10,6 +10,7 @@ export type NetworkSelectorProps = {
   networksConfiguration: EnhancedModularDrawerConfiguration["networks"];
   onNetworkSelected: (network: CryptoOrTokenCurrency) => void;
   selectedAssetId?: string;
+  selectableNetworkIds?: readonly string[];
 };
 
 export function NetworkSelector({
@@ -17,6 +18,7 @@ export function NetworkSelector({
   onNetworkSelected,
   networksConfiguration,
   selectedAssetId,
+  selectableNetworkIds,
 }: Readonly<NetworkSelectorProps>) {
   return (
     <>
@@ -30,6 +32,7 @@ export function NetworkSelector({
         onNetworkSelected={onNetworkSelected}
         networksConfig={networksConfiguration}
         selectedAssetId={selectedAssetId}
+        selectableNetworkIds={selectableNetworkIds}
       />
     </>
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/types.ts
@@ -9,6 +9,7 @@ export type AssetType = {
   numberOfNetworks?: number;
   assetId?: string;
   shouldDisplayId?: boolean;
+  disabled?: boolean;
 };
 
 export const NAVIGATION_DIRECTION = {

--- a/apps/ledger-live-desktop/src/renderer/reducers/modularDialog.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/modularDialog.ts
@@ -9,6 +9,7 @@ export type ModularDialogPresentation = "dialog" | "embedded";
 export interface ModularDialogParams {
   currencies?: string[];
   networkIds?: readonly string[];
+  selectableNetworkIds?: readonly string[];
   presentation?: ModularDialogPresentation;
   dialogConfiguration?: EnhancedModularDrawerConfiguration;
   useCase?: string;
@@ -58,6 +59,9 @@ const modularDialogSlice = createSlice({
       state.dialogParams = {
         ...action.payload,
         networkIds: action.payload.networkIds ? [...action.payload.networkIds] : undefined,
+        selectableNetworkIds: action.payload.selectableNetworkIds
+          ? [...action.payload.selectableNetworkIds]
+          : undefined,
         presentation: action.payload.presentation ?? "dialog",
       };
       state.isOpen = true;
@@ -87,6 +91,8 @@ export const modularDialogCurrenciesSelector = (state: State) =>
   state.modularDialog.dialogParams?.currencies;
 export const modularDialogNetworkIdsSelector = (state: State) =>
   state.modularDialog.dialogParams?.networkIds;
+export const modularDialogSelectableNetworkIdsSelector = (state: State) =>
+  state.modularDialog.dialogParams?.selectableNetworkIds;
 export const modularDialogUseCaseSelector = (state: State) =>
   state.modularDialog.dialogParams?.useCase;
 export const modularDialogUiUseCaseSelector = (state: State) =>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Contacts and Modular Dialog integration tests cover the enabled and disabled paths.
- [x] **Impact of the changes:**
      In Contacts Add Address on Desktop, verify that unavailable assets and networks remain visible but cannot be selected.

### 📝 Description

Contacts previously sent feature-flag-eligible network IDs as a MAD data filter, hiding all unavailable assets and networks.

This change loads the standard MAD catalog and keeps the Contacts allowlist solely as a selectability constraint. Ineligible rows use the Lumen disabled state and are guarded against selection; valid EVM assets and networks remain selectable.

<img width="520" height="675" alt="image" src="https://github.com/user-attachments/assets/3a16eb62-de1d-4d2d-b012-30263c064894" />
<img width="527" height="641" alt="image" src="https://github.com/user-attachments/assets/3e0cde29-424d-4ab6-ac8a-63ea60939542" />


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-35855

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)