### PR TITLE
[LWDM] feat(pay-card): open the Baanx authorize page directly (LIVE-36301)

### DIFF
--- a/.changeset/plain-logins-open.md
+++ b/.changeset/plain-logins-open.md
@@ -24,3 +24,8 @@ code against this attempt's challenge, so no other attempt can exchange it. The 
 sends the same `redirect_uri`, and both token grants move to `/v1/auth/oauth2/token`.
 
 `oauthConfig` gains `apiUrl`, which is the host the authorize page lives on.
+
+`prepareAttempt` builds the authorize URL, rather than the transition that follows it. The URL builder
+throws on a misconfigured `apiUrl`, and a throw inside an action stops the machine instead of reaching
+a transition. From the actor it lands on `onError`, which wipes the stored attempt and reports a
+failure the user can retry.

--- a/.changeset/plain-logins-open.md
+++ b/.changeset/plain-logins-open.md
@@ -1,0 +1,26 @@
+---
+"@features/flow-pay-card-auth": minor
+"@domain/api-card-management": minor
+"live-mobile": minor
+"ledger-live-desktop": minor
+---
+
+Open the Baanx authorize page directly, and drop the CSRF state (LIVE-36301)
+
+The login no longer asks the backend where to send the user. It builds the authorize URL itself and
+opens the secure browser on it, and the provider hosts the page and owns the redirect. That removes a
+network call, a machine state and one way a login could fail.
+
+```
+GET {CARD_API_URL}/v1/auth/oauth2/authorize
+  ?client_id=…&response_type=code
+  &scope=openid profile email platform:full offline_access
+  &redirect_uri=…&code_challenge=…&code_challenge_method=S256&prompt=consent
+```
+
+The attempt is now a PKCE pair alone. The redirect carries `code`, and the `state` that used to travel
+with it is gone, because PKCE already ties the code to the verifier on disk: the provider issues the
+code against this attempt's challenge, so no other attempt can exchange it. The token exchange still
+sends the same `redirect_uri`, and both token grants move to `/v1/auth/oauth2/token`.
+
+`oauthConfig` gains `apiUrl`, which is the host the authorize page lives on.

--- a/.changeset/plain-logins-open.md
+++ b/.changeset/plain-logins-open.md
@@ -1,6 +1,7 @@
 ---
 "@features/flow-pay-card-auth": minor
 "@domain/api-card-management": minor
+"@features/platform-card": minor
 "live-mobile": minor
 "ledger-live-desktop": minor
 ---
@@ -14,14 +15,15 @@ network call, a machine state and one way a login could fail.
 ```
 GET {CARD_API_URL}/v1/auth/oauth2/authorize
   ?client_id=…&response_type=code
-  &scope=openid profile email platform:full offline_access
+  &scope=openid profile email offline_access
   &redirect_uri=…&code_challenge=…&code_challenge_method=S256&prompt=consent
 ```
 
 The attempt is now a PKCE pair alone. The redirect carries `code`, and the `state` that used to travel
 with it is gone, because PKCE already ties the code to the verifier on disk: the provider issues the
-code against this attempt's challenge, so no other attempt can exchange it. The token exchange still
-sends the same `redirect_uri`, and both token grants move to `/v1/auth/oauth2/token`.
+code against this attempt's challenge, so no other attempt can exchange it. Both token grants move to
+`/v1/auth/oauth2/token`, and neither repeats `redirect_uri` there: Baanx's contract for that endpoint
+takes only `grant_type`, `code`, and `code_verifier`.
 
 `oauthConfig` gains `apiUrl`, which is the host the authorize page lives on.
 
@@ -29,3 +31,8 @@ sends the same `redirect_uri`, and both token grants move to `/v1/auth/oauth2/to
 throws on a misconfigured `apiUrl`, and a throw inside an action stops the machine instead of reaching
 a transition. From the actor it lands on `onError`, which wipes the stored attempt and reports a
 failure the user can retry.
+
+A live exchange against Baanx's UAT environment answered with no `refresh_token_expires_in`, which
+`PayCardSessionResponseSchema` required. That field is gone from the schema, the session, and the
+stored lifetimes: Baanx's contract carries no lifetime for the refresh token, only for the access
+token, so nothing here can track one.

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/index.tsx
@@ -18,6 +18,7 @@ import { VerifyAddressExecutorLWD } from "./verifyAddressIntent/VerifyAddressExe
 
 // Baanx uses the same value for the client key header and the OAuth `client_id`.
 const oauthConfig: CardLoginOauthConfig = {
+  apiUrl: getEnv("CARD_API_URL"),
   clientId: getEnv("CARD_BAANX_CLIENT_KEY"),
   // No `deepLink`: the user's own browser opens the page, and it reports nothing back (LIVE-34740).
   redirectUri: getEnv("CARD_OAUTH_REDIRECT_URI"),

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.test.ts
@@ -70,6 +70,7 @@ describe("usePayTabViewModel", () => {
     // The provider matches the redirect URI verbatim on the token exchange. The deep link is the app's
     // own, and it comes from the module that also spells the Pay tab route.
     expect(result.current.oauthConfig).toEqual({
+      apiUrl: getEnv("CARD_API_URL"),
       clientId: getEnv("CARD_BAANX_CLIENT_KEY"),
       redirectUri: getEnv("CARD_OAUTH_REDIRECT_URI"),
       deepLink: PAY_TAB_DEEP_LINK,
@@ -77,18 +78,17 @@ describe("usePayTabViewModel", () => {
   });
 
   it("should hand the login flow the redirect the deep link carried", () => {
-    // react-navigation parses `ledgerlive://paytab?code=…&state=…` into the route params.
-    routeParams = { code: "auth-code", state: "state-value" };
+    // react-navigation parses `ledgerlive://paytab?code=…` into the route params.
+    routeParams = { code: "auth-code" };
 
     const { result } = renderHook(() => usePayTabViewModel());
 
-    expect(result.current.callback).toEqual({ code: "auth-code", state: "state-value" });
+    expect(result.current.callback).toEqual({ code: "auth-code" });
   });
 
   it.each([
     ["there are no params", undefined],
-    ["the code is missing", { state: "state-value" }],
-    ["the state is missing", { code: "auth-code" }],
+    ["the code is missing", {}],
   ])("should report no redirect when %s", (_case, params) => {
     routeParams = params;
 

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.test.ts
@@ -67,8 +67,9 @@ describe("usePayTabViewModel", () => {
   it("should expose the OAuth client configuration", () => {
     const { result } = renderHook(() => usePayTabViewModel());
 
-    // The provider matches the redirect URI verbatim on the token exchange. The deep link is the app's
-    // own, and it comes from the module that also spells the Pay tab route.
+    // The provider only sees the redirect URI on the authorize URL, where it must match what is
+    // whitelisted with the provider. The deep link is the app's own, and it comes from the module
+    // that also spells the Pay tab route.
     expect(result.current.oauthConfig).toEqual({
       apiUrl: getEnv("CARD_API_URL"),
       clientId: getEnv("CARD_BAANX_CLIENT_KEY"),

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
@@ -41,6 +41,7 @@ export function usePayTabViewModel() {
   // Baanx uses the same value for the client key header and the OAuth `client_id`.
   const oauthConfig: CardLoginOauthConfig = useMemo(
     () => ({
+      apiUrl: getEnv("CARD_API_URL"),
       clientId: getEnv("CARD_BAANX_CLIENT_KEY"),
       redirectUri: getEnv("CARD_OAUTH_REDIRECT_URI"),
       deepLink: PAY_TAB_DEEP_LINK,
@@ -48,10 +49,11 @@ export function usePayTabViewModel() {
     [],
   );
 
-  // The OAuth redirect, when the deep link brought one. Both halves must be there to mean anything.
+  // The OAuth redirect, when the deep link brought one. The code is the whole of it: PKCE ties it to
+  // the verifier on disk, so nothing else has to be echoed back.
   const callback: PayCardAuthCallback | null = useMemo(
-    () => (params?.code && params?.state ? { code: params.code, state: params.state } : null),
-    [params?.code, params?.state],
+    () => (params?.code ? { code: params.code } : null),
+    [params?.code],
   );
 
   const featureTour: FeatureTourProps = useMemo(

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/types.ts
@@ -2,8 +2,8 @@ import { ScreenName } from "~/const";
 
 export type PayTabNavigatorParamList = {
   /**
-   * `ledgerlive://paytab?code=…&state=…` is the OAuth redirect. React-navigation parses the query for
+   * `ledgerlive://paytab?code=…` is the OAuth redirect. React-navigation parses the query for
    * us, so the login flow receives the two values from the route rather than from the raw URL.
    */
-  [ScreenName.PayTab]: { code?: string; state?: string } | undefined;
+  [ScreenName.PayTab]: { code?: string } | undefined;
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/types.ts
@@ -3,7 +3,7 @@ import { ScreenName } from "~/const";
 export type PayTabNavigatorParamList = {
   /**
    * `ledgerlive://paytab?code=…` is the OAuth redirect. React-navigation parses the query for
-   * us, so the login flow receives the two values from the route rather than from the raw URL.
+   * us, so the login flow receives the value from the route rather than from the raw URL.
    */
   [ScreenName.PayTab]: { code?: string } | undefined;
 };

--- a/domain/api/card-management/src/api.test.ts
+++ b/domain/api/card-management/src/api.test.ts
@@ -17,14 +17,12 @@ const sessionResponse = {
   access_token: "at_token",
   expires_in: 21600,
   refresh_token: "rt_token",
-  refresh_token_expires_in: 15897600,
 };
 
 const session = {
   accessToken: "at_token",
   expiresIn: 21600,
   refreshToken: "rt_token",
-  refreshTokenExpiresIn: 15897600,
 };
 
 // Wired the way the apps wire it: the store registers the service api, never this package.
@@ -91,7 +89,6 @@ describe("cardManagementApi requests", () => {
       const result = await store.dispatch(
         cardManagementApi.endpoints.exchangeAuthorizationCode.initiate({
           code: "auth-code",
-          redirectUri: "ledgerlive://paytab",
           codeVerifier: "verifier",
         }),
       );
@@ -101,7 +98,6 @@ describe("cardManagementApi requests", () => {
       expect(JSON.parse(await request(fetchSpy).clone().text())).toEqual({
         grant_type: "authorization_code",
         code: "auth-code",
-        redirect_uri: "ledgerlive://paytab",
         code_verifier: "verifier",
       });
       expect(result.data).toEqual(session);
@@ -121,7 +117,6 @@ describe("cardManagementApi requests", () => {
       const result = await store.dispatch(
         cardManagementApi.endpoints.exchangeAuthorizationCode.initiate({
           code: "auth-code",
-          redirectUri: "ledgerlive://paytab",
           codeVerifier: "verifier",
         }),
       );

--- a/domain/api/card-management/src/api.test.ts
+++ b/domain/api/card-management/src/api.test.ts
@@ -58,7 +58,6 @@ describe("cardManagementApi configuration", () => {
     expect(Object.keys(cardManagementApi.endpoints).sort()).toEqual([
       "exchangeAuthorizationCode",
       "getUser",
-      "initiateAuthorize",
       "logout",
       "orderCard",
       "refreshSession",
@@ -84,40 +83,6 @@ describe("cardManagementApi requests", () => {
     fetchSpy?.mockRestore();
   });
 
-  describe("initiateAuthorize", () => {
-    it("sends the OAuth parameters and returns the hosted login URL", async () => {
-      fetchSpy = jest
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(jsonResponse({ token: "jwt", url: "https://card.test/login" }));
-
-      const store = makeStore();
-      const result = await store.dispatch(
-        cardManagementApi.endpoints.initiateAuthorize.initiate({
-          clientId: "client-key",
-          redirectUri: "ledgerlive://paytab",
-          state: "state-value",
-          codeChallenge: "challenge-value",
-        }),
-      );
-
-      const { searchParams, pathname } = new URL(request(fetchSpy).url);
-      expect(pathname).toBe("/v1/auth/oauth/authorize/initiate");
-      expect(request(fetchSpy).method).toBe("GET");
-      expect(Object.fromEntries(searchParams)).toEqual({
-        client_id: "client-key",
-        response_type: "code",
-        redirect_uri: "ledgerlive://paytab",
-        state: "state-value",
-        code_challenge: "challenge-value",
-        code_challenge_method: "S256",
-        mode: "api",
-      });
-      expect(request(fetchSpy).headers.get("x-client-key")).toBe("client-key");
-      expect(request(fetchSpy).headers.get("authorization")).toBeNull();
-      expect(result.data).toEqual({ url: "https://card.test/login" });
-    });
-  });
-
   describe("exchangeAuthorizationCode", () => {
     it("posts the authorization_code grant and maps the session onto camelCase", async () => {
       fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(sessionResponse));
@@ -131,7 +96,7 @@ describe("cardManagementApi requests", () => {
         }),
       );
 
-      expect(request(fetchSpy).url).toBe("https://card.test/v1/auth/oauth/token");
+      expect(request(fetchSpy).url).toBe("https://card.test/v1/auth/oauth2/token");
       expect(request(fetchSpy).method).toBe("POST");
       expect(JSON.parse(await request(fetchSpy).clone().text())).toEqual({
         grant_type: "authorization_code",
@@ -177,7 +142,7 @@ describe("cardManagementApi requests", () => {
         cardManagementApi.endpoints.refreshSession.initiate({ refreshToken: "rt_token" }),
       );
 
-      expect(request(fetchSpy).url).toBe("https://card.test/v1/auth/oauth/token");
+      expect(request(fetchSpy).url).toBe("https://card.test/v1/auth/oauth2/token");
       expect(JSON.parse(await request(fetchSpy).clone().text())).toEqual({
         grant_type: "refresh_token",
         refresh_token: "rt_token",
@@ -284,17 +249,10 @@ describe("cardManagementApi requests", () => {
   it("rejects a response that does not match the wire contract", async () => {
     fetchSpy = jest
       .spyOn(globalThis, "fetch")
-      .mockResolvedValue(jsonResponse({ token: "jwt", url: "not-a-url" }));
+      .mockResolvedValue(jsonResponse({ id: "not-a-uuid", verification_state: "VERIFIED" }));
 
-    const store = makeStore();
-    const result = await store.dispatch(
-      cardManagementApi.endpoints.initiateAuthorize.initiate({
-        clientId: "client-key",
-        redirectUri: "ledgerlive://paytab",
-        state: "state-value",
-        codeChallenge: "challenge-value",
-      }),
-    );
+    const store = makeStore(async () => "session-token");
+    const result = await store.dispatch(cardManagementApi.endpoints.getUser.initiate());
 
     expect(result.data).toBeUndefined();
     expect(result.error).toBeDefined();

--- a/domain/api/card-management/src/api.ts
+++ b/domain/api/card-management/src/api.ts
@@ -22,14 +22,12 @@ export const cardManagementApi = cardApi
   .injectEndpoints({
     endpoints: build => ({
       exchangeAuthorizationCode: build.mutation<PayCardSession, PayCardAuthorizationCodeRequest>({
-        query: ({ code, redirectUri, codeVerifier }) => ({
+        query: ({ code, codeVerifier }) => ({
           url: "/v1/auth/oauth2/token",
           method: "POST",
           body: {
             grant_type: "authorization_code",
             code,
-            // The provider compares it with the one the authorization carried.
-            redirect_uri: redirectUri,
             code_verifier: codeVerifier,
           },
         }),

--- a/domain/api/card-management/src/api.ts
+++ b/domain/api/card-management/src/api.ts
@@ -1,7 +1,6 @@
 import { cardApi } from "@shared/api-services";
 import { CARD_MANAGEMENT_TAGS } from "./constants";
 import {
-  PayCardAuthorizeInitiateResponseSchema,
   PayCardLogoutResponseSchema,
   PayCardOrderResponseSchema,
   PayCardSessionResponseSchema,
@@ -11,8 +10,6 @@ import {
 import { transformPayCardSessionResponse } from "./transforms";
 import type {
   PayCardAuthorizationCodeRequest,
-  PayCardAuthorizeInitiate,
-  PayCardAuthorizeInitiateRequest,
   PayCardLogoutResult,
   PayCardOrderResult,
   PayCardRefreshSessionRequest,
@@ -24,28 +21,9 @@ export const cardManagementApi = cardApi
   .enhanceEndpoints({ addTagTypes: CARD_MANAGEMENT_TAGS })
   .injectEndpoints({
     endpoints: build => ({
-      /** A mutation, not a query: every attempt carries a fresh `state` and PKCE challenge. */
-      initiateAuthorize: build.mutation<PayCardAuthorizeInitiate, PayCardAuthorizeInitiateRequest>({
-        query: ({ clientId, redirectUri, state, codeChallenge }) => ({
-          url: "/v1/auth/oauth/authorize/initiate",
-          method: "GET",
-          params: {
-            client_id: clientId,
-            response_type: "code",
-            redirect_uri: redirectUri,
-            state,
-            code_challenge: codeChallenge,
-            code_challenge_method: "S256",
-            // Without this the endpoint answers 302 to the hosted UI; `api` returns it as JSON.
-            mode: "api",
-          },
-        }),
-        responseSchema: PayCardAuthorizeInitiateResponseSchema,
-      }),
-
       exchangeAuthorizationCode: build.mutation<PayCardSession, PayCardAuthorizationCodeRequest>({
         query: ({ code, redirectUri, codeVerifier }) => ({
-          url: "/v1/auth/oauth/token",
+          url: "/v1/auth/oauth2/token",
           method: "POST",
           body: {
             grant_type: "authorization_code",
@@ -63,7 +41,7 @@ export const cardManagementApi = cardApi
       /** Same endpoint as the code exchange, separated by `grant_type`. */
       refreshSession: build.mutation<PayCardSession, PayCardRefreshSessionRequest>({
         query: ({ refreshToken }) => ({
-          url: "/v1/auth/oauth/token",
+          url: "/v1/auth/oauth2/token",
           method: "POST",
           body: {
             grant_type: "refresh_token",
@@ -109,7 +87,6 @@ export const cardManagementApi = cardApi
 export type CardManagementApi = typeof cardManagementApi;
 
 export const {
-  useInitiateAuthorizeMutation,
   useExchangeAuthorizationCodeMutation,
   useRefreshSessionMutation,
   useLogoutMutation,

--- a/domain/api/card-management/src/schema.test.ts
+++ b/domain/api/card-management/src/schema.test.ts
@@ -1,38 +1,9 @@
 import {
-  PayCardAuthorizeInitiateResponseSchema,
   PayCardLogoutResponseSchema,
   PayCardOrderResponseSchema,
   PayCardSessionResponseSchema,
   PayCardUserResponseSchema,
 } from "./schema";
-
-describe("PayCardAuthorizeInitiateResponseSchema", () => {
-  it("keeps the hosted login URL, and drops the programmatic-flow token", () => {
-    expect(
-      PayCardAuthorizeInitiateResponseSchema.parse({
-        token: "jwt",
-        url: "https://card.test/login",
-      }),
-    ).toEqual({ url: "https://card.test/login" });
-  });
-
-  it("rejects a malformed login URL", () => {
-    expect(() =>
-      PayCardAuthorizeInitiateResponseSchema.parse({ token: "jwt", url: "not-a-url" }),
-    ).toThrow();
-  });
-
-  it.each(["http://card.test/login", "javascript:alert('login')", "ledgerlive://paytab"])(
-    "rejects %s as a login URL",
-    url => {
-      expect(() => PayCardAuthorizeInitiateResponseSchema.parse({ token: "jwt", url })).toThrow();
-    },
-  );
-
-  it("rejects a payload missing the login URL", () => {
-    expect(() => PayCardAuthorizeInitiateResponseSchema.parse({ token: "jwt" })).toThrow();
-  });
-});
 
 describe("PayCardSessionResponseSchema", () => {
   it("accepts a token payload", () => {

--- a/domain/api/card-management/src/schema.test.ts
+++ b/domain/api/card-management/src/schema.test.ts
@@ -11,7 +11,6 @@ describe("PayCardSessionResponseSchema", () => {
       access_token: "at_token",
       expires_in: 21600,
       refresh_token: "rt_token",
-      refresh_token_expires_in: 15897600,
     };
 
     expect(PayCardSessionResponseSchema.parse(response)).toEqual(response);
@@ -23,7 +22,6 @@ describe("PayCardSessionResponseSchema", () => {
         access_token: "at_token",
         expires_in: 0,
         refresh_token: "rt_token",
-        refresh_token_expires_in: 15897600,
       }),
     ).toThrow();
   });

--- a/domain/api/card-management/src/schema.ts
+++ b/domain/api/card-management/src/schema.ts
@@ -1,15 +1,5 @@
 import { z } from "zod";
 
-/**
- * `mode=api` also answers with a `token`, the JWT of the programmatic flow — `POST /v1/auth/login`
- * then `POST /v1/auth/oauth/authorize`. The hosted UI needs none of it, so zod drops it here rather
- * than parking a short-lived credential in the cache.
- */
-export const PayCardAuthorizeInitiateResponseSchema = z.object({
-  /** Handed straight to a browser, so no other scheme is accepted. */
-  url: z.string().url().startsWith("https://"),
-});
-
 /** Both grants — `authorization_code` and `refresh_token` — answer with this shape. */
 export const PayCardSessionResponseSchema = z.object({
   access_token: z.string().min(1),

--- a/domain/api/card-management/src/schema.ts
+++ b/domain/api/card-management/src/schema.ts
@@ -1,19 +1,20 @@
 import { z } from "zod";
 
-/** Both grants — `authorization_code` and `refresh_token` — answer with this shape. */
+/**
+ * Both grants — `authorization_code` and `refresh_token` — answer with this shape. Baanx's contract
+ * carries no lifetime for the refresh token itself, only for the access token.
+ */
 export const PayCardSessionResponseSchema = z.object({
   access_token: z.string().min(1),
   expires_in: z.number().int().positive(),
   refresh_token: z.string().min(1),
-  refresh_token_expires_in: z.number().int().positive(),
 });
 
-/** Lifetimes stay the durations the backend sent: turning them into instants needs a clock. */
+/** The lifetime stays the duration the backend sent: turning it into an instant needs a clock. */
 export const PayCardSessionSchema = z.object({
   accessToken: z.string().min(1),
   expiresIn: z.number().int().positive(),
   refreshToken: z.string().min(1),
-  refreshTokenExpiresIn: z.number().int().positive(),
 });
 
 export const PayCardLogoutResponseSchema = z.object({

--- a/domain/api/card-management/src/transforms.test.ts
+++ b/domain/api/card-management/src/transforms.test.ts
@@ -7,13 +7,11 @@ describe("transformPayCardSessionResponse", () => {
         access_token: "access-token",
         expires_in: 3600,
         refresh_token: "refresh-token",
-        refresh_token_expires_in: 2592000,
       }),
     ).toEqual({
       accessToken: "access-token",
       expiresIn: 3600,
       refreshToken: "refresh-token",
-      refreshTokenExpiresIn: 2592000,
     });
   });
 });

--- a/domain/api/card-management/src/transforms.ts
+++ b/domain/api/card-management/src/transforms.ts
@@ -6,6 +6,5 @@ export function transformPayCardSessionResponse(response: PayCardSessionResponse
     accessToken: response.access_token,
     expiresIn: response.expires_in,
     refreshToken: response.refresh_token,
-    refreshTokenExpiresIn: response.refresh_token_expires_in,
   };
 }

--- a/domain/api/card-management/src/types.ts
+++ b/domain/api/card-management/src/types.ts
@@ -20,8 +20,6 @@ export type PayCardOrderResult = z.infer<typeof PayCardOrderResponseSchema>;
 
 export type PayCardAuthorizationCodeRequest = {
   readonly code: string;
-  /** Must match the `redirect_uri` sent on the authorize URL exactly. */
-  readonly redirectUri: string;
   readonly codeVerifier: string;
 };
 

--- a/domain/api/card-management/src/types.ts
+++ b/domain/api/card-management/src/types.ts
@@ -1,14 +1,11 @@
 import { z } from "zod";
 import {
-  PayCardAuthorizeInitiateResponseSchema,
   PayCardLogoutResponseSchema,
   PayCardOrderResponseSchema,
   PayCardSessionResponseSchema,
   PayCardSessionSchema,
   PayCardUserResponseSchema,
 } from "./schema";
-
-export type PayCardAuthorizeInitiate = z.infer<typeof PayCardAuthorizeInitiateResponseSchema>;
 
 /** Wire shape of a token response, before it is mapped onto {@link PayCardSession}. */
 export type PayCardSessionResponse = z.infer<typeof PayCardSessionResponseSchema>;
@@ -21,19 +18,9 @@ export type PayCardUser = z.infer<typeof PayCardUserResponseSchema>;
 
 export type PayCardOrderResult = z.infer<typeof PayCardOrderResponseSchema>;
 
-export type PayCardAuthorizeInitiateRequest = {
-  readonly clientId: string;
-  /** Whitelisted with the provider. The token exchange has to send the same value. */
-  readonly redirectUri: string;
-  /** CSRF token echoed back on the redirect. The backend requires at least 8 characters. */
-  readonly state: string;
-  /** `BASE64URL(SHA256(codeVerifier))`; the verifier itself is sent later to the token endpoint. */
-  readonly codeChallenge: string;
-};
-
 export type PayCardAuthorizationCodeRequest = {
   readonly code: string;
-  /** Must match the `redirectUri` sent to the authorize initiation exactly. */
+  /** Must match the `redirect_uri` sent on the authorize URL exactly. */
   readonly redirectUri: string;
   readonly codeVerifier: string;
 };

--- a/features/flow/pay-card-auth/src/components/CardLogin/__tests__/useCardLoginViewModel.web.test.tsx
+++ b/features/flow/pay-card-auth/src/components/CardLogin/__tests__/useCardLoginViewModel.web.test.tsx
@@ -13,7 +13,6 @@ describe("mapSnapshotToViewModel", () => {
   it.each([
     "hydrating",
     "preparingAttempt",
-    "initiatingAuthorize",
     "awaitingHostedLogin",
     "validatingCallback",
     "exchangingCode",
@@ -36,10 +35,8 @@ describe("mapSnapshotToViewModel", () => {
 
   it.each([
     "pkce_failed",
-    "initiate_failed",
     "browser_open_failed",
     "missing_attempt",
-    "state_mismatch",
     "exchange_failed",
     "persist_failed",
     "fetch_user_failed",

--- a/features/flow/pay-card-auth/src/components/CardLogin/useCardLoginViewModel.ts
+++ b/features/flow/pay-card-auth/src/components/CardLogin/useCardLoginViewModel.ts
@@ -13,10 +13,8 @@ type CardLoginStateValue = SnapshotFrom<typeof cardLoginMachine>["value"];
 /** Hardcoded English until the Pay tab gets its copy keys. */
 const ERROR_MESSAGES: Record<PayCardLoginErrorKind, string> = {
   pkce_failed: "Login could not start. Please try again.",
-  initiate_failed: "Login could not start. Please try again.",
   browser_open_failed: "The login page could not open. Please try again.",
   missing_attempt: "This login is no longer valid. Please log in again.",
-  state_mismatch: "This login could not be verified. Please log in again.",
   exchange_failed: "Login could not be completed. Please try again.",
   persist_failed: "Your session could not be saved. Please try again.",
   fetch_user_failed: "Your card could not be loaded. Please try again.",
@@ -67,7 +65,7 @@ export function useCardLoginViewModel({
     // A redirect that arrives while the screen is already open. The machine ignores it unless it is
     // waiting for one, so a repeat is harmless: the first callback wins.
     if (callback) {
-      send({ type: "CALLBACK_RECEIVED", code: callback.code, state: callback.state });
+      send({ type: "CALLBACK_RECEIVED", code: callback.code });
     }
   }, [callback, send]);
 

--- a/features/flow/pay-card-auth/src/state/__tests__/attemptStore.native.test.ts
+++ b/features/flow/pay-card-auth/src/state/__tests__/attemptStore.native.test.ts
@@ -14,7 +14,7 @@ jest.mock("react-native-keychain", () => ({
   resetGenericPassword: jest.fn(),
 }));
 
-const attempt = { state: "state-value", codeVerifier: "verifier-value" };
+const attempt = { codeVerifier: "verifier-value" };
 
 /** What a write answers: `Result`, which names the key and the storage. Never the secret back. */
 const writeResult = {
@@ -39,7 +39,7 @@ describe("attemptStore (native)", () => {
     jest.clearAllMocks();
   });
 
-  it("keeps both halves of the attempt under one key", async () => {
+  it("keeps the verifier under one key", async () => {
     await saveAttempt(attempt);
 
     expect(setGenericPassword).toHaveBeenCalledWith("payCard", JSON.stringify(attempt), {
@@ -69,7 +69,7 @@ describe("attemptStore (native)", () => {
     await expect(loadAttempt()).resolves.toBeNull();
   });
 
-  it.each(["not json at all", "{}", '{"state":"state-value"}', '{"codeVerifier":"v"}'])(
+  it.each(["not json at all", "{}", '{"codeVerifier":""}', '{"codeVerifier":42}'])(
     "reads no attempt when the payload is %s",
     async payload => {
       jest.mocked(getGenericPassword).mockResolvedValue({ ...storedEntry, password: payload });

--- a/features/flow/pay-card-auth/src/state/__tests__/attemptStore.web.test.ts
+++ b/features/flow/pay-card-auth/src/state/__tests__/attemptStore.web.test.ts
@@ -1,6 +1,6 @@
 import { clearAttempt, loadAttempt, saveAttempt } from "../attemptStore.web";
 
-const attempt = { state: "state-value", codeVerifier: "verifier-value" };
+const attempt = { codeVerifier: "verifier-value" };
 
 describe("attemptStore (web)", () => {
   afterEach(async () => {

--- a/features/flow/pay-card-auth/src/state/__tests__/authorizeAttempt.native.test.ts
+++ b/features/flow/pay-card-auth/src/state/__tests__/authorizeAttempt.native.test.ts
@@ -23,19 +23,16 @@ describe("createAuthorizeAttempt", () => {
     expect(mockedSha256Base64Url).toHaveBeenCalledTimes(1);
   });
 
-  it("draws the verifier and the state from separate random values", async () => {
-    const { state, codeVerifier } = await createAuthorizeAttempt();
+  it("draws one random value, and only the verifier", async () => {
+    await createAuthorizeAttempt();
 
-    expect(state).not.toBe(codeVerifier);
-    expect(mockedCreateRandomBase64Url).toHaveBeenCalledTimes(2);
+    expect(mockedCreateRandomBase64Url).toHaveBeenCalledTimes(1);
   });
 
-  // 32 bytes give the 43 base64url characters RFC 7636 sets as the minimum verifier length; the
-  // 16-byte state is far past the 8 characters the backend requires.
-  it("asks for enough entropy for both values", async () => {
+  // 32 bytes give the 43 base64url characters RFC 7636 sets as the minimum verifier length.
+  it("asks for enough entropy for the verifier", async () => {
     await createAuthorizeAttempt();
 
     expect(mockedCreateRandomBase64Url).toHaveBeenCalledWith(32);
-    expect(mockedCreateRandomBase64Url).toHaveBeenCalledWith(16);
   });
 });

--- a/features/flow/pay-card-auth/src/state/__tests__/buildAuthorizeUrl.native.test.ts
+++ b/features/flow/pay-card-auth/src/state/__tests__/buildAuthorizeUrl.native.test.ts
@@ -50,4 +50,10 @@ describe("buildAuthorizeUrl", () => {
 
     expect(new URL(url).pathname).toBe("/v1/auth/oauth2/authorize");
   });
+
+  it("refuses to open a non-https authorize URL", () => {
+    expect(() =>
+      buildAuthorizeUrl({ ...oauthConfig, apiUrl: "http://dev.api.baanx.com" }, "challenge"),
+    ).toThrow();
+  });
 });

--- a/features/flow/pay-card-auth/src/state/__tests__/buildAuthorizeUrl.native.test.ts
+++ b/features/flow/pay-card-auth/src/state/__tests__/buildAuthorizeUrl.native.test.ts
@@ -5,6 +5,8 @@ const oauthConfig: CardLoginOauthConfig = {
   apiUrl: "https://dev.api.baanx.com",
   clientId: "dc16bbda-eb1b-487c-be60-1a90ca7c9dd6",
   redirectUri: "https://go.ledger.com/ledger/card-baanx",
+  // Never reaches the authorize URL: the browser session ends on it, the provider never sees it.
+  deepLink: "ledgerlive://paytab",
 };
 
 describe("buildAuthorizeUrl", () => {

--- a/features/flow/pay-card-auth/src/state/__tests__/buildAuthorizeUrl.native.test.ts
+++ b/features/flow/pay-card-auth/src/state/__tests__/buildAuthorizeUrl.native.test.ts
@@ -23,7 +23,7 @@ describe("buildAuthorizeUrl", () => {
     expect(Object.fromEntries(searchParams)).toEqual({
       client_id: "dc16bbda-eb1b-487c-be60-1a90ca7c9dd6",
       response_type: "code",
-      scope: "openid profile email platform:full offline_access",
+      scope: "openid profile email offline_access",
       redirect_uri: "https://go.ledger.com/ledger/card-baanx",
       code_challenge: "challenge-value",
       code_challenge_method: "S256",
@@ -42,7 +42,7 @@ describe("buildAuthorizeUrl", () => {
 
     // A raw `:` or `/` in the query would end the redirect at the provider's parser.
     expect(url).toContain("redirect_uri=https%3A%2F%2Fgo.ledger.com%2Fledger%2Fcard-baanx");
-    expect(url).toContain("scope=openid+profile+email+platform%3Afull+offline_access");
+    expect(url).toContain("scope=openid+profile+email+offline_access");
   });
 
   it("keeps a base path on the API host", () => {

--- a/features/flow/pay-card-auth/src/state/__tests__/buildAuthorizeUrl.native.test.ts
+++ b/features/flow/pay-card-auth/src/state/__tests__/buildAuthorizeUrl.native.test.ts
@@ -1,0 +1,51 @@
+import { buildAuthorizeUrl } from "../buildAuthorizeUrl";
+import type { CardLoginOauthConfig } from "../types";
+
+const oauthConfig: CardLoginOauthConfig = {
+  apiUrl: "https://dev.api.baanx.com",
+  clientId: "dc16bbda-eb1b-487c-be60-1a90ca7c9dd6",
+  redirectUri: "https://go.ledger.com/ledger/card-baanx",
+};
+
+describe("buildAuthorizeUrl", () => {
+  it("addresses the provider's authorize page", () => {
+    const { origin, pathname } = new URL(buildAuthorizeUrl(oauthConfig, "challenge-value"));
+
+    expect(origin).toBe("https://dev.api.baanx.com");
+    expect(pathname).toBe("/v1/auth/oauth2/authorize");
+  });
+
+  it("carries every value the provider needs, and nothing else", () => {
+    const { searchParams } = new URL(buildAuthorizeUrl(oauthConfig, "challenge-value"));
+
+    expect(Object.fromEntries(searchParams)).toEqual({
+      client_id: "dc16bbda-eb1b-487c-be60-1a90ca7c9dd6",
+      response_type: "code",
+      scope: "openid profile email platform:full offline_access",
+      redirect_uri: "https://go.ledger.com/ledger/card-baanx",
+      code_challenge: "challenge-value",
+      code_challenge_method: "S256",
+      prompt: "consent",
+    });
+  });
+
+  it("never sends the verifier, only the challenge derived from it", () => {
+    const url = buildAuthorizeUrl(oauthConfig, "challenge-value");
+
+    expect(url).not.toContain("code_verifier");
+  });
+
+  it("encodes the redirect and the scope separators", () => {
+    const url = buildAuthorizeUrl(oauthConfig, "challenge-value");
+
+    // A raw `:` or `/` in the query would end the redirect at the provider's parser.
+    expect(url).toContain("redirect_uri=https%3A%2F%2Fgo.ledger.com%2Fledger%2Fcard-baanx");
+    expect(url).toContain("scope=openid+profile+email+platform%3Afull+offline_access");
+  });
+
+  it("keeps a base path on the API host", () => {
+    const url = buildAuthorizeUrl({ ...oauthConfig, apiUrl: "https://card.test/" }, "challenge");
+
+    expect(new URL(url).pathname).toBe("/v1/auth/oauth2/authorize");
+  });
+});

--- a/features/flow/pay-card-auth/src/state/__tests__/callbackUrl.native.test.ts
+++ b/features/flow/pay-card-auth/src/state/__tests__/callbackUrl.native.test.ts
@@ -1,32 +1,33 @@
 import { parseCallbackUrl } from "../callbackUrl";
 
+const REDIRECT = "https://go.ledger.com/ledger/card-baanx";
+
 describe("parseCallbackUrl", () => {
-  it("reads the code and the state from the redirect", () => {
-    expect(parseCallbackUrl("ledgerlive://paytab?code=auth-code&state=state-value")).toEqual({
+  it("reads the code from the redirect", () => {
+    expect(parseCallbackUrl(`${REDIRECT}?code=auth-code&app_id=app-value`)).toEqual({
       code: "auth-code",
-      state: "state-value",
     });
   });
 
-  it("keeps a percent-encoded value intact", () => {
-    expect(parseCallbackUrl("ledgerlive://paytab?code=a%2Bb&state=c%2Fd")).toEqual({
-      code: "a+b",
-      state: "c/d",
+  it("keeps a percent-encoded code intact", () => {
+    expect(parseCallbackUrl(`${REDIRECT}?code=a%2Bb`)).toEqual({ code: "a+b" });
+  });
+
+  it("ignores the parameters the provider adds beside it", () => {
+    expect(parseCallbackUrl(`${REDIRECT}?app_id=app-value&code=auth-code&scope=card`)).toEqual({
+      code: "auth-code",
     });
   });
 
-  it("ignores the parameters the provider adds beside them", () => {
-    expect(
-      parseCallbackUrl("ledgerlive://paytab?state=state-value&code=auth-code&scope=card"),
-    ).toEqual({ code: "auth-code", state: "state-value" });
+  it("still reads a custom scheme, which is not a hierarchical URL", () => {
+    expect(parseCallbackUrl("ledgerlive://paytab?code=auth-code")).toEqual({ code: "auth-code" });
   });
 
   it.each([
-    ["there is no query", "ledgerlive://paytab"],
-    ["the query is empty", "ledgerlive://paytab?"],
-    ["the code is missing", "ledgerlive://paytab?state=state-value"],
-    ["the state is missing", "ledgerlive://paytab?code=auth-code"],
-    ["the provider reported an error", "ledgerlive://paytab?error=access_denied"],
+    ["there is no query", REDIRECT],
+    ["the query is empty", `${REDIRECT}?`],
+    ["the code is missing", `${REDIRECT}?app_id=app-value`],
+    ["the provider reported an error", `${REDIRECT}?error=access_denied`],
   ])("reads no callback when %s", (_case, url) => {
     expect(parseCallbackUrl(url)).toBeNull();
   });

--- a/features/flow/pay-card-auth/src/state/__tests__/machine.native.test.ts
+++ b/features/flow/pay-card-auth/src/state/__tests__/machine.native.test.ts
@@ -5,13 +5,14 @@ import type { CardLoginOauthConfig, CardLoginPorts, PayCardAuthCallback } from "
 // Two different values on purpose: the provider gets the `https` redirect, and the browser session
 // ends on the app's deep link. A test that spelled them the same could not catch a swap.
 const oauthConfig: CardLoginOauthConfig = {
+  apiUrl: "https://card.test",
   clientId: "client-key",
   redirectUri: "https://go.test/ledger/card",
   deepLink: "ledgerlive://paytab",
 };
 
-const attempt = { state: "state-value", codeVerifier: "verifier-value" };
-const callback: PayCardAuthCallback = { code: "auth-code", state: "state-value" };
+const attempt = { codeVerifier: "verifier-value" };
+const callback: PayCardAuthCallback = { code: "auth-code" };
 
 const session = {
   accessToken: "at_token",
@@ -34,13 +35,12 @@ function stubPorts(overrides: Partial<Ports> = {}): Ports {
     hasSession: jest.fn(async () => false),
     persistSession: jest.fn(async () => undefined),
     clearSession: jest.fn(async () => undefined),
-    initiateAuthorize: jest.fn(async () => ({ url: "https://card.test/login" })),
     exchangeAuthorizationCode: jest.fn(async () => session),
     getUser: jest.fn(async () => user),
     setSignedIn: jest.fn(),
     openHostedLogin: jest.fn(async () => ({
       type: "success",
-      url: "ledgerlive://paytab?code=auth-code&state=state-value",
+      url: "https://go.ledger.com/ledger/card-baanx?code=auth-code&app_id=app-value",
     })),
     ...overrides,
   };
@@ -144,16 +144,22 @@ describe("cardLoginMachine login", () => {
 
     await settledAt(actor, "ready");
     expect(ports.saveAttempt).toHaveBeenCalledWith(attempt);
-    expect(ports.initiateAuthorize).toHaveBeenCalledWith({
-      clientId: "client-key",
-      redirectUri: "https://go.test/ledger/card",
-      state: "state-value",
-      codeChallenge: "challenge-value",
+
+    // The authorize page is opened straight away, with the challenge in the query and no call first.
+    const [loginUrl, deepLink] = ports.openHostedLogin.mock.calls[0];
+    const { origin, pathname, searchParams } = new URL(loginUrl);
+    expect(origin + pathname).toBe("https://card.test/v1/auth/oauth2/authorize");
+    expect(Object.fromEntries(searchParams)).toEqual({
+      client_id: "client-key",
+      response_type: "code",
+      scope: "openid profile email platform:full offline_access",
+      redirect_uri: "https://go.test/ledger/card",
+      code_challenge: "challenge-value",
+      code_challenge_method: "S256",
+      prompt: "consent",
     });
-    expect(ports.openHostedLogin).toHaveBeenCalledWith(
-      "https://card.test/login",
-      "ledgerlive://paytab",
-    );
+    // The provider gets the redirect URI; the browser session ends on the deep link.
+    expect(deepLink).toBe("ledgerlive://paytab");
     expect(ports.persistSession).toHaveBeenCalledWith(session);
     // The attempt is wiped once the session is on disk.
     expect(ports.clearAttempt).toHaveBeenCalled();
@@ -182,7 +188,7 @@ describe("cardLoginMachine login", () => {
     actor.send({ type: "LOGIN" });
     await settledAt(actor, "ready");
 
-    actor.send({ type: "CALLBACK_RECEIVED", code: "another-code", state: "state-value" });
+    actor.send({ type: "CALLBACK_RECEIVED", code: "another-code" });
 
     expect(actor.getSnapshot().value).toBe("ready");
     expect(ports.exchangeAuthorizationCode).toHaveBeenCalledTimes(1);
@@ -240,10 +246,6 @@ describe("cardLoginMachine failures", () => {
   it.each([
     ["pkce_failed", { saveAttempt: jest.fn(async () => Promise.reject(new Error("no store"))) }],
     [
-      "initiate_failed",
-      { initiateAuthorize: jest.fn(async () => Promise.reject(new Error("500"))) },
-    ],
-    [
       "browser_open_failed",
       { openHostedLogin: jest.fn(async () => Promise.reject(new Error("x"))) },
     ],
@@ -281,15 +283,15 @@ describe("cardLoginMachine failures", () => {
     expect(ports.persistSession).toHaveBeenCalledWith(session);
   });
 
-  it("reports a redirect whose state does not match the attempt", async () => {
-    const ports = stubPorts({
-      loadAttempt: jest.fn(async () => ({ ...attempt, state: "another-state" })),
-    });
+  it("reports a redirect whose attempt is gone before the exchange", async () => {
+    // Nothing is compared on this device any more. The verifier has to be there, and PKCE makes the
+    // provider refuse a code that was not issued against this attempt's challenge.
+    const ports = stubPorts({ loadAttempt: jest.fn(async () => null) });
 
     const actor = start(ports, callback);
 
     await settledAt(actor, "error");
-    expect(actor.getSnapshot().context.errorKind).toBe("state_mismatch");
+    expect(actor.getSnapshot().context.errorKind).toBe("missing_attempt");
     expect(ports.exchangeAuthorizationCode).not.toHaveBeenCalled();
   });
 

--- a/features/flow/pay-card-auth/src/state/__tests__/machine.native.test.ts
+++ b/features/flow/pay-card-auth/src/state/__tests__/machine.native.test.ts
@@ -18,7 +18,6 @@ const session = {
   accessToken: "at_token",
   expiresIn: 21600,
   refreshToken: "rt_token",
-  refreshTokenExpiresIn: 15897600,
 };
 
 const user = { id: "3f2504e0-4f89-11d3-9a0c-0305e82c3301", verificationState: "VERIFIED" } as const;
@@ -115,7 +114,6 @@ describe("cardLoginMachine cold start", () => {
     await settledAt(actor, "ready");
     expect(ports.exchangeAuthorizationCode).toHaveBeenCalledWith({
       code: "auth-code",
-      redirectUri: "https://go.test/ledger/card",
       codeVerifier: "verifier-value",
     });
     expect(ports.openHostedLogin).not.toHaveBeenCalled();
@@ -160,7 +158,7 @@ describe("cardLoginMachine login", () => {
     expect(Object.fromEntries(searchParams)).toEqual({
       client_id: "client-key",
       response_type: "code",
-      scope: "openid profile email platform:full offline_access",
+      scope: "openid profile email offline_access",
       redirect_uri: "https://go.test/ledger/card",
       code_challenge: "challenge-value",
       code_challenge_method: "S256",

--- a/features/flow/pay-card-auth/src/state/__tests__/machine.native.test.ts
+++ b/features/flow/pay-card-auth/src/state/__tests__/machine.native.test.ts
@@ -40,15 +40,23 @@ function stubPorts(overrides: Partial<Ports> = {}): Ports {
     setSignedIn: jest.fn(),
     openHostedLogin: jest.fn(async () => ({
       type: "success",
-      url: "https://go.ledger.com/ledger/card-baanx?code=auth-code&app_id=app-value",
+      url: "ledgerlive://paytab?code=auth-code&app_id=app-value",
     })),
     ...overrides,
   };
 }
 
-function start(ports: Ports, initialCallback: PayCardAuthCallback | null = null) {
+function start(
+  ports: Ports,
+  initialCallback: PayCardAuthCallback | null = null,
+  config: CardLoginOauthConfig = oauthConfig,
+) {
   const actor = createActor(cardLoginMachine, {
-    input: { ports: ports as unknown as CardLoginPorts, oauthConfig, callback: initialCallback },
+    input: {
+      ports: ports as unknown as CardLoginPorts,
+      oauthConfig: config,
+      callback: initialCallback,
+    },
   });
   actor.start();
   return actor;
@@ -163,6 +171,21 @@ describe("cardLoginMachine login", () => {
     expect(ports.persistSession).toHaveBeenCalledWith(session);
     // The attempt is wiped once the session is on disk.
     expect(ports.clearAttempt).toHaveBeenCalled();
+  });
+
+  it("reports a failure when the provider's API URL cannot build a URL", async () => {
+    const ports = stubPorts();
+    const actor = start(ports, null, { ...oauthConfig, apiUrl: "" });
+    await settledAt(actor, "idle");
+
+    actor.send({ type: "LOGIN" });
+
+    // The URL is built in the actor, so a bad `apiUrl` reports a failure instead of stopping the
+    // machine. The attempt reached the store before that, so it is wiped again.
+    await settledAt(actor, "error");
+    expect(actor.getSnapshot().context.errorKind).toBe("pkce_failed");
+    expect(ports.clearAttempt).toHaveBeenCalled();
+    expect(ports.openHostedLogin).not.toHaveBeenCalled();
   });
 
   it("accepts the deep link when it arrives before the browser answers", async () => {

--- a/features/flow/pay-card-auth/src/state/actions.ts
+++ b/features/flow/pay-card-auth/src/state/actions.ts
@@ -14,7 +14,6 @@ const assignContext = assign<CardLoginContext, CardLoginEvent, undefined, CardLo
 /** Everything an ended attempt leaves behind, except the error to show for it. */
 export const forgetAttempt = assignContext({
   callback: null,
-  initiation: null,
   loginUrl: null,
   session: null,
   clearSession: false,

--- a/features/flow/pay-card-auth/src/state/actors.ts
+++ b/features/flow/pay-card-auth/src/state/actors.ts
@@ -82,11 +82,7 @@ export const validateCallback = fromPromise(
 );
 
 export const exchangeAuthorizationCode = fromPromise(
-  async ({
-    input,
-  }: {
-    input: { ports: CardLoginPorts; callback: PayCardAuthCallback | null; redirectUri: string };
-  }) => {
+  async ({ input }: { input: { ports: CardLoginPorts; callback: PayCardAuthCallback | null } }) => {
     const attempt = await input.ports.loadAttempt();
     if (!attempt || !input.callback) {
       throw new MissingLoginStateError("attempt");
@@ -94,7 +90,6 @@ export const exchangeAuthorizationCode = fromPromise(
 
     return input.ports.exchangeAuthorizationCode({
       code: input.callback.code,
-      redirectUri: input.redirectUri,
       codeVerifier: attempt.codeVerifier,
     });
   },

--- a/features/flow/pay-card-auth/src/state/actors.ts
+++ b/features/flow/pay-card-auth/src/state/actors.ts
@@ -1,9 +1,10 @@
 import type { PayCardSession } from "@domain/api-card-management";
 import { fromPromise } from "xstate";
+import { buildAuthorizeUrl } from "./buildAuthorizeUrl";
 import { parseCallbackUrl } from "./callbackUrl";
 import { MissingLoginStateError } from "./errors";
 import type { PayCardLoginErrorKind } from "./errors";
-import type { CardLoginPorts, PayCardAuthCallback } from "./types";
+import type { CardLoginOauthConfig, CardLoginPorts, PayCardAuthCallback } from "./types";
 
 /**
  * Every asynchronous step of the login, as an invoked actor. Each one takes what it needs as input and
@@ -21,13 +22,23 @@ export const hydrate = fromPromise(async ({ input }: { input: { ports: CardLogin
   return { hasAttempt: attempt !== null, hasSession };
 });
 
+/**
+ * Mints the attempt, stores it, and builds the URL that opens it. The URL is built here and not in an
+ * `assign`, because `buildAuthorizeUrl` throws on a misconfigured `apiUrl`, and a throw inside an
+ * action stops the machine instead of reaching a transition. As a rejection it lands on `onError`, and
+ * the login reports a failure it can retry.
+ */
 export const prepareAttempt = fromPromise(
-  async ({ input }: { input: { ports: CardLoginPorts } }): Promise<{ codeChallenge: string }> => {
+  async ({
+    input,
+  }: {
+    input: { ports: CardLoginPorts; oauthConfig: CardLoginOauthConfig };
+  }): Promise<{ loginUrl: string }> => {
     const { codeVerifier, codeChallenge } = await input.ports.createAttempt();
     await input.ports.saveAttempt({ codeVerifier });
 
-    // Only the challenge travels on. The verifier stays in the store until the token exchange.
-    return { codeChallenge };
+    // Only the challenge leaves the device. The verifier stays in the store until the token exchange.
+    return { loginUrl: buildAuthorizeUrl(input.oauthConfig, codeChallenge) };
   },
 );
 
@@ -51,7 +62,11 @@ export const openHostedLogin = fromPromise(
   },
 );
 
-/** Compares the redirect against the attempt on disk. `kind` is null when they agree. */
+/**
+ * Checks that a redirect and the attempt behind it are both there. Nothing is compared: the OAuth
+ * `state` is gone, so there are no two values to hold against each other. `kind` is null when both
+ * are present.
+ */
 export const validateCallback = fromPromise(
   async ({
     input,

--- a/features/flow/pay-card-auth/src/state/actors.ts
+++ b/features/flow/pay-card-auth/src/state/actors.ts
@@ -3,12 +3,7 @@ import { fromPromise } from "xstate";
 import { parseCallbackUrl } from "./callbackUrl";
 import { MissingLoginStateError } from "./errors";
 import type { PayCardLoginErrorKind } from "./errors";
-import type {
-  CardLoginInitiation,
-  CardLoginOauthConfig,
-  CardLoginPorts,
-  PayCardAuthCallback,
-} from "./types";
+import type { CardLoginPorts, PayCardAuthCallback } from "./types";
 
 /**
  * Every asynchronous step of the login, as an invoked actor. Each one takes what it needs as input and
@@ -27,35 +22,12 @@ export const hydrate = fromPromise(async ({ input }: { input: { ports: CardLogin
 });
 
 export const prepareAttempt = fromPromise(
-  async ({ input }: { input: { ports: CardLoginPorts } }): Promise<CardLoginInitiation> => {
-    const { state, codeVerifier, codeChallenge } = await input.ports.createAttempt();
-    await input.ports.saveAttempt({ state, codeVerifier });
+  async ({ input }: { input: { ports: CardLoginPorts } }): Promise<{ codeChallenge: string }> => {
+    const { codeVerifier, codeChallenge } = await input.ports.createAttempt();
+    await input.ports.saveAttempt({ codeVerifier });
 
-    // Only the public halves travel on. The verifier stays in the store until the token exchange.
-    return { state, codeChallenge };
-  },
-);
-
-export const initiateAuthorize = fromPromise(
-  ({
-    input,
-  }: {
-    input: {
-      ports: CardLoginPorts;
-      oauthConfig: CardLoginOauthConfig;
-      initiation: CardLoginInitiation | null;
-    };
-  }) => {
-    if (!input.initiation) {
-      throw new MissingLoginStateError("attempt");
-    }
-
-    return input.ports.initiateAuthorize({
-      clientId: input.oauthConfig.clientId,
-      redirectUri: input.oauthConfig.redirectUri,
-      state: input.initiation.state,
-      codeChallenge: input.initiation.codeChallenge,
-    });
+    // Only the challenge travels on. The verifier stays in the store until the token exchange.
+    return { codeChallenge };
   },
 );
 
@@ -87,11 +59,10 @@ export const validateCallback = fromPromise(
     input: { ports: CardLoginPorts; callback: PayCardAuthCallback | null };
   }): Promise<{ kind: PayCardLoginErrorKind | null }> => {
     const attempt = await input.ports.loadAttempt();
-    if (!attempt || !input.callback) {
-      return { kind: "missing_attempt" };
-    }
 
-    return { kind: attempt.state === input.callback.state ? null : "state_mismatch" };
+    // A redirect with no verifier behind it cannot be exchanged, so the login starts over. PKCE does
+    // the rest: the provider only accepts this code against the challenge this attempt sent.
+    return { kind: attempt && input.callback ? null : "missing_attempt" };
   },
 );
 

--- a/features/flow/pay-card-auth/src/state/authorizeAttempt.ts
+++ b/features/flow/pay-card-auth/src/state/authorizeAttempt.ts
@@ -8,23 +8,14 @@ import type { PayCardAuthorizeAttempt } from "./types";
 const CODE_VERIFIER_BYTE_LENGTH = 32;
 
 /**
- * OAuth state has no fixed standard length. Encoding 16 random bytes as unpadded base64url gives
- * 22 characters and 128 bits of entropy, safely above the backend's 8-character minimum.
- */
-const STATE_BYTE_LENGTH = 16;
-
-/**
- * Builds one login attempt: a CSRF `state` plus a PKCE pair.
+ * Builds one login attempt: a PKCE pair.
  *
- * Both halves are minted here so an attempt is always internally consistent — the `state` the
- * callback must echo and the verifier the token exchange must present belong to the same login. Only
- * the challenge is spent on the authorize initiation.
+ * The challenge travels on the authorize URL and the verifier stays on disk. The provider ties the
+ * code it issues to that challenge, so only this attempt can exchange it. That binding is what makes
+ * a separate CSRF value unnecessary.
  */
 export async function createAuthorizeAttempt(): Promise<PayCardAuthorizeAttempt> {
-  const [state, codeVerifier] = await Promise.all([
-    createRandomBase64Url(STATE_BYTE_LENGTH),
-    createRandomBase64Url(CODE_VERIFIER_BYTE_LENGTH),
-  ]);
+  const codeVerifier = await createRandomBase64Url(CODE_VERIFIER_BYTE_LENGTH);
 
-  return { state, codeVerifier, codeChallenge: await sha256Base64Url(codeVerifier) };
+  return { codeVerifier, codeChallenge: await sha256Base64Url(codeVerifier) };
 }

--- a/features/flow/pay-card-auth/src/state/buildAuthorizeUrl.ts
+++ b/features/flow/pay-card-auth/src/state/buildAuthorizeUrl.ts
@@ -24,6 +24,11 @@ export function buildAuthorizeUrl(
 ): string {
   const url = new URL(AUTHORIZE_PATH, oauthConfig.apiUrl);
 
+  // A misconfigured apiUrl must not open the secure browser on an insecure or unexpected page.
+  if (url.protocol !== "https:") {
+    throw new Error(`buildAuthorizeUrl: apiUrl must be https, got "${url.protocol}"`);
+  }
+
   url.search = new URLSearchParams({
     client_id: oauthConfig.clientId,
     response_type: "code",

--- a/features/flow/pay-card-auth/src/state/buildAuthorizeUrl.ts
+++ b/features/flow/pay-card-auth/src/state/buildAuthorizeUrl.ts
@@ -1,0 +1,38 @@
+import type { CardLoginOauthConfig } from "./types";
+
+const AUTHORIZE_PATH = "/v1/auth/oauth2/authorize";
+
+/**
+ * What the session must cover: who the user is, and a refresh token so the session outlives the
+ * access token. `platform:full` is the Card platform scope.
+ */
+const SCOPE = "openid profile email platform:full offline_access";
+
+/**
+ * Builds the authorize URL the secure browser opens.
+ *
+ * There is no call to the backend first. The provider owns the page and the redirect, so every value
+ * it needs travels in the query, and the browser goes straight there. `prompt=consent` makes the
+ * provider ask every time, which is what a login has to do.
+ *
+ * Only the challenge leaves the device. The verifier stays in the attempt store until the token
+ * exchange, which is what binds that exchange to this attempt.
+ */
+export function buildAuthorizeUrl(
+  oauthConfig: CardLoginOauthConfig,
+  codeChallenge: string,
+): string {
+  const url = new URL(AUTHORIZE_PATH, oauthConfig.apiUrl);
+
+  url.search = new URLSearchParams({
+    client_id: oauthConfig.clientId,
+    response_type: "code",
+    scope: SCOPE,
+    redirect_uri: oauthConfig.redirectUri,
+    code_challenge: codeChallenge,
+    code_challenge_method: "S256",
+    prompt: "consent",
+  }).toString();
+
+  return url.toString();
+}

--- a/features/flow/pay-card-auth/src/state/buildAuthorizeUrl.ts
+++ b/features/flow/pay-card-auth/src/state/buildAuthorizeUrl.ts
@@ -3,10 +3,10 @@ import type { CardLoginOauthConfig } from "./types";
 const AUTHORIZE_PATH = "/v1/auth/oauth2/authorize";
 
 /**
- * What the session must cover: who the user is, and a refresh token so the session outlives the
- * access token. `platform:full` is the Card platform scope.
+ * Who the user is, and `offline_access` so the token grant includes a refresh token. A live exchange
+ * without it came back with no `refresh_token` at all.
  */
-const SCOPE = "openid profile email platform:full offline_access";
+const SCOPE = "openid profile email offline_access";
 
 /**
  * Builds the authorize URL the secure browser opens.

--- a/features/flow/pay-card-auth/src/state/callbackUrl.ts
+++ b/features/flow/pay-card-auth/src/state/callbackUrl.ts
@@ -5,8 +5,11 @@ import type { PayCardAuthCallback } from "./types";
  * parsed callback, because react-navigation parses the deep link for it; this is the other source,
  * where the OS session answers with the raw URL it stopped on.
  *
- * `ledgerlive://paytab?code=…&state=…` is not a hierarchical URL, so `URL` cannot be trusted to
- * expose its query. The query is read from the string itself.
+ * `ledgerlive://paytab?code=…` is not a hierarchical URL, so `URL` cannot be trusted to expose its
+ * query. The query is read from the string itself.
+ *
+ * The redirect also carries `app_id`, which nothing here needs: PKCE already ties the code to the
+ * verifier on disk.
  */
 export function parseCallbackUrl(url: string): PayCardAuthCallback | null {
   const query = url.slice(url.indexOf("?") + 1);
@@ -14,9 +17,7 @@ export function parseCallbackUrl(url: string): PayCardAuthCallback | null {
     return null;
   }
 
-  const params = new URLSearchParams(query);
-  const code = params.get("code");
-  const state = params.get("state");
+  const code = new URLSearchParams(query).get("code");
 
-  return code && state ? { code, state } : null;
+  return code ? { code } : null;
 }

--- a/features/flow/pay-card-auth/src/state/createCardLoginPorts.ts
+++ b/features/flow/pay-card-auth/src/state/createCardLoginPorts.ts
@@ -33,8 +33,6 @@ export function createCardLoginPorts({
     hasSession: async () => Boolean(await getCardSessionToken()),
     persistSession: session => cardSession.set(session),
     clearSession: () => cardSession.clear(),
-    initiateAuthorize: request =>
-      dispatch(cardManagementApi.endpoints.initiateAuthorize.initiate(request)).unwrap(),
     exchangeAuthorizationCode: request =>
       dispatch(cardManagementApi.endpoints.exchangeAuthorizationCode.initiate(request)).unwrap(),
     getUser: async () => {

--- a/features/flow/pay-card-auth/src/state/errors.ts
+++ b/features/flow/pay-card-auth/src/state/errors.ts
@@ -6,10 +6,8 @@ const UNAUTHORIZED_STATUS = 401;
  */
 export type PayCardLoginErrorKind =
   | "pkce_failed"
-  | "initiate_failed"
   | "browser_open_failed"
   | "missing_attempt"
-  | "state_mismatch"
   | "exchange_failed"
   | "persist_failed"
   | "fetch_user_failed";

--- a/features/flow/pay-card-auth/src/state/internals/attemptPayload.ts
+++ b/features/flow/pay-card-auth/src/state/internals/attemptPayload.ts
@@ -1,18 +1,15 @@
 import type { PayCardStoredAttempt } from "../types";
 
-/**
- * One key holds one attempt. Both halves must travel together: the `state` the callback echoes and
- * the verifier the token exchange presents belong to the same login.
- */
+/** One key holds one attempt: the PKCE verifier the token exchange presents. */
 export const PKCE_ATTEMPT_KEY = "payCard.pkce.attempt";
 
 export function serializeAttempt(attempt: PayCardStoredAttempt): string {
-  return JSON.stringify({ state: attempt.state, codeVerifier: attempt.codeVerifier });
+  return JSON.stringify({ codeVerifier: attempt.codeVerifier });
 }
 
 /**
- * A payload that does not hold both halves is no attempt at all. Reading it as absent restarts the
- * login instead of sending a mismatched verifier to the token endpoint.
+ * A payload without a verifier is no attempt at all. Reading it as absent restarts the login instead
+ * of sending an empty verifier to the token endpoint.
  */
 export function parseAttempt(payload: string | null): PayCardStoredAttempt | null {
   if (!payload) {
@@ -20,10 +17,8 @@ export function parseAttempt(payload: string | null): PayCardStoredAttempt | nul
   }
 
   try {
-    const { state, codeVerifier } = JSON.parse(payload) as Record<string, unknown>;
-    return typeof state === "string" && state && typeof codeVerifier === "string" && codeVerifier
-      ? { state, codeVerifier }
-      : null;
+    const { codeVerifier } = JSON.parse(payload) as Record<string, unknown>;
+    return typeof codeVerifier === "string" && codeVerifier ? { codeVerifier } : null;
   } catch {
     return null;
   }

--- a/features/flow/pay-card-auth/src/state/machine.ts
+++ b/features/flow/pay-card-auth/src/state/machine.ts
@@ -4,13 +4,13 @@ import {
   exchangeAuthorizationCode,
   getUser,
   hydrate,
-  initiateAuthorize,
   openHostedLogin,
   persistSession,
   prepareAttempt,
   validateCallback,
 } from "./actors";
 import { clearErrorKind, failPkce, forgetAttempt } from "./actions";
+import { buildAuthorizeUrl } from "./buildAuthorizeUrl";
 import { isUnauthorizedError } from "./errors";
 import { hasErrorKind, shouldResumeAuthenticated } from "./guards";
 import type { CardLoginContext, CardLoginEvent, CardLoginMachineInput } from "./types";
@@ -24,7 +24,6 @@ export const cardLoginMachine = setup({
   actors: {
     hydrate,
     prepareAttempt,
-    initiateAuthorize,
     openHostedLogin,
     validateCallback,
     exchangeAuthorizationCode,
@@ -53,7 +52,6 @@ export const cardLoginMachine = setup({
     ports: input.ports,
     oauthConfig: input.oauthConfig,
     callback: input.callback ?? null,
-    initiation: null,
     loginUrl: null,
     session: null,
     errorKind: null,
@@ -91,7 +89,7 @@ export const cardLoginMachine = setup({
         // arrives one render after mount can never overtake the disk read.
         CALLBACK_RECEIVED: {
           actions: assign({
-            callback: ({ event }) => ({ code: event.code, state: event.state }),
+            callback: ({ event }) => ({ code: event.code }),
           }),
         },
       },
@@ -108,30 +106,16 @@ export const cardLoginMachine = setup({
         src: "prepareAttempt",
         input: ({ context }) => ({ ports: context.ports }),
         onDone: {
-          target: "initiatingAuthorize",
-          actions: assign({ initiation: ({ event }) => event.output }),
+          // The provider hosts the authorize page, so the URL is built here and nothing is asked of
+          // the backend first. One step fewer, and one fewer way for a login to fail.
+          target: "awaitingHostedLogin",
+          actions: assign({
+            loginUrl: ({ context, event }) =>
+              buildAuthorizeUrl(context.oauthConfig, event.output.codeChallenge),
+          }),
         },
         // Nothing reached the store, so there is nothing to wipe.
         onError: { target: "error", actions: "failPkce" },
-      },
-    },
-
-    initiatingAuthorize: {
-      invoke: {
-        src: "initiateAuthorize",
-        input: ({ context }) => ({
-          ports: context.ports,
-          oauthConfig: context.oauthConfig,
-          initiation: context.initiation,
-        }),
-        onDone: {
-          target: "awaitingHostedLogin",
-          actions: assign({ loginUrl: ({ event }) => event.output.url }),
-        },
-        onError: {
-          target: "clearingAttempt",
-          actions: assign({ errorKind: "initiate_failed" }),
-        },
       },
     },
 
@@ -163,7 +147,7 @@ export const cardLoginMachine = setup({
         CALLBACK_RECEIVED: {
           target: "validatingCallback",
           actions: assign({
-            callback: ({ event }) => ({ code: event.code, state: event.state }),
+            callback: ({ event }) => ({ code: event.code }),
           }),
         },
       },

--- a/features/flow/pay-card-auth/src/state/machine.ts
+++ b/features/flow/pay-card-auth/src/state/machine.ts
@@ -10,7 +10,6 @@ import {
   validateCallback,
 } from "./actors";
 import { clearErrorKind, failPkce, forgetAttempt } from "./actions";
-import { buildAuthorizeUrl } from "./buildAuthorizeUrl";
 import { isUnauthorizedError } from "./errors";
 import { hasErrorKind, shouldResumeAuthenticated } from "./guards";
 import type { CardLoginContext, CardLoginEvent, CardLoginMachineInput } from "./types";
@@ -104,18 +103,16 @@ export const cardLoginMachine = setup({
       entry: ["forgetAttempt", "clearErrorKind"],
       invoke: {
         src: "prepareAttempt",
-        input: ({ context }) => ({ ports: context.ports }),
+        input: ({ context }) => ({ ports: context.ports, oauthConfig: context.oauthConfig }),
         onDone: {
-          // The provider hosts the authorize page, so the URL is built here and nothing is asked of
-          // the backend first. One step fewer, and one fewer way for a login to fail.
+          // The provider hosts the authorize page, so the actor builds the URL and nothing is asked
+          // of the backend first. One step fewer, and one fewer way for a login to fail.
           target: "awaitingHostedLogin",
-          actions: assign({
-            loginUrl: ({ context, event }) =>
-              buildAuthorizeUrl(context.oauthConfig, event.output.codeChallenge),
-          }),
+          actions: assign({ loginUrl: ({ event }) => event.output.loginUrl }),
         },
-        // Nothing reached the store, so there is nothing to wipe.
-        onError: { target: "error", actions: "failPkce" },
+        // The attempt may already be stored, because the URL is built after the write. `clearingAttempt`
+        // wipes it and then reads the error kind, which sends this to `error`.
+        onError: { target: "clearingAttempt", actions: "failPkce" },
       },
     },
 

--- a/features/flow/pay-card-auth/src/state/machine.ts
+++ b/features/flow/pay-card-auth/src/state/machine.ts
@@ -174,7 +174,6 @@ export const cardLoginMachine = setup({
         input: ({ context }) => ({
           ports: context.ports,
           callback: context.callback,
-          redirectUri: context.oauthConfig.redirectUri,
         }),
         onDone: {
           target: "persistingSession",

--- a/features/flow/pay-card-auth/src/state/types.ts
+++ b/features/flow/pay-card-auth/src/state/types.ts
@@ -1,7 +1,5 @@
 import type {
   PayCardAuthorizationCodeRequest,
-  PayCardAuthorizeInitiate,
-  PayCardAuthorizeInitiateRequest,
   PayCardSession,
   PayCardUser,
 } from "@domain/api-card-management";
@@ -10,38 +8,37 @@ import type { PayCardLoginErrorKind } from "./errors";
 /* --- The login attempt, and what the provider sends back ------------------------------------- */
 
 /**
- * One login attempt: the `state` the callback must echo back, the PKCE verifier the token exchange
- * must present, and the challenge derived from that verifier for the authorize initiation.
+ * One login attempt: the PKCE verifier the token exchange must present, and the challenge derived
+ * from that verifier for the authorize URL.
  */
 export type PayCardAuthorizeAttempt = Readonly<{
-  state: string;
   codeVerifier: string;
   codeChallenge: string;
 }>;
 
 /**
- * What survives the hosted login: the `state` to compare and the verifier to present. The challenge
- * is spent on the initiation, so it is not kept.
+ * What survives the hosted login. The challenge is spent on the authorize URL, so only the verifier
+ * is kept, and the token exchange presents it.
  */
 export type PayCardStoredAttempt = Readonly<{
-  state: string;
   codeVerifier: string;
 }>;
 
 /**
- * What the provider sends back on the redirect: the authorization code to exchange, and the `state`
- * that proves the redirect answers our own attempt.
+ * What the provider sends back on the redirect. PKCE binds the code to the verifier on disk, so the
+ * code alone identifies the attempt and no CSRF value is echoed.
  */
 export type PayCardAuthCallback = Readonly<{
   code: string;
-  state: string;
 }>;
 
 /**
- * Per-app OAuth client configuration. The values are the app's to know: the client id comes from its
- * environment, and the redirect URI is the one it has whitelisted with the provider.
+ * Per-app OAuth client configuration. The values are the app's to know: the API host and the client
+ * id come from its environment, and the redirect URI is the one it has whitelisted with the provider.
  */
 export type CardLoginOauthConfig = Readonly<{
+  /** Base of the Card API, which also hosts the authorize page the browser opens. */
+  apiUrl: string;
   clientId: string;
   /**
    * Sent to the provider on authorize, and repeated on the token exchange. The provider whitelists
@@ -80,7 +77,7 @@ export type OpenHostedLogin = (loginUrl: string, deepLink?: string) => Promise<H
  * platform-card session store.
  */
 export type CardLoginPorts = Readonly<{
-  /** Mints a fresh CSRF state and PKCE pair. */
+  /** Mints a fresh PKCE pair. */
   createAttempt: () => Promise<PayCardAuthorizeAttempt>;
   saveAttempt: (attempt: PayCardStoredAttempt) => Promise<void>;
   loadAttempt: () => Promise<PayCardStoredAttempt | null>;
@@ -89,9 +86,6 @@ export type CardLoginPorts = Readonly<{
   hasSession: () => Promise<boolean>;
   persistSession: (session: PayCardSession) => Promise<void>;
   clearSession: () => Promise<void>;
-  initiateAuthorize: (
-    request: PayCardAuthorizeInitiateRequest,
-  ) => Promise<PayCardAuthorizeInitiate>;
   exchangeAuthorizationCode: (request: PayCardAuthorizationCodeRequest) => Promise<PayCardSession>;
   /** Fills the RTK Query cache, so every other screen sees the user too. */
   getUser: () => Promise<PayCardUser>;
@@ -127,12 +121,6 @@ export type CardLoginMachineInput = Readonly<{
   callback?: PayCardAuthCallback | null;
 }>;
 
-/** The public halves of one attempt: the CSRF state, and the PKCE challenge derived from the verifier. */
-export type CardLoginInitiation = Readonly<{
-  state: string;
-  codeChallenge: string;
-}>;
-
 /**
  * The machine's working memory. No secret is kept here as a source of truth: the PKCE verifier lives
  * in the flow's store and the session lives in platform-card. `session` holds the freshly exchanged
@@ -143,7 +131,6 @@ export type CardLoginContext = {
   ports: CardLoginPorts;
   oauthConfig: CardLoginOauthConfig;
   callback: PayCardAuthCallback | null;
-  initiation: CardLoginInitiation | null;
   loginUrl: string | null;
   session: PayCardSession | null;
   errorKind: PayCardLoginErrorKind | null;
@@ -158,7 +145,7 @@ export type CardLoginEvent =
   | { type: "LOGIN" }
   | { type: "RETRY" }
   | { type: "SESSION_ENDED" }
-  | { type: "CALLBACK_RECEIVED"; code: string; state: string };
+  | { type: "CALLBACK_RECEIVED"; code: string };
 
 /* --- Redux ----------------------------------------------------------------------------------- */
 

--- a/features/flow/pay-card-auth/src/state/types.ts
+++ b/features/flow/pay-card-auth/src/state/types.ts
@@ -41,7 +41,7 @@ export type CardLoginOauthConfig = Readonly<{
   apiUrl: string;
   clientId: string;
   /**
-   * Sent to the provider on authorize, and repeated on the token exchange. The provider whitelists
+   * Sent to the provider on authorize. The token exchange does not repeat it. The provider whitelists
    * an `https` URL only, so this one cannot be the app's own link. It redirects to `deepLink`.
    */
   redirectUri: string;

--- a/features/platform/card/src/session/cardSession.native.test.ts
+++ b/features/platform/card/src/session/cardSession.native.test.ts
@@ -30,7 +30,6 @@ const session = {
   accessToken: "at_token",
   expiresIn: 21600,
   refreshToken: "rt_token",
-  refreshTokenExpiresIn: 15897600,
 };
 
 /** The wiring the mobile app gets: the same accessors, over the keychain store. */

--- a/features/platform/card/src/session/cardSession.web.test.ts
+++ b/features/platform/card/src/session/cardSession.web.test.ts
@@ -4,7 +4,6 @@ const session = {
   accessToken: "at_token",
   expiresIn: 21600,
   refreshToken: "rt_token",
-  refreshTokenExpiresIn: 15897600,
 };
 
 /** The wiring the desktop app gets: the same accessors, over the in-memory store. */

--- a/features/platform/card/src/session/internals/createCardSession.test.ts
+++ b/features/platform/card/src/session/internals/createCardSession.test.ts
@@ -5,7 +5,6 @@ const session = {
   accessToken: "at_token",
   expiresIn: 21600,
   refreshToken: "rt_token",
-  refreshTokenExpiresIn: 15897600,
 };
 
 /** The session a re-login writes over. Every field differs, so a mixed read is visible. */
@@ -13,7 +12,6 @@ const previousSession = {
   accessToken: "at_old",
   expiresIn: 60,
   refreshToken: "rt_old",
-  refreshTokenExpiresIn: 120,
 };
 
 function fakeStore(initial: Record<string, string> = {}) {
@@ -63,10 +61,7 @@ describe("createCardSession", () => {
     expect(Object.fromEntries(slots)).toEqual({
       [CARD_SESSION_KEYS.accessToken]: "at_token",
       [CARD_SESSION_KEYS.refreshToken]: "rt_token",
-      [CARD_SESSION_KEYS.lifetimes]: JSON.stringify({
-        expiresIn: 21600,
-        refreshTokenExpiresIn: 15897600,
-      }),
+      [CARD_SESSION_KEYS.lifetimes]: JSON.stringify({ expiresIn: 21600 }),
     });
   });
 
@@ -243,10 +238,7 @@ describe("createCardSession", () => {
     const stored: Record<string, string> = {
       [CARD_SESSION_KEYS.accessToken]: "at_token",
       [CARD_SESSION_KEYS.refreshToken]: "rt_token",
-      [CARD_SESSION_KEYS.lifetimes]: JSON.stringify({
-        expiresIn: 1,
-        refreshTokenExpiresIn: 2,
-      }),
+      [CARD_SESSION_KEYS.lifetimes]: JSON.stringify({ expiresIn: 1 }),
     };
     for (const key of Object.keys(missing)) {
       delete stored[key];

--- a/features/platform/card/src/session/internals/createCardSession.ts
+++ b/features/platform/card/src/session/internals/createCardSession.ts
@@ -36,13 +36,7 @@ export function createCardSession(store: CardSessionStore) {
       // The access token is written last, because it is the only key the request path reads.
       const coldWriteResults = await Promise.allSettled([
         store.write(CARD_SESSION_KEYS.refreshToken, session.refreshToken),
-        store.write(
-          CARD_SESSION_KEYS.lifetimes,
-          JSON.stringify({
-            expiresIn: session.expiresIn,
-            refreshTokenExpiresIn: session.refreshTokenExpiresIn,
-          }),
-        ),
+        store.write(CARD_SESSION_KEYS.lifetimes, JSON.stringify({ expiresIn: session.expiresIn })),
       ]);
       const failedColdWrite = coldWriteResults.find(
         (result): result is PromiseRejectedResult => result.status === "rejected",
@@ -133,18 +127,14 @@ export function createCardSession(store: CardSessionStore) {
 }
 
 /** Unreadable or incomplete lifetimes answer null, so the caller reports no session. */
-function parseLifetimes(
-  value: string | null,
-): Pick<PayCardSession, "expiresIn" | "refreshTokenExpiresIn"> | null {
+function parseLifetimes(value: string | null): Pick<PayCardSession, "expiresIn"> | null {
   if (!value) {
     return null;
   }
 
   try {
-    const { expiresIn, refreshTokenExpiresIn } = JSON.parse(value) as Record<string, unknown>;
-    return typeof expiresIn === "number" && typeof refreshTokenExpiresIn === "number"
-      ? { expiresIn, refreshTokenExpiresIn }
-      : null;
+    const { expiresIn } = JSON.parse(value) as Record<string, unknown>;
+    return typeof expiresIn === "number" ? { expiresIn } : null;
   } catch {
     return null;
   }


### PR DESCRIPTION
### 📝 Description

**Why**

Baanx moved the login to a page it hosts itself, at `/v1/auth/oauth2/authorize`. The browser opens this page directly, and the app skips a call to backend first. This PR moves the login to that new flow.

https://github.com/user-attachments/assets/1ed85eac-b362-416d-a8d5-71546305bb47

**How**
<img width="4080" height="2541" alt="mermaid-diagram-2026-08-24-155943" src="https://github.com/user-attachments/assets/589b08fe-8e90-4ae7-94a3-62153527bb85" />



`buildAuthorizeUrl` builds the authorize URL from the OAuth config and the PKCE challenge. The app hands this URL to the secure browser. The browser opens the page. Baanx hosts the page, and Baanx owns the redirect.

```
GET {CARD_API_URL}/v1/auth/oauth2/authorize
  ?client_id=…&response_type=code
  &scope=openid profile email offline_access
  &redirect_uri=https://go.ledger.com/ledger/card-baanx
  &code_challenge=…&code_challenge_method=S256&prompt=consent
```

The app no longer asks the backend for a login URL first. One request, one machine state, and one error case all disappear.

| | Before | Now |
|---|---|---|
| Get the login URL | `GET /v1/auth/oauth/authorize/initiate?…&mode=api` → `{ url }` | Built on the device |
| Machine states | `preparingAttempt → initiatingAuthorize → awaitingHostedLogin` | `preparingAttempt → awaitingHostedLogin` |
| Attempt on disk | `{ state, codeVerifier }` | `{ codeVerifier }` |
| Redirect | `?code=…&state=…` | `?code=…` |
| Token grant | `/v1/auth/oauth/token` | `/v1/auth/oauth2/token` |

**Why `state` is gone**

The redirect now carries `code` and `app_id`. It no longer carries `state`.

PKCE covers the same risk that `state` covered here. The provider issues the code against this attempt's `code_challenge`. The exchange must present the `code_verifier` that produced it. Nobody can redeem a stolen code with our verifier, so an injected callback fails.

Only the place that catches the failure moves. The device used to catch it early, as `state_mismatch`, before it sent any request. The provider now catches it, and reports it as `exchange_failed`. `validateCallback` still runs, but it now only checks that a verifier and a code both exist.

This PR removes `state_mismatch` and `initiate_failed`, and their user-facing text.

**A fix on top**

`buildAuthorizeUrl` throws when `apiUrl` is misconfigured. That call first ran inside an `assign` action, on the transition after `prepareAttempt`. A throw inside an action stops the machine. It never reaches a transition. So the login just stopped: the user saw no error, and had no way to retry.

`prepareAttempt` now builds the URL itself. A throw there is a rejected promise. This rejection reaches `onError`. `onError` now targets `clearingAttempt`, not `error` directly, because the attempt is already saved by the time the app builds the URL. `clearingAttempt` then clears the attempt, and reports the error kind.

**Three fixes from a live exchange against Baanx's UAT environment**

The token exchange sent `redirect_uri` in its body. Baanx's documented contract for `/v1/auth/oauth2/token` does not accept it: only `grant_type`, `code`, and `code_verifier`. This PR drops it from the request, and from `PayCardAuthorizationCodeRequest`. `redirectUri` still travels on the authorize URL; it is no longer repeated on the exchange.

The scope also dropped `offline_access` at one point, to match a working authorize request. A live exchange against that scope came back with no `refresh_token` at all — only `access_token`, `expires_in`, `id_token`, `scope`, `token_type`. `PayCardSessionResponseSchema` requires `refresh_token`, so every login failed after the redirect. `offline_access` is back in the scope for that reason; `platform:full` stays out.

With `refresh_token` back, the next live exchange answered with no `refresh_token_expires_in` either. `PayCardSessionResponseSchema` required that field too, so the exchange still failed. Baanx's contract carries no lifetime for the refresh token, only for the access token, so this PR removes it from the schema, `PayCardSession`, and the stored session lifetimes in `@features/platform-card`. Nothing consumed it: `refreshCardSession` does not renew yet (LIVE-34741), so the field was already dead weight, and one that made every session read fail once the exchange started answering without it.

**What this removes**

This PR deletes the `initiateAuthorize` actor, its port, the RTK Query mutation, and their request, response, and zod types. It also deletes `CardLoginInitiation`. Net change: **−81 lines across 28 files**.

`CardLoginOauthConfig` gains `apiUrl`, read from `CARD_API_URL`. The authorize page lives on the API host, so the config needs that host.

### ✅ Tests

| Package | Result |
|---|---|
| `@features/flow-pay-card-auth` | **126 / 126**, 18 suites |
| `@domain/api-card-management` | **16 / 16** |
| `@features/platform-card` | **36 / 36** |
| mobile `PayTab` | **31 / 31** |
| desktop `PayTab` | **40 / 40** |

`buildAuthorizeUrl.ts` has 100% coverage. Its 5 tests check the path and the exact query. They check the encoding of the redirect and the scope separators. They also check that the verifier never leaves the device.

All three fixes above came from a real login against Baanx's UAT environment, not from a test: the redirect, the token exchange, and each missing field were observed live, then reproduced in the suite.

### 🔗 Context

- **JIRA**: [LIVE-36301](https://ledgerhq.atlassian.net/browse/LIVE-36301) — parent [LIVE-33829](https://ledgerhq.atlassian.net/browse/LIVE-33829)
- **Baanx docs**: `GET /v1/auth/oauth2/authorize`, `POST /v1/auth/oauth2/token`
- **Stacked on**: #20816
- **ADR**: [Guideline Monorepo DDD Re-architecture — Structure & Flow](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/6111232117/Guideline+Monorepo+DDD+Re-architecture+Structure+Flow)


[LIVE-36301]: https://ledgerhq.atlassian.net/browse/LIVE-36301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

