### PR TITLE
feat(braze): drop generateAnonymousId from identity (LIVE-34724)

### DIFF
--- a/.changeset/quiet-braze-ids.md
+++ b/.changeset/quiet-braze-ids.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": minor
+"live-mobile": minor
+"ledger-live-desktop": minor
+---
+
+Stop using generateAnonymousId for Braze identity

--- a/apps/ledger-live-desktop/src/renderer/braze/__tests__/brazeIdentity.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/braze/__tests__/brazeIdentity.test.ts
@@ -1,23 +1,9 @@
 import { UserId, DUMMY_USER_ID } from "@domain/entity-client-identity";
-import { generateAnonymousId } from "@ledgerhq/live-common/braze/anonymousUsers";
-import {
-  resolveDesktopBrazeUserId,
-  shouldPersistAnonymousBrazeId,
-  ensureLegacyAnonymousBrazeIdStored,
-} from "../brazeIdentity";
+import { resolveDesktopBrazeUserId } from "../brazeIdentity";
 
-jest.mock("@ledgerhq/live-common/braze/anonymousUsers", () => ({
-  generateAnonymousId: jest.fn(() => "anonymous_id_1"),
-}));
-
-const mockedGenerateAnonymousId = jest.mocked(generateAnonymousId);
 const REAL_USER_ID = UserId.fromString("11111111-1111-1111-1111-111111111111");
 
 describe("brazeIdentity", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   describe("resolveDesktopBrazeUserId", () => {
     it("returns null for dummy user id", () => {
       expect(
@@ -51,10 +37,9 @@ describe("brazeIdentity", () => {
             brazeOptOutIdentityCleanup: false,
           }),
         ).toBe("stored_anonymous");
-        expect(mockedGenerateAnonymousId).not.toHaveBeenCalled();
       });
 
-      it("generates anonymous id when opted out and none persisted", () => {
+      it("returns null when opted out and no anonymous id is persisted", () => {
         expect(
           resolveDesktopBrazeUserId({
             isTrackedUser: false,
@@ -62,7 +47,7 @@ describe("brazeIdentity", () => {
             anonymousBrazeId: null,
             brazeOptOutIdentityCleanup: false,
           }),
-        ).toBe("anonymous_id_1");
+        ).toBeNull();
       });
     });
 
@@ -87,37 +72,7 @@ describe("brazeIdentity", () => {
             brazeOptOutIdentityCleanup: true,
           }),
         ).toBeNull();
-        expect(mockedGenerateAnonymousId).not.toHaveBeenCalled();
       });
-    });
-  });
-
-  describe("shouldPersistAnonymousBrazeId", () => {
-    it("returns true when flag is off", () => {
-      expect(shouldPersistAnonymousBrazeId(false)).toBe(true);
-    });
-
-    it("returns false when flag is on", () => {
-      expect(shouldPersistAnonymousBrazeId(true)).toBe(false);
-    });
-  });
-
-  describe("ensureLegacyAnonymousBrazeIdStored", () => {
-    it("persists a generated anonymous id when legacy mode is active", () => {
-      expect(ensureLegacyAnonymousBrazeIdStored(null, false)).toEqual({
-        anonymousBrazeId: "anonymous_id_1",
-        action: { type: "SET_ANONYMOUS_BRAZE_ID", payload: "anonymous_id_1" },
-      });
-    });
-
-    it("returns null when an anonymous id is already stored", () => {
-      expect(ensureLegacyAnonymousBrazeIdStored("stored_anonymous", false)).toBeNull();
-      expect(mockedGenerateAnonymousId).not.toHaveBeenCalled();
-    });
-
-    it("returns null when brazeOptOutIdentityCleanup is enabled", () => {
-      expect(ensureLegacyAnonymousBrazeIdStored(null, true)).toBeNull();
-      expect(mockedGenerateAnonymousId).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/braze/brazeIdentity.ts
+++ b/apps/ledger-live-desktop/src/renderer/braze/brazeIdentity.ts
@@ -1,5 +1,4 @@
 import { type UserId, isDummyUserId } from "@domain/entity-client-identity";
-import { generateAnonymousId } from "@ledgerhq/live-common/braze/anonymousUsers";
 
 type ResolveDesktopBrazeUserIdArgs = {
   isTrackedUser: boolean;
@@ -15,36 +14,6 @@ export function resolveDesktopBrazeUserId({
   brazeOptOutIdentityCleanup,
 }: ResolveDesktopBrazeUserIdArgs): string | null {
   if (isDummyUserId(userId)) return null;
-
-  if (brazeOptOutIdentityCleanup) {
-    return isTrackedUser ? userId.exportUserIdForBraze() : null;
-  }
-
-  return isTrackedUser
-    ? userId.exportUserIdForBraze()
-    : (anonymousBrazeId ?? generateAnonymousId());
-}
-
-export function shouldPersistAnonymousBrazeId(brazeOptOutIdentityCleanup: boolean): boolean {
-  return !brazeOptOutIdentityCleanup;
-}
-
-export type LegacyAnonymousBrazeIdPersistenceAction = {
-  type: "SET_ANONYMOUS_BRAZE_ID";
-  payload: string;
-};
-
-export function ensureLegacyAnonymousBrazeIdStored(
-  anonymousBrazeId: string | null,
-  brazeOptOutIdentityCleanup: boolean,
-): { anonymousBrazeId: string; action: LegacyAnonymousBrazeIdPersistenceAction } | null {
-  if (!shouldPersistAnonymousBrazeId(brazeOptOutIdentityCleanup) || anonymousBrazeId) {
-    return null;
-  }
-
-  const id = generateAnonymousId();
-  return {
-    anonymousBrazeId: id,
-    action: { type: "SET_ANONYMOUS_BRAZE_ID", payload: id },
-  };
+  if (isTrackedUser) return userId.exportUserIdForBraze();
+  return brazeOptOutIdentityCleanup ? null : anonymousBrazeId;
 }

--- a/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
@@ -10,10 +10,7 @@ import { ALWAYS_ON_CATEGORY_ID } from "LLD/features/DynamicContent/utils/constan
 import { userIdSelector } from "@domain/entity-client-identity";
 import { useFeature } from "@features/platform-feature-flags";
 import { getBrazeConfig } from "~/braze-setup";
-import {
-  resolveDesktopBrazeUserId,
-  ensureLegacyAnonymousBrazeIdStored,
-} from "../braze/brazeIdentity";
+import { resolveDesktopBrazeUserId } from "../braze/brazeIdentity";
 import {
   ActionContentCard,
   CategoryContentCard,
@@ -182,15 +179,6 @@ export function useBraze() {
   const initBraze = useCallback(async () => {
     const brazeConfig = getBrazeConfig();
     const isPlaywright = !!getEnv("PLAYWRIGHT_RUN");
-
-    const legacyAnonymousBrazeIdPersistence = ensureLegacyAnonymousBrazeIdStored(
-      anonymousBrazeId.current,
-      brazeOptOutIdentityCleanupEnabled,
-    );
-    if (legacyAnonymousBrazeIdPersistence) {
-      anonymousBrazeId.current = legacyAnonymousBrazeIdPersistence.anonymousBrazeId;
-      dispatch(legacyAnonymousBrazeIdPersistence.action);
-    }
 
     const isInitialized = braze.initialize(brazeConfig.apiKey, {
       baseUrl: brazeConfig.endpoint,

--- a/apps/ledger-live-mobile/src/notifications/braze.test.ts
+++ b/apps/ledger-live-mobile/src/notifications/braze.test.ts
@@ -1,6 +1,5 @@
 import Braze from "@braze/react-native-sdk";
 import { UserId, DUMMY_USER_ID } from "@domain/entity-client-identity";
-import { generateAnonymousId } from "@ledgerhq/live-common/braze/anonymousUsers";
 import { start, updateUserPreferences } from "./braze";
 import type { NotificationsSettings } from "../reducers/types";
 
@@ -12,13 +11,8 @@ jest.mock("@braze/react-native-sdk", () => ({
   },
 }));
 
-jest.mock("@ledgerhq/live-common/braze/anonymousUsers", () => ({
-  generateAnonymousId: jest.fn(() => "anonymous_id_1"),
-}));
-
 const mockedChangeUser = jest.mocked(Braze.changeUser);
 const mockedSetCustomUserAttribute = jest.mocked(Braze.setCustomUserAttribute);
-const mockedGenerateAnonymousId = jest.mocked(generateAnonymousId);
 
 const defaultNotifications = {
   areNotificationsAllowed: true,
@@ -40,19 +34,16 @@ describe("start", () => {
     it("should call changeUser with real id when user is tracked", () => {
       start(true, REAL_USER_ID);
       expect(mockedChangeUser).toHaveBeenCalledWith(REAL_USER_ID.exportUserIdForBraze());
-      expect(mockedGenerateAnonymousId).not.toHaveBeenCalled();
     });
 
-    it("should call changeUser with anonymous id when user is opted out", () => {
+    it("should skip changeUser when user is opted out", () => {
       start(false, REAL_USER_ID);
-      expect(mockedGenerateAnonymousId).toHaveBeenCalled();
-      expect(mockedChangeUser).toHaveBeenCalledWith("anonymous_id_1");
+      expect(mockedChangeUser).not.toHaveBeenCalled();
     });
 
     it("should skip changeUser when user id is dummy", () => {
       start(true, DUMMY_USER_ID);
       expect(mockedChangeUser).not.toHaveBeenCalled();
-      expect(mockedGenerateAnonymousId).not.toHaveBeenCalled();
     });
   });
 
@@ -62,19 +53,16 @@ describe("start", () => {
     it("should call changeUser with real id when user is tracked", () => {
       start(true, REAL_USER_ID, options);
       expect(mockedChangeUser).toHaveBeenCalledWith(REAL_USER_ID.exportUserIdForBraze());
-      expect(mockedGenerateAnonymousId).not.toHaveBeenCalled();
     });
 
     it("should skip changeUser when user is opted out", () => {
       start(false, REAL_USER_ID, options);
       expect(mockedChangeUser).not.toHaveBeenCalled();
-      expect(mockedGenerateAnonymousId).not.toHaveBeenCalled();
     });
 
     it("should skip changeUser when user id is dummy", () => {
       start(false, DUMMY_USER_ID, options);
       expect(mockedChangeUser).not.toHaveBeenCalled();
-      expect(mockedGenerateAnonymousId).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/ledger-live-mobile/src/notifications/braze.ts
+++ b/apps/ledger-live-mobile/src/notifications/braze.ts
@@ -1,29 +1,17 @@
 import Braze from "@braze/react-native-sdk";
 import { type UserId, isDummyUserId } from "@domain/entity-client-identity";
 import { NotificationsSettings } from "../reducers/types";
-import { generateAnonymousId } from "@ledgerhq/live-common/braze/anonymousUsers";
 
 export type StartBrazeOptions = {
   brazeOptOutIdentityCleanup?: boolean;
 };
 
-export const start = (
-  isTrackedUser: boolean,
-  userId: UserId,
-  { brazeOptOutIdentityCleanup = false }: StartBrazeOptions = {},
-) => {
+export const start = (isTrackedUser: boolean, userId: UserId, _options: StartBrazeOptions = {}) => {
   if (isDummyUserId(userId)) return;
 
-  if (brazeOptOutIdentityCleanup) {
-    // Opted-out: do not call changeUser. Prior Braze profile wipe/reset is handled
-    // separately before this flag is enabled in production (see LIVE-34717).
-    if (isTrackedUser) {
-      Braze.changeUser(userId.exportUserIdForBraze());
-    }
-    return;
+  if (isTrackedUser) {
+    Braze.changeUser(userId.exportUserIdForBraze());
   }
-
-  Braze.changeUser(isTrackedUser ? userId.exportUserIdForBraze() : generateAnonymousId());
 };
 
 export type UpdateUserPreferencesOptions = {

--- a/libs/ledger-live-common/src/braze/anonymousUsers.test.ts
+++ b/libs/ledger-live-common/src/braze/anonymousUsers.test.ts
@@ -3,7 +3,7 @@ import { getOldCampaignIds, generateAnonymousId } from "./anonymousUsers";
 const millisecondsInAMonth = 30 * 24 * 60 * 60 * 1000;
 
 describe("anonymousUsers", () => {
-  test("generateAnonymousId should returns an id", () => {
+  test("generateAnonymousId should return an id (deprecated, not for identity)", () => {
     expect(generateAnonymousId()).toMatch(/anonymous_id_\d+/);
   });
   test("getOldCampaignIds should return old ids", () => {

--- a/libs/ledger-live-common/src/braze/anonymousUsers.ts
+++ b/libs/ledger-live-common/src/braze/anonymousUsers.ts
@@ -4,6 +4,10 @@ const MILLISECONDS_IN_A_MONTH = 30 * 24 * 60 * 60 * 1000;
 export const getBrazeCampaignCutoff = (now: Date) =>
   now.getTime() - NUMBER_OF_MONTHS * MILLISECONDS_IN_A_MONTH;
 
+/**
+ * @deprecated Not for Braze identity (`changeUser` / `external_id`).
+ * Campaign expiry helpers in this module do not use it.
+ */
 export const generateAnonymousId = () => {
   return "anonymous_id_" + (Math.floor(Math.random() * 20) + 1);
 };


### PR DESCRIPTION
### 📝 Description

[LIVE-34724](https://ledgerhq.atlassian.net/browse/LIVE-34724): stop using `generateAnonymousId()` as a Braze identity (`changeUser` / `external_id`). Campaign expiry helpers in the same module are unchanged.

- Mark `generateAnonymousId` `@deprecated` in live-common. No production identity path imports it.
- Mobile `start()` calls `changeUser` only for tracked users; opted-out never mints a fake id, even with `brazeOptOutIdentityCleanup` off.
- Desktop no longer generates or persists a new anonymous id. Flag-off opted-out still uses a stored `anonymousBrazeId` if one exists; otherwise it skips `changeUser`. Flag-on opted-out stays `null`.

This branch is stacked on [LIVE-34723](https://ledgerhq.atlassian.net/browse/LIVE-34723) (desktop Segment `updateIdentify({ force: true })` omits `userId` / `braze_external_id` when tracking is off). If that PR is not merged yet, set the base to `feat/LIVE-34723` (or keep develop and review both).

### Test plan

- [ ] Opted-in user still gets `changeUser` / Segment identify with the real user id
- [ ] Opted-out + flag off: no new `anonymous_id_*` is minted; desktop can still use a previously stored anonymous id
- [ ] Opted-out + `brazeOptOutIdentityCleanup` on: no Braze `changeUser`, no `braze_external_id` on forced Segment identify
- [ ] Dynamic content campaign expiry still works (`getOldCampaignIds` / `getBrazeCampaignCutoff`)
- [ ] Dummy user id still skips Braze identity

[LIVE-34724]: https://ledgerhq.atlassian.net/browse/LIVE-34724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-34723]: https://ledgerhq.atlassian.net/browse/LIVE-34723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ