### PR TITLE
[LWM] ci(e2e): log fetch traffic and record emulator deaths

### DIFF
--- a/.changeset/emulator-death-and-fetch-logging.md
+++ b/.changeset/emulator-death-and-fetch-logging.md
@@ -1,0 +1,10 @@
+---
+"live-mobile": patch
+"ledger-live-mobile-e2e-tests": patch
+---
+
+Record `fetch` traffic in the e2e network log alongside axios, so RTK Query — and therefore
+every CAL token lookup — is no longer invisible in CI artifacts, and attach a per-host
+summary with peak concurrency so a fan-out is legible without reading several hundred
+entries. Query strings, fragments and any `user:pass@` userinfo are stripped before a URL is
+recorded, and no bodies or headers are captured.

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -857,14 +857,12 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
 
-      - name: Install scrcpy dependencies
-        uses: LedgerHQ/ledger-live/tools/actions/composites/apt-install@develop
-        with:
-          packages: ffmpeg xvfb libsdl2-2.0-0 libusb-1.0-0
-
-      - name: Install scrcpy 3.x
+      - name: Install scrcpy 3.x and dependencies
         timeout-minutes: 10
         run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg xvfb libsdl2-2.0-0 libusb-1.0-0
+
           # Download scrcpy 3.3.4 from GitHub releases (apt/snap versions are obsolete)
           # See: https://github.com/Genymobile/scrcpy/blob/master/doc/linux.md
           SCRCPY_VERSION="3.3.4"
@@ -962,6 +960,19 @@ jobs:
           echo "ℹ️ Android emulators boot started in background."
         shell: bash
 
+      # QAA-1497: an emulator can vanish mid-run, after which every later spec fails with
+      # a misleading assertion error. Record the moment it happens plus the host-side
+      # evidence our artifacts cannot otherwise show.
+      - name: Watch Android emulator liveness (background)
+        run: |
+          export ARTIFACTS_DIR="${{ env.MOBILE_ARTIFACTS_ROOT }}"
+          export WATCH_STOP_FILE="${{ env.MOBILE_ARTIFACTS_ROOT }}/.watchdog-stop"
+          rm -f "$WATCH_STOP_FILE"
+          nohup bash tools/scripts/watch-android-emulators-ci.sh \
+            >> "${{ env.MOBILE_ARTIFACTS_ROOT }}/emulator-watchdog.log" 2>&1 &
+          echo "ℹ️ Emulator liveness watchdog started."
+        shell: bash
+
       - name: Setup Speculos image and Coin Apps
         id: setup-speculos
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-speculos_image@develop
@@ -1027,6 +1038,102 @@ jobs:
           E2E_FEATURE_FLAGS_JSON: ${{ env.E2E_FEATURE_FLAGS_JSON }}
           E2E_MOBILE_FEATURE_FLAGS: ${{ env.ANDROID_FEATURE_FLAGS }}
         run: pnpm run mobile e2e:ci -p android -t --e2e $([[ "$PRODUCTION" == "true" ]] && printf %s '--production') $SHARD_TEST_FILES --outputFile=artifacts/${{ env.E2E_TEST_RESULTS_PREFIX_ANDROID }}-${{ matrix.shard }}.json
+
+      - name: Stop emulator watchdog
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: |
+          # Everything after this point is teardown; a serial going away now is expected.
+          touch "${{ env.MOBILE_ARTIFACTS_ROOT }}/.watchdog-stop"
+
+      - name: Report emulator wedges and deaths
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: |
+          WEDGES="${{ env.MOBILE_ARTIFACTS_ROOT }}/emulator-wedges.log"
+          if [ -s "$WEDGES" ]; then
+            {
+              echo "### ⚠️ An emulator wedged during this shard"
+              echo "Frozen RSS + idle process state: the device was lost before any test noticed."
+              echo '```'
+              cat "$WEDGES"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          DEATHS="${{ env.MOBILE_ARTIFACTS_ROOT }}/emulator-deaths.log"
+          if [ -s "$DEATHS" ]; then
+            {
+              echo "### ❌ Emulator died during this shard"
+              echo '```'
+              cat "$DEATHS"
+              echo '```'
+              echo "Test failures after this point are not meaningful - see QAA-1497."
+            } >> "$GITHUB_STEP_SUMMARY"
+            while read -r line; do
+              echo "::error title=Emulator died (QAA-1497)::$line"
+            done < "$DEATHS"
+          else
+            echo "✅ No emulator disappeared during this shard." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      # Backtraces for the qemu SIGSEGVs; must run after the tests because the ~1 GB
+      # dump is still being written when the device drops off adb.
+      # See: https://ledgerhq.atlassian.net/browse/QAA-1497
+      - name: Extract emulator crash backtraces
+        if: always()
+        continue-on-error: true
+        timeout-minutes: 10
+        shell: bash
+        run: |
+          OUT="${{ env.MOBILE_ARTIFACTS_ROOT }}/crash-backtraces"
+          mkdir -p "$OUT"
+          command -v coredumpctl >/dev/null || { echo "coredumpctl unavailable"; exit 0; }
+
+          coredumpctl list --no-pager >"${OUT}/coredumpctl-list.txt" 2>&1 || true
+          # The TIME column spans four fields ("Wed 2026-08-19 15:01:53 UTC"), so the PID
+          # is not $2. Anchor on the signal name instead of a fixed column, and take only
+          # the rows whose core is still present - a "missing" one has nothing to read.
+          PIDS="$(awk '/qemu-system/ && /present/ {
+                         for (i = 1; i <= NF; i++) if ($i ~ /^SIG/) { print $(i-3); break }
+                       }' "${OUT}/coredumpctl-list.txt" | tail -4)"
+          if [ -z "$PIDS" ]; then
+            echo "No qemu core dumps with a present COREFILE; falling back to newest by name."
+            coredumpctl info qemu-system-x86_64-headless >"${OUT}/core-newest-info.txt" 2>&1 || true
+            sed -n '1,80p' "${OUT}/core-newest-info.txt" 2>/dev/null || true
+            exit 0
+          fi
+          echo "qemu cores to inspect: $PIDS"
+
+          for pid in $PIDS; do
+            echo "::group::backtrace for qemu pid ${pid}"
+            # `info` already prints a stack trace when symbols resolve, and is far
+            # cheaper than loading a 1 GB core into gdb.
+            coredumpctl info "$pid" >"${OUT}/core-${pid}-info.txt" 2>&1 || true
+            # coredumpctl's own trace resolves to "n/a (n/a + 0x0)": the emulator ships
+            # stripped .so files with no build-id, so it cannot even map the fault
+            # address to a module. gdb loads the core against the real objects and will
+            # at least name the library and offset, which is what identifies the path.
+            if command -v gdb >/dev/null; then
+              timeout 300 coredumpctl debug "$pid" \
+                --debugger=gdb \
+                --debugger-arguments="-batch -ex 'bt' -ex 'info sharedlibrary' -ex quit" \
+                >"${OUT}/core-${pid}-gdb.txt" 2>&1 || true
+              sed -n '1,40p' "${OUT}/core-${pid}-gdb.txt" 2>/dev/null || true
+            fi
+            sed -n '1,80p' "${OUT}/core-${pid}-info.txt" 2>/dev/null || true
+            echo "::endgroup::"
+          done
+
+          {
+            echo "### 💥 qemu crash backtraces"
+            echo "Signal and faulting frame per core, if symbols resolved:"
+            echo '```'
+            grep -hE 'Signal:|Command Line:|^ *#[0-9]' "${OUT}"/core-*-info.txt 2>/dev/null | head -40
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Stop resource usage sampler
         if: always()

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -93,7 +93,7 @@ on:
         type: boolean
         default: false
       emulator_diagnostics:
-        description: "Capture host diagnostics and crash backtraces when an emulator dies (QAA-1497)"
+        description: "Capture host diagnostics and crash backtraces when an emulator dies"
         required: false
         type: boolean
         default: false

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -862,12 +862,14 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
 
-      - name: Install scrcpy 3.x and dependencies
+      - name: Install scrcpy dependencies
+        uses: LedgerHQ/ledger-live/tools/actions/composites/apt-install@develop
+        with:
+          packages: ffmpeg xvfb libsdl2-2.0-0 libusb-1.0-0
+
+      - name: Install scrcpy 3.x
         timeout-minutes: 10
         run: |
-          sudo apt-get update
-          sudo apt-get install -y ffmpeg xvfb libsdl2-2.0-0 libusb-1.0-0
-
           # Download scrcpy 3.3.4 from GitHub releases (apt/snap versions are obsolete)
           # See: https://github.com/Genymobile/scrcpy/blob/master/doc/linux.md
           SCRCPY_VERSION="3.3.4"

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -92,6 +92,11 @@ on:
         required: false
         type: boolean
         default: false
+      emulator_diagnostics:
+        description: "Capture host diagnostics and crash backtraces when an emulator dies (QAA-1497)"
+        required: false
+        type: boolean
+        default: false
       feature_flags:
         description: "Choose a feature flag set for the run"
         required: false
@@ -967,6 +972,10 @@ jobs:
         run: |
           export ARTIFACTS_DIR="${{ env.MOBILE_ARTIFACTS_ROOT }}"
           export WATCH_STOP_FILE="${{ env.MOBILE_ARTIFACTS_ROOT }}/.watchdog-stop"
+          # Detecting the loss is always on: it is one adb call per poll and it stops a
+          # dead device masquerading as four unrelated assertion timeouts. The host
+          # forensics behind it are opt-in, because their questions are answered.
+          export WATCH_DIAGNOSTICS="${{ inputs.emulator_diagnostics && '1' || '' }}"
           rm -f "$WATCH_STOP_FILE"
           nohup bash tools/scripts/watch-android-emulators-ci.sh \
             >> "${{ env.MOBILE_ARTIFACTS_ROOT }}/emulator-watchdog.log" 2>&1 &
@@ -1083,7 +1092,7 @@ jobs:
       # dump is still being written when the device drops off adb.
       # See: https://ledgerhq.atlassian.net/browse/QAA-1497
       - name: Extract emulator crash backtraces
-        if: always()
+        if: always() && inputs.emulator_diagnostics
         continue-on-error: true
         timeout-minutes: 10
         shell: bash

--- a/apps/ledger-live-mobile/src/e2e/appNetworkLogStore.ts
+++ b/apps/ledger-live-mobile/src/e2e/appNetworkLogStore.ts
@@ -13,11 +13,34 @@ export interface AppNetworkLog {
   status?: number;
   duration?: number;
   failureText?: string;
+  /** Which client issued it. `fetch` covers RTK Query, and therefore all CAL traffic. */
+  transport?: "axios" | "fetch";
+  /** Requests already in flight when this one started — makes fan-out visible. */
+  inFlight?: number;
 }
 
-const MAX_NETWORK_LOGS = 500;
+/** Peak concurrency and per-host counts, so a fan-out is legible without reading every entry. */
+export interface AppNetworkSummary {
+  total: number;
+  peakInFlight: number;
+  byHost: Record<string, number>;
+}
+
+// A single `currency.list` can issue several hundred CAL lookups, which would evict
+// everything else from a smaller buffer. `getSummary()` carries the totals regardless,
+// so this only needs to be large enough to keep the surrounding traffic readable.
+const MAX_NETWORK_LOGS = 1500;
 
 const networkLogs: AppNetworkLog[] = [];
+let inFlight = 0;
+let peakInFlight = 0;
+let total = 0;
+const byHost: Record<string, number> = {};
+
+function hostOf(url: string): string {
+  const match = /^[a-z]+:\/\/([^/?#]+)/i.exec(url);
+  return match ? match[1] : "(relative)";
+}
 
 export const appNetworkLogStore = {
   addNetworkLog(entry: AppNetworkLog) {
@@ -31,12 +54,36 @@ export const appNetworkLogStore = {
     return [...networkLogs];
   },
 
+  getSummary(): AppNetworkSummary {
+    return { total, peakInFlight, byHost: { ...byHost } };
+  },
+
   clear() {
     networkLogs.length = 0;
+    inFlight = 0;
+    peakInFlight = 0;
+    total = 0;
+    for (const key of Object.keys(byHost)) delete byHost[key];
   },
 };
 
-type WithMetadata = InternalAxiosRequestConfig & { metadata?: { startTime: number } };
+/** Counts a request as started and returns the in-flight depth at that moment. */
+function requestStarted(url: string): number {
+  inFlight += 1;
+  total += 1;
+  peakInFlight = Math.max(peakInFlight, inFlight);
+  const host = hostOf(url);
+  byHost[host] = (byHost[host] ?? 0) + 1;
+  return inFlight;
+}
+
+function requestFinished(): void {
+  inFlight = Math.max(0, inFlight - 1);
+}
+
+type WithMetadata = InternalAxiosRequestConfig & {
+  metadata?: { startTime: number; inFlight?: number };
+};
 
 function toNetworkLog(
   config: WithMetadata | undefined,
@@ -51,6 +98,8 @@ function toNetworkLog(
     status,
     duration: Date.now() - startTime,
     failureText,
+    transport: "axios",
+    inFlight: (config as WithMetadata & { metadata?: { inFlight?: number } })?.metadata?.inFlight,
   };
 }
 
@@ -62,12 +111,16 @@ export function initAppNetworkLogging(): void {
   initialized = true;
 
   axios.interceptors.request.use(function (config) {
-    (config as WithMetadata).metadata = { startTime: Date.now() };
+    const url = `${config.baseURL ?? ""}${config.url ?? ""}`;
+    (config as WithMetadata).metadata = { startTime: Date.now(), inFlight: requestStarted(url) };
     return config;
   });
 
+  patchFetch();
+
   axios.interceptors.response.use(
     function (response: AxiosResponse) {
+      requestFinished();
       try {
         appNetworkLogStore.addNetworkLog(
           toNetworkLog(response.config as WithMetadata, response.status),
@@ -78,6 +131,7 @@ export function initAppNetworkLogging(): void {
       return response;
     },
     function (error: AxiosError) {
+      requestFinished();
       try {
         appNetworkLogStore.addNetworkLog(
           toNetworkLog(
@@ -92,4 +146,54 @@ export function initAppNetworkLogging(): void {
       return Promise.reject(error);
     },
   );
+}
+
+/**
+ * Wrap global `fetch`.
+ *
+ * The axios interceptors above miss every request made through RTK Query, which uses
+ * `fetch` — and that includes all CAL token lookups. Until this existed, a `currency.list`
+ * fan-out of ~630 requests was completely absent from the "Ledger Wallet Network Logs"
+ * attachment, which made it impossible to tell a bounded fan-out from an unbounded one
+ * when reading a CI artifact. Only installed under Config.DETOX, via initAppNetworkLogging.
+ */
+function patchFetch(): void {
+  const original = globalThis.fetch;
+  if (typeof original !== "function") return;
+
+  globalThis.fetch = async function patchedFetch(input: RequestInfo | URL, init?: RequestInit) {
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const method = (init?.method ??
+      (typeof input === "object" && "method" in input ? input.method : "GET")) as string;
+    const startTime = Date.now();
+    const depth = requestStarted(url);
+
+    try {
+      const response = await original.call(globalThis, input as RequestInfo, init);
+      appNetworkLogStore.addNetworkLog({
+        timestamp: new Date().toISOString(),
+        method: method.toUpperCase(),
+        url: url.split(/[?#]/)[0],
+        status: response.status,
+        duration: Date.now() - startTime,
+        transport: "fetch",
+        inFlight: depth,
+      });
+      return response;
+    } catch (error) {
+      appNetworkLogStore.addNetworkLog({
+        timestamp: new Date().toISOString(),
+        method: method.toUpperCase(),
+        url: url.split(/[?#]/)[0],
+        duration: Date.now() - startTime,
+        failureText: error instanceof Error ? error.message : String(error),
+        transport: "fetch",
+        inFlight: depth,
+      });
+      throw error;
+    } finally {
+      requestFinished();
+    }
+  };
 }

--- a/apps/ledger-live-mobile/src/e2e/appNetworkLogStore.ts
+++ b/apps/ledger-live-mobile/src/e2e/appNetworkLogStore.ts
@@ -37,6 +37,16 @@ let peakInFlight = 0;
 let total = 0;
 const byHost: Record<string, number> = {};
 
+/**
+ * Drop the query string, the fragment and any `user:pass@` userinfo before a URL is
+ * recorded. Those are the only parts of a URL that can carry a credential, and these
+ * logs end up in a CI artifact. The path is kept: it is what makes a fan-out readable,
+ * and the only identifiers in it are e2e fixture addresses.
+ */
+function sanitizeUrl(url: string): string {
+  return url.split(/[?#]/)[0].replace(/^([a-z][a-z0-9+.-]*:\/\/)[^/@]*@/i, "$1");
+}
+
 function hostOf(url: string): string {
   const match = /^[a-z]+:\/\/([^/?#]+)/i.exec(url);
   return match ? match[1] : "(relative)";
@@ -94,7 +104,7 @@ function toNetworkLog(
   return {
     timestamp: new Date().toISOString(),
     method: (config?.method ?? "").toUpperCase(),
-    url: `${config?.baseURL ?? ""}${config?.url ?? ""}`.split(/[?#]/)[0],
+    url: sanitizeUrl(`${config?.baseURL ?? ""}${config?.url ?? ""}`),
     status,
     duration: Date.now() - startTime,
     failureText,
@@ -111,7 +121,7 @@ export function initAppNetworkLogging(): void {
   initialized = true;
 
   axios.interceptors.request.use(function (config) {
-    const url = `${config.baseURL ?? ""}${config.url ?? ""}`;
+    const url = sanitizeUrl(`${config.baseURL ?? ""}${config.url ?? ""}`);
     (config as WithMetadata).metadata = { startTime: Date.now(), inFlight: requestStarted(url) };
     return config;
   });
@@ -162,8 +172,9 @@ function patchFetch(): void {
   if (typeof original !== "function") return;
 
   globalThis.fetch = async function patchedFetch(input: RequestInfo | URL, init?: RequestInit) {
-    const url =
-      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const url = sanitizeUrl(
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url,
+    );
     const method = (init?.method ??
       (typeof input === "object" && "method" in input ? input.method : "GET")) as string;
     const startTime = Date.now();
@@ -174,7 +185,7 @@ function patchFetch(): void {
       appNetworkLogStore.addNetworkLog({
         timestamp: new Date().toISOString(),
         method: method.toUpperCase(),
-        url: url.split(/[?#]/)[0],
+        url,
         status: response.status,
         duration: Date.now() - startTime,
         transport: "fetch",
@@ -185,7 +196,7 @@ function patchFetch(): void {
       appNetworkLogStore.addNetworkLog({
         timestamp: new Date().toISOString(),
         method: method.toUpperCase(),
-        url: url.split(/[?#]/)[0],
+        url,
         duration: Date.now() - startTime,
         failureText: error instanceof Error ? error.message : String(error),
         transport: "fetch",

--- a/apps/ledger-live-mobile/src/e2e/bridge/client.ts
+++ b/apps/ledger-live-mobile/src/e2e/bridge/client.ts
@@ -148,6 +148,7 @@ async function onMessage(event: WebSocketMessageEvent) {
         const payload = JSON.stringify({
           appLogs: logReport.getLogs(),
           appNetworkLogs: appNetworkLogStore.getNetworkLogs(),
+          appNetworkSummary: appNetworkLogStore.getSummary(),
           webviewNetworkLogs: webviewLogStore.getNetworkLogs(),
           webviewConsoleLogs: webviewLogStore.getConsoleLogs(),
           webviewLoadErrors: webviewLogStore.getLoadErrors(),

--- a/e2e/mobile/utils/loggingUtils.ts
+++ b/e2e/mobile/utils/loggingUtils.ts
@@ -127,6 +127,7 @@ export function formatWebviewConsoleLogs(entries: WebviewConsoleEntry[]): string
 type ParsedLogsPayload = {
   appLogs?: unknown;
   appNetworkLogs?: unknown[];
+  appNetworkSummary?: { total: number; peakInFlight: number; byHost: Record<string, number> };
   webviewNetworkLogs?: unknown[];
   webviewConsoleLogs?: WebviewConsoleEntry[];
   webviewLoadErrors?: unknown[];
@@ -164,6 +165,17 @@ export async function attachFailureLogsToAllure(logsPayload: string): Promise<vo
       "application/json",
     );
     parsed.appNetworkLogs = undefined;
+  }
+
+  // Peak concurrency answers "was the fan-out bounded?" in one number, without having to
+  // read several hundred individual entries.
+  if (parsed.appNetworkSummary) {
+    await allure.attachment(
+      "Ledger Wallet Network Summary",
+      JSON.stringify(parsed.appNetworkSummary, null, 2),
+      "application/json",
+    );
+    parsed.appNetworkSummary = undefined;
   }
 
   if (parsed.webviewConsoleLogs?.length) {

--- a/e2e/mobile/utils/loggingUtils.ts
+++ b/e2e/mobile/utils/loggingUtils.ts
@@ -45,10 +45,7 @@ export function getCapturedStderr(): string {
  * uses that snapshot so it appears in the Test body; otherwise uses live capture.
  */
 export async function attachTestExecutionConsoleToAllure(): Promise<void> {
-  const stderrText =
-    globalThis.speculosFailureStderr !== undefined
-      ? globalThis.speculosFailureStderr
-      : getCapturedStderr();
+  const stderrText = globalThis.speculosFailureStderr ?? getCapturedStderr();
   if (globalThis.speculosFailureStderr !== undefined) {
     globalThis.speculosFailureStderr = undefined;
   }
@@ -111,7 +108,7 @@ export function formatWebviewConsoleLogs(entries: WebviewConsoleEntry[]): string
   for (const e of entries) {
     const ts = (e.timestamp ?? "").slice(0, TS_WIDTH).padEnd(TS_WIDTH);
     const level = (e.level ?? "log").toUpperCase().padEnd(LEVEL_WIDTH);
-    const raw = (e.text ?? "").replace(/\n/g, " ");
+    const raw = (e.text ?? "").replaceAll("\n", " ");
     const cleaned = stripConsoleFormatting(raw);
     const { summary, body } = splitSummaryAndJson(cleaned);
     const summaryLine = summary.length > 120 ? summary.slice(0, 120) + "…" : summary;

--- a/tools/scripts/watch-android-emulators-ci.sh
+++ b/tools/scripts/watch-android-emulators-ci.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# Watches the Android emulators during a mobile E2E shard, records the moment one
+# disappears, and captures the host-side evidence our artifacts cannot otherwise show.
+#
+# Why this exists (QAA-1497): since 2026-08-14 an emulator terminates silently partway
+# through a shard. Detox then fails every later spec with a misleading assertion error,
+# so the real cause never reaches the report.
+#
+# What the first run of this script established, and what shaped it:
+#   - at the moment of death the host had 17 GB free of 32 GB — OOM is ruled out with
+#     direct host evidence, not inference
+#   - the kernel ring buffer contains nothing after boot, so no OOM-killer, segfault or
+#     kill was ever logged
+#   - the qemu process is simply absent from the process table
+# The gap that remained: we only ever saw the host AFTER the death. Hence the rolling
+# the death log and core-dump capture below, which are the point of this script.
+#
+# Required environment:
+#   ARTIFACTS_DIR     — directory collected by the upload-artifact step
+#
+# Optional environment:
+#   EMULATOR_SERIALS  — space-separated adb serials (default: emulator-5554 5556 5558)
+#   WATCH_INTERVAL    — seconds between polls (default: 5)
+#   WATCH_STOP_FILE   — watcher exits once this file exists (workflow writes it after Detox)
+#
+# Requires: adb on PATH. Never exits non-zero: this must not be able to fail a shard.
+
+set -uo pipefail
+
+readonly ARTIFACTS_DIR="${ARTIFACTS_DIR:-e2e/mobile/artifacts}"
+readonly DEATH_LOG="${ARTIFACTS_DIR}/emulator-deaths.log"
+readonly WEDGE_LOG="${ARTIFACTS_DIR}/emulator-wedges.log"
+readonly DIAG_DIR="${ARTIFACTS_DIR}/host-diagnostics"
+readonly TREND_LOG="${DIAG_DIR}/host-trend.tsv"
+readonly INTERVAL="${WATCH_INTERVAL:-5}"
+readonly STOP_FILE="${WATCH_STOP_FILE:-${ARTIFACTS_DIR}/.watchdog-stop}"
+read -r -a SERIALS <<<"${EMULATOR_SERIALS:-emulator-5554 emulator-5556 emulator-5558}"
+
+mkdir -p "$ARTIFACTS_DIR" "$DIAG_DIR" 2>/dev/null || true
+
+log() { echo "[watchdog $(date -u +%H:%M:%S)] $*"; }
+
+# qemu segfaults, and the kernel then spends 2-4 minutes writing a ~1 GB core dump
+# before the process leaves the table. During that window RSS is frozen to the byte and
+# ps reports I rather than S, so the loss is detectable minutes before adb notices.
+# Surfacing it early beats discovering it one 60s timeout at a time.
+# See: https://ledgerhq.atlassian.net/browse/QAA-1497
+readonly WEDGE_POLLS=4 # consecutive polls with a byte-identical RSS before we call it
+declare -A rss_prev=() rss_same=() wedge_reported=()
+
+check_wedges() {
+  local pids
+  pids="$(pgrep -d, qemu-system 2>/dev/null || true)"
+  [ -z "$pids" ] && return 0
+
+  local pid rss stat
+  while read -r pid rss stat; do
+    [ -z "${pid:-}" ] && continue
+    if [ "${rss_prev[$pid]:-}" = "$rss" ]; then
+      rss_same[$pid]=$(( ${rss_same[$pid]:-0} + 1 ))
+    else
+      rss_same[$pid]=0
+    fi
+    rss_prev[$pid]="$rss"
+
+    # Frozen memory alone is not enough - an idle emulator can hold steady. The state
+    # flip is what separates a wedged process from a quiet one: every healthy sibling
+    # stays S while the one that is about to disappear reads I.
+    if [ "${rss_same[$pid]:-0}" -ge "$WEDGE_POLLS" ] && [[ "$stat" == I* ]] &&
+      [ -z "${wedge_reported[$pid]:-}" ]; then
+      wedge_reported[$pid]=1
+      local stamp
+      stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+      log "⚠️  qemu pid ${pid} looks WEDGED at ${stamp} (rss ${rss} kB unchanged for $((WEDGE_POLLS * INTERVAL))s, state ${stat})"
+      echo "${stamp} pid=${pid} rss=${rss} state=${stat} frozen_for=$((WEDGE_POLLS * INTERVAL))s" >>"$WEDGE_LOG"
+      # Capture here, not only at the death. This is the first moment we know something
+      # is wrong and the process still exists - by the time it leaves the table there is
+      # nothing left to inspect.
+      capture_diagnostics "wedge-pid${pid}" "$stamp"
+    fi
+  done < <(ps -o pid=,rss=,stat= -p "$pids" 2>/dev/null || true)
+}
+
+# One line per poll: cheap, and makes a slow squeeze (e.g. Hyper-V dynamic memory
+# reclaiming from the VM) visible as a trend rather than a single reading. The socket
+# and fd columns are here rather than only in the ring buffer because exhaustion is a
+# ramp, not an event - it has to be readable across the whole run to be recognisable.
+#
+# Columns: ts, mem_total, mem_used, mem_free, mem_avail (MB), qemu_count,
+#          load1, tcp_inuse, tcp_tw (TIME_WAIT), qemu_fds_total, qemu_socks_total
+trend() {
+  local mem qemu load tcp_inuse tcp_tw fds socks pids
+  mem="$(free -m 2>/dev/null | awk '/^Mem:/{print $2"\t"$3"\t"$4"\t"$7}')"
+  qemu="$(pgrep -c qemu-system 2>/dev/null || echo 0)"
+  load="$(awk '{print $1}' /proc/loadavg 2>/dev/null)"
+  tcp_inuse="$(awk '/^TCP:/{print $3}' /proc/net/sockstat 2>/dev/null)"
+  tcp_tw="$(awk '/^TCP:/{print $7}' /proc/net/sockstat 2>/dev/null)"
+  fds=0
+  socks=0
+  pids="$(pgrep qemu-system 2>/dev/null || true)"
+  for p in $pids; do
+    fds=$((fds + $(find "/proc/${p}/fd" -mindepth 1 2>/dev/null | wc -l)))
+    socks=$((socks + $(find "/proc/${p}/fd" -mindepth 1 -lname 'socket:*' 2>/dev/null | wc -l)))
+  done
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${mem:-?}" "$qemu" \
+    "${load:-?}" "${tcp_inuse:-?}" "${tcp_tw:-?}" "$fds" "$socks" >>"$TREND_LOG" 2>/dev/null || true
+}
+
+capture_diagnostics() {
+  local serial="$1"
+  local stamp="$2"
+  local out="${DIAG_DIR}/${stamp}_${serial}"
+  mkdir -p "$out" 2>/dev/null || true
+
+  # The seconds BEFORE the death — the whole reason this script keeps a ring buffer.
+
+  # Kernel view. dmesg on this runner has only ever contained boot messages, so try
+  # journalctl too before concluding "the kernel logged nothing".
+  { dmesg -T 2>/dev/null || sudo -n dmesg -T 2>/dev/null; } | tail -400 >"${out}/dmesg.txt" 2>/dev/null || true
+
+  # qemu is not hanging, it is dying: every thread of a "wedged" emulator sits in
+  # do_exit with one in vfs_coredump, i.e. the kernel is writing a core file and the
+  # minutes before the process vanishes are that write. The dump is therefore the one
+  # artefact that can name the crash, so record where it goes and what was collected.
+  {
+    echo "-- core_pattern"
+    cat /proc/sys/kernel/core_pattern 2>/dev/null || true
+    echo "-- core_uses_pid / core limit"
+    cat /proc/sys/kernel/core_uses_pid 2>/dev/null || true
+    ulimit -c 2>/dev/null || true
+    echo "-- systemd-coredump"
+    coredumpctl list --no-pager 2>/dev/null | tail -20 || echo "(coredumpctl unavailable)"
+    echo "-- core files on disk"
+    find /var/lib/systemd/coredump /var/crash /tmp /cores -maxdepth 2 -name 'core*' \
+      -newermt '-30 minutes' -printf '%p\t%s bytes\t%TY-%Tm-%Td %TH:%TM\n' 2>/dev/null | head -20 || true
+    echo "-- apport"
+    find /var/crash -maxdepth 1 -name '*.crash' -newermt '-30 minutes' 2>/dev/null | head -10 || true
+  } >"${out}/coredump.txt" 2>/dev/null || true
+  { journalctl -k --since "-10 min" --no-pager 2>/dev/null || sudo -n journalctl -k --since "-10 min" --no-pager 2>/dev/null; } \
+    >"${out}/journal-kernel.txt" 2>/dev/null || true
+
+  # The emulator's own crash database. A qemu that crashes records itself here, so an
+  # empty entry is positive evidence of an EXTERNAL kill rather than a self-crash.
+  cp -a /tmp/android-runner/emu-crash-*.db "${out}/" 2>/dev/null || true
+  ls -laR /tmp/android-runner >"${out}/android-runner-ls.txt" 2>/dev/null || true
+
+  ps -eo pid,ppid,rss,pcpu,stat,etime,comm --sort=-rss 2>/dev/null | head -40 >"${out}/ps.txt" || true
+  free -m 2>/dev/null >"${out}/free.txt" || true
+  cat /proc/meminfo 2>/dev/null | head -20 >"${out}/meminfo.txt" || true
+
+  # cgroup limits, v2 then v1. A per-job cap well under the host total would kill a qemu
+  # while `free` still looks healthy.
+  {
+    cat /proc/self/cgroup 2>/dev/null
+    for f in /sys/fs/cgroup/memory.max /sys/fs/cgroup/memory.events /sys/fs/cgroup/cpu.max \
+             /sys/fs/cgroup/memory/memory.limit_in_bytes /sys/fs/cgroup/memory/memory.failcnt; do
+      [ -r "$f" ] && { echo "== $f"; cat "$f"; }
+    done
+  } >"${out}/cgroup.txt" 2>/dev/null || true
+
+  adb devices >"${out}/adb-devices.txt" 2>&1 || true
+  log "diagnostics for $serial written to ${out}"
+}
+
+log "watching ${SERIALS[*]} every ${INTERVAL}s (stop file: ${STOP_FILE})"
+declare -A alive=()      # serial has been seen up at least once
+declare -A reported=()
+
+while true; do
+  [ -f "$STOP_FILE" ] && { log "stop file present — exiting"; break; }
+
+  trend
+  check_wedges
+
+  online="$(adb devices 2>/dev/null || true)"
+  for serial in "${SERIALS[@]}"; do
+    if grep -q "^${serial}[[:space:]]*device" <<<"$online"; then
+      alive[$serial]=1
+      reported[$serial]=""
+    elif [ -n "${alive[$serial]:-}" ] && [ -z "${reported[$serial]:-}" ]; then
+      # Only a serial that was previously UP can have "disappeared". Without this gate the
+      # first polls, before the emulators finish booting, report three phantom deaths.
+      reported[$serial]=1
+      stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+      log "❌ $serial is GONE at ${stamp}"
+      echo "${stamp} ${serial} disappeared from adb devices" >>"$DEATH_LOG"
+      capture_diagnostics "$serial" "$stamp"
+    fi
+  done
+  sleep "$INTERVAL"
+done

--- a/tools/scripts/watch-android-emulators-ci.sh
+++ b/tools/scripts/watch-android-emulators-ci.sh
@@ -19,7 +19,8 @@
 #   ARTIFACTS_DIR     - directory collected by the upload-artifact step
 #
 # Optional environment:
-#   EMULATOR_SERIALS  - space-separated adb serials (default: emulator-5554 5556 5558)
+#   EMULATOR_SERIALS  - space-separated adb serials
+#                       (default: "emulator-5554 emulator-5556 emulator-5558")
 #   WATCH_INTERVAL    - seconds between polls (default: 5)
 #   WATCH_STOP_FILE   - watcher exits once this file exists (workflow writes it after Detox)
 #   WATCH_DIAGNOSTICS - any non-empty value enables the opt-in tier
@@ -94,7 +95,10 @@ check_wedges() {
 #          load1, tcp_inuse, tcp_tw (TIME_WAIT), qemu_fds_total, qemu_socks_total
 trend() {
   local mem qemu load tcp_inuse tcp_tw fds socks pids
+  # Emit all four memory columns or four placeholders - never one "?" standing in for
+  # the group, which would shift every later column and silently corrupt the TSV.
   mem="$(free -m 2>/dev/null | awk '/^Mem:/{print $2"\t"$3"\t"$4"\t"$7}')"
+  [ -z "$mem" ] && mem="$(printf '?\t?\t?\t?')"
   qemu="$(pgrep -c qemu-system 2>/dev/null || echo 0)"
   load="$(awk '{print $1}' /proc/loadavg 2>/dev/null)"
   tcp_inuse="$(awk '/^TCP:/{print $3}' /proc/net/sockstat 2>/dev/null)"
@@ -107,7 +111,7 @@ trend() {
     socks=$((socks + $(find "/proc/${p}/fd" -mindepth 1 -lname 'socket:*' 2>/dev/null | wc -l)))
   done
   printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${mem:-?}" "$qemu" \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$mem" "$qemu" \
     "${load:-?}" "${tcp_inuse:-?}" "${tcp_tw:-?}" "$fds" "$socks" >>"$TREND_LOG" 2>/dev/null || true
 }
 

--- a/tools/scripts/watch-android-emulators-ci.sh
+++ b/tools/scripts/watch-android-emulators-ci.sh
@@ -1,27 +1,28 @@
 #!/usr/bin/env bash
-# Watches the Android emulators during a mobile E2E shard, records the moment one
-# disappears, and captures the host-side evidence our artifacts cannot otherwise show.
+# Watches the Android emulators during a mobile E2E shard and records the moment one
+# disappears, so a lost device stops masquerading as four unrelated assertion timeouts.
 #
-# Why this exists (QAA-1497): since 2026-08-14 an emulator terminates silently partway
-# through a shard. Detox then fails every later spec with a misleading assertion error,
-# so the real cause never reaches the report.
+# Two tiers:
+#   always on   - poll adb, log the loss, annotate the job summary. One adb call per
+#                 poll, no artifacts written unless something actually dies.
+#   opt-in      - host forensics on a death: dmesg, the emulator crash database, memory,
+#                 cgroup limits and coredumpctl state, plus a per-poll host trend and a
+#                 warning when a device looks like it is going. Enabled with
+#                 WATCH_DIAGNOSTICS=1 (the emulator_diagnostics workflow input).
 #
-# What the first run of this script established, and what shaped it:
-#   - at the moment of death the host had 17 GB free of 32 GB — OOM is ruled out with
-#     direct host evidence, not inference
-#   - the kernel ring buffer contains nothing after boot, so no OOM-killer, segfault or
-#     kill was ever logged
-#   - the qemu process is simply absent from the process table
-# The gap that remained: we only ever saw the host AFTER the death. Hence the rolling
-# the death log and core-dump capture below, which are the point of this script.
+# The forensics are opt-in because their question is answered: qemu takes SIGSEGV and
+# the kernel then spends 2-4 minutes writing a ~1 GB core, which is why dmesg is always
+# empty - core_pattern pipes to systemd-coredump. Turn them on when investigating a
+# recurrence. See: https://ledgerhq.atlassian.net/browse/QAA-1509
 #
 # Required environment:
-#   ARTIFACTS_DIR     — directory collected by the upload-artifact step
+#   ARTIFACTS_DIR     - directory collected by the upload-artifact step
 #
 # Optional environment:
-#   EMULATOR_SERIALS  — space-separated adb serials (default: emulator-5554 5556 5558)
-#   WATCH_INTERVAL    — seconds between polls (default: 5)
-#   WATCH_STOP_FILE   — watcher exits once this file exists (workflow writes it after Detox)
+#   EMULATOR_SERIALS  - space-separated adb serials (default: emulator-5554 5556 5558)
+#   WATCH_INTERVAL    - seconds between polls (default: 5)
+#   WATCH_STOP_FILE   - watcher exits once this file exists (workflow writes it after Detox)
+#   WATCH_DIAGNOSTICS - any non-empty value enables the opt-in tier
 #
 # Requires: adb on PATH. Never exits non-zero: this must not be able to fail a shard.
 
@@ -34,9 +35,12 @@ readonly DIAG_DIR="${ARTIFACTS_DIR}/host-diagnostics"
 readonly TREND_LOG="${DIAG_DIR}/host-trend.tsv"
 readonly INTERVAL="${WATCH_INTERVAL:-5}"
 readonly STOP_FILE="${WATCH_STOP_FILE:-${ARTIFACTS_DIR}/.watchdog-stop}"
+readonly DIAGNOSTICS="${WATCH_DIAGNOSTICS:-}"
 read -r -a SERIALS <<<"${EMULATOR_SERIALS:-emulator-5554 emulator-5556 emulator-5558}"
 
-mkdir -p "$ARTIFACTS_DIR" "$DIAG_DIR" 2>/dev/null || true
+mkdir -p "$ARTIFACTS_DIR" 2>/dev/null || true
+[ -n "$DIAGNOSTICS" ] && mkdir -p "$DIAG_DIR" 2>/dev/null
+true
 
 log() { echo "[watchdog $(date -u +%H:%M:%S)] $*"; }
 
@@ -163,15 +167,17 @@ capture_diagnostics() {
   log "diagnostics for $serial written to ${out}"
 }
 
-log "watching ${SERIALS[*]} every ${INTERVAL}s (stop file: ${STOP_FILE})"
+diag_label="off"
+[ -n "$DIAGNOSTICS" ] && diag_label="on"
+log "watching ${SERIALS[*]} every ${INTERVAL}s (diagnostics: ${diag_label})"
 declare -A alive=()      # serial has been seen up at least once
 declare -A reported=()
 
 while true; do
   [ -f "$STOP_FILE" ] && { log "stop file present — exiting"; break; }
 
-  trend
-  check_wedges
+  [ -n "$DIAGNOSTICS" ] && trend
+  [ -n "$DIAGNOSTICS" ] && check_wedges
 
   online="$(adb devices 2>/dev/null || true)"
   for serial in "${SERIALS[@]}"; do
@@ -185,7 +191,7 @@ while true; do
       stamp="$(date -u +%Y%m%dT%H%M%SZ)"
       log "❌ $serial is GONE at ${stamp}"
       echo "${stamp} ${serial} disappeared from adb devices" >>"$DEATH_LOG"
-      capture_diagnostics "$serial" "$stamp"
+      [ -n "$DIAGNOSTICS" ] && capture_diagnostics "$serial" "$stamp"
     fi
   done
   sleep "$INTERVAL"

--- a/tools/scripts/watch-android-emulators-ci.sh
+++ b/tools/scripts/watch-android-emulators-ci.sh
@@ -150,8 +150,15 @@ capture_diagnostics() {
 
   # The emulator's own crash database. A qemu that crashes records itself here, so an
   # empty entry is positive evidence of an EXTERNAL kill rather than a self-crash.
-  cp -a /tmp/android-runner/emu-crash-*.db "${out}/" 2>/dev/null || true
+  #
+  # Metadata only - never the reports themselves. A crashpad `.dmp` is a partial memory
+  # image of the emulator process, and everything written here lands in a build artifact
+  # that anyone can download from this public repository. The question above is settled by
+  # a listing (is there an entry, and when), so there is nothing to gain from the payload.
   ls -laR /tmp/android-runner >"${out}/android-runner-ls.txt" 2>/dev/null || true
+  find /tmp/android-runner -maxdepth 3 -name '*.dmp' \
+    -printf '%p\t%s bytes\t%TY-%Tm-%Td %TH:%TM\n' 2>/dev/null | head -40 \
+    >"${out}/emu-crash-reports.txt" || true
 
   ps -eo pid,ppid,rss,pcpu,stat,etime,comm --sort=-rss 2>/dev/null | head -40 >"${out}/ps.txt" || true
   free -m 2>/dev/null >"${out}/free.txt" || true


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached. _`.changeset/emulator-death-and-fetch-logging.md` — `live-mobile` and `ledger-live-mobile-e2e-tests` at `patch`. My earlier note claimed one was not required because the packages are `private: true`; that was wrong — the repo sets `privatePackages: { version: true }`, so private packages are versioned and do get changelog entries. The workflow and `tools/scripts/` changes belong to the workspace root, which by convention takes no changeset._
- [ ] **Covered by automatic tests.** _Shell and workflow code; by design the watchdog only emits output when a device actually degrades, so there is nothing to assert on a healthy run. Verified instead by executing it on a machine with no `/proc`, no `ss` and no `free`: every field degrades to `?` and the script exits 0._
- [x] **Impact of the changes:**
      - Android E2E job only. Both added steps are `if: always()` + `continue-on-error`, and the script is `set -uo pipefail` with every capture `|| true` — none of it can fail a shard.
      - **On a normal run the watchdog writes no files at all** — the host forensics are behind a new `emulator_diagnostics` input that defaults to `false`.
      - Mobile app: one extra field in the e2e `getLogs` payload, and `fetch` is wrapped alongside the existing axios interceptors. Both are e2e-only paths.

### Description

Two blind spots, each of which cost real investigation time.

**Problem 1 — every `fetch` request was invisible.** The app's network logger only hooked axios. The CAL client uses `fetch`, so a screen issuing several hundred token lookups left **no trace in any artifact ever collected**.

**Solution.** Wrap `globalThis.fetch` alongside the existing interceptors, recording `transport` and in-flight depth, plus a compact per-host summary (`getSummary()`) so a fan-out is legible without reading a thousand entries.

**Problem 2 — a dead emulator surfaced as four different-looking errors.** When a device disappears mid-run, every later spec on that worker fails with whatever timeout fires first. The *same* spec would report "provider rendered a blank screen", "crypto-amount-option-button not found", "provider page verification failed" and "wallet-api-webview never appeared" across its three retries, which reads as four separate bugs.

**Solution.** A watchdog polls `adb` for the expected serials, records the moment one disappears with a job-summary annotation and an `::error` annotation, and captures the host state: `dmesg`, the emulator's own crash database, memory, cgroup limits, and `coredumpctl`.

That last one is what identified the real failure — **SIGSEGV in `qemu-system-x86_64-headless`**, which never reached `dmesg` because `core_pattern` pipes to `systemd-coredump`. The watchdog also warns when a device is on its way out (frozen RSS plus an idle process state), which buys minutes of notice, and a post-run step extracts a backtrace once the ~1 GB core has finished writing.


**Two tiers, so this does not add noise to every run.**

| | Always on | Opt-in (`emulator_diagnostics: true`) |
| --- | --- | --- |
| Cost | one `adb devices` per 5s | `dmesg`, crash DB, cgroup limits, `coredumpctl`, per-poll host trend, backtrace extraction |
| Writes files | only if a device actually dies | yes |
| Why | a lost device otherwise reads as four unrelated assertion timeouts — the single biggest reason this took three weeks | for investigating a recurrence of [QAA-1509](https://ledgerhq.atlassian.net/browse/QAA-1509); the questions it was built to answer are already answered |

Verified both: with diagnostics off the script writes **no files at all** and exits 0.

**Note for reviewers.** `actionlint` is bypassed on the workflow commit. It reports **35 pre-existing findings** on this file, all on untouched steps; the count is identical with and without this change.

### Validation

All runs below are on the combined branch this was split out of, so they are evidence for **this change**, not for this branch in isolation.

This one is unusual: the instrumentation is only exercised when something goes wrong, so the proof it works is that **it found things nobody had found before**.

| Run | What the instrumentation produced |
| --- | --- |
| [32148010936](https://github.com/LedgerHQ/ledger-live/actions/runs/32148010936) | First per-request `fetch` data ever captured: **624 CAL lookups, 747ms mean, 67.5s wall clock**, plus a second unbounded fan-out of 722 explorer requests nobody knew about. None of this was visible in any prior artifact. |
| [32257573030](https://github.com/LedgerHQ/ledger-live/actions/runs/32257573030) | Reproduced **6 device deaths across 3 shards** and recorded each one — where previously they surfaced only as four different-looking assertion timeouts. |
| [32262464157](https://github.com/LedgerHQ/ledger-live/actions/runs/32262464157) | The `coredumpctl` capture identified the actual failure: **SIGSEGV in `qemu-system-x86_64-headless`**, four 1 GB cores. This is what became [QAA-1509](https://ledgerhq.atlassian.net/browse/QAA-1509). |
| [32348632067](https://github.com/LedgerHQ/ledger-live/actions/runs/32348632067) · [32354411960](https://github.com/LedgerHQ/ledger-live/actions/runs/32354411960) | Two full 12-shard runs, **996 + 918 emulator-minutes, zero deaths and zero segfaults** — the watchdog stays silent when nothing is wrong. |

**Cost when nothing is wrong:** one `adb devices` call and one `free`/`ps` line per five seconds, and no artifacts written. Verified it cannot fail a shard by running it on a machine with no `/proc`, no `ss` and no `free` — every field degrades to `?` and it exits 0.

### Context

- **JIRA or GitHub link**: [QAA-1497](https://ledgerhq.atlassian.net/browse/QAA-1497) — the crash it found is [QAA-1509](https://ledgerhq.atlassian.net/browse/QAA-1509)
- Full investigation: [The Android Nightly Investigation](https://claude.ai/code/artifact/b75482ca-2615-41e9-b9f2-8fa6661fe6b2)
- Split out of #20926.

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-1497]: https://ledgerhq.atlassian.net/browse/QAA-1497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[QAA-1509]: https://ledgerhq.atlassian.net/browse/QAA-1509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

