### PR TITLE
feat(support): add lint rule package and suffix rule

### DIFF
--- a/.changeset/rapid-beetle-shine.md
+++ b/.changeset/rapid-beetle-shine.md
@@ -1,0 +1,5 @@
+---
+"@support/lint-rules": minor
+---
+
+Add ESLint plugin package with no-platform-suffix rule

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16006,6 +16006,12 @@ importers:
         specifier: 19.1.4
         version: 19.1.4
 
+  support/lint-rules:
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
   tests/dummy-live-app:
     dependencies:
       '@ledgerhq/live-app-sdk':
@@ -25040,7 +25046,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.1.4
       react-dom: 19.1.4
-      webpack: ^5.89.0
+      webpack: '*'
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -27350,7 +27356,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: ^5.5.10
+      rxjs: '*'
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -68340,7 +68346,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3(metro-transform-worker@0.83.3)
+      metro: 0.83.3
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -68360,7 +68366,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.7(metro-transform-worker@0.83.7)
+      metro: 0.83.7
       metro-babel-transformer: 0.83.7
       metro-cache: 0.83.7
       metro-cache-key: 0.83.7
@@ -68467,54 +68473,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metro@0.83.3(metro-transform-worker@0.83.3):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 1.3.8
-      chalk: 4.1.2
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.32.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0(metro@0.83.3)
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.3
-      metro-cache: 0.83.3
-      metro-cache-key: 0.83.3
-      metro-config: 0.83.3(metro-transform-worker@0.83.3)
-      metro-core: 0.83.3
-      metro-file-map: 0.83.3(metro@0.83.3)
-      metro-resolver: 0.83.3
-      metro-runtime: 0.83.3
-      metro-source-map: 0.83.3
-      metro-symbolicate: 0.83.3
-      metro-transform-plugins: 0.83.3
-      metro-transform-worker: 0.83.3
-      mime-types: 2.1.35
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
-      - supports-color
-      - utf-8-validate
-
   metro@0.83.7:
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -68558,53 +68516,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro@0.83.7(metro-transform-worker@0.83.7):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 2.0.0
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.35.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0(metro@0.83.7)
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.7
-      metro-cache: 0.83.7
-      metro-cache-key: 0.83.7
-      metro-config: 0.83.7(metro-transform-worker@0.83.7)
-      metro-core: 0.83.7
-      metro-file-map: 0.83.7(metro@0.83.7)
-      metro-resolver: 0.83.7
-      metro-runtime: 0.83.7
-      metro-source-map: 0.83.7
-      metro-symbolicate: 0.83.7
-      metro-transform-plugins: 0.83.7
-      metro-transform-worker: 0.83.7
-      mime-types: 3.0.1
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 

--- a/support/README.md
+++ b/support/README.md
@@ -37,6 +37,7 @@ Two kinds of preset:
 | --- | --- |
 | [`jest-devtools`](./jest-devtools) | `devtools/*` — dual web/native jest presets plus themed render fixtures |
 | [`jest-features-flow`](./jest-features-flow) | `features/flow/*` — dual web/native jest preset plus Lumen passthrough stubs |
+| [`lint-rules`](./lint-rules) | monorepo-wide custom ESLint rules |
 
 ## Adding a package
 

--- a/support/lint-rules/README.md
+++ b/support/lint-rules/README.md
@@ -1,0 +1,37 @@
+# @support/lint-rules
+
+> [!CAUTION]
+> **Status: UNSTABLE** — New package; in active development.
+
+Custom oxlint JS plugins for monorepo-wide lint rules.
+
+## Usage
+
+Reference a rule file in your `.oxlintrc.json`:
+
+```json
+{
+  "jsPlugins": ["../support/lint-rules/src/suffix-imports.js"],
+  "rules": {
+    "suffix-imports/no-platform-suffix": "error"
+  }
+}
+```
+
+## Rules
+
+### `suffix-imports/no-platform-suffix`
+
+Disallows explicit `.web` or `.native` suffixes in import paths. Platform resolution should be left to the bundler (Metro / webpack).
+
+**Autofix available** — run `oxlint --fix` to strip the suffix automatically.
+
+```ts
+// ✗
+import Foo from "./foo.native";
+import Bar from "../bar.web";
+
+// ✓
+import Foo from "./foo";
+import Bar from "../bar";
+```

--- a/support/lint-rules/package.json
+++ b/support/lint-rules/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@support/lint-rules",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Shared oxlint JS plugin for monorepo-wide custom lint rules",
+  "exports": {
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "files": [
+    "src"
+  ],
+  "scripts": {
+    "format": "oxfmt src",
+    "format:check": "oxfmt src --check",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "catalog:"
+  }
+}

--- a/support/lint-rules/project.json
+++ b/support/lint-rules/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@support/lint-rules",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/support/lint-rules/src/suffix-imports.js
+++ b/support/lint-rules/src/suffix-imports.js
@@ -1,0 +1,34 @@
+const noPlatformSuffixImports = {
+  meta: { fixable: "code" },
+  createOnce(context) {
+    function checkSource(node) {
+      const source = node.source?.value;
+      if (source?.includes(".web") || source?.includes(".native")) {
+        context.report({
+          message: "Imports should not contains .web or .native, use --fix to remove them",
+          node,
+          fix(fixer) {
+            const fixed = source.replace(/\.(web|native)/, "");
+            return fixer.replaceText(node.source, `"${fixed}"`);
+          },
+        });
+      }
+    }
+
+    return {
+      before() {},
+      ImportDeclaration: checkSource,
+      ExportNamedDeclaration: checkSource,
+      ExportAllDeclaration: checkSource,
+    };
+  },
+};
+
+export default {
+  meta: {
+    name: "suffix-imports",
+  },
+  rules: {
+    "no-platform-suffix": noPlatformSuffixImports,
+  },
+};

--- a/support/lint-rules/tsconfig.json
+++ b/support/lint-rules/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true
+  },
+  "include": ["src/**/*.js"],
+  "exclude": ["node_modules"]
+}

--- a/support/tsconfig.json
+++ b/support/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "files": [],
-  "references": [{ "path": "./jest-devtools" }, { "path": "./jest-features-flow" }]
+  "references": [{ "path": "./jest-devtools" }, { "path": "./jest-features-flow" }, { "path": "./lint-rules" }]
 }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

## Summary

Introduces `@support/lint-rules`, a new shared ESLint plugin package for monorepo-wide custom lint rules.

The first rule, `no-platform-suffix` (from the `suffix-imports` plugin), flags any import path that contains a `.web` or `.native` suffix and provides an auto-fix that strips the suffix, enforcing bare specifiers across the codebase.

### What changed

- **`support/lint-rules/`** — new private package `@support/lint-rules` exposing an oxlint-compatible ESLint plugin via `eslintCompatPlugin`.
- **`suffix-imports.js`** — the `no-platform-suffix` rule: reports imports whose `source` value includes `.web` or `.native`, with a fixer that rewrites the specifier to the suffix-free form.




Currently the package is not wired to any lint ruleset

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35810](https://ledgerhq.atlassian.net/browse/LIVE-35810)<!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-35810]: https://ledgerhq.atlassian.net/browse/LIVE-35810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ