### PR TITLE
[LWDM] feat(coin-casper): add generic-adapter CoinFrameworkSigner (LIVE-35913)

### DIFF
--- a/.changeset/thirty-cooks-tan.md
+++ b/.changeset/thirty-cooks-tan.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-casper": minor
+"@ledgerhq/live-common": minor
+---
+
+Add a `CoinFrameworkSigner` for Casper so the family can derive addresses and sign through the generic coin adapter. Address derivation, signature tagging and device access are now shared with the legacy bridge instead of duplicated, so the two paths cannot drift; legacy behaviour is unchanged and the adapter flag stays off.

--- a/libs/coin-modules/coin-casper/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/signOperation.ts
@@ -1,10 +1,11 @@
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { log } from "@ledgerhq/logs";
 import { Account, AccountBridge } from "@ledgerhq/types-live";
-import { KeyAlgorithm, Transaction as CasperTransaction } from "casper-js-sdk";
+import { Transaction as CasperTransaction } from "casper-js-sdk";
 import { Observable } from "rxjs";
 import { craftTransaction } from "../logic/craftTransaction";
 import { getAddress } from "../logic/validateAddress";
+import { tagSignature } from "../signer/deviceResponse";
 import { Transaction } from "../types";
 import { CasperSigner } from "../types";
 import { buildOptimisticOperation } from "./buildOptimisticOperation";
@@ -56,7 +57,7 @@ export const buildSignOperation =
 
         // signature verification
         const txHash = casperTx.hash.getHash()?.toHex() ?? "";
-        const signature = Buffer.concat([Buffer.from([KeyAlgorithm.SECP256K1]), r.signatureRS]);
+        const signature = tagSignature(r.signatureRS);
 
         const operation = buildOptimisticOperation(account, transaction, txHash);
         const txJson = casperTx.toJSON();
@@ -65,7 +66,7 @@ export const buildSignOperation =
           type: "signed",
           signedOperation: {
             operation,
-            signature: Buffer.from(signature).toString("hex"),
+            signature,
             rawData: {
               tx: JSON.stringify(txJson),
             },

--- a/libs/coin-modules/coin-casper/src/signer/deviceResponse.test.ts
+++ b/libs/coin-modules/coin-casper/src/signer/deviceResponse.test.ts
@@ -1,0 +1,42 @@
+import { PublicKey } from "casper-js-sdk";
+import { TEST_ADDRESSES } from "../__tests__/fixtures/addresses.fixture";
+import { CasperGetAddrResponse } from "../types";
+import { addressFromDeviceResponse, tagSignature } from "./deviceResponse";
+
+const response = (overrides: Partial<CasperGetAddrResponse> = {}): CasperGetAddrResponse => ({
+  errorMessage: "No errors",
+  returnCode: 0x9000,
+  publicKey: Buffer.from(TEST_ADDRESSES.SECP256K1.slice(2), "hex"),
+  Address: "",
+  ...overrides,
+});
+
+describe("addressFromDeviceResponse", () => {
+  it("lowercases the address the device supplies", () => {
+    expect(
+      addressFromDeviceResponse(response({ Address: TEST_ADDRESSES.SECP256K1.toUpperCase() })),
+    ).toBe(TEST_ADDRESSES.SECP256K1);
+  });
+
+  it("tags the public key with secp256k1 when the device supplies no address", () => {
+    expect(addressFromDeviceResponse(response())).toBe(TEST_ADDRESSES.SECP256K1);
+  });
+
+  it("returns a value casper-js-sdk parses as a public key on both branches", () => {
+    expect(() => PublicKey.fromHex(addressFromDeviceResponse(response()))).not.toThrow();
+    expect(() =>
+      PublicKey.fromHex(addressFromDeviceResponse(response({ Address: TEST_ADDRESSES.SECP256K1 }))),
+    ).not.toThrow();
+  });
+});
+
+describe("tagSignature", () => {
+  it("prepends the secp256k1 tag byte", () => {
+    const signatureRS = Buffer.alloc(64, 0xab);
+
+    const tagged = tagSignature(signatureRS);
+
+    expect(tagged).toHaveLength(130);
+    expect(tagged).toBe(`02${signatureRS.toString("hex")}`);
+  });
+});

--- a/libs/coin-modules/coin-casper/src/signer/deviceResponse.ts
+++ b/libs/coin-modules/coin-casper/src/signer/deviceResponse.ts
@@ -1,0 +1,15 @@
+import { KeyAlgorithm } from "casper-js-sdk";
+import { casperAddressFromPubKey } from "../logic/validateAddress";
+import type { CasperGetAddrResponse } from "../types";
+
+/** A Casper address is the algorithm-tagged public key. */
+export function addressFromDeviceResponse(r: CasperGetAddrResponse): string {
+  return r.Address.length
+    ? r.Address.toLowerCase()
+    : casperAddressFromPubKey(r.publicKey, KeyAlgorithm.SECP256K1);
+}
+
+/** The device omits the algorithm tag byte that `combine` and the node expect. */
+export function tagSignature(signatureRS: Buffer): string {
+  return Buffer.concat([Buffer.from([KeyAlgorithm.SECP256K1]), signatureRS]).toString("hex");
+}

--- a/libs/coin-modules/coin-casper/src/signer/frameworkSigner.test.ts
+++ b/libs/coin-modules/coin-casper/src/signer/frameworkSigner.test.ts
@@ -1,0 +1,133 @@
+import { Transaction } from "casper-js-sdk";
+import { combine } from "../logic/combine";
+import { createMockSignedTransaction } from "../__tests__/fixtures/transaction.fixture";
+import { CasperGetAddrResponse, CasperSignature, CasperSigner } from "../types";
+import { createFrameworkSigner } from "./frameworkSigner";
+
+const addrResponse = (overrides: Partial<CasperGetAddrResponse> = {}): CasperGetAddrResponse => ({
+  errorMessage: "No errors",
+  returnCode: 0x9000,
+  publicKey: Buffer.from("aabbcc", "hex"),
+  Address: "",
+  ...overrides,
+});
+
+const signResponse = (signatureRS: Buffer): CasperSignature => ({
+  errorMessage: "No errors",
+  returnCode: 0x9000,
+  signatureRS,
+  signatureRSV: Buffer.alloc(0),
+  signature_compact: new Uint8Array(),
+});
+
+const makeSigner = (overrides: Partial<CasperSigner> = {}): CasperSigner => ({
+  showAddressAndPubKey: jest.fn().mockResolvedValue(addrResponse()),
+  getAddressAndPubKey: jest.fn().mockResolvedValue(addrResponse()),
+  sign: jest.fn().mockResolvedValue(signResponse(Buffer.alloc(64, 0xab))),
+  ...overrides,
+});
+
+describe("createFrameworkSigner.getAddress", () => {
+  it("reads silently via getAddressAndPubKey when verify is not requested", async () => {
+    const device = makeSigner();
+    const framework = createFrameworkSigner(device);
+
+    await framework.getAddress("m/44'/506'/0'/0/0");
+
+    expect(device.getAddressAndPubKey).toHaveBeenCalledTimes(1);
+    expect(device.getAddressAndPubKey).toHaveBeenCalledWith("m/44'/506'/0'/0/0");
+    expect(device.showAddressAndPubKey).not.toHaveBeenCalled();
+  });
+
+  it("confirms on device via showAddressAndPubKey when verify is true", async () => {
+    const device = makeSigner();
+    const framework = createFrameworkSigner(device);
+
+    await framework.getAddress("m/44'/506'/0'/0/0", { verify: true });
+
+    expect(device.showAddressAndPubKey).toHaveBeenCalledTimes(1);
+    expect(device.showAddressAndPubKey).toHaveBeenCalledWith("m/44'/506'/0'/0/0");
+    expect(device.getAddressAndPubKey).not.toHaveBeenCalled();
+  });
+
+  it("returns the device address lowercased, as both address and public key", async () => {
+    const device = makeSigner({
+      getAddressAndPubKey: jest
+        .fn()
+        .mockResolvedValue(
+          addrResponse({ Address: "02ABCDEF", publicKey: Buffer.from("00112233", "hex") }),
+        ),
+    });
+    const framework = createFrameworkSigner(device);
+
+    const result = await framework.getAddress("m/44'/506'/0'/0/0");
+
+    expect(result).toEqual({
+      path: "m/44'/506'/0'/0/0",
+      address: "02abcdef",
+      publicKey: "02abcdef",
+    });
+  });
+
+  it("derives the address from the public key with the secp256k1 tag when the device omits it", async () => {
+    const device = makeSigner({
+      getAddressAndPubKey: jest
+        .fn()
+        .mockResolvedValue(
+          addrResponse({ Address: "", publicKey: Buffer.from("00112233", "hex") }),
+        ),
+    });
+    const framework = createFrameworkSigner(device);
+
+    const result = await framework.getAddress("m/44'/506'/0'/0/0");
+
+    expect(result.address).toBe("0200112233");
+    expect(result.publicKey).toBe("0200112233");
+  });
+});
+
+describe("createFrameworkSigner.signTransaction", () => {
+  it("signs the bytes of the crafted transaction, not the JSON string", async () => {
+    const { unsignedTx, untaggedSignature } = createMockSignedTransaction();
+    const sign = jest.fn().mockResolvedValue(signResponse(Buffer.from(untaggedSignature, "hex")));
+    const framework = createFrameworkSigner(makeSigner({ sign }));
+
+    await framework.signTransaction("m/44'/506'/0'/0/0", unsignedTx);
+
+    expect(sign).toHaveBeenCalledWith(
+      "m/44'/506'/0'/0/0",
+      Buffer.from(Transaction.fromJSON(unsignedTx).toBytes()),
+    );
+  });
+
+  it("prepends the secp256k1 tag byte, producing a 130-char signature combine accepts", async () => {
+    const { unsignedTx, untaggedSignature, taggedSignature } = createMockSignedTransaction();
+    const sign = jest.fn().mockResolvedValue(signResponse(Buffer.from(untaggedSignature, "hex")));
+    const framework = createFrameworkSigner(makeSigner({ sign }));
+
+    const signature = await framework.signTransaction("m/44'/506'/0'/0/0", unsignedTx);
+
+    expect(signature).toHaveLength(130);
+    expect(signature).toBe(taggedSignature);
+  });
+
+  it("combines the signature with the public key getAddress returned", async () => {
+    const { unsignedTx, untaggedSignature, publicKey } = createMockSignedTransaction();
+    const device = makeSigner({
+      // The device returns the untagged key body.
+      getAddressAndPubKey: jest
+        .fn()
+        .mockResolvedValue(
+          addrResponse({ Address: "", publicKey: Buffer.from(publicKey.slice(2), "hex") }),
+        ),
+      sign: jest.fn().mockResolvedValue(signResponse(Buffer.from(untaggedSignature, "hex"))),
+    });
+    const framework = createFrameworkSigner(device);
+
+    const address = await framework.getAddress("m/44'/506'/0'/0/0");
+    const signature = await framework.signTransaction("m/44'/506'/0'/0/0", unsignedTx);
+
+    const combined = combine(unsignedTx, [signature], address.publicKey);
+    expect(() => Transaction.fromJSON(combined)).not.toThrow();
+  });
+});

--- a/libs/coin-modules/coin-casper/src/signer/frameworkSigner.ts
+++ b/libs/coin-modules/coin-casper/src/signer/frameworkSigner.ts
@@ -1,0 +1,34 @@
+import { Transaction } from "casper-js-sdk";
+import { CasperSigner } from "../types";
+import { addressFromDeviceResponse, tagSignature } from "./deviceResponse";
+
+export type CasperFrameworkSigner = {
+  getAddress(
+    path: string,
+    // `derivationMode` is part of what the generic framework passes; Casper is secp256k1-only,
+    // so there is no curve to pick from it.
+    options?: { verify?: boolean; derivationMode?: string },
+  ): Promise<{ path: string; address: string; publicKey: string }>;
+  signTransaction(path: string, txJson: string): Promise<string>;
+};
+
+/** Adapts the device-level {@link CasperSigner} to the generic framework. secp256k1 only. */
+export function createFrameworkSigner(signer: CasperSigner): CasperFrameworkSigner {
+  return {
+    async getAddress(path, options = {}) {
+      const r = options.verify
+        ? await signer.showAddressAndPubKey(path)
+        : await signer.getAddressAndPubKey(path);
+
+      const address = addressFromDeviceResponse(r);
+      // The generic flow feeds this `publicKey` to `combine`, which only accepts the tagged form.
+      return { path, address, publicKey: address };
+    },
+    async signTransaction(path, txJson) {
+      // `craftTransaction` returns JSON, not the hex the framework's other families sign.
+      const txBytes = Transaction.fromJSON(txJson).toBytes();
+      const { signatureRS } = await signer.sign(path, Buffer.from(txBytes));
+      return tagSignature(signatureRS);
+    },
+  };
+}

--- a/libs/coin-modules/coin-casper/src/signer/getAddress.test.ts
+++ b/libs/coin-modules/coin-casper/src/signer/getAddress.test.ts
@@ -19,7 +19,8 @@ describe("getAddress resolver", () => {
   const mockCurrency = getCryptoCurrencyById("casper");
   const mockDerivationMode = "casper_wallet";
   const mockPubKey = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-  const mockDerivedAddress = "02cafe0123456789abcdef";
+  const mockDeviceAddress = "02CAFE0123456789ABCDEF";
+  const mockDerivedAddress = "02beef0123456789abcdef";
 
   let mockSigner: CasperSigner;
   let mockSignerContext: SignerContext<CasperSigner>;
@@ -29,10 +30,7 @@ describe("getAddress resolver", () => {
     errorMessage: "",
     returnCode: 0x9000,
     publicKey: Buffer.from(mockPubKey, "hex"),
-    Address: {
-      toString: jest.fn().mockReturnValue(includeAddress ? "02CAFE0123456789ABCDEF" : ""),
-      length: includeAddress ? 1 : 0,
-    },
+    Address: includeAddress ? mockDeviceAddress : "",
   });
 
   beforeEach(() => {
@@ -78,7 +76,7 @@ describe("getAddress resolver", () => {
 
     expect(result).toEqual({
       path: mockPath,
-      address: mockDerivedAddress,
+      address: mockDeviceAddress.toLowerCase(),
       publicKey: mockPubKey,
     });
   });
@@ -98,7 +96,7 @@ describe("getAddress resolver", () => {
 
     expect(result).toEqual({
       path: mockPath,
-      address: mockDerivedAddress,
+      address: mockDeviceAddress.toLowerCase(),
       publicKey: mockPubKey,
     });
   });

--- a/libs/coin-modules/coin-casper/src/signer/getAddress.ts
+++ b/libs/coin-modules/coin-casper/src/signer/getAddress.ts
@@ -2,9 +2,8 @@ import { GetAddressFn } from "@ledgerhq/ledger-wallet-framework/bridge/getAddres
 import { GetAddressOptions } from "@ledgerhq/ledger-wallet-framework/derivation";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { log } from "@ledgerhq/logs";
-import { KeyAlgorithm } from "casper-js-sdk";
-import { casperAddressFromPubKey } from "../logic/validateAddress";
 import { CasperSigner } from "../types";
+import { addressFromDeviceResponse } from "./deviceResponse";
 
 function resolver(signerContext: SignerContext<CasperSigner>): GetAddressFn {
   return async (deviceId: string, { path, verify }: GetAddressOptions) => {
@@ -20,9 +19,7 @@ function resolver(signerContext: SignerContext<CasperSigner>): GetAddressFn {
 
     return {
       path,
-      address: r.Address.length
-        ? r.Address.toString().toLowerCase()
-        : casperAddressFromPubKey(r.publicKey, KeyAlgorithm.SECP256K1),
+      address: addressFromDeviceResponse(r),
       publicKey: r.publicKey.toString("hex"),
     };
   };

--- a/libs/coin-modules/coin-casper/src/signer/index.ts
+++ b/libs/coin-modules/coin-casper/src/signer/index.ts
@@ -1,3 +1,5 @@
 import resolver from "./getAddress";
 
+export { createFrameworkSigner, type CasperFrameworkSigner } from "./frameworkSigner";
+
 export default resolver;

--- a/libs/coin-modules/coin-casper/src/types/signer.ts
+++ b/libs/coin-modules/coin-casper/src/types/signer.ts
@@ -10,7 +10,8 @@ export type CasperGetAddrResponse = {
   errorMessage: string;
   returnCode: number;
   publicKey: Buffer;
-  Address: any;
+  /** Algorithm-tagged hex. Empty on device apps that only return the public key. */
+  Address: string;
 };
 
 export interface CasperSigner {

--- a/libs/coin-tester-modules/coin-tester-casper/src/signer.ts
+++ b/libs/coin-tester-modules/coin-tester-casper/src/signer.ts
@@ -97,7 +97,7 @@ export function buildCasperSigner(pemByPath: Record<string, string>): CasperSign
     errorMessage: "",
     returnCode: APDU_SUCCESS,
     publicKey: Buffer.from(keyFor(path).publicKey.bytes()).subarray(1),
-    Address: Buffer.alloc(0),
+    Address: "",
   });
 
   return {

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -744,6 +744,8 @@
     "src/families/cardano/coinModuleApi.ts",
     "src/families/cardano/config.ts",
     "src/families/casper/config.ts",
+    "src/families/casper/deviceSigner.ts",
+    "src/families/casper/signer.ts",
     "src/families/celo/bridge/api.ts",
     "src/families/celo/coinModuleApi.ts",
     "src/families/celo/config.ts",

--- a/libs/ledger-live-common/src/coin-modules/loaders.ts
+++ b/libs/ledger-live-common/src/coin-modules/loaders.ts
@@ -89,6 +89,7 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-casper/deviceTransactionConfig").then(m => m.default),
     loadMockBridge: () => import("../families/casper/bridge/mock").then(m => m.default),
+    loadSigner: () => import("../families/casper/signer").then(m => m.default),
   },
   {
     family: "celo",

--- a/libs/ledger-live-common/src/families/casper/deviceSigner.test.ts
+++ b/libs/ledger-live-common/src/families/casper/deviceSigner.test.ts
@@ -1,0 +1,117 @@
+import Casper from "@zondax/ledger-casper";
+import Transport from "@ledgerhq/hw-transport";
+import { createDeviceSigner } from "./deviceSigner";
+
+jest.mock("@zondax/ledger-casper");
+
+const MockedCasper = Casper as jest.MockedClass<typeof Casper>;
+const mockTransport = {} as Transport;
+
+// "02" is the secp256k1 tag, the rest is the 33-byte key the device returns.
+const SECP256K1_ADDRESS = "0202ba6dc98cbe677711a45bf028a03646f9e588996eb223fad2485e8bc391b01581";
+
+const okAddress = {
+  errorMessage: "No errors",
+  returnCode: 0x9000,
+  publicKey: Buffer.from(SECP256K1_ADDRESS.slice(2), "hex"),
+  Address: SECP256K1_ADDRESS,
+};
+
+const okSign = {
+  errorMessage: "No errors",
+  returnCode: 0x9000,
+  signatureRS: Buffer.alloc(64, 0xab),
+  signatureRSV: Buffer.alloc(65, 0xab),
+};
+
+describe("createDeviceSigner (Casper)", () => {
+  let showAddressAndPubKey: jest.Mock;
+  let getAddressAndPubKey: jest.Mock;
+  let sign: jest.Mock;
+
+  beforeEach(() => {
+    showAddressAndPubKey = jest.fn().mockResolvedValue(okAddress);
+    getAddressAndPubKey = jest.fn().mockResolvedValue(okAddress);
+    sign = jest.fn().mockResolvedValue(okSign);
+    MockedCasper.mockImplementation(
+      () => ({ showAddressAndPubKey, getAddressAndPubKey, sign }) as unknown as Casper,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    ["getAddressAndPubKey", () => getAddressAndPubKey],
+    ["showAddressAndPubKey", () => showAddressAndPubKey],
+  ] as const)("prefixes the path with m/ when absent for %s", async (method, mock) => {
+    const signer = createDeviceSigner(mockTransport);
+
+    await signer[method]("44'/506'/0'/0/0");
+
+    expect(mock()).toHaveBeenCalledWith("m/44'/506'/0'/0/0");
+  });
+
+  it("prefixes the path with m/ when absent for sign", async () => {
+    const signer = createDeviceSigner(mockTransport);
+    const message = Buffer.from("deadbeef", "hex");
+
+    await signer.sign("44'/506'/0'/0/0", message);
+
+    expect(sign).toHaveBeenCalledWith("m/44'/506'/0'/0/0", message);
+  });
+
+  it("keeps an already-prefixed path untouched", async () => {
+    const signer = createDeviceSigner(mockTransport);
+
+    await signer.getAddressAndPubKey("m/44'/506'/0'/0/0");
+
+    expect(getAddressAndPubKey).toHaveBeenCalledWith("m/44'/506'/0'/0/0");
+  });
+
+  it("returns Address as a primitive string even when the device app hands back a wrapper", async () => {
+    getAddressAndPubKey.mockResolvedValue({ ...okAddress, Address: new String(SECP256K1_ADDRESS) });
+    const signer = createDeviceSigner(mockTransport);
+
+    const r = await signer.getAddressAndPubKey("m/44'/506'/0'/0/0");
+
+    expect(typeof r.Address).toBe("string");
+    expect(r.Address).toBe(SECP256K1_ADDRESS);
+  });
+
+  describe("throws on a non-0x9000 return code instead of returning a bad result", () => {
+    it("for getAddressAndPubKey", async () => {
+      getAddressAndPubKey.mockResolvedValue({
+        ...okAddress,
+        returnCode: 0x6a80,
+        errorMessage: "nope",
+      });
+      const signer = createDeviceSigner(mockTransport);
+
+      await expect(signer.getAddressAndPubKey("44'/506'/0'/0/0")).rejects.toThrow("27264 - nope");
+    });
+
+    it("for showAddressAndPubKey", async () => {
+      showAddressAndPubKey.mockResolvedValue({
+        ...okAddress,
+        returnCode: 0x6985,
+        errorMessage: "rejected",
+      });
+      const signer = createDeviceSigner(mockTransport);
+
+      await expect(signer.showAddressAndPubKey("44'/506'/0'/0/0")).rejects.toThrow(
+        "27013 - rejected",
+      );
+    });
+
+    it("for sign", async () => {
+      sign.mockResolvedValue({ ...okSign, returnCode: 0x6985, errorMessage: "rejected" });
+      const signer = createDeviceSigner(mockTransport);
+
+      await expect(signer.sign("44'/506'/0'/0/0", Buffer.alloc(4))).rejects.toThrow(
+        "27013 - rejected",
+      );
+    });
+  });
+});

--- a/libs/ledger-live-common/src/families/casper/deviceSigner.ts
+++ b/libs/ledger-live-common/src/families/casper/deviceSigner.ts
@@ -1,0 +1,31 @@
+import Transport from "@ledgerhq/hw-transport";
+import Casper, { type ResponseAddress } from "@zondax/ledger-casper";
+import { CreateSigner } from "../../bridge/setup";
+import { getPath, isError } from "./common";
+import { CasperGetAddrResponse, CasperSigner } from "./types";
+
+const throwOnDeviceError = async <T extends { returnCode: number; errorMessage?: string }>(
+  request: Promise<T>,
+): Promise<T> => {
+  const r = await request;
+  isError(r);
+  return r;
+};
+
+// @zondax/ledger-casper types `Address` as the boxed `String`; narrow it to a primitive.
+const toAddrResponse = ({ Address, ...rest }: ResponseAddress): CasperGetAddrResponse => ({
+  ...rest,
+  Address: String(Address),
+});
+
+// Casper has no DMK signer nor hw-app-casper; device access goes through @zondax/ledger-casper.
+export const createDeviceSigner: CreateSigner<CasperSigner> = (transport: Transport) => {
+  const casper = new Casper(transport);
+  return {
+    showAddressAndPubKey: path =>
+      throwOnDeviceError(casper.showAddressAndPubKey(getPath(path))).then(toAddrResponse),
+    getAddressAndPubKey: path =>
+      throwOnDeviceError(casper.getAddressAndPubKey(getPath(path))).then(toAddrResponse),
+    sign: (path, message) => throwOnDeviceError(casper.sign(getPath(path), message)),
+  };
+};

--- a/libs/ledger-live-common/src/families/casper/setup.ts
+++ b/libs/ledger-live-common/src/families/casper/setup.ts
@@ -1,47 +1,15 @@
 // Goal of this file is to inject all necessary device/signer dependency to coin-modules
 
 import { createBridges } from "@ledgerhq/coin-casper/bridge";
-import Transport from "@ledgerhq/hw-transport";
-import Casper from "@zondax/ledger-casper";
 import casperResolver from "@ledgerhq/coin-casper/signer";
 import { signMessage } from "@ledgerhq/coin-casper/hw-signMessage";
 import type { Account, Bridge } from "@ledgerhq/types-live";
-import {
-  CreateSigner,
-  createMessageSigner,
-  createResolver,
-  executeWithSigner,
-} from "../../bridge/setup";
+import { createMessageSigner, createResolver, executeWithSigner } from "../../bridge/setup";
 import { Resolver } from "../../hw/getAddress/types";
 import { TransactionStatus, Transaction } from "@ledgerhq/coin-casper/types";
-import { CasperGetAddrResponse, CasperSignature, CasperSigner } from "./types";
 import { getCurrencyConfiguration } from "../../config";
-import { getPath, isError } from "./common";
+import { createDeviceSigner as createSigner } from "./deviceSigner";
 import type { CasperCoinConfig } from "@ledgerhq/coin-casper/types";
-
-const createSigner: CreateSigner<CasperSigner> = (transport: Transport) => {
-  const casper = new Casper(transport);
-  return {
-    showAddressAndPubKey: async (path: string): Promise<CasperGetAddrResponse> => {
-      const r = await casper.showAddressAndPubKey(getPath(path));
-      isError(r);
-
-      return r;
-    },
-    getAddressAndPubKey: async (path: string): Promise<CasperGetAddrResponse> => {
-      const r = await casper.getAddressAndPubKey(getPath(path));
-      isError(r);
-
-      return r;
-    },
-    sign: async (path: string, message: Buffer): Promise<CasperSignature> => {
-      const r = await casper.sign(getPath(path), message);
-      isError(r);
-
-      return r;
-    },
-  };
-};
 
 const getCoinConfig: CasperCoinConfig = () =>
   getCurrencyConfiguration<ReturnType<CasperCoinConfig>>("casper");

--- a/libs/ledger-live-common/src/families/casper/signer.test.ts
+++ b/libs/ledger-live-common/src/families/casper/signer.test.ts
@@ -1,0 +1,97 @@
+import Casper from "@zondax/ledger-casper";
+import Transport from "@ledgerhq/hw-transport";
+import { getSigner } from "../../bridge/generic-coin-framework/signer";
+import { coinModuleLoaders } from "../../coin-modules/loaders";
+import casperSigner, { createSigner } from "./signer";
+
+jest.mock("@zondax/ledger-casper");
+
+const MockedCasper = Casper as jest.MockedClass<typeof Casper>;
+const mockTransport = {} as Transport;
+
+// "02" is the secp256k1 tag, the rest is the 33-byte key the device returns.
+const SECP256K1_ADDRESS = "0202ba6dc98cbe677711a45bf028a03646f9e588996eb223fad2485e8bc391b01581";
+
+const okAddress = {
+  errorMessage: "No errors",
+  returnCode: 0x9000,
+  publicKey: Buffer.from(SECP256K1_ADDRESS.slice(2), "hex"),
+  Address: SECP256K1_ADDRESS.toUpperCase(),
+};
+
+describe("createSigner (Casper)", () => {
+  let showAddressAndPubKey: jest.Mock;
+  let getAddressAndPubKey: jest.Mock;
+  let sign: jest.Mock;
+
+  beforeEach(() => {
+    showAddressAndPubKey = jest.fn().mockResolvedValue(okAddress);
+    getAddressAndPubKey = jest.fn().mockResolvedValue(okAddress);
+    sign = jest.fn();
+    MockedCasper.mockImplementation(
+      () => ({ showAddressAndPubKey, getAddressAndPubKey, sign }) as unknown as Casper,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("getAddress", () => {
+    it("reads silently and normalizes the path with an m/ prefix when absent", async () => {
+      const signer = createSigner(mockTransport);
+
+      const result = await signer.getAddress("44'/506'/0'/0/0");
+
+      expect(getAddressAndPubKey).toHaveBeenCalledTimes(1);
+      expect(getAddressAndPubKey).toHaveBeenCalledWith("m/44'/506'/0'/0/0");
+      expect(showAddressAndPubKey).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        path: "44'/506'/0'/0/0",
+        address: SECP256K1_ADDRESS,
+        publicKey: SECP256K1_ADDRESS,
+      });
+    });
+
+    it("keeps an already-prefixed path untouched", async () => {
+      const signer = createSigner(mockTransport);
+
+      await signer.getAddress("m/44'/506'/0'/0/0");
+
+      expect(getAddressAndPubKey).toHaveBeenCalledWith("m/44'/506'/0'/0/0");
+    });
+
+    it("confirms on device when verify is requested", async () => {
+      const signer = createSigner(mockTransport);
+
+      await signer.getAddress("44'/506'/0'/0/0", { verify: true });
+
+      expect(showAddressAndPubKey).toHaveBeenCalledTimes(1);
+      expect(showAddressAndPubKey).toHaveBeenCalledWith("m/44'/506'/0'/0/0");
+      expect(getAddressAndPubKey).not.toHaveBeenCalled();
+    });
+
+    it("throws on a non-0x9000 return code instead of returning a bad address", async () => {
+      getAddressAndPubKey.mockResolvedValue({
+        ...okAddress,
+        returnCode: 0x6a80,
+        errorMessage: "nope",
+      });
+      const signer = createSigner(mockTransport);
+
+      await expect(signer.getAddress("44'/506'/0'/0/0")).rejects.toThrow("27264 - nope");
+    });
+  });
+});
+
+describe("casper signer registration", () => {
+  it("registers a loadSigner on the casper coin-module loader", () => {
+    const loader = coinModuleLoaders.find(l => l.family === "casper");
+
+    expect(loader?.loadSigner).toBeDefined();
+  });
+
+  it("resolves through getSigner so the generic coin framework can reach it", async () => {
+    await expect(getSigner("casper")).resolves.toBe(casperSigner);
+  });
+});

--- a/libs/ledger-live-common/src/families/casper/signer.ts
+++ b/libs/ledger-live-common/src/families/casper/signer.ts
@@ -1,0 +1,25 @@
+import Transport from "@ledgerhq/hw-transport";
+import { createFrameworkSigner, type CasperFrameworkSigner } from "@ledgerhq/coin-casper/signer";
+import type { GetAddressFn } from "@ledgerhq/ledger-wallet-framework/bridge/getAddressWrapper";
+import type { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
+import type { CoinFrameworkSigner } from "../../bridge/generic-coin-framework/types";
+import { CreateSigner, executeWithSigner } from "../../bridge/setup";
+import { createDeviceSigner } from "./deviceSigner";
+
+export const createSigner: CreateSigner<CasperFrameworkSigner> = (transport: Transport) =>
+  createFrameworkSigner(createDeviceSigner(transport));
+
+export const casperGetAddress = (
+  signerContext: SignerContext<CasperFrameworkSigner>,
+): GetAddressFn => {
+  return (deviceId, { path, verify }) =>
+    signerContext(deviceId, signer => signer.getAddress(path, { verify }));
+};
+
+const context = executeWithSigner(createSigner);
+const getAddress = casperGetAddress(context);
+
+export default {
+  context,
+  getAddress,
+} satisfies CoinFrameworkSigner;


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Add a `CoinFrameworkSigner` for Casper so the family can derive addresses and sign through the generic coin adapter. Address derivation, signature tagging and device access are now shared with the legacy bridge instead of duplicated, so the two paths cannot drift; legacy behaviour is unchanged and the adapter flag stays off.

### 🔗 Context

https://ledgerhq.atlassian.net/browse/LIVE-35913