### PR TITLE
[LWDM] fix(contacts): hide currency selector balances (LIVE-35856)

### DIFF
--- a/.changeset/quiet-contacts-sort.md
+++ b/.changeset/quiet-contacts-sort.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Hide balances and preserve market-cap order in the Contacts currency selector.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.test.tsx
@@ -30,6 +30,10 @@ describe("useContactsCurrencySelectionAdapter", () => {
       assetDisplayName: ethereum.name,
     });
     expect(openCurrencyFlow).toHaveBeenCalledWith([ethereumId, bitcoinId], {
+      dialogConfiguration: {
+        assets: { leftElement: "undefined", rightElement: "undefined" },
+        networks: { leftElement: "undefined", rightElement: "undefined" },
+      },
       presentation: "embedded",
     });
   });

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
@@ -5,10 +5,16 @@ import type {
   ContactsCurrencySelectionPort,
 } from "@features/flow-contacts";
 import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
+import type { EnhancedModularDrawerConfiguration } from "@ledgerhq/live-common/wallet-api/ModularDrawer/types";
 import {
   type OpenCurrencyFlow,
   useOpenCurrencyFlow,
 } from "../../ModularDialog/hooks/useOpenCurrencyFlow";
+
+const CONTACTS_CURRENCY_SELECTION_CONFIGURATION: EnhancedModularDrawerConfiguration = {
+  assets: { leftElement: "undefined", rightElement: "undefined" },
+  networks: { leftElement: "undefined", rightElement: "undefined" },
+};
 
 function resolveContactCurrencySelection(
   currency: CryptoOrTokenCurrency | null,
@@ -28,7 +34,10 @@ function createCurrencySelectionPort(
   return {
     selectCurrency: async networkIds =>
       resolveContactCurrencySelection(
-        await openCurrencyFlow(networkIds, { presentation: "embedded" }),
+        await openCurrencyFlow(networkIds, {
+          dialogConfiguration: CONTACTS_CURRENCY_SELECTION_CONFIGURATION,
+          presentation: "embedded",
+        }),
       ),
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/__tests__/useOpenCurrencyFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/__tests__/useOpenCurrencyFlow.test.tsx
@@ -40,6 +40,20 @@ describe("useOpenCurrencyFlow", () => {
     expect(store.getState().modularDialog.dialogParams).toBeNull();
   });
 
+  it("should forward the dialog configuration", () => {
+    const { result, store } = renderHook(() => useOpenCurrencyFlow());
+    const dialogConfiguration = {
+      assets: { leftElement: "undefined" as const, rightElement: "undefined" as const },
+      networks: { leftElement: "undefined" as const, rightElement: "undefined" as const },
+    };
+
+    void result.current.openCurrencyFlow([ethereum.id], { dialogConfiguration });
+
+    expect(store.getState().modularDialog.dialogParams?.dialogConfiguration).toEqual(
+      dialogConfiguration,
+    );
+  });
+
   it("should cancel an embedded selection and reset the dialog", async () => {
     const { result, store } = renderHook(() => useOpenCurrencyFlow());
     const selection = result.current.openCurrencyFlow([ethereum.id], {

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useOpenCurrencyFlow.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useOpenCurrencyFlow.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import type { CryptoCurrency } from "@domain/entity-currency-crypto";
+import type { EnhancedModularDrawerConfiguration } from "@ledgerhq/live-common/wallet-api/ModularDrawer/types";
 import { useDispatch, useStore } from "LLD/hooks/redux";
 import {
   closeDialog,
@@ -19,6 +20,7 @@ type PendingCurrencySelection = Readonly<{
 export type OpenCurrencyFlow = (
   selectableNetworkIds: readonly CryptoCurrency["id"][],
   options?: Readonly<{
+    dialogConfiguration?: EnhancedModularDrawerConfiguration;
     presentation?: ModularDialogPresentation;
   }>,
 ) => Promise<CryptoOrTokenCurrency | null>;
@@ -65,6 +67,7 @@ export function useOpenCurrencyFlow(): Readonly<{
 
         dispatch(
           openDialog({
+            dialogConfiguration: options?.dialogConfiguration,
             selectableNetworkIds: [...selectableNetworkIds],
             presentation: options?.presentation,
             onAssetSelected,

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.test.tsx
@@ -130,7 +130,7 @@ describe("useContactsCurrencySelectionAdapter", () => {
       onAccountSelected: handleAccountSelected,
       onClose: closeDrawer,
       onCurrencySelected: handleCurrencySelected,
-      selectableNetworkIds: undefined,
+      selectableNetworkIds: [mockEthCryptoCurrency.id],
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.test.tsx
@@ -123,8 +123,10 @@ describe("useContactsCurrencySelectionAdapter", () => {
 
     expect(result.current.flowProps).toMatchObject({
       areCurrenciesFiltered: undefined,
+      assetsConfiguration: { leftElement: "undefined", rightElement: "undefined" },
       currencies: [mockEthCryptoCurrency.id, mockBtcCryptoCurrency.id],
       isOpen: true,
+      networksConfiguration: { leftElement: "undefined", rightElement: "undefined" },
       onAccountSelected: handleAccountSelected,
       onClose: closeDrawer,
       onCurrencySelected: handleCurrencySelected,

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.test.tsx
@@ -59,9 +59,11 @@ describe("useContactsCurrencySelectionAdapter", () => {
     );
 
     expect(openDrawer).toHaveBeenCalledWith({
+      assetsConfiguration: { leftElement: "undefined", rightElement: "undefined" },
       completionMode: "currency",
       enableAccountSelection: false,
       flow: "contacts_add_address",
+      networksConfiguration: { leftElement: "undefined", rightElement: "undefined" },
       presentation: "embedded",
       source: ScreenName.MyWalletContactDetail,
       selectableNetworkIds: networkIds,

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
@@ -54,7 +54,6 @@ export function useContactsCurrencySelectionAdapter({
     isOpen: isModularDrawerOpen,
     openDrawer,
     preselectedCurrencies,
-    selectableNetworkIds,
     uiUseCase,
     useCase,
   } = useModularDrawerController();
@@ -117,7 +116,7 @@ export function useContactsCurrencySelectionAdapter({
       onCurrencySelected: handleCurrencySelected,
       uiUseCase,
       useCase,
-      selectableNetworkIds,
+      selectableNetworkIds: networkIds,
     }),
     [
       areCurrenciesFiltered,
@@ -125,8 +124,8 @@ export function useContactsCurrencySelectionAdapter({
       handleAccountSelected,
       handleCurrencySelected,
       isModularDrawerOpen,
+      networkIds,
       preselectedCurrencies,
-      selectableNetworkIds,
       uiUseCase,
       useCase,
     ],

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
@@ -48,12 +48,10 @@ export function useContactsCurrencySelectionAdapter({
   const closeDrawerRef = useRef<() => void>(() => undefined);
   const {
     areCurrenciesFiltered,
-    assetsConfiguration,
     closeDrawer,
     handleAccountSelected,
     handleCurrencySelected,
     isOpen: isModularDrawerOpen,
-    networksConfiguration,
     openDrawer,
     preselectedCurrencies,
     selectableNetworkIds,
@@ -111,10 +109,9 @@ export function useContactsCurrencySelectionAdapter({
   const flowProps = useMemo<Omit<ModularDrawerFlowProps, "children">>(
     () => ({
       areCurrenciesFiltered,
-      assetsConfiguration,
+      ...CONTACTS_CURRENCY_SELECTION_CONFIGURATION,
       currencies: preselectedCurrencies,
       isOpen: isModularDrawerOpen,
-      networksConfiguration,
       onAccountSelected: handleAccountSelected,
       onClose: closeDrawer,
       onCurrencySelected: handleCurrencySelected,
@@ -124,12 +121,10 @@ export function useContactsCurrencySelectionAdapter({
     }),
     [
       areCurrenciesFiltered,
-      assetsConfiguration,
       closeDrawer,
       handleAccountSelected,
       handleCurrencySelected,
       isModularDrawerOpen,
-      networksConfiguration,
       preselectedCurrencies,
       selectableNetworkIds,
       uiUseCase,

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
@@ -10,6 +10,11 @@ import {
 
 const FLOW = "contacts_add_address";
 
+const CONTACTS_CURRENCY_SELECTION_CONFIGURATION = {
+  assetsConfiguration: { leftElement: "undefined", rightElement: "undefined" },
+  networksConfiguration: { leftElement: "undefined", rightElement: "undefined" },
+} as const;
+
 type UseContactsCurrencySelectionAdapterOptions = Readonly<{
   isOpen: boolean;
   networkIds: readonly string[];
@@ -92,6 +97,7 @@ export function useContactsCurrencySelectionAdapter({
 
     selectionStartedRef.current = true;
     openDrawer({
+      ...CONTACTS_CURRENCY_SELECTION_CONFIGURATION,
       completionMode: "currency",
       enableAccountSelection: false,
       flow: FLOW,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Desktop and Mobile Contacts adapter tests cover the configuration; the Desktop currency-flow test covers propagation to the Modular Dialog.
- [x] **Impact of the changes:**
      Contacts currency selection no longer displays asset or network balances and preserves DADA market-cap ordering on Desktop and Mobile.

### 📝 Description

Contacts currency selection inherited the Modular Asset Drawer defaults, displaying balances and re-sorting lists by account balance.

This PR provides a Contacts-specific drawer configuration on both platforms. It removes the asset/network side elements and avoids local balance or account-count sorting, leaving the market-cap order returned by DADA intact.

https://github.com/user-attachments/assets/8f425600-6a2a-4df5-9391-e3b877d08940

<img width="1076" height="747" alt="image" src="https://github.com/user-attachments/assets/efd1acac-8238-4d34-a2d4-bb2442be1a48" />
<img width="674" height="659" alt="image" src="https://github.com/user-attachments/assets/6f2419cf-8e8e-42f5-a4f3-0804c0c242b9" />

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-35856

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)