### PR TITLE
[LWDM] fix(coin-framework): stop truncating account history to one page

### DIFF
--- a/.changeset/lucky-cursors-walk.md
+++ b/.changeset/lucky-cursors-walk.md
@@ -1,0 +1,19 @@
+---
+"@ledgerhq/live-common": patch
+"@ledgerhq/coin-evm": patch
+---
+
+fix(coin-framework): follow the listOperations cursor so account history is no longer truncated to one page
+
+getAccountShape called listOperations once and discarded the returned `next`, so any account with
+more operations than one explorer page never received the rest, and no later sync recovered the
+tail: the walk is newest-first and `minHeight` only ever moves forward, so the pages below the
+first were lost for good.
+
+It now walks the cursor chain within a sync, treating a falsy cursor as end of stream. The walk is
+unbounded — only a module that cannot progress ends it early: an empty page, or a cursor already
+followed (a repeat, or a longer cycle). The `extra.pagingToken` resume read is removed:
+nothing could ever write it, and `minHeight` is the resume position across syncs.
+
+On the coin-evm side, the Ledger explorer's `fetchPaginatedOpsWithRetries` appends each batch in
+place instead of rebuilding the whole accumulator (`[...previous, ...batch]`) once per page.

--- a/libs/coin-modules/coin-evm/src/network/explorer/ledger.ts
+++ b/libs/coin-modules/coin-evm/src/network/explorer/ledger.ts
@@ -62,11 +62,11 @@ export async function fetchPaginatedOpsWithRetries(
       },
     });
 
-    const mergedOperations = [...previousOperations, ...operationsBatch];
+    previousOperations.push(...operationsBatch);
 
     return token
-      ? fetchPaginatedOpsWithRetries(params, token, mergedOperations, retries)
-      : mergedOperations.sort(
+      ? fetchPaginatedOpsWithRetries(params, token, previousOperations, retries)
+      : previousOperations.sort(
           // sorting DESC order
           (a, b) => new Date(b.block.time).getTime() - new Date(a.block.time).getTime(),
         );

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
@@ -16,6 +16,7 @@ import { getAccountRawAssignHooks } from "./accountRawAssign";
 import { adaptCoreOperationToLiveOperation, cleanedOperation, extractBalance } from "./utils";
 import { inferSubOperations } from "@ledgerhq/ledger-wallet-framework/serialization";
 import { buildSubAccounts, mergeSubAccounts } from "./buildSubAccounts";
+import { paginateOperations } from "./paginateOperations";
 import type { Balance, Operation, Stake } from "@ledgerhq/coin-module-framework/api/types";
 import type { OperationCommon } from "./types";
 import type {
@@ -565,18 +566,20 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
         ? op
         : { ...op, accountId, id: encodeOperationId(accountId, op.hash, op.type) },
     );
-    const cursor = oldOps[0]?.extra?.pagingToken || "";
     const syncHash = await getSyncHash(currency.id, syncConfig.blacklistedTokenIds);
     const syncFromScratch = !initialAccount?.blockHeight || initialAccount?.syncHash !== syncHash;
-    // Calculate minHeight for pagination
+    // Resume position across syncs: `minHeight` alone, derived from the newest stored operation.
+    // It is non-volatile by construction and already persisted, unlike a module cursor (coin-hypercore
+    // documents its own as volatile). Only the cursor varies from page to page below.
     const minHeight = syncFromScratch ? 0 : (oldOps[0]?.blockHeight ?? 0) + 1;
-    const paginationCursor = cursor && !syncFromScratch ? cursor : undefined;
 
-    const { items: newCoreOps } = await coinModuleApi.listOperations(context, address, {
-      minHeight,
-      cursor: paginationCursor,
-      order: "desc",
-    });
+    const newCoreOps = await paginateOperations(cursor =>
+      coinModuleApi.listOperations(context, address, {
+        minHeight,
+        cursor,
+        order: "desc",
+      }),
+    );
     // Same hooks the persist/restore path uses, so the family bag on a freshly-synced operation ends
     // up in the shape a restored one has — the family's `fromOperationExtraRaw` is the single
     // definition of it. Loaded per sync rather than per operation; the registry caches the import.

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/paginateOperations.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/paginateOperations.test.ts
@@ -1,0 +1,90 @@
+import type { Operation, Page } from "@ledgerhq/coin-module-framework/api/types";
+import { paginateOperations } from "./paginateOperations";
+
+const op = (hash: string) => ({ tx: { hash } }) as unknown as Operation;
+
+const pages =
+  (...responses: Page<Operation>[]) =>
+  (cursor: string | undefined) => {
+    calls.push(cursor);
+    const next = responses[calls.length - 1];
+    if (!next) throw new Error("fetched more pages than the test provided");
+    return Promise.resolve(next);
+  };
+
+let calls: (string | undefined)[] = [];
+beforeEach(() => {
+  calls = [];
+});
+
+describe("paginateOperations", () => {
+  it("stops on an absent cursor", async () => {
+    const items = await paginateOperations(pages({ items: [op("a")] }));
+
+    expect(items.map(o => o.tx.hash)).toEqual(["a"]);
+    expect(calls).toEqual([undefined]);
+  });
+
+  it("stops on an empty-string cursor (coin-evm's Ledger explorer arm, coin-algorand)", async () => {
+    const items = await paginateOperations(pages({ items: [op("a")], next: "" }));
+
+    expect(items.map(o => o.tx.hash)).toEqual(["a"]);
+    expect(calls).toEqual([undefined]);
+  });
+
+  it("follows the chain across pages, threading each cursor into the next request", async () => {
+    const items = await paginateOperations(
+      pages(
+        { items: [op("a")], next: "c1" },
+        { items: [op("b")], next: "c2" },
+        { items: [op("c")] },
+      ),
+    );
+
+    expect(items.map(o => o.tx.hash)).toEqual(["a", "b", "c"]);
+    expect(calls).toEqual([undefined, "c1", "c2"]);
+  });
+
+  it("stops when the cursor does not advance", async () => {
+    const items = await paginateOperations(
+      pages({ items: [op("a")], next: "c1" }, { items: [op("b")], next: "c1" }),
+    );
+
+    expect(items.map(o => o.tx.hash)).toEqual(["a", "b"]);
+    expect(calls).toEqual([undefined, "c1"]);
+  });
+
+  it("stops on a cursor cycle longer than one page, which no equality check would catch", async () => {
+    const items = await paginateOperations(
+      pages(
+        { items: [op("a")], next: "c1" },
+        { items: [op("b")], next: "c2" },
+        { items: [op("c")], next: "c1" },
+      ),
+    );
+
+    expect(items.map(o => o.tx.hash)).toEqual(["a", "b", "c"]);
+    expect(calls).toEqual([undefined, "c1", "c2"]);
+  });
+
+  it("stops on an empty page handed back with a cursor (coin-vechain's early return)", async () => {
+    const items = await paginateOperations(
+      pages({ items: [op("a")], next: "c1" }, { items: [], next: "c2" }),
+    );
+
+    expect(items.map(o => o.tx.hash)).toEqual(["a"]);
+    expect(calls).toEqual([undefined, "c1"]);
+  });
+
+  it("propagates a mid-chain failure rather than returning a truncated history", async () => {
+    await expect(
+      paginateOperations(cursor => {
+        calls.push(cursor);
+        return calls.length === 1
+          ? Promise.resolve({ items: [op("a")], next: "c1" })
+          : Promise.reject(new Error("transient explorer failure"));
+      }),
+    ).rejects.toThrow("transient explorer failure");
+    expect(calls).toEqual([undefined, "c1"]);
+  });
+});

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/paginateOperations.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/paginateOperations.ts
@@ -1,0 +1,41 @@
+import { log } from "@ledgerhq/logs";
+import type { Operation, Page } from "@ledgerhq/coin-module-framework/api/types";
+
+/**
+ * Walks a module's `listOperations` cursor chain within one sync. End of stream is a *falsy* `next`:
+ * several modules send `""` rather than omitting it. Errors are not caught on purpose - we walk
+ * newest-first, so a persisted partial history would never be completed by a later sync.
+ */
+export async function paginateOperations(
+  fetchPage: (cursor: string | undefined) => Promise<Page<Operation>>,
+): Promise<Operation[]> {
+  const items: Operation[] = [];
+  const followed = new Set<string>();
+  let cursor: string | undefined;
+
+  for (;;) {
+    const { items: pageItems, next } = await fetchPage(cursor);
+    for (const item of pageItems) items.push(item);
+
+    if (!next) return items;
+
+    if (pageItems.length === 0) {
+      log("generic-coin-framework", "listOperations returned an empty page with a cursor", {
+        cursor,
+        next,
+      });
+      return items;
+    }
+
+    if (followed.has(next)) {
+      log("generic-coin-framework", "listOperations cursor cycled", {
+        cursor,
+        next,
+      });
+      return items;
+    }
+
+    followed.add(next);
+    cursor = next;
+  }
+}

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
@@ -295,7 +295,6 @@ describe("genericGetAccountShape", () => {
         {
           minHeight: 11,
           order: "desc",
-          cursor: "pt1",
         },
         [
           {
@@ -319,7 +318,7 @@ describe("genericGetAccountShape", () => {
             hash: "h1",
             blockHeight: 10,
             type: "OPT_IN",
-            extra: { pagingToken: "pt1", assetReference: "ar1", assetOwner: "ow1" },
+            extra: { assetReference: "ar1", assetOwner: "ow1" },
           },
         ],
       ],
@@ -357,7 +356,7 @@ describe("genericGetAccountShape", () => {
           hash: "h1",
           blockHeight: 10,
           type: "OPT_IN",
-          extra: { pagingToken: "pt1", assetReference: "ar1", assetOwner: "ow1" },
+          extra: { assetReference: "ar1", assetOwner: "ow1" },
         };
         const pendingOp = {
           hash: "h0",
@@ -447,7 +446,9 @@ describe("genericGetAccountShape", () => {
           {
             minHeight: expectedPagination.minHeight,
             order: expectedPagination.order,
-            ...("cursor" in expectedPagination ? { cursor: expectedPagination.cursor } : {}),
+            // The first page is always requested cursor-less: the resume position across syncs is
+            // `minHeight`, never a cursor read back off a stored operation's `extra`.
+            cursor: undefined,
           },
         );
 
@@ -480,6 +481,54 @@ describe("genericGetAccountShape", () => {
         });
       },
     );
+
+    test("walks every page of the module's cursor chain within one sync", async () => {
+      getBalanceMock.mockResolvedValue([{ asset: { type: "native" }, value: 0n, locked: 0n }]);
+      extractBalanceMock.mockReturnValue({ value: 0n, locked: 0n });
+      buildSubAccountsMock.mockReturnValue([]);
+      adaptCoreOperationToLiveOperationMock.mockImplementation((_accId, op: any) => ({
+        hash: op.hash,
+        type: op.type,
+        blockHeight: op.height,
+        extra: {},
+      }));
+      mergeOpsMock.mockImplementation((oldOps, newOps) => [...newOps, ...oldOps]);
+      cleanedOperationMock.mockImplementation(operation => operation);
+      lastBlockMock.mockResolvedValue({ height: 123 });
+
+      listOperationsMock
+        .mockResolvedValueOnce({
+          items: [{ hash: "p1", type: "IN", tx: { failed: false }, height: 3 }],
+          next: "c1",
+        })
+        .mockResolvedValueOnce({
+          items: [{ hash: "p2", type: "IN", tx: { failed: false }, height: 2 }],
+          next: "c2",
+        })
+        .mockResolvedValueOnce({
+          items: [{ hash: "p3", type: "IN", tx: { failed: false }, height: 1 }],
+        });
+
+      const getShape = genericGetAccountShape(network, currency.id);
+      const result = await getShape(
+        {
+          address: `${currency.id}_addr3`,
+          initialAccount: undefined,
+          currency,
+          derivationMode: "",
+        } as any,
+        { paginationConfig: {} as any },
+      );
+
+      expect(listOperationsMock).toHaveBeenCalledTimes(3);
+      // Only the cursor moves: minHeight and order are identical on every page.
+      expect(listOperationsMock.mock.calls.map(call => call[2])).toEqual([
+        { minHeight: 0, order: "desc", cursor: undefined },
+        { minHeight: 0, order: "desc", cursor: "c1" },
+        { minHeight: 0, order: "desc", cursor: "c2" },
+      ]);
+      expect(result.operations?.map(op => op.hash)).toEqual(["p1", "p2", "p3"]);
+    });
 
     test("handles empty operations (no old ops, no new ops) and blockHeight=0", async () => {
       getBalanceMock.mockResolvedValue([{ asset: { type: "native" }, value: 0n, locked: 0n }]);
@@ -558,7 +607,7 @@ describe("genericGetAccountShape", () => {
           hash: "h1",
           blockHeight: 10,
           type: "OPT_IN",
-          extra: { pagingToken: "pt1", assetReference: "ar1", assetOwner: "ow1" },
+          extra: { assetReference: "ar1", assetOwner: "ow1" },
           accountId: "accId",
           id: "accId_h1_OPT_IN",
         },

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
@@ -1632,15 +1632,15 @@ describe("coin-framework utils", () => {
     });
 
     it("never lets the family shadow a framework-owned extra", () => {
-      // Including `pagingToken`, which the framework only reads and never writes here. The reviver
-      // spreads its input, so this also pins the strip as running after it.
+      // Including `memo`, which the framework writes only when the coin module supplies one. The
+      // reviver spreads its input, so this also pins the strip as running after it.
       const operation = adaptCoreOperationToLiveOperation(
         "accountId",
         {
           ...coreOperation,
           details: {
             ledgerOpType: "FREEZE",
-            familyExtra: { ledgerOpType: "HIJACKED", internal: true, pagingToken: "hijacked" },
+            familyExtra: { ledgerOpType: "HIJACKED", internal: true, memo: "hijacked" },
           },
         },
         extraRaw => ({ ...(extraRaw as Record<string, unknown>) }),
@@ -1649,7 +1649,7 @@ describe("coin-framework utils", () => {
 
       expect(extra.ledgerOpType).toBe("FREEZE");
       expect(extra.internal).toBeUndefined();
-      expect(extra.pagingToken).toBeUndefined();
+      expect(extra.memo).toBeUndefined();
     });
 
     it("leaves the framework's own keys alone when the coin module sends no family bag", () => {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
@@ -531,10 +531,9 @@ type FrameworkOperationExtra = {
 };
 
 /**
- * Every key of the above, plus `pagingToken` — read as the next sync's cursor in `getAccountShape` but
- * never written here. The family bag lands flat beside these, so a collision is dropped rather than
- * merged: each framework key is written *conditionally*, so a surviving family key would supply the
- * framework's own answer on an operation where the framework wrote none.
+ * Every key of the above. The family bag lands flat beside these, so a collision is dropped rather
+ * than merged: each framework key is written *conditionally*, so a surviving family key would supply
+ * the framework's own answer on an operation where the framework wrote none.
  *
  * `satisfies Record<…, true>` keeps this list honest: adding a field to `FrameworkOperationExtra`
  * without reserving it here fails to compile.
@@ -553,8 +552,7 @@ const FRAMEWORK_RESERVED_EXTRA_KEYS: ReadonlySet<string> = new Set(
     internal: true,
     feePayer: true,
     stake: true,
-    pagingToken: true,
-  } satisfies Record<keyof FrameworkOperationExtra | "pagingToken", true>),
+  } satisfies Record<keyof FrameworkOperationExtra, true>),
 );
 
 function stripFrameworkReservedKeys(bag: Record<string, unknown>): Record<string, unknown> {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

**Previous behaviour.** `getAccountShape` called `listOperations` once and dropped the returned `next`, so any account longer than one explorer page was truncated for good. No later sync came back for it: the walk is newest-first and `minHeight` only moves forward. The one resume path was dead — `extra.pagingToken` is a reserved key, stripped on every write path, so it was always empty.

**Fix.** `paginateOperations` walks the cursor chain within a sync. A falsy `next` ends the stream, since several modules send `""` rather than omitting it. It also stops when the module stops advancing — an empty page with a cursor, or a cursor already followed (a `Set`, so a `c1 -> c2 -> c1` cycle ends it too). Errors propagate on purpose: walking newest-first, a partial history would never be completed later. The dead `pagingToken` read is removed rather than repaired.

Also appends the coin-evm Ledger explorer's batches in place instead of rebuilding the accumulator once per page.

**Regression cover.** 7 unit tests in `paginateOperations.test.ts`: the multi-page walk, both terminators, the empty-page guard, a repeated cursor, a longer cycle, and error propagation.

**No cap.** A 50k cap was written and dropped: counted in explorer records it bounds nothing, since `getOperations` expands each record into as many operations as it carries events. Measured through the `eth` explorer:

| address | records | ERC20 events | payload |
|---|---|---|---|
| `0xa271266Ea7CF…` | 28 800 | 12 | 26 MB |
| `0xde0B295669a9…` | 32 570 | 2 657 590 | 1 984 MB |

The second shows 3 197 transactions on Etherscan and expands to ~2.6M operations — under a 50k-record cap, which never fired. 50k fails as an operation count too: the healthy address produces ~57.6k. Don't size a limit from the heavy one either — it's an old multisig contract (nonce 0) sprayed with spam, 1000 forged `Transfer` events per transaction. A real limit needs the right unit and a call on which end of the history to keep, since the explorer is walked ascending. Own ticket.

**QA.** From-scratch sync of a long account on the six enabled families, then a second sync — no duplicates, no gaps. Stellar `GBGHNJRD…CL32X`: 682 operations over 30 pages, matching the explorer; before, one page. An already-synced account won't show the difference, since incremental syncs resume above the newest known block.

Reviewers: Ethereum mainnet is configured `explorer: { type: "ledger" }`, which returns `NO_TOKEN`, so `paginateOperations` makes a single call there. Test on an etherscan-configured network or a non-EVM module.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36317](https://ledgerhq.atlassian.net/browse/LIVE-36317), [LIVE-36446](https://ledgerhq.atlassian.net/browse/LIVE-36446)
- **ADR** (if any): n/a
