### PR TITLE
[LWDM] feat(contacts): introduce prefilled Add Address flow (LIVE-35745)

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/prefillAddAddress/PrefillAddAddressFlowRoot.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/prefillAddAddress/PrefillAddAddressFlowRoot.tsx
@@ -1,0 +1,219 @@
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { v4 as uuid } from "uuid";
+import {
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  addAddress,
+  contactAddress,
+  type ContactAddress,
+} from "@domain/entity-contact";
+import {
+  useAddAddressFlowViewModel,
+  type AddAddressCompletionLabels,
+  type ContactsAddAddressNameLabels,
+  type ContactsAddAddressReviewLabels,
+  type OpenPrefillAddAddressParams,
+  type OpenPrefillAddAddressResult,
+} from "@features/flow-contacts";
+import { createMockContactDeviceIntentsPort, useContacts } from "@features/platform-contacts";
+import { useDispatch } from "LLD/hooks/redux";
+import { ContactsAddAddressFlowDialog } from "../../screens/Contacts/components/ContactsAddAddressFlowDialog";
+import type { ContactsAddAddressFlowDialogProps } from "../../screens/Contacts/components/ContactsAddAddressFlowDialog/types";
+import { useContactsAddressValidationAdapter } from "../useContactsAddressValidationAdapter";
+import { setPrefillAddAddressFlowListener } from "./prefillAddAddressFlowStore";
+
+type PendingRequest = Readonly<{
+  resolve: (result: OpenPrefillAddAddressResult) => void;
+}>;
+
+export function PrefillAddAddressFlowRoot(): React.JSX.Element | null {
+  const dispatch = useDispatch();
+  const { t } = useTranslation();
+  const contacts = useContacts();
+  const deviceIntents = useMemo(() => createMockContactDeviceIntentsPort(), []);
+  const addressValidation = useContactsAddressValidationAdapter();
+  const pendingRequest = useRef<PendingRequest | null>(null);
+  const {
+    state,
+    startWithPrefilled,
+    updateAddressLabel,
+    continueFromName,
+    continueFromReview,
+    goBack,
+    close,
+  } = useAddAddressFlowViewModel({ addressValidation });
+
+  const settle = useCallback((result: OpenPrefillAddAddressResult) => {
+    pendingRequest.current?.resolve(result);
+    pendingRequest.current = null;
+  }, []);
+
+  const onClose = useCallback(() => {
+    close();
+    settle({ status: "cancelled" });
+  }, [close, settle]);
+
+  const onBack = useCallback(() => {
+    if (state.status === "namingAddress" && state.entryMode === "prefilled") {
+      onClose();
+      return;
+    }
+    goBack();
+  }, [goBack, onClose, state]);
+
+  const saveFromReview = useCallback(async () => {
+    if (state.status !== "reviewingAddress" || state.entryMode !== "prefilled") {
+      return;
+    }
+
+    const selectedContact = contacts.find(contact => contact.id === state.selectedContactId);
+    if (selectedContact === undefined) {
+      close();
+      settle({ status: "confirmation_failed" });
+      return;
+    }
+
+    try {
+      const signedAddress = await deviceIntents.registerExternalAddress({
+        contact: selectedContact,
+        currencyId: state.selectedCurrencyId,
+        label: state.addressLabel.label,
+        address: state.addressEntry.resolvedAddress,
+      });
+      const address: ContactAddress = contactAddress({
+        id: `address-${uuid()}`,
+        currencyId: state.selectedCurrencyId,
+        label: state.addressLabel.label,
+        address: state.addressEntry.resolvedAddress,
+        device: signedAddress.addressDeviceContext,
+      });
+
+      dispatch(
+        addAddress({
+          contactId: state.selectedContactId,
+          address,
+          deviceCredentials: signedAddress.deviceCredentials,
+        }),
+      );
+      continueFromReview();
+      close();
+      settle({ status: "saved", address });
+    } catch {
+      close();
+      settle({ status: "confirmation_failed" });
+    }
+  }, [close, contacts, continueFromReview, deviceIntents, dispatch, settle, state]);
+
+  const openPrefillAddAddressFlow = useCallback(
+    async (params: OpenPrefillAddAddressParams): Promise<OpenPrefillAddAddressResult> => {
+      const contact = contacts.find(item => item.id === params.contactId);
+      if (contact === undefined) {
+        return { status: "unavailable" };
+      }
+
+      const startResult = await startWithPrefilled({
+        contact,
+        address: params.address,
+        currency: params.currency,
+        network: params.network,
+      });
+
+      if (startResult.status !== "started") {
+        return startResult;
+      }
+
+      return new Promise<OpenPrefillAddAddressResult>(resolve => {
+        pendingRequest.current = { resolve };
+      });
+    },
+    [contacts, startWithPrefilled],
+  );
+
+  useEffect(() => {
+    setPrefillAddAddressFlowListener(openPrefillAddAddressFlow);
+    return () => setPrefillAddAddressFlowListener(null);
+  }, [openPrefillAddAddressFlow]);
+
+  const nameLabels = useMemo<ContactsAddAddressNameLabels>(
+    () => ({
+      inputLabel: t("contacts.addAddressName.inputLabel"),
+      namingDisclaimer: t("contacts.addAddressName.namingDisclaimer"),
+      namingDisclaimerAccessibilityLabel: t(
+        "contacts.addAddressName.namingDisclaimerAccessibilityLabel",
+      ),
+      continueToReview: t("contacts.addAddressName.continueToReview"),
+      validationErrors: {
+        [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.invalidLabel"),
+        [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.duplicateLabel"),
+        [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: t("contacts.addAddressName.tooLongLabel"),
+      },
+    }),
+    [t],
+  );
+  const reviewLabels = useMemo<ContactsAddAddressReviewLabels>(
+    () => ({
+      title: t("contacts.addAddressReview.title"),
+      addressLabel: t("contacts.addAddressReview.addressLabel"),
+      currencyLabel: t("contacts.addAddressReview.currencyLabel"),
+      networkLabel: t("contacts.addAddressReview.networkLabel"),
+      nameLabel: t("contacts.addAddressReview.nameLabel"),
+      continue: t("contacts.addAddressReview.continue"),
+    }),
+    [t],
+  );
+  const completionLabels = useMemo<AddAddressCompletionLabels>(
+    () => ({
+      title: t("contacts.addAddressReview.title"),
+      continue: t("contacts.addAddressReview.continue"),
+      successTitle: t("contacts.addAddressReview.successTitle"),
+      close: t("contacts.addAddressReview.close"),
+    }),
+    [t],
+  );
+
+  if (
+    state.status === "closed" ||
+    state.status === "selectingCurrency" ||
+    state.entryMode !== "prefilled"
+  ) {
+    return null;
+  }
+
+  const dialogProps: ContactsAddAddressFlowDialogProps = {
+    state,
+    entryLabels: {
+      title: t("contacts.addAddressEntry.title"),
+      addressPlaceholder: t("contacts.addAddressEntry.addressPlaceholder"),
+      confirmAddress: t("contacts.addAddressEntry.confirmAddress"),
+      validatingAddress: t("contacts.addAddressEntry.validatingAddress"),
+      validAddress: t("contacts.addAddressEntry.validAddress"),
+      invalidAddress: t("contacts.addAddressEntry.invalidAddress"),
+      domainNotFound: t("contacts.addAddressEntry.domainNotFound"),
+      sanctionedAddress: t("contacts.addAddressEntry.sanctionedAddress"),
+      validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
+      ensDisclaimer: t("contacts.addAddressEntry.ensDisclaimer"),
+    },
+    sanctionedAddressBanner: {
+      description: t("contacts.addAddressEntry.sanctioned.description"),
+      actionLabel: t("contacts.addAddressEntry.sanctioned.learnMore"),
+      onAction: () => undefined,
+    },
+    nameLabels,
+    reviewLabels,
+    completionLabels,
+    onAddressChange: () => undefined,
+    onContinueFromAddressDetails: () => undefined,
+    onAddressLabelChange: updateAddressLabel,
+    onContinueFromName: continueFromName,
+    onContinueFromReview: () => {
+      void saveFromReview();
+    },
+    onCompleteMockConfirmation: () => undefined,
+    onBack,
+    onClose,
+  };
+
+  return <ContactsAddAddressFlowDialog {...dialogProps} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/prefillAddAddress/index.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/prefillAddAddress/index.ts
@@ -1,0 +1,2 @@
+export { PrefillAddAddressFlowRoot } from "./PrefillAddAddressFlowRoot";
+export { useOpenPrefillAddAddressFlow } from "./useOpenPrefillAddAddressFlow";

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/prefillAddAddress/prefillAddAddressFlowStore.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/prefillAddAddress/prefillAddAddressFlowStore.test.ts
@@ -1,0 +1,33 @@
+import { requestPrefillAddAddressFlow, setPrefillAddAddressFlowListener } from "./prefillAddAddressFlowStore";
+
+describe("prefillAddAddressFlowStore", () => {
+  afterEach(() => {
+    setPrefillAddAddressFlowListener(null);
+  });
+
+  it("should reject when the root is not mounted", async () => {
+    await expect(
+      requestPrefillAddAddressFlow({
+        contactId: "contact-1" as never,
+        address: "0xabc",
+        currency: { currencyId: "ethereum" as never, assetDisplayName: "Ethereum" },
+        network: { networkId: "ethereum", displayName: "Ethereum" },
+      }),
+    ).rejects.toThrow("PrefillAddAddressFlowRoot is not mounted");
+  });
+
+  it("should forward open requests to the registered listener", async () => {
+    const listener = jest.fn().mockResolvedValue({ status: "cancelled" });
+    setPrefillAddAddressFlowListener(listener);
+
+    const params = {
+      contactId: "contact-1" as never,
+      address: "0xabc",
+      currency: { currencyId: "ethereum" as never, assetDisplayName: "Ethereum" },
+      network: { networkId: "ethereum", displayName: "Ethereum" },
+    };
+
+    await expect(requestPrefillAddAddressFlow(params)).resolves.toEqual({ status: "cancelled" });
+    expect(listener).toHaveBeenCalledWith(params);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/prefillAddAddress/prefillAddAddressFlowStore.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/prefillAddAddress/prefillAddAddressFlowStore.ts
@@ -1,0 +1,26 @@
+import type {
+  OpenPrefillAddAddressParams,
+  OpenPrefillAddAddressResult,
+} from "@features/flow-contacts";
+
+type PrefillAddAddressFlowListener = (
+  params: OpenPrefillAddAddressParams,
+) => Promise<OpenPrefillAddAddressResult>;
+
+let listener: PrefillAddAddressFlowListener | null = null;
+
+export function setPrefillAddAddressFlowListener(
+  nextListener: PrefillAddAddressFlowListener | null,
+): void {
+  listener = nextListener;
+}
+
+export function requestPrefillAddAddressFlow(
+  params: OpenPrefillAddAddressParams,
+): Promise<OpenPrefillAddAddressResult> {
+  if (listener === null) {
+    return Promise.reject(new Error("PrefillAddAddressFlowRoot is not mounted"));
+  }
+
+  return listener(params);
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/prefillAddAddress/useOpenPrefillAddAddressFlow.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/prefillAddAddress/useOpenPrefillAddAddressFlow.ts
@@ -1,0 +1,19 @@
+import { useCallback } from "react";
+import type {
+  OpenPrefillAddAddressParams,
+  OpenPrefillAddAddressResult,
+} from "@features/flow-contacts";
+import { requestPrefillAddAddressFlow } from "./prefillAddAddressFlowStore";
+
+/**
+ * Public entry point for Send and other consumers to open the prefilled Add Address flow.
+ * Requires PrefillAddAddressFlowRoot to be mounted.
+ */
+export function useOpenPrefillAddAddressFlow(): (
+  params: OpenPrefillAddAddressParams,
+) => Promise<OpenPrefillAddAddressResult> {
+  return useCallback(
+    (params: OpenPrefillAddAddressParams) => requestPrefillAddAddressFlow(params),
+    [],
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/index.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/index.ts
@@ -1,2 +1,6 @@
 export { ContactsButton } from "./components/ContactsButton";
 export { default } from "./screens/Contacts";
+export {
+  PrefillAddAddressFlowRoot,
+  useOpenPrefillAddAddressFlow,
+} from "./hooks/prefillAddAddress";

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/ContactsAddAddressFlowDialog.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/ContactsAddAddressFlowDialog.tsx
@@ -15,6 +15,7 @@ export function ContactsAddAddressFlowDialog({
   sanctionedAddressBanner,
   nameLabels,
   reviewLabels,
+  completionLabels,
   onAddressChange,
   onContinueFromAddressDetails,
   onAddressLabelChange,
@@ -39,10 +40,11 @@ export function ContactsAddAddressFlowDialog({
             modularDialog.content
           ) : (
             <ContactsAddAddressFlowContent
-              completionLabels={reviewLabels}
+              completionLabels={completionLabels}
               entryLabels={entryLabels}
               sanctionedAddressBanner={sanctionedAddressBanner}
               nameLabels={nameLabels}
+              reviewLabels={reviewLabels}
               onAddressChange={onAddressChange}
               onAddressLabelChange={onAddressLabelChange}
               onClose={onClose}

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/index.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/index.ts
@@ -1,2 +1,2 @@
 export { ContactsAddAddressFlowDialog } from "./ContactsAddAddressFlowDialog";
-export type { ContactsAddAddressFlowDialogProps, ContactsAddAddressReviewLabels } from "./types";
+export type { ContactsAddAddressFlowDialogProps } from "./types";

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/types.ts
@@ -4,10 +4,9 @@ import type {
   AddAddressInputSource,
   ContactsAddAddressEntryLabels,
   ContactsAddAddressNameLabels,
+  ContactsAddAddressReviewLabels,
   SanctionedAddressBannerProps,
 } from "@features/flow-contacts";
-
-export type ContactsAddAddressReviewLabels = AddAddressCompletionLabels;
 
 export type ContactsAddAddressFlowDialogProps = Readonly<{
   state: AddAddressFlowState;
@@ -15,6 +14,7 @@ export type ContactsAddAddressFlowDialogProps = Readonly<{
   sanctionedAddressBanner: SanctionedAddressBannerProps;
   nameLabels: ContactsAddAddressNameLabels;
   reviewLabels: ContactsAddAddressReviewLabels;
+  completionLabels: AddAddressCompletionLabels;
   onAddressChange: (address: string, inputMethod: AddAddressInputSource) => void;
   onContinueFromAddressDetails: () => void;
   onAddressLabelChange: (value: string) => void;

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -53,8 +53,11 @@ import { useContactDetailEditDeleteAdapter } from "./useContactDetailEditDeleteA
 import { useDispatch } from "LLD/hooks/redux";
 import type {
   ContactsAddAddressFlowDialogProps,
-  ContactsAddAddressReviewLabels,
 } from "./components/ContactsAddAddressFlowDialog";
+import type {
+  AddAddressCompletionLabels,
+  ContactsAddAddressReviewLabels,
+} from "@features/flow-contacts";
 
 export type ContactsPageViewModel = Omit<ContactsViewProps, "onAddContact"> &
   Readonly<{
@@ -228,7 +231,6 @@ export function useContactsViewModel(): ContactsPageViewModel {
         "contacts.addAddressName.namingDisclaimerAccessibilityLabel",
       ),
       continueToReview: t("contacts.addAddressName.continueToReview"),
-      validAddress: t("contacts.addAddressEntry.validAddress"),
       validationErrors: {
         [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.invalidLabel"),
         [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.duplicateLabel"),
@@ -238,6 +240,17 @@ export function useContactsViewModel(): ContactsPageViewModel {
     [t],
   );
   const addAddressReviewLabels = useMemo<ContactsAddAddressReviewLabels>(
+    () => ({
+      title: t("contacts.addAddressReview.title"),
+      addressLabel: t("contacts.addAddressReview.addressLabel"),
+      currencyLabel: t("contacts.addAddressReview.currencyLabel"),
+      networkLabel: t("contacts.addAddressReview.networkLabel"),
+      nameLabel: t("contacts.addAddressReview.nameLabel"),
+      continue: t("contacts.addAddressReview.continue"),
+    }),
+    [t],
+  );
+  const addAddressCompletionLabels = useMemo<AddAddressCompletionLabels>(
     () => ({
       title: t("contacts.addAddressReview.title"),
       continue: t("contacts.addAddressReview.continue"),
@@ -257,6 +270,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
       },
       nameLabels: addAddressNameLabels,
       reviewLabels: addAddressReviewLabels,
+      completionLabels: addAddressCompletionLabels,
       onAddressChange: (address, inputMethod) => {
         void updateAddress(address, inputMethod);
       },
@@ -273,6 +287,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
       handleSanctionedAddressLearnMore,
       addAddressNameLabels,
       addAddressReviewLabels,
+      addAddressCompletionLabels,
       addAddressFlowState,
       onBackAddAddress,
       onCloseAddAddress,

--- a/apps/ledger-live-desktop/src/mvvm/features/GlobalDialogs/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GlobalDialogs/index.tsx
@@ -3,6 +3,7 @@ import ModularDialogRoot from "LLD/features/ModularDialog/ModularDialogRoot";
 import SendFlowRoot from "LLD/features/Send/SendFlowRoot";
 import PerpsSignRoot from "LLD/features/Perps/screens/PerpsSign/PerpsSignDialog";
 import ActionConfirmationDialog from "LLD/features/ActionConfirmationDialog";
+import { PrefillAddAddressFlowRoot } from "LLD/features/Contacts";
 
 const ReleaseNotes = lazy(() => import("LLD/features/ReleaseNotes"));
 const BuyDevice = lazy(() => import("LLD/features/BuyDevice"));
@@ -24,6 +25,7 @@ const GlobalDialogs = () => (
     <Suspense fallback={null}>
       <SendFlowRoot />
     </Suspense>
+    <PrefillAddAddressFlowRoot />
     <PerpsSignRoot />
     <ActionConfirmationDialog />
     <Suspense fallback={null}>

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9409,6 +9409,10 @@
     },
     "addAddressReview": {
       "title": "Review address",
+      "addressLabel": "Address",
+      "currencyLabel": "Currency",
+      "networkLabel": "Network",
+      "nameLabel": "Address name",
       "continue": "Confirm address",
       "successTitle": "Address saved",
       "close": "Close"

--- a/apps/ledger-live-mobile/src/GlobalDrawers/__tests__/registry.test.ts
+++ b/apps/ledger-live-mobile/src/GlobalDrawers/__tests__/registry.test.ts
@@ -3,6 +3,7 @@ import { ModularDrawerWrapper } from "LLM/features/ModularDrawer";
 import ReceiveDrawerWrapper from "LLM/features/Receive/drawers/ReceiveFundsOptionsDrawer";
 import { NotificationsPromptWrapper } from "LLM/features/NotificationsPrompt";
 import { SwapTransactionStatusDrawerWrapper } from "LLM/features/SwapTransactionStatus";
+import { PrefillAddAddressFlowRoot } from "LLM/features/Contacts";
 
 describe("GlobalDrawers Registry", () => {
   it("should contain all expected drawer entries with correct components", () => {
@@ -19,6 +20,9 @@ describe("GlobalDrawers Registry", () => {
     expect(DRAWER_REGISTRY.swapTransactionStatus.component).toBe(
       SwapTransactionStatusDrawerWrapper,
     );
+
+    expect(DRAWER_REGISTRY.prefillAddAddress).toBeDefined();
+    expect(DRAWER_REGISTRY.prefillAddAddress.component).toBe(PrefillAddAddressFlowRoot);
   });
 
   it("should have all entries with valid structure", () => {

--- a/apps/ledger-live-mobile/src/GlobalDrawers/registry.ts
+++ b/apps/ledger-live-mobile/src/GlobalDrawers/registry.ts
@@ -5,6 +5,7 @@ import RebornBuyDeviceDrawer from "LLM/features/Reborn/drawers/RebornBuyDeviceDr
 import { DeeplinkInstallAppDrawer } from "LLM/features/DeeplinkInstallApp";
 import { NotificationsPromptWrapper } from "LLM/features/NotificationsPrompt";
 import { SwapTransactionStatusDrawerWrapper } from "LLM/features/SwapTransactionStatus";
+import { PrefillAddAddressFlowRoot } from "LLM/features/Contacts";
 
 /**
  * Registry of all global drawers in the application.
@@ -36,6 +37,9 @@ export const DRAWER_REGISTRY = {
   },
   swapTransactionStatus: {
     component: SwapTransactionStatusDrawerWrapper,
+  },
+  prefillAddAddress: {
+    component: PrefillAddAddressFlowRoot,
   },
 } as const satisfies Record<string, DrawerRegistryEntry>;
 

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10318,6 +10318,14 @@
       "duplicateLabel": "This address name is already used for this contact.",
       "labelTooLong": "This address name is too long."
     },
+    "addAddressReview": {
+      "title": "Review address",
+      "addressLabel": "Address",
+      "currencyLabel": "Currency",
+      "networkLabel": "Network",
+      "nameLabel": "Address name",
+      "continue": "Confirm address"
+    },
     "addressCount_zero": "0 address",
     "addressCount_one": "{{count}} address",
     "addressCount_other": "{{count}} addresses",

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/prefillAddAddress/PrefillAddAddressFlowRoot.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/prefillAddAddress/PrefillAddAddressFlowRoot.tsx
@@ -1,0 +1,245 @@
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import { v4 as uuid } from "uuid";
+import {
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  addAddress,
+  contactAddress,
+  type ContactAddress,
+} from "@domain/entity-contact";
+import {
+  ContactsAddAddressFlowContent,
+  useAddAddressFlowViewModel,
+  type ContactsAddAddressReviewLabels,
+  type OpenPrefillAddAddressParams,
+  type OpenPrefillAddAddressResult,
+} from "@features/flow-contacts";
+import { createMockContactDeviceIntentsPort, useContacts } from "@features/platform-contacts";
+import {
+  QueuedDrawerFlow,
+  type QueuedDrawerFlowOptions,
+  type QueuedDrawerFlowScreenRegistry,
+} from "LLM/components/QueuedDrawerFlow";
+import { useDispatch } from "~/context/hooks";
+import { useTranslation } from "~/context/Locale";
+import { useContactsAddressValidationAdapter } from "../useContactsAddressValidationAdapter";
+import { setPrefillAddAddressFlowListener } from "./prefillAddAddressFlowStore";
+
+type PrefillDrawerStep = "name" | "review";
+
+type PendingRequest = Readonly<{
+  resolve: (result: OpenPrefillAddAddressResult) => void;
+}>;
+
+const FLOW_OPTIONS = {
+  snapPoints: ["92%"],
+} as const satisfies QueuedDrawerFlowOptions;
+
+const LOCKED_STEP_OPTIONS = {
+  hasBackButton: true,
+  noCloseButton: true,
+  hideHandle: true,
+  preventBackdropClick: true,
+  enablePanDownToClose: false,
+} as const satisfies QueuedDrawerFlowOptions;
+
+function resolveStep(status: "namingAddress" | "reviewingAddress"): PrefillDrawerStep {
+  return status === "namingAddress" ? "name" : "review";
+}
+
+export function PrefillAddAddressFlowRoot(): React.JSX.Element | null {
+  const dispatch = useDispatch();
+  const { t } = useTranslation();
+  const contacts = useContacts();
+  const deviceIntents = useMemo(() => createMockContactDeviceIntentsPort(), []);
+  const addressValidation = useContactsAddressValidationAdapter();
+  const pendingRequest = useRef<PendingRequest | null>(null);
+  const {
+    state,
+    startWithPrefilled,
+    updateAddressLabel,
+    continueFromName,
+    continueFromReview,
+    goBack,
+    close,
+  } = useAddAddressFlowViewModel({ addressValidation });
+
+  const settle = useCallback((result: OpenPrefillAddAddressResult) => {
+    pendingRequest.current?.resolve(result);
+    pendingRequest.current = null;
+  }, []);
+
+  const onClose = useCallback(() => {
+    close();
+    settle({ status: "cancelled" });
+  }, [close, settle]);
+
+  const onBack = useCallback(() => {
+    if (state.status === "namingAddress") {
+      onClose();
+      return;
+    }
+    goBack();
+  }, [goBack, onClose, state.status]);
+
+  const saveFromReview = useCallback(async () => {
+    if (state.status !== "reviewingAddress" || state.entryMode !== "prefilled") {
+      return;
+    }
+
+    const selectedContact = contacts.find(contact => contact.id === state.selectedContactId);
+    if (selectedContact === undefined) {
+      close();
+      settle({ status: "confirmation_failed" });
+      return;
+    }
+
+    try {
+      const signedAddress = await deviceIntents.registerExternalAddress({
+        contact: selectedContact,
+        currencyId: state.selectedCurrencyId,
+        label: state.addressLabel.label,
+        address: state.addressEntry.resolvedAddress,
+      });
+      const address: ContactAddress = contactAddress({
+        id: `address-${uuid()}`,
+        currencyId: state.selectedCurrencyId,
+        label: state.addressLabel.label,
+        address: state.addressEntry.resolvedAddress,
+        device: signedAddress.addressDeviceContext,
+      });
+
+      dispatch(
+        addAddress({
+          contactId: state.selectedContactId,
+          address,
+          deviceCredentials: signedAddress.deviceCredentials,
+        }),
+      );
+      continueFromReview();
+      close();
+      settle({ status: "saved", address });
+    } catch {
+      close();
+      settle({ status: "confirmation_failed" });
+    }
+  }, [close, contacts, continueFromReview, deviceIntents, dispatch, settle, state]);
+
+  const openPrefillAddAddressFlow = useCallback(
+    async (params: OpenPrefillAddAddressParams): Promise<OpenPrefillAddAddressResult> => {
+      const contact = contacts.find(item => item.id === params.contactId);
+      if (contact === undefined) {
+        return { status: "unavailable" };
+      }
+
+      const startResult = await startWithPrefilled({
+        contact,
+        address: params.address,
+        currency: params.currency,
+        network: params.network,
+      });
+
+      if (startResult.status !== "started") {
+        return startResult;
+      }
+
+      return new Promise<OpenPrefillAddAddressResult>(resolve => {
+        pendingRequest.current = { resolve };
+      });
+    },
+    [contacts, startWithPrefilled],
+  );
+
+  useEffect(() => {
+    setPrefillAddAddressFlowListener(openPrefillAddAddressFlow);
+    return () => setPrefillAddAddressFlowListener(null);
+  }, [openPrefillAddAddressFlow]);
+
+  const reviewLabels = useMemo<ContactsAddAddressReviewLabels>(
+    () => ({
+      title: t("contacts.addAddressReview.title"),
+      addressLabel: t("contacts.addAddressReview.addressLabel"),
+      currencyLabel: t("contacts.addAddressReview.currencyLabel"),
+      networkLabel: t("contacts.addAddressReview.networkLabel"),
+      nameLabel: t("contacts.addAddressReview.nameLabel"),
+      continue: t("contacts.addAddressReview.continue"),
+    }),
+    [t],
+  );
+
+  if (
+    (state.status !== "namingAddress" && state.status !== "reviewingAddress") ||
+    state.entryMode !== "prefilled"
+  ) {
+    return null;
+  }
+
+  const currentStep = resolveStep(state.status);
+  const screens: QueuedDrawerFlowScreenRegistry<PrefillDrawerStep> = {
+    name: {
+      content: (
+        <ContactsAddAddressFlowContent
+          addressEntryProps={null}
+          addressNameProps={{
+            addressLabel: state.addressLabel,
+            labels: {
+              title: t("contacts.addAddressName.title"),
+              inputLabel: t("contacts.addAddressName.inputLabel"),
+              namingDisclaimer: t("contacts.addAddressName.namingDisclaimer"),
+              continueToReview: t("contacts.addAddressName.continueToReview"),
+              validationErrors: {
+                [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t(
+                  "contacts.addAddressName.invalidLabel",
+                ),
+                [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t(
+                  "contacts.addAddressName.duplicateLabel",
+                ),
+                [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: t(
+                  "contacts.addAddressName.labelTooLong",
+                ),
+              },
+            },
+            onChangeText: updateAddressLabel,
+            onContinue: continueFromName,
+          }}
+          addressReviewProps={null}
+          step="name"
+        />
+      ),
+      options: LOCKED_STEP_OPTIONS,
+    },
+    review: {
+      content: (
+        <ContactsAddAddressFlowContent
+          addressEntryProps={null}
+          addressNameProps={null}
+          addressReviewProps={{
+            address: state.addressEntry.resolvedAddress,
+            currency: state.displayContext.assetDisplayName,
+            network: state.displayContext.network.displayName,
+            name: state.addressLabel.label,
+            labels: reviewLabels,
+            onContinue: () => {
+              void saveFromReview();
+            },
+          }}
+          step="review"
+        />
+      ),
+      options: LOCKED_STEP_OPTIONS,
+    },
+  };
+
+  return (
+    <QueuedDrawerFlow
+      currentStep={currentStep}
+      defaultOptions={FLOW_OPTIONS}
+      isOpen
+      onBack={onBack}
+      onClose={onClose}
+      screens={screens}
+      testID="contacts-prefill-add-address-flow-drawer"
+    />
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/prefillAddAddress/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/prefillAddAddress/index.ts
@@ -1,0 +1,2 @@
+export { PrefillAddAddressFlowRoot } from "./PrefillAddAddressFlowRoot";
+export { useOpenPrefillAddAddressFlow } from "./useOpenPrefillAddAddressFlow";

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/prefillAddAddress/prefillAddAddressFlowStore.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/prefillAddAddress/prefillAddAddressFlowStore.test.ts
@@ -1,0 +1,36 @@
+import {
+  requestPrefillAddAddressFlow,
+  setPrefillAddAddressFlowListener,
+} from "./prefillAddAddressFlowStore";
+
+describe("prefillAddAddressFlowStore", () => {
+  afterEach(() => {
+    setPrefillAddAddressFlowListener(null);
+  });
+
+  it("should reject when the root is not mounted", async () => {
+    await expect(
+      requestPrefillAddAddressFlow({
+        contactId: "contact-1" as never,
+        address: "0xabc",
+        currency: { currencyId: "ethereum" as never, assetDisplayName: "Ethereum" },
+        network: { networkId: "ethereum", displayName: "Ethereum" },
+      }),
+    ).rejects.toThrow("PrefillAddAddressFlowRoot is not mounted");
+  });
+
+  it("should forward open requests to the registered listener", async () => {
+    const listener = jest.fn().mockResolvedValue({ status: "cancelled" });
+    setPrefillAddAddressFlowListener(listener);
+
+    const params = {
+      contactId: "contact-1" as never,
+      address: "0xabc",
+      currency: { currencyId: "ethereum" as never, assetDisplayName: "Ethereum" },
+      network: { networkId: "ethereum", displayName: "Ethereum" },
+    };
+
+    await expect(requestPrefillAddAddressFlow(params)).resolves.toEqual({ status: "cancelled" });
+    expect(listener).toHaveBeenCalledWith(params);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/prefillAddAddress/prefillAddAddressFlowStore.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/prefillAddAddress/prefillAddAddressFlowStore.ts
@@ -1,0 +1,26 @@
+import type {
+  OpenPrefillAddAddressParams,
+  OpenPrefillAddAddressResult,
+} from "@features/flow-contacts";
+
+type PrefillAddAddressFlowListener = (
+  params: OpenPrefillAddAddressParams,
+) => Promise<OpenPrefillAddAddressResult>;
+
+let listener: PrefillAddAddressFlowListener | null = null;
+
+export function setPrefillAddAddressFlowListener(
+  nextListener: PrefillAddAddressFlowListener | null,
+): void {
+  listener = nextListener;
+}
+
+export function requestPrefillAddAddressFlow(
+  params: OpenPrefillAddAddressParams,
+): Promise<OpenPrefillAddAddressResult> {
+  if (listener === null) {
+    return Promise.reject(new Error("PrefillAddAddressFlowRoot is not mounted"));
+  }
+
+  return listener(params);
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/prefillAddAddress/useOpenPrefillAddAddressFlow.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/prefillAddAddress/useOpenPrefillAddAddressFlow.ts
@@ -1,0 +1,19 @@
+import { useCallback } from "react";
+import type {
+  OpenPrefillAddAddressParams,
+  OpenPrefillAddAddressResult,
+} from "@features/flow-contacts";
+import { requestPrefillAddAddressFlow } from "./prefillAddAddressFlowStore";
+
+/**
+ * Public entry point for Send and other consumers to open the prefilled Add Address flow.
+ * Requires PrefillAddAddressFlowRoot to be mounted.
+ */
+export function useOpenPrefillAddAddressFlow(): (
+  params: OpenPrefillAddAddressParams,
+) => Promise<OpenPrefillAddAddressResult> {
+  return useCallback(
+    (params: OpenPrefillAddAddressParams) => requestPrefillAddAddressFlow(params),
+    [],
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/index.ts
@@ -1,3 +1,7 @@
 export { ContactsButton } from "./components/ContactsButton";
 export { ContactsScreen } from "./screens/ContactsPage";
 export type { ContactAddressDetailActionsFlowProps } from "./hooks/useContactAddressDetailActionsAdapter";
+export {
+  PrefillAddAddressFlowRoot,
+  useOpenPrefillAddAddressFlow,
+} from "./hooks/prefillAddAddress";

--- a/features/flow/contacts/README.md
+++ b/features/flow/contacts/README.md
@@ -18,6 +18,8 @@ Shared Contacts flow package for Desktop and Mobile.
 - Contacts orchestration through `ContactsView`, which composes List, Detail, and Introduction
   journeys
 - Add Address session, address-entry validation state, and address-label state
+- Prefill Add Address entry (`startWithPrefilled` / `OpenPrefillAddAddressParams`) that bypasses
+  MAD and address entry and starts on the naming screen
 - Add Address network eligibility and final currency selection state (MAD integration uses an
   injected selection port)
 - Shared UI components (`.web.tsx` / `.native.tsx`)

--- a/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressNameView.web.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressNameView.web.test.tsx
@@ -3,22 +3,16 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import {
   CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
   ContactAddressLabelSchema,
-  ContactAddressValueSchema,
   DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
 } from "@domain/entity-contact";
 import { ContactsAddAddressNameView } from "./ContactsAddAddressNameView.web";
 import type { ContactsAddAddressNameViewProps } from "./types";
 
-const RESOLVED_ADDRESS = ContactAddressValueSchema.parse(
-  "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
-);
-
 function createProps(
   overrides: Partial<ContactsAddAddressNameViewProps> = {},
 ): ContactsAddAddressNameViewProps {
   return {
-    address: RESOLVED_ADDRESS,
     addressLabel: {
       status: "valid",
       value: "Ethereum",
@@ -30,7 +24,6 @@ function createProps(
       namingDisclaimer: "Address naming disclaimer",
       namingDisclaimerAccessibilityLabel: "Address name information",
       continueToReview: "Continue to review",
-      validAddress: "Valid address",
       validationErrors: {
         [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: "Special characters are not allowed.",
         [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]:
@@ -46,17 +39,15 @@ function createProps(
 }
 
 describe("ContactsAddAddressNameView", () => {
-  it("should render the address details and forward input actions", () => {
+  it("should render only the name input with disclaimer and forward actions", () => {
     const onAddressLabelChange = jest.fn();
     const onContinue = jest.fn();
 
     render(<ContactsAddAddressNameView {...createProps({ onAddressLabelChange, onContinue })} />);
 
-    expect(screen.getByTestId("contacts-add-address-confirmed-input")).toHaveAttribute(
-      "value",
-      RESOLVED_ADDRESS,
-    );
+    expect(screen.queryByTestId("contacts-add-address-confirmed-input")).not.toBeInTheDocument();
     expect(screen.getByTestId("contacts-add-address-name-input")).toHaveValue("Ethereum");
+    expect(screen.getByTestId("contacts-add-address-name-disclaimer")).toBeInTheDocument();
 
     fireEvent.change(screen.getByTestId("contacts-add-address-name-input"), {
       target: { value: "Exchange" },

--- a/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressNameView.web.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressNameView.web.tsx
@@ -1,11 +1,10 @@
 import React from "react";
-import { AddressInput, Button, TextInput } from "@ledgerhq/lumen-ui-react";
+import { Banner, Button, TextInput } from "@ledgerhq/lumen-ui-react";
 import { LedgerLogo } from "@ledgerhq/lumen-ui-react/symbols";
 import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "@domain/entity-contact";
 import type { ContactsAddAddressNameViewProps } from "./types";
 
 export function ContactsAddAddressNameView({
-  address,
   addressLabel,
   labels,
   validationMessage,
@@ -15,23 +14,12 @@ export function ContactsAddAddressNameView({
 }: ContactsAddAddressNameViewProps): React.JSX.Element {
   return (
     <div className="flex flex-col gap-24">
-      <AddressInput
-        autoComplete="off"
-        autoCorrect="off"
-        data-testid="contacts-add-address-confirmed-input"
-        helperText={labels.validAddress}
-        hideClearButton
-        prefix=""
-        readOnly
-        spellCheck={false}
-        status="success"
-        value={address}
-      />
       <TextInput
         autoComplete="off"
         autoCorrect="off"
         data-testid="contacts-add-address-name-input"
         helperText={validationMessage}
+        hideClearButton
         label={labels.inputLabel}
         maxCount={CONTACT_ADDRESS_LABEL_MAX_LENGTH}
         maxLength={CONTACT_ADDRESS_LABEL_MAX_LENGTH}
@@ -39,6 +27,11 @@ export function ContactsAddAddressNameView({
         spellCheck={false}
         status={addressLabel.status === "invalid" ? "error" : undefined}
         value={addressLabel.value}
+      />
+      <Banner
+        appearance="info"
+        data-testid="contacts-add-address-name-disclaimer"
+        description={labels.namingDisclaimer}
       />
       <Button
         appearance="base"

--- a/features/flow/contacts/src/steps/AddAddress/AddressName/Input/ContactsAddAddressNameInput.web.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/AddressName/Input/ContactsAddAddressNameInput.web.test.tsx
@@ -5,25 +5,14 @@ import {
   DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   ContactAddressLabelSchema,
-  ContactAddressValueSchema,
 } from "@domain/entity-contact";
 import { ContactsAddAddressNameInput } from "./ContactsAddAddressNameInput.web";
 import type { ContactsAddAddressNameProps } from "../types";
-
-const RESOLVED_ADDRESS = ContactAddressValueSchema.parse(
-  "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
-);
 
 function createProps(
   overrides: Partial<ContactsAddAddressNameProps> = {},
 ): ContactsAddAddressNameProps {
   return {
-    addressEntry: {
-      status: "valid",
-      value: RESOLVED_ADDRESS,
-      resolvedAddress: RESOLVED_ADDRESS,
-      inputMethod: "manual",
-    },
     addressLabel: {
       status: "valid",
       value: "Ethereum",
@@ -35,7 +24,6 @@ function createProps(
       namingDisclaimer: "Address naming disclaimer",
       namingDisclaimerAccessibilityLabel: "Address name information",
       continueToReview: "Continue to review",
-      validAddress: "Valid address",
       validationErrors: {
         [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: "Special characters are not allowed.",
         [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]:
@@ -51,18 +39,16 @@ function createProps(
 }
 
 describe("ContactsAddAddressNameInput", () => {
-  it("should render the confirmed address and prefilled label with the 32-character limit", () => {
+  it("should render only the name input with the 32-character limit", () => {
     render(<ContactsAddAddressNameInput {...createProps()} />);
 
-    expect(screen.getByTestId("contacts-add-address-confirmed-input")).toHaveAttribute(
-      "value",
-      RESOLVED_ADDRESS,
-    );
+    expect(screen.queryByTestId("contacts-add-address-confirmed-input")).not.toBeInTheDocument();
     expect(screen.getByTestId("contacts-add-address-name-input")).toHaveValue("Ethereum");
     expect(screen.getByTestId("contacts-add-address-name-input")).toHaveAttribute(
       "maxlength",
       "32",
     );
+    expect(screen.getByTestId("contacts-add-address-name-disclaimer")).toBeInTheDocument();
     expect(screen.getByTestId("contacts-add-address-name-continue")).toBeEnabled();
   });
 

--- a/features/flow/contacts/src/steps/AddAddress/AddressName/types.ts
+++ b/features/flow/contacts/src/steps/AddAddress/AddressName/types.ts
@@ -1,22 +1,16 @@
 import type { ChangeEvent } from "react";
 import type { ContactAddressLabelValidationErrorName } from "@domain/entity-contact";
-import type {
-  AddAddressLabelState,
-  AddAddressNameLabels,
-  ValidAddAddressEntryState,
-} from "../types";
+import type { AddAddressLabelState, AddAddressNameLabels } from "../types";
 
 export type ContactsAddAddressNameLabels = Readonly<{
   inputLabel: string;
   namingDisclaimer: string;
   namingDisclaimerAccessibilityLabel: string;
   continueToReview: string;
-  validAddress: string;
   validationErrors: Record<ContactAddressLabelValidationErrorName, string>;
 }>;
 
 export type ContactsAddAddressNameProps = Readonly<{
-  addressEntry: ValidAddAddressEntryState;
   addressLabel: AddAddressLabelState;
   labels: ContactsAddAddressNameLabels;
   onAddressLabelChange: (value: string) => void;
@@ -24,7 +18,6 @@ export type ContactsAddAddressNameProps = Readonly<{
 }>;
 
 export type ContactsAddAddressNameViewProps = Readonly<{
-  address: string;
   addressLabel: AddAddressLabelState;
   labels: ContactsAddAddressNameLabels;
   validationMessage?: string;

--- a/features/flow/contacts/src/steps/AddAddress/AddressName/useContactsAddAddressNameViewModel.web.ts
+++ b/features/flow/contacts/src/steps/AddAddress/AddressName/useContactsAddAddressNameViewModel.web.ts
@@ -2,7 +2,6 @@ import { useCallback, useMemo, type ChangeEvent } from "react";
 import type { ContactsAddAddressNameProps, ContactsAddAddressNameViewProps } from "./types";
 
 export function useContactsAddAddressNameViewModel({
-  addressEntry,
   addressLabel,
   labels,
   onAddressLabelChange,
@@ -21,7 +20,6 @@ export function useContactsAddAddressNameViewModel({
   );
 
   return {
-    address: addressEntry.value,
     addressLabel,
     labels,
     validationMessage,

--- a/features/flow/contacts/src/steps/AddAddress/Flow/ContactsAddAddressFlowContent.native.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/Flow/ContactsAddAddressFlowContent.native.tsx
@@ -4,15 +4,20 @@ import { ContactsAddAddressEntry } from "../ContactsAddAddressEntry.native";
 import type { ContactsAddAddressEntryProps } from "../ContactsAddAddressEntry.types";
 import { ContactsAddAddressName } from "../AddressName/ContactsAddAddressName.native";
 import type { ContactsAddAddressNameNativeProps } from "../AddressName/types";
+import {
+  ContactsAddAddressReview,
+  type ContactsAddAddressReviewNativeProps,
+} from "../Review/ContactsAddAddressReview.native";
 
 const STEP_FRAME_HEIGHT = "100%";
 
-export type ContactsAddAddressNativeFlowStep = "address" | "name";
+export type ContactsAddAddressNativeFlowStep = "address" | "name" | "review";
 
 export type ContactsAddAddressFlowContentProps = Readonly<{
   step: ContactsAddAddressNativeFlowStep;
   addressEntryProps: ContactsAddAddressEntryProps | null;
   addressNameProps: ContactsAddAddressNameNativeProps | null;
+  addressReviewProps?: ContactsAddAddressReviewNativeProps | null;
 }>;
 
 function ContactsAddAddressStepFrame({ children }: React.PropsWithChildren): React.JSX.Element {
@@ -27,6 +32,7 @@ export function ContactsAddAddressFlowContent({
   step,
   addressEntryProps,
   addressNameProps,
+  addressReviewProps = null,
 }: ContactsAddAddressFlowContentProps): React.JSX.Element | null {
   switch (step) {
     case "address":
@@ -39,6 +45,12 @@ export function ContactsAddAddressFlowContent({
       return addressNameProps ? (
         <ContactsAddAddressStepFrame>
           <ContactsAddAddressName {...addressNameProps} />
+        </ContactsAddAddressStepFrame>
+      ) : null;
+    case "review":
+      return addressReviewProps ? (
+        <ContactsAddAddressStepFrame>
+          <ContactsAddAddressReview {...addressReviewProps} />
         </ContactsAddAddressStepFrame>
       ) : null;
   }

--- a/features/flow/contacts/src/steps/AddAddress/Flow/ContactsAddAddressFlowContent.web.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/Flow/ContactsAddAddressFlowContent.web.test.tsx
@@ -20,6 +20,7 @@ import {
   type AddAddressWebFlowStep,
 } from "./ContactsAddAddressFlowContent.web";
 import type { ContactsAddAddressNameLabels } from "../AddressName/types";
+import type { ContactsAddAddressReviewLabels } from "../Review/types";
 
 type OpenAddAddressFlowState = Exclude<AddAddressFlowState, { status: "closed" }>;
 
@@ -44,11 +45,18 @@ const nameLabels: ContactsAddAddressNameLabels = {
   namingDisclaimer: "Address naming disclaimer",
   namingDisclaimerAccessibilityLabel: "Address name information",
   continueToReview: "Continue to review",
-  validAddress: "Valid address",
   validationErrors: {} as Record<ContactAddressLabelValidationErrorName, string>,
 };
-const completionLabels: AddAddressCompletionLabels = {
+const reviewLabels: ContactsAddAddressReviewLabels = {
   title: "Review address",
+  addressLabel: "Address",
+  currencyLabel: "Currency",
+  networkLabel: "Network",
+  nameLabel: "Address name",
+  continue: "Confirm address",
+};
+const completionLabels: AddAddressCompletionLabels = {
+  title: "Confirm on device",
   continue: "Continue",
   successTitle: "Address added",
   close: "Close",
@@ -63,6 +71,14 @@ function createContentState(
     selectedContactId: "contact" as ContactId,
     existingAddressLabels: [],
     selectedCurrencyId: "ethereum" as ContactAddress["currencyId"],
+    entryMode: "mad" as const,
+    displayContext: {
+      assetDisplayName: "Ethereum",
+      network: {
+        networkId: "ethereum",
+        displayName: "Ethereum",
+      },
+    },
     addressEntry: {
       status: "valid" as const,
       value: address,
@@ -91,6 +107,7 @@ function createContentProps(
     state,
     entryLabels,
     nameLabels,
+    reviewLabels,
     completionLabels,
     onAddressChange: jest.fn(),
     onContinueFromAddressDetails: jest.fn(),
@@ -131,6 +148,7 @@ describe("ContactsAddAddressFlowContent", () => {
 
     fireEvent.click(screen.getByTestId("contacts-add-address-name-continue"));
     expect(nameProps.onContinueFromName).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId("contacts-add-address-confirmed-input")).not.toBeInTheDocument();
 
     const confirmationProps = createContentProps(createContentState("confirmationRequired"));
     rerender(<ContactsAddAddressFlowContent {...confirmationProps} />);
@@ -143,6 +161,23 @@ describe("ContactsAddAddressFlowContent", () => {
 
     fireEvent.click(screen.getByTestId("contacts-add-address-review-continue"));
     expect(reviewProps.onContinueFromReview).toHaveBeenCalledTimes(1);
+
+    const prefilledReviewState = {
+      ...createContentState("reviewingAddress"),
+      entryMode: "prefilled" as const,
+      origin: "addressName" as const,
+    };
+    const prefilledReviewProps = createContentProps(prefilledReviewState);
+    rerender(<ContactsAddAddressFlowContent {...prefilledReviewProps} />);
+
+    expect(screen.getByTestId("contacts-add-address-review-address")).toHaveTextContent(address);
+    expect(screen.getByTestId("contacts-add-address-review-currency")).toHaveTextContent(
+      "Ethereum",
+    );
+    expect(screen.getByTestId("contacts-add-address-review-network")).toHaveTextContent("Ethereum");
+    expect(screen.getByTestId("contacts-add-address-review-name")).toHaveTextContent(label);
+    fireEvent.click(screen.getByTestId("contacts-add-address-review-continue"));
+    expect(prefilledReviewProps.onContinueFromReview).toHaveBeenCalledTimes(1);
 
     const successProps = createContentProps(createContentState("success"));
     rerender(<ContactsAddAddressFlowContent {...successProps} />);

--- a/features/flow/contacts/src/steps/AddAddress/Flow/ContactsAddAddressFlowContent.web.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/Flow/ContactsAddAddressFlowContent.web.tsx
@@ -3,6 +3,7 @@ import { ContactsAddAddressEntry } from "../ContactsAddAddressEntry.web";
 import { ContactsAddAddressNameInput } from "../AddressName/Input/ContactsAddAddressNameInput.web";
 import type { ContactsAddAddressNameLabels } from "../AddressName/types";
 import { ContactsAddAddressCompletion } from "../Completion/ContactsAddAddressCompletion.web";
+import { ContactsAddAddressReview, type ContactsAddAddressReviewLabels } from "../Review";
 import type {
   AddAddressCompletionLabels,
   AddAddressEntryLabels,
@@ -21,6 +22,7 @@ export type ContactsAddAddressFlowContentProps = Readonly<{
   entryLabels: AddAddressEntryLabels;
   sanctionedAddressBanner?: SanctionedAddressBannerProps;
   nameLabels: ContactsAddAddressNameLabels;
+  reviewLabels: ContactsAddAddressReviewLabels;
   completionLabels: AddAddressCompletionLabels;
   onAddressChange: (address: string, inputMethod: AddAddressInputSource) => void;
   onContinueFromAddressDetails: () => void;
@@ -63,6 +65,7 @@ export function ContactsAddAddressFlowContent({
   entryLabels,
   sanctionedAddressBanner,
   nameLabels,
+  reviewLabels,
   completionLabels,
   onAddressChange,
   onContinueFromAddressDetails,
@@ -89,7 +92,6 @@ export function ContactsAddAddressFlowContent({
     case "namingAddress":
       return (
         <ContactsAddAddressNameInput
-          addressEntry={state.addressEntry}
           addressLabel={state.addressLabel}
           labels={nameLabels}
           onAddressLabelChange={onAddressLabelChange}
@@ -106,12 +108,20 @@ export function ContactsAddAddressFlowContent({
         />
       );
     case "reviewingAddress":
-      return (
+      return state.entryMode === "prefilled" ? (
+        <ContactsAddAddressReview
+          addressEntry={state.addressEntry}
+          addressLabel={state.addressLabel}
+          displayContext={state.displayContext}
+          labels={reviewLabels}
+          onContinue={onContinueFromReview}
+        />
+      ) : (
         <ContactsAddAddressCompletion
-          buttonLabel={completionLabels.continue}
+          buttonLabel={reviewLabels.continue}
           onContinue={onContinueFromReview}
           testID="contacts-add-address-review"
-          title={completionLabels.title}
+          title={reviewLabels.title}
         />
       );
     case "success":

--- a/features/flow/contacts/src/steps/AddAddress/Review/ContactsAddAddressReview.native.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/Review/ContactsAddAddressReview.native.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { BottomSheetHeader, BottomSheetView, Box, Button, Text } from "@ledgerhq/lumen-ui-rnative";
+import { LedgerLogo } from "@ledgerhq/lumen-ui-rnative/symbols";
+import type { ContactsAddAddressReviewViewProps } from "./types";
+
+function ReviewRow({
+  label,
+  value,
+  testID,
+}: Readonly<{
+  label: string;
+  value: string;
+  testID: string;
+}>): React.JSX.Element {
+  return (
+    <Box testID={testID} lx={{ gap: "s4" }}>
+      <Text typography="body3" lx={{ color: "muted" }}>
+        {label}
+      </Text>
+      <Text typography="body2SemiBold" lx={{ color: "base" }}>
+        {value}
+      </Text>
+    </Box>
+  );
+}
+
+export type ContactsAddAddressReviewNativeProps = ContactsAddAddressReviewViewProps &
+  Readonly<{
+    bottomOffset?: number;
+  }>;
+
+export function ContactsAddAddressReview({
+  address,
+  currency,
+  network,
+  name,
+  labels,
+  bottomOffset = 0,
+  onContinue,
+}: ContactsAddAddressReviewNativeProps): React.JSX.Element {
+  return (
+    <BottomSheetView
+      testID="contacts-add-address-review"
+      style={{ bottom: 0, paddingBottom: 32 + bottomOffset }}
+    >
+      <BottomSheetHeader density="expanded" title={labels.title} />
+      <Box style={{ flex: 1 }} lx={{ justifyContent: "space-between", gap: "s16" }}>
+        <Box lx={{ gap: "s16" }}>
+          <ReviewRow
+            label={labels.addressLabel}
+            testID="contacts-add-address-review-address"
+            value={address}
+          />
+          <ReviewRow
+            label={labels.currencyLabel}
+            testID="contacts-add-address-review-currency"
+            value={currency}
+          />
+          <ReviewRow
+            label={labels.networkLabel}
+            testID="contacts-add-address-review-network"
+            value={network}
+          />
+          <ReviewRow
+            label={labels.nameLabel}
+            testID="contacts-add-address-review-name"
+            value={name}
+          />
+        </Box>
+        <Button
+          testID="contacts-add-address-review-continue"
+          appearance="base"
+          size="lg"
+          isFull
+          icon={LedgerLogo}
+          onPress={onContinue}
+        >
+          {labels.continue}
+        </Button>
+      </Box>
+    </BottomSheetView>
+  );
+}

--- a/features/flow/contacts/src/steps/AddAddress/Review/ContactsAddAddressReview.web.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/Review/ContactsAddAddressReview.web.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { ContactsAddAddressReviewView } from "./ContactsAddAddressReviewView.web";
+import type { ContactsAddAddressReviewProps } from "./types";
+import { useContactsAddAddressReviewViewModel } from "./useContactsAddAddressReviewViewModel.web";
+
+export function ContactsAddAddressReview(props: ContactsAddAddressReviewProps): React.JSX.Element {
+  return <ContactsAddAddressReviewView {...useContactsAddAddressReviewViewModel(props)} />;
+}

--- a/features/flow/contacts/src/steps/AddAddress/Review/ContactsAddAddressReviewView.web.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/Review/ContactsAddAddressReviewView.web.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ContactAddressLabelSchema, ContactAddressValueSchema } from "@domain/entity-contact";
+import { ContactsAddAddressReviewView } from "./ContactsAddAddressReviewView.web";
+
+const ADDRESS = ContactAddressValueSchema.parse("0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034");
+const NAME = ContactAddressLabelSchema.parse("Exchange");
+
+describe("ContactsAddAddressReviewView", () => {
+  it("should render destination address, currency, network, and name", () => {
+    const onContinue = jest.fn();
+
+    render(
+      <ContactsAddAddressReviewView
+        address={ADDRESS}
+        currency="Ethereum"
+        network="Ethereum"
+        name={NAME}
+        labels={{
+          title: "Review address",
+          addressLabel: "Address",
+          currencyLabel: "Currency",
+          networkLabel: "Network",
+          nameLabel: "Address name",
+          continue: "Confirm address",
+        }}
+        onContinue={onContinue}
+      />,
+    );
+
+    expect(screen.getByTestId("contacts-add-address-review-address")).toHaveTextContent(ADDRESS);
+    expect(screen.getByTestId("contacts-add-address-review-currency")).toHaveTextContent(
+      "Ethereum",
+    );
+    expect(screen.getByTestId("contacts-add-address-review-network")).toHaveTextContent("Ethereum");
+    expect(screen.getByTestId("contacts-add-address-review-name")).toHaveTextContent(NAME);
+
+    fireEvent.click(screen.getByTestId("contacts-add-address-review-continue"));
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/flow/contacts/src/steps/AddAddress/Review/ContactsAddAddressReviewView.web.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/Review/ContactsAddAddressReviewView.web.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { Button } from "@ledgerhq/lumen-ui-react";
+import type { ContactsAddAddressReviewViewProps } from "./types";
+
+function ReviewRow({
+  label,
+  value,
+  testID,
+}: Readonly<{
+  label: string;
+  value: string;
+  testID: string;
+}>): React.JSX.Element {
+  return (
+    <div className="flex flex-col gap-4" data-testid={testID}>
+      <span className="body-2-semi-bold text-muted">{label}</span>
+      <span className="body-1-semi-bold break-all text-base">{value}</span>
+    </div>
+  );
+}
+
+export function ContactsAddAddressReviewView({
+  address,
+  currency,
+  network,
+  name,
+  labels,
+  onContinue,
+}: ContactsAddAddressReviewViewProps): React.JSX.Element {
+  return (
+    <div
+      className="flex min-h-256 flex-col justify-between gap-24"
+      data-testid="contacts-add-address-review"
+    >
+      <div className="flex flex-col gap-16">
+        <ReviewRow
+          label={labels.addressLabel}
+          testID="contacts-add-address-review-address"
+          value={address}
+        />
+        <ReviewRow
+          label={labels.currencyLabel}
+          testID="contacts-add-address-review-currency"
+          value={currency}
+        />
+        <ReviewRow
+          label={labels.networkLabel}
+          testID="contacts-add-address-review-network"
+          value={network}
+        />
+        <ReviewRow
+          label={labels.nameLabel}
+          testID="contacts-add-address-review-name"
+          value={name}
+        />
+      </div>
+      <Button
+        appearance="base"
+        className="w-full"
+        data-testid="contacts-add-address-review-continue"
+        onClick={onContinue}
+        size="lg"
+      >
+        {labels.continue}
+      </Button>
+    </div>
+  );
+}

--- a/features/flow/contacts/src/steps/AddAddress/Review/index.ts
+++ b/features/flow/contacts/src/steps/AddAddress/Review/index.ts
@@ -1,0 +1,6 @@
+export { ContactsAddAddressReview } from "./ContactsAddAddressReview.web";
+export type {
+  ContactsAddAddressReviewLabels,
+  ContactsAddAddressReviewProps,
+  ContactsAddAddressReviewViewProps,
+} from "./types";

--- a/features/flow/contacts/src/steps/AddAddress/Review/types.ts
+++ b/features/flow/contacts/src/steps/AddAddress/Review/types.ts
@@ -1,0 +1,31 @@
+import type {
+  AddAddressDisplayContext,
+  ValidAddAddressEntryState,
+  ValidAddAddressLabelState,
+} from "../types";
+
+export type ContactsAddAddressReviewLabels = Readonly<{
+  title: string;
+  addressLabel: string;
+  currencyLabel: string;
+  networkLabel: string;
+  nameLabel: string;
+  continue: string;
+}>;
+
+export type ContactsAddAddressReviewProps = Readonly<{
+  addressEntry: ValidAddAddressEntryState;
+  addressLabel: ValidAddAddressLabelState;
+  displayContext: AddAddressDisplayContext;
+  labels: ContactsAddAddressReviewLabels;
+  onContinue: () => void;
+}>;
+
+export type ContactsAddAddressReviewViewProps = Readonly<{
+  address: string;
+  currency: string;
+  network: string;
+  name: string;
+  labels: ContactsAddAddressReviewLabels;
+  onContinue: () => void;
+}>;

--- a/features/flow/contacts/src/steps/AddAddress/Review/useContactsAddAddressReviewViewModel.web.ts
+++ b/features/flow/contacts/src/steps/AddAddress/Review/useContactsAddAddressReviewViewModel.web.ts
@@ -1,0 +1,18 @@
+import type { ContactsAddAddressReviewProps, ContactsAddAddressReviewViewProps } from "./types";
+
+export function useContactsAddAddressReviewViewModel({
+  addressEntry,
+  addressLabel,
+  displayContext,
+  labels,
+  onContinue,
+}: ContactsAddAddressReviewProps): ContactsAddAddressReviewViewProps {
+  return {
+    address: addressEntry.resolvedAddress,
+    currency: displayContext.assetDisplayName,
+    network: displayContext.network.displayName,
+    name: addressLabel.label,
+    labels,
+    onContinue,
+  };
+}

--- a/features/flow/contacts/src/steps/AddAddress/index.ts
+++ b/features/flow/contacts/src/steps/AddAddress/index.ts
@@ -4,3 +4,4 @@ export * from "./model/resolveEligibleAddressCurrencyIds";
 export * from "./useAddAddressCurrencySelectionViewModel";
 export * from "./types";
 export * from "./useAddAddressFlowViewModel";
+export * from "./prefillAddAddress";

--- a/features/flow/contacts/src/steps/AddAddress/native.ts
+++ b/features/flow/contacts/src/steps/AddAddress/native.ts
@@ -2,5 +2,8 @@ export { ContactsAddAddressEntry } from "./ContactsAddAddressEntry.native";
 export type { ContactsAddAddressEntryProps } from "./ContactsAddAddressEntry.types";
 export { ContactsAddAddressName } from "./AddressName/ContactsAddAddressName.native";
 export type { ContactsAddAddressNameNativeProps as ContactsAddAddressNameProps } from "./AddressName/types";
+export { ContactsAddAddressReview } from "./Review/ContactsAddAddressReview.native";
+export type { ContactsAddAddressReviewNativeProps } from "./Review/ContactsAddAddressReview.native";
+export type { ContactsAddAddressReviewLabels } from "./Review/types";
 export { ContactsAddAddressFlowContent } from "./Flow/ContactsAddAddressFlowContent.native";
 export type { ContactsAddAddressFlowContentProps } from "./Flow/ContactsAddAddressFlowContent.native";

--- a/features/flow/contacts/src/steps/AddAddress/prefillAddAddress.ts
+++ b/features/flow/contacts/src/steps/AddAddress/prefillAddAddress.ts
@@ -1,0 +1,23 @@
+import type { ContactAddress, ContactId } from "@domain/entity-contact";
+import type { AddAddressCurrencySelection, AddAddressNetworkContext } from "./types";
+
+/**
+ * Public entry params for the prefilled Add Address flow (MAD bypass).
+ * Consumers such as Send provide a known contact, destination, currency, and network.
+ */
+export type OpenPrefillAddAddressParams = Readonly<{
+  contactId: ContactId;
+  address: string;
+  currency: AddAddressCurrencySelection;
+  network: AddAddressNetworkContext;
+}>;
+
+export type OpenPrefillAddAddressResult =
+  | Readonly<{ status: "saved"; address: ContactAddress }>
+  | Readonly<{ status: "cancelled" }>
+  | Readonly<{
+      status: "invalid_address";
+      error: "invalid_format" | "domain_not_found" | "sanctioned";
+    }>
+  | Readonly<{ status: "unavailable" }>
+  | Readonly<{ status: "confirmation_failed" }>;

--- a/features/flow/contacts/src/steps/AddAddress/types.ts
+++ b/features/flow/contacts/src/steps/AddAddress/types.ts
@@ -16,6 +16,33 @@ export type AddAddressCurrencySelection = Readonly<{
   assetDisplayName: string;
 }>;
 
+export type AddAddressNetworkContext = Readonly<{
+  networkId: string;
+  displayName: string;
+}>;
+
+export type AddAddressEntryMode = "mad" | "prefilled";
+
+export type AddAddressDisplayContext = Readonly<{
+  assetDisplayName: string;
+  network: AddAddressNetworkContext;
+}>;
+
+export type PrefillAddAddressParams = Readonly<{
+  contact: AddAddressContact;
+  address: string;
+  currency: AddAddressCurrencySelection;
+  network: AddAddressNetworkContext;
+}>;
+
+export type PrefillAddAddressStartResult =
+  | Readonly<{ status: "started" }>
+  | Readonly<{
+      status: "invalid_address";
+      error: "invalid_format" | "domain_not_found" | "sanctioned";
+    }>
+  | Readonly<{ status: "unavailable" }>;
+
 export type AddAddressEntryState =
   | Readonly<{
       status: "empty";
@@ -76,6 +103,8 @@ type AddAddressSession = Readonly<{
   selectedContactId: ContactId;
   existingAddressLabels: readonly ContactAddress["label"][];
   selectedCurrencyId: ContactAddress["currencyId"];
+  entryMode: AddAddressEntryMode;
+  displayContext: AddAddressDisplayContext;
   addressEntry: AddAddressEntryState;
   addressLabel: AddAddressLabelState;
 }>;
@@ -119,6 +148,7 @@ export type AddAddressFlowState =
 export type AddAddressFlowViewModel = Readonly<{
   state: AddAddressFlowState;
   start: (contact: AddAddressContact) => void;
+  startWithPrefilled: (params: PrefillAddAddressParams) => Promise<PrefillAddAddressStartResult>;
   completeCurrencySelection: (contactId: ContactId, selection: AddAddressCurrencySelection) => void;
   updateAddress: (address: string, inputMethod: AddAddressInputSource) => Promise<void>;
   updateAddressLabel: (label: string) => void;

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.ts
@@ -18,11 +18,15 @@ import { wait } from "../../utils/wait";
 import type {
   AddAddressContact,
   AddAddressCurrencySelection,
+  AddAddressDisplayContext,
   AddAddressEntryState,
   AddAddressFlowState,
   AddAddressFlowViewModel,
   AddAddressInputSource,
   AddAddressLabelState,
+  PrefillAddAddressParams,
+  PrefillAddAddressStartResult,
+  ValidAddAddressEntryState,
 } from "./types";
 
 const CLOSED_ADD_ADDRESS_FLOW_STATE = {
@@ -74,6 +78,16 @@ function limitAddressLabelLength(value: string): string {
   return value.slice(0, CONTACT_ADDRESS_LABEL_MAX_LENGTH);
 }
 
+function createMadDisplayContext(selection: AddAddressCurrencySelection): AddAddressDisplayContext {
+  return {
+    assetDisplayName: selection.assetDisplayName,
+    network: {
+      networkId: selection.currencyId,
+      displayName: selection.assetDisplayName,
+    },
+  };
+}
+
 function applyAddressEntryState(
   currentState: AddAddressFlowState,
   selectedCurrencyId: ContactAddress["currencyId"],
@@ -111,6 +125,67 @@ export function useAddAddressFlowViewModel({
     },
     [cancelAddressValidation],
   );
+  const startWithPrefilled = useCallback(
+    async (params: PrefillAddAddressParams): Promise<PrefillAddAddressStartResult> => {
+      cancelAddressValidation();
+      const existingAddressLabels = params.contact.addresses.map(address => address.label);
+      const normalizedAddress = params.address.trim();
+      const requestId = validationRequestId.current + 1;
+      validationRequestId.current = requestId;
+
+      if (normalizedAddress.length === 0) {
+        setState(CLOSED_ADD_ADDRESS_FLOW_STATE);
+        return { status: "invalid_address", error: "invalid_format" };
+      }
+
+      const validationResult = await requestAddressValidation(
+        addressValidation,
+        params.currency.currencyId,
+        normalizedAddress,
+      );
+
+      if (validationRequestId.current !== requestId) {
+        return { status: "unavailable" };
+      }
+
+      if (validationResult.status === "unavailable") {
+        setState(CLOSED_ADD_ADDRESS_FLOW_STATE);
+        return { status: "unavailable" };
+      }
+
+      if (validationResult.status !== "valid") {
+        setState(CLOSED_ADD_ADDRESS_FLOW_STATE);
+        return { status: "invalid_address", error: validationResult.status };
+      }
+
+      const addressEntry: ValidAddAddressEntryState = {
+        status: "valid",
+        value: params.address,
+        resolvedAddress: validationResult.resolvedAddress,
+        inputMethod: validationResult.isDomain ? "ens" : "manual",
+      };
+
+      setState({
+        status: "namingAddress",
+        selectedContactId: params.contact.id,
+        existingAddressLabels,
+        selectedCurrencyId: params.currency.currencyId,
+        entryMode: "prefilled",
+        displayContext: {
+          assetDisplayName: params.currency.assetDisplayName,
+          network: params.network,
+        },
+        addressEntry,
+        addressLabel: createAddressLabelState(
+          limitAddressLabelLength(params.currency.assetDisplayName),
+          existingAddressLabels,
+        ),
+      });
+
+      return { status: "started" };
+    },
+    [addressValidation, cancelAddressValidation],
+  );
   const completeCurrencySelection = useCallback(
     (selectedContactId: ContactId, selection: AddAddressCurrencySelection) => {
       setState(currentState => {
@@ -126,6 +201,8 @@ export function useAddAddressFlowViewModel({
           selectedContactId,
           existingAddressLabels: currentState.existingAddressLabels,
           selectedCurrencyId: selection.currencyId,
+          entryMode: "mad",
+          displayContext: createMadDisplayContext(selection),
           addressEntry: EMPTY_ADDRESS_ENTRY_STATE,
           addressLabel: createAddressLabelState(
             limitAddressLabelLength(selection.assetDisplayName),
@@ -220,6 +297,8 @@ export function useAddAddressFlowViewModel({
         selectedContactId: currentState.selectedContactId,
         existingAddressLabels: currentState.existingAddressLabels,
         selectedCurrencyId: currentState.selectedCurrencyId,
+        entryMode: currentState.entryMode,
+        displayContext: currentState.displayContext,
         addressEntry: currentState.addressEntry,
         addressLabel: currentState.addressLabel,
       };
@@ -231,11 +310,27 @@ export function useAddAddressFlowViewModel({
         return currentState;
       }
 
+      if (currentState.entryMode === "prefilled") {
+        return {
+          status: "reviewingAddress",
+          selectedContactId: currentState.selectedContactId,
+          existingAddressLabels: currentState.existingAddressLabels,
+          selectedCurrencyId: currentState.selectedCurrencyId,
+          entryMode: currentState.entryMode,
+          displayContext: currentState.displayContext,
+          addressEntry: currentState.addressEntry,
+          addressLabel: currentState.addressLabel,
+          origin: "addressName",
+        };
+      }
+
       return {
         status: "confirmationRequired",
         selectedContactId: currentState.selectedContactId,
         existingAddressLabels: currentState.existingAddressLabels,
         selectedCurrencyId: currentState.selectedCurrencyId,
+        entryMode: currentState.entryMode,
+        displayContext: currentState.displayContext,
         addressEntry: currentState.addressEntry,
         addressLabel: currentState.addressLabel,
       };
@@ -257,6 +352,8 @@ export function useAddAddressFlowViewModel({
         selectedContactId: currentState.selectedContactId,
         existingAddressLabels: currentState.existingAddressLabels,
         selectedCurrencyId: currentState.selectedCurrencyId,
+        entryMode: currentState.entryMode,
+        displayContext: currentState.displayContext,
         addressEntry: currentState.addressEntry,
         addressLabel: currentState.addressLabel,
         origin: "addressDetails",
@@ -302,6 +399,9 @@ export function useAddAddressFlowViewModel({
             existingAddressLabels: currentState.existingAddressLabels,
           };
         case "namingAddress":
+          if (currentState.entryMode === "prefilled") {
+            return CLOSED_ADD_ADDRESS_FLOW_STATE;
+          }
           return { ...currentState, status: "enteringAddress" };
         case "reviewingAddress": {
           const { origin, ...session } = currentState;
@@ -325,6 +425,7 @@ export function useAddAddressFlowViewModel({
   return {
     state,
     start,
+    startWithPrefilled,
     completeCurrencySelection,
     updateAddress,
     updateAddressLabel,

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.web.test.ts
@@ -100,6 +100,14 @@ describe("useAddAddressFlowViewModel", () => {
       selectedContactId: contactId,
       existingAddressLabels: [],
       selectedCurrencyId: ETHEREUM_CURRENCY_ID,
+      entryMode: "mad",
+      displayContext: {
+        assetDisplayName: "Ethereum",
+        network: {
+          networkId: ETHEREUM_CURRENCY_ID,
+          displayName: "Ethereum",
+        },
+      },
       addressEntry: {
         status: "empty",
         value: "",
@@ -889,5 +897,130 @@ describe("useAddAddressFlowViewModel", () => {
     });
 
     expect(result.current.state).toEqual({ status: "closed" });
+  });
+
+  describe("startWithPrefilled", () => {
+    const ETHEREUM_NETWORK = {
+      networkId: "ethereum",
+      displayName: "Ethereum",
+    } as const;
+
+    it("should start on the naming screen after validating the supplied address", async () => {
+      const contact = mockContact({ addresses: [] });
+      const addressValidation = createValidationPort();
+      const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
+
+      let startResult: Awaited<ReturnType<typeof result.current.startWithPrefilled>> | undefined;
+      await act(async () => {
+        startResult = await result.current.startWithPrefilled({
+          contact,
+          address: RAW_ADDRESS,
+          currency: ETHEREUM_SELECTION,
+          network: ETHEREUM_NETWORK,
+        });
+      });
+
+      expect(startResult).toEqual({ status: "started" });
+      expect(addressValidation.validateAddress).toHaveBeenCalledWith({
+        currencyId: ETHEREUM_CURRENCY_ID,
+        address: RAW_ADDRESS,
+      });
+      expect(result.current.state).toMatchObject({
+        status: "namingAddress",
+        entryMode: "prefilled",
+        selectedContactId: contact.id,
+        selectedCurrencyId: ETHEREUM_CURRENCY_ID,
+        displayContext: {
+          assetDisplayName: "Ethereum",
+          network: ETHEREUM_NETWORK,
+        },
+        addressEntry: {
+          status: "valid",
+          resolvedAddress: VALID_ADDRESS,
+        },
+      });
+    });
+
+    it("should bypass MAD and address-entry steps and continue through review", async () => {
+      const contact = mockContact({ addresses: [] });
+      const addressValidation = createValidationPort();
+      const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
+
+      await act(async () => {
+        await result.current.startWithPrefilled({
+          contact,
+          address: RAW_ADDRESS,
+          currency: ETHEREUM_SELECTION,
+          network: ETHEREUM_NETWORK,
+        });
+      });
+      act(() => result.current.updateAddressLabel("Exchange"));
+      act(() => result.current.continueFromName());
+
+      expect(result.current.state).toMatchObject({
+        status: "reviewingAddress",
+        origin: "addressName",
+        entryMode: "prefilled",
+        addressLabel: { label: "Exchange", status: "valid" },
+        displayContext: {
+          assetDisplayName: "Ethereum",
+          network: ETHEREUM_NETWORK,
+        },
+      });
+    });
+
+    it("should reject an invalid supplied address without opening naming", async () => {
+      const contact = mockContact({ addresses: [] });
+      const addressValidation = createValidationPort({ status: "invalid_format" });
+      const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
+
+      let startResult: Awaited<ReturnType<typeof result.current.startWithPrefilled>> | undefined;
+      await act(async () => {
+        startResult = await result.current.startWithPrefilled({
+          contact,
+          address: "not-an-address",
+          currency: ETHEREUM_SELECTION,
+          network: ETHEREUM_NETWORK,
+        });
+      });
+
+      expect(startResult).toEqual({ status: "invalid_address", error: "invalid_format" });
+      expect(result.current.state).toEqual({ status: "closed" });
+    });
+
+    it("should close the prefilled naming step on back without returning to address entry", async () => {
+      const contact = mockContact({ addresses: [] });
+      const addressValidation = createValidationPort();
+      const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
+
+      await act(async () => {
+        await result.current.startWithPrefilled({
+          contact,
+          address: RAW_ADDRESS,
+          currency: ETHEREUM_SELECTION,
+          network: ETHEREUM_NETWORK,
+        });
+      });
+      act(() => result.current.goBack());
+
+      expect(result.current.state).toEqual({ status: "closed" });
+    });
+
+    it("should keep MAD naming confirmation behavior unchanged", async () => {
+      const contact = mockContact({ addresses: [] });
+      const addressValidation = createValidationPort();
+      const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
+
+      act(() => result.current.start(contact));
+      act(() => result.current.completeCurrencySelection(contact.id, ETHEREUM_SELECTION));
+      await act(() => result.current.updateAddress(RAW_ADDRESS, "manual"));
+      act(() => result.current.confirmAddress());
+      act(() => result.current.continueFromName());
+
+      expect(result.current.state).toMatchObject({
+        status: "confirmationRequired",
+        entryMode: "mad",
+      });
+    });
   });
 });

--- a/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.test.ts
@@ -29,7 +29,6 @@ const nameLabels: ContactsAddAddressNameLabels = {
   namingDisclaimer: "Address naming disclaimer",
   namingDisclaimerAccessibilityLabel: "Address name information",
   continueToReview: "Continue to review",
-  validAddress: "Valid address",
   validationErrors: {
     InvalidContactAddressLabelError: "Special characters are not allowed.",
     DuplicateContactAddressLabelError: "Duplicate address name.",

--- a/features/flow/contacts/src/steps/AddAddress/web.ts
+++ b/features/flow/contacts/src/steps/AddAddress/web.ts
@@ -4,6 +4,8 @@ export type { SanctionedAddressBannerProps } from "./ContactsAddAddressEntry.typ
 export type { AddAddressEntryLabels as ContactsAddAddressEntryLabels } from "./types";
 export { ContactsAddAddressNameInput as ContactsAddAddressName } from "./AddressName/Input/ContactsAddAddressNameInput.web";
 export { ContactsAddAddressCompletion } from "./Completion/ContactsAddAddressCompletion.web";
+export { ContactsAddAddressReview } from "./Review";
+export type { ContactsAddAddressReviewLabels, ContactsAddAddressReviewProps } from "./Review";
 export {
   ContactsAddAddressFlowContent,
   resolveAddAddressWebFlowStep,


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

- Adds a public prefilled Add Address entry point for Send (and other consumers) that accepts `contactId`, destination address, currency, and network, and bypasses MAD / currency / network / address-entry screens.
- Starts on the address naming screen (Desktop: name input + validation + disclaimer only; destination address is not shown or editable), then continues through review and device confirmation before persistence.
- Wires Desktop (`PrefillAddAddressFlowRoot` in GlobalDialogs) and Mobile (GlobalDrawers registry) with `useOpenPrefillAddAddressFlow`, without exposing Contacts internals. Existing MAD-based Contacts Add Address flow is unchanged.


### 🔗 Context

[LIVE-35745](https://ledgerhq.atlassian.net/browse/LIVE-35745)


[LIVE-35745]: https://ledgerhq.atlassian.net/browse/LIVE-35745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ