### PR TITLE
[LWDM] fix(contacts): enable sharing and align empty copy (LIVE-35868)

### DIFF
--- a/.changeset/clear-contacts-copy.md
+++ b/.changeset/clear-contacts-copy.md
@@ -1,0 +1,7 @@
+---
+"@features/flow-contacts": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Fix Contact sharing and align empty address copy

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -401,7 +401,7 @@ describe("Contacts integration", () => {
     expect(screen.getByTestId("contacts-detail-avatar")).toBeVisible();
     expect(screen.getByText("No saved addresses for Ada")).toBeVisible();
     expect(
-      screen.getByText("Save their wallet addresses to send to them by name next time."),
+      screen.getByText("Save their wallet addresses to send to them by name next time"),
     ).toBeVisible();
     expect(screen.getByTestId("contacts-detail-add-address")).toBeVisible();
   });

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9429,7 +9429,7 @@
         "meTitle": "No saved addresses for you",
         "contactTitle": "No saved addresses for {{name}}",
         "meDescription": "Save your wallet addresses to receive crypto by name next time.",
-        "contactDescription": "Save their wallet addresses to send to them by name next time."
+        "contactDescription": "Save their wallet addresses to send to them by name next time"
       }
     },
     "addressDetail": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10328,10 +10328,10 @@
       "ledgerWalletAddresses": "Ledger Wallet addresses",
       "myAddresses": "My addresses",
       "emptyState": {
-        "title": "No address yet",
+        "contactTitle": "No saved addresses for {{name}}",
         "meTitle": "Save your own addresses",
         "meDescription": "Save the external addresses you own on exchanges or other wallets. Next time you send to yourself, your Ledger device will show the name you chose.",
-        "contactDescription": "Save a wallet address to send to {{name}}"
+        "contactDescription": "Save their wallet addresses to send to them by name next time"
       }
     },
     "addressDetail": {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -565,7 +565,10 @@ describe("Contacts integration", () => {
     await waitFor(() => {
       expect(screen.getByTestId("contacts-detail-screen")).toBeVisible();
       expect(screen.getByTestId("contacts-detail-add-address")).toHaveTextContent("Add address");
-      expect(screen.getByText("Save a wallet address to send to Benoit")).toBeVisible();
+      expect(screen.getByText("No saved addresses for Benoit")).toBeVisible();
+      expect(
+        screen.getByText("Save their wallet addresses to send to them by name next time"),
+      ).toBeVisible();
       expect(screen.getByTestId("contacts-detail-avatar")).toBeVisible();
       expect(screen.queryByTestId("contacts-detail-ledger-wallet-addresses")).toBeNull();
     });

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactAddressDetailDialogSheet/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactAddressDetailDialogSheet/index.tsx
@@ -4,6 +4,7 @@ import {
   ContactAddressDetailDialog,
   type ContactAddressDetailDialogNativeProps,
 } from "@features/flow-contacts";
+import { Share } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { QueuedBottomSheet } from "@shared/ui-queued-bottom-sheet";
 
@@ -15,6 +16,9 @@ export function ContactAddressDetailDialogSheet({
   const { bottom: bottomInset } = useSafeAreaInsets();
   const onCopyAddress = useCallback((address: string) => {
     Clipboard.setString(address);
+  }, []);
+  const onShareAddress = useCallback((address: string) => {
+    void Share.share({ message: address }).catch(() => undefined);
   }, []);
 
   return (
@@ -30,6 +34,7 @@ export function ContactAddressDetailDialogSheet({
         onClose={onClose}
         bottomInset={bottomInset}
         onCopyAddress={onCopyAddress}
+        onShareAddress={onShareAddress}
       />
     </QueuedBottomSheet>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
@@ -184,7 +184,7 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
       addAddress: t("contacts.addAddress"),
       addYourAddress: t("contacts.addYourAddress"),
       emptyMeTitle: t("contacts.detail.emptyState.meTitle"),
-      emptyContactTitle: () => t("contacts.detail.emptyState.title"),
+      emptyContactTitle: name => t("contacts.detail.emptyState.contactTitle", { name }),
       emptyMeDescription: t("contacts.detail.emptyState.meDescription"),
       emptyContactDescription: name => t("contacts.detail.emptyState.contactDescription", { name }),
       ledgerWalletAddresses: t("contacts.detail.ledgerWalletAddresses"),

--- a/features/flow/contacts/src/steps/Detail/ContactDetailView.native.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/ContactDetailView.native.test.tsx
@@ -11,9 +11,9 @@ const labels: ContactDetailLabels = {
   addAddress: "Add address",
   addYourAddress: "Add your address",
   emptyMeTitle: "Save your own addresses",
-  emptyContactTitle: () => "No address yet",
+  emptyContactTitle: name => `No saved addresses for ${name}`,
   emptyMeDescription: "Save external addresses for Me.",
-  emptyContactDescription: name => `Save wallet address to send to ${name}`,
+  emptyContactDescription: () => "Save their wallet addresses to send to them by name next time",
   ledgerWalletAddresses: "Ledger Wallet addresses",
   myAddresses: "My addresses",
   formatAddressCount: count => `${count} address`,
@@ -60,8 +60,10 @@ describe("ContactDetailPage", () => {
     expect(screen.getByText("Benoit")).toBeVisible();
     expect(screen.getByTestId("contacts-detail-add-address")).toHaveTextContent("Add address");
     expect(screen.queryByTestId("contacts-detail-ledger-wallet-addresses")).toBeNull();
-    expect(screen.getByText("No address yet")).toBeVisible();
-    expect(screen.getByText("Save wallet address to send to Benoit")).toBeVisible();
+    expect(screen.getByText("No saved addresses for Benoit")).toBeVisible();
+    expect(
+      screen.getByText("Save their wallet addresses to send to them by name next time"),
+    ).toBeVisible();
   });
 
   it("should keep the shared detail defaults without Mobile-specific props", () => {

--- a/features/flow/contacts/src/steps/Detail/ContactDetailView.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/ContactDetailView.web.test.tsx
@@ -13,7 +13,7 @@ const labels: ContactDetailLabels = {
   emptyMeTitle: "No saved addresses for you",
   emptyContactTitle: name => `No saved addresses for ${name}`,
   emptyMeDescription: "Save your wallet addresses to receive crypto by name next time.",
-  emptyContactDescription: () => "Save their wallet addresses to send to them by name next time.",
+  emptyContactDescription: () => "Save their wallet addresses to send to them by name next time",
   formatMeDisplayName: name => `${name} (Me)`,
   formatAddressCount: count => `${count} address`,
 };
@@ -57,7 +57,7 @@ describe("ContactDetailView", () => {
     expect(screen.getByText("Benoit")).toBeInTheDocument();
     expect(screen.getByText("No saved addresses for Benoit")).toBeInTheDocument();
     expect(
-      screen.getByText("Save their wallet addresses to send to them by name next time."),
+      screen.getByText("Save their wallet addresses to send to them by name next time"),
     ).toBeInTheDocument();
   });
 

--- a/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/ContactAddressDetailActions.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/ContactAddressDetailActions.native.tsx
@@ -7,6 +7,7 @@ type ContactAddressDetailActionsProps = Readonly<{
   labels: ContactAddressDetailDialogNativeLabels;
   hasCopied: boolean;
   onCopy: () => void;
+  onShare?: () => void;
   onSend?: () => void;
   onEdit?: () => void;
   onDelete?: () => void;
@@ -19,6 +20,7 @@ export function ContactAddressDetailActions({
   labels,
   hasCopied,
   onCopy,
+  onShare,
   onSend,
   onEdit,
   onDelete,
@@ -57,7 +59,14 @@ export function ContactAddressDetailActions({
         >
           {labels.edit}
         </TileButton>
-        <TileButton icon={Share} disabled isFull lx={{ flex: 1 }}>
+        <TileButton
+          icon={Share}
+          disabled={!onShare}
+          onPress={onShare}
+          isFull
+          lx={{ flex: 1 }}
+          testID="contacts-address-detail-share"
+        >
           {labels.share}
         </TileButton>
         <TileButton

--- a/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/ContactAddressDetailDialog.native.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/ContactAddressDetailDialog.native.test.tsx
@@ -101,6 +101,15 @@ describe("ContactAddressDetailDialog", () => {
     });
   });
 
+  it("should share the selected address when sharing is available", () => {
+    const onShareAddress = jest.fn();
+    render(<ContactAddressDetailDialog {...createProps({ onShareAddress })} />);
+
+    fireEvent.press(screen.getByTestId("contacts-address-detail-share"));
+
+    expect(onShareAddress).toHaveBeenCalledWith("0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034");
+  });
+
   it("should render nothing when row or network is missing", () => {
     render(<ContactAddressDetailDialog {...createProps({ row: undefined })} />);
 

--- a/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/ContactAddressDetailDialog.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/ContactAddressDetailDialog.native.tsx
@@ -15,6 +15,7 @@ export function ContactAddressDetailDialog({
   labels,
   bottomInset = 0,
   onCopyAddress,
+  onShareAddress,
   onSend,
   onEdit,
   onDelete,
@@ -22,11 +23,12 @@ export function ContactAddressDetailDialog({
   canEdit = false,
   canDelete = false,
 }: ContactAddressDetailDialogNativeProps): React.JSX.Element {
-  const { hasSelection, hasCopied, onCopy } = useContactAddressDetailDialogViewModel({
+  const { hasSelection, hasCopied, onCopy, onShare } = useContactAddressDetailDialogViewModel({
     isOpen,
     row,
     network,
     onCopyAddress,
+    onShareAddress,
   });
 
   return (
@@ -47,6 +49,7 @@ export function ContactAddressDetailDialog({
               labels={labels}
               hasCopied={hasCopied}
               onCopy={onCopy}
+              onShare={onShare}
               onSend={onSend}
               onEdit={onEdit}
               onDelete={onDelete}

--- a/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/types.ts
+++ b/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/types.ts
@@ -38,4 +38,5 @@ export type ContactAddressDetailDialogNativeProps = Omit<
     labels: ContactAddressDetailDialogNativeLabels;
     bottomInset?: number;
     onCopyAddress?: (address: string) => void;
+    onShareAddress?: (address: string) => void;
   }>;

--- a/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/useContactAddressDetailDialogViewModel.native.ts
+++ b/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/useContactAddressDetailDialogViewModel.native.ts
@@ -5,13 +5,14 @@ const COPY_FEEDBACK_MS = 3000;
 
 type ContactAddressDetailDialogViewModelInput = Pick<
   ContactAddressDetailDialogNativeProps,
-  "isOpen" | "row" | "network" | "onCopyAddress"
+  "isOpen" | "row" | "network" | "onCopyAddress" | "onShareAddress"
 >;
 
 export type ContactAddressDetailDialogViewModel = Readonly<{
   hasSelection: boolean;
   hasCopied: boolean;
   onCopy: () => void;
+  onShare: (() => void) | undefined;
 }>;
 
 export function useContactAddressDetailDialogViewModel({
@@ -19,6 +20,7 @@ export function useContactAddressDetailDialogViewModel({
   row,
   network,
   onCopyAddress,
+  onShareAddress,
 }: ContactAddressDetailDialogViewModelInput): ContactAddressDetailDialogViewModel {
   const [hasCopied, setHasCopied] = useState(false);
 
@@ -47,11 +49,20 @@ export function useContactAddressDetailDialogViewModel({
     setHasCopied(true);
   }, [onCopyAddress, row]);
 
+  const onShare = useCallback(() => {
+    if (row === undefined || onShareAddress === undefined) {
+      return;
+    }
+
+    onShareAddress(row.address);
+  }, [onShareAddress, row]);
+
   const hasSelection = isOpen && row !== undefined && network !== undefined;
 
   return {
     hasSelection,
     hasCopied,
     onCopy,
+    onShare: onShareAddress === undefined ? undefined : onShare,
   };
 }


### PR DESCRIPTION
### 📝 Description

Fixes three regressions found during the Contacts LWM/LWD testing session.

- [LIVE-35868](https://ledgerhq.atlassian.net/browse/LIVE-35868) — On Mobile, the Share action in a saved address detail was permanently disabled. The selected address is now passed to the native sharing sheet.
- [LIVE-35870](https://ledgerhq.atlassian.net/browse/LIVE-35870) — On Desktop, the saved-contact empty-state description ended with an extra period. The final period has been removed.
- [LIVE-35871](https://ledgerhq.atlassian.net/browse/LIVE-35871) — The saved-contact empty state used different copy on Mobile and Desktop. Mobile now uses the same English title and description as Desktop:

  - No saved addresses for Benoit
  - Save their wallet addresses to send to them by name next time

The shared native Contacts dialog only exposes a share callback; the Mobile app owns the React Native sharing side effect. This keeps the shared Flow component platform-agnostic while allowing the Share action to be enabled only where native sharing is available.

### ✅ Validation

- Focused Contacts Flow tests: 3 suites passed, 19 tests passed.
- Mobile and Desktop lint passed.
- Mobile/Desktop integration tests and typechecks could not run locally because unrelated workspace exports were missing from the checkout: Pay Card, Platform Feature Flags and Device Core.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35868](https://ledgerhq.atlassian.net/browse/LIVE-35868), [LIVE-35870](https://ledgerhq.atlassian.net/browse/LIVE-35870), [LIVE-35871](https://ledgerhq.atlassian.net/browse/LIVE-35871)
- **ADR** (if any): None


[LIVE-35868]: https://ledgerhq.atlassian.net/browse/LIVE-35868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-35870]: https://ledgerhq.atlassian.net/browse/LIVE-35870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-35871]: https://ledgerhq.atlassian.net/browse/LIVE-35871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-35868]: https://ledgerhq.atlassian.net/browse/LIVE-35868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ