### PR TITLE
ci(workflows): stub PR-only required checks in merge queue

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -247,6 +247,20 @@ jobs:
       AWS_CACHE_ROLE_NAME: ${{ secrets.AWS_CACHE_ROLE_NAME }}
       NX_KEY: ${{ secrets.NX_KEY }}
 
+  # Stubs for required checks whose real workflow only runs on pull_request.
+  check-sync: # mirrors test-workflows-sync.yml
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Report not applicable
+        run: echo "Workflow files in a merge group are already merged with develop - nothing to check."
+
+  danger:
+    name: "Validate PR conventions"
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Report not applicable
+        run: echo "PR conventions are validated on the pull request, before it can be queued."
+
   # Final Check required
   ok:
     name: "OK"


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Prevent merge queue from stalling due to required danger and sync check jobs - Checks can only be defined on a branch overall, there is no way to use different checks for PR and merge queue. Without these the merge queue would fail
