### PR TITLE
[LWDM] feat(send): add network filtered contact selection to the recipient step

### DIFF
--- a/.changeset/six-cycles-watch.md
+++ b/.changeset/six-cycles-watch.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+feat(send): add network-filtered contact selection to the Send recipient step on desktop and mobile

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -94,6 +94,7 @@
     "@features/flow-contacts-add-address": "workspace:^",
     "@features/flow-contacts-add-contact": "workspace:^",
     "@features/flow-contacts-introduction": "workspace:^",
+    "@features/flow-contacts-list": "workspace:^",
     "@features/flow-fear-and-greed": "workspace:^",
     "@features/flow-large-screen-upsell": "workspace:^",
     "@features/flow-pay-card-auth": "workspace:^",

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
@@ -2,6 +2,7 @@ import BigNumber from "bignumber.js";
 import { NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import { bitcoinPickingStrategy } from "@ledgerhq/live-common/families/bitcoin/types";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import { mockContact, mockContactAddress } from "@domain/entity-contact/schema.mock";
 import {
   createBitcoinAccount,
   createEthereumAccount,
@@ -18,6 +19,7 @@ import {
   waitFor,
   setMockBridgeRecipientValidation,
   setMockScannedCode,
+  setMockContacts,
   setMockStatus,
   setMockStatusResolver,
   setMockTransaction,
@@ -52,6 +54,42 @@ describe("Send Flow Integration", () => {
 
       expect(await screen.findByTestId("send-recipient-input")).toBeVisible();
       expect(screen.queryByTestId("send-amount-step")).not.toBeInTheDocument();
+    });
+
+    it("shows only contacts with addresses on the recipient network and advances directly for one address", async () => {
+      setMockContacts([
+        mockContact({
+          id: "contact-vincent",
+          name: "Vincent",
+          addresses: [
+            mockContactAddress({
+              id: "address-vincent-eth",
+              currencyId: "ethereum",
+              label: "Ethereum Main",
+              address: VALID_EVM_RECIPIENT,
+            }),
+          ],
+        }),
+        mockContact({
+          id: "contact-solana",
+          name: "Solana contact",
+          addresses: [
+            mockContactAddress({
+              id: "address-solana",
+              currencyId: "solana",
+              label: "Solana",
+              address: "SolanaAddress123",
+            }),
+          ],
+        }),
+      ]);
+      const { user } = renderSendFlow(ethereumAccount);
+
+      expect(await screen.findByTestId("contacts-compact-row-contact-vincent")).toBeVisible();
+      expect(screen.queryByText("Solana contact")).not.toBeInTheDocument();
+
+      await user.click(screen.getByTestId("contacts-compact-row-contact-vincent"));
+      expect(await screen.findByTestId("send-amount-step")).toBeVisible();
     });
 
     it("should show the collapsable security card collapsed by default and expand on click", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/__mocks__/sendFlowTestUtils.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/__mocks__/sendFlowTestUtils.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from "tests/testSetup";
 import BigNumber from "bignumber.js";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import type { Contact } from "@domain/entity-contact";
 import type { Account } from "@ledgerhq/types-live";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import { SendWorkflow } from "../index";
@@ -23,6 +24,8 @@ export type MockTransactionStatus = {
 let mockBridgeRecipientValidation = { errors: {}, warnings: {}, isLoading: false };
 let mockDeviceActionResult: unknown = null;
 let mockScannedCode = "";
+let mockContacts: readonly Contact[] = [];
+let mockContactsFeatureEnabled = false;
 
 const mockSetTransaction = jest.fn();
 const mockUpdateTransaction = jest.fn();
@@ -139,12 +142,18 @@ export const setMockScannedCode = (code: string) => {
   mockScannedCode = code;
 };
 
+export const setMockContacts = (contacts: readonly Contact[], isEnabled = true) => {
+  mockContacts = contacts;
+  mockContactsFeatureEnabled = isEnabled;
+};
+
 export const resetSendFlowTestState = (family: SupportedMockFamily = "evm") => {
   jest.clearAllMocks();
   resetBridgeState(family);
   setMockDeviceActionResult(null);
   setMockBridgeRecipientValidation({ errors: {}, warnings: {}, isLoading: false });
   setMockScannedCode("");
+  setMockContacts([], false);
 };
 
 jest.mock("@ledgerhq/live-common/market/state-manager/api", () => ({
@@ -239,6 +248,16 @@ jest.mock("@ledgerhq/ledger-wallet-framework/sanction/index", () => ({
 
 jest.mock("@ledgerhq/live-common/flows/send/recipient/hooks/useBridgeRecipientValidation", () => ({
   useBridgeRecipientValidation: jest.fn(() => mockBridgeRecipientValidation),
+}));
+
+jest.mock("@features/platform-contacts", () => ({
+  ...jest.requireActual("@features/platform-contacts"),
+  useContacts: () => mockContacts,
+  useContactsFeature: () => ({
+    isEnabled: mockContactsFeatureEnabled,
+    showNewBadge: false,
+    eligibleAddressFamilies: ["evm"],
+  }),
 }));
 
 jest.mock("@ledgerhq/live-common/account/index", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendHeader.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendHeader.tsx
@@ -103,7 +103,7 @@ export function SendHeader() {
     return (
       <>
         <AddressInput
-          className="mb-12 px-24"
+          className="-mt-12 mb-12 px-24"
           id="send-recipient-input"
           data-testid="send-recipient-input"
           autoFocus

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/constants.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/constants.ts
@@ -17,7 +17,6 @@ export const SEND_STEP_CONFIGS: Record<SendFlowStep, SendStepConfig> = {
     id: SEND_FLOW_STEP.RECIPIENT,
     canGoBack: true,
     addressInput: true,
-    height: "fit",
   },
   [SEND_FLOW_STEP.RECENT_HISTORY]: {
     id: SEND_FLOW_STEP.RECENT_HISTORY,

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/LoadingState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/LoadingState.tsx
@@ -1,14 +1,30 @@
 import React from "react";
-import { Skeleton } from "@ledgerhq/lumen-ui-react";
+import { Card, CardContent, CardHeader, CardLeading, Skeleton } from "@ledgerhq/lumen-ui-react";
 
 export function LoadingState() {
   return (
-    <div className="flex items-center mt-32" data-testid="send-loading-spinner">
-      <Skeleton className="mr-14 size-48 rounded-full" />
-      <div className="flex flex-1 flex-col gap-8">
-        <Skeleton className="h-12 w-176 pb-12" />
-        <Skeleton className="h-12 w-112" />
-      </div>
+    <div className="-mt-8 mb-12 flex w-full min-w-0 flex-col">
+      <Card data-testid="send-loading-spinner">
+        <CardHeader>
+          <CardLeading>
+            <Skeleton className="size-48 shrink-0 rounded-full" />
+            <CardContent>
+              {/* Wrapper heights mirror the title and description line-heights of RecipientCard */}
+              <div className="flex h-20 items-center">
+                <Skeleton className="h-12 w-176 rounded-full" />
+              </div>
+              <div className="flex h-16 items-center">
+                <Skeleton className="h-12 w-112 rounded-full" />
+              </div>
+            </CardContent>
+          </CardLeading>
+        </CardHeader>
+
+        <div className="flex gap-8 px-16 pb-16">
+          <Skeleton className="h-40 flex-1 rounded-full" />
+          <Skeleton className="h-40 flex-1 rounded-full" />
+        </div>
+      </Card>
     </div>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/RecipientAddressModalView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/RecipientAddressModalView.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { DialogBody } from "@ledgerhq/lumen-ui-react";
 import { cn } from "LLD/utils/cn";
 import type { AddressValidationError as AddressValidationErrorType } from "@ledgerhq/live-common/flows/send/recipient/types";
+import type { Contact } from "@domain/entity-contact";
 import { shouldShowMatchedAddress } from "@ledgerhq/live-common/flows/send/recipient/utils/shouldShowMatchedAddress";
 import type { AddressMatchedSectionViewModel } from "../hooks/useAddressMatchedSectionViewModel";
 import { AddressMatchedSection } from "./AddressMatchedSection";
@@ -11,11 +12,15 @@ import { LoadingState } from "./LoadingState";
 import { RecipientEmptyContactsState } from "./RecipientEmptyContactsState";
 import { RecipientIntroCard } from "./RecipientIntroCard";
 import { ValidationBanner } from "./ValidationBanner";
+import { RecipientContactsList } from "./RecipientContactsList";
 
 type RecipientAddressModalViewProps = Readonly<{
   isLoading: boolean;
   showInitialState: boolean;
+  showContactsList: boolean;
   showEmptyContactsState: boolean;
+  contactsOnNetwork: readonly Contact[];
+  handleContactSelect: (contact: Contact) => void;
   showMatchedAddress: boolean;
   showAddressValidationError: boolean;
   showEmptyState: boolean;
@@ -37,7 +42,10 @@ type RecipientAddressModalViewProps = Readonly<{
 export function RecipientAddressModalView({
   isLoading,
   showInitialState,
+  showContactsList,
   showEmptyContactsState,
+  contactsOnNetwork,
+  handleContactSelect,
   showMatchedAddress,
   showAddressValidationError,
   showEmptyState,
@@ -72,15 +80,15 @@ export function RecipientAddressModalView({
 
   return (
     <DialogBody className={cn("flex flex-col py-16", !isWaitingForMemo && "min-h-[156px]")}>
-      {isLoading && !showMatched && (
-        <div className="flex flex-1 items-center">
-          <LoadingState />
-        </div>
-      )}
+      {isLoading && !showMatched && <LoadingState />}
 
       {showInitialState && showEmptyContactsState && <RecipientEmptyContactsState />}
 
-      {showInitialState && !showEmptyContactsState && <RecipientIntroCard />}
+      {showInitialState && showContactsList && (
+        <RecipientContactsList contacts={contactsOnNetwork} onContactSelect={handleContactSelect} />
+      )}
+
+      {showInitialState && !showEmptyContactsState && !showContactsList && <RecipientIntroCard />}
 
       {showMatched && <AddressMatchedSection viewModel={addressMatchedSectionViewModel} />}
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/RecipientContactsList.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/RecipientContactsList.tsx
@@ -1,0 +1,32 @@
+import type { Contact } from "@domain/entity-contact";
+import { ContactsCompactList } from "@features/flow-contacts-list";
+import { Subheader, SubheaderRow, SubheaderTitle } from "@ledgerhq/lumen-ui-react";
+import React, { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+type RecipientContactsListProps = Readonly<{
+  contacts: readonly Contact[];
+  onContactSelect: (contact: Contact) => void;
+}>;
+
+export function RecipientContactsList({ contacts, onContactSelect }: RecipientContactsListProps) {
+  const { t } = useTranslation();
+  const labels = useMemo(
+    () => ({
+      emptyAddress: t("contacts.addressCount", { count: 0 }),
+      formatAddressCount: (count: number) => t("contacts.addressCount", { count }),
+    }),
+    [t],
+  );
+
+  return (
+    <div data-testid="send-recipient-contacts">
+      <Subheader className="mb-4">
+        <SubheaderRow>
+          <SubheaderTitle>{t("contacts.title")}</SubheaderTitle>
+        </SubheaderRow>
+      </Subheader>
+      <ContactsCompactList contacts={contacts} labels={labels} onContactSelect={onContactSelect} />
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/__tests__/RecipientContactsList.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/__tests__/RecipientContactsList.test.tsx
@@ -1,0 +1,36 @@
+import {
+  mockContact,
+  mockContactAddress,
+  mockContactWithMultipleAddresses,
+} from "@domain/entity-contact/schema.mock";
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { RecipientContactsList } from "../RecipientContactsList";
+
+describe("RecipientContactsList", () => {
+  it("renders the contact section with network-filtered address descriptions", async () => {
+    const singleAddressContact = mockContact({
+      id: "contact-single",
+      name: "Vincent",
+      addresses: [mockContactAddress({ label: "Ethereum Main" })],
+    });
+    const multipleAddressContact = mockContactWithMultipleAddresses({
+      id: "contact-multiple",
+      name: "Benoit",
+    });
+    const onContactSelect = jest.fn();
+    const { user } = render(
+      <RecipientContactsList
+        contacts={[singleAddressContact, multipleAddressContact]}
+        onContactSelect={onContactSelect}
+      />,
+    );
+
+    expect(screen.getByText("Contacts")).toBeVisible();
+    expect(screen.getByText("Ethereum Main")).toBeVisible();
+    expect(screen.getByText("2 addresses")).toBeVisible();
+
+    await user.click(screen.getByTestId("contacts-compact-row-contact-multiple"));
+    expect(onContactSelect).toHaveBeenCalledWith(multipleAddressContact);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientAddressModalViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientAddressModalViewModel.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { useRecipientAddressModalViewModel } from "../useRecipientAddressModalViewModel";
 import { useAddressValidation } from "../useAddressValidation";
 import { useAddressMatchedSectionViewModel } from "../useAddressMatchedSectionViewModel";
@@ -15,9 +15,11 @@ import {
 import {
   createMockAccount,
   createMockCurrency,
+  createMockTokenCurrency,
 } from "../../__integrations__/__fixtures__/accounts";
 import type { SendFlowState } from "@ledgerhq/live-common/flows/send/types";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import type { AddressSearchResult } from "@ledgerhq/live-common/flows/send/recipient/types";
 import { mockContact, mockContactAddress } from "@domain/entity-contact/schema.mock";
 
 jest.mock("../useAddressValidation");
@@ -59,6 +61,29 @@ const DEFAULT_STATE = {
   },
 } as unknown as SendFlowState;
 
+function createAddressSearchResult(
+  overrides: Partial<AddressSearchResult> = {},
+): AddressSearchResult {
+  return {
+    status: "idle",
+    error: null,
+    bridgeErrors: {},
+    bridgeWarnings: {},
+    hasBridgeValidationResult: false,
+    matchedAccounts: [],
+    matchedContact: undefined,
+    resolvedAddress: undefined,
+    ensName: undefined,
+    isLedgerAccount: false,
+    accountName: undefined,
+    accountBalance: undefined,
+    accountBalanceFormatted: undefined,
+    isFirstInteraction: true,
+    matchedRecentAddress: undefined,
+    ...overrides,
+  };
+}
+
 describe("useRecipientAddressModalViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -81,23 +106,7 @@ describe("useRecipientAddressModalViewModel", () => {
       isRecipientAddressComplete: false,
     });
     mockedUseAddressValidation.mockReturnValue({
-      result: {
-        status: "idle",
-        error: null,
-        bridgeErrors: {},
-        bridgeWarnings: {},
-        hasBridgeValidationResult: false,
-        matchedAccounts: [],
-        matchedContact: undefined,
-        resolvedAddress: undefined,
-        ensName: undefined,
-        isLedgerAccount: false,
-        accountName: undefined,
-        accountBalance: undefined,
-        accountBalanceFormatted: undefined,
-        isFirstInteraction: true,
-        matchedRecentAddress: undefined,
-      },
+      result: createAddressSearchResult(),
       isLoading: false,
       validateAddress: jest.fn(),
     });
@@ -220,7 +229,136 @@ describe("useRecipientAddressModalViewModel", () => {
     );
 
     expect(result.current.showInitialState).toBe(true);
+    expect(result.current.showContactsList).toBe(true);
     expect(result.current.showEmptyContactsState).toBe(false);
+  });
+
+  it("only exposes saved contact addresses from the selected network", () => {
+    mockedSendFeatures.hasAddressBook.mockReturnValue(true);
+    mockedUseContactsFeature.mockReturnValue({
+      isEnabled: true,
+      showNewBadge: false,
+      eligibleAddressFamilies: ["evm"],
+    });
+    mockedUseContacts.mockReturnValue([
+      mockContact({
+        id: "contact-me",
+        isMe: true,
+        name: "Me",
+        addresses: [mockContactAddress({ id: "address-me", currencyId: "ethereum" })],
+      }),
+      mockContact({
+        id: "contact-alice",
+        name: "Alice",
+        addresses: [
+          mockContactAddress({ id: "address-eth", currencyId: "ethereum" }),
+          mockContactAddress({ id: "address-usdc", currencyId: "ethereum/erc20/usd_coin" }),
+          mockContactAddress({ id: "address-sol", currencyId: "solana" }),
+        ],
+      }),
+      mockContact({
+        id: "contact-bob",
+        name: "Bob",
+        addresses: [mockContactAddress({ id: "address-btc", currencyId: "bitcoin" })],
+      }),
+    ]);
+
+    const { result } = renderHook(() =>
+      useRecipientAddressModalViewModel({
+        account: mockAccount,
+        currency: createMockCurrency({ id: "ethereum" }),
+        onAddressSelected: jest.fn(),
+        recipientSupportsDomain: true,
+      }),
+    );
+
+    expect(result.current.contactsOnNetwork).toHaveLength(1);
+    expect(result.current.contactsOnNetwork[0]).toMatchObject({
+      id: "contact-alice",
+      addresses: [{ id: "address-eth" }, { id: "address-usdc" }],
+    });
+  });
+
+  it("advances with the address matching the current currency when a contact has several network addresses", () => {
+    const onAddressSelected = jest.fn();
+    const contact = mockContact({
+      addresses: [
+        mockContactAddress({
+          id: "address-eth",
+          currencyId: "ethereum",
+          address: "0xeth",
+        }),
+        mockContactAddress({
+          id: "address-usdt",
+          currencyId: "ethereum/erc20/usdt",
+          address: "0xusdt",
+        }),
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useRecipientAddressModalViewModel({
+        account: mockAccount,
+        currency: createMockTokenCurrency(),
+        onAddressSelected,
+        recipientSupportsDomain: true,
+      }),
+    );
+
+    act(() => result.current.handleContactSelect(contact));
+
+    expect(onAddressSelected).toHaveBeenCalledWith("0xusdt", undefined, true);
+  });
+
+  it("advances with the sole address when a selected contact has exactly one address", () => {
+    const onAddressSelected = jest.fn();
+    const contact = mockContact({
+      addresses: [mockContactAddress({ address: "0x123" })],
+    });
+
+    const { result } = renderHook(() =>
+      useRecipientAddressModalViewModel({
+        account: mockAccount,
+        currency: mockAccount.currency,
+        onAddressSelected,
+        recipientSupportsDomain: true,
+      }),
+    );
+
+    act(() => result.current.handleContactSelect(contact));
+
+    expect(onAddressSelected).toHaveBeenCalledWith("0x123", undefined, true);
+  });
+
+  it("does not advance when a contact has several addresses and none match the current currency", () => {
+    const onAddressSelected = jest.fn();
+    const contact = mockContact({
+      addresses: [
+        mockContactAddress({
+          id: "address-eth",
+          currencyId: "ethereum",
+          address: "0xeth",
+        }),
+        mockContactAddress({
+          id: "address-usdc",
+          currencyId: "ethereum/erc20/usd_coin",
+          address: "0xusdc",
+        }),
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useRecipientAddressModalViewModel({
+        account: mockAccount,
+        currency: createMockTokenCurrency(),
+        onAddressSelected,
+        recipientSupportsDomain: true,
+      }),
+    );
+
+    act(() => result.current.handleContactSelect(contact));
+
+    expect(onAddressSelected).not.toHaveBeenCalled();
   });
 
   it("shows search results when search value is provided", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientAddressModalViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientAddressModalViewModel.ts
@@ -3,9 +3,11 @@ import { useContacts, useContactsFeature } from "@features/platform-contacts";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import { useRecipientSearchState } from "@ledgerhq/live-common/flows/send/recipient/hooks/useRecipientSearchState";
-import { hasContactsOnNetwork } from "@ledgerhq/live-common/flows/send/recipient/utils/hasContactsOnNetwork";
+import { pickContactAddressForCurrency } from "@ledgerhq/live-common/flows/send/recipient/utils/pickContactAddressForCurrency";
+import { resolveRecipientNetworkId } from "@ledgerhq/live-common/flows/send/recipient/utils/resolveRecipientNetworkId";
 import type { CryptoCurrency } from "@domain/entity-currency-crypto";
 import type { TokenCurrency } from "@domain/entity-currency-token";
+import type { Contact } from "@domain/entity-contact";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import { SEND_FLOW_STEP, type SendFlowStep } from "@ledgerhq/live-common/flows/send/types";
 import { useFlowWizard } from "../../../../FlowWizard/FlowWizardContext";
@@ -53,15 +55,37 @@ export function useRecipientAddressModalViewModel({
     canSearchContactsByName: isContactsFeatureEnabled && hasAddressBook,
   });
 
+  const contactsOnNetwork = useMemo(() => {
+    const networkId = resolveRecipientNetworkId(currency.id);
+
+    return contacts.reduce<Contact[]>((matchingContacts, contact) => {
+      if (contact.isMe) {
+        return matchingContacts;
+      }
+
+      const addresses = contact.addresses.filter(
+        address => resolveRecipientNetworkId(address.currencyId) === networkId,
+      );
+      if (addresses.length === 0) {
+        return matchingContacts;
+      }
+
+      matchingContacts.push({ ...contact, addresses });
+      return matchingContacts;
+    }, []);
+  }, [contacts, currency.id]);
+
   const hasSearchValue = recipientSearch.value.length > 0;
   const showInitialState = !hasSearchValue;
+  const showContactsList =
+    showInitialState && isContactsFeatureEnabled && hasAddressBook && contactsOnNetwork.length > 0;
   const showEmptyContactsState = useMemo(() => {
     if (!showInitialState || !isContactsFeatureEnabled || !hasAddressBook) {
       return false;
     }
 
-    return !hasContactsOnNetwork(contacts, currency.id);
-  }, [contacts, currency.id, hasAddressBook, isContactsFeatureEnabled, showInitialState]);
+    return contactsOnNetwork.length === 0;
+  }, [contactsOnNetwork.length, hasAddressBook, isContactsFeatureEnabled, showInitialState]);
 
   const hasMemo = sendFeatures.hasMemo(currency);
   const memoType = sendFeatures.getMemoType(currency);
@@ -94,6 +118,16 @@ export function useRecipientAddressModalViewModel({
     [onAddressSelected, sendFlowTrackingProperties],
   );
 
+  const handleContactSelect = useCallback(
+    (contact: Contact) => {
+      const address = pickContactAddressForCurrency(contact.addresses, currency.id);
+      if (address) {
+        handleAddressSelect(address.address);
+      }
+    },
+    [currency.id, handleAddressSelect],
+  );
+
   const handleAddContact = useCallback(() => {
     navigation.goToStep(SEND_FLOW_STEP.ADD_CONTACT);
   }, [navigation]);
@@ -104,6 +138,7 @@ export function useRecipientAddressModalViewModel({
     isLoading,
     recipientSupportsDomain,
   });
+
   const addressBookFamilyName = mainAccount.currency.name;
   const addressMatchedSectionViewModel = useAddressMatchedSectionViewModel({
     searchResult: result,
@@ -123,8 +158,11 @@ export function useRecipientAddressModalViewModel({
     isLoading,
     result,
     showInitialState,
+    showContactsList,
     showEmptyContactsState,
+    contactsOnNetwork,
     handleAddressSelect,
+    handleContactSelect,
     hasMemo,
     hasMemoValidationError,
     hasFilledMemo,

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -121,6 +121,7 @@
     "@features/flow-contacts-add-address": "workspace:^",
     "@features/flow-contacts-add-contact": "workspace:^",
     "@features/flow-contacts-introduction": "workspace:^",
+    "@features/flow-contacts-list": "workspace:^",
     "@features/flow-fear-and-greed": "workspace:^",
     "@features/flow-lazy-onboarding-banner": "workspace:^",
     "@features/flow-large-screen-upsell": "workspace:^",

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
@@ -5,6 +5,7 @@ import { setEnv } from "@shared/env";
 import { BigNumber } from "bignumber.js";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { mockContact, mockContactAddress } from "@domain/entity-contact/schema.mock";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import {
   act,
@@ -64,6 +65,7 @@ type DriveOpts = Readonly<{
 
 type RenderForAccountOptions = Readonly<{
   contactsEnabled?: boolean;
+  contacts?: State["contacts"]["contacts"];
 }>;
 
 jest.mock("LLM/components/DeviceIntentExecutor", () => {
@@ -123,6 +125,7 @@ describe("Send flow integration tests", () => {
     const withAccount = (state: State): State => ({
       ...state,
       accounts: { ...state.accounts, active: [account] },
+      contacts: options.contacts ? { contacts: options.contacts } : state.contacts,
     });
 
     return renderWithReactQuery(<SendPage initParams={{ account, ...initParams }} />, {
@@ -194,6 +197,43 @@ describe("Send flow integration tests", () => {
     await flushTimers();
 
     expect(await screen.findByRole("button", { name: "Add contact" })).toBeEnabled();
+  });
+
+  it("should show network contacts and advance when selecting a contact with one address", async () => {
+    const contacts = [
+      mockContact({
+        id: "contact-vincent",
+        name: "Vincent",
+        addresses: [
+          mockContactAddress({
+            id: "address-vincent-eth",
+            currencyId: "ethereum",
+            label: "Ethereum Main",
+            address: VALID_ETHEREUM_RECIPIENT,
+          }),
+        ],
+      }),
+      mockContact({
+        id: "contact-solana",
+        name: "Solana contact",
+        addresses: [
+          mockContactAddress({
+            id: "address-solana",
+            currencyId: "solana",
+            label: "Solana",
+            address: "SolanaAddress123",
+          }),
+        ],
+      }),
+    ];
+    const { user } = renderForAccount(accountEthereum, {}, { contactsEnabled: true, contacts });
+
+    expect(await screen.findByTestId("contacts-compact-row-contact-vincent")).toBeVisible();
+    expect(screen.queryByText("Solana contact")).toBeNull();
+
+    await user.press(screen.getByTestId("contacts-compact-row-contact-vincent"));
+
+    expect(await screen.findByText("Review")).toBeVisible();
   });
 
   it("should explain why add contact is unavailable on an unsupported network", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientContactsList.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientContactsList.tsx
@@ -1,0 +1,32 @@
+import type { Contact } from "@domain/entity-contact";
+import { ContactsCompactList } from "@features/flow-contacts-list";
+import { Box, Subheader, SubheaderRow, SubheaderTitle } from "@ledgerhq/lumen-ui-rnative";
+import React, { useMemo } from "react";
+import { useTranslation } from "~/context/Locale";
+
+type RecipientContactsListProps = Readonly<{
+  contacts: readonly Contact[];
+  onContactSelect: (contact: Contact) => void;
+}>;
+
+export function RecipientContactsList({ contacts, onContactSelect }: RecipientContactsListProps) {
+  const { t } = useTranslation();
+  const labels = useMemo(
+    () => ({
+      emptyAddress: t("contacts.addressCount", { count: 0 }),
+      formatAddressCount: (count: number) => t("contacts.addressCount", { count }),
+    }),
+    [t],
+  );
+
+  return (
+    <Box lx={{ marginHorizontal: "s8" }} testID="send-recipient-contacts">
+      <Subheader>
+        <SubheaderRow lx={{ marginBottom: "s4" }}>
+          <SubheaderTitle>{t("contacts.title")}</SubheaderTitle>
+        </SubheaderRow>
+      </Subheader>
+      <ContactsCompactList contacts={contacts} labels={labels} onContactSelect={onContactSelect} />
+    </Box>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientScreenView.tsx
@@ -8,6 +8,7 @@ import { AddressMatchedSection } from "./AddressMatchedSection";
 import { AddressValidationError } from "./AddressValidationError";
 import { LoadingState } from "./LoadingState";
 import { PasteFromClipboard } from "./PasteFromClipboard";
+import { RecipientContactsList } from "./RecipientContactsList";
 import { RecipientEmptyContactsState } from "./RecipientEmptyContactsState";
 import { ValidationBanner } from "./ValidationBanner";
 
@@ -28,7 +29,9 @@ export const RecipientScreenView = ({ viewModel }: RecipientScreenViewProps) => 
   const {
     isLoading,
     showInitialState,
+    showContactsList,
     showEmptyContactsState,
+    contactsOnNetwork,
     showBridgeSenderError,
     bridgeSenderError,
     showSanctionedBanner,
@@ -40,6 +43,7 @@ export const RecipientScreenView = ({ viewModel }: RecipientScreenViewProps) => 
     addressValidationErrorType,
     clipboardAddress,
     handlePasteFromClipboard,
+    handleContactSelect,
   } = recipient;
 
   return (
@@ -59,6 +63,13 @@ export const RecipientScreenView = ({ viewModel }: RecipientScreenViewProps) => 
           )}
 
           {showInitialState && showEmptyContactsState && <RecipientEmptyContactsState />}
+
+          {showInitialState && showContactsList && (
+            <RecipientContactsList
+              contacts={contactsOnNetwork}
+              onContactSelect={handleContactSelect}
+            />
+          )}
 
           {showMemo && <MemoControls vm={memo} />}
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/__tests__/RecipientContactsList.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/__tests__/RecipientContactsList.test.tsx
@@ -1,0 +1,36 @@
+import {
+  mockContact,
+  mockContactAddress,
+  mockContactWithMultipleAddresses,
+} from "@domain/entity-contact/schema.mock";
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { RecipientContactsList } from "../RecipientContactsList";
+
+describe("RecipientContactsList", () => {
+  it("should render contacts with their network-filtered address descriptions", async () => {
+    const singleAddressContact = mockContact({
+      id: "contact-single",
+      name: "Vincent",
+      addresses: [mockContactAddress({ label: "Ethereum Main" })],
+    });
+    const multipleAddressContact = mockContactWithMultipleAddresses({
+      id: "contact-multiple",
+      name: "Benoit",
+    });
+    const onContactSelect = jest.fn();
+    const { user } = render(
+      <RecipientContactsList
+        contacts={[singleAddressContact, multipleAddressContact]}
+        onContactSelect={onContactSelect}
+      />,
+    );
+
+    expect(screen.getByText("Contacts")).toBeVisible();
+    expect(screen.getByText("Ethereum Main")).toBeVisible();
+    expect(screen.getByText("2 addresses")).toBeVisible();
+
+    await user.press(screen.getByTestId("contacts-compact-row-contact-multiple"));
+    expect(onContactSelect).toHaveBeenCalledWith(multipleAddressContact);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenView.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenView.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react-native";
+import { act, renderHook } from "@testing-library/react-native";
 import { useRecipientScreenView } from "../useRecipientScreenView";
 import { useAddressValidation } from "../useAddressValidation";
 import { useClipboardRecipient } from "../useClipboardRecipient";
@@ -12,7 +12,7 @@ import {
 } from "@ledgerhq/ledger-wallet-framework/errors";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import { mockContact, mockContactAddress } from "@domain/entity-contact/schema.mock";
-import { createMockAccount, createMockCurrency } from "./accounts";
+import { createMockAccount, createMockCurrency, createMockTokenCurrency } from "./accounts";
 
 jest.mock("../useAddressValidation");
 jest.mock("../useClipboardRecipient");
@@ -193,7 +193,136 @@ describe("useRecipientScreenView", () => {
     );
 
     expect(result.current.showInitialState).toBe(true);
+    expect(result.current.showContactsList).toBe(true);
     expect(result.current.showEmptyContactsState).toBe(false);
+  });
+
+  it("only exposes saved contact addresses from the selected network", () => {
+    mockedSendFeatures.hasAddressBook.mockReturnValue(true);
+    mockedUseContactsFeature.mockReturnValue({
+      isEnabled: true,
+      showNewBadge: false,
+      eligibleAddressFamilies: ["evm"],
+    });
+    mockedUseContacts.mockReturnValue([
+      mockContact({
+        id: "contact-me",
+        isMe: true,
+        name: "Me",
+        addresses: [mockContactAddress({ id: "address-me", currencyId: "ethereum" })],
+      }),
+      mockContact({
+        id: "contact-alice",
+        name: "Alice",
+        addresses: [
+          mockContactAddress({ id: "address-eth", currencyId: "ethereum" }),
+          mockContactAddress({ id: "address-usdc", currencyId: "ethereum/erc20/usd_coin" }),
+          mockContactAddress({ id: "address-sol", currencyId: "solana" }),
+        ],
+      }),
+      mockContact({
+        id: "contact-bob",
+        name: "Bob",
+        addresses: [mockContactAddress({ id: "address-btc", currencyId: "bitcoin" })],
+      }),
+    ]);
+
+    const { result } = renderHook(() =>
+      useRecipientScreenView({
+        account: mockAccount,
+        currency: createMockCurrency({ id: "ethereum" }),
+        onAddressSelected: jest.fn(),
+        recipientSupportsDomain: true,
+      }),
+    );
+
+    expect(result.current.contactsOnNetwork).toHaveLength(1);
+    expect(result.current.contactsOnNetwork[0]).toMatchObject({
+      id: "contact-alice",
+      addresses: [{ id: "address-eth" }, { id: "address-usdc" }],
+    });
+  });
+
+  it("advances with the address matching the current currency among network addresses", () => {
+    const onAddressSelected = jest.fn();
+    const contact = mockContact({
+      addresses: [
+        mockContactAddress({
+          id: "address-eth",
+          currencyId: "ethereum",
+          address: "0xeth",
+        }),
+        mockContactAddress({
+          id: "address-usdt",
+          currencyId: "ethereum/erc20/usdt",
+          address: "0xusdt",
+        }),
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useRecipientScreenView({
+        account: mockAccount,
+        currency: createMockTokenCurrency(),
+        onAddressSelected,
+        recipientSupportsDomain: true,
+      }),
+    );
+
+    act(() => result.current.handleContactSelect(contact));
+
+    expect(onAddressSelected).toHaveBeenCalledWith("0xusdt", undefined);
+  });
+
+  it("advances with the sole address of a selected contact", () => {
+    const onAddressSelected = jest.fn();
+    const contact = mockContact({
+      addresses: [mockContactAddress({ address: "0x123" })],
+    });
+
+    const { result } = renderHook(() =>
+      useRecipientScreenView({
+        account: mockAccount,
+        currency: mockAccount.currency,
+        onAddressSelected,
+        recipientSupportsDomain: true,
+      }),
+    );
+
+    act(() => result.current.handleContactSelect(contact));
+
+    expect(onAddressSelected).toHaveBeenCalledWith("0x123", undefined);
+  });
+
+  it("does not advance when several addresses remain without a currency match", () => {
+    const onAddressSelected = jest.fn();
+    const contact = mockContact({
+      addresses: [
+        mockContactAddress({
+          id: "address-eth",
+          currencyId: "ethereum",
+          address: "0xeth",
+        }),
+        mockContactAddress({
+          id: "address-usdc",
+          currencyId: "ethereum/erc20/usd_coin",
+          address: "0xusdc",
+        }),
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useRecipientScreenView({
+        account: mockAccount,
+        currency: createMockTokenCurrency(),
+        onAddressSelected,
+        recipientSupportsDomain: true,
+      }),
+    );
+
+    act(() => result.current.handleContactSelect(contact));
+
+    expect(onAddressSelected).not.toHaveBeenCalled();
   });
 
   it("shows search results when search value is provided", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenView.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenView.ts
@@ -2,10 +2,12 @@ import { useContacts, useContactsFeature } from "@features/platform-contacts";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import { useRecipientSearchState } from "@ledgerhq/live-common/flows/send/recipient/hooks/useRecipientSearchState";
-import { hasContactsOnNetwork } from "@ledgerhq/live-common/flows/send/recipient/utils/hasContactsOnNetwork";
+import { pickContactAddressForCurrency } from "@ledgerhq/live-common/flows/send/recipient/utils/pickContactAddressForCurrency";
+import { resolveRecipientNetworkId } from "@ledgerhq/live-common/flows/send/recipient/utils/resolveRecipientNetworkId";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import type { CryptoCurrency } from "@domain/entity-currency-crypto";
 import type { TokenCurrency } from "@domain/entity-currency-token";
+import type { Contact } from "@domain/entity-contact";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import { useCallback, useMemo } from "react";
 import { useSendFlowData } from "../../../context/SendFlowContext";
@@ -47,15 +49,37 @@ export function useRecipientScreenView({
     canSearchContactsByName: isContactsFeatureEnabled && hasAddressBook,
   });
 
+  const contactsOnNetwork = useMemo(() => {
+    const networkId = resolveRecipientNetworkId(currency.id);
+
+    return contacts.reduce<Contact[]>((matchingContacts, contact) => {
+      if (contact.isMe) {
+        return matchingContacts;
+      }
+
+      const addresses = contact.addresses.filter(
+        address => resolveRecipientNetworkId(address.currencyId) === networkId,
+      );
+      if (addresses.length === 0) {
+        return matchingContacts;
+      }
+
+      matchingContacts.push({ ...contact, addresses });
+      return matchingContacts;
+    }, []);
+  }, [contacts, currency.id]);
+
   const hasSearchValue = recipientSearch.value.length > 0;
   const showInitialState = !hasSearchValue;
+  const showContactsList =
+    showInitialState && isContactsFeatureEnabled && hasAddressBook && contactsOnNetwork.length > 0;
   const showEmptyContactsState = useMemo(() => {
     if (!showInitialState || !isContactsFeatureEnabled || !hasAddressBook) {
       return false;
     }
 
-    return !hasContactsOnNetwork(contacts, currency.id);
-  }, [contacts, currency.id, hasAddressBook, isContactsFeatureEnabled, showInitialState]);
+    return contactsOnNetwork.length === 0;
+  }, [contactsOnNetwork.length, hasAddressBook, isContactsFeatureEnabled, showInitialState]);
 
   const { clipboardAddress } = useClipboardRecipient({
     enabled: showInitialState,
@@ -80,6 +104,16 @@ export function useRecipientScreenView({
     [onAddressSelected],
   );
 
+  const handleContactSelect = useCallback(
+    (contact: Contact) => {
+      const address = pickContactAddressForCurrency(contact.addresses, currency.id);
+      if (address) {
+        handleAddressSelect(address.address);
+      }
+    },
+    [currency.id, handleAddressSelect],
+  );
+
   const searchState = useRecipientSearchState({
     searchValue: recipientSearch.value,
     result,
@@ -95,10 +129,13 @@ export function useRecipientScreenView({
     hasAddressBook,
     addressBookFamilyName: mainAccount.currency.name,
     showInitialState,
+    showContactsList,
     showEmptyContactsState,
+    contactsOnNetwork,
     clipboardAddress,
     handlePasteFromClipboard,
     handleAddressSelect,
+    handleContactSelect,
     isContactsFeatureEnabled,
     ...searchState,
   };

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -649,6 +649,7 @@
     "src/flows/send/recipient/utils/getRecipientMatchPresentation.ts",
     "src/flows/send/recipient/utils/hasContactsOnNetwork.ts",
     "src/flows/send/recipient/utils/memoValue.ts",
+    "src/flows/send/recipient/utils/pickContactAddressForCurrency.ts",
     "src/flows/send/recipient/utils/resolveRecipientNetworkId.ts",
     "src/flows/send/recipient/utils/shouldShowMatchedAddress.ts",
     "src/flows/send/types.ts",

--- a/libs/ledger-live-common/src/flows/send/recipient/utils/__tests__/pickContactAddressForCurrency.test.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/utils/__tests__/pickContactAddressForCurrency.test.ts
@@ -1,0 +1,42 @@
+import { pickContactAddressForCurrency } from "../pickContactAddressForCurrency";
+
+describe("pickContactAddressForCurrency", () => {
+  it("selects the address that matches the currency id among several network addresses", () => {
+    const ethAddress = {
+      id: "eth",
+      currencyId: "ethereum",
+      address: "0xeth",
+    };
+    const usdcAddress = {
+      id: "usdc",
+      currencyId: "ethereum/erc20/usd_coin",
+      address: "0xusdc",
+    };
+
+    expect(
+      pickContactAddressForCurrency([ethAddress, usdcAddress], "ethereum/erc20/usd_coin"),
+    ).toBe(usdcAddress);
+  });
+
+  it("falls back to the only address when there is no exact currency match", () => {
+    const ethAddress = {
+      id: "eth",
+      currencyId: "ethereum",
+      address: "0xeth",
+    };
+
+    expect(pickContactAddressForCurrency([ethAddress], "ethereum/erc20/usd_coin")).toBe(ethAddress);
+  });
+
+  it("does not pick an address when several candidates remain without an exact currency match", () => {
+    expect(
+      pickContactAddressForCurrency(
+        [
+          { id: "eth", currencyId: "ethereum", address: "0xeth" },
+          { id: "usdc", currencyId: "ethereum/erc20/usd_coin", address: "0xusdc" },
+        ],
+        "ethereum/erc20/usd_tether",
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/libs/ledger-live-common/src/flows/send/recipient/utils/findMatchedContact.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/utils/findMatchedContact.ts
@@ -29,9 +29,6 @@ export function findMatchedContact(
 ): MatchedContact | undefined {
   const recipientAddress = resolvedRecipient ?? recipient;
   const recipientNetworkId = resolveRecipientNetworkId(currencyId);
-  if (!recipientAddress.trim()) {
-    return undefined;
-  }
   const normalizedRecipient = recipient.trim().toLowerCase();
 
   const sortedContacts = [...contacts].sort(

--- a/libs/ledger-live-common/src/flows/send/recipient/utils/pickContactAddressForCurrency.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/utils/pickContactAddressForCurrency.ts
@@ -1,0 +1,11 @@
+type ContactAddress = Readonly<{
+  currencyId: string;
+}>;
+
+export function pickContactAddressForCurrency<T extends ContactAddress>(
+  addresses: readonly T[],
+  currencyId: string,
+): T | undefined {
+  const exactCurrencyAddress = addresses.find(address => address.currencyId === currencyId);
+  return exactCurrencyAddress ?? (addresses.length === 1 ? addresses[0] : undefined);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -952,6 +952,9 @@ importers:
       '@features/flow-contacts-introduction':
         specifier: workspace:^
         version: link:../../features/flow/flow-contacts-introduction
+      '@features/flow-contacts-list':
+        specifier: workspace:^
+        version: link:../../features/flow/flow-contacts-list
       '@features/flow-fear-and-greed':
         specifier: workspace:^
         version: link:../../features/flow/fear-and-greed
@@ -1764,6 +1767,9 @@ importers:
       '@features/flow-contacts-introduction':
         specifier: workspace:^
         version: link:../../features/flow/flow-contacts-introduction
+      '@features/flow-contacts-list':
+        specifier: workspace:^
+        version: link:../../features/flow/flow-contacts-list
       '@features/flow-fear-and-greed':
         specifier: workspace:^
         version: link:../../features/flow/fear-and-greed


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

The Send recipient step now surfaces the user's saved contacts as soon as it opens, instead of the generic intro card: contacts are kept only when they hold at least one address on the recipient network, their address list is narrowed to that network, and the "me" contact is excluded, so the intro card is still shown when nothing relevant remains. 

### 🔗 Context

- **[JIRA / GitHub issue](https://ledgerhq.atlassian.net/browse/LIVE-34099)** <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
