### PR TITLE
[LWDM] fix(LIVE-34637): sell quotes on back to quote

### DIFF
--- a/.changeset/fix-sell-quotes-on-back-to-quote.md
+++ b/.changeset/fix-sell-quotes-on-back-to-quote.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Fix: sell quotes now correctly shown when returning from a provider via "Back to quote". Previously, BuySellUI defaulted to buy mode because the stored flow name was not passed back during navigation. Desktop also removed a hardcoded `|| "buy"` fallback when saving the flow name to localStorage.

--- a/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/TopBar.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/TopBar.test.tsx
@@ -149,4 +149,41 @@ describe("TopBar", () => {
 
     expect(mockNavigate).toHaveBeenCalledWith("/card/cl-card?goToURL=https://example.com");
   });
+
+  it("stores flowName in localStorage when flowName is present in goToManifest URL", () => {
+    const setItemSpy = jest.spyOn(Storage.prototype, "setItem");
+    (useSelector as unknown as jest.Mock).mockReturnValue(false);
+
+    const urlWithFlowName =
+      "http://localhost:3000?goToManifest=provider-id&goToURL=https%3A%2F%2Fprovider.com&flowName=sell";
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <TopBar {...defaultProps} webviewState={{ ...mockWebviewState, url: urlWithFlowName }} />
+      </MemoryRouter>,
+    );
+
+    expect(setItemSpy).toHaveBeenCalledWith("flow-name", "sell");
+    setItemSpy.mockRestore();
+  });
+
+  it("does not write flow-name to localStorage when flowName is absent from goToManifest URL", () => {
+    const setItemSpy = jest.spyOn(Storage.prototype, "setItem");
+    (useSelector as unknown as jest.Mock).mockReturnValue(false);
+
+    const urlWithoutFlowName =
+      "http://localhost:3000?goToManifest=provider-id&goToURL=https%3A%2F%2Fprovider.com";
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <TopBar
+          {...defaultProps}
+          webviewState={{ ...mockWebviewState, url: urlWithoutFlowName }}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(setItemSpy).not.toHaveBeenCalledWith("flow-name", expect.anything());
+    setItemSpy.mockRestore();
+  });
 });

--- a/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/TopBar.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/TopBar.test.tsx
@@ -176,10 +176,7 @@ describe("TopBar", () => {
 
     render(
       <MemoryRouter initialEntries={["/"]}>
-        <TopBar
-          {...defaultProps}
-          webviewState={{ ...mockWebviewState, url: urlWithoutFlowName }}
-        />
+        <TopBar {...defaultProps} webviewState={{ ...mockWebviewState, url: urlWithoutFlowName }} />
       </MemoryRouter>,
     );
 

--- a/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/TopBar.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/TopBar.tsx
@@ -242,10 +242,13 @@ export const TopBar = ({
 
         if (goToURL) {
           localStorage.setItem("manifest-id", manifestId);
-          localStorage.setItem("flow-name", url.searchParams.get("flowName") || "buy");
+          const flowName = url.searchParams.get("flowName");
+          if (flowName) {
+            localStorage.setItem("flow-name", flowName);
+          }
           localStorage.setItem(
             "last-screen",
-            url.searchParams.get("lastScreen") || url.searchParams.get("flowName") || "",
+            url.searchParams.get("lastScreen") || flowName || "",
           );
 
           navigate(`${basePath}/${manifestId}?goToURL=${goToURL}`);

--- a/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/TopBar.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/TopBar.tsx
@@ -246,10 +246,7 @@ export const TopBar = ({
           if (flowName) {
             localStorage.setItem("flow-name", flowName);
           }
-          localStorage.setItem(
-            "last-screen",
-            url.searchParams.get("lastScreen") || flowName || "",
-          );
+          localStorage.setItem("last-screen", url.searchParams.get("lastScreen") || flowName || "");
 
           navigate(`${basePath}/${manifestId}?goToURL=${goToURL}`);
         }

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/BackToLwButton.test.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/BackToLwButton.test.tsx
@@ -169,4 +169,57 @@ describe("BackToInternalDomain", () => {
 
     expect(mockedTrack).not.toHaveBeenCalled();
   });
+
+  it("should pass mode from flow-name storage to handleBackToLwEntryPoint", async () => {
+    mockedStorage.getString.mockImplementation((key: string): Promise<string | null> => {
+      const data: Record<string, string> = {
+        "manifest-id": "provider-123",
+        "last-screen": "compare_providers",
+        "flow-name": "sell",
+      };
+      return Promise.resolve(data[key] ?? null);
+    });
+
+    const { user } = render(
+      <BackToInternalDomain
+        config={{
+          screen: ScreenName.ExchangeSell,
+        }}
+      />,
+    );
+
+    await user.press(screen.getByText("Back"));
+
+    expect(mockedHandleBackToLwEntryPoint).toHaveBeenCalledWith(
+      { navigate: mockNavigate },
+      ScreenName.ExchangeSell,
+      { referrer: "isExternal", mode: "sell" },
+    );
+  });
+
+  it("should not pass mode when flow-name is absent from storage", async () => {
+    mockedStorage.getString.mockImplementation((key: string): Promise<string | null> => {
+      const data: Record<string, string> = {
+        "manifest-id": "provider-123",
+        "last-screen": "compare_providers",
+      };
+      return Promise.resolve(data[key] ?? null);
+    });
+
+    const { user } = render(
+      <BackToInternalDomain
+        config={{
+          screen: ScreenName.ExchangeSell,
+        }}
+      />,
+    );
+
+    await user.press(screen.getByText("Back"));
+
+    expect(mockedHandleBackToLwEntryPoint).toHaveBeenCalledWith(
+      { navigate: mockNavigate },
+      ScreenName.ExchangeSell,
+      { referrer: "isExternal" },
+    );
+  });
 });

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/BackToLwButton.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/BackToLwButton.tsx
@@ -58,6 +58,7 @@ export function BackToInternalDomain({ config }: BackToInternalDomainProps) {
 
     handleBackToLwEntryPoint(navigation, screen, {
       referrer: "isExternal",
+      ...(flowName && { mode: flowName }),
     });
   };
 


### PR DESCRIPTION
### 📝 Description

After completing the Sell flow and selecting a provider, tapping **"Back to quote"** incorrectly showed **BUY** quotes instead of SELL quotes.

**Root cause:**
- **Mobile** — `BackToLwButton` read `flow-name` from AsyncStorage for analytics but never forwarded it to navigation. BuySellUI received no `mode` param on return and defaulted to buy.
- **Desktop** — `TopBar` fell back to `|| "buy"` when saving `flow-name` to localStorage if `flowName` was absent from the URL, hardcoding buy mode.

**Fix:**
- **Mobile** — `BackToLwButton` now passes `mode: flowName` (e.g. `"sell"`) to `handleBackToLwEntryPoint`, mirroring what the desktop already does.
- **Desktop** — `flow-name` is only written to localStorage when `flowName` is explicitly present in the `goToManifest` URL.

Both fixes are covered by new unit tests.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34637]


[LIVE-34637]: https://ledgerhq.atlassian.net/browse/LIVE-34637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ