### PR TITLE
fix(pay-card): skip receive options on Pay deposit (LIVE-36096)

### DIFF
--- a/.changeset/pay-skip-receive-options-desktop.md
+++ b/.changeset/pay-skip-receive-options-desktop.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Skip the Noah receive options step when depositing from Pay so users are not asked to choose crypto vs bank transfer twice

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/__tests__/useOpenAssetFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/__tests__/useOpenAssetFlow.test.tsx
@@ -1,9 +1,31 @@
 import React from "react";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
 import { ModularDrawerLocation } from "@ledgerhq/live-common/modularDrawer/enums";
 import { renderHook, withFlagOverrides } from "tests/testSetup";
 import { useOpenAssetFlow } from "../useOpenAssetFlow";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { BTC_ACCOUNT } from "LLD/features/__mocks__/accounts.mock";
 import { setDrawer } from "~/renderer/drawers/Provider";
+
+type OnAccountSelected = (account: AccountLike, parentAccount?: Account) => void;
+
+const getLastOnAccountSelected = (): OnAccountSelected => {
+  const lastCall = jest.mocked(setDrawer).mock.calls.at(-1);
+  const props = lastCall?.[1] as { onAccountSelected?: OnAccountSelected } | undefined;
+  if (!props?.onAccountSelected) {
+    throw new Error("setDrawer was not called with an onAccountSelected callback");
+  }
+  return props.onAccountSelected;
+};
+
+const MODULAR_DRAWER_ENABLED = withFlagOverrides({
+  lldModularDrawer: {
+    enabled: true,
+    params: {
+      [ModularDrawerLocation.ADD_ACCOUNT]: true,
+    },
+  },
+});
 
 jest.mock("~/renderer/drawers/Provider", () => ({
   __esModule: true,
@@ -109,5 +131,50 @@ describe("useOpenAssetFlow", () => {
 
     expect(store.getState().modularDialog.isOpen).toBe(false);
     expect(setDrawer).toHaveBeenCalledTimes(1);
+  });
+
+  it("reopens the modal with the extra modal data when the account flow finishes", () => {
+    const { result, store } = renderHook(
+      () =>
+        useOpenAssetFlow({ location: ModularDrawerLocation.ADD_ACCOUNT }, "Pay", "MODAL_RECEIVE", {
+          shouldUseReceiveOptions: false,
+        }),
+      { initialState: MODULAR_DRAWER_ENABLED },
+    );
+
+    result.current.openAddAccountFlow(getCryptoCurrencyById("bitcoin"));
+    getLastOnAccountSelected()(BTC_ACCOUNT);
+
+    expect(store.getState().modals.MODAL_RECEIVE).toEqual({
+      isOpened: true,
+      data: {
+        account: BTC_ACCOUNT,
+        parentAccount: undefined,
+        shouldUseReceiveOptions: false,
+      },
+    });
+  });
+
+  it("reopens the modal without extra data when none is provided", () => {
+    const { result, store } = renderHook(
+      () =>
+        useOpenAssetFlow(
+          { location: ModularDrawerLocation.ADD_ACCOUNT },
+          "receive",
+          "MODAL_RECEIVE",
+        ),
+      { initialState: MODULAR_DRAWER_ENABLED },
+    );
+
+    result.current.openAddAccountFlow(getCryptoCurrencyById("bitcoin"));
+    getLastOnAccountSelected()(BTC_ACCOUNT);
+
+    expect(store.getState().modals.MODAL_RECEIVE).toEqual({
+      isOpened: true,
+      data: {
+        account: BTC_ACCOUNT,
+        parentAccount: undefined,
+      },
+    });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useOpenAssetFlow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useOpenAssetFlow.tsx
@@ -7,7 +7,7 @@ import { useDispatch } from "LLD/hooks/redux";
 import { openModal } from "~/renderer/actions/modals";
 import { currentRouteNameRef } from "~/renderer/analytics/screenRefs";
 import { setDrawer } from "~/renderer/drawers/Provider";
-import { GlobalModalData } from "~/renderer/modals/types";
+import { GlobalModalData, ModalData } from "~/renderer/modals/types";
 import ModularDrawerAddAccountFlowManager from "../../AddAccountDrawer/ModularDrawerAddAccountFlowManager";
 import { useModularDialogAnalytics } from "../analytics/useModularDialogAnalytics";
 import { CloseButton } from "../components/CloseButton";
@@ -42,10 +42,11 @@ function selectCurrencyDialog(
   );
 }
 
-export function useOpenAssetFlow(
+export function useOpenAssetFlow<Name extends keyof GlobalModalData = keyof GlobalModalData>(
   modularDrawerVisibleParams: ModularDrawerVisibleParams,
   source: string,
-  modalNameToReopen?: keyof GlobalModalData,
+  modalNameToReopen?: Name,
+  extraModalData?: Omit<NonNullable<GlobalModalData[Name]>, "account" | "parentAccount">,
 ) {
   const dispatch = useDispatch();
   const { trackModularDialogEvent } = useModularDialogAnalytics();
@@ -78,7 +79,15 @@ export function useOpenAssetFlow(
       const onFlowFinishedWithModalReopen = (account: AccountLike, parentAccount?: Account) => {
         setDrawer();
         if (modalNameToReopen) {
-          dispatch(openModal(modalNameToReopen, { account, parentAccount }));
+          // openModal's payload creator collapses ModalData[Name] to `never` for a generic
+          // Name, so we assert the merged payload back to the modal's data type.
+          dispatch(
+            openModal(modalNameToReopen, {
+              ...extraModalData,
+              account,
+              parentAccount,
+            } as ModalData[Name]),
+          );
         }
       };
 
@@ -91,7 +100,7 @@ export function useOpenAssetFlow(
         { closeButtonComponent: CloseButton, onRequestClose: onClose },
       );
     },
-    [dispatch, modalNameToReopen, source, trackModularDialogEvent],
+    [dispatch, extraModalData, modalNameToReopen, source, trackModularDialogEvent],
   );
 
   const openAssetFlow = useCallback(

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayTabDepositOptions.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayTabDepositOptions.test.tsx
@@ -102,4 +102,12 @@ describe("usePayTabDepositOptions", () => {
     expect(mockOpenAssetFlow).toHaveBeenCalledWith(undefined, STABLECOIN_IDS);
     expect(mockNavigate).not.toHaveBeenCalled();
   });
+
+  it("skips receive options when opening receive from Pay", () => {
+    render();
+
+    expect(mockedUseOpenAssetFlow).toHaveBeenCalledWith(expect.anything(), "Pay", "MODAL_RECEIVE", {
+      shouldUseReceiveOptions: false,
+    });
+  });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabDepositOptions.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabDepositOptions.ts
@@ -26,6 +26,7 @@ export function usePayTabDepositOptions(
     { location: ModularDrawerLocation.ADD_ACCOUNT },
     DEPOSIT_PAGE,
     "MODAL_RECEIVE",
+    { shouldUseReceiveOptions: false },
   );
 
   const onSelect = useCallback(

--- a/apps/ledger-live-desktop/src/renderer/modals/Receive/index.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Receive/index.test.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { render, screen, withFlagOverrides } from "tests/testSetup";
+import { BTC_ACCOUNT } from "LLD/features/__mocks__/accounts.mock";
+import ReceiveModal from "./index";
+
+const noahEnabledState = {
+  ...withFlagOverrides({
+    noah: {
+      enabled: true,
+      params: { activeCurrencyIds: [BTC_ACCOUNT.currency.id] },
+    },
+  }),
+  accounts: [BTC_ACCOUNT],
+};
+
+describe("ReceiveModal", () => {
+  it("shows the Noah receive options when Noah is active and no skip flag is passed", () => {
+    render(<ReceiveModal account={BTC_ACCOUNT} />, { initialState: noahEnabledState });
+
+    expect(screen.getByTestId("receive-step-options")).toBeVisible();
+  });
+
+  it("skips the Noah receive options when shouldUseReceiveOptions is false", () => {
+    render(<ReceiveModal account={BTC_ACCOUNT} shouldUseReceiveOptions={false} />, {
+      initialState: noahEnabledState,
+    });
+
+    expect(screen.queryByTestId("receive-step-options")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### 📝 Description

On Pay, Deposit already asks the user to choose a method: **Bank transfer** vs **Receive via crypto address**. When the user picks Receive and Noah is enabled, the generic receive flow (`MODAL_RECEIVE`) started again on **Receive options** (crypto vs bank/fiat), asking the same question twice.

This PR passes `shouldUseReceiveOptions: false` when receive is launched from Pay Deposit, so Noah's Receive options step is skipped and the user lands directly on the crypto receive flow (stablecoin-filtered asset/account selection).

Implementation:
- `useOpenAssetFlow` gains an optional, generic `extraModalData` argument that is merged into the reopened modal payload. The type is tied to `modalNameToReopen`, and `account`/`parentAccount` are excluded so they can't be overridden.
- `usePayTabDepositOptions` passes `{ shouldUseReceiveOptions: false }` when opening receive.

Generic receive entry points (Portfolio, account, Quick Actions, sidebar, deeplinks) are unchanged and still show Receive options when Noah is enabled. Pay Deposit → Bank transfer still goes to the bank flow (unchanged).

Covered by tests:
- `usePayTabDepositOptions`: asserts receive is opened with `{ shouldUseReceiveOptions: false }`; bank/swap/buy paths unchanged.
- `useOpenAssetFlow`: reopen payload includes the extra data when provided, and omits it otherwise.
- `ReceiveModal`: Noah options are shown when no flag is passed, and skipped when `shouldUseReceiveOptions: false`.

> Stacked on `feat/pay-card-LIVE-34911-mobile-deposit-options` (foundation). The sibling mobile change is tracked separately under LIVE-36097.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36096](https://ledgerhq.atlassian.net/browse/LIVE-36096)

[LIVE-36096]: https://ledgerhq.atlassian.net/browse/LIVE-36096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ