### PR TITLE
feat(pay-card): add request receive VM (LIVE-36119)

### DIFF
--- a/.changeset/LIVE-36119-pay-card-request-vm.md
+++ b/.changeset/LIVE-36119-pay-card-request-vm.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-pay-card-request": minor
+---
+
+Add the shared, pure Pay Card Request receive view-model `useRequestReceiveViewModel` to `@features/flow-pay-card-request`: it formats the injected asset/network/address into display data (split address parts, QR payload) and wraps the host-owned share/copy/save/verify callbacks with `button_clicked` tracking via the injected `onTrackEvent`. No Redux, navigation, device I/O, i18n or domain dependencies.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -131,10 +131,6 @@ features/flow/pay-card-deposit/                          @ledgerhq/wallet-xp
 features/flow/pay-card-feature-tour/                     @ledgerhq/wallet-xp
 features/flow/pay-card-request/                          @ledgerhq/wallet-xp
 
-features/platform/card/                                  @ledgerhq/wallet-xp
-domain/api/card-management/                              @ledgerhq/wallet-xp
-/shared/api-services/src/services/card/                  @ledgerhq/wallet-xp
-
 # Wallet — shared UI
 /shared/ui-queued-bottom-sheet/                          @ledgerhq/wallet-xp
 

--- a/features/flow/pay-card-request/README.md
+++ b/features/flow/pay-card-request/README.md
@@ -1,17 +1,47 @@
 # Pay Card Request
 
 > [!CAUTION]
-> **Status: UNSTABLE** — Scaffold only; public API is still being designed.
+> **Status: UNSTABLE** — In active development; API may change.
 
-Dual-platform flow package that will host the Pay tab **Request receive-screen** experience for
-Ledger Wallet: a shared view-model and receive-screen component (QR, truncated address, action
-slot, shareable card) consumed by the platform presentations on desktop and mobile.
+Dual-platform flow package for the Pay tab **Request receive-screen** experience for Ledger Wallet:
+a shared view-model and (soon) receive-screen component (QR, highlighted address, action slot,
+shareable card) consumed by the platform presentations on desktop and mobile.
 
-## Scope
+## View-model
 
-The receive-screen view-model and component land in
-[LIVE-35187](https://ledgerhq.atlassian.net/browse/LIVE-35187) and its platform tickets
-(LIVE-35188 / LIVE-35189). The first shipped surface is the **VerifyAddress** overlay.
+`useRequestReceiveViewModel` is pure and platform-agnostic: no Redux, navigation, device I/O, i18n
+or domain dependencies. The host resolves the selected account into primitives and injects the
+action side effects; the view-model formats display data and wraps each action with tracking.
+
+```tsx
+import { useRequestReceiveViewModel } from "@features/flow-pay-card-request";
+
+const vm = useRequestReceiveViewModel({
+  address,
+  asset: { name: "Ethereum", ticker: "ETH" },
+  network: "Ethereum",
+  page: "Pay",
+  onShare: shareCard,
+  onCopy: copyToClipboard,
+  onSave: saveCardImage,
+  onVerify: verifyOnDevice,
+  onTrackEvent: track,
+});
+
+// vm.asset, vm.network, vm.address, vm.addressParts, vm.qrPayload
+// vm.onShare(), vm.onCopy(), vm.onSave(), vm.onVerify()  ← argument-less, tracked
+```
+
+The host owns the actual work behind each callback (clipboard, share sheet, card-to-image, device
+address verification). Navigation and account selection stay in the app.
+
+`addressParts` is `{ start, middle, end }` (8 + middle + 8) so the UI can highlight the edges
+without masking the middle.
+
+### Tracking
+
+Each action emits `button_clicked { button, buttonLocation: "request", page }` via the injected
+`onTrackEvent`, where `button` is `share` | `copy address` | `save` | `verify on device`.
 
 ## Components
 
@@ -47,8 +77,8 @@ import { VerifyAddress } from "@features/flow-pay-card-request";
 
 ## Platform resolution
 
-Only views carry a platform suffix (`.web` / `.native`). The container, view-model, and types stay
-platform-agnostic and import without a suffix; TypeScript `moduleSuffixes`, the bundlers
+Only views carry a platform suffix (`.web` / `.native`). The container, view-model, types and utils
+are platform-agnostic and import without a suffix; TypeScript `moduleSuffixes`, the bundlers
 (Rspack / Metro) and the jest preset resolve the right side.
 
 ## Structure
@@ -59,11 +89,17 @@ Every `index.*` is a pure barrel (`export *` only).
 pay-card-request/
 ├── package.json
 └── src/
-    ├── index.ts          # Public API barrel (web/default)
-    ├── index.native.ts   # Public API barrel (native)
-    ├── exports.ts        # Shared barrel re-exported by both platforms
-    ├── types.ts          # Platform-agnostic props/labels contract
+    ├── index.ts                                # Public API barrel (web/default) → ./exports
+    ├── index.native.ts                         # Native public API barrel → ./exports
+    ├── exports.ts                              # Shared public surface (VM + component + utils + types)
+    ├── types.ts                                # VM params/return + props/labels contracts
+    ├── utils/
+    │   ├── splitAddress.ts
+    │   └── __tests__/
     └── components/
+        ├── RequestReceive/
+        │   ├── useRequestReceiveViewModel.ts   # pure VM: display data + tracked handlers
+        │   └── __tests__/
         └── VerifyAddress/
             ├── VerifyAddress.tsx                  # Container; switches phase
             ├── useVerifyAddressViewModel.ts       # Presentation logic + tracking

--- a/features/flow/pay-card-request/package.json
+++ b/features/flow/pay-card-request/package.json
@@ -2,7 +2,7 @@
   "name": "@features/flow-pay-card-request",
   "version": "0.1.0",
   "private": true,
-  "description": "Pay Card request flow for Ledger Wallet (scaffold)",
+  "description": "Pay Card request flow for Ledger Wallet",
   "main": "src/index.ts",
   "react-native": "src/index.native.ts",
   "types": "src/index.ts",

--- a/features/flow/pay-card-request/src/components/RequestReceive/__tests__/useRequestReceiveViewModel.web.test.ts
+++ b/features/flow/pay-card-request/src/components/RequestReceive/__tests__/useRequestReceiveViewModel.web.test.ts
@@ -1,0 +1,63 @@
+import { renderHook } from "@testing-library/react";
+import type { RequestReceiveViewModelParams } from "../../../types";
+import { useRequestReceiveViewModel } from "../useRequestReceiveViewModel";
+
+const ADDRESS = "0x1234567890abcdef1234567890abcdef";
+
+function setup(overrides: Partial<RequestReceiveViewModelParams> = {}) {
+  const props: RequestReceiveViewModelParams = {
+    address: ADDRESS,
+    asset: { name: "Ethereum", ticker: "ETH" },
+    network: "Ethereum",
+    page: "Pay",
+    onShare: jest.fn(),
+    onCopy: jest.fn(),
+    onSave: jest.fn(),
+    onVerify: jest.fn(),
+    onTrackEvent: jest.fn(),
+    ...overrides,
+  };
+  const { result } = renderHook(() => useRequestReceiveViewModel(props));
+  return { props, result };
+}
+
+describe("useRequestReceiveViewModel", () => {
+  it("exposes asset, network, address, address parts and QR payload", () => {
+    const { result } = setup();
+
+    expect(result.current.asset).toEqual({ name: "Ethereum", ticker: "ETH" });
+    expect(result.current.network).toBe("Ethereum");
+    expect(result.current.address).toBe(ADDRESS);
+    expect(result.current.addressParts).toEqual({
+      start: "0x123456",
+      middle: "7890abcdef12345678",
+      end: "90abcdef",
+    });
+    expect(result.current.qrPayload).toBe(ADDRESS);
+  });
+
+  it.each([
+    ["onShare", "share"],
+    ["onCopy", "copy address"],
+    ["onSave", "save"],
+    ["onVerify", "verify on device"],
+  ] as const)("tracks then invokes the injected callback for %s", (handler, button) => {
+    const { props, result } = setup();
+
+    result.current[handler]();
+
+    expect(props.onTrackEvent).toHaveBeenCalledWith("button_clicked", {
+      button,
+      buttonLocation: "request",
+      page: "Pay",
+    });
+    expect(props[handler]).toHaveBeenCalledWith(ADDRESS);
+  });
+
+  it("does not throw when no tracker is provided", () => {
+    const { props, result } = setup({ onTrackEvent: undefined });
+
+    expect(() => result.current.onCopy()).not.toThrow();
+    expect(props.onCopy).toHaveBeenCalledWith(ADDRESS);
+  });
+});

--- a/features/flow/pay-card-request/src/components/RequestReceive/useRequestReceiveViewModel.ts
+++ b/features/flow/pay-card-request/src/components/RequestReceive/useRequestReceiveViewModel.ts
@@ -1,0 +1,57 @@
+import { useCallback, useMemo } from "react";
+import type { RequestReceiveViewModel, RequestReceiveViewModelParams } from "../../types";
+import { splitAddress } from "../../utils/splitAddress";
+
+type RequestActionId = "share" | "copy" | "save" | "verify";
+
+// Analytics button names per the Pay Tracking Plan (wording still to confirm with product).
+const TRACK_BUTTON: Readonly<Record<RequestActionId, string>> = {
+  share: "share",
+  copy: "copy address",
+  save: "save",
+  verify: "verify on device",
+};
+
+export function useRequestReceiveViewModel({
+  address,
+  asset,
+  network,
+  page,
+  onShare,
+  onCopy,
+  onSave,
+  onVerify,
+  onTrackEvent,
+}: RequestReceiveViewModelParams): RequestReceiveViewModel {
+  const addressParts = useMemo(() => splitAddress(address), [address]);
+
+  const runAction = useCallback(
+    (id: RequestActionId, callback: (address: string) => void) => {
+      onTrackEvent?.("button_clicked", {
+        button: TRACK_BUTTON[id],
+        buttonLocation: "request",
+        page,
+      });
+      callback(address);
+    },
+    [address, page, onTrackEvent],
+  );
+
+  const handleShare = useCallback(() => runAction("share", onShare), [runAction, onShare]);
+  const handleCopy = useCallback(() => runAction("copy", onCopy), [runAction, onCopy]);
+  const handleSave = useCallback(() => runAction("save", onSave), [runAction, onSave]);
+  const handleVerify = useCallback(() => runAction("verify", onVerify), [runAction, onVerify]);
+
+  return {
+    asset,
+    network,
+    address,
+    addressParts,
+    // Plain address payload for now; a URI scheme (amount/label) can be layered in later if needed.
+    qrPayload: address,
+    onShare: handleShare,
+    onCopy: handleCopy,
+    onSave: handleSave,
+    onVerify: handleVerify,
+  };
+}

--- a/features/flow/pay-card-request/src/exports.ts
+++ b/features/flow/pay-card-request/src/exports.ts
@@ -1,3 +1,5 @@
 export * from "./components/VerifyAddress/VerifyAddress";
 export * from "./components/VerifyAddress/useVerifyAddressViewModel";
+export * from "./components/RequestReceive/useRequestReceiveViewModel";
+export * from "./utils/splitAddress";
 export * from "./types";

--- a/features/flow/pay-card-request/src/types.ts
+++ b/features/flow/pay-card-request/src/types.ts
@@ -1,3 +1,5 @@
+import type { AddressParts } from "./utils/splitAddress";
+
 export type PayCardTrackEvent = (event: string, params: Record<string, unknown>) => void;
 
 export type VerifyAddressPhase = "hidden" | "intro" | "success";
@@ -63,4 +65,40 @@ export type VerifyAddressSuccessViewProps = Readonly<{
   gotItCta: string;
   onGotIt: () => void;
   onClose: () => void;
+}>;
+
+/**
+ * Display data for the requested asset.
+ */
+export type RequestReceiveAsset = Readonly<{
+  name: string;
+  ticker: string;
+}>;
+
+export type RequestActionCallbacks = Readonly<{
+  onShare: (address: string) => void;
+  onCopy: (address: string) => void;
+  onSave: (address: string) => void;
+  onVerify: (address: string) => void;
+}>;
+
+export type RequestReceiveViewModelParams = RequestActionCallbacks &
+  Readonly<{
+    address: string;
+    asset: RequestReceiveAsset;
+    network: string;
+    page: string;
+    onTrackEvent?: PayCardTrackEvent;
+  }>;
+
+export type RequestReceiveViewModel = Readonly<{
+  asset: RequestReceiveAsset;
+  network: string;
+  address: string;
+  addressParts: AddressParts;
+  qrPayload: string;
+  onShare: () => void;
+  onCopy: () => void;
+  onSave: () => void;
+  onVerify: () => void;
 }>;

--- a/features/flow/pay-card-request/src/utils/__tests__/splitAddress.web.test.ts
+++ b/features/flow/pay-card-request/src/utils/__tests__/splitAddress.web.test.ts
@@ -1,0 +1,36 @@
+import { splitAddress } from "../splitAddress";
+
+describe("splitAddress", () => {
+  it("splits first and last 8 characters for highlighting", () => {
+    expect(splitAddress("0xe4912d2d1234567890abcdef40517672")).toEqual({
+      start: "0xe4912d",
+      middle: "2d1234567890abcdef",
+      end: "40517672",
+    });
+  });
+
+  it("respects a custom edge", () => {
+    expect(splitAddress("0x1234567890abcdef", 4)).toEqual({
+      start: "0x12",
+      middle: "34567890ab",
+      end: "cdef",
+    });
+  });
+
+  it("returns the full address as start when too short to split", () => {
+    expect(splitAddress("0x1234")).toEqual({ start: "0x1234", middle: "", end: "" });
+    expect(splitAddress("abcdefghijklmnop", 8)).toEqual({
+      start: "abcdefghijklmnop",
+      middle: "",
+      end: "",
+    });
+  });
+
+  it("returns the full address as start when edge is non-positive", () => {
+    expect(splitAddress("0x1234567890abcdef", 0)).toEqual({
+      start: "0x1234567890abcdef",
+      middle: "",
+      end: "",
+    });
+  });
+});

--- a/features/flow/pay-card-request/src/utils/splitAddress.ts
+++ b/features/flow/pay-card-request/src/utils/splitAddress.ts
@@ -1,0 +1,19 @@
+const DEFAULT_EDGE = 8;
+
+export type AddressParts = Readonly<{
+  start: string;
+  middle: string;
+  end: string;
+}>;
+
+export function splitAddress(address: string, edge: number = DEFAULT_EDGE): AddressParts {
+  if (edge <= 0 || address.length <= edge * 2) {
+    return { start: address, middle: "", end: "" };
+  }
+
+  return {
+    start: address.slice(0, edge),
+    middle: address.slice(edge, -edge),
+    end: address.slice(-edge),
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24685,7 +24685,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.1.4
       react-dom: 19.1.4
-      webpack: '*'
+      webpack: ^5.89.0
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -67920,7 +67920,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3
+      metro: 0.83.3(metro-transform-worker@0.83.3)
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -68044,6 +68044,54 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.83.3(metro-transform-worker@0.83.3):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.28.5
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 1.3.8
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.32.0
+      image-size: 1.1.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0(metro@0.83.3)
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.3
+      metro-cache: 0.83.3
+      metro-cache-key: 0.83.3
+      metro-config: 0.83.3(metro-transform-worker@0.83.3)
+      metro-core: 0.83.3
+      metro-file-map: 0.83.3(metro@0.83.3)
+      metro-resolver: 0.83.3
+      metro-runtime: 0.83.3
+      metro-source-map: 0.83.3
+      metro-symbolicate: 0.83.3
+      metro-transform-plugins: 0.83.3
+      metro-transform-worker: 0.83.3
+      mime-types: 2.1.35
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
### 📝 Description

Adds the shared, pure **Request receive view-model** to `@features/flow-pay-card-request`, the first real code in the package after the scaffold.

**Problem**: the Pay tab Request (receive) flow needs a single, platform-agnostic source of truth for the receive-screen data and actions, shared by desktop and mobile.

**Solution**: `useRequestReceiveViewModel` takes host-injected primitives (address, asset, network) plus the action callbacks, and returns display data + argument-less, tracked handlers. It is pure: no Redux, navigation, device I/O, i18n or domain dependencies. The host owns the actual work behind each callback (clipboard, share sheet, card-to-image, device address verification) and account selection / navigation.

```tsx
import { useRequestReceiveViewModel } from "@features/flow-pay-card-request";

const vm = useRequestReceiveViewModel({
  address,
  asset: { name: "Ethereum", ticker: "ETH" },
  network: "Ethereum",
  page: "Pay",
  onShare, onCopy, onSave, onVerify,
  onTrackEvent: track,
});
// vm.asset, vm.network, vm.address, vm.addressParts, vm.qrPayload
// vm.onShare(), vm.onCopy(), vm.onSave(), vm.onVerify()  ← tracked
```

- `addressParts` is `{ start, middle, end }` so the UI can highlight the edges.
- Each action emits `button_clicked { button, buttonLocation: "request", page }` via the injected `onTrackEvent`.
- Container/View land in LIVE-36120, QR web export in LIVE-36118, shareable card in LIVE-36121.

Covered by unit tests (VM + `splitAddress`), 100% coverage on the new files.

> [!NOTE]
> Stacked on top of the scaffold PR (base branch `feat/pay-card-LIVE-36094-scaffold-request-package`, LIVE-36094). Merge/rebase that first.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36119](https://ledgerhq.atlassian.net/browse/LIVE-36119)
- **ADR** (if any): n/a

[LIVE-36119]: https://ledgerhq.atlassian.net/browse/LIVE-36119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ