### PR TITLE
[LWD] fix(onboarding): skip app listing on unseeded ESC update (LIVE-36215)

### DIFF
--- a/.changeset/fix-esc-unseeded-firmware-drawer.md
+++ b/.changeset/fix-esc-unseeded-firmware-drawer.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Skip installed-app listing before the ESC firmware update drawer on unseeded devices (LIVE-36215)

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/firmwareUpdateAppsRestore.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/firmwareUpdateAppsRestore.test.ts
@@ -35,6 +35,33 @@ describe("resolveInstalledAppsForFirmwareUpdate", () => {
       type: "needsListing",
     });
   });
+
+  it("returns empty apps without listing when the device is not onboarded", () => {
+    expect(
+      resolveInstalledAppsForFirmwareUpdate([], undefined, {
+        onboarded: false,
+        isRecoveryMode: false,
+      }),
+    ).toEqual({ type: "ready", installed: [] });
+  });
+
+  it("returns needsListing when the device is onboarded", () => {
+    expect(
+      resolveInstalledAppsForFirmwareUpdate([], undefined, {
+        onboarded: true,
+        isRecoveryMode: false,
+      }),
+    ).toEqual({ type: "needsListing" });
+  });
+
+  it("returns needsListing when the device is in recovery mode", () => {
+    expect(
+      resolveInstalledAppsForFirmwareUpdate([], undefined, {
+        onboarded: false,
+        isRecoveryMode: true,
+      }),
+    ).toEqual({ type: "needsListing" });
+  });
 });
 
 describe("resolveListedAppsListingEffect", () => {

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/firmwareUpdateAppsRestore.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/firmwareUpdateAppsRestore.ts
@@ -1,13 +1,27 @@
 import type { InstalledItem } from "@ledgerhq/live-common/apps/types";
+import type { DeviceInfo } from "@ledgerhq/types-live";
 
 export type InstalledAppsResolution =
   | { type: "ready"; installed: readonly InstalledItem[] }
   | { type: "needsListing" };
 
+type FirmwareUpdateListingDeviceInfo = Pick<DeviceInfo, "onboarded" | "isRecoveryMode">;
+
+function canListInstalledAppsForFirmwareUpdate(
+  deviceInfo?: FirmwareUpdateListingDeviceInfo | null,
+): boolean {
+  if (!deviceInfo) return true;
+  return Boolean(deviceInfo.onboarded || deviceInfo.isRecoveryMode);
+}
+
 export function resolveInstalledAppsForFirmwareUpdate(
   cachedInstalled: readonly InstalledItem[],
   listedInstalled: readonly InstalledItem[] | undefined,
+  deviceInfo?: FirmwareUpdateListingDeviceInfo | null,
 ): InstalledAppsResolution {
+  if (!canListInstalledAppsForFirmwareUpdate(deviceInfo)) {
+    return { type: "ready", installed: [] };
+  }
   if (cachedInstalled.length > 0) {
     return { type: "ready", installed: cachedInstalled };
   }

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Flex, Popin } from "@ledgerhq/react-ui";
 import manager from "@ledgerhq/live-common/manager/index";
 import type { InstalledItem } from "@ledgerhq/live-common/apps/types";
@@ -140,10 +140,11 @@ const EarlySecurityChecks = ({
   const [completionLoading, setCompletionLoading] = useState(false);
   const [shouldListInstalledApps, setShouldListInstalledApps] = useState(false);
   const managerAction = useConnectManagerAction();
-  const listAppsState = managerAction.useHook(
-    device,
-    shouldListInstalledApps ? {} : { cancelExecution: true },
+  const listInstalledAppsRequest = useMemo(
+    () => (shouldListInstalledApps ? {} : { cancelExecution: true }),
+    [shouldListInstalledApps],
   );
+  const listAppsState = managerAction.useHook(device, listInstalledAppsRequest);
   const { result: listedAppsResult, isLoading: isListingInstalledApps } = listAppsState;
   const isAllowManagerOpen =
     shouldListInstalledApps &&
@@ -264,6 +265,7 @@ const EarlySecurityChecks = ({
     const installedAppsResolution = resolveInstalledAppsForFirmwareUpdate(
       installedAppsRef.current,
       listedAppsResult?.installed,
+      deviceInfo,
     );
     if (installedAppsResolution.type === "ready") {
       openFirmwareUpdateDrawer(installedAppsResolution.installed);
@@ -271,7 +273,7 @@ const EarlySecurityChecks = ({
     }
 
     setShouldListInstalledApps(true);
-  }, [listedAppsResult?.installed, openFirmwareUpdateDrawer]);
+  }, [deviceInfo, listedAppsResult?.installed, openFirmwareUpdateDrawer]);
 
   useEffect(() => {
     const listingEffect = resolveListedAppsListingEffect(


### PR DESCRIPTION
## Summary
- Fixes a 4.17 release blocker: on an unseeded touchscreen device with an available OS update, Early Security Checks listed installed apps via `connectManager` before opening the firmware drawer. That always fails with `DeviceNotOnboarded` and, with an unstable manager request, loops so the update drawer never opens.
- Unseeded / non-recovery devices now open `UpdateFirmwareModal` with an empty app list. Seeded and recovery devices still list apps so they can be restored after the update.
- Memoizes the manager request so listing cannot restart on every render.

Ticket: [LIVE-36215](https://ledgerhq.atlassian.net/browse/LIVE-36215)

## Test plan
- [ ] LWD 4.17 candidate, unseeded Stax / Flex / Nano Gen 5, OS not latest
- [ ] Sync onboarding → ESC shows Update … OS → click it
- [ ] Firmware update proposal drawer opens; no spinner / connectManager loop
- [ ] Seeded outdated device still lists apps and can restore them after the update

[LIVE-36215]: https://ledgerhq.atlassian.net/browse/LIVE-36215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ