### PR TITLE
chore(codeowners): assign platform device-intent to live-devices

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -386,6 +386,7 @@ libs/ledger-live-common/src/device/                                @ledgerhq/liv
 libs/ledger-live-common/src/deviceSDK/                             @ledgerhq/live-devices
 libs/device-core/                                                  @ledgerhq/live-devices
 libs/device-intent/                                                @ledgerhq/live-devices
+features/platform/device-intent/                                   @ledgerhq/live-devices
 libs/device-react/                                                 @ledgerhq/live-devices
 libs/live-dmk/                                                     @ledgerhq/live-devices
 libs/speculos-transport/                                           @ledgerhq/live-devices @ledgerhq/qaa


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

The upcoming device-intent migration moves the package from `libs/device-intent/` to `features/platform/device-intent/`. GitHub uses CODEOWNERS from the **base** branch when requesting reviewers, so that ownership must land on `develop` first.

This PR adds `features/platform/device-intent/` to `@ledgerhq/live-devices` and keeps the existing `libs/device-intent/` rule so current ownership is unchanged until the migration lands.

### 🔗 Context

- **JIRA / GitHub issue**: N/A — prerequisite for the device-intent platform migration PR
- **ADR** (if any): N/A