### PR TITLE
[LWDM] feat(coin-casper): wire validateAddress and getNextSequence (LIVE-35911)

### DIFF
--- a/.changeset/few-mugs-act.md
+++ b/.changeset/few-mugs-act.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-casper": minor
+---
+
+Wire `validateAddress` in the Casper coin module API to the existing address validation logic. `getNextSequence` now returns `0n` instead of throwing, as Casper has no account nonce.

--- a/libs/coin-modules/coin-casper/src/api/index.test.ts
+++ b/libs/coin-modules/coin-casper/src/api/index.test.ts
@@ -1,8 +1,12 @@
 import type { Balance, TransactionIntent } from "@ledgerhq/coin-module-framework/api/index";
 import { CASPER_FEES_MOTES } from "../constants";
 import { TEST_ADDRESSES } from "../__tests__/fixtures/addresses.fixture";
-import type { CasperMemo } from "../types";
+import type { CasperContext, CasperMemo } from "../types";
 import { createApi } from "./index";
+
+const context = {} as CasperContext;
+const api = createApi();
+const validEd25519 = "016470ae57b0a3ad5a679d2e0422909bfb9ded445e20cbe6b4c9806f844c94d401";
 
 const FEES = BigInt(CASPER_FEES_MOTES);
 const AMOUNT = 3_000_000_000n;
@@ -22,7 +26,6 @@ const balances: Balance[] = [{ value: BALANCE, asset: { type: "native" }, locked
 
 describe("createApi", () => {
   it("returns an object with all CoinModuleApi methods", () => {
-    const api = createApi();
     const methods = [
       "lastBlock",
       "getBlockInfo",
@@ -50,9 +53,7 @@ describe("createApi", () => {
 
   describe("validateIntent", () => {
     it("validates a send intent through the api surface", async () => {
-      const api = createApi();
-
-      const result = await api.validateIntent({} as never, sendIntent, balances, {
+      const result = await api.validateIntent(context, sendIntent, balances, {
         customFees: { value: FEES },
       });
 
@@ -61,6 +62,29 @@ describe("createApi", () => {
       expect(result.estimatedFees).toBe(FEES);
       expect(result.amount).toBe(AMOUNT);
       expect(result.totalSpent).toBe(AMOUNT + FEES);
+    });
+  });
+
+  describe("validateAddress", () => {
+    // Mixed case opts the address into checksum verification, which this one fails.
+    const badChecksum = "016470ae57b0a3ad5a679d2e0422909bfb9ded445e20cbe6b4c9806f844c94D401";
+
+    it("returns true for a valid Casper address", async () => {
+      await expect(api.validateAddress(context, validEd25519, {})).resolves.toBe(true);
+    });
+
+    it("returns false when the address checksum does not match", async () => {
+      await expect(api.validateAddress(context, badChecksum, {})).resolves.toBe(false);
+    });
+
+    it("returns false for a malformed address", async () => {
+      await expect(api.validateAddress(context, "not-an-address", {})).resolves.toBe(false);
+    });
+  });
+
+  describe("getNextSequence", () => {
+    it("resolves to 0n instead of throwing, as Casper has no account nonce", async () => {
+      await expect(api.getNextSequence(context, validEd25519)).resolves.toBe(0n);
     });
   });
 });

--- a/libs/coin-modules/coin-casper/src/api/index.ts
+++ b/libs/coin-modules/coin-casper/src/api/index.ts
@@ -21,6 +21,7 @@ import { getBalance as getAccountBalance } from "../logic/getBalance";
 import { listOperations } from "../logic/listOperations";
 import { estimateFees } from "../logic/estimateFees";
 import { validateIntent } from "../logic/validateIntent";
+import { validateAddress } from "../bridge/validateAddress";
 import type { CasperConfig, CasperContext, CasperMemo } from "../types";
 
 // The caller builds the {@link CasperContext} (config + logger) and passes it to each method (ADR-019).
@@ -83,16 +84,10 @@ export function createApi(): CoinModuleApi<CasperConfig, CasperMemo> {
     estimateFees,
     validateIntent: async (_context, intent, balances, options) =>
       validateIntent(intent, balances, options?.customFees),
-    getNextSequence(_context: CasperContext, _address: string): Promise<bigint> {
-      throw new Error("getNextSequence is not supported");
-    },
-    validateAddress(
-      _context: CasperContext,
-      _address: string,
-      _parameters: unknown,
-    ): Promise<boolean> {
-      throw new Error("validateAddress is not supported");
-    },
+    // Casper uses (transaction hash + TTL) for replay protection rather than a
+    // per-account nonce, so getNextSequence has no meaningful value here.
+    getNextSequence: async (_context: CasperContext, _address: string) => 0n,
+    validateAddress: (_context, address, parameters) => validateAddress(address, parameters),
     craftTransactionData(_context: CasperContext, _intent: TransactionIntent<CasperMemo>) {
       throw new Error("craftTransactionData is not supported");
     },


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Wire `validateAddress` in the Casper coin module API to the existing address validation logic. `getNextSequence` now returns `0n` instead of throwing, as Casper has no account nonce.

### 🔗 Context

https://ledgerhq.atlassian.net/browse/LIVE-35911