### PR TITLE
[LWDM] feat(coin-casper): implement validateIntent in createApi (LIVE-34145)

### DIFF
--- a/.changeset/blue-peas-beg.md
+++ b/.changeset/blue-peas-beg.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-casper": minor
+---
+
+Implement `validateIntent` for the Casper coin module and wire it into `createApi`, porting the `bridge/getTransactionStatus` rules to the Alpaca surface. The legacy bridge is unchanged and stays live as the rollback path, so the tests assert rule parity between the two.

--- a/libs/coin-modules/coin-casper/src/api/index.test.ts
+++ b/libs/coin-modules/coin-casper/src/api/index.test.ts
@@ -1,4 +1,24 @@
+import type { Balance, TransactionIntent } from "@ledgerhq/coin-module-framework/api/index";
+import { CASPER_FEES_MOTES } from "../constants";
+import { TEST_ADDRESSES } from "../__tests__/fixtures/addresses.fixture";
+import type { CasperMemo } from "../types";
 import { createApi } from "./index";
+
+const FEES = BigInt(CASPER_FEES_MOTES);
+const AMOUNT = 3_000_000_000n;
+const BALANCE = 100_000_000_000n;
+
+const sendIntent: TransactionIntent<CasperMemo> = {
+  intentType: "transaction",
+  type: "send",
+  sender: TEST_ADDRESSES.SECP256K1,
+  recipient: TEST_ADDRESSES.RECIPIENT_SECP256K1,
+  amount: AMOUNT,
+  asset: { type: "native" },
+  useAllAmount: false,
+};
+
+const balances: Balance[] = [{ value: BALANCE, asset: { type: "native" }, locked: 0n }];
 
 describe("createApi", () => {
   it("returns an object with all CoinModuleApi methods", () => {
@@ -26,5 +46,21 @@ describe("createApi", () => {
     for (const method of methods) {
       expect(typeof api[method as keyof typeof api]).toBe("function");
     }
+  });
+
+  describe("validateIntent", () => {
+    it("validates a send intent through the api surface", async () => {
+      const api = createApi();
+
+      const result = await api.validateIntent({} as never, sendIntent, balances, {
+        customFees: { value: FEES },
+      });
+
+      expect(result.errors).toEqual({});
+      expect(result.warnings).toEqual({});
+      expect(result.estimatedFees).toBe(FEES);
+      expect(result.amount).toBe(AMOUNT);
+      expect(result.totalSpent).toBe(AMOUNT + FEES);
+    });
   });
 });

--- a/libs/coin-modules/coin-casper/src/api/index.ts
+++ b/libs/coin-modules/coin-casper/src/api/index.ts
@@ -6,12 +6,10 @@ import type {
   CoinModuleApi,
   CraftedTransaction,
   Cursor,
-  FeeEstimation,
   Page,
   Reward,
   Stake,
   TransactionIntent,
-  TransactionValidation,
   Validator,
 } from "@ledgerhq/coin-module-framework/api/index";
 import { rejectBalanceOptions } from "@ledgerhq/coin-module-framework/api/getBalance/rejectBalanceOptions";
@@ -22,6 +20,7 @@ import { lastBlock } from "../logic/lastBlock";
 import { getBalance as getAccountBalance } from "../logic/getBalance";
 import { listOperations } from "../logic/listOperations";
 import { estimateFees } from "../logic/estimateFees";
+import { validateIntent } from "../logic/validateIntent";
 import type { CasperConfig, CasperContext, CasperMemo } from "../types";
 
 // The caller builds the {@link CasperContext} (config + logger) and passes it to each method (ADR-019).
@@ -82,14 +81,8 @@ export function createApi(): CoinModuleApi<CasperConfig, CasperMemo> {
     combine: (_context, tx, signature, options) => combine(tx, signature, options?.pubkey),
     broadcast: (context, tx) => broadcast(context, tx),
     estimateFees,
-    validateIntent(
-      _context: CasperContext,
-      _intent: TransactionIntent<CasperMemo>,
-      _balances: Balance[],
-      _options?: { customFees?: FeeEstimation },
-    ): Promise<TransactionValidation> {
-      throw new Error("validateIntent is not supported");
-    },
+    validateIntent: async (_context, intent, balances, options) =>
+      validateIntent(intent, balances, options?.customFees),
     getNextSequence(_context: CasperContext, _address: string): Promise<bigint> {
       throw new Error("getNextSequence is not supported");
     },

--- a/libs/coin-modules/coin-casper/src/logic/index.ts
+++ b/libs/coin-modules/coin-casper/src/logic/index.ts
@@ -6,4 +6,5 @@ export * from "./getBalance";
 export * from "./listOperations";
 export * from "./utils";
 export * from "./validateAddress";
+export * from "./validateIntent";
 export * from "./validateMemo";

--- a/libs/coin-modules/coin-casper/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-casper/src/logic/validateIntent.test.ts
@@ -4,6 +4,7 @@ import type {
   TransactionIntent,
 } from "@ledgerhq/coin-module-framework/api/index";
 import {
+  AmountRequired,
   InvalidAddress,
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
@@ -149,6 +150,12 @@ describe("validateIntent", () => {
 
     expect(result.amount).toBe(balance - FEES);
     expect(result.errors).toEqual({});
+  });
+
+  it.each([0n, -1n, -VALID_AMOUNT])("reports AmountRequired for an amount of %s", amount => {
+    const { errors } = validate(sendCase({ amount }));
+
+    expect(errors.amount).toBeInstanceOf(AmountRequired);
   });
 
   it("reports InvalidMinimumAmount for an amount below the minimum", () => {

--- a/libs/coin-modules/coin-casper/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-casper/src/logic/validateIntent.test.ts
@@ -1,0 +1,216 @@
+import type {
+  Balance,
+  FeeEstimation,
+  TransactionIntent,
+} from "@ledgerhq/coin-module-framework/api/index";
+import {
+  InvalidAddress,
+  InvalidAddressBecauseDestinationIsAlsoSource,
+  NotEnoughBalance,
+  RecipientRequired,
+} from "@ledgerhq/ledger-wallet-framework/errors";
+import BigNumber from "bignumber.js";
+import { getTransactionStatus } from "../bridge/getTransactionStatus";
+import {
+  CASPER_FEES_MOTES,
+  CASPER_MAX_TRANSFER_ID,
+  CASPER_MINIMUM_VALID_AMOUNT_MOTES,
+} from "../constants";
+import { CasperInvalidTransferId, InvalidMinimumAmount, MayBlockAccount } from "../errors";
+import { TEST_ADDRESSES } from "../__tests__/fixtures/addresses.fixture";
+import type { CasperAccount, CasperMemo, Transaction } from "../types";
+import { validateIntent } from "./validateIntent";
+
+const FEES = BigInt(CASPER_FEES_MOTES);
+const MIN_AMOUNT = BigInt(CASPER_MINIMUM_VALID_AMOUNT_MOTES);
+const OUT_OF_RANGE_TRANSFER_ID = (BigInt(CASPER_MAX_TRANSFER_ID) + 1n).toString();
+const LARGE_BALANCE = 100_000_000_000n;
+const VALID_AMOUNT = 3_000_000_000n;
+const SENDER = TEST_ADDRESSES.SECP256K1;
+const RECIPIENT = TEST_ADDRESSES.RECIPIENT_SECP256K1;
+
+type Case = {
+  name?: string;
+  sender?: string;
+  recipient: string;
+  amount: bigint;
+  useAllAmount?: boolean;
+  transferId?: string;
+  balance: bigint;
+  locked?: bigint;
+};
+
+const sendCase = (overrides: Partial<Case> = {}): Case => ({
+  recipient: RECIPIENT,
+  amount: VALID_AMOUNT,
+  balance: LARGE_BALANCE,
+  ...overrides,
+});
+
+const buildIntent = (c: Case): TransactionIntent<CasperMemo> => ({
+  intentType: "transaction",
+  type: "send",
+  sender: c.sender ?? SENDER,
+  recipient: c.recipient,
+  amount: c.amount,
+  asset: { type: "native" },
+  useAllAmount: !!c.useAllAmount,
+  ...(c.transferId ? { memo: { type: "string", kind: "transferId", value: c.transferId } } : {}),
+});
+
+const buildBalances = (c: Case): Balance[] => [
+  { value: c.balance, asset: { type: "native" }, locked: c.locked ?? 0n },
+];
+
+const buildAccount = (c: Case): CasperAccount =>
+  ({
+    currency: { name: "Casper" },
+    balance: new BigNumber(c.balance.toString()),
+    spendableBalance: new BigNumber((c.balance - (c.locked ?? 0n)).toString()),
+    freshAddress: c.sender ?? SENDER,
+    freshAddressPath: "44'/506'/0'/0/0",
+  }) as unknown as CasperAccount;
+
+const buildTransaction = (c: Case): Transaction =>
+  ({
+    family: "casper",
+    recipient: c.recipient,
+    amount: new BigNumber(c.amount.toString()),
+    useAllAmount: !!c.useAllAmount,
+    fees: new BigNumber(FEES.toString()),
+    transferId: c.transferId,
+  }) as unknown as Transaction;
+
+const validate = (c: Case, customFees: FeeEstimation = { value: FEES }) =>
+  validateIntent(buildIntent(c), buildBalances(c), customFees);
+
+const errorClasses = (rec: Record<string, Error>): Array<[string, unknown]> =>
+  Object.entries(rec)
+    .map(([k, v]): [string, unknown] => [k, v.constructor])
+    .sort(([a], [b]) => a.localeCompare(b));
+
+const parityCases: Case[] = [
+  sendCase({ name: "empty recipient", recipient: "" }),
+  sendCase({ name: "invalid recipient", recipient: TEST_ADDRESSES.INVALID }),
+  sendCase({ name: "self-send with differing case", recipient: SENDER.toUpperCase() }),
+  sendCase({ name: "invalid sender", sender: TEST_ADDRESSES.INVALID }),
+  sendCase({ name: "out-of-range transfer id", transferId: OUT_OF_RANGE_TRANSFER_ID }),
+  sendCase({ name: "zero amount", amount: 0n }),
+  sendCase({ name: "below-minimum amount", amount: 1_000_000_000n }),
+  sendCase({ name: "amount exceeding spendable", amount: LARGE_BALANCE + 1n }),
+  sendCase({ name: "useAllAmount with sufficient balance", amount: 0n, useAllAmount: true }),
+  sendCase({
+    name: "useAllAmount without sufficient balance",
+    amount: 0n,
+    useAllAmount: true,
+    balance: FEES,
+  }),
+  sendCase({ name: "may-block boundary", amount: MIN_AMOUNT, balance: 5_000_000_000n }),
+];
+
+describe("validateIntent", () => {
+  describe("rule parity with bridge/getTransactionStatus", () => {
+    it.each(parityCases)("produces the same error and warning classes for: $name", async c => {
+      const legacyResult = await getTransactionStatus(buildAccount(c), buildTransaction(c));
+      const result = validate(c);
+
+      expect(errorClasses(result.errors)).toEqual(errorClasses(legacyResult.errors));
+      expect(errorClasses(result.warnings)).toEqual(errorClasses(legacyResult.warnings));
+    });
+
+    it.each(parityCases)("produces the same amount and totalSpent for: $name", async c => {
+      const legacyResult = await getTransactionStatus(buildAccount(c), buildTransaction(c));
+      const result = validate(c);
+
+      expect(result.amount.toString()).toBe(legacyResult.amount.toString());
+      expect(result.totalSpent.toString()).toBe(legacyResult.totalSpent.toString());
+    });
+  });
+
+  it("populates both errors.sender and errors.transaction for an out-of-range transfer id", () => {
+    const { errors } = validate(sendCase({ transferId: OUT_OF_RANGE_TRANSFER_ID }));
+
+    expect(errors.sender).toBeInstanceOf(CasperInvalidTransferId);
+    expect(errors.transaction).toBeInstanceOf(CasperInvalidTransferId);
+  });
+
+  it("reduces the accepted useAllAmount by the locked funds", () => {
+    const locked = 10_000_000_000n;
+
+    const result = validate(sendCase({ amount: 0n, useAllAmount: true, locked }));
+
+    expect(result.amount).toBe(LARGE_BALANCE - locked - FEES);
+  });
+
+  it("converts balances above BigNumber's exponential-notation threshold without throwing", () => {
+    const balance = 2n * 10n ** 21n;
+
+    const result = validate(sendCase({ amount: 0n, useAllAmount: true, balance }));
+
+    expect(result.amount).toBe(balance - FEES);
+    expect(result.errors).toEqual({});
+  });
+
+  it("reports InvalidMinimumAmount for an amount below the minimum", () => {
+    const { errors } = validate(sendCase({ amount: 1_000_000_000n }));
+
+    expect(errors.amount).toBeInstanceOf(InvalidMinimumAmount);
+  });
+
+  it("keeps NotEnoughBalance over InvalidMinimumAmount when both would apply", () => {
+    const { errors } = validate(sendCase({ amount: 1_000_000_000n, balance: 100_000_000n }));
+
+    expect(errors.amount).toBeInstanceOf(NotEnoughBalance);
+  });
+
+  it("warns with MayBlockAccount when the remaining balance falls below the minimum", () => {
+    const { warnings } = validate(sendCase({ amount: MIN_AMOUNT, balance: 5_000_000_000n }));
+
+    expect(warnings.amount).toBeInstanceOf(MayBlockAccount);
+  });
+
+  it("treats a missing native balance as zero funds", () => {
+    const { errors, totalSpent } = validateIntent(buildIntent(sendCase()), [], { value: FEES });
+
+    expect(errors.amount).toBeInstanceOf(NotEnoughBalance);
+    expect(totalSpent).toBe(VALID_AMOUNT + FEES);
+  });
+
+  it("defaults estimatedFees to 0 when no customFees are provided", () => {
+    const c = sendCase();
+
+    const { estimatedFees } = validateIntent(buildIntent(c), buildBalances(c));
+
+    expect(estimatedFees).toBe(0n);
+  });
+
+  it.each([
+    ["an empty recipient", "", RecipientRequired],
+    ["an invalid recipient", TEST_ADDRESSES.INVALID, InvalidAddress],
+    ["a self-send", SENDER.toUpperCase(), InvalidAddressBecauseDestinationIsAlsoSource],
+  ])("reports %s", (_name, recipient, expected) => {
+    const { errors } = validate(sendCase({ recipient }));
+
+    expect(errors.recipient).toBeInstanceOf(expected);
+  });
+
+  describe("unsupported intents", () => {
+    it("throws for a non-native asset", () => {
+      const intent = {
+        ...buildIntent(sendCase()),
+        asset: { type: "token", assetReference: "cep18-contract" },
+      } as unknown as TransactionIntent<CasperMemo>;
+
+      expect(() => validateIntent(intent, buildBalances(sendCase()))).toThrow(/asset type/);
+    });
+
+    it("throws for a staking intent", () => {
+      const intent = {
+        ...buildIntent(sendCase()),
+        intentType: "staking",
+      } as unknown as TransactionIntent<CasperMemo>;
+
+      expect(() => validateIntent(intent, buildBalances(sendCase()))).toThrow(/staking/);
+    });
+  });
+});

--- a/libs/coin-modules/coin-casper/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-casper/src/logic/validateIntent.ts
@@ -1,0 +1,107 @@
+import type {
+  Balance,
+  FeeEstimation,
+  TransactionIntent,
+  TransactionValidation,
+} from "@ledgerhq/coin-module-framework/api/index";
+import {
+  AmountRequired,
+  InvalidAddress,
+  InvalidAddressBecauseDestinationIsAlsoSource,
+  NotEnoughBalance,
+  RecipientRequired,
+} from "@ledgerhq/ledger-wallet-framework/errors";
+import invariant from "invariant";
+import {
+  CASPER_MAX_TRANSFER_ID,
+  CASPER_MINIMUM_VALID_AMOUNT_MOTES,
+  InvalidMinimumAmountError,
+  MayBlockAccountError,
+} from "../constants";
+import { CasperInvalidTransferId } from "../errors";
+import type { CasperMemo } from "../types";
+import { isAddressValid } from "./validateAddress";
+import { validateMemo } from "./validateMemo";
+
+const MIN_VALID_AMOUNT_MOTES = BigInt(CASPER_MINIMUM_VALID_AMOUNT_MOTES);
+
+export function validateIntent(
+  intent: TransactionIntent<CasperMemo>,
+  balances: Balance[],
+  customFees?: FeeEstimation,
+): TransactionValidation {
+  invariant(intent.intentType !== "staking", "casper: staking is not supported");
+  invariant(
+    intent.asset.type === "native",
+    "casper: asset type %s is not supported",
+    intent.asset.type,
+  );
+
+  const errors: Record<string, Error> = {};
+  const warnings: Record<string, Error> = {};
+
+  const { sender, recipient, useAllAmount } = intent;
+  const currencyName = intent.asset.name ?? "Casper";
+
+  const nativeBalance = balances.find(b => b.asset.type === "native");
+  const balance = nativeBalance?.value ?? 0n;
+  const spendableBalance = balance - (nativeBalance?.locked ?? 0n);
+
+  const memo = "memo" in intent ? intent.memo : undefined;
+  const transferId = memo?.type === "string" && memo.kind === "transferId" ? memo.value : undefined;
+
+  if (!recipient) {
+    errors.recipient = new RecipientRequired();
+  } else if (!isAddressValid(recipient)) {
+    errors.recipient = new InvalidAddress("", { currencyName });
+  } else if (recipient.toLowerCase() === sender.toLowerCase()) {
+    errors.recipient = new InvalidAddressBecauseDestinationIsAlsoSource();
+  }
+
+  if (!isAddressValid(sender)) {
+    errors.sender = new InvalidAddress("", { currencyName });
+  } else if (!validateMemo(transferId)) {
+    errors.sender = new CasperInvalidTransferId("", { maxTransferId: CASPER_MAX_TRANSFER_ID });
+    errors.transaction = new CasperInvalidTransferId("", { maxTransferId: CASPER_MAX_TRANSFER_ID });
+  }
+
+  const estimatedFees = customFees?.value ?? 0n;
+
+  let amount = intent.amount;
+  let totalSpent: bigint;
+
+  if (useAllAmount) {
+    totalSpent = spendableBalance;
+    amount = totalSpent - estimatedFees;
+    if (amount <= 0n || totalSpent > balance) {
+      errors.amount = new NotEnoughBalance();
+    }
+  } else {
+    totalSpent = amount + estimatedFees;
+    if (amount === 0n) {
+      errors.amount = new AmountRequired();
+    }
+    if (totalSpent > spendableBalance) {
+      errors.amount = new NotEnoughBalance();
+    }
+  }
+
+  if (amount < MIN_VALID_AMOUNT_MOTES && !errors.amount) {
+    errors.amount = InvalidMinimumAmountError;
+  }
+
+  // `totalSpent` already includes the fees, so subtracting `estimatedFees` again counts them
+  // twice. Kept on purpose: this reproduces bridge/getTransactionStatus, and the parity tests
+  // pin it. Changing the threshold is a product decision, not a refactor.
+  if (spendableBalance - totalSpent - estimatedFees < MIN_VALID_AMOUNT_MOTES) {
+    warnings.amount = MayBlockAccountError;
+  }
+
+  return {
+    errors,
+    warnings,
+    estimatedFees,
+    amount,
+    totalSpent,
+  };
+}

--- a/libs/coin-modules/coin-casper/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-casper/src/logic/validateIntent.ts
@@ -25,6 +25,68 @@ import { validateMemo } from "./validateMemo";
 
 const MIN_VALID_AMOUNT_MOTES = BigInt(CASPER_MINIMUM_VALID_AMOUNT_MOTES);
 
+function validateRecipient(
+  recipient: string,
+  sender: string,
+  currencyName: string,
+  errors: Record<string, Error>,
+): void {
+  if (!recipient) {
+    errors.recipient = new RecipientRequired();
+  } else if (!isAddressValid(recipient)) {
+    errors.recipient = new InvalidAddress("", { currencyName });
+  } else if (recipient.toLowerCase() === sender.toLowerCase()) {
+    errors.recipient = new InvalidAddressBecauseDestinationIsAlsoSource();
+  }
+}
+
+function validateSender(
+  sender: string,
+  transferId: string | undefined,
+  currencyName: string,
+  errors: Record<string, Error>,
+): void {
+  if (!isAddressValid(sender)) {
+    errors.sender = new InvalidAddress("", { currencyName });
+  } else if (!validateMemo(transferId)) {
+    errors.sender = new CasperInvalidTransferId("", { maxTransferId: CASPER_MAX_TRANSFER_ID });
+    errors.transaction = new CasperInvalidTransferId("", { maxTransferId: CASPER_MAX_TRANSFER_ID });
+  }
+}
+
+function computeAmount(
+  intent: TransactionIntent<CasperMemo>,
+  balance: bigint,
+  spendableBalance: bigint,
+  estimatedFees: bigint,
+  errors: Record<string, Error>,
+): { amount: bigint; totalSpent: bigint } {
+  let amount = intent.amount;
+  let totalSpent: bigint;
+
+  if (intent.useAllAmount) {
+    totalSpent = spendableBalance;
+    amount = totalSpent - estimatedFees;
+    if (amount <= 0n || totalSpent > balance) {
+      errors.amount = new NotEnoughBalance();
+    }
+  } else {
+    totalSpent = amount + estimatedFees;
+    if (amount <= 0n) {
+      errors.amount = new AmountRequired();
+    }
+    if (totalSpent > spendableBalance) {
+      errors.amount = new NotEnoughBalance();
+    }
+  }
+
+  if (amount < MIN_VALID_AMOUNT_MOTES && !errors.amount) {
+    errors.amount = InvalidMinimumAmountError;
+  }
+
+  return { amount, totalSpent };
+}
+
 export function validateIntent(
   intent: TransactionIntent<CasperMemo>,
   balances: Balance[],
@@ -40,7 +102,7 @@ export function validateIntent(
   const errors: Record<string, Error> = {};
   const warnings: Record<string, Error> = {};
 
-  const { sender, recipient, useAllAmount } = intent;
+  const { sender, recipient } = intent;
   const currencyName = intent.asset.name ?? "Casper";
 
   const nativeBalance = balances.find(b => b.asset.type === "native");
@@ -50,49 +112,19 @@ export function validateIntent(
   const memo = "memo" in intent ? intent.memo : undefined;
   const transferId = memo?.type === "string" && memo.kind === "transferId" ? memo.value : undefined;
 
-  if (!recipient) {
-    errors.recipient = new RecipientRequired();
-  } else if (!isAddressValid(recipient)) {
-    errors.recipient = new InvalidAddress("", { currencyName });
-  } else if (recipient.toLowerCase() === sender.toLowerCase()) {
-    errors.recipient = new InvalidAddressBecauseDestinationIsAlsoSource();
-  }
-
-  if (!isAddressValid(sender)) {
-    errors.sender = new InvalidAddress("", { currencyName });
-  } else if (!validateMemo(transferId)) {
-    errors.sender = new CasperInvalidTransferId("", { maxTransferId: CASPER_MAX_TRANSFER_ID });
-    errors.transaction = new CasperInvalidTransferId("", { maxTransferId: CASPER_MAX_TRANSFER_ID });
-  }
+  validateRecipient(recipient, sender, currencyName, errors);
+  validateSender(sender, transferId, currencyName, errors);
 
   const estimatedFees = customFees?.value ?? 0n;
+  const { amount, totalSpent } = computeAmount(
+    intent,
+    balance,
+    spendableBalance,
+    estimatedFees,
+    errors,
+  );
 
-  let amount = intent.amount;
-  let totalSpent: bigint;
-
-  if (useAllAmount) {
-    totalSpent = spendableBalance;
-    amount = totalSpent - estimatedFees;
-    if (amount <= 0n || totalSpent > balance) {
-      errors.amount = new NotEnoughBalance();
-    }
-  } else {
-    totalSpent = amount + estimatedFees;
-    if (amount === 0n) {
-      errors.amount = new AmountRequired();
-    }
-    if (totalSpent > spendableBalance) {
-      errors.amount = new NotEnoughBalance();
-    }
-  }
-
-  if (amount < MIN_VALID_AMOUNT_MOTES && !errors.amount) {
-    errors.amount = InvalidMinimumAmountError;
-  }
-
-  // `totalSpent` already includes the fees, so subtracting `estimatedFees` again counts them
-  // twice. Kept on purpose: this reproduces bridge/getTransactionStatus, and the parity tests
-  // pin it. Changing the threshold is a product decision, not a refactor.
+  // Double-counts the fees on purpose, mirroring bridge/getTransactionStatus.
   if (spendableBalance - totalSpent - estimatedFees < MIN_VALID_AMOUNT_MOTES) {
     warnings.amount = MayBlockAccountError;
   }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Implement `validateIntent` for the Casper coin module and wire it into `createApi`, porting the `bridge/getTransactionStatus` rules to the Alpaca surface. The legacy bridge is unchanged and stays live as the rollback path, so the tests assert rule parity between the two.

### 🔗 Context

https://ledgerhq.atlassian.net/browse/LIVE-35910