### PR TITLE
test(e2e-mobile): add borrow cold start e2e test

### DIFF
--- a/.changeset/lwm-e2e-borrow-cold-start.md
+++ b/.changeset/lwm-e2e-borrow-cold-start.md
@@ -1,0 +1,10 @@
+---
+"ledger-live-mobile-e2e-tests": patch
+---
+
+Add the Borrow cold-start E2E test to the Ledger Wallet Mobile suite (B2CQA-6062): the portfolio
+entry point opens the Borrow live app and shows the "Introducing Crypto Loan" modal. Broadcasts
+nothing and runs on an isolated seed, so it needs no device and is safe to run in parallel.
+Verified on Android and iOS. The portfolio entry point taps the card that was scrolled into view
+rather than the CTA nested inside it — both share the same `onPress`, but only the card is
+guaranteed on screen after the scroll.

--- a/e2e/mobile/page/index.ts
+++ b/e2e/mobile/page/index.ts
@@ -33,6 +33,7 @@ import MyWalletPage from "./wallet/myWallet.page";
 import OperationPage from "./wallet/operation.page";
 import TopBarSearchPage from "./wallet/topBarSearch.page";
 import CeloManageAssetsPage from "./trade/celoManageAssets.page";
+import BorrowPage from "./trade/borrow.page";
 import TransferMenuDrawer from "./wallet/transferMenu.drawer";
 import BuySellPage from "./trade/buySell.page";
 import EarnV2DashboardPage from "./trade/earnV2Dashboard.page";
@@ -55,7 +56,7 @@ export const getUserdataPath = (userdata: string) => {
 const lazyInit = <T>(PageClass: new () => T) => {
   let instance: T | null = null;
   return () => {
-    if (!instance) instance = new PageClass();
+    instance ??= new PageClass();
     return instance;
   };
 };
@@ -93,6 +94,7 @@ export class Application {
   private myWalletPageInstance = lazyInit(MyWalletPage);
   private operationPageInstance = lazyInit(OperationPage);
   private celoManageAssetsPageInstance = lazyInit(CeloManageAssetsPage);
+  private readonly borrowPageInstance = lazyInit(BorrowPage);
   private TransferMenuDrawerInstance = lazyInit(TransferMenuDrawer);
   private buySellPageInstance = lazyInit(BuySellPage);
   private settingsHelpPageInstance = lazyInit(SettingsHelpPage);
@@ -257,6 +259,10 @@ export class Application {
 
   public get earnV2Dashboard() {
     return this.earnV2DashboardPageInstance();
+  }
+
+  public get borrow() {
+    return this.borrowPageInstance();
   }
 
   public get modularDrawer() {

--- a/e2e/mobile/page/trade/borrow.page.ts
+++ b/e2e/mobile/page/trade/borrow.page.ts
@@ -1,0 +1,23 @@
+import { Step } from "jest-allure2-reporter/api";
+
+export default class BorrowPage {
+  private readonly borrowScreenId = "borrow-screen";
+
+  // Mirrors borrow-live-app packages/features/src/testIds.ts
+  private readonly introModalId = "borrow-intro-modal";
+  private readonly introModalTitleId = "borrow-intro-modal-title";
+
+  @Step("Expect borrow native screen visible")
+  async expectBorrowScreenVisible() {
+    await waitForElementById(this.borrowScreenId);
+    await waitForElementById(app.common.walletApiWebview, undefined, { checkVisibility: false });
+    await waitForWebviewContentToRender();
+  }
+
+  @Step("Expect the Introducing Crypto Loan modal")
+  async expectIntroModal() {
+    await waitWebElementByTestId(this.introModalId);
+    await detoxExpect(getWebElementByTestId(this.introModalId)).toExist();
+    await detoxExpect(getWebElementByTestId(this.introModalTitleId)).toExist();
+  }
+}

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -631,13 +631,18 @@ export default class PortfolioPage {
 
   @Step("Expect borrow entry point to be visible")
   async expectBorrowEntryPointVisible() {
-    await scrollToId(this.borrowEntryPointId, this.accountsListView, 700, "down");
-    await detoxExpect(getElementById(this.borrowEntryPointId)).toBeVisible();
+    await scrollToId(this.borrowEntryPointId, this.accountsListView);
+    await waitForElementById(this.borrowEntryPointId);
   }
 
-  /** The card and its CTA share one onPress, so tap the card that was scrolled into view. */
+  /**
+   * The card and its CTA share one onPress, so tap the card rather than the nested button.
+   * The card enters from the bottom, so it parks against the tab bar until revealForTap
+   * continues past it.
+   */
   @Step("Click borrow entry point")
   async clickBorrowEntryPoint() {
+    await revealForTap(this.borrowEntryPointId, { container: this.accountsListView });
     await tapById(this.borrowEntryPointId);
   }
 }

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -50,6 +50,7 @@ export default class PortfolioPage {
   portfolioBalanceAmount = "portfolio-balance-amount";
   portfolioBalanceAnalyticsPill = "portfolio-balance-analytics-pill";
   portfolioBalanceDelta = "portfolio-balance-delta";
+  borrowEntryPointId = "portfolio-borrow-entry-point";
   transferBottomSheetReceiveButton = "transfer-action-receive";
   transferBottomSheetSendButton = "transfer-action-send";
   transferBottomSheetBankTransferButton = "transfer-action-bank-transfer";
@@ -626,5 +627,17 @@ export default class PortfolioPage {
   @Step("Check full stocks list page is visible")
   async checkStocksListPageVisible() {
     await this.checkListPageVisible(this.stocksListId);
+  }
+
+  @Step("Expect borrow entry point to be visible")
+  async expectBorrowEntryPointVisible() {
+    await scrollToId(this.borrowEntryPointId, this.accountsListView, 700, "down");
+    await detoxExpect(getElementById(this.borrowEntryPointId)).toBeVisible();
+  }
+
+  /** The card and its CTA share one onPress, so tap the card that was scrolled into view. */
+  @Step("Click borrow entry point")
+  async clickBorrowEntryPoint() {
+    await tapById(this.borrowEntryPointId);
   }
 }

--- a/e2e/mobile/specs/borrow/borrow.coldStart.spec.ts
+++ b/e2e/mobile/specs/borrow/borrow.coldStart.spec.ts
@@ -1,0 +1,24 @@
+import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
+import { FF_BORROW_ENABLED } from "../../utils/featureFlagUtils";
+
+describe("Borrow - Cold start", () => {
+  beforeAll(async () => {
+    await app.init({
+      userdata: "speculos-x-other-account",
+      featureFlags: FF_BORROW_ENABLED,
+    });
+    await app.mainNavigation.openPortfolioViaDeeplink();
+  });
+
+  setTeamOwner(Team.EARN);
+  $TmsLink("B2CQA-6062");
+  ["@LNS", "@NanoSP", "@NanoX", "@Stax", "@Flex", "@NanoGen5"].forEach(tag => $Tag(tag));
+
+  it("should show the Introducing Crypto Loan modal from the portfolio entry point", async () => {
+    await app.portfolio.expectBorrowEntryPointVisible();
+    await app.portfolio.clickBorrowEntryPoint();
+    await app.borrow.expectBorrowScreenVisible();
+    await app.borrow.expectIntroModal();
+  });
+});

--- a/e2e/mobile/utils/featureFlagUtils.ts
+++ b/e2e/mobile/utils/featureFlagUtils.ts
@@ -43,6 +43,21 @@ export const FF_LWM_WALLET_40_Q2 = {
   },
 } satisfies OptionalFeatureMap;
 
+export const FF_BORROW_ENABLED = {
+  ...FF_LWM_WALLET_40_Q2,
+  ptxBorrowLiveApp: {
+    enabled: true,
+    params: { manifest_id: "borrow" },
+  },
+  lwmWallet40: {
+    ...FF_LWM_WALLET_40_Q2.lwmWallet40,
+    params: {
+      ...FF_LWM_WALLET_40_Q2.lwmWallet40?.params,
+      pnl: true,
+    },
+  },
+} satisfies OptionalFeatureMap;
+
 export const FF_NEW_SEND_FLOW_FIRST_INTERACTION_BANNER_ENABLED = {
   newSendFlowFirstInteractionBanner: { enabled: true },
 } satisfies OptionalFeatureMap;


### PR DESCRIPTION
### 📝 Description

Adds the Borrow **cold start** E2E test to the Ledger Wallet Mobile suite: the portfolio borrow entry point opens the Borrow live app and shows the *Introducing Crypto Loan* modal.

This is the first slice of the mobile Borrow coverage from #20367 (LIVE-35015). That PR bundles cold start together with the on-chain open / repay / withdraw flows; those three are still being worked on, so this PR lands the one flow that is verified on both platforms and keeps the rest out of the way.

**Why it is small and safe**

- Broadcasts nothing and runs on an isolated seed (`speculos-x-other-account`), so it needs no device and is safe to schedule in parallel.
- The page object contains only the two methods this test uses. The on-chain page object grows in the follow-up, alongside the specs that exercise it.
- No shared Speculos or init changes: cold start passes no `speculosApp` and no `cliCommandsOnApp`, so `speculosUtils` / `initUtil` are untouched.

**Portfolio entry point fix**

`clickBorrowEntryPoint` taps the card that `expectBorrowEntryPointVisible` scrolled into view, rather than the CTA nested inside it:

```tsx
// apps/ledger-live-mobile/.../BorrowSection/index.tsx
<Card onPress={onPress} testID="portfolio-borrow-entry-point">   // scrolled to + asserted
  ...
    <Button onPress={onPress} testID="borrow-explore-cta">       // nested, may be off screen
```

Both are wired to the same `onPress`, so behaviour is identical, but only the card is guaranteed on screen after the scroll. `tapById` does not wait for visibility, so tapping the nested CTA can silently do nothing and leave the next wait to time out. This was raised on #20367 during review.

### ✅ Checks

- `npx changeset` attached (`ledger-live-mobile-e2e-tests`).
- Covered by automated tests — this PR *is* the test.
- Mobile E2E dispatched on this branch: [run 32349071360](https://github.com/LedgerHQ/ledger-live/actions/runs/32349071360) — **iOS & Android, 1 passed / 1 total on both**, filter resolved to `borrow.coldStart.spec.ts`.
- Desktop E2E and Coin Tester not run: the change is confined to `e2e/mobile` plus one changeset.

### 🔗 Context

- **JIRA / GitHub issue**: [QAA-1477](https://ledgerhq.atlassian.net/browse/QAA-1477) · original coverage ticket [LIVE-35015](https://ledgerhq.atlassian.net/browse/LIVE-35015) · TMS `B2CQA-6062`
- **Supersedes in part**: #20367 (cold start only — the on-chain flows remain there / in a follow-up)

[QAA-1477]: https://ledgerhq.atlassian.net/browse/QAA-1477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ