### PR TITLE
[LWM] fix(pay): skip receive options when depositing from Pay (LIVE-36097)

### DIFF
--- a/.changeset/pay-skip-receive-options-mobile.md
+++ b/.changeset/pay-skip-receive-options-mobile.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Skip the Noah receive funds options drawer when depositing from Pay so users are not asked to choose crypto vs bank transfer twice

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/__tests__/usePayTabDepositOptions.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/__tests__/usePayTabDepositOptions.test.tsx
@@ -102,6 +102,7 @@ describe("usePayTabDepositOptions", () => {
     expect(useOpenReceiveDrawer).toHaveBeenCalledWith({
       currencyIds: STABLECOIN_IDS,
       sourceScreenName: "Pay",
+      fromMenu: true,
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabDepositOptions.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabDepositOptions.ts
@@ -28,6 +28,7 @@ export function usePayTabDepositOptions(
   const { handleOpenReceiveDrawer } = useOpenReceiveDrawer({
     currencyIds: stablecoinCurrencyIds,
     sourceScreenName: DEPOSIT_PAGE,
+    fromMenu: true,
   });
   const { handleOpenSwap } = useOpenSwap({ sourceScreenName: DEPOSIT_PAGE });
   const { handleOpenBuySell } = useOpenBuySell({ sourceScreenName: DEPOSIT_PAGE });


### PR DESCRIPTION
### 📝 Description

On Pay, Deposit already asks the user to choose a method (Bank transfer vs Receive via crypto address). When the user picks **Receive** and Noah is enabled, the generic receive flow then shows the **Receive funds options** drawer (crypto vs bank) again — asking the same question twice.

This wires the Pay deposit → receive entry to pass `fromMenu: true` to `useOpenReceiveDrawer`, the same skip already used by the Transfer drawer and onboarding. With Noah on, `shouldShowNoahMenu` now returns `false` for this entry, so the user lands directly on the stablecoin-filtered crypto receive flow (Modular Drawer asset/account selection).

Generic receive entry points (Portfolio, Quick Actions, etc.) are unchanged and still show the Receive funds options drawer when Noah is enabled. The Pay Deposit → Bank transfer path is unchanged.

Regression coverage: `usePayTabDepositOptions.test.tsx` now asserts `useOpenReceiveDrawer` is configured with `fromMenu: true`; `shouldShowNoahMenu.test.ts` already asserts `fromMenu: true` hides the Noah menu and that generic (no `fromMenu`) receive still shows it.

> [!NOTE]
> Depends on [LIVE-34911](https://ledgerhq.atlassian.net/browse/LIVE-34911) (Pay deposit options bottom sheet + wire). This PR targets the LIVE-34911 branch and should be merged/rebased after it. Desktop is handled by sibling ticket [LIVE-36096](https://ledgerhq.atlassian.net/browse/LIVE-36096).

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36097](https://ledgerhq.atlassian.net/browse/LIVE-36097)
- **ADR** (if any): n/a


[LIVE-34911]: https://ledgerhq.atlassian.net/browse/LIVE-34911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ