### PR TITLE
[LWM] feat(app-lock): add the two-step password form (LIVE-35961)

### DIFF
--- a/.changeset/app-lock-two-step-password-form.md
+++ b/.changeset/app-lock-two-step-password-form.md
@@ -1,0 +1,11 @@
+---
+"@features/platform-app-lock": minor
+"@features/flow-app-lock": minor
+"live-mobile": minor
+---
+
+Add the two-step form for setting an app lock password, behind `lwmPasswordRevamp`. The legacy screens stay on the flag-off path untouched.
+
+`@features/flow-app-lock` gains one shared password field that every password surface will use, the two entry steps as ViewModel and View, and a draft that carries the chosen password from the first step to the second in memory — not through navigation state, which is serialisable and gets persisted. `@features/platform-app-lock` gains the minimum-length rule, which the migration off short passwords will need as well.
+
+Nothing is stored yet: confirming closes the flow and leaves the Settings switch off until the verifier lands.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -133,6 +133,7 @@ features/flow/pay-card-request/                          @ledgerhq/wallet-xp
 
 # Wallet — App lock
 features/platform/app-lock/                              @ledgerhq/wallet-xp
+features/flow/app-lock/                                  @ledgerhq/wallet-xp
 /shared/password-verifier/                               @ledgerhq/wallet-xp
 
 # Wallet — shared UI

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -111,6 +111,7 @@
     "@domain/entity-starred-account": "workspace:^",
     "@domain/entity-wallet-sync": "workspace:^",
     "@features/flow-analytics-consent": "workspace:*",
+    "@features/flow-app-lock": "workspace:*",
     "@features/flow-pay-card-auth": "workspace:^",
     "@features/flow-pay-card-balance": "workspace:^",
     "@features/flow-pay-card-deposit": "workspace:^",

--- a/apps/ledger-live-mobile/src/components/RootNavigator/PasswordAddFlowNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/PasswordAddFlowNavigator.tsx
@@ -1,35 +1,47 @@
-import React, { useMemo } from "react";
+import { useFeature } from "@features/platform-feature-flags";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import { useTranslation } from "~/context/Locale";
+import React, { useMemo } from "react";
 import { useTheme } from "styled-components/native";
-import { ScreenName } from "~/const";
-import PasswordAdd from "~/screens/Settings/General/PasswordAdd";
-import ConfirmPassword from "~/screens/Settings/General/ConfirmPassword";
+import { AppLockPasswordAddNavigator } from "LLM/features/AppLock/Navigator";
 import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
-import { PasswordAddFlowParamList } from "./types/PasswordAddFlowNavigator";
+import { ScreenName } from "~/const";
+import { useTranslation } from "~/context/Locale";
+import ConfirmPassword from "~/screens/Settings/General/ConfirmPassword";
+import PasswordAdd from "~/screens/Settings/General/PasswordAdd";
+import { LegacyPasswordAddFlowParamList } from "./types/PasswordAddFlowNavigator";
 
-const Stack = createNativeStackNavigator<PasswordAddFlowParamList>();
+const LegacyStack = createNativeStackNavigator<LegacyPasswordAddFlowParamList>();
 
-export default function PasswordAddFlowNavigator() {
+function LegacyPasswordAddFlowNavigator() {
   const { t } = useTranslation();
   const { colors } = useTheme();
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   return (
-    <Stack.Navigator screenOptions={stackNavigationConfig}>
-      <Stack.Screen
+    <LegacyStack.Navigator screenOptions={stackNavigationConfig}>
+      <LegacyStack.Screen
         name={ScreenName.PasswordAdd}
         component={PasswordAdd}
         options={{
           title: t("auth.addPassword.title"),
         }}
       />
-      <Stack.Screen
+      <LegacyStack.Screen
         name={ScreenName.ConfirmPassword}
         component={ConfirmPassword}
         options={{
           title: t("auth.confirmPassword.title"),
         }}
       />
-    </Stack.Navigator>
+    </LegacyStack.Navigator>
+  );
+}
+
+export default function PasswordAddFlowNavigator() {
+  const passwordRevamp = useFeature("lwmPasswordRevamp");
+
+  return passwordRevamp?.enabled ? (
+    <AppLockPasswordAddNavigator />
+  ) : (
+    <LegacyPasswordAddFlowNavigator />
   );
 }

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/PasswordAddFlowNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/PasswordAddFlowNavigator.ts
@@ -2,6 +2,11 @@ import { ScreenName } from "~/const";
 
 export type PasswordAddFlowParamList = {
   [ScreenName.PasswordAdd]: undefined;
+  [ScreenName.ConfirmPassword]: undefined;
+};
+
+export type LegacyPasswordAddFlowParamList = {
+  [ScreenName.PasswordAdd]: undefined;
   [ScreenName.ConfirmPassword]: {
     password?: string;
   };

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -1516,6 +1516,25 @@
     "disclaimer": "All account data will be removed from your phone.",
     "action": "Sign me out"
   },
+  "appLock": {
+    "field": {
+      "label": "Enter password",
+      "reveal": "Show password",
+      "hide": "Hide password",
+      "minLength": "Must be at least 6 characters"
+    },
+    "setupPassword": {
+      "title": "Enter password",
+      "description": "You'll need this password each time you open the app. If you lose it, reinstall the app and restore your wallet.",
+      "cta": "Continue"
+    },
+    "confirmPassword": {
+      "title": "Confirm password",
+      "description": "You'll need this password each time you open the app. If you lose it, reinstall the app and restore your wallet.",
+      "mismatch": "Passwords don't match",
+      "cta": "Confirm"
+    }
+  },
   "auth": {
     "failed": {
       "biometrics": {

--- a/apps/ledger-live-mobile/src/mvvm/features/AppLock/Navigator.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AppLock/Navigator.tsx
@@ -1,0 +1,50 @@
+import { PasswordDraftProvider } from "@features/flow-app-lock";
+import { useTheme } from "@ledgerhq/lumen-ui-rnative/styles";
+import React, { useMemo } from "react";
+import { Platform } from "react-native";
+import {
+  createLumenNativeStackNavigator,
+  getStackNavigationConfigV4,
+} from "LLM/components/Navigation";
+import type { PasswordAddFlowParamList } from "~/components/RootNavigator/types/PasswordAddFlowNavigator";
+import { ScreenName } from "~/const";
+import { useTranslation } from "~/context/Locale";
+import { ConfirmPasswordScreen } from "./screens/ConfirmPassword";
+import { SetupPasswordScreen } from "./screens/SetupPassword";
+
+const Stack = createLumenNativeStackNavigator<PasswordAddFlowParamList>();
+
+export function AppLockPasswordAddNavigator(): React.JSX.Element {
+  const { t } = useTranslation();
+  const { theme } = useTheme();
+
+  const stackNavigationConfig = useMemo(
+    () => getStackNavigationConfigV4(theme, "expanded"),
+    [theme],
+  );
+
+  return (
+    <PasswordDraftProvider>
+      <Stack.Navigator
+        screenOptions={{ ...stackNavigationConfig, gestureEnabled: Platform.OS === "ios" }}
+      >
+        <Stack.Screen
+          name={ScreenName.PasswordAdd}
+          component={SetupPasswordScreen}
+          options={{
+            title: t("appLock.setupPassword.title"),
+            lumenNavBar: { description: t("appLock.setupPassword.description") },
+          }}
+        />
+        <Stack.Screen
+          name={ScreenName.ConfirmPassword}
+          component={ConfirmPasswordScreen}
+          options={{
+            title: t("appLock.confirmPassword.title"),
+            lumenNavBar: { description: t("appLock.confirmPassword.description") },
+          }}
+        />
+      </Stack.Navigator>
+    </PasswordDraftProvider>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AppLock/__integrations__/addPassword.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AppLock/__integrations__/addPassword.test.tsx
@@ -1,0 +1,72 @@
+import { PasswordDraftProvider, usePasswordDraft } from "@features/flow-app-lock";
+import { render, screen, waitFor } from "@tests/test-renderer";
+import React from "react";
+import { ConfirmPasswordScreen } from "../screens/ConfirmPassword";
+import { SetupPasswordScreen } from "../screens/SetupPassword";
+
+const PASSWORD = "longenough";
+
+function ChosenPassword({
+  password,
+  children,
+}: Readonly<{ password: string; children: React.ReactNode }>): React.JSX.Element {
+  usePasswordDraft().write(password);
+
+  return <>{children}</>;
+}
+
+describe("choosing a password", () => {
+  it("only offers to continue once the minimum is met", async () => {
+    const { user } = render(
+      <PasswordDraftProvider>
+        <SetupPasswordScreen />
+      </PasswordDraftProvider>,
+    );
+
+    const field = await screen.findByTestId("app-lock-setup-password-field");
+    const cta = screen.getByTestId("app-lock-setup-password-continue");
+
+    expect(cta).toBeDisabled();
+
+    await user.type(field, "short");
+    await waitFor(() => expect(cta).toBeDisabled());
+
+    await user.clear(field);
+    await user.type(field, PASSWORD);
+    await waitFor(() => expect(cta).toBeEnabled());
+  });
+});
+
+describe("confirming a password", () => {
+  const renderConfirm = () =>
+    render(
+      <PasswordDraftProvider>
+        <ChosenPassword password={PASSWORD}>
+          <ConfirmPasswordScreen />
+        </ChosenPassword>
+      </PasswordDraftProvider>,
+    );
+
+  it("accepts an entry that matches the one chosen in the step before", async () => {
+    const { user } = renderConfirm();
+
+    const field = await screen.findByTestId("app-lock-confirm-password-field");
+    await user.type(field, PASSWORD);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("app-lock-confirm-password-confirm")).toBeEnabled(),
+    );
+    expect(screen.queryByText("Passwords don't match")).toBeNull();
+  });
+
+  it("says so in place when the two entries differ", async () => {
+    const { user } = renderConfirm();
+
+    const field = await screen.findByTestId("app-lock-confirm-password-field");
+    await user.type(field, "somethingelse");
+    await user.press(screen.getByTestId("app-lock-confirm-password-confirm"));
+
+    expect(await screen.findByText("Passwords don't match")).toBeVisible();
+    expect(screen.getByTestId("app-lock-confirm-password-field")).toBeVisible();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/AppLock/hooks/useKeyboardInset.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AppLock/hooks/useKeyboardInset.test.tsx
@@ -1,0 +1,100 @@
+import { act, renderHook } from "@tests/test-renderer";
+import { Keyboard, Platform } from "react-native";
+import { useKeyboardInset } from "./useKeyboardInset";
+
+const WINDOW_HEIGHT = 800;
+
+jest.mock("react-native/Libraries/Utilities/useWindowDimensions", () => ({
+  __esModule: true,
+  default: () => ({ height: windowHeight, width: 400, scale: 2, fontScale: 1 }),
+}));
+
+let windowHeight = WINDOW_HEIGHT;
+
+const listeners = new Map<string, (event: { endCoordinates: { screenY: number } }) => void>();
+
+const showEvent = Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow";
+const hideEvent = Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide";
+
+beforeEach(() => {
+  windowHeight = WINDOW_HEIGHT;
+  listeners.clear();
+  jest.spyOn(Keyboard, "metrics").mockReturnValue(undefined);
+  jest.spyOn(Keyboard, "addListener").mockImplementation(((
+    event: string,
+    listener: (payload: { endCoordinates: { screenY: number } }) => void,
+  ) => {
+    listeners.set(event, listener);
+    return { remove: jest.fn() };
+  }) as unknown as typeof Keyboard.addListener);
+});
+
+afterEach(() => jest.restoreAllMocks());
+
+const show = (keyboardTop: number, resizeTo?: number) =>
+  act(() => {
+    if (resizeTo !== undefined) {
+      windowHeight = resizeTo;
+    }
+    listeners.get(showEvent)?.({ endCoordinates: { screenY: keyboardTop } });
+  });
+
+const hide = () =>
+  act(() => {
+    windowHeight = WINDOW_HEIGHT;
+    listeners.get(hideEvent)?.({ endCoordinates: { screenY: WINDOW_HEIGHT } });
+  });
+
+describe("the keyboard inset", () => {
+  it("is nothing while the keyboard is down", () => {
+    const { result } = renderHook(() => useKeyboardInset());
+
+    expect(result.current).toBe(0);
+  });
+
+  it("is the gap left below the keyboard when the window keeps its height", () => {
+    const { result } = renderHook(() => useKeyboardInset());
+
+    show(500);
+
+    expect(result.current).toBe(300);
+  });
+
+  it("is nothing when the window shrank to where the keyboard starts", () => {
+    const { result } = renderHook(() => useKeyboardInset());
+
+    show(500, 500);
+
+    expect(result.current).toBe(0);
+  });
+
+  it("is the remainder when the window shrank by only part of the keyboard", () => {
+    const { result } = renderHook(() => useKeyboardInset());
+
+    show(500, 650);
+
+    expect(result.current).toBe(150);
+  });
+
+  it("pads a screen that mounts with the keyboard already up", () => {
+    jest.spyOn(Keyboard, "metrics").mockReturnValue({
+      screenY: 500,
+      screenX: 0,
+      width: 400,
+      height: 300,
+    });
+
+    const { result } = renderHook(() => useKeyboardInset());
+
+    expect(result.current).toBe(300);
+  });
+
+  it("goes back to nothing on dismissal, leaving no padding behind", () => {
+    const { result } = renderHook(() => useKeyboardInset());
+
+    show(500);
+    hide();
+
+    expect(result.current).toBe(0);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/AppLock/hooks/useKeyboardInset.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AppLock/hooks/useKeyboardInset.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+import { Keyboard, Platform, useWindowDimensions } from "react-native";
+
+/**
+ * How much a screen has to pad itself for the keyboard: the gap between the bottom of the app window
+ * and the top of the keyboard.
+ *
+ * Measured from the keyboard's position rather than its height, which answers both platforms at once
+ * — a window that `adjustResize` shrank ends where the keyboard starts, so the gap is zero, while an
+ * edge-to-edge window keeps its full height and the gap is the whole keyboard. It is also read
+ * straight from the current metrics, so a screen that mounts with the keyboard already up — the
+ * confirm step of the password flow, arriving from the step before it — pads itself without waiting
+ * for an event that has already been and gone.
+ */
+export function useKeyboardInset(): number {
+  const { height } = useWindowDimensions();
+  const [keyboardTop, setKeyboardTop] = useState(() => Keyboard.metrics()?.screenY);
+
+  useEffect(() => {
+    const isIOS = Platform.OS === "ios";
+    const show = Keyboard.addListener(
+      isIOS ? "keyboardWillShow" : "keyboardDidShow",
+      ({ endCoordinates }) => setKeyboardTop(endCoordinates.screenY),
+    );
+    const hide = Keyboard.addListener(isIOS ? "keyboardWillHide" : "keyboardDidHide", () =>
+      setKeyboardTop(undefined),
+    );
+
+    return () => {
+      show.remove();
+      hide.remove();
+    };
+  }, []);
+
+  return keyboardTop === undefined ? 0 : Math.max(0, height - keyboardTop);
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AppLock/screens/ConfirmPassword/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AppLock/screens/ConfirmPassword/index.tsx
@@ -1,0 +1,25 @@
+import { ConfirmPasswordView, type ConfirmPasswordLabels } from "@features/flow-app-lock";
+import React, { useMemo } from "react";
+import { useTranslation } from "~/context/Locale";
+import { useKeyboardInset } from "../../hooks/useKeyboardInset";
+import useConfirmPasswordScreenViewModel from "./useConfirmPasswordScreenViewModel";
+
+export function ConfirmPasswordScreen(): React.JSX.Element {
+  const { t } = useTranslation();
+  const keyboardInset = useKeyboardInset();
+  const viewModel = useConfirmPasswordScreenViewModel();
+
+  const labels = useMemo<ConfirmPasswordLabels>(
+    () => ({
+      fieldLabel: t("appLock.field.label"),
+      revealPassword: t("appLock.field.reveal"),
+      hidePassword: t("appLock.field.hide"),
+      minLengthHelper: t("appLock.field.minLength"),
+      mismatchError: t("appLock.confirmPassword.mismatch"),
+      confirmLabel: t("appLock.confirmPassword.cta"),
+    }),
+    [t],
+  );
+
+  return <ConfirmPasswordView {...viewModel} labels={labels} keyboardHeight={keyboardInset} />;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AppLock/screens/ConfirmPassword/useConfirmPasswordScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AppLock/screens/ConfirmPassword/useConfirmPasswordScreenViewModel.ts
@@ -1,0 +1,23 @@
+import {
+  useConfirmPasswordViewModel,
+  usePasswordDraft,
+  type ConfirmPasswordViewModel,
+} from "@features/flow-app-lock";
+import { useNavigation } from "@react-navigation/native";
+import { useCallback } from "react";
+import type { PasswordAddFlowNavigatorProps } from "../../types";
+
+function useConfirmPasswordScreenViewModel(): ConfirmPasswordViewModel {
+  const navigation = useNavigation<PasswordAddFlowNavigatorProps["navigation"]>();
+  const draft = usePasswordDraft();
+
+  const onConfirmed = useCallback(() => {
+    draft.clear();
+    // The parent, not this stack: goBack() here would land on the enter-password step.
+    navigation.getParent()?.goBack();
+  }, [draft, navigation]);
+
+  return useConfirmPasswordViewModel({ onConfirmed });
+}
+
+export default useConfirmPasswordScreenViewModel;

--- a/apps/ledger-live-mobile/src/mvvm/features/AppLock/screens/SetupPassword/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AppLock/screens/SetupPassword/index.tsx
@@ -1,0 +1,24 @@
+import { SetupPasswordView, type SetupPasswordLabels } from "@features/flow-app-lock";
+import React, { useMemo } from "react";
+import { useTranslation } from "~/context/Locale";
+import { useKeyboardInset } from "../../hooks/useKeyboardInset";
+import useSetupPasswordScreenViewModel from "./useSetupPasswordScreenViewModel";
+
+export function SetupPasswordScreen(): React.JSX.Element {
+  const { t } = useTranslation();
+  const keyboardInset = useKeyboardInset();
+  const viewModel = useSetupPasswordScreenViewModel();
+
+  const labels = useMemo<SetupPasswordLabels>(
+    () => ({
+      fieldLabel: t("appLock.field.label"),
+      revealPassword: t("appLock.field.reveal"),
+      hidePassword: t("appLock.field.hide"),
+      minLengthHelper: t("appLock.field.minLength"),
+      continueLabel: t("appLock.setupPassword.cta"),
+    }),
+    [t],
+  );
+
+  return <SetupPasswordView {...viewModel} labels={labels} keyboardHeight={keyboardInset} />;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/AppLock/screens/SetupPassword/useSetupPasswordScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AppLock/screens/SetupPassword/useSetupPasswordScreenViewModel.ts
@@ -1,0 +1,17 @@
+import { useSetupPasswordViewModel, type SetupPasswordViewModel } from "@features/flow-app-lock";
+import { useNavigation } from "@react-navigation/native";
+import { useCallback } from "react";
+import { ScreenName } from "~/const";
+import type { PasswordAddFlowNavigatorProps } from "../../types";
+
+function useSetupPasswordScreenViewModel(): SetupPasswordViewModel {
+  const navigation = useNavigation<PasswordAddFlowNavigatorProps["navigation"]>();
+
+  const onValid = useCallback(() => {
+    navigation.navigate(ScreenName.ConfirmPassword);
+  }, [navigation]);
+
+  return useSetupPasswordViewModel({ onValid });
+}
+
+export default useSetupPasswordScreenViewModel;

--- a/apps/ledger-live-mobile/src/mvvm/features/AppLock/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AppLock/types.ts
@@ -1,0 +1,8 @@
+import type { ScreenName } from "~/const";
+import type { PasswordAddFlowParamList } from "~/components/RootNavigator/types/PasswordAddFlowNavigator";
+import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+
+export type PasswordAddFlowNavigatorProps = StackNavigatorProps<
+  PasswordAddFlowParamList,
+  ScreenName.PasswordAdd | ScreenName.ConfirmPassword
+>;

--- a/apps/ledger-live-mobile/src/screens/Settings/General/ConfirmPassword.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/General/ConfirmPassword.tsx
@@ -10,7 +10,7 @@ import { setPrivacy } from "~/actions/settings";
 import PasswordForm from "./PasswordForm";
 import { VIBRATION_PATTERN_ERROR } from "~/utils/constants";
 import { ScreenName } from "~/const";
-import type { PasswordAddFlowParamList } from "~/components/RootNavigator/types/PasswordAddFlowNavigator";
+import type { LegacyPasswordAddFlowParamList } from "~/components/RootNavigator/types/PasswordAddFlowNavigator";
 import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import {
   StackNavigatorNavigation,
@@ -18,7 +18,7 @@ import {
 } from "~/components/RootNavigator/types/helpers";
 
 type Props = CompositeScreenProps<
-  StackNavigatorProps<PasswordAddFlowParamList, ScreenName.ConfirmPassword>,
+  StackNavigatorProps<LegacyPasswordAddFlowParamList, ScreenName.ConfirmPassword>,
   StackNavigatorProps<BaseNavigatorStackParamList>
 >;
 

--- a/apps/ledger-live-mobile/src/screens/Settings/General/PasswordAdd.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/General/PasswordAdd.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from "react";
 import { useTranslation } from "~/context/Locale";
-import { PasswordAddFlowParamList } from "~/components/RootNavigator/types/PasswordAddFlowNavigator";
+import { LegacyPasswordAddFlowParamList } from "~/components/RootNavigator/types/PasswordAddFlowNavigator";
 import { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { ScreenName } from "~/const";
 import PasswordForm from "./PasswordForm";
 import { Keyboard } from "react-native";
 
-type Props = StackNavigatorProps<PasswordAddFlowParamList, ScreenName.PasswordAdd>;
+type Props = StackNavigatorProps<LegacyPasswordAddFlowParamList, ScreenName.PasswordAdd>;
 
 const PasswordAdd = ({ navigation }: Props) => {
   const { t } = useTranslation();

--- a/features/flow/app-lock/README.md
+++ b/features/flow/app-lock/README.md
@@ -1,0 +1,90 @@
+# @features/flow-app-lock
+
+> [!CAUTION]
+> **Status: UNSTABLE** — the public API grows with each ticket of the epic.
+
+Flow package hosting the app lock experience for Ledger Wallet Mobile, each screen as a
+container → ViewModel → View triplet, the container living in the app.
+
+## Scope
+
+What it holds today, from [LIVE-35961](https://ledgerhq.atlassian.net/browse/LIVE-35961):
+
+- `components/PasswordField` — the one password input every password surface uses, so the label,
+  the reveal toggle and the error treatment cannot drift between them.
+- `screens/SetupPassword` and `screens/ConfirmPassword` — the two steps of adding a password.
+- `state/passwordDraft` — carries the chosen password from the first step to the second in a ref,
+  deliberately not in navigation state, which is serialisable and gets persisted.
+
+**Unlock**, **DeactivatePassword** and the migration views arrive with their own tickets.
+
+Protection state, the biometrics status unions and the errors come from
+[`@features/platform-app-lock`](../../platform/app-lock/README.md); the password verifier and its
+constant-time comparison come from [`@shared/password-verifier`](../../../shared/password-verifier/README.md).
+
+## Native only
+
+The epic is mobile only — desktop is out of scope in the product spec — so this package ships **no**
+`.web.tsx` variants and no web stubs. There are no `.web` / `.native` suffixes at all: plain
+`.ts` / `.tsx` files behind a single `src/index.ts` barrel. The flow-layer convention reserves those
+suffixes for genuinely platform-split files, and with one platform they would be machinery for
+nothing. This differs from `features/flow/pay-card-auth`, which is cross-platform and therefore
+carries `index.tsx` / `index.native.tsx` pairs plus `src/index.native.ts`.
+
+If desktop ever needs this flow, introducing the split then is a mechanical rename.
+
+For the same reason there is no `tsconfig.test.json`: in the cross-platform packages it exists only
+to strip the other platform's files from the typecheck, and here `tsconfig.json` already covers
+`src/**/*`.
+
+Tests use the shared `@support/jest-features-flow` config, whose native project selects
+`*.native.test.tsx`. That suffix is a jest project selector on **test** files, not a platform split
+of source files.
+
+## Structure
+
+Today:
+
+```text
+src/
+├── components/PasswordField/   # shared by every password screen
+├── screens/ConfirmPassword/
+├── screens/SetupPassword/
+├── state/passwordDraft.tsx
+└── index.ts                    # Public API
+```
+
+Target, as the remaining tickets land:
+
+```text
+src/
+├── components/                 # shared by several views
+├── hooks/
+├── screens/<Name>/             # Unlock, SetupPassword, Confirm, Migration
+│   ├── components/             # used only by this view
+│   ├── viewModel.ts
+│   ├── view.tsx
+│   ├── view.native.test.tsx
+│   └── index.ts
+├── state/
+└── index.ts
+```
+
+**`screens/`, not `steps/`.** Both appear in the repo, so this is settled here to save the next
+ticket the decision. The [architecture guideline](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/6111232117)
+names the folder `screens/`, and peer practice follows it 3:1 —
+`flow-contacts-add-contact`, `flow-contacts-introduction` and `large-screen-upsell` use `screens/`,
+only `features/flow/contacts` uses `steps/`. The `<Name>/` nesting comes from those packages rather
+than from the guideline, whose example omits it because it shows a single-view flow.
+
+Note that the `ddd-structure-flow` skill documents `steps/<StepName>/` while citing that guideline as
+its upstream source — the two disagree, and the skill is the minority. Worth reconciling in the docs
+rather than per package.
+
+## Validation
+
+```sh
+pnpm test
+pnpm typecheck
+pnpm unimported
+```

--- a/features/flow/app-lock/jest.config.js
+++ b/features/flow/app-lock/jest.config.js
@@ -1,0 +1,9 @@
+// Native-only: the shared config's jsdom project matches nothing and needs jest-environment-jsdom.
+const { projects, ...config } = require("@support/jest-features-flow").createFlowJestConfig({
+  passWithNoTests: true,
+});
+
+module.exports = {
+  ...config,
+  projects: projects.filter(project => project.displayName === "native"),
+};

--- a/features/flow/app-lock/package.json
+++ b/features/flow/app-lock/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@features/flow-app-lock",
+  "version": "0.1.0",
+  "private": true,
+  "description": "App lock flow for Ledger Wallet Mobile: unlock, password setup, migration (scaffold)",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "format": "oxfmt src",
+    "format:check": "oxfmt src --check",
+    "lint": "oxlint src",
+    "lint:ci": "oxlint src --quiet",
+    "lint:fix": "oxfmt src && oxlint src --fix --quiet",
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../../.. -W features/flow/app-lock"
+  },
+  "dependencies": {
+    "@features/platform-app-lock": "workspace:*"
+  },
+  "peerDependencies": {
+    "@ledgerhq/lumen-design-core": "catalog:",
+    "@ledgerhq/lumen-ui-rnative": "catalog:",
+    "react": ">=19.0.0",
+    "react-native": ">=0.70.0"
+  },
+  "peerDependenciesMeta": {
+    "@ledgerhq/lumen-design-core": {
+      "optional": true
+    },
+    "@ledgerhq/lumen-ui-rnative": {
+      "optional": true
+    },
+    "react-native": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@ledgerhq/lumen-design-core": "catalog:",
+    "@ledgerhq/lumen-ui-rnative": "catalog:",
+    "@support/jest-features-flow": "workspace:*",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@testing-library/react-native": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/react": "catalog:",
+    "jest": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
+    "react": "catalog:",
+    "react-native": "catalog:",
+    "react-test-renderer": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/features/flow/app-lock/project.json
+++ b/features/flow/app-lock/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@features/flow-app-lock",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/features/flow/app-lock/src/components/PasswordField/PasswordField.tsx
+++ b/features/flow/app-lock/src/components/PasswordField/PasswordField.tsx
@@ -1,0 +1,49 @@
+import { TextInput } from "@ledgerhq/lumen-ui-rnative";
+import { Eye, EyeCross } from "@ledgerhq/lumen-ui-rnative/symbols";
+import React, { useCallback, useState } from "react";
+import { Pressable } from "react-native";
+import type { PasswordFieldProps } from "./types";
+
+export function PasswordField({
+  value,
+  onChangeText,
+  labels,
+  helperText,
+  hasError = false,
+  autoFocus = false,
+  onSubmitEditing,
+  testID,
+}: PasswordFieldProps): React.JSX.Element {
+  const [isRevealed, setIsRevealed] = useState(false);
+  const toggleReveal = useCallback(() => setIsRevealed(revealed => !revealed), []);
+  const RevealIcon = isRevealed ? EyeCross : Eye;
+
+  return (
+    <TextInput
+      label={labels.fieldLabel}
+      value={value}
+      onChangeText={onChangeText}
+      secureTextEntry={!isRevealed}
+      autoCapitalize="none"
+      autoCorrect={false}
+      autoComplete="off"
+      spellCheck={false}
+      helperText={helperText}
+      status={hasError ? "error" : undefined}
+      hideClearButton
+      autoFocus={autoFocus}
+      onSubmitEditing={onSubmitEditing}
+      testID={testID}
+      suffix={
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={isRevealed ? labels.hidePassword : labels.revealPassword}
+          onPress={toggleReveal}
+          testID={testID ? `${testID}-reveal` : undefined}
+        >
+          <RevealIcon size={20} />
+        </Pressable>
+      }
+    />
+  );
+}

--- a/features/flow/app-lock/src/components/PasswordField/index.ts
+++ b/features/flow/app-lock/src/components/PasswordField/index.ts
@@ -1,0 +1,2 @@
+export * from "./PasswordField";
+export * from "./types";

--- a/features/flow/app-lock/src/components/PasswordField/types.ts
+++ b/features/flow/app-lock/src/components/PasswordField/types.ts
@@ -1,0 +1,16 @@
+export type PasswordFieldLabels = Readonly<{
+  fieldLabel: string;
+  revealPassword: string;
+  hidePassword: string;
+}>;
+
+export type PasswordFieldProps = Readonly<{
+  value: string;
+  onChangeText: (value: string) => void;
+  labels: PasswordFieldLabels;
+  helperText?: string;
+  hasError?: boolean;
+  autoFocus?: boolean;
+  onSubmitEditing?: () => void;
+  testID?: string;
+}>;

--- a/features/flow/app-lock/src/index.ts
+++ b/features/flow/app-lock/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./components/PasswordField";
+export * from "./state/passwordDraft";
+export * from "./screens/SetupPassword";
+export * from "./screens/ConfirmPassword";

--- a/features/flow/app-lock/src/screens/ConfirmPassword/index.ts
+++ b/features/flow/app-lock/src/screens/ConfirmPassword/index.ts
@@ -1,0 +1,3 @@
+export * from "./types";
+export * from "./viewModel";
+export * from "./view";

--- a/features/flow/app-lock/src/screens/ConfirmPassword/types.ts
+++ b/features/flow/app-lock/src/screens/ConfirmPassword/types.ts
@@ -1,0 +1,23 @@
+import type { PasswordFieldLabels } from "../../components/PasswordField";
+
+export type ConfirmPasswordLabels = PasswordFieldLabels &
+  Readonly<{
+    minLengthHelper: string;
+    mismatchError: string;
+    confirmLabel: string;
+  }>;
+
+export type ConfirmPasswordViewModel = Readonly<{
+  password: string;
+  isConfirmEnabled: boolean;
+  hasMismatch: boolean;
+  onPasswordChange: (password: string) => void;
+  onConfirm: () => void;
+}>;
+
+export type UseConfirmPasswordViewModelOptions = Readonly<{
+  onConfirmed: (password: string) => void;
+}>;
+
+export type ConfirmPasswordViewProps = ConfirmPasswordViewModel &
+  Readonly<{ labels: ConfirmPasswordLabels; keyboardHeight?: number }>;

--- a/features/flow/app-lock/src/screens/ConfirmPassword/view.tsx
+++ b/features/flow/app-lock/src/screens/ConfirmPassword/view.tsx
@@ -1,0 +1,41 @@
+import { Box, Button } from "@ledgerhq/lumen-ui-rnative";
+import React from "react";
+import { PasswordField } from "../../components/PasswordField";
+import type { ConfirmPasswordViewProps } from "./types";
+
+export function ConfirmPasswordView({
+  password,
+  isConfirmEnabled,
+  hasMismatch,
+  onPasswordChange,
+  onConfirm,
+  labels,
+  keyboardHeight = 0,
+}: ConfirmPasswordViewProps): React.JSX.Element {
+  return (
+    <Box
+      lx={{ flex: 1, paddingHorizontal: "s16", gap: "s24" }}
+      style={{ paddingBottom: keyboardHeight + 16 }}
+    >
+      <PasswordField
+        value={password}
+        onChangeText={onPasswordChange}
+        labels={labels}
+        helperText={hasMismatch ? labels.mismatchError : labels.minLengthHelper}
+        hasError={hasMismatch}
+        autoFocus
+        onSubmitEditing={onConfirm}
+        testID="app-lock-confirm-password-field"
+      />
+      <Box lx={{ flex: 1 }} />
+      <Button
+        appearance="base"
+        disabled={!isConfirmEnabled}
+        onPress={onConfirm}
+        testID="app-lock-confirm-password-confirm"
+      >
+        {labels.confirmLabel}
+      </Button>
+    </Box>
+  );
+}

--- a/features/flow/app-lock/src/screens/ConfirmPassword/viewModel.native.test.tsx
+++ b/features/flow/app-lock/src/screens/ConfirmPassword/viewModel.native.test.tsx
@@ -1,0 +1,88 @@
+import { act, renderHook } from "@testing-library/react-native";
+import React from "react";
+import { PasswordDraftProvider, usePasswordDraft } from "../../state/passwordDraft";
+import { useConfirmPasswordViewModel } from "./viewModel";
+
+function wrapper({ children }: Readonly<{ children: React.ReactNode }>) {
+  return <PasswordDraftProvider>{children}</PasswordDraftProvider>;
+}
+
+function renderViewModel(chosen: string | null, onConfirmed = jest.fn()) {
+  const rendered = renderHook(
+    () => ({
+      viewModel: useConfirmPasswordViewModel({ onConfirmed }),
+      draft: usePasswordDraft(),
+    }),
+    { wrapper },
+  );
+
+  if (chosen !== null) {
+    act(() => rendered.result.current.draft.write(chosen));
+  }
+
+  return { ...rendered, onConfirmed };
+}
+
+describe("useConfirmPasswordViewModel", () => {
+  it("enables Confirm as soon as the field is non-empty", () => {
+    const { result } = renderViewModel("123456");
+
+    expect(result.current.viewModel.isConfirmEnabled).toBe(false);
+
+    act(() => result.current.viewModel.onPasswordChange("1"));
+    expect(result.current.viewModel.isConfirmEnabled).toBe(true);
+  });
+
+  it("confirms a matching password", () => {
+    const { result, onConfirmed } = renderViewModel("123456");
+
+    act(() => result.current.viewModel.onPasswordChange("123456"));
+    act(() => result.current.viewModel.onConfirm());
+
+    expect(onConfirmed).toHaveBeenCalledWith("123456");
+    expect(result.current.viewModel.hasMismatch).toBe(false);
+  });
+
+  it("surfaces a mismatch and does not confirm", () => {
+    const { result, onConfirmed } = renderViewModel("123456");
+
+    act(() => result.current.viewModel.onPasswordChange("123457"));
+    act(() => result.current.viewModel.onConfirm());
+
+    expect(onConfirmed).not.toHaveBeenCalled();
+    expect(result.current.viewModel.hasMismatch).toBe(true);
+  });
+
+  it("clears the mismatch as soon as the user types again", () => {
+    const { result } = renderViewModel("123456");
+
+    act(() => result.current.viewModel.onPasswordChange("123457"));
+    act(() => result.current.viewModel.onConfirm());
+    expect(result.current.viewModel.hasMismatch).toBe(true);
+
+    act(() => result.current.viewModel.onPasswordChange("12345"));
+    expect(result.current.viewModel.hasMismatch).toBe(false);
+  });
+
+  it("treats whitespace as significant", () => {
+    const { result, onConfirmed } = renderViewModel("  ab  ");
+
+    act(() => result.current.viewModel.onPasswordChange("  ab"));
+    act(() => result.current.viewModel.onConfirm());
+    expect(onConfirmed).not.toHaveBeenCalled();
+
+    act(() => result.current.viewModel.onPasswordChange("  ab  "));
+    act(() => result.current.viewModel.onConfirm());
+    expect(onConfirmed).toHaveBeenCalledWith("  ab  ");
+  });
+
+  it("cannot confirm when no password was chosen", () => {
+    const { result, onConfirmed } = renderViewModel(null);
+
+    act(() => result.current.viewModel.onPasswordChange("123456"));
+    act(() => result.current.viewModel.onConfirm());
+
+    expect(onConfirmed).not.toHaveBeenCalled();
+    expect(result.current.viewModel.hasMismatch).toBe(true);
+  });
+});

--- a/features/flow/app-lock/src/screens/ConfirmPassword/viewModel.ts
+++ b/features/flow/app-lock/src/screens/ConfirmPassword/viewModel.ts
@@ -1,0 +1,35 @@
+import { useCallback, useState } from "react";
+import { usePasswordDraft } from "../../state/passwordDraft";
+import type { ConfirmPasswordViewModel, UseConfirmPasswordViewModelOptions } from "./types";
+
+export function useConfirmPasswordViewModel({
+  onConfirmed,
+}: UseConfirmPasswordViewModelOptions): ConfirmPasswordViewModel {
+  const draft = usePasswordDraft();
+  const [password, setPassword] = useState("");
+  const [hasMismatch, setHasMismatch] = useState(false);
+
+  const onPasswordChange = useCallback((next: string) => {
+    setPassword(next);
+    setHasMismatch(false);
+  }, []);
+
+  const onConfirm = useCallback(() => {
+    const chosen = draft.read();
+
+    if (chosen === null || password !== chosen) {
+      setHasMismatch(true);
+      return;
+    }
+
+    onConfirmed(chosen);
+  }, [draft, onConfirmed, password]);
+
+  return {
+    password,
+    isConfirmEnabled: password.length > 0,
+    hasMismatch,
+    onPasswordChange,
+    onConfirm,
+  };
+}

--- a/features/flow/app-lock/src/screens/SetupPassword/index.ts
+++ b/features/flow/app-lock/src/screens/SetupPassword/index.ts
@@ -1,0 +1,3 @@
+export * from "./types";
+export * from "./viewModel";
+export * from "./view";

--- a/features/flow/app-lock/src/screens/SetupPassword/types.ts
+++ b/features/flow/app-lock/src/screens/SetupPassword/types.ts
@@ -1,0 +1,21 @@
+import type { PasswordFieldLabels } from "../../components/PasswordField";
+
+export type SetupPasswordLabels = PasswordFieldLabels &
+  Readonly<{
+    minLengthHelper: string;
+    continueLabel: string;
+  }>;
+
+export type SetupPasswordViewModel = Readonly<{
+  password: string;
+  isContinueEnabled: boolean;
+  onPasswordChange: (password: string) => void;
+  onContinue: () => void;
+}>;
+
+export type UseSetupPasswordViewModelOptions = Readonly<{
+  onValid: () => void;
+}>;
+
+export type SetupPasswordViewProps = SetupPasswordViewModel &
+  Readonly<{ labels: SetupPasswordLabels; keyboardHeight?: number }>;

--- a/features/flow/app-lock/src/screens/SetupPassword/view.tsx
+++ b/features/flow/app-lock/src/screens/SetupPassword/view.tsx
@@ -1,0 +1,39 @@
+import { Box, Button } from "@ledgerhq/lumen-ui-rnative";
+import React from "react";
+import { PasswordField } from "../../components/PasswordField";
+import type { SetupPasswordViewProps } from "./types";
+
+export function SetupPasswordView({
+  password,
+  isContinueEnabled,
+  onPasswordChange,
+  onContinue,
+  labels,
+  keyboardHeight = 0,
+}: SetupPasswordViewProps): React.JSX.Element {
+  return (
+    <Box
+      lx={{ flex: 1, paddingHorizontal: "s16", gap: "s24" }}
+      style={{ paddingBottom: keyboardHeight + 16 }}
+    >
+      <PasswordField
+        value={password}
+        onChangeText={onPasswordChange}
+        labels={labels}
+        helperText={labels.minLengthHelper}
+        autoFocus
+        onSubmitEditing={onContinue}
+        testID="app-lock-setup-password-field"
+      />
+      <Box lx={{ flex: 1 }} />
+      <Button
+        appearance="base"
+        disabled={!isContinueEnabled}
+        onPress={onContinue}
+        testID="app-lock-setup-password-continue"
+      >
+        {labels.continueLabel}
+      </Button>
+    </Box>
+  );
+}

--- a/features/flow/app-lock/src/screens/SetupPassword/viewModel.native.test.tsx
+++ b/features/flow/app-lock/src/screens/SetupPassword/viewModel.native.test.tsx
@@ -1,0 +1,86 @@
+import { act, renderHook } from "@testing-library/react-native";
+import React from "react";
+import { PasswordDraftProvider, usePasswordDraft } from "../../state/passwordDraft";
+import { useSetupPasswordViewModel } from "./viewModel";
+
+function wrapper({ children }: Readonly<{ children: React.ReactNode }>) {
+  return <PasswordDraftProvider>{children}</PasswordDraftProvider>;
+}
+
+function renderViewModel(onValid = jest.fn()) {
+  const rendered = renderHook(
+    () => ({
+      viewModel: useSetupPasswordViewModel({ onValid }),
+      draft: usePasswordDraft(),
+    }),
+    { wrapper },
+  );
+
+  return { ...rendered, onValid };
+}
+
+describe("useSetupPasswordViewModel", () => {
+  it("keeps Continue disabled under six characters", () => {
+    const { result } = renderViewModel();
+
+    expect(result.current.viewModel.isContinueEnabled).toBe(false);
+
+    act(() => result.current.viewModel.onPasswordChange("12345"));
+    expect(result.current.viewModel.isContinueEnabled).toBe(false);
+
+    act(() => result.current.viewModel.onPasswordChange("123456"));
+    expect(result.current.viewModel.isContinueEnabled).toBe(true);
+  });
+
+  it("accepts six symbols", () => {
+    const { result } = renderViewModel();
+
+    act(() => result.current.viewModel.onPasswordChange("!@#$%^"));
+
+    expect(result.current.viewModel.isContinueEnabled).toBe(true);
+  });
+
+  it("preserves leading and trailing spaces", () => {
+    const { result } = renderViewModel();
+
+    act(() => result.current.viewModel.onPasswordChange("  ab  "));
+
+    expect(result.current.viewModel.password).toBe("  ab  ");
+    expect(result.current.viewModel.isContinueEnabled).toBe(true);
+
+    act(() => result.current.viewModel.onContinue());
+    expect(result.current.draft.read()).toBe("  ab  ");
+  });
+
+  it("writes the draft and advances only when valid", () => {
+    const { result, onValid } = renderViewModel();
+
+    act(() => result.current.viewModel.onPasswordChange("12345"));
+    act(() => result.current.viewModel.onContinue());
+
+    expect(onValid).not.toHaveBeenCalled();
+    expect(result.current.draft.read()).toBeNull();
+
+    act(() => result.current.viewModel.onPasswordChange("123456"));
+    act(() => result.current.viewModel.onContinue());
+
+    expect(onValid).toHaveBeenCalledTimes(1);
+    expect(result.current.draft.read()).toBe("123456");
+  });
+});
+
+describe("usePasswordDraft", () => {
+  it("throws without a provider, so the password cannot silently fall back to nav state", () => {
+    expect(() => renderHook(() => usePasswordDraft())).toThrow(/PasswordDraftProvider/);
+  });
+
+  it("clears on demand", () => {
+    const { result } = renderHook(() => usePasswordDraft(), { wrapper });
+
+    act(() => result.current.write("secret1"));
+    expect(result.current.read()).toBe("secret1");
+
+    act(() => result.current.clear());
+    expect(result.current.read()).toBeNull();
+  });
+});

--- a/features/flow/app-lock/src/screens/SetupPassword/viewModel.ts
+++ b/features/flow/app-lock/src/screens/SetupPassword/viewModel.ts
@@ -1,0 +1,29 @@
+import { isPasswordLongEnough } from "@features/platform-app-lock";
+import { useCallback, useState } from "react";
+import { usePasswordDraft } from "../../state/passwordDraft";
+import type { SetupPasswordViewModel, UseSetupPasswordViewModelOptions } from "./types";
+
+export function useSetupPasswordViewModel({
+  onValid,
+}: UseSetupPasswordViewModelOptions): SetupPasswordViewModel {
+  const draft = usePasswordDraft();
+  const [password, setPassword] = useState("");
+
+  const isContinueEnabled = isPasswordLongEnough(password);
+
+  const onContinue = useCallback(() => {
+    if (!isPasswordLongEnough(password)) {
+      return;
+    }
+
+    draft.write(password);
+    onValid();
+  }, [draft, onValid, password]);
+
+  return {
+    password,
+    isContinueEnabled,
+    onPasswordChange: setPassword,
+    onContinue,
+  };
+}

--- a/features/flow/app-lock/src/state/passwordDraft.tsx
+++ b/features/flow/app-lock/src/state/passwordDraft.tsx
@@ -1,0 +1,40 @@
+import React, { createContext, useContext, useMemo, useRef } from "react";
+
+export type PasswordDraft = Readonly<{
+  read: () => string | null;
+  write: (password: string) => void;
+  clear: () => void;
+}>;
+
+const PasswordDraftContext = createContext<PasswordDraft | null>(null);
+
+export function PasswordDraftProvider({
+  children,
+}: Readonly<{ children: React.ReactNode }>): React.JSX.Element {
+  const draft = useRef<string | null>(null);
+
+  const value = useMemo<PasswordDraft>(
+    () => ({
+      read: () => draft.current,
+      write: password => {
+        draft.current = password;
+      },
+      clear: () => {
+        draft.current = null;
+      },
+    }),
+    [],
+  );
+
+  return <PasswordDraftContext.Provider value={value}>{children}</PasswordDraftContext.Provider>;
+}
+
+export function usePasswordDraft(): PasswordDraft {
+  const draft = useContext(PasswordDraftContext);
+
+  if (!draft) {
+    throw new Error("usePasswordDraft requires a PasswordDraftProvider above it");
+  }
+
+  return draft;
+}

--- a/features/flow/app-lock/tsconfig.json
+++ b/features/flow/app-lock/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["jest"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/features/platform/app-lock/src/index.ts
+++ b/features/platform/app-lock/src/index.ts
@@ -2,3 +2,4 @@ export * from "./state/schema";
 export * from "./state/types";
 export * from "./biometrics";
 export * from "./errors";
+export * from "./password";

--- a/features/platform/app-lock/src/password.test.ts
+++ b/features/platform/app-lock/src/password.test.ts
@@ -1,0 +1,24 @@
+import { PASSWORD_MIN_LENGTH, isPasswordLongEnough } from "./password";
+
+describe("isPasswordLongEnough", () => {
+  it("requires six characters", () => {
+    expect(PASSWORD_MIN_LENGTH).toBe(6);
+    expect(isPasswordLongEnough("12345")).toBe(false);
+    expect(isPasswordLongEnough("123456")).toBe(true);
+  });
+
+  it("accepts any character class", () => {
+    expect(isPasswordLongEnough("!@#$%^")).toBe(true);
+    expect(isPasswordLongEnough("      ")).toBe(true);
+    expect(isPasswordLongEnough("éàüñçß")).toBe(true);
+  });
+
+  it("does not trim", () => {
+    expect(isPasswordLongEnough("  ab  ")).toBe(true);
+    expect(isPasswordLongEnough(" abc ")).toBe(false);
+  });
+
+  it("rejects an empty password", () => {
+    expect(isPasswordLongEnough("")).toBe(false);
+  });
+});

--- a/features/platform/app-lock/src/password.ts
+++ b/features/platform/app-lock/src/password.ts
@@ -1,0 +1,5 @@
+export const PASSWORD_MIN_LENGTH = 6;
+
+export function isPasswordLongEnough(password: string): boolean {
+  return password.length >= PASSWORD_MIN_LENGTH;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1743,6 +1743,9 @@ importers:
       '@features/flow-analytics-consent':
         specifier: workspace:*
         version: link:../../features/flow/analytics-consent
+      '@features/flow-app-lock':
+        specifier: workspace:*
+        version: link:../../features/flow/app-lock
       '@features/flow-contacts':
         specifier: workspace:^
         version: link:../../features/flow/contacts
@@ -4950,6 +4953,58 @@ importers:
       react:
         specifier: 19.1.4
         version: 19.1.4
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
+  features/flow/app-lock:
+    dependencies:
+      '@features/platform-app-lock':
+        specifier: workspace:*
+        version: link:../../platform/app-lock
+    devDependencies:
+      '@ledgerhq/lumen-design-core':
+        specifier: 'catalog:'
+        version: 0.1.25
+      '@ledgerhq/lumen-ui-rnative':
+        specifier: 'catalog:'
+        version: 0.1.57(@ledgerhq/lumen-design-core@0.1.25)(@types/react@19.0.14)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@support/jest-features-flow':
+        specifier: workspace:*
+        version: link:../../../support/jest-features-flow
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@testing-library/react-native':
+        specifier: 'catalog:'
+        version: 13.3.3(patch_hash=4f93e75372e62b6dc0f0b2635b62a322b37a3727637bd94a38df1ed8648e2e76)(jest@30.2.0)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react-test-renderer@19.1.4(react@19.1.4))(react@19.1.4)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.0.14
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.36.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.51.0
+      react:
+        specifier: 19.1.4
+        version: 19.1.4
+      react-native:
+        specifier: 'catalog:'
+        version: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
+      react-test-renderer:
+        specifier: 'catalog:'
+        version: 19.1.4(react@19.1.4)
       typescript:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
@@ -49443,6 +49498,18 @@ snapshots:
       react-i18next: 14.1.3(i18next@23.10.1)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
       react-native-svg: 15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+    transitivePeerDependencies:
+      - react-dom
+
+  '@ledgerhq/lumen-ui-rnative@0.1.57(@ledgerhq/lumen-design-core@0.1.25)(@types/react@19.0.14)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)':
+    dependencies:
+      '@ledgerhq/lumen-design-core': 0.1.25
+      '@ledgerhq/lumen-utils-shared': 0.1.10(react@19.1.4)
+      '@types/react': 19.0.14
+      i18next: 23.10.1
+      react: 19.1.4
+      react-i18next: 14.1.3(i18next@23.10.1)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
     transitivePeerDependencies:
       - react-dom
 


### PR DESCRIPTION
### 📝 Description

The add-password flow, MVVM per screen, behind `lwmPasswordRevamp`. The legacy stack stays on the flag-off path untouched, and nothing here stores anything yet — the verifier lands in [LIVE-35962](https://ledgerhq.atlassian.net/browse/LIVE-35962), which is why this flow currently closes without writing a password.

Second commit of the [User App Authentication](https://ledgerhq.atlassian.net/browse/LIVE-35505) epic, after #20847. The whole epic is visible in #20905 for context; this is its `feat(app-lock): add the two-step password form` commit, unchanged.

**In the packages**

| | |
|---|---|
| `@features/platform-app-lock` | `PASSWORD_MIN_LENGTH` and `isPasswordLongEnough`. Here rather than in the flow because the migration off short passwords ([LIVE-35980](https://ledgerhq.atlassian.net/browse/LIVE-35980)) needs the same rule. |
| `@features/flow-app-lock` | The package itself, one shared `PasswordField` that every password surface will consume, the `SetupPassword` and `ConfirmPassword` screens, and a `PasswordDraftProvider`. |

`@features/flow-app-lock` starts here rather than in #20847 because a package with an empty public API has no barrel to check, which `enforce-package-structure` rejects outright.

**In the app**

- `LLM/features/AppLock`: containers injecting i18n labels, and a navigator on `createLumenNativeStackNavigator` + `getStackNavigationConfigV4` with two real routes, so the header, description and back button come from the navigator instead of a hand-rolled NavBar.
- `PasswordAddFlowParamList.ConfirmPassword` becomes `undefined`. The legacy screens move to `LegacyPasswordAddFlowParamList`, which keeps the password-in-params shape until they are removed.

**Decisions worth a look**

- **The draft is not a navigation param.** Navigation state is serialisable and gets persisted; a ref never enters the tree devtools inspect. `PasswordDraftProvider` wraps the stack so the chosen password crosses the two steps in memory only.
- **Validation is length only** — no trimming, every character class counts.
- **Confirming leaves the flow with `getParent()?.goBack()`.** A plain `goBack()` pops one screen, which is the enter-password step; this returns to whatever opened the flow, Settings or onboarding, since the navigator is registered in both.
- **The CTA is pinned to the foot of the screen**, as the design shows, which means the keyboard has to be accounted for: the screens pad themselves by the measured keyboard height rather than using the app's `KeyboardAvoidingView`, which leaves its padding behind after a dismissal and put the CTA halfway up the screen once the keyboard had opened and closed. Measured from the keyboard's position, so a window that `adjustResize` shrank needs nothing while an edge-to-edge one needs the whole keyboard, and a screen that mounts with the keyboard already up — the confirm step, arriving from the step before it — pads itself without waiting for an event that has already been and gone.

### 🧪 Tests

18 unit tests: the two view models (validation, mismatch, draft handoff, exit) and the keyboard inset (both window behaviours, and the mount-with-keyboard-up case).

Verified locally: `typecheck`, `test`, `format:check`, `lint`, `enforce-package-structure`, `enforce-boundaries:lint:boundaries`, and `pnpm install --frozen-lockfile` on this commit alone.

### 👀 QA

Enable `lwmPasswordRevamp`, then Settings → Password lock:

- the two steps show the shared field with its reveal toggle, the label floats, and Continue only lights up at six characters;
- a mismatched confirmation says so in place and keeps you on the step;
- confirming returns to Settings, not to step one. **The switch stays off** — storing the verifier is LIVE-35962;
- with the keyboard up, the CTA sits above it on both steps, and stays where it belongs after the keyboard has been dismissed once.

With the flag off, the legacy screens are unchanged.

https://github.com/user-attachments/assets/18944395-d9a7-462a-bc21-6a0c5f7a2e86

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35961](https://ledgerhq.atlassian.net/browse/LIVE-35961) (epic: [LIVE-35505](https://ledgerhq.atlassian.net/browse/LIVE-35505))
- **Guideline**: [Monorepo DDD Re-architecture: Structure & Flow](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/6111232117)
- **Related**: #20847 (merged, the packages this builds on) and #20905 (the whole epic, for review context)


[LIVE-35962]: https://ledgerhq.atlassian.net/browse/LIVE-35962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-35980]: https://ledgerhq.atlassian.net/browse/LIVE-35980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-35961]: https://ledgerhq.atlassian.net/browse/LIVE-35961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ