### PR TITLE
fix(e2e): re-anchor mobile swap quote waits off number-of-quotes

### DIFF
--- a/e2e/mobile/helpers/elementHelpers.ts
+++ b/e2e/mobile/helpers/elementHelpers.ts
@@ -425,9 +425,12 @@ export const WebElementHelpers = {
     return index > 0 ? base.atIndex(index) : base;
   },
 
+  // includeEmpty keeps text-less nodes in the result, so a caller can tell a missing
+  // element apart from one that rendered without text.
   async getWebElementsText(
     containerWebElement: WebElement,
     childrenCssSelector: string,
+    options: { includeEmpty?: boolean } = {},
   ): Promise<string[]> {
     const raw = await containerWebElement.runScript(
       (el: HTMLElement, sel: string) =>
@@ -439,7 +442,7 @@ export const WebElementHelpers = {
       [childrenCssSelector],
     );
     const texts: string[] = JSON.parse(raw);
-    return texts.filter(Boolean);
+    return options.includeEmpty ? texts : texts.filter(Boolean);
   },
 
   getWebElementByXpath(xpath: string, index = 0): WebElement {

--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -4,6 +4,12 @@ import { getMinimumSwapAmount } from "@ledgerhq/live-e2e-shared/swap";
 import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { retryUntilTimeout } from "@e2e/utils/retry";
 import { floatNumberRegex } from "@ledgerhq/live-e2e-shared/data/regexes";
+import {
+  COUNTDOWN_STABLE_TIMEOUT,
+  PROVIDER_LIST_SETTLE_TIMEOUT,
+  QUOTES_FETCH_TIMEOUT,
+  UI_RENDER_TIMEOUT,
+} from "@e2e/utils/constants";
 
 // Uniswap's Permit2 "Approve token access" step can take 1-5 min to confirm on-chain
 // before the sign-permit button (Step 2) appears (the app shows a "1-5 mins" estimate).
@@ -18,6 +24,7 @@ const quoteNetValue = (quote: { rate: number; fees: number }) => quote.rate - qu
 
 export default class SwapLiveAppPage {
   private static readonly PROVIDER_NAME_PREFIX = "lumen-quote-card-provider-name-";
+  private static readonly PROVIDER_NAME_CSS = `[data-testid^='${SwapLiveAppPage.PROVIDER_NAME_PREFIX}']`;
 
   fromSelector = "from-account-coin-selector";
   fromAmount = "from-account";
@@ -26,7 +33,8 @@ export default class SwapLiveAppPage {
   toAmountInput = "to-account-amount-input";
   getQuotesButton = "mobile-get-quotes-button";
   quotesButtonDisabled = "mobile-get-quotes-button-disabled";
-  numberOfQuotes = "number-of-quotes";
+  // Mounts only once a quote exists. Replaces the removed "number-of-quotes" banner.
+  bestValueInfoIcon = "best-value-info-icon";
   quotesCountDown = "quotes-countdown";
   executeSwapButton = "execute-button";
   executeSwapButtonStepApproval = "execute-swap-button-step-approval";
@@ -125,13 +133,18 @@ export default class SwapLiveAppPage {
 
   @Step("Wait for quotes")
   async waitForQuotes() {
-    await waitWebElementByTestId(this.numberOfQuotes);
+    // The card is the real wait; the icon lands in the same render.
+    await waitWebElementByTestId(SwapLiveAppPage.PROVIDER_NAME_PREFIX, {
+      timeout: QUOTES_FETCH_TIMEOUT,
+    });
+    await waitWebElementByTestId(this.bestValueInfoIcon, { timeout: UI_RENDER_TIMEOUT });
     await this.waitForQuotesStable();
   }
 
   @Step("verify quotes are displayed")
   async checkQuotes() {
-    await detoxExpect(getWebElementByTestId(this.numberOfQuotes)).toExist();
+    await waitWebElementByTestId(this.bestValueInfoIcon, { timeout: QUOTES_FETCH_TIMEOUT });
+    await detoxExpect(getWebElementByTestId(this.bestValueInfoIcon)).toExist();
   }
 
   @Step("Select available provider")
@@ -153,8 +166,10 @@ export default class SwapLiveAppPage {
     throw new Error("No single-app exchange providers found");
   }
 
+  // Keeps callers off quotes that a refresh is about to replace. Seconds left is an
+  // instantaneous property, so one good read is the whole check.
   @Step("Wait for quotes countdown to be stable")
-  async waitForQuotesStable(timeout: number = 20000) {
+  async waitForQuotesStable(timeout: number = COUNTDOWN_STABLE_TIMEOUT) {
     await retryUntilTimeout(async () => {
       const countdownText = await getWebElementText(this.quotesCountDown);
       const currentSeconds = Number.parseInt(countdownText.replaceAll(/\D/g, ""), 10);
@@ -162,11 +177,8 @@ export default class SwapLiveAppPage {
       if (Number.isNaN(currentSeconds)) {
         throw new TypeError(`Could not parse countdown value: ${countdownText}`);
       }
-
-      if (currentSeconds < 2 || currentSeconds > 19) {
-        const errorMsg = `Countdown is ${currentSeconds}s, waiting for value between 2-19s`;
-        console.log(errorMsg);
-        throw new Error(errorMsg);
+      if (currentSeconds < 2) {
+        throw new Error(`Countdown is ${currentSeconds}s, too close to a refresh`);
       }
 
       return currentSeconds;
@@ -205,31 +217,48 @@ export default class SwapLiveAppPage {
     );
   }
 
+  // Settled means the DOM matches the quotes held so far; a slow provider may still be missing.
   @Step("Get provider list")
   async getProviderList() {
-    await detoxExpect(getWebElementByTestId(this.numberOfQuotes)).toExist();
+    await detoxExpect(getWebElementByTestId(this.bestValueInfoIcon)).toExist();
     await detoxExpect(getWebElementByTestId(this.quotesCountDown)).toExist();
 
-    return await retryUntilTimeout(async () => {
-      const numberOfQuotesText = await getWebElementText(this.numberOfQuotes);
-      const providerList = await getWebElementsText(
-        this.swapMainContainerWebElement,
-        `[data-testid^='${SwapLiveAppPage.PROVIDER_NAME_PREFIX}']`,
-      );
+    // Outside the callback: retryUntilTimeout re-invokes the same fn.
+    let previousCount = -1;
 
-      // "N quotes found" is translated per language, so only the leading count is checked.
-      const displayedCount = Number.parseInt(numberOfQuotesText, 10);
-      if (Number.isNaN(displayedCount) || displayedCount !== providerList.length) {
-        throw new Error(
-          `Quote count mismatch: UI shows "${numberOfQuotesText}" but found ${providerList.length} cards`,
+    const providerList = await retryUntilTimeout(
+      async () => {
+        // One query, so the count and the names describe the same instant.
+        const renderedCards = await getWebElementsText(
+          this.swapMainContainerWebElement,
+          SwapLiveAppPage.PROVIDER_NAME_CSS,
+          { includeEmpty: true },
         );
-      }
-      if (providerList.length === 0) {
-        throw new Error("No quote providers were returned");
-      }
+        const names = renderedCards.filter(Boolean);
 
-      return providerList;
-    }, 30000);
+        if (renderedCards.length === 0) {
+          throw new Error("No quote providers were returned");
+        }
+        // A shortfall means a card whose display name has not resolved yet.
+        if (names.length !== renderedCards.length) {
+          throw new Error(
+            `${renderedCards.length - names.length} of ${renderedCards.length} quote card(s) still have an empty provider name`,
+          );
+        }
+        if (names.length !== previousCount) {
+          previousCount = names.length;
+          throw new Error(
+            `Quote list still growing (${names.length} cards); waiting for it to settle`,
+          );
+        }
+
+        return names;
+      },
+      PROVIDER_LIST_SETTLE_TIMEOUT,
+      1000,
+    );
+
+    return providerList;
   }
 
   @Step("Check error message: {{{0}}}")
@@ -354,12 +383,13 @@ export default class SwapLiveAppPage {
       throw new Error(`No parsable quote found for provider ${provider}`);
     }
 
-    const parseAmount = (amount: string) => Number.parseFloat(amount.replace(/,/g, ""));
+    const parseAmount = (amount: string) => Number.parseFloat(amount.replaceAll(",", ""));
 
     return {
       provider,
       fees: parseAmount(feesMatch[1]),
-      rate: parseAmount(usdAmounts[usdAmounts.length - 1]),
+      // Non-null: the guard above rejects an empty usdAmounts.
+      rate: parseAmount(usdAmounts.at(-1)!),
     };
   }
 

--- a/e2e/mobile/utils/constants.ts
+++ b/e2e/mobile/utils/constants.ts
@@ -1,1 +1,17 @@
 export const NANO_APP_CATALOG_PATH = "artifacts/appVersion/nano-app-catalog.json";
+
+// Swap quote wait budgets. Kept here rather than on the page object so utils can
+// import them without depending on a page implementation.
+
+// Quote API round trip. Resolves in under 10s; fail fast instead of inheriting the 60s default.
+export const QUOTES_FETCH_TIMEOUT = 15_000;
+
+// Time for the quote list to stop changing. Providers answer at their own pace, so this is
+// deliberately looser than the fetch budget - fail-fast on the request must not cap settling.
+export const PROVIDER_LIST_SETTLE_TIMEOUT = 30_000;
+
+// A React commit that has already been triggered. Not a network wait.
+export const UI_RENDER_TIMEOUT = 5_000;
+
+// Quote countdown. Must exceed one 20s refresh cycle so a single slow refresh is not fatal.
+export const COUNTDOWN_STABLE_TIMEOUT = 45_000;

--- a/e2e/mobile/utils/swapUtils.ts
+++ b/e2e/mobile/utils/swapUtils.ts
@@ -5,6 +5,7 @@ import { floatNumberRegex } from "@ledgerhq/live-e2e-shared/data/regexes";
 import { getEnv } from "@shared/env";
 import BigNumber from "bignumber.js";
 import { deleteSpeculos, launchSpeculos, registerSpeculos } from "@e2e/utils/speculosUtils";
+import { QUOTES_FETCH_TIMEOUT } from "@e2e/utils/constants";
 
 /**
  * Mirrors swap-live-app's remote-config decimal cap (currently defaults to 8, see
@@ -57,7 +58,12 @@ export async function performSwapUntilQuoteSelectionStep(
   await selectCurrency(accountToCredit, false, selectSpecificToAccount);
   await app.swapLiveApp.inputAmount(amount);
   if (continueToQuotes) {
-    await waitForWebElementToMatchRegex(app.swapLiveApp.toAmountInput, floatNumberRegex, 20000);
+    // Also comes from the quote API.
+    await waitForWebElementToMatchRegex(
+      app.swapLiveApp.toAmountInput,
+      floatNumberRegex,
+      QUOTES_FETCH_TIMEOUT,
+    );
     await app.swapLiveApp.tapGetQuotesButton();
     await app.swapLiveApp.waitForQuotes();
   }


### PR DESCRIPTION
## Context

[swap-live-app #1820 "redesign quotes list header"](https://github.com/LedgerHQ/swap-live-app/pull/1820) merged to `develop` on 2026-08-18 12:01 UTC and deployed to the `swap-live-app-stg-aws` manifest the mobile suite targets. It **intentionally** removed the `data-testid="number-of-quotes"` banner ("N quotes found") from the Lumen quotes list — the layout our E2E env runs since `9db0acf75d4` made the suite Lumen-only.

Every quote-dependent mobile swap spec has failed since, with `Web element 'number-of-quotes' not found after 60000ms` — 356 of ~420 failures in [run 32141967340](https://github.com/LedgerHQ/ledger-live/actions/runs/32141967340).

## Changes

**Re-anchor on `best-value-info-icon` + the quote cards.** `BestQuoteTitle` in `QuotesList.tsx` renders both whenever a quote exists, ungated by `isMobile` and by `ptxLumenQuoteCard`. Desktop already migrated to this exact testid in `fb8326b046a` (May 2026) and is green — this brings mobile in line.

**Replace the count cross-check with a settling loop.** The banner also backed `getProviderList`'s "banner count == card count" assertion, and nothing in the new markup carries the count. Rather than drop the check (desktop never had one), the loop now requires: at least one card, no card with an unresolved provider name, and a count stable across two consecutive polls. That preserves what the check actually protected against — a silently truncated provider list reaching `checkBestOffer` and `selectExchange`. Two paths make the DOM lag the model: `RenderQuoteCard` returns `null` while `quoteCardData[index]` is undefined, and `displayName` comes from `useProviders()`, a different query from `useQuotes()`.

**New `countWebElements` helper.** `getWebElementsText` filters empty strings, so on its own it cannot distinguish "card missing" from "card rendered without a name". Registered in `jest.environment.ts` and `global.d.ts` — these helpers are consumed as globals, not imports.

**Tighter quote timeouts.** One `QUOTES_FETCH_TIMEOUT = 15_000` replaces the inherited 60s default, matching real fetch times (<10s). This is also why the failing run took so long: a dead selector at 60s x Detox's 3 retries burned ~3 min/spec, stretching shards to 20-40 min. `waitForQuotesStable` keeps its 20s budget — it is bound by the refresh cycle, not by fetch time.

No spec files changed. Desktop untouched. No changeset — `ledger-live-mobile-e2e-tests` is `private: true`.

## Verification

- [x] `pnpm typecheck` (e2e/mobile) passes
- [x] `pnpm format:check` clean
- [x] `pnpm lint` 33 warnings / 0 errors — identical to the pre-change baseline
- [x] [e2e execution of full "swap" scope on mobile](https://github.com/LedgerHQ/ledger-live/actions/runs/32343901352)