### PR TITLE
[LWD] feat(dynamic-content): add carousel shop UTMs (LIVE-35393)

### DIFF
--- a/.changeset/calm-carousel-close.md
+++ b/.changeset/calm-carousel-close.md
@@ -1,5 +1,6 @@
 ---
 "ledger-live-desktop": minor
+"@features/flow-large-screen-upsell": minor
 ---
 
-Add hardware carousel close all control on portfolio
+Add hardware carousel close all and shop UTMs on desktop portfolio

--- a/.changeset/calm-carousel-close.md
+++ b/.changeset/calm-carousel-close.md
@@ -1,6 +1,5 @@
 ---
 "ledger-live-desktop": minor
-"@features/flow-large-screen-upsell": minor
 ---
 
-Add hardware carousel close all and shop UTMs on desktop portfolio
+Add hardware carousel close all control on portfolio

--- a/.changeset/tidy-carousel-shop.md
+++ b/.changeset/tidy-carousel-shop.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@features/flow-large-screen-upsell": minor
+---
+
+Add shop UTMs on hardware carousel card clicks in the desktop portfolio

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/ContentCardsCategory.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/ContentCardsCategory.test.tsx
@@ -3,9 +3,11 @@ import React from "react";
 import type { Card as BrazeCard } from "@braze/web-sdk";
 import { logCardDismissal, logContentCardClick, ClassicCard } from "@braze/web-sdk";
 import { DeviceModelId } from "@ledgerhq/types-devices";
+import { LARGE_SCREEN_UPSELL_UTM } from "@features/flow-large-screen-upsell";
 import { fireEvent, render, screen } from "tests/testSetup";
 import { track } from "~/renderer/analytics/segment";
 import { ContentCardEvent } from "@ledgerhq/live-common/braze/contentCardExtras";
+import { openURL } from "~/renderer/linking";
 import {
   CategoryContentCard,
   ContentCardsLayout,
@@ -210,9 +212,22 @@ describe("ContentCardsLocation", () => {
       expect.objectContaining({
         campaign: "child-flex",
         contentcard: "Nano Case",
+        location: LocationContentCard.Portfolio,
       }),
     );
     expect(logContentCardClick).toHaveBeenCalled();
+    expect(openURL).toHaveBeenCalledTimes(1);
+
+    const openedUrl = new URL(jest.mocked(openURL).mock.calls[0]![0] as string);
+    expect(openedUrl.origin + openedUrl.pathname).toBe("https://shop.ledger.com/products");
+    expect(openedUrl.searchParams.get("utm_source")).toBe(
+      LARGE_SCREEN_UPSELL_UTM.sourceByPlatform.desktop,
+    );
+    expect(openedUrl.searchParams.get("utm_medium")).toBe(LARGE_SCREEN_UPSELL_UTM.medium);
+    expect(openedUrl.searchParams.get("utm_campaign")).toBe(LARGE_SCREEN_UPSELL_UTM.campaign);
+    expect(openedUrl.searchParams.get("utm_content")).toBe(
+      LARGE_SCREEN_UPSELL_UTM.content.hardware_carousel,
+    );
   });
 
   test("renders the close all link for dismissable hardware carousel categories", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/__tests__/useContentCardsCategoryViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/__tests__/useContentCardsCategoryViewModel.test.tsx
@@ -127,11 +127,55 @@ describe("useContentCardsCategoryViewModel", () => {
       expect.objectContaining({
         campaign: "child-1",
         contentcard: "Card child-1",
+        location: LocationContentCard.Portfolio,
       }),
     );
     expect(logClickCard).toHaveBeenCalledWith("child-1");
     expect(mockNavigate).toHaveBeenCalledWith("/market", { state: { source: "banner" } });
     expect(openURL).not.toHaveBeenCalled();
+  });
+
+  it("opens external shop links with hardware carousel UTMs", () => {
+    const { result } = renderHook(() =>
+      useContentCardsCategoryViewModel({
+        category: CATEGORY,
+        categoryContentCards: [childCard("child-1", "1", "https://shop.ledger.com/products")],
+      }),
+    );
+
+    result.current.onCardClick(result.current.slides[0]!.card, 0);
+
+    expect(trackContentCardEvent).toHaveBeenCalledWith(
+      ContentCardEvent.Clicked,
+      expect.objectContaining({
+        campaign: "child-1",
+        contentcard: "Card child-1",
+        location: LocationContentCard.Portfolio,
+      }),
+    );
+    expect(logClickCard).toHaveBeenCalledWith("child-1");
+    expect(openURL).toHaveBeenCalledTimes(1);
+
+    const openedUrl = new URL(jest.mocked(openURL).mock.calls[0]![0] as string);
+    expect(openedUrl.origin + openedUrl.pathname).toBe("https://shop.ledger.com/products");
+    expect(openedUrl.searchParams.get("utm_source")).toBe("ledger_wallet_desktop");
+    expect(openedUrl.searchParams.get("utm_medium")).toBe("ledger_live");
+    expect(openedUrl.searchParams.get("utm_campaign")).toBe("nano_upgrade_program");
+    expect(openedUrl.searchParams.get("utm_content")).toBe("hardware_carousel");
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("opens ledgerlive deeplinks without appending UTMs", () => {
+    const { result } = renderHook(() =>
+      useContentCardsCategoryViewModel({
+        category: CATEGORY,
+        categoryContentCards: [childCard("child-1", "1", "ledgerlive://market")],
+      }),
+    );
+
+    result.current.onCardClick(result.current.slides[0]!.card, 0);
+
+    expect(openURL).toHaveBeenCalledWith("ledgerlive://market?deeplinkLocation=portfolio");
   });
 
   it("routes the header CTA through the same deeplink handler", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/__tests__/useContentCardsCategoryViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/__tests__/useContentCardsCategoryViewModel.test.tsx
@@ -165,6 +165,19 @@ describe("useContentCardsCategoryViewModel", () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
+  it("does not append hardware carousel UTMs for other category cards", () => {
+    const { result } = renderHook(() =>
+      useContentCardsCategoryViewModel({
+        category: { ...CATEGORY, categoryId: "promo", isDismissable: false },
+        categoryContentCards: [childCard("child-1", "1", "https://shop.ledger.com/products")],
+      }),
+    );
+
+    result.current.onCardClick(result.current.slides[0]!.card, 0);
+
+    expect(openURL).toHaveBeenCalledWith("https://shop.ledger.com/products");
+  });
+
   it("opens ledgerlive deeplinks without appending UTMs", () => {
     const { result } = renderHook(() =>
       useContentCardsCategoryViewModel({

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/useContentCardsCategoryViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/useContentCardsCategoryViewModel.ts
@@ -147,9 +147,14 @@ export function useContentCardsCategoryViewModel({
       }
       trackCategoryEvent(ContentCardEvent.Clicked, card, displayedPosition);
       logClickCard(card.id);
-      openContentCardLink(resolveHardwareCarouselCardLink(card.link), navigate);
+      openContentCardLink(
+        shouldShowHardwareCarouselCloseAll(category)
+          ? resolveHardwareCarouselCardLink(card.link)
+          : card.link,
+        navigate,
+      );
     },
-    [logClickCard, navigate, trackCategoryEvent],
+    [category, logClickCard, navigate, trackCategoryEvent],
   );
 
   const onCardDismiss = useCallback(

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/useContentCardsCategoryViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/useContentCardsCategoryViewModel.ts
@@ -3,6 +3,10 @@ import { useCallback, useMemo } from "react";
 import { useNavigate, type NavigateFunction } from "react-router";
 
 import {
+  LARGE_SCREEN_UPSELL_UTM,
+  buildLargeScreenUpsellCtaLink,
+} from "@features/flow-large-screen-upsell";
+import {
   buildContentCardTrackingProperties,
   ContentCardEvent,
   type ContentCardInteractionEvent,
@@ -17,6 +21,16 @@ import { shouldShowHardwareCarouselCloseAll } from "../../hardwareCarousel/shoul
 import { getRenderableSmallSquareSlides } from "../../utils/getRenderableSmallSquareSlides";
 import type { SmallSquareContentCard } from "../../utils/mapSmallSquareContentCard";
 
+const WEB_PROTOCOLS = new Set(["http:", "https:"]);
+
+function isWebLink(link: string): boolean {
+  try {
+    return WEB_PROTOCOLS.has(new URL(link).protocol);
+  } catch {
+    return false;
+  }
+}
+
 function openContentCardLink(link: string, navigate: NavigateFunction): void {
   if (link.startsWith("ledger-live:")) {
     const path = link
@@ -27,6 +41,18 @@ function openContentCardLink(link: string, navigate: NavigateFunction): void {
     return;
   }
   openURL(link);
+}
+
+function resolveHardwareCarouselCardLink(link: string): string {
+  if (!isWebLink(link)) {
+    return link;
+  }
+
+  return buildLargeScreenUpsellCtaLink(
+    link,
+    "desktop",
+    LARGE_SCREEN_UPSELL_UTM.content.hardware_carousel,
+  );
 }
 
 export type MappedCategorySlide = {
@@ -121,7 +147,7 @@ export function useContentCardsCategoryViewModel({
       }
       trackCategoryEvent(ContentCardEvent.Clicked, card, displayedPosition);
       logClickCard(card.id);
-      openContentCardLink(card.link, navigate);
+      openContentCardLink(resolveHardwareCarouselCardLink(card.link), navigate);
     },
     [logClickCard, navigate, trackCategoryEvent],
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/SmallSquareCard/__tests__/SmallSquareCard.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/SmallSquareCard/__tests__/SmallSquareCard.test.tsx
@@ -47,4 +47,18 @@ describe("SmallSquareCard", () => {
 
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
+
+  it("should highlight the card on hover only when it is clickable", () => {
+    const { rerender } = render(<SmallSquareCard title="Ledger Stax" onClick={jest.fn()} />);
+
+    expect(screen.getByTestId("small-square-card")).toHaveClass(
+      "group-hover/card:bg-surface-hover",
+    );
+
+    rerender(<SmallSquareCard title="Ledger Stax" />);
+
+    expect(screen.getByTestId("small-square-card")).not.toHaveClass(
+      "group-hover/card:bg-surface-hover",
+    );
+  });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/SmallSquareCard/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/SmallSquareCard/index.tsx
@@ -62,10 +62,13 @@ type CardContainerProps = Readonly<{
   ariaLabel?: string;
 }>;
 
+const INTERACTIVE_CLASSES =
+  "cursor-pointer group-hover/card:bg-surface-hover active:bg-surface-pressed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus";
+
 function CardContainer({ children, isMediaOnly, onClick, ariaLabel }: CardContainerProps) {
-  const className = `flex w-full flex-col overflow-hidden rounded-lg border-0 bg-surface p-0 ${
+  const className = `flex w-full flex-col overflow-hidden rounded-lg border-0 bg-surface p-0 transition-colors ${
     isMediaOnly ? "items-center justify-center" : ""
-  } ${onClick ? "cursor-pointer" : "cursor-default"}`;
+  } ${onClick ? INTERACTIVE_CLASSES : "cursor-default"}`;
   const style = { height: CARD_HEIGHT_PX };
 
   if (onClick) {
@@ -176,7 +179,7 @@ function SmallSquareCard({
     : undefined;
 
   return (
-    <div className="relative w-full min-w-0">
+    <div className="group/card relative w-full min-w-0">
       <CardOverlay tag={tag} isDismissable={isDismissable} onDismiss={onDismiss} />
       <CardContainer isMediaOnly={isMediaOnly} onClick={onClick} ariaLabel={clickableCardLabel}>
         <CardMedia title={title} media={media} mediaType={mediaType} filledMedia={filledMedia} />

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/BrazeTools/Hooks/useGenerateLocalBraze.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/BrazeTools/Hooks/useGenerateLocalBraze.ts
@@ -229,6 +229,7 @@ export const useGenerateLocalBraze = () => {
         subDescription: sample.subDescription,
         tag: sample.tag,
         mediaUrl: sample.mediaUrl,
+        link: sample.link,
         order: String(index),
       };
       const cardId = `${DEBUG_CARD_PREFIX}-top-wallet-hardware-${baseTimestamp}-${index}`;

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/BrazeTools/__tests__/hardwareCarouselDebug.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/BrazeTools/__tests__/hardwareCarouselDebug.test.ts
@@ -5,6 +5,7 @@ import {
   buildHardwareCarouselDebugCards,
   buildRandomLedgerImageUrl,
   getHardwareCarouselProductImage,
+  HARDWARE_CAROUSEL_DEFAULT_LINK,
   HARDWARE_CAROUSEL_LOCAL_IMAGE_URLS,
   HARDWARE_CAROUSEL_PRODUCTS,
   HARDWARE_CAROUSEL_SAMPLE_PRODUCTS,
@@ -17,7 +18,7 @@ describe("hardwareCarouselDebug", () => {
     expect(defaults.categoryTitle).toBe("");
     expect(defaults.productTitle).toBe(HARDWARE_CAROUSEL_PRODUCTS[0]);
     expect(defaults.tag).toBe("30% off");
-    expect(defaults.link).toBe("");
+    expect(defaults.link).toBe(HARDWARE_CAROUSEL_DEFAULT_LINK);
     expect(defaults.mediaUrl).toBe(getHardwareCarouselProductImage(HARDWARE_CAROUSEL_PRODUCTS[0]));
   });
 
@@ -27,6 +28,19 @@ describe("hardwareCarouselDebug", () => {
     HARDWARE_CAROUSEL_SAMPLE_PRODUCTS.forEach(sample => {
       expect(HARDWARE_CAROUSEL_LOCAL_IMAGE_URLS).toContain(sample.mediaUrl);
     });
+  });
+
+  it("should give sample cards a shop link so they stay clickable", () => {
+    HARDWARE_CAROUSEL_SAMPLE_PRODUCTS.forEach(sample => {
+      expect(sample.link).toBe(HARDWARE_CAROUSEL_DEFAULT_LINK);
+    });
+
+    const { card } = buildHardwareCarouselDebugCards(
+      buildDefaultHardwareCarouselValues(),
+      "debug-card-link",
+    );
+
+    expect(card.extras?.link).toBe(HARDWARE_CAROUSEL_DEFAULT_LINK);
   });
 
   it("should build an alwayson category shell and a small_square child card", () => {

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/BrazeTools/hardwareCarouselDebug.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/BrazeTools/hardwareCarouselDebug.ts
@@ -29,10 +29,31 @@ export const HARDWARE_CAROUSEL_LOCAL_IMAGE_URLS = [
 
 export const HARDWARE_CAROUSEL_PRODUCTS = ["Ledger Stax", "Nano Pod", "Ledger Flex"] as const;
 
+export const HARDWARE_CAROUSEL_DEFAULT_LINK =
+  "https://shop.ledger.com/pages/hardware-wallets-comparison";
+
 export const HARDWARE_CAROUSEL_SAMPLE_PRODUCTS = [
-  { productTitle: "Nano Pod", subDescription: "$50", tag: "30% off", mediaUrl: apexImage },
-  { productTitle: "Nano Case", subDescription: "$89", tag: "", mediaUrl: blueImage },
-  { productTitle: "Ledger Flex™", subDescription: "", tag: "$50 off", mediaUrl: flexImage },
+  {
+    productTitle: "Nano Pod",
+    subDescription: "$50",
+    tag: "30% off",
+    mediaUrl: apexImage,
+    link: HARDWARE_CAROUSEL_DEFAULT_LINK,
+  },
+  {
+    productTitle: "Nano Case",
+    subDescription: "$89",
+    tag: "",
+    mediaUrl: blueImage,
+    link: HARDWARE_CAROUSEL_DEFAULT_LINK,
+  },
+  {
+    productTitle: "Ledger Flex™",
+    subDescription: "",
+    tag: "$50 off",
+    mediaUrl: flexImage,
+    link: HARDWARE_CAROUSEL_DEFAULT_LINK,
+  },
 ] as const;
 
 const HARDWARE_CAROUSEL_PRODUCT_IMAGES: Record<
@@ -84,7 +105,7 @@ export function buildDefaultHardwareCarouselValues(): HardwareCarouselBuilderVal
     subDescription: "",
     tag: "30% off",
     mediaUrl: getHardwareCarouselProductImage(HARDWARE_CAROUSEL_PRODUCTS[0]) ?? staxImage,
-    link: "",
+    link: HARDWARE_CAROUSEL_DEFAULT_LINK,
     order: "0",
   };
 }

--- a/features/flow/large-screen-upsell/src/utils/upsellCta.test.ts
+++ b/features/flow/large-screen-upsell/src/utils/upsellCta.test.ts
@@ -102,6 +102,24 @@ describe("buildLargeScreenUpsellCtaLink", () => {
     expect(url.searchParams.get("utm_content")).toBe(LARGE_SCREEN_UPSELL_UTM.content.profile_cta);
   });
 
+  it("should set hardware_carousel utm_content", () => {
+    const result = buildLargeScreenUpsellCtaLink(
+      "https://example.com/offer",
+      "desktop",
+      LARGE_SCREEN_UPSELL_UTM.content.hardware_carousel,
+    );
+    const url = new URL(result);
+
+    expect(url.searchParams.get("utm_source")).toBe(
+      LARGE_SCREEN_UPSELL_UTM.sourceByPlatform.desktop,
+    );
+    expect(url.searchParams.get("utm_medium")).toBe(LARGE_SCREEN_UPSELL_UTM.medium);
+    expect(url.searchParams.get("utm_campaign")).toBe(LARGE_SCREEN_UPSELL_UTM.campaign);
+    expect(url.searchParams.get("utm_content")).toBe(
+      LARGE_SCREEN_UPSELL_UTM.content.hardware_carousel,
+    );
+  });
+
   it("should preserve existing query params while setting UTM values", () => {
     const result = buildLargeScreenUpsellCtaLink(
       "https://example.com/offer?foo=bar",

--- a/features/flow/large-screen-upsell/src/utils/upsellCta.ts
+++ b/features/flow/large-screen-upsell/src/utils/upsellCta.ts
@@ -10,6 +10,7 @@ export const LARGE_SCREEN_UPSELL_UTM = {
     backups_cta: "backups_cta",
     profile_cta: "profile_cta",
     recover_trigger: "recover_trigger",
+    hardware_carousel: "hardware_carousel",
   },
 } as const;
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

https://github.com/user-attachments/assets/77e83c40-1e86-45f5-a4a5-7c0ab69ad1cd

On hardware carousel card click, open the shop with openURL and the approved UTMs (utm_source=ledger_wallet_desktop, utm_medium=ledger_live, utm_campaign=nano_upgrade_program, utm_content=hardware_carousel). Fire contentcard_clicked with location=portfolio.

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35393]<!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-35393]: https://ledgerhq.atlassian.net/browse/LIVE-35393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ