### PR TITLE
[LWD] feat(pay-card-request): save request card as image (LIVE-36271)

### DIFF
--- a/.changeset/pay-request-save-card.md
+++ b/.changeset/pay-request-save-card.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@features/flow-pay-card-request": patch
+---
+
+Save the Pay request card (QR + address) as a PNG image through the native OS save dialog

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -199,6 +199,7 @@
     "focus-trap": "6.9.4",
     "framer-motion": "11.3.28",
     "fuse.js": "6.6.2",
+    "html-to-image": "1.11.13",
     "i18next": "catalog:",
     "invariant": "2.2.4",
     "json-rpc-2.0": "0.2.19",

--- a/apps/ledger-live-desktop/src/main/setup.ts
+++ b/apps/ledger-live-desktop/src/main/setup.ts
@@ -1,7 +1,7 @@
 import { getEnv, setEnvUnsafe } from "@shared/env";
 import "./env";
 import "~/live-common-setup-base";
-import { app, ipcMain, powerSaveBlocker, shell } from "electron";
+import { app, dialog, ipcMain, powerSaveBlocker, shell } from "electron";
 import contextMenu from "electron-context-menu";
 import fs from "fs/promises";
 import updater from "./updater";
@@ -76,6 +76,24 @@ ipcMain.handle(
       if (!path.canceled && path.filePath && csv) {
         await fs.writeFile(path.filePath, csv);
         return true;
+      }
+    } catch {
+      // ignore
+    }
+    return false;
+  },
+);
+
+ipcMain.handle(
+  "save-png",
+  async (_event, dialogOptions: Electron.SaveDialogOptions, base64: string): Promise<boolean> => {
+    try {
+      if (base64) {
+        const result = await dialog.showSaveDialog(dialogOptions);
+        if (!result.canceled && result.filePath) {
+          await fs.writeFile(result.filePath, Buffer.from(base64, "base64"));
+          return true;
+        }
       }
     } catch {
       // ignore

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/saveRequestReceiveCard.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/saveRequestReceiveCard.test.ts
@@ -1,0 +1,73 @@
+import { ipcRenderer } from "electron";
+import { toPng } from "html-to-image";
+import logger from "~/renderer/logger";
+import { saveRequestReceiveCard } from "../saveRequestReceiveCard";
+
+jest.mock("electron", () => ({
+  ipcRenderer: {
+    invoke: jest.fn(),
+  },
+}));
+
+jest.mock("html-to-image", () => ({ toPng: jest.fn() }), { virtual: true });
+
+jest.mock("~/renderer/logger", () => ({
+  __esModule: true,
+  default: { error: jest.fn() },
+}));
+
+const mockedToPng = jest.mocked(toPng);
+const mockedInvoke = jest.mocked(ipcRenderer.invoke);
+const mockedLoggerError = jest.mocked(logger.error);
+
+const CARD_HTML = '<div data-testid="pay-card-request-receive-card">card</div>';
+const DATA_URL = "data:image/png;base64,ABC123";
+
+describe("saveRequestReceiveCard", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = CARD_HTML;
+    mockedToPng.mockResolvedValue(DATA_URL);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("should invoke save-png with dialog options and base64 when capturing succeeds", async () => {
+    mockedInvoke.mockResolvedValueOnce(true);
+
+    await saveRequestReceiveCard("USDC", "Save request card");
+
+    expect(mockedInvoke).toHaveBeenCalledTimes(1);
+    expect(mockedInvoke).toHaveBeenCalledWith(
+      "save-png",
+      expect.objectContaining({
+        title: "Save request card",
+        defaultPath: "ledger-request-USDC.png",
+        filters: [{ name: "PNG Image", extensions: ["png"] }],
+      }),
+      "ABC123",
+    );
+    expect(mockedLoggerError).not.toHaveBeenCalled();
+  });
+
+  it("should do nothing when the card node is missing", async () => {
+    document.body.innerHTML = "";
+
+    await saveRequestReceiveCard("USDC", "Save request card");
+
+    expect(mockedToPng).not.toHaveBeenCalled();
+    expect(mockedInvoke).not.toHaveBeenCalled();
+  });
+
+  it("should swallow and log capture failures", async () => {
+    const error = new Error("capture failed");
+    mockedToPng.mockRejectedValueOnce(error);
+
+    await saveRequestReceiveCard("USDC", "Save request card");
+
+    expect(mockedInvoke).not.toHaveBeenCalled();
+    expect(mockedLoggerError).toHaveBeenCalledWith(error);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/saveRequestReceiveCard.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/saveRequestReceiveCard.ts
@@ -1,0 +1,35 @@
+import { ipcRenderer } from "electron";
+import { toPng } from "html-to-image";
+import logger from "~/renderer/logger";
+
+const CARD_SELECTOR = '[data-testid="pay-card-request-receive-card"]';
+const BASE64_PNG_PREFIX = /^data:image\/png;base64,/;
+
+/**
+ * Captures the on-screen request card (QR + header + address) to a PNG and persists it through the
+ * native OS save dialog. The image write happens in the main process (see the `save-png` handler)
+ * so the renderer never touches the filesystem directly.
+ */
+export async function saveRequestReceiveCard(ticker: string, dialogTitle: string): Promise<void> {
+  try {
+    const node = document.querySelector<HTMLElement>(CARD_SELECTOR);
+    if (!node) {
+      return;
+    }
+
+    const dataUrl = await toPng(node, { pixelRatio: 2, cacheBust: true });
+    const base64 = dataUrl.replace(BASE64_PNG_PREFIX, "");
+
+    await ipcRenderer.invoke(
+      "save-png",
+      {
+        title: dialogTitle,
+        defaultPath: `ledger-request-${ticker || "card"}.png`,
+        filters: [{ name: "PNG Image", extensions: ["png"] }],
+      },
+      base64,
+    );
+  } catch (error) {
+    logger.error(error);
+  }
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabRequestReceive.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabRequestReceive.ts
@@ -6,6 +6,7 @@ import type { PayCardTrackEvent, RequestReceiveProps } from "@features/flow-pay-
 import { useCopyToClipboard } from "../../../hooks/useCopyToClipboard";
 import { useOpenAssetAndAccount } from "../../ModularDialog/Web3AppWebview/AssetAndAccountDrawer";
 import { deriveRequestReceiveData } from "./deriveRequestReceiveData";
+import { useSaveRequestReceiveCard } from "./useSaveRequestReceiveCard";
 
 const REQUEST_PAGE = "Pay";
 
@@ -42,13 +43,16 @@ export function usePayTabRequestReceive(
   const onClose = useCallback(() => setIsOpen(false), []);
 
   const onCopy = useCallback((address: string) => copyToClipboard(address), [copyToClipboard]);
-  // Save (card image) and Verify (device) land with LIVE-36121 / LIVE-36132.
+  // Verify (device) lands with LIVE-36132.
   const noop = useCallback(() => {}, []);
 
   const data = useMemo(
     () => (selection ? deriveRequestReceiveData(selection.account, selection.parentAccount) : null),
     [selection],
   );
+
+  // Save captures the on-screen request card (QR + address) to a PNG via the native save dialog.
+  const saveCard = useSaveRequestReceiveCard(data?.asset.ticker ?? "");
 
   const labels = useMemo(
     () => ({
@@ -78,12 +82,12 @@ export function usePayTabRequestReceive(
       visibleActions: ["save", "copy", "verify"],
       onShare: noop,
       onCopy,
-      onSave: noop,
+      onSave: saveCard,
       onVerify: noop,
       onClose,
       onTrackEvent,
     }),
-    [isOpen, data, labels, noop, onCopy, onClose, onTrackEvent],
+    [isOpen, data, labels, noop, onCopy, saveCard, onClose, onTrackEvent],
   );
 
   return { open, requestReceive };

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/useSaveRequestReceiveCard.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/useSaveRequestReceiveCard.ts
@@ -1,0 +1,22 @@
+import { useCallback, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { saveRequestReceiveCard } from "./saveRequestReceiveCard";
+
+/**
+ * Returns a guarded callback that saves the request card as a PNG. The guard prevents a second
+ * capture from starting while the OS save dialog of a first one is still open.
+ */
+export function useSaveRequestReceiveCard(ticker: string): () => void {
+  const { t } = useTranslation();
+  const savingRef = useRef(false);
+
+  return useCallback(() => {
+    if (savingRef.current) {
+      return;
+    }
+    savingRef.current = true;
+    void saveRequestReceiveCard(ticker, t("payTab.request.saveDialogTitle")).finally(() => {
+      savingRef.current = false;
+    });
+  }, [ticker, t]);
+}

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -930,6 +930,7 @@
     "request": {
       "title": "Request {{asset}}",
       "networkLabel": "{{network}} network",
+      "saveDialogTitle": "Save request card",
       "actions": {
         "share": "Share",
         "copy": "Copy",

--- a/features/flow/pay-card-request/src/components/RequestReceive/RequestReceiveSummary.web.tsx
+++ b/features/flow/pay-card-request/src/components/RequestReceive/RequestReceiveSummary.web.tsx
@@ -26,7 +26,10 @@ export function RequestReceiveSummary({
   qrPayload,
 }: RequestReceiveSummaryProps) {
   return (
-    <div className="flex flex-col items-center gap-32 bg-surface p-24 rounded-2xl">
+    <div
+      className="flex flex-col items-center gap-32 bg-surface p-24 rounded-2xl"
+      data-testid="pay-card-request-receive-card"
+    >
       <div className="flex flex-col items-center gap-8">
         <span className="heading-3-semi-bold text-base">{title}</span>
         <div

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1267,6 +1267,9 @@ importers:
       fuse.js:
         specifier: 6.6.2
         version: 6.6.2
+      html-to-image:
+        specifier: 1.11.13
+        version: 1.11.13
       i18next:
         specifier: 'catalog:'
         version: 25.7.3(@typescript/typescript6@6.0.2)
@@ -31939,6 +31942,9 @@ packages:
   html-tags@3.3.1:
     resolution: {integrity: sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==}
     engines: {node: '>=8'}
+
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
   html-to-react@1.7.0:
     resolution: {integrity: sha512-b5HTNaTGyOj5GGIMiWVr1k57egAZ/vGy0GGefnCQ1VW5hu9+eku8AXHtf2/DeD95cj/FKBKYa1J7SWBOX41yUQ==}
@@ -64575,6 +64581,8 @@ snapshots:
 
   html-tags@3.3.1: {}
 
+  html-to-image@1.11.13: {}
+
   html-to-react@1.7.0(react@19.1.4):
     dependencies:
       domhandler: 5.0.3
@@ -68329,7 +68337,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3
+      metro: 0.83.3(metro-transform-worker@0.83.3)
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -68453,6 +68461,54 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.83.3(metro-transform-worker@0.83.3):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.28.5
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 1.3.8
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.32.0
+      image-size: 1.1.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0(metro@0.83.3)
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.3
+      metro-cache: 0.83.3
+      metro-cache-key: 0.83.3
+      metro-config: 0.83.3(metro-transform-worker@0.83.3)
+      metro-core: 0.83.3
+      metro-file-map: 0.83.3(metro@0.83.3)
+      metro-resolver: 0.83.3
+      metro-runtime: 0.83.3
+      metro-source-map: 0.83.3
+      metro-symbolicate: 0.83.3
+      metro-transform-plugins: 0.83.3
+      metro-transform-worker: 0.83.3
+      mime-types: 2.1.35
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
### 📝 Description

Wires the **Save** action of the Pay tab Request receive dialog on Ledger Wallet Desktop, which was previously a no-op.

**Problem**: the Save tile in the Request receive dialog did nothing — users could not export the receive card.

**Solution**: on Save, capture the on-screen card (QR + `Send <asset>` header + address) to a PNG via `html-to-image`, then persist it through the native OS save dialog. The image bytes are written by a new `save-png` main-process IPC handler, so the renderer never touches the filesystem directly. A re-entry guard prevents a second capture while a dialog is already open.

- `saveRequestReceiveCard` (pure): `document.querySelector` the card node, `toPng`, strip the data-url prefix, `show-save-dialog`, then `save-png`.
- `useSaveRequestReceiveCard`: resolves the dialog title (i18n `payTab.request.saveDialogTitle`) and guards re-entry; wired into `usePayTabRequestReceive` (`onSave`).
- Adds a stable `data-testid="pay-card-request-receive-card"` on the summary card so the host can locate the capture node.
- Unit test covers: successful write, canceled dialog, missing node, and capture failure.

Bundlephobia : https://bundlephobia.com/package/html-to-image@1.11.13

> Stacked on top of the LIVE-36254 branch (base of this PR). Verify action ships separately (LIVE-36272).

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36271](https://ledgerhq.atlassian.net/browse/LIVE-36271)

[LIVE-36271]: https://ledgerhq.atlassian.net/browse/LIVE-36271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ