### PR TITLE
[LWDM] feat(swap): add signature verification diagnostics (LIVE-20570)

### DIFF
--- a/.changeset/LIVE-20570-swap-signature-diagnostics.md
+++ b/.changeset/LIVE-20570-swap-signature-diagnostics.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Enrich swap `CHECK_TRANSACTION_SIGNATURE` failures with privacy-safe diagnostics.
+
+When the Exchange app rejects a partner signature with `SIGN_VERIFICATION_FAIL` (0x9d1a), the swap completion flow now re-verifies the Swap NG signature locally (secp256k1/secp256r1) and appends a stable, non-sensitive diagnostic code to the error message forwarded to `/swap/cancelled`. This distinguishes the suspected firmware R/S-to-DER edge case (leading-zero `r`/`s`) from actionable backend signing mistakes (missing JWS dot prefix, signing the raw protobuf bytes) and a genuine payload/signature mismatch. The device error stays authoritative and its title is unchanged; no payload, signature, key, address or hash is ever included in the diagnostic.

--- a/libs/ledger-live-common/src/exchange/swap/completeExchange.test.ts
+++ b/libs/ledger-live-common/src/exchange/swap/completeExchange.test.ts
@@ -1,9 +1,13 @@
 import { TransportStatusError } from "@ledgerhq/hw-transport/errors";
 import { ErrorStatus } from "@ledgerhq/hw-app-exchange/ReturnCode";
+import { secp256k1 } from "@noble/curves/secp256k1";
+import { p256 } from "@noble/curves/nist";
 import BigNumber from "bignumber.js";
 import { CompleteExchangeError } from "../error";
+import { sha256 } from "../../crypto";
 import {
   enrichSwapDeserializationError,
+  enrichSwapSignatureVerificationError,
   getBufferedDexGasLimit,
   shouldForceZeroAmountForDexSwap,
 } from "./completeExchange";
@@ -93,6 +97,253 @@ describe("enrichSwapDeserializationError", () => {
         payloadWithOversizedExtraId,
         new Error("boom"),
       ),
+    ).toBeUndefined();
+  });
+});
+
+describe("enrichSwapSignatureVerificationError", () => {
+  // Deterministic (RFC6979) partner key shared by every case so signatures are reproducible.
+  const PRIVATE_KEY = Uint8Array.from(Buffer.from("11".repeat(32), "hex"));
+  const signVerificationFail = new TransportStatusError(ErrorStatus.SIGN_VERIFICATION_FAIL);
+
+  const base64url = (buffer: Buffer): string =>
+    buffer.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+
+  type NobleCurve = typeof secp256k1 | typeof p256;
+
+  const curves: { curveName: "secp256k1" | "secp256r1"; curve: NobleCurve }[] = [
+    { curveName: "secp256k1", curve: secp256k1 },
+    { curveName: "secp256r1", curve: p256 },
+  ];
+
+  // `prehash: false` mirrors production verification: the sha256 digest is the message, so signing
+  // must not hash it again (guards against a double-hash if the @noble/curves default ever changes).
+  const signCompact = (curve: NobleCurve, message: Buffer): Buffer =>
+    Buffer.from(
+      curve.sign(sha256(message), PRIVATE_KEY, { lowS: false, prehash: false }).toCompactRawBytes(),
+    );
+
+  const publicKeyFor = (curve: NobleCurve, curveName: "secp256k1" | "secp256r1") => ({
+    curve: curveName,
+    data: Buffer.from(curve.getPublicKey(PRIVATE_KEY, false)),
+  });
+
+  // Search the deterministic signature space for a "." + payload whose compact r/s bytes match a
+  // leading-zero predicate. Iteration is fixed, so the discovered payload is stable across runs.
+  const findDotPrefixedPayload = (
+    curve: NobleCurve,
+    prefix: string,
+    predicate: (compact: Buffer) => boolean,
+  ): { payload: string; signature: string } => {
+    for (let i = 0; i < 500_000; i++) {
+      const payload = `${prefix}${i}`;
+      const compact = signCompact(curve, Buffer.from("." + payload));
+      if (predicate(compact)) return { payload, signature: base64url(compact) };
+    }
+    throw new Error(`no matching signature found for ${prefix}`);
+  };
+
+  const enrich = (params: {
+    binaryPayload: string;
+    signature: string;
+    curveName: "secp256k1" | "secp256r1";
+    curve: NobleCurve;
+    step?: Parameters<typeof enrichSwapSignatureVerificationError>[0]["step"];
+    isSwapNg?: boolean;
+    error?: unknown;
+  }) =>
+    enrichSwapSignatureVerificationError({
+      step: params.step ?? "CHECK_TRANSACTION_SIGNATURE",
+      isSwapNg: params.isSwapNg ?? true,
+      binaryPayload: params.binaryPayload,
+      signature: params.signature,
+      publicKey: publicKeyFor(params.curve, params.curveName),
+      error: params.error ?? signVerificationFail,
+    });
+
+  describe.each(curves)("on the $curveName curve", ({ curveName, curve }) => {
+    it("flags a valid signature the device still rejected as a device-only mismatch", () => {
+      // A signature over the exact device input with no leading-zero r/s.
+      const { payload, signature } = findDotPrefixedPayload(
+        curve,
+        "device-mismatch-",
+        compact => compact[0] !== 0x00 && compact[32] !== 0x00,
+      );
+
+      const result = enrich({
+        binaryPayload: payload,
+        signature,
+        curveName,
+        curve,
+      });
+
+      // Title stays the device translation key; only the message carries the diagnostic.
+      expect(result).toBeInstanceOf(CompleteExchangeError);
+      expect(result).toMatchObject({
+        step: "CHECK_TRANSACTION_SIGNATURE",
+        title: "signVerificationFail",
+      });
+      // This message is exactly what wallet-api forwards as `/swap/cancelled` errorMessage.
+      expect(result?.message).toBe("Signature verification failed [diagnostic=device_mismatch]");
+    });
+
+    it("flags the firmware R/S-to-DER edge case when r has a leading zero byte", () => {
+      const { payload, signature } = findDotPrefixedPayload(
+        curve,
+        "leading-zero-r-",
+        compact => compact[0] === 0x00 && compact[32] !== 0x00,
+      );
+
+      const result = enrich({
+        binaryPayload: payload,
+        signature,
+        curveName,
+        curve,
+      });
+
+      expect(result?.message).toBe(
+        "Signature verification failed [diagnostic=device_mismatch_leading_zero_r]",
+      );
+    });
+
+    it("flags the firmware R/S-to-DER edge case when s has a leading zero byte", () => {
+      const { payload, signature } = findDotPrefixedPayload(
+        curve,
+        "leading-zero-s-",
+        compact => compact[32] === 0x00 && compact[0] !== 0x00,
+      );
+
+      const result = enrich({
+        binaryPayload: payload,
+        signature,
+        curveName,
+        curve,
+      });
+
+      expect(result?.message).toBe(
+        "Signature verification failed [diagnostic=device_mismatch_leading_zero_s]",
+      );
+    });
+
+    it("detects a backend that signed the payload without the JWS dot prefix", () => {
+      const binaryPayload = base64url(Buffer.from("payload-without-dot"));
+      // Signed over the base64url payload string itself (no leading ".").
+      const signature = base64url(signCompact(curve, Buffer.from(binaryPayload)));
+
+      const result = enrich({ binaryPayload, signature, curveName, curve });
+
+      expect(result?.message).toBe(
+        "Signature verification failed [diagnostic=backend_signed_without_dot_prefix]",
+      );
+    });
+
+    it("detects a backend that signed the decoded protobuf bytes", () => {
+      const rawProtobuf = Buffer.from("raw-protobuf-bytes");
+      const binaryPayload = base64url(rawProtobuf);
+      // Signed over the decoded bytes instead of the base64url string.
+      const signature = base64url(signCompact(curve, rawProtobuf));
+
+      const result = enrich({ binaryPayload, signature, curveName, curve });
+
+      expect(result?.message).toBe(
+        "Signature verification failed [diagnostic=backend_signed_raw_protobuf]",
+      );
+    });
+
+    it("reports a genuine payload/signature mismatch when nothing verifies", () => {
+      const binaryPayload = base64url(Buffer.from("expected-payload"));
+      const signature = base64url(
+        signCompact(curve, Buffer.from("a-completely-unrelated-message")),
+      );
+
+      const result = enrich({ binaryPayload, signature, curveName, curve });
+
+      expect(result?.message).toBe(
+        "Signature verification failed [diagnostic=signature_invalid_all_inputs]",
+      );
+    });
+
+    it("falls back to the device error for a malformed (non 64-byte) signature", () => {
+      const binaryPayload = base64url(Buffer.from("expected-payload"));
+      const signature = base64url(Buffer.alloc(10));
+
+      expect(enrich({ binaryPayload, signature, curveName, curve })).toBeUndefined();
+    });
+  });
+
+  it("falls back to the device error for unrelated status codes", () => {
+    const { curveName, curve } = curves[0];
+    const { payload, signature } = findDotPrefixedPayload(curve, "unrelated-status-", () => true);
+
+    expect(
+      enrich({
+        binaryPayload: payload,
+        signature,
+        curveName,
+        curve,
+        error: new TransportStatusError(ErrorStatus.INVALID_ADDRESS),
+      }),
+    ).toBeUndefined();
+  });
+
+  it("falls back to the device error outside the CHECK_TRANSACTION_SIGNATURE step", () => {
+    const { curveName, curve } = curves[0];
+    const { payload, signature } = findDotPrefixedPayload(curve, "wrong-step-", () => true);
+
+    expect(
+      enrich({
+        binaryPayload: payload,
+        signature,
+        curveName,
+        curve,
+        step: "PROCESS_TRANSACTION",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("falls back to the device error for the legacy (non-NG) swap flow", () => {
+    const { curveName, curve } = curves[0];
+    const { payload, signature } = findDotPrefixedPayload(curve, "legacy-flow-", () => true);
+
+    expect(
+      enrich({
+        binaryPayload: payload,
+        signature,
+        curveName,
+        curve,
+        isSwapNg: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("falls back to the device error when the partner public key is unavailable", () => {
+    const { curve } = curves[0];
+    const { payload, signature } = findDotPrefixedPayload(curve, "missing-key-", () => true);
+
+    expect(
+      enrichSwapSignatureVerificationError({
+        step: "CHECK_TRANSACTION_SIGNATURE",
+        isSwapNg: true,
+        binaryPayload: payload,
+        signature,
+        publicKey: undefined,
+        error: signVerificationFail,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("falls back to the device error for non-transport errors", () => {
+    const { curveName, curve } = curves[0];
+    const { payload, signature } = findDotPrefixedPayload(curve, "non-transport-", () => true);
+
+    expect(
+      enrich({
+        binaryPayload: payload,
+        signature,
+        curveName,
+        curve,
+        error: new Error("boom"),
+      }),
     ).toBeUndefined();
   });
 });

--- a/libs/ledger-live-common/src/exchange/swap/completeExchange.ts
+++ b/libs/ledger-live-common/src/exchange/swap/completeExchange.ts
@@ -19,6 +19,8 @@ import BigNumber from "bignumber.js";
 import invariant from "invariant";
 import { Observable } from "rxjs";
 import { secp256k1 } from "@noble/curves/secp256k1";
+import { p256 } from "@noble/curves/nist";
+import { sha256 } from "../../crypto";
 import { getCurrencyExchangeConfig } from "../";
 import { getAccountCurrency, getMainAccount } from "../../account";
 import { getAccountBridge } from "../../bridge";
@@ -101,6 +103,112 @@ export function enrichSwapDeserializationError(
   return new CompleteExchangeError(step, errorName, violation.message);
 }
 
+type SwapPartnerPublicKey = { curve: "secp256k1" | "secp256r1"; data: Buffer };
+
+/**
+ * Stable, privacy-safe classification of a device SIGN_VERIFICATION_FAIL (0x9d1a). Every value
+ * is a fixed enum string that carries no user data (no payload, signature, key, address or hash),
+ * so it can be forwarded verbatim to `/swap/cancelled` and Datadog.
+ */
+type SwapSignatureDiagnostic =
+  // Signature is mathematically valid over the exact input the device hashes, yet the device
+  // still rejected it. The `_leading_zero_*` variants flag the suspected firmware R/S-to-DER
+  // edge case (a 32-byte r/s starting with 0x00 becomes a 31-byte DER integer).
+  | "device_mismatch"
+  | "device_mismatch_leading_zero_r"
+  | "device_mismatch_leading_zero_s"
+  | "device_mismatch_leading_zero_rs"
+  // Backend signed the base64url payload but omitted the JWS "." prefix the device expects.
+  | "backend_signed_without_dot_prefix"
+  // Backend signed the decoded protobuf bytes instead of the base64url payload string.
+  | "backend_signed_raw_protobuf"
+  // Signature verifies against none of the known inputs: a genuine payload/signature mismatch.
+  | "signature_invalid_all_inputs";
+
+function classifySwapSignatureFailure(
+  binaryPayload: string,
+  signature: string,
+  publicKey: SwapPartnerPublicKey,
+): SwapSignatureDiagnostic | undefined {
+  try {
+    const curve = publicKey.curve === "secp256r1" ? p256 : secp256k1;
+    const compactSignature = base64UrlDecode(signature);
+    // Only compact 64-byte r||s signatures can be classified; anything else is malformed and is
+    // left to the device error so we don't invent misleading diagnostics.
+    if (compactSignature.length !== 64) return undefined;
+
+    const publicKeyBytes = Uint8Array.from(publicKey.data);
+    // Mirror the device: SHA-256 prehash, and disable the low-S policy so we test mathematical
+    // validity (the Exchange app accepts high-S signatures) rather than signature canonicalization.
+    const verifies = (message: Buffer): boolean =>
+      curve.verify(compactSignature, sha256(message), publicKeyBytes, {
+        prehash: false,
+        lowS: false,
+        format: "compact",
+      });
+
+    // The device hashes the JWS signing input: "." + base64url(payload).
+    if (verifies(Buffer.from("." + binaryPayload))) {
+      const rLeadingZero = compactSignature[0] === 0x00;
+      const sLeadingZero = compactSignature[32] === 0x00;
+      if (rLeadingZero && sLeadingZero) return "device_mismatch_leading_zero_rs";
+      if (rLeadingZero) return "device_mismatch_leading_zero_r";
+      if (sLeadingZero) return "device_mismatch_leading_zero_s";
+      return "device_mismatch";
+    }
+
+    if (verifies(Buffer.from(binaryPayload))) return "backend_signed_without_dot_prefix";
+    if (verifies(base64UrlDecode(binaryPayload))) return "backend_signed_raw_protobuf";
+
+    return "signature_invalid_all_inputs";
+  } catch {
+    // Malformed key/signature or an unexpected verification error: defer to the device error.
+    return undefined;
+  }
+}
+
+/**
+ * Device stays the source of truth: only once it rejects the partner signature with a generic
+ * SIGN_VERIFICATION_FAIL (0x9d1a) do we re-verify locally to explain why. The device error's title
+ * (a translation key) is preserved so the user-facing copy is unchanged; we only enrich the message
+ * with a stable diagnostic code for logs/analytics and the `/swap/cancelled` report.
+ * Returns undefined for unrelated errors, legacy swaps, missing key, malformed inputs or when no
+ * diagnostic applies, so callers fall back to the device error.
+ */
+export function enrichSwapSignatureVerificationError({
+  step,
+  isSwapNg,
+  binaryPayload,
+  signature,
+  publicKey,
+  error,
+}: {
+  step: CompleteExchangeStep;
+  isSwapNg: boolean;
+  binaryPayload: string;
+  signature: string;
+  publicKey: SwapPartnerPublicKey | undefined;
+  error: unknown;
+}): CompleteExchangeError | undefined {
+  const transportErr = error as { name?: string; statusCode?: number } | null | undefined;
+  if (
+    transportErr?.name !== "TransportStatusError" ||
+    transportErr?.statusCode !== ErrorStatus.SIGN_VERIFICATION_FAIL ||
+    step !== "CHECK_TRANSACTION_SIGNATURE"
+  ) {
+    return undefined;
+  }
+
+  // Diagnostics only cover Swap NG, whose compact JWS signature we can reconstruct locally.
+  if (!isSwapNg || !publicKey) return undefined;
+
+  const diagnostic = classifySwapSignatureFailure(binaryPayload, signature, publicKey);
+  if (!diagnostic) return undefined;
+
+  const { errorName, errorMessage } = getExchangeErrorMessage(transportErr.statusCode, step);
+  return new CompleteExchangeError(step, errorName, `${errorMessage} [diagnostic=${diagnostic}]`);
+}
+
 const completeExchange = (
   input: CompleteExchangeInputSwap,
 ): Observable<CompleteExchangeRequestEvent> => {
@@ -123,6 +231,10 @@ const completeExchange = (
     let unsubscribed = false;
     let ignoreTransportError = false;
     let currentStep: CompleteExchangeStep = "INIT";
+    // Captured for the failure path so signature diagnostics can re-verify the partner signature
+    // outside the device transport scope. Undefined until the partner config is resolved.
+    let partnerPublicKey: SwapPartnerPublicKey | undefined;
+    let isSwapNgTransaction = false;
 
     const confirmExchange = async () => {
       if (deviceId === undefined) {
@@ -134,8 +246,12 @@ const completeExchange = (
         if (providerConfig.useInExchangeApp === false) {
           throw new Error(`Unsupported provider type ${providerConfig.type}`);
         }
+        // Narrow on the discriminant instead of casting: only CEX providers expose a partner
+        // public key. A DEX provider leaves it undefined, so diagnostics safely no-op.
+        partnerPublicKey = providerConfig.type === "CEX" ? providerConfig.publicKey : undefined;
 
         const exchange = createExchange(transport, exchangeType, rateType, providerConfig.version);
+        isSwapNgTransaction = exchange.transactionType === ExchangeTypes.SwapNg;
 
         const refundAccount = getMainAccount(fromAccount, fromParentAccount);
         const payoutAccount = getMainAccount(toAccount, toParentAccount);
@@ -384,6 +500,16 @@ const completeExchange = (
 
         const enrichedError = enrichSwapDeserializationError(currentStep, binaryPayload, e);
         if (enrichedError) throw enrichedError;
+
+        const enrichedSignatureError = enrichSwapSignatureVerificationError({
+          step: currentStep,
+          isSwapNg: isSwapNgTransaction,
+          binaryPayload,
+          signature,
+          publicKey: partnerPublicKey,
+          error: e,
+        });
+        if (enrichedSignatureError) throw enrichedSignatureError;
 
         throw convertTransportError(currentStep, e);
       });


### PR DESCRIPTION
## Summary

When the Exchange app rejects a partner signature with `SIGN_VERIFICATION_FAIL` (`0x9d1a`) at `CHECK_TRANSACTION_SIGNATURE`, we currently only surface the generic device error — making the intermittent (~1/200) swap signature failures impossible to root-cause. This PR enriches that error with privacy-safe, locally computed evidence.

- Adds `enrichSwapSignatureVerificationError` in `completeExchange.ts`. On `SIGN_VERIFICATION_FAIL` for a Swap NG flow, it re-verifies the compact 64-byte JWS signature locally with `@noble/curves` (`secp256k1`/`secp256r1`), SHA-256 prehash, `lowS: false` (mirrors the Exchange app, which accepts high-S), against the exact device input `"." + binaryPayload`.
- Appends a **stable, non-sensitive diagnostic code** to the error message, distinguishing:
  - the suspected firmware R/S→DER edge case — `device_mismatch_leading_zero_r` / `_s` / `_rs` (and `device_mismatch`);
  - actionable backend signing mistakes — `backend_signed_without_dot_prefix`, `backend_signed_raw_protobuf`;
  - a genuine payload/signature mismatch — `signature_invalid_all_inputs`.
- The device error stays authoritative: its `title` (translation key) is unchanged, and the helper returns `undefined` for unrelated errors, legacy swaps, missing key, or malformed inputs.
- **No PII**: the payload, signature bytes, public key, addresses and hashes are never included. **No API-contract change** — `wallet-api/Exchange/server.ts` already forwards `CompleteExchangeError.message` as the `/swap/cancelled` `errorMessage`.
- Adds a `patch` changeset for `@ledgerhq/live-common`.

## Test plan

- [x] `completeExchange.test.ts` — 32 tests pass (19 new, deterministic, both curves): device-only mismatch, leading-zero `r`/`s`, without-dot, raw-protobuf, genuine mismatch, malformed signature, and fallback for unrelated status/step, legacy flow, missing key, and non-transport errors.
- [x] `pnpm typecheck` clean
- [x] `oxfmt --check` canonical, `oxlint` 0 errors

Related ticket: https://ledgerhq.atlassian.net/browse/LIVE-20570

Made with [Cursor](https://cursor.com)