### PR TITLE
[LWM] fix(solana): make default validator option for delegation summary

### DIFF
--- a/.changeset/olive-berries-beam.md
+++ b/.changeset/olive-berries-beam.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix(solana): make default validator option for delegation summary

--- a/apps/ledger-live-mobile/src/families/solana/DelegationFlow/Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/DelegationFlow/Summary.tsx
@@ -77,16 +77,23 @@ export default function DelegationSummary({ navigation, route }: Props) {
     () => ({
       account,
       parentAccount,
-      transaction: tx({
-        delegationAction,
-        defaultValidator: validators[0],
-        amount: route.params.amount,
-        chosenValidator,
-      }),
+      transaction:
+        validators.length > 0
+          ? tx({
+              delegationAction,
+              defaultValidator: validators[0],
+              amount: route.params.amount,
+              chosenValidator,
+            })
+          : route.params.transaction,
     }),
   );
 
   useEffect(() => {
+    if (validators.length === 0) {
+      return;
+    }
+
     setTransaction(
       tx({
         delegationAction,


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

make default validator option for delegation summary
Validators may not be loaded at time, so default validator is now optional, to handle this case

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 --> [LIVE-36352](https://ledgerhq.atlassian.net/browse/LIVE-36352?atlOrigin=eyJpIjoiNTkzOTNjNDc3OTEwNDBjOGEwNGE3NGFiYWNjZjcxYzMiLCJwIjoiaiJ9)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-36352]: https://ledgerhq.atlassian.net/browse/LIVE-36352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ