### PR TITLE
[LWDM] fix(live-apps): retry failed catalog fetch, never cache empty (QAA-1498)

### DIFF
--- a/.changeset/witty-catalog-retry.md
+++ b/.changeset/witty-catalog-retry.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Stop treating a failed live-app catalog fetch as an empty catalog. The fetch used to swallow network errors and resolve to `[]`, which `RemoteLiveAppProvider` then stored as a successful (but empty) registry with `error: null` and did not refetch for 30 minutes — so a transient failure at startup left every live app unresolvable ("App not found") for the whole session. Errors now propagate, a failed refresh keeps the previously loaded catalog, and a failure is retried with backoff instead of waiting for the next scheduled refresh

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/index.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/index.tsx
@@ -25,6 +25,8 @@ import { useDeeplinkCustomHandlers } from "../WebPlatformPlayer/CustomHandlers";
 import { WalletAPICustomHandlers } from "@ledgerhq/live-common/wallet-api/types";
 import { BackConfig, BackToInternalDomain } from "./BackToLwButton";
 import { handleBackToLwEntryPoint } from "./handleBackToLwEntryPoint";
+import Config from "react-native-config";
+import { ptxHandoffStore } from "~/e2e/ptxHandoffStore";
 
 export type { BackConfig } from "./BackToLwButton";
 
@@ -85,6 +87,10 @@ export const WebPTXPlayer = ({
           const manifestId = url.searchParams.get("goToManifest");
 
           if (manifestId && goToURL) {
+            // e2e asserts the handoff contract on this URL instead of driving into
+            // the partner's own page. See ptxHandoffStore.
+            if (Config.DETOX) ptxHandoffStore.set(url.href);
+
             const searchParams = url.searchParams;
             const flowName = searchParams.get("flowName") || "";
             const lastScreen = searchParams.get("lastScreen") || flowName;

--- a/apps/ledger-live-mobile/src/e2e/bridge/client.ts
+++ b/apps/ledger-live-mobile/src/e2e/bridge/client.ts
@@ -23,6 +23,7 @@ import {
 import { LaunchArguments } from "react-native-launch-arguments";
 import logReport from "~/log-report";
 import { webviewLogStore } from "~/e2e/webviewLogStore";
+import { ptxHandoffStore } from "~/e2e/ptxHandoffStore";
 import { MessageData, ServerData, mockDeviceEventSubject } from "./types";
 import { getAllEnvs, setEnv } from "@shared/env";
 import Config from "react-native-config";
@@ -155,6 +156,13 @@ async function onMessage(event: WebSocketMessageEvent) {
         postMessage({
           type: "appLogs",
           payload,
+        });
+        break;
+      }
+      case "getPtxHandoff": {
+        postMessage({
+          type: "ptxHandoff",
+          payload: ptxHandoffStore.take() ?? "",
         });
         break;
       }

--- a/apps/ledger-live-mobile/src/e2e/bridge/types.ts
+++ b/apps/ledger-live-mobile/src/e2e/bridge/types.ts
@@ -45,6 +45,10 @@ export type ServerData =
       type: "appEnvs";
       payload: string;
     }
+  | {
+      type: "ptxHandoff";
+      payload: string;
+    }
   | { type: "ACK"; id: string }
   | { type: "swapSetupDone" }
   | { type: "swapLiveAppReady" }
@@ -65,6 +69,7 @@ export type MessageData =
   | { type: "getLogs"; id: string }
   | { type: "getFlags"; id: string }
   | { type: "getEnvs"; id: string }
+  | { type: "getPtxHandoff"; id: string }
   | { type: "navigate"; id: string; payload: string }
   | { type: "importSettings"; id: string; payload: Partial<SettingsState> }
   | {

--- a/apps/ledger-live-mobile/src/e2e/ptxHandoffStore.ts
+++ b/apps/ledger-live-mobile/src/e2e/ptxHandoffStore.ts
@@ -1,0 +1,22 @@
+/**
+ * Records the PTX (Buy/Sell) handoff URL for e2e tests: the Ledger-owned webview URL
+ * carrying `goToManifest` + `goToURL` at the moment the user is sent off to a partner.
+ *
+ * E2E asserts the handoff contract (provider + query params) on this URL rather than
+ * driving into the partner's own page, which is a third-party production site and not
+ * something Ledger Live owns. Mirrors what e2e/desktop reads from `webviewUrlHistory`.
+ */
+let lastHandoffUrl: string | null = null;
+
+export const ptxHandoffStore = {
+  set(url: string) {
+    lastHandoffUrl = url;
+  },
+
+  /** Reads and clears, so a handoff can never be mistaken for a later flow's. */
+  take(): string | null {
+    const url = lastHandoffUrl;
+    lastHandoffUrl = null;
+    return url;
+  },
+};

--- a/e2e/mobile/bridge/server.ts
+++ b/e2e/mobile/bridge/server.ts
@@ -171,6 +171,11 @@ export async function getEnvs() {
   return fetchData({ type: "getEnvs", id: uniqueId() });
 }
 
+/** Last Buy/Sell handoff URL (`goToManifest` + `goToURL`) seen by the app, or "" if none yet. */
+export async function getPtxHandoff() {
+  return fetchData({ type: "getPtxHandoff", id: uniqueId() });
+}
+
 async function fetchData(message: MessageData, timeout = RESPONSE_TIMEOUT): Promise<string> {
   return new Promise<string>(resolve => {
     postMessage(message);
@@ -219,6 +224,14 @@ function onMessage(messageStr: string) {
       const pending = global.pendingCallbacks?.get("getLogs");
       if (pending) {
         global.pendingCallbacks.delete("getLogs");
+        pending.callback(msg.payload);
+      }
+      break;
+    }
+    case "ptxHandoff": {
+      const pending = global.pendingCallbacks?.get("getPtxHandoff");
+      if (pending) {
+        global.pendingCallbacks.delete("getPtxHandoff");
         pending.callback(msg.payload);
       }
       break;

--- a/e2e/mobile/bridge/server.ts
+++ b/e2e/mobile/bridge/server.ts
@@ -208,6 +208,14 @@ export async function removeKnownSpeculos(address: string) {
   postMessage({ type: "removeKnownSpeculos", id: uniqueId(), payload: address });
 }
 
+/** Resolve the `fetchData` promise waiting on `key`, if any. Each response type does this. */
+function resolvePending(key: string, payload: string) {
+  const pending = global.pendingCallbacks?.get(key);
+  if (!pending) return;
+  global.pendingCallbacks.delete(key);
+  pending.callback(payload);
+}
+
 function onMessage(messageStr: string) {
   const msg: ServerData = JSON.parse(messageStr);
   log(`Message received ${msg.type}`);
@@ -220,62 +228,27 @@ function onMessage(messageStr: string) {
     case "walletAPIResponse":
       webSocket.e2eBridgeServer.next(msg);
       break;
-    case "appLogs": {
-      const pending = global.pendingCallbacks?.get("getLogs");
-      if (pending) {
-        global.pendingCallbacks.delete("getLogs");
-        pending.callback(msg.payload);
-      }
+    case "appLogs":
+      resolvePending("getLogs", msg.payload);
       break;
-    }
-    case "ptxHandoff": {
-      const pending = global.pendingCallbacks?.get("getPtxHandoff");
-      if (pending) {
-        global.pendingCallbacks.delete("getPtxHandoff");
-        pending.callback(msg.payload);
-      }
+    case "ptxHandoff":
+      resolvePending("getPtxHandoff", msg.payload);
       break;
-    }
-    case "appFlags": {
-      const pending = global.pendingCallbacks?.get("getFlags");
-      if (pending) {
-        global.pendingCallbacks.delete("getFlags");
-        pending.callback(msg.payload);
-      }
+    case "appFlags":
+      resolvePending("getFlags", msg.payload);
       break;
-    }
-    case "appEnvs": {
-      const pending = global.pendingCallbacks?.get("getEnvs");
-      if (pending) {
-        global.pendingCallbacks.delete("getEnvs");
-        pending.callback(msg.payload);
-      }
+    case "appEnvs":
+      resolvePending("getEnvs", msg.payload);
       break;
-    }
-    case "swapSetupDone": {
-      const pending = global.pendingCallbacks?.get("swapSetup");
-      if (pending) {
-        global.pendingCallbacks.delete("swapSetup");
-        pending.callback("swapSetup done");
-      }
+    case "swapSetupDone":
+      resolvePending("swapSetup", "swapSetup done");
       break;
-    }
-    case "swapLiveAppReady": {
-      const pending = global.pendingCallbacks?.get("waitSwapReady");
-      if (pending) {
-        global.pendingCallbacks.delete("waitSwapReady");
-        pending.callback("Swap Live App is ready");
-      }
+    case "swapLiveAppReady":
+      resolvePending("waitSwapReady", "Swap Live App is ready");
       break;
-    }
-    case "earnLiveAppReady": {
-      const pending = global.pendingCallbacks?.get("waitEarnReady");
-      if (pending) {
-        global.pendingCallbacks.delete("waitEarnReady");
-        pending.callback("Earn Live App is ready");
-      }
+    case "earnLiveAppReady":
+      resolvePending("waitEarnReady", "Earn Live App is ready");
       break;
-    }
     case "appFile":
       try {
         const { fileName, fileContent }: { fileName: string; fileContent: string } = JSON.parse(

--- a/e2e/mobile/page/trade/buySell.page.ts
+++ b/e2e/mobile/page/trade/buySell.page.ts
@@ -244,10 +244,15 @@ export default class BuySellPage {
     await this.chooseAssetIfNotSelected(buySell.crypto);
     await this.tapSellPercentageButton("75%");
     await this.chooseCountryIfNotSelected(buySell.fiat);
+    // The flow sells a percentage of the balance, so the amount handed to the partner
+    // is whatever the UI resolved it to - not the caller's `buySell.amount`, which the
+    // sell flow never types. Read it back so the handoff is checked against the amount
+    // the user actually selected.
+    const selectedAmount = normalizeText(await getValueByWebTestId(this.amountInputSectionId()));
     await this.tapSeeQuotes();
     await this.selectPaymentMethod(paymentMethod);
     await this.selectProvider(provider.name);
     await this.tapBuySellWithCta(provider.uiName, buySell.operation);
-    await this.verifyProviderHandoff(provider, buySell);
+    await this.verifyProviderHandoff(provider, { ...buySell, amount: selectedAmount });
   }
 }

--- a/e2e/mobile/page/trade/buySell.page.ts
+++ b/e2e/mobile/page/trade/buySell.page.ts
@@ -3,9 +3,14 @@ import { AccountType, getParentAccountName } from "@ledgerhq/live-e2e-shared/enu
 import { BuySell, Fiat } from "@ledgerhq/live-e2e-shared/models/BuySell";
 import { BuySellProvider } from "@ledgerhq/live-e2e-shared/enum/Provider";
 import { pickRotatingProvider } from "@ledgerhq/live-e2e-shared/buySell";
+import {
+  extractGoToUrl,
+  getExpectedQueryParams,
+  urlMatchesProvider,
+} from "@ledgerhq/live-e2e-shared/buySellHandoff";
 import { openDeeplink, normalizeText } from "../../helpers/commonHelpers";
-import { checkForErrorElement, ERROR_MODAL_SELECTORS } from "../../helpers/errorHelpers";
-import { sanitizeError } from "@ledgerhq/live-e2e-shared/index";
+import { getPtxHandoff } from "../../bridge/server";
+import { retryUntilTimeout } from "../../utils/retry";
 
 export default class BuySellPage {
   appContainerCssSelector = "#app-container";
@@ -182,33 +187,38 @@ export default class BuySellPage {
     await tapWebElementByTestId(this.provider(provider));
   }
 
-  @Step("Verify provider page loaded with correct URL")
-  async verifyProviderPageLoadedWithCorrectUrl(provider: string) {
-    try {
-      const normalizedProvider = provider.toLowerCase().replace(/\s/g, "");
-      const currentUrl = await waitForCurrentWebviewUrlToContain(normalizedProvider);
-      jestExpect(currentUrl.toLowerCase()).toContain(normalizedProvider);
-    } catch (error) {
-      throw Object.assign(new Error(`Provider page verification failed: ${sanitizeError(error)}`), {
-        cause: error,
-      });
-    }
-  }
+  /**
+   * Asserts the handoff Ledger Live actually owns: the `goToURL` the app hands to the
+   * partner, and its query parameters. Deliberately does NOT wait on the partner's own
+   * page to load or render - that page is third-party and uncontrolled, and rendering it
+   * on the Android CI emulator's software renderer takes the emulator down mid-test.
+   * Mirrors e2e/desktop, which asserts the same handoff out of `webviewUrlHistory`.
+   */
+  @Step("Verify provider handoff URL and query parameters")
+  async verifyProviderHandoff(provider: BuySellProvider, buySell: BuySell) {
+    const rawHandoffUrl = await retryUntilTimeout(async () => {
+      const url = await getPtxHandoff();
+      if (!url) throw new Error("No Buy/Sell handoff URL recorded by the app yet");
+      return url;
+    }, 30000);
 
-  @Step("Verify provider page is displayed and not a blank/error screen")
-  async verifyProviderPageIsNotBlank(provider: string) {
-    try {
-      await waitForWebviewContentToRender();
-    } catch (error) {
-      throw Object.assign(
-        new Error(
-          `Provider "${provider}" redirected to the correct URL but rendered a blank screen: ${sanitizeError(error)}`,
-        ),
-        { cause: error },
+    const partnerUrl = new URL(extractGoToUrl(rawHandoffUrl));
+
+    if (!urlMatchesProvider(partnerUrl.href, provider)) {
+      throw new Error(
+        `Provider "${provider.uiName}" should appear in the handoff URL: ${partnerUrl.href}`,
       );
     }
-    for (const errorSelector of ERROR_MODAL_SELECTORS) {
-      await checkForErrorElement(errorSelector, 1000);
+
+    const params = Object.fromEntries(
+      Array.from(partnerUrl.searchParams).map(([key, value]) => [key.toLowerCase(), value]),
+    );
+    for (const [key, expected] of Object.entries(getExpectedQueryParams(provider, buySell))) {
+      const actual = params[key];
+      if (actual === undefined) {
+        throw new Error(`Query param "${key}" not found in handoff URL: ${partnerUrl.href}`);
+      }
+      jestExpect(actual.toLowerCase()).toContain(expected);
     }
   }
 
@@ -225,8 +235,7 @@ export default class BuySellPage {
     await this.selectPaymentMethod(paymentMethod);
     const selectedProvider = await this.selectRotatingProvider();
     await this.tapBuySellWithCta(selectedProvider.uiName, buySell.operation);
-    await this.verifyProviderPageLoadedWithCorrectUrl(selectedProvider.uiName);
-    await this.verifyProviderPageIsNotBlank(selectedProvider.uiName);
+    await this.verifyProviderHandoff(selectedProvider, buySell);
   }
 
   @Step("Handle sell flow")
@@ -239,7 +248,6 @@ export default class BuySellPage {
     await this.selectPaymentMethod(paymentMethod);
     await this.selectProvider(provider.name);
     await this.tapBuySellWithCta(provider.uiName, buySell.operation);
-    await this.verifyProviderPageLoadedWithCorrectUrl(provider.uiName);
-    await this.verifyProviderPageIsNotBlank(provider.uiName);
+    await this.verifyProviderHandoff(provider, buySell);
   }
 }

--- a/libs/ledger-live-common/src/platform/providers/RemoteLiveAppProvider/api/index.test.ts
+++ b/libs/ledger-live-common/src/platform/providers/RemoteLiveAppProvider/api/index.test.ts
@@ -1,0 +1,51 @@
+import { getEnv } from "@shared/env";
+import api from "./index";
+import type { LiveAppManifest } from "../../../types";
+
+jest.mock("@ledgerhq/live-network/network", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+jest.mock("@shared/env", () => ({
+  getEnv: jest.fn(() => false),
+}));
+
+const mockGetEnv = jest.mocked(getEnv);
+const network = jest.requireMock("@ledgerhq/live-network/network").default;
+
+const manifests = [{ id: "buy-sell-ui" }] as LiveAppManifest[];
+
+describe("RemoteLiveAppProvider API", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetEnv.mockImplementation(() => false);
+  });
+
+  it("returns the manifests when the catalog call succeeds", async () => {
+    network.mockResolvedValueOnce({ data: manifests });
+
+    await expect(api.fetchLiveAppManifests("https://catalog.example.com")).resolves.toEqual(
+      manifests,
+    );
+  });
+
+  // Regression: the catalog fetch used to swallow network failures and resolve
+  // to `[]`. Callers then could not tell "catalog is empty" from "catalog never
+  // loaded", so a transient failure looked like a successful empty catalog.
+  it("rejects instead of resolving to an empty list when the network call fails", async () => {
+    const networkError = new Error("Network Error");
+    network.mockRejectedValueOnce(networkError);
+
+    await expect(api.fetchLiveAppManifests("https://catalog.example.com")).rejects.toThrow(
+      "Network Error",
+    );
+  });
+
+  it("rejects when the response payload is not an array", async () => {
+    network.mockResolvedValueOnce({ data: { nope: true } });
+
+    await expect(api.fetchLiveAppManifests("https://catalog.example.com")).rejects.toThrow(
+      "Response is not an Array",
+    );
+  });
+});

--- a/libs/ledger-live-common/src/platform/providers/RemoteLiveAppProvider/api/index.ts
+++ b/libs/ledger-live-common/src/platform/providers/RemoteLiveAppProvider/api/index.ts
@@ -16,22 +16,21 @@ const api = {
       }
       return mockData as LiveAppManifest[];
     }
-    try {
-      const { data }: { data: LiveAppManifest[] } = await network({
-        method: "GET",
-        params,
-        paramsSerializer: params => {
-          return qs.stringify(params, { arrayFormat: "repeat" });
-        },
-        url,
-      });
+    // Failures must propagate: resolving to `[]` would be indistinguishable from
+    // a genuinely empty catalog, and callers would cache that as a successful
+    // (but empty) registry — leaving every live app unresolvable ("App not found")
+    // until the next scheduled refresh.
+    const { data }: { data: LiveAppManifest[] } = await network({
+      method: "GET",
+      params,
+      paramsSerializer: params => {
+        return qs.stringify(params, { arrayFormat: "repeat" });
+      },
+      url,
+    });
 
-      if (!Array.isArray(data)) throw new Error("Response is not an Array");
-      return data;
-    } catch (e) {
-      console.error(e);
-      return [];
-    }
+    if (!Array.isArray(data)) throw new Error("Response is not an Array");
+    return data;
   },
 };
 export default api;

--- a/libs/ledger-live-common/src/platform/providers/RemoteLiveAppProvider/index.test.tsx
+++ b/libs/ledger-live-common/src/platform/providers/RemoteLiveAppProvider/index.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import { RemoteLiveAppProvider, useRemoteLiveAppContext } from "./index";
+import api from "./api";
+import type { LiveAppManifest } from "../../types";
+
+jest.mock("./api", () => ({
+  __esModule: true,
+  default: { fetchLiveAppManifests: jest.fn() },
+}));
+jest.mock("@features/platform-env", () => ({
+  __esModule: true,
+  default: () => "https://catalog.example.com",
+}));
+
+const fetchLiveAppManifests = jest.mocked(api.fetchLiveAppManifests);
+
+const manifests = [{ id: "buy-sell-ui" }] as LiveAppManifest[];
+
+// Well beyond any retry delay: nothing here may rely on the periodic refresh.
+const UPDATE_FREQUENCY = 30 * 60 * 1000;
+
+function Probe() {
+  const { state } = useRemoteLiveAppContext();
+  return (
+    <>
+      <div data-testid="ids">{Object.keys(state.value?.liveAppById ?? {}).join(",")}</div>
+      <div data-testid="error">{state.error ? "has-error" : "no-error"}</div>
+    </>
+  );
+}
+
+function renderProvider() {
+  return render(
+    <RemoteLiveAppProvider
+      updateFrequency={UPDATE_FREQUENCY}
+      parameters={{
+        platform: "android",
+        allowDebugApps: false,
+        allowExperimentalApps: false,
+        llVersion: "1.0.0",
+      }}
+    >
+      <Probe />
+    </RemoteLiveAppProvider>,
+  );
+}
+
+describe("RemoteLiveAppProvider", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("exposes the manifests when the catalog loads", async () => {
+    fetchLiveAppManifests.mockResolvedValue(manifests);
+    renderProvider();
+
+    await waitFor(() => expect(screen.getByTestId("ids").textContent).toBe("buy-sell-ui"));
+    expect(screen.getByTestId("error").textContent).toBe("no-error");
+  });
+
+  // Regression: a failed catalog fetch used to be stored as a *successful* empty
+  // registry (error: null), so nothing could tell the catalog had never loaded.
+  it("reports an error instead of a silently empty catalog when the fetch fails", async () => {
+    fetchLiveAppManifests.mockRejectedValue(new Error("Network Error"));
+    renderProvider();
+
+    await waitFor(() => expect(screen.getByTestId("error").textContent).toBe("has-error"));
+    expect(screen.getByTestId("ids").textContent).toBe("");
+  });
+
+  // Regression: the only refetch was the `updateFrequency` interval (30 min in the
+  // apps), so a transient failure at startup - e.g. the device network not being
+  // up yet - left every live app unresolvable for the whole session.
+  it("retries shortly after a failure instead of waiting for the next scheduled refresh", async () => {
+    jest.useFakeTimers();
+    fetchLiveAppManifests
+      .mockRejectedValueOnce(new Error("Network Error"))
+      .mockRejectedValueOnce(new Error("Network Error"))
+      .mockResolvedValue(manifests);
+
+    renderProvider();
+
+    // Let the initial (failing) attempt settle.
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(0);
+    });
+    expect(screen.getByTestId("ids").textContent).toBe("");
+
+    // Well under UPDATE_FREQUENCY: recovery must come from the retry, not the interval.
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(30_000);
+    });
+
+    expect(screen.getByTestId("ids").textContent).toBe("buy-sell-ui");
+    expect(screen.getByTestId("error").textContent).toBe("no-error");
+  });
+});

--- a/libs/ledger-live-common/src/platform/providers/RemoteLiveAppProvider/index.tsx
+++ b/libs/ledger-live-common/src/platform/providers/RemoteLiveAppProvider/index.tsx
@@ -20,6 +20,15 @@ const initialParams: FilterParams = {
   branches: ["stable", "soon"],
 };
 
+// A failed catalog fetch leaves every live app unresolvable ("App not found"),
+// so it must not wait for the next scheduled refresh (30 min in the apps) to be
+// retried. Typical cause: the device has no usable network yet at startup.
+const RETRY_BASE_DELAY_MS = 2000;
+const RETRY_MAX_DELAY_MS = 30000;
+// ~90s of recovery window, then fall back to the regular refresh cadence so an
+// offline device does not keep polling for the whole session.
+const MAX_CONSECUTIVE_RETRIES = 6;
+
 type LiveAppContextType = {
   state: Loadable<LiveAppRegistry>;
   provider: string;
@@ -108,7 +117,7 @@ export function RemoteLiveAppProvider({
 
   const providerURL = provider === "production" ? envProviderURL : provider;
 
-  const updateManifests = useCallback(async () => {
+  const fetchManifests = useCallback(async (): Promise<boolean> => {
     setState(currentState => ({
       ...currentState,
       isLoading: true,
@@ -141,14 +150,16 @@ export function RemoteLiveAppProvider({
         (e): { manifests: null; fetchError: unknown } => ({ manifests: null, fetchError: e }),
       );
 
-    if (!isMounted()) return;
+    if (!isMounted()) return false;
 
     if (result.manifests === null) {
+      // Keep any previously loaded catalog: a failed refresh must not wipe it.
       setState(currentState => ({
         ...currentState,
         isLoading: false,
         error: result.fetchError,
       }));
+      return false;
     } else {
       const { allManifests, catalogManifests } = result.manifests;
       setState(() => ({
@@ -167,9 +178,14 @@ export function RemoteLiveAppProvider({
         },
         error: null,
       }));
+      return true;
     }
     // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [allowDebugApps, allowExperimentalApps, providerURL, lang, isMounted]);
+
+  const updateManifests = useCallback(async () => {
+    await fetchManifests();
+  }, [fetchManifests]);
 
   const value: LiveAppContextType = useMemo(
     () => ({
@@ -182,14 +198,31 @@ export function RemoteLiveAppProvider({
   );
 
   useEffect(() => {
-    const interval = setInterval(() => {
-      updateManifests();
-    }, updateFrequency);
-    updateManifests();
-    return () => {
-      clearInterval(interval);
+    let cancelled = false;
+    let retryTimeout: ReturnType<typeof setTimeout> | undefined;
+    let failedAttempts = 0;
+
+    const run = async () => {
+      const succeeded = await fetchManifests();
+      if (cancelled) return;
+      if (succeeded) {
+        failedAttempts = 0;
+        return;
+      }
+      if (failedAttempts >= MAX_CONSECUTIVE_RETRIES) return;
+      const delay = Math.min(RETRY_BASE_DELAY_MS * 2 ** failedAttempts, RETRY_MAX_DELAY_MS);
+      failedAttempts += 1;
+      retryTimeout = setTimeout(run, delay);
     };
-  }, [updateFrequency, updateManifests]);
+
+    const interval = setInterval(run, updateFrequency);
+    run();
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+      clearTimeout(retryTimeout);
+    };
+  }, [updateFrequency, fetchManifests]);
 
   return <liveAppContext.Provider value={value}>{children}</liveAppContext.Provider>;
 }

--- a/libs/live-e2e-shared/src/buySellHandoff.ts
+++ b/libs/live-e2e-shared/src/buySellHandoff.ts
@@ -1,0 +1,76 @@
+import { BuySell } from "./models/BuySell";
+import { BuySellProvider } from "./enum/Provider";
+import { OperationType } from "./enum/OperationType";
+
+/**
+ * Helpers for asserting the Buy/Sell **handoff** contract: the Ledger-owned webview URL
+ * that carries `goToURL=<partner url>` when the user is sent off to a partner.
+ *
+ * This handoff is the boundary Ledger Live actually owns. Asserting here keeps the tests
+ * off the partner's own production page, which is third-party, uncontrolled, and - on the
+ * Android CI emulator's software renderer - heavy enough to take the emulator down
+ * mid-test. Mirrors what e2e/desktop reads out of `webviewUrlHistory`.
+ */
+
+/** Some partners are named differently in their own URLs than in the quote list. */
+const providerUrlAliases: Record<string, string> = {
+  [BuySellProvider.MERCURYO.uiName]: "mrcr",
+};
+
+type ParamExpectations = Record<string, (buySell: BuySell) => string | number>;
+
+const standardSellParams: ParamExpectations = {
+  cryptoAmount: buySell => buySell.amount,
+  cryptoCurrency: buySell => buySell.crypto.currency.ticker,
+  fiatCurrency: buySell => buySell.fiat.currencyTicker,
+};
+
+/** Only partners with a known, stable URL contract are asserted param-by-param. */
+const providerUrlConfigs: Record<
+  string,
+  { buyParams: ParamExpectations; sellParams: ParamExpectations }
+> = {
+  [BuySellProvider.MOONPAY.uiName]: {
+    buyParams: {
+      baseCurrencyAmount: buySell => buySell.amount,
+      currencyCode: buySell => buySell.crypto.currency.ticker,
+      baseCurrencyCode: buySell => buySell.fiat.currencyTicker,
+    },
+    sellParams: standardSellParams,
+  },
+};
+
+const alphanumeric = (value: string) => value.toLowerCase().replace(/[^a-z0-9]/g, "");
+
+/** Pulls the partner URL out of a handoff URL's `goToURL` param. */
+export function extractGoToUrl(rawHandoffUrl: string): string {
+  const match = rawHandoffUrl.match(/gotourl=([^&]+)/i);
+  if (!match) throw new Error(`Missing 'goToURL' param in handoff URL:\n${rawHandoffUrl}`);
+  return decodeURIComponent(match[1]);
+}
+
+/** True when the partner URL identifies `provider` (punctuation-insensitive, alias-aware). */
+export function urlMatchesProvider(partnerUrl: string, provider: BuySellProvider): boolean {
+  const expected = alphanumeric(providerUrlAliases[provider.uiName] ?? provider.uiName);
+  return alphanumeric(partnerUrl).includes(expected);
+}
+
+/**
+ * Lower-cased `param -> expected value` map for the operation. Empty for partners whose
+ * URL contract is not pinned down, so callers assert only what is actually specified.
+ */
+export function getExpectedQueryParams(
+  provider: BuySellProvider,
+  buySell: BuySell,
+): Record<string, string> {
+  const config = providerUrlConfigs[provider.uiName];
+  if (!config) return {};
+
+  const paramMap = buySell.operation === OperationType.Buy ? config.buyParams : config.sellParams;
+  return Object.fromEntries(
+    Object.entries(paramMap).map(([key, resolve]) => [
+      key.toLowerCase(),
+      String(resolve(buySell)).toLowerCase(),
+    ]),
+  );
+}

--- a/libs/live-e2e-shared/src/buySellHandoff.ts
+++ b/libs/live-e2e-shared/src/buySellHandoff.ts
@@ -42,11 +42,55 @@ const providerUrlConfigs: Record<
 
 const alphanumeric = (value: string) => value.toLowerCase().replace(/[^a-z0-9]/g, "");
 
-/** Pulls the partner URL out of a handoff URL's `goToURL` param. */
+/**
+ * Pulls the partner URL out of a handoff URL's `goToURL` param.
+ *
+ * Reads the param via `URLSearchParams` (which decodes exactly once) rather than a
+ * regex, and tolerates a double-encoded value, which is otherwise indistinguishable
+ * from a single-encoded one until you try to parse it. Throws with the raw handoff
+ * URL attached, because a bare "Invalid URL" from `new URL()` says nothing about what
+ * the app actually handed over.
+ */
 export function extractGoToUrl(rawHandoffUrl: string): string {
-  const match = rawHandoffUrl.match(/gotourl=([^&]+)/i);
-  if (!match) throw new Error(`Missing 'goToURL' param in handoff URL:\n${rawHandoffUrl}`);
-  return decodeURIComponent(match[1]);
+  const fail = (why: string): never => {
+    throw new Error(`${why}\nHandoff URL was: ${rawHandoffUrl}`);
+  };
+
+  let handoff: URL;
+  try {
+    handoff = new URL(rawHandoffUrl);
+  } catch {
+    return fail("Handoff URL is not a valid URL");
+  }
+
+  // Param lookup is case-insensitive: the app has used both `goToURL` and `gotourl`.
+  const key = Array.from(handoff.searchParams.keys()).find(k => k.toLowerCase() === "gotourl");
+  if (!key) return fail("Missing 'goToURL' param in handoff URL");
+
+  const value = handoff.searchParams.get(key) ?? "";
+  if (!value) return fail("Empty 'goToURL' param in handoff URL");
+
+  if (isAbsoluteUrl(value)) return value;
+
+  // Double-encoded (`https%3A%2F%2F...` survives the first decode) - decode once more.
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(value);
+  } catch {
+    return fail(`'goToURL' is not a valid URL and cannot be decoded: ${value}`);
+  }
+  if (isAbsoluteUrl(decoded)) return decoded;
+
+  return fail(`'goToURL' is not an absolute URL: ${value}`);
+}
+
+function isAbsoluteUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
 }
 
 /** True when the partner URL identifies `provider` (punctuation-insensitive, alias-aware). */


### PR DESCRIPTION
> 📊 **Full evidence report** — what is going on across all three breaks, how each is fixed, who owns which, and the ticket/PR recap: **[Android E2E failure modes](https://claude.ai/code/artifact/b75482ca-2615-41e9-b9f2-8fa6661fe6b2)**

### Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _The `live-common` fix is fully covered by 6 new unit tests (both failure modes were verified red first). The E2E page-object change cannot be covered by unit tests and needs a mobile E2E run to validate — see "Validation still needed" below. The new pure helpers in `libs/live-e2e-shared` have no permanent unit test because that package has no jest harness; they were verified executably via `tsx` (11 checks incl. the end-to-end assertion the page object performs)._
- [x] **Impact of the changes:**
      - Any surface that resolves a live app: Buy/Sell, Swap, Earn, Discover, Card — on both Desktop and Mobile.
      - Specifically: cold app start with a slow/absent network, then navigating to a live app. Previously this showed "App not found" for 30 minutes with no retry; it should now recover within ~90s.
      - Desktop's `NetworkErrorScreen` refresh path (`exchange`, `earn`, `Swap2`, `SwapWebViewEmbedded`) — it now actually receives an error state, where before `error` was never set.
      - Mobile Buy/Sell E2E: `buyQueryParameters_*`, `navigateToBuyFrom*`, `sellFlow_BTC`.

### Description

**Problem.** `RemoteLiveAppProvider/api/index.ts` wrapped the live-app catalog request in a `try/catch` that logged the error and returned `[]`. `RemoteLiveAppProvider` cannot distinguish that from a genuinely empty catalog, so it stored the result as a **successful empty registry with `error: null`** — and the only refetch is the `updateFrequency` interval, which both apps set to **30 minutes** (`AUTO_UPDATE_DEFAULT_DELAY`).

So a single failed catalog request at startup makes **every live app unresolvable for 30 minutes**, with no error state and no retry. On mobile that is the "App not found" screen (which offers only "Save logs", no retry). The same `try/catch` also swallowed its own `throw new Error("Response is not an Array")`, leaving that guard dead.

This was found in the Android nightly ([31981083442](https://github.com/LedgerHQ/ledger-live/actions/runs/31981083442)): in 3 of 3 shards examined, all 6 `live-app-catalog.ledger.com/api/v1/apps` attempts fail with `Network Error` inside the first ~4s of app launch, and the first successful request of any kind only lands at 10.9s / 27.2s. The emulator simply has no network yet — the only readiness gate before tests is `sys.boot_completed`, with no network/DNS wait anywhere. iOS simulators share the host network stack and never see this.

**Solution.**

- `api/index.ts` — let failures propagate instead of resolving to `[]`, so callers can tell "catalog is empty" from "catalog never loaded".
- `RemoteLiveAppProvider/index.tsx` — record a real `error`; keep any previously loaded catalog when a *refresh* fails (a bad refresh no longer wipes a good catalog); retry with backoff (2s → 30s, capped at 6 attempts ≈ 90s) instead of waiting for the next scheduled refresh, then fall back to the normal cadence so an offline device does not poll forever.

**Second commit — Buy/Sell E2E stops driving into the partner's page.** `handleBuyFlow`/`handleSellFlow` used to wait up to 70s for the third-party provider's *production* checkout page to render. That makes the suite go red on Transak/MoonPay uptime rather than on Ledger Live, and it is not a boundary we own. Mobile now asserts the **handoff** — the `goToURL` the app hands to the partner, plus its query parameters — which is exactly what `e2e/desktop` already asserts from `webviewUrlHistory`. The app records the handoff URL under `Config.DETOX` and exposes it over the e2e bridge as `getPtxHandoff`, following the existing `getLogs`/`getFlags` pattern; the store reads-and-clears so a handoff cannot leak into a later test. Side effect: the `Buy and sell query parameters` test previously asserted **no** query parameters at all despite its name — it now does.

**Validation still needed.** A mobile E2E run on this branch, to exercise the new handoff assertion. Note it will likely still be red: the current Android nightly failures are dominated by an infrastructure regression where the emulator process dies mid-run (tracked in [QAA-1497](https://ledgerhq.atlassian.net/browse/QAA-1497)), which this PR does **not** fix and does not claim to.

**Not included on purpose.** `waitForWebviewContentToRender` in `e2e/mobile/helpers/elementHelpers.ts` now has no caller. It is left in place as a generic helper rather than widening this diff.

### Context

- **JIRA or GitHub link**: [QAA-1498](https://ledgerhq.atlassian.net/browse/QAA-1498)
- **Related**: [QAA-1497](https://ledgerhq.atlassian.net/browse/QAA-1497) — Android E2E emulators die mid-run since 2026-08-14 (runner fleet regression)

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-1497]: https://ledgerhq.atlassian.net/browse/QAA-1497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
