### PR TITLE
[LWM] feat(perps): add the perps deposit screen to mobile

### DIFF
--- a/.changeset/quiet-lions-deposit-mobile.md
+++ b/.changeset/quiet-lions-deposit-mobile.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add the perps deposit amount form, so a deposit requested by the live app collects its funding account and amount before the review step

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -68,6 +68,7 @@ import { getOperationTypeI18nKey } from "~/logic/operationTypeName";
 import { BaseNavigatorStackParamList } from "./types/BaseNavigator";
 import DeviceConnect, { deviceConnectHeaderOptions } from "~/screens/DeviceConnect";
 import PerpsSign from "LLM/features/Perps/screens/PerpsSign/PerpsSignScreen";
+import PerpsDeposit from "LLM/features/Perps/screens/PerpsDeposit/PerpsDepositScreen";
 import NoFundsFlowNavigator from "./NoFundsFlowNavigator";
 import StakeFlowNavigator from "./StakeFlowNavigator";
 import { RecoverPlayer } from "~/screens/Protect/Player";
@@ -184,6 +185,7 @@ export default function BaseNavigator() {
   // whole screen — same canvas `getStackNavigationConfigV4` paints from (`theme.colors.bg.canvas`).
   const { theme: lumenTheme } = useLumenTheme();
   const liveAppCanvasColor = lumenTheme.colors.bg.canvas;
+  const lumenBaseColor = lumenTheme.colors.bg.base;
   const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
   const nativeStackScreenOptions: Partial<NativeStackNavigationOptions> = stackNavigationConfig;
   const noNanoBuyNanoWallScreenOptions = useNoNanoBuyNanoWallScreenOptions();
@@ -576,6 +578,15 @@ export default function BaseNavigator() {
           name={ScreenName.PerpsSign}
           component={PerpsSign}
           options={{ headerShown: false }}
+        />
+        <Stack.Screen
+          name={ScreenName.PerpsDeposit}
+          component={PerpsDeposit}
+          options={{
+            title: t("perpsDeposit.title"),
+            headerStyle: { backgroundColor: lumenBaseColor },
+            contentStyle: { backgroundColor: lumenBaseColor },
+          }}
         />
         <Stack.Screen
           name={ScreenName.RedirectToOnboardingRecoverFlow}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
@@ -11,7 +11,10 @@ import type { NavigatorScreenParams } from "@react-navigation/native";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import { AppResult } from "@ledgerhq/live-common/hw/actions/app";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
-import type { PerpsSignResult } from "@ledgerhq/live-common/wallet-api/Perps/server";
+import type {
+  PerpsDepositUiParams,
+  PerpsSignResult,
+} from "@ledgerhq/live-common/wallet-api/Perps/server";
 import type { SendFlowInitParams } from "@ledgerhq/live-common/flows/send/types";
 import type { DecodedURISchemePayment } from "@ledgerhq/live-common/flows/send/utils/uriScheme";
 import type { AssetDetailNavigatorParamsList } from "LLM/features/AssetDetail/types";
@@ -362,6 +365,7 @@ export type BaseNavigatorStackParamList = {
     onError: (error: Error) => void;
     onCancel: () => void;
   };
+  [ScreenName.PerpsDeposit]: PerpsDepositUiParams;
   [ScreenName.DeeplinkInstallAppDeviceSelection]: {
     appKey: string;
   };

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -110,6 +110,7 @@ export enum ScreenName {
   DeveloperSettings = "DeveloperSettings",
   DeviceConnect = "DeviceConnect",
   PerpsSign = "PerpsSign",
+  PerpsDeposit = "PerpsDeposit",
   EditAccountName = "EditAccountName",
   EditDeviceName = "EditDeviceName",
   Card = "Card",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -9831,7 +9831,8 @@
     "review": "Review",
     "keypadDelete": "Delete last digit",
     "formErrors": {
-      "amountExceedsBalance": "Insufficient balance"
+      "amountExceedsBalance": "Insufficient balance",
+      "quoteUnavailable": "We can’t get a quote from SwapKit, try with a different asset or come back later."
     }
   },
   "swapErrors": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -9827,7 +9827,7 @@
     "inputSubText": "Swap and deposit via SwapKit",
     "selectCurrencyTitle": "Deposit with {{currencyTicker}}",
     "selectCurrencyAccount": "{{accountName}} · {{counterValue}}",
-    "selectCurrencyDescription": "No account",
+    "selectCurrencyNoAccount": "No account",
     "review": "Review",
     "keypadDelete": "Delete last digit",
     "formErrors": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -9821,6 +9821,19 @@
       "cta": "Try again"
     }
   },
+  "perpsDeposit": {
+    "title": "Deposit",
+    "inputDepositAmount": "Deposit ~{{value}}{{currencyTicker}}",
+    "inputSubText": "Swap and deposit via SwapKit",
+    "selectCurrencyTitle": "Deposit with {{currencyTicker}}",
+    "selectCurrencyAccount": "{{accountName}} · {{counterValue}}",
+    "selectCurrencyDescription": "No account",
+    "review": "Review",
+    "keypadDelete": "Delete last digit",
+    "formErrors": {
+      "amountExceedsBalance": "Insufficient balance"
+    }
+  },
   "swapErrors": {
     "incorrectCommandData": {
       "title": "Incorrect command data",

--- a/apps/ledger-live-mobile/src/mvvm/components/AmountKeypad/__tests__/AmountKeypad.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/AmountKeypad/__tests__/AmountKeypad.test.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { AmountKeypad, KEYPAD_DELETE_KEY } from "../index";
+
+const renderKeypad = (props: Partial<React.ComponentProps<typeof AmountKeypad>> = {}) => {
+  const onKeyPress = jest.fn();
+  const { user } = render(
+    <AmountKeypad
+      onKeyPress={onKeyPress}
+      testIDPrefix="amount-key"
+      deleteAccessibilityLabel="Delete last digit"
+      {...props}
+    />,
+  );
+  return { onKeyPress, user };
+};
+
+describe("AmountKeypad", () => {
+  it("emits the digit that was pressed", async () => {
+    const { onKeyPress, user } = renderKeypad();
+
+    await user.press(screen.getByTestId("amount-key-7"));
+
+    expect(onKeyPress).toHaveBeenCalledWith("7");
+  });
+
+  it("emits the decimal separator under its own test id", async () => {
+    const { onKeyPress, user } = renderKeypad();
+
+    await user.press(screen.getByTestId("amount-key-decimal"));
+
+    expect(onKeyPress).toHaveBeenCalledWith(".");
+  });
+
+  it("emits the delete key so the caller can trim the amount", async () => {
+    const { onKeyPress, user } = renderKeypad();
+
+    await user.press(screen.getByTestId("amount-key-delete"));
+
+    expect(onKeyPress).toHaveBeenCalledWith(KEYPAD_DELETE_KEY);
+  });
+
+  it("labels the delete key for screen readers", () => {
+    renderKeypad();
+
+    expect(screen.getByLabelText("Delete last digit")).toBeOnTheScreen();
+  });
+
+  it("ignores presses while disabled", async () => {
+    const { onKeyPress, user } = renderKeypad({ disabled: true });
+
+    await user.press(screen.getByTestId("amount-key-1"));
+
+    expect(onKeyPress).not.toHaveBeenCalled();
+  });
+
+  it("namespaces every key with the given prefix", () => {
+    renderKeypad({ testIDPrefix: "send-key" });
+
+    expect(screen.getByTestId("send-key-0")).toBeOnTheScreen();
+    expect(screen.getByTestId("send-key-delete")).toBeOnTheScreen();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/AmountKeypad/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/AmountKeypad/index.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { Pressable, View } from "react-native";
+import { Text } from "@ledgerhq/lumen-ui-rnative";
+import { Delete } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
+
+export const KEYPAD_DELETE_KEY = "delete";
+
+type AmountKeypadProps = Readonly<{
+  onKeyPress: (key: string) => void;
+  testIDPrefix: string;
+  deleteAccessibilityLabel: string;
+  disabled?: boolean;
+}>;
+
+const KEY_ROWS = [
+  ["1", "2", "3"],
+  ["4", "5", "6"],
+  ["7", "8", "9"],
+  [".", "0", KEYPAD_DELETE_KEY],
+];
+
+const KEY_TEST_ID_SUFFIXES: Record<string, string> = {
+  ".": "decimal",
+  [KEYPAD_DELETE_KEY]: "delete",
+};
+
+/**
+ * In-app numeric keypad for amount entry. Emits raw key presses, including
+ * `KEYPAD_DELETE_KEY`, and leaves it to the caller to build the amount text.
+ */
+export function AmountKeypad({
+  onKeyPress,
+  testIDPrefix,
+  deleteAccessibilityLabel,
+  disabled,
+}: AmountKeypadProps) {
+  const styles = useStyleSheet(
+    theme => ({
+      row: {
+        flexDirection: "row",
+        marginBottom: theme.spacings.s4,
+      },
+      key: {
+        flex: 1,
+        height: 52,
+        justifyContent: "center",
+        alignItems: "center",
+      },
+      keyPressed: {
+        backgroundColor: theme.colors.bg.mutedTransparent,
+      },
+    }),
+    [],
+  );
+
+  return (
+    <View>
+      {KEY_ROWS.map(row => (
+        <View key={row.join()} style={styles.row}>
+          {row.map(key => (
+            <Pressable
+              key={key}
+              disabled={disabled}
+              testID={`${testIDPrefix}-${KEY_TEST_ID_SUFFIXES[key] ?? key}`}
+              accessibilityLabel={key === KEYPAD_DELETE_KEY ? deleteAccessibilityLabel : key}
+              style={({ pressed }) => [styles.key, pressed && styles.keyPressed]}
+              onPress={() => onKeyPress(key)}
+            >
+              {key === KEYPAD_DELETE_KEY ? (
+                <Delete size={24} />
+              ) : (
+                <Text typography="heading2" lx={{ color: "base" }}>
+                  {key}
+                </Text>
+              )}
+            </Pressable>
+          ))}
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/RatioPicker/__tests__/RatioPicker.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/RatioPicker/__tests__/RatioPicker.test.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { RatioPicker } from "../index";
+
+const renderPicker = (props: Partial<React.ComponentProps<typeof RatioPicker>> = {}) => {
+  const onChange = jest.fn();
+  const onMax = jest.fn();
+  const { user } = render(
+    <RatioPicker
+      value={0}
+      maxValue={100}
+      decimalPlaces={2}
+      onChange={onChange}
+      onMax={onMax}
+      testIDPrefix="ratio"
+      {...props}
+    />,
+  );
+  return { onChange, onMax, user };
+};
+
+describe("RatioPicker", () => {
+  it("fills the field with the pressed share of the maximum", async () => {
+    const { onChange, user } = renderPicker();
+
+    await user.press(screen.getByTestId("ratio-25%"));
+
+    expect(onChange).toHaveBeenCalledWith(25);
+  });
+
+  it("rounds the share down to the allowed precision", async () => {
+    const { onChange, user } = renderPicker({ maxValue: 10.005, decimalPlaces: 2 });
+
+    await user.press(screen.getByTestId("ratio-50%"));
+
+    expect(onChange).toHaveBeenCalledWith(5);
+  });
+
+  it("delegates the max pill to its own handler", async () => {
+    const { onMax, onChange, user } = renderPicker();
+
+    await user.press(screen.getByTestId("ratio-MAX"));
+
+    expect(onMax).toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("disables the pill whose value the field already holds", async () => {
+    const { onChange, user } = renderPicker({ value: 50 });
+
+    await user.press(screen.getByTestId("ratio-50%"));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("disables the max pill once the field holds the whole balance", async () => {
+    const { onMax, user } = renderPicker({ value: 100 });
+
+    await user.press(screen.getByTestId("ratio-MAX"));
+
+    expect(onMax).not.toHaveBeenCalled();
+  });
+
+  it("disables every pill when there is nothing to spend", async () => {
+    const { onChange, onMax, user } = renderPicker({ maxValue: 0 });
+
+    await user.press(screen.getByTestId("ratio-25%"));
+    await user.press(screen.getByTestId("ratio-MAX"));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onMax).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/RatioPicker/applyRatio.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/RatioPicker/applyRatio.ts
@@ -1,0 +1,9 @@
+import BigNumber from "bignumber.js";
+
+/** `ratio` of `value`, rounded down to `decimalPlaces`. */
+export function applyRatio(value: number, ratio: number, decimalPlaces: number): number {
+  return BigNumber(value)
+    .times(ratio)
+    .decimalPlaces(decimalPlaces, BigNumber.ROUND_DOWN)
+    .toNumber();
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/RatioPicker/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/RatioPicker/index.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { Box, Button } from "@ledgerhq/lumen-ui-rnative";
+import { applyRatio } from "./applyRatio";
+
+export { applyRatio };
+
+type RatioPickerProps = Readonly<{
+  value: number;
+  maxValue: number;
+  decimalPlaces: number;
+  onChange: (value: number) => void;
+  onMax: () => void;
+  testIDPrefix: string;
+  disabled?: boolean;
+}>;
+
+const RATIOS = [
+  { label: "25%", ratio: 0.25 },
+  { label: "50%", ratio: 0.5 },
+  { label: "75%", ratio: 0.75 },
+];
+
+const MAX_LABEL = "MAX";
+
+/**
+ * Percentage pills that fill an amount field with a share of `maxValue`.
+ * A pill is disabled once the field already holds the value it would set.
+ */
+export function RatioPicker({
+  value,
+  maxValue,
+  decimalPlaces,
+  onChange,
+  onMax,
+  testIDPrefix,
+  disabled,
+}: RatioPickerProps) {
+  const maxOption = applyRatio(maxValue, 1, decimalPlaces);
+
+  return (
+    <Box lx={{ flexDirection: "row", gap: "s12" }}>
+      {RATIOS.map(({ label, ratio }) => {
+        const ratioValue = applyRatio(maxValue, ratio, decimalPlaces);
+        return (
+          <Button
+            key={label}
+            appearance="gray"
+            size="sm"
+            lx={{ flex: 1 }}
+            disabled={disabled || maxValue === 0 || value === ratioValue}
+            onPress={() => onChange(ratioValue)}
+            testID={`${testIDPrefix}-${label}`}
+          >
+            {label}
+          </Button>
+        );
+      })}
+      <Button
+        appearance="gray"
+        size="sm"
+        lx={{ flex: 1 }}
+        disabled={disabled || maxValue === 0 || value === maxOption}
+        onPress={onMax}
+        testID={`${testIDPrefix}-${MAX_LABEL}`}
+      >
+        {MAX_LABEL}
+      </Button>
+    </Box>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/constants/depositFunding.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/constants/depositFunding.ts
@@ -1,0 +1,3 @@
+/** Shown before the user picks a funding account */
+export const PERPS_DEPOSIT_DEFAULT_FUNDING_CURRENCY_ID = "arbitrum/erc20/usd_coin";
+export const PERPS_DEPOSIT_DEFAULT_FUNDING_TICKER = "USDC";

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/hooks/__tests__/usePerpsHandlers.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/hooks/__tests__/usePerpsHandlers.test.ts
@@ -59,4 +59,16 @@ describe("usePerpsHandlers", () => {
       onCancel: params.onCancel,
     });
   });
+
+  it("should navigate to the deposit amount form when deposit.execute is called", () => {
+    const accounts = [{ id: "acc-1" }] as never[];
+    const receiverAccount = { id: "receiver-1", name: "HL Account" } as never;
+
+    renderHook(() => usePerpsHandlers(accounts));
+
+    const depositExecute = mockedPerpsHandlers.mock.calls[0][0].uiHooks["deposit.execute"];
+    depositExecute?.({ receiverAccount });
+
+    expect(mockNavigate).toHaveBeenCalledWith("PerpsDeposit", { receiverAccount });
+  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/hooks/usePerpsHandlers.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/hooks/usePerpsHandlers.ts
@@ -47,7 +47,12 @@ export function usePerpsHandlers(accounts: AccountLike[]): WalletAPICustomHandle
     [navigation],
   );
 
-  const uiDepositExecute = useCallback((_params: PerpsDepositUiParams) => undefined, []);
+  const uiDepositExecute = useCallback(
+    (params: PerpsDepositUiParams) => {
+      navigation.navigate(ScreenName.PerpsDeposit, params);
+    },
+    [navigation],
+  );
 
   return useMemo<WalletAPICustomHandlers>(
     () =>

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/PerpsDepositScreen.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/PerpsDepositScreen.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { RootComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { ScreenName } from "~/const";
+import { PerpsDepositView } from ".";
+import { usePerpsDepositViewModel } from "./usePerpsDepositViewModel";
+
+type NavigationProps = RootComposite<
+  StackNavigatorProps<BaseNavigatorStackParamList, ScreenName.PerpsDeposit>
+>;
+
+export default function PerpsDepositScreen(props: NavigationProps) {
+  const viewModel = usePerpsDepositViewModel(props);
+  return <PerpsDepositView {...viewModel} />;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__integrations__/perpsDeposit.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__integrations__/perpsDeposit.integration.test.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import BigNumber from "bignumber.js";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
-import type { AccountLike } from "@ledgerhq/types-live";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import type { Account } from "@ledgerhq/types-live";
 import { act, render, screen } from "@tests/test-renderer";
 import PerpsDepositScreen from "../PerpsDepositScreen";
 
@@ -28,14 +29,12 @@ jest.mock("../usePerpsDepositQuote", () => ({
   usePerpsDepositQuote: () => mockUsePerpsDepositQuote(),
 }));
 
-function createAccount(id: string, spendableBalance: number): AccountLike {
+function createAccount(id: string, spendableBalance: number): Account {
   return {
-    type: "Account",
-    id,
-    currency: getCryptoCurrencyById("ethereum"),
+    ...genAccount(id, { currency: getCryptoCurrencyById("ethereum"), operationsSize: 0 }),
     spendableBalance: new BigNumber(spendableBalance),
     balance: new BigNumber(spendableBalance),
-  } as AccountLike;
+  };
 }
 
 const receiverAccount = createAccount("receiver-1", 0);
@@ -43,6 +42,19 @@ const fundingAccount = createAccount("funding-1", 10000);
 
 const mockNavigation = { navigate: jest.fn(), goBack: jest.fn(), setOptions: jest.fn() };
 const mockRoute = { params: { receiverAccount } };
+
+/** The funding account is read back from the store, so it has to live there. */
+function renderDeposit() {
+  return render(
+    <PerpsDepositScreen navigation={mockNavigation as never} route={mockRoute as never} />,
+    {
+      overrideInitialState: state => ({
+        ...state,
+        accounts: { ...state.accounts, active: [fundingAccount] },
+      }),
+    },
+  );
+}
 
 describe("PerpsDeposit integration", () => {
   beforeEach(() => {
@@ -54,9 +66,7 @@ describe("PerpsDeposit integration", () => {
   });
 
   it("should let the user pick a funding account before reviewing", async () => {
-    const { user } = render(
-      <PerpsDepositScreen navigation={mockNavigation as never} route={mockRoute as never} />,
-    );
+    const { user } = renderDeposit();
 
     expect(screen.getByTestId("perps-deposit-amount-input")).toBeOnTheScreen();
     // No funding account and no amount yet, so the review CTA stays disabled.
@@ -70,9 +80,7 @@ describe("PerpsDeposit integration", () => {
   });
 
   it("should type the amount with the in-app keypad", async () => {
-    const { user } = render(
-      <PerpsDepositScreen navigation={mockNavigation as never} route={mockRoute as never} />,
-    );
+    const { user } = renderDeposit();
 
     await user.press(screen.getByTestId("perps-deposit-key-5"));
     await user.press(screen.getByTestId("perps-deposit-key-0"));
@@ -85,9 +93,7 @@ describe("PerpsDeposit integration", () => {
   });
 
   it("should enable the review CTA once a funding account and amount are entered", async () => {
-    const { user } = render(
-      <PerpsDepositScreen navigation={mockNavigation as never} route={mockRoute as never} />,
-    );
+    const { user } = renderDeposit();
 
     await user.press(screen.getByTestId("perps-deposit-select-currency"));
     const { onAccountSelected } = mockOpenDrawer.mock.calls[0][0];
@@ -100,9 +106,7 @@ describe("PerpsDeposit integration", () => {
   });
 
   it("should only advertise the provider once an amount is entered", async () => {
-    const { user } = render(
-      <PerpsDepositScreen navigation={mockNavigation as never} route={mockRoute as never} />,
-    );
+    const { user } = renderDeposit();
 
     expect(screen.queryByText("Swap and deposit via SwapKit")).not.toBeOnTheScreen();
 
@@ -118,9 +122,7 @@ describe("PerpsDeposit integration", () => {
 
   it("should shimmer the quoted amount and keep the CTA disabled while quoting", async () => {
     mockUsePerpsDepositQuote.mockReturnValue({ quote: undefined, isLoading: true });
-    const { user } = render(
-      <PerpsDepositScreen navigation={mockNavigation as never} route={mockRoute as never} />,
-    );
+    const { user } = renderDeposit();
 
     await user.press(screen.getByTestId("perps-deposit-select-currency"));
     const { onAccountSelected } = mockOpenDrawer.mock.calls[0][0];

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__integrations__/perpsDeposit.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__integrations__/perpsDeposit.integration.test.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import type { AccountLike } from "@ledgerhq/types-live";
+import { act, render, screen } from "@tests/test-renderer";
+import PerpsDepositScreen from "../PerpsDepositScreen";
+
+const mockOpenDrawer = jest.fn();
+jest.mock("LLM/features/ModularDrawer", () => ({
+  useModularDrawerController: () => ({ openDrawer: mockOpenDrawer }),
+}));
+
+// Countervalues are priced 1:1 with the account balance so the form ceiling is
+// predictable: a balance of 10_000 (2 decimals for USD) means a $100 maximum.
+jest.mock("@ledgerhq/live-countervalues-react", () => ({
+  ...jest.requireActual("@ledgerhq/live-countervalues-react"),
+  useCalculateCountervalueCallback: () => (_currency: unknown, value: BigNumber) => value,
+  useCountervaluesState: () => ({}),
+}));
+
+jest.mock("@ledgerhq/live-countervalues/logic", () => ({
+  ...jest.requireActual("@ledgerhq/live-countervalues/logic"),
+  calculate: () => 20000000000000000,
+}));
+
+const mockUsePerpsDepositQuote = jest.fn();
+jest.mock("../usePerpsDepositQuote", () => ({
+  usePerpsDepositQuote: () => mockUsePerpsDepositQuote(),
+}));
+
+function createAccount(id: string, spendableBalance: number): AccountLike {
+  return {
+    type: "Account",
+    id,
+    currency: getCryptoCurrencyById("ethereum"),
+    spendableBalance: new BigNumber(spendableBalance),
+    balance: new BigNumber(spendableBalance),
+  } as AccountLike;
+}
+
+const receiverAccount = createAccount("receiver-1", 0);
+const fundingAccount = createAccount("funding-1", 10000);
+
+const mockNavigation = { navigate: jest.fn(), goBack: jest.fn(), setOptions: jest.fn() };
+const mockRoute = { params: { receiverAccount } };
+
+describe("PerpsDeposit integration", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePerpsDepositQuote.mockReturnValue({
+      quote: { amountTo: new BigNumber(42) },
+      isLoading: false,
+    });
+  });
+
+  it("should let the user pick a funding account before reviewing", async () => {
+    const { user } = render(
+      <PerpsDepositScreen navigation={mockNavigation as never} route={mockRoute as never} />,
+    );
+
+    expect(screen.getByTestId("perps-deposit-amount-input")).toBeOnTheScreen();
+    // No funding account and no amount yet, so the review CTA stays disabled.
+    expect(screen.getByTestId("perps-deposit-review-cta")).toBeDisabled();
+
+    await user.press(screen.getByTestId("perps-deposit-select-currency"));
+
+    expect(mockOpenDrawer).toHaveBeenCalledWith(
+      expect.objectContaining({ uiUseCase: "perpetuals:fund" }),
+    );
+  });
+
+  it("should type the amount with the in-app keypad", async () => {
+    const { user } = render(
+      <PerpsDepositScreen navigation={mockNavigation as never} route={mockRoute as never} />,
+    );
+
+    await user.press(screen.getByTestId("perps-deposit-key-5"));
+    await user.press(screen.getByTestId("perps-deposit-key-0"));
+
+    expect(screen.getByTestId("perps-deposit-amount-input").props.value).toBe("50");
+
+    await user.press(screen.getByTestId("perps-deposit-key-delete"));
+
+    expect(screen.getByTestId("perps-deposit-amount-input").props.value).toBe("5");
+  });
+
+  it("should enable the review CTA once a funding account and amount are entered", async () => {
+    const { user } = render(
+      <PerpsDepositScreen navigation={mockNavigation as never} route={mockRoute as never} />,
+    );
+
+    await user.press(screen.getByTestId("perps-deposit-select-currency"));
+    const { onAccountSelected } = mockOpenDrawer.mock.calls[0][0];
+    act(() => onAccountSelected(fundingAccount));
+
+    await user.press(screen.getByTestId("perps-deposit-key-2"));
+    await user.press(screen.getByTestId("perps-deposit-key-0"));
+
+    expect(screen.getByTestId("perps-deposit-review-cta")).not.toBeDisabled();
+  });
+
+  it("should only advertise the provider once an amount is entered", async () => {
+    const { user } = render(
+      <PerpsDepositScreen navigation={mockNavigation as never} route={mockRoute as never} />,
+    );
+
+    expect(screen.queryByText("Swap and deposit via SwapKit")).not.toBeOnTheScreen();
+
+    await user.press(screen.getByTestId("perps-deposit-select-currency"));
+    const { onAccountSelected } = mockOpenDrawer.mock.calls[0][0];
+    act(() => onAccountSelected(fundingAccount));
+
+    await user.press(screen.getByTestId("perps-deposit-key-2"));
+    await user.press(screen.getByTestId("perps-deposit-key-0"));
+
+    expect(screen.getByText("Swap and deposit via SwapKit")).toBeOnTheScreen();
+  });
+
+  it("should shimmer the quoted amount and keep the CTA disabled while quoting", async () => {
+    mockUsePerpsDepositQuote.mockReturnValue({ quote: undefined, isLoading: true });
+    const { user } = render(
+      <PerpsDepositScreen navigation={mockNavigation as never} route={mockRoute as never} />,
+    );
+
+    await user.press(screen.getByTestId("perps-deposit-select-currency"));
+    const { onAccountSelected } = mockOpenDrawer.mock.calls[0][0];
+    act(() => onAccountSelected(fundingAccount));
+
+    await user.press(screen.getByTestId("perps-deposit-key-2"));
+    await user.press(screen.getByTestId("perps-deposit-key-0"));
+
+    expect(screen.getByTestId("perps-deposit-quote-skeleton")).toBeOnTheScreen();
+    expect(screen.getByTestId("perps-deposit-review-cta")).toBeDisabled();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__integrations__/perpsDeposit.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__integrations__/perpsDeposit.integration.test.tsx
@@ -62,6 +62,7 @@ describe("PerpsDeposit integration", () => {
     mockUsePerpsDepositQuote.mockReturnValue({
       quote: { amountTo: new BigNumber(42) },
       isLoading: false,
+      isUnavailable: false,
     });
   });
 
@@ -120,8 +121,35 @@ describe("PerpsDeposit integration", () => {
     expect(screen.getByText("Swap and deposit via SwapKit")).toBeOnTheScreen();
   });
 
+  it("should tell the user when the provider has no quote for the pair", async () => {
+    mockUsePerpsDepositQuote.mockReturnValue({
+      quote: undefined,
+      isLoading: false,
+      isUnavailable: true,
+    });
+    const { user } = renderDeposit();
+
+    await user.press(screen.getByTestId("perps-deposit-select-currency"));
+    const { onAccountSelected } = mockOpenDrawer.mock.calls[0][0];
+    act(() => onAccountSelected(fundingAccount));
+
+    await user.press(screen.getByTestId("perps-deposit-key-2"));
+    await user.press(screen.getByTestId("perps-deposit-key-0"));
+
+    expect(screen.getByTestId("perps-deposit-form-error")).toHaveTextContent(
+      "We can’t get a quote from SwapKit, try with a different asset or come back later.",
+    );
+    // The message replaces the provider notice instead of stacking with it.
+    expect(screen.queryByText("Swap and deposit via SwapKit")).not.toBeOnTheScreen();
+    expect(screen.getByTestId("perps-deposit-review-cta")).toBeDisabled();
+  });
+
   it("should shimmer the quoted amount and keep the CTA disabled while quoting", async () => {
-    mockUsePerpsDepositQuote.mockReturnValue({ quote: undefined, isLoading: true });
+    mockUsePerpsDepositQuote.mockReturnValue({
+      quote: undefined,
+      isLoading: true,
+      isUnavailable: false,
+    });
     const { user } = renderDeposit();
 
     await user.press(screen.getByTestId("perps-deposit-select-currency"));

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositQuote.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositQuote.test.ts
@@ -116,6 +116,19 @@ describe("usePerpsDepositQuote", () => {
     expect(result.current.quote).toBeUndefined();
   });
 
+  it("keeps the quote when the funding account is only refreshed", async () => {
+    const { result, rerenderWith } = renderQuote({ amount: "2000", depositAccount });
+
+    await waitFor(() => expect(result.current.quote).toBeDefined(), { timeout: 2000 });
+    // A background sync hands back the same account as a new object.
+    rerenderWith({ amount: "2000", depositAccount: { ...depositAccount } });
+    await passDebounce();
+
+    expect(result.current.quote?.quoteId).toBe("quote-1");
+    expect(result.current.isLoading).toBe(false);
+    expect(mockFetchPerpsDepositQuote).toHaveBeenCalledTimes(1);
+  });
+
   it("drops the quoted amount when the funding account changes", async () => {
     const { result, rerenderWith, seen } = renderQuote({ amount: "2000", depositAccount });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositQuote.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositQuote.test.ts
@@ -1,0 +1,128 @@
+import BigNumber from "bignumber.js";
+import type { AccountLike } from "@ledgerhq/types-live";
+import { act, renderHook, waitFor } from "@tests/test-renderer";
+import { usePerpsDepositQuote, type PerpsDepositQuoteState } from "../usePerpsDepositQuote";
+
+const mockFetchPerpsDepositQuote = jest.fn();
+jest.mock("@ledgerhq/live-common/wallet-api/Perps/depositQuote", () => ({
+  fetchPerpsDepositQuote: (params: unknown) => mockFetchPerpsDepositQuote(params),
+}));
+
+const receiverAccount = { id: "receiver-1" } as AccountLike;
+const depositAccount = { id: "funding-1" } as AccountLike;
+
+type QuoteProps = { amount: string; depositAccount: AccountLike | undefined };
+
+function renderQuote(initialProps: QuoteProps) {
+  let props = initialProps;
+
+  const seen: PerpsDepositQuoteState[] = [];
+  const view = renderHook(() => {
+    const state = usePerpsDepositQuote({ ...props, receiverAccount });
+    seen.push(state);
+    return state;
+  });
+
+  return {
+    ...view,
+    seen,
+    rerenderWith(next: QuoteProps) {
+      props = next;
+      act(() => view.rerender(undefined));
+    },
+  };
+}
+
+/** Outlasts the debounce the hook waits out before reaching the provider. */
+async function passDebounce() {
+  await act(async () => {
+    jest.advanceTimersByTime(600);
+  });
+}
+
+describe("usePerpsDepositQuote", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetchPerpsDepositQuote.mockResolvedValue({
+      amountTo: new BigNumber("19.75"),
+      quoteId: "quote-1",
+    });
+  });
+
+  it("returns the amount the provider quotes for the funding pair", async () => {
+    const { result } = renderQuote({ amount: "2000", depositAccount });
+
+    await waitFor(() => expect(result.current.quote?.amountTo.toString()).toBe("19.75"), {
+      timeout: 2000,
+    });
+    expect(result.current.quote?.quoteId).toBe("quote-1");
+    expect(result.current.isLoading).toBe(false);
+    expect(mockFetchPerpsDepositQuote).toHaveBeenCalledWith(
+      expect.objectContaining({ depositAccount, receiverAccount, amount: "2000" }),
+    );
+  });
+
+  it("reports no route for the pair as unavailable", async () => {
+    mockFetchPerpsDepositQuote.mockResolvedValue(undefined);
+    const { result } = renderQuote({ amount: "2000", depositAccount });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false), { timeout: 2000 });
+    expect(result.current.quote).toBeUndefined();
+    expect(result.current.isUnavailable).toBe(true);
+  });
+
+  it("reports a failed provider request as unavailable", async () => {
+    mockFetchPerpsDepositQuote.mockRejectedValue(new Error("network down"));
+    const { result } = renderQuote({ amount: "2000", depositAccount });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false), { timeout: 2000 });
+    expect(result.current.quote).toBeUndefined();
+    expect(result.current.isUnavailable).toBe(true);
+  });
+
+  it("only quotes the amount the form settled on", async () => {
+    const { rerenderWith } = renderQuote({ amount: "2000", depositAccount });
+
+    rerenderWith({ amount: "3000", depositAccount });
+    await passDebounce();
+
+    expect(mockFetchPerpsDepositQuote).toHaveBeenCalledTimes(1);
+    expect(mockFetchPerpsDepositQuote).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: "3000" }),
+    );
+  });
+
+  it("quotes nothing without an amount or a funding account", async () => {
+    const { result } = renderQuote({ amount: "", depositAccount });
+    renderQuote({ amount: "2000", depositAccount: undefined });
+
+    await passDebounce();
+
+    expect(mockFetchPerpsDepositQuote).not.toHaveBeenCalled();
+    // Nothing to quote is idle: neither pending nor a provider outage.
+    expect(result.current).toEqual({ quote: undefined, isLoading: false, isUnavailable: false });
+  });
+
+  it("drops the quoted amount in the very render the amount changes", async () => {
+    const { result, rerenderWith, seen } = renderQuote({ amount: "2000", depositAccount });
+
+    await waitFor(() => expect(result.current.quote).toBeDefined(), { timeout: 2000 });
+    seen.length = 0;
+    rerenderWith({ amount: "3000", depositAccount });
+
+    // The review reads the quote during render, so $2000 must not still be
+    // quotable in the render that asks for $3000.
+    expect(seen[0]).toEqual({ quote: undefined, isLoading: true, isUnavailable: false });
+    expect(result.current.quote).toBeUndefined();
+  });
+
+  it("drops the quoted amount when the funding account changes", async () => {
+    const { result, rerenderWith, seen } = renderQuote({ amount: "2000", depositAccount });
+
+    await waitFor(() => expect(result.current.quote).toBeDefined(), { timeout: 2000 });
+    seen.length = 0;
+    rerenderWith({ amount: "2000", depositAccount: { id: "funding-2" } as AccountLike });
+
+    expect(seen[0]?.quote).toBeUndefined();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
@@ -1,0 +1,192 @@
+import BigNumber from "bignumber.js";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import type { AccountLike } from "@ledgerhq/types-live";
+import { act, renderHook } from "@tests/test-renderer";
+import { usePerpsDepositViewModel } from "../usePerpsDepositViewModel";
+
+const mockOpenDrawer = jest.fn();
+jest.mock("LLM/features/ModularDrawer", () => ({
+  useModularDrawerController: () => ({ openDrawer: mockOpenDrawer }),
+}));
+
+jest.mock("@ledgerhq/live-countervalues-react", () => ({
+  ...jest.requireActual("@ledgerhq/live-countervalues-react"),
+  useCalculateCountervalueCallback: () => (_currency: unknown, value: BigNumber) => value,
+  useCountervaluesState: () => ({}),
+}));
+
+jest.mock("@ledgerhq/live-countervalues/logic", () => ({
+  ...jest.requireActual("@ledgerhq/live-countervalues/logic"),
+  calculate: () => 20000000000000000,
+}));
+
+const mockUsePerpsDepositQuote = jest.fn();
+jest.mock("../usePerpsDepositQuote", () => ({
+  usePerpsDepositQuote: () => mockUsePerpsDepositQuote(),
+}));
+
+function createAccount(id: string, currencyId: string, spendableBalance: number): AccountLike {
+  const currency = getCryptoCurrencyById(currencyId);
+  return {
+    type: "Account",
+    id,
+    currency,
+    spendableBalance: new BigNumber(spendableBalance),
+    balance: new BigNumber(spendableBalance),
+  } as AccountLike;
+}
+
+const receiverAccount = createAccount("receiver-1", "ethereum", 0);
+const fundingAccount = createAccount("funding-1", "ethereum", 10000);
+
+function createProps(navigate = jest.fn()) {
+  return {
+    props: { navigation: { navigate }, route: { params: { receiverAccount } } } as never,
+    navigate,
+  };
+}
+
+function selectFundingAccount() {
+  const { onAccountSelected } = mockOpenDrawer.mock.calls[0][0];
+  act(() => onAccountSelected(fundingAccount));
+}
+
+/** The keypad is the only way into the amount, so tests enter digits the same way. */
+function typeAmount(pressAmountKey: (key: string) => void, amount: string) {
+  act(() => [...amount].forEach(key => pressAmountKey(key)));
+}
+
+describe("usePerpsDepositViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePerpsDepositQuote.mockReturnValue({
+      quote: { amountTo: new BigNumber(42) },
+      isLoading: false,
+    });
+  });
+
+  it("starts with an empty amount and no funding account", () => {
+    const { props } = createProps();
+    const { result } = renderHook(() => usePerpsDepositViewModel(props));
+
+    expect(result.current.amountText).toBe("");
+    expect(result.current.depositAmount).toBe(0);
+    expect(result.current.depositAccountName).toBeNull();
+    expect(result.current.depositCurrencyTicker).toBe("USDC");
+    expect(result.current.canReview).toBe(false);
+  });
+
+  it("keeps partially typed decimals and leaves the deposit floor to the live app", () => {
+    const { props } = createProps();
+    const { result } = renderHook(() => usePerpsDepositViewModel(props));
+
+    typeAmount(result.current.pressAmountKey, "3.");
+
+    expect(result.current.amountText).toBe("3.");
+    expect(result.current.depositAmount).toBe(3);
+    expect(result.current.submitError).toBeNull();
+    expect(result.current.missingAccount).toBe(true);
+    expect(result.current.canReview).toBe(false);
+  });
+
+  it("types, corrects and clears the amount from the keypad", () => {
+    const { props } = createProps();
+    const { result } = renderHook(() => usePerpsDepositViewModel(props));
+
+    act(() => ["5", "0", "0"].forEach(key => result.current.pressAmountKey(key)));
+    expect(result.current.amountText).toBe("500");
+
+    act(() => result.current.pressAmountKey("delete"));
+    expect(result.current.amountText).toBe("50");
+
+    // A leading separator is completed to "0." and repeats are ignored.
+    act(() =>
+      ["delete", "delete", ".", ".", "2", "5"].forEach(key => result.current.pressAmountKey(key)),
+    );
+    expect(result.current.amountText).toBe("0.25");
+
+    // Extra decimals are refused, so the amount always matches what is displayed.
+    act(() => result.current.pressAmountKey("9"));
+    expect(result.current.amountText).toBe("0.25");
+    expect(result.current.depositAmount).toBe(0.25);
+  });
+
+  it("adopts the funding account picked in the modular drawer", () => {
+    const { props } = createProps();
+    const { result } = renderHook(() => usePerpsDepositViewModel(props));
+
+    typeAmount(result.current.pressAmountKey, "42");
+    act(() => result.current.pickDepositAccount());
+
+    expect(mockOpenDrawer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enableAccountSelection: true,
+        uiUseCase: "perpetuals:fund",
+      }),
+    );
+
+    selectFundingAccount();
+
+    expect(result.current.depositCurrencyTicker).toBe("ETH");
+    expect(result.current.depositAccountName).not.toBeNull();
+
+    expect(result.current.amountText).toBe("");
+    expect(result.current.maxAmount).toBe(100);
+  });
+
+  it("flags amounts above the funding balance", () => {
+    const { props } = createProps();
+    const { result } = renderHook(() => usePerpsDepositViewModel(props));
+
+    act(() => result.current.pickDepositAccount());
+    selectFundingAccount();
+    typeAmount(result.current.pressAmountKey, "150");
+
+    expect(result.current.exceedsBalance).toBe(true);
+    expect(result.current.submitError).toEqual({
+      labelKey: "perpsDeposit.formErrors.amountExceedsBalance",
+    });
+    expect(result.current.canReview).toBe(false);
+  });
+
+  it("enables the review CTA once a funding account and amount are set", () => {
+    const { props } = createProps();
+    const { result } = renderHook(() => usePerpsDepositViewModel(props));
+
+    act(() => result.current.pickDepositAccount());
+    selectFundingAccount();
+    typeAmount(result.current.pressAmountKey, "20");
+
+    expect(result.current.canReview).toBe(true);
+  });
+
+  it("holds the review CTA back until the quote lands", () => {
+    mockUsePerpsDepositQuote.mockReturnValue({ quote: undefined, isLoading: true });
+    const { props } = createProps();
+    const { result } = renderHook(() => usePerpsDepositViewModel(props));
+
+    act(() => result.current.pickDepositAccount());
+    selectFundingAccount();
+    typeAmount(result.current.pressAmountKey, "20");
+
+    // The form itself is valid, so only the missing quote keeps the CTA disabled.
+    expect(result.current.submitError).toBeNull();
+    expect(result.current.canReview).toBe(false);
+    expect(result.current.isQuoteLoading).toBe(true);
+    expect(result.current.formattedDepositAmount).toBe("");
+  });
+
+  it("stops shimmering when the provider settles on no quote", () => {
+    mockUsePerpsDepositQuote.mockReturnValue({ quote: undefined, isLoading: false });
+    const { props } = createProps();
+    const { result } = renderHook(() => usePerpsDepositViewModel(props));
+
+    act(() => result.current.pickDepositAccount());
+    selectFundingAccount();
+    typeAmount(result.current.pressAmountKey, "20");
+
+    // A pair the provider cannot route is an answer, not a pending request.
+    expect(result.current.isQuoteLoading).toBe(false);
+    expect(result.current.canReview).toBe(false);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
@@ -10,9 +10,11 @@ jest.mock("LLM/features/ModularDrawer", () => ({
   useModularDrawerController: () => ({ openDrawer: mockOpenDrawer }),
 }));
 
+const mockCalculateCountervalue = jest.fn((_currency: unknown, value: BigNumber) => value);
 jest.mock("@ledgerhq/live-countervalues-react", () => ({
   ...jest.requireActual("@ledgerhq/live-countervalues-react"),
-  useCalculateCountervalueCallback: () => (_currency: unknown, value: BigNumber) => value,
+  useCalculateCountervalueCallback: () => (currency: unknown, value: BigNumber) =>
+    mockCalculateCountervalue(currency, value),
   useCountervaluesState: () => ({}),
 }));
 
@@ -77,6 +79,7 @@ function typeAmount(pressAmountKey: (key: string) => void, amount: string) {
 describe("usePerpsDepositViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockCalculateCountervalue.mockImplementation((_currency, value) => value);
     mockCalculate.mockReturnValue(0);
     mockUsePerpsDepositQuote.mockReturnValue({
       quote: { amountTo: new BigNumber(42) },
@@ -167,6 +170,24 @@ describe("usePerpsDepositViewModel", () => {
       labelKey: "perpsDeposit.formErrors.amountExceedsBalance",
     });
     expect(result.current.canReview).toBe(false);
+  });
+
+  it("holds back rather than blaming the balance while the funding rate is missing", () => {
+   
+    mockCalculateCountervalue.mockReturnValue(null as unknown as BigNumber);
+    const { props } = createProps();
+    const { result } = renderViewModel(props);
+
+    act(() => result.current.pickDepositAccount());
+    selectFundingAccount();
+    typeAmount(result.current.pressAmountKey, "20");
+
+    expect(result.current.exceedsBalance).toBe(false);
+    expect(result.current.statusError).toBeNull();
+    expect(result.current.maxAmount).toBe(0);
+
+    expect(result.current.canReview).toBe(false);
+    expect(quotedAmount()).toBe("");
   });
 
   it("enables the review CTA once a funding account and amount are set", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
@@ -1,6 +1,7 @@
 import BigNumber from "bignumber.js";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
-import type { AccountLike } from "@ledgerhq/types-live";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import type { Account } from "@ledgerhq/types-live";
 import { act, renderHook } from "@tests/test-renderer";
 import { usePerpsDepositViewModel } from "../usePerpsDepositViewModel";
 
@@ -25,15 +26,12 @@ jest.mock("../usePerpsDepositQuote", () => ({
   usePerpsDepositQuote: () => mockUsePerpsDepositQuote(),
 }));
 
-function createAccount(id: string, currencyId: string, spendableBalance: number): AccountLike {
-  const currency = getCryptoCurrencyById(currencyId);
+function createAccount(id: string, currencyId: string, spendableBalance: number): Account {
   return {
-    type: "Account",
-    id,
-    currency,
+    ...genAccount(id, { currency: getCryptoCurrencyById(currencyId), operationsSize: 0 }),
     spendableBalance: new BigNumber(spendableBalance),
     balance: new BigNumber(spendableBalance),
-  } as AccountLike;
+  };
 }
 
 const receiverAccount = createAccount("receiver-1", "ethereum", 0);
@@ -44,6 +42,17 @@ function createProps(navigate = jest.fn()) {
     props: { navigation: { navigate }, route: { params: { receiverAccount } } } as never,
     navigate,
   };
+}
+
+/** The funding account is read back from the store, so it has to live there. */
+function renderViewModel(props: never, discreetMode = false) {
+  return renderHook(() => usePerpsDepositViewModel(props), {
+    overrideInitialState: state => ({
+      ...state,
+      accounts: { ...state.accounts, active: [fundingAccount] },
+      settings: { ...state.settings, discreetMode },
+    }),
+  });
 }
 
 function selectFundingAccount() {
@@ -67,7 +76,7 @@ describe("usePerpsDepositViewModel", () => {
 
   it("starts with an empty amount and no funding account", () => {
     const { props } = createProps();
-    const { result } = renderHook(() => usePerpsDepositViewModel(props));
+    const { result } = renderViewModel(props);
 
     expect(result.current.amountText).toBe("");
     expect(result.current.depositAmount).toBe(0);
@@ -78,7 +87,7 @@ describe("usePerpsDepositViewModel", () => {
 
   it("keeps partially typed decimals and leaves the deposit floor to the live app", () => {
     const { props } = createProps();
-    const { result } = renderHook(() => usePerpsDepositViewModel(props));
+    const { result } = renderViewModel(props);
 
     typeAmount(result.current.pressAmountKey, "3.");
 
@@ -91,7 +100,7 @@ describe("usePerpsDepositViewModel", () => {
 
   it("types, corrects and clears the amount from the keypad", () => {
     const { props } = createProps();
-    const { result } = renderHook(() => usePerpsDepositViewModel(props));
+    const { result } = renderViewModel(props);
 
     act(() => ["5", "0", "0"].forEach(key => result.current.pressAmountKey(key)));
     expect(result.current.amountText).toBe("500");
@@ -113,7 +122,7 @@ describe("usePerpsDepositViewModel", () => {
 
   it("adopts the funding account picked in the modular drawer", () => {
     const { props } = createProps();
-    const { result } = renderHook(() => usePerpsDepositViewModel(props));
+    const { result } = renderViewModel(props);
 
     typeAmount(result.current.pressAmountKey, "42");
     act(() => result.current.pickDepositAccount());
@@ -136,7 +145,7 @@ describe("usePerpsDepositViewModel", () => {
 
   it("flags amounts above the funding balance", () => {
     const { props } = createProps();
-    const { result } = renderHook(() => usePerpsDepositViewModel(props));
+    const { result } = renderViewModel(props);
 
     act(() => result.current.pickDepositAccount());
     selectFundingAccount();
@@ -151,7 +160,7 @@ describe("usePerpsDepositViewModel", () => {
 
   it("enables the review CTA once a funding account and amount are set", () => {
     const { props } = createProps();
-    const { result } = renderHook(() => usePerpsDepositViewModel(props));
+    const { result } = renderViewModel(props);
 
     act(() => result.current.pickDepositAccount());
     selectFundingAccount();
@@ -160,10 +169,21 @@ describe("usePerpsDepositViewModel", () => {
     expect(result.current.canReview).toBe(true);
   });
 
+  it("hides both balances when discreet mode is on", () => {
+    const { props } = createProps();
+    const { result } = renderViewModel(props, true);
+
+    act(() => result.current.pickDepositAccount());
+    selectFundingAccount();
+
+    expect(result.current.headerDescription).toContain("***");
+    expect(result.current.depositAccountCounterValue).toBe("***");
+  });
+
   it("holds the review CTA back until the quote lands", () => {
     mockUsePerpsDepositQuote.mockReturnValue({ quote: undefined, isLoading: true });
     const { props } = createProps();
-    const { result } = renderHook(() => usePerpsDepositViewModel(props));
+    const { result } = renderViewModel(props);
 
     act(() => result.current.pickDepositAccount());
     selectFundingAccount();
@@ -179,7 +199,7 @@ describe("usePerpsDepositViewModel", () => {
   it("stops shimmering when the provider settles on no quote", () => {
     mockUsePerpsDepositQuote.mockReturnValue({ quote: undefined, isLoading: false });
     const { props } = createProps();
-    const { result } = renderHook(() => usePerpsDepositViewModel(props));
+    const { result } = renderViewModel(props);
 
     act(() => result.current.pickDepositAccount());
     selectFundingAccount();

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
@@ -173,7 +173,6 @@ describe("usePerpsDepositViewModel", () => {
   });
 
   it("holds back rather than blaming the balance while the funding rate is missing", () => {
-   
     mockCalculateCountervalue.mockReturnValue(null as unknown as BigNumber);
     const { props } = createProps();
     const { result } = renderViewModel(props);

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
@@ -16,14 +16,16 @@ jest.mock("@ledgerhq/live-countervalues-react", () => ({
   useCountervaluesState: () => ({}),
 }));
 
+// Prices the typed amount back into the funding currency, in its smallest unit.
+const mockCalculate = jest.fn();
 jest.mock("@ledgerhq/live-countervalues/logic", () => ({
   ...jest.requireActual("@ledgerhq/live-countervalues/logic"),
-  calculate: () => 20000000000000000,
+  calculate: (...args: unknown[]) => mockCalculate(...args),
 }));
 
 const mockUsePerpsDepositQuote = jest.fn();
 jest.mock("../usePerpsDepositQuote", () => ({
-  usePerpsDepositQuote: () => mockUsePerpsDepositQuote(),
+  usePerpsDepositQuote: (params: unknown) => mockUsePerpsDepositQuote(params),
 }));
 
 function createAccount(id: string, currencyId: string, spendableBalance: number): Account {
@@ -36,6 +38,8 @@ function createAccount(id: string, currencyId: string, spendableBalance: number)
 
 const receiverAccount = createAccount("receiver-1", "ethereum", 0);
 const fundingAccount = createAccount("funding-1", "ethereum", 10000);
+/** Holds more than the form can ask for, so the balance cap never kicks in. */
+const fundedAccount = createAccount("funding-2", "ethereum", 1e18);
 
 function createProps(navigate = jest.fn()) {
   return {
@@ -49,15 +53,20 @@ function renderViewModel(props: never, discreetMode = false) {
   return renderHook(() => usePerpsDepositViewModel(props), {
     overrideInitialState: state => ({
       ...state,
-      accounts: { ...state.accounts, active: [fundingAccount] },
+      accounts: { ...state.accounts, active: [fundingAccount, fundedAccount] },
       settings: { ...state.settings, discreetMode },
     }),
   });
 }
 
-function selectFundingAccount() {
+function selectFundingAccount(account: Account = fundingAccount) {
   const { onAccountSelected } = mockOpenDrawer.mock.calls[0][0];
-  act(() => onAccountSelected(fundingAccount));
+  act(() => onAccountSelected(account));
+}
+
+/** The display-unit amount the form settled on and sent to the provider. */
+function quotedAmount(): string {
+  return mockUsePerpsDepositQuote.mock.lastCall?.[0].amount;
 }
 
 /** The keypad is the only way into the amount, so tests enter digits the same way. */
@@ -68,9 +77,11 @@ function typeAmount(pressAmountKey: (key: string) => void, amount: string) {
 describe("usePerpsDepositViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockCalculate.mockReturnValue(0);
     mockUsePerpsDepositQuote.mockReturnValue({
       quote: { amountTo: new BigNumber(42) },
       isLoading: false,
+      isUnavailable: false,
     });
   });
 
@@ -93,7 +104,7 @@ describe("usePerpsDepositViewModel", () => {
 
     expect(result.current.amountText).toBe("3.");
     expect(result.current.depositAmount).toBe(3);
-    expect(result.current.submitError).toBeNull();
+    expect(result.current.statusError).toBeNull();
     expect(result.current.missingAccount).toBe(true);
     expect(result.current.canReview).toBe(false);
   });
@@ -152,7 +163,7 @@ describe("usePerpsDepositViewModel", () => {
     typeAmount(result.current.pressAmountKey, "150");
 
     expect(result.current.exceedsBalance).toBe(true);
-    expect(result.current.submitError).toEqual({
+    expect(result.current.statusError).toEqual({
       labelKey: "perpsDeposit.formErrors.amountExceedsBalance",
     });
     expect(result.current.canReview).toBe(false);
@@ -169,6 +180,51 @@ describe("usePerpsDepositViewModel", () => {
     expect(result.current.canReview).toBe(true);
   });
 
+  it("quotes the typed amount converted into the funding currency", () => {
+    // $20 buys 0.025 ETH, which the provider expects in display units.
+    mockCalculate.mockReturnValue(2.5e16);
+    const { props } = createProps();
+    const { result } = renderViewModel(props);
+
+    act(() => result.current.pickDepositAccount());
+    selectFundingAccount(fundedAccount);
+    typeAmount(result.current.pressAmountKey, "20");
+
+    expect(quotedAmount()).toBe("0.025");
+  });
+
+  it("quotes no more than the funding account can spend", () => {
+    // The rate prices the amount above the balance, which caps what we can send.
+    mockCalculate.mockReturnValue(2.5e16);
+    const { props } = createProps();
+    const { result } = renderViewModel(props);
+
+    act(() => result.current.pickDepositAccount());
+    selectFundingAccount();
+    typeAmount(result.current.pressAmountKey, "20");
+
+    expect(result.current.statusError).toBeNull();
+    expect(quotedAmount()).toBe(new BigNumber(10000).shiftedBy(-18).toFixed());
+  });
+
+  it("floors a quote that lands between two atomic units", () => {
+    mockCalculate.mockReturnValue(1.6);
+    const { props } = createProps();
+    const { result } = renderViewModel(props);
+
+    act(() => result.current.pickDepositAccount());
+    selectFundingAccount();
+    typeAmount(result.current.pressAmountKey, "20");
+
+    // Rounding up would price the deposit above what the user typed, so the
+    // conversion stays fractional and only the floor below rounds it.
+    expect(mockCalculate).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({ reverse: true, disableRounding: true }),
+    );
+    expect(quotedAmount()).toBe(new BigNumber(1).shiftedBy(-18).toFixed());
+  });
+
   it("hides both balances when discreet mode is on", () => {
     const { props } = createProps();
     const { result } = renderViewModel(props, true);
@@ -181,7 +237,11 @@ describe("usePerpsDepositViewModel", () => {
   });
 
   it("holds the review CTA back until the quote lands", () => {
-    mockUsePerpsDepositQuote.mockReturnValue({ quote: undefined, isLoading: true });
+    mockUsePerpsDepositQuote.mockReturnValue({
+      quote: undefined,
+      isLoading: true,
+      isUnavailable: false,
+    });
     const { props } = createProps();
     const { result } = renderViewModel(props);
 
@@ -190,14 +250,18 @@ describe("usePerpsDepositViewModel", () => {
     typeAmount(result.current.pressAmountKey, "20");
 
     // The form itself is valid, so only the missing quote keeps the CTA disabled.
-    expect(result.current.submitError).toBeNull();
+    expect(result.current.statusError).toBeNull();
     expect(result.current.canReview).toBe(false);
     expect(result.current.isQuoteLoading).toBe(true);
-    expect(result.current.formattedDepositAmount).toBe("");
+    expect(result.current.formattedQuotedAmount).toBe("");
   });
 
-  it("stops shimmering when the provider settles on no quote", () => {
-    mockUsePerpsDepositQuote.mockReturnValue({ quote: undefined, isLoading: false });
+  it("stops shimmering and explains itself when the provider has no quote", () => {
+    mockUsePerpsDepositQuote.mockReturnValue({
+      quote: undefined,
+      isLoading: false,
+      isUnavailable: true,
+    });
     const { props } = createProps();
     const { result } = renderViewModel(props);
 
@@ -208,5 +272,26 @@ describe("usePerpsDepositViewModel", () => {
     // A pair the provider cannot route is an answer, not a pending request.
     expect(result.current.isQuoteLoading).toBe(false);
     expect(result.current.canReview).toBe(false);
+    expect(result.current.statusError).toEqual({
+      labelKey: "perpsDeposit.formErrors.quoteUnavailable",
+    });
+  });
+
+  it("blames the balance rather than the provider when both are wrong", () => {
+    mockUsePerpsDepositQuote.mockReturnValue({
+      quote: undefined,
+      isLoading: false,
+      isUnavailable: true,
+    });
+    const { props } = createProps();
+    const { result } = renderViewModel(props);
+
+    act(() => result.current.pickDepositAccount());
+    selectFundingAccount();
+    typeAmount(result.current.pressAmountKey, "150");
+
+    expect(result.current.statusError).toEqual({
+      labelKey: "perpsDeposit.formErrors.amountExceedsBalance",
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/DepositAccountSelector.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/DepositAccountSelector.tsx
@@ -9,6 +9,7 @@ import {
   ListItemTrailing,
 } from "@ledgerhq/lumen-ui-rnative";
 import { ChevronDown } from "@ledgerhq/lumen-ui-rnative/symbols";
+import type { TFunction } from "i18next";
 import { useTranslation } from "~/context/Locale";
 
 type DepositAccountSelectorProps = Readonly<{
@@ -20,6 +21,17 @@ type DepositAccountSelectorProps = Readonly<{
   missingAccount: boolean;
   onSelect: () => void;
 }>;
+
+/** An account with no price to show falls back to its name alone. */
+function describeAccount(
+  t: TFunction,
+  accountName: string | null,
+  counterValue: string | null,
+): string {
+  if (accountName === null) return t("perpsDeposit.selectCurrencyNoAccount");
+  if (counterValue === null) return accountName;
+  return t("perpsDeposit.selectCurrencyAccount", { accountName, counterValue });
+}
 
 export function DepositAccountSelector({
   ticker,
@@ -34,12 +46,7 @@ export function DepositAccountSelector({
   const hasAccount = accountName !== null;
   const hasError = hasAccount ? exceedsBalance : missingAccount;
 
-  const description =
-    accountName === null
-      ? t("perpsDeposit.selectCurrencyNoAccount")
-      : counterValue === null
-        ? accountName
-        : t("perpsDeposit.selectCurrencyAccount", { accountName, counterValue });
+  const description = describeAccount(t, accountName, counterValue);
 
   return (
     <ListItem

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/DepositAccountSelector.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/DepositAccountSelector.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import CryptoIcon from "@ledgerhq/crypto-icons/native";
+import {
+  ListItem,
+  ListItemContent,
+  ListItemDescription,
+  ListItemLeading,
+  ListItemTitle,
+  ListItemTrailing,
+} from "@ledgerhq/lumen-ui-rnative";
+import { ChevronDown } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { useTranslation } from "~/context/Locale";
+
+type DepositAccountSelectorProps = Readonly<{
+  ticker: string;
+  ledgerId: string;
+  accountName: string | null;
+  counterValue: string | null;
+  exceedsBalance: boolean;
+  missingAccount: boolean;
+  onSelect: () => void;
+}>;
+
+export function DepositAccountSelector({
+  ticker,
+  ledgerId,
+  accountName,
+  counterValue,
+  exceedsBalance,
+  missingAccount,
+  onSelect,
+}: DepositAccountSelectorProps) {
+  const { t } = useTranslation();
+  const hasAccount = accountName !== null && counterValue !== null;
+  const hasError = hasAccount ? exceedsBalance : missingAccount;
+
+  return (
+    <ListItem
+      onPress={onSelect}
+      lx={{ backgroundColor: "surface", borderRadius: "md" }}
+      testID="perps-deposit-select-currency"
+    >
+      <ListItemLeading>
+        <CryptoIcon size={32} ledgerId={ledgerId} ticker={ticker} />
+        <ListItemContent>
+          <ListItemTitle>
+            {t("perpsDeposit.selectCurrencyTitle", { currencyTicker: ticker })}
+          </ListItemTitle>
+          <ListItemDescription lx={{ color: hasError ? "error" : "muted" }}>
+            {hasAccount
+              ? t("perpsDeposit.selectCurrencyAccount", { accountName, counterValue })
+              : t("perpsDeposit.selectCurrencyDescription")}
+          </ListItemDescription>
+        </ListItemContent>
+      </ListItemLeading>
+      <ListItemTrailing>
+        <ChevronDown size={24} />
+      </ListItemTrailing>
+    </ListItem>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/DepositAccountSelector.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/DepositAccountSelector.tsx
@@ -31,8 +31,15 @@ export function DepositAccountSelector({
   onSelect,
 }: DepositAccountSelectorProps) {
   const { t } = useTranslation();
-  const hasAccount = accountName !== null && counterValue !== null;
+  const hasAccount = accountName !== null;
   const hasError = hasAccount ? exceedsBalance : missingAccount;
+
+  const description =
+    accountName === null
+      ? t("perpsDeposit.selectCurrencyNoAccount")
+      : counterValue === null
+        ? accountName
+        : t("perpsDeposit.selectCurrencyAccount", { accountName, counterValue });
 
   return (
     <ListItem
@@ -47,9 +54,7 @@ export function DepositAccountSelector({
             {t("perpsDeposit.selectCurrencyTitle", { currencyTicker: ticker })}
           </ListItemTitle>
           <ListItemDescription lx={{ color: hasError ? "error" : "muted" }}>
-            {hasAccount
-              ? t("perpsDeposit.selectCurrencyAccount", { accountName, counterValue })
-              : t("perpsDeposit.selectCurrencyDescription")}
+            {description}
           </ListItemDescription>
         </ListItemContent>
       </ListItemLeading>

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/index.tsx
@@ -75,7 +75,6 @@ export function PerpsDepositView({
   depositAmountTicker,
   isQuoteLoading,
   counterValueCode,
-  maxIntegerLength,
   maxDecimalLength,
   pressAmountKey,
   setDepositAmount,
@@ -114,8 +113,6 @@ export function PerpsDepositView({
           <AmountInput
             value={amountText}
             currencyText={counterValueCode}
-            maxIntegerLength={maxIntegerLength}
-            maxDecimalLength={maxDecimalLength}
             autoFocus
             showSoftInputOnFocus={false}
             // The in-app keypad is the only input path, so the field is display-only.

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/index.tsx
@@ -1,0 +1,174 @@
+import React from "react";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { AmountInput, Box, Button, Skeleton, Text } from "@ledgerhq/lumen-ui-rnative";
+import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
+import { useTranslation } from "~/context/Locale";
+import { AmountKeypad } from "LLM/components/AmountKeypad";
+import { RatioPicker } from "LLM/components/RatioPicker";
+import { DepositAccountSelector } from "./components/DepositAccountSelector";
+import type { PerpsDepositViewModel } from "./usePerpsDepositViewModel";
+
+const QUOTED_AMOUNT_SKELETON_SIZE = { width: 112, height: 16 };
+
+function QuotedAmount({
+  formattedDepositAmount,
+  depositAmountTicker,
+  isQuoteLoading,
+}: Pick<
+  PerpsDepositViewModel,
+  "formattedDepositAmount" | "depositAmountTicker" | "isQuoteLoading"
+>) {
+  const { t } = useTranslation();
+
+  if (isQuoteLoading) {
+    return (
+      <Skeleton
+        testID="perps-deposit-quote-skeleton"
+        lx={{ borderRadius: "sm" }}
+        style={QUOTED_AMOUNT_SKELETON_SIZE}
+      />
+    );
+  }
+
+  if (!formattedDepositAmount) return null;
+
+  return (
+    <Text typography="body3" lx={{ color: "muted" }}>
+      {t("perpsDeposit.inputDepositAmount", {
+        value: formattedDepositAmount,
+        currencyTicker: depositAmountTicker,
+      })}
+    </Text>
+  );
+}
+
+function AmountMessage({
+  submitError,
+  depositAmount,
+}: Pick<PerpsDepositViewModel, "submitError" | "depositAmount">) {
+  const { t } = useTranslation();
+
+  if (submitError) {
+    return (
+      <Text typography="body3" lx={{ color: "error" }} testID="perps-deposit-form-error">
+        {t(submitError.labelKey)}
+      </Text>
+    );
+  }
+
+  if (depositAmount > 0) {
+    return (
+      <Text typography="body3" lx={{ color: "base" }}>
+        {t("perpsDeposit.inputSubText")}
+      </Text>
+    );
+  }
+
+  return null;
+}
+
+export function PerpsDepositView({
+  headerDescription,
+  amountText,
+  depositAmount,
+  formattedDepositAmount,
+  depositAmountTicker,
+  isQuoteLoading,
+  counterValueCode,
+  maxIntegerLength,
+  maxDecimalLength,
+  pressAmountKey,
+  setDepositAmount,
+  depositCurrencyTicker,
+  depositCurrencyLedgerId,
+  depositAccountName,
+  depositAccountCounterValue,
+  maxAmount,
+  selectMax,
+  submitError,
+  canReview,
+  exceedsBalance,
+  missingAccount,
+  pickDepositAccount,
+  handleReview,
+}: Readonly<PerpsDepositViewModel>) {
+  const { t } = useTranslation();
+  const styles = useStyleSheet(
+    theme => ({
+      root: {
+        flex: 1,
+        backgroundColor: theme.colors.bg.base,
+      },
+    }),
+    [],
+  );
+
+  return (
+    <SafeAreaView edges={["bottom"]} style={styles.root}>
+      <Box lx={{ flex: 1, paddingHorizontal: "s16", gap: "s16" }}>
+        <Text typography="body2" lx={{ color: "muted", textAlign: "center" }}>
+          {headerDescription}
+        </Text>
+
+        <Box lx={{ flex: 1, justifyContent: "center", alignItems: "center", gap: "s8" }}>
+          <AmountInput
+            value={amountText}
+            currencyText={counterValueCode}
+            maxIntegerLength={maxIntegerLength}
+            maxDecimalLength={maxDecimalLength}
+            autoFocus
+            showSoftInputOnFocus={false}
+            // The in-app keypad is the only input path, so the field is display-only.
+            onChangeText={() => undefined}
+            isInvalid={submitError !== null}
+            testID="perps-deposit-amount-input"
+          />
+          <QuotedAmount
+            formattedDepositAmount={formattedDepositAmount}
+            depositAmountTicker={depositAmountTicker}
+            isQuoteLoading={isQuoteLoading}
+          />
+          <AmountMessage submitError={submitError} depositAmount={depositAmount} />
+        </Box>
+
+        <DepositAccountSelector
+          ticker={depositCurrencyTicker}
+          ledgerId={depositCurrencyLedgerId}
+          accountName={depositAccountName}
+          counterValue={depositAccountCounterValue}
+          exceedsBalance={exceedsBalance}
+          missingAccount={missingAccount}
+          onSelect={pickDepositAccount}
+        />
+
+        <RatioPicker
+          maxValue={maxAmount}
+          value={depositAmount}
+          decimalPlaces={maxDecimalLength}
+          onChange={setDepositAmount}
+          onMax={selectMax}
+          testIDPrefix="perps-deposit-ratio"
+        />
+
+        <AmountKeypad
+          onKeyPress={pressAmountKey}
+          testIDPrefix="perps-deposit-key"
+          deleteAccessibilityLabel={t("perpsDeposit.keypadDelete")}
+        />
+      </Box>
+
+      <Box lx={{ paddingHorizontal: "s16", paddingTop: "s16" }}>
+        <Button
+          appearance="base"
+          size="lg"
+          lx={{ width: "full" }}
+          disabled={!canReview}
+          onPress={handleReview}
+          testID="perps-deposit-review-cta"
+        >
+          {t("perpsDeposit.review")}
+        </Button>
+      </Box>
+    </SafeAreaView>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/index.tsx
@@ -11,13 +11,10 @@ import type { PerpsDepositViewModel } from "./usePerpsDepositViewModel";
 const QUOTED_AMOUNT_SKELETON_SIZE = { width: 112, height: 16 };
 
 function QuotedAmount({
-  formattedDepositAmount,
-  depositAmountTicker,
+  formattedQuotedAmount,
+  quotedAmountTicker,
   isQuoteLoading,
-}: Pick<
-  PerpsDepositViewModel,
-  "formattedDepositAmount" | "depositAmountTicker" | "isQuoteLoading"
->) {
+}: Pick<PerpsDepositViewModel, "formattedQuotedAmount" | "quotedAmountTicker" | "isQuoteLoading">) {
   const { t } = useTranslation();
 
   if (isQuoteLoading) {
@@ -30,28 +27,28 @@ function QuotedAmount({
     );
   }
 
-  if (!formattedDepositAmount) return null;
+  if (!formattedQuotedAmount) return null;
 
   return (
     <Text typography="body3" lx={{ color: "muted" }}>
       {t("perpsDeposit.inputDepositAmount", {
-        value: formattedDepositAmount,
-        currencyTicker: depositAmountTicker,
+        value: formattedQuotedAmount,
+        currencyTicker: quotedAmountTicker,
       })}
     </Text>
   );
 }
 
 function AmountMessage({
-  submitError,
+  statusError,
   depositAmount,
-}: Pick<PerpsDepositViewModel, "submitError" | "depositAmount">) {
+}: Pick<PerpsDepositViewModel, "statusError" | "depositAmount">) {
   const { t } = useTranslation();
 
-  if (submitError) {
+  if (statusError) {
     return (
       <Text typography="body3" lx={{ color: "error" }} testID="perps-deposit-form-error">
-        {t(submitError.labelKey)}
+        {t(statusError.labelKey)}
       </Text>
     );
   }
@@ -71,20 +68,20 @@ export function PerpsDepositView({
   headerDescription,
   amountText,
   depositAmount,
-  formattedDepositAmount,
-  depositAmountTicker,
+  formattedQuotedAmount,
+  quotedAmountTicker,
   isQuoteLoading,
   counterValueCode,
   maxDecimalLength,
   pressAmountKey,
-  setDepositAmount,
+  selectAmountRatio,
   depositCurrencyTicker,
   depositCurrencyLedgerId,
   depositAccountName,
   depositAccountCounterValue,
   maxAmount,
   selectMax,
-  submitError,
+  statusError,
   canReview,
   exceedsBalance,
   missingAccount,
@@ -117,15 +114,15 @@ export function PerpsDepositView({
             showSoftInputOnFocus={false}
             // The in-app keypad is the only input path, so the field is display-only.
             onChangeText={() => undefined}
-            isInvalid={submitError !== null}
+            isInvalid={statusError !== null}
             testID="perps-deposit-amount-input"
           />
           <QuotedAmount
-            formattedDepositAmount={formattedDepositAmount}
-            depositAmountTicker={depositAmountTicker}
+            formattedQuotedAmount={formattedQuotedAmount}
+            quotedAmountTicker={quotedAmountTicker}
             isQuoteLoading={isQuoteLoading}
           />
-          <AmountMessage submitError={submitError} depositAmount={depositAmount} />
+          <AmountMessage statusError={statusError} depositAmount={depositAmount} />
         </Box>
 
         <DepositAccountSelector
@@ -142,7 +139,7 @@ export function PerpsDepositView({
           maxValue={maxAmount}
           value={depositAmount}
           decimalPlaces={maxDecimalLength}
-          onChange={setDepositAmount}
+          onChange={selectAmountRatio}
           onMax={selectMax}
           testIDPrefix="perps-deposit-ratio"
         />

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositQuote.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositQuote.ts
@@ -19,7 +19,6 @@ type PerpsDepositQuoteParams = {
 export type PerpsDepositQuoteState = {
   quote: PerpsDepositQuote | undefined;
   isLoading: boolean;
-  /** The provider answered, but has nothing to route this pair with. */
   isUnavailable: boolean;
 };
 
@@ -31,6 +30,15 @@ const UNAVAILABLE: PerpsDepositQuoteState = {
   isUnavailable: true,
 };
 
+/** What a quote was asked for, so it is never read back for anything else. */
+function requestKeyOf(
+  { depositAccount, receiverAccount, amount }: PerpsDepositQuoteParams,
+  counterValueTicker: string,
+) {
+  if (!depositAccount || !amount) return null;
+  return [depositAccount.id, receiverAccount.id, amount, counterValueTicker].join("|");
+}
+
 /**
  * Debounced quote for the funding pair.
  */
@@ -41,15 +49,23 @@ export function usePerpsDepositQuote({
 }: PerpsDepositQuoteParams): PerpsDepositQuoteState {
   const accounts = useSelector(flattenAccountsSelector);
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
-  const [state, setState] = useState<PerpsDepositQuoteState>(IDLE);
+  const [current, setCurrent] = useState<{ key: string | null; state: PerpsDepositQuoteState }>({
+    key: null,
+    state: IDLE,
+  });
+
+  const requestKey = requestKeyOf(
+    { depositAccount, receiverAccount, amount },
+    counterValueCurrency.ticker,
+  );
 
   useEffect(() => {
     if (!depositAccount || !amount) {
-      setState(IDLE);
+      setCurrent({ key: null, state: IDLE });
       return;
     }
 
-    setState(LOADING);
+    setCurrent({ key: requestKey, state: LOADING });
 
     let stale = false;
     const timeout = setTimeout(() => {
@@ -62,12 +78,15 @@ export function usePerpsDepositQuote({
       })
         .then(received => {
           if (stale) return;
-          setState(
-            received ? { quote: received, isLoading: false, isUnavailable: false } : UNAVAILABLE,
-          );
+          setCurrent({
+            key: requestKey,
+            state: received
+              ? { quote: received, isLoading: false, isUnavailable: false }
+              : UNAVAILABLE,
+          });
         })
         .catch(() => {
-          if (!stale) setState(UNAVAILABLE);
+          if (!stale) setCurrent({ key: requestKey, state: UNAVAILABLE });
         });
     }, QUOTE_DEBOUNCE_MS);
 
@@ -75,7 +94,9 @@ export function usePerpsDepositQuote({
       stale = true;
       clearTimeout(timeout);
     };
-  }, [accounts, amount, counterValueCurrency.ticker, depositAccount, receiverAccount]);
+  }, [accounts, amount, counterValueCurrency.ticker, depositAccount, receiverAccount, requestKey]);
 
-  return state;
+  // Effects run a render late, so the stale quote is dropped here instead.
+  if (current.key !== requestKey) return requestKey === null ? IDLE : LOADING;
+  return current.state;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositQuote.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositQuote.ts
@@ -1,0 +1,70 @@
+import { useEffect, useState } from "react";
+import type { AccountLike } from "@ledgerhq/types-live";
+import {
+  fetchPerpsDepositQuote,
+  type PerpsDepositQuote,
+} from "@ledgerhq/live-common/wallet-api/Perps/depositQuote";
+import { useSelector } from "~/context/hooks";
+import { flattenAccountsSelector } from "~/reducers/accounts";
+import { counterValueCurrencySelector } from "~/reducers/settings";
+
+const QUOTE_DEBOUNCE_MS = 500;
+
+type PerpsDepositQuoteParams = {
+  depositAccount: AccountLike | undefined;
+  receiverAccount: AccountLike;
+  amount: string;
+};
+
+export type PerpsDepositQuoteState = {
+  quote: PerpsDepositQuote | undefined;
+  isLoading: boolean;
+};
+
+const IDLE: PerpsDepositQuoteState = { quote: undefined, isLoading: false };
+
+/**
+ * Debounced quote for the funding pair.
+ */
+export function usePerpsDepositQuote({
+  depositAccount,
+  receiverAccount,
+  amount,
+}: PerpsDepositQuoteParams): PerpsDepositQuoteState {
+  const accounts = useSelector(flattenAccountsSelector);
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const [state, setState] = useState<PerpsDepositQuoteState>(IDLE);
+
+  useEffect(() => {
+    if (!depositAccount || !amount) {
+      setState(IDLE);
+      return;
+    }
+
+    setState({ quote: undefined, isLoading: true });
+
+    let stale = false;
+    const timeout = setTimeout(() => {
+      fetchPerpsDepositQuote({
+        accounts,
+        depositAccount,
+        receiverAccount,
+        amount,
+        counterValueCurrency: counterValueCurrency.ticker,
+      })
+        .then(received => {
+          if (!stale) setState({ quote: received, isLoading: false });
+        })
+        .catch(() => {
+          if (!stale) setState(IDLE);
+        });
+    }, QUOTE_DEBOUNCE_MS);
+
+    return () => {
+      stale = true;
+      clearTimeout(timeout);
+    };
+  }, [accounts, amount, counterValueCurrency.ticker, depositAccount, receiverAccount]);
+
+  return state;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositQuote.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositQuote.ts
@@ -19,9 +19,17 @@ type PerpsDepositQuoteParams = {
 export type PerpsDepositQuoteState = {
   quote: PerpsDepositQuote | undefined;
   isLoading: boolean;
+  /** The provider answered, but has nothing to route this pair with. */
+  isUnavailable: boolean;
 };
 
-const IDLE: PerpsDepositQuoteState = { quote: undefined, isLoading: false };
+const IDLE: PerpsDepositQuoteState = { quote: undefined, isLoading: false, isUnavailable: false };
+const LOADING: PerpsDepositQuoteState = { quote: undefined, isLoading: true, isUnavailable: false };
+const UNAVAILABLE: PerpsDepositQuoteState = {
+  quote: undefined,
+  isLoading: false,
+  isUnavailable: true,
+};
 
 /**
  * Debounced quote for the funding pair.
@@ -41,7 +49,7 @@ export function usePerpsDepositQuote({
       return;
     }
 
-    setState({ quote: undefined, isLoading: true });
+    setState(LOADING);
 
     let stale = false;
     const timeout = setTimeout(() => {
@@ -53,10 +61,13 @@ export function usePerpsDepositQuote({
         counterValueCurrency: counterValueCurrency.ticker,
       })
         .then(received => {
-          if (!stale) setState({ quote: received, isLoading: false });
+          if (stale) return;
+          setState(
+            received ? { quote: received, isLoading: false, isUnavailable: false } : UNAVAILABLE,
+          );
         })
         .catch(() => {
-          if (!stale) setState(IDLE);
+          if (!stale) setState(UNAVAILABLE);
         });
     }, QUOTE_DEBOUNCE_MS);
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositQuote.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositQuote.ts
@@ -94,7 +94,9 @@ export function usePerpsDepositQuote({
       stale = true;
       clearTimeout(timeout);
     };
-  }, [accounts, amount, counterValueCurrency.ticker, depositAccount, receiverAccount, requestKey]);
+    // The key covers every input; account churn must not restart the request.
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
+  }, [requestKey]);
 
   // Effects run a render late, so the stale quote is dropped here instead.
   if (current.key !== requestKey) return requestKey === null ? IDLE : LOADING;

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
@@ -1,6 +1,5 @@
 import { useCallback, useMemo, useState } from "react";
 import BigNumber from "bignumber.js";
-import type { AccountLike } from "@ledgerhq/types-live";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit, valueFromUnit } from "@ledgerhq/live-common/currencies/index";
 import { PERPS_UI_USE_CASE } from "@ledgerhq/live-common/wallet-api/ModularDrawer/uiUseCase";
@@ -11,7 +10,12 @@ import {
 import { calculate } from "@ledgerhq/live-countervalues/logic";
 import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import { useSelector } from "~/context/hooks";
-import { counterValueCurrencySelector, localeSelector } from "~/reducers/settings";
+import { flattenAccountsSelector } from "~/reducers/accounts";
+import {
+  counterValueCurrencySelector,
+  discreetModeSelector,
+  localeSelector,
+} from "~/reducers/settings";
 import { accountNameWithDefaultSelector, walletSelector } from "~/reducers/wallet";
 import { useModularDrawerController } from "LLM/features/ModularDrawer";
 import type { RootComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
@@ -59,12 +63,20 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
   const { receiverAccount } = route.params;
 
   const walletState = useSelector(walletSelector);
+  const accounts = useSelector(flattenAccountsSelector);
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   const locale = useSelector(localeSelector);
+  const discreet = useSelector(discreetModeSelector);
   const { openDrawer } = useModularDrawerController();
 
-  const [depositAccount, setDepositAccount] = useState<AccountLike | undefined>(undefined);
+  const [depositAccountId, setDepositAccountId] = useState<string | undefined>(undefined);
   const [amountText, setAmountText] = useState("");
+
+  /** Read from the store so balances stay live while the form is open. */
+  const depositAccount = useMemo(
+    () => accounts.find(account => account.id === depositAccountId),
+    [accounts, depositAccountId],
+  );
 
   const depositAmount = useMemo(() => {
     const parsed = Number(amountText.replace(/[^0-9.]/g, ""));
@@ -107,6 +119,7 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
           to: counterValueCurrency,
           value: new BigNumber(depositAmount).shiftedBy(counterValueUnit.magnitude).toNumber(),
           reverse: true,
+          disableRounding: true,
         }) ?? 0,
       ),
     [counterValueCurrency, counterValueUnit.magnitude, countervaluesState, depositAmount],
@@ -120,10 +133,15 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
   const receiverAccountCounterValue = useMemo(() => {
     const counterValue =
       calculateCountervalue(receiverCurrency, receiverAccount.spendableBalance) ?? new BigNumber(0);
-    return formatCurrencyUnit(counterValueUnit, counterValue, { showCode: false, locale });
+    return formatCurrencyUnit(counterValueUnit, counterValue, {
+      showCode: false,
+      discreet,
+      locale,
+    });
   }, [
     calculateCountervalue,
     counterValueUnit,
+    discreet,
     locale,
     receiverAccount.spendableBalance,
     receiverCurrency,
@@ -138,9 +156,10 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
     if (!depositAccountBalanceCounterValue) return null;
     return formatCurrencyUnit(counterValueUnit, depositAccountBalanceCounterValue, {
       showCode: false,
+      discreet,
       locale,
     });
-  }, [counterValueUnit, depositAccountBalanceCounterValue, locale]);
+  }, [counterValueUnit, depositAccountBalanceCounterValue, discreet, locale]);
 
   const maxAmount = useMemo(
     () => depositAccountBalanceCounterValue?.shiftedBy(-counterValueUnit.magnitude).toNumber() ?? 0,
@@ -199,7 +218,7 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
       areCurrenciesFiltered: false,
       uiUseCase: PERPS_UI_USE_CASE.fund,
       onAccountSelected: account => {
-        setDepositAccount(account);
+        setDepositAccountId(account.id);
         setAmountText("");
       },
     });

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
@@ -22,7 +22,7 @@ import {
   PERPS_DEPOSIT_DEFAULT_FUNDING_TICKER,
 } from "../../constants/depositFunding";
 import { usePerpsDepositQuote } from "./usePerpsDepositQuote";
-import { AMOUNT_MAX_INTEGER_DIGITS, applyAmountKey, toAmountText } from "./utils/amountKeys";
+import { applyAmountKey, toAmountText } from "./utils/amountKeys";
 import { toAmountValue } from "./utils/toAmountValue";
 import { validateDepositFlow } from "./utils/validateDepositFlow";
 
@@ -38,7 +38,6 @@ export type PerpsDepositViewModel = Readonly<{
   depositAmountTicker: string;
   isQuoteLoading: boolean;
   counterValueCode: string;
-  maxIntegerLength: number;
   maxDecimalLength: number;
   pressAmountKey: (key: string) => void;
   setDepositAmount: (amount: number) => void;
@@ -216,7 +215,6 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
     depositAmountTicker: receiverCurrency.ticker,
     isQuoteLoading,
     counterValueCode: counterValueUnit.code,
-    maxIntegerLength: AMOUNT_MAX_INTEGER_DIGITS,
     maxDecimalLength,
     pressAmountKey,
     setDepositAmount,

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
@@ -189,7 +189,7 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
 
   const exceedsBalance = submitError !== null;
   const missingAccount = !depositAccount && depositAmount > 0;
- 
+
   const isFormComplete =
     depositAmount > 0 && Boolean(depositAccount) && submitError === null && maxAmount !== null;
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
@@ -1,0 +1,238 @@
+import { useCallback, useMemo, useState } from "react";
+import BigNumber from "bignumber.js";
+import type { AccountLike } from "@ledgerhq/types-live";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
+import { formatCurrencyUnit, valueFromUnit } from "@ledgerhq/live-common/currencies/index";
+import { PERPS_UI_USE_CASE } from "@ledgerhq/live-common/wallet-api/ModularDrawer/uiUseCase";
+import {
+  useCalculateCountervalueCallback,
+  useCountervaluesState,
+} from "@ledgerhq/live-countervalues-react";
+import { calculate } from "@ledgerhq/live-countervalues/logic";
+import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
+import { useSelector } from "~/context/hooks";
+import { counterValueCurrencySelector, localeSelector } from "~/reducers/settings";
+import { accountNameWithDefaultSelector, walletSelector } from "~/reducers/wallet";
+import { useModularDrawerController } from "LLM/features/ModularDrawer";
+import type { RootComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { ScreenName } from "~/const";
+import {
+  PERPS_DEPOSIT_DEFAULT_FUNDING_CURRENCY_ID,
+  PERPS_DEPOSIT_DEFAULT_FUNDING_TICKER,
+} from "../../constants/depositFunding";
+import { usePerpsDepositQuote } from "./usePerpsDepositQuote";
+import { AMOUNT_MAX_INTEGER_DIGITS, applyAmountKey, toAmountText } from "./utils/amountKeys";
+import { toAmountValue } from "./utils/toAmountValue";
+import { validateDepositFlow } from "./utils/validateDepositFlow";
+
+type NavigationProps = RootComposite<
+  StackNavigatorProps<BaseNavigatorStackParamList, ScreenName.PerpsDeposit>
+>;
+
+export type PerpsDepositViewModel = Readonly<{
+  headerDescription: string;
+  amountText: string;
+  depositAmount: number;
+  formattedDepositAmount: string;
+  depositAmountTicker: string;
+  isQuoteLoading: boolean;
+  counterValueCode: string;
+  maxIntegerLength: number;
+  maxDecimalLength: number;
+  pressAmountKey: (key: string) => void;
+  setDepositAmount: (amount: number) => void;
+  depositCurrencyTicker: string;
+  depositCurrencyLedgerId: string;
+  depositAccountName: string | null;
+  depositAccountCounterValue: string | null;
+  maxAmount: number;
+  selectMax: () => void;
+  submitError: ReturnType<typeof validateDepositFlow>;
+  canReview: boolean;
+  exceedsBalance: boolean;
+  missingAccount: boolean;
+  pickDepositAccount: () => void;
+  handleReview: () => void;
+}>;
+
+export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepositViewModel {
+  const { receiverAccount } = route.params;
+
+  const walletState = useSelector(walletSelector);
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const locale = useSelector(localeSelector);
+  const { openDrawer } = useModularDrawerController();
+
+  const [depositAccount, setDepositAccount] = useState<AccountLike | undefined>(undefined);
+  const [amountText, setAmountText] = useState("");
+
+  const depositAmount = useMemo(() => {
+    const parsed = Number(amountText.replace(/[^0-9.]/g, ""));
+    return Number.isFinite(parsed) ? parsed : 0;
+  }, [amountText]);
+
+  const counterValueUnit = counterValueCurrency.units[0];
+
+  const maxDecimalLength = Math.max(0, counterValueUnit.magnitude);
+
+  const setDepositAmount = useCallback(
+    (amount: number) => {
+      setAmountText(toAmountText(amount, maxDecimalLength));
+    },
+    [maxDecimalLength],
+  );
+
+  const pressAmountKey = useCallback(
+    (key: string) => {
+      setAmountText(current => applyAmountKey(current, key, maxDecimalLength));
+    },
+    [maxDecimalLength],
+  );
+
+  const receiverCurrency = useMemo(() => getAccountCurrency(receiverAccount), [receiverAccount]);
+  const depositCurrency = useMemo(
+    () => (depositAccount ? getAccountCurrency(depositAccount) : undefined),
+    [depositAccount],
+  );
+
+  const calculateCountervalue = useCalculateCountervalueCallback({ to: counterValueCurrency });
+  const countervaluesState = useCountervaluesState();
+
+  /** Prices the typed amount back into `currency`, in its smallest unit. */
+  const toCurrencyAmount = useCallback(
+    (currency: CryptoOrTokenCurrency) =>
+      new BigNumber(
+        calculate(countervaluesState, {
+          from: currency,
+          to: counterValueCurrency,
+          value: new BigNumber(depositAmount).shiftedBy(counterValueUnit.magnitude).toNumber(),
+          reverse: true,
+        }) ?? 0,
+      ),
+    [counterValueCurrency, counterValueUnit.magnitude, countervaluesState, depositAmount],
+  );
+
+  const receiverAccountName = useMemo(
+    () => accountNameWithDefaultSelector(walletState, receiverAccount),
+    [receiverAccount, walletState],
+  );
+
+  const receiverAccountCounterValue = useMemo(() => {
+    const counterValue =
+      calculateCountervalue(receiverCurrency, receiverAccount.spendableBalance) ?? new BigNumber(0);
+    return formatCurrencyUnit(counterValueUnit, counterValue, { showCode: false, locale });
+  }, [
+    calculateCountervalue,
+    counterValueUnit,
+    locale,
+    receiverAccount.spendableBalance,
+    receiverCurrency,
+  ]);
+
+  const depositAccountBalanceCounterValue = useMemo(() => {
+    if (!depositAccount || !depositCurrency) return null;
+    return calculateCountervalue(depositCurrency, depositAccount.spendableBalance) ?? null;
+  }, [calculateCountervalue, depositAccount, depositCurrency]);
+
+  const depositAccountCounterValue = useMemo(() => {
+    if (!depositAccountBalanceCounterValue) return null;
+    return formatCurrencyUnit(counterValueUnit, depositAccountBalanceCounterValue, {
+      showCode: false,
+      locale,
+    });
+  }, [counterValueUnit, depositAccountBalanceCounterValue, locale]);
+
+  const maxAmount = useMemo(
+    () => depositAccountBalanceCounterValue?.shiftedBy(-counterValueUnit.magnitude).toNumber() ?? 0,
+    [counterValueUnit.magnitude, depositAccountBalanceCounterValue],
+  );
+
+  const selectMax = useCallback(() => setDepositAmount(maxAmount), [maxAmount, setDepositAmount]);
+
+  const submitError = useMemo(
+    () =>
+      validateDepositFlow({
+        amount: depositAmount,
+        maxAmount,
+        hasFundingAccount: Boolean(depositAccount),
+      }),
+    [depositAccount, depositAmount, maxAmount],
+  );
+
+  const exceedsBalance = submitError !== null;
+  const missingAccount = !depositAccount && depositAmount > 0;
+  const isFormComplete = depositAmount > 0 && Boolean(depositAccount) && submitError === null;
+
+  const sentAmount = useMemo(() => {
+    if (!isFormComplete || !depositAccount || !depositCurrency) return "";
+    const atomicAmount = BigNumber.min(
+      toCurrencyAmount(depositCurrency),
+      depositAccount.spendableBalance,
+    ).integerValue(BigNumber.ROUND_FLOOR);
+    return toAmountValue(atomicAmount, depositCurrency.units[0].magnitude);
+  }, [isFormComplete, depositAccount, depositCurrency, toCurrencyAmount]);
+
+  const { quote, isLoading: isQuoteLoading } = usePerpsDepositQuote({
+    depositAccount,
+    receiverAccount,
+    amount: sentAmount,
+  });
+
+  const canReview = isFormComplete && quote !== undefined;
+
+  const receiverUnit = receiverCurrency.units[0];
+
+  const formattedDepositAmount = useMemo(
+    () =>
+      quote
+        ? formatCurrencyUnit(receiverUnit, valueFromUnit(quote.amountTo, receiverUnit), {
+            showCode: false,
+            locale,
+          })
+        : "",
+    [locale, quote, receiverUnit],
+  );
+
+  const pickDepositAccount = useCallback(() => {
+    openDrawer({
+      enableAccountSelection: true,
+      areCurrenciesFiltered: false,
+      uiUseCase: PERPS_UI_USE_CASE.fund,
+      onAccountSelected: account => {
+        setDepositAccount(account);
+        setAmountText("");
+      },
+    });
+  }, [openDrawer]);
+
+  const handleReview = useCallback(() => undefined, []);
+
+  return {
+    headerDescription: `${receiverAccountName} · ${receiverAccountCounterValue}`,
+    amountText,
+    depositAmount,
+    formattedDepositAmount,
+    depositAmountTicker: receiverCurrency.ticker,
+    isQuoteLoading,
+    counterValueCode: counterValueUnit.code,
+    maxIntegerLength: AMOUNT_MAX_INTEGER_DIGITS,
+    maxDecimalLength,
+    pressAmountKey,
+    setDepositAmount,
+    depositCurrencyTicker: depositCurrency?.ticker ?? PERPS_DEPOSIT_DEFAULT_FUNDING_TICKER,
+    depositCurrencyLedgerId: depositCurrency?.id ?? PERPS_DEPOSIT_DEFAULT_FUNDING_CURRENCY_ID,
+    depositAccountName: depositAccount
+      ? accountNameWithDefaultSelector(walletState, depositAccount)
+      : null,
+    depositAccountCounterValue,
+    maxAmount,
+    selectMax,
+    submitError,
+    canReview,
+    exceedsBalance,
+    missingAccount,
+    pickDepositAccount,
+    handleReview,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
@@ -28,30 +28,34 @@ import {
 import { usePerpsDepositQuote } from "./usePerpsDepositQuote";
 import { applyAmountKey, toAmountText } from "./utils/amountKeys";
 import { toAmountValue } from "./utils/toAmountValue";
-import { validateDepositFlow } from "./utils/validateDepositFlow";
+import { validateDepositFlow, type DepositFormError } from "./utils/validateDepositFlow";
 
 type NavigationProps = RootComposite<
   StackNavigatorProps<BaseNavigatorStackParamList, ScreenName.PerpsDeposit>
 >;
 
+const QUOTE_UNAVAILABLE_ERROR: DepositFormError = {
+  labelKey: "perpsDeposit.formErrors.quoteUnavailable",
+};
+
 export type PerpsDepositViewModel = Readonly<{
   headerDescription: string;
   amountText: string;
   depositAmount: number;
-  formattedDepositAmount: string;
-  depositAmountTicker: string;
+  formattedQuotedAmount: string;
+  quotedAmountTicker: string;
   isQuoteLoading: boolean;
   counterValueCode: string;
   maxDecimalLength: number;
   pressAmountKey: (key: string) => void;
-  setDepositAmount: (amount: number) => void;
+  selectAmountRatio: (amount: number) => void;
   depositCurrencyTicker: string;
   depositCurrencyLedgerId: string;
   depositAccountName: string | null;
   depositAccountCounterValue: string | null;
   maxAmount: number;
   selectMax: () => void;
-  submitError: ReturnType<typeof validateDepositFlow>;
+  statusError: DepositFormError | null;
   canReview: boolean;
   exceedsBalance: boolean;
   missingAccount: boolean;
@@ -87,7 +91,8 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
 
   const maxDecimalLength = Math.max(0, counterValueUnit.magnitude);
 
-  const setDepositAmount = useCallback(
+  /** Fills the input with the amount a ratio pill resolved to. */
+  const selectAmountRatio = useCallback(
     (amount: number) => {
       setAmountText(toAmountText(amount, maxDecimalLength));
     },
@@ -166,7 +171,7 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
     [counterValueUnit.magnitude, depositAccountBalanceCounterValue],
   );
 
-  const selectMax = useCallback(() => setDepositAmount(maxAmount), [maxAmount, setDepositAmount]);
+  const selectMax = useCallback(() => selectAmountRatio(maxAmount), [maxAmount, selectAmountRatio]);
 
   const submitError = useMemo(
     () =>
@@ -191,7 +196,11 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
     return toAmountValue(atomicAmount, depositCurrency.units[0].magnitude);
   }, [isFormComplete, depositAccount, depositCurrency, toCurrencyAmount]);
 
-  const { quote, isLoading: isQuoteLoading } = usePerpsDepositQuote({
+  const {
+    quote,
+    isLoading: isQuoteLoading,
+    isUnavailable: isQuoteUnavailable,
+  } = usePerpsDepositQuote({
     depositAccount,
     receiverAccount,
     amount: sentAmount,
@@ -199,9 +208,12 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
 
   const canReview = isFormComplete && quote !== undefined;
 
+  /** What the user typed comes first; a missing quote only matters once it is valid. */
+  const statusError = submitError ?? (isQuoteUnavailable ? QUOTE_UNAVAILABLE_ERROR : null);
+
   const receiverUnit = receiverCurrency.units[0];
 
-  const formattedDepositAmount = useMemo(
+  const formattedQuotedAmount = useMemo(
     () =>
       quote
         ? formatCurrencyUnit(receiverUnit, valueFromUnit(quote.amountTo, receiverUnit), {
@@ -230,13 +242,13 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
     headerDescription: `${receiverAccountName} · ${receiverAccountCounterValue}`,
     amountText,
     depositAmount,
-    formattedDepositAmount,
-    depositAmountTicker: receiverCurrency.ticker,
+    formattedQuotedAmount,
+    quotedAmountTicker: receiverCurrency.ticker,
     isQuoteLoading,
     counterValueCode: counterValueUnit.code,
     maxDecimalLength,
     pressAmountKey,
-    setDepositAmount,
+    selectAmountRatio,
     depositCurrencyTicker: depositCurrency?.ticker ?? PERPS_DEPOSIT_DEFAULT_FUNDING_TICKER,
     depositCurrencyLedgerId: depositCurrency?.id ?? PERPS_DEPOSIT_DEFAULT_FUNDING_CURRENCY_ID,
     depositAccountName: depositAccount
@@ -245,7 +257,7 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
     depositAccountCounterValue,
     maxAmount,
     selectMax,
-    submitError,
+    statusError,
     canReview,
     exceedsBalance,
     missingAccount,

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
@@ -167,11 +167,15 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
   }, [counterValueUnit, depositAccountBalanceCounterValue, discreet, locale]);
 
   const maxAmount = useMemo(
-    () => depositAccountBalanceCounterValue?.shiftedBy(-counterValueUnit.magnitude).toNumber() ?? 0,
+    () =>
+      depositAccountBalanceCounterValue?.shiftedBy(-counterValueUnit.magnitude).toNumber() ?? null,
     [counterValueUnit.magnitude, depositAccountBalanceCounterValue],
   );
 
-  const selectMax = useCallback(() => selectAmountRatio(maxAmount), [maxAmount, selectAmountRatio]);
+  const selectMax = useCallback(() => {
+    if (maxAmount === null) return;
+    selectAmountRatio(maxAmount);
+  }, [maxAmount, selectAmountRatio]);
 
   const submitError = useMemo(
     () =>
@@ -185,7 +189,9 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
 
   const exceedsBalance = submitError !== null;
   const missingAccount = !depositAccount && depositAmount > 0;
-  const isFormComplete = depositAmount > 0 && Boolean(depositAccount) && submitError === null;
+ 
+  const isFormComplete =
+    depositAmount > 0 && Boolean(depositAccount) && submitError === null && maxAmount !== null;
 
   const sentAmount = useMemo(() => {
     if (!isFormComplete || !depositAccount || !depositCurrency) return "";
@@ -255,7 +261,7 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
       ? accountNameWithDefaultSelector(walletState, depositAccount)
       : null,
     depositAccountCounterValue,
-    maxAmount,
+    maxAmount: maxAmount ?? 0,
     selectMax,
     statusError,
     canReview,

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/utils/amountKeys.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/utils/amountKeys.ts
@@ -1,9 +1,10 @@
 import BigNumber from "bignumber.js";
 import { KEYPAD_DELETE_KEY } from "LLM/components/AmountKeypad";
 
-export const AMOUNT_MAX_INTEGER_DIGITS = 8;
-
 const AMOUNT_DELETE_KEY = KEYPAD_DELETE_KEY;
+
+/** Mirrors AmountInput's own maxIntegerLength default, past which it truncates the display. */
+const AMOUNT_MAX_INTEGER_DIGITS = 9;
 
 /**
  * Returns the amount text after pressing `key` on the in-app keypad.
@@ -23,7 +24,12 @@ export function applyAmountKey(currentText: string, key: string, maxDecimalDigit
 /** Serializes a computed amount (ratio, max) as keypad-compatible text. */
 export function toAmountText(amount: number, maxDecimalDigits: number): string {
   if (amount === 0) return "";
-  return BigNumber(amount).decimalPlaces(maxDecimalDigits, BigNumber.ROUND_DOWN).toFixed();
+  const [integerPart = "", decimalPart = ""] = BigNumber(amount)
+    .decimalPlaces(maxDecimalDigits, BigNumber.ROUND_DOWN)
+    .toFixed()
+    .split(".");
+  const truncated = integerPart.slice(0, AMOUNT_MAX_INTEGER_DIGITS);
+  return decimalPart ? `${truncated}.${decimalPart}` : truncated;
 }
 
 function isWithinPrecision(text: string, maxDecimalDigits: number): boolean {

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/utils/amountKeys.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/utils/amountKeys.ts
@@ -1,0 +1,32 @@
+import BigNumber from "bignumber.js";
+import { KEYPAD_DELETE_KEY } from "LLM/components/AmountKeypad";
+
+export const AMOUNT_MAX_INTEGER_DIGITS = 8;
+
+const AMOUNT_DELETE_KEY = KEYPAD_DELETE_KEY;
+
+/**
+ * Returns the amount text after pressing `key` on the in-app keypad.
+ */
+export function applyAmountKey(currentText: string, key: string, maxDecimalDigits: number): string {
+  if (key === AMOUNT_DELETE_KEY) return currentText.slice(0, -1);
+
+  if (key === ".") {
+    if (maxDecimalDigits === 0 || currentText.includes(".")) return currentText;
+    return `${currentText || "0"}.`;
+  }
+
+  const nextText = currentText === "0" ? key : `${currentText}${key}`;
+  return isWithinPrecision(nextText, maxDecimalDigits) ? nextText : currentText;
+}
+
+/** Serializes a computed amount (ratio, max) as keypad-compatible text. */
+export function toAmountText(amount: number, maxDecimalDigits: number): string {
+  if (amount === 0) return "";
+  return BigNumber(amount).decimalPlaces(maxDecimalDigits, BigNumber.ROUND_DOWN).toFixed();
+}
+
+function isWithinPrecision(text: string, maxDecimalDigits: number): boolean {
+  const [integerPart = "", decimalPart = ""] = text.split(".");
+  return integerPart.length <= AMOUNT_MAX_INTEGER_DIGITS && decimalPart.length <= maxDecimalDigits;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/utils/toAmountValue.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/utils/toAmountValue.ts
@@ -1,0 +1,6 @@
+import BigNumber from "bignumber.js";
+
+/** `atomicAmount` shifted down by `magnitude`, as a plain decimal string. */
+export function toAmountValue(atomicAmount: BigNumber, magnitude: number): string {
+  return atomicAmount.shiftedBy(-magnitude).toFixed();
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/utils/validateDepositFlow.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/utils/validateDepositFlow.ts
@@ -4,12 +4,12 @@ export type DepositFormError = Readonly<{
 
 export function validateDepositFlow(params: {
   amount: number;
-  maxAmount: number;
+  maxAmount: number | null;
   hasFundingAccount: boolean;
 }): DepositFormError | null {
   const { amount, maxAmount, hasFundingAccount } = params;
 
-  if (hasFundingAccount && amount > maxAmount) {
+  if (hasFundingAccount && maxAmount !== null && amount > maxAmount) {
     return { labelKey: "perpsDeposit.formErrors.amountExceedsBalance" };
   }
   return null;

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/utils/validateDepositFlow.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/utils/validateDepositFlow.ts
@@ -1,0 +1,16 @@
+export type DepositFormError = Readonly<{
+  labelKey: string;
+}>;
+
+export function validateDepositFlow(params: {
+  amount: number;
+  maxAmount: number;
+  hasFundingAccount: boolean;
+}): DepositFormError | null {
+  const { amount, maxAmount, hasFundingAccount } = params;
+
+  if (hasFundingAccount && amount > maxAmount) {
+    return { labelKey: "perpsDeposit.formErrors.amountExceedsBalance" };
+  }
+  return null;
+}


### PR DESCRIPTION
### 📝 Description

The screen the live app hands over to when it calls `custom.perps.deposit`: pick a funding account, enter an amount, move on to review. Desktop only — the mobile screen is #21029, and the two do not depend on each other.

What's worth a look:

- The amount is entered in the counter value currency, and the USDC figure under it comes from the SwapKit quote. While the quote is in flight, the line shimmers, and the Review CTA stays disabled until a quote lands.
- Percentage pills and MAX round to the counter value's precision, which keeps MAX from drifting past the spendable balance when the rate moves between renders.

Also adds `wallet-api/Perps/depositQuote` in `live-common`. #21029 carries an identical copy so it can stand on its own .

<img width="1008" height="1912" alt="Perps deposit screen on mobile" src="https://github.com/user-attachments/assets/3c622b9b-e9ab-4750-9b1a-c0193d902b84" />

### 🧱 Stack

- **mobile** — this PR, then #21031 (review step)
- **desktop** — #21028, then #21030 (review step)

### 🔗 Context

https://ledgerhq.atlassian.net/browse/LIVE-34567
https://ledgerhq.atlassian.net/browse/LIVE-35359