### PR TITLE
feat(card): join the card-linked wallets to their balances

### DIFF
--- a/.changeset/pay-card-linked-wallet-balances.md
+++ b/.changeset/pay-card-linked-wallet-balances.md
@@ -1,0 +1,10 @@
+---
+"@features/flow-pay-card-wallets": minor
+---
+
+New package joining the card's funding wallets to their balances:
+
+- `combineCardLinkedWallets` — joins the two wallet endpoints on `id`, orders by Baanx's charging priority, and totals the counter-values.
+- `useCardLinkedWallets` — runs both reads in parallel and memoizes the join.
+- The counter-value conversion is an injected port, so resolving Baanx's `currency`/`network` onto a Ledger currency stays in the app.
+- `isPartialTotal` flags a total that is understating, because a balance or a rate was missing.

--- a/features/flow/pay-card-wallets/README.md
+++ b/features/flow/pay-card-wallets/README.md
@@ -1,0 +1,46 @@
+# @features/flow-pay-card-wallets
+
+> [!CAUTION]
+> **Status: UNSTABLE** — Part of the emerging DDD layer; under active development.
+
+The custodial wallets funding the Pay card: which ones are linked, what they hold, and what the card
+can spend in total.
+
+Two Baanx endpoints have to be read together, because neither answers the question alone:
+
+| Endpoint | Carries | Missing |
+| -------- | ------- | ------- |
+| `GET /v1/wallet/internal` | every custodial wallet, **with balances** | which ones fund the card |
+| `GET /v1/wallet/internal/card_linked` | the linked ones, **in charging order** | balances |
+
+`id` joins them. Both live in [`@domain/api-card-management`](../../../domain/api/card-management/README.md);
+this package owns the join, the ordering and the total.
+
+- `combineCardLinkedWallets` — pure. Takes both lists and a counter-value resolver, returns the
+  linked wallets in charging order plus the total.
+- `useCardLinkedWallets` — runs both reads in parallel and memoizes the join.
+
+## The counter-value resolver is a port
+
+Balances arrive as **per-currency decimal strings** (`"125.40"` of `usdc`), so a total is only
+meaningful in one currency. Converting needs two things this package deliberately does not have:
+the asset catalogue that maps Baanx's `currency`/`network` pair onto a Ledger currency, and the
+countervalues state holding the rates. Both belong to the app, so the conversion arrives as
+`ResolveWalletCounterValue` and the package stays free of that graph.
+
+The raw decimal string is never parsed here — it is handed to the resolver as it came off the wire,
+so nothing rounds a balance on the way through.
+
+## `isPartialTotal` means the total is understating
+
+A wallet contributes nothing to `total` when its balance has not arrived, when no custodial wallet
+matched the link, or when the resolver has no rate for its asset. Any of those sets
+`isPartialTotal`, because a total that silently omits a funding source is worse than one that says
+it is incomplete. A link with no matching balance is **kept** in `wallets` with a `null` balance
+rather than dropped: the provider disagreeing with itself is worth showing.
+
+A `"0.00"` balance is not a missing one — it converts to `0` and leaves `isPartialTotal` alone.
+
+A resolver that answers `NaN` or `Infinity` counts as no rate at all. Left alone it would poison
+`total` while `isPartialTotal` still read `false`, which is the one combination this type is
+supposed to make impossible.

--- a/features/flow/pay-card-wallets/package.json
+++ b/features/flow/pay-card-wallets/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@features/flow-pay-card-wallets",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Card-linked custodial wallets for Ledger Wallet: joins Baanx linked wallets with their balances and totals them",
+  "main": "src/index.ts",
+  "react-native": "src/index.native.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "react-native": "./src/index.native.ts",
+      "default": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "format": "oxfmt src",
+    "format:check": "oxfmt src --check",
+    "lint": "oxlint src",
+    "lint:ci": "oxlint src --quiet",
+    "lint:fix": "oxfmt src && oxlint src --fix --quiet",
+    "typecheck": "tsc --noEmit -p tsconfig.web.json && tsc --noEmit -p tsconfig.native.json",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../../.. -W features/flow/pay-card-wallets"
+  },
+  "dependencies": {
+    "@domain/api-card-management": "workspace:^"
+  },
+  "devDependencies": {
+    "@support/jest-features-flow": "workspace:*",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@testing-library/dom": "catalog:",
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "jest": "catalog:",
+    "jest-environment-jsdom": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "react-redux": "catalog:",
+    "typescript": "catalog:"
+  },
+  "optionalDependencies": {
+    "@oxlint/binding-darwin-arm64": "1.51.0",
+    "@oxlint/binding-darwin-x64": "1.51.0",
+    "@oxlint/binding-linux-x64-gnu": "1.51.0",
+    "@oxlint/binding-win32-x64-msvc": "1.51.0"
+  },
+  "peerDependencies": {
+    "react": "catalog:",
+    "react-redux": "catalog:"
+  }
+}

--- a/features/flow/pay-card-wallets/project.json
+++ b/features/flow/pay-card-wallets/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@features/flow-pay-card-wallets",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/features/flow/pay-card-wallets/src/__tests__/combineCardLinkedWallets.web.test.ts
+++ b/features/flow/pay-card-wallets/src/__tests__/combineCardLinkedWallets.web.test.ts
@@ -1,0 +1,165 @@
+import type { PayCardInternalWallet, PayCardLinkedWallet } from "@domain/api-card-management";
+import { combineCardLinkedWallets } from "../logic/combineCardLinkedWallets";
+import type { ResolveWalletCounterValue } from "../types";
+
+const internal: PayCardInternalWallet[] = [
+  { id: "w-usdc", balance: "125.40", currency: "usdc", address: "0xusdc", addressMemo: null },
+  { id: "w-usdt", balance: "10.00", currency: "usdt", address: "0xusdt", addressMemo: null },
+  { id: "w-sol", balance: "2.5", currency: "sol", address: "sol-addr", addressMemo: null },
+  {
+    id: "w-unlinked",
+    balance: "999.99",
+    currency: "usdc",
+    address: "0xunlinked",
+    addressMemo: null,
+  },
+];
+
+const linked: PayCardLinkedWallet[] = [
+  { id: "w-usdt", address: "0xusdt", currency: "usdt", network: "ethereum", priority: 2 },
+  { id: "w-usdc", address: "0xusdc", currency: "usdc", network: "ethereum", priority: 1 },
+];
+
+const rates: Record<string, number> = { usdc: 1, usdt: 1, sol: 150 };
+const resolveCounterValue: ResolveWalletCounterValue = ({ currency }, balance) => {
+  const rate = rates[currency];
+  return rate === undefined ? null : Number(balance) * rate;
+};
+
+describe("combineCardLinkedWallets", () => {
+  it("returns the linked wallets in charging order, lowest priority first", () => {
+    const { wallets } = combineCardLinkedWallets({ linked, internal, resolveCounterValue });
+
+    expect(wallets.map(({ id }) => id)).toEqual(["w-usdc", "w-usdt"]);
+  });
+
+  it("joins each link to its balance on id", () => {
+    const { wallets } = combineCardLinkedWallets({ linked, internal, resolveCounterValue });
+
+    expect(wallets[0]).toEqual({
+      id: "w-usdc",
+      address: "0xusdc",
+      currency: "usdc",
+      network: "ethereum",
+      priority: 1,
+      balance: "125.40",
+      counterValue: 125.4,
+    });
+  });
+
+  it("totals the counter-values, not the raw balances", () => {
+    const { total, isPartialTotal } = combineCardLinkedWallets({
+      linked: [
+        ...linked,
+        { id: "w-sol", address: "sol-addr", currency: "sol", network: "solana", priority: 3 },
+      ],
+      internal,
+      resolveCounterValue,
+    });
+
+    expect(total).toBe(510.4);
+    expect(isPartialTotal).toBe(false);
+  });
+
+  it("leaves out a custodial wallet that funds nothing", () => {
+    const { wallets, total } = combineCardLinkedWallets({ linked, internal, resolveCounterValue });
+
+    expect(wallets.map(({ id }) => id)).not.toContain("w-unlinked");
+    expect(total).toBe(135.4);
+  });
+
+  it("does not mutate the linked list it was handed", () => {
+    const cacheEntry: PayCardLinkedWallet[] = [...linked];
+
+    combineCardLinkedWallets({ linked: cacheEntry, internal, resolveCounterValue });
+
+    expect(cacheEntry.map(({ id }) => id)).toEqual(["w-usdt", "w-usdc"]);
+  });
+
+  it("keeps a link with no matching balance, and says the total is partial", () => {
+    const { wallets, total, isPartialTotal } = combineCardLinkedWallets({
+      linked: [
+        ...linked,
+        { id: "w-missing", address: "0xmissing", currency: "usdc", network: "base", priority: 4 },
+      ],
+      internal,
+      resolveCounterValue,
+    });
+
+    expect(wallets.at(-1)).toMatchObject({ id: "w-missing", balance: null, counterValue: null });
+    expect(total).toBe(135.4);
+    expect(isPartialTotal).toBe(true);
+  });
+
+  it("says the total is partial when a rate is missing, rather than counting the asset as zero", () => {
+    const { total, isPartialTotal } = combineCardLinkedWallets({
+      linked: [
+        ...linked,
+        { id: "w-sol", address: "sol-addr", currency: "sol", network: "solana", priority: 3 },
+      ],
+      internal,
+      resolveCounterValue: ({ currency }, balance) => (currency === "sol" ? null : Number(balance)),
+    });
+
+    expect(total).toBe(135.4);
+    expect(isPartialTotal).toBe(true);
+  });
+
+  it("treats a NaN counter-value as missing, so the total stays a usable number", () => {
+    const { wallets, total, isPartialTotal } = combineCardLinkedWallets({
+      linked,
+      internal,
+      resolveCounterValue: ({ currency }, balance) =>
+        currency === "usdt" ? Number.NaN : Number(balance),
+    });
+
+    expect(wallets.find(({ id }) => id === "w-usdt")?.counterValue).toBeNull();
+    expect(total).toBe(125.4);
+    expect(isPartialTotal).toBe(true);
+  });
+
+  it("treats an infinite counter-value as missing", () => {
+    const { total, isPartialTotal } = combineCardLinkedWallets({
+      linked,
+      internal,
+      resolveCounterValue: ({ currency }, balance) =>
+        currency === "usdt" ? Number.POSITIVE_INFINITY : Number(balance),
+    });
+
+    expect(total).toBe(125.4);
+    expect(isPartialTotal).toBe(true);
+  });
+
+  it("reads a card with nothing linked as an empty list and a zero total", () => {
+    expect(combineCardLinkedWallets({ linked: [], internal, resolveCounterValue })).toEqual({
+      wallets: [],
+      total: 0,
+      isPartialTotal: false,
+    });
+  });
+
+  it("does not resolve a rate for a wallet whose balance never arrived", () => {
+    const resolve = jest.fn<number | null, [{ currency: string; network: string }, string]>();
+
+    combineCardLinkedWallets({
+      linked: [{ id: "w-missing", address: "0x", currency: "usdc", network: "base", priority: 1 }],
+      internal: [],
+      resolveCounterValue: resolve,
+    });
+
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it("keeps a zero balance distinct from a missing one", () => {
+    const { wallets, isPartialTotal } = combineCardLinkedWallets({
+      linked: [linked[1]],
+      internal: [
+        { id: "w-usdc", balance: "0.00", currency: "usdc", address: "0xusdc", addressMemo: null },
+      ],
+      resolveCounterValue,
+    });
+
+    expect(wallets[0]).toMatchObject({ balance: "0.00", counterValue: 0 });
+    expect(isPartialTotal).toBe(false);
+  });
+});

--- a/features/flow/pay-card-wallets/src/__tests__/useCardLinkedWallets.web.test.tsx
+++ b/features/flow/pay-card-wallets/src/__tests__/useCardLinkedWallets.web.test.tsx
@@ -1,0 +1,174 @@
+import { renderHook } from "@testing-library/react";
+import { useCardLinkedWallets } from "../hooks/useCardLinkedWallets";
+import type { ResolveWalletCounterValue } from "../types";
+
+const mockGetCardLinkedWallets = jest.fn();
+const mockGetInternalWallets = jest.fn();
+
+jest.mock("@domain/api-card-management", () => ({
+  useGetCardLinkedWalletsQuery: (...args: unknown[]) => mockGetCardLinkedWallets(...args),
+  useGetInternalWalletsQuery: (...args: unknown[]) => mockGetInternalWallets(...args),
+}));
+
+const internalWallets = [
+  { id: "w-usdc", balance: "125.40", currency: "usdc", address: "0xusdc" },
+  { id: "w-usdt", balance: "10.00", currency: "usdt", address: "0xusdt" },
+];
+
+const linkedWallets = [
+  { id: "w-usdt", address: "0xusdt", currency: "usdt", network: "ethereum", priority: 2 },
+  { id: "w-usdc", address: "0xusdc", currency: "usdc", network: "ethereum", priority: 1 },
+];
+
+const resolveCounterValue: ResolveWalletCounterValue = (_wallet, balance) => Number(balance);
+
+type QueryStub = Readonly<{
+  data?: unknown;
+  isLoading?: boolean;
+  isFetching?: boolean;
+  isError?: boolean;
+  refetch?: () => void;
+}>;
+
+function stubQueries(linked: QueryStub, internal: QueryStub) {
+  const linkedRefetch = jest.fn();
+  const internalRefetch = jest.fn();
+
+  // A fresh object per call: a shared one would make the stability assertions below pass for free.
+  mockGetCardLinkedWallets.mockImplementation(() => ({
+    data: undefined,
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    refetch: linkedRefetch,
+    ...linked,
+  }));
+  mockGetInternalWallets.mockImplementation(() => ({
+    data: undefined,
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    refetch: internalRefetch,
+    ...internal,
+  }));
+
+  return { linkedRefetch, internalRefetch };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("useCardLinkedWallets", () => {
+  it("joins both reads into wallets in charging order, with a counter-value total", () => {
+    stubQueries({ data: linkedWallets }, { data: internalWallets });
+
+    const { result } = renderHook(() => useCardLinkedWallets({ resolveCounterValue }));
+
+    expect(result.current.wallets.map(({ id }) => id)).toEqual(["w-usdc", "w-usdt"]);
+    expect(result.current.total).toBe(135.4);
+    expect(result.current.isPartialTotal).toBe(false);
+  });
+
+  it("subscribes to both endpoints, and skips neither by default", () => {
+    stubQueries({ data: linkedWallets }, { data: internalWallets });
+
+    renderHook(() => useCardLinkedWallets({ resolveCounterValue }));
+
+    expect(mockGetCardLinkedWallets).toHaveBeenCalledWith(undefined, { skip: false });
+    expect(mockGetInternalWallets).toHaveBeenCalledWith(undefined, { skip: false });
+  });
+
+  it("passes skip through to both, so a signed-out host provokes no 401", () => {
+    stubQueries({}, {});
+
+    const { result } = renderHook(() => useCardLinkedWallets({ resolveCounterValue, skip: true }));
+
+    expect(mockGetCardLinkedWallets).toHaveBeenCalledWith(undefined, { skip: true });
+    expect(mockGetInternalWallets).toHaveBeenCalledWith(undefined, { skip: true });
+    expect(result.current.wallets).toEqual([]);
+    expect(result.current.total).toBe(0);
+  });
+
+  it("reads as loading while either read is in flight", () => {
+    stubQueries({ isLoading: true }, { data: internalWallets });
+
+    const { result } = renderHook(() => useCardLinkedWallets({ resolveCounterValue }));
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("reads as failed when either read failed", () => {
+    stubQueries({ data: linkedWallets }, { isError: true });
+
+    const { result } = renderHook(() => useCardLinkedWallets({ resolveCounterValue }));
+
+    expect(result.current.isError).toBe(true);
+  });
+
+  it("joins on whatever has arrived: a link whose balances are still in flight reads as null", () => {
+    stubQueries({ data: linkedWallets }, { isLoading: true });
+
+    const { result } = renderHook(() => useCardLinkedWallets({ resolveCounterValue }));
+
+    expect(result.current.wallets).toHaveLength(2);
+    expect(result.current.wallets.every(({ balance }) => balance === null)).toBe(true);
+    expect(result.current.isPartialTotal).toBe(true);
+  });
+
+  it("refetches both endpoints", () => {
+    const { linkedRefetch, internalRefetch } = stubQueries(
+      { data: linkedWallets },
+      { data: internalWallets },
+    );
+
+    const { result } = renderHook(() => useCardLinkedWallets({ resolveCounterValue }));
+    result.current.refetch();
+
+    expect(linkedRefetch).toHaveBeenCalledTimes(1);
+    expect(internalRefetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not refetch while skipped, so a pull-to-refresh cannot undo it", () => {
+    const { linkedRefetch, internalRefetch } = stubQueries({}, {});
+
+    const { result } = renderHook(() => useCardLinkedWallets({ resolveCounterValue, skip: true }));
+    result.current.refetch();
+
+    expect(linkedRefetch).not.toHaveBeenCalled();
+    expect(internalRefetch).not.toHaveBeenCalled();
+  });
+
+  it("keeps refetch stable across renders, so consumers memoizing on it are not rebuilt", () => {
+    stubQueries({ data: linkedWallets }, { data: internalWallets });
+
+    const { result, rerender } = renderHook(() => useCardLinkedWallets({ resolveCounterValue }));
+    const first = result.current.refetch;
+    rerender();
+
+    expect(result.current.refetch).toBe(first);
+  });
+
+  it("keeps the whole result stable across renders when nothing changed", () => {
+    stubQueries({ data: linkedWallets }, { data: internalWallets });
+
+    const { result, rerender } = renderHook(() => useCardLinkedWallets({ resolveCounterValue }));
+    const first = result.current;
+    rerender();
+
+    expect(result.current).toBe(first);
+    expect(result.current.wallets).toBe(first.wallets);
+  });
+
+  it("reports a refetch through isFetching, leaving isLoading to the first load", () => {
+    stubQueries(
+      { data: linkedWallets, isFetching: true },
+      { data: internalWallets, isFetching: false },
+    );
+
+    const { result } = renderHook(() => useCardLinkedWallets({ resolveCounterValue }));
+
+    expect(result.current.isFetching).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/features/flow/pay-card-wallets/src/exports.ts
+++ b/features/flow/pay-card-wallets/src/exports.ts
@@ -1,0 +1,3 @@
+export * from "./logic/combineCardLinkedWallets";
+export * from "./hooks/useCardLinkedWallets";
+export * from "./types";

--- a/features/flow/pay-card-wallets/src/hooks/useCardLinkedWallets.ts
+++ b/features/flow/pay-card-wallets/src/hooks/useCardLinkedWallets.ts
@@ -1,0 +1,84 @@
+import { useCallback, useMemo } from "react";
+import {
+  useGetCardLinkedWalletsQuery,
+  useGetInternalWalletsQuery,
+} from "@domain/api-card-management";
+import { combineCardLinkedWallets } from "../logic/combineCardLinkedWallets";
+import type { CardLinkedWallets, ResolveWalletCounterValue } from "../types";
+
+export type UseCardLinkedWalletsParams = Readonly<{
+  resolveCounterValue: ResolveWalletCounterValue;
+  skip?: boolean;
+}>;
+
+export type UseCardLinkedWalletsResult = CardLinkedWallets &
+  Readonly<{
+    /** The first load only. A refetch reports through `isFetching`. */
+    isLoading: boolean;
+    isFetching: boolean;
+    isError: boolean;
+    refetch: () => void;
+  }>;
+
+const NO_WALLETS: readonly [] = [];
+
+export function useCardLinkedWallets({
+  resolveCounterValue,
+  skip = false,
+}: UseCardLinkedWalletsParams): UseCardLinkedWalletsResult {
+  const linkedQuery = useGetCardLinkedWalletsQuery(undefined, { skip });
+  const internalQuery = useGetInternalWalletsQuery(undefined, { skip });
+
+  const combined = useMemo(
+    () =>
+      combineCardLinkedWallets({
+        linked: linkedQuery.data ?? NO_WALLETS,
+        internal: internalQuery.data ?? NO_WALLETS,
+        resolveCounterValue,
+      }),
+    [linkedQuery.data, internalQuery.data, resolveCounterValue],
+  );
+
+  const { refetch: refetchLinked } = linkedQuery;
+  const { refetch: refetchInternal } = internalQuery;
+
+  const refetch = useCallback(() => {
+    if (skip) {
+      return;
+    }
+
+    refetchLinked();
+    refetchInternal();
+  }, [skip, refetchLinked, refetchInternal]);
+
+  const {
+    isLoading: linkedLoading,
+    isFetching: linkedFetching,
+    isError: linkedError,
+  } = linkedQuery;
+  const {
+    isLoading: internalLoading,
+    isFetching: internalFetching,
+    isError: internalError,
+  } = internalQuery;
+
+  return useMemo(
+    () => ({
+      ...combined,
+      isLoading: linkedLoading || internalLoading,
+      isFetching: linkedFetching || internalFetching,
+      isError: linkedError || internalError,
+      refetch,
+    }),
+    [
+      combined,
+      linkedLoading,
+      internalLoading,
+      linkedFetching,
+      internalFetching,
+      linkedError,
+      internalError,
+      refetch,
+    ],
+  );
+}

--- a/features/flow/pay-card-wallets/src/index.native.ts
+++ b/features/flow/pay-card-wallets/src/index.native.ts
@@ -1,0 +1,1 @@
+export * from "./exports";

--- a/features/flow/pay-card-wallets/src/index.ts
+++ b/features/flow/pay-card-wallets/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./exports";

--- a/features/flow/pay-card-wallets/src/logic/combineCardLinkedWallets.ts
+++ b/features/flow/pay-card-wallets/src/logic/combineCardLinkedWallets.ts
@@ -1,0 +1,54 @@
+import type { PayCardInternalWallet, PayCardLinkedWallet } from "@domain/api-card-management";
+import type {
+  CardLinkedWalletBalance,
+  CardLinkedWallets,
+  ResolveWalletCounterValue,
+} from "../types";
+
+export type CombineCardLinkedWalletsParams = Readonly<{
+  linked: readonly PayCardLinkedWallet[];
+  internal: readonly PayCardInternalWallet[];
+  resolveCounterValue: ResolveWalletCounterValue;
+}>;
+
+export function combineCardLinkedWallets({
+  linked,
+  internal,
+  resolveCounterValue,
+}: CombineCardLinkedWalletsParams): CardLinkedWallets {
+  const balanceById = new Map(internal.map(wallet => [wallet.id, wallet.balance]));
+
+  const counterValueFor = (
+    wallet: Readonly<{ currency: string; network: string }>,
+    balance: string,
+  ): number | null => {
+    const resolved = resolveCounterValue(wallet, balance);
+    return resolved === null || !Number.isFinite(resolved) ? null : resolved;
+  };
+
+  const wallets: CardLinkedWalletBalance[] = linked
+    // `linked` is the cache entry: never sort it in place.
+    .slice()
+    .sort((a, b) => a.priority - b.priority)
+    .map(({ id, address, currency, network, priority }) => {
+      const balance = balanceById.get(id) ?? null;
+
+      return {
+        id,
+        address,
+        currency,
+        network,
+        priority,
+        balance,
+        counterValue: balance === null ? null : counterValueFor({ currency, network }, balance),
+      };
+    });
+
+  const total = wallets.reduce((sum, { counterValue }) => sum + (counterValue ?? 0), 0);
+
+  return {
+    wallets,
+    total,
+    isPartialTotal: wallets.some(({ counterValue }) => counterValue === null),
+  };
+}

--- a/features/flow/pay-card-wallets/src/types.ts
+++ b/features/flow/pay-card-wallets/src/types.ts
@@ -1,0 +1,20 @@
+export type ResolveWalletCounterValue = (
+  wallet: Readonly<{ currency: string; network: string }>,
+  balance: string,
+) => number | null;
+
+export type CardLinkedWalletBalance = Readonly<{
+  id: string;
+  address: string;
+  currency: string;
+  network: string;
+  priority: number;
+  balance: string | null;
+  counterValue: number | null;
+}>;
+
+export type CardLinkedWallets = Readonly<{
+  wallets: readonly CardLinkedWalletBalance[];
+  total: number;
+  isPartialTotal: boolean;
+}>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6943,6 +6943,77 @@ importers:
         specifier: 1.51.0
         version: 1.51.0
 
+  features/flow/pay-card-wallets:
+    dependencies:
+      '@domain/api-card-management':
+        specifier: workspace:^
+        version: link:../../../domain/api/card-management
+    devDependencies:
+      '@support/jest-features-flow':
+        specifier: workspace:*
+        version: link:../../../support/jest-features-flow
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@testing-library/dom':
+        specifier: 'catalog:'
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: 'catalog:'
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.0.14
+      jest:
+        specifier: 'catalog:'
+        version: 30.5.0(@types/node@24.12.0)
+      jest-environment-jsdom:
+        specifier: 'catalog:'
+        version: 30.5.0
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.64.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.79.0
+      react:
+        specifier: 19.1.4
+        version: 19.1.4
+      react-dom:
+        specifier: 19.1.4
+        version: 19.1.4(react@19.1.4)
+      react-redux:
+        specifier: 'catalog:'
+        version: 9.2.0(@types/react@19.0.14)(react@19.1.4)
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+    optionalDependencies:
+      '@oxlint/binding-darwin-arm64':
+        specifier: 1.51.0
+        version: 1.51.0
+      '@oxlint/binding-darwin-x64':
+        specifier: 1.51.0
+        version: 1.51.0
+      '@oxlint/binding-linux-x64-gnu':
+        specifier: 1.51.0
+        version: 1.51.0
+      '@oxlint/binding-win32-x64-msvc':
+        specifier: 1.51.0
+        version: 1.51.0
+
   features/flow/pay-contact:
     dependencies:
       '@domain/entity-contact':


### PR DESCRIPTION
<!-- stac-man:stack-start -->
**Stack** _(managed by [stac-man](https://github.com/bluegardenproject/stac-man))_

- **#21000 feat/LIVE-34772-card-linked-wallet-balances ← this PR**
- #21444 feat/pay-card-devtools-card-interaction
- #21163 feat/LIVE-34784-card-freeze-unfreeze
- #21399 feat/LIVE-35428-native-card-visual
- #21425 feat/LIVE-34772-card-balance-from-linked-wallets
- #21445 fix/pay-card-schema-failure-detail
- #21448 feat/pay-card-devtools-balance
- #21467 feat/LIVE-34778-card-details-token
- #21468 feat/pay-card-devtools-card-details
<!-- stac-man:stack-end -->

Neither wallet endpoint answers the question on its own: `/v1/wallet/internal`
carries the balances but not which wallets fund the card, and
`/v1/wallet/internal/card_linked` carries the links and their charging order but
no balances. This joins them on `id`, orders by priority and totals what the
card can spend.

Balances are per-currency decimal strings, so a total only means something in one
currency. Converting needs the asset catalogue that maps Baanx's
currency/network pair onto a Ledger currency and the countervalues rates — both
the app's — so the conversion arrives as a port and the raw string is never
parsed here.

`isPartialTotal` says the total is understating: a balance that has not arrived,
a link no custodial wallet matched, or an asset the resolver has no rate for. A
link with no matching balance is kept with a null balance rather than dropped,
because the provider disagreeing with itself is worth showing.

### 🔗 Context

- **JIRA**: [LIVE-34772 — expose total card balance](https://ledgerhq.atlassian.net/browse/LIVE-34772) · [LIVE-34773 — expose linked wallet balances](https://ledgerhq.atlassian.net/browse/LIVE-34773) · [LIVE-34774 — expose card debit order](https://ledgerhq.atlassian.net/browse/LIVE-34774)
- **Epic**: [LIVE-35974 — Frontend Adapter to Baanx API](https://ledgerhq.atlassian.net/browse/LIVE-35974)
- **Stacked on**: #20999 — the two endpoints this joins

LIVE-34772 says the total is "calculated server-side". That backend was removed after the Donjon
review, so it is computed here instead — which is why the counter-value conversion arrives as an
injected port rather than a number off the wire.
