### PR TITLE
[LWDM] feat(device-intent): add typed job result contract (LIVE-36335)

### DIFF
--- a/.changeset/typed-jobs-report.md
+++ b/.changeset/typed-jobs-report.md
@@ -1,0 +1,5 @@
+---
+"@features/platform-device-intent": minor
+---
+
+Add a typed result callback contract to device intent jobs

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/index.tsx
@@ -33,11 +33,12 @@ export { RetryableDeviceLocked } from "./components/DeviceGenericStates/Retryabl
 export { UnlockDevice } from "./components/DeviceGenericStates/UnlockDevice";
 export type { DeviceIntentTrackingProperties, SourceFlow } from "@ledgerhq/live-dmk-shared";
 
-type Props<JobState, Input, ExtraProps> = DeviceIntentExecutorProps<
+type Props<JobState, Input, ExtraProps, Result = undefined> = DeviceIntentExecutorProps<
   JobState,
   Input,
   ExtraProps,
-  InitializationInput
+  InitializationInput,
+  Result
 > & {
   initializerConfig?: InitializerConfig;
   /**
@@ -60,8 +61,8 @@ const platformConfig: ExecutorPlatformConfiguration<InitializationInput, Initial
 
 const emptyAnalyticsProperties: DeviceIntentTrackingProperties = {};
 
-export function DeviceIntentExecutorLWD<JobState, Input, ExtraProps>(
-  props: Props<JobState, Input, ExtraProps>,
+export function DeviceIntentExecutorLWD<JobState, Input, ExtraProps, Result = undefined>(
+  props: Props<JobState, Input, ExtraProps, Result>,
 ): React.ReactElement | null {
   const {
     wrappedProps,

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWDViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWDViewModel.ts
@@ -23,11 +23,12 @@ import {
   trackDrawerCloseButtonClicked,
 } from "./utils/trackDeviceIntent";
 
-type Props<JobState, Input, ExtraProps> = DeviceIntentExecutorProps<
+type Props<JobState, Input, ExtraProps, Result = undefined> = DeviceIntentExecutorProps<
   JobState,
   Input,
   ExtraProps,
-  InitializationInput
+  InitializationInput,
+  Result
 > & {
   initializerConfig?: InitializerConfig;
   sourceFlow: SourceFlow;
@@ -36,8 +37,8 @@ type Props<JobState, Input, ExtraProps> = DeviceIntentExecutorProps<
 
 type PreventableEvent = Pick<Event, "preventDefault">;
 
-export type DeviceIntentExecutorLWDViewModel<JobState, Input, ExtraProps> = {
-  wrappedProps: Props<JobState, Input, ExtraProps>;
+export type DeviceIntentExecutorLWDViewModel<JobState, Input, ExtraProps, Result = undefined> = {
+  wrappedProps: Props<JobState, Input, ExtraProps, Result>;
   hasHeaderOverride: boolean;
   headerContextValue: DeviceIntentExecutorHeaderContextValue;
   onOpenChange: (open: boolean) => void;
@@ -73,9 +74,14 @@ function mapConnectionResult(result: DeviceConnectionResult): ConnectionTracking
   };
 }
 
-export function useDeviceIntentExecutorLWDViewModel<JobState, Input, ExtraProps>(
-  props: Props<JobState, Input, ExtraProps>,
-): DeviceIntentExecutorLWDViewModel<JobState, Input, ExtraProps> {
+export function useDeviceIntentExecutorLWDViewModel<
+  JobState,
+  Input,
+  ExtraProps,
+  Result = undefined,
+>(
+  props: Props<JobState, Input, ExtraProps, Result>,
+): DeviceIntentExecutorLWDViewModel<JobState, Input, ExtraProps, Result> {
   const {
     enabled,
     sourceFlow,

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/index.tsx
@@ -34,11 +34,12 @@ export type {
   SourceFlow,
 } from "./utils/DeviceIntentTrackingContext";
 
-type Props<JobState, Input, ExtraProps> = DeviceIntentExecutorProps<
+type Props<JobState, Input, ExtraProps, Result = undefined> = DeviceIntentExecutorProps<
   JobState,
   Input,
   ExtraProps,
-  InitializationInput
+  InitializationInput,
+  Result
 > & {
   initializerConfig?: InitializerConfig;
   /**
@@ -65,8 +66,8 @@ const emptyAnalyticsProperties: DeviceIntentTrackingProperties = {};
 /**
  * LWM wrapper around `@features/platform-device-intent`'s `DeviceIntentExecutor`.
  */
-export function DeviceIntentExecutorLWM<JobState, Input, ExtraProps>(
-  props: Props<JobState, Input, ExtraProps>,
+export function DeviceIntentExecutorLWM<JobState, Input, ExtraProps, Result = undefined>(
+  props: Props<JobState, Input, ExtraProps, Result>,
 ): React.ReactElement {
   const { height: windowHeight } = useWindowDimensions();
   const { top: topInset, bottom: bottomInset } = useSafeAreaInsets();

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.ts
@@ -25,20 +25,21 @@ import type {
   SourceFlow,
 } from "./utils/DeviceIntentTrackingContext";
 
-type Props<JobState, Input, ExtraProps> = DeviceIntentExecutorProps<
+type Props<JobState, Input, ExtraProps, Result = undefined> = DeviceIntentExecutorProps<
   JobState,
   Input,
   ExtraProps,
-  InitializationInput
+  InitializationInput,
+  Result
 > & {
   initializerConfig?: InitializerConfig;
   sourceFlow: SourceFlow;
   analyticsProperties?: DeviceIntentTrackingProperties;
 };
 
-export type DeviceIntentExecutorLWMViewModel<JobState, Input, ExtraProps> = {
+export type DeviceIntentExecutorLWMViewModel<JobState, Input, ExtraProps, Result = undefined> = {
   sourceFlow: SourceFlow;
-  wrappedProps: Props<JobState, Input, ExtraProps>;
+  wrappedProps: Props<JobState, Input, ExtraProps, Result>;
   hasHeaderOverride: boolean;
   headerContextValue: DeviceIntentExecutorHeaderContextValue;
   /**
@@ -69,9 +70,14 @@ function mapConnectionResult(result: DeviceConnectionResult): ConnectionTracking
   };
 }
 
-export function useDeviceIntentExecutorLWMViewModel<JobState, Input, ExtraProps>(
-  props: Props<JobState, Input, ExtraProps>,
-): DeviceIntentExecutorLWMViewModel<JobState, Input, ExtraProps> {
+export function useDeviceIntentExecutorLWMViewModel<
+  JobState,
+  Input,
+  ExtraProps,
+  Result = undefined,
+>(
+  props: Props<JobState, Input, ExtraProps, Result>,
+): DeviceIntentExecutorLWMViewModel<JobState, Input, ExtraProps, Result> {
   const {
     enabled,
     sourceFlow,

--- a/apps/wallet-cli/src/commands/swap/cli-swap-die-pipeline.ts
+++ b/apps/wallet-cli/src/commands/swap/cli-swap-die-pipeline.ts
@@ -130,24 +130,28 @@ function launchIntent(args: {
           deviceConnectionResult,
           deviceExtractedContext: STUB_DEVICE_EXTRACTED_CONTEXT,
           input: intent.input,
+          onResult: () => {},
         });
       case "sign-permit2":
         return signPermit2EvmJob({
           deviceConnectionResult,
           deviceExtractedContext: STUB_DEVICE_EXTRACTED_CONTEXT,
           input: intent.input,
+          onResult: () => {},
         });
       case "sign-swap":
         return signSwapEvmJob({
           deviceConnectionResult,
           deviceExtractedContext: STUB_DEVICE_EXTRACTED_CONTEXT,
           input: intent.input,
+          onResult: () => {},
         });
       default:
         return broadcastEvmJob({
           deviceConnectionResult,
           deviceExtractedContext: STUB_DEVICE_EXTRACTED_CONTEXT,
           input: intent.input,
+          onResult: () => {},
         });
     }
   })();

--- a/features/platform/device-intent/README.md
+++ b/features/platform/device-intent/README.md
@@ -259,17 +259,17 @@ sequenceDiagram
 
 ### Core types (`src/core.ts`)
 
-| Export                                                  | Description                                                                  |
-| ------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| `DeviceConnectionParams`                                | Declarative params for device selection                                      |
-| `DeviceConnectionResult`                                | Result of a device connection (DMK session + connected device)               |
-| `DeviceExtractedContext`                                | Normalised info produced once the initializer has established device context |
-| `Job<JobState, Input>`                                  | Execution logic for one step, returns `Observable<JobState>`                 |
-| `IntentDefinition<JobState, Input>`                     | Reusable, cross-platform definition of one step                              |
-| `IntentPlatformDefinition<JobState, Input, ExtraProps>` | Platform-specific definition adding a UI component                           |
-| `IntentListeners<JobState>`                             | Optional lifecycle callbacks attachable to an intent instance                |
-| `Intent<JobState, Input, ExtraProps>`                   | Runtime instance passed to the executor                                      |
-| `createIntent(definition, input, listeners?)`           | Helper to instantiate an `Intent` from a platform definition                 |
+| Export                                                          | Description                                                                  |
+| --------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `DeviceConnectionParams`                                        | Declarative params for device selection                                      |
+| `DeviceConnectionResult`                                        | Result of a device connection (DMK session + connected device)               |
+| `DeviceExtractedContext`                                        | Normalised info produced once the initializer has established device context |
+| `Job<JobState, Input, Result>`                                  | Execution logic emitting UI state and reporting a typed final result         |
+| `IntentDefinition<JobState, Input, Result>`                     | Reusable, cross-platform definition of one step                              |
+| `IntentPlatformDefinition<JobState, Input, ExtraProps, Result>` | Platform-specific definition adding a UI component                           |
+| `IntentListeners<JobState, Result>`                             | Optional lifecycle and result callbacks attachable to an intent instance     |
+| `Intent<JobState, Input, ExtraProps, Result>`                   | Runtime instance passed to the executor                                      |
+| `createIntent(definition, input, listeners?)`                   | Helper to instantiate an `Intent` from a platform definition                 |
 
 ### Executor types (`src/executor.ts`)
 
@@ -345,8 +345,9 @@ implementation guide for adding a new intent.
    an imperative `new Observable(observer => { ... })`, or another internal
    abstraction. Consider XState when orchestration is complex, especially when
    it includes user interactivity, retries, guards, or many explicit
-   transitions. The job should emit `JobState` values, model recoverable errors
-   as `JobState`, and complete when the intent is finished.
+   transitions. The job should emit `JobState` values for the intent UI, report
+   the consumer-facing `Result` through `onResult`, model recoverable errors as
+   `JobState`, and complete when the intent is finished.
    Read more:
    [`IntentDefinition`](#1-intentdefinition----shared-cross-platform-logic),
    [Job completion contract](#job-completion-contract),
@@ -365,9 +366,10 @@ implementation guide for adding a new intent.
    Import the platform-specific DeviceIntentExecutor component, build the
    `deviceInitializationInput` with the appropriate helper, then either use the
    flow orchestration hook or create the intent at runtime and pass it with the
-   initialization input to the DIE component. Add job state listeners when the
-   caller needs to capture intermediate results, and wire cancellation or
-   lifecycle callbacks when the flow needs them.
+   initialization input to the DIE component. Attach `onResult` on
+   `createIntent()` to capture consumer-facing results, and wire cancellation or
+   lifecycle callbacks when the flow needs them. `JobState` is for the intent
+   UI only.
    Read more:
    [Mounting the executor](#mounting-the-executor),
    [Building the `deviceInitializationInput`](#building-the-deviceinitializationinput),
@@ -416,7 +418,7 @@ function MyFlowScreen({ enabled, onDone }: Props) {
         /* track lifecycle */
       }}
       onIntentJobStateChanged={jobState => {
-        /* react to progress */
+        /* optional UI / debug reaction — not for flow results */
       }}
       onIntentJobComplete={() => {
         /* advance flow */
@@ -646,7 +648,7 @@ function SignTransactionStep({
         /* track lifecycle if needed */
       }}
       onIntentJobStateChanged={state => {
-        /* react to progress */
+        /* optional UI / debug reaction — not for flow results */
       }}
       onIntentJobComplete={() => onSigned()}
       onIntentJobError={onError}
@@ -679,16 +681,21 @@ Intents are defined in three layers, from most reusable to most specific:
 #### 1. `IntentDefinition` -- shared, cross-platform logic
 
 An `IntentDefinition` contains the `Job` function and execution metadata. The
-job receives the device connection, extracted context and typed input, and
-returns an `Observable<JobState>`.
+job receives the device connection, extracted context, typed input and an
+`onResult` callback, and returns an `Observable<JobState>`.
 
 The executor does not prescribe how a job is implemented internally. A job can
 be written as an RxJS operator pipeline, as an imperative
 `new Observable(observer => { ... })`, or by adapting another workflow tool.
 Choose the style that makes the flow easiest to understand, test and maintain.
-The boundary contract is what matters: emit meaningful `JobState` values,
+The boundary contract is what matters: emit meaningful `JobState` values for
+the intent UI, report the final consumer-facing `Result` through `onResult`,
 complete when the job is done, and keep internal orchestration details out of
-React.
+React. `Result` is unconstrained, so an intent may use a plain success value or
+its own discriminated union for success, failure and partial-result semantics.
+Jobs conventionally call `onResult` once with their final result, but the
+executor forwards every call so intent implementations remain free to report
+more than one result when needed.
 
 For complex flows with many explicit states, transitions, guards, retries or
 user-driven branches, consider using a state machine such as XState internally.
@@ -727,7 +734,7 @@ Example of a synchronous initial emission in an RxJS pipeline:
 
 ```typescript
 import { of } from "rxjs";
-import { map, catchError, startWith } from "rxjs/operators";
+import { map, catchError, startWith, tap } from "rxjs/operators";
 import type { Job } from "@features/platform-device-intent";
 
 type MyJobState =
@@ -735,9 +742,16 @@ type MyJobState =
   | { step: "signed"; signedTxHex: string }
   | { step: "error"; error: Error };
 
-const myJob: Job<MyJobState, { rawTxHex: string }> = ({ deviceConnectionResult, input }) =>
+type MyJobResult = string;
+
+const myJob: Job<MyJobState, { rawTxHex: string }, MyJobResult> = ({
+  deviceConnectionResult,
+  input,
+  onResult,
+}) =>
   signOnDevice(deviceConnectionResult.sessionId, input.rawTxHex).pipe(
     // Async device work follows
+    tap(hex => onResult(hex)),
     map((hex): MyJobState => ({ step: "signed", signedTxHex: hex })),
     catchError(err =>
       of<MyJobState>({
@@ -749,7 +763,7 @@ const myJob: Job<MyJobState, { rawTxHex: string }> = ({ deviceConnectionResult, 
     startWith<MyJobState>({ step: "waiting-for-confirmation" }),
   );
 
-const MyIntentDefinition: IntentDefinition<MyJobState, { rawTxHex: string }> = {
+const MyIntentDefinition: IntentDefinition<MyJobState, { rawTxHex: string }, MyJobResult> = {
   label: "sign-transaction",
   requiresConnectedDevice: true,
   delegateDeviceLockStateHandlingToExecutor: true,
@@ -781,7 +795,8 @@ const MobileSignTransactionView: React.FC<{
 const MobileSignTransactionPlatformDef: IntentPlatformDefinition<
   MyJobState,
   { rawTxHex: string },
-  { title: string }
+  { title: string },
+  MyJobResult
 > = {
   ...MyIntentDefinition,
   component: MobileSignTransactionView,
@@ -814,6 +829,9 @@ const intent = createIntent(
     rawTxHex: "0xabc...",
   },
   {
+    onResult: signedTxHex => {
+      /* store the typed result */
+    },
     onJobComplete: () => {
       /* intent-specific reaction */
     },
@@ -858,8 +876,8 @@ apps/ledger-live-desktop/src/.../signTransactionDemoIntent/
 
 Recommended responsibilities:
 
-- `types.ts` -- exports the intent's `JobState`, `Input`, and `ExtraProps`
-  types, plus the precomposed aliases for `MyIntentDefinition`,
+- `types.ts` -- exports the intent's `JobState`, `Input`, `Result`, and
+  `ExtraProps` types, plus the precomposed aliases for `MyIntentDefinition`,
   `MyIntentPlatformDefinition`, and runtime `MyIntent`.
 - `job.ts` -- exports the `Job` implementation and any non-React helpers or
   constants used by that job.
@@ -987,8 +1005,8 @@ The caller owns the business flow. The recommended pattern is an
 **orchestration hook** that:
 
 1. Maintains flow state (current phase, terminal outcomes).
-2. Reacts to executor callbacks (`onIntentJobStateChanged`,
-   `onIntentJobComplete`, `onIntentJobError`) to decide the next intent.
+2. Captures each intent's typed `Result` with intent-level `onResult`, then
+   advances on `onIntentJobComplete` (and handles `onIntentJobError`).
 3. Returns the current `intent`, `deviceInitializationInput`,
    `intentComponentExtraProps`, and the callback props for the executor.
 
@@ -1017,11 +1035,21 @@ const EXCHANGE_INITIALIZATION_INPUT: InitializationInput = {
 };
 
 function useSwapFlowOrchestration({ enabled, quote, platformDefs, deps }) {
+  const lastResultRef = useRef<unknown>(undefined);
+
   const [state, setState] = useState<FlowState>(() => ({
     type: "running",
     phase: {
       step: "exchange-init",
-      intent: createIntent(platformDefs.exchangeInit, { quote }),
+      intent: createIntent(
+        platformDefs.exchangeInit,
+        { quote },
+        {
+          onResult: preparedTxHex => {
+            lastResultRef.current = preparedTxHex;
+          },
+        },
+      ),
     },
   }));
 
@@ -1037,37 +1065,36 @@ function useSwapFlowOrchestration({ enabled, quote, platformDefs, deps }) {
     }
   }, [state, quote, deps]);
 
-  // Store results from the running job -- do NOT transition from here.
-  const lastJobStateRef = useRef<unknown>(null);
-  const onIntentJobStateChanged = useCallback(jobState => {
-    lastJobStateRef.current = jobState;
-  }, []);
-
-  // Advance the flow only once the job has completed.
+  // Advance only once the job has completed.
   const onIntentJobComplete = useCallback(() => {
     if (state.type !== "running") return;
-    const jobState = lastJobStateRef.current;
     switch (state.phase.step) {
       case "exchange-init": {
-        if (jobState?.step === "exchange-accepted") {
-          // Phase 2 will re-run in the coin app because both intent and
-          // deviceInitializationInput change in the same render.
-          setState({
-            type: "running",
-            phase: {
-              step: "signing",
-              intent: createIntent(platformDefs.sign, {
-                preparedTxHex: jobState.preparedTxHex,
-              }),
-            },
-          });
-        }
+        const preparedTxHex = lastResultRef.current as string | undefined;
+        if (!preparedTxHex) return;
+        // Phase 2 will re-run in the coin app because both intent and
+        // deviceInitializationInput change in the same render.
+        setState({
+          type: "running",
+          phase: {
+            step: "signing",
+            intent: createIntent(
+              platformDefs.sign,
+              { preparedTxHex },
+              {
+                onResult: signedTxHash => {
+                  lastResultRef.current = signedTxHash;
+                },
+              },
+            ),
+          },
+        });
         break;
       }
       case "signing": {
-        if (jobState?.step === "signed") {
-          setState({ type: "done", signedTxHash: jobState.signedTxHash });
-        }
+        const signedTxHash = lastResultRef.current as string | undefined;
+        if (!signedTxHash) return;
+        setState({ type: "done", signedTxHash });
         break;
       }
     }
@@ -1105,9 +1132,15 @@ In practice this means:
 - **`onIntentJobComplete` is the definitive signal** that a job has finished
   and it is safe to transition to the next phase. Always drive phase
   transitions from this callback.
-- **Use `onIntentJobStateChanged` to capture intermediate results** (e.g. a
-  signed transaction hex), but do **not** set a new intent or context from it
-  -- the job is still running at that point.
+- **Use intent-level `onResult` to capture the typed consumer-facing
+  result.** It is independent from `JobState`. Jobs normally report their final
+  result once, but every reported result is forwarded. Store it (typically in a
+  ref) and wait for `onIntentJobComplete` before changing the intent or
+  context.
+- **`JobState` is for the intent UI only.** Do not derive the next intent's
+  input, a flow outcome, or any other consumer-facing value from
+  `onIntentJobStateChanged` / `onJobStateChanged`.
+  The job is still running when they fire.
 - **Interactive jobs must complete before the orchestrator advances.** If a
   job waits for user action, emit callbacks in `JobState` and let the intent
   component call them from UI handlers. The callback can resume the job, emit a
@@ -1174,7 +1207,7 @@ The executor reports progress and lifecycle changes through callback props:
 | Callback                            | Fires when                                                                                                                                                |
 | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `onExecutorStateChanged(state)`     | The executor transitions between lifecycle phases (`connectingDevice`, `initializingDeviceContext`, `executingIntent`, `idle`, and their error variants). |
-| `onIntentJobStateChanged(jobState)` | Optional. The running job's observable emits a new `JobState` value.                                                                                      |
+| `onIntentJobStateChanged(jobState)` | Optional. The running job's observable emits a new `JobState` value (UI / observability only).                                                            |
 | `onIntentJobComplete()`             | Optional. The job observable completes (no more emissions). The executor transitions to `idle`.                                                           |
 | `onIntentJobError(error)`           | Optional. The job observable errors. The executor transitions to `executingIntentError`.                                                                  |
 
@@ -1188,7 +1221,8 @@ Each intent instance can optionally carry its own lifecycle callbacks:
 
 | Callback                      | Fires when                                       |
 | ----------------------------- | ------------------------------------------------ |
-| `onJobStateChanged(jobState)` | The job observable emits a new `JobState` value. |
+| `onJobStateChanged(jobState)` | The job observable emits a new `JobState` value (UI / observability only). |
+| `onResult(result)`             | The job reports a typed `Result` value.          |
 | `onJobComplete()`             | The job observable completes.                    |
 | `onJobError(error)`           | The job observable errors.                       |
 
@@ -1199,8 +1233,11 @@ const intent = createIntent(
   myDef,
   { derivationPath: "44'/60'/0'/0/0" },
   {
+    onResult: result => {
+      /* capture the consumer-facing result */
+    },
     onJobStateChanged: state => {
-      /* intent-specific reaction */
+      /* optional UI / debug reaction — not for flow results */
     },
     onJobComplete: () => {
       /* advance to next phase */
@@ -1210,8 +1247,8 @@ const intent = createIntent(
 ```
 
 **Firing order:** intent-level callbacks fire **before** executor-level
-callbacks. This lets an intent-specific handler (e.g. storing a derived
-address) run before a cross-cutting executor callback reads it.
+callbacks. This lets an intent-specific `onResult` handler (e.g. storing a
+derived address) run before a cross-cutting executor callback reads it.
 
 Intent-level callbacks are useful for orchestrating multi-intent flows where
 each phase needs its own reaction logic, while executor-level callbacks handle
@@ -1436,9 +1473,9 @@ close or restart path.
 
 Common causes:
 
-- Advancing the flow from `onIntentJobStateChanged` instead of
-  `onIntentJobComplete`. The job may still be emitting when the state callback
-  fires.
+- Advancing the flow from `onResult` or `onIntentJobStateChanged` instead of
+  `onIntentJobComplete`. The job may still be running when those callbacks
+  fire.
 - Leaving an interactive job waiting forever. If the observable never
   completes, the orchestrator is forced to bypass the completion contract. Emit
   callbacks in `JobState` so the component can resume or cancel the job, then

--- a/features/platform/device-intent/src/DeviceIntentExecutor.tsx
+++ b/features/platform/device-intent/src/DeviceIntentExecutor.tsx
@@ -5,12 +5,14 @@ import {
   type DeviceIntentExecutorHookState,
 } from "./useDeviceIntentExecutor";
 
-type Props<JobState, Input, ExtraProps, InitInput, InitializerConfig> = DeviceIntentExecutorProps<
+type Props<
   JobState,
   Input,
   ExtraProps,
-  InitInput
-> & {
+  InitInput,
+  InitializerConfig,
+  Result = undefined,
+> = DeviceIntentExecutorProps<JobState, Input, ExtraProps, InitInput, Result> & {
   platformConfig: ExecutorPlatformConfiguration<InitInput, InitializerConfig>;
   initializerConfig?: InitializerConfig;
   /**
@@ -19,16 +21,30 @@ type Props<JobState, Input, ExtraProps, InitInput, InitializerConfig> = DeviceIn
    * runtime scenarios.
    */
   useExecutorHook?: (
-    props: DeviceIntentExecutorProps<JobState, Input, ExtraProps, InitInput>,
+    props: DeviceIntentExecutorProps<JobState, Input, ExtraProps, InitInput, Result>,
   ) => DeviceIntentExecutorHookState<JobState, Input, ExtraProps, InitInput> | null;
 };
 
-export function DeviceIntentExecutor<JobState, Input, ExtraProps, InitInput, InitializerConfig>({
+export function DeviceIntentExecutor<
+  JobState,
+  Input,
+  ExtraProps,
+  InitInput,
+  InitializerConfig,
+  Result = undefined,
+>({
   useExecutorHook = useDeviceIntentExecutor,
   platformConfig,
   initializerConfig,
   ...executorProps
-}: Props<JobState, Input, ExtraProps, InitInput, InitializerConfig>): React.ReactElement | null {
+}: Props<
+  JobState,
+  Input,
+  ExtraProps,
+  InitInput,
+  InitializerConfig,
+  Result
+>): React.ReactElement | null {
   const state = useExecutorHook(executorProps);
   if (!state) return null;
 

--- a/features/platform/device-intent/src/DeviceIntentExecutorStateMachine.test.ts
+++ b/features/platform/device-intent/src/DeviceIntentExecutorStateMachine.test.ts
@@ -3,7 +3,7 @@ import {
   DefaultDeviceIntentExecutorStateMachine,
   type StateMachineListeners,
 } from "./DeviceIntentExecutorStateMachine";
-import type { Intent } from "./core";
+import type { Intent, Job } from "./core";
 import type { ExecutorState } from "./executor";
 import {
   makeExtractedContext,
@@ -16,7 +16,7 @@ import {
 
 type TestJobState = { step: "running" } | { step: "done" };
 
-const makeIntent = (job: () => Observable<unknown> = () => NEVER) => makeBaseIntent({ job });
+const makeIntent = (job: Job<unknown, unknown> = () => NEVER) => makeBaseIntent({ job });
 
 function makeListeners(): StateMachineListeners<unknown, unknown, unknown> & {
   executorStates: ExecutorState[];
@@ -52,7 +52,7 @@ function makeListeners(): StateMachineListeners<unknown, unknown, unknown> & {
 
 function createSM(
   overrides: {
-    job?: () => Observable<unknown>;
+    job?: Job<unknown, unknown>;
     intent?: Intent<unknown, unknown, unknown>;
     listeners?: ReturnType<typeof makeListeners>;
   } = {},
@@ -239,6 +239,7 @@ describe("DeviceIntentExecutorStateMachine", () => {
 
   describe("GIVEN the machine is in intentExecution state", () => {
     it("THEN the job receives the correct parameters", () => {
+      // GIVEN
       const connectionResult = makeConnectionResult();
       const extractedContext = makeExtractedContext();
       const jobInput = { amount: 42 };
@@ -249,11 +250,16 @@ describe("DeviceIntentExecutorStateMachine", () => {
         input: jobInput,
       };
       const { sm } = createSM({ intent });
+
+      // WHEN
       driveToExecution(sm, connectionResult, extractedContext);
+
+      // THEN
       expect(jobSpy).toHaveBeenCalledWith({
         deviceConnectionResult: connectionResult,
         deviceExtractedContext: extractedContext,
         input: jobInput,
+        onResult: expect.any(Function),
       });
       sm.stop();
     });
@@ -677,6 +683,42 @@ describe("DeviceIntentExecutorStateMachine", () => {
   });
 
   describe("intent-level listeners", () => {
+    it("GIVEN a job reports multiple results WHEN it executes THEN every result is forwarded", () => {
+      // GIVEN
+      const onResult = jest.fn();
+      const intent: Intent<unknown, unknown, unknown, string> = {
+        ...makeBaseIntent(),
+        job: ({ onResult }) => {
+          onResult("first");
+          onResult("second");
+          return NEVER;
+        },
+        onResult,
+      };
+      const listeners: StateMachineListeners<unknown, unknown, unknown, string> = {
+        onExecutorStateChanged: jest.fn(),
+        onIntentJobStateChanged: jest.fn(),
+        onIntentJobComplete: jest.fn(),
+        onIntentJobError: jest.fn(),
+      };
+      const sm = new DefaultDeviceIntentExecutorStateMachine({
+        deviceConnectionParams: { acceptedDeviceModelIds: [] },
+        intent,
+        listeners,
+      });
+      sm.start();
+
+      // WHEN
+      sm.deviceConnected(makeConnectionResult());
+      sm.deviceContextInitialized(makeExtractedContext());
+
+      // THEN
+      expect(onResult).toHaveBeenCalledTimes(2);
+      expect(onResult).toHaveBeenNthCalledWith(1, "first");
+      expect(onResult).toHaveBeenNthCalledWith(2, "second");
+      sm.stop();
+    });
+
     it("WHEN the job emits THEN intent.onJobStateChanged fires before the executor listener", async () => {
       const callOrder: string[] = [];
       const subject = new Subject<TestJobState>();

--- a/features/platform/device-intent/src/DeviceIntentExecutorStateMachine.ts
+++ b/features/platform/device-intent/src/DeviceIntentExecutorStateMachine.ts
@@ -13,7 +13,7 @@ const LOG_TYPE = "DIEStateMachine";
 
 // ---- Listener types ----
 
-export type StateMachineListeners<JobState, Input, ExtraProps> = {
+export type StateMachineListeners<JobState, Input, ExtraProps, Result = undefined> = {
   /**
    * Called when the executor state changes.
    */
@@ -22,72 +22,75 @@ export type StateMachineListeners<JobState, Input, ExtraProps> = {
    * Called when the job Observable emits a new value.
    */
   onIntentJobStateChanged: (
-    intent: Intent<JobState, Input, ExtraProps>,
+    intent: Intent<JobState, Input, ExtraProps, Result>,
     jobState: JobState,
   ) => void;
   /**
    * Called when the job Observable completes.
    */
-  onIntentJobComplete: (intent: Intent<JobState, Input, ExtraProps>) => void;
+  onIntentJobComplete: (intent: Intent<JobState, Input, ExtraProps, Result>) => void;
   /**
    * Called when the job Observable emits an error.
    */
-  onIntentJobError: (intent: Intent<JobState, Input, ExtraProps>, error: unknown) => void;
+  onIntentJobError: (intent: Intent<JobState, Input, ExtraProps, Result>, error: unknown) => void;
 };
 
 // ---- Internal machine types ----
 
-type MachineContext<JobState, Input, ExtraProps> = {
-  listeners: StateMachineListeners<JobState, Input, ExtraProps>;
+type MachineContext<JobState, Input, ExtraProps, Result> = {
+  listeners: StateMachineListeners<JobState, Input, ExtraProps, Result>;
   deviceConnectionParams: DeviceConnectionParams;
-  currentIntent: Intent<JobState, Input, ExtraProps>;
+  currentIntent: Intent<JobState, Input, ExtraProps, Result>;
   deviceConnectionResult: DeviceConnectionResult | null;
   deviceExtractedContext: DeviceExtractedContext | null;
   error: unknown;
 };
 
-type MachineEvent<JobState, Input, ExtraProps> =
+type MachineEvent<JobState, Input, ExtraProps, Result> =
   | { type: "DEVICE_CONNECTED"; result: DeviceConnectionResult }
   | { type: "DEVICE_INITIALIZED"; context: DeviceExtractedContext }
   | { type: "DEVICE_DISCONNECTED" }
   | { type: "RETRY" }
-  | { type: "SET_INTENT"; intent: Intent<JobState, Input, ExtraProps> }
+  | { type: "SET_INTENT"; intent: Intent<JobState, Input, ExtraProps, Result> }
   | { type: "REINITIALIZE" }
   | { type: "STOP_INTENT" };
 
-type MachineInput<JobState, Input, ExtraProps> = {
+type MachineInput<JobState, Input, ExtraProps, Result> = {
   deviceConnectionParams: DeviceConnectionParams;
-  intent: Intent<JobState, Input, ExtraProps>;
-  listeners: StateMachineListeners<JobState, Input, ExtraProps>;
+  intent: Intent<JobState, Input, ExtraProps, Result>;
+  listeners: StateMachineListeners<JobState, Input, ExtraProps, Result>;
 };
 
-type JobInvokeInput<JobState, Input> = {
+type JobInvokeInput<JobState, Input, Result> = {
   job: (params: {
     deviceConnectionResult: DeviceConnectionResult;
     deviceExtractedContext: DeviceExtractedContext;
     input: Input;
+    onResult: (result: Result) => void;
   }) => Observable<JobState>;
   deviceConnectionResult: DeviceConnectionResult;
   deviceExtractedContext: DeviceExtractedContext;
   intentInput: Input;
+  onResult: (result: Result) => void;
 };
 
 // ---- Machine factory ----
 
-function createExecutorMachine<JobState, Input, ExtraProps>() {
+function createExecutorMachine<JobState, Input, ExtraProps, Result>() {
   /** @xstate-layout N4IgpgJg5mDOIC5QBEwDcCWBjMBJAdgC5hECiAHmFgK6ED2ATgHQTrZgDCd++VhG3AMTJSANVwdSAfQ4B5AHLzSHACqlkAbQAMAXUSgADnVgZ+3fSHKIAjNYAcAVibWAbHZcBmAOxeAnG60HOwAaEABPGy1rJg8PXzsAJi0PawAWa18vVIcAXxzQ1EwcAmIyShp6ZlYisGQMWCxuXixiCEEAJVIVdoBNbT0kECMTM3wLKwQ7XyctVPTfeKSEjwcvUIiEBJcmTN9vVJd7VK1HXPyQQvYSkkIKKlpGFjZi-FMMAEMAGwwAL3fR4RiCTSXDyXAqXAAQQAMrgAFrqfoWYZvcyDCa2KbOWIOFy+E7WBJTELhRAuLweJiHdyrDx2OmJXx5ArPPBEG53CqPapXV78L6-f4CfCCADKXSkoLU8hUSMGKNG4xsc0pKwcvlSCWsDlxuvWiFiqSYDi05JSXgSRLs1uZF1Z1zK90qTxqBDeAr+AJE4kkUmQuFFckUyjUml0yOMqLG6MQ9KNCXShw8S2sXgc+oQOKps0ceLs2QcydtlxepVu5QeVXtfI+309wo6pFB4KhsIRcsMkcVMYQ2uslKSmo8qS8ZsJGeWlNSvgSXgydkCppHCWL1bLnMrTAw7MdFQbEG4YC3+DQdAA1keS2z1xXndub07hQht6esELuP0O0Mu8Klb3B0wI6xAs2RTPYaykr2theEws6jqkjjWi4lorucV4OuWTqPPeHK3g2YAMAwjwGJ8-wAGaMAAtkw6E7phXLMDhu60E+L50G+oyfuG8o-mioATBS2wuFolralMLguOkqQZnO2yTvODj2MsWhMmha64VhjF0RuXpAr6-qBgoSiqIi3GdiMv49nGsGJv2KZZL4GZBL4MSjvYyaSaaUyrq62m3thfmPkI4oqJKMqkDKX4KpZ-GIPE2yBKO+bxOqWg+Bm+bbCaWSJHY9jTISPm8g+DHHiVLHBSosgAAphdKspmd+Fl8ZYNhagksEZA4CS7NkwkQRs1iBNERLpN1SSpssLhFaWGmlUx9EVSKnTNhCMLwqQUW8dGsUIH4lJTCaHhaMkCwOJqGUHMaaXzMlqaHDN15zZuC2kIRjCNt0fSNdFLUCYSVJuFscTZWkCQZkN5JMHlLjnRJM5ePSHiPRhOkBeu70MGKEpShFDUDOZUZ-u4diwTDUSWtMQTSZBkMwTDcN4rO9JnCyvnlXe2mY42q2thtW3NTtrWZpkziIV4KnUohTnpM45JpRLWQmtNans89d4QJ8YDY6FuORT921-mkriA9qebuP2I4Q7YTg+GmiTCXiqQrCjgXzZr2vesCfoBkGxmhgLRM9q4TgrESmRzEkqz5hDs5aNDI74isUxzCprsc9hHs82Ca1tptBuC0bJrRCqzupo4UkkhsimkxSo6ZHiUQrKkeTnPgdCsPAgy0RnDARoXwepjE3VTFkmqJTHkEALT2Ns9JbLYImuKOyzp+r3KslwPB8DFTVB7ttgLIBPgpArc4Lum0-xDsik6v4d9xJ4a-Mc6PI4HUDRNHwkD9-vwuZUwG6w5VgajpIjDMR8th2BPvmLUhw0rP0Wq-as7o6zviFr9IWGIExCXVLiaBEtNQuAzKBWCc5Yh4iyNqC0LdVbFXXlpDmu9MFGwyPHaYPg5jQOOgcGSiRjSxEEWDCWWxEFo0YRyTGv9uy7ViB1K0zsfAJFxISDUMlYiAWQgrPY7gVjIzobNF+mctbSN3tg-szgRKzj2EENM0xY4SxiAmBCCEL7Jn0WzehRitJoAFBAWQBgCLoNMX9RA05bZagpMkbwyQtQZUUjfNy-ZtTJBtK3IAA */
   return setup({
     types: {
-      context: {} as MachineContext<JobState, Input, ExtraProps>,
-      events: {} as MachineEvent<JobState, Input, ExtraProps>,
-      input: {} as MachineInput<JobState, Input, ExtraProps>,
+      context: {} as MachineContext<JobState, Input, ExtraProps, Result>,
+      events: {} as MachineEvent<JobState, Input, ExtraProps, Result>,
+      input: {} as MachineInput<JobState, Input, ExtraProps, Result>,
     },
     actors: {
-      executeJob: fromObservable(({ input }: { input: JobInvokeInput<JobState, Input> }) =>
+      executeJob: fromObservable(({ input }: { input: JobInvokeInput<JobState, Input, Result> }) =>
         input.job({
           deviceConnectionResult: input.deviceConnectionResult,
           deviceExtractedContext: input.deviceExtractedContext,
           input: input.intentInput,
+          onResult: input.onResult,
         }),
       ),
     },
@@ -191,6 +194,7 @@ function createExecutorMachine<JobState, Input, ExtraProps>() {
             deviceConnectionResult: context.deviceConnectionResult!,
             deviceExtractedContext: context.deviceExtractedContext!,
             intentInput: context.currentIntent.input,
+            onResult: context.currentIntent.onResult ?? (() => undefined),
           }),
           onSnapshot: {
             actions: ({ event, context }) => {
@@ -326,23 +330,28 @@ function createExecutorMachine<JobState, Input, ExtraProps>() {
 
 // ---- Public interface ----
 
-export interface DeviceIntentExecutorStateMachine<JobState, Input, ExtraProps> {
+export interface DeviceIntentExecutorStateMachine<JobState, Input, ExtraProps, Result = undefined> {
   start(): void;
   deviceConnected(result: DeviceConnectionResult): void;
   deviceContextInitialized(context: DeviceExtractedContext): void;
   deviceDisconnected(): void;
   retry(): void;
-  setIntent(intent: Intent<JobState, Input, ExtraProps>): void;
+  setIntent(intent: Intent<JobState, Input, ExtraProps, Result>): void;
   reinitialize(): void;
   stopIntent(): void;
   stop(): void;
 }
 
-export type StateMachineConstructor<JobState, Input, ExtraProps> = new (params: {
+export type StateMachineConstructor<
+  JobState,
+  Input,
+  ExtraProps,
+  Result = undefined,
+> = new (params: {
   deviceConnectionParams: DeviceConnectionParams;
-  intent: Intent<JobState, Input, ExtraProps>;
-  listeners: StateMachineListeners<JobState, Input, ExtraProps>;
-}) => DeviceIntentExecutorStateMachine<JobState, Input, ExtraProps>;
+  intent: Intent<JobState, Input, ExtraProps, Result>;
+  listeners: StateMachineListeners<JobState, Input, ExtraProps, Result>;
+}) => DeviceIntentExecutorStateMachine<JobState, Input, ExtraProps, Result>;
 
 // ---- Default implementation ----
 
@@ -350,16 +359,17 @@ export class DefaultDeviceIntentExecutorStateMachine<
   JobState,
   Input,
   ExtraProps,
-> implements DeviceIntentExecutorStateMachine<JobState, Input, ExtraProps> {
+  Result = undefined,
+> implements DeviceIntentExecutorStateMachine<JobState, Input, ExtraProps, Result> {
   private readonly actor;
   private hasStarted = false;
 
   constructor(params: {
     deviceConnectionParams: DeviceConnectionParams;
-    intent: Intent<JobState, Input, ExtraProps>;
-    listeners: StateMachineListeners<JobState, Input, ExtraProps>;
+    intent: Intent<JobState, Input, ExtraProps, Result>;
+    listeners: StateMachineListeners<JobState, Input, ExtraProps, Result>;
   }) {
-    const machine = createExecutorMachine<JobState, Input, ExtraProps>();
+    const machine = createExecutorMachine<JobState, Input, ExtraProps, Result>();
     this.actor = createActor(machine, { input: params });
   }
 
@@ -396,7 +406,7 @@ export class DefaultDeviceIntentExecutorStateMachine<
 
   // -- Caller-driven events --
 
-  setIntent(intent: Intent<JobState, Input, ExtraProps>): void {
+  setIntent(intent: Intent<JobState, Input, ExtraProps, Result>): void {
     log(LOG_TYPE, "event: setIntent", { label: intent.label });
     this.actor.send({ type: "SET_INTENT", intent });
   }

--- a/features/platform/device-intent/src/core.test.ts
+++ b/features/platform/device-intent/src/core.test.ts
@@ -101,6 +101,21 @@ describe("createIntent", () => {
     expect(intent.onJobComplete).toBe(onJobComplete);
   });
 
+  it("GIVEN a typed result definition WHEN creating an intent THEN it attaches its result listener", () => {
+    // GIVEN
+    const definition: IntentPlatformDefinition<TestJobState, TestInput, TestExtraProps, string> = {
+      ...myIntentDefinitionWithInput,
+      job: () => of({ step: "done" as const, result: "ok" }),
+    };
+    const onResult = jest.fn<void, [string]>();
+
+    // WHEN
+    const intent = createIntent(definition, { value: 1 }, { onResult });
+
+    // THEN
+    expect(intent.onResult).toBe(onResult);
+  });
+
   it("has no listener fields when none are provided", () => {
     const intent = createIntent(myIntentDefinitionWithInput, { value: 1 });
 

--- a/features/platform/device-intent/src/core.ts
+++ b/features/platform/device-intent/src/core.ts
@@ -57,11 +57,13 @@ export type DeviceExtractedContext = {
  *
  * @typeParam JobState - Discriminated union of states emitted by this job.
  * @typeParam Input - Data provided to the job at runtime (default `undefined`).
+ * @typeParam Result - Final consumer-facing value produced by the job (default `undefined`).
  */
-export type Job<JobState, Input = undefined> = (params: {
+export type Job<JobState, Input = undefined, Result = undefined> = (params: {
   deviceConnectionResult: DeviceConnectionResult;
   deviceExtractedContext: DeviceExtractedContext;
   input: Input;
+  onResult: (result: Result) => void;
 }) => Observable<JobState>;
 
 /**
@@ -72,8 +74,9 @@ export type Job<JobState, Input = undefined> = (params: {
  *
  * @typeParam JobState - Discriminated union of states emitted by the job.
  * @typeParam Input - Data provided to the job at runtime (default `undefined`).
+ * @typeParam Result - Final consumer-facing value produced by the job (default `undefined`).
  */
-export interface IntentDefinition<JobState, Input = undefined> {
+export interface IntentDefinition<JobState, Input = undefined, Result = undefined> {
   /** Human-readable label identifying this intent (used for logging / debugging). */
   readonly label: string;
   /** Whether this intent requires an active device connection to run its job. */
@@ -81,7 +84,7 @@ export interface IntentDefinition<JobState, Input = undefined> {
   /** When `true`, the executor handles device lock/unlock transitions on behalf of the job. */
   readonly delegateDeviceLockStateHandlingToExecutor: boolean;
   /** The execution logic for this intent. */
-  readonly job: Job<JobState, Input>;
+  readonly job: Job<JobState, Input, Result>;
 }
 
 /**
@@ -94,12 +97,14 @@ export interface IntentDefinition<JobState, Input = undefined> {
  * @typeParam JobState - Discriminated union of states emitted by the job.
  * @typeParam Input - Data provided to the job at runtime (default `undefined`).
  * @typeParam ExtraProps - Additional props forwarded to the component by the caller.
+ * @typeParam Result - Final consumer-facing value produced by the job (default `undefined`).
  */
 export interface IntentPlatformDefinition<
   JobState,
   Input = undefined,
   ExtraProps = void,
-> extends IntentDefinition<JobState, Input> {
+  Result = undefined,
+> extends IntentDefinition<JobState, Input, Result> {
   /** React component that renders the current {@link JobState}. */
   readonly component: React.ComponentType<{
     jobState: JobState | undefined;
@@ -118,10 +123,13 @@ export interface IntentPlatformDefinition<
  * cross-cutting executor callbacks.
  *
  * @typeParam JobState - Discriminated union of states emitted by the job.
+ * @typeParam Result - Final consumer-facing value produced by the job.
  */
-export type IntentListeners<JobState> = {
+export type IntentListeners<JobState, Result = undefined> = {
   /** Called when the job observable emits a new state. */
   readonly onJobStateChanged?: (jobState: JobState) => void;
+  /** Called whenever the job reports a result. Jobs conventionally report their final result once. */
+  readonly onResult?: (result: Result) => void;
   /** Called when the job observable completes. */
   readonly onJobComplete?: () => void;
   /** Called when the job observable errors. */
@@ -137,18 +145,22 @@ export type IntentListeners<JobState> = {
  * @typeParam JobState - Discriminated union of states emitted by the job.
  * @typeParam Input - Data provided to the job at runtime (default `undefined`).
  * @typeParam ExtraProps - Additional props forwarded to the component by the caller.
+ * @typeParam Result - Final consumer-facing value produced by the job (default `undefined`).
  */
 export interface Intent<
   JobState,
   Input = undefined,
   ExtraProps = void,
-> extends IntentPlatformDefinition<JobState, Input, ExtraProps> {
+  Result = undefined,
+> extends IntentPlatformDefinition<JobState, Input, ExtraProps, Result> {
   /** Unique identifier for this runtime instance, useful for logging and debugging. */
   readonly uuid: string;
   /** Concrete input passed to the job when the executor runs this intent. */
   readonly input: Input;
   /** Called when the job observable emits a new state. Fires before executor-level callback. */
   readonly onJobStateChanged?: (jobState: JobState) => void;
+  /** Called whenever the job reports a result. Jobs conventionally report their final result once. */
+  readonly onResult?: (result: Result) => void;
   /** Called when the job observable completes. Fires before executor-level callback. */
   readonly onJobComplete?: () => void;
   /** Called when the job observable errors. Fires before executor-level callback. */
@@ -164,12 +176,12 @@ export interface Intent<
  * Each call generates a new `uuid` so intent instances can be told apart in
  * logs and debugging, even when the same definition is reused.
  */
-export function createIntent<JobState, Input, ExtraProps>(
-  definition: IntentPlatformDefinition<JobState, Input, ExtraProps>,
+export function createIntent<JobState, Input, ExtraProps, Result = undefined>(
+  definition: IntentPlatformDefinition<JobState, Input, ExtraProps, Result>,
   ...args: Input extends undefined
-    ? [input?: undefined, listeners?: IntentListeners<JobState>]
-    : [input: Input, listeners?: IntentListeners<JobState>]
-): Intent<JobState, Input, ExtraProps> {
+    ? [input?: undefined, listeners?: IntentListeners<JobState, Result>]
+    : [input: Input, listeners?: IntentListeners<JobState, Result>]
+): Intent<JobState, Input, ExtraProps, Result> {
   const [input, listeners] = args;
   return {
     ...definition,

--- a/features/platform/device-intent/src/core.ts
+++ b/features/platform/device-intent/src/core.ts
@@ -51,8 +51,9 @@ export type DeviceExtractedContext = {
 /**
  * Execution logic for one step of a flow.
  *
- * A job is called with the connected device, the extracted device context and
- * step-specific input, and returns an `Observable` that emits typed state
+ * A job is called with the connected device, the extracted device context,
+ * step-specific input, and an `onResult` callback for reporting a typed
+ * consumer-facing result. It returns an `Observable` that emits typed state
  * updates (`JobState`) as it progresses.
  *
  * @typeParam JobState - Discriminated union of states emitted by this job.

--- a/features/platform/device-intent/src/executor.ts
+++ b/features/platform/device-intent/src/executor.ts
@@ -142,8 +142,15 @@ export type ExecutorState =
  * @typeParam Input - Input type for the current intent's job.
  * @typeParam ExtraProps - Extra props forwarded to the intent's UI component.
  * @typeParam InitInput - Input type for the device context initializer.
+ * @typeParam Result - Final consumer-facing value produced by the intent's job.
  */
-export interface DeviceIntentExecutorProps<JobState, Input, ExtraProps, InitInput = void> {
+export interface DeviceIntentExecutorProps<
+  JobState,
+  Input,
+  ExtraProps,
+  InitInput = void,
+  Result = undefined,
+> {
   /** Parameters for device selection / connection. */
   deviceConnectionParams: DeviceConnectionParams;
   /** Initialization input; changing it triggers a new device-context initialisation. */
@@ -151,15 +158,9 @@ export interface DeviceIntentExecutorProps<JobState, Input, ExtraProps, InitInpu
   /** Called whenever the executor's own lifecycle state changes. */
   onExecutorStateChanged: (executorState: ExecutorState) => void;
   /** The current intent to execute. */
-  intent: Intent<JobState, Input, ExtraProps>;
+  intent: Intent<JobState, Input, ExtraProps, Result>;
   /** Extra props forwarded directly to the intent's UI component. */
   intentComponentExtraProps: ExtraProps;
-  /** Optional. Called whenever the running job emits a new state. */
-  onIntentJobStateChanged?: (jobState: JobState) => void;
-  /** Optional. Called when the job observable completes. */
-  onIntentJobComplete?: () => void;
-  /** Optional. Called when the job observable errors. */
-  onIntentJobError?: (error: unknown) => void;
   /** When `false` the executor is hidden and inactive; setting to `false` terminates any running job. */
   enabled: boolean;
   /** Called when the user performs an action that cancels the current execution
@@ -168,4 +169,10 @@ export interface DeviceIntentExecutorProps<JobState, Input, ExtraProps, InitInpu
   onUserCancel: () => void;
   /** Set to a new value to request cancellation of the ongoing job. */
   cancelIntentRequestId: string | undefined;
+  /** Optional. Called whenever the running job emits a new state. */
+  onIntentJobStateChanged?: (jobState: JobState) => void;
+  /** Optional. Called when the job observable completes. */
+  onIntentJobComplete?: () => void;
+  /** Optional. Called when the job observable errors. */
+  onIntentJobError?: (error: unknown) => void;
 }

--- a/features/platform/device-intent/src/useDeviceIntentExecutor.ts
+++ b/features/platform/device-intent/src/useDeviceIntentExecutor.ts
@@ -20,16 +20,16 @@ export type { DeviceIntentExecutorHookState, IntentExecutionSnapshot } from "./d
  * @internal Test-only options for dependency injection. Not intended for
  * production use — the defaults are correct for all runtime scenarios.
  */
-type UseDeviceIntentExecutorOptions<JobState, Input, ExtraProps> = {
+type UseDeviceIntentExecutorOptions<JobState, Input, ExtraProps, Result> = {
   /** Overrides the state machine constructor. Inject a mock class in unit tests. */
-  StateMachineClass?: StateMachineConstructor<JobState, Input, ExtraProps>;
+  StateMachineClass?: StateMachineConstructor<JobState, Input, ExtraProps, Result>;
 };
 
-export function useDeviceIntentExecutor<JobState, Input, ExtraProps, InitInput>(
-  props: DeviceIntentExecutorProps<JobState, Input, ExtraProps, InitInput>,
+export function useDeviceIntentExecutor<JobState, Input, ExtraProps, InitInput, Result = undefined>(
+  props: DeviceIntentExecutorProps<JobState, Input, ExtraProps, InitInput, Result>,
   {
     StateMachineClass = DefaultDeviceIntentExecutorStateMachine,
-  }: UseDeviceIntentExecutorOptions<JobState, Input, ExtraProps> = {},
+  }: UseDeviceIntentExecutorOptions<JobState, Input, ExtraProps, Result> = {},
 ): DeviceIntentExecutorHookState<JobState, Input, ExtraProps, InitInput> | null {
   // ---- 1. Refs for props ----
 
@@ -62,7 +62,12 @@ export function useDeviceIntentExecutor<JobState, Input, ExtraProps, InitInput>(
 
   // ---- 2. Internal state ----
 
-  const smRef = useRef<DeviceIntentExecutorStateMachine<JobState, Input, ExtraProps> | null>(null);
+  const smRef = useRef<DeviceIntentExecutorStateMachine<
+    JobState,
+    Input,
+    ExtraProps,
+    Result
+  > | null>(null);
   const [executorState, setExecutorState] = useState<ExecutorState>({
     type: "connectingDevice",
   });

--- a/features/platform/verify-address-intent/src/__tests__/job.test.ts
+++ b/features/platform/verify-address-intent/src/__tests__/job.test.ts
@@ -37,6 +37,7 @@ function startJob(expectedAddress = EXPECTED_ADDRESS) {
     },
     deviceExtractedContext: {} as never,
     input: { expectedAddress, startAddressVerification },
+    onResult: jest.fn(),
   }).subscribe({
     next: state => states.push(state),
     error: e => {

--- a/libs/ledger-live-common/src/intents/signMessageIntent/__tests__/job.test.ts
+++ b/libs/ledger-live-common/src/intents/signMessageIntent/__tests__/job.test.ts
@@ -60,7 +60,12 @@ function mockSignMessageExec(result$: Observable<Result>) {
 }
 
 function startJob() {
-  return signMessageIntentJob({ deviceConnectionResult, deviceExtractedContext, input });
+  return signMessageIntentJob({
+    deviceConnectionResult,
+    deviceExtractedContext,
+    input,
+    onResult: jest.fn(),
+  });
 }
 
 describe("signMessageIntentJob", () => {

--- a/libs/ledger-live-common/src/intents/signTransactionIntent/__tests__/job.test.ts
+++ b/libs/ledger-live-common/src/intents/signTransactionIntent/__tests__/job.test.ts
@@ -80,7 +80,12 @@ function mockGetAccountBridgeResolvedValue(bridge: BridgeMock) {
 }
 
 function startJob() {
-  return signTransactionIntentJob({ deviceConnectionResult, deviceExtractedContext, input });
+  return signTransactionIntentJob({
+    deviceConnectionResult,
+    deviceExtractedContext,
+    input,
+    onResult: jest.fn(),
+  });
 }
 
 async function flushPromises() {

--- a/libs/ledger-live-common/src/wallet-api/Exchange/intents/broadcastEvm/job.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/intents/broadcastEvm/job.test.ts
@@ -37,6 +37,7 @@ function collect(input: BroadcastEvmIntentInput = BASE_INPUT): Promise<Broadcast
       deviceConnectionResult: FAKE_CONNECTION,
       deviceExtractedContext: FAKE_CONTEXT,
       input,
+      onResult: jest.fn(),
     }).pipe(toArray()),
   );
 }

--- a/libs/ledger-live-common/src/wallet-api/Exchange/intents/signApprovalEvm/job.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/intents/signApprovalEvm/job.test.ts
@@ -82,6 +82,7 @@ function run(input: SignApprovalEvmIntentInput = BASE_INPUT) {
     deviceConnectionResult: FAKE_CONNECTION,
     deviceExtractedContext: FAKE_CONTEXT,
     input,
+    onResult: jest.fn(),
   });
 }
 

--- a/libs/ledger-live-common/src/wallet-api/Exchange/intents/signPermit2Evm/job.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/intents/signPermit2Evm/job.test.ts
@@ -29,6 +29,7 @@ function run(input: SignPermit2EvmIntentInput = BASE_INPUT) {
     deviceConnectionResult: FAKE_CONNECTION,
     deviceExtractedContext: FAKE_CONTEXT,
     input,
+    onResult: jest.fn(),
   });
 }
 

--- a/libs/ledger-live-common/src/wallet-api/Exchange/intents/signRfqOrderEvm/job.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/intents/signRfqOrderEvm/job.test.ts
@@ -29,6 +29,7 @@ function run(input: SignRfqOrderEvmIntentInput = BASE_INPUT) {
     deviceConnectionResult: FAKE_CONNECTION,
     deviceExtractedContext: FAKE_CONTEXT,
     input,
+    onResult: jest.fn(),
   });
 }
 

--- a/libs/ledger-live-common/src/wallet-api/Exchange/intents/signSwapEvm/job.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/intents/signSwapEvm/job.test.ts
@@ -80,6 +80,7 @@ function run(input: SignSwapEvmIntentInput = BASE_INPUT) {
     deviceConnectionResult: FAKE_CONNECTION,
     deviceExtractedContext: FAKE_CONTEXT,
     input,
+    onResult: jest.fn(),
   });
 }
 

--- a/libs/ledger-live-common/src/wallet-api/Exchange/intents/submitRfqOrderEvm/job.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/intents/submitRfqOrderEvm/job.test.ts
@@ -35,6 +35,7 @@ async function collectStates(
       deviceConnectionResult: FAKE_DEVICE_CONNECTION,
       deviceExtractedContext: FAKE_DEVICE_CONTEXT,
       input,
+      onResult: jest.fn(),
     }).pipe(toArray()),
   );
 }
@@ -155,6 +156,7 @@ describe("submitRfqOrderEvmJob", () => {
         deviceConnectionResult: FAKE_DEVICE_CONNECTION,
         deviceExtractedContext: FAKE_DEVICE_CONTEXT,
         input: { ...BASE_INPUT, fetchImpl },
+        onResult: jest.fn(),
       }),
     );
     expect(first).toEqual({ type: "submitting" });


### PR DESCRIPTION
### 📝 Description

Device intent consumers currently have to inspect UI-oriented JobState emissions to recover programmatic results. This duplicates terminal-state knowledge and couples orchestration to rendering state.

This PR adds a separate typed Result channel across the complete Device Intent Executor contract. Jobs receive an onResult callback, runtime intents can provide their own typed onResult listener, and every reported value is forwarded without imposing settlement or lifecycle policy. Existing job implementations remain source-compatible through default generic parameters; direct job invocations now provide an explicit reporter.

~~~typescript
const job: Job<JobState, Input, Result> = ({ input, onResult }) => {
  // ...execute the operation
  onResult(result);
  return jobState$;
};

const intent = createIntent(definition, input, {
  onResult: result => consume(result),
});
~~~

The result generic is also propagated through the shared executor, state machine, hook, and LWD/LWM wrappers. Documentation, focused tests, and a changeset are included.

### ✅ Validation

- Device Intent Executor: 140 tests passed
- Ledger Live Common direct job callers: 41 tests passed
- LWD wrapper: 28 tests passed
- LWM wrapper: 25 tests passed
- Device Intent Executor, Contacts, Ledger Live Common, and Mobile typechecks passed
- Package formatting, structure, and unused-import checks passed
- Desktop typecheck reported only the known unrelated missing html-to-image dependency

### 🔗 Context

- **JIRA issue**: [LIVE-36335](https://ledgerhq.atlassian.net/browse/LIVE-36335)
- **ADR**: https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/6852083917

[LIVE-36335]: https://ledgerhq.atlassian.net/browse/LIVE-36335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ