### PR TITLE
[LWM] fix(contacts): disable ineligible assets (LIVE-35855)

### DIFF
--- a/.changeset/quiet-networks-glow.md
+++ b/.changeset/quiet-networks-glow.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Show unavailable Contacts asset and network options as disabled in the asset drawer.

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -322,6 +322,13 @@ function withContactsPageReadyState(
   });
 }
 
+const evmOnlyContactsFeatureFlag: Parameters<typeof withContactsPageReadyState>[0] = {
+  lwmContacts: {
+    enabled: true,
+    params: { newBadge: false, eligibleAddressFamilies: ["evm"] },
+  },
+};
+
 describe("Contacts integration", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -633,12 +640,7 @@ describe("Contacts integration", () => {
   it("should continue Add Address with the final currency selected in the shared drawer", async () => {
     const { user } = render(<ContactDetailViewModelTestApp />, {
       navigationInitialState: contactDetailNavigationState,
-      overrideInitialState: withContactsPageReadyState({
-        lwmContacts: {
-          enabled: true,
-          params: { newBadge: false, eligibleAddressFamilies: ["evm"] },
-        },
-      }),
+      overrideInitialState: withContactsPageReadyState(evmOnlyContactsFeatureFlag),
     });
 
     await user.press(screen.getByTestId("contacts-start-add-address"));
@@ -660,15 +662,10 @@ describe("Contacts integration", () => {
     const contact = mockContact({ id: "contact-benoit", name: "Benoit" });
     const { user } = render(<ContactDetailAddressEntryTestApp />, {
       navigationInitialState: savedContactDetailNavigationState,
-      overrideInitialState: withContactsPageReadyState(
-        {
-          lwmContacts: {
-            enabled: true,
-            params: { newBadge: false, eligibleAddressFamilies: ["evm"] },
-          },
-        },
-        state => ({ ...state, contacts: { contacts: [mockMeContact(), contact] } }),
-      ),
+      overrideInitialState: withContactsPageReadyState(evmOnlyContactsFeatureFlag, state => ({
+        ...state,
+        contacts: { contacts: [mockMeContact(), contact] },
+      })),
     });
 
     await user.press(screen.getByTestId("contacts-detail-add-address"));
@@ -725,12 +722,7 @@ describe("Contacts integration", () => {
   it("should keep the currency selector usable when searching for a network", async () => {
     const { user } = render(<ContactDetailAddressEntryTestApp />, {
       navigationInitialState: contactDetailNavigationState,
-      overrideInitialState: withContactsPageReadyState({
-        lwmContacts: {
-          enabled: true,
-          params: { newBadge: false, eligibleAddressFamilies: ["evm"] },
-        },
-      }),
+      overrideInitialState: withContactsPageReadyState(evmOnlyContactsFeatureFlag),
     });
 
     await user.press(screen.getByTestId("contacts-detail-add-address"));
@@ -745,15 +737,37 @@ describe("Contacts integration", () => {
     });
   });
 
+  it("should keep the standard catalog visible while disabling ineligible asset and network rows", async () => {
+    const { user } = render(<ContactDetailAddressEntryTestApp />, {
+      navigationInitialState: contactDetailNavigationState,
+      overrideInitialState: withContactsPageReadyState(evmOnlyContactsFeatureFlag),
+    });
+
+    await user.press(screen.getByTestId("contacts-detail-add-address"));
+
+    const bitcoinAsset = await screen.findByTestId("asset-item-BTC");
+    const tetherAsset = screen.getByTestId("asset-item-USDT");
+    expect(bitcoinAsset).toBeDisabled();
+    expect(tetherAsset).toBeEnabled();
+
+    await user.press(tetherAsset);
+
+    const solanaNetwork = await screen.findByTestId("network-item-Solana");
+    const ethereumNetwork = screen.getByTestId("network-item-Ethereum");
+    expect(solanaNetwork).toBeDisabled();
+    expect(ethereumNetwork).toBeEnabled();
+
+    await user.press(ethereumNetwork);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts-add-address-input")).toBeVisible();
+    });
+  });
+
   it("should return to currency selection without removing the contact detail route", async () => {
     const { user } = render(<ContactDetailAddressEntryTestApp />, {
       navigationInitialState: contactDetailNavigationState,
-      overrideInitialState: withContactsPageReadyState({
-        lwmContacts: {
-          enabled: true,
-          params: { newBadge: false, eligibleAddressFamilies: ["evm"] },
-        },
-      }),
+      overrideInitialState: withContactsPageReadyState(evmOnlyContactsFeatureFlag),
     });
 
     await user.press(screen.getByTestId("contacts-detail-add-address"));

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.test.tsx
@@ -21,7 +21,7 @@ function mockModularDrawerController(
   overrides: Partial<ReturnType<typeof useModularDrawerController>> = {},
 ) {
   mockedUseModularDrawerController.mockReturnValue({
-    areCurrenciesFiltered: true,
+    areCurrenciesFiltered: undefined,
     assetsConfiguration: undefined,
     closeDrawer,
     completionMode: "currency",
@@ -33,6 +33,7 @@ function mockModularDrawerController(
     openDrawer,
     presentation: "embedded",
     preselectedCurrencies: [mockEthCryptoCurrency.id, mockBtcCryptoCurrency.id],
+    selectableNetworkIds: undefined,
     uiUseCase: undefined,
     useCase: undefined,
     ...overrides,
@@ -58,13 +59,12 @@ describe("useContactsCurrencySelectionAdapter", () => {
     );
 
     expect(openDrawer).toHaveBeenCalledWith({
-      currencies: networkIds,
-      areCurrenciesFiltered: true,
       completionMode: "currency",
       enableAccountSelection: false,
       flow: "contacts_add_address",
       presentation: "embedded",
       source: ScreenName.MyWalletContactDetail,
+      selectableNetworkIds: networkIds,
       onCurrencySelected: expect.any(Function),
     });
   });
@@ -120,12 +120,13 @@ describe("useContactsCurrencySelectionAdapter", () => {
     );
 
     expect(result.current.flowProps).toMatchObject({
-      areCurrenciesFiltered: true,
+      areCurrenciesFiltered: undefined,
       currencies: [mockEthCryptoCurrency.id, mockBtcCryptoCurrency.id],
       isOpen: true,
       onAccountSelected: handleAccountSelected,
       onClose: closeDrawer,
       onCurrencySelected: handleCurrencySelected,
+      selectableNetworkIds: undefined,
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
@@ -51,6 +51,7 @@ export function useContactsCurrencySelectionAdapter({
     networksConfiguration,
     openDrawer,
     preselectedCurrencies,
+    selectableNetworkIds,
     uiUseCase,
     useCase,
   } = useModularDrawerController();
@@ -91,13 +92,12 @@ export function useContactsCurrencySelectionAdapter({
 
     selectionStartedRef.current = true;
     openDrawer({
-      currencies: [...networkIds],
-      areCurrenciesFiltered: true,
       completionMode: "currency",
       enableAccountSelection: false,
       flow: FLOW,
       presentation: "embedded",
       source: ScreenName.MyWalletContactDetail,
+      selectableNetworkIds: [...networkIds],
       onCurrencySelected: completeSelection,
     });
   }, [completeSelection, isOpen, networkIds, openDrawer]);
@@ -114,6 +114,7 @@ export function useContactsCurrencySelectionAdapter({
       onCurrencySelected: handleCurrencySelected,
       uiUseCase,
       useCase,
+      selectableNetworkIds,
     }),
     [
       areCurrenciesFiltered,
@@ -124,6 +125,7 @@ export function useContactsCurrencySelectionAdapter({
       isModularDrawerOpen,
       networksConfiguration,
       preselectedCurrencies,
+      selectableNetworkIds,
       uiUseCase,
       useCase,
     ],

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawerFlow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawerFlow.tsx
@@ -53,6 +53,8 @@ export type ModularDrawerFlowProps = Readonly<{
   uiUseCase?: string;
   /** Whether the currencies are filtered */
   areCurrenciesFiltered?: boolean;
+  /** Network IDs that remain selectable while all MAD rows stay visible. */
+  selectableNetworkIds?: readonly string[];
 
   /** Renders the Modular Drawer flow inside a presentation shell */
   children: (props: ModularDrawerFlowRenderProps) => React.ReactNode;
@@ -69,6 +71,7 @@ export function ModularDrawerFlow({
   useCase,
   uiUseCase,
   areCurrenciesFiltered,
+  selectableNetworkIds,
   children,
 }: ModularDrawerFlowProps): React.JSX.Element {
   const {
@@ -110,6 +113,7 @@ export function ModularDrawerFlow({
     hasSearchedValue: searchValue.length > 0,
     onAccountSelected,
     onCurrencySelected,
+    selectableNetworkIds,
   });
 
   const content = (
@@ -125,11 +129,13 @@ export function ModularDrawerFlow({
         loadNext,
         assetsSorted,
         uiUseCase,
+        selectableNetworkIds,
       }}
       networksViewModel={{
         onNetworkSelected: handleNetwork,
         availableNetworks,
         networksConfiguration: networkConfigurationSanitized,
+        selectableNetworkIds,
       }}
       accountsViewModel={{
         onAddNewAccount,

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useModularDrawerController.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useModularDrawerController.test.ts
@@ -132,13 +132,18 @@ describe("useModularDrawerController", () => {
           presentation: "embedded",
           enableAccountSelection: true,
           onCurrencySelected: jest.fn(),
+          selectableNetworkIds: [mockEthCryptoCurrency.id],
         });
       });
 
       expect(store.getState().modularDrawer.presentation).toBe("embedded");
       expect(store.getState().modularDrawer.enableAccountSelection).toBe(false);
       expect(store.getState().modularDrawer.step).toBe(ModularDrawerStep.Asset);
+      expect(store.getState().modularDrawer.selectableNetworkIds).toEqual([
+        mockEthCryptoCurrency.id,
+      ]);
       expect(result.current.presentation).toBe("embedded");
+      expect(result.current.selectableNetworkIds).toEqual([mockEthCryptoCurrency.id]);
     });
 
     it("should restore drawer presentation when embedded selection is replaced", () => {
@@ -178,6 +183,7 @@ describe("useModularDrawerController", () => {
         callbackId: undefined,
         completionMode: undefined,
         presentation: "drawer",
+        selectableNetworkIds: undefined,
         step: "Asset",
       });
     });

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useModularDrawerState.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useModularDrawerState.test.ts
@@ -7,6 +7,7 @@ import {
   mockArbitrumCryptoCurrency,
   mockBaseCryptoCurrency,
   mockCurrencyIds,
+  usdcToken,
 } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
 import { NavigationProp } from "@react-navigation/native";
 import { AssetData } from "@ledgerhq/live-common/modularDrawer/utils/type";
@@ -55,6 +56,14 @@ const mockNavigate = jest.fn();
 const mockNavigation: Partial<NavigationProp<Record<string, never>>> = {
   navigate: mockNavigate,
 };
+
+const withCurrencyCompletionMode = (state: State): State => ({
+  ...state,
+  modularDrawer: {
+    ...state.modularDrawer,
+    completionMode: "currency",
+  },
+});
 
 jest.mock("@react-navigation/native", () => ({
   useNavigation: () => mockNavigation,
@@ -239,13 +248,7 @@ describe("useModularDrawerState", () => {
           onCurrencySelected,
         }),
       {
-        overrideInitialState: (state: State) => ({
-          ...state,
-          modularDrawer: {
-            ...state.modularDrawer,
-            completionMode: "currency",
-          },
-        }),
+        overrideInitialState: withCurrencyCompletionMode,
       },
     );
 
@@ -267,13 +270,7 @@ describe("useModularDrawerState", () => {
           onCurrencySelected,
         }),
       {
-        overrideInitialState: (state: State) => ({
-          ...state,
-          modularDrawer: {
-            ...state.modularDrawer,
-            completionMode: "currency",
-          },
-        }),
+        overrideInitialState: withCurrencyCompletionMode,
       },
     );
 
@@ -282,6 +279,81 @@ describe("useModularDrawerState", () => {
 
     expect(onCurrencySelected).toHaveBeenCalledWith(mockArbitrumCryptoCurrency);
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("should not select assets or networks outside the selectable network IDs", () => {
+    const onCurrencySelected = jest.fn();
+    const { result } = renderHook(
+      () =>
+        useModularDrawerState({
+          currencyIds: [],
+          assetsSorted,
+          onAccountSelected: mockOnAccountSelected,
+          onCurrencySelected,
+          selectableNetworkIds: [mockEthCryptoCurrency.id],
+        }),
+      {
+        overrideInitialState: withCurrencyCompletionMode,
+      },
+    );
+
+    act(() => result.current.handleAsset(mockBtcCryptoCurrency));
+    expect(onCurrencySelected).not.toHaveBeenCalled();
+
+    act(() => result.current.handleAsset(mockEthCryptoCurrency));
+    act(() => result.current.handleNetwork(mockArbitrumCryptoCurrency));
+
+    expect(onCurrencySelected).not.toHaveBeenCalled();
+  });
+
+  it("should allow a token when its parent network is selectable", () => {
+    const onCurrencySelected = jest.fn();
+    const tokenAsset: AssetData[] = [
+      {
+        ...assetsSorted[0],
+        networks: [mockEthCryptoCurrency, usdcToken],
+      },
+    ];
+    const { result } = renderHook(
+      () =>
+        useModularDrawerState({
+          currencyIds: [],
+          assetsSorted: tokenAsset,
+          onAccountSelected: mockOnAccountSelected,
+          onCurrencySelected,
+          selectableNetworkIds: [mockEthCryptoCurrency.id],
+        }),
+      {
+        overrideInitialState: withCurrencyCompletionMode,
+      },
+    );
+
+    act(() => result.current.handleAsset(mockEthCryptoCurrency));
+    act(() => result.current.handleNetwork(usdcToken));
+
+    expect(onCurrencySelected).toHaveBeenCalledWith(mockEthCryptoCurrency);
+  });
+
+  it("should reject every asset when selectable network IDs are empty", () => {
+    const onCurrencySelected = jest.fn();
+    const { result } = renderHook(
+      () =>
+        useModularDrawerState({
+          currencyIds: [],
+          assetsSorted,
+          onAccountSelected: mockOnAccountSelected,
+          onCurrencySelected,
+          selectableNetworkIds: [],
+        }),
+      {
+        overrideInitialState: withCurrencyCompletionMode,
+      },
+    );
+
+    act(() => result.current.handleAsset(mockEthCryptoCurrency));
+
+    expect(result.current.availableNetworks).toEqual([]);
+    expect(onCurrencySelected).not.toHaveBeenCalled();
   });
 
   it("should handle multiple currencies", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
@@ -38,6 +38,7 @@ export const useModularDrawerController = () => {
     useCase,
     uiUseCase,
     areCurrenciesFiltered,
+    selectableNetworkIds,
   } = useSelector(
     (state: State) => ({
       isOpen: state.modularDrawer.isOpen,
@@ -51,6 +52,7 @@ export const useModularDrawerController = () => {
       useCase: state.modularDrawer.useCase,
       uiUseCase: state.modularDrawer.uiUseCase,
       areCurrenciesFiltered: state.modularDrawer.areCurrenciesFiltered,
+      selectableNetworkIds: state.modularDrawer.selectableNetworkIds,
     }),
     shallowEqual,
   );
@@ -144,6 +146,7 @@ export const useModularDrawerController = () => {
     useCase,
     uiUseCase,
     areCurrenciesFiltered,
+    selectableNetworkIds,
     openDrawer,
     closeDrawer,
     handleAccountSelected,

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerState.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerState.ts
@@ -24,6 +24,7 @@ type ModularDrawerStateProps = {
   onAccountSelected: ModularDrawerProps["onAccountSelected"];
   onCurrencySelected?: NonNullable<ModularDrawerProps["onCurrencySelected"]>;
   hasSearchedValue?: boolean;
+  selectableNetworkIds?: readonly string[];
 };
 
 export function useModularDrawerState({
@@ -34,6 +35,7 @@ export function useModularDrawerState({
   hasSearchedValue,
   onAccountSelected,
   onCurrencySelected,
+  selectableNetworkIds,
 }: ModularDrawerStateProps) {
   const isAcceptedCurrency = useAcceptedCurrency();
   const enableAccountSelection = useSelector(modularDrawerEnableAccountSelectionSelector);
@@ -44,6 +46,23 @@ export function useModularDrawerState({
   const [network, setNetwork] = useState<CryptoOrTokenCurrency>();
   const [availableNetworks, setAvailableNetworks] = useState<CryptoOrTokenCurrency[]>([]);
   const autoSelectRef = useRef(false);
+  const selectableNetworkIdSet = useMemo(
+    () => (selectableNetworkIds === undefined ? undefined : new Set(selectableNetworkIds)),
+    [selectableNetworkIds],
+  );
+
+  const isSelectableNetwork = useCallback(
+    (selectedNetwork: CryptoOrTokenCurrency) => {
+      if (selectableNetworkIdSet === undefined) return true;
+
+      const networkId =
+        selectedNetwork.type === "CryptoCurrency"
+          ? selectedNetwork.id
+          : selectedNetwork.parentCurrencyId;
+      return selectableNetworkIdSet.has(networkId);
+    },
+    [selectableNetworkIdSet],
+  );
 
   const singleCurrency = useMemo(
     () => (assetsSorted?.length === 1 ? assetsSorted[0].networks[0] : undefined),
@@ -86,12 +105,15 @@ export function useModularDrawerState({
   // Handle asset selection and determine next step
   const handleAsset = useCallback(
     (selected: CryptoOrTokenCurrency) => {
-      setAsset(selected);
       const availableNetworksList = getNetworksForAsset(
         assetsSorted,
         selected.id,
         isAcceptedCurrency,
       );
+      if (selectableNetworkIds !== undefined && !availableNetworksList.some(isSelectableNetwork)) {
+        return;
+      }
+      setAsset(selected);
 
       if (availableNetworksList.length > 1) {
         setAvailableNetworks(availableNetworksList);
@@ -123,6 +145,8 @@ export function useModularDrawerState({
       onCurrencySelected,
       proceedToNextStep,
       isAcceptedCurrency,
+      isSelectableNetwork,
+      selectableNetworkIds,
     ],
   );
 
@@ -130,6 +154,7 @@ export function useModularDrawerState({
   const handleNetwork = useCallback(
     (selectedNetwork: CryptoOrTokenCurrency) => {
       if (!asset) return;
+      if (!isSelectableNetwork(selectedNetwork)) return;
       const correspondingCurrency = resolveCurrency(
         assetsSorted,
         isAcceptedCurrency,
@@ -140,7 +165,7 @@ export function useModularDrawerState({
         proceedToNextStep(correspondingCurrency, selectedNetwork);
       }
     },
-    [asset, assetsSorted, proceedToNextStep, isAcceptedCurrency],
+    [asset, assetsSorted, proceedToNextStep, isAcceptedCurrency, isSelectableNetwork],
   );
 
   const { handleBackButton, handleCloseButton } = useDrawerLifecycle({

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AssetSelection/components/AssetRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AssetSelection/components/AssetRow.tsx
@@ -17,6 +17,7 @@ export type AssetRowData = {
   ticker: string;
   leftElement?: React.ReactNode;
   rightElement?: React.ReactNode;
+  disabled?: boolean;
 };
 
 type Props = AssetRowData & {
@@ -25,9 +26,18 @@ type Props = AssetRowData & {
 
 const NEGATIVE_MARGIN_OFFSET: LumenViewStyle = { marginHorizontal: "-s8" };
 
-export const AssetRow = ({ id, name, ticker, leftElement, rightElement, onClick }: Props) => (
+export const AssetRow = ({
+  id,
+  name,
+  ticker,
+  leftElement,
+  rightElement,
+  onClick,
+  disabled,
+}: Props) => (
   <ListItem
-    onPress={() => onClick({ id, name, ticker })}
+    disabled={disabled}
+    onPress={() => onClick({ id, name, ticker, disabled })}
     testID={`asset-item-${ticker}`}
     lx={NEGATIVE_MARGIN_OFFSET}
   >

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AssetSelection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AssetSelection/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from "react";
+import React, { useCallback, useMemo, useRef } from "react";
 import { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import { AssetRow, AssetRowData } from "./components/AssetRow";
 import { MarketPriceIndicator } from "../../components/MarketPriceIndicator";
@@ -48,6 +48,7 @@ export type AssetSelectionStepProps = {
   loadNext?: () => void;
   assetsSorted?: AssetData[];
   uiUseCase?: string;
+  selectableNetworkIds?: readonly string[];
 };
 
 const SAFE_MARGIN_BOTTOM = 48;
@@ -63,6 +64,7 @@ const AssetSelection = ({
   loadNext,
   assetsSorted,
   uiUseCase,
+  selectableNetworkIds,
 }: Readonly<AssetSelectionStepProps>) => {
   const { t } = useTranslation();
   const { isInternetReachable } = useNetInfo();
@@ -92,6 +94,10 @@ const AssetSelection = ({
   };
 
   const assetsMap = groupCurrenciesByAsset(assetsSorted || []);
+  const selectableNetworkIdSet = useMemo(
+    () => (selectableNetworkIds === undefined ? undefined : new Set(selectableNetworkIds)),
+    [selectableNetworkIds],
+  );
 
   const formattedAssets = useAssetConfiguration(availableAssets ?? [], {
     ApyIndicator,
@@ -101,10 +107,20 @@ const AssetSelection = ({
     balanceItem,
     assetsMap,
     ...assetsConfiguration,
+  }).map(asset => {
+    if (selectableNetworkIdSet === undefined) return asset;
+
+    const isSelectable = assetsMap.get(asset.id)?.currencies.some(network => {
+      const networkId = network.type === "CryptoCurrency" ? network.id : network.parentCurrencyId;
+      return selectableNetworkIdSet.has(networkId);
+    });
+
+    return { ...asset, disabled: !isSelectable };
   });
 
   const handleAssetClick = useCallback(
     (asset: AssetRowData) => {
+      if (asset.disabled) return;
       const originalAsset = availableAssets.find(a => a.id === asset.id);
       if (originalAsset) {
         collapse();

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/NetworkSelection/components/NetworkRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/NetworkSelection/components/NetworkRow.tsx
@@ -16,6 +16,7 @@ export type NetworkRowData = {
   ticker: string;
   leftElement?: React.ReactNode;
   rightElement?: React.ReactNode;
+  disabled?: boolean;
 };
 
 type Props = NetworkRowData & {
@@ -24,8 +25,21 @@ type Props = NetworkRowData & {
 
 const NEGATIVE_MARGIN_OFFSET: LumenViewStyle = { marginHorizontal: "-s8" };
 
-export const NetworkRow = ({ id, name, ticker, leftElement, rightElement, onClick }: Props) => (
-  <ListItem onPress={onClick} testID={`network-item-${name}`} lx={NEGATIVE_MARGIN_OFFSET}>
+export const NetworkRow = ({
+  id,
+  name,
+  ticker,
+  leftElement,
+  rightElement,
+  onClick,
+  disabled,
+}: Props) => (
+  <ListItem
+    disabled={disabled}
+    onPress={onClick}
+    testID={`network-item-${name}`}
+    lx={NEGATIVE_MARGIN_OFFSET}
+  >
     <ListItemLeading>
       <Icon ledgerId={id} ticker={ticker} size={48} shape="square" />
       <ListItemContent style={{ flex: 1, minWidth: 0 }}>

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/NetworkSelection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/NetworkSelection/index.tsx
@@ -1,5 +1,6 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import { CryptoOrTokenCurrency } from "@domain/entity-currency";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { NetworkRow, NetworkRowData } from "./components/NetworkRow";
 import { EnhancedModularDrawerConfiguration } from "@ledgerhq/live-common/wallet-api/ModularDrawer/types";
 import {
@@ -25,6 +26,7 @@ export type NetworkSelectionStepProps = {
   availableNetworks: CryptoOrTokenCurrency[];
   onNetworkSelected: (asset: CryptoOrTokenCurrency) => void;
   networksConfiguration?: EnhancedModularDrawerConfiguration["networks"];
+  selectableNetworkIds?: readonly string[];
 };
 
 const SAFE_MARGIN_BOTTOM = 48;
@@ -33,14 +35,29 @@ const NetworkSelection = ({
   availableNetworks,
   onNetworkSelected,
   networksConfiguration,
+  selectableNetworkIds,
 }: Readonly<NetworkSelectionStepProps>) => {
   const { t } = useTranslation();
   const flow = useSelector(modularDrawerFlowSelector);
   const source = useSelector(modularDrawerSourceSelector);
   const { trackModularDrawerEvent } = useModularDrawerAnalytics();
+  const selectableNetworkIdSet = useMemo(
+    () => (selectableNetworkIds === undefined ? undefined : new Set(selectableNetworkIds)),
+    [selectableNetworkIds],
+  );
+
+  const isSelectableNetwork = useCallback(
+    (networkId: string) => {
+      if (selectableNetworkIdSet === undefined) return true;
+
+      return selectableNetworkIdSet.has(networkId);
+    },
+    [selectableNetworkIdSet],
+  );
 
   const handleNetworkClick = useCallback(
     (networkId: string) => {
+      if (!isSelectableNetwork(networkId)) return;
       const originalNetwork = availableNetworks.find(n =>
         n.type === "CryptoCurrency" ? n.id === networkId : n.parentCurrencyId === networkId,
       );
@@ -50,7 +67,7 @@ const NetworkSelection = ({
           {
             flow,
             source,
-            network: originalNetwork.name,
+            network: getCryptoCurrencyById(networkId).name,
             page: MODULAR_DRAWER_PAGE_NAME.MODULAR_NETWORK_SELECTION,
           },
           {
@@ -69,6 +86,7 @@ const NetworkSelection = ({
       source,
       networksConfiguration,
       onNetworkSelected,
+      isSelectableNetwork,
     ],
   );
 
@@ -103,7 +121,11 @@ const NetworkSelection = ({
         data={formattedNetworks}
         keyExtractor={keyExtractor}
         renderItem={({ item }: { item: NetworkRowData }) => (
-          <NetworkRow {...item} onClick={() => handleNetworkClick(item.id)} />
+          <NetworkRow
+            {...item}
+            disabled={isSelectableNetwork(item.id) ? undefined : true}
+            onClick={() => handleNetworkClick(item.id)}
+          />
         )}
         contentContainerStyle={{
           paddingBottom: SAFE_MARGIN_BOTTOM,

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/types.ts
@@ -24,6 +24,7 @@ export type DrawerBaseParams = {
   flow?: string;
   source?: string;
   areCurrenciesFiltered?: boolean;
+  selectableNetworkIds?: string[];
   useCase?: string;
   uiUseCase?: string;
 };

--- a/apps/ledger-live-mobile/src/reducers/modularDrawer.ts
+++ b/apps/ledger-live-mobile/src/reducers/modularDrawer.ts
@@ -24,6 +24,7 @@ export interface ModularDrawerState {
   useCase?: string;
   uiUseCase?: string;
   areCurrenciesFiltered?: boolean;
+  selectableNetworkIds?: string[];
   searchValue: string;
   step: ModularDrawerStep;
 }
@@ -48,6 +49,7 @@ export const INITIAL_STATE: ModularDrawerState = {
   useCase: undefined,
   uiUseCase: undefined,
   areCurrenciesFiltered: undefined,
+  selectableNetworkIds: undefined,
   searchValue: "",
   step: ModularDrawerStep.Asset,
 };
@@ -88,6 +90,7 @@ const modularDrawerSlice = createSlice({
         useCase,
         uiUseCase,
         areCurrenciesFiltered,
+        selectableNetworkIds,
         step,
       } = action.payload;
       const isEmbeddedCurrency = completionMode === "currency" && presentation === "embedded";
@@ -124,6 +127,9 @@ const modularDrawerSlice = createSlice({
       if (areCurrenciesFiltered !== undefined) {
         state.areCurrenciesFiltered = areCurrenciesFiltered;
       }
+      if (selectableNetworkIds !== undefined) {
+        state.selectableNetworkIds = selectableNetworkIds;
+      }
       if (isEmbeddedCurrency) {
         state.step = ModularDrawerStep.Asset;
       } else if (step !== undefined) {
@@ -144,6 +150,7 @@ const modularDrawerSlice = createSlice({
       state.useCase = undefined;
       state.uiUseCase = undefined;
       state.areCurrenciesFiltered = undefined;
+      state.selectableNetworkIds = undefined;
       state.searchValue = "";
       state.step = ModularDrawerStep.Asset;
     },


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Contacts and Modular Drawer tests cover enabled and disabled selection paths.
- [x] **Impact of the changes:**
      In Contacts Add Address on Mobile, unavailable assets and networks remain visible but cannot be selected.

### 📝 Description

Contacts previously sent feature-flag-eligible network IDs as a Modular Asset Drawer data filter, hiding unavailable assets and networks.

This change loads the standard catalog and keeps the Contacts allowlist solely as a selectability constraint. Ineligible rows use the Lumen disabled state and are guarded against selection; valid EVM assets and networks remain selectable.

<img width="350" height="750" alt="Simulator Screenshot - iOS Simulator - 2026-08-18 at 08 49 58" src="https://github.com/user-attachments/assets/79c15d84-073f-4fa9-9789-435d6ece49bf" />
<img width="350" height="750" alt="Simulator Screenshot - iOS Simulator - 2026-08-18 at 08 49 31" src="https://github.com/user-attachments/assets/aceccdfa-e7c3-4d03-9e01-fe9bd25850cf" />


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-35855

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)