### PR TITLE
[LWD] fix(desktop): stop Password Lock wiping the persisted trustchain

### DIFF
--- a/.changeset/hungry-cheetahs-repeat.md
+++ b/.changeset/hungry-cheetahs-repeat.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix Ledger Sync being wiped on every launch when Password Lock is enabled. `app.trustchain` is an encrypted db path, so before unlock it read back as a ciphertext string; importing it regenerated member credentials, nulled the trustchain, and persisted that fresh state over the encrypted blob in plaintext. The import is now skipped while the value is still a string, and trustchain writes are suppressed while the app is locked.

--- a/.changeset/hungry-cheetahs-repeat.md
+++ b/.changeset/hungry-cheetahs-repeat.md
@@ -2,4 +2,4 @@
 "ledger-live-desktop": patch
 ---
 
-Fix Ledger Sync being wiped on every launch when Password Lock is enabled. `app.trustchain` is an encrypted db path, so before unlock it read back as a ciphertext string; importing it regenerated member credentials, nulled the trustchain, and persisted that fresh state over the encrypted blob in plaintext. The import is now skipped while the value is still a string, and trustchain writes are suppressed while the app is locked.
+Fix Ledger Sync being wiped on every launch when Password Lock is enabled. `app.trustchain` is an encrypted db path, so before unlock it reads back as a ciphertext string; importing it regenerated member credentials, nulled the trustchain, and persisted that fresh state over the encrypted blob in plaintext. The import is now skipped while the value is still a string, and trustchain writes are suppressed while the app is locked.

--- a/apps/ledger-live-desktop/src/renderer/actions/trustchain.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/trustchain.test.ts
@@ -55,8 +55,6 @@ describe("fetchTrustchain", () => {
   });
 
   it("should not dispatch when storage returns an encrypted string (app is password-locked)", async () => {
-    // `app.trustchain` is an encrypted db path: before unlock it reads back as ciphertext.
-    // Importing it would wipe the persisted trustchain and mint new credentials (LIVE-36130).
     jest.mocked(getKey).mockResolvedValue("6a9f1c...ciphertext..." as unknown as TrustchainStore);
 
     await fetchTrustchain()(dispatch, jest.fn(), undefined);

--- a/apps/ledger-live-desktop/src/renderer/actions/trustchain.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/trustchain.test.ts
@@ -53,4 +53,15 @@ describe("fetchTrustchain", () => {
       },
     });
   });
+
+  it("should not dispatch when storage returns an encrypted string (app is password-locked)", async () => {
+    // `app.trustchain` is an encrypted db path: before unlock it reads back as ciphertext.
+    // Importing it would wipe the persisted trustchain and mint new credentials (LIVE-36130).
+    jest.mocked(getKey).mockResolvedValue("6a9f1c...ciphertext..." as unknown as TrustchainStore);
+
+    await fetchTrustchain()(dispatch, jest.fn(), undefined);
+
+    expect(getKey).toHaveBeenCalledWith("app", "trustchain");
+    expect(dispatch).not.toHaveBeenCalled();
+  });
 });

--- a/apps/ledger-live-desktop/src/renderer/actions/trustchain.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/trustchain.ts
@@ -5,10 +5,7 @@ import { ThunkResult } from "./types";
 export const fetchTrustchain =
   (): ThunkResult<Promise<void>> => async (dispatch, _getState, _extra) => {
     const data = await getKey("app", "trustchain");
-    // NB `app.trustchain` is an encrypted db path: while the app is password-locked it reads back
-    // as the ciphertext string. Importing it would regenerate member credentials and null the
-    // trustchain (LIVE-36130). IsUnlocked re-runs this thunk once the encryption key is set.
-    // `undefined` must still go through: that is the legitimate "nothing persisted" case.
-    if (typeof data === "string") return;
+    const dataIsEncrypted = typeof data === "string";
+    if (dataIsEncrypted) return;
     dispatch(importTrustchainStoreState(data));
   };

--- a/apps/ledger-live-desktop/src/renderer/actions/trustchain.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/trustchain.ts
@@ -5,5 +5,10 @@ import { ThunkResult } from "./types";
 export const fetchTrustchain =
   (): ThunkResult<Promise<void>> => async (dispatch, _getState, _extra) => {
     const data = await getKey("app", "trustchain");
+    // NB `app.trustchain` is an encrypted db path: while the app is password-locked it reads back
+    // as the ciphertext string. Importing it would regenerate member credentials and null the
+    // trustchain (LIVE-36130). IsUnlocked re-runs this thunk once the encryption key is set.
+    // `undefined` must still go through: that is the legitimate "nothing persisted" case.
+    if (typeof data === "string") return;
     dispatch(importTrustchainStoreState(data));
   };

--- a/apps/ledger-live-desktop/src/renderer/middlewares/__tests__/db.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/__tests__/db.test.ts
@@ -318,3 +318,34 @@ describe("DBMiddleware - coinConfigOverrides branch", () => {
     expect(mockedSetKey).toHaveBeenCalledWith("app", "coinConfigOverrides", { overrides: {} });
   });
 });
+
+describe("DBMiddleware - trustchain branch", () => {
+  beforeEach(() => {
+    mockedSetKey.mockReset();
+  });
+
+  it("persists the trustchain on TRUSTCHAIN_STORE_* actions when the app is unlocked", () => {
+    const state: FakeState = {
+      ...baseState(),
+      trustchain: { trustchain: { rootId: "root-id" }, memberCredentials: { pubkey: "ab" } },
+    };
+
+    runMiddleware([state, state], { type: "TRUSTCHAIN_STORE_IMPORT_STATE" });
+
+    expect(mockedSetKey).toHaveBeenCalledWith("app", "trustchain", state.trustchain);
+  });
+
+  it("does not persist the trustchain while the app is locked", () => {
+    // app.trustchain is an encrypted path: writing before setEncryptionKey would overwrite the
+    // ciphertext on disk with plaintext and destroy the persisted trustchain (LIVE-36130).
+    const state: FakeState = {
+      ...baseState(),
+      application: { isLocked: true },
+      trustchain: { trustchain: null, memberCredentials: { pubkey: "ab" } },
+    };
+
+    runMiddleware([state, state], { type: "TRUSTCHAIN_STORE_IMPORT_STATE" });
+
+    expect(mockedSetKey).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/middlewares/__tests__/db.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/__tests__/db.test.ts
@@ -336,8 +336,6 @@ describe("DBMiddleware - trustchain branch", () => {
   });
 
   it("does not persist the trustchain while the app is locked", () => {
-    // app.trustchain is an encrypted path: writing before setEncryptionKey would overwrite the
-    // ciphertext on disk with plaintext and destroy the persisted trustchain (LIVE-36130).
     const state: FakeState = {
       ...baseState(),
       application: { isLocked: true },

--- a/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
@@ -92,7 +92,9 @@ const DBMiddleware: Middleware<object, State> = store => next => action => {
   if (action.type.startsWith(trustchainStoreActionTypePrefix)) {
     const res = next(action);
     const state = store.getState();
-    setKey("app", "trustchain", trustchainStoreSelector(state));
+    if (!state.application.isLocked) {
+      setKey("app", "trustchain", trustchainStoreSelector(state));
+    }
     return res;
   }
 


### PR DESCRIPTION
### 📝 Description

**Previous behaviour** — with Password Lock enabled, Ledger Sync was destroyed on **every** launch: My Ledger showed "Your wallet isn't synced", and the "Ledger Wallet apps synced" list grew by one entry per launch.

Regression from #19634. `app.trustchain` is one of three encrypted db paths (alongside `accounts` and `wallet`). On a locked launch, `fetchTrustchain()` runs before the user types their password, so `getKey("app", "trustchain")` returns the **ciphertext string**. That PR removed the guard that skipped this case, so the string was handed to `importTrustchainStoreState`, which reads it as "invalid credentials" and replaces the store with a freshly generated random keypair and `trustchain: null`. The db middleware then wrote that fresh state straight back to `app.json` — **in plaintext**, because `encryptionKeys.app` isn't populated until unlock — permanently overwriting the user's `rootId` / `walletSyncEncryptionKey` / member credentials.

Self-sustaining cycle: the next boot parses the plaintext object fine but it holds throwaway credentials, so the user re-syncs (new member), unlock re-encrypts it, and the launch after that wipes it again.

**The fix** — two independent guards, one commit each:

1. `renderer/actions/trustchain.ts` — skip the import when the value read back is still a string. `undefined` deliberately keeps going through: that's the legitimate "nothing persisted" case #19634 was written for, and it must still generate credentials. `IsUnlocked` already re-runs the thunk after `setEncryptionKey`.
2. `renderer/middlewares/db.ts` — don't persist `app.trustchain` while `application.isLocked`, following the precedent already used for settings in the same middleware. This kills the irreversible half of the bug (plaintext overwrite + private key on disk) regardless of which trustchain action fires pre-unlock.

**Automated checks preventing regression**

- `renderer/actions/trustchain.test.ts` — new case: `getKey` resolves a ciphertext string → nothing is dispatched. Both existing cases stay green, since they encode #19634's intent.
- `renderer/middlewares/__tests__/db.test.ts` — new `trustchain branch` describe: `TRUSTCHAIN_STORE_IMPORT_STATE` persists when unlocked, and does not when `isLocked: true`.

**Not affected** — Password Lock off (value on disk is a plain object), `app.wallet` (`fetchWallet` kept its guard), `app.accounts` (protected by the string check in its transform), and mobile (`LedgerStore.tsx` also lost the guard but has no encrypted-string read; `undefined` there genuinely means "nothing stored").

**Manual QA** (needs a device for the sync)

1. Fresh profile → enable Password Lock → sync → note the entries under "Ledger Wallet apps synced".
2. Quit, reopen, unlock, open My Ledger → must not show "Your wallet isn't synced".
3. Repeat the quit/reopen cycle twice → the instance count must not grow.
4. On a locked launch, before typing the password, inspect `app.json` in the user-data dir → `data.trustchain` must still be an encrypted string, and the file must contain no plaintext `privatekey`.
5. Toggle Password Lock off then on, restart → still synced.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36130](https://ledgerhq.atlassian.net/browse/LIVE-36130) — regression from #19634
- **ADR** (if any): n/a

### ⚠️ Notes for reviewers / follow-ups

- **Already-affected users cannot be recovered in code.** Their `rootId` / `walletSyncEncryptionKey` / credentials were overwritten; this fix only stops further loss. Each will need to prune the accumulated stale entries from "Ledger Wallet apps synced" once. The plaintext-private-key-on-disk aspect is worth a severity call from security.
- Two other sharp edges spotted while investigating, out of scope here: `resetTrustchainStore()` is no longer idempotent (each call mints new member credentials, and it has several call sites), and `MemberCredentialsSchema` is a `strictObject` with lowercase-hex constraints, so an extra field or uppercase hex in persisted credentials would silently trigger the same wipe-and-regenerate path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LIVE-36130]: https://ledgerhq.atlassian.net/browse/LIVE-36130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ