### PR TITLE
[LWD] feat(pay-card): add verify-address DIE for Pay (LIVE-36132)

### DIFF
--- a/.changeset/LIVE-36132-verify-address-intent.md
+++ b/.changeset/LIVE-36132-verify-address-intent.md
@@ -1,0 +1,10 @@
+---
+"@features/platform-verify-address-intent": minor
+"ledger-live-desktop": minor
+---
+
+Add `@features/platform-verify-address-intent`, a Device Intent that verifies a receive address on the device Secure Screen, and wire it to the desktop Pay tab Verify CTA.
+
+The host injects a family-agnostic `startAddressVerification` (generic `getAddress` over the DIE DMK transport). When `ldmkTransport` is off, Verify opens the classic Receive modal. Address comparison is encoding-aware (case-insensitive for hex, exact otherwise). `verified` / `cancelled` / `unsupported` return to the request summary; `mismatch` closes the flow.
+
+Generalize desktop `InfoState` by adding a full-width `content` slot and optional `backgroundTone` support for the `spot` preset.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -131,6 +131,9 @@ features/flow/pay-card-deposit/                          @ledgerhq/wallet-xp
 features/flow/pay-card-feature-tour/                     @ledgerhq/wallet-xp
 features/flow/pay-card-request/                          @ledgerhq/wallet-xp
 
+# Wallet — Intents
+features/platform/verify-address-intent/                 @ledgerhq/wallet-xp
+
 # Wallet — App lock
 features/platform/app-lock/                              @ledgerhq/wallet-xp
 /shared/password-verifier/                               @ledgerhq/wallet-xp

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -109,6 +109,7 @@
     "@features/platform-env": "workspace:*",
     "@features/platform-feature-flags": "workspace:^",
     "@features/platform-style": "workspace:^",
+    "@features/platform-verify-address-intent": "workspace:^",
     "@features/platform-wallet-sync": "workspace:^",
     "@ledgerhq/asset-aggregation": "workspace:^",
     "@ledgerhq/asset-detail": "workspace:^",

--- a/apps/ledger-live-desktop/src/mvvm/components/InfoState/InfoState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/InfoState/InfoState.test.tsx
@@ -66,6 +66,21 @@ describe("InfoState", () => {
     expect(onSecondaryPress).toHaveBeenCalledTimes(1);
   });
 
+  it("GIVEN an InfoState with custom content WHEN it is rendered THEN the content is displayed", () => {
+    // GIVEN / WHEN
+    render(
+      <InfoState
+        preset="spot"
+        spotProps={{ icon: Search }}
+        title="State title"
+        content={<div data-testid="info-state-content">Custom content</div>}
+      />,
+    );
+
+    // THEN
+    expect(screen.getByTestId("info-state-content")).toBeVisible();
+  });
+
   it("GIVEN an InfoState with no optional props WHEN it is rendered THEN it does not display title, description, banner or actions", () => {
     // GIVEN / WHEN
     render(<InfoState preset="info" testID="info-state" />);
@@ -143,6 +158,21 @@ describe("InfoState", () => {
       expect(cleanup).toHaveBeenCalledTimes(1);
     },
   );
+
+  it("GIVEN the spot preset with a background tone WHEN the InfoState mounts THEN it requests that tone", () => {
+    // GIVEN
+    const requestBackgroundTone = jest.fn(() => jest.fn());
+
+    // WHEN
+    render(
+      <DialogBackgroundContext.Provider value={{ requestBackgroundTone }}>
+        <InfoState preset="spot" spotProps={{ icon: Search, size: 72 }} backgroundTone="info" />
+      </DialogBackgroundContext.Provider>,
+    );
+
+    // THEN
+    expect(requestBackgroundTone).toHaveBeenCalledWith("info");
+  });
 
   it.each(["illustration", "spot", "text"] as const)(
     "GIVEN the non-status %s preset inside a DialogBackgroundContext provider WHEN the InfoState renders THEN it does not request a background tone",

--- a/apps/ledger-live-desktop/src/mvvm/components/InfoState/components/PresetVisual.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/InfoState/components/PresetVisual.tsx
@@ -13,7 +13,13 @@ export function PresetVisual(props: InfoStateProps) {
         </div>
       );
     case "spot":
-      return <Spot appearance="icon" size={SPOT_SIZE} icon={props.spotProps.icon} />;
+      return (
+        <Spot
+          appearance="icon"
+          size={props.spotProps.size ?? SPOT_SIZE}
+          icon={props.spotProps.icon}
+        />
+      );
     case "success":
       return <Spot appearance="check" size={SPOT_SIZE} />;
     case "error":

--- a/apps/ledger-live-desktop/src/mvvm/components/InfoState/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/InfoState/index.tsx
@@ -14,6 +14,7 @@ export function InfoState(props: InfoStateProps) {
   const {
     title,
     description,
+    content,
     primaryCta,
     secondaryCta,
     banner,
@@ -22,7 +23,7 @@ export function InfoState(props: InfoStateProps) {
   } = props;
   const isTextPreset = props.preset === "text";
   const isFullHeight = size === "full-height";
-  useDialogBackgroundTone(getInfoStateDialogTone(props.preset));
+  useDialogBackgroundTone(getInfoStateDialogTone(props));
 
   return (
     <div className={cn("w-full", isFullHeight && "flex flex-1")} data-testid={testID}>
@@ -47,6 +48,8 @@ export function InfoState(props: InfoStateProps) {
             </div>
           ) : null}
         </div>
+
+        {content ? <div className="w-full">{content}</div> : null}
 
         {banner ? (
           <div className="w-full">

--- a/apps/ledger-live-desktop/src/mvvm/components/InfoState/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/InfoState/types.ts
@@ -1,4 +1,5 @@
 import type { ComponentProps, ReactNode } from "react";
+import type { DialogBackgroundTone } from "LLD/contexts/DialogBackgroundContext";
 
 type LumenSpotProps = ComponentProps<(typeof import("@ledgerhq/lumen-ui-react"))["Spot"]>;
 type LumenIconSpotProps = Extract<LumenSpotProps, { icon?: unknown }>;
@@ -33,8 +34,10 @@ export type InfoStateBanner = Readonly<{
   appearance?: "info" | "warning" | "error" | "success";
 }>;
 
-/** Props forwarded to the Lumen Spot for the custom spot preset. */
-export type InfoStateSpotProps = Pick<LumenIconSpotProps, "icon">;
+/**
+ * Props forwarded to the Lumen Spot for the custom spot preset.
+ */
+export type InfoStateSpotProps = Pick<LumenIconSpotProps, "icon" | "size">;
 
 type InfoStateBaseProps = Readonly<{
   /** Optional centered heading. */
@@ -42,6 +45,9 @@ type InfoStateBaseProps = Readonly<{
 
   /** Optional centered explanatory copy below the title. */
   description?: ReactNode;
+
+  /** Optional full-width custom content rendered between the copy and the banner. */
+  content?: ReactNode;
 
   /** Primary action rendered first in the action stack. */
   primaryCta?: InfoStateCta;
@@ -70,6 +76,13 @@ export type InfoStateProps =
       /** Renders a Lumen Spot with caller-provided icon props. */
       preset: "spot";
       spotProps: InfoStateSpotProps;
+
+      /**
+       * Tints the dialog with a status gradient. Only the custom spot preset can opt
+       * in: the status presets already carry their own tone and the remaining presets
+       * draw none.
+       */
+      backgroundTone?: DialogBackgroundTone;
     })
   | (InfoStateBaseProps & {
       /** Renders a success status Spot. */

--- a/apps/ledger-live-desktop/src/mvvm/components/InfoState/utils/getInfoStateDialogTone.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/InfoState/utils/getInfoStateDialogTone.ts
@@ -1,22 +1,21 @@
 import type { DialogBackgroundTone } from "LLD/contexts/DialogBackgroundContext";
 import type { InfoStateProps } from "../types";
 
-export function getInfoStateDialogTone(
-  preset: InfoStateProps["preset"],
-): DialogBackgroundTone | undefined {
-  switch (preset) {
+export function getInfoStateDialogTone(props: InfoStateProps): DialogBackgroundTone | undefined {
+  switch (props.preset) {
     case "error":
       return "error";
     case "info":
       return "info";
     case "success":
       return "success";
-    case "illustration":
     case "spot":
+      return props.backgroundTone;
+    case "illustration":
     case "text":
       return undefined;
     default:
-      return assertNever(preset);
+      return assertNever(props);
   }
 }
 

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  act,
   renderWithMockedCounterValuesProvider,
   fireEvent,
   screen,
@@ -8,13 +9,28 @@ import {
   within,
 } from "tests/testSetup";
 import { useNavigate } from "react-router";
+import type { TokenAccount } from "@ledgerhq/types-live";
+import type { VerifyAddressIntentJobState } from "@features/platform-verify-address-intent";
+import { buildDeviceInitializationInput } from "LLD/components/DeviceIntentExecutor";
+import { useOpenAssetAndAccount } from "LLD/features/ModularDialog/Web3AppWebview/AssetAndAccountDrawer";
 import { track, trackPage } from "~/renderer/analytics/segment";
-import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
 import { BTC_ACCOUNT, ETH_ACCOUNT_WITH_USDC } from "LLD/features/__mocks__/accounts.mock";
 import { payCardFeatureTourInitialState } from "@features/flow-pay-card-feature-tour/state";
 import PayTab from "LLD/features/PayTab";
 import { usePayStablecoins, type PayStablecoins } from "../hooks/usePayStablecoins";
-import { USDC, USDT, makeItem } from "../hooks/__tests__/fixtures";
+import { USDC, makeItem } from "../hooks/__tests__/fixtures";
+import {
+  EMPTY_DESCRIPTION,
+  EMPTY_TITLE,
+  FEATURE_TOUR_ROW,
+  INIT_INPUT,
+  USDC_TOKEN,
+  defaultPayStablecoins,
+  dieEnabledState,
+  fundedState,
+  onboardedState,
+  tourSeenState,
+} from "./fixtures";
 
 const mockNavigate = jest.fn();
 
@@ -31,27 +47,6 @@ const mockedUseNavigate = jest.mocked(useNavigate);
 const mockedTrackPage = jest.mocked(trackPage);
 const mockedTrack = jest.mocked(track);
 const mockedUsePayStablecoins = jest.mocked(usePayStablecoins);
-
-const EMPTY_TITLE = "Pay and get paid";
-const EMPTY_DESCRIPTION = "Start by depositing stablecoin to your wallet";
-const FEATURE_TOUR_ROW = "Minimal volatility";
-
-const onboardedState = { settings: { ...AFTER_ONBOARDING_STATE, counterValue: "USD" } };
-const tourSeenState = {
-  payCardFeatureTour: { ...payCardFeatureTourInitialState, hasSeenFeatureTour: true },
-};
-const fundedState = {
-  ...onboardedState,
-  ...tourSeenState,
-  accounts: [BTC_ACCOUNT, ETH_ACCOUNT_WITH_USDC],
-};
-
-const defaultPayStablecoins: PayStablecoins = {
-  stablecoins: [],
-  defaultStablecoins: [USDC, USDT],
-  isLoading: false,
-  isError: false,
-};
 
 function mockPayStablecoins(overrides: Partial<PayStablecoins> = {}) {
   mockedUsePayStablecoins.mockReturnValue({
@@ -71,11 +66,43 @@ jest.mock("@features/flow-pay-card-auth", () => ({
   CardLogout: () => null,
 }));
 
+type CapturedExecutor = {
+  sourceFlow: string;
+  intent: { input: { expectedAddress: string } };
+  onIntentJobStateChanged: (jobState: VerifyAddressIntentJobState) => void;
+};
+
+let capturedExecutor: CapturedExecutor | undefined;
+
+jest.mock("LLD/components/DeviceIntentExecutor", () => ({
+  buildDeviceInitializationInput: jest.fn(),
+  DeviceIntentExecutorLWD: (props: CapturedExecutor) => {
+    capturedExecutor = props;
+    return <div data-testid="device-intent-executor" />;
+  },
+}));
+
+jest.mock("LLD/features/ModularDialog/Web3AppWebview/AssetAndAccountDrawer", () => ({
+  useOpenAssetAndAccount: jest.fn(),
+}));
+
+const mockedBuildInit = jest.mocked(buildDeviceInitializationInput);
+const mockedUseOpenAssetAndAccount = jest.mocked(useOpenAssetAndAccount);
+
+let openAssetAndAccount: jest.Mock;
+
 describe("PayTab integration", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    capturedExecutor = undefined;
     mockPayStablecoins();
     mockedUseNavigate.mockReturnValue(mockNavigate);
+    openAssetAndAccount = jest.fn();
+    mockedUseOpenAssetAndAccount.mockReturnValue({
+      openAssetAndAccount,
+      openAssetAndAccountPromise: jest.fn(),
+    });
+    mockedBuildInit.mockResolvedValue(INIT_INPUT);
   });
 
   it("should show the feature tour on first visit", () => {
@@ -222,5 +249,35 @@ describe("PayTab integration", () => {
       button: "confirm_balance_filter",
       asset: "USDC",
     });
+  });
+
+  it("should mount the DIE on verify and restore the request card once the address is confirmed", async () => {
+    mockFundedPayStablecoins();
+    const { user } = renderWithMockedCounterValuesProvider(<PayTab />, {
+      initialState: dieEnabledState,
+    });
+
+    await user.click(await screen.findByRole("button", { name: "Request" }));
+    const { onSuccess } = openAssetAndAccount.mock.calls[0][0] as {
+      onSuccess: (account: TokenAccount, parentAccount: typeof ETH_ACCOUNT_WITH_USDC) => void;
+    };
+    act(() => onSuccess(USDC_TOKEN, ETH_ACCOUNT_WITH_USDC));
+
+    await user.click(await screen.findByTestId("pay-card-request-receive-verify"));
+    await user.click(await screen.findByTestId("pay-card-verify-address-verify-cta"));
+
+    await waitFor(() => expect(screen.getByTestId("device-intent-executor")).toBeVisible());
+    expect(capturedExecutor?.sourceFlow).toBe("receive");
+    expect(capturedExecutor?.intent.input.expectedAddress).toBe(ETH_ACCOUNT_WITH_USDC.freshAddress);
+
+    act(() => {
+      capturedExecutor!.onIntentJobStateChanged({
+        type: "verified",
+        address: ETH_ACCOUNT_WITH_USDC.freshAddress,
+      });
+    });
+
+    expect(await screen.findByTestId("pay-card-request-receive")).toBeVisible();
+    expect(screen.queryByTestId("device-intent-executor")).not.toBeInTheDocument();
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/fixtures.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/fixtures.ts
@@ -1,0 +1,40 @@
+import type { TokenAccount } from "@ledgerhq/types-live";
+import type { InitializationInput } from "LLD/components/DeviceIntentExecutor";
+import { BTC_ACCOUNT, ETH_ACCOUNT_WITH_USDC } from "LLD/features/__mocks__/accounts.mock";
+import { payCardFeatureTourInitialState } from "@features/flow-pay-card-feature-tour/state";
+import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+import { withFlagOverrides } from "tests/testSetup";
+import type { PayStablecoins } from "../hooks/usePayStablecoins";
+import { USDC, USDT } from "../hooks/__tests__/fixtures";
+
+export const EMPTY_TITLE = "Pay and get paid";
+export const EMPTY_DESCRIPTION = "Start by depositing stablecoin to your wallet";
+export const FEATURE_TOUR_ROW = "Minimal volatility";
+
+export const onboardedState = { settings: { ...AFTER_ONBOARDING_STATE, counterValue: "USD" } };
+
+export const tourSeenState = {
+  payCardFeatureTour: { ...payCardFeatureTourInitialState, hasSeenFeatureTour: true },
+};
+
+export const fundedState = {
+  ...onboardedState,
+  ...tourSeenState,
+  accounts: [BTC_ACCOUNT, ETH_ACCOUNT_WITH_USDC],
+};
+
+export const dieEnabledState = {
+  ...fundedState,
+  ...withFlagOverrides({ ldmkTransport: { enabled: true } }),
+};
+
+export const defaultPayStablecoins: PayStablecoins = {
+  stablecoins: [],
+  defaultStablecoins: [USDC, USDT],
+  isLoading: false,
+  isError: false,
+};
+
+export const INIT_INPUT = { appName: "Ethereum" } as InitializationInput;
+
+export const USDC_TOKEN = ETH_ACCOUNT_WITH_USDC.subAccounts![0] as TokenAccount;

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayTabRequestReceive.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayTabRequestReceive.test.ts
@@ -92,18 +92,36 @@ describe("usePayTabRequestReceive", () => {
     expect(result.current.requestReceive.isOpen).toBe(false);
   });
 
-  it("should close the receive dialog and hand off to the injected verify callback", () => {
-    const account = { type: "Account" } as unknown as AccountLike;
+  it("should close the receive dialog and hand off the selection to the injected verify callback", () => {
+    const account = { type: "TokenAccount" } as unknown as AccountLike;
+    const parentAccount = { type: "Account" } as unknown as Account;
     const onVerify = jest.fn();
     const { result } = renderHook(() => usePayTabRequestReceive(undefined, onVerify));
 
     act(() => result.current.open());
-    act(() => openAssetAndAccount.mock.calls[0][0].onSuccess(account, undefined));
+    act(() => openAssetAndAccount.mock.calls[0][0].onSuccess(account, parentAccount));
     expect(result.current.requestReceive.isOpen).toBe(true);
 
     act(() => result.current.requestReceive.onVerify(DERIVED.address));
 
     expect(result.current.requestReceive.isOpen).toBe(false);
-    expect(onVerify).toHaveBeenCalledWith(DERIVED.address);
+    expect(onVerify).toHaveBeenCalledWith({ account, parentAccount }, expect.any(Function));
+  });
+
+  it("should reopen the receive dialog when the verify flow calls back", () => {
+    const account = { type: "TokenAccount" } as unknown as AccountLike;
+    const onVerify = jest.fn();
+    const { result } = renderHook(() => usePayTabRequestReceive(undefined, onVerify));
+
+    act(() => result.current.open());
+    act(() => openAssetAndAccount.mock.calls[0][0].onSuccess(account, undefined));
+    act(() => result.current.requestReceive.onVerify(DERIVED.address));
+    expect(result.current.requestReceive.isOpen).toBe(false);
+
+    const [, onDone] = onVerify.mock.calls[0];
+    act(() => onDone());
+
+    expect(result.current.requestReceive.isOpen).toBe(true);
+    expect(result.current.requestReceive.address).toBe(DERIVED.address);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayTabVerifyAddress.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayTabVerifyAddress.test.ts
@@ -1,68 +1,146 @@
-import { act, renderHook } from "tests/testSetup";
-import { usePayTabVerifyAddress } from "../usePayTabVerifyAddress";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
+import { act, renderHook, withFlagOverrides } from "tests/testSetup";
+import { usePayTabVerifyAddress, type PayVerifySelection } from "../usePayTabVerifyAddress";
+
+const SELECTION: PayVerifySelection = {
+  account: { type: "TokenAccount" } as unknown as AccountLike,
+  parentAccount: { type: "Account" } as unknown as Account,
+};
+
+function renderVerifyAddress(ldmkEnabled = false) {
+  return renderHook(() => usePayTabVerifyAddress(undefined), {
+    initialState: withFlagOverrides({ ldmkTransport: { enabled: ldmkEnabled } }),
+  });
+}
 
 describe("usePayTabVerifyAddress", () => {
   it("should start hidden with resolved copy", () => {
-    const { result } = renderHook(() => usePayTabVerifyAddress(undefined));
+    const { result } = renderVerifyAddress();
 
     expect(result.current.phase).toBe("hidden");
     expect(result.current.verifyAddress.phase).toBe("hidden");
-    expect(result.current.verifyAddress.labels).toEqual({
-      introTitle: "Verify your address",
-      introDescription:
-        "To protect against address replacement attacks, verify your address on your Ledger device's Secure Screen.",
-      verifyCta: "Verify address",
-      successTitle: "Address displayed on the device's Secure Screen",
-      nextStepsLabel: "Next steps",
-      nextStepShare: "Share your address via your desired app",
-      nextStepMatch: "Ensure the shared address matches the one on your Ledger Device.",
-      gotItCta: "Got it",
-    });
+    expect(result.current.verifyAddress.labels.introTitle).toBe("Verify your address");
+    expect(result.current.verifyAddress.labels.verifyCta).toBe("Verify address");
+    expect(result.current.deviceIntent.active).toBe(false);
   });
 
-  it("should open the intro phase", () => {
-    const { result } = renderHook(() => usePayTabVerifyAddress(undefined));
+  it("should open the intro phase and stash the selection", () => {
+    const { result } = renderVerifyAddress();
 
-    act(() => result.current.openIntro());
+    act(() => result.current.openIntro(SELECTION));
 
     expect(result.current.phase).toBe("intro");
-    expect(result.current.verifyAddress.phase).toBe("intro");
+    expect(result.current.deviceIntent.selection).toEqual(SELECTION);
   });
 
-  it("should advance from the intro to the success screen on verify", () => {
-    const { result } = renderHook(() => usePayTabVerifyAddress(undefined));
+  it("mounts the DIE but keeps the intro visible until the executor is ready", () => {
+    const { result, store } = renderVerifyAddress(true);
 
-    act(() => result.current.openIntro());
+    act(() => result.current.openIntro(SELECTION));
     act(() => result.current.verifyAddress.onVerify());
 
-    expect(result.current.phase).toBe("success");
-    expect(result.current.verifyAddress.phase).toBe("success");
+    // Intro stays up (no blank gap) while the DIE initializes.
+    expect(result.current.phase).toBe("intro");
+    expect(result.current.deviceIntent.active).toBe(true);
+    expect(result.current.deviceIntent.selection).toEqual(SELECTION);
+    expect(store.getState().modals.MODAL_RECEIVE).toBeUndefined();
+
+    // Once the executor dialog is up, the intro steps aside; DIE stays mounted.
+    act(() => result.current.deviceIntent.onReady());
+    expect(result.current.phase).toBe("hidden");
+    expect(result.current.deviceIntent.active).toBe(true);
   });
 
-  it("should show the success phase when verification completes", () => {
-    const { result } = renderHook(() => usePayTabVerifyAddress(undefined));
+  it("opens the legacy Receive modal and restores the card on verify when ldmkTransport is disabled", () => {
+    const onDone = jest.fn();
+    const { result, store } = renderVerifyAddress(false);
 
-    act(() => result.current.showSuccess());
-
-    expect(result.current.phase).toBe("success");
-    expect(result.current.verifyAddress.phase).toBe("success");
-  });
-
-  it("should hide the overlay from the success CTA", () => {
-    const { result } = renderHook(() => usePayTabVerifyAddress(undefined));
-
-    act(() => result.current.showSuccess());
-    act(() => result.current.verifyAddress.onGotIt());
+    act(() => result.current.openIntro(SELECTION, onDone));
+    act(() => result.current.verifyAddress.onVerify());
 
     expect(result.current.phase).toBe("hidden");
+    expect(result.current.deviceIntent.active).toBe(false);
+    expect(store.getState().modals.MODAL_RECEIVE).toEqual({
+      isOpened: true,
+      data: {
+        account: SELECTION.account,
+        parentAccount: SELECTION.parentAccount,
+      },
+    });
+    expect(onDone).toHaveBeenCalledTimes(1);
   });
 
-  it("should hide the overlay when closed", () => {
-    const { result } = renderHook(() => usePayTabVerifyAddress(undefined));
+  it("does nothing on verify when no selection was made", () => {
+    const { result, store } = renderVerifyAddress(true);
 
-    act(() => result.current.openIntro());
+    act(() => result.current.verifyAddress.onVerify());
+
+    expect(result.current.deviceIntent.active).toBe(false);
+    expect(store.getState().modals.MODAL_RECEIVE).toBeUndefined();
+  });
+
+  it.each(["verified", "cancelled", "unsupported", "dismissed", "initFailed"] as const)(
+    "brings the receive summary back when the device flow exits with %s",
+    outcome => {
+      const onDone = jest.fn();
+      const { result } = renderVerifyAddress(true);
+
+      act(() => result.current.openIntro(SELECTION, onDone));
+      act(() => result.current.verifyAddress.onVerify());
+      act(() => result.current.deviceIntent.onExit(outcome));
+
+      expect(result.current.phase).toBe("hidden");
+      expect(result.current.deviceIntent.active).toBe(false);
+      expect(onDone).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("closes the whole flow without restoring the card on mismatch", () => {
+    const onDone = jest.fn();
+    const { result } = renderVerifyAddress(true);
+
+    act(() => result.current.openIntro(SELECTION, onDone));
+    act(() => result.current.verifyAddress.onVerify());
+    act(() => result.current.deviceIntent.onExit("mismatch"));
+
+    expect(result.current.phase).toBe("hidden");
+    expect(result.current.deviceIntent.active).toBe(false);
+    expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it("consumes the restore callback at most once across repeated exits", () => {
+    const onDone = jest.fn();
+    const { result } = renderVerifyAddress(true);
+
+    act(() => result.current.openIntro(SELECTION, onDone));
+    act(() => result.current.verifyAddress.onVerify());
+    act(() => result.current.deviceIntent.onExit("verified"));
+    act(() => result.current.deviceIntent.onExit("dismissed"));
+
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it("brings the receive summary back when the intro overlay is dismissed", () => {
+    const onDone = jest.fn();
+    const { result, store } = renderVerifyAddress();
+
+    act(() => result.current.openIntro(SELECTION, onDone));
     act(() => result.current.verifyAddress.onClose());
 
+    expect(result.current.deviceIntent.active).toBe(false);
+    expect(store.getState().modals.MODAL_RECEIVE).toBeUndefined();
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the overlay from the success CTA and on close", () => {
+    const { result } = renderVerifyAddress();
+
+    act(() => result.current.openIntro(SELECTION));
+    act(() => result.current.verifyAddress.onClose());
+    expect(result.current.phase).toBe("hidden");
+
+    act(() => result.current.openIntro(SELECTION));
+    act(() => result.current.verifyAddress.onGotIt());
     expect(result.current.phase).toBe("hidden");
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabRequestReceive.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabRequestReceive.ts
@@ -7,6 +7,7 @@ import { useCopyToClipboard } from "../../../hooks/useCopyToClipboard";
 import { useOpenAssetAndAccount } from "../../ModularDialog/Web3AppWebview/AssetAndAccountDrawer";
 import { deriveRequestReceiveData } from "./deriveRequestReceiveData";
 import { useSaveRequestReceiveCard } from "./useSaveRequestReceiveCard";
+import type { PayVerifySelection } from "./usePayTabVerifyAddress";
 
 const REQUEST_PAGE = "Pay";
 
@@ -23,7 +24,7 @@ export type UsePayTabRequestReceive = Readonly<{
 
 export function usePayTabRequestReceive(
   onTrackEvent: PayCardTrackEvent | undefined,
-  onVerify: (address: string) => void,
+  onVerify: (selection: PayVerifySelection, onDone: () => void) => void,
 ): UsePayTabRequestReceive {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
@@ -43,15 +44,15 @@ export function usePayTabRequestReceive(
 
   const onClose = useCallback(() => setIsOpen(false), []);
 
+  const reopen = useCallback(() => setIsOpen(true), []);
+
   const onCopy = useCallback((address: string) => copyToClipboard(address), [copyToClipboard]);
 
-  const handleVerify = useCallback(
-    (address: string) => {
-      onClose();
-      onVerify(address);
-    },
-    [onVerify, onClose],
-  );
+  const handleVerify = useCallback(() => {
+    if (!selection) return;
+    onClose();
+    onVerify(selection, reopen);
+  }, [onVerify, onClose, reopen, selection]);
 
   const data = useMemo(
     () => (selection ? deriveRequestReceiveData(selection.account, selection.parentAccount) : null),

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabVerifyAddress.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabVerifyAddress.ts
@@ -1,40 +1,129 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
+import { useFeature } from "@features/platform-feature-flags";
 import type {
   PayCardTrackEvent,
   VerifyAddressLabels,
   VerifyAddressPhase,
   VerifyAddressProps,
 } from "@features/flow-pay-card-request";
+import { useDispatch } from "LLD/hooks/redux";
+import { openModal } from "~/renderer/actions/modals";
 
 const VERIFY_PAGE = "Request Address Verification";
 
-export type UsePayTabVerifyAddress = Readonly<{
-  phase: VerifyAddressPhase;
-  openIntro: () => void;
-  showSuccess: () => void;
-  verifyAddress: VerifyAddressProps;
+/** Account (and optional parent) whose receive address is being verified. */
+export type PayVerifySelection = Readonly<{
+  account: AccountLike;
+  parentAccount?: Account;
 }>;
 
 /**
- * Owns the `hidden -> intro -> success` phase of the Request VerifyAddress overlay and resolves its
- * copy.
+ * How the device flow ended. Everything but `mismatch` brings the receive
+ * summary back; `mismatch` closes the whole flow because the reported address
+ * must not be shared.
+ */
+export type PayVerifyOutcome =
+  | "verified"
+  | "cancelled"
+  | "unsupported"
+  | "mismatch"
+  | "dismissed"
+  | "initFailed";
+
+/** Controls the app-side Device Intent Executor host for the verify flow. */
+export type PayVerifyDeviceIntent = Readonly<{
+  /** Whether the DIE should be mounted (only when `ldmkTransport` is on). */
+  active: boolean;
+  /** Selection to verify; `null` before the user starts. */
+  selection: PayVerifySelection | null;
+  /** Called once the executor dialog is actually showing, so the intro can step aside. */
+  onReady: () => void;
+  /** Called when the executor host leaves, with the outcome that drives navigation. */
+  onExit: (outcome: PayVerifyOutcome) => void;
+}>;
+
+export type UsePayTabVerifyAddress = Readonly<{
+  phase: VerifyAddressPhase;
+  /** `onDone` runs when the user leaves the verify flow, to bring the receive summary back. */
+  openIntro: (selection: PayVerifySelection, onDone?: () => void) => void;
+  verifyAddress: VerifyAddressProps;
+  deviceIntent: PayVerifyDeviceIntent;
+}>;
+
+/**
+ * Owns the `hidden -> intro` phase of the Request VerifyAddress overlay and drives the on-device
+ * verification. Once the device flow starts, the executor dialog owns the screen: it shows the
+ * next steps as soon as the address reaches the Secure Screen, and closing it — on device
+ * confirmation or on a user dismissal — comes back here.
  *
- * UI-only for now: the intro CTA advances straight to the success screen. Once the shared
- * `verifyAddressIntent` lands (LIVE-36132), the CTA will instead start the device intent and the
- * app's DIE host will render the executing phase and call `showSuccess` on device confirmation.
+ * The whole DMK/DIE path is gated by the `ldmkTransport` feature flag (see `App.tsx` ->
+ * `DeviceManagementKitProvider`): when the flag is off, `useDeviceManagementKit()` returns `null`
+ * and mounting the DIE would immediately error. So the intro CTA branches:
+ * - flag on  -> mount the shared `verifyAddressIntent` DIE (DMK-native per family + legacy
+ *   fallback).
+ * - flag off -> open the classic Receive modal, which verifies via the legacy transport.
  */
 export function usePayTabVerifyAddress(
   onTrackEvent: PayCardTrackEvent | undefined,
 ): UsePayTabVerifyAddress {
   const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const ldmkTransport = useFeature("ldmkTransport");
   const [phase, setPhase] = useState<VerifyAddressPhase>("hidden");
+  const [selection, setSelection] = useState<PayVerifySelection | null>(null);
+  const [dieActive, setDieActive] = useState(false);
+  const onDoneRef = useRef<(() => void) | undefined>(undefined);
 
-  const openIntro = useCallback(() => setPhase("intro"), []);
-  const showSuccess = useCallback(() => setPhase("success"), []);
-  const close = useCallback(() => setPhase("hidden"), []);
+  const openIntro = useCallback((nextSelection: PayVerifySelection, onDone?: () => void) => {
+    setSelection(nextSelection);
+    onDoneRef.current = onDone;
+    setDieActive(false);
+    setPhase("intro");
+  }, []);
 
-  const onVerify = showSuccess;
+  /**
+   * Leaves the verify flow. Idempotent: `onDone` is consumed at most once so a
+   * device confirmation followed by the dialog unmount cannot restore the card
+   * twice. `restore` is false only for `mismatch`, which must close everything.
+   */
+  const finish = useCallback((restore: boolean) => {
+    setPhase("hidden");
+    setDieActive(false);
+    const onDone = onDoneRef.current;
+    onDoneRef.current = undefined;
+    if (restore) onDone?.();
+  }, []);
+
+  const onVerify = useCallback(() => {
+    if (!selection) return;
+
+    if (ldmkTransport?.enabled) {
+      // Keep the intro visible until the executor dialog is actually up (onReady),
+      // otherwise the PayTab shows a blank, clickable gap while the DIE initializes.
+      setDieActive(true);
+      return;
+    }
+
+    // Pure-legacy path: the classic Receive modal verifies via the legacy transport.
+    // Bring the request card back behind it so the user returns to the summary on close.
+    dispatch(
+      openModal("MODAL_RECEIVE", {
+        account: selection.account,
+        parentAccount: selection.parentAccount ?? null,
+      }),
+    );
+    finish(true);
+  }, [selection, ldmkTransport, dispatch, finish]);
+
+  // The executor dialog is up: step the intro aside so only one dialog is visible.
+  const onReady = useCallback(() => setPhase("hidden"), []);
+
+  const onExit = useCallback(
+    (outcome: PayVerifyOutcome) => finish(outcome !== "mismatch"),
+    [finish],
+  );
 
   const labels = useMemo<VerifyAddressLabels>(
     () => ({
@@ -50,18 +139,31 @@ export function usePayTabVerifyAddress(
     [t],
   );
 
+  // Dismissing the intro (X / Escape / Got it) backs out to the request summary.
+  const onIntroDismiss = useCallback(() => finish(true), [finish]);
+
   const verifyAddress = useMemo<VerifyAddressProps>(
     () => ({
       phase,
       labels,
       page: VERIFY_PAGE,
       onVerify,
-      onGotIt: close,
-      onClose: close,
+      onGotIt: onIntroDismiss,
+      onClose: onIntroDismiss,
       onTrackEvent,
     }),
-    [phase, labels, onVerify, close, onTrackEvent],
+    [phase, labels, onVerify, onIntroDismiss, onTrackEvent],
   );
 
-  return { phase, openIntro, showSuccess, verifyAddress };
+  const deviceIntent = useMemo<PayVerifyDeviceIntent>(
+    () => ({
+      active: dieActive,
+      selection,
+      onReady,
+      onExit,
+    }),
+    [dieActive, selection, onReady, onExit],
+  );
+
+  return { phase, openIntro, verifyAddress, deviceIntent };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/index.tsx
@@ -13,6 +13,7 @@ import { usePayTabActionTiles } from "./hooks/usePayTabActionTiles";
 import { usePayTabDepositOptions } from "./hooks/usePayTabDepositOptions";
 import { usePayTabRequestReceive } from "./hooks/usePayTabRequestReceive";
 import { usePayTabVerifyAddress } from "./hooks/usePayTabVerifyAddress";
+import { VerifyAddressExecutorLWD } from "./verifyAddressIntent/VerifyAddressExecutorLWD";
 
 // Baanx uses the same value for the client key header and the OAuth `client_id`.
 const oauthConfig: CardLoginOauthConfig = {
@@ -38,6 +39,13 @@ const PayTab = () => {
       <DepositOptions {...deposit.depositOptions} />
       <RequestReceive {...request.requestReceive} />
       <VerifyAddress {...verify.verifyAddress} />
+      {verify.deviceIntent.active && verify.deviceIntent.selection && (
+        <VerifyAddressExecutorLWD
+          selection={verify.deviceIntent.selection}
+          onReady={verify.deviceIntent.onReady}
+          onExit={verify.deviceIntent.onExit}
+        />
+      )}
       {/* Each one decides whether it belongs on screen: the login while nobody is signed in, and
           the logout once somebody is. */}
       <CardLogin oauthConfig={oauthConfig} />

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/verifyAddressIntent/VerifyAddressExecutorLWD.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/verifyAddressIntent/VerifyAddressExecutorLWD.tsx
@@ -1,0 +1,133 @@
+import React, { useCallback, useEffect, useMemo, useState, useRef } from "react";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { FlowName } from "@ledgerhq/live-common/device-action/utils";
+import { createIntent, type DeviceConnectionParams } from "@features/platform-device-intent";
+import type {
+  VerifyAddressIntentInput,
+  VerifyAddressIntentJobState,
+} from "@features/platform-verify-address-intent";
+import {
+  buildDeviceInitializationInput,
+  DeviceIntentExecutorLWD,
+  type InitializationInput,
+} from "LLD/components/DeviceIntentExecutor";
+import type { PayVerifyOutcome, PayVerifySelection } from "../hooks/usePayTabVerifyAddress";
+import { buildVerifyAddressIntentInput } from "./buildVerifyAddressIntentInput";
+import { verifyAddressIntentLWDDefinition } from "./intentLWDDefinition";
+
+const CONNECTION_PARAMS: DeviceConnectionParams = { acceptedDeviceModelIds: [] };
+
+type Props = Readonly<{
+  selection: PayVerifySelection;
+  /** Called once the executor dialog is actually showing, so the intro can step aside. */
+  onReady: () => void;
+  /** Called once when the executor leaves, with the outcome that drives navigation. */
+  onExit: (outcome: PayVerifyOutcome) => void;
+}>;
+
+const noop = () => {};
+
+/** Maps the last observed job state to the outcome a user dismissal should report. */
+function outcomeFromLastState(state: VerifyAddressIntentJobState | undefined): PayVerifyOutcome {
+  switch (state?.type) {
+    case "mismatch":
+      return "mismatch";
+    case "unsupported":
+      return "unsupported";
+    case "cancelled":
+      return "cancelled";
+    default:
+      return "dismissed";
+  }
+}
+
+export function VerifyAddressExecutorLWD({
+  selection,
+  onReady,
+  onExit,
+}: Props): React.ReactElement | null {
+  const { account, parentAccount } = selection;
+  const [initInput, setInitInput] = useState<InitializationInput | null>(null);
+  const lastJobStateRef = useRef<VerifyAddressIntentJobState | undefined>(undefined);
+  const exitedRef = useRef(false);
+
+  const mainAccount = useMemo(
+    () => getMainAccount(account, parentAccount ?? undefined),
+    [account, parentAccount],
+  );
+
+  const exit = useCallback(
+    (outcome: PayVerifyOutcome) => {
+      if (exitedRef.current) return;
+      exitedRef.current = true;
+      onExit(outcome);
+    },
+    [onExit],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    buildDeviceInitializationInput({
+      appRequest: {
+        account: mainAccount,
+        currency: mainAccount.currency,
+        tokenCurrency: account.type === "TokenAccount" ? account.token : undefined,
+      },
+      flow: FlowName.receive,
+    })
+      .then(input => {
+        if (cancelled) return;
+        setInitInput(input);
+        onReady();
+      })
+      .catch(() => {
+        // Fail closed and restore the request card so the flow never hangs on a broken init.
+        if (!cancelled) exit("initFailed");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [mainAccount, account, onReady, exit]);
+
+  const onJobStateChanged = useCallback(
+    (jobState: VerifyAddressIntentJobState) => {
+      lastJobStateRef.current = jobState;
+      // Confirming on the device ends the flow: no extra acknowledgement needed.
+      if (jobState.type === "verified") exit("verified");
+    },
+    [exit],
+  );
+
+  const onUserCancel = useCallback(
+    () => exit(outcomeFromLastState(lastJobStateRef.current)),
+    [exit],
+  );
+
+  const intent = useMemo(
+    () =>
+      createIntent(
+        verifyAddressIntentLWDDefinition,
+        buildVerifyAddressIntentInput(account, parentAccount),
+      ),
+    [account, parentAccount],
+  );
+
+  if (!initInput) return null;
+
+  return (
+    <DeviceIntentExecutorLWD<VerifyAddressIntentJobState, VerifyAddressIntentInput, undefined>
+      enabled
+      sourceFlow="receive"
+      deviceConnectionParams={CONNECTION_PARAMS}
+      deviceInitializationInput={initInput}
+      intent={intent}
+      intentComponentExtraProps={undefined}
+      onExecutorStateChanged={noop}
+      onIntentJobStateChanged={onJobStateChanged}
+      onIntentJobComplete={noop}
+      onIntentJobError={noop}
+      cancelIntentRequestId={undefined}
+      onUserCancel={onUserCancel}
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/verifyAddressIntent/__tests__/VerifyAddressExecutorLWD.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/verifyAddressIntent/__tests__/VerifyAddressExecutorLWD.test.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { act, render, screen, waitFor } from "tests/testSetup";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { buildDeviceInitializationInput } from "LLD/components/DeviceIntentExecutor";
+import { VerifyAddressExecutorLWD } from "../VerifyAddressExecutorLWD";
+
+let onJobStateChanged: (state: { type: string }) => void;
+
+jest.mock("LLD/components/DeviceIntentExecutor", () => ({
+  buildDeviceInitializationInput: jest.fn(),
+  DeviceIntentExecutorLWD: (props: { onIntentJobStateChanged: typeof onJobStateChanged }) => {
+    onJobStateChanged = props.onIntentJobStateChanged;
+    return <div data-testid="device-intent-executor" />;
+  },
+}));
+
+const buildInit = jest.mocked(buildDeviceInitializationInput);
+const account = genAccount("pay-verify-address-executor");
+
+function renderExecutor(onReady = jest.fn(), onExit = jest.fn()) {
+  render(<VerifyAddressExecutorLWD selection={{ account }} onReady={onReady} onExit={onExit} />);
+  return { onReady, onExit };
+}
+
+describe("VerifyAddressExecutorLWD", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    buildInit.mockResolvedValue({} as never);
+  });
+
+  it("should call onReady then onExit(verified) once the address is confirmed", async () => {
+    const { onReady, onExit } = renderExecutor();
+
+    await waitFor(() => expect(screen.getByTestId("device-intent-executor")).toBeVisible());
+    expect(onReady).toHaveBeenCalledTimes(1);
+
+    act(() => onJobStateChanged({ type: "verified" }));
+
+    expect(onExit).toHaveBeenCalledWith("verified");
+  });
+
+  it("should call onExit with initFailed when device initialization fails", async () => {
+    buildInit.mockRejectedValueOnce(new Error("fail"));
+    const { onExit } = renderExecutor();
+
+    await waitFor(() => expect(onExit).toHaveBeenCalledWith("initFailed"));
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/verifyAddressIntent/__tests__/componentLWD.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/verifyAddressIntent/__tests__/componentLWD.test.tsx
@@ -1,0 +1,141 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { DeviceModelId } from "@ledgerhq/device-management-kit";
+import type { VerifyAddressIntentJobState } from "@features/platform-verify-address-intent";
+import { VerifyAddressIntentComponentLWD } from "../componentLWD";
+
+const ADDRESS = "0xAbC0000000000000000000000000000000000001";
+
+const COPY = {
+  nextStepsTitle: "Address displayed on the device's Secure Screen",
+  nextStepShare: "Share your address via your desired app",
+  nextStepMatch: "Ensure the shared address matches the one on your Ledger Device.",
+  cancelledTitle: "Address verification cancelled",
+  cancelledDescription:
+    "You declined the address on your device. You can display it again to verify it.",
+  mismatchTitle: "Addresses don't match",
+  mismatchDescription:
+    "The address shown on your device is different from the requested one. Do not share this address.",
+  unsupportedTitle: "Verification not available",
+  unsupportedDescription: "This device app can't display the address for on-device verification.",
+} as const;
+
+const CTA = {
+  gotIt: "pay-card-verify-address-got-it-cta",
+  retry: "pay-card-verify-address-retry-cta",
+  close: "pay-card-verify-address-close-cta",
+} as const;
+
+const jobStates = {
+  verifying: (): VerifyAddressIntentJobState => ({
+    type: "verifying",
+    deviceModelId: DeviceModelId.STAX,
+    deviceName: "Ledger Stax",
+  }),
+  verified: (): VerifyAddressIntentJobState => ({ type: "verified", address: ADDRESS }),
+  cancelled: (retry: () => void = jest.fn()): VerifyAddressIntentJobState => ({
+    type: "cancelled",
+    retry,
+  }),
+  mismatch: (): VerifyAddressIntentJobState => ({
+    type: "mismatch",
+    expectedAddress: ADDRESS,
+    reportedAddress: "0xDEAD",
+  }),
+  unsupported: (): VerifyAddressIntentJobState => ({
+    type: "unsupported",
+    error: new Error("cannot display"),
+  }),
+};
+
+function renderComponent(jobState: VerifyAddressIntentJobState | undefined) {
+  const onClose = jest.fn();
+  const { user, container } = render(
+    <VerifyAddressIntentComponentLWD
+      jobState={jobState}
+      extraProps={undefined}
+      onClose={onClose}
+    />,
+  );
+
+  return { user, onClose, container };
+}
+
+describe("VerifyAddressIntentComponentLWD", () => {
+  describe("when the job has not emitted a state yet", () => {
+    it("should render nothing", () => {
+      const { container } = renderComponent(undefined);
+
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  /** `verified` keeps the same screen for the frame before the host unmounts the executor. */
+  describe.each([
+    ["verifying", jobStates.verifying],
+    ["verified", jobStates.verified],
+  ])("when the job state is %s", (_, buildJobState) => {
+    it("should show the next steps to follow while the address is on the Secure Screen", () => {
+      renderComponent(buildJobState());
+
+      expect(screen.getByText(COPY.nextStepsTitle)).toBeVisible();
+      expect(screen.getByText(COPY.nextStepShare)).toBeVisible();
+      expect(screen.getByText(COPY.nextStepMatch)).toBeVisible();
+    });
+
+    it("should hand the flow back when the user presses Got it", async () => {
+      const { user, onClose } = renderComponent(buildJobState());
+
+      await user.click(screen.getByTestId(CTA.gotIt));
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe.each([
+    {
+      state: "cancelled",
+      buildJobState: () => jobStates.cancelled(),
+      title: COPY.cancelledTitle,
+      description: COPY.cancelledDescription,
+    },
+    {
+      state: "mismatch",
+      buildJobState: jobStates.mismatch,
+      title: COPY.mismatchTitle,
+      description: COPY.mismatchDescription,
+    },
+    {
+      state: "unsupported",
+      buildJobState: jobStates.unsupported,
+      title: COPY.unsupportedTitle,
+      description: COPY.unsupportedDescription,
+    },
+  ])("when the job state is $state", ({ buildJobState, title, description }) => {
+    it("should explain the outcome to the user", () => {
+      renderComponent(buildJobState());
+
+      expect(screen.getByText(title)).toBeVisible();
+      expect(screen.getByText(description)).toBeVisible();
+    });
+
+    it("should hand the flow back when the user presses Close", async () => {
+      const { user, onClose } = renderComponent(buildJobState());
+
+      await user.click(screen.getByTestId(CTA.close));
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when the job state is cancelled", () => {
+    it("should display the address again when the user presses the retry CTA", async () => {
+      const retry = jest.fn();
+      const { user } = renderComponent(jobStates.cancelled(retry));
+
+      await user.click(screen.getByTestId(CTA.retry));
+
+      expect(retry).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/verifyAddressIntent/adapters/__tests__/getAddressVerification.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/verifyAddressIntent/adapters/__tests__/getAddressVerification.test.ts
@@ -1,0 +1,119 @@
+import { firstValueFrom, lastValueFrom, toArray } from "rxjs";
+import type { CryptoCurrency } from "@domain/entity-currency-crypto";
+import type { DeviceConnectionResult } from "@features/platform-device-intent";
+import type { VerifyAddressDeviceState } from "@features/platform-verify-address-intent";
+import { getAddressVerification } from "../getAddressVerification";
+
+jest.mock("@ledgerhq/live-dmk-shared", () => ({
+  DmkCompatTransport: jest.fn(),
+}));
+
+jest.mock("@ledgerhq/live-common/hw/getAddress/index", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const getAddress = jest.requireMock("@ledgerhq/live-common/hw/getAddress/index")
+  .default as jest.Mock;
+
+const ADDRESS = "0xAbC0000000000000000000000000000000000001";
+
+const connection = {
+  dmk: {},
+  sessionId: "session-id",
+} as unknown as DeviceConnectionResult;
+
+function named(name: string, extra: Record<string, unknown> = {}): Error {
+  return Object.assign(new Error(name), { name }, extra);
+}
+
+function collect(): Promise<VerifyAddressDeviceState[]> {
+  return lastValueFrom(
+    getAddressVerification(connection, {
+      currency: { id: "ethereum" } as CryptoCurrency,
+      path: "44'/60'/0'/0/0",
+      derivationMode: "",
+    }).observable.pipe(toArray()),
+  );
+}
+
+describe("getAddressVerification", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("emits the device address once the user confirms", async () => {
+    getAddress.mockResolvedValue({ address: ADDRESS });
+
+    await expect(collect()).resolves.toEqual([
+      { type: "awaiting-confirmation" },
+      { type: "confirmed", address: ADDRESS },
+    ]);
+  });
+
+  it.each([
+    ["UserRefusedAddress (legacy signer)", named("UserRefusedAddress")],
+    ["UserRefusedOnDevice (DMK-native signer)", named("UserRefusedOnDevice")],
+    ["TransportStatusError 0x6985", named("TransportStatusError", { statusCode: 0x6985 })],
+    ["TransportStatusError 0x5501", named("TransportStatusError", { statusCode: 0x5501 })],
+    [
+      "a refusal status code carried by any other error",
+      named("EthAppPleaseEnableContractData", {
+        statusCode: 0x6985,
+      }),
+    ],
+  ])("maps %s to refused so the intent can offer a retry", async (_label, error) => {
+    getAddress.mockRejectedValue(error);
+
+    await expect(collect()).resolves.toEqual([
+      { type: "awaiting-confirmation" },
+      { type: "refused" },
+    ]);
+  });
+
+  it("maps DeviceAppVerifyNotSupported to unsupported", async () => {
+    const error = named("DeviceAppVerifyNotSupported");
+    getAddress.mockRejectedValue(error);
+
+    await expect(collect()).resolves.toEqual([
+      { type: "awaiting-confirmation" },
+      { type: "unsupported", error },
+    ]);
+  });
+
+  it("lets an unrelated transport status code escape as an observable error", async () => {
+    const error = named("TransportStatusError", { statusCode: 0x6a80 });
+    getAddress.mockRejectedValue(error);
+
+    await expect(collect()).rejects.toBe(error);
+  });
+
+  it("stays silent once cancelled", async () => {
+    let rejectGetAddress: (error: Error) => void = () => {};
+    getAddress.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        rejectGetAddress = reject;
+      }),
+    );
+
+    const action = getAddressVerification(connection, {
+      currency: { id: "ethereum" } as CryptoCurrency,
+      path: "44'/60'/0'/0/0",
+      derivationMode: "",
+    });
+
+    const next = jest.fn();
+    const error = jest.fn();
+    const first = firstValueFrom(action.observable);
+    const subscription = action.observable.subscribe({ next, error });
+    await expect(first).resolves.toEqual({ type: "awaiting-confirmation" });
+
+    action.cancel();
+    rejectGetAddress(named("UserRefusedOnDevice"));
+    await Promise.resolve();
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(error).not.toHaveBeenCalled();
+    subscription.unsubscribe();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/verifyAddressIntent/adapters/getAddressVerification.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/verifyAddressIntent/adapters/getAddressVerification.ts
@@ -1,0 +1,133 @@
+import getAddress from "@ledgerhq/live-common/hw/getAddress/index";
+import { StatusCodes } from "@ledgerhq/hw-transport";
+import { DmkCompatTransport } from "@ledgerhq/live-dmk-shared";
+import { Observable } from "rxjs";
+import type { CryptoCurrency } from "@domain/entity-currency-crypto";
+import type { DerivationMode } from "@ledgerhq/types-live";
+import type { DeviceConnectionResult } from "@features/platform-device-intent";
+import type {
+  VerifyAddressDeviceAction,
+  VerifyAddressDeviceState,
+} from "@features/platform-verify-address-intent";
+
+const USER_REFUSED_ERROR_NAMES = new Set(["UserRefusedAddress", "UserRefusedOnDevice"]);
+
+/**
+ * Status words that both mean "the user declined on the device": the generic one
+ * most coin apps answer with, and the OS-level one some apps return instead.
+ */
+const USER_REFUSED_STATUS_CODES = new Set<number>([
+  StatusCodes.CONDITIONS_OF_USE_NOT_SATISFIED,
+  StatusCodes.USER_REFUSED_ON_DEVICE,
+]);
+
+const UNSUPPORTED_ERROR_NAME = "DeviceAppVerifyNotSupported";
+
+type Params = Readonly<{
+  currency: CryptoCurrency;
+  path: string;
+  derivationMode: DerivationMode;
+}>;
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+type DeviceError = Readonly<{ name?: string; statusCode?: number }>;
+
+/**
+ * Reads the two fields we classify on. Signers throw from several packages (and
+ * duplicated copies of `@ledgerhq/errors` defeat `instanceof` across workspace
+ * boundaries), so the error is duck-typed rather than matched on its class.
+ */
+function readDeviceError(error: unknown): DeviceError {
+  if (typeof error !== "object" || error === null) return {};
+
+  const { name, statusCode } = error as Record<"name" | "statusCode", unknown>;
+
+  return {
+    name: typeof name === "string" ? name : undefined,
+    statusCode: typeof statusCode === "number" ? statusCode : undefined,
+  };
+}
+
+/**
+ * A refusal reaches us either already named by a signer that maps it, or as a raw
+ * status word. The status word is conclusive on its own: whatever class carries
+ * it, the device answered that the user declined.
+ */
+function isUserRefusal({ name, statusCode }: DeviceError): boolean {
+  if (name && USER_REFUSED_ERROR_NAMES.has(name)) return true;
+
+  return statusCode !== undefined && USER_REFUSED_STATUS_CODES.has(statusCode);
+}
+
+/**
+ * Single verification path for every coin family.
+ *
+ * It runs the generic `getAddress` resolver over a {@link DmkCompatTransport}
+ * built from the live DIE session. That resolver dispatches to each family's
+ * coin-module signer, which itself picks the DMK-native signer when the family
+ * has one wired and its `ldmk*Signer` flag allows it (EVM always, Solana via
+ * `ldmkSolanaSigner`, Cosmos via `ldmkCosmosSigner`, …), and the legacy signer
+ * otherwise — all over the same DMK transport under the hood. So this stays
+ * signer-agnostic and needs no per-family branching here.
+ *
+ * Rejections reach us under several shapes depending on the signer: the legacy
+ * resolver normalizes them to `UserRefusedAddress`, DMK-native signers throw
+ * `UserRefusedOnDevice`, and some families let the raw `TransportStatusError`
+ * through. All of them map to `refused`, an unsupported on-device display maps
+ * to `unsupported`, and anything else escapes as an error.
+ * The device-derived address is returned so the job can compare it against the
+ * expected one and surface a rich `mismatch`.
+ */
+export function getAddressVerification(
+  { dmk, sessionId }: DeviceConnectionResult,
+  { currency, path, derivationMode }: Params,
+): VerifyAddressDeviceAction {
+  let cancelled = false;
+
+  const observable = new Observable<VerifyAddressDeviceState>(subscriber => {
+    subscriber.next({ type: "awaiting-confirmation" });
+
+    getAddress(new DmkCompatTransport(dmk, sessionId), {
+      currency,
+      path,
+      derivationMode,
+      verify: true,
+    })
+      .then(result => {
+        if (cancelled) return;
+        subscriber.next({ type: "confirmed", address: result.address });
+        subscriber.complete();
+      })
+      .catch(error => {
+        if (cancelled) return;
+
+        const deviceError = readDeviceError(error);
+
+        if (isUserRefusal(deviceError)) {
+          subscriber.next({ type: "refused" });
+          subscriber.complete();
+          return;
+        }
+        if (deviceError.name === UNSUPPORTED_ERROR_NAME) {
+          subscriber.next({ type: "unsupported", error: toError(error) });
+          subscriber.complete();
+          return;
+        }
+        subscriber.error(toError(error));
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  });
+
+  return {
+    observable,
+    cancel: () => {
+      cancelled = true;
+    },
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/verifyAddressIntent/buildVerifyAddressIntentInput.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/verifyAddressIntent/buildVerifyAddressIntentInput.ts
@@ -1,0 +1,31 @@
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type { VerifyAddressIntentInput } from "@features/platform-verify-address-intent";
+import { getAddressVerification } from "./adapters/getAddressVerification";
+
+/**
+ * Build the {@link VerifyAddressIntentInput} for the Pay request flow.
+ *
+ * This is the app-side dependency-injection seam: the shared intent package
+ * stays free of any signer. The host verifies through the generic `getAddress`
+ * resolver run over the DIE's DMK transport, which already routes to the right
+ * per-family signer (DMK-native where wired and flag-enabled, legacy otherwise)
+ * — so no per-family branching is needed here. See {@link getAddressVerification}.
+ */
+export function buildVerifyAddressIntentInput(
+  account: AccountLike,
+  parentAccount?: Account | null,
+): VerifyAddressIntentInput {
+  const mainAccount = getMainAccount(account, parentAccount ?? undefined);
+  const { freshAddress, freshAddressPath, currency, derivationMode } = mainAccount;
+
+  return {
+    expectedAddress: freshAddress,
+    startAddressVerification: connection =>
+      getAddressVerification(connection, {
+        currency,
+        path: freshAddressPath,
+        derivationMode,
+      }),
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/verifyAddressIntent/componentLWD.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/verifyAddressIntent/componentLWD.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { Spot } from "@ledgerhq/lumen-ui-react";
+import { ShieldLock } from "@ledgerhq/lumen-ui-react/symbols";
+import type { VerifyAddressIntentJobState } from "@features/platform-verify-address-intent";
+import { InfoState } from "LLD/components/InfoState";
+
+type Props = Readonly<{
+  jobState: VerifyAddressIntentJobState | undefined;
+  extraProps: undefined;
+  onClose: () => void;
+}>;
+
+/**
+ * Shown while the address sits on the device's Secure Screen. The user reads the
+ * next steps while confirming on device; "Got it" is the manual way out — leaving
+ * unmounts the executor, which cancels the pending device action.
+ */
+function NextStepsScreen({ onGotIt }: Readonly<{ onGotIt: () => void }>) {
+  const { t } = useTranslation();
+  const steps = [
+    { index: 1, label: t("payTab.request.verifyAddress.nextStepShare") },
+    { index: 2, label: t("payTab.request.verifyAddress.nextStepMatch") },
+  ] as const;
+
+  return (
+    <InfoState
+      preset="spot"
+      size="hug"
+      spotProps={{ icon: ShieldLock, size: 56 }}
+      backgroundTone="info"
+      title={t("payTab.request.verifyAddress.successTitle")}
+      content={
+        <div className="flex w-full flex-col gap-16 rounded-md bg-surface p-16 text-left">
+          <span className="body-2 text-muted">
+            {t("payTab.request.verifyAddress.nextStepsLabel")}
+          </span>
+          <ol className="flex flex-col gap-16">
+            {steps.map(step => (
+              <li key={step.index} className="flex flex-row items-center justify-start gap-12">
+                <Spot appearance="number" number={step.index} size={32} />
+                <span className="body-2 text-base">{step.label}</span>
+              </li>
+            ))}
+          </ol>
+        </div>
+      }
+      primaryCta={{
+        label: t("payTab.request.verifyAddress.gotItCta"),
+        onPress: onGotIt,
+        testID: "pay-card-verify-address-got-it-cta",
+      }}
+      testID="pay-card-verify-address-next-steps"
+    />
+  );
+}
+
+/**
+ * Desktop renderer for the shared verify-address device intent. It maps each
+ * {@link VerifyAddressIntentJobState} to a screen; generic device failures are
+ * handled upstream by the executor's shared error screen.
+ */
+export function VerifyAddressIntentComponentLWD({
+  jobState,
+  onClose,
+}: Props): React.ReactElement | null {
+  const { t } = useTranslation();
+
+  // The executor mounts this component before the job emits its first state.
+  if (!jobState) return null;
+
+  switch (jobState.type) {
+    case "verifying":
+    case "verified":
+      return <NextStepsScreen onGotIt={onClose} />;
+    case "cancelled":
+      return (
+        <InfoState
+          preset="info"
+          size="hug"
+          title={t("payTab.request.verifyAddress.device.cancelledTitle")}
+          description={t("payTab.request.verifyAddress.device.cancelledDescription")}
+          primaryCta={{
+            label: t("payTab.request.verifyAddress.device.retryCta"),
+            onPress: jobState.retry,
+            testID: "pay-card-verify-address-retry-cta",
+          }}
+          secondaryCta={{
+            label: t("payTab.request.verifyAddress.device.closeCta"),
+            onPress: onClose,
+            testID: "pay-card-verify-address-close-cta",
+          }}
+          testID="pay-card-verify-address-cancelled"
+        />
+      );
+    case "mismatch":
+      return (
+        <InfoState
+          preset="error"
+          size="hug"
+          title={t("payTab.request.verifyAddress.device.mismatchTitle")}
+          description={t("payTab.request.verifyAddress.device.mismatchDescription")}
+          primaryCta={{
+            label: t("payTab.request.verifyAddress.device.closeCta"),
+            onPress: onClose,
+            testID: "pay-card-verify-address-close-cta",
+          }}
+          testID="pay-card-verify-address-mismatch"
+        />
+      );
+    case "unsupported":
+      return (
+        <InfoState
+          preset="error"
+          size="hug"
+          title={t("payTab.request.verifyAddress.device.unsupportedTitle")}
+          description={t("payTab.request.verifyAddress.device.unsupportedDescription")}
+          primaryCta={{
+            label: t("payTab.request.verifyAddress.device.closeCta"),
+            onPress: onClose,
+            testID: "pay-card-verify-address-close-cta",
+          }}
+          testID="pay-card-verify-address-unsupported"
+        />
+      );
+  }
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/verifyAddressIntent/intentLWDDefinition.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/verifyAddressIntent/intentLWDDefinition.ts
@@ -1,0 +1,10 @@
+import {
+  verifyAddressIntentDefinition,
+  type VerifyAddressIntentPlatformDefinition,
+} from "@features/platform-verify-address-intent";
+import { VerifyAddressIntentComponentLWD } from "./componentLWD";
+
+export const verifyAddressIntentLWDDefinition: VerifyAddressIntentPlatformDefinition = {
+  ...verifyAddressIntentDefinition,
+  component: VerifyAddressIntentComponentLWD,
+};

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -946,7 +946,17 @@
         "nextStepsLabel": "Next steps",
         "nextStepShare": "Share your address via your desired app",
         "nextStepMatch": "Ensure the shared address matches the one on your Ledger Device.",
-        "gotItCta": "Got it"
+        "gotItCta": "Got it",
+        "device": {
+          "cancelledTitle": "Address verification cancelled",
+          "cancelledDescription": "You declined the address on your device. You can display it again to verify it.",
+          "mismatchTitle": "Addresses don't match",
+          "mismatchDescription": "The address shown on your device is different from the requested one. Do not share this address.",
+          "unsupportedTitle": "Verification not available",
+          "unsupportedDescription": "This device app can't display the address for on-device verification.",
+          "retryCta": "Show address again",
+          "closeCta": "Close"
+        }
       }
     }
   },

--- a/features/platform/verify-address-intent/README.md
+++ b/features/platform/verify-address-intent/README.md
@@ -1,0 +1,88 @@
+# @features/platform-verify-address-intent
+
+> [!CAUTION]
+> **Status: UNSTABLE** — part of the Device Intent Executor (DIE) rollout; API may change.
+
+Cross-platform [Device Intent](../device-intent/README.md) that verifies a
+receive address on the device Secure Screen.
+
+## What it does
+
+The job hands the live DMK session to a **host-injected** device operation and
+maps its device-action stream to a small, UI-friendly state union:
+
+| `JobState`    | Meaning                                                       | Terminal |
+| ------------- | ------------------------------------------------------------- | -------- |
+| `verifying`   | Address is being displayed on the device, awaiting the user.  | no       |
+| `verified`    | Device address matches the expected one.                      | yes      |
+| `mismatch`    | Device address differs from the expected one.                 | yes      |
+| `cancelled`   | User refused on device. Carries a `retry()` handler.          | no       |
+| `unsupported` | Device app cannot display the address.                        | yes      |
+
+Any other device failure escapes as an observable error, so the executor renders
+its shared intent-error screen.
+
+`verified` vs `mismatch` is decided by an **encoding-aware** comparison: hex
+(`0x…`) addresses are compared case-insensitively (EIP-55 checksum), every other
+encoding (Base58, Bech32, …) exactly — so a real mismatch on a case-sensitive
+network is never reported as `verified`.
+
+## Why dependencies are injected
+
+`features/**` packages must not import legacy in-repo `@ledgerhq/*` libs (the
+`enforce-boundaries` CI check forbids it), and this intent must stay agnostic of
+how any given coin family talks to the device. So instead of importing a signer,
+this package declares a structural seam — `StartAddressVerification` — that the
+host app (LWD / LWM) fulfils by returning a `VerifyAddressDeviceAction`: an
+observable of **normalized**, signer-agnostic `VerifyAddressDeviceState` events
+(`awaiting-confirmation` / `confirmed` / `refused` / `unsupported`) plus a
+`cancel`. The job maps those to its `JobState` union.
+
+The host is free to implement the seam however it wants — a DMK-native signer
+kit, or (as LWD does) the generic `getAddress` resolver run over the DIE's DMK
+transport, which already dispatches to each family's DMK-native or legacy signer
+under the hood:
+
+```ts
+import { createIntent } from "@features/platform-device-intent";
+import { verifyAddressIntentDefinition } from "@features/platform-verify-address-intent";
+
+// Host builds the platform definition by adding its renderer:
+const verifyAddressIntentPlatformDefinition = {
+  ...verifyAddressIntentDefinition,
+  component: VerifyAddressComponentLWD,
+};
+
+const intent = createIntent(verifyAddressIntentPlatformDefinition, {
+  expectedAddress: mainAccount.freshAddress,
+  // Host-injected device operation returning { observable, cancel }, emitting
+  // normalized VerifyAddressDeviceState events (see the LWD adapter).
+  startAddressVerification: connection => getAddressVerification(connection, params),
+});
+```
+
+## Exports
+
+| Export                                  | Description                                              |
+| --------------------------------------- | -------------------------------------------------------- |
+| `verifyAddressIntentDefinition`         | Cross-platform `IntentDefinition` (label, flags, job).   |
+| `verifyAddressIntentJob`                | The `Job` implementation.                                |
+| `VerifyAddressIntentJobState`           | Discriminated union rendered by the platform component.  |
+| `VerifyAddressIntentInput`              | Job input: `expectedAddress` + `startAddressVerification`. |
+| `StartAddressVerification`              | The host-injected device-operation seam.                 |
+| `VerifyAddressDeviceAction`             | Structural shape returned by the injected operation (`observable` + `cancel`). |
+| `VerifyAddressDeviceState`              | Normalized device-progress events consumed by the job.   |
+| `VerifyAddressIntentPlatformDefinition` | Platform definition alias (adds the renderer).           |
+| `VerifyAddressIntent`                   | Runtime intent alias.                                    |
+
+## Installation
+
+Internal package, available to other workspace packages via:
+
+```json
+{
+  "dependencies": {
+    "@features/platform-verify-address-intent": "workspace:*"
+  }
+}
+```

--- a/features/platform/verify-address-intent/jest.config.js
+++ b/features/platform/verify-address-intent/jest.config.js
@@ -1,0 +1,24 @@
+module.exports = {
+  testEnvironment: "node",
+  testPathIgnorePatterns: ["lib/", "lib-es/", "__tests__/test-utils"],
+  coveragePathIgnorePatterns: ["__tests__/test-utils"],
+  moduleNameMapper: {
+    "^(\\.\\.?/.*)\\.js$": "$1",
+  },
+  transform: {
+    "^.+\\.(t|j)sx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+        },
+      },
+    ],
+  },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
+  reporters: [
+    "default",
+    ...(process.env.CI ? ["github-actions"] : []),
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/features/platform/verify-address-intent/package.json
+++ b/features/platform/verify-address-intent/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@features/platform-verify-address-intent",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Cross-platform Device Intent that verifies a receive address on the device Secure Screen",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "format": "oxfmt src",
+    "format:check": "oxfmt src --check",
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../../.. -W features/platform/verify-address-intent"
+  },
+  "dependencies": {
+    "@features/platform-device-intent": "workspace:^"
+  },
+  "peerDependencies": {
+    "@ledgerhq/device-management-kit": "catalog:",
+    "rxjs": "catalog:"
+  },
+  "devDependencies": {
+    "@ledgerhq/device-management-kit": "catalog:",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "jest": "catalog:",
+    "oxfmt": "catalog:",
+    "rxjs": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/features/platform/verify-address-intent/project.json
+++ b/features/platform/verify-address-intent/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@features/platform-verify-address-intent",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/features/platform/verify-address-intent/src/__tests__/job.test.ts
+++ b/features/platform/verify-address-intent/src/__tests__/job.test.ts
@@ -1,0 +1,134 @@
+import { DeviceModelId } from "@ledgerhq/device-management-kit";
+import { Subject } from "rxjs";
+import { verifyAddressIntentJob } from "../job";
+import type {
+  VerifyAddressDeviceAction,
+  VerifyAddressDeviceState,
+  VerifyAddressIntentJobState,
+} from "../types";
+
+const EXPECTED_ADDRESS = "0xAbC0000000000000000000000000000000000001";
+const BASE58_ADDRESS = "So11111111111111111111111111111111111111112";
+const VERIFYING: VerifyAddressIntentJobState = {
+  type: "verifying",
+  deviceModelId: DeviceModelId.STAX,
+  deviceName: "Ledger Stax",
+};
+
+function startJob(expectedAddress = EXPECTED_ADDRESS) {
+  const subject = new Subject<VerifyAddressDeviceState>();
+  const cancel = jest.fn();
+  const startAddressVerification = jest.fn(
+    (): VerifyAddressDeviceAction => ({
+      observable: subject.asObservable(),
+      cancel,
+    }),
+  );
+  const states: VerifyAddressIntentJobState[] = [];
+  let error: unknown;
+  let completed = false;
+
+  const subscription = verifyAddressIntentJob({
+    deviceConnectionResult: {
+      dmk: {} as never,
+      sessionId: "session-1",
+      connectedDevice: { modelId: DeviceModelId.STAX } as never,
+      compatDeviceId: "compat-1",
+      compatDeviceName: "Ledger Stax",
+      compatDeviceWired: true,
+    },
+    deviceExtractedContext: {} as never,
+    input: { expectedAddress, startAddressVerification },
+  }).subscribe({
+    next: state => states.push(state),
+    error: e => {
+      error = e;
+    },
+    complete: () => {
+      completed = true;
+    },
+  });
+
+  return {
+    states,
+    cancel,
+    startAddressVerification,
+    subscription,
+    emit: (state: VerifyAddressDeviceState) => subject.next(state),
+    fail: (err: Error) => subject.error(err),
+    isCompleted: () => completed,
+    getError: () => error,
+  };
+}
+
+describe("verifyAddressIntentJob", () => {
+  it.each([
+    ["hex, case-insensitive", EXPECTED_ADDRESS, EXPECTED_ADDRESS.toLowerCase()],
+    ["non-hex, exact", BASE58_ADDRESS, BASE58_ADDRESS],
+  ] as const)("emits verified when addresses match (%s)", (_label, expected, reported) => {
+    const { states, emit, isCompleted } = startJob(expected);
+    emit({ type: "confirmed", address: reported });
+    expect(states).toEqual([VERIFYING, { type: "verified", address: reported }]);
+    expect(isCompleted()).toBe(true);
+  });
+
+  it.each([
+    ["hex mismatch", EXPECTED_ADDRESS, "0xDEAD000000000000000000000000000000000000"],
+    ["non-hex casing", BASE58_ADDRESS, BASE58_ADDRESS.toLowerCase()],
+  ] as const)("emits mismatch when addresses differ (%s)", (_label, expected, reported) => {
+    const { states, emit, isCompleted } = startJob(expected);
+    emit({ type: "confirmed", address: reported });
+    expect(states).toEqual([
+      VERIFYING,
+      { type: "mismatch", expectedAddress: expected, reportedAddress: reported },
+    ]);
+    expect(isCompleted()).toBe(true);
+  });
+
+  it("ignores awaiting-confirmation", () => {
+    const { states, emit } = startJob();
+    emit({ type: "awaiting-confirmation" });
+    expect(states).toEqual([VERIFYING]);
+  });
+
+  it("emits cancelled with a working retry when refused", () => {
+    const { states, emit, startAddressVerification } = startJob();
+    emit({ type: "refused" });
+
+    const cancelled = states[1] as Extract<VerifyAddressIntentJobState, { type: "cancelled" }>;
+    expect(cancelled.type).toBe("cancelled");
+    expect(startAddressVerification).toHaveBeenCalledTimes(1);
+
+    cancelled.retry();
+    expect(startAddressVerification).toHaveBeenCalledTimes(2);
+    expect(states[2]).toEqual(VERIFYING);
+  });
+
+  it("emits unsupported with the adapter error and completes", () => {
+    const error = new Error("cannot display");
+    const { states, emit, isCompleted } = startJob();
+    emit({ type: "unsupported", error });
+    expect(states).toEqual([VERIFYING, { type: "unsupported", error }]);
+    expect(isCompleted()).toBe(true);
+  });
+
+  it("defaults the unsupported error when omitted", () => {
+    const { states, emit } = startJob();
+    emit({ type: "unsupported" });
+    expect(states[1]).toMatchObject({ type: "unsupported" });
+    expect((states[1] as { error: unknown }).error).toBeInstanceOf(Error);
+  });
+
+  it("propagates unexpected device errors", () => {
+    const { fail, getError, isCompleted } = startJob();
+    fail(new Error("device disconnected"));
+    expect(getError()).toBeInstanceOf(Error);
+    expect(isCompleted()).toBe(false);
+  });
+
+  it("cancels the device action on unsubscribe", () => {
+    const { cancel, subscription } = startJob();
+    subscription.unsubscribe();
+    expect(cancel).toHaveBeenCalled();
+  });
+});

--- a/features/platform/verify-address-intent/src/index.ts
+++ b/features/platform/verify-address-intent/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./intentDefinition";
+export * from "./job";
+export * from "./types";

--- a/features/platform/verify-address-intent/src/intentDefinition.ts
+++ b/features/platform/verify-address-intent/src/intentDefinition.ts
@@ -1,0 +1,16 @@
+import { verifyAddressIntentJob } from "./job";
+import type { VerifyAddressIntentDefinition } from "./types";
+
+/**
+ * Cross-platform definition for the receive-address verification intent.
+ *
+ * The device is required, and device lock-state handling is left to the job so
+ * the underlying device-action's own states surface through
+ * {@link VerifyAddressIntentJobState}.
+ */
+export const verifyAddressIntentDefinition: VerifyAddressIntentDefinition = {
+  label: "Verify address",
+  requiresConnectedDevice: true,
+  delegateDeviceLockStateHandlingToExecutor: false,
+  job: verifyAddressIntentJob,
+};

--- a/features/platform/verify-address-intent/src/job.ts
+++ b/features/platform/verify-address-intent/src/job.ts
@@ -1,0 +1,119 @@
+import type { Job } from "@features/platform-device-intent";
+import { Observable, type Subscription } from "rxjs";
+import type { VerifyAddressIntentInput, VerifyAddressIntentJobState } from "./types";
+
+function toError(error: unknown, fallbackMessage: string): Error {
+  if (error instanceof Error) return error;
+  if (typeof error === "object" && error !== null) {
+    const tag = (error as { _tag?: unknown })._tag;
+    if (typeof tag === "string") return new Error(tag);
+  }
+  return new Error(fallbackMessage);
+}
+
+/**
+ * Case only carries meaning for some address encodings. Hex (`0x…`) addresses
+ * use EIP-55 checksum casing that a device and the app can legitimately format
+ * differently, so they are compared case-insensitively. Every other encoding
+ * (Base58 for Solana/Tron, Bech32, …) is case-significant, so it is compared
+ * exactly — otherwise a genuine mismatch could be reported as `verified`.
+ */
+function addressesMatch(expected: string, reported: string): boolean {
+  const left = expected.trim();
+  const right = reported.trim();
+
+  return left.startsWith("0x") && right.startsWith("0x")
+    ? left.toLowerCase() === right.toLowerCase()
+    : left === right;
+}
+
+/**
+ * Verify a receive address on the device Secure Screen.
+ *
+ * The executor already owns the device session and opened the app during
+ * Phase 2, so the job hands the live session to the host-injected
+ * {@link VerifyAddressIntentInput.startAddressVerification} and maps its
+ * normalized {@link VerifyAddressDeviceState} stream to
+ * {@link VerifyAddressIntentJobState}. The host decides *how* verification
+ * happens per coin family (DMK-native signer or legacy `receive`); this job
+ * stays signer-agnostic.
+ *
+ * Outcomes:
+ * - device output matches the expected address → `verified` (terminal).
+ * - device output differs → `mismatch` (terminal), so the host can warn the user.
+ * - user refuses on device → `cancelled` with a `retry` handler (non-terminal).
+ * - device app cannot display the address → `unsupported` (terminal).
+ * - any other device failure → observable error (executor's shared error screen).
+ */
+export const verifyAddressIntentJob: Job<VerifyAddressIntentJobState, VerifyAddressIntentInput> = ({
+  deviceConnectionResult,
+  input,
+}) =>
+  new Observable<VerifyAddressIntentJobState>(subscriber => {
+    const { connectedDevice, compatDeviceName } = deviceConnectionResult;
+    const { expectedAddress, startAddressVerification } = input;
+
+    let innerSubscription: Subscription | undefined;
+    let cancelDeviceAction: (() => void) | undefined;
+    let runToken = 0;
+
+    const run = () => {
+      const currentRunToken = ++runToken;
+      innerSubscription?.unsubscribe();
+      cancelDeviceAction?.();
+
+      subscriber.next({
+        type: "verifying",
+        deviceModelId: connectedDevice.modelId,
+        deviceName: compatDeviceName,
+      });
+
+      const { observable, cancel } = startAddressVerification(deviceConnectionResult);
+      cancelDeviceAction = cancel;
+
+      innerSubscription = observable.subscribe({
+        next: state => {
+          if (subscriber.closed || currentRunToken !== runToken) return;
+
+          switch (state.type) {
+            case "awaiting-confirmation":
+              return;
+            case "confirmed": {
+              const reportedAddress = state.address;
+              if (addressesMatch(expectedAddress, reportedAddress)) {
+                subscriber.next({ type: "verified", address: reportedAddress });
+              } else {
+                subscriber.next({ type: "mismatch", expectedAddress, reportedAddress });
+              }
+              subscriber.complete();
+              return;
+            }
+            case "refused":
+              // Non-terminal: keep the intent open so the user can retry.
+              subscriber.next({ type: "cancelled", retry: run });
+              return;
+            case "unsupported":
+              subscriber.next({
+                type: "unsupported",
+                error:
+                  state.error ?? new Error("Address verification not supported on this device"),
+              });
+              subscriber.complete();
+              return;
+          }
+        },
+        error: error => {
+          if (subscriber.closed || currentRunToken !== runToken) return;
+          subscriber.error(toError(error, "Verify address failed"));
+        },
+      });
+    };
+
+    run();
+
+    return () => {
+      runToken += 1;
+      innerSubscription?.unsubscribe();
+      cancelDeviceAction?.();
+    };
+  });

--- a/features/platform/verify-address-intent/src/types.ts
+++ b/features/platform/verify-address-intent/src/types.ts
@@ -1,0 +1,56 @@
+import type { DeviceModelId } from "@ledgerhq/device-management-kit";
+import type {
+  DeviceConnectionResult,
+  Intent,
+  IntentDefinition,
+  IntentPlatformDefinition,
+} from "@features/platform-device-intent";
+import type { Observable } from "rxjs";
+
+/** Unexpected failures must be observable errors, not a state. */
+export type VerifyAddressDeviceState =
+  | { type: "awaiting-confirmation" }
+  | { type: "confirmed"; address: string }
+  | { type: "refused" }
+  | { type: "unsupported"; error?: Error };
+
+export type VerifyAddressDeviceAction = {
+  readonly observable: Observable<VerifyAddressDeviceState>;
+  readonly cancel: () => void;
+};
+
+/** Host-injected verify. The app is already open (DIE Phase 2). */
+export type StartAddressVerification = (
+  connection: DeviceConnectionResult,
+) => VerifyAddressDeviceAction;
+
+export type VerifyAddressIntentInput = {
+  /** Compared case-insensitively to the device-derived address. */
+  readonly expectedAddress: string;
+  readonly startAddressVerification: StartAddressVerification;
+};
+
+/**
+ * `verified` / `mismatch` / `unsupported` complete the observable.
+ * `cancelled` stays open and exposes `retry`. Other failures are observable errors.
+ */
+export type VerifyAddressIntentJobState =
+  | { type: "verifying"; deviceModelId: DeviceModelId; deviceName: string }
+  | { type: "verified"; address: string }
+  | { type: "cancelled"; retry: () => void }
+  | { type: "mismatch"; expectedAddress: string; reportedAddress: string }
+  | { type: "unsupported"; error: Error };
+
+export type VerifyAddressIntentDefinition = IntentDefinition<
+  VerifyAddressIntentJobState,
+  VerifyAddressIntentInput
+>;
+
+export type VerifyAddressIntentPlatformDefinition<ExtraProps = undefined> =
+  IntentPlatformDefinition<VerifyAddressIntentJobState, VerifyAddressIntentInput, ExtraProps>;
+
+export type VerifyAddressIntent<ExtraProps = undefined> = Intent<
+  VerifyAddressIntentJobState,
+  VerifyAddressIntentInput,
+  ExtraProps
+>;

--- a/features/platform/verify-address-intent/tsconfig.json
+++ b/features/platform/verify-address-intent/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["jest"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -997,6 +997,9 @@ importers:
       '@features/platform-style':
         specifier: workspace:^
         version: link:../../features/platform/style
+      '@features/platform-verify-address-intent':
+        specifier: workspace:^
+        version: link:../../features/platform/verify-address-intent
       '@features/platform-wallet-sync':
         specifier: workspace:^
         version: link:../../features/platform/wallet-sync
@@ -6680,6 +6683,37 @@ importers:
       styled-components:
         specifier: 'catalog:'
         version: 6.1.19(patch_hash=810073718ccefe69fd016893be54d80d86cc6e5ee521455028b93c7cbf3103d7)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
+  features/platform/verify-address-intent:
+    dependencies:
+      '@features/platform-device-intent':
+        specifier: workspace:^
+        version: link:../device-intent
+    devDependencies:
+      '@ledgerhq/device-management-kit':
+        specifier: 'catalog:'
+        version: 1.7.1(rxjs@7.8.2)
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.36.0
+      rxjs:
+        specifier: 'catalog:'
+        version: 7.8.2
       typescript:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
@@ -25034,7 +25068,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.1.4
       react-dom: 19.1.4
-      webpack: ^5.89.0
+      webpack: '*'
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -68334,7 +68368,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3(metro-transform-worker@0.83.3)
+      metro: 0.83.3
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -68458,54 +68492,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro@0.83.3(metro-transform-worker@0.83.3):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 1.3.8
-      chalk: 4.1.2
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.32.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0(metro@0.83.3)
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.3
-      metro-cache: 0.83.3
-      metro-cache-key: 0.83.3
-      metro-config: 0.83.3(metro-transform-worker@0.83.3)
-      metro-core: 0.83.3
-      metro-file-map: 0.83.3(metro@0.83.3)
-      metro-resolver: 0.83.3
-      metro-runtime: 0.83.3
-      metro-source-map: 0.83.3
-      metro-symbolicate: 0.83.3
-      metro-transform-plugins: 0.83.3
-      metro-transform-worker: 0.83.3
-      mime-types: 2.1.35
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION

## 📝 Description

Adds `@features/platform-verify-address-intent` — a cross-platform Device Intent (DIE) that verifies a receive address on the device Secure Screen — and wires it into the **Ledger Wallet Desktop** Pay tab Request flow. This iteration also **hardens the flow lifecycle** and **generalizes the shared desktop `InfoState`** so the visual and the dialog background gradient are decoupled.

### Verify-address intent (`features/platform/verify-address-intent`)

- Signer-agnostic, boundary-safe job: it consumes a host-injected `startAddressVerification` operation emitting normalized `awaiting-confirmation` / `confirmed` / `refused` / `unsupported` events and maps them to `verified` / `mismatch` / `cancelled` (with `retry`) / `unsupported`. Unexpected device failures surface through the executor's shared error screen.
- **Encoding-aware equality**: hex (`0x…`) addresses match case-insensitively (EIP-55 checksum), every other encoding (Base58, Bech32, …) matches **exactly** — so a genuine mismatch on a case-sensitive network (e.g. Solana) can never be reported as `verified`.

### Desktop wiring & lifecycle hardening

- The host verifies through a **family-agnostic** path: the generic `getAddress` resolver over the DIE's DMK transport (DMK-native signer when the family is wired and its flag allows it, legacy otherwise). No per-family branching in the app.
- Gated by `ldmkTransport`: when off, the Verify CTA opens the classic Receive modal instead — and now **restores the request card** behind it.
- **No blank gap on start**: the intro stays visible until the executor dialog is actually up (`onReady`), then steps aside.
- **Single, navigation-aware exit** (`onExit`): `verified`, `cancelled`, `unsupported`, a plain dismissal and an init failure all bring the request summary back; **`mismatch` closes the whole flow** so the wrong address is never surfaced for sharing again.
- While the address is on the Secure Screen the user reads the next steps and confirms on device; **"Got it"** is the manual way out, and leaving unmounts the executor which cancels the pending device action.

### `InfoState` generalization (desktop, non-breaking)

- `backgroundTone` moves to the **common props** with a local `error | info | success | none` type (no longer importing the dialog-context tone). Any preset can now combine a visual with a dialog gradient, and status presets can opt out with `"none"`. Implicit tones for `error` / `info` / `success` are preserved.
- The `spot` preset keeps `spotProps={{ icon, size }}`; the full-width `content` slot remains available on desktop and mobile.

## 🔁 Flow

```mermaid
sequenceDiagram
    autonumber
    actor User
    participant Card as Request receive card
    participant Intro as Verify intro
    participant Host as usePayTabVerifyAddress
    participant Exec as VerifyAddressExecutorLWD
    participant Job as verifyAddressIntentJob
    participant Adapter as getAddressVerification
    participant Device as Ledger device

    User->>Card: Tap Verify
    Card->>Host: openIntro(selection, restoreCard)
    Host->>Intro: show intro
    User->>Intro: Tap Verify address

    alt ldmkTransport enabled
        Intro->>Host: onVerify()
        Host->>Exec: mount executor (intro stays visible)
        Exec->>Exec: buildDeviceInitializationInput()
        alt Init succeeds
            Exec-->>Host: onReady()
            Host->>Intro: hide intro
            Exec->>Job: start after connect and open app
            Job->>Adapter: startAddressVerification(session)
            Adapter->>Device: getAddress(verify)
            Job-->>Exec: verifying (next steps + Got it)

            alt Device confirms matching address
                Device-->>Adapter: address
                Adapter-->>Job: confirmed
                Job-->>Exec: verified
                Exec-->>Host: onExit(verified)
                Host->>Card: restore request card
            else Device confirms different address
                Device-->>Adapter: other address
                Adapter-->>Job: confirmed
                Job-->>Exec: mismatch
                User->>Exec: Close
                Exec-->>Host: onExit(mismatch)
                Note over Host: close whole flow, do not restore
            else User refuses on device
                Device-->>Adapter: refused
                Adapter-->>Job: refused
                Job-->>Exec: cancelled (retry stays open)
                User->>Exec: Close (or Retry then Close)
                Exec-->>Host: onExit(cancelled)
                Host->>Card: restore request card
            else App cannot display address
                Adapter-->>Job: unsupported
                Job-->>Exec: unsupported
                User->>Exec: Close
                Exec-->>Host: onExit(unsupported)
                Host->>Card: restore request card
            else User taps Got it
                User->>Exec: Got it
                Exec-->>Host: onExit(dismissed)
                Host->>Card: restore request card
            end
        else Init fails
            Exec-->>Host: onExit(initFailed)
            Host->>Card: restore request card
        end
    else ldmkTransport disabled
        Intro->>Host: onVerify()
        Host->>Card: open classic Receive modal and restore card
    end
```



## Screenshots 📸

https://github.com/user-attachments/assets/efef7e9d-aa33-4715-bc2d-493acf7d5b87




## 🧪 Test plan

- [x] `verifyAddressIntentJob`: verifying → verified, hex case-insensitive match, non-hex exact match, mismatch (incl. case-only difference on Base58), cancelled + retry, unsupported, error propagation, cancel on unsubscribe.
- [x] `usePayTabVerifyAddress`: intro kept visible until `onReady`; legacy fallback opens Receive modal and restores the card; every outcome except `mismatch` restores the summary; `mismatch` closes the flow; restore callback consumed at most once; intro dismissal restores.
- [x] `VerifyAddressIntentComponentLWD`: next-steps rendered on `verifying`/`verified` with a working "Got it"; cancelled/mismatch/unsupported screens wire retry/close.
- [x] `InfoState`: status presets tint implicitly; explicit `backgroundTone` overrides; `"none"` opts out; `content` slot renders.
- [x] `pnpm nx run @features/platform-verify-address-intent:typecheck` and `pnpm nx run ledger-live-desktop:typecheck` pass.

### Manual QA

- With `ldmkTransport` on: Request → Verify → confirm on device returns to the request card; refuse → retry then close returns to the card; force a mismatch (or an unsupported app) and confirm the mismatch closes the flow while unsupported returns to the card; "Got it" while the address is displayed returns to the card.
- With `ldmkTransport` off: Verify opens the classic Receive modal and the request card is back on close.
