### PR TITLE
[LWD] feat(pay-card-request): show branded QrCode on receive (LIVE-36233)

### DIFF
--- a/.changeset/kind-foxes-attend.md
+++ b/.changeset/kind-foxes-attend.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-pay-card-request": minor
+"ledger-live-desktop": minor
+---
+
+Show a branded `QrCode` (asset icon in the center) on Pay Card request receive (LIVE-36233).

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -206,7 +206,7 @@
     "lodash": "catalog:",
     "prando": "5.1.2",
     "prop-types": "15.8.1",
-    "qrcode": "1.5.3",
+    "qrcode": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-easy-crop": "4.7.5",

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabRequestReceive.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabRequestReceive.ts
@@ -52,7 +52,11 @@ export function usePayTabRequestReceive(
       network: STUB_NETWORK,
       page: REQUEST_PAGE,
       labels,
-      assetIcon: { ledgerId: "usd_coin", ticker: STUB_ASSET.ticker, network: "base" },
+      assetIcon: {
+        ledgerId: "ethereum/erc20/usd__coin",
+        ticker: STUB_ASSET.ticker,
+        network: "base",
+      },
       networkIcon: { ledgerId: "base", ticker: "ETH" },
       visibleActions: ["save", "copy", "verify"],
       onShare: noop,

--- a/features/flow/pay-card-request/package.json
+++ b/features/flow/pay-card-request/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@ledgerhq/crypto-icons": "catalog:",
+    "@shared/ui-qr-code": "workspace:*",
     "@shared/ui-queued-bottom-sheet": "workspace:*"
   },
   "devDependencies": {

--- a/features/flow/pay-card-request/src/components/RequestReceive/RequestReceiveSummary.web.tsx
+++ b/features/flow/pay-card-request/src/components/RequestReceive/RequestReceiveSummary.web.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { CryptoIcon } from "@ledgerhq/crypto-icons";
+import { QrCode } from "@shared/ui-qr-code";
 import { RequestReceiveAddress } from "./RequestReceiveAddress.web";
 import type { RequestReceiveIconProps } from "../../types";
 import type { AddressParts } from "../../utils/splitAddress";
 
-const ASSET_ICON_SIZE = 48;
+const QR_CENTER_ICON_SIZE = 48;
 const NETWORK_ICON_SIZE = 20;
 
 type RequestReceiveSummaryProps = Readonly<{
@@ -13,6 +14,7 @@ type RequestReceiveSummaryProps = Readonly<{
   assetIcon: RequestReceiveIconProps;
   networkIcon?: RequestReceiveIconProps;
   addressParts: AddressParts;
+  qrPayload: string;
 }>;
 
 export function RequestReceiveSummary({
@@ -21,6 +23,7 @@ export function RequestReceiveSummary({
   assetIcon,
   networkIcon,
   addressParts,
+  qrPayload,
 }: RequestReceiveSummaryProps) {
   return (
     <div className="flex flex-col items-center gap-32 bg-surface p-24 rounded-2xl">
@@ -42,14 +45,19 @@ export function RequestReceiveSummary({
           <span className="body-2 text-muted">{networkLabel}</span>
         </div>
       </div>
-
-      <div className="flex flex-col items-center gap-8">
-        <CryptoIcon
-          ledgerId={assetIcon.ledgerId}
-          ticker={assetIcon.ticker}
-          size={ASSET_ICON_SIZE}
-          shape="circle"
-        />
+      <QrCode
+        value={qrPayload}
+        testID="pay-card-request-receive-qr-code"
+        centerContent={
+          <CryptoIcon
+            ledgerId={assetIcon.ledgerId}
+            ticker={assetIcon.ticker}
+            size={QR_CENTER_ICON_SIZE}
+            shape="circle"
+          />
+        }
+      />
+      <div className="flex flex-col items-center">
         <RequestReceiveAddress addressParts={addressParts} />
       </div>
     </div>

--- a/features/flow/pay-card-request/src/components/RequestReceive/RequestReceiveView.web.tsx
+++ b/features/flow/pay-card-request/src/components/RequestReceive/RequestReceiveView.web.tsx
@@ -12,6 +12,7 @@ export function RequestReceiveView({
   networkIcon,
   visibleActions,
   addressParts,
+  qrPayload,
   onClose,
   onShare,
   onCopy,
@@ -29,16 +30,17 @@ export function RequestReceiveView({
   }
 
   return (
-    <Dialog open onOpenChange={handleOpenChange}>
-      <DialogContent>
+    <Dialog open onOpenChange={handleOpenChange} height="fit">
+      <DialogContent className="max-h-[90vh]">
         <DialogHeader onClose={onClose} />
-        <DialogBody className="flex flex-col gap-32" data-testid="pay-card-request-receive">
+        <DialogBody className="flex flex-col gap-12" data-testid="pay-card-request-receive">
           <RequestReceiveSummary
             title={labels.title}
             networkLabel={labels.networkLabel}
             assetIcon={assetIcon}
             networkIcon={networkIcon}
             addressParts={addressParts}
+            qrPayload={qrPayload}
           />
           <RequestReceiveActions
             labels={labels.actions}

--- a/features/flow/pay-card-request/src/components/RequestReceive/__tests__/RequestReceive.web.test.tsx
+++ b/features/flow/pay-card-request/src/components/RequestReceive/__tests__/RequestReceive.web.test.tsx
@@ -6,6 +6,15 @@ import { RequestReceiveView } from "../RequestReceiveView.web";
 import { createRequestReceiveProps, REQUEST_RECEIVE_ADDRESS } from "./fixtures";
 import type { RequestReceiveProps } from "../../../types";
 
+// The QR renderer draws on a real canvas, which is not meaningful under jsdom; it is unit-tested in
+// @shared/ui-qr-code. Stub it here so this suite focuses on the RequestReceive composition.
+jest.mock("@shared/ui-qr-code", () => ({
+  QrCode: ({ value, testID }: { value: string; testID?: string }) => {
+    const React = require("react");
+    return React.createElement("div", { "data-testid": testID }, value);
+  },
+}));
+
 function renderRequestReceive(overrides: Partial<RequestReceiveProps> = {}) {
   const props = createRequestReceiveProps(overrides);
   return { props, ...render(<RequestReceive {...props} />) };
@@ -30,6 +39,14 @@ describe("RequestReceive (Web)", () => {
     expect(screen.getByText("Request USD Coin")).toBeVisible();
     expect(screen.getByText("Base network")).toBeVisible();
     expect(screen.getByTestId("pay-card-request-receive-address")).toHaveTextContent(
+      REQUEST_RECEIVE_ADDRESS,
+    );
+  });
+
+  it("renders the QR code for the address", () => {
+    renderRequestReceive();
+
+    expect(screen.getByTestId("pay-card-request-receive-qr-code")).toHaveTextContent(
       REQUEST_RECEIVE_ADDRESS,
     );
   });

--- a/features/flow/pay-card-request/src/components/RequestReceive/__tests__/fixtures.ts
+++ b/features/flow/pay-card-request/src/components/RequestReceive/__tests__/fixtures.ts
@@ -46,6 +46,7 @@ export function createRequestReceiveViewProps(
   return {
     ...shell,
     addressParts: splitAddress(REQUEST_RECEIVE_ADDRESS),
+    qrPayload: REQUEST_RECEIVE_ADDRESS,
     onShare: jest.fn(),
     onCopy: jest.fn(),
     onSave: jest.fn(),

--- a/features/flow/pay-card-request/src/types.ts
+++ b/features/flow/pay-card-request/src/types.ts
@@ -146,5 +146,5 @@ export type RequestReceiveProps = RequestReceiveViewModelParams & RequestReceive
 export type RequestReceiveViewProps = RequestReceiveShell &
   Pick<
     RequestReceiveViewModel,
-    "address" | "addressParts" | "onShare" | "onCopy" | "onSave" | "onVerify"
+    "address" | "addressParts" | "qrPayload" | "onShare" | "onCopy" | "onSave" | "onVerify"
   >;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1047,7 +1047,7 @@ importers:
         version: 1.7.1(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-ethereum':
         specifier: 'catalog:'
-        version: 1.16.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        version: 1.16.0(@ledgerhq/context-module@2.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../libs/ledgerjs/packages/devices
@@ -1289,8 +1289,8 @@ importers:
         specifier: 15.8.1
         version: 15.8.1
       qrcode:
-        specifier: 1.5.3
-        version: 1.5.3
+        specifier: 'catalog:'
+        version: 1.5.4
       react:
         specifier: 19.1.4
         version: 19.1.4
@@ -6099,6 +6099,9 @@ importers:
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
         version: 2.0.4(@ledgerhq/lumen-design-core@0.1.25)(@ledgerhq/lumen-ui-react@0.1.53(@ledgerhq/lumen-design-core@0.1.25)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(@ledgerhq/lumen-ui-rnative@0.1.57(@ledgerhq/lumen-design-core@0.1.25)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@shared/ui-qr-code':
+        specifier: workspace:*
+        version: link:../../../shared/ui-qr-code
       '@shared/ui-queued-bottom-sheet':
         specifier: workspace:*
         version: link:../../../shared/ui-queued-bottom-sheet
@@ -24964,7 +24967,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.1.4
       react-dom: 19.1.4
-      webpack: ^5.89.0
+      webpack: '*'
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -30134,9 +30137,6 @@ packages:
 
   enabled@2.0.0:
     resolution: {integrity: sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==}
-
-  encode-utf8@1.0.3:
-    resolution: {integrity: sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==}
 
   encodeurl@1.0.2:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
@@ -36528,11 +36528,6 @@ packages:
 
   qrcode-terminal@0.12.0:
     resolution: {integrity: sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==}
-    hasBin: true
-
-  qrcode@1.5.3:
-    resolution: {integrity: sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==}
-    engines: {node: '>=10.13.0'}
     hasBin: true
 
   qrcode@1.5.4:
@@ -48936,20 +48931,6 @@ snapshots:
   '@ledgerhq/device-signer-kit-ethereum@1.16.0(@ledgerhq/context-module@2.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
     dependencies:
       '@ledgerhq/context-module': 2.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
-      '@ledgerhq/device-management-kit': 1.7.1(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
-      ethers: 6.15.0
-      inversify: 7.5.1(reflect-metadata@0.2.2)
-      purify-ts: 2.1.0
-      reflect-metadata: 0.2.2
-      semver: 7.7.2
-      xstate: 5.19.2
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  '@ledgerhq/device-signer-kit-ethereum@1.16.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
-    dependencies:
       '@ledgerhq/device-management-kit': 1.7.1(rxjs@7.8.2)
       '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       ethers: 6.15.0
@@ -62234,8 +62215,6 @@ snapshots:
 
   enabled@2.0.0: {}
 
-  encode-utf8@1.0.3: {}
-
   encodeurl@1.0.2: {}
 
   encodeurl@2.0.0: {}
@@ -68282,7 +68261,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3
+      metro: 0.83.3(metro-transform-worker@0.83.3)
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -68406,6 +68385,54 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.83.3(metro-transform-worker@0.83.3):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.28.5
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 1.3.8
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.32.0
+      image-size: 1.1.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0(metro@0.83.3)
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.3
+      metro-cache: 0.83.3
+      metro-cache-key: 0.83.3
+      metro-config: 0.83.3(metro-transform-worker@0.83.3)
+      metro-core: 0.83.3
+      metro-file-map: 0.83.3(metro@0.83.3)
+      metro-resolver: 0.83.3
+      metro-runtime: 0.83.3
+      metro-source-map: 0.83.3
+      metro-symbolicate: 0.83.3
+      metro-transform-plugins: 0.83.3
+      metro-transform-worker: 0.83.3
+      mime-types: 2.1.35
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - metro-transform-worker
       - supports-color
       - utf-8-validate
 
@@ -70991,13 +71018,6 @@ snapshots:
   qrcode-terminal@0.11.0: {}
 
   qrcode-terminal@0.12.0: {}
-
-  qrcode@1.5.3:
-    dependencies:
-      dijkstrajs: 1.0.3
-      encode-utf8: 1.0.3
-      pngjs: 5.0.0
-      yargs: 15.4.1
 
   qrcode@1.5.4:
     dependencies:


### PR DESCRIPTION
### 📝 Description

Integrate the branded `QrCode` from `@shared/qr-code` into the Pay **Request receive** flow (Ledger Wallet Desktop).

- Render `QrCode` in `RequestReceiveSummary` with the currency `CryptoIcon` centered via `centerContent`.
- Wire `qrPayload` from the view model through `RequestReceiveView` to the summary.
- Size the dialog (`height="fit"` + `max-h-[90vh]`) so the content fits without scrolling, matching the Figma.
- Update the PayTab wiring and tests.

> ⚠️ Stacked on #20937 — review/merge that first. Base is `feat/qr-code-LIVE-36118-web-export`; it will retarget to `develop` once the foundation PR merges.



<img width="599" height="731" alt="Screenshot 2026-08-19 at 12 26 44" src="https://github.com/user-attachments/assets/33c55c48-2c17-48e4-b00e-1aba7ff96cdf" />

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36233](https://ledgerhq.atlassian.net/browse/LIVE-36233) (blocked by [LIVE-36118](https://ledgerhq.atlassian.net/browse/LIVE-36118))
- **ADR** (if any): n/a
- **Design**: [Figma — LWD 8340-114413](https://www.figma.com/design/WYQQwem0QyG2fTuaAKAe3Y/Pay-%E2%80%A2-Production?node-id=8340-114413&m=dev)

[LIVE-36233]: https://ledgerhq.atlassian.net/browse/LIVE-36233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-36118]: https://ledgerhq.atlassian.net/browse/LIVE-36118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ