### PR TITLE
[LWDM] feat(perps): sign the deposit through the exchange swap flow

### DIFF
--- a/.changeset/perps-deposit-signing.md
+++ b/.changeset/perps-deposit-signing.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Add the Perps deposit signing step on desktop and mobile, reached from the review screen. It runs on the same swap orchestration as the `custom.exchange.swap` handler — now extracted into a shared `executeSwap` — behind the perps screens, and executes against the quote the review priced against.

--- a/apps/ledger-live-desktop/src/mvvm/features/GlobalDialogs/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GlobalDialogs/index.tsx
@@ -4,6 +4,7 @@ import SendFlowRoot from "LLD/features/Send/SendFlowRoot";
 import PerpsSignRoot from "LLD/features/Perps/screens/PerpsSign/PerpsSignDialog";
 import PerpsDepositRoot from "LLD/features/Perps/screens/PerpsDeposit/PerpsDepositDialog";
 import PerpsReviewRoot from "LLD/features/Perps/screens/PerpsReview/PerpsReviewDialog";
+import PerpsDepositSignRoot from "LLD/features/Perps/screens/PerpsDepositSign/PerpsDepositSignDialog";
 import ActionConfirmationDialog from "LLD/features/ActionConfirmationDialog";
 
 const ReleaseNotes = lazy(() => import("LLD/features/ReleaseNotes"));
@@ -29,6 +30,7 @@ const GlobalDialogs = () => (
     <PerpsSignRoot />
     <PerpsDepositRoot />
     <PerpsReviewRoot />
+    <PerpsDepositSignRoot />
     <ActionConfirmationDialog />
     <Suspense fallback={null}>
       <ReleaseNotes />

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/__tests__/usePerpsDepositExecution.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/__tests__/usePerpsDepositExecution.test.ts
@@ -1,0 +1,201 @@
+import BigNumber from "bignumber.js";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import type { AccountLike } from "@ledgerhq/types-live";
+import { act, renderHook } from "tests/testSetup";
+import { usePerpsDepositExecution, type PerpsDepositDeviceStep } from "../usePerpsDepositExecution";
+
+const mockExecuteSwap = jest.fn();
+jest.mock("@ledgerhq/live-common/wallet-api/Exchange/executeSwap", () => ({
+  executeSwap: (deps: unknown, params: unknown) => mockExecuteSwap(deps, params),
+}));
+
+const mockBroadcast = jest.fn();
+jest.mock("@ledgerhq/live-common/hooks/useBroadcast", () => ({
+  useBroadcast: () => mockBroadcast,
+}));
+
+jest.mock("~/renderer/hooks/useConnectAppAction", () => ({
+  useStartExchangeAction: () => "start-action",
+  useTransactionAction: () => "sign-action",
+}));
+
+jest.mock("@ledgerhq/live-common/hw/actions/completeExchange", () => ({
+  createAction: () => "complete-action",
+}));
+
+jest.mock("@ledgerhq/live-common/exchange/platform/completeExchange", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+// The account updater needs a full swap exchange to build its updaters; the
+// deposit only cares that the broadcast reached the signed dialog.
+jest.mock("@ledgerhq/live-common/exchange/swap/getUpdateAccountWithUpdaterParams", () => ({
+  getUpdateAccountWithUpdaterParams: () => [],
+}));
+
+function createAccount(id: string, currencyId: string): AccountLike {
+  return {
+    type: "Account",
+    id,
+    currency: getCryptoCurrencyById(currencyId),
+    spendableBalance: new BigNumber(0),
+    balance: new BigNumber(0),
+  } as AccountLike;
+}
+
+const depositAccount = createAccount("funding-1", "ethereum");
+const receiverAccount = createAccount("receiver-1", "ethereum");
+
+const params = {
+  depositAccount,
+  receiverAccount,
+  amountSent: { value: "0.02", currencyId: "ethereum" },
+  amountTo: { value: "0.019", currencyId: "ethereum" },
+  quoteId: "quote-1",
+};
+
+const swapUiRequest = {
+  provider: "swapkit_hyperliquid",
+  transaction: { family: "ethereum" },
+  binaryPayload: "payload",
+  signature: "signature",
+  exchange: { fromAccount: depositAccount, toAccount: receiverAccount },
+  swapId: "swap-1",
+  magnitudeAwareRate: new BigNumber(1),
+};
+
+const operation = { id: "operation-1", hash: "0xhash" };
+
+/** Answers the device action the hook is currently waiting on. */
+function answerDeviceStep(deviceStep: PerpsDepositDeviceStep, result: unknown) {
+  if (deviceStep.kind !== "device")
+    throw new Error(`expected a device step, got ${deviceStep.kind}`);
+  return act(async () => {
+    deviceStep.withDeviceAction(binding => binding.onResult(result as never));
+  });
+}
+
+function renderExecution(onDone = jest.fn()) {
+  const { result } = renderHook(() => usePerpsDepositExecution(params, onDone));
+  return { result, onDone };
+}
+
+describe("usePerpsDepositExecution", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockBroadcast.mockResolvedValue(operation);
+  });
+
+  it("quotes the deposit as a swap against the perps provider, at the price the review showed", async () => {
+    mockExecuteSwap.mockResolvedValue({ operationHash: operation.hash, swapId: "swap-1" });
+    const { result } = renderExecution();
+
+    await act(async () => {
+      await result.current.executeDeposit();
+    });
+
+    expect(mockExecuteSwap).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        exchangeType: "SWAP",
+        provider: "swapkit_hyperliquid",
+        fromAmount: "0.02",
+        fromAmountAtomic: new BigNumber("20000000000000000"),
+        quoteId: "quote-1",
+        feeStrategy: "medium",
+      }),
+    );
+  });
+
+  it("drives every device step and hands off to the signed dialog", async () => {
+    const onStartSuccess = jest.fn();
+    const onSwapSuccess = jest.fn();
+    mockExecuteSwap.mockImplementation(async deps => {
+      const nonce = await new Promise<string>((resolve, reject) =>
+        deps.uiHooks["custom.exchange.start"]({
+          exchangeParams: { exchangeType: "SWAP", provider: "swapkit_hyperliquid", exchange: {} },
+          onSuccess: (...args: unknown[]) => {
+            onStartSuccess(...args);
+            resolve(args[0] as string);
+          },
+          onCancel: reject,
+        }),
+      );
+      expect(nonce).toBe("nonce-1");
+
+      await new Promise<void>((resolve, reject) =>
+        deps.uiHooks["custom.exchange.swap"]({
+          exchangeParams: swapUiRequest,
+          onSuccess: (...args: unknown[]) => {
+            onSwapSuccess(...args);
+            resolve();
+          },
+          onCancel: reject,
+        }),
+      );
+    });
+
+    const { result, onDone } = renderExecution();
+    act(() => {
+      void result.current.executeDeposit();
+    });
+
+    // Nonce: the Exchange app opens and returns a device transaction id.
+    expect(result.current.deviceStep).toMatchObject({
+      stepId: "start",
+      isPerpsConfirmation: false,
+    });
+    await answerDeviceStep(result.current.deviceStep, {
+      startExchangeResult: { nonce: "nonce-1", device: { modelId: "stax" } },
+    });
+    expect(onStartSuccess).toHaveBeenCalledWith("nonce-1", { modelId: "stax" });
+
+    // Confirm, sign, broadcast: the perps confirmation screen only shows on the
+    // Exchange app's payload check.
+    expect(result.current.deviceStep).toMatchObject({
+      stepId: "confirm",
+      isPerpsConfirmation: true,
+    });
+    await answerDeviceStep(result.current.deviceStep, {
+      completeExchangeResult: { family: "ethereum" },
+    });
+
+    expect(result.current.deviceStep).toMatchObject({ stepId: "sign", isPerpsConfirmation: false });
+    await answerDeviceStep(result.current.deviceStep, { signedOperation: { operation } });
+
+    expect(mockBroadcast).toHaveBeenCalledWith({ operation });
+    expect(onSwapSuccess).toHaveBeenCalledWith({ operationHash: "0xhash", swapId: "swap-1" });
+    expect(onDone).toHaveBeenCalled();
+  });
+
+  it("surfaces a refused signature instead of spinning", async () => {
+    mockExecuteSwap.mockImplementation(async (deps, _params) => {
+      await new Promise<void>((resolve, reject) => {
+        deps.uiHooks["custom.exchange.swap"]({
+          exchangeParams: swapUiRequest,
+          onSuccess: () => resolve(),
+          onCancel: reject,
+        });
+      });
+    });
+
+    const { result, onDone } = renderExecution();
+    act(() => {
+      void result.current.executeDeposit();
+    });
+
+    await answerDeviceStep(result.current.deviceStep, {
+      completeExchangeResult: { family: "ethereum" },
+    });
+    await answerDeviceStep(result.current.deviceStep, {
+      transactionSignError: new Error("refused on device"),
+    });
+
+    expect(result.current.deviceStep).toEqual({
+      kind: "error",
+      error: new Error("refused on device"),
+    });
+    expect(onDone).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/usePerpsDepositExecution.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/usePerpsDepositExecution.ts
@@ -1,0 +1,314 @@
+import { useCallback, useMemo, useState } from "react";
+import BigNumber from "bignumber.js";
+import type { SignedOperation } from "@ledgerhq/types-live";
+import {
+  addPendingOperation,
+  getAccountCurrency,
+  getMainAccount,
+  getParentAccount,
+} from "@ledgerhq/live-common/account/index";
+import { parseCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import { getUpdateAccountWithUpdaterParams } from "@ledgerhq/live-common/exchange/swap/getUpdateAccountWithUpdaterParams";
+import type { ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
+import { ExchangeType } from "@ledgerhq/live-common/wallet-api/react";
+import { executeSwap } from "@ledgerhq/live-common/wallet-api/Exchange/executeSwap";
+import trackingWrapper from "@ledgerhq/live-common/wallet-api/Exchange/tracking";
+import type { SwapUiRequest } from "@ledgerhq/live-common/wallet-api/Exchange/server";
+import {
+  getWalletApiIdFromAccountId,
+  setWalletApiIdForAccountId,
+} from "@ledgerhq/live-common/wallet-api/converters";
+import { PERPS_DEPOSIT_QUOTE_PROVIDER } from "@ledgerhq/live-common/wallet-api/Perps/depositQuote";
+import type { PerpsDepositReviewParams } from "@ledgerhq/live-common/wallet-api/Perps/server";
+import { createAction as createCompleteExchangeAction } from "@ledgerhq/live-common/hw/actions/completeExchange";
+import type { Action } from "@ledgerhq/live-common/hw/actions/types";
+import completeExchange from "@ledgerhq/live-common/exchange/platform/completeExchange";
+import { useBroadcast } from "@ledgerhq/live-common/hooks/useBroadcast";
+import type { Result as StartExchangeResult } from "@ledgerhq/live-common/hw/actions/startExchange";
+import type { Result as CompleteExchangeResult } from "@ledgerhq/live-common/hw/actions/completeExchange";
+import { useFeatureFlags } from "@features/platform-feature-flags";
+import type { Feature, FeatureId } from "@shared/feature-flags";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
+import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
+import { shallowAccountsSelector } from "~/renderer/reducers/accounts";
+import { mevProtectionSelector } from "~/renderer/reducers/settings";
+import { useStartExchangeAction, useTransactionAction } from "~/renderer/hooks/useConnectAppAction";
+import type { States } from "~/renderer/components/DeviceAction";
+import { broadcastLogger } from "~/datadog/logs";
+import { track } from "~/renderer/analytics/segment";
+
+type StartResult = StartExchangeResult;
+type CompleteResult = CompleteExchangeResult;
+type SignResult = { signedOperation: SignedOperation } | { transactionSignError: Error };
+
+export type PerpsDepositDeviceStep =
+  | { kind: "processing" }
+  | { kind: "error"; error: Error }
+  | {
+      kind: "device";
+      stepId: "start" | "confirm" | "sign";
+      isPerpsConfirmation: boolean;
+      withDeviceAction: <T>(
+        render: <R, H extends States, P>(binding: {
+          action: Action<R, H, P>;
+          request: R;
+          onResult: (result: P) => void;
+        }) => T,
+      ) => T;
+    };
+
+type PerpsDepositDevicePhase = Extract<PerpsDepositDeviceStep, { kind: "device" }>;
+
+const PROCESSING_STEP: PerpsDepositDeviceStep = { kind: "processing" };
+
+export type PerpsDepositExecution = Readonly<{
+  deviceStep: PerpsDepositDeviceStep;
+  executeDeposit: () => Promise<void>;
+  retry: () => void;
+}>;
+
+const EXCHANGE_APP_NAME = "Exchange";
+const FEE_STRATEGY = "medium";
+
+/** The swap orchestration's analytics sink, pointed at the perps flow. */
+const tracking = trackingWrapper((eventName, properties, mandatory) =>
+  track(eventName, { ...properties, flowInitiatedFrom: "Perps" }, mandatory),
+);
+
+/**
+ * Drives a perps deposit through the shared swap orchestration, rendering each
+ * device step in the perps signing dialog rather than the live-app drawer.
+ *
+ * The sequence itself — nonce, provider payload, funding transaction — belongs to
+ * `executeSwap`; this hook only supplies the screens and the app-state updates
+ * that follow the broadcast.
+ */
+export function usePerpsDepositExecution(
+  params: PerpsDepositReviewParams,
+  onDone: () => void,
+): PerpsDepositExecution {
+  const [deviceStep, setDeviceStep] = useState<PerpsDepositDeviceStep>(PROCESSING_STEP);
+
+  const dispatch = useDispatch();
+  const accounts = useSelector(shallowAccountsSelector);
+  const mevProtected = useSelector(mevProtectionSelector);
+
+  const featureFlagsMap = useFeatureFlags();
+  const getFeature = useCallback(
+    (id: FeatureId): Feature | null => featureFlagsMap[id] ?? null,
+    [featureFlagsMap],
+  );
+
+  const startAction = useStartExchangeAction();
+  const signAction = useTransactionAction();
+  const completeAction = useMemo(() => createCompleteExchangeAction(completeExchange), []);
+
+  const { depositAccount, receiverAccount, amountSent, quoteId } = params;
+  const fromParentAccount = useMemo(
+    () => getParentAccount(depositAccount, accounts),
+    [depositAccount, accounts],
+  );
+
+  const broadcastConfig = useMemo(
+    () => ({ mevProtected, source: { type: "swap" as const, name: "perps-deposit" } }),
+    [mevProtected],
+  );
+  const broadcast = useBroadcast({
+    account: depositAccount,
+    parentAccount: fromParentAccount,
+    broadcastConfig,
+    logger: broadcastLogger,
+  });
+
+  const runDeviceStep = useCallback(
+    <R>(build: (onResult: (result: R) => void) => PerpsDepositDevicePhase): Promise<R> =>
+      new Promise<R>(resolve => setDeviceStep(build(resolve))).finally(() =>
+        setDeviceStep(PROCESSING_STEP),
+      ),
+    [],
+  );
+
+  /**
+   * Confirms the provider payload on the Exchange app, signs the funding
+   * transaction with the coin app, then broadcasts it.
+   */
+  const confirmSignAndBroadcast = useCallback(
+    async (exchangeParams: SwapUiRequest) => {
+      const completeResult = await runDeviceStep<CompleteResult>(onResult => ({
+        kind: "device",
+        stepId: "confirm",
+        isPerpsConfirmation: true,
+        withDeviceAction: render =>
+          render({
+            action: completeAction,
+            request: {
+              provider: exchangeParams.provider ?? PERPS_DEPOSIT_QUOTE_PROVIDER,
+              transaction: exchangeParams.transaction,
+              binaryPayload: exchangeParams.binaryPayload,
+              signature: exchangeParams.signature,
+              exchange: exchangeParams.exchange,
+              exchangeType: ExchangeType.SWAP,
+            },
+            onResult,
+          }),
+      }));
+      if ("completeExchangeError" in completeResult) {
+        throw completeResult.completeExchangeError;
+      }
+      const finalTransaction = completeResult.completeExchangeResult;
+
+      const tokenCurrency =
+        depositAccount.type === "TokenAccount" ? depositAccount.token : undefined;
+      const signResult = await runDeviceStep<SignResult>(onResult => ({
+        kind: "device",
+        stepId: "sign",
+        isPerpsConfirmation: false,
+        withDeviceAction: render =>
+          render({
+            action: signAction,
+            request: {
+              tokenCurrency,
+              parentAccount: fromParentAccount,
+              account: depositAccount,
+              transaction: finalTransaction,
+              appName: EXCHANGE_APP_NAME,
+            },
+            onResult,
+          }),
+      }));
+      if ("transactionSignError" in signResult) {
+        throw signResult.transactionSignError;
+      }
+
+      const operation = await broadcast(signResult.signedOperation);
+
+      const swapId = exchangeParams.swapId;
+      if (swapId) {
+        const updateParams = getUpdateAccountWithUpdaterParams({
+          result: { operation, swapId },
+          exchange: exchangeParams.exchange as ExchangeSwap,
+          transaction: finalTransaction,
+          magnitudeAwareRate: exchangeParams.magnitudeAwareRate ?? new BigNumber(0),
+          provider: PERPS_DEPOSIT_QUOTE_PROVIDER,
+        });
+        if (updateParams.length) {
+          dispatch(updateAccountWithUpdater(...updateParams));
+        }
+      } else {
+        const mainFromAccount = getMainAccount(depositAccount, fromParentAccount);
+        dispatch(
+          updateAccountWithUpdater(mainFromAccount.id, account =>
+            addPendingOperation(account, operation),
+          ),
+        );
+      }
+
+      return { operation, swapId };
+    },
+    [
+      broadcast,
+      completeAction,
+      depositAccount,
+      dispatch,
+      fromParentAccount,
+      runDeviceStep,
+      signAction,
+    ],
+  );
+
+  const executeDeposit = useCallback(async () => {
+    try {
+      // Reset to the loading state on every run (including retry after an error).
+      setDeviceStep(PROCESSING_STEP);
+
+      // `executeSwap` resolves both accounts by their wallet-api id.
+      setWalletApiIdForAccountId(depositAccount.id);
+      setWalletApiIdForAccountId(receiverAccount.id);
+
+      const depositCurrency = getAccountCurrency(depositAccount);
+
+      let signed: Awaited<ReturnType<typeof confirmSignAndBroadcast>> | undefined;
+
+      await executeSwap(
+        {
+          accounts,
+          tracking,
+          getFeature,
+          uiHooks: {
+            "custom.exchange.start": ({ exchangeParams, onSuccess, onCancel }) => {
+              void runDeviceStep<StartResult>(onResult => ({
+                kind: "device",
+                stepId: "start",
+                isPerpsConfirmation: false,
+                withDeviceAction: render =>
+                  render({
+                    action: startAction,
+                    request: {
+                      ...exchangeParams,
+                      exchangeType: ExchangeType[exchangeParams.exchangeType],
+                    },
+                    onResult,
+                  }),
+              })).then(result =>
+                "startExchangeError" in result
+                  ? onCancel(result.startExchangeError.error)
+                  : onSuccess(result.startExchangeResult.nonce, result.startExchangeResult.device),
+              );
+            },
+            "custom.exchange.swap": ({ exchangeParams, onSuccess, onCancel }) => {
+              void confirmSignAndBroadcast(exchangeParams).then(result => {
+                signed = result;
+                onSuccess({ operationHash: result.operation.hash, swapId: result.swapId ?? "" });
+              }, onCancel);
+            },
+            // The signing dialog renders errors itself, so there is no separate
+            // error screen to open — reject and let the catch below take over.
+            "custom.exchange.error": ({ onCancel }) => onCancel(),
+          },
+        },
+        {
+          exchangeType: "SWAP",
+          provider: PERPS_DEPOSIT_QUOTE_PROVIDER,
+          fromAccountId: getWalletApiIdFromAccountId(depositAccount.id),
+          toAccountId: getWalletApiIdFromAccountId(receiverAccount.id),
+          fromAmount: amountSent.value,
+          fromAmountAtomic: parseCurrencyUnit(depositCurrency.units[0], amountSent.value),
+          quoteId,
+          feeStrategy: FEE_STRATEGY,
+        },
+      );
+
+      if (!signed) return;
+
+      onDone();
+    } catch (e) {
+      // Device connection errors (lock / disconnect / wrong app) are rendered and
+      // retried in-place by <DeviceAction>, so they never reach here. What lands
+      // here is a result-variant error it delegates to us — a user cancel/refusal
+      // or a business failure — so we surface it (with retry) instead of spinning.
+      setDeviceStep({ kind: "error", error: e instanceof Error ? e : new Error(String(e)) });
+    }
+  }, [
+    accounts,
+    amountSent,
+    confirmSignAndBroadcast,
+    depositAccount,
+    fromParentAccount,
+    getFeature,
+    onDone,
+    quoteId,
+    receiverAccount,
+    runDeviceStep,
+    startAction,
+  ]);
+
+  const retry = useCallback(() => {
+    void executeDeposit();
+  }, [executeDeposit]);
+
+  return {
+    deviceStep,
+    executeDeposit,
+    retry,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/PerpsDepositSignDialog.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/PerpsDepositSignDialog.tsx
@@ -1,0 +1,62 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { Dialog, DialogContent } from "@ledgerhq/lumen-ui-react";
+import {
+  usePerpsDepositSignViewModel,
+  type PerpsDepositSignData,
+} from "./usePerpsDepositSignViewModel";
+import { PerpsDepositSignView } from "./PerpsDepositSignView";
+
+let _opener: ((data: PerpsDepositSignData) => void) | null = null;
+
+function registerPerpsDepositSignOpener(fn: (data: PerpsDepositSignData) => void): () => void {
+  _opener = fn;
+  return () => {
+    _opener = null;
+  };
+}
+
+export function openPerpsDepositSign(data: PerpsDepositSignData) {
+  _opener?.(data);
+}
+
+function PerpsDepositSignBody({
+  data,
+  onClose,
+}: Readonly<{ data: PerpsDepositSignData; onClose: () => void }>) {
+  const viewModel = usePerpsDepositSignViewModel(data, onClose);
+  return <PerpsDepositSignView {...viewModel} />;
+}
+
+function PerpsDepositSignInnerDialog({
+  data,
+  onClose,
+}: Readonly<{ data: PerpsDepositSignData | null; onClose: () => void }>) {
+  const isOpen = data !== null;
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) onClose();
+    },
+    [onClose],
+  );
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent
+        onInteractOutside={e => e.preventDefault()}
+        onEscapeKeyDown={e => e.preventDefault()}
+      >
+        {data ? <PerpsDepositSignBody data={data} onClose={onClose} /> : null}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default function PerpsDepositSignRoot() {
+  const [data, setData] = useState<PerpsDepositSignData | null>(null);
+  const close = useCallback(() => setData(null), []);
+
+  useEffect(() => registerPerpsDepositSignOpener(setData), []);
+
+  return <PerpsDepositSignInnerDialog data={data} onClose={close} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/PerpsDepositSignView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/PerpsDepositSignView.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { Title as DialogTitle } from "@radix-ui/react-dialog";
+import { useTranslation } from "react-i18next";
+import { DialogBody } from "@ledgerhq/lumen-ui-react";
+import DeviceAction from "~/renderer/components/DeviceAction";
+import { renderError, renderLoading } from "~/renderer/components/DeviceAction/rendering";
+import type { PerpsDepositSignViewModel } from "./usePerpsDepositSignViewModel";
+
+type PerpsDepositSignViewProps = Readonly<PerpsDepositSignViewModel>;
+
+export function PerpsDepositSignView({ deviceStep, retry }: PerpsDepositSignViewProps) {
+  const { t } = useTranslation();
+
+  // A result-variant error (user cancel / refusal / business failure) that
+  // <DeviceAction> hands back to us — show its own error screen, with retry.
+  if (deviceStep.kind === "error")
+    return renderError({ error: deviceStep.error, t, onRetry: retry });
+
+  // Off-device phases (quote / payload fetch / broadcast) have no device action to
+  // render, so we show <DeviceAction>'s own loader for a consistent look.
+  if (deviceStep.kind !== "device") return renderLoading();
+
+  return (
+    <>
+      <DialogTitle className="sr-only">{t("perpsDepositSign.a11yTitle")}</DialogTitle>
+
+      <DialogBody>
+        <div className="flex w-full flex-col items-center gap-24 px-16 pb-24 pt-24">
+          {deviceStep.withDeviceAction(({ action, request, onResult }) => (
+            <DeviceAction
+              key={deviceStep.stepId}
+              action={action}
+              request={request}
+              onResult={onResult}
+              isPerpsConfirmation={deviceStep.isPerpsConfirmation}
+            />
+          ))}
+        </div>
+      </DialogBody>
+    </>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/components/PerpsDepositContinueOnDevice.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/components/PerpsDepositContinueOnDevice.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { DeviceModelId, getProductName } from "@ledgerhq/devices";
+import { useSelector } from "LLD/hooks/redux";
+import { getCurrentDevice } from "~/renderer/reducers/devices";
+import { ContinueOnDevice } from "LLD/components/DeviceIntentExecutor/components/DeviceGenericStates/ContinueOnDevice";
+import { PerpsDepositSignTerms } from "./PerpsDepositSignTerms";
+
+/**
+ * The single "continue on your device" screen for the perps deposit: the on-device
+ * prompt plus the SwapKit terms. Rendered both between device steps (the flow's
+ * fallback) and as the completeExchange confirmation (via <DeviceAction>), so the
+ * terms always travel with this screen instead of living in the view.
+ */
+export function PerpsDepositContinueOnDevice() {
+  const device = useSelector(getCurrentDevice);
+  const deviceModelId = device?.modelId ?? DeviceModelId.stax;
+  const deviceName = device?.deviceName || getProductName(deviceModelId);
+
+  return (
+    <div className="flex w-full flex-col items-center gap-24">
+      <ContinueOnDevice deviceModelId={deviceModelId} deviceName={deviceName} />
+      <PerpsDepositSignTerms />
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/components/PerpsDepositSignTerms.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/components/PerpsDepositSignTerms.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { Trans } from "react-i18next";
+import { openURL } from "~/renderer/linking";
+
+const SWAPKIT_TERMS_URL = "https://swapkit.dev/terms-of-service/";
+
+export const PerpsDepositSignTerms = () => (
+  <p className="body-4 text-muted text-center">
+    <Trans
+      i18nKey="perpsDepositSign.terms"
+      components={{
+        termsLink: (
+          <span className="cursor-pointer underline" onClick={() => openURL(SWAPKIT_TERMS_URL)} />
+        ),
+      }}
+    />
+  </p>
+);

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/usePerpsDepositSignViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/usePerpsDepositSignViewModel.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from "react";
+import type { PerpsDepositReviewParams } from "@ledgerhq/live-common/wallet-api/Perps/server";
+import {
+  usePerpsDepositExecution,
+  type PerpsDepositDeviceStep,
+} from "LLD/features/Perps/hooks/usePerpsDepositExecution";
+
+export type PerpsDepositSignData = PerpsDepositReviewParams;
+
+export type PerpsDepositSignViewModel = {
+  deviceStep: PerpsDepositDeviceStep;
+  retry: () => void;
+  onClose: () => void;
+};
+
+export function usePerpsDepositSignViewModel(
+  data: PerpsDepositSignData,
+  onClose: () => void,
+): PerpsDepositSignViewModel {
+  const { deviceStep, executeDeposit, retry } = usePerpsDepositExecution(data, onClose);
+
+  const startedRef = useRef(false);
+  useEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+    void executeDeposit();
+  }, [executeDeposit]);
+
+  return {
+    deviceStep,
+    retry,
+    onClose,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/__tests__/usePerpsReviewViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/__tests__/usePerpsReviewViewModel.test.ts
@@ -9,6 +9,11 @@ jest.mock("../../PerpsDeposit/PerpsDepositDialog", () => ({
   openPerpsDeposit: (data: unknown) => mockOpenPerpsDeposit(data),
 }));
 
+const mockOpenPerpsDepositSign = jest.fn();
+jest.mock("../../PerpsDepositSign/PerpsDepositSignDialog", () => ({
+  openPerpsDepositSign: (data: unknown) => mockOpenPerpsDepositSign(data),
+}));
+
 function createAccount(id: string, currencyId: string): AccountLike {
   return {
     type: "Account",
@@ -76,12 +81,24 @@ describe("usePerpsReviewViewModel", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it("should close the review when confirming the deposit", () => {
+  it("should hand the signing dialog the quote the review priced against", () => {
     const onClose = jest.fn();
-    const { result } = renderHook(() => usePerpsReviewViewModel(createData(), onClose));
+    const data = createData({
+      amountTo: { value: "0.019", currencyId: "ethereum" },
+      quoteId: "quote-1",
+      draft: { depositAccount, depositAmount: 20 },
+    });
+    const { result } = renderHook(() => usePerpsReviewViewModel(data, onClose));
 
     result.current.handleDeposit();
 
+    expect(mockOpenPerpsDepositSign).toHaveBeenCalledWith({
+      depositAccount,
+      receiverAccount,
+      amountSent: data.amountSent,
+      amountTo: data.amountTo,
+      quoteId: "quote-1",
+    });
     expect(onClose).toHaveBeenCalled();
     expect(mockOpenPerpsDeposit).not.toHaveBeenCalled();
   });

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/usePerpsReviewViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/usePerpsReviewViewModel.ts
@@ -4,6 +4,7 @@ import { useSelector } from "LLD/hooks/redux";
 import { accountNameWithDefaultSelector, walletSelector } from "~/renderer/reducers/wallet";
 import { openPerpsDeposit } from "../PerpsDeposit/PerpsDepositDialog";
 import type { PerpsDepositDraft } from "../PerpsDeposit/usePerpsDepositViewModel";
+import { openPerpsDepositSign } from "../PerpsDepositSign/PerpsDepositSignDialog";
 import { formatDepositAmount } from "./utils/formatDepositAmount";
 export type PerpsReviewData = PerpsDepositReviewParams & {
   draft?: PerpsDepositDraft;
@@ -81,10 +82,23 @@ export function usePerpsReviewViewModel(
     onClose();
   }, [data.draft, data.receiverAccount, onClose]);
 
-  // The signing dialog is not built yet, so confirming just closes the review.
   const handleDeposit = useCallback(() => {
+    openPerpsDepositSign({
+      receiverAccount: data.receiverAccount,
+      depositAccount: data.depositAccount,
+      amountSent: data.amountSent,
+      amountTo: data.amountTo,
+      quoteId: data.quoteId,
+    });
     onClose();
-  }, [onClose]);
+  }, [
+    data.amountTo,
+    data.amountSent,
+    data.depositAccount,
+    data.quoteId,
+    data.receiverAccount,
+    onClose,
+  ]);
 
   return {
     swapDetails,

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -77,6 +77,7 @@ import { useTrackTransactionChecksFlow } from "~/renderer/analytics/hooks/useTra
 import { useTrackDmkErrorsEvents } from "~/renderer/analytics/hooks/useTrackDmkErrorsEvents";
 import { identitiesSlice, DeviceId } from "@domain/entity-client-identity";
 import { useBuyDeviceIntercept } from "~/renderer/hooks/useBuyDeviceIntercept";
+import { PerpsDepositContinueOnDevice } from "LLD/features/Perps/screens/PerpsDepositSign/components/PerpsDepositContinueOnDevice";
 import {
   DeviceDeprecationScreen,
   DeviceDeprecationScreens,
@@ -88,7 +89,7 @@ type PartialNullable<T> = {
   [P in keyof T]?: T[P] | null;
 };
 
-type States = PartialNullable<{
+export type States = PartialNullable<{
   appAndVersion: AppAndVersion;
   device: Device;
   unresponsive: boolean;
@@ -168,6 +169,9 @@ type InnerProps<P> = {
   overridesPreferredDeviceModel?: DeviceModelId;
   inlineRetry?: boolean; // Set to false if the retry mechanism is handled externally.
   location?: HOOKS_TRACKING_LOCATIONS;
+  // Marks a perps deposit device action so its swap confirmation renders the
+  // perps "continue on your device" screen instead of the generic swap summary.
+  isPerpsConfirmation?: boolean;
 };
 
 type Props<H extends States, P> = InnerProps<P> & {
@@ -200,6 +204,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
   inlineRetry = true,
   analyticsPropertyFlow,
   location,
+  isPerpsConfirmation,
 }: Props<H, P> & {
   request?: R;
 }) => {
@@ -512,6 +517,11 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
   }
 
   if (completeExchangeStarted && !completeExchangeResult && !completeExchangeError && !isLoading) {
+    // Perps deposit is a FUND, but keeps its own "continue on your device" screen
+    // regardless of exchange type — handle it before the swap/sell/fund switch.
+    if (isPerpsConfirmation) {
+      return <PerpsDepositContinueOnDevice />;
+    }
     const { exchangeType } = request as { exchangeType: number };
 
     // FIXME: could use a TS enum (when LLD will be in TS) or a JS object instead of raw numbers for switch values for clarity
@@ -547,6 +557,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
           estimatedFees: estimatedFees?.toString() ?? undefined,
           stateSettings,
           walletState,
+          isPerpsConfirmation,
         });
       }
 

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -12,6 +12,7 @@ import { CryptoCurrency } from "@domain/entity-currency-crypto";
 import { TokenCurrency } from "@domain/entity-currency-token";
 import { Account, ABTestingVariants } from "@ledgerhq/types-live";
 import { DeviceModelId, getDeviceModel } from "@ledgerhq/devices";
+import { PerpsDepositContinueOnDevice } from "LLD/features/Perps/screens/PerpsDepositSign/components/PerpsDepositContinueOnDevice";
 import {
   Button as ButtonV3,
   Flex,
@@ -1306,6 +1307,12 @@ interface SwapConfirmationProps {
   swapDefaultTrack: Record<string, string | boolean>;
   stateSettings: SettingsState;
   walletState: WalletState;
+  /**
+   * Perps deposit funds via the swap exchange flow, but shows the design's
+   * "continue on your device" confirmation instead of the generic swap summary.
+   * Set by the perps <DeviceAction>; leaves every other swap flow unchanged.
+   */
+  isPerpsConfirmation?: boolean;
 }
 
 const SwapConfirmationDetailedView: React.FC<{
@@ -1506,9 +1513,12 @@ const SwapDeviceConfirmation: React.FC<SwapConfirmationProps> = ({
   );
 };
 
-export const renderSwapDeviceConfirmation = (props: SwapConfirmationProps) => (
-  <SwapDeviceConfirmation {...props} />
-);
+export const renderSwapDeviceConfirmation = (props: SwapConfirmationProps) =>
+  props.isPerpsConfirmation ? (
+    <PerpsDepositContinueOnDevice />
+  ) : (
+    <SwapDeviceConfirmation {...props} />
+  );
 
 export const renderSecureTransferDeviceConfirmation = ({
   exchangeType,

--- a/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
@@ -70,7 +70,7 @@ import { DeviceModelId, getDeviceModel } from "@ledgerhq/devices";
 import { FlowName, getCurrencyName, getFlowName } from "./utils";
 import { useFeature } from "@features/platform-feature-flags";
 
-type Status = PartialNullable<{
+export type Status = PartialNullable<{
   appAndVersion: AppAndVersion;
   device: Device;
   unresponsive: boolean;

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -69,6 +69,7 @@ import { BaseNavigatorStackParamList } from "./types/BaseNavigator";
 import DeviceConnect, { deviceConnectHeaderOptions } from "~/screens/DeviceConnect";
 import PerpsSign from "LLM/features/Perps/screens/PerpsSign/PerpsSignScreen";
 import PerpsDeposit from "LLM/features/Perps/screens/PerpsDeposit/PerpsDepositScreen";
+import PerpsDepositSign from "LLM/features/Perps/screens/PerpsDepositSign/PerpsDepositSignScreen";
 import NoFundsFlowNavigator from "./NoFundsFlowNavigator";
 import StakeFlowNavigator from "./StakeFlowNavigator";
 import { RecoverPlayer } from "~/screens/Protect/Player";
@@ -586,6 +587,11 @@ export default function BaseNavigator() {
             headerStyle: { backgroundColor: lumenBaseColor },
             contentStyle: { backgroundColor: lumenBaseColor },
           }}
+        />
+        <Stack.Screen
+          name={ScreenName.PerpsDepositSign}
+          component={PerpsDepositSign}
+          options={{ headerShown: false }}
         />
         <Stack.Screen
           name={ScreenName.RedirectToOnboardingRecoverFlow}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
@@ -12,6 +12,7 @@ import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import { AppResult } from "@ledgerhq/live-common/hw/actions/app";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import type {
+  PerpsDepositReviewParams,
   PerpsDepositUiParams,
   PerpsSignResult,
 } from "@ledgerhq/live-common/wallet-api/Perps/server";
@@ -360,6 +361,7 @@ export type BaseNavigatorStackParamList = {
     onCancel: () => void;
   };
   [ScreenName.PerpsDeposit]: PerpsDepositUiParams;
+  [ScreenName.PerpsDepositSign]: PerpsDepositReviewParams;
   [ScreenName.DeeplinkInstallAppDeviceSelection]: {
     appKey: string;
   };

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -108,6 +108,7 @@ export enum ScreenName {
   DeviceConnect = "DeviceConnect",
   PerpsSign = "PerpsSign",
   PerpsDeposit = "PerpsDeposit",
+  PerpsDepositSign = "PerpsDepositSign",
   EditAccountName = "EditAccountName",
   EditDeviceName = "EditDeviceName",
   Card = "Card",

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/hooks/__tests__/usePerpsDepositExecution.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/hooks/__tests__/usePerpsDepositExecution.test.ts
@@ -1,0 +1,191 @@
+import BigNumber from "bignumber.js";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import type { AccountLike } from "@ledgerhq/types-live";
+import { act, renderHook } from "@tests/test-renderer";
+import { usePerpsDepositExecution, type PerpsDepositDeviceStep } from "../usePerpsDepositExecution";
+
+const mockExecuteSwap = jest.fn();
+jest.mock("@ledgerhq/live-common/wallet-api/Exchange/executeSwap", () => ({
+  executeSwap: (deps: unknown, params: unknown) => mockExecuteSwap(deps, params),
+}));
+
+const mockBroadcast = jest.fn();
+jest.mock("@ledgerhq/live-common/hooks/useBroadcast", () => ({
+  useBroadcast: () => mockBroadcast,
+}));
+
+jest.mock("~/hooks/deviceActions", () => ({
+  useStartExchangeDeviceAction: () => "start-action",
+  useCompleteExchangeDeviceAction: () => "complete-action",
+  useTransactionDeviceAction: () => "sign-action",
+}));
+
+// The account updater needs a full swap exchange to build its updaters; the
+// deposit only cares that the broadcast reached the caller.
+jest.mock("@ledgerhq/live-common/exchange/swap/getUpdateAccountWithUpdaterParams", () => ({
+  getUpdateAccountWithUpdaterParams: () => [],
+}));
+
+function createAccount(id: string, currencyId: string): AccountLike {
+  return {
+    type: "Account",
+    id,
+    currency: getCryptoCurrencyById(currencyId),
+    spendableBalance: new BigNumber(0),
+    balance: new BigNumber(0),
+  } as AccountLike;
+}
+
+const depositAccount = createAccount("funding-1", "ethereum");
+const receiverAccount = createAccount("receiver-1", "ethereum");
+
+const params = {
+  depositAccount,
+  receiverAccount,
+  amountSent: { value: "0.02", currencyId: "ethereum" },
+  amountTo: { value: "0.019", currencyId: "ethereum" },
+  quoteId: "quote-1",
+};
+
+const swapUiRequest = {
+  provider: "swapkit_hyperliquid",
+  transaction: { family: "ethereum" },
+  binaryPayload: "payload",
+  signature: "signature",
+  exchange: { fromAccount: depositAccount, toAccount: receiverAccount },
+  swapId: "swap-1",
+  magnitudeAwareRate: new BigNumber(1),
+};
+
+const operation = { id: "operation-1", hash: "0xhash" };
+
+/** Answers the device action the hook is currently waiting on. */
+function answerDeviceStep(deviceStep: PerpsDepositDeviceStep, result: unknown) {
+  if (deviceStep.kind !== "device") {
+    throw new Error(`expected a device step, got ${deviceStep.kind}`);
+  }
+  return act(async () => {
+    deviceStep.withDeviceAction(binding => binding.onResult(result as never));
+  });
+}
+
+function renderExecution(onSigned = jest.fn()) {
+  const { result } = renderHook(() => usePerpsDepositExecution(params, onSigned));
+  return { result, onSigned };
+}
+
+describe("usePerpsDepositExecution", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockBroadcast.mockResolvedValue(operation);
+  });
+
+  it("quotes the deposit as a swap against the perps provider, at the price the review showed", async () => {
+    mockExecuteSwap.mockResolvedValue({ operationHash: operation.hash, swapId: "swap-1" });
+    const { result } = renderExecution();
+
+    await act(async () => {
+      await result.current.executeDeposit();
+    });
+
+    expect(mockExecuteSwap).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        exchangeType: "SWAP",
+        provider: "swapkit_hyperliquid",
+        fromAmount: "0.02",
+        fromAmountAtomic: new BigNumber("20000000000000000"),
+        quoteId: "quote-1",
+        feeStrategy: "medium",
+      }),
+    );
+  });
+
+  it("drives every device step and reports the signed deposit", async () => {
+    const onStartSuccess = jest.fn();
+    const onSwapSuccess = jest.fn();
+    mockExecuteSwap.mockImplementation(async deps => {
+      const nonce = await new Promise<string>((resolve, reject) =>
+        deps.uiHooks["custom.exchange.start"]({
+          exchangeParams: { exchangeType: "SWAP", provider: "swapkit_hyperliquid", exchange: {} },
+          onSuccess: (...args: unknown[]) => {
+            onStartSuccess(...args);
+            resolve(args[0] as string);
+          },
+          onCancel: reject,
+        }),
+      );
+      expect(nonce).toBe("nonce-1");
+
+      await new Promise<void>((resolve, reject) =>
+        deps.uiHooks["custom.exchange.swap"]({
+          exchangeParams: swapUiRequest,
+          onSuccess: (...args: unknown[]) => {
+            onSwapSuccess(...args);
+            resolve();
+          },
+          onCancel: reject,
+        }),
+      );
+    });
+
+    const { result, onSigned } = renderExecution();
+    act(() => {
+      void result.current.executeDeposit();
+    });
+
+    // Nonce: the Exchange app opens and returns a device transaction id.
+    expect(result.current.deviceStep).toMatchObject({ stepId: "start" });
+    await answerDeviceStep(result.current.deviceStep, {
+      startExchangeResult: { nonce: "nonce-1", device: { modelId: "stax" } },
+    });
+    expect(onStartSuccess).toHaveBeenCalledWith("nonce-1", { modelId: "stax" });
+
+    expect(result.current.deviceStep).toMatchObject({ stepId: "confirm" });
+    await answerDeviceStep(result.current.deviceStep, {
+      completeExchangeResult: { family: "ethereum" },
+    });
+
+    expect(result.current.deviceStep).toMatchObject({ stepId: "sign" });
+    await answerDeviceStep(result.current.deviceStep, { signedOperation: { operation } });
+
+    expect(mockBroadcast).toHaveBeenCalledWith({ operation });
+    expect(onSwapSuccess).toHaveBeenCalledWith({ operationHash: "0xhash", swapId: "swap-1" });
+    expect(onSigned).toHaveBeenCalledWith({
+      operationId: "operation-1",
+      accountId: "funding-1",
+      receiveCurrencyTicker: "ETH",
+      swapId: "swap-1",
+    });
+  });
+
+  it("surfaces a refused signature instead of spinning", async () => {
+    mockExecuteSwap.mockImplementation(async deps => {
+      await new Promise<void>((resolve, reject) => {
+        deps.uiHooks["custom.exchange.swap"]({
+          exchangeParams: swapUiRequest,
+          onSuccess: () => resolve(),
+          onCancel: reject,
+        });
+      });
+    });
+
+    const { result, onSigned } = renderExecution();
+    act(() => {
+      void result.current.executeDeposit();
+    });
+
+    await answerDeviceStep(result.current.deviceStep, {
+      completeExchangeResult: { family: "ethereum" },
+    });
+    await answerDeviceStep(result.current.deviceStep, {
+      transactionSignError: new Error("refused on device"),
+    });
+
+    expect(result.current.deviceStep).toEqual({
+      kind: "error",
+      error: new Error("refused on device"),
+    });
+    expect(onSigned).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/hooks/usePerpsDepositExecution.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/hooks/usePerpsDepositExecution.ts
@@ -1,0 +1,306 @@
+import { useCallback, useState } from "react";
+import BigNumber from "bignumber.js";
+import type { SignedOperation } from "@ledgerhq/types-live";
+import {
+  addPendingOperation,
+  getAccountCurrency,
+  getMainAccount,
+  getParentAccount,
+} from "@ledgerhq/live-common/account/index";
+import { parseCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import { getUpdateAccountWithUpdaterParams } from "@ledgerhq/live-common/exchange/swap/getUpdateAccountWithUpdaterParams";
+import type { ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
+import { ExchangeType } from "@ledgerhq/live-common/wallet-api/react";
+import { executeSwap } from "@ledgerhq/live-common/wallet-api/Exchange/executeSwap";
+import trackingWrapper from "@ledgerhq/live-common/wallet-api/Exchange/tracking";
+import type { SwapUiRequest } from "@ledgerhq/live-common/wallet-api/Exchange/server";
+import {
+  getWalletApiIdFromAccountId,
+  setWalletApiIdForAccountId,
+} from "@ledgerhq/live-common/wallet-api/converters";
+import { PERPS_DEPOSIT_QUOTE_PROVIDER } from "@ledgerhq/live-common/wallet-api/Perps/depositQuote";
+import type { PerpsDepositReviewParams } from "@ledgerhq/live-common/wallet-api/Perps/server";
+import { useBroadcast } from "@ledgerhq/live-common/hooks/useBroadcast";
+import type { Result as StartExchangeResult } from "@ledgerhq/live-common/hw/actions/startExchange";
+import type { Result as CompleteExchangeResult } from "@ledgerhq/live-common/hw/actions/completeExchange";
+import type { Action } from "@ledgerhq/live-common/hw/actions/types";
+import type { Status as DeviceActionStatus } from "~/components/DeviceAction";
+import { useDispatch, useSelector } from "~/context/hooks";
+import { updateAccountWithUpdater } from "~/actions/accounts";
+import { shallowAccountsSelector } from "~/reducers/accounts";
+import { mevProtectionSelector } from "~/reducers/settings";
+import {
+  useCompleteExchangeDeviceAction,
+  useStartExchangeDeviceAction,
+  useTransactionDeviceAction,
+} from "~/hooks/deviceActions";
+import { broadcastLogger } from "~/datadog";
+import { track } from "~/analytics";
+
+type StartResult = StartExchangeResult;
+type CompleteResult = CompleteExchangeResult;
+type SignResult = { signedOperation: SignedOperation } | { transactionSignError: Error };
+
+export type PerpsDepositSignedResult = Readonly<{
+  operationId: string;
+  accountId: string;
+  receiveCurrencyTicker: string;
+  swapId?: string;
+}>;
+
+export type PerpsDepositDeviceStep =
+  | { kind: "processing" }
+  | { kind: "error"; error: Error }
+  | {
+      kind: "device";
+      stepId: "start" | "confirm" | "sign";
+      withDeviceAction: <T>(
+        render: <R, H extends DeviceActionStatus, P>(binding: {
+          action: Action<R, H, P>;
+          request: R;
+          onResult: (result: NonNullable<P>) => void;
+        }) => T,
+      ) => T;
+    };
+
+type PerpsDepositDevicePhase = Extract<PerpsDepositDeviceStep, { kind: "device" }>;
+
+const PROCESSING_STEP: PerpsDepositDeviceStep = { kind: "processing" };
+
+export type PerpsDepositExecution = Readonly<{
+  deviceStep: PerpsDepositDeviceStep;
+  executeDeposit: () => Promise<void>;
+  retry: () => void;
+}>;
+
+const EXCHANGE_APP_NAME = "Exchange";
+const FEE_STRATEGY = "medium";
+
+/** The swap orchestration's analytics sink, pointed at the perps flow. */
+const tracking = trackingWrapper((eventName, properties, mandatory) =>
+  track(eventName, { ...properties, flowInitiatedFrom: "Perps" }, mandatory),
+);
+
+/**
+ * Drives a perps deposit through the shared swap orchestration, rendering each
+ * device step in the perps signing screen rather than the live-app flow.
+ *
+ * The sequence itself — nonce, provider payload, funding transaction — belongs to
+ * `executeSwap`; this hook only supplies the steps and the app-state updates that
+ * follow the broadcast.
+ */
+export function usePerpsDepositExecution(
+  params: PerpsDepositReviewParams,
+  onSigned: (result: PerpsDepositSignedResult) => void,
+): PerpsDepositExecution {
+  const [deviceStep, setDeviceStep] = useState<PerpsDepositDeviceStep>(PROCESSING_STEP);
+
+  const dispatch = useDispatch();
+  const accounts = useSelector(shallowAccountsSelector);
+  const mevProtected = useSelector(mevProtectionSelector);
+
+  const startAction = useStartExchangeDeviceAction();
+  const completeAction = useCompleteExchangeDeviceAction();
+  const signAction = useTransactionDeviceAction();
+
+  const { depositAccount, receiverAccount, amountSent, quoteId } = params;
+  const fromParentAccount = getParentAccount(depositAccount, accounts);
+
+  const broadcast = useBroadcast({
+    account: depositAccount,
+    parentAccount: fromParentAccount,
+    broadcastConfig: { mevProtected, source: { type: "swap", name: "perps-deposit" } },
+    logger: broadcastLogger,
+  });
+
+  const runDeviceStep = useCallback(
+    <R>(build: (onResult: (result: R) => void) => PerpsDepositDevicePhase): Promise<R> =>
+      new Promise<R>(resolve => setDeviceStep(build(resolve))).finally(() =>
+        setDeviceStep(PROCESSING_STEP),
+      ),
+    [],
+  );
+
+  /**
+   * Confirms the provider payload on the Exchange app, signs the funding
+   * transaction with the coin app, then broadcasts it.
+   */
+  const confirmSignAndBroadcast = useCallback(
+    async (exchangeParams: SwapUiRequest) => {
+      const completeResult = await runDeviceStep<CompleteResult>(onResult => ({
+        kind: "device",
+        stepId: "confirm",
+        withDeviceAction: render =>
+          render({
+            action: completeAction,
+            request: {
+              provider: exchangeParams.provider ?? PERPS_DEPOSIT_QUOTE_PROVIDER,
+              transaction: exchangeParams.transaction,
+              binaryPayload: exchangeParams.binaryPayload,
+              signature: exchangeParams.signature,
+              exchange: exchangeParams.exchange,
+              exchangeType: ExchangeType.SWAP,
+            },
+            onResult,
+          }),
+      }));
+      if ("completeExchangeError" in completeResult) {
+        throw completeResult.completeExchangeError;
+      }
+      const finalTransaction = completeResult.completeExchangeResult;
+
+      const tokenCurrency =
+        depositAccount.type === "TokenAccount" ? depositAccount.token : undefined;
+      const signResult = await runDeviceStep<SignResult>(onResult => ({
+        kind: "device",
+        stepId: "sign",
+        withDeviceAction: render =>
+          render({
+            action: signAction,
+            request: {
+              tokenCurrency,
+              parentAccount: fromParentAccount,
+              account: depositAccount,
+              transaction: finalTransaction,
+              appName: EXCHANGE_APP_NAME,
+            },
+            onResult,
+          }),
+      }));
+      if ("transactionSignError" in signResult) {
+        throw signResult.transactionSignError;
+      }
+
+      const operation = await broadcast(signResult.signedOperation);
+
+      const swapId = exchangeParams.swapId;
+      if (swapId) {
+        const [accountId, updater] = getUpdateAccountWithUpdaterParams({
+          result: { operation, swapId },
+          exchange: exchangeParams.exchange as ExchangeSwap,
+          transaction: finalTransaction,
+          magnitudeAwareRate: exchangeParams.magnitudeAwareRate ?? new BigNumber(0),
+          provider: PERPS_DEPOSIT_QUOTE_PROVIDER,
+        });
+        if (accountId && updater) {
+          dispatch(updateAccountWithUpdater({ accountId, updater }));
+        }
+      } else {
+        const mainFromAccount = getMainAccount(depositAccount, fromParentAccount);
+        dispatch(
+          updateAccountWithUpdater({
+            accountId: mainFromAccount.id,
+            updater: account => addPendingOperation(account, operation),
+          }),
+        );
+      }
+
+      return { operation, swapId };
+    },
+    [
+      broadcast,
+      completeAction,
+      depositAccount,
+      dispatch,
+      fromParentAccount,
+      runDeviceStep,
+      signAction,
+    ],
+  );
+
+  const executeDeposit = useCallback(async () => {
+    try {
+      // Reset to the loading state on every run (including retry after an error).
+      setDeviceStep(PROCESSING_STEP);
+
+      // `executeSwap` resolves both accounts by their wallet-api id.
+      setWalletApiIdForAccountId(depositAccount.id);
+      setWalletApiIdForAccountId(receiverAccount.id);
+
+      const depositCurrency = getAccountCurrency(depositAccount);
+      const receiveCurrency = getAccountCurrency(receiverAccount);
+      const mainFromAccount = getMainAccount(depositAccount, fromParentAccount);
+
+      let signed: Awaited<ReturnType<typeof confirmSignAndBroadcast>> | undefined;
+
+      await executeSwap(
+        {
+          accounts,
+          tracking,
+          uiHooks: {
+            "custom.exchange.start": ({ exchangeParams, onSuccess, onCancel }) => {
+              void runDeviceStep<StartResult>(onResult => ({
+                kind: "device",
+                stepId: "start",
+                withDeviceAction: render =>
+                  render({
+                    action: startAction,
+                    request: {
+                      ...exchangeParams,
+                      exchangeType: ExchangeType[exchangeParams.exchangeType],
+                    },
+                    onResult,
+                  }),
+              })).then(result =>
+                "startExchangeError" in result
+                  ? onCancel(result.startExchangeError.error)
+                  : onSuccess(result.startExchangeResult.nonce, result.startExchangeResult.device),
+              );
+            },
+            "custom.exchange.swap": ({ exchangeParams, onSuccess, onCancel }) => {
+              void confirmSignAndBroadcast(exchangeParams).then(result => {
+                signed = result;
+                onSuccess({ operationHash: result.operation.hash, swapId: result.swapId ?? "" });
+              }, onCancel);
+            },
+            // The signing screen renders errors itself, so there is no separate
+            // error screen to open — reject and let the catch below take over.
+            "custom.exchange.error": ({ onCancel }) => onCancel(),
+          },
+        },
+        {
+          exchangeType: "SWAP",
+          provider: PERPS_DEPOSIT_QUOTE_PROVIDER,
+          fromAccountId: getWalletApiIdFromAccountId(depositAccount.id),
+          toAccountId: getWalletApiIdFromAccountId(receiverAccount.id),
+          fromAmount: amountSent.value,
+          fromAmountAtomic: parseCurrencyUnit(depositCurrency.units[0], amountSent.value),
+          quoteId,
+          feeStrategy: FEE_STRATEGY,
+        },
+      );
+
+      if (!signed) return;
+
+      onSigned({
+        operationId: signed.operation.id,
+        accountId: mainFromAccount.id,
+        receiveCurrencyTicker: receiveCurrency.ticker,
+        swapId: signed.swapId,
+      });
+    } catch (e) {
+      // Device connection errors (lock / disconnect / wrong app) are rendered and
+      // retried in-place by <DeviceAction>, so they never reach here. What lands
+      // here is a result-variant error it delegates to us — a user cancel/refusal
+      // or a business failure — so we surface it (with retry) instead of spinning.
+      setDeviceStep({ kind: "error", error: e instanceof Error ? e : new Error(String(e)) });
+    }
+  }, [
+    accounts,
+    amountSent,
+    confirmSignAndBroadcast,
+    depositAccount,
+    fromParentAccount,
+    onSigned,
+    quoteId,
+    receiverAccount,
+    runDeviceStep,
+    startAction,
+  ]);
+
+  const retry = useCallback(() => {
+    void executeDeposit();
+  }, [executeDeposit]);
+
+  return { deviceStep, executeDeposit, retry };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/__tests__/usePerpsReviewViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/__tests__/usePerpsReviewViewModel.test.ts
@@ -2,7 +2,15 @@ import BigNumber from "bignumber.js";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { AccountLike } from "@ledgerhq/types-live";
 import { renderHook, waitFor } from "@tests/test-renderer";
+import { ScreenName } from "~/const";
 import { usePerpsReviewViewModel, type PerpsReviewProps } from "../usePerpsReviewViewModel";
+
+const mockNavigate = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
 
 function createAccount(id: string, currencyId: string): AccountLike {
   return {
@@ -70,5 +78,26 @@ describe("usePerpsReviewViewModel", () => {
     result.current.handleDeposit();
 
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it("hands the signing screen the quote the review priced against", () => {
+    const { result } = renderHook(() =>
+      usePerpsReviewViewModel(
+        createProps({
+          amountTo: { value: "0.019", currencyId: "ethereum" },
+          quoteId: "quote-1",
+        }),
+      ),
+    );
+
+    result.current.handleDeposit();
+
+    expect(mockNavigate).toHaveBeenCalledWith(ScreenName.PerpsDepositSign, {
+      depositAccount,
+      receiverAccount,
+      amountSent: { value: "0.02", currencyId: "ethereum" },
+      amountTo: { value: "0.019", currencyId: "ethereum" },
+      quoteId: "quote-1",
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/usePerpsReviewViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/usePerpsReviewViewModel.ts
@@ -1,7 +1,11 @@
 import { useCallback, useMemo } from "react";
+import { useNavigation } from "@react-navigation/native";
 import type { PerpsDepositReviewParams } from "@ledgerhq/live-common/wallet-api/Perps/server";
 import { useSelector } from "~/context/hooks";
+import { ScreenName } from "~/const";
 import { accountNameWithDefaultSelector, walletSelector } from "~/reducers/wallet";
+import type { StackNavigatorNavigation } from "~/components/RootNavigator/types/helpers";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { formatDepositAmount } from "./utils/formatDepositAmount";
 
 export type PerpsReviewDetailItem = Readonly<{
@@ -33,8 +37,10 @@ export function usePerpsReviewViewModel({
   amountTo,
   depositAccount,
   receiverAccount,
+  quoteId,
 }: PerpsReviewProps): PerpsReviewViewModel {
   const walletState = useSelector(walletSelector);
+  const navigation = useNavigation<StackNavigatorNavigation<BaseNavigatorStackParamList>>();
 
   const formattedAmountSent = useMemo(
     () => formatDepositAmount(amountSent, depositAccount),
@@ -84,10 +90,15 @@ export function usePerpsReviewViewModel({
   );
 
   const handleDeposit = useCallback(() => {
-    // Confirming closes the drawer; executing the deposit (sign + broadcast) is
-    // owned by the wallet's deposit flow and reports no result to the live app.
     onClose();
-  }, [onClose]);
+    navigation.navigate(ScreenName.PerpsDepositSign, {
+      depositAccount,
+      receiverAccount,
+      amountSent,
+      amountTo,
+      quoteId,
+    });
+  }, [amountTo, amountSent, depositAccount, navigation, onClose, quoteId, receiverAccount]);
 
   return {
     drawerOpen: isOpen,

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDepositSign/PerpsDepositSignScreen.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDepositSign/PerpsDepositSignScreen.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import type { RootComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { ScreenName } from "~/const";
+import { PerpsDepositSignView } from ".";
+import { usePerpsDepositSignViewModel } from "./usePerpsDepositSignViewModel";
+
+type NavigationProps = RootComposite<
+  StackNavigatorProps<BaseNavigatorStackParamList, ScreenName.PerpsDepositSign>
+>;
+
+export default function PerpsDepositSignScreen(props: NavigationProps) {
+  const viewModel = usePerpsDepositSignViewModel(props);
+  return <PerpsDepositSignView {...viewModel} />;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDepositSign/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDepositSign/index.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Box, Button, Spinner } from "@ledgerhq/lumen-ui-rnative";
+import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
+import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
+import DeviceAction from "~/components/DeviceAction";
+import GenericErrorView from "~/components/GenericErrorView";
+import SelectDevice2 from "~/components/SelectDevice2";
+import { useTranslation } from "~/context/Locale";
+import type { PerpsDepositSignViewModel } from "./usePerpsDepositSignViewModel";
+
+export function PerpsDepositSignView({
+  selectedDevice,
+  deviceStep,
+  setSelectedDevice,
+  retry,
+  requestToSetHeaderOptions,
+}: Readonly<PerpsDepositSignViewModel>) {
+  const { t } = useTranslation();
+  const styles = useStyleSheet(
+    theme => ({
+      root: {
+        flex: 1,
+        backgroundColor: theme.colors.bg.base,
+      },
+    }),
+    [],
+  );
+
+  if (!selectedDevice) {
+    return (
+      <SafeAreaView edges={["bottom"]} style={styles.root}>
+        <Box lx={{ paddingHorizontal: "s16", paddingVertical: "s8", flex: 1 }}>
+          <SelectDevice2
+            onSelect={setSelectedDevice}
+            requestToSetHeaderOptions={requestToSetHeaderOptions}
+            autoSelectLastConnectedDevice
+          />
+        </Box>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView edges={["bottom"]} style={styles.root}>
+      <Box lx={{ alignItems: "center", justifyContent: "center", padding: "s24", flex: 1 }}>
+        {deviceStep.kind === "error" ? (
+          <GenericErrorView
+            error={deviceStep.error}
+            footerComponent={
+              <Button appearance="base" size="lg" onPress={retry} testID="perps-deposit-sign-retry">
+                {t("common.retry")}
+              </Button>
+            }
+          />
+        ) : deviceStep.kind === "device" ? (
+          deviceStep.withDeviceAction(({ action, request, onResult }) => (
+            <DeviceAction
+              key={deviceStep.stepId}
+              action={action}
+              device={selectedDevice}
+              request={request}
+              onResult={onResult}
+              analyticsPropertyFlow="perps deposit"
+            />
+          ))
+        ) : (
+          // The off-device phases (provider payload, broadcast) have nothing to show.
+          <Spinner />
+        )}
+        <SyncSkipUnderPriority priority={100} />
+      </Box>
+    </SafeAreaView>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDepositSign/usePerpsDepositSignViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDepositSign/usePerpsDepositSignViewModel.ts
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Device } from "@ledgerhq/live-common/hw/actions/types";
+import type { SetHeaderOptionsRequest } from "~/components/SelectDevice2";
+import type { RootComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { ScreenName } from "~/const";
+import {
+  usePerpsDepositExecution,
+  type PerpsDepositDeviceStep,
+  type PerpsDepositSignedResult,
+} from "../../hooks/usePerpsDepositExecution";
+
+type NavigationProps = RootComposite<
+  StackNavigatorProps<BaseNavigatorStackParamList, ScreenName.PerpsDepositSign>
+>;
+
+export type PerpsDepositSignViewModel = Readonly<{
+  selectedDevice: Device | null | undefined;
+  deviceStep: PerpsDepositDeviceStep;
+  setSelectedDevice: (device: Device | null | undefined) => void;
+  retry: () => void;
+  requestToSetHeaderOptions: (req: SetHeaderOptionsRequest) => void;
+}>;
+
+export function usePerpsDepositSignViewModel({
+  navigation,
+  route,
+}: NavigationProps): PerpsDepositSignViewModel {
+  const [selectedDevice, setSelectedDevice] = useState<Device | null | undefined>();
+
+  const handleSigned = useCallback(
+    (_result: PerpsDepositSignedResult) => {
+      // The deposit lands asynchronously through the provider; there is no
+      // mobile confirmation screen yet, so return to the perps app.
+      navigation.goBack();
+    },
+    [navigation],
+  );
+
+  const { deviceStep, executeDeposit, retry } = usePerpsDepositExecution(
+    route.params,
+    handleSigned,
+  );
+
+  const startedRef = useRef(false);
+  useEffect(() => {
+    if (!selectedDevice || startedRef.current) return;
+    startedRef.current = true;
+    void executeDeposit();
+  }, [executeDeposit, selectedDevice]);
+
+  const requestToSetHeaderOptions = useCallback(
+    (req: SetHeaderOptionsRequest) => {
+      if (req.type === "set") {
+        navigation.setOptions({
+          headerShown: true,
+          headerLeft: req.options.headerLeft,
+          headerRight: req.options.headerRight,
+        });
+      } else {
+        navigation.setOptions({
+          headerShown: false,
+          headerLeft: () => null,
+          headerRight: () => null,
+        });
+      }
+    },
+    [navigation],
+  );
+
+  return {
+    selectedDevice,
+    deviceStep,
+    setSelectedDevice,
+    retry,
+    requestToSetHeaderOptions,
+  };
+}

--- a/libs/ledger-live-common/src/hw/actions/completeExchange.ts
+++ b/libs/ledger-live-common/src/hw/actions/completeExchange.ts
@@ -32,7 +32,7 @@ type CompleteExchangeRequest = {
   rate?: number;
   amountExpectedTo?: number;
 };
-type Result =
+export type Result =
   | {
       completeExchangeResult: Transaction;
     }

--- a/libs/ledger-live-common/src/wallet-api/Exchange/executeSwap.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/executeSwap.ts
@@ -18,7 +18,7 @@ import {
 } from "@ledgerhq/wallet-api-exchange-module";
 import { BigNumber } from "bignumber.js";
 import get from "lodash/get";
-import { Transaction as EvmTransaction } from "@ledgerhq/coin-evm/types/index";
+import type { Transaction as EvmTransaction } from "../../families/evm/types";
 import { padHexString } from "@ledgerhq/hw-app-eth";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { getAccountBridge } from "../../bridge";

--- a/libs/ledger-live-common/src/wallet-api/Exchange/executeSwap.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/executeSwap.ts
@@ -1,0 +1,523 @@
+import {
+  getMainAccount,
+  getParentAccount,
+  makeEmptyTokenAccount,
+} from "@ledgerhq/ledger-wallet-framework/account/index";
+import { getCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
+import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { CryptoOrTokenCurrency } from "@domain/entity-currency";
+import { decodeSwapPayload } from "@ledgerhq/hw-app-exchange";
+import { Account, AccountLike, getCurrencyForAccount } from "@ledgerhq/types-live";
+import { createAccountNotFound, ServerError } from "@ledgerhq/wallet-api-core";
+import {
+  ExchangeStartResult,
+  ExchangeStartSwapParams,
+  ExchangeSwapParams,
+  ExchangeType,
+  SwapResult,
+} from "@ledgerhq/wallet-api-exchange-module";
+import { BigNumber } from "bignumber.js";
+import get from "lodash/get";
+import { Transaction as EvmTransaction } from "@ledgerhq/coin-evm/types/index";
+import { padHexString } from "@ledgerhq/hw-app-eth";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { getAccountBridge } from "../../bridge";
+import { Transaction } from "../../coin-modules/transaction-types";
+import { CompleteExchangeError, getErrorDetails, getSwapStepFromError } from "../../exchange/error";
+import { postSwapCancelled } from "../../exchange/swap";
+import { retrieveSwapPayload } from "../../exchange/swap/api/v5/actions";
+import { setBroadcastTransaction } from "../../exchange/swap/setBroadcastTransaction";
+import { transactionStrategy } from "../../exchange/swap/transactionStrategies";
+import { FeatureFlags } from "../../exchange/swap/types";
+import { getAccountIdFromWalletAccountId } from "../converters";
+import type { GetFeatureFn } from "../FeatureFlags/resolver";
+import { createAccounIdNotFound, createWrongSwapParams, ExchangeError } from "./error";
+import { handleErrors } from "./handleSwapErrors";
+import { createStepError, StepError, toError } from "./parser";
+import { SwapError } from "./SwapError";
+import { TrackingAPI } from "./tracking";
+import type {
+  ExchangeStartParamsUiRequest,
+  ExchangeUiHooks,
+  SwapStartParamsUiRequest,
+} from "./uiRequests";
+
+/**
+ * Everything the swap needs that the wallet-api handler factory would otherwise
+ * capture. The hooks are the only host-specific part: whoever calls this decides
+ * which screens drive the device steps.
+ */
+export type SwapDeps = {
+  accounts: AccountLike[];
+  tracking: TrackingAPI;
+  flags?: FeatureFlags;
+  getFeature?: GetFeatureFn;
+  uiHooks: Pick<
+    ExchangeUiHooks,
+    "custom.exchange.start" | "custom.exchange.swap" | "custom.exchange.error"
+  >;
+};
+
+/**
+ * Runs a swap end to end: nonce on device, provider payload, funding
+ * transaction, then the device confirmation / signature / broadcast the caller's
+ * `custom.exchange.swap` hook is responsible for.
+ *
+ * Shared by the `custom.exchange.swap` RPC handler (live apps) and by in-app
+ * flows that need the same sequence behind their own screens, so the two can't
+ * drift apart.
+ */
+export async function executeSwap(
+  { accounts, tracking, flags, getFeature, uiHooks }: SwapDeps,
+  params: ExchangeSwapParams,
+): Promise<SwapResult> {
+  const {
+    "custom.exchange.start": uiExchangeStart,
+    "custom.exchange.swap": uiSwap,
+    "custom.exchange.error": uiError,
+  } = uiHooks;
+
+  try {
+    const {
+      provider,
+      fromAmount,
+      fromAmountAtomic,
+      quoteId,
+      toNewTokenId,
+      customFeeConfig,
+      swapAppVersion,
+      sponsored,
+      isEmbedded,
+      swapEntryPoint,
+      correlationId,
+    } = params;
+
+    const trackingParams = {
+      provider: params.provider,
+      exchangeType: params.exchangeType,
+      isEmbeddedSwap: isEmbedded,
+      swapEntryPoint,
+    };
+
+    tracking.startExchangeRequested(trackingParams);
+
+    const exchangeStartParams: ExchangeStartParamsUiRequest = (await extractSwapStartParam(
+      params,
+      accounts,
+    )) as SwapStartParamsUiRequest;
+
+    const {
+      fromCurrency,
+      fromAccount,
+      fromParentAccount,
+      toCurrency,
+      toAccount,
+      toParentAccount,
+    } = exchangeStartParams.exchange;
+
+    if (!fromAccount || !fromCurrency) {
+      throw new ServerError(createAccountNotFound(params.fromAccountId));
+    }
+
+    const fromAccountAddress = fromParentAccount
+      ? fromParentAccount.freshAddress
+      : (fromAccount as Account).freshAddress;
+
+    const toAccountAddress = toParentAccount
+      ? toParentAccount.freshAddress
+      : (toAccount as Account).freshAddress;
+
+    // Step 1: Open the drawer and open exchange app
+    const startExchange = async () => {
+      return new Promise<{ transactionId: string; device?: ExchangeStartResult["device"] }>(
+        (resolve, reject) => {
+          uiExchangeStart({
+            exchangeParams: exchangeStartParams,
+            onSuccess: (nonce, device) => {
+              tracking.startExchangeSuccess(trackingParams);
+              resolve({ transactionId: nonce, device });
+            },
+            onCancel: error => {
+              tracking.startExchangeFail(trackingParams);
+              reject(error);
+            },
+          });
+        },
+      );
+    };
+
+    let transactionId: string;
+    let deviceInfo: ExchangeStartResult["device"];
+
+    try {
+      const result = await startExchange();
+      transactionId = result.transactionId;
+      deviceInfo = result.device;
+    } catch (error) {
+      const rawError = get(error, "response.data.error", error);
+      const wrappedError = createStepError({
+        error: toError(rawError),
+        step: StepError.NONCE,
+        correlationId: params?.correlationId,
+      });
+      throw wrappedError;
+    }
+
+    tracking.swapPayloadRequested({
+      provider,
+      transactionId,
+      fromAccountAddress,
+      toAccountAddress,
+      fromCurrencyId: fromCurrency!.id,
+      toCurrencyId: toCurrency?.id,
+      fromAmount,
+      quoteId,
+    });
+
+    const {
+      binaryPayload,
+      signature,
+      payinAddress,
+      swapId,
+      payinExtraId,
+      extraTransactionParameters,
+    } = await retrieveSwapPayload({
+      provider,
+      deviceTransactionId: transactionId,
+      fromAccountAddress,
+      toAccountAddress,
+      fromAccountCurrency: fromCurrency!.id,
+      toAccountCurrency: toCurrency!.id,
+      amount: fromAmount,
+      amountInAtomicUnit: fromAmountAtomic,
+      quoteId,
+      toNewTokenId,
+      flags,
+      correlationId,
+    }).catch((error: Error) => {
+      const wrappedError = createStepError({
+        error: get(error, "response.data.error", error),
+        step: StepError.PAYLOAD,
+        correlationId: params?.correlationId,
+      });
+      throw wrappedError;
+    });
+
+    tracking.swapResponseRetrieved({
+      binaryPayload,
+      signature,
+      payinAddress,
+      swapId,
+      payinExtraId,
+      extraTransactionParameters,
+    });
+
+    tracking.completeExchangeRequested(trackingParams);
+
+    const strategyData = {
+      recipient: payinAddress,
+      amount: fromAmountAtomic,
+      currency: fromCurrency as CryptoOrTokenCurrency,
+      customFeeConfig: customFeeConfig ?? {},
+      payinExtraId,
+      extraTransactionParameters,
+      sponsored,
+    };
+
+    const transaction: Transaction = await getStrategy(strategyData, "swap", getFeature);
+
+    const mainFromAccount = getMainAccount(fromAccount, fromParentAccount);
+
+    if (transaction.family !== mainFromAccount.currency.family) {
+      return Promise.reject(
+        new Error(
+          `Account and transaction must be from the same family. Account family: ${mainFromAccount.currency.family}, Transaction family: ${transaction.family}`,
+        ),
+      );
+    }
+
+    const accountBridge = await getAccountBridge(fromAccount, fromParentAccount);
+
+    /**
+     * 'subAccountId' is used for ETH and it's ERC-20 tokens.
+     * This field is ignored for BTC
+     */
+    const subAccountId =
+      fromParentAccount && fromParentAccount.id !== fromAccount.id ? fromAccount.id : undefined;
+
+    const bridgeTx = accountBridge.createTransaction(fromAccount);
+    /**
+     * We append the `recipient` to the tx created from `createTransaction`
+     * to avoid having userGasLimit reset to null for ETH txs
+     * cf. libs/ledger-live-common/src/families/ethereum/updateTransaction.ts
+     */
+    const tx = accountBridge.updateTransaction(
+      {
+        ...bridgeTx,
+        recipient: transaction.recipient,
+      },
+      {
+        ...transaction,
+        feesStrategy: params.feeStrategy.toLowerCase(),
+        subAccountId,
+      },
+    );
+
+    // Get amountExpectedTo and magnitudeAwareRate from binary payload
+    const decodePayload = await decodeSwapPayload(binaryPayload);
+    const amountExpectedTo = new BigNumber(decodePayload.amountToWallet.toString());
+    const magnitudeAwareRate = tx.amount && amountExpectedTo.dividedBy(tx.amount);
+    const refundAddress = decodePayload.refundAddress;
+    const payoutAddress = decodePayload.payoutAddress;
+
+    // tx.amount should be BigNumber
+    tx.amount = new BigNumber(tx.amount);
+
+    return new Promise((resolve, reject) =>
+      uiSwap({
+        exchangeParams: {
+          exchangeType: ExchangeType.SWAP,
+          provider: params.provider,
+          transaction: tx,
+          signature: signature,
+          binaryPayload: binaryPayload,
+          exchange: {
+            fromAccount,
+            fromParentAccount,
+            toAccount,
+            toParentAccount,
+            fromCurrency: fromCurrency!,
+            toCurrency: toCurrency!,
+          },
+          feesStrategy: params.feeStrategy,
+          swapId: swapId,
+          amountExpectedTo: amountExpectedTo.toNumber(),
+          magnitudeAwareRate,
+          refundAddress,
+          payoutAddress,
+          sponsored,
+          isEmbeddedSwap: isEmbedded,
+          swapEntryPoint,
+          ...(correlationId && { correlationId }),
+        },
+        onSuccess: ({ operationHash, swapId }: { operationHash: string; swapId: string }) => {
+          tracking.completeExchangeSuccess({
+            ...trackingParams,
+            currency: transaction.family,
+          });
+
+          setBroadcastTransaction({
+            provider,
+            result: { operation: operationHash, swapId },
+            sourceCurrencyId: fromCurrency.id,
+            targetCurrencyId: toCurrency?.id,
+            hardwareWalletType: deviceInfo?.modelId as DeviceModelId,
+            swapAppVersion,
+            fromAccountAddress,
+            toAccountAddress,
+            fromAmount,
+            flags,
+          });
+
+          resolve({ operationHash, swapId });
+        },
+        onCancel: error => {
+          const {
+            name: rawErrorName,
+            message: rawErrorMessage,
+            cause: rawErrorCause,
+          } = getErrorDetails(error);
+          const causeSuffix = rawErrorCause ? `, ${JSON.stringify(rawErrorCause)}` : "";
+          const errorMessageWithCause = rawErrorMessage + causeSuffix;
+
+          const completeExchangeError =
+            // step provided in libs/ledger-live-common/src/exchange/platform/transfer/completeExchange.ts
+            error instanceof CompleteExchangeError
+              ? error
+              : new CompleteExchangeError("INIT", rawErrorName, errorMessageWithCause);
+
+          postSwapCancelled({
+            provider: provider,
+            swapId: swapId,
+            swapStep: getSwapStepFromError(completeExchangeError),
+            statusCode: completeExchangeError.title || completeExchangeError.name,
+            errorMessage: completeExchangeError.message || errorMessageWithCause,
+            sourceCurrencyId: fromCurrency.id,
+            targetCurrencyId: toCurrency?.id,
+            hardwareWalletType: deviceInfo?.modelId as DeviceModelId,
+            swapType: quoteId ? "fixed" : "float",
+            swapAppVersion,
+            fromAccountAddress,
+            toAccountAddress,
+            refundAddress,
+            payoutAddress,
+            fromAmount,
+            seedIdFrom: mainFromAccount.seedIdentifier,
+            seedIdTo: toParentAccount?.seedIdentifier || (toAccount as Account)?.seedIdentifier,
+            data: (transaction as EvmTransaction).data
+              ? `0x${padHexString((transaction as EvmTransaction).data?.toString("hex") || "")}`
+              : "0x",
+            flags,
+          });
+
+          reject(completeExchangeError);
+        },
+      }),
+    );
+  } catch (error) {
+    // Skip DrawerClosedError
+    // do not redirect to the error screen
+    if (isDrawerClosedError(error)) {
+      throw error;
+    }
+
+    // Global catch for any errors during the swap process
+    // moved out as sonarcloud suggested to avoid 4 level nested functions
+    const createErrorRejector = (error: SwapError, reject: (error: SwapError) => void) => {
+      return () => reject(error);
+    };
+
+    const displayError = (error: SwapError): Promise<void> =>
+      new Promise((resolve, reject) => {
+        const rejectWithError = createErrorRejector(error, reject);
+        uiError({
+          error,
+          onSuccess: rejectWithError,
+          onCancel: rejectWithError,
+        });
+      });
+
+    handleErrors(error, {
+      onDisplayError: displayError,
+    });
+
+    throw error;
+  }
+}
+
+export async function extractSwapStartParam(
+  params: ExchangeStartSwapParams,
+  accounts: AccountLike[],
+): Promise<ExchangeStartParamsUiRequest> {
+  if (!("fromAccountId" in params && "toAccountId" in params)) {
+    throw new ExchangeError(createWrongSwapParams(params));
+  }
+
+  const realFromAccountId = getAccountIdFromWalletAccountId(params.fromAccountId);
+  if (!realFromAccountId) {
+    throw new ExchangeError(createAccounIdNotFound(params.fromAccountId));
+  }
+
+  const fromAccount = accounts.find(acc => acc.id === realFromAccountId);
+  if (!fromAccount) {
+    throw new ServerError(createAccountNotFound(params.fromAccountId));
+  }
+
+  let toAccount;
+
+  if (params.exchangeType === "SWAP" && params.toAccountId) {
+    const realToAccountId = getAccountIdFromWalletAccountId(params.toAccountId);
+    if (!realToAccountId) {
+      throw new ExchangeError(createAccounIdNotFound(params.toAccountId));
+    }
+
+    toAccount = accounts.find(a => a.id === realToAccountId);
+
+    if (!toAccount) {
+      throw new ServerError(createAccountNotFound(params.toAccountId));
+    }
+  }
+
+  const fromParentAccount = getParentAccount(fromAccount, accounts);
+  const toParentAccount = toAccount ? getParentAccount(toAccount, accounts) : undefined;
+
+  const currency = params.tokenCurrency
+    ? await getCryptoAssetsStore().findTokenById(params.tokenCurrency)
+    : null;
+  const newTokenAccount = currency ? makeEmptyTokenAccount(toAccount, currency) : null;
+
+  return {
+    exchangeType: params.exchangeType,
+    provider: params.provider,
+    exchange: {
+      fromAccount,
+      fromParentAccount,
+      fromCurrency: getCurrencyForAccount(fromAccount),
+      toAccount: newTokenAccount ? newTokenAccount : toAccount,
+      toParentAccount: toParentAccount,
+      toCurrency: getCurrencyForAccount(newTokenAccount ? newTokenAccount : toAccount),
+    },
+  };
+}
+
+interface StrategyParams {
+  recipient: string;
+  amount: BigNumber | number | string;
+  currency: CryptoOrTokenCurrency;
+  customFeeConfig?: Record<string, unknown>;
+  payinExtraId?: string;
+  extraTransactionParameters?: string;
+  sponsored?: boolean;
+}
+
+async function getStrategy(
+  {
+    recipient,
+    amount,
+    currency,
+    customFeeConfig,
+    payinExtraId,
+    extraTransactionParameters,
+    sponsored,
+  }: StrategyParams,
+  customErrorType?: any,
+  getFeature?: GetFeatureFn,
+): Promise<Transaction> {
+  const family =
+    currency.type === "TokenCurrency"
+      ? findCryptoCurrencyById(currency.parentCurrencyId)?.family
+      : currency.family;
+
+  if (!family) {
+    throw new Error(`TokenCurrency missing parentCurrency family: ${currency.id}`);
+  }
+
+  // Remove unsupported utxoStrategy for now
+  if (customFeeConfig?.utxoStrategy) {
+    delete customFeeConfig.utxoStrategy;
+  }
+
+  const strategy = transactionStrategy?.[family];
+
+  if (!strategy) {
+    throw new Error(`No transaction strategy found for family: ${family}`);
+  }
+
+  // Convert customFeeConfig values to BigNumber
+  const convertedCustomFeeConfig: { [key: string]: BigNumber } = {};
+  if (customFeeConfig) {
+    for (const [key, value] of Object.entries(customFeeConfig)) {
+      convertedCustomFeeConfig[key] = new BigNumber(value?.toString() || 0);
+    }
+  }
+
+  return strategy(
+    {
+      family,
+      amount: new BigNumber(amount),
+      recipient,
+      customFeeConfig: convertedCustomFeeConfig,
+      payinExtraId,
+      extraTransactionParameters,
+      customErrorType,
+      sponsored,
+    },
+    getFeature,
+  );
+}
+
+function isDrawerClosedError(error: unknown) {
+  if (!error || typeof error !== "object") return false;
+  const details = getErrorDetails(error);
+  return details.name === "DrawerClosedError" || details.cause?.name === "DrawerClosedError";
+}

--- a/libs/ledger-live-common/src/wallet-api/Exchange/server.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/server.ts
@@ -5,10 +5,9 @@ import {
   makeEmptyTokenAccount,
 } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { getCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
-import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import { decodeSwapPayload } from "@ledgerhq/hw-app-exchange";
-import { Account, AccountLike, getCurrencyForAccount, TokenAccount } from "@ledgerhq/types-live";
+import { AccountLike, getCurrencyForAccount, TokenAccount } from "@ledgerhq/types-live";
 import {
   createAccountNotFound,
   createCurrencyNotFound,
@@ -34,35 +33,20 @@ import {
 import { customWrapper, RPCHandler } from "@ledgerhq/wallet-api-server";
 import { BigNumber } from "bignumber.js";
 import { getAccountBridge } from "../../bridge";
-import { retrieveSwapPayload } from "../../exchange/swap/api/v5/actions";
-import { transactionStrategy } from "../../exchange/swap/transactionStrategies";
 import type { GetFeatureFn } from "../FeatureFlags/resolver";
-import { ExchangeSwap, FeatureFlags } from "../../exchange/swap/types";
+import { FeatureFlags } from "../../exchange/swap/types";
 import { Exchange } from "../../exchange/types";
-import { Transaction } from "../../coin-modules/transaction-types";
-import {
-  getAccountIdFromWalletAccountId,
-  getWalletAPITransactionSignFlowInfos,
-} from "../converters";
+import { getAccountIdFromWalletAccountId, getWalletAPITransactionSignFlowInfos } from "../converters";
 import { AppManifest } from "../types";
 import {
   createAccounIdNotFound,
   createWrongSellParams,
-  createWrongSwapParams,
   createWrongFundParams,
   ExchangeError,
 } from "./error";
+import { executeSwap, extractSwapStartParam } from "./executeSwap";
 import { TrackingAPI } from "./tracking";
-import { CompleteExchangeError, getErrorDetails, getSwapStepFromError } from "../../exchange/error";
-import { postSwapCancelled } from "../../exchange/swap";
 import { DeviceModelId } from "@ledgerhq/types-devices";
-import { setBroadcastTransaction } from "../../exchange/swap/setBroadcastTransaction";
-import type { Transaction as EvmTransaction } from "../../families/evm/types";
-import { padHexString } from "@ledgerhq/hw-app-eth";
-import { createStepError, StepError, toError } from "./parser";
-import { handleErrors } from "./handleSwapErrors";
-import get from "lodash/get";
-import { SwapError } from "./SwapError";
 import { getQuotes } from "./quotes";
 import { resolveQuotesInput } from "./quotes/resolveQuotesInput";
 import { fetchSpotPrices } from "./quotes/service/fetchSpotPrices";
@@ -71,6 +55,12 @@ import {
   type GetTransactionStatusResponse,
   type GetTransactionStatusWireArgs,
 } from "./transactionStatus";
+import type {
+  CompleteExchangeUiRequest,
+  ExchangeStartParamsUiRequest,
+  ExchangeUiHooks,
+  SwapUiRequest,
+} from "./uiRequests";
 
 export { ExchangeType };
 
@@ -90,77 +80,7 @@ type Handlers = {
   >;
 };
 
-export type CompleteExchangeUiRequest = {
-  provider: string;
-  exchange: Exchange;
-  transaction: Transaction;
-  binaryPayload: string;
-  signature: string;
-  feesStrategy: string;
-  exchangeType: number;
-  swapId?: string;
-  amountExpectedTo?: number;
-  magnitudeAwareRate?: BigNumber;
-  refundAddress?: string;
-  payoutAddress?: string;
-  sponsored?: boolean;
-  isEmbeddedSwap?: boolean;
-  swapEntryPoint?: string;
-};
-type FundStartParamsUiRequest = {
-  exchangeType: "FUND";
-  provider: string;
-  exchange: Partial<Exchange> | undefined;
-};
-
-type SellStartParamsUiRequest = {
-  exchangeType: "SELL";
-  provider: string;
-  exchange: Partial<Exchange> | undefined;
-};
-
-type SwapStartParamsUiRequest = {
-  exchangeType: "SWAP";
-  provider: string;
-  exchange: Partial<ExchangeSwap>;
-};
-
-type ExchangeStartParamsUiRequest =
-  | FundStartParamsUiRequest
-  | SellStartParamsUiRequest
-  | SwapStartParamsUiRequest;
-
-export type SwapUiRequest = CompleteExchangeUiRequest & {
-  provider?: string;
-  fromAccountId?: string;
-  toAccountId?: string;
-  tokenCurrency?: string;
-  correlationId?: string;
-};
-
-type ExchangeUiHooks = {
-  "custom.exchange.start": (params: {
-    exchangeParams: ExchangeStartParamsUiRequest;
-    onSuccess: (nonce: string, device?: ExchangeStartResult["device"]) => void;
-    onCancel: (error: Error, device?: ExchangeStartResult["device"]) => void;
-  }) => void;
-  "custom.exchange.complete": (params: {
-    exchangeParams: CompleteExchangeUiRequest;
-    onSuccess: (hash: string) => void;
-    onCancel: (error: Error) => void;
-  }) => void;
-  "custom.exchange.error": (params: {
-    error: SwapLiveError | undefined;
-    onSuccess: () => void;
-    onCancel: () => void;
-  }) => void;
-  "custom.isReady": (params: { onSuccess: () => void; onCancel: () => void }) => void;
-  "custom.exchange.swap": (params: {
-    exchangeParams: SwapUiRequest;
-    onSuccess: ({ operationHash, swapId }: { operationHash: string; swapId: string }) => void;
-    onCancel: (error: Error) => void;
-  }) => void;
-};
+export type { CompleteExchangeUiRequest, SwapUiRequest };
 
 /**
  * Build the wallet-api exchange handlers for a given wallet instance.
@@ -443,327 +363,25 @@ export const handlers = ({
       );
     }),
     "custom.exchange.swap": customWrapper<ExchangeSwapParams, SwapResult>(async params => {
-      try {
-        if (!params) {
-          tracking.startExchangeNoParams(manifest);
-          throw new ServerError(createUnknownError({ message: "params is undefined" }));
-        }
-
-        const {
-          provider,
-          fromAmount,
-          fromAmountAtomic,
-          quoteId,
-          toNewTokenId,
-          customFeeConfig,
-          swapAppVersion,
-          sponsored,
-          isEmbedded,
-          swapEntryPoint,
-          correlationId,
-        } = params;
-
-        const trackingParams = {
-          provider: params.provider,
-          exchangeType: params.exchangeType,
-          isEmbeddedSwap: isEmbedded,
-          swapEntryPoint,
-        };
-
-        tracking.startExchangeRequested(trackingParams);
-
-        const exchangeStartParams: ExchangeStartParamsUiRequest = (await extractSwapStartParam(
-          params,
-          accounts,
-        )) as SwapStartParamsUiRequest;
-
-        const {
-          fromCurrency,
-          fromAccount,
-          fromParentAccount,
-          toCurrency,
-          toAccount,
-          toParentAccount,
-        } = exchangeStartParams.exchange;
-
-        if (!fromAccount || !fromCurrency) {
-          throw new ServerError(createAccountNotFound(params.fromAccountId));
-        }
-
-        const fromAccountAddress = fromParentAccount
-          ? fromParentAccount.freshAddress
-          : (fromAccount as Account).freshAddress;
-
-        const toAccountAddress = toParentAccount
-          ? toParentAccount.freshAddress
-          : (toAccount as Account).freshAddress;
-
-        // Step 1: Open the drawer and open exchange app
-        const startExchange = async () => {
-          return new Promise<{ transactionId: string; device?: ExchangeStartResult["device"] }>(
-            (resolve, reject) => {
-              uiExchangeStart({
-                exchangeParams: exchangeStartParams,
-                onSuccess: (nonce, device) => {
-                  tracking.startExchangeSuccess(trackingParams);
-                  resolve({ transactionId: nonce, device });
-                },
-                onCancel: error => {
-                  tracking.startExchangeFail(trackingParams);
-                  reject(error);
-                },
-              });
-            },
-          );
-        };
-
-        let transactionId: string;
-        let deviceInfo: ExchangeStartResult["device"];
-
-        try {
-          const result = await startExchange();
-          transactionId = result.transactionId;
-          deviceInfo = result.device;
-        } catch (error) {
-          const rawError = get(error, "response.data.error", error);
-          const wrappedError = createStepError({
-            error: toError(rawError),
-            step: StepError.NONCE,
-            correlationId: params?.correlationId,
-          });
-          throw wrappedError;
-        }
-
-        tracking.swapPayloadRequested({
-          provider,
-          transactionId,
-          fromAccountAddress,
-          toAccountAddress,
-          fromCurrencyId: fromCurrency!.id,
-          toCurrencyId: toCurrency?.id,
-          fromAmount,
-          quoteId,
-        });
-
-        const {
-          binaryPayload,
-          signature,
-          payinAddress,
-          swapId,
-          payinExtraId,
-          extraTransactionParameters,
-        } = await retrieveSwapPayload({
-          provider,
-          deviceTransactionId: transactionId,
-          fromAccountAddress,
-          toAccountAddress,
-          fromAccountCurrency: fromCurrency!.id,
-          toAccountCurrency: toCurrency!.id,
-          amount: fromAmount,
-          amountInAtomicUnit: fromAmountAtomic,
-          quoteId,
-          toNewTokenId,
-          flags,
-          correlationId,
-        }).catch((error: Error) => {
-          const wrappedError = createStepError({
-            error: get(error, "response.data.error", error),
-            step: StepError.PAYLOAD,
-            correlationId: params?.correlationId,
-          });
-          throw wrappedError;
-        });
-
-        tracking.swapResponseRetrieved({
-          binaryPayload,
-          signature,
-          payinAddress,
-          swapId,
-          payinExtraId,
-          extraTransactionParameters,
-        });
-
-        tracking.completeExchangeRequested(trackingParams);
-
-        const strategyData = {
-          recipient: payinAddress,
-          amount: fromAmountAtomic,
-          currency: fromCurrency as CryptoOrTokenCurrency,
-          customFeeConfig: customFeeConfig ?? {},
-          payinExtraId,
-          extraTransactionParameters,
-          sponsored,
-        };
-
-        const transaction: Transaction = await getStrategy(strategyData, "swap", getFeature);
-
-        const mainFromAccount = getMainAccount(fromAccount, fromParentAccount);
-
-        if (transaction.family !== mainFromAccount.currency.family) {
-          return Promise.reject(
-            new Error(
-              `Account and transaction must be from the same family. Account family: ${mainFromAccount.currency.family}, Transaction family: ${transaction.family}`,
-            ),
-          );
-        }
-
-        const accountBridge = await getAccountBridge(fromAccount, fromParentAccount);
-
-        /**
-         * 'subAccountId' is used for ETH and it's ERC-20 tokens.
-         * This field is ignored for BTC
-         */
-        const subAccountId =
-          fromParentAccount && fromParentAccount.id !== fromAccount.id ? fromAccount.id : undefined;
-
-        const bridgeTx = accountBridge.createTransaction(fromAccount);
-        /**
-         * We append the `recipient` to the tx created from `createTransaction`
-         * to avoid having userGasLimit reset to null for ETH txs
-         * cf. libs/ledger-live-common/src/families/ethereum/updateTransaction.ts
-         */
-        const tx = accountBridge.updateTransaction(
-          {
-            ...bridgeTx,
-            recipient: transaction.recipient,
-          },
-          {
-            ...transaction,
-            feesStrategy: params.feeStrategy.toLowerCase(),
-            subAccountId,
-          },
-        );
-
-        // Get amountExpectedTo and magnitudeAwareRate from binary payload
-        const decodePayload = await decodeSwapPayload(binaryPayload);
-        const amountExpectedTo = new BigNumber(decodePayload.amountToWallet.toString());
-        const magnitudeAwareRate = tx.amount && amountExpectedTo.dividedBy(tx.amount);
-        const refundAddress = decodePayload.refundAddress;
-        const payoutAddress = decodePayload.payoutAddress;
-
-        // tx.amount should be BigNumber
-        tx.amount = new BigNumber(tx.amount);
-
-        return new Promise((resolve, reject) =>
-          uiSwap({
-            exchangeParams: {
-              exchangeType: ExchangeType.SWAP,
-              provider: params.provider,
-              transaction: tx,
-              signature: signature,
-              binaryPayload: binaryPayload,
-              exchange: {
-                fromAccount,
-                fromParentAccount,
-                toAccount,
-                toParentAccount,
-                fromCurrency: fromCurrency!,
-                toCurrency: toCurrency!,
-              },
-              feesStrategy: params.feeStrategy,
-              swapId: swapId,
-              amountExpectedTo: amountExpectedTo.toNumber(),
-              magnitudeAwareRate,
-              refundAddress,
-              payoutAddress,
-              sponsored,
-              isEmbeddedSwap: isEmbedded,
-              swapEntryPoint,
-              ...(correlationId && { correlationId }),
-            },
-            onSuccess: ({ operationHash, swapId }: { operationHash: string; swapId: string }) => {
-              tracking.completeExchangeSuccess({
-                ...trackingParams,
-                currency: transaction.family,
-              });
-
-              setBroadcastTransaction({
-                provider,
-                result: { operation: operationHash, swapId },
-                sourceCurrencyId: fromCurrency.id,
-                targetCurrencyId: toCurrency?.id,
-                hardwareWalletType: deviceInfo?.modelId as DeviceModelId,
-                swapAppVersion,
-                fromAccountAddress,
-                toAccountAddress,
-                fromAmount,
-                flags,
-              });
-
-              resolve({ operationHash, swapId });
-            },
-            onCancel: error => {
-              const {
-                name: rawErrorName,
-                message: rawErrorMessage,
-                cause: rawErrorCause,
-              } = getErrorDetails(error);
-              const causeSuffix = rawErrorCause ? `, ${JSON.stringify(rawErrorCause)}` : "";
-              const errorMessageWithCause = rawErrorMessage + causeSuffix;
-
-              const completeExchangeError =
-                // step provided in libs/ledger-live-common/src/exchange/platform/transfer/completeExchange.ts
-                error instanceof CompleteExchangeError
-                  ? error
-                  : new CompleteExchangeError("INIT", rawErrorName, errorMessageWithCause);
-
-              postSwapCancelled({
-                provider: provider,
-                swapId: swapId,
-                swapStep: getSwapStepFromError(completeExchangeError),
-                statusCode: completeExchangeError.title || completeExchangeError.name,
-                errorMessage: completeExchangeError.message || errorMessageWithCause,
-                sourceCurrencyId: fromCurrency.id,
-                targetCurrencyId: toCurrency?.id,
-                hardwareWalletType: deviceInfo?.modelId as DeviceModelId,
-                swapType: quoteId ? "fixed" : "float",
-                swapAppVersion,
-                fromAccountAddress,
-                toAccountAddress,
-                refundAddress,
-                payoutAddress,
-                fromAmount,
-                seedIdFrom: mainFromAccount.seedIdentifier,
-                seedIdTo: toParentAccount?.seedIdentifier || (toAccount as Account)?.seedIdentifier,
-                data: (transaction as EvmTransaction).data
-                  ? `0x${padHexString((transaction as EvmTransaction).data?.toString("hex") || "")}`
-                  : "0x",
-                flags,
-              });
-
-              reject(completeExchangeError);
-            },
-          }),
-        );
-      } catch (error) {
-        // Skip DrawerClosedError
-        // do not redirect to the error screen
-        if (isDrawerClosedError(error)) {
-          throw error;
-        }
-
-        // Global catch for any errors during the swap process
-        // moved out as sonarcloud suggested to avoid 4 level nested functions
-        const createErrorRejector = (error: SwapError, reject: (error: SwapError) => void) => {
-          return () => reject(error);
-        };
-
-        const displayError = (error: SwapError): Promise<void> =>
-          new Promise((resolve, reject) => {
-            const rejectWithError = createErrorRejector(error, reject);
-            uiError({
-              error,
-              onSuccess: rejectWithError,
-              onCancel: rejectWithError,
-            });
-          });
-
-        handleErrors(error, {
-          onDisplayError: displayError,
-        });
-
-        throw error;
+      if (!params) {
+        tracking.startExchangeNoParams(manifest);
+        throw new ServerError(createUnknownError({ message: "params is undefined" }));
       }
+
+      return executeSwap(
+        {
+          accounts,
+          tracking,
+          flags,
+          getFeature,
+          uiHooks: {
+            "custom.exchange.start": uiExchangeStart,
+            "custom.exchange.swap": uiSwap,
+            "custom.exchange.error": uiError,
+          },
+        },
+        params,
+      );
     }),
 
     "custom.isReady": customWrapper<void, void>(async () => {
@@ -818,61 +436,6 @@ export const handlers = ({
       return getTransactionStatus(params, { accounts });
     }),
   }) as const satisfies Handlers;
-
-async function extractSwapStartParam(
-  params: ExchangeStartSwapParams,
-  accounts: AccountLike[],
-): Promise<ExchangeStartParamsUiRequest> {
-  if (!("fromAccountId" in params && "toAccountId" in params)) {
-    throw new ExchangeError(createWrongSwapParams(params));
-  }
-
-  const realFromAccountId = getAccountIdFromWalletAccountId(params.fromAccountId);
-  if (!realFromAccountId) {
-    throw new ExchangeError(createAccounIdNotFound(params.fromAccountId));
-  }
-
-  const fromAccount = accounts.find(acc => acc.id === realFromAccountId);
-  if (!fromAccount) {
-    throw new ServerError(createAccountNotFound(params.fromAccountId));
-  }
-
-  let toAccount;
-
-  if (params.exchangeType === "SWAP" && params.toAccountId) {
-    const realToAccountId = getAccountIdFromWalletAccountId(params.toAccountId);
-    if (!realToAccountId) {
-      throw new ExchangeError(createAccounIdNotFound(params.toAccountId));
-    }
-
-    toAccount = accounts.find(a => a.id === realToAccountId);
-
-    if (!toAccount) {
-      throw new ServerError(createAccountNotFound(params.toAccountId));
-    }
-  }
-
-  const fromParentAccount = getParentAccount(fromAccount, accounts);
-  const toParentAccount = toAccount ? getParentAccount(toAccount, accounts) : undefined;
-
-  const currency = params.tokenCurrency
-    ? await getCryptoAssetsStore().findTokenById(params.tokenCurrency)
-    : null;
-  const newTokenAccount = currency ? makeEmptyTokenAccount(toAccount, currency) : null;
-
-  return {
-    exchangeType: params.exchangeType,
-    provider: params.provider,
-    exchange: {
-      fromAccount,
-      fromParentAccount,
-      fromCurrency: getCurrencyForAccount(fromAccount),
-      toAccount: newTokenAccount ? newTokenAccount : toAccount,
-      toParentAccount: toParentAccount,
-      toCurrency: getCurrencyForAccount(newTokenAccount ? newTokenAccount : toAccount),
-    },
-  };
-}
 
 function extractSellStartParam(
   params: ExchangeStartSellParams,
@@ -974,76 +537,4 @@ async function getToCurrency(
   }
 
   return newTokenAccount?.token ?? getCurrencyForAccount(toAccount);
-}
-
-interface StrategyParams {
-  recipient: string;
-  amount: BigNumber | number | string;
-  currency: CryptoOrTokenCurrency;
-  customFeeConfig?: Record<string, unknown>;
-  payinExtraId?: string;
-  extraTransactionParameters?: string;
-  sponsored?: boolean;
-}
-
-async function getStrategy(
-  {
-    recipient,
-    amount,
-    currency,
-    customFeeConfig,
-    payinExtraId,
-    extraTransactionParameters,
-    sponsored,
-  }: StrategyParams,
-  customErrorType?: any,
-  getFeature?: GetFeatureFn,
-): Promise<Transaction> {
-  const family =
-    currency.type === "TokenCurrency"
-      ? findCryptoCurrencyById(currency.parentCurrencyId)?.family
-      : currency.family;
-
-  if (!family) {
-    throw new Error(`TokenCurrency missing parentCurrency family: ${currency.id}`);
-  }
-
-  // Remove unsupported utxoStrategy for now
-  if (customFeeConfig?.utxoStrategy) {
-    delete customFeeConfig.utxoStrategy;
-  }
-
-  const strategy = transactionStrategy?.[family];
-
-  if (!strategy) {
-    throw new Error(`No transaction strategy found for family: ${family}`);
-  }
-
-  // Convert customFeeConfig values to BigNumber
-  const convertedCustomFeeConfig: { [key: string]: BigNumber } = {};
-  if (customFeeConfig) {
-    for (const [key, value] of Object.entries(customFeeConfig)) {
-      convertedCustomFeeConfig[key] = new BigNumber(value?.toString() || 0);
-    }
-  }
-
-  return strategy(
-    {
-      family,
-      amount: new BigNumber(amount),
-      recipient,
-      customFeeConfig: convertedCustomFeeConfig,
-      payinExtraId,
-      extraTransactionParameters,
-      customErrorType,
-      sponsored,
-    },
-    getFeature,
-  );
-}
-
-function isDrawerClosedError(error: unknown) {
-  if (!error || typeof error !== "object") return false;
-  const details = getErrorDetails(error);
-  return details.name === "DrawerClosedError" || details.cause?.name === "DrawerClosedError";
 }

--- a/libs/ledger-live-common/src/wallet-api/Exchange/uiRequests.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/uiRequests.ts
@@ -1,0 +1,78 @@
+import { ExchangeStartResult, SwapLiveError } from "@ledgerhq/wallet-api-exchange-module";
+import { BigNumber } from "bignumber.js";
+import { ExchangeSwap } from "../../exchange/swap/types";
+import { Exchange } from "../../exchange/types";
+import { Transaction } from "../../coin-modules/transaction-types";
+
+export type CompleteExchangeUiRequest = {
+  provider: string;
+  exchange: Exchange;
+  transaction: Transaction;
+  binaryPayload: string;
+  signature: string;
+  feesStrategy: string;
+  exchangeType: number;
+  swapId?: string;
+  amountExpectedTo?: number;
+  magnitudeAwareRate?: BigNumber;
+  refundAddress?: string;
+  payoutAddress?: string;
+  sponsored?: boolean;
+  isEmbeddedSwap?: boolean;
+  swapEntryPoint?: string;
+};
+
+type FundStartParamsUiRequest = {
+  exchangeType: "FUND";
+  provider: string;
+  exchange: Partial<Exchange> | undefined;
+};
+
+type SellStartParamsUiRequest = {
+  exchangeType: "SELL";
+  provider: string;
+  exchange: Partial<Exchange> | undefined;
+};
+
+export type SwapStartParamsUiRequest = {
+  exchangeType: "SWAP";
+  provider: string;
+  exchange: Partial<ExchangeSwap>;
+};
+
+export type ExchangeStartParamsUiRequest =
+  | FundStartParamsUiRequest
+  | SellStartParamsUiRequest
+  | SwapStartParamsUiRequest;
+
+export type SwapUiRequest = CompleteExchangeUiRequest & {
+  provider?: string;
+  fromAccountId?: string;
+  toAccountId?: string;
+  tokenCurrency?: string;
+  correlationId?: string;
+};
+
+export type ExchangeUiHooks = {
+  "custom.exchange.start": (params: {
+    exchangeParams: ExchangeStartParamsUiRequest;
+    onSuccess: (nonce: string, device?: ExchangeStartResult["device"]) => void;
+    onCancel: (error: Error, device?: ExchangeStartResult["device"]) => void;
+  }) => void;
+  "custom.exchange.complete": (params: {
+    exchangeParams: CompleteExchangeUiRequest;
+    onSuccess: (hash: string) => void;
+    onCancel: (error: Error) => void;
+  }) => void;
+  "custom.exchange.error": (params: {
+    error: SwapLiveError | undefined;
+    onSuccess: () => void;
+    onCancel: () => void;
+  }) => void;
+  "custom.isReady": (params: { onSuccess: () => void; onCancel: () => void }) => void;
+  "custom.exchange.swap": (params: {
+    exchangeParams: SwapUiRequest;
+    onSuccess: ({ operationHash, swapId }: { operationHash: string; swapId: string }) => void;
+    onCancel: (error: Error) => void;
+  }) => void;
+};


### PR DESCRIPTION
### 📝 Description

Adds the signing step of the Perps deposit flow - the screen reached from the
review, where the user confirms the deposit on device.

The swap orchestration that already backs the `custom.exchange.swap` handler is
extracted out of `server.ts` into a shared `executeSwap`, so the perps screens
drive the exact same device flow (partner key, payload, payout/refund address
checks, sign, broadcast) instead of a second implementation of it. The perps UI
stays perps: only the orchestration is shared.

The deposit executes against the quote the review screen priced against, so the
amount signed on device is the amount the user was shown.

### 🔗 Context

https://ledgerhq.atlassian.net/browse/LIVE-35328

Stacked on #20441 (LIVE-35327, the review step).

### ✅ Checklist

- Unit tests cover the device step sequence and the signed payload on both
  desktop and mobile.