### PR TITLE
[LWDM] refactor(data-model): remove EVM NFT operation filter

### DIFF
--- a/.changeset/calm-bears-run.md
+++ b/.changeset/calm-bears-run.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Remove EVM NFT operation filter from DataModel (NFT sunset)

--- a/libs/ledger-live-common/src/DataModel.test.ts
+++ b/libs/ledger-live-common/src/DataModel.test.ts
@@ -3,12 +3,7 @@ import { APTOS_NON_HARDENED_DERIVATION_PATH } from "@ledgerhq/coin-aptos/constan
 import { accountRawToAccountUserData } from "./account/serialization";
 import { createDataModel } from "./DataModel";
 import { fromAccountRaw, toAccountRaw } from "./account";
-import { getCurrencyConfiguration } from "./config";
 import { setCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
-
-jest.mock("./config", () => ({
-  getCurrencyConfiguration: jest.fn(),
-}));
 
 const opRetentionStategy =
   (maxDaysOld: number, keepFirst: number) =>
@@ -139,31 +134,12 @@ describe("DataModel", () => {
     expect(migratedAptosAccountRaw.id).toBeDefined();
   });
 
-  describe("test for shownNfts true", () => {
-    beforeAll(() => {
-      (getCurrencyConfiguration as jest.Mock).mockReturnValue({
-        showNfts: true,
-      });
-    });
-
-    test("evm account", async () => {
+  describe("evm account", () => {
+    test("decodes all operations including those with nftOperations", async () => {
       const data = await createDataModel(schema).decode(evmAccount);
       const account = data.at(0) as Account;
-      expect(account.id).toBeDefined();
-    });
-  });
-
-  describe("test for shownNfts false", () => {
-    beforeAll(() => {
-      (getCurrencyConfiguration as jest.Mock).mockReturnValue({
-        showNfts: false,
-      });
-    });
-
-    test("evm account", async () => {
-      const data = await createDataModel(schema).decode(evmAccount);
-      const account = data.at(0) as Account;
-      expect(account.id).toBeDefined();
+      expect(account.operations).toHaveLength(2);
+      expect(account.operations.find(op => op.id === "op_evm_002")).toBeDefined();
     });
   });
 });

--- a/libs/ledger-live-common/src/DataModel.ts
+++ b/libs/ledger-live-common/src/DataModel.ts
@@ -1,6 +1,3 @@
-import { getCurrencyConfiguration } from "./config";
-import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
-
 /**
  * Interface for the end user.
  * @memberof DataModel
@@ -43,13 +40,6 @@ export function createDataModel<R, M>(schema: DataSchema<R, M>): DataModel<R, M>
   const version = migrations.length;
   async function decodeModel(raw) {
     let { data } = raw;
-    const { currencyId } = data;
-    const currency = findCryptoCurrencyById(currencyId);
-    if (currency && currency.family == "evm" && !getCurrencyConfiguration(currency.id).showNfts) {
-      if (Array.isArray(data.operations)) {
-        data.operations = data.operations.filter(tx => !("nftOperations" in tx));
-      }
-    }
 
     for (let i = raw.version; i < version; i++) {
       data = migrations[i](data);


### PR DESCRIPTION
### 📝 Description

`DataModel.ts` contained an EVM-specific block that filtered out `nftOperations` from account operations on every decode, conditionally on the `showNfts` runtime config flag. Unlike a one-time migration, this filter ran on every load — making it an even worse fit for a generic, domain-agnostic migration engine.

With NFTs being sunset, this filter has no remaining purpose. This PR removes the block and its now-unused imports (`getCurrencyConfiguration`, `findCryptoCurrencyById`), leaving `DataModel.ts` with zero imports and zero domain references.

**Stacked on**: #20993 (LIVE-34069 — Aptos + crypto_org migrations moved to app level)

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34070](https://ledgerhq.atlassian.net/browse/LIVE-34070) / Epic [LIVE-33671](https://ledgerhq.atlassian.net/browse/LIVE-33671)
- **ADR** (if any): N/A

[LIVE-34070]: https://ledgerhq.atlassian.net/browse/LIVE-34070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-33671]: https://ledgerhq.atlassian.net/browse/LIVE-33671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ