### PR TITLE
feat(contacts): wire prefilled Add Address entry for Send (LIVE-35745)

### DIFF
--- a/.changeset/LIVE-35745-prefill-add-address-apps.md
+++ b/.changeset/LIVE-35745-prefill-add-address-apps.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Expose useOpenPrefillAddAddressFlow and mount PrefillAddAddressFlowRoot on Desktop and Mobile so consumers such as Send can open the prefilled Add Address flow without depending on Contacts internals.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/prefillAddAddress/PrefillAddAddressFlowRoot.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/prefillAddAddress/PrefillAddAddressFlowRoot.tsx
@@ -1,0 +1,104 @@
+import React, { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+} from "@domain/entity-contact";
+import {
+  isPrefillAddAddressFlowOpen,
+  usePrefillAddAddressFlow,
+  type AddAddressCompletionLabels,
+  type ContactsAddAddressNameLabels,
+  type ContactsAddAddressReviewLabels,
+} from "@features/flow-contacts-add-address";
+import { createMockContactDeviceIntentsPort } from "@features/platform-contacts";
+import { ContactsAddAddressFlowDialog } from "../../screens/Contacts/components/ContactsAddAddressFlowDialog";
+import type { ContactsAddAddressFlowDialogProps } from "../../screens/Contacts/components/ContactsAddAddressFlowDialog/types";
+import { useContactsAddressValidationAdapter } from "../useContactsAddressValidationAdapter";
+
+export function PrefillAddAddressFlowRoot(): React.JSX.Element | null {
+  const { t } = useTranslation();
+  const addressValidation = useContactsAddressValidationAdapter();
+  const deviceIntents = useMemo(() => createMockContactDeviceIntentsPort(), []);
+  const { state, updateAddressLabel, continueFromName, onBack, onClose, saveFromReview } =
+    usePrefillAddAddressFlow({ addressValidation, deviceIntents });
+
+  const nameLabels = useMemo<ContactsAddAddressNameLabels>(
+    () => ({
+      inputLabel: t("contacts.addAddressName.inputLabel"),
+      namingDisclaimer: t("contacts.addAddressName.namingDisclaimer"),
+      namingDisclaimerAccessibilityLabel: t(
+        "contacts.addAddressName.namingDisclaimerAccessibilityLabel",
+      ),
+      continueToReview: t("contacts.addAddressName.continueToReview"),
+      validAddress: t("contacts.addAddressEntry.validAddress"),
+      validationErrors: {
+        [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.invalidLabel"),
+        [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.duplicateLabel"),
+        [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: t("contacts.addAddressName.tooLongLabel"),
+      },
+    }),
+    [t],
+  );
+  const reviewLabels = useMemo<ContactsAddAddressReviewLabels>(
+    () => ({
+      title: t("contacts.addAddressReview.title"),
+      addressLabel: t("contacts.addAddressReview.addressLabel"),
+      currencyLabel: t("contacts.addAddressReview.currencyLabel"),
+      networkLabel: t("contacts.addAddressReview.networkLabel"),
+      nameLabel: t("contacts.addAddressReview.nameLabel"),
+      continue: t("contacts.addAddressReview.continue"),
+    }),
+    [t],
+  );
+  const completionLabels = useMemo<AddAddressCompletionLabels>(
+    () => ({
+      title: t("contacts.addAddressReview.title"),
+      continue: t("contacts.addAddressReview.continue"),
+      successTitle: t("contacts.addAddressReview.successTitle"),
+      close: t("contacts.addAddressReview.close"),
+    }),
+    [t],
+  );
+
+  if (!isPrefillAddAddressFlowOpen(state)) {
+    return null;
+  }
+
+  const dialogProps: ContactsAddAddressFlowDialogProps = {
+    state,
+    entryLabels: {
+      title: t("contacts.addAddressEntry.title"),
+      addressPlaceholder: t("contacts.addAddressEntry.addressPlaceholder"),
+      confirmAddress: t("contacts.addAddressEntry.confirmAddress"),
+      validatingAddress: t("contacts.addAddressEntry.validatingAddress"),
+      validAddress: t("contacts.addAddressEntry.validAddress"),
+      invalidAddress: t("contacts.addAddressEntry.invalidAddress"),
+      domainNotFound: t("contacts.addAddressEntry.domainNotFound"),
+      sanctionedAddress: t("contacts.addAddressEntry.sanctionedAddress"),
+      validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
+      ensDisclaimer: t("contacts.addAddressEntry.ensDisclaimer"),
+    },
+    sanctionedAddressBanner: {
+      description: t("contacts.addAddressEntry.sanctioned.description"),
+      actionLabel: t("contacts.addAddressEntry.sanctioned.learnMore"),
+      onAction: () => undefined,
+    },
+    nameLabels,
+    reviewLabels,
+    completionLabels,
+    onAddressChange: () => undefined,
+    onContinueFromAddressDetails: () => undefined,
+    onAddressLabelChange: updateAddressLabel,
+    onContinueFromName: continueFromName,
+    onContinueFromReview: () => {
+      void saveFromReview();
+    },
+    onCompleteMockConfirmation: () => undefined,
+    onBack,
+    onClose,
+  };
+
+  return <ContactsAddAddressFlowDialog {...dialogProps} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/prefillAddAddress/index.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/prefillAddAddress/index.ts
@@ -1,0 +1,2 @@
+export { PrefillAddAddressFlowRoot } from "./PrefillAddAddressFlowRoot";
+export { useOpenPrefillAddAddressFlow } from "@features/flow-contacts-add-address";

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/index.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/index.ts
@@ -1,2 +1,3 @@
 export { ContactsButton } from "./components/ContactsButton";
 export { default } from "./screens/Contacts";
+export { PrefillAddAddressFlowRoot, useOpenPrefillAddAddressFlow } from "./hooks/prefillAddAddress";

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/ContactsAddAddressFlowDialog.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/ContactsAddAddressFlowDialog.tsx
@@ -15,6 +15,7 @@ export function ContactsAddAddressFlowDialog({
   sanctionedAddressBanner,
   nameLabels,
   reviewLabels,
+  completionLabels,
   onAddressChange,
   onContinueFromAddressDetails,
   onAddressLabelChange,
@@ -39,10 +40,11 @@ export function ContactsAddAddressFlowDialog({
             modularDialog.content
           ) : (
             <ContactsAddAddressFlowContent
-              completionLabels={reviewLabels}
+              completionLabels={completionLabels}
               entryLabels={entryLabels}
               sanctionedAddressBanner={sanctionedAddressBanner}
               nameLabels={nameLabels}
+              reviewLabels={reviewLabels}
               onAddressChange={onAddressChange}
               onAddressLabelChange={onAddressLabelChange}
               onClose={onClose}

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/index.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/index.ts
@@ -1,2 +1,2 @@
 export { ContactsAddAddressFlowDialog } from "./ContactsAddAddressFlowDialog";
-export type { ContactsAddAddressFlowDialogProps, ContactsAddAddressReviewLabels } from "./types";
+export type { ContactsAddAddressFlowDialogProps } from "./types";

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/types.ts
@@ -4,10 +4,9 @@ import type {
   AddAddressFlowState,
   AddAddressInputSource,
   ContactsAddAddressNameLabels,
+  ContactsAddAddressReviewLabels,
   SanctionedAddressBannerProps,
 } from "@features/flow-contacts-add-address";
-
-export type ContactsAddAddressReviewLabels = AddAddressCompletionLabels;
 
 export type ContactsAddAddressFlowDialogProps = Readonly<{
   state: AddAddressFlowState;
@@ -15,6 +14,7 @@ export type ContactsAddAddressFlowDialogProps = Readonly<{
   sanctionedAddressBanner: SanctionedAddressBannerProps;
   nameLabels: ContactsAddAddressNameLabels;
   reviewLabels: ContactsAddAddressReviewLabels;
+  completionLabels: AddAddressCompletionLabels;
   onAddressChange: (address: string, inputMethod: AddAddressInputSource) => void;
   onContinueFromAddressDetails: () => void;
   onAddressLabelChange: (value: string) => void;

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -32,9 +32,11 @@ import {
   useAddAddressCurrencySelectionViewModel,
   useAddAddressFlowViewModel,
   type AddAddressContact,
+  type AddAddressCompletionLabels,
   type AddAddressEntryLabels,
   type AddAddressFlowState,
   type ContactsAddAddressNameLabels,
+  type ContactsAddAddressReviewLabels,
 } from "@features/flow-contacts-add-address";
 import {
   CONTACTS_FEATURE_INTRODUCTION_HIGHLIGHTS,
@@ -56,10 +58,7 @@ import { useContactDetailPaneAdapter } from "./useContactDetailPaneAdapter";
 import type { ContactAddressDetailActionsDialogProps } from "./useContactAddressDetailActionsAdapter";
 import { useContactDetailEditDeleteAdapter } from "./useContactDetailEditDeleteAdapter";
 import { useDispatch } from "LLD/hooks/redux";
-import type {
-  ContactsAddAddressFlowDialogProps,
-  ContactsAddAddressReviewLabels,
-} from "./components/ContactsAddAddressFlowDialog";
+import type { ContactsAddAddressFlowDialogProps } from "./components/ContactsAddAddressFlowDialog";
 
 export type ContactsPageViewModel = Omit<ContactsViewProps, "onAddContact"> &
   Readonly<{
@@ -245,6 +244,17 @@ export function useContactsViewModel(): ContactsPageViewModel {
   const addAddressReviewLabels = useMemo<ContactsAddAddressReviewLabels>(
     () => ({
       title: t("contacts.addAddressReview.title"),
+      addressLabel: t("contacts.addAddressReview.addressLabel"),
+      currencyLabel: t("contacts.addAddressReview.currencyLabel"),
+      networkLabel: t("contacts.addAddressReview.networkLabel"),
+      nameLabel: t("contacts.addAddressReview.nameLabel"),
+      continue: t("contacts.addAddressReview.continue"),
+    }),
+    [t],
+  );
+  const addAddressCompletionLabels = useMemo<AddAddressCompletionLabels>(
+    () => ({
+      title: t("contacts.addAddressReview.title"),
       continue: t("contacts.addAddressReview.continue"),
       successTitle: t("contacts.addAddressReview.successTitle"),
       close: t("contacts.addAddressReview.close"),
@@ -262,6 +272,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
       },
       nameLabels: addAddressNameLabels,
       reviewLabels: addAddressReviewLabels,
+      completionLabels: addAddressCompletionLabels,
       onAddressChange: (address, inputMethod) => {
         void updateAddress(address, inputMethod);
       },
@@ -278,6 +289,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
       handleSanctionedAddressLearnMore,
       addAddressNameLabels,
       addAddressReviewLabels,
+      addAddressCompletionLabels,
       addAddressFlowState,
       onBackAddAddress,
       onCloseAddAddress,

--- a/apps/ledger-live-desktop/src/mvvm/features/GlobalDialogs/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GlobalDialogs/index.tsx
@@ -3,6 +3,7 @@ import ModularDialogRoot from "LLD/features/ModularDialog/ModularDialogRoot";
 import SendFlowRoot from "LLD/features/Send/SendFlowRoot";
 import PerpsSignRoot from "LLD/features/Perps/screens/PerpsSign/PerpsSignDialog";
 import ActionConfirmationDialog from "LLD/features/ActionConfirmationDialog";
+import { PrefillAddAddressFlowRoot } from "LLD/features/Contacts";
 
 const ReleaseNotes = lazy(() => import("LLD/features/ReleaseNotes"));
 const BuyDevice = lazy(() => import("LLD/features/BuyDevice"));
@@ -24,6 +25,7 @@ const GlobalDialogs = () => (
     <Suspense fallback={null}>
       <SendFlowRoot />
     </Suspense>
+    <PrefillAddAddressFlowRoot />
     <PerpsSignRoot />
     <ActionConfirmationDialog />
     <Suspense fallback={null}>

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9444,6 +9444,10 @@
     },
     "addAddressReview": {
       "title": "Review address",
+      "addressLabel": "Address",
+      "currencyLabel": "Currency",
+      "networkLabel": "Network",
+      "nameLabel": "Address name",
       "continue": "Confirm address",
       "successTitle": "Address saved",
       "close": "Close"

--- a/apps/ledger-live-mobile/src/GlobalDrawers/__tests__/registry.test.ts
+++ b/apps/ledger-live-mobile/src/GlobalDrawers/__tests__/registry.test.ts
@@ -3,6 +3,7 @@ import { ModularDrawerWrapper } from "LLM/features/ModularDrawer";
 import ReceiveDrawerWrapper from "LLM/features/Receive/drawers/ReceiveFundsOptionsDrawer";
 import { NotificationsPromptWrapper } from "LLM/features/NotificationsPrompt";
 import { SwapTransactionStatusDrawerWrapper } from "LLM/features/SwapTransactionStatus";
+import { PrefillAddAddressFlowRoot } from "LLM/features/Contacts";
 
 describe("GlobalDrawers Registry", () => {
   it("should contain all expected drawer entries with correct components", () => {
@@ -19,6 +20,9 @@ describe("GlobalDrawers Registry", () => {
     expect(DRAWER_REGISTRY.swapTransactionStatus.component).toBe(
       SwapTransactionStatusDrawerWrapper,
     );
+
+    expect(DRAWER_REGISTRY.prefillAddAddress).toBeDefined();
+    expect(DRAWER_REGISTRY.prefillAddAddress.component).toBe(PrefillAddAddressFlowRoot);
   });
 
   it("should have all entries with valid structure", () => {

--- a/apps/ledger-live-mobile/src/GlobalDrawers/registry.ts
+++ b/apps/ledger-live-mobile/src/GlobalDrawers/registry.ts
@@ -5,6 +5,7 @@ import RebornBuyDeviceDrawer from "LLM/features/Reborn/drawers/RebornBuyDeviceDr
 import { DeeplinkInstallAppDrawer } from "LLM/features/DeeplinkInstallApp";
 import { NotificationsPromptWrapper } from "LLM/features/NotificationsPrompt";
 import { SwapTransactionStatusDrawerWrapper } from "LLM/features/SwapTransactionStatus";
+import { PrefillAddAddressFlowRoot } from "LLM/features/Contacts";
 
 /**
  * Registry of all global drawers in the application.
@@ -36,6 +37,9 @@ export const DRAWER_REGISTRY = {
   },
   swapTransactionStatus: {
     component: SwapTransactionStatusDrawerWrapper,
+  },
+  prefillAddAddress: {
+    component: PrefillAddAddressFlowRoot,
   },
 } as const satisfies Record<string, DrawerRegistryEntry>;
 

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10345,6 +10345,14 @@
       "duplicateLabel": "This address name is already used for this contact.",
       "labelTooLong": "This address name is too long."
     },
+    "addAddressReview": {
+      "title": "Review address",
+      "addressLabel": "Address",
+      "currencyLabel": "Currency",
+      "networkLabel": "Network",
+      "nameLabel": "Address name",
+      "continue": "Confirm address"
+    },
     "addressCount_zero": "0 address",
     "addressCount_one": "{{count}} address",
     "addressCount_other": "{{count}} addresses",

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/prefillAddAddress/PrefillAddAddressFlowRoot.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/prefillAddAddress/PrefillAddAddressFlowRoot.tsx
@@ -1,0 +1,129 @@
+import React, { useMemo } from "react";
+import {
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+} from "@domain/entity-contact";
+import {
+  ContactsAddAddressFlowContent,
+  isPrefillAddAddressFlowOpen,
+  usePrefillAddAddressFlow,
+  type ContactsAddAddressReviewLabels,
+} from "@features/flow-contacts-add-address";
+import { createMockContactDeviceIntentsPort } from "@features/platform-contacts";
+import {
+  QueuedDrawerFlow,
+  type QueuedDrawerFlowOptions,
+  type QueuedDrawerFlowScreenRegistry,
+} from "LLM/components/QueuedDrawerFlow";
+import { useTranslation } from "~/context/Locale";
+import { useContactsAddressValidationAdapter } from "../useContactsAddressValidationAdapter";
+
+type PrefillDrawerStep = "name" | "review";
+
+const FLOW_OPTIONS = {
+  snapPoints: ["92%"],
+} as const satisfies QueuedDrawerFlowOptions;
+
+const LOCKED_STEP_OPTIONS = {
+  hasBackButton: true,
+  noCloseButton: true,
+  hideHandle: true,
+  preventBackdropClick: true,
+  enablePanDownToClose: false,
+} as const satisfies QueuedDrawerFlowOptions;
+
+function resolveStep(status: "namingAddress" | "reviewingAddress"): PrefillDrawerStep {
+  return status === "namingAddress" ? "name" : "review";
+}
+
+export function PrefillAddAddressFlowRoot(): React.JSX.Element | null {
+  const { t } = useTranslation();
+  const addressValidation = useContactsAddressValidationAdapter();
+  const deviceIntents = useMemo(() => createMockContactDeviceIntentsPort(), []);
+  const { state, updateAddressLabel, continueFromName, onBack, onClose, saveFromReview } =
+    usePrefillAddAddressFlow({ addressValidation, deviceIntents });
+  const reviewLabels = useMemo<ContactsAddAddressReviewLabels>(
+    () => ({
+      title: t("contacts.addAddressReview.title"),
+      addressLabel: t("contacts.addAddressReview.addressLabel"),
+      currencyLabel: t("contacts.addAddressReview.currencyLabel"),
+      networkLabel: t("contacts.addAddressReview.networkLabel"),
+      nameLabel: t("contacts.addAddressReview.nameLabel"),
+      continue: t("contacts.addAddressReview.continue"),
+    }),
+    [t],
+  );
+
+  if (!isPrefillAddAddressFlowOpen(state)) {
+    return null;
+  }
+
+  const currentStep = resolveStep(state.status);
+  const screens: QueuedDrawerFlowScreenRegistry<PrefillDrawerStep> = {
+    name: {
+      content: (
+        <ContactsAddAddressFlowContent
+          addressEntryProps={null}
+          addressNameProps={{
+            addressLabel: state.addressLabel,
+            labels: {
+              title: t("contacts.addAddressName.title"),
+              inputLabel: t("contacts.addAddressName.inputLabel"),
+              namingDisclaimer: t("contacts.addAddressName.namingDisclaimer"),
+              continueToReview: t("contacts.addAddressName.continueToReview"),
+              validationErrors: {
+                [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t(
+                  "contacts.addAddressName.invalidLabel",
+                ),
+                [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t(
+                  "contacts.addAddressName.duplicateLabel",
+                ),
+                [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: t(
+                  "contacts.addAddressName.labelTooLong",
+                ),
+              },
+            },
+            onChangeText: updateAddressLabel,
+            onContinue: continueFromName,
+          }}
+          addressReviewProps={null}
+          step="name"
+        />
+      ),
+      options: LOCKED_STEP_OPTIONS,
+    },
+    review: {
+      content: (
+        <ContactsAddAddressFlowContent
+          addressEntryProps={null}
+          addressNameProps={null}
+          addressReviewProps={{
+            address: state.addressEntry.resolvedAddress,
+            currency: state.displayContext.assetDisplayName,
+            network: state.displayContext.network.displayName,
+            name: state.addressLabel.label ?? state.addressLabel.value,
+            labels: reviewLabels,
+            onContinue: () => {
+              void saveFromReview();
+            },
+          }}
+          step="review"
+        />
+      ),
+      options: LOCKED_STEP_OPTIONS,
+    },
+  };
+
+  return (
+    <QueuedDrawerFlow
+      currentStep={currentStep}
+      defaultOptions={FLOW_OPTIONS}
+      isOpen
+      onBack={onBack}
+      onClose={onClose}
+      screens={screens}
+      testID="contacts-prefill-add-address-flow-drawer"
+    />
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/prefillAddAddress/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/prefillAddAddress/index.ts
@@ -1,0 +1,2 @@
+export { PrefillAddAddressFlowRoot } from "./PrefillAddAddressFlowRoot";
+export { useOpenPrefillAddAddressFlow } from "@features/flow-contacts-add-address";

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/index.ts
@@ -1,3 +1,4 @@
 export { ContactsButton } from "./components/ContactsButton";
 export { ContactsScreen } from "./screens/ContactsPage";
 export type { ContactAddressDetailActionsFlowProps } from "./hooks/useContactAddressDetailActionsAdapter";
+export { PrefillAddAddressFlowRoot, useOpenPrefillAddAddressFlow } from "./hooks/prefillAddAddress";

--- a/features/flow/flow-contacts-add-address/README.md
+++ b/features/flow/flow-contacts-add-address/README.md
@@ -12,6 +12,8 @@ Shared Add address flow for Desktop and Mobile.
 - Dedicated prefilled-address review UI for Web and React Native.
 - Web dialog content and React Native bottom-sheet content.
 - Public ports and helpers used by application-owned currency selection and validation adapters.
+- Shared prefill-session orchestration (`usePrefillAddAddressFlow` and
+  `useOpenPrefillAddAddressFlow`) so Desktop and Mobile only own translations and chrome.
 
 ## Structure
 
@@ -22,6 +24,8 @@ Shared Add address flow for Desktop and Mobile.
 - `state/` owns the Add address session, label validation, and currency-selection orchestration.
   Shared Contacts address-entry validation state and input behavior are consumed from
   `@features/platform-contacts`.
+- `usePrefillAddAddressFlow` owns opening, saving, and settling a prefilled session. Apps mount a
+  thin root that renders dialog or drawer chrome from that controller.
 
 ## Public API
 

--- a/features/flow/flow-contacts-add-address/package.json
+++ b/features/flow/flow-contacts-add-address/package.json
@@ -27,7 +27,8 @@
     "@domain/entity-contact": "workspace:*",
     "@domain/entity-currency-crypto": "workspace:*",
     "@domain/entity-currency-token": "workspace:*",
-    "@features/platform-contacts": "workspace:^"
+    "@features/platform-contacts": "workspace:^",
+    "uuid": "^9.0.0"
   },
   "peerDependencies": {
     "react": ">=19.0.0",
@@ -57,6 +58,7 @@
     "@testing-library/user-event": "catalog:",
     "@types/jest": "catalog:",
     "@types/react": "catalog:",
+    "@types/uuid": "^9.0.0",
     "jest": "catalog:",
     "jest-environment-jsdom": "catalog:",
     "oxfmt": "catalog:",

--- a/features/flow/flow-contacts-add-address/src/exports.ts
+++ b/features/flow/flow-contacts-add-address/src/exports.ts
@@ -1,4 +1,6 @@
 export * from "./prefillAddAddress";
+export * from "./useOpenPrefillAddAddressFlow";
+export * from "./usePrefillAddAddressFlow";
 export * from "./state/addressValidation/dependencies";
 export * from "./state/addressValidation/service";
 export * from "./state/ports";

--- a/features/flow/flow-contacts-add-address/src/prefillAddAddressFlowStore.ts
+++ b/features/flow/flow-contacts-add-address/src/prefillAddAddressFlowStore.ts
@@ -1,0 +1,23 @@
+import type { OpenPrefillAddAddressParams, OpenPrefillAddAddressResult } from "./prefillAddAddress";
+
+type PrefillAddAddressFlowListener = (
+  params: OpenPrefillAddAddressParams,
+) => Promise<OpenPrefillAddAddressResult>;
+
+let listener: PrefillAddAddressFlowListener | null = null;
+
+export function setPrefillAddAddressFlowListener(
+  nextListener: PrefillAddAddressFlowListener | null,
+): void {
+  listener = nextListener;
+}
+
+export function requestPrefillAddAddressFlow(
+  params: OpenPrefillAddAddressParams,
+): Promise<OpenPrefillAddAddressResult> {
+  if (listener === null) {
+    return Promise.resolve({ status: "unavailable" });
+  }
+
+  return listener(params);
+}

--- a/features/flow/flow-contacts-add-address/src/prefillAddAddressFlowStore.web.test.ts
+++ b/features/flow/flow-contacts-add-address/src/prefillAddAddressFlowStore.web.test.ts
@@ -1,0 +1,36 @@
+import {
+  requestPrefillAddAddressFlow,
+  setPrefillAddAddressFlowListener,
+} from "./prefillAddAddressFlowStore";
+
+describe("prefillAddAddressFlowStore", () => {
+  afterEach(() => {
+    setPrefillAddAddressFlowListener(null);
+  });
+
+  it("should resolve as unavailable when the root is not mounted", async () => {
+    await expect(
+      requestPrefillAddAddressFlow({
+        contactId: "contact-1" as never,
+        address: "0xabc",
+        currency: { currencyId: "ethereum" as never, assetDisplayName: "Ethereum" },
+        network: { networkId: "ethereum", displayName: "Ethereum" },
+      }),
+    ).resolves.toEqual({ status: "unavailable" });
+  });
+
+  it("should forward open requests to the registered listener", async () => {
+    const listener = jest.fn().mockResolvedValue({ status: "cancelled" });
+    setPrefillAddAddressFlowListener(listener);
+
+    const params = {
+      contactId: "contact-1" as never,
+      address: "0xabc",
+      currency: { currencyId: "ethereum" as never, assetDisplayName: "Ethereum" },
+      network: { networkId: "ethereum", displayName: "Ethereum" },
+    };
+
+    await expect(requestPrefillAddAddressFlow(params)).resolves.toEqual({ status: "cancelled" });
+    expect(listener).toHaveBeenCalledWith(params);
+  });
+});

--- a/features/flow/flow-contacts-add-address/src/useOpenPrefillAddAddressFlow.ts
+++ b/features/flow/flow-contacts-add-address/src/useOpenPrefillAddAddressFlow.ts
@@ -1,0 +1,8 @@
+import type { OpenPrefillAddAddressParams, OpenPrefillAddAddressResult } from "./prefillAddAddress";
+import { requestPrefillAddAddressFlow } from "./prefillAddAddressFlowStore";
+
+export function useOpenPrefillAddAddressFlow(): (
+  params: OpenPrefillAddAddressParams,
+) => Promise<OpenPrefillAddAddressResult> {
+  return requestPrefillAddAddressFlow;
+}

--- a/features/flow/flow-contacts-add-address/src/usePrefillAddAddressFlow.ts
+++ b/features/flow/flow-contacts-add-address/src/usePrefillAddAddressFlow.ts
@@ -1,0 +1,211 @@
+import { useCallback, useEffect, useRef } from "react";
+import { useDispatch } from "react-redux";
+import { v4 as uuid } from "uuid";
+import { addAddress, contactAddress, type ContactAddress } from "@domain/entity-contact";
+import {
+  useContacts,
+  type ContactDeviceIntentsPort,
+  type ContactsAddressValidationPort,
+} from "@features/platform-contacts";
+import type { OpenPrefillAddAddressParams, OpenPrefillAddAddressResult } from "./prefillAddAddress";
+import { setPrefillAddAddressFlowListener } from "./prefillAddAddressFlowStore";
+import type { AddAddressDisplayContext, AddAddressFlowState } from "./state/types";
+import {
+  useAddAddressFlowViewModel,
+  type UseAddAddressFlowViewModelOptions,
+} from "./state/useAddAddressFlowViewModel";
+
+type PendingRequest = Readonly<{
+  resolve: (result: OpenPrefillAddAddressResult) => void;
+}>;
+
+export type PrefillAddAddressFlowVisibleState = Extract<
+  AddAddressFlowState,
+  { status: "namingAddress" | "reviewingAddress" }
+> &
+  Readonly<{
+    entryMode: "prefilled";
+    displayContext: AddAddressDisplayContext;
+  }>;
+
+export type UsePrefillAddAddressFlowOptions = Readonly<{
+  addressValidation: ContactsAddressValidationPort;
+  deviceIntents: ContactDeviceIntentsPort;
+  createAddressId?: () => string;
+  manualValidationDebounceMs?: UseAddAddressFlowViewModelOptions["manualValidationDebounceMs"];
+}>;
+
+export type PrefillAddAddressFlowController = Readonly<{
+  state: AddAddressFlowState;
+  updateAddressLabel: (label: string) => void;
+  continueFromName: () => void;
+  onBack: () => void;
+  onClose: () => void;
+  saveFromReview: () => Promise<void>;
+}>;
+
+function createPrefillAddressId(): string {
+  return `address-${uuid()}`;
+}
+
+export function isPrefillAddAddressFlowOpen(
+  state: AddAddressFlowState,
+): state is PrefillAddAddressFlowVisibleState {
+  return (
+    (state.status === "namingAddress" || state.status === "reviewingAddress") &&
+    state.entryMode === "prefilled" &&
+    state.displayContext !== null
+  );
+}
+
+export function usePrefillAddAddressFlow({
+  addressValidation,
+  deviceIntents,
+  createAddressId = createPrefillAddressId,
+  manualValidationDebounceMs,
+}: UsePrefillAddAddressFlowOptions): PrefillAddAddressFlowController {
+  const dispatch = useDispatch();
+  const contacts = useContacts();
+  const pendingRequest = useRef<PendingRequest | null>(null);
+  const {
+    state,
+    startWithPrefilled,
+    updateAddressLabel,
+    continueFromName,
+    continueFromReview,
+    goBack,
+    close,
+  } = useAddAddressFlowViewModel({ addressValidation, manualValidationDebounceMs });
+
+  const settle = useCallback((result: OpenPrefillAddAddressResult) => {
+    pendingRequest.current?.resolve(result);
+    pendingRequest.current = null;
+  }, []);
+
+  const onClose = useCallback(() => {
+    close();
+    settle({ status: "cancelled" });
+  }, [close, settle]);
+
+  const isPrefilledNaming = state.status === "namingAddress" && state.entryMode === "prefilled";
+  const onBack = useCallback(() => {
+    if (isPrefilledNaming) {
+      onClose();
+      return;
+    }
+    goBack();
+  }, [goBack, isPrefilledNaming, onClose]);
+
+  const saveFromReview = useCallback(async () => {
+    if (state.status !== "reviewingAddress" || state.entryMode !== "prefilled") {
+      return;
+    }
+
+    const selectedContact = contacts.find(contact => contact.id === state.selectedContactId);
+    if (selectedContact === undefined) {
+      close();
+      settle({ status: "confirmation_failed" });
+      return;
+    }
+
+    const request = pendingRequest.current;
+    // The user can cancel while the device confirmation is in flight: nothing may be persisted then.
+    const isRequestActive = () => pendingRequest.current === request;
+
+    try {
+      const signedAddress = await deviceIntents.registerExternalAddress({
+        contact: selectedContact,
+        currencyId: state.selectedCurrencyId,
+        label: state.addressLabel.label,
+        address: state.addressEntry.resolvedAddress,
+      });
+      if (!isRequestActive()) {
+        return;
+      }
+
+      const address: ContactAddress = contactAddress({
+        id: createAddressId(),
+        currencyId: state.selectedCurrencyId,
+        label: state.addressLabel.label,
+        address: state.addressEntry.resolvedAddress,
+        device: signedAddress.addressDeviceContext,
+      });
+
+      dispatch(
+        addAddress({
+          contactId: state.selectedContactId,
+          address,
+          deviceCredentials: signedAddress.deviceCredentials,
+        }),
+      );
+      continueFromReview();
+      close();
+      settle({ status: "saved", address });
+    } catch {
+      if (!isRequestActive()) {
+        return;
+      }
+
+      close();
+      settle({ status: "confirmation_failed" });
+    }
+  }, [
+    close,
+    contacts,
+    continueFromReview,
+    createAddressId,
+    deviceIntents,
+    dispatch,
+    settle,
+    state,
+  ]);
+
+  const openPrefillAddAddressFlow = useCallback(
+    async (params: OpenPrefillAddAddressParams): Promise<OpenPrefillAddAddressResult> => {
+      if (pendingRequest.current !== null) {
+        return { status: "unavailable" };
+      }
+
+      const contact = contacts.find(item => item.id === params.contactId);
+      if (contact === undefined) {
+        return { status: "unavailable" };
+      }
+
+      // Registered before any await so an unmount while starting still settles the caller.
+      let resolveRequest!: (result: OpenPrefillAddAddressResult) => void;
+      const request = new Promise<OpenPrefillAddAddressResult>(resolve => {
+        resolveRequest = resolve;
+      });
+      pendingRequest.current = { resolve: resolveRequest };
+
+      const startResult = await startWithPrefilled({
+        contact,
+        address: params.address,
+        currency: params.currency,
+        network: params.network,
+      });
+
+      if (startResult.status !== "started") {
+        settle(startResult);
+      }
+
+      return request;
+    },
+    [contacts, settle, startWithPrefilled],
+  );
+
+  useEffect(() => {
+    setPrefillAddAddressFlowListener(openPrefillAddAddressFlow);
+    return () => setPrefillAddAddressFlowListener(null);
+  }, [openPrefillAddAddressFlow]);
+  useEffect(() => () => settle({ status: "unavailable" }), [settle]);
+
+  return {
+    state,
+    updateAddressLabel,
+    continueFromName,
+    onBack,
+    onClose,
+    saveFromReview,
+  };
+}

--- a/features/flow/flow-contacts-add-address/src/usePrefillAddAddressFlow.web.test.ts
+++ b/features/flow/flow-contacts-add-address/src/usePrefillAddAddressFlow.web.test.ts
@@ -1,0 +1,390 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useDispatch } from "react-redux";
+import { addAddress, ContactAddressValueSchema } from "@domain/entity-contact";
+import {
+  mockContact,
+  mockDeviceContactGroupCredentials,
+  mockExternalAddressDeviceContext,
+} from "@domain/entity-contact/schema.mock";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import {
+  createMockContactDeviceIntentsPort,
+  useContacts,
+  type ContactsAddressValidationPort,
+} from "@features/platform-contacts";
+import type { OpenPrefillAddAddressParams } from "./prefillAddAddress";
+import { requestPrefillAddAddressFlow } from "./prefillAddAddressFlowStore";
+import {
+  isPrefillAddAddressFlowOpen,
+  usePrefillAddAddressFlow,
+  type UsePrefillAddAddressFlowOptions,
+} from "./usePrefillAddAddressFlow";
+
+jest.mock("@features/platform-contacts", () => ({
+  ...jest.requireActual("@features/platform-contacts"),
+  useContacts: jest.fn(),
+}));
+
+jest.mock("react-redux", () => ({
+  ...jest.requireActual("react-redux"),
+  useDispatch: jest.fn(),
+}));
+
+const mockedUseContacts = jest.mocked(useContacts);
+const mockedUseDispatch = jest.mocked(useDispatch);
+const ETHEREUM_CURRENCY_ID = getCryptoCurrencyById("ethereum").id;
+const RAW_ADDRESS = "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034";
+const VALID_ADDRESS = ContactAddressValueSchema.parse(RAW_ADDRESS);
+const PREFILL_PARAMS: OpenPrefillAddAddressParams = {
+  contactId: mockContact().id,
+  address: RAW_ADDRESS,
+  currency: { currencyId: ETHEREUM_CURRENCY_ID, assetDisplayName: "Ethereum" },
+  network: { networkId: "ethereum", displayName: "Ethereum" },
+};
+
+function createValidationPort(): ContactsAddressValidationPort & {
+  validateAddress: jest.MockedFunction<ContactsAddressValidationPort["validateAddress"]>;
+} {
+  return {
+    validateAddress: jest.fn().mockResolvedValue({
+      status: "valid",
+      resolvedAddress: VALID_ADDRESS,
+      isDomain: false,
+    }),
+  };
+}
+
+function openPrefillFlow() {
+  return requestPrefillAddAddressFlow(PREFILL_PARAMS);
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(resolvePromise => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
+
+function renderPrefillFlow(
+  options: Omit<UsePrefillAddAddressFlowOptions, "deviceIntents"> &
+    Partial<Pick<UsePrefillAddAddressFlowOptions, "deviceIntents">>,
+) {
+  const deviceIntents = options.deviceIntents ?? createMockContactDeviceIntentsPort();
+
+  return renderHook(() => usePrefillAddAddressFlow({ ...options, deviceIntents }));
+}
+
+describe("usePrefillAddAddressFlow", () => {
+  const dispatch = jest.fn();
+  const contact = mockContact({ addresses: [] });
+
+  beforeEach(() => {
+    dispatch.mockReset();
+    mockedUseDispatch.mockReturnValue(dispatch);
+    mockedUseContacts.mockReturnValue([contact]);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should mark a prefilled naming state as open", () => {
+    expect(
+      isPrefillAddAddressFlowOpen({
+        status: "namingAddress",
+        selectedContactId: contact.id,
+        existingAddressLabels: [],
+        selectedCurrencyId: ETHEREUM_CURRENCY_ID,
+        entryMode: "prefilled",
+        displayContext: {
+          assetDisplayName: "Ethereum",
+          network: { networkId: "ethereum", displayName: "Ethereum" },
+        },
+        addressEntry: {
+          status: "valid",
+          value: RAW_ADDRESS,
+          resolvedAddress: VALID_ADDRESS,
+          inputMethod: "manual",
+        },
+        addressLabel: {
+          status: "valid",
+          value: "Ethereum",
+          label: "Ethereum" as never,
+          validationError: null,
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("should resolve as unavailable when the contact is missing", async () => {
+    mockedUseContacts.mockReturnValue([]);
+    const addressValidation = createValidationPort();
+    renderPrefillFlow({ addressValidation });
+
+    await expect(requestPrefillAddAddressFlow(PREFILL_PARAMS)).resolves.toEqual({
+      status: "unavailable",
+    });
+  });
+
+  it("should cancel a pending request when the flow is closed from naming", async () => {
+    const addressValidation = createValidationPort();
+    const { result } = renderPrefillFlow({ addressValidation });
+    const pending = openPrefillFlow();
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe("namingAddress");
+    });
+
+    act(() => {
+      result.current.onBack();
+    });
+
+    await expect(pending).resolves.toEqual({ status: "cancelled" });
+    expect(result.current.state).toEqual({ status: "closed" });
+  });
+
+  it("should save the address from review and settle as saved", async () => {
+    const addressValidation = createValidationPort();
+    const deviceCredentials = mockDeviceContactGroupCredentials();
+    const addressDeviceContext = mockExternalAddressDeviceContext();
+    const deviceIntents = {
+      registerExternalAddress: jest.fn().mockResolvedValue({
+        deviceCredentials,
+        addressDeviceContext,
+      }),
+      renameExternalContact: jest.fn(),
+      editExternalAddressScope: jest.fn(),
+    };
+    const { result } = renderPrefillFlow({
+      addressValidation,
+      deviceIntents,
+      createAddressId: () => "address-prefill",
+    });
+    const pending = openPrefillFlow();
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe("namingAddress");
+    });
+
+    act(() => {
+      result.current.updateAddressLabel("Exchange");
+      result.current.continueFromName();
+    });
+
+    await act(async () => {
+      await result.current.saveFromReview();
+    });
+
+    const resolved = await pending;
+    expect(resolved).toMatchObject({
+      status: "saved",
+      address: {
+        id: "address-prefill",
+        currencyId: ETHEREUM_CURRENCY_ID,
+        label: "Exchange",
+        address: VALID_ADDRESS,
+        device: addressDeviceContext,
+      },
+    });
+    expect(dispatch).toHaveBeenCalledWith(
+      addAddress({
+        contactId: contact.id,
+        address: expect.objectContaining({ id: "address-prefill" }),
+        deviceCredentials,
+      }),
+    );
+    expect(result.current.state).toEqual({ status: "closed" });
+  });
+
+  it("should settle as confirmation_failed when device confirmation throws", async () => {
+    const addressValidation = createValidationPort();
+    const deviceIntents = {
+      registerExternalAddress: jest.fn().mockRejectedValue(new Error("device")),
+      renameExternalContact: jest.fn(),
+      editExternalAddressScope: jest.fn(),
+    };
+    const { result } = renderPrefillFlow({ addressValidation, deviceIntents });
+    const pending = openPrefillFlow();
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe("namingAddress");
+    });
+
+    act(() => {
+      result.current.continueFromName();
+    });
+
+    await act(async () => {
+      await result.current.saveFromReview();
+    });
+
+    await expect(pending).resolves.toEqual({ status: "confirmation_failed" });
+  });
+
+  it("should settle as unavailable when the root unmounts", async () => {
+    const addressValidation = createValidationPort();
+    const { result, unmount } = renderPrefillFlow({ addressValidation });
+    const pending = openPrefillFlow();
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe("namingAddress");
+    });
+
+    unmount();
+
+    await expect(pending).resolves.toEqual({ status: "unavailable" });
+  });
+
+  it("should settle as unavailable when the root unmounts while the flow is starting", async () => {
+    const addressValidation = createValidationPort();
+    const validation =
+      deferred<Awaited<ReturnType<ContactsAddressValidationPort["validateAddress"]>>>();
+    addressValidation.validateAddress.mockReturnValue(validation.promise);
+    const { unmount } = renderPrefillFlow({ addressValidation });
+    const pending = openPrefillFlow();
+
+    unmount();
+    await act(async () => {
+      validation.resolve({ status: "valid", resolvedAddress: VALID_ADDRESS, isDomain: false });
+    });
+
+    await expect(pending).resolves.toEqual({ status: "unavailable" });
+  });
+
+  it("should not persist the address when the flow is cancelled during device confirmation", async () => {
+    const addressValidation = createValidationPort();
+    const confirmation = deferred<{
+      deviceCredentials: ReturnType<typeof mockDeviceContactGroupCredentials>;
+      addressDeviceContext: ReturnType<typeof mockExternalAddressDeviceContext>;
+    }>();
+    const deviceIntents = {
+      registerExternalAddress: jest.fn().mockReturnValue(confirmation.promise),
+      renameExternalContact: jest.fn(),
+      editExternalAddressScope: jest.fn(),
+    };
+    const { result } = renderPrefillFlow({ addressValidation, deviceIntents });
+    const pending = openPrefillFlow();
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe("namingAddress");
+    });
+
+    act(() => {
+      result.current.continueFromName();
+    });
+
+    let saving: Promise<void>;
+    act(() => {
+      saving = result.current.saveFromReview();
+    });
+    act(() => {
+      result.current.onClose();
+    });
+
+    await act(async () => {
+      confirmation.resolve({
+        deviceCredentials: mockDeviceContactGroupCredentials(),
+        addressDeviceContext: mockExternalAddressDeviceContext(),
+      });
+      await saving;
+    });
+
+    await expect(pending).resolves.toEqual({ status: "cancelled" });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("should return unavailable when a second open is requested while one is pending", async () => {
+    const addressValidation = createValidationPort();
+    const { result } = renderPrefillFlow({ addressValidation });
+    const pending = openPrefillFlow();
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe("namingAddress");
+    });
+
+    await expect(openPrefillFlow()).resolves.toEqual({ status: "unavailable" });
+
+    act(() => {
+      result.current.onClose();
+    });
+    await pending;
+  });
+
+  it("should return the start result when the supplied address is invalid", async () => {
+    const addressValidation = createValidationPort();
+    addressValidation.validateAddress.mockResolvedValue({ status: "invalid_format" });
+    renderPrefillFlow({ addressValidation });
+
+    await expect(openPrefillFlow()).resolves.toEqual({
+      status: "invalid_address",
+      error: "invalid_format",
+    });
+  });
+
+  it("should go back from review to naming without cancelling", async () => {
+    const addressValidation = createValidationPort();
+    const { result } = renderPrefillFlow({ addressValidation });
+    const pending = openPrefillFlow();
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe("namingAddress");
+    });
+
+    act(() => {
+      result.current.continueFromName();
+    });
+    act(() => {
+      result.current.onBack();
+    });
+
+    expect(result.current.state.status).toBe("namingAddress");
+    act(() => {
+      result.current.onClose();
+    });
+    await expect(pending).resolves.toEqual({ status: "cancelled" });
+  });
+
+  it("should settle as confirmation_failed when the selected contact is gone", async () => {
+    const addressValidation = createValidationPort();
+    const { result, rerender } = renderPrefillFlow({ addressValidation });
+    const pending = openPrefillFlow();
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe("namingAddress");
+    });
+
+    act(() => {
+      result.current.continueFromName();
+    });
+    mockedUseContacts.mockReturnValue([]);
+    rerender();
+
+    await act(async () => {
+      await result.current.saveFromReview();
+    });
+
+    await expect(pending).resolves.toEqual({ status: "confirmation_failed" });
+  });
+
+  it("should ignore saveFromReview when the flow is not reviewing", async () => {
+    const addressValidation = createValidationPort();
+    const { result } = renderPrefillFlow({ addressValidation });
+    const pending = openPrefillFlow();
+
+    await waitFor(() => {
+      expect(result.current.state.status).toBe("namingAddress");
+    });
+
+    await act(async () => {
+      await result.current.saveFromReview();
+    });
+
+    expect(result.current.state.status).toBe("namingAddress");
+    act(() => {
+      result.current.onClose();
+    });
+    await pending;
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5128,6 +5128,9 @@ importers:
       '@features/platform-contacts':
         specifier: workspace:^
         version: link:../../platform/contacts
+      uuid:
+        specifier: ^9.0.0
+        version: 9.0.1
     devDependencies:
       '@features/platform-feature-flags':
         specifier: workspace:^
@@ -5174,6 +5177,9 @@ importers:
       '@types/react':
         specifier: 'catalog:'
         version: 19.0.14
+      '@types/uuid':
+        specifier: ^9.0.0
+        version: 9.0.8
       jest:
         specifier: 'catalog:'
         version: 30.2.0


### PR DESCRIPTION
### 📝 Description

Gives Send (and any other consumer) a one-call way to open the prefilled Add Address flow and await
its outcome, without importing Contacts internals or owning any drawer/dialog state.

```ts
const openPrefillAddAddress = useOpenPrefillAddAddressFlow();

const result = await openPrefillAddAddress({ contactId, address, currency, network });
// { status: "saved", address } | "cancelled" | "invalid_address" | "confirmation_failed" | "unavailable"
```

The call resolves only once the user finishes: it validates the supplied address, opens on the
naming step, walks through review and device confirmation, persists via `addAddress`, and settles
the promise. `unavailable` covers every case where the flow can't run — no root mounted, unknown
`contactId`, address validation unreachable, or a request already in flight — so callers never hang.

**Approach.** `@features/flow-contacts-add-address` owns the session (`usePrefillAddAddressFlow`
for open/back/close/save/settle, `useOpenPrefillAddAddressFlow` for consumers), and a module-level
listener store connects the two so callers need no ref or context to the mounted root. Both apps
mount a thin root that supplies only translations and platform chrome: Desktop renders
`ContactsAddAddressFlowDialog` from `GlobalDialogs`, Mobile renders `QueuedDrawerFlow` registered as
`DRAWER_REGISTRY.prefillAddAddress`. Keeping orchestration in the flow package stops the two roots
from each holding a copy of the same save logic.

**Drive-by fix.** Desktop passed `completionLabels={reviewLabels}`, so the review step rendered
completion copy. The two are now separate props, with the review keys (`addressLabel`,
`currencyLabel`, `networkLabel`, `nameLabel`) added to EN on both apps, and the app-local
`ContactsAddAddressReviewLabels` alias replaced by the flow package's type.

**Regression cover.** 11 cases on `usePrefillAddAddressFlow`: the save path dispatches `addAddress`
and resolves `saved`; back from naming resolves `cancelled`; device rejection and a vanished contact
resolve `confirmation_failed`; unmount resolves `unavailable`; a concurrent open and an invalid
address are rejected without opening. Plus listener-store tests and the Mobile drawer registry
assertion. Desktop and Mobile `typecheck` pass.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35745](https://ledgerhq.atlassian.net/browse/LIVE-35745)
- **ADR** (if any): n/a
- **Stacked on**: #20910 (base branch)


[LIVE-35745]: https://ledgerhq.atlassian.net/browse/LIVE-35745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ