### PR TITLE
feat(device-intent): make executor job callbacks optional

### DIFF
--- a/.changeset/quiet-listeners-relax.md
+++ b/.changeset/quiet-listeners-relax.md
@@ -1,0 +1,5 @@
+---
+"@features/platform-device-intent": minor
+---
+
+Make DeviceIntentExecutor job lifecycle callbacks optional

--- a/features/platform/device-intent/README.md
+++ b/features/platform/device-intent/README.md
@@ -1174,9 +1174,9 @@ The executor reports progress and lifecycle changes through callback props:
 | Callback                            | Fires when                                                                                                                                                |
 | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `onExecutorStateChanged(state)`     | The executor transitions between lifecycle phases (`connectingDevice`, `initializingDeviceContext`, `executingIntent`, `idle`, and their error variants). |
-| `onIntentJobStateChanged(jobState)` | The running job's observable emits a new `JobState` value.                                                                                                |
-| `onIntentJobComplete()`             | The job observable completes (no more emissions). The executor transitions to `idle`.                                                                     |
-| `onIntentJobError(error)`           | The job observable errors. The executor transitions to `executingIntentError`.                                                                            |
+| `onIntentJobStateChanged(jobState)` | Optional. The running job's observable emits a new `JobState` value.                                                                                      |
+| `onIntentJobComplete()`             | Optional. The job observable completes (no more emissions). The executor transitions to `idle`.                                                           |
+| `onIntentJobError(error)`           | Optional. The job observable errors. The executor transitions to `executingIntentError`.                                                                  |
 
 All callbacks use refs internally, so the executor always calls the **latest**
 version of each callback without needing to be recreated when the callback

--- a/features/platform/device-intent/src/executor.ts
+++ b/features/platform/device-intent/src/executor.ts
@@ -154,12 +154,12 @@ export interface DeviceIntentExecutorProps<JobState, Input, ExtraProps, InitInpu
   intent: Intent<JobState, Input, ExtraProps>;
   /** Extra props forwarded directly to the intent's UI component. */
   intentComponentExtraProps: ExtraProps;
-  /** Called whenever the running job emits a new state. */
-  onIntentJobStateChanged: (jobState: JobState) => void;
-  /** On intent job complete */
-  onIntentJobComplete: () => void;
-  /** On intent job error */
-  onIntentJobError: (error: unknown) => void;
+  /** Optional. Called whenever the running job emits a new state. */
+  onIntentJobStateChanged?: (jobState: JobState) => void;
+  /** Optional. Called when the job observable completes. */
+  onIntentJobComplete?: () => void;
+  /** Optional. Called when the job observable errors. */
+  onIntentJobError?: (error: unknown) => void;
   /** When `false` the executor is hidden and inactive; setting to `false` terminates any running job. */
   enabled: boolean;
   /** Called when the user performs an action that cancels the current execution

--- a/features/platform/device-intent/src/useDeviceIntentExecutor.ts
+++ b/features/platform/device-intent/src/useDeviceIntentExecutor.ts
@@ -122,15 +122,15 @@ export function useDeviceIntentExecutor<JobState, Input, ExtraProps, InitInput>(
         },
         onIntentJobStateChanged: (intent, jobState) => {
           setLatestJobState(jobState);
-          onIntentJobStateChangedRef.current(jobState);
+          onIntentJobStateChangedRef.current?.(jobState);
           lastIntentSnapshotRef.current = {
             intentComponent: intent.component,
             jobState,
             intentComponentExtraProps: intentComponentExtraPropsRef.current,
           };
         },
-        onIntentJobComplete: () => onIntentJobCompleteRef.current(),
-        onIntentJobError: (_intent, error) => onIntentJobErrorRef.current(error),
+        onIntentJobComplete: () => onIntentJobCompleteRef.current?.(),
+        onIntentJobError: (_intent, error) => onIntentJobErrorRef.current?.(error),
       },
     });
   }, [StateMachineClass]);


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

`DeviceIntentExecutorProps` required `onIntentJobStateChanged`, `onIntentJobComplete`, and `onIntentJobError` even when lifecycle handling lives on the current `Intent` via `createIntent()` listeners. Callers had to pass no-ops.

Those three executor-level job callbacks are now optional. `useDeviceIntentExecutor` forwards them with optional calls. Intent-level listeners, state-machine dispatch, and `onExecutorStateChanged` are unchanged.

```tsx
<DeviceIntentExecutorLWM
  enabled={enabled}
  intent={createIntent(definition, input, {
    onJobComplete: settleOperation,
    onJobError: failOperation,
  })}
  onExecutorStateChanged={onExecutorStateChanged}
  onUserCancel={onUserCancel}
  cancelIntentRequestId={cancelIntentRequestId}
/>
```

Existing callers that still pass executor-level callbacks remain source-compatible.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36316](https://ledgerhq.atlassian.net/browse/LIVE-36316)
- **ADR** (if any):

[LIVE-36316]: https://ledgerhq.atlassian.net/browse/LIVE-36316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ