### PR TITLE
[LWDM] fix(contacts): expose contact avatar from root

### DIFF
--- a/.changeset/calm-avatars-unify.md
+++ b/.changeset/calm-avatars-unify.md
@@ -1,0 +1,7 @@
+---
+"@features/flow-contacts": patch
+"@features/flow-contacts-list": patch
+"@features/platform-contacts": patch
+---
+
+Expose ContactAvatar through the platform root API.

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/components/RecipientHeaderPrefix.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/components/RecipientHeaderPrefix.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ContactAvatar } from "@features/platform-contacts/web";
+import { ContactAvatar } from "@features/platform-contacts";
 import type { RecipientHeaderContact } from "@ledgerhq/live-common/flows/send/recipient/utils/getRecipientHeaderPresentation";
 import type { ContactId } from "@domain/entity-contact";
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/RecipientCard.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/RecipientCard.tsx
@@ -1,5 +1,5 @@
 import { ContactIdSchema } from "@domain/entity-contact";
-import { ContactAvatar } from "@features/platform-contacts/web";
+import { ContactAvatar } from "@features/platform-contacts";
 import type { MatchedContact } from "@ledgerhq/live-common/flows/send/recipient/types";
 import {
   Button,

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/__tests__/AddressMatchedSection.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/__tests__/AddressMatchedSection.test.tsx
@@ -11,6 +11,10 @@ import {
 import { AddressMatchedSection } from "../AddressMatchedSection";
 import { useAddressMatchedSectionViewModel } from "../../hooks/useAddressMatchedSectionViewModel";
 
+jest.mock("@features/platform-contacts", () => ({
+  ContactAvatar: ({ testId }: { testId?: string }) => <span data-testid={testId} />,
+}));
+
 const FIXED_NOW = new Date("2026-07-31T10:00:00.000Z");
 const address = "0x95f98055ag77xe7csuz15e36";
 const formattedAddress = "0x95f980...suz15e36";

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/RecipientContactRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/RecipientContactRow.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Text, View } from "react-native";
 import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
-import { ContactAvatar } from "@features/platform-contacts/native";
+import { ContactAvatar } from "@features/platform-contacts";
 import type { RecipientHeaderContact } from "@ledgerhq/live-common/flows/send/recipient/utils/getRecipientHeaderPresentation";
 import type { ContactId } from "@domain/entity-contact";
 
@@ -45,7 +45,7 @@ export function RecipientContactRow({ contact, label, value }: RecipientContactR
         contactId={contact.id as ContactId}
         name={contact.name}
         size="xs"
-        testID="recipient-contact-avatar"
+        testId="recipient-contact-avatar"
       />
       <Text style={styles.name} numberOfLines={1}>
         {value}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientCard.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientCard.tsx
@@ -1,5 +1,5 @@
 import { ContactIdSchema } from "@domain/entity-contact";
-import { ContactAvatar } from "@features/platform-contacts/native";
+import { ContactAvatar } from "@features/platform-contacts";
 import type { MatchedContact } from "@ledgerhq/live-common/flows/send/recipient/types";
 import {
   Box,
@@ -45,7 +45,7 @@ export function RecipientCard({
               contactId={ContactIdSchema.parse(contact.contactId)}
               name={contact.contactName}
               size="md"
-              testID="send-recipient-card-avatar"
+              testId="send-recipient-card-avatar"
             />
           ) : (
             <Spot appearance="icon" icon={Wallet} />

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/__tests__/AddressMatchedSection.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/__tests__/AddressMatchedSection.test.tsx
@@ -19,10 +19,10 @@ jest.mock("~/context/hooks", () => ({
   useSelector: () => "en",
 }));
 
-jest.mock("@features/platform-contacts/native", () => ({
-  ContactAvatar: ({ name, testID }: { name: string; testID?: string }) => {
+jest.mock("@features/platform-contacts", () => ({
+  ContactAvatar: ({ name, testId }: { name: string; testId?: string }) => {
     const RN = jest.requireActual<typeof import("react-native")>("react-native");
-    return <RN.Text testID={testID}>{name}</RN.Text>;
+    return <RN.Text testID={testId}>{name}</RN.Text>;
   },
 }));
 

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailAvatar.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailAvatar.native.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { Contact } from "@domain/entity-contact";
-import { ContactAvatar } from "@features/platform-contacts/native";
+import { ContactAvatar } from "@features/platform-contacts";
 
 type ContactDetailAvatarProps = Readonly<{
   contact: Contact;
@@ -18,7 +18,7 @@ export function ContactDetailAvatar({
       isMe={contact.isMe}
       src={meAvatarSrc}
       size="xl"
-      testID={contact.isMe ? "contacts-detail-me-avatar" : "contacts-detail-avatar"}
+      testId={contact.isMe ? "contacts-detail-me-avatar" : "contacts-detail-avatar"}
     />
   );
 }

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailAvatar.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailAvatar.web.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { Contact } from "@domain/entity-contact";
-import { ContactAvatar } from "@features/platform-contacts/web";
+import { ContactAvatar } from "@features/platform-contacts";
 
 type ContactDetailAvatarProps = Readonly<{
   contact: Contact;

--- a/features/flow/flow-contacts-list/src/components/ContactsCompactList/ContactsCompactList.native.tsx
+++ b/features/flow/flow-contacts-list/src/components/ContactsCompactList/ContactsCompactList.native.tsx
@@ -6,7 +6,7 @@ import {
   ListItemLeading,
   ListItemTitle,
 } from "@ledgerhq/lumen-ui-rnative";
-import { ContactAvatar } from "@features/platform-contacts/native";
+import { ContactAvatar } from "@features/platform-contacts";
 import type { ContactsCompactListProps } from "../../types";
 import {
   getCompactContactAddressDescription,

--- a/features/flow/flow-contacts-list/src/components/ContactsCompactList/ContactsCompactList.web.tsx
+++ b/features/flow/flow-contacts-list/src/components/ContactsCompactList/ContactsCompactList.web.tsx
@@ -6,7 +6,7 @@ import {
   ListItemLeading,
   ListItemTitle,
 } from "@ledgerhq/lumen-ui-react";
-import { ContactAvatar } from "@features/platform-contacts/web";
+import { ContactAvatar } from "@features/platform-contacts";
 import type { ContactsCompactListProps } from "../../types";
 import {
   getCompactContactAddressDescription,

--- a/features/flow/flow-contacts-list/src/components/ContactsList/ListItems/ContactsMeListItem.web.tsx
+++ b/features/flow/flow-contacts-list/src/components/ContactsList/ListItems/ContactsMeListItem.web.tsx
@@ -6,7 +6,7 @@ import {
   ListItemLeading,
   ListItemTitle,
 } from "@ledgerhq/lumen-ui-react";
-import { ContactAvatar } from "@features/platform-contacts/web";
+import { ContactAvatar } from "@features/platform-contacts";
 import type { ContactsListItem } from "../../../types";
 
 type ContactsMeListItemProps = Readonly<{

--- a/features/flow/flow-contacts-list/src/components/ContactsList/ListItems/ContactsSavedContactListItem.native.tsx
+++ b/features/flow/flow-contacts-list/src/components/ContactsList/ListItems/ContactsSavedContactListItem.native.tsx
@@ -6,7 +6,7 @@ import {
   ListItemLeading,
   ListItemTitle,
 } from "@ledgerhq/lumen-ui-rnative";
-import { ContactAvatar } from "@features/platform-contacts/native";
+import { ContactAvatar } from "@features/platform-contacts";
 import type { ContactsListItem } from "../../../types";
 
 type ContactsSavedContactListItemProps = Readonly<{

--- a/features/flow/flow-contacts-list/src/components/ContactsList/ListItems/ContactsSavedListItem.web.tsx
+++ b/features/flow/flow-contacts-list/src/components/ContactsList/ListItems/ContactsSavedListItem.web.tsx
@@ -6,7 +6,7 @@ import {
   ListItemLeading,
   ListItemTitle,
 } from "@ledgerhq/lumen-ui-react";
-import { ContactAvatar } from "@features/platform-contacts/web";
+import { ContactAvatar } from "@features/platform-contacts";
 import type { ContactsListItem } from "../../../types";
 
 type ContactsSavedListItemProps = Readonly<{

--- a/features/platform/contacts/knip.native.config.mjs
+++ b/features/platform/contacts/knip.native.config.mjs
@@ -1,0 +1,15 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const rootConfig = require("../../../knip.json");
+
+export default {
+  ...rootConfig,
+  workspaces: {
+    ...rootConfig.workspaces,
+    "features/platform/contacts": {
+      entry: ["src/index.native.ts"],
+      project: ["src/**/*", "!src/**/*.web.*", "!src/index.ts", "!src/web.ts"],
+    },
+  },
+};

--- a/features/platform/contacts/knip.web.config.mjs
+++ b/features/platform/contacts/knip.web.config.mjs
@@ -1,0 +1,15 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const rootConfig = require("../../../knip.json");
+
+export default {
+  ...rootConfig,
+  workspaces: {
+    ...rootConfig.workspaces,
+    "features/platform/contacts": {
+      entry: ["src/index.ts", "src/web.ts"],
+      project: ["src/**/*", "!src/**/*.native.*", "!src/index.native.ts"],
+    },
+  },
+};

--- a/features/platform/contacts/package.json
+++ b/features/platform/contacts/package.json
@@ -23,7 +23,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "coverage": "jest --coverage",
-    "unimported": "pnpm knip --directory ../../.. -W features/platform/contacts"
+    "unimported": "pnpm knip --directory ../../.. -c features/platform/contacts/knip.web.config.mjs -W features/platform/contacts --tsConfig tsconfig.web.json --isolate-workspaces && pnpm knip --directory ../../.. -c features/platform/contacts/knip.native.config.mjs -W features/platform/contacts --tsConfig tsconfig.native.json --isolate-workspaces"
   },
   "dependencies": {
     "@domain/entity-contact": "workspace:*",

--- a/features/platform/contacts/src/components/ContactAvatar/ContactAvatar.native.test.tsx
+++ b/features/platform/contacts/src/components/ContactAvatar/ContactAvatar.native.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen } from "@testing-library/react-native";
 import { ContactIdSchema } from "@domain/entity-contact";
-import { ContactAvatar } from "./ContactAvatar";
+import { ContactAvatar } from ".";
 
 jest.mock("@ledgerhq/lumen-ui-rnative", () => ({
   Avatar: ({ testID, ...props }: { testID?: string }) => {
@@ -34,7 +34,7 @@ describe("ContactAvatar", () => {
         contactId={contactId}
         name="Benoit Jean"
         size="xl"
-        testID="contacts-detail-avatar"
+        testId="contacts-detail-avatar"
       />,
     );
 
@@ -65,7 +65,7 @@ describe("ContactAvatar", () => {
         isMe
         src="https://example.com/me.png"
         size="xl"
-        testID="contacts-detail-me-avatar"
+        testId="contacts-detail-me-avatar"
       />,
     );
 

--- a/features/platform/contacts/src/components/ContactAvatar/ContactAvatar.native.tsx
+++ b/features/platform/contacts/src/components/ContactAvatar/ContactAvatar.native.tsx
@@ -13,7 +13,7 @@ export type ContactAvatarProps = Readonly<{
   isMe?: boolean;
   src?: string;
   size?: LumenAvatarProps["size"];
-  testID?: string;
+  testId?: string;
 }>;
 
 export function ContactAvatar({
@@ -22,9 +22,9 @@ export function ContactAvatar({
   isMe = false,
   src,
   size = "sm",
-  testID,
+  testId,
 }: ContactAvatarProps): React.JSX.Element {
-  const resolvedTestID = testID ?? `contacts-avatar-${contactId}`;
+  const resolvedTestID = testId ?? `contacts-avatar-${contactId}`;
 
   if (isMe) {
     return (

--- a/features/platform/contacts/src/components/ContactAvatar/ContactAvatar.web.test.tsx
+++ b/features/platform/contacts/src/components/ContactAvatar/ContactAvatar.web.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import { ContactIdSchema } from "@domain/entity-contact";
-import { ContactAvatar } from "./ContactAvatar";
+import { ContactAvatar } from ".";
 
 describe("ContactAvatar", () => {
   it("should bind a contact initial and Lumen pastel color for the default list size", () => {

--- a/features/platform/contacts/src/components/ContactAvatar/index.native.ts
+++ b/features/platform/contacts/src/components/ContactAvatar/index.native.ts
@@ -1,0 +1,1 @@
+export * from "./ContactAvatar.native";

--- a/features/platform/contacts/src/components/ContactAvatar/index.ts
+++ b/features/platform/contacts/src/components/ContactAvatar/index.ts
@@ -1,0 +1,1 @@
+export * from "./ContactAvatar.web";

--- a/features/platform/contacts/src/index.native.ts
+++ b/features/platform/contacts/src/index.native.ts
@@ -6,7 +6,7 @@ export * from "./utils/formatMeDisplayName";
 export * from "./utils/resolveMeContactDisplayName";
 export * from "./featureFlags";
 export * from "./utils/resolveEligibleAddressCurrencyIds";
-export * from "./components/ContactAvatar/ContactAvatar.native";
+export * from "./components/ContactAvatar/index.native";
 export * from "./contactDeviceIntentsPort";
 export * from "./addressEntry/types";
 export * from "./addressEntry/validation";

--- a/features/platform/contacts/src/index.ts
+++ b/features/platform/contacts/src/index.ts
@@ -7,6 +7,7 @@ export * from "./utils/resolveMeContactDisplayName";
 export * from "./contactDeviceIntentsPort";
 export * from "./featureFlags";
 export * from "./utils/resolveEligibleAddressCurrencyIds";
+export * from "./components/ContactAvatar";
 export * from "./addressEntry/types";
 export * from "./addressEntry/validation";
 export * from "./addressEntry/state";

--- a/features/platform/contacts/src/web.ts
+++ b/features/platform/contacts/src/web.ts
@@ -6,4 +6,4 @@ export * from "./utils/resolveMeContactDisplayName";
 export * from "./contactDeviceIntentsPort";
 export * from "./featureFlags";
 export * from "./utils/resolveEligibleAddressCurrencyIds";
-export * from "./components/ContactAvatar/ContactAvatar.web";
+export * from "./components/ContactAvatar";


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Focused Desktop and Mobile Send tests, Mobile My Wallet integration, and ContactAvatar Web/Native tests pass.
- [x] **Impact of the changes:**
      Verify contact avatars render in Contacts and Send on Desktop and Mobile through the root Platform Contacts import.

### 📝 Description

This PR replaces the temporary platform-suffixed `ContactAvatar` imports introduced by #20948.

`@features/platform-contacts` now exposes `ContactAvatar` from its conditional root entry, so consumers use:

```ts
import { ContactAvatar } from "@features/platform-contacts";
```

Desktop resolves the Web implementation and Mobile resolves the Native implementation.

### ❓ Context

- **JIRA or GitHub link**: https://github.com/LedgerHQ/ledger-live/pull/20948

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked Jira or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)