### PR TITLE
feat(card): add the getCardStatus query and invalidate it on order

### DIFF
--- a/.changeset/lucky-cards-report.md
+++ b/.changeset/lucky-cards-report.md
@@ -1,0 +1,13 @@
+---
+"@domain/api-card-management": minor
+---
+
+Add the `getCardStatus` query for `GET /v1/card/status`.
+
+- Makes an ordered card observable: `orderCard` answers `{ success: true }` and nothing else.
+- New `CardStatus` cache tag — provided by the query, invalidated by `orderCard`, so a successful
+  order refetches the status on its own.
+- `PayCardStatusResponseSchema` stays narrow, keeping any PAN, CVV or PIN the endpoint might grow out
+  of the RTK Query cache.
+- A user who never ordered a card surfaces as `error.status === 404`, not as an empty success.
+- Drops the unused `CardManagement` tag, which no endpoint provided or invalidated.

--- a/domain/api/card-management/README.md
+++ b/domain/api/card-management/README.md
@@ -24,6 +24,7 @@ shape and the reasons.
 | `logout` | POST | `/v1/auth/logout` | End the session |
 | `getUser` | GET | `/v1/user` | Read the account id and verification state |
 | `orderCard` | POST | `/v1/card/order` | Order a virtual card |
+| `getCardStatus` | GET | `/v1/card/status` | Read the ordered card's state and preview fields |
 
 `cardManagementApi` **is** `cardApi` after injection: importing this package is a module-level side
 effect that adds its endpoints to the shared service. The app registers `cardApi` (not this package)

--- a/domain/api/card-management/src/api.test.ts
+++ b/domain/api/card-management/src/api.test.ts
@@ -1,12 +1,21 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { cardApi, cardApiExtra } from "@shared/api-services";
-import { cardManagementApi, useOrderCardMutation } from "./api";
+import { cardManagementApi, useGetCardStatusQuery, useOrderCardMutation } from "./api";
 
 function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
     status: 200,
     headers: { "Content-Type": "application/json" },
   });
+}
+
+/**
+ * The refetch an invalidation triggers only reaches `fetch` a tick later: the base query awaits the
+ * session token first. Drain the queue before counting requests, so the assertion does not depend on
+ * how many microtasks the awaited dispatch happened to spend.
+ */
+function flushPendingRequests(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 0));
 }
 
 function request(spy: jest.SpyInstance): Request {
@@ -23,6 +32,16 @@ const session = {
   accessToken: "at_token",
   expiresIn: 21600,
   refreshToken: "rt_token",
+};
+
+const cardStatus = {
+  id: "card-1",
+  holderName: "Ada Lovelace",
+  expiryDate: "2029/08",
+  panLast4: "1234",
+  status: "ACTIVE",
+  type: "VIRTUAL",
+  orderedAt: "2026-08-19T10:00:00.000Z",
 };
 
 // Wired the way the apps wire it: the store registers the service api, never this package.
@@ -55,6 +74,7 @@ describe("cardManagementApi configuration", () => {
   it("injects exactly its own endpoints", () => {
     expect(Object.keys(cardManagementApi.endpoints).sort()).toEqual([
       "exchangeAuthorizationCode",
+      "getCardStatus",
       "getUser",
       "logout",
       "orderCard",
@@ -65,6 +85,11 @@ describe("cardManagementApi configuration", () => {
   it("exposes the orderCard endpoint and its hook", () => {
     expect(cardManagementApi.endpoints.orderCard).toBeDefined();
     expect(useOrderCardMutation).toBeDefined();
+  });
+
+  it("exposes the getCardStatus endpoint and its hook", () => {
+    expect(cardManagementApi.endpoints.getCardStatus).toBeDefined();
+    expect(useGetCardStatusQuery).toBeDefined();
   });
 
   it("shares the Card service reducer and middleware once registered in a store", () => {
@@ -238,6 +263,75 @@ describe("cardManagementApi requests", () => {
 
       expect(result.data).toBeUndefined();
       expect(JSON.stringify(result.error)).not.toContain("pan-must-not-reach-the-cache");
+    });
+  });
+
+  describe("getCardStatus", () => {
+    it("reads the card and drops everything the wire contract does not declare", async () => {
+      fetchSpy = jest
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(jsonResponse({ ...cardStatus, pan: "4111111111111111", cvv: "123" }));
+
+      const store = makeStore(async () => "session-token");
+      const result = await store.dispatch(cardManagementApi.endpoints.getCardStatus.initiate());
+
+      expect(request(fetchSpy).url).toBe("https://card.test/v1/card/status");
+      expect(request(fetchSpy).method).toBe("GET");
+      expect(request(fetchSpy).headers.get("authorization")).toBe("Bearer session-token");
+      expect(result.data).toEqual(cardStatus);
+    });
+
+    it("reports a user who never ordered a card as a 404", async () => {
+      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({ message: "CARD NOT FOUND" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      const store = makeStore(async () => "session-token");
+      const result = await store.dispatch(cardManagementApi.endpoints.getCardStatus.initiate());
+
+      expect(result.data).toBeUndefined();
+      expect(result.error).toMatchObject({ status: 404 });
+    });
+
+    it("rejects a status the wire contract does not name", async () => {
+      fetchSpy = jest
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(jsonResponse({ ...cardStatus, status: "SOMETHING_ELSE" }));
+
+      const store = makeStore(async () => "session-token");
+      const result = await store.dispatch(cardManagementApi.endpoints.getCardStatus.initiate());
+
+      expect(result.data).toBeUndefined();
+      expect(result.error).toBeDefined();
+    });
+
+    it("refetches after an order, because the order invalidates the card status", async () => {
+      fetchSpy = jest
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(async (input: RequestInfo | URL) =>
+          new URL((input as Request).url).pathname === "/v1/card/order"
+            ? jsonResponse({ success: true })
+            : jsonResponse(cardStatus),
+        );
+
+      const store = makeStore(async () => "session-token");
+      // Subscribed, so the invalidation has a live cache entry to refetch.
+      const status = store.dispatch(
+        cardManagementApi.endpoints.getCardStatus.initiate(undefined, { subscribe: true }),
+      );
+      await status;
+      await store.dispatch(cardManagementApi.endpoints.orderCard.initiate());
+      await flushPendingRequests();
+
+      const statusRequests = fetchSpy.mock.calls.filter(
+        ([input]) => new URL((input as Request).url).pathname === "/v1/card/status",
+      );
+      expect(statusRequests).toHaveLength(2);
+
+      status.unsubscribe();
     });
   });
 

--- a/domain/api/card-management/src/api.ts
+++ b/domain/api/card-management/src/api.ts
@@ -5,6 +5,7 @@ import {
   PayCardOrderResponseSchema,
   PayCardSessionResponseSchema,
   PayCardSessionSchema,
+  PayCardStatusResponseSchema,
   PayCardUserResponseSchema,
 } from "./schema";
 import { transformPayCardSessionResponse } from "./transforms";
@@ -14,6 +15,7 @@ import type {
   PayCardOrderResult,
   PayCardRefreshSessionRequest,
   PayCardSession,
+  PayCardStatus,
   PayCardUser,
 } from "./types";
 
@@ -78,6 +80,18 @@ export const cardManagementApi = cardApi
           body: { type: "VIRTUAL" },
         }),
         responseSchema: PayCardOrderResponseSchema,
+        // The order answers `{ success: true }` and nothing else, so the card it created only
+        // becomes observable once the status is read again.
+        invalidatesTags: ["CardStatus"],
+      }),
+
+      getCardStatus: build.query<PayCardStatus, void>({
+        query: () => ({
+          url: "/v1/card/status",
+          method: "GET",
+        }),
+        responseSchema: PayCardStatusResponseSchema,
+        providesTags: ["CardStatus"],
       }),
     }),
   });
@@ -90,4 +104,5 @@ export const {
   useLogoutMutation,
   useGetUserQuery,
   useOrderCardMutation,
+  useGetCardStatusQuery,
 } = cardManagementApi;

--- a/domain/api/card-management/src/constants.ts
+++ b/domain/api/card-management/src/constants.ts
@@ -2,4 +2,4 @@
  * RTK Query cache tags owned by the Card Management use case. Registered on the shared `cardApi` via
  * `enhanceEndpoints({ addTagTypes })`, so the shared service never has to know they exist.
  */
-export const CARD_MANAGEMENT_TAGS = ["CardManagement"] as const;
+export const CARD_MANAGEMENT_TAGS = ["CardStatus"] as const;

--- a/domain/api/card-management/src/schema.test.ts
+++ b/domain/api/card-management/src/schema.test.ts
@@ -2,6 +2,7 @@ import {
   PayCardLogoutResponseSchema,
   PayCardOrderResponseSchema,
   PayCardSessionResponseSchema,
+  PayCardStatusResponseSchema,
   PayCardUserResponseSchema,
 } from "./schema";
 
@@ -72,5 +73,40 @@ describe("PayCardOrderResponseSchema", () => {
 
   it("rejects a success flag that is not a boolean", () => {
     expect(() => PayCardOrderResponseSchema.parse({ success: "yes" })).toThrow();
+  });
+});
+
+describe("PayCardStatusResponseSchema", () => {
+  const cardStatus = {
+    id: "card-1",
+    holderName: "Ada Lovelace",
+    expiryDate: "2029/08",
+    panLast4: "1234",
+    status: "ACTIVE",
+    type: "VIRTUAL",
+    orderedAt: "2026-08-19T10:00:00.000Z",
+  };
+
+  it("drops the card secrets the endpoint must never be trusted to withhold", () => {
+    expect(
+      PayCardStatusResponseSchema.parse({
+        ...cardStatus,
+        pan: "4111111111111111",
+        cvv: "123",
+        pin: "0000",
+      }),
+    ).toEqual(cardStatus);
+  });
+
+  it("rejects a status the wire contract does not name", () => {
+    expect(() =>
+      PayCardStatusResponseSchema.parse({ ...cardStatus, status: "SOMETHING_ELSE" }),
+    ).toThrow();
+  });
+
+  it("rejects a card type the wire contract does not name", () => {
+    expect(() =>
+      PayCardStatusResponseSchema.parse({ ...cardStatus, type: "SOMETHING_ELSE" }),
+    ).toThrow();
   });
 });

--- a/domain/api/card-management/src/schema.ts
+++ b/domain/api/card-management/src/schema.ts
@@ -37,3 +37,18 @@ export const PayCardUserResponseSchema = z.object({
 export const PayCardOrderResponseSchema = z.object({
   success: z.boolean(),
 });
+
+/**
+ * Narrow on purpose, like the user schema: the card's own status carries no PAN, CVV or PIN, and
+ * anything the provider adds later stays out of the cache until a caller asks for it.
+ */
+export const PayCardStatusResponseSchema = z.object({
+  id: z.string().min(1),
+  holderName: z.string().min(1),
+  /** `YYYY/MM`, as the provider formats it. */
+  expiryDate: z.string().min(1),
+  panLast4: z.string().min(1),
+  status: z.enum(["ACTIVE", "FROZEN", "BLOCKED"]),
+  type: z.enum(["VIRTUAL", "PHYSICAL", "METAL"]),
+  orderedAt: z.string().min(1),
+});

--- a/domain/api/card-management/src/types.ts
+++ b/domain/api/card-management/src/types.ts
@@ -4,6 +4,7 @@ import {
   PayCardOrderResponseSchema,
   PayCardSessionResponseSchema,
   PayCardSessionSchema,
+  PayCardStatusResponseSchema,
   PayCardUserResponseSchema,
 } from "./schema";
 
@@ -17,6 +18,8 @@ export type PayCardLogoutResult = z.infer<typeof PayCardLogoutResponseSchema>;
 export type PayCardUser = z.infer<typeof PayCardUserResponseSchema>;
 
 export type PayCardOrderResult = z.infer<typeof PayCardOrderResponseSchema>;
+
+export type PayCardStatus = z.infer<typeof PayCardStatusResponseSchema>;
 
 export type PayCardAuthorizationCodeRequest = {
   readonly code: string;


### PR DESCRIPTION
<!-- stac-man:stack-start -->
**Stack** _(managed by [stac-man](https://github.com/bluegardenproject/stac-man))_

- **#20980 feat/LIVE-34779-card-status-endpoint ← this PR**
- #20999 feat/LIVE-34773-card-wallet-endpoints
- #21000 feat/LIVE-34772-card-linked-wallet-balances
- #21115 fix/pay-card-forget-user-on-session-end
<!-- stac-man:stack-end -->

### 📝 Description

Adds `getCardStatus` (`GET /v1/card/status`) and wires it to the order from #20979.

`POST /v1/card/order` answers `{ success: true }` and nothing else, so the card it created only
becomes observable through the status read. That is the whole reason this follows immediately:

```ts
getCardStatus: build.query<PayCardStatus, void>({
  query: () => ({ url: "/v1/card/status", method: "GET" }),
  responseSchema: PayCardStatusResponseSchema,
  providesTags: ["CardStatus"],
}),
```

The new `CardStatus` tag is provided here and invalidated by `orderCard`, so a successful order
refetches the status on its own — no caller has to sequence the two.

`PayCardStatusResponseSchema` stays narrow, like `PayCardUserResponseSchema`: the status carries no
PAN, CVV or PIN today, and zod dropping undeclared keys is what keeps it that way if the endpoint
ever grows them.

**A user who never ordered a card surfaces as `error.status === 404`**, not as an empty success. That
is the signal every downstream screen keys off, so it has its own test.

37 tests pass in `@domain/api-card-management`; `tsc --noEmit` clean.

### 🧐 Review notes

Pre-push review outcome: **pass** (no blocking findings). Warns acknowledged:

- **Enum values verified against the Baanx spec.** The reviewer flagged that an undocumented status
  (`PENDING`/`CREATED`) would reject the whole response, and that the refetch this PR introduces is
  exactly where that would bite. Checked the [status reference](https://docs.baanx.com/api-reference/card/status):
  the documented sets are exactly `ACTIVE | FROZEN | BLOCKED` and `VIRTUAL | PHYSICAL | METAL`, with
  no provisioning status — a card that is not ready yet answers **404**, which this PR already
  handles. Schema left as declared.
- **Schema strictness** — added `.min(1)` to the free-form strings. Deliberately stopped short of
  `.uuid()` on `id`, `.datetime()` on `orderedAt` and a `YYYY/MM` regex on `expiryDate`: we have not
  yet observed a real staging response, and over-strict validation on an unobserved boundary fails
  closed and blanks the card screen. Worth tightening once the DevTools harness has exercised it.
- **Invalidation test** — the reviewer noted the more valuable case is `404 → order → refetch` rather
  than the seeded-success path tested here. Confirmed the current test is not a tautology (removing
  `invalidatesTags` fails it: 1 status request instead of 2). The 404-seeded variant is worth adding
  alongside it.
- **Invalidation test timing** — the assertion now waits on an explicit flush before counting
  requests. `cardBaseQuery` awaits the session token before it calls `fetch`, so the refetch an
  invalidation triggers lands a tick later; the test previously passed only because awaiting the
  mutation happened to drain enough microtasks.
- **`CARD_MANAGEMENT_TAGS`** — the unused `CardManagement` tag is **now removed** in this PR, so the
  constant is `["CardStatus"]`. It was flagged again in review, and since this PR is the one that
  introduces the tag the constant exists to hold, removing it here beat leaving dead cache config
  behind. Nothing provided or invalidated it; a repo-wide search found only the declaration.

### 🔗 Context

- **JIRA**: [LIVE-34779](https://ledgerhq.atlassian.net/browse/LIVE-34779)
- **Baanx**: [`GET /v1/card/status`](https://docs.baanx.com/api-reference/card/status)
- **Was stacked on**: #20979 (**merged**) — the order this observes. This PR now targets `develop`.


[LIVE-34779]: https://ledgerhq.atlassian.net/browse/LIVE-34779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
