### PR TITLE
[LWD] fix(device-intent): prevent connect race condition (LIVE-36168)

### DIFF
--- a/.changeset/calm-devices-connect.md
+++ b/.changeset/calm-devices-connect.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix duplicate WebHID connections when known devices update during device discovery

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/useDeviceConnectionComponentLWDViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/useDeviceConnectionComponentLWDViewModel.test.tsx
@@ -291,6 +291,27 @@ describe("useDeviceConnectionComponentLWDViewModel", () => {
     expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
   });
 
+  it("GIVEN a connection flow WHEN known devices change THEN it keeps the existing subscription", () => {
+    // GIVEN
+    const { store } = renderViewModel();
+
+    // WHEN
+    act(() => {
+      store.dispatch({
+        type: "ADD_DEVICE",
+        payload: {
+          deviceId: "",
+          modelId: DeviceModelId.nanoX,
+          wired: true,
+        },
+      });
+    });
+
+    // THEN
+    expect(mockedConnectDevice).toHaveBeenCalledTimes(1);
+    expect(mockUnsubscribe).not.toHaveBeenCalled();
+  });
+
   it("GIVEN connect device reports a connection WHEN handling the result THEN it updates desktop device state and notifies the executor", () => {
     // GIVEN
     const onConnected = jest.fn();

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/useDeviceConnectionComponentLWDViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/useDeviceConnectionComponentLWDViewModel.ts
@@ -41,6 +41,9 @@ export function useDeviceConnectionComponentLWDViewModel({
   const dispatch = useDispatch();
   const dmk = useDeviceManagementKit();
   const knownDevices = useSelector(knownDevicesSelector);
+  // Plugging in a device updates knownDevices while connecting. Keep the initial value so that
+  // the update cannot restart dmk.connect and race the active WebHID connection.
+  const knownDevicesRef = useRef(knownDevices);
   const { handleConnect, handleBuyDevice } = useLazyOnboardingActions();
   const { sourceFlow, analyticsProperties } = useDeviceIntentTracking();
   const [state, setState] = useState<ConnectDeviceUIState>({
@@ -100,7 +103,7 @@ export function useDeviceConnectionComponentLWDViewModel({
     }
 
     const subscription = connectDevice({
-      knownDevices,
+      knownDevices: knownDevicesRef.current,
       acceptedDeviceModelIds: deviceConnectionParams.acceptedDeviceModelIds.map(
         deviceModelId => dmkToLedgerDeviceIdMap[deviceModelId],
       ),
@@ -115,7 +118,7 @@ export function useDeviceConnectionComponentLWDViewModel({
     return () => {
       subscription.unsubscribe();
     };
-  }, [deviceConnectionParams.acceptedDeviceModelIds, dmk, knownDevices, wrappedOnConnected]);
+  }, [deviceConnectionParams.acceptedDeviceModelIds, dmk, wrappedOnConnected]);
 
   return {
     state,


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Connecting a locked Ledger device while the Device Intent Executor playground is already open can fail with `SendCommandTimeoutError` / `SendApduTimeoutError`, and the UI can then show `WebHidSendReportError`.

The global HID listener updates `knownDevices` during that first connection. Because the desktop connection effect depended on `knownDevices`, it restarted `connectDevice` and raced the active WebHID `oninputreport` handler.

This keeps the initial `knownDevices` snapshot in a ref so discovery updates cannot restart the connection, and adds a regression test that a `knownDevices` change keeps the existing subscription.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36168](https://ledgerhq.atlassian.net/browse/LIVE-36168)
- **ADR** (if any):

[LIVE-36168]: https://ledgerhq.atlassian.net/browse/LIVE-36168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ