### PR TITLE
chore(ldmk-solana-signer): Add solana txc feature flag switch

### DIFF
--- a/.changeset/famous-zebras-draw.md
+++ b/.changeset/famous-zebras-draw.md
@@ -1,0 +1,10 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+"@ledgerhq/live-signer-solana": patch
+"@shared/feature-flags": patch
+"@ledgerhq/types-live": patch
+---
+
+Add Solana TXC flag

--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -62,7 +62,10 @@ import { useSuppressQ2TourForNewUsers } from "LLD/features/Q2Tour/hooks/useSuppr
 import { useDeviceManagementKit } from "@ledgerhq/live-dmk-desktop";
 import { AppGeoBlocker } from "LLD/features/AppBlockers/components/AppGeoBlocker";
 import { AppVersionBlocker } from "LLD/features/AppBlockers/components/AppVersionBlocker";
-import { setSolanaLdmkEnabled } from "@ledgerhq/live-common/families/solana/setup";
+import {
+  setSolanaLdmkEnabled,
+  setSolanaTxcEnabled,
+} from "@ledgerhq/live-common/families/solana/setup";
 import { setCosmosLdmkEnabled } from "@ledgerhq/live-common/families/cosmos/setup";
 import { setSuiGraphqlEnabled } from "@ledgerhq/live-common/families/sui/setup";
 import { themeSelector } from "./actions/general";
@@ -377,6 +380,7 @@ export default function Default() {
   const themeConsoleActive = useEnv("DEBUG_THEME");
   const providerNumber = useEnv("FORCE_PROVIDER");
   const ldmkSolanaSignerFeatureFlag = useFeature("ldmkSolanaSigner");
+  const ldmkSolanaSignerIsTxcActiveFeatureFlag = useFeature("ldmkSolanaSignerIsTxcActive");
   const ldmkCosmosSignerFeatureFlag = useFeature("ldmkCosmosSigner");
   const suiGraphqlTransportFeatureFlag = useFeature("suiGraphqlTransport");
 
@@ -400,6 +404,12 @@ export default function Default() {
       setSolanaLdmkEnabled(ldmkSolanaSignerFeatureFlag?.enabled);
     }
   }, [ldmkSolanaSignerFeatureFlag]);
+
+  useEffect(() => {
+    if (typeof ldmkSolanaSignerIsTxcActiveFeatureFlag?.enabled === "boolean") {
+      setSolanaTxcEnabled(ldmkSolanaSignerIsTxcActiveFeatureFlag?.enabled);
+    }
+  }, [ldmkSolanaSignerIsTxcActiveFeatureFlag]);
 
   useEffect(() => {
     if (typeof ldmkCosmosSignerFeatureFlag?.enabled === "boolean") {

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -94,7 +94,10 @@ import { datadogIdSelector, isDummyDatadogId } from "@domain/entity-client-ident
 import { FIRST_PARTY_MAIN_HOST_DOMAIN } from "./utils/constants";
 import { ConfigureDBSaveEffects } from "./components/DBSave";
 import HookDevTools from "./devTools/useDevTools";
-import { setSolanaLdmkEnabled } from "@ledgerhq/live-common/families/solana/setup";
+import {
+  setSolanaLdmkEnabled,
+  setSolanaTxcEnabled,
+} from "@ledgerhq/live-common/families/solana/setup";
 import { setCosmosLdmkEnabled } from "@ledgerhq/live-common/families/cosmos/setup";
 import { setSuiGraphqlEnabled } from "@ledgerhq/live-common/families/sui/setup";
 import useCheckAccountWithFunds from "./logic/postOnboarding/useCheckAccountWithFunds";
@@ -141,6 +144,7 @@ function App() {
   const automaticBugReportingEnabled = useSelector(reportErrorsEnabledSelector);
   const datadogId = useSelector(datadogIdSelector);
   const ldmkSolanaSignerFeatureFlag = useFeature("ldmkSolanaSigner");
+  const ldmkSolanaSignerIsTxcActiveFeatureFlag = useFeature("ldmkSolanaSignerIsTxcActive");
   const ldmkCosmosSignerFeatureFlag = useFeature("ldmkCosmosSigner");
   const suiGraphqlTransportFeatureFlag = useFeature("suiGraphqlTransport");
   const datadogAutoInstrumentation: AutoInstrumentationConfiguration = useMemo(
@@ -166,6 +170,12 @@ function App() {
       setSolanaLdmkEnabled(ldmkSolanaSignerFeatureFlag?.enabled);
     }
   }, [ldmkSolanaSignerFeatureFlag]);
+
+  useEffect(() => {
+    if (typeof ldmkSolanaSignerIsTxcActiveFeatureFlag?.enabled === "boolean") {
+      setSolanaTxcEnabled(ldmkSolanaSignerIsTxcActiveFeatureFlag?.enabled);
+    }
+  }, [ldmkSolanaSignerIsTxcActiveFeatureFlag]);
 
   useEffect(() => {
     if (typeof ldmkCosmosSignerFeatureFlag?.enabled === "boolean") {

--- a/libs/ledger-live-common/src/families/solana/setup.ts
+++ b/libs/ledger-live-common/src/families/solana/setup.ts
@@ -15,12 +15,17 @@ import { LegacySignerSolana, DmkSignerSol } from "@ledgerhq/live-signer-solana";
 import { DeviceManagementKit } from "@ledgerhq/device-management-kit";
 
 let _solanaLdmkFFEnabled: boolean = false;
+let _solanaTxcFFEnabled: boolean = true;
 
 // temporary solution to dynamically enable/disable the Solana DMK signer,
 // waiting for LIVE-20250 to be implemented
 // to be removed together with useFeature("ldmkSolanaSigner")
 export function setSolanaLdmkEnabled(enabled: boolean): void {
   _solanaLdmkFFEnabled = enabled;
+}
+
+export function setSolanaTxcEnabled(enabled: boolean): void {
+  _solanaTxcFFEnabled = enabled;
 }
 
 const canDMKSignerBeUsed = (
@@ -34,7 +39,9 @@ export function getSolanaSignerInstance(
   transport: Transport & Partial<{ dmk: DeviceManagementKit; sessionId: string }>,
 ): SolanaSigner {
   if (canDMKSignerBeUsed(transport)) {
-    return new DmkSignerSol(transport.dmk, transport.sessionId);
+    return new DmkSignerSol(transport.dmk, transport.sessionId, {
+      transactionChecks: !_solanaTxcFFEnabled,
+    });
   }
   return new LegacySignerSolana(transport);
 }

--- a/libs/live-signer-solana/src/DmkSignerSol.ts
+++ b/libs/live-signer-solana/src/DmkSignerSol.ts
@@ -15,6 +15,7 @@ import {
   SignerSolana,
   TransactionResolutionContext,
   SignMessageVersion,
+  type SolanaSignerFeaturesNames,
 } from "@ledgerhq/device-signer-kit-solana";
 import { DeviceActionStatus, DeviceManagementKit } from "@ledgerhq/device-management-kit";
 import { ContextModuleBuilder, ContextModuleChainID } from "@ledgerhq/context-module";
@@ -44,8 +45,13 @@ export class DmkSignerSol implements SolanaSigner {
   /**
    * @param dmk - instance of Device Management Kit
    * @param sessionId - active session ID of the connected device
+   * @param disabledFeatures - map of signer features to disable (e.g. { transactionChecks: true })
    */
-  constructor(dmk: DeviceManagementKit, sessionId: string) {
+  constructor(
+    dmk: DeviceManagementKit,
+    sessionId: string,
+    disabledFeatures: Partial<Record<SolanaSignerFeaturesNames, boolean>> = {},
+  ) {
     const originToken = "1e55ba3959f4543af24809d9066a2120bd2ac9246e626e26a1ff77eb109ca0e5"; // gitleaks:allow
     const calUrl = getEnv("CAL_SERVICE_URL");
     const calMode = calUrl.includes("ledger-test") || calUrl.includes(".stg.") ? "test" : "prod";
@@ -54,10 +60,14 @@ export class DmkSignerSol implements SolanaSigner {
       .setChain(ContextModuleChainID.Solana)
       .setCalConfig({ url: `${calUrl}/v1`, mode: calMode, branch: "main" })
       .build();
+    const disabledFeaturesArray = (
+      Object.keys(disabledFeatures) as SolanaSignerFeaturesNames[]
+    ).filter(f => disabledFeatures[f]);
     this.dmkSigner = new SignerSolanaBuilder({
       dmk,
       sessionId,
       originToken,
+      disabledFeatures: disabledFeaturesArray,
     })
       .withContextModule(contextModule)
       .build();

--- a/libs/live-signer-solana/src/index.ts
+++ b/libs/live-signer-solana/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./LegacySignerSolana";
 export * from "./DmkSignerSol";
+export type { SolanaSignerFeaturesNames } from "@ledgerhq/device-signer-kit-solana";

--- a/libs/types-live/src/feature.ts
+++ b/libs/types-live/src/feature.ts
@@ -263,6 +263,7 @@ export type Features = CurrencyFeatures & {
   llmModularDrawer: Feature_ModularDrawer;
   llNftEntryPoint: Feature_LlNftEntryPoint;
   ldmkSolanaSigner: DefaultFeature;
+  ldmkSolanaSignerIsTxcActive: DefaultFeature;
   ldmkCosmosSigner: DefaultFeature;
   suiGraphqlTransport: DefaultFeature;
   ldmkConnectApp: DefaultFeature;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ catalogs:
       specifier: 0.2.0
       version: 0.2.0
     '@ledgerhq/device-signer-kit-solana':
-      specifier: 1.11.0
-      version: 1.11.0
+      specifier: 1.12.0
+      version: 1.12.0
     '@ledgerhq/device-transport-kit-react-native-ble':
       specifier: 1.3.2
       version: 1.3.2
@@ -542,7 +542,7 @@ overrides:
   remove-flow-types-loader>loader-utils: '*'
   '@ledgerhq/devices': workspace:*
   '@ledgerhq/hw-transport': workspace:*
-  '@ledgerhq/context-module': 2.3.1
+  '@ledgerhq/context-module': 2.4.0
   tslib: 2.6.2
   '@ethersproject/providers>ws': 7.5.10
   elliptic: 6.6.1
@@ -1810,8 +1810,8 @@ importers:
         specifier: workspace:^
         version: link:../../libs/coin-modules/coin-stacks
       '@ledgerhq/context-module':
-        specifier: 2.3.1
-        version: 2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        specifier: 2.4.0
+        version: 2.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
         version: 2.0.4(@ledgerhq/lumen-design-core@0.1.25)(@ledgerhq/lumen-ui-rnative@0.1.57(3661de544386f386753f6d86b099056a))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
@@ -1823,7 +1823,7 @@ importers:
         version: 1.7.1(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-ethereum':
         specifier: 'catalog:'
-        version: 1.16.0(@ledgerhq/context-module@2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        version: 1.16.0(@ledgerhq/context-module@2.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/device-transport-kit-react-native-hid':
         specifier: 'catalog:'
         version: 1.0.4(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(rxjs@7.8.2)
@@ -2579,14 +2579,14 @@ importers:
         specifier: workspace:^
         version: link:../../libs/coin-modules/coin-solana
       '@ledgerhq/context-module':
-        specifier: 2.3.1
-        version: 2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        specifier: 2.4.0
+        version: 2.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
         version: 1.7.1(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-ethereum':
         specifier: 'catalog:'
-        version: 1.16.0(@ledgerhq/context-module@2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        version: 1.16.0(@ledgerhq/context-module@2.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/hw-app-exchange':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/hw-app-exchange
@@ -10977,8 +10977,8 @@ importers:
         specifier: workspace:^
         version: link:../coin-modules/coin-zcash
       '@ledgerhq/context-module':
-        specifier: 2.3.1
-        version: 2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        specifier: 2.4.0
+        version: 2.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/device-core':
         specifier: workspace:^
         version: link:../device-core
@@ -10987,7 +10987,7 @@ importers:
         version: 1.7.1(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-ethereum':
         specifier: 'catalog:'
-        version: 1.16.0(@ledgerhq/context-module@2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        version: 1.16.0(@ledgerhq/context-module@2.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../ledgerjs/packages/devices
@@ -13325,8 +13325,8 @@ importers:
   libs/live-dmk-shared:
     dependencies:
       '@ledgerhq/context-module':
-        specifier: 2.3.1
-        version: 2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        specifier: 2.4.0
+        version: 2.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../ledgerjs/packages/hw-transport
@@ -13649,14 +13649,14 @@ importers:
         specifier: workspace:^
         version: link:../coin-modules/coin-aleo
       '@ledgerhq/context-module':
-        specifier: 2.3.1
-        version: 2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        specifier: 2.4.0
+        version: 2.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
         version: 1.7.1(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-aleo':
         specifier: 'catalog:'
-        version: 0.4.0(@ledgerhq/context-module@2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        version: 0.4.0(@ledgerhq/context-module@2.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../ledgerjs/packages/hw-transport
@@ -13790,14 +13790,14 @@ importers:
         specifier: workspace:^
         version: link:../concordium-core
       '@ledgerhq/context-module':
-        specifier: 2.3.1
-        version: 2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        specifier: 2.4.0
+        version: 2.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
         version: 1.7.1(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-concordium':
         specifier: 'catalog:'
-        version: 0.4.0(@ledgerhq/context-module@2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        version: 0.4.0(@ledgerhq/context-module@2.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../ledgerjs/packages/hw-transport
@@ -13885,14 +13885,14 @@ importers:
   libs/live-signer-evm:
     dependencies:
       '@ledgerhq/context-module':
-        specifier: 2.3.1
-        version: 2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        specifier: 2.4.0
+        version: 2.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
         version: 1.7.1(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-ethereum':
         specifier: 'catalog:'
-        version: 1.16.0(@ledgerhq/context-module@2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        version: 1.16.0(@ledgerhq/context-module@2.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/hw-app-eth':
         specifier: workspace:^
         version: link:../ledgerjs/packages/hw-app-eth
@@ -14035,14 +14035,14 @@ importers:
         specifier: workspace:^
         version: link:../coin-modules/coin-solana
       '@ledgerhq/context-module':
-        specifier: 2.3.1
-        version: 2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        specifier: 2.4.0
+        version: 2.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
         version: 1.7.1(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-solana':
         specifier: 'catalog:'
-        version: 1.11.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))(@typescript/typescript6@6.0.2)
+        version: 1.12.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))(@typescript/typescript6@6.0.2)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../ledgerjs/packages/devices
@@ -20317,10 +20317,10 @@ packages:
       '@ledgerhq/live-network': ^3.0.0
       '@ledgerhq/logs': ^6.17.0
 
-  '@ledgerhq/context-module@2.3.1':
-    resolution: {integrity: sha512-OfpvgNlI1tz+2B6UPOeHR5FuDmmW9LVfDBOXbK5u1fOnr6r//tArJvhhHc3mLePozbXpBfHl0dhr7UZb347+aw==}
+  '@ledgerhq/context-module@2.4.0':
+    resolution: {integrity: sha512-/rjrIXLPYBvhhrtE7rs0rNsh1LUhQzWknLxCxHwz0V8rWwTsy+IFrUOAFfx2T8T/fwfNoFCoK5zRGN8uiF5wnQ==}
     peerDependencies:
-      '@ledgerhq/device-management-kit': ^1.7.1
+      '@ledgerhq/device-management-kit': ^1.8.0
 
   '@ledgerhq/crypto-icons@2.0.4':
     resolution: {integrity: sha512-PbUs85RtyGaq4R/KBcscHxbeSb7s6E69JbISJkBH9q7V7pmKtsABu31Yaq7UmOodiulidQKrYo7lKcZ7UxXO9w==}
@@ -20351,13 +20351,13 @@ packages:
   '@ledgerhq/device-signer-kit-aleo@0.4.0':
     resolution: {integrity: sha512-GeWvln9TY/EAVxnxmMTPITxOstZLD5tiwupFih2avIayoeYa3Q8Gh8gkW77wd/Sd9oQLmwLQByHdcwRmMcSLrQ==}
     peerDependencies:
-      '@ledgerhq/context-module': 2.3.1
+      '@ledgerhq/context-module': 2.4.0
       '@ledgerhq/device-management-kit': ^1.6.0
 
   '@ledgerhq/device-signer-kit-concordium@0.4.0':
     resolution: {integrity: sha512-jqVp8232dkI34ZVbsQOcGpjK9J+g8BzGD9+/0Ezy7nGtMUfX8c6AhEmn79kj3w96kJ0z1YkakaClCHxicFWtKQ==}
     peerDependencies:
-      '@ledgerhq/context-module': 2.3.1
+      '@ledgerhq/context-module': 2.4.0
       '@ledgerhq/device-management-kit': ^1.5.0
 
   '@ledgerhq/device-signer-kit-cosmos@1.0.1':
@@ -20368,7 +20368,7 @@ packages:
   '@ledgerhq/device-signer-kit-ethereum@1.16.0':
     resolution: {integrity: sha512-lRXCAHlNcZObazX4sQrD2fiVssolzJYjcyzH+9b2AKnV1bfxN5JCY4coIge/L+23LjDVhqibVK6jg8ioUJ4znQ==}
     peerDependencies:
-      '@ledgerhq/context-module': 2.3.1
+      '@ledgerhq/context-module': 2.4.0
       '@ledgerhq/device-management-kit': ^1.5.0
 
   '@ledgerhq/device-signer-kit-hyperliquid@0.0.0-hyperliquid-unified-20260728150448':
@@ -20381,10 +20381,10 @@ packages:
     peerDependencies:
       '@ledgerhq/device-management-kit': ^1.7.1
 
-  '@ledgerhq/device-signer-kit-solana@1.11.0':
-    resolution: {integrity: sha512-rMYdhERYAcwLFRgNEsDToBvyut55nFxxmviL0kgP8Q535XiKgXdKERTEASm3OB83deAhvjOAeZUM0x+OoatF6Q==}
+  '@ledgerhq/device-signer-kit-solana@1.12.0':
+    resolution: {integrity: sha512-yGso2UPREQEyjQhz4mBmr215/Mr+C+UgHh2shxqbMna1bbVTRuO3wV4o/8oZ8Khm1ayFDOjG82n15KeXopNYRw==}
     peerDependencies:
-      '@ledgerhq/device-management-kit': ^1.7.1
+      '@ledgerhq/device-management-kit': ^1.8.0
 
   '@ledgerhq/device-signer-kit-zcash@0.6.0':
     resolution: {integrity: sha512-RASZEFtPKW+PY8N8Q5NMUT3OF3PkVX0UGLS05GKpbkS5w1eGwtsbXXcgv67oR1DwtJpfPW+98ifdWi42RHalHw==}
@@ -48475,7 +48475,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/context-module@2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
+  '@ledgerhq/context-module@2.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
     dependencies:
       '@ledgerhq/device-management-kit': 1.7.1(rxjs@7.8.2)
       bs58: 6.0.0
@@ -48584,9 +48584,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/device-signer-kit-aleo@0.4.0(@ledgerhq/context-module@2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-aleo@0.4.0(@ledgerhq/context-module@2.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/context-module': 2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+      '@ledgerhq/context-module': 2.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/device-management-kit': 1.7.1(rxjs@7.8.2)
       '@ledgerhq/signer-utils': 1.1.3(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       inversify: 7.5.1(reflect-metadata@0.2.2)
@@ -48594,9 +48594,9 @@ snapshots:
       reflect-metadata: 0.2.2
       xstate: 5.19.2
 
-  '@ledgerhq/device-signer-kit-concordium@0.4.0(@ledgerhq/context-module@2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-concordium@0.4.0(@ledgerhq/context-module@2.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/context-module': 2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+      '@ledgerhq/context-module': 2.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/device-management-kit': 1.7.1(rxjs@7.8.2)
       '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       inversify: 7.5.1(reflect-metadata@0.2.2)
@@ -48613,9 +48613,9 @@ snapshots:
       reflect-metadata: 0.2.2
       xstate: 5.19.2
 
-  '@ledgerhq/device-signer-kit-ethereum@1.16.0(@ledgerhq/context-module@2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-ethereum@1.16.0(@ledgerhq/context-module@2.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/context-module': 2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+      '@ledgerhq/context-module': 2.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/device-management-kit': 1.7.1(rxjs@7.8.2)
       '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       ethers: 6.15.0
@@ -48630,7 +48630,7 @@ snapshots:
 
   '@ledgerhq/device-signer-kit-hyperliquid@0.0.0-hyperliquid-unified-20260728150448(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/context-module': 2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+      '@ledgerhq/context-module': 2.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/device-management-kit': 1.7.1(rxjs@7.8.2)
       '@ledgerhq/signer-utils': 0.0.0-hyperliquid-unified-20260728150448(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       inversify: 7.5.1(reflect-metadata@0.2.2)
@@ -48650,9 +48650,9 @@ snapshots:
       reflect-metadata: 0.2.2
       xstate: 5.19.2
 
-  '@ledgerhq/device-signer-kit-solana@1.11.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))(@typescript/typescript6@6.0.2)':
+  '@ledgerhq/device-signer-kit-solana@1.12.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@ledgerhq/context-module': 2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+      '@ledgerhq/context-module': 2.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/device-management-kit': 1.7.1(rxjs@7.8.2)
       '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@solana/web3.js': 1.98.4(@typescript/typescript6@6.0.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,14 +22,14 @@ packages:
 
 catalog:
   "@jest/globals": 30.2.0
-  "@ledgerhq/context-module": 2.3.1
+  "@ledgerhq/context-module": 2.4.0
   "@ledgerhq/crypto-icons": "2.0.4"
   "@ledgerhq/device-management-kit": 1.7.1
   "@ledgerhq/device-signer-kit-aleo": 0.4.0
   "@ledgerhq/device-signer-kit-concordium": 0.4.0
   "@ledgerhq/device-signer-kit-ethereum": 1.16.0
   "@ledgerhq/device-signer-kit-hyperliquid": 0.0.0-hyperliquid-unified-20260728150448
-  "@ledgerhq/device-signer-kit-solana": 1.11.0
+  "@ledgerhq/device-signer-kit-solana": 1.12.0
   "@ledgerhq/device-signer-kit-cosmos": 1.0.1
   "@ledgerhq/device-signer-kit-icp": 0.2.0
   "@ledgerhq/device-transport-kit-react-native-ble": 1.3.2

--- a/shared/feature-flags/src/flags/team-live-devices/index.ts
+++ b/shared/feature-flags/src/flags/team-live-devices/index.ts
@@ -3,6 +3,7 @@ export * from "./enableAppsBackup";
 export * from "./ldmkConnectApp";
 export * from "./ldmkCosmosSigner";
 export * from "./ldmkSolanaSigner";
+export * from "./ldmkSolanaSignerIsTxcActive";
 export * from "./ldmkTransport";
 export * from "./llmNanoSDeprecation";
 export * from "./myLedgerDisplayAppDeveloperName";

--- a/shared/feature-flags/src/flags/team-live-devices/ldmkSolanaSignerIsTxcActive.ts
+++ b/shared/feature-flags/src/flags/team-live-devices/ldmkSolanaSignerIsTxcActive.ts
@@ -1,0 +1,2 @@
+import { flag } from "../../define";
+export const ldmkSolanaSignerIsTxcActive = flag({ enabled: true });


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR wires up a new Firebase feature flag `feature_ldmk_solana_signer_is_txc_active` to enable/disable TxC remotely without a release.

### Changes

Feature flag (shared/feature-flags, libs/types-live)
- New boolean flag `ldmkSolanaSignerIsTxcActive`, enabled by default.

DmkSignerSol constructor (libs/live-signer-solana)
- Now accepts `disabledFeatures: Partial<Record<SolanaSignerFeaturesNames, boolean>>`, a keyed object where true means the feature is disabled.
- Internally converts it to the `SolanaSignerFeaturesNames[]` array that `SignerSolanaBuilder` expects.

solana/setup.ts (libs/ledger-live-common)
- New module-level `_solanaTxcFFEnabled` flag (default true) and `setSolanaTxcEnabled` setter, following the same pattern as `setSolanaLdmkEnabled`.
- Passes `{ transactionChecks: !_solanaTxcFFEnabled }` to `DmkSignerSol` at signer creation time.

App roots (apps/ledger-live-desktop, apps/ledger-live-mobile)
- Read the new Firebase flag via `useFeature("ldmkSolanaSignerIsTxcActive")` and call `setSolanaTxcEnabled` in a `useEffect`, same pattern as the existing `ldmkSolanaSigner` flag.



### 🔗 Context

- **JIRA / GitHub issue**: [DSDK-1431](https://ledgerhq.atlassian.net/browse/DSDK-1431)


[DSDK-1431]: https://ledgerhq.atlassian.net/browse/DSDK-1431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ