### PR TITLE
[LWDM] fix(mobile): open contact send at amount (LIVE-35878)

### DIFF
--- a/.changeset/quick-contacts-send.md
+++ b/.changeset/quick-contacts-send.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Open the amount step when sending to a saved contact.

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/SendFundsNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/SendFundsNavigator.ts
@@ -398,6 +398,8 @@ export type SendFundsNavigatorStackParamList = {
     account: AccountLike;
     parentAccount?: Account;
     isSelfTransfer: boolean;
+    recipient?: string;
+    skipRecipientStep?: boolean;
   };
   [ScreenName.AleoMandatoryPrivateSync]: {
     account: AccountLike;

--- a/apps/ledger-live-mobile/src/families/aleo/Send/BalanceSelectionScreen.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/BalanceSelectionScreen.tsx
@@ -45,19 +45,21 @@ function buildTransaction({
   account,
   mainAccount,
   isSelfTransfer,
+  recipient,
   mode,
 }: {
   bridge: AccountBridge<AleoTransaction>;
   account: AccountLike;
   mainAccount: AleoAccount;
   isSelfTransfer: boolean;
+  recipient?: string;
   mode: AleoTransaction["mode"];
 }): AleoTransaction {
   const tx = bridge.createTransaction(account);
 
   return bridge.updateTransaction(tx, {
     mode,
-    recipient: isSelfTransfer ? mainAccount.freshAddress : "",
+    recipient: recipient ?? (isSelfTransfer ? mainAccount.freshAddress : ""),
     ...(account.type === "TokenAccount" && { subAccountId: account.id }),
   });
 }
@@ -77,7 +79,7 @@ function getCtaLabelKey(isSelfTransfer: boolean, option: BalanceOption) {
 export function BalanceSelectionScreen() {
   const navigation = useNavigation<Props["navigation"]>();
   const route = useRoute<Props["route"]>();
-  const { account, parentAccount, isSelfTransfer } = route.params;
+  const { account, parentAccount, isSelfTransfer, recipient, skipRecipientStep } = route.params;
   const [selected, setSelected] = useState<BalanceOption>("public");
   const { t } = useTranslation();
   const bridge = useAccountBridge<AleoTransaction>(account, parentAccount);
@@ -106,9 +108,17 @@ export function BalanceSelectionScreen() {
     const isPublic = selected === "public";
     const deriveMode = isPublic ? derivePublicTransactionMode : derivePrivateTransactionMode;
     const mode = deriveMode({ isTokenTx: isToken, isSelfTransfer });
-    const transaction = buildTransaction({ bridge, account, mainAccount, isSelfTransfer, mode });
+    const isDirectContactSend = skipRecipientStep === true && Boolean(recipient?.trim());
+    const transaction = buildTransaction({
+      bridge,
+      account,
+      mainAccount,
+      isSelfTransfer,
+      recipient: isDirectContactSend ? recipient : undefined,
+      mode,
+    });
 
-    if (!isPublic && isSelfTransfer) {
+    if (!isPublic && (isSelfTransfer || isDirectContactSend)) {
       navigation.navigate(ScreenName.AleoMandatoryPrivateSync, {
         account,
         parentAccount,
@@ -117,14 +127,28 @@ export function BalanceSelectionScreen() {
       return;
     }
 
-    const nextScreen = isSelfTransfer ? ScreenName.SendAmountCoin : ScreenName.SendSelectRecipient;
+    const nextScreen =
+      isSelfTransfer || isDirectContactSend
+        ? ScreenName.SendAmountCoin
+        : ScreenName.SendSelectRecipient;
 
     navigation.navigate(nextScreen, {
       accountId: account.id,
       parentId: parentAccount?.id,
       transaction,
     });
-  }, [selected, isToken, isSelfTransfer, bridge, account, mainAccount, navigation, parentAccount]);
+  }, [
+    selected,
+    isToken,
+    isSelfTransfer,
+    skipRecipientStep,
+    recipient,
+    bridge,
+    account,
+    mainAccount,
+    navigation,
+    parentAccount,
+  ]);
 
   return (
     <Box lx={wrapperStyle}>

--- a/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/BalanceSelectionScreen.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/BalanceSelectionScreen.test.tsx
@@ -64,15 +64,19 @@ function makeRoute({
   isSelfTransfer,
   account,
   parentAccount,
+  recipient,
+  skipRecipientStep,
 }: {
   isSelfTransfer: boolean;
   account: AccountLike;
   parentAccount?: Account;
+  recipient?: string;
+  skipRecipientStep?: boolean;
 }) {
   return {
     key: "aleo-balance-selection",
     name: "AleoSendBalanceSelection" as const,
-    params: { account, parentAccount, isSelfTransfer },
+    params: { account, parentAccount, isSelfTransfer, recipient, skipRecipientStep },
   };
 }
 
@@ -80,6 +84,19 @@ describe("BalanceSelectionScreen", () => {
   const mockNavigation = makeNavigation();
   const sendRoute = makeRoute({ account: ALEO_ACCOUNT_1, isSelfTransfer: false });
   const selfTransferRoute = makeRoute({ account: ALEO_ACCOUNT_1, isSelfTransfer: true });
+  const directContactRecipient = "aleo1contactrecipient";
+  const directContactRoute = makeRoute({
+    account: ALEO_ACCOUNT_1,
+    isSelfTransfer: false,
+    recipient: directContactRecipient,
+    skipRecipientStep: true,
+  });
+  const emptyDirectContactRoute = makeRoute({
+    account: ALEO_ACCOUNT_1,
+    isSelfTransfer: false,
+    recipient: "   ",
+    skipRecipientStep: true,
+  });
   const tokenSendRoute = makeRoute({
     account: ALEO_TOKEN_ACCOUNT_1,
     parentAccount: ALEO_ACCOUNT_1,
@@ -128,6 +145,57 @@ describe("BalanceSelectionScreen", () => {
         expect.objectContaining({
           accountId: ALEO_ACCOUNT_1.id,
           transaction: expect.objectContaining({ mode: "transfer_private", recipient: "" }),
+        }),
+      );
+    });
+
+    it("navigates to SendAmountCoin with the saved recipient", async () => {
+      mockUseRoute.mockReturnValue(directContactRoute as never);
+      const { user } = render(<BalanceSelectionScreen />);
+
+      await user.press(screen.getByText("Send publicly"));
+
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
+        ScreenName.SendAmountCoin,
+        expect.objectContaining({
+          accountId: ALEO_ACCOUNT_1.id,
+          transaction: expect.objectContaining({
+            mode: "transfer_public",
+            recipient: directContactRecipient,
+          }),
+        }),
+      );
+    });
+
+    it("keeps the private balance sync before opening amount for a saved recipient", async () => {
+      mockUseRoute.mockReturnValue(directContactRoute as never);
+      const { user } = render(<BalanceSelectionScreen />);
+
+      await user.press(screen.getByText("Private"));
+      await user.press(screen.getByText("Send privately"));
+
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
+        ScreenName.AleoMandatoryPrivateSync,
+        expect.objectContaining({
+          account: ALEO_ACCOUNT_1,
+          transaction: expect.objectContaining({
+            mode: "transfer_private",
+            recipient: directContactRecipient,
+          }),
+        }),
+      );
+    });
+
+    it("keeps recipient selection for an empty direct recipient", async () => {
+      mockUseRoute.mockReturnValue(emptyDirectContactRoute as never);
+      const { user } = render(<BalanceSelectionScreen />);
+
+      await user.press(screen.getByText("Send publicly"));
+
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
+        ScreenName.SendSelectRecipient,
+        expect.objectContaining({
+          transaction: expect.objectContaining({ recipient: "" }),
         }),
       );
     });

--- a/apps/ledger-live-mobile/src/families/aleo/customSendFlow.ts
+++ b/apps/ledger-live-mobile/src/families/aleo/customSendFlow.ts
@@ -32,9 +32,9 @@ const aleoSendFlow = {
   AfterAmountInput: QuickAmountSelector,
   hideSummaryTotalSection: true,
   showAllDigits: true,
-  buildSendEntrypoint: ({ account, parentAccount }) => ({
+  buildSendEntrypoint: ({ account, parentAccount, recipient, skipRecipientStep }) => ({
     screen: ScreenName.AleoSendBalanceSelection,
-    params: { account, parentAccount, isSelfTransfer: false },
+    params: { account, parentAccount, isSelfTransfer: false, recipient, skipRecipientStep },
   }),
   navigateToInitialScreen: ({ navigation, account, parentAccount, extra }) => {
     navigation.navigate(ScreenName.AleoSendBalanceSelection, {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -888,6 +888,7 @@ describe("Contacts integration", () => {
     expect(mockHandleOpenSendFlow).toHaveBeenCalledWith({
       currencyIds: ["ethereum"],
       recipient: "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+      skipRecipientStep: true,
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.ts
@@ -126,6 +126,7 @@ export function useContactAddressDetailActionsAdapter(
       handleOpenSendFlow({
         currencyIds: [intent.currencyId],
         recipient: intent.address,
+        skipRecipientStep: true,
       });
       onCloseAddressDetail();
     },

--- a/apps/ledger-live-mobile/src/mvvm/features/FlowWizard/FlowStackNavigator.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/FlowWizard/FlowStackNavigator.tsx
@@ -208,8 +208,18 @@ export function FlowStackNavigator<
     };
   }, [defaultStackNavigationConfig, baseScreenOptions]);
 
+  const initialRouteName = useMemo(() => {
+    const { initialStep } = flowConfig;
+
+    if (initialStep === undefined || !screenConfigs.some(config => config.step === initialStep)) {
+      return undefined;
+    }
+
+    return getScreenName ? getScreenName(initialStep) : `Flow${initialStep}`;
+  }, [flowConfig, getScreenName, screenConfigs]);
+
   return (
-    <Stack.Navigator screenOptions={mergedScreenOptions}>
+    <Stack.Navigator initialRouteName={initialRouteName} screenOptions={mergedScreenOptions}>
       {screenConfigs.map(config => (
         <Stack.Screen
           key={config.step}

--- a/apps/ledger-live-mobile/src/mvvm/features/FlowWizard/__tests__/FlowStackNavigator.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/FlowWizard/__tests__/FlowStackNavigator.test.tsx
@@ -97,6 +97,15 @@ describe("FlowStackNavigator", () => {
     expect(screen.getByText("Step 1")).toBeOnTheScreen();
   });
 
+  it("should render the configured initial step", () => {
+    renderFlowNavigator(defaultStepRegistry, {
+      ...defaultFlowConfig,
+      initialStep: "step2",
+    });
+
+    expect(screen.getByText("Step 2")).toBeOnTheScreen();
+  });
+
   it("should use getScreenName when provided", () => {
     const getScreenName = (step: FlowStep) => `Custom_${step}`;
     renderFlowNavigator(defaultStepRegistry, defaultFlowConfig, { getScreenName });

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/SendFlowOrchestrator.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/SendFlowOrchestrator.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useCallback } from "react";
 import type { StepRegistry } from "@ledgerhq/live-common/flows/wizard/types";
 import {
   SEND_FLOW_STEP,
+  canSkipRecipientStep,
   type SendFlowStep,
   type SendFlowInitParams,
 } from "@ledgerhq/live-common/flows/send/types";
@@ -66,9 +67,11 @@ export function SendFlowOrchestrator({
   const configuredFlowConfig = useMemo(
     () => ({
       ...flowConfig,
-      initialStep: SEND_FLOW_STEP.RECIPIENT,
+      initialStep: canSkipRecipientStep(initParams, businessContext.uiConfig)
+        ? SEND_FLOW_STEP.AMOUNT
+        : SEND_FLOW_STEP.RECIPIENT,
     }),
-    [flowConfig],
+    [businessContext.uiConfig, flowConfig, initParams],
   );
 
   return (

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/__tests__/SendFlowOrchestrator.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/__tests__/SendFlowOrchestrator.test.tsx
@@ -99,7 +99,12 @@ function createFlowConfig(overrides?: Partial<SendFlowConfig>): SendFlowConfig {
 
 describe("SendFlowOrchestrator", () => {
   const mockOnClose = jest.fn();
-  const mockBusinessContext = { state: {}, transaction: {}, operation: {} };
+  const mockBusinessContext = {
+    state: {},
+    transaction: {},
+    operation: {},
+    uiConfig: { hasMemo: false },
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -142,6 +147,74 @@ describe("SendFlowOrchestrator", () => {
           initialStep: SEND_FLOW_STEP.RECIPIENT,
           stepOrder: flowConfig.stepOrder,
           stepConfigs: flowConfig.stepConfigs,
+        }),
+      }),
+    );
+  });
+
+  it("should pass flowConfig with initialStep AMOUNT for a direct recipient", () => {
+    render(
+      <SendFlowOrchestrator
+        initParams={{
+          recipient: "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+          skipRecipientStep: true,
+        }}
+        onClose={mockOnClose}
+        stepRegistry={createStepRegistry()}
+        flowConfig={createFlowConfig()}
+      />,
+    );
+
+    expect(MockFlowStackNavigator).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flowConfig: expect.objectContaining({
+          initialStep: SEND_FLOW_STEP.AMOUNT,
+        }),
+      }),
+    );
+  });
+
+  it("should keep the recipient step for an empty direct recipient", () => {
+    render(
+      <SendFlowOrchestrator
+        initParams={{ recipient: "   ", skipRecipientStep: true }}
+        onClose={mockOnClose}
+        stepRegistry={createStepRegistry()}
+        flowConfig={createFlowConfig()}
+      />,
+    );
+
+    expect(MockFlowStackNavigator).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flowConfig: expect.objectContaining({
+          initialStep: SEND_FLOW_STEP.RECIPIENT,
+        }),
+      }),
+    );
+  });
+
+  it("should keep the recipient step when the selected currency requires a memo", () => {
+    mockUseSendFlowBusinessLogic.mockReturnValue({
+      ...mockBusinessContext,
+      uiConfig: { hasMemo: true },
+    });
+
+    render(
+      <SendFlowOrchestrator
+        initParams={{
+          recipient: "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+          skipRecipientStep: true,
+        }}
+        onClose={mockOnClose}
+        stepRegistry={createStepRegistry()}
+        flowConfig={createFlowConfig()}
+      />,
+    );
+
+    expect(MockFlowStackNavigator).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flowConfig: expect.objectContaining({
+          initialStep: SEND_FLOW_STEP.RECIPIENT,
         }),
       }),
     );

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useOpenSendFlow.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useOpenSendFlow.test.ts
@@ -108,6 +108,41 @@ describe("useOpenSendFlow", () => {
     });
   });
 
+  it("forwards the direct recipient intent to the new send flow", () => {
+    const currency = getCryptoCurrencyById("ethereum");
+    const account = genAccount("direct-new-send-account-selection", { currency });
+    const recipient = "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034";
+    const { result } = renderHook(
+      () =>
+        useOpenSendFlow({
+          currency,
+          sourceScreenName: "Contact Detail",
+        }),
+      {
+        overrideInitialState: withFlagOverrides({
+          newSendFlow: {
+            enabled: true,
+            params: { families: ["evm"], excludedCurrencyIds: [] },
+          },
+        }),
+      },
+    );
+
+    act(() => result.current.handleOpenSendFlow({ recipient, skipRecipientStep: true }));
+    const onAccountSelected = mockOpenDrawer.mock.calls[0][0].onAccountSelected;
+    act(() => onAccountSelected(account));
+
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SendFlow, {
+      params: {
+        account,
+        parentAccount: undefined,
+        fromMAD: true,
+        recipient,
+        skipRecipientStep: true,
+      },
+    });
+  });
+
   it("falls back to the legacy recipient screen when the selected account is not eligible", () => {
     const currency = getCryptoCurrencyById("ethereum");
     const account = genAccount("legacy-send-account-selection", { currency });
@@ -161,6 +196,89 @@ describe("useOpenSendFlow", () => {
     });
   });
 
+  it("opens the legacy amount step for a direct recipient", async () => {
+    const currency = getCryptoCurrencyById("ethereum");
+    const account = genAccount("legacy-send-contact", { currency });
+    const recipient = "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034";
+    const { result } = renderHook(() =>
+      useOpenSendFlow({
+        currency,
+        sourceScreenName: "Contact Detail",
+      }),
+    );
+
+    act(() => result.current.handleOpenSendFlow({ recipient, skipRecipientStep: true }));
+    const onAccountSelected = mockOpenDrawer.mock.calls[0][0].onAccountSelected;
+    await act(async () => {
+      onAccountSelected(account);
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SendFunds, {
+        screen: ScreenName.SendAmountCoin,
+        params: expect.objectContaining({
+          accountId: account.id,
+          transaction: expect.objectContaining({ recipient }),
+        }),
+      });
+    });
+  });
+
+  it("keeps the legacy recipient step for a direct recipient on a currency with a memo", async () => {
+    const currency = getCryptoCurrencyById("stellar");
+    const account = genAccount("legacy-send-contact-with-memo", { currency });
+    const recipient = "GABCD1234EFGH5678IJKL9012MNOP3456QRST7890UVWXYZ";
+    const { result } = renderHook(() =>
+      useOpenSendFlow({
+        currency,
+        sourceScreenName: "Contact Detail",
+      }),
+    );
+
+    act(() => result.current.handleOpenSendFlow({ recipient, skipRecipientStep: true }));
+    const onAccountSelected = mockOpenDrawer.mock.calls[0][0].onAccountSelected;
+    await act(async () => {
+      onAccountSelected(account);
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SendFunds, {
+        screen: ScreenName.SendSelectRecipient,
+        params: expect.objectContaining({
+          accountId: account.id,
+          transaction: expect.objectContaining({ recipient }),
+        }),
+      });
+    });
+  });
+
+  it("keeps recipient selection for an empty direct legacy recipient", async () => {
+    const currency = getCryptoCurrencyById("ethereum");
+    const account = genAccount("legacy-send-empty-contact", { currency });
+    const { result } = renderHook(() =>
+      useOpenSendFlow({
+        currency,
+        sourceScreenName: "Contact Detail",
+      }),
+    );
+
+    act(() => result.current.handleOpenSendFlow({ recipient: "   ", skipRecipientStep: true }));
+    const onAccountSelected = mockOpenDrawer.mock.calls[0][0].onAccountSelected;
+    await act(async () => {
+      onAccountSelected(account);
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SendFunds, {
+        screen: ScreenName.SendSelectRecipient,
+        params: expect.objectContaining({
+          accountId: account.id,
+          transaction: expect.objectContaining({ recipient: "   " }),
+        }),
+      });
+    });
+  });
+
   it("falls back safely when a token account is selected without its parent account", () => {
     const currency = getCryptoCurrencyById("ethereum");
     const parentId = "missing-parent";
@@ -199,16 +317,17 @@ describe("useOpenSendFlow", () => {
     });
   });
 
-  it("uses a custom family entrypoint when the selected account provides one", () => {
+  it("passes the direct recipient intent to a custom family entrypoint", () => {
     const currency = getCryptoCurrencyById("ethereum");
     const account = genAccount("custom-send-account-selection", { currency });
     const customEntrypoint = {
       screen: ScreenName.SendCoin,
       params: { selectedCurrency: currency },
     };
+    const buildSendEntrypoint = jest.fn(() => customEntrypoint);
     mockGetCustomSendFlow.mockReturnValue({
       screens: [],
-      buildSendEntrypoint: () => customEntrypoint,
+      buildSendEntrypoint,
     });
     const { result } = renderHook(() =>
       useOpenSendFlow({
@@ -217,10 +336,17 @@ describe("useOpenSendFlow", () => {
       }),
     );
 
-    act(() => result.current.handleOpenSendFlow());
+    const recipient = "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034";
+    act(() => result.current.handleOpenSendFlow({ recipient, skipRecipientStep: true }));
     const onAccountSelected = mockOpenDrawer.mock.calls[0][0].onAccountSelected;
     act(() => onAccountSelected(account));
 
     expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SendFunds, customEntrypoint);
+    expect(buildSendEntrypoint).toHaveBeenCalledWith({
+      account,
+      parentAccount: undefined,
+      recipient,
+      skipRecipientStep: true,
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useSendHeaderViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useSendHeaderViewModel.test.ts
@@ -327,5 +327,18 @@ describe("useSendHeaderViewModel", () => {
       expect(result.current.recipientContact).toBeUndefined();
       expect(result.current.formattedAddress).toBe("0x123456...12345678");
     });
+
+    it("opens Recipient when Amount is the first screen in the flow", () => {
+      mockAmountStep();
+      mockCanGoBack.mockReturnValue(false);
+
+      const { result } = renderHook(() => useSendHeaderViewModel());
+
+      result.current.handleRecipientInputPress();
+
+      expect(mockSetRecipientSearchValue).toHaveBeenCalledWith(ADDRESS);
+      expect(mockNavigate).toHaveBeenCalledWith(ScreenName.SendFlowRecipient);
+      expect(mockGoBack).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useOpenSendFlow.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useOpenSendFlow.ts
@@ -4,6 +4,9 @@ import type { NavigatorScreenParams } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
+import { getSendUiConfig } from "@ledgerhq/live-common/flows/send/uiConfig";
+import { canSkipRecipientStep } from "@ledgerhq/live-common/flows/send/types";
 import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import { NavigatorName, ScreenName } from "~/const";
@@ -16,12 +19,14 @@ import { useNewSendFlowFeature } from "./useNewSendFlowFeature";
 type OpenSendFlowOverride = Readonly<{
   currencyIds?: string[];
   recipient?: string;
+  skipRecipientStep?: boolean;
 }>;
 
 type UseOpenSendFlowProps = Readonly<{
   currency?: CryptoOrTokenCurrency;
   currencyIds?: string[];
   recipient?: string;
+  skipRecipientStep?: boolean;
   sourceScreenName: string;
 }>;
 
@@ -29,6 +34,7 @@ export function useOpenSendFlow({
   currency,
   currencyIds,
   recipient,
+  skipRecipientStep,
   sourceScreenName,
 }: UseOpenSendFlowProps) {
   const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
@@ -37,7 +43,12 @@ export function useOpenSendFlow({
     useNewSendFlowFeature();
 
   const navigateToLegacyRecipient = useCallback(
-    async (account: AccountLike, parentAccount?: Account, prefilledRecipient?: string) => {
+    async (
+      account: AccountLike,
+      parentAccount?: Account,
+      prefilledRecipient?: string,
+      skipRecipientStep?: boolean,
+    ) => {
       const params: SendFundsNavigatorStackParamList[typeof ScreenName.SendSelectRecipient] = {
         accountId: account.id,
         parentId: account.type === "TokenAccount" ? account.parentId : undefined,
@@ -66,6 +77,24 @@ export function useOpenSendFlow({
         }
       }
 
+      if (
+        canSkipRecipientStep(
+          { recipient: prefilledRecipient, skipRecipientStep },
+          getSendUiConfig(getAccountCurrency(account)),
+        ) &&
+        params.transaction
+      ) {
+        navigation.navigate(NavigatorName.SendFunds, {
+          screen: ScreenName.SendAmountCoin,
+          params: {
+            accountId: account.id,
+            parentId: account.type === "TokenAccount" ? account.parentId : undefined,
+            transaction: params.transaction,
+          },
+        });
+        return;
+      }
+
       navigation.navigate(NavigatorName.SendFunds, {
         screen: ScreenName.SendSelectRecipient,
         params,
@@ -75,9 +104,19 @@ export function useOpenSendFlow({
   );
 
   const navigateAfterAccountSelection = useCallback(
-    (account: AccountLike, parentAccount?: Account, prefilledRecipient?: string) => {
+    (
+      account: AccountLike,
+      parentAccount?: Account,
+      prefilledRecipient?: string,
+      skipRecipientStep?: boolean,
+    ) => {
       if (account.type === "TokenAccount" && !parentAccount) {
-        void navigateToLegacyRecipient(account, parentAccount, prefilledRecipient);
+        void navigateToLegacyRecipient(
+          account,
+          parentAccount,
+          prefilledRecipient,
+          skipRecipientStep,
+        );
         return;
       }
 
@@ -92,6 +131,7 @@ export function useOpenSendFlow({
             parentAccount: mainAccount === account ? undefined : mainAccount,
             fromMAD: true,
             recipient: prefilledRecipient,
+            skipRecipientStep,
           },
         });
         return;
@@ -101,6 +141,8 @@ export function useOpenSendFlow({
         ? getCustomSendFlow(family)?.buildSendEntrypoint?.({
             account,
             parentAccount: mainAccount === account ? undefined : mainAccount,
+            recipient: prefilledRecipient,
+            skipRecipientStep,
           })
         : undefined;
 
@@ -112,7 +154,7 @@ export function useOpenSendFlow({
         return;
       }
 
-      void navigateToLegacyRecipient(account, parentAccount, prefilledRecipient);
+      void navigateToLegacyRecipient(account, parentAccount, prefilledRecipient, skipRecipientStep);
     },
     [
       getCurrencyIdFromAccount,
@@ -127,18 +169,40 @@ export function useOpenSendFlow({
     (override?: OpenSendFlowOverride) => {
       const resolvedCurrencyIds = override?.currencyIds ?? currencyIds;
       const resolvedRecipient = override?.recipient ?? recipient;
+      const resolvedSkipRecipientStep = override?.skipRecipientStep ?? skipRecipientStep;
       const hasCurrencyIds = Boolean(resolvedCurrencyIds?.length);
+      let currencies: string[] = [];
+
+      if (hasCurrencyIds) {
+        currencies = resolvedCurrencyIds ?? [];
+      } else if (currency) {
+        currencies = [currency.id];
+      }
+
       openDrawer({
-        currencies: hasCurrencyIds ? resolvedCurrencyIds : currency ? [currency.id] : [],
+        currencies,
         flow: "send",
         source: sourceScreenName,
         areCurrenciesFiltered: hasCurrencyIds || Boolean(currency),
         enableAccountSelection: true,
         onAccountSelected: (account, parentAccount) =>
-          navigateAfterAccountSelection(account, parentAccount, resolvedRecipient),
+          navigateAfterAccountSelection(
+            account,
+            parentAccount,
+            resolvedRecipient,
+            resolvedSkipRecipientStep,
+          ),
       });
     },
-    [currency, currencyIds, navigateAfterAccountSelection, openDrawer, recipient, sourceScreenName],
+    [
+      currency,
+      currencyIds,
+      navigateAfterAccountSelection,
+      openDrawer,
+      recipient,
+      skipRecipientStep,
+      sourceScreenName,
+    ],
   );
 
   return { handleOpenSendFlow };

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendHeaderViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendHeaderViewModel.ts
@@ -153,7 +153,11 @@ export function useSendHeaderViewModel(): SendHeaderViewModel {
       setRecipientSearchValue(prefillValue);
     }
 
-    navigation.goBack();
+    if (navigation.canGoBack()) {
+      navigation.goBack();
+    } else {
+      navigation.navigate(ScreenName.SendFlowRecipient);
+    }
   }, [isAmountStep, navigation, recipientFromTransaction, setRecipientSearchValue]);
 
   const handleScannedURI = useCallback(

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/index.tsx
@@ -33,6 +33,7 @@ type SendWorkflowParams = Readonly<{
   account?: AccountLike;
   parentAccount?: Account;
   recipient?: string;
+  skipRecipientStep?: boolean;
   amount?: string;
   memo?: string;
   fromMAD?: boolean;
@@ -45,6 +46,7 @@ type SendWorkflowRouteParams = {
   account?: AccountLike;
   parentAccount?: Account;
   recipient?: string;
+  skipRecipientStep?: boolean;
   amount?: string;
   memo?: string;
   fromMAD?: boolean;
@@ -72,6 +74,7 @@ export default function SendWorkflow() {
       account: params?.account ?? routeParams?.account,
       parentAccount: params?.parentAccount ?? routeParams?.parentAccount,
       recipient: params?.recipient ?? routeParams?.recipient,
+      skipRecipientStep: params?.skipRecipientStep ?? routeParams?.skipRecipientStep,
       amount: params?.amount ?? routeParams?.amount,
       memo: params?.memo ?? routeParams?.memo,
       fromMAD: params?.fromMAD ?? routeParams?.fromMAD ?? false,

--- a/apps/ledger-live-mobile/src/screens/SendFunds/utils/customSendFlow.ts
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/utils/customSendFlow.ts
@@ -59,7 +59,12 @@ type AfterRecipientNavParams = {
 export type CustomSendFlow = {
   screens: CustomSendFlowScreen[];
   /** Declarative entrypoint for navigation from outside the SendFunds navigator (e.g. asset action buttons). */
-  buildSendEntrypoint?: (opts: { account: AccountLike; parentAccount: Account | undefined }) => {
+  buildSendEntrypoint?: (opts: {
+    account: AccountLike;
+    parentAccount: Account | undefined;
+    recipient?: string;
+    skipRecipientStep?: boolean;
+  }) => {
     screen: keyof SendFundsNavigatorStackParamList;
     params: Record<string, unknown>;
   };

--- a/libs/ledger-live-common/src/flows/send/hooks/__tests__/useSendFlowBusinessLogic.test.ts
+++ b/libs/ledger-live-common/src/flows/send/hooks/__tests__/useSendFlowBusinessLogic.test.ts
@@ -2,9 +2,16 @@
  * @jest-environment jsdom
  */
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
-import { renderHook } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import type { SendFlowOperationActions, SendFlowTransactionActions } from "../../types";
 import { useSendFlowBusinessLogic } from "../useSendFlowBusinessLogic";
+import { getSendUiConfig } from "../../uiConfig";
+
+jest.mock("../../uiConfig", () => ({
+  getSendUiConfig: jest.fn(),
+}));
+
+const mockGetSendUiConfig = jest.mocked(getSendUiConfig);
 
 const transactionActions: SendFlowTransactionActions = {
   setTransaction: jest.fn(),
@@ -42,6 +49,7 @@ const useOperationHook = () => ({
 describe("useSendFlowBusinessLogic", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetSendUiConfig.mockReturnValue({ hasMemo: false } as ReturnType<typeof getSendUiConfig>);
   });
 
   it("should prefill recipient search without accepting the recipient before validation", () => {
@@ -56,6 +64,92 @@ describe("useSendFlowBusinessLogic", () => {
 
     expect(result.current.recipientSearch.value).toBe(recipient);
     expect(result.current.state.recipient).toBeNull();
+    expect(transactionActions.setRecipient).not.toHaveBeenCalled();
+  });
+
+  it("should accept a direct recipient when instructed to skip recipient selection", async () => {
+    const recipient = "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034";
+    let hasTransaction = false;
+    const useTransactionHookWithTransaction = () => ({
+      state: {
+        transaction: hasTransaction ? ({} as never) : null,
+        status: {} as never,
+        bridgeError: null,
+        bridgePending: false,
+      },
+      actions: transactionActions,
+    });
+    const { result, rerender } = renderHook(() =>
+      useSendFlowBusinessLogic({
+        initParams: { recipient, skipRecipientStep: true },
+        useTransactionHook: useTransactionHookWithTransaction,
+        useOperationHook,
+      }),
+    );
+
+    expect(result.current.state.recipient).toBeNull();
+    expect(transactionActions.setRecipient).not.toHaveBeenCalled();
+
+    hasTransaction = true;
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.state.recipient).toEqual({ address: recipient });
+    });
+    expect(result.current.isRecipientAddressComplete).toBe(true);
+    expect(transactionActions.setRecipient).toHaveBeenCalledWith({ address: recipient });
+  });
+
+  it("should not accept an empty direct recipient", async () => {
+    const useTransactionHookWithTransaction = () => ({
+      state: {
+        transaction: {} as never,
+        status: {} as never,
+        bridgeError: null,
+        bridgePending: false,
+      },
+      actions: transactionActions,
+    });
+    const { result } = renderHook(() =>
+      useSendFlowBusinessLogic({
+        initParams: { recipient: "   ", skipRecipientStep: true },
+        useTransactionHook: useTransactionHookWithTransaction,
+        useOperationHook,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.state.recipient).toBeNull();
+    });
+    expect(result.current.isRecipientAddressComplete).toBe(false);
+    expect(transactionActions.setRecipient).not.toHaveBeenCalled();
+  });
+
+  it("should keep a direct recipient unaccepted when its currency requires a memo", async () => {
+    const recipient = "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034";
+    const useTransactionHookWithTransaction = () => ({
+      state: {
+        transaction: {} as never,
+        status: {} as never,
+        bridgeError: null,
+        bridgePending: false,
+      },
+      actions: transactionActions,
+    });
+    mockGetSendUiConfig.mockReturnValue({ hasMemo: true } as ReturnType<typeof getSendUiConfig>);
+
+    const { result } = renderHook(() =>
+      useSendFlowBusinessLogic({
+        initParams: { recipient, skipRecipientStep: true },
+        useTransactionHook: useTransactionHookWithTransaction,
+        useOperationHook,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.state.recipient).toBeNull();
+    });
+    expect(result.current.isRecipientAddressComplete).toBe(false);
     expect(transactionActions.setRecipient).not.toHaveBeenCalled();
   });
 });

--- a/libs/ledger-live-common/src/flows/send/hooks/useSendFlowBusinessLogic.ts
+++ b/libs/ledger-live-common/src/flows/send/hooks/useSendFlowBusinessLogic.ts
@@ -1,8 +1,9 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import { FLOW_STATUS, type FlowStatus } from "../../wizard/types";
 import { useSendFlowAccount } from "./useSendFlowAccount";
 import { getSendUiConfig } from "../uiConfig";
+import { canSkipRecipientStep } from "../types";
 import type {
   SendFlowState,
   SendFlowInitParams,
@@ -73,6 +74,7 @@ export function useSendFlowBusinessLogic({
   );
   const [isRecipientAddressComplete, setIsRecipientAddressComplete] = useState(false);
   const [recipient, setRecipient] = useState<RecipientData | null>(null);
+  const hasInitializedDirectRecipient = useRef(false);
 
   const accountHook = useSendFlowAccount({
     initialAccount: initParams?.account,
@@ -109,6 +111,30 @@ export function useSendFlowBusinessLogic({
     },
     [transactionHook.actions],
   );
+
+  useEffect(() => {
+    const directRecipient = canSkipRecipientStep(initParams, uiConfig)
+      ? initParams?.recipient
+      : undefined;
+
+    if (
+      directRecipient === undefined ||
+      hasInitializedDirectRecipient.current ||
+      transactionHook.state.transaction === null
+    ) {
+      return;
+    }
+
+    hasInitializedDirectRecipient.current = true;
+    setIsRecipientAddressComplete(true);
+    handleRecipientSet({ address: directRecipient });
+  }, [
+    handleRecipientSet,
+    initParams?.recipient,
+    initParams?.skipRecipientStep,
+    transactionHook.state.transaction,
+    uiConfig,
+  ]);
 
   const recipientSearch = useMemo(
     () => ({

--- a/libs/ledger-live-common/src/flows/send/types.ts
+++ b/libs/ledger-live-common/src/flows/send/types.ts
@@ -93,10 +93,27 @@ export type SendFlowInitParams = Readonly<{
   account?: AccountLike;
   parentAccount?: Account;
   recipient?: string;
+  skipRecipientStep?: boolean;
   amount?: string;
   memo?: string;
   fromMAD?: boolean;
 }>;
+
+export function hasDirectRecipient(
+  params: Pick<SendFlowInitParams, "recipient" | "skipRecipientStep"> | undefined,
+): params is Pick<SendFlowInitParams, "recipient"> & {
+  recipient: string;
+  skipRecipientStep: true;
+} {
+  return params?.skipRecipientStep === true && Boolean(params.recipient?.trim());
+}
+
+export function canSkipRecipientStep(
+  params: Pick<SendFlowInitParams, "recipient" | "skipRecipientStep"> | undefined,
+  uiConfig: Pick<SendFlowUiConfig, "hasMemo">,
+): boolean {
+  return hasDirectRecipient(params) && !uiConfig.hasMemo;
+}
 
 export type SendFlowBusinessContext = Readonly<{
   state: SendFlowState;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Focused Mobile, shared Send-flow, and Aleo regression suites pass.
- [x] **Impact of the changes:**
      Sending from a saved contact opens Amount directly on Mobile while generic prefilled recipients retain recipient validation.

### 📝 Description

Adds the trusted Contacts direct-send entry to Mobile and the shared Send contract. 

https://github.com/user-attachments/assets/308df493-38d0-4cca-84ed-9796dab0023c


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-35878

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)