### PR TITLE
[LWDM] fix(canton): fix kiln validator name typo in setup copy

### DIFF
--- a/.changeset/curly-beans-teach.md
+++ b/.changeset/curly-beans-teach.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+fix(canton): fix kiln validator name typo in setup copy

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -6578,7 +6578,7 @@
           },
           "dualValidator": {
             "title": "Dual-validator security",
-            "body": "Transactions require co-signing from both Ledger and Klin. Neither can act on your behalf alone."
+            "body": "Transactions require co-signing from both Ledger and Kiln. Neither can act on your behalf alone."
           },
           "tokenLiability": {
             "title": "Standard token liability ⚠️",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -9800,7 +9800,7 @@
         },
         "dualValidator": {
           "title": "Dual-validator security",
-          "body": "Transactions require co-signing from both Ledger and Klin. Neither can act on your behalf alone."
+          "body": "Transactions require co-signing from both Ledger and Kiln. Neither can act on your behalf alone."
         },
         "tokenLiability": {
           "title": "Standard token liability ⚠️",


### PR DESCRIPTION
### 📝 Description

Fixes a typo in the "Set up Canton Network" modal copy: "Klin" → "Kiln" (the co-signing validator name), in the English source strings for both ledger-live-desktop and ledger-live-mobile.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36279](https://ledgerhq.atlassian.net/browse/LIVE-36279)
- **ADR** (if any): n/a

[LIVE-36279]: https://ledgerhq.atlassian.net/browse/LIVE-36279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ