### PR TITLE
fix(e2e): approve borrow speculos txs on touch devices

### DIFF
--- a/.changeset/borrow-e2e-touch-devices.md
+++ b/.changeset/borrow-e2e-touch-devices.md
@@ -1,0 +1,12 @@
+---
+"@ledgerhq/live-e2e-shared": patch
+---
+
+Make the Borrow E2E Speculos approval work on touch devices: dispatch on the device model the way
+the send flow does — swipe to "Hold to sign" then long-press on Stax/Flex/Nano Gen5, right then both
+on Nano S+/X, "Accept and send" on Nano S — instead of hard-coding Nano button presses that a
+touchscreen has no way to receive. Clear the "Enable Transaction Check?" opt-in the Ethereum app
+shows before its first review, which blocks the review and cannot be dismissed by swipes or presses.
+Report a signer failure as a rejection from the executor rather than an unhandled one that kills the
+process, and reach the device through the shared helpers so navigation goes through the retry wrapper
+and honours `SPECULOS_ADDRESS` instead of assuming localhost.

--- a/libs/live-e2e-shared/src/borrow/README.md
+++ b/libs/live-e2e-shared/src/borrow/README.md
@@ -147,7 +147,11 @@ against it in parallel**. `playwright.config.ts` is `fullyParallel: true`, `work
   either — so a fully-repaid, collateral-only position is still withdrawable.
 - Arbitrary borrow calldata (e.g. the Morpho `repay`) requires **Blind signing enabled** on the
   Speculos Ethereum app, or the device rejects with `6a80`. The ERC-20 approval clear-signs.
-- Auto-approval walks the review carousel to the **"Sign transaction"** screen and presses both
-  (nanoSP). Confirm labels vary by device model; use `BORROW_MANUAL_APPROVE=1` to confirm by hand.
+- Auto-approval first clears the **"Enable Transaction Check?"** opt-in that the Ethereum app shows
+  before its first review (it blocks the review, and swipes/presses do not dismiss it), then walks
+  the review carousel to the confirm screen and signs, per `SPECULOS_DEVICE`:
+  swipe to **"Hold to sign"** then long-press on stax/flex/nanoGen5, right to **"Sign transaction"**
+  then both on nanoSP/nanoX, **"Accept and send"** on nanoS. Use `BORROW_MANUAL_APPROVE=1` to
+  confirm by hand instead.
 - A full dry-run close (`--dry-run`) is validated end-to-end: approval + repay + withdraw all sign
   on Speculos and produce valid signed transactions (no broadcast).

--- a/libs/live-e2e-shared/src/borrow/borrowFlow.ts
+++ b/libs/live-e2e-shared/src/borrow/borrowFlow.ts
@@ -249,10 +249,11 @@ export async function runBorrow(options: BorrowFlowOptions): Promise<string | vo
       device = await startSpeculos(`borrow-${options.flow}`, spec);
       if (!device) throw new Error("Speculos not started");
       apiPort = device.port;
-      setEnv("SPECULOS_API_PORT", device.port);
-      process.env.SPECULOS_API_PORT = String(device.port);
     }
     if (apiPort === undefined) throw new Error("Speculos API port unavailable");
+    // The shared device helpers resolve the device from this env, not from a parameter.
+    setEnv("SPECULOS_API_PORT", apiPort);
+    process.env.SPECULOS_API_PORT = String(apiPort);
 
     const transport = await DeviceManagementKitTransportSpeculos.open({ apiPort: String(apiPort) });
     const executor = new EvmSpeculosExecutor(transport, {

--- a/libs/live-e2e-shared/src/borrow/evmSpeculos.ts
+++ b/libs/live-e2e-shared/src/borrow/evmSpeculos.ts
@@ -1,10 +1,19 @@
-import axios from "axios";
 import { JsonRpcProvider, Signature, Transaction, isError } from "ethers";
 import { filter, firstValueFrom } from "rxjs";
 import { getEnv } from "@shared/env";
+import { DeviceModelId } from "@ledgerhq/devices";
 import { DeviceManagementKitTransportSpeculos } from "@ledgerhq/live-dmk-speculos";
 import { DmkSignerEth } from "@ledgerhq/live-signer-evm";
 import type { EvmSignature } from "@ledgerhq/live-signer-evm";
+import {
+  acceptEnableTransactionCheck,
+  fetchCurrentScreenTexts,
+  pressUntilTextFound,
+} from "../speculos";
+import { getSpeculosModel, isTouchDevice } from "../speculosAppVersion";
+import { longPressAndRelease } from "../deviceInteraction/TouchDeviceSimulator";
+import { withDeviceController } from "../deviceInteraction/DeviceController";
+import { DeviceLabels } from "../enum/DeviceLabels";
 import type { EvmSignablePayload } from "./types";
 
 export type SpeculosDmkTransport = Awaited<
@@ -17,50 +26,55 @@ function prefix0x(hex: string): string {
 
 const sleep = (ms: number): Promise<void> => new Promise(r => setTimeout(r, ms));
 
-/** Screen labels that mean "confirm & sign" on the Ethereum app review carousel. */
-const CONFIRM = /sign transaction|accept and send|hold to sign/i;
-/** The idle dashboard — we must not press buttons here (it opens Settings/Quit). */
+/** The idle dashboard — we must not navigate here (it opens Settings/Quit). */
 const READY = /is ready/i;
+const REVIEW_POLL_ATTEMPTS = 40;
+const REVIEW_POLL_INTERVAL_MS = 300;
 
 /**
- * Actively approves the transaction on Speculos: waits for the review to
- * appear, presses right until the "Sign transaction" screen, then presses
- * both. This is the button-device flow (default nanoSP); set
- * `BORROW_MANUAL_APPROVE=1` to approve by hand via VNC instead.
+ * The sign APDU is sent concurrently with the approval, so the device can still
+ * be showing the dashboard when we start driving it.
+ */
+async function waitForDeviceReview(apiPort: number): Promise<void> {
+  for (let i = 0; i < REVIEW_POLL_ATTEMPTS; i++) {
+    const texts = await fetchCurrentScreenTexts(apiPort).catch(() => "");
+    if (texts.trim() && !READY.test(texts)) return;
+    await sleep(REVIEW_POLL_INTERVAL_MS);
+  }
+}
+
+const approveOnTouchDevice = async (): Promise<void> => {
+  await pressUntilTextFound(DeviceLabels.HOLD_TO_SIGN);
+  await longPressAndRelease(DeviceLabels.HOLD_TO_SIGN, 3);
+};
+
+const approveOnButtonDevice = withDeviceController(
+  ({ getButtonsController }) =>
+    async (confirmLabel: string): Promise<void> => {
+      await pressUntilTextFound(confirmLabel);
+      await getButtonsController().both();
+    },
+);
+
+/**
+ * Actively approves the transaction on Speculos: clears the Transaction Check
+ * opt-in the Ethereum app shows before the first review, then walks the review
+ * carousel to the confirm screen and signs — swipe + hold-to-sign on touch
+ * devices, right + both on button devices. Set `BORROW_MANUAL_APPROVE=1` to
+ * approve by hand via VNC instead.
  *
- * We drive the Speculos REST API directly (rather than the automation rule)
+ * We drive the device ourselves (rather than the Speculos automation rule)
  * because a blind rule can walk past "Sign transaction" onto "Reject".
  */
 async function approveOnDevice(apiPort: number): Promise<void> {
   if (process.env.BORROW_MANUAL_APPROVE) return;
-  const base = `http://localhost:${apiPort}`;
-  const screen = async (): Promise<string> => {
-    const { data } = await axios.get(`${base}/events?currentscreenonly=true`);
-    const events: { text: string }[] = data.events ?? [];
-    return events.map(e => e.text).join(" | ");
-  };
-  const pressRight = (): Promise<unknown> =>
-    axios.post(`${base}/button/right`, { action: "press-and-release" });
-  const pressBoth = (): Promise<unknown> =>
-    axios.post(`${base}/button/both`, { action: "press-and-release" });
-
-  // Wait for the review to come up (don't press while on the dashboard).
-  for (let i = 0; i < 40; i++) {
-    const s = await screen().catch(() => "");
-    if (s.trim() && !READY.test(s)) break;
-    await sleep(300);
+  await acceptEnableTransactionCheck();
+  await waitForDeviceReview(apiPort);
+  if (isTouchDevice()) return approveOnTouchDevice();
+  if (getSpeculosModel() === DeviceModelId.nanoS) {
+    return approveOnButtonDevice(DeviceLabels.ACCEPT_AND_SEND);
   }
-  // Walk the review carousel to the confirm screen, then sign.
-  for (let i = 0; i < 24; i++) {
-    const s = await screen().catch(() => "");
-    if (CONFIRM.test(s)) {
-      await pressBoth();
-      return;
-    }
-    await pressRight().catch(() => {});
-    await sleep(350);
-  }
-  throw new Error("[borrow] could not find the 'Sign transaction' screen to approve");
+  return approveOnButtonDevice(DeviceLabels.SIGN_TRANSACTION);
 }
 
 export interface ExecutorConfig {
@@ -115,8 +129,9 @@ export class EvmSpeculosExecutor {
           ),
         ),
     );
-    await approveOnDevice(this.config.speculosApiPort);
-    const { value } = await signed;
+    // Promise.all so a signer failure surfaces as a rejection here instead of an
+    // unhandled one while the approval is still driving the device.
+    const [{ value }] = await Promise.all([signed, approveOnDevice(this.config.speculosApiPort)]);
     return value;
   }
 


### PR DESCRIPTION
### 📝 Description

**Previous behaviour.** The Borrow driver's on-device approval hard-coded Nano navigation — it POSTed
straight to Speculos' `/button/right` and `/button/both` from `approveOnDevice`
(`libs/live-e2e-shared/src/borrow/evmSpeculos.ts`). Stax, Flex and Nano Gen5 have no navigation
buttons, so the Ethereum review carousel never advanced, the confirm screen was never reached, and the
helper threw after ~8.4s:

```
Error: [borrow] could not find the 'Sign transaction' screen to approve
  at approveOnDevice  evmSpeculos.ts:63
  at resetLoanState   borrowSetup.ts:241
  at                  borrow.spec.ts:111
```

The specs are already tagged `@Stax`, `@Flex` and `@NanoGen5` (`buildTags({ currencyId, skipLNS: true })`),
so a touch leg selects them — they had simply never *run* there, being gated behind
`DISABLE_TRANSACTION_BROADCAST=0` and the primary-device leg. The first Flex run with broadcast on
([run #5130](https://github.com/LedgerHQ/ledger-live/actions/runs/32115558518)) failed in
`beforeAll`/`afterAll`, which is why the stack points at `borrow.spec.ts:111` rather than the test body.
The `GeneralDmkError` in that report is downstream, not a second bug.

**The fix.** Dispatch on the device model the way the send flow already does (`sendEVM` in
`families/evm.ts`):

| Device | Navigate | Confirm |
| --- | --- | --- |
| Stax / Flex / Nano Gen5 | `swipeRight()` to `Hold to sign` | `longPressAndRelease(HOLD_TO_SIGN, 3)` |
| Nano S+ / Nano X | right to `Sign transaction` | `buttons.both()` |
| Nano S | right to `Accept and send` | `buttons.both()` |

Navigation is now `pressUntilTextFound`, which already branches touch vs button, so the raw `axios`
calls are gone: every request goes through `retryAxiosRequest`, honours `SPECULOS_ADDRESS` instead of
assuming `localhost` (the old code was broken under `REMOTE_SPECULOS`), and on failure names every
screen it observed instead of today's message that names none. The old code swallowed all 24 failed
presses with `.catch(() => {})`, which is why the Flex log showed nothing.

Two things found while verifying, both included:

- **The Transaction Check opt-in was the real blocker on Flex.** With the swipe path in, Flex still
  failed — the device sits on an `Enable / Transaction Check?` modal (`Yes, enable` / `Maybe later`)
  that the Ethereum app shows before its first review. Swipes and presses cannot dismiss it, so the
  review never appears. `approveOnDevice` now calls the existing touch-aware
  `acceptEnableTransactionCheck()` first; the spec's UI path already did this, the headless driver
  never had. It polls for either the prompt or the review and returns silently if the prompt is
  absent, so Nano is unaffected (measured: no added latency).
- **A signer failure killed the process instead of reporting.** `firstValueFrom` is created before the
  approval runs, so a signer error was an unhandled rejection — which is exactly why the original
  report showed a bare DMK stack and nothing about the device. Now `Promise.all([signed, approve])`,
  so whichever fails first surfaces as a proper rejection.

**Regression cover.** The touch path is what the existing `@Stax`/`@Flex`/`@NanoGen5` tags already
select, so the scheduled rotation (Tue = stax, Thu = flex, Fri = nanoGen5) exercises it on every
broadcast-enabled run — no tag change needed, and no new spec: this fixes the driver the existing
specs depend on.

**Verified locally with broadcast enabled** — real mainnet transactions, run sequentially since both
legs share ETH_4 and would collide on its nonce:

| Device | `borrow.spec.ts` | Time |
| --- | --- | --- |
| nanoSP | 4/4 passed | 7.7m |
| flex | 4/4 passed | 8.9m |

Both cover cold start, open-loan (B2CQA-6065), full repay (B2CQA-6073) and withdraw (B2CQA-6080), and
exercise both the headless driver in the hooks and the UI signing in the test bodies. Also
dry-run-signed on stax and nanoGen5 via `pnpm e2e-cli borrow open --dry-run`. ETH_4 was left with no
open position; ~20 mainnet txs cost 0.000243 ETH in gas.

Worth noting the repay flow passed on Flex through both paths, so the blind-signing caveat in the
borrow README does not bite for this app/firmware pair.

### 🔗 Context

- **JIRA / GitHub issue**: none — no ticket covers this yet. Follow-up to
  [QAA-1401](https://ledgerhq.atlassian.net/browse/QAA-1401), which added the driver, and surfaced by
  [run #5130](https://github.com/LedgerHQ/ledger-live/actions/runs/32115558518). Happy to open a QAA
  ticket if you want one linked.
- **ADR** (if any): n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[QAA-1401]: https://ledgerhq.atlassian.net/browse/QAA-1401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ