### PR TITLE
fix(e2e): keep large screen upsell modal from covering smoke tests

### DIFF
--- a/.changeset/e2e-disable-large-screen-upsell.md
+++ b/.changeset/e2e-disable-large-screen-upsell.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-mobile-e2e-tests": patch
+"ledger-live-desktop-e2e-tests": patch
+---
+
+Disable the large-screen upsell modal in E2E defaults so "Spot scams before signing" cannot cover Wallet 4.0 navigation.

--- a/e2e/desktop/tests/utils/featureFlagUtils.ts
+++ b/e2e/desktop/tests/utils/featureFlagUtils.ts
@@ -164,6 +164,7 @@ export const getMergedFeatureFlags = ({
 
   const defaultFlags: OptionalFeatureMap = {
     // explicit defaults
+    largeScreenUpsell: { enabled: false },
     lldModularDrawer: {
       enabled: true,
       params: {

--- a/e2e/mobile/utils/featureFlagUtils.ts
+++ b/e2e/mobile/utils/featureFlagUtils.ts
@@ -78,6 +78,7 @@ export const getMergedFeatureFlags = ({
     onboardingWidget: {
       enabled: true,
     },
+    largeScreenUpsell: { enabled: false },
     llmModularDrawer: {
       enabled: true,
       params: {


### PR DESCRIPTION
## Summary
- iOS UI E2E smoke on #20950 fails because the opted-out large-screen upsell drawer ("Spot scams before signing") covers `topbar-discover`.
- Force `largeScreenUpsell` off in E2E default flags, and dismiss that drawer in `waitForWallet40Ready` if it still appears.

## Test plan
- [ ] Confirm iOS UI E2E Smoke on this PR is green
- [ ] Confirm #20950 can pick this up / merge this into `support/release-merge-conflicts`