### PR TITLE
[LWM] refactor(notifications): rename hook useNotificationsPrompt

### DIFF
--- a/.changeset/prompt-hook-rename.md
+++ b/.changeset/prompt-hook-rename.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Rename notifications prompt context hook to useNotificationsPrompt

--- a/apps/ledger-live-mobile/src/components/RootNavigator/ReceiveFundsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/ReceiveFundsNavigator.tsx
@@ -24,7 +24,7 @@ import { urls } from "~/utils/urls";
 import ReceiveProvider from "~/screens/ReceiveFunds/01b-ReceiveProvider.";
 import { setIsOnboardingFlowReceiveSuccess } from "~/actions/settings";
 import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 export default function ReceiveFundsNavigator() {
   const { colors } = useTheme();
@@ -34,7 +34,7 @@ export default function ReceiveFundsNavigator() {
   const isOnboardingFlow = useSelector(isOnboardingFlowSelector);
   const dispatchRedux = useDispatch();
   const localizedWithdrawCryptoUrl = useLocalizedUrl(urls.withdrawCrypto);
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
 
   const onClose = useCallback(() => {
     track("button_clicked", {

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SendFundsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SendFundsNavigator.tsx
@@ -16,7 +16,7 @@ import SendValidationError from "~/screens/SendFunds/07-ValidationError";
 import { getStackNavigatorConfig, bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
 import StepHeader from "../StepHeader";
 import type { SendFundsNavigatorStackParamList } from "./types/SendFundsNavigator";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 import perFamilySendFlow from "~/generated/customSendFlow";
 
 const totalSteps = "5";
@@ -26,7 +26,7 @@ const Stack = createNativeStackNavigator<SendFundsNavigatorStackParamList>();
 export default function SendFundsNavigator() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
 
   return (

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SwapNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SwapNavigator.tsx
@@ -17,7 +17,7 @@ import { StackNavigatorNavigation, StackNavigatorProps } from "./types/helpers";
 import { SwapNavigatorParamList } from "./types/SwapNavigator";
 import { NavigationHeaderBackButton } from "../NavigationHeaderBackButton";
 import SwapCustomError from "~/screens/Swap/SubScreens/SwapCustomError";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const TRACKING_SOURCES = {
   Accounts: "Account",
@@ -55,7 +55,7 @@ export default function SwapNavigator(
   const noNanoBuyNanoWallScreenOptions = useNoNanoBuyNanoWallScreenOptions();
   const page = usePageNameFromRoute();
   const navigation = useNavigation<StackNavigatorNavigation<SwapNavigatorParamList>>();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
 
   const trackButtonClick = useCallback(
     (source: string) => {

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SwapSubScreensNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SwapSubScreensNavigator.tsx
@@ -10,7 +10,7 @@ import { OperationDetails, PendingOperation, SwapLoading } from "~/screens/Swap/
 import SwapCustomError from "~/screens/Swap/SubScreens/SwapCustomError";
 import { SwapSubScreensNavigatorParamList } from "./types/SwapSubScreensNavigator";
 import { navigateBackToSwapTab } from "~/screens/Swap/navigation/navigateBackToSwapTab";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const Stack = createNativeStackNavigator<SwapSubScreensNavigatorParamList>();
 
@@ -51,7 +51,7 @@ function getSwapHistoryScreenOptions({ headerTitle }: { headerTitle: string }) {
 export default function SwapSubScreensNavigator() {
   const { colors } = useTheme();
   const { t } = useTranslation();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
 
   return (

--- a/apps/ledger-live-mobile/src/components/WebPlatformPlayer/index.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPlatformPlayer/index.tsx
@@ -27,7 +27,7 @@ import {
   useDeeplinkCustomHandlers,
   useLiveAppModalCustomHandlers,
 } from "./CustomHandlers";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 type Props = {
   manifest: LiveAppManifest;
@@ -39,7 +39,7 @@ const WebPlatformPlayer = ({ manifest, inputs }: Props) => {
   const [webviewState, setWebviewState] = useState<WebviewState>(initialWebviewState);
   const [isInfoPanelOpened, setIsInfoPanelOpened] = useState(false);
   const hasBroadcastedWalletApiTransactionRef = useRef(false);
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
 
   const navigation =
     useNavigation<RootNavigationComposite<StackNavigatorNavigation<BaseNavigatorStackParamList>>>();

--- a/apps/ledger-live-mobile/src/families/algorand/Rewards/ClaimRewardsFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/algorand/Rewards/ClaimRewardsFlow/index.tsx
@@ -18,12 +18,12 @@ import ClaimRewardsValidation from "./03-Validation";
 import ClaimRewardsValidationError from "./03-ValidationError";
 import ClaimRewardsValidationSuccess from "./03-ValidationSuccess";
 import type { AlgorandClaimRewardsFlowParamList } from "./type";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 function ClaimRewardsFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator

--- a/apps/ledger-live-mobile/src/families/cardano/DelegationFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/cardano/DelegationFlow/index.tsx
@@ -15,14 +15,14 @@ import SelectPool from "./SelectPool";
 import DelegationValidationError from "./04-ValidationError";
 import DelegationValidationSuccess from "./04-ValidationSuccess";
 import { CardanoDelegationFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function DelegationFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator

--- a/apps/ledger-live-mobile/src/families/cardano/UndelegationFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/cardano/UndelegationFlow/index.tsx
@@ -12,14 +12,14 @@ import UndelegationValidationSuccess from "./03-ValidationSuccess";
 import SelectDevice from "~/screens/SelectDevice";
 import ConnectDevice from "~/screens/ConnectDevice";
 import { CardanoUndelegationFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function UndelegationFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator

--- a/apps/ledger-live-mobile/src/families/celo/ActivateFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/ActivateFlow/index.tsx
@@ -13,14 +13,14 @@ import ActivateSummary from "./02-Summary";
 import DelegationValidationError from "./ValidationError";
 import DelegationValidationSuccess from "./ValidationSuccess";
 import type { CeloActivateFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function ActivateFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator

--- a/apps/ledger-live-mobile/src/families/celo/LockFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/LockFlow/index.tsx
@@ -12,14 +12,14 @@ import ConnectDevice from "~/screens/ConnectDevice";
 import ValidationSuccess from "./ValidationSuccess";
 import ValidationError from "./ValidationError";
 import type { CeloLockFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function LockFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
 
   const stackNavigatorConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
 

--- a/apps/ledger-live-mobile/src/families/celo/RegistrationFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/RegistrationFlow/index.tsx
@@ -12,14 +12,14 @@ import ConnectDevice from "~/screens/ConnectDevice";
 import ValidationSuccess from "./ValidationSuccess";
 import ValidationError from "./ValidationError";
 import type { CeloRegistrationFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function RegisterAccountFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
 
   const stackNavigatorConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
 

--- a/apps/ledger-live-mobile/src/families/celo/RevokeFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/RevokeFlow/index.tsx
@@ -14,14 +14,14 @@ import VoteSummary from "./01-Summary";
 import DelegationValidationError from "./ValidationError";
 import DelegationValidationSuccess from "./ValidationSuccess";
 import type { CeloRevokeFlowFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function RevokeFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator

--- a/apps/ledger-live-mobile/src/families/celo/UnlockFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/UnlockFlow/index.tsx
@@ -12,14 +12,14 @@ import ConnectDevice from "~/screens/ConnectDevice";
 import ValidationSuccess from "./ValidationSuccess";
 import ValidationError from "./ValidationError";
 import { CeloUnlockFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function UnlockFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
 
   const stackNavigatorConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
 

--- a/apps/ledger-live-mobile/src/families/celo/VoteFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/VoteFlow/index.tsx
@@ -15,14 +15,14 @@ import VoteSummary from "./02-Summary";
 import DelegationValidationError from "./ValidationError";
 import DelegationValidationSuccess from "./ValidationSuccess";
 import type { CeloVoteFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function VoteFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator

--- a/apps/ledger-live-mobile/src/families/celo/WithdrawFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/WithdrawFlow/index.tsx
@@ -12,14 +12,14 @@ import WithdrawAmount from "./WithdrawAmount";
 import ValidationError from "./ValidationError";
 import ValidationSuccess from "./ValidationSuccess";
 import { CeloWithdrawFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3"; // Withdraw, Device, Confirmation
 
 function WithdrawFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator

--- a/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/index.tsx
@@ -18,14 +18,14 @@ import ClaimRewardsValidationError from "./04-ValidationError";
 import ClaimRewardsValidationSuccess from "./04-ValidationSuccess";
 import type { CosmosClaimRewardsFlowParamList } from "./types";
 import { Flex } from "@ledgerhq/native-ui";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function ClaimRewardsFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator

--- a/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/index.tsx
@@ -15,14 +15,14 @@ import DelegationSummary from "./02-Summary";
 import DelegationValidationError from "./04-ValidationError";
 import DelegationValidationSuccess from "./04-ValidationSuccess";
 import type { CosmosDelegationFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function DelegationFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator

--- a/apps/ledger-live-mobile/src/families/cosmos/RedelegationFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/RedelegationFlow/index.tsx
@@ -18,14 +18,14 @@ import ConnectDevice from "~/screens/ConnectDevice";
 import RedelegationValidationError from "./04-ValidationError";
 import RedelegationValidationSuccess from "./04-ValidationSuccess";
 import type { CosmosRedelegationFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function RedelegationFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator

--- a/apps/ledger-live-mobile/src/families/cosmos/UndelegationFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/UndelegationFlow/index.tsx
@@ -13,14 +13,14 @@ import UndelegationValidationError from "./03-ValidationError";
 import UndelegationValidationSuccess from "./03-ValidationSuccess";
 import UndelegationBridgeTransaction from "../shared/03-BridgeTransaction";
 import type { CosmosUndelegationFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function UndelegationFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator

--- a/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/index.tsx
@@ -18,7 +18,7 @@ import ClaimRewardsValidationError from "./04-ValidationError";
 import ClaimRewardsValidationSuccess from "./04-ValidationSuccess";
 import type { EvmClaimRewardsFlowParamList } from "./types";
 import { Flex } from "@ledgerhq/native-ui";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "4";
 
@@ -59,7 +59,7 @@ function ConnectDeviceHeader() {
 
 function ClaimRewardsFlow() {
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator

--- a/apps/ledger-live-mobile/src/families/evm/DelegationFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/DelegationFlow/index.tsx
@@ -18,14 +18,14 @@ import RedelegationAmount from "./05-RedelegationAmount";
 import RedelegationValidationError from "./06-RedelegationValidationError";
 import RedelegationValidationSuccess from "./06-RedelegationValidationSuccess";
 import type { EvmDelegationFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function DelegationFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
 
   return (

--- a/apps/ledger-live-mobile/src/families/evm/UndelegationFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/UndelegationFlow/index.tsx
@@ -12,14 +12,14 @@ import ConnectDevice from "~/screens/ConnectDevice";
 import UndelegationValidationError from "./03-ValidationError";
 import UndelegationValidationSuccess from "./03-ValidationSuccess";
 import type { EvmUndelegationFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function UndelegationFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator

--- a/apps/ledger-live-mobile/src/families/evm/WithdrawFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/WithdrawFlow/index.tsx
@@ -16,7 +16,7 @@ import WithdrawConnectDevice from "~/screens/ConnectDevice";
 import WithdrawValidationError from "./03-ValidationError";
 import WithdrawValidationSuccess from "./03-ValidationSuccess";
 import type { EvmWithdrawFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
@@ -44,7 +44,7 @@ function ConnectDeviceHeader() {
 
 function WithdrawFlow() {
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator

--- a/apps/ledger-live-mobile/src/families/hedera/ClaimRewardsFlow/__integrations__/claimRewardsFlow.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/ClaimRewardsFlow/__integrations__/claimRewardsFlow.integration.test.tsx
@@ -11,7 +11,7 @@ import { makeMockAccountBridge } from "../../__mocks__/bridge.mock";
 import { mockEnrichedDelegation } from "../../__mocks__/delegation.mock";
 
 jest.mock("LLM/features/NotificationsPrompt", () => ({
-  useNotificationsContext: () => ({ notifyFlowCompleted: jest.fn() }),
+  useNotificationsPrompt: () => ({ notifyFlowCompleted: jest.fn() }),
 }));
 
 jest.mock(

--- a/apps/ledger-live-mobile/src/families/hedera/ClaimRewardsFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/ClaimRewardsFlow/index.tsx
@@ -13,14 +13,14 @@ import ClaimRewardsClaim from "./Claim";
 import ClaimRewardsValidationError from "./ValidationError";
 import ClaimRewardsValidationSuccess from "./ValidationSuccess";
 import type { HederaClaimRewardsFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function ClaimRewardsFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
 
   return (

--- a/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/__integrations__/delegationFlow.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/__integrations__/delegationFlow.integration.test.tsx
@@ -11,7 +11,7 @@ import { HEDERA_ACCOUNT_1, overrideWithHederaAccount1 } from "../../__mocks__/ac
 import { makeMockAccountBridge } from "../../__mocks__/bridge.mock";
 
 jest.mock("LLM/features/NotificationsPrompt", () => ({
-  useNotificationsContext: () => ({ notifyFlowCompleted: jest.fn() }),
+  useNotificationsPrompt: () => ({ notifyFlowCompleted: jest.fn() }),
 }));
 
 jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({

--- a/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/index.tsx
@@ -13,14 +13,14 @@ import DelegationSummary from "./Summary";
 import DelegationValidationError from "./ValidationError";
 import DelegationValidationSuccess from "./ValidationSuccess";
 import type { HederaDelegationFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function DelegationFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
 
   return (

--- a/apps/ledger-live-mobile/src/families/hedera/RedelegationFlow/__integrations__/redelegationFlow.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/RedelegationFlow/__integrations__/redelegationFlow.integration.test.tsx
@@ -12,7 +12,7 @@ import { makeMockAccountBridge } from "../../__mocks__/bridge.mock";
 import { mockEnrichedDelegation } from "../../__mocks__/delegation.mock";
 
 jest.mock("LLM/features/NotificationsPrompt", () => ({
-  useNotificationsContext: () => ({ notifyFlowCompleted: jest.fn() }),
+  useNotificationsPrompt: () => ({ notifyFlowCompleted: jest.fn() }),
 }));
 
 jest.mock(

--- a/apps/ledger-live-mobile/src/families/hedera/RedelegationFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/RedelegationFlow/index.tsx
@@ -14,14 +14,14 @@ import RedelegationAmount from "./Amount";
 import RedelegationValidationError from "./ValidationError";
 import RedelegationValidationSuccess from "./ValidationSuccess";
 import type { HederaRedelegationFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function RedelegationFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
 
   return (

--- a/apps/ledger-live-mobile/src/families/hedera/UndelegationFlow/__integrations__/undelegationFlow.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/UndelegationFlow/__integrations__/undelegationFlow.integration.test.tsx
@@ -11,7 +11,7 @@ import { makeMockAccountBridge } from "../../__mocks__/bridge.mock";
 import { mockEnrichedDelegation } from "../../__mocks__/delegation.mock";
 
 jest.mock("LLM/features/NotificationsPrompt", () => ({
-  useNotificationsContext: () => ({ notifyFlowCompleted: jest.fn() }),
+  useNotificationsPrompt: () => ({ notifyFlowCompleted: jest.fn() }),
 }));
 
 jest.mock(

--- a/apps/ledger-live-mobile/src/families/hedera/UndelegationFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/UndelegationFlow/index.tsx
@@ -12,14 +12,14 @@ import UndelegationAmount from "./Amount";
 import UndelegationValidationError from "./ValidationError";
 import UndelegationValidationSuccess from "./ValidationSuccess";
 import type { HederaUndelegationFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function UndelegationFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
 
   return (

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Claim/Claim.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Claim/Claim.tsx
@@ -17,7 +17,7 @@ import ValidationError from "./components/ValidationError";
 import ValidationSuccess from "./components/ValidationSuccess";
 
 import type { MultiversXClaimRewardsFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const Stack = createNativeStackNavigator<MultiversXClaimRewardsFlowParamList>();
 const totalSteps = "3";
@@ -32,7 +32,7 @@ const options = {
 const Claim = () => {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
 
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
 

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Delegate/Delegate.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Delegate/Delegate.tsx
@@ -19,7 +19,7 @@ import SelectDevice from "~/screens/SelectDevice";
 import ConnectDevice from "~/screens/ConnectDevice";
 
 import type { MultiversXDelegationFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 const options = {
@@ -35,7 +35,7 @@ const Stack = createNativeStackNavigator<MultiversXDelegationFlowParamList>();
 const Delegate = () => {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
 
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
 

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Undelegate/Undelegate.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Undelegate/Undelegate.tsx
@@ -16,7 +16,7 @@ import MultiversXUndelegationSelectDevice from "~/screens/SelectDevice";
 import MultiversXUndelegationConnectDevice from "~/screens/ConnectDevice";
 
 import type { MultiversXUndelegationFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const Stack = createNativeStackNavigator<MultiversXUndelegationFlowParamList>();
 const totalSteps = "3";
@@ -31,7 +31,7 @@ const options = {
 const Undelegate = () => {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
 
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
 

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Withdraw/Withdraw.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Withdraw/Withdraw.tsx
@@ -16,7 +16,7 @@ import ValidationError from "./components/ValidationError";
 import ValidationSuccess from "./components/ValidationSuccess";
 
 import type { MultiversXWithdrawFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const Stack = createNativeStackNavigator<MultiversXWithdrawFlowParamList>();
 const totalSteps = "3";
@@ -31,7 +31,7 @@ const options = {
 const Withdraw = () => {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
 
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
 

--- a/apps/ledger-live-mobile/src/families/near/StakingFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/near/StakingFlow/index.tsx
@@ -16,14 +16,14 @@ import StakingSummary from "./02-Summary";
 import StakingValidationError from "./04-ValidationError";
 import StakingValidationSuccess from "./04-ValidationSuccess";
 import { NearStakingFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function StakingFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator

--- a/apps/ledger-live-mobile/src/families/near/UnstakingFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/near/UnstakingFlow/index.tsx
@@ -12,14 +12,14 @@ import ConnectDevice from "~/screens/ConnectDevice";
 import UnstakingValidationError from "./03-ValidationError";
 import UnstakingValidationSuccess from "./03-ValidationSuccess";
 import { NearUnstakingFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function UnstakingFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator

--- a/apps/ledger-live-mobile/src/families/near/WithdrawingFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/near/WithdrawingFlow/index.tsx
@@ -12,14 +12,14 @@ import ConnectDevice from "~/screens/ConnectDevice";
 import WithdrawingValidationError from "./03-ValidationError";
 import WithdrawingValidationSuccess from "./03-ValidationSuccess";
 import { NearWithdrawingFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function WithdrawingFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator

--- a/apps/ledger-live-mobile/src/families/polkadot/BondFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/BondFlow/index.tsx
@@ -12,14 +12,14 @@ import ConnectDevice from "~/screens/ConnectDevice";
 import ValidationSuccess from "./04-ValidationSuccess";
 import ValidationError from "./04-ValidationError";
 import type { PolkadotBondFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function BondFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigatorConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator screenOptions={stackNavigatorConfig}>

--- a/apps/ledger-live-mobile/src/families/polkadot/NominateFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/NominateFlow/index.tsx
@@ -11,14 +11,14 @@ import ConnectDevice from "~/screens/ConnectDevice";
 import ValidationSuccess from "./03-ValidationSuccess";
 import ValidationError from "./03-ValidationError";
 import type { PolkadotNominateFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function NominateFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigatorConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator screenOptions={stackNavigatorConfig}>

--- a/apps/ledger-live-mobile/src/families/polkadot/RebondFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/RebondFlow/index.tsx
@@ -11,14 +11,14 @@ import ConnectDevice from "~/screens/ConnectDevice";
 import ValidationSuccess from "./03-ValidationSuccess";
 import ValidationError from "./03-ValidationError";
 import type { PolkadotRebondFlowParamList } from "./type";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function RebondFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigatorConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator screenOptions={stackNavigatorConfig}>

--- a/apps/ledger-live-mobile/src/families/polkadot/SimpleOperationFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/SimpleOperationFlow/index.tsx
@@ -11,14 +11,14 @@ import ConnectDevice from "~/screens/ConnectDevice";
 import ValidationSuccess from "./03-ValidationSuccess";
 import ValidationError from "./03-ValidationError";
 import { PolkadotSimpleOperationFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "2";
 
 function SimpleOperationFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigatorConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator screenOptions={stackNavigatorConfig}>

--- a/apps/ledger-live-mobile/src/families/polkadot/UnbondFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/UnbondFlow/index.tsx
@@ -11,14 +11,14 @@ import ConnectDevice from "~/screens/ConnectDevice";
 import ValidationSuccess from "./03-ValidationSuccess";
 import ValidationError from "./03-ValidationError";
 import type { PolkadotUnbondFlowParamList } from "./type";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function UnbondFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigatorConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator screenOptions={stackNavigatorConfig}>

--- a/apps/ledger-live-mobile/src/families/solana/DelegationFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/DelegationFlow/index.tsx
@@ -15,14 +15,14 @@ import DelegationValidationError from "./ValidationError";
 import DelegationValidationSuccess from "./ValidationSuccess";
 import DelegationSelectAmount from "./SelectAmount";
 import type { SolanaDelegationFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function DelegationFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator

--- a/apps/ledger-live-mobile/src/families/sui/StakingFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/sui/StakingFlow/index.tsx
@@ -15,14 +15,14 @@ import StakingSummary from "./02-Summary";
 import StakingValidationError from "./04-ValidationError";
 import StakingValidationSuccess from "./04-ValidationSuccess";
 import { SuiStakingFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function StakingFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator

--- a/apps/ledger-live-mobile/src/families/sui/UnstakingFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/sui/UnstakingFlow/index.tsx
@@ -12,14 +12,14 @@ import ConnectDevice from "~/screens/ConnectDevice";
 import UnstakingValidationError from "./03-ValidationError";
 import UnstakingValidationSuccess from "./03-ValidationSuccess";
 import { SuiUnstakingFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function UnstakingFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator

--- a/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/index.tsx
@@ -15,14 +15,14 @@ import DelegationConnectDevice from "~/screens/ConnectDevice";
 import DelegationValidationSuccess from "./ValidationSuccess";
 import DelegationValidationError from "./ValidationError";
 import type { TezosDelegationFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function DelegationFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator

--- a/apps/ledger-live-mobile/src/families/tezos/StakeFlow/__tests__/StakeFlow.integ.test.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/StakeFlow/__tests__/StakeFlow.integ.test.tsx
@@ -17,7 +17,7 @@ const mockAccount = makeMockTezosAccount("tezos-stake-integ");
 // The stake flow completes a notification prompt on flow exit; stub the context so the
 // navigator doesn't need the real provider tree.
 jest.mock("LLM/features/NotificationsPrompt", () => ({
-  useNotificationsContext: () => ({ notifyFlowCompleted: jest.fn() }),
+  useNotificationsPrompt: () => ({ notifyFlowCompleted: jest.fn() }),
 }));
 
 jest.mock("LLM/hooks/useAccountScreen", () => ({

--- a/apps/ledger-live-mobile/src/families/tezos/StakeFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/StakeFlow/index.tsx
@@ -12,14 +12,14 @@ import StakeConnectDevice from "~/screens/ConnectDevice";
 import StakeValidationSuccess from "./02-ValidationSuccess";
 import StakeValidationError from "./02-ValidationError";
 import type { TezosStakeFlowParamList } from "./types";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 const totalSteps = "3";
 
 function StakeFlow() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
     <Stack.Navigator

--- a/apps/ledger-live-mobile/src/hooks/analyticsOptInPrompt/useAnalyticsConsentLogic.ts
+++ b/apps/ledger-live-mobile/src/hooks/analyticsOptInPrompt/useAnalyticsConsentLogic.ts
@@ -24,7 +24,7 @@ import {
 import { OnboardingNavigatorParamList } from "~/components/RootNavigator/types/OnboardingNavigator";
 import { EntryPoint } from "~/components/RootNavigator/types/AnalyticsOptInPromptNavigator";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 import { useCompleteLazyOnboarding } from "LLM/features/NotificationsOptIn";
 
 type NavigationProp = RootNavigationComposite<
@@ -67,7 +67,7 @@ const useAnalyticsConsentLogic = ({ entryPoint }: Props): UseAnalyticsConsentLog
   const hasSeenAnalyticsOptInPrompt = useSelector(hasSeenAnalyticsOptInPromptSelector);
   const shouldWeTrack = isTrackingEnabled || !hasSeenAnalyticsOptInPrompt;
   const { shouldUseLazyOnboarding } = useWalletFeaturesConfig("mobile");
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const analyticsOptInFeature = useFeature("analyticsOptIn");
   const lwmNotificationsOptIn = useFeature("lwmNotificationsOptIn");
   const completeLazyOnboarding = useCompleteLazyOnboarding();

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotifications.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotifications.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect } from "react";
 import { getNotificationPermissionStatus } from "~/logic/getNotificationPermissionStatus";
 import { useNotificationsPermission } from "LLM/hooks/useNotificationsPermission";
 import { useNotificationsData } from "./useNotificationsData";
-import { useNotificationsPrompt } from "./useNotificationsPrompt";
+import { useNotificationsPromptEligibility } from "./useNotificationsPromptEligibility";
 import { useNotificationsDrawer } from "./useNotificationsDrawer";
 import { getPushNotificationsDataOfUserFromStorage } from "../utils/storage";
 
@@ -23,7 +23,7 @@ const useNotifications = () => {
   } = useNotificationsData();
 
   const { nextRepromptDelay, shouldPromptOptInDrawerAfterAction, checkIsInactive } =
-    useNotificationsPrompt({
+    useNotificationsPromptEligibility({
       permissionStatus,
       areNotificationsAllowed: notifications.areNotificationsAllowed,
       transactionsAlertsCategory: notifications.transactionsAlertsCategory,

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsPromptEligibility.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsPromptEligibility.ts
@@ -18,7 +18,7 @@ type UseNotificationsPromptParams = {
   pushNotificationsDataOfUser: DataOfUser | null | undefined;
 };
 
-export const useNotificationsPrompt = ({
+export const useNotificationsPromptEligibility = ({
   permissionStatus,
   areNotificationsAllowed,
   transactionsAlertsCategory,

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/index.ts
@@ -1,9 +1,9 @@
 export { useNotifications } from "./hooks/useNotifications";
 export { NotificationsPromptWrapper } from "./new/NotificationsPromptWrapper";
 export { NotificationsPromptProvider } from "./new/NotificationsPromptProvider";
-export { useNotificationsContext } from "./new/NotificationsPromptProvider";
+export { useNotificationsPrompt } from "./new/NotificationsPromptProvider";
 export { useNotificationsData } from "./hooks/useNotificationsData";
-export { useNotificationsPrompt } from "./hooks/useNotificationsPrompt";
+export { useNotificationsPromptEligibility } from "./hooks/useNotificationsPromptEligibility";
 export { useNotificationsDrawer } from "./hooks/useNotificationsDrawer";
 export {
   INACTIVITY_DRAWER_DELAY_MS,

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/NotificationsPromptBootstrap.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/NotificationsPromptBootstrap.tsx
@@ -5,12 +5,12 @@ import { useNotificationsPermission } from "LLM/hooks/useNotificationsPermission
 import {
   getPushNotificationsDataOfUserFromStorage,
   type InitPushNotificationsDataResult,
-  useNotificationsContext,
+  useNotificationsPrompt,
   useNotificationsData,
 } from "LLM/features/NotificationsPrompt";
 
 export function NotificationsPromptBootstrap() {
-  const { tryTriggerPushNotificationDrawerAfterInactivity } = useNotificationsContext();
+  const { tryTriggerPushNotificationDrawerAfterInactivity } = useNotificationsPrompt();
   const { setPermissionStatus } = useNotificationsPermission();
   const {
     notifications,

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/NotificationsPromptProvider.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/NotificationsPromptProvider.tsx
@@ -18,11 +18,11 @@ export const NotificationsPromptContext = createContext<NotificationsPromptConte
   null,
 );
 
-export function useNotificationsContext() {
+export function useNotificationsPrompt() {
   const context = useContext(NotificationsPromptContext);
 
   if (!context) {
-    throw new Error("useNotificationsContext must be used within a NotificationsPromptProvider");
+    throw new Error("useNotificationsPrompt must be used within a NotificationsPromptProvider");
   }
 
   return context;

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/index.tsx
@@ -4,7 +4,7 @@ import { Box, Button, Text } from "@ledgerhq/lumen-ui-rnative";
 import { useFeature } from "@features/platform-feature-flags";
 import {
   type NotificationsPromptAfterActionSource,
-  useNotificationsContext,
+  useNotificationsPrompt,
   useNotificationsData,
 } from "LLM/features/NotificationsPrompt";
 import { useNotificationsPromptDrawerScheduler } from "LLM/features/NotificationsPrompt/new/hooks/useNotificationsPromptDrawerScheduler";
@@ -47,7 +47,7 @@ export default function DebugNotificationsPromptQA() {
   const { permissionStatus } = useNotificationsPermission();
   const { pushNotificationsDataOfUser, updatePushNotificationsDataOfUserInStateAndStore } =
     useNotificationsData();
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const { openDrawer } = useNotificationsPromptDrawerScheduler();
 
   const globalPushNotificationsDismissals = useMemo(

--- a/apps/ledger-live-mobile/src/screens/Swap/SubScreens/PendingOperation.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/SubScreens/PendingOperation.tsx
@@ -22,7 +22,7 @@ import {
   hasSwapTabRoute,
   navigateBackToSwapTab,
 } from "../navigation/navigateBackToSwapTab";
-import { useNotificationsContext } from "LLM/features/NotificationsPrompt";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt";
 
 export function PendingOperation({ route, navigation }: PendingOperationParamList) {
   const { colors } = useTheme();
@@ -31,7 +31,7 @@ export function PendingOperation({ route, navigation }: PendingOperationParamLis
   const { isEmbeddedSwap, sponsored } = route.params;
   const syncAccounts = useSyncAllAccounts();
   const supportsSwapTabRoute = hasSwapTabRoute(navigation.getState());
-  const { notifyFlowCompleted } = useNotificationsContext();
+  const { notifyFlowCompleted } = useNotificationsPrompt();
   const allowRemovalRef = useRef(false);
   const completeSwapFlow = useCallback(() => {
     notifyFlowCompleted("swap");

--- a/apps/ledger-live-mobile/src/screens/Swap/SubScreens/__tests__/PendingOperation.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/SubScreens/__tests__/PendingOperation.test.tsx
@@ -10,7 +10,7 @@ import { PendingOperation } from "../PendingOperation";
 const mockNotifyFlowCompleted = jest.fn();
 
 jest.mock("LLM/features/NotificationsPrompt", () => ({
-  useNotificationsContext: () => ({
+  useNotificationsPrompt: () => ({
     notifyFlowCompleted: mockNotifyFlowCompleted,
   }),
 }));


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Rename `useNotificationsContext` to `useNotificationsPrompt` at existing after-action call sites. No behavior change: they already call `notifyFlowCompleted`.

The eligibility hook is renamed to `useNotificationsPromptEligibility` so the public name is free.

Stacked PR 1 of 2. Review one family file; the rest is the same 4-line rename.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-25271](https://ledgerhq.atlassian.net/browse/LIVE-25271)
- **ADR** (if any):
- **Follow-up**: stacked on this — leftover opt-out cleanup

[LIVE-25271]: https://ledgerhq.atlassian.net/browse/LIVE-25271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ