### PR TITLE
[LWM] fix(pay): keep Pay sheets fully visible (LIVE-36255)

### DIFF
--- a/.changeset/friendly-pigs-leave.md
+++ b/.changeset/friendly-pigs-leave.md
@@ -1,0 +1,7 @@
+---
+"@features/flow-pay-card-balance": minor
+"@features/flow-pay-card-deposit": minor
+"live-mobile": minor
+---
+
+Fix Pay tab bottom sheets so the filter opens expanded and deposit options stay fully visible

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabDepositOptions.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabDepositOptions.ts
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import { useNavigation } from "@react-navigation/native";
 import { AssetCategory } from "@domain/api-aggregated-assets";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import {
   useDepositOptionsAdapter,
   type DepositOptionId,
@@ -26,6 +27,7 @@ export function usePayTabDepositOptions(
 ): UsePayTabDepositOptions {
   const { t } = useTranslation();
   const navigation = useNavigation();
+  const { bottom: bottomInset } = useSafeAreaInsets();
 
   const { handleOpenReceiveDrawer } = useOpenReceiveDrawer({
     categories: DEPOSIT_CATEGORIES,
@@ -80,5 +82,12 @@ export function usePayTabDepositOptions(
     },
   };
 
-  return useDepositOptionsAdapter({ labels, page: DEPOSIT_PAGE, onSelect, onTrackEvent });
+  const { open, depositOptions } = useDepositOptionsAdapter({
+    labels,
+    page: DEPOSIT_PAGE,
+    onSelect,
+    onTrackEvent,
+  });
+
+  return { open, depositOptions: { ...depositOptions, bottomInset } };
 }

--- a/features/flow/pay-card-balance/src/components/Filter/BalanceFilterPickerView.native.tsx
+++ b/features/flow/pay-card-balance/src/components/Filter/BalanceFilterPickerView.native.tsx
@@ -24,8 +24,7 @@ export function BalanceFilterPickerView({
     <QueuedBottomSheet
       isRequestingToBeOpened={isOpen}
       onClose={onClose}
-      enableDynamicSizing
-      maxDynamicContentSize="fullWithOffset"
+      snapPoints="fullWithOffset"
       testID="pay-card-balance-filter-sheet"
     >
       {isOpen ? (

--- a/features/flow/pay-card-deposit/src/components/DepositOptions/DepositOptions.tsx
+++ b/features/flow/pay-card-deposit/src/components/DepositOptions/DepositOptions.tsx
@@ -11,6 +11,7 @@ export function DepositOptions(props: DepositOptionsProps) {
       isOpen={props.isOpen}
       title={props.labels.title}
       options={options}
+      bottomInset={props.bottomInset}
       onClose={props.onClose}
       onSelectOption={onSelectOption}
     />

--- a/features/flow/pay-card-deposit/src/components/DepositOptions/DepositOptionsView.native.tsx
+++ b/features/flow/pay-card-deposit/src/components/DepositOptions/DepositOptionsView.native.tsx
@@ -8,6 +8,7 @@ export function DepositOptionsView({
   isOpen,
   title,
   options,
+  bottomInset = 0,
   onClose,
   onSelectOption,
 }: DepositOptionsViewProps) {
@@ -19,11 +20,18 @@ export function DepositOptionsView({
       testID="pay-card-deposit-sheet"
     >
       {isOpen ? (
-        <BottomSheetView style={{ paddingHorizontal: 0 }}>
+        <BottomSheetView
+          style={{ paddingHorizontal: 0, paddingBottom: bottomInset + 24 }}
+          testID="pay-card-deposit-sheet-content"
+        >
           <BottomSheetHeader spacing density="expanded" title={title} />
 
           <Box
-            lx={{ flexDirection: "column", gap: "s8", paddingBottom: "s16" }}
+            lx={{
+              flexDirection: "column",
+              gap: "s8",
+              marginHorizontal: "s8",
+            }}
             testID="pay-card-deposit-options"
           >
             {options.map(option => (

--- a/features/flow/pay-card-deposit/src/components/DepositOptions/__tests__/DepositOptionsView.native.test.tsx
+++ b/features/flow/pay-card-deposit/src/components/DepositOptions/__tests__/DepositOptionsView.native.test.tsx
@@ -54,6 +54,13 @@ describe("DepositOptionsView (Native)", () => {
     expect(screen.getByTestId("pay-card-deposit-option-swap")).toBeVisible();
   });
 
+  it("reserves the bottom safe area so the last option stays visible", () => {
+    render(<DepositOptionsView {...defaultProps} bottomInset={48} />);
+
+    const content = screen.getByTestId("pay-card-deposit-sheet-content");
+    expect(content.props.style.paddingBottom).toBeGreaterThanOrEqual(48);
+  });
+
   it("emits the pressed option id", async () => {
     const user = userEvent.setup();
     const onSelectOption = jest.fn();

--- a/features/flow/pay-card-deposit/src/types.ts
+++ b/features/flow/pay-card-deposit/src/types.ts
@@ -20,6 +20,7 @@ export type DepositOptionsProps = Readonly<{
   isOpen: boolean;
   labels: DepositOptionsLabels;
   page: string;
+  bottomInset?: number;
   onClose: () => void;
   /** Host-owned navigation intent for the pressed option. Navigation stays in the app. */
   onSelect: (id: DepositOptionId) => void;
@@ -37,6 +38,7 @@ export type DepositOptionsViewProps = Readonly<{
   isOpen: boolean;
   title: string;
   options: readonly DepositOption[];
+  bottomInset?: number;
   onClose: () => void;
   onSelectOption: (id: DepositOptionId) => void;
 }>;


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Fixes two Pay tab bottom sheets on mobile.

The stablecoin filter opened reduced and could not be expanded: `enableDynamicSizing` measured only the `BottomSheetScrollView` content, so Gorhom had a single detent. The sheet now opens at `fullWithOffset` so the list can scroll.

The deposit options sheet clipped the last item (Buy) behind the Android navigation bar: dynamic sizing did not reserve the bottom inset. The host now passes `bottomInset`, and the sheet uses `paddingBottom: bottomInset + 24`.

A native test asserts the deposit sheet content reserves that bottom padding.


## Showcase 📸

### Android 🤖

https://github.com/user-attachments/assets/e723ab72-0920-41af-a423-dedfff6ccf84

### iOS 🍏

https://github.com/user-attachments/assets/ecd73050-9923-4c09-998b-dae199bb85f0



### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36255](https://ledgerhq.atlassian.net/browse/LIVE-36255), [LIVE-36257](https://ledgerhq.atlassian.net/browse/LIVE-36257)
- **ADR** (if any): n/a

[LIVE-36255]: https://ledgerhq.atlassian.net/browse/LIVE-36255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LIVE-36257]: https://ledgerhq.atlassian.net/browse/LIVE-36257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ