### PR TITLE
feat(test-quarantine): report flakes from Playwright runs

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -89,6 +89,8 @@ jobs:
       NX_KEY: ${{ secrets.NX_KEY }}
       SEED_QAA_B2C: ${{ secrets.SEED_QAA_B2C }}
       SLACK_LIVE_CI_BOT_TOKEN: ${{ secrets.SLACK_LIVE_CI_BOT_TOKEN }}
+      FLAKE_API_KEY_CI: ${{ secrets.FLAKE_API_KEY_CI }}
+      FLAKE_API_HOST: ${{ secrets.FLAKE_API_HOST }}
 
   codecheck-desktop:
     name: "Desktop Lint & Unit Tests"

--- a/.github/workflows/build-and-test-push.yml
+++ b/.github/workflows/build-and-test-push.yml
@@ -47,6 +47,8 @@ jobs:
       NX_KEY: ${{ secrets.NX_KEY }}
       SEED_QAA_B2C: ${{ secrets.SEED_QAA_B2C }}
       SLACK_LIVE_CI_BOT_TOKEN: ${{ secrets.SLACK_LIVE_CI_BOT_TOKEN }}
+      FLAKE_API_KEY_CI: ${{ secrets.FLAKE_API_KEY_CI }}
+      FLAKE_API_HOST: ${{ secrets.FLAKE_API_HOST }}
 
   codecheck-desktop:
     name: "Desktop Lint & Unit Tests"

--- a/.github/workflows/test-desktop-reusable.yml
+++ b/.github/workflows/test-desktop-reusable.yml
@@ -24,6 +24,10 @@ on:
         required: true
       NX_KEY:
         required: true
+      FLAKE_API_KEY_CI:
+        required: false
+      FLAKE_API_HOST:
+        required: false
       SEED_QAA_B2C:
         required: true
       SLACK_LIVE_CI_BOT_TOKEN:
@@ -227,6 +231,9 @@ jobs:
 
       - name: Run playwright tests [Linux => xvfb-run]
         id: tests
+        env:
+          FLAKE_API_KEY: ${{ secrets.FLAKE_API_KEY_CI }}
+          FLAKE_API_HOST: ${{ secrets.FLAKE_API_HOST }}
         run: |
           xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- pnpm desktop test:playwright
 
@@ -263,10 +270,11 @@ jobs:
         with:
           name: images
           path: images-linux.json
-      - name: Upload playwright test results [On Failure]
+      - name: Upload playwright test results
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        if: failure() && !cancelled()
+        if: ${{ !cancelled() }}
         with:
+          if-no-files-found: ignore
           name: playwright-results-linux
           path: |
             apps/ledger-live-desktop/tests/artifacts/test-results

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -247,6 +247,7 @@
     "@ledgerhq/live-cli": "workspace:^",
     "@ledgerhq/live-e2e-shared": "workspace:^",
     "@ledgerhq/speculos-transport": "workspace:^",
+    "@ledgerhq/test-quarantine": "workspace:^",
     "@ledgerhq/test-utils": "workspace:^",
     "@playwright/test": "catalog:",
     "@rsbuild/core": "catalog:",

--- a/apps/ledger-live-desktop/tests/playwright.config.ts
+++ b/apps/ledger-live-desktop/tests/playwright.config.ts
@@ -39,7 +39,10 @@ const config: PlaywrightTestConfig = {
   reportSlowTests: process.env.CI ? { max: 0, threshold: 60000 } : null,
   fullyParallel: true,
   workers: "60%", // NOTE: 'macos-latest' and 'windows-latest' can't run 3 concurrent workers
-  retries: 0, // We explicitly want to disable retries to be strict about avoiding flaky tests. (see https://github.com/LedgerHQ/ledger-live/pull/4918)
+  // One CI retry so a flake is observable at all — without a second attempt it is
+  // indistinguishable from a plain failure. Local stays strict and immediate.
+  retries: process.env.CI ? 1 : 0,
+  failOnFlakyTests: false,
   reporter: process.env.CI
     ? [
         ["html", { open: "never", outputFolder: "artifacts/html-report" }],
@@ -47,6 +50,7 @@ const config: PlaywrightTestConfig = {
         ["line"],
         ["allure-playwright"],
         ["./utils/customJsonReporter.ts"],
+        ["@ledgerhq/test-quarantine/playwright"],
       ]
     : [["allure-playwright"]],
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1400,6 +1400,9 @@ importers:
       '@ledgerhq/speculos-transport':
         specifier: workspace:^
         version: link:../../libs/speculos-transport
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:^
+        version: link:../../tools/test-quarantine
       '@ledgerhq/test-utils':
         specifier: workspace:^
         version: link:../../libs/test-utils
@@ -16214,11 +16217,14 @@ importers:
       '@jest/test-result':
         specifier: 'catalog:'
         version: 30.2.0
+      '@playwright/test':
+        specifier: 'catalog:'
+        version: 1.60.0
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.0
-      jest-cli:
-        specifier: 30.2.0
+      jest:
+        specifier: 'catalog:'
         version: 30.2.0(@types/node@24.12.0)
       typescript:
         specifier: 'catalog:'
@@ -27252,7 +27258,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: ^5.5.10
+      rxjs: '*'
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -68264,7 +68270,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.7
+      metro: 0.83.7(metro-transform-worker@0.83.7)
       metro-babel-transformer: 0.83.7
       metro-cache: 0.83.7
       metro-cache-key: 0.83.7
@@ -68414,6 +68420,53 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.83.7(metro-transform-worker@0.83.7):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.28.5
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 2.0.0
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.35.0
+      image-size: 1.1.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0(metro@0.83.7)
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.7
+      metro-cache: 0.83.7
+      metro-cache-key: 0.83.7
+      metro-config: 0.83.7(metro-transform-worker@0.83.7)
+      metro-core: 0.83.7
+      metro-file-map: 0.83.7(metro@0.83.7)
+      metro-resolver: 0.83.7
+      metro-runtime: 0.83.7
+      metro-source-map: 0.83.7
+      metro-symbolicate: 0.83.7
+      metro-transform-plugins: 0.83.7
+      metro-transform-worker: 0.83.7
+      mime-types: 3.0.1
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - metro-transform-worker
       - supports-color
       - utf-8-validate
 
@@ -68964,7 +69017,7 @@ snapshots:
       '@open-draft/until': 2.1.0
       '@types/cookie': 0.6.0
       '@types/statuses': 2.0.5
-      graphql: 16.13.2
+      graphql: 16.14.2
       headers-polyfill: 4.0.3
       is-node-process: 1.2.0
       outvariant: 1.4.3

--- a/tools/test-quarantine/README.md
+++ b/tools/test-quarantine/README.md
@@ -1,6 +1,7 @@
 # @ledgerhq/test-quarantine
 
-Flake reporting for the repo's test suites. Test quarantine follows in a later phase.
+Flake reporting for the repo's jest and Playwright suites. Detox and test quarantine
+follow in later phases.
 
 A **flake** is a test that failed an attempt and passed a later one within the same run.
 This package spots those and reports them to the wallet-flake-reporting ingest API, so
@@ -23,6 +24,7 @@ core/       runner-agnostic; no runner imports
   ci          CI detection and the run URL
 
 jest/       the jest reporter
+playwright/ the Playwright reporter
 ```
 
 Only `core/redact.ts` uses regular expressions, because redaction is inherently pattern
@@ -81,6 +83,34 @@ evidence, so a hard failure in one case is never reported as a flake because a s
 passed. The cost is that if one such case genuinely flakes, the failure text may be
 attributed to a sibling. Interpolate the parameters into `each` titles
 (`test.each([...])("rejects %s", …)`) and the ambiguity disappears.
+
+## Enabling it for a Playwright project
+
+Add the reporter to the config's `reporter` list and declare the dependency, as above:
+
+```ts
+reporter: [
+  ["line"],
+  ["@ledgerhq/test-quarantine/playwright"],
+],
+```
+
+Retries are what make it produce anything — with no second attempt a flake cannot be
+distinguished from a failure:
+
+```ts
+retries: process.env.CI ? 1 : 0,
+failOnFlakyTests: false,
+```
+
+Turning `retries` on is what changes behaviour; `false` is already Playwright's default, so
+the line is an explicit anchor rather than the operative change — set it to `true` to keep
+flakes failing the build, but deleting it restores nothing. The default is what we want once
+flakes are recorded: a test that passes on retry stops blocking the merge and is reported
+instead. Note a `--fail-on-flaky-tests` CLI flag overrides the config either way.
+
+A test that fails **every** attempt still fails the build, and local runs stay strict at
+zero retries so a failure surfaces immediately.
 
 ## Configuration
 

--- a/tools/test-quarantine/package.json
+++ b/tools/test-quarantine/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./jest": "./src/jest/flake-reporter.ts"
+    "./jest": "./src/jest/flake-reporter.ts",
+    "./playwright": "./src/playwright/flake-reporter.ts"
   },
   "scripts": {
     "test": "node --test \"test/**/*.test.ts\"",
@@ -17,8 +18,9 @@
   "devDependencies": {
     "@jest/reporters": "catalog:",
     "@jest/test-result": "catalog:",
+    "@playwright/test": "catalog:",
     "@types/node": "catalog:",
-    "jest-cli": "30.2.0",
+    "jest": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/tools/test-quarantine/src/core/detect.ts
+++ b/tools/test-quarantine/src/core/detect.ts
@@ -29,11 +29,15 @@ export function canContributeToFlake(outcome: TestOutcome): boolean {
 }
 
 /**
- * Grouping key for one test. JSON encoding keeps the two fields unambiguous
- * without inventing a separator that a path or title might itself contain.
+ * Grouping key for one test. JSON encoding keeps the fields unambiguous without
+ * inventing a separator that a path or title might itself contain.
+ *
+ * `variant` keeps independent runs of the same spec apart — without it, two
+ * Playwright projects running one spec merge into a single group and only one of
+ * their flakes is ever reported.
  */
-function testKey(file: string, title: string): string {
-  return JSON.stringify([file, title]);
+function testKey(outcome: TestOutcome): string {
+  return JSON.stringify([outcome.file, outcome.title, outcome.variant ?? ""]);
 }
 
 /**
@@ -46,7 +50,7 @@ export function detectFlakes(outcomes: TestOutcome[]): Flake[] {
   const attemptsByTest = new Map<string, TestOutcome[]>();
   for (const outcome of outcomes) {
     if (!canContributeToFlake(outcome)) continue;
-    const key = testKey(outcome.file, outcome.title);
+    const key = testKey(outcome);
     const attempts = attemptsByTest.get(key);
     if (attempts) attempts.push(outcome);
     else attemptsByTest.set(key, [outcome]);

--- a/tools/test-quarantine/src/core/outcome.ts
+++ b/tools/test-quarantine/src/core/outcome.ts
@@ -18,4 +18,13 @@ export interface TestOutcome {
   status: TestStatus;
   /** Failure text for this attempt. Only meaningful when `status` is "failed". */
   errorMessage?: string;
+  /**
+   * Runner-specific discriminator for tests that share a file and title but are
+   * genuinely separate runs of it — a Playwright project, for instance.
+   *
+   * It groups attempts and is never reported: two projects running the same spec
+   * are two tests that can flake independently, but the reported title should
+   * stay the test's own title.
+   */
+  variant?: string;
 }

--- a/tools/test-quarantine/src/playwright/flake-reporter.ts
+++ b/tools/test-quarantine/src/playwright/flake-reporter.ts
@@ -1,0 +1,139 @@
+import type {
+  FullConfig,
+  FullResult,
+  Reporter,
+  Suite,
+  TestCase,
+  TestResult,
+} from "@playwright/test/reporter";
+import { detectFlakes } from "../core/detect.ts";
+import { reportFlakes, type IngestOptions } from "../core/ingest.ts";
+import type { TestOutcome, TestStatus } from "../core/outcome.ts";
+import { repoRoot, toRepoRelative } from "../core/paths.ts";
+
+/**
+ * Translate Playwright's status vocabulary into ours.
+ *
+ * A timeout is a failure that happens to have run out of clock; `interrupted`
+ * means the run was cut short before this attempt finished, so it says nothing
+ * about the test and is treated as not-run.
+ */
+function toTestStatus(status: TestResult["status"]): TestStatus {
+  if (status === "passed") return "passed";
+  if (status === "failed" || status === "timedOut") return "failed";
+  return "skipped";
+}
+
+/**
+ * The describe titles plus the test title, space-joined.
+ *
+ * Deliberately NOT `titlePath()`: that also includes the root, the project name
+ * and the file path, so the reported title would change when a project is
+ * renamed and would duplicate the `file` field. Walking the suite chain and
+ * keeping only `describe` suites gives the same shape as jest's `fullName`, so a
+ * title means the same thing whichever runner produced it.
+ */
+export function fullTitle(test: TestCase): string {
+  const titles: string[] = [];
+  for (let suite: Suite | undefined = test.parent; suite; suite = suite.parent) {
+    if (suite.type === "describe") titles.unshift(suite.title);
+  }
+  titles.push(test.title);
+  return titles.join(" ");
+}
+
+function errorMessage(result: TestResult): string | undefined {
+  const messages = result.errors.map(error => error.message).filter(Boolean);
+  return messages.length > 0 ? messages.join("\n") : undefined;
+}
+
+/**
+ * One outcome per attempt Playwright recorded for this test.
+ *
+ * `result.retry` is already the 0-based attempt index we want, so unlike jest
+ * there is nothing to convert.
+ */
+export function toOutcomes(test: TestCase, root: string): TestOutcome[] {
+  // A test declared with `test.fail()` is expected to fail; its failures are the
+  // point, not a flake.
+  if (test.expectedStatus !== "passed") return [];
+
+  const file = toRepoRelative(test.location.file, root);
+  const title = fullTitle(test);
+  // Each project runs the spec independently and can flake on its own, so the
+  // project name keeps their attempts in separate groups.
+  const variant = test.parent.project()?.name;
+
+  return test.results.map(result => {
+    const status = toTestStatus(result.status);
+    return {
+      file,
+      title,
+      attempt: result.retry,
+      status,
+      errorMessage: status === "failed" ? errorMessage(result) : undefined,
+      variant,
+    };
+  });
+}
+
+/**
+ * Reports Playwright tests that only passed after a retry.
+ *
+ * Playwright hands reporters the whole suite once the run is over, so unlike the
+ * jest adapter this one does its work in a single pass at the end. It reads only
+ * what the runner reports and changes nothing about the run.
+ *
+ * It is inert unless the project configures `retries`: with no retries there is
+ * never a second attempt, so a flake cannot be distinguished from a failure.
+ *
+ * Delivery is best-effort — see `reportFlakes`. Nothing here can fail a run.
+ */
+export default class PlaywrightFlakeReporter implements Reporter {
+  readonly #repoRoot: string;
+  readonly #options: IngestOptions;
+  #suite: Suite | undefined;
+
+  /**
+   * Playwright merges its own `{ configDir, _mode, _commandHash }` into whatever
+   * the config supplies, so the argument is wider than this — only `host` is
+   * meaningfully settable from a config file. The rest of `IngestOptions` exists
+   * for tests.
+   */
+  constructor(options: IngestOptions = {}) {
+    this.#options = options;
+    this.#repoRoot = repoRoot(options.env);
+  }
+
+  onBegin(_config: FullConfig, suite: Suite): void {
+    this.#suite = suite;
+  }
+
+  /** Playwright waits on the returned promise, so reporting completes before exit. */
+  async onEnd(_result: FullResult): Promise<void> {
+    // Nothing here is worth failing an otherwise healthy run over.
+    try {
+      const tests = this.#suite?.allTests() ?? [];
+      const outcomes = tests.flatMap(test => toOutcomes(test, this.#repoRoot));
+      const flakes = detectFlakes(outcomes);
+      if (flakes.length === 0) return;
+
+      // Playwright's own output marks flaky tests, but name them here too so the
+      // reported set is visible next to the delivery result.
+      console.log(`[test-quarantine] ${flakes.length} test(s) passed only after a retry:`);
+      for (const flake of flakes) {
+        console.log(`  - ${flake.file} > ${flake.title} (passed on retry ${flake.retryCount})`);
+      }
+
+      const summary = await reportFlakes(flakes, this.#options);
+      if (summary.skipped) return;
+      console.log(
+        `[test-quarantine] reported ${summary.delivered}/${flakes.length} to the ingest API.`,
+      );
+    } catch (error) {
+      console.warn(
+        `[test-quarantine] flake reporting failed: ${(error as Error).message} — continuing.`,
+      );
+    }
+  }
+}

--- a/tools/test-quarantine/test/jest-integration.test.ts
+++ b/tools/test-quarantine/test/jest-integration.test.ts
@@ -31,7 +31,7 @@ const packageRoot = fileURLToPath(new URL("..", import.meta.url));
 function resolveJestBin(): string | undefined {
   if (process.env.TEST_QUARANTINE_JEST_BIN) return process.env.TEST_QUARANTINE_JEST_BIN;
   try {
-    return createRequire(import.meta.url).resolve("jest-cli/bin/jest");
+    return createRequire(import.meta.url).resolve("jest/bin/jest");
   } catch {
     return undefined;
   }
@@ -128,33 +128,48 @@ function createFixtureProject(): { root: string; counterFile: string } {
   return { root, counterFile };
 }
 
-function runJest(jestBin: string, root: string, env: NodeJS.ProcessEnv): Promise<number> {
-  return new Promise(resolve => {
-    const child = spawn(process.execPath, [jestBin, "--config", join(root, "jest.config.js")], {
-      cwd: root,
-      env: { ...process.env, ...env },
-      stdio: "pipe",
-    });
-    child.on("close", code => resolve(code ?? 1));
+/**
+ * Runs jest and returns its exit code plus everything it printed.
+ *
+ * The output must be drained: an unread pipe blocks the child once it fills, and
+ * `node --test` has no default timeout, so that would hang the suite rather than
+ * fail it. Returning the output also makes a failed assertion diagnosable.
+ */
+async function runJest(
+  jestBin: string,
+  root: string,
+  env: NodeJS.ProcessEnv,
+): Promise<{ code: number; output: string }> {
+  const child = spawn(process.execPath, [jestBin, "--config", join(root, "jest.config.js")], {
+    cwd: root,
+    env: { ...process.env, ...env },
+    stdio: ["ignore", "pipe", "pipe"],
   });
+
+  let output = "";
+  child.stdout.on("data", chunk => (output += chunk));
+  child.stderr.on("data", chunk => (output += chunk));
+
+  const code = await new Promise<number>(resolve => child.on("close", c => resolve(c ?? 1)));
+  return { code, output };
 }
 
 const jestBin = resolveJestBin();
-const skip = jestBin ? false : "jest-cli is not installed; run pnpm install for this package";
+const skip = jestBin ? false : "jest is not installed; run pnpm install for this package";
 
 test("a real jest run reports a genuinely flaky test", { skip }, async () => {
   const ingest = await startIngestStub();
   const { root } = createFixtureProject();
 
   try {
-    const exitCode = await runJest(jestBin as string, root, {
+    const { code, output } = await runJest(jestBin as string, root, {
       CI: "true",
       FLAKE_API_KEY: "test-key",
       FLAKE_API_HOST: ingest.url,
       QUARANTINE_REPO_ROOT: root,
     });
 
-    assert.equal(exitCode, 0, "the retried test passes, so the run is green");
+    assert.equal(code, 0, output || "the retried test passes, so the run is green");
     assert.equal(ingest.requests.length, 1, "exactly one ingest request");
 
     const { events, apiKey } = ingest.requests[0];
@@ -178,14 +193,14 @@ test("a real jest run reports nothing when no test is retried", { skip }, async 
   writeFileSync(counterFile, "1");
 
   try {
-    const exitCode = await runJest(jestBin as string, root, {
+    const { code, output } = await runJest(jestBin as string, root, {
       CI: "true",
       FLAKE_API_KEY: "test-key",
       FLAKE_API_HOST: ingest.url,
       QUARANTINE_REPO_ROOT: root,
     });
 
-    assert.equal(exitCode, 0);
+    assert.equal(code, 0, output);
     assert.equal(ingest.requests.length, 0, "a clean run posts nothing");
   } finally {
     await ingest.close();
@@ -244,14 +259,14 @@ test("a real jest run stays green when the ingest API returns 500", { skip }, as
   const { root } = createFixtureProject();
 
   try {
-    const exitCode = await runJest(jestBin as string, root, {
+    const { code, output } = await runJest(jestBin as string, root, {
       CI: "true",
       FLAKE_API_KEY: "test-key",
       FLAKE_API_HOST: ingest.url,
       QUARANTINE_REPO_ROOT: root,
     });
 
-    assert.equal(exitCode, 0, "a broken ingest API must never fail a test run");
+    assert.equal(code, 0, output || "a broken ingest API must never fail a test run");
     assert.equal(ingest.requests.length, 1, "it did try");
   } finally {
     await ingest.close();
@@ -262,27 +277,27 @@ test("a real jest run stays green when nothing is listening", { skip }, async ()
   const { root } = createFixtureProject();
 
   // Port 9 (discard) refuses connections.
-  const exitCode = await runJest(jestBin as string, root, {
+  const { code, output } = await runJest(jestBin as string, root, {
     CI: "true",
     FLAKE_API_KEY: "test-key",
     FLAKE_API_HOST: "http://127.0.0.1:9",
     QUARANTINE_REPO_ROOT: root,
   });
 
-  assert.equal(exitCode, 0, "an unreachable ingest API must never fail a test run");
+  assert.equal(code, 0, output || "an unreachable ingest API must never fail a test run");
 });
 
 test("a real jest run stays green when the host is malformed", { skip }, async () => {
   const { root } = createFixtureProject();
 
-  const exitCode = await runJest(jestBin as string, root, {
+  const { code, output } = await runJest(jestBin as string, root, {
     CI: "true",
     FLAKE_API_KEY: "test-key",
     FLAKE_API_HOST: "definitely not a url",
     QUARANTINE_REPO_ROOT: root,
   });
 
-  assert.equal(exitCode, 0, "a misconfigured host must never fail a test run");
+  assert.equal(code, 0, output || "a misconfigured host must never fail a test run");
 });
 
 test("same-titled cases are not reported as a flake by a real jest run", { skip }, async () => {
@@ -303,14 +318,14 @@ test("same-titled cases are not reported as a flake by a real jest run", { skip 
   );
 
   try {
-    const exitCode = await runJest(jestBin as string, root, {
+    const { code, output } = await runJest(jestBin as string, root, {
       CI: "true",
       FLAKE_API_KEY: "test-key",
       FLAKE_API_HOST: ingest.url,
       QUARANTINE_REPO_ROOT: root,
     });
 
-    assert.equal(exitCode, 1, "the hard failure still fails the run");
+    assert.equal(code, 1, output || "the hard failure still fails the run");
     assert.equal(ingest.requests.length, 0, "and is not reported as a flake");
   } finally {
     await ingest.close();

--- a/tools/test-quarantine/test/playwright-integration.test.ts
+++ b/tools/test-quarantine/test/playwright-integration.test.ts
@@ -1,0 +1,357 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer, type Server } from "node:http";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+/**
+ * End-to-end cover for the Playwright adapter: a real `playwright test` process
+ * loading the real reporter through the package's `exports`, against a spec that
+ * genuinely fails and then passes.
+ *
+ * This pins the API shapes the adapter reads — `TestResult.retry`,
+ * `Suite.type`, `TestCase.expectedStatus`, `TestCase.results` — so an upstream
+ * change surfaces here rather than as silently missing flake reports.
+ *
+ * No browser is launched: the fixture specs never touch the `page` fixture, so
+ * this runs anywhere without `playwright install`.
+ */
+
+const packageRoot = fileURLToPath(new URL("..", import.meta.url));
+
+/** Fixture roots to remove when the suite finishes; each holds symlinks into the repo. */
+const fixtureRoots: string[] = [];
+test.after(() => {
+  for (const root of fixtureRoots) rmSync(root, { recursive: true, force: true });
+});
+
+function resolvePlaywrightBin(): string | undefined {
+  if (process.env.TEST_QUARANTINE_PLAYWRIGHT_BIN) {
+    return process.env.TEST_QUARANTINE_PLAYWRIGHT_BIN;
+  }
+  try {
+    return createRequire(import.meta.url).resolve("@playwright/test/cli");
+  } catch {
+    return undefined;
+  }
+}
+
+const playwrightBin = resolvePlaywrightBin();
+const skip = playwrightBin
+  ? false
+  : "@playwright/test is not installed; run pnpm install for this package";
+
+interface IngestRequest {
+  events: { testTitle: string; file: string; retryCount: number; errorMessage: string }[];
+}
+
+async function startIngestStub(status = 200): Promise<{
+  url: string;
+  requests: IngestRequest[];
+  close: () => Promise<void>;
+}> {
+  const requests: IngestRequest[] = [];
+  const server: Server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", chunk => chunks.push(chunk));
+    req.on("end", () => {
+      requests.push(JSON.parse(Buffer.concat(chunks).toString("utf8")));
+      res.writeHead(status, { "content-type": "application/json" });
+      res.end("{}");
+    });
+  });
+
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (address === null || typeof address === "string") throw new Error("no port");
+
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    requests,
+    close: () => new Promise<void>(resolve => server.close(() => resolve())),
+  };
+}
+
+/**
+ * A consumer project laid out as pnpm lays out a workspace dependency: the
+ * package is symlinked, not copied, so Node will strip types from its `.ts`.
+ */
+function createFixtureProject(spec: string, retries = 1): { root: string; counterFile: string } {
+  const root = mkdtempSync(join(tmpdir(), "tq-pw-integration-"));
+  fixtureRoots.push(root);
+  mkdirSync(join(root, "specs"), { recursive: true });
+  mkdirSync(join(root, "node_modules", "@ledgerhq"), { recursive: true });
+  mkdirSync(join(root, "node_modules", "@playwright"), { recursive: true });
+  symlinkSync(packageRoot, join(root, "node_modules", "@ledgerhq", "test-quarantine"), "dir");
+  // The specs `require("@playwright/test")`, so the fixture needs it resolvable.
+  // Derived from the CLI we are about to run, so both always agree on a version.
+  symlinkSync(
+    dirname(playwrightBin as string),
+    join(root, "node_modules", "@playwright", "test"),
+    "dir",
+  );
+
+  writeFileSync(
+    join(root, "package.json"),
+    JSON.stringify({ name: "pw-fixture", version: "1.0.0", private: true }, null, 2),
+  );
+  writeFileSync(
+    join(root, "playwright.config.js"),
+    [
+      "module.exports = {",
+      `  testDir: "./specs",`,
+      `  retries: ${retries},`,
+      `  reporter: [["@ledgerhq/test-quarantine/playwright"]],`,
+      "};",
+      "",
+    ].join("\n"),
+  );
+
+  const counterFile = join(root, "attempts.txt");
+  writeFileSync(counterFile, "0");
+  writeFileSync(join(root, "specs", "a.spec.js"), spec.replace("__COUNTER__", counterFile));
+
+  return { root, counterFile };
+}
+
+/**
+ * Playwright starts a fresh worker process for every retry, so a module-scoped
+ * counter would reset. The attempt count has to live on disk.
+ */
+const FLAKY_SPEC = `
+const fs = require("node:fs");
+const { test, expect } = require("@playwright/test");
+
+test.describe("payments", () => {
+  test("settles eventually", () => {
+    const file = ${JSON.stringify("__COUNTER__")};
+    const attempt = Number(fs.readFileSync(file, "utf8"));
+    fs.writeFileSync(file, String(attempt + 1));
+    if (attempt < 1) throw new Error("not settled yet");
+    expect(attempt).toBe(1);
+  });
+
+  test("is stable", () => {
+    expect(1).toBe(1);
+  });
+});
+`;
+
+const ALWAYS_FAILS_SPEC = `
+const { test, expect } = require("@playwright/test");
+test("never works", () => {
+  expect(1).toBe(2);
+});
+`;
+
+const EXPECTED_FAILURE_SPEC = `
+const { test, expect } = require("@playwright/test");
+test("known broken", () => {
+  test.fail();
+  expect(1).toBe(2);
+});
+`;
+
+/**
+ * Runs Playwright and returns its exit code plus everything it printed.
+ *
+ * The output must be drained: an unread pipe blocks the child once it fills, and
+ * `node --test` has no default timeout, so that would hang the suite rather than
+ * fail it. Returning the output also makes a failed assertion diagnosable.
+ */
+async function runPlaywright(
+  bin: string,
+  root: string,
+  env: NodeJS.ProcessEnv,
+): Promise<{ code: number; output: string }> {
+  const child = spawn(process.execPath, [bin, "test"], {
+    cwd: root,
+    env: { ...process.env, ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let output = "";
+  child.stdout.on("data", chunk => (output += chunk));
+  child.stderr.on("data", chunk => (output += chunk));
+
+  const code = await new Promise<number>(resolve => child.on("close", c => resolve(c ?? 1)));
+  return { code, output };
+}
+
+test("a real playwright run reports a genuinely flaky test", { skip }, async () => {
+  const ingest = await startIngestStub();
+  const { root } = createFixtureProject(FLAKY_SPEC);
+
+  try {
+    const { code, output } = await runPlaywright(playwrightBin as string, root, {
+      CI: "true",
+      FLAKE_API_KEY: "test-key",
+      FLAKE_API_HOST: ingest.url,
+      QUARANTINE_REPO_ROOT: root,
+    });
+
+    assert.equal(code, 0, output || "the retried test passes, so the run is green");
+    assert.equal(ingest.requests.length, 1, "exactly one ingest request");
+
+    const { events } = ingest.requests[0];
+    assert.equal(events.length, 1, "only the flaky test is reported");
+
+    const [flake] = events;
+    assert.equal(flake.testTitle, "payments settles eventually", "describes plus title");
+    assert.equal(flake.file, "specs/a.spec.js", "reported relative to the repo root");
+    assert.equal(flake.retryCount, 1, "passed on the first retry");
+    assert.match(flake.errorMessage, /not settled yet/);
+    assert.ok(!flake.errorMessage.includes("\n    at "), "stack frames are stripped");
+  } finally {
+    await ingest.close();
+  }
+});
+
+test("a real playwright run reports nothing when a test just fails", { skip }, async () => {
+  const ingest = await startIngestStub();
+  const { root } = createFixtureProject(ALWAYS_FAILS_SPEC);
+
+  try {
+    const { code, output } = await runPlaywright(playwrightBin as string, root, {
+      CI: "true",
+      FLAKE_API_KEY: "test-key",
+      FLAKE_API_HOST: ingest.url,
+      QUARANTINE_REPO_ROOT: root,
+    });
+
+    assert.equal(code, 1, output || "a hard failure still fails the run");
+    assert.equal(ingest.requests.length, 0, "and is not reported as a flake");
+  } finally {
+    await ingest.close();
+  }
+});
+
+test("a test declared with test.fail() is not reported", { skip }, async () => {
+  const ingest = await startIngestStub();
+  const { root } = createFixtureProject(EXPECTED_FAILURE_SPEC);
+
+  try {
+    await runPlaywright(playwrightBin as string, root, {
+      CI: "true",
+      FLAKE_API_KEY: "test-key",
+      FLAKE_API_HOST: ingest.url,
+      QUARANTINE_REPO_ROOT: root,
+    });
+
+    assert.equal(ingest.requests.length, 0, "an expected failure is not a flake");
+  } finally {
+    await ingest.close();
+  }
+});
+
+test("a real playwright run reports nothing with retries disabled", { skip }, async () => {
+  const ingest = await startIngestStub();
+  const { root } = createFixtureProject(FLAKY_SPEC, 0);
+
+  try {
+    const { code, output } = await runPlaywright(playwrightBin as string, root, {
+      CI: "true",
+      FLAKE_API_KEY: "test-key",
+      FLAKE_API_HOST: ingest.url,
+      QUARANTINE_REPO_ROOT: root,
+    });
+
+    assert.equal(code, 1, output || "without a retry the flake is just a failure");
+    assert.equal(ingest.requests.length, 0);
+  } finally {
+    await ingest.close();
+  }
+});
+
+test("a real playwright run stays green when the ingest API fails", { skip }, async () => {
+  const ingest = await startIngestStub(500);
+  const { root } = createFixtureProject(FLAKY_SPEC);
+
+  try {
+    const { code, output } = await runPlaywright(playwrightBin as string, root, {
+      CI: "true",
+      FLAKE_API_KEY: "test-key",
+      FLAKE_API_HOST: ingest.url,
+      QUARANTINE_REPO_ROOT: root,
+    });
+
+    assert.equal(code, 0, output || "a broken ingest API must never fail a test run");
+    assert.equal(ingest.requests.length, 1, "it did try");
+  } finally {
+    await ingest.close();
+  }
+});
+
+test("two projects flaking on the same spec each get reported", { skip }, async () => {
+  const ingest = await startIngestStub();
+  const root = mkdtempSync(join(tmpdir(), "tq-pw-projects-"));
+  fixtureRoots.push(root);
+  mkdirSync(join(root, "specs"), { recursive: true });
+  mkdirSync(join(root, "node_modules", "@ledgerhq"), { recursive: true });
+  mkdirSync(join(root, "node_modules", "@playwright"), { recursive: true });
+  symlinkSync(packageRoot, join(root, "node_modules", "@ledgerhq", "test-quarantine"), "dir");
+  symlinkSync(
+    dirname(playwrightBin as string),
+    join(root, "node_modules", "@playwright", "test"),
+    "dir",
+  );
+  writeFileSync(
+    join(root, "package.json"),
+    JSON.stringify({ name: "pw-projects", version: "1.0.0", private: true }, null, 2),
+  );
+  writeFileSync(
+    join(root, "playwright.config.js"),
+    [
+      "module.exports = {",
+      "  retries: 1,",
+      "  projects: [",
+      '    { name: "alpha", testDir: "./specs" },',
+      '    { name: "beta", testDir: "./specs" },',
+      "  ],",
+      '  reporter: [["@ledgerhq/test-quarantine/playwright"]],',
+      "};",
+      "",
+    ].join("\n"),
+  );
+  // A counter per project, so both projects genuinely flake.
+  writeFileSync(
+    join(root, "specs", "a.spec.js"),
+    [
+      'const fs = require("node:fs");',
+      'const path = require("node:path");',
+      'const { test, expect } = require("@playwright/test");',
+      'test("settles eventually", ({}, testInfo) => {',
+      `  const file = path.join(${JSON.stringify(root)}, "c-" + testInfo.project.name + ".txt");`,
+      '  const n = fs.existsSync(file) ? Number(fs.readFileSync(file, "utf8")) : 0;',
+      "  fs.writeFileSync(file, String(n + 1));",
+      '  if (n === 0) throw new Error("first attempt fails in " + testInfo.project.name);',
+      "  expect(n).toBe(1);",
+      "});",
+      "",
+    ].join("\n"),
+  );
+
+  try {
+    const { code, output } = await runPlaywright(playwrightBin as string, root, {
+      CI: "true",
+      FLAKE_API_KEY: "test-key",
+      FLAKE_API_HOST: ingest.url,
+      QUARANTINE_REPO_ROOT: root,
+    });
+
+    assert.equal(code, 0, output);
+    const events = ingest.requests.flatMap(request => request.events);
+    assert.equal(events.length, 2, `expected one flake per project\n${output}`);
+    assert.deepEqual(
+      events.map(event => event.errorMessage.split("\n")[0]).sort(),
+      ["Error: first attempt fails in alpha", "Error: first attempt fails in beta"],
+      "each project reports its own failure",
+    );
+  } finally {
+    await ingest.close();
+  }
+});

--- a/tools/test-quarantine/test/playwright-reporter.test.ts
+++ b/tools/test-quarantine/test/playwright-reporter.test.ts
@@ -1,0 +1,224 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { Suite, TestCase, TestResult } from "@playwright/test/reporter";
+import { detectFlakes } from "../src/core/detect.ts";
+import PlaywrightFlakeReporter, {
+  fullTitle,
+  toOutcomes,
+} from "../src/playwright/flake-reporter.ts";
+
+/**
+ * Minimal stand-ins for Playwright's reporter objects. Only the fields the
+ * adapter reads are modelled; `test/playwright-integration.test.ts` runs the
+ * real thing and pins the shapes.
+ */
+function suite(type: Suite["type"], title: string, parent?: Suite): Suite {
+  // `project()` walks up to the project suite, as Playwright's own does.
+  const self = { type, title, parent } as Suite;
+  (self as { project: () => { name: string } | undefined }).project = () => {
+    for (let s: Suite | undefined = self; s; s = s.parent) {
+      if (s.type === "project") return { name: s.title };
+    }
+    return undefined;
+  };
+  return self;
+}
+
+function result(partial: Partial<TestResult> = {}): TestResult {
+  return { retry: 0, status: "passed", errors: [], ...partial } as TestResult;
+}
+
+function testCase(partial: Partial<TestCase> = {}): TestCase {
+  const file = suite("file", "a.spec.ts", suite("project", "mocked_tests", suite("root", "")));
+  return {
+    title: "does a thing",
+    parent: file,
+    expectedStatus: "passed",
+    location: { file: "/repo/apps/x/tests/specs/a.spec.ts", line: 1, column: 1 },
+    results: [result()],
+    ...partial,
+  } as TestCase;
+}
+
+test("the title is the describes plus the test title", () => {
+  const outer = suite("describe", "wallet", suite("file", "a.spec.ts"));
+  const inner = suite("describe", "balance", outer);
+  assert.equal(fullTitle(testCase({ parent: inner })), "wallet balance does a thing");
+});
+
+test("the project and file titles are left out of the title", () => {
+  // titlePath() would include both; the file is reported separately and the
+  // project name is not part of a test's identity.
+  assert.equal(fullTitle(testCase()), "does a thing");
+});
+
+test("attempts map straight from retry indices", () => {
+  const outcomes = toOutcomes(
+    testCase({
+      results: [
+        result({ retry: 0, status: "failed", errors: [{ message: "boom" }] }),
+        result({ retry: 1, status: "passed" }),
+      ],
+    }),
+    "/repo",
+  );
+
+  assert.deepEqual(
+    outcomes.map(outcome => [outcome.attempt, outcome.status]),
+    [
+      [0, "failed"],
+      [1, "passed"],
+    ],
+  );
+  assert.equal(outcomes[0].errorMessage, "boom");
+  assert.equal(outcomes[0].file, "apps/x/tests/specs/a.spec.ts");
+});
+
+test("a timeout counts as a failure", () => {
+  const [outcome] = toOutcomes(testCase({ results: [result({ status: "timedOut" })] }), "/repo");
+  assert.equal(outcome.status, "failed");
+});
+
+test("an interrupted attempt is not treated as a failure", () => {
+  // The run was cut short before this attempt finished; it says nothing about
+  // the test, so it must not pair with a later pass to look like a flake.
+  const [outcome] = toOutcomes(testCase({ results: [result({ status: "interrupted" })] }), "/repo");
+  assert.equal(outcome.status, "skipped");
+});
+
+test("a test expected to fail is ignored entirely", () => {
+  const outcomes = toOutcomes(
+    testCase({
+      expectedStatus: "failed",
+      results: [
+        result({ retry: 0, status: "failed", errors: [{ message: "as designed" }] }),
+        result({ retry: 1, status: "passed" }),
+      ],
+    }),
+    "/repo",
+  );
+  assert.deepEqual(outcomes, [], "test.fail() failures are the point, not a flake");
+});
+
+test("a fail-then-pass sequence is detected as one flake", () => {
+  const outcomes = toOutcomes(
+    testCase({
+      results: [
+        result({ retry: 0, status: "failed", errors: [{ message: "boom" }] }),
+        result({ retry: 1, status: "passed" }),
+      ],
+    }),
+    "/repo",
+  );
+
+  const flakes = detectFlakes(outcomes);
+  assert.equal(flakes.length, 1);
+  assert.equal(flakes[0].retryCount, 1);
+  assert.equal(flakes[0].title, "does a thing");
+});
+
+test("a test that fails every attempt is not a flake", () => {
+  const outcomes = toOutcomes(
+    testCase({
+      results: [
+        result({ retry: 0, status: "failed", errors: [{ message: "boom" }] }),
+        result({ retry: 1, status: "failed", errors: [{ message: "boom" }] }),
+      ],
+    }),
+    "/repo",
+  );
+  assert.deepEqual(detectFlakes(outcomes), []);
+});
+
+test("a test that passes first time is not a flake", () => {
+  assert.deepEqual(detectFlakes(toOutcomes(testCase(), "/repo")), []);
+});
+
+test("several error messages on one attempt are joined", () => {
+  const [outcome] = toOutcomes(
+    testCase({
+      results: [result({ status: "failed", errors: [{ message: "one" }, { message: "two" }] })],
+    }),
+    "/repo",
+  );
+  assert.equal(outcome.errorMessage, "one\ntwo");
+});
+
+test("a failure with no error message does not become an empty string", () => {
+  const [outcome] = toOutcomes(testCase({ results: [result({ status: "failed" })] }), "/repo");
+  assert.equal(outcome.errorMessage, undefined);
+});
+
+function inProject(name: string, results: TestResult[]): ReturnType<typeof toOutcomes> {
+  const project = suite("project", name, suite("root", ""));
+  return toOutcomes(testCase({ parent: suite("file", "a.spec.ts", project), results }), "/repo");
+}
+
+test("two projects flaking on the same spec are reported separately", () => {
+  // Playwright runs the spec once per project, so each can flake independently.
+  // Grouping on (file, title) alone merged them and reported only one.
+  const flakes = detectFlakes([
+    ...inProject("alpha", [
+      result({ retry: 0, status: "failed", errors: [{ message: "alpha failed" }] }),
+      result({ retry: 1, status: "passed" }),
+    ]),
+    ...inProject("beta", [
+      result({ retry: 0, status: "failed", errors: [{ message: "beta failed" }] }),
+      result({ retry: 1, status: "passed" }),
+    ]),
+  ]);
+
+  assert.equal(flakes.length, 2, "one flake per project");
+  assert.deepEqual(
+    flakes.map(flake => flake.errorMessage).sort(),
+    ["alpha failed", "beta failed"],
+    "each carries its own failure, not the other project's",
+  );
+});
+
+test("the project name is not part of the reported title", () => {
+  const [outcome] = inProject("alpha", [result()]);
+  assert.equal(outcome.title, "does a thing");
+  assert.equal(outcome.variant, "alpha", "it discriminates, it is not reported");
+});
+
+test("a failure in one project is not cured by another project passing", () => {
+  const flakes = detectFlakes([
+    ...inProject("alpha", [
+      result({ retry: 0, status: "failed", errors: [{ message: "alpha failed" }] }),
+    ]),
+    ...inProject("beta", [result({ retry: 0, status: "passed" })]),
+  ]);
+  assert.deepEqual(flakes, [], "a hard failure is not a flake");
+});
+
+const CI_ENV = { CI: "true", FLAKE_API_KEY: "key", FLAKE_API_HOST: "https://flake.example" };
+
+test("onEnd without onBegin does nothing rather than throwing", async () => {
+  // globalSetup throwing means Playwright never calls onBegin, so there is no
+  // suite to walk.
+  const reporter = new PlaywrightFlakeReporter({
+    env: CI_ENV,
+    fetchImpl: (() => assert.fail("must not post without a suite")) as unknown as typeof fetch,
+  });
+
+  await reporter.onEnd({ status: "failed" } as never);
+});
+
+test("an unexpected internal failure never propagates out of onEnd", async () => {
+  const reporter = new PlaywrightFlakeReporter({
+    env: CI_ENV,
+    // Not a Response; this throws past reportFlakes' own try/catch.
+    fetchImpl: (async () => null) as unknown as typeof fetch,
+  });
+
+  const flaky = testCase({
+    results: [
+      result({ retry: 0, status: "failed", errors: [{ message: "boom" }] }),
+      result({ retry: 1, status: "passed" }),
+    ],
+  });
+  reporter.onBegin({} as never, { allTests: () => [flaky] } as never);
+
+  await reporter.onEnd({ status: "passed" } as never);
+});


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Flakes in the desktop Playwright suite are currently invisible. With `retries: 0`, a test that would have passed on a second attempt is indistinguishable from one that is genuinely broken — both are just a red job — so there is no data on *which* specs are unreliable and no way to tell an infrastructure blip from a real regression.

This adds a Playwright adapter to `@ledgerhq/test-quarantine` (which already ships the jest one) and wires it into `ledger-live-desktop`. A test that fails an attempt and passes a later one in the same run is recorded and reported to the wallet-flake-reporting ingest API.


### Of note
pnpm lock oddities verified

`retries: 0 → 1` on CI supersedes the decision in #4918, which set retries to zero deliberately to stay strict about flakes. The retry is what makes a flake *observable at all* — without a second attempt there is nothing to compare. 

The trade-off:

- A test that fails then passes **no longer blocks the merge**; it is reported instead. `failOnFlakyTests: false` is what allows this. It is already Playwright's default, so the line is an explicit anchor rather than the operative change — set it to `true` to keep flakes failing the build.
- A test that fails **every** attempt still fails the build, unchanged.
- Local runs stay at zero retries, so a failure surfaces immediately.
- A genuinely failing spec now runs twice on CI, so a red job is slower than before.
### 🔗 Context

Test run: https://github.com/LedgerHQ/ledger-live/actions/runs/32256241806
Flake capture verified in remote
