### PR TITLE
refactor(contacts): extract shared address entry presentation

### DIFF
--- a/features/flow/contacts/src/model/addressInputFieldProps.native.ts
+++ b/features/flow/contacts/src/model/addressInputFieldProps.native.ts
@@ -1,0 +1,6 @@
+export const CONTACTS_NATIVE_ADDRESS_INPUT_PROPS = {
+  autoCapitalize: "none",
+  autoComplete: "off",
+  autoCorrect: false,
+  spellCheck: false,
+} as const;

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntryView.native.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntryView.native.tsx
@@ -7,6 +7,7 @@ import {
   Box,
   Button,
 } from "@ledgerhq/lumen-ui-rnative";
+import { CONTACTS_NATIVE_ADDRESS_INPUT_PROPS } from "../../model/addressInputFieldProps.native";
 import type { ContactsAddAddressEntryViewProps } from "./ContactsAddAddressEntry.types";
 import { SanctionedAddressBanner } from "./components/SanctionedAddressBanner/SanctionedAddressBanner.native";
 
@@ -42,9 +43,7 @@ export function ContactsAddAddressEntryView({
             status={inputStatus}
             helperText={helperText}
             autoFocus
-            autoCapitalize="none"
-            autoCorrect={false}
-            spellCheck={false}
+            {...CONTACTS_NATIVE_ADDRESS_INPUT_PROPS}
           />
           {sanctionedAddressBanner ? (
             <SanctionedAddressBanner {...sanctionedAddressBanner} />

--- a/features/flow/contacts/src/steps/AddAddress/model/addressInputPresentation.ts
+++ b/features/flow/contacts/src/steps/AddAddress/model/addressInputPresentation.ts
@@ -1,0 +1,85 @@
+import type { SanctionedAddressBannerProps } from "../ContactsAddAddressEntry.types";
+import type { AddAddressEntryState } from "../types";
+
+export type AddressValidationLabels = Readonly<{
+  validatingAddress: string;
+  validAddress: string;
+  invalidAddress: string;
+  domainNotFound: string;
+  sanctionedAddress: string;
+  validationUnavailable: string;
+}>;
+
+export type AddressInputPresentation = Readonly<{
+  inputStatus: "success" | "error" | undefined;
+  helperText: string | undefined;
+  showEnsDisclaimer: boolean;
+}>;
+
+export type AddressEntryPresentation = AddressInputPresentation &
+  Readonly<{
+    isConfirmEnabled: boolean;
+  }>;
+
+export function resolveAddressInputPresentation(
+  addressEntry: AddAddressEntryState,
+  labels: AddressValidationLabels,
+): AddressInputPresentation {
+  switch (addressEntry.status) {
+    case "empty":
+      return { inputStatus: undefined, helperText: undefined, showEnsDisclaimer: false };
+    case "validating":
+      return {
+        inputStatus: undefined,
+        helperText: labels.validatingAddress,
+        showEnsDisclaimer: false,
+      };
+    case "valid":
+      return {
+        inputStatus: "success",
+        helperText: labels.validAddress,
+        showEnsDisclaimer: addressEntry.inputMethod === "ens",
+      };
+    case "invalid": {
+      let helperText = labels.invalidAddress;
+      if (addressEntry.error === "domain_not_found") {
+        helperText = labels.domainNotFound;
+      } else if (addressEntry.error === "sanctioned") {
+        helperText = labels.sanctionedAddress;
+      }
+
+      return {
+        inputStatus: "error",
+        helperText,
+        showEnsDisclaimer: addressEntry.inputMethod === "ens",
+      };
+    }
+    case "unavailable":
+      return {
+        inputStatus: "error",
+        helperText: labels.validationUnavailable,
+        showEnsDisclaimer: false,
+      };
+  }
+}
+
+export function resolveAddressEntryPresentation(
+  addressEntry: AddAddressEntryState,
+  labels: AddressValidationLabels,
+): AddressEntryPresentation {
+  return {
+    ...resolveAddressInputPresentation(addressEntry, labels),
+    isConfirmEnabled: addressEntry.status === "valid",
+  };
+}
+
+export function shouldShowSanctionedAddressBanner(
+  addressEntry: AddAddressEntryState,
+  sanctionedAddressBanner: SanctionedAddressBannerProps | undefined,
+): boolean {
+  return (
+    addressEntry.status === "invalid" &&
+    addressEntry.error === "sanctioned" &&
+    sanctionedAddressBanner !== undefined
+  );
+}

--- a/features/flow/contacts/src/steps/AddAddress/model/addressInputPresentation.web.test.ts
+++ b/features/flow/contacts/src/steps/AddAddress/model/addressInputPresentation.web.test.ts
@@ -1,0 +1,101 @@
+import { ContactAddressValueSchema } from "@domain/entity-contact";
+import {
+  resolveAddressEntryPresentation,
+  resolveAddressInputPresentation,
+} from "./addressInputPresentation";
+
+const labels = {
+  validatingAddress: "Validating",
+  validAddress: "Valid",
+  invalidAddress: "Invalid",
+  domainNotFound: "Domain not found",
+  sanctionedAddress: "Sanctioned",
+  validationUnavailable: "Unavailable",
+};
+
+describe("resolveAddressInputPresentation", () => {
+  it("should expose validating feedback while validation is in progress", () => {
+    expect(
+      resolveAddressInputPresentation(
+        {
+          status: "validating",
+          value: "0x123",
+          resolvedAddress: null,
+          inputMethod: "manual",
+        },
+        labels,
+      ),
+    ).toEqual({
+      inputStatus: undefined,
+      helperText: "Validating",
+      showEnsDisclaimer: false,
+    });
+  });
+
+  it("should expose ENS disclaimer for resolved domain addresses", () => {
+    expect(
+      resolveAddressInputPresentation(
+        {
+          status: "valid",
+          value: "vitalik.eth",
+          resolvedAddress: ContactAddressValueSchema.parse(
+            "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+          ),
+          inputMethod: "ens",
+        },
+        labels,
+      ),
+    ).toEqual({
+      inputStatus: "success",
+      helperText: "Valid",
+      showEnsDisclaimer: true,
+    });
+  });
+
+  it("should map sanctioned validation errors to the dedicated helper text", () => {
+    expect(
+      resolveAddressInputPresentation(
+        {
+          status: "invalid",
+          value: "0xbad",
+          resolvedAddress: null,
+          inputMethod: "manual",
+          error: "sanctioned",
+        },
+        labels,
+      ),
+    ).toEqual({
+      inputStatus: "error",
+      helperText: "Sanctioned",
+      showEnsDisclaimer: false,
+    });
+  });
+
+  it("should expose confirm enabled only for valid address entries", () => {
+    expect(
+      resolveAddressEntryPresentation(
+        {
+          status: "valid",
+          value: "0x123",
+          resolvedAddress: ContactAddressValueSchema.parse(
+            "0x1234567890123456789012345678901234567890",
+          ),
+          inputMethod: "manual",
+        },
+        labels,
+      ).isConfirmEnabled,
+    ).toBe(true);
+
+    expect(
+      resolveAddressEntryPresentation(
+        {
+          status: "validating",
+          value: "0x123",
+          resolvedAddress: null,
+          inputMethod: "manual",
+        },
+        labels,
+      ).isConfirmEnabled,
+    ).toBe(false);
+  });
+});

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.ts
@@ -8,6 +8,7 @@ import {
   type ContactId,
 } from "@domain/entity-contact";
 import type { ContactsAddressValidationPort, ContactsAddressValidationResult } from "./model/ports";
+import { wait } from "../../utils/wait";
 import type {
   AddAddressContact,
   AddAddressCurrencySelection,
@@ -37,10 +38,6 @@ export type UseAddAddressFlowViewModelOptions = Readonly<{
   addressValidation?: ContactsAddressValidationPort;
   manualValidationDebounceMs?: number;
 }>;
-
-function wait(delayMs: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, delayMs));
-}
 
 function createAddressLabelState(
   value: string,

--- a/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.native.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.native.ts
@@ -1,88 +1,13 @@
 import { useCallback } from "react";
+import {
+  resolveAddressEntryPresentation,
+  shouldShowSanctionedAddressBanner,
+} from "./model/addressInputPresentation";
 import type {
   ContactsAddAddressEntryProps,
   ContactsAddAddressEntryViewProps,
 } from "./ContactsAddAddressEntry.types";
-import type { AddAddressEntryLabels, AddAddressEntryState } from "./types";
-
-type AddressInputPresentation = Readonly<{
-  status?: "error" | "success";
-  helperText?: string;
-  showEnsDisclaimer: boolean;
-  isConfirmEnabled: boolean;
-}>;
-
-function getInsertedCharacterCount(previousValue: string, nextValue: string): number {
-  // Native only exposes the full next value, so isolate the changed middle section to detect paste.
-  let prefixLength = 0;
-  while (
-    prefixLength < previousValue.length &&
-    prefixLength < nextValue.length &&
-    previousValue[prefixLength] === nextValue[prefixLength]
-  ) {
-    prefixLength += 1;
-  }
-
-  let suffixLength = 0;
-  while (
-    suffixLength < previousValue.length - prefixLength &&
-    suffixLength < nextValue.length - prefixLength &&
-    previousValue[previousValue.length - 1 - suffixLength] ===
-      nextValue[nextValue.length - 1 - suffixLength]
-  ) {
-    suffixLength += 1;
-  }
-
-  return nextValue.length - prefixLength - suffixLength;
-}
-
-function resolveAddressInputPresentation(
-  addressEntry: AddAddressEntryState,
-  labels: AddAddressEntryLabels,
-): AddressInputPresentation {
-  switch (addressEntry.status) {
-    case "empty":
-      return {
-        showEnsDisclaimer: false,
-        isConfirmEnabled: false,
-      };
-    case "validating":
-      return {
-        helperText: labels.validatingAddress,
-        showEnsDisclaimer: false,
-        isConfirmEnabled: false,
-      };
-    case "valid":
-      return {
-        status: "success",
-        helperText: labels.validAddress,
-        showEnsDisclaimer: addressEntry.inputMethod === "ens",
-        isConfirmEnabled: true,
-      };
-    case "invalid": {
-      let helperText = labels.invalidAddress;
-      if (addressEntry.error === "domain_not_found") {
-        helperText = labels.domainNotFound;
-      } else if (addressEntry.error === "sanctioned") {
-        helperText = labels.sanctionedAddress;
-      }
-
-      return {
-        status: "error",
-        helperText,
-        showEnsDisclaimer: addressEntry.inputMethod === "ens",
-        isConfirmEnabled: false,
-      };
-    }
-    case "unavailable":
-      return {
-        status: "error",
-        helperText: labels.validationUnavailable,
-        showEnsDisclaimer: false,
-        isConfirmEnabled: false,
-      };
-  }
-}
+import { classifyNativeAddressInputMethod } from "../../utils/classifyNativeAddressInputMethod";
 
 export function useContactsAddAddressEntryViewModel({
   addressEntry,
@@ -93,16 +18,14 @@ export function useContactsAddAddressEntryViewModel({
   onConfirm,
   onQrCodeClick,
 }: ContactsAddAddressEntryProps): ContactsAddAddressEntryViewProps {
-  const presentation = resolveAddressInputPresentation(addressEntry, labels);
-  const shouldShowSanctionedAddressBanner =
-    addressEntry.status === "invalid" &&
-    addressEntry.error === "sanctioned" &&
-    sanctionedAddressBanner !== undefined;
+  const presentation = resolveAddressEntryPresentation(addressEntry, labels);
+  const showSanctionedAddressBanner = shouldShowSanctionedAddressBanner(
+    addressEntry,
+    sanctionedAddressBanner,
+  );
   const onAddressChange = useCallback(
     (value: string) => {
-      const inputMethod =
-        getInsertedCharacterCount(addressEntry.value, value) > 1 ? "paste" : "manual";
-      onChangeText(value, inputMethod);
+      onChangeText(value, classifyNativeAddressInputMethod(addressEntry.value, value));
     },
     [addressEntry.value, onChangeText],
   );
@@ -112,11 +35,9 @@ export function useContactsAddAddressEntryViewModel({
     labels,
     bottomOffset,
     bottomPadding: 32,
-    inputStatus: presentation.status,
-    helperText: shouldShowSanctionedAddressBanner ? undefined : presentation.helperText,
-    sanctionedAddressBanner: shouldShowSanctionedAddressBanner
-      ? sanctionedAddressBanner
-      : undefined,
+    inputStatus: presentation.inputStatus,
+    helperText: showSanctionedAddressBanner ? undefined : presentation.helperText,
+    sanctionedAddressBanner: showSanctionedAddressBanner ? sanctionedAddressBanner : undefined,
     showEnsDisclaimer: presentation.showEnsDisclaimer,
     isConfirmEnabled: presentation.isConfirmEnabled,
     onAddressChange,

--- a/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.ts
@@ -1,4 +1,9 @@
 import { useCallback, useMemo, type ChangeEvent, type ClipboardEvent } from "react";
+import { getPastedValue } from "../../utils/getPastedValue.web";
+import {
+  resolveAddressEntryPresentation,
+  shouldShowSanctionedAddressBanner,
+} from "./model/addressInputPresentation";
 import type {
   AddressLabelConfiguration,
   ContactsAddAddressEntryWebProps,
@@ -15,63 +20,6 @@ function getAddressLabelConfiguration({
     : undefined;
 }
 
-function getPastedValue(value: string, event: ClipboardEvent<HTMLInputElement>): string {
-  const input = event.currentTarget;
-  const pastedText = event.clipboardData.getData("text");
-  const selectionStart = input.selectionStart ?? value.length;
-  const selectionEnd = input.selectionEnd ?? value.length;
-
-  return `${value.slice(0, selectionStart)}${pastedText}${value.slice(selectionEnd)}`;
-}
-
-function resolveAddressInputPresentation(
-  addressEntry: ContactsAddAddressEntryWebProps["addressEntry"],
-  labels: ContactsAddAddressEntryWebProps["labels"],
-): Pick<
-  ContactsAddAddressEntryWebViewProps,
-  "inputStatus" | "helperText" | "showEnsDisclaimer" | "isConfirmEnabled"
-> {
-  switch (addressEntry.status) {
-    case "empty":
-      return { showEnsDisclaimer: false, isConfirmEnabled: false };
-    case "validating":
-      return {
-        helperText: labels.validatingAddress,
-        showEnsDisclaimer: false,
-        isConfirmEnabled: false,
-      };
-    case "valid":
-      return {
-        inputStatus: "success",
-        helperText: labels.validAddress,
-        showEnsDisclaimer: addressEntry.inputMethod === "ens",
-        isConfirmEnabled: true,
-      };
-    case "invalid": {
-      let helperText = labels.invalidAddress;
-      if (addressEntry.error === "domain_not_found") {
-        helperText = labels.domainNotFound;
-      } else if (addressEntry.error === "sanctioned") {
-        helperText = labels.sanctionedAddress;
-      }
-
-      return {
-        inputStatus: "error",
-        helperText,
-        showEnsDisclaimer: addressEntry.inputMethod === "ens",
-        isConfirmEnabled: false,
-      };
-    }
-    case "unavailable":
-      return {
-        inputStatus: "error",
-        helperText: labels.validationUnavailable,
-        showEnsDisclaimer: false,
-        isConfirmEnabled: false,
-      };
-  }
-}
-
 export function useContactsAddAddressEntryViewModel({
   addressEntry,
   labels,
@@ -82,7 +30,7 @@ export function useContactsAddAddressEntryViewModel({
 }: ContactsAddAddressEntryWebProps): ContactsAddAddressEntryWebViewProps {
   const addressLabelConfiguration = getAddressLabelConfiguration(addressLabelProps);
   const presentation = useMemo(
-    () => resolveAddressInputPresentation(addressEntry, labels),
+    () => resolveAddressEntryPresentation(addressEntry, labels),
     [addressEntry, labels],
   );
   const onChange = useCallback(
@@ -113,10 +61,10 @@ export function useContactsAddAddressEntryViewModel({
   const isNameValid =
     addressLabelConfiguration === undefined ||
     addressLabelConfiguration.addressLabel.status === "valid";
-  const shouldShowSanctionedAddressBanner =
-    addressEntry.status === "invalid" &&
-    addressEntry.error === "sanctioned" &&
-    sanctionedAddressBanner !== undefined;
+  const showSanctionedAddressBanner = shouldShowSanctionedAddressBanner(
+    addressEntry,
+    sanctionedAddressBanner,
+  );
 
   const addressLabelViewProps = addressLabelConfiguration
     ? {
@@ -131,9 +79,7 @@ export function useContactsAddAddressEntryViewModel({
     value: addressEntry.value,
     labels,
     ...presentation,
-    sanctionedAddressBanner: shouldShowSanctionedAddressBanner
-      ? sanctionedAddressBanner
-      : undefined,
+    sanctionedAddressBanner: showSanctionedAddressBanner ? sanctionedAddressBanner : undefined,
     ...addressLabelViewProps,
     isConfirmEnabled: presentation.isConfirmEnabled && isNameValid && onConfirm !== undefined,
     onChange,

--- a/features/flow/contacts/src/utils/classifyNativeAddressInputMethod.ts
+++ b/features/flow/contacts/src/utils/classifyNativeAddressInputMethod.ts
@@ -1,0 +1,9 @@
+import type { AddAddressInputSource } from "../steps/AddAddress/types";
+import { getInsertedCharacterCount } from "./getInsertedCharacterCount";
+
+export function classifyNativeAddressInputMethod(
+  previousValue: string,
+  nextValue: string,
+): AddAddressInputSource {
+  return getInsertedCharacterCount(previousValue, nextValue) > 1 ? "paste" : "manual";
+}

--- a/features/flow/contacts/src/utils/classifyNativeAddressInputMethod.web.test.ts
+++ b/features/flow/contacts/src/utils/classifyNativeAddressInputMethod.web.test.ts
@@ -1,0 +1,11 @@
+import { classifyNativeAddressInputMethod } from "./classifyNativeAddressInputMethod";
+
+describe("classifyNativeAddressInputMethod", () => {
+  it("should classify single-character edits as manual input", () => {
+    expect(classifyNativeAddressInputMethod("0x123", "0x1234")).toBe("manual");
+  });
+
+  it("should classify multi-character inserts as paste", () => {
+    expect(classifyNativeAddressInputMethod("0x1234", "0x1234567890")).toBe("paste");
+  });
+});

--- a/features/flow/contacts/src/utils/getInsertedCharacterCount.ts
+++ b/features/flow/contacts/src/utils/getInsertedCharacterCount.ts
@@ -1,0 +1,22 @@
+export function getInsertedCharacterCount(previousValue: string, nextValue: string): number {
+  let prefixLength = 0;
+  while (
+    prefixLength < previousValue.length &&
+    prefixLength < nextValue.length &&
+    previousValue[prefixLength] === nextValue[prefixLength]
+  ) {
+    prefixLength += 1;
+  }
+
+  let suffixLength = 0;
+  while (
+    suffixLength < previousValue.length - prefixLength &&
+    suffixLength < nextValue.length - prefixLength &&
+    previousValue[previousValue.length - 1 - suffixLength] ===
+      nextValue[nextValue.length - 1 - suffixLength]
+  ) {
+    suffixLength += 1;
+  }
+
+  return nextValue.length - prefixLength - suffixLength;
+}

--- a/features/flow/contacts/src/utils/getInsertedCharacterCount.web.test.ts
+++ b/features/flow/contacts/src/utils/getInsertedCharacterCount.web.test.ts
@@ -1,0 +1,16 @@
+import { getInsertedCharacterCount } from "./getInsertedCharacterCount";
+
+describe("getInsertedCharacterCount", () => {
+  it("should return zero when the value is unchanged", () => {
+    expect(getInsertedCharacterCount("0x1234", "0x1234")).toBe(0);
+  });
+
+  it("should return one for a single-character edit", () => {
+    expect(getInsertedCharacterCount("0x123", "0x1234")).toBe(1);
+  });
+
+  it("should return the pasted segment length for multi-character inserts", () => {
+    expect(getInsertedCharacterCount("0x1234", "0x1234567890")).toBe(6);
+    expect(getInsertedCharacterCount("0x1234", "0x12pasted567890")).toBe(12);
+  });
+});

--- a/features/flow/contacts/src/utils/getPastedValue.web.test.ts
+++ b/features/flow/contacts/src/utils/getPastedValue.web.test.ts
@@ -1,0 +1,61 @@
+import type { ClipboardEvent } from "react";
+import { getPastedValue } from "./getPastedValue.web";
+
+function createClipboardEvent({
+  pastedText,
+  selectionStart,
+  selectionEnd,
+  getData = () => pastedText,
+}: {
+  pastedText: string;
+  selectionStart: number | null;
+  selectionEnd: number | null;
+  getData?: (format: string) => string;
+}): ClipboardEvent<HTMLInputElement> {
+  return {
+    currentTarget: { selectionStart, selectionEnd },
+    clipboardData: { getData },
+  } as unknown as ClipboardEvent<HTMLInputElement>;
+}
+
+describe("getPastedValue", () => {
+  it("should insert the pasted text at the caret position", () => {
+    const event = createClipboardEvent({ pastedText: "34", selectionStart: 4, selectionEnd: 4 });
+
+    expect(getPastedValue("0x12", event)).toBe("0x1234");
+  });
+
+  it("should replace the selected range with the pasted text", () => {
+    const event = createClipboardEvent({
+      pastedText: "abcd",
+      selectionStart: 2,
+      selectionEnd: 6,
+    });
+
+    expect(getPastedValue("0x1234", event)).toBe("0xabcd");
+  });
+
+  it("should append the pasted text when the selection is unavailable", () => {
+    const event = createClipboardEvent({
+      pastedText: "34",
+      selectionStart: null,
+      selectionEnd: null,
+    });
+
+    expect(getPastedValue("0x12", event)).toBe("0x1234");
+  });
+
+  it("should read the clipboard as plain text", () => {
+    const getData = jest.fn(() => "34");
+    const event = createClipboardEvent({
+      pastedText: "34",
+      selectionStart: 4,
+      selectionEnd: 4,
+      getData,
+    });
+
+    getPastedValue("0x12", event);
+
+    expect(getData).toHaveBeenCalledWith("text/plain");
+  });
+});

--- a/features/flow/contacts/src/utils/getPastedValue.web.ts
+++ b/features/flow/contacts/src/utils/getPastedValue.web.ts
@@ -1,0 +1,10 @@
+import type { ClipboardEvent } from "react";
+
+export function getPastedValue(value: string, event: ClipboardEvent<HTMLInputElement>): string {
+  const input = event.currentTarget;
+  const pastedText = event.clipboardData.getData("text/plain");
+  const selectionStart = input.selectionStart ?? value.length;
+  const selectionEnd = input.selectionEnd ?? value.length;
+
+  return `${value.slice(0, selectionStart)}${pastedText}${value.slice(selectionEnd)}`;
+}

--- a/features/flow/contacts/src/utils/wait.ts
+++ b/features/flow/contacts/src/utils/wait.ts
@@ -1,0 +1,3 @@
+export function wait(delayMs: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, delayMs));
+}


### PR DESCRIPTION
## Summary
- Extract shared address-entry helpers from Add Address: validation presentation, native paste classification, web paste handling, debounce wait helper, and native input props.
- Independent of the Edit Address feature. Edit Address consumption lands in the next PR in the stack.

Replaces the previous extract PR #20762, which GitHub auto-merged after the stack rewrite (the extract commit became an ancestor of the former base branch).

## Test plan
- [x] `pnpm --filter @features/flow-contacts typecheck`
- [x] `pnpm --filter @features/flow-contacts test` (presentation + utils)
- [ ] Verify Add Address entry still shows validation feedback on web and mobile


Made with [Cursor](https://cursor.com)