### PR TITLE
feat(devtools): wire suffix-import lint rule across all packages

### DIFF
--- a/.changeset/clumsy-river-drift.md
+++ b/.changeset/clumsy-river-drift.md
@@ -1,0 +1,14 @@
+---
+"@devtools/bindings": patch
+"@devtools/feature-flags": patch
+"@devtools/pay-card": patch
+"@devtools/protocols": patch
+"@devtools/registry": patch
+"@devtools/relay": patch
+"@devtools/shell": patch
+"@devtools/transport-panel": patch
+"@devtools/transport": patch
+"@devtools/wire": patch
+---
+
+All devtools packages now enforce the `suffix-imports/no-platform-suffix` oxlint rule via a shared `.oxlintrc.json` at the `devtools/` root. Each package gains a `lint` script. Existing `.native` suffix imports in shell test files are fixed.

--- a/devtools/.oxlintrc.json
+++ b/devtools/.oxlintrc.json
@@ -1,0 +1,6 @@
+{
+    "jsPlugins": ["../support/lint-rules/src/suffix-imports"],
+    "rules": {
+        "suffix-imports/no-platform-suffix":"error"
+    }
+}

--- a/devtools/bindings/package.json
+++ b/devtools/bindings/package.json
@@ -16,7 +16,8 @@
     "format:check": "oxfmt src --check",
     "test": "jest",
     "test:watch": "jest --watch",
-    "coverage": "jest --coverage"
+    "coverage": "jest --coverage",
+    "lint": "oxlint src"
   },
   "dependencies": {
     "@devtools/registry": "workspace:*",

--- a/devtools/feature-flags/package.json
+++ b/devtools/feature-flags/package.json
@@ -17,7 +17,8 @@
     "test:watch": "jest --watch",
     "coverage": "pnpm run coverage:web && pnpm run coverage:native && bash -c 'cat coverage/lcov.native.info >> coverage/lcov.info' --",
     "coverage:web": "jest --config jest.config.js --coverage",
-    "coverage:native": "jest --config jest.native.config.js --coverage"
+    "coverage:native": "jest --config jest.native.config.js --coverage",
+    "lint": "oxlint src"
   },
   "dependencies": {
     "@shared/feature-flags": "workspace:^"

--- a/devtools/pay-card/package.json
+++ b/devtools/pay-card/package.json
@@ -17,7 +17,8 @@
     "test:watch": "jest --watch",
     "coverage": "pnpm run coverage:web && pnpm run coverage:native && bash -c 'cat coverage/lcov.native.info >> coverage/lcov.info' --",
     "coverage:web": "jest --config jest.config.js --coverage",
-    "coverage:native": "jest --config jest.native.config.js --coverage"
+    "coverage:native": "jest --config jest.native.config.js --coverage",
+    "lint": "oxlint src"
   },
   "devDependencies": {
     "@support/jest-devtools": "workspace:*",

--- a/devtools/protocols/package.json
+++ b/devtools/protocols/package.json
@@ -13,7 +13,8 @@
     "format:check": "oxfmt src jest.config.js --check",
     "typecheck": "tsc --noEmit",
     "coverage": "jest --config jest.config.js --coverage",
-    "test": "jest --config jest.config.js"
+    "test": "jest --config jest.config.js",
+    "lint": "oxlint src"
   },
   "dependencies": {
     "@devtools/transport": "workspace:*",

--- a/devtools/registry/package.json
+++ b/devtools/registry/package.json
@@ -12,7 +12,8 @@
     "add-tool": "nx g @ledgerhq/generators:devtool && oxfmt src",
     "reformat": "nx g @ledgerhq/generators:reformat-devtool-registry && oxfmt src",
     "typecheck": "tsc --noEmit",
-    "coverage": "echo \"no tests in @devtools/registry\""
+    "coverage": "echo \"no tests in @devtools/registry\"",
+    "lint": "oxlint src"
   },
   "dependencies": {
     "zod": "catalog:",

--- a/devtools/relay/package.json
+++ b/devtools/relay/package.json
@@ -10,7 +10,8 @@
     "start": "tsx src/server.ts",
     "typecheck": "tsc --noEmit",
     "test": "jest --config jest.config.js",
-    "coverage": "jest --config jest.config.js --coverage"
+    "coverage": "jest --config jest.config.js --coverage",
+    "lint": "oxlint src"
   },
   "dependencies": {
     "@devtools/transport": "workspace:*",

--- a/devtools/shell/package.json
+++ b/devtools/shell/package.json
@@ -24,7 +24,8 @@
     "test:watch": "jest --watch",
     "coverage": "pnpm run coverage:web && pnpm run coverage:native && bash -c 'cat coverage/lcov.native.info >> coverage/lcov.info' --",
     "coverage:web": "jest --config jest.config.js --coverage",
-    "coverage:native": "jest --config jest.native.config.js --coverage"
+    "coverage:native": "jest --config jest.native.config.js --coverage",
+    "lint": "oxlint src"
   },
   "dependencies": {
     "@devtools/registry": "workspace:*"

--- a/devtools/shell/src/DevTools/DevTools.native.test.tsx
+++ b/devtools/shell/src/DevTools/DevTools.native.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithNavigation, screen, userEvent } from "jest/screens.native";
+import { renderWithNavigation, screen, userEvent } from "jest/screens";
 import { mockDevToolsConfig } from "../../jest/test-utils";
 import { DevTools } from "./DevTools";
 

--- a/devtools/shell/src/DevTools/DevTools.platform.native.test.tsx
+++ b/devtools/shell/src/DevTools/DevTools.platform.native.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithNavigation, screen, userEvent } from "jest/screens.native";
+import { renderWithNavigation, screen, userEvent } from "jest/screens";
 
 import { DevTools } from "./DevTools";
 import { mockDevToolsConfig } from "jest/test-utils";

--- a/devtools/shell/src/DevTools/screens/CategoriesScreen.native.test.tsx
+++ b/devtools/shell/src/DevTools/screens/CategoriesScreen.native.test.tsx
@@ -1,4 +1,4 @@
-import { renderScreen, screen, userEvent } from "jest/screens.native";
+import { renderScreen, screen, userEvent } from "jest/screens";
 import { Category } from "@devtools/registry";
 import { makeTool } from "jest/fixtures";
 import { CategoriesScreen } from "./CategoriesScreen";

--- a/devtools/shell/src/DevTools/screens/ToolScreen.native.test.tsx
+++ b/devtools/shell/src/DevTools/screens/ToolScreen.native.test.tsx
@@ -1,5 +1,5 @@
 import { Text } from "react-native";
-import { renderScreen, screen } from "jest/screens.native";
+import { renderScreen, screen } from "jest/screens";
 import { Category } from "@devtools/registry";
 import { makeTool } from "jest/fixtures";
 import { ToolScreen } from "./ToolScreen";

--- a/devtools/shell/src/DevTools/screens/ToolsScreen.native.test.tsx
+++ b/devtools/shell/src/DevTools/screens/ToolsScreen.native.test.tsx
@@ -1,4 +1,4 @@
-import { renderScreen, screen, userEvent } from "jest/screens.native";
+import { renderScreen, screen, userEvent } from "jest/screens";
 import { Category } from "@devtools/registry";
 import { makeTool } from "jest/fixtures";
 import { ToolsScreen } from "./ToolsScreen";

--- a/devtools/transport-panel/package.json
+++ b/devtools/transport-panel/package.json
@@ -24,7 +24,8 @@
     "test:watch": "jest --watch",
     "coverage": "pnpm run coverage:web && pnpm run coverage:native && bash -c 'cat coverage/lcov.native.info >> coverage/lcov.info' --",
     "coverage:web": "jest --config jest.config.js --coverage",
-    "coverage:native": "jest --config jest.native.config.js --coverage"
+    "coverage:native": "jest --config jest.native.config.js --coverage",
+    "lint": "oxlint src"
   },
   "dependencies": {
     "@devtools/transport": "workspace:*"

--- a/devtools/transport-panel/src/TransportPanel.web.test.tsx
+++ b/devtools/transport-panel/src/TransportPanel.web.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from "@support/jest-devtools/web";
 import { mockTransportPanelProps } from "jest/mocks/transport";
-import { TransportPanel } from "./TransportPanel.web";
+import { TransportPanel } from "./TransportPanel";
 
 describe("TransportPanel", () => {
   it("renders the current connection status from transport state", () => {

--- a/devtools/transport-panel/src/components/HistoryLine/HistoryLine.native.test.tsx
+++ b/devtools/transport-panel/src/components/HistoryLine/HistoryLine.native.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from "@support/jest-devtools/native";
 import type { Envelope, MessageMap } from "@devtools/transport";
-import { HistoryLine } from "./HistoryLine.native";
+import { HistoryLine } from "./HistoryLine";
 
 const makeEnvelope = (overrides?: Partial<Envelope<MessageMap>>): Envelope<MessageMap> => ({
   id: "abc-123",

--- a/devtools/transport-panel/src/components/HistoryLine/HistoryLine.web.test.tsx
+++ b/devtools/transport-panel/src/components/HistoryLine/HistoryLine.web.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from "@support/jest-devtools/web";
 import type { Envelope, MessageMap } from "@devtools/transport";
-import { HistoryLine } from "./HistoryLine.web";
+import { HistoryLine } from "./HistoryLine";
 
 const makeEnvelope = (overrides?: Partial<Envelope<MessageMap>>): Envelope<MessageMap> => ({
   id: "abc-123",

--- a/devtools/transport-panel/src/components/QRScannerSheet/QRScannerSheet.native.test.tsx
+++ b/devtools/transport-panel/src/components/QRScannerSheet/QRScannerSheet.native.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen, act } from "@support/jest-devtools/native";
-import { QRScannerSheet } from "./QRScannerSheet.native";
+import { QRScannerSheet } from "./QRScannerSheet";
 
 jest.mock("react-native-vision-camera", () => ({
   Camera: "Camera",

--- a/devtools/transport-panel/src/components/QRScannerSheet/index.native.ts
+++ b/devtools/transport-panel/src/components/QRScannerSheet/index.native.ts
@@ -1,1 +1,1 @@
-export { QRScannerSheet } from "./QRScannerSheet.native";
+export { QRScannerSheet } from "./QRScannerSheet";

--- a/devtools/transport-panel/src/components/TransportDebug/TransportDebug.native.test.tsx
+++ b/devtools/transport-panel/src/components/TransportDebug/TransportDebug.native.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen, fireEvent } from "@support/jest-devtools/native";
 import { mockTransport, mockTransportPanelProps } from "jest/mocks/transport";
-import { TransportDebug } from "./TransportDebug.native";
+import { TransportDebug } from "./TransportDebug";
 
 function makeRef() {
   return { current: null } as React.RefObject<unknown>;

--- a/devtools/transport-panel/src/components/TransportDebug/TransportDebug.native.tsx
+++ b/devtools/transport-panel/src/components/TransportDebug/TransportDebug.native.tsx
@@ -9,7 +9,7 @@ import {
 } from "@ledgerhq/lumen-ui-rnative";
 import type { TransportPanelProps } from "../..";
 import type { MessageMap } from "@devtools/transport";
-import { HistoryLine } from "../HistoryLine/HistoryLine.native";
+import { HistoryLine } from "../HistoryLine/HistoryLine";
 import { useTransportSend } from "../../hooks";
 import { RefObject } from "react";
 

--- a/devtools/transport-panel/src/components/TransportDebug/TransportDebug.web.test.tsx
+++ b/devtools/transport-panel/src/components/TransportDebug/TransportDebug.web.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from "@support/jest-devtools/web";
 import { mockTransportPanelProps, mockTransport } from "jest/mocks/transport";
-import { TransportDebug } from "./TransportDebug.web";
+import { TransportDebug } from "./TransportDebug";
 
 describe("TransportDebug", () => {
   it("renders the dialog when open", () => {

--- a/devtools/transport-panel/src/components/TransportPanelContent/TransportPanelContent.web.test.tsx
+++ b/devtools/transport-panel/src/components/TransportPanelContent/TransportPanelContent.web.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from "@support/jest-devtools/web";
 import { mockTransportPanelProps, mockTransport } from "jest/mocks/transport";
-import { TransportPanelContent } from "./TransportPanelContent.web";
+import { TransportPanelContent } from "./TransportPanelContent";
 
 describe("TransportPanelContent", () => {
   it("always renders the Hub URL field", () => {

--- a/devtools/transport/package.json
+++ b/devtools/transport/package.json
@@ -11,7 +11,8 @@
     "format:check": "oxfmt src jest.config.js --check",
     "typecheck": "tsc --noEmit",
     "test": "jest --config jest.config.js",
-    "coverage": "jest --config jest.config.js --coverage"
+    "coverage": "jest --config jest.config.js --coverage",
+    "lint": "oxlint src"
   },
   "devDependencies": {
     "@swc/core": "catalog:",

--- a/devtools/wire/package.json
+++ b/devtools/wire/package.json
@@ -11,7 +11,8 @@
     "format:check": "oxfmt src jest.config.js --check",
     "typecheck": "tsc --noEmit",
     "test": "jest --config jest.config.js",
-    "coverage": "jest --config jest.config.js --coverage"
+    "coverage": "jest --config jest.config.js --coverage",
+    "lint": "oxlint src"
   },
   "dependencies": {
     "@devtools/protocols": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22163,7 +22163,6 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.51.0':
     resolution: {integrity: sha512-wD8HGTWhYBKXvRDvoBVB1y+fEYV01samhWQSy1Zkxq2vpezvMnjaFKRuiP6tBNITLGuffbNDEXOwcAhJ3gI5Ug==}
@@ -25228,7 +25227,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.1.4
       react-dom: 19.1.4
-      webpack: '*'
+      webpack: ^5.89.0
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -36784,7 +36783,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qrcode-terminal@0.11.0:
@@ -68545,7 +68543,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3
+      metro: 0.83.3(metro-transform-worker@0.83.3)
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -68669,6 +68667,54 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.83.3(metro-transform-worker@0.83.3):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.28.5
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 1.3.8
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.32.0
+      image-size: 1.1.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0(metro@0.83.3)
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.3
+      metro-cache: 0.83.3
+      metro-cache-key: 0.83.3
+      metro-config: 0.83.3(metro-transform-worker@0.83.3)
+      metro-core: 0.83.3
+      metro-file-map: 0.83.3(metro@0.83.3)
+      metro-resolver: 0.83.3
+      metro-runtime: 0.83.3
+      metro-source-map: 0.83.3
+      metro-symbolicate: 0.83.3
+      metro-transform-plugins: 0.83.3
+      metro-transform-worker: 0.83.3
+      mime-types: 2.1.35
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

## Summary

Wires the `suffix-imports/no-platform-suffix` oxlint rule (introduced in `@support/lint-rules`) into every devtools package, and fixes the existing violations in the shell test files.

### What changed

- **`devtools/.oxlintrc.json`** (new) — shared oxlint config at the devtools root referencing the `@support/lint-rules` suffix plugin and setting `no-platform-suffix` to `error`.
- **All devtools `package.json` files** — each gains a `"lint": "oxlint src"` script so the rule can be run per-package.
- **`devtools/shell/src/DevTools/**/*.native.test.tsx`** — five test files had `jest/screens.native` imports; those are stripped to `jest/screens`, matching how the bundler resolves platform suffixes at runtime.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36346](https://ledgerhq.atlassian.net/browse/LIVE-36346)<!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-36346]: https://ledgerhq.atlassian.net/browse/LIVE-36346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ