### PR TITLE
fix(contacts): prevent short address list bounce (LIVE-35858)

### DIFF
--- a/.changeset/tame-address-bounce.md
+++ b/.changeset/tame-address-bounce.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": minor
+---
+
+Prevent address lists from bouncing when their content fits on screen.

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailAddressList/ContactDetailAddressList.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailAddressList/ContactDetailAddressList.native.tsx
@@ -16,6 +16,7 @@ export function ContactDetailAddressList({
   return (
     <ScrollView
       testID="contacts-detail-address-list"
+      alwaysBounceVertical={false}
       contentContainerStyle={{ flexGrow: 1 }}
       showsVerticalScrollIndicator={false}
     >


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** The native Contacts detail test verifies the list disables vertical bounce.
- [x] **Impact of the changes:**
      Confirm a contact with one saved address does not move on a vertical swipe; confirm longer address lists still scroll.

### 📝 Description

A populated Contacts detail screen could vertically bounce even when it contained only one address.

The native address list now disables `alwaysBounceVertical`, preserving normal scrolling when content exceeds the available space. A focused native regression test covers the property.

<img width="350" height="750" alt="Simulator Screenshot - iOS Simulator - 2026-08-21 at 14 40 34" src="https://github.com/user-attachments/assets/908fc6f6-ea95-4643-a39d-371d8da5c7d2" />

https://github.com/user-attachments/assets/edf4fb87-bc42-462a-94dd-fbb7e1676744



### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-35858

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)