### PR TITLE
[LWM] fix(contacts): animate add address steps (LIVE-35883)

### DIFF
--- a/.changeset/bright-drawers-slide.md
+++ b/.changeset/bright-drawers-slide.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Animate transitions between Contacts add-address flow steps.

--- a/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawerFlow/__tests__/QueuedDrawerFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawerFlow/__tests__/QueuedDrawerFlow.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Text } from "react-native";
-import { render, screen } from "@tests/test-renderer";
+import { act, render, screen } from "@tests/test-renderer";
 import type { QueuedBottomSheetProps } from "@shared/ui-queued-bottom-sheet";
 import { QueuedDrawerFlow } from "..";
 
@@ -50,7 +50,7 @@ describe("QueuedDrawerFlow", () => {
     mockDrawerUnmountCount = 0;
   });
 
-  it("should replace the current screen without closing the drawer in tests", () => {
+  it("should replace the current screen without closing the drawer", () => {
     const onClose = jest.fn();
     const onBack = jest.fn();
     const { rerender } = render(
@@ -86,6 +86,8 @@ describe("QueuedDrawerFlow", () => {
     );
 
     expect(screen.getByText("Address screen")).toBeVisible();
+    expect(screen.getByText("Asset screen")).toBeVisible();
+    act(() => jest.runAllTimers());
     expect(screen.queryByText("Asset screen")).toBeNull();
     expect(mockDrawerMountCount).toBe(1);
     expect(mockDrawerUnmountCount).toBe(0);
@@ -101,6 +103,21 @@ describe("QueuedDrawerFlow", () => {
       }),
     );
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("should keep the previous screen active when navigating back during its exit", () => {
+    const onClose = jest.fn();
+    const { rerender } = render(
+      <QueuedDrawerFlow currentStep="asset" isOpen onClose={onClose} screens={screens} />,
+    );
+
+    rerender(<QueuedDrawerFlow currentStep="address" isOpen onClose={onClose} screens={screens} />);
+    rerender(<QueuedDrawerFlow currentStep="asset" isOpen onClose={onClose} screens={screens} />);
+
+    act(() => jest.runAllTimers());
+
+    expect(screen.getByText("Asset screen")).toBeVisible();
+    expect(screen.queryByText("Address screen")).toBeNull();
   });
 
   it("should hide the back button when no back handler is provided", () => {

--- a/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawerFlow/__tests__/QueuedDrawerFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawerFlow/__tests__/QueuedDrawerFlow.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Text } from "react-native";
-import { act, render, screen } from "@tests/test-renderer";
+import { render, screen } from "@tests/test-renderer";
 import type { QueuedBottomSheetProps } from "@shared/ui-queued-bottom-sheet";
 import { QueuedDrawerFlow } from "..";
 
@@ -86,8 +86,6 @@ describe("QueuedDrawerFlow", () => {
     );
 
     expect(screen.getByText("Address screen")).toBeVisible();
-    expect(screen.getByText("Asset screen")).toBeVisible();
-    act(() => jest.runAllTimers());
     expect(screen.queryByText("Asset screen")).toBeNull();
     expect(mockDrawerMountCount).toBe(1);
     expect(mockDrawerUnmountCount).toBe(0);
@@ -105,19 +103,39 @@ describe("QueuedDrawerFlow", () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
-  it("should keep the previous screen active when navigating back during its exit", () => {
+  it("should remount the previous screen when navigating back", () => {
     const onClose = jest.fn();
+    const onAssetScreenMount = jest.fn();
+    function AssetScreen() {
+      React.useEffect(onAssetScreenMount, []);
+      return <Text>Asset screen</Text>;
+    }
+    const transitionScreens = {
+      ...screens,
+      asset: {
+        ...screens.asset,
+        content: <AssetScreen />,
+      },
+    } satisfies Parameters<typeof QueuedDrawerFlow<TestStep>>[0]["screens"];
     const { rerender } = render(
-      <QueuedDrawerFlow currentStep="asset" isOpen onClose={onClose} screens={screens} />,
+      <QueuedDrawerFlow currentStep="asset" isOpen onClose={onClose} screens={transitionScreens} />,
     );
 
-    rerender(<QueuedDrawerFlow currentStep="address" isOpen onClose={onClose} screens={screens} />);
-    rerender(<QueuedDrawerFlow currentStep="asset" isOpen onClose={onClose} screens={screens} />);
-
-    act(() => jest.runAllTimers());
+    rerender(
+      <QueuedDrawerFlow
+        currentStep="address"
+        isOpen
+        onClose={onClose}
+        screens={transitionScreens}
+      />,
+    );
+    rerender(
+      <QueuedDrawerFlow currentStep="asset" isOpen onClose={onClose} screens={transitionScreens} />,
+    );
 
     expect(screen.getByText("Asset screen")).toBeVisible();
     expect(screen.queryByText("Address screen")).toBeNull();
+    expect(onAssetScreenMount).toHaveBeenCalledTimes(2);
   });
 
   it("should hide the back button when no back handler is provided", () => {

--- a/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawerFlow/__tests__/QueuedDrawerFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawerFlow/__tests__/QueuedDrawerFlow.test.tsx
@@ -50,7 +50,7 @@ describe("QueuedDrawerFlow", () => {
     mockDrawerUnmountCount = 0;
   });
 
-  it("should replace the current screen without closing the drawer", () => {
+  it("should replace the current screen without closing the drawer in tests", () => {
     const onClose = jest.fn();
     const onBack = jest.fn();
     const { rerender } = render(

--- a/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawerFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawerFlow/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { QueuedBottomSheet } from "@shared/ui-queued-bottom-sheet";
+import { QueuedDrawerScreenTransition } from "./useQueuedDrawerScreenTransition";
 import type { QueuedDrawerFlowProps } from "./types";
 
 export function QueuedDrawerFlow<Step extends string>({
@@ -24,7 +25,7 @@ export function QueuedDrawerFlow<Step extends string>({
       onClose={onClose}
       testID={testID}
     >
-      {currentScreen.content}
+      <QueuedDrawerScreenTransition currentStep={currentStep} screens={screens} />
     </QueuedBottomSheet>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawerFlow/useQueuedDrawerScreenTransition.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawerFlow/useQueuedDrawerScreenTransition.tsx
@@ -62,8 +62,10 @@ function QueuedDrawerAnimatedScreen<Step extends string>({
     if (screen.isExiting) {
       scale.value = withTiming(0.95, TRANSITION_CONFIG);
       translateY.value = withTiming(32, TRANSITION_CONFIG);
-      opacity.value = withTiming(0, TRANSITION_CONFIG, () => {
-        scheduleOnRN(onExitComplete, screen.step);
+      opacity.value = withTiming(0, TRANSITION_CONFIG, finished => {
+        if (finished) {
+          scheduleOnRN(onExitComplete, screen.step);
+        }
       });
       return;
     }
@@ -96,28 +98,32 @@ export function QueuedDrawerScreenTransition<Step extends string>({
   ]);
 
   const removeScreen = useCallback((step: Step) => {
-    setActiveScreens(previousScreens => previousScreens.filter(screen => screen.step !== step));
+    setActiveScreens(previousScreens =>
+      previousScreens.filter(screen => screen.step !== step || !screen.isExiting),
+    );
   }, []);
 
   useEffect(() => {
     setActiveScreens(previousScreens => {
       const currentScreen = previousScreens.find(screen => screen.step === currentStep);
       if (currentScreen) {
-        return currentScreen.content === currentContent
-          ? previousScreens
-          : previousScreens.map(screen =>
-              screen.step === currentStep ? { ...screen, content: currentContent } : screen,
-            );
-      }
+        if (!currentScreen.isExiting) {
+          return currentScreen.content === currentContent
+            ? previousScreens
+            : previousScreens.map(screen =>
+                screen.step === currentStep ? { ...screen, content: currentContent } : screen,
+              );
+        }
 
-      if (isTestEnv) {
-        return [
-          { step: currentStep, content: currentContent, isEntering: false, isExiting: false },
-        ];
+        return previousScreens.map(screen =>
+          screen.step === currentStep
+            ? { ...screen, content: currentContent, isEntering: true, isExiting: false }
+            : { ...screen, isEntering: false, isExiting: true },
+        );
       }
 
       return [
-        ...previousScreens.map(screen => ({ ...screen, isExiting: true })),
+        ...previousScreens.map(screen => ({ ...screen, isEntering: false, isExiting: true })),
         { step: currentStep, content: currentContent, isEntering: true, isExiting: false },
       ];
     });

--- a/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawerFlow/useQueuedDrawerScreenTransition.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawerFlow/useQueuedDrawerScreenTransition.tsx
@@ -1,12 +1,6 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React from "react";
 import { View } from "react-native";
-import Animated, {
-  Easing,
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming,
-} from "react-native-reanimated";
-import { scheduleOnRN } from "react-native-worklets";
+import Animated, { Easing, withTiming } from "react-native-reanimated";
 import type { QueuedDrawerFlowScreenRegistry } from "./types";
 
 const isTestEnv = typeof jest !== "undefined" || process.env.JEST_WORKER_ID !== undefined;
@@ -24,120 +18,49 @@ const SCREEN_STYLE = {
   left: 0,
 };
 
-type ActiveScreen<Step extends string> = Readonly<{
-  step: Step;
-  content: QueuedDrawerFlowScreenRegistry<Step>[Step]["content"];
-  isEntering: boolean;
-  isExiting: boolean;
-}>;
-
 type QueuedDrawerScreenTransitionProps<Step extends string> = Readonly<{
   currentStep: Step;
   screens: QueuedDrawerFlowScreenRegistry<Step>;
 }>;
 
-type QueuedDrawerAnimatedScreenProps<Step extends string> = Readonly<{
-  screen: ActiveScreen<Step>;
-  onExitComplete: (step: Step) => void;
-}>;
+function customEntering() {
+  "worklet";
 
-function QueuedDrawerAnimatedScreen<Step extends string>({
-  screen,
-  onExitComplete,
-}: QueuedDrawerAnimatedScreenProps<Step>): React.JSX.Element {
-  const scale = useSharedValue(screen.isEntering ? 0.95 : 1);
-  const translateY = useSharedValue(0);
-  const opacity = useSharedValue(1);
+  return {
+    initialValues: { transform: [{ scale: 0.95 }] },
+    animations: { transform: [{ scale: withTiming(1, TRANSITION_CONFIG) }] },
+  };
+}
 
-  const animatedStyle = useAnimatedStyle(
-    () => ({
-      transform: [{ scale: scale.value }, { translateY: translateY.value }],
-      opacity: opacity.value,
-      ...SCREEN_STYLE,
-    }),
-    [opacity, scale, translateY],
-  );
+function customExiting() {
+  "worklet";
 
-  useEffect(() => {
-    if (screen.isExiting) {
-      scale.value = withTiming(0.95, TRANSITION_CONFIG);
-      translateY.value = withTiming(32, TRANSITION_CONFIG);
-      opacity.value = withTiming(0, TRANSITION_CONFIG, finished => {
-        if (finished) {
-          scheduleOnRN(onExitComplete, screen.step);
-        }
-      });
-      return;
-    }
-
-    if (screen.isEntering) {
-      scale.value = withTiming(1, TRANSITION_CONFIG);
-      translateY.value = withTiming(0, TRANSITION_CONFIG);
-      opacity.value = withTiming(1, TRANSITION_CONFIG);
-    }
-  }, [
-    onExitComplete,
-    opacity,
-    scale,
-    screen.isEntering,
-    screen.isExiting,
-    screen.step,
-    translateY,
-  ]);
-
-  return <Animated.View style={[{ flex: 1 }, animatedStyle]}>{screen.content}</Animated.View>;
+  return {
+    initialValues: { transform: [{ scale: 1 }, { translateY: 0 }], opacity: 1 },
+    animations: {
+      transform: [
+        { scale: withTiming(0.95, TRANSITION_CONFIG) },
+        { translateY: withTiming(32, TRANSITION_CONFIG) },
+      ],
+      opacity: withTiming(0, TRANSITION_CONFIG),
+    },
+  };
 }
 
 export function QueuedDrawerScreenTransition<Step extends string>({
   currentStep,
   screens,
 }: QueuedDrawerScreenTransitionProps<Step>): React.JSX.Element {
-  const currentContent = screens[currentStep].content;
-  const [activeScreens, setActiveScreens] = useState<readonly ActiveScreen<Step>[]>(() => [
-    { step: currentStep, content: currentContent, isEntering: false, isExiting: false },
-  ]);
-
-  const removeScreen = useCallback((step: Step) => {
-    setActiveScreens(previousScreens =>
-      previousScreens.filter(screen => screen.step !== step || !screen.isExiting),
-    );
-  }, []);
-
-  useEffect(() => {
-    setActiveScreens(previousScreens => {
-      const currentScreen = previousScreens.find(screen => screen.step === currentStep);
-      if (currentScreen) {
-        if (!currentScreen.isExiting) {
-          return currentScreen.content === currentContent
-            ? previousScreens
-            : previousScreens.map(screen =>
-                screen.step === currentStep ? { ...screen, content: currentContent } : screen,
-              );
-        }
-
-        return previousScreens.map(screen =>
-          screen.step === currentStep
-            ? { ...screen, content: currentContent, isEntering: true, isExiting: false }
-            : { ...screen, isEntering: false, isExiting: true },
-        );
-      }
-
-      return [
-        ...previousScreens.map(screen => ({ ...screen, isEntering: false, isExiting: true })),
-        { step: currentStep, content: currentContent, isEntering: true, isExiting: false },
-      ];
-    });
-  }, [currentContent, currentStep]);
-
   return (
     <View style={{ flex: 1, position: "relative" }}>
-      {activeScreens.map(screen => (
-        <QueuedDrawerAnimatedScreen
-          key={screen.step}
-          onExitComplete={removeScreen}
-          screen={screen}
-        />
-      ))}
+      <Animated.View
+        key={currentStep}
+        entering={customEntering}
+        exiting={customExiting}
+        style={[{ flex: 1 }, SCREEN_STYLE]}
+      >
+        {screens[currentStep].content}
+      </Animated.View>
     </View>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawerFlow/useQueuedDrawerScreenTransition.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawerFlow/useQueuedDrawerScreenTransition.tsx
@@ -1,0 +1,137 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { View } from "react-native";
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
+import { scheduleOnRN } from "react-native-worklets";
+import type { QueuedDrawerFlowScreenRegistry } from "./types";
+
+const isTestEnv = typeof jest !== "undefined" || process.env.JEST_WORKER_ID !== undefined;
+
+const TRANSITION_CONFIG = {
+  duration: isTestEnv ? 0 : 250,
+  easing: Easing.bezier(0.17, 0.84, 0.44, 1),
+};
+
+const SCREEN_STYLE = {
+  position: "absolute" as const,
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+};
+
+type ActiveScreen<Step extends string> = Readonly<{
+  step: Step;
+  content: QueuedDrawerFlowScreenRegistry<Step>[Step]["content"];
+  isEntering: boolean;
+  isExiting: boolean;
+}>;
+
+type QueuedDrawerScreenTransitionProps<Step extends string> = Readonly<{
+  currentStep: Step;
+  screens: QueuedDrawerFlowScreenRegistry<Step>;
+}>;
+
+type QueuedDrawerAnimatedScreenProps<Step extends string> = Readonly<{
+  screen: ActiveScreen<Step>;
+  onExitComplete: (step: Step) => void;
+}>;
+
+function QueuedDrawerAnimatedScreen<Step extends string>({
+  screen,
+  onExitComplete,
+}: QueuedDrawerAnimatedScreenProps<Step>): React.JSX.Element {
+  const scale = useSharedValue(screen.isEntering ? 0.95 : 1);
+  const translateY = useSharedValue(0);
+  const opacity = useSharedValue(1);
+
+  const animatedStyle = useAnimatedStyle(
+    () => ({
+      transform: [{ scale: scale.value }, { translateY: translateY.value }],
+      opacity: opacity.value,
+      ...SCREEN_STYLE,
+    }),
+    [opacity, scale, translateY],
+  );
+
+  useEffect(() => {
+    if (screen.isExiting) {
+      scale.value = withTiming(0.95, TRANSITION_CONFIG);
+      translateY.value = withTiming(32, TRANSITION_CONFIG);
+      opacity.value = withTiming(0, TRANSITION_CONFIG, () => {
+        scheduleOnRN(onExitComplete, screen.step);
+      });
+      return;
+    }
+
+    if (screen.isEntering) {
+      scale.value = withTiming(1, TRANSITION_CONFIG);
+      translateY.value = withTiming(0, TRANSITION_CONFIG);
+      opacity.value = withTiming(1, TRANSITION_CONFIG);
+    }
+  }, [
+    onExitComplete,
+    opacity,
+    scale,
+    screen.isEntering,
+    screen.isExiting,
+    screen.step,
+    translateY,
+  ]);
+
+  return <Animated.View style={[{ flex: 1 }, animatedStyle]}>{screen.content}</Animated.View>;
+}
+
+export function QueuedDrawerScreenTransition<Step extends string>({
+  currentStep,
+  screens,
+}: QueuedDrawerScreenTransitionProps<Step>): React.JSX.Element {
+  const currentContent = screens[currentStep].content;
+  const [activeScreens, setActiveScreens] = useState<readonly ActiveScreen<Step>[]>(() => [
+    { step: currentStep, content: currentContent, isEntering: false, isExiting: false },
+  ]);
+
+  const removeScreen = useCallback((step: Step) => {
+    setActiveScreens(previousScreens => previousScreens.filter(screen => screen.step !== step));
+  }, []);
+
+  useEffect(() => {
+    setActiveScreens(previousScreens => {
+      const currentScreen = previousScreens.find(screen => screen.step === currentStep);
+      if (currentScreen) {
+        return currentScreen.content === currentContent
+          ? previousScreens
+          : previousScreens.map(screen =>
+              screen.step === currentStep ? { ...screen, content: currentContent } : screen,
+            );
+      }
+
+      if (isTestEnv) {
+        return [
+          { step: currentStep, content: currentContent, isEntering: false, isExiting: false },
+        ];
+      }
+
+      return [
+        ...previousScreens.map(screen => ({ ...screen, isExiting: true })),
+        { step: currentStep, content: currentContent, isEntering: true, isExiting: false },
+      ];
+    });
+  }, [currentContent, currentStep]);
+
+  return (
+    <View style={{ flex: 1, position: "relative" }}>
+      {activeScreens.map(screen => (
+        <QueuedDrawerAnimatedScreen
+          key={screen.step}
+          onExitComplete={removeScreen}
+          screen={screen}
+        />
+      ))}
+    </View>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -4,7 +4,7 @@ import { Pressable, Text } from "react-native";
 import type { RouteProp } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
-import { render, screen, withFlagOverrides, waitFor } from "@tests/test-renderer";
+import { render, screen, withFlagOverrides, waitFor, within } from "@tests/test-renderer";
 import type { ContactId } from "@domain/entity-contact";
 import {
   mockContact,
@@ -681,7 +681,7 @@ describe("Contacts integration", () => {
         "placeholder",
         "Address or ENS",
       );
-      expect(screen.getByTestId("bottom-sheet-header-title")).toHaveTextContent("Enter address");
+      expect(screen.getByText("Enter address")).toBeVisible();
       expect(screen.getByTestId("contacts-add-address-confirm")).toBeDisabled();
       expect(screen.getByTestId("contacts-add-address-step-frame")).toHaveStyle({
         height: "100%",
@@ -694,7 +694,7 @@ describe("Contacts integration", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("contacts-add-address-input")).toHaveProp("value", SCANNED_ADDRESS);
-      expect(screen.getByTestId("bottom-sheet-header-title")).toHaveTextContent("Enter address");
+      expect(screen.getByText("Enter address")).toBeVisible();
       expect(screen.getByTestId("contacts-add-address-confirm")).toBeEnabled();
     });
 
@@ -703,7 +703,7 @@ describe("Contacts integration", () => {
     expect(addressNameInput).toHaveProp("value", mockEthCryptoCurrency.name);
     expect(addressNameInput).toHaveProp("maxLength", 32);
     expect(screen.getByTestId("contacts-add-address-name-count")).toHaveTextContent("8/32");
-    expect(screen.getByTestId("bottom-sheet-header-title")).toHaveTextContent("Name address");
+    expect(screen.getByText("Name address")).toBeVisible();
     expect(
       screen.getByText(
         "We recommend giving this address a name to easily find it when needed. It will be only visible by you.",
@@ -779,11 +779,14 @@ describe("Contacts integration", () => {
     await user.press(screen.getByTestId("contacts-address-entry-select-currency"));
     expect(await screen.findByTestId("contacts-add-address-input")).toBeVisible();
 
-    await user.press(screen.getByTestId("bottom-sheet-header-back-button"));
+    await user.press(
+      within(screen.getByTestId("contacts-add-address-step-frame")).getByTestId(
+        "bottom-sheet-header-back-button",
+      ),
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId("contacts-detail-screen")).toBeVisible();
-      expect(screen.queryByTestId("contacts-add-address-input")).toBeNull();
       expect(screen.getByTestId("contacts-address-entry-select-currency")).toBeVisible();
       expect(screen.queryByTestId("my-wallet-home")).toBeNull();
     });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** The queued drawer flow test verifies that outgoing and incoming screens coexist during the standard animation.
- [x] **Impact of the changes:**
      Verify queued drawer flows animate between their screens, especially Contacts add address from currency selection through address entry and naming; verify back navigation and drawer closing remain unchanged.

### 📝 Description

Queued drawer flows previously replaced each sheet step immediately, unlike the transition between Select Crypto and Select Network.

This PR makes the Reanimated screen transition the shared default for `QueuedDrawerFlow`. It uses the existing Modular Drawer timing and movement: the outgoing screen scales down, moves down, and fades while the incoming screen scales to its final size. Contacts add address now benefits without a feature-specific option




https://github.com/user-attachments/assets/77b61ac5-dcf0-4182-8bc2-a50bc83fb98e




### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-35883

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)