### PR TITLE
chore(codeowners): move card folders to ptx team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -129,9 +129,6 @@ features/flow/flow-contacts-list/                         @ledgerhq/wallet-xp
 features/flow/pay-card-balance/                          @ledgerhq/wallet-xp
 features/flow/pay-card-deposit/                          @ledgerhq/wallet-xp
 features/flow/pay-card-feature-tour/                     @ledgerhq/wallet-xp
-features/platform/card/                                  @ledgerhq/wallet-xp
-domain/api/card-management/                              @ledgerhq/wallet-xp
-/shared/api-services/src/services/card/                  @ledgerhq/wallet-xp
 
 # Wallet — shared UI
 /shared/ui-queued-bottom-sheet/                          @ledgerhq/wallet-xp
@@ -257,6 +254,9 @@ libs/concordium-core/                                                    @ledger
 
 # PTX team
 features/flow/pay-card-auth/                                             @ledgerhq/ptx
+features/platform/card/                                                  @ledgerhq/ptx
+domain/api/card-management/                                              @ledgerhq/ptx
+/shared/api-services/src/services/card/                                  @ledgerhq/ptx
 apps/cli/src/commands/ptx                                            					@ledgerhq/ptx
 apps/ledger-live-desktop/src/renderer/components/ProviderIcon/       					@ledgerhq/ptx
 apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/       					@ledgerhq/ptx


### PR DESCRIPTION
## Summary
- Move code ownership of `shared/api-services/src/services/card/`, `domain/api/card-management/`, and `features/platform/card/` from `@ledgerhq/wallet-xp` to `@ledgerhq/ptx`.
- Grouped alongside the existing `features/flow/pay-card-auth/` entry in the PTX team section.

## Test plan
- [ ] Confirm `CODEOWNERS` resolves the three folders to `@ledgerhq/ptx` (verified locally with `resolve-codeowners.js`).