### PR TITLE
fix(contacts): align contacts with wallet content (LIVE-35880)

### DIFF
--- a/.changeset/tidy-contacts-align.md
+++ b/.changeset/tidy-contacts-align.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts-list": minor
+---
+
+Align the Contacts page with the wallet content area on Desktop.

--- a/features/flow/flow-contacts-list/src/ContactsListView.web.tsx
+++ b/features/flow/flow-contacts-list/src/ContactsListView.web.tsx
@@ -25,7 +25,7 @@ export function ContactsListView(props: ContactsListViewProps): React.ReactNode 
   const contactsList = <ContactsList {...props} />;
 
   return (
-    <div className="relative flex min-h-0 flex-1 flex-col px-24 pb-32" data-testid="contacts-page">
+    <div className="relative flex min-h-0 flex-1 flex-col pb-32" data-testid="contacts-page">
       <div
         aria-busy={isLedgerSyncChecking}
         className={`flex min-h-0 flex-1 flex-col${isLedgerSyncChecking ? " pointer-events-none" : ""}`}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** No dedicated test was added for this CSS-only layout correction; the existing targeted suite passes (9 tests).
- [x] **Impact of the changes:**
      Verify Contacts left and right alignment against the Wallet content area on Desktop.

### 📝 Description

The Contacts page added its own horizontal padding even though the Wallet shell already provides the common content gutter. This made the Contacts list and detail layout narrower and visually misaligned with other Wallet pages.

This PR removes the duplicate `px-24` class from the shared Web Contacts list Flow. No behavior or data flow changes are introduced.

| Before | After |
| --- | --- |
| _Not captured_ | _Not captured — CSS-only layout correction_ |

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-35880

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
