### PR TITLE
ci(workflows): enforce --frozen-lockfile across all pnpm installs

### DIFF
--- a/.github/workflows/account-migration.yml
+++ b/.github/workflows/account-migration.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: install dependencies and build
         run: |
-          pnpm i --filter="!./apps/**"
+          pnpm i --frozen-lockfile --filter="!./apps/**"
           pnpm exec nx run @ledgerhq/live-common:build
 
       - name: Generate target output filename
@@ -69,7 +69,7 @@ jobs:
 
       - name: install dependencies and build
         run: |
-          pnpm i --filter="!./apps/**"
+          pnpm i --frozen-lockfile --filter="!./apps/**"
           pnpm exec nx run @ledgerhq/live-common:build
 
       - name: run synchronisation on current branch

--- a/.github/workflows/build-mobile-external-reusable.yml
+++ b/.github/workflows/build-mobile-external-reusable.yml
@@ -52,7 +52,7 @@ jobs:
       - name: setup Android SDK
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
       - name: install dependencies
-        run: pnpm i --filter="live-mobile..." --filter="ledger-live" --no-frozen-lockfile --unsafe-perm
+        run: pnpm i --filter="live-mobile..." --filter="ledger-live" --frozen-lockfile --unsafe-perm
       - uses: LedgerHQ/ledger-live/tools/actions/get-package-infos@develop
         id: version
         with:
@@ -111,4 +111,4 @@ jobs:
         with:
           ruby-version: 3.3.0
       - name: install dependencies
-        run: pnpm i --filter="live-mobile..." --filter="ledger-live" --no-frozen-lockfile --unsafe-perm
+        run: pnpm i --filter="live-mobile..." --filter="ledger-live" --frozen-lockfile --unsafe-perm

--- a/.github/workflows/build-mobile-reusable.yml
+++ b/.github/workflows/build-mobile-reusable.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           registry: ${{ vars.ARTIFACTORY_URL }}
       - name: install dependencies
-        run: pnpm i --filter="live-mobile..." --filter="ledger-live" --no-frozen-lockfile --unsafe-perm
+        run: pnpm i --filter="live-mobile..." --filter="ledger-live" --frozen-lockfile --unsafe-perm
       - uses: LedgerHQ/ledger-live/tools/actions/get-package-infos@develop
         id: version
         with:

--- a/.github/workflows/build-wallet-cli-reusable.yml
+++ b/.github/workflows/build-wallet-cli-reusable.yml
@@ -64,7 +64,7 @@ jobs:
           region: ${{ secrets.AWS_CACHE_REGION }}
 
       - name: Install dependencies
-        run: pnpm i --filter "@ledgerhq/wallet-cli..." --filter "ledger-live"
+        run: pnpm i --frozen-lockfile --filter "@ledgerhq/wallet-cli..." --filter "ledger-live"
 
       - name: format check wallet-cli
         if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -45,7 +45,7 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
       - name: Install dependencies
-        run: pnpm i --filter="ledger-live"
+        run: pnpm i --frozen-lockfile --filter="ledger-live"
       - name: Lint commits
         env:
           EVENT_NAME: ${{ github.event_name }}

--- a/.github/workflows/generate-e2e-userdata.yml
+++ b/.github/workflows/generate-e2e-userdata.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           registry: ${{ vars.ARTIFACTORY_URL }}
       - name: Install dependencies
-        run: pnpm i --filter="live-cli..." --filter="ledger-live-desktop-e2e-tests..." --filter="ledger-live" --no-frozen-lockfile --unsafe-perm --ignore-scripts
+        run: pnpm i --filter="live-cli..." --filter="ledger-live-desktop-e2e-tests..." --filter="ledger-live" --frozen-lockfile --unsafe-perm --ignore-scripts
 
       - name: Setup Speculos image and Coin Apps
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-speculos_image@develop
@@ -213,7 +213,7 @@ jobs:
           registry: ${{ vars.ARTIFACTORY_URL }}
 
       - name: Install dependencies
-        run: pnpm i --filter="live-cli..." --filter="ledger-live-desktop-e2e-tests..." --filter="ledger-live" --no-frozen-lockfile --unsafe-perm --ignore-scripts
+        run: pnpm i --filter="live-cli..." --filter="ledger-live-desktop-e2e-tests..." --filter="ledger-live" --frozen-lockfile --unsafe-perm --ignore-scripts
 
       - name: Setup Speculos image and Coin Apps
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-speculos_image@develop

--- a/.github/workflows/nx-affected-reusable.yml
+++ b/.github/workflows/nx-affected-reusable.yml
@@ -77,7 +77,7 @@ jobs:
           version: 10.24.0
 
       - name: Install dev dependencies for root workspace
-        run: pnpm i -D -F "ledger-live" --ignore-scripts
+        run: pnpm i --frozen-lockfile -D -F "ledger-live" --ignore-scripts
 
       - name: Skip Nx cache for job
         if: ${{ inputs.skip_nx_cache }}

--- a/.github/workflows/regen-doc.yml
+++ b/.github/workflows/regen-doc.yml
@@ -71,7 +71,7 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
       - name: Install dependencies
-        run: pnpm i --filter="!./apps/**"
+        run: pnpm i --frozen-lockfile --filter="!./apps/**"
       - name: run doc
         run: pnpm exec nx run-many -t doc --projects=tag:scope:libs-ledgerjs
       - name: status

--- a/.github/workflows/regen-pods.yml
+++ b/.github/workflows/regen-pods.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           ruby-version: 3.3.0
       - name: install dependencies
-        run: pnpm i --filter="live-mobile..." --filter="ledger-live" --no-frozen-lockfile --unsafe-perm
+        run: pnpm i --filter="live-mobile..." --filter="ledger-live" --frozen-lockfile --unsafe-perm
       - name: regenerate pods
         run: NO_FLIPPER=1 pnpm mobile pod
       - name: status

--- a/.github/workflows/release-create-hotfix.yml
+++ b/.github/workflows/release-create-hotfix.yml
@@ -56,7 +56,7 @@ jobs:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           skip-nx-cache: "true"
       - name: install dependencies
-        run: pnpm i -F "ledger-live"
+        run: pnpm i --frozen-lockfile -F "ledger-live"
       - name: Move minor updates to patch for hotfix branch
         # For more info about why we do this, see this doc:
         # https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/4710989838/LL+Incident+Recovery+-+Hotfix+in+all+cases

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -45,7 +45,7 @@ jobs:
           from_level: patch
           to_level: minor
       - name: Install dependencies
-        run: pnpm install -D --ignore-scripts
+        run: pnpm install --frozen-lockfile -D --ignore-scripts
       - name: enter prerelease mode
         run: pnpm changeset pre enter next
       - name: Prune changelogs

--- a/.github/workflows/release-final-nightly.yml
+++ b/.github/workflows/release-final-nightly.yml
@@ -63,7 +63,7 @@ jobs:
           registry: ${{ vars.ARTIFACTORY_URL }}
 
       - name: install dependencies
-        run: pnpm i -F "ledger-live" -F "{libs/**}..." -F "@ledgerhq/live-cli"
+        run: pnpm i --frozen-lockfile -F "ledger-live" -F "{libs/**}..." -F "@ledgerhq/live-cli"
 
       - name: build libs
         run: pnpm exec nx run-many -t build --projects=tag:scope:libs

--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -89,7 +89,7 @@ jobs:
           registry: ${{ vars.ARTIFACTORY_URL }}
 
       - name: install dependencies
-        run: pnpm i -F "ledger-live" -F "{libs/**}..." -F "@ledgerhq/live-cli..." -F "@ledgerhq/wallet-cli..." -F "@ledgerhq/wallet-cli-*"
+        run: pnpm i --frozen-lockfile -F "ledger-live" -F "{libs/**}..." -F "@ledgerhq/live-cli..." -F "@ledgerhq/wallet-cli..." -F "@ledgerhq/wallet-cli-*"
 
       - name: build libs
         run: pnpm exec nx run-many -t build --projects=tag:scope:libs,@ledgerhq/live-e2e-shared

--- a/.github/workflows/release-prepare-hotfix.yml
+++ b/.github/workflows/release-prepare-hotfix.yml
@@ -61,7 +61,7 @@ jobs:
           skip-nx-cache: "true"
 
       - name: install dependencies
-        run: pnpm i -F "ledger-live"
+        run: pnpm i --frozen-lockfile -F "ledger-live"
 
       - name: exit prerelease mode
         run: pnpm changeset pre exit

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -43,7 +43,7 @@ jobs:
           skip-nx-cache: "true"
 
       - name: install dependencies
-        run: pnpm i -F "ledger-live"
+        run: pnpm i --frozen-lockfile -F "ledger-live"
 
       - name: exit prerelease mode
         run: pnpm changeset pre exit

--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -51,7 +51,7 @@ jobs:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           skip-nx-cache: "true"
       - name: install dependencies
-        run: pnpm i -D -F "ledger-live" --ignore-scripts
+        run: pnpm i --frozen-lockfile -D -F "ledger-live" --ignore-scripts
       - name: Move patch updates to minor for release branch
         # For more info about why we do this, see this doc:
         # https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/4710989838/LL+Incident+Recovery+-+Hotfix+in+all+cases

--- a/.github/workflows/release-rollback.yml
+++ b/.github/workflows/release-rollback.yml
@@ -67,7 +67,7 @@ jobs:
           skip-nx-cache: "true"
 
       - name: Install dependencies
-        run: pnpm i -D -F "ledger-live" --ignore-scripts
+        run: pnpm i --frozen-lockfile -D -F "ledger-live" --ignore-scripts
 
       - name: Checkout rollback branch
         run: |

--- a/.github/workflows/rsdoctor-pr.yml
+++ b/.github/workflows/rsdoctor-pr.yml
@@ -72,7 +72,7 @@ jobs:
           region: ${{ secrets.AWS_CACHE_REGION }}
 
       - name: Install dependencies
-        run: pnpm i
+        run: pnpm i --frozen-lockfile
 
       - name: Build desktop dependencies
         run: pnpm build:lld:deps

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -51,7 +51,7 @@ jobs:
         env:
           LANG: en_US.UTF-8
         run: |
-          pnpm i --filter="./libs/**" --filter="./features/**" --filter="./shared/**" --filter="./domain/**" --filter="./devtools/**" --filter="live-mobile..." --filter="ledger-live-desktop..." --no-frozen-lockfile --unsafe-perm
+          pnpm i --filter="./libs/**" --filter="./features/**" --filter="./shared/**" --filter="./domain/**" --filter="./devtools/**" --filter="live-mobile..." --filter="ledger-live-desktop..." --frozen-lockfile --unsafe-perm
 
       - name: Build dependencies
         run: |
@@ -183,7 +183,7 @@ jobs:
 
       - name: Generate Unit test coverage for wallet-cli
         run: |
-          pnpm i --filter="@ledgerhq/wallet-cli..." --no-frozen-lockfile --unsafe-perm
+          pnpm i --filter="@ledgerhq/wallet-cli..." --frozen-lockfile --unsafe-perm
           pnpm exec nx run @ledgerhq/wallet-cli:build
           mkdir -p apps/wallet-cli/coverage
           touch apps/wallet-cli/coverage/lcov.info

--- a/.github/workflows/test-boundaries-reusable.yml
+++ b/.github/workflows/test-boundaries-reusable.yml
@@ -56,7 +56,7 @@ jobs:
           region: ${{ secrets.AWS_CACHE_REGION }}
 
       - name: Install dependencies
-        run: pnpm i
+        run: pnpm i --frozen-lockfile
 
       - name: Enforce module boundaries
         run: pnpm exec nx run enforce-boundaries:lint:boundaries

--- a/.github/workflows/test-bridge-pr.yml
+++ b/.github/workflows/test-bridge-pr.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           pnpm add -g node-gyp@3.8.0
       - name: Install dependencies
-        run: pnpm i --filter="live-common..." --filter="ledger-live"
+        run: pnpm i --frozen-lockfile --filter="live-common..." --filter="ledger-live"
       - name: Build
         run: pnpm exec nx run @ledgerhq/live-common:build
       - name: Test

--- a/.github/workflows/test-cli-reusable.yml
+++ b/.github/workflows/test-cli-reusable.yml
@@ -57,7 +57,7 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
       - name: Install dependencies
-        run: pnpm i -F "live-cli*..." -F "ledger-live"
+        run: pnpm i --frozen-lockfile -F "live-cli*..." -F "ledger-live"
       - name: build cli
         run: pnpm exec nx run @ledgerhq/live-cli:build
       - name: format check cli

--- a/.github/workflows/test-coin-modules-integ.yml
+++ b/.github/workflows/test-coin-modules-integ.yml
@@ -72,7 +72,7 @@ jobs:
           region: ${{ secrets.AWS_CACHE_REGION }}
 
       - name: Install dependencies
-        run: pnpm i --filter="!./apps/**"
+        run: pnpm i --frozen-lockfile --filter="!./apps/**"
 
       - name: Build
         run: pnpm exec nx run-many -t build --projects=tag:type:coin-module

--- a/.github/workflows/test-design-system-reusable.yml
+++ b/.github/workflows/test-design-system-reusable.yml
@@ -69,7 +69,7 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
       - name: Install dependencies
-        run: pnpm i --filter="./libs/ui/**"
+        run: pnpm i --frozen-lockfile --filter="./libs/ui/**"
       - name: Run unit tests
         run: pnpm --filter="./libs/ui/**" test:jest:coverage
       - name: Upload unit test coverage (react)

--- a/.github/workflows/test-desktop-codechecks-reusable.yml
+++ b/.github/workflows/test-desktop-codechecks-reusable.yml
@@ -146,7 +146,7 @@ jobs:
           registry: ${{ vars.ARTIFACTORY_URL }}
 
       - name: Install dependencies
-        run: pnpm i --filter="ledger-live-desktop..." --filter="ledger-live"
+        run: pnpm i --frozen-lockfile --filter="ledger-live-desktop..." --filter="ledger-live"
 
       - name: Build dependencies
         run: pnpm exec nx run ledger-live-desktop:build-lib-deps

--- a/.github/workflows/test-desktop-e2e-lint-reusable.yml
+++ b/.github/workflows/test-desktop-e2e-lint-reusable.yml
@@ -46,7 +46,7 @@ jobs:
           region: ${{ secrets.AWS_CACHE_REGION }}
 
       - name: Install dependencies
-        run: pnpm i --filter="ledger-live-desktop-e2e-tests..." --filter="ledger-live-desktop..." --no-frozen-lockfile --unsafe-perm
+        run: pnpm i --filter="ledger-live-desktop-e2e-tests..." --filter="ledger-live-desktop..." --frozen-lockfile --unsafe-perm
 
       - name: Run format check
         if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || github.event_name == 'merge_group'

--- a/.github/workflows/test-integration-pr.yml
+++ b/.github/workflows/test-integration-pr.yml
@@ -62,7 +62,7 @@ jobs:
           region: ${{ secrets.AWS_CACHE_REGION }}
 
       - name: Install dependencies
-        run: pnpm i --filter="live-common..." --filter="ledger-live" --filter="@ledgerhq/ledger-wallet-framework"
+        run: pnpm i --frozen-lockfile --filter="live-common..." --filter="ledger-live" --filter="@ledgerhq/ledger-wallet-framework"
 
       # Seed the local nx cache for live-common's transitive deps in two
       # chunks. Each chunk runs in its own nx process so the per-task fd burst

--- a/.github/workflows/test-integration-weekly.yml
+++ b/.github/workflows/test-integration-weekly.yml
@@ -48,7 +48,7 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
       - name: Install dependencies
-        run: pnpm i --filter="live-common..." --filter="ledger-live"
+        run: pnpm i --frozen-lockfile --filter="live-common..." --filter="ledger-live"
       - name: Build
         run: pnpm exec nx run @ledgerhq/live-common:build
       - name: Test

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -53,7 +53,7 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
       - name: Install dependencies
-        run: pnpm i --filter="live-common..." --filter="ledger-live" --filter="@ledgerhq/ledger-wallet-framework"
+        run: pnpm i --frozen-lockfile --filter="live-common..." --filter="ledger-live" --filter="@ledgerhq/ledger-wallet-framework"
 
       # Seed the local nx cache for live-common's transitive deps in two
       # chunks. Each chunk runs in its own nx process so the per-task fd burst

--- a/.github/workflows/test-libs-reusable.yml
+++ b/.github/workflows/test-libs-reusable.yml
@@ -89,7 +89,7 @@ jobs:
           registry: ${{ vars.ARTIFACTORY_URL }}
 
       - name: Install dependencies
-        run: pnpm i --filter="{./libs/**}..."
+        run: pnpm i --frozen-lockfile --filter="{./libs/**}..."
 
       - name: Run coverage on appropriate libraries
         run: |
@@ -204,7 +204,7 @@ jobs:
         with:
           registry: ${{ vars.ARTIFACTORY_URL }}
       - name: Install dependencies
-        run: pnpm i --filter="{./libs/**}..."
+        run: pnpm i --frozen-lockfile --filter="{./libs/**}..."
       - name: Codechecks
         uses: LedgerHQ/ledger-live/tools/actions/composites/nx-codechecks@develop
         with:
@@ -243,7 +243,7 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
       - name: Install dependencies
-        run: pnpm i --filter="!./apps/**"
+        run: pnpm i --frozen-lockfile --filter="!./apps/**"
       - name: run doc
         run: pnpm exec nx run-many -t doc --projects=tag:scope:libs-ledgerjs
       - name: get diff

--- a/.github/workflows/test-mobile-build-android-reusable.yml
+++ b/.github/workflows/test-mobile-build-android-reusable.yml
@@ -156,7 +156,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pnpm i --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --filter="live-cli*..." --unsafe-perm
+          pnpm i --frozen-lockfile --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --filter="live-cli*..." --unsafe-perm
 
       - name: Build Android app for Detox test run
         uses: LedgerHQ/ledger-live/tools/actions/composites/nx-step@develop
@@ -230,8 +230,8 @@ jobs:
         with:
           max_attempts: 2
           timeout_minutes: 15
-          command: pnpm i --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --unsafe-perm
-          new_command_on_retry: rm -rf ~/.cocoapods/ && pnpm clean && pnpm i --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --unsafe-perm
+          command: pnpm i --frozen-lockfile --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --unsafe-perm
+          new_command_on_retry: rm -rf ~/.cocoapods/ && pnpm clean && pnpm i --frozen-lockfile --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --unsafe-perm
 
       - name: Build JS bundle and minify for size analysis
         uses: LedgerHQ/ledger-live/tools/actions/composites/nx-step@develop

--- a/.github/workflows/test-mobile-build-ios-reusable.yml
+++ b/.github/workflows/test-mobile-build-ios-reusable.yml
@@ -164,8 +164,8 @@ jobs:
         with:
           max_attempts: 2
           timeout_minutes: 15
-          command: pnpm i --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --unsafe-perm
-          new_command_on_retry: rm -rf ~/.cocoapods/ && pnpm clean && pnpm i --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --unsafe-perm && pnpm nx:write-cache-config --cache-key-prefix "${{ steps.setup-caches.outputs.nx-cache-key-prefix }}"
+          command: pnpm i --frozen-lockfile --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --unsafe-perm
+          new_command_on_retry: rm -rf ~/.cocoapods/ && pnpm clean && pnpm i --frozen-lockfile --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --unsafe-perm && pnpm nx:write-cache-config --cache-key-prefix "${{ steps.setup-caches.outputs.nx-cache-key-prefix }}"
 
       - name: Build iOS app for Detox test run
         uses: LedgerHQ/ledger-live/tools/actions/composites/nx-step@develop
@@ -243,8 +243,8 @@ jobs:
         with:
           max_attempts: 2
           timeout_minutes: 15
-          command: pnpm i --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --unsafe-perm
-          new_command_on_retry: rm -rf ~/.cocoapods/ && pnpm clean && pnpm i --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --unsafe-perm
+          command: pnpm i --frozen-lockfile --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --unsafe-perm
+          new_command_on_retry: rm -rf ~/.cocoapods/ && pnpm clean && pnpm i --frozen-lockfile --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --unsafe-perm
 
       - name: Build JS bundle and minify for size analysis
         uses: LedgerHQ/ledger-live/tools/actions/composites/nx-step@develop

--- a/.github/workflows/test-mobile-e2e-lint-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-lint-reusable.yml
@@ -46,7 +46,7 @@ jobs:
           region: ${{ secrets.AWS_CACHE_REGION }}
 
       - name: Install dependencies
-        run: pnpm i --filter="ledger-live-mobile-e2e-tests..." --no-frozen-lockfile --unsafe-perm
+        run: pnpm i --filter="ledger-live-mobile-e2e-tests..." --frozen-lockfile --unsafe-perm
 
       - name: Run format check
         if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || github.event_name == 'merge_group'

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -676,8 +676,8 @@ jobs:
         with:
           max_attempts: 2
           timeout_minutes: 15
-          command: pnpm i --filter="live-mobile..."  --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --filter="ledger-live-mobile-e2e-tests" --filter="live-cli*..." --no-frozen-lockfile --unsafe-perm --ignore-scripts
-          new_command_on_retry: rm -rf ~/.cocoapods/ && pnpm clean && pnpm i --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --filter="ledger-live-mobile-e2e-tests" --filter="live-cli*..." --no-frozen-lockfile --unsafe-perm --ignore-scripts
+          command: pnpm i --filter="live-mobile..."  --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --filter="ledger-live-mobile-e2e-tests" --filter="live-cli*..." --frozen-lockfile --unsafe-perm --ignore-scripts
+          new_command_on_retry: rm -rf ~/.cocoapods/ && pnpm clean && pnpm i --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --filter="ledger-live-mobile-e2e-tests" --filter="live-cli*..." --frozen-lockfile --unsafe-perm --ignore-scripts
 
       - name: Boot iOS Simulator in Background
         uses: LedgerHQ/ledger-live/tools/actions/composites/boot-ios-simulators-background@develop
@@ -923,7 +923,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pnpm i --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --filter="ledger-live-mobile-e2e-tests" --filter="live-cli*..." --no-frozen-lockfile --unsafe-perm --ignore-scripts
+          pnpm i --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --filter="ledger-live-mobile-e2e-tests" --filter="live-cli*..." --frozen-lockfile --unsafe-perm --ignore-scripts
 
       - name: Detox Post Install
         run: node node_modules/detox/scripts/postinstall.js

--- a/.github/workflows/test-mobile-mock-reusable.yml
+++ b/.github/workflows/test-mobile-mock-reusable.yml
@@ -496,7 +496,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pnpm i --filter="live-mobile..." --filter="ledger-live" --filter="ledger-live-mobile-e2e-tests" --filter="live-cli*..." --filter="@ledgerhq/dummy-*-app..." --unsafe-perm --ignore-scripts
+          pnpm i --frozen-lockfile --filter="live-mobile..." --filter="ledger-live" --filter="ledger-live-mobile-e2e-tests" --filter="live-cli*..." --filter="@ledgerhq/dummy-*-app..." --unsafe-perm --ignore-scripts
 
       - name: Detox Post Install
         run: node apps/ledger-live-mobile/node_modules/detox/scripts/postinstall.js
@@ -727,8 +727,8 @@ jobs:
         with:
           max_attempts: 2
           timeout_minutes: 15
-          command: pnpm i --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --filter="ledger-live-mobile-e2e-tests" --filter="live-cli*..." --no-frozen-lockfile --unsafe-perm --ignore-scripts
-          new_command_on_retry: rm -rf ~/.cocoapods/ && pnpm clean && pnpm i --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --filter="ledger-live-mobile-e2e-tests" --filter="live-cli*..." --no-frozen-lockfile --unsafe-perm --ignore-scripts
+          command: pnpm i --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --filter="ledger-live-mobile-e2e-tests" --filter="live-cli*..." --frozen-lockfile --unsafe-perm --ignore-scripts
+          new_command_on_retry: rm -rf ~/.cocoapods/ && pnpm clean && pnpm i --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --filter="ledger-live-mobile-e2e-tests" --filter="live-cli*..." --frozen-lockfile --unsafe-perm --ignore-scripts
 
       # Warm simulators before Detox; worker_count matches the iOS Simulator … N names in detox.config.js.
       - name: Boot iOS Simulators in Background
@@ -912,7 +912,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pnpm i --filter="live-mobile..." --unsafe-perm --ignore-scripts
+          pnpm i --frozen-lockfile --filter="live-mobile..." --unsafe-perm --ignore-scripts
 
       - name: Test Pod Lockfile
         run: |

--- a/.github/workflows/test-mobile-reusable.yml
+++ b/.github/workflows/test-mobile-reusable.yml
@@ -81,7 +81,7 @@ jobs:
           ruby-version: 3.3.0
 
       - name: Install dependencies
-        run: pnpm i --filter="live-mobile..." --filter="ledger-live" --no-frozen-lockfile --unsafe-perm
+        run: pnpm i --filter="live-mobile..." --filter="ledger-live" --frozen-lockfile --unsafe-perm
 
       - name: Run format check
         if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
@@ -138,7 +138,7 @@ jobs:
           registry: ${{ vars.ARTIFACTORY_URL }}
 
       - name: Install dependencies
-        run: pnpm i --filter="live-mobile..." --filter="ledger-live" --unsafe-perm
+        run: pnpm i --frozen-lockfile --filter="live-mobile..." --filter="ledger-live" --unsafe-perm
 
       - name: Build dependencies
         run: pnpm exec nx run live-mobile:build-lib-deps

--- a/.github/workflows/test-scope-reusable.yml
+++ b/.github/workflows/test-scope-reusable.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Install dependencies
         env:
           SCOPE: ${{ inputs.scope }}
-        run: pnpm i --filter="{./$SCOPE/**}..."
+        run: pnpm i --frozen-lockfile --filter="{./$SCOPE/**}..."
         shell: bash
 
       - name: Run extra targets


### PR DESCRIPTION
Of ~55 pnpm i/pnpm install calls across CI, only one previously passed --frozen-lockfile. The rest either omitted the flag (defaulting to pnpm's mutable behaviour) or explicitly passed --no-frozen-lockfile.

This PR makes every workflow install frozen:

- Replaces --no-frozen-lockfile with --frozen-lockfile in 10 workflows (mobile builds, e2e, sonar, generate-e2e-userdata)
- Adds --frozen-lockfile to all unflagged installs across the remaining 27 workflows (release pipelines, integration/bridge tests, lib tests, desktop, CLI, design system, rsdoctor, boundaries)
- .npmrc is unchanged — this is CI-only

Why it matters: without frozen installs, CI can silently resolve different transitive dependency versions on every run, making builds non-reproducible and leaving a gap for supply-chain drift between what's in pnpm-lock.yaml and what actually gets installed. With this change, any lockfile drift fails fast instead of passing silently.

Test run: https://github.com/LedgerHQ/ledger-live/actions/runs/32496006890