### PR TITLE
[LWDM] fix(zcash): birthday defaults to Ironwood activation (LIVE-36263)

### DIFF
--- a/.changeset/gentle-zebras-dance.md
+++ b/.changeset/gentle-zebras-dance.md
@@ -1,6 +1,6 @@
 ---
-"@ledgerhq/coin-zcash": patch
-"ledger-live-desktop": patch
+"@ledgerhq/coin-zcash": minor
+"ledger-live-desktop": minor
 ---
 
 Default the Zcash shielded-balance birthday to Ironwood (NU6.3) mainnet activation

--- a/.changeset/gentle-zebras-dance.md
+++ b/.changeset/gentle-zebras-dance.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-zcash": patch
+"ledger-live-desktop": patch
+---
+
+Default the Zcash shielded-balance birthday to Ironwood (NU6.3) mainnet activation
+instead of Orchard/NU5 activation, and reject a birthday dated in the future.

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/__tests__/ZCashExportKeyFlowModal.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/__tests__/ZCashExportKeyFlowModal.integ.test.tsx
@@ -52,11 +52,15 @@ jest.mock("../Body", () => {
   return function MockBody({
     onUfvkChanged,
     handleBirthdayChange,
+    handleSyncFromZero,
     handleEnableShieldedBalance,
+    invalidBirthday,
   }: {
     onUfvkChanged: (ufvk: string) => void;
     handleBirthdayChange: (birthday: string) => void;
+    handleSyncFromZero: () => void;
     handleEnableShieldedBalance: (nextSyncState: "ready" | "running") => void;
+    invalidBirthday: boolean;
   }) {
     return (
       <div>
@@ -66,6 +70,14 @@ jest.mock("../Body", () => {
         <button type="button" onClick={() => handleBirthdayChange("2025-01-01")}>
           set birthday
         </button>
+        <input
+          data-testid="birthday-input"
+          onChange={event => handleBirthdayChange(event.target.value)}
+        />
+        <button type="button" onClick={handleSyncFromZero}>
+          sync from zero
+        </button>
+        <span data-testid="invalid-birthday">{String(invalidBirthday)}</span>
         <button type="button" onClick={() => handleEnableShieldedBalance("ready")}>
           Close
         </button>
@@ -439,5 +451,93 @@ describe("ZCash Export UFVK Flow - Persistence integration", () => {
       );
     });
     expect(mockDispatch).toHaveBeenCalledWith({ type: "TEST_SYNC_STATE_ACTION" });
+  });
+
+  describe("birthday validation", () => {
+    const today = new Date().toISOString().split("T")[0];
+    const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().split("T")[0];
+
+    it("rejects a birthday before Ironwood activation", async () => {
+      render(<ExportKeyModal account={account} />);
+
+      fireEvent.change(screen.getByTestId("birthday-input"), {
+        target: { value: "2026-07-27" },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("invalid-birthday")).toHaveTextContent("true");
+      });
+    });
+
+    it("accepts a birthday exactly at Ironwood activation", async () => {
+      render(<ExportKeyModal account={account} />);
+
+      fireEvent.change(screen.getByTestId("birthday-input"), {
+        target: { value: "2026-07-28" },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("invalid-birthday")).toHaveTextContent("false");
+      });
+    });
+
+    it("rejects a future birthday", async () => {
+      render(<ExportKeyModal account={account} />);
+
+      fireEvent.change(screen.getByTestId("birthday-input"), {
+        target: { value: tomorrow },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("invalid-birthday")).toHaveTextContent("true");
+      });
+    });
+
+    it("accepts a birthday equal to today", async () => {
+      render(<ExportKeyModal account={account} />);
+
+      fireEvent.change(screen.getByTestId("birthday-input"), {
+        target: { value: today },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("invalid-birthday")).toHaveTextContent("false");
+      });
+    });
+
+    it("rejects a malformed birthday", async () => {
+      render(<ExportKeyModal account={account} />);
+
+      fireEvent.change(screen.getByTestId("birthday-input"), {
+        target: { value: "not-a-date" },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("invalid-birthday")).toHaveTextContent("true");
+      });
+    });
+
+    it("syncFromZero sets the Ironwood activation date", async () => {
+      mockSyncStateUpdater.mockReturnValue({ type: "TEST_SYNC_STATE_ACTION" });
+      render(<ExportKeyModal account={account} />);
+
+      await userEvent.click(screen.getByRole("button", { name: /set ufvk/i }));
+      await userEvent.click(screen.getByRole("button", { name: /sync from zero/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("invalid-birthday")).toHaveTextContent("false");
+      });
+
+      await userEvent.click(screen.getByRole("button", { name: /close/i }));
+
+      await waitFor(() => {
+        expect(mockSyncStateUpdater).toHaveBeenCalledWith(
+          account,
+          expect.objectContaining({
+            birthday: "2026-07-28",
+          }),
+        );
+      });
+    });
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/__tests__/ZCashExportKeyFlowModal.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/__tests__/ZCashExportKeyFlowModal.integ.test.tsx
@@ -403,6 +403,64 @@ describe("ZCash Export UFVK Flow - Integration test", () => {
       expect(onUfvkChanged).toHaveBeenCalledWith("", null, exportError);
     });
   });
+
+  it("disables Continue on the birthday step when the birthday is invalid", async () => {
+    render(
+      <RealBody
+        stepId="birthday"
+        ufvk={ufvk}
+        ufvkExportError={ufvkExportError}
+        onStepIdChanged={jest.fn()}
+        onUfvkChanged={jest.fn()}
+        onRetry={jest.fn()}
+        onClose={jest.fn()}
+        birthday="2000-02-11"
+        invalidBirthday
+        syncFromZero={false}
+        handleBirthdayChange={jest.fn()}
+        handleSyncFromZero={jest.fn()}
+        handleEnableShieldedBalance={jest.fn()}
+        params={{ account }}
+      />,
+      {
+        initialState: {
+          settings: AFTER_ONBOARDING_STATE,
+          devices: { currentDevice: mockDevice, devices: [mockDevice] },
+        },
+      },
+    );
+
+    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();
+  });
+
+  it("enables Continue on the birthday step when the birthday is valid", async () => {
+    render(
+      <RealBody
+        stepId="birthday"
+        ufvk={ufvk}
+        ufvkExportError={ufvkExportError}
+        onStepIdChanged={jest.fn()}
+        onUfvkChanged={jest.fn()}
+        onRetry={jest.fn()}
+        onClose={jest.fn()}
+        birthday={birthday}
+        invalidBirthday={false}
+        syncFromZero={false}
+        handleBirthdayChange={jest.fn()}
+        handleSyncFromZero={jest.fn()}
+        handleEnableShieldedBalance={jest.fn()}
+        params={{ account }}
+      />,
+      {
+        initialState: {
+          settings: AFTER_ONBOARDING_STATE,
+          devices: { currentDevice: mockDevice, devices: [mockDevice] },
+        },
+      },
+    );
+
+    expect(screen.getByRole("button", { name: /continue/i })).toBeEnabled();
+  });
 });
 
 describe("ZCash Export UFVK Flow - Persistence integration", () => {

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/__tests__/ZCashExportKeyFlowModal.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/__tests__/ZCashExportKeyFlowModal.integ.test.tsx
@@ -454,8 +454,13 @@ describe("ZCash Export UFVK Flow - Persistence integration", () => {
   });
 
   describe("birthday validation", () => {
-    const today = new Date().toISOString().split("T")[0];
-    const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().split("T")[0];
+    // Local date parts, matching the component's own "today" (see index.tsx) -- not
+    // toISOString(), which would desync from the assertions on machines/CI runners
+    // whose timezone isn't UTC.
+    const toLocalDateString = (date: Date) =>
+      `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+    const today = toLocalDateString(new Date());
+    const tomorrow = toLocalDateString(new Date(Date.now() + 24 * 60 * 60 * 1000));
 
     it("rejects a birthday before Ironwood activation", async () => {
       render(<ExportKeyModal account={account} />);

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/__tests__/ZCashExportKeyFlowModal.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/__tests__/ZCashExportKeyFlowModal.integ.test.tsx
@@ -67,7 +67,7 @@ jest.mock("../Body", () => {
         <button type="button" onClick={() => onUfvkChanged("test-ufvk")}>
           set ufvk
         </button>
-        <button type="button" onClick={() => handleBirthdayChange("2025-01-01")}>
+        <button type="button" onClick={() => handleBirthdayChange("2026-08-01")}>
           set birthday
         </button>
         <input
@@ -425,7 +425,7 @@ describe("ZCash Export UFVK Flow - Persistence integration", () => {
         expect.objectContaining({
           syncState: "ready",
           ufvk: "test-ufvk",
-          birthday: "2025-01-01",
+          birthday: "2026-08-01",
         }),
       );
     });
@@ -446,7 +446,7 @@ describe("ZCash Export UFVK Flow - Persistence integration", () => {
         expect.objectContaining({
           syncState: "running",
           ufvk: "test-ufvk",
-          birthday: "2025-01-01",
+          birthday: "2026-08-01",
         }),
       );
     });

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/__tests__/ZCashExportKeyFlowModal.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/__tests__/ZCashExportKeyFlowModal.test.tsx
@@ -1,11 +1,14 @@
 import React from "react";
-import { render, screen, waitFor } from "tests/testSetup";
+import { render, screen, userEvent, waitFor } from "tests/testSetup";
 import { createFixtureAccount } from "@ledgerhq/coin-bitcoin/fixtures/common.fixtures";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { DeviceModelId } from "@ledgerhq/devices";
+import { openURL } from "~/renderer/linking";
 import Body from "../Body";
 import { StepId } from "../types";
 import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+
+jest.mock("~/renderer/linking", () => ({ openURL: jest.fn() }));
 
 jest.mock("@ledgerhq/live-common/bridge/index", () => {
   const actual = jest.requireActual<Record<PropertyKey, unknown>>(
@@ -108,6 +111,33 @@ describe("ZCash Export UFVK Flow", () => {
         name: /continue/i,
       }),
     ).toBeVisible();
+  });
+
+  it("opens the support article when Learn more is clicked", async () => {
+    const stepId: StepId = "birthday";
+
+    render(
+      <Body
+        stepId={stepId}
+        ufvk={ufvk}
+        ufvkExportError={ufvkExportError}
+        onStepIdChanged={jest.fn()}
+        onUfvkChanged={jest.fn()}
+        onRetry={jest.fn()}
+        onClose={jest.fn()}
+        birthday={birthday}
+        invalidBirthday={invalidBirthday}
+        syncFromZero={syncFromZero}
+        handleBirthdayChange={jest.fn()}
+        handleSyncFromZero={jest.fn()}
+        handleEnableShieldedBalance={jest.fn()}
+        params={{ account }}
+      />,
+    );
+
+    await userEvent.click(screen.getByText(/learn more/i));
+
+    expect(openURL).toHaveBeenCalledWith("https://support.ledger.com/article/115005177269-zd");
   });
 
   it("should show ufvk step", async () => {

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/index.tsx
@@ -34,14 +34,21 @@ const ExportKeyModal = ({ account }: { account: ZcashAccount }) => {
     );
   };
 
-  const handleBirthdayChange = useCallback((value: string) => {
-    setBirthday(value);
-    if (isNaN(new Date(value).getDate()) || new Date(value) < ZCASH_ACTIVATION_DATE) {
-      setInvalidBirthday(true);
-      return;
-    }
-    setInvalidBirthday(false);
-  }, []);
+  const handleBirthdayChange = useCallback(
+    (value: string) => {
+      setBirthday(value);
+      if (
+        isNaN(new Date(value).getDate()) ||
+        new Date(value) < ZCASH_ACTIVATION_DATE ||
+        value > today
+      ) {
+        setInvalidBirthday(true);
+        return;
+      }
+      setInvalidBirthday(false);
+    },
+    [today],
+  );
 
   const handleSyncFromZero = useCallback(() => {
     if (!syncFromZero) {

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/index.tsx
@@ -19,7 +19,11 @@ const ExportKeyModal = ({ account }: { account: ZcashAccount }) => {
   const [shieldedAddress, setShieldedAddress] = useState<string | null>(null);
   const [ufvkExportError, setUfvkExportError] = useState<Error | undefined | null>(null);
 
-  const today = new Date().toISOString().split("T")[0];
+  // The DatePicker's native <input type="date"> shows the user's local calendar day, so
+  // "today" must be computed from local date parts -- toISOString() gives the UTC day,
+  // which would wrongly reject the user's own local "today" for positive UTC-offset zones.
+  const now = new Date();
+  const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
   const [birthday, setBirthday] = useState(today);
   const [invalidBirthday, setInvalidBirthday] = useState(false);
   const [syncFromZero, setSyncFromZero] = useState(false);

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/shared/ContinueFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/shared/ContinueFooter.tsx
@@ -5,7 +5,12 @@ import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
 import type { StepProps } from "../types";
 
-export function ContinueFooter({ account, transitionTo, stepId }: Readonly<StepProps>) {
+export function ContinueFooter({
+  account,
+  transitionTo,
+  stepId,
+  invalidBirthday,
+}: Readonly<StepProps>) {
   invariant(account, "account required");
 
   const nextStep = useCallback(() => {
@@ -21,9 +26,18 @@ export function ContinueFooter({ account, transitionTo, stepId }: Readonly<StepP
     }
   }, [stepId]);
 
+  // invalidBirthday only gates the birthday step itself -- it stays irrelevant once the
+  // user has moved past it, so a later step's Continue is never blocked by it.
+  const disabled = stepId === "birthday" && invalidBirthday;
+
   return (
     <Box horizontal>
-      <Button id="export-key-continue-button" primary onClick={() => transitionTo(nextStep())}>
+      <Button
+        id="export-key-continue-button"
+        primary
+        disabled={disabled}
+        onClick={() => transitionTo(nextStep())}
+      >
         <Trans i18nKey="common.continue" />
       </Button>
     </Box>

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/steps/StepBirthday.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/steps/StepBirthday.tsx
@@ -11,6 +11,11 @@ import { Container } from "../shared/Container";
 import ToolTip from "~/renderer/components/Tooltip";
 import { Title, TitleWrapper } from "../../AccountBalanceSummaryFooter";
 import InfoCircle from "~/renderer/icons/InfoCircle";
+import LinkWithExternalIcon from "~/renderer/components/LinkWithExternalIcon";
+import { openURL } from "~/renderer/linking";
+
+// Placeholder support article; content owners plan to swap this for a dedicated one later.
+const BIRTHDAY_LEARN_MORE_URL = "https://support.ledger.com/article/115005177269-zd";
 
 function StepBirthday({
   t,
@@ -41,11 +46,11 @@ function StepBirthday({
             color="neutral.c100"
             fontSize={13}
           >
-            <Trans i18nKey="zcash.shielded.flows.export.steps.birthday.text" />
-            <b>
-              {" "}
-              <Trans i18nKey="zcash.shielded.flows.export.steps.birthday.cta" />
-            </b>
+            <Trans i18nKey="zcash.shielded.flows.export.steps.birthday.text" />{" "}
+            <LinkWithExternalIcon
+              label={<Trans i18nKey="zcash.shielded.flows.export.steps.birthday.cta" />}
+              onClick={() => openURL(BIRTHDAY_LEARN_MORE_URL)}
+            />
           </Text>
         )}
       />

--- a/libs/coin-modules/coin-zcash/src/constants.ts
+++ b/libs/coin-modules/coin-zcash/src/constants.ts
@@ -55,10 +55,11 @@ export const getZainoEndpoint = (): { grpcUrl: string; network: ZcashNetwork } =
 // app mirrors into live-common (`bridge/zcashRouting.ts`). This module never has
 // to ask: it is only ever reached when the answer is yes.
 
-// NU5 activation, the earliest block a Ledger-created shielded account can hold
-// a note -- and so the default birthday a scan starts from.
-export const ZCASH_ACTIVATION_DATE = new Date("2022-05-31");
-export const ZCASH_ACTIVATION_DATE_STRING = "2022-05-31";
+// Ironwood (NU6.3) activation, not Orchard/NU5 -- Ledger's shielded balance
+// covers the Ironwood pool only. The earliest block a Ledger-created
+// shielded account can hold a note, and so the default birthday a scan starts from.
+export const ZCASH_ACTIVATION_DATE = new Date("2026-07-28");
+export const ZCASH_ACTIVATION_DATE_STRING = "2026-07-28";
 // A freshly shielded note is scanned into the spendable (Ironwood) balance
 // before it can actually be spent: it first needs to gain confirmations. Until
 // the note's transaction has this many blocks mined on top of it, the spendable


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Updates the Zcash shielded-balance default birthday and its validation bound from Orchard/NU5 activation (2022-05-31) to Ironwood/NU6.3 mainnet activation (2026-07-28), and adds a missing check that rejects a birthday dated in the future.

Previous behaviour: the default/minimum birthday was Orchard (NU5) activation, so a fresh account would scan roughly four years of history that Ledger's shielded balance (Ironwood pool only) never uses; there was also no upper bound, so a birthday dated in the future was silently accepted as valid.

Fix: bumped `ZCASH_ACTIVATION_DATE` / `ZCASH_ACTIVATION_DATE_STRING` (`coin-zcash/src/constants.ts`) to Ironwood mainnet activation, and added a `value > today` check to `ZCashExportKeyFlowModal`'s `handleBirthdayChange` — a timezone-safe string comparison, not a raw `Date` comparison against `new Date()`, which would wrongly reject "today" for users in positive-UTC-offset timezones.

Automated check preventing regression: six new tests cover the before/at-boundary/after/malformed birthday cases and the "scan from block 0" checkbox, extending the existing `ZCashExportKeyFlowModal` integration test.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36263](https://ledgerhq.atlassian.net/browse/LIVE-36263)
- **ADR** (if any): none


[LIVE-36263]: https://ledgerhq.atlassian.net/browse/LIVE-36263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ