### PR TITLE
[LWDM] feat(contacts): wire edit address into desktop and mobile (LIVE-35836)

### DIFF
--- a/.changeset/contacts-edit-address-apps.md
+++ b/.changeset/contacts-edit-address-apps.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Wire Contacts edit-address validation and analytics into desktop.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -957,6 +957,9 @@ describe("Contacts integration", () => {
       expect(screen.queryByTestId("contacts-edit-signer-dialog")).not.toBeInTheDocument();
       expect(screen.queryByTestId("contacts-address-detail-dialog")).not.toBeInTheDocument();
       expect(screen.getByTestId("contacts-rename-address-dialog")).toBeVisible();
+      expect(screen.getByTestId("contacts-edit-address-input")).toHaveValue(
+        "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+      );
     });
   });
 
@@ -984,6 +987,43 @@ describe("Contacts integration", () => {
       expect(screen.getByTestId("contacts-detail-address-row-address-ethereum")).toHaveTextContent(
         "Main ETH",
       );
+    });
+  });
+
+  it("should update an address value and close the edit dialog", async () => {
+    const newAddress = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd";
+    const { user } = renderContactsScreen(populatedContactsPageState);
+
+    await user.click(screen.getByTestId("contacts-saved-row-contact-ben"));
+    await user.click(screen.getByTestId("contacts-detail-address-row-address-ethereum"));
+
+    await user.click(screen.getByTestId("contacts-address-detail-edit"));
+    await user.click(screen.getByTestId("contacts-edit-signer-confirm"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts-rename-address-dialog")).toBeVisible();
+    });
+
+    fireEvent.change(screen.getByTestId("contacts-edit-address-input"), {
+      target: { value: newAddress },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts-rename-address-confirm")).not.toBeDisabled();
+    });
+
+    await user.click(screen.getByTestId("contacts-rename-address-confirm"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("contacts-rename-address-dialog")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("contacts-address-detail-dialog")).not.toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("contacts-detail-address-row-address-ethereum"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts-address-detail-dialog")).toBeVisible();
+      expect(screen.getByTestId("contacts-address-detail-dialog")).toHaveTextContent(newAddress);
     });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactAddressDetailActionsAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactAddressDetailActionsAdapter.ts
@@ -1,4 +1,5 @@
 import { ContactIdSchema, type ContactAddressId, type ContactId } from "@domain/entity-contact";
+import { getCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
 import {
   type ContactsDeleteAddressDialogProps,
   type ContactsEditSignerDialogProps,
@@ -6,18 +7,27 @@ import {
   type ContactsRenameAddressDialogProps,
   type ContactAddressDetailDialogProps,
   type ContactAddressDetailSendIntent,
+  CONTACTS_EVENT_SOURCE,
+  CONTACTS_FLOW,
+  CONTACTS_PAGE_EVENTS,
+  CONTACTS_PAGE_PROPERTY,
+  CONTACTS_TRACK_EVENTS,
+  CONTACTS_TRACKING_BUTTON,
   createActiveContactAddressDetailActionsUiState,
   createInactiveContactAddressDetailActionsUiState,
   resolveContactAddressDetailActionsLabels,
   useContactAddressDetailActionsFlowBindings,
   useContactsAddressDetailActionsPorts,
-  CONTACTS_TRACKING_BUTTON,
   trackContactAddressDetailQuickAction,
+  type ContactAddressEditSavePayload,
 } from "@features/flow-contacts";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useOpenSendFlow } from "LLD/features/Send/hooks/useOpenSendFlow";
-import { useContactsAnalytics } from "../../analytics";
+import { useContactsAnalytics, resolveContactsCurrencyAnalytics } from "../../analytics";
+import { useContactsAddressValidationAdapter } from "../../hooks/useContactsAddressValidationAdapter";
+
+const MANUAL_ADDRESS_VALIDATION_DEBOUNCE_MS = 200;
 
 export type ContactAddressDetailActionsDialogProps = Readonly<{
   addressDetailDialog: Pick<
@@ -47,18 +57,49 @@ export function useContactAddressDetailActionsAdapter(
   addressId: ContactAddressId | undefined,
   onCloseAddressDetail: () => void,
   asset?: string,
+  network?: string,
 ): ContactAddressDetailActionsDialogProps {
   const { t } = useTranslation();
   const analytics = useContactsAnalytics();
   const ports = useContactsAddressDetailActionsPorts();
+  const addressValidation = useContactsAddressValidationAdapter();
   const openSendFlow = useOpenSendFlow();
+  const hasTrackedEditAddressPage = useRef(false);
+  const hasTrackedSignerMismatch = useRef(false);
   const isSelectionActive = contactId !== undefined && addressId !== undefined;
   const labels = useMemo(() => resolveContactAddressDetailActionsLabels({ t }), [t]);
   const trackQuickAction = useCallback(
     (button: Parameters<typeof trackContactAddressDetailQuickAction>[1]) => {
-      trackContactAddressDetailQuickAction(analytics, button, asset);
+      trackContactAddressDetailQuickAction(analytics, button, asset, network);
     },
-    [analytics, asset],
+    [analytics, asset, network],
+  );
+  const onEditAddressSaved = useCallback(
+    async (payload: ContactAddressEditSavePayload) => {
+      if (payload.currencyId === undefined) {
+        return;
+      }
+
+      try {
+        const { network: resolvedNetwork, asset: resolvedAsset } =
+          await resolveContactsCurrencyAnalytics(payload.currencyId, {
+            findTokenById: currencyId => getCryptoAssetsStore().findTokenById(currencyId),
+          });
+        const inputMethod = payload.inputMethod ?? "manual";
+
+        analytics.trackEvent(CONTACTS_TRACK_EVENTS.ADDRESS_EDITED, {
+          source: CONTACTS_EVENT_SOURCE.EDIT_ADDRESS,
+          network: network ?? resolvedNetwork,
+          asset: asset ?? resolvedAsset,
+          inputMethod,
+          isEns: inputMethod === "ens",
+          flow: CONTACTS_FLOW.CONTACTS,
+        });
+      } catch {
+        // Analytics enrichment is best-effort and must not affect the user flow.
+      }
+    },
+    [analytics, asset, network],
   );
   const onSend = useCallback(
     (intent: ContactAddressDetailSendIntent) => {
@@ -75,8 +116,11 @@ export function useContactAddressDetailActionsAdapter(
     contactId: contactId ?? ContactIdSchema.parse("contact-me"),
     addressId: isSelectionActive ? addressId : undefined,
     ports,
+    addressValidation,
+    manualValidationDebounceMs: MANUAL_ADDRESS_VALIDATION_DEBOUNCE_MS,
     onSend,
     onCloseAddressDetail,
+    onEditAddressSaved,
   });
   const onEdit = useCallback(() => {
     trackQuickAction(CONTACTS_TRACKING_BUTTON.edit);
@@ -86,6 +130,51 @@ export function useContactAddressDetailActionsAdapter(
     trackQuickAction(CONTACTS_TRACKING_BUTTON.delete);
     flow.onDeletePress();
   }, [flow, trackQuickAction]);
+  const onConfirmEditAddress = useCallback(async () => {
+    analytics.trackEvent(CONTACTS_TRACK_EVENTS.BUTTON_CLICKED, {
+      source: CONTACTS_EVENT_SOURCE.EDIT_ADDRESS,
+      button: CONTACTS_TRACKING_BUTTON.applyChanges,
+      page: CONTACTS_PAGE_PROPERTY.EDIT_ADDRESS,
+      ...(asset ? { asset } : {}),
+      ...(network ? { network } : {}),
+      flow: CONTACTS_FLOW.CONTACTS,
+    });
+    await renameViewModel.onConfirm();
+  }, [analytics, asset, network, renameViewModel]);
+
+  useEffect(() => {
+    if (!renameViewModel.isOpen) {
+      hasTrackedEditAddressPage.current = false;
+      return;
+    }
+
+    if (hasTrackedEditAddressPage.current || asset === undefined || network === undefined) {
+      return;
+    }
+
+    hasTrackedEditAddressPage.current = true;
+    analytics.trackPage(CONTACTS_PAGE_EVENTS.EDIT_ADDRESS, {
+      source: CONTACTS_EVENT_SOURCE.EDIT_ADDRESS,
+      network,
+      asset,
+    });
+  }, [analytics, asset, network, renameViewModel.isOpen]);
+
+  useEffect(() => {
+    if (flow.editUiState === "signer-mismatch" && !hasTrackedSignerMismatch.current) {
+      hasTrackedSignerMismatch.current = true;
+      analytics.trackEvent(CONTACTS_TRACK_EVENTS.ERROR_DISPLAYED, {
+        source: CONTACTS_EVENT_SOURCE.EDIT_ADDRESS,
+        page: CONTACTS_PAGE_PROPERTY.EDIT_ADDRESS,
+        errorType: "signer_mismatch",
+      });
+      return;
+    }
+
+    if (flow.editUiState !== "signer-mismatch") {
+      hasTrackedSignerMismatch.current = false;
+    }
+  }, [analytics, flow.editUiState]);
 
   if (!isSelectionActive) {
     return mapUiStateToDialogProps(createInactiveContactAddressDetailActionsUiState(labels));
@@ -99,6 +188,10 @@ export function useContactAddressDetailActionsAdapter(
       ...uiState.addressDetailDialog,
       onEdit,
       onDelete,
+    },
+    renameDialog: {
+      ...uiState.rename,
+      onConfirm: onConfirmEditAddress,
     },
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailPaneAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailPaneAdapter.ts
@@ -57,11 +57,13 @@ export function useContactDetailPaneAdapter(
     clearSelection,
   } = useContactAddressDetailDialog(populatedContactDetail);
   const addressDetailAsset = selection?.network.networkTicker;
+  const addressDetailNetwork = selection?.network.networkName;
   const addressDetailActionsDialogs = useContactAddressDetailActionsAdapter(
     detailContactId,
     selection?.row?.addressId,
     onCloseAddressDetail,
     addressDetailAsset,
+    addressDetailNetwork,
   );
   const labels = useMemo<ContactDetailLabels>(
     () => ({

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.ts
@@ -19,6 +19,9 @@ import { useCallback, useMemo } from "react";
 import { ScreenName } from "~/const";
 import { useTranslation } from "~/context/Locale";
 import { useContactsAnalytics } from "../analytics/useContactsAnalytics";
+import { useContactsAddressValidationAdapter } from "./useContactsAddressValidationAdapter";
+
+const MANUAL_ADDRESS_VALIDATION_DEBOUNCE_MS = 200;
 
 export type ContactAddressDetailActionsFlowProps = Readonly<{
   addressDetailDialog: Pick<
@@ -52,6 +55,7 @@ export function useContactAddressDetailActionsAdapter(
   const { t } = useTranslation();
   const analytics = useContactsAnalytics();
   const ports = useContactsAddressDetailActionsPorts();
+  const addressValidation = useContactsAddressValidationAdapter();
   const { handleOpenSendFlow } = useOpenSendFlow({
     sourceScreenName: ScreenName.MyWalletContactDetail,
   });
@@ -90,6 +94,8 @@ export function useContactAddressDetailActionsAdapter(
     contactId: contactId ?? ContactIdSchema.parse("contact-me"),
     addressId: isSelectionActive ? addressId : undefined,
     ports,
+    addressValidation,
+    manualValidationDebounceMs: MANUAL_ADDRESS_VALIDATION_DEBOUNCE_MS,
     onSend,
     onCloseAddressDetail,
   });


### PR DESCRIPTION
## Summary
- Wire address validation into desktop and mobile Edit Address adapters so the saved wallet address can actually be validated and saved.
- Add desktop edit-address analytics (page view, apply changes, `address_edited`, signer mismatch) and integration coverage for updating the address value.

Stacked on #20748. Bottom of the stack is #20881.

## Test plan
- [x] Desktop Contacts integration: rename address and update address value
- [x] Mobile `useContactAddressDetailActionsAdapter` test
- [ ] Desktop: edit a saved address value and confirm it updates
- [ ] Mobile: edit a saved address value and confirm it updates


Made with [Cursor](https://cursor.com)