### PR TITLE
feat(card): add the internal and card-linked wallet queries

### DIFF
--- a/.changeset/wallet-linked-endpoints.md
+++ b/.changeset/wallet-linked-endpoints.md
@@ -1,0 +1,12 @@
+---
+"@domain/api-card-management": minor
+---
+
+Add the custodial wallet queries the card balance is built from:
+
+- `getInternalWallets` for `GET /v1/wallet/internal` — the only endpoint carrying balances, kept as decimal strings so the provider's precision survives.
+- `getCardLinkedWallets` for `GET /v1/wallet/internal/card_linked` — the wallets funding the card, with the priority Baanx charges them in.
+
+Both schemas are narrow: the internal wallet drops `addressId` and the constant `type`, and neither endpoint is given a cache tag until the link/unlink mutations that would invalidate it exist.
+
+`addressMemo` accepts an explicit `null`, which is what the provider sends for a wallet with no memo. Requiring a string or an absent key would have failed that wallet, and with it the whole array.

--- a/domain/api/card-management/README.md
+++ b/domain/api/card-management/README.md
@@ -25,6 +25,8 @@ shape and the reasons.
 | `getUser` | GET | `/v1/user` | Read the account id and verification state |
 | `orderCard` | POST | `/v1/card/order` | Order a virtual card |
 | `getCardStatus` | GET | `/v1/card/status` | Read the ordered card's state and preview fields |
+| `getInternalWallets` | GET | `/v1/wallet/internal` | Read every custodial wallet, with balances |
+| `getCardLinkedWallets` | GET | `/v1/wallet/internal/card_linked` | Read the wallets funding the card, in charging order |
 
 `cardManagementApi` **is** `cardApi` after injection: importing this package is a module-level side
 effect that adds its endpoints to the shared service. The app registers `cardApi` (not this package)

--- a/domain/api/card-management/src/api.test.ts
+++ b/domain/api/card-management/src/api.test.ts
@@ -1,6 +1,12 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { cardApi, cardApiExtra } from "@shared/api-services";
-import { cardManagementApi, useGetCardStatusQuery, useOrderCardMutation } from "./api";
+import {
+  cardManagementApi,
+  useGetCardLinkedWalletsQuery,
+  useGetCardStatusQuery,
+  useGetInternalWalletsQuery,
+  useOrderCardMutation,
+} from "./api";
 import { PayCardErrorResponseSchema } from "./schema";
 
 function jsonResponse(body: unknown): Response {
@@ -42,7 +48,7 @@ const session = {
   refreshToken: "rt_token",
 };
 
-// The provider's own example response, field for field.
+// The provider's own example response.
 const cardStatus = {
   id: "000000000050277836",
   holderName: "JOHN DOE",
@@ -52,6 +58,49 @@ const cardStatus = {
   type: "VIRTUAL",
   orderedAt: "2023-03-27T17:07:12.662Z",
 };
+
+// The provider's own example responses, as they arrive on the wire.
+const internalWalletsOnTheWire = [
+  {
+    id: "098aeb90-e7f7-4f81-bc2e-4963330122c5",
+    balance: "125.50",
+    currency: "xrp",
+    address: "rNxp4h8apvRis6mJf9Sh8C6iRxfrDWN7AA",
+    addressMemo: "78",
+    addressId: "0x0a4b21fa733e9aeaddbf070302a85c559de13c4c",
+    type: "INTERNAL",
+  },
+  {
+    id: "7c1839ee-918e-4787-b74f-deeb48ead58b",
+    balance: "500.00",
+    currency: "usdc",
+    address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb4",
+    addressMemo: null,
+    addressId: "7c1839ee-918e-4787-b74f-deeb48ead58b",
+    type: "INTERNAL",
+  },
+];
+
+const internalWallets = internalWalletsOnTheWire.map(
+  ({ addressId: _addressId, type: _type, ...wallet }) => wallet,
+);
+
+const linkedWallets = [
+  {
+    id: "1693a6da-5945-4461-ba1c-0b9891f78848",
+    address: "DfKNsYfrCEHb7ScJkuMTtPTeDiyjmBBm9NMHnbR7uFHz",
+    currency: "sol",
+    network: "solana",
+    priority: 1,
+  },
+  {
+    id: "7c1839ee-918e-4787-b74f-deeb48ead58b",
+    address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb4",
+    currency: "usdc",
+    network: "ethereum",
+    priority: 2,
+  },
+];
 
 // Wired the way the apps wire it: the store registers the service api, never this package.
 const makeStore = (
@@ -83,7 +132,9 @@ describe("cardManagementApi configuration", () => {
   it("injects exactly its own endpoints", () => {
     expect(Object.keys(cardManagementApi.endpoints).sort()).toEqual([
       "exchangeAuthorizationCode",
+      "getCardLinkedWallets",
       "getCardStatus",
+      "getInternalWallets",
       "getUser",
       "logout",
       "orderCard",
@@ -99,6 +150,13 @@ describe("cardManagementApi configuration", () => {
   it("exposes the getCardStatus endpoint and its hook", () => {
     expect(cardManagementApi.endpoints.getCardStatus).toBeDefined();
     expect(useGetCardStatusQuery).toBeDefined();
+  });
+
+  it("exposes the wallet endpoints and their hooks", () => {
+    expect(cardManagementApi.endpoints.getInternalWallets).toBeDefined();
+    expect(useGetInternalWalletsQuery).toBeDefined();
+    expect(cardManagementApi.endpoints.getCardLinkedWallets).toBeDefined();
+    expect(useGetCardLinkedWalletsQuery).toBeDefined();
   });
 
   it("shares the Card service reducer and middleware once registered in a store", () => {
@@ -323,6 +381,149 @@ describe("cardManagementApi requests", () => {
       expect(statusRequests).toHaveLength(2);
 
       status.unsubscribe();
+    });
+  });
+
+  describe("getInternalWallets", () => {
+    it("reads every custodial wallet with the bearer token and the client key", async () => {
+      fetchSpy = jest
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(jsonResponse(internalWalletsOnTheWire));
+
+      const store = makeStore(async () => "session-token");
+      const result = await store.dispatch(
+        cardManagementApi.endpoints.getInternalWallets.initiate(),
+      );
+
+      expect(request(fetchSpy).url).toBe("https://card.test/v1/wallet/internal");
+      expect(request(fetchSpy).method).toBe("GET");
+      expect(request(fetchSpy).headers.get("authorization")).toBe("Bearer session-token");
+      expect(request(fetchSpy).headers.get("x-client-key")).toBe("client-key");
+      expect(result.data).toEqual(internalWallets);
+    });
+
+    it("keeps the balance a string, so the provider's precision survives", async () => {
+      fetchSpy = jest
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(
+          jsonResponse([{ ...internalWallets[0], balance: "9007199254740993.000001" }]),
+        );
+
+      const store = makeStore(async () => "session-token");
+      const result = await store.dispatch(
+        cardManagementApi.endpoints.getInternalWallets.initiate(),
+      );
+
+      expect(result.data?.[0].balance).toBe("9007199254740993.000001");
+    });
+
+    it("drops the keys the wire contract does not declare", async () => {
+      fetchSpy = jest
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(jsonResponse([internalWalletsOnTheWire[0]]));
+
+      const store = makeStore(async () => "session-token");
+      const result = await store.dispatch(
+        cardManagementApi.endpoints.getInternalWallets.initiate(),
+      );
+
+      expect(result.data).toEqual([internalWallets[0]]);
+    });
+
+    it("accepts a user with no wallets as an empty list, not an error", async () => {
+      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse([]));
+
+      const store = makeStore(async () => "session-token");
+      const result = await store.dispatch(
+        cardManagementApi.endpoints.getInternalWallets.initiate(),
+      );
+
+      expect(result.data).toEqual([]);
+      expect(result.error).toBeUndefined();
+    });
+
+    it("rejects a balance the provider sent as a number", async () => {
+      fetchSpy = jest
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(jsonResponse([{ ...internalWallets[0], balance: 125.4 }]));
+
+      const store = makeStore(async () => "session-token");
+      const result = await store.dispatch(
+        cardManagementApi.endpoints.getInternalWallets.initiate(),
+      );
+
+      expect(result.data).toBeUndefined();
+      expect(result.error).toBeDefined();
+    });
+
+    it("rejects an envelope where the contract promises a bare array", async () => {
+      fetchSpy = jest
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(jsonResponse({ wallets: internalWallets }));
+
+      const store = makeStore(async () => "session-token");
+      const result = await store.dispatch(
+        cardManagementApi.endpoints.getInternalWallets.initiate(),
+      );
+
+      expect(result.data).toBeUndefined();
+      expect(result.error).toBeDefined();
+    });
+  });
+
+  describe("getCardLinkedWallets", () => {
+    it("reads the linked wallets with the bearer token and the client key", async () => {
+      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(linkedWallets));
+
+      const store = makeStore(async () => "session-token");
+      const result = await store.dispatch(
+        cardManagementApi.endpoints.getCardLinkedWallets.initiate(),
+      );
+
+      expect(request(fetchSpy).url).toBe("https://card.test/v1/wallet/internal/card_linked");
+      expect(request(fetchSpy).method).toBe("GET");
+      expect(request(fetchSpy).headers.get("authorization")).toBe("Bearer session-token");
+      expect(request(fetchSpy).headers.get("x-client-key")).toBe("client-key");
+      expect(result.data).toEqual(linkedWallets);
+    });
+
+    it("keeps a priority of zero, which is the first wallet charged", async () => {
+      fetchSpy = jest
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(jsonResponse([{ ...linkedWallets[0], priority: 0 }]));
+
+      const store = makeStore(async () => "session-token");
+      const result = await store.dispatch(
+        cardManagementApi.endpoints.getCardLinkedWallets.initiate(),
+      );
+
+      expect(result.data?.[0].priority).toBe(0);
+    });
+
+    it("accepts a card with nothing linked to it as an empty list", async () => {
+      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse([]));
+
+      const store = makeStore(async () => "session-token");
+      const result = await store.dispatch(
+        cardManagementApi.endpoints.getCardLinkedWallets.initiate(),
+      );
+
+      expect(result.data).toEqual([]);
+      expect(result.error).toBeUndefined();
+    });
+
+    it("rejects a wallet whose priority is not a number", async () => {
+      fetchSpy = jest
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(jsonResponse([{ ...linkedWallets[0], priority: "1" }]));
+
+      const store = makeStore(async () => "session-token");
+      const result = await store.dispatch(
+        cardManagementApi.endpoints.getCardLinkedWallets.initiate(),
+      );
+
+      expect(result.data).toBeUndefined();
+      expect(result.error).toBeDefined();
     });
   });
 

--- a/domain/api/card-management/src/api.ts
+++ b/domain/api/card-management/src/api.ts
@@ -1,6 +1,8 @@
 import { cardApi } from "@shared/api-services";
 import { CARD_MANAGEMENT_TAGS } from "./constants";
 import {
+  PayCardInternalWalletsResponseSchema,
+  PayCardLinkedWalletsResponseSchema,
   PayCardLogoutResponseSchema,
   PayCardOrderResponseSchema,
   PayCardSessionResponseSchema,
@@ -11,6 +13,8 @@ import {
 import { transformPayCardSessionResponse } from "./transforms";
 import type {
   PayCardAuthorizationCodeRequest,
+  PayCardInternalWallet,
+  PayCardLinkedWallet,
   PayCardLogoutResult,
   PayCardOrderResult,
   PayCardRefreshSessionRequest,
@@ -93,6 +97,22 @@ export const cardManagementApi = cardApi
         responseSchema: PayCardStatusResponseSchema,
         providesTags: ["CardStatus"],
       }),
+
+      getInternalWallets: build.query<PayCardInternalWallet[], void>({
+        query: () => ({
+          url: "/v1/wallet/internal",
+          method: "GET",
+        }),
+        responseSchema: PayCardInternalWalletsResponseSchema,
+      }),
+
+      getCardLinkedWallets: build.query<PayCardLinkedWallet[], void>({
+        query: () => ({
+          url: "/v1/wallet/internal/card_linked",
+          method: "GET",
+        }),
+        responseSchema: PayCardLinkedWalletsResponseSchema,
+      }),
     }),
   });
 
@@ -105,4 +125,6 @@ export const {
   useGetUserQuery,
   useOrderCardMutation,
   useGetCardStatusQuery,
+  useGetInternalWalletsQuery,
+  useGetCardLinkedWalletsQuery,
 } = cardManagementApi;

--- a/domain/api/card-management/src/schema.test.ts
+++ b/domain/api/card-management/src/schema.test.ts
@@ -1,5 +1,7 @@
 import {
   PayCardErrorResponseSchema,
+  PayCardInternalWalletSchema,
+  PayCardLinkedWalletSchema,
   PayCardLogoutResponseSchema,
   PayCardOrderResponseSchema,
   PayCardSessionResponseSchema,
@@ -72,7 +74,7 @@ describe("PayCardOrderResponseSchema", () => {
 });
 
 describe("PayCardStatusResponseSchema", () => {
-  // The provider's own example response, field for field.
+  // The provider's own example response.
   const cardStatus = {
     id: "000000000050277836",
     holderName: "JOHN DOE",
@@ -120,5 +122,108 @@ describe("PayCardErrorResponseSchema", () => {
 
   it("rejects an error body with no message", () => {
     expect(() => PayCardErrorResponseSchema.parse({})).toThrow();
+  });
+});
+
+describe("PayCardInternalWalletSchema", () => {
+  // The provider's own example response.
+  const documentedWallets = [
+    {
+      id: "098aeb90-e7f7-4f81-bc2e-4963330122c5",
+      balance: "125.50",
+      currency: "xrp",
+      address: "rNxp4h8apvRis6mJf9Sh8C6iRxfrDWN7AA",
+      addressMemo: "78",
+      addressId: "0x0a4b21fa733e9aeaddbf070302a85c559de13c4c",
+      type: "INTERNAL",
+    },
+    {
+      id: "7c1839ee-918e-4787-b74f-deeb48ead58b",
+      balance: "500.00",
+      currency: "usdc",
+      address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb4",
+      addressMemo: null,
+      addressId: "7c1839ee-918e-4787-b74f-deeb48ead58b",
+      type: "INTERNAL",
+    },
+  ];
+
+  const wallet = documentedWallets[0];
+
+  it("reads the whole documented response, memo-less wallet included", () => {
+    expect(documentedWallets.map(entry => PayCardInternalWalletSchema.parse(entry))).toHaveLength(
+      2,
+    );
+  });
+
+  it("keeps an explicit null memo as null", () => {
+    expect(PayCardInternalWalletSchema.parse(documentedWallets[1]).addressMemo).toBeNull();
+  });
+
+  it("keeps the balance as the string the provider sent", () => {
+    expect(PayCardInternalWalletSchema.parse(wallet).balance).toBe("125.50");
+  });
+
+  it("drops the internal address id and the constant type the contract does not declare", () => {
+    const parsed = PayCardInternalWalletSchema.parse(wallet);
+
+    expect(parsed).not.toHaveProperty("addressId");
+    expect(parsed).not.toHaveProperty("type");
+  });
+
+  it("keeps the address memo the chain needs", () => {
+    expect(PayCardInternalWalletSchema.parse(wallet).addressMemo).toBe("78");
+  });
+
+  it("rejects an empty memo, because the provider writes no memo as null", () => {
+    expect(() => PayCardInternalWalletSchema.parse({ ...wallet, addressMemo: "" })).toThrow();
+  });
+
+  it("rejects a balance sent as a number, which would already have lost precision", () => {
+    expect(() => PayCardInternalWalletSchema.parse({ ...wallet, balance: 125.4 })).toThrow();
+  });
+
+  it("rejects an empty balance, which is not the same as zero", () => {
+    expect(() => PayCardInternalWalletSchema.parse({ ...wallet, balance: "" })).toThrow();
+  });
+});
+
+describe("PayCardLinkedWalletSchema", () => {
+  // The provider's own example response.
+  const linked = {
+    id: "7c1839ee-918e-4787-b74f-deeb48ead58b",
+    address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb4",
+    currency: "usdc",
+    network: "ethereum",
+    priority: 2,
+  };
+
+  it("reads the documented linked wallet", () => {
+    expect(PayCardLinkedWalletSchema.parse(linked)).toEqual(linked);
+  });
+
+  it("accepts a priority of zero", () => {
+    expect(PayCardLinkedWalletSchema.parse({ ...linked, priority: 0 }).priority).toBe(0);
+  });
+
+  it("rejects a priority sent as a string", () => {
+    expect(() => PayCardLinkedWalletSchema.parse({ ...linked, priority: "1" })).toThrow();
+  });
+
+  it("rejects an overflowing priority, which JSON hands over as Infinity", () => {
+    const overflowed = JSON.parse('{"priority":1e400}') as { priority: number };
+
+    expect(overflowed.priority).toBe(Infinity);
+    expect(() =>
+      PayCardLinkedWalletSchema.parse({ ...linked, priority: overflowed.priority }),
+    ).toThrow();
+  });
+
+  it("keeps a negative priority, which sorts first and is not a parse failure", () => {
+    expect(PayCardLinkedWalletSchema.parse({ ...linked, priority: -1 }).priority).toBe(-1);
+  });
+
+  it("rejects a linked wallet with no network, which would not identify the asset", () => {
+    expect(() => PayCardLinkedWalletSchema.parse({ ...linked, network: "" })).toThrow();
   });
 });

--- a/domain/api/card-management/src/schema.ts
+++ b/domain/api/card-management/src/schema.ts
@@ -30,11 +30,6 @@ export const PayCardUserResponseSchema = z.object({
   verificationState: z.enum(["UNVERIFIED", "PENDING", "VERIFIED", "REJECTED"]),
 });
 
-/**
- * Not wired to an endpoint's `rawErrorResponseSchema`: a body that failed to validate would replace
- * the `FetchBaseQueryError` with a schema error, and `isUnauthorizedError` reads `status === 401`
- * off that error to end a session.
- */
 export const PayCardErrorResponseSchema = z.object({
   message: z.string(),
 });
@@ -57,3 +52,23 @@ export const PayCardStatusResponseSchema = z.object({
   type: z.enum(["VIRTUAL", "PHYSICAL", "METAL"]),
   orderedAt: z.string().min(1),
 });
+
+export const PayCardInternalWalletSchema = z.object({
+  id: z.string().min(1),
+  balance: z.string().min(1),
+  currency: z.string().min(1),
+  address: z.string().min(1),
+  addressMemo: z.string().min(1).nullable(),
+});
+
+export const PayCardInternalWalletsResponseSchema = z.array(PayCardInternalWalletSchema);
+
+export const PayCardLinkedWalletSchema = z.object({
+  id: z.string().min(1),
+  address: z.string().min(1),
+  currency: z.string().min(1),
+  network: z.string().min(1),
+  priority: z.number().finite(),
+});
+
+export const PayCardLinkedWalletsResponseSchema = z.array(PayCardLinkedWalletSchema);

--- a/domain/api/card-management/src/types.ts
+++ b/domain/api/card-management/src/types.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 import {
   PayCardErrorResponseSchema,
+  PayCardInternalWalletSchema,
+  PayCardLinkedWalletSchema,
   PayCardLogoutResponseSchema,
   PayCardOrderResponseSchema,
   PayCardSessionResponseSchema,
@@ -32,3 +34,7 @@ export type PayCardAuthorizationCodeRequest = {
 export type PayCardRefreshSessionRequest = {
   readonly refreshToken: string;
 };
+
+export type PayCardInternalWallet = z.infer<typeof PayCardInternalWalletSchema>;
+
+export type PayCardLinkedWallet = z.infer<typeof PayCardLinkedWalletSchema>;


### PR DESCRIPTION
<!-- stac-man:stack-start -->
**Stack** _(managed by [stac-man](https://github.com/bluegardenproject/stac-man))_

- **#20999 feat/LIVE-34773-card-wallet-endpoints ← this PR**
- #21000 feat/LIVE-34772-card-linked-wallet-balances
- #21163 feat/LIVE-34784-card-freeze-unfreeze
<!-- stac-man:stack-end -->

The card balance needs two endpoints joined: `GET /v1/wallet/internal` is the
only one carrying balances, and `GET /v1/wallet/internal/card_linked` names the
subset funding the card, in the order Baanx charges them. `id` joins them.

Balances stay decimal strings so the provider's precision survives to the
caller, which parses them with BigNumber. Both schemas are narrow: the internal
wallet drops `addressId` and the constant `type`. Neither query is given a cache
tag yet — the link and unlink mutations that would invalidate one do not exist.

### 🔗 Context

- **JIRA**: [LIVE-34773 — expose linked wallet balances](https://ledgerhq.atlassian.net/browse/LIVE-34773) · [LIVE-34774 — expose card debit order](https://ledgerhq.atlassian.net/browse/LIVE-34774)
- **Epic**: [LIVE-35974 — Frontend Adapter to Baanx API](https://ledgerhq.atlassian.net/browse/LIVE-35974)
- **Baanx**: [`GET /v1/wallet/internal`](https://docs.baanx.com/api-reference/wallet/internal) · [`GET /v1/wallet/internal/card_linked`](https://docs.baanx.com/api-reference/wallet/internal-card-linked-get)

This PR carries the two endpoints. The join, the charging order and the total that
LIVE-34773/34774 also describe land in #21000 on top of it.
