### PR TITLE
[LWDM] test(contacts): automate create, rename and delete (B2CQA-6238)

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -838,7 +838,7 @@ describe("Contacts integration", () => {
     expect(screen.getByTestId("contacts-rename-contact-dialog")).toBeVisible();
     expect(screen.getByTestId("contacts-rename-contact-confirm")).toBeDisabled();
 
-    fireEvent.change(screen.getByTestId("contacts-add-contact-name-input"), {
+    fireEvent.change(screen.getByTestId("contacts-rename-contact-name-input"), {
       target: { value: "Alice" },
     });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -1065,8 +1065,8 @@ describe("Contacts integration", () => {
       expect(screen.getByTestId("contacts-rename-contact-confirm")).toBeDisabled();
     });
 
-    await user.clear(screen.getByTestId("contacts-add-contact-name-input"));
-    await user.type(screen.getByTestId("contacts-add-contact-name-input"), "Alice");
+    await user.clear(screen.getByTestId("contacts-rename-contact-name-input"));
+    await user.type(screen.getByTestId("contacts-rename-contact-name-input"), "Alice");
 
     await waitFor(() => {
       expect(screen.getByTestId("contacts-rename-contact-confirm")).toBeEnabled();

--- a/e2e/mobile/helpers/elementHelpers.ts
+++ b/e2e/mobile/helpers/elementHelpers.ts
@@ -50,6 +50,7 @@ export type WaitForElementOptions = {
   errorCheckTimeout?: number;
   errorElementId?: string;
   checkVisibility?: boolean;
+  visibilityPercentage?: number;
 };
 
 export const NativeElementHelpers = {
@@ -91,7 +92,7 @@ export const NativeElementHelpers = {
     const errorCheckTimeout = options?.errorCheckTimeout ?? 500;
     const checkVisibility = options?.checkVisibility ?? true;
     const waitCondition = checkVisibility
-      ? waitFor(nativeElement).toBeVisible()
+      ? waitFor(nativeElement).toBeVisible(options?.visibilityPercentage)
       : waitFor(nativeElement).toExist();
     if (!options?.errorElementId) {
       return waitCondition.withTimeout(timeout);
@@ -126,6 +127,11 @@ export const NativeElementHelpers = {
     options?: WaitForElementOptions,
   ) {
     return NativeElementHelpers.waitForElement(element(by.id(id)), timeout, options);
+  },
+
+  /** Detox's default is 75%, which a sliding bottom sheet satisfies before it settles. */
+  async waitForFullyVisibleById(id: string | RegExp, timeout: number = DEFAULT_TIMEOUT) {
+    return NativeElementHelpers.waitForElementById(id, timeout, { visibilityPercentage: 100 });
   },
 
   async waitForElementByText(

--- a/e2e/mobile/jest.environment.ts
+++ b/e2e/mobile/jest.environment.ts
@@ -198,6 +198,7 @@ export default class TestEnvironment extends DetoxEnvironment {
       waitForElement: NativeElementHelpers.waitForElement,
       waitForElementById: NativeElementHelpers.waitForElementById,
       waitForElementByText: NativeElementHelpers.waitForElementByText,
+      waitForFullyVisibleById: NativeElementHelpers.waitForFullyVisibleById,
       waitForElementNotVisible: NativeElementHelpers.waitForElementNotVisible,
     };
 

--- a/e2e/mobile/page/drawer/contactName.drawer.ts
+++ b/e2e/mobile/page/drawer/contactName.drawer.ts
@@ -1,0 +1,31 @@
+import { Step } from "jest-allure2-reporter/api";
+
+export const RENAME_CONTACT_PREFIX = "contacts-rename-contact";
+
+export type ContactNameDrawerPrefix = typeof RENAME_CONTACT_PREFIX;
+
+/** The shared `ContactsContactNameDrawerContent`, namespaced by its host's test id prefix. */
+export default class ContactNameDrawer {
+  constructor(private readonly testIDPrefix: ContactNameDrawerPrefix) {}
+
+  contentId = () => `${this.testIDPrefix}-content`;
+
+  content = () => getElementById(this.contentId());
+  nameInput = () => getElementById(`${this.testIDPrefix}-name-input`);
+  confirmButton = () => getElementById(`${this.testIDPrefix}-confirm`);
+
+  @Step("Expect the contact name drawer visible")
+  async expectVisible() {
+    await waitForFullyVisibleById(this.contentId());
+  }
+
+  @Step("Type contact name: {{0}}")
+  async typeName(name: string) {
+    await typeTextByElement(this.nameInput(), name);
+  }
+
+  @Step("Confirm the contact name")
+  async confirm() {
+    await tapByElement(this.confirmButton());
+  }
+}

--- a/e2e/mobile/page/index.ts
+++ b/e2e/mobile/page/index.ts
@@ -30,6 +30,7 @@ import SwapPage from "./trade/swap.page";
 import SwapLiveAppPage from "./liveApps/swapLiveApp";
 import MainNavigationPage from "./wallet/mainNavigation.page";
 import MyWalletPage from "./wallet/myWallet.page";
+import ContactsPage from "./wallet/contacts.page";
 import OperationPage from "./wallet/operation.page";
 import TopBarSearchPage from "./wallet/topBarSearch.page";
 import CeloManageAssetsPage from "./trade/celoManageAssets.page";
@@ -91,6 +92,7 @@ export class Application {
   private swapPageInstance = lazyInit(SwapPage);
   private mainNavigationPageInstance = lazyInit(MainNavigationPage);
   private myWalletPageInstance = lazyInit(MyWalletPage);
+  private contactsPageInstance = lazyInit(ContactsPage);
   private operationPageInstance = lazyInit(OperationPage);
   private celoManageAssetsPageInstance = lazyInit(CeloManageAssetsPage);
   private TransferMenuDrawerInstance = lazyInit(TransferMenuDrawer);
@@ -233,6 +235,10 @@ export class Application {
 
   public get myWallet() {
     return this.myWalletPageInstance();
+  }
+
+  public get contacts() {
+    return this.contactsPageInstance();
   }
 
   public get operation() {

--- a/e2e/mobile/page/wallet/contactDetail.page.ts
+++ b/e2e/mobile/page/wallet/contactDetail.page.ts
@@ -1,0 +1,69 @@
+import { Step } from "jest-allure2-reporter/api";
+import ContactNameDrawer, { RENAME_CONTACT_PREFIX } from "../drawer/contactName.drawer";
+
+export default class ContactDetailPage {
+  renameDrawer = new ContactNameDrawer(RENAME_CONTACT_PREFIX);
+
+  screen = () => getElementById("contacts-detail-screen");
+  name = () => getElementById("contacts-detail-name");
+  emptyState = () => getElementById("contacts-detail-empty-state");
+  actionsTrigger = () => getElementById("contacts-detail-actions-trigger");
+  editAction = () => getElementById("contacts-detail-edit-action");
+  deleteAction = () => getElementById("contacts-detail-delete-action");
+  actionsMenuContentId = "contacts-detail-actions-menu";
+  deleteContentId = "contacts-delete-contact-content";
+  deleteConfirmButton = () => getElementById("contacts-delete-contact-confirm");
+
+  @Step("Expect contact detail screen visible")
+  async expectScreenVisible() {
+    await detoxExpect(this.screen()).toBeVisible();
+  }
+
+  @Step("Expect contact detail name to be {{0}}")
+  async expectName(name: string) {
+    await detoxExpect(this.name()).toHaveText(name);
+  }
+
+  @Step("Expect the contact to have no address")
+  async expectNoAddresses() {
+    await detoxExpect(this.emptyState()).toBeVisible();
+  }
+
+  @Step("Open the contact actions menu")
+  async openActionsMenu() {
+    await tapByElement(this.actionsTrigger());
+    await waitForFullyVisibleById(this.actionsMenuContentId);
+  }
+
+  @Step("Open the rename contact drawer")
+  async openRenameDrawer() {
+    await tapByElement(this.editAction());
+    await this.renameDrawer.expectVisible();
+  }
+
+  @Step("Rename the contact to {{0}}")
+  async renameContact(name: string) {
+    await this.openActionsMenu();
+    await this.openRenameDrawer();
+    await this.renameDrawer.typeName(name);
+    await this.renameDrawer.confirm();
+  }
+
+  @Step("Open the delete contact confirmation")
+  async openDeleteConfirmation() {
+    await tapByElement(this.deleteAction());
+    await waitForFullyVisibleById(this.deleteContentId);
+  }
+
+  @Step("Confirm the contact deletion")
+  async tapConfirmDelete() {
+    await tapByElement(this.deleteConfirmButton());
+  }
+
+  @Step("Delete the contact")
+  async deleteContact() {
+    await this.openActionsMenu();
+    await this.openDeleteConfirmation();
+    await this.tapConfirmDelete();
+  }
+}

--- a/e2e/mobile/page/wallet/contacts.page.ts
+++ b/e2e/mobile/page/wallet/contacts.page.ts
@@ -1,0 +1,98 @@
+import { Step } from "jest-allure2-reporter/api";
+import ContactDetailPage from "./contactDetail.page";
+
+const DEFAULT_ME_CONTACT_NAME = "Me";
+
+export default class ContactsPage {
+  savedContactNameRegExp = /^contacts-saved-contact-.+-name$/;
+
+  detail = new ContactDetailPage();
+
+  addContactContentId = "contacts-add-contact-content";
+
+  contactsContent = () => getElementById("contacts-content");
+  meName = () => getElementById("contacts-me-name");
+  meAddressCount = () => getElementById("contacts-me-address-count");
+  addContactHeaderButton = () => getElementById("contacts-add-contact-header");
+  addContactRow = () => getElementById("contacts-add-contact-row");
+  addContactNameInput = () => getElementById("contacts-add-contact-name-input");
+  addContactSaveButton = () => getElementById("contacts-add-contact-save");
+  savedContactName = (name: string) => getElementByIdAndText(this.savedContactNameRegExp, name);
+  savedContactRow = (rowId: string) => getElementById(rowId);
+  savedContactRowName = (rowId: string) => getElementById(`${rowId}-name`);
+  savedContactAddressCount = (rowId: string) => getElementById(`${rowId}-address-count`);
+
+  @Step("Expect Contacts screen visible")
+  async expectScreenVisible() {
+    await detoxExpect(this.contactsContent()).toBeVisible();
+  }
+
+  @Step("Expect Me contact displayed")
+  async expectMeContactDisplayed() {
+    await detoxExpect(this.meName()).toHaveText(DEFAULT_ME_CONTACT_NAME);
+  }
+
+  @Step("Expect Me contact address count to show {{0}}")
+  async expectMeAddressCount(expectedLabel: string) {
+    await detoxExpect(this.meAddressCount()).toHaveText(expectedLabel);
+  }
+
+  @Step("Open the Add contact drawer")
+  async openAddContactDrawer() {
+    await tapByElement(this.addContactHeaderButton());
+    await waitForFullyVisibleById(this.addContactContentId);
+  }
+
+  @Step("Add the contact {{0}}")
+  async addContact(name: string) {
+    await this.openAddContactDrawer();
+    await typeTextByElement(this.addContactNameInput(), name);
+    await tapByElement(this.addContactSaveButton());
+  }
+
+  /** Rows carry a runtime uuid, so the id is resolved from the name label. Names are unique. */
+  async getSavedContactRowId(name: string): Promise<string> {
+    const nameId = await getIdOfElement(this.savedContactName(name));
+
+    return nameId.replace(/-name$/, "");
+  }
+
+  @Step("Expect contact {{0}} displayed")
+  async expectSavedContactDisplayed(name: string) {
+    await detoxExpect(this.savedContactName(name)).toBeVisible();
+  }
+
+  @Step("Expect contact {{0}} address count to show {{1}}")
+  async expectSavedContactAddressCount(name: string, expectedLabel: string) {
+    const rowId = await this.getSavedContactRowId(name);
+
+    await detoxExpect(this.savedContactAddressCount(rowId)).toHaveText(expectedLabel);
+  }
+
+  @Step("Open the contact row {{0}}")
+  async openSavedContact(rowId: string) {
+    await tapByElement(this.savedContactRow(rowId));
+    await this.detail.expectScreenVisible();
+  }
+
+  @Step("Delete contact {{0}}")
+  async deleteContact(rowId: string) {
+    await this.openSavedContact(rowId);
+    await this.detail.deleteContact();
+  }
+
+  @Step("Expect contact row {{0}} to be named {{1}}")
+  async expectSavedContactRowName(rowId: string, name: string) {
+    await detoxExpect(this.savedContactRowName(rowId)).toHaveText(name);
+  }
+
+  @Step("Expect contact row {{0}} removed")
+  async expectSavedContactRemoved(rowId: string) {
+    await detoxExpect(this.savedContactRow(rowId)).not.toExist();
+  }
+
+  @Step("Expect the empty contacts list")
+  async expectEmptyState() {
+    await detoxExpect(this.addContactRow()).toBeVisible();
+  }
+}

--- a/e2e/mobile/page/wallet/mainNavigation.page.ts
+++ b/e2e/mobile/page/wallet/mainNavigation.page.ts
@@ -66,6 +66,14 @@ export default class MainNavigationPage {
     await tapById(this.topBarMyWalletId);
   }
 
+  // The top bar belongs to the navigation chrome, the arrival check to My Wallet — so this composes
+  // that page's own assertion instead of duplicating its locator.
+  @Step("Open My Wallet from top bar")
+  async openMyWallet() {
+    await this.tapTopBarMyWallet();
+    await app.myWallet.expectScreenVisible();
+  }
+
   @Step("Tap Discover in top bar")
   async tapTopBarDiscover() {
     await tapById(this.topBarDiscoverId);

--- a/e2e/mobile/page/wallet/myWallet.page.ts
+++ b/e2e/mobile/page/wallet/myWallet.page.ts
@@ -1,8 +1,8 @@
 import { Step } from "jest-allure2-reporter/api";
 
 export default class MyWalletPage {
-  topBarMyWalletId = "topbar-mywallet";
   avatarId = "my-wallet-avatar";
+  contactsButtonId = "my-wallet-contacts-button";
   quickActionHelpId = "my-wallet-quick-action-help";
   headerSettingsButtonId = "my-wallet-header-settings-button";
   headerNotificationsButtonId = "my-wallet-header-notifications-button";
@@ -10,15 +10,16 @@ export default class MyWalletPage {
   helpScreenId = "my-wallet-help-screen";
   settingsScreenId = "general-settings-card";
 
-  @Step("Open My Wallet from top bar")
-  async openFromTopBar() {
-    await tapById(this.topBarMyWalletId);
-    await this.expectScreenVisible();
-  }
-
   @Step("Expect My Wallet screen visible")
   async expectScreenVisible() {
     await waitForElementById(this.headerSettingsButtonId);
+  }
+
+  // Composes the Contacts page's own arrival assertion rather than duplicating its locator.
+  @Step("Open Contacts")
+  async openContacts() {
+    await tapById(this.contactsButtonId);
+    await app.contacts.expectScreenVisible();
   }
 
   @Step("Tap Help quick action")

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -18,7 +18,6 @@ export default class PortfolioPage {
   emptyPortfolioListId = "PortfolioEmptyList";
   portfolioSettingsId = "topbar-settings";
   myWalletHeaderSettingsButtonId = "my-wallet-header-settings-button";
-  topBarMyWalletId = "topbar-mywallet";
   portfolioListIdRegex = new RegExp(`portfolio-screen|${this.readOnlyItemsId}`);
   addAccountCta = "add-account-cta";
   transactionHistorySectionTitleId = "portfolio-transaction-history-section";

--- a/e2e/mobile/specs/contacts/contacts.ts
+++ b/e2e/mobile/specs/contacts/contacts.ts
@@ -1,0 +1,82 @@
+import { generateContactName } from "@ledgerhq/live-e2e-shared/contacts";
+import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
+import { setTeamOwner } from "helpers/allure/allure-helper";
+import { FF_LWM_WALLET_40_Q2 } from "utils/featureFlagUtils";
+
+import type { ApplicationOptions } from "page";
+import type { OptionalFeatureMap } from "@shared/feature-flags";
+
+// Pinned: the Contacts entry point lives on My Wallet, which the Q1 preset turns off.
+const CONTACTS_FEATURE_FLAGS: OptionalFeatureMap = {
+  lwmContacts: {
+    enabled: true,
+    params: { newBadge: false, eligibleAddressFamilies: ["evm"] },
+  },
+  ...FF_LWM_WALLET_40_Q2,
+};
+
+// skip-onboarding with the one-time Contacts introduction already dismissed.
+const CONTACTS_USERDATA = "contacts";
+
+const CONTACT_NAME = generateContactName();
+const RENAMED_CONTACT_NAME = generateContactName();
+// i18n `contacts.addressCount_zero`.
+const NO_ADDRESS_LABEL = "0 address";
+
+async function initApp(options: ApplicationOptions = {}) {
+  await app.init({
+    userdata: options.userdata ?? CONTACTS_USERDATA,
+    speculosApp: options.speculosApp,
+    cliCommands: options.cliCommands,
+    featureFlags: { ...CONTACTS_FEATURE_FLAGS, ...options.featureFlags },
+  });
+  await app.mainNavigation.waitForWallet40Ready();
+}
+
+/**
+ * B2CQA-6238. No device confirmation is asserted: `initApp` starts without a Speculos device, so a
+ * step needing one would block rather than pass.
+ */
+export function runCreateRenameDeleteContactTest(tmsLinks: string[], tags: string[]) {
+  describe("Contacts", () => {
+    beforeAll(async () => {
+      await initApp();
+    });
+
+    setTeamOwner(Team.WALLET_XP);
+    tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
+    tags.forEach(tag => $Tag(tag));
+
+    it("Create, rename and delete a contact without an address", async () => {
+      await app.mainNavigation.openMyWallet();
+      await app.myWallet.openContacts();
+      await app.contacts.expectMeContactDisplayed();
+      await app.contacts.expectMeAddressCount(NO_ADDRESS_LABEL);
+
+      await app.contacts.addContact(CONTACT_NAME);
+
+      await app.contacts.expectSavedContactDisplayed(CONTACT_NAME);
+      await app.contacts.expectSavedContactAddressCount(CONTACT_NAME, NO_ADDRESS_LABEL);
+
+      // Resolved before the rename: the row id survives it, the name does not.
+      const contactRowId = await app.contacts.getSavedContactRowId(CONTACT_NAME);
+
+      await app.contacts.openSavedContact(contactRowId);
+      await app.contacts.detail.expectName(CONTACT_NAME);
+      await app.contacts.detail.expectNoAddresses();
+
+      await app.contacts.detail.renameContact(RENAMED_CONTACT_NAME);
+      await app.contacts.detail.expectName(RENAMED_CONTACT_NAME);
+
+      await app.common.goToPreviousPage();
+      await app.contacts.expectScreenVisible();
+      await app.contacts.expectSavedContactRowName(contactRowId, RENAMED_CONTACT_NAME);
+
+      await app.contacts.deleteContact(contactRowId);
+
+      await app.contacts.expectScreenVisible();
+      await app.contacts.expectSavedContactRemoved(contactRowId);
+      await app.contacts.expectEmptyState();
+    });
+  });
+}

--- a/e2e/mobile/specs/contacts/createRenameDeleteContact.spec.ts
+++ b/e2e/mobile/specs/contacts/createRenameDeleteContact.spec.ts
@@ -1,0 +1,8 @@
+import { runCreateRenameDeleteContactTest } from "./contacts";
+
+const testConfig = {
+  tmsLinks: ["B2CQA-6238"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],
+};
+
+runCreateRenameDeleteContactTest(testConfig.tmsLinks, testConfig.tags);

--- a/e2e/mobile/specs/wallet40Q2/myWallet.spec.ts
+++ b/e2e/mobile/specs/wallet40Q2/myWallet.spec.ts
@@ -26,26 +26,26 @@ describe("My Wallet", () => {
 
   it("Open My Wallet from portfolio and earn", async () => {
     await app.mainNavigation.expectPortfolioPageVisible();
-    await app.myWallet.openFromTopBar();
+    await app.mainNavigation.openMyWallet();
     await app.myWallet.tapHeaderBack();
 
     await app.mainNavigation.expectPortfolioPageVisible();
 
     await app.mainNavigation.tapWallet40Tab("earn");
     await app.mainNavigation.expectEarnPageVisible();
-    await app.myWallet.openFromTopBar();
+    await app.mainNavigation.openMyWallet();
   });
 
   it("Access help from My Wallet", async () => {
     await app.mainNavigation.openPortfolioViaDeeplink();
-    await app.myWallet.openFromTopBar();
+    await app.mainNavigation.openMyWallet();
     await app.myWallet.tapHelp();
     await app.myWallet.expectHelpScreenVisible();
   });
 
   it("Access settings from My Wallet", async () => {
     await app.mainNavigation.openPortfolioViaDeeplink();
-    await app.myWallet.openFromTopBar();
+    await app.mainNavigation.openMyWallet();
     await app.myWallet.tapHeaderSettings();
     await app.myWallet.expectSettingsScreenVisible();
   });

--- a/e2e/mobile/types/global.d.ts
+++ b/e2e/mobile/types/global.d.ts
@@ -88,6 +88,7 @@ declare global {
   var waitForElement: typeof NativeElementHelpers.waitForElement;
   var waitForElementById: typeof NativeElementHelpers.waitForElementById;
   var waitForElementByText: typeof NativeElementHelpers.waitForElementByText;
+  var waitForFullyVisibleById: typeof NativeElementHelpers.waitForFullyVisibleById;
   var waitForElementNotVisible: typeof NativeElementHelpers.waitForElementNotVisible;
 
   var expectWebElementNotVisible: typeof WebElementHelpers.expectWebElementNotVisible;

--- a/e2e/mobile/userdata/contacts.json
+++ b/e2e/mobile/userdata/contacts.json
@@ -1,0 +1,59 @@
+{
+  "data": {
+    "SPECTRON_RUN": {
+      "localStorage": {
+        "acceptedTermsVersion": "2019-12-04"
+      }
+    },
+    "settings": {
+      "hasCompletedOnboarding": true,
+      "counterValue": "USD",
+      "language": "en",
+      "theme": "light",
+      "region": null,
+      "locale": "en-US",
+      "orderAccounts": "balance|desc",
+      "countervalueFirst": false,
+      "autoLockTimeout": 10,
+      "marketIndicator": "western",
+      "currenciesSettings": {},
+      "pairExchanges": {},
+      "developerMode": false,
+      "loaded": true,
+      "shareAnalytics": false,
+      "sharePersonalizedRecommandations": false,
+      "hasSeenAnalyticsOptInPrompt": true,
+      "analyticsEnabled": false,
+      "personalizedRecommendationsEnabled": false,
+      "trackingEnabled": false,
+      "sentryLogs": true,
+      "readOnlyModeEnabled": false,
+      "hasOrderedNano": true,
+      "lastUsedVersion": "99.99.99",
+      "dismissedBanners": [],
+      "accountsViewMode": "list",
+      "showAccountsHelperBanner": true,
+      "hideEmptyTokenAccounts": false,
+      "sidebarCollapsed": false,
+      "discreetMode": false,
+      "preferredDeviceModel": "nanoS",
+      "hasInstalledApps": true,
+      "dismissedDynamicCards": [],
+      "seenDevices": [],
+      "blacklistedTokenIds": [],
+      "swapAcceptedProviderIds": [],
+      "deepLinkUrl": null,
+      "firstTimeLend": false,
+      "swapProviders": [],
+      "showClearCacheBanner": false,
+      "starredAccountIds": [],
+      "hasPassword": false,
+      "hasDismissedContactsFeatureIntroduction": true
+    },
+    "user": {
+      "id": "08cf3393-c5eb-4ea7-92de-0deea22e3971"
+    },
+    "accounts": [],
+    "countervalues": {}
+  }
+}

--- a/features/flow/contacts/src/steps/Detail/components/ContactConfirmationBottomSheet/ContactConfirmationBottomSheet.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactConfirmationBottomSheet/ContactConfirmationBottomSheet.native.tsx
@@ -25,6 +25,8 @@ export type ContactConfirmationBottomSheetProps = Readonly<{
   confirmLoading?: boolean;
   confirmDisabled?: boolean;
   confirmTestID?: string;
+  /** Anchor for the sheet's content, present only while the sheet is open. */
+  contentTestID?: string;
   onConfirm: () => void;
   onCancel: () => void;
 }>;
@@ -38,13 +40,14 @@ export function ContactConfirmationBottomSheet({
   confirmLoading = false,
   confirmDisabled = false,
   confirmTestID,
+  contentTestID,
   onConfirm,
   onCancel,
 }: ContactConfirmationBottomSheetProps): React.JSX.Element {
   return (
     <BottomSheetView style={{ paddingBottom: bottomInset + 24 }}>
       {isOpen ? (
-        <Box lx={{ gap: "s24", paddingHorizontal: "s16" }}>
+        <Box testID={contentTestID} lx={{ gap: "s24", paddingHorizontal: "s16" }}>
           <BottomSheetHeader />
           <Box lx={{ alignItems: "center", gap: "s16" }}>
             <Spot appearance="icon" icon={icon} size={56} />

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailHeader.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailHeader.native.tsx
@@ -26,10 +26,10 @@ export function ContactDetailHeader({
       <Box lx={{ alignItems: "center", gap: "s16" }}>
         <ContactDetailAvatar contact={contact} meAvatarSrc={meAvatarSrc} />
         <Box lx={{ alignItems: "center", gap: "s4" }}>
-          <Text typography="heading3SemiBold" lx={{ color: "base" }}>
+          <Text testID="contacts-detail-name" typography="heading3SemiBold" lx={{ color: "base" }}>
             {displayName}
           </Text>
-          <Text typography="body2" lx={{ color: "muted" }}>
+          <Text testID="contacts-detail-address-count" typography="body2" lx={{ color: "muted" }}>
             {labels.formatAddressCount(contact.addresses.length)}
           </Text>
         </Box>

--- a/features/flow/contacts/src/steps/Detail/components/ContactsDeleteContactDialog/ContactsDeleteContactDialog.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactsDeleteContactDialog/ContactsDeleteContactDialog.native.tsx
@@ -21,6 +21,7 @@ export function ContactsDeleteContactDialog({
       confirmLoading={isDeleting}
       confirmDisabled={isDeleting}
       confirmTestID="contacts-delete-contact-confirm"
+      contentTestID="contacts-delete-contact-content"
       onConfirm={() => void onConfirm()}
       onCancel={onCancel}
     />

--- a/features/flow/contacts/src/steps/EditContact/ContactsRenameContactDialog.web.tsx
+++ b/features/flow/contacts/src/steps/EditContact/ContactsRenameContactDialog.web.tsx
@@ -39,6 +39,7 @@ export function ContactsRenameContactDialog({
         <DialogBody className="flex flex-col gap-32 px-24 pb-24">
           <div className="flex flex-col gap-24">
             <ContactNameInput
+              testIDPrefix="contacts-rename-contact"
               value={draftName}
               placeholder={labels.namePlaceholder}
               errorMessage={nameValidationError}

--- a/features/flow/contacts/src/steps/EditContact/ContactsRenameContactDrawer.native.tsx
+++ b/features/flow/contacts/src/steps/EditContact/ContactsRenameContactDrawer.native.tsx
@@ -26,6 +26,7 @@ export function ContactsRenameContactDrawer({
       labels={labels}
       confirmLabel={labels.confirmName}
       confirmTestID="contacts-rename-contact-confirm"
+      testIDPrefix="contacts-rename-contact"
       onDraftNameChange={onDraftNameChange}
       onConfirm={onConfirm}
     />

--- a/features/flow/flow-contacts-add-contact/src/components/ContactNameInput/ContactNameInput.native.tsx
+++ b/features/flow/flow-contacts-add-contact/src/components/ContactNameInput/ContactNameInput.native.tsx
@@ -8,6 +8,8 @@ type ContactNameInputProps = Readonly<{
   placeholder: string;
   errorMessage?: string;
   isEditable?: boolean;
+  /** Namespaces the test ids, so each host drawer identifies its own input. */
+  testIDPrefix?: string;
   onChangeText: (name: string) => void;
 }>;
 
@@ -16,6 +18,7 @@ export function ContactNameInput({
   placeholder,
   errorMessage,
   isEditable = true,
+  testIDPrefix = "contacts-add-contact",
   onChangeText,
 }: ContactNameInputProps): React.JSX.Element {
   const isAtNameLengthLimit = value.length === CONTACT_NAME_MAX_LENGTH;
@@ -23,7 +26,7 @@ export function ContactNameInput({
   return (
     <Box lx={{ gap: "s8" }}>
       <TextInput
-        testID="contacts-add-contact-name-input"
+        testID={`${testIDPrefix}-name-input`}
         autoFocus
         placeholder={placeholder}
         value={value}
@@ -50,7 +53,7 @@ export function ContactNameInput({
           >
             <DeleteCircleFill color="error" size={16} />
             <Text
-              testID="contacts-add-contact-name-error"
+              testID={`${testIDPrefix}-name-error`}
               typography="body3"
               accessibilityLiveRegion="polite"
               lx={{ color: "error" }}
@@ -60,7 +63,7 @@ export function ContactNameInput({
           </Box>
         ) : null}
         <Text
-          testID="contacts-add-contact-name-count"
+          testID={`${testIDPrefix}-name-count`}
           typography="body3"
           accessibilityLiveRegion="polite"
           lx={{ color: isAtNameLengthLimit ? "error" : "muted" }}

--- a/features/flow/flow-contacts-add-contact/src/components/ContactNameInput/ContactNameInput.web.tsx
+++ b/features/flow/flow-contacts-add-contact/src/components/ContactNameInput/ContactNameInput.web.tsx
@@ -7,6 +7,8 @@ type ContactNameInputProps = Readonly<{
   placeholder: string;
   errorMessage?: string;
   isEditable?: boolean;
+  /** Namespaces the test ids, so each host dialog identifies its own input. */
+  testIDPrefix?: string;
   onChange: (value: string) => void;
 }>;
 
@@ -15,11 +17,12 @@ export function ContactNameInput({
   placeholder,
   errorMessage,
   isEditable = true,
+  testIDPrefix = "contacts-add-contact",
   onChange,
 }: ContactNameInputProps): React.ReactNode {
   return (
     <TextInput
-      data-testid="contacts-add-contact-name-input"
+      data-testid={`${testIDPrefix}-name-input`}
       label={placeholder}
       value={value}
       onChange={event => onChange(event.target.value)}

--- a/features/flow/flow-contacts-add-contact/src/components/ContactsContactNameDrawer/ContactsContactNameDrawerContent.native.tsx
+++ b/features/flow/flow-contacts-add-contact/src/components/ContactsContactNameDrawer/ContactsContactNameDrawerContent.native.tsx
@@ -29,6 +29,8 @@ export type ContactsContactNameDrawerContentProps = Readonly<{
   labels: ContactsContactNameDrawerLabels;
   confirmLabel: string;
   confirmTestID?: string;
+  /** Namespaces the drawer's content anchor and its input ids. */
+  testIDPrefix?: string;
   onDraftNameChange: (name: string) => void;
   onConfirm: () => Promise<void>;
 }>;
@@ -45,6 +47,7 @@ export function ContactsContactNameDrawerContent({
   labels,
   confirmLabel,
   confirmTestID,
+  testIDPrefix,
   onDraftNameChange,
   onConfirm,
 }: ContactsContactNameDrawerContentProps): React.JSX.Element {
@@ -54,13 +57,14 @@ export function ContactsContactNameDrawerContent({
   return (
     <BottomSheetView style={{ paddingBottom: bottomInset + 24 + keyboardInset }}>
       {isOpen ? (
-        <Box lx={{ gap: "s24" }}>
+        <Box testID={testIDPrefix ? `${testIDPrefix}-content` : undefined} lx={{ gap: "s24" }}>
           <BottomSheetHeader />
           <Box lx={{ gap: "s16" }}>
             <Text typography="heading3SemiBold" lx={{ color: "base" }}>
               {labels.title}
             </Text>
             <ContactNameInput
+              testIDPrefix={testIDPrefix}
               value={draftName}
               placeholder={labels.namePlaceholder}
               errorMessage={nameValidationError}

--- a/features/flow/flow-contacts-add-contact/src/screens/AddContact/ContactsAddContactContent.native.tsx
+++ b/features/flow/flow-contacts-add-contact/src/screens/AddContact/ContactsAddContactContent.native.tsx
@@ -16,7 +16,7 @@ export function ContactsAddContactContent({
     invalidNameError === null ? undefined : labels.nameValidationErrors[invalidNameError];
 
   return (
-    <Box lx={{ gap: "s24" }}>
+    <Box testID="contacts-add-contact-content" lx={{ gap: "s24" }}>
       <Box lx={{ gap: "s16" }}>
         <Text typography="heading3SemiBold" lx={{ color: "base" }}>
           {labels.title}

--- a/features/flow/flow-contacts-list/src/components/ContactsList/ListItems/ContactsMeListItem.native.tsx
+++ b/features/flow/flow-contacts-list/src/components/ContactsList/ListItems/ContactsMeListItem.native.tsx
@@ -38,8 +38,10 @@ export function ContactsMeListItem({
           alt={contact.name}
         />
         <ListItemContent>
-          <ListItemTitle>{contact.name}</ListItemTitle>
-          <ListItemDescription>{addressCountLabel}</ListItemDescription>
+          <ListItemTitle testID="contacts-me-name">{contact.name}</ListItemTitle>
+          <ListItemDescription testID="contacts-me-address-count">
+            {addressCountLabel}
+          </ListItemDescription>
         </ListItemContent>
       </ListItemLeading>
     </ListItem>

--- a/features/flow/flow-contacts-list/src/components/ContactsList/ListItems/ContactsSavedContactListItem.native.tsx
+++ b/features/flow/flow-contacts-list/src/components/ContactsList/ListItems/ContactsSavedContactListItem.native.tsx
@@ -30,8 +30,12 @@ export function ContactsSavedContactListItem({
       <ListItemLeading>
         <ContactAvatar contactId={contact.contactId} name={contact.name} size="md" />
         <ListItemContent>
-          <ListItemTitle>{contact.name}</ListItemTitle>
-          <ListItemDescription>{addressCountLabel}</ListItemDescription>
+          <ListItemTitle testID={`contacts-saved-contact-${contact.contactId}-name`}>
+            {contact.name}
+          </ListItemTitle>
+          <ListItemDescription testID={`contacts-saved-contact-${contact.contactId}-address-count`}>
+            {addressCountLabel}
+          </ListItemDescription>
         </ListItemContent>
       </ListItemLeading>
     </ListItem>

--- a/libs/live-e2e-shared/src/contacts.ts
+++ b/libs/live-e2e-shared/src/contacts.ts
@@ -1,0 +1,15 @@
+import { randomUUID } from "node:crypto";
+
+// Every separator a user can type. The straight `'` is excluded: iOS rewrites it to `’` on input.
+const CONTACT_NAME_FORMAT_SAMPLE = "O’Neil-Zoé";
+
+/**
+ * Valid contact name, unique per call — duplicates are rejected on save.
+ *
+ * @see [ContactNamePattern](../../../domain/entity/contact/src/schema.ts) for the accepted format.
+ */
+export function generateContactName(): string {
+  const suffix = randomUUID().replaceAll("-", "").slice(0, 6);
+
+  return `${CONTACT_NAME_FORMAT_SAMPLE} ${suffix}`.normalize("NFC");
+}


### PR DESCRIPTION
## What

Automates [B2CQA-6238](https://ledgerhq.atlassian.net/browse/B2CQA-6238) on mobile: a contact without an address can be created, renamed and deleted, with no device confirmation at any step.

The test drives the real UI end to end — create through the add-contact drawer, rename and delete from the contact detail screen — and re-checks the rename on the list after navigating back, so it is verified on a screen rebuilt from state rather than only on the screen that performed it.

## Changes

**E2E**

- `specs/contacts/` — spec + test function file, following the existing spec/run-function split
- `page/wallet/contacts.page.ts`, `page/wallet/contactDetail.page.ts` and `page/drawer/contactName.drawer.ts` — the list screen, the detail screen with its rename/delete sheets, and the shared name drawer, reachable as `app.contacts`, `app.contacts.detail` and `…renameDrawer`
- `userdata/contacts.json` — `skip-onboarding` plus `hasDismissedContactsFeatureIntroduction: true`, so the one-time "try Contacts" sheet never covers the list
- `libs/live-e2e-shared/src/contacts.ts` — `generateContactName`, shared with Desktop for the LWD half of the ticket. The fixed part exercises the separators `ContactNamePattern` allows *and* a user can type (space, `’`, `-`); the random suffix keeps names unique, since a duplicate name is rejected on save. The straight `'` is deliberately excluded — iOS smart punctuation rewrites it to `’` on input, so it can never be asserted back; `ContactNameSchema` covers that character in `schema.test.ts`.
- `waitForFullyVisibleById` — sheet arrivals wait for the sheet's own content anchor to be **fully** visible instead of Detox's default 75%. See "On the visibility threshold" below.

**Product code** (`@ledgerhq/wallet-xp`)

- testids on the contact name and address-count labels of the Me row, the saved contact rows and the detail header, so assertions can use `toHaveText` on the label itself instead of matching text through its row
- `ContactNameInput` gains an optional `testIDPrefix` (defaulting to today's ids) so each host names its own input. It hardcoded `contacts-add-contact-*`, which meant the rename drawer **and** the LWD rename dialog both identified their input as an add-contact one — visible in both Contacts integration tests, which reached for the add-contact input inside their rename case.
- one content anchor per sheet — `contacts-add-contact-content`, `contacts-rename-contact-content`, `contacts-delete-contact-content` — each rendered only while that sheet is open, so a test can say which sheet it is waiting for instead of keying off whichever control sits inside it

**Drive-by**

- `topbar-mywallet` was declared in three page objects. It belongs to the shared top bar, which `mainNavigation` already owns, so the duplicates are gone from `myWallet` and `portfolio` (the portfolio one was unused) and `mainNavigation.openMyWallet()` composes My Wallet's own arrival assertion. `wallet40Q2/myWallet.spec.ts` follows.

## On the visibility threshold

The sheets slide up from the bottom, and Detox's default expectation is "at least 75% visible", which a sliding sheet satisfies before it comes to rest. Acting on a sheet still in motion made the *next* step time out, which is why failures moved around between the actions menu and the delete confirmation.

Measured on a CPU-starved emulator (4 busy loops, throttled network):

| Wait | Result |
|---|---|
| default 75% | 2 fail / 4 |
| fully visible | 0 fail / 13 |

At the observed ~30% failure rate, 13 consecutive passes has probability ≈ 0.9%. iOS is unaffected and passes either way. Cost is ~4s per run: the test now waits for the animation instead of racing it.

## Notes

- The "no device confirmation" clause holds by construction: the app starts without a Speculos device, so any step requiring one would block instead of completing.
- The Ledger Sync precondition needs no setup yet — `useContactsPageViewModel` hardcodes `ledgerSyncStatus: "ready"`, so the Ledger Sync introduction sheet never shows. Worth revisiting when that is wired to the real trustchain state.
- Contacts cannot be seeded through userdata today (`loadConfig` only imports settings and accounts), so this test arranges its data through the create UI. That is deliberate — a seeded contact would not be the object the create flow produces — but an e2e-bridge seeding path is the natural next step for cases the UI cannot reach cheaply, such as the 8-contact cap on the Pay strip.
- Rebased onto develop after `feat(contacts): make add contact content embeddable`: the add flow now renders `ContactsAddContactContent` with its own `contacts-add-contact-save` button rather than the shared name drawer, so the page object drives it directly and `ContactNameDrawer` serves rename only. The detail header keeps upstream's `resolveMeContactDisplayName` from #21021 with the name testid on top.
- **Scope is LWDM, not LWM**: the `testIDPrefix` change reaches the web rename dialog and the Desktop Contacts integration test, even though only the mobile suite is automated here.

## Known gaps

- `contentTestID` is wired only for the delete host of `ContactConfirmationBottomSheet`; delete-address, edit-signer and signer-mismatch still have none.

## Test plan

- Mobile E2E, filtered to the affected specs — see the run linked in the comments
- Unit and integration suites green across every package that touches contacts: `ledger-live-desktop` Contacts 51, `ledger-live-mobile` Contacts 82, `flow-contacts` 186, `flow-contacts-list` 40, `flow-contacts-add-contact` 23, `entity-contact` 97
- e2e typecheck, lint and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[B2CQA-6238]: https://ledgerhq.atlassian.net/browse/B2CQA-6238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ