### PR TITLE
feat(pay): connect MAD to mobile Request flow (LIVE-36345)

### DIFF
--- a/.changeset/tidy-rivers-request.md
+++ b/.changeset/tidy-rivers-request.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Connect the Modular Asset Drawer to the Pay tab Request action, filtered to stablecoins with account selection

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -116,6 +116,7 @@
     "@features/flow-pay-card-balance": "workspace:^",
     "@features/flow-pay-card-deposit": "workspace:^",
     "@features/flow-pay-card-feature-tour": "workspace:^",
+    "@features/flow-pay-card-request": "workspace:^",
     "@features/flow-contacts": "workspace:^",
     "@features/flow-contacts-add-address": "workspace:^",
     "@features/flow-contacts-add-contact": "workspace:^",

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
@@ -289,4 +289,22 @@ describe("PayTab integration", () => {
       });
     });
   });
+
+  describe("request", () => {
+    beforeEach(() => {
+      mockStablecoins({ stablecoins: [heldUsdc(1000)] });
+    });
+
+    it("opens the modular asset drawer for the request flow when the request tile is pressed", async () => {
+      const { user, store } = render(<PayTabScreen />, { overrideInitialState: tourSeen });
+
+      await user.press(await screen.findByTestId("action-tile-request"));
+
+      await waitFor(() => {
+        expect(store.getState().modularDrawer.isOpen).toBe(true);
+      });
+      expect(store.getState().modularDrawer.flow).toBe("request");
+      expect(store.getState().modularDrawer.source).toBe("Pay");
+    });
+  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/__tests__/usePayTabRequestReceive.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/__tests__/usePayTabRequestReceive.test.ts
@@ -1,0 +1,91 @@
+import type { Account, AccountLike } from "@ledgerhq/types-live";
+import { AssetCategory } from "@domain/api-aggregated-assets";
+import { act, renderHook } from "@tests/test-renderer";
+import { useModularDrawerController } from "LLM/features/ModularDrawer";
+import { deriveRequestReceiveData } from "../deriveRequestReceiveData";
+import { usePayTabRequestReceive } from "../usePayTabRequestReceive";
+
+jest.mock("LLM/features/ModularDrawer", () => ({
+  useModularDrawerController: jest.fn(),
+}));
+jest.mock("../deriveRequestReceiveData", () => ({ deriveRequestReceiveData: jest.fn() }));
+
+const mockedUseModularDrawerController = jest.mocked(useModularDrawerController);
+const mockedDerive = jest.mocked(deriveRequestReceiveData);
+
+const DERIVED = {
+  address: "0xTokenParentAddress",
+  asset: { name: "USD Coin", ticker: "USDC" },
+  network: "Base",
+  assetIcon: { ledgerId: "base/erc20/usd__coin", ticker: "USDC", network: "base" },
+  networkIcon: { ledgerId: "base", ticker: "ETH" },
+};
+
+let openDrawer: jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  openDrawer = jest.fn();
+  mockedUseModularDrawerController.mockReturnValue({
+    openDrawer,
+  } as unknown as ReturnType<typeof useModularDrawerController>);
+  mockedDerive.mockReturnValue(DERIVED);
+});
+
+describe("usePayTabRequestReceive", () => {
+  it("should start closed with empty display data", () => {
+    const { result } = renderHook(() => usePayTabRequestReceive(undefined));
+
+    expect(result.current.requestReceive.isOpen).toBe(false);
+    expect(result.current.requestReceive.address).toBe("");
+    expect(result.current.requestReceive.asset).toEqual({ name: "", ticker: "" });
+    expect(mockedDerive).not.toHaveBeenCalled();
+  });
+
+  it("should open MAD filtered to the stablecoin category with account selection enabled", () => {
+    const { result } = renderHook(() => usePayTabRequestReceive(undefined));
+
+    act(() => result.current.open());
+
+    expect(openDrawer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        categories: [AssetCategory.Stablecoins],
+        enableAccountSelection: true,
+        flow: "request",
+        source: "Pay",
+      }),
+    );
+  });
+
+  it("should populate the receive screen from the selected account on success", () => {
+    const account = { type: "TokenAccount" } as unknown as AccountLike;
+    const parentAccount = { type: "Account" } as unknown as Account;
+
+    const { result } = renderHook(() => usePayTabRequestReceive(undefined));
+
+    act(() => result.current.open());
+    const { onAccountSelected } = openDrawer.mock.calls[0][0];
+    act(() => onAccountSelected(account, parentAccount));
+
+    expect(mockedDerive).toHaveBeenCalledWith(account, parentAccount);
+    const { requestReceive } = result.current;
+    expect(requestReceive.isOpen).toBe(true);
+    expect(requestReceive.address).toBe(DERIVED.address);
+    expect(requestReceive.asset).toEqual(DERIVED.asset);
+    expect(requestReceive.network).toBe(DERIVED.network);
+    expect(requestReceive.assetIcon).toEqual(DERIVED.assetIcon);
+    expect(requestReceive.networkIcon).toEqual(DERIVED.networkIcon);
+  });
+
+  it("should close the receive screen through onClose", () => {
+    const account = { type: "Account" } as unknown as AccountLike;
+    const { result } = renderHook(() => usePayTabRequestReceive(undefined));
+
+    act(() => result.current.open());
+    act(() => openDrawer.mock.calls[0][0].onAccountSelected(account, undefined));
+    expect(result.current.requestReceive.isOpen).toBe(true);
+
+    act(() => result.current.requestReceive.onClose());
+    expect(result.current.requestReceive.isOpen).toBe(false);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/deriveRequestReceiveData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/deriveRequestReceiveData.ts
@@ -1,0 +1,32 @@
+import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type { RequestReceiveAsset, RequestReceiveIconProps } from "@features/flow-pay-card-request";
+
+export type RequestReceiveData = Readonly<{
+  address: string;
+  asset: RequestReceiveAsset;
+  network: string;
+  assetIcon: RequestReceiveIconProps;
+  networkIcon: RequestReceiveIconProps;
+}>;
+
+export function deriveRequestReceiveData(
+  account: AccountLike,
+  parentAccount?: Account,
+): RequestReceiveData {
+  const currency = getAccountCurrency(account);
+  const mainAccount = getMainAccount(account, parentAccount);
+  const networkCurrency = mainAccount.currency;
+
+  return {
+    address: mainAccount.freshAddress,
+    asset: { name: currency.name, ticker: currency.ticker },
+    network: networkCurrency.name,
+    assetIcon: {
+      ledgerId: currency.id,
+      ticker: currency.ticker,
+      network: networkCurrency.id,
+    },
+    networkIcon: { ledgerId: networkCurrency.id, ticker: networkCurrency.ticker },
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabActionTiles.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabActionTiles.ts
@@ -2,11 +2,10 @@ import { useMemo } from "react";
 import { useTranslation } from "~/context/Locale";
 import type { ActionTilesProps } from "@features/flow-pay-card-balance";
 
-const noop = () => {};
-
 export function usePayTabActionTiles(
   onTrackEvent: ActionTilesProps["onTrackEvent"],
   onDeposit: () => void,
+  onRequest: () => void,
 ): ActionTilesProps {
   const { t } = useTranslation();
 
@@ -14,11 +13,11 @@ export function usePayTabActionTiles(
     () => ({
       tiles: [
         { id: "deposit", label: t("payTab.actions.deposit"), onPress: onDeposit },
-        { id: "request", label: t("payTab.actions.request"), onPress: noop },
+        { id: "request", label: t("payTab.actions.request"), onPress: onRequest },
       ],
       page: "Pay",
       onTrackEvent,
     }),
-    [t, onTrackEvent, onDeposit],
+    [t, onTrackEvent, onDeposit, onRequest],
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabRequestReceive.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabRequestReceive.ts
@@ -1,0 +1,82 @@
+import { useCallback, useMemo, useState } from "react";
+import { Share } from "react-native";
+import Clipboard from "@react-native-clipboard/clipboard";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
+import { AssetCategory } from "@domain/api-aggregated-assets";
+import type { PayCardTrackEvent, RequestReceiveProps } from "@features/flow-pay-card-request";
+import { useModularDrawerController } from "LLM/features/ModularDrawer";
+import { deriveRequestReceiveData } from "./deriveRequestReceiveData";
+
+const REQUEST_PAGE = "Pay";
+const REQUEST_CATEGORIES: AssetCategory[] = [AssetCategory.Stablecoins];
+
+const EMPTY_LABELS: RequestReceiveProps["labels"] = {
+  title: "",
+  networkLabel: "",
+  actions: { share: "", copy: "", copied: "", save: "", verify: "" },
+};
+
+type Selection = Readonly<{ account: AccountLike; parentAccount?: Account }>;
+
+export type UsePayTabRequestReceive = Readonly<{
+  open: () => void;
+  requestReceive: RequestReceiveProps;
+}>;
+
+export function usePayTabRequestReceive(
+  onTrackEvent: PayCardTrackEvent | undefined,
+): UsePayTabRequestReceive {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selection, setSelection] = useState<Selection | null>(null);
+  const { openDrawer } = useModularDrawerController();
+
+  const open = useCallback(() => {
+    openDrawer({
+      categories: REQUEST_CATEGORIES,
+      flow: "request",
+      source: REQUEST_PAGE,
+      enableAccountSelection: true,
+      onAccountSelected: (account, parentAccount) => {
+        setSelection({ account, parentAccount });
+        setIsOpen(true);
+      },
+    });
+  }, [openDrawer]);
+
+  const onClose = useCallback(() => setIsOpen(false), []);
+
+  const onCopy = useCallback((address: string) => {
+    Clipboard.setString(address);
+  }, []);
+
+  const onShare = useCallback((address: string) => {
+    void Share.share({ message: address }).catch(() => undefined);
+  }, []);
+
+  const data = useMemo(
+    () => (selection ? deriveRequestReceiveData(selection.account, selection.parentAccount) : null),
+    [selection],
+  );
+
+  const requestReceive = useMemo<RequestReceiveProps>(
+    () => ({
+      isOpen,
+      address: data?.address ?? "",
+      asset: data?.asset ?? { name: "", ticker: "" },
+      network: data?.network ?? "",
+      page: REQUEST_PAGE,
+      labels: EMPTY_LABELS,
+      assetIcon: data?.assetIcon ?? { ledgerId: "", ticker: "" },
+      networkIcon: data?.networkIcon,
+      visibleActions: ["share", "copy"],
+      onShare,
+      onCopy,
+      onVerify: () => {},
+      onClose,
+      onTrackEvent,
+    }),
+    [isOpen, data, onShare, onCopy, onClose, onTrackEvent],
+  );
+
+  return { open, requestReceive };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/PayTabView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/PayTabView.tsx
@@ -13,6 +13,7 @@ import {
   type BalanceLabels,
 } from "@features/flow-pay-card-balance";
 import { DepositOptions, type DepositOptionsProps } from "@features/flow-pay-card-deposit";
+import { RequestReceive, type RequestReceiveProps } from "@features/flow-pay-card-request";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { TrackScreen } from "~/analytics";
 
@@ -25,6 +26,7 @@ type PayTabViewProps = {
   readonly balanceLabels: BalanceLabels;
   readonly actionTiles: ActionTilesProps;
   readonly depositOptions: DepositOptionsProps;
+  readonly requestReceive: RequestReceiveProps;
 };
 
 export function PayTabView({
@@ -36,6 +38,7 @@ export function PayTabView({
   balanceLabels,
   actionTiles,
   depositOptions,
+  requestReceive,
 }: PayTabViewProps) {
   return (
     <Box
@@ -46,6 +49,7 @@ export function PayTabView({
       <TrackScreen category="Pay" balance_filter={balance.filter} />
       <Balance {...balance} labels={balanceLabels} actionTiles={actionTiles} />
       <DepositOptions {...depositOptions} />
+      <RequestReceive {...requestReceive} />
       <CardLogin oauthConfig={oauthConfig} callback={callback} />
       <CardLogout />
       <FeatureTour {...featureTour} />

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
@@ -11,6 +11,7 @@ import { useNavigationBarHeights } from "LLM/hooks/useNavigationBarHeights";
 import { usePayCardBalance } from "LLM/features/PayTab/hooks/usePayCardBalance";
 import { usePayTabActionTiles } from "LLM/features/PayTab/hooks/usePayTabActionTiles";
 import { usePayTabDepositOptions } from "LLM/features/PayTab/hooks/usePayTabDepositOptions";
+import { usePayTabRequestReceive } from "LLM/features/PayTab/hooks/usePayTabRequestReceive";
 import { track } from "~/analytics";
 import { PAY_TAB_DEEP_LINK } from "~/navigation/deeplinks/payTabDeepLink";
 
@@ -21,7 +22,8 @@ export function usePayTabViewModel() {
 
   const balance = usePayCardBalance();
   const deposit = usePayTabDepositOptions(balance.onTrackEvent);
-  const actionTiles = usePayTabActionTiles(balance.onTrackEvent, deposit.open);
+  const request = usePayTabRequestReceive(balance.onTrackEvent);
+  const actionTiles = usePayTabActionTiles(balance.onTrackEvent, deposit.open, request.open);
 
   const balanceLabels: BalanceLabels = useMemo(
     () => ({
@@ -89,5 +91,6 @@ export function usePayTabViewModel() {
     balanceLabels,
     actionTiles,
     depositOptions: deposit.depositOptions,
+    requestReceive: request.requestReceive,
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1785,6 +1785,9 @@ importers:
       '@features/flow-pay-card-feature-tour':
         specifier: workspace:^
         version: link:../../features/flow/pay-card-feature-tour
+      '@features/flow-pay-card-request':
+        specifier: workspace:^
+        version: link:../../features/flow/pay-card-request
       '@features/platform-aggregated-assets':
         specifier: workspace:*
         version: link:../../features/platform/aggregated-assets
@@ -27445,7 +27448,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: ^5.5.10
+      rxjs: '*'
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -68467,7 +68470,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.7(metro-transform-worker@0.83.7)
+      metro: 0.83.7
       metro-babel-transformer: 0.83.7
       metro-cache: 0.83.7
       metro-cache-key: 0.83.7
@@ -68617,53 +68620,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro@0.83.7(metro-transform-worker@0.83.7):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 2.0.0
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.35.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0(metro@0.83.7)
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.7
-      metro-cache: 0.83.7
-      metro-cache-key: 0.83.7
-      metro-config: 0.83.7(metro-transform-worker@0.83.7)
-      metro-core: 0.83.7
-      metro-file-map: 0.83.7(metro@0.83.7)
-      metro-resolver: 0.83.7
-      metro-runtime: 0.83.7
-      metro-source-map: 0.83.7
-      metro-symbolicate: 0.83.7
-      metro-transform-plugins: 0.83.7
-      metro-transform-worker: 0.83.7
-      mime-types: 3.0.1
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
### 📝 Description

Connects the Modular Asset Drawer (MAD) to the **Request** action on the mobile Pay tab, mirroring the Desktop implementation (`usePayTabRequestReceive` + `useOpenAssetAndAccount`).

**Problem**: On mobile, the Request tile on the Pay tab was a no-op — tapping it did nothing.

**Solution**: Tapping Request now opens MAD via `useModularDrawerController().openDrawer`, filtered server-side to stablecoins with account selection enabled. Once an account is picked, the host derives the address/asset/network primitives and drives the shared `RequestReceive` component.

- `usePayTabRequestReceive` opens MAD with `categories: [AssetCategory.Stablecoins]`, `enableAccountSelection: true`, `flow: "request"`, `source: "Pay"`.
- `deriveRequestReceiveData` maps the selected account to display primitives (copied from Desktop; the shared `@features/flow-pay-card-request` package is intentionally domain-agnostic).
- `usePayTabActionTiles` / `usePayTabViewModel` wire `request.open` to the tile; `PayTabView` mounts `<RequestReceive />`.

**Note**: The native `RequestReceiveView` is still a stub (returns `null`) pending [LIVE-35188](https://ledgerhq.atlassian.net/browse/LIVE-35188), so after selecting an account no receive screen is shown yet — but MAD and the host wiring are fully in place for the native UI to drop in. Verify-address is out of scope ([LIVE-36274](https://ledgerhq.atlassian.net/browse/LIVE-36274)).

Covered by a new `usePayTabRequestReceive` unit test and an extended `PayTab.integration.test.tsx` asserting the drawer opens for the request flow (39 PayTab tests passing).


https://github.com/user-attachments/assets/7c93a9a5-4bbc-48e3-a535-9765563b3d15





### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36345](https://ledgerhq.atlassian.net/browse/LIVE-36345)
- **ADR** (if any): n/a

[LIVE-35188]: https://ledgerhq.atlassian.net/browse/LIVE-35188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ