### PR TITLE
[LWDM] fix(coin-tron): fix getBalance returning empty instead of surfacing errors

### DIFF
--- a/.changeset/tron-balance-surface-errors.md
+++ b/.changeset/tron-balance-surface-errors.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tron": minor
+---
+
+Fix getBalance returning a zero balance instead of surfacing upstream API errors

--- a/libs/coin-modules/coin-tron/src/logic/getBalance.integ.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/getBalance.integ.test.ts
@@ -4,7 +4,7 @@ import { getBalance } from "./getBalance";
 
 const mockConfig = {
   status: { type: "active" },
-  explorer: { url: "https://api.trongrid.io" },
+  explorer: { url: "https://tron.coin.ledger.com" },
 } as TronCoinConfig;
 
 describe("getBalance", () => {
@@ -30,9 +30,15 @@ describe("getBalance", () => {
     balances.forEach(balance => expect(balance.value).toBeGreaterThanOrEqual(0));
   });
 
-  it("returns 0 when address is not found", async () => {
-    const result = await getBalance(mockConfig, "TPqmGMoidNTbMZ8ApgcbPMf7JDyiHi1sv0");
+  it("returns 0 when account is not activated", async () => {
+    const result = await getBalance(mockConfig, "TXFeV31qgUQYMLog3axKJeEBbXpQFtHsXD");
 
     expect(result).toEqual([{ value: BigInt(0), asset: { type: "native" } }]);
+  });
+
+  it("propagates upstream API errors for an invalid address", async () => {
+    await expect(getBalance(mockConfig, "TPqmGMoidNTbMZ8ApgcbPMf7JDyiHi1sv0")).rejects.toThrow(
+      /valid account address/i,
+    );
   });
 });

--- a/libs/coin-modules/coin-tron/src/logic/getBalance.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/getBalance.test.ts
@@ -1,12 +1,12 @@
 import type { TronCoinConfig } from "../config";
 import BigNumber from "bignumber.js";
-import { fetchTronAccount } from "../network";
+import { fetchTronAccountOrFail } from "../network";
 import type { AccountTronAPI } from "../network/types";
 import { computeBalance, computeBalanceBridge, getBalance } from "./getBalance";
 import { getTronResources } from "./utils";
 
 jest.mock("../network", () => ({
-  fetchTronAccount: jest.fn(),
+  fetchTronAccountOrFail: jest.fn(),
 }));
 
 jest.mock("./utils", () => {
@@ -17,7 +17,9 @@ jest.mock("./utils", () => {
   };
 });
 
-const mockedFetchTronAccount = fetchTronAccount as jest.MockedFunction<typeof fetchTronAccount>;
+const mockedFetchTronAccountOrFail = fetchTronAccountOrFail as jest.MockedFunction<
+  typeof fetchTronAccountOrFail
+>;
 const mockedGetTronResources = getTronResources as jest.MockedFunction<typeof getTronResources>;
 
 const address = "41ae18eb0a9e067f8884058470ed187f44135d816d";
@@ -183,20 +185,20 @@ describe("computeBalanceBridge", () => {
 
 describe("getBalance", () => {
   beforeEach(() => {
-    mockedFetchTronAccount.mockReset();
+    mockedFetchTronAccountOrFail.mockReset();
   });
 
   it("returns a zeroed native balance when the account is inactive", async () => {
-    mockedFetchTronAccount.mockResolvedValueOnce([]);
+    mockedFetchTronAccountOrFail.mockResolvedValueOnce([]);
 
     const balance = await getBalance(mockConfig, address);
 
     expect(balance).toEqual([{ asset: { type: "native" }, value: 0n }]);
-    expect(mockedFetchTronAccount).toHaveBeenCalledWith(mockConfig, address);
+    expect(mockedFetchTronAccountOrFail).toHaveBeenCalledWith(mockConfig, address);
   });
 
   it("returns native + trc10 + trc20 balances", async () => {
-    mockedFetchTronAccount.mockResolvedValueOnce([
+    mockedFetchTronAccountOrFail.mockResolvedValueOnce([
       {
         ...baseAccount,
         balance: 27_781_772,
@@ -243,7 +245,7 @@ describe("getBalance", () => {
   });
 
   it("returns only the native balance when there is no assetV2 nor trc20", async () => {
-    mockedFetchTronAccount.mockResolvedValueOnce([baseAccount]);
+    mockedFetchTronAccountOrFail.mockResolvedValueOnce([baseAccount]);
 
     const balance = await getBalance(mockConfig, address);
 
@@ -251,7 +253,7 @@ describe("getBalance", () => {
   });
 
   it("propagates upstream API errors", async () => {
-    mockedFetchTronAccount.mockRejectedValueOnce(new Error("upstream API error"));
+    mockedFetchTronAccountOrFail.mockRejectedValueOnce(new Error("upstream API error"));
 
     await expect(getBalance(mockConfig, address)).rejects.toThrow("upstream API error");
   });

--- a/libs/coin-modules/coin-tron/src/logic/getBalance.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/getBalance.test.ts
@@ -249,4 +249,10 @@ describe("getBalance", () => {
 
     expect(balance).toEqual([{ asset: { type: "native" }, value: 1_781_772n }]);
   });
+
+  it("propagates upstream API errors", async () => {
+    mockedFetchTronAccount.mockRejectedValueOnce(new Error("upstream API error"));
+
+    await expect(getBalance(mockConfig, address)).rejects.toThrow("upstream API error");
+  });
 });

--- a/libs/coin-modules/coin-tron/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-tron/src/logic/getBalance.ts
@@ -1,7 +1,7 @@
 import { Balance } from "@ledgerhq/coin-module-framework/api/index";
 import BigNumber from "bignumber.js";
 import type { TronCoinConfig } from "../config";
-import { fetchTronAccount } from "../network";
+import { fetchTronAccountOrFail } from "../network";
 import type { AccountTronAPI } from "../network/types";
 import { getTronResources } from "./utils";
 
@@ -9,7 +9,7 @@ const bigIntOrZero = (val: number | BigNumber | undefined | null): bigint =>
   BigInt(val?.toString() ?? 0);
 
 export async function getBalance(config: TronCoinConfig, address: string): Promise<Balance[]> {
-  const accounts = await fetchTronAccount(config, address);
+  const accounts = await fetchTronAccountOrFail(config, address);
 
   // if account is not activated, an empty balance is returned
   if (accounts.length === 0) return [{ value: BigInt(0), asset: { type: "native" } }];

--- a/libs/coin-modules/coin-tron/src/network/index.test.ts
+++ b/libs/coin-modules/coin-tron/src/network/index.test.ts
@@ -13,6 +13,8 @@ import {
   createTronTransaction,
   defaultFetchParams,
   fetchTronAccount,
+  fetchTronAccountOrEmpty,
+  fetchTronAccountOrFail,
   fetchTronAccountTxs,
   fetchTronAccountTxsPage,
   fetchTronContract,
@@ -97,9 +99,9 @@ describe("post / fetch error handling", () => {
     await expect(post(mockConfig, "/wallet/anything", {})).rejects.toThrow("raw-string");
   });
 
-  it("propagates GET errors from fetch", async () => {
+  it("returns [] on GET errors from fetch", async () => {
     mockedNetwork.mockResolvedValueOnce(mockResponse({ Error: { message: "get-boom" } }));
-    await expect(fetchTronAccount(mockConfig, senderBase58)).rejects.toThrow();
+    await expect(fetchTronAccount(mockConfig, senderBase58)).resolves.toEqual([]);
   });
 });
 
@@ -454,9 +456,32 @@ describe("fetchTronAccount", () => {
     expect(result).toEqual([{ address: senderHex }]);
   });
 
+  it("returns [] on network error", async () => {
+    mockedNetwork.mockRejectedValueOnce(new Error("network"));
+    await expect(fetchTronAccount(mockConfig, senderBase58)).resolves.toEqual([]);
+  });
+
+  it("fetchTronAccountOrEmpty matches fetchTronAccount behavior", async () => {
+    mockedNetwork.mockRejectedValueOnce(new Error("network"));
+    await expect(fetchTronAccountOrEmpty(mockConfig, senderBase58)).resolves.toEqual([]);
+  });
+});
+
+describe("fetchTronAccountOrFail", () => {
+  it("returns parsed data on success", async () => {
+    mockedNetwork.mockResolvedValueOnce(mockResponse({ data: [{ address: senderHex }] }));
+    const result = await fetchTronAccountOrFail(mockConfig, senderBase58);
+    expect(result).toEqual([{ address: senderHex }]);
+  });
+
+  it("propagates GET errors from fetch", async () => {
+    mockedNetwork.mockResolvedValueOnce(mockResponse({ Error: { message: "get-boom" } }));
+    await expect(fetchTronAccountOrFail(mockConfig, senderBase58)).rejects.toThrow();
+  });
+
   it("propagates network errors", async () => {
     mockedNetwork.mockRejectedValueOnce(new Error("network"));
-    await expect(fetchTronAccount(mockConfig, senderBase58)).rejects.toThrow("network");
+    await expect(fetchTronAccountOrFail(mockConfig, senderBase58)).rejects.toThrow("network");
   });
 });
 

--- a/libs/coin-modules/coin-tron/src/network/index.test.ts
+++ b/libs/coin-modules/coin-tron/src/network/index.test.ts
@@ -476,7 +476,7 @@ describe("fetchTronAccountOrFail", () => {
 
   it("propagates GET errors from fetch", async () => {
     mockedNetwork.mockResolvedValueOnce(mockResponse({ Error: { message: "get-boom" } }));
-    await expect(fetchTronAccountOrFail(mockConfig, senderBase58)).rejects.toThrow();
+    await expect(fetchTronAccountOrFail(mockConfig, senderBase58)).rejects.toThrow("get-boom");
   });
 
   it("propagates network errors", async () => {

--- a/libs/coin-modules/coin-tron/src/network/index.test.ts
+++ b/libs/coin-modules/coin-tron/src/network/index.test.ts
@@ -99,7 +99,7 @@ describe("post / fetch error handling", () => {
 
   it("propagates GET errors from fetch", async () => {
     mockedNetwork.mockResolvedValueOnce(mockResponse({ Error: { message: "get-boom" } }));
-    await expect(fetchTronAccount(mockConfig, senderBase58)).resolves.toEqual([]);
+    await expect(fetchTronAccount(mockConfig, senderBase58)).rejects.toThrow();
   });
 });
 
@@ -454,9 +454,9 @@ describe("fetchTronAccount", () => {
     expect(result).toEqual([{ address: senderHex }]);
   });
 
-  it("returns [] on network error", async () => {
+  it("propagates network errors", async () => {
     mockedNetwork.mockRejectedValueOnce(new Error("network"));
-    await expect(fetchTronAccount(mockConfig, senderBase58)).resolves.toEqual([]);
+    await expect(fetchTronAccount(mockConfig, senderBase58)).rejects.toThrow("network");
   });
 });
 

--- a/libs/coin-modules/coin-tron/src/network/index.ts
+++ b/libs/coin-modules/coin-tron/src/network/index.ts
@@ -463,12 +463,30 @@ export const broadcastHexTron = async (
 /**
  * {@link https://github.com/tronprotocol/java-tron/blob/develop/framework/src/main/java/org/tron/core/services/http/GetAccountServlet.java | Tron Framework}
  */
-export async function fetchTronAccount(
+export async function fetchTronAccountOrFail(
   config: TronCoinConfig,
   addr: string,
 ): Promise<AccountTronAPI[]> {
   const data = await fetch(config, `/v1/accounts/${addr}`);
   return data.data;
+}
+
+export async function fetchTronAccountOrEmpty(
+  config: TronCoinConfig,
+  addr: string,
+): Promise<AccountTronAPI[]> {
+  try {
+    return await fetchTronAccountOrFail(config, addr);
+  } catch {
+    return [];
+  }
+}
+
+export async function fetchTronAccount(
+  config: TronCoinConfig,
+  addr: string,
+): Promise<AccountTronAPI[]> {
+  return fetchTronAccountOrEmpty(config, addr);
 }
 
 export async function getLastBlock(config: TronCoinConfig): Promise<Block> {

--- a/libs/coin-modules/coin-tron/src/network/index.ts
+++ b/libs/coin-modules/coin-tron/src/network/index.ts
@@ -467,12 +467,8 @@ export async function fetchTronAccount(
   config: TronCoinConfig,
   addr: string,
 ): Promise<AccountTronAPI[]> {
-  try {
-    const data = await fetch(config, `/v1/accounts/${addr}`);
-    return data.data;
-  } catch {
-    return [];
-  }
+  const data = await fetch(config, `/v1/accounts/${addr}`);
+  return data.data;
 }
 
 export async function getLastBlock(config: TronCoinConfig): Promise<Block> {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Tron coin module returns an empty balance when upstream API fails, which means balance=0. This is wrong, errors should be surfaced and handled by the caller.

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/BACK-12103
- **ADR** (if any): <!-- link to the relevant architectural decision record -->

Related: https://github.com/LedgerHQ/coin-modules/pull/791
