### PR TITLE
[LWM] fix(contacts): show Me name in mobile detail

### DIFF
--- a/.changeset/bright-me-detail.md
+++ b/.changeset/bright-me-detail.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": minor
+---
+
+Fix the mobile Me contact detail name after it is customized

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -539,7 +539,7 @@ describe("Contacts integration", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("contacts-detail-screen")).toBeVisible();
-      expect(screen.getByText("My addresses")).toBeVisible();
+      expect(screen.getByText("Me")).toBeVisible();
       expect(screen.getByTestId("contacts-detail-add-address")).toHaveTextContent(
         "Add your address",
       );

--- a/features/flow/contacts/src/steps/Detail/ContactDetailView.native.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/ContactDetailView.native.test.tsx
@@ -15,7 +15,7 @@ const labels: ContactDetailLabels = {
   emptyMeDescription: "Save external addresses for Me.",
   emptyContactDescription: () => "Save their wallet addresses to send to them by name next time",
   ledgerWalletAddresses: "Ledger Wallet addresses",
-  myAddresses: "My addresses",
+  formatMeDisplayName: name => `${name} (Me)`,
   formatAddressCount: count => `${count} address`,
 };
 
@@ -39,13 +39,19 @@ describe("ContactDetailPage", () => {
     render(<ContactDetailView {...meDetailProps} contact={mockMeContact()} />);
 
     expect(screen.getByTestId("contacts-detail-me-avatar")).toBeVisible();
-    expect(screen.getByText("My addresses")).toBeVisible();
+    expect(screen.getByText("Me")).toBeVisible();
     expect(screen.getByTestId("contacts-detail-add-address")).toHaveTextContent("Add your address");
     expect(screen.getByTestId("contacts-detail-ledger-wallet-addresses")).toHaveTextContent(
       "Ledger Wallet addresses",
     );
     expect(screen.getByText("Save your own addresses")).toBeVisible();
     expect(screen.getByText("Save external addresses for Me.")).toBeVisible();
+  });
+
+  it("should render a custom Me display name with the Me suffix", () => {
+    render(<ContactDetailView {...meDetailProps} contact={mockMeContact({ name: "Maxime" })} />);
+
+    expect(screen.getByText("Maxime (Me)")).toBeVisible();
   });
 
   it("should render a saved contact empty state", () => {

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailHeader.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailHeader.native.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Box, Button, Text } from "@ledgerhq/lumen-ui-rnative";
 import { Plus } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { resolveMeContactDisplayName } from "@features/platform-contacts";
 import type { ContactDetailViewProps } from "../types";
 import { ContactDetailAvatar } from "./ContactDetailAvatar.native";
 
@@ -15,13 +16,18 @@ export function ContactDetailHeader({
   meAvatarSrc,
   onAddAddress,
 }: ContactDetailHeaderProps): React.JSX.Element {
+  const displayName = resolveMeContactDisplayName(
+    contact,
+    labels.formatMeDisplayName ?? (name => name),
+  );
+
   return (
     <Box lx={{ alignItems: "center", gap: "s24", paddingTop: "s24" }}>
       <Box lx={{ alignItems: "center", gap: "s16" }}>
         <ContactDetailAvatar contact={contact} meAvatarSrc={meAvatarSrc} />
         <Box lx={{ alignItems: "center", gap: "s4" }}>
           <Text typography="heading3SemiBold" lx={{ color: "base" }}>
-            {contact.isMe ? (labels.myAddresses ?? contact.name) : contact.name}
+            {displayName}
           </Text>
           <Text typography="body2" lx={{ color: "muted" }}>
             {labels.formatAddressCount(contact.addresses.length)}


### PR DESCRIPTION
### ✅ Checklist

- [x] A changeset is attached.
- [x] **Covered by automatic tests.** The Native Contact Detail Flow test covers both the default Me title and a customized name with the (Me) suffix.
- [x] **Impact of the changes:**
      Mobile Contacts → Contact Detail → self-contact header, including customized self-contact names.

### 📝 Description

The mobile self-contact detail header displayed the generic “My addresses” label, while the contact list displayed “Me”. A customized self-contact name was therefore not reflected in the detail view.

The Native Contacts Flow now uses the shared self-contact display-name resolver already used on Web. It displays “Me” for the default contact name and “Custom name (Me)” after the contact is renamed. The targeted Flow test, formatting, and TypeScript checks pass. The Mobile integration suite is currently blocked before test execution by an existing Ledger Auth initialization error (codeChallengeMethod.replace).

| Before                        | After                         |
|-------------------------------|-------------------------------|
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-35859

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
