### PR TITLE
[LWM] feat(braze): wire mobile consent to identity lifecycle (LIVE-34731)

### DIFF
--- a/.changeset/swift-braze-consent.md
+++ b/.changeset/swift-braze-consent.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Wire mobile Braze consent toggles to the identity lifecycle

--- a/apps/ledger-live-mobile/__tests__/jest-setup.js
+++ b/apps/ledger-live-mobile/__tests__/jest-setup.js
@@ -348,6 +348,8 @@ jest.mock("@braze/react-native-sdk", () => ({
     logContentCardClicked: jest.fn(),
     logContentCardImpression: jest.fn(),
     requestContentCardsRefresh: jest.fn(),
+    wipeData: jest.fn(),
+    enableSDK: jest.fn(),
     getContentCards: jest.fn().mockResolvedValue([]),
     getInitialPushPayload: jest.fn(),
   },

--- a/apps/ledger-live-mobile/src/notifications/HookNotifications.test.tsx
+++ b/apps/ledger-live-mobile/src/notifications/HookNotifications.test.tsx
@@ -1,14 +1,15 @@
 import React from "react";
-import { render } from "@testing-library/react-native";
+import { act, render } from "@testing-library/react-native";
 import { UserId, DUMMY_USER_ID, userIdSelector } from "@domain/entity-client-identity";
 import { useFeature } from "@features/platform-feature-flags";
 import { useSelector } from "~/context/hooks";
 import { notificationsSelector, trackingEnabledSelector } from "../reducers/settings";
 import HookNotifications from "./HookNotifications";
-import { start, updateUserPreferences } from "./braze";
+import { applyBrazeConsentTransition, start, updateUserPreferences } from "./braze";
 import type { NotificationsSettings } from "../reducers/types";
 
 jest.mock("./braze", () => ({
+  applyBrazeConsentTransition: jest.fn().mockResolvedValue(undefined),
   start: jest.fn(),
   updateUserPreferences: jest.fn(),
 }));
@@ -21,6 +22,7 @@ jest.mock("~/context/hooks", () => ({
   useSelector: jest.fn(),
 }));
 
+const mockedApplyBrazeConsentTransition = jest.mocked(applyBrazeConsentTransition);
 const mockedStart = jest.mocked(start);
 const mockedUpdateUserPreferences = jest.mocked(updateUserPreferences);
 const mockedUseFeature = jest.mocked(useFeature);
@@ -58,6 +60,7 @@ describe("HookNotifications", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedUseFeature.mockReturnValue({ enabled: true } as ReturnType<typeof useFeature>);
+    mockedApplyBrazeConsentTransition.mockResolvedValue(undefined);
   });
 
   it("should sync Braze identity once for unchanged consent and user id", () => {
@@ -70,9 +73,41 @@ describe("HookNotifications", () => {
     expect(mockedStart).toHaveBeenCalledWith(true, REAL_USER_ID, {
       brazeOptOutIdentityCleanup: true,
     });
+    expect(mockedApplyBrazeConsentTransition).not.toHaveBeenCalled();
   });
 
-  it("should re-sync Braze identity when consent changes from opt-in to opt-out", () => {
+  it("should run the opt-out lifecycle when consent changes from opt-in to opt-out", () => {
+    mockSelectors({ isTrackedUser: true, userId: REAL_USER_ID });
+    const { rerender } = render(<HookNotifications />);
+
+    mockSelectors({ isTrackedUser: false, userId: REAL_USER_ID });
+    rerender(<HookNotifications />);
+
+    expect(mockedStart).toHaveBeenCalledTimes(1);
+    expect(mockedApplyBrazeConsentTransition).toHaveBeenCalledTimes(1);
+    expect(mockedApplyBrazeConsentTransition).toHaveBeenCalledWith({
+      isTrackedUser: false,
+      userId: REAL_USER_ID,
+    });
+  });
+
+  it("should run the opt-in lifecycle when consent changes from opt-out to opt-in", () => {
+    mockSelectors({ isTrackedUser: false, userId: REAL_USER_ID });
+    const { rerender } = render(<HookNotifications />);
+
+    mockSelectors({ isTrackedUser: true, userId: REAL_USER_ID });
+    rerender(<HookNotifications />);
+
+    expect(mockedStart).toHaveBeenCalledTimes(1);
+    expect(mockedApplyBrazeConsentTransition).toHaveBeenCalledTimes(1);
+    expect(mockedApplyBrazeConsentTransition).toHaveBeenCalledWith({
+      isTrackedUser: true,
+      userId: REAL_USER_ID,
+    });
+  });
+
+  it("should re-sync Braze identity with start when the cleanup flag is off and consent changes", () => {
+    mockedUseFeature.mockReturnValue({ enabled: false } as ReturnType<typeof useFeature>);
     mockSelectors({ isTrackedUser: true, userId: REAL_USER_ID });
     const { rerender } = render(<HookNotifications />);
 
@@ -81,21 +116,9 @@ describe("HookNotifications", () => {
 
     expect(mockedStart).toHaveBeenCalledTimes(2);
     expect(mockedStart).toHaveBeenLastCalledWith(false, REAL_USER_ID, {
-      brazeOptOutIdentityCleanup: true,
+      brazeOptOutIdentityCleanup: false,
     });
-  });
-
-  it("should re-sync Braze identity when consent changes from opt-out to opt-in", () => {
-    mockSelectors({ isTrackedUser: false, userId: REAL_USER_ID });
-    const { rerender } = render(<HookNotifications />);
-
-    mockSelectors({ isTrackedUser: true, userId: REAL_USER_ID });
-    rerender(<HookNotifications />);
-
-    expect(mockedStart).toHaveBeenCalledTimes(2);
-    expect(mockedStart).toHaveBeenLastCalledWith(true, REAL_USER_ID, {
-      brazeOptOutIdentityCleanup: true,
-    });
+    expect(mockedApplyBrazeConsentTransition).not.toHaveBeenCalled();
   });
 
   it("should retry Braze identity sync when dummy user id becomes real", () => {
@@ -110,6 +133,7 @@ describe("HookNotifications", () => {
     expect(mockedStart).toHaveBeenCalledWith(true, REAL_USER_ID, {
       brazeOptOutIdentityCleanup: true,
     });
+    expect(mockedApplyBrazeConsentTransition).not.toHaveBeenCalled();
   });
 
   it("should re-sync Braze identity when the cleanup feature flag changes", () => {
@@ -128,6 +152,7 @@ describe("HookNotifications", () => {
     expect(mockedStart).toHaveBeenLastCalledWith(false, REAL_USER_ID, {
       brazeOptOutIdentityCleanup: true,
     });
+    expect(mockedApplyBrazeConsentTransition).not.toHaveBeenCalled();
   });
 
   it("should update notification preferences when settings change", () => {
@@ -156,6 +181,133 @@ describe("HookNotifications", () => {
     render(<HookNotifications />);
 
     expect(mockedUpdateUserPreferences).toHaveBeenCalledWith(defaultNotifications, false, {
+      brazeOptOutIdentityCleanup: true,
+    });
+  });
+
+  it("should hold notification preferences back until the opt-in lifecycle completes", async () => {
+    let completeTransition: () => void = () => {};
+    mockedApplyBrazeConsentTransition.mockReturnValueOnce(
+      new Promise<void>(resolve => {
+        completeTransition = resolve;
+      }),
+    );
+    mockSelectors({ isTrackedUser: false, userId: REAL_USER_ID });
+    const { rerender } = render(<HookNotifications />);
+    mockedUpdateUserPreferences.mockClear();
+
+    mockSelectors({ isTrackedUser: true, userId: REAL_USER_ID });
+    rerender(<HookNotifications />);
+
+    // Writing here would hit a wiped, still anonymous profile.
+    expect(mockedUpdateUserPreferences).not.toHaveBeenCalled();
+
+    await act(async () => {
+      completeTransition();
+    });
+
+    expect(mockedUpdateUserPreferences).toHaveBeenCalledTimes(1);
+    expect(mockedUpdateUserPreferences).toHaveBeenCalledWith(defaultNotifications, true, {
+      brazeOptOutIdentityCleanup: true,
+    });
+  });
+
+  it("should write the latest notification preferences once the opt-in lifecycle completes", async () => {
+    let completeTransition: () => void = () => {};
+    mockedApplyBrazeConsentTransition.mockReturnValueOnce(
+      new Promise<void>(resolve => {
+        completeTransition = resolve;
+      }),
+    );
+    const updatedNotifications = { ...defaultNotifications, announcementsCategory: false };
+    mockSelectors({ isTrackedUser: false, userId: REAL_USER_ID });
+    const { rerender } = render(<HookNotifications />);
+
+    mockSelectors({ isTrackedUser: true, userId: REAL_USER_ID });
+    rerender(<HookNotifications />);
+    mockedUpdateUserPreferences.mockClear();
+
+    mockSelectors({
+      isTrackedUser: true,
+      userId: REAL_USER_ID,
+      notifications: updatedNotifications,
+    });
+    rerender(<HookNotifications />);
+
+    await act(async () => {
+      completeTransition();
+    });
+
+    expect(mockedUpdateUserPreferences).toHaveBeenCalledTimes(1);
+    expect(mockedUpdateUserPreferences).toHaveBeenCalledWith(updatedNotifications, true, {
+      brazeOptOutIdentityCleanup: true,
+    });
+  });
+
+  it("should skip notification preferences when the opt-in lifecycle fails", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    mockedApplyBrazeConsentTransition.mockRejectedValue(new Error("wipe failed"));
+    mockSelectors({ isTrackedUser: false, userId: REAL_USER_ID });
+    const { rerender } = render(<HookNotifications />);
+    mockedUpdateUserPreferences.mockClear();
+
+    try {
+      mockSelectors({ isTrackedUser: true, userId: REAL_USER_ID });
+      await act(async () => {
+        rerender(<HookNotifications />);
+      });
+
+      expect(mockedUpdateUserPreferences).not.toHaveBeenCalled();
+      expect(mockedApplyBrazeConsentTransition).toHaveBeenCalledTimes(2);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("should retry a failed consent transition without treating it as synced", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    mockedApplyBrazeConsentTransition
+      .mockRejectedValueOnce(new Error("wipe failed"))
+      .mockResolvedValueOnce(undefined);
+    mockSelectors({ isTrackedUser: false, userId: REAL_USER_ID });
+    const { rerender } = render(<HookNotifications />);
+    mockedUpdateUserPreferences.mockClear();
+
+    try {
+      mockSelectors({ isTrackedUser: true, userId: REAL_USER_ID });
+      await act(async () => {
+        rerender(<HookNotifications />);
+      });
+
+      expect(mockedApplyBrazeConsentTransition).toHaveBeenCalledTimes(2);
+      expect(mockedUpdateUserPreferences).toHaveBeenCalledTimes(1);
+      expect(mockedUpdateUserPreferences).toHaveBeenCalledWith(defaultNotifications, true, {
+        brazeOptOutIdentityCleanup: true,
+      });
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("should write notification preferences directly once a transition has settled", async () => {
+    const updatedNotifications = { ...defaultNotifications, topGainersLosers: false };
+    mockSelectors({ isTrackedUser: false, userId: REAL_USER_ID });
+    const { rerender } = render(<HookNotifications />);
+
+    mockSelectors({ isTrackedUser: true, userId: REAL_USER_ID });
+    await act(async () => {
+      rerender(<HookNotifications />);
+    });
+    mockedUpdateUserPreferences.mockClear();
+
+    mockSelectors({
+      isTrackedUser: true,
+      userId: REAL_USER_ID,
+      notifications: updatedNotifications,
+    });
+    rerender(<HookNotifications />);
+
+    expect(mockedUpdateUserPreferences).toHaveBeenCalledWith(updatedNotifications, true, {
       brazeOptOutIdentityCleanup: true,
     });
   });

--- a/apps/ledger-live-mobile/src/notifications/HookNotifications.test.tsx
+++ b/apps/ledger-live-mobile/src/notifications/HookNotifications.test.tsx
@@ -289,6 +289,84 @@ describe("HookNotifications", () => {
     }
   });
 
+  it("should apply the latest consent when it flips back while opt-out is in flight", async () => {
+    let completeFirstTransition: () => void = () => {};
+    mockedApplyBrazeConsentTransition.mockImplementationOnce(
+      () =>
+        new Promise<void>(resolve => {
+          completeFirstTransition = resolve;
+        }),
+    );
+    mockSelectors({ isTrackedUser: true, userId: REAL_USER_ID });
+    const { rerender } = render(<HookNotifications />);
+
+    mockSelectors({ isTrackedUser: false, userId: REAL_USER_ID });
+    rerender(<HookNotifications />);
+
+    expect(mockedApplyBrazeConsentTransition).toHaveBeenCalledTimes(1);
+    expect(mockedApplyBrazeConsentTransition).toHaveBeenCalledWith({
+      isTrackedUser: false,
+      userId: REAL_USER_ID,
+    });
+
+    mockSelectors({ isTrackedUser: true, userId: REAL_USER_ID });
+    rerender(<HookNotifications />);
+    expect(mockedApplyBrazeConsentTransition).toHaveBeenCalledTimes(1);
+    mockedUpdateUserPreferences.mockClear();
+
+    await act(async () => {
+      completeFirstTransition();
+    });
+
+    expect(mockedApplyBrazeConsentTransition).toHaveBeenCalledTimes(2);
+    expect(mockedApplyBrazeConsentTransition).toHaveBeenLastCalledWith({
+      isTrackedUser: true,
+      userId: REAL_USER_ID,
+    });
+    expect(mockedUpdateUserPreferences).toHaveBeenCalledWith(defaultNotifications, true, {
+      brazeOptOutIdentityCleanup: true,
+    });
+  });
+
+  it("should apply the latest consent when it flips back while opt-in is in flight", async () => {
+    let completeFirstTransition: () => void = () => {};
+    mockedApplyBrazeConsentTransition.mockImplementationOnce(
+      () =>
+        new Promise<void>(resolve => {
+          completeFirstTransition = resolve;
+        }),
+    );
+    mockSelectors({ isTrackedUser: false, userId: REAL_USER_ID });
+    const { rerender } = render(<HookNotifications />);
+
+    mockSelectors({ isTrackedUser: true, userId: REAL_USER_ID });
+    rerender(<HookNotifications />);
+
+    expect(mockedApplyBrazeConsentTransition).toHaveBeenCalledTimes(1);
+    expect(mockedApplyBrazeConsentTransition).toHaveBeenCalledWith({
+      isTrackedUser: true,
+      userId: REAL_USER_ID,
+    });
+
+    mockSelectors({ isTrackedUser: false, userId: REAL_USER_ID });
+    rerender(<HookNotifications />);
+    expect(mockedApplyBrazeConsentTransition).toHaveBeenCalledTimes(1);
+    mockedUpdateUserPreferences.mockClear();
+
+    await act(async () => {
+      completeFirstTransition();
+    });
+
+    expect(mockedApplyBrazeConsentTransition).toHaveBeenCalledTimes(2);
+    expect(mockedApplyBrazeConsentTransition).toHaveBeenLastCalledWith({
+      isTrackedUser: false,
+      userId: REAL_USER_ID,
+    });
+    expect(mockedUpdateUserPreferences).toHaveBeenCalledWith(defaultNotifications, false, {
+      brazeOptOutIdentityCleanup: true,
+    });
+  });
+
   it("should write notification preferences directly once a transition has settled", async () => {
     const updatedNotifications = { ...defaultNotifications, topGainersLosers: false };
     mockSelectors({ isTrackedUser: false, userId: REAL_USER_ID });

--- a/apps/ledger-live-mobile/src/notifications/HookNotifications.ts
+++ b/apps/ledger-live-mobile/src/notifications/HookNotifications.ts
@@ -87,6 +87,10 @@ const HookNotifications = () => {
         if (didTransitionSucceed) {
           lastSyncedIdentityRef.current = currentIdentity;
           retryCountRef.current = 0;
+          if (!identitiesMatch(currentIdentity, targetIdentityRef.current)) {
+            syncBrazeIdentityRef.current();
+            return;
+          }
           setSyncedEpoch(epoch => epoch + 1);
           return;
         }

--- a/apps/ledger-live-mobile/src/notifications/HookNotifications.ts
+++ b/apps/ledger-live-mobile/src/notifications/HookNotifications.ts
@@ -1,9 +1,9 @@
-import { useEffect, useRef, useCallback } from "react";
+import { useEffect, useRef, useCallback, useState } from "react";
 import { type UserId, userIdSelector, isDummyUserId } from "@domain/entity-client-identity";
 import { useFeature } from "@features/platform-feature-flags";
 import { useSelector } from "~/context/hooks";
 import { notificationsSelector, trackingEnabledSelector } from "../reducers/settings";
-import { start, updateUserPreferences } from "./braze";
+import { applyBrazeConsentTransition, start, updateUserPreferences } from "./braze";
 
 type SyncedBrazeIdentity = {
   userId: UserId;
@@ -11,50 +11,127 @@ type SyncedBrazeIdentity = {
   brazeOptOutIdentityCleanup: boolean;
 };
 
+const MAX_CONSENT_TRANSITION_RETRIES = 1;
+
+const identitiesMatch = (
+  left: SyncedBrazeIdentity | null,
+  right: SyncedBrazeIdentity | null,
+): boolean =>
+  left != null &&
+  right != null &&
+  left.userId.equals(right.userId) &&
+  left.isTrackedUser === right.isTrackedUser &&
+  left.brazeOptOutIdentityCleanup === right.brazeOptOutIdentityCleanup;
+
 const HookNotifications = () => {
   const notifications = useSelector(notificationsSelector);
   const isTrackedUser = useSelector(trackingEnabledSelector);
   const userId = useSelector(userIdSelector);
   const brazeOptOutIdentityCleanup = useFeature("brazeOptOutIdentityCleanup");
+  const brazeOptOutIdentityCleanupEnabled = brazeOptOutIdentityCleanup?.enabled ?? false;
   const lastSyncedIdentityRef = useRef<SyncedBrazeIdentity | null>(null);
+  const pendingConsentTransitionRef = useRef<Promise<boolean> | null>(null);
+  const targetIdentityRef = useRef<SyncedBrazeIdentity | null>(null);
+  const retryCountRef = useRef(0);
+  const syncBrazeIdentityRef = useRef<() => void>(() => {});
+  const [syncedEpoch, setSyncedEpoch] = useState(0);
 
   const syncBrazeIdentity = useCallback(() => {
     if (isDummyUserId(userId)) {
       lastSyncedIdentityRef.current = null;
+      targetIdentityRef.current = null;
+      retryCountRef.current = 0;
       return;
     }
 
-    const brazeOptOutIdentityCleanupEnabled = brazeOptOutIdentityCleanup?.enabled ?? false;
     const currentIdentity: SyncedBrazeIdentity = {
       userId,
       isTrackedUser,
       brazeOptOutIdentityCleanup: brazeOptOutIdentityCleanupEnabled,
     };
-    const lastSyncedIdentity = lastSyncedIdentityRef.current;
-    if (
-      lastSyncedIdentity &&
-      lastSyncedIdentity.userId.equals(currentIdentity.userId) &&
-      lastSyncedIdentity.isTrackedUser === currentIdentity.isTrackedUser &&
-      lastSyncedIdentity.brazeOptOutIdentityCleanup === currentIdentity.brazeOptOutIdentityCleanup
-    ) {
+
+    if (!identitiesMatch(targetIdentityRef.current, currentIdentity)) {
+      targetIdentityRef.current = currentIdentity;
+      retryCountRef.current = 0;
+    }
+
+    if (identitiesMatch(lastSyncedIdentityRef.current, currentIdentity)) {
+      retryCountRef.current = 0;
       return;
     }
 
-    lastSyncedIdentityRef.current = currentIdentity;
+    if (pendingConsentTransitionRef.current) {
+      return;
+    }
+
+    const lastSyncedIdentity = lastSyncedIdentityRef.current;
+    const isConsentTransition =
+      brazeOptOutIdentityCleanupEnabled &&
+      lastSyncedIdentity != null &&
+      lastSyncedIdentity.isTrackedUser !== currentIdentity.isTrackedUser;
+
+    if (isConsentTransition) {
+      const transition = Promise.resolve(applyBrazeConsentTransition({ isTrackedUser, userId }))
+        .then(() => true)
+        .catch(error => {
+          console.warn("Braze consent transition failed", error);
+          return false;
+        });
+
+      pendingConsentTransitionRef.current = transition;
+      void transition.then(didTransitionSucceed => {
+        if (pendingConsentTransitionRef.current === transition) {
+          pendingConsentTransitionRef.current = null;
+        }
+
+        if (didTransitionSucceed) {
+          lastSyncedIdentityRef.current = currentIdentity;
+          retryCountRef.current = 0;
+          setSyncedEpoch(epoch => epoch + 1);
+          return;
+        }
+
+        if (retryCountRef.current >= MAX_CONSENT_TRANSITION_RETRIES) {
+          return;
+        }
+
+        retryCountRef.current += 1;
+        syncBrazeIdentityRef.current();
+      });
+      return;
+    }
+
     start(isTrackedUser, userId, {
       brazeOptOutIdentityCleanup: brazeOptOutIdentityCleanupEnabled,
     });
-  }, [brazeOptOutIdentityCleanup?.enabled, isTrackedUser, userId]);
+    lastSyncedIdentityRef.current = currentIdentity;
+  }, [brazeOptOutIdentityCleanupEnabled, isTrackedUser, userId]);
+
+  useEffect(() => {
+    syncBrazeIdentityRef.current = syncBrazeIdentity;
+  }, [syncBrazeIdentity]);
 
   useEffect(() => {
     syncBrazeIdentity();
   }, [syncBrazeIdentity]);
 
   useEffect(() => {
+    const currentIdentity: SyncedBrazeIdentity | null = isDummyUserId(userId)
+      ? null
+      : {
+          userId,
+          isTrackedUser,
+          brazeOptOutIdentityCleanup: brazeOptOutIdentityCleanupEnabled,
+        };
+
+    if (!identitiesMatch(lastSyncedIdentityRef.current, currentIdentity)) {
+      return;
+    }
+
     updateUserPreferences(notifications, isTrackedUser, {
-      brazeOptOutIdentityCleanup: brazeOptOutIdentityCleanup?.enabled ?? false,
+      brazeOptOutIdentityCleanup: brazeOptOutIdentityCleanupEnabled,
     });
-  }, [notifications, isTrackedUser, brazeOptOutIdentityCleanup?.enabled]);
+  }, [brazeOptOutIdentityCleanupEnabled, isTrackedUser, notifications, syncedEpoch, userId]);
 
   return null;
 };

--- a/apps/ledger-live-mobile/src/notifications/braze.test.ts
+++ b/apps/ledger-live-mobile/src/notifications/braze.test.ts
@@ -1,18 +1,13 @@
 import Braze from "@braze/react-native-sdk";
 import { UserId, DUMMY_USER_ID } from "@domain/entity-client-identity";
-import { start, updateUserPreferences } from "./braze";
+import { applyBrazeConsentTransition, start, updateUserPreferences } from "./braze";
 import type { NotificationsSettings } from "../reducers/types";
-
-jest.mock("@braze/react-native-sdk", () => ({
-  __esModule: true,
-  default: {
-    changeUser: jest.fn(),
-    setCustomUserAttribute: jest.fn(),
-  },
-}));
 
 const mockedChangeUser = jest.mocked(Braze.changeUser);
 const mockedSetCustomUserAttribute = jest.mocked(Braze.setCustomUserAttribute);
+const mockedWipeData = jest.mocked(Braze.wipeData);
+const mockedEnableSDK = jest.mocked(Braze.enableSDK);
+const mockedRequestContentCardsRefresh = jest.mocked(Braze.requestContentCardsRefresh);
 
 const defaultNotifications = {
   areNotificationsAllowed: true,
@@ -96,5 +91,54 @@ describe("updateUserPreferences", () => {
     expect(mockedSetCustomUserAttribute).toHaveBeenCalledWith("notificationsAllowed", true);
     expect(mockedSetCustomUserAttribute).toHaveBeenCalledWith("optInAnnouncements", true);
     expect(mockedSetCustomUserAttribute).toHaveBeenCalledWith("optInLargeMovers", false);
+  });
+});
+
+describe("applyBrazeConsentTransition", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should reset the SDK without identifying when opting out", async () => {
+    await applyBrazeConsentTransition({ isTrackedUser: false, userId: REAL_USER_ID });
+
+    expect(mockedWipeData).toHaveBeenCalledTimes(1);
+    expect(mockedEnableSDK).toHaveBeenCalledTimes(1);
+    expect(mockedRequestContentCardsRefresh).toHaveBeenCalledTimes(1);
+    expect(mockedChangeUser).not.toHaveBeenCalled();
+    expect(mockedWipeData.mock.invocationCallOrder[0]).toBeLessThan(
+      mockedEnableSDK.mock.invocationCallOrder[0],
+    );
+    expect(mockedEnableSDK.mock.invocationCallOrder[0]).toBeLessThan(
+      mockedRequestContentCardsRefresh.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("should recover the SDK then identify with the real user id when opting in", async () => {
+    await applyBrazeConsentTransition({ isTrackedUser: true, userId: REAL_USER_ID });
+
+    expect(mockedWipeData).toHaveBeenCalledTimes(1);
+    expect(mockedEnableSDK).toHaveBeenCalledTimes(1);
+    expect(mockedChangeUser).toHaveBeenCalledTimes(1);
+    expect(mockedChangeUser).toHaveBeenCalledWith(REAL_USER_ID.exportUserIdForBraze());
+    expect(mockedRequestContentCardsRefresh).toHaveBeenCalledTimes(1);
+    expect(mockedWipeData.mock.invocationCallOrder[0]).toBeLessThan(
+      mockedEnableSDK.mock.invocationCallOrder[0],
+    );
+    expect(mockedEnableSDK.mock.invocationCallOrder[0]).toBeLessThan(
+      mockedChangeUser.mock.invocationCallOrder[0],
+    );
+    expect(mockedChangeUser.mock.invocationCallOrder[0]).toBeLessThan(
+      mockedRequestContentCardsRefresh.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("should skip the SDK when the user id is dummy", async () => {
+    await applyBrazeConsentTransition({ isTrackedUser: true, userId: DUMMY_USER_ID });
+
+    expect(mockedWipeData).not.toHaveBeenCalled();
+    expect(mockedEnableSDK).not.toHaveBeenCalled();
+    expect(mockedChangeUser).not.toHaveBeenCalled();
+    expect(mockedRequestContentCardsRefresh).not.toHaveBeenCalled();
   });
 });

--- a/apps/ledger-live-mobile/src/notifications/braze.ts
+++ b/apps/ledger-live-mobile/src/notifications/braze.ts
@@ -1,6 +1,37 @@
 import Braze from "@braze/react-native-sdk";
 import { type UserId, isDummyUserId } from "@domain/entity-client-identity";
+import {
+  runBrazeOptInTransition,
+  runBrazeOptOutTransition,
+  type BrazeIdentityLifecycleSdk,
+} from "@ledgerhq/live-common/braze/identityLifecycle";
 import { NotificationsSettings } from "../reducers/types";
+
+const mobileBrazeSdk: BrazeIdentityLifecycleSdk = {
+  wipeData: () => Braze.wipeData(),
+  enableSDK: () => Braze.enableSDK(),
+  changeUser: userId => Braze.changeUser(userId),
+  refreshContentCards: () => Braze.requestContentCardsRefresh(),
+};
+
+export const applyBrazeConsentTransition = async ({
+  isTrackedUser,
+  userId,
+}: {
+  isTrackedUser: boolean;
+  userId: UserId;
+}): Promise<void> => {
+  if (isDummyUserId(userId)) return;
+
+  if (!isTrackedUser) {
+    await runBrazeOptOutTransition(mobileBrazeSdk);
+    return;
+  }
+
+  await runBrazeOptInTransition(mobileBrazeSdk, {
+    userId: userId.exportUserIdForBraze(),
+  });
+};
 
 export type StartBrazeOptions = {
   brazeOptOutIdentityCleanup?: boolean;


### PR DESCRIPTION
### 📝 Description

[LIVE-34731](https://ledgerhq.atlassian.net/browse/LIVE-34731): wire mobile consent toggles to the shared Braze identity lifecycle from [LIVE-34730](https://ledgerhq.atlassian.net/browse/LIVE-34730).

- Behind `brazeOptOutIdentityCleanup`, `HookNotifications` runs `applyBrazeConsentTransition` only when `lastSyncedIdentityRef` shows an `isTrackedUser` flip — not on cold start
- Opt-out: wipe → enable → refresh. No `changeUser`, no fake `external_id`
- Opt-in: wipe → enable → `changeUser(realId)` → refresh. Does not also call `start()` (would double `changeUser`)
- First sync, user-id repair, and flag-only changes still use `start()`. Flag off keeps the legacy `start()` path
- Content Card refresh is the adapter’s `Braze.requestContentCardsRefresh()`. Single Content Card owner is [LIVE-34733](https://ledgerhq.atlassian.net/browse/LIVE-34733)

This branch sits on [LIVE-34730](https://ledgerhq.atlassian.net/browse/LIVE-34730). If that PR is not merged, set the base to `feat/LIVE-34730`.

### Test plan

- [ ] `pnpm mobile test:jest --watchman=false src/notifications/braze.test.ts src/notifications/HookNotifications.test.tsx`
- [ ] Flag on: opt in → opt out wipes local SDK, does not assign an `external_id`, then refreshes cards
- [ ] Flag on: opt out → opt in recovers, `changeUser(realId)`, then refreshes cards
- [ ] Cold start / first sync does not wipe
- [ ] Flag off: consent toggle still only calls `start()`

[LIVE-34731]: https://ledgerhq.atlassian.net/browse/LIVE-34731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-34730]: https://ledgerhq.atlassian.net/browse/LIVE-34730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-34733]: https://ledgerhq.atlassian.net/browse/LIVE-34733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-34730]: https://ledgerhq.atlassian.net/browse/LIVE-34730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ