### PR TITLE
chore(knip): centralize dual-platform config (LIVE-36302)

### DIFF
--- a/.changeset/tidy-knip-configs-share.md
+++ b/.changeset/tidy-knip-configs-share.md
@@ -1,0 +1,9 @@
+---
+"@features/flow-contacts-add-address": patch
+"@features/platform-contacts": patch
+"@features/flow-contacts-add-contact": patch
+"@features/flow-contacts-introduction": patch
+"@features/flow-contacts-list": patch
+---
+
+Centralize dual-platform Knip configuration.

--- a/features/flow/flow-contacts-add-address/knip.web.config.mjs
+++ b/features/flow/flow-contacts-add-address/knip.web.config.mjs
@@ -1,20 +1,12 @@
-import { createRequire } from "node:module";
+import { createDualPlatformKnipConfig } from "../../../knip.config.base.mjs";
 
-const require = createRequire(import.meta.url);
-const rootConfig = require("../../../knip.json");
-
-export default {
-  ...rootConfig,
-  workspaces: {
-    ...rootConfig.workspaces,
-    "features/flow/flow-contacts-add-address": {
-      entry: [
-        "src/web.ts",
-        "src/screens/AddressEntry/components/ContactsAddAddressEntry/ContactsAddAddressEntry.web.tsx",
-        "src/screens/AddressEntry/components/ContactsAddAddressEntry/ContactsAddAddressEntry.types.web.ts",
-        "src/screens/AddressName/components/Input/ContactsAddAddressNameInput.web.tsx",
-      ],
-      project: ["src/**/*", "!src/**/*.native.*"],
-    },
-  },
-};
+export default createDualPlatformKnipConfig({
+  packagePath: "features/flow/flow-contacts-add-address",
+  platform: "web",
+  entry: [
+    "src/web.ts",
+    "src/screens/AddressEntry/components/ContactsAddAddressEntry/ContactsAddAddressEntry.web.tsx",
+    "src/screens/AddressEntry/components/ContactsAddAddressEntry/ContactsAddAddressEntry.types.web.ts",
+    "src/screens/AddressName/components/Input/ContactsAddAddressNameInput.web.tsx",
+  ],
+});

--- a/features/flow/flow-contacts-add-contact/knip.native.config.mjs
+++ b/features/flow/flow-contacts-add-contact/knip.native.config.mjs
@@ -1,0 +1,8 @@
+import { createDualPlatformKnipConfig } from "../../../knip.config.base.mjs";
+
+export default createDualPlatformKnipConfig({
+  packagePath: "features/flow/flow-contacts-add-contact",
+  platform: "native",
+  entry: ["src/index.native.ts"],
+  additionalProjectExcludes: ["src/index.ts", "src/**/web.ts"],
+});

--- a/features/flow/flow-contacts-add-contact/knip.web.config.mjs
+++ b/features/flow/flow-contacts-add-contact/knip.web.config.mjs
@@ -1,0 +1,8 @@
+import { createDualPlatformKnipConfig } from "../../../knip.config.base.mjs";
+
+export default createDualPlatformKnipConfig({
+  packagePath: "features/flow/flow-contacts-add-contact",
+  platform: "web",
+  entry: ["src/index.ts"],
+  additionalProjectExcludes: ["src/**/native.ts"],
+});

--- a/features/flow/flow-contacts-add-contact/package.json
+++ b/features/flow/flow-contacts-add-contact/package.json
@@ -18,11 +18,11 @@
   "scripts": {
     "format": "oxfmt src",
     "format:check": "oxfmt src --check",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit -p tsconfig.web.json && tsc --noEmit -p tsconfig.native.json",
     "test": "jest",
     "test:watch": "jest --watch",
     "coverage": "jest --coverage",
-    "unimported": "pnpm knip --directory ../../.. -W features/flow/flow-contacts-add-contact"
+    "unimported": "pnpm knip --directory ../../.. -c features/flow/flow-contacts-add-contact/knip.web.config.mjs -W features/flow/flow-contacts-add-contact --tsConfig tsconfig.web.json --isolate-workspaces && pnpm knip --directory ../../.. -c features/flow/flow-contacts-add-contact/knip.native.config.mjs -W features/flow/flow-contacts-add-contact --tsConfig tsconfig.native.json --isolate-workspaces"
   },
   "dependencies": {
     "@domain/entity-contact": "workspace:*",

--- a/features/flow/flow-contacts-add-contact/tsconfig.native.json
+++ b/features/flow/flow-contacts-add-contact/tsconfig.native.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleSuffixes": [".native", ""]
+  },
+  "include": ["src/**/*", "**/*.d.ts"],
+  "exclude": ["node_modules", "lib", "src/**/*.web.*", "src/index.ts", "src/**/web.ts"]
+}

--- a/features/flow/flow-contacts-add-contact/tsconfig.web.json
+++ b/features/flow/flow-contacts-add-contact/tsconfig.web.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleSuffixes": [".web", ""],
+    "types": ["jest", "@testing-library/jest-dom"]
+  },
+  "include": ["src/**/*", "**/*.d.ts"],
+  "exclude": ["node_modules", "lib", "src/**/*.native.*", "src/**/native.ts"]
+}

--- a/features/flow/flow-contacts-introduction/knip.native.config.mjs
+++ b/features/flow/flow-contacts-introduction/knip.native.config.mjs
@@ -1,11 +1,9 @@
 import { createDualPlatformKnipConfig } from "../../../knip.config.base.mjs";
 
 export default createDualPlatformKnipConfig({
-  packagePath: "features/flow/flow-contacts-add-address",
+  packagePath: "features/flow/flow-contacts-introduction",
   platform: "native",
-  entry: [
-    "src/index.native.ts",
-    "src/screens/AddressEntry/components/ContactsAddAddressEntry/ContactsAddAddressEntry.native.tsx",
-  ],
+  entry: ["src/index.native.ts"],
   additionalProjectExcludes: ["src/index.ts", "src/web.ts"],
+  additionalIgnoreDependencies: ["class-variance-authority", "clsx", "tailwind-merge"],
 });

--- a/features/flow/flow-contacts-introduction/knip.web.config.mjs
+++ b/features/flow/flow-contacts-introduction/knip.web.config.mjs
@@ -1,0 +1,8 @@
+import { createDualPlatformKnipConfig } from "../../../knip.config.base.mjs";
+
+export default createDualPlatformKnipConfig({
+  packagePath: "features/flow/flow-contacts-introduction",
+  platform: "web",
+  entry: ["src/web.ts"],
+  additionalIgnoreDependencies: ["class-variance-authority", "clsx", "tailwind-merge"],
+});

--- a/features/flow/flow-contacts-introduction/package.json
+++ b/features/flow/flow-contacts-introduction/package.json
@@ -21,7 +21,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.web.json && tsc --noEmit -p tsconfig.native.json",
     "test": "jest",
     "coverage": "jest --coverage",
-    "unimported": "pnpm knip --directory ../../.. -W features/flow/flow-contacts-introduction"
+    "unimported": "pnpm knip --directory ../../.. -c features/flow/flow-contacts-introduction/knip.web.config.mjs -W features/flow/flow-contacts-introduction --tsConfig tsconfig.web.json --isolate-workspaces && pnpm knip --directory ../../.. -c features/flow/flow-contacts-introduction/knip.native.config.mjs -W features/flow/flow-contacts-introduction --tsConfig tsconfig.native.json --isolate-workspaces"
   },
   "dependencies": {
     "class-variance-authority": "catalog:",

--- a/features/flow/flow-contacts-list/knip.native.config.mjs
+++ b/features/flow/flow-contacts-list/knip.native.config.mjs
@@ -1,11 +1,9 @@
 import { createDualPlatformKnipConfig } from "../../../knip.config.base.mjs";
 
 export default createDualPlatformKnipConfig({
-  packagePath: "features/flow/flow-contacts-add-address",
+  packagePath: "features/flow/flow-contacts-list",
   platform: "native",
-  entry: [
-    "src/index.native.ts",
-    "src/screens/AddressEntry/components/ContactsAddAddressEntry/ContactsAddAddressEntry.native.tsx",
-  ],
+  entry: ["src/index.native.ts"],
   additionalProjectExcludes: ["src/index.ts", "src/web.ts"],
+  additionalIgnoreDependencies: ["class-variance-authority", "clsx", "tailwind-merge"],
 });

--- a/features/flow/flow-contacts-list/knip.web.config.mjs
+++ b/features/flow/flow-contacts-list/knip.web.config.mjs
@@ -1,0 +1,8 @@
+import { createDualPlatformKnipConfig } from "../../../knip.config.base.mjs";
+
+export default createDualPlatformKnipConfig({
+  packagePath: "features/flow/flow-contacts-list",
+  platform: "web",
+  entry: ["src/web.ts"],
+  additionalIgnoreDependencies: ["class-variance-authority", "clsx", "tailwind-merge"],
+});

--- a/features/flow/flow-contacts-list/package.json
+++ b/features/flow/flow-contacts-list/package.json
@@ -18,10 +18,10 @@
   "scripts": {
     "format": "oxfmt src",
     "format:check": "oxfmt src --check",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit -p tsconfig.web.json && tsc --noEmit -p tsconfig.native.json",
     "test": "jest",
     "coverage": "jest --coverage",
-    "unimported": "pnpm knip --directory ../../.. -W features/flow/flow-contacts-list"
+    "unimported": "pnpm knip --directory ../../.. -c features/flow/flow-contacts-list/knip.web.config.mjs -W features/flow/flow-contacts-list --tsConfig tsconfig.web.json --isolate-workspaces && pnpm knip --directory ../../.. -c features/flow/flow-contacts-list/knip.native.config.mjs -W features/flow/flow-contacts-list --tsConfig tsconfig.native.json --isolate-workspaces"
   },
   "dependencies": {
     "@domain/entity-contact": "workspace:*",

--- a/features/flow/flow-contacts-list/tsconfig.native.json
+++ b/features/flow/flow-contacts-list/tsconfig.native.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleSuffixes": [".native", ""]
+  },
+  "include": ["src/**/*", "**/*.d.ts"],
+  "exclude": ["node_modules", "lib", "src/**/*.web.*", "src/index.ts", "src/web.ts"]
+}

--- a/features/flow/flow-contacts-list/tsconfig.web.json
+++ b/features/flow/flow-contacts-list/tsconfig.web.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleSuffixes": [".web", ""],
+    "types": ["jest", "@testing-library/jest-dom"]
+  },
+  "include": ["src/**/*", "**/*.d.ts"],
+  "exclude": ["node_modules", "lib", "src/**/*.native.*"]
+}

--- a/features/platform/contacts/knip.native.config.mjs
+++ b/features/platform/contacts/knip.native.config.mjs
@@ -1,15 +1,8 @@
-import { createRequire } from "node:module";
+import { createDualPlatformKnipConfig } from "../../../knip.config.base.mjs";
 
-const require = createRequire(import.meta.url);
-const rootConfig = require("../../../knip.json");
-
-export default {
-  ...rootConfig,
-  workspaces: {
-    ...rootConfig.workspaces,
-    "features/platform/contacts": {
-      entry: ["src/index.native.ts", "src/device/intents/index.ts"],
-      project: ["src/**/*", "!src/**/*.web.*", "!src/index.ts", "!src/web.ts"],
-    },
-  },
-};
+export default createDualPlatformKnipConfig({
+  packagePath: "features/platform/contacts",
+  platform: "native",
+  entry: ["src/index.native.ts", "src/device/intents/index.ts"],
+  additionalProjectExcludes: ["src/index.ts", "src/web.ts"],
+});

--- a/features/platform/contacts/knip.web.config.mjs
+++ b/features/platform/contacts/knip.web.config.mjs
@@ -1,15 +1,8 @@
-import { createRequire } from "node:module";
+import { createDualPlatformKnipConfig } from "../../../knip.config.base.mjs";
 
-const require = createRequire(import.meta.url);
-const rootConfig = require("../../../knip.json");
-
-export default {
-  ...rootConfig,
-  workspaces: {
-    ...rootConfig.workspaces,
-    "features/platform/contacts": {
-      entry: ["src/index.ts", "src/web.ts", "src/device/intents/index.ts"],
-      project: ["src/**/*", "!src/**/*.native.*", "!src/index.native.ts"],
-    },
-  },
-};
+export default createDualPlatformKnipConfig({
+  packagePath: "features/platform/contacts",
+  platform: "web",
+  entry: ["src/index.ts", "src/web.ts", "src/device/intents/index.ts"],
+  additionalProjectExcludes: ["src/index.native.ts"],
+});

--- a/knip.config.base.mjs
+++ b/knip.config.base.mjs
@@ -1,0 +1,56 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const rootConfig = require("./knip.json");
+
+/**
+ * Creates a Knip configuration for one platform of a dual-platform package.
+ *
+ * @param {{
+ *   packagePath: string;
+ *   platform: "native" | "web";
+ *   entry: string[];
+ *   additionalProjectExcludes?: string[];
+ *   additionalIgnoreDependencies?: string[];
+ * }} options
+ * `additionalProjectExcludes` values must omit the leading `!`.
+ * @example
+ * createDualPlatformKnipConfig({
+ *   packagePath: "features/flow/example",
+ *   platform: "web",
+ *   entry: ["src/index.ts"],
+ * });
+ */
+export function createDualPlatformKnipConfig({
+  packagePath,
+  platform,
+  entry,
+  additionalProjectExcludes = [],
+  additionalIgnoreDependencies = [],
+}) {
+  const platformProjectExclude = platform === "web" ? "!src/**/*.native.*" : "!src/**/*.web.*";
+  const workspace = {
+    ...rootConfig.workspaces[packagePath],
+    entry,
+    project: [
+      "src/**/*",
+      platformProjectExclude,
+      ...additionalProjectExcludes.map(pattern => `!${pattern}`),
+    ],
+  };
+
+  if (additionalIgnoreDependencies.length > 0) {
+    workspace.ignoreDependencies = [
+      ...(rootConfig.workspaces[packagePath]?.ignoreDependencies ?? []),
+      ...additionalIgnoreDependencies,
+    ];
+  }
+
+  return {
+    ...rootConfig,
+    workspaces: {
+      ...rootConfig.workspaces,
+      [packagePath]: workspace,
+    },
+  };
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Ran the affected Jest suites, web/native typechecks, and isolated web/native Knip checks.
- [x] **Impact of the changes:**
      Add Address, Platform Contacts, Add Contact, Contacts Introduction, and Contacts List now share the same dual-platform Knip configuration pattern. Required Lumen peer dependencies remain declared and are explicitly ignored by isolated Knip checks.

### 📝 Description

This PR introduces a root-level factory for dual-platform Knip configurations. It preserves the shared root rules and workspace overrides while accepting package-specific entries and platform exclusions.

The factory is used by Add Address, Platform Contacts, Add Contact, Contacts Introduction, and Contacts List. Add Contact and Contacts List now use separate web and native TypeScript programs, so each Knip invocation resolves the correct platform files in isolation.

Contacts Introduction and Contacts List keep the Lumen UI React peer dependencies required by consumers. Their isolated Knip configurations explicitly ignore these dependencies because their usage is transitive through Lumen.

`@features/flow-contacts` is intentionally not migrated here: its web and native package-resolution incompatibilities need a dedicated follow-up before enabling isolated platform typechecks.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-36302](https://ledgerhq.atlassian.net/browse/LIVE-36302)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-36302]: https://ledgerhq.atlassian.net/browse/LIVE-36302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ