### PR TITLE
[LWDM] feat(coin-tron): add Tronify energy-rent fee option to estimateFees

### DIFF
--- a/.changeset/LIVE-34999-coin-tron-tronify-estimatefee.md
+++ b/.changeset/LIVE-34999-coin-tron-tronify-estimatefee.md
@@ -4,4 +4,4 @@
 
 Add Tronify energy-rent fee option to `estimateFees`.
 
-When `feeOptionId: "tronify"` is passed via `EstimateFeesOptions`, `estimateFees` calls the Tronify quote API instead of computing the standard on-chain burn. The returned `FeeEstimation` carries `value` (Tronify rental cost in SUN), `originalValue` (standard burn cost for comparison), and `savings` (the difference). Errors from the Tronify API propagate without fallback, per ADR-050 Option 3.
+When `feeOptionId: "tronify"` is passed via `EstimateFeesOptions`, `estimateFees` prices the Tronify energy-rental option alongside the standard on-chain burn. The returned `FeeEstimation` carries `value` (Tronify rental cost in SUN), `originalValue` (standard burn cost for comparison), and `savings` (non-negative difference, `0n` when Tronify is not cheaper). Errors from the Tronify API propagate without fallback, per ADR-050 Option 3.

--- a/.changeset/LIVE-34999-coin-tron-tronify-estimatefee.md
+++ b/.changeset/LIVE-34999-coin-tron-tronify-estimatefee.md
@@ -4,4 +4,4 @@
 
 Add Tronify energy-rent fee option to `estimateFees`.
 
-When `feeOptionId: "tronify"` is passed via `EstimateFeesOptions`, `estimateFees` prices the Tronify energy-rental option alongside the standard on-chain burn. The returned `FeeEstimation` carries `value` (Tronify rental cost in SUN), `originalValue` (standard burn cost for comparison), and `savings` (non-negative difference, `0n` when Tronify is not cheaper). Errors from the Tronify API propagate without fallback, per ADR-050 Option 3.
+When `feeOptionId: "tronify"` is passed via `EstimateFeesOptions`, the CoinModule API's `estimateFees` dispatches to a dedicated `estimateTronifyFees` path that still computes the standard on-chain burn for comparison and prices the Tronify energy-rental option against it. The returned `FeeEstimation` carries `value` (Tronify rental cost in SUN), `originalValue` (standard burn cost for comparison), and `savings` (non-negative difference, `0n` when Tronify is not cheaper). Errors from the Tronify API propagate without fallback, per ADR-050 Option 3.

--- a/.changeset/LIVE-34999-coin-tron-tronify-estimatefee.md
+++ b/.changeset/LIVE-34999-coin-tron-tronify-estimatefee.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-tron": minor
+---
+
+Add Tronify energy-rent fee option to `estimateFees`.
+
+When `feeOptionId: "tronify"` is passed via `EstimateFeesOptions`, `estimateFees` calls the Tronify quote API instead of computing the standard on-chain burn. The returned `FeeEstimation` carries `value` (Tronify rental cost in SUN), `originalValue` (standard burn cost for comparison), and `savings` (the difference). Errors from the Tronify API propagate without fallback, per ADR-050 Option 3.

--- a/libs/coin-modules/coin-tron/src/api/index.test.ts
+++ b/libs/coin-modules/coin-tron/src/api/index.test.ts
@@ -139,6 +139,13 @@ describe("createApi", () => {
   });
 
   describe("estimateFees routing", () => {
+    const mockFeeEstimation = { value: 1_000_000n };
+
+    beforeEach(() => {
+      mockEstimateFees.mockResolvedValue(mockFeeEstimation);
+      mockEstimateTronifyFees.mockResolvedValue(mockFeeEstimation);
+    });
+
     const trc20Intent: TransactionIntent<TronMemo, TronTxData> = {
       intentType: "transaction",
       type: "send",

--- a/libs/coin-modules/coin-tron/src/api/index.test.ts
+++ b/libs/coin-modules/coin-tron/src/api/index.test.ts
@@ -12,22 +12,28 @@ import {
   combine,
   craftTransaction,
   estimateFees,
+  estimateTronifyFees,
   getAccountInfo,
   getBalance,
   lastBlock,
   listOperations,
 } from "../logic";
+import { TRONIFY_FEE_OPTION_ID } from ".";
 
 jest.mock("../logic", () => ({
   broadcast: jest.fn(),
   combine: jest.fn(),
   craftTransaction: jest.fn(),
   estimateFees: jest.fn(),
+  estimateTronifyFees: jest.fn(),
   getAccountInfo: jest.fn(),
   getBalance: jest.fn(),
   listOperations: jest.fn().mockResolvedValue({ items: [], next: undefined }),
   lastBlock: jest.fn(),
 }));
+
+const mockEstimateFees = jest.mocked(estimateFees);
+const mockEstimateTronifyFees = jest.mocked(estimateTronifyFees);
 
 jest.mock("../network", () => ({
   defaultFetchParams: { minTimestamp: 0 },
@@ -96,7 +102,7 @@ describe("createApi", () => {
     // Test that each of the methods was called with correct arguments, threading the config
     expect(broadcast).toHaveBeenCalledWith(mockTronConfig, "transaction");
     expect(combine).toHaveBeenCalledWith("tx", ["signature"]);
-    expect(estimateFees).toHaveBeenCalledWith(mockTronConfig, intent);
+    expect(mockEstimateFees).toHaveBeenCalledWith(mockTronConfig, intent);
     expect(craftTransaction).toHaveBeenCalledWith(mockTronConfig, intent, undefined);
     expect(getBalance).toHaveBeenCalledWith(mockTronConfig, "address");
     expect(getAccountInfo).toHaveBeenCalledWith(mockTronConfig, "address");
@@ -130,6 +136,44 @@ describe("createApi", () => {
       "address",
       expect.objectContaining({ limit: 200, minTimestamp: 0 }),
     );
+  });
+
+  describe("estimateFees routing", () => {
+    const trc20Intent: TransactionIntent<TronMemo, TronTxData> = {
+      intentType: "transaction",
+      type: "send",
+      sender: "sender",
+      recipient: "recipient",
+      amount: BigInt(1000),
+      asset: { type: "trc20", assetReference: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t" },
+      data: { type: "tron" },
+    };
+
+    it("should call estimateFees when no feeOption is provided", async () => {
+      const api = createApi();
+      await api.estimateFees(context, trc20Intent);
+
+      expect(mockEstimateFees).toHaveBeenCalledWith(mockTronConfig, trc20Intent);
+      expect(mockEstimateTronifyFees).not.toHaveBeenCalled();
+    });
+
+    it("should call estimateTronifyFees when feeOptionId is TRONIFY_FEE_OPTION_ID", async () => {
+      const api = createApi();
+      await api.estimateFees(context, trc20Intent, {
+        feeOption: { feeOptionId: TRONIFY_FEE_OPTION_ID },
+      });
+
+      expect(mockEstimateTronifyFees).toHaveBeenCalledWith(mockTronConfig, trc20Intent);
+      expect(mockEstimateFees).not.toHaveBeenCalled();
+    });
+
+    it("should call estimateFees when feeOptionId is an unknown value", async () => {
+      const api = createApi();
+      await api.estimateFees(context, trc20Intent, { feeOption: { feeOptionId: "unknown" } });
+
+      expect(mockEstimateFees).toHaveBeenCalledWith(mockTronConfig, trc20Intent);
+      expect(mockEstimateTronifyFees).not.toHaveBeenCalled();
+    });
   });
 
   describe("getBalance", () => {

--- a/libs/coin-modules/coin-tron/src/api/index.ts
+++ b/libs/coin-modules/coin-tron/src/api/index.ts
@@ -19,6 +19,7 @@ import {
   combine,
   craftTransaction,
   estimateFees,
+  estimateTronifyFees,
   getAccountInfo,
   getBalance,
   getBlock,
@@ -34,6 +35,8 @@ import { defaultFetchParams, getBlock as getBlockNetwork } from "../network";
 import type { TronMemo, TronTxData } from "../types";
 
 const MAX_TRONGRID_LIMIT = 200;
+
+export const TRONIFY_FEE_OPTION_ID = "tronify" as const;
 
 // Checked against CoinModuleImpl with `satisfies` rather than annotated as it, so the precise shape
 // survives and a caller sees exactly which methods exist.
@@ -55,8 +58,11 @@ export function createApi() {
       const config = await context.config();
       return craftTransaction(config, transactionIntent, options?.customFees);
     },
-    estimateFees: async (context, transactionIntent, _options?) => {
+    estimateFees: async (context, transactionIntent, options) => {
       const config = await context.config();
+      if (options?.feeOption?.feeOptionId === TRONIFY_FEE_OPTION_ID) {
+        return estimateTronifyFees(config, transactionIntent);
+      }
       return estimateFees(config, transactionIntent);
     },
     getAccountInfo: async (context, address): Promise<AccountInfo> => {

--- a/libs/coin-modules/coin-tron/src/config.ts
+++ b/libs/coin-modules/coin-tron/src/config.ts
@@ -13,6 +13,16 @@ export type TronifyProviderConfig = {
    * (all except `uploadHash`, which is keyed by the order id alone).
    */
   sourceFlag: string;
+  /**
+   * fastTrade rental window in seconds sent with each quote/order. Optional — falls back to 600
+   * (matches the UI fee-quote TTL) when the remote coin-config omits it.
+   */
+  rentalDurationSeconds?: number;
+  /**
+   * Bandwidth top-up in TRX bundled with each rental to cover the transaction's bandwidth cost.
+   * Optional — falls back to 0.8 when the remote coin-config omits it.
+   */
+  rentalExtraTrx?: number;
 };
 
 /**

--- a/libs/coin-modules/coin-tron/src/index.ts
+++ b/libs/coin-modules/coin-tron/src/index.ts
@@ -2,3 +2,4 @@ export * from "./types";
 
 export { isAccountEmpty } from "./resources";
 export { ENERGY_PROVIDERS, TRONIFY_PROVIDER, getEnergyProvider } from "./logic/energyProviders";
+export { TRONIFY_FEE_OPTION_ID } from "./api";

--- a/libs/coin-modules/coin-tron/src/index.ts
+++ b/libs/coin-modules/coin-tron/src/index.ts
@@ -2,4 +2,5 @@ export * from "./types";
 
 export { isAccountEmpty } from "./resources";
 export { ENERGY_PROVIDERS, TRONIFY_PROVIDER, getEnergyProvider } from "./logic/energyProviders";
+// TODO(LIVE-34996): promote to stable public API once listFeeOptions is implemented
 export { TRONIFY_FEE_OPTION_ID } from "./api";

--- a/libs/coin-modules/coin-tron/src/logic/estimateFees.integ.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/estimateFees.integ.test.ts
@@ -4,7 +4,7 @@ import { randomBytes } from "crypto";
 import { getChainParameters, getTronAccountNetwork } from "../network";
 import { encode58Check } from "../network/format";
 import type { TronMemo, TronTxData } from "../types";
-import { estimateFees } from "./estimateFees";
+import { estimateFees, estimateTronifyFees } from "./estimateFees";
 
 type TronIntent = TransactionIntent<TronMemo, TronTxData>;
 
@@ -117,5 +117,23 @@ describe("estimateFees [integ]", () => {
 
       expect(first.value).toBe(second.value);
     });
+  });
+});
+
+// estimateTronifyFees integ tests require a live Tronify provider wired into coinConfig, which
+// is not available in standard CI. The Tronify code path is fully covered by unit tests in
+// estimateFees.test.ts. Enable this block locally by pointing coinConfig at a real provider.
+describe.skip("estimateTronifyFees [integ — requires live Tronify provider]", () => {
+  it("returns value < originalValue for a USDT TRC-20 transfer with a cheap energy window", async () => {
+    const intent = sendIntent({ asset: { type: "trc20", assetReference: USDT_CONTRACT } });
+
+    const result = await estimateTronifyFees(mockConfig, intent);
+
+    expect(typeof result.value).toBe("bigint");
+    expect(typeof result.originalValue).toBe("bigint");
+    expect(result.value).toBeGreaterThan(0n);
+    expect(result.originalValue).toBeGreaterThan(0n);
+    // savings may be 0 if Tronify is currently not cheaper — just assert it's non-negative
+    expect(result.savings).toBeGreaterThanOrEqual(0n);
   });
 });

--- a/libs/coin-modules/coin-tron/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/estimateFees.test.ts
@@ -752,6 +752,12 @@ describe("estimateTronifyFees", () => {
     );
   });
 
+  it("should throw when Tronify returns a non-numeric payCoinAmt", async () => {
+    mockGetEnergyRentQuote.mockResolvedValue({ ...trxQuote, payCoinAmt: "not-a-number" });
+
+    await expect(estimateTronifyFees(mockConfig, sendTrc20)).rejects.toThrow(/invalid payCoinAmt/);
+  });
+
   it("should propagate TronifyApiError from getEnergyRentQuote without silent fallback", async () => {
     const apiError = Object.assign(new Error("quota exceeded"), {
       name: "TronifyApiError",

--- a/libs/coin-modules/coin-tron/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/estimateFees.test.ts
@@ -744,6 +744,13 @@ describe("estimateTronifyFees", () => {
     expect(mockGetEnergyRentQuote).not.toHaveBeenCalled();
   });
 
+  it("should throw when the recipient is empty", async () => {
+    await expect(estimateTronifyFees(mockConfig, { ...sendTrc20, recipient: "" })).rejects.toThrow(
+      /requires a recipient/,
+    );
+    expect(mockGetEnergyRentQuote).not.toHaveBeenCalled();
+  });
+
   it("should throw when Tronify returns a USDT-denominated quote", async () => {
     mockGetEnergyRentQuote.mockResolvedValue({ ...trxQuote, payCoinCode: "USDT" });
 

--- a/libs/coin-modules/coin-tron/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/estimateFees.test.ts
@@ -813,6 +813,19 @@ describe("estimateTronifyFees", () => {
     );
   });
 
+  it("should throw a clear error (not a TypeError) when payCoinCode is missing", async () => {
+    // payCoinCode is unvalidated network data; a missing/non-string value must yield the explicit
+    // "unsupported payCoinCode" error rather than a raw TypeError from toUpperCase().
+    mockGetEnergyRentQuote.mockResolvedValue({
+      ...trxQuote,
+      payCoinCode: undefined as unknown as string,
+    });
+
+    await expect(estimateTronifyFees(mockConfig, sendTrc20)).rejects.toThrow(
+      /unsupported payCoinCode/,
+    );
+  });
+
   it("should throw when Tronify returns a non-numeric payCoinAmt", async () => {
     mockGetEnergyRentQuote.mockResolvedValue({ ...trxQuote, payCoinAmt: "not-a-number" });
 

--- a/libs/coin-modules/coin-tron/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/estimateFees.test.ts
@@ -1,4 +1,4 @@
-import type { TronCoinConfig } from "../config";
+import coinConfig, { type TronCoinConfig } from "../config";
 import { TransactionIntent } from "@ledgerhq/coin-module-framework/api/index";
 import BigNumber from "bignumber.js";
 import {
@@ -674,6 +674,16 @@ const trxQuote = {
 describe("estimateTronifyFees", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // energyRent must be configured for the Tronify path; rental params omitted here so the
+    // defaults apply (overridden explicitly in the coin-config test below).
+    coinConfig.setCoinConfig(() => ({
+      status: { type: "active" },
+      explorer: { url: "https://tron.coin.ledger.com" },
+      energyRent: {
+        provider: "tronify",
+        tronify: { url: "https://open.tronify.io", sourceFlag: "ledgerLive" },
+      },
+    }));
     // no free bandwidth or energy → full standard burn applies
     mockGetTronAccountNetwork.mockResolvedValue(buildNetworkInfo());
     mockGetChainParameters.mockResolvedValue(chainParams);
@@ -714,11 +724,33 @@ describe("estimateTronifyFees", () => {
     );
   });
 
-  it("should quote with the 10-min fastTrade duration and 0.8 TRX bandwidth top-up", async () => {
+  it("should default to the 10-min fastTrade duration and 0.8 TRX top-up when coin-config omits them", async () => {
     await estimateTronifyFees(mockConfig, sendTrc20);
 
     expect(mockGetEnergyRentQuote).toHaveBeenCalledWith(
       expect.objectContaining({ durationSeconds: 600, extraTrx: 0.8 }),
+    );
+  });
+
+  it("should use the rental duration and extra TRX from coin-config when provided", async () => {
+    coinConfig.setCoinConfig(() => ({
+      status: { type: "active" },
+      explorer: { url: "https://tron.coin.ledger.com" },
+      energyRent: {
+        provider: "tronify",
+        tronify: {
+          url: "https://open.tronify.io",
+          sourceFlag: "ledgerLive",
+          rentalDurationSeconds: 1200,
+          rentalExtraTrx: 1.5,
+        },
+      },
+    }));
+
+    await estimateTronifyFees(mockConfig, sendTrc20);
+
+    expect(mockGetEnergyRentQuote).toHaveBeenCalledWith(
+      expect.objectContaining({ durationSeconds: 1200, extraTrx: 1.5 }),
     );
   });
 

--- a/libs/coin-modules/coin-tron/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/estimateFees.test.ts
@@ -670,7 +670,7 @@ describe("estimateTronifyFees", () => {
     mockGetEnergyRentQuote.mockResolvedValue(trxQuote);
   });
 
-  it("returns value, originalValue and savings for a TRX-denominated quote", async () => {
+  it("should return value, originalValue and savings when the quote is TRX-denominated", async () => {
     const result = await estimateTronifyFees(mockConfig, sendTrc20);
 
     expect(result).toEqual({
@@ -680,7 +680,7 @@ describe("estimateTronifyFees", () => {
     });
   });
 
-  it("passes the raw estimateEnergy result as the energy pledge (no client-side minimum)", async () => {
+  it("should pass the raw estimateEnergy result as the energy pledge without a client-side minimum", async () => {
     mockTriggerConstantContract.mockResolvedValue({ energy_used: 5_000 });
 
     await estimateTronifyFees(mockConfig, sendTrc20);
@@ -690,7 +690,7 @@ describe("estimateTronifyFees", () => {
     );
   });
 
-  it("delegates energy to the sender address, not the recipient", async () => {
+  it("should delegate energy to the sender address, not the recipient", async () => {
     await estimateTronifyFees(mockConfig, sendTrc20);
 
     expect(mockGetEnergyRentQuote).toHaveBeenCalledWith(
@@ -701,7 +701,7 @@ describe("estimateTronifyFees", () => {
     );
   });
 
-  it("quotes with the 10-min fastTrade duration and 0.8 TRX bandwidth top-up", async () => {
+  it("should quote with the 10-min fastTrade duration and 0.8 TRX bandwidth top-up", async () => {
     await estimateTronifyFees(mockConfig, sendTrc20);
 
     expect(mockGetEnergyRentQuote).toHaveBeenCalledWith(
@@ -709,28 +709,29 @@ describe("estimateTronifyFees", () => {
     );
   });
 
-  it("computes savings correctly as originalValue - value", async () => {
+  it("should compute savings as originalValue - value", async () => {
     const result = await estimateTronifyFees(mockConfig, sendTrc20);
 
     expect(result.originalValue).toBeDefined();
-    expect(result.savings).toBe(result.originalValue! - result.value);
+    const originalValue = result.originalValue as bigint;
+    expect(result.savings).toBe(originalValue - result.value);
   });
 
-  it("throws for a native TRX send — Tronify only covers TRC-20", async () => {
+  it("should throw when the intent is a native TRX send", async () => {
     await expect(estimateTronifyFees(mockConfig, sendNative)).rejects.toThrow(
       /only available for TRC-20/,
     );
     expect(mockGetEnergyRentQuote).not.toHaveBeenCalled();
   });
 
-  it("throws for a TRC-10 send — Tronify only covers TRC-20", async () => {
+  it("should throw when the intent is a TRC-10 send", async () => {
     await expect(estimateTronifyFees(mockConfig, sendTrc10)).rejects.toThrow(
       /only available for TRC-20/,
     );
     expect(mockGetEnergyRentQuote).not.toHaveBeenCalled();
   });
 
-  it("throws when Tronify returns a USDT-denominated quote (Flow 2 not yet supported)", async () => {
+  it("should throw when Tronify returns a USDT-denominated quote", async () => {
     mockGetEnergyRentQuote.mockResolvedValue({ ...trxQuote, payCoinCode: "USDT" });
 
     await expect(estimateTronifyFees(mockConfig, sendTrc20)).rejects.toThrow(
@@ -738,7 +739,7 @@ describe("estimateTronifyFees", () => {
     );
   });
 
-  it("propagates TronifyApiError from getEnergyRentQuote — no silent fallback", async () => {
+  it("should propagate TronifyApiError from getEnergyRentQuote without silent fallback", async () => {
     const apiError = Object.assign(new Error("quota exceeded"), {
       name: "TronifyApiError",
       resCode: 429,
@@ -751,14 +752,14 @@ describe("estimateTronifyFees", () => {
     });
   });
 
-  it("propagates an estimateEnergy failure — no silent fallback", async () => {
+  it("should propagate an estimateEnergy failure without silent fallback", async () => {
     mockTriggerConstantContract.mockRejectedValue(new Error("node unreachable"));
 
     await expect(estimateTronifyFees(mockConfig, sendTrc20)).rejects.toThrow("node unreachable");
     expect(mockGetEnergyRentQuote).not.toHaveBeenCalled();
   });
 
-  it("propagates a getChainParameters failure — no silent fallback to pessimistic originalValue", async () => {
+  it("should propagate a getChainParameters failure without silent fallback to pessimistic originalValue", async () => {
     mockGetChainParameters.mockRejectedValue(new Error("chain params unavailable"));
 
     await expect(estimateTronifyFees(mockConfig, sendTrc20)).rejects.toThrow(
@@ -766,7 +767,7 @@ describe("estimateTronifyFees", () => {
     );
   });
 
-  it("clamps savings to 0n when Tronify quote exceeds the standard burn", async () => {
+  it("should clamp savings to 0n when the Tronify quote exceeds the standard burn", async () => {
     // 10 TRX (10_000_000 SUN) > STANDARD_BURN (7_047_950n)
     mockGetEnergyRentQuote.mockResolvedValue({ ...trxQuote, payCoinAmt: "10" });
 
@@ -777,19 +778,27 @@ describe("estimateTronifyFees", () => {
     expect(result.originalValue).toBe(STANDARD_BURN);
   });
 
-  it("propagates the Tronify API response when energyNeeded is 0 — no client-side guard", async () => {
-    // energyNeeded=0 is unusual for a TRC-20 transfer but estimateEnergy does not throw on it.
-    // We let getEnergyRentQuote receive 0n and propagate whatever the API returns (error or quote).
+  it("should propagate the Tronify API response when simulation returns energyNeeded=0", async () => {
+    // triggerConstantContract returns 0 — estimateEnergy reports 0, simulation did run.
     mockTriggerConstantContract.mockResolvedValue({ energy_used: 0 });
 
-    // Default mock returns a valid quote even for energy=0 — behaviour is well-defined.
     const result = await estimateTronifyFees(mockConfig, sendTrc20);
 
     expect(mockGetEnergyRentQuote).toHaveBeenCalledWith(expect.objectContaining({ energy: 0n }));
     expect(result.value).toBeDefined();
   });
 
-  it("standard estimateFees path is unchanged when feeOptionId is not tronify", async () => {
+  it("should pass energyNeeded=0 to getEnergyRentQuote when the amount-guard short-circuits the simulation", async () => {
+    // amount === 0n && !useAllAmount → estimateEnergy returns 0 without calling triggerConstantContract
+    const zeroAmountIntent = { ...sendTrc20, amount: 0n };
+
+    await estimateTronifyFees(mockConfig, zeroAmountIntent);
+
+    expect(mockTriggerConstantContract).not.toHaveBeenCalled();
+    expect(mockGetEnergyRentQuote).toHaveBeenCalledWith(expect.objectContaining({ energy: 0n }));
+  });
+
+  it("should use the standard estimateFees path when feeOptionId is not tronify", async () => {
     const result = await estimateFees(mockConfig, sendTrc20);
 
     expect(result.value).toBe(STANDARD_BURN);

--- a/libs/coin-modules/coin-tron/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/estimateFees.test.ts
@@ -638,6 +638,10 @@ describe("estimateFees", () => {
   });
 
   it("should not call getEnergyRentQuote when invoked directly (no feeOption routing)", async () => {
+    // no free resources → full standard burn applies
+    mockGetTronAccountNetwork.mockResolvedValue(buildNetworkInfo());
+    mockTriggerConstantContract.mockResolvedValue({ energy_used: ENERGY_USED });
+
     const result = await estimateFees(mockConfig, sendTrc20);
 
     expect(result.value).toBe(STANDARD_BURN);
@@ -721,7 +725,7 @@ describe("estimateTronifyFees", () => {
   it("should compute savings as originalValue - value", async () => {
     const result = await estimateTronifyFees(mockConfig, sendTrc20);
 
-    expect(result.originalValue).toBeDefined();
+    expect(result.originalValue).toBe(STANDARD_BURN);
     const originalValue = result.originalValue as bigint;
     expect(result.savings).toBe(originalValue - result.value);
   });
@@ -794,7 +798,7 @@ describe("estimateTronifyFees", () => {
     const result = await estimateTronifyFees(mockConfig, sendTrc20);
 
     expect(mockGetEnergyRentQuote).toHaveBeenCalledWith(expect.objectContaining({ energy: 0n }));
-    expect(result.value).toBeDefined();
+    expect(result.value).toBe(TRONIFY_VALUE);
   });
 
   it("should pass energyNeeded=0 to getEnergyRentQuote when the amount-guard short-circuits the simulation", async () => {

--- a/libs/coin-modules/coin-tron/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/estimateFees.test.ts
@@ -636,6 +636,13 @@ describe("estimateFees", () => {
       expect(BigInt(breakdown.energyRequired)).toBeGreaterThan(BigInt(breakdown.energyAvailable));
     });
   });
+
+  it("should not call getEnergyRentQuote when invoked directly (no feeOption routing)", async () => {
+    const result = await estimateFees(mockConfig, sendTrc20);
+
+    expect(result.value).toBe(STANDARD_BURN);
+    expect(mockGetEnergyRentQuote).not.toHaveBeenCalled();
+  });
 });
 
 function breakdownOf(estimation: { parameters?: Record<string, unknown> }): TronResourceBreakdown {
@@ -670,13 +677,15 @@ describe("estimateTronifyFees", () => {
     mockGetEnergyRentQuote.mockResolvedValue(trxQuote);
   });
 
-  it("should return value, originalValue and savings when the quote is TRX-denominated", async () => {
+  it("should return value, originalValue, savings and a resource breakdown when the quote is TRX-denominated", async () => {
     const result = await estimateTronifyFees(mockConfig, sendTrc20);
 
-    expect(result).toEqual({
-      value: TRONIFY_VALUE,
-      originalValue: STANDARD_BURN,
-      savings: STANDARD_BURN - TRONIFY_VALUE,
+    expect(result.value).toBe(TRONIFY_VALUE);
+    expect(result.originalValue).toBe(STANDARD_BURN);
+    expect(result.savings).toBe(STANDARD_BURN - TRONIFY_VALUE);
+    expect(result.parameters).toMatchObject({
+      energyRequired: String(ENERGY_USED),
+      energyEstimated: true,
     });
   });
 
@@ -796,12 +805,5 @@ describe("estimateTronifyFees", () => {
 
     expect(mockTriggerConstantContract).not.toHaveBeenCalled();
     expect(mockGetEnergyRentQuote).toHaveBeenCalledWith(expect.objectContaining({ energy: 0n }));
-  });
-
-  it("should use the standard estimateFees path when feeOptionId is not tronify", async () => {
-    const result = await estimateFees(mockConfig, sendTrc20);
-
-    expect(result.value).toBe(STANDARD_BURN);
-    expect(mockGetEnergyRentQuote).not.toHaveBeenCalled();
   });
 });

--- a/libs/coin-modules/coin-tron/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/estimateFees.test.ts
@@ -24,9 +24,11 @@ import {
   estimateEnergy,
   estimatedTxSize,
   estimateFees,
+  estimateTronifyFees,
   type TronResourceBreakdown,
 } from "./estimateFees";
 import { getBalance } from "./getBalance";
+import { getEnergyRentQuote } from "./energyRent";
 
 jest.mock("../network", () => ({
   fetchTronAccount: jest.fn(),
@@ -36,12 +38,15 @@ jest.mock("../network", () => ({
 }));
 
 jest.mock("./getBalance", () => ({ getBalance: jest.fn() }));
+jest.mock("./energyRent", () => ({ getEnergyRentQuote: jest.fn() }));
 
 const mockGetBalance = jest.mocked(getBalance);
+
 const mockGetTronAccountNetwork = jest.mocked(getTronAccountNetwork);
 const mockFetchTronAccount = jest.mocked(fetchTronAccount);
 const mockGetChainParameters = jest.mocked(getChainParameters);
 const mockTriggerConstantContract = jest.mocked(triggerConstantContract);
+const mockGetEnergyRentQuote = jest.mocked(getEnergyRentQuote);
 
 const TRC20_CONTRACT = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
 
@@ -636,3 +641,158 @@ describe("estimateFees", () => {
 function breakdownOf(estimation: { parameters?: Record<string, unknown> }): TronResourceBreakdown {
   return estimation.parameters as TronResourceBreakdown;
 }
+
+// Expected standard burn for sendTrc20 with no free resources:
+//   bandwidth: 350 * transactionFee(1000) = 350_000
+//   energy:    31_895 * energyFee(210)    = 6_697_950
+//   activation: 0 (TRC-20 send)
+//   total: 7_047_950n
+const STANDARD_BURN = 7_047_950n;
+const ENERGY_USED = 31_895;
+const TRX_QUOTE_AMT = "3.5"; // → 3_500_000 SUN
+const TRONIFY_VALUE = 3_500_000n;
+
+const trxQuote = {
+  energy: BigInt(ENERGY_USED),
+  durationSeconds: 600,
+  payCoinCode: "TRX",
+  payCoinAmt: TRX_QUOTE_AMT,
+  fees: { energy: "2.727", trx: "0.773", bandwidth: "0", activateAccount: "0" },
+};
+
+describe("estimateTronifyFees", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // no free bandwidth or energy → full standard burn applies
+    mockGetTronAccountNetwork.mockResolvedValue(buildNetworkInfo());
+    mockGetChainParameters.mockResolvedValue(chainParams);
+    mockTriggerConstantContract.mockResolvedValue({ energy_used: ENERGY_USED });
+    mockGetEnergyRentQuote.mockResolvedValue(trxQuote);
+  });
+
+  it("returns value, originalValue and savings for a TRX-denominated quote", async () => {
+    const result = await estimateTronifyFees(mockConfig, sendTrc20);
+
+    expect(result).toEqual({
+      value: TRONIFY_VALUE,
+      originalValue: STANDARD_BURN,
+      savings: STANDARD_BURN - TRONIFY_VALUE,
+    });
+  });
+
+  it("passes the raw estimateEnergy result as the energy pledge (no client-side minimum)", async () => {
+    mockTriggerConstantContract.mockResolvedValue({ energy_used: 5_000 });
+
+    await estimateTronifyFees(mockConfig, sendTrc20);
+
+    expect(mockGetEnergyRentQuote).toHaveBeenCalledWith(
+      expect.objectContaining({ energy: 5_000n }),
+    );
+  });
+
+  it("delegates energy to the sender address, not the recipient", async () => {
+    await estimateTronifyFees(mockConfig, sendTrc20);
+
+    expect(mockGetEnergyRentQuote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payerAddress: SENDER,
+        receiverAddress: SENDER,
+      }),
+    );
+  });
+
+  it("quotes with the 10-min fastTrade duration and 0.8 TRX bandwidth top-up", async () => {
+    await estimateTronifyFees(mockConfig, sendTrc20);
+
+    expect(mockGetEnergyRentQuote).toHaveBeenCalledWith(
+      expect.objectContaining({ durationSeconds: 600, extraTrx: 0.8 }),
+    );
+  });
+
+  it("computes savings correctly as originalValue - value", async () => {
+    const result = await estimateTronifyFees(mockConfig, sendTrc20);
+
+    expect(result.originalValue).toBeDefined();
+    expect(result.savings).toBe(result.originalValue! - result.value);
+  });
+
+  it("throws for a native TRX send — Tronify only covers TRC-20", async () => {
+    await expect(estimateTronifyFees(mockConfig, sendNative)).rejects.toThrow(
+      /only available for TRC-20/,
+    );
+    expect(mockGetEnergyRentQuote).not.toHaveBeenCalled();
+  });
+
+  it("throws for a TRC-10 send — Tronify only covers TRC-20", async () => {
+    await expect(estimateTronifyFees(mockConfig, sendTrc10)).rejects.toThrow(
+      /only available for TRC-20/,
+    );
+    expect(mockGetEnergyRentQuote).not.toHaveBeenCalled();
+  });
+
+  it("throws when Tronify returns a USDT-denominated quote (Flow 2 not yet supported)", async () => {
+    mockGetEnergyRentQuote.mockResolvedValue({ ...trxQuote, payCoinCode: "USDT" });
+
+    await expect(estimateTronifyFees(mockConfig, sendTrc20)).rejects.toThrow(
+      /unsupported payCoinCode/,
+    );
+  });
+
+  it("propagates TronifyApiError from getEnergyRentQuote — no silent fallback", async () => {
+    const apiError = Object.assign(new Error("quota exceeded"), {
+      name: "TronifyApiError",
+      resCode: 429,
+    });
+    mockGetEnergyRentQuote.mockRejectedValue(apiError);
+
+    await expect(estimateTronifyFees(mockConfig, sendTrc20)).rejects.toMatchObject({
+      name: "TronifyApiError",
+      resCode: 429,
+    });
+  });
+
+  it("propagates an estimateEnergy failure — no silent fallback", async () => {
+    mockTriggerConstantContract.mockRejectedValue(new Error("node unreachable"));
+
+    await expect(estimateTronifyFees(mockConfig, sendTrc20)).rejects.toThrow("node unreachable");
+    expect(mockGetEnergyRentQuote).not.toHaveBeenCalled();
+  });
+
+  it("propagates a getChainParameters failure — no silent fallback to pessimistic originalValue", async () => {
+    mockGetChainParameters.mockRejectedValue(new Error("chain params unavailable"));
+
+    await expect(estimateTronifyFees(mockConfig, sendTrc20)).rejects.toThrow(
+      "chain params unavailable",
+    );
+  });
+
+  it("clamps savings to 0n when Tronify quote exceeds the standard burn", async () => {
+    // 10 TRX (10_000_000 SUN) > STANDARD_BURN (7_047_950n)
+    mockGetEnergyRentQuote.mockResolvedValue({ ...trxQuote, payCoinAmt: "10" });
+
+    const result = await estimateTronifyFees(mockConfig, sendTrc20);
+
+    expect(result.savings).toBe(0n);
+    expect(result.value).toBe(10_000_000n);
+    expect(result.originalValue).toBe(STANDARD_BURN);
+  });
+
+  it("propagates the Tronify API response when energyNeeded is 0 — no client-side guard", async () => {
+    // energyNeeded=0 is unusual for a TRC-20 transfer but estimateEnergy does not throw on it.
+    // We let getEnergyRentQuote receive 0n and propagate whatever the API returns (error or quote).
+    mockTriggerConstantContract.mockResolvedValue({ energy_used: 0 });
+
+    // Default mock returns a valid quote even for energy=0 — behaviour is well-defined.
+    const result = await estimateTronifyFees(mockConfig, sendTrc20);
+
+    expect(mockGetEnergyRentQuote).toHaveBeenCalledWith(expect.objectContaining({ energy: 0n }));
+    expect(result.value).toBeDefined();
+  });
+
+  it("standard estimateFees path is unchanged when feeOptionId is not tronify", async () => {
+    const result = await estimateFees(mockConfig, sendTrc20);
+
+    expect(result.value).toBe(STANDARD_BURN);
+    expect(mockGetEnergyRentQuote).not.toHaveBeenCalled();
+  });
+});

--- a/libs/coin-modules/coin-tron/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/estimateFees.test.ts
@@ -754,6 +754,28 @@ describe("estimateTronifyFees", () => {
     );
   });
 
+  it("should fall back to defaults when coin-config rental params are invalid", async () => {
+    coinConfig.setCoinConfig(() => ({
+      status: { type: "active" },
+      explorer: { url: "https://tron.coin.ledger.com" },
+      energyRent: {
+        provider: "tronify",
+        tronify: {
+          url: "https://open.tronify.io",
+          sourceFlag: "ledgerLive",
+          rentalDurationSeconds: -5,
+          rentalExtraTrx: Number.NaN,
+        },
+      },
+    }));
+
+    await estimateTronifyFees(mockConfig, sendTrc20);
+
+    expect(mockGetEnergyRentQuote).toHaveBeenCalledWith(
+      expect.objectContaining({ durationSeconds: 600, extraTrx: 0.8 }),
+    );
+  });
+
   it("should compute savings as originalValue - value", async () => {
     const result = await estimateTronifyFees(mockConfig, sendTrc20);
 

--- a/libs/coin-modules/coin-tron/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-tron/src/logic/estimateFees.ts
@@ -212,16 +212,23 @@ const fallbackFee = (intent: TronIntent): bigint => {
 const isTrc20Send = (intent: TronIntent): boolean =>
   intent.type === "send" && intent.asset.type === "trc20";
 
-// Internal: compute fee from a pre-fetched energyNeeded. Does NOT catch — callers decide
-// whether to fall back. Allows callers that already have energyNeeded to avoid re-fetching it.
-async function computeFeesRaw(
+// Fetches the three network inputs shared by estimateFees and computeFeesRaw — extracted to avoid
+// duplicating the Promise.all in both callers.
+async function fetchTronFeeInputs(
   config: TronCoinConfig,
   transactionIntent: TronIntent,
-  energyNeeded: number,
-): Promise<bigint> {
+): Promise<{
+  networkInfo: NetworkInfo;
+  recipientAccount: AccountTronAPI | undefined;
+  chainParams: ChainParameters;
+}> {
   const [networkInfo, recipientAccount, chainParams] = await Promise.all([
     getTronAccountNetwork(config, transactionIntent.sender),
-    // Only native sends need the recipient account for the activation-fee branch.
+    // Only native sends need the recipient account for the activation-fee branch, and only once a
+    // recipient exists: `prepareTransaction` estimates on every transaction change, so an empty
+    // recipient would send `/v1/accounts/` with no address, and `fetchTronAccount` propagates that
+    // failure into the outer catch — quoting the pessimistic flat fee before the user has typed
+    // anything.
     transactionIntent.type === "send" &&
     transactionIntent.asset.type === "native" &&
     transactionIntent.recipient
@@ -229,12 +236,30 @@ async function computeFeesRaw(
       : Promise.resolve<AccountTronAPI | undefined>(undefined),
     getChainParameters(config),
   ]);
+  return { networkInfo, recipientAccount, chainParams };
+}
+
+// Internal: compute fee from a pre-fetched energyNeeded. Does NOT catch — callers decide
+// whether to fall back. Returns networkInfo alongside the fee so callers can build a
+// TronResourceBreakdown without a second network round-trip.
+async function computeFeesRaw(
+  config: TronCoinConfig,
+  transactionIntent: TronIntent,
+  energyNeeded: number,
+): Promise<{ value: bigint; networkInfo: NetworkInfo }> {
+  const { networkInfo, recipientAccount, chainParams } = await fetchTronFeeInputs(
+    config,
+    transactionIntent,
+  );
 
   const total = computeBandwidthFee(estimatedTxSize(transactionIntent), networkInfo, chainParams)
     .plus(computeEnergyFee(energyNeeded, networkInfo, chainParams))
     .plus(computeActivationFee(transactionIntent, recipientAccount, chainParams));
 
-  return BigInt(total.integerValue(BigNumber.ROUND_CEIL).toFixed());
+  return {
+    value: BigInt(total.integerValue(BigNumber.ROUND_CEIL).toFixed()),
+    networkInfo,
+  };
 }
 
 export async function estimateFees(
@@ -246,20 +271,10 @@ export async function estimateFees(
   const size = estimatedTxSize(transactionIntent);
 
   try {
-    const [networkInfo, recipientAccount, chainParams] = await Promise.all([
-      getTronAccountNetwork(config, transactionIntent.sender),
-      // Only native sends need the recipient account for the activation-fee branch, and only once a
-      // recipient exists: `prepareTransaction` estimates on every transaction change, so an empty
-      // recipient would send `/v1/accounts/` with no address, and `fetchTronAccount` propagates that
-      // failure into the outer catch — quoting the pessimistic flat fee before the user has typed
-      // anything.
-      transactionIntent.type === "send" &&
-      transactionIntent.asset.type === "native" &&
-      transactionIntent.recipient
-        ? fetchTronAccount(config, transactionIntent.recipient).then(accounts => accounts[0])
-        : Promise.resolve<AccountTronAPI | undefined>(undefined),
-      getChainParameters(config),
-    ]);
+    const { networkInfo, recipientAccount, chainParams } = await fetchTronFeeInputs(
+      config,
+      transactionIntent,
+    );
 
     const energyPool = energyAvailable(networkInfo);
     let energyRequired: BigNumber;
@@ -324,7 +339,7 @@ const withBreakdown = (value: bigint, breakdown: TronResourceBreakdown): FeeEsti
 
 // 10-min fastTrade window matching the UI's fee-quote TTL
 const TRONIFY_RENTAL_DURATION_SECONDS = 600;
-// Bandwidth top-up Tronify bundles with each rental to cover the transaction's bandwidth cost
+// Bandwidth top-up Tronify bundles with each rental to cover the transaction's bandwidth cost — 0.8 TRX (not SUN)
 const TRONIFY_RENTAL_EXTRA_TRX = 0.8;
 
 /**
@@ -352,7 +367,8 @@ export async function estimateTronifyFees(
   // known, so they run in parallel to keep pricing latency minimal.
   // getEnergyRentQuote resolves its provider through the coinConfig singleton (not `config`); this
   // is the shared design of the energyRent module — the provider is selected via remote coin-config.
-  const [originalValue, quote] = await Promise.all([
+  // TODO(LIVE-34996): align energyRent config threading with the injected `config` pattern.
+  const [{ value: originalValue, networkInfo }, quote] = await Promise.all([
     computeFeesRaw(config, intent, energyNeeded),
     getEnergyRentQuote({
       payerAddress: intent.sender,
@@ -378,10 +394,22 @@ export async function estimateTronifyFees(
       .toFixed(),
   );
 
+  // Populate a breakdown so validateIntent/resolveFeeContext doesn't fire an extra estimateFees
+  // RPC on every keystroke for the Tronify path (resolveFeeContext gates re-estimation on whether
+  // customFees?.parameters carries a valid TronResourceBreakdown).
+  const breakdown: TronResourceBreakdown = {
+    energyRequired: String(energyNeeded),
+    energyAvailable: energyAvailable(networkInfo).toFixed(),
+    bandwidthRequired: String(estimatedTxSize(intent)),
+    bandwidthAvailable: bandwidthAvailable(networkInfo).toFixed(),
+    energyEstimated: true,
+  };
+
   return {
     value,
     originalValue,
     // Clamp to 0n: Tronify may be more expensive than burning during low-energy-price periods.
     savings: originalValue > value ? originalValue - value : 0n,
+    parameters: { ...breakdown },
   };
 }

--- a/libs/coin-modules/coin-tron/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-tron/src/logic/estimateFees.ts
@@ -343,6 +343,16 @@ const DEFAULT_TRONIFY_RENTAL_DURATION_SECONDS = 600;
 // Bandwidth top-up Tronify bundles with each rental to cover the transaction's bandwidth cost — 0.8 TRX (not SUN).
 const DEFAULT_TRONIFY_RENTAL_EXTRA_TRX = 0.8;
 
+// Remote coin-config is unvalidated JSON: a provided value that isn't a finite number >= min is a
+// misconfiguration, not a valid override. Fall back to the default and log it — so a config typo is
+// debuggable instead of silently sending a malformed/negative quote request.
+const readRentalParam = (value: unknown, fallback: number, min: number, name: string): number => {
+  if (value === undefined) return fallback;
+  if (typeof value === "number" && Number.isFinite(value) && value >= min) return value;
+  log("tron/estimateFees", `ignoring invalid coin-config ${name}, using default`, { value });
+  return fallback;
+};
+
 /**
  * Estimate fees for the Tronify energy-rent option.
  *
@@ -374,9 +384,18 @@ export async function estimateTronifyFees(
   // tuned without a release; fall back to the defaults when unset. Read from the coinConfig
   // singleton — the same source the energyRent provider selection uses (network/tronify, energyRent).
   const tronifyConfig = coinConfig.getCoinConfig().energyRent?.tronify;
-  const durationSeconds =
-    tronifyConfig?.rentalDurationSeconds ?? DEFAULT_TRONIFY_RENTAL_DURATION_SECONDS;
-  const extraTrx = tronifyConfig?.rentalExtraTrx ?? DEFAULT_TRONIFY_RENTAL_EXTRA_TRX;
+  const durationSeconds = readRentalParam(
+    tronifyConfig?.rentalDurationSeconds,
+    DEFAULT_TRONIFY_RENTAL_DURATION_SECONDS,
+    1,
+    "rentalDurationSeconds",
+  );
+  const extraTrx = readRentalParam(
+    tronifyConfig?.rentalExtraTrx,
+    DEFAULT_TRONIFY_RENTAL_EXTRA_TRX,
+    0,
+    "rentalExtraTrx",
+  );
 
   // computeFeesRaw does not catch — any chain-params failure propagates here (no silent fallback
   // on originalValue, per ADR-050 Option 3). Both calls are independent once energyNeeded is

--- a/libs/coin-modules/coin-tron/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-tron/src/logic/estimateFees.ts
@@ -387,11 +387,16 @@ export async function estimateTronifyFees(
     );
   }
 
+  // payCoinAmt is an unvalidated API string: a non-numeric/NaN/Infinity value would otherwise reach
+  // BigInt() as "NaN"/"Infinity" and throw an opaque SyntaxError. Fail with a clear error instead
+  // (no silent fallback, per ADR-050 Option 3).
+  const payCoinAmt = new BigNumber(quote.payCoinAmt);
+  if (!payCoinAmt.isFinite() || payCoinAmt.isNegative()) {
+    throw new Error(`Tronify returned an invalid payCoinAmt: ${quote.payCoinAmt}`);
+  }
+
   const value = BigInt(
-    new BigNumber(quote.payCoinAmt)
-      .multipliedBy(ONE_TRX)
-      .integerValue(BigNumber.ROUND_CEIL)
-      .toFixed(),
+    payCoinAmt.multipliedBy(ONE_TRX).integerValue(BigNumber.ROUND_CEIL).toFixed(),
   );
 
   // Populate a breakdown so validateIntent/resolveFeeContext doesn't fire an extra estimateFees

--- a/libs/coin-modules/coin-tron/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-tron/src/logic/estimateFees.ts
@@ -15,11 +15,13 @@ import type { NetworkInfo, TronMemo, TronTxData } from "../types";
 import {
   ACTIVATION_FEES,
   MEMO_FEE_PESSIMISTIC,
+  ONE_TRX,
   STANDARD_FEES_NATIVE,
   STANDARD_FEES_TRC_20,
 } from "./constants";
 import { getBalance } from "./getBalance";
 import { findBalance } from "./utils";
+import { getEnergyRentQuote } from "./energyRent";
 
 type TronIntent = TransactionIntent<TronMemo, TronTxData>;
 
@@ -210,6 +212,31 @@ const fallbackFee = (intent: TronIntent): bigint => {
 const isTrc20Send = (intent: TronIntent): boolean =>
   intent.type === "send" && intent.asset.type === "trc20";
 
+// Internal: compute fee from a pre-fetched energyNeeded. Does NOT catch — callers decide
+// whether to fall back. Allows callers that already have energyNeeded to avoid re-fetching it.
+async function computeFeesRaw(
+  config: TronCoinConfig,
+  transactionIntent: TronIntent,
+  energyNeeded: number,
+): Promise<bigint> {
+  const [networkInfo, recipientAccount, chainParams] = await Promise.all([
+    getTronAccountNetwork(config, transactionIntent.sender),
+    // Only native sends need the recipient account for the activation-fee branch.
+    transactionIntent.type === "send" &&
+    transactionIntent.asset.type === "native" &&
+    transactionIntent.recipient
+      ? fetchTronAccount(config, transactionIntent.recipient).then(accounts => accounts[0])
+      : Promise.resolve<AccountTronAPI | undefined>(undefined),
+    getChainParameters(config),
+  ]);
+
+  const total = computeBandwidthFee(estimatedTxSize(transactionIntent), networkInfo, chainParams)
+    .plus(computeEnergyFee(energyNeeded, networkInfo, chainParams))
+    .plus(computeActivationFee(transactionIntent, recipientAccount, chainParams));
+
+  return BigInt(total.integerValue(BigNumber.ROUND_CEIL).toFixed());
+}
+
 export async function estimateFees(
   config: TronCoinConfig,
   transactionIntent: TronIntent,
@@ -294,3 +321,66 @@ const withBreakdown = (value: bigint, breakdown: TronResourceBreakdown): FeeEsti
   value,
   parameters: { ...breakdown },
 });
+
+// 10-min fastTrade window; aligns with SPONSORED_RENTAL_DURATION_SECONDS in bridge/getEstimateFees.ts
+const TRONIFY_RENTAL_DURATION_SECONDS = 600;
+// Bandwidth top-up Tronify bundles; aligns with SPONSORED_RENTAL_EXTRA_TRX in bridge/getEstimateFees.ts
+const TRONIFY_RENTAL_EXTRA_TRX = 0.8;
+
+/**
+ * Estimate fees for the Tronify energy-rent option.
+ *
+ * Calls the Tronify quote API and returns a priced FeeEstimation alongside the standard burn cost
+ * for comparison. Only applicable to TRC-20 transfers (the only intent type Tronify covers).
+ *
+ * Throws on any error — including Tronify API failures — as the caller must handle unavailability
+ * explicitly (no silent fallback, per ADR-050 Option 3 AC).
+ */
+export async function estimateTronifyFees(
+  config: TronCoinConfig,
+  intent: TronIntent,
+): Promise<FeeEstimation> {
+  if (intent.type !== "send" || intent.asset.type !== "trc20" || !intent.asset.assetReference) {
+    throw new Error("Tronify fee option is only available for TRC-20 send intents");
+  }
+
+  // Single energy simulation; result feeds both the standard burn calc and the Tronify quote.
+  const energyNeeded = await estimateEnergy(config, intent);
+
+  // computeFeesRaw does not catch — any chain-params failure propagates here (no silent fallback
+  // on originalValue, per ADR-050 Option 3). Run in parallel with the Tronify quote.
+  // getEnergyRentQuote resolves its provider through the coinConfig singleton (not `config`); this
+  // is the shared design of the energyRent module — the provider is selected via remote coin-config.
+  const [originalValue, quote] = await Promise.all([
+    computeFeesRaw(config, intent, energyNeeded),
+    getEnergyRentQuote({
+      payerAddress: intent.sender,
+      receiverAddress: intent.sender, // energy is delegated to the sender (they call the contract)
+      energy: BigInt(energyNeeded),
+      durationSeconds: TRONIFY_RENTAL_DURATION_SECONDS,
+      extraTrx: TRONIFY_RENTAL_EXTRA_TRX,
+    }),
+  ]);
+
+  // Only TRX-denominated quotes are supported here. USDT-denominated rent (Flow 2) carries amounts
+  // in a different unit than the standard fee and requires separate handling.
+  if (quote.payCoinCode.toUpperCase() !== "TRX") {
+    throw new Error(
+      `Tronify returned unsupported payCoinCode: ${quote.payCoinCode}; only TRX is supported`,
+    );
+  }
+
+  const value = BigInt(
+    new BigNumber(quote.payCoinAmt)
+      .multipliedBy(ONE_TRX)
+      .integerValue(BigNumber.ROUND_CEIL)
+      .toFixed(),
+  );
+
+  return {
+    value,
+    originalValue,
+    // Clamp to 0n: Tronify may be more expensive than burning during low-energy-price periods.
+    savings: originalValue > value ? originalValue - value : 0n,
+  };
+}

--- a/libs/coin-modules/coin-tron/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-tron/src/logic/estimateFees.ts
@@ -1,7 +1,7 @@
 import type { FeeEstimation, TransactionIntent } from "@ledgerhq/coin-module-framework/api/index";
 import { log } from "@ledgerhq/logs";
 import BigNumber from "bignumber.js";
-import type { TronCoinConfig } from "../config";
+import coinConfig, { type TronCoinConfig } from "../config";
 import {
   fetchTronAccount,
   getChainParameters,
@@ -337,10 +337,11 @@ const withBreakdown = (value: bigint, breakdown: TronResourceBreakdown): FeeEsti
   parameters: { ...breakdown },
 });
 
-// 10-min fastTrade window matching the UI's fee-quote TTL
-const TRONIFY_RENTAL_DURATION_SECONDS = 600;
-// Bandwidth top-up Tronify bundles with each rental to cover the transaction's bandwidth cost — 0.8 TRX (not SUN)
-const TRONIFY_RENTAL_EXTRA_TRX = 0.8;
+// Defaults used when the remote coin-config (energyRent.tronify) doesn't override them.
+// 10-min fastTrade window matching the UI's fee-quote TTL.
+const DEFAULT_TRONIFY_RENTAL_DURATION_SECONDS = 600;
+// Bandwidth top-up Tronify bundles with each rental to cover the transaction's bandwidth cost — 0.8 TRX (not SUN).
+const DEFAULT_TRONIFY_RENTAL_EXTRA_TRX = 0.8;
 
 /**
  * Estimate fees for the Tronify energy-rent option.
@@ -369,6 +370,14 @@ export async function estimateTronifyFees(
   // Single energy simulation; result feeds both the standard burn calc and the Tronify quote.
   const energyNeeded = await estimateEnergy(config, intent);
 
+  // Rental params are remote-configurable via coin-config (energyRent.tronify), so they can be
+  // tuned without a release; fall back to the defaults when unset. Read from the coinConfig
+  // singleton — the same source the energyRent provider selection uses (network/tronify, energyRent).
+  const tronifyConfig = coinConfig.getCoinConfig().energyRent?.tronify;
+  const durationSeconds =
+    tronifyConfig?.rentalDurationSeconds ?? DEFAULT_TRONIFY_RENTAL_DURATION_SECONDS;
+  const extraTrx = tronifyConfig?.rentalExtraTrx ?? DEFAULT_TRONIFY_RENTAL_EXTRA_TRX;
+
   // computeFeesRaw does not catch — any chain-params failure propagates here (no silent fallback
   // on originalValue, per ADR-050 Option 3). Both calls are independent once energyNeeded is
   // known, so they run in parallel to keep pricing latency minimal.
@@ -381,8 +390,8 @@ export async function estimateTronifyFees(
       payerAddress: intent.sender,
       receiverAddress: intent.sender, // energy is delegated to the sender (they call the contract)
       energy: BigInt(energyNeeded),
-      durationSeconds: TRONIFY_RENTAL_DURATION_SECONDS,
-      extraTrx: TRONIFY_RENTAL_EXTRA_TRX,
+      durationSeconds,
+      extraTrx,
     }),
   ]);
 

--- a/libs/coin-modules/coin-tron/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-tron/src/logic/estimateFees.ts
@@ -322,9 +322,9 @@ const withBreakdown = (value: bigint, breakdown: TronResourceBreakdown): FeeEsti
   parameters: { ...breakdown },
 });
 
-// 10-min fastTrade window; aligns with SPONSORED_RENTAL_DURATION_SECONDS in bridge/getEstimateFees.ts
+// 10-min fastTrade window matching the UI's fee-quote TTL
 const TRONIFY_RENTAL_DURATION_SECONDS = 600;
-// Bandwidth top-up Tronify bundles; aligns with SPONSORED_RENTAL_EXTRA_TRX in bridge/getEstimateFees.ts
+// Bandwidth top-up Tronify bundles with each rental to cover the transaction's bandwidth cost
 const TRONIFY_RENTAL_EXTRA_TRX = 0.8;
 
 /**
@@ -348,7 +348,8 @@ export async function estimateTronifyFees(
   const energyNeeded = await estimateEnergy(config, intent);
 
   // computeFeesRaw does not catch — any chain-params failure propagates here (no silent fallback
-  // on originalValue, per ADR-050 Option 3). Run in parallel with the Tronify quote.
+  // on originalValue, per ADR-050 Option 3). Both calls are independent once energyNeeded is
+  // known, so they run in parallel to keep pricing latency minimal.
   // getEnergyRentQuote resolves its provider through the coinConfig singleton (not `config`); this
   // is the shared design of the energyRent module — the provider is selected via remote coin-config.
   const [originalValue, quote] = await Promise.all([

--- a/libs/coin-modules/coin-tron/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-tron/src/logic/estimateFees.ts
@@ -415,10 +415,13 @@ export async function estimateTronifyFees(
   ]);
 
   // Only TRX-denominated quotes are supported here. USDT-denominated rent (Flow 2) carries amounts
-  // in a different unit than the standard fee and requires separate handling.
-  if (quote.payCoinCode.toUpperCase() !== "TRX") {
+  // in a different unit than the standard fee and requires separate handling. payCoinCode is an
+  // unvalidated API field (typed string, but a missing/non-string value would make toUpperCase()
+  // throw an opaque TypeError) — guard it so a bad response yields the clear error below.
+  const payCoinCode = quote.payCoinCode;
+  if (typeof payCoinCode !== "string" || payCoinCode.toUpperCase() !== "TRX") {
     throw new Error(
-      `Tronify returned unsupported payCoinCode: ${quote.payCoinCode}; only TRX is supported`,
+      `Tronify returned unsupported payCoinCode: ${String(payCoinCode)}; only TRX is supported`,
     );
   }
 

--- a/libs/coin-modules/coin-tron/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-tron/src/logic/estimateFees.ts
@@ -359,6 +359,13 @@ export async function estimateTronifyFees(
     throw new Error("Tronify fee option is only available for TRC-20 send intents");
   }
 
+  // prepareTransaction re-estimates on every change, so this can run before a recipient is entered.
+  // Guard explicitly: estimateEnergy would otherwise reach decode58Check("") and throw an opaque
+  // bs58check error instead of a clear one (no silent fallback, per ADR-050 Option 3).
+  if (!intent.recipient) {
+    throw new Error("Tronify fee estimation requires a recipient");
+  }
+
   // Single energy simulation; result feeds both the standard burn calc and the Tronify quote.
   const energyNeeded = await estimateEnergy(config, intent);
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

- Add `estimateTronifyFees` to `logic/estimateFees.ts`: calls the Tronify quote API and returns a `FeeEstimation` with `value` (rental cost in SUN), `originalValue` (standard burn for comparison), and `savings` (clamped to `0n`)
- Extract internal `computeFeesRaw` helper so both `estimateFees` and `estimateTronifyFees` share one energy simulation call — no double `triggerConstantContract` RPC
- Wire the Tronify path in `api/index.ts` behind `feeOptionId: TRONIFY_FEE_OPTION_ID` via `EstimateFeesOptions`; standard path is completely unchanged (bridge layer compat preserved)
- Export `TRONIFY_FEE_OPTION_ID = "tronify" as const` for compile-time safety at call sites
- Errors from Tronify (API failures, chain-params failure, wrong `payCoinCode`) propagate without fallback — per ADR-050 Option 3

## Dependencies

 **Blocked on** [LedgerHQ/coin-modules#810](https://github.com/LedgerHQ/coin-modules/pull/810) — adds `originalValue?` / `savings?` to `FeeEstimation` in `@ledgerhq/coin-module-framework`.
After that merges and publishes, bump `pnpm-workspace.yaml`:
`"@ledgerhq/coin-module-framework": 8.1.0` + `pnpm install`, then mark this PR ready.

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 --> [LIVE-34999](https://ledgerhq.atlassian.net/browse/LIVE-34999) / parent epic [LIVE-34992](https://ledgerhq.atlassian.net/browse/LIVE-34992)
- **ADR** (if any): <!-- link to the relevant architectural decision record --> [ADR-050](https://ledgerhq.atlassian.net/wiki/spaces/CF/pages/7341375672/)
