### PR TITLE
fix(contacts): correct compact list avatar import

### DIFF
--- a/.changeset/fix-contacts-avatar-web-import.md
+++ b/.changeset/fix-contacts-avatar-web-import.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts-list": patch
+---
+
+Fix the web ContactAvatar import for compact contact lists

--- a/features/flow/flow-contacts-list/src/components/ContactsCompactList/ContactsCompactList.web.tsx
+++ b/features/flow/flow-contacts-list/src/components/ContactsCompactList/ContactsCompactList.web.tsx
@@ -6,7 +6,7 @@ import {
   ListItemLeading,
   ListItemTitle,
 } from "@ledgerhq/lumen-ui-react";
-import { ContactAvatar } from "@features/platform-contacts";
+import { ContactAvatar } from "@features/platform-contacts/web";
 import type { ContactsCompactListProps } from "../../types";
 import {
   getCompactContactAddressDescription,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** The compact list Web test and package typecheck pass; the PR CI will run the exact Desktop build.
- [x] **Impact of the changes:**
      Verify the Desktop production bundle resolves the compact Contacts list avatar through the Web public API.

### 📝 Description

The Desktop Linux CI failed while bundling the compact Contacts list: `ContactAvatar` was imported from the platform package root, which does not export the Web component.

This PR imports the avatar from the public `@features/platform-contacts/web` entry point, matching existing Web consumers and restoring Rspack ESM resolution.

### ❓ Context

- **JIRA or GitHub link**: [failing CI run](https://github.com/LedgerHQ/ledger-live/actions/runs/32263618298/job/96102611923), [regressing commit](https://github.com/LedgerHQ/ledger-live/commit/229a6b5b2029ceb65c2698bbd4746d792f0bf096)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)