### PR TITLE
[LWDM] fix(contacts): allow numeric names and hide search CTA

### DIFF
--- a/.changeset/bright-contacts-input-search.md
+++ b/.changeset/bright-contacts-input-search.md
@@ -1,0 +1,8 @@
+---
+"@domain/entity-contact": patch
+"@features/flow-contacts-list": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Allow numbers in contact names and hide add-contact actions when a Contacts search has no results.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -284,21 +284,15 @@ describe("Contacts integration", () => {
 
     const input = screen.getByTestId("contacts-add-contact-name-input");
 
-    await user.type(input, "Ada1");
+    await user.type(input, "Coinbase 1");
 
-    expect(screen.getByText("Special characters are not allowed.")).toBeVisible();
-    expect(screen.getByTestId("contacts-add-contact-save")).toBeDisabled();
-
-    fireEvent.change(input, { target: { value: "Ada" } });
-
-    expect(screen.queryByText("Special characters are not allowed.")).not.toBeInTheDocument();
     expect(screen.getByTestId("contacts-add-contact-save")).toBeEnabled();
 
     await user.click(screen.getByTestId("contacts-add-contact-save"));
 
     await waitFor(() => {
       expect(screen.queryByTestId("contacts-add-contact-dialog")).not.toBeInTheDocument();
-      expect(screen.getByText("Ada")).toBeVisible();
+      expect(screen.getByText("Coinbase 1")).toBeVisible();
     });
   });
 
@@ -339,6 +333,8 @@ describe("Contacts integration", () => {
     expect(screen.getByTestId("contacts-search-no-results")).toBeVisible();
     expect(screen.getByText("No contact found")).toBeVisible();
     expect(screen.queryByTestId("contacts-saved-row-contact-ben")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("contacts-add-contact")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("contacts-add-contact-header")).not.toBeInTheDocument();
   });
 
   it("should show the one-time feature introduction on first visit and complete it from Try contacts", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/AddContactDrawer.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/AddContactDrawer.integration.test.tsx
@@ -45,22 +45,16 @@ describe("Contacts add contact drawer integration", () => {
     await user.press(screen.getByTestId("contacts-add-contact-row"));
     const input = screen.getByTestId("contacts-add-contact-name-input");
 
-    await user.type(input, "Ada1");
-
-    expect(screen.getByText("Special characters are not allowed.")).toBeVisible();
-    expect(screen.getByRole("button", { name: "Confirm name" })).toBeDisabled();
-
-    fireEvent.changeText(input, "Ada");
+    await user.type(input, "Coinbase 1");
 
     await waitFor(() => {
-      expect(screen.queryByText("Special characters are not allowed.")).toBeNull();
       expect(screen.getByRole("button", { name: "Confirm name" })).toBeEnabled();
     });
 
     await user.press(screen.getByRole("button", { name: "Confirm name" }));
 
     await waitFor(() => {
-      expect(screen.getByText("Ada")).toBeVisible();
+      expect(screen.getByText("Coinbase 1")).toBeVisible();
       expect(screen.queryByTestId("contacts-add-contact-row")).toBeNull();
       expect(screen.queryByTestId("contacts-add-contact-name-input")).toBeNull();
     });
@@ -116,7 +110,13 @@ describe("Contacts add contact drawer integration", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("contacts-search-no-results")).toBeVisible();
-      expect(screen.getByTestId("contacts-add-contact-header")).toBeEnabled();
+      expect(screen.queryByTestId("contacts-add-contact-header")).toBeNull();
+    });
+
+    await user.clear(screen.getByTestId("contacts-search-input"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts-add-contact-header")).toBeVisible();
     });
 
     await user.press(screen.getByTestId("contacts-add-contact-header"));

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -508,6 +508,7 @@ describe("Contacts integration", () => {
       );
       expect(screen.queryByTestId("contacts-me-item")).toBeNull();
       expect(screen.queryByTestId("contacts-add-contact-row")).toBeNull();
+      expect(screen.queryByTestId("contacts-add-contact-header")).toBeNull();
     });
 
     await user.clear(input);
@@ -515,6 +516,7 @@ describe("Contacts integration", () => {
     await waitFor(() => {
       expect(screen.queryByTestId("contacts-search-no-results")).toBeNull();
       expect(screen.getByTestId("contacts-add-contact-row")).toBeVisible();
+      expect(screen.getByTestId("contacts-add-contact-header")).toBeVisible();
     });
 
     await user.type(input, "Me");

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/ContactsAddContactDrawerSheet.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/ContactsAddContactDrawerSheet.test.tsx
@@ -99,7 +99,7 @@ describe("ContactsAddContactDrawerSheet", () => {
   it("should render the shared validation error and disable confirmation", () => {
     render(
       <ContactsAddContactDrawerSheet
-        {...createViewModel({ draftName: "Ada1", invalidNameError: "InvalidContactNameError" })}
+        {...createViewModel({ draftName: "Ada@1", invalidNameError: "InvalidContactNameError" })}
       />,
     );
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsAddContactDrawerAdapter.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsAddContactDrawerAdapter.test.tsx
@@ -23,7 +23,7 @@ describe("useContactsAddContactDrawerAdapter", () => {
 
     act(() => {
       result.current.onOpen();
-      result.current.onDraftNameChange("Ada1");
+      result.current.onDraftNameChange("Ada@1");
     });
 
     expect(result.current.isOpen).toBe(true);

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageNavigationViewModel.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageNavigationViewModel.tsx
@@ -6,6 +6,7 @@ import { ContactsAddContactHeaderButton } from "@features/flow-contacts";
 
 export function useContactsPageNavigationViewModel(
   addContactLabel: string,
+  showAddContact: boolean,
   onAddContact: () => void,
 ) {
   const navigation =
@@ -21,10 +22,10 @@ export function useContactsPageNavigationViewModel(
   useLayoutEffect(() => {
     const opts: Partial<LumenNativeStackNavigationOptions> = {
       lumenNavBar: {
-        renderTrailing,
+        renderTrailing: showAddContact ? renderTrailing : undefined,
       },
     };
 
     navigation.setOptions(opts);
-  }, [navigation, renderTrailing]);
+  }, [navigation, renderTrailing, showAddContact]);
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/index.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useLayoutEffect } from "react";
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
-import { useContactsFeature } from "@features/flow-contacts";
+import { isContactsSearchNoResultsViewModel, useContactsFeature } from "@features/flow-contacts";
 import { ContactsPageContent } from "./components/ContactsPageContent";
 import { useContactsAddContactDrawerAdapter } from "./hooks/useContactsAddContactDrawerAdapter";
 import { useContactsPageNavigationViewModel } from "./hooks/useContactsPageNavigationViewModel";
@@ -31,7 +31,11 @@ function ContactsScreenContent() {
     addContactDrawer,
   };
 
-  useContactsPageNavigationViewModel(pageViewModel.labels.addContact, addContactDrawer.onOpen);
+  useContactsPageNavigationViewModel(
+    pageViewModel.labels.addContact,
+    !isContactsSearchNoResultsViewModel(pageViewModel.viewModel),
+    addContactDrawer.onOpen,
+  );
 
   return <ContactsPageContent {...viewModel} />;
 }

--- a/domain/entity/contact/src/schema.test.ts
+++ b/domain/entity/contact/src/schema.test.ts
@@ -51,13 +51,13 @@ describe("ContactSchema", () => {
     expect(ContactNameSchema.parse("Jean-Luc O'Connor")).toBe("Jean-Luc O'Connor");
     expect(ContactNameSchema.parse("Coinbase 1")).toBe("Coinbase 1");
     expect(ContactNameSchema.parse("Web3")).toBe("Web3");
-    expect(ContactNameSchema.parse("1Password")).toBe("1Password");
     expect(ContactNameSchema.parse("Алексей")).toBe("Алексей");
     expect(ContactNameSchema.parse("مريم")).toBe("مريم");
   });
 
   it("rejects unsupported contact name characters", () => {
     expect(() => ContactNameSchema.parse("\u0301")).toThrow();
+    expect(() => ContactNameSchema.parse("1Password")).toThrow();
     expect(() => ContactNameSchema.parse("@Olive")).toThrow();
     expect(() => ContactNameSchema.parse("Olive@2")).toThrow();
     expect(() => ContactNameSchema.parse("Olive 💎")).toThrow();

--- a/domain/entity/contact/src/schema.test.ts
+++ b/domain/entity/contact/src/schema.test.ts
@@ -46,16 +46,20 @@ describe("ContactSchema", () => {
     expect(() => ContactSchema.parse(mockContact({ name: "   " }))).toThrow();
   });
 
-  it("accepts international contact names", () => {
+  it("accepts international contact names with numbers", () => {
     expect(ContactNameInputSchema.parse(" E\u0301lodie ")).toBe("Élodie");
     expect(ContactNameSchema.parse("Jean-Luc O'Connor")).toBe("Jean-Luc O'Connor");
+    expect(ContactNameSchema.parse("Coinbase 1")).toBe("Coinbase 1");
+    expect(ContactNameSchema.parse("Web3")).toBe("Web3");
+    expect(ContactNameSchema.parse("1Password")).toBe("1Password");
     expect(ContactNameSchema.parse("Алексей")).toBe("Алексей");
     expect(ContactNameSchema.parse("مريم")).toBe("مريم");
   });
 
   it("rejects unsupported contact name characters", () => {
     expect(() => ContactNameSchema.parse("\u0301")).toThrow();
-    expect(() => ContactNameSchema.parse("Olive2")).toThrow();
+    expect(() => ContactNameSchema.parse("@Olive")).toThrow();
+    expect(() => ContactNameSchema.parse("Olive@2")).toThrow();
     expect(() => ContactNameSchema.parse("Olive 💎")).toThrow();
     expect(() => ContactNameSchema.parse("Olive@")).toThrow();
   });

--- a/domain/entity/contact/src/schema.ts
+++ b/domain/entity/contact/src/schema.ts
@@ -17,7 +17,7 @@ export const ContactAddressIdSchema = NonEmptyStringSchema;
 export const ContactCurrencyIdSchema = z.union([CryptoCurrencyIdSchema, TokenCurrencyIdSchema]);
 
 const ContactNamePattern =
-  /^\p{L}[\p{L}\p{Mn}\p{Mc}]*(?:[\p{Zs}'\u2019-]\p{L}[\p{L}\p{Mn}\p{Mc}]*)*$/u;
+  /^[\p{L}\p{Nd}][\p{L}\p{Mn}\p{Mc}\p{Nd}]*(?:[\p{Zs}'\u2019-][\p{L}\p{Nd}][\p{L}\p{Mn}\p{Mc}\p{Nd}]*)*$/u;
 const ContactAddressLabelPattern = /^(?=.*[A-Za-z0-9])[\x20-\x7E]+$/;
 
 export const CONTACT_ADDRESS_LABEL_MAX_LENGTH = 32;

--- a/domain/entity/contact/src/schema.ts
+++ b/domain/entity/contact/src/schema.ts
@@ -17,7 +17,7 @@ export const ContactAddressIdSchema = NonEmptyStringSchema;
 export const ContactCurrencyIdSchema = z.union([CryptoCurrencyIdSchema, TokenCurrencyIdSchema]);
 
 const ContactNamePattern =
-  /^[\p{L}\p{Nd}][\p{L}\p{Mn}\p{Mc}\p{Nd}]*(?:[\p{Zs}'\u2019-][\p{L}\p{Nd}][\p{L}\p{Mn}\p{Mc}\p{Nd}]*)*$/u;
+  /^\p{L}[\p{L}\p{Mn}\p{Mc}\p{Nd}]*(?:[\p{Zs}'\u2019-][\p{L}\p{Nd}][\p{L}\p{Mn}\p{Mc}\p{Nd}]*)*$/u;
 const ContactAddressLabelPattern = /^(?=.*[A-Za-z0-9])[\x20-\x7E]+$/;
 
 export const CONTACT_ADDRESS_LABEL_MAX_LENGTH = 32;

--- a/domain/entity/contact/src/validation.test.ts
+++ b/domain/entity/contact/src/validation.test.ts
@@ -38,6 +38,7 @@ describe("contact name validation", () => {
 
   it("reports the stable InvalidContactNameError name for a non-empty invalid draft name", () => {
     expect(getContactNameValidationError("Olive@2")).toBe(INVALID_CONTACT_NAME_ERROR_NAME);
+    expect(getContactNameValidationError("1Password")).toBe(INVALID_CONTACT_NAME_ERROR_NAME);
   });
 
   it("reports a duplicate name after trimming, normalizing, and folding case", () => {
@@ -67,6 +68,7 @@ describe("contact name validation", () => {
   it("validates trimmed names consistently", () => {
     expect(isValidContactName("  Ben  ")).toBe(true);
     expect(isValidContactName("Coinbase 1")).toBe(true);
+    expect(isValidContactName("1Password")).toBe(false);
     expect(isValidContactName("Olive@2")).toBe(false);
     expect(isValidContactName("")).toBe(false);
   });

--- a/domain/entity/contact/src/validation.test.ts
+++ b/domain/entity/contact/src/validation.test.ts
@@ -37,7 +37,7 @@ describe("contact name validation", () => {
   });
 
   it("reports the stable InvalidContactNameError name for a non-empty invalid draft name", () => {
-    expect(getContactNameValidationError("Olive2")).toBe(INVALID_CONTACT_NAME_ERROR_NAME);
+    expect(getContactNameValidationError("Olive@2")).toBe(INVALID_CONTACT_NAME_ERROR_NAME);
   });
 
   it("reports a duplicate name after trimming, normalizing, and folding case", () => {
@@ -66,12 +66,13 @@ describe("contact name validation", () => {
 
   it("validates trimmed names consistently", () => {
     expect(isValidContactName("  Ben  ")).toBe(true);
-    expect(isValidContactName("Olive2")).toBe(false);
+    expect(isValidContactName("Coinbase 1")).toBe(true);
+    expect(isValidContactName("Olive@2")).toBe(false);
     expect(isValidContactName("")).toBe(false);
   });
 
   it("parseContactName throws InvalidContactNameError for an invalid draft name", () => {
-    expect(() => parseContactName("Olive2")).toThrow(InvalidContactNameError);
+    expect(() => parseContactName("Olive@2")).toThrow(InvalidContactNameError);
   });
 
   it("parseContactName throws DuplicateContactNameError for an existing name", () => {

--- a/features/flow/contacts/src/ContactsView.web.test.tsx
+++ b/features/flow/contacts/src/ContactsView.web.test.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { mockMeContact, mockPopulatedContacts } from "@domain/entity-contact/schema.mock";
+import { createContactsSearchViewModel } from "@features/flow-contacts-list";
+import { ContactsView } from "./ContactsView.web";
+
+const labels = {
+  title: "Contacts",
+  searchPlaceholder: "Search contact",
+  searchNoResults: "No contact found",
+  addContact: "Add contact",
+  ledgerSyncCheckingAccessibilityLabel: "Checking Ledger Sync status",
+  formatAddressCount: (count: number) => `${count} address`,
+};
+
+describe("ContactsView", () => {
+  it("should hide add contact actions when a search has no result", () => {
+    const contacts = mockPopulatedContacts();
+    const me = contacts.find(contact => contact.isMe) ?? mockMeContact();
+
+    render(
+      <ContactsView
+        viewModel={createContactsSearchViewModel(me, contacts, "unknown")}
+        labels={labels}
+        searchQuery="unknown"
+        meAvatarSrc="https://example.com/black/user.png"
+        onSearchInputChange={jest.fn()}
+        onOpenMe={jest.fn()}
+        onOpenContact={jest.fn()}
+        onAddContact={jest.fn()}
+        ledgerSyncStatus="ready"
+        featureIntroduction={{
+          isOpen: false,
+          title: "Add contacts",
+          description: "Save recipient addresses.",
+          highlights: [],
+          primaryActionLabel: "Try contacts",
+          onComplete: jest.fn(),
+          onClose: jest.fn(),
+        }}
+        ledgerSyncIntroduction={{
+          isOpen: false,
+          description: "Keep contacts in sync.",
+          dismissLabel: "Got it",
+          onDismiss: jest.fn(),
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("contacts-search-no-results")).toBeVisible();
+    expect(screen.queryByTestId("contacts-add-contact")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("contacts-add-contact-header")).not.toBeInTheDocument();
+  });
+});

--- a/features/flow/contacts/src/hooks/useAddContactAppAdapter.web.test.ts
+++ b/features/flow/contacts/src/hooks/useAddContactAppAdapter.web.test.ts
@@ -97,7 +97,7 @@ describe("useAddContactAppAdapter", () => {
 
     act(() => {
       result.current.onOpen();
-      result.current.onDraftNameChange("Ada1");
+      result.current.onDraftNameChange("Ada@1");
     });
 
     await act(async () => {
@@ -146,7 +146,7 @@ describe("useAddContactAppAdapter", () => {
 
     act(() => {
       result.current.onOpen();
-      result.current.onDraftNameChange("Ada1");
+      result.current.onDraftNameChange("Ada@1");
     });
 
     expect(analytics.trackEvent).toHaveBeenCalledWith(CONTACTS_TRACK_EVENTS.ERROR_DISPLAYED, {
@@ -156,7 +156,7 @@ describe("useAddContactAppAdapter", () => {
     });
 
     act(() => {
-      result.current.onDraftNameChange("Ada1!");
+      result.current.onDraftNameChange("Ada@1!");
     });
 
     expect(analytics.trackEvent).toHaveBeenCalledTimes(2);
@@ -167,7 +167,7 @@ describe("useAddContactAppAdapter", () => {
 
     act(() => {
       result.current.onOpen();
-      result.current.onDraftNameChange("Ada1");
+      result.current.onDraftNameChange("Ada@1");
     });
 
     act(() => {
@@ -175,7 +175,7 @@ describe("useAddContactAppAdapter", () => {
     });
 
     act(() => {
-      result.current.onDraftNameChange("Ada1");
+      result.current.onDraftNameChange("Ada@1");
     });
 
     expect(analytics.trackEvent).toHaveBeenCalledTimes(3);

--- a/features/flow/flow-contacts-add-contact/src/screens/AddContact/model/controller.web.test.ts
+++ b/features/flow/flow-contacts-add-contact/src/screens/AddContact/model/controller.web.test.ts
@@ -23,7 +23,7 @@ describe("createAddContactController", () => {
   it("exposes the stable invalid name error while the draft name is invalid", () => {
     const controller = createAddContactController(createContactCreationPort(jest.fn()));
 
-    expect(controller.getViewModel("Olive2")).toMatchObject({
+    expect(controller.getViewModel("Olive@2")).toMatchObject({
       invalidNameError: "InvalidContactNameError",
       isSaveEnabled: false,
     });

--- a/features/flow/flow-contacts-add-contact/src/screens/AddContact/model/viewModel.web.test.ts
+++ b/features/flow/flow-contacts-add-contact/src/screens/AddContact/model/viewModel.web.test.ts
@@ -25,8 +25,8 @@ describe("createAddContactViewModel", () => {
   });
 
   it("exposes the stable invalid name error for an invalid draft name", () => {
-    expect(createAddContactViewModel("Olive2")).toEqual({
-      draftName: "Olive2",
+    expect(createAddContactViewModel("Olive@2")).toEqual({
+      draftName: "Olive@2",
       avatarInitial: "O",
       invalidNameError: INVALID_CONTACT_NAME_ERROR_NAME,
       isSaveEnabled: false,

--- a/features/flow/flow-contacts-add-contact/src/screens/AddContact/useAddContactDrawerViewModel.web.test.ts
+++ b/features/flow/flow-contacts-add-contact/src/screens/AddContact/useAddContactDrawerViewModel.web.test.ts
@@ -35,7 +35,7 @@ describe("useAddContactDrawerViewModel", () => {
 
     act(() => {
       result.current.onOpen();
-      result.current.onDraftNameChange("Ada1");
+      result.current.onDraftNameChange("Ada@1");
     });
 
     expect(result.current).toMatchObject({
@@ -129,7 +129,7 @@ describe("useAddContactDrawerViewModel", () => {
     });
 
     act(() => {
-      result.current.onDraftNameChange("Ada1");
+      result.current.onDraftNameChange("Ada@1");
     });
 
     expect(result.current.draftName).toBe("Ada");

--- a/features/flow/flow-contacts-add-contact/src/screens/AddContact/useAddContactViewModel.web.test.ts
+++ b/features/flow/flow-contacts-add-contact/src/screens/AddContact/useAddContactViewModel.web.test.ts
@@ -48,7 +48,7 @@ describe("useAddContactViewModel", () => {
     const { result } = renderHook(() => useAddContactViewModel(contactCreation));
 
     act(() => {
-      result.current.setDraftName("Olive2");
+      result.current.setDraftName("Olive@2");
     });
 
     expect(result.current.invalidNameError).toBe(INVALID_CONTACT_NAME_ERROR_NAME);
@@ -104,7 +104,7 @@ describe("useAddContactViewModel", () => {
     const { result } = renderHook(() => useAddContactViewModel(contactCreation));
 
     act(() => {
-      result.current.setDraftName("Olive2");
+      result.current.setDraftName("Olive@2");
     });
 
     await expect(

--- a/features/flow/flow-contacts-list/src/ContactsListView.web.test.tsx
+++ b/features/flow/flow-contacts-list/src/ContactsListView.web.test.tsx
@@ -261,5 +261,7 @@ describe("ContactsPage", () => {
     expect(screen.getByTestId("contacts-search-no-results")).toBeVisible();
     expect(screen.getByText("No contact found")).toBeVisible();
     expect(contactsList).not.toHaveTextContent("Ben");
+    expect(screen.queryByTestId("contacts-add-contact")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("contacts-add-contact-header")).not.toBeInTheDocument();
   });
 });

--- a/features/flow/flow-contacts-list/src/ContactsListView.web.tsx
+++ b/features/flow/flow-contacts-list/src/ContactsListView.web.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import type { ContactsListViewProps } from "./types";
+import { isContactsSearchNoResultsViewModel, type ContactsListViewProps } from "./types";
 import { ContactsLedgerSyncLoadingPane } from "./components/LedgerSyncLoadingPane/ContactsLedgerSyncLoadingPane.web";
 import { ContactsList } from "./components/ContactsList/ContactsList.web";
 import { ContactsPageLayout } from "./components/PageLayout/ContactsPageLayout.web";
@@ -21,6 +21,7 @@ function renderContactsDetailPane(
 
 export function ContactsListView(props: ContactsListViewProps): React.ReactNode {
   const { isLedgerSyncChecking } = props;
+  const showAddContact = !isContactsSearchNoResultsViewModel(props.viewModel);
   const contactsList = <ContactsList {...props} />;
 
   return (
@@ -33,6 +34,7 @@ export function ContactsListView(props: ContactsListViewProps): React.ReactNode 
         <ContactsPageLayout
           title={props.labels.title}
           addContactLabel={props.labels.addContact}
+          showAddContact={showAddContact}
           onAddContact={props.onAddContact}
           list={
             isLedgerSyncChecking ? (

--- a/features/flow/flow-contacts-list/src/components/ContactsList/ContactsList.web.tsx
+++ b/features/flow/flow-contacts-list/src/components/ContactsList/ContactsList.web.tsx
@@ -36,6 +36,7 @@ export function ContactsList({
     ? viewModel.sections
     : [];
   const showNoResults = isContactsSearchNoResultsViewModel(viewModel);
+  const showAddContact = !showNoResults;
   const me = "me" in viewModel ? viewModel.me : undefined;
 
   let savedContactsContent: React.ReactNode = null;
@@ -94,7 +95,9 @@ export function ContactsList({
       >
         <div className="flex flex-col gap-16">
           {savedContactsContent}
-          <ContactsAddContactListItem label={labels.addContact} onAddContact={onAddContact} />
+          {showAddContact ? (
+            <ContactsAddContactListItem label={labels.addContact} onAddContact={onAddContact} />
+          ) : null}
         </div>
       </div>
     </div>

--- a/features/flow/flow-contacts-list/src/components/PageLayout/ContactsHeader.web.tsx
+++ b/features/flow/flow-contacts-list/src/components/PageLayout/ContactsHeader.web.tsx
@@ -5,29 +5,33 @@ import { UserAdd } from "@ledgerhq/lumen-ui-react/symbols";
 type ContactsHeaderProps = Readonly<{
   title: string;
   addContactLabel: string;
+  showAddContact: boolean;
   onAddContact: () => void;
 }>;
 
 export function ContactsHeader({
   title,
   addContactLabel,
+  showAddContact,
   onAddContact,
 }: ContactsHeaderProps): React.ReactNode {
   return (
     <NavBar data-testid="contacts-page-header">
       <NavBarTitle as="h1">{title}</NavBarTitle>
-      <NavBarTrailing>
-        <Button
-          appearance="base"
-          size="md"
-          icon={UserAdd}
-          onClick={onAddContact}
-          data-testid="contacts-add-contact-header"
-          className="shrink-0 whitespace-nowrap"
-        >
-          {addContactLabel}
-        </Button>
-      </NavBarTrailing>
+      {showAddContact ? (
+        <NavBarTrailing>
+          <Button
+            appearance="base"
+            size="md"
+            icon={UserAdd}
+            onClick={onAddContact}
+            data-testid="contacts-add-contact-header"
+            className="shrink-0 whitespace-nowrap"
+          >
+            {addContactLabel}
+          </Button>
+        </NavBarTrailing>
+      ) : null}
     </NavBar>
   );
 }

--- a/features/flow/flow-contacts-list/src/components/PageLayout/ContactsPageLayout.web.tsx
+++ b/features/flow/flow-contacts-list/src/components/PageLayout/ContactsPageLayout.web.tsx
@@ -6,6 +6,7 @@ import { ContactsListPane } from "./ContactsListPane.web";
 type ContactsPageLayoutProps = Readonly<{
   title: string;
   addContactLabel: string;
+  showAddContact: boolean;
   onAddContact: () => void;
   list: ReactNode;
   detail?: ReactNode;
@@ -14,13 +15,19 @@ type ContactsPageLayoutProps = Readonly<{
 export function ContactsPageLayout({
   title,
   addContactLabel,
+  showAddContact,
   onAddContact,
   list,
   detail,
 }: ContactsPageLayoutProps): React.ReactNode {
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-32" data-testid="contacts-page-layout">
-      <ContactsHeader title={title} addContactLabel={addContactLabel} onAddContact={onAddContact} />
+      <ContactsHeader
+        title={title}
+        addContactLabel={addContactLabel}
+        showAddContact={showAddContact}
+        onAddContact={onAddContact}
+      />
       <div className="flex min-h-0 flex-1 gap-16">
         <ContactsListPane>{list}</ContactsListPane>
         <ContactsDetailPane>{detail}</ContactsDetailPane>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** The focused Flow Contacts suite, Add Contact Flow tests, and Mobile tests pass.
- [x] **Impact of the changes:**
      QA: create contacts named `Coinbase 1` and `Web3` on both apps; search an absent contact and verify all Add contact actions disappear, then clear the search and verify they return.

### 📝 Description

Contacts rejected names containing numbers, and the no-results search state still showed one or more Add contact CTAs.

The shared contact-name schema now accepts Unicode digits after its initial Unicode letter. The Contacts list Flow hides its Desktop list and header CTAs for no-result searches, while Mobile also removes its navigation-header action. Regression coverage verifies the numeric-name path and the CTA behavior on both platforms.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-35873](https://ledgerhq.atlassian.net/browse/LIVE-35873), [LIVE-35857](https://ledgerhq.atlassian.net/browse/LIVE-35857)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked Jira issues.
- **The PR description clearly documents the changes** made and explains the retained first-letter constraint.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The changes have been tested** thoroughly, including the no-results state.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-35873]: https://ledgerhq.atlassian.net/browse/LIVE-35873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-35857]: https://ledgerhq.atlassian.net/browse/LIVE-35857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ