### PR TITLE
refactor(data-model): move coin-specific migrations to app level

### DIFF
--- a/.changeset/brave-foxes-sleep.md
+++ b/.changeset/brave-foxes-sleep.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Move Aptos and crypto_org account migrations out of DataModel into app-level accountModel

--- a/apps/ledger-live-desktop/src/helpers/accountModel.test.ts
+++ b/apps/ledger-live-desktop/src/helpers/accountModel.test.ts
@@ -1,0 +1,91 @@
+import { AccountRaw } from "@ledgerhq/types-live";
+import { setCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
+import accountModel from "./accountModel";
+
+setCryptoAssetsStore({
+  findTokenById: async () => undefined,
+  findTokenByAddressInCurrency: async () => undefined,
+  getTokensSyncHash: async () => "",
+});
+
+const baseRaw = {
+  seedIdentifier: "test-seed",
+  derivationMode: "" as AccountRaw["derivationMode"],
+  index: 0,
+  balance: "0",
+  blockHeight: 0,
+  operations: [],
+  pendingOperations: [],
+  lastSyncDate: new Date().toISOString(),
+};
+
+const aptosRaw = (freshAddressPath: string): AccountRaw =>
+  ({
+    ...baseRaw,
+    id: "js:2:aptos:0x1234567890abcdef:",
+    freshAddress: "0x1234567890abcdef",
+    freshAddressPath,
+    currencyId: "aptos",
+  }) as AccountRaw;
+
+// Accounts stored before the migrations were introduced sit at version 1
+// (only the 2018 account-id migration existed at the time).
+const decodeLegacy = (data: AccountRaw) => accountModel.decode({ data, version: 1 });
+
+describe("accountModel migrations", () => {
+  describe("aptos derivation path hardening", () => {
+    it("hardens the 'change' and 'address_index' levels", async () => {
+      const [account] = await decodeLegacy(aptosRaw("44'/637'/0'/0/0"));
+      expect(account.freshAddressPath).toBe("44'/637'/0'/0'/0'");
+    });
+
+    it("hardens non-zero account, change and address_index levels", async () => {
+      const [account] = await decodeLegacy(aptosRaw("44'/637'/12'/3/45"));
+      expect(account.freshAddressPath).toBe("44'/637'/12'/3'/45'");
+    });
+
+    it("leaves an already hardened path untouched", async () => {
+      const path = "44'/637'/0'/0'/0'";
+      const [account] = await decodeLegacy(aptosRaw(path));
+      expect(account.freshAddressPath).toBe(path);
+    });
+
+    it("does not touch non-aptos accounts sharing a similar path shape", async () => {
+      const path = "44'/60'/0'/0/0";
+      const [account] = await decodeLegacy({
+        ...baseRaw,
+        id: "js:2:ethereum:0xabc:",
+        freshAddress: "0xabc",
+        freshAddressPath: path,
+        currencyId: "ethereum",
+      } as AccountRaw);
+      expect(account.freshAddressPath).toBe(path);
+    });
+  });
+
+  describe("crypto_org cosmosResources fallback", () => {
+    const cryptoOrgRaw = (extra: Partial<AccountRaw> = {}): AccountRaw =>
+      ({
+        ...baseRaw,
+        id: "js:2:crypto_org:cosmos1address:",
+        freshAddress: "cosmos1address",
+        freshAddressPath: "44'/394'/0'/0/0",
+        currencyId: "crypto_org",
+        ...extra,
+      }) as AccountRaw;
+
+    it("initialises cosmosResources when missing", async () => {
+      const [account] = await decodeLegacy(cryptoOrgRaw());
+      const { cosmosResources } = account as typeof account & {
+        cosmosResources: Record<string, unknown>;
+      };
+      expect(cosmosResources).toBeDefined();
+      expect(cosmosResources.delegations).toEqual([]);
+      expect(cosmosResources.withdrawAddress).toBe("cosmos1address");
+    });
+  });
+
+  it("exposes a version matching the number of migrations", () => {
+    expect(accountModel.version).toBe(3);
+  });
+});

--- a/apps/ledger-live-desktop/src/helpers/accountModel.ts
+++ b/apps/ledger-live-desktop/src/helpers/accountModel.ts
@@ -1,6 +1,7 @@
 /**
  * @module models/account
  */
+import BigNumber from "bignumber.js";
 import { createDataModel, DataModel } from "@ledgerhq/live-common/DataModel";
 import {
   fromAccountRaw,
@@ -8,6 +9,8 @@ import {
   accountRawToAccountUserData,
 } from "@ledgerhq/live-common/account/index";
 import { Account, AccountRaw, Operation, AccountUserData } from "@ledgerhq/types-live";
+
+const APTOS_NON_HARDENED_DERIVATION_PATH_REGEX = /^44'\/637'\/\d+'\/\d+\/\d+$/;
 
 /**
  * @memberof models/account
@@ -78,6 +81,43 @@ const accountModel: DataModel<AccountRaw, [Account, AccountUserData]> = createDa
         derivationMode,
         seedIdentifier,
       };
+    },
+    // Set 'change' and 'address_index' levels to be hardened for Aptos derivation path
+    raw => {
+      const { currencyId, freshAddressPath } = raw;
+      if (
+        currencyId === "aptos" &&
+        freshAddressPath.match(APTOS_NON_HARDENED_DERIVATION_PATH_REGEX)
+      ) {
+        return {
+          ...raw,
+          freshAddressPath: freshAddressPath
+            .split("/")
+            .map((value: string) => (value.endsWith("'") ? value : value + "'"))
+            .join("/"),
+        };
+      }
+      return raw;
+    },
+    // Initialize cosmosResources for crypto_org accounts missing it
+    raw => {
+      const { currencyId } = raw;
+      if (currencyId === "crypto_org" && !raw.cosmosResources) {
+        return {
+          ...raw,
+          cosmosResources: {
+            delegations: [],
+            redelegations: [],
+            unbondings: [],
+            delegatedBalance: new BigNumber(0),
+            pendingRewardsBalance: new BigNumber(0),
+            unbondingBalance: new BigNumber(0),
+            withdrawAddress: raw.freshAddress,
+            sequence: 0,
+          },
+        };
+      }
+      return raw;
     },
     // ^- Each time a modification is brought to the model, add here a migration function here
   ],

--- a/apps/ledger-live-mobile/src/logic/__tests__/accountModel.test.ts
+++ b/apps/ledger-live-mobile/src/logic/__tests__/accountModel.test.ts
@@ -1,0 +1,87 @@
+import type { AccountRaw } from "@ledgerhq/types-live";
+import { setCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
+import accountModel from "../accountModel";
+
+setCryptoAssetsStore({
+  findTokenById: async () => undefined,
+  findTokenByAddressInCurrency: async () => undefined,
+  getTokensSyncHash: async () => "",
+});
+
+const baseRaw = {
+  seedIdentifier: "test-seed",
+  derivationMode: "" as AccountRaw["derivationMode"],
+  index: 0,
+  balance: "0",
+  blockHeight: 0,
+  operations: [],
+  pendingOperations: [],
+  lastSyncDate: new Date().toISOString(),
+};
+
+const aptosRaw = (freshAddressPath: string): AccountRaw =>
+  ({
+    ...baseRaw,
+    id: "js:2:aptos:0x1234567890abcdef:",
+    freshAddress: "0x1234567890abcdef",
+    freshAddressPath,
+    currencyId: "aptos",
+  }) as AccountRaw;
+
+// Mobile hardcodes the stored version to 0 (see actions/accounts.ts), so every
+// migration replays on each load. Both are idempotent, which the tests below cover.
+const decodeStored = (data: AccountRaw) => accountModel.decode({ data, version: 0 });
+
+describe("accountModel migrations", () => {
+  describe("aptos derivation path hardening", () => {
+    it("hardens the 'change' and 'address_index' levels", async () => {
+      const [account] = await decodeStored(aptosRaw("44'/637'/0'/0/0"));
+      expect(account.freshAddressPath).toBe("44'/637'/0'/0'/0'");
+    });
+
+    it("hardens non-zero account, change and address_index levels", async () => {
+      const [account] = await decodeStored(aptosRaw("44'/637'/12'/3/45"));
+      expect(account.freshAddressPath).toBe("44'/637'/12'/3'/45'");
+    });
+
+    it("leaves an already hardened path untouched", async () => {
+      const path = "44'/637'/0'/0'/0'";
+      const [account] = await decodeStored(aptosRaw(path));
+      expect(account.freshAddressPath).toBe(path);
+    });
+
+    it("does not touch non-aptos accounts sharing a similar path shape", async () => {
+      const path = "44'/60'/0'/0/0";
+      const [account] = await decodeStored({
+        ...baseRaw,
+        id: "js:2:ethereum:0xabc:",
+        freshAddress: "0xabc",
+        freshAddressPath: path,
+        currencyId: "ethereum",
+      } as AccountRaw);
+      expect(account.freshAddressPath).toBe(path);
+    });
+  });
+
+  describe("crypto_org cosmosResources fallback", () => {
+    it("initialises cosmosResources when missing", async () => {
+      const [account] = await decodeStored({
+        ...baseRaw,
+        id: "js:2:crypto_org:cosmos1address:",
+        freshAddress: "cosmos1address",
+        freshAddressPath: "44'/394'/0'/0/0",
+        currencyId: "crypto_org",
+      } as AccountRaw);
+      const { cosmosResources } = account as typeof account & {
+        cosmosResources: Record<string, unknown>;
+      };
+      expect(cosmosResources).toBeDefined();
+      expect(cosmosResources.delegations).toEqual([]);
+      expect(cosmosResources.withdrawAddress).toBe("cosmos1address");
+    });
+  });
+
+  it("exposes a version matching the number of migrations", () => {
+    expect(accountModel.version).toBe(2);
+  });
+});

--- a/apps/ledger-live-mobile/src/logic/accountModel.ts
+++ b/apps/ledger-live-mobile/src/logic/accountModel.ts
@@ -1,3 +1,4 @@
+import BigNumber from "bignumber.js";
 import { createDataModel } from "@ledgerhq/live-common/DataModel";
 import type { DataModel } from "@ledgerhq/live-common/DataModel";
 import type { Account, AccountRaw, Operation, AccountUserData } from "@ledgerhq/types-live";
@@ -6,6 +7,8 @@ import {
   toAccountRaw,
   accountRawToAccountUserData,
 } from "@ledgerhq/live-common/account/index";
+
+const APTOS_NON_HARDENED_DERIVATION_PATH_REGEX = /^44'\/637'\/\d+'\/\d+\/\d+$/;
 
 /**
  * @memberof models/account
@@ -18,7 +21,45 @@ export const opRetentionStategy =
 const opRetentionFilter = opRetentionStategy(366, 500);
 
 const accountModel: DataModel<AccountRaw, [Account, AccountUserData]> = createDataModel({
-  migrations: [],
+  migrations: [
+    // Set 'change' and 'address_index' levels to be hardened for Aptos derivation path
+    raw => {
+      const { currencyId, freshAddressPath } = raw;
+      if (
+        currencyId === "aptos" &&
+        freshAddressPath.match(APTOS_NON_HARDENED_DERIVATION_PATH_REGEX)
+      ) {
+        return {
+          ...raw,
+          freshAddressPath: freshAddressPath
+            .split("/")
+            .map((value: string) => (value.endsWith("'") ? value : value + "'"))
+            .join("/"),
+        };
+      }
+      return raw;
+    },
+    // Initialize cosmosResources for crypto_org accounts missing it
+    raw => {
+      const { currencyId } = raw;
+      if (currencyId === "crypto_org" && !raw.cosmosResources) {
+        return {
+          ...raw,
+          cosmosResources: {
+            delegations: [],
+            redelegations: [],
+            unbondings: [],
+            delegatedBalance: new BigNumber(0),
+            pendingRewardsBalance: new BigNumber(0),
+            unbondingBalance: new BigNumber(0),
+            withdrawAddress: raw.freshAddress,
+            sequence: 0,
+          },
+        };
+      }
+      return raw;
+    },
+  ],
   decode: async (raw: AccountRaw) => [await fromAccountRaw(raw), accountRawToAccountUserData(raw)],
   encode: async ([account, userData]: [Account, AccountUserData]): Promise<AccountRaw> =>
     toAccountRaw(

--- a/libs/ledger-live-common/src/DataModel.ts
+++ b/libs/ledger-live-common/src/DataModel.ts
@@ -1,5 +1,3 @@
-import BigNumber from "bignumber.js";
-import { APTOS_NON_HARDENED_DERIVATION_PATH_REGEX } from "@ledgerhq/coin-aptos/constants";
 import { getCurrencyConfiguration } from "./config";
 import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
 
@@ -23,6 +21,10 @@ export type DataModel<R, M> = {
 /**
  * this is to be implemented to create a DataModel
  * @memberof DataModel
+ *
+ * IMPORTANT: This file must remain domain-agnostic. Do NOT add any account-specific,
+ * coin-specific, or app-specific migration logic here. Such logic belongs in the
+ * app-level accountModel (apps/ledger-live-desktop, apps/ledger-live-mobile).
  */
 export type DataSchema<R, M> = {
   // write extra logic to transform raw data into your model
@@ -41,31 +43,8 @@ export function createDataModel<R, M>(schema: DataSchema<R, M>): DataModel<R, M>
   const version = migrations.length;
   async function decodeModel(raw) {
     let { data } = raw;
-    const { currencyId, freshAddressPath } = data;
+    const { currencyId } = data;
     const currency = findCryptoCurrencyById(currencyId);
-    // Set 'change' and 'address_index' levels to be hardened for Aptos derivation path
-    if (
-      currencyId === "aptos" &&
-      freshAddressPath.match(APTOS_NON_HARDENED_DERIVATION_PATH_REGEX)
-    ) {
-      data.freshAddressPath = freshAddressPath
-        .split("/")
-        .map(value => (value.endsWith("'") ? value : value + "'"))
-        .join("/");
-    }
-
-    if (currencyId == "crypto_org" && !data.cosmosResources) {
-      data.cosmosResources = {
-        delegations: [],
-        redelegations: [],
-        unbondings: [],
-        delegatedBalance: new BigNumber(0),
-        pendingRewardsBalance: new BigNumber(0),
-        unbondingBalance: new BigNumber(0),
-        withdrawAddress: data.freshAddress,
-        sequence: 0,
-      };
-    }
     if (currency && currency.family == "evm" && !getCurrencyConfiguration(currency.id).showNfts) {
       if (Array.isArray(data.operations)) {
         data.operations = data.operations.filter(tx => !("nftOperations" in tx));


### PR DESCRIPTION
### 📝 Description

`DataModel.ts` is a generic migration engine parametrised over arbitrary types `R` and `M`. Over time, two coin-specific fixups leaked into `decodeModel`:

1. **Aptos derivation path hardening** — rewrites non-hardened `change`/`address_index` path levels for Aptos accounts
2. **`crypto_org` cosmosResources fallback** — initialises `cosmosResources` with zeroed values when missing

These have nothing to do with the generic migration mechanism. This PR removes them from `DataModel.ts` and re-introduces them as explicit versioned entries in the `migrations` arrays of both desktop and mobile `accountModel`.

The EVM NFT operations filter is out of scope (covered separately by LIVE-34070).

Changes:
- Remove Aptos + crypto_org blocks and their now-unused imports from `DataModel.ts`
- Add a JSDoc warning on `DataSchema` forbidding future domain-specific additions
- Add two explicit migrations (Aptos path hardening, crypto_org cosmosResources fallback) in both `apps/ledger-live-desktop/src/helpers/accountModel.ts` and `apps/ledger-live-mobile/src/logic/accountModel.ts`

Reference implementation: https://github.com/LedgerHQ/ledger-live/pull/19241

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34069](https://ledgerhq.atlassian.net/browse/LIVE-34069) / Epic [LIVE-33671](https://ledgerhq.atlassian.net/browse/LIVE-33671)
- **ADR** (if any): N/A

[LIVE-34069]: https://ledgerhq.atlassian.net/browse/LIVE-34069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ