### PR TITLE
[LWD] feat(pay): wire desktop New payment action to new Send flow (LIVE-35377)

### DIFF
--- a/.changeset/pay-new-payment-desktop.md
+++ b/.changeset/pay-new-payment-desktop.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Wire the Pay tab "New payment" action to open the new Send flow with a stablecoin-filtered account picker and `source: "Pay"`

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
@@ -19,6 +19,7 @@ import { payCardFeatureTourInitialState } from "@features/flow-pay-card-feature-
 import PayTab from "LLD/features/PayTab";
 import { usePayStablecoins, type PayStablecoins } from "../hooks/usePayStablecoins";
 import { USDC, makeItem } from "../hooks/__tests__/fixtures";
+import { AssetCategory } from "@domain/api-aggregated-assets";
 import {
   EMPTY_DESCRIPTION,
   EMPTY_TITLE,
@@ -28,6 +29,7 @@ import {
   defaultPayStablecoins,
   dieEnabledState,
   fundedState,
+  newSendFlowEnabledState,
   onboardedState,
   tourSeenState,
 } from "./fixtures";
@@ -218,6 +220,26 @@ describe("PayTab integration", () => {
 
     expect(await screen.findByTestId("pay-card-deposit-options")).toBeVisible();
     expect(screen.getByTestId("pay-card-deposit-option-swap")).toBeVisible();
+  });
+
+  it("should open the stablecoin-filtered send account selection from the new payment action tile", async () => {
+    mockFundedPayStablecoins();
+
+    const { store } = renderWithMockedCounterValuesProvider(<PayTab />, {
+      initialState: newSendFlowEnabledState,
+    });
+
+    const payTile = await screen.findByRole("button", { name: "New payment" });
+    fireEvent.click(payTile);
+
+    await waitFor(() => {
+      expect(store.getState().modularDialog.isOpen).toBe(true);
+    });
+    expect(store.getState().modularDialog.flow).toBe("send");
+    expect(store.getState().modularDialog.source).toBe("Pay");
+    expect(store.getState().modularDialog.dialogParams?.categories).toEqual([
+      AssetCategory.Stablecoins,
+    ]);
   });
 
   it("should persist the selected stablecoin, update the hero pill and track the confirmation", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/fixtures.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/fixtures.ts
@@ -28,6 +28,13 @@ export const dieEnabledState = {
   ...withFlagOverrides({ ldmkTransport: { enabled: true } }),
 };
 
+export const newSendFlowEnabledState = {
+  ...fundedState,
+  ...withFlagOverrides({
+    newSendFlow: { enabled: true, params: { families: ["evm"], excludedCurrencyIds: [] } },
+  }),
+};
+
 export const defaultPayStablecoins: PayStablecoins = {
   stablecoins: [],
   defaultStablecoins: [USDC, USDT],

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayTabNewPayment.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayTabNewPayment.test.ts
@@ -1,0 +1,27 @@
+import { renderHook, act } from "tests/testSetup";
+import { AssetCategory } from "@domain/api-aggregated-assets";
+import { useOpenSendFlow } from "LLD/features/Send/hooks/useOpenSendFlow";
+import { usePayTabNewPayment } from "../usePayTabNewPayment";
+
+jest.mock("LLD/features/Send/hooks/useOpenSendFlow");
+
+const mockOpenSendFlow = jest.fn();
+const mockUseOpenSendFlow = useOpenSendFlow as jest.MockedFunction<typeof useOpenSendFlow>;
+
+describe("usePayTabNewPayment", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseOpenSendFlow.mockReturnValue(mockOpenSendFlow);
+  });
+
+  it("opens the send flow from the Pay page filtered to stablecoins", () => {
+    const { result } = renderHook(() => usePayTabNewPayment());
+
+    act(() => result.current.open());
+
+    expect(mockOpenSendFlow).toHaveBeenCalledWith({
+      source: "Pay",
+      categories: [AssetCategory.Stablecoins],
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabActionTiles.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabActionTiles.ts
@@ -2,12 +2,11 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type { ActionTilesProps } from "@features/flow-pay-card-balance";
 
-const noop = () => {};
-
 export function usePayTabActionTiles(
   onTrackEvent: ActionTilesProps["onTrackEvent"],
   onDeposit: () => void,
   onRequest: () => void,
+  onPay: () => void,
 ): ActionTilesProps {
   const { t } = useTranslation();
 
@@ -26,11 +25,11 @@ export function usePayTabActionTiles(
           onPress: onRequest,
           appearance: "transparent",
         },
-        { id: "pay", label: t("payTab.actions.pay"), onPress: noop, appearance: "transparent" },
+        { id: "pay", label: t("payTab.actions.pay"), onPress: onPay, appearance: "transparent" },
       ],
       page: "Pay",
       onTrackEvent,
     }),
-    [t, onTrackEvent, onDeposit, onRequest],
+    [t, onTrackEvent, onDeposit, onRequest, onPay],
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabNewPayment.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabNewPayment.ts
@@ -1,0 +1,23 @@
+import { useCallback } from "react";
+import { AssetCategory } from "@domain/api-aggregated-assets";
+import { useOpenSendFlow } from "LLD/features/Send/hooks/useOpenSendFlow";
+
+const PAY_PAGE = "Pay";
+
+// Card payments only spend stablecoins; filter the account picker by category so the
+// user still picks any supported network without listing every currency id.
+const PAY_CATEGORIES = [AssetCategory.Stablecoins] as const;
+
+export type UsePayTabNewPayment = Readonly<{
+  open: () => void;
+}>;
+
+export function usePayTabNewPayment(): UsePayTabNewPayment {
+  const openSendFlow = useOpenSendFlow();
+
+  const open = useCallback(() => {
+    openSendFlow({ source: PAY_PAGE, categories: PAY_CATEGORIES });
+  }, [openSendFlow]);
+
+  return { open };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/index.tsx
@@ -12,6 +12,7 @@ import { usePayTabFeatureTour } from "./hooks/usePayTabFeatureTour";
 import { usePayTabActionTiles } from "./hooks/usePayTabActionTiles";
 import { usePayTabDepositOptions } from "./hooks/usePayTabDepositOptions";
 import { usePayTabRequestReceive } from "./hooks/usePayTabRequestReceive";
+import { usePayTabNewPayment } from "./hooks/usePayTabNewPayment";
 import { usePayTabVerifyAddress } from "./hooks/usePayTabVerifyAddress";
 import { VerifyAddressExecutorLWD } from "./verifyAddressIntent/VerifyAddressExecutorLWD";
 
@@ -28,7 +29,13 @@ const PayTab = () => {
   const deposit = usePayTabDepositOptions(balance.onTrackEvent);
   const verify = usePayTabVerifyAddress(balance.onTrackEvent);
   const request = usePayTabRequestReceive(balance.onTrackEvent, verify.openIntro);
-  const actionTiles = usePayTabActionTiles(balance.onTrackEvent, deposit.open, request.open);
+  const newPayment = usePayTabNewPayment();
+  const actionTiles = usePayTabActionTiles(
+    balance.onTrackEvent,
+    deposit.open,
+    request.open,
+    newPayment.open,
+  );
 
   return (
     <div className="flex flex-col gap-24">

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useOpenSendFlow.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useOpenSendFlow.test.ts
@@ -1,5 +1,6 @@
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { AssetCategory } from "@domain/api-aggregated-assets";
 import { renderHook, withFlagOverrides } from "tests/testSetup";
 import { useOpenSendFlow } from "../useOpenSendFlow";
 
@@ -44,5 +45,39 @@ describe("useOpenSendFlow", () => {
         account,
       }),
     );
+  });
+
+  it("forwards categories to the account selection drawer without leaking them into the send params", () => {
+    const account = genAccount("send-account-selection-categories", {
+      currency: getCryptoCurrencyById("ethereum"),
+    });
+    const { result, store } = renderHook(() => useOpenSendFlow(), {
+      initialState: {
+        ...withFlagOverrides({
+          newSendFlow: {
+            enabled: true,
+            params: { families: ["evm"], excludedCurrencyIds: [] },
+          },
+        }),
+        accounts: [account],
+      },
+    });
+
+    result.current({
+      source: "Pay",
+      categories: [AssetCategory.Stablecoins],
+    });
+
+    expect(store.getState().modularDialog.isOpen).toBe(true);
+    expect(store.getState().modularDialog.flow).toBe("send");
+    expect(store.getState().modularDialog.source).toBe("Pay");
+    expect(store.getState().modularDialog.dialogParams?.categories).toEqual([
+      AssetCategory.Stablecoins,
+    ]);
+
+    store.getState().modularDialog.dialogParams?.onAccountSelected?.(account);
+
+    expect(store.getState().sendFlow.isOpen).toBe(true);
+    expect(store.getState().sendFlow.data?.params).not.toHaveProperty("categories");
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useOpenSendFlow.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useOpenSendFlow.ts
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { Account, AccountLike } from "@ledgerhq/types-live";
+import type { AssetCategory } from "@domain/api-aggregated-assets";
 import { openModal } from "~/renderer/actions/modals";
 import { accountsSelector } from "~/renderer/reducers/accounts";
 import BigNumber from "bignumber.js";
@@ -27,6 +28,7 @@ type WorkflowParams = {
   account?: AccountLike;
   parentAccount?: Account;
   currencyIds?: readonly string[];
+  categories?: readonly AssetCategory[];
   recipient?: string;
   amount?: string | BigNumber;
   memo?: string;
@@ -46,7 +48,7 @@ export function useOpenSendFlow() {
       setOriginFlow(HOOKS_TRACKING_LOCATIONS.sendModal);
 
       const openSendFlowImpl = (nextParams?: WorkflowParams) => {
-        const { currencyIds, ...flowParams } = nextParams ?? {};
+        const { currencyIds, categories, ...flowParams } = nextParams ?? {};
 
         if (!flowParams.account) {
           // When there are no accounts, the old modal requires an account and would throw.
@@ -59,6 +61,7 @@ export function useOpenSendFlow() {
             dispatch(
               openDialog({
                 currencies: currencyIds ? [...currencyIds] : [],
+                categories,
                 areCurrenciesFiltered: Boolean(currencyIds?.length),
                 dialogConfiguration: SEND_ACCOUNT_SELECTION_DRAWER_CONFIGURATION,
                 onAccountSelected: (account: AccountLike, parentAccount?: Account) => {


### PR DESCRIPTION
### 📝 Description

Wires the Pay tab **New payment** action tile on Desktop to the new Send flow. Previously the tile rendered but its `onPress` was a `noop`.

Pressing **New payment** now opens the new Send flow via `useOpenSendFlow`, with no pre-selected account, so it presents the Modular Dialog account picker filtered to **stablecoins** (`AssetCategory.Stablecoins`) and tags the entry with `source: "Pay"`. Pay does not own recipient/QR UI — it reuses the new Send flow entirely.

To support the stablecoin filter, `useOpenSendFlow` gains an optional `categories` param that is forwarded to the account-selection drawer (`openDialog`) and deliberately kept out of the `SendFlowParams` / legacy `MODAL_SEND` payloads.

Changes:
- `useOpenSendFlow`: add optional `categories` and forward it to the account picker.
- New `usePayTabNewPayment` view-model hook: `open()` → `openSendFlow({ source: "Pay", categories: [Stablecoins] })`.
- `usePayTabActionTiles`: accept and wire an `onPay` handler for the `pay` tile.
- `PayTab/index.tsx`: mount the new hook and pass `newPayment.open`.

Tests:
- `useOpenSendFlow`: asserts `categories` reaches the drawer and does not leak into send params.
- New `usePayTabNewPayment` unit test.
- PayTab integration test: clicking **New payment** opens the stablecoin-filtered send account selection with `flow: "send"`, `source: "Pay"`.



https://github.com/user-attachments/assets/ceaae8dc-7fbb-4c70-85b4-1a0a8f848b7e


### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35377](https://ledgerhq.atlassian.net/browse/LIVE-35377)
- **Figma**: [LWD entry](https://www.figma.com/design/WYQQwem0QyG2fTuaAKAe3Y/Pay-%E2%80%A2-Production?node-id=7731-42419&m=dev)
- Mobile is delivered in a separate branch/PR.

[LIVE-35377]: https://ledgerhq.atlassian.net/browse/LIVE-35377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ