### PR TITLE
[LWDM] feat(perps): add the deposit review step to mobile

### DIFF
--- a/.changeset/perps-deposit-review-mobile.md
+++ b/.changeset/perps-deposit-review-mobile.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Add the Perps deposit review step on mobile, reached from the deposit form, showing the swap and deposit details before the user confirms. The amount landing on the perps account now comes from a provider quote, since that balance has no counter value of its own.

--- a/.changeset/perps-deposit-review-mobile.md
+++ b/.changeset/perps-deposit-review-mobile.md
@@ -1,6 +1,5 @@
 ---
 "live-mobile": minor
-"@ledgerhq/live-common": minor
 ---
 
 Add the Perps deposit review step on mobile, reached from the deposit form, showing the swap and deposit details before the user confirms. The amount landing on the perps account now comes from a provider quote, since that balance has no counter value of its own.

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -9827,6 +9827,7 @@
     "swapDetailTitle": "Swap details",
     "amountSendLabel": "Amount send",
     "amountReceiveLabel": "Amount receive",
+    "approximateValue": "~{{value}}",
     "depositDetailTitle": "Deposit details",
     "depositAmountLabel": "Deposit amount",
     "depositReceiveLabel": "Receiver account",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -9835,7 +9835,7 @@
   },
   "perpsDeposit": {
     "title": "Deposit",
-    "inputDepositAmount": "Deposit ~{{value}}{{currencyTicker}}",
+    "inputDepositAmount": "Deposit ~{{value}}",
     "inputSubText": "Swap and deposit via {{provider}}",
     "selectCurrencyTitle": "Deposit with {{currencyTicker}}",
     "selectCurrencyAccount": "{{accountName}} · {{counterValue}}",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -9836,7 +9836,7 @@
   "perpsDeposit": {
     "title": "Deposit",
     "inputDepositAmount": "Deposit ~{{value}}{{currencyTicker}}",
-    "inputSubText": "Swap and deposit via SwapKit",
+    "inputSubText": "Swap and deposit via {{provider}}",
     "selectCurrencyTitle": "Deposit with {{currencyTicker}}",
     "selectCurrencyAccount": "{{accountName}} · {{counterValue}}",
     "selectCurrencyNoAccount": "No account",
@@ -9844,7 +9844,7 @@
     "keypadDelete": "Delete last digit",
     "formErrors": {
       "amountExceedsBalance": "Insufficient balance",
-      "quoteUnavailable": "We can’t get a quote from SwapKit, try with a different asset or come back later."
+      "quoteUnavailable": "We can’t get a quote from {{provider}}, try with a different asset or come back later."
     }
   },
   "swapErrors": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -9821,6 +9821,17 @@
       "cta": "Try again"
     }
   },
+  "perpsReview": {
+    "depositTitle": "Deposit via SwapKit",
+    "depositSubtitle": "Our partner SwapKit manages your swap and deposit in one transaction - all secured by your Ledger device.",
+    "swapDetailTitle": "Swap details",
+    "amountSendLabel": "Amount send",
+    "amountReceiveLabel": "Amount receive",
+    "depositDetailTitle": "Deposit details",
+    "depositAmountLabel": "Deposit amount",
+    "depositReceiveLabel": "Receiver account",
+    "depositCTA": "Deposit"
+  },
   "perpsDeposit": {
     "title": "Deposit",
     "inputDepositAmount": "Deposit ~{{value}}{{currencyTicker}}",

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/constants/depositFunding.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/constants/depositFunding.ts
@@ -1,3 +1,6 @@
 /** Shown before the user picks a funding account */
 export const PERPS_DEPOSIT_DEFAULT_FUNDING_CURRENCY_ID = "arbitrum/erc20/usd_coin";
 export const PERPS_DEPOSIT_DEFAULT_FUNDING_TICKER = "USDC";
+
+/** The CAL partner quoting the deposit, which owns its name and terms. */
+export const PERPS_DEPOSIT_PROVIDER_ID = "swapkit_hyperliquid";

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/constants/depositFunding.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/constants/depositFunding.ts
@@ -3,4 +3,4 @@ export const PERPS_DEPOSIT_DEFAULT_FUNDING_CURRENCY_ID = "arbitrum/erc20/usd_coi
 export const PERPS_DEPOSIT_DEFAULT_FUNDING_TICKER = "USDC";
 
 /** The CAL partner quoting the deposit, which owns its name and terms. */
-export const PERPS_DEPOSIT_PROVIDER_ID = "swapkit_hyperliquid";
+export { PERPS_DEPOSIT_QUOTE_PROVIDER as PERPS_DEPOSIT_PROVIDER_ID } from "@ledgerhq/live-common/wallet-api/Perps/depositQuote";

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__integrations__/perpsDeposit.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__integrations__/perpsDeposit.integration.test.tsx
@@ -162,4 +162,19 @@ describe("PerpsDeposit integration", () => {
     expect(screen.getByTestId("perps-deposit-quote-skeleton")).toBeOnTheScreen();
     expect(screen.getByTestId("perps-deposit-review-cta")).toBeDisabled();
   });
+
+  it("should open the review drawer when the form is submitted", async () => {
+    const { user } = renderDeposit();
+
+    await user.press(screen.getByTestId("perps-deposit-select-currency"));
+    const { onAccountSelected } = mockOpenDrawer.mock.calls[0][0];
+    act(() => onAccountSelected(fundingAccount));
+
+    await user.press(screen.getByTestId("perps-deposit-key-2"));
+    await user.press(screen.getByTestId("perps-deposit-key-0"));
+    await user.press(screen.getByTestId("perps-deposit-review-cta"));
+
+    expect(await screen.findByTestId("perps-deposit-cta")).toBeOnTheScreen();
+    expect(screen.getByTestId("perps-deposit-amount-sent")).toBeOnTheScreen();
+  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
@@ -314,4 +314,37 @@ describe("usePerpsDepositViewModel", () => {
       labelKey: "perpsDeposit.formErrors.amountExceedsBalance",
     });
   });
+
+  it("opens the review with the amount converted into the funding currency", () => {
+    // $20 buys 0.025 ETH, which the review shows in the funding currency.
+    mockCalculate.mockReturnValue(2.5e16);
+    const { props } = createProps();
+    const { result } = renderViewModel(props);
+
+    act(() => result.current.pickDepositAccount());
+    selectFundingAccount(fundedAccount);
+    typeAmount(result.current.pressAmountKey, "20");
+
+    act(() => result.current.handleReview());
+
+    expect(result.current.isReviewOpen).toBe(true);
+    // The received side is whatever the provider quoted, not a local conversion.
+    expect(result.current.reviewParams).toEqual({
+      depositAccount: fundedAccount,
+      receiverAccount,
+      amountSent: "0.025",
+      amountTo: "42",
+    });
+  });
+
+  it("keeps the review closed while the form is incomplete", () => {
+    const { props } = createProps();
+    const { result } = renderViewModel(props);
+
+    typeAmount(result.current.pressAmountKey, "20");
+    act(() => result.current.handleReview());
+
+    expect(result.current.isReviewOpen).toBe(false);
+    expect(result.current.reviewParams).toBeNull();
+  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
@@ -82,7 +82,7 @@ describe("usePerpsDepositViewModel", () => {
     mockCalculateCountervalue.mockImplementation((_currency, value) => value);
     mockCalculate.mockReturnValue(0);
     mockUsePerpsDepositQuote.mockReturnValue({
-      quote: { amountTo: new BigNumber(42) },
+      quote: { amountTo: new BigNumber(42), quoteId: "quote-1" },
       isLoading: false,
       isUnavailable: false,
     });
@@ -328,12 +328,12 @@ describe("usePerpsDepositViewModel", () => {
     act(() => result.current.handleReview());
 
     expect(result.current.isReviewOpen).toBe(true);
-    // The received side is whatever the provider quoted, not a local conversion.
     expect(result.current.reviewParams).toEqual({
       depositAccount: fundedAccount,
       receiverAccount,
       amountSent: "0.025",
       amountTo: "42",
+      quoteId: "quote-1",
     });
   });
 
@@ -348,8 +348,7 @@ describe("usePerpsDepositViewModel", () => {
     act(() => result.current.handleReview());
 
     const reviewed = result.current.reviewParams;
-    // The provider drops the quote while refetching; the open review must not
-    // vanish along with it.
+
     mockUsePerpsDepositQuote.mockReturnValue({
       quote: undefined,
       isLoading: true,

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
@@ -253,7 +253,7 @@ describe("usePerpsDepositViewModel", () => {
     selectFundingAccount();
 
     expect(result.current.headerDescription).toContain("***");
-    expect(result.current.depositAccountCounterValue).toBe("***");
+    expect(result.current.depositAccountCounterValue).toBe("$***");
   });
 
   it("holds the review CTA back until the quote lands", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
@@ -337,6 +337,30 @@ describe("usePerpsDepositViewModel", () => {
     });
   });
 
+  it("holds the reviewed amounts still while quotes refresh behind it", () => {
+    mockCalculate.mockReturnValue(2.5e16);
+    const { props } = createProps();
+    const { result, rerender } = renderViewModel(props);
+
+    act(() => result.current.pickDepositAccount());
+    selectFundingAccount(fundedAccount);
+    typeAmount(result.current.pressAmountKey, "20");
+    act(() => result.current.handleReview());
+
+    const reviewed = result.current.reviewParams;
+    // The provider drops the quote while refetching; the open review must not
+    // vanish along with it.
+    mockUsePerpsDepositQuote.mockReturnValue({
+      quote: undefined,
+      isLoading: true,
+      isUnavailable: false,
+    });
+    act(() => rerender(undefined));
+
+    expect(result.current.isReviewOpen).toBe(true);
+    expect(result.current.reviewParams).toEqual(reviewed);
+  });
+
   it("keeps the review closed while the form is incomplete", () => {
     const { props } = createProps();
     const { result } = renderViewModel(props);

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/PerpsReviewView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/PerpsReviewView.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import {
+  BottomSheetHeader,
+  BottomSheetView,
+  Box,
+  Button,
+  Subheader,
+  SubheaderRow,
+  SubheaderTitle,
+} from "@ledgerhq/lumen-ui-rnative";
+import { LedgerLogo as LedgerIcon } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { QueuedBottomSheet } from "@shared/ui-queued-bottom-sheet";
+import { useTranslation } from "~/context/Locale";
+import { PerpsReviewDetailRow } from "./components/PerpsReviewDetailRow";
+import type { PerpsReviewDetailItem, PerpsReviewViewModel } from "./usePerpsReviewViewModel";
+
+type PerpsReviewSectionProps = Readonly<{
+  titleKey: string;
+  details: readonly PerpsReviewDetailItem[];
+}>;
+
+function PerpsReviewSection({ titleKey, details }: PerpsReviewSectionProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Box lx={{ gap: "s12" }}>
+      <Subheader>
+        <SubheaderRow lx={{ marginBottom: "s4" }}>
+          <SubheaderTitle>{t(titleKey)}</SubheaderTitle>
+        </SubheaderRow>
+      </Subheader>
+      <Box lx={{ gap: "s8" }}>
+        {details.map(detail => (
+          <PerpsReviewDetailRow
+            key={detail.labelKey}
+            label={t(detail.labelKey)}
+            value={detail.value}
+            testID={detail.testID}
+          />
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
+export function PerpsReviewView({
+  drawerOpen,
+  swapDetails,
+  depositDetails,
+  handleDrawerClose,
+  handleDeposit,
+}: Readonly<PerpsReviewViewModel>) {
+  const { t } = useTranslation();
+  const insets = useSafeAreaInsets();
+
+  return (
+    <QueuedBottomSheet
+      isRequestingToBeOpened={drawerOpen}
+      onClose={handleDrawerClose}
+      enableDynamicSizing
+    >
+      <BottomSheetView style={{ paddingBottom: insets.bottom }}>
+        <BottomSheetHeader
+          title={t("perpsReview.depositTitle")}
+          description={t("perpsReview.depositSubtitle")}
+          spacing
+          density="expanded"
+          lx={{ paddingHorizontal: "s0" }}
+        />
+        <Box lx={{ gap: "s24", paddingTop: "s16", paddingBottom: "s24" }}>
+          <PerpsReviewSection titleKey="perpsReview.swapDetailTitle" details={swapDetails} />
+          <PerpsReviewSection titleKey="perpsReview.depositDetailTitle" details={depositDetails} />
+
+          <Button
+            appearance="base"
+            size="lg"
+            lx={{ width: "full" }}
+            onPress={handleDeposit}
+            testID="perps-deposit-cta"
+            icon={LedgerIcon}
+          >
+            {t("perpsReview.depositCTA")}
+          </Button>
+        </Box>
+      </BottomSheetView>
+    </QueuedBottomSheet>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/__tests__/usePerpsReviewViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/__tests__/usePerpsReviewViewModel.test.ts
@@ -39,6 +39,23 @@ describe("usePerpsReviewViewModel", () => {
     expect(result.current.swapDetails[0].value).toMatch(/^0\.02[\s\u00A0]ETH$/);
   });
 
+  it("reads the amount in the unit it was handed over in", async () => {
+   
+    const gwei = getCryptoCurrencyById("ethereum").units[1];
+    const { result } = renderHook(() => usePerpsReviewViewModel(createProps()), {
+      overrideInitialState: state => ({
+        ...state,
+        settings: {
+          ...state.settings,
+          currenciesSettings: { ETH: { unit: gwei, confirmationsNb: 0 } },
+        },
+      }),
+    });
+
+    await waitFor(() => expect(result.current.swapDetails[0].value).not.toBe(""));
+    expect(result.current.swapDetails[0].value).toMatch(/^0\.02[\s\u00A0]ETH$/);
+  });
+
   it("formats the received amount in the receiving currency, as an estimate", async () => {
     const { result } = renderHook(() => usePerpsReviewViewModel(createProps()));
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/__tests__/usePerpsReviewViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/__tests__/usePerpsReviewViewModel.test.ts
@@ -39,18 +39,18 @@ describe("usePerpsReviewViewModel", () => {
     expect(result.current.swapDetails[0].value).toMatch(/^0\.02[\s\u00A0]ETH$/);
   });
 
-  it("formats the received amount in the receiving currency", async () => {
+  it("formats the received amount in the receiving currency, as an estimate", async () => {
     const { result } = renderHook(() => usePerpsReviewViewModel(createProps()));
 
     await waitFor(() => expect(result.current.swapDetails[1].value).not.toBe(""));
-    expect(result.current.swapDetails[1].value).toMatch(/^0\.019[\s\u00A0]ETH$/);
+    expect(result.current.swapDetails[1].value).toMatch(/^~0\.019[\s\u00A0]ETH$/);
   });
 
   it("shows the received amount and the receiver account in the deposit details", async () => {
     const { result } = renderHook(() => usePerpsReviewViewModel(createProps()));
 
     await waitFor(() => expect(result.current.depositDetails[0].value).not.toBe(""));
-    expect(result.current.depositDetails[0].value).toMatch(/^0\.019[\s\u00A0]ETH$/);
+    expect(result.current.depositDetails[0].value).toMatch(/^~0\.019[\s\u00A0]ETH$/);
     expect(result.current.depositDetails[1].testID).toBe("perps-deposit-receiver-account");
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/__tests__/usePerpsReviewViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/__tests__/usePerpsReviewViewModel.test.ts
@@ -1,0 +1,71 @@
+import BigNumber from "bignumber.js";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import type { AccountLike } from "@ledgerhq/types-live";
+import { renderHook, waitFor } from "@tests/test-renderer";
+import { usePerpsReviewViewModel, type PerpsReviewProps } from "../usePerpsReviewViewModel";
+
+function createAccount(id: string, currencyId: string): AccountLike {
+  return {
+    type: "Account",
+    id,
+    currency: getCryptoCurrencyById(currencyId),
+    spendableBalance: new BigNumber(0),
+    balance: new BigNumber(0),
+  } as AccountLike;
+}
+
+const depositAccount = createAccount("funding-1", "ethereum");
+const receiverAccount = createAccount("receiver-1", "ethereum");
+
+function createProps(overrides?: Partial<PerpsReviewProps>): PerpsReviewProps {
+  return {
+    depositAccount,
+    receiverAccount,
+    amountSent: "0.02",
+    amountTo: "0.019",
+    isOpen: true,
+    onClose: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe("usePerpsReviewViewModel", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("formats the sent amount in the funding currency", async () => {
+    const { result } = renderHook(() => usePerpsReviewViewModel(createProps()));
+
+    await waitFor(() => expect(result.current.swapDetails[0].value).not.toBe(""));
+    expect(result.current.swapDetails[0].value).toMatch(/^0\.02[\s\u00A0]ETH$/);
+  });
+
+  it("formats the received amount in the receiving currency", async () => {
+    const { result } = renderHook(() => usePerpsReviewViewModel(createProps()));
+
+    await waitFor(() => expect(result.current.swapDetails[1].value).not.toBe(""));
+    expect(result.current.swapDetails[1].value).toMatch(/^0\.019[\s\u00A0]ETH$/);
+  });
+
+  it("shows the received amount and the receiver account in the deposit details", async () => {
+    const { result } = renderHook(() => usePerpsReviewViewModel(createProps()));
+
+    await waitFor(() => expect(result.current.depositDetails[0].value).not.toBe(""));
+    expect(result.current.depositDetails[0].value).toMatch(/^0\.019[\s\u00A0]ETH$/);
+    expect(result.current.depositDetails[1].testID).toBe("perps-deposit-receiver-account");
+  });
+
+  it("mirrors the open state onto the drawer", () => {
+    const { result } = renderHook(() => usePerpsReviewViewModel(createProps({ isOpen: false })));
+
+    expect(result.current.drawerOpen).toBe(false);
+  });
+
+  it("closes the drawer when confirming the deposit", () => {
+    const onClose = jest.fn();
+    const { result } = renderHook(() => usePerpsReviewViewModel(createProps({ onClose })));
+
+    result.current.handleDeposit();
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/__tests__/usePerpsReviewViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/__tests__/usePerpsReviewViewModel.test.ts
@@ -1,21 +1,11 @@
-import BigNumber from "bignumber.js";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
-import type { AccountLike } from "@ledgerhq/types-live";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { renderHook, waitFor } from "@tests/test-renderer";
 import { usePerpsReviewViewModel, type PerpsReviewProps } from "../usePerpsReviewViewModel";
 
-function createAccount(id: string, currencyId: string): AccountLike {
-  return {
-    type: "Account",
-    id,
-    currency: getCryptoCurrencyById(currencyId),
-    spendableBalance: new BigNumber(0),
-    balance: new BigNumber(0),
-  } as AccountLike;
-}
-
-const depositAccount = createAccount("funding-1", "ethereum");
-const receiverAccount = createAccount("receiver-1", "ethereum");
+const ethereum = getCryptoCurrencyById("ethereum");
+const depositAccount = genAccount("funding-1", { currency: ethereum, operationsSize: 0 });
+const receiverAccount = genAccount("receiver-1", { currency: ethereum, operationsSize: 0 });
 
 function createProps(overrides?: Partial<PerpsReviewProps>): PerpsReviewProps {
   return {
@@ -40,8 +30,7 @@ describe("usePerpsReviewViewModel", () => {
   });
 
   it("reads the amount in the unit it was handed over in", async () => {
-   
-    const gwei = getCryptoCurrencyById("ethereum").units[1];
+    const gwei = ethereum.units[1];
     const { result } = renderHook(() => usePerpsReviewViewModel(createProps()), {
       overrideInitialState: state => ({
         ...state,

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/components/PerpsReviewDetailRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/components/PerpsReviewDetailRow.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import {
+  DescriptionItem,
+  DescriptionItemLabel,
+  DescriptionItemLeading,
+  DescriptionItemTrailing,
+  DescriptionItemValue,
+} from "@ledgerhq/lumen-ui-rnative";
+
+type PerpsReviewDetailRowProps = Readonly<{
+  label: string;
+  value: string;
+  testID?: string;
+}>;
+
+export function PerpsReviewDetailRow({ label, value, testID }: PerpsReviewDetailRowProps) {
+  return (
+    <DescriptionItem size="md" testID={testID}>
+      <DescriptionItemLeading>
+        <DescriptionItemLabel>{label}</DescriptionItemLabel>
+      </DescriptionItemLeading>
+      <DescriptionItemTrailing>
+        <DescriptionItemValue>{value}</DescriptionItemValue>
+      </DescriptionItemTrailing>
+    </DescriptionItem>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/index.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { PerpsReviewView } from "./PerpsReviewView";
+import { usePerpsReviewViewModel, type PerpsReviewProps } from "./usePerpsReviewViewModel";
+
+export type { PerpsReviewParams, PerpsReviewProps } from "./usePerpsReviewViewModel";
+
+export function PerpsReview(props: PerpsReviewProps) {
+  const viewModel = usePerpsReviewViewModel(props);
+  return <PerpsReviewView {...viewModel} />;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/usePerpsReviewViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/usePerpsReviewViewModel.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from "react";
 import type { PerpsDepositReviewParams } from "@ledgerhq/live-common/wallet-api/Perps/server";
 import { formatCurrencyUnit, parseCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import { useTranslation } from "~/context/Locale";
 import { useSelector } from "~/context/hooks";
 import { accountNameWithDefaultSelector, walletSelector } from "~/reducers/wallet";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
@@ -35,6 +36,7 @@ export function usePerpsReviewViewModel({
   depositAccount,
   receiverAccount,
 }: PerpsReviewProps): PerpsReviewViewModel {
+  const { t } = useTranslation();
   const walletState = useSelector(walletSelector);
   const sentUnit = useAccountUnit(depositAccount);
   const receivedUnit = useAccountUnit(receiverAccount);
@@ -55,6 +57,11 @@ export function usePerpsReviewViewModel({
     [amountTo, receivedUnit],
   );
 
+  const approximateAmountReceived = useMemo(
+    () => t("perpsReview.approximateValue", { value: formattedAmountReceived }),
+    [formattedAmountReceived, t],
+  );
+
   const receiverAccountLabel = useMemo(
     () => accountNameWithDefaultSelector(walletState, receiverAccount),
     [receiverAccount, walletState],
@@ -69,18 +76,18 @@ export function usePerpsReviewViewModel({
       },
       {
         labelKey: "perpsReview.amountReceiveLabel",
-        value: formattedAmountReceived,
+        value: approximateAmountReceived,
         testID: "perps-deposit-amount-received",
       },
     ],
-    [formattedAmountReceived, formattedAmountSent],
+    [approximateAmountReceived, formattedAmountSent],
   );
 
   const depositDetails = useMemo<readonly PerpsReviewDetailItem[]>(
     () => [
       {
         labelKey: "perpsReview.depositAmountLabel",
-        value: formattedAmountReceived,
+        value: approximateAmountReceived,
         testID: "perps-deposit-deposited-amount",
       },
       {
@@ -89,7 +96,7 @@ export function usePerpsReviewViewModel({
         testID: "perps-deposit-receiver-account",
       },
     ],
-    [formattedAmountReceived, receiverAccountLabel],
+    [approximateAmountReceived, receiverAccountLabel],
   );
 
   const handleDeposit = useCallback(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/usePerpsReviewViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/usePerpsReviewViewModel.ts
@@ -1,10 +1,10 @@
 import { useCallback, useMemo } from "react";
 import type { PerpsDepositReviewParams } from "@ledgerhq/live-common/wallet-api/Perps/server";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit, parseCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { useTranslation } from "~/context/Locale";
 import { useSelector } from "~/context/hooks";
 import { accountNameWithDefaultSelector, walletSelector } from "~/reducers/wallet";
-import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 
 export type PerpsReviewDetailItem = Readonly<{
   labelKey: string;
@@ -38,8 +38,9 @@ export function usePerpsReviewViewModel({
 }: PerpsReviewProps): PerpsReviewViewModel {
   const { t } = useTranslation();
   const walletState = useSelector(walletSelector);
-  const sentUnit = useAccountUnit(depositAccount);
-  const receivedUnit = useAccountUnit(receiverAccount);
+  
+  const sentUnit = getAccountCurrency(depositAccount).units[0];
+  const receivedUnit = getAccountCurrency(receiverAccount).units[0];
 
   const formattedAmountSent = useMemo(
     () =>

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/usePerpsReviewViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/usePerpsReviewViewModel.ts
@@ -38,7 +38,7 @@ export function usePerpsReviewViewModel({
 }: PerpsReviewProps): PerpsReviewViewModel {
   const { t } = useTranslation();
   const walletState = useSelector(walletSelector);
-  
+
   const sentUnit = getAccountCurrency(depositAccount).units[0];
   const receivedUnit = getAccountCurrency(receiverAccount).units[0];
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/usePerpsReviewViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/usePerpsReviewViewModel.ts
@@ -4,6 +4,7 @@ import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit, parseCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { useTranslation } from "~/context/Locale";
 import { useSelector } from "~/context/hooks";
+import { localeSelector } from "~/reducers/settings";
 import { accountNameWithDefaultSelector, walletSelector } from "~/reducers/wallet";
 
 export type PerpsReviewDetailItem = Readonly<{
@@ -38,6 +39,7 @@ export function usePerpsReviewViewModel({
 }: PerpsReviewProps): PerpsReviewViewModel {
   const { t } = useTranslation();
   const walletState = useSelector(walletSelector);
+  const locale = useSelector(localeSelector);
 
   const sentUnit = getAccountCurrency(depositAccount).units[0];
   const receivedUnit = getAccountCurrency(receiverAccount).units[0];
@@ -46,16 +48,18 @@ export function usePerpsReviewViewModel({
     () =>
       formatCurrencyUnit(sentUnit, parseCurrencyUnit(sentUnit, amountSent), {
         showCode: true,
+        locale,
       }),
-    [amountSent, sentUnit],
+    [amountSent, sentUnit, locale],
   );
 
   const formattedAmountReceived = useMemo(
     () =>
       formatCurrencyUnit(receivedUnit, parseCurrencyUnit(receivedUnit, amountTo), {
         showCode: true,
+        locale,
       }),
-    [amountTo, receivedUnit],
+    [amountTo, receivedUnit, locale],
   );
 
   const approximateAmountReceived = useMemo(

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/usePerpsReviewViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/usePerpsReviewViewModel.ts
@@ -1,0 +1,108 @@
+import { useCallback, useMemo } from "react";
+import type { PerpsDepositReviewParams } from "@ledgerhq/live-common/wallet-api/Perps/server";
+import { formatCurrencyUnit, parseCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import { useSelector } from "~/context/hooks";
+import { accountNameWithDefaultSelector, walletSelector } from "~/reducers/wallet";
+import { useAccountUnit } from "LLM/hooks/useAccountUnit";
+
+export type PerpsReviewDetailItem = Readonly<{
+  labelKey: string;
+  value: string;
+  testID?: string;
+}>;
+
+export type PerpsReviewParams = Readonly<PerpsDepositReviewParams>;
+
+export type PerpsReviewProps = PerpsReviewParams &
+  Readonly<{
+    isOpen: boolean;
+    onClose: () => void;
+  }>;
+
+export type PerpsReviewViewModel = Readonly<{
+  drawerOpen: boolean;
+  swapDetails: readonly PerpsReviewDetailItem[];
+  depositDetails: readonly PerpsReviewDetailItem[];
+  handleDrawerClose: () => void;
+  handleDeposit: () => void;
+}>;
+
+export function usePerpsReviewViewModel({
+  isOpen,
+  onClose,
+  amountSent,
+  amountTo,
+  depositAccount,
+  receiverAccount,
+}: PerpsReviewProps): PerpsReviewViewModel {
+  const walletState = useSelector(walletSelector);
+  const sentUnit = useAccountUnit(depositAccount);
+  const receivedUnit = useAccountUnit(receiverAccount);
+
+  const formattedAmountSent = useMemo(
+    () =>
+      formatCurrencyUnit(sentUnit, parseCurrencyUnit(sentUnit, amountSent), {
+        showCode: true,
+      }),
+    [amountSent, sentUnit],
+  );
+
+  const formattedAmountReceived = useMemo(
+    () =>
+      formatCurrencyUnit(receivedUnit, parseCurrencyUnit(receivedUnit, amountTo), {
+        showCode: true,
+      }),
+    [amountTo, receivedUnit],
+  );
+
+  const receiverAccountLabel = useMemo(
+    () => accountNameWithDefaultSelector(walletState, receiverAccount),
+    [receiverAccount, walletState],
+  );
+
+  const swapDetails = useMemo<readonly PerpsReviewDetailItem[]>(
+    () => [
+      {
+        labelKey: "perpsReview.amountSendLabel",
+        value: formattedAmountSent,
+        testID: "perps-deposit-amount-sent",
+      },
+      {
+        labelKey: "perpsReview.amountReceiveLabel",
+        value: formattedAmountReceived,
+        testID: "perps-deposit-amount-received",
+      },
+    ],
+    [formattedAmountReceived, formattedAmountSent],
+  );
+
+  const depositDetails = useMemo<readonly PerpsReviewDetailItem[]>(
+    () => [
+      {
+        labelKey: "perpsReview.depositAmountLabel",
+        value: formattedAmountReceived,
+        testID: "perps-deposit-deposited-amount",
+      },
+      {
+        labelKey: "perpsReview.depositReceiveLabel",
+        value: receiverAccountLabel,
+        testID: "perps-deposit-receiver-account",
+      },
+    ],
+    [formattedAmountReceived, receiverAccountLabel],
+  );
+
+  const handleDeposit = useCallback(() => {
+    // Confirming closes the drawer; executing the deposit (sign + broadcast) is
+    // owned by the wallet's deposit flow and reports no result to the live app.
+    onClose();
+  }, [onClose]);
+
+  return {
+    drawerOpen: isOpen,
+    swapDetails,
+    depositDetails,
+    handleDrawerClose: onClose,
+    handleDeposit,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/index.tsx
@@ -2,7 +2,9 @@ import React from "react";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { AmountInput, Box, Button, Skeleton, Text } from "@ledgerhq/lumen-ui-rnative";
 import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
+import { getProviderName } from "@ledgerhq/live-common/exchange/swap/utils/index";
 import { useTranslation } from "~/context/Locale";
+import { PERPS_DEPOSIT_PROVIDER_ID } from "../../constants/depositFunding";
 import { AmountKeypad } from "LLM/components/AmountKeypad";
 import { RatioPicker } from "LLM/components/RatioPicker";
 import { DepositAccountSelector } from "./components/DepositAccountSelector";
@@ -45,11 +47,12 @@ function AmountMessage({
   depositAmount,
 }: Pick<PerpsDepositViewModel, "statusError" | "depositAmount">) {
   const { t } = useTranslation();
+  const provider = getProviderName(PERPS_DEPOSIT_PROVIDER_ID);
 
   if (statusError) {
     return (
       <Text typography="body3" lx={{ color: "error" }} testID="perps-deposit-form-error">
-        {t(statusError.labelKey)}
+        {t(statusError.labelKey, { provider })}
       </Text>
     );
   }
@@ -57,7 +60,7 @@ function AmountMessage({
   if (depositAmount > 0) {
     return (
       <Text typography="body3" lx={{ color: "base" }}>
-        {t("perpsDeposit.inputSubText")}
+        {t("perpsDeposit.inputSubText", { provider })}
       </Text>
     );
   }

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/index.tsx
@@ -15,9 +15,8 @@ const QUOTED_AMOUNT_SKELETON_SIZE = { width: 112, height: 16 };
 
 function QuotedAmount({
   formattedQuotedAmount,
-  quotedAmountTicker,
   isQuoteLoading,
-}: Pick<PerpsDepositViewModel, "formattedQuotedAmount" | "quotedAmountTicker" | "isQuoteLoading">) {
+}: Pick<PerpsDepositViewModel, "formattedQuotedAmount" | "isQuoteLoading">) {
   const { t } = useTranslation();
 
   if (isQuoteLoading) {
@@ -34,10 +33,7 @@ function QuotedAmount({
 
   return (
     <Text typography="body3" lx={{ color: "muted" }}>
-      {t("perpsDeposit.inputDepositAmount", {
-        value: formattedQuotedAmount,
-        currencyTicker: quotedAmountTicker,
-      })}
+      {t("perpsDeposit.inputDepositAmount", { value: formattedQuotedAmount })}
     </Text>
   );
 }
@@ -73,7 +69,6 @@ export function PerpsDepositView({
   amountText,
   depositAmount,
   formattedQuotedAmount,
-  quotedAmountTicker,
   isQuoteLoading,
   counterValueCode,
   maxDecimalLength,
@@ -126,7 +121,6 @@ export function PerpsDepositView({
           />
           <QuotedAmount
             formattedQuotedAmount={formattedQuotedAmount}
-            quotedAmountTicker={quotedAmountTicker}
             isQuoteLoading={isQuoteLoading}
           />
           <AmountMessage statusError={statusError} depositAmount={depositAmount} />

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/index.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "~/context/Locale";
 import { AmountKeypad } from "LLM/components/AmountKeypad";
 import { RatioPicker } from "LLM/components/RatioPicker";
 import { DepositAccountSelector } from "./components/DepositAccountSelector";
+import { PerpsReview } from "./components/PerpsReview";
 import type { PerpsDepositViewModel } from "./usePerpsDepositViewModel";
 
 const QUOTED_AMOUNT_SKELETON_SIZE = { width: 112, height: 16 };
@@ -87,6 +88,9 @@ export function PerpsDepositView({
   missingAccount,
   pickDepositAccount,
   handleReview,
+  isReviewOpen,
+  reviewParams,
+  closeReview,
 }: Readonly<PerpsDepositViewModel>) {
   const { t } = useTranslation();
   const styles = useStyleSheet(
@@ -163,6 +167,10 @@ export function PerpsDepositView({
           {t("perpsDeposit.review")}
         </Button>
       </Box>
+
+      {reviewParams ? (
+        <PerpsReview {...reviewParams} isOpen={isReviewOpen} onClose={closeReview} />
+      ) : null}
     </SafeAreaView>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
@@ -44,7 +44,6 @@ export type PerpsDepositViewModel = Readonly<{
   amountText: string;
   depositAmount: number;
   formattedQuotedAmount: string;
-  quotedAmountTicker: string;
   isQuoteLoading: boolean;
   counterValueCode: string;
   maxDecimalLength: number;
@@ -145,7 +144,7 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
     const counterValue =
       calculateCountervalue(receiverCurrency, receiverAccount.spendableBalance) ?? new BigNumber(0);
     return formatCurrencyUnit(counterValueUnit, counterValue, {
-      showCode: false,
+      showCode: true,
       discreet,
       locale,
     });
@@ -166,7 +165,7 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
   const depositAccountCounterValue = useMemo(() => {
     if (!depositAccountBalanceCounterValue) return null;
     return formatCurrencyUnit(counterValueUnit, depositAccountBalanceCounterValue, {
-      showCode: false,
+      showCode: true,
       discreet,
       locale,
     });
@@ -229,7 +228,7 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
     () =>
       quote
         ? formatCurrencyUnit(receiverUnit, valueFromUnit(quote.amountTo, receiverUnit), {
-            showCode: false,
+            showCode: true,
             locale,
           })
         : "",
@@ -267,7 +266,6 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
     amountText,
     depositAmount,
     formattedQuotedAmount,
-    quotedAmountTicker: receiverCurrency.ticker,
     isQuoteLoading,
     counterValueCode: counterValueUnit.code,
     maxDecimalLength,

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
@@ -25,6 +25,7 @@ import {
   PERPS_DEPOSIT_DEFAULT_FUNDING_CURRENCY_ID,
   PERPS_DEPOSIT_DEFAULT_FUNDING_TICKER,
 } from "../../constants/depositFunding";
+import type { PerpsReviewParams } from "./components/PerpsReview";
 import { usePerpsDepositQuote } from "./usePerpsDepositQuote";
 import { applyAmountKey, toAmountText } from "./utils/amountKeys";
 import { toAmountValue } from "./utils/toAmountValue";
@@ -61,6 +62,9 @@ export type PerpsDepositViewModel = Readonly<{
   missingAccount: boolean;
   pickDepositAccount: () => void;
   handleReview: () => void;
+  isReviewOpen: boolean;
+  reviewParams: PerpsReviewParams | null;
+  closeReview: () => void;
 }>;
 
 export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepositViewModel {
@@ -75,6 +79,7 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
 
   const [depositAccountId, setDepositAccountId] = useState<string | undefined>(undefined);
   const [amountText, setAmountText] = useState("");
+  const [isReviewOpen, setIsReviewOpen] = useState(false);
 
   /** Read from the store so balances stay live while the form is open. */
   const depositAccount = useMemo(
@@ -242,7 +247,23 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
     });
   }, [openDrawer]);
 
-  const handleReview = useCallback(() => undefined, []);
+  const reviewParams = useMemo<PerpsReviewParams | null>(() => {
+    if (!depositAccount || !depositCurrency || !sentAmount || !quote) return null;
+
+    return {
+      depositAccount,
+      receiverAccount,
+      amountSent: sentAmount,
+      amountTo: quote.amountTo.toFixed(),
+    };
+  }, [depositAccount, depositCurrency, quote, receiverAccount, sentAmount]);
+
+  const handleReview = useCallback(() => {
+    if (!canReview) return;
+    setIsReviewOpen(true);
+  }, [canReview]);
+
+  const closeReview = useCallback(() => setIsReviewOpen(false), []);
 
   return {
     headerDescription: `${receiverAccountName} · ${receiverAccountCounterValue}`,
@@ -269,5 +290,8 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
     missingAccount,
     pickDepositAccount,
     handleReview,
+    isReviewOpen,
+    reviewParams,
+    closeReview,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
@@ -255,6 +255,7 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
       receiverAccount,
       amountSent: sentAmount,
       amountTo: quote.amountTo.toFixed(),
+      quoteId: quote.quoteId,
     });
     setIsReviewOpen(true);
   }, [canReview, depositAccount, quote, receiverAccount, sentAmount]);

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
@@ -80,6 +80,7 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
   const [depositAccountId, setDepositAccountId] = useState<string | undefined>(undefined);
   const [amountText, setAmountText] = useState("");
   const [isReviewOpen, setIsReviewOpen] = useState(false);
+  const [reviewParams, setReviewParams] = useState<PerpsReviewParams | null>(null);
 
   /** Read from the store so balances stay live while the form is open. */
   const depositAccount = useMemo(
@@ -247,21 +248,16 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
     });
   }, [openDrawer]);
 
-  const reviewParams = useMemo<PerpsReviewParams | null>(() => {
-    if (!depositAccount || !depositCurrency || !sentAmount || !quote) return null;
-
-    return {
+  const handleReview = useCallback(() => {
+    if (!canReview || !depositAccount || !sentAmount || !quote) return;
+    setReviewParams({
       depositAccount,
       receiverAccount,
       amountSent: sentAmount,
       amountTo: quote.amountTo.toFixed(),
-    };
-  }, [depositAccount, depositCurrency, quote, receiverAccount, sentAmount]);
-
-  const handleReview = useCallback(() => {
-    if (!canReview) return;
+    });
     setIsReviewOpen(true);
-  }, [canReview]);
+  }, [canReview, depositAccount, quote, receiverAccount, sentAmount]);
 
   const closeReview = useCallback(() => setIsReviewOpen(false), []);
 

--- a/libs/ledger-live-common/src/exchange/swap/utils/index.test.ts
+++ b/libs/ledger-live-common/src/exchange/swap/utils/index.test.ts
@@ -10,6 +10,7 @@ import {
   getAvailableAccountsById,
   getNoticeType,
   getProviderName,
+  getProviderTermsOfUseUrl,
   isRegistrationRequired,
 } from "./index";
 
@@ -226,6 +227,30 @@ describe("swap/utils/getProviderName", () => {
     const result = getProviderName("changelly");
 
     expect(result).toBe(expectedResult);
+  });
+});
+
+describe("swap/utils/getProviderTermsOfUseUrl", () => {
+  test("should return the terms of use url for changelly", () => {
+    const expectedResult = "https://changelly.com/terms-of-use";
+
+    const result = getProviderTermsOfUseUrl("changelly");
+
+    expect(result).toBe(expectedResult);
+  });
+
+  test("should return the terms of use url for the perps deposit provider", () => {
+    const expectedResult = "https://swapkit.dev/terms-of-service/";
+
+    const result = getProviderTermsOfUseUrl("swapkit_hyperliquid");
+
+    expect(result).toBe(expectedResult);
+  });
+
+  test("should return undefined for an unknown provider", () => {
+    const result = getProviderTermsOfUseUrl("unknown-provider");
+
+    expect(result).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
### 📝 Description

The step between entering an amount and signing: what SwapKit will take, what it will credit, and where it lands. Mobile only, presented as a bottom sheet over the deposit screen — the desktop dialog is #21030.

What's worth a look:

- Both amounts are rendered from the quote in their own currency, sent in the funding currency and received in USDC, so the sheet never echoes one side back as the other. Amounts cross the boundary as display-unit strings; the accounts they belong to are already on the params, so no currency ids are threaded through.
- Opening the review is gated on a quote being present, which is why the deposit CTA in #21029 waits for one.

Carries the same `PerpsDepositReviewParams` addition as #21030 — that duplication is what keeps this chain independent of desktop, and it no-ops for whichever merges second.

<img width="1206" height="2622" alt="Perps deposit review step on mobile" src="https://github.com/user-attachments/assets/a4ef9808-1930-4b7a-82dd-8f454615815c" />

### 🧱 Stack

Mobile chain: #21029 (deposit screen) → this PR. Independent of the desktop chain (#21028 → #21030).

### 🔗 Context

https://ledgerhq.atlassian.net/browse/LIVE-34568
https://ledgerhq.atlassian.net/browse/LIVE-35327