### PR TITLE
[LWM] fix(backup-hub): gate RK warning with banner flag (LIVE-36339)

### DIFF
--- a/apps/ledger-live-mobile/src/mvvm/features/BackupHub/__integrations__/BackupHub.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/BackupHub/__integrations__/BackupHub.integration.test.tsx
@@ -4,6 +4,7 @@ import { SafeAreaProvider } from "react-native-safe-area-context";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import type { DeviceModelInfo } from "@ledgerhq/types-live";
+import { FEATURE_FLAGS_DEFAULTS, type Features } from "@shared/feature-flags";
 import {
   LARGE_SCREEN_UPSELL_BACKUPS_UTM_CONTENT,
   LARGE_SCREEN_UPSELL_UTM_CAMPAIGN,
@@ -77,11 +78,13 @@ const overrideWith = (
   subscriptionState: LedgerRecoverSubscriptionStateEnum,
   devicesModelList: DeviceModelId[] = [],
   lastSeenModelId?: DeviceModelId,
+  largeScreenUpsell: Features["largeScreenUpsell"] = { enabled: true },
 ) =>
   withFlagOverrides(
     {
       lwmBackupHub: { enabled: true },
       protectServicesMobile: { enabled: true, params: { protectId: PROTECT_ID } },
+      largeScreenUpsell,
     },
     (state: State): State => {
       const withSub = seedSubscriptionState(subscriptionState)(state);
@@ -246,6 +249,51 @@ describe("BackupHub screen (mobile)", () => {
 
     expect(await screen.findByText("A PIN-protected smart card.")).toBeVisible();
     expect(screen.queryByText("Not compatible with your device")).toBeNull();
+  });
+
+  it.each([
+    [
+      "the backup-hub-recovery-key-text-warning placement is off",
+      (() => {
+        const defaultParams = FEATURE_FLAGS_DEFAULTS.largeScreenUpsell.params;
+        if (!defaultParams) {
+          throw new Error("Expected large-screen upsell default params");
+        }
+        return {
+          enabled: true,
+          params: {
+            ...defaultParams,
+            banners: {
+              ...defaultParams.banners,
+              "backup-hub-recovery-key-text-warning": false,
+            },
+          },
+        };
+      })(),
+    ],
+    ["the large-screen upsell campaign is off", { enabled: false }],
+  ] as const)("keeps the Recovery Key row unchanged when %s", async (_, largeScreenUpsell) => {
+    const openURLSpy = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
+    const { user } = render(<BackupHubTestNavigator />, {
+      overrideInitialState: overrideWith(
+        LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION,
+        [DeviceModelId.nanoS],
+        undefined,
+        largeScreenUpsell,
+      ),
+    });
+
+    expect(await screen.findByText("A PIN-protected smart card.")).toBeVisible();
+    expect(screen.queryByText("Not compatible with your device")).toBeNull();
+
+    await user.press(screen.getByTestId("backup-hub-physical-row-recovery-key"));
+
+    expect(openURLSpy).toHaveBeenCalledWith(urls.backupHub.recoveryKey);
+    expect(track).toHaveBeenCalledWith("button_clicked", {
+      button: BACKUP_HUB_TRACKING_BUTTON.recoveryKey,
+      page: BACKUP_HUB_TRACKING_PAGE_NAME,
+    });
+    expect(track).not.toHaveBeenCalledWith("deeplink_clicked", expect.anything());
   });
 
   it("uses the last-seen nano for Recovery Key upsell analytics when several nanos are known", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/BackupHub/screens/BackupHubScreen/useBackupHubScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/BackupHub/screens/BackupHubScreen/useBackupHubScreenViewModel.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from "react";
 import { Linking, type ImageSourcePropType } from "react-native";
 import { getNanoOnlyDeviceModel } from "@features/flow-large-screen-upsell/utils/getNanoOnlyDeviceModel";
+import { isLargeScreenUpsellBannerEnabled } from "@features/flow-large-screen-upsell/utils/isLargeScreenUpsellBannerEnabled";
 import {
   LARGE_SCREEN_UPSELL_BACKUPS_UTM_CONTENT,
   LARGE_SCREEN_UPSELL_UTM_CAMPAIGN,
@@ -75,7 +76,12 @@ export function useBackupHubScreenViewModel(): BackupHubScreenViewModel {
     [knownDeviceModelIds],
   );
 
-  const incompatibleModel = getNanoOnlyDeviceModel(devicesModelList, lastSeenDevice?.modelId);
+  const incompatibleModel = isLargeScreenUpsellBannerEnabled(
+    largeScreenUpsell,
+    "backup-hub-recovery-key-text-warning",
+  )
+    ? getNanoOnlyDeviceModel(devicesModelList, lastSeenDevice?.modelId)
+    : undefined;
 
   const upsellLink = useMemo(() => {
     const variant = personalRecoOptIn ? "opted_in" : "opted_out";

--- a/features/flow/large-screen-upsell/package.json
+++ b/features/flow/large-screen-upsell/package.json
@@ -8,6 +8,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./utils/getNanoOnlyDeviceModel": "./src/utils/getNanoOnlyDeviceModel.ts",
+    "./utils/isLargeScreenUpsellBannerEnabled": "./src/utils/isLargeScreenUpsellBannerEnabled.ts",
     "./utils/upsellCta": "./src/utils/upsellCta.ts",
     "./schema.mock": "./src/state/schema.mock.ts",
     "./package.json": "./package.json"


### PR DESCRIPTION
## Context

Desktop can turn the Backup Hub Recovery Key warning off independently via `largeScreenUpsell.params.banners["backup-hub-recovery-key-text-warning"]` without disabling the rest of the campaign ([LIVE-35484](https://ledgerhq.atlassian.net/browse/LIVE-35484), [PR #20925](https://github.com/LedgerHQ/ledger-live/pull/20925)).

On mobile, Backup Hub still personalised the Recovery Key row from device detection only. PMs could not turn that warning off without disabling `largeScreenUpsell` entirely.

LWM has no Recover Nano S intercept (desktop-only `RecoverRouteGuard`). This PR does not add one.

Ticket: [LIVE-36339](https://ledgerhq.atlassian.net/browse/LIVE-36339)

## Changes

- Treat a Nano as Recovery Key incompatible only when `isLargeScreenUpsellBannerEnabled(largeScreenUpsell, "backup-hub-recovery-key-text-warning")` is true.
- Campaign off or placement off: keep the normal Recovery Key shop row (copy, original URL, no upsell analytics).
- Campaign on + Nano-only wallet: keep the existing warning and upsell LP behaviour.
- Export `isLargeScreenUpsellBannerEnabled` as a mobile-safe package subpath so Jest does not pull the web modal barrel.

## Test plan

- [x] Backup Hub mobile integration tests (`BackupHub.integration.test.tsx`)
- [ ] Nano S / SP / X + campaign on + banner on → warning copy + upsell CTA
- [ ] Same devices + `banners["backup-hub-recovery-key-text-warning"] = false` → normal Recovery Key row
- [ ] Same devices + `largeScreenUpsell.enabled = false` → normal Recovery Key row
- [ ] Large-screen / mixed wallets unchanged

[LIVE-35484]: https://ledgerhq.atlassian.net/browse/LIVE-35484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-36339]: https://ledgerhq.atlassian.net/browse/LIVE-36339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ