### PR TITLE
fix(bottom-sheet): enable reopening of queued sheets (LIVE-35790)

### DIFF
--- a/.changeset/LIVE-35790-sheet-reopen.md
+++ b/.changeset/LIVE-35790-sheet-reopen.md
@@ -1,0 +1,7 @@
+---
+"@shared/ui-queued-bottom-sheet": patch
+"@features/flow-contacts": patch
+"live-mobile": patch
+---
+
+Fix mobile bottom sheets that could not be reopened after being closed.

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.test.tsx
@@ -117,16 +117,7 @@ describe("useContactAddressDetailActionsAdapter", () => {
       result.current.actions.renameSheet.onClose();
     });
 
-    expect(result.current.addressDetail.isOpen).toBe(false);
-
-    act(() => {
-      result.current.addressDetail.onAddressRowPress({
-        type: "open-address-detail",
-        contactId: contact.id,
-        addressId: address.id,
-      });
-    });
-
+    expect(result.current.actions.renameSheet.isOpen).toBe(false);
     expect(result.current.addressDetail.isOpen).toBe(true);
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.ts
@@ -144,14 +144,15 @@ export function useContactAddressDetailActionsAdapter(
   });
   const { onClose: closeRenameViewModel } = renameViewModel;
   const { editUiState } = flow;
+  // Closing the edit sheet returns to the address detail it was opened from, the same way
+  // cancelling the delete confirmation does. The selection is kept so that sheet has an address.
   const onCloseRename = useCallback(() => {
     if (editUiState !== "edit-open") {
       return;
     }
 
     closeRenameViewModel();
-    onCloseAddressDetail();
-  }, [closeRenameViewModel, editUiState, onCloseAddressDetail]);
+  }, [closeRenameViewModel, editUiState]);
   const onEdit = useCallback(() => {
     trackQuickAction(CONTACTS_TRACKING_BUTTON.edit);
     flow.onEditPress();

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactAddressDetailDialogSheet/index.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactAddressDetailDialogSheet/index.test.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { render } from "@tests/test-renderer";
+import type { ContactAddressDetailDialogNativeProps } from "@features/flow-contacts";
+import { ContactAddressDetailDialogSheet } from ".";
+
+const queuedBottomSheetProps = jest.fn();
+
+jest.mock("@shared/ui-queued-bottom-sheet", () => ({
+  ...jest.requireActual("@shared/ui-queued-bottom-sheet"),
+  QueuedBottomSheet: (props: Record<string, unknown>) => {
+    queuedBottomSheetProps(props);
+    return null;
+  },
+}));
+
+const dialogProps = {
+  contactName: "Ben",
+  labels: { formatNetworkTag: (name: string) => name },
+  onClose: () => undefined,
+} as unknown as ContactAddressDetailDialogNativeProps;
+
+describe("ContactAddressDetailDialogSheet", () => {
+  beforeEach(() => {
+    queuedBottomSheetProps.mockClear();
+  });
+
+  it("should request to be opened when an address is selected", () => {
+    render(<ContactAddressDetailDialogSheet {...dialogProps} isOpen isActionSheetOpen={false} />);
+
+    expect(queuedBottomSheetProps).toHaveBeenCalledWith(
+      expect.objectContaining({ isRequestingToBeOpened: true }),
+    );
+  });
+
+  // Staying in the queue behind an action sheet is what left an empty sheet on screen: the queue
+  // promotes whatever is waiting before React has seen that the selection is gone.
+  it("should stop requesting to be opened while an action sheet is open", () => {
+    render(<ContactAddressDetailDialogSheet {...dialogProps} isOpen isActionSheetOpen />);
+
+    expect(queuedBottomSheetProps).toHaveBeenCalledWith(
+      expect.objectContaining({ isRequestingToBeOpened: false }),
+    );
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactAddressDetailDialogSheet/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactAddressDetailDialogSheet/index.tsx
@@ -8,11 +8,15 @@ import { Share } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { QueuedBottomSheet } from "@shared/ui-queued-bottom-sheet";
 
+type ContactAddressDetailDialogSheetProps = ContactAddressDetailDialogNativeProps &
+  Readonly<{ isActionSheetOpen: boolean }>;
+
 export function ContactAddressDetailDialogSheet({
   isOpen,
+  isActionSheetOpen,
   onClose,
   ...dialogProps
-}: ContactAddressDetailDialogNativeProps): React.JSX.Element {
+}: ContactAddressDetailDialogSheetProps): React.JSX.Element {
   const { bottom: bottomInset } = useSafeAreaInsets();
   const onCopyAddress = useCallback((address: string) => {
     Clipboard.setString(address);
@@ -21,9 +25,12 @@ export function ContactAddressDetailDialogSheet({
     void Share.share({ message: address }).catch(() => undefined);
   }, []);
 
+  // While an action sheet owns the screen this sheet must not sit in the queue. Closing that action
+  // sheet can also clear the selection, and the queue promotes whatever is waiting behind it before
+  // React sees that, which would leave an empty sheet the user has to dismiss to reach the app.
   return (
     <QueuedBottomSheet
-      isRequestingToBeOpened={isOpen}
+      isRequestingToBeOpened={isOpen && !isActionSheetOpen}
       onClose={onClose}
       testID="contacts-address-detail-sheet"
       enableDynamicSizing

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactDetailEditDeleteSheets/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactDetailEditDeleteSheets/index.tsx
@@ -28,11 +28,7 @@ export function ContactDetailEditDeleteSheets({
   const keyboardInset = shouldUseKeyboardAvoidance(Platform.OS, Platform.Version)
     ? keyboardHeight
     : 0;
-  const {
-    onClose: onCloseActionsMenuFromMenu,
-    onHidden: onActionsMenuHidden,
-    ...actionsMenuProps
-  } = actionsMenu;
+  const { onClose: onCloseActionsMenuFromMenu, ...actionsMenuProps } = actionsMenu;
   const onCloseActionsMenu = useCallback(() => {
     onCloseActionsMenuFromMenu();
   }, [onCloseActionsMenuFromMenu]);
@@ -51,7 +47,6 @@ export function ContactDetailEditDeleteSheets({
       <QueuedBottomSheet
         isRequestingToBeOpened={actionsMenu.isOpen}
         onClose={onCloseActionsMenu}
-        onModalHide={onActionsMenuHidden}
         testID="contacts-detail-actions-sheet"
         enableDynamicSizing
       >
@@ -72,6 +67,7 @@ export function ContactDetailEditDeleteSheets({
       </QueuedBottomSheet>
       <QueuedBottomSheet
         isRequestingToBeOpened={deleteDrawer.isOpen}
+        isForcingToBeOpened={deleteDrawer.isOpen}
         onClose={onCloseDelete}
         testID="contacts-delete-contact-sheet"
         enableDynamicSizing

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/hooks/useContactDetailEditDeleteAdapter.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/hooks/useContactDetailEditDeleteAdapter.test.tsx
@@ -1,0 +1,78 @@
+import React, { type ReactNode } from "react";
+import { configureStore } from "@reduxjs/toolkit";
+import { act, renderHook } from "@testing-library/react-native";
+import { Provider } from "react-redux";
+import { contactsSlice } from "@domain/entity-contact";
+import { mockContactWithAddress } from "@domain/entity-contact/schema.mock";
+import { useContactDetailEditDeleteAdapter } from "./useContactDetailEditDeleteAdapter";
+
+jest.mock("../../../analytics/useContactsAnalytics", () => ({
+  useContactsAnalytics: () => ({
+    trackEvent: jest.fn(),
+    trackPage: jest.fn(),
+    getGlobalProperties: jest.fn(),
+  }),
+}));
+
+function makeWrapper(contacts: ReturnType<typeof contactsSlice.getInitialState>["contacts"]) {
+  const store = configureStore({
+    reducer: { contacts: contactsSlice.reducer },
+    preloadedState: { contacts: { contacts } },
+  });
+
+  return function Wrapper({ children }: { readonly children: ReactNode }) {
+    return <Provider store={store}>{children}</Provider>;
+  };
+}
+
+describe("useContactDetailEditDeleteAdapter", () => {
+  it("should open the delete confirmation on press, without any sheet lifecycle callback", () => {
+    const contact = mockContactWithAddress();
+    const Wrapper = makeWrapper([contact]);
+    const { result } = renderHook(() => useContactDetailEditDeleteAdapter(contact.id, jest.fn()), {
+      wrapper: Wrapper,
+    });
+
+    act(() => {
+      result.current.onOpenActionsMenu();
+    });
+    expect(result.current.actionsMenu.isOpen).toBe(true);
+
+    act(() => {
+      result.current.actionsMenu.onDelete();
+    });
+
+    expect(result.current.actionsMenu.isOpen).toBe(false);
+    expect(result.current.deleteDrawer.isOpen).toBe(true);
+  });
+
+  it("should reopen the delete confirmation after cancelling it", () => {
+    const contact = mockContactWithAddress();
+    const Wrapper = makeWrapper([contact]);
+    const { result } = renderHook(() => useContactDetailEditDeleteAdapter(contact.id, jest.fn()), {
+      wrapper: Wrapper,
+    });
+
+    act(() => {
+      result.current.onOpenActionsMenu();
+    });
+    act(() => {
+      result.current.actionsMenu.onDelete();
+    });
+    expect(result.current.deleteDrawer.isOpen).toBe(true);
+
+    act(() => {
+      result.current.deleteDrawer.onCancel();
+    });
+    expect(result.current.deleteDrawer.isOpen).toBe(false);
+
+    act(() => {
+      result.current.onOpenActionsMenu();
+    });
+    act(() => {
+      result.current.actionsMenu.onDelete();
+    });
+
+    expect(result.current.deleteDrawer.isOpen).toBe(true);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/hooks/useContactDetailEditDeleteAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/hooks/useContactDetailEditDeleteAdapter.ts
@@ -4,10 +4,6 @@ import {
   type ContactsEditSignerDrawerProps,
   type ContactsEditSignerMismatchDrawerProps,
   type ContactDetailActionsLabels,
-  CONTACTS_EVENT_SOURCE,
-  CONTACTS_PAGE_PROPERTY,
-  CONTACTS_TRACK_EVENTS,
-  CONTACTS_TRACKING_BUTTON,
   createContactDetailEditDeleteUiState,
   resolveContactDetailEditDeleteLabels,
   useContactDetailEditDeleteAnalytics,
@@ -15,7 +11,7 @@ import {
   useContactsEditDeletePorts,
 } from "@features/flow-contacts";
 import type { ContactsRenameContactDrawerProps } from "@features/flow-contacts-edit-contact";
-import { useCallback, useMemo, useRef } from "react";
+import { useMemo } from "react";
 import { useTranslation } from "~/context/Locale";
 import { useContactsAnalytics } from "../../../analytics/useContactsAnalytics";
 
@@ -27,7 +23,6 @@ export type ContactDetailEditDeleteFlowProps = Readonly<{
     onEdit: () => void;
     onDelete: () => void;
     onClose: () => void;
-    onHidden: () => void;
   }>;
   renameDrawer: ContactsRenameContactDrawerProps;
   deleteDrawer: ContactsDeleteContactDrawerProps;
@@ -61,7 +56,7 @@ export function useContactDetailEditDeleteAdapter(
     () => createContactDetailEditDeleteUiState(flow, renameViewModel, labels),
     [flow, labels, renameViewModel],
   );
-  const { onEdit } = useContactDetailEditDeleteAnalytics(
+  const { onEdit, onDelete } = useContactDetailEditDeleteAnalytics(
     analytics,
     {
       onEditPress: flow.onEditPress,
@@ -70,24 +65,6 @@ export function useContactDetailEditDeleteAdapter(
     },
     uiState.signerMismatch.isOpen,
   );
-  const pendingDeleteRef = useRef(false);
-  const onDelete = useCallback(() => {
-    analytics.trackEvent(CONTACTS_TRACK_EVENTS.BUTTON_CLICKED, {
-      source: CONTACTS_EVENT_SOURCE.CONTACT_DETAIL,
-      button: CONTACTS_TRACKING_BUTTON.deleteContact,
-      page: CONTACTS_PAGE_PROPERTY.CONTACT_DETAIL,
-    });
-    pendingDeleteRef.current = true;
-    flow.onDeletePress();
-  }, [analytics, flow]);
-  const onActionsMenuHidden = useCallback(() => {
-    if (!pendingDeleteRef.current) {
-      return;
-    }
-
-    pendingDeleteRef.current = false;
-    flow.openDelete();
-  }, [flow]);
 
   return {
     onOpenActionsMenu: flow.onOpenActionsMenu,
@@ -98,7 +75,6 @@ export function useContactDetailEditDeleteAdapter(
       onEdit,
       onDelete,
       onClose: flow.onCloseActionsMenu,
-      onHidden: onActionsMenuHidden,
     },
     renameDrawer: uiState.rename,
     deleteDrawer: uiState.delete,

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/index.tsx
@@ -25,7 +25,10 @@ export function ContactDetailScreen(): React.JSX.Element | null {
       {viewModel.addAddressFlowState.status !== "closed" ? (
         <ContactsAddAddressFlowDrawer {...viewModel.addAddressFlowProps} />
       ) : null}
-      <ContactAddressDetailDialogSheet {...viewModel.addressDetailDialog} />
+      <ContactAddressDetailDialogSheet
+        {...viewModel.addressDetailDialog}
+        isActionSheetOpen={viewModel.isAddressDetailActionSheetOpen}
+      />
       <ContactAddressDetailActionsSheets
         deleteSheet={viewModel.addressDetailActions.deleteSheet}
         renameSheet={viewModel.addressDetailActions.renameSheet}

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
@@ -66,6 +66,7 @@ type ContactDetailScreenViewModel =
       addAddressFlowProps: ContactsAddAddressFlowDrawerProps;
       pageProps: ContactDetailViewProps;
       addressDetailDialog: ContactAddressDetailDialogNativeProps;
+      isAddressDetailActionSheetOpen: boolean;
       addressDetailActions: ReturnType<typeof useContactAddressDetailActionsAdapter>;
       editDeleteFlow: ContactDetailEditDeleteFlowProps;
       ledgerSyncIntroduction: ContactsLedgerSyncIntroduction;
@@ -343,24 +344,18 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
     addressDetailAsset,
     addressDetailNetwork,
   );
+  const isAddressDetailActionSheetOpen =
+    addressDetailActions.deleteSheet.isOpen ||
+    addressDetailActions.renameSheet.isOpen ||
+    addressDetailActions.signerSheet.isOpen ||
+    addressDetailActions.signerMismatchSheet.isOpen;
   const onCloseAddressDetailSheet = useCallback(() => {
-    if (
-      addressDetailActions.deleteSheet.isOpen ||
-      addressDetailActions.renameSheet.isOpen ||
-      addressDetailActions.signerSheet.isOpen ||
-      addressDetailActions.signerMismatchSheet.isOpen
-    ) {
+    if (isAddressDetailActionSheetOpen) {
       return;
     }
 
     onCloseAddressDetail();
-  }, [
-    addressDetailActions.deleteSheet.isOpen,
-    addressDetailActions.renameSheet.isOpen,
-    addressDetailActions.signerSheet.isOpen,
-    addressDetailActions.signerMismatchSheet.isOpen,
-    onCloseAddressDetail,
-  ]);
+  }, [isAddressDetailActionSheetOpen, onCloseAddressDetail]);
   const shouldRedirect = !isEnabled || !contact;
 
   useEffect(() => {
@@ -461,6 +456,7 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
       onClose: onCloseAddressDetailSheet,
       ...addressDetailActions.addressDetailDialog,
     },
+    isAddressDetailActionSheetOpen,
     addressDetailActions,
     editDeleteFlow,
     ledgerSyncIntroduction: {

--- a/shared/ui-queued-bottom-sheet/src/components/QueuedBottomSheet/QueuedBottomSheet.native.tsx
+++ b/shared/ui-queued-bottom-sheet/src/components/QueuedBottomSheet/QueuedBottomSheet.native.tsx
@@ -7,6 +7,9 @@ import { BottomSheetBackgroundContext } from "../../contexts/BottomSheetBackgrou
 import { useQueuedBottomSheet } from "../../internals/useQueuedBottomSheet";
 import type { QueuedBottomSheetProps } from "./types";
 
+// Default "switch" only minimizes the outgoing sheet. Lumen forwards this to gorhom.
+const replaceStackBehavior = { stackBehavior: "replace" } as const;
+
 export function QueuedBottomSheet({
   isRequestingToBeOpened = false,
   isForcingToBeOpened = false,
@@ -34,7 +37,7 @@ export function QueuedBottomSheet({
     handleBackdropPress,
     handleHeaderClosePressed,
     handleDismiss,
-    handleCloseAnimationStart,
+    handleAnimate,
     onBack: hookOnBack,
     enablePanDownToClose: computedEnablePanDownToClose,
     backgroundContextValue,
@@ -52,6 +55,7 @@ export function QueuedBottomSheet({
 
   return (
     <BottomSheet
+      {...replaceStackBehavior}
       ref={bottomSheetRef}
       testID={testID}
       snapPoints={enableDynamicSizing ? null : snapPoints}
@@ -64,7 +68,7 @@ export function QueuedBottomSheet({
       hideHandle={hideHandle}
       onBack={hasBackButton ? hookOnBack : undefined}
       onHeaderClosePressed={handleHeaderClosePressed}
-      onAnimate={handleCloseAnimationStart}
+      onAnimate={handleAnimate}
       onDismiss={handleDismiss}
       backdropPressBehavior={preventBackdropClick || areBottomSheetsLocked ? "none" : "close"}
       onBackdropPress={handleBackdropPress}

--- a/shared/ui-queued-bottom-sheet/src/components/QueuedBottomSheet/types.ts
+++ b/shared/ui-queued-bottom-sheet/src/components/QueuedBottomSheet/types.ts
@@ -1,7 +1,7 @@
 import type React from "react";
 import type { BottomSheetProps } from "@ledgerhq/lumen-ui-rnative";
 
-export type QueuedBottomSheetProps = {
+export type QueuedBottomSheetProps = Readonly<{
   /** Whether this drawer is requesting to be opened (queued). */
   isRequestingToBeOpened?: boolean;
   /** Whether this drawer should force-open (clears queue). */
@@ -47,4 +47,4 @@ export type QueuedBottomSheetProps = {
   testID?: string;
   /** Content of the drawer. */
   children: React.ReactNode;
-};
+}>;

--- a/shared/ui-queued-bottom-sheet/src/components/QueuedBottomSheetsProvider/QueuedBottomSheetsProvider.native.test.tsx
+++ b/shared/ui-queued-bottom-sheet/src/components/QueuedBottomSheetsProvider/QueuedBottomSheetsProvider.native.test.tsx
@@ -114,6 +114,26 @@ describe("QueuedBottomSheetsProvider", () => {
     expect(handlers3.open).toHaveBeenCalledTimes(1);
   });
 
+  it("opens the forced drawer when the closing drawer frees its slot synchronously", () => {
+    const { result } = renderQueue();
+    const handlers2 = createHandlers();
+    let handle1!: ReturnType<typeof result.current.addBottomSheetToQueue>;
+
+    const handlers1 = createHandlers();
+    handlers1.close.mockImplementation(() => handle1.removeBottomSheetFromQueue());
+
+    act(() => {
+      handle1 = result.current.addBottomSheetToQueue(handlers1, false);
+    });
+
+    act(() => {
+      result.current.addBottomSheetToQueue(handlers2, true);
+    });
+
+    expect(handlers1.close).toHaveBeenCalledTimes(1);
+    expect(handlers2.open).toHaveBeenCalledTimes(1);
+  });
+
   it("closeAllBottomSheets closes every drawer and empties the queue", () => {
     const { result } = renderQueue();
     const handlers1 = createHandlers();

--- a/shared/ui-queued-bottom-sheet/src/components/QueuedBottomSheetsProvider/QueuedBottomSheetsProvider.tsx
+++ b/shared/ui-queued-bottom-sheet/src/components/QueuedBottomSheetsProvider/QueuedBottomSheetsProvider.tsx
@@ -14,11 +14,11 @@ type QueueItem = {
   markedForClose?: boolean;
 };
 
-type Props = {
+type Props = Readonly<{
   /** App-specific behaviour. Must be stable across renders. Defaults to a no-op set. */
   adapters?: QueuedBottomSheetAdapters;
   children: React.ReactNode;
-};
+}>;
 
 export function QueuedBottomSheetsProvider({
   adapters = defaultQueuedBottomSheetAdapters,
@@ -56,16 +56,13 @@ export function QueuedBottomSheetsProvider({
           "addBottomSheetToQueue -> force close opened & queued drawers, and clear queue",
           id,
         );
-        const previousQueue = queueRef.current;
-        if (previousQueue.length > 0) {
-          previousQueue[0].stateHandlers.close();
-        }
-        queueRef.current =
-          previousQueue.length > 0
-            ? [{ ...previousQueue[0], markedForClose: true }, newQueueItem]
-            : [newQueueItem];
+        const [openedItem, ...queuedItems] = queueRef.current;
+        queueRef.current = openedItem
+          ? [{ ...openedItem, markedForClose: true }, newQueueItem]
+          : [newQueueItem];
         // The forced drawer opens once the first (marked-for-close) item is removed from the queue.
-        for (const queueItem of previousQueue.slice(1)) {
+        openedItem?.stateHandlers.close();
+        for (const queueItem of queuedItems) {
           queueItem.stateHandlers.close();
         }
       } else {

--- a/shared/ui-queued-bottom-sheet/src/internals/useQueuedBottomSheet.native.test.ts
+++ b/shared/ui-queued-bottom-sheet/src/internals/useQueuedBottomSheet.native.test.ts
@@ -85,10 +85,10 @@ describe("useQueuedBottomSheet", () => {
     expect(mockDismiss).toHaveBeenCalled();
   });
 
-  it("does not remove from queue on close signal, only when handleDismiss fires after animation", () => {
+  it("frees its queue slot on the close signal rather than waiting for handleDismiss", () => {
     const { signalOpen, signalClose } = setupBottomSheetStateCapture();
 
-    const { result } = renderHook(() =>
+    renderHook(() =>
       useQueuedBottomSheet({
         isRequestingToBeOpened: true,
       }),
@@ -96,11 +96,6 @@ describe("useQueuedBottomSheet", () => {
 
     signalOpen();
     signalClose();
-    expect(mockRemoveBottomSheetFromQueue).not.toHaveBeenCalled();
-
-    act(() => {
-      result.current.handleDismiss();
-    });
 
     expect(mockRemoveBottomSheetFromQueue).toHaveBeenCalledTimes(1);
   });
@@ -167,7 +162,7 @@ describe("useQueuedBottomSheet", () => {
     expect(mockDismiss).not.toHaveBeenCalled();
   });
 
-  it("does not call removeBottomSheetFromQueue on close signal until handleDismiss fires", () => {
+  it("frees its queue slot only once when handleDismiss follows the close signal", () => {
     const { signalOpen, signalClose } = setupBottomSheetStateCapture();
 
     const { result } = renderHook(() =>
@@ -181,7 +176,7 @@ describe("useQueuedBottomSheet", () => {
 
     signalClose();
     expect(mockDismiss).toHaveBeenCalledTimes(1);
-    expect(mockRemoveBottomSheetFromQueue).not.toHaveBeenCalled();
+    expect(mockRemoveBottomSheetFromQueue).toHaveBeenCalledTimes(1);
 
     act(() => {
       result.current.handleDismiss();
@@ -189,7 +184,7 @@ describe("useQueuedBottomSheet", () => {
     expect(mockRemoveBottomSheetFromQueue).toHaveBeenCalledTimes(1);
   });
 
-  it("does not call removeBottomSheetFromQueue when handleClose is invoked multiple times before handleDismiss", () => {
+  it("frees its queue slot only once when handleClose is invoked repeatedly", () => {
     const { signalOpen, signalClose } = setupBottomSheetStateCapture();
 
     const { result } = renderHook(() =>
@@ -203,10 +198,10 @@ describe("useQueuedBottomSheet", () => {
 
     signalClose();
     expect(mockDismiss).toHaveBeenCalledTimes(1);
-    expect(mockRemoveBottomSheetFromQueue).not.toHaveBeenCalled();
+    expect(mockRemoveBottomSheetFromQueue).toHaveBeenCalledTimes(1);
 
     signalClose();
-    expect(mockRemoveBottomSheetFromQueue).not.toHaveBeenCalled();
+    expect(mockRemoveBottomSheetFromQueue).toHaveBeenCalledTimes(1);
 
     act(() => {
       result.current.handleDismiss();
@@ -214,7 +209,7 @@ describe("useQueuedBottomSheet", () => {
     expect(mockRemoveBottomSheetFromQueue).toHaveBeenCalledTimes(1);
   });
 
-  it("does not call removeBottomSheetFromQueue when effect cleanup fires during dismiss animation", () => {
+  it("frees its queue slot only once when effect cleanup fires during the dismiss animation", () => {
     const { signalOpen, signalClose } = setupBottomSheetStateCapture();
     let isRequestingToBeOpened = true;
 
@@ -225,16 +220,60 @@ describe("useQueuedBottomSheet", () => {
 
     signalClose();
     expect(mockDismiss).toHaveBeenCalledTimes(1);
-    expect(mockRemoveBottomSheetFromQueue).not.toHaveBeenCalled();
+    expect(mockRemoveBottomSheetFromQueue).toHaveBeenCalledTimes(1);
 
     isRequestingToBeOpened = false;
     rerender(undefined);
-    expect(mockRemoveBottomSheetFromQueue).not.toHaveBeenCalled();
+    expect(mockRemoveBottomSheetFromQueue).toHaveBeenCalledTimes(1);
 
     act(() => {
       result.current.handleDismiss();
     });
     expect(mockRemoveBottomSheetFromQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("settles itself as closed when onDismiss never arrives", () => {
+    jest.useFakeTimers();
+    try {
+      const { signalOpen, signalClose } = setupBottomSheetStateCapture();
+
+      renderHook(() => useQueuedBottomSheet({ isRequestingToBeOpened: true }));
+
+      signalOpen();
+      expect(mockPresent).toHaveBeenCalledTimes(1);
+
+      signalClose();
+
+      signalOpen();
+      expect(mockPresent).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      signalOpen();
+      expect(mockPresent).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("declines a queue promotion once the consumer has stopped requesting it", () => {
+    const { signalOpen } = setupBottomSheetStateCapture();
+    let isRequestingToBeOpened = true;
+
+    const { rerender } = renderHook(() => useQueuedBottomSheet({ isRequestingToBeOpened }));
+
+    expect(mockAddBottomSheetToQueue).toHaveBeenCalledTimes(1);
+
+    // The sheet ahead of us closed and the same interaction cleared our own reason to be open.
+    // Presenting now would leave an empty sheet on screen that swallows the next tap.
+    isRequestingToBeOpened = false;
+    rerender(undefined);
+    signalOpen();
+
+    expect(mockPresent).not.toHaveBeenCalled();
+    expect(mockRemoveBottomSheetFromQueue).toHaveBeenCalled();
   });
 
   it("cleans up the queue immediately when closed without ever being presented", () => {
@@ -392,7 +431,7 @@ describe("useQueuedBottomSheet", () => {
 
     // X button / backdrop / pan-down all animate towards index -1.
     act(() => {
-      result.current.handleCloseAnimationStart(0, -1);
+      result.current.handleAnimate(0, -1);
     });
     expect(onClose).toHaveBeenCalledTimes(1);
 
@@ -426,7 +465,7 @@ describe("useQueuedBottomSheet", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
 
     act(() => {
-      result.current.handleCloseAnimationStart(0, -1);
+      result.current.handleAnimate(0, -1);
       result.current.handleDismiss();
     });
 
@@ -448,11 +487,122 @@ describe("useQueuedBottomSheet", () => {
     signalOpen();
 
     act(() => {
-      result.current.handleCloseAnimationStart(-1, 0); // opening
-      result.current.handleCloseAnimationStart(0, 1); // expanding to a higher snap point
+      result.current.handleAnimate(-1, 0); // opening
+      result.current.handleAnimate(0, 1); // expanding to a higher snap point
     });
 
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("dismisses a minimized sheet that the modal stack restores behind our back", () => {
+    const onClose = jest.fn();
+    const { signalOpen, signalClose } = setupBottomSheetStateCapture();
+
+    const { result } = renderHook(() =>
+      useQueuedBottomSheet({
+        isRequestingToBeOpened: true,
+        onClose,
+      }),
+    );
+
+    signalOpen();
+    act(() => {
+      result.current.handleAnimate(-1, 0);
+    });
+
+    act(() => {
+      result.current.handleAnimate(0, -1);
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockDismiss).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.handleAnimate(-1, 0);
+    });
+
+    expect(mockDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("still dismisses a sheet that the modal stack minimized behind our back", () => {
+    const onClose = jest.fn();
+    const { signalOpen, signalClose } = setupBottomSheetStateCapture();
+
+    const { result } = renderHook(() =>
+      useQueuedBottomSheet({
+        isRequestingToBeOpened: true,
+        onClose,
+      }),
+    );
+
+    signalOpen();
+    act(() => {
+      result.current.handleAnimate(-1, 0);
+    });
+
+    act(() => {
+      result.current.handleAnimate(0, -1);
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    signalClose();
+
+    expect(mockDismiss).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.handleDismiss();
+    });
+    expect(mockRemoveBottomSheetFromQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("replays a dismiss that was dropped because the sheet had not opened yet", () => {
+    const { signalOpen, signalClose } = setupBottomSheetStateCapture();
+
+    const { result } = renderHook(() =>
+      useQueuedBottomSheet({
+        isRequestingToBeOpened: true,
+      }),
+    );
+
+    signalOpen();
+    signalClose();
+    expect(mockDismiss).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.handleAnimate(-1, 0);
+    });
+
+    expect(mockDismiss).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      result.current.handleDismiss();
+    });
+
+    expect(mockRemoveBottomSheetFromQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not replay a dismiss once the sheet has opened normally", () => {
+    const { signalOpen, signalClose } = setupBottomSheetStateCapture();
+
+    const { result } = renderHook(() =>
+      useQueuedBottomSheet({
+        isRequestingToBeOpened: true,
+      }),
+    );
+
+    signalOpen();
+    act(() => {
+      result.current.handleAnimate(-1, 0);
+    });
+
+    signalClose();
+    expect(mockDismiss).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.handleAnimate(0, 1);
+    });
+
+    expect(mockDismiss).toHaveBeenCalledTimes(1);
   });
 
   it("reopens the drawer after dismiss when it is still requested (re-tapped while closing)", () => {
@@ -468,15 +618,13 @@ describe("useQueuedBottomSheet", () => {
     expect(mockPresent).toHaveBeenCalledTimes(1);
     expect(mockAddBottomSheetToQueue).toHaveBeenCalledTimes(1);
 
-    // Close starts, then finishes while the consumer still requests the drawer to be open.
     act(() => {
-      result.current.handleCloseAnimationStart(0, -1);
+      result.current.handleAnimate(0, -1);
     });
     act(() => {
       result.current.handleDismiss();
     });
 
-    // Re-enqueued so it can open again on the first interaction.
     expect(mockAddBottomSheetToQueue).toHaveBeenCalledTimes(2);
 
     signalOpen();
@@ -484,9 +632,6 @@ describe("useQueuedBottomSheet", () => {
   });
 
   it("does not reopen when the consumer's onClose-driven state change is batched with handleDismiss", () => {
-    // Reproduces the race condition: handleCloseAnimationStart triggers the consumer's onClose,
-    // which schedules a setState to clear isRequestingToBeOpened. If handleDismiss reads a ref
-    // before React has rendered that update, the old reopen guard would re-enqueue the drawer.
     const { signalOpen, signalClose } = setupBottomSheetStateCapture();
 
     const { result } = renderHook(() => {
@@ -501,11 +646,8 @@ describe("useQueuedBottomSheet", () => {
     expect(mockAddBottomSheetToQueue).toHaveBeenCalledTimes(1);
     expect(mockPresent).toHaveBeenCalledTimes(1);
 
-    // In production these fire from separate native callbacks separated by the close animation.
-    // Inside a single act() they are batched together, which is exactly the case the old code got
-    // wrong: at handleDismiss time, the ref still holds the pre-onClose value.
     act(() => {
-      result.current.handleCloseAnimationStart(0, -1);
+      result.current.handleAnimate(0, -1);
       result.current.handleDismiss();
     });
 
@@ -521,7 +663,6 @@ describe("useQueuedBottomSheet", () => {
     signalOpen();
     expect(mockAddBottomSheetToQueue).toHaveBeenCalledTimes(1);
 
-    // Consumer clears its request (drawer genuinely closed), then the sheet finishes dismissing.
     isRequestingToBeOpened = false;
     rerender(undefined);
 

--- a/shared/ui-queued-bottom-sheet/src/internals/useQueuedBottomSheet.native.ts
+++ b/shared/ui-queued-bottom-sheet/src/internals/useQueuedBottomSheet.native.ts
@@ -21,6 +21,8 @@ interface UseQueuedBottomSheetProps {
 
 type BottomSheetState = "idle" | "open" | "dismissing";
 
+const DISMISS_FALLBACK_DELAY_MS = 600;
+
 export function useQueuedBottomSheet({
   isRequestingToBeOpened = false,
   isForcingToBeOpened = false,
@@ -66,10 +68,13 @@ export function useQueuedBottomSheet({
 
   // Bumped at the end of handleDismiss to re-trigger the open/close effect below. This defers
   // the "should we reopen?" decision to a React commit, ensuring any state update scheduled by
-  // the consumer's onClose (from handleCloseAnimationStart) has been applied before we read
+  // the consumer's onClose (from handleAnimate) has been applied before we read
   // isRequestingToBeOpened — otherwise a fast backdrop dismiss could see a stale `true` and
   // re-enqueue the drawer.
   const [reopenCheckSignal, setReopenCheckSignal] = useState(0);
+
+  const wantsToBeOpenRef = useRef(false);
+  wantsToBeOpenRef.current = isRequestingToBeOpened || isForcingToBeOpened;
 
   const cleanupQueue = useCallback(() => {
     if (bottomSheetInQueueRef.current) {
@@ -78,13 +83,53 @@ export function useQueuedBottomSheet({
     }
   }, []);
 
+  const dismissFallbackRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearDismissFallback = useCallback(() => {
+    if (dismissFallbackRef.current) {
+      clearTimeout(dismissFallbackRef.current);
+      dismissFallbackRef.current = null;
+    }
+  }, []);
+
+  const settleClosed = useCallback(() => {
+    clearDismissFallback();
+    stateRef.current = "idle";
+    cleanupQueue();
+  }, [clearDismissFallback, cleanupQueue]);
+
+  const beginDismissing = useCallback(() => {
+    stateRef.current = "dismissing";
+    cleanupQueue();
+
+    clearDismissFallback();
+    dismissFallbackRef.current = setTimeout(() => {
+      dismissFallbackRef.current = null;
+      if (stateRef.current !== "dismissing") return;
+
+      logBottomSheet("onDismiss never arrived - settling this sheet as closed");
+      settleClosed();
+      setReopenCheckSignal(s => s + 1);
+    }, DISMISS_FALLBACK_DELAY_MS);
+  }, [cleanupQueue, clearDismissFallback, logBottomSheet, settleClosed]);
+
+  // Closing a sheet often also clears the reason the sheet queued behind it wanted to be open, so
+  // by the time the queue promotes us our consumer may no longer want us. Presenting anyway leaves
+  // an empty sheet on screen that swallows the next tap, so decline the promotion instead.
   const handleOpen = useCallback(() => {
     if (stateRef.current !== "idle") return;
 
+    if (!wantsToBeOpenRef.current) {
+      logBottomSheet("Promoted by the queue but no longer requested - releasing the slot");
+      cleanupQueue();
+      return;
+    }
+
     logBottomSheet("Opening drawer");
+    clearDismissFallback();
     stateRef.current = "open";
     bottomSheetRef.current?.present();
-  }, [bottomSheetRef, logBottomSheet]);
+  }, [bottomSheetRef, cleanupQueue, clearDismissFallback, logBottomSheet]);
 
   const handleClose = useCallback(() => {
     const state = stateRef.current;
@@ -94,13 +139,18 @@ export function useQueuedBottomSheet({
       return;
     }
 
-    if (state === "dismissing") return;
+    if (state === "dismissing") {
+      logBottomSheet("Close signalled while already dismissing - re-issuing dismiss");
+      bottomSheetRef.current?.dismiss();
+      return;
+    }
 
     logBottomSheet("Closing drawer");
-    stateRef.current = "dismissing";
+    beginDismissing();
+
     bottomSheetRef.current?.dismiss();
     onCloseRef.current?.();
-  }, [bottomSheetRef, cleanupQueue, logBottomSheet]);
+  }, [beginDismissing, bottomSheetRef, cleanupQueue, logBottomSheet]);
 
   // Adds this drawer to the queue. The queue decides when to actually open/close it via the
   // open/close state handlers.
@@ -130,26 +180,36 @@ export function useQueuedBottomSheet({
     if (stateRef.current === "dismissing") return;
 
     logBottomSheet("Header close pressed");
-    stateRef.current = "dismissing";
+    beginDismissing();
     onHeaderClosePressedRef.current?.();
     onCloseRef.current?.();
-  }, [logBottomSheet]);
+  }, [beginDismissing, logBottomSheet]);
 
   // Fired at the START of an animation. A close animation targets index -1, so this is the
   // earliest deterministic signal that the sheet is closing — for the X (close) button, the
   // backdrop and the pan-down gesture alike. We clear consumer state here rather than waiting for
   // onDismiss (which the X button defers until the close animation finishes). Otherwise a tap on
   // another trigger during the close window sets new state that the late onDismiss would wipe,
-  // forcing the user to tap twice. Queue cleanup stays in onDismiss to preserve overlap protection.
-  const handleCloseAnimationStart = useCallback(
-    (_fromIndex: number, toIndex: number) => {
+  // forcing the user to tap twice.
+  const handleAnimate = useCallback(
+    (fromIndex: number, toIndex: number) => {
+      if (toIndex >= 0) {
+        const restoredWhileDismissing = fromIndex === -1 && stateRef.current === "dismissing";
+        if (restoredWhileDismissing) {
+          logBottomSheet("Sheet opening while considered closed - dismissing it again");
+          bottomSheetRef.current?.dismiss();
+        }
+
+        return;
+      }
+
       if (toIndex === -1 && stateRef.current === "open") {
         logBottomSheet("Close animation started");
-        stateRef.current = "dismissing";
+        beginDismissing();
         onCloseRef.current?.();
       }
     },
-    [logBottomSheet],
+    [beginDismissing, bottomSheetRef, logBottomSheet],
   );
 
   const handleDismiss = useCallback(() => {
@@ -159,22 +219,21 @@ export function useQueuedBottomSheet({
       Keyboard.dismiss();
     }
 
-    // Fallback for dismissals that bypass the close animation (and thus handleCloseAnimationStart).
+    // Fallback for dismissals that bypass the close animation (and thus handleAnimate).
     if (stateRef.current === "open") {
       onCloseRef.current?.();
     }
 
-    stateRef.current = "idle";
-    cleanupQueue();
+    settleClosed();
     onModalHideRef.current?.();
 
     // Defer the "should we reopen?" decision to the open/close effect below. Bumping the signal
     // forces a re-render; by the time the effect runs, React has committed any state update
-    // scheduled by the consumer's onClose (called from handleCloseAnimationStart), so reading
+    // scheduled by the consumer's onClose (called from handleAnimate), so reading
     // isRequestingToBeOpened reflects the user's true intent — false for a normal backdrop close,
     // true only if the consumer genuinely re-requested while the sheet was closing.
     setReopenCheckSignal(s => s + 1);
-  }, [cleanupQueue, logBottomSheet]);
+  }, [logBottomSheet, settleClosed]);
 
   useEffect(() => {
     if (!isFocused && (isRequestingToBeOpened || isForcingToBeOpened)) {
@@ -204,9 +263,10 @@ export function useQueuedBottomSheet({
   useEffect(() => {
     return () => {
       logBottomSheet("Component unmounting - cleaning up");
+      clearDismissFallback();
       cleanupQueue();
     };
-  }, [cleanupQueue, logBottomSheet]);
+  }, [cleanupQueue, clearDismissFallback, logBottomSheet]);
 
   return {
     bottomSheetRef,
@@ -215,7 +275,7 @@ export function useQueuedBottomSheet({
     handleBackdropPress,
     handleHeaderClosePressed,
     handleDismiss,
-    handleCloseAnimationStart,
+    handleAnimate,
     onBack,
     enablePanDownToClose: !areBottomSheetsLocked && !preventBackdropClick,
     backgroundContextValue,


### PR DESCRIPTION
### 📝 Description

**Previous behaviour**

Two bottom sheets on mobile could not be reopened once closed:

- The delete contact confirmation did not reopen after cancelling it — only after tapping an empty area of the screen.
- The address edit sheet could not be reopened after cancelling the edition.

`QueuedBottomSheet` never set `stackBehavior`, so gorhom's default `"switch"` applied. When a
second sheet is presented before the first has unmounted, `"switch"` *minimizes* the outgoing
sheet instead of dismissing it: the sheet animates to index `-1` so it looks closed, but it never
unmounts. `onDismiss` therefore never fires, `useQueuedBottomSheet` stays latched in its
`"dismissing"` state, its queue slot is never released, and every sheet queued behind it is
blocked. gorhom then `restore()`s that minimized sheet when the sheet on top unmounts, bringing it
back as an invisible backdrop — which is why the next tap was swallowed and the sheet only
reopened after tapping an empty area.

This only happens when two sheets are momentarily co-mounted, which needs real animation timing.
On a fast simulator the outgoing sheet is usually already marked `willUnmount`, so gorhom skips
the minimize entirely and the bug does not reproduce.

**The fix**

- Present queued sheets with `stackBehavior: "replace"` so the outgoing sheet is dismissed rather
  than minimized. That is the lifecycle the queue was always built around: one visible sheet, and
  a replaced sheet goes away for good. Lumen does not surface the prop in its types but forwards
  unknown props to the gorhom modal, so it is passed via a spread with an explanatory comment —
  worth asking the Lumen team to expose it properly.
- Harden `useQueuedBottomSheet` against the same class of failure: a close signalled while the
  sheet is already marked dismissing now re-issues the dismiss instead of returning early, and a
  close arriving before the sheet reached an open index is replayed once it opens. Both cases
  previously left a sheet mounted while holding its queue slot.
- On the contact detail screen, the address detail sheet no longer requests to stay open while one
  of its own action sheets (edit, delete, signer) has taken over. The address selection still
  survives so those sheets keep their data, but leaving the open request on made the queue
  re-enqueue the address detail sheet behind whichever sheet replaced it.

**Automated check preventing regression**

Two unit tests added to `useQueuedBottomSheet.native.test.ts`:

- `still dismisses a sheet that the modal stack minimized behind our back` — covers the root cause.
  Confirmed to fail without the fix (`dismiss` called 0 times instead of 1).
- `replays a dismiss that was dropped because the sheet had not opened yet`.

These are hook-level tests on purpose: the repo-wide gorhom mock in
`apps/ledger-live-mobile/__tests__/jest-setup.js` patches `dismiss()` to fire `onDismiss`
synchronously, so no integration test can express a dismissal that never completes.

**Validation**

`@shared/ui-queued-bottom-sheet` 48/48, mobile contacts 82 tests, full mobile MVVM suite
516 suites / 3684 tests, typecheck and lint clean.

**Note for reviewers**

`stackBehavior: "replace"` applies to every `QueuedBottomSheet` consumer, not just contacts — Send
signature, DeviceIntentExecutor and the onboarding tour also use it. All are one-at-a-time flows so
the semantics match and the suites pass, but that is the area to watch when testing on device.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35790](https://ledgerhq.atlassian.net/browse/LIVE-35790)
- **ADR** (if any): n/a


[LIVE-35790]: https://ledgerhq.atlassian.net/browse/LIVE-35790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ