### PR TITLE
fix(braze): disable user-supplied javascript (LIVE-36343)

### DIFF
--- a/.changeset/quiet-otters-yell.md
+++ b/.changeset/quiet-otters-yell.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Disable Braze user-supplied JavaScript in HTML in-app messages and banners for security hardening

--- a/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
@@ -194,7 +194,7 @@ export function useBraze() {
 
     const isInitialized = braze.initialize(brazeConfig.apiKey, {
       baseUrl: brazeConfig.endpoint,
-      allowUserSuppliedJavascript: true,
+      allowUserSuppliedJavascript: false,
       enableLogging: __DEV__,
       sessionTimeoutInSeconds: devMode ? 1 : 1800,
       appVersion: isTrackedUser ? __APP_VERSION__ : undefined,


### PR DESCRIPTION
## Summary
- Sets `allowUserSuppliedJavascript: false` when initializing the Braze Web SDK (`apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts`), disabling Braze's native HTML in-app-message/Banner renderer's ability to execute JavaScript.
- Content Cards, the Generic Awareness Modal, and Dynamic Content are unaffected — they're rendered by custom React components fed from typed `card.extras`, not Braze's raw HTML renderer. No other Banner usage exists in the app, so no functional feature is lost.
- Mobile (`@braze/react-native-sdk`) is intentionally out of scope: its in-app-message rendering happens entirely inside Braze's native SDK, and the only JS-level control (`subscribeToInAppMessage`) is all-or-nothing with no way to block just JS-capable message types. Per discussion, mobile is not addressed in this PR.

Related: LIVE-36343, LIVE-36344

## Test plan
- [ ] `pnpm typecheck` / `pnpm lint` scoped to `ledger-live-desktop`
- [ ] Manually verify Braze initializes without errors in the desktop app
- [ ] Confirm Content Cards / Generic Awareness Modal / Dynamic Content still render correctly
- [ ] Confirm changeset is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)