### PR TITLE
[LWD] fix(desktop): declare signer context-module peer dependency

### DIFF
--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -122,6 +122,7 @@
     "@ledgerhq/coin-filecoin": "workspace:^",
     "@ledgerhq/coin-module-framework": "catalog:",
     "@ledgerhq/coin-zcash": "workspace:^",
+    "@ledgerhq/context-module": "catalog:",
     "@ledgerhq/crypto-icons": "catalog:",
     "@ledgerhq/device-management-kit": "catalog:",
     "@ledgerhq/device-signer-kit-ethereum": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1030,6 +1030,9 @@ importers:
       '@ledgerhq/coin-zcash':
         specifier: workspace:^
         version: link:../../libs/coin-modules/coin-zcash
+      '@ledgerhq/context-module':
+        specifier: 2.4.0
+        version: 2.4.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
         version: 2.0.4(@ledgerhq/lumen-design-core@0.1.25)(@ledgerhq/lumen-ui-react@0.1.53(@ledgerhq/lumen-design-core@0.1.25)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)


### PR DESCRIPTION
### 📝 Description

Declare `@ledgerhq/context-module` as a direct Ledger Wallet Desktop dependency so pnpm resolves the required peer dependency of `@ledgerhq/device-signer-kit-ethereum`.

Without this declaration, regenerating the lockfile can produce a signer-kit peer snapshot without `context-module`, causing the Desktop renderer build to fail with `Module not found: Can't resolve '@ledgerhq/context-module'`.

### 🔗 Context

- **JIRA / GitHub issue**: Discovered while implementing [LIVE-35698](https://ledgerhq.atlassian.net/browse/LIVE-35698)
- **ADR** (if any): N/A

### ✅ Validation

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm desktop lint`
- `pnpm desktop typecheck`
- `pnpm --filter ledger-live-desktop build:js`

[LIVE-35698]: https://ledgerhq.atlassian.net/browse/LIVE-35698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ