### PR TITLE
[LWDM] fix(contacts): defer device connection for contact editing (LIVE-35851)

### DIFF
--- a/.changeset/LIVE-35851-contacts-signer-after-save.md
+++ b/.changeset/LIVE-35851-contacts-signer-after-save.md
@@ -1,0 +1,7 @@
+---
+"@features/flow-contacts": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Fix Contacts edit flow so the device connection prompt appears after saving a contact name or address, not before opening the edit form.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -905,18 +905,32 @@ describe("Contacts integration", () => {
     });
   });
 
-  it("should open the signer dialog before renaming a contact with addresses", async () => {
+  it("should ask for the signer only after saving a contact with addresses", async () => {
     const { user } = renderContactsScreen(populatedContactsPageState);
 
     await user.click(screen.getByTestId("contacts-saved-row-contact-ben"));
     await user.click(screen.getByTestId("contacts-detail-edit-action"));
 
-    expect(screen.getByTestId("contacts-edit-signer-dialog")).toBeVisible();
-    expect(screen.queryByTestId("contacts-rename-contact-dialog")).not.toBeInTheDocument();
+    expect(screen.getByTestId("contacts-rename-contact-dialog")).toBeVisible();
+    expect(screen.queryByTestId("contacts-edit-signer-dialog")).not.toBeInTheDocument();
+
+    const nameInput = screen.getByTestId("contacts-rename-contact-name-input");
+    await user.clear(nameInput);
+    await user.type(nameInput, "Benjamin");
+    await user.click(screen.getByTestId("contacts-rename-contact-confirm"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts-edit-signer-dialog")).toBeVisible();
+    });
+    expect(screen.getByTestId("contacts-saved-row-contact-ben")).toHaveTextContent("Ben");
 
     await user.click(screen.getByTestId("contacts-edit-signer-confirm"));
 
-    expect(screen.getByTestId("contacts-rename-contact-dialog")).toBeVisible();
+    await waitFor(() => {
+      expect(screen.queryByTestId("contacts-edit-signer-dialog")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("contacts-rename-contact-dialog")).not.toBeInTheDocument();
+      expect(screen.getByTestId("contacts-saved-row-contact-ben")).toHaveTextContent("Benjamin");
+    });
   });
 
   it("should delete a saved contact and return to the Me detail pane", async () => {
@@ -987,7 +1001,7 @@ describe("Contacts integration", () => {
     expect(screen.getByTestId("contacts-detail-address-row-address-polygon")).toBeInTheDocument();
   });
 
-  it("should open the rename address dialog after signer confirmation", async () => {
+  it("should open the rename address dialog without asking for the signer first", async () => {
     const { user } = renderContactsScreen(populatedContactsPageState);
 
     await user.click(screen.getByTestId("contacts-saved-row-contact-ben"));
@@ -997,14 +1011,7 @@ describe("Contacts integration", () => {
 
     await waitFor(() => {
       expect(screen.queryByTestId("contacts-address-detail-dialog")).not.toBeInTheDocument();
-      expect(screen.getByTestId("contacts-edit-signer-dialog")).toBeVisible();
-    });
-
-    await user.click(screen.getByTestId("contacts-edit-signer-confirm"));
-
-    await waitFor(() => {
       expect(screen.queryByTestId("contacts-edit-signer-dialog")).not.toBeInTheDocument();
-      expect(screen.queryByTestId("contacts-address-detail-dialog")).not.toBeInTheDocument();
       expect(screen.getByTestId("contacts-rename-address-dialog")).toBeVisible();
       expect(screen.getByTestId("contacts-edit-address-input")).toHaveValue(
         "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
@@ -1019,7 +1026,6 @@ describe("Contacts integration", () => {
     await user.click(screen.getByTestId("contacts-detail-address-row-address-ethereum"));
 
     await user.click(screen.getByTestId("contacts-address-detail-edit"));
-    await user.click(screen.getByTestId("contacts-edit-signer-confirm"));
 
     await waitFor(() => {
       expect(screen.getByTestId("contacts-rename-address-dialog")).toBeVisible();
@@ -1029,6 +1035,12 @@ describe("Contacts integration", () => {
       target: { value: "Main ETH" },
     });
     await user.click(screen.getByTestId("contacts-rename-address-confirm"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts-edit-signer-dialog")).toBeVisible();
+    });
+
+    await user.click(screen.getByTestId("contacts-edit-signer-confirm"));
 
     await waitFor(() => {
       expect(screen.queryByTestId("contacts-rename-address-dialog")).not.toBeInTheDocument();
@@ -1047,7 +1059,6 @@ describe("Contacts integration", () => {
     await user.click(screen.getByTestId("contacts-detail-address-row-address-ethereum"));
 
     await user.click(screen.getByTestId("contacts-address-detail-edit"));
-    await user.click(screen.getByTestId("contacts-edit-signer-confirm"));
 
     await waitFor(() => {
       expect(screen.getByTestId("contacts-rename-address-dialog")).toBeVisible();
@@ -1062,6 +1073,12 @@ describe("Contacts integration", () => {
     });
 
     await user.click(screen.getByTestId("contacts-rename-address-confirm"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts-edit-signer-dialog")).toBeVisible();
+    });
+
+    await user.click(screen.getByTestId("contacts-edit-signer-confirm"));
 
     await waitFor(() => {
       expect(screen.queryByTestId("contacts-rename-address-dialog")).not.toBeInTheDocument();

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.signerMismatch.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.signerMismatch.integration.test.tsx
@@ -69,6 +69,15 @@ describe("Contacts signer mismatch integration", () => {
     await user.click(screen.getByTestId("contacts-detail-address-row-address-ethereum"));
     await user.click(screen.getByTestId("contacts-address-detail-edit"));
 
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts-rename-address-dialog")).toBeVisible();
+    });
+
+    const labelInput = screen.getByTestId("contacts-rename-address-input");
+    await user.clear(labelInput);
+    await user.type(labelInput, "Main ETH");
+    await user.click(screen.getByTestId("contacts-rename-address-confirm"));
+
     await expectSignerMismatchDialog(user);
   });
 
@@ -78,6 +87,42 @@ describe("Contacts signer mismatch integration", () => {
     await user.click(screen.getByTestId("contacts-saved-row-contact-ben"));
     await user.click(screen.getByTestId("contacts-detail-edit-action"));
 
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts-rename-contact-dialog")).toBeVisible();
+    });
+
+    const nameInput = screen.getByTestId("contacts-rename-contact-name-input");
+    await user.clear(nameInput);
+    await user.type(nameInput, "Benjamin");
+    await user.click(screen.getByTestId("contacts-rename-contact-confirm"));
+
     await expectSignerMismatchDialog(user);
+  });
+
+  it("should return to the edit dialog with the draft intact when the mismatch is cancelled", async () => {
+    const { user } = renderContactsScreen({ contacts: { contacts: mockPopulatedContacts() } });
+
+    await user.click(screen.getByTestId("contacts-saved-row-contact-ben"));
+    await user.click(screen.getByTestId("contacts-detail-edit-action"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts-rename-contact-dialog")).toBeVisible();
+    });
+
+    const nameInput = screen.getByTestId("contacts-rename-contact-name-input");
+    await user.clear(nameInput);
+    await user.type(nameInput, "Benjamin");
+    await user.click(screen.getByTestId("contacts-rename-contact-confirm"));
+
+    await expectSignerMismatchDialog(user);
+
+    await user.click(screen.getByTestId("contacts-edit-signer-mismatch-cancel"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("contacts-edit-signer-mismatch-dialog")).not.toBeInTheDocument();
+      expect(screen.getByTestId("contacts-rename-contact-dialog")).toBeVisible();
+      expect(screen.getByTestId("contacts-rename-contact-name-input")).toHaveValue("Benjamin");
+    });
+    expect(screen.getByTestId("contacts-saved-row-contact-ben")).toHaveTextContent("Ben");
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactAddressDetailActionsAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactAddressDetailActionsAdapter.ts
@@ -9,7 +9,6 @@ import {
   type ContactAddressDetailSendIntent,
   CONTACTS_EVENT_SOURCE,
   CONTACTS_FLOW,
-  CONTACTS_PAGE_EVENTS,
   CONTACTS_PAGE_PROPERTY,
   CONTACTS_TRACK_EVENTS,
   CONTACTS_TRACKING_BUTTON,
@@ -17,11 +16,12 @@ import {
   createInactiveContactAddressDetailActionsUiState,
   resolveContactAddressDetailActionsLabels,
   useContactAddressDetailActionsFlowBindings,
+  useContactAddressEditAnalytics,
   useContactsAddressDetailActionsPorts,
   trackContactAddressDetailQuickAction,
   type ContactAddressEditSavePayload,
 } from "@features/flow-contacts";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useOpenSendFlow } from "LLD/features/Send/hooks/useOpenSendFlow";
 import { useContactsAnalytics, resolveContactsCurrencyAnalytics } from "../../analytics";
@@ -64,8 +64,6 @@ export function useContactAddressDetailActionsAdapter(
   const ports = useContactsAddressDetailActionsPorts();
   const addressValidation = useContactsAddressValidationAdapter();
   const openSendFlow = useOpenSendFlow();
-  const hasTrackedEditAddressPage = useRef(false);
-  const hasTrackedSignerMismatch = useRef(false);
   const isSelectionActive = contactId !== undefined && addressId !== undefined;
   const labels = useMemo(() => resolveContactAddressDetailActionsLabels({ t }), [t]);
   const trackQuickAction = useCallback(
@@ -143,39 +141,13 @@ export function useContactAddressDetailActionsAdapter(
     await renameViewModel.onConfirm();
   }, [analytics, asset, network, renameViewModel]);
 
-  useEffect(() => {
-    if (!renameViewModel.isOpen) {
-      hasTrackedEditAddressPage.current = false;
-      return;
-    }
-
-    if (hasTrackedEditAddressPage.current || asset === undefined || network === undefined) {
-      return;
-    }
-
-    hasTrackedEditAddressPage.current = true;
-    analytics.trackPage(CONTACTS_PAGE_EVENTS.EDIT_ADDRESS, {
-      source: CONTACTS_EVENT_SOURCE.EDIT_ADDRESS,
-      network,
-      asset,
-    });
-  }, [analytics, asset, network, renameViewModel.isOpen]);
-
-  useEffect(() => {
-    if (flow.editUiState === "signer-mismatch" && !hasTrackedSignerMismatch.current) {
-      hasTrackedSignerMismatch.current = true;
-      analytics.trackEvent(CONTACTS_TRACK_EVENTS.ERROR_DISPLAYED, {
-        source: CONTACTS_EVENT_SOURCE.EDIT_ADDRESS,
-        page: CONTACTS_PAGE_PROPERTY.EDIT_ADDRESS,
-        errorType: "signer_mismatch",
-      });
-      return;
-    }
-
-    if (flow.editUiState !== "signer-mismatch") {
-      hasTrackedSignerMismatch.current = false;
-    }
-  }, [analytics, flow.editUiState]);
+  useContactAddressEditAnalytics(analytics, {
+    isEditSessionActive: flow.isEditSessionActive,
+    isRenameOpen: renameViewModel.isOpen,
+    isSignerMismatchOpen: flow.editUiState === "signer-mismatch",
+    asset,
+    network,
+  });
 
   if (!isSelectionActive) {
     return mapUiStateToDialogProps(createInactiveContactAddressDetailActionsUiState(labels));

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -1035,7 +1035,7 @@ describe("Contacts integration", () => {
     });
   });
 
-  it("should open the signer sheet before editing an address", async () => {
+  it("should open the edit address sheet without asking for the signer first", async () => {
     const { user } = render(<MyWalletNavigator />, {
       overrideInitialState: withContactsPageReadyState(
         { lwmContacts: { enabled: true, params: { newBadge: false } } },
@@ -1047,11 +1047,6 @@ describe("Contacts integration", () => {
     await user.press(await screen.findByTestId("contacts-saved-contact-contact-ben"));
     await user.press(await screen.findByTestId("contacts-detail-address-row-address-ethereum"));
     await user.press(await screen.findByText("Edit"));
-
-    expect(await screen.findByTestId("contacts-edit-signer-confirm")).toBeVisible();
-    expect(screen.getByText("Confirm on your device")).toBeVisible();
-
-    await user.press(screen.getByTestId("contacts-edit-signer-confirm"));
 
     await waitFor(() => {
       expect(screen.queryByTestId("contacts-edit-signer-confirm")).toBeNull();
@@ -1075,13 +1070,18 @@ describe("Contacts integration", () => {
     await user.press(await screen.findByTestId("contacts-saved-contact-contact-ben"));
     await user.press(await screen.findByTestId("contacts-detail-address-row-address-ethereum"));
     await user.press(await screen.findByText("Edit"));
-    await user.press(await screen.findByTestId("contacts-edit-signer-confirm"));
     const renameInput = await screen.findByDisplayValue("Ethereum");
     await user.clear(renameInput);
     await user.type(renameInput, "Exchange wallet");
     await user.press(screen.getByTestId("contacts-rename-address-confirm"));
 
+    expect(await screen.findByTestId("contacts-edit-signer-confirm")).toBeVisible();
+    expect(screen.getByText("Confirm on your device")).toBeVisible();
+
+    await user.press(screen.getByTestId("contacts-edit-signer-confirm"));
+
     await waitFor(() => {
+      expect(screen.queryByTestId("contacts-edit-signer-confirm")).toBeNull();
       expect(screen.queryByTestId("contacts-rename-address-confirm")).toBeNull();
       expect(screen.queryByTestId("contacts-address-detail-dialog")).toBeNull();
       expect(screen.getByText("Exchange wallet")).toBeVisible();
@@ -1101,7 +1101,6 @@ describe("Contacts integration", () => {
     await user.press(await screen.findByTestId("contacts-saved-contact-contact-ben"));
     await user.press(await screen.findByTestId("contacts-detail-address-row-address-ethereum"));
     await user.press(await screen.findByText("Edit"));
-    await user.press(await screen.findByTestId("contacts-edit-signer-confirm"));
 
     const addressInput = await screen.findByTestId("contacts-edit-address-input");
     expect(addressInput).toHaveProp("value", "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034");
@@ -1114,6 +1113,7 @@ describe("Contacts integration", () => {
     });
 
     await user.press(screen.getByTestId("contacts-rename-address-confirm"));
+    await user.press(await screen.findByTestId("contacts-edit-signer-confirm"));
 
     await waitFor(() => {
       expect(screen.queryByTestId("contacts-rename-address-confirm")).toBeNull();
@@ -1177,6 +1177,54 @@ describe("Contacts integration", () => {
     await waitFor(() => {
       expect(screen.queryByTestId("contacts-rename-contact-confirm")).toBeNull();
       expect(screen.getByText("Alice")).toBeVisible();
+    });
+  });
+
+  it("should open the rename contact sheet without asking for the signer first", async () => {
+    const { user } = render(<MyWalletNavigator />, {
+      overrideInitialState: withContactsPageReadyState(
+        { lwmContacts: { enabled: true, params: { newBadge: false } } },
+        state => ({ ...state, contacts: { contacts: mockPopulatedContacts() } }),
+      ),
+    });
+
+    await user.press(screen.getByTestId("my-wallet-contacts-button"));
+    await user.press(await screen.findByTestId("contacts-saved-contact-contact-ben"));
+    await user.press(await screen.findByTestId("contacts-detail-actions-trigger"));
+    await user.press(await screen.findByTestId("contacts-detail-edit-action"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("contacts-edit-signer-confirm")).toBeNull();
+      expect(screen.getByTestId("contacts-rename-contact-confirm")).toBeVisible();
+    });
+  });
+
+  it("should rename a saved contact after confirming on the signer sheet", async () => {
+    const { user } = render(<MyWalletNavigator />, {
+      overrideInitialState: withContactsPageReadyState(
+        { lwmContacts: { enabled: true, params: { newBadge: false } } },
+        state => ({ ...state, contacts: { contacts: mockPopulatedContacts() } }),
+      ),
+    });
+
+    await user.press(screen.getByTestId("my-wallet-contacts-button"));
+    await user.press(await screen.findByTestId("contacts-saved-contact-contact-ben"));
+    await user.press(await screen.findByTestId("contacts-detail-actions-trigger"));
+    await user.press(await screen.findByTestId("contacts-detail-edit-action"));
+
+    const renameInput = await screen.findByTestId("contacts-rename-contact-name-input");
+    await user.clear(renameInput);
+    await user.type(renameInput, "Benjamin");
+    await user.press(screen.getByTestId("contacts-rename-contact-confirm"));
+
+    expect(await screen.findByTestId("contacts-edit-signer-confirm")).toBeVisible();
+
+    await user.press(screen.getByTestId("contacts-edit-signer-confirm"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("contacts-edit-signer-confirm")).toBeNull();
+      expect(screen.queryByTestId("contacts-rename-contact-confirm")).toBeNull();
+      expect(screen.getByText("Benjamin")).toBeVisible();
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.signerMismatch.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.signerMismatch.integration.test.tsx
@@ -37,6 +37,15 @@ jest.mock("@features/flow-contacts", () => {
             currentSignerId: "signer-b",
           }),
       ),
+    useContactsEditDeletePorts: (
+      signerValidation?: Parameters<typeof actual.useContactsEditDeletePorts>[0],
+    ) =>
+      actual.useContactsEditDeletePorts(
+        signerValidation ??
+          actual.createMockContactSignerValidationPort({
+            currentSignerId: "signer-b",
+          }),
+      ),
   };
 });
 
@@ -81,6 +90,11 @@ describe("Contacts signer mismatch integration", () => {
     await user.press(await screen.findByTestId("contacts-detail-address-row-address-ethereum"));
     await user.press(await screen.findByTestId("contacts-address-detail-edit"));
 
+    const renameInput = await screen.findByDisplayValue("Ethereum");
+    await user.clear(renameInput);
+    await user.type(renameInput, "Exchange wallet");
+    await user.press(screen.getByTestId("contacts-rename-address-confirm"));
+
     await waitFor(() => {
       expect(screen.getByTestId("contacts-edit-signer-confirm")).toBeVisible();
     });
@@ -95,5 +109,72 @@ describe("Contacts signer mismatch integration", () => {
       expect(screen.getByText("The connected device isn't a match.")).toBeVisible();
       expect(screen.getByTestId("contacts-edit-signer-mismatch-connect")).toBeVisible();
     });
+  });
+
+  it("should show the signer mismatch sheet when contact edit validation fails", async () => {
+    const { user } = render(<MyWalletNavigator />, {
+      overrideInitialState: withContactsPageReadyState(
+        { lwmContacts: { enabled: true, params: { newBadge: false } } },
+        state => ({ ...state, contacts: { contacts: mockPopulatedContacts() } }),
+      ),
+    });
+
+    await user.press(screen.getByTestId("my-wallet-contacts-button"));
+    await user.press(await screen.findByTestId("contacts-saved-contact-contact-ben"));
+    await user.press(await screen.findByTestId("contacts-detail-actions-trigger"));
+    await user.press(await screen.findByTestId("contacts-detail-edit-action"));
+
+    const renameInput = await screen.findByTestId("contacts-rename-contact-name-input");
+    await user.clear(renameInput);
+    await user.type(renameInput, "Benjamin");
+    await user.press(screen.getByTestId("contacts-rename-contact-confirm"));
+
+    expect(await screen.findByTestId("contacts-edit-signer-confirm")).toBeVisible();
+
+    await user.press(screen.getByTestId("contacts-edit-signer-confirm"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("contacts-edit-signer-confirm")).toBeNull();
+      expect(
+        screen.getByText("Use the same Ledger device you used to add this contact"),
+      ).toBeVisible();
+      expect(screen.getByText("The connected device isn't a match.")).toBeVisible();
+      expect(screen.getByTestId("contacts-edit-signer-mismatch-connect")).toBeVisible();
+    });
+  });
+
+  it("should return to the edit sheet with the draft intact when the mismatch is cancelled", async () => {
+    const { user } = render(<MyWalletNavigator />, {
+      overrideInitialState: withContactsPageReadyState(
+        { lwmContacts: { enabled: true, params: { newBadge: false } } },
+        state => ({ ...state, contacts: { contacts: mockPopulatedContacts() } }),
+      ),
+    });
+
+    await user.press(screen.getByTestId("my-wallet-contacts-button"));
+    await user.press(await screen.findByTestId("contacts-saved-contact-contact-ben"));
+    await user.press(await screen.findByTestId("contacts-detail-actions-trigger"));
+    await user.press(await screen.findByTestId("contacts-detail-edit-action"));
+
+    const renameInput = await screen.findByTestId("contacts-rename-contact-name-input");
+    await user.clear(renameInput);
+    await user.type(renameInput, "Benjamin");
+    await user.press(screen.getByTestId("contacts-rename-contact-confirm"));
+
+    expect(await screen.findByTestId("contacts-edit-signer-confirm")).toBeVisible();
+    await user.press(screen.getByTestId("contacts-edit-signer-confirm"));
+    expect(await screen.findByTestId("contacts-edit-signer-mismatch-cancel")).toBeVisible();
+
+    await user.press(screen.getByTestId("contacts-edit-signer-mismatch-cancel"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("contacts-edit-signer-mismatch-cancel")).toBeNull();
+      expect(screen.getByTestId("contacts-rename-contact-confirm")).toBeVisible();
+      expect(screen.getByTestId("contacts-rename-contact-name-input")).toHaveProp(
+        "value",
+        "Benjamin",
+      );
+    });
+    expect(screen.getByText("Ben")).toBeVisible();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.test.tsx
@@ -108,6 +108,12 @@ describe("useContactAddressDetailActionsAdapter", () => {
     expect(result.current.addressDetail.isOpen).toBe(true);
 
     act(() => {
+      result.current.actions.addressDetailDialog.onEdit?.();
+    });
+
+    expect(result.current.actions.renameSheet.isOpen).toBe(true);
+
+    act(() => {
       result.current.actions.renameSheet.onClose();
     });
 
@@ -159,11 +165,7 @@ describe("useContactAddressDetailActionsAdapter", () => {
       result.current.actions.addressDetailDialog.onEdit?.();
     });
 
-    expect(result.current.actions.signerSheet.isOpen).toBe(true);
-
-    await act(async () => {
-      await result.current.actions.signerSheet.onConfirm();
-    });
+    expect(result.current.actions.signerSheet.isOpen).toBe(false);
 
     await waitFor(() => {
       expect(result.current.actions.renameSheet.isOpen).toBe(true);
@@ -179,8 +181,10 @@ describe("useContactAddressDetailActionsAdapter", () => {
       result.current.actions.renameSheet.onDraftLabelChange("Main ETH");
     });
 
-    await act(async () => {
-      await result.current.actions.renameSheet.onConfirm();
+    let confirmed!: Promise<void>;
+
+    act(() => {
+      confirmed = result.current.actions.renameSheet.onConfirm();
     });
 
     expect(trackEvent).toHaveBeenCalledWith(CONTACTS_TRACK_EVENTS.BUTTON_CLICKED, {
@@ -191,5 +195,16 @@ describe("useContactAddressDetailActionsAdapter", () => {
       network: "Ethereum",
       flow: CONTACTS_FLOW.CONTACTS,
     });
+
+    await waitFor(() => {
+      expect(result.current.actions.signerSheet.isOpen).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.actions.signerSheet.onConfirm();
+      await confirmed;
+    });
+
+    expect(trackPage).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.ts
@@ -9,7 +9,6 @@ import {
   type ContactAddressEditSavePayload,
   CONTACTS_EVENT_SOURCE,
   CONTACTS_FLOW,
-  CONTACTS_PAGE_EVENTS,
   CONTACTS_PAGE_PROPERTY,
   CONTACTS_TRACK_EVENTS,
   CONTACTS_TRACKING_BUTTON,
@@ -17,11 +16,12 @@ import {
   createInactiveContactAddressDetailActionsUiState,
   resolveContactAddressDetailActionsLabels,
   useContactAddressDetailActionsFlowBindings,
+  useContactAddressEditAnalytics,
   useContactsAddressDetailActionsPorts,
   trackContactAddressDetailQuickAction,
 } from "@features/flow-contacts";
 import { useOpenSendFlow } from "LLM/features/Send/hooks/useOpenSendFlow";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useMemo } from "react";
 import { ScreenName } from "~/const";
 import { useTranslation } from "~/context/Locale";
 import {
@@ -67,8 +67,6 @@ export function useContactAddressDetailActionsAdapter(
   const analytics = useContactsAnalytics();
   const ports = useContactsAddressDetailActionsPorts();
   const addressValidation = useContactsAddressValidationAdapter();
-  const hasTrackedEditAddressPage = useRef(false);
-  const hasTrackedSignerMismatch = useRef(false);
   const { handleOpenSendFlow } = useOpenSendFlow({
     sourceScreenName: ScreenName.MyWalletContactDetail,
   });
@@ -143,10 +141,15 @@ export function useContactAddressDetailActionsAdapter(
     onEditAddressSaved,
   });
   const { onClose: closeRenameViewModel } = renameViewModel;
+  const { editUiState } = flow;
   const onCloseRename = useCallback(() => {
+    if (editUiState !== "edit-open") {
+      return;
+    }
+
     closeRenameViewModel();
     onCloseAddressDetail();
-  }, [closeRenameViewModel, onCloseAddressDetail]);
+  }, [closeRenameViewModel, editUiState, onCloseAddressDetail]);
   const onEdit = useCallback(() => {
     trackQuickAction(CONTACTS_TRACKING_BUTTON.edit);
     flow.onEditPress();
@@ -167,39 +170,13 @@ export function useContactAddressDetailActionsAdapter(
     await renameViewModel.onConfirm();
   }, [analytics, asset, network, renameViewModel]);
 
-  useEffect(() => {
-    if (!renameViewModel.isOpen) {
-      hasTrackedEditAddressPage.current = false;
-      return;
-    }
-
-    if (hasTrackedEditAddressPage.current || asset === undefined || network === undefined) {
-      return;
-    }
-
-    hasTrackedEditAddressPage.current = true;
-    analytics.trackPage(CONTACTS_PAGE_EVENTS.EDIT_ADDRESS, {
-      source: CONTACTS_EVENT_SOURCE.EDIT_ADDRESS,
-      network,
-      asset,
-    });
-  }, [analytics, asset, network, renameViewModel.isOpen]);
-
-  useEffect(() => {
-    if (flow.editUiState === "signer-mismatch" && !hasTrackedSignerMismatch.current) {
-      hasTrackedSignerMismatch.current = true;
-      analytics.trackEvent(CONTACTS_TRACK_EVENTS.ERROR_DISPLAYED, {
-        source: CONTACTS_EVENT_SOURCE.EDIT_ADDRESS,
-        page: CONTACTS_PAGE_PROPERTY.EDIT_ADDRESS,
-        errorType: "signer_mismatch",
-      });
-      return;
-    }
-
-    if (flow.editUiState !== "signer-mismatch") {
-      hasTrackedSignerMismatch.current = false;
-    }
-  }, [analytics, flow.editUiState]);
+  useContactAddressEditAnalytics(analytics, {
+    isEditSessionActive: flow.isEditSessionActive,
+    isRenameOpen: renameViewModel.isOpen,
+    isSignerMismatchOpen: flow.editUiState === "signer-mismatch",
+    asset,
+    network,
+  });
 
   if (!isSelectionActive) {
     return mapUiStateToFlowProps(createInactiveContactAddressDetailActionsUiState(labels));

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactDetailEditDeleteSheets/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactDetailEditDeleteSheets/index.tsx
@@ -59,6 +59,7 @@ export function ContactDetailEditDeleteSheets({
       </QueuedBottomSheet>
       <QueuedBottomSheet
         isRequestingToBeOpened={renameDrawer.isOpen}
+        isForcingToBeOpened={renameDrawer.isOpen}
         onClose={renameDrawer.onClose}
         testID="contacts-rename-contact-sheet"
         enableDynamicSizing
@@ -79,6 +80,7 @@ export function ContactDetailEditDeleteSheets({
       </QueuedBottomSheet>
       <QueuedBottomSheet
         isRequestingToBeOpened={signerDrawer.isOpen}
+        isForcingToBeOpened={signerDrawer.isOpen}
         onClose={onCloseSigner}
         testID="contacts-edit-signer-sheet"
         enableDynamicSizing

--- a/features/flow/contacts/src/hooks/index.ts
+++ b/features/flow/contacts/src/hooks/index.ts
@@ -2,6 +2,7 @@ export * from "./useContactsEditDeletePorts";
 export * from "./useContactsAddressDetailActionsPorts";
 export * from "../platform/contactSignerValidationPort";
 export * from "./contactsHooks";
+export * from "./useContactAddressEditAnalytics";
 export * from "./useContactDetailEditDeleteAnalytics";
 export * from "./useContactsListPageAnalytics";
 export * from "./useAddContactAppAdapter";

--- a/features/flow/contacts/src/hooks/useContactAddressEditAnalytics.ts
+++ b/features/flow/contacts/src/hooks/useContactAddressEditAnalytics.ts
@@ -1,0 +1,69 @@
+import { useEffect, useRef } from "react";
+import {
+  CONTACTS_EVENT_SOURCE,
+  CONTACTS_PAGE_EVENTS,
+  CONTACTS_PAGE_PROPERTY,
+  CONTACTS_TRACK_EVENTS,
+} from "../analytics/contactsAnalytics.types";
+import type { ContactsAnalyticsHelper } from "../analytics/createContactsAnalyticsHelper";
+
+export type UseContactAddressEditAnalyticsOptions = Readonly<{
+  isEditSessionActive: boolean;
+  isRenameOpen: boolean;
+  isSignerMismatchOpen: boolean;
+  asset?: string;
+  network?: string;
+}>;
+
+export function useContactAddressEditAnalytics(
+  analytics: ContactsAnalyticsHelper,
+  {
+    isEditSessionActive,
+    isRenameOpen,
+    isSignerMismatchOpen,
+    asset,
+    network,
+  }: UseContactAddressEditAnalyticsOptions,
+): void {
+  const hasTrackedEditAddressPage = useRef(false);
+  const hasTrackedSignerMismatch = useRef(false);
+
+  useEffect(() => {
+    if (!isEditSessionActive) {
+      hasTrackedEditAddressPage.current = false;
+      return;
+    }
+
+    if (
+      !isRenameOpen ||
+      hasTrackedEditAddressPage.current ||
+      asset === undefined ||
+      network === undefined
+    ) {
+      return;
+    }
+
+    hasTrackedEditAddressPage.current = true;
+    analytics.trackPage(CONTACTS_PAGE_EVENTS.EDIT_ADDRESS, {
+      source: CONTACTS_EVENT_SOURCE.EDIT_ADDRESS,
+      network,
+      asset,
+    });
+  }, [analytics, asset, isEditSessionActive, isRenameOpen, network]);
+
+  useEffect(() => {
+    if (isSignerMismatchOpen && !hasTrackedSignerMismatch.current) {
+      hasTrackedSignerMismatch.current = true;
+      analytics.trackEvent(CONTACTS_TRACK_EVENTS.ERROR_DISPLAYED, {
+        source: CONTACTS_EVENT_SOURCE.EDIT_ADDRESS,
+        page: CONTACTS_PAGE_PROPERTY.EDIT_ADDRESS,
+        errorType: "signer_mismatch",
+      });
+      return;
+    }
+
+    if (!isSignerMismatchOpen) {
+      hasTrackedSignerMismatch.current = false;
+    }
+  }, [analytics, isSignerMismatchOpen]);
+}

--- a/features/flow/contacts/src/hooks/useContactAddressEditAnalytics.web.test.ts
+++ b/features/flow/contacts/src/hooks/useContactAddressEditAnalytics.web.test.ts
@@ -1,0 +1,128 @@
+import { renderHook } from "@testing-library/react";
+import {
+  CONTACTS_EVENT_SOURCE,
+  CONTACTS_PAGE_EVENTS,
+  CONTACTS_PAGE_PROPERTY,
+  CONTACTS_TRACK_EVENTS,
+} from "../analytics/contactsAnalytics.types";
+import type { ContactsAnalyticsHelper } from "../analytics/createContactsAnalyticsHelper";
+import {
+  useContactAddressEditAnalytics,
+  type UseContactAddressEditAnalyticsOptions,
+} from "./useContactAddressEditAnalytics";
+
+function createAnalytics(): ContactsAnalyticsHelper {
+  return {
+    trackEvent: jest.fn(),
+    trackPage: jest.fn(),
+    getGlobalProperties: jest.fn(),
+  };
+}
+
+const closedSession: UseContactAddressEditAnalyticsOptions = {
+  isEditSessionActive: false,
+  isRenameOpen: false,
+  isSignerMismatchOpen: false,
+  asset: "ETH",
+  network: "ethereum",
+};
+
+const openRename: UseContactAddressEditAnalyticsOptions = {
+  ...closedSession,
+  isEditSessionActive: true,
+  isRenameOpen: true,
+};
+
+describe("useContactAddressEditAnalytics", () => {
+  it("should track the edit address page when the rename dialog opens", () => {
+    const analytics = createAnalytics();
+    const { rerender } = renderHook(
+      (options: UseContactAddressEditAnalyticsOptions) =>
+        useContactAddressEditAnalytics(analytics, options),
+      { initialProps: closedSession },
+    );
+
+    rerender(openRename);
+
+    expect(analytics.trackPage).toHaveBeenCalledWith(CONTACTS_PAGE_EVENTS.EDIT_ADDRESS, {
+      source: CONTACTS_EVENT_SOURCE.EDIT_ADDRESS,
+      network: "ethereum",
+      asset: "ETH",
+    });
+  });
+
+  it("should not track the page again when the signer step hides the rename dialog", () => {
+    const analytics = createAnalytics();
+    const { rerender } = renderHook(
+      (options: UseContactAddressEditAnalyticsOptions) =>
+        useContactAddressEditAnalytics(analytics, options),
+      { initialProps: openRename },
+    );
+
+    rerender({ ...openRename, isRenameOpen: false });
+    rerender(openRename);
+
+    expect(analytics.trackPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("should track the page again for a new edit session", () => {
+    const analytics = createAnalytics();
+    const { rerender } = renderHook(
+      (options: UseContactAddressEditAnalyticsOptions) =>
+        useContactAddressEditAnalytics(analytics, options),
+      { initialProps: openRename },
+    );
+
+    rerender(closedSession);
+    rerender(openRename);
+
+    expect(analytics.trackPage).toHaveBeenCalledTimes(2);
+  });
+
+  it("should not track the page when the asset and network are unresolved", () => {
+    const analytics = createAnalytics();
+
+    renderHook(() =>
+      useContactAddressEditAnalytics(analytics, {
+        ...openRename,
+        asset: undefined,
+        network: undefined,
+      }),
+    );
+
+    expect(analytics.trackPage).not.toHaveBeenCalled();
+  });
+
+  it("should track signer mismatch errors once while the dialog is open", () => {
+    const analytics = createAnalytics();
+    const { rerender } = renderHook(
+      (options: UseContactAddressEditAnalyticsOptions) =>
+        useContactAddressEditAnalytics(analytics, options),
+      { initialProps: openRename },
+    );
+
+    rerender({ ...openRename, isSignerMismatchOpen: true });
+    rerender({ ...openRename, isSignerMismatchOpen: true });
+
+    expect(analytics.trackEvent).toHaveBeenCalledTimes(1);
+    expect(analytics.trackEvent).toHaveBeenCalledWith(CONTACTS_TRACK_EVENTS.ERROR_DISPLAYED, {
+      source: CONTACTS_EVENT_SOURCE.EDIT_ADDRESS,
+      page: CONTACTS_PAGE_PROPERTY.EDIT_ADDRESS,
+      errorType: "signer_mismatch",
+    });
+  });
+
+  it("should allow signer mismatch tracking again after the dialog closes", () => {
+    const analytics = createAnalytics();
+    const { rerender } = renderHook(
+      (options: UseContactAddressEditAnalyticsOptions) =>
+        useContactAddressEditAnalytics(analytics, options),
+      { initialProps: { ...openRename, isSignerMismatchOpen: true } },
+    );
+
+    rerender(openRename);
+    rerender({ ...openRename, isSignerMismatchOpen: true });
+
+    expect(analytics.trackEvent).toHaveBeenCalledTimes(2);
+  });
+});

--- a/features/flow/contacts/src/steps/Detail/components/ContactConfirmationBottomSheet/ContactConfirmationBottomSheet.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactConfirmationBottomSheet/ContactConfirmationBottomSheet.native.tsx
@@ -27,6 +27,7 @@ export type ContactConfirmationBottomSheetProps = Readonly<{
   confirmTestID?: string;
   /** Anchor for the sheet's content, present only while the sheet is open. */
   contentTestID?: string;
+  cancelTestID?: string;
   onConfirm: () => void;
   onCancel: () => void;
 }>;
@@ -41,6 +42,7 @@ export function ContactConfirmationBottomSheet({
   confirmDisabled = false,
   confirmTestID,
   contentTestID,
+  cancelTestID,
   onConfirm,
   onCancel,
 }: ContactConfirmationBottomSheetProps): React.JSX.Element {
@@ -72,7 +74,14 @@ export function ContactConfirmationBottomSheet({
             >
               {labels.confirm}
             </Button>
-            <Button appearance="gray" size="lg" isFull disabled={confirmLoading} onPress={onCancel}>
+            <Button
+              appearance="gray"
+              size="lg"
+              isFull
+              disabled={confirmLoading}
+              onPress={onCancel}
+              testID={cancelTestID}
+            >
               {labels.cancel}
             </Button>
           </Box>

--- a/features/flow/contacts/src/steps/Detail/components/ContactsEditSignerMismatchDialog/ContactsEditSignerMismatchDialog.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactsEditSignerMismatchDialog/ContactsEditSignerMismatchDialog.native.tsx
@@ -23,6 +23,7 @@ export function ContactsEditSignerMismatchDialog({
       }}
       confirmAppearance="base"
       confirmTestID="contacts-edit-signer-mismatch-connect"
+      cancelTestID="contacts-edit-signer-mismatch-cancel"
       onConfirm={onConnectDifferentDevice}
       onCancel={onCancel}
     />

--- a/features/flow/contacts/src/steps/Detail/components/ContactsEditSignerMismatchDialog/ContactsEditSignerMismatchDialog.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactsEditSignerMismatchDialog/ContactsEditSignerMismatchDialog.web.tsx
@@ -47,7 +47,13 @@ export function ContactsEditSignerMismatchDialog({
             >
               {labels.connectDifferentDevice}
             </Button>
-            <Button appearance="gray" size="lg" isFull onClick={onCancel}>
+            <Button
+              appearance="gray"
+              size="lg"
+              isFull
+              onClick={onCancel}
+              data-testid="contacts-edit-signer-mismatch-cancel"
+            >
               {labels.cancel}
             </Button>
           </div>

--- a/features/flow/contacts/src/steps/Detail/editDelete/useContactDetailEditDeleteFlowBindings.ts
+++ b/features/flow/contacts/src/steps/Detail/editDelete/useContactDetailEditDeleteFlowBindings.ts
@@ -24,8 +24,10 @@ export function useContactDetailEditDeleteFlowBindings({
     currentName: flow.contactName,
     editPort: ports.edit,
     isRequestedOpen: flow.editUiState === "edit-open",
+    isEditSessionActive: flow.isEditSessionActive,
     onCloseRequest: flow.onEditClose,
     onSaveSuccess: () => undefined,
+    requestSaveApproval: flow.requestSaveApproval,
   });
 
   return { flow, renameViewModel };

--- a/features/flow/contacts/src/steps/Detail/editDelete/useContactDetailEditDeleteFlowViewModel.ts
+++ b/features/flow/contacts/src/steps/Detail/editDelete/useContactDetailEditDeleteFlowViewModel.ts
@@ -28,10 +28,12 @@ export type UseContactDetailEditDeleteFlowViewModelResult = ReturnType<
     canDelete: boolean;
     contactName: string;
     editUiState: ContactDetailEditUiState;
+    isEditSessionActive: boolean;
     isActionsMenuOpen: boolean;
     isDeleting: boolean;
     onEditPress: () => void;
     onDeletePress: () => void;
+    requestSaveApproval: () => Promise<boolean>;
     onSignerConfirm: () => Promise<void>;
     onSignerCancel: () => void;
     onSignerMismatchCancel: () => void;
@@ -58,7 +60,9 @@ export function useContactDetailEditDeleteFlowViewModel({
   } = useContactDetailActionsViewModel(contactId, ports);
   const {
     editUiState,
-    openSignerDialog,
+    isEditSessionActive,
+    requestSignerApproval,
+    grantSignerApproval,
     openSignerMismatchDialog,
     openEditDialog,
     onSignerCancel: closeSignerOnCancel,
@@ -73,20 +77,19 @@ export function useContactDetailEditDeleteFlowViewModel({
 
   const onEditPress = useCallback(() => {
     setIsActionsMenuOpen(false);
-
-    if (isSignerRequiredForEdit) {
-      openSignerDialog();
-      return;
-    }
-
     openEditDialog();
-  }, [isSignerRequiredForEdit, openEditDialog, openSignerDialog]);
+  }, [openEditDialog]);
+
+  const requestSaveApproval = useCallback(
+    () => (isSignerRequiredForEdit ? requestSignerApproval() : Promise.resolve(true)),
+    [isSignerRequiredForEdit, requestSignerApproval],
+  );
 
   const onSignerConfirm = useCallback(async () => {
     const validationLookup = editIntent?.signerValidationLookup;
 
     if (validationLookup === undefined) {
-      openEditDialog();
+      grantSignerApproval();
       return;
     }
 
@@ -101,10 +104,10 @@ export function useContactDetailEditDeleteFlowViewModel({
       return;
     }
 
-    openEditDialog();
+    grantSignerApproval();
   }, [
     editIntent?.signerValidationLookup,
-    openEditDialog,
+    grantSignerApproval,
     openSignerMismatchDialog,
     ports.signerValidation,
   ]);
@@ -159,10 +162,12 @@ export function useContactDetailEditDeleteFlowViewModel({
     canDelete,
     contactName,
     editUiState,
+    isEditSessionActive,
     isActionsMenuOpen,
     isDeleting,
     onEditPress,
     onDeletePress,
+    requestSaveApproval,
     onSignerConfirm,
     onSignerCancel,
     onSignerMismatchCancel,

--- a/features/flow/contacts/src/steps/Detail/editDelete/useContactDetailEditDeleteFlowViewModel.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/editDelete/useContactDetailEditDeleteFlowViewModel.web.test.tsx
@@ -48,7 +48,7 @@ describe("useContactDetailEditDeleteFlowViewModel", () => {
     expect(result.current.isActionsMenuOpen).toBe(false);
   });
 
-  it("should open the signer dialog when editing a contact with addresses", () => {
+  it("should open the edit dialog without asking for the signer first", () => {
     const contact = mockContactWithAddress();
     const Wrapper = makeContactsWrapper([mockMeContact(), contact]);
     const { result } = renderHook(
@@ -62,13 +62,49 @@ describe("useContactDetailEditDeleteFlowViewModel", () => {
 
     act(() => {
       result.current.onEditPress();
+    });
+
+    expect(result.current.editUiState).toBe("edit-open");
+  });
+
+  it("should ask for the signer when saving a contact with addresses", async () => {
+    const contact = mockContactWithAddress();
+    const Wrapper = makeContactsWrapper([mockMeContact(), contact]);
+    const { result } = renderHook(
+      () =>
+        useContactDetailEditDeleteFlowViewModel({
+          contactId: contact.id,
+          ports: createPorts(),
+        }),
+      { wrapper: Wrapper },
+    );
+    const onApproval = jest.fn();
+
+    act(() => {
+      result.current.onEditPress();
+    });
+
+    let approval!: Promise<boolean>;
+
+    act(() => {
+      approval = result.current.requestSaveApproval();
+      void approval.then(onApproval);
     });
 
     expect(result.current.editUiState).toBe("signer-open");
+    expect(onApproval).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await result.current.onSignerConfirm();
+      await approval;
+    });
+
+    expect(onApproval).toHaveBeenCalledWith(true);
+    expect(result.current.editUiState).toBe("edit-open");
   });
 
-  it("should open edit state after signer confirmation", async () => {
-    const contact = mockContactWithAddress();
+  it("should approve the save without a signer step when the contact has no address", async () => {
+    const contact = mockContact();
     const Wrapper = makeContactsWrapper([mockMeContact(), contact]);
     const { result } = renderHook(
       () =>
@@ -82,8 +118,9 @@ describe("useContactDetailEditDeleteFlowViewModel", () => {
     act(() => {
       result.current.onEditPress();
     });
+
     await act(async () => {
-      await result.current.onSignerConfirm();
+      await expect(result.current.requestSaveApproval()).resolves.toBe(true);
     });
 
     expect(result.current.editUiState).toBe("edit-open");
@@ -103,6 +140,7 @@ describe("useContactDetailEditDeleteFlowViewModel", () => {
 
     act(() => {
       result.current.onEditPress();
+      void result.current.requestSaveApproval();
     });
     await act(async () => {
       await result.current.onSignerConfirm();
@@ -134,6 +172,7 @@ describe("useContactDetailEditDeleteFlowViewModel", () => {
 
     act(() => {
       result.current.onEditPress();
+      void result.current.requestSaveApproval();
     });
 
     expect(result.current.editUiState).toBe("signer-open");
@@ -162,6 +201,7 @@ describe("useContactDetailEditDeleteFlowViewModel", () => {
 
     act(() => {
       result.current.onEditPress();
+      void result.current.requestSaveApproval();
     });
     await act(async () => {
       await result.current.onSignerConfirm();
@@ -176,7 +216,7 @@ describe("useContactDetailEditDeleteFlowViewModel", () => {
     expect(result.current.editUiState).toBe("signer-open");
   });
 
-  it("should close the signer mismatch dialog on cancel", async () => {
+  it("should decline the save and return to the edit dialog when the mismatch is cancelled", async () => {
     const contact = mockContactWithAddress();
     const mismatchPort: ContactSignerValidationPort = createMockContactSignerValidationPort({
       currentSignerId: "signer-b",
@@ -190,9 +230,11 @@ describe("useContactDetailEditDeleteFlowViewModel", () => {
         }),
       { wrapper: Wrapper },
     );
+    let approval!: Promise<boolean>;
 
     act(() => {
       result.current.onEditPress();
+      approval = result.current.requestSaveApproval();
     });
     await act(async () => {
       await result.current.onSignerConfirm();
@@ -200,11 +242,12 @@ describe("useContactDetailEditDeleteFlowViewModel", () => {
 
     expect(result.current.editUiState).toBe("signer-mismatch");
 
-    act(() => {
+    await act(async () => {
       result.current.onSignerMismatchCancel();
+      await expect(approval).resolves.toBe(false);
     });
 
-    expect(result.current.editUiState).toBe("closed");
+    expect(result.current.editUiState).toBe("edit-open");
   });
 
   it("should prevent deleting the Me contact", () => {

--- a/features/flow/contacts/src/steps/Detail/model/signerEditUiState.ts
+++ b/features/flow/contacts/src/steps/Detail/model/signerEditUiState.ts
@@ -5,7 +5,7 @@ export function resolveEditUiStateOnSignerMismatch(): SignerEditUiState {
 }
 
 export function resolveEditUiStateOnSignerMismatchCancel(): SignerEditUiState {
-  return "closed";
+  return "edit-open";
 }
 
 export function resolveEditUiStateOnConnectDifferentDevice(): SignerEditUiState {

--- a/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowBindings.ts
+++ b/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowBindings.ts
@@ -72,7 +72,9 @@ export function useContactAddressDetailActionsFlowBindings({
     addressValidation,
     manualValidationDebounceMs,
     isRequestedOpen: flow.editUiState === "edit-open",
+    isEditSessionActive: flow.isEditSessionActive,
     onCloseRequest: flow.onEditClose,
+    requestSaveApproval: flow.requestSaveApproval,
     onSaveSuccess: payload => {
       onEditAddressSaved?.(payload);
       onCloseAddressDetail?.();

--- a/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowViewModel.ts
+++ b/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowViewModel.ts
@@ -27,11 +27,13 @@ export type UseContactAddressDetailActionsFlowViewModelResult = Readonly<{
   canEdit: boolean;
   canDelete: boolean;
   editUiState: ReturnType<typeof useContactEditSignerUiState>["editUiState"];
+  isEditSessionActive: boolean;
   isDeleting: boolean;
   deleteLifecycle: ReturnType<typeof useContactAddressDetailActionsViewModel>["deleteLifecycle"];
   onSendPress: () => void;
   onEditPress: () => void;
   onDeletePress: () => void;
+  requestSaveApproval: () => Promise<boolean>;
   onSignerConfirm: () => Promise<void>;
   onSignerCancel: () => void;
   onSignerMismatchCancel: () => void;
@@ -61,7 +63,9 @@ export function useContactAddressDetailActionsFlowViewModel({
   } = useContactAddressDetailActionsViewModel(contactId, resolvedAddressId, ports);
   const {
     editUiState,
-    openSignerDialog,
+    isEditSessionActive,
+    requestSignerApproval,
+    grantSignerApproval,
     openSignerMismatchDialog,
     openEditDialog,
     onSignerCancel: closeSignerOnCancel,
@@ -89,13 +93,13 @@ export function useContactAddressDetailActionsFlowViewModel({
       return;
     }
 
-    if (isSignerRequiredForEdit) {
-      openSignerDialog();
-      return;
-    }
-
     openEditDialog();
-  }, [editIntent, isSignerRequiredForEdit, openEditDialog, openSignerDialog]);
+  }, [editIntent, openEditDialog]);
+
+  const requestSaveApproval = useCallback(
+    () => (isSignerRequiredForEdit ? requestSignerApproval() : Promise.resolve(true)),
+    [isSignerRequiredForEdit, requestSignerApproval],
+  );
 
   const onSignerConfirm = useCallback(async () => {
     if (editIntent === undefined) {
@@ -116,8 +120,8 @@ export function useContactAddressDetailActionsFlowViewModel({
       return;
     }
 
-    openEditDialog();
-  }, [editIntent, openEditDialog, openSignerMismatchDialog, ports.signerValidation]);
+    grantSignerApproval();
+  }, [editIntent, grantSignerApproval, openSignerMismatchDialog, ports.signerValidation]);
 
   const onSignerCancel = useCallback(() => {
     closeSignerOnCancel();
@@ -171,11 +175,13 @@ export function useContactAddressDetailActionsFlowViewModel({
     canEdit,
     canDelete,
     editUiState,
+    isEditSessionActive,
     isDeleting,
     deleteLifecycle,
     onSendPress,
     onEditPress,
     onDeletePress,
+    requestSaveApproval,
     onSignerConfirm,
     onSignerCancel,
     onSignerMismatchCancel,

--- a/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowViewModel.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowViewModel.web.test.tsx
@@ -46,7 +46,7 @@ function makeWrapper(contacts: ReturnType<typeof contactsSlice.getInitialState>[
 }
 
 describe("useContactAddressDetailActionsFlowViewModel", () => {
-  it("should open the signer dialog before editing an address", () => {
+  it("should open the edit dialog before asking for the signer", () => {
     const contact = mockContactWithAddress();
     const address = contact.addresses[0]!;
     const Wrapper = makeWrapper([mockMeContact(), contact]);
@@ -62,32 +62,42 @@ describe("useContactAddressDetailActionsFlowViewModel", () => {
 
     act(() => {
       result.current.onEditPress();
+    });
+
+    expect(result.current.editUiState).toBe("edit-open");
+  });
+
+  it("should ask for the signer when the save is confirmed", async () => {
+    const contact = mockContactWithAddress();
+    const address = contact.addresses[0]!;
+    const Wrapper = makeWrapper([mockMeContact(), contact]);
+    const { result } = renderHook(
+      () =>
+        useContactAddressDetailActionsFlowViewModel({
+          contactId: contact.id,
+          addressId: address.id,
+          ports: createPorts(),
+        }),
+      { wrapper: Wrapper },
+    );
+    const onApproval = jest.fn();
+    let approval!: Promise<boolean>;
+
+    act(() => {
+      result.current.onEditPress();
+      approval = result.current.requestSaveApproval();
+      void approval.then(onApproval);
     });
 
     expect(result.current.editUiState).toBe("signer-open");
-  });
+    expect(onApproval).not.toHaveBeenCalled();
 
-  it("should open edit state after signer confirmation", async () => {
-    const contact = mockContactWithAddress();
-    const address = contact.addresses[0]!;
-    const Wrapper = makeWrapper([mockMeContact(), contact]);
-    const { result } = renderHook(
-      () =>
-        useContactAddressDetailActionsFlowViewModel({
-          contactId: contact.id,
-          addressId: address.id,
-          ports: createPorts(),
-        }),
-      { wrapper: Wrapper },
-    );
-
-    act(() => {
-      result.current.onEditPress();
-    });
     await act(async () => {
       await result.current.onSignerConfirm();
+      await approval;
     });
 
+    expect(onApproval).toHaveBeenCalledWith(true);
     expect(result.current.editUiState).toBe("edit-open");
   });
 
@@ -107,6 +117,7 @@ describe("useContactAddressDetailActionsFlowViewModel", () => {
 
     act(() => {
       result.current.onEditPress();
+      void result.current.requestSaveApproval();
     });
     await act(async () => {
       await result.current.onSignerConfirm();
@@ -140,6 +151,7 @@ describe("useContactAddressDetailActionsFlowViewModel", () => {
 
     act(() => {
       result.current.onEditPress();
+      void result.current.requestSaveApproval();
     });
 
     expect(result.current.editUiState).toBe("signer-open");
@@ -170,6 +182,7 @@ describe("useContactAddressDetailActionsFlowViewModel", () => {
 
     act(() => {
       result.current.onEditPress();
+      void result.current.requestSaveApproval();
     });
     await act(async () => {
       await result.current.onSignerConfirm();
@@ -313,6 +326,7 @@ describe("useContactAddressDetailActionsFlowViewModel", () => {
 
     act(() => {
       result.current.onEditPress();
+      void result.current.requestSaveApproval();
     });
 
     expect(result.current.editUiState).toBe("signer-open");

--- a/features/flow/contacts/src/steps/Detail/useContactEditSignerUiState.ts
+++ b/features/flow/contacts/src/steps/Detail/useContactEditSignerUiState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   resolveEditUiStateOnConnectDifferentDevice,
   resolveEditUiStateOnSignerMismatch,
@@ -8,11 +8,11 @@ import {
 
 export type UseContactEditSignerUiStateResult = Readonly<{
   editUiState: SignerEditUiState;
-  openSignerDialog: () => void;
-  openSignerMismatchDialog: () => void;
+  isEditSessionActive: boolean;
   openEditDialog: () => void;
-  closeSignerDialog: () => void;
-  onSignerConfirm: () => void;
+  requestSignerApproval: () => Promise<boolean>;
+  grantSignerApproval: () => void;
+  openSignerMismatchDialog: () => void;
   onSignerCancel: () => void;
   onSignerMismatchCancel: () => void;
   onConnectDifferentDevice: () => void;
@@ -22,56 +22,88 @@ export type UseContactEditSignerUiStateResult = Readonly<{
 
 export function useContactEditSignerUiState(): UseContactEditSignerUiStateResult {
   const [editUiState, setEditUiState] = useState<SignerEditUiState>("closed");
+  const editUiStateRef = useRef<SignerEditUiState>("closed");
+  const pendingApprovalRef = useRef<((approved: boolean) => void) | undefined>(undefined);
 
-  const openSignerDialog = useCallback(() => {
-    setEditUiState("signer-open");
+  const transitionEditUiState = useCallback((next: SignerEditUiState) => {
+    editUiStateRef.current = next;
+    setEditUiState(next);
   }, []);
 
-  const openSignerMismatchDialog = useCallback(() => {
-    setEditUiState(resolveEditUiStateOnSignerMismatch());
+  const settleSignerApproval = useCallback((approved: boolean) => {
+    const resolvePendingApproval = pendingApprovalRef.current;
+    pendingApprovalRef.current = undefined;
+    resolvePendingApproval?.(approved);
   }, []);
 
   const openEditDialog = useCallback(() => {
-    setEditUiState("edit-open");
-  }, []);
+    transitionEditUiState("edit-open");
+  }, [transitionEditUiState]);
 
-  const closeSignerDialog = useCallback(() => {
-    setEditUiState("closed");
-  }, []);
+  const requestSignerApproval = useCallback(
+    () =>
+      new Promise<boolean>(resolve => {
+        settleSignerApproval(false);
+        pendingApprovalRef.current = resolve;
+        transitionEditUiState("signer-open");
+      }),
+    [settleSignerApproval, transitionEditUiState],
+  );
 
-  const onSignerConfirm = useCallback(() => {
-    setEditUiState("edit-open");
-  }, []);
+  const grantSignerApproval = useCallback(() => {
+    transitionEditUiState("edit-open");
+    settleSignerApproval(true);
+  }, [settleSignerApproval, transitionEditUiState]);
 
-  const onSignerMismatchCancel = useCallback(() => {
-    setEditUiState(resolveEditUiStateOnSignerMismatchCancel());
-  }, []);
-
-  const onConnectDifferentDevice = useCallback(() => {
-    setEditUiState(resolveEditUiStateOnConnectDifferentDevice());
-  }, []);
+  const openSignerMismatchDialog = useCallback(() => {
+    transitionEditUiState(resolveEditUiStateOnSignerMismatch());
+  }, [transitionEditUiState]);
 
   const onSignerCancel = useCallback(() => {
-    // QueuedBottomSheet calls onClose when isRequestingToBeOpened becomes false — including
-    // after the user confirms and we transition to edit-open. Only cancel when still on signer.
-    setEditUiState(current => (current === "signer-open" ? "closed" : current));
-  }, []);
+    if (editUiStateRef.current !== "signer-open") {
+      return;
+    }
+
+    transitionEditUiState("edit-open");
+    settleSignerApproval(false);
+  }, [settleSignerApproval, transitionEditUiState]);
+
+  const onSignerMismatchCancel = useCallback(() => {
+    if (editUiStateRef.current !== "signer-mismatch") {
+      return;
+    }
+
+    transitionEditUiState(resolveEditUiStateOnSignerMismatchCancel());
+    settleSignerApproval(false);
+  }, [settleSignerApproval, transitionEditUiState]);
+
+  const onConnectDifferentDevice = useCallback(() => {
+    transitionEditUiState(resolveEditUiStateOnConnectDifferentDevice());
+  }, [transitionEditUiState]);
 
   const onEditClose = useCallback(() => {
-    setEditUiState("closed");
-  }, []);
+    if (editUiStateRef.current !== "edit-open") {
+      return;
+    }
+
+    transitionEditUiState("closed");
+    settleSignerApproval(false);
+  }, [settleSignerApproval, transitionEditUiState]);
 
   const resetEditUiState = useCallback(() => {
-    setEditUiState("closed");
-  }, []);
+    transitionEditUiState("closed");
+    settleSignerApproval(false);
+  }, [settleSignerApproval, transitionEditUiState]);
+
+  useEffect(() => () => settleSignerApproval(false), [settleSignerApproval]);
 
   return {
     editUiState,
-    openSignerDialog,
-    openSignerMismatchDialog,
+    isEditSessionActive: editUiState !== "closed",
     openEditDialog,
-    closeSignerDialog,
-    onSignerConfirm,
+    requestSignerApproval,
+    grantSignerApproval,
+    openSignerMismatchDialog,
     onSignerCancel,
     onSignerMismatchCancel,
     onConnectDifferentDevice,

--- a/features/flow/contacts/src/steps/Detail/useContactEditSignerUiState.web.test.ts
+++ b/features/flow/contacts/src/steps/Detail/useContactEditSignerUiState.web.test.ts
@@ -2,81 +2,210 @@ import { act, renderHook } from "@testing-library/react";
 import { useContactEditSignerUiState } from "./useContactEditSignerUiState";
 
 describe("useContactEditSignerUiState", () => {
-  it("should open the signer dialog", () => {
+  it("should open the edit dialog without asking for the signer", () => {
     const { result } = renderHook(() => useContactEditSignerUiState());
 
     act(() => {
-      result.current.openSignerDialog();
+      result.current.openEditDialog();
+    });
+
+    expect(result.current.editUiState).toBe("edit-open");
+    expect(result.current.isEditSessionActive).toBe(true);
+  });
+
+  it("should open the signer dialog and keep the approval pending until it is granted", async () => {
+    const { result } = renderHook(() => useContactEditSignerUiState());
+    const onApproval = jest.fn();
+    let approval!: Promise<boolean>;
+
+    act(() => {
+      result.current.openEditDialog();
+      approval = result.current.requestSignerApproval();
+      void approval.then(onApproval);
     });
 
     expect(result.current.editUiState).toBe("signer-open");
+    expect(onApproval).not.toHaveBeenCalled();
+
+    await act(async () => {
+      result.current.grantSignerApproval();
+      await approval;
+    });
+
+    expect(result.current.editUiState).toBe("edit-open");
+    expect(onApproval).toHaveBeenCalledWith(true);
   });
 
-  it("should transition to edit-open after signer confirmation", () => {
+  it("should decline the approval and return to the edit dialog when the signer is cancelled", async () => {
     const { result } = renderHook(() => useContactEditSignerUiState());
+    let approval!: Promise<boolean>;
 
     act(() => {
-      result.current.openSignerDialog();
-      result.current.onSignerConfirm();
+      result.current.openEditDialog();
+      approval = result.current.requestSignerApproval();
+    });
+
+    await act(async () => {
+      result.current.onSignerCancel();
+      await expect(approval).resolves.toBe(false);
     });
 
     expect(result.current.editUiState).toBe("edit-open");
   });
 
-  it("should keep edit-open when signer close fires after confirm", () => {
+  it("should ignore a signer cancel fired after leaving the signer step", async () => {
     const { result } = renderHook(() => useContactEditSignerUiState());
+    let approval!: Promise<boolean>;
 
     act(() => {
-      result.current.openSignerDialog();
-      result.current.onSignerConfirm();
+      result.current.openEditDialog();
+      approval = result.current.requestSignerApproval();
+    });
+
+    await act(async () => {
+      result.current.grantSignerApproval();
+      await approval;
+    });
+
+    act(() => {
       result.current.onSignerCancel();
     });
 
     expect(result.current.editUiState).toBe("edit-open");
   });
 
-  it("should reset to closed when edit is closed or reset", () => {
+  it("should keep the approval pending while the user connects a different device", async () => {
     const { result } = renderHook(() => useContactEditSignerUiState());
+    const onApproval = jest.fn();
+    let approval!: Promise<boolean>;
 
     act(() => {
       result.current.openEditDialog();
-      result.current.onEditClose();
-    });
-
-    expect(result.current.editUiState).toBe("closed");
-
-    act(() => {
-      result.current.openSignerDialog();
-      result.current.resetEditUiState();
-    });
-
-    expect(result.current.editUiState).toBe("closed");
-  });
-
-  it("should open the signer mismatch dialog and close it on cancel", () => {
-    const { result } = renderHook(() => useContactEditSignerUiState());
-
-    act(() => {
+      approval = result.current.requestSignerApproval();
+      void approval.then(onApproval);
       result.current.openSignerMismatchDialog();
     });
 
     expect(result.current.editUiState).toBe("signer-mismatch");
 
     act(() => {
+      result.current.onConnectDifferentDevice();
+    });
+
+    expect(result.current.editUiState).toBe("signer-open");
+    expect(onApproval).not.toHaveBeenCalled();
+
+    await act(async () => {
+      result.current.grantSignerApproval();
+      await approval;
+    });
+
+    expect(onApproval).toHaveBeenCalledWith(true);
+  });
+
+  it("should decline the approval and return to the edit dialog when the mismatch is cancelled", async () => {
+    const { result } = renderHook(() => useContactEditSignerUiState());
+    let approval!: Promise<boolean>;
+
+    act(() => {
+      result.current.openEditDialog();
+      approval = result.current.requestSignerApproval();
+      result.current.openSignerMismatchDialog();
+    });
+
+    await act(async () => {
       result.current.onSignerMismatchCancel();
+      await expect(approval).resolves.toBe(false);
+    });
+
+    expect(result.current.editUiState).toBe("edit-open");
+  });
+
+  it("should ignore a mismatch cancel fired after leaving the mismatch step", async () => {
+    const { result } = renderHook(() => useContactEditSignerUiState());
+    const onApproval = jest.fn();
+    let approval!: Promise<boolean>;
+
+    act(() => {
+      result.current.openEditDialog();
+      approval = result.current.requestSignerApproval();
+      void approval.then(onApproval);
+      result.current.openSignerMismatchDialog();
+    });
+
+    act(() => {
+      result.current.onConnectDifferentDevice();
+      result.current.onSignerMismatchCancel();
+    });
+
+    expect(result.current.editUiState).toBe("signer-open");
+    expect(onApproval).not.toHaveBeenCalled();
+
+    await act(async () => {
+      result.current.grantSignerApproval();
+      await approval;
+    });
+
+    expect(onApproval).toHaveBeenCalledWith(true);
+  });
+
+  it("should close the edit dialog only from the edit step", () => {
+    const { result } = renderHook(() => useContactEditSignerUiState());
+
+    act(() => {
+      result.current.openEditDialog();
+      void result.current.requestSignerApproval();
+      result.current.onEditClose();
+    });
+
+    expect(result.current.editUiState).toBe("signer-open");
+
+    act(() => {
+      result.current.grantSignerApproval();
+      result.current.onEditClose();
+    });
+
+    expect(result.current.editUiState).toBe("closed");
+    expect(result.current.isEditSessionActive).toBe(false);
+  });
+
+  it("should decline the approval when the flow is reset", async () => {
+    const { result } = renderHook(() => useContactEditSignerUiState());
+    let approval!: Promise<boolean>;
+
+    act(() => {
+      result.current.openEditDialog();
+      approval = result.current.requestSignerApproval();
+    });
+
+    await act(async () => {
+      result.current.resetEditUiState();
+      await expect(approval).resolves.toBe(false);
     });
 
     expect(result.current.editUiState).toBe("closed");
   });
 
-  it("should return to the signer dialog when connecting a different device", () => {
+  it("should decline a pending approval when a new signer request replaces it", async () => {
     const { result } = renderHook(() => useContactEditSignerUiState());
+    let firstApproval!: Promise<boolean>;
+    let secondApproval!: Promise<boolean>;
 
     act(() => {
-      result.current.openSignerMismatchDialog();
-      result.current.onConnectDifferentDevice();
+      result.current.openEditDialog();
+      firstApproval = result.current.requestSignerApproval();
     });
 
+    act(() => {
+      secondApproval = result.current.requestSignerApproval();
+    });
+
+    await expect(firstApproval).resolves.toBe(false);
     expect(result.current.editUiState).toBe("signer-open");
+
+    await act(async () => {
+      result.current.grantSignerApproval();
+      await expect(secondApproval).resolves.toBe(true);
+    });
   });
 });

--- a/features/flow/contacts/src/steps/EditAddress/types.ts
+++ b/features/flow/contacts/src/steps/EditAddress/types.ts
@@ -45,7 +45,11 @@ export type UseRenameAddressDialogViewModelOptions = Readonly<{
   currencyId: ContactAddress["currencyId"] | undefined;
   existingLabels: readonly ContactAddressLabel[];
   editPort: ContactAddressEditPort;
+  isRequestedOpen: boolean;
+  isEditSessionActive?: boolean;
+  onCloseRequest: () => void;
   onSaveSuccess?: (payload: ContactAddressEditSavePayload) => void;
+  requestSaveApproval?: () => Promise<boolean>;
 }>;
 
 export type ContactsEditAddressValidationLabels = Readonly<{

--- a/features/flow/contacts/src/steps/EditAddress/useRenameAddressDialogViewModel.ts
+++ b/features/flow/contacts/src/steps/EditAddress/useRenameAddressDialogViewModel.ts
@@ -23,20 +23,18 @@ export function useRenameAddressDialogViewModel({
   addressValidation,
   manualValidationDebounceMs,
   isRequestedOpen,
+  isEditSessionActive = isRequestedOpen,
   onCloseRequest,
   onSaveSuccess,
-}: UseRenameAddressDialogViewModelOptionsWithValidation &
-  Readonly<{
-    isRequestedOpen: boolean;
-    onCloseRequest: () => void;
-  }>): RenameAddressDialogViewModel {
+  requestSaveApproval,
+}: UseRenameAddressDialogViewModelOptionsWithValidation): RenameAddressDialogViewModel {
   const [draftLabel, setDraftLabel] = useState(currentLabel);
   const [isSaving, setIsSaving] = useState(false);
   const { addressEntry, onAddressChange } = useEditAddressAddressEntry({
     addressValidation,
     currencyId,
     currentAddress,
-    isActive: isRequestedOpen,
+    isActive: isEditSessionActive,
     manualValidationDebounceMs,
   });
   const { invalidLabelError, isConfirmEnabled, save } = useRenameAddressViewModel(
@@ -51,15 +49,10 @@ export function useRenameAddressDialogViewModel({
   );
 
   useEffect(() => {
-    if (isRequestedOpen) {
+    if (isEditSessionActive) {
       setDraftLabel(currentLabel);
     }
-  }, [currentLabel, isRequestedOpen]);
-
-  const onClose = useCallback(() => {
-    onCloseRequest();
-    setDraftLabel(currentLabel);
-  }, [currentLabel, onCloseRequest]);
+  }, [currentLabel, isEditSessionActive]);
 
   const onDraftLabelChange = useCallback(
     (label: string) => setDraftLabel(label.slice(0, CONTACT_ADDRESS_LABEL_MAX_LENGTH)),
@@ -74,6 +67,10 @@ export function useRenameAddressDialogViewModel({
     setIsSaving(true);
 
     try {
+      if (requestSaveApproval !== undefined && !(await requestSaveApproval())) {
+        return;
+      }
+
       await save();
       const addressChanged =
         addressEntry.status === "valid" &&
@@ -101,6 +98,7 @@ export function useRenameAddressDialogViewModel({
     isSaving,
     onCloseRequest,
     onSaveSuccess,
+    requestSaveApproval,
     save,
   ]);
 
@@ -112,7 +110,7 @@ export function useRenameAddressDialogViewModel({
     addressEntry,
     isConfirmEnabled: isConfirmEnabled && !isSaving,
     onOpen: () => undefined,
-    onClose,
+    onClose: onCloseRequest,
     onDraftLabelChange,
     onAddressChange,
     onConfirm,

--- a/features/flow/contacts/src/steps/EditAddress/useRenameAddressDialogViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/EditAddress/useRenameAddressDialogViewModel.web.test.ts
@@ -132,4 +132,109 @@ describe("useRenameAddressDialogViewModel", () => {
     });
     expect(onCloseRequest).toHaveBeenCalledTimes(1);
   });
+
+  it("should keep the draft while the signer approval is pending", async () => {
+    const onCloseRequest = jest.fn();
+    const onSaveSuccess = jest.fn();
+    const updateAddress = jest.fn().mockResolvedValue(
+      contactAddress({
+        ...address,
+        label: "Main ETH",
+      }),
+    );
+    let approveSave!: (approved: boolean) => void;
+    const requestSaveApproval = jest.fn(
+      () =>
+        new Promise<boolean>(resolve => {
+          approveSave = resolve;
+        }),
+    );
+    const { result, rerender } = renderHook(
+      ({ isRequestedOpen }) =>
+        useRenameAddressDialogViewModel({
+          contactId: contact.id,
+          addressId: address.id,
+          currentLabel: address.label,
+          currentAddress: address.address,
+          currencyId: address.currencyId,
+          existingLabels: [],
+          editPort: createEditPort({ updateAddress }),
+          isRequestedOpen,
+          isEditSessionActive: true,
+          onCloseRequest,
+          onSaveSuccess,
+          requestSaveApproval,
+        }),
+      { initialProps: { isRequestedOpen: true } },
+    );
+
+    act(() => {
+      result.current.onDraftLabelChange("Main ETH");
+    });
+
+    let confirmed!: Promise<void>;
+
+    act(() => {
+      confirmed = result.current.onConfirm();
+    });
+
+    rerender({ isRequestedOpen: false });
+
+    expect(updateAddress).not.toHaveBeenCalled();
+    expect(result.current.isSaving).toBe(true);
+    expect(result.current.draftLabel).toBe("Main ETH");
+    expect(result.current.addressEntry.value).toBe(address.address);
+
+    await act(async () => {
+      approveSave(true);
+      await confirmed;
+    });
+
+    expect(updateAddress).toHaveBeenCalledWith({
+      contactId: contact.id,
+      addressId: address.id,
+      label: "Main ETH",
+      address: address.address,
+    });
+    expect(onSaveSuccess).toHaveBeenCalledTimes(1);
+    expect(onCloseRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not save when the signer approval is declined", async () => {
+    const onCloseRequest = jest.fn();
+    const onSaveSuccess = jest.fn();
+    const updateAddress = jest.fn();
+    const requestSaveApproval = jest.fn().mockResolvedValue(false);
+    const { result } = renderHook(() =>
+      useRenameAddressDialogViewModel({
+        contactId: contact.id,
+        addressId: address.id,
+        currentLabel: address.label,
+        currentAddress: address.address,
+        currencyId: address.currencyId,
+        existingLabels: [],
+        editPort: createEditPort({ updateAddress }),
+        isRequestedOpen: true,
+        isEditSessionActive: true,
+        onCloseRequest,
+        onSaveSuccess,
+        requestSaveApproval,
+      }),
+    );
+
+    act(() => {
+      result.current.onDraftLabelChange("Main ETH");
+    });
+
+    await act(async () => {
+      await result.current.onConfirm();
+    });
+
+    expect(updateAddress).not.toHaveBeenCalled();
+    expect(onSaveSuccess).not.toHaveBeenCalled();
+    expect(onCloseRequest).not.toHaveBeenCalled();
+    expect(result.current.draftLabel).toBe("Main ETH");
+    expect(result.current.addressEntry.value).toBe(address.address);
+    expect(result.current.isSaving).toBe(false);
+  });
 });

--- a/features/flow/contacts/src/steps/EditContact/types.ts
+++ b/features/flow/contacts/src/steps/EditContact/types.ts
@@ -21,7 +21,11 @@ export type UseRenameContactDialogViewModelOptions = Readonly<{
   contactId: ContactId;
   currentName: string;
   editPort: ContactEditPort;
+  isRequestedOpen: boolean;
+  isEditSessionActive?: boolean;
+  onCloseRequest: () => void;
   onSaveSuccess: () => void;
+  requestSaveApproval?: () => Promise<boolean>;
 }>;
 
 export type ContactsRenameContactLabels = Readonly<{

--- a/features/flow/contacts/src/steps/EditContact/useRenameContactDialogViewModel.ts
+++ b/features/flow/contacts/src/steps/EditContact/useRenameContactDialogViewModel.ts
@@ -8,13 +8,11 @@ export function useRenameContactDialogViewModel({
   currentName,
   editPort,
   isRequestedOpen,
+  isEditSessionActive = isRequestedOpen,
   onCloseRequest,
   onSaveSuccess,
-}: UseRenameContactDialogViewModelOptions &
-  Readonly<{
-    isRequestedOpen: boolean;
-    onCloseRequest: () => void;
-  }>): RenameContactDialogViewModel {
+  requestSaveApproval,
+}: UseRenameContactDialogViewModelOptions): RenameContactDialogViewModel {
   const [draftName, setDraftName] = useState(currentName);
   const [isSaving, setIsSaving] = useState(false);
   const { invalidNameError, isConfirmEnabled, save } = useRenameContactViewModel(
@@ -25,15 +23,10 @@ export function useRenameContactDialogViewModel({
   );
 
   useEffect(() => {
-    if (isRequestedOpen) {
+    if (isEditSessionActive) {
       setDraftName(currentName);
     }
-  }, [currentName, isRequestedOpen]);
-
-  const onClose = useCallback(() => {
-    onCloseRequest();
-    setDraftName(currentName);
-  }, [currentName, onCloseRequest]);
+  }, [currentName, isEditSessionActive]);
 
   const onDraftNameChange = useCallback(
     (name: string) => setDraftName(name.slice(0, CONTACT_NAME_MAX_LENGTH)),
@@ -48,6 +41,10 @@ export function useRenameContactDialogViewModel({
     setIsSaving(true);
 
     try {
+      if (requestSaveApproval !== undefined && !(await requestSaveApproval())) {
+        return;
+      }
+
       await save();
       onSaveSuccess();
       onCloseRequest();
@@ -56,7 +53,7 @@ export function useRenameContactDialogViewModel({
     } finally {
       setIsSaving(false);
     }
-  }, [isConfirmEnabled, isSaving, onCloseRequest, onSaveSuccess, save]);
+  }, [isConfirmEnabled, isSaving, onCloseRequest, onSaveSuccess, requestSaveApproval, save]);
 
   return {
     isOpen: isRequestedOpen,
@@ -65,7 +62,7 @@ export function useRenameContactDialogViewModel({
     invalidNameError,
     isConfirmEnabled: isConfirmEnabled && !isSaving,
     onOpen: () => undefined,
-    onClose,
+    onClose: onCloseRequest,
     onDraftNameChange,
     onConfirm,
   };

--- a/features/flow/contacts/src/steps/EditContact/useRenameContactDialogViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/EditContact/useRenameContactDialogViewModel.web.test.ts
@@ -82,18 +82,20 @@ describe("useRenameContactDialogViewModel", () => {
     expect(result.current.isSaving).toBe(false);
   });
 
-  it("should reset the draft and close when cancel is requested", () => {
+  it("should discard the draft when the dialog is cancelled and opened again", () => {
     const onCloseRequest = jest.fn();
     const onSaveSuccess = jest.fn();
-    const { result } = renderHook(() =>
-      useRenameContactDialogViewModel({
-        contactId: savedContact.id,
-        currentName: "Ada",
-        editPort: createEditPort(),
-        isRequestedOpen: true,
-        onCloseRequest,
-        onSaveSuccess,
-      }),
+    const { result, rerender } = renderHook(
+      ({ isRequestedOpen }) =>
+        useRenameContactDialogViewModel({
+          contactId: savedContact.id,
+          currentName: "Ada",
+          editPort: createEditPort(),
+          isRequestedOpen,
+          onCloseRequest,
+          onSaveSuccess,
+        }),
+      { initialProps: { isRequestedOpen: true } },
     );
 
     act(() => {
@@ -102,6 +104,102 @@ describe("useRenameContactDialogViewModel", () => {
     });
 
     expect(onCloseRequest).toHaveBeenCalledTimes(1);
+
+    rerender({ isRequestedOpen: false });
+    rerender({ isRequestedOpen: true });
+
     expect(result.current.draftName).toBe("Ada");
+  });
+
+  it("should keep the draft while the signer approval is pending", async () => {
+    const onCloseRequest = jest.fn();
+    const onSaveSuccess = jest.fn();
+    const renameContact = jest.fn().mockResolvedValue(
+      contact({
+        id: savedContact.id,
+        isMe: false,
+        name: "Ben",
+        addresses: [],
+      }),
+    );
+    let approveSave!: (approved: boolean) => void;
+    const requestSaveApproval = jest.fn(
+      () =>
+        new Promise<boolean>(resolve => {
+          approveSave = resolve;
+        }),
+    );
+    const { result, rerender } = renderHook(
+      ({ isRequestedOpen }) =>
+        useRenameContactDialogViewModel({
+          contactId: savedContact.id,
+          currentName: "Ada",
+          editPort: createEditPort({ renameContact }),
+          isRequestedOpen,
+          isEditSessionActive: true,
+          onCloseRequest,
+          onSaveSuccess,
+          requestSaveApproval,
+        }),
+      { initialProps: { isRequestedOpen: true } },
+    );
+
+    act(() => {
+      result.current.onDraftNameChange("Ben");
+    });
+
+    let confirmed!: Promise<void>;
+
+    act(() => {
+      confirmed = result.current.onConfirm();
+    });
+
+    rerender({ isRequestedOpen: false });
+
+    expect(renameContact).not.toHaveBeenCalled();
+    expect(result.current.isSaving).toBe(true);
+
+    await act(async () => {
+      approveSave(true);
+      await confirmed;
+    });
+
+    expect(result.current.draftName).toBe("Ben");
+    expect(renameContact).toHaveBeenCalledWith({ contactId: savedContact.id, name: "Ben" });
+    expect(onSaveSuccess).toHaveBeenCalledTimes(1);
+    expect(onCloseRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not save when the signer approval is declined", async () => {
+    const onCloseRequest = jest.fn();
+    const onSaveSuccess = jest.fn();
+    const renameContact = jest.fn();
+    const requestSaveApproval = jest.fn().mockResolvedValue(false);
+    const { result } = renderHook(() =>
+      useRenameContactDialogViewModel({
+        contactId: savedContact.id,
+        currentName: "Ada",
+        editPort: createEditPort({ renameContact }),
+        isRequestedOpen: true,
+        isEditSessionActive: true,
+        onCloseRequest,
+        onSaveSuccess,
+        requestSaveApproval,
+      }),
+    );
+
+    act(() => {
+      result.current.onDraftNameChange("Ben");
+    });
+
+    await act(async () => {
+      await result.current.onConfirm();
+    });
+
+    expect(renameContact).not.toHaveBeenCalled();
+    expect(onSaveSuccess).not.toHaveBeenCalled();
+    expect(onCloseRequest).not.toHaveBeenCalled();
+    expect(result.current.draftName).toBe("Ben");
+    expect(result.current.isSaving).toBe(false);
   });
 });


### PR DESCRIPTION
### 📝 Description

Editing a contact name or an address label prompted the user to connect their Ledger **before** the edit form even opened, so people had to plug in a device just to discover what they were about to change — and the device step was wasted if they backed out.

**Previous behaviour:** pressing *Edit* on a contact (or an address) immediately opened the signer validation step. Only once the device was connected and confirmed did the rename form appear.

**Fix:** the edit form now opens straight away, and device validation is deferred to *Save*. The signer step became an awaitable gate:

- `useContactEditSignerUiState` exposes `requestSignerApproval()` (returns a promise resolved by `grantSignerApproval()` once the device confirms) alongside a new `isEditSessionActive` flag.
- `onEditPress` in both flow view models (`useContactDetailEditDeleteFlowViewModel`, `useContactAddressDetailActionsFlowViewModel`) just opens the edit dialog; each now provides `requestSaveApproval`, which only hits the device when signer validation is actually required for that edit.
- The rename view models (`useRenameContactDialogViewModel`, `useRenameAddressDialogViewModel`) `await requestSaveApproval()` inside `onConfirm` and skip the write if the user declines.

**Draft preservation:** because the edit dialog hides while the signer step is on screen, the draft reset is now keyed on `isEditSessionActive` rather than the dialog's open state, so the user's typed name/label survives the device round trip. Cancelling a signer mismatch returns to the still-populated form (`resolveEditUiStateOnSignerMismatchCancel` now yields `"edit-open"` instead of `"closed"`).

**Mobile specifics:** `QueuedBottomSheet` fires `onClose` whenever it stops being requested, which would have cleared the selected address as soon as the signer sheet took over — `useContactAddressDetailActionsAdapter` now guards its close on `editUiState === "edit-open"`. Both adapters also scope the "edit address" page event to `isEditSessionActive` so returning from the signer step doesn't emit a duplicate analytics event.


https://github.com/user-attachments/assets/5b747f97-8e5d-4126-acf0-f7f2e7f006f8



### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35851](https://ledgerhq.atlassian.net/browse/LIVE-35851)
- **ADR** (if any): n/a

[LIVE-35851]: https://ledgerhq.atlassian.net/browse/LIVE-35851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ