### PR TITLE
[LWM] fix(pay): list all stablecoins in mobile deposit (LIVE-36252)

### DIFF
--- a/.changeset/pay-mobile-stablecoin-category.md
+++ b/.changeset/pay-mobile-stablecoin-category.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix the Pay tab "Add stablecoin" receive flow on mobile to list the full stablecoin catalog by filtering the Modular Asset Drawer on the stablecoin category, instead of pre-selecting only the two default stablecoins (USDC/USDT)

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.test.tsx
@@ -23,6 +23,7 @@ function mockModularDrawerController(
   mockedUseModularDrawerController.mockReturnValue({
     areCurrenciesFiltered: undefined,
     assetsConfiguration: undefined,
+    categories: undefined,
     closeDrawer,
     completionMode: "currency",
     enableAccountSelection: false,

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawerFlow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawerFlow.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
+import type { AssetCategory } from "@domain/api-aggregated-assets";
 import type { EnhancedModularDrawerConfiguration } from "@ledgerhq/live-common/wallet-api/ModularDrawer/types";
 import { useModularDrawerConfiguration } from "@ledgerhq/live-common/modularDrawer/hooks/useModularDrawerConfiguration";
 import type { AccountLike } from "@ledgerhq/types-live";
@@ -37,6 +38,8 @@ export type ModularDrawerFlowProps = Readonly<{
 
   /** List of preselected currencies to display in the drawer */
   currencies?: string[];
+  /** DADA asset categories to filter the drawer server-side (e.g. Stablecoins) */
+  categories?: AssetCategory[];
   /** Configuration for assets display */
   assetsConfiguration?: EnhancedModularDrawerConfiguration["assets"];
   /** Configuration for networks display */
@@ -64,6 +67,7 @@ export function ModularDrawerFlow({
   isOpen,
   onClose,
   currencies,
+  categories,
   assetsConfiguration,
   networksConfiguration,
   onAccountSelected,
@@ -89,6 +93,7 @@ export function ModularDrawerFlow({
     {
       currencyIds: completionMode === "currency" ? undefined : currencies,
       networkIds: completionMode === "currency" ? currencies : undefined,
+      categories,
       searchedValue: searchValue,
       useCase,
       areCurrenciesFiltered,

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawerWrapper.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawerWrapper.tsx
@@ -6,6 +6,7 @@ export function ModularDrawerWrapper() {
   const {
     isOpen,
     preselectedCurrencies,
+    categories,
     closeDrawer,
     handleAccountSelected,
     handleCurrencySelected,
@@ -25,6 +26,7 @@ export function ModularDrawerWrapper() {
     <ModularDrawer
       isOpen={isOpen}
       currencies={preselectedCurrencies}
+      categories={categories}
       onClose={closeDrawer}
       assetsConfiguration={assetsConfiguration}
       networksConfiguration={networksConfiguration}

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useAssets.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useAssets.test.ts
@@ -1,5 +1,6 @@
 import { renderHook, waitFor } from "@tests/test-renderer";
 import { http, HttpResponse, server } from "@tests/server";
+import { AssetCategory } from "@domain/api-aggregated-assets";
 import { useAssets } from "../useAssets";
 import {
   expectedAssetsSorted as expectedAssetsSortedFromMock,
@@ -86,5 +87,15 @@ describe("useAssets", () => {
     const searchParams = new URL(requests[0]).searchParams;
     expect(searchParams.get("currencyIds")).toBe("bitcoin");
     expect(searchParams.has("networkIds")).toBe(false);
+  });
+
+  it("forwards asset categories to the DADA request", async () => {
+    const requests = captureDadaRequests();
+    const { result } = renderHook(() => useAssets({ categories: [AssetCategory.Stablecoins] }));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const searchParams = new URL(requests[0]).searchParams;
+    expect(searchParams.get("categories")).toBe(AssetCategory.Stablecoins);
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useModularDrawerController.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useModularDrawerController.test.ts
@@ -1,4 +1,5 @@
 import { renderHook, act } from "@tests/test-renderer";
+import { AssetCategory } from "@domain/api-aggregated-assets";
 import { useModularDrawerController } from "../useModularDrawerController";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { AccountLike } from "@ledgerhq/types-live";
@@ -42,6 +43,26 @@ describe("useModularDrawerController", () => {
     expect(state.enableAccountSelection).toBe(true);
     expect(state.preselectedCurrencies).toEqual(["bitcoin"]);
     expect(state.presentation).toBe("drawer");
+  });
+
+  it("should store asset categories and reset them on close", () => {
+    const { result, store } = renderHook(() => useModularDrawerController());
+
+    act(() => {
+      result.current.openDrawer({
+        flow: "receive_flow",
+        source: "test_source",
+        categories: [AssetCategory.Stablecoins],
+      });
+    });
+
+    expect(store.getState().modularDrawer.categories).toEqual([AssetCategory.Stablecoins]);
+
+    act(() => {
+      result.current.closeDrawer();
+    });
+
+    expect(store.getState().modularDrawer.categories).toBeUndefined();
   });
 
   it("should close the drawer when closeDrawer is called", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useAssets.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useAssets.ts
@@ -9,10 +9,12 @@ import { useAcceptedCurrency } from "@ledgerhq/live-common/modularDrawer/hooks/u
 import { useSelector } from "~/context/hooks";
 import { modularDrawerFlowSelector } from "~/reducers/modularDrawer";
 import useEnv from "@features/platform-env";
+import type { AssetCategory } from "@domain/api-aggregated-assets";
 
 interface AssetsProps {
   currencyIds?: string[];
   networkIds?: readonly string[];
+  categories?: AssetCategory[];
   searchedValue?: string;
   useCase?: string;
   areCurrenciesFiltered?: boolean;
@@ -21,6 +23,7 @@ interface AssetsProps {
 export function useAssets({
   currencyIds,
   networkIds,
+  categories,
   searchedValue,
   useCase,
   areCurrenciesFiltered,
@@ -36,10 +39,13 @@ export function useAssets({
     [modularDrawerFeature?.params?.backendEnvironment],
   );
 
+  const resolvedCategories = categories?.length ? categories : undefined;
+
   const { data, isLoading, isSuccess, isError, error, refetch, loadNext } = useAssetsData({
     search: searchedValue,
     currencyIds: resolvedNetworkIds === undefined ? currencyIds : undefined,
     networkIds: resolvedNetworkIds,
+    categories: resolvedCategories,
     product: "llm",
     version: VersionNumber.appVersion,
     useCase,

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
@@ -39,6 +39,7 @@ export const useModularDrawerController = () => {
   const {
     isOpen,
     preselectedCurrencies,
+    categories,
     callbackId,
     cancelCallbackId,
     enableAccountSelection,
@@ -54,6 +55,7 @@ export const useModularDrawerController = () => {
     (state: State) => ({
       isOpen: state.modularDrawer.isOpen,
       preselectedCurrencies: state.modularDrawer.preselectedCurrencies,
+      categories: state.modularDrawer.categories,
       callbackId: state.modularDrawer.callbackId,
       cancelCallbackId: state.modularDrawer.cancelCallbackId,
       enableAccountSelection: state.modularDrawer.enableAccountSelection,
@@ -187,6 +189,7 @@ export const useModularDrawerController = () => {
   return {
     isOpen,
     preselectedCurrencies,
+    categories,
     enableAccountSelection,
     completionMode,
     presentation,

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/types.ts
@@ -1,6 +1,7 @@
 import { AccountLike, Account } from "@ledgerhq/types-live";
 import { EnhancedModularDrawerConfiguration } from "@ledgerhq/live-common/wallet-api/ModularDrawer/types";
 import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
+import type { AssetCategory } from "@domain/api-aggregated-assets";
 
 export enum ModularDrawerStep {
   Asset = "Asset",
@@ -20,6 +21,7 @@ export type DrawerExtras = {
 
 export type DrawerBaseParams = {
   currencies?: string[];
+  categories?: AssetCategory[];
   enableAccountSelection?: boolean;
   flow?: string;
   source?: string;

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/__tests__/usePayTabDepositOptions.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/__tests__/usePayTabDepositOptions.test.tsx
@@ -1,4 +1,5 @@
 import { act, renderHook } from "@tests/test-renderer";
+import { AssetCategory } from "@domain/api-aggregated-assets";
 import { NavigatorName, ScreenName } from "~/const";
 import { useOpenReceiveDrawer } from "LLM/features/Receive";
 import { usePayTabDepositOptions } from "../usePayTabDepositOptions";
@@ -27,10 +28,8 @@ jest.mock("LLM/features/Buy", () => ({
   useOpenBuySell: jest.fn(() => ({ handleOpenBuySell: mockHandleOpenBuySell })),
 }));
 
-const STABLECOIN_IDS = ["ethereum/erc20/usd__coin", "ethereum/erc20/usd_tether__erc20_"];
-
 function render(onTrackEvent = jest.fn()) {
-  return renderHook(() => usePayTabDepositOptions(onTrackEvent, STABLECOIN_IDS));
+  return renderHook(() => usePayTabDepositOptions(onTrackEvent));
 }
 
 describe("usePayTabDepositOptions", () => {
@@ -96,11 +95,11 @@ describe("usePayTabDepositOptions", () => {
     expect(mockHandleOpenBuySell).toHaveBeenCalledWith("buy");
   });
 
-  it("configures the receive drawer with the stablecoin filter", () => {
+  it("configures the receive drawer filtered to the stablecoin category", () => {
     render();
 
     expect(useOpenReceiveDrawer).toHaveBeenCalledWith({
-      currencyIds: STABLECOIN_IDS,
+      categories: [AssetCategory.Stablecoins],
       sourceScreenName: "Pay",
       fromMenu: true,
     });

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabDepositOptions.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabDepositOptions.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { useNavigation } from "@react-navigation/native";
+import { AssetCategory } from "@domain/api-aggregated-assets";
 import {
   useDepositOptionsAdapter,
   type DepositOptionId,
@@ -16,17 +17,18 @@ import { useOpenBuySell } from "LLM/features/Buy";
 const DEPOSIT_PAGE = "Pay";
 const FIAT_PROVIDER_MANIFEST_ID = "noah";
 
+const DEPOSIT_CATEGORIES: AssetCategory[] = [AssetCategory.Stablecoins];
+
 export type UsePayTabDepositOptions = UseDepositOptionsAdapter;
 
 export function usePayTabDepositOptions(
   onTrackEvent: PayCardTrackEvent | undefined,
-  stablecoinCurrencyIds: string[],
 ): UsePayTabDepositOptions {
   const { t } = useTranslation();
   const navigation = useNavigation();
 
   const { handleOpenReceiveDrawer } = useOpenReceiveDrawer({
-    currencyIds: stablecoinCurrencyIds,
+    categories: DEPOSIT_CATEGORIES,
     sourceScreenName: DEPOSIT_PAGE,
     fromMenu: true,
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.test.ts
@@ -43,15 +43,6 @@ const mockDepositOptions = {
   onSelect: jest.fn(),
 };
 
-jest.mock("LLM/features/PayTab/hooks/usePayStablecoins", () => ({
-  usePayStablecoins: () => ({
-    stablecoins: [],
-    defaultStablecoins: [{ id: "ethereum/erc20/usd__coin" }],
-    isLoading: false,
-    isError: false,
-  }),
-}));
-
 jest.mock("LLM/features/PayTab/hooks/usePayTabDepositOptions", () => ({
   usePayTabDepositOptions: () => ({
     open: mockDepositOpen,

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
@@ -11,7 +11,6 @@ import { useNavigationBarHeights } from "LLM/hooks/useNavigationBarHeights";
 import { usePayCardBalance } from "LLM/features/PayTab/hooks/usePayCardBalance";
 import { usePayTabActionTiles } from "LLM/features/PayTab/hooks/usePayTabActionTiles";
 import { usePayTabDepositOptions } from "LLM/features/PayTab/hooks/usePayTabDepositOptions";
-import { usePayStablecoins } from "LLM/features/PayTab/hooks/usePayStablecoins";
 import { track } from "~/analytics";
 import { PAY_TAB_DEEP_LINK } from "~/navigation/deeplinks/payTabDeepLink";
 
@@ -21,11 +20,7 @@ export function usePayTabViewModel() {
   const { params } = useRoute<RouteProp<PayTabNavigatorParamList, ScreenName.PayTab>>();
 
   const balance = usePayCardBalance();
-  const { defaultStablecoins } = usePayStablecoins();
-  const deposit = usePayTabDepositOptions(
-    balance.onTrackEvent,
-    defaultStablecoins.map(stablecoin => stablecoin.id),
-  );
+  const deposit = usePayTabDepositOptions(balance.onTrackEvent);
   const actionTiles = usePayTabActionTiles(balance.onTrackEvent, deposit.open);
 
   const balanceLabels: BalanceLabels = useMemo(

--- a/apps/ledger-live-mobile/src/mvvm/features/Receive/__tests__/useOpenReceiveDrawer.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Receive/__tests__/useOpenReceiveDrawer.test.tsx
@@ -1,4 +1,5 @@
 import { renderHook, act } from "@testing-library/react-native";
+import { AssetCategory } from "@domain/api-aggregated-assets";
 import { useOpenReceiveDrawer } from "../index";
 import { HOOKS_TRACKING_LOCATIONS } from "~/analytics/hooks/variables";
 import { mockEthCryptoCurrency } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
@@ -145,6 +146,26 @@ describe("useOpenReceiveDrawer", () => {
         enableAccountSelection: true,
         onAccountSelected: expect.any(Function),
       });
+    });
+
+    it("should forward asset categories to the modular drawer for a category-filtered flow", () => {
+      const { result } = renderHook(() =>
+        useOpenReceiveDrawer(
+          createTestProps({ currency: undefined, categories: [AssetCategory.Stablecoins] }),
+        ),
+      );
+
+      act(() => {
+        result.current.handleOpenReceiveDrawer();
+      });
+
+      expect(mockOpenDrawer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          currencies: [],
+          categories: [AssetCategory.Stablecoins],
+          areCurrenciesFiltered: false,
+        }),
+      );
     });
 
     it("should give currencyIds priority over currency when both are provided", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Receive/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Receive/index.ts
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import { useModularDrawerController } from "../ModularDrawer";
 import { CryptoOrTokenCurrency } from "@domain/entity-currency";
+import type { AssetCategory } from "@domain/api-aggregated-assets";
 import { NavigatorName, ScreenName } from "~/const";
 import { useNavigation } from "@react-navigation/native";
 import { AccountLike, Account } from "@ledgerhq/types-live";
@@ -19,6 +20,12 @@ type Props = {
    * of a multi-network asset (e.g. USDC on Ethereum + Polygon + Base).
    */
   currencyIds?: string[];
+  /**
+   * DADA asset categories to filter the drawer server-side (e.g. Stablecoins).
+   * Unlike `currencyIds`, the full category catalog stays browsable instead of
+   * pre-selecting a fixed set of ledger ids.
+   */
+  categories?: AssetCategory[];
   sourceScreenName: string;
   navigationOverride?: RootNavigation;
   hideBackButton?: boolean;
@@ -27,6 +34,7 @@ type Props = {
 export function useOpenReceiveDrawer({
   currency,
   currencyIds,
+  categories,
   sourceScreenName,
   navigationOverride,
   hideBackButton,
@@ -90,6 +98,7 @@ export function useOpenReceiveDrawer({
         const currencies = hasCurrencyIds ? currencyIds : currency ? [currency.id] : [];
         return openDrawer({
           currencies,
+          categories,
           flow: "receive_flow",
           source: sourceScreenName,
           areCurrenciesFiltered: hasCurrencyIds || !!currency,
@@ -101,6 +110,7 @@ export function useOpenReceiveDrawer({
     [
       currency,
       currencyIds,
+      categories,
       openDrawer,
       sourceScreenName,
       openReceiveConfirmation,

--- a/apps/ledger-live-mobile/src/reducers/modularDrawer.ts
+++ b/apps/ledger-live-mobile/src/reducers/modularDrawer.ts
@@ -9,10 +9,12 @@ import {
 } from "LLM/features/ModularDrawer/types";
 import { State } from "~/reducers/types";
 import { EnhancedModularDrawerConfiguration } from "@ledgerhq/live-common/wallet-api/ModularDrawer/types";
+import type { AssetCategory } from "@domain/api-aggregated-assets";
 
 export interface ModularDrawerState {
   isOpen: boolean;
   preselectedCurrencies: string[];
+  categories?: AssetCategory[];
   callbackId?: string;
   cancelCallbackId?: string;
   enableAccountSelection?: boolean;
@@ -33,6 +35,7 @@ export interface ModularDrawerState {
 export const INITIAL_STATE: ModularDrawerState = {
   isOpen: false,
   preselectedCurrencies: [],
+  categories: undefined,
   callbackId: undefined,
   cancelCallbackId: undefined,
   enableAccountSelection: false,
@@ -81,6 +84,7 @@ const modularDrawerSlice = createSlice({
       state.searchValue = "";
       const {
         currencies,
+        categories,
         callbackId,
         cancelCallbackId,
         enableAccountSelection,
@@ -101,6 +105,7 @@ const modularDrawerSlice = createSlice({
       if (currencies !== undefined) {
         state.preselectedCurrencies = currencies;
       }
+      state.categories = categories;
       state.callbackId = callbackId;
       state.cancelCallbackId = cancelCallbackId;
       state.completionMode = completionMode;
@@ -143,6 +148,7 @@ const modularDrawerSlice = createSlice({
     closeModularDrawer: state => {
       state.isOpen = false;
       state.preselectedCurrencies = [];
+      state.categories = undefined;
       state.callbackId = undefined;
       state.cancelCallbackId = undefined;
       state.enableAccountSelection = false;


### PR DESCRIPTION
### 📝 Description

On the mobile Pay tab, the **Add stablecoin → Receive** flow only listed the two default stablecoins (USDC/USDT) instead of the full stablecoin catalog.

**Previous behaviour**: `usePayTabViewModel` passed `defaultStablecoins` (the hard-coded top 2 by market cap) into the receive drawer's `currencyIds`, so the Modular Asset Drawer was pre-filtered to just those two ledger ids.

**Fix**: mirror desktop and open the Modular Asset Drawer filtered by the `Stablecoins` asset category instead of a fixed id list. This adds optional `categories` plumbing through the mobile Modular Drawer (types, reducer, controller, wrapper, flow, `useAssets`) and the receive hook, then wires `usePayTabDepositOptions` to pass `[AssetCategory.Stablecoins]`. `defaultStablecoins` now feeds only the balance filter UI.

**Automated check preventing regression**: unit tests assert the receive drawer is opened with the stablecoin category (not the two-id list), that categories survive the drawer state/controller plumbing, and that they reach the DADA request.


https://github.com/user-attachments/assets/bbdc9c03-f1b9-46c2-ad58-f21ab4bad9e8





### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36252](https://ledgerhq.atlassian.net/browse/LIVE-36252)
- **ADR** (if any): N/A

[LIVE-36252]: https://ledgerhq.atlassian.net/browse/LIVE-36252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ