### PR TITLE
[LWD] fix(LIVE-32046): fix hint of previous user location tab

### DIFF
--- a/.changeset/spotty-yaks-hear.md
+++ b/.changeset/spotty-yaks-hear.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fix hint of previous user location tab when entering swap from deeplink

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/SideBarView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/SideBarView.tsx
@@ -47,6 +47,7 @@ export function SideBarView({ viewModel }: SideBarViewProps) {
 
       <div className="min-h-0">
         <SideBar
+          ref={viewModel.navRef}
           active={viewModel.active}
           onActiveChange={viewModel.handleActiveChange}
           collapsed={viewModel.collapsed}

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/__integrations__/SideBar.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/__integrations__/SideBar.integration.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "tests/testSetup";
+import { fireEvent, render, screen } from "tests/testSetup";
 import { useNavigate } from "react-router";
 import SideBar from "../index";
 import { defaultInitialState, withFeatureFlags } from "../__tests__/testUtils";
@@ -317,6 +317,33 @@ describe("SideBar", () => {
       await user.click(screen.getByText("Refer a friend"));
 
       expect(mockNavigate).toHaveBeenCalledWith("/refer-a-friend");
+    });
+  });
+
+  describe("Window focus", () => {
+    it("should drop focus from the clicked item when the window loses focus", async () => {
+      const { user } = renderSideBarWithRoute("/");
+
+      const swapButton = screen.getByText("Swap").closest("button");
+      await user.click(swapButton!);
+      expect(swapButton).toHaveFocus();
+
+      fireEvent.blur(window);
+
+      expect(swapButton).not.toHaveFocus();
+    });
+
+    it("should keep focus outside the sidebar untouched when the window loses focus", () => {
+      renderSideBarWithRoute("/");
+
+      const outsideButton = document.createElement("button");
+      document.body.appendChild(outsideButton);
+      outsideButton.focus();
+
+      fireEvent.blur(window);
+
+      expect(outsideButton).toHaveFocus();
+      outsideButton.remove();
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/types.ts
@@ -1,3 +1,4 @@
+import type { RefObject } from "react";
 import type { Location } from "react-router";
 import type { SideBarActiveValue } from "./utils";
 
@@ -25,6 +26,7 @@ export interface RecoverFeatureConfig {
 export interface SideBarViewModel {
   readonly pathname: string;
   readonly location: Location;
+  readonly navRef: RefObject<HTMLElement | null>;
   readonly collapsed: boolean;
   readonly navigationLocked?: boolean;
   readonly noAccounts: boolean;

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/useSideBarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/useSideBarViewModel.ts
@@ -147,6 +147,19 @@ export function useSideBarViewModel(): SideBarViewModel {
   const accountsSidebarPath = getAccountsSidebarPath(shouldDisplayAssetSection);
 
   const wasNarrowRef = useRef<boolean | null>(null);
+  const navRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    const dropSideBarFocus = () => {
+      const focused = document.activeElement;
+      if (focused instanceof HTMLElement && navRef.current?.contains(focused)) {
+        focused.blur();
+      }
+    };
+
+    window.addEventListener("blur", dropSideBarFocus);
+    return () => window.removeEventListener("blur", dropSideBarFocus);
+  }, []);
 
   useEffect(() => {
     const handleResize = () => {
@@ -316,6 +329,7 @@ export function useSideBarViewModel(): SideBarViewModel {
   return {
     pathname: location.pathname,
     location,
+    navRef,
     collapsed,
     navigationLocked,
     noAccounts,


### PR DESCRIPTION

<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

fix hint of previous user location tab when entering swap from deeplink

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

https://ledgerhq.atlassian.net/browse/LIVE-32046

https://github.com/user-attachments/assets/1d4a1b00-5443-43d1-b12c-ece8b5dd0fff


- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
