### PR TITLE
feat(test-quarantine): flake reporting core and jest reporter

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -170,6 +170,8 @@ jobs:
       AWS_CACHE_REGION: ${{ secrets.AWS_CACHE_REGION }}
       AWS_CACHE_ROLE_NAME: ${{ secrets.AWS_CACHE_ROLE_NAME }}
       NX_KEY: ${{ secrets.NX_KEY }}
+      FLAKE_API_KEY_CI: ${{ secrets.FLAKE_API_KEY_CI }}
+      FLAKE_API_HOST: ${{ secrets.FLAKE_API_HOST }}
 
   test-features:
     name: "Test Features"

--- a/.github/workflows/build-and-test-push.yml
+++ b/.github/workflows/build-and-test-push.yml
@@ -122,6 +122,8 @@ jobs:
       AWS_CACHE_REGION: ${{ secrets.AWS_CACHE_REGION }}
       AWS_CACHE_ROLE_NAME: ${{ secrets.AWS_CACHE_ROLE_NAME }}
       NX_KEY: ${{ secrets.NX_KEY }}
+      FLAKE_API_KEY_CI: ${{ secrets.FLAKE_API_KEY_CI }}
+      FLAKE_API_HOST: ${{ secrets.FLAKE_API_HOST }}
 
   test-features:
     name: "Test Features"

--- a/.github/workflows/test-libs-reusable.yml
+++ b/.github/workflows/test-libs-reusable.yml
@@ -19,6 +19,12 @@ on:
         required: true
       NX_KEY:
         required: true
+      # Without credentials the flake reporter degrades gracefully
+      FLAKE_API_KEY_CI:
+        required: false
+      FLAKE_API_HOST:
+        required: false
+
   workflow_dispatch:
     inputs:
       since_branch:
@@ -45,6 +51,8 @@ jobs:
       NODE_OPTIONS: "--max-old-space-size=7168"
       FORCE_COLOR: 3
       CI_OS: ubuntu-22.04
+      FLAKE_API_KEY: ${{ secrets.FLAKE_API_KEY_CI }}
+      FLAKE_API_HOST: ${{ secrets.FLAKE_API_HOST }}
     outputs:
       coverage_generated: ${{ contains(steps.generate_coverage.outcome, 'success') }}
 

--- a/libs/coin-modules/coin-bitcoin/jest.config.js
+++ b/libs/coin-modules/coin-bitcoin/jest.config.js
@@ -32,6 +32,7 @@ module.exports = {
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
-  setupFilesAfterEnv: ["@ledgerhq/wallet-framework-test-setup"],
+  setupFilesAfterEnv: ["@ledgerhq/wallet-framework-test-setup", "<rootDir>/jest.retries.js"],
 };

--- a/libs/coin-modules/coin-bitcoin/jest.retries.js
+++ b/libs/coin-modules/coin-bitcoin/jest.retries.js
@@ -1,0 +1,20 @@
+// Retry a failing test once in CI so that genuinely flaky tests are observable.
+//
+// This is what makes @ledgerhq/test-quarantine/jest produce data: with no
+// retries there is never a second attempt, so a flake is indistinguishable from
+// a hard failure. A test that fails both attempts still fails the build.
+//
+// Safe to key off CI alone here because this config runs unit tests only — the
+// integration tests have their own config (jest.integ.config.js) and are
+// excluded from this one, so nothing that touches the network is retried.
+//
+// Deliberately CI-only: locally a failure should surface immediately rather than
+// being retried behind the engineer's back.
+//
+// logErrorsBeforeRetry is not optional in spirit: without it jest discards the
+// failed attempt entirely and prints nothing, so a flaky test is reported as a
+// plain pass and the run looks clean. With it, jest logs the failure and a code
+// frame before retrying, which is the only place the actual cause is visible.
+if (process.env.CI) {
+  jest.retryTimes(1, { logErrorsBeforeRetry: true });
+}

--- a/libs/coin-modules/coin-bitcoin/package.json
+++ b/libs/coin-modules/coin-bitcoin/package.json
@@ -68,6 +68,7 @@
     "@bitcoinerlab/secp256k1": "1.2.0",
     "@domain/entity-currency-crypto": "workspace:^",
     "@ledgerhq/disable-network-setup": "workspace:^",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@ledgerhq/wallet-framework-test-setup": "workspace:^",
     "@noble/curves": "1.9.7",
     "@swc/core": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ catalogs:
     '@jest/reporters':
       specifier: 30.2.0
       version: 30.2.0
+    '@jest/test-result':
+      specifier: 30.2.0
+      version: 30.2.0
     '@ledgerhq/coin-hypercore':
       specifier: 2.0.0
       version: 2.0.0
@@ -6960,6 +6963,9 @@ importers:
       '@ledgerhq/disable-network-setup':
         specifier: workspace:^
         version: link:../../disable-network-setup
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../tools/test-quarantine
       '@ledgerhq/wallet-framework-test-setup':
         specifier: workspace:^
         version: link:../../wallet-framework-test-setup
@@ -16007,6 +16013,24 @@ importers:
       prettier:
         specifier: 2.8.8
         version: 2.8.8
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
+  tools/test-quarantine:
+    devDependencies:
+      '@jest/reporters':
+        specifier: 'catalog:'
+        version: 30.2.0
+      '@jest/test-result':
+        specifier: 'catalog:'
+        version: 30.2.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      jest-cli:
+        specifier: 30.2.0
+        version: 30.2.0(@types/node@24.12.0)
       typescript:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -84,6 +84,7 @@ catalog:
   expo-modules-autolinking: 3.0.24
   expo-modules-core: 3.0.29
   "@jest/reporters": 30.2.0
+  "@jest/test-result": 30.2.0
   "@reduxjs/toolkit": 2.11.2
   "@rsbuild/core": 2.0.9
   "@rsbuild/plugin-node-polyfill": 1.4.5

--- a/tools/test-quarantine/README.md
+++ b/tools/test-quarantine/README.md
@@ -1,0 +1,143 @@
+# @ledgerhq/test-quarantine
+
+Flake reporting for the repo's test suites. Test quarantine follows in a later phase.
+
+A **flake** is a test that failed an attempt and passed a later one within the same run.
+This package spots those and reports them to the wallet-flake-reporting ingest API, so
+flakiness can be triaged from data rather than from memory.
+
+## How it plugs in
+
+Everything happens **in-process, through each runner's own reporter API**. Nothing here
+wraps a runner, rewrites its command-line arguments, or parses its output files. That is
+a deliberate constraint: argument rewriting collides with whatever the caller and the
+project's config already pass, and it silently changes which tests run.
+
+```
+core/       runner-agnostic; no runner imports
+  outcome     the one normalised record: a single attempt at a single test
+  detect      groups attempts per test and flags fail-then-pass
+  redact      strips secret-shaped text out of failure messages
+  ingest      batching, retry and delivery to the ingest API
+  paths       repo-relative path normalisation
+  ci          CI detection and the run URL
+
+jest/       the jest reporter
+```
+
+Only `core/redact.ts` uses regular expressions, because redaction is inherently pattern
+matching. Everything else compares strings exactly.
+
+## Enabling it for a jest package
+
+Add the reporter to the package's jest config:
+
+```js
+reporters: [
+  "default",
+  "@ledgerhq/test-quarantine/jest",
+],
+```
+
+and add the dependency, which is required rather than optional — the repo sets
+`hoist=false`, so an undeclared import only resolves by accident:
+
+```json
+"devDependencies": { "@ledgerhq/test-quarantine": "workspace:*" }
+```
+
+**The reporter is inert until the package enables retries.** With no retries there is
+never a second attempt, so a flake is indistinguishable from a hard failure:
+
+```js
+// jest.retries.js, referenced from setupFilesAfterEnv
+if (process.env.CI) {
+  jest.retryTimes(1, { logErrorsBeforeRetry: true });
+}
+```
+
+Pass `logErrorsBeforeRetry`. Without it jest throws the failed attempt away and prints
+nothing at all — the test is reported as a plain pass and the run looks clean, so the only
+hint a flake happened is this tool's own output. With it, jest logs the failure and a code
+frame before retrying, which is where the actual cause shows up.
+
+**Check what else that config runs before you enable it.** Retrying a suite that talks to
+third-party nodes turns a real outage green. `coin-bitcoin` is safe keyed off `CI` alone
+because its integration tests live in a separate config (`jest.integ.config.js`) and are
+excluded from the unit one. Where a single config serves several suites — as
+`ledger-live-common` does for its unit, integration, weekly and bridge runs — gate on a flag
+that only the unit run sets (an entry in its `.ci.unit.env`) instead of on `CI`.
+
+Enabling retries is a real change to CI semantics: a flaky test starts passing the build and
+gets reported instead of failing it. A test that fails every attempt still fails the build.
+Roll it out per package, deliberately.
+
+### One thing it cannot see
+
+Flakes are grouped by `(file, full title)`, because no runner exposes a stable per-test id.
+So `test.each` with a **static** title gives every case one title, and the tool cannot tell
+those cases apart. It errs towards silence: a first-attempt pass is never treated as
+evidence, so a hard failure in one case is never reported as a flake because a sibling
+passed. The cost is that if one such case genuinely flakes, the failure text may be
+attributed to a sibling. Interpolate the parameters into `each` titles
+(`test.each([...])("rejects %s", …)`) and the ambiguity disappears.
+
+## Configuration
+
+| Variable               | Effect                                                                 |
+| ---------------------- | ---------------------------------------------------------------------- |
+| `CI`                   | Reporting only happens in CI. Unset locally, nothing is sent.           |
+| `FLAKE_API_HOST`       | Ingest host. Reporting no-ops with a warning when unset.                |
+| `FLAKE_API_KEY`        | Ingest credential. Reporting no-ops with a warning when unset.          |
+| `QUARANTINE_REPO_ROOT` | Pins the root that reported paths are relative to. Discovered if unset. |
+
+Reporting is best-effort by design: every failure path warns and continues, and total time
+spent waiting on rate limits is capped for the whole run. Nothing in this package can fail
+or stall a test job — `test/jest-integration.test.ts` asserts that a real jest run still
+exits 0 when the ingest API returns 500, refuses the connection, or is misconfigured.
+
+## What gets sent
+
+Per flake: the full test title, the repo-relative file path, a retry count, the CI run URL,
+and the failure text.
+
+The failure text is processed before it leaves the machine. Runners hand over message and
+stack as one string, so the stack is **cut at the first frame** and only the human-readable
+part above it is kept — that is what makes "stacks are never sent" true rather than
+aspirational. What remains is then denylist-redacted for secret-shaped content
+(mnemonic-like word runs, long hex blobs, bech32 addresses, URLs). Redaction deliberately
+over-matches: it will swallow innocent prose next to a secret rather than risk the reverse.
+
+This policy is still provisional pending the security sign-off the PRD tracks.
+
+The ingest endpoint is contacted by CI test tooling only, never by the shipped apps, so it
+is deliberately not listed in [`docs/services.md`](../../docs/services.md) — that catalog
+covers what Ledger Live Desktop and Mobile contact at runtime.
+
+## Why the source ships as raw TypeScript
+
+There is no build step, matching `tools/prune-changelogs`. Node 24 strips the types on
+load, which works because pnpm links workspace packages as symlinks: Node resolves the
+real path, which lives outside `node_modules`. Node refuses to strip types from files
+whose real path *is* under `node_modules`, so a copied — rather than linked — install of
+this package would fail to load the reporter. `test/jest-integration.test.ts` reproduces
+the symlinked layout so this stays covered.
+
+Two consequences for anyone editing `src/`:
+
+- Do not use `enum`, `namespace`, or constructor parameter properties. Node's type
+  stripping rejects anything that needs code generation.
+- Import with explicit `.ts` extensions, as the existing files do.
+
+## Tests
+
+```sh
+pnpm --filter @ledgerhq/test-quarantine test
+```
+
+Unit tests cover the core. `test/jest-integration.test.ts` runs a **real jest process**
+against a fixture project with a genuinely flaky test, loading the real reporter through
+the package's `exports`, and asserts against a stub ingest server. That test pins the
+upstream behaviour the reporter depends on — that jest-circus reports each attempt
+separately, with a 1-based `invocations` count — so an upstream change surfaces as a
+failure here instead of silently reducing every flake to `retryCount: 0`.

--- a/tools/test-quarantine/package.json
+++ b/tools/test-quarantine/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@ledgerhq/test-quarantine",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Flake reporting and test quarantine for the repo's jest, Playwright and Detox suites.",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./jest": "./src/jest/flake-reporter.ts"
+  },
+  "scripts": {
+    "test": "node --test \"test/**/*.test.ts\"",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint ./",
+    "lint:fix": "oxlint ./ --fix --quiet"
+  },
+  "devDependencies": {
+    "@jest/reporters": "catalog:",
+    "@jest/test-result": "catalog:",
+    "@types/node": "catalog:",
+    "jest-cli": "30.2.0",
+    "typescript": "catalog:"
+  }
+}

--- a/tools/test-quarantine/src/core/ci.ts
+++ b/tools/test-quarantine/src/core/ci.ts
@@ -1,0 +1,18 @@
+/**
+ * Flake reporting only runs in CI: a local run retrying a test says nothing
+ * about the health of the shared suite, and developers should not need
+ * credentials to run tests.
+ */
+export function isCI(env: NodeJS.ProcessEnv = process.env): boolean {
+  const flag = env.CI;
+  if (!flag) return false;
+  // Some setups export CI explicitly disabled rather than leaving it unset.
+  return flag !== "false" && flag !== "0";
+}
+
+/** Link back to the workflow run a flake was observed in, when on GitHub Actions. */
+export function ciRunUrl(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } = env;
+  if (!GITHUB_SERVER_URL || !GITHUB_REPOSITORY || !GITHUB_RUN_ID) return undefined;
+  return `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`;
+}

--- a/tools/test-quarantine/src/core/detect.ts
+++ b/tools/test-quarantine/src/core/detect.ts
@@ -1,0 +1,88 @@
+import type { TestOutcome } from "./outcome.ts";
+
+/** A test that failed at least once and then passed, within a single run. */
+export interface Flake {
+  file: string;
+  title: string;
+  /** Failure text from the last failing attempt before the test passed. */
+  errorMessage?: string;
+  /** How many retries it took to pass. A test that passed on its first retry is 1. */
+  retryCount: number;
+}
+
+/**
+ * Could this attempt be half of a fail-then-pass pair?
+ *
+ * A pass on the very first attempt cannot follow a failure of the same test, and
+ * a skip is never part of a flake. Discarding those is not just an optimisation:
+ * it is what stops tests that merely SHARE a title from being mistaken for one
+ * test that failed and then passed.
+ *
+ * That case is real and common. `test.each` with a static title produces several
+ * cases under a single `fullName`, and no runner exposes a stable per-case id, so
+ * grouping cannot tell them apart. Without this filter, "case A failed on its
+ * first attempt, case B passed on its first attempt" reads as a flake — and gets
+ * reported with `retryCount: 0` on a run that is genuinely red.
+ */
+export function canContributeToFlake(outcome: TestOutcome): boolean {
+  return outcome.status === "failed" || outcome.attempt > 0;
+}
+
+/**
+ * Grouping key for one test. JSON encoding keeps the two fields unambiguous
+ * without inventing a separator that a path or title might itself contain.
+ */
+function testKey(file: string, title: string): string {
+  return JSON.stringify([file, title]);
+}
+
+/**
+ * Group attempts by test, then flag every test that failed and later passed.
+ *
+ * This is deliberately the only place flakiness is defined. Each runner adapter
+ * decides how to observe attempts; none of them decides what a flake is.
+ */
+export function detectFlakes(outcomes: TestOutcome[]): Flake[] {
+  const attemptsByTest = new Map<string, TestOutcome[]>();
+  for (const outcome of outcomes) {
+    if (!canContributeToFlake(outcome)) continue;
+    const key = testKey(outcome.file, outcome.title);
+    const attempts = attemptsByTest.get(key);
+    if (attempts) attempts.push(outcome);
+    else attemptsByTest.set(key, [outcome]);
+  }
+
+  const flakes: Flake[] = [];
+  for (const attempts of attemptsByTest.values()) {
+    const flake = findFailThenPass(attempts);
+    if (flake) flakes.push(flake);
+  }
+  return flakes;
+}
+
+/**
+ * A test is a flake when an earlier attempt failed and a later one passed.
+ *
+ * The reported `errorMessage` comes from the last failure before that pass,
+ * which is the failure someone debugging the flake will want to see.
+ */
+function findFailThenPass(attempts: TestOutcome[]): Flake | undefined {
+  // Sorting by attempt alone is enough: the sort is stable, so attempts a runner
+  // reported under the same index keep the order they arrived in.
+  const ordered = [...attempts].sort((a, b) => a.attempt - b.attempt);
+
+  let lastFailure: TestOutcome | undefined;
+  for (const attempt of ordered) {
+    if (attempt.status === "failed") {
+      lastFailure = attempt;
+    } else if (attempt.status === "passed" && lastFailure) {
+      return {
+        file: lastFailure.file,
+        title: lastFailure.title,
+        errorMessage: lastFailure.errorMessage,
+        retryCount: attempt.attempt,
+      };
+    }
+  }
+  return undefined;
+}

--- a/tools/test-quarantine/src/core/ingest.ts
+++ b/tools/test-quarantine/src/core/ingest.ts
@@ -1,0 +1,247 @@
+import { ciRunUrl, isCI } from "./ci.ts";
+import type { Flake } from "./detect.ts";
+import { redactErrorMessage, stripStackFrames } from "./redact.ts";
+
+/** One flake as accepted by the wallet-flake-reporting ingest API. */
+export interface IngestEvent {
+  testTitle: string;
+  file: string;
+  /**
+   * Human-readable failure text with the stack trace removed and secrets
+   * redacted. Stacks are never sent: they are the most likely place for a secret
+   * to leak, and they are mostly runner internals. See `redact.ts`.
+   */
+  errorMessage: string;
+  retryCount?: number;
+  ciRunUrl?: string;
+  codeowner?: string;
+  /** ISO 8601. */
+  occurredAt: string;
+}
+
+const MAX_TITLE_LENGTH = 1000;
+const MAX_FILE_LENGTH = 1000;
+const MAX_ERROR_LENGTH = 20000;
+const MAX_RETRY_COUNT = 100;
+
+const MAX_EVENTS_PER_REQUEST = 500;
+const MAX_BODY_BYTES = 1024 * 1024;
+
+const REQUEST_TIMEOUT_MS = 15_000;
+const MAX_ATTEMPTS_PER_BATCH = 5;
+
+/**
+ * Bounds on how long a 429 may park the job.
+ *
+ * Reporting is best-effort and runs at the very end of a test job, so honouring
+ * an unbounded `Retry-After` would let a misconfigured server hold a CI runner
+ * for hours. One second is the fallback when the header is missing or unusable.
+ */
+const DEFAULT_RETRY_AFTER_SECONDS = 1;
+const MAX_RETRY_AFTER_SECONDS = 30;
+
+/**
+ * Total time all batches together may spend waiting on rate limits.
+ *
+ * Per-batch bounds are not enough: a run with many batches could still park a
+ * runner for a long time by waiting the maximum on each one. Once this budget is
+ * spent, remaining batches are dropped rather than delaying the job further.
+ */
+const MAX_TOTAL_BACKOFF_MS = 60_000;
+
+export interface IngestOptions {
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+  /** Overrides `FLAKE_API_HOST`; used by tests and the stub server. */
+  host?: string;
+  warn?: (message: string) => void;
+  sleep?: (ms: number) => Promise<void>;
+  now?: Date;
+}
+
+export interface IngestSummary {
+  attempted: number;
+  delivered: number;
+  /** True when nothing was sent because reporting was not configured or not in CI. */
+  skipped: boolean;
+  reason?: string;
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? value.slice(0, max) : value;
+}
+
+/** Shape, redact and clamp flakes into the ingest contract. */
+export function toIngestEvents(flakes: Flake[], options: IngestOptions = {}): IngestEvent[] {
+  const env = options.env ?? process.env;
+  const occurredAt = (options.now ?? new Date()).toISOString();
+  const runUrl = ciRunUrl(env);
+
+  return flakes.map(flake => ({
+    testTitle: truncate(flake.title, MAX_TITLE_LENGTH),
+    file: truncate(flake.file, MAX_FILE_LENGTH),
+    errorMessage: truncate(
+      redactErrorMessage(stripStackFrames(flake.errorMessage)),
+      MAX_ERROR_LENGTH,
+    ),
+    retryCount: Math.min(Math.max(flake.retryCount, 0), MAX_RETRY_COUNT),
+    ciRunUrl: runUrl,
+    occurredAt,
+  }));
+}
+
+/** Split events so no request exceeds the server's count or body-size limits. */
+export function batchEvents(events: IngestEvent[]): IngestEvent[][] {
+  const bodyBytes = (batch: IngestEvent[]): number =>
+    Buffer.byteLength(JSON.stringify({ events: batch }), "utf8");
+
+  const batches: IngestEvent[][] = [];
+  let current: IngestEvent[] = [];
+
+  for (const event of events) {
+    const candidate = [...current, event];
+    const tooMany = candidate.length > MAX_EVENTS_PER_REQUEST;
+    const tooBig = bodyBytes(candidate) > MAX_BODY_BYTES;
+    if (current.length > 0 && (tooMany || tooBig)) {
+      batches.push(current);
+      current = [event];
+    } else {
+      current = candidate;
+    }
+  }
+  if (current.length > 0) batches.push(current);
+  return batches;
+}
+
+/**
+ * How long to wait before retrying a 429.
+ *
+ * Anything absent, non-numeric, negative or absurdly large falls back to a
+ * bounded default rather than being trusted.
+ */
+export function retryAfterSeconds(headerValue: string | null): number {
+  // `Number("")` and `Number("   ")` are both 0, which would busy-loop the
+  // retries, so blank is treated as absent rather than as a number.
+  if (headerValue === null || headerValue.trim() === "") {
+    return DEFAULT_RETRY_AFTER_SECONDS;
+  }
+  const parsed = Number(headerValue);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_RETRY_AFTER_SECONDS;
+  return Math.min(parsed, MAX_RETRY_AFTER_SECONDS);
+}
+
+/**
+ * Build the ingest endpoint from the configured host.
+ *
+ * The trailing slash matters: it keeps any path prefix in the host (a proxy
+ * mounted at `/flake`, say) instead of silently discarding it. Returns
+ * `undefined` for a host that is not a URL at all, so a typo in CI config warns
+ * rather than throwing out of the reporter.
+ */
+function ingestUrl(host: string): string | undefined {
+  // The one `endsWith` outside redact.ts. It tests for a single character rather
+  // than matching a path, so it is not the fuzzy suffix comparison the tool's
+  // matching rules rule out.
+  const base = host.endsWith("/") ? host : `${host}/`;
+  try {
+    return new URL("api/ingest", base).toString();
+  } catch {
+    return undefined;
+  }
+}
+
+const defaultSleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Send flakes to the ingest API.
+ *
+ * Reporting must never fail or stall a test job, so every failure path here
+ * warns and continues, and the only blocking wait (a 429 backoff) is bounded.
+ */
+export async function reportFlakes(
+  flakes: Flake[],
+  options: IngestOptions = {},
+): Promise<IngestSummary> {
+  const env = options.env ?? process.env;
+  const warn = options.warn ?? ((message: string) => console.warn(message));
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const sleep = options.sleep ?? defaultSleep;
+
+  if (!isCI(env)) {
+    return { attempted: flakes.length, delivered: 0, skipped: true, reason: "not CI" };
+  }
+
+  const apiKey = env.FLAKE_API_KEY;
+  const host = options.host ?? env.FLAKE_API_HOST;
+  if (!apiKey || !host) {
+    warn("[test-quarantine] FLAKE_API_KEY or FLAKE_API_HOST unset — flake reporting is a no-op.");
+    return { attempted: flakes.length, delivered: 0, skipped: true, reason: "not configured" };
+  }
+  if (flakes.length === 0) {
+    return { attempted: 0, delivered: 0, skipped: false };
+  }
+
+  const url = ingestUrl(host);
+  if (url === undefined) {
+    warn(`[test-quarantine] FLAKE_API_HOST is not a valid URL (${host}) — not reporting.`);
+    return { attempted: flakes.length, delivered: 0, skipped: true, reason: "bad host" };
+  }
+
+  const batches = batchEvents(toIngestEvents(flakes, options));
+  const budget = { remainingBackoffMs: MAX_TOTAL_BACKOFF_MS };
+  let delivered = 0;
+
+  for (const batch of batches) {
+    delivered += await deliverBatch(batch, { url, apiKey, fetchImpl, sleep, warn, budget });
+  }
+
+  return { attempted: flakes.length, delivered, skipped: false };
+}
+
+interface DeliveryContext {
+  url: string;
+  apiKey: string;
+  fetchImpl: typeof fetch;
+  sleep: (ms: number) => Promise<void>;
+  warn: (message: string) => void;
+  /** Shared across every batch in the run, so total waiting stays bounded. */
+  budget: { remainingBackoffMs: number };
+}
+
+/** Post one batch, retrying only while the server asks us to. Returns how many landed. */
+async function deliverBatch(batch: IngestEvent[], ctx: DeliveryContext): Promise<number> {
+  for (let attempt = 0; attempt < MAX_ATTEMPTS_PER_BATCH; attempt += 1) {
+    let response: Response;
+    try {
+      response = await ctx.fetchImpl(ctx.url, {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-api-key": ctx.apiKey },
+        body: JSON.stringify({ events: batch }),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+    } catch (error) {
+      ctx.warn(`[test-quarantine] flake ingest error: ${(error as Error).message} — continuing.`);
+      return 0;
+    }
+
+    if (response.status === 429) {
+      const waitMs = retryAfterSeconds(response.headers.get("retry-after")) * 1000;
+      if (waitMs > ctx.budget.remainingBackoffMs) {
+        ctx.warn("[test-quarantine] flake ingest backoff budget spent — dropping this batch.");
+        return 0;
+      }
+      ctx.budget.remainingBackoffMs -= waitMs;
+      ctx.warn(`[test-quarantine] flake ingest rate-limited — retrying in ${waitMs / 1000}s.`);
+      await ctx.sleep(waitMs);
+      continue;
+    }
+    if (!response.ok) {
+      ctx.warn(`[test-quarantine] flake ingest failed (${response.status}) — continuing.`);
+      return 0;
+    }
+    return batch.length;
+  }
+
+  ctx.warn("[test-quarantine] flake ingest still rate-limited — giving up on this batch.");
+  return 0;
+}

--- a/tools/test-quarantine/src/core/outcome.ts
+++ b/tools/test-quarantine/src/core/outcome.ts
@@ -1,0 +1,21 @@
+/** Whether a single attempt at a test passed, failed, or never ran. */
+export type TestStatus = "passed" | "failed" | "skipped";
+
+/**
+ * One attempt at running one test, normalised across runners.
+ *
+ * Every runner adapter produces these and nothing else; the rest of the tool is
+ * runner-agnostic. "Attempt" is the important part: a test that jest retried
+ * twice produces three outcomes, not one.
+ */
+export interface TestOutcome {
+  /** Repo-relative path of the test file, always with forward slashes. */
+  file: string;
+  /** Full test title: ancestor describe titles and the test title, space-joined. */
+  title: string;
+  /** 0-based attempt index. 0 is the first run, 1 the first retry. */
+  attempt: number;
+  status: TestStatus;
+  /** Failure text for this attempt. Only meaningful when `status` is "failed". */
+  errorMessage?: string;
+}

--- a/tools/test-quarantine/src/core/paths.ts
+++ b/tools/test-quarantine/src/core/paths.ts
@@ -1,0 +1,72 @@
+import { existsSync, realpathSync } from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+
+/** The file that marks the monorepo root. */
+const WORKSPACE_MARKER = "pnpm-workspace.yaml";
+
+/**
+ * Convert a path to forward slashes.
+ *
+ * Split/join rather than a regex: this is the only transformation involved, and
+ * the tool deliberately avoids constructed patterns for anything path-related.
+ */
+export function toPosix(path: string): string {
+  return path.split("\\").join("/");
+}
+
+/** Resolve symlinks, falling back to the input for paths that do not exist. */
+function realPathOrSelf(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+}
+
+/** Does this relative path climb out of the directory it was resolved against? */
+function escapesRoot(relativePath: string): boolean {
+  return relativePath === ".." || relativePath.startsWith("../");
+}
+
+/**
+ * Express `path` relative to `repoRoot`, so the same test reported from macOS,
+ * Linux and a Windows dev machine reduces to the same string.
+ *
+ * Test runners report real paths, while the configured root may still contain a
+ * symlink — macOS resolves `/tmp` to `/private/tmp`, and checkouts under a
+ * symlinked home directory behave the same way. When the naive result climbs
+ * out of the root, the two disagree about symlinks rather than the file really
+ * being outside the repo, so compare real paths before accepting that.
+ */
+export function toRepoRelative(path: string, repoRoot: string): string {
+  const absolute = isAbsolute(path) ? path : resolve(process.cwd(), path);
+  const direct = toPosix(relative(repoRoot, absolute));
+  if (!escapesRoot(direct)) return direct;
+  return toPosix(relative(realPathOrSelf(repoRoot), realPathOrSelf(absolute)));
+}
+
+/**
+ * Walk up from `startDir` looking for the workspace marker.
+ *
+ * Returns `undefined` rather than guessing when the marker is absent — callers
+ * fall back to the cwd, which keeps paths stable for a single-package checkout.
+ */
+export function findRepoRoot(startDir: string): string | undefined {
+  let current = resolve(startDir);
+  for (;;) {
+    if (existsSync(join(current, WORKSPACE_MARKER))) return current;
+    const parent = dirname(current);
+    if (parent === current) return undefined;
+    current = parent;
+  }
+}
+
+/**
+ * The repo root used to normalise every reported path.
+ *
+ * `QUARANTINE_REPO_ROOT` wins so a runner that spawns test processes from an
+ * unexpected cwd can pin it explicitly.
+ */
+export function repoRoot(env: NodeJS.ProcessEnv = process.env, cwd = process.cwd()): string {
+  return env.QUARANTINE_REPO_ROOT ?? findRepoRoot(cwd) ?? cwd;
+}

--- a/tools/test-quarantine/src/core/redact.ts
+++ b/tools/test-quarantine/src/core/redact.ts
@@ -1,0 +1,53 @@
+/**
+ * Secret redaction for failure text leaving the repo.
+ *
+ * This is the ONE module in the tool that uses regular expressions, and it does
+ * so because redaction is inherently pattern matching — everything else (path
+ * and title matching) uses exact string comparison by design.
+ *
+ * The policy is deliberately over-cautious and still PROVISIONAL, pending the
+ * security sign-off tracked in the PRD: a wallet repo's E2E failures can carry
+ * mock mnemonics, addresses and RPC URLs. Stack traces are never sent at all —
+ * see `toIngestEvents`.
+ */
+const REDACTION_RULES: { name: string; pattern: RegExp }[] = [
+  // A run of 12+ lowercase words, which is what a BIP39 mnemonic looks like.
+  { name: "mnemonic", pattern: /\b(?:[a-z]{3,8}\s+){11,23}[a-z]{3,8}\b/g },
+  // Hex addresses and private-key-shaped blobs.
+  { name: "hex", pattern: /\b0x[a-fA-F0-9]{16,}\b/g },
+  // Bech32-style addresses.
+  { name: "bech32", pattern: /\b(?:bc1|tb1|cosmos1|ltc1)[a-z0-9]{20,}\b/g },
+  // Any URL, which may carry credentials or keys in its query string.
+  { name: "url", pattern: /\bhttps?:\/\/[^\s"']+/g },
+];
+
+/** Replace anything secret-shaped with a labelled placeholder. */
+export function redactErrorMessage(message: string | undefined): string {
+  if (!message) return "";
+  let redacted = message;
+  for (const rule of REDACTION_RULES) {
+    redacted = redacted.replace(rule.pattern, `[redacted:${rule.name}]`);
+  }
+  return redacted;
+}
+
+/**
+ * Drop the stack trace from a runner's failure text, keeping the human-readable
+ * part above it.
+ *
+ * Runners hand us message and stack as one string — jest's `failureMessages` and
+ * Playwright's `TestError.message` both do — so honouring "stacks are never
+ * sent" means cutting them out here rather than simply declining to read a
+ * separate field. What survives is the part that identifies the failure (the
+ * assertion diff, the thrown message); what goes is the frame list, which is
+ * mostly runner internals and absolute filesystem paths.
+ *
+ * Line-by-line rather than a pattern, in keeping with the tool's regex policy.
+ */
+export function stripStackFrames(message: string | undefined): string {
+  if (!message) return "";
+  const lines = message.split("\n");
+  const firstFrame = lines.findIndex(line => line.trimStart().startsWith("at "));
+  const kept = firstFrame === -1 ? lines : lines.slice(0, firstFrame);
+  return kept.join("\n").trimEnd();
+}

--- a/tools/test-quarantine/src/index.ts
+++ b/tools/test-quarantine/src/index.ts
@@ -1,0 +1,14 @@
+export { isCI, ciRunUrl } from "./core/ci.ts";
+export { canContributeToFlake, detectFlakes, type Flake } from "./core/detect.ts";
+export {
+  batchEvents,
+  reportFlakes,
+  retryAfterSeconds,
+  toIngestEvents,
+  type IngestEvent,
+  type IngestOptions,
+  type IngestSummary,
+} from "./core/ingest.ts";
+export type { TestOutcome, TestStatus } from "./core/outcome.ts";
+export { findRepoRoot, repoRoot, toPosix, toRepoRelative } from "./core/paths.ts";
+export { redactErrorMessage, stripStackFrames } from "./core/redact.ts";

--- a/tools/test-quarantine/src/jest/flake-reporter.ts
+++ b/tools/test-quarantine/src/jest/flake-reporter.ts
@@ -1,0 +1,111 @@
+import type { Reporter, Test, TestContext } from "@jest/reporters";
+import type { AggregatedResult, TestCaseResult } from "@jest/test-result";
+import { canContributeToFlake, detectFlakes } from "../core/detect.ts";
+import { reportFlakes, type IngestOptions } from "../core/ingest.ts";
+import type { TestOutcome, TestStatus } from "../core/outcome.ts";
+import { repoRoot, toRepoRelative } from "../core/paths.ts";
+
+/**
+ * Translate jest's status vocabulary into ours.
+ *
+ * Only "passed" and "failed" carry meaning for flake detection; every flavour of
+ * not-run collapses to "skipped".
+ */
+function toTestStatus(status: TestCaseResult["status"]): TestStatus {
+  if (status === "passed") return "passed";
+  if (status === "failed") return "failed";
+  return "skipped";
+}
+
+/**
+ * Turn one `onTestCaseResult` call into one attempt.
+ *
+ * jest-circus calls the reporter once PER ATTEMPT, not once per test, and
+ * `invocations` is that attempt's 1-based index. So a test that fails and then
+ * passes arrives as two calls: (failed, invocations 1) then (passed,
+ * invocations 2). `invocations` is optional in jest's types and only populated
+ * by jest-circus, hence the fallback.
+ */
+export function toOutcome(result: TestCaseResult, file: string): TestOutcome {
+  const status = toTestStatus(result.status);
+  return {
+    file,
+    title: result.fullName,
+    attempt: (result.invocations ?? 1) - 1,
+    status,
+    // Optional access rather than a bare join: `failureMessages` is guaranteed by
+    // jest-circus but not by every custom runner, and this is called from an
+    // unawaited jest event listener where a throw would fail the run.
+    errorMessage: status === "failed" ? (result.failureMessages?.join("\n") ?? "") : undefined,
+  };
+}
+
+/**
+ * Reports tests that jest had to retry before they passed.
+ *
+ * The reporter observes attempts in-process and never inspects jest's CLI
+ * arguments or output files, so it cannot interfere with how a project's tests
+ * are selected or reported. It is inert unless the project enables retries via
+ * `jest.retryTimes()`: with no retries there is no second attempt to observe.
+ *
+ * Delivery is best-effort — see `reportFlakes`. Nothing here can fail a run.
+ */
+export default class FlakeReporter implements Reporter {
+  readonly #outcomes: TestOutcome[] = [];
+  readonly #repoRoot: string;
+  readonly #options: IngestOptions;
+  #warned = false;
+
+  constructor(_globalConfig?: unknown, options: IngestOptions = {}) {
+    this.#options = options;
+    this.#repoRoot = repoRoot(options.env);
+  }
+
+  onTestCaseResult(test: Test, testCaseResult: TestCaseResult): void {
+    // jest calls this from an unawaited event listener, so a throw here would
+    // surface inside the test run itself and fail it.
+    try {
+      const outcome = toOutcome(testCaseResult, toRepoRelative(test.path, this.#repoRoot));
+      // Keeping only attempts that could form a fail-then-pass pair is what stops
+      // same-titled tests being merged into a phantom flake, and leaves a green
+      // run retaining nothing.
+      if (canContributeToFlake(outcome)) this.#outcomes.push(outcome);
+    } catch (error) {
+      this.#warnOnce(`could not record a test result: ${(error as Error).message}`);
+    }
+  }
+
+  async onRunComplete(_contexts?: Set<TestContext>, _results?: AggregatedResult): Promise<void> {
+    // A reporter that throws here fails an otherwise healthy run. Flake
+    // reporting is never worth that, so nothing is allowed out of this method.
+    try {
+      const flakes = detectFlakes(this.#outcomes);
+      if (flakes.length === 0) return;
+
+      // Name them in the log, always. jest reports only a test's final outcome,
+      // so a retried test that passed looks identical to one that never failed —
+      // without this, a flake leaves no trace anyone reading the run would see.
+      // This happens whether or not delivery is configured or succeeds.
+      console.log(`[test-quarantine] ${flakes.length} test(s) passed only after a retry:`);
+      for (const flake of flakes) {
+        console.log(`  - ${flake.file} > ${flake.title} (passed on retry ${flake.retryCount})`);
+      }
+
+      const summary = await reportFlakes(flakes, this.#options);
+      if (summary.skipped) return;
+      console.log(
+        `[test-quarantine] reported ${summary.delivered}/${flakes.length} to the ingest API.`,
+      );
+    } catch (error) {
+      this.#warnOnce(`flake reporting failed: ${(error as Error).message}`);
+    }
+  }
+
+  /** Warn at most once per run, so a systematic fault cannot spam the log per test. */
+  #warnOnce(message: string): void {
+    if (this.#warned) return;
+    this.#warned = true;
+    const warn = this.#options.warn ?? ((text: string) => console.warn(text));
+    warn(`[test-quarantine] ${message} — continuing.`);
+  }
+}

--- a/tools/test-quarantine/test/detect.test.ts
+++ b/tools/test-quarantine/test/detect.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { canContributeToFlake, detectFlakes } from "../src/core/detect.ts";
+import type { TestOutcome } from "../src/core/outcome.ts";
+
+function outcome(partial: Partial<TestOutcome> & Pick<TestOutcome, "status">): TestOutcome {
+  return {
+    file: "libs/example/src/a.test.ts",
+    title: "suite does a thing",
+    attempt: 0,
+    ...partial,
+  };
+}
+
+test("a test that passes first time is not a flake", () => {
+  assert.deepEqual(detectFlakes([outcome({ status: "passed" })]), []);
+});
+
+test("a test that never passes is not a flake", () => {
+  const flakes = detectFlakes([
+    outcome({ status: "failed", attempt: 0 }),
+    outcome({ status: "failed", attempt: 1 }),
+  ]);
+  assert.deepEqual(flakes, []);
+});
+
+test("a test that fails then passes is a flake", () => {
+  const flakes = detectFlakes([
+    outcome({ status: "failed", attempt: 0, errorMessage: "boom" }),
+    outcome({ status: "passed", attempt: 1 }),
+  ]);
+  assert.deepEqual(flakes, [
+    {
+      file: "libs/example/src/a.test.ts",
+      title: "suite does a thing",
+      errorMessage: "boom",
+      retryCount: 1,
+    },
+  ]);
+});
+
+test("retryCount is the attempt that finally passed", () => {
+  const flakes = detectFlakes([
+    outcome({ status: "failed", attempt: 0, errorMessage: "first" }),
+    outcome({ status: "failed", attempt: 1, errorMessage: "second" }),
+    outcome({ status: "passed", attempt: 2 }),
+  ]);
+  assert.equal(flakes.length, 1);
+  assert.equal(flakes[0].retryCount, 2);
+  assert.equal(flakes[0].errorMessage, "second", "reports the last failure before the pass");
+});
+
+test("attempts arriving out of order are still ordered by attempt index", () => {
+  const flakes = detectFlakes([
+    outcome({ status: "passed", attempt: 1 }),
+    outcome({ status: "failed", attempt: 0, errorMessage: "boom" }),
+  ]);
+  assert.equal(flakes.length, 1);
+  assert.equal(flakes[0].errorMessage, "boom");
+});
+
+test("two same-titled cases, one failing, are not a flake", () => {
+  // `test.each` with a static title gives every case the same fullName, and no
+  // runner exposes a per-case id. Without the eligibility filter this reads as
+  // "failed then passed" and reports a phantom flake on a genuinely red run.
+  const flakes = detectFlakes([
+    outcome({ status: "failed", attempt: 0, errorMessage: "case one failed" }),
+    outcome({ status: "passed", attempt: 0 }),
+  ]);
+  assert.deepEqual(flakes, []);
+});
+
+test("two same-titled cases that both fail are not a flake", () => {
+  const flakes = detectFlakes([
+    outcome({ status: "failed", attempt: 0, errorMessage: "one" }),
+    outcome({ status: "failed", attempt: 0, errorMessage: "two" }),
+  ]);
+  assert.deepEqual(flakes, []);
+});
+
+test("a same-titled case failing does not mask a real retry-driven flake", () => {
+  const flakes = detectFlakes([
+    outcome({ status: "passed", attempt: 0 }),
+    outcome({ status: "failed", attempt: 0, errorMessage: "boom" }),
+    outcome({ status: "passed", attempt: 1 }),
+  ]);
+  assert.equal(flakes.length, 1);
+  assert.equal(flakes[0].retryCount, 1);
+});
+
+test("a first-attempt pass is never retained as evidence", () => {
+  assert.equal(canContributeToFlake({ ...outcome({ status: "passed" }), attempt: 0 }), false);
+  assert.equal(canContributeToFlake({ ...outcome({ status: "skipped" }), attempt: 0 }), false);
+  assert.equal(canContributeToFlake({ ...outcome({ status: "skipped" }), attempt: 2 }), true);
+  assert.equal(canContributeToFlake({ ...outcome({ status: "failed" }), attempt: 0 }), true);
+  assert.equal(canContributeToFlake({ ...outcome({ status: "passed" }), attempt: 1 }), true);
+});
+
+test("tests are grouped by file and title, not by title alone", () => {
+  const flakes = detectFlakes([
+    outcome({ file: "a.test.ts", status: "failed", attempt: 0, errorMessage: "boom" }),
+    outcome({ file: "b.test.ts", status: "passed", attempt: 1 }),
+  ]);
+  assert.deepEqual(flakes, [], "a failure in one file is not cured by a pass in another");
+});
+
+test("a same-named test in two files is reported separately", () => {
+  const flakes = detectFlakes([
+    outcome({ file: "a.test.ts", status: "failed", attempt: 0, errorMessage: "a" }),
+    outcome({ file: "a.test.ts", status: "passed", attempt: 1 }),
+    outcome({ file: "b.test.ts", status: "failed", attempt: 0, errorMessage: "b" }),
+    outcome({ file: "b.test.ts", status: "passed", attempt: 1 }),
+  ]);
+  assert.deepEqual(flakes.map(flake => flake.file).sort(), ["a.test.ts", "b.test.ts"]);
+});
+
+test("skipped attempts never make a test a flake", () => {
+  const flakes = detectFlakes([
+    outcome({ status: "failed", attempt: 0, errorMessage: "boom" }),
+    outcome({ status: "skipped", attempt: 1 }),
+  ]);
+  assert.deepEqual(flakes, []);
+});

--- a/tools/test-quarantine/test/ingest.test.ts
+++ b/tools/test-quarantine/test/ingest.test.ts
@@ -1,0 +1,294 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { Flake } from "../src/core/detect.ts";
+import {
+  batchEvents,
+  reportFlakes,
+  retryAfterSeconds,
+  toIngestEvents,
+  type IngestEvent,
+} from "../src/core/ingest.ts";
+
+const CI_ENV: NodeJS.ProcessEnv = {
+  CI: "true",
+  FLAKE_API_KEY: "key",
+  FLAKE_API_HOST: "https://flake.example",
+};
+
+function flake(partial: Partial<Flake> = {}): Flake {
+  return { file: "a.test.ts", title: "does a thing", retryCount: 1, ...partial };
+}
+
+function event(partial: Partial<IngestEvent> = {}): IngestEvent {
+  return {
+    testTitle: "t",
+    file: "f",
+    errorMessage: "",
+    occurredAt: "2026-01-01T00:00:00.000Z",
+    ...partial,
+  };
+}
+
+test("events carry the GitHub run URL when the CI variables are present", () => {
+  const [ingested] = toIngestEvents([flake()], {
+    env: {
+      ...CI_ENV,
+      GITHUB_SERVER_URL: "https://github.com",
+      GITHUB_REPOSITORY: "LedgerHQ/ledger-live",
+      GITHUB_RUN_ID: "42",
+    },
+    now: new Date("2026-01-01T00:00:00.000Z"),
+  });
+  assert.equal(ingested.ciRunUrl, "https://github.com/LedgerHQ/ledger-live/actions/runs/42");
+  assert.equal(ingested.occurredAt, "2026-01-01T00:00:00.000Z");
+});
+
+test("error messages are redacted", () => {
+  const [ingested] = toIngestEvents(
+    [flake({ errorMessage: "failed at https://rpc.example/?key=abc123" })],
+    { env: CI_ENV },
+  );
+  assert.equal(ingested.errorMessage, "failed at [redacted:url]");
+});
+
+test("stack frames are stripped out of the reported error", () => {
+  // Real jest failure text: assertion diff, then the frame list.
+  const jestFailure = [
+    "Error: expect(received).toBe(expected)",
+    "",
+    "Expected: true",
+    "Received: false",
+    "    at toBe (/Users/someone/repo/src/dup.test.js:3:16)",
+    "    at Object.<anonymous> (/Users/someone/repo/node_modules/jest-each/build/index.js:80:140)",
+  ].join("\n");
+
+  const [ingested] = toIngestEvents([flake({ errorMessage: jestFailure })], { env: CI_ENV });
+
+  assert.equal(
+    ingested.errorMessage,
+    "Error: expect(received).toBe(expected)\n\nExpected: true\nReceived: false",
+  );
+  assert.ok(!ingested.errorMessage.includes("at "), "no frames survive");
+  assert.ok(!ingested.errorMessage.includes("/Users/"), "no absolute paths survive");
+});
+
+test("retryCount is clamped into the contract's range", () => {
+  const [low] = toIngestEvents([flake({ retryCount: -5 })], { env: CI_ENV });
+  const [high] = toIngestEvents([flake({ retryCount: 10_000 })], { env: CI_ENV });
+  assert.equal(low.retryCount, 0);
+  assert.equal(high.retryCount, 100);
+});
+
+test("long fields are truncated to the contract's limits", () => {
+  const [ingested] = toIngestEvents(
+    [
+      flake({
+        title: "t".repeat(1500),
+        file: "f".repeat(1500),
+        errorMessage: "e".repeat(25_000),
+      }),
+    ],
+    { env: CI_ENV },
+  );
+  assert.equal(ingested.testTitle.length, 1000);
+  assert.equal(ingested.file.length, 1000);
+  assert.equal(ingested.errorMessage.length, 20_000);
+});
+
+test("batches are capped at 500 events", () => {
+  const events = Array.from({ length: 1200 }, () => event());
+  const batches = batchEvents(events);
+  assert.deepEqual(
+    batches.map(batch => batch.length),
+    [500, 500, 200],
+  );
+});
+
+test("events are split when the body would exceed the size limit", () => {
+  // Each event is capped at 20 KB of error text by toIngestEvents, so reaching
+  // the 1 MiB body limit takes many of them rather than one huge one.
+  const big = event({ errorMessage: "x".repeat(20_000) });
+  const batches = batchEvents(Array.from({ length: 100 }, () => big));
+
+  assert.equal(batches.flat().length, 100, "no event is lost");
+  assert.ok(batches.length >= 2, "the batch was split");
+  for (const batch of batches) {
+    const bytes = Buffer.byteLength(JSON.stringify({ events: batch }), "utf8");
+    assert.ok(bytes <= 1024 * 1024, `batch of ${batch.length} is ${bytes} bytes`);
+  }
+});
+
+test("Retry-After is bounded so a bad header cannot park the job", () => {
+  assert.equal(retryAfterSeconds("5"), 5);
+  assert.equal(retryAfterSeconds("86400"), 30, "clamped to the ceiling");
+  assert.equal(retryAfterSeconds("-1"), 1, "negative falls back to the default");
+  assert.equal(retryAfterSeconds("soon"), 1, "non-numeric falls back to the default");
+  assert.equal(retryAfterSeconds(null), 1, "missing falls back to the default");
+});
+
+test("reporting is a no-op outside CI", async () => {
+  let called = false;
+  const summary = await reportFlakes([flake()], {
+    env: { FLAKE_API_KEY: "key", FLAKE_API_HOST: "https://flake.example" },
+    fetchImpl: (async () => {
+      called = true;
+      return new Response("", { status: 200 });
+    }) as typeof fetch,
+  });
+  assert.equal(summary.skipped, true);
+  assert.equal(summary.reason, "not CI");
+  assert.equal(called, false);
+});
+
+test("reporting warns once and no-ops when it is not configured", async () => {
+  const warnings: string[] = [];
+  const summary = await reportFlakes([flake()], {
+    env: { CI: "true" },
+    warn: message => warnings.push(message),
+    fetchImpl: (() => assert.fail("must not call fetch")) as unknown as typeof fetch,
+  });
+  assert.equal(summary.skipped, true);
+  assert.equal(warnings.length, 1);
+});
+
+test("a successful post reports what was delivered", async () => {
+  const requests: { url: string; body: string; apiKey: string }[] = [];
+  const summary = await reportFlakes([flake(), flake({ title: "another" })], {
+    env: CI_ENV,
+    fetchImpl: (async (url, init = {}) => {
+      requests.push({
+        url: String(url),
+        body: String(init.body),
+        apiKey: String((init.headers as Record<string, string>)["x-api-key"]),
+      });
+      return new Response("", { status: 200 });
+    }) as typeof fetch,
+  });
+
+  assert.deepEqual(summary, { attempted: 2, delivered: 2, skipped: false });
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].url, "https://flake.example/api/ingest");
+  assert.equal(requests[0].apiKey, "key");
+  assert.equal(JSON.parse(requests[0].body).events.length, 2);
+});
+
+test("a rate-limited batch is retried after the bounded delay", async () => {
+  const slept: number[] = [];
+  let calls = 0;
+  const summary = await reportFlakes([flake()], {
+    env: CI_ENV,
+    sleep: async ms => {
+      slept.push(ms);
+    },
+    fetchImpl: (async () => {
+      calls += 1;
+      if (calls === 1) {
+        return new Response("", { status: 429, headers: { "retry-after": "86400" } });
+      }
+      return new Response("", { status: 200 });
+    }) as typeof fetch,
+  });
+
+  assert.deepEqual(slept, [30_000], "the absurd Retry-After was clamped");
+  assert.equal(summary.delivered, 1);
+});
+
+test("a persistently rate-limited batch gives up instead of looping forever", async () => {
+  let calls = 0;
+  const summary = await reportFlakes([flake()], {
+    env: CI_ENV,
+    warn: () => {},
+    sleep: async () => {},
+    fetchImpl: (async () => {
+      calls += 1;
+      return new Response("", { status: 429, headers: { "retry-after": "1" } });
+    }) as typeof fetch,
+  });
+  assert.equal(calls, 5, "bounded by the per-batch attempt limit");
+  assert.equal(summary.delivered, 0);
+});
+
+test("a server error is logged and never thrown", async () => {
+  const warnings: string[] = [];
+  const summary = await reportFlakes([flake()], {
+    env: CI_ENV,
+    warn: message => warnings.push(message),
+    fetchImpl: (async () => new Response("", { status: 500 })) as typeof fetch,
+  });
+  assert.equal(summary.delivered, 0);
+  assert.equal(summary.skipped, false);
+  assert.equal(warnings.length, 1);
+});
+
+test("a network failure is logged and never thrown", async () => {
+  const warnings: string[] = [];
+  const summary = await reportFlakes([flake()], {
+    env: CI_ENV,
+    warn: message => warnings.push(message),
+    fetchImpl: (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as typeof fetch,
+  });
+  assert.equal(summary.delivered, 0);
+  assert.match(warnings[0], /ECONNREFUSED/);
+});
+
+test("a malformed FLAKE_API_HOST warns instead of throwing", async () => {
+  const warnings: string[] = [];
+  const summary = await reportFlakes([flake()], {
+    env: { CI: "true", FLAKE_API_KEY: "key", FLAKE_API_HOST: "not a url" },
+    warn: message => warnings.push(message),
+    fetchImpl: (() => assert.fail("must not fetch with a bad host")) as unknown as typeof fetch,
+  });
+  assert.equal(summary.skipped, true);
+  assert.equal(summary.reason, "bad host");
+  assert.match(warnings[0], /not a valid URL/);
+});
+
+test("a host with a path prefix keeps that prefix", async () => {
+  const urls: string[] = [];
+  await reportFlakes([flake()], {
+    env: { CI: "true", FLAKE_API_KEY: "key", FLAKE_API_HOST: "https://proxy.example/flake" },
+    fetchImpl: (async url => {
+      urls.push(String(url));
+      return new Response("", { status: 200 });
+    }) as typeof fetch,
+  });
+  assert.deepEqual(urls, ["https://proxy.example/flake/api/ingest"]);
+});
+
+test("a trailing slash on the host does not double up", async () => {
+  const urls: string[] = [];
+  await reportFlakes([flake()], {
+    env: { CI: "true", FLAKE_API_KEY: "key", FLAKE_API_HOST: "https://flake.example/" },
+    fetchImpl: (async url => {
+      urls.push(String(url));
+      return new Response("", { status: 200 });
+    }) as typeof fetch,
+  });
+  assert.deepEqual(urls, ["https://flake.example/api/ingest"]);
+});
+
+test("the 429 backoff budget is shared across batches, not per batch", async () => {
+  // Enough events to need several batches, every one rate-limited forever.
+  const many = Array.from({ length: 1200 }, (_, index) => flake({ title: `t${index}` }));
+  const slept: number[] = [];
+
+  await reportFlakes(many, {
+    env: CI_ENV,
+    warn: () => {},
+    sleep: async ms => {
+      slept.push(ms);
+    },
+    fetchImpl: (async () =>
+      new Response("", { status: 429, headers: { "retry-after": "30" } })) as typeof fetch,
+  });
+
+  const totalMs = slept.reduce((sum, ms) => sum + ms, 0);
+  assert.ok(totalMs <= 60_000, `total backoff was ${totalMs}ms`);
+});
+
+test("a blank Retry-After does not busy-loop", () => {
+  assert.equal(retryAfterSeconds(""), 1);
+  assert.equal(retryAfterSeconds("   "), 1);
+});

--- a/tools/test-quarantine/test/jest-integration.test.ts
+++ b/tools/test-quarantine/test/jest-integration.test.ts
@@ -1,0 +1,318 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer, type Server } from "node:http";
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+/**
+ * End-to-end cover for the jest adapter: a real jest process, loading the real
+ * reporter through the package's `exports`, against a test that genuinely fails
+ * and then passes.
+ *
+ * This is the test that pins the contract the reporter depends on — that
+ * jest-circus reports each attempt separately, with a 1-based `invocations`
+ * count — so an upstream change to that behaviour fails here rather than
+ * silently reducing every flake to `retryCount: 0`.
+ */
+
+const packageRoot = fileURLToPath(new URL("..", import.meta.url));
+
+/**
+ * The jest CLI to drive the fixture with.
+ *
+ * Normally resolved from this package's own devDependency. The override exists
+ * so the suite can run against the workspace's installed jest before this
+ * package has been installed itself.
+ */
+function resolveJestBin(): string | undefined {
+  if (process.env.TEST_QUARANTINE_JEST_BIN) return process.env.TEST_QUARANTINE_JEST_BIN;
+  try {
+    return createRequire(import.meta.url).resolve("jest-cli/bin/jest");
+  } catch {
+    return undefined;
+  }
+}
+
+interface IngestRequest {
+  apiKey: string | undefined;
+  events: { testTitle: string; file: string; retryCount: number; errorMessage: string }[];
+}
+
+/** A stand-in for the ingest API that records what the reporter sent it. */
+async function startIngestStub(status = 200): Promise<{
+  url: string;
+  requests: IngestRequest[];
+  close: () => Promise<void>;
+}> {
+  const requests: IngestRequest[] = [];
+  const server: Server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", chunk => chunks.push(chunk));
+    req.on("end", () => {
+      const body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      requests.push({
+        apiKey: req.headers["x-api-key"] as string | undefined,
+        events: body.events,
+      });
+      res.writeHead(status, { "content-type": "application/json" });
+      res.end("{}");
+    });
+  });
+
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (address === null || typeof address === "string") throw new Error("no port");
+
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    requests,
+    close: () => new Promise<void>(resolve => server.close(() => resolve())),
+  };
+}
+
+/**
+ * A consumer package laid out the way pnpm lays out a workspace dependency: the
+ * package is a symlink into the repo, not a copy inside node_modules. That
+ * distinction matters — Node refuses to strip types from files whose real path
+ * is under node_modules, so a copied package would fail to load the reporter.
+ */
+function createFixtureProject(): { root: string; counterFile: string } {
+  const root = mkdtempSync(join(tmpdir(), "tq-jest-integration-"));
+  mkdirSync(join(root, "src"), { recursive: true });
+  mkdirSync(join(root, "node_modules", "@ledgerhq"), { recursive: true });
+  symlinkSync(packageRoot, join(root, "node_modules", "@ledgerhq", "test-quarantine"), "dir");
+
+  writeFileSync(
+    join(root, "package.json"),
+    JSON.stringify({ name: "fixture", version: "1.0.0", private: true }, null, 2),
+  );
+  writeFileSync(
+    join(root, "jest.config.js"),
+    [
+      "module.exports = {",
+      "  rootDir: __dirname,",
+      '  testEnvironment: "node",',
+      '  testMatch: ["<rootDir>/src/**/*.test.js"],',
+      '  setupFilesAfterEnv: ["<rootDir>/setup.js"],',
+      '  reporters: ["@ledgerhq/test-quarantine/jest"],',
+      "};",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(join(root, "setup.js"), "jest.retryTimes(2);\n");
+
+  const counterFile = join(root, "attempts.txt");
+  writeFileSync(counterFile, "0");
+  writeFileSync(
+    join(root, "src", "flaky.test.js"),
+    [
+      'const fs = require("node:fs");',
+      "describe('payments', () => {",
+      "  test('settles eventually', () => {",
+      `    const file = ${JSON.stringify(counterFile)};`,
+      '    const attempt = Number(fs.readFileSync(file, "utf8"));',
+      "    fs.writeFileSync(file, String(attempt + 1));",
+      '    if (attempt < 1) throw new Error("not settled yet");',
+      "    expect(attempt).toBe(1);",
+      "  });",
+      "  test('is stable', () => { expect(1).toBe(1); });",
+      "});",
+      "",
+    ].join("\n"),
+  );
+
+  return { root, counterFile };
+}
+
+function runJest(jestBin: string, root: string, env: NodeJS.ProcessEnv): Promise<number> {
+  return new Promise(resolve => {
+    const child = spawn(process.execPath, [jestBin, "--config", join(root, "jest.config.js")], {
+      cwd: root,
+      env: { ...process.env, ...env },
+      stdio: "pipe",
+    });
+    child.on("close", code => resolve(code ?? 1));
+  });
+}
+
+const jestBin = resolveJestBin();
+const skip = jestBin ? false : "jest-cli is not installed; run pnpm install for this package";
+
+test("a real jest run reports a genuinely flaky test", { skip }, async () => {
+  const ingest = await startIngestStub();
+  const { root } = createFixtureProject();
+
+  try {
+    const exitCode = await runJest(jestBin as string, root, {
+      CI: "true",
+      FLAKE_API_KEY: "test-key",
+      FLAKE_API_HOST: ingest.url,
+      QUARANTINE_REPO_ROOT: root,
+    });
+
+    assert.equal(exitCode, 0, "the retried test passes, so the run is green");
+    assert.equal(ingest.requests.length, 1, "exactly one ingest request");
+
+    const { events, apiKey } = ingest.requests[0];
+    assert.equal(apiKey, "test-key");
+    assert.equal(events.length, 1, "only the flaky test is reported");
+
+    const [flake] = events;
+    assert.equal(flake.testTitle, "payments settles eventually");
+    assert.equal(flake.file, "src/flaky.test.js", "reported relative to the repo root");
+    assert.equal(flake.retryCount, 1, "passed on the first retry");
+    assert.match(flake.errorMessage, /not settled yet/);
+  } finally {
+    await ingest.close();
+  }
+});
+
+test("a real jest run reports nothing when no test is retried", { skip }, async () => {
+  const ingest = await startIngestStub();
+  const { root, counterFile } = createFixtureProject();
+  // Start past the failing attempt so the test passes first time.
+  writeFileSync(counterFile, "1");
+
+  try {
+    const exitCode = await runJest(jestBin as string, root, {
+      CI: "true",
+      FLAKE_API_KEY: "test-key",
+      FLAKE_API_HOST: ingest.url,
+      QUARANTINE_REPO_ROOT: root,
+    });
+
+    assert.equal(exitCode, 0);
+    assert.equal(ingest.requests.length, 0, "a clean run posts nothing");
+  } finally {
+    await ingest.close();
+  }
+});
+
+test("a real jest run outside CI posts nothing", { skip }, async () => {
+  const ingest = await startIngestStub();
+  const { root } = createFixtureProject();
+
+  try {
+    await runJest(jestBin as string, root, {
+      CI: "",
+      FLAKE_API_KEY: "test-key",
+      FLAKE_API_HOST: ingest.url,
+      QUARANTINE_REPO_ROOT: root,
+    });
+
+    assert.equal(ingest.requests.length, 0, "local runs never report");
+  } finally {
+    await ingest.close();
+  }
+});
+
+test("the reporter does not change which tests jest runs", { skip }, async () => {
+  const ingest = await startIngestStub();
+  const { root } = createFixtureProject();
+
+  try {
+    const listed = await new Promise<string>(resolve => {
+      const child = spawn(
+        process.execPath,
+        [jestBin as string, "--config", join(root, "jest.config.js"), "--listTests"],
+        { cwd: root, env: { ...process.env, CI: "" }, stdio: ["ignore", "pipe", "ignore"] },
+      );
+      let out = "";
+      child.stdout.on("data", chunk => {
+        out += chunk;
+      });
+      child.on("close", () => resolve(out));
+    });
+
+    assert.match(listed, /flaky\.test\.js/);
+    assert.equal(
+      listed.trim().split("\n").filter(Boolean).length,
+      1,
+      "collection is untouched by the reporter",
+    );
+  } finally {
+    await ingest.close();
+  }
+});
+
+test("a real jest run stays green when the ingest API returns 500", { skip }, async () => {
+  const ingest = await startIngestStub(500);
+  const { root } = createFixtureProject();
+
+  try {
+    const exitCode = await runJest(jestBin as string, root, {
+      CI: "true",
+      FLAKE_API_KEY: "test-key",
+      FLAKE_API_HOST: ingest.url,
+      QUARANTINE_REPO_ROOT: root,
+    });
+
+    assert.equal(exitCode, 0, "a broken ingest API must never fail a test run");
+    assert.equal(ingest.requests.length, 1, "it did try");
+  } finally {
+    await ingest.close();
+  }
+});
+
+test("a real jest run stays green when nothing is listening", { skip }, async () => {
+  const { root } = createFixtureProject();
+
+  // Port 9 (discard) refuses connections.
+  const exitCode = await runJest(jestBin as string, root, {
+    CI: "true",
+    FLAKE_API_KEY: "test-key",
+    FLAKE_API_HOST: "http://127.0.0.1:9",
+    QUARANTINE_REPO_ROOT: root,
+  });
+
+  assert.equal(exitCode, 0, "an unreachable ingest API must never fail a test run");
+});
+
+test("a real jest run stays green when the host is malformed", { skip }, async () => {
+  const { root } = createFixtureProject();
+
+  const exitCode = await runJest(jestBin as string, root, {
+    CI: "true",
+    FLAKE_API_KEY: "test-key",
+    FLAKE_API_HOST: "definitely not a url",
+    QUARANTINE_REPO_ROOT: root,
+  });
+
+  assert.equal(exitCode, 0, "a misconfigured host must never fail a test run");
+});
+
+test("same-titled cases are not reported as a flake by a real jest run", { skip }, async () => {
+  const ingest = await startIngestStub();
+  const { root } = createFixtureProject();
+
+  // test.each with a static title: one fullName, two cases, one failing for real.
+  writeFileSync(
+    join(root, "src", "flaky.test.js"),
+    [
+      "describe('wallet', () => {",
+      "  test.each([false, true])('balance is right', ok => {",
+      "    expect(ok).toBe(true);",
+      "  });",
+      "});",
+      "",
+    ].join("\n"),
+  );
+
+  try {
+    const exitCode = await runJest(jestBin as string, root, {
+      CI: "true",
+      FLAKE_API_KEY: "test-key",
+      FLAKE_API_HOST: ingest.url,
+      QUARANTINE_REPO_ROOT: root,
+    });
+
+    assert.equal(exitCode, 1, "the hard failure still fails the run");
+    assert.equal(ingest.requests.length, 0, "and is not reported as a flake");
+  } finally {
+    await ingest.close();
+  }
+});

--- a/tools/test-quarantine/test/jest-reporter.test.ts
+++ b/tools/test-quarantine/test/jest-reporter.test.ts
@@ -1,0 +1,221 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { TestCaseResult } from "@jest/test-result";
+import FlakeReporter, { toOutcome } from "../src/jest/flake-reporter.ts";
+
+/**
+ * Shapes taken from a real jest 30 run: jest-circus calls `onTestCaseResult`
+ * once per attempt, with `invocations` as that attempt's 1-based index.
+ */
+function caseResult(partial: Partial<TestCaseResult> = {}): TestCaseResult {
+  return {
+    ancestorTitles: ["outer"],
+    title: "flaky one",
+    fullName: "outer flaky one",
+    status: "passed",
+    invocations: 1,
+    failureMessages: [],
+    failureDetails: [],
+    numPassingAsserts: 1,
+    retryReasons: [],
+    ...partial,
+  } as TestCaseResult;
+}
+
+const jestTest = { path: "/repo/libs/example/a.test.ts", context: {} as never };
+
+test("invocations map onto 0-based attempt indices", () => {
+  assert.equal(toOutcome(caseResult({ invocations: 1 }), "a.test.ts").attempt, 0);
+  assert.equal(toOutcome(caseResult({ invocations: 2 }), "a.test.ts").attempt, 1);
+});
+
+test("a missing invocations count is treated as the first attempt", () => {
+  assert.equal(toOutcome(caseResult({ invocations: undefined }), "a.test.ts").attempt, 0);
+});
+
+test("a failing attempt carries its own failure messages", () => {
+  const outcome = toOutcome(
+    caseResult({ status: "failed", invocations: 1, failureMessages: ["boom", "bang"] }),
+    "a.test.ts",
+  );
+  assert.equal(outcome.status, "failed");
+  assert.equal(outcome.errorMessage, "boom\nbang");
+});
+
+test("a passing attempt carries no error message", () => {
+  assert.equal(toOutcome(caseResult(), "a.test.ts").errorMessage, undefined);
+});
+
+test("every not-run status collapses to skipped", () => {
+  for (const status of ["skipped", "pending", "todo", "disabled"] as const) {
+    assert.equal(toOutcome(caseResult({ status }), "a.test.ts").status, "skipped");
+  }
+});
+
+test("the reporter reports a test that failed then passed", async () => {
+  const posted: unknown[] = [];
+  const reporter = new FlakeReporter(undefined, {
+    env: { CI: "true", FLAKE_API_KEY: "key", FLAKE_API_HOST: "https://flake.example" },
+    fetchImpl: (async (_url, init) => {
+      posted.push(JSON.parse(String(init?.body)));
+      return new Response("", { status: 200 });
+    }) as typeof fetch,
+  });
+
+  reporter.onTestCaseResult(
+    jestTest,
+    caseResult({ status: "failed", invocations: 1, failureMessages: ["boom"] }),
+  );
+  reporter.onTestCaseResult(jestTest, caseResult({ status: "passed", invocations: 2 }));
+  await reporter.onRunComplete();
+
+  assert.equal(posted.length, 1);
+  const { events } = posted[0] as { events: { testTitle: string; retryCount: number }[] };
+  assert.equal(events.length, 1);
+  assert.equal(events[0].testTitle, "outer flaky one");
+  assert.equal(events[0].retryCount, 1);
+});
+
+test("the reporter stays silent when nothing flaked", async () => {
+  const reporter = new FlakeReporter(undefined, {
+    env: { CI: "true", FLAKE_API_KEY: "key", FLAKE_API_HOST: "https://flake.example" },
+    fetchImpl: (() =>
+      assert.fail("must not post when there are no flakes")) as unknown as typeof fetch,
+  });
+
+  reporter.onTestCaseResult(jestTest, caseResult());
+  await reporter.onRunComplete();
+});
+
+test("a test that only ever fails is not reported as a flake", async () => {
+  const reporter = new FlakeReporter(undefined, {
+    env: { CI: "true", FLAKE_API_KEY: "key", FLAKE_API_HOST: "https://flake.example" },
+    fetchImpl: (() => assert.fail("must not post for a hard failure")) as unknown as typeof fetch,
+  });
+
+  reporter.onTestCaseResult(
+    jestTest,
+    caseResult({ status: "failed", invocations: 1, failureMessages: ["boom"] }),
+  );
+  reporter.onTestCaseResult(
+    jestTest,
+    caseResult({ status: "failed", invocations: 2, failureMessages: ["boom"] }),
+  );
+  await reporter.onRunComplete();
+});
+
+test("test file paths are reported relative to the repo root", async () => {
+  const posted: { events: { file: string }[] }[] = [];
+  const reporter = new FlakeReporter(undefined, {
+    env: {
+      CI: "true",
+      FLAKE_API_KEY: "key",
+      FLAKE_API_HOST: "https://flake.example",
+      QUARANTINE_REPO_ROOT: "/repo",
+    },
+    fetchImpl: (async (_url, init) => {
+      posted.push(JSON.parse(String(init?.body)));
+      return new Response("", { status: 200 });
+    }) as typeof fetch,
+  });
+
+  reporter.onTestCaseResult(
+    jestTest,
+    caseResult({ status: "failed", invocations: 1, failureMessages: ["boom"] }),
+  );
+  reporter.onTestCaseResult(jestTest, caseResult({ status: "passed", invocations: 2 }));
+  await reporter.onRunComplete();
+
+  assert.equal(posted[0].events[0].file, "libs/example/a.test.ts");
+});
+
+test("a reporting failure never propagates out of the reporter", async () => {
+  const reporter = new FlakeReporter(undefined, {
+    env: { CI: "true", FLAKE_API_KEY: "key", FLAKE_API_HOST: "https://flake.example" },
+    warn: () => {},
+    fetchImpl: (async () => {
+      throw new Error("ingest is down");
+    }) as typeof fetch,
+  });
+
+  reporter.onTestCaseResult(
+    jestTest,
+    caseResult({ status: "failed", invocations: 1, failureMessages: ["boom"] }),
+  );
+  reporter.onTestCaseResult(jestTest, caseResult({ status: "passed", invocations: 2 }));
+
+  await reporter.onRunComplete();
+});
+
+test("an unexpected internal failure never propagates out of onRunComplete", async () => {
+  const warnings: string[] = [];
+  const reporter = new FlakeReporter(undefined, {
+    env: { CI: "true", FLAKE_API_KEY: "key", FLAKE_API_HOST: "https://flake.example" },
+    warn: message => warnings.push(message),
+    // Not a Response. A broken fetch polyfill or mock looks like this, and it
+    // throws past reportFlakes' own try/catch, so only the reporter's guard
+    // keeps it from failing the run.
+    fetchImpl: (async () => null) as unknown as typeof fetch,
+  });
+
+  reporter.onTestCaseResult(
+    jestTest,
+    caseResult({ status: "failed", invocations: 1, failureMessages: ["boom"] }),
+  );
+  reporter.onTestCaseResult(jestTest, caseResult({ status: "passed", invocations: 2 }));
+
+  await reporter.onRunComplete();
+  assert.match(warnings.join("\n"), /flake reporting failed/);
+});
+
+test("a malformed test result cannot fail the run", () => {
+  const warnings: string[] = [];
+  const reporter = new FlakeReporter(undefined, {
+    env: { CI: "true" },
+    warn: message => warnings.push(message),
+  });
+
+  // jest calls onTestCaseResult from an unawaited listener, so a throw here would
+  // surface inside the test run itself.
+  reporter.onTestCaseResult(jestTest, null as unknown as TestCaseResult);
+
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /could not record a test result/);
+});
+
+test("only one warning is emitted however many results are malformed", () => {
+  const warnings: string[] = [];
+  const reporter = new FlakeReporter(undefined, {
+    env: { CI: "true" },
+    warn: message => warnings.push(message),
+  });
+
+  for (let index = 0; index < 50; index += 1) {
+    reporter.onTestCaseResult(jestTest, null as unknown as TestCaseResult);
+  }
+  assert.equal(warnings.length, 1, "a systematic fault must not spam the log per test");
+});
+
+test("a failing test alongside a same-titled passing one is not reported", async () => {
+  // The test.each shape: two cases, one fullName, both on their first attempt.
+  const reporter = new FlakeReporter(undefined, {
+    env: { CI: "true", FLAKE_API_KEY: "key", FLAKE_API_HOST: "https://flake.example" },
+    fetchImpl: (() =>
+      assert.fail("must not report a hard failure as a flake")) as unknown as typeof fetch,
+  });
+
+  reporter.onTestCaseResult(
+    jestTest,
+    caseResult({ status: "failed", invocations: 1, failureMessages: ["case one"] }),
+  );
+  reporter.onTestCaseResult(jestTest, caseResult({ status: "passed", invocations: 1 }));
+  await reporter.onRunComplete();
+});
+
+test("a missing failureMessages array does not throw", () => {
+  const outcome = toOutcome(
+    caseResult({ status: "failed", failureMessages: undefined as unknown as string[] }),
+    "a.test.ts",
+  );
+  assert.equal(outcome.errorMessage, "");
+});

--- a/tools/test-quarantine/test/paths.test.ts
+++ b/tools/test-quarantine/test/paths.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { findRepoRoot, repoRoot, toPosix, toRepoRelative } from "../src/core/paths.ts";
+
+test("paths are normalised to forward slashes", () => {
+  assert.equal(toPosix("libs\\example\\a.test.ts"), "libs/example/a.test.ts");
+  assert.equal(toPosix("libs/example/a.test.ts"), "libs/example/a.test.ts");
+});
+
+test("absolute test paths become repo-relative", () => {
+  assert.equal(toRepoRelative("/repo/libs/example/a.test.ts", "/repo"), "libs/example/a.test.ts");
+});
+
+test("a path already inside the repo root is left alone", () => {
+  assert.equal(toRepoRelative("/repo/a.test.ts", "/repo"), "a.test.ts");
+});
+
+test("a symlinked repo root still yields a path inside the repo", () => {
+  // Test runners report real paths, so a root configured through a symlink
+  // (macOS /tmp, a symlinked home directory) must not produce a ../.. escape.
+  const real = mkdtempSync(join(tmpdir(), "tq-real-"));
+  mkdirSync(join(real, "src"), { recursive: true });
+  writeFileSync(join(real, "src", "a.test.ts"), "");
+
+  const link = join(mkdtempSync(join(tmpdir(), "tq-link-")), "repo");
+  symlinkSync(real, link, "dir");
+
+  assert.equal(toRepoRelative(join(real, "src", "a.test.ts"), link), "src/a.test.ts");
+});
+
+test("a file genuinely outside the repo is still reported as outside", () => {
+  const root = mkdtempSync(join(tmpdir(), "tq-outside-root-"));
+  const other = mkdtempSync(join(tmpdir(), "tq-outside-other-"));
+  writeFileSync(join(other, "a.test.ts"), "");
+
+  assert.ok(toRepoRelative(join(other, "a.test.ts"), root).startsWith("../"));
+});
+
+test("the repo root is found by walking up to the workspace marker", () => {
+  const root = mkdtempSync(join(tmpdir(), "tq-paths-"));
+  writeFileSync(join(root, "pnpm-workspace.yaml"), "packages: []\n");
+  const nested = join(root, "libs", "example", "src");
+  mkdirSync(nested, { recursive: true });
+
+  assert.equal(findRepoRoot(nested), root);
+});
+
+test("a directory outside any workspace resolves to undefined", () => {
+  const orphan = mkdtempSync(join(tmpdir(), "tq-orphan-"));
+  assert.equal(findRepoRoot(orphan), undefined);
+});
+
+test("QUARANTINE_REPO_ROOT wins over discovery", () => {
+  assert.equal(repoRoot({ QUARANTINE_REPO_ROOT: "/pinned" }, "/somewhere/else"), "/pinned");
+});
+
+test("the cwd is the fallback when no workspace marker exists", () => {
+  const orphan = mkdtempSync(join(tmpdir(), "tq-fallback-"));
+  assert.equal(repoRoot({}, orphan), orphan);
+});

--- a/tools/test-quarantine/test/redact.test.ts
+++ b/tools/test-quarantine/test/redact.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { redactErrorMessage, stripStackFrames } from "../src/core/redact.ts";
+
+test("an absent message becomes the empty string", () => {
+  assert.equal(redactErrorMessage(undefined), "");
+  assert.equal(redactErrorMessage(""), "");
+});
+
+test("an ordinary assertion message is left intact", () => {
+  const message = "expected 3 to equal 4";
+  assert.equal(redactErrorMessage(message), message);
+});
+
+/**
+ * Deliberately NOT a real BIP39 phrase. The rule matches the *shape* of a
+ * mnemonic — a long run of short lowercase words — so a synthetic run exercises
+ * it identically, without committing something the repo's secret scanner (or a
+ * human skimming the diff) would rightly treat as a leaked seed.
+ */
+const MNEMONIC_SHAPED = Array.from(
+  { length: 12 },
+  (_, index) => ["alpha", "bravo", "charlie", "delta"][index % 4],
+).join(" ");
+
+test("mnemonic-shaped word runs are redacted", () => {
+  assert.equal(redactErrorMessage(MNEMONIC_SHAPED), "[redacted:mnemonic]");
+});
+
+test("a mnemonic surrounded by prose is redacted along with the adjacent words", () => {
+  // The rule matches any long run of lowercase words, so neighbouring prose is
+  // swallowed too. Over-redaction is the deliberate trade: never leak a seed.
+  const redacted = redactErrorMessage(`seed was ${MNEMONIC_SHAPED} oops`);
+
+  assert.match(redacted, /\[redacted:mnemonic\]/);
+  for (const word of new Set(MNEMONIC_SHAPED.split(" "))) {
+    assert.ok(!redacted.includes(word), `expected "${word}" to be redacted`);
+  }
+});
+
+test("long hex blobs are redacted", () => {
+  assert.equal(
+    redactErrorMessage("key 0xdeadbeefdeadbeefdeadbeef failed"),
+    "key [redacted:hex] failed",
+  );
+});
+
+test("a short hex value is not mistaken for a secret", () => {
+  assert.equal(redactErrorMessage("code 0xdead failed"), "code 0xdead failed");
+});
+
+test("bech32 addresses are redacted", () => {
+  assert.equal(
+    redactErrorMessage("to bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4 now"),
+    "to [redacted:bech32] now",
+  );
+});
+
+test("URLs are redacted because they may carry keys", () => {
+  assert.equal(
+    redactErrorMessage("GET https://rpc.example/v1?apiKey=secret failed"),
+    "GET [redacted:url] failed",
+  );
+});
+
+test("several secrets in one message are all redacted", () => {
+  const redacted = redactErrorMessage("0xdeadbeefdeadbeefdeadbeef at https://rpc.example/x");
+  assert.equal(redacted, "[redacted:hex] at [redacted:url]");
+});
+
+test("stack frames are removed but the failure text is kept", () => {
+  const message = [
+    "expect(received).toBe(expected)",
+    "",
+    "Expected: 2",
+    "Received: 1",
+    "    at Object.<anonymous> (/Users/someone/repo/a.test.ts:4:19)",
+    "    at processTicksAndRejections (node:internal/process/task_queues:104:5)",
+  ].join("\n");
+
+  assert.equal(
+    stripStackFrames(message),
+    "expect(received).toBe(expected)\n\nExpected: 2\nReceived: 1",
+  );
+});
+
+test("a message with no stack is returned unchanged", () => {
+  assert.equal(stripStackFrames("plain failure"), "plain failure");
+});
+
+test("an empty or absent message becomes the empty string", () => {
+  assert.equal(stripStackFrames(undefined), "");
+  assert.equal(stripStackFrames(""), "");
+});
+
+test("a message that is nothing but frames collapses to empty", () => {
+  assert.equal(stripStackFrames("    at foo (/x.ts:1:1)\n    at bar (/y.ts:2:2)"), "");
+});
+
+test("the word 'at' inside prose is not mistaken for a frame", () => {
+  assert.equal(
+    stripStackFrames("failed at the second step"),
+    "failed at the second step",
+    "only a line that STARTS with 'at ' begins the stack",
+  );
+});

--- a/tools/test-quarantine/tsconfig.json
+++ b/tools/test-quarantine/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base",
+  "compilerOptions": {
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "types": ["node"],
+    "lib": ["ESNext"],
+    "customConditions": []
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR phase splits the quarantine and flake reporting mechanism - with shared logic and only the jest flake reporter.

When the API details are not passed or, there is a network error in the flake reporting api, the flake reporting mechanism exits without causing any failures.

When details are passed and a retry is detected, it reports it to the central flake database. This is currently wired in to only coin-bitcoin - purely to keep the review list on this PR as light as possible.

Retries have been enabled however, as flakes are centrally reported this should allow us to increase reliability while also not hiding failure.

Noise in lockfiles introduced by pnpm quirks and expo auto-linking

### 🔗 Context

Test run: https://github.com/LedgerHQ/ledger-live/actions/runs/32135770783/job/95707309563?pr=20885
- Retry reported
- Flake captured in API
