### PR TITLE
[LWDM] fix(coin-zcash): memo missing in operation details after shielded send

### DIFF
--- a/.changeset/LIVE-36354-zcash-memo.md
+++ b/.changeset/LIVE-36354-zcash-memo.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-zcash": patch
+"ledger-live-desktop": patch
+---
+
+Fix missing memo in Zcash shielded operation details. After a shielded send with a memo, the memo is now persisted in the operation extra and displayed in Transaction details.

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/operationDetails.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/operationDetails.test.tsx
@@ -71,6 +71,44 @@ describe("Zcash operationDetails", () => {
 
       expect(container.firstChild).toBeNull();
     });
+
+    it("should render the Memo section when operation.extra.memo is set", () => {
+      const operation = {
+        ...createOperation("SHIELDED_TX_IRONWOOD_OUT"),
+        extra: { zcashShielded: true, memo: "Invoice #42" },
+      } as never;
+
+      render(<OperationDetailsExtra account={zcashAccount} operation={operation} />);
+
+      expect(screen.getByText("Memo")).toBeInTheDocument();
+      expect(screen.getByText("Invoice #42")).toBeInTheDocument();
+    });
+
+    // The optimistic operation emitted right after signing is a plain OUT, which has
+    // no transaction-type label: the memo section must render on its own.
+    it("should render the Memo section alone for an OUT operation", () => {
+      const operation = {
+        ...createOperation("OUT"),
+        extra: { zcashShielded: true, memo: "Invoice #43" },
+      } as never;
+
+      render(<OperationDetailsExtra account={zcashAccount} operation={operation} />);
+
+      expect(screen.getByText("Memo")).toBeInTheDocument();
+      expect(screen.getByText("Invoice #43")).toBeInTheDocument();
+      expect(screen.queryByText("Transaction type")).not.toBeInTheDocument();
+    });
+
+    it("should not render a Memo section when extra.memo is absent", () => {
+      const operation = {
+        ...createOperation("SHIELDED_TX_IRONWOOD_OUT"),
+        extra: { zcashShielded: true },
+      } as never;
+
+      render(<OperationDetailsExtra account={zcashAccount} operation={operation} />);
+
+      expect(screen.queryByText("Memo")).not.toBeInTheDocument();
+    });
   });
 });
 

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/operationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/operationDetails.tsx
@@ -8,6 +8,7 @@ import {
 } from "~/renderer/drawers/OperationDetails/styledComponents";
 import Box from "~/renderer/components/Box";
 import Discreet from "~/renderer/components/Discreet";
+import Ellipsis from "~/renderer/components/Ellipsis";
 import {
   Address,
   Cell,
@@ -79,19 +80,37 @@ const OperationDetailsExtra = ({
   const { type } = operation;
   const i18nKey = getI18nKey(type);
 
-  if (account.currency.id !== "zcash" || !i18nKey) {
+  if (account.currency.id !== "zcash") {
     return null;
   }
 
+  const memo = (operation.extra as { memo?: string } | undefined)?.memo;
+
+  if (!i18nKey && !memo) return null;
+
   return (
-    <OpDetailsSection>
-      <OpDetailsTitle>
-        <Trans i18nKey={"zcash.operationDetails.txType"} />
-      </OpDetailsTitle>
-      <OpDetailsData>
-        <Trans i18nKey={i18nKey} />
-      </OpDetailsData>
-    </OpDetailsSection>
+    <>
+      {i18nKey && (
+        <OpDetailsSection>
+          <OpDetailsTitle>
+            <Trans i18nKey={"zcash.operationDetails.txType"} />
+          </OpDetailsTitle>
+          <OpDetailsData>
+            <Trans i18nKey={i18nKey} />
+          </OpDetailsData>
+        </OpDetailsSection>
+      )}
+      {memo && (
+        <OpDetailsSection>
+          <OpDetailsTitle>
+            <Trans i18nKey={"zcash.operationDetails.memo"} />
+          </OpDetailsTitle>
+          <OpDetailsData>
+            <Ellipsis>{memo}</Ellipsis>
+          </OpDetailsData>
+        </OpDetailsSection>
+      )}
+    </>
   );
 };
 

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9142,7 +9142,8 @@
       "transparentTx": "Transparent",
       "shieldedSaplingTx": "🛡 Private (Sapling)",
       "shieldedOrchardTx": "🛡 Private (Orchard)",
-      "shieldedIronwoodTx": "🛡 Private (Ironwood)"
+      "shieldedIronwoodTx": "🛡 Private (Ironwood)",
+      "memo": "Memo"
     }
   },
   "aleo": {

--- a/libs/coin-modules/coin-zcash/src/bridge/operations.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/operations.test.ts
@@ -688,6 +688,92 @@ describe("convertShieldedTransactionsToOperations", () => {
     expect(op.value).toEqual(new BigNumber(515_000));
   });
 
+  // ── memo extraction ───────────────────────────────────────────────────
+
+  it("reads the memo from the outgoing note of a shielded send", () => {
+    const tx: ShieldedTransaction = {
+      id: "tx-memo-out",
+      hex: "00",
+      blockHeight: 200,
+      blockHash: "hash-memo",
+      timestamp: 1_700_000_000,
+      fee: new BigNumber(100),
+      decryptedData: {
+        orchard_outputs: [],
+        sapling_outputs: [],
+        ironwood_outputs: [
+          { amount: new BigNumber(5_000), memo: "Hello receiver", transfer_type: "outgoing" },
+          { amount: new BigNumber(1_000), memo: "", transfer_type: "internal" },
+        ],
+      },
+    };
+    const [op] = convertShieldedTransactionsToOperations([tx], "acc-1");
+    expect((op.extra as { memo?: string }).memo).toBe("Hello receiver");
+  });
+
+  it("reads the memo from the incoming note of a shielded receive", () => {
+    const tx: ShieldedTransaction = {
+      id: "tx-memo-in",
+      hex: "00",
+      blockHeight: 201,
+      blockHash: "hash-memo-in",
+      timestamp: 1_700_000_000,
+      fee: new BigNumber(100),
+      decryptedData: {
+        orchard_outputs: [],
+        sapling_outputs: [],
+        ironwood_outputs: [
+          { amount: new BigNumber(8_000), memo: "Payment for invoice", transfer_type: "incoming" },
+        ],
+      },
+    };
+    const [op] = convertShieldedTransactionsToOperations([tx], "acc-1");
+    expect((op.extra as { memo?: string }).memo).toBe("Payment for invoice");
+  });
+
+  it("picks the correct note's memo when incoming and outgoing notes are both present", () => {
+    const tx: ShieldedTransaction = {
+      id: "tx-mixed-memo",
+      hex: "00",
+      blockHeight: 202,
+      blockHash: "hash-mixed-memo",
+      timestamp: 1_700_000_000,
+      fee: new BigNumber(100),
+      decryptedData: {
+        orchard_outputs: [],
+        sapling_outputs: [],
+        // The incoming note comes first on purpose: picking the first non-empty memo
+        // instead of the one matching the operation direction would fail this test.
+        ironwood_outputs: [
+          { amount: new BigNumber(1_000), memo: "incoming memo", transfer_type: "incoming" },
+          { amount: new BigNumber(3_000), memo: "outgoing memo", transfer_type: "outgoing" },
+          { amount: new BigNumber(500), memo: "change note", transfer_type: "internal" },
+        ],
+      },
+    };
+    const [op] = convertShieldedTransactionsToOperations([tx], "acc-1");
+    expect(op.type).toBe("SHIELDED_TX_IRONWOOD_OUT");
+    expect((op.extra as { memo?: string }).memo).toBe("outgoing memo");
+  });
+
+  it("produces no memo field when the note memo is empty", () => {
+    const tx: ShieldedTransaction = {
+      id: "tx-no-memo",
+      hex: "00",
+      blockHeight: 203,
+      blockHash: "hash-no-memo",
+      timestamp: 1_700_000_000,
+      fee: new BigNumber(100),
+      decryptedData: {
+        orchard_outputs: [],
+        sapling_outputs: [],
+        ironwood_outputs: [{ amount: new BigNumber(2_000), memo: "", transfer_type: "outgoing" }],
+      },
+    };
+    const [op] = convertShieldedTransactionsToOperations([tx], "acc-1");
+    expect((op.extra as { memo?: string }).memo).toBeUndefined();
+  });
+
   // The newest pool present labels the operation, but every pool that moved funds
   // is counted: the label answers "which protocol", not "how much".
   it("op.value for a mixed-pool outgoing tx counts the notes of every pool", () => {

--- a/libs/coin-modules/coin-zcash/src/bridge/operations.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/operations.ts
@@ -2,7 +2,7 @@ import { BigNumber } from "bignumber.js";
 import type { OperationType } from "@ledgerhq/types-live";
 import type { DecryptedOutput, ShieldedTransaction, SpendableNote } from "../network/types";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
-import type { BtcOperation } from "../types/bridge";
+import type { BtcOperation, ZcashOperationExtra } from "../types/bridge";
 
 /**
  * Value the transaction moved out of the shielded pools through its transparent
@@ -254,6 +254,14 @@ export function convertShieldedTransactionsToOperations(
     }
 
     const operationType = toOperationType(txType);
+
+    let memo: string | undefined;
+    if (txType.endsWith("_OUT")) {
+      memo = allNotes.find(n => n.transfer_type === "outgoing" && n.memo)?.memo;
+    } else if (txType.endsWith("_IN")) {
+      memo = allNotes.find(n => n.transfer_type === "incoming" && n.memo)?.memo;
+    }
+
     const operation: BtcOperation = {
       id: encodeOperationId(accountId, tx.id, operationType),
       hash: tx.id,
@@ -266,7 +274,7 @@ export function convertShieldedTransactionsToOperations(
       date: new Date(tx.timestamp * 1000), // zcash shielded transaction timestamps are Unix seconds.
       value,
       fee,
-      extra: {},
+      extra: (memo ? { memo } : {}) as ZcashOperationExtra,
       transactionSequenceNumber: new BigNumber(tx.blockHeight),
       subOperations: [],
       nftOperations: [],

--- a/libs/coin-modules/coin-zcash/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/signOperation.test.ts
@@ -521,6 +521,48 @@ describe("bridge/signOperation", () => {
     ).rejects.toThrow(/signPcztTransaction/);
   });
 
+  // ── memo on operation.extra ───────────────────────────────────────────
+
+  describe("memo on operation.extra", () => {
+    it("includes memo in extra when the transaction carries one", async () => {
+      const account = makeAccount();
+      const tx = makeTx("shielded", { memo: "Hello shielded receiver" });
+      const signOp = buildSignOperation(makeSignerContext());
+
+      const events = await collectEvents(signOp, {
+        account,
+        deviceId: "device-1",
+        transaction: tx,
+      } as never);
+
+      const signedEvent = events.find(e => e.type === "signed");
+      expect(signedEvent?.type).toBe("signed");
+      if (signedEvent?.type === "signed") {
+        const extra = signedEvent.signedOperation.operation.extra as Record<string, unknown>;
+        expect(extra.memo).toBe("Hello shielded receiver");
+      }
+    });
+
+    it("omits memo from extra when the transaction has none", async () => {
+      const account = makeAccount();
+      const tx = makeTx("shielded"); // no memo field
+      const signOp = buildSignOperation(makeSignerContext());
+
+      const events = await collectEvents(signOp, {
+        account,
+        deviceId: "device-1",
+        transaction: tx,
+      } as never);
+
+      const signedEvent = events.find(e => e.type === "signed");
+      expect(signedEvent?.type).toBe("signed");
+      if (signedEvent?.type === "signed") {
+        const extra = signedEvent.signedOperation.operation.extra as Record<string, unknown>;
+        expect(extra).not.toHaveProperty("memo");
+      }
+    });
+  });
+
   describe("shieldedNullifiers on operation.extra", () => {
     beforeEach(() => {
       _resetReservationsForTest();

--- a/libs/coin-modules/coin-zcash/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/signOperation.ts
@@ -225,6 +225,7 @@ export const buildSignOperation =
               inputs: inputRefs.map(r => `${r.hash}-${r.outputIndex}`),
               inputRefs,
             }),
+            ...(transaction.memo && { memo: transaction.memo }),
           } satisfies ZcashOperationExtra,
         };
 

--- a/libs/coin-modules/coin-zcash/src/bridge/sync.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/sync.test.ts
@@ -6,7 +6,7 @@ import {
   getSessionReservedNullifiers,
   _resetReservationsForTest,
 } from "./note-reservation";
-import type { ZcashAccount } from "../types/bridge";
+import type { ZcashAccount, ZcashOperationExtra } from "../types/bridge";
 import type { ShieldedSyncResult, ShieldedTransaction } from "../network/types";
 import type { BtcOperation } from "../types/bridge";
 
@@ -403,6 +403,34 @@ describe("postSync", () => {
     const synced = postSync(account([], []), account([], [optimistic]));
 
     expect(synced.pendingOperations).toEqual([optimistic]);
+  });
+
+  // ── memo propagation ─────────────────────────────────────────────────
+
+  it("copies the optimistic memo to a confirmed operation that has none", () => {
+    const confirmed = operation({ extra: {} as ZcashOperationExtra });
+    const optimistic = operation({
+      id: "op-pending",
+      extra: { zcashShielded: true, memo: "shielded memo" } as ZcashOperationExtra,
+    });
+
+    const synced = postSync(account([], []), account([confirmed], [optimistic]));
+
+    expect((synced.operations[0].extra as ZcashOperationExtra).memo).toBe("shielded memo");
+  });
+
+  it("preserves a memo already present on the confirmed operation", () => {
+    const confirmed = operation({
+      extra: { zcashShielded: true, memo: "decoded by LWD" } as ZcashOperationExtra,
+    });
+    const optimistic = operation({
+      id: "op-pending",
+      extra: { zcashShielded: true, memo: "signed memo" } as ZcashOperationExtra,
+    });
+
+    const synced = postSync(account([], []), account([confirmed], [optimistic]));
+
+    expect((synced.operations[0].extra as ZcashOperationExtra).memo).toBe("decoded by LWD");
   });
 
   // The notes a shielded send spends are released on the same evidence that

--- a/libs/coin-modules/coin-zcash/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/sync.ts
@@ -30,7 +30,12 @@ import {
   isNativeSegwitDerivationMode,
   isTaprootDerivationMode,
 } from "@ledgerhq/ledger-wallet-framework/derivation";
-import type { BitcoinOutput, BtcOperation, ZcashAccount } from "../types/bridge";
+import type {
+  BitcoinOutput,
+  BtcOperation,
+  ZcashAccount,
+  ZcashOperationExtra,
+} from "../types/bridge";
 import type { SignerContext } from "../types/signer";
 import type { ShieldedSyncResult, ShieldedTransaction, ZcashPrivateInfo } from "../network/types";
 import { ZCASH_SHIELDED_TX_TYPES } from "../network/types";
@@ -1062,8 +1067,18 @@ function reconcileConfirmedPendingOperations(account: ZcashAccount): ZcashAccoun
     const optimistic = pendingByHash.get(op.hash);
     // An incoming operation shares its hash with the send that produced it, but
     // it is not the operation that paid the entered address.
-    if (!optimistic?.recipients.length || op.type.endsWith("IN")) return op;
-    return { ...op, recipients: optimistic.recipients };
+    if (!optimistic || op.type.endsWith("IN")) return op;
+    const patch: Partial<BtcOperation> = {};
+    if (optimistic.recipients.length) patch.recipients = optimistic.recipients;
+    const optimisticMemo = (optimistic.extra as ZcashOperationExtra | undefined)?.memo;
+    if (optimisticMemo && !(op.extra as ZcashOperationExtra | undefined)?.memo) {
+      const newExtra: ZcashOperationExtra = {
+        ...(op.extra as ZcashOperationExtra | undefined),
+        memo: optimisticMemo,
+      };
+      patch.extra = newExtra;
+    }
+    return Object.keys(patch).length ? { ...op, ...patch } : op;
   });
 
   // Only the optimistic operations that now have a confirmed counterpart are

--- a/libs/coin-modules/coin-zcash/src/types/bridge.ts
+++ b/libs/coin-modules/coin-zcash/src/types/bridge.ts
@@ -77,6 +77,8 @@ export type ZcashOperationExtra = BtcOperationExtra & {
    * Mirrors the transparent inputs/inputRefs fields for shielded sends.
    */
   shieldedNullifiers?: string[];
+  /** Memo attached to the shielded output, decoded from the note. */
+  memo?: string;
 };
 
 export type BtcOperation = Operation<BtcOperationExtra>;


### PR DESCRIPTION
### 📝 Description

After a shielded send (t→z or z→z) with a memo, the memo was correctly confirmed on the device and embedded in the transaction, but it never appeared in the Transaction details panel after confirmation.

**Root cause:** `convertShieldedTransactionsToOperations` built the confirmed operation with `extra: {}`, discarding the `memo` field present on every `DecryptedOutput`. Similarly, the optimistic operation created at signing time did not carry `transaction.memo` forward.

**Fix:**
- `types/bridge.ts` — adds `memo?: string` to `ZcashOperationExtra`
- `bridge/operations.ts` — reads memo from the relevant decrypted note (`outgoing` for a send, `incoming` for a receive) and stores it in `extra.memo`
- `bridge/signOperation.ts` — carries `transaction.memo` into the optimistic operation's `extra`, so the memo is visible immediately after signing (before the next sync)
- `bridge/sync.ts` — `reconcileConfirmedPendingOperations` propagates `extra.memo` from the optimistic op to the confirmed one as a fallback
- `operationDetails.tsx` — renders a **Memo** section in the desktop transaction details panel when `extra.memo` is set

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36354](https://ledgerhq.atlassian.net/browse/LIVE-36354)

[LIVE-36354]: https://ledgerhq.atlassian.net/browse/LIVE-36354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ