### PR TITLE
fix(mobile): startup time regresion for api hardening

### DIFF
--- a/.changeset/good-bulldogs-chew.md
+++ b/.changeset/good-bulldogs-chew.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/ledger-key-ring-protocol": minor
+"live-mobile": minor
+---
+
+Prevent keypair generation at each startup and remove zod valdiation which is coslty at startup

--- a/apps/ledger-live-mobile/src/components/DBSave.ts
+++ b/apps/ledger-live-mobile/src/components/DBSave.ts
@@ -322,6 +322,7 @@ export const ConfigureDBSaveEffects = () => {
     throttle: 500,
     getChangesStats: trustchainNotEquals,
     lense: trustchainStoreSelector,
+    saveAtStart: true,
   });
 
   useDBSaveEffect({

--- a/libs/ledger-key-ring-protocol/src/__tests__/unit/types.test.ts
+++ b/libs/ledger-key-ring-protocol/src/__tests__/unit/types.test.ts
@@ -18,7 +18,6 @@ describe("MemberCredentialsSchema", () => {
     { ...memberCredentials, unexpected: "value" },
     { ...memberCredentials, pubkey: memberCredentials.pubkey.toUpperCase() },
     { ...memberCredentials, privatekey: memberCredentials.privatekey.toUpperCase() },
-    { ...memberCredentials, privatekey: "01".repeat(32) },
   ])("should reject invalid member credentials", invalidCredentials => {
     expect(MemberCredentialsSchema.safeParse(invalidCredentials).success).toBe(false);
   });

--- a/libs/ledger-key-ring-protocol/src/types.ts
+++ b/libs/ledger-key-ring-protocol/src/types.ts
@@ -1,7 +1,6 @@
 import type { Observable } from "rxjs";
 import { z } from "zod";
 import type Transport from "@ledgerhq/hw-transport";
-import { crypto } from "@ledgerhq/hw-ledger-key-ring-protocol";
 import type { TrustchainsResponse } from "./api";
 
 /**
@@ -45,25 +44,10 @@ export type Trustchain = {
 /**
  * The Trustchain member credentials are stored on each client, with the privatekey only known by the current client.
  */
-export const MemberCredentialsSchema = z
-  .strictObject({
-    pubkey: z.hex().length(66).lowercase(),
-    privatekey: z.hex().length(64).lowercase(),
-  })
-  .refine(
-    ({ pubkey, privatekey }) => {
-      try {
-        const keyPair = crypto.keypairFromSecretKey(crypto.from_hex(privatekey));
-        return crypto.to_hex(keyPair.publicKey) === pubkey;
-      } catch {
-        return false;
-      }
-    },
-    {
-      path: ["pubkey"],
-      message: "Public key does not match private key",
-    },
-  );
+export const MemberCredentialsSchema = z.strictObject({
+  pubkey: z.hex().length(66).lowercase(),
+  privatekey: z.hex().length(64).lowercase(),
+});
 
 export type MemberCredentials = z.infer<typeof MemberCredentialsSchema>;
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

We have a regression in startup time on Mobile introduced by forcing the generation of the keypair for API Hardening.
Two reasons for the regression:
- The crypto lib is heavy to import, and by relying on it on zod validation, we slow down everyone by confirming that the private key and public key match.
- In the useDBEffect, as we generate the keypair for customers not having Ledger Sync activated at startup, without using the saveAtStart property, because we don't manipulate the keychain property for users not having Ledger Sync, it's never persisted, so they all fall into member credentials generation every time they start the app.

Overall, we move from a startup regression for everyone to a startup regression for the first time you start the app without having generated a keypair.

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-36190

On the video you can see that at first launch we have a cost in Trustchain restore part at first launch then it's free on the second launch:

https://github.com/user-attachments/assets/337d2fef-2891-4fed-8d56-ef64c96e48db





