### PR TITLE
[LWDM] fix(live-apps): reuse unchanged manifests to stop idle walletapi load

### DIFF
--- a/.changeset/tender-toys-roll.md
+++ b/.changeset/tender-toys-roll.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+fix(live-apps): reuse unchanged manifests to stop idle WalletAPI Load

--- a/libs/ledger-live-common/src/platform/providers/RemoteLiveAppProvider/index.test.tsx
+++ b/libs/ledger-live-common/src/platform/providers/RemoteLiveAppProvider/index.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { LiveAppManifest } from "../../types";
+import api from "./api";
+import { RemoteLiveAppProvider, useRemoteLiveAppContext, useRemoteLiveAppManifest } from "./index";
+
+jest.mock("./api", () => ({
+  __esModule: true,
+  default: {
+    fetchLiveAppManifests: jest.fn(),
+  },
+}));
+
+jest.mock("../../../hooks/useIsMounted", () => {
+  const isMounted = () => true;
+  return {
+    __esModule: true,
+    default: () => isMounted,
+  };
+});
+
+jest.mock("@features/platform-env", () => ({
+  __esModule: true,
+  default: () => "https://live-app-catalog.test",
+}));
+
+const manifest: LiveAppManifest = {
+  id: "test-app",
+  name: "Test App",
+  private: false,
+  url: "https://example.com",
+  homepageUrl: "https://example.com",
+  icon: "",
+  platforms: ["desktop"],
+  providerTestBaseUrl: "",
+  providerTestId: "",
+  apiVersion: "^2.0.0",
+  manifestVersion: "2",
+  branch: "stable",
+  categories: [],
+  currencies: "*",
+  content: {
+    shortDescription: { en: "Test" },
+    description: { en: "Test" },
+  },
+  permissions: [],
+  domains: ["https://example.com"],
+  visibility: "complete",
+};
+
+const cloneManifest = (value: LiveAppManifest): LiveAppManifest =>
+  JSON.parse(JSON.stringify(value)) as LiveAppManifest;
+
+describe("RemoteLiveAppProvider", () => {
+  it("preserves unchanged manifest references and replaces changed manifests", async () => {
+    let remoteManifest = manifest;
+    jest
+      .mocked(api.fetchLiveAppManifests)
+      .mockImplementation(async () => [cloneManifest(remoteManifest)]);
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <RemoteLiveAppProvider
+        parameters={{
+          platform: "desktop",
+          allowDebugApps: false,
+          allowExperimentalApps: false,
+          llVersion: "1.0.0",
+        }}
+        updateFrequency={60_000}
+      >
+        {children}
+      </RemoteLiveAppProvider>
+    );
+
+    const { result } = renderHook(
+      () => ({
+        manifest: useRemoteLiveAppManifest(manifest.id),
+        updateManifests: useRemoteLiveAppContext().updateManifests,
+      }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.manifest).toBeDefined());
+    const initialManifest = result.current.manifest;
+
+    await act(() => result.current.updateManifests());
+
+    expect(result.current.manifest).toBe(initialManifest);
+
+    remoteManifest = { ...manifest, name: "Updated App" };
+    await act(() => result.current.updateManifests());
+
+    expect(result.current.manifest).not.toBe(initialManifest);
+    expect(result.current.manifest?.name).toBe("Updated App");
+  });
+
+  it("should not pollute Object.prototype when a remote manifest id is __proto__", async () => {
+    const protoManifest = { ...manifest, id: "__proto__" };
+    jest.mocked(api.fetchLiveAppManifests).mockResolvedValue([protoManifest]);
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <RemoteLiveAppProvider
+        parameters={{
+          platform: "desktop",
+          allowDebugApps: false,
+          allowExperimentalApps: false,
+          llVersion: "1.0.0",
+        }}
+        updateFrequency={60_000}
+      >
+        {children}
+      </RemoteLiveAppProvider>
+    );
+
+    const { result } = renderHook(
+      () => ({
+        protoManifest: useRemoteLiveAppManifest("__proto__"),
+        registry: useRemoteLiveAppContext().state.value,
+      }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.protoManifest).toBeDefined());
+
+    expect(result.current.protoManifest?.name).toBe("Test App");
+    expect(Object.hasOwn(result.current.registry!.liveAppById, "__proto__")).toBe(true);
+    expect(Object.getPrototypeOf(result.current.registry!.liveAppById)).toBeNull();
+    expect(Object.prototype).not.toHaveProperty("id");
+  });
+});

--- a/libs/ledger-live-common/src/platform/providers/RemoteLiveAppProvider/index.tsx
+++ b/libs/ledger-live-common/src/platform/providers/RemoteLiveAppProvider/index.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, createContext, useMemo, useState, useCallback } from "react";
+import isEqual from "lodash/isEqual";
 import { LiveAppRegistry } from "./types";
 import { AppPlatform, LiveAppManifest, Loadable } from "../../types";
 
@@ -48,6 +49,23 @@ type LiveAppProviderProps = {
   parameters: FetchLiveAppCatalogPrams;
   updateFrequency: number;
 };
+
+function preserveManifestReferences(
+  manifests: LiveAppManifest[],
+  previousManifestsById: LiveAppRegistry["liveAppById"] | undefined,
+): LiveAppManifest[] {
+  return manifests.map(manifest => {
+    const previousManifest = previousManifestsById?.[manifest.id];
+    return previousManifest && isEqual(previousManifest, manifest) ? previousManifest : manifest;
+  });
+}
+
+function indexManifests(manifests: LiveAppManifest[]): LiveAppRegistry["liveAppById"] {
+  return manifests.reduce<LiveAppRegistry["liveAppById"]>((accumulator, manifest) => {
+    accumulator[manifest.id] = manifest;
+    return accumulator;
+  }, Object.create(null));
+}
 
 export function useRemoteLiveAppManifest(appId?: string): LiveAppManifest | undefined {
   const liveAppRegistry = useContext(liveAppContext).state;
@@ -151,22 +169,27 @@ export function RemoteLiveAppProvider({
       }));
     } else {
       const { allManifests, catalogManifests } = result.manifests;
-      setState(() => ({
-        isLoading: false,
-        value: {
-          liveAppByIndex: allManifests,
-          liveAppFiltered: catalogManifests,
-          liveAppFilteredById: catalogManifests.reduce((acc, liveAppManifest) => {
-            acc[liveAppManifest.id] = liveAppManifest;
-            return acc;
-          }, {}),
-          liveAppById: allManifests.reduce((acc, liveAppManifest) => {
-            acc[liveAppManifest.id] = liveAppManifest;
-            return acc;
-          }, {}),
-        },
-        error: null,
-      }));
+      setState(currentState => {
+        const stableAllManifests = preserveManifestReferences(
+          allManifests,
+          currentState.value?.liveAppById,
+        );
+        const stableCatalogManifests = preserveManifestReferences(
+          catalogManifests,
+          currentState.value?.liveAppFilteredById,
+        );
+
+        return {
+          isLoading: false,
+          value: {
+            liveAppByIndex: stableAllManifests,
+            liveAppFiltered: stableCatalogManifests,
+            liveAppFilteredById: indexManifests(stableCatalogManifests),
+            liveAppById: indexManifests(stableAllManifests),
+          },
+          error: null,
+        };
+      });
     }
     // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [allowDebugApps, allowExperimentalApps, providerURL, lang, isMounted]);

--- a/libs/ledger-live-common/src/wallet-api/react.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.test.ts
@@ -244,6 +244,38 @@ describe("useWalletAPIServer", () => {
     expect(options.tracking.load).toHaveBeenCalledWith(options.manifest);
   });
 
+  it("does not track load again when the same live app manifest is replaced", () => {
+    const options = createDefaultOptions();
+    const { rerender } = renderHook(
+      (props: useWalletAPIServerOptions) => useWalletAPIServer(props),
+      { initialProps: options },
+    );
+
+    expect(options.tracking.load).toHaveBeenCalledTimes(1);
+
+    rerender({
+      ...options,
+      manifest: { ...options.manifest, name: "Renamed App" },
+    });
+
+    expect(options.tracking.load).toHaveBeenCalledTimes(1);
+  });
+
+  it("tracks load when the live app id changes", () => {
+    const options = createDefaultOptions();
+    const { rerender } = renderHook(
+      (props: useWalletAPIServerOptions) => useWalletAPIServer(props),
+      { initialProps: options },
+    );
+
+    rerender({
+      ...options,
+      manifest: { ...options.manifest, id: "other-app" },
+    });
+
+    expect(options.tracking.load).toHaveBeenCalledTimes(2);
+  });
+
   it("should register handlers on the server", () => {
     const options = createDefaultOptions();
     renderHook(() => useWalletAPIServer(options));

--- a/libs/ledger-live-common/src/wallet-api/react.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.ts
@@ -372,7 +372,7 @@ export function useWalletAPIServer({
   );
   useEffect(() => {
     tracking.load(manifest);
-  }, [tracking, manifest]);
+  }, [tracking, manifest.id]);
 
   // TODO: refactor each handler into its own logic function for clarity
   useEffect(() => {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Idle live apps (for example Swap) were emitting extra `WalletAPI Load` events every 30 minutes because the remote catalog refresh replaced unchanged manifests with new object references, which retriggered the Wallet API `tracking.load` effect. The provider now reuses previous manifest references when the payload is deeply equal, and still replaces a manifest when its content actually changes

### 🔗 Context

- **[JIRA / GitHub issue](https://ledgerhq.atlassian.net/browse/LIVE-36281)** <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
