### PR TITLE
[LWDM] fix(hypercore): hide accounts from send and receive pickers

### DIFF
--- a/.changeset/quiet-pandas-repeat.md
+++ b/.changeset/quiet-pandas-repeat.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Hide accounts that cannot send from the send pickers, and accounts that cannot receive from the receive pickers (HyperCore)

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useAssetSelection.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useAssetSelection.ts
@@ -2,6 +2,8 @@ import { useMemo } from "react";
 import { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import { useAcceptedCurrency } from "@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency";
 import type { AssetData } from "@ledgerhq/live-common/modularDrawer/utils/type";
+import { useSelector } from "LLD/hooks/redux";
+import { modularDialogFlowSelector } from "~/renderer/reducers/modularDialog";
 
 function getNetworkId(currency: CryptoOrTokenCurrency): string {
   return currency.type === "CryptoCurrency" ? currency.id : currency.parentCurrencyId;
@@ -12,10 +14,11 @@ export function useAssetSelection(
   assetsSorted: AssetData[] | undefined = [],
   selectableNetworkIds: readonly string[] | undefined = undefined,
 ) {
-  const isAcceptedCurrency = useAcceptedCurrency();
+  const flow = useSelector(modularDialogFlowSelector);
+  const isAcceptedCurrency = useAcceptedCurrency({ flow });
 
   const assetsToDisplay = useMemo(
-    () => sortedCryptoCurrencies.filter(isAcceptedCurrency),
+    () => sortedCryptoCurrencies.filter(currency => isAcceptedCurrency(currency)),
     [sortedCryptoCurrencies, isAcceptedCurrency],
   );
   const disabledAssetIds = useMemo(() => {

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useModularDialogFlowState.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useModularDialogFlowState.ts
@@ -13,6 +13,7 @@ import {
   modularDialogOnAccountSelectedSelector,
   modularDialogOnAssetSelectedSelector,
   modularDialogSearchedSelector,
+  modularDialogFlowSelector,
   modularDialogSelectableNetworkIdsSelector,
 } from "~/renderer/reducers/modularDialog";
 import { AssetData } from "@ledgerhq/live-common/modularDrawer/utils/type";
@@ -31,7 +32,8 @@ export function useModularDialogFlowState({
   setNetworksToDisplay,
   goToStep,
 }: Props) {
-  const isAcceptedCurrency = useAcceptedCurrency();
+  const flow = useSelector(modularDialogFlowSelector);
+  const isAcceptedCurrency = useAcceptedCurrency({ flow });
   const { trackModularDialogEvent } = useModularDialogAnalytics();
   const searchedValue = useSelector(modularDialogSearchedSelector);
   const currencyIds = useSelector(modularDialogCurrenciesSelector);

--- a/apps/ledger-live-desktop/src/renderer/components/__tests__/SelectAccount.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/__tests__/SelectAccount.test.tsx
@@ -135,6 +135,26 @@ describe("RawSelectAccount", () => {
     ]);
   });
 
+  it("only hands main accounts to filter, never token sub-accounts", () => {
+    const filter = jest.fn((_account: Account) => true);
+
+    render(
+      <RawSelectAccount
+        accounts={[parentAccount]}
+        withSubAccounts
+        filter={filter}
+        onChange={jest.fn()}
+        value={null}
+      />,
+    );
+
+    expect(parentAccount.subAccounts?.length).toBeGreaterThan(0);
+    expect(filter).toHaveBeenCalled();
+    for (const [account] of filter.mock.calls) {
+      expect(account.type).toBe("Account");
+    }
+  });
+
   it("does not apply subAccountFilter when withSubAccounts is false", () => {
     render(
       <RawSelectAccount

--- a/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepAccount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepAccount.tsx
@@ -3,7 +3,11 @@ import { Trans } from "react-i18next";
 import { Account, AccountLike } from "@ledgerhq/types-live";
 import { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import { TokenCurrency } from "@domain/entity-currency-token";
-import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
+import {
+  canReceive,
+  getAccountCurrency,
+  getMainAccount,
+} from "@ledgerhq/live-common/account/index";
 import { useTokensData } from "@features/platform-currencies";
 import { supportLinkByTokenType } from "~/config/urls";
 import TrackPage from "~/renderer/analytics/TrackPage";
@@ -19,6 +23,10 @@ import { useLLDCoinFamily } from "~/renderer/families";
 import { StepProps } from "../Body";
 
 type OnChangeAccount = (account?: AccountLike | null, tokenAccount?: Account | null) => void;
+
+// Some families expose no receive on Ledger Wallet (e.g. HyperCore).
+const canCreditAccount = (account: Account) => canReceive(account, null);
+
 const AccountSelection = ({
   onChangeAccount,
   account,
@@ -30,7 +38,13 @@ const AccountSelection = ({
     <Label>
       <Trans i18nKey="receive.steps.chooseAccount.label" />
     </Label>
-    <SelectAccount autoFocus withSubAccounts onChange={onChangeAccount} value={account} />
+    <SelectAccount
+      autoFocus
+      withSubAccounts
+      onChange={onChangeAccount}
+      value={account}
+      filter={canCreditAccount}
+    />
   </>
 );
 const TokenParentSelection = ({

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import { useAccountBridgeOrNull } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Trans } from "react-i18next";
-import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { getMainAccount, isSendDisabledForFamily } from "@ledgerhq/live-common/account/index";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
@@ -254,7 +254,7 @@ export const DefaultStepRecipient = ({
   const accountFilter = useMemo(
     () => (acc: Account) => {
       const family = acc.currency.family;
-      return !isEnabledForFamily(family, acc.currency.id);
+      return !isSendDisabledForFamily(family) && !isEnabledForFamily(family, acc.currency.id);
     },
     [isEnabledForFamily],
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useAssets.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useAssets.ts
@@ -6,6 +6,8 @@ import VersionNumber from "react-native-version-number";
 import { useFeature } from "@features/platform-feature-flags";
 import { buildAssetsSorted } from "@ledgerhq/live-common/modularDrawer/utils/buildAssetsSorted";
 import { useAcceptedCurrency } from "@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency";
+import { useSelector } from "~/context/hooks";
+import { modularDrawerFlowSelector } from "~/reducers/modularDrawer";
 import useEnv from "@features/platform-env";
 
 interface AssetsProps {
@@ -23,7 +25,8 @@ export function useAssets({
   useCase,
   areCurrenciesFiltered,
 }: AssetsProps) {
-  const isAcceptedCurrency = useAcceptedCurrency();
+  const flow = useSelector(modularDrawerFlowSelector);
+  const isAcceptedCurrency = useAcceptedCurrency({ flow });
   const modularDrawerFeature = useFeature("llmModularDrawer");
   const devMode = useEnv("MANAGER_DEV_MODE");
   const resolvedNetworkIds = networkIds?.length ? networkIds : undefined;

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerState.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerState.ts
@@ -10,6 +10,7 @@ import { useSelector, useDispatch } from "~/context/hooks";
 import {
   modularDrawerCompletionModeSelector,
   modularDrawerEnableAccountSelectionSelector,
+  modularDrawerFlowSelector,
   setStep,
 } from "~/reducers/modularDrawer";
 import { useAcceptedCurrency } from "@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency";
@@ -35,7 +36,8 @@ export function useModularDrawerState({
   onAccountSelected,
   onCurrencySelected,
 }: ModularDrawerStateProps) {
-  const isAcceptedCurrency = useAcceptedCurrency();
+  const flow = useSelector(modularDrawerFlowSelector);
+  const isAcceptedCurrency = useAcceptedCurrency({ flow });
   const enableAccountSelection = useSelector(modularDrawerEnableAccountSelectionSelector);
   const completionMode = useSelector(modularDrawerCompletionModeSelector);
   const dispatch = useDispatch();

--- a/apps/ledger-live-mobile/src/screens/SelectAccount.tsx
+++ b/apps/ledger-live-mobile/src/screens/SelectAccount.tsx
@@ -6,7 +6,12 @@ import {
   getParentAccount,
 } from "@ledgerhq/live-common/account/helpers";
 import { Flex } from "@ledgerhq/native-ui";
-import { getAccountSpendableBalance, getMainAccount } from "@ledgerhq/live-common/account/index";
+import {
+  getAccountSpendableBalance,
+  getMainAccount,
+  isReceiveDisabledForFamily,
+  isSendDisabledForFamily,
+} from "@ledgerhq/live-common/account/index";
 import { useAccountBridgeMany } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import { ScreenName, NavigatorName } from "~/const";
@@ -80,12 +85,17 @@ function ReceiveFunds({ navigation, route }: Props) {
   );
   const mainAccounts = accounts.filter((a): a is Account => parentAccountIds.has(a.id));
   const bridges = useAccountBridgeMany(mainAccounts);
-  const bridgeById = new Map(mainAccounts.map((a, i) => [a.id, bridges[i]]));
-  const allAccounts = notEmptyAccounts
-    ? enhancedAccounts.filter(
-        a => !bridgeById.get(a.type === "Account" ? a.id : a.parentId)?.isAccountEmpty(a),
-      )
-    : enhancedAccounts;
+  const mainById = new Map(mainAccounts.map((a, i) => [a.id, { account: a, bridge: bridges[i] }]));
+  // Some families expose no send or no receive on Ledger Wallet (e.g. HyperCore): keep them out of
+  // the picker instead of letting the flow fail later when crafting the transaction. This screen
+  // serves both directions, hence picking the check off `next`.
+  const isDisabledForFlow =
+    next === ScreenName.SendSelectRecipient ? isSendDisabledForFamily : isReceiveDisabledForFamily;
+  const allAccounts = enhancedAccounts.filter(a => {
+    const main = mainById.get(a.type === "Account" ? a.id : a.parentId);
+    if (main && isDisabledForFlow(main.account.currency.family)) return false;
+    return !notEmptyAccounts || !main?.bridge?.isAccountEmpty(a);
+  });
 
   const { isEnabledForFamily, getFamilyFromAccount, getCurrencyIdFromAccount } =
     useNewSendFlowFeature();

--- a/apps/ledger-live-mobile/src/screens/__tests__/SelectAccount.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/__tests__/SelectAccount.test.tsx
@@ -57,6 +57,7 @@ jest.mock("LLM/features/Send/hooks/useNewSendFlowFeature", () => ({
 }));
 
 const ethereum = getCryptoCurrencyById("ethereum");
+const hypercore = getCryptoCurrencyById("hypercore");
 const polygon = getCryptoCurrencyById("polygon");
 const usdc = { parentCurrencyId: ethereum.id } as unknown as TokenCurrency;
 const usdtEth = {
@@ -164,6 +165,29 @@ describe("SelectAccount — notEmptyAccounts filter via bridge", () => {
 
     expect(screen.queryByTestId(`account-${FUNDED_ETH.id}`)).not.toBeNull();
     expect(screen.queryByTestId(`account-${FUNDED_TOKEN.id}`)).not.toBeNull();
+  });
+});
+
+describe("SelectAccount — families without transfer support", () => {
+  it("hides an account whose family cannot send, in the send flow (hypercore)", () => {
+    const HYPERCORE = genAccount("sa-hypercore", {
+      currency: hypercore,
+      operationsSize: 5,
+      subAccountsCount: 0,
+    });
+
+    render(
+      <SelectAccount
+        // oxlint-disable-next-line typescript/no-explicit-any
+        navigation={makeNavigation() as any}
+        // oxlint-disable-next-line typescript/no-explicit-any
+        route={makeRoute({ next: ScreenName.SendSelectRecipient }) as any}
+      />,
+      { overrideInitialState: withAccounts([FUNDED_ETH, HYPERCORE]) },
+    );
+
+    expect(screen.queryByTestId(`account-${HYPERCORE.id}`)).toBeNull();
+    expect(screen.queryByTestId(`account-${FUNDED_ETH.id}`)).not.toBeNull();
   });
 });
 

--- a/libs/ledger-live-common/src/modularDrawer/hooks/__tests__/useAcceptedCurrency.test.ts
+++ b/libs/ledger-live-common/src/modularDrawer/hooks/__tests__/useAcceptedCurrency.test.ts
@@ -7,6 +7,7 @@ import { CryptoCurrency, getCryptoCurrencyById } from "@domain/entity-currency-c
 import { TokenCurrency } from "@domain/entity-currency-token";
 import { useCurrenciesUnderFeatureFlag } from "../useCurrenciesUnderFeatureFlag";
 import { isCurrencySupported } from "../../../coin-modules/registry";
+import { ModularDrawerLocation } from "../../enums";
 
 // Mock dependencies
 jest.mock("../useCurrenciesUnderFeatureFlag");
@@ -160,6 +161,54 @@ describe("useAcceptedCurrency", () => {
     } as any);
     rerender();
     expect(result.current(mockCryptoCurrency)).toBe(false);
+  });
+
+  describe("transfer flows", () => {
+    const hypercore = {
+      ...mockCryptoCurrency,
+      id: "hypercore",
+      family: "hypercore",
+    } as CryptoCurrency;
+    const hypercoreToken = {
+      ...mockTokenCurrency,
+      parentCurrencyId: "hypercore",
+    } as TokenCurrency;
+
+    beforeEach(() => {
+      mockUseCurrenciesUnderFeatureFlag.mockReturnValue({
+        deactivatedCurrencyIds: new Set<string>(),
+        featureFlaggedCurrencies: {},
+      } as any);
+      mockIsCurrencySupported.mockReturnValue(true);
+    });
+
+    it("should reject a family that cannot send, in the send flow (hypercore)", () => {
+      const { result } = renderHook(() => useAcceptedCurrency({ flow: "send" }));
+
+      expect(result.current(hypercore)).toBe(false);
+    });
+
+    it("should reject a token whose parent family cannot send", () => {
+      const { result } = renderHook(() => useAcceptedCurrency({ flow: "send" }));
+
+      expect(result.current(hypercoreToken)).toBe(false);
+    });
+
+    it("should reject a family that cannot receive, in the receive flow", () => {
+      const { result } = renderHook(() =>
+        useAcceptedCurrency({ flow: ModularDrawerLocation.RECEIVE_FLOW }),
+      );
+
+      expect(result.current(hypercore)).toBe(false);
+    });
+
+    it("should accept that same family outside of a transfer flow", () => {
+      const { result } = renderHook(() =>
+        useAcceptedCurrency({ flow: ModularDrawerLocation.ADD_ACCOUNT }),
+      );
+
+      expect(result.current(hypercore)).toBe(true);
+    });
   });
 
   it("should handle multiple currencies in deactivated set", () => {

--- a/libs/ledger-live-common/src/modularDrawer/hooks/useAcceptedCurrency.ts
+++ b/libs/ledger-live-common/src/modularDrawer/hooks/useAcceptedCurrency.ts
@@ -2,18 +2,40 @@ import { useCallback } from "react";
 import { CryptoCurrency, getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import { isCurrencySupported } from "../../currencies";
+import { isSendDisabledForFamily, isReceiveDisabledForFamily } from "../../account/support";
+import { ModularDrawerLocation } from "../enums";
 import { useCurrenciesUnderFeatureFlag } from "./useCurrenciesUnderFeatureFlag";
+
+type Options = {
+  /**
+   * Flow the drawer was opened for. In the send flow, families that cannot send (e.g. hypercore)
+   * are rejected; in the receive flow, those that cannot receive. Everywhere else (add account,
+   * live apps, market) nothing is filtered out.
+   */
+  flow?: string;
+};
+
+// Per-flow capability check. The send flow dispatches a bare "send" while receive uses the enum;
+// SEND_FLOW is mapped too so that aligning the send opener on the enum later keeps working.
+// Any other flow (add account, live apps, market) has no direction and filters nothing.
+const DISABLED_FOR_FLOW: Record<string, (family: CryptoCurrency["family"]) => boolean> = {
+  send: isSendDisabledForFamily,
+  [ModularDrawerLocation.SEND_FLOW]: isSendDisabledForFamily,
+  [ModularDrawerLocation.RECEIVE_FLOW]: isReceiveDisabledForFamily,
+};
 
 /**
  * Hook that returns a predicate function to check if a currency or token is accepted.
  * A currency is accepted if:
  * - It is supported by the platform (via isCurrencySupported)
  * - It is not deactivated by a feature flag
+ * - Its family supports the direction of the flow it was opened from (send or receive)
  *
  * For tokens, the parent currency is checked instead.
  */
-export function useAcceptedCurrency() {
+export function useAcceptedCurrency({ flow }: Options = {}) {
   const { deactivatedCurrencyIds } = useCurrenciesUnderFeatureFlag();
+  const isDisabledForFlow = flow === undefined ? undefined : DISABLED_FOR_FLOW[flow];
 
   const isAcceptedCurrency = useCallback(
     (currencyOrToken: CryptoOrTokenCurrency): boolean => {
@@ -22,9 +44,11 @@ export function useAcceptedCurrency() {
           ? getCryptoCurrencyById(currencyOrToken.parentCurrencyId)
           : currencyOrToken;
 
+      if (isDisabledForFlow?.(currency.family)) return false;
+
       return isCurrencySupported(currency) && !deactivatedCurrencyIds.has(currency.id);
     },
-    [deactivatedCurrencyIds],
+    [deactivatedCurrencyIds, isDisabledForFlow],
   );
 
   return isAcceptedCurrency;


### PR DESCRIPTION
### 📝 Description

Hyperliquid (`hypercore`) supports neither send nor receive, but its accounts were still offered in the send and receive pickers — picking one failed later, when crafting the transaction.

The capability already exists in `account/support.ts` (`FAMILY_TRANSFER_CAPABILITY`) and already hides the action buttons; it was just never applied to the lists. This PR closes that gap:

- new sibling helper `isTransferDisabledForFamily`, same source of truth as the existing ones;
- `useAcceptedCurrency` takes the drawer `flow` and rejects those families in the send/receive flows only — one line at each of the 4 call sites, covering the asset and network steps;
- legacy screens that bypass that hook: LLD `StepRecipient`, LLD `StepAccount` (previously unfiltered), LLM `SelectAccount`.

**Add account is deliberately untouched**: it is the only way to get a hypercore account (generic flow or Perps live app), so the rejection is conditional on the flow, with a test asserting hypercore still passes with `flow: ADD_ACCOUNT`.

### Screenshots
| Before | After |
|-------------------------------|-------------------------------|
| <img width="641" height="688" alt="Screenshot 2026-08-17 at 17 22 35-20260817-152247" src="https://github.com/user-attachments/assets/39c6b71a-8734-4810-b956-7d771da24fbb" /> |https://github.com/user-attachments/assets/d54d7699-a173-4178-a780-4bd35f1f30f0 |

### 🧪 Tests

Partial: live-common hook + mobile `SelectAccount` regression covered; the new desktop receive filter is not. LLD (185), LLM (164) and live-common suites green, typecheck OK on all three.

### 🔍 QA focus

- Hyperliquid absent from send **and** receive pickers, Desktop + Mobile, drawer and legacy modals.
- **Adding** a Hyperliquid account still works (generic flow + Perps) — main regression risk.
- Known edge case left as is: on Desktop, adding a hypercore account from Receive reopens the modal with it pre-selected though the dropdown filters it out.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36103](https://ledgerhq.atlassian.net/browse/LIVE-36103)

[LIVE-36103]: https://ledgerhq.atlassian.net/browse/LIVE-36103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ