### PR TITLE
[LWM] feat(upsell): add Profile banner for Nano S SP X (LIVE-35483)

### DIFF
--- a/.changeset/quiet-profile-banners.md
+++ b/.changeset/quiet-profile-banners.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add a Profile upsell banner on My Wallet for Nano S, SP and X

--- a/apps/ledger-live-mobile/src/mvvm/features/LNUpsell/components/LNUpsellBanner/LNUpsellBanner.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LNUpsell/components/LNUpsellBanner/LNUpsellBanner.test.tsx
@@ -5,7 +5,9 @@ import { Linking } from "react-native";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { render, screen, fireEvent, renderHook } from "@tests/test-renderer";
 import { FEATURE_FLAGS_DEFAULTS } from "@shared/feature-flags";
-import { track } from "~/analytics";
+import { LARGE_SCREEN_UPSELL_UTM } from "@features/flow-large-screen-upsell/utils/upsellCta";
+import { screen as analyticsScreen, track } from "~/analytics";
+import type { LNBannerLocation } from "../../types";
 import { LNUpsellBanner } from ".";
 
 describe("LNUpsellBanner", () => {
@@ -32,6 +34,9 @@ describe("LNUpsellBanner", () => {
       page: "NotificationPanel",
     },
   ] as const)("on the $page page", ({ location, placement, page }) => {
+    const renderBanner = (options: RenderBannerOptions = {}) =>
+      renderLNUpsellBanner({ location, placement, now, ...options });
+
     it("should not render if the feature flag is disabled", () => {
       renderBanner({ largeScreenUpsellEnabled: false });
       expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
@@ -182,98 +187,283 @@ describe("LNUpsellBanner", () => {
         page,
       });
     });
+  });
 
-    function renderBanner({
-      largeScreenUpsellEnabled = true,
-      isOptIn = true,
-      devicesModelList = [DeviceModelId.nanoS],
-      onboardingDate = now.toISOString(),
-      audienceModels = {},
-      targetedByHighTierUpsell = false,
-      brazePlacement = false,
-      largeScreenPlacementEnabled = true,
-      hasLargeScreenBannersParam = true,
-      hasTrackingParams = true,
-      ctaLink = undefined as string | undefined,
-    }) {
-      const largeScreenUpsellParams = FEATURE_FLAGS_DEFAULTS.largeScreenUpsell.params;
+  describe("on the Profile page", () => {
+    const location = "profile" as const;
+    const placement = "profile";
+    const renderBanner = (options: RenderBannerOptions = {}) =>
+      renderLNUpsellBanner({ location, placement, now, ...options });
 
-      if (!largeScreenUpsellParams) {
-        throw new Error("Expected large-screen upsell default params");
-      }
+    const optedInAnalyticsProps = {
+      deviceModel: "lns",
+      personalRecoOptIn: true,
+      offerType: "discount",
+      platform: "lwm",
+    } as const;
 
-      const resolvedCtaLink =
-        ctaLink ?? (isOptIn ? "https://example.com/optInCta" : "https://example.com/optOutCta");
-      const configuredParams = {
-        ...largeScreenUpsellParams,
-        audience: {
-          models: {
-            ...largeScreenUpsellParams.audience.models,
-            ...audienceModels,
-          },
-        },
-        banners: {
-          ...largeScreenUpsellParams.banners,
-          [placement]: largeScreenPlacementEnabled,
-        },
-        opted_in: {
-          ...largeScreenUpsellParams.opted_in,
-          enabled: true,
-          link: isOptIn ? resolvedCtaLink : "https://example.com/optInCta",
-        },
-        opted_out: {
-          ...largeScreenUpsellParams.opted_out,
-          enabled: true,
-          link: isOptIn ? "https://example.com/optOutCta" : resolvedCtaLink,
-        },
-      };
-      const { banners: _banners, ...legacyLargeScreenUpsellParams } = configuredParams;
-      const tracking = isOptIn ? "opted_in" : "opted_out";
-      const paramsWithTracking = hasTrackingParams
-        ? configuredParams
-        : { ...configuredParams, [tracking]: null };
-      const largeScreenUpsell = {
-        ...FEATURE_FLAGS_DEFAULTS.largeScreenUpsell,
-        enabled: largeScreenUpsellEnabled,
-        params: hasLargeScreenBannersParam ? paramsWithTracking : legacyLargeScreenUpsellParams,
-      };
+    it("should not render if the feature flag is disabled", () => {
+      renderBanner({ largeScreenUpsellEnabled: false });
+      expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
+    });
 
-      render(<LNUpsellBanner location={location} />, {
-        overrideInitialState: state =>
-          merge({}, state, {
-            settings: {
-              shareAnalytics: true,
-              personalizedRecommendationsEnabled: isOptIn,
-              knownDeviceModelIds: Object.fromEntries(devicesModelList.map(model => [model, true])),
-              anonymousUserNotifications: {},
-            },
-            featureFlags: {
-              overrides: {
-                largeScreenUpsell,
-                ...(brazePlacement
-                  ? {
-                      lwmWallet40: {
-                        enabled: true,
-                        params: { brazePlacement: true },
-                      },
-                    }
-                  : {}),
-              },
-            },
-            dynamicContent: {
-              mobileCards: [
-                {
-                  extras: {
-                    campaign: targetedByHighTierUpsell && "LNS_UPSELL_HIGH_TIER",
-                  },
-                },
-              ],
-            },
-            postOnboarding: {
-              onboardingDate,
-            },
-          }),
+    it("should not render if its large-screen upsell placement is disabled", () => {
+      renderBanner({ largeScreenPlacementEnabled: false });
+      expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
+    });
+
+    it("should render with legacy large-screen upsell params missing banners", () => {
+      renderBanner({ hasLargeScreenBannersParam: false });
+      expect(screen.getByText(t(`lnsUpsell.opted_in.cta`))).toBeVisible();
+    });
+
+    it.each([DeviceModelId.nanoSP, DeviceModelId.nanoX])(
+      "should respect the cooldown for %s",
+      deviceModelId => {
+        renderBanner({
+          devicesModelList: [deviceModelId],
+          onboardingDate: "2026-06-07T12:00:00.000Z",
+        });
+        expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
+      },
+    );
+
+    it("should not render if the user also owns a large-screen device", () => {
+      renderBanner({
+        devicesModelList: [DeviceModelId.nanoS, DeviceModelId.stax],
       });
-    }
+      expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
+    });
+
+    it("should not render if the user has no devices", () => {
+      renderBanner({ devicesModelList: [] });
+      expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
+      expectNoProfilePageEvent();
+    });
+
+    it("should fire a Profile page event when the banner is shown", () => {
+      renderBanner({});
+
+      expect(jest.mocked(analyticsScreen)).toHaveBeenCalledWith(
+        "Profile",
+        undefined,
+        {
+          name: "Profile",
+          ...optedInAnalyticsProps,
+        },
+        false,
+      );
+    });
+
+    it("should not fire a Profile page event during cooldown", () => {
+      renderBanner({
+        devicesModelList: [DeviceModelId.nanoSP],
+        onboardingDate: "2026-06-07T12:00:00.000Z",
+      });
+
+      expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
+      expectNoProfilePageEvent();
+    });
+
+    it("should not fire a Profile page event when the placement is disabled", () => {
+      renderBanner({ largeScreenPlacementEnabled: false });
+      expectNoProfilePageEvent();
+    });
+
+    it("should not fire a Profile page event when the tracking params are missing", () => {
+      renderBanner({ hasTrackingParams: false });
+      expectNoProfilePageEvent();
+    });
+
+    it("should not fire a Profile page event when a higher tier upsell is targeting the user", () => {
+      renderBanner({ targetedByHighTierUpsell: true });
+      expectNoProfilePageEvent();
+    });
+
+    it("should open the upsell LP with profile UTM and fire upgrade analytics", () => {
+      renderBanner({});
+      fireEvent.press(screen.getByText(t(`lnsUpsell.opted_in.cta`)));
+
+      expect(Linking.openURL).toHaveBeenCalledTimes(1);
+      const openedUrl = new URL(String(jest.mocked(Linking.openURL).mock.calls[0][0]));
+      expect(openedUrl.origin + openedUrl.pathname).toBe("https://example.com/optInCta");
+      expect(openedUrl.searchParams.get("utm_source")).toBe(
+        LARGE_SCREEN_UPSELL_UTM.sourceByPlatform.mobile,
+      );
+      expect(openedUrl.searchParams.get("utm_medium")).toBe(LARGE_SCREEN_UPSELL_UTM.medium);
+      expect(openedUrl.searchParams.get("utm_campaign")).toBe(LARGE_SCREEN_UPSELL_UTM.campaign);
+      expect(openedUrl.searchParams.get("utm_content")).toBe(
+        LARGE_SCREEN_UPSELL_UTM.content.profile_cta,
+      );
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "upgrade",
+        page: "Profile",
+        ...optedInAnalyticsProps,
+      });
+      expect(track).toHaveBeenCalledWith("deeplink_clicked", {
+        page: "Profile",
+        deeplinkSource: LARGE_SCREEN_UPSELL_UTM.sourceByPlatform.mobile,
+        deeplinkMedium: LARGE_SCREEN_UPSELL_UTM.medium,
+        deeplinkCampaign: LARGE_SCREEN_UPSELL_UTM.campaign,
+        ...optedInAnalyticsProps,
+      });
+    });
+
+    it("should render Lumen MediaBanner and fire profile analytics when lwmWallet40 brazePlacement is on", () => {
+      renderBanner({ brazePlacement: true });
+      fireEvent.press(screen.getByTestId("lns-upsell-media-banner"));
+
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "upgrade",
+        page: "Profile",
+        ...optedInAnalyticsProps,
+      });
+      expect(track).toHaveBeenCalledWith(
+        "deeplink_clicked",
+        expect.objectContaining({ page: "Profile" }),
+      );
+    });
+
+    it("should render the banner for opted out users with none offerType", () => {
+      renderBanner({ isOptIn: false });
+      fireEvent.press(screen.getByText(t(`lnsUpsell.opted_out.cta`)));
+
+      expect(Linking.openURL).toHaveBeenCalledTimes(1);
+      const openedUrl = new URL(String(jest.mocked(Linking.openURL).mock.calls[0][0]));
+      expect(openedUrl.searchParams.get("utm_content")).toBe(
+        LARGE_SCREEN_UPSELL_UTM.content.profile_cta,
+      );
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "upgrade",
+        page: "Profile",
+        deviceModel: "lns",
+        personalRecoOptIn: false,
+        offerType: "none",
+        platform: "lwm",
+      });
+    });
   });
 });
+
+function expectNoProfilePageEvent() {
+  expect(jest.mocked(analyticsScreen)).not.toHaveBeenCalledWith(
+    "Profile",
+    undefined,
+    expect.objectContaining({ name: "Profile" }),
+    false,
+  );
+}
+
+type RenderBannerOptions = {
+  largeScreenUpsellEnabled?: boolean;
+  isOptIn?: boolean;
+  devicesModelList?: DeviceModelId[];
+  onboardingDate?: string;
+  audienceModels?: Partial<Record<DeviceModelId, boolean>>;
+  targetedByHighTierUpsell?: boolean;
+  brazePlacement?: boolean;
+  largeScreenPlacementEnabled?: boolean;
+  hasLargeScreenBannersParam?: boolean;
+  hasTrackingParams?: boolean;
+  ctaLink?: string;
+};
+
+function renderLNUpsellBanner({
+  location,
+  placement,
+  now,
+  largeScreenUpsellEnabled = true,
+  isOptIn = true,
+  devicesModelList = [DeviceModelId.nanoS],
+  onboardingDate = now.toISOString(),
+  audienceModels = {},
+  targetedByHighTierUpsell = false,
+  brazePlacement = false,
+  largeScreenPlacementEnabled = true,
+  hasLargeScreenBannersParam = true,
+  hasTrackingParams = true,
+  ctaLink = undefined as string | undefined,
+}: RenderBannerOptions & {
+  location: LNBannerLocation;
+  placement: string;
+  now: Date;
+}) {
+  const largeScreenUpsellParams = FEATURE_FLAGS_DEFAULTS.largeScreenUpsell.params;
+
+  if (!largeScreenUpsellParams) {
+    throw new Error("Expected large-screen upsell default params");
+  }
+
+  const resolvedCtaLink =
+    ctaLink ?? (isOptIn ? "https://example.com/optInCta" : "https://example.com/optOutCta");
+  const configuredParams = {
+    ...largeScreenUpsellParams,
+    audience: {
+      models: {
+        ...largeScreenUpsellParams.audience.models,
+        ...audienceModels,
+      },
+    },
+    banners: {
+      ...largeScreenUpsellParams.banners,
+      [placement]: largeScreenPlacementEnabled,
+    },
+    opted_in: {
+      ...largeScreenUpsellParams.opted_in,
+      enabled: true,
+      link: isOptIn ? resolvedCtaLink : "https://example.com/optInCta",
+    },
+    opted_out: {
+      ...largeScreenUpsellParams.opted_out,
+      enabled: true,
+      link: isOptIn ? "https://example.com/optOutCta" : resolvedCtaLink,
+    },
+  };
+  const { banners: _banners, ...legacyLargeScreenUpsellParams } = configuredParams;
+  const tracking = isOptIn ? "opted_in" : "opted_out";
+  const paramsWithTracking = hasTrackingParams
+    ? configuredParams
+    : { ...configuredParams, [tracking]: null };
+  const largeScreenUpsell = {
+    ...FEATURE_FLAGS_DEFAULTS.largeScreenUpsell,
+    enabled: largeScreenUpsellEnabled,
+    params: hasLargeScreenBannersParam ? paramsWithTracking : legacyLargeScreenUpsellParams,
+  };
+
+  render(<LNUpsellBanner location={location} />, {
+    overrideInitialState: state =>
+      merge({}, state, {
+        settings: {
+          shareAnalytics: true,
+          personalizedRecommendationsEnabled: isOptIn,
+          knownDeviceModelIds: Object.fromEntries(devicesModelList.map(model => [model, true])),
+          anonymousUserNotifications: {},
+        },
+        featureFlags: {
+          overrides: {
+            largeScreenUpsell,
+            ...(brazePlacement
+              ? {
+                  lwmWallet40: {
+                    enabled: true,
+                    params: { brazePlacement: true },
+                  },
+                }
+              : {}),
+          },
+        },
+        dynamicContent: {
+          mobileCards: [
+            {
+              extras: {
+                campaign: targetedByHighTierUpsell && "LNS_UPSELL_HIGH_TIER",
+              },
+            },
+          ],
+        },
+        postOnboarding: {
+          onboardingDate,
+        },
+      }),
+  });
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/LNUpsell/components/LNUpsellBanner/useLNUpsellBannerModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LNUpsell/components/LNUpsellBanner/useLNUpsellBannerModel.ts
@@ -1,11 +1,19 @@
+import { useCallback, useEffect, useMemo } from "react";
 import { Image, Linking } from "react-native";
-import { toLargeScreenUpsellDeviceModelAnalyticsValue } from "LLM/features/LargeScreenUpsell";
-import { track } from "~/analytics";
+import {
+  LARGE_SCREEN_UPSELL_UTM,
+  buildLargeScreenUpsellCtaLink,
+} from "@features/flow-large-screen-upsell/utils/upsellCta";
+import {
+  toLargeScreenUpsellDeviceModelAnalyticsValue,
+  type LargeScreenUpsellDeviceModelAnalyticsValue,
+} from "LLM/features/LargeScreenUpsell/analytics";
+import { screen, track } from "~/analytics";
 import type { LNBannerLocation, LNBannerModel } from "../../types";
 import { useLNUpsellBannerState } from "../../hooks/useLNUpsellBannerState";
 
 /* eslint-disable @typescript-eslint/no-require-imports */
-// Accounts reuses the Notification Center illustration (same audience, no dedicated asset).
+// Accounts and Profile reuse the Notification Center illustration (same audience, no dedicated asset).
 const lnsUpsellNotificationCenterImageUri = Image.resolveAssetSource(
   require("~/images/lns-upsell-banner-notification-center.webp"),
 ).uri;
@@ -15,8 +23,19 @@ const lnUpsellImageByLocation: Record<LNBannerLocation, string> = {
   manager: Image.resolveAssetSource(require("~/images/lns-upsell-banner-manager.webp")).uri,
   notification_center: lnsUpsellNotificationCenterImageUri,
   accounts: lnsUpsellNotificationCenterImageUri,
+  profile: lnsUpsellNotificationCenterImageUri,
 };
 /* eslint-enable @typescript-eslint/no-require-imports */
+
+const PROFILE_PAGE = "Profile";
+const PROFILE_UPGRADE_BUTTON = "upgrade";
+
+type ProfileSharedAnalyticsProps = Readonly<{
+  deviceModel: LargeScreenUpsellDeviceModelAnalyticsValue;
+  personalRecoOptIn: boolean;
+  offerType: "discount" | "none";
+  platform: "lwm";
+}>;
 
 export function useLNUpsellBannerModel(location: LNBannerLocation): LNBannerModel {
   const { isShown, ctaLink, discount, deviceModelId, tracking } = useLNUpsellBannerState(location);
@@ -24,9 +43,33 @@ export function useLNUpsellBannerModel(location: LNBannerLocation): LNBannerMode
   const deviceModel = deviceModelId
     ? toLargeScreenUpsellDeviceModelAnalyticsValue(deviceModelId)
     : undefined;
+  const personalRecoOptIn = tracking === "opted_in";
+  const profileAnalyticsProps = useMemo(
+    () =>
+      deviceModel
+        ? {
+            deviceModel,
+            personalRecoOptIn,
+            offerType: personalRecoOptIn ? ("discount" as const) : ("none" as const),
+            platform: "lwm" as const,
+          }
+        : undefined,
+    [deviceModel, personalRecoOptIn],
+  );
 
-  const handleCTAPress = () => {
+  useEffect(() => {
+    if (location !== "profile" || !isShown || !profileAnalyticsProps) return;
+    trackProfilePageViewed(profileAnalyticsProps);
+  }, [isShown, location, profileAnalyticsProps]);
+
+  const handleCTAPress = useCallback(() => {
     if (!ctaLink) return;
+
+    if (location === "profile") {
+      if (!profileAnalyticsProps) return;
+      openProfileUpsell(ctaLink, profileAnalyticsProps);
+      return;
+    }
 
     track("button_clicked", {
       button: "Level up wallet",
@@ -35,7 +78,7 @@ export function useLNUpsellBannerModel(location: LNBannerLocation): LNBannerMode
       page: analyticsPage,
     });
     Linking.openURL(ctaLink);
-  };
+  }, [analyticsPage, ctaLink, deviceModel, location, profileAnalyticsProps]);
 
   return {
     location,
@@ -47,9 +90,37 @@ export function useLNUpsellBannerModel(location: LNBannerLocation): LNBannerMode
   };
 }
 
+function trackProfilePageViewed(sharedProps: ProfileSharedAnalyticsProps) {
+  screen(PROFILE_PAGE, undefined, { name: PROFILE_PAGE, ...sharedProps }, false);
+}
+
+function openProfileUpsell(ctaLink: string, sharedProps: ProfileSharedAnalyticsProps) {
+  const upsellLink = buildLargeScreenUpsellCtaLink(
+    ctaLink,
+    "mobile",
+    LARGE_SCREEN_UPSELL_UTM.content.profile_cta,
+  );
+
+  track("button_clicked", {
+    button: PROFILE_UPGRADE_BUTTON,
+    page: PROFILE_PAGE,
+    ...sharedProps,
+  });
+  track("deeplink_clicked", {
+    page: PROFILE_PAGE,
+    deeplinkSource: LARGE_SCREEN_UPSELL_UTM.sourceByPlatform.mobile,
+    deeplinkMedium: LARGE_SCREEN_UPSELL_UTM.medium,
+    deeplinkCampaign: LARGE_SCREEN_UPSELL_UTM.campaign,
+    ...sharedProps,
+  });
+
+  Linking.openURL(upsellLink);
+}
+
 const AnalyticsPageMap = {
   manager: "Manager",
   accounts: "Accounts",
   notification_center: "NotificationPanel",
   wallet: "Wallet",
+  profile: PROFILE_PAGE,
 } as const satisfies Record<LNBannerLocation, unknown>;

--- a/apps/ledger-live-mobile/src/mvvm/features/LNUpsell/hooks/useLNUpsellBannerState.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LNUpsell/hooks/useLNUpsellBannerState.ts
@@ -25,6 +25,7 @@ const LARGE_SCREEN_UPSELL_BANNER_PLACEMENT_BY_LOCATION = {
   accounts: "accounts",
   notification_center: "notification-center",
   wallet: "homepage",
+  profile: "profile",
 } as const satisfies Record<LNBannerLocation, LargeScreenUpsellBannerPlacement>;
 
 const LNS_UPSELL_HIGH_TIER = "LNS_UPSELL_HIGH_TIER";

--- a/apps/ledger-live-mobile/src/mvvm/features/LNUpsell/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LNUpsell/types.ts
@@ -1,4 +1,9 @@
-export type LNBannerLocation = "manager" | "accounts" | "notification_center" | "wallet";
+export type LNBannerLocation =
+  | "manager"
+  | "accounts"
+  | "notification_center"
+  | "wallet"
+  | "profile";
 
 export type LNBannerModel = {
   location: LNBannerLocation;

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/__integrations__/ProfileSection.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/__integrations__/ProfileSection.integration.test.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { render, screen, withFlagOverrides } from "@tests/test-renderer";
+import type { State } from "~/reducers/types";
+import { ProfileSection } from "../views/ProfileSection";
+
+const withNanoProfileUpsell = withFlagOverrides(
+  { largeScreenUpsell: { enabled: true } },
+  (state: State): State => ({
+    ...state,
+    settings: {
+      ...state.settings,
+      personalizedRecommendationsEnabled: true,
+      knownDeviceModelIds: {
+        ...state.settings.knownDeviceModelIds,
+        [DeviceModelId.nanoS]: true,
+      },
+    },
+  }),
+);
+
+describe("ProfileSection", () => {
+  it("should render the avatar without the profile upsell banner", () => {
+    render(<ProfileSection />, { overrideInitialState: withNanoProfileUpsell });
+
+    expect(screen.getByTestId("my-wallet-avatar")).toBeVisible();
+    expect(screen.queryByText("Upgrade my Ledger")).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/__integrations__/DeviceSection.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/__integrations__/DeviceSection.integration.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { render, screen, fireEvent, waitFor } from "@tests/test-renderer";
+import { render, screen, fireEvent, waitFor, withFlagOverrides } from "@tests/test-renderer";
 import { DeviceModelId } from "@ledgerhq/devices";
+import type { State } from "~/reducers/types";
 import { DeviceSectionView } from "../DeviceSectionView";
 import { type DeviceSectionDevice } from "../useDeviceSectionViewModel";
 
@@ -34,12 +35,28 @@ const mockOnDeviceActionError = jest.fn();
 
 const mockManagerAction = { useHook: jest.fn(), mapResult: jest.fn() } as const;
 
+const withNanoProfileUpsell = withFlagOverrides(
+  { largeScreenUpsell: { enabled: true } },
+  (state: State): State => ({
+    ...state,
+    settings: {
+      ...state.settings,
+      personalizedRecommendationsEnabled: true,
+      knownDeviceModelIds: {
+        ...state.settings.knownDeviceModelIds,
+        [DeviceModelId.nanoS]: true,
+      },
+    },
+  }),
+);
+
 const renderView = (
   devices: readonly DeviceSectionDevice[],
   overrides: Partial<{
     deviceToRemove: DeviceSectionDevice | null;
     isRemoveDrawerOpen: boolean;
   }> = {},
+  overrideInitialState?: (state: State) => State,
 ) =>
   render(
     <DeviceSectionView
@@ -59,6 +76,7 @@ const renderView = (
       onDeviceActionClose={mockOnDeviceActionClose}
       onDeviceActionError={mockOnDeviceActionError}
     />,
+    overrideInitialState ? { overrideInitialState } : undefined,
   );
 
 describe("DeviceSection", () => {
@@ -182,6 +200,40 @@ describe("DeviceSection", () => {
       expect(screen.getByTestId("my-wallet-device-item-device-1-menu")).toBeVisible();
       expect(screen.getByTestId("my-wallet-device-item-device-2-menu")).toBeVisible();
       expect(screen.getByTestId("my-wallet-device-item-device-3-menu")).toBeVisible();
+    });
+  });
+
+  describe("profile upsell banner", () => {
+    it("should hide the banner when the user has no nano", () => {
+      renderView([mockDevices[0]]);
+
+      expect(screen.queryByText("Upgrade my Ledger")).toBeNull();
+      expect(screen.getByTestId("my-wallet-device-section-explore")).toBeVisible();
+    });
+
+    it("should render the banner after discovered devices for a nano owner", () => {
+      renderView([mockDevices[0]], {}, withNanoProfileUpsell);
+
+      expect(screen.getByText("Flex Pro")).toBeVisible();
+      expect(screen.getByText("Upgrade my Ledger")).toBeVisible();
+      expect(screen.getByTestId("my-wallet-device-section-explore")).toBeVisible();
+
+      const tree = JSON.stringify(screen.toJSON());
+      expect(tree.indexOf("Flex Pro")).toBeLessThan(tree.indexOf("Upgrade my Ledger"));
+      expect(tree.indexOf("Upgrade my Ledger")).toBeLessThan(
+        tree.indexOf("Explore all Ledger devices"),
+      );
+    });
+
+    it("should render the banner after the add-device CTA when there are no paired devices", () => {
+      renderView([], {}, withNanoProfileUpsell);
+
+      expect(screen.getByTestId("my-wallet-device-section-add-device")).toBeVisible();
+      expect(screen.getByText("Upgrade my Ledger")).toBeVisible();
+      expect(screen.queryByTestId("my-wallet-device-section-explore")).toBeNull();
+
+      const tree = JSON.stringify(screen.toJSON());
+      expect(tree.indexOf("Add a Ledger device")).toBeLessThan(tree.indexOf("Upgrade my Ledger"));
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/DeviceListContent.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/components/DeviceListContent.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
+import { LNUpsellBanner } from "LLM/features/LNUpsell";
 import { type DeviceSectionDevice } from "../useDeviceSectionViewModel";
+import { AddDeviceItem } from "./AddDeviceItem";
 import { DeviceListItem } from "./DeviceListItem";
 import { ExploreDevicesItem } from "./ExploreDevicesItem";
-import { AddDeviceItem } from "./AddDeviceItem";
 
 type DeviceListContentProps = {
   readonly devices: readonly DeviceSectionDevice[];
@@ -20,8 +21,15 @@ export function DeviceListContent({
   onDevicePress,
   onOpenMenu,
 }: DeviceListContentProps) {
+  const profileUpsell = <LNUpsellBanner location="profile" />;
+
   if (devices.length === 0) {
-    return <AddDeviceItem onPress={onAddDevice} />;
+    return (
+      <>
+        <AddDeviceItem onPress={onAddDevice} />
+        {profileUpsell}
+      </>
+    );
   }
 
   return (
@@ -36,6 +44,7 @@ export function DeviceListContent({
           />
         ))}
       </Box>
+      {profileUpsell}
       <ExploreDevicesItem onPress={onExploreDevices} />
     </>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/MyLedgerSection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/MyLedgerSection.tsx
@@ -17,6 +17,7 @@ import { useAutoRedirectToPostOnboarding } from "~/hooks/useAutoRedirectToPostOn
 import { HOOKS_TRACKING_LOCATIONS } from "~/analytics/hooks/variables";
 import { urls } from "~/utils/urls";
 import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
+import { LNUpsellBanner } from "LLM/features/LNUpsell";
 import type { LumenNativeStackNavigationOptions } from "LLM/components/Navigation";
 import type { MyWalletNavigatorStackParamList } from "../types";
 import { ExploreDevicesItem } from "./DeviceSection/components/ExploreDevicesItem";
@@ -133,6 +134,9 @@ function MyLedgerSectionContent({ onPairingStateChanged }: MyLedgerSectionProps)
           requestToSetHeaderOptions={requestToSetHeaderOptions}
           withMyLedgerTracking
         >
+          <Box lx={{ paddingHorizontal: "s16", paddingTop: "s16" }}>
+            <LNUpsellBanner location="profile" />
+          </Box>
           {/* TODO(wallet40-myWallet): enable ExploreDevicesItem when ready */}
           {!shouldDisplayMyWallet && <ExploreDevicesItem onPress={onExploreDevices} />}
         </SelectDevice2>

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/ProfileSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/ProfileSection/index.tsx
@@ -4,7 +4,7 @@ import { UserAvatar } from "LLM/components/UserAvatar";
 
 export function ProfileSection() {
   return (
-    <Box lx={{ alignItems: "center" }}>
+    <Box lx={{ alignItems: "center", alignSelf: "stretch" }}>
       <UserAvatar size="xl" />
     </Box>
   );


### PR DESCRIPTION
### 📝 Description

Adds the Nano upgrade banner to My Wallet / Profile. Other LNUpsell placements stay on the old click/UTM path; Profile does not clone them.

- New `largeScreenUpsell.banners.profile` toggle (default on). `llmNanoSUpsellBanners` is untouched.
- Reuses `LNUpsellBanner` under the avatar. Existing `TrackScreen category="My Wallet"` is unchanged.
- CTA uses `buildLargeScreenUpsellCtaLink` with `utm_source=ledger_wallet_mobile`, `utm_medium=ledger_live`, `utm_campaign=nano_upgrade_program`, `utm_content=profile_cta`
- Eligibility is the shared large-screen upsell gate (flag, placement, audience, cooldown, high-tier exclusion)

Profile analytics (shared props: `deviceModel`, `personalRecoOptIn`, `offerType`, `platform: lwm`):

- `page('Profile', { name: 'Profile', ...shared })` for nano users, including cooldown (CTR denominator)
- `button_clicked` with `button: 'upgrade'`
- `deeplink_clicked` with the UTM source / medium / campaign above

Stacked on `feat/LIVE-35485` for the flow-package UTM helper subpath. Target `develop`.

<img width="45%" height="2400" alt="Screenshot_20260819-195916" src="https://github.com/user-attachments/assets/aedb2e32-f95a-407f-9509-16f33ab2242d" />
<img width="45%" height="2400" alt="Screenshot_20260819-195942" src="https://github.com/user-attachments/assets/a5df1ae9-9153-4b98-8c2a-f6795366994d" />


### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35483](https://ledgerhq.atlassian.net/browse/LIVE-35483)
- **Depends on**: [LIVE-35485](https://ledgerhq.atlassian.net/browse/LIVE-35485)
- **Desktop twin**: [LIVE-35481](https://ledgerhq.atlassian.net/browse/LIVE-35481)
- **Figma**: [Large touchscreen upsell program](https://www.figma.com/design/5cl7T8upzeVpwRTpNMZIDL/Large-touchscreen-upsell-program?node-id=1-119864&m=dev)

### Test plan

- [ ] Nano S only: banner shows under the avatar with opted-in / opted-out copy
- [x] Nano SP / X: hidden during cooldown, shown after 30 days
- [x] Known Stax / Flex / Apex (even with a Nano): no banner
- [x] `banners.profile=false` or flag off: no banner
- [x] CTA opens the upgrade LP with `utm_content=profile_cta`
- [x] `page` / `button_clicked` (`upgrade`) / `deeplink_clicked` fire with `platform: lwm`
- [x] My Wallet screen event is still `Page My Wallet`
- [x] QA debug tool: flip `knownDeviceModelIds` between Nano-only and large-screen

[LIVE-35483]: https://ledgerhq.atlassian.net/browse/LIVE-35483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ