### PR TITLE
[LWM] feat(backup-hub): warn Recovery Key for Nano S SP X (LIVE-35485)

### DIFF
--- a/.changeset/amber-keys-warn.md
+++ b/.changeset/amber-keys-warn.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@features/flow-large-screen-upsell": patch
+---
+
+Warn Backup Hub Recovery Key for Nano S, SP and X and open the upgrade landing page

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -121,6 +121,7 @@
     "@features/flow-contacts-introduction": "workspace:^",
     "@features/flow-fear-and-greed": "workspace:^",
     "@features/flow-lazy-onboarding-banner": "workspace:^",
+    "@features/flow-large-screen-upsell": "workspace:^",
     "@features/platform-aggregated-assets": "workspace:*",
     "@features/platform-card": "workspace:*",
     "@features/platform-currencies": "workspace:^",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10120,7 +10120,8 @@
       },
       "recoveryKey": {
         "title": "Ledger Recovery Key",
-        "description": "A PIN-protected smart card."
+        "description": "A PIN-protected smart card.",
+        "incompatible": "Not compatible with your device"
       },
       "secretRecoveryPhrase": {
         "title": "24-word metal storage",

--- a/apps/ledger-live-mobile/src/mvvm/features/BackupHub/__integrations__/BackupHub.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/BackupHub/__integrations__/BackupHub.integration.test.tsx
@@ -2,6 +2,14 @@ import React from "react";
 import { Linking, Text } from "react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import type { DeviceModelInfo } from "@ledgerhq/types-live";
+import {
+  LARGE_SCREEN_UPSELL_BACKUPS_UTM_CONTENT,
+  LARGE_SCREEN_UPSELL_UTM_CAMPAIGN,
+  LARGE_SCREEN_UPSELL_UTM_MEDIUM,
+  LARGE_SCREEN_UPSELL_UTM_SOURCE_BY_PLATFORM,
+} from "@features/flow-large-screen-upsell/utils/upsellCta";
 import { render, screen, withFlagOverrides } from "@tests/test-renderer";
 import { screen as analyticsScreen, track } from "~/analytics";
 import { ScreenName } from "~/const";
@@ -16,6 +24,7 @@ import {
 } from "../analytics";
 import {
   BACKUP_HUB_RECOVER_DEEPLINK_QUERY,
+  BACKUP_HUB_TRACKING_BUTTON,
   BACKUP_HUB_TRACKING_PAGE_NAME,
   RECOVER_DEEPLINK_BASE,
 } from "../constants";
@@ -58,13 +67,40 @@ const seedSubscriptionState =
     },
   });
 
-const overrideWith = (subscriptionState: LedgerRecoverSubscriptionStateEnum) =>
+const NANO_UPSELL_DEVICE_MODEL = {
+  [DeviceModelId.nanoS]: "lns",
+  [DeviceModelId.nanoSP]: "lnsp",
+  [DeviceModelId.nanoX]: "lnx",
+} as const;
+
+const overrideWith = (
+  subscriptionState: LedgerRecoverSubscriptionStateEnum,
+  devicesModelList: DeviceModelId[] = [],
+  lastSeenModelId?: DeviceModelId,
+) =>
   withFlagOverrides(
     {
       lwmBackupHub: { enabled: true },
       protectServicesMobile: { enabled: true, params: { protectId: PROTECT_ID } },
     },
-    seedSubscriptionState(subscriptionState),
+    (state: State): State => {
+      const withSub = seedSubscriptionState(subscriptionState)(state);
+      const seenModelIds = lastSeenModelId
+        ? [...devicesModelList.filter(id => id !== lastSeenModelId), lastSeenModelId]
+        : devicesModelList;
+
+      return {
+        ...withSub,
+        settings: {
+          ...withSub.settings,
+          knownDeviceModelIds: {
+            ...withSub.settings.knownDeviceModelIds,
+            ...Object.fromEntries(devicesModelList.map(id => [id, true])),
+          },
+          seenDevices: seenModelIds.map(modelId => ({ modelId }) as DeviceModelInfo),
+        },
+      };
+    },
   );
 
 describe("BackupHub screen (mobile)", () => {
@@ -185,4 +221,99 @@ describe("BackupHub screen (mobile)", () => {
       page: BACKUP_HUB_TRACKING_PAGE_NAME,
     });
   });
+
+  it.each([DeviceModelId.nanoS, DeviceModelId.nanoSP, DeviceModelId.nanoX])(
+    "shows the Recovery Key warning copy for %s",
+    async deviceModelId => {
+      render(<BackupHubTestNavigator />, {
+        overrideInitialState: overrideWith(LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION, [
+          deviceModelId,
+        ]),
+      });
+
+      expect(await screen.findByText("Not compatible with your device")).toBeVisible();
+      expect(screen.queryByText("A PIN-protected smart card.")).toBeNull();
+    },
+  );
+
+  it("keeps the Recovery Key row unchanged when a large-screen device is known", async () => {
+    render(<BackupHubTestNavigator />, {
+      overrideInitialState: overrideWith(LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION, [
+        DeviceModelId.nanoS,
+        DeviceModelId.stax,
+      ]),
+    });
+
+    expect(await screen.findByText("A PIN-protected smart card.")).toBeVisible();
+    expect(screen.queryByText("Not compatible with your device")).toBeNull();
+  });
+
+  it("uses the last-seen nano for Recovery Key upsell analytics when several nanos are known", async () => {
+    jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
+
+    const { user } = render(<BackupHubTestNavigator />, {
+      overrideInitialState: overrideWith(
+        LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION,
+        [DeviceModelId.nanoS, DeviceModelId.nanoX],
+        DeviceModelId.nanoX,
+      ),
+    });
+
+    await user.press(await screen.findByTestId("backup-hub-physical-row-recovery-key"));
+
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({
+        button: BACKUP_HUB_TRACKING_BUTTON.recoveryKey,
+        deviceModel: NANO_UPSELL_DEVICE_MODEL[DeviceModelId.nanoX],
+      }),
+    );
+  });
+
+  it.each([DeviceModelId.nanoS, DeviceModelId.nanoSP, DeviceModelId.nanoX] as const)(
+    "opens the upsell LP with backups UTM when Recovery Key is clicked on %s",
+    async deviceModelId => {
+      const openURLSpy = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
+
+      const { user } = render(<BackupHubTestNavigator />, {
+        overrideInitialState: overrideWith(LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION, [
+          deviceModelId,
+        ]),
+      });
+
+      await user.press(await screen.findByTestId("backup-hub-physical-row-recovery-key"));
+
+      expect(openURLSpy).toHaveBeenCalledTimes(1);
+      const openedUrl = new URL(String(openURLSpy.mock.calls[0][0]));
+      expect(openedUrl.origin + openedUrl.pathname).toBe(
+        "https://shop.ledger.com/pages/ledger-nano-upgrade-program",
+      );
+      expect(openedUrl.searchParams.get("utm_source")).toBe(
+        LARGE_SCREEN_UPSELL_UTM_SOURCE_BY_PLATFORM.mobile,
+      );
+      expect(openedUrl.searchParams.get("utm_medium")).toBe(LARGE_SCREEN_UPSELL_UTM_MEDIUM);
+      expect(openedUrl.searchParams.get("utm_campaign")).toBe(LARGE_SCREEN_UPSELL_UTM_CAMPAIGN);
+      expect(openedUrl.searchParams.get("utm_content")).toBe(
+        LARGE_SCREEN_UPSELL_BACKUPS_UTM_CONTENT,
+      );
+      const upsellAnalyticsProps = {
+        deviceModel: NANO_UPSELL_DEVICE_MODEL[deviceModelId],
+        personalRecoOptIn: false,
+        offerType: "none",
+        platform: "lwm",
+      };
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: BACKUP_HUB_TRACKING_BUTTON.recoveryKey,
+        page: BACKUP_HUB_TRACKING_PAGE_NAME,
+        ...upsellAnalyticsProps,
+      });
+      expect(track).toHaveBeenCalledWith("deeplink_clicked", {
+        page: BACKUP_HUB_TRACKING_PAGE_NAME,
+        deeplinkSource: LARGE_SCREEN_UPSELL_UTM_SOURCE_BY_PLATFORM.mobile,
+        deeplinkMedium: LARGE_SCREEN_UPSELL_UTM_MEDIUM,
+        deeplinkCampaign: LARGE_SCREEN_UPSELL_UTM_CAMPAIGN,
+        ...upsellAnalyticsProps,
+      });
+    },
+  );
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/BackupHub/components/PhysicalBackupRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/BackupHub/components/PhysicalBackupRow.tsx
@@ -14,6 +14,7 @@ export type PhysicalBackupRowProps = {
   image: ImageSourcePropType;
   title: string;
   description: string;
+  isWarning?: boolean;
   onPress: () => void;
   testID?: string;
 };
@@ -22,6 +23,7 @@ export function PhysicalBackupRow({
   image,
   title,
   description,
+  isWarning = false,
   onPress,
   testID,
 }: Readonly<PhysicalBackupRowProps>) {
@@ -35,7 +37,9 @@ export function PhysicalBackupRow({
         />
         <ListItemContent>
           <ListItemTitle>{title}</ListItemTitle>
-          <ListItemDescription>{description}</ListItemDescription>
+          <ListItemDescription numberOfLines={2} lx={isWarning ? { color: "warning" } : undefined}>
+            {description}
+          </ListItemDescription>
         </ListItemContent>
       </ListItemLeading>
       <ListItemTrailing>

--- a/apps/ledger-live-mobile/src/mvvm/features/BackupHub/constants.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/BackupHub/constants.ts
@@ -2,6 +2,9 @@ import type { BackupBucket } from "./types";
 
 export const BACKUP_HUB_TRACKING_PAGE_NAME = "Backup hub";
 
+export const BACKUP_HUB_UPSELL_FALLBACK_LINK =
+  "https://shop.ledger.com/pages/ledger-nano-upgrade-program";
+
 export const BACKUP_HUB_TRACKING_BUTTON = {
   recover: "Ledger Recover",
   recoveryKey: "Ledger Recovery Key",

--- a/apps/ledger-live-mobile/src/mvvm/features/BackupHub/screens/BackupHubScreen/BackupHubScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/BackupHub/screens/BackupHubScreen/BackupHubScreenView.tsx
@@ -99,12 +99,17 @@ export function BackupHubScreenView({
               </SubheaderRow>
             </Subheader>
             <Box lx={{ backgroundColor: "surface", borderRadius: "lg", overflow: "hidden" }}>
-              {physicalRows.map(({ id, image, onPress }) => (
+              {physicalRows.map(({ id, image, isWarning, onPress }) => (
                 <PhysicalBackupRow
                   key={id}
                   image={image}
                   title={t(PHYSICAL_ROW_I18N[id].titleKey)}
-                  description={t(PHYSICAL_ROW_I18N[id].descriptionKey)}
+                  description={t(
+                    isWarning
+                      ? "myWallet.backupHub.recoveryKey.incompatible"
+                      : PHYSICAL_ROW_I18N[id].descriptionKey,
+                  )}
+                  isWarning={isWarning}
                   onPress={onPress}
                   testID={`backup-hub-physical-row-${id}`}
                 />

--- a/apps/ledger-live-mobile/src/mvvm/features/BackupHub/screens/BackupHubScreen/useBackupHubScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/BackupHub/screens/BackupHubScreen/useBackupHubScreenViewModel.ts
@@ -1,11 +1,30 @@
 import { useCallback, useMemo } from "react";
 import { Linking, type ImageSourcePropType } from "react-native";
+import { getNanoOnlyDeviceModel } from "@features/flow-large-screen-upsell/utils/getNanoOnlyDeviceModel";
+import {
+  LARGE_SCREEN_UPSELL_BACKUPS_UTM_CONTENT,
+  LARGE_SCREEN_UPSELL_UTM_CAMPAIGN,
+  LARGE_SCREEN_UPSELL_UTM_MEDIUM,
+  LARGE_SCREEN_UPSELL_UTM_SOURCE_BY_PLATFORM,
+  buildLargeScreenUpsellCtaLink,
+} from "@features/flow-large-screen-upsell/utils/upsellCta";
+import { useFeature } from "@features/platform-feature-flags";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import {
+  toLargeScreenUpsellDeviceModelAnalyticsValue,
+  type LargeScreenUpsellNanoDeviceModelId,
+} from "LLM/features/LargeScreenUpsell/analytics";
 import { track } from "~/analytics";
 import useRecoverBannerState from "LLM/features/Portfolio/hooks/useRecoverBannerState";
 import { useRecoverEntry } from "LLM/hooks/useRecoverEntry";
 import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
-import { useDispatch } from "~/context/hooks";
+import { useDispatch, useSelector } from "~/context/hooks";
 import { openBackupHubFeatureIntro } from "~/reducers/backupHubFeatureIntro";
+import {
+  knownDeviceModelIdsSelector,
+  lastSeenDeviceSelector,
+  personalizedRecommendationsEnabledSelector,
+} from "~/reducers/settings";
 import { urls } from "~/utils/urls";
 import { getBackupBucket } from "../../utils/getBackupBucket";
 import {
@@ -13,6 +32,7 @@ import {
   BACKUP_HUB_TRACKING_PAGE_NAME,
   BACKUP_HUB_RECOVER_DEEPLINK_QUERY,
   BACKUP_HUB_RECOVER_TRACKING_STATUS,
+  BACKUP_HUB_UPSELL_FALLBACK_LINK,
   RECOVER_DEEPLINK_BASE,
 } from "../../constants";
 import type { BackupBucket, PhysicalRowId } from "../../types";
@@ -22,6 +42,7 @@ import secretRecoveryPhraseImage from "../../assets/24-words.webp";
 export type PhysicalRowData = {
   id: PhysicalRowId;
   image: ImageSourcePropType;
+  isWarning: boolean;
   onPress: () => void;
 };
 
@@ -42,6 +63,29 @@ export function useBackupHubScreenViewModel(): BackupHubScreenViewModel {
   const recoveryKeyUrl = useLocalizedUrl(urls.backupHub.recoveryKey);
   const secretRecoveryPhraseUrl = useLocalizedUrl(urls.backupHub.secretRecoveryPhrase);
   const compareAllUrl = useLocalizedUrl(urls.backupHub.compareAll);
+
+  const knownDeviceModelIds = useSelector(knownDeviceModelIdsSelector);
+  const lastSeenDevice = useSelector(lastSeenDeviceSelector);
+  const personalRecoOptIn = useSelector(personalizedRecommendationsEnabledSelector);
+  const largeScreenUpsell = useFeature("largeScreenUpsell");
+
+  const devicesModelList = useMemo(
+    () =>
+      (Object.keys(knownDeviceModelIds) as DeviceModelId[]).filter(id => knownDeviceModelIds[id]),
+    [knownDeviceModelIds],
+  );
+
+  const incompatibleModel = getNanoOnlyDeviceModel(devicesModelList, lastSeenDevice?.modelId);
+
+  const upsellLink = useMemo(() => {
+    const variant = personalRecoOptIn ? "opted_in" : "opted_out";
+    const configuredLink = largeScreenUpsell?.params?.[variant].link?.trim();
+    return buildLargeScreenUpsellCtaLink(
+      configuredLink || BACKUP_HUB_UPSELL_FALLBACK_LINK,
+      "mobile",
+      LARGE_SCREEN_UPSELL_BACKUPS_UTM_CONTENT,
+    );
+  }, [largeScreenUpsell?.params, personalRecoOptIn]);
 
   const onRecoverPress = useCallback(() => {
     markRecoverSeen();
@@ -75,21 +119,53 @@ export function useBackupHubScreenViewModel(): BackupHubScreenViewModel {
     openShop(compareAllUrl, BACKUP_HUB_TRACKING_BUTTON.compare);
   }, [openShop, compareAllUrl]);
 
+  const onRecoveryKeyPress = useCallback(() => {
+    if (!incompatibleModel) {
+      openShop(recoveryKeyUrl, BACKUP_HUB_TRACKING_BUTTON.recoveryKey);
+      return;
+    }
+
+    const sharedProps = {
+      deviceModel: toLargeScreenUpsellDeviceModelAnalyticsValue(
+        incompatibleModel as LargeScreenUpsellNanoDeviceModelId,
+      ),
+      personalRecoOptIn,
+      offerType: personalRecoOptIn ? ("discount" as const) : ("none" as const),
+      platform: "lwm" as const,
+    };
+
+    track("button_clicked", {
+      button: BACKUP_HUB_TRACKING_BUTTON.recoveryKey,
+      page: BACKUP_HUB_TRACKING_PAGE_NAME,
+      ...sharedProps,
+    });
+    track("deeplink_clicked", {
+      page: BACKUP_HUB_TRACKING_PAGE_NAME,
+      deeplinkSource: LARGE_SCREEN_UPSELL_UTM_SOURCE_BY_PLATFORM.mobile,
+      deeplinkMedium: LARGE_SCREEN_UPSELL_UTM_MEDIUM,
+      deeplinkCampaign: LARGE_SCREEN_UPSELL_UTM_CAMPAIGN,
+      ...sharedProps,
+    });
+    Linking.openURL(upsellLink);
+  }, [incompatibleModel, openShop, personalRecoOptIn, recoveryKeyUrl, upsellLink]);
+
   const physicalRows = useMemo<readonly PhysicalRowData[]>(
     () => [
       {
         id: "recovery-key",
         image: recoveryKeyImage,
-        onPress: () => openShop(recoveryKeyUrl, BACKUP_HUB_TRACKING_BUTTON.recoveryKey),
+        isWarning: incompatibleModel !== undefined,
+        onPress: onRecoveryKeyPress,
       },
       {
         id: "secret-recovery-phrase",
         image: secretRecoveryPhraseImage,
+        isWarning: false,
         onPress: () =>
           openShop(secretRecoveryPhraseUrl, BACKUP_HUB_TRACKING_BUTTON.secretRecoveryPhrase),
       },
     ],
-    [openShop, recoveryKeyUrl, secretRecoveryPhraseUrl],
+    [incompatibleModel, onRecoveryKeyPress, openShop, secretRecoveryPhraseUrl],
   );
 
   return {

--- a/features/flow/large-screen-upsell/package.json
+++ b/features/flow/large-screen-upsell/package.json
@@ -7,6 +7,8 @@
   "types": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./utils/getNanoOnlyDeviceModel": "./src/utils/getNanoOnlyDeviceModel.ts",
+    "./utils/upsellCta": "./src/utils/upsellCta.ts",
     "./schema.mock": "./src/state/schema.mock.ts",
     "./package.json": "./package.json"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1725,6 +1725,9 @@ importers:
       '@features/flow-fear-and-greed':
         specifier: workspace:^
         version: link:../../features/flow/fear-and-greed
+      '@features/flow-large-screen-upsell':
+        specifier: workspace:^
+        version: link:../../features/flow/large-screen-upsell
       '@features/flow-lazy-onboarding-banner':
         specifier: workspace:^
         version: link:../../features/flow/lazy-onboarding-banner


### PR DESCRIPTION
### 📝 Description

On Nano S, Nano SP, and Nano X, Ledger Recovery Key is not available, but Backup Hub still treated that row like a normal shop CTA.

This personalises the existing Recovery Key row (no new banner, no feature flag):

- Warning copy: **Not compatible with your device** (row stays visible and tappable)
- CTA opens the Nano upgrade landing page via `buildLargeScreenUpsellCtaLink`, with `utm_source=ledger_wallet_mobile`, `utm_medium=ledger_live`, `utm_campaign=nano_upgrade_program`, `utm_content=backups_cta`
- Compatible / large-screen owners keep the original copy and Recovery Key shop URL
- Analytics keep page `Backup hub` and button `Ledger Recovery Key`; the Nano path adds shared upsell props plus `deeplink_clicked`

Helpers are imported from `@features/flow-large-screen-upsell/utils/*` so mobile does not load the web modal barrel.

<img width="35%" height="2400" alt="Screenshot_20260819-191645" src="https://github.com/user-attachments/assets/24c9d4c2-18b2-4791-a491-07f39abae414" />

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35485](https://ledgerhq.atlassian.net/browse/LIVE-35485)
- **Desktop twin**: [LIVE-35484](https://ledgerhq.atlassian.net/browse/LIVE-35484)
- **Figma**: [Large touchscreen upsell program](https://www.figma.com/design/5cl7T8upzeVpwRTpNMZIDL/Large-touchscreen-upsell-program?node-id=1-119969&m=dev)

### Test plan

- [x] Nano S / SP / X only: Recovery Key row shows “Not compatible with your device” and is still tappable
- [x] Tapping it opens `https://shop.ledger.com/pages/ledger-nano-upgrade-program` with the backups UTM above
- [ ] A known Stax / Flex / Apex (even with a Nano) keeps the original copy and Recovery Key shop URL
- [ ] With several Nanos, last-seen model is used for `deviceModel` (`lns` / `lnsp` / `lnx`)
- [ ] `button_clicked` and `deeplink_clicked` fire with `platform: lwm`, `offerType`, `personalRecoOptIn`
- [ ] QA debug tool: flip `knownDeviceModelIds` between Nano-only and large-screen

[LIVE-35485]: https://ledgerhq.atlassian.net/browse/LIVE-35485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ