### PR TITLE
feat(pay-card): add RequestReceive web UI and LLD wiring (LIVE-36120)

### DIFF
--- a/.changeset/pay-card-request-receive-ui.md
+++ b/.changeset/pay-card-request-receive-ui.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-pay-card-request": minor
+"ledger-live-desktop": minor
+---
+
+Add the web RequestReceive dialog (asset icon, network row, highlighted address, action tiles) and wire the Pay tab Request tile on desktop to open it with copy support (LIVE-36120).

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -99,6 +99,7 @@
     "@features/flow-pay-card-balance": "workspace:^",
     "@features/flow-pay-card-deposit": "workspace:^",
     "@features/flow-pay-card-feature-tour": "workspace:^",
+    "@features/flow-pay-card-request": "workspace:^",
     "@features/platform-aggregated-assets": "workspace:*",
     "@features/platform-card": "workspace:*",
     "@features/platform-contacts": "workspace:^",

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabActionTiles.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabActionTiles.ts
@@ -7,6 +7,7 @@ const noop = () => {};
 export function usePayTabActionTiles(
   onTrackEvent: ActionTilesProps["onTrackEvent"],
   onDeposit: () => void,
+  onRequest: () => void,
 ): ActionTilesProps {
   const { t } = useTranslation();
 
@@ -22,7 +23,7 @@ export function usePayTabActionTiles(
         {
           id: "request",
           label: t("payTab.actions.request"),
-          onPress: noop,
+          onPress: onRequest,
           appearance: "transparent",
         },
         { id: "pay", label: t("payTab.actions.pay"), onPress: noop, appearance: "transparent" },
@@ -30,6 +31,6 @@ export function usePayTabActionTiles(
       page: "Pay",
       onTrackEvent,
     }),
-    [t, onTrackEvent, onDeposit],
+    [t, onTrackEvent, onDeposit, onRequest],
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabRequestReceive.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabRequestReceive.ts
@@ -1,0 +1,69 @@
+import { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { PayCardTrackEvent, RequestReceiveProps } from "@features/flow-pay-card-request";
+import { useCopyToClipboard } from "../../../hooks/useCopyToClipboard";
+
+const REQUEST_PAGE = "Pay";
+
+// Placeholder account until the Request flow selects one through the MAD (LIVE-35189).
+const STUB_ADDRESS = "0xe4912d2d16Dd20c6B57Bf4757dAB7D240517672";
+const STUB_ASSET = { name: "USD Coin", ticker: "USDC" } as const;
+const STUB_NETWORK = "Base";
+
+export type UsePayTabRequestReceive = Readonly<{
+  open: () => void;
+  requestReceive: RequestReceiveProps;
+}>;
+
+export function usePayTabRequestReceive(
+  onTrackEvent: PayCardTrackEvent | undefined,
+): UsePayTabRequestReceive {
+  const { t } = useTranslation();
+  const [isOpen, setIsOpen] = useState(false);
+  const copyToClipboard = useCopyToClipboard();
+
+  const open = useCallback(() => setIsOpen(true), []);
+  const onClose = useCallback(() => setIsOpen(false), []);
+
+  const onCopy = useCallback((address: string) => copyToClipboard(address), [copyToClipboard]);
+  // Save (card image) and Verify (device) land with LIVE-36121 / LIVE-36132.
+  const noop = useCallback(() => {}, []);
+
+  const labels = useMemo(
+    () => ({
+      title: t("payTab.request.title", { asset: STUB_ASSET.name }),
+      networkLabel: t("payTab.request.networkLabel", { network: STUB_NETWORK }),
+      actions: {
+        share: t("payTab.request.actions.share"),
+        copy: t("payTab.request.actions.copy"),
+        copied: t("payTab.request.actions.copied"),
+        save: t("payTab.request.actions.save"),
+        verify: t("payTab.request.actions.verify"),
+      },
+    }),
+    [t],
+  );
+
+  const requestReceive = useMemo<RequestReceiveProps>(
+    () => ({
+      isOpen,
+      address: STUB_ADDRESS,
+      asset: STUB_ASSET,
+      network: STUB_NETWORK,
+      page: REQUEST_PAGE,
+      labels,
+      assetIcon: { ledgerId: "usd_coin", ticker: STUB_ASSET.ticker, network: "base" },
+      networkIcon: { ledgerId: "base", ticker: "ETH" },
+      visibleActions: ["save", "copy", "verify"],
+      onShare: noop,
+      onCopy,
+      onSave: noop,
+      onVerify: noop,
+      onClose,
+      onTrackEvent,
+    }),
+    [isOpen, labels, noop, onCopy, onClose, onTrackEvent],
+  );
+
+  return { open, requestReceive };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { CardLogin, type CardLoginOauthConfig } from "@features/flow-pay-card-auth";
 import { Balance } from "@features/flow-pay-card-balance";
 import { DepositOptions } from "@features/flow-pay-card-deposit";
+import { RequestReceive } from "@features/flow-pay-card-request";
 import { getEnv } from "@shared/env";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import PayTabHeader from "./components/PayTabHeader";
@@ -10,6 +11,7 @@ import { FeatureTour } from "@features/flow-pay-card-feature-tour";
 import { usePayTabFeatureTour } from "./hooks/usePayTabFeatureTour";
 import { usePayTabActionTiles } from "./hooks/usePayTabActionTiles";
 import { usePayTabDepositOptions } from "./hooks/usePayTabDepositOptions";
+import { usePayTabRequestReceive } from "./hooks/usePayTabRequestReceive";
 import { usePayStablecoins } from "./hooks/usePayStablecoins";
 
 // Baanx uses the same value for the client key header and the OAuth `client_id`.
@@ -26,7 +28,8 @@ const PayTab = () => {
     balance.onTrackEvent,
     defaultStablecoins.map(stablecoin => stablecoin.id),
   );
-  const actionTiles = usePayTabActionTiles(balance.onTrackEvent, deposit.open);
+  const request = usePayTabRequestReceive(balance.onTrackEvent);
+  const actionTiles = usePayTabActionTiles(balance.onTrackEvent, deposit.open, request.open);
 
   return (
     <div className="flex flex-col gap-24">
@@ -34,6 +37,7 @@ const PayTab = () => {
       <PayTabHeader />
       <Balance {...balance} actionTiles={actionTiles} />
       <DepositOptions {...deposit.depositOptions} />
+      <RequestReceive {...request.requestReceive} />
       <CardLogin oauthConfig={oauthConfig} />
       <FeatureTour {...featureTour} />
     </div>

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -926,6 +926,17 @@
           "description": "Buy stablecoins with credit card."
         }
       }
+    },
+    "request": {
+      "title": "Request {{asset}}",
+      "networkLabel": "{{network}} network",
+      "actions": {
+        "share": "Share",
+        "copy": "Copy",
+        "copied": "Copied",
+        "save": "Save",
+        "verify": "Verify"
+      }
     }
   },
   "lend": {

--- a/features/flow/pay-card-request/README.md
+++ b/features/flow/pay-card-request/README.md
@@ -4,8 +4,9 @@
 > **Status: UNSTABLE** — In active development; API may change.
 
 Dual-platform flow package for the Pay tab **Request receive-screen** experience for Ledger Wallet:
-a shared view-model and (soon) receive-screen component (QR, highlighted address, action slot,
-shareable card) consumed by the platform presentations on desktop and mobile.
+a shared view-model and receive-screen component (highlighted address, action tiles) consumed by
+the platform presentations on desktop and mobile. QR rendering and the shareable card are added
+separately (LIVE-36118 / LIVE-36121).
 
 ## View-model
 
@@ -45,6 +46,45 @@ Each action emits `button_clicked { button, buttonLocation: "request", page }` v
 
 ## Components
 
+### `RequestReceive`
+
+Receive dialog/screen for the Pay Request flow. It consumes `useRequestReceiveViewModel` and renders
+the asset icon, network row, highlighted address and the action tiles. The host injects copy,
+icons, the visible actions and the side-effect callbacks; the component stays i18n-, device- and
+navigation-agnostic.
+
+> Web only for now — the native screen is delivered with the LWM wiring (LIVE-35188), and the
+> branded QR is added via `@shared/qr-code` (LIVE-36118).
+
+```tsx
+import { RequestReceive } from "@features/flow-pay-card-request";
+
+<RequestReceive
+  isOpen={isOpen}
+  address={address}
+  asset={{ name: "USD Coin", ticker: "USDC" }}
+  network="Base"
+  page="Pay"
+  labels={{
+    title: "Request USD Coin",
+    networkLabel: "Base network",
+    actions: { share: "Share", copy: "Copy", copied: "Copied", save: "Save", verify: "Verify" },
+  }}
+  assetIcon={{ ledgerId: "usd_coin", ticker: "USDC", network: "base" }}
+  networkIcon={{ ledgerId: "base", ticker: "ETH" }}
+  visibleActions={["save", "copy", "verify"]}
+  onShare={shareCard}
+  onCopy={copyToClipboard}
+  onSave={saveCardImage}
+  onVerify={verifyOnDevice}
+  onClose={close}
+  onTrackEvent={track}
+/>;
+```
+
+`visibleActions` controls which tiles render, in order. Desktop uses `["save", "copy", "verify"]`;
+mobile will use `["share", "verify"]`. The Copy tile flips to the `copied` label briefly after use.
+
 ### `VerifyAddress`
 
 On-device address-verification overlay used by the Pay Request receive screen. It renders two
@@ -81,6 +121,10 @@ Only views carry a platform suffix (`.web` / `.native`). The container, view-mod
 are platform-agnostic and import without a suffix; TypeScript `moduleSuffixes`, the bundlers
 (Rspack / Metro) and the jest preset resolve the right side.
 
+Each view also has a test importing it through its full platform filename. Dead-code analysis
+(knip) reads only the solution `tsconfig.json`, which declares no `moduleSuffixes`, so a suffixed
+file it can reach through no other path would be reported as dead.
+
 ## Structure
 
 Every `index.*` is a pure barrel (`export *` only).
@@ -98,7 +142,10 @@ pay-card-request/
     │   └── __tests__/
     └── components/
         ├── RequestReceive/
-        │   ├── useRequestReceiveViewModel.ts   # pure VM: display data + tracked handlers
+        │   ├── RequestReceive.tsx                 # Container (platform-agnostic)
+        │   ├── useRequestReceiveViewModel.ts      # pure VM: display data + tracked handlers
+        │   ├── RequestReceiveView.web.tsx         # Dialog (LWD)
+        │   ├── RequestReceiveView.native.tsx      # Stub until LIVE-35188
         │   └── __tests__/
         └── VerifyAddress/
             ├── VerifyAddress.tsx                  # Container; switches phase

--- a/features/flow/pay-card-request/package.json
+++ b/features/flow/pay-card-request/package.json
@@ -28,6 +28,7 @@
     "unimported": "pnpm knip --directory ../../.. -W features/flow/pay-card-request"
   },
   "dependencies": {
+    "@ledgerhq/crypto-icons": "catalog:",
     "@shared/ui-queued-bottom-sheet": "workspace:*"
   },
   "devDependencies": {

--- a/features/flow/pay-card-request/src/components/RequestReceive/RequestReceive.tsx
+++ b/features/flow/pay-card-request/src/components/RequestReceive/RequestReceive.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { RequestReceiveView } from "./RequestReceiveView";
+import { useRequestReceiveViewModel } from "./useRequestReceiveViewModel";
+import type { RequestReceiveProps } from "../../types";
+
+export function RequestReceive(props: RequestReceiveProps) {
+  const vm = useRequestReceiveViewModel(props);
+
+  return <RequestReceiveView {...props} {...vm} />;
+}

--- a/features/flow/pay-card-request/src/components/RequestReceive/RequestReceiveActions.web.tsx
+++ b/features/flow/pay-card-request/src/components/RequestReceive/RequestReceiveActions.web.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { TileButton } from "@ledgerhq/lumen-ui-react";
+import { useRequestReceiveActions } from "./useRequestReceiveActions.web";
+import type { RequestReceiveActionId, RequestReceiveActionLabels } from "../../types";
+
+type RequestReceiveActionsProps = Readonly<{
+  labels: RequestReceiveActionLabels;
+  visibleActions: readonly RequestReceiveActionId[];
+  hasCopied: boolean;
+  onShare: () => void;
+  onCopy: () => void;
+  onSave: () => void;
+  onVerify: () => void;
+}>;
+
+export function RequestReceiveActions(props: RequestReceiveActionsProps) {
+  const tiles = useRequestReceiveActions(props);
+
+  return (
+    <div className="flex w-full flex-row gap-8">
+      {tiles.map(tile => (
+        <div key={tile.id} className="flex-1">
+          <TileButton icon={tile.icon} isFull onClick={tile.onClick} data-testid={tile.testId}>
+            {tile.label}
+          </TileButton>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/features/flow/pay-card-request/src/components/RequestReceive/RequestReceiveAddress.web.tsx
+++ b/features/flow/pay-card-request/src/components/RequestReceive/RequestReceiveAddress.web.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import type { AddressParts } from "../../utils/splitAddress";
+
+type RequestReceiveAddressProps = Readonly<{
+  addressParts: AddressParts;
+}>;
+
+export function RequestReceiveAddress({ addressParts }: RequestReceiveAddressProps) {
+  const { start, middle, end } = addressParts;
+
+  return (
+    <p className="break-all text-center pl-48 pr-48" data-testid="pay-card-request-receive-address">
+      <span className="body-2-semi-bold text-base">{start}</span>
+      <span className="body-2 text-muted">{middle}</span>
+      <span className="body-2-semi-bold text-base">{end}</span>
+    </p>
+  );
+}

--- a/features/flow/pay-card-request/src/components/RequestReceive/RequestReceiveSummary.web.tsx
+++ b/features/flow/pay-card-request/src/components/RequestReceive/RequestReceiveSummary.web.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { CryptoIcon } from "@ledgerhq/crypto-icons";
+import { RequestReceiveAddress } from "./RequestReceiveAddress.web";
+import type { RequestReceiveIconProps } from "../../types";
+import type { AddressParts } from "../../utils/splitAddress";
+
+const ASSET_ICON_SIZE = 48;
+const NETWORK_ICON_SIZE = 20;
+
+type RequestReceiveSummaryProps = Readonly<{
+  title: string;
+  networkLabel: string;
+  assetIcon: RequestReceiveIconProps;
+  networkIcon?: RequestReceiveIconProps;
+  addressParts: AddressParts;
+}>;
+
+export function RequestReceiveSummary({
+  title,
+  networkLabel,
+  assetIcon,
+  networkIcon,
+  addressParts,
+}: RequestReceiveSummaryProps) {
+  return (
+    <div className="flex flex-col items-center gap-32 bg-surface p-24 rounded-2xl">
+      <div className="flex flex-col items-center gap-8">
+        <span className="heading-3-semi-bold text-base">{title}</span>
+        <div
+          className="flex flex-row items-center gap-6"
+          data-testid="pay-card-request-receive-network"
+        >
+          {networkIcon ? (
+            <CryptoIcon
+              ledgerId={networkIcon.ledgerId}
+              ticker={networkIcon.ticker}
+              network={networkIcon.network}
+              size={NETWORK_ICON_SIZE}
+              shape="circle"
+            />
+          ) : null}
+          <span className="body-2 text-muted">{networkLabel}</span>
+        </div>
+      </div>
+
+      <div className="flex flex-col items-center gap-8">
+        <CryptoIcon
+          ledgerId={assetIcon.ledgerId}
+          ticker={assetIcon.ticker}
+          size={ASSET_ICON_SIZE}
+          shape="circle"
+        />
+        <RequestReceiveAddress addressParts={addressParts} />
+      </div>
+    </div>
+  );
+}

--- a/features/flow/pay-card-request/src/components/RequestReceive/RequestReceiveView.native.tsx
+++ b/features/flow/pay-card-request/src/components/RequestReceive/RequestReceiveView.native.tsx
@@ -1,0 +1,7 @@
+import type { RequestReceiveViewProps } from "../../types";
+
+// Native receive screen is delivered separately (LIVE-35188). This stub keeps the shared
+// container importable on React Native without shipping an unfinished UI.
+export function RequestReceiveView(_props: RequestReceiveViewProps): null {
+  return null;
+}

--- a/features/flow/pay-card-request/src/components/RequestReceive/RequestReceiveView.web.tsx
+++ b/features/flow/pay-card-request/src/components/RequestReceive/RequestReceiveView.web.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { Dialog, DialogBody, DialogContent, DialogHeader } from "@ledgerhq/lumen-ui-react";
+import { RequestReceiveSummary } from "./RequestReceiveSummary.web";
+import { RequestReceiveActions } from "./RequestReceiveActions.web";
+import { useRequestReceiveView } from "./useRequestReceiveView.web";
+import type { RequestReceiveViewProps } from "../../types";
+
+export function RequestReceiveView({
+  isOpen,
+  labels,
+  assetIcon,
+  networkIcon,
+  visibleActions,
+  addressParts,
+  onClose,
+  onShare,
+  onCopy,
+  onSave,
+  onVerify,
+}: RequestReceiveViewProps) {
+  const { hasCopied, handleOpenChange, handleCopy } = useRequestReceiveView({
+    isOpen,
+    onClose,
+    onCopy,
+  });
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <Dialog open onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader onClose={onClose} />
+        <DialogBody className="flex flex-col gap-32" data-testid="pay-card-request-receive">
+          <RequestReceiveSummary
+            title={labels.title}
+            networkLabel={labels.networkLabel}
+            assetIcon={assetIcon}
+            networkIcon={networkIcon}
+            addressParts={addressParts}
+          />
+          <RequestReceiveActions
+            labels={labels.actions}
+            visibleActions={visibleActions}
+            hasCopied={hasCopied}
+            onShare={onShare}
+            onCopy={handleCopy}
+            onSave={onSave}
+            onVerify={onVerify}
+          />
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/flow/pay-card-request/src/components/RequestReceive/__tests__/RequestReceive.web.test.tsx
+++ b/features/flow/pay-card-request/src/components/RequestReceive/__tests__/RequestReceive.web.test.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { RequestReceive } from "../RequestReceive";
+import { RequestReceiveView } from "../RequestReceiveView.web";
+import { createRequestReceiveProps, REQUEST_RECEIVE_ADDRESS } from "./fixtures";
+import type { RequestReceiveProps } from "../../../types";
+
+function renderRequestReceive(overrides: Partial<RequestReceiveProps> = {}) {
+  const props = createRequestReceiveProps(overrides);
+  return { props, ...render(<RequestReceive {...props} />) };
+}
+
+describe("RequestReceive (Web)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders nothing while closed", () => {
+    renderRequestReceive({ isOpen: false });
+
+    expect(screen.queryByTestId("pay-card-request-receive")).toBeNull();
+  });
+
+  it("renders the title, network and highlighted address", () => {
+    renderRequestReceive();
+
+    expect(RequestReceiveView).toEqual(expect.any(Function));
+    expect(screen.getByTestId("pay-card-request-receive")).toBeVisible();
+    expect(screen.getByText("Request USD Coin")).toBeVisible();
+    expect(screen.getByText("Base network")).toBeVisible();
+    expect(screen.getByTestId("pay-card-request-receive-address")).toHaveTextContent(
+      REQUEST_RECEIVE_ADDRESS,
+    );
+  });
+
+  it("renders only the visible actions in order", () => {
+    renderRequestReceive({ visibleActions: ["save", "verify"] });
+
+    expect(screen.getByTestId("pay-card-request-receive-save")).toBeVisible();
+    expect(screen.getByTestId("pay-card-request-receive-verify")).toBeVisible();
+    expect(screen.queryByTestId("pay-card-request-receive-copy")).toBeNull();
+    expect(screen.queryByTestId("pay-card-request-receive-share")).toBeNull();
+  });
+
+  it("tracks then invokes the injected callbacks", async () => {
+    const user = userEvent.setup();
+    const { props } = renderRequestReceive();
+
+    await user.click(screen.getByTestId("pay-card-request-receive-save"));
+    expect(props.onTrackEvent).toHaveBeenCalledWith("button_clicked", {
+      button: "save",
+      buttonLocation: "request",
+      page: "Pay",
+    });
+    expect(props.onSave).toHaveBeenCalledWith(REQUEST_RECEIVE_ADDRESS);
+
+    await user.click(screen.getByTestId("pay-card-request-receive-verify"));
+    expect(props.onVerify).toHaveBeenCalledWith(REQUEST_RECEIVE_ADDRESS);
+  });
+
+  it("flips the copy tile to the copied label after copying", async () => {
+    const user = userEvent.setup();
+    const { props } = renderRequestReceive();
+
+    const copyTile = screen.getByTestId("pay-card-request-receive-copy");
+    expect(copyTile).toHaveTextContent("Copy");
+
+    await user.click(copyTile);
+
+    expect(props.onCopy).toHaveBeenCalledWith(REQUEST_RECEIVE_ADDRESS);
+    expect(screen.getByTestId("pay-card-request-receive-copy")).toHaveTextContent("Copied");
+  });
+
+  it("closes from the dialog close button", async () => {
+    const user = userEvent.setup();
+    const { props } = renderRequestReceive();
+
+    await user.click(screen.getByRole("button", { name: /close/i }));
+
+    expect(props.onClose).toHaveBeenCalled();
+  });
+});

--- a/features/flow/pay-card-request/src/components/RequestReceive/__tests__/RequestReceiveView.native.test.tsx
+++ b/features/flow/pay-card-request/src/components/RequestReceive/__tests__/RequestReceiveView.native.test.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react-native";
+import { RequestReceiveView } from "../RequestReceiveView.native";
+import { createRequestReceiveViewProps, REQUEST_RECEIVE_LABELS } from "./fixtures";
+
+describe("RequestReceiveView (Native)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders nothing until the native receive screen ships", () => {
+    render(<RequestReceiveView {...createRequestReceiveViewProps()} />);
+
+    expect(screen.queryByText(REQUEST_RECEIVE_LABELS.title)).toBeNull();
+    expect(screen.queryByText(REQUEST_RECEIVE_LABELS.networkLabel)).toBeNull();
+  });
+});

--- a/features/flow/pay-card-request/src/components/RequestReceive/__tests__/fixtures.ts
+++ b/features/flow/pay-card-request/src/components/RequestReceive/__tests__/fixtures.ts
@@ -1,0 +1,55 @@
+import type { RequestReceiveProps, RequestReceiveViewProps } from "../../../types";
+import { splitAddress } from "../../../utils/splitAddress";
+
+export const REQUEST_RECEIVE_ADDRESS = "0x1234567890abcdef1234567890abcdef";
+
+export const REQUEST_RECEIVE_LABELS: RequestReceiveProps["labels"] = {
+  title: "Request USD Coin",
+  networkLabel: "Base network",
+  actions: { share: "Share", copy: "Copy", copied: "Copied", save: "Save", verify: "Verify" },
+};
+
+export function createRequestReceiveProps(
+  overrides: Partial<RequestReceiveProps> = {},
+): RequestReceiveProps {
+  return {
+    isOpen: true,
+    address: REQUEST_RECEIVE_ADDRESS,
+    asset: { name: "USD Coin", ticker: "USDC" },
+    network: "Base",
+    page: "Pay",
+    labels: REQUEST_RECEIVE_LABELS,
+    assetIcon: { ledgerId: "usd_coin", ticker: "USDC", network: "base" },
+    networkIcon: { ledgerId: "base", ticker: "ETH" },
+    visibleActions: ["save", "copy", "verify"],
+    onShare: jest.fn(),
+    onCopy: jest.fn(),
+    onSave: jest.fn(),
+    onVerify: jest.fn(),
+    onClose: jest.fn(),
+    onTrackEvent: jest.fn(),
+    ...overrides,
+  };
+}
+
+export function createRequestReceiveViewProps(
+  overrides: Partial<RequestReceiveViewProps> = {},
+): RequestReceiveViewProps {
+  const {
+    asset: _asset,
+    network: _network,
+    page: _page,
+    onTrackEvent: _onTrackEvent,
+    ...shell
+  } = createRequestReceiveProps();
+
+  return {
+    ...shell,
+    addressParts: splitAddress(REQUEST_RECEIVE_ADDRESS),
+    onShare: jest.fn(),
+    onCopy: jest.fn(),
+    onSave: jest.fn(),
+    onVerify: jest.fn(),
+    ...overrides,
+  };
+}

--- a/features/flow/pay-card-request/src/components/RequestReceive/useRequestReceiveActions.web.ts
+++ b/features/flow/pay-card-request/src/components/RequestReceive/useRequestReceiveActions.web.ts
@@ -1,0 +1,68 @@
+import { useMemo } from "react";
+import { Check, Copy, Download, LedgerLogo, Share } from "@ledgerhq/lumen-ui-react/symbols";
+import type { RequestReceiveActionId, RequestReceiveActionLabels } from "../../types";
+
+type SymbolComponent = typeof Copy;
+
+export type RequestReceiveActionTile = Readonly<{
+  id: RequestReceiveActionId;
+  icon: SymbolComponent;
+  label: string;
+  onClick: () => void;
+  testId: string;
+}>;
+
+type UseRequestReceiveActionsParams = Readonly<{
+  labels: RequestReceiveActionLabels;
+  visibleActions: readonly RequestReceiveActionId[];
+  hasCopied: boolean;
+  onShare: () => void;
+  onCopy: () => void;
+  onSave: () => void;
+  onVerify: () => void;
+}>;
+
+export function useRequestReceiveActions({
+  labels,
+  visibleActions,
+  hasCopied,
+  onShare,
+  onCopy,
+  onSave,
+  onVerify,
+}: UseRequestReceiveActionsParams): readonly RequestReceiveActionTile[] {
+  return useMemo(() => {
+    const byId: Readonly<Record<RequestReceiveActionId, RequestReceiveActionTile>> = {
+      share: {
+        id: "share",
+        icon: Share,
+        label: labels.share,
+        onClick: onShare,
+        testId: "pay-card-request-receive-share",
+      },
+      copy: {
+        id: "copy",
+        icon: hasCopied ? Check : Copy,
+        label: hasCopied ? labels.copied : labels.copy,
+        onClick: onCopy,
+        testId: "pay-card-request-receive-copy",
+      },
+      save: {
+        id: "save",
+        icon: Download,
+        label: labels.save,
+        onClick: onSave,
+        testId: "pay-card-request-receive-save",
+      },
+      verify: {
+        id: "verify",
+        icon: LedgerLogo,
+        label: labels.verify,
+        onClick: onVerify,
+        testId: "pay-card-request-receive-verify",
+      },
+    };
+
+    return visibleActions.map(id => byId[id]);
+  }, [labels, visibleActions, hasCopied, onShare, onCopy, onSave, onVerify]);
+}

--- a/features/flow/pay-card-request/src/components/RequestReceive/useRequestReceiveView.web.ts
+++ b/features/flow/pay-card-request/src/components/RequestReceive/useRequestReceiveView.web.ts
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useState } from "react";
+
+const COPY_FEEDBACK_MS = 3000;
+
+type UseRequestReceiveViewParams = Readonly<{
+  isOpen: boolean;
+  onClose: () => void;
+  onCopy: () => void;
+}>;
+
+type UseRequestReceiveView = Readonly<{
+  hasCopied: boolean;
+  handleOpenChange: (open: boolean) => void;
+  handleCopy: () => void;
+}>;
+
+export function useRequestReceiveView({
+  isOpen,
+  onClose,
+  onCopy,
+}: UseRequestReceiveViewParams): UseRequestReceiveView {
+  const [hasCopied, setHasCopied] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setHasCopied(false);
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!hasCopied) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => setHasCopied(false), COPY_FEEDBACK_MS);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [hasCopied]);
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  const handleCopy = useCallback(() => {
+    onCopy();
+    setHasCopied(true);
+  }, [onCopy]);
+
+  return { hasCopied, handleOpenChange, handleCopy };
+}

--- a/features/flow/pay-card-request/src/components/RequestReceive/useRequestReceiveViewModel.ts
+++ b/features/flow/pay-card-request/src/components/RequestReceive/useRequestReceiveViewModel.ts
@@ -1,11 +1,13 @@
 import { useCallback, useMemo } from "react";
-import type { RequestReceiveViewModel, RequestReceiveViewModelParams } from "../../types";
+import type {
+  RequestReceiveActionId,
+  RequestReceiveViewModel,
+  RequestReceiveViewModelParams,
+} from "../../types";
 import { splitAddress } from "../../utils/splitAddress";
 
-type RequestActionId = "share" | "copy" | "save" | "verify";
-
 // Analytics button names per the Pay Tracking Plan (wording still to confirm with product).
-const TRACK_BUTTON: Readonly<Record<RequestActionId, string>> = {
+const TRACK_BUTTON: Readonly<Record<RequestReceiveActionId, string>> = {
   share: "share",
   copy: "copy address",
   save: "save",
@@ -26,7 +28,7 @@ export function useRequestReceiveViewModel({
   const addressParts = useMemo(() => splitAddress(address), [address]);
 
   const runAction = useCallback(
-    (id: RequestActionId, callback: (address: string) => void) => {
+    (id: RequestReceiveActionId, callback: (address: string) => void) => {
       onTrackEvent?.("button_clicked", {
         button: TRACK_BUTTON[id],
         buttonLocation: "request",

--- a/features/flow/pay-card-request/src/exports.ts
+++ b/features/flow/pay-card-request/src/exports.ts
@@ -1,5 +1,6 @@
 export * from "./components/VerifyAddress/VerifyAddress";
 export * from "./components/VerifyAddress/useVerifyAddressViewModel";
+export * from "./components/RequestReceive/RequestReceive";
 export * from "./components/RequestReceive/useRequestReceiveViewModel";
 export * from "./utils/splitAddress";
 export * from "./types";

--- a/features/flow/pay-card-request/src/types.ts
+++ b/features/flow/pay-card-request/src/types.ts
@@ -102,3 +102,49 @@ export type RequestReceiveViewModel = Readonly<{
   onSave: () => void;
   onVerify: () => void;
 }>;
+
+export type RequestReceiveActionId = "share" | "copy" | "save" | "verify";
+
+/**
+ * User-facing copy injected by the host app. Copy stays i18n-agnostic; `copied` is the transient
+ * label shown right after the address is copied.
+ */
+export type RequestReceiveActionLabels = Readonly<{
+  share: string;
+  copy: string;
+  copied: string;
+  save: string;
+  verify: string;
+}>;
+
+export type RequestReceiveLabels = Readonly<{
+  title: string;
+  networkLabel: string;
+  actions: RequestReceiveActionLabels;
+}>;
+
+/** Props for the branded `CryptoIcon` shown for the asset and (optionally) the network row. */
+export type RequestReceiveIconProps = Readonly<{
+  ledgerId: string;
+  ticker: string;
+  network?: string;
+}>;
+
+/** Presentation inputs shared by the container props and the view props. */
+type RequestReceiveShell = Readonly<{
+  isOpen: boolean;
+  labels: RequestReceiveLabels;
+  assetIcon: RequestReceiveIconProps;
+  networkIcon?: RequestReceiveIconProps;
+  /** Actions rendered, in order. Desktop uses `["save", "copy", "verify"]`. */
+  visibleActions: readonly RequestReceiveActionId[];
+  onClose: () => void;
+}>;
+
+export type RequestReceiveProps = RequestReceiveViewModelParams & RequestReceiveShell;
+
+export type RequestReceiveViewProps = RequestReceiveShell &
+  Pick<
+    RequestReceiveViewModel,
+    "address" | "addressParts" | "onShare" | "onCopy" | "onSave" | "onVerify"
+  >;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -955,6 +955,9 @@ importers:
       '@features/flow-pay-card-feature-tour':
         specifier: workspace:^
         version: link:../../features/flow/pay-card-feature-tour
+      '@features/flow-pay-card-request':
+        specifier: workspace:^
+        version: link:../../features/flow/pay-card-request
       '@features/platform-aggregated-assets':
         specifier: workspace:*
         version: link:../../features/platform/aggregated-assets
@@ -5996,6 +5999,9 @@ importers:
 
   features/flow/pay-card-request:
     dependencies:
+      '@ledgerhq/crypto-icons':
+        specifier: 'catalog:'
+        version: 2.0.4(@ledgerhq/lumen-design-core@0.1.25)(@ledgerhq/lumen-ui-react@0.1.53(@ledgerhq/lumen-design-core@0.1.25)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(@ledgerhq/lumen-ui-rnative@0.1.57(@ledgerhq/lumen-design-core@0.1.25)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@shared/ui-queued-bottom-sheet':
         specifier: workspace:*
         version: link:../../../shared/ui-queued-bottom-sheet
@@ -24685,7 +24691,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.1.4
       react-dom: 19.1.4
-      webpack: ^5.89.0
+      webpack: '*'
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -67920,7 +67926,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3(metro-transform-worker@0.83.3)
+      metro: 0.83.3
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -68044,54 +68050,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro@0.83.3(metro-transform-worker@0.83.3):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 1.3.8
-      chalk: 4.1.2
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.32.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0(metro@0.83.3)
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.3
-      metro-cache: 0.83.3
-      metro-cache-key: 0.83.3
-      metro-config: 0.83.3(metro-transform-worker@0.83.3)
-      metro-core: 0.83.3
-      metro-file-map: 0.83.3(metro@0.83.3)
-      metro-resolver: 0.83.3
-      metro-runtime: 0.83.3
-      metro-source-map: 0.83.3
-      metro-symbolicate: 0.83.3
-      metro-transform-plugins: 0.83.3
-      metro-transform-worker: 0.83.3
-      mime-types: 2.1.35
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 

--- a/support/jest-features-flow/mocks/passthrough-web.js
+++ b/support/jest-features-flow/mocks/passthrough-web.js
@@ -5,6 +5,16 @@ function resolveAvatarColor(identifier) {
   return `avatar-color:${identifier}`;
 }
 
+// Render the header's close button so tests can query getByRole("button", { name: /close/i }).
+function DialogHeader({ title, onClose }) {
+  return React.createElement(
+    "div",
+    undefined,
+    title === undefined ? null : React.createElement("h2", undefined, title),
+    React.createElement("button", { type: "button", "aria-label": "Close", onClick: onClose }),
+  );
+}
+
 function Avatar(avatarProps) {
   const { alt, fallbackColor, fallbackText, size = "md", ...props } = avatarProps;
   const hasAriaLabel = Object.hasOwn(avatarProps, "aria-label");
@@ -75,6 +85,7 @@ module.exports = new Proxy(
   {
     __esModule: true,
     Avatar,
+    DialogHeader,
     InteractiveIcon,
     resolveAvatarColor,
     Tooltip,


### PR DESCRIPTION
### 📝 Description

Implements the web `RequestReceive` dialog in `@features/flow-pay-card-request` and wires the desktop Pay tab **Request** tile to open it.

**Problem**: The Pay Request flow had a view-model (LIVE-36119) but no shared UI to display the requested asset, its network, the receive address, and the associated actions.

**Solution**: Add the shared web `RequestReceive` dialog and its sub-components:
- `RequestReceiveSummary` — asset `CryptoIcon`, network row (with optional network icon), and highlighted/truncated address.
- `RequestReceiveActions` — action tiles (`save`, `copy`, `verify`, `share`) driven by `visibleActions`, with transient "copied" feedback.
- View split into `useRequestReceiveView` / `useRequestReceiveActions` hooks (MVVM), consuming the existing `useRequestReceiveViewModel`.
- Desktop host: new `usePayTabRequestReceive` hook manages open state, i18n labels, and copy/save/verify callbacks; the Pay tab Request tile now opens the dialog.

The package stays i18n-agnostic — the host app injects all labels and icon props. QR and native views are intentionally out of scope for this pass (native view is a stub deferred to LIVE-35188).

Usage:

```tsx
<RequestReceive
  isOpen={isOpen}
  labels={labels}
  assetIcon={{ ledgerId, ticker }}
  visibleActions={["save", "copy", "verify"]}
  address={address}
  asset={asset}
  network={network}
  page="pay/request"
  onClose={onClose}
  onCopy={onCopy}
  onSave={onSave}
  onVerify={onVerify}
  onShare={onShare}
/>
```

### Screenshots


https://github.com/user-attachments/assets/8dd92317-964b-4fb4-887f-eadf2b86a018



### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-35189
- **ADR** (if any): N/A

[LIVE-36120]: https://ledgerhq.atlassian.net/browse/LIVE-36120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ