### PR TITLE
[LWD] feat(dynamic-content): add hardware carousel close all on portfolio

### DIFF
--- a/.changeset/calm-carousel-close.md
+++ b/.changeset/calm-carousel-close.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add hardware carousel close all control on portfolio

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/ContentCardsCategory.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/ContentCardsCategory.test.tsx
@@ -88,10 +88,12 @@ const CHILD_CARDS = [
   childCard("child-nano", "Ledger Flex™", "3", "$249", "$50 off"),
 ];
 
+const FIXED_CONSENT_DATE = "2026-01-01T00:00:00.000Z";
+
 const trackedUserSettings = {
   shareAnalytics: true,
   sharePersonalizedRecommandations: true,
-  lastAnalyticsConsentDate: new Date().toISOString(),
+  lastAnalyticsConsentDate: FIXED_CONSENT_DATE,
   privacyPolicyVersion: 1,
 };
 
@@ -120,7 +122,7 @@ describe("ContentCardsLocation", () => {
         settings: {
           shareAnalytics: true,
           sharePersonalizedRecommandations: true,
-          lastAnalyticsConsentDate: new Date().toISOString(),
+          lastAnalyticsConsentDate: FIXED_CONSENT_DATE,
           privacyPolicyVersion: 1,
         },
       },
@@ -150,7 +152,7 @@ describe("ContentCardsLocation", () => {
           settings: {
             shareAnalytics: true,
             sharePersonalizedRecommandations: true,
-            lastAnalyticsConsentDate: new Date().toISOString(),
+            lastAnalyticsConsentDate: FIXED_CONSENT_DATE,
             privacyPolicyVersion: 1,
           },
         },
@@ -195,7 +197,7 @@ describe("ContentCardsLocation", () => {
         settings: {
           shareAnalytics: true,
           sharePersonalizedRecommandations: true,
-          lastAnalyticsConsentDate: new Date().toISOString(),
+          lastAnalyticsConsentDate: FIXED_CONSENT_DATE,
           privacyPolicyVersion: 1,
         },
       },
@@ -253,9 +255,6 @@ describe("ContentCardsLocation", () => {
         platform: "lld",
       }),
     );
-    expect(track).not.toHaveBeenCalledWith(
-      ContentCardEvent.Dismissed,
-      expect.anything(),
-    );
+    expect(track).not.toHaveBeenCalledWith(ContentCardEvent.Dismissed, expect.anything());
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/ContentCardsCategory.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/ContentCardsCategory.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import type { Card as BrazeCard } from "@braze/web-sdk";
 import { logCardDismissal, logContentCardClick, ClassicCard } from "@braze/web-sdk";
+import { DeviceModelId } from "@ledgerhq/types-devices";
 import { fireEvent, render, screen } from "tests/testSetup";
 import { track } from "~/renderer/analytics/segment";
 import { ContentCardEvent } from "@ledgerhq/live-common/braze/contentCardExtras";
@@ -86,6 +87,22 @@ const CHILD_CARDS = [
   childCard("child-flex", "Nano Case", "2", "$89"),
   childCard("child-nano", "Ledger Flex™", "3", "$249", "$50 off"),
 ];
+
+const trackedUserSettings = {
+  shareAnalytics: true,
+  sharePersonalizedRecommandations: true,
+  lastAnalyticsConsentDate: new Date().toISOString(),
+  privacyPolicyVersion: 1,
+};
+
+const hardwareCarouselState = {
+  dynamicContent: {
+    ...DYNAMIC_CONTENT_INITIAL_STATE,
+    localCategoriesCards: [CATEGORY],
+    localCategoryChildCards: CHILD_CARDS,
+  },
+  settings: trackedUserSettings,
+};
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -194,5 +211,51 @@ describe("ContentCardsLocation", () => {
       }),
     );
     expect(logContentCardClick).toHaveBeenCalled();
+  });
+
+  test("renders the close all link for dismissable hardware carousel categories", async () => {
+    render(<ContentCardsLocation locationId={LocationContentCard.Portfolio} />, {
+      initialState: hardwareCarouselState,
+    });
+
+    await screen.findByText("Discover our devices");
+    expect(screen.getByTestId("hardware-carousel-close-all")).toBeVisible();
+    expect(screen.getByText("Close all")).toBeVisible();
+  });
+
+  test("dismisses all child cards when close all is clicked", async () => {
+    const { user, store } = render(
+      <ContentCardsLocation locationId={LocationContentCard.Portfolio} />,
+      {
+        initialState: {
+          ...hardwareCarouselState,
+          settings: {
+            ...trackedUserSettings,
+            devicesModelList: [DeviceModelId.nanoX],
+          },
+        },
+      },
+    );
+
+    await screen.findByText("Nano Pod");
+    await user.click(screen.getByTestId("hardware-carousel-close-all"));
+
+    expect(store.getState().dynamicContent.localCategoryChildCards).toHaveLength(0);
+    expect(screen.queryByTestId("content-cards-category")).not.toBeInTheDocument();
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({
+        button: "close all",
+        page: "hardware carousel",
+        deviceModel: "lnx",
+        personalRecoOptIn: true,
+        offerType: "discount",
+        platform: "lld",
+      }),
+    );
+    expect(track).not.toHaveBeenCalledWith(
+      ContentCardEvent.Dismissed,
+      expect.anything(),
+    );
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/CategoryCarousel.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/CategoryCarousel.tsx
@@ -85,8 +85,8 @@ function CategoryCarousel({ slides, leadingSlide }: CategoryCarouselProps) {
 
   return (
     <div className="group relative" data-testid="category-carousel">
-      {canScrollPrev && <ScrollEdge direction="left" onClick={scrollPrev} hideGradient />}
-      {canScrollNext && <ScrollEdge direction="right" onClick={scrollNext} hideGradient />}
+      {canScrollPrev && <ScrollEdge direction="left" onClick={scrollPrev} />}
+      {canScrollNext && <ScrollEdge direction="right" onClick={scrollNext} />}
       <div ref={emblaRef} className="overflow-hidden">
         <div className="flex items-start" style={{ gap: HARDWARE_CAROUSEL_ITEM_GAP_PX }}>
           {slideEntries.map(entry => (

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/Header.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/Header.tsx
@@ -13,13 +13,7 @@ type HeaderProps = Readonly<{
 
 export default Header;
 
-function Header({
-  title,
-  cta,
-  centered = false,
-  closeAllCardIds,
-  onCtaPress,
-}: HeaderProps) {
+function Header({ title, cta, centered = false, closeAllCardIds, onCtaPress }: HeaderProps) {
   const showCloseAll = Boolean(closeAllCardIds?.length);
   const showHeaderCta = Boolean(onCtaPress && cta && !centered && !showCloseAll);
   const hasTitleRow = Boolean(title || showHeaderCta || showCloseAll);
@@ -34,13 +28,19 @@ function Header({
       data-testid="content-cards-category-header"
     >
       {title ? (
-        <span className="min-w-0 shrink truncate heading-4-semi-bold text-base">{title}</span>
+        <h2 className="m-0 min-w-0 shrink truncate heading-4-semi-bold text-base">{title}</h2>
       ) : null}
       {showCloseAll && closeAllCardIds ? (
         <HardwareCarouselCloseAllLink cardIds={closeAllCardIds} />
       ) : null}
       {showHeaderCta ? (
-        <Link appearance="accent" className="shrink-0" onClick={onCtaPress} size="sm" underline={false}>
+        <Link
+          appearance="accent"
+          className="shrink-0"
+          onClick={onCtaPress}
+          size="sm"
+          underline={false}
+        >
           {cta}
         </Link>
       ) : null}

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/Header.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/Header.tsx
@@ -1,20 +1,30 @@
 import React from "react";
 
-import { Link, Subheader, SubheaderRow, SubheaderTitle } from "@ledgerhq/lumen-ui-react";
+import { Link } from "@ledgerhq/lumen-ui-react";
+import HardwareCarouselCloseAllLink from "../../hardwareCarousel/components/HardwareCarouselCloseAllLink";
 
 type HeaderProps = Readonly<{
   title?: string;
   cta?: string;
   centered?: boolean;
+  closeAllCardIds?: readonly string[];
   onCtaPress?: () => void;
 }>;
 
 export default Header;
 
-function Header({ title, cta, centered = false, onCtaPress }: HeaderProps) {
-  const showHeaderCta = Boolean(onCtaPress && cta && !centered);
+function Header({
+  title,
+  cta,
+  centered = false,
+  closeAllCardIds,
+  onCtaPress,
+}: HeaderProps) {
+  const showCloseAll = Boolean(closeAllCardIds?.length);
+  const showHeaderCta = Boolean(onCtaPress && cta && !centered && !showCloseAll);
+  const hasTitleRow = Boolean(title || showHeaderCta || showCloseAll);
 
-  if (!title && !showHeaderCta) {
+  if (!hasTitleRow) {
     return null;
   }
 
@@ -24,14 +34,13 @@ function Header({ title, cta, centered = false, onCtaPress }: HeaderProps) {
       data-testid="content-cards-category-header"
     >
       {title ? (
-        <Subheader className="min-w-0 flex-1">
-          <SubheaderRow className={centered ? "justify-center" : undefined}>
-            <SubheaderTitle>{title}</SubheaderTitle>
-          </SubheaderRow>
-        </Subheader>
+        <span className="min-w-0 shrink truncate heading-4-semi-bold text-base">{title}</span>
+      ) : null}
+      {showCloseAll && closeAllCardIds ? (
+        <HardwareCarouselCloseAllLink cardIds={closeAllCardIds} />
       ) : null}
       {showHeaderCta ? (
-        <Link onClick={onCtaPress} size="sm">
+        <Link appearance="accent" className="shrink-0" onClick={onCtaPress} size="sm" underline={false}>
           {cta}
         </Link>
       ) : null}

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/__tests__/CategoryCarousel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/__tests__/CategoryCarousel.test.tsx
@@ -102,6 +102,15 @@ describe("CategoryCarousel", () => {
     expect(screen.queryByTestId("scroll-arrow-right")).not.toBeInTheDocument();
   });
 
+  it("renders a fade gradient on the scroll edge when more content is available", () => {
+    fakeEmblaApi.canScrollPrevValue = false;
+    fakeEmblaApi.canScrollNextValue = true;
+
+    const { container } = render(<CategoryCarousel slides={[slide("a"), slide("b"), slide("c")]} />);
+
+    expect(container.querySelector(".bg-gradient-to-l")).toBeInTheDocument();
+  });
+
   it("calls scrollPrev/scrollNext when the arrows are clicked", async () => {
     fakeEmblaApi.canScrollPrevValue = true;
     fakeEmblaApi.canScrollNextValue = true;

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/__tests__/CategoryCarousel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/__tests__/CategoryCarousel.test.tsx
@@ -102,15 +102,6 @@ describe("CategoryCarousel", () => {
     expect(screen.queryByTestId("scroll-arrow-right")).not.toBeInTheDocument();
   });
 
-  it("renders a fade gradient on the scroll edge when more content is available", () => {
-    fakeEmblaApi.canScrollPrevValue = false;
-    fakeEmblaApi.canScrollNextValue = true;
-
-    const { container } = render(<CategoryCarousel slides={[slide("a"), slide("b"), slide("c")]} />);
-
-    expect(container.querySelector(".bg-gradient-to-l")).toBeInTheDocument();
-  });
-
   it("calls scrollPrev/scrollNext when the arrows are clicked", async () => {
     fakeEmblaApi.canScrollPrevValue = true;
     fakeEmblaApi.canScrollNextValue = true;

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/__tests__/useContentCardsCategoryViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/__tests__/useContentCardsCategoryViewModel.test.tsx
@@ -171,4 +171,26 @@ describe("useContentCardsCategoryViewModel", () => {
       }),
     );
   });
+
+  it("exposes closeAllCardIds for dismissable portfolio hardware carousel categories", () => {
+    const { result } = renderHook(() =>
+      useContentCardsCategoryViewModel({
+        category: CATEGORY,
+        categoryContentCards: [childCard("child-1", "1"), childCard("child-2", "2")],
+      }),
+    );
+
+    expect(result.current.closeAllCardIds).toEqual(["child-1", "child-2"]);
+  });
+
+  it("does not expose closeAllCardIds for non-dismissable categories", () => {
+    const { result } = renderHook(() =>
+      useContentCardsCategoryViewModel({
+        category: { ...CATEGORY, isDismissable: false },
+        categoryContentCards: [childCard("child-1", "1")],
+      }),
+    );
+
+    expect(result.current.closeAllCardIds).toBeUndefined();
+  });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/index.tsx
@@ -29,6 +29,7 @@ function ContentCardsCategory({
     leadingSlide: leading,
     slides,
     isDismissable,
+    closeAllCardIds,
     onHeaderCtaPress,
     onCardClick,
     onCardDismiss,
@@ -55,7 +56,13 @@ function ContentCardsCategory({
   return (
     <LogContentCardWrapper id={category.id} location={category.location}>
       <div className="flex w-full flex-col" data-testid="content-cards-category">
-        <Header title={title} cta={cta} centered={centered} onCtaPress={onHeaderCtaPress} />
+        <Header
+          title={title}
+          cta={cta}
+          centered={centered}
+          closeAllCardIds={closeAllCardIds}
+          onCtaPress={onHeaderCtaPress}
+        />
         <Layout
           category={category}
           slides={slides}

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/useContentCardsCategoryViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/useContentCardsCategoryViewModel.ts
@@ -13,6 +13,7 @@ import { openURL } from "~/renderer/linking";
 import type { CategoryContentCard } from "~/types/dynamicContent";
 import { LocationContentCard } from "~/types/dynamicContent";
 import { useDynamicContent } from "../../hooks/useDynamicContent";
+import { shouldShowHardwareCarouselCloseAll } from "../../hardwareCarousel/shouldShowHardwareCarouselCloseAll";
 import { getRenderableSmallSquareSlides } from "../../utils/getRenderableSmallSquareSlides";
 import type { SmallSquareContentCard } from "../../utils/mapSmallSquareContentCard";
 
@@ -47,6 +48,7 @@ export type UseContentCardsCategoryViewModelResult = Readonly<{
   leadingSlide?: React.ReactNode;
   slides: MappedCategorySlide[];
   isDismissable: boolean;
+  closeAllCardIds?: readonly string[];
   onHeaderCtaPress?: () => void;
   onCardClick: (card: SmallSquareContentCard, displayedPosition: number) => void;
   onCardDismiss: (card: SmallSquareContentCard, displayedPosition: number) => void;
@@ -72,6 +74,14 @@ export function useContentCardsCategoryViewModel({
       displayedPosition: index + positionOffset,
     }));
   }, [category, categoryContentCards, positionOffset]);
+
+  const closeAllCardIds = useMemo(() => {
+    if (!shouldShowHardwareCarouselCloseAll(category)) {
+      return undefined;
+    }
+
+    return categoryContentCards.map(card => String(card.id));
+  }, [category, categoryContentCards]);
 
   const trackCategoryEvent = useCallback(
     (
@@ -133,6 +143,7 @@ export function useContentCardsCategoryViewModel({
     leadingSlide,
     slides,
     isDismissable: Boolean(category.isDismissable),
+    closeAllCardIds,
     onHeaderCtaPress: showHeaderCta ? onHeaderCtaPress : undefined,
     onCardClick,
     onCardDismiss,

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/analytics.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/analytics.ts
@@ -1,0 +1,22 @@
+import { track } from "~/renderer/analytics/segment";
+
+export const HARDWARE_CAROUSEL_PAGE = "hardware carousel";
+
+export type HardwareCarouselDeviceModel = "lnx" | "lnsp";
+
+export type HardwareCarouselSharedAnalyticsProps = Readonly<{
+  deviceModel: HardwareCarouselDeviceModel;
+  personalRecoOptIn: boolean;
+  offerType: "discount" | "none";
+  platform: "lld";
+}>;
+
+export function trackHardwareCarouselCloseAll(
+  sharedProps: HardwareCarouselSharedAnalyticsProps,
+): void {
+  track("button_clicked", {
+    button: "close all",
+    page: HARDWARE_CAROUSEL_PAGE,
+    ...sharedProps,
+  });
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/components/HardwareCarouselCloseAllLink/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/components/HardwareCarouselCloseAllLink/index.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+import { useHardwareCarouselCloseAllLinkViewModel } from "./useHardwareCarouselCloseAllLinkViewModel";
+
+type HardwareCarouselCloseAllLinkProps = Readonly<{
+  cardIds: readonly string[];
+}>;
+
+export default HardwareCarouselCloseAllLink;
+
+function HardwareCarouselCloseAllLink({ cardIds }: HardwareCarouselCloseAllLinkProps) {
+  const { handleCloseAll, label } = useHardwareCarouselCloseAllLinkViewModel({ cardIds });
+
+  return (
+    <button
+      className="shrink-0 flex cursor-pointer items-center border-0 bg-transparent p-0 body-2-semi-bold text-muted hover:text-muted-pressed"
+      data-testid="hardware-carousel-close-all"
+      onClick={handleCloseAll}
+      type="button"
+    >
+      {label}
+    </button>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/components/HardwareCarouselCloseAllLink/useHardwareCarouselCloseAllLinkViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/components/HardwareCarouselCloseAllLink/useHardwareCarouselCloseAllLinkViewModel.ts
@@ -1,0 +1,19 @@
+import { useTranslation } from "react-i18next";
+
+import { useHardwareCarouselCloseAll } from "../../useHardwareCarouselCloseAll";
+
+type UseHardwareCarouselCloseAllLinkViewModelArgs = Readonly<{
+  cardIds: readonly string[];
+}>;
+
+export function useHardwareCarouselCloseAllLinkViewModel({
+  cardIds,
+}: UseHardwareCarouselCloseAllLinkViewModelArgs) {
+  const { t } = useTranslation();
+  const handleCloseAll = useHardwareCarouselCloseAll(cardIds);
+
+  return {
+    handleCloseAll,
+    label: t("portfolio.carousel.closeAll"),
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/shouldShowHardwareCarouselCloseAll.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/shouldShowHardwareCarouselCloseAll.test.ts
@@ -1,0 +1,64 @@
+import {
+  CategoryContentCard,
+  ContentCardsLayout,
+  ContentCardsType,
+  LocationContentCard,
+} from "~/types/dynamicContent";
+import { shouldShowHardwareCarouselCloseAll } from "./shouldShowHardwareCarouselCloseAll";
+
+const baseCategory = {
+  id: "alwayson-category",
+  categoryId: "alwayson",
+  title: "Discover our devices",
+  description: "",
+  created: new Date("2026-01-01"),
+  type: ContentCardsType.category,
+} as CategoryContentCard;
+
+describe("shouldShowHardwareCarouselCloseAll", () => {
+  it("returns true for dismissable portfolio carousel categories", () => {
+    expect(
+      shouldShowHardwareCarouselCloseAll({
+        ...baseCategory,
+        location: LocationContentCard.Portfolio,
+        cardsLayout: ContentCardsLayout.carousel,
+        cardsType: ContentCardsType.smallSquare,
+        isDismissable: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for non-small_square carousel types such as action cards", () => {
+    expect(
+      shouldShowHardwareCarouselCloseAll({
+        ...baseCategory,
+        location: LocationContentCard.Portfolio,
+        cardsLayout: ContentCardsLayout.carousel,
+        cardsType: ContentCardsType.action,
+        isDismissable: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for unique layout or non-portfolio placements", () => {
+    expect(
+      shouldShowHardwareCarouselCloseAll({
+        ...baseCategory,
+        location: LocationContentCard.Portfolio,
+        cardsLayout: ContentCardsLayout.unique,
+        cardsType: ContentCardsType.hero,
+        isDismissable: true,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldShowHardwareCarouselCloseAll({
+        ...baseCategory,
+        location: LocationContentCard.Action,
+        cardsLayout: ContentCardsLayout.carousel,
+        cardsType: ContentCardsType.smallSquare,
+        isDismissable: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/shouldShowHardwareCarouselCloseAll.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/shouldShowHardwareCarouselCloseAll.test.ts
@@ -40,6 +40,19 @@ describe("shouldShowHardwareCarouselCloseAll", () => {
     ).toBe(false);
   });
 
+  it("returns false for non-alwayson category ids", () => {
+    expect(
+      shouldShowHardwareCarouselCloseAll({
+        ...baseCategory,
+        categoryId: "other-category",
+        location: LocationContentCard.Portfolio,
+        cardsLayout: ContentCardsLayout.carousel,
+        cardsType: ContentCardsType.smallSquare,
+        isDismissable: true,
+      }),
+    ).toBe(false);
+  });
+
   it("returns false for unique layout or non-portfolio placements", () => {
     expect(
       shouldShowHardwareCarouselCloseAll({

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/shouldShowHardwareCarouselCloseAll.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/shouldShowHardwareCarouselCloseAll.ts
@@ -1,0 +1,15 @@
+import {
+  CategoryContentCard,
+  ContentCardsLayout,
+  ContentCardsType,
+  LocationContentCard,
+} from "~/types/dynamicContent";
+
+export function shouldShowHardwareCarouselCloseAll(category: CategoryContentCard): boolean {
+  return (
+    category.location === LocationContentCard.Portfolio &&
+    category.isDismissable === true &&
+    category.cardsLayout === ContentCardsLayout.carousel &&
+    category.cardsType === ContentCardsType.smallSquare
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/shouldShowHardwareCarouselCloseAll.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/shouldShowHardwareCarouselCloseAll.ts
@@ -4,9 +4,11 @@ import {
   ContentCardsType,
   LocationContentCard,
 } from "~/types/dynamicContent";
+import { ALWAYS_ON_CATEGORY_ID } from "../utils/constants";
 
 export function shouldShowHardwareCarouselCloseAll(category: CategoryContentCard): boolean {
   return (
+    category.categoryId === ALWAYS_ON_CATEGORY_ID &&
     category.location === LocationContentCard.Portfolio &&
     category.isDismissable === true &&
     category.cardsLayout === ContentCardsLayout.carousel &&

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/useHardwareCarouselCloseAll.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/useHardwareCarouselCloseAll.test.ts
@@ -1,0 +1,62 @@
+import { act, renderHook } from "tests/testSetup";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+
+import { useDynamicContent } from "../hooks/useDynamicContent";
+import { useHardwareCarouselCloseAll } from "./useHardwareCarouselCloseAll";
+import { trackHardwareCarouselCloseAll } from "./analytics";
+
+jest.mock("../hooks/useDynamicContent", () => ({
+  useDynamicContent: jest.fn(),
+}));
+
+jest.mock("./analytics", () => ({
+  trackHardwareCarouselCloseAll: jest.fn(),
+}));
+
+const mockDismissCards = jest.fn();
+const mockUseDynamicContent = useDynamicContent as jest.MockedFunction<typeof useDynamicContent>;
+
+describe("useHardwareCarouselCloseAll", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseDynamicContent.mockReturnValue({
+      dismissCards: mockDismissCards,
+    } as unknown as ReturnType<typeof useDynamicContent>);
+  });
+
+  it("tracks analytics only when dismissCards dismisses at least one card", () => {
+    mockDismissCards.mockReturnValue(true);
+    const { result } = renderHook(() => useHardwareCarouselCloseAll(["card-1", "card-2"]), {
+      initialState: {
+        settings: {
+          devicesModelList: [DeviceModelId.nanoX],
+          sharePersonalizedRecommandations: true,
+        },
+      },
+    });
+
+    act(() => {
+      result.current();
+    });
+
+    expect(mockDismissCards).toHaveBeenCalledWith(["card-1", "card-2"]);
+    expect(trackHardwareCarouselCloseAll).toHaveBeenCalledWith({
+      deviceModel: "lnx",
+      personalRecoOptIn: true,
+      offerType: "discount",
+      platform: "lld",
+    });
+  });
+
+  it("does not track analytics when every card was already dismissed", () => {
+    mockDismissCards.mockReturnValue(false);
+    const { result } = renderHook(() => useHardwareCarouselCloseAll(["card-1"]));
+
+    act(() => {
+      result.current();
+    });
+
+    expect(mockDismissCards).toHaveBeenCalledWith(["card-1"]);
+    expect(trackHardwareCarouselCloseAll).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/useHardwareCarouselCloseAll.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/useHardwareCarouselCloseAll.ts
@@ -1,0 +1,52 @@
+import { useCallback, useMemo } from "react";
+import { useSelector } from "LLD/hooks/redux";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+
+import {
+  devicesModelListSelector,
+  sharePersonalizedRecommendationsSelector,
+} from "~/renderer/reducers/settings";
+import { useDynamicContent } from "../hooks/useDynamicContent";
+import {
+  trackHardwareCarouselCloseAll,
+  type HardwareCarouselDeviceModel,
+  type HardwareCarouselSharedAnalyticsProps,
+} from "./analytics";
+
+const EMPTY_DEVICES_MODEL_LIST: DeviceModelId[] = [];
+
+function resolveHardwareCarouselDeviceModel(
+  devicesModelList: DeviceModelId[],
+): HardwareCarouselDeviceModel {
+  if (devicesModelList.includes(DeviceModelId.nanoX)) {
+    return "lnx";
+  }
+
+  return "lnsp";
+}
+
+export function useHardwareCarouselCloseAll(cardIds: readonly string[]) {
+  const { dismissCards } = useDynamicContent();
+  const devicesModelList = useSelector(devicesModelListSelector) ?? EMPTY_DEVICES_MODEL_LIST;
+  const personalRecoOptIn = useSelector(sharePersonalizedRecommendationsSelector);
+
+  const sharedAnalyticsProps: HardwareCarouselSharedAnalyticsProps = useMemo(
+    () => ({
+      deviceModel: resolveHardwareCarouselDeviceModel(devicesModelList),
+      personalRecoOptIn,
+      offerType: personalRecoOptIn ? "discount" : "none",
+      platform: "lld",
+    }),
+    [devicesModelList, personalRecoOptIn],
+  );
+
+  const handleCloseAll = useCallback(() => {
+    if (!dismissCards(cardIds)) {
+      return;
+    }
+
+    trackHardwareCarouselCloseAll(sharedAnalyticsProps);
+  }, [cardIds, dismissCards, sharedAnalyticsProps]);
+
+  return handleCloseAll;
+}

--- a/apps/ledger-live-desktop/src/renderer/braze/__tests__/brazeIdentity.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/braze/__tests__/brazeIdentity.test.ts
@@ -1,6 +1,10 @@
 import { UserId, DUMMY_USER_ID } from "@domain/entity-client-identity";
 import { generateAnonymousId } from "@ledgerhq/live-common/braze/anonymousUsers";
-import { resolveDesktopBrazeUserId, shouldPersistAnonymousBrazeId } from "../brazeIdentity";
+import {
+  resolveDesktopBrazeUserId,
+  shouldPersistAnonymousBrazeId,
+  ensureLegacyAnonymousBrazeIdStored,
+} from "../brazeIdentity";
 
 jest.mock("@ledgerhq/live-common/braze/anonymousUsers", () => ({
   generateAnonymousId: jest.fn(() => "anonymous_id_1"),
@@ -95,6 +99,25 @@ describe("brazeIdentity", () => {
 
     it("returns false when flag is on", () => {
       expect(shouldPersistAnonymousBrazeId(true)).toBe(false);
+    });
+  });
+
+  describe("ensureLegacyAnonymousBrazeIdStored", () => {
+    it("persists a generated anonymous id when legacy mode is active", () => {
+      expect(ensureLegacyAnonymousBrazeIdStored(null, false)).toEqual({
+        anonymousBrazeId: "anonymous_id_1",
+        action: { type: "SET_ANONYMOUS_BRAZE_ID", payload: "anonymous_id_1" },
+      });
+    });
+
+    it("returns null when an anonymous id is already stored", () => {
+      expect(ensureLegacyAnonymousBrazeIdStored("stored_anonymous", false)).toBeNull();
+      expect(mockedGenerateAnonymousId).not.toHaveBeenCalled();
+    });
+
+    it("returns null when brazeOptOutIdentityCleanup is enabled", () => {
+      expect(ensureLegacyAnonymousBrazeIdStored(null, true)).toBeNull();
+      expect(mockedGenerateAnonymousId).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/braze/brazeIdentity.ts
+++ b/apps/ledger-live-desktop/src/renderer/braze/brazeIdentity.ts
@@ -28,3 +28,23 @@ export function resolveDesktopBrazeUserId({
 export function shouldPersistAnonymousBrazeId(brazeOptOutIdentityCleanup: boolean): boolean {
   return !brazeOptOutIdentityCleanup;
 }
+
+export type LegacyAnonymousBrazeIdPersistenceAction = {
+  type: "SET_ANONYMOUS_BRAZE_ID";
+  payload: string;
+};
+
+export function ensureLegacyAnonymousBrazeIdStored(
+  anonymousBrazeId: string | null,
+  brazeOptOutIdentityCleanup: boolean,
+): { anonymousBrazeId: string; action: LegacyAnonymousBrazeIdPersistenceAction } | null {
+  if (!shouldPersistAnonymousBrazeId(brazeOptOutIdentityCleanup) || anonymousBrazeId) {
+    return null;
+  }
+
+  const id = generateAnonymousId();
+  return {
+    anonymousBrazeId: id,
+    action: { type: "SET_ANONYMOUS_BRAZE_ID", payload: id },
+  };
+}

--- a/apps/ledger-live-desktop/src/renderer/hooks/__tests__/useBraze.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/__tests__/useBraze.test.ts
@@ -94,6 +94,29 @@ describe("mapAsCategoryContentCard", () => {
     });
   });
 
+  it("should default isDismissable for alwayson hardware carousel categories", () => {
+    const card = aBrazeCard({
+      type: "category",
+      id: "alwayson",
+      cardsLayout: "carousel",
+      cardsType: "small_square",
+    });
+
+    expect(mapAsCategoryContentCard(card).isDismissable).toBe(true);
+  });
+
+  it("should not default isDismissable for non-alwayson categories", () => {
+    const card = aBrazeCard({
+      type: "category",
+      id: "promo",
+      location: "portfolio",
+      cardsLayout: "carousel",
+      cardsType: "small_square",
+    });
+
+    expect(mapAsCategoryContentCard(card).isDismissable).toBe(false);
+  });
+
   it("should append the resolved location to the deeplink", () => {
     const card = aBrazeCard({
       type: "category",

--- a/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
@@ -1,6 +1,5 @@
 import * as braze from "@braze/web-sdk";
 import { ClassicCard } from "@braze/web-sdk";
-import { generateAnonymousId } from "@ledgerhq/live-common/braze/anonymousUsers";
 import { parseOrder, sanitizeExtras } from "@ledgerhq/live-common/braze/contentCardExtras";
 import { appendDeeplinkLocationIfDefined } from "@ledgerhq/live-common/deeplinks/index";
 import { getEnv } from "@shared/env";
@@ -11,7 +10,10 @@ import { ALWAYS_ON_CATEGORY_ID } from "LLD/features/DynamicContent/utils/constan
 import { userIdSelector } from "@domain/entity-client-identity";
 import { useFeature } from "@features/platform-feature-flags";
 import { getBrazeConfig } from "~/braze-setup";
-import { resolveDesktopBrazeUserId, shouldPersistAnonymousBrazeId } from "../braze/brazeIdentity";
+import {
+  resolveDesktopBrazeUserId,
+  ensureLegacyAnonymousBrazeIdStored,
+} from "../braze/brazeIdentity";
 import {
   ActionContentCard,
   CategoryContentCard,
@@ -39,7 +41,6 @@ import {
 import {
   clearDismissedContentCards,
   purgeExpiredAnonymousUserNotifications,
-  setAnonymousBrazeId,
 } from "../actions/settings";
 import {
   anonymousBrazeIdSelector,
@@ -182,12 +183,13 @@ export function useBraze() {
     const brazeConfig = getBrazeConfig();
     const isPlaywright = !!getEnv("PLAYWRIGHT_RUN");
 
-    if (
-      shouldPersistAnonymousBrazeId(brazeOptOutIdentityCleanupEnabled) &&
-      !anonymousBrazeId.current
-    ) {
-      anonymousBrazeId.current = generateAnonymousId();
-      dispatch(setAnonymousBrazeId(anonymousBrazeId.current));
+    const legacyAnonymousBrazeIdPersistence = ensureLegacyAnonymousBrazeIdStored(
+      anonymousBrazeId.current,
+      brazeOptOutIdentityCleanupEnabled,
+    );
+    if (legacyAnonymousBrazeIdPersistence) {
+      anonymousBrazeId.current = legacyAnonymousBrazeIdPersistence.anonymousBrazeId;
+      dispatch(legacyAnonymousBrazeIdPersistence.action);
     }
 
     const isInitialized = braze.initialize(brazeConfig.apiKey, {

--- a/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
@@ -119,6 +119,10 @@ export const mapAsCategoryContentCard = (card: ClassicCard): CategoryContentCard
       ? LocationContentCard.Portfolio
       : // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         (card.extras?.location as LocationContentCard);
+  const isAlwaysOnHardwareCarousel =
+    card.extras?.id === ALWAYS_ON_CATEGORY_ID &&
+    card.extras?.cardsLayout === ContentCardsLayout.carousel &&
+    card.extras?.cardsType === ContentCardsType.smallSquare;
 
   return {
     id: String(card.id),
@@ -136,7 +140,7 @@ export const mapAsCategoryContentCard = (card: ClassicCard): CategoryContentCard
     description: card.extras?.description,
     link: appendDeeplinkLocationIfDefined(card.extras?.link, location),
     cta: card.extras?.cta,
-    isDismissable: card.extras?.isDismissable === "true",
+    isDismissable: card.extras?.isDismissable === "true" || isAlwaysOnHardwareCarousel,
     hasPagination: card.extras?.hasPagination === "true",
     centeredText: card.extras?.centeredText === "true",
     extras: card.extras,

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8808,7 +8808,8 @@
     "title": "Home",
     "today": "Today",
     "carousel": {
-      "title": "For you"
+      "title": "For you",
+      "closeAll": "Close all"
     },
     "addAccountCta": "Add crypto account",
     "noBalanceTitle": "Start by funding your wallet",


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Adds Close all to the portfolio hardware carousel (alwayson), aligned with mobile: dismisses all child cards in one action and hides the section.
Tracks button_clicked with button: "close all", page: "hardware carousel", platform: "lld".
Defaults isDismissable for alwayson Braze categories so the control appears without an extra Braze flag.
Restores scroll-edge fade gradients on the hardware carousel (parity with other portfolio carousels).

https://github.com/user-attachments/assets/43f7bc3e-2709-4b43-a9bb-55140eabbd29

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35392]<!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-35392]: https://ledgerhq.atlassian.net/browse/LIVE-35392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ