### PR TITLE
feat(pay-card): add verify address UI to request flow (LIVE-36133)

### DIFF
--- a/features/flow/pay-card-request/README.md
+++ b/features/flow/pay-card-request/README.md
@@ -9,15 +9,46 @@ slot, shareable card) consumed by the platform presentations on desktop and mobi
 
 ## Scope
 
-This package is currently an **empty scaffold** created in
-[LIVE-36094](https://ledgerhq.atlassian.net/browse/LIVE-36094). The receive-screen view-model and
-component land in [LIVE-35187](https://ledgerhq.atlassian.net/browse/LIVE-35187) and its platform
-tickets (LIVE-35188 / LIVE-35189). Until then the barrels only expose a compile-only placeholder.
+The receive-screen view-model and component land in
+[LIVE-35187](https://ledgerhq.atlassian.net/browse/LIVE-35187) and its platform tickets
+(LIVE-35188 / LIVE-35189). The first shipped surface is the **VerifyAddress** overlay.
+
+## Components
+
+### `VerifyAddress`
+
+On-device address-verification overlay used by the Pay Request receive screen. It renders two
+phases and stays i18n-, analytics- and device-agnostic — the host app injects copy, tracking and
+owns the device interaction:
+
+- `intro` — "Verify your address" sheet/dialog with the **Verify address** CTA. Pressing it calls
+  `onVerify`, which the app wires to the shared `verifyAddressIntent` device intent (DIE lives in the
+  app, never in this package).
+- `success` — "Address displayed on the device's Secure Screen" with the numbered **Next steps** and
+  a **Got it** CTA (`onGotIt`).
+
+The `executing` device phase (connect / open app / waiting) is rendered by the app's own
+`DeviceIntentExecutor` host, not by this package. The host drives the `phase` prop
+(`hidden` → `intro` → `success`).
+
+```tsx
+import { VerifyAddress } from "@features/flow-pay-card-request";
+
+<VerifyAddress
+  phase={phase}
+  labels={labels}
+  page="Pay"
+  onVerify={startDeviceIntent}
+  onGotIt={close}
+  onClose={close}
+  onTrackEvent={track}
+/>;
+```
 
 ## Platform resolution
 
-Only views will carry a platform suffix (`.web` / `.native`). The container, view-model, and types
-stay platform-agnostic and import without a suffix; TypeScript `moduleSuffixes`, the bundlers
+Only views carry a platform suffix (`.web` / `.native`). The container, view-model, and types stay
+platform-agnostic and import without a suffix; TypeScript `moduleSuffixes`, the bundlers
 (Rspack / Metro) and the jest preset resolve the right side.
 
 ## Structure
@@ -30,5 +61,15 @@ pay-card-request/
 └── src/
     ├── index.ts          # Public API barrel (web/default)
     ├── index.native.ts   # Public API barrel (native)
-    └── placeholder.ts    # Compile-only placeholder (removed once real exports land)
+    ├── exports.ts        # Shared barrel re-exported by both platforms
+    ├── types.ts          # Platform-agnostic props/labels contract
+    └── components/
+        └── VerifyAddress/
+            ├── VerifyAddress.tsx                  # Container; switches phase
+            ├── useVerifyAddressViewModel.ts       # Presentation logic + tracking
+            ├── VerifyAddressIntroView.web.tsx     # Dialog (LWD)
+            ├── VerifyAddressIntroView.native.tsx  # BottomSheet (LWM)
+            ├── VerifyAddressSuccessView.web.tsx
+            ├── VerifyAddressSuccessView.native.tsx
+            └── __tests__/
 ```

--- a/features/flow/pay-card-request/package.json
+++ b/features/flow/pay-card-request/package.json
@@ -27,13 +27,25 @@
     "coverage": "jest --coverage",
     "unimported": "pnpm knip --directory ../../.. -W features/flow/pay-card-request"
   },
+  "dependencies": {
+    "@shared/ui-queued-bottom-sheet": "workspace:*"
+  },
   "devDependencies": {
+    "@features/platform-style": "workspace:*",
+    "@ledgerhq/lumen-design-core": "catalog:",
+    "@ledgerhq/lumen-ui-react": "catalog:",
+    "@ledgerhq/lumen-ui-rnative": "catalog:",
     "@support/jest-features-flow": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
+    "@testing-library/dom": "catalog:",
     "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
+    "@testing-library/react-native": "catalog:",
+    "@testing-library/user-event": "catalog:",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",
+    "@types/react": "catalog:",
     "@typescript-eslint/parser": "catalog:",
     "eslint": "8.57.0",
     "eslint-plugin-better-tailwindcss": "catalog:",
@@ -41,6 +53,10 @@
     "jest-environment-jsdom": "catalog:",
     "oxfmt": "catalog:",
     "oxlint": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "react-native": "catalog:",
+    "react-test-renderer": "catalog:",
     "tailwindcss": "catalog:",
     "typescript": "catalog:"
   },
@@ -49,5 +65,26 @@
     "@oxlint/binding-darwin-x64": "1.51.0",
     "@oxlint/binding-linux-x64-gnu": "1.51.0",
     "@oxlint/binding-win32-x64-msvc": "1.51.0"
+  },
+  "peerDependencies": {
+    "@ledgerhq/lumen-design-core": "catalog:",
+    "@ledgerhq/lumen-ui-react": "catalog:",
+    "@ledgerhq/lumen-ui-rnative": "catalog:",
+    "react": "catalog:",
+    "react-native": "catalog:"
+  },
+  "peerDependenciesMeta": {
+    "react-native": {
+      "optional": true
+    },
+    "@ledgerhq/lumen-ui-react": {
+      "optional": true
+    },
+    "@ledgerhq/lumen-ui-rnative": {
+      "optional": true
+    },
+    "@ledgerhq/lumen-design-core": {
+      "optional": true
+    }
   }
 }

--- a/features/flow/pay-card-request/src/components/VerifyAddress/VerifyAddress.tsx
+++ b/features/flow/pay-card-request/src/components/VerifyAddress/VerifyAddress.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { VerifyAddressIntroView } from "./VerifyAddressIntroView";
+import { VerifyAddressSuccessView } from "./VerifyAddressSuccessView";
+import type { VerifyAddressProps } from "../../types";
+import { useVerifyAddressViewModel } from "./useVerifyAddressViewModel";
+
+export function VerifyAddress(props: VerifyAddressProps) {
+  const { isIntroOpen, isSuccessOpen, nextSteps, onVerify, onGotIt, onClose } =
+    useVerifyAddressViewModel(props);
+
+  return (
+    <>
+      <VerifyAddressIntroView
+        isOpen={isIntroOpen}
+        title={props.labels.introTitle}
+        description={props.labels.introDescription}
+        verifyCta={props.labels.verifyCta}
+        onVerify={onVerify}
+        onClose={onClose}
+      />
+      <VerifyAddressSuccessView
+        isOpen={isSuccessOpen}
+        title={props.labels.successTitle}
+        nextStepsLabel={props.labels.nextStepsLabel}
+        nextSteps={nextSteps}
+        gotItCta={props.labels.gotItCta}
+        onGotIt={onGotIt}
+        onClose={onClose}
+      />
+    </>
+  );
+}

--- a/features/flow/pay-card-request/src/components/VerifyAddress/VerifyAddressDialog.web.tsx
+++ b/features/flow/pay-card-request/src/components/VerifyAddress/VerifyAddressDialog.web.tsx
@@ -1,0 +1,70 @@
+import React, { useCallback } from "react";
+import {
+  Button,
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogHeader,
+  Spot,
+} from "@ledgerhq/lumen-ui-react";
+import { ShieldLock } from "@ledgerhq/lumen-ui-react/symbols";
+
+type DialogIcon = typeof ShieldLock;
+
+type VerifyAddressDialogProps = Readonly<{
+  isOpen: boolean;
+  onClose: () => void;
+  contentTestId: string;
+  icon: DialogIcon;
+  title: string;
+  description?: string;
+  ctaLabel: string;
+  onCta: () => void;
+  ctaTestId: string;
+  children?: React.ReactNode;
+}>;
+
+export function VerifyAddressDialog({
+  isOpen,
+  onClose,
+  contentTestId,
+  icon,
+  title,
+  description,
+  ctaLabel,
+  onCta,
+  ctaTestId,
+  children,
+}: VerifyAddressDialogProps) {
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <Dialog open onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader density="compact" onClose={onClose} />
+        <DialogBody className="flex flex-col gap-24" data-testid={contentTestId}>
+          <div className="flex flex-col items-center gap-12 text-center">
+            <Spot appearance="icon" icon={icon} size={56} />
+            <h2 className="heading-3-semi-bold text-base">{title}</h2>
+            {description ? <p className="body-2 text-muted">{description}</p> : null}
+          </div>
+          {children}
+          <Button appearance="base" isFull onClick={onCta} data-testid={ctaTestId}>
+            {ctaLabel}
+          </Button>
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/flow/pay-card-request/src/components/VerifyAddress/VerifyAddressIntroView.native.tsx
+++ b/features/flow/pay-card-request/src/components/VerifyAddress/VerifyAddressIntroView.native.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { QrCodeScanner } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { VerifyAddressSheet } from "./VerifyAddressSheet.native";
+import type { VerifyAddressIntroViewProps } from "../../types";
+
+export function VerifyAddressIntroView({
+  isOpen,
+  title,
+  description,
+  verifyCta,
+  onVerify,
+  onClose,
+}: VerifyAddressIntroViewProps) {
+  return (
+    <VerifyAddressSheet
+      isOpen={isOpen}
+      onClose={onClose}
+      sheetTestId="pay-card-verify-address-intro-sheet"
+      contentTestId="pay-card-verify-address-intro"
+      icon={QrCodeScanner}
+      title={title}
+      description={description}
+      ctaLabel={verifyCta}
+      onCta={onVerify}
+      ctaTestId="pay-card-verify-address-verify-cta"
+    />
+  );
+}

--- a/features/flow/pay-card-request/src/components/VerifyAddress/VerifyAddressIntroView.web.tsx
+++ b/features/flow/pay-card-request/src/components/VerifyAddress/VerifyAddressIntroView.web.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { QrCodeScanner } from "@ledgerhq/lumen-ui-react/symbols";
+import { VerifyAddressDialog } from "./VerifyAddressDialog.web";
+import type { VerifyAddressIntroViewProps } from "../../types";
+
+export function VerifyAddressIntroView({
+  isOpen,
+  title,
+  description,
+  verifyCta,
+  onVerify,
+  onClose,
+}: VerifyAddressIntroViewProps) {
+  return (
+    <VerifyAddressDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      contentTestId="pay-card-verify-address-intro"
+      icon={QrCodeScanner}
+      title={title}
+      description={description}
+      ctaLabel={verifyCta}
+      onCta={onVerify}
+      ctaTestId="pay-card-verify-address-verify-cta"
+    />
+  );
+}

--- a/features/flow/pay-card-request/src/components/VerifyAddress/VerifyAddressSheet.native.tsx
+++ b/features/flow/pay-card-request/src/components/VerifyAddress/VerifyAddressSheet.native.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { BottomSheetView, Box, Button, Spot, Text } from "@ledgerhq/lumen-ui-rnative";
+import { ShieldLock } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { QueuedBottomSheet } from "@shared/ui-queued-bottom-sheet";
+
+type SheetIcon = typeof ShieldLock;
+
+type VerifyAddressSheetProps = Readonly<{
+  isOpen: boolean;
+  onClose: () => void;
+  sheetTestId: string;
+  contentTestId: string;
+  icon: SheetIcon;
+  title: string;
+  description?: string;
+  ctaLabel: string;
+  onCta: () => void;
+  ctaTestId: string;
+  children?: React.ReactNode;
+}>;
+
+export function VerifyAddressSheet({
+  isOpen,
+  onClose,
+  sheetTestId,
+  contentTestId,
+  icon,
+  title,
+  description,
+  ctaLabel,
+  onCta,
+  ctaTestId,
+  children,
+}: VerifyAddressSheetProps) {
+  return (
+    <QueuedBottomSheet
+      isRequestingToBeOpened={isOpen}
+      onClose={onClose}
+      enableDynamicSizing
+      testID={sheetTestId}
+    >
+      {isOpen ? (
+        <BottomSheetView style={{ paddingHorizontal: 16 }}>
+          <Box lx={{ gap: "s24", paddingVertical: "s24" }} testID={contentTestId}>
+            <Box lx={{ alignItems: "center", gap: "s12" }}>
+              <Spot appearance="icon" icon={icon} size={56} />
+              <Text typography="heading4SemiBold" lx={{ color: "base", textAlign: "center" }}>
+                {title}
+              </Text>
+              {description ? (
+                <Text typography="body3" lx={{ color: "muted", textAlign: "center" }}>
+                  {description}
+                </Text>
+              ) : null}
+            </Box>
+            {children}
+            <Button appearance="base" size="lg" isFull onPress={onCta} testID={ctaTestId}>
+              {ctaLabel}
+            </Button>
+          </Box>
+        </BottomSheetView>
+      ) : null}
+    </QueuedBottomSheet>
+  );
+}

--- a/features/flow/pay-card-request/src/components/VerifyAddress/VerifyAddressSuccessView.native.tsx
+++ b/features/flow/pay-card-request/src/components/VerifyAddress/VerifyAddressSuccessView.native.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { Box, Spot, Text } from "@ledgerhq/lumen-ui-rnative";
+import { ShieldLock } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { VerifyAddressSheet } from "./VerifyAddressSheet.native";
+import type { VerifyAddressSuccessViewProps } from "../../types";
+
+export function VerifyAddressSuccessView({
+  isOpen,
+  title,
+  nextStepsLabel,
+  nextSteps,
+  gotItCta,
+  onGotIt,
+  onClose,
+}: VerifyAddressSuccessViewProps) {
+  return (
+    <VerifyAddressSheet
+      isOpen={isOpen}
+      onClose={onClose}
+      sheetTestId="pay-card-verify-address-success-sheet"
+      contentTestId="pay-card-verify-address-success"
+      icon={ShieldLock}
+      title={title}
+      ctaLabel={gotItCta}
+      onCta={onGotIt}
+      ctaTestId="pay-card-verify-address-got-it-cta"
+    >
+      <Box lx={{ backgroundColor: "surface", borderRadius: "md", gap: "s16", padding: "s16" }}>
+        <Text typography="body4" lx={{ color: "muted" }}>
+          {nextStepsLabel}
+        </Text>
+        {nextSteps.map(step => (
+          <Box key={step.index} lx={{ alignItems: "flex-start", flexDirection: "row", gap: "s12" }}>
+            <Spot appearance="number" number={step.index} size={32} />
+            <Text typography="body3" lx={{ color: "base", flexShrink: 1 }}>
+              {step.label}
+            </Text>
+          </Box>
+        ))}
+      </Box>
+    </VerifyAddressSheet>
+  );
+}

--- a/features/flow/pay-card-request/src/components/VerifyAddress/VerifyAddressSuccessView.web.tsx
+++ b/features/flow/pay-card-request/src/components/VerifyAddress/VerifyAddressSuccessView.web.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { Spot } from "@ledgerhq/lumen-ui-react";
+import { ShieldLock } from "@ledgerhq/lumen-ui-react/symbols";
+import { VerifyAddressDialog } from "./VerifyAddressDialog.web";
+import type { VerifyAddressSuccessViewProps } from "../../types";
+
+export function VerifyAddressSuccessView({
+  isOpen,
+  title,
+  nextStepsLabel,
+  nextSteps,
+  gotItCta,
+  onGotIt,
+  onClose,
+}: VerifyAddressSuccessViewProps) {
+  return (
+    <VerifyAddressDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      contentTestId="pay-card-verify-address-success"
+      icon={ShieldLock}
+      title={title}
+      ctaLabel={gotItCta}
+      onCta={onGotIt}
+      ctaTestId="pay-card-verify-address-got-it-cta"
+    >
+      <div className="flex flex-col gap-16 rounded-md bg-surface p-16">
+        <span className="body-2 text-muted">{nextStepsLabel}</span>
+        {nextSteps.map(step => (
+          <div key={step.index} className="flex flex-row items-start gap-12">
+            <Spot appearance="number" number={step.index} size={32} />
+            <span className="body-2 text-base">{step.label}</span>
+          </div>
+        ))}
+      </div>
+    </VerifyAddressDialog>
+  );
+}

--- a/features/flow/pay-card-request/src/components/VerifyAddress/__tests__/VerifyAddress.web.test.tsx
+++ b/features/flow/pay-card-request/src/components/VerifyAddress/__tests__/VerifyAddress.web.test.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { VerifyAddress } from "../VerifyAddress";
+import type { VerifyAddressLabels, VerifyAddressProps } from "../../../types";
+
+const LABELS: VerifyAddressLabels = {
+  introTitle: "Verify your address",
+  introDescription: "To protect against address replacement attacks, verify your address.",
+  verifyCta: "Verify address",
+  successTitle: "Address displayed on the device's Secure Screen",
+  nextStepsLabel: "Next steps",
+  nextStepShare: "Share your address via your desired app",
+  nextStepMatch: "Ensure the shared address matches the one on your Ledger Device.",
+  gotItCta: "Got it",
+};
+
+function renderVerifyAddress(overrides: Partial<VerifyAddressProps> = {}) {
+  const props: VerifyAddressProps = {
+    phase: "intro",
+    labels: LABELS,
+    page: "Pay",
+    onVerify: jest.fn(),
+    onGotIt: jest.fn(),
+    onClose: jest.fn(),
+    onTrackEvent: jest.fn(),
+    ...overrides,
+  };
+  return { props, ...render(<VerifyAddress {...props} />) };
+}
+
+describe("VerifyAddress (Web)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders nothing while hidden", () => {
+    renderVerifyAddress({ phase: "hidden" });
+
+    expect(screen.queryByTestId("pay-card-verify-address-intro")).toBeNull();
+    expect(screen.queryByTestId("pay-card-verify-address-success")).toBeNull();
+  });
+
+  it("tracks and starts the device intent from the intro CTA", async () => {
+    const user = userEvent.setup();
+    const { props } = renderVerifyAddress();
+
+    expect(screen.getByTestId("pay-card-verify-address-intro")).toBeVisible();
+
+    await user.click(screen.getByTestId("pay-card-verify-address-verify-cta"));
+
+    expect(props.onTrackEvent).toHaveBeenCalledWith("button_clicked", {
+      button: "verify address",
+      buttonLocation: "verify address",
+      page: "Pay",
+    });
+    expect(props.onVerify).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the next steps and closes from the success CTA", async () => {
+    const user = userEvent.setup();
+    const { props } = renderVerifyAddress({ phase: "success" });
+
+    expect(screen.getByTestId("pay-card-verify-address-success")).toBeVisible();
+
+    await user.click(screen.getByTestId("pay-card-verify-address-got-it-cta"));
+
+    expect(props.onTrackEvent).toHaveBeenCalledWith("button_clicked", {
+      button: "got it",
+      buttonLocation: "verify address",
+      page: "Pay",
+    });
+    expect(props.onGotIt).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/flow/pay-card-request/src/components/VerifyAddress/__tests__/VerifyAddressIntroView.native.test.tsx
+++ b/features/flow/pay-card-request/src/components/VerifyAddress/__tests__/VerifyAddressIntroView.native.test.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { View } from "react-native";
+import { cleanup, render, screen, userEvent } from "@testing-library/react-native";
+import { VerifyAddressIntroView } from "../VerifyAddressIntroView.native";
+
+jest.mock("@shared/ui-queued-bottom-sheet", () => ({
+  QueuedBottomSheet: ({
+    children,
+    isRequestingToBeOpened,
+    testID,
+  }: {
+    children: React.ReactNode;
+    isRequestingToBeOpened?: boolean;
+    testID?: string;
+  }) => (
+    <View testID={testID} accessibilityState={{ expanded: !!isRequestingToBeOpened }}>
+      {children}
+    </View>
+  ),
+}));
+
+const defaultProps: React.ComponentProps<typeof VerifyAddressIntroView> = {
+  isOpen: true,
+  title: "Verify your address",
+  description: "To protect against address replacement attacks, verify your address.",
+  verifyCta: "Verify address",
+  onVerify: jest.fn(),
+  onClose: jest.fn(),
+};
+
+describe("VerifyAddressIntroView (Native)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("keeps the sheet mounted but hides its content while closed", () => {
+    render(<VerifyAddressIntroView {...defaultProps} isOpen={false} />);
+
+    const sheet = screen.getByTestId("pay-card-verify-address-intro-sheet");
+    expect(sheet.props.accessibilityState.expanded).toBe(false);
+    expect(screen.queryByTestId("pay-card-verify-address-intro")).toBeNull();
+  });
+
+  it("renders the title and description when open", () => {
+    render(<VerifyAddressIntroView {...defaultProps} />);
+
+    const sheet = screen.getByTestId("pay-card-verify-address-intro-sheet");
+    expect(sheet.props.accessibilityState.expanded).toBe(true);
+    expect(screen.getByText(defaultProps.title)).toBeVisible();
+    expect(screen.getByText(defaultProps.description as string)).toBeVisible();
+  });
+
+  it("emits verify when the CTA is pressed", async () => {
+    const user = userEvent.setup();
+    const onVerify = jest.fn();
+    render(<VerifyAddressIntroView {...defaultProps} onVerify={onVerify} />);
+
+    await user.press(screen.getByTestId("pay-card-verify-address-verify-cta"));
+
+    expect(onVerify).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/flow/pay-card-request/src/components/VerifyAddress/__tests__/VerifyAddressIntroView.web.test.tsx
+++ b/features/flow/pay-card-request/src/components/VerifyAddress/__tests__/VerifyAddressIntroView.web.test.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { VerifyAddressIntroView } from "../VerifyAddressIntroView.web";
+
+const defaultProps: React.ComponentProps<typeof VerifyAddressIntroView> = {
+  isOpen: true,
+  title: "Verify your address",
+  description: "To protect against address replacement attacks, verify your address.",
+  verifyCta: "Verify address",
+  onVerify: jest.fn(),
+  onClose: jest.fn(),
+};
+
+describe("VerifyAddressIntroView (Web)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the title and description when open", () => {
+    render(<VerifyAddressIntroView {...defaultProps} />);
+
+    expect(screen.getByTestId("pay-card-verify-address-intro")).toBeVisible();
+    expect(screen.getByText(defaultProps.title)).toBeVisible();
+    expect(screen.getByText(defaultProps.description as string)).toBeVisible();
+  });
+
+  it("renders nothing when closed", () => {
+    render(<VerifyAddressIntroView {...defaultProps} isOpen={false} />);
+
+    expect(screen.queryByTestId("pay-card-verify-address-intro")).toBeNull();
+  });
+
+  it("emits verify when the CTA is clicked", async () => {
+    const user = userEvent.setup();
+    const onVerify = jest.fn();
+    render(<VerifyAddressIntroView {...defaultProps} onVerify={onVerify} />);
+
+    await user.click(screen.getByTestId("pay-card-verify-address-verify-cta"));
+
+    expect(onVerify).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/flow/pay-card-request/src/components/VerifyAddress/__tests__/VerifyAddressSuccessView.native.test.tsx
+++ b/features/flow/pay-card-request/src/components/VerifyAddress/__tests__/VerifyAddressSuccessView.native.test.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { View } from "react-native";
+import { cleanup, render, screen, userEvent } from "@testing-library/react-native";
+import { VerifyAddressSuccessView } from "../VerifyAddressSuccessView.native";
+
+jest.mock("@shared/ui-queued-bottom-sheet", () => ({
+  QueuedBottomSheet: ({
+    children,
+    isRequestingToBeOpened,
+    testID,
+  }: {
+    children: React.ReactNode;
+    isRequestingToBeOpened?: boolean;
+    testID?: string;
+  }) => (
+    <View testID={testID} accessibilityState={{ expanded: !!isRequestingToBeOpened }}>
+      {children}
+    </View>
+  ),
+}));
+
+const defaultProps: React.ComponentProps<typeof VerifyAddressSuccessView> = {
+  isOpen: true,
+  title: "Address displayed on the device's Secure Screen",
+  nextStepsLabel: "Next steps",
+  nextSteps: [
+    { index: 1, label: "Share your address via your desired app" },
+    { index: 2, label: "Ensure the shared address matches the one on your Ledger Device." },
+  ],
+  gotItCta: "Got it",
+  onGotIt: jest.fn(),
+  onClose: jest.fn(),
+};
+
+describe("VerifyAddressSuccessView (Native)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("keeps the sheet mounted but hides its content while closed", () => {
+    render(<VerifyAddressSuccessView {...defaultProps} isOpen={false} />);
+
+    const sheet = screen.getByTestId("pay-card-verify-address-success-sheet");
+    expect(sheet.props.accessibilityState.expanded).toBe(false);
+    expect(screen.queryByTestId("pay-card-verify-address-success")).toBeNull();
+  });
+
+  it("renders the title and next steps when open", () => {
+    render(<VerifyAddressSuccessView {...defaultProps} />);
+
+    const sheet = screen.getByTestId("pay-card-verify-address-success-sheet");
+    expect(sheet.props.accessibilityState.expanded).toBe(true);
+    expect(screen.getByText(defaultProps.title)).toBeVisible();
+    expect(screen.getByText(defaultProps.nextSteps[0].label)).toBeVisible();
+    expect(screen.getByText(defaultProps.nextSteps[1].label)).toBeVisible();
+  });
+
+  it("emits got it when the CTA is pressed", async () => {
+    const user = userEvent.setup();
+    const onGotIt = jest.fn();
+    render(<VerifyAddressSuccessView {...defaultProps} onGotIt={onGotIt} />);
+
+    await user.press(screen.getByTestId("pay-card-verify-address-got-it-cta"));
+
+    expect(onGotIt).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/flow/pay-card-request/src/components/VerifyAddress/__tests__/VerifyAddressSuccessView.web.test.tsx
+++ b/features/flow/pay-card-request/src/components/VerifyAddress/__tests__/VerifyAddressSuccessView.web.test.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { VerifyAddressSuccessView } from "../VerifyAddressSuccessView.web";
+
+const defaultProps: React.ComponentProps<typeof VerifyAddressSuccessView> = {
+  isOpen: true,
+  title: "Address displayed on the device's Secure Screen",
+  nextStepsLabel: "Next steps",
+  nextSteps: [
+    { index: 1, label: "Share your address via your desired app" },
+    { index: 2, label: "Ensure the shared address matches the one on your Ledger Device." },
+  ],
+  gotItCta: "Got it",
+  onGotIt: jest.fn(),
+  onClose: jest.fn(),
+};
+
+describe("VerifyAddressSuccessView (Web)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the title and next steps when open", () => {
+    render(<VerifyAddressSuccessView {...defaultProps} />);
+
+    expect(screen.getByTestId("pay-card-verify-address-success")).toBeVisible();
+    expect(screen.getByText(defaultProps.title)).toBeVisible();
+    expect(screen.getByText(defaultProps.nextSteps[0].label)).toBeVisible();
+    expect(screen.getByText(defaultProps.nextSteps[1].label)).toBeVisible();
+  });
+
+  it("renders nothing when closed", () => {
+    render(<VerifyAddressSuccessView {...defaultProps} isOpen={false} />);
+
+    expect(screen.queryByTestId("pay-card-verify-address-success")).toBeNull();
+  });
+
+  it("emits got it when the CTA is clicked", async () => {
+    const user = userEvent.setup();
+    const onGotIt = jest.fn();
+    render(<VerifyAddressSuccessView {...defaultProps} onGotIt={onGotIt} />);
+
+    await user.click(screen.getByTestId("pay-card-verify-address-got-it-cta"));
+
+    expect(onGotIt).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/flow/pay-card-request/src/components/VerifyAddress/__tests__/useVerifyAddressViewModel.web.test.ts
+++ b/features/flow/pay-card-request/src/components/VerifyAddress/__tests__/useVerifyAddressViewModel.web.test.ts
@@ -1,0 +1,88 @@
+import { renderHook } from "@testing-library/react";
+import { useVerifyAddressViewModel } from "../useVerifyAddressViewModel";
+import type { VerifyAddressLabels, VerifyAddressProps } from "../../../types";
+
+const LABELS: VerifyAddressLabels = {
+  introTitle: "Verify your address",
+  introDescription: "To protect against address replacement attacks, verify your address.",
+  verifyCta: "Verify address",
+  successTitle: "Address displayed on the device's Secure Screen",
+  nextStepsLabel: "Next steps",
+  nextStepShare: "Share your address via your desired app",
+  nextStepMatch: "Ensure the shared address matches the one on your Ledger Device.",
+  gotItCta: "Got it",
+};
+
+function setup(overrides: Partial<VerifyAddressProps> = {}) {
+  const props: VerifyAddressProps = {
+    phase: "intro",
+    labels: LABELS,
+    page: "Pay",
+    onVerify: jest.fn(),
+    onGotIt: jest.fn(),
+    onClose: jest.fn(),
+    onTrackEvent: jest.fn(),
+    ...overrides,
+  };
+  const { result } = renderHook(() => useVerifyAddressViewModel(props));
+  return { props, result };
+}
+
+describe("useVerifyAddressViewModel", () => {
+  it("maps the phase to open flags", () => {
+    expect(setup({ phase: "hidden" }).result.current).toMatchObject({
+      isIntroOpen: false,
+      isSuccessOpen: false,
+    });
+    expect(setup({ phase: "intro" }).result.current).toMatchObject({
+      isIntroOpen: true,
+      isSuccessOpen: false,
+    });
+    expect(setup({ phase: "success" }).result.current).toMatchObject({
+      isIntroOpen: false,
+      isSuccessOpen: true,
+    });
+  });
+
+  it("builds the two ordered next steps from the labels", () => {
+    const { result } = setup();
+
+    expect(result.current.nextSteps).toEqual([
+      { index: 1, label: LABELS.nextStepShare },
+      { index: 2, label: LABELS.nextStepMatch },
+    ]);
+  });
+
+  it("tracks then starts the device intent on verify", () => {
+    const { props, result } = setup();
+
+    result.current.onVerify();
+
+    expect(props.onTrackEvent).toHaveBeenCalledWith("button_clicked", {
+      button: "verify address",
+      buttonLocation: "verify address",
+      page: "Pay",
+    });
+    expect(props.onVerify).toHaveBeenCalledTimes(1);
+  });
+
+  it("tracks then closes on got it", () => {
+    const { props, result } = setup();
+
+    result.current.onGotIt();
+
+    expect(props.onTrackEvent).toHaveBeenCalledWith("button_clicked", {
+      button: "got it",
+      buttonLocation: "verify address",
+      page: "Pay",
+    });
+    expect(props.onGotIt).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not throw when no tracker is provided", () => {
+    const { props, result } = setup({ onTrackEvent: undefined });
+
+    expect(() => result.current.onVerify()).not.toThrow();
+    expect(props.onVerify).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/flow/pay-card-request/src/components/VerifyAddress/useVerifyAddressViewModel.ts
+++ b/features/flow/pay-card-request/src/components/VerifyAddress/useVerifyAddressViewModel.ts
@@ -1,0 +1,53 @@
+import { useCallback, useMemo } from "react";
+import type {
+  VerifyAddressNextStep,
+  VerifyAddressProps,
+  VerifyAddressViewModel,
+} from "../../types";
+
+const TRACK_LOCATION = "verify address";
+
+export function useVerifyAddressViewModel({
+  phase,
+  labels,
+  page,
+  onVerify,
+  onGotIt,
+  onClose,
+  onTrackEvent,
+}: VerifyAddressProps): VerifyAddressViewModel {
+  const nextSteps = useMemo<readonly VerifyAddressNextStep[]>(
+    () => [
+      { index: 1, label: labels.nextStepShare },
+      { index: 2, label: labels.nextStepMatch },
+    ],
+    [labels],
+  );
+
+  const handleVerify = useCallback(() => {
+    onTrackEvent?.("button_clicked", {
+      button: "verify address",
+      buttonLocation: TRACK_LOCATION,
+      page,
+    });
+    onVerify();
+  }, [onVerify, onTrackEvent, page]);
+
+  const handleGotIt = useCallback(() => {
+    onTrackEvent?.("button_clicked", {
+      button: "got it",
+      buttonLocation: TRACK_LOCATION,
+      page,
+    });
+    onGotIt();
+  }, [onGotIt, onTrackEvent, page]);
+
+  return {
+    isIntroOpen: phase === "intro",
+    isSuccessOpen: phase === "success",
+    nextSteps,
+    onVerify: handleVerify,
+    onGotIt: handleGotIt,
+    onClose,
+  };
+}

--- a/features/flow/pay-card-request/src/exports.ts
+++ b/features/flow/pay-card-request/src/exports.ts
@@ -1,0 +1,3 @@
+export * from "./components/VerifyAddress/VerifyAddress";
+export * from "./components/VerifyAddress/useVerifyAddressViewModel";
+export * from "./types";

--- a/features/flow/pay-card-request/src/index.native.ts
+++ b/features/flow/pay-card-request/src/index.native.ts
@@ -1,1 +1,1 @@
-export * from "./placeholder";
+export * from "./exports";

--- a/features/flow/pay-card-request/src/index.ts
+++ b/features/flow/pay-card-request/src/index.ts
@@ -1,1 +1,1 @@
-export * from "./placeholder";
+export * from "./exports";

--- a/features/flow/pay-card-request/src/placeholder.ts
+++ b/features/flow/pay-card-request/src/placeholder.ts
@@ -1,1 +1,0 @@
-export const FLOW_PAY_CARD_REQUEST_PACKAGE = "@features/flow-pay-card-request";

--- a/features/flow/pay-card-request/src/types.ts
+++ b/features/flow/pay-card-request/src/types.ts
@@ -1,0 +1,66 @@
+export type PayCardTrackEvent = (event: string, params: Record<string, unknown>) => void;
+
+export type VerifyAddressPhase = "hidden" | "intro" | "success";
+
+/** Single digit index of a "Next steps" entry, matching the design-system numbered Spot. */
+export type VerifyAddressNextStepIndex = 1 | 2;
+
+export type VerifyAddressNextStep = Readonly<{
+  index: VerifyAddressNextStepIndex;
+  label: string;
+}>;
+
+/**
+ * User-facing copy injected by the host app. This package stays i18n-agnostic: the app
+ * resolves translations and passes the strings in.
+ */
+export type VerifyAddressLabels = Readonly<{
+  introTitle: string;
+  introDescription: string;
+  verifyCta: string;
+  successTitle: string;
+  nextStepsLabel: string;
+  nextStepShare: string;
+  nextStepMatch: string;
+  gotItCta: string;
+}>;
+
+export type VerifyAddressProps = Readonly<{
+  phase: VerifyAddressPhase;
+  labels: VerifyAddressLabels;
+  page: string;
+  /** Host starts the device intent (DIE lives in the app, not in this package). */
+  onVerify: () => void;
+  /** Host closes the success overlay. */
+  onGotIt: () => void;
+  onClose: () => void;
+  onTrackEvent?: PayCardTrackEvent;
+}>;
+
+export type VerifyAddressViewModel = Readonly<{
+  isIntroOpen: boolean;
+  isSuccessOpen: boolean;
+  nextSteps: readonly VerifyAddressNextStep[];
+  onVerify: () => void;
+  onGotIt: () => void;
+  onClose: () => void;
+}>;
+
+export type VerifyAddressIntroViewProps = Readonly<{
+  isOpen: boolean;
+  title: string;
+  description: string;
+  verifyCta: string;
+  onVerify: () => void;
+  onClose: () => void;
+}>;
+
+export type VerifyAddressSuccessViewProps = Readonly<{
+  isOpen: boolean;
+  title: string;
+  nextStepsLabel: string;
+  nextSteps: readonly VerifyAddressNextStep[];
+  gotItCta: string;
+  onGotIt: () => void;
+  onClose: () => void;
+}>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5995,7 +5995,23 @@ importers:
         version: 1.51.0
 
   features/flow/pay-card-request:
+    dependencies:
+      '@shared/ui-queued-bottom-sheet':
+        specifier: workspace:*
+        version: link:../../../shared/ui-queued-bottom-sheet
     devDependencies:
+      '@features/platform-style':
+        specifier: workspace:*
+        version: link:../../platform/style
+      '@ledgerhq/lumen-design-core':
+        specifier: 'catalog:'
+        version: 0.1.25
+      '@ledgerhq/lumen-ui-react':
+        specifier: 'catalog:'
+        version: 0.1.53(@ledgerhq/lumen-design-core@0.1.25)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@ledgerhq/lumen-ui-rnative':
+        specifier: 'catalog:'
+        version: 0.1.57(@ledgerhq/lumen-design-core@0.1.25)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@support/jest-features-flow':
         specifier: workspace:*
         version: link:../../../support/jest-features-flow
@@ -6005,15 +6021,30 @@ importers:
       '@swc/jest':
         specifier: 'catalog:'
         version: 0.2.39(@swc/core@1.15.11)
+      '@testing-library/dom':
+        specifier: 'catalog:'
+        version: 10.4.1
       '@testing-library/jest-dom':
         specifier: 'catalog:'
         version: 6.9.1
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@testing-library/react-native':
+        specifier: 'catalog:'
+        version: 13.3.3(patch_hash=4f93e75372e62b6dc0f0b2635b62a322b37a3727637bd94a38df1ed8648e2e76)(jest@30.2.0(@types/node@24.12.0))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react-test-renderer@19.1.4(react@19.1.4))(react@19.1.4)
+      '@testing-library/user-event':
+        specifier: 'catalog:'
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/jest':
         specifier: 'catalog:'
         version: 30.0.0
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.0
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.0.14
       '@typescript-eslint/parser':
         specifier: 'catalog:'
         version: 8.48.1(@typescript/typescript6@6.0.2)(eslint@8.57.0)
@@ -6035,6 +6066,18 @@ importers:
       oxlint:
         specifier: 'catalog:'
         version: 1.51.0
+      react:
+        specifier: 19.1.4
+        version: 19.1.4
+      react-dom:
+        specifier: 19.1.4
+        version: 19.1.4(react@19.1.4)
+      react-native:
+        specifier: 'catalog:'
+        version: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
+      react-test-renderer:
+        specifier: 'catalog:'
+        version: 19.1.4(react@19.1.4)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.1.18
@@ -67877,7 +67920,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3(metro-transform-worker@0.83.3)
+      metro: 0.83.3
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -68001,54 +68044,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro@0.83.3(metro-transform-worker@0.83.3):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 1.3.8
-      chalk: 4.1.2
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.32.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0(metro@0.83.3)
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.3
-      metro-cache: 0.83.3
-      metro-cache-key: 0.83.3
-      metro-config: 0.83.3(metro-transform-worker@0.83.3)
-      metro-core: 0.83.3
-      metro-file-map: 0.83.3(metro@0.83.3)
-      metro-resolver: 0.83.3
-      metro-runtime: 0.83.3
-      metro-source-map: 0.83.3
-      metro-symbolicate: 0.83.3
-      metro-transform-plugins: 0.83.3
-      metro-transform-worker: 0.83.3
-      mime-types: 2.1.35
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
### 📝 Description

Adds the `VerifyAddress` UI to `@features/flow-pay-card-request`: the pre-intent (intro) and post-intent (success) screens for the Pay card request address-verification step, for both web (LWD) and native (LWM).

**Problem**: The Pay card request flow needs shared, dual-platform screens to introduce on-device address verification and to confirm success, matching the Figma designs.

**Solution**: A `VerifyAddress` container that renders an intro or success view depending on its `phase` prop, backed by a `useVerifyAddressViewModel` hook that maps the phase to labels / next-steps and wires tracking. Intro and success views share a `VerifyAddressDialog` scaffold (web) and a `VerifyAddressSheet` scaffold (native) to keep layout consistent and avoid duplication. The device interaction itself is handled by the DIE `verifyAddressIntent` shipped in [LIVE-36132](https://ledgerhq.atlassian.net/browse/LIVE-36132) (#20875).


| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36133](https://ledgerhq.atlassian.net/browse/LIVE-36133)
- **Related**: DIE intent [LIVE-36132](https://ledgerhq.atlassian.net/browse/LIVE-36132) — #20875
- **Design**: [Figma — Pay Verify address](https://www.figma.com/design/WYQQwem0QyG2fTuaAKAe3Y/Pay-%E2%80%A2-Production?node-id=6784-63692&p=f&m=dev)
- **ADR** (if any): n/a

[LIVE-36132]: https://ledgerhq.atlassian.net/browse/LIVE-36132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-36133]: https://ledgerhq.atlassian.net/browse/LIVE-36133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ