### PR TITLE
[LWD] Hotfix: Sync bug (LIVE-36130)

### DIFF
--- a/.changeset/hungry-cheetahs-repeat.md
+++ b/.changeset/hungry-cheetahs-repeat.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix Ledger Sync being wiped on every launch when Password Lock is enabled. `app.trustchain` is an encrypted db path, so before unlock it read back as a ciphertext string; importing it regenerated member credentials, nulled the trustchain, and persisted that fresh state over the encrypted blob in plaintext. The import is now skipped while the value is still a string, and trustchain writes are suppressed while the app is locked.

--- a/.changeset/hungry-cheetahs-repeat.md
+++ b/.changeset/hungry-cheetahs-repeat.md
@@ -2,4 +2,4 @@
 "ledger-live-desktop": patch
 ---
 
-Fix Ledger Sync being wiped on every launch when Password Lock is enabled. `app.trustchain` is an encrypted db path, so before unlock it read back as a ciphertext string; importing it regenerated member credentials, nulled the trustchain, and persisted that fresh state over the encrypted blob in plaintext. The import is now skipped while the value is still a string, and trustchain writes are suppressed while the app is locked.
+Fix Ledger Sync being wiped on every launch when Password Lock is enabled. `app.trustchain` is an encrypted db path, so before unlock it reads back as a ciphertext string; importing it regenerated member credentials, nulled the trustchain, and persisted that fresh state over the encrypted blob in plaintext. The import is now skipped while the value is still a string, and trustchain writes are suppressed while the app is locked.

--- a/apps/ledger-live-desktop/src/renderer/actions/trustchain.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/trustchain.test.ts
@@ -55,8 +55,6 @@ describe("fetchTrustchain", () => {
   });
 
   it("should not dispatch when storage returns an encrypted string (app is password-locked)", async () => {
-    // `app.trustchain` is an encrypted db path: before unlock it reads back as ciphertext.
-    // Importing it would wipe the persisted trustchain and mint new credentials (LIVE-36130).
     jest.mocked(getKey).mockResolvedValue("6a9f1c...ciphertext..." as unknown as TrustchainStore);
 
     await fetchTrustchain()(dispatch, jest.fn(), undefined);

--- a/apps/ledger-live-desktop/src/renderer/actions/trustchain.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/trustchain.test.ts
@@ -53,4 +53,15 @@ describe("fetchTrustchain", () => {
       },
     });
   });
+
+  it("should not dispatch when storage returns an encrypted string (app is password-locked)", async () => {
+    // `app.trustchain` is an encrypted db path: before unlock it reads back as ciphertext.
+    // Importing it would wipe the persisted trustchain and mint new credentials (LIVE-36130).
+    jest.mocked(getKey).mockResolvedValue("6a9f1c...ciphertext..." as unknown as TrustchainStore);
+
+    await fetchTrustchain()(dispatch, jest.fn(), undefined);
+
+    expect(getKey).toHaveBeenCalledWith("app", "trustchain");
+    expect(dispatch).not.toHaveBeenCalled();
+  });
 });

--- a/apps/ledger-live-desktop/src/renderer/actions/trustchain.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/trustchain.ts
@@ -5,10 +5,7 @@ import { ThunkResult } from "./types";
 export const fetchTrustchain =
   (): ThunkResult<Promise<void>> => async (dispatch, _getState, _extra) => {
     const data = await getKey("app", "trustchain");
-    // NB `app.trustchain` is an encrypted db path: while the app is password-locked it reads back
-    // as the ciphertext string. Importing it would regenerate member credentials and null the
-    // trustchain (LIVE-36130). IsUnlocked re-runs this thunk once the encryption key is set.
-    // `undefined` must still go through: that is the legitimate "nothing persisted" case.
-    if (typeof data === "string") return;
+    const dataIsEncrypted = typeof data === "string";
+    if (dataIsEncrypted) return;
     dispatch(importTrustchainStoreState(data));
   };

--- a/apps/ledger-live-desktop/src/renderer/actions/trustchain.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/trustchain.ts
@@ -5,5 +5,10 @@ import { ThunkResult } from "./types";
 export const fetchTrustchain =
   (): ThunkResult<Promise<void>> => async (dispatch, _getState, _extra) => {
     const data = await getKey("app", "trustchain");
+    // NB `app.trustchain` is an encrypted db path: while the app is password-locked it reads back
+    // as the ciphertext string. Importing it would regenerate member credentials and null the
+    // trustchain (LIVE-36130). IsUnlocked re-runs this thunk once the encryption key is set.
+    // `undefined` must still go through: that is the legitimate "nothing persisted" case.
+    if (typeof data === "string") return;
     dispatch(importTrustchainStoreState(data));
   };

--- a/apps/ledger-live-desktop/src/renderer/middlewares/__tests__/db.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/__tests__/db.test.ts
@@ -318,3 +318,34 @@ describe("DBMiddleware - coinConfigOverrides branch", () => {
     expect(mockedSetKey).toHaveBeenCalledWith("app", "coinConfigOverrides", { overrides: {} });
   });
 });
+
+describe("DBMiddleware - trustchain branch", () => {
+  beforeEach(() => {
+    mockedSetKey.mockReset();
+  });
+
+  it("persists the trustchain on TRUSTCHAIN_STORE_* actions when the app is unlocked", () => {
+    const state: FakeState = {
+      ...baseState(),
+      trustchain: { trustchain: { rootId: "root-id" }, memberCredentials: { pubkey: "ab" } },
+    };
+
+    runMiddleware([state, state], { type: "TRUSTCHAIN_STORE_IMPORT_STATE" });
+
+    expect(mockedSetKey).toHaveBeenCalledWith("app", "trustchain", state.trustchain);
+  });
+
+  it("does not persist the trustchain while the app is locked", () => {
+    // app.trustchain is an encrypted path: writing before setEncryptionKey would overwrite the
+    // ciphertext on disk with plaintext and destroy the persisted trustchain (LIVE-36130).
+    const state: FakeState = {
+      ...baseState(),
+      application: { isLocked: true },
+      trustchain: { trustchain: null, memberCredentials: { pubkey: "ab" } },
+    };
+
+    runMiddleware([state, state], { type: "TRUSTCHAIN_STORE_IMPORT_STATE" });
+
+    expect(mockedSetKey).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/middlewares/__tests__/db.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/__tests__/db.test.ts
@@ -336,8 +336,6 @@ describe("DBMiddleware - trustchain branch", () => {
   });
 
   it("does not persist the trustchain while the app is locked", () => {
-    // app.trustchain is an encrypted path: writing before setEncryptionKey would overwrite the
-    // ciphertext on disk with plaintext and destroy the persisted trustchain (LIVE-36130).
     const state: FakeState = {
       ...baseState(),
       application: { isLocked: true },

--- a/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
@@ -92,7 +92,9 @@ const DBMiddleware: Middleware<object, State> = store => next => action => {
   if (action.type.startsWith(trustchainStoreActionTypePrefix)) {
     const res = next(action);
     const state = store.getState();
-    setKey("app", "trustchain", trustchainStoreSelector(state));
+    if (!state.application.isLocked) {
+      setKey("app", "trustchain", trustchainStoreSelector(state));
+    }
     return res;
   }
 


### PR DESCRIPTION
### 📝 Description

When the desktop app was locked with a password the Ledger Sync was failing:

1. Attempts to read existing records would fail (because the records were encrypted)
2. New records were being created and added to the apps managed by Ledger Sync

The fix:

1. Don't try to read the record if the device is locked
2. Don't try to write the record if the device is locked

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36130](https://ledgerhq.atlassian.net/browse/LIVE-36130) — regression from https://github.com/LedgerHQ/ledger-live/pull/19634
- **ADR** (if any): n/a

PR targeting develop: https://github.com/LedgerHQ/ledger-live/pull/20894

[LIVE-36130]: https://ledgerhq.atlassian.net/browse/LIVE-36130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ