### PR TITLE
fix(zcash): expose only the transparent balance to live apps

### DIFF
--- a/.changeset/lucky-mayflies-smile.md
+++ b/.changeset/lucky-mayflies-smile.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+fix(zcash): expose only the transparent balance to live apps
+
+Swap, buy/sell and dApps read an account's spendable balance over the wallet-api. For Zcash that reported transparent + private, so the swap form displayed — and offered as MAX — private funds a live app cannot spend. It now reports the transparent balance, the same figure as the account page's "Transparent" label.

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -612,6 +612,7 @@
     "src/families/xrp/setup.ts",
     "src/families/xrp/transaction.ts",
     "src/families/xrp/walletApiAdapter.ts",
+    "src/families/zcash/bridgeExtensions.ts",
     "src/families/zcash/setup.ts",
     "src/flows/send/amount/SendAmountDisplayModeContext.tsx",
     "src/flows/send/amount/utils/amount.ts",

--- a/libs/ledger-live-common/src/coin-modules/loaders.ts
+++ b/libs/ledger-live-common/src/coin-modules/loaders.ts
@@ -448,5 +448,6 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
     loadTransaction: () => import("@ledgerhq/coin-zcash/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-zcash/deviceTransactionConfig").then(m => m.default),
+    loadBridgeExtensions: () => import("../families/zcash/bridgeExtensions").then(m => m.default),
   },
 ];

--- a/libs/ledger-live-common/src/families/zcash/bridgeExtensions.test.ts
+++ b/libs/ledger-live-common/src/families/zcash/bridgeExtensions.test.ts
@@ -1,0 +1,70 @@
+import { BigNumber } from "bignumber.js";
+import type { AccountLike } from "@ledgerhq/types-live";
+import extensions from "./bridgeExtensions";
+
+// Only the fields the extension reads: the account type, the currency, and the
+// transparent UTXO set. `balance`/`spendableBalance` hold the transparent +
+// private total the coin module writes, so a test asserting the transparent
+// figure also proves the extension does not read them.
+const makeAccount = (patch: Record<string, unknown> = {}): AccountLike =>
+  ({
+    type: "Account",
+    currency: { id: "zcash" },
+    balance: new BigNumber(4_976_022),
+    spendableBalance: new BigNumber(4_976_022),
+    bitcoinResources: {
+      utxos: [{ value: new BigNumber(4_000_000) }, { value: new BigNumber(590_920) }],
+    },
+    privateInfo: { ironwoodBalance: new BigNumber(385_102) },
+    ...patch,
+  }) as unknown as AccountLike;
+
+describe("zcash bridgeExtensions", () => {
+  describe("getWalletApiSpendableBalance", () => {
+    it("returns the transparent balance only, leaving the private pool out", () => {
+      const result = extensions.getWalletApiSpendableBalance?.(makeAccount());
+
+      expect(result).toEqual(new BigNumber(4_590_920));
+    });
+
+    it("reports zero when every fund the account holds is private", () => {
+      const result = extensions.getWalletApiSpendableBalance?.(
+        makeAccount({ bitcoinResources: { utxos: [] } }),
+      );
+
+      expect(result).toEqual(new BigNumber(0));
+    });
+
+    it("reports zero when the account has not been synced yet", () => {
+      const result = extensions.getWalletApiSpendableBalance?.(
+        makeAccount({ bitcoinResources: undefined }),
+      );
+
+      expect(result).toEqual(new BigNumber(0));
+    });
+
+    it("answers for an account whose shielded sync was never activated", () => {
+      const result = extensions.getWalletApiSpendableBalance?.(
+        makeAccount({ privateInfo: undefined }),
+      );
+
+      expect(result).toEqual(new BigNumber(4_590_920));
+    });
+
+    it("throws when the account is not a zcash account", () => {
+      const account = makeAccount({ currency: { id: "bitcoin" } });
+
+      expect(() => extensions.getWalletApiSpendableBalance?.(account)).toThrow(
+        "zcash: invalid account in bridgeExtensions",
+      );
+    });
+
+    it("throws for a token account", () => {
+      const account = makeAccount({ type: "TokenAccount" });
+
+      expect(() => extensions.getWalletApiSpendableBalance?.(account)).toThrow(
+        "zcash: invalid account in bridgeExtensions",
+      );
+    });
+  });
+});

--- a/libs/ledger-live-common/src/families/zcash/bridgeExtensions.ts
+++ b/libs/ledger-live-common/src/families/zcash/bridgeExtensions.ts
@@ -1,0 +1,32 @@
+import invariant from "invariant";
+import { getTransparentBalance } from "@ledgerhq/coin-zcash/logic/account/balance";
+import type { ZcashAccount } from "@ledgerhq/coin-zcash/types/bridge";
+import type { AccountBridgeExtensions, AccountLike } from "@ledgerhq/types-live";
+
+// Deliberately not `isZcashAccount` from the coin module: that guard requires a
+// `privateInfo` key, which an account whose shielded sync was never activated
+// does not carry -- and such an account is exactly the one this extension must
+// still answer for.
+const isZcashMainAccount = (account: AccountLike): account is ZcashAccount =>
+  account.type === "Account" && account.currency.id === "zcash";
+
+const extensions: AccountBridgeExtensions = {
+  // A live app (swap, buy/sell, a dApp) can only ever move transparent funds:
+  // the transaction it hands over carries no pool selection, so
+  // `updateTransaction` derives a transparent-input transfer type and
+  // `estimateMaxSpendable` caps on the transparent UTXO set. Reporting the
+  // account's `spendableBalance` here -- transparent + private, which the send
+  // flow legitimately offers -- would let those apps display, and offer as MAX,
+  // funds they cannot spend, failing only once an amount is entered.
+  //
+  // Summed from the UTXO set rather than derived from `balance`, so it stays the
+  // same figure as the account page's "Transparent" label and as the transparent
+  // branch of `estimateMaxSpendable`, whichever module last wrote `balance`.
+  getWalletApiSpendableBalance: account => {
+    invariant(isZcashMainAccount(account), "zcash: invalid account in bridgeExtensions");
+
+    return getTransparentBalance(account.bitcoinResources?.utxos);
+  },
+};
+
+export default extensions;


### PR DESCRIPTION
### 📝 Description

**Previous behaviour** — the Swap form displayed a Zcash account's *total* balance (transparent + private) as the amount available to swap, and offered it as MAX. On the reported account (transparent ≈ 0.0459092 ZEC, private ≈ 0.003851 ZEC) Swap showed ≈ 0.04976022 ZEC, i.e. the account page's **Available**, where it should show **Transparent**.

**Why** — a live app reads an account's spendable balance over the wallet-api, which resolves it through `bridge.getWalletApiSpendableBalance` (`wallet-api/converters.ts`). The `zcash` entry in `coin-modules/loaders.ts` declared no `loadBridgeExtensions`, so the bridge fell back to `defaultBridgeExtensions` → `account.spendableBalance`, which `coin-zcash` deliberately sets to transparent + private (the send flow can legitimately spend Ironwood notes).

A live app cannot: the transaction it hands over carries no pool selection, so `updateTransaction` derives a transparent-input transfer type and `estimateMaxSpendable` caps on the transparent UTXO set. The inflated figure was therefore wrong for the label, for MAX, for the percentage shortcuts and for the live app's insufficient-funds check alike.

**Fix** — a `zcash` bridge extension reporting the transparent balance only, mirroring what was done for Aleo in #19762 (which introduced this extension point for the same public/private reason). The value is summed from the account's UTXO set rather than derived from `balance`, so it is the same figure as the account page's "Transparent" label and as the transparent branch of `estimateMaxSpendable`, whichever module last wrote `balance` (`coin-zcash` with the flag on, `coin-bitcoin`'s Zcash adapter with it off). The guard is local rather than `isZcashAccount` from the coin module, whose required `privateInfo` key is absent from an account whose shielded sync was never activated — exactly an account this extension must still answer for.

**Regression cover** — `families/zcash/bridgeExtensions.test.ts`: transparent-only against an account whose `balance` holds the total, an all-private account, an unsynced account, an account with no `privateInfo`, and the two rejected account shapes. `coin-modules/loaders.test.ts` additionally smoke-tests the new loader entry.

Applies to every wallet-api consumer, not just Swap — Buy/Sell, Earn and dApps are equally unable to spend private funds — and to both Desktop and Mobile, since the resolution lives in `live-common`.

Out of scope, tracked separately: the native account-selection drawer still lists `account.balance` (same gap on Aleo), and a Zcash swap has yet to be run end-to-end on device with the shielded flag on — the wallet-api `bitcoin` adapter overwrites `family` and injects a `feePerByte` that `coin-zcash` ignores in favour of its ZIP-317 model.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36264](https://ledgerhq.atlassian.net/browse/LIVE-36264)
- **ADR** (if any): —


[LIVE-36264]: https://ledgerhq.atlassian.net/browse/LIVE-36264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ