### PR TITLE
[LWDM] feat(coin-tester): add the Kaspa coin-tester (LIVE-34179)

### DIFF
--- a/.changeset/kaspa-utxo-selection-and-signing-fixes.md
+++ b/.changeset/kaspa-utxo-selection-and-signing-fixes.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-kaspa": minor
+"@ledgerhq/live-common": minor
+---
+
+Fix UTXO selection picking an immature coinbase output ahead of a mature one across a digit-count boundary (sortUtxos compared blockDaaScore lexicographically as a string instead of numerically, e.g. treating "1202" as less than "200"), fix combine() to correctly unpack and validate the JSON-encoded per-input signature array the generic-adapter signer returns, and set a synthetic zero nonce in the generic-coin-framework's default Kaspa transaction (matching the existing near/vechain/cardano pattern) so getNextSequence is never called for a UTXO chain that has no account-level sequence.

--- a/.github/workflows/test-coin-tester.yml
+++ b/.github/workflows/test-coin-tester.yml
@@ -19,7 +19,7 @@ permissions:
   contents: read
 
 env:
-  COIN_TESTER_CURRENCIES: "evm polkadot solana bitcoin tezos tron xrp stellar multiversx cosmos cardano casper vechain near stacks"
+  COIN_TESTER_CURRENCIES: "evm polkadot solana bitcoin tezos tron xrp stellar multiversx cosmos cardano casper vechain near stacks kaspa"
 
 jobs:
   is-affected:

--- a/knip.json
+++ b/knip.json
@@ -96,6 +96,9 @@
     },
     "./libs/live-wallet": {
       "entry": ["src/walletSyncComposition.ts", "src/accounts/index.ts"]
+    },
+    "./libs/coin-tester-modules/coin-tester-kaspa": {
+      "ignore": ["miner/miner.js"]
     }
   }
 }

--- a/libs/coin-modules/coin-kaspa/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-kaspa/src/api/index.integ.test.ts
@@ -135,8 +135,10 @@ describe("createApi (integration)", () => {
 
   describe("craft -> combine round trip with a funded sender", () => {
     // Craft is real (selects the fixture's UTXOs); the signature is mocked. Kaspa needs one
-    // signature per input and `combine` only attaches the provided strings, so a mock hex
-    // signature per input verifies the craft → combine plumbing and signed-tx shape WITHOUT a
+    // signature per input, but the generic-adapter framework's `combine(tx, signatures)` only
+    // supports a single-string return value from the signer — so all per-input signatures are
+    // packed into one JSON-encoded string (see combine.ts). A mock hex signature per input,
+    // packed the same way, verifies the craft → combine plumbing and signed-tx shape WITHOUT a
     // private key (mirrors coin-filecoin's api/index.integ.test.ts mock-signature round trip).
     // A cryptographically valid signature + broadcast acceptance is out of scope for CI.
     it("produces a valid signed Kaspa transaction shape", async () => {
@@ -150,7 +152,8 @@ describe("createApi (integration)", () => {
       });
 
       const unsigned = JSON.parse(crafted.transaction);
-      const mockSignatures: string[] = unsigned.inputs.map(() => "b".repeat(128));
+      const perInputSignatures: string[] = unsigned.inputs.map(() => "b".repeat(128));
+      const mockSignatures = [JSON.stringify(perInputSignatures)];
       const signed = await api.combine(context, crafted.transaction, mockSignatures);
 
       const parsed = JSON.parse(signed);

--- a/libs/coin-modules/coin-kaspa/src/api/index.ts
+++ b/libs/coin-modules/coin-kaspa/src/api/index.ts
@@ -96,6 +96,8 @@ export function createApi(): CoinModuleApi<KaspaCoinConfig> {
     // --- Not applicable to Kaspa's UTXO model ---
     // No per-account sequence/nonce (replay protection comes from spending one-time UTXOs); no
     // raw-transaction craft; on-device address validation is not exposed through this API.
+    // (The generic-coin-framework's createTransaction sets a synthetic zero nonce for kaspa, the
+    // same way it does for near/vechain/cardano, so signOperation never actually calls this.)
     getNextSequence: (_context: KaspaContext, _address: string): Promise<bigint> => {
       throw new Error("getNextSequence is not applicable for Kaspa");
     },

--- a/libs/coin-modules/coin-kaspa/src/logic/tests/utxoLib.test.ts
+++ b/libs/coin-modules/coin-kaspa/src/logic/tests/utxoLib.test.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from "bignumber.js";
-import { calcMaxSpendableAmount } from "../utxos/lib";
+import { calcMaxSpendableAmount, sortUtxos } from "../utxos/lib";
 import { KaspaUtxoGenerator } from "./utxoSelection.test";
 
 describe("calcMaxSpendableAmount", () => {
@@ -41,5 +41,55 @@ describe("calcMaxSpendableAmount", () => {
     const result = calcMaxSpendableAmount(utxos, true, 14);
     // (506 + 5*1118 + 11) * 14 = 85498
     expect(result.toNumber()).toBe(5_0000_0000 - 85498);
+  });
+});
+
+describe("sortUtxos", () => {
+  // Regression test for a real bug: blockDaaScore is a numeric string, and comparing it with
+  // .localeCompare() (lexicographic) is wrong the moment two scores have different digit
+  // counts — e.g. "1202" < "200" as strings, even though 1202 > 200 numerically. This let a
+  // fresh, immature coinbase UTXO get selected ahead of a genuinely old, mature one, causing
+  // kaspad to reject the broadcast for spending an immature UTXO.
+  it("orders UTXOs by numeric DAA score, not lexicographic string order", () => {
+    const scores = ["9", "10", "99", "100", "999", "1000", "1202", "200"];
+    const utxos = scores.map(score => KaspaUtxoGenerator.generateUtxo(new BigNumber(1), score));
+
+    sortUtxos(utxos);
+
+    expect(utxos.map(u => u.utxoEntry.blockDaaScore)).toEqual([
+      "9",
+      "10",
+      "99",
+      "100",
+      "200",
+      "999",
+      "1000",
+      "1202",
+    ]);
+  });
+
+  it("never ranks a higher DAA score (newer) ahead of a lower one (older) across a digit boundary", () => {
+    // The exact real-world shape that triggered the bug: a handful of old, mature 1-3 digit
+    // UTXOs alongside a couple of fresh 4-digit confirmation-block UTXOs.
+    const older = KaspaUtxoGenerator.generateUtxo(new BigNumber(1), "200");
+    const fresh = KaspaUtxoGenerator.generateUtxo(new BigNumber(1), "1202");
+    const utxos = [fresh, older];
+
+    sortUtxos(utxos);
+
+    expect(utxos[0]).toBe(older);
+    expect(utxos[1]).toBe(fresh);
+  });
+
+  it("falls back to amount ascending when DAA scores are equal", () => {
+    const utxos = [
+      KaspaUtxoGenerator.generateUtxo(new BigNumber(300), "50"),
+      KaspaUtxoGenerator.generateUtxo(new BigNumber(100), "50"),
+      KaspaUtxoGenerator.generateUtxo(new BigNumber(200), "50"),
+    ];
+
+    sortUtxos(utxos);
+
+    expect(utxos.map(u => u.utxoEntry.amount.toNumber())).toEqual([100, 200, 300]);
   });
 });

--- a/libs/coin-modules/coin-kaspa/src/logic/tests/utxoSelection.test.ts
+++ b/libs/coin-modules/coin-kaspa/src/logic/tests/utxoSelection.test.ts
@@ -325,6 +325,23 @@ describe("1 output without discard", () => {
     expect(selectUtxos(utxos, isEcdsaRecipient, BigNumber(1_0000_0000)).utxos.length).toBe(2);
   });
 
+  test("regression: prefers a genuinely older (lower DAA) UTXO over a fresher (higher DAA) one across a digit-count boundary", () => {
+    // Real-world shape that broke sortUtxos' old lexicographic comparison: an old, mature
+    // 3-digit-DAA UTXO alongside a fresh, immature 4-digit-DAA one. "1202" < "200" as strings,
+    // so the buggy sort picked the fresh one first — exactly what a FIFO/maturity-aware
+    // selection must never do when the older UTXO alone is enough to cover the send.
+    const older = KaspaUtxoGenerator.generateUtxo(BigNumber(1_0000_0000), "200");
+    const fresh = KaspaUtxoGenerator.generateUtxo(BigNumber(1_0000_0000), "1202");
+    const utxos = [fresh, older];
+    // 1 input + 1 output, no change — matches the "send exact UTXO sum" pattern used elsewhere
+    // in this file, so selection never needs to reach for a second UTXO regardless of order.
+    const sendAmount = BigNumber(1_0000_0000 - (1118 + 506));
+
+    const selected = selectUtxos(utxos, false, sendAmount, 1);
+
+    expect(selected.utxos).toEqual([older]);
+  });
+
   afterEach(() => {
     jest.restoreAllMocks();
     // Reset to actual implementation

--- a/libs/coin-modules/coin-kaspa/src/logic/transaction/combine.ts
+++ b/libs/coin-modules/coin-kaspa/src/logic/transaction/combine.ts
@@ -7,19 +7,36 @@ import type { UnsignedKaspaTransaction } from "./craftTransaction";
 
 /**
  * Attach per-input device signatures to an unsigned Kaspa transaction (as produced by
- * `craftTransaction`) and return the signed transaction JSON ready for `broadcast`
- * (mirrors `bridge/signOperation.ts`'s `JSON.stringify(tx.toApiJSON())` serialization).
+ * `craftTransaction`) and return the signed transaction JSON ready for `broadcast`.
  *
- * Kaspa requires one signature per input (each input can be backed by a different key), so
- * unlike single-witness account chains, `signature` here holds one hex signature per input,
- * aligned by index with the crafted transaction's `inputs` array.
+ * Follows the generic-adapter contract: `signatures` is always a 1-element array containing
+ * a JSON-encoded string array of per-input hex signatures (one per UTXO input). Each input
+ * carries a different sighash, so N signatures are required — packed into one string by the
+ * signer so the chain-agnostic framework's single-return-value contract is satisfied.
  */
 export function combine(tx: string, signatures: string[]): string {
   const unsigned: UnsignedKaspaTransaction = JSON.parse(tx);
 
-  if (signatures.length !== unsigned.inputs.length) {
+  if (signatures.length !== 1) {
     throw new Error(
-      `kaspa: combine expected ${unsigned.inputs.length} signature(s), got ${signatures.length}`,
+      `kaspa: combine expects exactly 1 packed signature string, got ${signatures.length}`,
+    );
+  }
+
+  let sigs: string[];
+  try {
+    const parsed: unknown = JSON.parse(signatures[0]);
+    if (!Array.isArray(parsed) || !parsed.every(s => typeof s === "string")) {
+      throw new Error("not a string array");
+    }
+    sigs = parsed;
+  } catch {
+    throw new Error("kaspa: combine signature must be a JSON-encoded string array");
+  }
+
+  if (sigs.length !== unsigned.inputs.length) {
+    throw new Error(
+      `kaspa: combine expected ${unsigned.inputs.length} per-input signature(s), got ${sigs.length}`,
     );
   }
 
@@ -32,7 +49,7 @@ export function combine(tx: string, signatures: string[]): string {
       addressIndex: 0,
       address: "",
     });
-    hwInput.setSignature(signatures[index]);
+    hwInput.setSignature(sigs[index]);
     return hwInput;
   });
 

--- a/libs/coin-modules/coin-kaspa/src/logic/transaction/combine.unit.test.ts
+++ b/libs/coin-modules/coin-kaspa/src/logic/transaction/combine.unit.test.ts
@@ -11,11 +11,15 @@ function unsignedTx(overrides: Partial<UnsignedKaspaTransaction> = {}): string {
   return JSON.stringify(tx);
 }
 
+// The generic-adapter framework calls combine(tx, signatures) where signatures is the
+// array returned by the signer. Kaspa packs all per-input hex signatures into one
+// JSON-encoded string so the single-return-value framework contract is satisfied while
+// still supporting multi-input transactions (each input has a different sighash).
 describe("combine", () => {
   it("attaches the device signature to the matching input and returns the signed tx JSON", () => {
     const signature = "b".repeat(128);
 
-    const signed = combine(unsignedTx(), [signature]);
+    const signed = combine(unsignedTx(), [JSON.stringify([signature])]);
     const parsed = JSON.parse(signed);
 
     expect(parsed.transaction.inputs).toHaveLength(1);
@@ -31,7 +35,7 @@ describe("combine", () => {
       ],
     });
 
-    const signed = combine(tx, ["c".repeat(128)]);
+    const signed = combine(tx, [JSON.stringify(["c".repeat(128)])]);
     const parsed = JSON.parse(signed);
 
     expect(parsed.transaction.outputs).toEqual([
@@ -46,7 +50,7 @@ describe("combine", () => {
     ]);
   });
 
-  it("throws when the signature count does not match the input count", () => {
+  it("throws when the per-input signature count does not match the input count", () => {
     const tx = unsignedTx({
       inputs: [
         { prevTxId: "a".repeat(64), outpointIndex: 0, value: 1000000 },
@@ -54,8 +58,43 @@ describe("combine", () => {
       ],
     });
 
-    expect(() => combine(tx, ["only-one-signature"])).toThrow(
-      "kaspa: combine expected 2 signature(s), got 1",
+    expect(() => combine(tx, [JSON.stringify(["only-one-sig"])])).toThrow(
+      "kaspa: combine expected 2 per-input signature(s), got 1",
+    );
+  });
+
+  it("throws when the outer signatures array does not contain exactly one packed string", () => {
+    const tx = unsignedTx();
+
+    expect(() => combine(tx, [])).toThrow(
+      "kaspa: combine expects exactly 1 packed signature string, got 0",
+    );
+    expect(() =>
+      combine(tx, [JSON.stringify(["a".repeat(128)]), JSON.stringify(["b".repeat(128)])]),
+    ).toThrow("kaspa: combine expects exactly 1 packed signature string, got 2");
+  });
+
+  it("throws when the packed signature string is not valid JSON", () => {
+    const tx = unsignedTx();
+
+    expect(() => combine(tx, ["not-json"])).toThrow(
+      "kaspa: combine signature must be a JSON-encoded string array",
+    );
+  });
+
+  it("throws when the packed array contains a non-string element", () => {
+    const tx = unsignedTx();
+
+    expect(() => combine(tx, [JSON.stringify([12345])])).toThrow(
+      "kaspa: combine signature must be a JSON-encoded string array",
+    );
+  });
+
+  it("throws when the packed signature string is valid JSON but not an array", () => {
+    const tx = unsignedTx();
+
+    expect(() => combine(tx, [JSON.stringify({ signature: "a".repeat(128) })])).toThrow(
+      "kaspa: combine signature must be a JSON-encoded string array",
     );
   });
 });

--- a/libs/coin-modules/coin-kaspa/src/logic/transaction/craftTransaction.msw.test.ts
+++ b/libs/coin-modules/coin-kaspa/src/logic/transaction/craftTransaction.msw.test.ts
@@ -53,4 +53,26 @@ describe("craftTransaction via MSW", () => {
 
     await expect(craftTransaction(intent())).rejects.toThrow("no spendable UTXOs");
   });
+
+  it("regression: picks an old, low-DAA UTXO over a fresh, high-DAA one across a digit-count boundary", async () => {
+    // Real-world shape that broke the old lexicographic blockDaaScore sort: "1202" < "200" as
+    // strings, so a fresh, immature 4-digit UTXO got selected ahead of a genuinely old, mature
+    // 3-digit one. Both UTXOs alone can cover the send, so the sole way to tell them apart is
+    // which one craftTransaction actually picked.
+    server.use(
+      http.post(UTXOS_URL, () =>
+        HttpResponse.json([
+          makeApiUtxo(200_000_000, 0, "1202"),
+          makeApiUtxo(200_000_000, 1, "200"),
+        ]),
+      ),
+      http.get(FEE_URL, () => HttpResponse.json(FEE_ESTIMATE)),
+    );
+
+    const crafted = await craftTransaction(intent());
+    const parsed: UnsignedKaspaTransaction = JSON.parse(crafted.transaction);
+
+    expect(parsed.inputs).toHaveLength(1);
+    expect(parsed.inputs[0].outpointIndex).toBe(1); // the "200"-DAA UTXO, not the "1202" one
+  });
 });

--- a/libs/coin-modules/coin-kaspa/src/logic/utxos/lib.ts
+++ b/libs/coin-modules/coin-kaspa/src/logic/utxos/lib.ts
@@ -34,11 +34,16 @@ export const sumUtxoAmounts = (utxos: KaspaUtxo[]): BigNumber => {
 
 export const sortUtxos = (utxos: KaspaUtxo[]) => {
   utxos.sort((a, b) => {
-    const transactionComparison = a.utxoEntry.blockDaaScore.localeCompare(
-      b.utxoEntry.blockDaaScore,
-    );
-    if (transactionComparison !== 0) {
-      return transactionComparison;
+    // blockDaaScore is a numeric string. .localeCompare() (lexicographic) is wrong the moment two
+    // scores have different digit counts — e.g. "1202" < "200" as strings, even though 1202 > 200
+    // numerically — which can rank a fresh, immature coinbase UTXO ahead of a genuinely old,
+    // mature one and defeat the FIFO-oldest-first selection this function exists to provide.
+    // Compared as BigInt (not Number) so this stays correct even once DAA score exceeds
+    // Number.MAX_SAFE_INTEGER, which a plain numeric subtraction would silently get wrong.
+    const aDaa = BigInt(a.utxoEntry.blockDaaScore);
+    const bDaa = BigInt(b.utxoEntry.blockDaaScore);
+    if (aDaa !== bDaa) {
+      return aDaa < bDaa ? -1 : 1;
     }
     return a.utxoEntry.amount.minus(b.utxoEntry.amount).toNumber();
   });

--- a/libs/coin-modules/coin-kaspa/src/test/msw.mock.ts
+++ b/libs/coin-modules/coin-kaspa/src/test/msw.mock.ts
@@ -89,14 +89,14 @@ export const RECIPIENT = "kaspa:qyp8y7hlk9uj5l9vqsyz78x90yt84cujdytg93s8q8malhpd
 
 // Raw `/addresses/utxos` wire shape (amount as a JSON number; the network layer wraps it in a
 // BigNumber). A single large UTXO keeps KIP-9 storage mass under the per-tx limit.
-export function makeApiUtxo(amount: number, index: number) {
+export function makeApiUtxo(amount: number, index: number, blockDaaScore?: string) {
   return {
     address: SENDER,
     outpoint: { transactionId: index.toString(16).padStart(64, "0"), index },
     utxoEntry: {
       amount,
       scriptPublicKey: { version: 0, scriptPublicKey: "20" + "0".repeat(64) + "ac" },
-      blockDaaScore: (1000 + index).toString(),
+      blockDaaScore: blockDaaScore ?? (1000 + index).toString(),
       isCoinbase: false,
     },
   };

--- a/libs/coin-tester-modules/coin-tester-kaspa/README.md
+++ b/libs/coin-tester-modules/coin-tester-kaspa/README.md
@@ -41,7 +41,7 @@ This spins up kaspad in simnet mode plus a kaspa-rest-server, runs all scenario 
 - **Coinbase maturity is a real kaspad consensus rule** (~1000-block confirmation depth), not
   configurable away — `setup()` mines a 1000-block gap to satisfy it, sent to a throwaway address
   (not the tracked test address) so it doesn't inflate the account's own transaction history.
-- **`SETUP_BLOCKS` (200) is deliberately small.** Kaspa's simnet has no debug balance-injection
+- **`SETUP_BLOCKS` (100) is deliberately small.** Kaspa's simnet has no debug balance-injection
   RPC (unlike EVM's `anvil_setBalance`), so funding an account means actually mining real blocks —
   each one a transaction. Keeping this low avoids pushing the tracked address past the Kaspa REST
   API's 500-item page cap, which would require the coin module to paginate across multiple pages

--- a/libs/coin-tester-modules/coin-tester-kaspa/README.md
+++ b/libs/coin-tester-modules/coin-tester-kaspa/README.md
@@ -1,0 +1,54 @@
+# @ledgerhq/coin-tester-kaspa
+
+Deterministic integration tester for `@ledgerhq/coin-kaspa`. Validates the sync/craft/sign/broadcast
+path against a real local Kaspa node (kaspad + kaspa-rest-server in Docker), without Ledger Live UI,
+without real funds, and without external network calls.
+
+## Prerequisites
+
+- Docker and Docker Compose v2
+- `pnpm install` at the repo root
+
+## Running
+
+```sh
+pnpm coin:tester:kaspa start
+```
+
+This spins up kaspad in simnet mode plus a kaspa-rest-server, runs all scenario transactions for both
+`legacy` and `generic-adapter` bridge strategies, then tears down the containers.
+
+## Architecture
+
+- `src/signer.ts` — local BIP32/Schnorr signer (no hardware wallet, no Speculos)
+- `src/kaspaNode.ts` — Docker lifecycle (spawn/kill/mine/wait); `mineBlocks()` supports an
+  optional `payAddress` override so confirmation-only blocks can be sent to a throwaway address
+- `src/addressUtils.ts` — `kaspa:` ⇄ `kaspasim:` bech32 re-encoding (decode + recompute checksum,
+  not a text substitution — the checksum is a function of the prefix string)
+- `src/fixtures.ts` — constants, account builders, and an MSW interceptor that normalizes every
+  `kaspasim:` address in local REST responses to `kaspa:` before the coin module sees it
+- `src/helpers.ts` — `getBridges()` for both bridge strategies
+- `src/scenarii/kaspa.ts` — scenario: 4 transactions (fixed send, custom fee, multi-UTXO, send-max)
+- `src/negativeCases.test.ts` — status/validation checks that don't fit the happy-path scenario
+  runner (insufficient funds, invalid address, dust limit)
+- `src/globalSetup.ts` / `src/globalTeardown.ts` — start/stop the Docker stack once per Jest run
+- `docker-compose.yml` — kaspad (simnet) + postgres + indexer + kaspa-rest-server + miner sidecar
+- `miner/` — a from-scratch miner built on the official Kaspa WASM SDK, since rusty-kaspa v2.0.1
+  ships without a built-in one
+
+## Design notes
+
+- **Coinbase maturity is a real kaspad consensus rule** (~1000-block confirmation depth), not
+  configurable away — `setup()` mines a 1000-block gap to satisfy it, sent to a throwaway address
+  (not the tracked test address) so it doesn't inflate the account's own transaction history.
+- **`SETUP_BLOCKS` (200) is deliberately small.** Kaspa's simnet has no debug balance-injection
+  RPC (unlike EVM's `anvil_setBalance`), so funding an account means actually mining real blocks —
+  each one a transaction. Keeping this low avoids pushing the tracked address past the Kaspa REST
+  API's 500-item page cap, which would require the coin module to paginate across multiple pages
+  on every sync (a real, separate, framework-level limitation — see the code comments in
+  `coin-kaspa/src/logic/history/listOperations.ts` for details, not reproduced here to avoid
+  drifting out of sync with the actual code).
+- **`kaspa-miner` is built from a local Dockerfile**, not pulled from a registry — unlike this
+  repo's other coin-testers. `docker compose down` never removes images (only
+  containers/networks/volumes), so `spawnKaspaNode()` passes `--build` on every `up` to guarantee
+  local `miner.js` changes actually take effect.

--- a/libs/coin-tester-modules/coin-tester-kaspa/docker-compose.yml
+++ b/libs/coin-tester-modules/coin-tester-kaspa/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       retries: 30
 
   kaspa-db:
-    image: postgres:18-alpine
+    image: postgres:18-alpine@sha256:d3e1620b530c944afa6e887d22eb899824da68e19c52024bf98f5220c88a65b2
     environment:
       POSTGRES_USER: kaspa
       POSTGRES_PASSWORD: kaspa

--- a/libs/coin-tester-modules/coin-tester-kaspa/docker-compose.yml
+++ b/libs/coin-tester-modules/coin-tester-kaspa/docker-compose.yml
@@ -1,0 +1,122 @@
+# Local Kaspa test stack.
+# Image sources:
+#   kaspad       — supertypo/rusty-kaspad (pre-built rusty-kaspa v2.0.1)
+#   kaspa-db     — PostgreSQL (required by indexer and REST server)
+#   kaspa-indexer — supertypo/simply-kaspa-indexer (kaspad → postgres)
+#   kaspa-rest   — kaspanet/kaspa-rest-server (api.kaspa.org-compatible REST)
+#   kaspa-miner  — built locally; downloads kaspa WASM SDK and mines simnet blocks
+#
+# rusty-kaspa v2.0.1 has no built-in miner in kaspad — mining is a separate binary.
+# The kaspa-miner sidecar uses the official WASM SDK's PoW class to solve blocks and
+# submit them via wRPC, funded to KASPA_MINING_ADDRESS (kaspasim: prefix for simnet).
+#
+# NETWORK_TYPE=mainnet makes the REST server accept coin-kaspa's hardcoded "kaspa:" prefix.
+
+services:
+  kaspad:
+    image: supertypo/rusty-kaspad:v2.0.1@sha256:db36449e2f41cf33ab7c26683ce390cb71bdea9c403eefd2e740a7d5605bcd8b
+    platform: linux/amd64
+    command: >
+      kaspad
+      --yes
+      --simnet
+      --enable-unsynced-mining
+      --utxoindex
+      --nologfiles
+      --disable-upnp
+      --rpclisten=0.0.0.0:16110
+      --rpclisten-borsh=0.0.0.0:17110
+    healthcheck:
+      # busybox nc in this image is broken for TCP (-z always returns 1 even when port is open).
+      # netstat is available and reliably shows the bound port.
+      test: ["CMD-SHELL", "netstat -tlnp 2>/dev/null | grep -q ':16110' || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+
+  kaspa-db:
+    image: postgres:18-alpine
+    environment:
+      POSTGRES_USER: kaspa
+      POSTGRES_PASSWORD: kaspa
+      POSTGRES_DB: kaspa
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U kaspa"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+
+  kaspa-indexer:
+    image: supertypo/simply-kaspa-indexer:v2.3.0@sha256:f28478e046af83b8d490984ca76bd75c663a71e242feba51a176e5ab6ce0a62f
+    platform: linux/amd64
+    # -c initialises DB schema (creates composite types kaspa-rest needs at import time)
+    # -u auto-upgrades schema if a newer indexer version is pulled
+    # -b / --batch-concurrency / --block-interval tune the virtual chain processor:
+    #   live mode (~1ms/block) vs historical resync (~240ms/block). These values were
+    #   experimentally tuned to keep the processor in live mode when blocks arrive at ~50ms.
+    command: >
+      -c
+      -u
+      -s ws://kaspad:17110
+      -n simnet
+      -d postgresql://kaspa:kaspa@kaspa-db:5432/kaspa
+      --exclude-fields tx_out_script_public_key_address
+      -b 10
+      --batch-concurrency 10
+      --block-interval 200
+    depends_on:
+      kaspad:
+        condition: service_healthy
+      kaspa-db:
+        condition: service_healthy
+
+  kaspa-rest:
+    image: kaspanet/kaspa-rest-server:v2.3.0@sha256:999dd827d6c50bab4d9c6086b514220770375876445f402f9b9521fdcdfec8ca
+    platform: linux/amd64
+    environment:
+      KASPAD_WRPC_URL: ws://kaspad:17110
+      SQL_URI: postgresql+psycopg://kaspa:kaspa@kaspa-db:5432/kaspa
+      # mainnet so REGEX_KASPA_ADDRESS accepts coin-kaspa's hardcoded "kaspa:" prefix.
+      # USE_SCRIPT_FOR_ADDRESS=true makes lookups use scripts_transactions (populated by the
+      # indexer when tx_out_script_public_key_address is excluded) instead of
+      # addresses_transactions (which has kaspasim: addresses the kaspa: queries never match).
+      NETWORK_TYPE: mainnet
+      USE_SCRIPT_FOR_ADDRESS: "true"
+      DISABLE_PRICE: "true"
+    ports:
+      - "8080:8000"
+    depends_on:
+      kaspad:
+        condition: service_healthy
+      kaspa-db:
+        condition: service_healthy
+      kaspa-indexer:
+        condition: service_started
+    # Restarts until kaspa-indexer has created the postgres composite types
+    # (transactions_inputs, transactions_outputs) that dbsession.py fetches at import time.
+    restart: on-failure
+    healthcheck:
+      # curl is not present in this image; python3 is always available (it is a Python app).
+      test: ["CMD-SHELL", "python3 -c 'import urllib.request; urllib.request.urlopen(\"http://localhost:8000/info/blockdag\")' || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+
+  kaspa-miner:
+    build:
+      context: ./miner
+    platform: linux/amd64
+    environment:
+      KASPAD_WRPC_URL: ws://kaspad:17110
+      MINING_ADDRESS: ${KASPA_MINING_ADDRESS}
+    ports:
+      - "3939:3939"
+    depends_on:
+      kaspad:
+        condition: service_healthy
+    restart: on-failure
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"require('http').get('http://localhost:3939/health',r=>process.exit(r.statusCode===200?0:1))\""]
+      interval: 3s
+      timeout: 3s
+      retries: 20

--- a/libs/coin-tester-modules/coin-tester-kaspa/jest.config.ts
+++ b/libs/coin-tester-modules/coin-tester-kaspa/jest.config.ts
@@ -1,0 +1,43 @@
+import type { Config } from "jest";
+
+// Shared options reused by all projects.
+// `setupFiles` runs before coin-kaspa's config.ts captures API_KASPA_ENDPOINT at module-eval
+// time, so the env var must be set there (not in setupFilesAfterEnv). The `@ledgerhq/source`
+// export condition resolves workspace packages from TypeScript source without a prior build.
+const sharedConfig = {
+  testEnvironment: "node" as const,
+  setupFiles: ["<rootDir>/src/env.setup.ts"],
+  setupFilesAfterEnv: ["@ledgerhq/wallet-framework-test-setup"],
+  testEnvironmentOptions: {
+    customExportConditions: ["@ledgerhq/source", "node", "require", "default"],
+  },
+  transform: {
+    "^.+\\.(t|j)sx?$": ["@swc/jest", { jsc: { target: "esnext" } }],
+  },
+  transformIgnorePatterns: ["/node_modules/.pnpm/(?!@ledgerhq\\+)"],
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"] as string[],
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
+};
+
+const config: Config = {
+  reporters: ["default", ...(process.env.CI ? ["github-actions"] : [])],
+  // Serial execution across all projects: test files share the same Docker stack and
+  // on-chain state, so concurrent mining calls would race and produce 409s.
+  // maxWorkers must live here (top-level) — it is ignored inside a projects entry.
+  maxWorkers: 1,
+  projects: [
+    {
+      ...sharedConfig,
+      displayName: "devnet",
+      // globalSetup/globalTeardown start/stop the Docker stack once for all devnet test files.
+      // Both run in the main Jest process so kaspaNode's currentMiningAddress is shared between them.
+      globalSetup: "<rootDir>/src/globalSetup.ts",
+      globalTeardown: "<rootDir>/src/globalTeardown.ts",
+      testMatch: ["<rootDir>/src/scenarii.test.ts", "<rootDir>/src/negativeCases.test.ts"],
+    },
+  ],
+};
+
+export default config;

--- a/libs/coin-tester-modules/coin-tester-kaspa/jest.config.ts
+++ b/libs/coin-tester-modules/coin-tester-kaspa/jest.config.ts
@@ -30,6 +30,13 @@ const config: Config = {
   projects: [
     {
       ...sharedConfig,
+      displayName: "unit",
+      // No Docker stack — pure crypto/derivation logic, matching coin-tester-cardano and
+      // coin-tester-casper's own unit project for their signer.test.ts.
+      testMatch: ["<rootDir>/src/signer.test.ts"],
+    },
+    {
+      ...sharedConfig,
       displayName: "devnet",
       // globalSetup/globalTeardown start/stop the Docker stack once for all devnet test files.
       // Both run in the main Jest process so kaspaNode's currentMiningAddress is shared between them.

--- a/libs/coin-tester-modules/coin-tester-kaspa/miner/Dockerfile
+++ b/libs/coin-tester-modules/coin-tester-kaspa/miner/Dockerfile
@@ -1,0 +1,18 @@
+# Downloads the official kaspa WASM SDK (nodejs/kaspa-dev) from the rusty-kaspa v2.0.1 release.
+# The SDK is ~32 MB; Docker caches the layer after the first build.
+FROM node:22-alpine AS sdk-downloader
+RUN apk add --no-cache curl unzip
+RUN curl -sL \
+    https://github.com/kaspanet/rusty-kaspa/releases/download/v2.0.1/kaspa-wasm32-sdk-v2.0.1.zip \
+    -o /tmp/sdk.zip && \
+    unzip -q /tmp/sdk.zip 'kaspa-wasm32-sdk/nodejs/kaspa-dev/*' -d /tmp/ && \
+    mv /tmp/kaspa-wasm32-sdk/nodejs/kaspa-dev /kaspa
+
+# node:22 provides globalThis.WebSocket natively (stable since v22, experimental in v21,
+# absent in v20). The kaspa WASM RpcClient checks for this global at construction time;
+# without it the module panics immediately.
+FROM node:22-alpine
+WORKDIR /app
+COPY --from=sdk-downloader /kaspa /app/kaspa
+COPY miner.js .
+CMD ["node", "miner.js"]

--- a/libs/coin-tester-modules/coin-tester-kaspa/miner/Dockerfile
+++ b/libs/coin-tester-modules/coin-tester-kaspa/miner/Dockerfile
@@ -1,17 +1,22 @@
 # Downloads the official kaspa WASM SDK (nodejs/kaspa-dev) from the rusty-kaspa v2.0.1 release.
-# The SDK is ~32 MB; Docker caches the layer after the first build.
-FROM node:22-alpine AS sdk-downloader
+# The SDK is ~32 MB; Docker caches the layer after the first build. kaspanet/rusty-kaspa doesn't
+# publish an official checksum for this release, so SDK_SHA256 below is self-pinned (computed and
+# verified against this exact asset when it was vetted) rather than sourced from upstream — the
+# point is to catch the asset changing under this URL later, not to trust a third-party checksum.
+FROM node:22-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32 AS sdk-downloader
+ARG SDK_SHA256=7eaffac9cd920ef2fdf540c6e10f2a2b7761170ebc62ec57dfa0f71c64567a71
 RUN apk add --no-cache curl unzip
 RUN curl -sL \
     https://github.com/kaspanet/rusty-kaspa/releases/download/v2.0.1/kaspa-wasm32-sdk-v2.0.1.zip \
     -o /tmp/sdk.zip && \
+    echo "${SDK_SHA256}  /tmp/sdk.zip" | sha256sum -c - && \
     unzip -q /tmp/sdk.zip 'kaspa-wasm32-sdk/nodejs/kaspa-dev/*' -d /tmp/ && \
     mv /tmp/kaspa-wasm32-sdk/nodejs/kaspa-dev /kaspa
 
 # node:22 provides globalThis.WebSocket natively (stable since v22, experimental in v21,
 # absent in v20). The kaspa WASM RpcClient checks for this global at construction time;
 # without it the module panics immediately.
-FROM node:22-alpine
+FROM node:22-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32
 WORKDIR /app
 COPY --from=sdk-downloader /kaspa /app/kaspa
 COPY miner.js .

--- a/libs/coin-tester-modules/coin-tester-kaspa/miner/miner.js
+++ b/libs/coin-tester-modules/coin-tester-kaspa/miner/miner.js
@@ -30,6 +30,9 @@ async function connectWithRetry(client, maxAttempts = 60) {
   }
 }
 
+// Returns whether kaspad actually accepted the block, plus the rejection reason if not —
+// diagnostic visibility into how often the "stale template race" swallow below actually fires,
+// since a rejected block is otherwise indistinguishable from an accepted one to the caller.
 async function mineOneBlock(client, payAddress) {
   const { block } = await client.getBlockTemplate({
     payAddress: payAddress || MINING_ADDRESS,
@@ -49,14 +52,15 @@ async function mineOneBlock(client, payAddress) {
       try {
         await client.submitBlock({ block, allowNonDaaBlocks: false });
         console.log(`Block mined  nonce=${nonce}`);
+        return { accepted: true };
       } catch (e) {
         // Stale template race — not a fatal error
         const msg = String(e.message || e);
         if (!msg.includes("BlockAlreadyExists") && !msg.includes("OrphanBlock")) {
           console.warn(`submitBlock: ${msg}`);
         }
+        return { accepted: false, reason: msg };
       }
-      return;
     }
     nonce++;
     // Yield to the event loop periodically so the /health endpoint stays responsive even
@@ -104,15 +108,26 @@ async function main() {
           ? Math.min(Math.max(intervalMs, 0), 60_000)
           : 0;
         busy = true;
+        // Diagnostic counters — surfaced in the response so the caller (kaspaNode.ts) can log
+        // how many of the requested blocks kaspad actually accepted vs silently rejected.
+        let accepted = 0;
+        let rejected = 0;
+        const rejectionSamples = [];
         try {
           for (let i = 0; i < count; i++) {
-            await mineOneBlock(client, payAddress);
+            const result = await mineOneBlock(client, payAddress);
+            if (result.accepted) {
+              accepted++;
+            } else {
+              rejected++;
+              if (rejectionSamples.length < 3) rejectionSamples.push(result.reason);
+            }
             if (boundedIntervalMs > 0) {
               await new Promise(r => setTimeout(r, boundedIntervalMs));
             }
           }
           res.writeHead(200, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ mined: count }));
+          res.end(JSON.stringify({ mined: count, accepted, rejected, rejectionSamples }));
         } catch (e) {
           console.error(`Mining error: ${e.message || e}`);
           res.writeHead(500, { "Content-Type": "application/json" });

--- a/libs/coin-tester-modules/coin-tester-kaspa/miner/miner.js
+++ b/libs/coin-tester-modules/coin-tester-kaspa/miner/miner.js
@@ -1,0 +1,142 @@
+"use strict";
+
+const http = require("http");
+
+// Requires the kaspa WASM SDK (nodejs/kaspa-dev) installed at /app/kaspa by the Dockerfile.
+// The SDK is downloaded from the official rusty-kaspa GitHub release at build time.
+const kaspa = require("/app/kaspa/kaspa.js");
+
+kaspa.initConsolePanicHook();
+
+const KASPAD_WRPC_URL = process.env.KASPAD_WRPC_URL || "ws://kaspad:17110";
+const MINING_ADDRESS = process.env.MINING_ADDRESS;
+const PORT = parseInt(process.env.MINER_HTTP_PORT || "3939", 10);
+
+if (!MINING_ADDRESS) {
+  console.error("MINING_ADDRESS env var is required");
+  process.exit(1);
+}
+
+async function connectWithRetry(client, maxAttempts = 60) {
+  for (let i = 1; i <= maxAttempts; i++) {
+    try {
+      await client.connect();
+      return;
+    } catch (e) {
+      console.log(`Connection attempt ${i}/${maxAttempts} failed: ${e.message || e}`);
+      if (i === maxAttempts) throw e;
+      await new Promise(r => setTimeout(r, 2_000));
+    }
+  }
+}
+
+async function mineOneBlock(client, payAddress) {
+  const { block } = await client.getBlockTemplate({
+    payAddress: payAddress || MINING_ADDRESS,
+    extraData: "ledger-tester",
+  });
+
+  // Stamp current time — prePowHash includes the timestamp.
+  block.header.timestamp = BigInt(Date.now());
+  const pow = new kaspa.PoW(block.header);
+
+  let nonce = 0n;
+  let iterations = 0;
+  while (true) {
+    const [valid] = pow.checkWork(nonce);
+    if (valid) {
+      block.header.nonce = nonce;
+      try {
+        await client.submitBlock({ block, allowNonDaaBlocks: false });
+        console.log(`Block mined  nonce=${nonce}`);
+      } catch (e) {
+        // Stale template race — not a fatal error
+        const msg = String(e.message || e);
+        if (!msg.includes("BlockAlreadyExists") && !msg.includes("OrphanBlock")) {
+          console.warn(`submitBlock: ${msg}`);
+        }
+      }
+      return;
+    }
+    nonce++;
+    // Yield to the event loop periodically so the /health endpoint stays responsive even
+    // if difficulty (and therefore search length) ever grows — simnet's near-zero difficulty
+    // means this loop normally resolves in a handful of iterations, but nothing bounds it.
+    iterations++;
+    if (iterations % 100_000 === 0) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
+  }
+}
+
+async function main() {
+  const client = new kaspa.RpcClient({ url: KASPAD_WRPC_URL });
+
+  console.log(`Connecting to kaspad at ${KASPAD_WRPC_URL} …`);
+  await connectWithRetry(client);
+  console.log(`Connected. Mining to ${MINING_ADDRESS}. HTTP server on port ${PORT}`);
+
+  let busy = false;
+
+  const server = http.createServer((req, res) => {
+    if (req.method === "GET" && req.url === "/health") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true, connected: client.isConnected }));
+      return;
+    }
+
+    if (req.method === "POST" && req.url === "/mine") {
+      if (busy) {
+        res.writeHead(409, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "mining in progress" }));
+        return;
+      }
+
+      let body = "";
+      req.on("data", chunk => {
+        body += chunk;
+      });
+      req.on("end", async () => {
+        const { count = 1, intervalMs = 0, payAddress } = JSON.parse(body || "{}");
+        // Bound the caller-supplied delay — this is a local-only test sidecar, not a production
+        // service, but it's still an HTTP boundary parsing an arbitrary body.
+        const boundedIntervalMs = Number.isFinite(intervalMs)
+          ? Math.min(Math.max(intervalMs, 0), 60_000)
+          : 0;
+        busy = true;
+        try {
+          for (let i = 0; i < count; i++) {
+            await mineOneBlock(client, payAddress);
+            if (boundedIntervalMs > 0) {
+              await new Promise(r => setTimeout(r, boundedIntervalMs));
+            }
+          }
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ mined: count }));
+        } catch (e) {
+          console.error(`Mining error: ${e.message || e}`);
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: e.message || String(e) }));
+          if (!client.isConnected) {
+            connectWithRetry(client).catch(() => {});
+          }
+        } finally {
+          busy = false;
+        }
+      });
+      return;
+    }
+
+    res.writeHead(404);
+    res.end();
+  });
+
+  server.listen(PORT, () => {
+    console.log(`Miner HTTP server ready on port ${PORT}`);
+  });
+}
+
+main().catch(e => {
+  console.error("Fatal:", e);
+  process.exit(1);
+});

--- a/libs/coin-tester-modules/coin-tester-kaspa/miner/miner.js
+++ b/libs/coin-tester-modules/coin-tester-kaspa/miner/miner.js
@@ -30,9 +30,6 @@ async function connectWithRetry(client, maxAttempts = 60) {
   }
 }
 
-// Returns whether kaspad actually accepted the block, plus the rejection reason if not —
-// diagnostic visibility into how often the "stale template race" swallow below actually fires,
-// since a rejected block is otherwise indistinguishable from an accepted one to the caller.
 async function mineOneBlock(client, payAddress) {
   const { block } = await client.getBlockTemplate({
     payAddress: payAddress || MINING_ADDRESS,
@@ -52,15 +49,14 @@ async function mineOneBlock(client, payAddress) {
       try {
         await client.submitBlock({ block, allowNonDaaBlocks: false });
         console.log(`Block mined  nonce=${nonce}`);
-        return { accepted: true };
       } catch (e) {
         // Stale template race — not a fatal error
         const msg = String(e.message || e);
         if (!msg.includes("BlockAlreadyExists") && !msg.includes("OrphanBlock")) {
           console.warn(`submitBlock: ${msg}`);
         }
-        return { accepted: false, reason: msg };
       }
+      return;
     }
     nonce++;
     // Yield to the event loop periodically so the /health endpoint stays responsive even
@@ -108,26 +104,15 @@ async function main() {
           ? Math.min(Math.max(intervalMs, 0), 60_000)
           : 0;
         busy = true;
-        // Diagnostic counters — surfaced in the response so the caller (kaspaNode.ts) can log
-        // how many of the requested blocks kaspad actually accepted vs silently rejected.
-        let accepted = 0;
-        let rejected = 0;
-        const rejectionSamples = [];
         try {
           for (let i = 0; i < count; i++) {
-            const result = await mineOneBlock(client, payAddress);
-            if (result.accepted) {
-              accepted++;
-            } else {
-              rejected++;
-              if (rejectionSamples.length < 3) rejectionSamples.push(result.reason);
-            }
+            await mineOneBlock(client, payAddress);
             if (boundedIntervalMs > 0) {
               await new Promise(r => setTimeout(r, boundedIntervalMs));
             }
           }
           res.writeHead(200, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ mined: count, accepted, rejected, rejectionSamples }));
+          res.end(JSON.stringify({ mined: count }));
         } catch (e) {
           console.error(`Mining error: ${e.message || e}`);
           res.writeHead(500, { "Content-Type": "application/json" });

--- a/libs/coin-tester-modules/coin-tester-kaspa/miner/miner.js
+++ b/libs/coin-tester-modules/coin-tester-kaspa/miner/miner.js
@@ -30,7 +30,7 @@ async function connectWithRetry(client, maxAttempts = 60) {
   }
 }
 
-async function mineOneBlock(client, payAddress) {
+async function mineOneBlock(client, payAddress, retriesLeft = 3) {
   const { block } = await client.getBlockTemplate({
     payAddress: payAddress || MINING_ADDRESS,
     extraData: "ledger-tester",
@@ -50,11 +50,16 @@ async function mineOneBlock(client, payAddress) {
         await client.submitBlock({ block, allowNonDaaBlocks: false });
         console.log(`Block mined  nonce=${nonce}`);
       } catch (e) {
-        // Stale template race — not a fatal error
         const msg = String(e.message || e);
-        if (!msg.includes("BlockAlreadyExists") && !msg.includes("OrphanBlock")) {
-          console.warn(`submitBlock: ${msg}`);
+        if (msg.includes("BlockAlreadyExists") || msg.includes("OrphanBlock")) {
+          // Stale template race — not a fatal error, block is effectively mined.
+          return;
         }
+        if (retriesLeft > 0) {
+          console.warn(`submitBlock: ${msg}; retrying with fresh template (${retriesLeft} left)`);
+          return mineOneBlock(client, payAddress, retriesLeft - 1);
+        }
+        throw e;
       }
       return;
     }

--- a/libs/coin-tester-modules/coin-tester-kaspa/package.json
+++ b/libs/coin-tester-modules/coin-tester-kaspa/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@ledgerhq/coin-tester-kaspa",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Ledger Kaspa Coin Tester",
+  "main": "src/scenarii.test.ts",
+  "keywords": [
+    "Ledger",
+    "LedgerWallet",
+    "Kaspa",
+    "Testing"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LedgerHQ/ledger-live.git"
+  },
+  "bugs": {
+    "url": "https://github.com/LedgerHQ/ledger-live/issues"
+  },
+  "homepage": "https://github.com/LedgerHQ/ledger-live/tree/develop/libs/coin-tester-modules/coin-tester-kaspa",
+  "exports": {
+    "./package.json": "./package.json"
+  },
+  "license": "Apache-2.0",
+  "scripts": {
+    "clean": "rimraf lib lib-es",
+    "build": "tsc --project tsconfig.build.json && tsc --project tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es",
+    "prewatch": "pnpm build",
+    "watch": "tsc --watch --project tsconfig.build.json",
+    "watch:es": "tsc --watch --project tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es",
+    "lint": "oxlint src",
+    "lint:fix": "oxfmt src && oxlint src --fix --quiet",
+    "format": "oxfmt src",
+    "format:check": "oxfmt src --check",
+    "typecheck": "tsc --noEmit --customConditions node",
+    "start": "pnpm jest --runTestsByPath src/*.test.ts --runInBand",
+    "unimported": "pnpm knip --directory ../../.. -W libs/coin-tester-modules/coin-tester-kaspa"
+  },
+  "dependencies": {
+    "@shared/env": "workspace:*",
+    "@bitcoinerlab/secp256k1": "^1.1.1",
+    "@ledgerhq/coin-kaspa": "workspace:^",
+    "@ledgerhq/coin-tester": "workspace:^",
+    "@ledgerhq/ledger-wallet-framework": "workspace:^",
+    "@ledgerhq/live-common": "workspace:^",
+    "@ledgerhq/live-config": "workspace:^",
+    "@ledgerhq/types-live": "workspace:^",
+    "@noble/curves": "1.9.7",
+    "@noble/hashes": "1.8.0",
+    "bignumber.js": "^9.1.2",
+    "bip32": "^4.0.0",
+    "bip39": "^3.1.0",
+    "docker-compose": "^1.1.0",
+    "msw": "catalog:"
+  },
+  "devDependencies": {
+    "@ledgerhq/wallet-framework-test-setup": "workspace:^",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "jest": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
+    "rimraf": "^5",
+    "typescript": "catalog:"
+  }
+}

--- a/libs/coin-tester-modules/coin-tester-kaspa/src/addressUtils.ts
+++ b/libs/coin-tester-modules/coin-tester-kaspa/src/addressUtils.ts
@@ -1,0 +1,100 @@
+// Kaspa bech32 address utilities for the local test stack.
+// These are copied/adapted from coin-kaspa's kaspaAddresses.ts because the helpers are not
+// exported. The only external use is toSimnetAddress(), which converts a kaspa: address to its
+// kaspasim: equivalent (same pubkey, simnet network prefix + recomputed checksum). This is
+// needed so kaspad --simnet accepts our mining address; kaspad validates the prefix.
+
+import { addressToPublicKey } from "@ledgerhq/coin-kaspa/logic/kaspaAddresses";
+
+const CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+
+function encode5bit(data: number[]): string {
+  return data.map(v => CHARSET[v]).join("");
+}
+
+function convertBits(data: number[], from: number, to: number): number[] {
+  const result: number[] = [];
+  let accumulator = 0;
+  let bits = 0;
+  const mask = (1 << to) - 1;
+  for (const value of data) {
+    accumulator = (accumulator << from) | value;
+    bits += from;
+    while (bits >= to) {
+      bits -= to;
+      result.push((accumulator >> bits) & mask);
+    }
+  }
+  if (bits > 0) result.push((accumulator << (to - bits)) & mask);
+  return result;
+}
+
+function prefixToArray(prefix: string): number[] {
+  return Array.from(prefix).map(c => c.charCodeAt(0) & 31);
+}
+
+function polymod(data: number[]): number {
+  const G1 = [0x98, 0x79, 0xf3, 0xae, 0x1e];
+  const G2 = [0xf2bc8e61, 0xb76d99e2, 0x3e5fb3c4, 0x2eabe2a8, 0x4f43e470];
+  let c0 = 0;
+  let c1 = 1;
+  for (const d of data) {
+    const C = c0 >>> 3;
+    c0 = ((c0 & 0x07) << 5) | (c1 >>> 27);
+    c1 = ((c1 & 0x07ffffff) << 5) ^ d;
+    for (let i = 0; i < 5; i++) {
+      if (C & (1 << i)) {
+        c0 ^= G1[i];
+        c1 ^= G2[i];
+      }
+    }
+  }
+  c1 ^= 1;
+  if (c1 < 0) {
+    c1 ^= 1 << 31;
+    c1 += (1 << 30) * 2;
+  }
+  return c0 * (1 << 30) * 4 + c1;
+}
+
+function checksumToArray(checksum: number): number[] {
+  const result: number[] = [];
+  for (let i = 0; i < 8; i++) {
+    result.push(checksum & 31);
+    checksum = Math.floor(checksum / 32);
+  }
+  return result.reverse();
+}
+
+function encodeKaspaAddress(prefix: string, version: number, publicKey: number[]): string {
+  const eight0 = [0, 0, 0, 0, 0, 0, 0, 0];
+  const prefixData = prefixToArray(prefix).concat([0]);
+  const payloadData = convertBits([version, ...publicKey], 8, 5);
+  const checksumData = [...prefixData, ...payloadData, ...eight0];
+  const checksum = checksumToArray(polymod(checksumData));
+  return `${prefix}:${encode5bit([...payloadData, ...checksum])}`;
+}
+
+/**
+ * Re-encode a kaspa: address with the kaspasim: prefix (simnet).
+ * Same underlying pubkey/script, different network prefix + checksum.
+ * kaspad --simnet validates the address prefix for --mining-address, so the mining
+ * address must use kaspasim: even though coin-kaspa hardcodes kaspa: everywhere else.
+ */
+export function toSimnetAddress(kaspaAddr: string): string {
+  const { version, publicKey } = addressToPublicKey(kaspaAddr);
+  return encodeKaspaAddress("kaspasim", version, publicKey);
+}
+
+/**
+ * Inverse of toSimnetAddress(): re-encode a kaspasim: address back to kaspa: (mainnet).
+ * The bech32 checksum is a function of the prefix string itself, so a plain text
+ * substitution ("kaspasim:" -> "kaspa:") produces a syntactically kaspa:-looking string
+ * with the WRONG checksum tail — not the same string coin-kaspa itself would produce for
+ * that pubkey. Must decode and recompute the checksum under the new prefix, same as
+ * toSimnetAddress() above.
+ */
+export function toMainnetAddress(kaspasimAddr: string): string {
+  const { version, publicKey } = addressToPublicKey(kaspasimAddr);
+  return encodeKaspaAddress("kaspa", version, publicKey);
+}

--- a/libs/coin-tester-modules/coin-tester-kaspa/src/env.setup.ts
+++ b/libs/coin-tester-modules/coin-tester-kaspa/src/env.setup.ts
@@ -1,0 +1,8 @@
+// Runs in `setupFiles` before any test file is evaluated.
+// coin-kaspa's config.ts captures API_KASPA_ENDPOINT at module-eval time, so the env var
+// must be set here — setting it inside a test/beforeAll is too late.
+// Import from @shared/env (not @ledgerhq/live-env directly) so injectDefinitions() runs
+// before setEnv is called — @ledgerhq/live-env now requires it.
+import { setEnv } from "@shared/env";
+
+setEnv("API_KASPA_ENDPOINT", "http://localhost:8080");

--- a/libs/coin-tester-modules/coin-tester-kaspa/src/fixtures.ts
+++ b/libs/coin-tester-modules/coin-tester-kaspa/src/fixtures.ts
@@ -1,0 +1,125 @@
+import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
+import {
+  getDerivationScheme,
+  runDerivationScheme,
+} from "@ledgerhq/ledger-wallet-framework/derivation";
+import BigNumber from "bignumber.js";
+import { HttpResponse, bypass, http } from "msw";
+import { setupServer } from "msw/node";
+import type { KaspaAccount } from "@ledgerhq/coin-kaspa/types/bridge";
+import { toMainnetAddress } from "./addressUtils";
+
+export const KASPA = getCryptoCurrencyById("kaspa");
+
+// 1 KAS = 100_000_000 sompi (magnitude 8)
+export const ONE_KAS = 100_000_000;
+// Minimum balance to wait for before starting the scenario
+export const INITIAL_FUND_SOMPI = BigInt(1_000 * ONE_KAS); // 1000 KAS
+
+function makeBaseAccount(id: string, xpub: string, address: string): KaspaAccount {
+  const derivationMode = "";
+  const currency = KASPA;
+  const scheme = getDerivationScheme({ derivationMode, currency });
+  const freshAddressPath = runDerivationScheme(scheme, currency, {
+    account: 0,
+    node: 0,
+    address: 0,
+  });
+
+  return {
+    type: "Account",
+    id,
+    xpub,
+    seedIdentifier: xpub,
+    used: false,
+    swapHistory: [],
+    derivationMode,
+    currency,
+    index: 0,
+    freshAddress: address,
+    freshAddressPath,
+    creationDate: new Date(),
+    lastSyncDate: new Date(0),
+    blockHeight: 0,
+    balance: new BigNumber(0),
+    spendableBalance: new BigNumber(0),
+    operationsCount: 0,
+    operations: [],
+    pendingOperations: [],
+    nfts: [],
+    balanceHistoryCache: {
+      HOUR: { latestDate: null, balances: [] },
+      DAY: { latestDate: null, balances: [] },
+      WEEK: { latestDate: null, balances: [] },
+    },
+  } as unknown as KaspaAccount;
+}
+
+// Build a bare-bones KaspaAccount for the legacy bridge strategy. The account id follows
+// the pattern from bridgeDatasetTest.ts: "js:2:kaspa:<xpub>:" (empty derivation mode).
+// makeSync extracts the 99-byte xpub from the id; the legacy synchronization uses it to
+// scan all HD addresses via scanAddresses(compressedPublicKey, chainCode).
+export function makeAccount(address: string, xpub: string): KaspaAccount {
+  return makeBaseAccount(`js:2:kaspa:${xpub}:`, xpub, address);
+}
+
+// Build a bare-bones account for the generic-adapter (Alpaca) strategy. The account id
+// encodes the kaspa address itself (not the xpub), mirroring what genericGetAccountShape
+// writes back via encodeAccountId. makeSync extracts the id's xpubOrAddress segment and
+// passes it to coinModuleApi.getBalance/listOperations as the queried address — so this
+// must be a valid kaspa: address, not the 99-byte xpub.
+export function makeGenericAdapterAccount(address: string): KaspaAccount {
+  return makeBaseAccount(`js:2:kaspa:${address}:`, address, address);
+}
+
+const KASPA_REST_BASE = "http://localhost:8080";
+
+// Intercept external Ledger-service calls and reject unhandled non-local requests.
+// The coin module talks only to API_KASPA_ENDPOINT (local REST server), so no blockchain
+// endpoints need interception.
+export function initMSW(): () => void {
+  const mockServer = setupServer(
+    http.get("https://countervalues.api.live.ledger.com/*", () => HttpResponse.json({})),
+    http.get("https://global.api.prd.ledger.com/cal/v1/tokens", () => HttpResponse.json([])),
+    http.get("https://global.api.prd.ledger.com/cal/v1/certificates", () => HttpResponse.json([])),
+    // The simnet REST server can leak `kaspasim:`-prefixed addresses for some endpoints (e.g.
+    // POST /addresses/utxos returns the indexer's raw stored address string rather than
+    // re-deriving one under NETWORK_TYPE=mainnet, unlike full-transactions-page which does).
+    // coin-kaspa only ever knows `kaspa:` addresses, so pass every local REST call through and
+    // rewrite every kaspasim: address in the response body before the coin module sees it.
+    // Must decode + recompute the bech32 checksum (toMainnetAddress), not just swap the prefix
+    // text: the checksum is a function of the prefix string, so a plain text substitution
+    // produces a syntactically kaspa:-looking address with the wrong checksum tail — a string
+    // that will never match any real kaspa: address the wallet knows about. Coin-tester-only
+    // normalization — zero coin-module changes.
+    http.all(`${KASPA_REST_BASE}/*`, async ({ request }) => {
+      const response = await fetch(bypass(request));
+      const body = await response.text();
+      const normalized = body.replace(/kaspasim:[a-z0-9]+/g, match => toMainnetAddress(match));
+
+      // Rebuild headers explicitly rather than copying response.headers wholesale: the local
+      // REST server sends hop-by-hop headers (Transfer-Encoding: chunked, Connection) that are
+      // forbidden on a synthetic Response. Copying them silently corrupted header construction —
+      // this dropped X-Next-Page-After too, which made listOperations/getAllTransactions look
+      // permanently stuck on page 1 (500-item cap) even though the real server had more pages.
+      // Only forward the headers the coin module actually reads.
+      const headers = new Headers();
+      const contentType = response.headers.get("content-type");
+      if (contentType) headers.set("content-type", contentType);
+      const nextPageAfter = response.headers.get("x-next-page-after");
+      if (nextPageAfter) headers.set("x-next-page-after", nextPageAfter);
+
+      return new HttpResponse(normalized, { status: response.status, headers });
+    }),
+  );
+
+  mockServer.listen({
+    onUnhandledRequest: request => {
+      const { hostname } = new URL(request.url);
+      if (hostname === "127.0.0.1" || hostname === "localhost") return;
+      throw new Error(`Unhandled external request: ${request.method} ${request.url}`);
+    },
+  });
+
+  return () => mockServer.close();
+}

--- a/libs/coin-tester-modules/coin-tester-kaspa/src/globalSetup.ts
+++ b/libs/coin-tester-modules/coin-tester-kaspa/src/globalSetup.ts
@@ -1,0 +1,15 @@
+// Jest globalSetup: start the Kaspa Docker stack once before any test file runs.
+// Runs in the main Jest process (not a worker), so module state persists to globalTeardown.
+import { spawnKaspaNode, killKaspaNode } from "./kaspaNode";
+import { deriveAddress, KASPA_TEST_MNEMONIC } from "./signer";
+import { toSimnetAddress } from "./addressUtils";
+
+export default async function globalSetup(): Promise<void> {
+  const testAddress = await deriveAddress(KASPA_TEST_MNEMONIC, 0, 0);
+  await spawnKaspaNode(toSimnetAddress(testAddress));
+
+  // Best-effort cleanup on process interruption so Docker doesn't linger after Ctrl+C.
+  const cleanup = () => killKaspaNode().catch(() => {});
+  process.once("SIGINT", cleanup);
+  process.once("SIGTERM", cleanup);
+}

--- a/libs/coin-tester-modules/coin-tester-kaspa/src/globalTeardown.ts
+++ b/libs/coin-tester-modules/coin-tester-kaspa/src/globalTeardown.ts
@@ -1,0 +1,7 @@
+// Jest globalTeardown: tear down the Kaspa Docker stack after all test files finish.
+// Runs in the same main process as globalSetup, so kaspaNode's currentMiningAddress is set.
+import { killKaspaNode } from "./kaspaNode";
+
+export default async function globalTeardown(): Promise<void> {
+  await killKaspaNode();
+}

--- a/libs/coin-tester-modules/coin-tester-kaspa/src/helpers.ts
+++ b/libs/coin-tester-modules/coin-tester-kaspa/src/helpers.ts
@@ -1,0 +1,57 @@
+import { AccountBridge, CurrencyBridge } from "@ledgerhq/types-live";
+import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
+import type { GetAddressFn } from "@ledgerhq/ledger-wallet-framework/bridge/getAddressWrapper";
+import type { KaspaSigner } from "@ledgerhq/coin-kaspa/types/signer";
+import kaspaResolver from "@ledgerhq/coin-kaspa/hw-getAddress";
+import { createBridges } from "@ledgerhq/coin-kaspa/bridge";
+import { getCoinFrameworkCurrencyBridge } from "@ledgerhq/live-common/bridge/generic-coin-framework/currencyBridge";
+import { getCoinFrameworkAccountBridge } from "@ledgerhq/live-common/bridge/generic-coin-framework/accountBridge";
+import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
+import { registerCoinModules } from "@ledgerhq/live-common/coin-modules/registry";
+import { coinModuleLoaders } from "@ledgerhq/live-common/coin-modules/loaders";
+import type { BridgeStrategy } from "@ledgerhq/coin-tester/types";
+import type { Signers, GenericKaspaSigner } from "./signer";
+
+registerCoinModules(coinModuleLoaders);
+
+function kaspaGetAddress(signerContext: SignerContext<GenericKaspaSigner>): GetAddressFn {
+  return async (deviceId, { path, verify }) => {
+    const { address, publicKey } = await signerContext(deviceId, s => s.getAddress(path, verify));
+    return { address, publicKey, path };
+  };
+}
+
+export async function getBridges(
+  strategy: BridgeStrategy,
+  signers: Signers,
+): Promise<{
+  currencyBridge: CurrencyBridge;
+  accountBridge: AccountBridge<GenericTransaction>;
+  getAddress: GetAddressFn;
+}> {
+  if (strategy === "legacy") {
+    const signerContext: SignerContext<KaspaSigner> = (_, fn) => fn(signers.bridge);
+    const getAddress = kaspaResolver(signerContext);
+    const { currencyBridge, accountBridge } = createBridges(signerContext);
+    return {
+      currencyBridge,
+      accountBridge: accountBridge as unknown as AccountBridge<GenericTransaction>,
+      getAddress,
+    };
+  }
+
+  const signerContext: SignerContext<GenericKaspaSigner> = (_, fn) => fn(signers.generic);
+  const getAddress = kaspaGetAddress(signerContext);
+
+  return {
+    currencyBridge: await getCoinFrameworkCurrencyBridge("kaspa", "local", {
+      context: signerContext,
+      getAddress,
+    }),
+    accountBridge: await getCoinFrameworkAccountBridge("kaspa", "local", {
+      context: signerContext,
+      getAddress,
+    }),
+    getAddress,
+  };
+}

--- a/libs/coin-tester-modules/coin-tester-kaspa/src/kaspaNode.ts
+++ b/libs/coin-tester-modules/coin-tester-kaspa/src/kaspaNode.ts
@@ -48,28 +48,6 @@ export async function mineBlocks(
   if (!res.ok) {
     throw new Error(`mineBlocks failed (${res.status}): ${await res.text()}`);
   }
-  // Diagnostic: kaspad can silently reject a submitted block (stale template race — see
-  // miner.js) without the HTTP call itself failing, so "requested count" and "actually
-  // accepted" can diverge. Logged unconditionally to investigate a CI-only maturity failure
-  // (LIVE-34179) that hasn't reproduced locally, including under artificial CPU/memory limits.
-  const body = (await res.json()) as {
-    mined: number;
-    accepted: number;
-    rejected: number;
-    rejectionSamples: string[];
-  };
-  console.log(
-    `mineBlocks(count=${count}, payAddress=${payAddress ?? "<default>"}) -> accepted=${body.accepted} rejected=${body.rejected}` +
-      (body.rejectionSamples.length ? ` samples=${JSON.stringify(body.rejectionSamples)}` : ""),
-  );
-}
-
-// Diagnostic: real current chain height/DAA score from the REST server, to check whether
-// mineBlocks() requests actually advanced the chain as far as expected.
-export async function getVirtualDaaScore(): Promise<string> {
-  const res = await fetch(`${REST_BASE}/info/blockdag`);
-  const data = (await res.json()) as { virtualDaaScore: string };
-  return data.virtualDaaScore;
 }
 
 export async function killKaspaNode(): Promise<void> {

--- a/libs/coin-tester-modules/coin-tester-kaspa/src/kaspaNode.ts
+++ b/libs/coin-tester-modules/coin-tester-kaspa/src/kaspaNode.ts
@@ -48,6 +48,28 @@ export async function mineBlocks(
   if (!res.ok) {
     throw new Error(`mineBlocks failed (${res.status}): ${await res.text()}`);
   }
+  // Diagnostic: kaspad can silently reject a submitted block (stale template race — see
+  // miner.js) without the HTTP call itself failing, so "requested count" and "actually
+  // accepted" can diverge. Logged unconditionally to investigate a CI-only maturity failure
+  // (LIVE-34179) that hasn't reproduced locally, including under artificial CPU/memory limits.
+  const body = (await res.json()) as {
+    mined: number;
+    accepted: number;
+    rejected: number;
+    rejectionSamples: string[];
+  };
+  console.log(
+    `mineBlocks(count=${count}, payAddress=${payAddress ?? "<default>"}) -> accepted=${body.accepted} rejected=${body.rejected}` +
+      (body.rejectionSamples.length ? ` samples=${JSON.stringify(body.rejectionSamples)}` : ""),
+  );
+}
+
+// Diagnostic: real current chain height/DAA score from the REST server, to check whether
+// mineBlocks() requests actually advanced the chain as far as expected.
+export async function getVirtualDaaScore(): Promise<string> {
+  const res = await fetch(`${REST_BASE}/info/blockdag`);
+  const data = (await res.json()) as { virtualDaaScore: string };
+  return data.virtualDaaScore;
 }
 
 export async function killKaspaNode(): Promise<void> {

--- a/libs/coin-tester-modules/coin-tester-kaspa/src/kaspaNode.ts
+++ b/libs/coin-tester-modules/coin-tester-kaspa/src/kaspaNode.ts
@@ -1,0 +1,90 @@
+import path from "path";
+import { upMany, down } from "docker-compose";
+
+const COMPOSE_FILE = path.resolve(__dirname, "..", "docker-compose.yml");
+const COMPOSE_CWD = path.resolve(__dirname, "..");
+
+const REST_BASE = "http://localhost:8080";
+const MINER_BASE = "http://localhost:3939";
+
+// Stored so killKaspaNode() can tear down with the same env the stack started with.
+let currentMiningAddress = "";
+
+export async function spawnKaspaNode(miningAddress: string): Promise<void> {
+  currentMiningAddress = miningAddress;
+  await upMany(["kaspad", "kaspa-db", "kaspa-indexer", "kaspa-rest", "kaspa-miner"], {
+    cwd: COMPOSE_CWD,
+    config: COMPOSE_FILE,
+    log: true,
+    env: {
+      ...process.env,
+      KASPA_MINING_ADDRESS: miningAddress,
+    },
+    // --build: kaspa-miner is built from a local Dockerfile, not pulled from a registry.
+    // `docker compose down` (teardown, see killKaspaNode below) removes containers/networks but
+    // NOT images, so a stale cached image silently survives across runs and local miner.js edits
+    // never take effect without forcing a rebuild here.
+    commandOptions: ["--wait", "--build"],
+  });
+}
+
+// Mine exactly `count` blocks via the persistent miner HTTP server.
+// `intervalMs` controls the delay between blocks inside the miner — set to ~50ms during
+// setup to keep the indexer's virtual chain processor in live mode (~1ms/block) instead
+// of triggering a slow historical resync (~240ms/block).
+// `payAddress` overrides the container's default KASPA_MINING_ADDRESS for these blocks only —
+// used to send coinbase-maturity confirmation blocks to a throwaway address instead of the
+// wallet's own test address, so they don't inflate its transaction history.
+export async function mineBlocks(
+  count: number,
+  intervalMs = 0,
+  payAddress?: string,
+): Promise<void> {
+  const res = await fetch(`${MINER_BASE}/mine`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ count, intervalMs, payAddress }),
+  });
+  if (!res.ok) {
+    throw new Error(`mineBlocks failed (${res.status}): ${await res.text()}`);
+  }
+}
+
+export async function killKaspaNode(): Promise<void> {
+  await down({
+    cwd: COMPOSE_CWD,
+    config: COMPOSE_FILE,
+    log: true,
+    env: { ...process.env, KASPA_MINING_ADDRESS: currentMiningAddress || "" },
+    commandOptions: ["--volumes", "--remove-orphans"],
+  });
+}
+
+export async function getBalance(address: string): Promise<bigint> {
+  try {
+    const res = await fetch(`${REST_BASE}/addresses/${address}/balance`);
+    if (res.ok) {
+      const data = (await res.json()) as { address: string; balance: number };
+      return BigInt(data.balance);
+    }
+  } catch {}
+  return 0n;
+}
+
+// Poll the REST server until the address balance >= minSompi or the timeout elapses.
+export async function waitForBalance(
+  address: string,
+  minSompi: bigint,
+  timeoutMs = 120_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      if ((await getBalance(address)) >= minSompi) return;
+    } catch {
+      // REST server not yet ready — keep polling
+    }
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
+  throw new Error(`waitForBalance timed out after ${timeoutMs}ms for ${address}`);
+}

--- a/libs/coin-tester-modules/coin-tester-kaspa/src/negativeCases.test.ts
+++ b/libs/coin-tester-modules/coin-tester-kaspa/src/negativeCases.test.ts
@@ -40,13 +40,15 @@ describe("Kaspa negative cases (simnet devnet)", () => {
 
     // Safety net: if scenarii.test.ts drained the account, mine fresh spendable UTXOs.
     // Change UTXOs from scenario sends are non-coinbase (immediately spendable), but if the
-    // account is nearly empty we need more mature coinbase UTXOs. 200 blocks (matching
-    // scenarii/kaspa.ts's own SETUP_BLOCKS) is enough for the small amounts these negative
-    // cases use, and keeps this fallback from silently reintroducing the >500-transaction
-    // page-cap problem SETUP_BLOCKS was deliberately shrunk to avoid.
+    // account is nearly empty we need more mature coinbase UTXOs. These tests never broadcast
+    // (getTransactionStatus/prepareTransaction only) and use tiny amounts, so 50 blocks (2,500
+    // KAS) is far more than needed — kept deliberately small since this fallback shares
+    // testAddress with scenarii.test.ts's own setup, and their combined transaction count must
+    // stay well clear of the Kaspa REST API's 500-item page cap (LIVE-34179 hit that cap when
+    // both used larger values).
     const currentBalance = await getBalance(testAddress);
     if (currentBalance < BigInt(100 * ONE_KAS)) {
-      await mineBlocks(200, 50);
+      await mineBlocks(50, 50);
       await waitForBalance(testAddress, BigInt(100 * ONE_KAS), 120_000);
     }
 

--- a/libs/coin-tester-modules/coin-tester-kaspa/src/negativeCases.test.ts
+++ b/libs/coin-tester-modules/coin-tester-kaspa/src/negativeCases.test.ts
@@ -1,0 +1,129 @@
+import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
+import type { Account } from "@ledgerhq/types-live";
+import BigNumber from "bignumber.js";
+import { ONE_KAS, makeAccount, makeGenericAdapterAccount, initMSW } from "./fixtures";
+import { getBridges } from "./helpers";
+import { mineBlocks, waitForBalance, getBalance } from "./kaspaNode";
+import {
+  buildSigners,
+  deriveAddress,
+  KASPA_TEST_MNEMONIC,
+  KASPA_RECIPIENT_MNEMONIC,
+} from "./signer";
+
+// Validation and craft errors the real Kaspa node enforces.
+// executeScenario is happy-path only — it throws on any status error, so these can't be scenarios.
+jest.setTimeout(180_000);
+
+describe("Kaspa negative cases (simnet devnet)", () => {
+  let legacyBridge: Awaited<ReturnType<typeof getBridges>>["accountBridge"];
+  let genericBridge: Awaited<ReturnType<typeof getBridges>>["accountBridge"];
+  let account: Account;
+  let accountGeneric: Account;
+  let recipient: string;
+  let stopMSW: (() => void) | null = null;
+  // Live fee buckets from prepareTransaction — needed so getFeeRate doesn't throw
+  // "Invalid fee strategy provided" when getTransactionStatus is called without a prior prepare.
+  let baseNetworkInfo: { label: string; amount: BigNumber; estimatedSeconds: number }[] = [];
+
+  beforeAll(async () => {
+    LiveConfig.setConfig({
+      config_currency_kaspa: {
+        type: "object",
+        default: { status: { type: "active" } },
+      },
+    });
+
+    stopMSW = initMSW();
+    const testAddress = await deriveAddress(KASPA_TEST_MNEMONIC, 0, 0);
+    recipient = await deriveAddress(KASPA_RECIPIENT_MNEMONIC, 0, 0);
+
+    // Safety net: if scenarii.test.ts drained the account, mine fresh spendable UTXOs.
+    // Change UTXOs from scenario sends are non-coinbase (immediately spendable), but if the
+    // account is nearly empty we need more mature coinbase UTXOs. 200 blocks (matching
+    // scenarii/kaspa.ts's own SETUP_BLOCKS) is enough for the small amounts these negative
+    // cases use, and keeps this fallback from silently reintroducing the >500-transaction
+    // page-cap problem SETUP_BLOCKS was deliberately shrunk to avoid.
+    const currentBalance = await getBalance(testAddress);
+    if (currentBalance < BigInt(100 * ONE_KAS)) {
+      await mineBlocks(200, 50);
+      await waitForBalance(testAddress, BigInt(100 * ONE_KAS), 120_000);
+    }
+
+    const signers = await buildSigners(KASPA_TEST_MNEMONIC);
+    const legacy = await getBridges("legacy", signers);
+    const generic = await getBridges("generic-adapter", signers);
+    legacyBridge = legacy.accountBridge;
+    genericBridge = generic.accountBridge;
+
+    // Sync the legacy account so balance / UTXO cache reflects live on-chain state.
+    const xpub = (await signers.bridge.getAddress("44'/111111'/0'/0/0")).publicKey;
+    const legacyInitial = makeAccount(testAddress, xpub);
+    account = await new Promise<Account>((resolve, reject) => {
+      let acc: Account = legacyInitial;
+      legacyBridge.sync(legacyInitial, { paginationConfig: {} }).subscribe({
+        next: (update: (a: Account) => Account) => {
+          acc = update(acc);
+        },
+        error: reject,
+        complete: () => resolve(acc),
+      });
+    });
+    expect(account.balance.gt(0)).toBe(true);
+
+    // Fetch live fee buckets from the simnet so build() can produce transactions with
+    // populated networkInfo. Without this, getFeeRate() throws "Invalid fee strategy
+    // provided" because createTransaction() defaults networkInfo to [].
+    const seedTx = await legacyBridge.prepareTransaction(
+      account,
+      legacyBridge.createTransaction(account),
+    );
+    baseNetworkInfo = (seedTx as unknown as { networkInfo: typeof baseNetworkInfo }).networkInfo;
+
+    // Generic adapter account — address-based, no HD scan needed for crafting.
+    accountGeneric = makeGenericAdapterAccount(testAddress);
+  }, 180_000);
+
+  afterAll(() => {
+    stopMSW?.();
+  });
+
+  const build = (patch: Record<string, unknown>) =>
+    legacyBridge.updateTransaction(legacyBridge.createTransaction(account), {
+      networkInfo: baseNetworkInfo,
+      ...patch,
+    } as never);
+
+  const buildGeneric = (patch: Record<string, unknown>) =>
+    genericBridge.updateTransaction(
+      genericBridge.createTransaction(accountGeneric),
+      patch as never,
+    );
+
+  it("flags insufficient funds (NotEnoughBalance) — legacy", async () => {
+    const tx = build({ recipient, amount: account.balance.plus(10_000 * ONE_KAS) });
+    const status = await legacyBridge.getTransactionStatus(account, tx);
+    expect(status.errors.amount?.name).toBe("NotEnoughBalance");
+  });
+
+  it("flags a malformed recipient (InvalidAddress) — legacy", async () => {
+    const tx = build({ recipient: "not-a-valid-kaspa-address", amount: new BigNumber(ONE_KAS) });
+    const status = await legacyBridge.getTransactionStatus(account, tx);
+    expect(status.errors.recipient?.name).toBe("InvalidAddress");
+  });
+
+  it("rejects a dust output via getTransactionStatus (DustLimit) — legacy", async () => {
+    // 1 sompi < 0.2 KAS dust limit; getTransactionStatus.ts sets errors.dustLimit without crafting.
+    const tx = build({ recipient, amount: new BigNumber(1) });
+    const status = await legacyBridge.getTransactionStatus(account, tx);
+    expect(status.errors.dustLimit?.name).toBe("DustLimit");
+  });
+
+  it("rejects a dust output via prepareTransaction (KIP-9 storage mass) — generic adapter", async () => {
+    // 1 sompi causes KIP-9 storage mass overflow in selectUtxos, which throws an unhandled error.
+    // This test documents the current behaviour: prepareTransaction should convert the selectUtxos
+    // throw into a structured DustLimit / NotEnoughBalance error instead.
+    const tx = buildGeneric({ recipient, amount: new BigNumber(1) });
+    await expect(genericBridge.prepareTransaction(accountGeneric, tx)).rejects.toThrow();
+  });
+});

--- a/libs/coin-tester-modules/coin-tester-kaspa/src/scenarii.test.ts
+++ b/libs/coin-tester-modules/coin-tester-kaspa/src/scenarii.test.ts
@@ -1,0 +1,16 @@
+import { executeScenario } from "@ledgerhq/coin-tester/main";
+import type { BridgeStrategy } from "@ledgerhq/coin-tester/types";
+import { scenarioKaspa } from "./scenarii/kaspa";
+
+// Docker stack is started/stopped by globalSetup/globalTeardown (jest.config.ts).
+// 7 minutes: 2 × (1200-block mining at 50ms + indexer catch-up) + scenario execution.
+jest.setTimeout(420_000);
+
+describe.each([["legacy"], ["generic-adapter"]] as const)(
+  "Kaspa Deterministic Tester (%s strategy)",
+  (strategy: BridgeStrategy) => {
+    it("scenario Kaspa", async () => {
+      await executeScenario(scenarioKaspa, strategy);
+    });
+  },
+);

--- a/libs/coin-tester-modules/coin-tester-kaspa/src/scenarii/kaspa.ts
+++ b/libs/coin-tester-modules/coin-tester-kaspa/src/scenarii/kaspa.ts
@@ -11,7 +11,7 @@ import {
   makeGenericAdapterAccount,
   initMSW,
 } from "../fixtures";
-import { mineBlocks, waitForBalance, getBalance } from "../kaspaNode";
+import { mineBlocks, waitForBalance, getBalance, getVirtualDaaScore } from "../kaspaNode";
 import { getBridges } from "../helpers";
 import {
   buildSigners,
@@ -78,7 +78,13 @@ export const scenarioKaspa: Scenario<GenericTransaction, Account> = {
     const currentBalance = await getBalance(testAddress);
     if (currentBalance < BigInt(9_000 * ONE_KAS)) {
       await mineBlocks(SETUP_BLOCKS, SETUP_MINE_INTERVAL_MS);
+      console.log(
+        `[diag] daaScore after ${SETUP_BLOCKS} setup blocks: ${await getVirtualDaaScore()}`,
+      );
       await mineBlocks(MATURITY_GAP_BLOCKS, SETUP_MINE_INTERVAL_MS, maturityGapSink);
+      console.log(
+        `[diag] daaScore after ${MATURITY_GAP_BLOCKS} maturity-gap blocks: ${await getVirtualDaaScore()}`,
+      );
     }
 
     // Wait for the balance to confirm the indexer processed enough blocks.

--- a/libs/coin-tester-modules/coin-tester-kaspa/src/scenarii/kaspa.ts
+++ b/libs/coin-tester-modules/coin-tester-kaspa/src/scenarii/kaspa.ts
@@ -1,0 +1,197 @@
+import BigNumber from "bignumber.js";
+import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
+import type { Account } from "@ledgerhq/types-live";
+import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
+import type { Scenario, ScenarioTransaction } from "@ledgerhq/coin-tester/main";
+import type { BridgeStrategy } from "@ledgerhq/coin-tester/types";
+import {
+  INITIAL_FUND_SOMPI,
+  ONE_KAS,
+  makeAccount,
+  makeGenericAdapterAccount,
+  initMSW,
+} from "../fixtures";
+import { mineBlocks, waitForBalance, getBalance } from "../kaspaNode";
+import { getBridges } from "../helpers";
+import {
+  buildSigners,
+  deriveAddress,
+  KASPA_TEST_MNEMONIC,
+  KASPA_RECIPIENT_MNEMONIC,
+} from "../signer";
+import type { Signers } from "../signer";
+import { toSimnetAddress } from "../addressUtils";
+
+// Block reward = 50 KAS = 5,000,000,000 sompi. 200 blocks = 10,000 KAS total — enough mature
+// UTXOs to exercise the 88-input drain cap (see transaction #4) with comfortable buffer, without
+// pushing the test address's own transaction count anywhere near the Kaspa REST API's 500-item
+// page size (each block is a separate coinbase transaction to this address).
+const SETUP_BLOCKS = 200;
+
+// After setup blocks, mine 1000 more to advance the DAA score so every setup UTXO satisfies
+// the 1000-block coinbase maturity period. FIFO selection keeps these newer immature UTXOs
+// from being chosen first. Mined to a throwaway address (not testAddress) so these 1000
+// confirmation-only blocks don't inflate the wallet's own transaction history — maturity is a
+// chain-height/DAA-score rule, not a per-address one, so it doesn't matter who receives them.
+const MATURITY_GAP_BLOCKS = 1000;
+
+// Mining interval for setup blocks. At 50 ms/block the simply-kaspa-indexer's virtual chain
+// processor handles each block in live mode (~1 ms) instead of a slow historical resync
+// (~240 ms/block). 200 blocks × 50 ms = 10 s total, all blocks indexed by the time setup ends.
+const SETUP_MINE_INTERVAL_MS = 50;
+
+// Settle delay after mining a confirmation block. Live blocks process in ~1 ms at the indexer;
+// 500 ms gives the REST server time to reflect the new state before the first sync attempt.
+// The retry loop (retryInterval × retryLimit) covers any edge cases.
+const SETTLE_MS = 500;
+
+// Module-level state set in setup() and read by getTransactions() and beforeSync().
+let signers: Signers;
+let testAddress: string;
+let recipient: string;
+let stopMSW: (() => void) | null = null;
+
+export const scenarioKaspa: Scenario<GenericTransaction, Account> = {
+  name: "Kaspa",
+
+  setup: async (strategy: BridgeStrategy) => {
+    LiveConfig.setConfig({
+      config_currency_kaspa: {
+        type: "object",
+        default: { status: { type: "active" } },
+      },
+    });
+
+    testAddress = await deriveAddress(KASPA_TEST_MNEMONIC, 0, 0);
+    // Recipient from a different mnemonic so the legacy bridge's HD scanner never discovers
+    // it as a wallet address (which would turn outgoing sends into internal-transfer ops).
+    recipient = await deriveAddress(KASPA_RECIPIENT_MNEMONIC, 0, 0);
+    // A second, distinct address from the same throwaway mnemonic (index 1, so it never
+    // collides with `recipient` above) — pure sink for the maturity-gap blocks, never queried.
+    const maturityGapSink = toSimnetAddress(await deriveAddress(KASPA_RECIPIENT_MNEMONIC, 0, 1));
+    signers = await buildSigners(KASPA_TEST_MNEMONIC);
+
+    // Infra (kaspad + postgres + indexer + REST + miner) is already up — started by scenarii.test.ts
+    // beforeAll. Mine SETUP_BLOCKS only if the account doesn't already have enough balance:
+    // the second strategy run reuses the mature UTXOs left over after run 1's send-max,
+    // so mining is only needed for the first run (or a cold start).
+    const currentBalance = await getBalance(testAddress);
+    if (currentBalance < BigInt(9_000 * ONE_KAS)) {
+      await mineBlocks(SETUP_BLOCKS, SETUP_MINE_INTERVAL_MS);
+      await mineBlocks(MATURITY_GAP_BLOCKS, SETUP_MINE_INTERVAL_MS, maturityGapSink);
+    }
+
+    // Wait for the balance to confirm the indexer processed enough blocks.
+    await waitForBalance(testAddress, BigInt(9_000 * ONE_KAS), 300_000);
+
+    stopMSW = initMSW();
+
+    const { currencyBridge, accountBridge } = await getBridges(strategy, signers);
+
+    const account =
+      strategy === "legacy"
+        ? makeAccount(
+            testAddress,
+            (await signers.bridge.getAddress("44'/111111'/0'/0/0")).publicKey,
+          )
+        : makeGenericAdapterAccount(testAddress);
+
+    return {
+      currencyBridge,
+      accountBridge,
+      account,
+      retryInterval: 1_000,
+      retryLimit: 15,
+    };
+  },
+
+  // Mine 1 block to confirm the pending transaction, then give the indexer time to catch up.
+  // Without a new block, the transaction stays in the mempool and sync returns no new op.
+  beforeSync: async () => {
+    await mineBlocks(1);
+    await new Promise(resolve => setTimeout(resolve, SETTLE_MS));
+  },
+
+  beforeAll: async (account: Account) => {
+    // 200 mature UTXOs × 50 KAS = 10,000 KAS — well above the 1,000 KAS threshold.
+    expect(account.balance.toNumber()).toBeGreaterThanOrEqual(Number(INITIAL_FUND_SOMPI));
+    expect(account.operationsCount).toBeGreaterThan(0);
+  },
+
+  afterAll: async (account: Account) => {
+    expect(account.operationsCount).toBeGreaterThanOrEqual(4);
+  },
+
+  getTransactions: (_address: string): ScenarioTransaction<GenericTransaction, Account>[] => [
+    // #1 — Fixed-amount send (100 KAS)
+    {
+      name: "Send 100 KAS (fixed)",
+      amount: new BigNumber(100 * ONE_KAS),
+      recipient,
+      useAllAmount: false,
+      expect: (prev: Account, curr: Account) => {
+        expect(curr.operationsCount).toBeGreaterThanOrEqual(prev.operationsCount + 1);
+        const prevIds = new Set(prev.operations.map(o => o.id));
+        const op = curr.operations.find(o => !prevIds.has(o.id) && o.type === "OUT");
+        expect(op).toBeDefined();
+        expect(op!.value.toNumber()).toBeGreaterThanOrEqual(100 * ONE_KAS);
+        expect(op!.fee.toNumber()).toBeGreaterThan(0);
+      },
+    },
+
+    // #2 — Multi-UTXO consolidation send (200 KAS). With 200 mature UTXOs at 50 KAS each,
+    // craftTransaction selects multiple inputs to cover amount + fee.
+    {
+      name: "Send 200 KAS (multi-UTXO)",
+      amount: new BigNumber(200 * ONE_KAS),
+      recipient,
+      useAllAmount: false,
+      expect: (prev: Account, curr: Account) => {
+        expect(curr.operationsCount).toBeGreaterThanOrEqual(prev.operationsCount + 1);
+        const prevIds = new Set(prev.operations.map(o => o.id));
+        const op = curr.operations.find(o => !prevIds.has(o.id) && o.type === "OUT");
+        expect(op).toBeDefined();
+        expect(op!.value.toNumber()).toBeGreaterThanOrEqual(200 * ONE_KAS);
+      },
+    },
+
+    // #3 — Custom-fee send (50 KAS). Tests KIP-9 storage-mass fee enforcement:
+    // 10,000 sompi is above the storage-mass minimum for a simple 1-in 2-out transaction
+    // (~3,240 sompi base mass × KIP-9 coefficient); the node must accept it.
+    {
+      name: "Send 50 KAS with custom fee (KIP-9 storage mass)",
+      amount: new BigNumber(50 * ONE_KAS),
+      recipient,
+      useAllAmount: false,
+      fees: new BigNumber(10_000), // 10,000 sompi — explicitly above KIP-9 minimum
+      expect: (prev: Account, curr: Account) => {
+        expect(curr.operationsCount).toBeGreaterThanOrEqual(prev.operationsCount + 1);
+        const prevIds = new Set(prev.operations.map(o => o.id));
+        const op = curr.operations.find(o => !prevIds.has(o.id) && o.type === "OUT");
+        expect(op).toBeDefined();
+        expect(op!.fee.toNumber()).toBeGreaterThanOrEqual(10_000);
+      },
+    },
+
+    // #4 — Send max: Kaspa caps a transaction at MAX_UTXOS_PER_TX = 88 inputs.
+    // Each coinbase UTXO is 50 KAS, so one send-max moves at most 88 × 50 KAS = 4,400 KAS.
+    // Lower-bound at 4,000 KAS to allow for fees (~1 KAS).
+    {
+      name: "Send max (drain)",
+      amount: new BigNumber(0),
+      recipient,
+      useAllAmount: true,
+      expect: (prev: Account, curr: Account) => {
+        const prevIds = new Set(prev.operations.map(o => o.id));
+        const op = curr.operations.find(o => !prevIds.has(o.id) && o.type === "OUT");
+        expect(op).toBeDefined();
+        expect(op!.value.toNumber()).toBeGreaterThan(4_000 * ONE_KAS);
+      },
+    },
+  ],
+
+  teardown: async () => {
+    // Infra stays up — killed by scenarii.test.ts afterAll. Just stop MSW.
+    stopMSW?.();
+  },
+};

--- a/libs/coin-tester-modules/coin-tester-kaspa/src/scenarii/kaspa.ts
+++ b/libs/coin-tester-modules/coin-tester-kaspa/src/scenarii/kaspa.ts
@@ -40,7 +40,7 @@ const MATURITY_GAP_BLOCKS = 1000;
 
 // Mining interval for setup blocks. At 50 ms/block the simply-kaspa-indexer's virtual chain
 // processor handles each block in live mode (~1 ms) instead of a slow historical resync
-// (~240 ms/block). 200 blocks × 50 ms = 10 s total, all blocks indexed by the time setup ends.
+// (~240 ms/block). 100 blocks × 50 ms = 5 s total, all blocks indexed by the time setup ends.
 const SETUP_MINE_INTERVAL_MS = 50;
 
 // Settle delay after mining a confirmation block. Live blocks process in ~1 ms at the indexer;
@@ -201,7 +201,7 @@ export const scenarioKaspa: Scenario<GenericTransaction, Account> = {
       },
     },
 
-    // #2 — Multi-UTXO consolidation send (200 KAS). With 200 mature UTXOs at 50 KAS each,
+    // #2 — Multi-UTXO consolidation send (200 KAS). With 100 mature UTXOs at 50 KAS each,
     // craftTransaction selects multiple inputs to cover amount + fee.
     {
       name: "Send 200 KAS (multi-UTXO)",

--- a/libs/coin-tester-modules/coin-tester-kaspa/src/scenarii/kaspa.ts
+++ b/libs/coin-tester-modules/coin-tester-kaspa/src/scenarii/kaspa.ts
@@ -11,7 +11,7 @@ import {
   makeGenericAdapterAccount,
   initMSW,
 } from "../fixtures";
-import { mineBlocks, waitForBalance, getBalance, getVirtualDaaScore } from "../kaspaNode";
+import { mineBlocks, waitForBalance } from "../kaspaNode";
 import { getBridges } from "../helpers";
 import {
   buildSigners,
@@ -22,11 +22,14 @@ import {
 import type { Signers } from "../signer";
 import { toSimnetAddress } from "../addressUtils";
 
-// Block reward = 50 KAS = 5,000,000,000 sompi. 200 blocks = 10,000 KAS total — enough mature
-// UTXOs to exercise the 88-input drain cap (see transaction #4) with comfortable buffer, without
-// pushing the test address's own transaction count anywhere near the Kaspa REST API's 500-item
-// page size (each block is a separate coinbase transaction to this address).
-const SETUP_BLOCKS = 200;
+// Block reward = 50 KAS = 5,000,000,000 sompi. 100 blocks = 5,000 KAS total — still comfortably
+// above the 88-input drain cap (see transaction #4). setup() now mines this unconditionally on
+// every strategy run (see below), so testAddress's own transaction count accumulates across both
+// strategy runs *and* negativeCases.test.ts's own top-up in the same process — kept at 100
+// (halved from an earlier 200) specifically to stay well clear of the Kaspa REST API's 500-item
+// page cap (each block is a separate coinbase transaction to this address; LIVE-34179 hit exactly
+// that cap at 200/round).
+const SETUP_BLOCKS = 100;
 
 // After setup blocks, mine 1000 more to advance the DAA score so every setup UTXO satisfies
 // the 1000-block coinbase maturity period. FIFO selection keeps these newer immature UTXOs
@@ -45,11 +48,65 @@ const SETUP_MINE_INTERVAL_MS = 50;
 // The retry loop (retryInterval × retryLimit) covers any edge cases.
 const SETTLE_MS = 500;
 
+// Custom-fee values for transaction #3 below — chosen far from the network's own low-traffic
+// estimate (feerate ≈ 1) so the assertion proves the custom fee was actually applied, not that
+// it coincidentally matches the natural estimate. Also empirically must clear kaspad's real
+// mempool-standardness minimum, confirmed at exactly 100 sompi/mass-unit (its rejection reports
+// "157700 fees ... under ... 315400 for compute mass 3154", i.e. 315400 / 3154 = 100) — both
+// values below are chosen with margin above that.
+const CUSTOM_FEE_RATE = 200; // legacy bridge: sompi per compute-mass unit (see getFeeRate.ts)
+const CUSTOM_ABSOLUTE_FEE = 500_000; // generic adapter: absolute sompi (see prepareTransaction.ts)
+
 // Module-level state set in setup() and read by getTransactions() and beforeSync().
 let signers: Signers;
 let testAddress: string;
 let recipient: string;
 let stopMSW: (() => void) | null = null;
+
+// Transaction #3's custom-fee input is bridge-specific — a top-level `fees` field is not the
+// real custom-fee input for either bridge and is silently overwritten by the live network
+// estimate: the legacy Kaspa builder reads `feesStrategy`/`customFeeRate` (getFeeRate.ts), while
+// the generic adapter only honors `customFees.parameters.fees` (generic-coin-framework's
+// prepareTransaction.ts). `customFeeRate` isn't part of `GenericTransaction`, hence the cast.
+function customFeeTransactionLegacy(): ScenarioTransaction<GenericTransaction, Account> {
+  return {
+    name: "Send 50 KAS with custom fee (KIP-9 storage mass)",
+    amount: new BigNumber(50 * ONE_KAS),
+    recipient,
+    useAllAmount: false,
+    feesStrategy: "custom",
+    customFeeRate: new BigNumber(CUSTOM_FEE_RATE),
+    expect: (prev: Account, curr: Account) => {
+      expect(curr.operationsCount).toBeGreaterThanOrEqual(prev.operationsCount + 1);
+      const prevIds = new Set(prev.operations.map(o => o.id));
+      const op = curr.operations.find(o => !prevIds.has(o.id) && o.type === "OUT");
+      expect(op).toBeDefined();
+      // Total fee is always feerate × integer compute-mass (selection.ts) — a fee that isn't
+      // an exact multiple of our custom rate could not have come from it.
+      expect(op!.fee.toNumber() % CUSTOM_FEE_RATE).toBe(0);
+      expect(op!.fee.toNumber()).toBeGreaterThan(0);
+    },
+  } as unknown as ScenarioTransaction<GenericTransaction, Account>;
+}
+
+function customFeeTransactionGenericAdapter(): ScenarioTransaction<GenericTransaction, Account> {
+  return {
+    name: "Send 50 KAS with custom fee (KIP-9 storage mass)",
+    amount: new BigNumber(50 * ONE_KAS),
+    recipient,
+    useAllAmount: false,
+    customFees: { parameters: { fees: new BigNumber(CUSTOM_ABSOLUTE_FEE) } },
+    expect: (prev: Account, curr: Account) => {
+      expect(curr.operationsCount).toBeGreaterThanOrEqual(prev.operationsCount + 1);
+      const prevIds = new Set(prev.operations.map(o => o.id));
+      const op = curr.operations.find(o => !prevIds.has(o.id) && o.type === "OUT");
+      expect(op).toBeDefined();
+      // genericPrepareTransaction uses customFees.parameters.fees as the fee value verbatim
+      // (no estimation), so this must match exactly.
+      expect(op!.fee.toNumber()).toBe(CUSTOM_ABSOLUTE_FEE);
+    },
+  };
+}
 
 export const scenarioKaspa: Scenario<GenericTransaction, Account> = {
   name: "Kaspa",
@@ -72,23 +129,19 @@ export const scenarioKaspa: Scenario<GenericTransaction, Account> = {
     signers = await buildSigners(KASPA_TEST_MNEMONIC);
 
     // Infra (kaspad + postgres + indexer + REST + miner) is already up — started by scenarii.test.ts
-    // beforeAll. Mine SETUP_BLOCKS only if the account doesn't already have enough balance:
-    // the second strategy run reuses the mature UTXOs left over after run 1's send-max,
-    // so mining is only needed for the first run (or a cold start).
-    const currentBalance = await getBalance(testAddress);
-    if (currentBalance < BigInt(9_000 * ONE_KAS)) {
-      await mineBlocks(SETUP_BLOCKS, SETUP_MINE_INTERVAL_MS);
-      console.log(
-        `[diag] daaScore after ${SETUP_BLOCKS} setup blocks: ${await getVirtualDaaScore()}`,
-      );
-      await mineBlocks(MATURITY_GAP_BLOCKS, SETUP_MINE_INTERVAL_MS, maturityGapSink);
-      console.log(
-        `[diag] daaScore after ${MATURITY_GAP_BLOCKS} maturity-gap blocks: ${await getVirtualDaaScore()}`,
-      );
-    }
+    // beforeAll. Mine unconditionally — a raw balance check is not a valid "already set up"
+    // signal here: negativeCases.test.ts shares this same Docker stack and testAddress, and its
+    // own fallback funds testAddress with immature coinbase UTXOs. A balance-based skip would
+    // (and did, see LIVE-34179) treat that as "already funded" and skip this scenario's own
+    // maturity-gap mining, leaving only immature inputs for the first broadcast. The account's
+    // own "Send max (drain)" step empties it before every run anyway, so this never actually
+    // skipped anything in the intended flow — it only ever fired in the buggy cross-file case.
+    await mineBlocks(SETUP_BLOCKS, SETUP_MINE_INTERVAL_MS);
+    await mineBlocks(MATURITY_GAP_BLOCKS, SETUP_MINE_INTERVAL_MS, maturityGapSink);
 
-    // Wait for the balance to confirm the indexer processed enough blocks.
-    await waitForBalance(testAddress, BigInt(9_000 * ONE_KAS), 300_000);
+    // Wait for the balance to confirm the indexer processed enough blocks. 100 setup blocks
+    // mint 5,000 KAS; 4,500 leaves margin below that without requiring an exact match.
+    await waitForBalance(testAddress, BigInt(4_500 * ONE_KAS), 300_000);
 
     stopMSW = initMSW();
 
@@ -119,7 +172,7 @@ export const scenarioKaspa: Scenario<GenericTransaction, Account> = {
   },
 
   beforeAll: async (account: Account) => {
-    // 200 mature UTXOs × 50 KAS = 10,000 KAS — well above the 1,000 KAS threshold.
+    // 100 mature UTXOs × 50 KAS = 5,000 KAS — well above the 1,000 KAS threshold.
     expect(account.balance.toNumber()).toBeGreaterThanOrEqual(Number(INITIAL_FUND_SOMPI));
     expect(account.operationsCount).toBeGreaterThan(0);
   },
@@ -128,7 +181,10 @@ export const scenarioKaspa: Scenario<GenericTransaction, Account> = {
     expect(account.operationsCount).toBeGreaterThanOrEqual(4);
   },
 
-  getTransactions: (_address: string): ScenarioTransaction<GenericTransaction, Account>[] => [
+  getTransactions: (
+    _address: string,
+    strategy: BridgeStrategy,
+  ): ScenarioTransaction<GenericTransaction, Account>[] => [
     // #1 — Fixed-amount send (100 KAS)
     {
       name: "Send 100 KAS (fixed)",
@@ -161,23 +217,10 @@ export const scenarioKaspa: Scenario<GenericTransaction, Account> = {
       },
     },
 
-    // #3 — Custom-fee send (50 KAS). Tests KIP-9 storage-mass fee enforcement:
-    // 10,000 sompi is above the storage-mass minimum for a simple 1-in 2-out transaction
-    // (~3,240 sompi base mass × KIP-9 coefficient); the node must accept it.
-    {
-      name: "Send 50 KAS with custom fee (KIP-9 storage mass)",
-      amount: new BigNumber(50 * ONE_KAS),
-      recipient,
-      useAllAmount: false,
-      fees: new BigNumber(10_000), // 10,000 sompi — explicitly above KIP-9 minimum
-      expect: (prev: Account, curr: Account) => {
-        expect(curr.operationsCount).toBeGreaterThanOrEqual(prev.operationsCount + 1);
-        const prevIds = new Set(prev.operations.map(o => o.id));
-        const op = curr.operations.find(o => !prevIds.has(o.id) && o.type === "OUT");
-        expect(op).toBeDefined();
-        expect(op!.fee.toNumber()).toBeGreaterThanOrEqual(10_000);
-      },
-    },
+    // #3 — Custom-fee send (50 KAS), exercising KIP-9 storage-mass fee handling. The two bridges
+    // take a custom fee through different fields — see customFeeTransactionLegacy /
+    // customFeeTransactionGenericAdapter above.
+    strategy === "legacy" ? customFeeTransactionLegacy() : customFeeTransactionGenericAdapter(),
 
     // #4 — Send max: Kaspa caps a transaction at MAX_UTXOS_PER_TX = 88 inputs.
     // Each coinbase UTXO is 50 KAS, so one send-max moves at most 88 × 50 KAS = 4,400 KAS.

--- a/libs/coin-tester-modules/coin-tester-kaspa/src/signer.test.ts
+++ b/libs/coin-tester-modules/coin-tester-kaspa/src/signer.test.ts
@@ -1,0 +1,142 @@
+import { computeInputSighash, type TxForSighash } from "./signer";
+
+// Ground truth for these fixtures isn't a literal vector published by rusty-kaspa (its own
+// sighash.rs test suite is differential — it only checks that changing a field changes the
+// hash, not fixed input/output values) — it's captured from a real transaction that a real
+// kaspad node accepted during scenarii.test.ts. Schnorr verification requires an exact message
+// match, so kaspad accepting the broadcast is strong evidence computeInputSighash's byte layout
+// matches rusty-kaspa's calc_schnorr_signature_hash() exactly; a wrong field order/width would
+// have produced a different hash, an invalid signature, and a rejected broadcast instead.
+describe("computeInputSighash", () => {
+  it("matches a kaspad-accepted sighash for a 3-input consolidation (index 0)", () => {
+    const tx: TxForSighash = {
+      version: 0,
+      inputs: [
+        {
+          prevTxId: "4a7e3811e34301c583155b2237764f4f525e80ee706912fa8d7676caa525541b",
+          outpointIndex: 0,
+          value: 5000000000,
+        },
+        {
+          prevTxId: "81844aa1ea2cc95bc84ae92eebc111996dae4fcbabe45e0b7fd566a8d64b213b",
+          outpointIndex: 0,
+          value: 5000000000,
+        },
+        {
+          prevTxId: "213e36a47771cf5bb3744cdb568dec0c8be334d5c08cee3278a07fb7542c6464",
+          outpointIndex: 0,
+          value: 5000000000,
+        },
+      ],
+      outputs: [
+        {
+          value: 10000000000,
+          scriptPublicKey: "2089e1a064d54a60ff5814a29c8cdfc9ff0a666b7e51129b97df25c0be5f740114ac",
+        },
+        {
+          value: 4999572800,
+          scriptPublicKey: "201bacea84ca721c95d67ecace19bc499a77c03726bc8739af637bcd89abaaf058ac",
+        },
+      ],
+    };
+    const script = "201bacea84ca721c95d67ecace19bc499a77c03726bc8739af637bcd89abaaf058ac";
+
+    const sighash = computeInputSighash(tx, 0, script);
+
+    expect(Buffer.from(sighash).toString("hex")).toBe(
+      "45495078a434877433fd77a9316fd2c3d6eff188196376677383b193ca2e0f5e",
+    );
+  });
+
+  it("matches a kaspad-accepted sighash for a 5-input consolidation, non-zero input index (index 1)", () => {
+    const tx: TxForSighash = {
+      version: 0,
+      inputs: [
+        {
+          prevTxId: "9bb5719bb7c60afa2742c254730be81ecc47d8befea4dd6283f9324ad1ff8dac",
+          outpointIndex: 0,
+          value: 5000427200,
+        },
+        {
+          prevTxId: "d9ff54964b8fbdc44d318c0e9e2a771f0404f3293e728c8fcb503ec1637aadb0",
+          outpointIndex: 0,
+          value: 5000000000,
+        },
+        {
+          prevTxId: "0424933c1d2bc8e5cf463a1098f914969b9e7498c9e491443498729ed1308161",
+          outpointIndex: 0,
+          value: 5000000000,
+        },
+        {
+          prevTxId: "c01ef72d365515914535790342fa18f3e3bc181f0a521ab691b6670e7351d850",
+          outpointIndex: 0,
+          value: 5000650800,
+        },
+        {
+          prevTxId: "68799a07790bce275bbb61b57bd661987d6294d88ba0b345dfe96b5f5601312e",
+          outpointIndex: 0,
+          value: 5000000000,
+        },
+      ],
+      outputs: [
+        {
+          value: 20000000000,
+          scriptPublicKey: "2089e1a064d54a60ff5814a29c8cdfc9ff0a666b7e51129b97df25c0be5f740114ac",
+        },
+        {
+          value: 5000427200,
+          scriptPublicKey: "201bacea84ca721c95d67ecace19bc499a77c03726bc8739af637bcd89abaaf058ac",
+        },
+      ],
+    };
+    const script = "201bacea84ca721c95d67ecace19bc499a77c03726bc8739af637bcd89abaaf058ac";
+
+    const sighash = computeInputSighash(tx, 1, script);
+
+    expect(Buffer.from(sighash).toString("hex")).toBe(
+      "dd5177df557f4f6ff1e214192128b96b2d8fa537f1647f7c8af99557bd7bfcce",
+    );
+  });
+
+  // Mirrors rusty-kaspa's own sighash.rs differential test: every field that feeds the preimage
+  // must actually change the resulting hash, otherwise it isn't being committed to at all.
+  it("changes when any signed field changes", () => {
+    const base: TxForSighash = {
+      version: 0,
+      inputs: [
+        {
+          prevTxId: "4a7e3811e34301c583155b2237764f4f525e80ee706912fa8d7676caa525541b",
+          outpointIndex: 0,
+          value: 5000000000,
+        },
+      ],
+      outputs: [
+        {
+          value: 4999000000,
+          scriptPublicKey: "201bacea84ca721c95d67ecace19bc499a77c03726bc8739af637bcd89abaaf058ac",
+        },
+      ],
+    };
+    const script = "201bacea84ca721c95d67ecace19bc499a77c03726bc8739af637bcd89abaaf058ac";
+    const baseline = Buffer.from(computeInputSighash(base, 0, script)).toString("hex");
+
+    const variants: TxForSighash[] = [
+      { ...base, version: 1 },
+      { ...base, inputs: [{ ...base.inputs[0], outpointIndex: 1 }] },
+      { ...base, inputs: [{ ...base.inputs[0], value: base.inputs[0].value + 1 }] },
+      { ...base, outputs: [{ ...base.outputs[0], value: base.outputs[0].value + 1 }] },
+    ];
+    for (const variant of variants) {
+      expect(Buffer.from(computeInputSighash(variant, 0, script)).toString("hex")).not.toBe(
+        baseline,
+      );
+    }
+
+    // Same tx, different script public key for the input being signed — the script is part of
+    // the preimage per-input, not just the tx.
+    const otherScript = "2089e1a064d54a60ff5814a29c8cdfc9ff0a666b7e51129b97df25c0be5f740114ac";
+    expect(Buffer.from(computeInputSighash(base, 0, otherScript)).toString("hex")).not.toBe(
+      baseline,
+    );
+  });
+});

--- a/libs/coin-tester-modules/coin-tester-kaspa/src/signer.ts
+++ b/libs/coin-tester-modules/coin-tester-kaspa/src/signer.ts
@@ -47,7 +47,7 @@ export function buildKaspaXpub(compressedPubKey: Buffer, chainCode: Buffer): str
   ]).toString("hex");
 }
 
-type TxForSighash = {
+export type TxForSighash = {
   version: number;
   inputs: Array<{ prevTxId: string; outpointIndex: number; value: number }>;
   outputs: Array<{ value: number; scriptPublicKey: string }>;

--- a/libs/coin-tester-modules/coin-tester-kaspa/src/signer.ts
+++ b/libs/coin-tester-modules/coin-tester-kaspa/src/signer.ts
@@ -1,0 +1,268 @@
+import ecc from "@bitcoinerlab/secp256k1";
+import BIP32Factory from "bip32";
+import { mnemonicToSeed } from "bip39";
+import { schnorr, secp256k1 } from "@noble/curves/secp256k1";
+import { blake2b } from "@noble/hashes/blake2b";
+import type { KaspaSigner } from "@ledgerhq/coin-kaspa/types/signer";
+import type { KaspaAddress } from "@ledgerhq/coin-kaspa/types/signer";
+import { KaspaHwTransaction } from "@ledgerhq/coin-kaspa/types/kaspaHwTransaction";
+import { publicKeyToAddress } from "@ledgerhq/coin-kaspa/logic/kaspaAddresses";
+import type { UnsignedKaspaTransaction } from "@ledgerhq/coin-kaspa/logic/transaction/craftTransaction";
+
+export const KASPA_TEST_MNEMONIC =
+  "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+// Recipient mnemonic — intentionally different from KASPA_TEST_MNEMONIC so the
+// recipient address is never discovered by the legacy bridge's HD scanner.
+export const KASPA_RECIPIENT_MNEMONIC =
+  "test test test test test test test test test test test junk";
+
+// Kaspa BIP44 coin type (from bridgeDatasetTest.ts freshAddressPath "44'/111111'/0'/0/1")
+const KASPA_COIN_TYPE = 111111;
+
+// Kaspa uses BLAKE2b-256 in keyed mode for ALL hashes in the sighash preimage.
+// The key is the RAW string "TransactionSigningHash" (22 bytes) — NOT its hash.
+// Source: kaspa_hashes/src/hashers.rs blake2b_hasher! macro expands to
+//   blake2b_simd::Params::new().hash_length(32).key(b"TransactionSigningHash").to_state()
+const KASPA_SIGNING_KEY = new TextEncoder().encode("TransactionSigningHash");
+
+function kaspaSigningHash(data: Uint8Array): Uint8Array {
+  return blake2b(data, { key: KASPA_SIGNING_KEY, dkLen: 32 });
+}
+
+// Zero hash: kaspa returns 32 zero bytes for native subnetwork transactions with empty payload.
+// See payload_hash() in sighash.rs: `if tx.subnetwork_id.is_native() && tx.payload.is_empty() { return ZERO_HASH }`.
+const ZERO_HASH = Buffer.alloc(32);
+
+// Build the 99-byte extended public key expected by coin-kaspa's parseExtendedPublicKey:
+//   [0x41][04 ‖ x ‖ y (65 bytes)][0x20][chainCode (32 bytes)]
+export function buildKaspaXpub(compressedPubKey: Buffer, chainCode: Buffer): string {
+  const point = secp256k1.ProjectivePoint.fromHex(compressedPubKey.toString("hex"));
+  const uncompressed = point.toRawBytes(false); // 04 ‖ x ‖ y
+  return Buffer.concat([
+    Buffer.from([0x41]),
+    Buffer.from(uncompressed),
+    Buffer.from([0x20]),
+    chainCode,
+  ]).toString("hex");
+}
+
+type TxForSighash = {
+  version: number;
+  inputs: Array<{ prevTxId: string; outpointIndex: number; value: number }>;
+  outputs: Array<{ value: number; scriptPublicKey: string }>;
+};
+
+function computeHashPrevOuts(inputs: TxForSighash["inputs"]): Uint8Array {
+  const parts = inputs.map(inp => {
+    const b = Buffer.allocUnsafe(36);
+    Buffer.from(inp.prevTxId, "hex").copy(b, 0);
+    b.writeUInt32LE(inp.outpointIndex, 32);
+    return b;
+  });
+  return kaspaSigningHash(Buffer.concat(parts));
+}
+
+function computeHashSequences(count: number): Uint8Array {
+  // All Kaspa input sequences are 0; write count * 8 zero bytes.
+  return kaspaSigningHash(Buffer.alloc(count * 8));
+}
+
+function computeHashSigOpCounts(count: number): Uint8Array {
+  // Each P2PK input has sigOpCount = 1.
+  return kaspaSigningHash(Buffer.alloc(count).fill(1));
+}
+
+function computeHashOutputs(outputs: TxForSighash["outputs"]): Uint8Array {
+  const parts: Buffer[] = [];
+  for (const out of outputs) {
+    const scriptBytes = Buffer.from(out.scriptPublicKey, "hex");
+    const amtBuf = Buffer.allocUnsafe(8);
+    amtBuf.writeBigUInt64LE(BigInt(out.value), 0);
+    const versionBuf = Buffer.allocUnsafe(2);
+    versionBuf.writeUInt16LE(0, 0);
+    const lenBuf = Buffer.allocUnsafe(8);
+    lenBuf.writeBigUInt64LE(BigInt(scriptBytes.length), 0);
+    parts.push(amtBuf, versionBuf, lenBuf, scriptBytes);
+  }
+  return kaspaSigningHash(Buffer.concat(parts));
+}
+
+// Compute the per-input sighash (SIGHASH_ALL) for a Kaspa transaction.
+// Field order verified against rusty-kaspa consensus/core/src/hashing/sighash.rs
+// calc_schnorr_signature_hash(). All hashes (inner and outer) use the single
+// "TransactionSigningHash" keyed BLAKE2B domain.
+export function computeInputSighash(
+  tx: TxForSighash,
+  inputIndex: number,
+  scriptPublicKey: string,
+): Uint8Array {
+  const hashPO = computeHashPrevOuts(tx.inputs);
+  const hashSQ = computeHashSequences(tx.inputs.length);
+  const hashSOC = computeHashSigOpCounts(tx.inputs.length); // included for tx.version == 0 (< 1)
+  const hashOP = computeHashOutputs(tx.outputs);
+  const input = tx.inputs[inputIndex];
+  const scriptBytes = Buffer.from(scriptPublicKey, "hex");
+
+  const parts: Buffer[] = [];
+  // version: u16-LE (first field — NO sigHashType prefix)
+  const vBuf = Buffer.allocUnsafe(2);
+  vBuf.writeUInt16LE(tx.version, 0);
+  parts.push(vBuf);
+  // sub-hashes
+  parts.push(Buffer.from(hashPO));
+  parts.push(Buffer.from(hashSQ));
+  parts.push(Buffer.from(hashSOC)); // only for version < 1 (version 0)
+  // outpoint: txId (32 bytes) + index (u32-LE)
+  parts.push(Buffer.from(input.prevTxId, "hex"));
+  const idxBuf = Buffer.allocUnsafe(4);
+  idxBuf.writeUInt32LE(input.outpointIndex, 0);
+  parts.push(idxBuf);
+  // script public key: version (u16-LE) + varint length (u8 for <253) + bytes
+  const spkVersionBuf = Buffer.allocUnsafe(2);
+  spkVersionBuf.writeUInt16LE(0, 0);
+  parts.push(spkVersionBuf);
+  const spkLenBuf = Buffer.allocUnsafe(8);
+  spkLenBuf.writeBigUInt64LE(BigInt(scriptBytes.length), 0);
+  parts.push(spkLenBuf);
+  parts.push(scriptBytes);
+  // amount: u64-LE — BEFORE sequence (matches .write_u64(amount).write_u64(sequence) in rust)
+  const valueBuf = Buffer.allocUnsafe(8);
+  valueBuf.writeBigUInt64LE(BigInt(input.value), 0);
+  parts.push(valueBuf);
+  // sequence: u64-LE (always 0)
+  parts.push(Buffer.alloc(8));
+  // sigOpCount: u8 (always 1, only for version < 1)
+  parts.push(Buffer.from([0x01]));
+  // outputs hash
+  parts.push(Buffer.from(hashOP));
+  // lockTime: u64-LE (always 0)
+  parts.push(Buffer.alloc(8));
+  // subnetworkId: 20 bytes (zeros = native)
+  parts.push(Buffer.alloc(20));
+  // gas: u64-LE (always 0)
+  parts.push(Buffer.alloc(8));
+  // payload hash: ZERO_HASH for native subnetwork with empty payload
+  parts.push(ZERO_HASH);
+  // sigHashType: u8 — AT THE END (not at the beginning)
+  parts.push(Buffer.from([0x01])); // SIGHASH_ALL
+
+  return kaspaSigningHash(Buffer.concat(parts));
+}
+
+export type GenericKaspaSigner = {
+  getAddress: (path: string, opts?: unknown) => Promise<{ address: string; publicKey: string }>;
+  signTransaction: (path: string, unsignedJson: string, opts?: unknown) => Promise<string>;
+};
+
+export type Signers = {
+  bridge: KaspaSigner;
+  generic: GenericKaspaSigner;
+};
+
+export async function buildSigners(mnemonic = KASPA_TEST_MNEMONIC): Promise<Signers> {
+  const bip32 = BIP32Factory(ecc);
+  const seed = await mnemonicToSeed(mnemonic);
+  const root = bip32.fromSeed(seed);
+  const accountNode = root.derivePath(`m/44'/${KASPA_COIN_TYPE}'/0'`);
+
+  const accountXpub = buildKaspaXpub(
+    Buffer.from(accountNode.publicKey),
+    Buffer.from(accountNode.chainCode),
+  );
+
+  function xCoordToP2PKScript(xCoord: Buffer): string {
+    return "20" + xCoord.toString("hex") + "ac";
+  }
+
+  const bridge: KaspaSigner = {
+    getAddress: async (path: string): Promise<KaspaAddress> => {
+      const node = root.derivePath("m/" + path);
+      const xCoord = Buffer.from(node.publicKey.subarray(1, 33));
+      const address = publicKeyToAddress(xCoord);
+      // publicKey is the account-level 99-byte xpub; coin-kaspa's hw-getAddress sets
+      // account.xpub from it, which drives the HD address scanner in synchronization.ts.
+      return { address, publicKey: accountXpub };
+    },
+
+    signMessage: async () => {
+      throw new Error("signMessage not implemented in coin-tester signer");
+    },
+
+    signTransaction: async (tx: KaspaHwTransaction): Promise<void> => {
+      const txForSighash: TxForSighash = {
+        version: tx.version,
+        inputs: tx.inputs.map(i => ({
+          prevTxId: i.prevTxId,
+          outpointIndex: i.outpointIndex,
+          value: i.value,
+        })),
+        outputs: tx.outputs.map(o => ({
+          value: o.value,
+          scriptPublicKey: o.scriptPublicKey,
+        })),
+      };
+      for (let i = 0; i < tx.inputs.length; i++) {
+        const input = tx.inputs[i];
+        // addressType and addressIndex are the HD child indices set by buildTransaction.
+        const child = accountNode.derive(input.addressType).derive(input.addressIndex);
+        if (!child.privateKey) throw new Error("bip32: missing private key");
+        const xCoord = Buffer.from(child.publicKey.subarray(1, 33));
+        const script = xCoordToP2PKScript(xCoord);
+        const sighash = computeInputSighash(txForSighash, i, script);
+        const sig = schnorr.sign(sighash, child.privateKey);
+        input.setSignature(Buffer.from(sig).toString("hex"));
+      }
+    },
+  };
+
+  const generic: GenericKaspaSigner = {
+    getAddress: async (path: string): Promise<{ address: string; publicKey: string }> => {
+      const node = root.derivePath("m/" + path);
+      const xCoord = Buffer.from(node.publicKey.subarray(1, 33));
+      const address = publicKeyToAddress(xCoord);
+      // publicKey passes through to transactionIntent.senderPublicKey; combine() ignores it.
+      return { address, publicKey: accountXpub };
+    },
+
+    signTransaction: async (path: string, unsignedJson: string): Promise<string> => {
+      const unsigned: UnsignedKaspaTransaction = JSON.parse(unsignedJson);
+      // craftTransaction sets accountType/accountIndex to 0/0 placeholders for the Alpaca API
+      // (single-address model). Derive the signing key from the leaf path directly.
+      const node = root.derivePath("m/" + path);
+      if (!node.privateKey) throw new Error("bip32: missing private key at path " + path);
+      const xCoord = Buffer.from(node.publicKey.subarray(1, 33));
+      const script = xCoordToP2PKScript(xCoord);
+
+      const txForSighash: TxForSighash = {
+        version: unsigned.version,
+        inputs: unsigned.inputs,
+        outputs: unsigned.outputs,
+      };
+      const sigs = unsigned.inputs.map((_, index) => {
+        const sighash = computeInputSighash(txForSighash, index, script);
+        const sig = schnorr.sign(sighash, node.privateKey!);
+        return Buffer.from(sig).toString("hex");
+      });
+      return JSON.stringify(sigs);
+    },
+  };
+
+  return { bridge, generic };
+}
+
+export async function deriveAddress(
+  mnemonic: string,
+  addressType = 0,
+  addressIndex = 0,
+): Promise<string> {
+  const bip32 = BIP32Factory(ecc);
+  const seed = await mnemonicToSeed(mnemonic);
+  const node = bip32
+    .fromSeed(seed)
+    .derivePath(`m/44'/${KASPA_COIN_TYPE}'/0'`)
+    .derive(addressType)
+    .derive(addressIndex);
+  const xCoord = Buffer.from(node.publicKey.subarray(1, 33));
+  return publicKeyToAddress(xCoord);
+}

--- a/libs/coin-tester-modules/coin-tester-kaspa/tsconfig.build.json
+++ b/libs/coin-tester-modules/coin-tester-kaspa/tsconfig.build.json
@@ -1,0 +1,25 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "customConditions": [],
+    "types": [
+      "node",
+      "jest"
+    ]
+  },
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/__tests__/**/*",
+    "**/tests/**/*",
+    "**/__mocks__/**/*",
+    "**/*.test.js",
+    "**/*.test.jsx",
+    "**/*.spec.js",
+    "**/*.spec.jsx"
+  ]
+}

--- a/libs/coin-tester-modules/coin-tester-kaspa/tsconfig.json
+++ b/libs/coin-tester-modules/coin-tester-kaspa/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../tsconfig.base",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["es2022", "dom"],
+    "outDir": "lib",
+    "rootDir": "src",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "types": ["node", "jest"]
+  },
+  "include": ["src/**/*", "src/**/*.json"]
+}

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/createTransaction.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/createTransaction.test.ts
@@ -73,6 +73,24 @@ describe("createTransaction", () => {
     });
   });
 
+  it("returns the Kaspa default native send transaction", () => {
+    const account = {
+      type: "Account",
+      currency: getCryptoCurrencyById("kaspa"),
+    } as unknown as Account;
+
+    expect(createTransaction(account)).toEqual({
+      family: "kaspa",
+      amount: new BigNumber(0),
+      recipient: "",
+      fees: null,
+      useAllAmount: false,
+      mode: "send",
+      feesStrategy: "fast",
+      nonce: new BigNumber(0),
+    });
+  });
+
   it("throws for an unsupported currency family", () => {
     const account = {
       type: "Account",

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/createTransaction.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/createTransaction.ts
@@ -118,6 +118,22 @@ export function createTransaction(account: Account | TokenAccount): GenericTrans
         memoValue: null,
         networkInfo: null,
       };
+    case "kaspa":
+      // UTXO chain — no account nonce/sequence, same as near/vechain/cardano above. Setting a
+      // synthetic zero nonce here (inert for crafting — craftTransaction ignores it and builds
+      // its own inputs from real UTXOs) makes transactionIntent.sequence a valid bigint, so
+      // signOperation's guard skips calling getNextSequence entirely — which is then free to
+      // throw like every other no-sequence family's, instead of needing a silent 0n stub.
+      return {
+        family: currency.family,
+        amount: new BigNumber(0),
+        recipient: "",
+        fees: null,
+        useAllAmount: false,
+        mode: "send",
+        feesStrategy: "fast",
+        nonce: new BigNumber(0),
+      };
     case "stacks":
       // Unlike near/vechain/cardano above, leaving nonce unset lets craftTransaction/estimateFees
       // fetch the real sequential nonce instead of defaulting to 0.

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "coin:tester:near": "pnpm --filter coin-tester-near",
     "coin:tester:tron": "pnpm --filter coin-tester-tron",
     "coin:tester:vechain": "pnpm --filter coin-tester-vechain",
+    "coin:tester:kaspa": "pnpm --filter coin-tester-kaspa",
     "coin:tester:xrp": "pnpm --filter coin-tester-xrp",
     "evm-tools": "pnpm --filter evm-tools",
     "domain": "pnpm --filter domain-service",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9820,6 +9820,85 @@ importers:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
 
+  libs/coin-tester-modules/coin-tester-kaspa:
+    dependencies:
+      '@bitcoinerlab/secp256k1':
+        specifier: ^1.1.1
+        version: 1.2.0
+      '@ledgerhq/coin-kaspa':
+        specifier: workspace:^
+        version: link:../../coin-modules/coin-kaspa
+      '@ledgerhq/coin-tester':
+        specifier: workspace:^
+        version: link:../../coin-tester
+      '@ledgerhq/ledger-wallet-framework':
+        specifier: workspace:^
+        version: link:../../ledger-wallet-framework
+      '@ledgerhq/live-common':
+        specifier: workspace:^
+        version: link:../../ledger-live-common
+      '@ledgerhq/live-config':
+        specifier: workspace:^
+        version: link:../../live-config
+      '@ledgerhq/types-live':
+        specifier: workspace:^
+        version: link:../../types-live
+      '@noble/curves':
+        specifier: 1.9.7
+        version: 1.9.7
+      '@noble/hashes':
+        specifier: 1.8.0
+        version: 1.8.0
+      '@shared/env':
+        specifier: workspace:*
+        version: link:../../../shared/env
+      bignumber.js:
+        specifier: 9.1.2
+        version: 9.1.2
+      bip32:
+        specifier: ^4.0.0
+        version: 4.0.0
+      bip39:
+        specifier: ^3.1.0
+        version: 3.1.0
+      docker-compose:
+        specifier: ^1.1.0
+        version: 1.1.0
+      msw:
+        specifier: 'catalog:'
+        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+    devDependencies:
+      '@ledgerhq/wallet-framework-test-setup':
+        specifier: workspace:^
+        version: link:../../wallet-framework-test-setup
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0(@types/node@24.12.0)
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.36.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.51.0
+      rimraf:
+        specifier: ^5
+        version: 5.0.10
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
   libs/coin-tester-modules/coin-tester-multiversx:
     dependencies:
       '@ledgerhq/coin-multiversx':


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Adds `@ledgerhq/coin-tester-kaspa`, a deterministic integration tester for the Kaspa family, plus three small production fixes it caught along the way. Stabilizing the tester itself surfaced three more bugs internal to the tester — see below.

**Bugs the tester caught in `@ledgerhq/coin-kaspa`:**

- **UTXO selection picked immature coinbase outputs ahead of mature ones.** `sortUtxos` compared `blockDaaScore` with `.localeCompare()` (lexicographic) instead of numerically — `"1202" < "200"` as strings, even though 1202 > 200 as numbers. Once an account's UTXOs span a digit-count boundary (any long-lived Kaspa wallet eventually does), a fresh, immature UTXO could get selected ahead of a genuinely old, mature one, causing kaspad to reject the broadcast (`one of the transaction inputs spends an immature UTXO`). Fixed with a numeric (BigInt) comparison; added regression tests at the `sortUtxos`, `selectUtxos`, and `craftTransaction` (MSW/HTTP) layers, all using the exact real-world DAA-score pair that reproduced the failure.
- **`combine()` didn't match the generic-adapter signer's actual output shape.** Kaspa needs one signature per input, but the generic-coin-framework's `combine(tx, signatures)` only supports a single-string return value from the signer — so the signer packs all per-input signatures into one JSON-encoded string. `combine()` now unpacks and validates that string (array length, element types) instead of expecting one raw signature per array element.
- **`getNextSequence`/nonce inconsistency with sibling UTXO-model chains.** near/vechain/cardano's `createTransaction` cases all set a synthetic `nonce: new BigNumber(0)` so `signOperation`'s guard never calls `getNextSequence` for them, letting that method safely throw ("not applicable"). Kaspa's case didn't set a nonce, so `getNextSequence` would have been called and crashed signing for the generic-adapter path. Fixed by adding the same synthetic nonce, matching the established pattern exactly instead of giving Kaspa a one-off silent-stub convention.

**User paths tested** — both the legacy account bridge and the generic-coin-framework bridge (Alpaca/CoinModuleApi), asserted for equivalence:

- Send a fixed amount (100 KAS)
- Send an amount requiring multi-UTXO consolidation (200 KAS)
- Send with a custom fee, exercising KIP-9 storage-mass enforcement (50 KAS, explicit fee above the storage-mass floor)
- Send-max / drain, exercising Kaspa's 88-input-per-transaction cap
- Negative cases: insufficient funds, malformed recipient address, dust-limit rejection (via both `getTransactionStatus` and `prepareTransaction`)

**Infra:** unlike every other coin-tester in the repo (all single-binary devnets — `anvil`, `agave`, `flextesa`, etc.), Kaspa has no debug balance-injection RPC, so funding an account means actually mining real PoW blocks — each one a real transaction. That requires a real multi-service stack via `docker-compose`: `kaspad` (simnet consensus node) → `simply-kaspa-indexer` (kaspad → Postgres) → `postgres` → `kaspa-rest-server` (api.kaspa.org-compatible REST API) → a custom miner sidecar (rusty-kaspa v2.0.1 ships without a built-in miner, so this is built from scratch on the official Kaspa WASM SDK). Coinbase maturity (~1000-block confirmation depth, a real kaspad consensus rule) is satisfied by mining a dedicated gap of confirmation-only blocks to a throwaway address, kept separate from the tracked test account so it doesn't inflate that account's own transaction history. External images are pinned to version + SHA256 digest rather than `:latest`, matching the other coin-testers' convention. The miner sidecar's own Dockerfile pins its `node:22-alpine` base image the same way and verifies the downloaded Kaspa WASM SDK zip against a checksum before unzipping (no official checksum is published for the release, so this is self-pinned against the exact asset that's been vetted).

**Test-infra bugs found and fixed while stabilizing the tester** (all internal to the tester, no coin-kaspa impact):

- **Maturity-gap mining could be silently skipped.** `scenarii.test.ts`'s setup used `getBalance(testAddress) < threshold` to decide whether it still needed to mine its own 1000-block maturity gap. `negativeCases.test.ts` shares the same Docker stack and `testAddress`, and its own fallback (for when `scenarii.test.ts` drained the account) funds it with immature coinbase UTXOs — enough to satisfy the balance check without any real maturity gap being mined. When that fallback ran first, the first scenario broadcast picked an immature input and failed. Fixed by mining the setup + maturity-gap blocks unconditionally every run instead of gating on balance, which was never a valid proxy for maturity to begin with.
- **The custom-fee test wasn't exercising a custom fee.** It set a plain `fees` field on the scenario transaction, but neither bridge treats that as a custom-fee input — the legacy builder reads `feesStrategy`/`customFeeRate`, the generic adapter only honors `customFees.parameters.fees`. The field was silently overwritten by the live network fee estimate every time, so the assertion (`fee >= 10_000`) passed by coincidence, not because a custom fee was applied. Split into a per-strategy custom-fee input with an assertion that can only pass if the custom value was genuinely used (exact match for the generic adapter; exact multiple of the custom rate for the legacy builder).
- **Unconditional maturity-gap mining hit the REST API's page cap.** Once mining runs every time (previous point), each strategy run — plus `negativeCases.test.ts`'s own top-up — mints a fresh round of coinbase transactions to the same shared `testAddress`. At the original 200-block setup size this pushed the account's total transaction count to exactly the Kaspa REST API's 500-item page cap, silently reintroducing the framework's pagination-cursor gap (see Limitations below). Halved to 100 blocks (still comfortably above the 88-input drain cap) to keep clear of it.

**Limitations:**

- ⚠️ **`generic-coin-framework` gap, pre-existing, not introduced by this PR:** `listOperations`'s pagination cursor works correctly in isolation (verified against real `api.kaspa.org` data during development, not included in this PR — see the JIRA ticket) but is never actually exercised end-to-end by the generic-coin-framework today: `getAccountShape.ts` discards the `.next` cursor `listOperations` returns and never persists it, so incremental sync always restarts from page 1 for every coin module, not just Kaspa. Confirmed with `@ledgerhq/coin-integration` as a real, framework-wide issue — tracked separately, out of scope here. This PR's scenario stays under the 500-transaction page cap specifically to avoid needing a Kaspa-side workaround for a framework limitation.
- ⚠️ **`generic-coin-framework` gap, pre-existing, not introduced by this PR:** `genericSignRawOperation` (`generic-coin-framework/signRawOperation.ts`, the wallet-api/Exchange raw-transaction entry point) unconditionally calls `getNextSequence` then `craftRawTransaction` with no nonce-guard, then calls `combine()` with a single raw signature string rather than the packed-array shape `combine()` now expects. Currently unreachable for Kaspa — the same family gate below routes Kaspa to the legacy bridge, which throws "not supported" before ever reaching this code — and near/vechain/cardano hit the exact same gap today. Fixing it means deciding how `signRawOperation` should behave for no-sequence chains across all four families, a `generic-coin-framework` design change out of scope here.
- The `kaspasim:`/`kaspa:` address-prefix mismatch (kaspad `--simnet` requires `kaspasim:`, coin-kaspa hardcodes `kaspa:`) is normalized entirely on the coin-tester side, via an MSW interceptor that decodes and re-encodes the bech32 address (not a text substitution — the checksum is a function of the prefix string) before the coin module ever sees it. Zero coin-module changes for this.
- `combine()`'s packed-signature contract has no real production caller yet: Kaspa isn't in `genericCoinFrameworkFamilies.json`, so `getAccountBridge` always resolves the legacy bridge for Kaspa today, whose own `signRawOperation` throws "not supported" directly. This PR's generic-adapter coverage is forward-looking, validated only by the coin-tester itself.
- Out of scope: RBF, mempool-eviction edge cases, transactions beyond the 4 scenario shapes above.

**Run:** `pnpm coin:tester:kaspa start` (requires a running Docker daemon).

**Result:** both strategies (legacy + generic-adapter) and all negative cases green — 6/6, confirmed across multiple local runs. Coin-kaspa unit/MSW suite: 230/230. Real-network integration suite (against `api.kaspa.org`): 33/33.

### 🔗 Context

- **JIRA / GitHub issue**: LIVE-34179
- **ADR** (if any): —
