### PR TITLE
feat(contacts): add prefilled Add Address flow state and UI (LIVE-35745)

### DIFF
--- a/.changeset/LIVE-35745-prefill-add-address-flow.md
+++ b/.changeset/LIVE-35745-prefill-add-address-flow.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts-add-address": minor
+---
+
+Add a prefilled Add Address flow that bypasses the Modular Asset Drawer, with a name-only Desktop naming step and a dedicated review step, while keeping the existing MAD path unchanged.

--- a/features/flow/flow-contacts-add-address/README.md
+++ b/features/flow/flow-contacts-add-address/README.md
@@ -8,12 +8,14 @@ Shared Add address flow for Desktop and Mobile.
 ## Scope
 
 - Address validation, selection state, label validation, and flow transitions.
+- Prefilled entry that bypasses currency and address selection and starts on the naming screen.
+- Dedicated prefilled-address review UI for Web and React Native.
 - Web dialog content and React Native bottom-sheet content.
 - Public ports and helpers used by application-owned currency selection and validation adapters.
 
 ## Structure
 
-- `screens/` owns the Address Entry, Address Name, Completion, and Flow UI. Each screen provides
+- `screens/` owns the Address Entry, Address Name, Review, Completion, and Flow UI. Each screen provides
   explicit `index.ts` and, where required, `index.native.ts` entry points. Address Entry and
   Address Name group their UI components separately from their view models.
 - `components/` owns UI shared by more than one Add address screen.

--- a/features/flow/flow-contacts-add-address/src/exports.ts
+++ b/features/flow/flow-contacts-add-address/src/exports.ts
@@ -1,3 +1,4 @@
+export * from "./prefillAddAddress";
 export * from "./state/addressValidation/dependencies";
 export * from "./state/addressValidation/service";
 export * from "./state/ports";

--- a/features/flow/flow-contacts-add-address/src/index.native.ts
+++ b/features/flow/flow-contacts-add-address/src/index.native.ts
@@ -3,3 +3,5 @@ export * from "./screens/AddressEntry/components/ContactsAddAddressEntry/Contact
 export * from "./screens/AddressEntry/components/ContactsAddAddressEntry/ContactsAddAddressEntry.types";
 export * from "./screens/AddressName/ContactsAddAddressName.native";
 export * from "./screens/Flow/ContactsAddAddressFlowContent.native";
+export * from "./screens/Review/ContactsAddAddressReview.native";
+export * from "./screens/Review/types";

--- a/features/flow/flow-contacts-add-address/src/prefillAddAddress.ts
+++ b/features/flow/flow-contacts-add-address/src/prefillAddAddress.ts
@@ -1,0 +1,23 @@
+import type { ContactAddress, ContactId } from "@domain/entity-contact";
+import type {
+  AddAddressCurrencySelection,
+  AddAddressNetworkContext,
+  PrefillAddAddressInvalidReason,
+} from "./state/types";
+
+export type OpenPrefillAddAddressParams = Readonly<{
+  contactId: ContactId;
+  address: string;
+  currency: AddAddressCurrencySelection;
+  network: AddAddressNetworkContext;
+}>;
+
+export type OpenPrefillAddAddressResult =
+  | Readonly<{ status: "saved"; address: ContactAddress }>
+  | Readonly<{ status: "cancelled" }>
+  | Readonly<{
+      status: "invalid_address";
+      error: PrefillAddAddressInvalidReason;
+    }>
+  | Readonly<{ status: "unavailable" }>
+  | Readonly<{ status: "confirmation_failed" }>;

--- a/features/flow/flow-contacts-add-address/src/screens/AddressName/ContactsAddAddressNameView.web.test.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressName/ContactsAddAddressNameView.web.test.tsx
@@ -3,22 +3,17 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import {
   CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
   ContactAddressLabelSchema,
-  ContactAddressValueSchema,
   DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
 } from "@domain/entity-contact";
 import { ContactsAddAddressNameView } from "./ContactsAddAddressNameView";
 import type { ContactsAddAddressNameViewProps } from "./types";
 
-const RESOLVED_ADDRESS = ContactAddressValueSchema.parse(
-  "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
-);
-
 function createProps(
   overrides: Partial<ContactsAddAddressNameViewProps> = {},
 ): ContactsAddAddressNameViewProps {
   return {
-    address: RESOLVED_ADDRESS,
+    address: "0xabc",
     addressLabel: {
       status: "valid",
       value: "Ethereum",
@@ -38,6 +33,7 @@ function createProps(
         [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: "This address name is too long.",
       },
     },
+    showConfirmedAddress: false,
     isContinueEnabled: true,
     onAddressLabelChange: jest.fn(),
     onContinue: jest.fn(),
@@ -46,17 +42,15 @@ function createProps(
 }
 
 describe("ContactsAddAddressNameView", () => {
-  it("should render the address details and forward input actions", () => {
+  it("should render only the name input with disclaimer and forward actions", () => {
     const onAddressLabelChange = jest.fn();
     const onContinue = jest.fn();
 
     render(<ContactsAddAddressNameView {...createProps({ onAddressLabelChange, onContinue })} />);
 
-    expect(screen.getByTestId("contacts-add-address-confirmed-input")).toHaveAttribute(
-      "value",
-      RESOLVED_ADDRESS,
-    );
+    expect(screen.queryByTestId("contacts-add-address-confirmed-input")).not.toBeInTheDocument();
     expect(screen.getByTestId("contacts-add-address-name-input")).toHaveValue("Ethereum");
+    expect(screen.getByTestId("contacts-add-address-name-disclaimer")).toBeInTheDocument();
 
     fireEvent.change(screen.getByTestId("contacts-add-address-name-input"), {
       target: { value: "Exchange" },
@@ -88,5 +82,12 @@ describe("ContactsAddAddressNameView", () => {
       "Special characters are not allowed.",
     );
     expect(screen.getByTestId("contacts-add-address-name-continue")).toBeDisabled();
+  });
+
+  it("should preserve the confirmed address UI for the MAD path", () => {
+    render(<ContactsAddAddressNameView {...createProps({ showConfirmedAddress: true })} />);
+
+    expect(screen.getByTestId("contacts-add-address-confirmed-input")).toBeInTheDocument();
+    expect(screen.queryByTestId("contacts-add-address-name-disclaimer")).not.toBeInTheDocument();
   });
 });

--- a/features/flow/flow-contacts-add-address/src/screens/AddressName/ContactsAddAddressNameView.web.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressName/ContactsAddAddressNameView.web.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { AddressInput, Button, TextInput } from "@ledgerhq/lumen-ui-react";
+import { AddressInput, Banner, Button, TextInput } from "@ledgerhq/lumen-ui-react";
 import { LedgerLogo } from "@ledgerhq/lumen-ui-react/symbols";
 import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "@domain/entity-contact";
 import type { ContactsAddAddressNameViewProps } from "./types";
@@ -8,6 +8,7 @@ export function ContactsAddAddressNameView({
   address,
   addressLabel,
   labels,
+  showConfirmedAddress,
   validationMessage,
   isContinueEnabled,
   onAddressLabelChange,
@@ -15,23 +16,26 @@ export function ContactsAddAddressNameView({
 }: ContactsAddAddressNameViewProps): React.JSX.Element {
   return (
     <div className="flex flex-col gap-24">
-      <AddressInput
-        autoComplete="off"
-        autoCorrect="off"
-        data-testid="contacts-add-address-confirmed-input"
-        helperText={labels.validAddress}
-        hideClearButton
-        prefix=""
-        readOnly
-        spellCheck={false}
-        status="success"
-        value={address}
-      />
+      {showConfirmedAddress ? (
+        <AddressInput
+          autoComplete="off"
+          autoCorrect="off"
+          data-testid="contacts-add-address-confirmed-input"
+          helperText={labels.validAddress}
+          hideClearButton
+          prefix=""
+          readOnly
+          spellCheck={false}
+          status="success"
+          value={address}
+        />
+      ) : null}
       <TextInput
         autoComplete="off"
         autoCorrect="off"
         data-testid="contacts-add-address-name-input"
         helperText={validationMessage}
+        hideClearButton
         label={labels.inputLabel}
         maxCount={CONTACT_ADDRESS_LABEL_MAX_LENGTH}
         maxLength={CONTACT_ADDRESS_LABEL_MAX_LENGTH}
@@ -40,6 +44,14 @@ export function ContactsAddAddressNameView({
         status={addressLabel.status === "invalid" ? "error" : undefined}
         value={addressLabel.value}
       />
+      {showConfirmedAddress ? null : (
+        <Banner
+          appearance="info"
+          aria-label={labels.namingDisclaimerAccessibilityLabel}
+          data-testid="contacts-add-address-name-disclaimer"
+          description={labels.namingDisclaimer}
+        />
+      )}
       <Button
         appearance="base"
         className="w-full"

--- a/features/flow/flow-contacts-add-address/src/screens/AddressName/components/Input/ContactsAddAddressNameInput.web.test.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressName/components/Input/ContactsAddAddressNameInput.web.test.tsx
@@ -10,9 +10,7 @@ import {
 import { ContactsAddAddressNameInput } from "./ContactsAddAddressNameInput";
 import type { ContactsAddAddressNameProps } from "../../types";
 
-const RESOLVED_ADDRESS = ContactAddressValueSchema.parse(
-  "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
-);
+const ADDRESS = ContactAddressValueSchema.parse("0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034");
 
 function createProps(
   overrides: Partial<ContactsAddAddressNameProps> = {},
@@ -20,8 +18,8 @@ function createProps(
   return {
     addressEntry: {
       status: "valid",
-      value: RESOLVED_ADDRESS,
-      resolvedAddress: RESOLVED_ADDRESS,
+      value: ADDRESS,
+      resolvedAddress: ADDRESS,
       inputMethod: "manual",
     },
     addressLabel: {
@@ -44,6 +42,7 @@ function createProps(
           "Address names must be 32 characters or fewer.",
       },
     },
+    showConfirmedAddress: false,
     onAddressLabelChange: jest.fn(),
     onContinue: jest.fn(),
     ...overrides,
@@ -51,18 +50,16 @@ function createProps(
 }
 
 describe("ContactsAddAddressNameInput", () => {
-  it("should render the confirmed address and prefilled label with the 32-character limit", () => {
+  it("should render only the name input with the 32-character limit", () => {
     render(<ContactsAddAddressNameInput {...createProps()} />);
 
-    expect(screen.getByTestId("contacts-add-address-confirmed-input")).toHaveAttribute(
-      "value",
-      RESOLVED_ADDRESS,
-    );
+    expect(screen.queryByTestId("contacts-add-address-confirmed-input")).not.toBeInTheDocument();
     expect(screen.getByTestId("contacts-add-address-name-input")).toHaveValue("Ethereum");
     expect(screen.getByTestId("contacts-add-address-name-input")).toHaveAttribute(
       "maxlength",
       "32",
     );
+    expect(screen.getByTestId("contacts-add-address-name-disclaimer")).toBeInTheDocument();
     expect(screen.getByTestId("contacts-add-address-name-continue")).toBeEnabled();
   });
 

--- a/features/flow/flow-contacts-add-address/src/screens/AddressName/types.ts
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressName/types.ts
@@ -15,6 +15,7 @@ export type ContactsAddAddressNameProps = Readonly<{
   addressEntry: ValidAddAddressEntryState;
   addressLabel: AddAddressLabelState;
   labels: ContactsAddAddressNameLabels;
+  showConfirmedAddress?: boolean;
   onAddressLabelChange: (value: string) => void;
   onContinue: () => void;
 }>;
@@ -23,6 +24,7 @@ export type ContactsAddAddressNameViewProps = Readonly<{
   address: string;
   addressLabel: AddAddressLabelState;
   labels: ContactsAddAddressNameLabels;
+  showConfirmedAddress: boolean;
   validationMessage?: string;
   isContinueEnabled: boolean;
   onAddressLabelChange: (event: ChangeEvent<HTMLInputElement>) => void;

--- a/features/flow/flow-contacts-add-address/src/screens/AddressName/useContactsAddAddressNameViewModel.web.ts
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressName/useContactsAddAddressNameViewModel.web.ts
@@ -5,6 +5,7 @@ export function useContactsAddAddressNameViewModel({
   addressEntry,
   addressLabel,
   labels,
+  showConfirmedAddress = true,
   onAddressLabelChange,
   onContinue,
 }: ContactsAddAddressNameProps): ContactsAddAddressNameViewProps {
@@ -24,6 +25,7 @@ export function useContactsAddAddressNameViewModel({
     address: addressEntry.value,
     addressLabel,
     labels,
+    showConfirmedAddress,
     validationMessage,
     isContinueEnabled: addressLabel.status === "valid",
     onAddressLabelChange: onChange,

--- a/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.native.test.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.native.test.tsx
@@ -65,11 +65,26 @@ function createProps(
       onChangeText: jest.fn(),
       onContinue: jest.fn(),
     },
+    addressReviewProps: {
+      address,
+      currency: "Ethereum",
+      network: "Ethereum",
+      name: "Ethereum",
+      labels: {
+        title: "Review address",
+        addressLabel: "Address",
+        currencyLabel: "Currency",
+        networkLabel: "Network",
+        nameLabel: "Address name",
+        continue: "Confirm address",
+      },
+      onContinue: jest.fn(),
+    },
   };
 }
 
 describe("ContactsAddAddressFlowContent", () => {
-  it("should render the address and name content with their actions", () => {
+  it("should render each step and call its action", () => {
     const addressProps = createProps("address");
     const { rerender } = render(<ContactsAddAddressFlowContent {...addressProps} />);
 
@@ -81,5 +96,12 @@ describe("ContactsAddAddressFlowContent", () => {
 
     fireEvent.press(screen.getByTestId("contacts-add-address-name-continue"));
     expect(nameProps.addressNameProps?.onContinue).toHaveBeenCalledTimes(1);
+
+    const reviewProps = createProps("review");
+    rerender(<ContactsAddAddressFlowContent {...reviewProps} />);
+
+    expect(screen.getByText(address)).toBeVisible();
+    fireEvent.press(screen.getByTestId("contacts-add-address-review-continue"));
+    expect(reviewProps.addressReviewProps?.onContinue).toHaveBeenCalledTimes(1);
   });
 });

--- a/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.native.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.native.tsx
@@ -4,15 +4,20 @@ import { ContactsAddAddressEntry } from "../AddressEntry/components/ContactsAddA
 import type { ContactsAddAddressEntryProps } from "../AddressEntry/components/ContactsAddAddressEntry/ContactsAddAddressEntry.types";
 import { ContactsAddAddressName } from "../AddressName/ContactsAddAddressName";
 import type { ContactsAddAddressNameProps } from "../AddressName/ContactsAddAddressName";
+import {
+  ContactsAddAddressReview,
+  type ContactsAddAddressReviewNativeProps,
+} from "../Review/ContactsAddAddressReview.native";
 
 const STEP_FRAME_HEIGHT = "100%";
 
-export type ContactsAddAddressNativeFlowStep = "address" | "name";
+export type ContactsAddAddressNativeFlowStep = "address" | "name" | "review";
 
 export type ContactsAddAddressFlowContentProps = Readonly<{
   step: ContactsAddAddressNativeFlowStep;
   addressEntryProps: ContactsAddAddressEntryProps | null;
   addressNameProps: ContactsAddAddressNameProps | null;
+  addressReviewProps?: ContactsAddAddressReviewNativeProps | null;
 }>;
 
 function ContactsAddAddressStepFrame({ children }: React.PropsWithChildren): React.JSX.Element {
@@ -27,6 +32,7 @@ export function ContactsAddAddressFlowContent({
   step,
   addressEntryProps,
   addressNameProps,
+  addressReviewProps = null,
 }: ContactsAddAddressFlowContentProps): React.JSX.Element | null {
   switch (step) {
     case "address":
@@ -39,6 +45,12 @@ export function ContactsAddAddressFlowContent({
       return addressNameProps ? (
         <ContactsAddAddressStepFrame>
           <ContactsAddAddressName {...addressNameProps} />
+        </ContactsAddAddressStepFrame>
+      ) : null;
+    case "review":
+      return addressReviewProps ? (
+        <ContactsAddAddressStepFrame>
+          <ContactsAddAddressReview {...addressReviewProps} />
         </ContactsAddAddressStepFrame>
       ) : null;
   }

--- a/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.web.test.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.web.test.tsx
@@ -20,6 +20,7 @@ import {
   type AddAddressWebFlowStep,
 } from "./ContactsAddAddressFlowContent";
 import type { ContactsAddAddressNameLabels } from "../AddressName/types";
+import type { ContactsAddAddressReviewLabels } from "../Review/types";
 
 type OpenAddAddressFlowState = Exclude<AddAddressFlowState, { status: "closed" }>;
 
@@ -47,8 +48,16 @@ const nameLabels: ContactsAddAddressNameLabels = {
   validAddress: "Valid address",
   validationErrors: {} as Record<ContactAddressLabelValidationErrorName, string>,
 };
-const completionLabels: AddAddressCompletionLabels = {
+const reviewLabels: ContactsAddAddressReviewLabels = {
   title: "Review address",
+  addressLabel: "Address",
+  currencyLabel: "Currency",
+  networkLabel: "Network",
+  nameLabel: "Address name",
+  continue: "Confirm address",
+};
+const completionLabels: AddAddressCompletionLabels = {
+  title: "Confirm on device",
   continue: "Continue",
   successTitle: "Address added",
   close: "Close",
@@ -63,6 +72,8 @@ function createContentState(
     selectedContactId: "contact" as ContactId,
     existingAddressLabels: [],
     selectedCurrencyId: "ethereum" as ContactAddress["currencyId"],
+    entryMode: "mad" as const,
+    displayContext: null,
     addressEntry: {
       status: "valid" as const,
       value: address,
@@ -91,6 +102,7 @@ function createContentProps(
     state,
     entryLabels,
     nameLabels,
+    reviewLabels,
     completionLabels,
     onAddressChange: jest.fn(),
     onContinueFromAddressDetails: jest.fn(),
@@ -131,6 +143,7 @@ describe("ContactsAddAddressFlowContent", () => {
 
     fireEvent.click(screen.getByTestId("contacts-add-address-name-continue"));
     expect(nameProps.onContinueFromName).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("contacts-add-address-confirmed-input")).toBeInTheDocument();
 
     const confirmationProps = createContentProps(createContentState("confirmationRequired"));
     rerender(<ContactsAddAddressFlowContent {...confirmationProps} />);
@@ -143,6 +156,30 @@ describe("ContactsAddAddressFlowContent", () => {
 
     fireEvent.click(screen.getByTestId("contacts-add-address-review-continue"));
     expect(reviewProps.onContinueFromReview).toHaveBeenCalledTimes(1);
+
+    const prefilledReviewState = {
+      ...createContentState("reviewingAddress"),
+      entryMode: "prefilled" as const,
+      displayContext: {
+        assetDisplayName: "Ethereum",
+        network: {
+          networkId: "ethereum",
+          displayName: "Ethereum",
+        },
+      },
+      origin: "addressName" as const,
+    };
+    const prefilledReviewProps = createContentProps(prefilledReviewState);
+    rerender(<ContactsAddAddressFlowContent {...prefilledReviewProps} />);
+
+    expect(screen.getByTestId("contacts-add-address-review-address")).toHaveTextContent(address);
+    expect(screen.getByTestId("contacts-add-address-review-currency")).toHaveTextContent(
+      "Ethereum",
+    );
+    expect(screen.getByTestId("contacts-add-address-review-network")).toHaveTextContent("Ethereum");
+    expect(screen.getByTestId("contacts-add-address-review-name")).toHaveTextContent(label);
+    fireEvent.click(screen.getByTestId("contacts-add-address-review-continue"));
+    expect(prefilledReviewProps.onContinueFromReview).toHaveBeenCalledTimes(1);
 
     const successProps = createContentProps(createContentState("success"));
     rerender(<ContactsAddAddressFlowContent {...successProps} />);

--- a/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.web.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/Flow/ContactsAddAddressFlowContent.web.tsx
@@ -4,6 +4,7 @@ import type { SanctionedAddressBannerProps } from "../../components/SanctionedAd
 import { ContactsAddAddressNameInput } from "../AddressName/components/Input/ContactsAddAddressNameInput";
 import type { ContactsAddAddressNameLabels } from "../AddressName/types";
 import { ContactsAddAddressCompletion } from "../Completion/ContactsAddAddressCompletion";
+import { ContactsAddAddressReview, type ContactsAddAddressReviewLabels } from "../Review";
 import type {
   AddAddressCompletionLabels,
   AddAddressEntryLabels,
@@ -21,6 +22,7 @@ export type ContactsAddAddressFlowContentProps = Readonly<{
   entryLabels: AddAddressEntryLabels;
   sanctionedAddressBanner?: SanctionedAddressBannerProps;
   nameLabels: ContactsAddAddressNameLabels;
+  reviewLabels?: ContactsAddAddressReviewLabels;
   completionLabels: AddAddressCompletionLabels;
   onAddressChange: (address: string, inputMethod: AddAddressInputSource) => void;
   onContinueFromAddressDetails: () => void;
@@ -63,6 +65,7 @@ export function ContactsAddAddressFlowContent({
   entryLabels,
   sanctionedAddressBanner,
   nameLabels,
+  reviewLabels,
   completionLabels,
   onAddressChange,
   onContinueFromAddressDetails,
@@ -92,6 +95,7 @@ export function ContactsAddAddressFlowContent({
           addressEntry={state.addressEntry}
           addressLabel={state.addressLabel}
           labels={nameLabels}
+          showConfirmedAddress={state.entryMode === "mad"}
           onAddressLabelChange={onAddressLabelChange}
           onContinue={onContinueFromName}
         />
@@ -106,6 +110,21 @@ export function ContactsAddAddressFlowContent({
         />
       );
     case "reviewingAddress":
+      if (
+        state.entryMode === "prefilled" &&
+        state.displayContext !== null &&
+        reviewLabels !== undefined
+      ) {
+        return (
+          <ContactsAddAddressReview
+            addressEntry={state.addressEntry}
+            addressLabel={state.addressLabel}
+            displayContext={state.displayContext}
+            labels={reviewLabels}
+            onContinue={onContinueFromReview}
+          />
+        );
+      }
       return (
         <ContactsAddAddressCompletion
           buttonLabel={completionLabels.continue}

--- a/features/flow/flow-contacts-add-address/src/screens/Review/ContactsAddAddressReview.native.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/Review/ContactsAddAddressReview.native.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { BottomSheetHeader, BottomSheetView, Box, Button, Text } from "@ledgerhq/lumen-ui-rnative";
+import { LedgerLogo } from "@ledgerhq/lumen-ui-rnative/symbols";
+import type { ContactsAddAddressReviewViewProps } from "./types";
+
+function ReviewRow({
+  label,
+  value,
+  testID,
+}: Readonly<{
+  label: string;
+  value: string;
+  testID: string;
+}>): React.JSX.Element {
+  return (
+    <Box testID={testID} lx={{ gap: "s4" }}>
+      <Text typography="body3" lx={{ color: "muted" }}>
+        {label}
+      </Text>
+      <Text typography="body2SemiBold" lx={{ color: "base" }}>
+        {value}
+      </Text>
+    </Box>
+  );
+}
+
+export type ContactsAddAddressReviewNativeProps = ContactsAddAddressReviewViewProps &
+  Readonly<{
+    bottomOffset?: number;
+  }>;
+
+export function ContactsAddAddressReview({
+  address,
+  currency,
+  network,
+  name,
+  labels,
+  bottomOffset = 0,
+  onContinue,
+}: ContactsAddAddressReviewNativeProps): React.JSX.Element {
+  return (
+    <BottomSheetView
+      testID="contacts-add-address-review"
+      style={{ bottom: 0, paddingBottom: 32 + bottomOffset }}
+    >
+      <BottomSheetHeader density="expanded" title={labels.title} />
+      <Box style={{ flex: 1 }} lx={{ justifyContent: "space-between", gap: "s16" }}>
+        <Box lx={{ gap: "s16" }}>
+          <ReviewRow
+            label={labels.addressLabel}
+            testID="contacts-add-address-review-address"
+            value={address}
+          />
+          <ReviewRow
+            label={labels.currencyLabel}
+            testID="contacts-add-address-review-currency"
+            value={currency}
+          />
+          <ReviewRow
+            label={labels.networkLabel}
+            testID="contacts-add-address-review-network"
+            value={network}
+          />
+          <ReviewRow
+            label={labels.nameLabel}
+            testID="contacts-add-address-review-name"
+            value={name}
+          />
+        </Box>
+        <Button
+          testID="contacts-add-address-review-continue"
+          appearance="base"
+          size="lg"
+          isFull
+          icon={LedgerLogo}
+          onPress={onContinue}
+        >
+          {labels.continue}
+        </Button>
+      </Box>
+    </BottomSheetView>
+  );
+}

--- a/features/flow/flow-contacts-add-address/src/screens/Review/ContactsAddAddressReview.web.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/Review/ContactsAddAddressReview.web.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { ContactsAddAddressReviewView } from "./ContactsAddAddressReviewView.web";
+import type { ContactsAddAddressReviewProps } from "./types";
+import { useContactsAddAddressReviewViewModel } from "./useContactsAddAddressReviewViewModel.web";
+
+export function ContactsAddAddressReview(props: ContactsAddAddressReviewProps): React.JSX.Element {
+  return <ContactsAddAddressReviewView {...useContactsAddAddressReviewViewModel(props)} />;
+}

--- a/features/flow/flow-contacts-add-address/src/screens/Review/ContactsAddAddressReviewView.web.test.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/Review/ContactsAddAddressReviewView.web.test.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ContactAddressLabelSchema, ContactAddressValueSchema } from "@domain/entity-contact";
+import { ContactsAddAddressReviewView } from "./ContactsAddAddressReviewView.web";
+
+const ADDRESS = ContactAddressValueSchema.parse("0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034");
+const NAME = ContactAddressLabelSchema.parse("Exchange");
+
+describe("ContactsAddAddressReviewView", () => {
+  it("should render destination address, currency, network, and name", async () => {
+    const onContinue = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+      <ContactsAddAddressReviewView
+        address={ADDRESS}
+        currency="Ethereum"
+        network="Ethereum"
+        name={NAME}
+        labels={{
+          title: "Review address",
+          addressLabel: "Address",
+          currencyLabel: "Currency",
+          networkLabel: "Network",
+          nameLabel: "Address name",
+          continue: "Confirm address",
+        }}
+        onContinue={onContinue}
+      />,
+    );
+
+    expect(screen.getByTestId("contacts-add-address-review-title")).toHaveTextContent(
+      "Review address",
+    );
+    expect(screen.getByTestId("contacts-add-address-review-address")).toHaveTextContent(ADDRESS);
+    expect(screen.getByTestId("contacts-add-address-review-currency")).toHaveTextContent(
+      "Ethereum",
+    );
+    expect(screen.getByTestId("contacts-add-address-review-network")).toHaveTextContent("Ethereum");
+    expect(screen.getByTestId("contacts-add-address-review-name")).toHaveTextContent(NAME);
+
+    await user.click(screen.getByTestId("contacts-add-address-review-continue"));
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/flow/flow-contacts-add-address/src/screens/Review/ContactsAddAddressReviewView.web.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/Review/ContactsAddAddressReviewView.web.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { Button } from "@ledgerhq/lumen-ui-react";
+import type { ContactsAddAddressReviewViewProps } from "./types";
+
+function ReviewRow({
+  label,
+  value,
+  testID,
+}: Readonly<{
+  label: string;
+  value: string;
+  testID: string;
+}>): React.JSX.Element {
+  return (
+    <div className="flex flex-col gap-4" data-testid={testID}>
+      <span className="body-2-semi-bold text-muted">{label}</span>
+      <span className="body-1-semi-bold break-all text-base">{value}</span>
+    </div>
+  );
+}
+
+export function ContactsAddAddressReviewView({
+  address,
+  currency,
+  network,
+  name,
+  labels,
+  onContinue,
+}: ContactsAddAddressReviewViewProps): React.JSX.Element {
+  return (
+    <div
+      className="flex min-h-256 flex-col justify-between gap-24"
+      data-testid="contacts-add-address-review"
+    >
+      <div className="flex flex-col gap-16">
+        <span
+          className="heading-4-semi-bold text-base"
+          data-testid="contacts-add-address-review-title"
+        >
+          {labels.title}
+        </span>
+        <ReviewRow
+          label={labels.addressLabel}
+          testID="contacts-add-address-review-address"
+          value={address}
+        />
+        <ReviewRow
+          label={labels.currencyLabel}
+          testID="contacts-add-address-review-currency"
+          value={currency}
+        />
+        <ReviewRow
+          label={labels.networkLabel}
+          testID="contacts-add-address-review-network"
+          value={network}
+        />
+        <ReviewRow
+          label={labels.nameLabel}
+          testID="contacts-add-address-review-name"
+          value={name}
+        />
+      </div>
+      <Button
+        appearance="base"
+        className="w-full"
+        data-testid="contacts-add-address-review-continue"
+        onClick={onContinue}
+        size="lg"
+      >
+        {labels.continue}
+      </Button>
+    </div>
+  );
+}

--- a/features/flow/flow-contacts-add-address/src/screens/Review/index.ts
+++ b/features/flow/flow-contacts-add-address/src/screens/Review/index.ts
@@ -1,0 +1,2 @@
+export * from "./ContactsAddAddressReview.web";
+export * from "./types";

--- a/features/flow/flow-contacts-add-address/src/screens/Review/types.ts
+++ b/features/flow/flow-contacts-add-address/src/screens/Review/types.ts
@@ -1,0 +1,31 @@
+import type {
+  AddAddressDisplayContext,
+  ValidAddAddressEntryState,
+  ValidAddAddressLabelState,
+} from "../../state/types";
+
+export type ContactsAddAddressReviewLabels = Readonly<{
+  title: string;
+  addressLabel: string;
+  currencyLabel: string;
+  networkLabel: string;
+  nameLabel: string;
+  continue: string;
+}>;
+
+export type ContactsAddAddressReviewProps = Readonly<{
+  addressEntry: ValidAddAddressEntryState;
+  addressLabel: ValidAddAddressLabelState;
+  displayContext: AddAddressDisplayContext;
+  labels: ContactsAddAddressReviewLabels;
+  onContinue: () => void;
+}>;
+
+export type ContactsAddAddressReviewViewProps = Readonly<{
+  address: string;
+  currency: string;
+  network: string;
+  name: string;
+  labels: ContactsAddAddressReviewLabels;
+  onContinue: () => void;
+}>;

--- a/features/flow/flow-contacts-add-address/src/screens/Review/useContactsAddAddressReviewViewModel.web.test.ts
+++ b/features/flow/flow-contacts-add-address/src/screens/Review/useContactsAddAddressReviewViewModel.web.test.ts
@@ -1,0 +1,48 @@
+import { ContactAddressLabelSchema, ContactAddressValueSchema } from "@domain/entity-contact";
+import { useContactsAddAddressReviewViewModel } from "./useContactsAddAddressReviewViewModel.web";
+
+describe("useContactsAddAddressReviewViewModel", () => {
+  it("should map the confirmed address and display context to review props", () => {
+    const onContinue = jest.fn();
+    const labels = {
+      title: "Review address",
+      addressLabel: "Address",
+      currencyLabel: "Currency",
+      networkLabel: "Network",
+      nameLabel: "Address name",
+      continue: "Confirm address",
+    };
+    const address = ContactAddressValueSchema.parse("0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034");
+    const name = ContactAddressLabelSchema.parse("Exchange");
+
+    expect(
+      useContactsAddAddressReviewViewModel({
+        addressEntry: {
+          status: "valid",
+          value: "ledger.eth",
+          resolvedAddress: address,
+          inputMethod: "ens",
+        },
+        addressLabel: {
+          status: "valid",
+          value: name,
+          label: name,
+          validationError: null,
+        },
+        displayContext: {
+          assetDisplayName: "USDC",
+          network: { networkId: "ethereum", displayName: "Ethereum" },
+        },
+        labels,
+        onContinue,
+      }),
+    ).toEqual({
+      address,
+      currency: "USDC",
+      network: "Ethereum",
+      name,
+      labels,
+      onContinue,
+    });
+  });
+});

--- a/features/flow/flow-contacts-add-address/src/screens/Review/useContactsAddAddressReviewViewModel.web.ts
+++ b/features/flow/flow-contacts-add-address/src/screens/Review/useContactsAddAddressReviewViewModel.web.ts
@@ -1,0 +1,18 @@
+import type { ContactsAddAddressReviewProps, ContactsAddAddressReviewViewProps } from "./types";
+
+export function useContactsAddAddressReviewViewModel({
+  addressEntry,
+  addressLabel,
+  displayContext,
+  labels,
+  onContinue,
+}: ContactsAddAddressReviewProps): ContactsAddAddressReviewViewProps {
+  return {
+    address: addressEntry.resolvedAddress,
+    currency: displayContext.assetDisplayName,
+    network: displayContext.network.displayName,
+    name: addressLabel.label,
+    labels,
+    onContinue,
+  };
+}

--- a/features/flow/flow-contacts-add-address/src/state/types.ts
+++ b/features/flow/flow-contacts-add-address/src/state/types.ts
@@ -21,6 +21,36 @@ export type AddAddressCurrencySelection = Readonly<{
   assetDisplayName: string;
 }>;
 
+export type AddAddressNetworkContext = Readonly<{
+  networkId: string;
+  displayName: string;
+}>;
+
+export type AddAddressEntryMode = "mad" | "prefilled";
+
+export type AddAddressDisplayContext = Readonly<{
+  assetDisplayName: string;
+  network: AddAddressNetworkContext;
+}>;
+
+export type PrefillAddAddressParams = Readonly<{
+  contact: AddAddressContact;
+  address: string;
+  currency: AddAddressCurrencySelection;
+  network: AddAddressNetworkContext;
+}>;
+
+export type PrefillAddAddressInvalidReason = "invalid_format" | "domain_not_found" | "sanctioned";
+
+export type PrefillAddAddressStartResult =
+  | Readonly<{ status: "started" }>
+  | Readonly<{
+      status: "invalid_address";
+      error: PrefillAddAddressInvalidReason;
+    }>
+  | Readonly<{ status: "cancelled" }>
+  | Readonly<{ status: "unavailable" }>;
+
 export type AddAddressEntryState = ContactsAddressEntryState;
 
 export type AddAddressLabelState =
@@ -50,6 +80,8 @@ type AddAddressSession = Readonly<{
   selectedContactId: ContactId;
   existingAddressLabels: readonly ContactAddress["label"][];
   selectedCurrencyId: ContactAddress["currencyId"];
+  entryMode: AddAddressEntryMode;
+  displayContext: AddAddressDisplayContext | null;
   addressEntry: AddAddressEntryState;
   addressLabel: AddAddressLabelState;
 }>;
@@ -93,6 +125,7 @@ export type AddAddressFlowState =
 export type AddAddressFlowViewModel = Readonly<{
   state: AddAddressFlowState;
   start: (contact: AddAddressContact) => void;
+  startWithPrefilled: (params: PrefillAddAddressParams) => Promise<PrefillAddAddressStartResult>;
   completeCurrencySelection: (contactId: ContactId, selection: AddAddressCurrencySelection) => void;
   updateAddress: (address: string, inputMethod: AddAddressInputSource) => Promise<void>;
   updateAddressLabel: (label: string) => void;

--- a/features/flow/flow-contacts-add-address/src/state/useAddAddressFlowViewModel.ts
+++ b/features/flow/flow-contacts-add-address/src/state/useAddAddressFlowViewModel.ts
@@ -23,6 +23,9 @@ import type {
   AddAddressFlowViewModel,
   AddAddressInputSource,
   AddAddressLabelState,
+  PrefillAddAddressParams,
+  PrefillAddAddressStartResult,
+  ValidAddAddressEntryState,
 } from "./types";
 
 const CLOSED_ADD_ADDRESS_FLOW_STATE = {
@@ -111,6 +114,66 @@ export function useAddAddressFlowViewModel({
     },
     [cancelAddressValidation],
   );
+  const startWithPrefilled = useCallback(
+    async (params: PrefillAddAddressParams): Promise<PrefillAddAddressStartResult> => {
+      cancelAddressValidation();
+      const existingAddressLabels = params.contact.addresses.map(address => address.label);
+      const normalizedAddress = params.address.trim();
+      const requestId = validationRequestId.current;
+
+      if (normalizedAddress.length === 0) {
+        setState(CLOSED_ADD_ADDRESS_FLOW_STATE);
+        return { status: "invalid_address", error: "invalid_format" };
+      }
+
+      const validationResult = await requestAddressValidation(
+        addressValidation,
+        params.currency.currencyId,
+        normalizedAddress,
+      );
+
+      if (validationRequestId.current !== requestId) {
+        return { status: "cancelled" };
+      }
+
+      if (validationResult.status === "unavailable") {
+        setState(CLOSED_ADD_ADDRESS_FLOW_STATE);
+        return { status: "unavailable" };
+      }
+
+      if (validationResult.status !== "valid") {
+        setState(CLOSED_ADD_ADDRESS_FLOW_STATE);
+        return { status: "invalid_address", error: validationResult.status };
+      }
+
+      const addressEntry: ValidAddAddressEntryState = {
+        status: "valid",
+        value: normalizedAddress,
+        resolvedAddress: validationResult.resolvedAddress,
+        inputMethod: validationResult.isDomain ? "ens" : "manual",
+      };
+
+      setState({
+        status: "namingAddress",
+        selectedContactId: params.contact.id,
+        existingAddressLabels,
+        selectedCurrencyId: params.currency.currencyId,
+        entryMode: "prefilled",
+        displayContext: {
+          assetDisplayName: params.currency.assetDisplayName,
+          network: params.network,
+        },
+        addressEntry,
+        addressLabel: createAddressLabelState(
+          limitAddressLabelLength(params.currency.assetDisplayName),
+          existingAddressLabels,
+        ),
+      });
+
+      return { status: "started" };
+    },
+    [addressValidation, cancelAddressValidation],
+  );
   const completeCurrencySelection = useCallback(
     (selectedContactId: ContactId, selection: AddAddressCurrencySelection) => {
       setState(currentState => {
@@ -126,6 +189,8 @@ export function useAddAddressFlowViewModel({
           selectedContactId,
           existingAddressLabels: currentState.existingAddressLabels,
           selectedCurrencyId: selection.currencyId,
+          entryMode: "mad",
+          displayContext: null,
           addressEntry: EMPTY_ADDRESS_ENTRY_STATE,
           addressLabel: createAddressLabelState(
             limitAddressLabelLength(selection.assetDisplayName),
@@ -220,6 +285,8 @@ export function useAddAddressFlowViewModel({
         selectedContactId: currentState.selectedContactId,
         existingAddressLabels: currentState.existingAddressLabels,
         selectedCurrencyId: currentState.selectedCurrencyId,
+        entryMode: currentState.entryMode,
+        displayContext: currentState.displayContext,
         addressEntry: currentState.addressEntry,
         addressLabel: currentState.addressLabel,
       };
@@ -231,11 +298,27 @@ export function useAddAddressFlowViewModel({
         return currentState;
       }
 
+      if (currentState.entryMode === "prefilled") {
+        return {
+          status: "reviewingAddress",
+          selectedContactId: currentState.selectedContactId,
+          existingAddressLabels: currentState.existingAddressLabels,
+          selectedCurrencyId: currentState.selectedCurrencyId,
+          entryMode: currentState.entryMode,
+          displayContext: currentState.displayContext,
+          addressEntry: currentState.addressEntry,
+          addressLabel: currentState.addressLabel,
+          origin: "addressName",
+        };
+      }
+
       return {
         status: "confirmationRequired",
         selectedContactId: currentState.selectedContactId,
         existingAddressLabels: currentState.existingAddressLabels,
         selectedCurrencyId: currentState.selectedCurrencyId,
+        entryMode: currentState.entryMode,
+        displayContext: currentState.displayContext,
         addressEntry: currentState.addressEntry,
         addressLabel: currentState.addressLabel,
       };
@@ -257,6 +340,8 @@ export function useAddAddressFlowViewModel({
         selectedContactId: currentState.selectedContactId,
         existingAddressLabels: currentState.existingAddressLabels,
         selectedCurrencyId: currentState.selectedCurrencyId,
+        entryMode: currentState.entryMode,
+        displayContext: currentState.displayContext,
         addressEntry: currentState.addressEntry,
         addressLabel: currentState.addressLabel,
         origin: "addressDetails",
@@ -302,8 +387,17 @@ export function useAddAddressFlowViewModel({
             existingAddressLabels: currentState.existingAddressLabels,
           };
         case "namingAddress":
+          if (currentState.entryMode === "prefilled") {
+            return CLOSED_ADD_ADDRESS_FLOW_STATE;
+          }
           return { ...currentState, status: "enteringAddress" };
         case "reviewingAddress": {
+          if (currentState.entryMode === "prefilled") {
+            const { origin, ...session } = currentState;
+            return origin === "addressDetails"
+              ? { ...session, status: "enteringAddress" }
+              : { ...session, status: "namingAddress" };
+          }
           const { origin, ...session } = currentState;
           return origin === "addressDetails"
             ? { ...session, status: "enteringAddress" }
@@ -325,6 +419,7 @@ export function useAddAddressFlowViewModel({
   return {
     state,
     start,
+    startWithPrefilled,
     completeCurrencySelection,
     updateAddress,
     updateAddressLabel,

--- a/features/flow/flow-contacts-add-address/src/state/useAddAddressFlowViewModel.web.test.ts
+++ b/features/flow/flow-contacts-add-address/src/state/useAddAddressFlowViewModel.web.test.ts
@@ -103,6 +103,8 @@ describe("useAddAddressFlowViewModel", () => {
       selectedContactId: contactId,
       existingAddressLabels: [],
       selectedCurrencyId: ETHEREUM_CURRENCY_ID,
+      entryMode: "mad",
+      displayContext: null,
       addressEntry: {
         status: "empty",
         value: "",
@@ -892,5 +894,183 @@ describe("useAddAddressFlowViewModel", () => {
     });
 
     expect(result.current.state).toEqual({ status: "closed" });
+  });
+
+  describe("startWithPrefilled", () => {
+    const ETHEREUM_NETWORK = {
+      networkId: "ethereum",
+      displayName: "Ethereum",
+    } as const;
+
+    it("should start on the naming screen after validating the supplied address", async () => {
+      const contact = mockContact({ addresses: [] });
+      const addressValidation = createValidationPort();
+      const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
+
+      let startResult: Awaited<ReturnType<typeof result.current.startWithPrefilled>> | undefined;
+      await act(async () => {
+        startResult = await result.current.startWithPrefilled({
+          contact,
+          address: RAW_ADDRESS,
+          currency: ETHEREUM_SELECTION,
+          network: ETHEREUM_NETWORK,
+        });
+      });
+
+      expect(startResult).toEqual({ status: "started" });
+      expect(addressValidation.validateAddress).toHaveBeenCalledWith({
+        currencyId: ETHEREUM_CURRENCY_ID,
+        address: RAW_ADDRESS,
+      });
+      expect(result.current.state).toMatchObject({
+        status: "namingAddress",
+        entryMode: "prefilled",
+        selectedContactId: contact.id,
+        selectedCurrencyId: ETHEREUM_CURRENCY_ID,
+        displayContext: {
+          assetDisplayName: "Ethereum",
+          network: ETHEREUM_NETWORK,
+        },
+        addressEntry: {
+          status: "valid",
+          resolvedAddress: VALID_ADDRESS,
+        },
+      });
+    });
+
+    it("should bypass MAD and address-entry steps and continue through review", async () => {
+      const contact = mockContact({ addresses: [] });
+      const addressValidation = createValidationPort();
+      const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
+
+      await act(async () => {
+        await result.current.startWithPrefilled({
+          contact,
+          address: RAW_ADDRESS,
+          currency: ETHEREUM_SELECTION,
+          network: ETHEREUM_NETWORK,
+        });
+      });
+      act(() => result.current.updateAddressLabel("Exchange"));
+      act(() => result.current.continueFromName());
+
+      expect(result.current.state).toMatchObject({
+        status: "reviewingAddress",
+        origin: "addressName",
+        entryMode: "prefilled",
+        addressLabel: { label: "Exchange", status: "valid" },
+        displayContext: {
+          assetDisplayName: "Ethereum",
+          network: ETHEREUM_NETWORK,
+        },
+      });
+    });
+
+    it("should reject an invalid supplied address without opening naming", async () => {
+      const contact = mockContact({ addresses: [] });
+      const addressValidation = createValidationPort({ status: "invalid_format" });
+      const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
+
+      let startResult: Awaited<ReturnType<typeof result.current.startWithPrefilled>> | undefined;
+      await act(async () => {
+        startResult = await result.current.startWithPrefilled({
+          contact,
+          address: "not-an-address",
+          currency: ETHEREUM_SELECTION,
+          network: ETHEREUM_NETWORK,
+        });
+      });
+
+      expect(startResult).toEqual({ status: "invalid_address", error: "invalid_format" });
+      expect(result.current.state).toEqual({ status: "closed" });
+    });
+
+    it("should remain closed when prefilled validation is unavailable", async () => {
+      const contact = mockContact({ addresses: [] });
+      const addressValidation = createValidationPort({ status: "unavailable" });
+      const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
+
+      let startResult: Awaited<ReturnType<typeof result.current.startWithPrefilled>> | undefined;
+      await act(async () => {
+        startResult = await result.current.startWithPrefilled({
+          contact,
+          address: RAW_ADDRESS,
+          currency: ETHEREUM_SELECTION,
+          network: ETHEREUM_NETWORK,
+        });
+      });
+
+      expect(startResult).toEqual({ status: "unavailable" });
+      expect(result.current.state).toEqual({ status: "closed" });
+    });
+
+    it("should report cancellation when pending prefilled validation is superseded", async () => {
+      const contact = mockContact({ addresses: [] });
+      const deferredValidation = createDeferredValidation();
+      const addressValidation = createValidationPort();
+      addressValidation.validateAddress.mockReturnValue(deferredValidation.promise);
+      const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
+
+      let start = Promise.resolve<Awaited<ReturnType<typeof result.current.startWithPrefilled>>>({
+        status: "cancelled",
+      });
+      act(() => {
+        start = result.current.startWithPrefilled({
+          contact,
+          address: RAW_ADDRESS,
+          currency: ETHEREUM_SELECTION,
+          network: ETHEREUM_NETWORK,
+        });
+      });
+      act(() => result.current.close());
+
+      let startResult: Awaited<ReturnType<typeof result.current.startWithPrefilled>> | undefined;
+      await act(async () => {
+        deferredValidation.resolve({
+          status: "valid",
+          resolvedAddress: VALID_ADDRESS,
+          isDomain: false,
+        });
+        startResult = await start;
+      });
+
+      expect(startResult).toEqual({ status: "cancelled" });
+      expect(result.current.state).toEqual({ status: "closed" });
+    });
+
+    it("should close the prefilled naming step on back without returning to address entry", async () => {
+      const contact = mockContact({ addresses: [] });
+      const addressValidation = createValidationPort();
+      const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
+
+      await act(async () => {
+        await result.current.startWithPrefilled({
+          contact,
+          address: RAW_ADDRESS,
+          currency: ETHEREUM_SELECTION,
+          network: ETHEREUM_NETWORK,
+        });
+      });
+      act(() => result.current.goBack());
+
+      expect(result.current.state).toEqual({ status: "closed" });
+    });
+
+    it("should keep MAD naming confirmation behavior unchanged", async () => {
+      const contact = mockContact({ addresses: [] });
+      const addressValidation = createValidationPort();
+      const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
+
+      act(() => result.current.start(contact));
+      act(() => result.current.completeCurrencySelection(contact.id, ETHEREUM_SELECTION));
+      await act(() => result.current.updateAddress(RAW_ADDRESS, "manual"));
+      act(() => result.current.confirmAddress());
+      act(() => result.current.continueFromName());
+
+      expect(result.current.state).toMatchObject({
+        status: "confirmationRequired",
+        entryMode: "mad",
+      });
+    });
   });
 });

--- a/features/flow/flow-contacts-add-address/src/web.ts
+++ b/features/flow/flow-contacts-add-address/src/web.ts
@@ -4,3 +4,4 @@ export * from "./screens/AddressEntry/components/ContactsAddAddressEntry/Contact
 export * from "./screens/AddressName/components/Input/ContactsAddAddressNameInput.web";
 export * from "./screens/Completion/ContactsAddAddressCompletion.web";
 export * from "./screens/Flow/ContactsAddAddressFlowContent.web";
+export * from "./screens/Review";


### PR DESCRIPTION
### Description

Adds a **prefilled Add Address path** in `@features/flow-contacts-add-address` so a known contact, address, currency, and network can skip currency selection (MAD) and address entry.

`startWithPrefilled` validates the destination, then opens on the **naming** screen. Desktop naming is name-only (input, validation, disclaimer) and does not show the confirmed address. Continue goes to a dedicated **review** step (web + native) that shows address, asset, network, and label. Back from naming closes the flow; back from review returns to naming.

The existing MAD Add Address path is unchanged: it still goes through currency selection, address entry, and device confirmation.

Public types (`OpenPrefillAddAddressParams` / `OpenPrefillAddAddressResult`) are exported from this package for the next PR, which wires Desktop and Mobile.

Stacked under: [PR 20911](https://github.com/LedgerHQ/ledger-live/pull/20911)

### Context
[LIVE-35745](https://ledgerhq.atlassian.net/browse/LIVE-35745)

[LIVE-35745]: https://ledgerhq.atlassian.net/browse/LIVE-35745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ