### PR TITLE
[LWD] feat(pay-card-request): wire request verify address action (LIVE-36272)

### DIFF
--- a/.changeset/LIVE-36272-pay-request-verify-address.md
+++ b/.changeset/LIVE-36272-pay-request-verify-address.md
@@ -1,0 +1,8 @@
+---
+"ledger-live-desktop": minor
+"@features/flow-pay-card-request": minor
+---
+
+Wire the desktop Pay tab Request "Verify" action: pressing it closes the receive dialog and opens the shared VerifyAddress overlay (intro then success), tracking the `Page Request Address Verification` page view. The device intent (DIE) is kept behind the exposed `showSuccess` bridge for LIVE-36132.
+
+Make the request action `onShare` (mobile-only) and `onSave` (desktop-only) callbacks optional, align the request verify tracking button to `verify`, and give the VerifyAddress dialog an InfoState-style muted background with centered next steps.

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayTabRequestReceive.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayTabRequestReceive.test.ts
@@ -36,9 +36,11 @@ beforeEach(() => {
   mockedDerive.mockReturnValue(DERIVED);
 });
 
+const noop = () => {};
+
 describe("usePayTabRequestReceive", () => {
   it("should start closed with empty display data", () => {
-    const { result } = renderHook(() => usePayTabRequestReceive(undefined));
+    const { result } = renderHook(() => usePayTabRequestReceive(undefined, noop));
 
     expect(result.current.requestReceive.isOpen).toBe(false);
     expect(result.current.requestReceive.address).toBe("");
@@ -47,7 +49,7 @@ describe("usePayTabRequestReceive", () => {
   });
 
   it("should open MAD filtered to the stablecoin category", () => {
-    const { result } = renderHook(() => usePayTabRequestReceive(undefined));
+    const { result } = renderHook(() => usePayTabRequestReceive(undefined, noop));
 
     act(() => result.current.open());
 
@@ -62,7 +64,7 @@ describe("usePayTabRequestReceive", () => {
     const account = { type: "TokenAccount" } as unknown as AccountLike;
     const parentAccount = { type: "Account" } as unknown as Account;
 
-    const { result } = renderHook(() => usePayTabRequestReceive(undefined));
+    const { result } = renderHook(() => usePayTabRequestReceive(undefined, noop));
 
     act(() => result.current.open());
     const { onSuccess } = openAssetAndAccount.mock.calls[0][0];
@@ -80,7 +82,7 @@ describe("usePayTabRequestReceive", () => {
 
   it("should close the dialog through onClose", () => {
     const account = { type: "Account" } as unknown as AccountLike;
-    const { result } = renderHook(() => usePayTabRequestReceive(undefined));
+    const { result } = renderHook(() => usePayTabRequestReceive(undefined, noop));
 
     act(() => result.current.open());
     act(() => openAssetAndAccount.mock.calls[0][0].onSuccess(account, undefined));
@@ -88,5 +90,20 @@ describe("usePayTabRequestReceive", () => {
 
     act(() => result.current.requestReceive.onClose());
     expect(result.current.requestReceive.isOpen).toBe(false);
+  });
+
+  it("should close the receive dialog and hand off to the injected verify callback", () => {
+    const account = { type: "Account" } as unknown as AccountLike;
+    const onVerify = jest.fn();
+    const { result } = renderHook(() => usePayTabRequestReceive(undefined, onVerify));
+
+    act(() => result.current.open());
+    act(() => openAssetAndAccount.mock.calls[0][0].onSuccess(account, undefined));
+    expect(result.current.requestReceive.isOpen).toBe(true);
+
+    act(() => result.current.requestReceive.onVerify(DERIVED.address));
+
+    expect(result.current.requestReceive.isOpen).toBe(false);
+    expect(onVerify).toHaveBeenCalledWith(DERIVED.address);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayTabVerifyAddress.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayTabVerifyAddress.test.ts
@@ -1,0 +1,68 @@
+import { act, renderHook } from "tests/testSetup";
+import { usePayTabVerifyAddress } from "../usePayTabVerifyAddress";
+
+describe("usePayTabVerifyAddress", () => {
+  it("should start hidden with resolved copy", () => {
+    const { result } = renderHook(() => usePayTabVerifyAddress(undefined));
+
+    expect(result.current.phase).toBe("hidden");
+    expect(result.current.verifyAddress.phase).toBe("hidden");
+    expect(result.current.verifyAddress.labels).toEqual({
+      introTitle: "Verify your address",
+      introDescription:
+        "To protect against address replacement attacks, verify your address on your Ledger device's Secure Screen.",
+      verifyCta: "Verify address",
+      successTitle: "Address displayed on the device's Secure Screen",
+      nextStepsLabel: "Next steps",
+      nextStepShare: "Share your address via your desired app",
+      nextStepMatch: "Ensure the shared address matches the one on your Ledger Device.",
+      gotItCta: "Got it",
+    });
+  });
+
+  it("should open the intro phase", () => {
+    const { result } = renderHook(() => usePayTabVerifyAddress(undefined));
+
+    act(() => result.current.openIntro());
+
+    expect(result.current.phase).toBe("intro");
+    expect(result.current.verifyAddress.phase).toBe("intro");
+  });
+
+  it("should advance from the intro to the success screen on verify", () => {
+    const { result } = renderHook(() => usePayTabVerifyAddress(undefined));
+
+    act(() => result.current.openIntro());
+    act(() => result.current.verifyAddress.onVerify());
+
+    expect(result.current.phase).toBe("success");
+    expect(result.current.verifyAddress.phase).toBe("success");
+  });
+
+  it("should show the success phase when verification completes", () => {
+    const { result } = renderHook(() => usePayTabVerifyAddress(undefined));
+
+    act(() => result.current.showSuccess());
+
+    expect(result.current.phase).toBe("success");
+    expect(result.current.verifyAddress.phase).toBe("success");
+  });
+
+  it("should hide the overlay from the success CTA", () => {
+    const { result } = renderHook(() => usePayTabVerifyAddress(undefined));
+
+    act(() => result.current.showSuccess());
+    act(() => result.current.verifyAddress.onGotIt());
+
+    expect(result.current.phase).toBe("hidden");
+  });
+
+  it("should hide the overlay when closed", () => {
+    const { result } = renderHook(() => usePayTabVerifyAddress(undefined));
+
+    act(() => result.current.openIntro());
+    act(() => result.current.verifyAddress.onClose());
+
+    expect(result.current.phase).toBe("hidden");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabRequestReceive.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabRequestReceive.ts
@@ -23,6 +23,7 @@ export type UsePayTabRequestReceive = Readonly<{
 
 export function usePayTabRequestReceive(
   onTrackEvent: PayCardTrackEvent | undefined,
+  onVerify: (address: string) => void,
 ): UsePayTabRequestReceive {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
@@ -43,15 +44,20 @@ export function usePayTabRequestReceive(
   const onClose = useCallback(() => setIsOpen(false), []);
 
   const onCopy = useCallback((address: string) => copyToClipboard(address), [copyToClipboard]);
-  // Verify (device) lands with LIVE-36132.
-  const noop = useCallback(() => {}, []);
+
+  const handleVerify = useCallback(
+    (address: string) => {
+      onClose();
+      onVerify(address);
+    },
+    [onVerify, onClose],
+  );
 
   const data = useMemo(
     () => (selection ? deriveRequestReceiveData(selection.account, selection.parentAccount) : null),
     [selection],
   );
 
-  // Save captures the on-screen request card (QR + address) to a PNG via the native save dialog.
   const saveCard = useSaveRequestReceiveCard(data?.asset.ticker ?? "");
 
   const labels = useMemo(
@@ -80,14 +86,13 @@ export function usePayTabRequestReceive(
       assetIcon: data?.assetIcon ?? { ledgerId: "", ticker: "" },
       networkIcon: data?.networkIcon,
       visibleActions: ["save", "copy", "verify"],
-      onShare: noop,
       onCopy,
       onSave: saveCard,
-      onVerify: noop,
+      onVerify: handleVerify,
       onClose,
       onTrackEvent,
     }),
-    [isOpen, data, labels, noop, onCopy, saveCard, onClose, onTrackEvent],
+    [isOpen, data, labels, onCopy, saveCard, handleVerify, onClose, onTrackEvent],
   );
 
   return { open, requestReceive };

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabVerifyAddress.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabVerifyAddress.ts
@@ -1,0 +1,67 @@
+import { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type {
+  PayCardTrackEvent,
+  VerifyAddressLabels,
+  VerifyAddressPhase,
+  VerifyAddressProps,
+} from "@features/flow-pay-card-request";
+
+const VERIFY_PAGE = "Request Address Verification";
+
+export type UsePayTabVerifyAddress = Readonly<{
+  phase: VerifyAddressPhase;
+  openIntro: () => void;
+  showSuccess: () => void;
+  verifyAddress: VerifyAddressProps;
+}>;
+
+/**
+ * Owns the `hidden -> intro -> success` phase of the Request VerifyAddress overlay and resolves its
+ * copy.
+ *
+ * UI-only for now: the intro CTA advances straight to the success screen. Once the shared
+ * `verifyAddressIntent` lands (LIVE-36132), the CTA will instead start the device intent and the
+ * app's DIE host will render the executing phase and call `showSuccess` on device confirmation.
+ */
+export function usePayTabVerifyAddress(
+  onTrackEvent: PayCardTrackEvent | undefined,
+): UsePayTabVerifyAddress {
+  const { t } = useTranslation();
+  const [phase, setPhase] = useState<VerifyAddressPhase>("hidden");
+
+  const openIntro = useCallback(() => setPhase("intro"), []);
+  const showSuccess = useCallback(() => setPhase("success"), []);
+  const close = useCallback(() => setPhase("hidden"), []);
+
+  const onVerify = showSuccess;
+
+  const labels = useMemo<VerifyAddressLabels>(
+    () => ({
+      introTitle: t("payTab.request.verifyAddress.introTitle"),
+      introDescription: t("payTab.request.verifyAddress.introDescription"),
+      verifyCta: t("payTab.request.verifyAddress.verifyCta"),
+      successTitle: t("payTab.request.verifyAddress.successTitle"),
+      nextStepsLabel: t("payTab.request.verifyAddress.nextStepsLabel"),
+      nextStepShare: t("payTab.request.verifyAddress.nextStepShare"),
+      nextStepMatch: t("payTab.request.verifyAddress.nextStepMatch"),
+      gotItCta: t("payTab.request.verifyAddress.gotItCta"),
+    }),
+    [t],
+  );
+
+  const verifyAddress = useMemo<VerifyAddressProps>(
+    () => ({
+      phase,
+      labels,
+      page: VERIFY_PAGE,
+      onVerify,
+      onGotIt: close,
+      onClose: close,
+      onTrackEvent,
+    }),
+    [phase, labels, onVerify, close, onTrackEvent],
+  );
+
+  return { phase, openIntro, showSuccess, verifyAddress };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { CardLogin, type CardLoginOauthConfig } from "@features/flow-pay-card-auth";
 import { Balance } from "@features/flow-pay-card-balance";
 import { DepositOptions } from "@features/flow-pay-card-deposit";
-import { RequestReceive } from "@features/flow-pay-card-request";
+import { RequestReceive, VerifyAddress } from "@features/flow-pay-card-request";
 import { getEnv } from "@shared/env";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import PayTabHeader from "./components/PayTabHeader";
@@ -12,6 +12,7 @@ import { usePayTabFeatureTour } from "./hooks/usePayTabFeatureTour";
 import { usePayTabActionTiles } from "./hooks/usePayTabActionTiles";
 import { usePayTabDepositOptions } from "./hooks/usePayTabDepositOptions";
 import { usePayTabRequestReceive } from "./hooks/usePayTabRequestReceive";
+import { usePayTabVerifyAddress } from "./hooks/usePayTabVerifyAddress";
 
 // Baanx uses the same value for the client key header and the OAuth `client_id`.
 const oauthConfig: CardLoginOauthConfig = {
@@ -23,16 +24,19 @@ const PayTab = () => {
   const balance = usePayCardBalance();
   const featureTour = usePayTabFeatureTour();
   const deposit = usePayTabDepositOptions(balance.onTrackEvent);
-  const request = usePayTabRequestReceive(balance.onTrackEvent);
+  const verify = usePayTabVerifyAddress(balance.onTrackEvent);
+  const request = usePayTabRequestReceive(balance.onTrackEvent, verify.openIntro);
   const actionTiles = usePayTabActionTiles(balance.onTrackEvent, deposit.open, request.open);
 
   return (
     <div className="flex flex-col gap-24">
       <TrackPage category="Pay" balance_filter={balance.filter} />
+      {verify.phase === "intro" && <TrackPage category="Request Address Verification" />}
       <PayTabHeader />
       <Balance {...balance} actionTiles={actionTiles} />
       <DepositOptions {...deposit.depositOptions} />
       <RequestReceive {...request.requestReceive} />
+      <VerifyAddress {...verify.verifyAddress} />
       <CardLogin oauthConfig={oauthConfig} />
       <FeatureTour {...featureTour} />
     </div>

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -937,6 +937,16 @@
         "copied": "Copied",
         "save": "Save",
         "verify": "Verify"
+      },
+      "verifyAddress": {
+        "introTitle": "Verify your address",
+        "introDescription": "To protect against address replacement attacks, verify your address on your Ledger device's Secure Screen.",
+        "verifyCta": "Verify address",
+        "successTitle": "Address displayed on the device's Secure Screen",
+        "nextStepsLabel": "Next steps",
+        "nextStepShare": "Share your address via your desired app",
+        "nextStepMatch": "Ensure the shared address matches the one on your Ledger Device.",
+        "gotItCta": "Got it"
       }
     }
   },

--- a/features/flow/pay-card-request/README.md
+++ b/features/flow/pay-card-request/README.md
@@ -42,7 +42,7 @@ without masking the middle.
 ### Tracking
 
 Each action emits `button_clicked { button, buttonLocation: "request", page }` via the injected
-`onTrackEvent`, where `button` is `share` | `copy address` | `save` | `verify on device`.
+`onTrackEvent`, where `button` is `share` | `copy address` | `save` | `verify`.
 
 ## Components
 

--- a/features/flow/pay-card-request/src/components/RequestReceive/__tests__/useRequestReceiveViewModel.web.test.ts
+++ b/features/flow/pay-card-request/src/components/RequestReceive/__tests__/useRequestReceiveViewModel.web.test.ts
@@ -40,7 +40,7 @@ describe("useRequestReceiveViewModel", () => {
     ["onShare", "share"],
     ["onCopy", "copy address"],
     ["onSave", "save"],
-    ["onVerify", "verify on device"],
+    ["onVerify", "verify"],
   ] as const)("tracks then invokes the injected callback for %s", (handler, button) => {
     const { props, result } = setup();
 
@@ -60,4 +60,15 @@ describe("useRequestReceiveViewModel", () => {
     expect(() => result.current.onCopy()).not.toThrow();
     expect(props.onCopy).toHaveBeenCalledWith(ADDRESS);
   });
+
+  // Share is mobile-only and Save is desktop-only, so each platform omits the other's callback.
+  it.each(["onShare", "onSave"] as const)(
+    "neither tracks nor throws when the optional %s callback is omitted",
+    handler => {
+      const { props, result } = setup({ [handler]: undefined });
+
+      expect(() => result.current[handler]()).not.toThrow();
+      expect(props.onTrackEvent).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/features/flow/pay-card-request/src/components/RequestReceive/useRequestReceiveViewModel.ts
+++ b/features/flow/pay-card-request/src/components/RequestReceive/useRequestReceiveViewModel.ts
@@ -6,12 +6,12 @@ import type {
 } from "../../types";
 import { splitAddress } from "../../utils/splitAddress";
 
-// Analytics button names per the Pay Tracking Plan (wording still to confirm with product).
+// Analytics button names per the Pay Tracking Plan.
 const TRACK_BUTTON: Readonly<Record<RequestReceiveActionId, string>> = {
   share: "share",
   copy: "copy address",
   save: "save",
-  verify: "verify on device",
+  verify: "verify",
 };
 
 export function useRequestReceiveViewModel({
@@ -28,7 +28,10 @@ export function useRequestReceiveViewModel({
   const addressParts = useMemo(() => splitAddress(address), [address]);
 
   const runAction = useCallback(
-    (id: RequestReceiveActionId, callback: (address: string) => void) => {
+    (id: RequestReceiveActionId, callback?: (address: string) => void) => {
+      if (!callback) {
+        return;
+      }
       onTrackEvent?.("button_clicked", {
         button: TRACK_BUTTON[id],
         buttonLocation: "request",

--- a/features/flow/pay-card-request/src/components/VerifyAddress/VerifyAddressDialog.web.tsx
+++ b/features/flow/pay-card-request/src/components/VerifyAddress/VerifyAddressDialog.web.tsx
@@ -52,11 +52,15 @@ export function VerifyAddressDialog({
   return (
     <Dialog open onOpenChange={handleOpenChange}>
       <DialogContent>
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 top-0 h-full bg-gradient-muted"
+        />
         <DialogHeader density="compact" onClose={onClose} />
         <DialogBody className="flex flex-col gap-24" data-testid={contentTestId}>
           <div className="flex flex-col items-center gap-12 text-center">
             <Spot appearance="icon" icon={icon} size={56} />
-            <h2 className="heading-3-semi-bold text-base">{title}</h2>
+            <h2 className="heading-4-semi-bold text-base">{title}</h2>
             {description ? <p className="body-2 text-muted">{description}</p> : null}
           </div>
           {children}

--- a/features/flow/pay-card-request/src/components/VerifyAddress/VerifyAddressSuccessView.web.tsx
+++ b/features/flow/pay-card-request/src/components/VerifyAddress/VerifyAddressSuccessView.web.tsx
@@ -27,7 +27,7 @@ export function VerifyAddressSuccessView({
       <div className="flex flex-col gap-16 rounded-md bg-surface p-16">
         <span className="body-2 text-muted">{nextStepsLabel}</span>
         {nextSteps.map(step => (
-          <div key={step.index} className="flex flex-row items-start gap-12">
+          <div key={step.index} className="flex flex-row items-center justify-start gap-12">
             <Spot appearance="number" number={step.index} size={32} />
             <span className="body-2 text-base">{step.label}</span>
           </div>

--- a/features/flow/pay-card-request/src/types.ts
+++ b/features/flow/pay-card-request/src/types.ts
@@ -76,9 +76,11 @@ export type RequestReceiveAsset = Readonly<{
 }>;
 
 export type RequestActionCallbacks = Readonly<{
-  onShare: (address: string) => void;
+  /** Optional: mobile-only tile. Desktop does not surface Share. */
+  onShare?: (address: string) => void;
   onCopy: (address: string) => void;
-  onSave: (address: string) => void;
+  /** Optional: desktop-only tile. Mobile does not surface Save. */
+  onSave?: (address: string) => void;
   onVerify: (address: string) => void;
 }>;
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Wires the **Verify** tile of the Pay tab Request receive dialog on Ledger Wallet Desktop.

**Problem**: The Request receive dialog exposed a Verify tile but it was a no-op on desktop — the shared `VerifyAddress` overlay (intro + success, delivered by LIVE-36133) was never mounted or driven.

**Solution**: Added a `usePayTabVerifyAddress` phase controller (`hidden → intro → success`) that resolves the overlay copy and callbacks, mounted `VerifyAddress` in the Pay tab, and connected the Request Verify tile:

- Pressing **Verify** closes the receive dialog and opens the Verify **intro** dialog, firing the `Page Request Address Verification` page view.
- The intro **Verify address** CTA advances to the **success** screen (UI-only for now).
- **Got it** / close dismisses the overlay.

The device intent (DIE) is intentionally kept out of scope and behind the exposed `showSuccess` bridge: once `verifyAddressIntent` lands (LIVE-36132), the intro CTA will start the device intent and the app's DIE host will call `showSuccess` on device confirmation.

Shared `@features/flow-pay-card-request` changes:

- `onShare` (mobile-only) and `onSave` (desktop-only) request action callbacks are now optional, and the view-model no longer tracks/invokes a missing callback.
- The request Verify tracking button is aligned to `verify` (per the Pay tracking plan).
- The `VerifyAddress` dialog gets an InfoState-style muted spotlight background, a `heading-4-semi-bold` title, and centered next steps.

### 📸 Screenshots


https://github.com/user-attachments/assets/621c0226-f1aa-490b-9bba-64161b8f9690




### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36272](https://ledgerhq.atlassian.net/browse/LIVE-36272)
- Depends on [LIVE-36133](https://ledgerhq.atlassian.net/browse/LIVE-36133) (VerifyAddress UI) and stacks on the LIVE-36271 save-card PR (#20953). DIE integration is tracked in [LIVE-36132](https://ledgerhq.atlassian.net/browse/LIVE-36132).



[LIVE-36272]: https://ledgerhq.atlassian.net/browse/LIVE-36272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ