### PR TITLE
[LWDM] feat(braze): add identity lifecycle module (LIVE-34730)

### DIFF
--- a/.changeset/quiet-braze-lifecycle.md
+++ b/.changeset/quiet-braze-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Add a shared Braze identity lifecycle module for opt-in and opt-out SDK reset

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -390,6 +390,7 @@
     "src/api/ofacGeoBlockApi.ts",
     "src/braze/anonymousUsers.ts",
     "src/braze/contentCardExtras.ts",
+    "src/braze/identityLifecycle.ts",
     "src/bridge/descriptor/registry.ts",
     "src/bridge/descriptor/send/features.ts",
     "src/bridge/descriptor/send/memo.ts",

--- a/libs/ledger-live-common/src/braze/identityLifecycle.test.ts
+++ b/libs/ledger-live-common/src/braze/identityLifecycle.test.ts
@@ -1,0 +1,127 @@
+import {
+  runBrazeOptInTransition,
+  runBrazeOptOutTransition,
+  type BrazeIdentityLifecycleSdk,
+} from "./identityLifecycle";
+
+const USER_ID = "11111111-1111-1111-1111-111111111111";
+
+function createSdk(
+  overrides: Partial<jest.Mocked<BrazeIdentityLifecycleSdk>> = {},
+): jest.Mocked<BrazeIdentityLifecycleSdk> {
+  return {
+    wipeData: jest.fn(),
+    enableSDK: jest.fn(),
+    changeUser: jest.fn(),
+    refreshContentCards: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe("runBrazeOptOutTransition", () => {
+  it("should reset the SDK and refresh cards without identifying when opting out", async () => {
+    const sdk = createSdk();
+
+    await runBrazeOptOutTransition(sdk);
+
+    expect(sdk.wipeData).toHaveBeenCalledTimes(1);
+    expect(sdk.enableSDK).toHaveBeenCalledTimes(1);
+    expect(sdk.refreshContentCards).toHaveBeenCalledTimes(1);
+    expect(sdk.changeUser).not.toHaveBeenCalled();
+    expect(sdk.wipeData.mock.invocationCallOrder[0]).toBeLessThan(
+      sdk.enableSDK.mock.invocationCallOrder[0],
+    );
+    expect(sdk.enableSDK.mock.invocationCallOrder[0]).toBeLessThan(
+      sdk.refreshContentCards.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("should not enable the SDK when wipeData fails", async () => {
+    const sdk = createSdk({
+      wipeData: jest.fn(async () => {
+        throw new Error("wipe failed");
+      }),
+    });
+
+    await expect(runBrazeOptOutTransition(sdk)).rejects.toThrow("wipe failed");
+    expect(sdk.enableSDK).not.toHaveBeenCalled();
+    expect(sdk.refreshContentCards).not.toHaveBeenCalled();
+    expect(sdk.changeUser).not.toHaveBeenCalled();
+  });
+
+  it("should not refresh cards when enableSDK fails", async () => {
+    const sdk = createSdk({
+      enableSDK: jest.fn(async () => {
+        throw new Error("enable failed");
+      }),
+    });
+
+    await expect(runBrazeOptOutTransition(sdk)).rejects.toThrow("enable failed");
+    expect(sdk.wipeData).toHaveBeenCalledTimes(1);
+    expect(sdk.refreshContentCards).not.toHaveBeenCalled();
+    expect(sdk.changeUser).not.toHaveBeenCalled();
+  });
+});
+
+describe("runBrazeOptInTransition", () => {
+  it("should identify after resetting the SDK when opting in", async () => {
+    const sdk = createSdk();
+
+    await runBrazeOptInTransition(sdk, { userId: USER_ID });
+
+    expect(sdk.wipeData).toHaveBeenCalledTimes(1);
+    expect(sdk.enableSDK).toHaveBeenCalledTimes(1);
+    expect(sdk.changeUser).toHaveBeenCalledTimes(1);
+    expect(sdk.changeUser).toHaveBeenCalledWith(USER_ID);
+    expect(sdk.refreshContentCards).toHaveBeenCalledTimes(1);
+    expect(sdk.wipeData.mock.invocationCallOrder[0]).toBeLessThan(
+      sdk.enableSDK.mock.invocationCallOrder[0],
+    );
+    expect(sdk.enableSDK.mock.invocationCallOrder[0]).toBeLessThan(
+      sdk.changeUser.mock.invocationCallOrder[0],
+    );
+    expect(sdk.changeUser.mock.invocationCallOrder[0]).toBeLessThan(
+      sdk.refreshContentCards.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("should not call the SDK when the user id is missing", async () => {
+    const sdk = createSdk();
+
+    await expect(runBrazeOptInTransition(sdk, { userId: "" })).rejects.toThrow(
+      "Braze opt-in transition requires a user id",
+    );
+    expect(sdk.wipeData).not.toHaveBeenCalled();
+    expect(sdk.enableSDK).not.toHaveBeenCalled();
+    expect(sdk.changeUser).not.toHaveBeenCalled();
+    expect(sdk.refreshContentCards).not.toHaveBeenCalled();
+  });
+
+  it("should not identify when wipeData fails", async () => {
+    const sdk = createSdk({
+      wipeData: jest.fn(async () => {
+        throw new Error("wipe failed");
+      }),
+    });
+
+    await expect(runBrazeOptInTransition(sdk, { userId: USER_ID })).rejects.toThrow("wipe failed");
+    expect(sdk.enableSDK).not.toHaveBeenCalled();
+    expect(sdk.changeUser).not.toHaveBeenCalled();
+    expect(sdk.refreshContentCards).not.toHaveBeenCalled();
+  });
+
+  it("should not refresh cards when changeUser fails", async () => {
+    const sdk = createSdk({
+      changeUser: jest.fn(async (_userId: string) => {
+        throw new Error("changeUser failed");
+      }),
+    });
+
+    await expect(runBrazeOptInTransition(sdk, { userId: USER_ID })).rejects.toThrow(
+      "changeUser failed",
+    );
+    expect(sdk.wipeData).toHaveBeenCalledTimes(1);
+    expect(sdk.enableSDK).toHaveBeenCalledTimes(1);
+    expect(sdk.refreshContentCards).not.toHaveBeenCalled();
+  });
+});

--- a/libs/ledger-live-common/src/braze/identityLifecycle.ts
+++ b/libs/ledger-live-common/src/braze/identityLifecycle.ts
@@ -1,0 +1,46 @@
+/**
+ * Client-side Braze identity transitions for consent changes.
+ *
+ * `wipeData()` only clears **local** SDK state on the device and disables the SDK
+ * until `enableSDK()`. It does **not** delete the Braze server profile
+ * (`/users/delete`). See https://www.braze.com/docs/developer_guide/analytics/managing_data_collection/
+ */
+
+export type BrazeIdentityLifecycleSdk = {
+  wipeData: () => void | Promise<void>;
+  enableSDK: () => void | Promise<void>;
+  changeUser: (userId: string) => void | Promise<void>;
+  refreshContentCards: () => void | Promise<void>;
+};
+
+export type BrazeOptInIdentity = {
+  userId: string;
+};
+
+/**
+ * Opt-in → opt-out: reset the local SDK session and refetch broad Content Cards.
+ * Does not assign an `external_id`.
+ */
+export async function runBrazeOptOutTransition(sdk: BrazeIdentityLifecycleSdk): Promise<void> {
+  await sdk.wipeData();
+  await sdk.enableSDK();
+  await sdk.refreshContentCards();
+}
+
+/**
+ * Opt-out → opt-in: reset the local SDK session, identify with the real user id,
+ * then refetch Content Cards.
+ */
+export async function runBrazeOptInTransition(
+  sdk: BrazeIdentityLifecycleSdk,
+  identity: BrazeOptInIdentity,
+): Promise<void> {
+  if (!identity.userId) {
+    throw new Error("Braze opt-in transition requires a user id");
+  }
+
+  await sdk.wipeData();
+  await sdk.enableSDK();
+  await sdk.changeUser(identity.userId);
+  await sdk.refreshContentCards();
+}


### PR DESCRIPTION
### 📝 Description

[LIVE-34730](https://ledgerhq.atlassian.net/browse/LIVE-34730): shared, platform-agnostic Braze opt-in / opt-out sequences in live-common. No app wiring yet (LIVE-34731 / LIVE-34732).

- New `identityLifecycle` module with an injected SDK adapter (`wipeData`, `enableSDK`, `changeUser`, `refreshContentCards`)
- Opt-out: wipe → enable → refresh. Does not call `changeUser`
- Opt-in: wipe → enable → `changeUser(userId)` → refresh. Empty user id fails before any SDK call
- JSDoc: `wipeData()` is **local-only** (clears device SDK state and disables until `enableSDK`). It does not delete the Braze server profile (`/users/delete`)

This branch sits on [LIVE-34724](https://ledgerhq.atlassian.net/browse/LIVE-34724). If that PR is not merged, set the base to `feat/LIVE-34724`.

### Test plan

- [ ] Opt-out does not call `changeUser`
- [ ] Opt-in identifies only after wipe + enable
- [ ] A failed step does not run later steps
- [ ] Missing opt-in user id does not touch the SDK
- [ ] Staging (follow-up, not this PR): after opt-out the device is no longer the old `external_id`; `enableSDK` + card refetch still works; a leftover Braze dashboard profile is expected

[LIVE-34730]: https://ledgerhq.atlassian.net/browse/LIVE-34730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-34724]: https://ledgerhq.atlassian.net/browse/LIVE-34724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ