### PR TITLE
[LWDM] fix(coin-zcash): reject a dust amount on the Amount step

### DIFF
--- a/.changeset/LIVE-36329-zcash-dust-amount-validation.md
+++ b/.changeset/LIVE-36329-zcash-dust-amount-validation.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-zcash": patch
+---
+
+[ZEC] Reject a transparent-output amount below the network's dust threshold at the Amount step instead of signing and failing at broadcast.

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7295,6 +7295,9 @@
     "ZcashSaplingRecipientNotSupported": {
       "title": "Sending to Sapling addresses is not supported"
     },
+    "ZcashAmountBelowDustThreshold": {
+      "title": "Amount is too small to be broadcast (minimum {{minimumZatoshis}} zatoshis)"
+    },
     "InvalidNonce": {
       "title": "Nonce is required"
     },

--- a/libs/coin-modules/coin-zcash/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/getTransactionStatus.test.ts
@@ -4,9 +4,11 @@ import {
   computeAmountError,
   computeRecipientError,
   isTransparentInputTransfer,
+  isTransparentOutputDust,
   resolveTransparentUtxos,
 } from "./statusHelpers";
-import { ZIP317_MINIMUM_FEE } from "../logic/coin-selection";
+import { TRANSPARENT_OUTPUT_DUST_THRESHOLD, ZIP317_MINIMUM_FEE } from "../logic/coin-selection";
+import { ZcashAmountBelowDustThreshold } from "../types/errors";
 import type { BitcoinOutput, Transaction, ZcashAccount, ZcashTransferType } from "../types/bridge";
 import type { SpendableNote } from "../network/types";
 import { ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS } from "../constants";
@@ -236,6 +238,22 @@ describe("computeRecipientError", () => {
   });
 });
 
+describe("isTransparentOutputDust", () => {
+  it("is false for a non-positive amount -- that is caught by the positive-amount check instead", () => {
+    expect(isTransparentOutputDust(new BigNumber(0))).toBe(false);
+    expect(isTransparentOutputDust(new BigNumber(-1))).toBe(false);
+  });
+
+  // The bound is exclusive: exactly the threshold is a valid, non-dust value.
+  it.each([
+    ["one zatoshi below the threshold", TRANSPARENT_OUTPUT_DUST_THRESHOLD - 1, true],
+    ["exactly the threshold", TRANSPARENT_OUTPUT_DUST_THRESHOLD, false],
+    ["one zatoshi above the threshold", TRANSPARENT_OUTPUT_DUST_THRESHOLD + 1, false],
+  ] as [string, number, boolean][])("is %s -> dust: %s", (_label, amount, expected) => {
+    expect(isTransparentOutputDust(new BigNumber(amount))).toBe(expected);
+  });
+});
+
 describe("computeAmountError", () => {
   const pool = new BigNumber(50_000);
 
@@ -414,12 +432,56 @@ describe("getTransactionStatus, transparent-input flows", () => {
     expect(errorNames(status.errors)).toEqual({ recipient: "ZcashShieldedKeyMissing" });
   });
 
-  // The counterpart, and the flow LIVE-36260 restored: spending public funds
-  // from an account that never exported its UFVK stays available.
+  // The counterpart, and the flow restored: spending public funds from an
+  // account that never exported its UFVK stays available.
   it("still accepts a transparent send when the UFVK has not been exported", async () => {
     const status = await getTransactionStatus(
       account({ shieldedKey: false }),
       transaction({ transferType: "transparent", recipient: T_ADDRESS }),
+    );
+
+    expect(status.errors).toEqual({});
+  });
+
+  it("rejects a t->t send one zatoshi below the dust threshold", async () => {
+    const status = await getTransactionStatus(
+      account({ utxos: [1_000_000] }),
+      transaction({
+        amount: new BigNumber(TRANSPARENT_OUTPUT_DUST_THRESHOLD - 1),
+        zcashFee: new BigNumber(10_000),
+      }),
+    );
+
+    expect(errorNames(status.errors)).toEqual({ amount: "ZcashAmountBelowDustThreshold" });
+    expect((status.errors.amount as ZcashAmountBelowDustThreshold).minimumZatoshis).toBe(
+      TRANSPARENT_OUTPUT_DUST_THRESHOLD,
+    );
+  });
+
+  // The bound is exclusive: exactly the threshold is a valid, non-dust send.
+  it("accepts a t->t send exactly at the dust threshold", async () => {
+    const status = await getTransactionStatus(
+      account({ utxos: [1_000_000] }),
+      transaction({
+        amount: new BigNumber(TRANSPARENT_OUTPUT_DUST_THRESHOLD),
+        zcashFee: new BigNumber(10_000),
+      }),
+    );
+
+    expect(status.errors).toEqual({});
+  });
+
+  // A dust amount only matters for a transparent recipient output;
+  // "transparent-to-shielded" turns it into an Orchard note.
+  it("does not apply the transparent dust rule to a shielding (t->s) send", async () => {
+    const status = await getTransactionStatus(
+      account({ utxos: [1_000_000] }),
+      transaction({
+        transferType: "transparent-to-shielded",
+        recipient: U_ADDRESS,
+        amount: new BigNumber(TRANSPARENT_OUTPUT_DUST_THRESHOLD - 1),
+        zcashFee: new BigNumber(10_000),
+      }),
     );
 
     expect(status.errors).toEqual({});
@@ -523,6 +585,56 @@ describe("getTransactionStatus, note-spending flows", () => {
     });
 
     expect((await getTransactionStatus(acc, tx)).errors).toEqual({});
+  });
+
+  // A shielded-to-transparent recipient is also a transparent output, priced
+  // through computeAmountError rather than getTransparentInputStatus, but
+  // subject to the same dust rule.
+  it("rejects a shielded-to-transparent send one zatoshi below the dust threshold", async () => {
+    const status = await getTransactionStatus(
+      account(),
+      transaction({
+        transferType: "shielded-to-transparent",
+        recipient: T_ADDRESS,
+        amount: new BigNumber(TRANSPARENT_OUTPUT_DUST_THRESHOLD - 1),
+        selectedNotes: [note(50_000)],
+        zcashFee: new BigNumber(10_000),
+      }),
+    );
+
+    expect(errorNames(status.errors)).toEqual({ amount: "ZcashAmountBelowDustThreshold" });
+  });
+
+  it("accepts a shielded-to-transparent send exactly at the dust threshold", async () => {
+    const status = await getTransactionStatus(
+      account(),
+      transaction({
+        transferType: "shielded-to-transparent",
+        recipient: T_ADDRESS,
+        amount: new BigNumber(TRANSPARENT_OUTPUT_DUST_THRESHOLD),
+        selectedNotes: [note(50_000)],
+        zcashFee: new BigNumber(10_000),
+      }),
+    );
+
+    expect(status.errors).toEqual({});
+  });
+
+  // A dust amount only matters when the recipient output is transparent; a
+  // pure "shielded" (z->z) recipient is an Orchard note.
+  it("does not apply the transparent dust rule to a pure shielded (z->z) send", async () => {
+    const status = await getTransactionStatus(
+      account(),
+      transaction({
+        transferType: "shielded",
+        recipient: U_ADDRESS,
+        amount: new BigNumber(TRANSPARENT_OUTPUT_DUST_THRESHOLD - 1),
+        selectedNotes: [note(50_000)],
+        zcashFee: new BigNumber(10_000),
+      }),
+    );
+
+    expect(status.errors).toEqual({});
   });
 
   it("refuses a shielded send that selected no note, however full the pool", async () => {

--- a/libs/coin-modules/coin-zcash/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/getTransactionStatus.ts
@@ -3,11 +3,13 @@ import { NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import type { AccountBridge } from "@ledgerhq/types-live";
 import type { Transaction, TransactionStatus, ZcashAccount } from "../types/bridge";
 import { ZIP317_MINIMUM_FEE } from "../logic/coin-selection";
+import { ZcashAmountBelowDustThreshold } from "../types/errors";
 import {
   computeAmountError,
   computeRecipientError,
   hasShieldedKey,
   isTransparentInputTransfer,
+  isTransparentOutputDust,
   resolveTransparentUtxos,
 } from "./statusHelpers";
 import { getReservedNullifiers } from "./note-reservation";
@@ -42,6 +44,8 @@ function getTransparentInputStatus(
     errors.amount = new Error("Amount must be positive");
   } else if (totalSpent.gt(transparentBalance)) {
     errors.amount = new NotEnoughBalance();
+  } else if (tx.transferType === "transparent" && isTransparentOutputDust(tx.amount)) {
+    errors.amount = new ZcashAmountBelowDustThreshold();
   }
 
   return {
@@ -94,7 +98,16 @@ export const getTransactionStatus: AccountBridge<
   if (recipientError) errors.recipient = recipientError;
 
   const amountError = computeAmountError(transaction, totalSpent, poolBalance);
-  if (amountError) errors.amount = amountError;
+  if (amountError) {
+    errors.amount = amountError;
+  } else if (
+    transaction.transferType === "shielded-to-transparent" &&
+    isTransparentOutputDust(transaction.amount)
+  ) {
+    // A shielded-to-transparent (z->t) recipient is also a transparent
+    // output, so it needs the same dust check as a t->t send.
+    errors.amount = new ZcashAmountBelowDustThreshold();
+  }
 
   return {
     errors,

--- a/libs/coin-modules/coin-zcash/src/bridge/statusHelpers.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/statusHelpers.ts
@@ -3,6 +3,7 @@ import { InvalidAddress, RecipientRequired } from "@ledgerhq/ledger-wallet-frame
 import type { BitcoinOutput, ZcashAccount, Transaction } from "../types/bridge";
 import { ZcashSaplingRecipientNotSupported, ZcashShieldedKeyMissing } from "../types/errors";
 import { classifyZcashRecipient } from "../logic/address";
+import { TRANSPARENT_OUTPUT_DUST_THRESHOLD } from "../logic/coin-selection";
 
 // Transfer types that actually spend transparent UTXOs as inputs. A pure
 // shielded send ("shielded" / "shielded-to-transparent") spends Ironwood notes
@@ -61,6 +62,11 @@ export const computeRecipientError = (
   }
   return undefined;
 };
+
+/** True when `amount` (zatoshis) is below the dust floor for a transparent
+ * output. A non-positive amount isn't "dust" -- that's caught separately. */
+export const isTransparentOutputDust = (amount: BigNumber): boolean =>
+  amount.gt(0) && amount.lt(TRANSPARENT_OUTPUT_DUST_THRESHOLD);
 
 export const computeAmountError = (
   tx: Transaction,

--- a/libs/coin-modules/coin-zcash/src/logic/coin-selection.ts
+++ b/libs/coin-modules/coin-zcash/src/logic/coin-selection.ts
@@ -26,6 +26,11 @@ const DUST_THRESHOLD = ZIP317_MARGINAL_FEE;
 /** Maximum fee iteration rounds before giving up. */
 const MAX_ITERATIONS = 5;
 
+/** Minimum non-dust value (zatoshis) for a transparent output: the network
+ * rejects a smaller one at broadcast, so the wallet must refuse it up front
+ * instead of signing first. Same value for both transparent address kinds. */
+export const TRANSPARENT_OUTPUT_DUST_THRESHOLD = 54;
+
 /**
  * ZIP-317 fee in zatoshis for a per-pool action layout. Mirror of
  * `zip317_fee(n_spends, n_orchard_outputs, n_transparent_inputs,

--- a/libs/coin-modules/coin-zcash/src/types/errors.test.ts
+++ b/libs/coin-modules/coin-zcash/src/types/errors.test.ts
@@ -1,4 +1,5 @@
 import {
+  ZcashAmountBelowDustThreshold,
   ZcashNotesNotYetSpendable,
   ZcashSaplingRecipientNotSupported,
   ZcashShieldedKeyMissing,
@@ -6,6 +7,7 @@ import {
   ZcashSigningCancelled,
   ZcashUtxoNotInAccount,
 } from "./errors";
+import { TRANSPARENT_OUTPUT_DUST_THRESHOLD } from "../logic/coin-selection";
 
 // Ledger Live renders an error through its `name`, so that is what the UI and
 // the callers branch on -- not the message.
@@ -18,6 +20,10 @@ describe("zcash errors", () => {
     [
       ZcashShieldedKeyMissing,
       "Activate your private balance first: this transfer needs the viewing key from your device",
+    ],
+    [
+      ZcashAmountBelowDustThreshold,
+      `Amount is too small to be broadcast (minimum ${TRANSPARENT_OUTPUT_DUST_THRESHOLD} zatoshis)`,
     ],
   ])("names %p and gives it a readable default message", (Err, message) => {
     const error = new Err();
@@ -40,5 +46,11 @@ describe("zcash errors", () => {
 
     expect({ txid: error.txid, vout: error.vout }).toEqual({ txid: undefined, vout: undefined });
     expect(error.message).toBe("please re-sync");
+  });
+
+  it("carries the network's dust threshold", () => {
+    expect(new ZcashAmountBelowDustThreshold().minimumZatoshis).toBe(
+      TRANSPARENT_OUTPUT_DUST_THRESHOLD,
+    );
   });
 });

--- a/libs/coin-modules/coin-zcash/src/types/errors.ts
+++ b/libs/coin-modules/coin-zcash/src/types/errors.ts
@@ -2,6 +2,8 @@
 // docs/new-library.md's `src/errors.ts` guidance. Errors that already exist for
 // every coin come from @ledgerhq/ledger-wallet-framework/errors instead.
 
+import { TRANSPARENT_OUTPUT_DUST_THRESHOLD } from "../logic/coin-selection";
+
 export class ZcashSaplingRecipientNotSupported extends Error {
   constructor(message = "Sapling recipients are not supported") {
     super(message);
@@ -57,6 +59,19 @@ export class ZcashUtxoNotInAccount extends Error {
       this.txid = extra.txid;
       this.vout = extra.vout;
     }
+  }
+}
+
+/** Raised when a transparent output's amount is below the network's
+ * minimum non-dust value -- signing would succeed but broadcast would fail. */
+export class ZcashAmountBelowDustThreshold extends Error {
+  minimumZatoshis = TRANSPARENT_OUTPUT_DUST_THRESHOLD;
+
+  constructor(
+    message = `Amount is too small to be broadcast (minimum ${TRANSPARENT_OUTPUT_DUST_THRESHOLD} zatoshis)`,
+  ) {
+    super(message);
+    this.name = "ZcashAmountBelowDustThreshold";
   }
 }
 


### PR DESCRIPTION
### 📝 Description

A transparent (t→t) send amount below Zebra's mempool dust threshold used to pass the Amount step (Continue stayed enabled), get signed on the device, and only fail at the final broadcast with an opaque `InternalServerError: error receiving data from backing node` — instead of a clear validation at the Amount step.

- **Previous behaviour**: `getTransparentInputStatus` only checked `amount > 0` and `totalSpent <= balance`; no floor on the recipient output value.
- **Fix**: reject the amount at `getTransactionStatus` time when it would produce a transparent output below Zebra's dust threshold (`TransparentOutput::is_dust`, 54 zatoshis for a standard P2PKH/P2SH output), via a new `ZcashAmountBelowDustThreshold` error surfaced as `errors.amount` — same mechanism every other amount validation (e.g. `NotEnoughBalance`) already uses to disable Continue. Applies to both `transferType === "transparent"` (t→t) and `"shielded-to-transparent"` (z→t): both build a transparent recipient output, so both are subject to the same dust rule. A `"transparent-to-shielded"` or pure `"shielded"` recipient is an Orchard note, which this rule does not apply to.
- **Regression check**: `getTransactionStatus.test.ts` covers the rejected case (threshold − 1) and the accepted boundary (exactly the threshold, inclusive) for both t→t and z→t, and confirms the rule does not fire for a shielding (t→s) or pure shielded (z→z) send.

### 🔗 Context

- **JIRA**: [LIVE-36329](https://ledgerhq.atlassian.net/browse/LIVE-36329)

[LIVE-36329]: https://ledgerhq.atlassian.net/browse/LIVE-36329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ