### PR TITLE
ci(merge-queue): add static-only merge queue gate workflow

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -1,7 +1,5 @@
 name: "[All Platforms] - Build and Test - PR"
 on:
-  merge_group:
-    types: [checks_requested]
   pull_request: ~
 
 concurrency:
@@ -46,8 +44,8 @@ jobs:
     if: ${{!github.event.pull_request.head.repo.fork && needs.pre_job.outputs.should_skip != 'true'}}
     uses: LedgerHQ/ledger-live/.github/workflows/nx-affected-reusable.yml@develop
     with:
-      head_branch: ${{ github.event.pull_request.head.ref || github.event.merge_group.head_ref }}
-      base_branch: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+      head_branch: ${{ github.event.pull_request.head.ref }}
+      base_branch: ${{ github.event.pull_request.base.ref }}
 
   # LLD
   build-desktop:

--- a/.github/workflows/build-desktop-reusable.yml
+++ b/.github/workflows/build-desktop-reusable.yml
@@ -2,6 +2,17 @@ name: "[Desktop] - Build - Called"
 
 on:
   workflow_call:
+    inputs:
+      linux-only:
+        description: "Build Linux only, skipping the Windows and macOS matrix entries."
+        type: boolean
+        required: false
+        default: false
+      skip-artifact-upload:
+        description: "Skip uploading the built app and bundle metafiles. Set at the merge gate, where the Report job does not run and nothing consumes them."
+        type: boolean
+        required: false
+        default: false
     secrets:
       AWS_ACCOUNT_ID_PROD:
         required: true
@@ -48,12 +59,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config:
-          [
-            { name: "Linux", os: "ledger-live-linux-8CPU-32RAM", image: "linux-x86_64.AppImage", output-name: "linux" },
-            { name: "Windows", os: "windows-2022", dotnet: true, image: "win-x64.exe", output-name: "win" },
-            { name: "macOS", os: "macos-14", image: "mac.dmg", output-name: "mac" },
-          ]
+        config: >-
+          ${{ fromJSON(inputs.linux-only
+          && '[{"name":"Linux","os":"ledger-live-linux-8CPU-32RAM","image":"linux-x86_64.AppImage","output-name":"linux"}]'
+          || '[{"name":"Linux","os":"ledger-live-linux-8CPU-32RAM","image":"linux-x86_64.AppImage","output-name":"linux"},{"name":"Windows","os":"windows-2022","dotnet":true,"image":"win-x64.exe","output-name":"win"},{"name":"macOS","os":"macos-14","image":"mac.dmg","output-name":"mac"}]') }}
     name: "${{ matrix.config.name }} Build"
     runs-on: ${{ matrix.config.os }}
     timeout-minutes: 20
@@ -105,6 +114,7 @@ jobs:
         run: pnpm exec nx run ledger-live-desktop:build
 
       - name: Upload ${{ matrix.config.name }} app
+        if: ${{ !inputs.skip-artifact-upload }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: ${{ steps.build-desktop.outputs.version }}-${{ matrix.config.image }}
@@ -112,7 +122,7 @@ jobs:
 
       - name: Upload bundle metafiles
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && !inputs.skip-artifact-upload }}
         with:
           name: ${{ matrix.config.output-name }}-js-bundle-metafiles
           path: ${{ github.workspace }}/apps/ledger-live-desktop/metafile.*

--- a/.github/workflows/build-wallet-cli-reusable.yml
+++ b/.github/workflows/build-wallet-cli-reusable.yml
@@ -67,7 +67,7 @@ jobs:
         run: pnpm i --filter "@ledgerhq/wallet-cli..." --filter "ledger-live"
 
       - name: format check wallet-cli
-        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || github.event_name == 'workflow_dispatch'
+        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
         run: pnpm exec nx run @ledgerhq/wallet-cli:format:check
 
       - name: Build, lint, typecheck and test wallet-cli

--- a/.github/workflows/build-web-tools-reusable.yml
+++ b/.github/workflows/build-web-tools-reusable.yml
@@ -119,7 +119,7 @@ jobs:
           production: ${{ inputs.vercel-production }}
 
       - name: Check formatting web-tools
-        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || github.event_name == 'workflow_dispatch'
+        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
         uses: LedgerHQ/ledger-live/tools/actions/composites/nx-step@develop
         with:
           command: pnpm exec nx run @ledgerhq/web-tools:format:check

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -1,0 +1,275 @@
+name: "[All Platforms] - Merge Queue Gate"
+
+# Tier 2 of the PR staleness ADR. The gate answers one question: does the merged base still
+# lint, format, typecheck and compile? Nothing here executes product code, so no test flake can
+# re-queue a group, and every failure reproduces locally on the first attempt. Unit tests, e2e,
+# mock, builds and Sonar still run on every PR in build-and-test-pr.yml.
+
+on:
+  merge_group:
+    types: [checks_requested]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  determine-affected:
+    name: "Affected"
+    uses: LedgerHQ/ledger-live/.github/workflows/nx-affected-reusable.yml@develop
+    with:
+      head_branch: ${{ github.event.merge_group.head_ref }}
+      base_branch: ${{ github.event.merge_group.base_ref }}
+
+  build-desktop:
+    name: "Build Desktop (Linux)"
+    permissions:
+      id-token: write
+      contents: read
+    needs: determine-affected
+    if: ${{ contains(needs.determine-affected.outputs.paths, 'ledger-live-desktop') }}
+    uses: LedgerHQ/ledger-live/.github/workflows/build-desktop-reusable.yml@develop
+    secrets:
+      AWS_ACCOUNT_ID_PROD: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
+      AWS_CACHE_OIDC_ROLE_ARN_BRANCH: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_BRANCH }}
+      AWS_CACHE_OIDC_ROLE_ARN_DEVELOP: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
+      AWS_CACHE_REGION: ${{ secrets.AWS_CACHE_REGION }}
+      AWS_CACHE_ROLE_NAME: ${{ secrets.AWS_CACHE_ROLE_NAME }}
+      GH_BOT_CLIENT_ID: ${{ secrets.GH_BOT_CLIENT_ID }}
+      GH_BOT_PRIVATE_KEY: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+      NX_KEY: ${{ secrets.NX_KEY }}
+    with:
+      linux-only: true
+      skip-artifact-upload: true
+
+  codecheck-desktop:
+    name: "Codecheck Desktop"
+    permissions:
+      id-token: write
+      contents: read
+    needs: determine-affected
+    if: ${{ contains(needs.determine-affected.outputs.paths, 'ledger-live-desktop') }}
+    uses: LedgerHQ/ledger-live/.github/workflows/test-desktop-codechecks-reusable.yml@develop
+    secrets:
+      AWS_ACCOUNT_ID_PROD: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
+      AWS_CACHE_OIDC_ROLE_ARN_BRANCH: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_BRANCH }}
+      AWS_CACHE_OIDC_ROLE_ARN_DEVELOP: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
+      AWS_CACHE_REGION: ${{ secrets.AWS_CACHE_REGION }}
+      AWS_CACHE_ROLE_NAME: ${{ secrets.AWS_CACHE_ROLE_NAME }}
+      NX_KEY: ${{ secrets.NX_KEY }}
+      SLACK_LIVE_CI_BOT_TOKEN: ${{ secrets.SLACK_LIVE_CI_BOT_TOKEN }}
+    with:
+      skip-unit-tests: true
+
+  test-mobile:
+    name: "Codecheck Mobile"
+    permissions:
+      id-token: write
+      contents: read
+    needs: determine-affected
+    if: ${{ contains(needs.determine-affected.outputs.paths, 'ledger-live-mobile') }}
+    uses: LedgerHQ/ledger-live/.github/workflows/test-mobile-reusable.yml@develop
+    secrets:
+      AWS_ACCOUNT_ID_PROD: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
+      AWS_CACHE_OIDC_ROLE_ARN_BRANCH: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_BRANCH }}
+      AWS_CACHE_OIDC_ROLE_ARN_DEVELOP: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
+      AWS_CACHE_REGION: ${{ secrets.AWS_CACHE_REGION }}
+      AWS_CACHE_ROLE_NAME: ${{ secrets.AWS_CACHE_ROLE_NAME }}
+      NX_KEY: ${{ secrets.NX_KEY }}
+    with:
+      skip-unit-tests: true
+
+  test-libraries:
+    name: "Codecheck Libraries"
+    permissions:
+      id-token: write
+      contents: read
+    needs: determine-affected
+    if: ${{ contains(needs.determine-affected.outputs.paths, 'libs') }}
+    uses: LedgerHQ/ledger-live/.github/workflows/test-libs-reusable.yml@develop
+    secrets:
+      AWS_ACCOUNT_ID_PROD: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
+      AWS_CACHE_OIDC_ROLE_ARN_BRANCH: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_BRANCH }}
+      AWS_CACHE_OIDC_ROLE_ARN_DEVELOP: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
+      AWS_CACHE_REGION: ${{ secrets.AWS_CACHE_REGION }}
+      AWS_CACHE_ROLE_NAME: ${{ secrets.AWS_CACHE_ROLE_NAME }}
+      NX_KEY: ${{ secrets.NX_KEY }}
+    with:
+      skip-unit-tests: true
+
+  test-features:
+    name: "Codecheck Features"
+    permissions:
+      id-token: write
+      contents: read
+    needs: determine-affected
+    if: ${{ contains(needs.determine-affected.outputs.paths, 'features') }}
+    uses: LedgerHQ/ledger-live/.github/workflows/test-features-reusable.yml@develop
+    secrets:
+      AWS_ACCOUNT_ID_PROD: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
+      AWS_CACHE_OIDC_ROLE_ARN_BRANCH: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_BRANCH }}
+      AWS_CACHE_OIDC_ROLE_ARN_DEVELOP: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
+      AWS_CACHE_REGION: ${{ secrets.AWS_CACHE_REGION }}
+      AWS_CACHE_ROLE_NAME: ${{ secrets.AWS_CACHE_ROLE_NAME }}
+      NX_KEY: ${{ secrets.NX_KEY }}
+    with:
+      skip-coverage: true
+
+  test-shared:
+    name: "Codecheck Shared"
+    permissions:
+      id-token: write
+      contents: read
+    needs: determine-affected
+    if: ${{ contains(needs.determine-affected.outputs.paths, 'shared') }}
+    uses: LedgerHQ/ledger-live/.github/workflows/test-shared-reusable.yml@develop
+    secrets:
+      AWS_ACCOUNT_ID_PROD: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
+      AWS_CACHE_OIDC_ROLE_ARN_BRANCH: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_BRANCH }}
+      AWS_CACHE_OIDC_ROLE_ARN_DEVELOP: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
+      AWS_CACHE_REGION: ${{ secrets.AWS_CACHE_REGION }}
+      AWS_CACHE_ROLE_NAME: ${{ secrets.AWS_CACHE_ROLE_NAME }}
+      NX_KEY: ${{ secrets.NX_KEY }}
+    with:
+      skip-coverage: true
+
+  test-domain:
+    name: "Codecheck Domain"
+    permissions:
+      id-token: write
+      contents: read
+    needs: determine-affected
+    if: ${{ contains(needs.determine-affected.outputs.paths, 'domain') }}
+    uses: LedgerHQ/ledger-live/.github/workflows/test-domain-reusable.yml@develop
+    secrets:
+      AWS_ACCOUNT_ID_PROD: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
+      AWS_CACHE_OIDC_ROLE_ARN_BRANCH: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_BRANCH }}
+      AWS_CACHE_OIDC_ROLE_ARN_DEVELOP: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
+      AWS_CACHE_REGION: ${{ secrets.AWS_CACHE_REGION }}
+      AWS_CACHE_ROLE_NAME: ${{ secrets.AWS_CACHE_ROLE_NAME }}
+      NX_KEY: ${{ secrets.NX_KEY }}
+    with:
+      skip-coverage: true
+
+  test-devtools:
+    name: "Codecheck DevTools"
+    permissions:
+      id-token: write
+      contents: read
+    needs: determine-affected
+    if: ${{ contains(needs.determine-affected.outputs.paths, 'devtools') }}
+    uses: LedgerHQ/ledger-live/.github/workflows/test-devtools-reusable.yml@develop
+    secrets:
+      AWS_ACCOUNT_ID_PROD: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
+      AWS_CACHE_OIDC_ROLE_ARN_BRANCH: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_BRANCH }}
+      AWS_CACHE_OIDC_ROLE_ARN_DEVELOP: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
+      AWS_CACHE_REGION: ${{ secrets.AWS_CACHE_REGION }}
+      AWS_CACHE_ROLE_NAME: ${{ secrets.AWS_CACHE_ROLE_NAME }}
+      NX_KEY: ${{ secrets.NX_KEY }}
+    with:
+      skip-coverage: true
+
+  test-support:
+    name: "Codecheck Support"
+    permissions:
+      id-token: write
+      contents: read
+    needs: determine-affected
+    if: ${{ contains(needs.determine-affected.outputs.paths, 'support') }}
+    uses: LedgerHQ/ledger-live/.github/workflows/test-support-reusable.yml@develop
+    secrets:
+      AWS_ACCOUNT_ID_PROD: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
+      AWS_CACHE_OIDC_ROLE_ARN_BRANCH: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_BRANCH }}
+      AWS_CACHE_OIDC_ROLE_ARN_DEVELOP: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
+      AWS_CACHE_REGION: ${{ secrets.AWS_CACHE_REGION }}
+      AWS_CACHE_ROLE_NAME: ${{ secrets.AWS_CACHE_ROLE_NAME }}
+      NX_KEY: ${{ secrets.NX_KEY }}
+    with:
+      skip-coverage: true
+
+  enforce-boundaries:
+    name: "Enforce Module Boundaries"
+    permissions:
+      id-token: write
+      contents: read
+    needs: determine-affected
+    if: ${{ contains(needs.determine-affected.outputs.paths, 'domain') || contains(needs.determine-affected.outputs.paths, 'shared') || contains(needs.determine-affected.outputs.paths, 'features') }}
+    uses: LedgerHQ/ledger-live/.github/workflows/test-boundaries-reusable.yml@develop
+    secrets:
+      AWS_ACCOUNT_ID_PROD: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
+      AWS_CACHE_OIDC_ROLE_ARN_BRANCH: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_BRANCH }}
+      AWS_CACHE_OIDC_ROLE_ARN_DEVELOP: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
+      AWS_CACHE_REGION: ${{ secrets.AWS_CACHE_REGION }}
+      AWS_CACHE_ROLE_NAME: ${{ secrets.AWS_CACHE_ROLE_NAME }}
+      NX_KEY: ${{ secrets.NX_KEY }}
+
+  test-additional:
+    name: "Additional Checks"
+    permissions:
+      contents: read
+    uses: LedgerHQ/ledger-live/.github/workflows/test-additional.yml@develop
+    with:
+      skip-ci-sast: true
+
+  test-mobile-e2e-lint:
+    name: "Mobile E2E Lint & Typecheck"
+    permissions:
+      id-token: write
+      contents: read
+    needs: determine-affected
+    if: ${{ contains(needs.determine-affected.outputs.paths, 'e2e/mobile') || contains(needs.determine-affected.outputs.paths, 'apps/ledger-live-mobile') }}
+    uses: LedgerHQ/ledger-live/.github/workflows/test-mobile-e2e-lint-reusable.yml@develop
+    secrets:
+      AWS_ACCOUNT_ID_PROD: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
+      AWS_CACHE_OIDC_ROLE_ARN_BRANCH: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_BRANCH }}
+      AWS_CACHE_OIDC_ROLE_ARN_DEVELOP: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
+      AWS_CACHE_REGION: ${{ secrets.AWS_CACHE_REGION }}
+      AWS_CACHE_ROLE_NAME: ${{ secrets.AWS_CACHE_ROLE_NAME }}
+      NX_KEY: ${{ secrets.NX_KEY }}
+
+  test-desktop-e2e-lint:
+    name: "Desktop E2E Lint & Typecheck"
+    permissions:
+      id-token: write
+      contents: read
+    needs: determine-affected
+    if: ${{ contains(needs.determine-affected.outputs.paths, 'e2e/desktop') }}
+    uses: LedgerHQ/ledger-live/.github/workflows/test-desktop-e2e-lint-reusable.yml@develop
+    secrets:
+      AWS_ACCOUNT_ID_PROD: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
+      AWS_CACHE_OIDC_ROLE_ARN_BRANCH: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_BRANCH }}
+      AWS_CACHE_OIDC_ROLE_ARN_DEVELOP: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
+      AWS_CACHE_REGION: ${{ secrets.AWS_CACHE_REGION }}
+      AWS_CACHE_ROLE_NAME: ${{ secrets.AWS_CACHE_ROLE_NAME }}
+      NX_KEY: ${{ secrets.NX_KEY }}
+
+  # Final Check required
+  ok:
+    name: "OK"
+    needs:
+      - determine-affected
+      - build-desktop
+      - codecheck-desktop
+      - test-mobile
+      - test-libraries
+      - test-features
+      - test-shared
+      - test-domain
+      - test-devtools
+      - test-support
+      - enforce-boundaries
+      - test-additional
+      - test-mobile-e2e-lint
+      - test-desktop-e2e-lint
+    runs-on: ubuntu-22.04
+    # always(), never !cancelled(): a required check that reports nothing holds the merge group
+    # open until check_response_timeout_minutes and then fails it. Reporting a failure is cheaper
+    # than reporting nothing.
+    if: always()
+    steps:
+      - name: Check result
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/test-additional.yml
+++ b/.github/workflows/test-additional.yml
@@ -2,6 +2,13 @@ name: "[CI] - Additional Tests - Called"
 
 on:
   workflow_call:
+    inputs:
+      skip-ci-sast:
+        description: "Skip workflow-file SAST. Set at the merge gate, which has no pull request to diff against."
+        type: boolean
+        required: false
+        default: false
+
   workflow_dispatch:
     inputs:
       ref:
@@ -38,6 +45,7 @@ jobs:
 
   changes:
     name: Detect Workflow File Changes
+    if: ${{ !inputs.skip-ci-sast }}
     runs-on: ubuntu-24.04
     outputs:
       workflow-files: ${{ steps.filter.outputs.workflow-files }}

--- a/.github/workflows/test-cli-reusable.yml
+++ b/.github/workflows/test-cli-reusable.yml
@@ -61,7 +61,7 @@ jobs:
       - name: build cli
         run: pnpm exec nx run @ledgerhq/live-cli:build
       - name: format check cli
-        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || github.event_name == 'workflow_dispatch'
+        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
         run: pnpm exec nx run @ledgerhq/live-cli:format:check
       - name: lint cli
         run: pnpm exec nx run @ledgerhq/live-cli:lint -- --quiet

--- a/.github/workflows/test-desktop-codechecks-reusable.yml
+++ b/.github/workflows/test-desktop-codechecks-reusable.yml
@@ -2,6 +2,13 @@ name: "[Desktop] - Lint & Unit Tests - Called"
 
 on:
   workflow_call:
+    inputs:
+      skip-unit-tests:
+        description: "Skip the unit test job. Set at the merge gate, where no product code executes."
+        type: boolean
+        required: false
+        default: false
+
     outputs:
       coverage_generated:
         value: ${{ jobs.unit-tests.outputs.coverage_generated }}
@@ -85,7 +92,7 @@ jobs:
           skip_builds: true
 
       - name: format check
-        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || github.event_name == 'workflow_dispatch'
+        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
         run: pnpm desktop format:check
 
       - name: lint
@@ -102,6 +109,7 @@ jobs:
 
   unit-tests:
     name: "Desktop Unit Tests"
+    if: ${{ !inputs.skip-unit-tests }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/test-desktop-e2e-lint-reusable.yml
+++ b/.github/workflows/test-desktop-e2e-lint-reusable.yml
@@ -49,7 +49,7 @@ jobs:
         run: pnpm i --filter="ledger-live-desktop-e2e-tests..." --filter="ledger-live-desktop..." --no-frozen-lockfile --unsafe-perm
 
       - name: Run format check
-        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop'
+        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || github.event_name == 'merge_group'
         run: pnpm exec nx run ledger-live-desktop-e2e-tests:format:check
 
       - name: Run lint and typecheck

--- a/.github/workflows/test-devtools-reusable.yml
+++ b/.github/workflows/test-devtools-reusable.yml
@@ -2,6 +2,13 @@ name: "[DevTools] - Test - Called"
 
 on:
   workflow_call:
+    inputs:
+      skip-coverage:
+        description: "Skip coverage and run codechecks only. Set at the merge gate, where no product code executes."
+        type: boolean
+        required: false
+        default: false
+
     outputs:
       coverage_generated:
         value: ${{ jobs.test-devtools.outputs.coverage_generated }}
@@ -46,3 +53,4 @@ jobs:
     with:
       scope: devtools
       ref: ${{ inputs.ref || github.sha }}
+      skip-coverage: ${{ inputs.skip-coverage || false }}

--- a/.github/workflows/test-domain-reusable.yml
+++ b/.github/workflows/test-domain-reusable.yml
@@ -2,6 +2,13 @@ name: "[Domain] - Test - Called"
 
 on:
   workflow_call:
+    inputs:
+      skip-coverage:
+        description: "Skip coverage and run codechecks only. Set at the merge gate, where no product code executes."
+        type: boolean
+        required: false
+        default: false
+
     outputs:
       coverage_generated:
         value: ${{ jobs.test-domain.outputs.coverage_generated }}
@@ -47,3 +54,4 @@ jobs:
       scope: domain
       extra-targets: check-export-rules
       ref: ${{ inputs.ref || github.sha }}
+      skip-coverage: ${{ inputs.skip-coverage || false }}

--- a/.github/workflows/test-features-reusable.yml
+++ b/.github/workflows/test-features-reusable.yml
@@ -2,6 +2,13 @@ name: "[Features] - Test - Called"
 
 on:
   workflow_call:
+    inputs:
+      skip-coverage:
+        description: "Skip coverage and run codechecks only. Set at the merge gate, where no product code executes."
+        type: boolean
+        required: false
+        default: false
+
     outputs:
       coverage_generated:
         value: ${{ jobs.test-features.outputs.coverage_generated }}
@@ -47,3 +54,4 @@ jobs:
       scope: features
       timeout-minutes: 20
       ref: ${{ inputs.ref || github.sha }}
+      skip-coverage: ${{ inputs.skip-coverage || false }}

--- a/.github/workflows/test-libs-reusable.yml
+++ b/.github/workflows/test-libs-reusable.yml
@@ -2,6 +2,13 @@ name: "[Libraries] - Test - Called"
 
 on:
   workflow_call:
+    inputs:
+      skip-unit-tests:
+        description: "Skip the unit test job. Set at the merge gate, where no product code executes."
+        type: boolean
+        required: false
+        default: false
+
     outputs:
       coverage_generated:
         value: ${{ jobs.test-libraries.outputs.coverage_generated }}
@@ -43,6 +50,7 @@ permissions:
 jobs:
   test-libraries:
     name: "Libraries Test"
+    if: ${{ !inputs.skip-unit-tests }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/test-mobile-e2e-lint-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-lint-reusable.yml
@@ -49,7 +49,7 @@ jobs:
         run: pnpm i --filter="ledger-live-mobile-e2e-tests..." --no-frozen-lockfile --unsafe-perm
 
       - name: Run format check
-        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop'
+        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || github.event_name == 'merge_group'
         run: pnpm exec nx run ledger-live-mobile-e2e-tests:format:check
 
       - name: Run lint and typecheck

--- a/.github/workflows/test-mobile-reusable.yml
+++ b/.github/workflows/test-mobile-reusable.yml
@@ -2,6 +2,13 @@ name: "[Mobile] - Code Check - Called"
 
 on:
   workflow_call:
+    inputs:
+      skip-unit-tests:
+        description: "Skip the unit test job. Set at the merge gate, where no product code executes."
+        type: boolean
+        required: false
+        default: false
+
     outputs:
       coverage_generated:
         value: ${{ jobs.unit-tests.outputs.coverage_generated }}
@@ -77,7 +84,7 @@ jobs:
         run: pnpm i --filter="live-mobile..." --filter="ledger-live" --no-frozen-lockfile --unsafe-perm
 
       - name: Run format check
-        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || github.event_name == 'workflow_dispatch'
+        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
         run: pnpm exec nx run live-mobile:format:check
 
       - name: Run linter
@@ -95,6 +102,7 @@ jobs:
 
   unit-tests:
     name: "Mobile Unit Tests"
+    if: ${{ !inputs.skip-unit-tests }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/test-scope-reusable.yml
+++ b/.github/workflows/test-scope-reusable.yml
@@ -21,6 +21,11 @@ on:
         description: "Ref to check out. Defaults to github.sha."
         type: string
         required: false
+      skip-coverage:
+        description: "Skip coverage and run codechecks only. Set at the merge gate, where no product code executes."
+        type: boolean
+        required: false
+        default: false
 
     outputs:
       coverage_generated:
@@ -94,6 +99,7 @@ jobs:
         shell: bash
 
       - name: Run coverage
+        if: ${{ !inputs.skip-coverage }}
         env:
           SCOPE: ${{ inputs.scope }}
         run: |
@@ -105,6 +111,7 @@ jobs:
         shell: bash
 
       - name: Process coverage files
+        if: ${{ !inputs.skip-coverage }}
         id: process-coverage
         env:
           SCOPE: ${{ inputs.scope }}
@@ -132,7 +139,7 @@ jobs:
           parallel: "4"
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && !inputs.skip-coverage }}
         id: generate_coverage
         with:
           name: coverage-${{ inputs.scope }}

--- a/.github/workflows/test-shared-reusable.yml
+++ b/.github/workflows/test-shared-reusable.yml
@@ -2,6 +2,13 @@ name: "[Shared] - Test - Called"
 
 on:
   workflow_call:
+    inputs:
+      skip-coverage:
+        description: "Skip coverage and run codechecks only. Set at the merge gate, where no product code executes."
+        type: boolean
+        required: false
+        default: false
+
     outputs:
       coverage_generated:
         value: ${{ jobs.test-shared.outputs.coverage_generated }}
@@ -46,3 +53,4 @@ jobs:
     with:
       scope: shared
       ref: ${{ inputs.ref || github.sha }}
+      skip-coverage: ${{ inputs.skip-coverage || false }}

--- a/.github/workflows/test-support-reusable.yml
+++ b/.github/workflows/test-support-reusable.yml
@@ -2,6 +2,13 @@ name: "[Support] - Test - Called"
 
 on:
   workflow_call:
+    inputs:
+      skip-coverage:
+        description: "Skip coverage and run codechecks only. Set at the merge gate, where no product code executes."
+        type: boolean
+        required: false
+        default: false
+
     outputs:
       coverage_generated:
         value: ${{ jobs.test-support.outputs.coverage_generated }}
@@ -46,3 +53,4 @@ jobs:
     with:
       scope: support
       ref: ${{ inputs.ref || github.sha }}
+      skip-coverage: ${{ inputs.skip-coverage || false }}

--- a/tools/actions/composites/nx-codechecks/action.yml
+++ b/tools/actions/composites/nx-codechecks/action.yml
@@ -19,7 +19,7 @@ runs:
   steps:
     - name: Check formatting
       id: format-check
-      if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || github.event_name == 'workflow_dispatch'
+      if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
       run: pnpm exec nx run-many -t format:check --projects="$PROJECTS" --parallel="$PARALLEL" --nxBail=false
       shell: bash
       env:


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Groundwork for the Option 4 static-only merge queue gate (ADR: PR Staleness). No behaviour change: every input is negatively named and defaults to false, so an unset input - including on workflow_dispatch, where workflow_call inputs do not exist - keeps today's behaviour.

- skip-unit-tests on the desktop codechecks, mobile and libs reusables
- skip-coverage on test-scope-reusable, plumbed through the five scope wrappers
- skip-ci-sast on test-additional
- linux-only on build-desktop-reusable, which had no workflow_call inputs at all

Also widen the eight format:check conditions to recognise merge_group. In a merge group github.base_ref is unset and github.ref is a gh-readonly-queue ref, so every format check silently skipped. The eighth site is the nx-codechecks composite, which feeds Libraries Codecheck and all five scope lanes.

Note: Inactive until enabled on repo rules. **PR aim is no-op** and merge changes to aid in MQ testing

### 🔗 Context

ADR: https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/7406780552/ADR+PR+Staleness
Test run: https://github.com/LedgerHQ/ledger-live/actions/runs/32251467137 (note - PR check - should just run identical tasks to current PR flow)
