### PR TITLE
[LWDM] fix(coin-zcash): send public funds without a UFVK (LIVE-36260)

### DIFF
--- a/.changeset/LIVE-36260-zcash-public-send-without-ufvk.md
+++ b/.changeset/LIVE-36260-zcash-public-send-without-ufvk.md
@@ -6,4 +6,6 @@ Send transparent funds without the account's UFVK. Every Zcash send required one
 
 This needs `@ledgerhq/zcash-utils` 2.2.0, which the catalog now pins: earlier versions require the viewing key for every build, whatever the flow.
 
+The shielded pools stay out of reach in exchange: a unified address carrying an Orchard receiver is now refused as a recipient when the account has no UFVK, reported on the address field instead of accepted and failed at the device step. A malformed or Sapling address keeps its own error, so the user is not sent to the export flow over a typo.
+
 A transparent send carries no shielded bundle and reads no shielded key material: the only key it needs is the account-level transparent pubkey, which is the payload of the account xpub the account already holds. It is now read from there (`accountPubkeyFromXpub`, the counterpart of the existing `composeXpub`) and passed to the builder in place of the UFVK, whose absence no longer blocks the flow. An account that does have a UFVK keeps using it, so its code path is unchanged. Flows that spend or create shielded value still require the UFVK and now report it as a typed `ZcashShieldedKeyMissing` rather than a bare error.

--- a/.changeset/LIVE-36260-zcash-public-send-without-ufvk.md
+++ b/.changeset/LIVE-36260-zcash-public-send-without-ufvk.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-zcash": patch
+---
+
+Send transparent funds without the account's UFVK. Every Zcash send required one, so a public t→t send failed at the device step with "Missing UFVK — account not yet synced" on any account that had not run the viewing-key export flow — which is a device confirmation, and which the send flow deliberately does not ask for (only the private transfer option is gated on it). Transparent funds were therefore unspendable until the user activated their private balance.
+
+A transparent send carries no shielded bundle and reads no shielded key material: the only key it needs is the account-level transparent pubkey, which is the payload of the account xpub the account already holds. It is now read from there (`accountPubkeyFromXpub`, the counterpart of the existing `composeXpub`) and passed to the builder in place of the UFVK, whose absence no longer blocks the flow. An account that does have a UFVK keeps using it, so its code path is unchanged. Flows that spend or create shielded value still require the UFVK and now report it as a typed `ZcashShieldedKeyMissing` rather than a bare error.

--- a/.changeset/LIVE-36260-zcash-public-send-without-ufvk.md
+++ b/.changeset/LIVE-36260-zcash-public-send-without-ufvk.md
@@ -4,4 +4,6 @@
 
 Send transparent funds without the account's UFVK. Every Zcash send required one, so a public t→t send failed at the device step with "Missing UFVK — account not yet synced" on any account that had not run the viewing-key export flow — which is a device confirmation, and which the send flow deliberately does not ask for (only the private transfer option is gated on it). Transparent funds were therefore unspendable until the user activated their private balance.
 
+This needs `@ledgerhq/zcash-utils` 2.2.0, which the catalog now pins: earlier versions require the viewing key for every build, whatever the flow.
+
 A transparent send carries no shielded bundle and reads no shielded key material: the only key it needs is the account-level transparent pubkey, which is the payload of the account xpub the account already holds. It is now read from there (`accountPubkeyFromXpub`, the counterpart of the existing `composeXpub`) and passed to the builder in place of the UFVK, whose absence no longer blocks the flow. An account that does have a UFVK keeps using it, so its code path is unchanged. Flows that spend or create shielded value still require the UFVK and now report it as a typed `ZcashShieldedKeyMissing` rather than a bare error.

--- a/libs/coin-modules/coin-zcash/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/getTransactionStatus.test.ts
@@ -62,6 +62,7 @@ function account({
   ironwoodNotes = [50_000],
   freshIronwoodNotes = [],
   synced = true,
+  shieldedKey = true,
   lastProcessedBlock = REFERENCE_HEIGHT,
 }: {
   utxos?: number[];
@@ -71,6 +72,9 @@ function account({
   /** Ironwood notes scanned only a few blocks ago -- still maturing. */
   freshIronwoodNotes?: number[];
   synced?: boolean;
+  /** Whether the UFVK has been exported from the device, i.e. the account can
+   *  take part in the shielded pools at all. */
+  shieldedKey?: boolean;
   lastProcessedBlock?: number | null;
 } = {}): ZcashAccount {
   const ironwoodBalance = [...ironwoodNotes, ...freshIronwoodNotes].reduce((s, v) => s + v, 0);
@@ -121,6 +125,7 @@ function account({
           orchardBalance: new BigNumber(orchardBalance),
           ironwoodBalance: new BigNumber(ironwoodBalance),
           saplingBalance: new BigNumber(0),
+          ufvk: shieldedKey ? "uview1test" : null,
           lastProcessedBlock,
           transactions,
         }
@@ -204,11 +209,30 @@ describe("computeRecipientError", () => {
     ["not-an-address", "InvalidAddress"],
     [ZS_ADDRESS, "ZcashSaplingRecipientNotSupported"],
   ])("rejects %s with %s", (recipient, expected) => {
-    expect(computeRecipientError(recipient, "Zcash")?.name).toBe(expected);
+    expect(computeRecipientError(recipient, "Zcash", true)?.name).toBe(expected);
   });
 
   it.each([T_ADDRESS, U_ADDRESS])("accepts %s", recipient => {
-    expect(computeRecipientError(recipient, "Zcash")).toBe(undefined);
+    expect(computeRecipientError(recipient, "Zcash", true)).toBe(undefined);
+  });
+
+  // Paying an Orchard receiver needs a shielded bundle, which the builder can
+  // only assemble from the account's UFVK.
+  it("rejects a shielded recipient when the account has no UFVK", () => {
+    expect(computeRecipientError(U_ADDRESS, "Zcash", false)?.name).toBe("ZcashShieldedKeyMissing");
+  });
+
+  it("still accepts a transparent recipient when the account has no UFVK", () => {
+    expect(computeRecipientError(T_ADDRESS, "Zcash", false)).toBe(undefined);
+  });
+
+  // The address is malformed whether or not a viewing key exists; reporting the
+  // missing key instead would send the user off to the export flow for nothing.
+  it.each([
+    ["not-an-address", "InvalidAddress"],
+    [ZS_ADDRESS, "ZcashSaplingRecipientNotSupported"],
+  ])("keeps reporting %s as %s without a UFVK", (recipient, expected) => {
+    expect(computeRecipientError(recipient, "Zcash", false)?.name).toBe(expected);
   });
 });
 
@@ -373,6 +397,29 @@ describe("getTransactionStatus, transparent-input flows", () => {
     const status = await getTransactionStatus(
       account(),
       transaction({ transferType: "transparent-to-shielded", recipient: U_ADDRESS }),
+    );
+
+    expect(status.errors).toEqual({});
+  });
+
+  // Without the UFVK the shielded pools are out of reach, so a shielded
+  // recipient has to be refused here -- at the address field, where the user can
+  // act on it -- rather than accepted and failed at the device step.
+  it("refuses a shielded recipient when the UFVK has not been exported", async () => {
+    const status = await getTransactionStatus(
+      account({ shieldedKey: false }),
+      transaction({ transferType: "transparent-to-shielded", recipient: U_ADDRESS }),
+    );
+
+    expect(errorNames(status.errors)).toEqual({ recipient: "ZcashShieldedKeyMissing" });
+  });
+
+  // The counterpart, and the flow LIVE-36260 restored: spending public funds
+  // from an account that never exported its UFVK stays available.
+  it("still accepts a transparent send when the UFVK has not been exported", async () => {
+    const status = await getTransactionStatus(
+      account({ shieldedKey: false }),
+      transaction({ transferType: "transparent", recipient: T_ADDRESS }),
     );
 
     expect(status.errors).toEqual({});

--- a/libs/coin-modules/coin-zcash/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/getTransactionStatus.ts
@@ -6,6 +6,7 @@ import { ZIP317_MINIMUM_FEE } from "../logic/coin-selection";
 import {
   computeAmountError,
   computeRecipientError,
+  hasShieldedKey,
   isTransparentInputTransfer,
   resolveTransparentUtxos,
 } from "./statusHelpers";
@@ -14,8 +15,9 @@ import { getSpendableIronwoodBalance } from "../logic/account/spendability";
 
 /**
  * Transaction status for a transparent-input (Public→*) send: the recipient
- * class differs per flow (u1 for →shielded, t1/t3 for →transparent) but both
- * are covered by `computeRecipientError`.
+ * class differs per flow (u1 for →shielded, t1/t3 for →transparent) and both are
+ * covered by `computeRecipientError` -- which also rejects a shielded recipient
+ * when the account has no UFVK to build the shielded bundle with.
  */
 function getTransparentInputStatus(
   account: ZcashAccount,
@@ -33,7 +35,7 @@ function getTransparentInputStatus(
   const fee = tx.zcashFee ?? new BigNumber(ZIP317_MINIMUM_FEE);
   const totalSpent = tx.amount.plus(fee);
 
-  const recipientError = computeRecipientError(tx.recipient, currencyName);
+  const recipientError = computeRecipientError(tx.recipient, currencyName, hasShieldedKey(account));
   if (recipientError) errors.recipient = recipientError;
 
   if (tx.amount.lte(0) && !tx.useAllAmount) {
@@ -84,7 +86,11 @@ export const getTransactionStatus: AccountBridge<
   const fee = transaction.zcashFee ?? new BigNumber(ZIP317_MINIMUM_FEE);
   const totalSpent = transaction.amount.plus(fee);
 
-  const recipientError = computeRecipientError(transaction.recipient, account.currency.name);
+  const recipientError = computeRecipientError(
+    transaction.recipient,
+    account.currency.name,
+    hasShieldedKey(account),
+  );
   if (recipientError) errors.recipient = recipientError;
 
   const amountError = computeAmountError(transaction, totalSpent, poolBalance);

--- a/libs/coin-modules/coin-zcash/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/signOperation.test.ts
@@ -21,7 +21,7 @@ import {
 import type { SpendableNote } from "../network/types";
 import type { SignerContext } from "../types/signer";
 import type { Transaction, ZcashAccount } from "../types/bridge";
-import { ZcashNotesNotYetSpendable } from "../types/errors";
+import { ZcashNotesNotYetSpendable, ZcashShieldedKeyMissing } from "../types/errors";
 
 jest.mock("../logic/transaction/craftTransaction");
 jest.mock("../logic/transaction/combine");
@@ -45,6 +45,14 @@ const MOCK_PCZT_HEX = "pczt" + "00".repeat(30);
 // the device and the finalizer.
 const MOCK_PCZT_V2_HEX = "pczt" + "02".repeat(30);
 const MOCK_UFVK = "uview1testkey";
+
+// BIP-32 test vector 1 (m/0H) — a real serialized xpub, so the account key
+// material extracted from it is checkable against the published vector rather
+// than against our own encoder. See `signer/xpub.test.ts`.
+const ACCOUNT_XPUB =
+  "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw";
+const ACCOUNT_CHAIN_CODE_HEX = "47fdacbd0f1097043b78c63c20c34ef4ed9a111d980047ad16282c7ae6236141";
+const ACCOUNT_PUBKEY_HEX = "035a784662a4a20a65bf6aab9ae98a6c068a81c52e4b032c0fb5400c706cfccc56";
 
 const defaultBuildResult = {
   pcztHex: MOCK_PCZT_HEX,
@@ -111,6 +119,7 @@ function makeAccount(overrides: Partial<ZcashAccount> = {}): ZcashAccount {
   return {
     id: "zcash:v2:account:test",
     seedIdentifier: "seed1",
+    xpub: ACCOUNT_XPUB,
     derivationMode: "",
     index: 0,
     freshAddress: "t1abc",
@@ -332,15 +341,92 @@ describe("bridge/signOperation", () => {
     expect(mockCraftIronwoodTransaction).not.toHaveBeenCalled();
   });
 
-  it("errors when the account has no UFVK yet (not synced)", async () => {
-    const account = makeAccount();
-    delete (account as { privateInfo?: unknown }).privateInfo;
-    const tx = makeTx("shielded");
+  // A UFVK only reaches the wallet through the export flow, which the user has
+  // to confirm on the device. So it is present for a shielded-enabled account
+  // and absent for one that only ever held public funds -- and a t→t send, which
+  // reads no shielded key material, must work in both cases.
+  describe("an account whose UFVK has not been exported", () => {
+    function accountWithoutUfvk(): ZcashAccount {
+      const account = makeAccount();
+      delete (account as { privateInfo?: unknown }).privateInfo;
+      return account;
+    }
+
+    it.each(["shielded", "shielded-to-transparent", "transparent-to-shielded"] as const)(
+      "refuses a %s send, which cannot be built without the shielded keys",
+      async transferType => {
+        const signOp = buildSignOperation(makeSignerContext());
+
+        await expect(
+          lastValueFrom(
+            signOp({
+              account: accountWithoutUfvk(),
+              deviceId: "device-1",
+              transaction: makeTx(transferType),
+            } as never),
+          ),
+        ).rejects.toThrow(ZcashShieldedKeyMissing);
+        expect(mockCraftIronwoodTransaction).not.toHaveBeenCalled();
+      },
+    );
+
+    it("signs a transparent send from the account xpub alone (LIVE-36260)", async () => {
+      const signOp = buildSignOperation(makeSignerContext());
+
+      const events = await collectEvents(signOp, {
+        account: accountWithoutUfvk(),
+        deviceId: "device-1",
+        transaction: makeTx("transparent"),
+      } as never);
+
+      expect(events.map(e => e.type)).toEqual([
+        "device-signature-requested",
+        "device-signature-granted",
+        "signed",
+      ]);
+      // The transparent account pubkey stands in for the UFVK: same account, and
+      // the only key material a transparent build reads.
+      expect(mockCraftTransaction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          transparentAccountPubkey: ACCOUNT_CHAIN_CODE_HEX + ACCOUNT_PUBKEY_HEX,
+        }),
+      );
+      expect(mockCraftTransaction).toHaveBeenCalledWith(
+        expect.not.objectContaining({ ufvk: expect.anything() }),
+      );
+    });
+
+    it("reports a missing xpub rather than building from no key at all", async () => {
+      const account = accountWithoutUfvk();
+      delete (account as { xpub?: unknown }).xpub;
+      const signOp = buildSignOperation(makeSignerContext());
+
+      await expect(
+        lastValueFrom(
+          signOp({
+            account,
+            deviceId: "device-1",
+            transaction: makeTx("transparent"),
+          } as never),
+        ),
+      ).rejects.toThrow("Missing xpub");
+      expect(mockCraftTransaction).not.toHaveBeenCalled();
+    });
+  });
+
+  it("prefers the UFVK for a transparent send when the account has one", async () => {
     const signOp = buildSignOperation(makeSignerContext());
 
-    await expect(
-      lastValueFrom(signOp({ account, deviceId: "device-1", transaction: tx } as never)),
-    ).rejects.toThrow("Missing UFVK");
+    await collectEvents(signOp, {
+      account: makeAccount(),
+      deviceId: "device-1",
+      transaction: makeTx("transparent"),
+    } as never);
+
+    expect(mockCraftTransaction).toHaveBeenCalledWith(expect.objectContaining({ ufvk: MOCK_UFVK }));
+    expect(mockCraftTransaction).toHaveBeenCalledWith(
+      expect.not.objectContaining({ transparentAccountPubkey: expect.anything() }),
+    );
   });
 
   it("errors when selectedNotes/zcashFee were not resolved by prepareTransaction", async () => {

--- a/libs/coin-modules/coin-zcash/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/signOperation.test.ts
@@ -345,13 +345,28 @@ describe("bridge/signOperation", () => {
   // to confirm on the device. So it is present for a shielded-enabled account
   // and absent for one that only ever held public funds -- and a t→t send, which
   // reads no shielded key material, must work in both cases.
-  describe("an account whose UFVK has not been exported", () => {
-    function accountWithoutUfvk(): ZcashAccount {
-      const account = makeAccount();
-      delete (account as { privateInfo?: unknown }).privateInfo;
-      return account;
-    }
-
+  // An account represents "no UFVK" in more than one way: no privateInfo at all,
+  // or a privateInfo whose ufvk is null or an empty string -- which is why the
+  // shielded scan gates on its length as well (`sync.ts`'s `ufvkIsPresent`).
+  // Every one of them must behave identically here.
+  describe.each([
+    [
+      "no privateInfo",
+      () => {
+        const account = makeAccount();
+        delete (account as { privateInfo?: unknown }).privateInfo;
+        return account;
+      },
+    ],
+    [
+      "a null ufvk",
+      () => makeAccount({ privateInfo: { ...makeAccount().privateInfo, ufvk: null } } as never),
+    ],
+    [
+      "an empty ufvk",
+      () => makeAccount({ privateInfo: { ...makeAccount().privateInfo, ufvk: "" } } as never),
+    ],
+  ] as const)("an account with %s", (_label, accountWithoutUfvk) => {
     it.each(["shielded", "shielded-to-transparent", "transparent-to-shielded"] as const)(
       "refuses a %s send, which cannot be built without the shielded keys",
       async transferType => {

--- a/libs/coin-modules/coin-zcash/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/signOperation.ts
@@ -11,9 +11,11 @@ import type { Transaction, ZcashAccount, BtcInputRef, ZcashOperationExtra } from
 import type { SignerContext } from "../types/signer";
 import {
   ZcashNotesNotYetSpendable,
+  ZcashShieldedKeyMissing,
   ZcashSignerNotSupported,
   ZcashSigningCancelled,
 } from "../types/errors";
+import { accountPubkeyFromXpub } from "../signer/xpub";
 import { assertCanSend } from "../logic/engineClient";
 import { craftIronwoodTransaction, craftTransaction } from "../logic/transaction/craftTransaction";
 import { combine } from "../logic/transaction/combine";
@@ -46,6 +48,36 @@ const IRONWOOD_BUNDLE_TRANSFER_TYPES = new Set<Transaction["transferType"]>([
 function isNotePositionPastAnchor(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return message.includes("compute_ironwood_witnesses") && message.includes("anchor_total_leaves");
+}
+
+/**
+ * A shielded bundle can only be built from the account's shielded keys, so the
+ * UFVK is mandatory there -- and it only reaches the wallet through the export
+ * flow, which the user has to confirm on the device.
+ */
+function requireUfvk(ufvk: string | undefined): string {
+  if (!ufvk) throw new ZcashShieldedKeyMissing();
+  return ufvk;
+}
+
+/**
+ * The account key material a transparent send needs, in whichever form the
+ * account can supply: the UFVK when it has one, otherwise the account's
+ * transparent pubkey read off its xpub.
+ *
+ * Both forms describe the same account and derive the same change address and
+ * signing paths; the UFVK is preferred when present so that an account which has
+ * one keeps a single code path across all its flows.
+ */
+function resolveAccountKey(
+  account: ZcashAccount,
+  ufvk: string | undefined,
+): { ufvk: string } | { transparentAccountPubkey: string } {
+  if (ufvk !== undefined) return { ufvk };
+  // Every synced account is built from its xpub, so this is an invariant
+  // violation rather than a state the user can reach or resolve.
+  if (!account.xpub) throw new Error("Missing xpub -- cannot derive the account's transparent key");
+  return { transparentAccountPubkey: accountPubkeyFromXpub(account.xpub) };
 }
 
 /**
@@ -85,8 +117,12 @@ export const buildSignOperation =
       };
 
       (async () => {
-        const ufvk = account.privateInfo?.ufvk;
-        if (!ufvk) throw new Error("Missing UFVK -- account not yet synced");
+        const useIronwood = IRONWOOD_BUNDLE_TRANSFER_TYPES.has(transaction.transferType);
+        // Absent until the user exports it from the device, so only the flows
+        // that genuinely read shielded key material may depend on it: a
+        // transparent send identifies its account by the xpub instead, and stays
+        // available to an account that holds nothing but public funds.
+        const ufvk = account.privateInfo?.ufvk ?? undefined;
         if (!transaction.selectedNotes)
           throw new Error("Missing selectedNotes -- run prepareTransaction first");
         if (transaction.zcashFee === undefined)
@@ -100,7 +136,6 @@ export const buildSignOperation =
         if (bailIfCancelled()) return;
 
         const plan = {
-          ufvk,
           accountIndex,
           feeZat: transaction.zcashFee.toFixed(0),
           spends: mapSpends(transaction.selectedNotes),
@@ -108,13 +143,12 @@ export const buildSignOperation =
           outputs: mapOutputs(transaction),
         };
 
-        const useIronwood = IRONWOOD_BUNDLE_TRANSFER_TYPES.has(transaction.transferType);
         const buildResult = useIronwood
-          ? await craftIronwoodTransaction(plan).catch(err => {
+          ? await craftIronwoodTransaction({ ...plan, ufvk: requireUfvk(ufvk) }).catch(err => {
               if (isNotePositionPastAnchor(err)) throw new ZcashNotesNotYetSpendable();
               throw err;
             })
-          : await craftTransaction(plan);
+          : await craftTransaction({ ...plan, ...resolveAccountKey(account, ufvk) });
 
         const { pcztTransaction } = buildResult;
 

--- a/libs/coin-modules/coin-zcash/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/signOperation.ts
@@ -73,7 +73,8 @@ function resolveAccountKey(
   account: ZcashAccount,
   ufvk: string | undefined,
 ): { ufvk: string } | { transparentAccountPubkey: string } {
-  if (ufvk !== undefined) return { ufvk };
+  // Truthiness, like `requireUfvk`: an empty viewing key is no key.
+  if (ufvk) return { ufvk };
   // Every synced account is built from its xpub, so this is an invariant
   // violation rather than a state the user can reach or resolve.
   if (!account.xpub) throw new Error("Missing xpub -- cannot derive the account's transparent key");
@@ -122,7 +123,13 @@ export const buildSignOperation =
         // that genuinely read shielded key material may depend on it: a
         // transparent send identifies its account by the xpub instead, and stays
         // available to an account that holds nothing but public funds.
-        const ufvk = account.privateInfo?.ufvk ?? undefined;
+        //
+        // An account can carry an empty string rather than null, which is why the
+        // shielded scan gates on its length too (`sync.ts`'s `ufvkIsPresent`).
+        // Normalising here keeps the two readers below agreeing on what
+        // "present" means: without it a transparent send would forward `ufvk: ""`
+        // to the builder and fail decoding a viewing key it never needed.
+        const ufvk = account.privateInfo?.ufvk || undefined;
         if (!transaction.selectedNotes)
           throw new Error("Missing selectedNotes -- run prepareTransaction first");
         if (transaction.zcashFee === undefined)

--- a/libs/coin-modules/coin-zcash/src/bridge/statusHelpers.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/statusHelpers.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from "bignumber.js";
 import { InvalidAddress, RecipientRequired } from "@ledgerhq/ledger-wallet-framework/errors";
 import type { BitcoinOutput, ZcashAccount, Transaction } from "../types/bridge";
-import { ZcashSaplingRecipientNotSupported } from "../types/errors";
+import { ZcashSaplingRecipientNotSupported, ZcashShieldedKeyMissing } from "../types/errors";
 import { classifyZcashRecipient } from "../logic/address";
 
 // Transfer types that actually spend transparent UTXOs as inputs. A pure
@@ -29,16 +29,37 @@ export function resolveTransparentUtxos(account: ZcashAccount, tx: Transaction):
   return tx.selectedUtxos ?? account.bitcoinResources?.utxos ?? [];
 }
 
+/**
+ * Whether the account can take part in the shielded pools at all, which is what
+ * having exported the UFVK from the device amounts to. An empty string counts as
+ * absent, as everywhere else (see `bridge/signOperation`, `sync.ts`).
+ */
+export const hasShieldedKey = (account: ZcashAccount): boolean =>
+  Boolean(account.privateInfo?.ufvk);
+
+/**
+ * `shieldedKeyAvailable` gates the shielded recipient classes. Paying an Orchard
+ * receiver builds a transaction with a shielded bundle, which the builder can
+ * only assemble from the account's UFVK -- so without one the address is not a
+ * recipient this account can pay, and saying so here keeps the send flow from
+ * accepting it and failing at the device step instead.
+ */
 export const computeRecipientError = (
   recipient: string,
   currencyName: string,
+  shieldedKeyAvailable: boolean,
 ): Error | undefined => {
   if (!recipient) return new RecipientRequired("");
   const cls = classifyZcashRecipient(recipient);
-  if (!("error" in cls)) return undefined;
-  return cls.error === "sapling-unsupported"
-    ? new ZcashSaplingRecipientNotSupported()
-    : new InvalidAddress("", { currencyName });
+  if ("error" in cls) {
+    return cls.error === "sapling-unsupported"
+      ? new ZcashSaplingRecipientNotSupported()
+      : new InvalidAddress("", { currencyName });
+  }
+  if (cls.recipientType === "private" && !shieldedKeyAvailable) {
+    return new ZcashShieldedKeyMissing();
+  }
+  return undefined;
 };
 
 export const computeAmountError = (

--- a/libs/coin-modules/coin-zcash/src/logic/transaction/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-zcash/src/logic/transaction/craftTransaction.test.ts
@@ -1,7 +1,7 @@
 import { craftIronwoodTransaction, craftTransaction } from "./craftTransaction";
 import { combine } from "./combine";
 import { setZainoGrpcUrl, ZCASH_GRPC_URL_MAINNET } from "../../constants";
-import type { CraftPlan } from "./craftTransaction";
+import type { CraftPlan, IronwoodCraftPlan } from "./craftTransaction";
 
 const buildTransaction = jest.fn(async () => ({ pcztHex: "01", nActionsOrchard: 2 }));
 const buildIronwoodTransaction = jest.fn(async () => ({ pcztHex: "02", nActionsIronwood: 2 }));
@@ -16,14 +16,14 @@ jest.mock(
 
 const client = () => ({ buildTransaction, buildIronwoodTransaction, finalizeTransaction });
 
-const plan: CraftPlan = {
+const plan: IronwoodCraftPlan = {
   ufvk: "uview1key",
   accountIndex: 0,
   feeZat: "15000",
   spends: [],
   transparentInputs: [],
   outputs: [{ address: "u1recipient", valueZat: "50000" }],
-} as unknown as CraftPlan;
+} as unknown as IronwoodCraftPlan;
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -60,6 +60,26 @@ describe("craftTransaction", () => {
 
     expect(buildTransaction).toHaveBeenCalledWith(
       expect.objectContaining({ seedFingerprint: "ab".repeat(32) }),
+    );
+  });
+
+  it("builds a transparent send from the account pubkey alone, with no viewing key", async () => {
+    const transparentPlan: CraftPlan = {
+      transparentAccountPubkey: "ab".repeat(65),
+      accountIndex: 0,
+      feeZat: "10000",
+      spends: [],
+      transparentInputs: [],
+      outputs: [{ address: "t1recipient", valueZat: "50000" }],
+    } as unknown as CraftPlan;
+
+    await craftTransaction(transparentPlan);
+
+    expect(buildTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({ transparentAccountPubkey: "ab".repeat(65) }),
+    );
+    expect(buildTransaction).toHaveBeenCalledWith(
+      expect.not.objectContaining({ ufvk: expect.anything() }),
     );
   });
 

--- a/libs/coin-modules/coin-zcash/src/logic/transaction/craftTransaction.ts
+++ b/libs/coin-modules/coin-zcash/src/logic/transaction/craftTransaction.ts
@@ -13,6 +13,13 @@ export type CraftPlan = Omit<
 > & { seedFingerprint?: string };
 
 /**
+ * An Ironwood transaction always carries a shielded bundle, so unlike
+ * `CraftPlan` -- whose transparent-only case identifies the account by its
+ * transparent pubkey alone -- its plan always carries the UFVK.
+ */
+export type IronwoodCraftPlan = CraftPlan & { ufvk: string };
+
+/**
  * Resolves the engine client and completes the craft plan into native build
  * arguments. Both builders take the same argument shape, so the two entry
  * points below differ only in which one they call.
@@ -74,7 +81,7 @@ export async function craftTransaction(plan: CraftPlan): Promise<BuildTransactio
  * Ironwood commitment tree), so Orchard notes must not be routed here.
  */
 export async function craftIronwoodTransaction(
-  plan: CraftPlan,
+  plan: IronwoodCraftPlan,
 ): Promise<BuildIronwoodTransactionResult> {
   const { client, args } = await resolveCraft(plan);
 
@@ -82,5 +89,7 @@ export async function craftIronwoodTransaction(
     throw new Error("Zcash V6 (Ironwood) transactions are not supported in this environment");
   }
 
-  return client.buildIronwoodTransaction(args);
+  // Restating `ufvk` carries the plan's guarantee that it is present into the
+  // V6 argument type, which requires it.
+  return client.buildIronwoodTransaction({ ...args, ufvk: plan.ufvk });
 }

--- a/libs/coin-modules/coin-zcash/src/network/engine.ts
+++ b/libs/coin-modules/coin-zcash/src/network/engine.ts
@@ -228,7 +228,14 @@ export async function buildTransactionJob(
   args: Omit<BuildTransactionArgs, "requestId">,
 ): Promise<BuildTransactionResult> {
   const native = await getPcztModule();
-  const built = await native.buildTransaction(args);
+  // `transparentAccountPubkey`, and with it an optional `ufvk` (a transparent
+  // send needs no viewing key), landed in @ledgerhq/zcash-utils 2.2.0; the
+  // catalog pin in `pnpm-workspace.yaml` may still predate it, and its older
+  // signature declares `ufvk` required. Same provenance gap as
+  // `nativeIronwoodBundle` above.
+  const built = await native.buildTransaction(
+    args as Parameters<NativeModule["buildTransaction"]>[0],
+  );
   const rawPczt = native.parsePczt(built.pcztHex);
   return {
     pcztHex: built.pcztHex,

--- a/libs/coin-modules/coin-zcash/src/network/engine.ts
+++ b/libs/coin-modules/coin-zcash/src/network/engine.ts
@@ -228,14 +228,7 @@ export async function buildTransactionJob(
   args: Omit<BuildTransactionArgs, "requestId">,
 ): Promise<BuildTransactionResult> {
   const native = await getPcztModule();
-  // `transparentAccountPubkey`, and with it an optional `ufvk` (a transparent
-  // send needs no viewing key), landed in @ledgerhq/zcash-utils 2.2.0; the
-  // catalog pin in `pnpm-workspace.yaml` may still predate it, and its older
-  // signature declares `ufvk` required. Same provenance gap as
-  // `nativeIronwoodBundle` above.
-  const built = await native.buildTransaction(
-    args as Parameters<NativeModule["buildTransaction"]>[0],
-  );
+  const built = await native.buildTransaction(args);
   const rawPczt = native.parsePczt(built.pcztHex);
   return {
     pcztHex: built.pcztHex,

--- a/libs/coin-modules/coin-zcash/src/network/types.ts
+++ b/libs/coin-modules/coin-zcash/src/network/types.ts
@@ -219,7 +219,22 @@ export const ZCASH_SHIELDED_TX_TYPES = [
 export type BuildTransactionArgs = {
   requestId: string;
   grpcUrl: string;
-  ufvk: string;
+  /**
+   * Unified full viewing key of the account. Required by every flow carrying a
+   * shielded bundle; absent for a transparent send, which reads no shielded key
+   * material and identifies its account with `transparentAccountPubkey`
+   * instead -- exactly so that spending public funds never needs the UFVK
+   * export flow (a device confirmation) to have been run.
+   */
+  ufvk?: string;
+  /**
+   * 130-char hex (65 bytes: 32-byte chain code + 33-byte compressed pubkey) of
+   * the account-level transparent pubkey at `m/44'/133'/account'` -- the payload
+   * of the account xpub (see `signer/xpub.ts`). The builder derives the internal
+   * change address from it and verifies each transparent input's signing path
+   * against it.
+   */
+  transparentAccountPubkey?: string;
   network?: string;
   seedFingerprint: string;
   accountIndex: number;

--- a/libs/coin-modules/coin-zcash/src/signer/xpub.test.ts
+++ b/libs/coin-modules/coin-zcash/src/signer/xpub.test.ts
@@ -1,5 +1,6 @@
 import { secp256k1 } from "@noble/curves/secp256k1";
-import { composeXpub } from "./xpub";
+import { sha256 } from "@noble/hashes/sha2";
+import { accountPubkeyFromXpub, composeXpub } from "./xpub";
 
 // ─── Reference test vector ──────────────────────────────────────────────
 //
@@ -150,7 +151,62 @@ describe("composeXpub", () => {
   });
 });
 
+describe("accountPubkeyFromXpub", () => {
+  it("extracts the chain code and compressed pubkey the BIP-32 vector declares", () => {
+    // These 65 bytes are what a ZIP-316 UFVK carries as its transparent item,
+    // and all the PCZT builder needs to build a transparent send.
+    expect(accountPubkeyFromXpub(EXPECTED_M_0H_XPUB)).toBe(
+      ACCOUNT_CHAIN_CODE_HEX + ACCOUNT_PUBKEY_HEX,
+    );
+  });
+
+  it("is the exact inverse of composeXpub, which produces the account xpub", () => {
+    const xpub = composeXpub({
+      xpubVersion: XPUB_MAINNET_VERSION,
+      depth: 3,
+      childNumber: HARDENED_BIT + 2, // m/44'/133'/2'
+      parentPublicKeyHex: MASTER_PUBKEY_HEX,
+      accountPublicKeyHex: ACCOUNT_PUBKEY_HEX,
+      accountChainCodeHex: ACCOUNT_CHAIN_CODE_HEX,
+    });
+
+    expect(accountPubkeyFromXpub(xpub)).toBe(ACCOUNT_CHAIN_CODE_HEX + ACCOUNT_PUBKEY_HEX);
+  });
+
+  it("rejects a truncated key rather than returning short key material", () => {
+    expect(() =>
+      accountPubkeyFromXpub(base58Encode(base58Decode(EXPECTED_M_0H_XPUB).subarray(0, 70))),
+    ).toThrow(/expected 82 bytes, got 70/);
+  });
+
+  it("rejects a corrupted xpub instead of deriving from altered key material", () => {
+    const corrupted = base58Decode(EXPECTED_M_0H_XPUB);
+    corrupted[50] ^= 0xff; // flip a pubkey byte, leaving the checksum stale
+    expect(() => accountPubkeyFromXpub(base58Encode(corrupted))).toThrow(/checksum mismatch/);
+  });
+
+  it("rejects an uncompressed public key, which is not what a UFVK item carries", () => {
+    const tampered = base58Decode(EXPECTED_M_0H_XPUB);
+    tampered[45] = 0x04;
+    expect(() => accountPubkeyFromXpub(base58Encode(withChecksum(tampered)))).toThrow(
+      /expected a compressed public key.*got 0x04/,
+    );
+  });
+});
+
 // ─── Helpers ────────────────────────────────────────────────────────────
+
+/** Recompute the trailing base58check checksum over a mutated payload. */
+function withChecksum(bytes: Buffer): Buffer {
+  const checksum = Buffer.from(sha256(sha256(bytes.subarray(0, 78)))).subarray(0, 4);
+  return Buffer.concat([bytes.subarray(0, 78), checksum]);
+}
+
+function base58Encode(input: Buffer): string {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const bs58 = require("bs58");
+  return bs58.encode(input);
+}
 
 function base58Decode(input: string): Buffer {
   // Avoid importing bs58 in tests so the assertions stay independent of the

--- a/libs/coin-modules/coin-zcash/src/signer/xpub.ts
+++ b/libs/coin-modules/coin-zcash/src/signer/xpub.ts
@@ -1,5 +1,6 @@
 /**
- * Compose a BIP32 extended public key (xpub) string from raw key material.
+ * Compose a BIP32 extended public key (xpub) string from raw key material, and
+ * read the account key material back out of one (`accountPubkeyFromXpub`).
  *
  * Mirrors the algorithm used by `hw-app-btc` `BtcOld.getWalletXpub`, kept local
  * because the `DmkSignerZcash` signer kit only exposes `getAddress` and not a
@@ -52,6 +53,46 @@ export function composeXpub(args: {
   ]);
   const checksum = hash256(extendedKeyBytes).slice(0, 4);
   return bs58.encode(Buffer.concat([extendedKeyBytes, checksum]));
+}
+
+/**
+ * Extract the account-level transparent key material from an xpub: the 32-byte
+ * chain code followed by the 33-byte compressed public key, hex-encoded.
+ *
+ * These 65 bytes are what a ZIP-316 UFVK carries as its transparent (P2PKH)
+ * item, and all the PCZT builder needs to derive the internal change address and
+ * to verify each transparent input's signing path. Deriving them from the xpub
+ * the account already holds is what lets a transparent send proceed without a
+ * UFVK, whose export costs a device confirmation.
+ *
+ * The BIP-32 metadata dropped here (version, depth, parent fingerprint, child
+ * number) plays no part in child derivation, and a UFVK does not preserve it
+ * either.
+ *
+ * wallet-btc reads the same two fields at the same offsets on its way to a
+ * derived child key (`crypto/base.ts`'s `getPubkeyAt`), but exposes neither them
+ * nor the account-level pair, hence this local reader — the counterpart of
+ * `composeXpub` above, which produces the xpub in the first place.
+ */
+export function accountPubkeyFromXpub(xpub: string): string {
+  const decoded = Buffer.from(bs58.decode(xpub));
+  // 4 version + 1 depth + 4 fingerprint + 4 child number + 32 chain code
+  // + 33 key + 4 checksum.
+  if (decoded.length !== 82) {
+    throw new Error(`Unexpected xpub length: expected 82 bytes, got ${decoded.length}`);
+  }
+  if (!hash256(decoded.subarray(0, 78)).subarray(0, 4).equals(decoded.subarray(78))) {
+    throw new Error("Invalid xpub: checksum mismatch");
+  }
+  const publicKey = decoded.subarray(45, 78);
+  if (publicKey[0] !== 0x02 && publicKey[0] !== 0x03) {
+    throw new Error(
+      `Invalid xpub: expected a compressed public key (0x02/0x03 prefix), got 0x${publicKey[0]
+        .toString(16)
+        .padStart(2, "0")}`,
+    );
+  }
+  return decoded.subarray(13, 78).toString("hex");
 }
 
 function asBufferUInt32BE(n: number): Buffer {

--- a/libs/coin-modules/coin-zcash/src/types/errors.test.ts
+++ b/libs/coin-modules/coin-zcash/src/types/errors.test.ts
@@ -1,6 +1,7 @@
 import {
   ZcashNotesNotYetSpendable,
   ZcashSaplingRecipientNotSupported,
+  ZcashShieldedKeyMissing,
   ZcashSignerNotSupported,
   ZcashSigningCancelled,
   ZcashUtxoNotInAccount,
@@ -14,6 +15,10 @@ describe("zcash errors", () => {
     [ZcashSignerNotSupported, "Signer does not support Zcash PCZT signing"],
     [ZcashSigningCancelled, "Zcash signing was cancelled"],
     [ZcashNotesNotYetSpendable, "These funds are not spendable yet, try again in a few minutes"],
+    [
+      ZcashShieldedKeyMissing,
+      "Activate your private balance first: this transfer needs the viewing key from your device",
+    ],
   ])("names %p and gives it a readable default message", (Err, message) => {
     const error = new Err();
 

--- a/libs/coin-modules/coin-zcash/src/types/errors.ts
+++ b/libs/coin-modules/coin-zcash/src/types/errors.ts
@@ -16,6 +16,22 @@ export class ZcashSignerNotSupported extends Error {
   }
 }
 
+/**
+ * Raised when a send that spends or creates shielded value is attempted on an
+ * account whose UFVK has not been exported from the device yet. The shielded
+ * pools are unreadable without it, so no such transaction can be built. A
+ * transparent send is unaffected -- it needs no viewing key (see
+ * `bridge/signOperation`'s `resolveAccountKey`).
+ */
+export class ZcashShieldedKeyMissing extends Error {
+  constructor(
+    message = "Activate your private balance first: this transfer needs the viewing key from your device",
+  ) {
+    super(message);
+    this.name = "ZcashShieldedKeyMissing";
+  }
+}
+
 /** Typed cancellation marker for the shielded (PCZT) signOperation flow. */
 export class ZcashSigningCancelled extends Error {
   constructor(message = "Zcash signing was cancelled") {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,8 +112,8 @@ catalogs:
       specifier: 2.3.3
       version: 2.3.3
     '@ledgerhq/zcash-utils':
-      specifier: 2.1.1
-      version: 2.1.1
+      specifier: 2.2.0
+      version: 2.2.0
     '@playwright/test':
       specifier: 1.60.0
       version: 1.60.0
@@ -1143,7 +1143,7 @@ importers:
         version: link:../../libs/wallet-pnl
       '@ledgerhq/zcash-utils':
         specifier: 'catalog:'
-        version: 2.1.1
+        version: 2.2.0
       '@lottiefiles/dotlottie-react':
         specifier: 0.17.13
         version: 0.17.13(react@19.1.4)
@@ -9331,7 +9331,7 @@ importers:
         version: link:../../wallet-btc
       '@ledgerhq/zcash-utils':
         specifier: 'catalog:'
-        version: 2.1.1
+        version: 2.2.0
       '@noble/hashes':
         specifier: 1.8.0
         version: 1.8.0
@@ -21012,8 +21012,8 @@ packages:
   '@ledgerhq/wallet-api-simulator@2.3.3':
     resolution: {integrity: sha512-gtSepkiGXvwIyvMC0DhNNYfZKt2BXFZ7IeFIY7h3Edz9ya5LxaRWWe3Zczo5Ex2CHgH2ALfXew+tZOod9Hd6Rg==}
 
-  '@ledgerhq/zcash-utils@2.1.1':
-    resolution: {integrity: sha512-ImaCqeOjngqFRsuBoSQ7iiTX9TUqvdpXdzvLoKQF2fI3J91nUUMU4TTMxC1hHvjzSnme4tlVJD6ZIiM2bavrDg==}
+  '@ledgerhq/zcash-utils@2.2.0':
+    resolution: {integrity: sha512-8ghTxspNrXUWaJBnoW/NuWF4sDlzH7E8/lg7iZc1BQ0RGZMEh3XiM0yF9mz5oB7Hqudb9UQNEg7Xu3q32J4YGQ==}
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
@@ -27439,7 +27439,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: ^5.5.10
+      rxjs: '*'
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -49669,7 +49669,7 @@ snapshots:
       - encoding
       - utf-8-validate
 
-  '@ledgerhq/zcash-utils@2.1.1': {}
+  '@ledgerhq/zcash-utils@2.2.0': {}
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 
@@ -68461,7 +68461,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.7(metro-transform-worker@0.83.7)
+      metro: 0.83.7
       metro-babel-transformer: 0.83.7
       metro-cache: 0.83.7
       metro-cache-key: 0.83.7
@@ -68611,53 +68611,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro@0.83.7(metro-transform-worker@0.83.7):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 2.0.0
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.35.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0(metro@0.83.7)
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.7
-      metro-cache: 0.83.7
-      metro-cache-key: 0.83.7
-      metro-config: 0.83.7(metro-transform-worker@0.83.7)
-      metro-core: 0.83.7
-      metro-file-map: 0.83.7(metro@0.83.7)
-      metro-resolver: 0.83.7
-      metro-runtime: 0.83.7
-      metro-source-map: 0.83.7
-      metro-symbolicate: 0.83.7
-      metro-transform-plugins: 0.83.7
-      metro-transform-worker: 0.83.7
-      mime-types: 3.0.1
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,7 +51,7 @@ catalog:
   "@ledgerhq/wallet-api-core": 2.0.0
   "@ledgerhq/wallet-api-server": 3.4.3
   "@ledgerhq/wallet-api-simulator": 2.3.3
-  "@ledgerhq/zcash-utils": 2.1.1
+  "@ledgerhq/zcash-utils": 2.2.0
   # React Native
   react-native: 0.81.6
   "@react-native/assets-registry": 0.81.6


### PR DESCRIPTION
### 📝 Description

**Previous behaviour.** Every Zcash send required the account's UFVK, so a
public t→t send failed at the device step with `Missing UFVK -- account not yet
synced`. A UFVK only reaches the wallet through the viewing-key export flow,
which the user has to confirm on the device — and the send flow deliberately does
not ask for it, since only the *private* transfer option is gated on its
presence (`ZcashTransferFromSelector`). Any account that had never activated its
private balance therefore could not spend its transparent funds at all.

**The fix.** A transparent send carries no shielded bundle and reads no shielded
key material. The only key it needs is the account-level transparent pubkey at
`m/44'/133'/n'` — which the builder uses to derive the internal change address
and to verify each transparent input's signing path — and that is exactly the
payload of the account xpub the account already holds. `signOperation` now reads
it from there and passes it to the builder in place of the UFVK:

```ts
// bridge/signOperation.ts
const buildResult = useIronwood
  ? await craftIronwoodTransaction({ ...plan, ufvk: requireUfvk(ufvk) })
  : await craftTransaction({ ...plan, ...resolveAccountKey(account, ufvk) });
```

`resolveAccountKey` prefers the UFVK when the account has one, so an account with
a private balance keeps its existing code path unchanged; otherwise it derives
the 65 bytes (32-byte chain code ‖ 33-byte compressed pubkey) with
`accountPubkeyFromXpub`, the counterpart of the existing `composeXpub` in the
same module. A UFVK-less shielded flow is now refused with a typed
`ZcashShieldedKeyMissing` instead of a bare `Error`.

Note that a transparent-only UFVK cannot be synthesized instead: ZIP-316 rejects
one (`ParseError::OnlyTransparent`), which is why the builder had to learn to
take the pubkey directly.

**Regression cover.** `signOperation.test.ts` adds a suite for an account whose
UFVK has not been exported: it signs a transparent send from the xpub alone (the
LIVE-36260 case), refuses each of the three shielded transfer types with
`ZcashShieldedKeyMissing`, and reports a missing xpub rather than building from no
key at all. A separate test asserts a UFVK-bearing account still takes the UFVK
path. `xpub.test.ts` checks `accountPubkeyFromXpub` against the published BIP-32
test vector and rejects a truncated, corrupted or uncompressed key.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36260](https://ledgerhq.atlassian.net/browse/LIVE-36260)
- **Requires**: [ledger-zcash-utils#44](https://github.com/LedgerHQ/ledger-zcash-utils/pull/44),
  which makes `ufvk` optional and adds `transparentAccountPubkey` to
  `buildTransaction`. Published as 2.2.0 and pinned here in the third commit,
  which also drops the cast that let this branch typecheck against the older
  signature while that release was in flight. Nothing is gated on it any more.

### Validation

`pnpm --filter @ledgerhq/coin-zcash test`: 733 passed. `pnpm nx build
@ledgerhq/coin-zcash`, `nx run @ledgerhq/coin-zcash:unimported`, `oxlint` and
`oxfmt --check`: all clean. Coverage on the touched files: `signOperation.ts`
92.2%, `xpub.ts` / `craftTransaction.ts` / `errors.ts` 100%.

Also verified end-to-end through the native binary: a t→t PCZT (1 transparent
input, 2 transparent outputs, 0 Orchard actions) built from the account pubkey
alone, with no UFVK anywhere in the call. `pnpm nx build @ledgerhq/coin-zcash
--skip-nx-cache` compiles against the published 2.2.0 types, which is what covers
the removed cast.

**Device pass:** validated manually — a Public send from an account that never
exported its UFVK reaches the device and signs, which is the flow the ticket
reports as failing.


[LIVE-36260]: https://ledgerhq.atlassian.net/browse/LIVE-36260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ