### PR TITLE
[LWD] feat(zcash): show spendable/maturing in balance warning (LIVE-36139)

### DIFF
--- a/.changeset/zcash-spendable-warning-banner.md
+++ b/.changeset/zcash-spendable-warning-banner.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+[ZEC] Replace pool-exclusion warning banner with spendable/maturing breakdown; move pool warning into private balance tooltip.

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/AccountBalanceSummaryFooter.tsx
@@ -66,18 +66,17 @@ const WarningWrapper = styled(Box).attrs(() => ({
   mt: 3,
 }))``;
 
-const WarningText = styled(Text).attrs(() => ({
-  fontSize: 3,
-  ff: "Inter|Medium",
-  color: "warning.c70",
-  ml: 2,
-}))``;
-
 const BalanceDetail = styled(Box).attrs(() => ({
   flex: "0 0 auto",
   alignItems: "start",
   paddingRight: 50,
 }))``;
+
+const TooltipWrapper = styled(Box)`
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space[1]}px;
+`;
 
 export const TitleWrapper = styled(Box).attrs(() => ({
   horizontal: true,
@@ -102,11 +101,11 @@ const AmountValue = styled(Text).attrs(() => ({
   ${p => p.paddingRight && `padding-right: ${p.paddingRight}px`};
 `;
 
-const MaturingAmount = styled(Text).attrs(() => ({
-  fontSize: 2,
-  ff: "Inter|Regular",
-  color: "neutral.c70",
-  mt: 1,
+const WarningBannerText = styled(Text).attrs(() => ({
+  fontSize: 3,
+  ff: "Inter|Medium",
+  color: "warning.c70",
+  ml: 2,
 }))``;
 
 const ActionButton = ({
@@ -409,7 +408,18 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
           </AmountValue>
         </BalanceDetail>
         <BalanceDetail>
-          <ToolTip content={<Trans i18nKey="zcash.account.privateBalanceTooltip" />}>
+          <ToolTip
+            content={
+              <TooltipWrapper>
+                <div>
+                  <Trans i18nKey="zcash.account.privateBalanceTooltip" />
+                </div>
+                <div>
+                  <Trans i18nKey="zcash.account.privateBalanceWarning" />
+                </div>
+              </TooltipWrapper>
+            }
+          >
             <TitleWrapper>
               <Title>
                 <Trans i18nKey="zcash.account.privateBalance" />
@@ -420,16 +430,6 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
           <AmountValue>
             <Discreet>{privateBalanceLabel}</Discreet>
           </AmountValue>
-          {hasMaturingFunds ? (
-            <MaturingAmount data-testid="zcash-private-maturing-amount">
-              <Discreet>
-                <Trans
-                  i18nKey="zcash.account.privateBalanceMaturing"
-                  values={{ spendable: spendableBalanceLabel, maturing: maturingAmountLabel }}
-                />
-              </Discreet>
-            </MaturingAmount>
-          ) : null}
         </BalanceDetail>
         <BalanceDetail>
           <div
@@ -448,12 +448,20 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
         </BalanceDetail>
       </Wrapper>
       <Separator />
-      <WarningWrapper>
-        <TriangleWarning size={16} />
-        <WarningText>
-          <Trans i18nKey="zcash.account.privateBalanceWarning" />
-        </WarningText>
-      </WarningWrapper>
+
+      {hasMaturingFunds ? (
+        <WarningWrapper>
+          <TriangleWarning size={16} />
+          <WarningBannerText data-testid="zcash-private-maturing-amount">
+            <Discreet>
+              <Trans
+                i18nKey="zcash.account.privateBalanceMaturing"
+                values={{ spendable: spendableBalanceLabel, maturing: maturingAmountLabel }}
+              />
+            </Discreet>
+          </WarningBannerText>
+        </WarningWrapper>
+      ) : null}
     </Container>
   );
 };

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/AccountBalanceSummaryFooter.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/AccountBalanceSummaryFooter.test.tsx
@@ -19,6 +19,14 @@ jest.mock("@ledgerhq/live-common/bridge/index", () => ({
 jest.mock("../ZCashExportKeyFlowModal/sync", () => ({
   syncStateUpdater: jest.fn(() => ({ type: "test/syncStateUpdater" })),
 }));
+jest.mock("@ledgerhq/coin-zcash/logic/account/spendability", () => ({
+  hasMaturingIronwoodNotes: jest.fn(() => false),
+  getSpendableIronwoodBalance: jest.fn(() => new BigNumber(0)),
+  getMaturingIronwoodBalance: jest.fn(() => new BigNumber(0)),
+}));
+jest.mock("@ledgerhq/coin-zcash/bridge/note-reservation", () => ({
+  getReservedNullifiers: jest.fn(() => []),
+}));
 const mockedGetAccountBridge = jest.mocked(getAccountBridge);
 const mockedSyncStateUpdater = jest.mocked(syncStateUpdater);
 
@@ -66,7 +74,9 @@ describe("Bitcoin Account Balance Summary Footer", () => {
       expect(screen.getByText("Transparent balance")).toBeInTheDocument();
       expect(screen.getByText("Private balance")).toBeInTheDocument();
       expect(screen.getByTestId("show-private-balance-button")).toBeInTheDocument();
-      expect(screen.getByText(PRIVATE_BALANCE_WARNING)).toBeVisible();
+      // Warning is now in the ℹ tooltip, not the banner. The banner only renders
+      // when maturing funds are present; a fresh account has none.
+      expect(screen.queryByTestId("zcash-private-maturing-amount")).not.toBeInTheDocument();
     });
   });
 

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8971,7 +8971,7 @@
       "privateBalance": "Private balance",
       "privateBalanceTooltip": "Balance that is hidden from the public",
       "privateBalanceWarning": "Private balance excludes Sapling and Orchard shielded funds",
-      "privateBalanceMaturing": "{{spendable}} spendable · {{maturing}} maturing"
+      "privateBalanceMaturing": "Private balance: {{spendable}} spendable · {{maturing}} maturing"
     },
     "shielded": {
       "send": {


### PR DESCRIPTION
### 📝 Description

The private balance section on the Zcash account page previously showed
a static pool-exclusion warning ("Private balance excludes Sapling and
Orchard shielded funds") as the primary callout below the balance row.
This is background context, not actionable information.

This PR swaps the content:
- **Warning banner** now shows the spendable · maturing breakdown
  (`X ZEC spendable · Y ZEC maturing`) so users immediately know how
  much they can actually send, without an extra click.
- **Private balance ℹ tooltip** now carries the pool-exclusion note
  alongside the existing balance description, where it belongs as
  contextual background.



The banner only renders when maturing funds are present
(`hasMaturingIronwoodNotes`), keeping the UI clean for fully-spendable
accounts.

> **Out of scope / pending:** whether to surface the spendable · maturing
> split in the send modal when sending from the private pool is pending
> product sign-off. A follow-up will be raised once confirmed.

<img width="482" height="136" alt="Screenshot 2026-08-18 at 16 41 09" src="https://github.com/user-attachments/assets/400f81ac-5196-48a5-af86-5261ce52c3b0" />
<img width="338" height="65" alt="Screenshot 2026-08-18 at 16 41 20" src="https://github.com/user-attachments/assets/9842a3bf-cdc9-4c48-816b-5c4e1926e66d" />


### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36139](https://ledgerhq.atlassian.net/browse/LIVE-36139)
- **ADR** (if any): N/A

[LIVE-36139]: https://ledgerhq.atlassian.net/browse/LIVE-36139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ