### PR TITLE
[LWDM] feat(aleo): private list ops framework part 2(LIVE-33469)

### DIFF
--- a/.changeset/old-beans-dream.md
+++ b/.changeset/old-beans-dream.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+aleo private list ops framework

--- a/libs/coin-modules/coin-aleo/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.integ.test.ts
@@ -5,7 +5,14 @@ import { AleoApiConfigurationResetError } from "../errors";
 import { fromHex } from "../logic/utils";
 import { accessProvableApi } from "../network/utils";
 import { getTestnetIntegConfig } from "../__tests__/fixtures/config.fixture";
-import { testnetAddress, testnetViewKey } from "../__tests__/fixtures/api.fixture";
+import {
+  referenceTransferPublicTx,
+  TEST_TOKEN_PROGRAM_ID,
+  testnetAddress,
+  testnetIncomingPrivateRecord1,
+  testnetSelfConversionTx,
+  testnetViewKey,
+} from "../__tests__/fixtures/api.fixture";
 import { setupCalStore } from "../__tests__/helpers/cal";
 import { getPristineAccount } from "../__tests__/helpers/account";
 import type { AleoAccountInfo, AleoContext, PreparedRequestResponse } from "../types";
@@ -177,6 +184,101 @@ describe("createApi", () => {
       const balance = await api.getBalance(emptyPrivacyContext, emptyAddress);
 
       expect(balance).toEqual([{ value: 0n, asset: { type: "native" } }]);
+    });
+  });
+
+  describe("listOperations", () => {
+    // The fixtures below all sit in the account's 18_140_1xx–18_140_9xx activity burst
+    const firstActivityBlock = referenceTransferPublicTx.blockHeight - 10;
+
+    it("throws when no privacy context is given", async () => {
+      await expect(api.listOperations(context, testnetAddress, { minHeight: 0 })).rejects.toThrow(
+        "aleo: provableId is missing",
+      );
+    });
+
+    it("resolves a counterparty the explorer left blank to the account's own address", async () => {
+      const { items } = await api.listOperations(privacyContext, testnetAddress, {
+        minHeight: testnetSelfConversionTx.block_number - 1,
+        order: "desc",
+      });
+
+      const shield = items.find(op => op.id === testnetSelfConversionTx.transaction_id);
+
+      invariant(shield, "guard: the shielding transaction is missing from the page");
+      expect(shield.recipients).toEqual([testnetAddress]);
+      expect(shield.type).toBe("OUT");
+    });
+
+    it("emits an operation for a token transaction that has no public row", async () => {
+      const { items } = await api.listOperations(privacyContext, testnetAddress, {
+        minHeight: firstActivityBlock,
+        order: "desc",
+      });
+
+      const privateOnly = items.find(
+        op => op.id === testnetIncomingPrivateRecord1.transaction_id.trim(),
+      );
+
+      invariant(privateOnly, "guard: the private-only token transaction is missing from the page");
+      expect(privateOnly.type).toBe("IN");
+      expect(privateOnly.asset).toMatchObject({ assetReference: TEST_TOKEN_PROGRAM_ID });
+      expect(privateOnly.details).toMatchObject({ transactionType: "private" });
+    });
+
+    it("never lists a block the record scanner has not reached", async () => {
+      const getAccountInfo = requireGetAccountInfo(api);
+      const info = (await getAccountInfo(privacyContext, testnetAddress)) as AleoAccountInfo;
+
+      const { items } = await api.listOperations(privacyContext, testnetAddress, {
+        minHeight: firstActivityBlock,
+        order: "desc",
+      });
+
+      expect(items.length).toBeGreaterThan(0);
+      for (const op of items) {
+        expect(op.tx.block.height).toBeLessThanOrEqual(info.scannedHeight);
+      }
+    });
+
+    it("resumes the next page past the last block of the previous one", async () => {
+      const options = { minHeight: firstActivityBlock, limit: 2, order: "desc" as const };
+
+      const firstPage = await api.listOperations(privacyContext, testnetAddress, options);
+
+      invariant(firstPage.next, "guard: expected the account's history to span several pages");
+
+      const secondPage = await api.listOperations(privacyContext, testnetAddress, {
+        ...options,
+        cursor: firstPage.next,
+      });
+
+      const firstIds = new Set(firstPage.items.map(op => op.id));
+      const overlap = secondPage.items.filter(op => firstIds.has(op.id));
+
+      expect(overlap).toEqual([]);
+      expect(Math.max(...secondPage.items.map(op => op.tx.block.height))).toBeLessThan(
+        Math.min(...firstPage.items.map(op => op.tx.block.height)),
+      );
+    });
+
+    it("emits exactly one operation per transaction", async () => {
+      const { items } = await api.listOperations(privacyContext, testnetAddress, {
+        minHeight: firstActivityBlock,
+        order: "desc",
+      });
+
+      expect(items.length).toBeGreaterThan(0);
+      expect(new Set(items.map(op => op.id)).size).toBe(items.length);
+    });
+
+    it("rejects a malformed cursor before any network call", async () => {
+      await expect(
+        api.listOperations(privacyContext, testnetAddress, {
+          minHeight: 0,
+          cursor: "not-a-height",
+        }),
+      ).rejects.toThrow(/malformed listOperations cursor/);
     });
   });
 

--- a/libs/coin-modules/coin-aleo/src/api/index.test.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.test.ts
@@ -17,12 +17,18 @@ import {
   lastBlock,
   register,
 } from "../logic";
-import { buildFeeConfigurationForRootIntent, getTransactionType } from "../logic/utils";
+import {
+  buildFeeConfigurationForRootIntent,
+  getTransactionType,
+  resolvePrivacyContext,
+} from "../logic/utils";
 import type { AleoContext } from "../types";
 import { createApi } from "./index";
+import { listOperations } from "../logic/listOperations";
 
 jest.mock("../logic");
 jest.mock("../logic/utils");
+jest.mock("../logic/listOperations");
 
 describe("createApi", () => {
   const api = createApi("aleo");
@@ -36,11 +42,13 @@ describe("createApi", () => {
   const mockedCraftTransaction = jest.mocked(craftTransaction);
   const mockedEstimateFees = jest.mocked(estimateFees);
   const mockedGetAccountInfo = jest.mocked(getAccountInfo);
+  const mockedListOperations = jest.mocked(listOperations);
   const mockedGetBalance = jest.mocked(getBalance);
   const mockedLastBlock = jest.mocked(lastBlock);
   const mockedRegister = jest.mocked(register);
   const mockedGetTransactionType = jest.mocked(getTransactionType);
   const mockedBuildFeeConfigurationForRootIntent = jest.mocked(buildFeeConfigurationForRootIntent);
+  const mockedResolvePrivacyContext = jest.mocked(resolvePrivacyContext);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -58,6 +66,10 @@ describe("createApi", () => {
       max_priority_fee: "0",
     });
     mockedRegister.mockResolvedValue({ type: "aleo", provableId: "scan-uuid-123" });
+    mockedResolvePrivacyContext.mockReturnValue({
+      provableId: "uuid1field",
+      viewKey: "AViewKey1test",
+    });
   });
 
   it("should return an API object with coin module api methods", () => {
@@ -401,12 +413,48 @@ describe("createApi", () => {
   });
 
   describe("listOperations", () => {
-    it("should throw unsupported error", () => {
-      const api = createApi("aleo");
+    it("should reject an order other than desc", async () => {
+      await expect(
+        api.listOperations(context, "aleo1test", { minHeight: 0, order: "asc" }),
+      ).rejects.toThrow('aleo: listOperations does not support order "asc"');
+      expect(mockedListOperations).not.toHaveBeenCalled();
+    });
 
-      expect(() => api.listOperations(context, "aleo1test", { minHeight: 0 })).toThrow(
-        "listOperations is not supported",
+    it("should reject without touching the logic layer when the context carries no private pair", async () => {
+      const api = createApi("aleo");
+      mockedResolvePrivacyContext.mockImplementation(() => {
+        throw new Error("aleo: provableId is missing");
+      });
+
+      await expect(api.listOperations(context, "aleo1test", { minHeight: 0 })).rejects.toThrow(
+        "aleo: provableId is missing",
       );
+      expect(mockedListOperations).not.toHaveBeenCalled();
+    });
+
+    it("should delegate to the logic layer with the context private pair", async () => {
+      const api = createApi("aleo");
+      const page = { items: [], next: undefined };
+      mockedListOperations.mockResolvedValue(page);
+
+      const result = await api.listOperations(
+        { ...context, provableId: "uuid1field", viewKey: "AViewKey1test" },
+        "aleo1test",
+        { minHeight: 0 },
+      );
+
+      expect(mockedResolvePrivacyContext).toHaveBeenCalledWith(
+        expect.objectContaining({ provableId: "uuid1field", viewKey: "AViewKey1test" }),
+      );
+      expect(mockedListOperations).toHaveBeenCalledTimes(1);
+      expect(mockedListOperations).toHaveBeenCalledWith({
+        config: mockConfig,
+        address: "aleo1test",
+        options: { minHeight: 0 },
+        provableId: "uuid1field",
+        viewKey: "AViewKey1test",
+      });
+      expect(result).toBe(page);
     });
   });
 

--- a/libs/coin-modules/coin-aleo/src/api/index.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.ts
@@ -31,13 +31,18 @@ import {
   register,
   validateAddress,
 } from "../logic";
-import { buildFeeConfigurationForRootIntent, getTransactionType } from "../logic/utils";
+import {
+  buildFeeConfigurationForRootIntent,
+  getTransactionType,
+  resolvePrivacyContext,
+} from "../logic/utils";
 import type {
   AleoContext,
   AleoCoinConfig,
   AleoRegistration,
   AleoTransactionIntentData,
 } from "../types";
+import { listOperations } from "../logic/listOperations";
 
 type AleoCoinModuleApi = CoinModuleApi<AleoCoinConfig, MemoNotSupported, AleoTransactionIntentData>;
 
@@ -50,9 +55,9 @@ function requireViewKey(context: AleoContext, action: string): string {
 }
 
 // currencyId is captured here (it can't live on the Context). The logic functions are shared with
-// the classic bridge (config-based), so each method resolves config via context.config() and passes
-// it down — no context-first wrappers.
-export function createApi(_currencyId: string): AleoCoinModuleApi {
+// the classic bridge (config-based), so each method resolves the config itself and passes it down —
+// no context-first wrappers.
+export function createApi(currencyId: string): AleoCoinModuleApi {
   return {
     async call() {
       throw new Error("call is not supported");
@@ -168,8 +173,16 @@ export function createApi(_currencyId: string): AleoCoinModuleApi {
       const config = await context.config();
       return lastBlock(config);
     },
-    listOperations: (_context, _address, _options) => {
-      throw new Error("listOperations is not supported");
+    listOperations: async (context: AleoContext, address, options) => {
+      if (options.order && options.order !== "desc") {
+        throw new Error(`aleo: listOperations does not support order "${options.order}"`);
+      }
+
+      const { provableId, viewKey } = resolvePrivacyContext(context);
+
+      const config = await context.config(currencyId);
+
+      return listOperations({ config, address, options, provableId, viewKey });
     },
     getBlock(_context, _height): Promise<Block> {
       throw new Error("getBlock is not supported");

--- a/libs/coin-modules/coin-aleo/src/bridge/tokens.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/tokens.ts
@@ -11,7 +11,7 @@ import {
   PRIVATE_TRANSFER_FUNCTIONS,
   SEMI_PUBLIC_TOKEN_FUNCTIONS,
 } from "../constants";
-import { parseAmount } from "../logic/utils";
+import { parseAmount, toBlockDate } from "../logic/utils";
 import { apiClient } from "../network/api";
 import { decryptRecordAmount, getTokenOutDetails } from "../network/utils";
 import type {
@@ -442,7 +442,7 @@ export function buildPrivateTokenOp(
     blockHeight: record.block_height,
     blockHash: "",
     accountId: tokenAccountId,
-    date: new Date(Number(record.block_timestamp) * 1000),
+    date: toBlockDate(record.block_timestamp),
     extra: {
       functionId: record.function_name,
       transactionType: "private",
@@ -787,7 +787,7 @@ export async function buildSubAccountsFromPrivateRecords({
     const tokenAccountId = encodeTokenAccountId(ledgerAccountId, tokenCurrency);
 
     if (!existingSubAccountIds.has(tokenAccountId)) {
-      const recordDate = new Date(Number(record.block_timestamp) * 1000);
+      const recordDate = toBlockDate(record.block_timestamp);
       const existingMeta = newSubAccountMeta.get(tokenAccountId);
       if (!existingMeta || recordDate < existingMeta.creationDate) {
         newSubAccountMeta.set(tokenAccountId, { token: tokenCurrency, creationDate: recordDate });

--- a/libs/coin-modules/coin-aleo/src/bridge/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/utils.ts
@@ -5,7 +5,7 @@ import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import { getCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
 import { promiseAllBatched } from "@ledgerhq/coin-module-framework/promises";
 import type { OperationType } from "@ledgerhq/types-live";
-import { parseTransactionFields, resolveTransactionAmount } from "../logic/utils";
+import { parseTransactionFields, resolveTransactionAmount, toBlockDate } from "../logic/utils";
 import type { AleoOperation, AleoPublicTransaction, EnrichedPrivateRecord } from "../types";
 
 export const toBridgeOperation = (
@@ -56,7 +56,7 @@ export const toPrivateBridgeOperation = (
 ): AleoOperation => {
   const transactionId = enrichedRecord.rawRecord.transaction_id.trim();
   const blockHeight = enrichedRecord.rawRecord.block_height;
-  const timestamp = new Date(Number(enrichedRecord.rawRecord.block_timestamp) * 1000);
+  const timestamp = toBlockDate(enrichedRecord.rawRecord.block_timestamp);
   const type: OperationType = enrichedRecord.recipient === address ? "IN" : "OUT";
 
   return {

--- a/libs/coin-modules/coin-aleo/src/constants.ts
+++ b/libs/coin-modules/coin-aleo/src/constants.ts
@@ -60,6 +60,10 @@ export const DEFAULT_RECORDS_PAGE_SIZE = 1000;
 // Pagination parameter for GET /tokens calls when fetching the full token registry.
 export const DEFAULT_TOKENS_PAGE_SIZE = 1000;
 
+// Hard cap of the explorer's public transitions endpoint — above it, 400 "Limit must be between 1
+// and 50". Counts transitions, not transactions: one transaction can span several rows.
+export const MAX_TRANSITIONS_PER_PAGE = 50;
+
 /**
  * Progress phase boundaries for private sync.
  *

--- a/libs/coin-modules/coin-aleo/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/listOperations.test.ts
@@ -1,0 +1,487 @@
+import BigNumber from "bignumber.js";
+import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
+import {
+  getMockedEnrichedPrivateRecord,
+  getMockedPublicTransaction,
+  getMockedRecord,
+  getMockedRecordScannerStatus,
+  getMockedTokenDetails,
+  getMockedTransactionDetails,
+} from "../__tests__/fixtures/api.fixture";
+import { apiClient } from "../network/api";
+import {
+  enrichPrivateRecords,
+  fetchAllOwnedRecords,
+  fetchAllTokens,
+  fetchTransitionPage,
+  getRecordScannerStatusOrThrow,
+  resolveTransferArguments,
+} from "../network/utils";
+import { lastBlock } from "./lastBlock";
+import { listOperations } from "./listOperations";
+
+jest.mock("../network/utils");
+jest.mock("../network/api");
+jest.mock("./lastBlock");
+
+const mockedFetchTransitionPage = jest.mocked(fetchTransitionPage);
+const mockedFetchAllOwnedRecords = jest.mocked(fetchAllOwnedRecords);
+const mockedGetRecordScannerStatusOrThrow = jest.mocked(getRecordScannerStatusOrThrow);
+const mockedLastBlock = jest.mocked(lastBlock);
+const mockedEnrichPrivateRecords = jest.mocked(enrichPrivateRecords);
+const mockedFetchAllTokens = jest.mocked(fetchAllTokens);
+const mockedResolveTransferArguments = jest.mocked(resolveTransferArguments);
+const mockedGetTransactionById = jest.mocked(apiClient.getTransactionById);
+
+const config = getMockedConfig("mainnet");
+const address = "aleo1a2ehlgqhvs3p7d4hqhs0tvgk954dr8gafu9kxse2mzu9a5sqxvpsrn98pr";
+const recipient = "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px";
+const provableId = "uuid1field";
+const viewKey = "AViewKey1test";
+
+const run = (options: Omit<Parameters<typeof listOperations>[0]["options"], "order">) =>
+  listOperations({ config, address, options: { ...options, order: "desc" }, provableId, viewKey });
+
+const runAsc = (options: Omit<Parameters<typeof listOperations>[0]["options"], "order">) =>
+  listOperations({ config, address, options: { ...options, order: "asc" }, provableId, viewKey });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  mockedLastBlock.mockResolvedValue({ hash: "ab1tip", height: 1000, time: new Date() });
+  mockedGetRecordScannerStatusOrThrow.mockResolvedValue(
+    getMockedRecordScannerStatus({ synced_up_to: 900 }),
+  );
+  mockedFetchTransitionPage.mockResolvedValue({ transitions: [], next: null });
+  mockedFetchAllOwnedRecords.mockResolvedValue([]);
+  mockedEnrichPrivateRecords.mockResolvedValue([]);
+  mockedFetchAllTokens.mockResolvedValue([]);
+  mockedGetTransactionById.mockResolvedValue(getMockedTransactionDetails());
+  mockedResolveTransferArguments.mockResolvedValue(null);
+});
+
+describe("listOperations", () => {
+  it("should emit one operation per transaction, collapsing its transitions", async () => {
+    mockedFetchTransitionPage.mockResolvedValue({
+      transitions: [
+        // batcher inner call, no addresses: must lose to the row carrying the transfer
+        getMockedPublicTransaction({
+          transaction_id: "at1multi",
+          transition_id: "au1inner",
+          block_number: 500,
+          sender_address: "",
+          recipient_address: "",
+          function_id: "burn_public",
+        }),
+        getMockedPublicTransaction({
+          transaction_id: "at1multi",
+          transition_id: "au1real",
+          block_number: 500,
+        }),
+      ],
+      next: null,
+    });
+
+    const { items } = await run({ minHeight: 0 });
+
+    expect(items).toEqual([
+      expect.objectContaining({
+        id: "at1multi",
+        details: expect.objectContaining({ functionId: "transfer_public" }),
+      }),
+    ]);
+  });
+
+  it("should withhold blocks above the scanner watermark", async () => {
+    mockedFetchTransitionPage.mockResolvedValue({
+      transitions: [
+        getMockedPublicTransaction({ transaction_id: "at1below", block_number: 800 }),
+        getMockedPublicTransaction({ transaction_id: "at1above", block_number: 950 }),
+      ],
+      next: null,
+    });
+
+    const { items } = await run({ minHeight: 0 });
+
+    expect(items.map(op => op.id)).toEqual(["at1below"]);
+  });
+
+  it("should return an empty page when the scanner reports no covered height", async () => {
+    mockedGetRecordScannerStatusOrThrow.mockResolvedValue(
+      getMockedRecordScannerStatus({ synced: false, percentage: 10, synced_up_to: null }),
+    );
+
+    const result = await run({ minHeight: 5 });
+
+    expect(result).toEqual({ items: [], next: undefined });
+    expect(mockedFetchTransitionPage).not.toHaveBeenCalled();
+  });
+
+  it("should cap the watermark at the chain tip", async () => {
+    mockedLastBlock.mockResolvedValue({ hash: "ab1tip", height: 600, time: new Date() });
+    mockedFetchTransitionPage.mockResolvedValue({
+      transitions: [getMockedPublicTransaction({ transaction_id: "at1a", block_number: 700 })],
+      next: null,
+    });
+
+    const { items } = await run({ minHeight: 0 });
+
+    expect(items).toEqual([]);
+  });
+
+  it("should pin the watermark in the cursor so later pages see one snapshot", async () => {
+    mockedFetchTransitionPage.mockResolvedValue({
+      transitions: [getMockedPublicTransaction({ transaction_id: "at1a", block_number: 500 })],
+      next: { blockNumber: 500, transitionId: "au1a" },
+    });
+
+    const { next } = await run({ minHeight: 0 });
+
+    expect(next).toBe("900:500:au1a");
+  });
+
+  it("should resume below the block a cursor already emitted whole", async () => {
+    mockedFetchAllOwnedRecords.mockResolvedValue([
+      getMockedRecord({ transaction_id: "at1done", block_height: 500 }),
+      getMockedRecord({ transaction_id: "at1next", block_height: 499 }),
+    ]);
+
+    await run({ minHeight: 0, cursor: "900:500:au1a" });
+
+    expect(mockedFetchTransitionPage).toHaveBeenCalledTimes(1);
+    expect(mockedFetchTransitionPage).toHaveBeenCalledWith(
+      expect.objectContaining({ cursor: { blockNumber: 500, transitionId: "au1a" } }),
+    );
+    // block 500 was emitted whole by the previous page, so only what sits below it is left
+    expect(mockedEnrichPrivateRecords).toHaveBeenCalledTimes(1);
+    expect(mockedEnrichPrivateRecords).toHaveBeenCalledWith(
+      expect.objectContaining({
+        records: [expect.objectContaining({ transaction_id: "at1next" })],
+      }),
+    );
+  });
+
+  it("should open a descending window above the watermark", async () => {
+    await run({ minHeight: 0 });
+
+    expect(mockedFetchTransitionPage).toHaveBeenCalledTimes(1);
+    expect(mockedFetchTransitionPage).toHaveBeenCalledWith(
+      expect.objectContaining({ cursor: { blockNumber: 901 }, order: "desc" }),
+    );
+  });
+
+  it("should drop the cursor once the stream leaves the window", async () => {
+    mockedFetchTransitionPage.mockResolvedValue({
+      transitions: [
+        getMockedPublicTransaction({ transaction_id: "at1in", block_number: 500 }),
+        getMockedPublicTransaction({ transaction_id: "at1out", block_number: 300 }),
+      ],
+      next: { blockNumber: 300, transitionId: "au1out" },
+    });
+
+    const { items, next } = await run({ minHeight: 400 });
+
+    expect(items.map(op => op.id)).toEqual(["at1in"]);
+    expect(next).toBeUndefined();
+  });
+
+  it("should tag a public row when the account owns a record of the same transaction", async () => {
+    mockedFetchTransitionPage.mockResolvedValue({
+      transitions: [
+        getMockedPublicTransaction({
+          transaction_id: "at1shield",
+          block_number: 500,
+          function_id: "transfer_public_to_private",
+          recipient_address: "",
+        }),
+      ],
+      next: null,
+    });
+    mockedFetchAllOwnedRecords.mockResolvedValue([
+      getMockedRecord({ transaction_id: "at1shield", block_height: 500 }),
+    ]);
+
+    const { items } = await run({ minHeight: 0 });
+
+    expect(items).toEqual([expect.objectContaining({ recipients: [address] })]);
+    expect(mockedEnrichPrivateRecords).toHaveBeenCalledTimes(1);
+    expect(mockedEnrichPrivateRecords).toHaveBeenCalledWith(
+      expect.objectContaining({ records: [] }),
+    );
+    // an owned record already reveals the counterparty, so no transition lookup is needed
+    expect(mockedGetTransactionById).not.toHaveBeenCalled();
+  });
+
+  it("should keep a batcher-wrapped record and leave the scanner filters off", async () => {
+    mockedFetchAllOwnedRecords.mockResolvedValue([
+      getMockedRecord({
+        transaction_id: "at1batched",
+        block_height: 500,
+        function_name: "transfer_private_2",
+      }),
+    ]);
+    mockedEnrichPrivateRecords.mockResolvedValue([
+      getMockedEnrichedPrivateRecord({
+        rawRecord: { transaction_id: "at1batched", block_height: 500 },
+        sender: recipient,
+        recipient: address,
+      }),
+    ]);
+
+    const { items } = await run({ minHeight: 0 });
+
+    // both scanner filters are exact-name matches, so they must stay off
+    expect(mockedFetchAllOwnedRecords).toHaveBeenCalledTimes(1);
+    expect(mockedFetchAllOwnedRecords).toHaveBeenCalledWith(
+      expect.objectContaining({ programs: [], functions: [] }),
+    );
+    expect(items).toEqual([expect.objectContaining({ id: "at1batched" })]);
+  });
+
+  it("should bound the record fetch by the page's block window", async () => {
+    mockedFetchTransitionPage.mockResolvedValue({
+      transitions: [getMockedPublicTransaction({ transaction_id: "at1a", block_number: 500 })],
+      next: { blockNumber: 500, transitionId: "au1a" },
+    });
+
+    await run({ minHeight: 400 });
+
+    // descending: this page covers [500, 900], so the scanner must not stream the tail below it
+    expect(mockedFetchAllOwnedRecords).toHaveBeenCalledTimes(1);
+    expect(mockedFetchAllOwnedRecords).toHaveBeenCalledWith(
+      expect.objectContaining({ start: 500, end: 900 }),
+    );
+  });
+
+  it("should drop a record whose function transfers nothing", async () => {
+    mockedFetchAllOwnedRecords.mockResolvedValue([
+      getMockedRecord({ transaction_id: "at1join", block_height: 500, function_name: "join" }),
+    ]);
+
+    const { items } = await run({ minHeight: 0 });
+
+    expect(mockedEnrichPrivateRecords).toHaveBeenCalledTimes(1);
+    expect(mockedEnrichPrivateRecords).toHaveBeenCalledWith(
+      expect.objectContaining({ records: [] }),
+    );
+    expect(items).toEqual([]);
+  });
+
+  it("should emit an operation for a record whose transaction has no public row", async () => {
+    mockedFetchAllOwnedRecords.mockResolvedValue([
+      getMockedRecord({ transaction_id: "at1private", block_height: 500 }),
+    ]);
+    mockedEnrichPrivateRecords.mockResolvedValue([
+      getMockedEnrichedPrivateRecord({
+        rawRecord: { transaction_id: "at1private", block_height: 500 },
+        sender: recipient,
+        recipient: address,
+        value: new BigNumber(42),
+      }),
+    ]);
+
+    const { items } = await run({ minHeight: 0 });
+
+    expect(items).toEqual([expect.objectContaining({ id: "at1private", type: "IN", value: 42n })]);
+  });
+
+  it("should drop records outside the page's block window", async () => {
+    mockedFetchAllOwnedRecords.mockResolvedValue([
+      getMockedRecord({ transaction_id: "at1late", block_height: 950 }),
+    ]);
+
+    await run({ minHeight: 0 });
+
+    expect(mockedEnrichPrivateRecords).toHaveBeenCalledTimes(1);
+    expect(mockedEnrichPrivateRecords).toHaveBeenCalledWith(
+      expect.objectContaining({ records: [] }),
+    );
+  });
+
+  it("should type a token operation from the registry's standard", async () => {
+    mockedFetchTransitionPage.mockResolvedValue({
+      transitions: [
+        getMockedPublicTransaction({
+          transaction_id: "at1token",
+          block_number: 500,
+          program_id: "arc20_eth.aleo",
+        }),
+      ],
+      next: null,
+    });
+    mockedFetchAllTokens.mockResolvedValue([
+      getMockedTokenDetails({ program_name: "arc20_eth.aleo", token_standard: "ARC-20" }),
+    ]);
+
+    const { items } = await run({ minHeight: 0 });
+
+    expect(items).toEqual([
+      expect.objectContaining({
+        asset: { type: "arc20", assetReference: "arc20_eth.aleo" },
+      }),
+    ]);
+  });
+
+  it("should reject a malformed cursor", async () => {
+    await expect(run({ minHeight: 0, cursor: "not-a-cursor" })).rejects.toThrow(
+      "malformed listOperations cursor",
+    );
+  });
+
+  it("should keep the lowest addressed transition when a transaction has several", async () => {
+    mockedFetchTransitionPage.mockResolvedValue({
+      transitions: [
+        getMockedPublicTransaction({
+          transaction_id: "at1multi",
+          transition_id: "au1second",
+          block_number: 500,
+          function_id: "transfer_public_second",
+        }),
+        getMockedPublicTransaction({
+          transaction_id: "at1multi",
+          transition_id: "au1first",
+          block_number: 500,
+        }),
+      ],
+      next: null,
+    });
+
+    const { items } = await run({ minHeight: 0 });
+
+    expect(items).toEqual([
+      expect.objectContaining({
+        details: expect.objectContaining({ functionId: "transfer_public" }),
+      }),
+    ]);
+  });
+
+  it("should emit one operation for a self-transfer owning both output and change record", async () => {
+    const output = getMockedRecord({
+      transaction_id: "at1self",
+      block_height: 500,
+      output_index: 0,
+      commitment: "cm1output",
+    });
+    mockedFetchAllOwnedRecords.mockResolvedValue([
+      getMockedRecord({
+        transaction_id: "at1self",
+        block_height: 500,
+        output_index: 1,
+        commitment: "cm1change",
+      }),
+      output,
+    ]);
+    mockedEnrichPrivateRecords.mockResolvedValue([
+      getMockedEnrichedPrivateRecord({
+        rawRecord: { transaction_id: "at1self", block_height: 500 },
+        sender: address,
+        recipient: address,
+        value: new BigNumber(7),
+      }),
+    ]);
+
+    const { items } = await run({ minHeight: 0 });
+
+    expect(mockedEnrichPrivateRecords).toHaveBeenCalledTimes(1);
+    expect(mockedEnrichPrivateRecords).toHaveBeenCalledWith(
+      expect.objectContaining({ records: [output] }),
+    );
+    expect(items).toEqual([expect.objectContaining({ id: "at1self", value: 7n })]);
+  });
+
+  it("should read a third-party shield recipient back from the transition inputs", async () => {
+    mockedFetchTransitionPage.mockResolvedValue({
+      transitions: [
+        getMockedPublicTransaction({
+          transaction_id: "at1shield3p",
+          block_number: 500,
+          function_id: "transfer_public_to_private",
+          sender_address: address,
+          recipient_address: "",
+        }),
+      ],
+      next: null,
+    });
+    mockedResolveTransferArguments.mockResolvedValue({ recipient, amount: "42u64" });
+
+    const { items } = await run({ minHeight: 0 });
+
+    expect(mockedGetTransactionById).toHaveBeenCalledTimes(1);
+    expect(mockedGetTransactionById).toHaveBeenCalledWith(config, "at1shield3p");
+    expect(items).toEqual([expect.objectContaining({ type: "OUT", recipients: [recipient] })]);
+  });
+
+  it("should read a batcher-wrapped shield recipient back too", async () => {
+    mockedFetchTransitionPage.mockResolvedValue({
+      transitions: [
+        getMockedPublicTransaction({
+          transaction_id: "at1shieldbatched",
+          block_number: 500,
+          function_id: "transfer_public_to_private_4",
+          sender_address: address,
+          recipient_address: "",
+        }),
+      ],
+      next: null,
+    });
+    mockedResolveTransferArguments.mockResolvedValue({ recipient, amount: "42u64" });
+
+    const { items } = await run({ minHeight: 0 });
+
+    expect(mockedGetTransactionById).toHaveBeenCalledTimes(1);
+    expect(items).toEqual([expect.objectContaining({ recipients: [recipient] })]);
+  });
+
+  it("should leave the recipient blank when the transition inputs cannot be read", async () => {
+    mockedFetchTransitionPage.mockResolvedValue({
+      transitions: [
+        getMockedPublicTransaction({
+          transaction_id: "at1shield3p",
+          block_number: 500,
+          function_id: "transfer_public_to_private",
+          sender_address: address,
+          recipient_address: "",
+        }),
+      ],
+      next: null,
+    });
+
+    const { items } = await run({ minHeight: 0 });
+
+    expect(items).toEqual([expect.objectContaining({ recipients: [""] })]);
+  });
+
+  it("should resume above the block a cursor already emitted whole when ascending", async () => {
+    mockedFetchAllOwnedRecords.mockResolvedValue([
+      getMockedRecord({ transaction_id: "at1done", block_height: 500 }),
+      getMockedRecord({ transaction_id: "at1next", block_height: 501 }),
+    ]);
+
+    await runAsc({ minHeight: 0, cursor: "900:500:au1a" });
+
+    expect(mockedFetchAllOwnedRecords).toHaveBeenCalledTimes(1);
+    expect(mockedFetchAllOwnedRecords).toHaveBeenCalledWith(
+      expect.objectContaining({ start: 501, end: 900 }),
+    );
+    expect(mockedEnrichPrivateRecords).toHaveBeenCalledTimes(1);
+    expect(mockedEnrichPrivateRecords).toHaveBeenCalledWith(
+      expect.objectContaining({
+        records: [expect.objectContaining({ transaction_id: "at1next" })],
+      }),
+    );
+  });
+
+  it("should sort operations from the newest block down", async () => {
+    mockedFetchTransitionPage.mockResolvedValue({
+      transitions: [
+        getMockedPublicTransaction({ transaction_id: "at1low", block_number: 400 }),
+        getMockedPublicTransaction({ transaction_id: "at1high", block_number: 600 }),
+      ],
+      next: null,
+    });
+
+    const { items } = await run({ minHeight: 0 });
+
+    expect(items.map(op => op.id)).toEqual(["at1high", "at1low"]);
+  });
+});

--- a/libs/coin-modules/coin-aleo/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/listOperations.ts
@@ -1,0 +1,336 @@
+import invariant from "invariant";
+import type {
+  ListOperationsOptions,
+  Operation,
+  Page,
+} from "@ledgerhq/coin-module-framework/api/types";
+import { promiseAllBatched } from "@ledgerhq/coin-module-framework/promises";
+import { EXPLORER_TRANSFER_TYPES } from "../constants";
+import { apiClient } from "../network/api";
+import {
+  enrichPrivateRecords,
+  fetchAllOwnedRecords,
+  fetchAllTokens,
+  fetchTransitionPage,
+  getRecordScannerStatusOrThrow,
+  resolveTransferArguments,
+} from "../network/utils";
+import type {
+  AleoCoinConfig,
+  AleoPrivateRecord,
+  AleoPublicTransaction,
+  AleoTokenType,
+  AleoTransitionCursor,
+  AleoExactTransitionCursor,
+  OperationsCursor,
+} from "../types";
+import { lastBlock } from "./lastBlock";
+import {
+  classifyAleoTokenType,
+  hasPublicAddress,
+  isParsableTransferFunction,
+  stripBatcherSuffix,
+  toPrivateOperation,
+  toPublicOperation,
+} from "./utils";
+
+function encodeCursor(maxBlockHeight: number, resumeFrom: AleoExactTransitionCursor): string {
+  return `${maxBlockHeight}:${resumeFrom.blockNumber}:${resumeFrom.transitionId}`;
+}
+
+function isValidHeight(raw: string | undefined): boolean {
+  return Boolean(raw) && Number.isInteger(Number(raw)) && Number(raw) >= 0;
+}
+
+function decodeCursor(raw: string): OperationsCursor {
+  const [maxBlockHeight, blockNumber, transitionId] = raw.split(":");
+  invariant(
+    isValidHeight(maxBlockHeight) && isValidHeight(blockNumber) && transitionId,
+    "aleo: malformed listOperations cursor",
+  );
+
+  return {
+    maxBlockHeight: Number(maxBlockHeight),
+    resumeFrom: { blockNumber: Number(blockNumber), transitionId },
+  };
+}
+
+function firstPageCursor({
+  order,
+  minHeight,
+  maxBlockHeight,
+}: {
+  order: "asc" | "desc";
+  minHeight: number;
+  maxBlockHeight: number;
+}): AleoTransitionCursor | undefined {
+  if (order === "desc") return { blockNumber: maxBlockHeight + 1 };
+
+  return minHeight > 0 ? { blockNumber: minHeight - 1 } : undefined;
+}
+
+// One row per transition, so a multi-transition transaction arrives as several rows. An addressed
+// row is the real transfer; ties break on `transition_id` so a replayed page picks the same row.
+function dedupeByTransaction(transitions: AleoPublicTransaction[]): AleoPublicTransaction[] {
+  const byTransactionId = new Map<string, AleoPublicTransaction>();
+
+  for (const tx of transitions) {
+    const current = byTransactionId.get(tx.transaction_id);
+
+    if (current) {
+      const candidateIsAddressed = hasPublicAddress(tx);
+      const currentIsAddressed = hasPublicAddress(current);
+      const isBetter =
+        candidateIsAddressed === currentIsAddressed
+          ? tx.transition_id < current.transition_id
+          : candidateIsAddressed;
+
+      if (!isBetter) continue;
+    }
+
+    byTransactionId.set(tx.transaction_id, tx);
+  }
+
+  return [...byTransactionId.values()];
+}
+
+function compareHash(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+// A self-transfer owns both the output record and the change record, but produces one operation.
+function isEarlierOutput(candidate: AleoPrivateRecord, current: AleoPrivateRecord): boolean {
+  if (candidate.output_index !== current.output_index) {
+    return candidate.output_index < current.output_index;
+  }
+
+  return candidate.commitment < current.commitment;
+}
+
+/**
+ * The private side of one page: an operation per owned record whose transaction has no public row,
+ * plus `ownedRecordTxIds` for the transactions that do have one — those only need tagging.
+ */
+async function collectPrivateOperations({
+  config,
+  address,
+  provableId,
+  viewKey,
+  publicTxIds,
+  recordsFrom,
+  recordsTo,
+  tokenTypeByProgramName,
+}: {
+  config: AleoCoinConfig;
+  address: string;
+  provableId: string;
+  viewKey: string;
+  publicTxIds: Set<string>;
+  recordsFrom: number;
+  recordsTo: number;
+  tokenTypeByProgramName: ReadonlyMap<string, AleoTokenType>;
+}): Promise<{ ownedRecordTxIds: Set<string>; operations: Operation[] }> {
+  const records = await fetchAllOwnedRecords({
+    config,
+    uuid: provableId,
+    start: recordsFrom,
+    end: recordsTo,
+    // Both filters are server-side exact matches: `programs` would drop token records, and
+    // `functions` would drop the batcher wrappers. Empty opts out of both; filtered below instead.
+    programs: [],
+    functions: [],
+  });
+
+  const ownedRecordTxIds = new Set<string>();
+  const byTransactionId = new Map<string, AleoPrivateRecord>();
+
+  for (const record of records) {
+    if (!isParsableTransferFunction(record.function_name)) continue;
+
+    // Redundant with the scanner's own bounds, but a page that re-emitted a covered block would
+    // duplicate operations, so the window is not left to the filter alone.
+    if (record.block_height < recordsFrom || record.block_height > recordsTo) continue;
+
+    const transactionId = record.transaction_id.trim();
+    ownedRecordTxIds.add(transactionId);
+    if (publicTxIds.has(transactionId)) continue;
+
+    const current = byTransactionId.get(transactionId);
+    if (!current || isEarlierOutput(record, current)) {
+      byTransactionId.set(transactionId, record);
+    }
+  }
+
+  const enriched = await enrichPrivateRecords({
+    config,
+    viewKey,
+    address,
+    records: [...byTransactionId.values()],
+  });
+
+  return {
+    ownedRecordTxIds,
+    operations: enriched.flatMap(record =>
+      record ? [toPrivateOperation(record, address, tokenTypeByProgramName)] : [],
+    ),
+  };
+}
+
+/**
+ * A shield to a third party is the one counterparty no owned record reveals: the explorer blanks the
+ * recipient and the account owns nothing on the private side, so the address has to be read back out
+ * of the transition inputs. Only those rows are looked up, so an account that only ever shields to
+ * itself pays for no extra requests.
+ */
+async function resolveThirdPartyShieldRecipients({
+  config,
+  viewKey,
+  transactions,
+  ownedRecordTxIds,
+}: {
+  config: AleoCoinConfig;
+  viewKey: string;
+  transactions: AleoPublicTransaction[];
+  ownedRecordTxIds: Set<string>;
+}): Promise<Map<string, string>> {
+  const unresolved = transactions.filter(
+    tx =>
+      stripBatcherSuffix(tx.function_id) === EXPLORER_TRANSFER_TYPES.PUBLIC_TO_PRIVATE &&
+      !tx.recipient_address &&
+      !ownedRecordTxIds.has(tx.transaction_id),
+  );
+
+  const recipients = new Map<string, string>();
+
+  await promiseAllBatched(4, unresolved, async ({ transaction_id: transactionId }) => {
+    const { execution } = await apiClient.getTransactionById(config, transactionId);
+    const transition = execution?.transitions[0];
+    if (!transition) return;
+
+    const transferArguments = await resolveTransferArguments({
+      config,
+      transition,
+      transactionId,
+      viewKey,
+    });
+
+    if (transferArguments) {
+      recipients.set(transactionId, transferArguments.recipient);
+    }
+  });
+
+  return recipients;
+}
+
+export async function listOperations({
+  config,
+  address,
+  options,
+  provableId,
+  viewKey,
+}: {
+  config: AleoCoinConfig;
+  address: string;
+  options: ListOperationsOptions;
+  provableId: string;
+  viewKey: string;
+}): Promise<Page<Operation>> {
+  const { minHeight } = options;
+  const order = options.order ?? "asc";
+  const cursor = options.cursor ? decodeCursor(options.cursor) : null;
+
+  const [latestBlock, scannerStatus, allTokens] = await Promise.all([
+    lastBlock(config),
+    // Read on every page so a dropped enrollment surfaces as AleoApiConfigurationResetError.
+    getRecordScannerStatusOrThrow(config, provableId),
+    // perf: re-read per page by design — a handful of tokens, one request in practice.
+    fetchAllTokens({ config }),
+  ]);
+
+  const tokenTypeByProgramName = new Map<string, AleoTokenType>(
+    allTokens.map(token => [token.program_name, classifyAleoTokenType(token)]),
+  );
+
+  // Above the scanner's watermark a shielded transfer would be listed as a bare public row and
+  // change shape on a later sync, so the listing stops there. Pinned in the cursor so every page of
+  // one listing sees the same snapshot.
+  const scannerCeiling = scannerStatus.synced_up_to ?? 0;
+  const maxBlockHeight = Math.min(cursor?.maxBlockHeight ?? scannerCeiling, latestBlock.height);
+
+  // A resume cursor names the last row of a block already emitted whole, so this page starts past
+  // it — otherwise the record fetch below re-emits the private-only records of covered blocks.
+  const resumeFrom = cursor?.resumeFrom;
+  const windowFrom =
+    resumeFrom && order === "asc" ? Math.max(minHeight, resumeFrom.blockNumber + 1) : minHeight;
+  const windowTo =
+    resumeFrom && order === "desc"
+      ? Math.min(maxBlockHeight, resumeFrom.blockNumber - 1)
+      : maxBlockHeight;
+
+  if (windowFrom > windowTo) return { items: [], next: undefined };
+
+  const pageCursor = resumeFrom ?? firstPageCursor({ order, minHeight, maxBlockHeight });
+  const { transitions, next } = await fetchTransitionPage({
+    config,
+    address,
+    order,
+    ...(options.limit && { limit: options.limit }),
+    ...(pageCursor && { cursor: pageCursor }),
+  });
+
+  const inWindow = transitions.filter(
+    tx => tx.block_number >= windowFrom && tx.block_number <= windowTo,
+  );
+  // Once the stream leaves the window there is nothing left to resume from.
+  const isLastPage = next === null || inWindow.length < transitions.length;
+
+  const lastFullBlockRow = isLastPage ? undefined : inWindow.at(-1);
+  const recordsFrom =
+    lastFullBlockRow && order === "desc" ? lastFullBlockRow.block_number : windowFrom;
+  const recordsTo = lastFullBlockRow && order === "asc" ? lastFullBlockRow.block_number : windowTo;
+
+  const publicTransactions = dedupeByTransaction(inWindow);
+  const publicTxIds = new Set(publicTransactions.map(tx => tx.transaction_id));
+
+  const { ownedRecordTxIds, operations: privateOperations } = await collectPrivateOperations({
+    config,
+    address,
+    provableId,
+    viewKey,
+    publicTxIds,
+    recordsFrom,
+    recordsTo,
+    tokenTypeByProgramName,
+  });
+
+  const shieldRecipients = await resolveThirdPartyShieldRecipients({
+    config,
+    viewKey,
+    transactions: publicTransactions,
+    ownedRecordTxIds,
+  });
+
+  const operations = publicTransactions.map(rawTx => {
+    const resolvedRecipient = shieldRecipients.get(rawTx.transaction_id);
+
+    return toPublicOperation({
+      rawTx,
+      address,
+      hasOwnedRecord: ownedRecordTxIds.has(rawTx.transaction_id),
+      tokenTypeByProgramName,
+      ...(resolvedRecipient && { resolvedRecipient }),
+    });
+  });
+  operations.push(...privateOperations);
+
+  const direction = order === "asc" ? 1 : -1;
+  operations.sort(
+    (a, b) =>
+      direction * (a.tx.block.height - b.tx.block.height || compareHash(a.tx.hash, b.tx.hash)),
+  );
+
+  return {
+    items: operations,
+    next: isLastPage || next === null ? undefined : encodeCursor(maxBlockHeight, next),
+  };
+}

--- a/libs/coin-modules/coin-aleo/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/listOperations.ts
@@ -95,7 +95,9 @@ function dedupeByTransaction(transitions: AleoPublicTransaction[]): AleoPublicTr
 }
 
 function compareHash(a: string, b: string): number {
-  return a < b ? -1 : a > b ? 1 : 0;
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
 }
 
 // A self-transfer owns both the output record and the change record, but produces one operation.

--- a/libs/coin-modules/coin-aleo/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/listOperations.ts
@@ -204,9 +204,11 @@ async function resolveThirdPartyShieldRecipients({
 
   const recipients = new Map<string, string>();
 
-  await promiseAllBatched(4, unresolved, async ({ transaction_id: transactionId }) => {
+  await promiseAllBatched(4, unresolved, async tx => {
+    const transactionId = tx.transaction_id;
     const { execution } = await apiClient.getTransactionById(config, transactionId);
-    const transition = execution?.transitions[0];
+    const transition =
+      execution?.transitions.find(ts => ts.id === tx.transition_id) ?? execution?.transitions[0];
     if (!transition) return;
 
     const transferArguments = await resolveTransferArguments({

--- a/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
@@ -47,7 +47,13 @@ import {
   mockTxIntentConvertTokenPrivateToPublic,
   mockTxIntentConvertTokenPrivateToPublic2,
 } from "../__tests__/fixtures/transaction.fixture";
-import type { AleoContext, AleoOperationExtra, ProvableApi } from "../types";
+import type {
+  AleoContext,
+  AleoOperationExtra,
+  AleoPublicTransaction,
+  AleoTokenType,
+  ProvableApi,
+} from "../types";
 import {
   parseMicrocredits,
   parseAmount,
@@ -58,7 +64,8 @@ import {
   findTransferArguments,
   determineTransactionType,
   patchAccountWithViewKey,
-  toCoinFrameworkOperation,
+  toPublicOperation,
+  hasPublicAddress,
   resolveConfig,
   getTransactionType,
   buildFeeConfigurationForRootIntent,
@@ -395,14 +402,42 @@ describe("determineTransactionType", () => {
   );
 });
 
-describe("toCoinFrameworkOperation", () => {
+describe("hasPublicAddress", () => {
+  it("should be true when either side is set", () => {
+    expect(hasPublicAddress(getMockedPublicTransaction({ recipient_address: "" }))).toBe(true);
+    expect(hasPublicAddress(getMockedPublicTransaction({ sender_address: "" }))).toBe(true);
+  });
+
+  it("should be false when both sides are blank", () => {
+    expect(
+      hasPublicAddress(getMockedPublicTransaction({ sender_address: "", recipient_address: "" })),
+    ).toBe(false);
+  });
+
+  it("should treat a missing address like a blank one", () => {
+    // the explorer is typed to send "" but has been seen omitting the field entirely
+    const { sender_address: _, recipient_address: __, ...rawTx } = getMockedPublicTransaction();
+
+    expect(hasPublicAddress(rawTx as AleoPublicTransaction)).toBe(false);
+  });
+});
+
+const NO_TOKENS = new Map<string, AleoTokenType>();
+
+describe("toPublicOperation", () => {
   const recipientAddress = "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px";
   const senderAddress = "aleo1a2ehlgqhvs3p7d4hqhs0tvgk954dr8gafu9kxse2mzu9a5sqxvpsrn98pr";
+  const otherAddress = "aleo1test123address456";
 
   it("should set type to IN when address is the recipient", () => {
     const rawTx = getMockedPublicTransaction();
 
-    const result = toCoinFrameworkOperation(rawTx, recipientAddress);
+    const result = toPublicOperation({
+      rawTx,
+      address: recipientAddress,
+      hasOwnedRecord: false,
+      tokenTypeByProgramName: NO_TOKENS,
+    });
 
     expect(result.type).toBe("IN");
   });
@@ -410,23 +445,65 @@ describe("toCoinFrameworkOperation", () => {
   it("should set type to OUT when address is the sender", () => {
     const rawTx = getMockedPublicTransaction();
 
-    const result = toCoinFrameworkOperation(rawTx, senderAddress);
+    const result = toPublicOperation({
+      rawTx,
+      address: senderAddress,
+      hasOwnedRecord: false,
+      tokenTypeByProgramName: NO_TOKENS,
+    });
 
     expect(result.type).toBe("OUT");
   });
 
-  it("should set type to NONE when program_id is not CREDITS", () => {
-    const rawTx = getMockedPublicTransaction({ program_id: "custom.aleo" });
+  it("should set type to NONE when address is neither sender nor recipient", () => {
+    const rawTx = getMockedPublicTransaction();
 
-    const result = toCoinFrameworkOperation(rawTx, recipientAddress);
+    const result = toPublicOperation({
+      rawTx,
+      address: otherAddress,
+      hasOwnedRecord: false,
+      tokenTypeByProgramName: NO_TOKENS,
+    });
 
     expect(result.type).toBe("NONE");
+  });
+
+  it("should map a token program to the standard the registry reports", () => {
+    const rawTx = getMockedPublicTransaction({ program_id: "custom.aleo" });
+
+    const result = toPublicOperation({
+      rawTx,
+      address: recipientAddress,
+      hasOwnedRecord: false,
+      tokenTypeByProgramName: new Map([["custom.aleo", "arc20"]]),
+    });
+
+    expect(result.asset).toEqual({ type: "arc20", assetReference: "custom.aleo" });
+    expect(result.type).toBe("IN");
+  });
+
+  it("should map a program missing from the registry to an unknown asset", () => {
+    const rawTx = getMockedPublicTransaction({ program_id: "custom.aleo" });
+
+    const result = toPublicOperation({
+      rawTx,
+      address: recipientAddress,
+      hasOwnedRecord: false,
+      tokenTypeByProgramName: NO_TOKENS,
+    });
+
+    expect(result.asset).toEqual({ type: "unknown", assetReference: "custom.aleo" });
   });
 
   it("should map core fields from rawTx", () => {
     const rawTx = getMockedPublicTransaction();
 
-    const result = toCoinFrameworkOperation(rawTx, recipientAddress);
+    const result = toPublicOperation({
+      rawTx,
+      address: recipientAddress,
+      hasOwnedRecord: false,
+      tokenTypeByProgramName: NO_TOKENS,
+    });
 
     expect(result.id).toBe(rawTx.transaction_id);
     expect(result.senders).toEqual([rawTx.sender_address]);
@@ -441,7 +518,12 @@ describe("toCoinFrameworkOperation", () => {
   it("should derive fees and blockHash from rawTx", () => {
     const rawTx = getMockedPublicTransaction();
 
-    const result = toCoinFrameworkOperation(rawTx, recipientAddress);
+    const result = toPublicOperation({
+      rawTx,
+      address: recipientAddress,
+      hasOwnedRecord: false,
+      tokenTypeByProgramName: NO_TOKENS,
+    });
 
     expect(result.tx.fees).toBe(BigInt(rawTx.fee));
     expect(result.tx.block.hash).toBe(rawTx.block_hash);
@@ -451,7 +533,12 @@ describe("toCoinFrameworkOperation", () => {
     const amountU128 = "123456789012345678901234567890";
     const rawTx = getMockedPublicTransaction({ amount: 10000000, amount_u128: amountU128 });
 
-    const result = toCoinFrameworkOperation(rawTx, recipientAddress);
+    const result = toPublicOperation({
+      rawTx,
+      address: recipientAddress,
+      hasOwnedRecord: false,
+      tokenTypeByProgramName: NO_TOKENS,
+    });
 
     expect(result.value).toBe(BigInt(amountU128));
   });
@@ -459,7 +546,12 @@ describe("toCoinFrameworkOperation", () => {
   it("should set failed to true when transaction_status is not Accepted", () => {
     const rawTx = getMockedPublicTransaction({ transaction_status: "Rejected" });
 
-    const result = toCoinFrameworkOperation(rawTx, recipientAddress);
+    const result = toPublicOperation({
+      rawTx,
+      address: recipientAddress,
+      hasOwnedRecord: false,
+      tokenTypeByProgramName: NO_TOKENS,
+    });
 
     expect(result.tx.failed).toBe(true);
   });
@@ -467,12 +559,131 @@ describe("toCoinFrameworkOperation", () => {
   it("should include functionId, transactionType, and ledgerOpType in details", () => {
     const rawTx = getMockedPublicTransaction();
 
-    const result = toCoinFrameworkOperation(rawTx, recipientAddress);
+    const result = toPublicOperation({
+      rawTx,
+      address: recipientAddress,
+      hasOwnedRecord: false,
+      tokenTypeByProgramName: NO_TOKENS,
+    });
 
     expect(result.details).toMatchObject({
       functionId: rawTx.function_id,
       ledgerOpType: "IN",
     });
+  });
+
+  it("should fill a blank recipient with the account address when it owns a record", () => {
+    const rawTx = getMockedPublicTransaction({
+      function_id: "transfer_public_to_private",
+      recipient_address: "",
+    });
+
+    const result = toPublicOperation({
+      rawTx,
+      address: senderAddress,
+      hasOwnedRecord: true,
+      tokenTypeByProgramName: NO_TOKENS,
+    });
+
+    expect(result.recipients).toEqual([senderAddress]);
+    // sender wins: the balance the transfer left is still the public one
+    expect(result.type).toBe("OUT");
+  });
+
+  it("should fill a blank sender with the account address when it owns a record", () => {
+    const rawTx = getMockedPublicTransaction({
+      function_id: "transfer_private_to_public",
+      sender_address: "",
+    });
+
+    const result = toPublicOperation({
+      rawTx,
+      address: recipientAddress,
+      hasOwnedRecord: true,
+      tokenTypeByProgramName: NO_TOKENS,
+    });
+
+    expect(result.senders).toEqual([recipientAddress]);
+    expect(result.type).toBe("OUT");
+  });
+
+  it("should leave blank addresses alone when no record is owned", () => {
+    const rawTx = getMockedPublicTransaction({ recipient_address: "" });
+
+    const result = toPublicOperation({
+      rawTx,
+      address: senderAddress,
+      hasOwnedRecord: false,
+      tokenTypeByProgramName: NO_TOKENS,
+    });
+
+    expect(result.recipients).toEqual([""]);
+  });
+
+  it("should set type to IN for a self-transfer, as the classic bridge does", () => {
+    const rawTx = getMockedPublicTransaction({
+      sender_address: senderAddress,
+      recipient_address: senderAddress,
+    });
+
+    const result = toPublicOperation({
+      rawTx,
+      address: senderAddress,
+      hasOwnedRecord: false,
+      tokenTypeByProgramName: NO_TOKENS,
+    });
+
+    expect(result.type).toBe("IN");
+  });
+
+  it("should keep a self shield OUT, since the explorer blanked the recipient", () => {
+    const rawTx = getMockedPublicTransaction({
+      sender_address: senderAddress,
+      recipient_address: "",
+      function_id: "transfer_public_to_private",
+    });
+
+    const result = toPublicOperation({
+      rawTx,
+      address: senderAddress,
+      hasOwnedRecord: true,
+      tokenTypeByProgramName: NO_TOKENS,
+    });
+
+    expect(result.type).toBe("OUT");
+    expect(result.recipients).toEqual([senderAddress]);
+  });
+
+  it("should use the resolved shield recipient when the explorer blanked it", () => {
+    const rawTx = getMockedPublicTransaction({
+      recipient_address: "",
+      function_id: "transfer_public_to_private",
+    });
+
+    const result = toPublicOperation({
+      rawTx,
+      address: senderAddress,
+      hasOwnedRecord: false,
+      tokenTypeByProgramName: NO_TOKENS,
+      resolvedRecipient: recipientAddress,
+    });
+
+    expect(result.recipients).toEqual([recipientAddress]);
+    expect(result.type).toBe("OUT");
+  });
+
+  it("should prefer the explorer's recipient over a resolved one", () => {
+    const rawTx = getMockedPublicTransaction({ recipient_address: recipientAddress });
+
+    const result = toPublicOperation({
+      rawTx,
+      address: senderAddress,
+      hasOwnedRecord: false,
+      tokenTypeByProgramName: NO_TOKENS,
+      resolvedRecipient: "aleo1someoneelse",
+    });
+
+    expect(result.recipients).toEqual([recipientAddress]);
   });
 });
 

--- a/libs/coin-modules/coin-aleo/src/logic/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.ts
@@ -9,6 +9,7 @@ import type {
   TokenAccount,
 } from "@ledgerhq/types-live";
 import type {
+  AssetInfo,
   Operation as CoinFrameworkOperation,
   MemoNotSupported,
   TransactionIntent,
@@ -57,6 +58,7 @@ import type {
   AleoContext,
   AleoTokenDetails,
   AleoTokenType,
+  EnrichedPrivateRecord,
 } from "../types";
 
 const MICROCREDITS_REGEX = /^(\d+)u\d+$/;
@@ -188,8 +190,17 @@ export function resolveTransactionAmount(rawTx: AleoPublicTransaction): BigNumbe
   return new BigNumber(rawTx.amount_u128 ?? rawTx.amount);
 }
 
+export function hasPublicAddress(rawTx: AleoPublicTransaction): boolean {
+  return Boolean(rawTx.sender_address || rawTx.recipient_address);
+}
+
+/** Explorer and scanner both timestamp blocks in seconds. */
+export function toBlockDate(blockTimestamp: string | number): Date {
+  return new Date(Number(blockTimestamp) * 1000);
+}
+
 export function parseTransactionFields(rawTx: AleoPublicTransaction, address: string) {
-  const date = new Date(Number(rawTx.block_timestamp) * 1000);
+  const date = toBlockDate(rawTx.block_timestamp);
   const hasFailed = rawTx.transaction_status !== "Accepted";
   let type: OperationType = "NONE";
   const fee = rawTx.fee;
@@ -204,36 +215,130 @@ export function parseTransactionFields(rawTx: AleoPublicTransaction, address: st
   return { type, fee, blockHash, transactionType, date, hasFailed };
 }
 
-export const toCoinFrameworkOperation = (
+/**
+ * A program is only a token of a given standard because the token registry says so — nothing in the
+ * program id tells them apart, so a program the registry does not list stays "unknown".
+ */
+function toOperationAsset(
+  programId: string,
+  tokenTypeByProgramName: ReadonlyMap<string, AleoTokenType>,
+): AssetInfo {
+  return programId === PROGRAM_ID.CREDITS
+    ? { type: "native" }
+    : { type: tokenTypeByProgramName.get(programId) ?? "unknown", assetReference: programId };
+}
+
+/**
+ * `sender`/`recipient` are the addresses after a blank side was substituted with the account's own;
+ * `rawTx` still shows which sides the explorer actually published.
+ *
+ * A token transfer is typed IN/OUT here, where `parseTransactionFields` (still used by the classic
+ * bridge) returns NONE: the framework operation carries the program as its asset, so there is
+ * nothing left for NONE to guard.
+ */
+function resolveOperationType(
   rawTx: AleoPublicTransaction,
   address: string,
-): CoinFrameworkOperation => {
-  const { type, fee, blockHash, transactionType, date, hasFailed } = parseTransactionFields(
-    rawTx,
-    address,
-  );
+  sender: string,
+  recipient: string,
+): OperationType {
+  if (rawTx.sender_address === address && rawTx.recipient_address === address) return "IN";
+  if (sender === address) return "OUT";
+  if (recipient === address) return "IN";
+
+  return "NONE";
+}
+
+/**
+ * The account's own view of a public transaction, merged with what its private records reveal.
+ *
+ * `hasOwnedRecord` means a record the account owns shares this transaction, so an address the
+ * explorer left blank is the account's own private side.
+ *
+ * `resolvedRecipient` is the third-party recipient of a shield read back from the transition inputs
+ * (see resolveThirdPartyShieldRecipients) — the explorer blanks it and no owned record can stand in
+ * for it.
+ */
+export const toPublicOperation = ({
+  rawTx,
+  address,
+  hasOwnedRecord,
+  tokenTypeByProgramName,
+  resolvedRecipient,
+}: {
+  rawTx: AleoPublicTransaction;
+  address: string;
+  hasOwnedRecord: boolean;
+  tokenTypeByProgramName: ReadonlyMap<string, AleoTokenType>;
+  resolvedRecipient?: string;
+}): CoinFrameworkOperation => {
+  const hash = rawTx.transaction_id.trim();
+  const date = toBlockDate(rawTx.block_timestamp);
+  const sender = !rawTx.sender_address && hasOwnedRecord ? address : rawTx.sender_address;
+  const recipient =
+    !rawTx.recipient_address && hasOwnedRecord
+      ? address
+      : rawTx.recipient_address || (resolvedRecipient ?? "");
+  const type = resolveOperationType(rawTx, address, sender, recipient);
+
   return {
-    id: rawTx.transaction_id,
+    id: hash,
     type,
-    recipients: [rawTx.recipient_address],
-    senders: [rawTx.sender_address],
+    senders: [sender],
+    recipients: [recipient],
     value: BigInt(resolveTransactionAmount(rawTx).toFixed(0)),
-    asset: { type: "native" },
+    asset: toOperationAsset(rawTx.program_id, tokenTypeByProgramName),
     details: {
       functionId: rawTx.function_id,
-      transactionType,
+      transactionType: determineTransactionType(rawTx.function_id, type),
       ledgerOpType: type,
     },
     tx: {
-      hash: rawTx.transaction_id,
-      fees: BigInt(fee.toFixed(0)),
-      date: date,
+      hash,
+      fees: BigInt(new BigNumber(rawTx.fee).toFixed(0)),
+      date,
       block: {
-        hash: blockHash,
+        hash: rawTx.block_hash,
         height: rawTx.block_number,
         time: date,
       },
-      failed: hasFailed ?? false,
+      failed: rawTx.transaction_status !== "Accepted",
+    },
+  };
+};
+
+export const toPrivateOperation = (
+  enrichedRecord: EnrichedPrivateRecord,
+  address: string,
+  tokenTypeByProgramName: ReadonlyMap<string, AleoTokenType>,
+): CoinFrameworkOperation => {
+  const { rawRecord, details } = enrichedRecord;
+  const hash = rawRecord.transaction_id.trim();
+  const date = toBlockDate(rawRecord.block_timestamp);
+  const type: OperationType = enrichedRecord.recipient === address ? "IN" : "OUT";
+
+  return {
+    id: hash,
+    type,
+    senders: [enrichedRecord.sender],
+    recipients: [enrichedRecord.recipient],
+    value: BigInt(enrichedRecord.value.toFixed(0)),
+    asset: toOperationAsset(rawRecord.program_name, tokenTypeByProgramName),
+    details: {
+      functionId: rawRecord.function_name,
+      transactionType: "private",
+      ledgerOpType: type,
+    },
+    tx: {
+      hash,
+      fees: BigInt(new BigNumber(details.fee_value).toFixed(0)),
+      date,
+      block: {
+        hash: details.block_hash,
+        height: rawRecord.block_height,
+        time: date,
+      },
+      failed: details.status !== "Accepted",
     },
   };
 };
@@ -1134,14 +1239,21 @@ export function isAleoAmountPlaintext(v: string): boolean {
 }
 
 /**
+ * Ledger's batching wrappers suffix the wrapped function with the record count
+ * (transfer_private_2, transfer_public_to_private_4), so an exact name match misses them.
+ */
+export function stripBatcherSuffix(functionName: string): string {
+  return functionName.replace(/_\d+$/, "");
+}
+
+/**
  * Whether a transition's (recipient, amount) arguments can be located by scanning for the first
- * address-shaped argument. Ledger's batching wrappers suffix the function with the record count
- * (transfer_private_4) but keep the wrapped function's argument order.
+ * address-shaped argument. A batching wrapper keeps the wrapped function's argument order.
  *
  * Excludes transfer_from_*, whose first address argument is the sender, not the recipient.
  */
 export function isParsableTransferFunction(functionName: string): boolean {
-  return PRIVATE_TRANSFER_FUNCTIONS.has(functionName.replace(/_\d+$/, ""));
+  return PRIVATE_TRANSFER_FUNCTIONS.has(stripBatcherSuffix(functionName));
 }
 
 /**

--- a/libs/coin-modules/coin-aleo/src/network/api.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/api.test.ts
@@ -186,7 +186,7 @@ describe("apiClient", () => {
     });
 
     it("should fetch transactions with cursor for pagination", async () => {
-      const cursor = "123456";
+      const cursor = { blockNumber: 123456 };
       const mockResponse = getMockedAccountPublicTransactions(MOCK_ALEO_ADDRESS, {
         transactions: [],
         prev_cursor: {
@@ -210,7 +210,7 @@ describe("apiClient", () => {
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${mockConfig.apiUrls.node}/v2/${mockConfig.networkType}/transactions/address/${MOCK_ALEO_ADDRESS}?metadata=true&limit=50&sort=asc&direction=next&token_info=true&cursor_block_number=${cursor}`,
+        url: `${mockConfig.apiUrls.node}/v2/${mockConfig.networkType}/transactions/address/${MOCK_ALEO_ADDRESS}?metadata=true&limit=50&sort=asc&direction=next&token_info=true&cursor_block_number=${cursor.blockNumber}`,
       });
     });
 
@@ -235,7 +235,7 @@ describe("apiClient", () => {
     });
 
     it("should fetch transactions with all custom parameters", async () => {
-      const cursor = "999999";
+      const cursor = { blockNumber: 999999, transitionId: "au1resume" };
       const mockResponse = getMockedAccountPublicTransactions(MOCK_ALEO_ADDRESS, {
         transactions: [
           {
@@ -269,7 +269,7 @@ describe("apiClient", () => {
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${mockConfig.apiUrls.node}/v2/${mockConfig.networkType}/transactions/address/${MOCK_ALEO_ADDRESS}?metadata=true&limit=20&sort=desc&direction=prev&token_info=true&cursor_block_number=${cursor}`,
+        url: `${mockConfig.apiUrls.node}/v2/${mockConfig.networkType}/transactions/address/${MOCK_ALEO_ADDRESS}?metadata=true&limit=20&sort=desc&direction=prev&token_info=true&cursor_block_number=${cursor.blockNumber}&cursor_transition_id=${cursor.transitionId}`,
       });
       expect(result).toEqual(mockResponse);
     });
@@ -673,6 +673,25 @@ describe("apiClient", () => {
       expect(network).toHaveBeenCalledWith(
         expect.objectContaining({
           data: { filter: { start: mockStart }, uuid: mockUuid },
+        }),
+      );
+    });
+
+    it("should include `filter.end` in the request body when end is provided", async () => {
+      const mockStart = 14192648;
+      jest.mocked(network).mockResolvedValue({ data: [testnetPrivateRecord], status: 200 });
+
+      await apiClient.getAccountOwnedRecords({
+        config: mockConfig,
+        uuid: mockUuid,
+        start: mockStart,
+        end: mockStart + 100,
+      });
+
+      expect(network).toHaveBeenCalledTimes(1);
+      expect(network).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { filter: { start: mockStart, end: mockStart + 100 }, uuid: mockUuid },
         }),
       );
     });

--- a/libs/coin-modules/coin-aleo/src/network/api.ts
+++ b/libs/coin-modules/coin-aleo/src/network/api.ts
@@ -11,9 +11,10 @@ import type {
   AleoGetTokensResponse,
   AleoPrivateRecord,
   DelegatedProvingResponse,
+  AleoTransitionCursor,
 } from "../types/api";
 import type { AleoCoinConfig } from "../types";
-import { PROGRAM_ID } from "../constants";
+import { MAX_TRANSITIONS_PER_PAGE, PROGRAM_ID } from "../constants";
 
 async function getLatestBlock(config: AleoCoinConfig): Promise<AleoLatestBlockResponse> {
   const { apiUrls, networkType } = config;
@@ -114,13 +115,13 @@ async function getAccountPublicTransactions({
   config,
   address,
   cursor,
-  limit = 50,
+  limit = MAX_TRANSITIONS_PER_PAGE,
   order = "asc",
   direction = "next",
 }: {
   config: AleoCoinConfig;
   address: string;
-  cursor?: string;
+  cursor?: AleoTransitionCursor;
   limit?: number;
   order?: "asc" | "desc";
   direction?: "prev" | "next";
@@ -128,11 +129,16 @@ async function getAccountPublicTransactions({
   const { apiUrls, networkType } = config;
   const params = new URLSearchParams({
     metadata: "true",
-    limit: limit.toString(),
+    limit: Math.min(limit, MAX_TRANSITIONS_PER_PAGE).toString(),
     sort: order,
     direction,
     token_info: "true",
-    ...(cursor && { cursor_block_number: cursor }),
+    ...(cursor && {
+      cursor_block_number: cursor.blockNumber.toString(),
+      // Sending the block alone resumes after the *whole* block, silently dropping the transitions of
+      // it that were not read yet. Verified against mainnet: 10 of 357 rows lost on one account.
+      ...(cursor.transitionId && { cursor_transition_id: cursor.transitionId }),
+    }),
   });
 
   const res: LiveNetworkResponse<AleoPublicTransactionsResponse> = await network({
@@ -202,6 +208,7 @@ async function getAccountOwnedRecords({
   uuid,
   unspent,
   start,
+  end,
   resultsPerPage,
   page,
   programs,
@@ -211,6 +218,7 @@ async function getAccountOwnedRecords({
   uuid: string;
   unspent?: boolean;
   start?: number;
+  end?: number;
   resultsPerPage?: number;
   page?: number;
   programs?: string[];
@@ -220,6 +228,7 @@ async function getAccountOwnedRecords({
 
   const filter = {
     ...(typeof start === "number" && { start }),
+    ...(typeof end === "number" && { end }),
     ...(typeof resultsPerPage === "number" && { results_per_page: resultsPerPage }),
     ...(typeof page === "number" && { page }),
     ...(programs && programs.length > 0 && { programs }),

--- a/libs/coin-modules/coin-aleo/src/network/utils.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.integ.test.ts
@@ -150,6 +150,33 @@ describe("fetchAllOwnedRecords", () => {
     expect(unspentFetch.length).toBe(fullFetch.filter(record => !record.spent).length);
   });
 
+  it("windows records by block height, both bounds inclusive", async () => {
+    const all = await fetchAllOwnedRecords({ config, uuid });
+    const heights = [...new Set(all.map(record => record.block_height))].sort((a, b) => a - b);
+    // guards that this fixture account spans enough blocks to window
+    expect(heights.length).toBeGreaterThan(2);
+
+    const [low] = heights;
+    const high = heights[heights.length - 2];
+    invariant(low !== undefined && high !== undefined, "guard: missing bounds");
+
+    const windowed = await fetchAllOwnedRecords({ config, uuid, start: low, end: high });
+
+    expect(windowed.length).toBeGreaterThan(0);
+    expect(
+      windowed.every(record => record.block_height >= low && record.block_height <= high),
+    ).toBe(true);
+    expect(windowed.some(record => record.block_height === low)).toBe(true);
+    expect(windowed.some(record => record.block_height === high)).toBe(true);
+    expect(windowed.length).toBeLessThan(all.length);
+  });
+
+  it("returns nothing for a window below the account's first record", async () => {
+    const records = await fetchAllOwnedRecords({ config, uuid, start: 1, end: 2 });
+
+    expect(records).toEqual([]);
+  });
+
   it("filters records by function name", async () => {
     const records = await fetchAllOwnedRecords({
       config,

--- a/libs/coin-modules/coin-aleo/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.test.ts
@@ -26,6 +26,7 @@ import {
   fetchAccountTransactionsFromHeight,
   fetchAllOwnedRecords,
   fetchAllTokens,
+  fetchTransitionPage,
   enrichPrivateRecord,
   enrichPrivateRecords,
   patchPublicOperations,
@@ -108,7 +109,7 @@ describe("network/utils", () => {
           address: mockAddress,
           limit: 50,
           order: "asc",
-          cursor: "140",
+          cursor: { blockNumber: 140 },
         });
         expect(result.transactions).toHaveLength(4);
         expect(result.nextCursor).toBeNull();
@@ -273,7 +274,7 @@ describe("network/utils", () => {
           address: mockAddress,
           limit: 50,
           order: "asc",
-          cursor,
+          cursor: { blockNumber: Number(cursor) },
         });
       });
     });
@@ -1295,6 +1296,156 @@ describe("network/utils", () => {
       expect(result?.value).toEqual(new BigNumber(25000));
     });
 
+    it("should locate recipient/amount at indices 1/2 when the token record has one leading record input (direct ARC-20-style call)", async () => {
+      const recipientAddress = "aleo1arc20explicit123";
+      const rawRecord = getMockedRecord({
+        function_name: EXPLORER_TRANSFER_TYPES.PRIVATE,
+        sender: mockEnrichAddress,
+        program_name: "arc20_token.aleo",
+        record_name: TOKEN_RECORD_NAME,
+        transition_index: 0,
+      });
+      const mockDetails = getMockedTransactionDetails(rawRecord.transaction_id, {
+        execution: {
+          transitions: [
+            {
+              id: "au1",
+              scm: "s",
+              tcm: "t",
+              tpk: "tpk_arc20",
+              inputs: [
+                { id: "in0", type: "record", tag: "record_tag_0" }, // leading spent record
+                { id: "in1", type: "private", value: "ciphertext_recipient" }, // recipient index = 1
+                { id: "in2", type: "private", value: "ciphertext_amount" }, // amount index = 2
+              ],
+              outputs: [],
+              program: "arc20_token.aleo",
+              function: "transfer_private",
+            },
+          ],
+        },
+      });
+      mockGetTransactionById.mockResolvedValueOnce(mockDetails);
+      mockDecryptCiphertext
+        .mockResolvedValueOnce({ plaintext: recipientAddress })
+        .mockResolvedValueOnce({ plaintext: "150000u64" });
+
+      const result = await enrichPrivateRecord({
+        config: mockConfig,
+        rawRecord,
+        address: mockEnrichAddress,
+        viewKey: mockViewKey,
+      });
+
+      expect(result?.recipient).toBe(recipientAddress);
+      expect(result?.value).toEqual(new BigNumber(150000));
+      expect(mockDecryptCiphertext).toHaveBeenCalledTimes(2);
+      expect(mockDecryptCiphertext).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ciphertext: "ciphertext_recipient",
+          outputIndex: 1,
+        }),
+      );
+      expect(mockDecryptCiphertext).toHaveBeenCalledWith(
+        expect.objectContaining({ ciphertext: "ciphertext_amount", outputIndex: 2 }),
+      );
+    });
+
+    it("should locate recipient/amount after N leading external_record inputs (Ledger multi-record batcher wrapper)", async () => {
+      const recipientAddress = "aleo1batcherrecipient789";
+      const rawRecord = getMockedRecord({
+        function_name: "transfer_private_2",
+        sender: mockEnrichAddress,
+        program_name: "ldg_usdcx_p_28.aleo",
+        record_name: TOKEN_RECORD_NAME,
+        transition_index: 0,
+      });
+      const mockDetails = getMockedTransactionDetails(rawRecord.transaction_id, {
+        execution: {
+          transitions: [
+            {
+              id: "au1",
+              scm: "s",
+              tcm: "t",
+              tpk: "tpk_batcher",
+              inputs: [
+                { id: "in0", type: "external_record" }, // consumed record #1, no tag
+                { id: "in1", type: "external_record" }, // consumed record #2, no tag
+                { id: "in2", type: "private", value: "ciphertext_recipient" }, // recipient index = 2
+                { id: "in3", type: "private", value: "ciphertext_amount" }, // amount index = 3
+                { id: "in4", type: "private", value: "ciphertext_exclusion_proof" },
+              ],
+              outputs: [],
+              program: "ldg_usdcx_p_28.aleo",
+              function: "transfer_private_2",
+            },
+          ],
+        },
+      });
+      mockGetTransactionById.mockResolvedValueOnce(mockDetails);
+      mockDecryptCiphertext
+        .mockResolvedValueOnce({ plaintext: recipientAddress })
+        .mockResolvedValueOnce({ plaintext: "250000u64" })
+        .mockRejectedValueOnce(new Error("cannot decrypt exclusion proof"));
+
+      const result = await enrichPrivateRecord({
+        config: mockConfig,
+        rawRecord,
+        address: mockEnrichAddress,
+        viewKey: mockViewKey,
+      });
+
+      expect(result?.recipient).toBe(recipientAddress);
+      expect(result?.value).toEqual(new BigNumber(250000));
+      expect(mockDecryptCiphertext).toHaveBeenCalledWith(
+        expect.objectContaining({ ciphertext: "ciphertext_recipient", outputIndex: 2 }),
+      );
+      expect(mockDecryptCiphertext).toHaveBeenCalledWith(
+        expect.objectContaining({ ciphertext: "ciphertext_amount", outputIndex: 3 }),
+      );
+    });
+
+    it("should return null for a pure record-consolidation transition (join) with no recipient/amount", async () => {
+      const rawRecord = getMockedRecord({
+        function_name: "join",
+        sender: mockEnrichAddress,
+        program_name: "usdcx_stablecoin.aleo",
+        record_name: TOKEN_RECORD_NAME,
+        transition_index: 0,
+      });
+      mockGetTransactionById.mockResolvedValueOnce(
+        getMockedTransactionDetails(rawRecord.transaction_id, {
+          execution: {
+            transitions: [
+              {
+                id: "au1",
+                scm: "s",
+                tcm: "t",
+                tpk: "tpk1",
+                inputs: [
+                  { id: "in0", type: "record", tag: "record_tag_0" },
+                  { id: "in1", type: "record", tag: "record_tag_1" },
+                ],
+                outputs: [],
+                program: "usdcx_stablecoin.aleo",
+                function: "join",
+              },
+            ],
+          },
+        }),
+      );
+
+      const result = await enrichPrivateRecord({
+        config: mockConfig,
+        rawRecord,
+        address: mockEnrichAddress,
+        viewKey: mockViewKey,
+      });
+
+      expect(result).toBeNull();
+      expect(mockDecryptCiphertext).not.toHaveBeenCalled();
+    });
+
     it("should return null without logging for a record-splitting transition (split)", async () => {
       const rawRecord = getMockedRecord({
         function_name: "split",
@@ -2294,6 +2445,121 @@ describe("network/utils", () => {
     });
   });
 
+  describe("fetchTransitionPage", () => {
+    const mockGetAccountPublicTransactions = jest.mocked(apiClient.getAccountPublicTransactions);
+
+    const row = (blockNumber: number, transitionId: string) =>
+      getMockedPublicTransaction({ block_number: blockNumber, transition_id: transitionId });
+
+    it("should defer the block the page stops inside and resume from an exact row", async () => {
+      // Mirrors mainnet block 20413950: 4 transitions of one transaction, page cut after the 2nd.
+      mockGetAccountPublicTransactions.mockResolvedValueOnce({
+        address: mockAddress,
+        transactions: [row(100, "au1a"), row(101, "au1b"), row(101, "au1c")],
+        next_cursor: { block_number: 101, transition_id: "au1c" },
+      });
+
+      const result = await fetchTransitionPage({
+        config: mockConfig,
+        address: mockAddress,
+        limit: 3,
+      });
+
+      expect(result.transitions.map(tx => tx.transition_id)).toEqual(["au1a"]);
+      expect(result.next).toEqual({ blockNumber: 100, transitionId: "au1a" });
+    });
+
+    it("should keep paging when the whole page sits in one block", async () => {
+      mockGetAccountPublicTransactions
+        .mockResolvedValueOnce({
+          address: mockAddress,
+          transactions: [row(100, "au1a"), row(100, "au1b")],
+          next_cursor: { block_number: 100, transition_id: "au1b" },
+        })
+        .mockResolvedValueOnce({
+          address: mockAddress,
+          transactions: [row(100, "au1c"), row(102, "au1d")],
+          next_cursor: { block_number: 102, transition_id: "au1d" },
+        });
+
+      const result = await fetchTransitionPage({
+        config: mockConfig,
+        address: mockAddress,
+        limit: 2,
+      });
+
+      expect(mockGetAccountPublicTransactions).toHaveBeenCalledTimes(2);
+      // block 100 is now whole, block 102 is the new open block
+      expect(result.transitions.map(tx => tx.transition_id)).toEqual(["au1a", "au1b", "au1c"]);
+      expect(result.next).toEqual({ blockNumber: 100, transitionId: "au1c" });
+    });
+
+    it("should resume the second page from the transition id, not the block alone", async () => {
+      mockGetAccountPublicTransactions.mockResolvedValueOnce({
+        address: mockAddress,
+        transactions: [row(101, "au1c")],
+      });
+
+      await fetchTransitionPage({
+        config: mockConfig,
+        address: mockAddress,
+        cursor: { blockNumber: 100, transitionId: "au1a" },
+      });
+
+      expect(mockGetAccountPublicTransactions).toHaveBeenCalledTimes(1);
+      expect(mockGetAccountPublicTransactions).toHaveBeenCalledWith({
+        config: mockConfig,
+        address: mockAddress,
+        order: "asc",
+        cursor: { blockNumber: 100, transitionId: "au1a" },
+      });
+    });
+
+    it("should return next null once the stream is exhausted", async () => {
+      mockGetAccountPublicTransactions.mockResolvedValueOnce({
+        address: mockAddress,
+        transactions: [row(100, "au1a"), row(100, "au1b")],
+      });
+
+      const result = await fetchTransitionPage({ config: mockConfig, address: mockAddress });
+
+      expect(result.transitions).toHaveLength(2);
+      expect(result.next).toBeNull();
+    });
+
+    it("should treat an empty page as exhausted", async () => {
+      mockGetAccountPublicTransactions.mockResolvedValueOnce({
+        address: mockAddress,
+        transactions: [],
+        next_cursor: { block_number: 100, transition_id: "au1a" },
+      });
+
+      const result = await fetchTransitionPage({ config: mockConfig, address: mockAddress });
+
+      expect(result).toEqual({ transitions: [], next: null });
+    });
+
+    it("should drop batcher outer call transitions", async () => {
+      mockGetAccountPublicTransactions.mockResolvedValueOnce({
+        address: mockAddress,
+        transactions: [
+          getMockedPublicTransaction({
+            block_number: 100,
+            transition_id: "au1inner",
+            function_id: "transfer_private_to_public",
+            sender_address: "",
+            recipient_address: "",
+          }),
+          row(100, "au1real"),
+        ],
+      });
+
+      const result = await fetchTransitionPage({ config: mockConfig, address: mockAddress });
+
+      expect(result.transitions.map(tx => tx.transition_id)).toEqual(["au1real"]);
+    });
+  });
+
   describe("fetchAllOwnedRecords", () => {
     const mockUUID = "uuid-abc-def";
     const mockGetAccountOwnedRecords = jest.mocked(apiClient.getAccountOwnedRecords);
@@ -2368,6 +2634,31 @@ describe("network/utils", () => {
         ],
       });
       expect(result).toEqual([...page0, ...page1]);
+    });
+
+    it("should forward the block-height bounds on every page", async () => {
+      const pageSize = 1;
+      mockGetAccountOwnedRecords
+        .mockResolvedValueOnce([getMockedRecord({ tag: "t0" })])
+        .mockResolvedValueOnce([]);
+
+      await fetchAllOwnedRecords({
+        config: mockConfig,
+        uuid: mockUUID,
+        start: 100,
+        end: 200,
+        resultsPerPage: pageSize,
+      });
+
+      expect(mockGetAccountOwnedRecords).toHaveBeenCalledTimes(2);
+      expect(mockGetAccountOwnedRecords).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ start: 100, end: 200, page: 0 }),
+      );
+      expect(mockGetAccountOwnedRecords).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ start: 100, end: 200, page: 1 }),
+      );
     });
 
     it("should stop immediately when the first page is empty", async () => {

--- a/libs/coin-modules/coin-aleo/src/network/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.ts
@@ -21,8 +21,11 @@ import type {
   AleoRecordScannerStatusResponse,
   AleoDecryptedRecordResponse,
   AleoTokenDetails,
+  AleoTransitionCursor,
+  AleoExactTransitionCursor,
 } from "../types";
 import {
+  hasPublicAddress,
   findTransferArguments,
   isParsableTransferFunction,
   parseAmount,
@@ -96,6 +99,74 @@ function hasReachedMinHeight(
   return transactions.some(tx => tx.block_number < minBlockHeight);
 }
 
+/**
+ * A transition with no direct account involvement (e.g. the outer call of a batching contract);
+ * a sibling transition of the same transaction carries the real amount and addresses.
+ * Testnet transaction showing this: at1lqugdt847uwnfem2xhzwq6ewrnd6ysjv2gumvglytskutxj3kcpsmc3rrf
+ */
+function isUnaddressedTransfer(tx: AleoPublicTransaction): boolean {
+  return tx.function_id.includes("transfer") && !hasPublicAddress(tx);
+}
+
+function toExactCursor(tx: AleoPublicTransaction): AleoExactTransitionCursor {
+  return { blockNumber: tx.block_number, transitionId: tx.transition_id };
+}
+
+/**
+ * One page of the explorer's per-transition stream, cut on a block boundary: the block the stream
+ * stops inside is handed to the next page whole, so a caller may bound record fetching by block
+ * height. `next` is `null` once the stream is exhausted.
+ */
+export async function fetchTransitionPage({
+  config,
+  address,
+  cursor,
+  limit,
+  order = "asc",
+}: {
+  config: AleoCoinConfig;
+  address: string;
+  cursor?: AleoTransitionCursor;
+  limit?: number;
+  order?: "asc" | "desc";
+}): Promise<{
+  transitions: AleoPublicTransaction[];
+  next: AleoExactTransitionCursor | null;
+}> {
+  const transitions: AleoPublicTransaction[] = [];
+  let currentCursor = cursor;
+  let hasMorePages = true;
+  let closedRows: AleoPublicTransaction[] = [];
+
+  while (hasMorePages && closedRows.length === 0) {
+    const page = await apiClient.getAccountPublicTransactions({
+      config,
+      address,
+      order,
+      ...(limit && { limit }),
+      ...(currentCursor && { cursor: currentCursor }),
+    });
+
+    transitions.push(...page.transactions.filter(tx => !isUnaddressedTransfer(tx)));
+
+    const lastRow = page.transactions.at(-1);
+
+    if (!page.next_cursor || !lastRow) {
+      hasMorePages = false;
+    } else {
+      currentCursor = toExactCursor(lastRow);
+
+      const openBlock = transitions.at(-1)?.block_number;
+      closedRows = transitions.filter(tx => tx.block_number !== openBlock);
+    }
+  }
+
+  const lastClosedRow = closedRows.at(-1);
+  if (!lastClosedRow) return { transitions, next: null };
+
+  return { transitions: closedRows, next: toExactCursor(lastClosedRow) };
+}
+
 export async function fetchAccountTransactionsFromHeight({
   config,
   address,
@@ -126,25 +197,15 @@ export async function fetchAccountTransactionsFromHeight({
       address,
       limit,
       order,
-      ...(currentCursor && { cursor: currentCursor }),
+      ...(currentCursor && { cursor: { blockNumber: Number(currentCursor) } }),
     });
 
     const nextCursorBlockNumber = page.next_cursor?.block_number.toString() ?? null;
     hasMorePages = nextCursorBlockNumber !== null;
 
-    const recentTxs = page.transactions.filter(tx => {
-      const hasValidBlockNumber = tx.block_number >= minBlockHeight;
-
-      // Skip transitions that have no direct account involvement (e.g. outer call in a batching contract).
-      // Other transition, sharing the same transaction_id, will carry the real amount and addresses.
-      // Testnet transaction showing this issue: at1lqugdt847uwnfem2xhzwq6ewrnd6ysjv2gumvglytskutxj3kcpsmc3rrf
-      const isInvalidTransition =
-        tx.function_id.includes("transfer") &&
-        tx.sender_address === "" &&
-        tx.recipient_address === "";
-
-      return hasValidBlockNumber && !isInvalidTransition;
-    });
+    const recentTxs = page.transactions.filter(
+      tx => tx.block_number >= minBlockHeight && !isUnaddressedTransfer(tx),
+    );
     transactions.push(...recentTxs);
 
     // stop if DESC order hit the min height boundary
@@ -200,6 +261,7 @@ export async function fetchAllOwnedRecords({
   uuid,
   unspent,
   start,
+  end,
   resultsPerPage = DEFAULT_RECORDS_PAGE_SIZE,
   signal,
   programs = [PROGRAM_ID.CREDITS],
@@ -214,6 +276,7 @@ export async function fetchAllOwnedRecords({
   uuid: string;
   unspent?: boolean;
   start?: number;
+  end?: number;
   resultsPerPage?: number;
   signal?: AbortSignal;
   programs?: string[];
@@ -230,6 +293,7 @@ export async function fetchAllOwnedRecords({
       uuid,
       ...(typeof unspent === "boolean" && { unspent }),
       ...(typeof start === "number" && { start }),
+      ...(typeof end === "number" && { end }),
       resultsPerPage,
       page,
       programs,
@@ -278,6 +342,7 @@ export async function fetchAllTokens({
   return tokens;
 }
 
+/** Reads the scanner status, mapping a dropped enrollment to {@link AleoApiConfigurationResetError}. */
 export async function getRecordScannerStatusOrThrow(
   config: AleoCoinConfig,
   uuid: string,
@@ -323,14 +388,13 @@ export async function accessProvableApi({
   let uuid = provableApi?.uuid;
   let synced: boolean | undefined = provableApi?.scannerStatus?.synced ?? false;
   let percentage: number | undefined = provableApi?.scannerStatus?.percentage ?? 0;
-  let status;
 
   if (!uuid) {
     const { provableId } = await register(config, viewKey);
     uuid = provableId;
   }
 
-  status = await getRecordScannerStatusOrThrow(config, uuid);
+  const status = await getRecordScannerStatusOrThrow(config, uuid);
 
   if (status) {
     synced = status.synced;
@@ -381,7 +445,7 @@ function getInputValue(input: AleoTransition["inputs"][number]): string | null {
  *
  * Returns null silently for non-transfer functions such as join/split.
  */
-async function resolveTransferArguments({
+export async function resolveTransferArguments({
   config,
   transition,
   transactionId,

--- a/libs/coin-modules/coin-aleo/src/network/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.ts
@@ -156,7 +156,7 @@ export async function fetchTransitionPage({
     } else {
       currentCursor = toExactCursor(lastRow);
 
-      const openBlock = transitions.at(-1)?.block_number;
+      const openBlock = lastRow.block_number;
       closedRows = transitions.filter(tx => tx.block_number !== openBlock);
     }
   }
@@ -472,14 +472,14 @@ export async function resolveTransferArguments({
   const decryptionErrors: unknown[] = [];
 
   const plaintexts = await Promise.all(
-    transition.inputs.map((input, index) => {
+    transition.inputs.map(async (input, index) => {
       const value = getInputValue(input);
       if (!value) return null;
       if (input.type !== "private") return value;
 
-      // The owning record's program/function cannot decrypt a batching wrapper's inputs.
-      return sdkClient
-        .decryptCiphertext({
+      try {
+        // The owning record's program/function cannot decrypt a batching wrapper's inputs.
+        const { plaintext } = await sdkClient.decryptCiphertext({
           config,
           ciphertext: value,
           tpk: transition.tpk,
@@ -487,14 +487,12 @@ export async function resolveTransferArguments({
           programId: transition.program,
           functionName: transition.function,
           outputIndex: index,
-        })
-        .then(
-          result => result.plaintext,
-          (error: unknown) => {
-            decryptionErrors.push(error);
-            return null;
-          },
-        );
+        });
+        return plaintext;
+      } catch (error) {
+        decryptionErrors.push(error);
+        return null;
+      }
     }),
   );
 

--- a/libs/coin-modules/coin-aleo/src/types/api.ts
+++ b/libs/coin-modules/coin-aleo/src/types/api.ts
@@ -78,6 +78,21 @@ export interface AleoPublicTransactionDetailsResponse {
   status: string;
 }
 
+/**
+ * A bound in the explorer's per-transition stream.
+ *
+ * Omitting `transitionId` makes the bound whole-block exclusive instead — useful to open a window
+ * (`minHeight - 1` ascending, `maxBlockHeight + 1` descending), but never to resume a page: the rest
+ * of the named block would be skipped.
+ */
+export type AleoTransitionCursor = {
+  blockNumber: number;
+  transitionId?: string;
+};
+
+/** A cursor that names an exact row, so paging can resume without skipping the rest of its block. */
+export type AleoExactTransitionCursor = Required<AleoTransitionCursor>;
+
 export interface AleoPublicTransactionsResponse {
   address: string;
   transactions: AleoPublicTransaction[];
@@ -85,6 +100,7 @@ export interface AleoPublicTransactionsResponse {
     block_number: number;
     transition_id: string;
   };
+  // Presence does not prove more rows follow; only its absence proves the stream is exhausted.
   next_cursor?: {
     block_number: number;
     transition_id: string;

--- a/libs/coin-modules/coin-aleo/src/types/logic.ts
+++ b/libs/coin-modules/coin-aleo/src/types/logic.ts
@@ -9,6 +9,7 @@ import type {
   AleoRecordScannerStatusResponse,
   AleoPublicTransactionDetailsResponse,
   AleoPrivateRecord,
+  AleoExactTransitionCursor,
 } from "./api";
 import type { AleoDecryptedRecordResponse } from "./sdk";
 
@@ -46,6 +47,12 @@ export type AleoAccountInfo = {
   percentage: number;
   startHeight: number;
   scannedHeight: number;
+};
+
+/** `<maxBlockHeight>:<blockNumber>:<transitionId>` — the pinned ceiling, then the row to resume after. */
+export type OperationsCursor = {
+  maxBlockHeight: number;
+  resumeFrom: AleoExactTransitionCursor;
 };
 
 export type RecordPickingStrategy = "manual" | "auto";


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

## What

Implements `listOperations` on the coin-aleo **coin-module API** (`createApi`), merging the
public explorer stream with the account's private records into one page of coin-framework
`Operation`s. Part 2 of the private list-ops work — part 1 is already on `develop`.

Previously `api.listOperations` threw `"listOperations is not supported"`.

## How it works

`src/logic/listOperations.ts` builds one page from three sources:

1. **Public half** — `fetchTransitionPage` pulls the explorer's per-transition stream and cuts
   the page on a **block boundary**: the block the stream stops inside is handed to the next
   page whole, so record fetching can be bounded by block height without losing rows.
   Multi-transition transactions are deduped down to one operation (`dedupeByTransaction`),
   preferring the addressed row.
2. **Private half** — owned records in the same block window. A record whose transaction has no
   public row becomes its own operation; a record that shares a transaction with a public row
   only tags it (`hasOwnedRecord`), which is what lets a blanked counterparty resolve to the
   account's own address.
3. **Third-party shield recipients** — a `transfer_public_to_private` to someone else is the one
   counterparty nothing reveals: the explorer blanks it and the account owns no record. Those
   rows (and only those) are re-read from the transition inputs, batched 4 at a time.

### Guarantees

- **Never lists above the record scanner's watermark.** Above it, a shielded transfer would show
  as a bare public row and change shape on a later sync. The ceiling is pinned into the cursor so
  every page of one listing sees the same snapshot.
- **Cursor is `<maxBlockHeight>:<blockNumber>:<transitionId>`** — non-volatile, resumes past the
  last row of a block already emitted whole, so no block is re-emitted or partially skipped.
- **One operation per transaction** per page.
- **`desc` only.** Any other explicit `order` throws.

## Notable fixes found on the way

- **Transition cursors were block-only.** Sending `cursor_block_number` alone resumes after the
  *whole* block, silently dropping the transitions of it that were not read yet — verified
  against mainnet: 10 of 357 rows lost on one account. Cursors are now
  `{ blockNumber, transitionId }` (`AleoTransitionCursor` / `AleoExactTransitionCursor`).
- **Explorer page limit is hard-capped at 50.** Above it the endpoint 400s with
  `"Limit must be between 1 and 50"`. Added `MAX_TRANSITIONS_PER_PAGE` and clamp on the way out.
- **Batcher-wrapped functions were missed by exact-name matching.** Ledger's batching wrappers
  suffix the record count (`transfer_private_2`, `transfer_public_to_private_4`). Extracted
  `stripBatcherSuffix` and used it for the shield lookup too; record filtering moved client-side
  (`programs: []`, `functions: []`) because those filters are server-side exact matches and would
  drop both token records and the wrappers.
- **Owned-record fetching had no upper bound**, so every page re-downloaded the account's whole
  record history. Added an `end` bound through `getAccountOwnedRecords` / `fetchAllOwnedRecords`.
- **Token typing comes from the registry, not the program id.** A program the registry does not
  list is typed `unknown` rather than guessed.
- Deduplicated `new Date(Number(ts) * 1000)` into `toBlockDate`, and the blank-address check into
  `hasPublicAddress` / `isUnaddressedTransfer` (the classic bridge now shares both).

## Framework vs classic bridge

`toPublicOperation` types a token transfer as IN/OUT where `parseTransactionFields` (still used by
the classic bridge) returns `NONE` — the framework operation carries the program as its `asset`,
so there is nothing left for `NONE` to guard. The bridge path is otherwise untouched.

## Tests


### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-33469
