### PR TITLE
[LWD] fix(desktop): open contact send at amount (LIVE-35878)

### DIFF
--- a/.changeset/steady-desktop-contact-send.md
+++ b/.changeset/steady-desktop-contact-send.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Open the amount step when sending to a saved contact.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -894,6 +894,7 @@ describe("Contacts integration", () => {
     expect(mockOpenSendFlow).toHaveBeenCalledWith({
       currencyIds: ["ethereum"],
       recipient: "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+      skipRecipientStep: true,
     });
     expect(screen.queryByTestId("contacts-address-detail-dialog")).not.toBeInTheDocument();
   });

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactAddressDetailActionsAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactAddressDetailActionsAdapter.ts
@@ -107,6 +107,7 @@ export function useContactAddressDetailActionsAdapter(
       openSendFlow({
         currencyIds: [intent.currencyId],
         recipient: intent.address,
+        skipRecipientStep: true,
       });
       onCloseAddressDetail();
     },

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/SendFlowOrchestrator.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/SendFlowOrchestrator.tsx
@@ -3,8 +3,12 @@ import type { StepRegistry } from "@ledgerhq/live-common/flows/wizard/types";
 import { SendFlowProvider } from "./context/SendFlowContext";
 import { useSendFlowBusinessLogic } from "./hooks/useSendFlowState";
 import { SEND_FLOW_CONFIG } from "./constants";
-import { SEND_FLOW_STEP } from "@ledgerhq/live-common/flows/send/types";
-import type { SendFlowStep, SendFlowInitParams } from "@ledgerhq/live-common/flows/send/types";
+import {
+  canSkipRecipientStep,
+  SEND_FLOW_STEP,
+  type SendFlowStep,
+  type SendFlowInitParams,
+} from "@ledgerhq/live-common/flows/send/types";
 import type { SendStepConfig as DesktopSendStepConfig } from "./types";
 import { FlowWizardOrchestrator } from "../FlowWizard/FlowWizardOrchestrator";
 
@@ -27,9 +31,11 @@ export function SendFlowOrchestrator({
   const flowConfig = useMemo(
     () => ({
       ...SEND_FLOW_CONFIG,
-      initialStep: SEND_FLOW_STEP.RECIPIENT,
+      initialStep: canSkipRecipientStep(initParams, businessContext.uiConfig)
+        ? SEND_FLOW_STEP.AMOUNT
+        : SEND_FLOW_STEP.RECIPIENT,
     }),
-    [],
+    [businessContext.uiConfig, initParams],
   );
 
   return (

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
@@ -34,6 +34,26 @@ describe("Send Flow Integration", () => {
   });
 
   describe("Recipient step", () => {
+    it("should start on amount when opened from a contact", async () => {
+      renderSendFlow(ethereumAccount, {
+        recipient: VALID_EVM_RECIPIENT,
+        skipRecipientStep: true,
+      });
+
+      expect(await screen.findByTestId("send-amount-step")).toBeVisible();
+      expect(screen.getByTestId("send-amount-input")).toBeVisible();
+    });
+
+    it("should keep the recipient step when a direct recipient is empty", async () => {
+      renderSendFlow(ethereumAccount, {
+        recipient: "   ",
+        skipRecipientStep: true,
+      });
+
+      expect(await screen.findByTestId("send-recipient-input")).toBeVisible();
+      expect(screen.queryByTestId("send-amount-step")).not.toBeInTheDocument();
+    });
+
     it("should show the collapsable security card collapsed by default and expand on click", async () => {
       const { user } = renderSendFlow(ethereumAccount);
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/__mocks__/sendFlowTestUtils.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/__mocks__/sendFlowTestUtils.tsx
@@ -332,8 +332,11 @@ export const createBitcoinAccount = (overrides?: Partial<Account>): Account => {
   };
 };
 
-export const renderSendFlow = (account: Account) =>
-  render(<SendWorkflow isOpen onClose={jest.fn()} params={{ account }} />, {
+export const renderSendFlow = (
+  account: Account,
+  params: Omit<NonNullable<React.ComponentProps<typeof SendWorkflow>["params"]>, "account"> = {},
+) =>
+  render(<SendWorkflow isOpen onClose={jest.fn()} params={{ account, ...params }} />, {
     initialState: {
       accounts: [account],
       settings: {

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useOpenSendFlow.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useOpenSendFlow.test.ts
@@ -51,6 +51,7 @@ describe("useOpenSendFlow", () => {
     const account = genAccount("send-account-selection-categories", {
       currency: getCryptoCurrencyById("ethereum"),
     });
+
     const { result, store } = renderHook(() => useOpenSendFlow(), {
       initialState: {
         ...withFlagOverrides({
@@ -79,5 +80,38 @@ describe("useOpenSendFlow", () => {
 
     expect(store.getState().sendFlow.isOpen).toBe(true);
     expect(store.getState().sendFlow.data?.params).not.toHaveProperty("categories");
+  });
+
+  it("preserves the direct-recipient intent after account selection", () => {
+    const account = genAccount("send-contact-account-selection", {
+      currency: getCryptoCurrencyById("bitcoin"),
+    });
+    const recipient = "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh";
+    const { result, store } = renderHook(() => useOpenSendFlow(), {
+      initialState: {
+        ...withFlagOverrides({
+          newSendFlow: {
+            enabled: true,
+            params: { families: ["bitcoin"], excludedCurrencyIds: [] },
+          },
+        }),
+        accounts: [account],
+      },
+    });
+
+    result.current({
+      currencyIds: ["bitcoin"],
+      recipient,
+      skipRecipientStep: true,
+    });
+    store.getState().modularDialog.dialogParams?.onAccountSelected?.(account);
+
+    expect(store.getState().sendFlow.data?.params).toEqual(
+      expect.objectContaining({
+        account,
+        recipient,
+        skipRecipientStep: true,
+      }),
+    );
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useOpenSendFlow.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useOpenSendFlow.ts
@@ -30,6 +30,7 @@ type WorkflowParams = {
   currencyIds?: readonly string[];
   categories?: readonly AssetCategory[];
   recipient?: string;
+  skipRecipientStep?: boolean;
   amount?: string | BigNumber;
   memo?: string;
   fromMAD?: boolean;

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/index.tsx
@@ -32,6 +32,7 @@ type SendWorkflowParams = Readonly<{
   account?: AccountLike;
   parentAccount?: Account;
   recipient?: string;
+  skipRecipientStep?: boolean;
   amount?: string;
   memo?: string;
   fromMAD?: boolean;
@@ -54,6 +55,7 @@ export function SendWorkflow({ onClose, params, isOpen }: SendWorkflowProps) {
       account: params?.account,
       parentAccount: params?.parentAccount,
       recipient: params?.recipient,
+      skipRecipientStep: params?.skipRecipientStep,
       amount: params?.amount,
       memo: params?.memo,
       fromMAD: params?.fromMAD ?? false,

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/Body.tsx
@@ -41,6 +41,7 @@ export type Data = {
   parentAccount?: Account | undefined | null;
   startWithWarning?: boolean;
   recipient?: string;
+  skipRecipientStep?: boolean;
   amount?: BigNumber;
   disableBacks?: string[];
   walletConnectProxy?: boolean;

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/index.tsx
@@ -10,6 +10,9 @@ import { isModalOpened, getModalData } from "~/renderer/reducers/modals";
 import { openSendFlowDialog } from "~/renderer/reducers/sendFlow";
 import type { State } from "~/renderer/reducers";
 import { useNewSendFlowFeature } from "LLD/features/Send/hooks/useNewSendFlowFeature";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
+import { getSendUiConfig } from "@ledgerhq/live-common/flows/send/uiConfig";
+import { canSkipRecipientStep } from "@ledgerhq/live-common/flows/send/types";
 
 type Props = {
   stepId?: StepId;
@@ -27,9 +30,15 @@ const MODAL_LOCKED: {
 };
 const SendModal = ({ stepId: initialStepId, onClose }: Props) => {
   const [stepId, setStepId] = useState<StepId>(() => initialStepId || "recipient");
-  const handleReset = useCallback(() => setStepId("recipient"), []);
-  const handleStepChange = useCallback((stepId: StepId) => setStepId(stepId), []);
-  const isModalLocked = MODAL_LOCKED[stepId];
+  const [hasStartedDirectSend, setHasStartedDirectSend] = useState(false);
+  const handleReset = useCallback(() => {
+    setStepId("recipient");
+    setHasStartedDirectSend(false);
+  }, []);
+  const handleStepChange = useCallback((nextStepId: StepId) => {
+    setHasStartedDirectSend(true);
+    setStepId(nextStepId);
+  }, []);
   const dispatch = useDispatch();
 
   const { isEnabledForFamily, getFamilyFromAccount, getCurrencyIdFromAccount } =
@@ -46,6 +55,17 @@ const SendModal = ({ stepId: initialStepId, onClose }: Props) => {
     modalData?.parentAccount ?? null,
   );
   const shouldRedirectToNewFlow = isEnabledForFamily(family, currencyId);
+  const canStartDirectSend =
+    modalData?.account &&
+    canSkipRecipientStep(
+      {
+        recipient: modalData.recipient,
+        skipRecipientStep: modalData.skipRecipientStep,
+      },
+      getSendUiConfig(getAccountCurrency(modalData.account)),
+    );
+  const effectiveStepId = !hasStartedDirectSend && canStartDirectSend ? "amount" : stepId;
+  const isModalLocked = MODAL_LOCKED[effectiveStepId];
 
   const handleModalClose = useCallback(() => {
     dispatch(
@@ -70,6 +90,7 @@ const SendModal = ({ stepId: initialStepId, onClose }: Props) => {
           account: sendData.account ?? undefined,
           parentAccount: sendData.parentAccount ?? undefined,
           recipient: sendData.recipient,
+          skipRecipientStep: sendData.skipRecipientStep,
           amount,
           fromMAD: false,
           startWithWarning: sendData.startWithWarning,
@@ -95,7 +116,7 @@ const SendModal = ({ stepId: initialStepId, onClose }: Props) => {
         preventBackdropClick={isModalLocked}
         render={({ onClose, data }) => (
           <Body
-            stepId={stepId}
+            stepId={effectiveStepId}
             onClose={onClose}
             onChangeStepId={handleStepChange}
             params={data || {}}

--- a/apps/ledger-live-desktop/src/renderer/reducers/sendFlow.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/sendFlow.ts
@@ -6,6 +6,7 @@ export type SendFlowParams = {
   account?: AccountLike;
   parentAccount?: Account;
   recipient?: string;
+  skipRecipientStep?: boolean;
   amount?: string;
   memo?: string;
   fromMAD?: boolean;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Focused Desktop Send-flow hook and integration suites pass.
- [x] **Impact of the changes:**
      Sending from a saved contact opens Amount directly on Desktop; this PR depends on #20977 for the shared direct-send contract.

### 📝 Description

Adds the Desktop Contacts adapter and Send-flow handling for the trusted direct-send intent, including the legacy modal amount-step lock.

<img width="1335" height="831" alt="image" src="https://github.com/user-attachments/assets/f42221b6-42ee-40e0-823b-b9d9a05f16c9" />

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-35878

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)