### PR TITLE
[LWM] feat(send): inform not available addressbook for a family

### DIFF
--- a/.changeset/seven-monkeys-admire.md
+++ b/.changeset/seven-monkeys-admire.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+feat(send): explain why the address book is unavailable for some families

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4537,6 +4537,10 @@
       "account": "Account",
       "alreadyUsed": "Already used · {{date}}",
       "notInRecentHistory": "Not in your recent history",
+      "addressBookUnsupported": {
+        "title": "{{family}} isn't supported yet",
+        "description": "You can't add a {{family}} address to your contacts yet. We're adding more cryptos over time."
+      },
       "relativeDate": {
         "justNow": "Just now",
         "minutesAgo_one": "1 min ago",

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
@@ -6,7 +6,13 @@ import { BigNumber } from "bignumber.js";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
-import { act, fireEvent, renderWithReactQuery, screen } from "@tests/test-renderer";
+import {
+  act,
+  fireEvent,
+  renderWithReactQuery,
+  screen,
+  withFlagOverrides,
+} from "@tests/test-renderer";
 import type { Account } from "@ledgerhq/types-live";
 import type { State } from "~/reducers/types";
 import { SendFlowOrchestrator } from "../SendFlowOrchestrator";
@@ -54,6 +60,10 @@ const HostStack = createNativeStackNavigator();
 type DriveOpts = Readonly<{
   recipient: string;
   memo?: string;
+}>;
+
+type RenderForAccountOptions = Readonly<{
+  contactsEnabled?: boolean;
 }>;
 
 jest.mock("LLM/components/DeviceIntentExecutor", () => {
@@ -108,12 +118,25 @@ describe("Send flow integration tests", () => {
   function renderForAccount(
     account: Account,
     initParams: Omit<SendFlowInitParams, "account"> = {},
+    options: RenderForAccountOptions = {},
   ) {
+    const withAccount = (state: State): State => ({
+      ...state,
+      accounts: { ...state.accounts, active: [account] },
+    });
+
     return renderWithReactQuery(<SendPage initParams={{ account, ...initParams }} />, {
-      overrideInitialState: (state: State) => ({
-        ...state,
-        accounts: { ...state.accounts, active: [account] },
-      }),
+      overrideInitialState: options.contactsEnabled
+        ? withFlagOverrides(
+            {
+              lwmContacts: {
+                enabled: true,
+                params: { newBadge: false, eligibleAddressFamilies: ["evm"] },
+              },
+            },
+            withAccount,
+          )
+        : withAccount,
     });
   }
 
@@ -159,6 +182,34 @@ describe("Send flow integration tests", () => {
     await user.press(await screen.findByText(/^Send to /));
 
     expect(await screen.findByText("Review")).toBeOnTheScreen();
+  });
+
+  it("should keep add contact enabled when the network supports the address book", async () => {
+    const { user } = renderForAccount(accountEthereum, {}, { contactsEnabled: true });
+
+    await user.paste(
+      await screen.findByPlaceholderText("Enter address or ENS"),
+      VALID_ETHEREUM_RECIPIENT,
+    );
+    await flushTimers();
+
+    expect(await screen.findByRole("button", { name: "Add contact" })).toBeEnabled();
+  });
+
+  it("should explain why add contact is unavailable on an unsupported network", async () => {
+    const { user } = renderForAccount(accountBitcoin, {}, { contactsEnabled: true });
+
+    await user.paste(await screen.findByPlaceholderText("Enter address"), VALID_BITCOIN_RECIPIENT);
+    await flushTimers();
+
+    await user.press(await screen.findByRole("button", { name: "Add contact" }));
+
+    expect(await screen.findByText("Bitcoin isn't supported yet")).toBeVisible();
+    expect(
+      screen.getByText(
+        "You can't add a Bitcoin address to your contacts yet. We're adding more cryptos over time.",
+      ),
+    ).toBeVisible();
   });
 
   describe("Stellar (memo flow)", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/AddContactAction.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/AddContactAction.tsx
@@ -1,0 +1,93 @@
+import {
+  BottomSheet,
+  BottomSheetContent,
+  BottomSheetHeader,
+  BottomSheetView,
+  Box,
+  Button,
+  Text,
+  useBottomSheetRef,
+} from "@ledgerhq/lumen-ui-rnative";
+import React, { useCallback } from "react";
+import { Keyboard, Pressable } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+type AddContactActionProps = Readonly<{
+  hasAddressBook: boolean;
+  label: string;
+  unsupportedTitle: string;
+  unsupportedDescription: string;
+}>;
+
+export function AddContactAction({
+  hasAddressBook,
+  label,
+  unsupportedTitle,
+  unsupportedDescription,
+}: AddContactActionProps) {
+  const { bottom: bottomInset } = useSafeAreaInsets();
+  const unsupportedSheetRef = useBottomSheetRef();
+
+  const openUnsupportedSheet = useCallback(() => {
+    Keyboard.dismiss();
+    unsupportedSheetRef.current?.present();
+  }, [unsupportedSheetRef]);
+
+  const button = (
+    <Button
+      appearance="gray"
+      size="sm"
+      onPress={() => undefined}
+      disabled={!hasAddressBook}
+      testID="send-recipient-card-add-contact"
+      isFull
+    >
+      {label}
+    </Button>
+  );
+
+  if (hasAddressBook) {
+    return <Box lx={{ flex: 1 }}>{button}</Box>;
+  }
+
+  return (
+    <>
+      {/* A disabled button never receives touches, so the explanation is triggered by a wrapper */}
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={label}
+        accessibilityHint={unsupportedTitle}
+        onPress={openUnsupportedSheet}
+        testID="send-recipient-card-add-contact-unsupported-trigger"
+        style={{ flex: 1 }}
+      >
+        <Box
+          pointerEvents="none"
+          accessibilityElementsHidden
+          importantForAccessibility="no-hide-descendants"
+        >
+          {button}
+        </Box>
+      </Pressable>
+
+      <BottomSheet
+        ref={unsupportedSheetRef}
+        enableDynamicSizing
+        snapPoints={null}
+        testID="send-address-book-unsupported-sheet"
+      >
+        <BottomSheetView style={{ paddingBottom: bottomInset }}>
+          <BottomSheetHeader density="compact" />
+          <BottomSheetContent lx={{ gap: "s12", paddingBottom: "s24" }}>
+            <Text typography="heading3SemiBold" lx={{ color: "base" }}>
+              {unsupportedTitle}
+            </Text>
+            <Text typography="body1" lx={{ color: "base" }}>
+              {unsupportedDescription}
+            </Text>
+          </BottomSheetContent>
+        </BottomSheetView>
+      </BottomSheet>
+    </>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/AddressMatchedSection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/AddressMatchedSection.tsx
@@ -54,6 +54,9 @@ export function AddressMatchedSection({ viewModel }: AddressMatchedSectionProps)
             contact={suggestion.contact}
             isReady={suggestion.isReady}
             showActions={suggestion.showActions}
+            hasAddressBook={suggestion.hasAddressBook}
+            addressBookUnsupportedTitle={suggestion.addressBookUnsupportedTitle}
+            addressBookUnsupportedDescription={suggestion.addressBookUnsupportedDescription}
             addContactLabel={suggestion.addContactLabel}
             sendLabel={suggestion.sendLabel}
             onSend={suggestion.onSend}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientCard.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientCard.tsx
@@ -14,6 +14,7 @@ import {
 } from "@ledgerhq/lumen-ui-rnative";
 import { Wallet } from "@ledgerhq/lumen-ui-rnative/symbols";
 import React from "react";
+import { AddContactAction } from "./AddContactAction";
 
 type RecipientCardProps = Readonly<{
   recipient: string;
@@ -21,6 +22,9 @@ type RecipientCardProps = Readonly<{
   contact?: MatchedContact;
   isReady: boolean;
   showActions: boolean;
+  hasAddressBook: boolean;
+  addressBookUnsupportedTitle: string;
+  addressBookUnsupportedDescription: string;
   addContactLabel: string;
   sendLabel: string;
   onSend: () => void;
@@ -32,6 +36,9 @@ export function RecipientCard({
   contact,
   isReady,
   showActions,
+  hasAddressBook,
+  addressBookUnsupportedTitle,
+  addressBookUnsupportedDescription,
   addContactLabel,
   sendLabel,
   onSend,
@@ -73,15 +80,12 @@ export function RecipientCard({
           }}
         >
           {!contact && (
-            <Button
-              appearance="gray"
-              size="sm"
-              onPress={() => undefined}
-              testID="send-recipient-card-add-contact"
-              lx={{ flex: 1 }}
-            >
-              {addContactLabel}
-            </Button>
+            <AddContactAction
+              hasAddressBook={hasAddressBook}
+              label={addContactLabel}
+              unsupportedTitle={addressBookUnsupportedTitle}
+              unsupportedDescription={addressBookUnsupportedDescription}
+            />
           )}
           <Button
             appearance="base"

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/__tests__/AddressMatchedSection.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/__tests__/AddressMatchedSection.test.tsx
@@ -4,6 +4,8 @@ import { fireEvent, render, screen } from "@testing-library/react-native";
 import { AddressMatchedSection } from "../AddressMatchedSection";
 import { useAddressMatchedSectionViewModel } from "../../hooks/useAddressMatchedSectionViewModel";
 
+const mockPresentBottomSheet = jest.fn();
+
 jest.mock("@features/platform-feature-flags", () => ({
   useFeature: () => ({ enabled: false }),
 }));
@@ -36,6 +38,7 @@ jest.mock("@ledgerhq/lumen-ui-rnative", () => {
   return {
     Banner: Container,
     BottomSheet: Container,
+    BottomSheetContent: Container,
     BottomSheetHeader: () => null,
     BottomSheetView: Container,
     Box: Container,
@@ -83,7 +86,7 @@ jest.mock("@ledgerhq/lumen-ui-rnative", () => {
     SubheaderRow: Container,
     SubheaderTitle: Label,
     Text: Label,
-    useBottomSheetRef: () => ({ current: { present: jest.fn() } }),
+    useBottomSheetRef: () => ({ current: { present: mockPresentBottomSheet } }),
   };
 });
 
@@ -116,10 +119,14 @@ const searchResult: AddressSearchResult = {
 function AddressMatchedSectionContainer({
   result,
   isContactsFeatureEnabled = false,
+  hasAddressBook = true,
+  addressBookFamilyName = "Ethereum",
   onSelect = jest.fn(),
 }: Readonly<{
   result: AddressSearchResult;
   isContactsFeatureEnabled?: boolean;
+  hasAddressBook?: boolean;
+  addressBookFamilyName?: string;
   onSelect?: (address: string, ensName?: string) => void;
 }>) {
   const viewModel = useAddressMatchedSectionViewModel({
@@ -128,12 +135,18 @@ function AddressMatchedSectionContainer({
     onSelect,
     isAddressComplete: true,
     isContactsFeatureEnabled,
+    hasAddressBook,
+    addressBookFamilyName,
   });
 
   return <AddressMatchedSection viewModel={viewModel} />;
 }
 
 describe("AddressMatchedSection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("shows a valid unmatched address selected by the shared presentation", () => {
     render(<AddressMatchedSectionContainer result={searchResult} />);
 
@@ -169,7 +182,7 @@ describe("AddressMatchedSection", () => {
     expect(onSelect).toHaveBeenCalledWith(address, "vitalik.eth");
   });
 
-  it("keeps add contact enabled as a no-op on the recipient card", () => {
+  it("keeps add contact enabled when the address book is supported", () => {
     render(
       <AddressMatchedSectionContainer
         result={{
@@ -183,5 +196,34 @@ describe("AddressMatchedSection", () => {
 
     expect(screen.getByTestId("send-recipient-card-add-contact")).toBeEnabled();
     expect(screen.getByTestId("send-recipient-card-send")).toBeEnabled();
+  });
+
+  it("opens the unsupported address book sheet from the disabled add contact button", () => {
+    render(
+      <AddressMatchedSectionContainer
+        result={{
+          ...searchResult,
+          status: "valid",
+          resolvedAddress: address,
+        }}
+        isContactsFeatureEnabled
+        hasAddressBook={false}
+        addressBookFamilyName="Solana"
+      />,
+    );
+
+    expect(
+      screen.getByTestId("send-recipient-card-add-contact", { includeHiddenElements: true }),
+    ).toBeDisabled();
+
+    fireEvent.press(screen.getByTestId("send-recipient-card-add-contact-unsupported-trigger"));
+
+    expect(mockPresentBottomSheet).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByText('send.newSendFlow.addressBookUnsupported.title {"family":"Solana"}'),
+    ).toBeVisible();
+    expect(
+      screen.getByText('send.newSendFlow.addressBookUnsupported.description {"family":"Solana"}'),
+    ).toBeVisible();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenContentViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenContentViewModel.test.ts
@@ -61,6 +61,8 @@ const recipientViewModel = {
   clipboardAddress: null,
   handlePasteFromClipboard: jest.fn(),
   isContactsFeatureEnabled: true,
+  hasAddressBook: false,
+  addressBookFamilyName: "Bitcoin",
 } as never;
 
 const memoViewModel = {
@@ -123,6 +125,12 @@ describe("useRecipientScreenContentViewModel", () => {
       address: "resolved-address",
       onSkip: expect.any(Function),
     });
+    expect(mockedUseAddressMatchedSectionViewModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hasAddressBook: false,
+        addressBookFamilyName: "Bitcoin",
+      }),
+    );
   });
 
   it("tracks and forwards matched-address selection", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressMatchedSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressMatchedSectionViewModel.ts
@@ -19,6 +19,8 @@ type UseAddressMatchedSectionViewModelProps = Readonly<{
   isAddressComplete?: boolean;
   hasBridgeError?: boolean;
   isContactsFeatureEnabled?: boolean;
+  hasAddressBook?: boolean;
+  addressBookFamilyName?: string;
 }>;
 
 type AddressListItemSuggestion = Readonly<{
@@ -48,6 +50,9 @@ type RecipientCardSuggestion = Readonly<{
   contact?: MatchedContact;
   isReady: boolean;
   showActions: boolean;
+  hasAddressBook: boolean;
+  addressBookUnsupportedTitle: string;
+  addressBookUnsupportedDescription: string;
   addContactLabel: string;
   sendLabel: string;
   onSend: () => void;
@@ -73,6 +78,8 @@ export function useAddressMatchedSectionViewModel({
   isAddressComplete = false,
   hasBridgeError = false,
   isContactsFeatureEnabled = false,
+  hasAddressBook = false,
+  addressBookFamilyName = "",
 }: UseAddressMatchedSectionViewModelProps): AddressMatchedSectionViewModel {
   const { t } = useTranslation();
   const formatRelativeDate = useFormatRelativeDate();
@@ -94,6 +101,14 @@ export function useAddressMatchedSectionViewModel({
         contact: undefined,
         isReady: false,
         showActions: false,
+        hasAddressBook,
+        addressBookUnsupportedTitle: t("send.newSendFlow.addressBookUnsupported.title", {
+          family: addressBookFamilyName,
+        }),
+        addressBookUnsupportedDescription: t(
+          "send.newSendFlow.addressBookUnsupported.description",
+          { family: addressBookFamilyName },
+        ),
         addContactLabel: t("contacts.addContact"),
         sendLabel: t("contacts.addressDetail.send"),
         onSend: () => onSelect(recipientAddress, searchResult.ensName),
@@ -157,6 +172,14 @@ export function useAddressMatchedSectionViewModel({
           contact: presentation.matchedContact,
           isReady: presentation.isReady,
           showActions: !hasBridgeError,
+          hasAddressBook,
+          addressBookUnsupportedTitle: t("send.newSendFlow.addressBookUnsupported.title", {
+            family: addressBookFamilyName,
+          }),
+          addressBookUnsupportedDescription: t(
+            "send.newSendFlow.addressBookUnsupported.description",
+            { family: addressBookFamilyName },
+          ),
           addContactLabel: t("contacts.addContact"),
           sendLabel: t("contacts.addressDetail.send"),
           onSend: () => onSelect(presentation.recipientAddress, presentation.ensName),

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenContentViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenContentViewModel.ts
@@ -89,6 +89,8 @@ export function useRecipientScreenContentViewModel({
     isAddressComplete: recipient.isAddressComplete,
     hasBridgeError: recipient.showBridgeRecipientError,
     isContactsFeatureEnabled: recipient.isContactsFeatureEnabled,
+    hasAddressBook: recipient.hasAddressBook,
+    addressBookFamilyName: recipient.addressBookFamilyName,
   });
 
   useEffect(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenView.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenView.ts
@@ -91,6 +91,8 @@ export function useRecipientScreenView({
     isLoading,
     result,
     mainAccount,
+    hasAddressBook,
+    addressBookFamilyName: mainAccount.currency.name,
     showInitialState,
     showEmptyContactsState,
     clipboardAddress,


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Display bottomsheet when clicking on the disabled "Add contact" on new send flow LWM
Explaining this family does not have address book yet
<img width="178" height="400" alt="image" src="https://github.com/user-attachments/assets/6fb25852-1c08-43f0-8e02-eaa1feb40340" />

### 🔗 Context

- **[JIRA / GitHub issue](https://ledgerhq.atlassian.net/browse/LIVE-35807)** <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
