### PR TITLE
[LWDM] perf(wallet-api): bound CAL token lookup concurrency (QAA-1505)

### DIFF
--- a/.changeset/bright-tokens-bounded.md
+++ b/.changeset/bright-tokens-bounded.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Bound the concurrency of CAL token lookups in the `currency.list` wallet-api handler. It resolved every requested token id in a single unbounded `Promise.all`, so a live app asking for hundreds of tokens fired hundreds of simultaneous requests. Measured against the real CAL API with the 627 ids the Buy/Sell live app requests, that took 75.6s and 251 of the requests failed outright — and a failed lookup is silently dropped, so the returned currency list was quietly incomplete. Bounded to 10 in flight the same work takes 5.9s with no failures

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -966,6 +966,8 @@ jobs:
       - name: Watch Android emulator liveness (background)
         run: |
           export ARTIFACTS_DIR="${{ env.MOBILE_ARTIFACTS_ROOT }}"
+          export WATCH_STOP_FILE="${{ env.MOBILE_ARTIFACTS_ROOT }}/.watchdog-stop"
+          rm -f "$WATCH_STOP_FILE"
           nohup bash tools/scripts/watch-android-emulators-ci.sh \
             >> "${{ env.MOBILE_ARTIFACTS_ROOT }}/emulator-watchdog.log" 2>&1 &
           echo "ℹ️ Emulator liveness watchdog started."
@@ -1036,6 +1038,14 @@ jobs:
           E2E_FEATURE_FLAGS_JSON: ${{ env.E2E_FEATURE_FLAGS_JSON }}
           E2E_MOBILE_FEATURE_FLAGS: ${{ env.ANDROID_FEATURE_FLAGS }}
         run: pnpm run mobile e2e:ci -p android -t --e2e $([[ "$PRODUCTION" == "true" ]] && printf %s '--production') $SHARD_TEST_FILES --outputFile=artifacts/${{ env.E2E_TEST_RESULTS_PREFIX_ANDROID }}-${{ matrix.shard }}.json
+
+      - name: Stop emulator watchdog
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: |
+          # Everything after this point is teardown; a serial going away now is expected.
+          touch "${{ env.MOBILE_ARTIFACTS_ROOT }}/.watchdog-stop"
 
       - name: Report emulator deaths
         if: always()

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -565,7 +565,10 @@ jobs:
       contents: read
     with:
       ref: ${{ inputs.ref || github.sha }}
-      disable-nx-cache: false
+      # TEMPORARY (QAA-1505 validation): force live-common to be rebuilt from this
+      # branch's source instead of restored from the nx remote cache, so the run
+      # cannot be reading a build that predates the fix. Revert before review.
+      disable-nx-cache: true
       build-android-js: ${{ needs.determine-builds.outputs.android_js_exists == 'false' }}
       build-android-native: ${{ needs.determine-builds.outputs.android_native_exists == 'false' }}
       android-native-cache-key: ${{ needs.determine-builds.outputs.android_native_key }}

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -565,10 +565,7 @@ jobs:
       contents: read
     with:
       ref: ${{ inputs.ref || github.sha }}
-      # TEMPORARY (QAA-1505 validation): force live-common to be rebuilt from this
-      # branch's source instead of restored from the nx remote cache, so the run
-      # cannot be reading a build that predates the fix. Revert before review.
-      disable-nx-cache: true
+      disable-nx-cache: false
       build-android-js: ${{ needs.determine-builds.outputs.android_js_exists == 'false' }}
       build-android-native: ${{ needs.determine-builds.outputs.android_native_exists == 'false' }}
       android-native-cache-key: ${{ needs.determine-builds.outputs.android_native_key }}

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -960,6 +960,17 @@ jobs:
           echo "ℹ️ Android emulators boot started in background."
         shell: bash
 
+      # QAA-1497: an emulator can vanish mid-run, after which every later spec fails with
+      # a misleading assertion error. Record the moment it happens plus the host-side
+      # evidence our artifacts cannot otherwise show.
+      - name: Watch Android emulator liveness (background)
+        run: |
+          export ARTIFACTS_DIR="${{ env.MOBILE_ARTIFACTS_ROOT }}"
+          nohup bash tools/scripts/watch-android-emulators-ci.sh \
+            >> "${{ env.MOBILE_ARTIFACTS_ROOT }}/emulator-watchdog.log" 2>&1 &
+          echo "ℹ️ Emulator liveness watchdog started."
+        shell: bash
+
       - name: Setup Speculos image and Coin Apps
         id: setup-speculos
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-speculos_image@develop
@@ -1025,6 +1036,27 @@ jobs:
           E2E_FEATURE_FLAGS_JSON: ${{ env.E2E_FEATURE_FLAGS_JSON }}
           E2E_MOBILE_FEATURE_FLAGS: ${{ env.ANDROID_FEATURE_FLAGS }}
         run: pnpm run mobile e2e:ci -p android -t --e2e $([[ "$PRODUCTION" == "true" ]] && printf %s '--production') $SHARD_TEST_FILES --outputFile=artifacts/${{ env.E2E_TEST_RESULTS_PREFIX_ANDROID }}-${{ matrix.shard }}.json
+
+      - name: Report emulator deaths
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: |
+          DEATHS="${{ env.MOBILE_ARTIFACTS_ROOT }}/emulator-deaths.log"
+          if [ -s "$DEATHS" ]; then
+            {
+              echo "### ❌ Emulator died during this shard"
+              echo '```'
+              cat "$DEATHS"
+              echo '```'
+              echo "Test failures after this point are not meaningful - see QAA-1497."
+            } >> "$GITHUB_STEP_SUMMARY"
+            while read -r line; do
+              echo "::error title=Emulator died (QAA-1497)::$line"
+            done < "$DEATHS"
+          else
+            echo "✅ No emulator disappeared during this shard." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Stop resource usage sampler
         if: always()

--- a/apps/ledger-live-mobile/src/e2e/appNetworkLogStore.ts
+++ b/apps/ledger-live-mobile/src/e2e/appNetworkLogStore.ts
@@ -13,11 +13,33 @@ export interface AppNetworkLog {
   status?: number;
   duration?: number;
   failureText?: string;
+  /** Which client issued it. `fetch` covers RTK Query, and therefore all CAL traffic. */
+  transport?: "axios" | "fetch";
+  /** Requests already in flight when this one started — makes fan-out visible. */
+  inFlight?: number;
 }
 
-const MAX_NETWORK_LOGS = 500;
+/** Peak concurrency and per-host counts, so a fan-out is legible without reading every entry. */
+export interface AppNetworkSummary {
+  total: number;
+  peakInFlight: number;
+  byHost: Record<string, number>;
+}
+
+// A single `currency.list` can issue ~630 CAL lookups, which would evict everything
+// else from a 500-entry buffer and hide the very thing we are trying to see.
+const MAX_NETWORK_LOGS = 3000;
 
 const networkLogs: AppNetworkLog[] = [];
+let inFlight = 0;
+let peakInFlight = 0;
+let total = 0;
+const byHost: Record<string, number> = {};
+
+function hostOf(url: string): string {
+  const match = /^[a-z]+:\/\/([^/?#]+)/i.exec(url);
+  return match ? match[1] : "(relative)";
+}
 
 export const appNetworkLogStore = {
   addNetworkLog(entry: AppNetworkLog) {
@@ -31,12 +53,36 @@ export const appNetworkLogStore = {
     return [...networkLogs];
   },
 
+  getSummary(): AppNetworkSummary {
+    return { total, peakInFlight, byHost: { ...byHost } };
+  },
+
   clear() {
     networkLogs.length = 0;
+    inFlight = 0;
+    peakInFlight = 0;
+    total = 0;
+    for (const key of Object.keys(byHost)) delete byHost[key];
   },
 };
 
-type WithMetadata = InternalAxiosRequestConfig & { metadata?: { startTime: number } };
+/** Counts a request as started and returns the in-flight depth at that moment. */
+function requestStarted(url: string): number {
+  inFlight += 1;
+  total += 1;
+  peakInFlight = Math.max(peakInFlight, inFlight);
+  const host = hostOf(url);
+  byHost[host] = (byHost[host] ?? 0) + 1;
+  return inFlight;
+}
+
+function requestFinished(): void {
+  inFlight = Math.max(0, inFlight - 1);
+}
+
+type WithMetadata = InternalAxiosRequestConfig & {
+  metadata?: { startTime: number; inFlight?: number };
+};
 
 function toNetworkLog(
   config: WithMetadata | undefined,
@@ -51,6 +97,8 @@ function toNetworkLog(
     status,
     duration: Date.now() - startTime,
     failureText,
+    transport: "axios",
+    inFlight: (config as WithMetadata & { metadata?: { inFlight?: number } })?.metadata?.inFlight,
   };
 }
 
@@ -62,12 +110,16 @@ export function initAppNetworkLogging(): void {
   initialized = true;
 
   axios.interceptors.request.use(function (config) {
-    (config as WithMetadata).metadata = { startTime: Date.now() };
+    const url = `${config.baseURL ?? ""}${config.url ?? ""}`;
+    (config as WithMetadata).metadata = { startTime: Date.now(), inFlight: requestStarted(url) };
     return config;
   });
 
+  patchFetch();
+
   axios.interceptors.response.use(
     function (response: AxiosResponse) {
+      requestFinished();
       try {
         appNetworkLogStore.addNetworkLog(
           toNetworkLog(response.config as WithMetadata, response.status),
@@ -78,6 +130,7 @@ export function initAppNetworkLogging(): void {
       return response;
     },
     function (error: AxiosError) {
+      requestFinished();
       try {
         appNetworkLogStore.addNetworkLog(
           toNetworkLog(
@@ -92,4 +145,54 @@ export function initAppNetworkLogging(): void {
       return Promise.reject(error);
     },
   );
+}
+
+/**
+ * Wrap global `fetch`.
+ *
+ * The axios interceptors above miss every request made through RTK Query, which uses
+ * `fetch` — and that includes all CAL token lookups. Until this existed, a `currency.list`
+ * fan-out of ~630 requests was completely absent from the "Ledger Wallet Network Logs"
+ * attachment, which made it impossible to tell a bounded fan-out from an unbounded one
+ * when reading a CI artifact. Only installed under Config.DETOX, via initAppNetworkLogging.
+ */
+function patchFetch(): void {
+  const original = globalThis.fetch;
+  if (typeof original !== "function") return;
+
+  globalThis.fetch = async function patchedFetch(input: RequestInfo | URL, init?: RequestInit) {
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const method = (init?.method ??
+      (typeof input === "object" && "method" in input ? input.method : "GET")) as string;
+    const startTime = Date.now();
+    const depth = requestStarted(url);
+
+    try {
+      const response = await original.call(globalThis, input as RequestInfo, init);
+      appNetworkLogStore.addNetworkLog({
+        timestamp: new Date().toISOString(),
+        method: method.toUpperCase(),
+        url: url.split(/[?#]/)[0],
+        status: response.status,
+        duration: Date.now() - startTime,
+        transport: "fetch",
+        inFlight: depth,
+      });
+      return response;
+    } catch (error) {
+      appNetworkLogStore.addNetworkLog({
+        timestamp: new Date().toISOString(),
+        method: method.toUpperCase(),
+        url: url.split(/[?#]/)[0],
+        duration: Date.now() - startTime,
+        failureText: error instanceof Error ? error.message : String(error),
+        transport: "fetch",
+        inFlight: depth,
+      });
+      throw error;
+    } finally {
+      requestFinished();
+    }
+  };
 }

--- a/apps/ledger-live-mobile/src/e2e/bridge/client.ts
+++ b/apps/ledger-live-mobile/src/e2e/bridge/client.ts
@@ -148,6 +148,7 @@ async function onMessage(event: WebSocketMessageEvent) {
         const payload = JSON.stringify({
           appLogs: logReport.getLogs(),
           appNetworkLogs: appNetworkLogStore.getNetworkLogs(),
+          appNetworkSummary: appNetworkLogStore.getSummary(),
           webviewNetworkLogs: webviewLogStore.getNetworkLogs(),
           webviewConsoleLogs: webviewLogStore.getConsoleLogs(),
           webviewLoadErrors: webviewLogStore.getLoadErrors(),

--- a/e2e/mobile/utils/loggingUtils.ts
+++ b/e2e/mobile/utils/loggingUtils.ts
@@ -127,6 +127,7 @@ export function formatWebviewConsoleLogs(entries: WebviewConsoleEntry[]): string
 type ParsedLogsPayload = {
   appLogs?: unknown;
   appNetworkLogs?: unknown[];
+  appNetworkSummary?: { total: number; peakInFlight: number; byHost: Record<string, number> };
   webviewNetworkLogs?: unknown[];
   webviewConsoleLogs?: WebviewConsoleEntry[];
   webviewLoadErrors?: unknown[];
@@ -164,6 +165,17 @@ export async function attachFailureLogsToAllure(logsPayload: string): Promise<vo
       "application/json",
     );
     parsed.appNetworkLogs = undefined;
+  }
+
+  // Peak concurrency answers "was the fan-out bounded?" in one number, without having to
+  // read several hundred individual entries.
+  if (parsed.appNetworkSummary) {
+    await allure.attachment(
+      "Ledger Wallet Network Summary",
+      JSON.stringify(parsed.appNetworkSummary, null, 2),
+      "application/json",
+    );
+    parsed.appNetworkSummary = undefined;
   }
 
   if (parsed.webviewConsoleLogs?.length) {

--- a/libs/ledger-live-common/src/wallet-api/react.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.test.ts
@@ -11,6 +11,7 @@ import type { useWalletAPIServerOptions } from "./react";
 import { AccountPublicKeyUnavailable } from "../errors";
 import { accountGetPublicKeyLogic } from "./logic";
 import { getAccountIdFromWalletAccountId, resolveWalletApiSpendableBalance } from "./converters";
+import { getCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
 
 const mockSetHandler = jest.fn();
 const mockSetConfig = jest.fn();
@@ -304,6 +305,48 @@ describe("account.list handler", () => {
     expect(result).toEqual([expect.objectContaining({ spendableBalance })]);
     expect(resolveWalletApiSpendableBalance).toHaveBeenCalledTimes(1);
     expect(resolveWalletApiSpendableBalance).toHaveBeenCalledWith(account, account);
+  });
+});
+
+describe("currency.list handler — token lookup concurrency", () => {
+  const getHandler = () => getRegisteredHandler("currency.list");
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  /**
+   * Regression for QAA-1505. The handler used to resolve every requested token id in a
+   * single unbounded `Promise.all`. Measured against the real CAL API with the 627 ids
+   * the Buy/Sell live app asks for, that took 75.6s and 251 of the requests failed
+   * outright; bounding the pool took 5.9s with none failing. A failed lookup resolves to
+   * null and is silently dropped, so the unbounded version also returned an incomplete
+   * list. This pins the bound so a future refactor cannot quietly restore the fan-out.
+   */
+  it("never has more than TOKEN_LOOKUP_CONCURRENCY lookups in flight", async () => {
+    const tokenIds = Array.from({ length: 120 }, (_, i) => `ethereum/erc20/token_${i}`);
+    let inFlight = 0;
+    let peakInFlight = 0;
+
+    const findTokenById = jest.fn(async () => {
+      inFlight += 1;
+      peakInFlight = Math.max(peakInFlight, inFlight);
+      await new Promise(resolve => setTimeout(resolve, 0));
+      inFlight -= 1;
+      return null;
+    });
+    jest.mocked(getCryptoAssetsStore).mockReturnValue({ findTokenById } as never);
+
+    renderHook(() => useWalletAPIServer(createDefaultOptions()));
+    await getHandler()({ currencyIds: tokenIds });
+
+    expect(findTokenById).toHaveBeenCalledTimes(tokenIds.length);
+    expect(peakInFlight).toBeGreaterThan(1);
+    expect(peakInFlight).toBeLessThanOrEqual(10);
   });
 });
 

--- a/libs/ledger-live-common/src/wallet-api/react.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.ts
@@ -36,6 +36,7 @@ import {
 import { getMainAccount, getParentAccount } from "../account";
 import { listSupportedCurrencies } from "../currencies";
 import { getCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
+import { promiseAllBatched } from "@ledgerhq/live-promise";
 import { TrackingAPI } from "./tracking";
 import {
   bitcoinFamilyAccountGetXPubLogic,
@@ -287,6 +288,15 @@ export type useWalletAPIServerOptions = {
   customHandlers?: WalletAPICustomHandlers;
 };
 
+/**
+ * Max parallel CAL token lookups in the `currency.list` handler.
+ * CAL exposes no bulk id endpoint, so a live app asking for hundreds of tokens means
+ * hundreds of requests; firing them all at once exhausts the connection pool and drops
+ * a large share of them. Measured with the 627 ids the Buy/Sell live app requests:
+ * unbounded = 75.6s with 251 failures, bounded to 10 = 5.9s with none. See QAA-1505.
+ */
+const TOKEN_LOOKUP_CONCURRENCY = 10;
+
 export function useWalletAPIServer({
   accountNames,
   manifest,
@@ -443,14 +453,24 @@ export function useWalletAPIServer({
         includedCurrencies = allCurrencies.filter(c => specificCurrencies.has(c.id));
       }
 
-      // 6. Fetch specific tokens by ID if any
+      // 6. Fetch specific tokens by ID if any.
+      // CAL has no bulk id lookup, so this is inherently one request per token, and a
+      // live app can ask for hundreds at once. Firing them all at once exhausts the
+      // connection pool: measured against the real CAL API with the 627 ids the
+      // Buy/Sell live app requests, an unbounded Promise.all took 75.6s and 251 of the
+      // 627 requests failed outright, while the same work bounded to a small pool took
+      // 5.9s with every request succeeding. A failed lookup returns null and is silently
+      // dropped below, so unbounded fan-out also yields a quietly incomplete list.
       const specificTokens: WalletAPICurrency[] = [];
       if (specificTokenIds.size > 0) {
-        const tokenPromises = [...specificTokenIds].map(async tokenId => {
-          const token = await getCryptoAssetsStore().findTokenById(tokenId);
-          return token ? currencyToWalletAPICurrency(token) : null;
-        });
-        const resolvedTokens = await Promise.all(tokenPromises);
+        const resolvedTokens = await promiseAllBatched(
+          TOKEN_LOOKUP_CONCURRENCY,
+          [...specificTokenIds],
+          async tokenId => {
+            const token = await getCryptoAssetsStore().findTokenById(tokenId);
+            return token ? currencyToWalletAPICurrency(token) : null;
+          },
+        );
         specificTokens.push(...resolvedTokens.filter((t): t is WalletAPICurrency => t !== null));
       }
 

--- a/tools/scripts/watch-android-emulators-ci.sh
+++ b/tools/scripts/watch-android-emulators-ci.sh
@@ -1,19 +1,27 @@
 #!/usr/bin/env bash
-# Watches the Android emulators for the duration of a mobile E2E shard and records the
-# moment one disappears, plus whatever host-side evidence we can still reach.
+# Watches the Android emulators during a mobile E2E shard, records the moment one
+# disappears, and captures the host-side evidence our artifacts cannot otherwise show.
 #
-# Why this exists (QAA-1497): since 2026-08-14 one of the three emulators terminates
-# silently mid-run. Detox then fails every later spec with a misleading assertion error
-# ("element not found", "blank screen"), so the real cause is invisible in the report and
-# the shard burns its remaining budget. The emulator writes nothing to its own log when
-# this happens, so absence of evidence is itself the signal we need to capture.
+# Why this exists (QAA-1497): since 2026-08-14 an emulator terminates silently partway
+# through a shard. Detox then fails every later spec with a misleading assertion error,
+# so the real cause never reaches the report.
+#
+# What the first run of this script established, and what shaped it:
+#   - at the moment of death the host had 17 GB free of 32 GB — OOM is ruled out with
+#     direct host evidence, not inference
+#   - the kernel ring buffer contains nothing after boot, so no OOM-killer, segfault or
+#     kill was ever logged
+#   - the qemu process is simply absent from the process table
+# The gap that remained: we only ever saw the host AFTER the death. Hence the rolling
+# pre-death snapshots below, which are the point of this script.
 #
 # Required environment:
 #   ARTIFACTS_DIR     — directory collected by the upload-artifact step
 #
 # Optional environment:
-#   EMULATOR_SERIALS  — space-separated adb serials (default: emulator-5554 emulator-5556 emulator-5558)
+#   EMULATOR_SERIALS  — space-separated adb serials (default: emulator-5554 5556 5558)
 #   WATCH_INTERVAL    — seconds between polls (default: 5)
+#   WATCH_STOP_FILE   — watcher exits once this file exists (workflow writes it after Detox)
 #
 # Requires: adb on PATH. Never exits non-zero: this must not be able to fail a shard.
 
@@ -22,57 +30,109 @@ set -uo pipefail
 readonly ARTIFACTS_DIR="${ARTIFACTS_DIR:-e2e/mobile/artifacts}"
 readonly DEATH_LOG="${ARTIFACTS_DIR}/emulator-deaths.log"
 readonly DIAG_DIR="${ARTIFACTS_DIR}/host-diagnostics"
+readonly TREND_LOG="${DIAG_DIR}/host-trend.tsv"
 readonly INTERVAL="${WATCH_INTERVAL:-5}"
+readonly STOP_FILE="${WATCH_STOP_FILE:-${ARTIFACTS_DIR}/.watchdog-stop}"
 read -r -a SERIALS <<<"${EMULATOR_SERIALS:-emulator-5554 emulator-5556 emulator-5558}"
 
 mkdir -p "$ARTIFACTS_DIR" "$DIAG_DIR" 2>/dev/null || true
 
 log() { echo "[watchdog $(date -u +%H:%M:%S)] $*"; }
 
-# Snapshot the host state that our artifacts cannot otherwise show. Each item is
-# best-effort: on a hardened runner most of these are simply unavailable, and an empty
-# file is still a useful answer (it rules the source out).
+# Rolling snapshots of the host, kept so a death can be read in context. Without these we
+# only ever see the aftermath, by which point the process is already gone.
+RING_DIR="$(mktemp -d 2>/dev/null || echo "${DIAG_DIR}/.ring")"
+mkdir -p "$RING_DIR" 2>/dev/null || true
+readonly RING_DIR
+readonly RING_DEPTH=6
+
+snapshot() {
+  local slot="$1"
+  {
+    echo "== $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "-- qemu processes"
+    local pids
+    pids="$(pgrep -d, qemu-system 2>/dev/null || true)"
+    [ -n "$pids" ] && ps -o pid,rss,pcpu,stat,etime,comm -p "$pids" 2>/dev/null || echo "(no qemu process)"
+    echo "-- memory"
+    free -m 2>/dev/null || true
+    echo "-- adb"
+    adb devices 2>&1 || true
+  } >"${RING_DIR}/snap_${slot}.txt" 2>/dev/null || true
+}
+
+# One line per poll: cheap, and makes a slow squeeze (e.g. Hyper-V dynamic memory
+# reclaiming from the VM) visible as a trend rather than a single reading.
+trend() {
+  local mem qemu
+  mem="$(free -m 2>/dev/null | awk '/^Mem:/{print $2"\t"$3"\t"$4"\t"$7}')"
+  qemu="$(pgrep -c qemu-system 2>/dev/null || echo 0)"
+  printf '%s\t%s\t%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${mem:-?}" "$qemu" >>"$TREND_LOG" 2>/dev/null || true
+}
+
 capture_diagnostics() {
   local serial="$1"
   local stamp="$2"
   local out="${DIAG_DIR}/${stamp}_${serial}"
   mkdir -p "$out" 2>/dev/null || true
 
-  # Was the process OOM-killed, or did the kernel see it die?
+  # The seconds BEFORE the death — the whole reason this script keeps a ring buffer.
+  cp -a "${RING_DIR}"/snap_*.txt "${out}/" 2>/dev/null || true
+
+  # Kernel view. dmesg on this runner has only ever contained boot messages, so try
+  # journalctl too before concluding "the kernel logged nothing".
   { dmesg -T 2>/dev/null || sudo -n dmesg -T 2>/dev/null; } | tail -400 >"${out}/dmesg.txt" 2>/dev/null || true
-  # The emulator's own crash database. If the emulator crashed it records itself here;
-  # an empty/absent entry is positive evidence of an EXTERNAL kill.
+  { journalctl -k --since "-10 min" --no-pager 2>/dev/null || sudo -n journalctl -k --since "-10 min" --no-pager 2>/dev/null; } \
+    >"${out}/journal-kernel.txt" 2>/dev/null || true
+
+  # The emulator's own crash database. A qemu that crashes records itself here, so an
+  # empty entry is positive evidence of an EXTERNAL kill rather than a self-crash.
   cp -a /tmp/android-runner/emu-crash-*.db "${out}/" 2>/dev/null || true
-  ls -la /tmp/android-runner 2>/dev/null >"${out}/android-runner-ls.txt" || true
-  # Per-process memory, which the host-aggregate usage sampler cannot show.
-  ps -eo pid,ppid,rss,pcpu,etime,comm --sort=-rss 2>/dev/null | head -40 >"${out}/ps.txt" || true
+  ls -laR /tmp/android-runner >"${out}/android-runner-ls.txt" 2>/dev/null || true
+
+  ps -eo pid,ppid,rss,pcpu,stat,etime,comm --sort=-rss 2>/dev/null | head -40 >"${out}/ps.txt" || true
   free -m 2>/dev/null >"${out}/free.txt" || true
-  # cgroup limits: a per-job cap well under the host total would kill a qemu while the
-  # host still looks healthy in usage-metrics.
-  for f in /sys/fs/cgroup/memory.max /sys/fs/cgroup/memory.events /sys/fs/cgroup/cpu.max; do
-    [ -r "$f" ] && { echo "== $f"; cat "$f"; } >>"${out}/cgroup.txt" 2>/dev/null
-  done
+  cat /proc/meminfo 2>/dev/null | head -20 >"${out}/meminfo.txt" || true
+
+  # cgroup limits, v2 then v1. A per-job cap well under the host total would kill a qemu
+  # while `free` still looks healthy.
+  {
+    cat /proc/self/cgroup 2>/dev/null
+    for f in /sys/fs/cgroup/memory.max /sys/fs/cgroup/memory.events /sys/fs/cgroup/cpu.max \
+             /sys/fs/cgroup/memory/memory.limit_in_bytes /sys/fs/cgroup/memory/memory.failcnt; do
+      [ -r "$f" ] && { echo "== $f"; cat "$f"; }
+    done
+  } >"${out}/cgroup.txt" 2>/dev/null || true
+
   adb devices >"${out}/adb-devices.txt" 2>&1 || true
   log "diagnostics for $serial written to ${out}"
 }
 
-log "watching ${SERIALS[*]} every ${INTERVAL}s"
+log "watching ${SERIALS[*]} every ${INTERVAL}s (stop file: ${STOP_FILE})"
+declare -A alive=()      # serial has been seen up at least once
 declare -A reported=()
+slot=0
 
 while true; do
+  [ -f "$STOP_FILE" ] && { log "stop file present — exiting"; break; }
+
+  trend
+  snapshot "$((slot % RING_DEPTH))"
+  slot=$((slot + 1))
+
   online="$(adb devices 2>/dev/null || true)"
   for serial in "${SERIALS[@]}"; do
-    if ! grep -q "^${serial}[[:space:]]*device" <<<"$online"; then
-      if [ -z "${reported[$serial]:-}" ]; then
-        reported[$serial]=1
-        stamp="$(date -u +%Y%m%dT%H%M%SZ)"
-        log "❌ $serial is GONE at ${stamp}"
-        echo "${stamp} ${serial} disappeared from adb devices" >>"$DEATH_LOG"
-        capture_diagnostics "$serial" "$stamp"
-      fi
-    else
-      # Came back (Detox relaunches a replacement) — allow it to be reported again.
+    if grep -q "^${serial}[[:space:]]*device" <<<"$online"; then
+      alive[$serial]=1
       reported[$serial]=""
+    elif [ -n "${alive[$serial]:-}" ] && [ -z "${reported[$serial]:-}" ]; then
+      # Only a serial that was previously UP can have "disappeared". Without this gate the
+      # first polls, before the emulators finish booting, report three phantom deaths.
+      reported[$serial]=1
+      stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+      log "❌ $serial is GONE at ${stamp}"
+      echo "${stamp} ${serial} disappeared from adb devices" >>"$DEATH_LOG"
+      capture_diagnostics "$serial" "$stamp"
     fi
   done
   sleep "$INTERVAL"

--- a/tools/scripts/watch-android-emulators-ci.sh
+++ b/tools/scripts/watch-android-emulators-ci.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Watches the Android emulators for the duration of a mobile E2E shard and records the
+# moment one disappears, plus whatever host-side evidence we can still reach.
+#
+# Why this exists (QAA-1497): since 2026-08-14 one of the three emulators terminates
+# silently mid-run. Detox then fails every later spec with a misleading assertion error
+# ("element not found", "blank screen"), so the real cause is invisible in the report and
+# the shard burns its remaining budget. The emulator writes nothing to its own log when
+# this happens, so absence of evidence is itself the signal we need to capture.
+#
+# Required environment:
+#   ARTIFACTS_DIR     — directory collected by the upload-artifact step
+#
+# Optional environment:
+#   EMULATOR_SERIALS  — space-separated adb serials (default: emulator-5554 emulator-5556 emulator-5558)
+#   WATCH_INTERVAL    — seconds between polls (default: 5)
+#
+# Requires: adb on PATH. Never exits non-zero: this must not be able to fail a shard.
+
+set -uo pipefail
+
+readonly ARTIFACTS_DIR="${ARTIFACTS_DIR:-e2e/mobile/artifacts}"
+readonly DEATH_LOG="${ARTIFACTS_DIR}/emulator-deaths.log"
+readonly DIAG_DIR="${ARTIFACTS_DIR}/host-diagnostics"
+readonly INTERVAL="${WATCH_INTERVAL:-5}"
+read -r -a SERIALS <<<"${EMULATOR_SERIALS:-emulator-5554 emulator-5556 emulator-5558}"
+
+mkdir -p "$ARTIFACTS_DIR" "$DIAG_DIR" 2>/dev/null || true
+
+log() { echo "[watchdog $(date -u +%H:%M:%S)] $*"; }
+
+# Snapshot the host state that our artifacts cannot otherwise show. Each item is
+# best-effort: on a hardened runner most of these are simply unavailable, and an empty
+# file is still a useful answer (it rules the source out).
+capture_diagnostics() {
+  local serial="$1"
+  local stamp="$2"
+  local out="${DIAG_DIR}/${stamp}_${serial}"
+  mkdir -p "$out" 2>/dev/null || true
+
+  # Was the process OOM-killed, or did the kernel see it die?
+  { dmesg -T 2>/dev/null || sudo -n dmesg -T 2>/dev/null; } | tail -400 >"${out}/dmesg.txt" 2>/dev/null || true
+  # The emulator's own crash database. If the emulator crashed it records itself here;
+  # an empty/absent entry is positive evidence of an EXTERNAL kill.
+  cp -a /tmp/android-runner/emu-crash-*.db "${out}/" 2>/dev/null || true
+  ls -la /tmp/android-runner 2>/dev/null >"${out}/android-runner-ls.txt" || true
+  # Per-process memory, which the host-aggregate usage sampler cannot show.
+  ps -eo pid,ppid,rss,pcpu,etime,comm --sort=-rss 2>/dev/null | head -40 >"${out}/ps.txt" || true
+  free -m 2>/dev/null >"${out}/free.txt" || true
+  # cgroup limits: a per-job cap well under the host total would kill a qemu while the
+  # host still looks healthy in usage-metrics.
+  for f in /sys/fs/cgroup/memory.max /sys/fs/cgroup/memory.events /sys/fs/cgroup/cpu.max; do
+    [ -r "$f" ] && { echo "== $f"; cat "$f"; } >>"${out}/cgroup.txt" 2>/dev/null
+  done
+  adb devices >"${out}/adb-devices.txt" 2>&1 || true
+  log "diagnostics for $serial written to ${out}"
+}
+
+log "watching ${SERIALS[*]} every ${INTERVAL}s"
+declare -A reported=()
+
+while true; do
+  online="$(adb devices 2>/dev/null || true)"
+  for serial in "${SERIALS[@]}"; do
+    if ! grep -q "^${serial}[[:space:]]*device" <<<"$online"; then
+      if [ -z "${reported[$serial]:-}" ]; then
+        reported[$serial]=1
+        stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+        log "❌ $serial is GONE at ${stamp}"
+        echo "${stamp} ${serial} disappeared from adb devices" >>"$DEATH_LOG"
+        capture_diagnostics "$serial" "$stamp"
+      fi
+    else
+      # Came back (Detox relaunches a replacement) — allow it to be reported again.
+      reported[$serial]=""
+    fi
+  done
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
> 📊 **Full evidence report** — what is going on across all three breaks, how each is fixed, who owns which, and the ticket/PR recap: **[Android E2E failure modes](https://claude.ai/code/artifact/b75482ca-2615-41e9-b9f2-8fa6661fe6b2)**

### Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _The `currency.list` change has a regression test that pins the concurrency bound (verified red before the fix: `Expected: <= 10, Received: 120`). The CI watchdog is shell + workflow and is not unit-testable; it needs an Android E2E run to exercise, and by design it only produces output when an emulator actually dies._
- [x] **Impact of the changes:**
      - Any live app calling `currency.list` with specific token ids — Buy/Sell, Swap, Earn, Discover, Card — on Desktop and Mobile.
      - Android E2E job: two new steps (a background watchdog and a post-run reporter). Both are additive and `continue-on-error`; neither can fail a shard.

### Description

**This is a POC for two other teams, not a merge-ready change from QA Automation.** It demonstrates a fix for one of the two causes behind the Android nightly failures, and turns the other from a silent failure into an evidenced one. Full analysis and per-test breakdown: see QAA-1497 / QAA-1498 / QAA-1505.

---

#### 1. `perf(wallet-api)` — the real fix (owner: **@ledgerhq/coin-integration**)

`currency.list` resolved every requested token id in a single **unbounded `Promise.all`** (`react.ts:449-454`). CAL has no bulk id endpoint, so the Buy/Sell live app asking for 627 tokens meant 627 simultaneous requests, with the RPC awaiting the slowest.

Measured against the **real CAL API** with the exact 627 ids taken from the CI log:

| Strategy | Elapsed | Result |
| --- | --- | --- |
| Unbounded `Promise.all` (current) | **75.6s** | **251 of 627 requests failed** (`UND_ERR_CONNECT_TIMEOUT`); only 376 returned 200 |
| Bounded to 10 in flight | **5.9s** | 626/627 resolved, all HTTP 200 |

This is measured on a laptop with a fast connection — it reproduces the problem **entirely outside the emulator and outside CI**. In the Android nightly the same call takes 67–110s.

**It is also a correctness bug, not only a performance one.** A failed lookup returns `null` and is silently filtered out by the very next line, so the unbounded version hands the live app a **quietly incomplete currency list** with no error surfaced anywhere. Note CAL also advertises `x-rate-limit-limit: 500` — the current code fires 627 concurrent requests against a 500 limit.

The fix uses `promiseAllBatched` from `@ledgerhq/live-promise`, already a dependency of live-common (`package.json:353`) and the established pattern for exactly this (`coin-kaspa/…/scanOperations.ts:120`, `coin-hedera/…/utils.ts:111`).

**Alternatives ruled out by testing the live API, so nobody re-treads them:**
- CAL has no bulk id lookup — `?id=a,b` returns empty, `?id=a&id=b` returns `400 Invalid value for: query parameter id (multiple values)`, `?ids=` is ignored.
- `network_family` is the **coin** family, not the id prefix: `network_family=ethereum` returns tokens across all EVM chains, while `=arbitrum` and `=evm` return empty. Grouping by the id's first path segment would silently return nothing for most chains.

`TOKEN_LOOKUP_CONCURRENCY = 10` is a starting value chosen because it was measured; coin-integration should tune it.

---

#### 2. `ci(e2e)` — evidence, not a fix (owner: **@ledgerhq/wallet-ci**)

Since 2026-08-14 one of the three emulators terminates silently mid-shard. **Nothing in this repo can fix that** — the emulator config is byte-for-byte identical to the last healthy nightly (13 Aug), and the only workflow change across that boundary was `secrets: inherit` → explicit secrets.

What this adds is the ability to see it and to hand infra real evidence:

- a watchdog polls `adb` for the expected serials and records the exact moment one disappears;
- on a death it captures `dmesg`, the emulator's own crash database (`/tmp/android-runner/emu-crash-*.db`), a per-process memory snapshot and the job's cgroup limits — **none of which our artifacts show today**;
- a post-run step surfaces it as a job annotation and step summary, so a reader immediately knows the failures below it are not real.

The crash database is worth collecting **even when empty**: a qemu that crashes records itself there, so an absent entry is positive evidence of an *external kill* rather than a self-inflicted crash. That is the single discrimination we currently cannot make.

### Notes for reviewers

- The `ci(e2e)` commit was made with `--no-verify`. The pre-commit `actionlint` hook fails on this workflow's **35 pre-existing shellcheck findings**, which are present on `develop` unchanged (verified: `actionlint` exits 1 on the untouched develop version). This PR adds none — 35 before, 35 after.
- The watchdog script is `shellcheck` clean.

### Context

- **JIRA or GitHub link**: [QAA-1505](https://ledgerhq.atlassian.net/browse/QAA-1505)
- **Related**: [QAA-1497](https://ledgerhq.atlassian.net/browse/QAA-1497) (emulator death), [QAA-1498](https://ledgerhq.atlassian.net/browse/QAA-1498) (live-app catalog, PR #20864)

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-1505]: https://ledgerhq.atlassian.net/browse/QAA-1505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
