### PR TITLE
[LWM] fix(e2e): show step parameters in mobile allure reports

### DIFF
--- a/e2e/mobile/page/accounts/account.page.ts
+++ b/e2e/mobile/page/accounts/account.page.ts
@@ -40,7 +40,7 @@ export default class AccountPage {
     `js:2:${account.currency.id}:${account.parentAccount ? account.parentAccount.address : account.address}:${account.currency.id}Sub+${account.address}`;
   accountGraphId = (accountId: string) => `account-graph-${accountId}`;
 
-  @Step("Wait for account screen and verify account name")
+  @Step("Wait for account screen and verify account name {{{0}}}")
   async waitAndVerifyAccountName(accountName: string) {
     await waitForElementById(this.accountScreenScrollView);
     await detoxExpect(getElementByText(accountName, 0)).toBeVisible();
@@ -64,13 +64,13 @@ export default class AccountPage {
     return await IsIdVisible(this.accountScreenScrollView, timeout);
   }
 
-  @Step("Go to the account with the name")
+  @Step("Go to the account with the name {{{0}}}")
   async goToAccountByName(name: string) {
     await scrollToId(this.baseAccountName + name, this.accountsListId);
     await tapById(this.baseAccountName + name);
   }
 
-  @Step("Go to the account with id")
+  @Step("Go to the account with id {{{0}}}")
   async goToAccountById(id: string) {
     const elementId = this.baseAccountRow + id;
     const element = getElementById(elementId);
@@ -80,12 +80,12 @@ export default class AccountPage {
     await tapByElement(element);
   }
 
-  @Step("Expect the account name at index")
+  @Step("Expect the account name {{{0}}}")
   async expectAccountName(accountName: string, index = 0) {
     jestExpect(await this.getAccountName(index)).toBe(accountName);
   }
 
-  @Step("Get the account name at index")
+  @Step("Get the account name at index {{{0}}}")
   async getAccountName(index = 0) {
     return await getTextOfElement(this.accountNameRegExp, index);
   }
@@ -116,12 +116,12 @@ export default class AccountPage {
     await tapByElement(this.accountRenameRow());
   }
 
-  @Step("Enter new account name and submit")
+  @Step("Enter new account name and submit {{{0}}}")
   async enterNewAccountName(name: string) {
     await typeTextById(this.accountRenameTextInputId, name);
   }
 
-  @Step("Expect operation history to be visible")
+  @Step("Expect operation history to be visible {{{0}}}")
   async expectOperationHistoryVisible(accountId: string) {
     await scrollToId(this.operationRowRegexp, this.accountScreenScrollView, 250, "down");
     await detoxExpect(getElementById(this.operationHistorySectionId(accountId))).toExist();
@@ -134,19 +134,19 @@ export default class AccountPage {
     await scrollToId(this.operationRowRegexp, this.accountScreenScrollView, 300, "down");
   }
 
-  @Step("Scroll to a Specific SubAccount Row")
+  @Step("Scroll to a Specific SubAccount Row {{{0}}}")
   async scrollToSubAccount(subAccountId: string) {
     await waitForElementById(this.accountScreenScrollView);
     await scrollToId(subAccountId, this.accountScreenScrollView);
   }
 
-  @Step("Expect account balance to be visible")
+  @Step("Expect account balance to be visible {{{0}}}")
   async expectAccountBalanceVisible(accountId: string) {
     await detoxExpect(this.accountGraph(accountId)).toBeVisible();
     await detoxExpect(this.accountBalance(accountId)).toBeVisible();
   }
 
-  @Step("Get visible account address label")
+  @Step("Get visible account address label {{{0}}}")
   async getVisibleAccountAddressLabel(accountId: string) {
     await scrollToId(this.accountAddressId(accountId), this.accountScreenScrollView);
     await detoxExpect(this.accountAddress(accountId)).toBeVisible();
@@ -160,7 +160,7 @@ export default class AccountPage {
     await detoxExpect(getElementById(this.sendButtonId)).toBeVisible();
   }
 
-  @Step("Expect address index")
+  @Step("Expect address index {{{0}}}")
   async expectAddressIndex(indexNumber: number) {
     await this.openAccountSettings();
     await this.openAccountAdvancedLogs();
@@ -199,14 +199,14 @@ export default class AccountPage {
     await tapById(this.buyButtonId);
   }
 
-  @Step("Navigate to token in account")
+  @Step("Navigate to token in account {{{0.accountName}}}")
   async navigateToTokenInAccount(subAccount: Account) {
     const subAccountId = this.baseSubAccountRow + subAccount.currency.ticker;
     await this.scrollToSubAccount(subAccountId);
     await tapById(subAccountId);
   }
 
-  @Step("Navigate to sub account")
+  @Step("Navigate to sub account {{{0.accountName}}}")
   async navigateToSubAccount(account: AccountType) {
     const subAccountId = this.subAccountId(account);
     await this.openViaDeeplink();
@@ -214,7 +214,7 @@ export default class AccountPage {
     await waitForElement(this.accountGraph(subAccountId));
   }
 
-  @Step("Scroll to history and click on last operation")
+  @Step("Scroll to history and click on last operation {{{0}}}")
   async scrollToHistoryAndClickOnLastOperation(operationType: string) {
     await this.scrollToTransactions();
     await tapByElement(this.getSpecificOperation(operationType));

--- a/e2e/mobile/page/accounts/accounts.page.ts
+++ b/e2e/mobile/page/accounts/accounts.page.ts
@@ -31,7 +31,7 @@ export default class AccountsPage extends CommonPage {
     }
   }
 
-  @Step("Expect accounts number")
+  @Step("Expect accounts number {{{0}}}")
   async expectAccountsNumber(expectedAccountCount: number, testDataJson?: string) {
     let expectedAccountIds: string[] = [];
 

--- a/e2e/mobile/page/accounts/addAccount.drawer.ts
+++ b/e2e/mobile/page/accounts/addAccount.drawer.ts
@@ -75,7 +75,7 @@ export default class AddAccountDrawer extends CommonPage {
     });
   }
 
-  @Step("Expect account discovered")
+  @Step("Expect account discovered {{{0}}}")
   async expectAccountDiscovery(currencyName: string, currencyId: string, index = 0) {
     await detoxExpect(this.accountItem(this.accountIdAccountDrawer(currencyId))).toBeVisible();
     const accountId = (await getIdByRegexp(this.accountItemRegExp(), index)).replace(
@@ -92,7 +92,7 @@ export default class AddAccountDrawer extends CommonPage {
     await tapById(this.closeAddAccountButtonId);
   }
 
-  @Step("Add only discovered account at index")
+  @Step("Add only discovered {{{0}}} account at index {{{2}}}")
   async addAccountAtIndex(currencyName: string, currencyId: string, index: number = 0) {
     await this.waitAccountsDiscovery();
     const accountCount = await countElementsById(this.accountItemRegExp());

--- a/e2e/mobile/page/accounts/assetAccounts.page.ts
+++ b/e2e/mobile/page/accounts/assetAccounts.page.ts
@@ -10,7 +10,7 @@ export default class AssetAccountsPage {
   assetQuickActionButton = (action: "send" | "receive" | "buy" | "sell" | "swap") =>
     getElementById(`asset-quick-action-button-${action}`);
 
-  @Step("Wait for asset page to load")
+  @Step("Wait for asset page to load {{{0}}}")
   async waitForAccountPageToLoad(
     assetName: string,
     currencyId?: string,
@@ -35,13 +35,13 @@ export default class AssetAccountsPage {
     await detoxExpect(balanceEl).toBeVisible();
   }
 
-  @Step("Wait for individual asset rows to load")
+  @Step("Wait for individual asset rows to load {{{0}}}")
   async waitForAccountAssetsToLoad(assetName: string) {
     await waitForElementById(this.titleId(assetName));
     await waitForElementById(this.accountAssetId(assetName));
   }
 
-  @Step("Open asset list via deeplink")
+  @Step("Open asset list via deeplink {{{0}}}")
   async openViaDeeplink(currencyLong?: string) {
     if (!currencyLong && (await isAggregatedAssetsEnabled())) {
       await openDeeplink("crypto-addresses");
@@ -51,7 +51,7 @@ export default class AssetAccountsPage {
     }
   }
 
-  @Step("Tap on asset quick action button ")
+  @Step("Tap on asset quick action button {{{0}}}")
   async tapOnAssetQuickActionButton(action: "send" | "receive" | "buy" | "sell" | "swap") {
     if (await isAggregatedAssetsEnabled()) {
       const q2TestIds: Partial<Record<typeof action, string>> = {
@@ -69,12 +69,12 @@ export default class AssetAccountsPage {
     }
   }
 
-  @Step("Open asset page via deeplink")
+  @Step("Open asset page via deeplink {{{0}}}")
   async openAssetPageViaDeeplink(currencyId: string) {
     await openDeeplink(`asset/${currencyId}`);
   }
 
-  @Step("Expect asset page to be visible")
+  @Step("Expect asset page to be visible {{{0}}}")
   async expectAssetPage(currencyId?: string) {
     const currency = currencyId?.toLowerCase() || "bitcoin";
     if (await isAggregatedAssetsEnabled()) {

--- a/e2e/mobile/page/common.page.ts
+++ b/e2e/mobile/page/common.page.ts
@@ -38,7 +38,7 @@ export default class CommonPage {
   accountId = (account: Account) =>
     `test-id-account-${getParentAccountName(account)}${account.tokenType !== undefined ? ` (${account.currency.ticker})` : ""}`;
 
-  @Step("Perform search")
+  @Step("Perform search {{{0}}}")
   async performSearch(text: string) {
     await waitForElementById(this.searchBarId);
     await typeTextByElement(this.searchBar(), text);
@@ -49,14 +49,14 @@ export default class CommonPage {
     await detoxExpect(this.searchBar()).toBeVisible();
   }
 
-  @Step("Select currency to debit")
+  @Step("Select currency to debit {{{0.accountName}}}")
   async selectAccount(account: Account) {
     const accountId = this.accountId(account);
     await waitForElementById(accountId);
     await tapByIdAndExpectToDisappear(accountId);
   }
 
-  @Step("Expect search")
+  @Step("Expect search {{{0}}}")
   async expectSearch(text: string) {
     await detoxExpect(this.searchBar()).toHaveText(text);
   }
@@ -86,7 +86,7 @@ export default class CommonPage {
     await tapById(this.accountCardRegExp());
   }
 
-  @Step("Go to the account")
+  @Step("Go to the account {{{0}}}")
   async goToAccount(accountId: string, currencyId: string) {
     if (await isAggregatedAssetsEnabled()) {
       if (await IsIdVisible(this.accountGraphId(accountId))) {
@@ -110,12 +110,12 @@ export default class CommonPage {
     await tapById(this.closeWithConfirmationButtonId);
   }
 
-  @Step("Check number of account rows")
+  @Step("Check number of account rows {{{0}}}")
   async checkAccountRowNumber(nbr: number) {
     jestExpect(await countElementsById(this.accountItemNameRegExp)).toBeLessThanOrEqual(nbr);
   }
 
-  @Step("Get the account name at index")
+  @Step("Get the account name at index {{{0}}}")
   async getAccountName(index = 0) {
     if (await isAggregatedAssetsEnabled()) {
       if (await IsIdVisible("CryptoAddressesList")) {
@@ -130,12 +130,12 @@ export default class CommonPage {
     }
   }
 
-  @Step("Expect the account name at index")
+  @Step("Expect the account name {{{0}}}")
   async expectAccountName(accountName: string, index = 0) {
     jestExpect(await this.getAccountName(index)).toBe(accountName);
   }
 
-  @Step("Go to the account with the name")
+  @Step("Go to the account with the name {{{0}}}")
   async goToAccountByName(name: string) {
     const accountTitle = getElementByText(name);
     const rowId = (await getIdOfElement(accountTitle)).replace("-name", ""); // Workaround on iOS (name on top of the return arrow clickable layout)

--- a/e2e/mobile/page/discover/discover.page.ts
+++ b/e2e/mobile/page/discover/discover.page.ts
@@ -37,7 +37,7 @@ export default class DiscoverPage {
     return app;
   }
 
-  @Step("Open discover page via deeplink")
+  @Step("Open discover page via deeplink {{{0}}}")
   async openViaDeeplink(appName?: DiscoverAppName) {
     await openDeeplink(this.baseLink + (appName ?? ""));
   }
@@ -47,7 +47,7 @@ export default class DiscoverPage {
     return app.url;
   }
 
-  @Step("Expect live app title")
+  @Step("Expect live app title {{{0}}}")
   async expectApp(app: DiscoverAppName) {
     // space is required as it is part of the element text
     await detoxExpect(this.liveAppTitle()).toHaveText(` ${this.getAppUrl(app)}`);
@@ -58,12 +58,12 @@ export default class DiscoverPage {
     await detoxExpect(this.discoverPageHeader()).toBeVisible();
   }
 
-  @Step("Type in catalog search bar")
+  @Step("Type in catalog search bar {{{0}}}")
   async typeInCatalogSearchBar(text: string) {
     await typeTextByElement(this.catalogSearchBar(), text);
   }
 
-  @Step("Expect catalog app card")
+  @Step("Expect catalog app card {{{0}}}")
   async expectCatalogAppCard(appName: DiscoverAppName) {
     await detoxExpect(this.catalogAppCard(appName)).toBeVisible();
   }

--- a/e2e/mobile/page/drawer/modular.drawer.ts
+++ b/e2e/mobile/page/drawer/modular.drawer.ts
@@ -43,7 +43,7 @@ export default class ModularDrawer {
     }
   }
 
-  @Step("Select Account")
+  @Step("Select Account {{{0}}}")
   async selectAccount(accountName: string): Promise<void> {
     const accountItemId = this.accountItemNameId(accountName);
     await tapById(accountItemId);
@@ -54,18 +54,18 @@ export default class ModularDrawer {
     await tapById(this.drawerBackButtonId);
   }
 
-  @Step("Validate account(s) present on account list")
+  @Step("Validate account(s) present on account list {{{0}}}")
   async validateNumberOfAccounts(expectedCount: number) {
     const elements = await countElements(getElementsById(this.accountItem));
     jestExpect(elements).toBe(expectedCount);
   }
 
-  @Step("Perform search on modular drawer by ticker")
+  @Step("Perform search on modular drawer by ticker {{{0}}}")
   async performSearchByTicker(ticker: string) {
     await typeTextByElement(this.searchBar(), ticker);
   }
 
-  @Step("Select currency in receive list by ticker")
+  @Step("Select currency in receive list by ticker {{{0}}}")
   async selectCurrencyByTicker(ticker: string): Promise<void> {
     const assetItemId = this.assetItemByTicker(ticker);
     if (!(await IsIdVisible(assetItemId))) {
@@ -74,7 +74,7 @@ export default class ModularDrawer {
     await tapById(assetItemId, 0);
   }
 
-  @Step("Check asset $0 amount is masked in discreet mode")
+  @Step("Check asset {{{0}}} amount is masked in discreet mode")
   async checkAssetAmountIsDiscreet(ticker: string): Promise<void> {
     await this.performSearchByTicker(ticker);
     const assetItemId = this.assetItemByTicker(ticker);
@@ -90,21 +90,21 @@ export default class ModularDrawer {
     ).toBeVisible();
   }
 
-  @Step("Check listed asset amounts are masked in discreet mode")
+  @Step("Check listed asset amounts are masked in discreet mode {{{0}}}")
   async checkAssetAmountsAreDiscreet(tickers: string[]): Promise<void> {
     for (const ticker of tickers) {
       await this.checkAssetAmountIsDiscreet(ticker);
     }
   }
 
-  @Step("Select network in list if needed")
+  @Step("Select network in list if needed {{{0}}}")
   async selectNetworkIfAsked(networkName: string): Promise<void> {
     if (await IsIdVisible(this.networkScreenId)) {
       await this.selectNetwork(networkName);
     }
   }
 
-  @Step("Select network")
+  @Step("Select network {{{0}}}")
   async selectNetwork(networkName: string): Promise<void> {
     const id = this.networkItemIdMAD(networkName);
     if (!(await IsIdVisible(id))) {
@@ -134,13 +134,13 @@ export default class ModularDrawer {
     await this.selectNetworkIfAsked(networkName);
   }
 
-  @Step("Select currency in modular drawer")
+  @Step("Select currency in modular drawer {{{0.accountName}}}")
   async selectAsset(account: Account): Promise<void> {
     await this.selectAssetCurrencyAndNetwork(account);
     await this.selectFirstAccount();
   }
 
-  @Step("Select currency then a specific account in modular drawer")
+  @Step("Select currency then a specific account in modular drawer {{{0.accountName}}}")
   async selectAssetAndAccount(account: Account): Promise<void> {
     await this.selectAssetCurrencyAndNetwork(account);
     // Token accounts are listed under their PARENT account's name in the drawer
@@ -149,7 +149,7 @@ export default class ModularDrawer {
     await this.selectAccount(accountName);
   }
 
-  @Step("Validate account(s) present on account list")
+  @Step("Validate account(s) present on account list {{{0}}}")
   async validateAccountsScreen(accounts?: string[]): Promise<void> {
     await waitForElement(getElementById(this.accountScreenId));
     jestExpect(await getTextOfElement(this.basedTitleIdMAD)).toMatch(/Select account.*/i);
@@ -163,7 +163,7 @@ export default class ModularDrawer {
     }
   }
 
-  @Step("Validate account name(s) visible on account list")
+  @Step("Validate account name(s) visible on account list {{{0}}}")
   async validateAccountNames(accounts: string[]): Promise<void> {
     for (const account of accounts) {
       const accountItemId = this.accountItemNameId(account);
@@ -171,7 +171,7 @@ export default class ModularDrawer {
     }
   }
 
-  @Step("Validate network(s) present on network list")
+  @Step("Validate network(s) present on network list {{{0}}}")
   async validateNetworksScreen(networks: string[]): Promise<void> {
     await waitForElement(getElementById(this.networkScreenId));
     jestExpect(await getTextOfElement(this.basedTitleIdMAD)).toMatch(/Select network.*/i);
@@ -183,7 +183,7 @@ export default class ModularDrawer {
     }
   }
 
-  @Step("Validate assets present on account list")
+  @Step("Validate assets present on account list {{{0}}}")
   async validateAssetsScreen(assets: string[]): Promise<void> {
     await waitForElement(getElementById(this.assetScreenId));
     jestExpect(await getLabelOfElement(this.basedTitleIdMAD)).toMatch(/Select asset.*/i);

--- a/e2e/mobile/page/drawer/swapTransactionStatus.drawer.ts
+++ b/e2e/mobile/page/drawer/swapTransactionStatus.drawer.ts
@@ -28,7 +28,7 @@ export default class SwapTransactionStatusDrawer {
   swapIdId = "swap-transaction-details-swap-id";
   viewInExplorerButtonId = "swap-transaction-view-explorer-btn";
 
-  @Step("Verify swap transaction status drawer information")
+  @Step("Verify swap transaction status drawer information {{{0}}}")
   async expectSwapTransactionStatusDrawerInfos(
     swapIdPrefix: string,
     provider: SwapProvider,

--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -94,7 +94,7 @@ export default class SwapLiveAppPage {
     await tapWebElementByTestId(this.fromSelector);
   }
 
-  @Step("Verify currency is selected")
+  @Step("Verify currency {{{0}}} is selected")
   async verifyCurrencyIsSelected(ticker: string, isFromCurrency: boolean) {
     const selector = isFromCurrency ? this.fromSelector : this.toSelector;
     const actualText = await getWebElementText(selector);
@@ -106,7 +106,7 @@ export default class SwapLiveAppPage {
     await tapWebElementByTestId(this.toSelector);
   }
 
-  @Step("Input amount")
+  @Step("Input amount {{{0}}}")
   async inputAmount(amount: string) {
     await typeTextByWebTestId(this.fromAmountInput, amount);
   }
@@ -173,7 +173,7 @@ export default class SwapLiveAppPage {
     }, timeout);
   }
 
-  @Step("Tap execute swap button")
+  @Step("Tap execute swap button {{{0}}}")
   async tapExecuteSwap(provider: string) {
     const button = getWebElementByCssSelector(this.providerExecuteButtonCss(provider), 0);
     await waitWebElement(button);
@@ -232,13 +232,13 @@ export default class SwapLiveAppPage {
     }, 30000);
   }
 
-  @Step("Check error message: $0")
+  @Step("Check error message: {{{0}}}")
   async checkErrorMessage(errorMessage: string) {
     const error = await getTextOfElement(this.deviceActionErrorDescriptionId);
     jestExpect(error).toContain(errorMessage);
   }
 
-  @Step("Check first quote container infos")
+  @Step("Check first quote container infos {{{0}}}")
   async checkFirstQuoteContainerInfos(providerList: string[]) {
     const provider: string = SwapProvider.getNameByUiName(providerList[0]);
     const baseProviderLocator = `quote-container-${provider}`;
@@ -292,7 +292,7 @@ export default class SwapLiveAppPage {
 
   // approvalRequired must reflect real allowance state — see isTokenApprovalExpected
   // in swapUtils.ts, rather than guessing it here.
-  @Step("Check exchange CTA text: $0")
+  @Step("Check exchange CTA text: {{{0}}}")
   async checkQuoteCardCta(provider: string, approvalRequired = false): Promise<void> {
     if (!SwapProvider.getNameByUiName(provider)) {
       throw new Error(`Unknown provider UI name: "${provider}"`);
@@ -363,7 +363,7 @@ export default class SwapLiveAppPage {
     };
   }
 
-  @Step("Verify swap amount error message match: $0")
+  @Step("Verify swap amount error message match: {{{0}}}")
   async verifySwapAmountErrorMessageIsCorrect(expectedMessage: string | RegExp) {
     await waitWebElementByTestId(this.fromAccountErrorId);
     const errorText: string = await getWebElementText(this.fromAccountErrorId);
@@ -372,7 +372,7 @@ export default class SwapLiveAppPage {
     await this.expectQuotesButtonNotVisible();
   }
 
-  @Step("Verify swap cross account error message match: $0")
+  @Step("Verify swap cross account error message match: {{{0}}}")
   async verifySwapCrossAccountErrorMessageIsCorrect(expectedMessage: string | RegExp) {
     // Cross-account warnings render in the same from-account error slot as amount errors.
     await this.verifySwapAmountErrorMessageIsCorrect(expectedMessage);
@@ -389,7 +389,7 @@ export default class SwapLiveAppPage {
     await detoxExpect(getWebElementByTestId(this.insufficientFundsBuyButton)).toExist();
   }
 
-  @Step("Click on swap max")
+  @Step("Click on swap max {{{0}}}")
   async clickSwapMax(pattern: RegExp = floatNumberRegex, timeout?: number) {
     await tapWebElementByTestId(this.swapMaxToggle);
     await waitForWebElementToMatchRegex(app.swapLiveApp.toAmountInput, pattern, timeout);
@@ -410,7 +410,7 @@ export default class SwapLiveAppPage {
     return await getWebElementText(this.fromAccountAmountInactive);
   }
 
-  @Step("Get quote card raw amount texts for $0")
+  @Step("Get quote card raw amount texts for {{{0}}}")
   async getQuoteCardRawText(provider: string) {
     const baseProviderLocator = `quote-container-${SwapProvider.getNameByUiName(provider)}`;
     const amount =
@@ -435,7 +435,7 @@ export default class SwapLiveAppPage {
     await tapWebElementByTestId(this.switchButton);
   }
 
-  @Step("Check currency to swap from is $0")
+  @Step("Check currency to swap from is {{{0}}} with amount {{{1}}}")
   async checkAssetFrom(currency: string, amount: string) {
     const fromAccount: string = await getWebElementText(this.fromSelector);
     const amountToSend = await app.swapLiveApp.getAmountToSend();
@@ -443,20 +443,20 @@ export default class SwapLiveAppPage {
     jestExpect(amountToSend).toEqual(amount);
   }
 
-  @Step("Check currency to swap from contains $0")
+  @Step("Check currency to swap from contains {{{0}}}")
   async checkAssetFromContains(expectedAssetText: string) {
     const fromAccount: string = await getWebElementText(this.fromSelector);
     jestExpect(fromAccount).toContain(expectedAssetText);
   }
 
-  @Step("Check from-account balance is masked in discreet mode for $0")
+  @Step("Check from-account balance is masked in discreet mode for {{{0}}}")
   async checkFromAccountBalanceIsDiscreet(ticker: string) {
     await waitWebElementByTestId(this.fromAccountBalance);
     const text = await getWebElementText(this.fromAccountBalance);
     jestExpect(text).toMatch(new RegExp(String.raw`\*\*\*\s+${escapeRegExp(ticker)}`, "i"));
   }
 
-  @Step("Check currency to swap from matches account $0")
+  @Step("Check currency to swap from matches account {{{0.accountName}}}")
   async checkAssetFromMatchesAccount(account: Account) {
     const selectedAccountText: string = await getWebElementText(this.fromSelector);
     const expectedAccountName = account.parentAccount?.accountName ?? account.accountName;
@@ -466,7 +466,7 @@ export default class SwapLiveAppPage {
     jestExpect(accountNameText).toContain(expectedAccountName);
   }
 
-  @Step("Check currency to swap to is $0 with amount $1")
+  @Step("Check currency to swap to is {{{0}}} with amount {{{1}}}")
   async checkAssetTo(currency: string, amount: string) {
     const assetTo: string = await getWebElementText(this.toSelector);
     if (currency === "") {
@@ -478,7 +478,7 @@ export default class SwapLiveAppPage {
     jestExpect(amountToReceive).toEqual(amount);
   }
 
-  @Step("Check currency to swap to contains $0")
+  @Step("Check currency to swap to contains {{{0}}}")
   async checkAssetToContains(expectedAssetText: string) {
     const assetTo: string = await getWebElementText(this.toSelector);
     if (expectedAssetText === "") {
@@ -488,7 +488,7 @@ export default class SwapLiveAppPage {
     }
   }
 
-  @Step("Check currency to swap to matches account $0")
+  @Step("Check currency to swap to matches account {{{0.accountName}}}")
   async checkAssetToMatchesAccount(account: Account) {
     const selectedAccountTicker: string = await getWebElementText(this.toSelector);
     const expectedAccountName = account.parentAccount?.accountName ?? account.accountName;
@@ -507,7 +507,7 @@ export default class SwapLiveAppPage {
     });
   }
 
-  @Step("Check Ledger Nano S not supported banner for $0")
+  @Step("Check Ledger Nano S not supported banner for {{{0}}}")
   async checkLnsNotSupportedBanner(provider: string) {
     await retryUntilTimeout(async () => {
       const bannerText = await getWebElementsText(
@@ -518,7 +518,7 @@ export default class SwapLiveAppPage {
     }, 20000);
   }
 
-  @Step("Select specific provider $0")
+  @Step("Select specific provider {{{0}}}")
   async selectSpecificProvider(provider: string) {
     const providersList = await this.getProviderList();
     if (!providersList.includes(provider)) {
@@ -533,7 +533,7 @@ export default class SwapLiveAppPage {
     await tapWebElementByTestId(providerTestId);
   }
 
-  @Step("Go to $0 live app")
+  @Step("Go to {{{0}}} live app")
   async goToProviderLiveApp(provider: string) {
     const button = getWebElementByCssSelector(this.providerExecuteButtonCss(provider));
     await detoxExpect(button).toExist();
@@ -541,7 +541,7 @@ export default class SwapLiveAppPage {
     await app.swapLiveApp.tapExecuteSwap(provider);
   }
 
-  @Step("Verify live app title contains $0")
+  @Step("Verify live app title contains {{{0}}}")
   async verifyLiveAppTitle(expectedText: string) {
     const liveAppTitle = await getTextOfElement("live-app-title");
     jestExpect(liveAppTitle.toLowerCase()).toContain(expectedText.toLowerCase());

--- a/e2e/mobile/page/market/market.page.ts
+++ b/e2e/mobile/page/market/market.page.ts
@@ -51,7 +51,7 @@ export default class MarketPage {
     await tapByIdAndExpectToDisappear(this.headerBackButtonId);
   }
 
-  @Step("Open market detail via deeplink")
+  @Step("Open market detail via deeplink {{{0}}}")
   async openViaDeeplink(currencyId?: string) {
     await openDeeplink(currencyId ? `market/${currencyId}` : "market");
   }
@@ -116,12 +116,12 @@ export default class MarketPage {
     }
   }
 
-  @Step("Search for asset")
+  @Step("Search for asset {{{0}}}")
   async searchAsset(asset: string) {
     await typeTextByElement(getElementById(await this.searchBarId()), asset);
   }
 
-  @Step("Open asset page")
+  @Step("Open asset page {{{0.name}}}")
   async openAssetPage(currency: CurrencyType) {
     if (await isAssetDiscoverabilityEnabled()) {
       await tapByElement(this.marketScreenRow(currency));
@@ -169,7 +169,7 @@ export default class MarketPage {
     await tapById(this.marketAssetsCategorySwitcherStarredId);
   }
 
-  @Step("Expect market row title")
+  @Step("Expect market row title {{{0.name}}}")
   async expectMarketRowTitle(currency: CurrencyType) {
     if (await isAssetDiscoverabilityEnabled()) {
       await detoxExpect(this.marketScreenRow(currency)).toBeVisible();
@@ -178,7 +178,7 @@ export default class MarketPage {
     }
   }
 
-  @Step("Check market screen item is visible")
+  @Step("Check market screen item {{{0}}} is visible")
   async isMarketScreenItemVisible(marketId: string, title: string): Promise<boolean> {
     try {
       await waitForElement(this.marketScreenItemWithTitle(marketId, title));
@@ -188,7 +188,7 @@ export default class MarketPage {
     }
   }
 
-  @Step("Tap on market quick action button ")
+  @Step("Tap on market quick action button {{{0}}}")
   async tapOnMarketQuickActionButton(action: "send" | "receive" | "buy" | "sell" | "swap") {
     if (await isAggregatedAssetsEnabled()) {
       const q2TestIds: Partial<Record<typeof action, string>> = {
@@ -215,13 +215,13 @@ export default class MarketPage {
     }
   }
 
-  @Step("Expect category tab $0 to be visible")
+  @Step("Expect category tab {{{0}}} to be visible")
   async expectCategoryTabVisible(value: string) {
     await waitForElementById(this.marketCategoryTabId(value));
     await detoxExpect(getElementById(this.marketCategoryTabId(value))).toBeVisible();
   }
 
-  @Step("Expect category $0 to be selected")
+  @Step("Expect category {{{0}}} to be selected")
   async expectCategorySelected(value: string) {
     await this.expectCategoryTabVisible(value);
   }

--- a/e2e/mobile/page/onboarding/onboardingSteps.page.ts
+++ b/e2e/mobile/page/onboarding/onboardingSteps.page.ts
@@ -48,20 +48,20 @@ export default class OnboardingStepsPage {
     await detoxExpect(this.onboardingGetStartedButton()).toBeVisible();
   }
 
-  @Step("Expect current selected language")
+  @Step("Expect current selected language {{{0}}}")
   async expectCurrentSelectedLanguageToBe(language: string): Promise<void> {
     const text = await getTextOfElement(this.currentSelectedLanguageId);
     jestExpect(text).toContain(language);
   }
 
-  @Step("Select language")
+  @Step("Select language {{{0}}}")
   async selectLanguage(language: string): Promise<void> {
     await tapById(this.languageSelectButtonId);
     await waitForElementById(this.languageSelectDrawerTitleId);
     await tapById(this.languageSelectElementId(language.toLowerCase()));
   }
 
-  @Step("Select starting option")
+  @Step("Select starting option {{{0}}}")
   async selectStartingOption(option: "setupLedger" | "accessWallet"): Promise<void> {
     switch (option) {
       case "setupLedger":

--- a/e2e/mobile/page/settings/settingsGeneral.page.ts
+++ b/e2e/mobile/page/settings/settingsGeneral.page.ts
@@ -20,7 +20,7 @@ export default class SettingsGeneralPage {
     await tapByElement(this.passwordSettingsSwitch());
   }
 
-  @Step("Expect password toggle to be $0")
+  @Step("Expect password toggle to be {{{0}}}")
   async expectPasswordToggleValue(value: "ON" | "OFF") {
     const expected = value === "ON";
     await detoxExpect(this.passwordSettingsSwitch()).toHaveToggleValue(expected);
@@ -41,7 +41,7 @@ export default class SettingsGeneralPage {
     await tapByElement(this.enterLedgerSync());
   }
 
-  @Step("Select language")
+  @Step("Select language {{{0}}}")
   async selectLanguage(lang: string) {
     await scrollToText(lang, this.languageScrollViewId);
     await tapByText(lang);
@@ -52,18 +52,18 @@ export default class SettingsGeneralPage {
     await detoxExpect(getElementById(this.countervalueSettingsRowId)).toBeVisible();
   }
 
-  @Step("Expect localized text")
+  @Step("Expect localized text {{{0}}}")
   async expectLocalizedText(text: string) {
     await detoxExpect(this.localizedText(text)).toBeVisible();
   }
 
-  @Step("Expect character set")
+  @Step("Expect character set {{{1}}} in {{{0}}}")
   async expectCharacterSet(testId: string, pattern: RegExp) {
     const substringPattern = new RegExp(`.*${pattern.source}.*`, pattern.flags);
     await detoxExpect(getElementByIdWithDescendantTexts(testId, substringPattern)).toBeVisible();
   }
 
-  @Step("Expect translated row")
+  @Step("Expect translated row {{{0}}} to be {{{1}}}")
   async expectTranslatedRow(testId: string, expectedText: string) {
     await detoxExpect(getElementByIdWithDescendantTexts(testId, expectedText)).toBeVisible();
   }
@@ -74,14 +74,14 @@ export default class SettingsGeneralPage {
     await tapById(this.countervalueSettingsRowId);
   }
 
-  @Step("Change counter value to $0")
+  @Step("Change counter value to {{{0}}}")
   async changeCounterValue(currency: string) {
     await this.clickOnCountervalueSettingsRow();
     await scrollToId(this.compactSettingsRowId(currency), this.counterValueSettingsFlatListId);
     await tapById(this.compactSettingsRowId(currency));
   }
 
-  @Step("Expect counter value to be $0")
+  @Step("Expect counter value to be {{{0}}}")
   async expectCounterValue(currency: string) {
     await waitForElementById(this.countervalueTickerSettingsRowId);
     await detoxExpect(getElementById(this.countervalueTickerSettingsRowId)).toHaveText(currency);

--- a/e2e/mobile/page/speculos.page.ts
+++ b/e2e/mobile/page/speculos.page.ts
@@ -25,17 +25,17 @@ function isSwap(value: SwapType | Account): value is SwapType {
 }
 
 export default class SpeculosPage {
-  @Step("Verify receive address correctness on device")
+  @Step("Verify receive address correctness on device {{{1}}}")
   async expectValidAddressDevice(account: AccountType, addressDisplayed: string) {
     await expectValidAddressDevice(account, addressDisplayed);
   }
 
-  @Step("Sign Send Transaction on Speculos")
+  @Step("Sign Send Transaction on Speculos {{{0.amount}}}")
   async signSendTransaction(tx: TransactionType) {
     await signSendTransaction(tx);
   }
 
-  @Step("Sign Delegation Transaction on Speculos")
+  @Step("Sign Delegation Transaction on Speculos {{{0.amount}}} to {{{0.provider}}}")
   async signDelegationTransaction(delegation: DelegateType) {
     await signDelegationTransaction(delegation);
   }
@@ -55,12 +55,12 @@ export default class SpeculosPage {
     await activateExpertMode();
   }
 
-  @Step("Verify amounts and accept swap")
+  @Step("Verify amounts and accept swap {{{1}}}")
   async verifyAmountsAndAcceptSwap(swap: SwapType, amount: string) {
     await verifyAmountsAndAcceptSwap(swap, amount);
   }
 
-  @Step("Verify amounts and accept swap for different seed")
+  @Step("Verify amounts {{{1}}} and accept swap for different seed")
   async verifyAmountsAndAcceptSwapForDifferentSeed(
     swap: SwapType,
     amount: string,
@@ -69,7 +69,7 @@ export default class SpeculosPage {
     await verifyAmountsAndAcceptSwapForDifferentSeed(swap, amount, errorMessage);
   }
 
-  @Step("Verify amounts and reject swap")
+  @Step("Verify amounts and reject swap {{{1}}}")
   async verifyAmountsAndRejectSwap(swap: SwapType, amount: string) {
     await verifyAmountsAndRejectSwap(swap, amount);
   }

--- a/e2e/mobile/page/trade/buySell.page.ts
+++ b/e2e/mobile/page/trade/buySell.page.ts
@@ -33,7 +33,7 @@ export default class BuySellPage {
   currencyListSelector = (curr: string) => `fiat-option-${curr}`;
   provider = (name: string) => `provider_${name.toLowerCase()}`;
 
-  @Step("Open page via deeplink")
+  @Step("Open page via deeplink {{{0}}}")
   async openViaDeeplink(page: "Buy" | "Sell") {
     await openDeeplink(page.toLowerCase());
     await waitForElementById(app.common.walletApiWebview, 60000, { checkVisibility: false });
@@ -61,14 +61,14 @@ export default class BuySellPage {
     await detoxExpect(getWebElementByTestId(this.sellPercentageButtonId("max"))).toExist();
   }
 
-  @Step("Select currency")
+  @Step("Select currency {{{0}}}")
   async selectCurrency(currencyId: string) {
     const id = this.currencyRow(currencyId);
     await waitForElementById(id);
     await tapById(id);
   }
 
-  @Step("Choose crypto asset if not selected")
+  @Step("Choose crypto asset if not selected {{{0.accountName}}}")
   async chooseAssetIfNotSelected(account: AccountType) {
     await tapWebElementByTestId(this.cryptoCurrencySelector);
     await app.modularDrawer.selectAsset(account);
@@ -78,7 +78,7 @@ export default class BuySellPage {
     );
   }
 
-  @Step("Choose country if not selected")
+  @Step("Choose country if not selected {{{0.locale}}}")
   async chooseCountryIfNotSelected(fiat: Fiat) {
     await tapWebElementByTestId(this.fiatAmountOptionButtonId);
     await tapWebElementByTestId(this.openCountryDrawerButtonId);
@@ -106,12 +106,12 @@ export default class BuySellPage {
     }
   }
 
-  @Step("Tap sell percentage button")
+  @Step("Tap sell percentage button {{{0}}}")
   async tapSellPercentageButton(percentage: "25%" | "50%" | "75%" | "max") {
     await tapWebElementByTestId(this.sellPercentageButtonId(percentage));
   }
 
-  @Step("Set amount to pay")
+  @Step("Set amount to pay {{{0}}}")
   async setAmountToPay(amount: string) {
     await typeTextByWebTestId(this.amountInputSectionId(), amount);
   }
@@ -124,7 +124,7 @@ export default class BuySellPage {
     await tapWebElementByTestId(this.formCta);
   }
 
-  @Step("Tap buy/sell cta")
+  @Step("Tap {{{1}}} cta for {{{0}}}")
   async tapBuySellWithCta(provider: string, page: "Buy" | "Sell") {
     await waitForWebElementToBeEnabled(this.formCta);
     const text = await getWebElementText(this.formCta);
@@ -132,7 +132,7 @@ export default class BuySellPage {
     await tapWebElementByTestId(this.formCta);
   }
 
-  @Step("Select payment method")
+  @Step("Select payment method {{{0}}}")
   async selectPaymentMethod(paymentMethod: string) {
     await tapWebElementByTestId(this.paymentSelector);
     await detoxExpect(getWebElementByTestId(this.paymentOptions)).toExist();
@@ -168,7 +168,7 @@ export default class BuySellPage {
     return selected;
   }
 
-  @Step("Select provider")
+  @Step("Select provider {{{0}}}")
   async selectProvider(provider: string) {
     await waitWebElementByTestId(this.providersList);
     const expandButton = await waitWebElementByTestId(this.expandButtonId, {
@@ -182,7 +182,7 @@ export default class BuySellPage {
     await tapWebElementByTestId(this.provider(provider));
   }
 
-  @Step("Verify provider page loaded with correct URL")
+  @Step("Verify provider page loaded with correct URL {{{0}}}")
   async verifyProviderPageLoadedWithCorrectUrl(provider: string) {
     try {
       const normalizedProvider = provider.toLowerCase().replace(/\s/g, "");
@@ -195,7 +195,7 @@ export default class BuySellPage {
     }
   }
 
-  @Step("Verify provider page is displayed and not a blank/error screen")
+  @Step("Verify provider page is displayed and not a blank/error screen {{{0}}}")
   async verifyProviderPageIsNotBlank(provider: string) {
     try {
       await waitForWebviewContentToRender();
@@ -212,7 +212,7 @@ export default class BuySellPage {
     }
   }
 
-  @Step("Handle buy flow")
+  @Step("Handle buy flow with {{{1}}}")
   async handleBuyFlow(buySell: BuySell, paymentMethod: string, skipQuickAmountVerify?: boolean) {
     await this.expectBuyScreenToBeVisible();
     await this.chooseAssetIfNotSelected(buySell.crypto);
@@ -229,7 +229,7 @@ export default class BuySellPage {
     await this.verifyProviderPageIsNotBlank(selectedProvider.uiName);
   }
 
-  @Step("Handle sell flow")
+  @Step("Handle sell flow {{{1}}}")
   async handleSellFlow(buySell: BuySell, paymentMethod: string, provider: BuySellProvider) {
     await this.expectSellScreenToBeVisible();
     await this.chooseAssetIfNotSelected(buySell.crypto);

--- a/e2e/mobile/page/trade/deviceValidation.page.ts
+++ b/e2e/mobile/page/trade/deviceValidation.page.ts
@@ -14,22 +14,22 @@ export default class DeviceValidationPage extends CommonPage {
     await waitForElementById(this.validationScrollViewId);
   }
 
-  @Step("Expect amount in device validation screen")
+  @Step("Expect amount in device validation screen {{{0}}}")
   async expectAmount(amount: string) {
     await detoxExpect(this.validationAmount()).toHaveText(amount);
   }
 
-  @Step("Expect address in device validation screen")
+  @Step("Expect address in device validation screen {{{0}}}")
   async expectAddress(recipient: string) {
     await detoxExpect(this.validationAddress()).toHaveText(recipient);
   }
 
-  @Step("Expect provider in device validation screen")
+  @Step("Expect provider in device validation screen {{{0}}}")
   async expectProvider(provider: string) {
     await detoxExpect(this.validationProvider()).toHaveText(provider);
   }
 
-  @Step("Expect fees in device validation screen")
+  @Step("Expect fees in device validation screen {{{0}}}")
   async expectFees(fees: string) {
     await detoxExpect(this.validationFees()).toHaveText(fees);
   }

--- a/e2e/mobile/page/trade/earnV2Dashboard.page.ts
+++ b/e2e/mobile/page/trade/earnV2Dashboard.page.ts
@@ -48,12 +48,12 @@ export default class EarnV2DashboardPage {
     await waitWebElementByTestId(this.crowdFavourites);
   }
 
-  @Step("Verify asset ready to earn")
+  @Step("Verify asset ready to earn {{{0}}}")
   async verifyAssetReadyToEarn(ticker: string) {
     await detoxExpect(getWebElementByTestId(this.assetItemTicker(ticker))).toExist();
   }
 
-  @Step("Click asset earn CTA")
+  @Step("Click asset earn CTA {{{0}}}")
   async clickAssetEarnCta(ticker: string) {
     await tapWebElementByTestId(this.assetEarnCta(ticker));
   }
@@ -70,12 +70,12 @@ export default class EarnV2DashboardPage {
     await detoxExpect(getWebElementByTestId(this.rewardsSummary)).toExist();
   }
 
-  @Step("Verify position row present for $0")
+  @Step("Verify position row present for {{{0}}}")
   async verifyPositionRowPresent(identifier: string) {
     await detoxExpect(getWebElementByXpath(this.depositRowXPath(identifier))).toExist();
   }
 
-  @Step("Click position row for $0")
+  @Step("Click position row for {{{0}}}")
   async clickPositionRow(identifier: string) {
     const row = getWebElementByXpath(this.depositRowXPath(identifier));
     await tapWebElementByElement(row);
@@ -97,7 +97,7 @@ export default class EarnV2DashboardPage {
 
   // --- Staking Flow Verification (native) ---
 
-  @Step("Verify staking flow opened for $0")
+  @Step("Verify staking flow opened for {{{0}}}")
   async verifyStakingFlowOpened(ticker: string) {
     const testId = EarnV2DashboardPage.stakingFlowTestIds[ticker];
     if (!testId) {
@@ -106,7 +106,7 @@ export default class EarnV2DashboardPage {
     await detoxExpect(getElementById(testId)).toBeVisible();
   }
 
-  @Step("Verify earn flow started for $0")
+  @Step("Verify earn flow started for {{{0}}}")
   async verifyEarnFlowStarted(ticker: string) {
     // ETH is redirected into the earn deposit webview (stakePrograms redirect) rather than
     // opening a native staking drawer, so it is verified by URL instead of a native test id.
@@ -132,7 +132,7 @@ export default class EarnV2DashboardPage {
     "stader-eth": "stader-eth",
   };
 
-  @Step("Complete ETH deposit amount step with $0 ETH")
+  @Step("Complete ETH deposit amount step with {{{0}}} ETH")
   async completeEthDepositAmountStep(amount: string) {
     await waitWebElementByTestId(this.ethAmountInput);
     await typeTextByWebTestId(this.ethAmountInput, amount);
@@ -140,7 +140,7 @@ export default class EarnV2DashboardPage {
     await tapWebElementByTestId(this.ethAmountContinueCta);
   }
 
-  @Step("Select ETH provider $0 in deposit webview")
+  @Step("Select ETH provider {{{0}}} in deposit webview")
   async selectEthProviderInWebview(providerId: string) {
     await waitWebElementByTestId(this.ethProviderPanel);
     // The ETH partner-dapp flags pin the deposit cohort to basic_sorting, so the category filter bar
@@ -158,12 +158,12 @@ export default class EarnV2DashboardPage {
     await tapWebElementByTestId(this.ethDepositProviderCta);
   }
 
-  @Step("Tap staking provider in EvmStakingDrawer: $0")
+  @Step("Tap staking provider in EvmStakingDrawer: {{{0}}}")
   async tapStakingProvider(providerId: string) {
     await tapById(this.stakingProvider(providerId));
   }
 
-  @Step("Verify partner dapp loaded (webview URL contains $0)")
+  @Step("Verify partner dapp loaded (webview URL contains {{{0}}})")
   async verifyPartnerDappLoaded(urlSubstring: string) {
     const url = await waitForCurrentWebviewUrlToContain(urlSubstring);
     jestExpect(url.toLowerCase()).toContain(urlSubstring.toLowerCase());
@@ -178,7 +178,7 @@ export default class EarnV2DashboardPage {
 
   // --- EarnMenuDrawer (native bottom sheet) ---
 
-  @Step("Wait for manage drawer and verify options present: $0")
+  @Step("Wait for manage drawer and verify options present: {{{0}}}")
   async waitForManageDrawerAndVerifyOptions(options: string[]) {
     await waitForElementById(this.earnMenuOption(options[0]));
     for (const option of options) {
@@ -186,7 +186,7 @@ export default class EarnV2DashboardPage {
     }
   }
 
-  @Step("Tap manage drawer option")
+  @Step("Tap manage drawer option {{{0}}}")
   async tapManageDrawerOption(optionText: string) {
     await tapById(this.earnMenuOption(optionText));
   }

--- a/e2e/mobile/page/trade/evmStake.page.ts
+++ b/e2e/mobile/page/trade/evmStake.page.ts
@@ -41,7 +41,7 @@ export default class EvmStakePage {
     return firstValidatorRowId;
   }
 
-  @Step("Set delegation amount to {amount}")
+  @Step("Set delegation amount to {{{0}}}")
   async setAmount(amount: string) {
     await waitForElementById(this.amountInputId);
     await typeTextById(this.amountInputId, amount);
@@ -65,7 +65,7 @@ export default class EvmStakePage {
     await tapById(this.amountContinueButtonId);
   }
 
-  @Step("Set amount and continue once fees are ready")
+  @Step("Set amount and continue once fees are ready {{{0}}}")
   async setAmountAndContinue(amount: string) {
     await this.setAmount(amount);
     await this.waitForAmountContinueEnabled();

--- a/e2e/mobile/page/trade/newSendFlow.page.ts
+++ b/e2e/mobile/page/trade/newSendFlow.page.ts
@@ -21,7 +21,7 @@ export default class NewSendFlowPage {
   signaturePromptId = "send-signature-prompt";
   successViewTransactionId = "send-confirmation-success-view-transaction";
 
-  @Step("Fill recipient address and continue: $0")
+  @Step("Fill recipient address and continue: {{{0}}}")
   async setRecipientAndContinueNewFlow(address: string | undefined, memoTag?: string) {
     if (!address) throw new Error("Recipient address is not set");
     await typeTextById(this.recipientInputId, address);
@@ -42,13 +42,13 @@ export default class NewSendFlowPage {
     }
   }
 
-  @Step("Type recipient address (stay on recipient step): $0")
+  @Step("Type recipient address (stay on recipient step): {{{0}}}")
   async typeRecipientNewFlow(address: string | undefined) {
     if (!address) throw new Error("Recipient address is not set");
     await typeTextById(this.recipientInputId, address);
   }
 
-  @Step("Open memo type dropdown and expect options: $0")
+  @Step("Open memo type dropdown and expect options: {{{0}}}")
   async expectMemoTypeOptions(optionValues: string[]) {
     await waitForElementById(this.memoTypeSelectId);
     await tapById(this.memoTypeSelectId);
@@ -57,7 +57,7 @@ export default class NewSendFlowPage {
     }
   }
 
-  @Step("Expect memo field to reject non-numeric input: $0")
+  @Step("Expect memo field to reject non-numeric input: {{{0}}}")
   async expectMemoRejectsNonNumericInput(rawInput: string, expectedSanitizedValue = "") {
     await waitForElementById(this.memoInputId);
     await typeTextById(this.memoInputId, rawInput);
@@ -67,7 +67,7 @@ export default class NewSendFlowPage {
     jestExpect(actualValue).toEqual(expectedSanitizedValue);
   }
 
-  @Step("Expect memo field to retain numeric input: $0")
+  @Step("Expect memo field to retain numeric input: {{{0}}}")
   async expectMemoRetainsNumericInput(numericInput: string) {
     await waitForElementById(this.memoInputId);
     await typeTextById(this.memoInputId, numericInput);
@@ -75,7 +75,7 @@ export default class NewSendFlowPage {
     jestExpect(actualValue).toEqual(numericInput);
   }
 
-  @Step("Fill crypto amount: $0")
+  @Step("Fill crypto amount: {{{0}}}")
   async setAmountNewFlow(amount: string) {
     // The amount step opens in fiat mode, so an untoggled "0.01" is $0.01, not 0.01 crypto —
     // the Speculos assertions compare against the crypto amount.
@@ -86,7 +86,7 @@ export default class NewSendFlowPage {
     }
   }
 
-  @Step("Click review to proceed to signature")
+  @Step("Click review to proceed to signature {{{0}}}")
   async setAmountAndReviewNewFlow(amount: string) {
     await this.setAmountNewFlow(amount);
     await waitForElementById(this.amountContinueEnabledButtonId);

--- a/e2e/mobile/page/trade/operationDetails.page.ts
+++ b/e2e/mobile/page/trade/operationDetails.page.ts
@@ -38,12 +38,12 @@ export default class OperationDetailsPage {
     await waitForElementById(this.titleId);
   }
 
-  @Step("Check account details")
+  @Step("Check account details {{{0}}}")
   async checkAccount(account: string) {
     await detoxExpect(this.account()).toHaveText(account);
   }
 
-  @Step("Check recipient details")
+  @Step("Check recipient details {{{0.accountName}}}")
   async checkRecipientAddress(recipient: Account) {
     await scrollToId(this.recipientId, this.operationDetailsScrollViewId);
     const recipientElement = getElementById(this.recipientId);
@@ -56,48 +56,48 @@ export default class OperationDetailsPage {
     }
   }
 
-  @Step("Check recipient as provider")
+  @Step("Check recipient as provider {{{0}}}")
   async checkRecipientAsProvider(recipientAddress: string) {
     await scrollToId(this.recipientId, this.operationDetailsScrollViewId);
     const recipientElement = getElementById(this.recipientId);
     await detoxExpect(recipientElement).toHaveText(recipientAddress);
   }
 
-  @Step("Check delegated provider")
+  @Step("Check delegated provider {{{0}}}")
   async checkProvider(provider: string) {
     await scrollToId(this.providerId, this.operationDetailsScrollViewId);
     await detoxExpect(getElementById(this.providerId)).toHaveText(provider);
   }
 
-  @Step("Check delegated amount")
+  @Step("Check delegated amount {{{0}}}")
   async checkDelegatedAmount(amount: string) {
     await scrollToId(this.delegatedAmountId, this.operationDetailsScrollViewId);
     await detoxExpect(getElementById(this.delegatedAmountId)).toHaveText(amount);
   }
 
-  @Step("Check sender")
+  @Step("Check sender {{{0}}}")
   async checkSender(sender: string) {
     await scrollToId(this.senderId, this.operationDetailsScrollViewId);
     await detoxExpect(getElementById(this.senderId)).toHaveText(sender);
   }
 
-  @Step("Check Fees")
+  @Step("Check Fees {{{0}}}")
   async checkFees(fees: string) {
     await scrollToId(this.feesId, this.operationDetailsScrollViewId);
     await detoxExpect(getElementById(this.feesId)).toHaveText(fees);
   }
 
-  @Step("Check transaction type")
+  @Step("Check transaction type {{{0}}}")
   async checkTransactionType(type: keyof typeof this.operationsType) {
     await detoxExpect(getElementById(this.titleId)).toHaveText(this.operationsType[type]);
   }
 
-  @Step("Check transaction title $0")
+  @Step("Check transaction title {{{0}}}")
   async checkTransactionTitle(title: string) {
     await detoxExpect(getElementById(this.titleId)).toHaveText(title);
   }
 
-  @Step("Check CELO validator group in operation details")
+  @Step("Check CELO validator group in operation details {{{0}}}")
   async checkCeloValidatorGroup(validatorGroup: string) {
     await scrollToId(this.celoValidatorGroupId, this.operationDetailsScrollViewId);
     await detoxExpect(getElementById(this.celoValidatorGroupId)).toHaveText(validatorGroup);
@@ -117,7 +117,7 @@ export default class OperationDetailsPage {
     if (operationType) await this.checkTransactionType(operationType);
   }
 
-  @Step("Check that transaction details are displayed")
+  @Step("Check that transaction details are displayed {{{0}}}")
   async checkTransactionDetailsVisibility(accountName?: string) {
     await this.waitForOperationDetails();
     await detoxExpect(this.account()).toBeVisible();
@@ -130,7 +130,7 @@ export default class OperationDetailsPage {
     await detoxExpect(this.date()).toBeVisible();
   }
 
-  @Step("Expect operation amount ticker")
+  @Step("Expect operation amount ticker {{{0}}}")
   async expectOperationAmountTicker(ticker: string) {
     await this.waitForOperationDetails();
     const amountText = await getTextOfElement(this.operationDetailsAmount);

--- a/e2e/mobile/page/trade/receive.page.ts
+++ b/e2e/mobile/page/trade/receive.page.ts
@@ -30,13 +30,13 @@ export default class ReceivePage {
     await openDeeplink(this.baseLink);
   }
 
-  @Step("Receive via deeplink")
+  @Step("Receive via deeplink {{{0}}}")
   async receiveViaDeeplink(currencyLong?: string): Promise<void> {
     const link = currencyLong ? this.baseLink + currencyParam + currencyLong : this.baseLink;
     await openDeeplink(link);
   }
 
-  @Step("Select currency in receive list")
+  @Step("Select currency in receive list {{{0}}}")
   async selectCurrency(currencyName: string): Promise<void> {
     const id = this.currencyNameId(currencyName.toLowerCase());
     if (!(await IsIdVisible(id))) {
@@ -45,7 +45,7 @@ export default class ReceivePage {
     await tapById(id);
   }
 
-  @Step("Select currency in receive list")
+  @Step("Select currency in receive list {{{0}}}")
   async selectCurrencyByType(currencyType: TokenType): Promise<void> {
     const id = this.currencyNameIdByRegex(currencyType.toLowerCase());
     if (!(await IsIdVisible(id))) {
@@ -54,13 +54,13 @@ export default class ReceivePage {
     await tapById(id);
   }
 
-  @Step("Select network")
+  @Step("Select network {{{0}}}")
   async selectNetwork(networkId: string): Promise<void> {
     const id = this.currencyNameId(networkId);
     await tapById(id);
   }
 
-  @Step("Select network in list if needed")
+  @Step("Select network in list if needed {{{0}}}")
   async selectNetworkIfAsked(networkId: string): Promise<void> {
     const id = this.networkBasedStep2HeaderTitleId;
     if (await IsIdVisible(id)) {
@@ -98,7 +98,7 @@ export default class ReceivePage {
     await tapById(this.noVerifyValidateButton);
   }
 
-  @Step("Expect receive page header")
+  @Step("Expect receive page header {{{0}}} for {{{1}}}")
   private async expectReceivePageHeader(tickerName: string, accountName: string): Promise<void> {
     const titleID = this.titleReceiveConfirmationPageId(tickerName);
     const accountNameID = this.accountNameReceiveId(accountName);
@@ -109,7 +109,7 @@ export default class ReceivePage {
     await detoxExpect(getElementById(accountNameID)).toBeVisible();
   }
 
-  @Step("Expect account receive page is displayed")
+  @Step("Expect account receive page is displayed for {{{1}}} ({{{0}}})")
   async expectReceivePageIsDisplayed(tickerName: string, accountName: string): Promise<void> {
     const qrCodeContainerID = this.receiveQrCodeContainerId(accountName);
 
@@ -118,7 +118,7 @@ export default class ReceivePage {
     await detoxExpect(getElementById(qrCodeContainerID)).toBeVisible();
   }
 
-  @Step("Expect receive warning page is displayed")
+  @Step("Expect receive warning page is displayed for {{{1}}} ({{{0}}})")
   async expectReceiveWarningPageIsDisplayed(
     tickerName: string,
     accountName: string,
@@ -126,12 +126,12 @@ export default class ReceivePage {
     await this.expectReceivePageHeader(tickerName, accountName);
   }
 
-  @Step("Verify address")
+  @Step("Verify address {{{0}}}")
   async verifyAddress(address: string): Promise<void> {
     await detoxExpect(getElementById(this.accountAddress)).toHaveText(address);
   }
 
-  @Step("Expect given address is displayed on receive page")
+  @Step("Expect given address is displayed on receive page {{{0}}}")
   async expectAddressIsCorrect(address: string): Promise<void> {
     await detoxExpect(getElementById(this.accountAddress)).toHaveText(address);
   }
@@ -149,7 +149,7 @@ export default class ReceivePage {
     );
   }
 
-  @Step("Expect receive network warning message for $0")
+  @Step("Expect receive network warning message for {{{0}}}")
   async expectSendCurrencyTokensWarningMessage(expectedWarningMessage: string): Promise<void> {
     await scrollToId(this.receiveNetworkWarningId, this.receivePageScrollViewId);
     await detoxExpect(getElementById(this.receiveNetworkWarningId)).toBeVisible();
@@ -172,7 +172,7 @@ export default class ReceivePage {
     );
   }
 
-  @Step("Select receive funds option")
+  @Step("Select receive funds option {{{0}}}")
   async selectReceiveFundsOption(receiveFundsOption: ReceiveFundsOptionsType): Promise<void> {
     await waitForElementById(this.receiveFundsOptionId(receiveFundsOption));
     await tapById(this.receiveFundsOptionId(receiveFundsOption));

--- a/e2e/mobile/page/trade/send.page.ts
+++ b/e2e/mobile/page/trade/send.page.ts
@@ -32,7 +32,7 @@ export default class SendPage {
   summaryContinueButton = () => getElementById(this.summaryContinueEnabledButtonId);
   feeStrategy = (fee: string) => getElementByText(fee);
 
-  @Step("Navigate to send screen")
+  @Step("Navigate to send screen {{{0}}}")
   async navigateToSendScreen(accountName: string) {
     await app.account.openViaDeeplink();
     await app.account.goToAccountByName(accountName);
@@ -44,7 +44,7 @@ export default class SendPage {
     await openDeeplink(this.baseLink);
   }
 
-  @Step("Send via deeplink")
+  @Step("Send via deeplink {{{0}}}")
   async sendViaDeeplink(currencyLong?: string) {
     const link = currencyLong ? this.baseLink + currencyParam + currencyLong : this.baseLink;
     await openDeeplink(link);
@@ -56,7 +56,7 @@ export default class SendPage {
     await detoxExpect(header).toBeVisible();
   }
 
-  @Step("Set recipient and memo tag")
+  @Step("Set recipient {{{0}}} and memo tag {{{1}}}")
   async setRecipient(address: string, memoTag?: string) {
     await waitForElementById(this.recipientInputId); // Issue with RN75 : QAA-370
     await typeTextById(this.recipientInputId, address);
@@ -65,7 +65,7 @@ export default class SendPage {
     }
   }
 
-  @Step("Continue to next step and skip memo tag if needed")
+  @Step("Continue to next step and skip memo tag if needed {{{0}}}")
   async recipientContinue(memoTag?: string) {
     await waitForElementById(this.recipientContinueEnabledButtonId);
     await tapById(this.recipientContinueEnabledButtonId);
@@ -76,12 +76,12 @@ export default class SendPage {
     }
   }
 
-  @Step("Expect recipient error message")
+  @Step("Expect recipient error message {{{0}}}")
   async expectSendRecipientError(errorMessage: string) {
     await this.expectRecipientMessage(errorMessage);
   }
 
-  @Step("Expect recipient warning message")
+  @Step("Expect recipient warning message {{{0}}}")
   async expectSendRecipientWarning(expectedWarningMessage: string | null) {
     await this.expectRecipientMessage(expectedWarningMessage, true);
   }
@@ -104,7 +104,7 @@ export default class SendPage {
     }
   }
 
-  @Step("Expect recipient step success")
+  @Step("Expect recipient step success {{{0}}}")
   async expectSendRecipientSuccess(expectedWarningMessage?: string) {
     const errElem = getElementById(this.recipientErrorId);
     if (!expectedWarningMessage) {
@@ -116,7 +116,7 @@ export default class SendPage {
     await detoxExpect(contBtn).toBeVisible();
   }
 
-  @Step("Set recipient and continue")
+  @Step("Set recipient {{{0}}} and continue")
   async setRecipientAndContinue(address: string | undefined, memoTag?: string) {
     if (!address) {
       throw new Error("Recipient address is not set");
@@ -125,7 +125,7 @@ export default class SendPage {
     await this.recipientContinue(memoTag);
   }
 
-  @Step("Set the amount and return the value")
+  @Step("Set the amount and return the value {{{0}}}")
   async setAmount(amount: string): Promise<string> {
     if (amount === "max") {
       const switchEl = this.amountMaxSwitch();
@@ -152,7 +152,7 @@ export default class SendPage {
     await detoxExpect(contBtn).toBeVisible();
   }
 
-  @Step("Expect amount error message")
+  @Step("Expect amount error message {{{0}}}")
   async expectSendAmountError(errorMessage: string) {
     const errElem = getElementById(this.amountErrorId);
     await detoxExpect(errElem).toHaveText(errorMessage);
@@ -162,7 +162,7 @@ export default class SendPage {
     await detoxExpect(disabledBtn).toBeVisible();
   }
 
-  @Step("Set amount and continue")
+  @Step("Set amount and continue {{{0}}}")
   async setAmountAndContinue(amount: string) {
     await this.setAmount(amount);
     await this.amountContinue();
@@ -174,13 +174,13 @@ export default class SendPage {
     await tapByElement(btn);
   }
 
-  @Step("Expect amount in summary")
+  @Step("Expect amount in summary {{{0}}}")
   async expectSummaryAmount(amount: string) {
     const amt = getElementById(this.summaryAmountId);
     await detoxExpect(amt).toHaveText(amount);
   }
 
-  @Step("Expect max amount is within range in summary")
+  @Step("Expect max amount is within range in summary {{{0}}}")
   async expectSummaryMaxAmount(amount: string, tolerance = 0.00005) {
     const text = await getTextOfElement(this.summaryAmountId);
     const summaryAmount = parseFloat(text.replace(/[^\d.-]/g, ""));
@@ -189,7 +189,7 @@ export default class SendPage {
     jestExpect(summaryAmount).toBeLessThanOrEqual(expected + tolerance);
   }
 
-  @Step("Expect recipient in summary")
+  @Step("Expect recipient in summary {{{0}}}")
   async expectSummaryRecipient(recipient: string | undefined) {
     if (!recipient) {
       throw new Error("Recipient address is not set");
@@ -198,7 +198,7 @@ export default class SendPage {
     await detoxExpect(rec).toHaveText(recipient);
   }
 
-  @Step("Expect error in summary")
+  @Step("Expect error in summary {{{0}}}")
   async expectSendSummaryError(errorMessage: RegExp) {
     const err = await getTextOfElement(this.summaryErrorId);
     jestExpect(err).toMatch(errorMessage);
@@ -208,19 +208,19 @@ export default class SendPage {
     await detoxExpect(disabledBtn).toBeVisible();
   }
 
-  @Step("Expect warning in summary")
+  @Step("Expect warning in summary {{{0}}}")
   async expectSummaryWarning(warningMessage: string) {
     const warn = this.summaryWarning();
     await detoxExpect(warn).toHaveText(warningMessage);
   }
 
-  @Step("Expect recipient ENS in summary")
+  @Step("Expect recipient ENS in summary {{{0}}}")
   async expectSummaryRecipientEns(ensName: string) {
     const ens = this.summaryRecipientEns();
     await detoxExpect(ens).toHaveText(ensName);
   }
 
-  @Step("Expect memo tag in summary")
+  @Step("Expect memo tag in summary {{{0}}}")
   async expectSummaryMemoTag(memoTag?: string) {
     if (memoTag && memoTag !== "noTag") {
       const memoEl = this.summaryMemoTag();
@@ -238,13 +238,13 @@ export default class SendPage {
     }
   }
 
-  @Step("Expect ENS name in device validation screen")
+  @Step("Expect ENS name in device validation screen {{{0}}}")
   async expectValidationEnsName(ensName: string) {
     const elem = getElementById(this.validationEnsId);
     await detoxExpect(elem).toHaveText(ensName);
   }
 
-  @Step("Choose fee strategy")
+  @Step("Choose fee strategy {{{0}}}")
   async chooseFeeStrategy(fee?: string) {
     if (fee) {
       await scrollToText(fee);

--- a/e2e/mobile/page/trade/stake.page.ts
+++ b/e2e/mobile/page/trade/stake.page.ts
@@ -29,27 +29,27 @@ export default class StakePage {
   currencyRow = (currencyId: string) => `currency-row-${currencyId}`;
   providerRow = (providerTicker: string) => `provider-row-${providerTicker}`;
 
-  @Step("Select currency")
+  @Step("Select currency {{{0}}}")
   async selectCurrency(currencyId: string) {
     const id = this.currencyRow(currencyId);
     await waitForElementById(id);
     await tapById(id);
   }
 
-  @Step("Click on start delegation button")
+  @Step("Click on start delegation button {{{0}}}")
   async delegationStart(currencyId: string) {
     await tapById(this.delegationStartId(currencyId));
     await waitForElementById(this.delegationSummaryValidatorId(currencyId));
   }
 
-  @Step("Dismiss delegation start page if displayed")
+  @Step("Dismiss delegation start page if displayed {{{0}}}")
   async dismissDelegationStart(currencyId: string) {
     if (await IsIdVisible(this.delegationStartId(currencyId))) {
       await this.delegationStart(currencyId);
     }
   }
 
-  @Step("Set delegated amount")
+  @Step("Set delegated amount {{{1}}} for {{{0}}}")
   async setAmount(currencyId: string, amount: string) {
     await waitForElementById(this.delegationSummaryAmountId(currencyId));
     await tapById(this.delegationSummaryAmountId(currencyId));
@@ -58,19 +58,19 @@ export default class StakePage {
     await waitForElementById(this.delegationAmountContinueId(currencyId)); // Issue with RN75 : QAA-370
   }
 
-  @Step("Set delegated amount percent")
+  @Step("Set delegated amount percent {{{1}}} for {{{0}}}")
   async setAmountPercent(currencyId: string, delegatedPercent: 25 | 50 | 75 | 100) {
     await waitForElementById(this.delegationSummaryAmountId(currencyId));
     await tapById(this.delegationSummaryAmountId(currencyId));
     await tapById(this.delegatedRatioId(currencyId, delegatedPercent));
   }
 
-  @Step("Expect provider in summary")
+  @Step("Expect provider {{{1}}} in summary")
   async expectProvider(currencyId: string, provider: string) {
     jestExpect(await this.delegationSummaryValidator(currencyId)).toContain(provider);
   }
 
-  @Step("Select new provider")
+  @Step("Select new provider {{{1}}}")
   async selectValidator(currencyId: string, provider: string) {
     const ticker = provider.split(" - ")[0];
     await tapById(this.delegationSummaryValidatorId(currencyId));
@@ -79,19 +79,19 @@ export default class StakePage {
     await tapById(this.providerRow(ticker));
   }
 
-  @Step("Verify fees visible in summary")
+  @Step("Verify fees visible in summary {{{0}}}")
   async verifyFeesVisible(currencyId: string) {
     await detoxExpect(getElementById(this.delegationFees(currencyId))).toBeVisible();
   }
 
-  @Step("Get fees displayed in summary")
+  @Step("Get fees displayed in summary {{{0}}}")
   async getDisplayedFees(currencyId: string) {
     const fees = await getTextOfElement(this.delegationFees(currencyId));
     invariant(fees, "Fees empty in summary");
     return fees;
   }
 
-  @Step("Validate the amount entered")
+  @Step("Validate the amount entered {{{0}}}")
   async validateAmount(currencyId: string) {
     await tapById(this.delegationAmountContinueId(currencyId));
     if (currencyId !== Currency.CELO.id) {
@@ -99,14 +99,14 @@ export default class StakePage {
     }
   }
 
-  @Step("Click on continue button in summary")
+  @Step("Click on continue button in summary {{{0}}}")
   async summaryContinue(currencyId: string): Promise<void> {
     const id = this.summaryContinueButtonId(currencyId);
     await waitForElementById(id);
     await tapById(id);
   }
 
-  @Step("Set Celo lock amount")
+  @Step("Set Celo lock amount {{{0}}}")
   async setCeloLockAmount(amount: string) {
     await typeTextById(this.celoLockAmountInput, amount);
   }
@@ -116,7 +116,7 @@ export default class StakePage {
     await tapById(this.celoVoteAmountId);
   }
 
-  @Step("Set CELO vote amount")
+  @Step("Set CELO vote amount {{{0}}}")
   async setCeloVoteAmount(amount: string) {
     await waitForElementById(this.celoVoteAmountInputId);
     await typeTextById(this.celoVoteAmountInputId, amount);

--- a/e2e/mobile/page/trade/swap.page.ts
+++ b/e2e/mobile/page/trade/swap.page.ts
@@ -38,7 +38,7 @@ export default class SwapPage extends CommonPage {
     `${this.operationRow.baseFromAmount}${swapId}`;
   specificOperationAmountToId = (swapId: string) => `${this.operationRow.baseToAmount}${swapId}`;
 
-  @Step("Open swap via deeplink")
+  @Step("Open swap via deeplink {{{0}}}")
   async openViaDeeplink(params?: string) {
     const deeplinkPath = params ? `${this.baseLink}?${params}` : this.baseLink;
     await openDeeplink(deeplinkPath);
@@ -61,7 +61,7 @@ export default class SwapPage extends CommonPage {
     }
   }
 
-  @Step("Check swap operation row details")
+  @Step("Check swap operation row details {{{0}}}")
   async checkSwapOperation(swapId: string, swap: SwapType) {
     await detoxExpect(this.operationRows()).toBeVisible();
     await detoxExpect(this.getSpecificOperation(swapId)).toBeVisible();
@@ -78,7 +78,7 @@ export default class SwapPage extends CommonPage {
     await detoxExpect(getElementById(this.specificOperationAmountToId(swapId))).toBeVisible();
   }
 
-  @Step("Open selected operation by swapId: $0")
+  @Step("Open selected operation by swapId: {{{0}}}")
   async openSelectedOperation(swapId: string) {
     await tapByElement(this.getSpecificOperation(swapId));
   }
@@ -91,7 +91,7 @@ export default class SwapPage extends CommonPage {
     jestExpect(fileExists).toBeTruthy();
   }
 
-  @Step("Check swap history feedback form URL")
+  @Step("Check swap history feedback form URL {{{0}}}")
   async checkSwapHistoryFeedbackFormUrl(expectedUrl: string) {
     await detoxExpect(getElementById(this.swapHistoryFeedbackLink)).toBeVisible();
     const { value, label } = await getAttributesOfElement(this.swapHistoryFeedbackLink);
@@ -103,7 +103,7 @@ export default class SwapPage extends CommonPage {
     }
   }
 
-  @Step("Check contents of exported operations file")
+  @Step("Check contents of exported operations file {{{2}}}")
   async checkExportedFileContents(swap: SwapType, provider: SwapProvider, id: string) {
     const targetFilePath = path.resolve(__dirname, "../../artifacts/ledgerwallet-swap-history.csv");
     const fileContents = await fs.readFile(targetFilePath, "utf-8");
@@ -119,12 +119,12 @@ export default class SwapPage extends CommonPage {
     jestExpect(fileContents).toContain(swap.accountToCredit.address);
   }
 
-  @Step("Verify the amounts and accept swap")
+  @Step("Verify the amounts and accept swap {{{1}}}")
   async verifyAmountsAndAcceptSwap(swap: SwapType, amount: string) {
     await app.speculos.verifyAmountsAndAcceptSwap(swap, amount);
   }
 
-  @Step("Verify amounts and accept swap for different seed")
+  @Step("Verify amounts {{{1}}} and accept swap for different seed")
   async verifyAmountsAndAcceptSwapForDifferentSeed(
     swap: SwapType,
     amount: string,
@@ -133,7 +133,7 @@ export default class SwapPage extends CommonPage {
     await app.speculos.verifyAmountsAndAcceptSwapForDifferentSeed(swap, amount, errorMessage);
   }
 
-  @Step("Verify the amounts and reject swap")
+  @Step("Verify the amounts and reject swap {{{1}}}")
   async verifyAmountsAndRejectSwap(swap: SwapType, amount: string) {
     await app.speculos.verifyAmountsAndRejectSwap(swap, amount);
   }
@@ -164,7 +164,7 @@ export default class SwapPage extends CommonPage {
     }, 60000);
   }
 
-  @Step("Selected provider: $0")
+  @Step("Selected provider: {{{0}}}")
   async logSelectedProvider(providerName: string) {
     jestExpect(providerName).toBeDefined();
   }

--- a/e2e/mobile/page/trade/tezosStake.page.ts
+++ b/e2e/mobile/page/trade/tezosStake.page.ts
@@ -70,7 +70,7 @@ export default class TezosStakePage {
     await waitForElementById(this.awaitingDelegationId);
   }
 
-  @Step("Fill stake amount $0")
+  @Step("Fill stake amount {{{0}}}")
   async fillStakeAmount(amount: string) {
     await waitForElementById(this.stakeAmountInputId);
     await typeTextById(this.stakeAmountInputId, amount);
@@ -96,7 +96,7 @@ export default class TezosStakePage {
     await waitForElementById(this.unstakeStakedBalanceId);
   }
 
-  @Step("Fill unstake amount $0")
+  @Step("Fill unstake amount {{{0}}}")
   async fillUnstakeAmount(amount: string) {
     await waitForElementById(this.unstakeAmountInputId);
     await typeTextById(this.unstakeAmountInputId, amount);

--- a/e2e/mobile/page/trade/undelegate.page.ts
+++ b/e2e/mobile/page/trade/undelegate.page.ts
@@ -20,7 +20,7 @@ export default class UndelegatePage {
     await tapById(this.unstakeActionId);
   }
 
-  @Step("Enter unstake amount")
+  @Step("Enter unstake amount {{{0}}}")
   async enterAmount(amount: string) {
     await waitForElementById(this.amountInputId);
     await typeTextById(this.amountInputId, amount);

--- a/e2e/mobile/page/wallet/assetDetail.page.ts
+++ b/e2e/mobile/page/wallet/assetDetail.page.ts
@@ -96,7 +96,7 @@ export default class AssetDetailPage {
     await tapByIdAndExpectToDisappear(this.coinOptionsFavouriteRowId);
   }
 
-  @Step("Expect Asset Detail page for ticker")
+  @Step("Expect Asset Detail page for ticker {{{0}}}")
   async expectAssetDetailPageForTicker(ticker: string) {
     const scrollViewId = await this.getScrollViewId();
     await scrollToId(this.marketPriceId, scrollViewId, undefined, "up");
@@ -118,7 +118,7 @@ export default class AssetDetailPage {
     return await IsIdVisible(this.scrollViewId, timeout);
   }
 
-  @Step("Check if Asset Detail page for ticker is visible")
+  @Step("Check if Asset Detail page for ticker is visible {{{0}}}")
   async isAssetDetailPageForTickerVisible(ticker: string, timeout = VISIBILITY_PROBE_TIMEOUT) {
     return (
       (await IsIdVisible(this.scrollViewId, timeout)) &&
@@ -135,7 +135,7 @@ export default class AssetDetailPage {
     await detoxExpect(getElementById(this.marketVariationId)).toBeVisible();
   }
 
-  @Step("Expect Asset Detail total crypto balance for ticker")
+  @Step("Expect Asset Detail total crypto balance for ticker {{{0}}}")
   async expectTotalBalanceCryptoForTicker(ticker: string) {
     const scrollViewId = await this.getScrollViewId();
     await scrollToId(this.totalBalanceId, scrollViewId);
@@ -156,7 +156,7 @@ export default class AssetDetailPage {
     await detoxExpect(getElementById(this.transactionsHeaderId)).toBeVisible();
   }
 
-  @Step("Expect holding address details")
+  @Step("Expect holding address details for {{{0.length}}} addresses")
   async expectHoldingAddressDetails(expectedAddresses: HoldingAddressExpectation[]) {
     for (const expectedAddress of expectedAddresses) {
       await this.scrollToAddressItem(expectedAddress.accountId);
@@ -181,7 +181,7 @@ export default class AssetDetailPage {
     }
   }
 
-  @Step("Expect holding address balances to add up to total")
+  @Step("Expect holding address balances to add up to total {{{1}}}")
   async expectHoldingAddressBalancesSumToTotal(accountIds: string[], ticker: string) {
     const scrollViewId = await this.getScrollViewId();
     await scrollToId(this.totalBalanceId, scrollViewId);
@@ -205,13 +205,13 @@ export default class AssetDetailPage {
     return { holdingBalance, totalBalance };
   }
 
-  @Step("Open holding address")
+  @Step("Open holding address {{{0}}}")
   async openHoldingAddress(accountId: string) {
     await this.scrollToAddressItem(accountId);
     await tapById(this.addressItemNameId(accountId));
   }
 
-  @Step("Get visible Asset Detail transaction count for ticker")
+  @Step("Get visible Asset Detail transaction count for ticker {{{0}}}")
   async getVisibleTransactionCountForTicker(ticker: string) {
     await this.scrollToTransactions();
     const scrollViewId = await this.getScrollViewId();
@@ -227,7 +227,7 @@ export default class AssetDetailPage {
     return visibleOperationsCount;
   }
 
-  @Step("Open first Asset Detail transaction")
+  @Step("Open first Asset Detail transaction {{{0}}}")
   async openFirstTransaction(ticker: string) {
     await this.scrollToTransactions();
     const scrollViewId = await this.getScrollViewId();
@@ -249,7 +249,7 @@ export default class AssetDetailPage {
     await this.scrollToAddressesSection();
   }
 
-  @Step("Get address item name at index")
+  @Step("Get address item name at index {{{0}}}")
   async getAddressItemName(index = 0) {
     return await getTextOfElement(/asset-detail-address-item-name-.*/, index);
   }

--- a/e2e/mobile/page/wallet/mainNavigation.page.ts
+++ b/e2e/mobile/page/wallet/mainNavigation.page.ts
@@ -52,7 +52,7 @@ export default class MainNavigationPage {
   // Wallet 4.0 Tab Actions
   // =====================
 
-  @Step("Tap W40 tab")
+  @Step("Tap W40 tab {{{0}}}")
   async tapWallet40Tab(tabName: Wallet40TabName) {
     await this.wallet40Tab(tabName).tap();
   }

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -108,12 +108,12 @@ export default class PortfolioPage {
     await waitForElementById(this.connectButtonId);
   }
 
-  @Step("Expect asset row to be visible")
+  @Step("Expect asset row to be visible {{{0}}}")
   async expectAssetRowToBeVisible(asset: string) {
     await detoxExpect(getElementById(this.assetItemBalanceId(asset))).toBeVisible();
   }
 
-  @Step("Expect asset row to have the correct counter value")
+  @Step("Expect asset row {{{0}}} to have the correct counter value {{{1}}}")
   async expectAssetRowCounterValue(asset: string, counterValue: string) {
     if (await isAggregatedAssetsEnabled()) {
       await scrollToId(this.assetItemCountervalueId(asset), this.accountsListView);
@@ -131,7 +131,7 @@ export default class PortfolioPage {
     await detoxExpect(getElementById(this.analyticsBalanceAmountId)).toBeVisible();
   }
 
-  @Step("Expect total balance value")
+  @Step("Expect total balance value {{{0}}}")
   async expectTotalBalanceCounterValue(counterValue: string) {
     const label = await getLabelOfElement(this.portfolioBalanceAmount);
     jestExpect(label).toContain(counterValue);
@@ -152,7 +152,7 @@ export default class PortfolioPage {
     await detoxExpect(getElementById(this.operationRowCounterValue)).toBeVisible();
   }
 
-  @Step("Expect operation to contain counter value")
+  @Step("Expect operation to contain counter value {{{0}}}")
   async expectOperationCounterValue(counterValue: string) {
     if (await isAggregatedAssetsEnabled()) {
       await app.mainNavigation.tapTopBarTransactionHistory();
@@ -193,7 +193,7 @@ export default class PortfolioPage {
     await waitForElementById(this.accountsListView, 10000);
   }
 
-  @Step("Go to asset's accounts from portfolio")
+  @Step("Go to {{{0}}} accounts from portfolio")
   async goToAccounts(currencyName: string, currencyId?: string) {
     await waitForElementById(this.accountsListView, 10000);
     if (await isAggregatedAssetsEnabled()) {
@@ -255,12 +255,12 @@ export default class PortfolioPage {
     return await countElementsById(app.common.accountItemNameRegExp);
   }
 
-  @Step("Compare Accounts Count")
+  @Step("Compare Accounts Count {{{0}}} and {{{1}}}")
   async compareAccountsCount(count1: number, count2: number) {
     jestExpect(count1).toBe(count2);
   }
 
-  @Step("Navigate asset Page")
+  @Step("Navigate asset Page {{{0}}}")
   async goToSpecificAsset(currencyName: string) {
     if (!(await isAssetSectionEnabled())) {
       await scrollToId(this.assetsListId, this.accountsListView);
@@ -283,12 +283,12 @@ export default class PortfolioPage {
     jestExpect(await countElements(getElementsById(this.operationRowDate))).toBeGreaterThan(3);
   }
 
-  @Step("Click on selected last operation")
+  @Step("Click on selected last operation {{{0}}} for {{{1}}}")
   async selectAndClickOnLastOperation(operationType: string | RegExp, accountName?: string) {
     await tapByElement(this.operationByType(operationType, accountName).atIndex(0));
   }
 
-  @Step("Tap on tab selector")
+  @Step("Tap on tab selector {{{0}}}")
   async tapTabSelector(id: "Accounts" | "Assets") {
     if (await isAssetSectionEnabled()) {
       return;
@@ -296,7 +296,7 @@ export default class PortfolioPage {
     await tapByElement(this.tabSelector(id));
   }
 
-  @Step("Tap on $0 tab selector")
+  @Step("Tap on {{{0}}} tab selector")
   async tapWalletTabSelector(id: "Wallet" | "Market") {
     await tapByElement(this.walletTabSelector(id));
   }
@@ -355,7 +355,7 @@ export default class PortfolioPage {
     await getElementById(this.bottomSheetCloseButton).swipe("down");
   }
 
-  @Step("Tap on market banner tile")
+  @Step("Tap on market banner tile {{{0}}}")
   async tapMarketBannerTile(index: number) {
     await detoxExpect(getElementById(`${this.marketBannerTileBase}${index}`)).toBeVisible();
     await tapById(`${this.marketBannerTileBase}${index}`);
@@ -473,12 +473,12 @@ export default class PortfolioPage {
     await detoxExpect(getElementById(lastItemId)).toBeVisible();
   }
 
-  @Step("Check cryptos list section is visible")
+  @Step("Check cryptos list section is visible {{{0}}}")
   async checkCryptosListSectionVisible(itemCount: number, isEmptyPortfolio = false) {
     await this.checkSectionVisible(this.portfolioCryptosListId, itemCount, isEmptyPortfolio);
   }
 
-  @Step("Check stablecoins list section is visible")
+  @Step("Check stablecoins list section is visible {{{0}}}")
   async checkStablecoinsListSectionVisible(itemCount: number, isEmptyPortfolio = false) {
     await this.checkSectionVisible(this.portfolioStablecoinsListId, itemCount, isEmptyPortfolio);
   }
@@ -489,7 +489,7 @@ export default class PortfolioPage {
     await detoxExpect(getElementById(this.addAccountCta)).toBeVisible();
   }
 
-  @Step("Check total asset item count on page")
+  @Step("Check total asset item count on page {{{0}}}")
   async checkTotalAssetItemCount(expected: number) {
     const count = await countElements(getElementsById(this.assetItemRegExp));
     jestExpect(count).toBe(expected);
@@ -500,12 +500,12 @@ export default class PortfolioPage {
     jestExpect(count).toBe(expected);
   }
 
-  @Step("Check cryptos section asset item count")
+  @Step("Check cryptos section asset item count {{{0}}}")
   async checkCryptosSectionAssetItemCount(expected: number) {
     await this.checkSectionAssetItemCount(this.portfolioCryptosListId, expected);
   }
 
-  @Step("Check stablecoins section asset item count")
+  @Step("Check stablecoins section asset item count {{{0}}}")
   async checkStablecoinsSectionAssetItemCount(expected: number) {
     await this.checkSectionAssetItemCount(this.portfolioStablecoinsListId, expected);
   }
@@ -519,12 +519,12 @@ export default class PortfolioPage {
     return currencyName;
   }
 
-  @Step("Check asset is visible on page")
+  @Step("Check asset is visible on page {{{0}}}")
   async checkAssetVisible(currencyName: string) {
     await detoxExpect(getElementById(`assetItem-${currencyName}`)).toExist();
   }
 
-  @Step("Check aggregated asset row is visible")
+  @Step("Check aggregated asset row {{{0}}} is visible")
   async checkAggregatedAssetRowVisible(currencyName: string, scrollViewId?: string) {
     if (scrollViewId) {
       await scrollToId(this.assetItemId(currencyName), scrollViewId);
@@ -533,12 +533,12 @@ export default class PortfolioPage {
     await detoxExpect(getElementById(this.assetItemId(currencyName))).toBeVisible();
   }
 
-  @Step("Get aggregated asset row count")
+  @Step("Get aggregated asset row count {{{0}}}")
   async getAggregatedAssetRowCount(currencyName: string) {
     return await countElements(getElementsById(this.assetItemExactRegExp(currencyName)));
   }
 
-  @Step("Check asset countervalue is visible")
+  @Step("Check asset countervalue {{{0}}} is visible")
   async checkAssetCountervalueVisible(currencyName: string, scrollViewId?: string) {
     if (scrollViewId) {
       await scrollToId(this.assetItemId(currencyName), scrollViewId);
@@ -547,7 +547,7 @@ export default class PortfolioPage {
     await detoxExpect(getElementById(this.assetItemCountervalueId(currencyName))).toBeVisible();
   }
 
-  @Step("Open Wallet 4.0 asset detail")
+  @Step("Open Wallet 4.0 asset detail {{{0}}}")
   async openAssetDetailW40(currencyName: string, scrollViewId?: string) {
     if (scrollViewId) {
       await scrollToId(this.assetItemId(currencyName), scrollViewId);

--- a/e2e/mobile/page/wallet/topBarSearch.page.ts
+++ b/e2e/mobile/page/wallet/topBarSearch.page.ts
@@ -49,7 +49,7 @@ export default class TopBarSearchPage {
     await tapById(this.stocksSectionHeaderId);
   }
 
-  @Step("Search for $0")
+  @Step("Search for {{{0}}}")
   async searchFor(query: string) {
     await typeTextById(this.searchInputId, query, false);
     await waitForElementById(this.searchResultsId, undefined, {
@@ -62,7 +62,7 @@ export default class TopBarSearchPage {
     await clearTextByElement(getElementById(this.searchInputId));
   }
 
-  @Step("Expect first search result to be $0")
+  @Step("Expect first search result to be {{{0}}}")
   async expectFirstResult(currencyId: string) {
     const expectedId = this.marketItemId(currencyId);
     await waitForElementById(expectedId);

--- a/e2e/mobile/utils/fileUtils.ts
+++ b/e2e/mobile/utils/fileUtils.ts
@@ -3,18 +3,18 @@ import * as fs from "fs/promises";
 import { sanitizeError } from "@ledgerhq/live-e2e-shared/index";
 
 export class FileUtils {
-  @Step("get app.json size")
+  @Step("get app.json size {{{0}}}")
   static async getAppJsonSize(userdataFile: string) {
     const fileStats = await fs.stat(userdataFile);
     return fileStats.size;
   }
 
-  @Step("Compare 2 app.json files")
+  @Step("Compare 2 app.json files ({{{0}}} vs {{{1}}})")
   static async compareAppJsonSize(appJson1: number, appJson2: number) {
     jestExpect(appJson1).not.toEqual(appJson2);
   }
 
-  @Step("Wait for file to exist after clicking download")
+  @Step("Wait for file to exist after clicking download {{{0}}}")
   static async waitForFileToExist(filePath: string, timeout: number = 5000): Promise<boolean> {
     const startTime = Date.now();
     while (Date.now() - startTime < timeout) {
@@ -30,7 +30,7 @@ export class FileUtils {
     return false;
   }
 
-  @Step("Read file as string")
+  @Step("Read file as string {{{0}}}")
   static async readFileAsString(filePath: string): Promise<string> {
     try {
       const base64Content = await fs.readFile(filePath, "utf8");


### PR DESCRIPTION
## Context

Mobile Allure steps hid the values they were called with, in three different ways.

**46 titles used `$0` / `$1`, which never interpolated** — the report shows the literal characters:

> Fill crypto amount: **$0**
> Select specific provider **$0**

**198 titles named no parameter at all**, so the report is full of steps you cannot tell apart:

> Select network · Select network · Set amount and continue · Expect recipient in summary

**Values that did render were HTML-escaped**, so an account named `Bob & Co's` arrived as `Bob &amp; Co&#x27;s`.

## Root cause

`jest-allure2-reporter` compiles the step title with **Handlebars**, over a context keyed by parameter index — `dist/runtime/modules/StepsDecorator.js`:

```js
const formatName = this.context.handlebars.compile(nameFormat);
// context: { "0": arg0, "1": arg1, ... }
```

So the placeholder that resolves is `{{0}}`, and `{{{0}}}` is the form that does not escape. `$0` is the allure-js / Playwright spelling used by the desktop suite, and has never worked on mobile. Verified against a real context:

| title | renders as |
| --- | --- |
| `Rename to $0` | `Rename to $0` |
| `Rename to {{0}}` | `Rename to Bob &amp; Co&#x27;s` |
| `Rename to {{{0}}}` | `Rename to Bob & Co's` |

The argument values were never *lost* — `StepsDecorator` also calls `runtime.parameter(name, value)` for every argument, so they appear in each step's parameter table. This puts them in the title, which is what you scan when triaging a failure.

## Change

260 placeholders across 30 files, all in the raw `{{{N}}}` form. Report text only — no assertion, locator, wait or flow is touched.

Object parameters are addressed by **property path** rather than by giving the shared fixtures in `live-e2e-shared` a `toString`:

```ts
@Step("Select currency to debit {{{0.accountName}}}")               // Account
@Step("Open asset page {{{0.name}}}")                                // Currency
@Step("Choose country if not selected {{{0.locale}}}")               // Fiat
@Step("Expect holding address details for {{{0.length}}} addresses") // array
```

It keeps display concerns out of the fixtures and says at the call site which field the report shows. `TokenAccount extends Account`, so `accountName` covers `AccountType` too. Both approaches work — Handlebars stringifies with `'' + value`, so a class `toString()` would also be picked up — the property path just has no blast radius on the desktop suite.

The commit also clears the **four pre-existing SonarCloud smells** in the touched files, which the quality gate counts against this PR even though the lines are untouched by it: three `replace(/…/g)` calls become `replaceAll`, and `usdAmounts[usdAmounts.length - 1]` becomes `at(-1)` hoisted into the guard that was already there (`length === 0` → `undefined`, identical semantics — a bare `.at(-1)` would not typecheck, since it feeds a `string` parameter).

## Deliberately left alone

| Case | Count | Why |
| --- | --- | --- |
| Password parameters | 4 | credentials do not belong in a report title |
| `timeout` / `options` only | 14 | noise, not identity |
| Booleans (`quotesVisible`, `isSentTransaction`) | 2 | `Verify swap CTA banner displayed true` reads worse than the original |
| `providersWhitelist` on `Get minimum amount for swap` | 1 | the subject is the two accounts, not the whitelist |

## Verification

- **244/244** titles compile under Handlebars and render every value, including nested property paths; 0 leftover `$N`, 0 unrendered or malformed braces, 0 `&amp;`/`&#x27;` in output — checked with a value containing `& ' " < >`.
- Two sweeps over every placeholder come back empty: none resolves to an object without a property path, and none skips a literal-union, regex or numeric argument that identifies the step. Both classes were found by review first — see the resolved threads.
- No placeholder index exceeds its method's parameter count, checked against each signature.
- Every changed line is an `@Step` line, apart from the five Sonar lines.
- ~35 titles were hand-worded rather than mechanically appended, where an append would name the wrong value (`Expect the account name at index` → `Expect the account name {{{0}}} at index {{{1}}}`) or read badly (`Tap buy/sell cta` → `Tap {{{1}}} cta for {{{0}}}`). One pre-existing single-brace pseudo placeholder was fixed too (`Set delegation amount to {amount}`).
- The 5 non-step `$N` occurrences in `e2e/mobile` are untouched: a literal `$0.01` in a comment, two test passwords, an `awk` field, a regex backreference.
- `pnpm typecheck` clean for the Sonar change; `oxfmt --check` clean on all 30 files; longest edited line 88 chars.
- Proven end-to-end on `B2CQA-6238`: after switching the Contacts page objects to a placeholder, an Android run wrote real values into `artifacts/*-result.json` — `Add the contact O’Neil-Zoé 6fb5cf`, `Expect contact row … to be named …`.

A malformed template throws at module load, so any spec importing a touched page object would fail immediately — which is what the CI run checks.

## Note

No Jira ticket — happy to create one if you want the convention respected strictly.