### PR TITLE
[LWDM] perf(wallet-api): bound CAL token lookups in currency.list

### DIFF
--- a/.changeset/bright-tokens-bounded.md
+++ b/.changeset/bright-tokens-bounded.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Bound the concurrency of CAL token lookups in the `currency.list` wallet-api handler. It resolved every requested token id in a single unbounded `Promise.all`, so a live app asking for hundreds of tokens fired hundreds of simultaneous requests. Measured against the real CAL API with the ids the Buy screen requests, that took 75.6s and 251 of 627 requests failed outright — and a failed lookup is silently dropped, so the returned currency list was quietly incomplete. Bounded, none fail. Note this is a correctness fix only: CAL exposes no bulk id endpoint, so the request count is fixed, and raising the bound does not make the call faster — measured on an Android emulator, going from 10 to 25 in flight took the same 624 lookups from 67.5s to 88.8s, because the connection is throughput-limited rather than latency-limited

--- a/libs/ledger-live-common/src/wallet-api/react.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.test.ts
@@ -11,6 +11,7 @@ import type { useWalletAPIServerOptions } from "./react";
 import { AccountPublicKeyUnavailable } from "../errors";
 import { accountGetPublicKeyLogic } from "./logic";
 import { getAccountIdFromWalletAccountId, resolveWalletApiSpendableBalance } from "./converters";
+import { getCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
 
 const mockSetHandler = jest.fn();
 const mockSetConfig = jest.fn();
@@ -81,7 +82,7 @@ jest.mock("../currencies", () => ({
 }));
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { useWalletAPIServer } = require("./react");
+const { useWalletAPIServer, TOKEN_LOOKUP_CONCURRENCY } = require("./react");
 
 function getRegisteredHandler<Name extends keyof WalletHandlers>(name: Name): WalletHandlers[Name] {
   const calls = mockSetHandler.mock.calls.filter(([handlerName]) => handlerName === name);
@@ -304,6 +305,51 @@ describe("account.list handler", () => {
     expect(result).toEqual([expect.objectContaining({ spendableBalance })]);
     expect(resolveWalletApiSpendableBalance).toHaveBeenCalledTimes(1);
     expect(resolveWalletApiSpendableBalance).toHaveBeenCalledWith(account, account);
+  });
+});
+
+describe("currency.list handler — token lookup concurrency", () => {
+  const getHandler = () => getRegisteredHandler("currency.list");
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  /**
+   * Regression for QAA-1497. The handler used to resolve every requested token id in a
+   * single unbounded `Promise.all`. Measured against the real CAL API with the ids the
+   * Buy screen asks for, that took 75.6s and 251 of the requests failed outright;
+   * bounding the pool took 5.9s with none failing. A failed lookup resolves to null and
+   * is silently dropped, so the unbounded version also returned an incomplete list.
+   * This pins the bound so a future refactor cannot quietly restore the fan-out.
+   */
+  it("never has more than TOKEN_LOOKUP_CONCURRENCY lookups in flight", async () => {
+    const tokenIds = Array.from(
+      { length: TOKEN_LOOKUP_CONCURRENCY * 8 },
+      (_, i) => `ethereum/erc20/token_${i}`,
+    );
+    let inFlight = 0;
+    let peakInFlight = 0;
+
+    const findTokenById = jest.fn(async () => {
+      inFlight += 1;
+      peakInFlight = Math.max(peakInFlight, inFlight);
+      await new Promise(resolve => setTimeout(resolve, 0));
+      inFlight -= 1;
+      return null;
+    });
+    jest.mocked(getCryptoAssetsStore).mockReturnValue({ findTokenById } as never);
+
+    renderHook(() => useWalletAPIServer(createDefaultOptions()));
+    await getHandler()({ currencyIds: tokenIds });
+
+    expect(findTokenById).toHaveBeenCalledTimes(tokenIds.length);
+    expect(peakInFlight).toBeGreaterThan(1);
+    expect(peakInFlight).toBeLessThanOrEqual(TOKEN_LOOKUP_CONCURRENCY);
   });
 });
 

--- a/libs/ledger-live-common/src/wallet-api/react.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.ts
@@ -36,6 +36,7 @@ import {
 import { getMainAccount, getParentAccount } from "../account";
 import { listSupportedCurrencies } from "../currencies";
 import { getCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
+import { promiseAllBatched } from "@ledgerhq/live-promise";
 import { TrackingAPI } from "./tracking";
 import {
   bitcoinFamilyAccountGetXPubLogic,
@@ -287,6 +288,32 @@ export type useWalletAPIServerOptions = {
   customHandlers?: WalletAPICustomHandlers;
 };
 
+/**
+ * Max parallel CAL token lookups in the `currency.list` handler.
+ *
+ * CAL exposes no bulk id endpoint - verified: `?id=a,b,c` returns an empty array with
+ * no error and `?id=a&id=b` is rejected 400 - so a live app asking for hundreds of
+ * tokens means hundreds of requests. The Buy screen currently asks for 736 of them.
+ *
+ * The bound exists for correctness. Unbounded, the connection pool is exhausted and a
+ * large share of the lookups fail; a failed lookup returns null and is dropped silently
+ * below, so unbounded fan-out yields a quietly incomplete currency list. Measured with
+ * the real ids against the real CAL API: unbounded = 75.6s with 251 of 627 failing;
+ * bounded = none failing.
+ *
+ * It is NOT a way to make the call fast, and raising it makes things worse. Measured
+ * on an Android emulator with the same 624 lookups:
+ *
+ *   bound 10 -> 67.5s, mean 747ms per request,  9.24 req/s
+ *   bound 25 -> 88.8s, mean 2369ms per request, 7.03 req/s
+ *
+ * The pipe is throughput-limited, not latency-limited: the extra concurrency bought
+ * nothing but queueing and cost 24% of the throughput. Whatever the ceiling is, more
+ * parallelism does not raise it. The only lever that moves this number is asking for
+ * fewer tokens - see QAA-1497.
+ */
+export const TOKEN_LOOKUP_CONCURRENCY = 10;
+
 export function useWalletAPIServer({
   accountNames,
   manifest,
@@ -443,14 +470,19 @@ export function useWalletAPIServer({
         includedCurrencies = allCurrencies.filter(c => specificCurrencies.has(c.id));
       }
 
-      // 6. Fetch specific tokens by ID if any
+      // 6. Fetch specific tokens by ID if any.
+      // One request per token — CAL has no bulk id lookup — and the Buy screen asks for
+      // 736. See TOKEN_LOOKUP_CONCURRENCY for why this is bounded and why at that value.
       const specificTokens: WalletAPICurrency[] = [];
       if (specificTokenIds.size > 0) {
-        const tokenPromises = [...specificTokenIds].map(async tokenId => {
-          const token = await getCryptoAssetsStore().findTokenById(tokenId);
-          return token ? currencyToWalletAPICurrency(token) : null;
-        });
-        const resolvedTokens = await Promise.all(tokenPromises);
+        const resolvedTokens = await promiseAllBatched(
+          TOKEN_LOOKUP_CONCURRENCY,
+          [...specificTokenIds],
+          async tokenId => {
+            const token = await getCryptoAssetsStore().findTokenById(tokenId);
+            return token ? currencyToWalletAPICurrency(token) : null;
+          },
+        );
         specificTokens.push(...resolvedTokens.filter((t): t is WalletAPICurrency => t !== null));
       }
 


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Any live app calling `currency.list` with specific token ids — Buy/Sell, Swap, Earn, Discover, Card — on Desktop and Mobile.
      - The completeness of the currency list those apps receive, which was previously incomplete without any error.
      - Time to render any screen that waits on `currency.list`.

### Description

**Problem.** `currency.list` resolved every requested token id in a single unbounded `Promise.all`:

```ts
const tokenPromises = [...specificTokenIds].map(async tokenId => {
  const token = await getCryptoAssetsStore().findTokenById(tokenId);
  return token ? currencyToWalletAPICurrency(token) : null;
});
const resolvedTokens = await Promise.all(tokenPromises);
```

`findTokenById` is a network-only lookup, and CAL has no bulk-by-ids endpoint — verified against the live API: `?id=a,b,c` returns an **empty array with no error**, `?id=a&id=b` is rejected `400`. So a live app asking for hundreds of tokens fired hundreds of simultaneous requests, and the RPC awaited the slowest.

**This is a correctness bug, not only a performance one.** Measured against the real CAL API with the ids the Buy screen sends: **251 of 627 requests failed outright**. A failed lookup resolves to `null` and is dropped by the very next line, so the currency list handed to the live app was **quietly incomplete**, with nothing surfaced anywhere. CAL also advertises `x-rate-limit-limit: 500`, so the old code fired 627 concurrent requests against a 500 limit.

**Solution.** Bound the pool with `promiseAllBatched` from `@ledgerhq/live-promise` — already a dependency, and the established pattern for this in `coin-kaspa/src/logic/history/scanOperations.ts` and `coin-hedera/src/bridge/utils.ts`. With the bound, none fail.

**Trade-off, stated explicitly.** This does not make the call fast, and raising the bound makes it worse. Measured on-device, same 624 lookups:

| Bound | Wall time | Mean per request | Throughput |
| --- | --- | --- | --- |
| 10 | 67.5s | 747ms | 9.24 req/s |
| 25 | 88.8s | 2369ms | 7.03 req/s |

Measured peak overlap was exactly 25, so the transport was not capping it — the connection is throughput-limited rather than latency-limited, and extra concurrency only adds queueing. The Buy screen stays at 80–151s until the caller asks for fewer ids: [LIVE-36229](https://ledgerhq.atlassian.net/browse/LIVE-36229).

Note also that the bound is **per call**, not global — two live apps calling `currency.list` concurrently each get their own pool.

### Validation

All runs below are on the combined branch this was split out of, so they are evidence for **this change**, not for this branch in isolation.

| Evidence | Result |
| --- | --- |
| Regression test pinning the bound | verified red first: `Expected: <= 10, Received: 120` |
| Replay of the real 627 ids against the live CAL API | unbounded: 75.6s, **251 failed**. Bounded: none failed. |
| [On-device measurement](https://github.com/LedgerHQ/ledger-live/actions/runs/32148010936) | `Ledger Wallet Network Summary` reports true peak overlap of **exactly 10** — the bound is provably active, and all 624 lookups returned 200 |
| [Raising the bound to 25](https://github.com/LedgerHQ/ledger-live/actions/runs/32238954146) | 67.5s → **88.8s**, throughput −24%. Reverted; this is why the bound stays at 10. |
| [Desktop E2E](https://github.com/LedgerHQ/ledger-live/actions/runs/32111343352) | 46 passed |
| [buySell + portfolio, Android](https://github.com/LedgerHQ/ledger-live/actions/runs/32354389376) | ✅ 5/5 shards |

**What this does not show.** The screen getting faster. It does not — see the trade-off above. The evidence here is that the list is now *complete*, not that it is quick.

### Context

- **JIRA or GitHub link**: [QAA-1505](https://ledgerhq.atlassian.net/browse/QAA-1505) — parent [QAA-1497](https://ledgerhq.atlassian.net/browse/QAA-1497)
- Full investigation: [The Android Nightly Investigation](https://claude.ai/code/artifact/b75482ca-2615-41e9-b9f2-8fa6661fe6b2)
- Split out of #20926.

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-36229]: https://ledgerhq.atlassian.net/browse/LIVE-36229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
