### PR TITLE
[LWDM] fix(coin-sui): reject an unstake above the staking position's principal

### DIFF
--- a/.changeset/sui-undelegate-exceeds-stake.md
+++ b/.changeset/sui-undelegate-exceeds-stake.md
@@ -1,0 +1,12 @@
+---
+"@ledgerhq/coin-sui": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Reject a SUI unstake above the staking position's principal, and make the remainder error actionable
+
+A partial unstake calls `staking_pool::split`, which asserts the withdrawn amount is at most the
+principal. Nothing validated that locally, so an amount far above the staked balance passed
+validation and only aborted on chain. It now fails with a dedicated error. The remainder error also
+names the way out — withdraw in full — because a position under 2 SUI cannot be split at all.

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7913,10 +7913,13 @@
       "title": "Minimum amount is 1 SUI"
     },
     "OneSuiMinForUnstakeToBeLeft": {
-      "title": "At least 1 SUI should be left in stake"
+      "title": "Unstake the full amount, or leave at least 1 SUI staked"
     },
     "SuiStakeNotFound": {
       "title": "Stake details unavailable. Please resynchronise your account and try again"
+    },
+    "SuiUnstakeExceedsStake": {
+      "title": "Amount exceeds the selected stake"
     },
     "SomeSuiForUnstake": {
       "title": "Please ensure you reserve at least 0.1 SUI in your wallet to cover future network fees and undelegate your stake"

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -752,10 +752,13 @@
       "title": "Minimum amount is 1 SUI"
     },
     "OneSuiMinForUnstakeToBeLeft": {
-      "title": "At least 1 SUI should be left in stake"
+      "title": "Unstake the full amount, or leave at least 1 SUI staked"
     },
     "SuiStakeNotFound": {
       "title": "Stake details unavailable. Please resynchronise your account and try again"
+    },
+    "SuiUnstakeExceedsStake": {
+      "title": "Amount exceeds the selected stake"
     },
     "PasswordIncorrect": {
       "title": "Incorrect password",

--- a/libs/coin-modules/coin-sui/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/getTransactionStatus.test.ts
@@ -11,12 +11,13 @@ import {
 import BigNumber from "bignumber.js";
 import { createFixtureAccount, createFixtureTransaction } from "../types/bridge.fixture";
 import getTransactionStatus from "./getTransactionStatus";
-import { ONE_SUI } from "../constants";
+import { mist, ONE_SUI } from "../constants";
 import {
   OneSuiMinForStake,
   OneSuiMinForUnstake,
   OneSuiMinForUnstakeToBeLeft,
   SuiStakeNotFound,
+  SuiUnstakeExceedsStake,
 } from "../errors";
 
 const account = createFixtureAccount();
@@ -221,8 +222,8 @@ describe("getTransactionStatus", () => {
       expect(result.errors.amount).toBeUndefined();
     });
 
-    // The QA case: 0.25 SUI out of a 1 SUI position. Both `split` asserts fail, and the remainder
-    // one is the more specific message.
+    // 0.25 SUI out of a 1 SUI position: both `split` asserts fail, and the remainder one is the
+    // more specific message.
     it("rejects an unstake that would leave less than 1 SUI in the position", async () => {
       const transaction = createFixtureTransaction({
         mode: "undelegate",
@@ -243,6 +244,59 @@ describe("getTransactionStatus", () => {
       const result = await getTransactionStatus(accountWithStake(String(3 * ONE_SUI)), transaction);
 
       expect(result.errors.amount).toEqual(new OneSuiMinForUnstake());
+    });
+
+    // `split` aborts `EInsufficientSuiTokenBalance` (3) on an overdraw, and the remainder rule
+    // below says nothing about one.
+    it("rejects an unstake larger than the position's principal", async () => {
+      const transaction = createFixtureTransaction({
+        mode: "undelegate",
+        stakedSuiId: STAKED_SUI_ID,
+        amount: BigNumber(mist(100000)),
+      });
+      const result = await getTransactionStatus(accountWithStake(mist(1.50657)), transaction);
+
+      expect(result.errors.amount).toEqual(new SuiUnstakeExceedsStake());
+    });
+
+    // Both halves must reach 1 SUI, so a position under 2 SUI cannot be split at all: an amount
+    // above the minimum is still rejected, and a full withdrawal is the only legal move.
+    it("rejects a partial unstake above 1 SUI that leaves an unstakeable remainder", async () => {
+      const transaction = createFixtureTransaction({
+        mode: "undelegate",
+        stakedSuiId: STAKED_SUI_ID,
+        amount: BigNumber(mist(1.12993137)),
+      });
+      const result = await getTransactionStatus(accountWithStake(mist(1.50657)), transaction);
+
+      expect(result.errors.amount).toEqual(new OneSuiMinForUnstakeToBeLeft());
+    });
+
+    // Mobile sets `useAllAmount` only on Continue (`02-SelectAmount.tsx`), so the exact max typed
+    // into the field reaches this status with the flag still false and must not trip the
+    // remainder rule.
+    it("accepts the exact principal before the flow marks it a full withdrawal", async () => {
+      const transaction = createFixtureTransaction({
+        mode: "undelegate",
+        stakedSuiId: STAKED_SUI_ID,
+        amount: BigNumber(mist(1.50657)),
+        useAllAmount: false,
+      });
+      const result = await getTransactionStatus(accountWithStake(mist(1.50657)), transaction);
+
+      expect(result.errors.amount).toBeUndefined();
+    });
+
+    it("accepts the same position withdrawn in full", async () => {
+      const transaction = createFixtureTransaction({
+        mode: "undelegate",
+        stakedSuiId: STAKED_SUI_ID,
+        amount: BigNumber(mist(1.50657)),
+        useAllAmount: true,
+      });
+      const result = await getTransactionStatus(accountWithStake(mist(1.50657)), transaction);
+
+      expect(result.errors.amount).toBeUndefined();
     });
 
     it("accepts a partial unstake leaving at least 1 SUI on both sides", async () => {

--- a/libs/coin-modules/coin-sui/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/getTransactionStatus.ts
@@ -19,6 +19,7 @@ import {
   OneSuiMinForUnstakeToBeLeft,
   SomeSuiForUnstake,
   SuiStakeNotFound,
+  SuiUnstakeExceedsStake,
 } from "../errors";
 import type { SuiAccount, Transaction, TransactionStatus } from "../types";
 import { ensureAddressFormat } from "../utils";
@@ -77,24 +78,35 @@ export const getTransactionStatus: AccountBridge<
     const stakes = account.suiResources?.stakes?.flatMap(({ stakes }) => stakes) ?? [];
     const stake = stakes.find(s => s.stakedSuiId === transaction.stakedSuiId);
 
-    // `staking_pool::split` asserts BOTH the withdrawn amount and the remainder reach 1 SUI, so a
-    // partial unstake below it aborts on chain (`EStakedSuiBelowThreshold`); a full withdrawal takes
-    // the no-split path and is exempt. The amount side needs no account data, hence it runs first.
-    if (!transaction.useAllAmount && amount.lt(ONE_SUI)) {
-      errors.amount = new OneSuiMinForUnstake();
-    }
-
-    if (stake) {
-      const stakeLeft = BigNumber(stake.principal).minus(amount);
-      if (!transaction.useAllAmount && stakeLeft.lt(ONE_SUI) && stakeLeft.gt(0)) {
-        errors.amount = new OneSuiMinForUnstakeToBeLeft();
+    // `staking_pool::split` asserts the withdrawn amount is at most the principal
+    // (`EInsufficientSuiTokenBalance`) and that BOTH the withdrawn amount and the remainder reach
+    // 1 SUI (`EStakedSuiBelowThreshold`), so a partial unstake that breaks either rule aborts on
+    // chain; a full withdrawal takes the no-split path and is exempt. The amount side needs no
+    // account data, hence it runs first.
+    if (!transaction.useAllAmount) {
+      if (amount.lt(ONE_SUI)) {
+        errors.amount = new OneSuiMinForUnstake();
       }
-    } else if (!transaction.useAllAmount && !errors.amount) {
-      // Fail closed on a split that cannot be verified: without the principal the remainder is
-      // unknowable, so a legal-looking amount may still abort on chain. A stale, degraded, or cleared
-      // sync is enough to lose the position. This is the last local guard — no transport rejects the
-      // build now, and `signOperation` reads `transaction.fees`, never this status.
-      errors.amount = new SuiStakeNotFound();
+
+      if (stake) {
+        const principal = BigNumber(stake.principal);
+        const stakeLeft = principal.minus(amount);
+        if (amount.gt(principal)) {
+          // Overwrites the sub-1-SUI error above on purpose: both apply to an overdraw of a
+          // position under 1 SUI, and naming the overdraw is the one that tells the user what to
+          // change.
+          errors.amount = new SuiUnstakeExceedsStake();
+        } else if (stakeLeft.lt(ONE_SUI) && stakeLeft.gt(0)) {
+          errors.amount = new OneSuiMinForUnstakeToBeLeft();
+        }
+      } else if (!errors.amount) {
+        // Fail closed on a split that cannot be verified: without the principal neither the
+        // remainder nor the overdraw is knowable, so a legal-looking amount may still abort on
+        // chain. A stale, degraded, or cleared sync is enough to lose the position. This is the
+        // last local guard — no transport rejects the build now, and `signOperation` reads
+        // `transaction.fees`, never this status.
+        errors.amount = new SuiStakeNotFound();
+      }
     }
   } else {
     if (!transaction.recipient) {

--- a/libs/coin-modules/coin-sui/src/bridge/stakeGuards.test.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/stakeGuards.test.ts
@@ -1,6 +1,11 @@
 import BigNumber from "bignumber.js";
 import { FIGMENT_SUI_VALIDATOR_ADDRESS, ONE_SUI } from "../constants";
-import { OneSuiMinForStake, OneSuiMinForUnstakeToBeLeft, SuiStakeNotFound } from "../errors";
+import {
+  OneSuiMinForStake,
+  OneSuiMinForUnstakeToBeLeft,
+  SuiStakeNotFound,
+  SuiUnstakeExceedsStake,
+} from "../errors";
 import { createFixtureAccount, createFixtureTransaction } from "../types/bridge.fixture";
 import getTransactionStatus from "./getTransactionStatus";
 import prepareTransaction from "./prepareTransaction";
@@ -48,7 +53,7 @@ describe("stake guards survive a tolerated simulation failure", () => {
     expect(status.errors.amount).toEqual(new OneSuiMinForStake());
   });
 
-  it("reports the remainder error for the unstake case QA hit", async () => {
+  it("reports the remainder error for a partial unstake leaving under 1 SUI", async () => {
     const account = accountWithStake(String(ONE_SUI));
     const transaction = createFixtureTransaction({
       mode: "undelegate",
@@ -60,6 +65,20 @@ describe("stake guards survive a tolerated simulation failure", () => {
     const status = await getTransactionStatus(account, prepared);
 
     expect(status.errors.amount).toEqual(new OneSuiMinForUnstakeToBeLeft());
+  });
+
+  it("reports the overdraw error for an unstake above the position's principal", async () => {
+    const account = accountWithStake(String(2 * ONE_SUI));
+    const transaction = createFixtureTransaction({
+      mode: "undelegate",
+      stakedSuiId: STAKED_SUI_ID,
+      amount: BigNumber(100000 * ONE_SUI),
+    });
+
+    const prepared = await prepareTransaction(account, transaction);
+    const status = await getTransactionStatus(account, prepared);
+
+    expect(status.errors.amount).toEqual(new SuiUnstakeExceedsStake());
   });
 
   it("blocks an unverifiable split when the position is absent from the synced stakes", async () => {

--- a/libs/coin-modules/coin-sui/src/errors.ts
+++ b/libs/coin-modules/coin-sui/src/errors.ts
@@ -53,3 +53,15 @@ export class SuiStakeNotFound extends Error {
     if (fields) Object.assign(this, fields);
   }
 }
+
+/*
+ * A partial unstake asks for more than the staking position holds. `staking_pool::split` asserts
+ * `split_amount <= principal` (`EInsufficientSuiTokenBalance`), so the chain aborts the withdrawal.
+ */
+export class SuiUnstakeExceedsStake extends Error {
+  override name = "SuiUnstakeExceedsStake";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SuiUnstakeExceedsStake");
+    if (fields) Object.assign(this, fields);
+  }
+}


### PR DESCRIPTION
### 📝 Description

A partial SUI unstake calls `staking_pool::split`, which asserts the withdrawn amount is at most the position's principal, and that both the withdrawn amount and the remainder reach 1 SUI. Only the two 1-SUI rules were validated locally.

**Previous behaviour:** an amount above the staked principal left a negative remainder, which failed the `stakeLeft.gt(0)` condition, so no error fired. The transaction passed validation and would have aborted on chain with `EInsufficientSuiTokenBalance`.

**Fix:** `getTransactionStatus` now rejects a partial unstake above the principal with a dedicated `SuiUnstakeExceedsStake` error. The guard lives in the bridge, so desktop and mobile both pick it up — each already disables Continue on a status error.

`OneSuiMinForUnstakeToBeLeft` is also reworded to "Unstake the full amount, or leave at least 1 SUI staked". The rule was correct but read as a minimum-amount rule; a position under 2 SUI cannot be split at all, so full withdrawal is the only legal move and the copy now says so.

**Regression cover:** unit tests for the overdraw, for a partial amount above 1 SUI that leaves an illegal remainder, and for the exact principal with `useAllAmount` both set and unset — the latter pins the mobile flow, which only sets the flag on Continue.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36166](https://ledgerhq.atlassian.net/browse/LIVE-36166)
- **ADR** (if any): n/a


[LIVE-36166]: https://ledgerhq.atlassian.net/browse/LIVE-36166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ