### PR TITLE
feat(card): add the orderCard mutation to the card management api

### DIFF
--- a/.changeset/plain-cards-order.md
+++ b/.changeset/plain-cards-order.md
@@ -1,0 +1,12 @@
+---
+"@domain/api-card-management": minor
+---
+
+Add the `orderCard` mutation for `POST /v1/card/order`.
+
+- A mutation, not a query: ordering a card is not idempotent and Baanx offers no idempotency key.
+- Takes no argument — `VIRTUAL` is the only type the provider issues today, so the body is fixed.
+- `PayCardOrderResponseSchema` declares `success` alone, keeping anything else the order answers with
+  out of the RTK Query cache.
+- The base query already sends the base URL, `x-client-key` and the Bearer token, so the endpoint
+  restates none of it.

--- a/domain/api/card-management/README.md
+++ b/domain/api/card-management/README.md
@@ -23,6 +23,7 @@ shape and the reasons.
 | `refreshSession` | POST | `/v1/auth/oauth/token` | Same endpoint, `refresh_token` grant |
 | `logout` | POST | `/v1/auth/logout` | End the session |
 | `getUser` | GET | `/v1/user` | Read the account id and verification state |
+| `orderCard` | POST | `/v1/card/order` | Order a virtual card |
 
 `cardManagementApi` **is** `cardApi` after injection: importing this package is a module-level side
 effect that adds its endpoints to the shared service. The app registers `cardApi` (not this package)

--- a/domain/api/card-management/src/api.test.ts
+++ b/domain/api/card-management/src/api.test.ts
@@ -1,6 +1,6 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { cardApi, cardApiExtra } from "@shared/api-services";
-import { cardManagementApi } from "./api";
+import { cardManagementApi, useOrderCardMutation } from "./api";
 
 function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -60,8 +60,14 @@ describe("cardManagementApi configuration", () => {
       "getUser",
       "initiateAuthorize",
       "logout",
+      "orderCard",
       "refreshSession",
     ]);
+  });
+
+  it("exposes the orderCard endpoint and its hook", () => {
+    expect(cardManagementApi.endpoints.orderCard).toBeDefined();
+    expect(useOrderCardMutation).toBeDefined();
   });
 
   it("shares the Card service reducer and middleware once registered in a store", () => {
@@ -231,6 +237,47 @@ describe("cardManagementApi requests", () => {
         id: "3f2504e0-4f89-11d3-9a0c-0305e82c3301",
         verificationState: "VERIFIED",
       });
+    });
+  });
+
+  describe("orderCard", () => {
+    it("posts a virtual card order with the session bearer token and the client key", async () => {
+      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ success: true }));
+
+      const store = makeStore(async () => "session-token");
+      const result = await store.dispatch(cardManagementApi.endpoints.orderCard.initiate());
+
+      expect(request(fetchSpy).url).toBe("https://card.test/v1/card/order");
+      expect(request(fetchSpy).method).toBe("POST");
+      expect(JSON.parse(await request(fetchSpy).clone().text())).toEqual({ type: "VIRTUAL" });
+      expect(request(fetchSpy).headers.get("authorization")).toBe("Bearer session-token");
+      expect(request(fetchSpy).headers.get("x-client-key")).toBe("client-key");
+      expect(result.data).toEqual({ success: true });
+    });
+
+    it("keeps everything the wire contract does not declare out of the cache", async () => {
+      fetchSpy = jest
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(
+          jsonResponse({ success: true, cardId: "card-1", pan: "pan-must-not-reach-the-cache" }),
+        );
+
+      const store = makeStore(async () => "session-token");
+      const result = await store.dispatch(cardManagementApi.endpoints.orderCard.initiate());
+
+      expect(result.data).toEqual({ success: true });
+    });
+
+    it("rejects a response whose success flag is not a boolean", async () => {
+      fetchSpy = jest
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(jsonResponse({ success: "yes", pan: "pan-must-not-reach-the-cache" }));
+
+      const store = makeStore(async () => "session-token");
+      const result = await store.dispatch(cardManagementApi.endpoints.orderCard.initiate());
+
+      expect(result.data).toBeUndefined();
+      expect(JSON.stringify(result.error)).not.toContain("pan-must-not-reach-the-cache");
     });
   });
 

--- a/domain/api/card-management/src/api.ts
+++ b/domain/api/card-management/src/api.ts
@@ -3,6 +3,7 @@ import { CARD_MANAGEMENT_TAGS } from "./constants";
 import {
   PayCardAuthorizeInitiateResponseSchema,
   PayCardLogoutResponseSchema,
+  PayCardOrderResponseSchema,
   PayCardSessionResponseSchema,
   PayCardSessionSchema,
   PayCardUserResponseSchema,
@@ -13,6 +14,7 @@ import type {
   PayCardAuthorizeInitiate,
   PayCardAuthorizeInitiateRequest,
   PayCardLogoutResult,
+  PayCardOrderResult,
   PayCardRefreshSessionRequest,
   PayCardSession,
   PayCardUser,
@@ -88,6 +90,19 @@ export const cardManagementApi = cardApi
         }),
         responseSchema: PayCardUserResponseSchema,
       }),
+
+      /**
+       * Takes no argument from the caller: the body is fixed to `{ type: "VIRTUAL" }`, because
+       * virtual is the only type the provider issues today.
+       */
+      orderCard: build.mutation<PayCardOrderResult, void>({
+        query: () => ({
+          url: "/v1/card/order",
+          method: "POST",
+          body: { type: "VIRTUAL" },
+        }),
+        responseSchema: PayCardOrderResponseSchema,
+      }),
     }),
   });
 
@@ -99,4 +114,5 @@ export const {
   useRefreshSessionMutation,
   useLogoutMutation,
   useGetUserQuery,
+  useOrderCardMutation,
 } = cardManagementApi;

--- a/domain/api/card-management/src/schema.test.ts
+++ b/domain/api/card-management/src/schema.test.ts
@@ -1,6 +1,7 @@
 import {
   PayCardAuthorizeInitiateResponseSchema,
   PayCardLogoutResponseSchema,
+  PayCardOrderResponseSchema,
   PayCardSessionResponseSchema,
   PayCardUserResponseSchema,
 } from "./schema";
@@ -86,5 +87,21 @@ describe("PayCardUserResponseSchema", () => {
         verificationState: "SOMETHING_ELSE",
       }),
     ).toThrow();
+  });
+});
+
+describe("PayCardOrderResponseSchema", () => {
+  it("keeps the success flag and drops everything else the order answers with", () => {
+    expect(
+      PayCardOrderResponseSchema.parse({
+        success: true,
+        cardId: "card-1",
+        pan: "pan-must-not-reach-the-cache",
+      }),
+    ).toEqual({ success: true });
+  });
+
+  it("rejects a success flag that is not a boolean", () => {
+    expect(() => PayCardOrderResponseSchema.parse({ success: "yes" })).toThrow();
   });
 });

--- a/domain/api/card-management/src/schema.ts
+++ b/domain/api/card-management/src/schema.ts
@@ -38,3 +38,11 @@ export const PayCardUserResponseSchema = z.object({
   id: z.string().uuid(),
   verificationState: z.enum(["UNVERIFIED", "PENDING", "VERIFIED", "REJECTED"]),
 });
+
+/**
+ * `POST /v1/card/order` answers with nothing but this flag. The card itself only becomes observable
+ * through the card status endpoint.
+ */
+export const PayCardOrderResponseSchema = z.object({
+  success: z.boolean(),
+});

--- a/domain/api/card-management/src/types.ts
+++ b/domain/api/card-management/src/types.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import {
   PayCardAuthorizeInitiateResponseSchema,
   PayCardLogoutResponseSchema,
+  PayCardOrderResponseSchema,
   PayCardSessionResponseSchema,
   PayCardSessionSchema,
   PayCardUserResponseSchema,
@@ -17,6 +18,8 @@ export type PayCardSession = z.infer<typeof PayCardSessionSchema>;
 export type PayCardLogoutResult = z.infer<typeof PayCardLogoutResponseSchema>;
 
 export type PayCardUser = z.infer<typeof PayCardUserResponseSchema>;
+
+export type PayCardOrderResult = z.infer<typeof PayCardOrderResponseSchema>;
 
 export type PayCardAuthorizeInitiateRequest = {
   readonly clientId: string;


### PR DESCRIPTION
<!-- stac-man:stack-start -->
**Stack** _(managed by [stac-man](https://github.com/bluegardenproject/stac-man))_

- **#20979 feat/LIVE-34771-card-order-endpoint ← this PR**
- #20980 feat/LIVE-34779-card-status-endpoint
- #20999 feat/LIVE-34773-card-wallet-endpoints
- #21000 feat/LIVE-34772-card-linked-wallet-balances
<!-- stac-man:stack-end -->

### 📝 Description

Adds `orderCard`, the first Card-management endpoint beyond auth: `POST /v1/card/order`.

```ts
orderCard: build.mutation<PayCardOrderResult, void>({
  query: () => ({ url: "/v1/card/order", method: "POST", body: { type: "VIRTUAL" } }),
  responseSchema: PayCardOrderResponseSchema,
}),
```

A **mutation**, not a query: ordering a card is not idempotent and Baanx offers no idempotency key.
It takes **no argument**, because `VIRTUAL` is the only type the provider issues today, so the body
is fixed rather than parameterised on a value with one legal setting.

`PayCardOrderResponseSchema` declares `success` alone. The order answers with nothing else worth
keeping, and zod dropping the undeclared keys is what keeps anything the provider adds later out of
the RTK Query cache.

The endpoint restates none of the transport: the shared base query in `@shared/api-services`
(`services/card`) already sets the base URL, `Content-Type`, `x-client-key` and the
`Authorization: Bearer` header from `getCardSessionToken()`, plus the single 401 refresh.

35 tests pass in `@domain/api-card-management`; `tsc --noEmit` clean.

### 🧐 Review notes

Pre-push review outcome: **pass** (no blocking findings). Warns acknowledged:

- **README** — the endpoint table was exhaustive and would have gone stale; this PR adds its own row
  so the README is correct with just this commit applied.
- **Cache tags** — `orderCard` gets no `invalidatesTags` here on purpose. `CardStatus` does not exist
  until #20980, and a tag nothing provides would be dead config. It lands with the query.
- **`CARD_MANAGEMENT_TAGS`** still carries `CardManagement`, which no endpoint provides or
  invalidates. Pre-existing; left alone rather than widening this PR.

### 🔗 Context

- **JIRA**: [LIVE-34771](https://ledgerhq.atlassian.net/browse/LIVE-34771)
- **Baanx**: [`POST /v1/card/order`](https://docs.baanx.com/api-reference/card/order)
- **Stacked below**: #20980 — the status read that makes an ordered card observable


[LIVE-34771]: https://ledgerhq.atlassian.net/browse/LIVE-34771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="350" alt="Screenshot_20260824_145540_LL  DEV" src="https://github.com/user-attachments/assets/c6e7b455-767a-4b16-a366-eea5ce853197" />
