### PR TITLE
feat(contacts): edit saved address value on mobile (LIVE-35960)

### DIFF
--- a/.changeset/contacts-mobile-edit-address-value.md
+++ b/.changeset/contacts-mobile-edit-address-value.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Enable editing a saved contact address value on mobile with validation and analytics.

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -954,6 +954,10 @@ describe("Contacts integration", () => {
     await waitFor(() => {
       expect(screen.queryByTestId("contacts-edit-signer-confirm")).toBeNull();
       expect(screen.getByTestId("contacts-rename-address-confirm")).toBeVisible();
+      expect(screen.getByTestId("contacts-edit-address-input")).toHaveProp(
+        "value",
+        "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+      );
     });
   });
 
@@ -979,6 +983,48 @@ describe("Contacts integration", () => {
       expect(screen.queryByTestId("contacts-rename-address-confirm")).toBeNull();
       expect(screen.queryByTestId("contacts-address-detail-dialog")).toBeNull();
       expect(screen.getByText("Exchange wallet")).toBeVisible();
+    });
+  });
+
+  it("should prefill the saved address and update the address value", async () => {
+    const newAddress = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd";
+    const { user } = render(<MyWalletNavigator />, {
+      overrideInitialState: withContactsPageReadyState(
+        { lwmContacts: { enabled: true, params: { newBadge: false } } },
+        state => ({ ...state, contacts: { contacts: mockPopulatedContacts() } }),
+      ),
+    });
+
+    await user.press(screen.getByTestId("my-wallet-contacts-button"));
+    await user.press(await screen.findByTestId("contacts-saved-contact-contact-ben"));
+    await user.press(await screen.findByTestId("contacts-detail-address-row-address-ethereum"));
+    await user.press(await screen.findByText("Edit"));
+    await user.press(await screen.findByTestId("contacts-edit-signer-confirm"));
+
+    const addressInput = await screen.findByTestId("contacts-edit-address-input");
+    expect(addressInput).toHaveProp("value", "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034");
+
+    await user.clear(addressInput);
+    await user.type(addressInput, newAddress);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts-rename-address-confirm")).toBeEnabled();
+    });
+
+    await user.press(screen.getByTestId("contacts-rename-address-confirm"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("contacts-rename-address-confirm")).toBeNull();
+      expect(screen.queryByTestId("contacts-address-detail-dialog")).toBeNull();
+    });
+
+    await user.press(await screen.findByTestId("contacts-detail-address-row-address-ethereum"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts-address-detail-dialog")).toBeVisible();
+      expect(screen.getByTestId("contacts-address-detail-full-address")).toHaveTextContent(
+        newAddress,
+      );
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.test.tsx
@@ -1,22 +1,49 @@
 import React, { type ReactNode } from "react";
 import { configureStore } from "@reduxjs/toolkit";
-import { act, renderHook } from "@testing-library/react-native";
+import { act, renderHook, waitFor } from "@testing-library/react-native";
 import { Provider } from "react-redux";
 import { contactsSlice } from "@domain/entity-contact";
 import { mockContactWithAddress, mockMeContact } from "@domain/entity-contact/schema.mock";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
-import { useContactAddressDetailDialog, usePopulatedContactDetail } from "@features/flow-contacts";
+import {
+  CONTACTS_EVENT_SOURCE,
+  CONTACTS_FLOW,
+  CONTACTS_PAGE_EVENTS,
+  CONTACTS_PAGE_PROPERTY,
+  CONTACTS_TRACK_EVENTS,
+  CONTACTS_TRACKING_BUTTON,
+  useContactAddressDetailDialog,
+  usePopulatedContactDetail,
+} from "@features/flow-contacts";
 import { useContactAddressDetailActionsAdapter } from "./useContactAddressDetailActionsAdapter";
+
+const trackEvent = jest.fn();
+const trackPage = jest.fn();
 
 jest.mock("LLM/features/Send/hooks/useOpenSendFlow", () => ({
   useOpenSendFlow: () => ({ handleOpenSendFlow: jest.fn() }),
 }));
 
-jest.mock("../analytics/useContactsAnalytics", () => ({
+jest.mock("../analytics", () => ({
+  contactsCurrencyAnalyticsDependencies: {},
+  resolveContactsCurrencyAnalytics: jest.fn().mockResolvedValue({
+    network: "Ethereum",
+    asset: "ETH",
+  }),
   useContactsAnalytics: () => ({
-    trackEvent: jest.fn(),
-    trackPage: jest.fn(),
+    trackEvent,
+    trackPage,
     getGlobalProperties: jest.fn(),
+  }),
+}));
+
+jest.mock("./useContactsAddressValidationAdapter", () => ({
+  useContactsAddressValidationAdapter: () => ({
+    validateAddress: async ({ address }: { address: string }) => ({
+      status: "valid",
+      resolvedAddress: address,
+      isDomain: false,
+    }),
   }),
 }));
 
@@ -32,6 +59,11 @@ function makeWrapper(contacts: ReturnType<typeof contactsSlice.getInitialState>[
 }
 
 describe("useContactAddressDetailActionsAdapter", () => {
+  beforeEach(() => {
+    trackEvent.mockClear();
+    trackPage.mockClear();
+  });
+
   it("should return inactive actions when no address is selected", () => {
     const Wrapper = makeWrapper([mockMeContact()]);
     const { result } = renderHook(
@@ -90,5 +122,74 @@ describe("useContactAddressDetailActionsAdapter", () => {
     });
 
     expect(result.current.addressDetail.isOpen).toBe(true);
+  });
+
+  it("should track edit-address page and apply-changes analytics", async () => {
+    const contact = mockContactWithAddress();
+    const address = contact.addresses[0]!;
+    const Wrapper = makeWrapper([mockMeContact(), contact]);
+    const { result } = renderHook(
+      () => {
+        const populatedContactDetail = usePopulatedContactDetail(contact.id, {
+          resolveNetworkId: () => getCryptoCurrencyById("ethereum").id,
+        });
+        const addressDetail = useContactAddressDetailDialog(populatedContactDetail);
+        const actions = useContactAddressDetailActionsAdapter(
+          contact.id,
+          addressDetail.selection?.row.addressId,
+          addressDetail.onClose,
+          "ETH",
+          "Ethereum",
+        );
+
+        return { addressDetail, actions };
+      },
+      { wrapper: Wrapper },
+    );
+
+    act(() => {
+      result.current.addressDetail.onAddressRowPress({
+        type: "open-address-detail",
+        contactId: contact.id,
+        addressId: address.id,
+      });
+    });
+
+    act(() => {
+      result.current.actions.addressDetailDialog.onEdit?.();
+    });
+
+    expect(result.current.actions.signerSheet.isOpen).toBe(true);
+
+    await act(async () => {
+      await result.current.actions.signerSheet.onConfirm();
+    });
+
+    await waitFor(() => {
+      expect(result.current.actions.renameSheet.isOpen).toBe(true);
+    });
+
+    expect(trackPage).toHaveBeenCalledWith(CONTACTS_PAGE_EVENTS.EDIT_ADDRESS, {
+      source: CONTACTS_EVENT_SOURCE.EDIT_ADDRESS,
+      network: "Ethereum",
+      asset: "ETH",
+    });
+
+    act(() => {
+      result.current.actions.renameSheet.onDraftLabelChange("Main ETH");
+    });
+
+    await act(async () => {
+      await result.current.actions.renameSheet.onConfirm();
+    });
+
+    expect(trackEvent).toHaveBeenCalledWith(CONTACTS_TRACK_EVENTS.BUTTON_CLICKED, {
+      source: CONTACTS_EVENT_SOURCE.EDIT_ADDRESS,
+      button: CONTACTS_TRACKING_BUTTON.applyChanges,
+      page: CONTACTS_PAGE_PROPERTY.EDIT_ADDRESS,
+      asset: "ETH",
+      network: "Ethereum",
+      flow: CONTACTS_FLOW.CONTACTS,
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.ts
@@ -6,19 +6,29 @@ import {
   type ContactsEditSignerMismatchDrawerProps,
   type ContactsRenameAddressDrawerProps,
   type ContactAddressDetailDialogNativeProps,
+  type ContactAddressEditSavePayload,
+  CONTACTS_EVENT_SOURCE,
+  CONTACTS_FLOW,
+  CONTACTS_PAGE_EVENTS,
+  CONTACTS_PAGE_PROPERTY,
+  CONTACTS_TRACK_EVENTS,
+  CONTACTS_TRACKING_BUTTON,
   createActiveContactAddressDetailActionsUiState,
   createInactiveContactAddressDetailActionsUiState,
   resolveContactAddressDetailActionsLabels,
   useContactAddressDetailActionsFlowBindings,
   useContactsAddressDetailActionsPorts,
-  CONTACTS_TRACKING_BUTTON,
   trackContactAddressDetailQuickAction,
 } from "@features/flow-contacts";
 import { useOpenSendFlow } from "LLM/features/Send/hooks/useOpenSendFlow";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { ScreenName } from "~/const";
 import { useTranslation } from "~/context/Locale";
-import { useContactsAnalytics } from "../analytics/useContactsAnalytics";
+import {
+  contactsCurrencyAnalyticsDependencies,
+  resolveContactsCurrencyAnalytics,
+  useContactsAnalytics,
+} from "../analytics";
 import { useContactsAddressValidationAdapter } from "./useContactsAddressValidationAdapter";
 
 const MANUAL_ADDRESS_VALIDATION_DEBOUNCE_MS = 200;
@@ -51,11 +61,14 @@ export function useContactAddressDetailActionsAdapter(
   addressId: ContactAddressId | undefined,
   onCloseAddressDetail: () => void,
   asset?: string,
+  network?: string,
 ): ContactAddressDetailActionsFlowProps {
   const { t } = useTranslation();
   const analytics = useContactsAnalytics();
   const ports = useContactsAddressDetailActionsPorts();
   const addressValidation = useContactsAddressValidationAdapter();
+  const hasTrackedEditAddressPage = useRef(false);
+  const hasTrackedSignerMismatch = useRef(false);
   const { handleOpenSendFlow } = useOpenSendFlow({
     sourceScreenName: ScreenName.MyWalletContactDetail,
   });
@@ -75,9 +88,37 @@ export function useContactAddressDetailActionsAdapter(
         | typeof CONTACTS_TRACKING_BUTTON.edit
         | typeof CONTACTS_TRACKING_BUTTON.delete,
     ) => {
-      trackContactAddressDetailQuickAction(analytics, button, asset);
+      trackContactAddressDetailQuickAction(analytics, button, asset, network);
     },
-    [analytics, asset],
+    [analytics, asset, network],
+  );
+  const onEditAddressSaved = useCallback(
+    async (payload: ContactAddressEditSavePayload) => {
+      if (payload.currencyId === undefined) {
+        return;
+      }
+
+      try {
+        const { network: resolvedNetwork, asset: resolvedAsset } =
+          await resolveContactsCurrencyAnalytics(
+            payload.currencyId,
+            contactsCurrencyAnalyticsDependencies,
+          );
+        const inputMethod = payload.inputMethod ?? "manual";
+
+        analytics.trackEvent(CONTACTS_TRACK_EVENTS.ADDRESS_EDITED, {
+          source: CONTACTS_EVENT_SOURCE.EDIT_ADDRESS,
+          network: network ?? resolvedNetwork,
+          asset: asset ?? resolvedAsset,
+          inputMethod,
+          isEns: inputMethod === "ens",
+          flow: CONTACTS_FLOW.CONTACTS,
+        });
+      } catch {
+        // Analytics enrichment is best-effort and must not affect the user flow.
+      }
+    },
+    [analytics, asset, network],
   );
   const onSend = useCallback(
     (intent: ContactAddressDetailSendIntent) => {
@@ -98,6 +139,7 @@ export function useContactAddressDetailActionsAdapter(
     manualValidationDebounceMs: MANUAL_ADDRESS_VALIDATION_DEBOUNCE_MS,
     onSend,
     onCloseAddressDetail,
+    onEditAddressSaved,
   });
   const { onClose: closeRenameViewModel } = renameViewModel;
   const onCloseRename = useCallback(() => {
@@ -112,6 +154,51 @@ export function useContactAddressDetailActionsAdapter(
     trackQuickAction(CONTACTS_TRACKING_BUTTON.delete);
     flow.onDeletePress();
   }, [flow, trackQuickAction]);
+  const onConfirmEditAddress = useCallback(async () => {
+    analytics.trackEvent(CONTACTS_TRACK_EVENTS.BUTTON_CLICKED, {
+      source: CONTACTS_EVENT_SOURCE.EDIT_ADDRESS,
+      button: CONTACTS_TRACKING_BUTTON.applyChanges,
+      page: CONTACTS_PAGE_PROPERTY.EDIT_ADDRESS,
+      ...(asset ? { asset } : {}),
+      ...(network ? { network } : {}),
+      flow: CONTACTS_FLOW.CONTACTS,
+    });
+    await renameViewModel.onConfirm();
+  }, [analytics, asset, network, renameViewModel]);
+
+  useEffect(() => {
+    if (!renameViewModel.isOpen) {
+      hasTrackedEditAddressPage.current = false;
+      return;
+    }
+
+    if (hasTrackedEditAddressPage.current || asset === undefined || network === undefined) {
+      return;
+    }
+
+    hasTrackedEditAddressPage.current = true;
+    analytics.trackPage(CONTACTS_PAGE_EVENTS.EDIT_ADDRESS, {
+      source: CONTACTS_EVENT_SOURCE.EDIT_ADDRESS,
+      network,
+      asset,
+    });
+  }, [analytics, asset, network, renameViewModel.isOpen]);
+
+  useEffect(() => {
+    if (flow.editUiState === "signer-mismatch" && !hasTrackedSignerMismatch.current) {
+      hasTrackedSignerMismatch.current = true;
+      analytics.trackEvent(CONTACTS_TRACK_EVENTS.ERROR_DISPLAYED, {
+        source: CONTACTS_EVENT_SOURCE.EDIT_ADDRESS,
+        page: CONTACTS_PAGE_PROPERTY.EDIT_ADDRESS,
+        errorType: "signer_mismatch",
+      });
+      return;
+    }
+
+    if (flow.editUiState !== "signer-mismatch") {
+      hasTrackedSignerMismatch.current = false;
+    }
+  }, [analytics, flow.editUiState]);
 
   if (!isSelectionActive) {
     return mapUiStateToFlowProps(createInactiveContactAddressDetailActionsUiState(labels));
@@ -131,6 +218,7 @@ export function useContactAddressDetailActionsAdapter(
     renameSheet: {
       ...uiState.renameSheet,
       onClose: onCloseRename,
+      onConfirm: onConfirmEditAddress,
     },
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
@@ -282,13 +282,15 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
   const onDeleteSuccess = useCallback(() => {
     navigation.navigate(ScreenName.MyWalletContacts);
   }, [navigation]);
-  const addressDetailAsset = selection?.network.networkTicker;
+  const addressDetailAsset = selection?.network?.networkTicker;
+  const addressDetailNetwork = selection?.network?.networkName;
   const editDeleteFlow = useContactDetailEditDeleteAdapter(route.params.contactId, onDeleteSuccess);
   const addressDetailActions = useContactAddressDetailActionsAdapter(
     route.params.contactId,
     selection?.row?.addressId,
     onCloseAddressDetail,
     addressDetailAsset,
+    addressDetailNetwork,
   );
   const onCloseAddressDetailSheet = useCallback(() => {
     if (


### PR DESCRIPTION
## Summary
- Complete the mobile Edit Address flow so users can update a saved wallet address (not only the label), with the same validation rules as Add Address.
- Wire edit-address analytics (page view, apply changes, `address_edited`, signer mismatch) and pass `network` into the detail actions adapter.
- Add mobile integration coverage for prefilled address input and persisting an updated address value.

## Acceptance criteria
- [x] Edit Address shows an editable address input
- [x] Existing address is pre-filled
- [x] Users can update label and/or address value
- [x] Address is validated with Add Address rules (shared validation port + debounce)
- [x] Invalid addresses cannot be saved (`isConfirmEnabled` gated on valid entry)
- [x] Saving persists updated address and label

## Test plan
- [x] Integration: open edit after signer → address input prefilled
- [x] Integration: update address value → persisted on address detail
- [x] Manual: edit address on device, invalid input blocks save, valid save updates contact


https://github.com/user-attachments/assets/096accf3-9046-4e18-8ab9-0696be288efa


