### PR TITLE
ci(notify-e2e): drop unused checkout and paginate PR files

### DIFF
--- a/.github/workflows/notify-e2e-required-reusable.yml
+++ b/.github/workflows/notify-e2e-required-reusable.yml
@@ -17,11 +17,6 @@ jobs:
     name: "Analyze and notify"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-
       - name: Analyze E2E requirements
         id: analyze
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -38,7 +33,7 @@ jobs:
               paths.some(path => path === needle || path.startsWith(`${needle}/`) || path.includes(needle));
 
             // Get all changed files to check for dependency updates
-            const { data: files } = await github.rest.pulls.listFiles({
+            const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number,


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Remove checkout from notify e2e. Est compute savings 1-2 minutes

The two github-script steps only call the GitHub API, so the fetch-depth: 0 checkout cloned the full ~2.4 GiB history for nothing.

listFiles was also capped at one page, so PRs touching more than 100 files under-reported criticalLibsChanged and affectedCoins, which could omit a required platform from the comment.

### 🔗 Context

Test run: https://github.com/LedgerHQ/ledger-live/actions/runs/32361447946
Ticket: https://ledgerhq.atlassian.net/browse/LIVE-36294