### PR TITLE
[LWDM] feat(perps): add the deposit review step to desktop

### DIFF
--- a/.changeset/perps-deposit-review.md
+++ b/.changeset/perps-deposit-review.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Add the Perps deposit review step on desktop and mobile, reached from the deposit form, showing the swap and deposit details before the user confirms. The amount landing on the perps account now comes from a provider quote, since that balance has no counter value of its own.

--- a/.changeset/perps-deposit-review.md
+++ b/.changeset/perps-deposit-review.md
@@ -1,7 +1,6 @@
 ---
 "ledger-live-desktop": minor
-"live-mobile": minor
 "@ledgerhq/live-common": minor
 ---
 
-Add the Perps deposit review step on desktop and mobile, reached from the deposit form, showing the swap and deposit details before the user confirms. The amount landing on the perps account now comes from a provider quote, since that balance has no counter value of its own.
+Add the Perps deposit review step on desktop, reached from the deposit form, showing the swap and deposit details before the user confirms. The amount landing on the perps account now comes from a provider quote, since that balance has no counter value of its own.

--- a/apps/ledger-live-desktop/src/mvvm/features/GlobalDialogs/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GlobalDialogs/index.tsx
@@ -8,6 +8,7 @@ const PerpsSignRoot = lazy(() => import("LLD/features/Perps/screens/PerpsSign/Pe
 const PerpsDepositRoot = lazy(
   () => import("LLD/features/Perps/screens/PerpsDeposit/PerpsDepositDialog"),
 );
+const PerpsReviewRoot = lazy(() => import("LLD/features/Perps/screens/PerpsReview/PerpsReviewDialog"));
 const ReleaseNotes = lazy(() => import("LLD/features/ReleaseNotes"));
 const BuyDevice = lazy(() => import("LLD/features/BuyDevice"));
 const FinishOnboardingDialog = lazy(
@@ -34,6 +35,9 @@ const GlobalDialogs = () => (
     </Suspense>
     <Suspense fallback={null}>
       <PerpsDepositRoot />
+    </Suspense>
+    <Suspense fallback={null}>
+      <PerpsReviewRoot />
     </Suspense>
     <ActionConfirmationDialog />
     <Suspense fallback={null}>

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDeposit/__integrations__/perpsDeposit.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDeposit/__integrations__/perpsDeposit.integration.test.tsx
@@ -5,6 +5,7 @@ import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import type { Account } from "@ledgerhq/types-live";
 import { act, render, screen } from "tests/testSetup";
 import PerpsDepositRoot, { openPerpsDeposit } from "../PerpsDepositDialog";
+import PerpsReviewRoot from "../../PerpsReview/PerpsReviewDialog";
 
 const mockOpenAssetAndAccount = jest.fn();
 jest.mock("LLD/features/ModularDialog/Web3AppWebview/AssetAndAccountDrawer", () => ({
@@ -171,5 +172,28 @@ describe("PerpsDeposit integration", () => {
 
     expect(screen.getByTestId("perps-deposit-amount-input")).toHaveValue("20");
     expect(screen.getByTestId("perps-deposit-review-cta")).not.toBeDisabled();
+  });
+
+  it("should hand over to the review dialog when the form is submitted", async () => {
+    const { user } = render(
+      <>
+        <PerpsDepositRoot />
+        <PerpsReviewRoot />
+      </>,
+    );
+
+    act(() =>
+      openPerpsDeposit({
+        receiverAccount,
+        draft: { depositAccount: fundingAccount, depositAmount: 20 },
+      }),
+    );
+
+    await user.click(screen.getByTestId("perps-deposit-review-cta"));
+
+    // The deposit form gives way to the review, which knows what is being sent.
+    expect(await screen.findByTestId("perps-deposit-cta")).toBeVisible();
+    expect(screen.getByTestId("perps-deposit-amount-sent")).toBeVisible();
+    expect(screen.queryByTestId("perps-deposit-amount-input")).not.toBeInTheDocument();
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDeposit/__integrations__/perpsDeposit.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDeposit/__integrations__/perpsDeposit.integration.test.tsx
@@ -180,6 +180,7 @@ describe("PerpsDeposit integration", () => {
         <PerpsDepositRoot />
         <PerpsReviewRoot />
       </>,
+      { initialState: { accounts: [fundingAccount] } },
     );
 
     act(() =>

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
@@ -27,11 +27,6 @@ jest.mock("@ledgerhq/live-countervalues-react", () => ({
   useCountervaluesState: () => ({}),
 }));
 
-jest.mock("@ledgerhq/live-countervalues/logic", () => ({
-  ...jest.requireActual("@ledgerhq/live-countervalues/logic"),
-  calculate: (_state: unknown, { value }: { value: number }) => value,
-}));
-
 // Prices the typed amount back into the funding currency, in its smallest unit.
 const mockCalculate = jest.fn();
 jest.mock("@ledgerhq/live-countervalues/logic", () => ({
@@ -290,19 +285,21 @@ describe("usePerpsDepositViewModel", () => {
   });
 
   it("hands the review the amount converted into the funding currency", () => {
+
+    mockCalculate.mockReturnValue(2.5e16);
     const { result, onClose } = renderViewModel({
-      draft: { depositAccount: fundingAccount, depositAmount: 20 },
+      draft: { depositAccount: fundedAccount, depositAmount: 20 },
     });
 
     act(() => result.current.handleReview());
 
     expect(mockOpenPerpsReview).toHaveBeenCalledWith({
       receiverAccount,
-      depositAccount: fundingAccount,
-      amountSent: "0.000000000000002",
+      depositAccount: fundedAccount,
+      amountSent: "0.025",
       // The received side is whatever the provider quoted, not a local conversion.
       amountTo: "42",
-      draft: { depositAccount: fundingAccount, depositAmount: 20 },
+      draft: { depositAccount: fundedAccount, depositAmount: 20 },
     });
     expect(onClose).toHaveBeenCalled();
   });

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
@@ -12,13 +12,24 @@ jest.mock("LLD/features/ModularDialog/Web3AppWebview/AssetAndAccountDrawer", () 
   }),
 }));
 
-// Countervalues are priced 1:1 with the account balance so the form ceiling is
-// predictable: a balance of 10_000 (2 decimals for USD) means a $100 maximum.
+const mockOpenPerpsReview = jest.fn();
+jest.mock("../../PerpsReview/PerpsReviewDialog", () => ({
+  openPerpsReview: (data: unknown) => mockOpenPerpsReview(data),
+}));
+
+// Countervalues are priced 1:1 in both directions, so the form ceiling is predictable:
+// a balance of 10_000 (2 decimals for USD) means a $100 maximum.
 const mockCalculateCountervalue = jest.fn((_currency: unknown, value: BigNumber) => value);
 jest.mock("@ledgerhq/live-countervalues-react", () => ({
   ...jest.requireActual("@ledgerhq/live-countervalues-react"),
   useCalculateCountervalueCallback: () => (currency: unknown, value: BigNumber) =>
     mockCalculateCountervalue(currency, value),
+  useCountervaluesState: () => ({}),
+}));
+
+jest.mock("@ledgerhq/live-countervalues/logic", () => ({
+  ...jest.requireActual("@ledgerhq/live-countervalues/logic"),
+  calculate: (_state: unknown, { value }: { value: number }) => value,
 }));
 
 // Prices the typed amount back into the funding currency, in its smallest unit.
@@ -278,13 +289,31 @@ describe("usePerpsDepositViewModel", () => {
     });
   });
 
-  it("closes the dialog when the form is ready to review", () => {
+  it("hands the review the amount converted into the funding currency", () => {
     const { result, onClose } = renderViewModel({
       draft: { depositAccount: fundingAccount, depositAmount: 20 },
     });
 
     act(() => result.current.handleReview());
 
+    expect(mockOpenPerpsReview).toHaveBeenCalledWith({
+      receiverAccount,
+      depositAccount: fundingAccount,
+      amountSent: "0.000000000000002",
+      // The received side is whatever the provider quoted, not a local conversion.
+      amountTo: "42",
+      draft: { depositAccount: fundingAccount, depositAmount: 20 },
+    });
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it("does not open the review while the form is incomplete", () => {
+    const { result, onClose } = renderViewModel();
+
+    act(() => result.current.changeDepositAmount("20"));
+    act(() => result.current.handleReview());
+
+    expect(mockOpenPerpsReview).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
@@ -85,7 +85,7 @@ describe("usePerpsDepositViewModel", () => {
     mockOpenAssetAndAccount.mockResolvedValue({ account: fundingAccount });
     mockCalculate.mockReturnValue(0);
     mockUsePerpsDepositQuote.mockReturnValue({
-      quote: { amountTo: new BigNumber(42) },
+      quote: { amountTo: new BigNumber(42), quoteId: "quote-1" },
       isLoading: false,
       isUnavailable: false,
     });
@@ -285,7 +285,6 @@ describe("usePerpsDepositViewModel", () => {
   });
 
   it("hands the review the amount converted into the funding currency", () => {
-
     mockCalculate.mockReturnValue(2.5e16);
     const { result, onClose } = renderViewModel({
       draft: { depositAccount: fundedAccount, depositAmount: 20 },
@@ -297,8 +296,8 @@ describe("usePerpsDepositViewModel", () => {
       receiverAccount,
       depositAccount: fundedAccount,
       amountSent: "0.025",
-      // The received side is whatever the provider quoted, not a local conversion.
       amountTo: "42",
+      quoteId: "quote-1",
       draft: { depositAccount: fundedAccount, depositAmount: 20 },
     });
     expect(onClose).toHaveBeenCalled();

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
@@ -264,6 +264,7 @@ export function usePerpsDepositViewModel(
       depositAccount,
       amountSent: sentAmount,
       amountTo: quote.amountTo.toFixed(),
+      quoteId: quote.quoteId,
       draft: { depositAccount, depositAmount },
     });
     onClose();

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
@@ -24,6 +24,7 @@ import {
   PERPS_DEPOSIT_DEFAULT_FUNDING_CURRENCY_ID,
   PERPS_DEPOSIT_DEFAULT_FUNDING_TICKER,
 } from "../../constants/depositFunding";
+import { openPerpsReview } from "../PerpsReview/PerpsReviewDialog";
 import { usePerpsDepositQuote } from "./usePerpsDepositQuote";
 import { applyRatio } from "./utils/applyRatio";
 import { toAmountValue } from "./utils/toAmountValue";
@@ -256,9 +257,26 @@ export function usePerpsDepositViewModel(
   }, [openAssetAndAccountPromise]);
 
   const handleReview = useCallback(() => {
-    if (!canReview || !depositAccount || !depositCurrency) return;
+    if (!canReview || !depositAccount || !depositCurrency || !quote) return;
+
+    openPerpsReview({
+      receiverAccount,
+      depositAccount,
+      amountSent: sentAmount,
+      amountTo: quote.amountTo.toFixed(),
+      draft: { depositAccount, depositAmount },
+    });
     onClose();
-  }, [canReview, depositAccount, depositCurrency, onClose]);
+  }, [
+    canReview,
+    depositAccount,
+    depositAmount,
+    depositCurrency,
+    onClose,
+    quote,
+    receiverAccount,
+    sentAmount,
+  ]);
 
   const headerDescription = `${receiverAccountName} · ${receiverAccountCounterValue}`;
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/PerpsReviewDialog.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/PerpsReviewDialog.tsx
@@ -1,0 +1,57 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { Dialog, DialogContent } from "@ledgerhq/lumen-ui-react";
+import type { PerpsReviewData } from "./usePerpsReviewViewModel";
+import { usePerpsReviewViewModel } from "./usePerpsReviewViewModel";
+import { PerpsReviewView } from "./PerpsReviewView";
+
+let _opener: ((data: PerpsReviewData) => void) | null = null;
+
+function registerPerpsReviewOpener(fn: (data: PerpsReviewData) => void): () => void {
+  _opener = fn;
+  return () => {
+    _opener = null;
+  };
+}
+
+export function openPerpsReview(data: PerpsReviewData) {
+  _opener?.(data);
+}
+
+function PerpsReviewBody({
+  data,
+  onClose,
+}: Readonly<{ data: PerpsReviewData; onClose: () => void }>) {
+  const viewModel = usePerpsReviewViewModel(data, onClose);
+  return <PerpsReviewView {...viewModel} />;
+}
+
+function PerpsReviewInnerDialog({
+  data,
+  onClose,
+}: Readonly<{ data: PerpsReviewData | null; onClose: () => void }>) {
+  const isOpen = data !== null;
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) onClose();
+    },
+    [onClose],
+  );
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent onInteractOutside={e => e.preventDefault()}>
+        {data ? <PerpsReviewBody data={data} onClose={onClose} /> : null}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default function PerpsReviewRoot() {
+  const [data, setData] = useState<PerpsReviewData | null>(null);
+  const close = useCallback(() => setData(null), []);
+
+  useEffect(() => registerPerpsReviewOpener(setData), []);
+
+  return <PerpsReviewInnerDialog data={data} onClose={close} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/PerpsReviewView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/PerpsReviewView.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Button,
+  DialogBody,
+  DialogHeader,
+  Subheader,
+  SubheaderRow,
+  SubheaderTitle,
+} from "@ledgerhq/lumen-ui-react";
+import { LedgerLogo as LedgerIcon } from "@ledgerhq/lumen-ui-react/symbols";
+import { PerpsReviewDetailRow } from "./components/PerpsReviewDetailRow";
+import type { PerpsReviewDetailItem, PerpsReviewViewModel } from "./usePerpsReviewViewModel";
+
+type PerpsReviewSectionProps = Readonly<{
+  titleKey: string;
+  details: readonly PerpsReviewDetailItem[];
+}>;
+
+function PerpsReviewSection({ titleKey, details }: PerpsReviewSectionProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex flex-col gap-12">
+      <Subheader>
+        <SubheaderRow className="mb-4">
+          <SubheaderTitle>{t(titleKey)}</SubheaderTitle>
+        </SubheaderRow>
+      </Subheader>
+      <div className="flex flex-col gap-8">
+        {details.map(detail => (
+          <PerpsReviewDetailRow
+            key={detail.labelKey}
+            label={t(detail.labelKey)}
+            value={detail.value}
+            testID={detail.testID}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function PerpsReviewView({
+  swapDetails,
+  depositDetails,
+  isSubmitting,
+  handleBack,
+  handleDeposit,
+}: Readonly<PerpsReviewViewModel>) {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <DialogHeader
+        density="expanded"
+        title={t("perpsReview.depositTitle")}
+        description={t("perpsReview.depositSubtitle")}
+        className="px-16!"
+        onBack={handleBack}
+      />
+      <DialogBody className="flex flex-col gap-24 px-16! pb-24!">
+        <PerpsReviewSection titleKey="perpsReview.swapDetailTitle" details={swapDetails} />
+        <PerpsReviewSection titleKey="perpsReview.depositDetailTitle" details={depositDetails} />
+        <Button
+          appearance="base"
+          size="lg"
+          className="w-full"
+          onClick={handleDeposit}
+          disabled={isSubmitting}
+          data-testid="perps-deposit-cta"
+          icon={LedgerIcon}
+        >
+          {t("perpsReview.depositCTA")}
+        </Button>
+      </DialogBody>
+    </>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/__integrations__/perpsReview.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/__integrations__/perpsReview.integration.test.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import type { Account } from "@ledgerhq/types-live";
+import { act, render, screen } from "tests/testSetup";
+import PerpsReviewRoot, { openPerpsReview } from "../PerpsReviewDialog";
+import type { PerpsReviewData } from "../usePerpsReviewViewModel";
+
+const mockOpenPerpsDeposit = jest.fn();
+jest.mock("../../PerpsDeposit/PerpsDepositDialog", () => ({
+  openPerpsDeposit: (data: unknown) => mockOpenPerpsDeposit(data),
+}));
+
+function createAccount(id: string): Account {
+  return genAccount(id, { currency: getCryptoCurrencyById("ethereum"), operationsSize: 0 });
+}
+
+const depositAccount = createAccount("funding-1");
+const receiverAccount = createAccount("receiver-1");
+
+const reviewData: PerpsReviewData = {
+  depositAccount,
+  receiverAccount,
+  amountSent: "0.02",
+  amountTo: "0.019",
+  draft: { depositAccount, depositAmount: 20 },
+};
+
+describe("PerpsReview integration", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("should not render the review until a deposit is handed over", () => {
+    render(<PerpsReviewRoot />);
+
+    expect(screen.queryByTestId("perps-deposit-cta")).not.toBeInTheDocument();
+  });
+
+  it("should show what is swapped and where it lands once opened", () => {
+    render(<PerpsReviewRoot />);
+
+    act(() => openPerpsReview(reviewData));
+
+    expect(screen.getByText("Swap details")).toBeVisible();
+    expect(screen.getByTestId("perps-deposit-amount-sent")).toHaveTextContent(/0\.02\s?ETH/);
+    // Everything downstream of the swap is a quote, so it reads as an estimate.
+    expect(screen.getByTestId("perps-deposit-amount-received")).toHaveTextContent(/~0\.019\s?ETH/);
+    expect(screen.getByTestId("perps-deposit-deposited-amount")).toHaveTextContent(/~0\.019\s?ETH/);
+    expect(screen.getByTestId("perps-deposit-receiver-account")).toBeVisible();
+    expect(screen.getByTestId("perps-deposit-cta")).toBeEnabled();
+  });
+
+  it("should hand the amount back to the deposit form when going back", async () => {
+    const { user } = render(<PerpsReviewRoot />);
+
+    act(() => openPerpsReview(reviewData));
+    await user.click(screen.getByRole("button", { name: /back/i }));
+
+    // The form reopens with the draft, so the user does not retype the amount.
+    expect(mockOpenPerpsDeposit).toHaveBeenCalledWith({
+      receiverAccount,
+      draft: reviewData.draft,
+    });
+    expect(screen.queryByTestId("perps-deposit-cta")).not.toBeInTheDocument();
+  });
+
+  it("should close the review once the deposit is confirmed", async () => {
+    const { user } = render(<PerpsReviewRoot />);
+
+    act(() => openPerpsReview(reviewData));
+    await user.click(screen.getByTestId("perps-deposit-cta"));
+
+    expect(screen.queryByTestId("perps-deposit-cta")).not.toBeInTheDocument();
+    expect(mockOpenPerpsDeposit).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/__tests__/usePerpsReviewViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/__tests__/usePerpsReviewViewModel.test.ts
@@ -46,6 +46,16 @@ describe("usePerpsReviewViewModel", () => {
     expect(result.current.swapDetails[0].value).toMatch(/^0\.02[\s\u00A0]ETH$/);
   });
 
+  it("should read the amount in the unit it was handed over in", async () => {
+    const gwei = getCryptoCurrencyById("ethereum").units[1];
+    const { result } = renderHook(() => usePerpsReviewViewModel(createData(), jest.fn()), {
+      initialState: { settings: { currenciesSettings: { ETH: { unit: gwei } } } },
+    });
+
+    await waitFor(() => expect(result.current.swapDetails[0].value).not.toBe(""));
+    expect(result.current.swapDetails[0].value).toMatch(/^0\.02[\s\u00A0]ETH$/);
+  });
+
   it("should format the received amount in the receiving currency, as an estimate", async () => {
     const { result } = renderHook(() => usePerpsReviewViewModel(createData(), jest.fn()));
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/__tests__/usePerpsReviewViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/__tests__/usePerpsReviewViewModel.test.ts
@@ -1,6 +1,5 @@
-import BigNumber from "bignumber.js";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
-import type { AccountLike } from "@ledgerhq/types-live";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { renderHook, waitFor } from "tests/testSetup";
 import { usePerpsReviewViewModel, type PerpsReviewData } from "../usePerpsReviewViewModel";
 
@@ -9,18 +8,9 @@ jest.mock("../../PerpsDeposit/PerpsDepositDialog", () => ({
   openPerpsDeposit: (data: unknown) => mockOpenPerpsDeposit(data),
 }));
 
-function createAccount(id: string, currencyId: string): AccountLike {
-  return {
-    type: "Account",
-    id,
-    currency: getCryptoCurrencyById(currencyId),
-    spendableBalance: new BigNumber(0),
-    balance: new BigNumber(0),
-  } as AccountLike;
-}
-
-const depositAccount = createAccount("funding-1", "ethereum");
-const receiverAccount = createAccount("receiver-1", "ethereum");
+const ethereum = getCryptoCurrencyById("ethereum");
+const depositAccount = genAccount("funding-1", { currency: ethereum, operationsSize: 0 });
+const receiverAccount = genAccount("receiver-1", { currency: ethereum, operationsSize: 0 });
 
 function createData(overrides?: Partial<PerpsReviewData>): PerpsReviewData {
   return {
@@ -47,7 +37,7 @@ describe("usePerpsReviewViewModel", () => {
   });
 
   it("should read the amount in the unit it was handed over in", async () => {
-    const gwei = getCryptoCurrencyById("ethereum").units[1];
+    const gwei = ethereum.units[1];
     const { result } = renderHook(() => usePerpsReviewViewModel(createData(), jest.fn()), {
       initialState: { settings: { currenciesSettings: { ETH: { unit: gwei } } } },
     });

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/__tests__/usePerpsReviewViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/__tests__/usePerpsReviewViewModel.test.ts
@@ -1,0 +1,84 @@
+import BigNumber from "bignumber.js";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import type { AccountLike } from "@ledgerhq/types-live";
+import { renderHook, waitFor } from "tests/testSetup";
+import { usePerpsReviewViewModel, type PerpsReviewData } from "../usePerpsReviewViewModel";
+
+const mockOpenPerpsDeposit = jest.fn();
+jest.mock("../../PerpsDeposit/PerpsDepositDialog", () => ({
+  openPerpsDeposit: (data: unknown) => mockOpenPerpsDeposit(data),
+}));
+
+function createAccount(id: string, currencyId: string): AccountLike {
+  return {
+    type: "Account",
+    id,
+    currency: getCryptoCurrencyById(currencyId),
+    spendableBalance: new BigNumber(0),
+    balance: new BigNumber(0),
+  } as AccountLike;
+}
+
+const depositAccount = createAccount("funding-1", "ethereum");
+const receiverAccount = createAccount("receiver-1", "ethereum");
+
+function createData(overrides?: Partial<PerpsReviewData>): PerpsReviewData {
+  return {
+    depositAccount,
+    receiverAccount,
+    amountSent: "0.02",
+    amountTo: "0.019",
+    ...overrides,
+  };
+}
+
+describe("usePerpsReviewViewModel", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("should format the sent amount in the funding currency", async () => {
+    const { result } = renderHook(() => usePerpsReviewViewModel(createData(), jest.fn()));
+
+    await waitFor(() =>
+      expect(result.current.swapDetails[0]).toEqual(
+        expect.objectContaining({ labelKey: "perpsReview.amountSendLabel" }),
+      ),
+    );
+    expect(result.current.swapDetails[0].value).toMatch(/^0\.02[\s\u00A0]ETH$/);
+  });
+
+  it("should format the received amount in the receiving currency", async () => {
+    const { result } = renderHook(() => usePerpsReviewViewModel(createData(), jest.fn()));
+
+    await waitFor(() => expect(result.current.swapDetails[1].value).not.toBe(""));
+    expect(result.current.swapDetails[1].value).toMatch(/^0\.019[\s\u00A0]ETH$/);
+  });
+
+  it("should show the received amount and the receiver account in the deposit details", async () => {
+    const { result } = renderHook(() => usePerpsReviewViewModel(createData(), jest.fn()));
+
+    await waitFor(() => expect(result.current.depositDetails[0].value).not.toBe(""));
+    expect(result.current.depositDetails[0].value).toMatch(/^0\.019[\s\u00A0]ETH$/);
+    expect(result.current.depositDetails[1].testID).toBe("perps-deposit-receiver-account");
+  });
+
+  it("should reopen the deposit form with the draft when going back", () => {
+    const onClose = jest.fn();
+    const draft = { depositAccount, depositAmount: 20 };
+    const { result } = renderHook(() => usePerpsReviewViewModel(createData({ draft }), onClose));
+
+    result.current.handleBack();
+
+    expect(mockOpenPerpsDeposit).toHaveBeenCalledWith({ receiverAccount, draft });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("should close the review when confirming the deposit", () => {
+    const onClose = jest.fn();
+    const { result } = renderHook(() => usePerpsReviewViewModel(createData(), onClose));
+
+    result.current.handleDeposit();
+
+    expect(onClose).toHaveBeenCalled();
+    expect(mockOpenPerpsDeposit).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/__tests__/usePerpsReviewViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/__tests__/usePerpsReviewViewModel.test.ts
@@ -46,18 +46,18 @@ describe("usePerpsReviewViewModel", () => {
     expect(result.current.swapDetails[0].value).toMatch(/^0\.02[\s\u00A0]ETH$/);
   });
 
-  it("should format the received amount in the receiving currency", async () => {
+  it("should format the received amount in the receiving currency, as an estimate", async () => {
     const { result } = renderHook(() => usePerpsReviewViewModel(createData(), jest.fn()));
 
     await waitFor(() => expect(result.current.swapDetails[1].value).not.toBe(""));
-    expect(result.current.swapDetails[1].value).toMatch(/^0\.019[\s\u00A0]ETH$/);
+    expect(result.current.swapDetails[1].value).toMatch(/^~0\.019[\s\u00A0]ETH$/);
   });
 
   it("should show the received amount and the receiver account in the deposit details", async () => {
     const { result } = renderHook(() => usePerpsReviewViewModel(createData(), jest.fn()));
 
     await waitFor(() => expect(result.current.depositDetails[0].value).not.toBe(""));
-    expect(result.current.depositDetails[0].value).toMatch(/^0\.019[\s\u00A0]ETH$/);
+    expect(result.current.depositDetails[0].value).toMatch(/^~0\.019[\s\u00A0]ETH$/);
     expect(result.current.depositDetails[1].testID).toBe("perps-deposit-receiver-account");
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/components/PerpsReviewDetailRow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/components/PerpsReviewDetailRow.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import {
+  DescriptionItem,
+  DescriptionItemLabel,
+  DescriptionItemLeading,
+  DescriptionItemTrailing,
+  DescriptionItemValue,
+} from "@ledgerhq/lumen-ui-react";
+
+type PerpsReviewDetailRowProps = Readonly<{
+  label: string;
+  value: string;
+  testID?: string;
+}>;
+
+export function PerpsReviewDetailRow({ label, value, testID }: PerpsReviewDetailRowProps) {
+  return (
+    <DescriptionItem size="md" data-testid={testID}>
+      <DescriptionItemLeading>
+        <DescriptionItemLabel>{label}</DescriptionItemLabel>
+      </DescriptionItemLeading>
+      <DescriptionItemTrailing>
+        <DescriptionItemValue>{value}</DescriptionItemValue>
+      </DescriptionItemTrailing>
+    </DescriptionItem>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/usePerpsReviewViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/usePerpsReviewViewModel.ts
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
 import type { PerpsDepositReviewParams } from "@ledgerhq/live-common/wallet-api/Perps/server";
 import { formatCurrencyUnit, parseCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { useSelector } from "LLD/hooks/redux";
@@ -28,6 +29,7 @@ export function usePerpsReviewViewModel(
   data: PerpsReviewData,
   onClose: () => void,
 ): PerpsReviewViewModel {
+  const { t } = useTranslation();
   const walletState = useSelector(walletSelector);
   const sentUnit = useAccountUnit(data.depositAccount);
   const receivedUnit = useAccountUnit(data.receiverAccount);
@@ -48,6 +50,11 @@ export function usePerpsReviewViewModel(
     [data.amountTo, receivedUnit],
   );
 
+  const approximateAmountReceived = useMemo(
+    () => t("perpsReview.approximateValue", { value: formattedAmountReceived }),
+    [formattedAmountReceived, t],
+  );
+
   const receiverAccountLabel = useMemo(
     () => accountNameWithDefaultSelector(walletState, data.receiverAccount),
     [data.receiverAccount, walletState],
@@ -62,18 +69,18 @@ export function usePerpsReviewViewModel(
       },
       {
         labelKey: "perpsReview.amountReceiveLabel",
-        value: formattedAmountReceived,
+        value: approximateAmountReceived,
         testID: "perps-deposit-amount-received",
       },
     ],
-    [formattedAmountReceived, formattedAmountSent],
+    [approximateAmountReceived, formattedAmountSent],
   );
 
   const depositDetails = useMemo<readonly PerpsReviewDetailItem[]>(
     () => [
       {
         labelKey: "perpsReview.depositAmountLabel",
-        value: formattedAmountReceived,
+        value: approximateAmountReceived,
         testID: "perps-deposit-deposited-amount",
       },
       {
@@ -82,7 +89,7 @@ export function usePerpsReviewViewModel(
         testID: "perps-deposit-receiver-account",
       },
     ],
-    [formattedAmountReceived, receiverAccountLabel],
+    [approximateAmountReceived, receiverAccountLabel],
   );
 
   const handleBack = useCallback(() => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/usePerpsReviewViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/usePerpsReviewViewModel.ts
@@ -1,0 +1,105 @@
+import { useCallback, useMemo } from "react";
+import type { PerpsDepositReviewParams } from "@ledgerhq/live-common/wallet-api/Perps/server";
+import { formatCurrencyUnit, parseCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import { useSelector } from "LLD/hooks/redux";
+import { accountNameWithDefaultSelector, walletSelector } from "~/renderer/reducers/wallet";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
+import { openPerpsDeposit } from "../PerpsDeposit/PerpsDepositDialog";
+import type { PerpsDepositDraft } from "../PerpsDeposit/usePerpsDepositViewModel";
+export type PerpsReviewData = PerpsDepositReviewParams & {
+  draft?: PerpsDepositDraft;
+};
+
+export type PerpsReviewDetailItem = Readonly<{
+  labelKey: string;
+  value: string;
+  testID?: string;
+}>;
+
+export type PerpsReviewViewModel = Readonly<{
+  swapDetails: readonly PerpsReviewDetailItem[];
+  depositDetails: readonly PerpsReviewDetailItem[];
+  isSubmitting: boolean;
+  handleBack: () => void;
+  handleDeposit: () => void;
+}>;
+
+export function usePerpsReviewViewModel(
+  data: PerpsReviewData,
+  onClose: () => void,
+): PerpsReviewViewModel {
+  const walletState = useSelector(walletSelector);
+  const sentUnit = useAccountUnit(data.depositAccount);
+  const receivedUnit = useAccountUnit(data.receiverAccount);
+
+  const formattedAmountSent = useMemo(
+    () =>
+      formatCurrencyUnit(sentUnit, parseCurrencyUnit(sentUnit, data.amountSent), {
+        showCode: true,
+      }),
+    [data.amountSent, sentUnit],
+  );
+
+  const formattedAmountReceived = useMemo(
+    () =>
+      formatCurrencyUnit(receivedUnit, parseCurrencyUnit(receivedUnit, data.amountTo), {
+        showCode: true,
+      }),
+    [data.amountTo, receivedUnit],
+  );
+
+  const receiverAccountLabel = useMemo(
+    () => accountNameWithDefaultSelector(walletState, data.receiverAccount),
+    [data.receiverAccount, walletState],
+  );
+
+  const swapDetails = useMemo<readonly PerpsReviewDetailItem[]>(
+    () => [
+      {
+        labelKey: "perpsReview.amountSendLabel",
+        value: formattedAmountSent,
+        testID: "perps-deposit-amount-sent",
+      },
+      {
+        labelKey: "perpsReview.amountReceiveLabel",
+        value: formattedAmountReceived,
+        testID: "perps-deposit-amount-received",
+      },
+    ],
+    [formattedAmountReceived, formattedAmountSent],
+  );
+
+  const depositDetails = useMemo<readonly PerpsReviewDetailItem[]>(
+    () => [
+      {
+        labelKey: "perpsReview.depositAmountLabel",
+        value: formattedAmountReceived,
+        testID: "perps-deposit-deposited-amount",
+      },
+      {
+        labelKey: "perpsReview.depositReceiveLabel",
+        value: receiverAccountLabel,
+        testID: "perps-deposit-receiver-account",
+      },
+    ],
+    [formattedAmountReceived, receiverAccountLabel],
+  );
+
+  const handleBack = useCallback(() => {
+    openPerpsDeposit({ receiverAccount: data.receiverAccount, draft: data.draft });
+    onClose();
+  }, [data.draft, data.receiverAccount, onClose]);
+
+  // The signing dialog is not built yet, so confirming just closes the review.
+  const handleDeposit = useCallback(() => {
+    onClose();
+  }, [onClose]);
+
+  return {
+    swapDetails,
+    depositDetails,
+    isSubmitting: false,
+    handleBack,
+    handleDeposit,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/usePerpsReviewViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/usePerpsReviewViewModel.ts
@@ -1,10 +1,10 @@
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type { PerpsDepositReviewParams } from "@ledgerhq/live-common/wallet-api/Perps/server";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit, parseCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { useSelector } from "LLD/hooks/redux";
 import { accountNameWithDefaultSelector, walletSelector } from "~/renderer/reducers/wallet";
-import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import { openPerpsDeposit } from "../PerpsDeposit/PerpsDepositDialog";
 import type { PerpsDepositDraft } from "../PerpsDeposit/usePerpsDepositViewModel";
 export type PerpsReviewData = PerpsDepositReviewParams & {
@@ -31,8 +31,9 @@ export function usePerpsReviewViewModel(
 ): PerpsReviewViewModel {
   const { t } = useTranslation();
   const walletState = useSelector(walletSelector);
-  const sentUnit = useAccountUnit(data.depositAccount);
-  const receivedUnit = useAccountUnit(data.receiverAccount);
+
+  const sentUnit = getAccountCurrency(data.depositAccount).units[0];
+  const receivedUnit = getAccountCurrency(data.receiverAccount).units[0];
 
   const formattedAmountSent = useMemo(
     () =>

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9860,6 +9860,17 @@
       "totalMaturityTooltip": "The total accumulated rewards from staking, including both staked and liquid maturity. These rewards can be either staked again or claimed as liquid ICP."
     }
   },
+  "perpsReview": {
+    "depositTitle": "Deposit via SwapKit",
+    "depositSubtitle": "Our partner SwapKit manages your swap and deposit in one transaction - all secured by your Ledger device.",
+    "swapDetailTitle": "Swap details",
+    "amountSendLabel": "Amount send",
+    "amountReceiveLabel": "Amount receive",
+    "depositDetailTitle": "Deposit details",
+    "depositAmountLabel": "Deposit amount",
+    "depositReceiveLabel": "Receiver account",
+    "depositCTA": "Deposit"
+  },
   "perpsDeposit": {
     "title": "Deposit",
     "inputDepositAmount": "Deposit ~{{value}}{{currencyTicker}}",

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9866,6 +9866,7 @@
     "swapDetailTitle": "Swap details",
     "amountSendLabel": "Amount send",
     "amountReceiveLabel": "Amount receive",
+    "approximateValue": "~{{value}}",
     "depositDetailTitle": "Deposit details",
     "depositAmountLabel": "Deposit amount",
     "depositReceiveLabel": "Receiver account",

--- a/libs/ledger-live-common/src/wallet-api/Perps/server.ts
+++ b/libs/ledger-live-common/src/wallet-api/Perps/server.ts
@@ -28,6 +28,13 @@ export type PerpsDepositUiParams = {
   receiverAccount: AccountLike;
 };
 
+export type PerpsDepositReviewParams = PerpsDepositUiParams & {
+  depositAccount: AccountLike;
+  amountSent: string;
+  amountTo: string;
+  quoteId?: string;
+};
+
 export type PerpsUiHooks = {
   "signing.execute": (params: {
     appName: string | undefined;


### PR DESCRIPTION
### 📝 Description

The step between entering an amount and signing: what SwapKit will take, what it will credit, and where it lands. Desktop only — the mobile sheet is #21031.

What's worth a look:

- Both amounts are rendered from the quote in their own currency, sent in the funding currency and received in USDC, so the screen never echoes one side back as the other. Amounts cross the boundary as display-unit strings; the accounts they belong to are already on the params, so no currency ids are threaded through.
- Opening the review is gated on a quote being present, which is why the deposit CTA in #21028 waits for one.

Adds `PerpsDepositReviewParams` to `wallet-api/Perps/server` in `live-common`. #21031 carries the identical change so the mobile chain stands alone; whichever merges second, it no-ops.

<img width="3024" height="1898" alt="Perps deposit review step on desktop" src="https://github.com/user-attachments/assets/109c81ba-c4a0-4258-a786-6836d14f5009" />

### 🧱 Stack

Desktop chain: #21028 (deposit screen) → this PR. Independent of the mobile chain (#21029 → #21031).

### 🔗 Context
https://ledgerhq.atlassian.net/browse/LIVE-34568
https://ledgerhq.atlassian.net/browse/LIVE-35327