### PR TITLE
[LWDM] feat(send): select the address of a contact with several addresses

### DIFF
--- a/.changeset/tidy-moons-gather.md
+++ b/.changeset/tidy-moons-gather.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+feat(send): select which address of a contact receives the funds in the Send recipient step

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
@@ -92,6 +92,82 @@ describe("Send Flow Integration", () => {
       expect(await screen.findByTestId("send-amount-step")).toBeVisible();
     });
 
+    it("opens address selection when a contact has several addresses on the recipient network", async () => {
+      setMockContacts([
+        mockContact({
+          id: "contact-benoit",
+          name: "Benoit",
+          addresses: [
+            mockContactAddress({
+              id: "address-benoit-main",
+              currencyId: "ethereum",
+              label: "Ethereum",
+              address: VALID_EVM_RECIPIENT,
+            }),
+            mockContactAddress({
+              id: "address-benoit-coinbase",
+              currencyId: "ethereum",
+              label: "Ethereum Coinbase",
+              address: "0x1234567890123456789012345678901234567890",
+            }),
+          ],
+        }),
+      ]);
+      const { user } = renderSendFlow(ethereumAccount);
+
+      await user.click(await screen.findByTestId("contacts-compact-row-contact-benoit"));
+
+      expect(await screen.findByTestId("send-recipient-contact-address-selection")).toBeVisible();
+      expect(screen.getAllByText("Select address")).toHaveLength(2);
+      expect(screen.getAllByText("Benoit")).toHaveLength(2);
+      expect(screen.queryByTestId("send-recipient-input")).not.toBeInTheDocument();
+
+      await user.click(
+        screen.getByTestId("send-recipient-contact-address-address-benoit-coinbase"),
+      );
+      expect(await screen.findByTestId("send-amount-step")).toBeVisible();
+    });
+
+    it("requires choosing an address when searching for a contact with several network addresses", async () => {
+      setMockContacts([
+        mockContact({
+          id: "contact-benoit",
+          name: "Benoit",
+          addresses: [
+            mockContactAddress({
+              id: "address-benoit-main",
+              currencyId: "ethereum",
+              label: "Ethereum",
+              address: VALID_EVM_RECIPIENT,
+            }),
+            mockContactAddress({
+              id: "address-benoit-coinbase",
+              currencyId: "ethereum",
+              label: "Ethereum Coinbase",
+              address: "0x1234567890123456789012345678901234567890",
+            }),
+          ],
+        }),
+      ]);
+      const { user } = renderSendFlow(ethereumAccount);
+
+      await user.type(await screen.findByTestId("send-recipient-input"), "Benoit");
+
+      expect(await screen.findByTestId("contacts-compact-row-contact-benoit")).toBeVisible();
+      expect(screen.queryByTestId("send-recipient-card")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("send-matched-address-button")).not.toBeInTheDocument();
+
+      await user.click(screen.getByTestId("contacts-compact-row-contact-benoit"));
+      expect(await screen.findByTestId("send-recipient-contact-address-selection")).toBeVisible();
+
+      await user.click(
+        screen.getByTestId("send-recipient-contact-address-address-benoit-coinbase"),
+      );
+
+      expect(await screen.findByTestId("send-amount-step")).toBeVisible();
+      expect(screen.queryByTestId("send-recipient-card")).not.toBeInTheDocument();
+    });
+
     it("should show the collapsable security card collapsed by default and expand on click", async () => {
       const { user } = renderSendFlow(ethereumAccount);
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendFlowLayout.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendFlowLayout.tsx
@@ -14,6 +14,7 @@ import { SendHeader } from "./SendHeader";
 import { AnimatedHeight } from "./AnimatedHeight";
 import { track } from "~/renderer/analytics/segment";
 import { getSendFlowTrackingProperties } from "../utils/tracking";
+import { RecipientContactSelectionProvider } from "../context/RecipientContactSelectionContext";
 
 type SendFlowLayoutProps = Readonly<{
   isOpen: boolean;
@@ -62,32 +63,34 @@ export function SendFlowLayout({ isOpen, onClose }: SendFlowLayoutProps) {
             })}
           />
         )}
-        <RecipientScannerProvider>
-          {shouldAnimateHeight ? (
-            <AnimatedHeight>
-              <div className="flex flex-col">
+        <RecipientContactSelectionProvider>
+          <RecipientScannerProvider>
+            {shouldAnimateHeight ? (
+              <AnimatedHeight>
+                <div className="flex flex-col">
+                  <SendHeader />
+                  {StepComponent && (
+                    <div key={wizard.currentStep} className="flex animate-fade-in flex-col">
+                      <StepComponent />
+                    </div>
+                  )}
+                </div>
+              </AnimatedHeight>
+            ) : (
+              <>
                 <SendHeader />
                 {StepComponent && (
-                  <div key={wizard.currentStep} className="flex animate-fade-in flex-col">
+                  <div
+                    key={wizard.currentStep}
+                    className="flex min-h-0 flex-1 animate-fade-in flex-col"
+                  >
                     <StepComponent />
                   </div>
                 )}
-              </div>
-            </AnimatedHeight>
-          ) : (
-            <>
-              <SendHeader />
-              {StepComponent && (
-                <div
-                  key={wizard.currentStep}
-                  className="flex min-h-0 flex-1 animate-fade-in flex-col"
-                >
-                  <StepComponent />
-                </div>
-              )}
-            </>
-          )}
-        </RecipientScannerProvider>
+              </>
+            )}
+          </RecipientScannerProvider>
+        </RecipientContactSelectionProvider>
       </DialogContent>
     </Dialog>
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/context/RecipientContactSelectionContext.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/context/RecipientContactSelectionContext.tsx
@@ -1,0 +1,46 @@
+import type { Contact } from "@domain/entity-contact";
+import React, { createContext, useCallback, useContext, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+
+type RecipientContactSelectionContextValue = Readonly<{
+  selectedContact: Contact | undefined;
+  selectContact: (contact: Contact) => void;
+  clearSelectedContact: () => void;
+}>;
+
+const RecipientContactSelectionContext =
+  createContext<RecipientContactSelectionContextValue | null>(null);
+
+type RecipientContactSelectionProviderProps = Readonly<{
+  children: ReactNode;
+}>;
+
+export function RecipientContactSelectionProvider({
+  children,
+}: RecipientContactSelectionProviderProps) {
+  const [selectedContact, setSelectedContact] = useState<Contact>();
+
+  const selectContact = useCallback((contact: Contact) => setSelectedContact(contact), []);
+  const clearSelectedContact = useCallback(() => setSelectedContact(undefined), []);
+
+  const value = useMemo(
+    () => ({ selectedContact, selectContact, clearSelectedContact }),
+    [clearSelectedContact, selectContact, selectedContact],
+  );
+
+  return (
+    <RecipientContactSelectionContext.Provider value={value}>
+      {children}
+    </RecipientContactSelectionContext.Provider>
+  );
+}
+
+export function useRecipientContactSelection(): RecipientContactSelectionContextValue {
+  const context = useContext(RecipientContactSelectionContext);
+  if (!context) {
+    throw new Error(
+      "useRecipientContactSelection must be used within a RecipientContactSelectionProvider",
+    );
+  }
+  return context;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useSendHeaderModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useSendHeaderModel.test.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { BigNumber } from "bignumber.js";
 import { act } from "tests/testSetup";
 import { SEND_FLOW_STEP } from "@ledgerhq/live-common/flows/send/types";
+import { mockContact } from "@domain/entity-contact/schema.mock";
 import { useSendHeaderModel } from "../useSendHeaderModel";
 
 jest.mock("../../../FlowWizard/FlowWizardContext", () => ({ useFlowWizard: jest.fn() }));
@@ -29,6 +30,9 @@ jest.mock("@ledgerhq/live-common/currencies/index", () => ({
 jest.mock("@ledgerhq/live-common/bridge/descriptor/send/features", () => ({
   sendFeatures: { hasAddressBook: jest.fn(() => false) },
 }));
+jest.mock("../../context/RecipientContactSelectionContext", () => ({
+  useRecipientContactSelection: jest.fn(),
+}));
 
 import { useFlowWizard } from "../../../FlowWizard/FlowWizardContext";
 import { useSendFlowData, useSendFlowActions } from "../../context/SendFlowContext";
@@ -39,6 +43,7 @@ import { RecipientScannerProvider } from "../../context/RecipientScannerContext"
 import { useSelector } from "LLD/hooks/redux";
 import { useContactsFeature } from "@features/platform-contacts";
 import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
+import { useRecipientContactSelection } from "../../context/RecipientContactSelectionContext";
 
 type VM = ReturnType<typeof useSendHeaderModel>;
 let container: HTMLElement;
@@ -129,6 +134,11 @@ beforeEach(() => {
     transaction: { status: {} },
   });
   (useMaybeAccountName as jest.Mock).mockReturnValue("Base 1");
+  jest.mocked(useRecipientContactSelection).mockReturnValue({
+    selectedContact: undefined,
+    selectContact: jest.fn(),
+    clearSelectedContact: jest.fn(),
+  });
 });
 
 afterEach(() => {
@@ -169,6 +179,31 @@ describe("useSendHeaderModel", () => {
 
       expect(latestVM?.title).toBe("Send ETH");
       expect(latestVM?.descriptionText).toBe("$5,969.83");
+    });
+
+    it("shows the contact address selection header and returns to the recipient list", () => {
+      const clearSelectedContact = jest.fn();
+      jest.mocked(useRecipientContactSelection).mockReturnValue({
+        selectedContact: mockContact({ name: "Benoit" }),
+        selectContact: jest.fn(),
+        clearSelectedContact,
+      });
+      mockActions();
+      (useFlowWizard as jest.Mock).mockReturnValue({
+        currentStep: SEND_FLOW_STEP.RECIPIENT,
+        currentStepConfig: { addressInput: true, showTitle: true },
+        navigation: { goToStep: jest.fn(), goToPreviousStep: jest.fn(), canGoBack: () => false },
+      });
+
+      renderHook("$5,969.83");
+
+      expect(latestVM?.title).toBe("Select address");
+      expect(latestVM?.descriptionText).toBe("Benoit");
+      expect(latestVM?.showRecipientInput).toBe(false);
+      expect(latestVM?.showBackButton).toBe(true);
+
+      act(() => latestVM?.handleBack());
+      expect(clearSelectedContact).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendHeaderModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendHeaderModel.ts
@@ -22,6 +22,7 @@ import { useMaybeAccountName } from "~/renderer/reducers/wallet";
 import { track, trackPage } from "~/renderer/analytics/segment";
 import { getSendFlowTrackingProperties } from "../utils/tracking";
 import { useRecipientScanner } from "../context/RecipientScannerContext";
+import { useRecipientContactSelection } from "../context/RecipientContactSelectionContext";
 
 type UseSendHeaderModelParams = Readonly<{
   availableText: string;
@@ -66,6 +67,7 @@ export function useSendHeaderModel({
   const { state, uiConfig, recipientSearch, isRecipientAddressComplete } = useSendFlowData();
   const { close, transaction } = useSendFlowActions();
   const { isScannerOpen, closeScanner, toggleScanner } = useRecipientScanner();
+  const { selectedContact, clearSelectedContact } = useRecipientContactSelection();
   const { isEnabled: isContactsFeatureEnabled } = useContactsFeature("desktop");
   const contacts = useSelector(selectContacts);
 
@@ -74,7 +76,11 @@ export function useSendHeaderModel({
 
   const { navigation, currentStep } = wizard;
   const currentStepConfig = wizard.currentStepConfig;
-  const showRecipientInput = currentStepConfig?.addressInput ?? false;
+  const isRecipientStep = currentStep === SEND_FLOW_STEP.RECIPIENT;
+  const isAmountStep = currentStep === SEND_FLOW_STEP.AMOUNT;
+  const isSelectingContactAddress = isRecipientStep && selectedContact !== undefined;
+  const showRecipientInput =
+    (currentStepConfig?.addressInput ?? false) && !isSelectingContactAddress;
   const showMemoControls = Boolean(
     showRecipientInput &&
     uiConfig.hasMemo &&
@@ -97,11 +103,9 @@ export function useSendHeaderModel({
 
   const backTarget = currentStepConfig?.backTarget;
 
-  const showBackButton = navigation.canGoBack();
+  const showBackButton = isSelectingContactAddress || navigation.canGoBack();
 
   const showTitle = currentStepConfig?.showTitle !== false;
-  const isRecipientStep = currentStep === SEND_FLOW_STEP.RECIPIENT;
-  const isAmountStep = currentStep === SEND_FLOW_STEP.AMOUNT;
 
   const accountSummary = useMemo(() => {
     if (accountName && availableText) return `${accountName} · ${availableText}`;
@@ -111,12 +115,25 @@ export function useSendHeaderModel({
   const titleKey = currentStepConfig?.titleKey ?? "newSendFlow.title";
   const showAvailable = currentStepConfig?.showAvailable ?? true;
 
-  const title = showTitle ? t(titleKey, { currency: currencyName }) : "";
+  const title = isSelectingContactAddress
+    ? t("newSendFlow.selectAddress")
+    : showTitle
+      ? t(titleKey, { currency: currencyName })
+      : "";
 
-  const descriptionText = showTitle && showAvailable && accountSummary ? accountSummary : "";
+  const descriptionText = isSelectingContactAddress
+    ? selectedContact.name
+    : showTitle && showAvailable && accountSummary
+      ? accountSummary
+      : "";
 
   const handleBack = useCallback(() => {
     closeScanner();
+
+    if (isSelectingContactAddress) {
+      clearSelectedContact();
+      return;
+    }
 
     // Per-step state cleanup that runs regardless of whether navigation uses backTarget
     // or goToPreviousStep, so floating steps and regular steps are treated uniformly
@@ -146,7 +163,17 @@ export function useSendHeaderModel({
     } else {
       close();
     }
-  }, [backTarget, close, closeScanner, currentStep, navigation, resetViewState, transaction]);
+  }, [
+    backTarget,
+    clearSelectedContact,
+    close,
+    closeScanner,
+    currentStep,
+    isSelectingContactAddress,
+    navigation,
+    resetViewState,
+    transaction,
+  ]);
 
   const recipientHeader = useMemo(
     () =>

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/RecipientAddressModalView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/RecipientAddressModalView.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { DialogBody } from "@ledgerhq/lumen-ui-react";
 import { cn } from "LLD/utils/cn";
 import type { AddressValidationError as AddressValidationErrorType } from "@ledgerhq/live-common/flows/send/recipient/types";
+import type { CryptoCurrency } from "@domain/entity-currency-crypto";
 import type { Contact } from "@domain/entity-contact";
 import { shouldShowMatchedAddress } from "@ledgerhq/live-common/flows/send/recipient/utils/shouldShowMatchedAddress";
 import type { AddressMatchedSectionViewModel } from "../hooks/useAddressMatchedSectionViewModel";
@@ -13,14 +14,20 @@ import { RecipientEmptyContactsState } from "./RecipientEmptyContactsState";
 import { RecipientIntroCard } from "./RecipientIntroCard";
 import { ValidationBanner } from "./ValidationBanner";
 import { RecipientContactsList } from "./RecipientContactsList";
+import { RecipientContactAddressSelection } from "./RecipientContactAddressSelection";
 
 type RecipientAddressModalViewProps = Readonly<{
   isLoading: boolean;
   showInitialState: boolean;
   showContactsList: boolean;
+  showContactSearchResult: boolean;
   showEmptyContactsState: boolean;
   contactsOnNetwork: readonly Contact[];
+  contactSearchResult: Contact | undefined;
+  selectedContact: Contact | undefined;
+  network: CryptoCurrency;
   handleContactSelect: (contact: Contact) => void;
+  handleContactAddressSelect: (address: string) => void;
   showMatchedAddress: boolean;
   showAddressValidationError: boolean;
   showEmptyState: boolean;
@@ -43,9 +50,14 @@ export function RecipientAddressModalView({
   isLoading,
   showInitialState,
   showContactsList,
+  showContactSearchResult,
   showEmptyContactsState,
   contactsOnNetwork,
+  contactSearchResult,
+  selectedContact,
+  network,
   handleContactSelect,
+  handleContactAddressSelect,
   showMatchedAddress,
   showAddressValidationError,
   showEmptyState,
@@ -88,7 +100,22 @@ export function RecipientAddressModalView({
         <RecipientContactsList contacts={contactsOnNetwork} onContactSelect={handleContactSelect} />
       )}
 
+      {showContactSearchResult && contactSearchResult && (
+        <RecipientContactsList
+          contacts={[contactSearchResult]}
+          onContactSelect={handleContactSelect}
+        />
+      )}
+
       {showInitialState && !showEmptyContactsState && !showContactsList && <RecipientIntroCard />}
+
+      {selectedContact && (
+        <RecipientContactAddressSelection
+          contact={selectedContact}
+          network={network}
+          onAddressSelect={handleContactAddressSelect}
+        />
+      )}
 
       {showMatched && <AddressMatchedSection viewModel={addressMatchedSectionViewModel} />}
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/RecipientContactAddressSelection.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/RecipientContactAddressSelection.tsx
@@ -1,0 +1,76 @@
+import { findCryptoCurrencyById, type CryptoCurrency } from "@domain/entity-currency-crypto";
+import type { Contact } from "@domain/entity-contact";
+import { CryptoIcon } from "@ledgerhq/crypto-icons";
+import { SEND_ADDRESS_FORMAT_OPTIONS } from "@ledgerhq/live-common/flows/send/utils";
+import { formatAddress } from "@ledgerhq/live-common/utils/addressUtils";
+import {
+  Card,
+  CardContent,
+  CardContentDescription,
+  CardContentTitle,
+  CardHeader,
+  CardLeading,
+} from "@ledgerhq/lumen-ui-react";
+import React, { useEffect, useRef } from "react";
+
+type RecipientContactAddressSelectionProps = Readonly<{
+  contact: Contact;
+  network: CryptoCurrency;
+  onAddressSelect: (address: string) => void;
+}>;
+
+export function RecipientContactAddressSelection({
+  contact,
+  network,
+  onAddressSelect,
+}: RecipientContactAddressSelectionProps) {
+  const sectionRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    sectionRef.current?.querySelector<HTMLElement>('[role="button"]')?.focus();
+  }, []);
+
+  return (
+    <section
+      ref={sectionRef}
+      className="flex flex-col gap-8"
+      data-testid="send-recipient-contact-address-selection"
+    >
+      <div className="flex items-center gap-8 px-8">
+        <CryptoIcon ledgerId={network.id} ticker={network.ticker} size={16} shape="square" />
+        <p className="body-2 text-muted">{network.name}</p>
+      </div>
+
+      {contact.addresses.map(address => {
+        const addressCurrency = findCryptoCurrencyById(address.currencyId);
+
+        return (
+          <Card
+            key={address.id}
+            type="interactive"
+            onClick={() => onAddressSelect(address.address)}
+            data-testid={`send-recipient-contact-address-${address.id}`}
+          >
+            <CardHeader>
+              <CardLeading>
+                <CryptoIcon
+                  ledgerId={address.currencyId}
+                  ticker={addressCurrency?.ticker ?? address.label}
+                  network={address.currencyId === network.id ? undefined : network.id}
+                  size={40}
+                  shape="circle"
+                />
+                <CardContent>
+                  <CardContentTitle>{address.label}</CardContentTitle>
+                  <CardContentDescription>
+                    {formatAddress(address.address, SEND_ADDRESS_FORMAT_OPTIONS)}
+                  </CardContentDescription>
+                </CardContent>
+              </CardLeading>
+            </CardHeader>
+          </Card>
+        );
+      })}
+    </section>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/__tests__/RecipientContactAddressSelection.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/__tests__/RecipientContactAddressSelection.test.tsx
@@ -1,0 +1,112 @@
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { mockContact, mockContactAddress } from "@domain/entity-contact/schema.mock";
+import { CryptoIcon } from "@ledgerhq/crypto-icons";
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { RecipientContactAddressSelection } from "../RecipientContactAddressSelection";
+
+jest.mock("@ledgerhq/crypto-icons", () => {
+  const React = jest.requireActual("react");
+
+  return {
+    CryptoIcon: jest.fn(({ ledgerId, network, ticker }) =>
+      React.createElement(
+        "span",
+        { "data-network": network ?? "", "data-testid": `crypto-icon-${ledgerId}` },
+        ticker,
+      ),
+    ),
+  };
+});
+
+const mockedCryptoIcon = jest.mocked(CryptoIcon);
+
+describe("RecipientContactAddressSelection", () => {
+  beforeEach(() => {
+    mockedCryptoIcon.mockClear();
+  });
+
+  it("renders compatible addresses and selects the requested address", async () => {
+    const network = getCryptoCurrencyById("ethereum");
+    const contact = mockContact({
+      id: "contact-benoit",
+      name: "Benoit",
+      addresses: [
+        mockContactAddress({
+          id: "address-main",
+          label: "Ethereum",
+          address: "0xd03f8fd01234567890abcdef123456783f0f2d19",
+        }),
+        mockContactAddress({
+          id: "address-coinbase",
+          label: "Ethereum Coinbase",
+          address: "0xabcdef01234567890abcdef1234567890abcdef0",
+        }),
+      ],
+    });
+    const onAddressSelect = jest.fn();
+    const { user } = render(
+      <RecipientContactAddressSelection
+        contact={contact}
+        network={network}
+        onAddressSelect={onAddressSelect}
+      />,
+    );
+
+    expect(screen.getAllByText("Ethereum")).toHaveLength(2);
+    expect(screen.getByText("Ethereum Coinbase")).toBeVisible();
+    expect(screen.getByText("0xd03f8f...3f0f2d19")).toBeVisible();
+    expect(screen.getByTestId("send-recipient-contact-address-address-main")).toHaveFocus();
+
+    await user.click(screen.getByTestId("send-recipient-contact-address-address-coinbase"));
+    expect(onAddressSelect).toHaveBeenCalledWith("0xabcdef01234567890abcdef1234567890abcdef0");
+  });
+
+  it("should derive each address icon from the address currency and omit a redundant network badge", () => {
+    const network = getCryptoCurrencyById("ethereum");
+    const contact = mockContact({
+      addresses: [
+        mockContactAddress({
+          id: "address-eth",
+          currencyId: "ethereum",
+          label: "Ethereum",
+        }),
+        mockContactAddress({
+          id: "address-usdc",
+          currencyId: "ethereum/erc20/usd_coin",
+          label: "USDC",
+        }),
+      ],
+    });
+
+    render(
+      <RecipientContactAddressSelection
+        contact={contact}
+        network={network}
+        onAddressSelect={jest.fn()}
+      />,
+    );
+
+    const nativeIconCall = mockedCryptoIcon.mock.calls.find(
+      ([props]) => props.ledgerId === "ethereum" && props.size === 40,
+    );
+    const tokenIconCall = mockedCryptoIcon.mock.calls.find(
+      ([props]) => props.ledgerId === "ethereum/erc20/usd_coin",
+    );
+
+    expect(nativeIconCall?.[0]).toEqual(
+      expect.objectContaining({
+        ledgerId: "ethereum",
+        ticker: network.ticker,
+        network: undefined,
+      }),
+    );
+    expect(tokenIconCall?.[0]).toEqual(
+      expect.objectContaining({
+        ledgerId: "ethereum/erc20/usd_coin",
+        ticker: "USDC",
+        network: network.id,
+      }),
+    );
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientAddressModalViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientAddressModalViewModel.test.ts
@@ -21,6 +21,7 @@ import type { SendFlowState } from "@ledgerhq/live-common/flows/send/types";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import type { AddressSearchResult } from "@ledgerhq/live-common/flows/send/recipient/types";
 import { mockContact, mockContactAddress } from "@domain/entity-contact/schema.mock";
+import { useRecipientContactSelection } from "../../../../context/RecipientContactSelectionContext";
 
 jest.mock("../useAddressValidation");
 jest.mock("../useAddressMatchedSectionViewModel");
@@ -31,6 +32,7 @@ jest.mock("../../../../../FlowWizard/FlowWizardContext", () => ({
 jest.mock("@ledgerhq/live-common/account/index");
 jest.mock("@ledgerhq/live-common/bridge/descriptor/send/features");
 jest.mock("@features/platform-contacts");
+jest.mock("../../../../context/RecipientContactSelectionContext");
 jest.mock("~/renderer/reducers/wallet", () => ({
   useMaybeAccountName: jest.fn(),
   useBatchMaybeAccountName: jest.fn(() => []),
@@ -44,6 +46,7 @@ const mockedGetMainAccount = jest.mocked(getMainAccount);
 const mockedSendFeatures = jest.mocked(sendFeatures);
 const mockedUseContacts = jest.mocked(useContacts);
 const mockedUseContactsFeature = jest.mocked(useContactsFeature);
+const mockedUseRecipientContactSelection = jest.mocked(useRecipientContactSelection);
 
 const mockAccount = createMockAccount({ id: "account_1" });
 
@@ -98,6 +101,11 @@ describe("useRecipientAddressModalViewModel", () => {
       isEnabled: false,
       showNewBadge: false,
       eligibleAddressFamilies: [],
+    });
+    mockedUseRecipientContactSelection.mockReturnValue({
+      selectedContact: undefined,
+      selectContact: jest.fn(),
+      clearSelectedContact: jest.fn(),
     });
     mockedUseSendFlowData.mockReturnValue({
       recipientSearch: mockRecipientSearch,
@@ -310,8 +318,79 @@ describe("useRecipientAddressModalViewModel", () => {
     expect(onAddressSelected).toHaveBeenCalledWith("0xusdt", undefined, true);
   });
 
-  it("advances with the sole address when a selected contact has exactly one address", () => {
+  it("shows a contact choice instead of resolving the first address when a searched contact has several addresses", () => {
+    const selectContact = jest.fn();
+    const contact = mockContact({
+      id: "contact-benoit",
+      name: "Benoit",
+      addresses: [
+        mockContactAddress({ id: "address-1", address: "0x123", currencyId: "ethereum" }),
+        mockContactAddress({ id: "address-2", address: "0x456", currencyId: "ethereum" }),
+      ],
+    });
+    mockedSendFeatures.hasAddressBook.mockReturnValue(true);
+    mockedUseContactsFeature.mockReturnValue({
+      isEnabled: true,
+      showNewBadge: false,
+      eligibleAddressFamilies: ["evm"],
+    });
+    mockedUseContacts.mockReturnValue([contact]);
+    mockedUseRecipientContactSelection.mockReturnValue({
+      selectedContact: undefined,
+      selectContact,
+      clearSelectedContact: jest.fn(),
+    });
+    mockedUseSendFlowData.mockReturnValue({
+      recipientSearch: { ...mockRecipientSearch, value: "Benoit" },
+      state: DEFAULT_STATE,
+      uiConfig: {} as never,
+      isRecipientAddressComplete: false,
+    });
+    mockedUseAddressValidation.mockReturnValue({
+      result: createAddressSearchResult({
+        status: "valid",
+        hasBridgeValidationResult: true,
+        matchedContact: {
+          contactId: contact.id,
+          contactName: contact.name,
+          addressId: contact.addresses[0]!.id,
+          addressLabel: contact.addresses[0]!.label,
+          address: contact.addresses[0]!.address,
+        },
+      }),
+      isLoading: false,
+      validateAddress: jest.fn(),
+    });
+
+    const { result } = renderHook(() =>
+      useRecipientAddressModalViewModel({
+        account: mockAccount,
+        currency: createMockCurrency({ id: "ethereum" }),
+        onAddressSelected: jest.fn(),
+        recipientSupportsDomain: true,
+      }),
+    );
+
+    expect(result.current.showContactSearchResult).toBe(true);
+    expect(result.current.contactSearchResult).toMatchObject({
+      id: contact.id,
+      addresses: [{ id: "address-1" }, { id: "address-2" }],
+    });
+    expect(result.current.showMatchedAddress).toBe(false);
+    expect(result.current.isAddressValid).toBe(false);
+
+    act(() => result.current.handleContactSelect(contact));
+    expect(selectContact).toHaveBeenCalledWith(contact);
+  });
+
+  it("advances straight to the next step for a contact with one address", () => {
     const onAddressSelected = jest.fn();
+    const selectContact = jest.fn();
+    mockedUseRecipientContactSelection.mockReturnValue({
+      selectedContact: undefined,
+      selectContact,
+      clearSelectedContact: jest.fn(),
+    });
     const contact = mockContact({
       addresses: [mockContactAddress({ address: "0x123" })],
     });
@@ -328,10 +407,51 @@ describe("useRecipientAddressModalViewModel", () => {
     act(() => result.current.handleContactSelect(contact));
 
     expect(onAddressSelected).toHaveBeenCalledWith("0x123", undefined, true);
+    expect(selectContact).not.toHaveBeenCalled();
   });
 
-  it("does not advance when a contact has several addresses and none match the current currency", () => {
+  it("opens address selection for a contact with multiple addresses", () => {
     const onAddressSelected = jest.fn();
+    const selectContact = jest.fn();
+    const clearSelectedContact = jest.fn();
+    mockedUseRecipientContactSelection.mockReturnValue({
+      selectedContact: undefined,
+      selectContact,
+      clearSelectedContact,
+    });
+    const contact = mockContact({
+      addresses: [
+        mockContactAddress({ id: "address-1", address: "0x123" }),
+        mockContactAddress({ id: "address-2", address: "0x456" }),
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useRecipientAddressModalViewModel({
+        account: mockAccount,
+        currency: mockAccount.currency,
+        onAddressSelected,
+        recipientSupportsDomain: true,
+      }),
+    );
+
+    act(() => result.current.handleContactSelect(contact));
+    expect(selectContact).toHaveBeenCalledWith(contact);
+    expect(onAddressSelected).not.toHaveBeenCalled();
+
+    act(() => result.current.handleContactAddressSelect("0x456"));
+    expect(clearSelectedContact).toHaveBeenCalledTimes(1);
+    expect(onAddressSelected).toHaveBeenCalledWith("0x456", undefined, true);
+  });
+
+  it("opens address selection when a contact has several addresses and none match the current currency", () => {
+    const onAddressSelected = jest.fn();
+    const selectContact = jest.fn();
+    mockedUseRecipientContactSelection.mockReturnValue({
+      selectedContact: undefined,
+      selectContact,
+      clearSelectedContact: jest.fn(),
+    });
     const contact = mockContact({
       addresses: [
         mockContactAddress({
@@ -358,6 +478,7 @@ describe("useRecipientAddressModalViewModel", () => {
 
     act(() => result.current.handleContactSelect(contact));
 
+    expect(selectContact).toHaveBeenCalledWith(contact);
     expect(onAddressSelected).not.toHaveBeenCalled();
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientAddressModalViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientAddressModalViewModel.ts
@@ -3,8 +3,8 @@ import { useContacts, useContactsFeature } from "@features/platform-contacts";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import { useRecipientSearchState } from "@ledgerhq/live-common/flows/send/recipient/hooks/useRecipientSearchState";
+import { filterContactsByNetwork } from "@ledgerhq/live-common/flows/send/recipient/utils/filterContactsByNetwork";
 import { pickContactAddressForCurrency } from "@ledgerhq/live-common/flows/send/recipient/utils/pickContactAddressForCurrency";
-import { resolveRecipientNetworkId } from "@ledgerhq/live-common/flows/send/recipient/utils/resolveRecipientNetworkId";
 import type { CryptoCurrency } from "@domain/entity-currency-crypto";
 import type { TokenCurrency } from "@domain/entity-currency-token";
 import type { Contact } from "@domain/entity-contact";
@@ -16,6 +16,7 @@ import { useAddressValidation } from "./useAddressValidation";
 import { useAddressMatchedSectionViewModel } from "./useAddressMatchedSectionViewModel";
 import { track } from "~/renderer/analytics/segment";
 import { getSendFlowTrackingProperties } from "../../../utils/tracking";
+import { useRecipientContactSelection } from "../../../context/RecipientContactSelectionContext";
 
 type UseRecipientAddressModalViewModelProps = Readonly<{
   account: AccountLike;
@@ -35,6 +36,7 @@ export function useRecipientAddressModalViewModel({
   const { recipientSearch, state } = useSendFlowData();
   const contacts = useContacts();
   const { isEnabled: isContactsFeatureEnabled } = useContactsFeature("desktop");
+  const { selectedContact, selectContact, clearSelectedContact } = useRecipientContactSelection();
   const { navigation } = useFlowWizard<SendFlowStep>();
 
   const mainAccount = getMainAccount(account, parentAccount);
@@ -55,28 +57,30 @@ export function useRecipientAddressModalViewModel({
     canSearchContactsByName: isContactsFeatureEnabled && hasAddressBook,
   });
 
-  const contactsOnNetwork = useMemo(() => {
-    const networkId = resolveRecipientNetworkId(currency.id);
-
-    return contacts.reduce<Contact[]>((matchingContacts, contact) => {
-      if (contact.isMe) {
-        return matchingContacts;
-      }
-
-      const addresses = contact.addresses.filter(
-        address => resolveRecipientNetworkId(address.currencyId) === networkId,
-      );
-      if (addresses.length === 0) {
-        return matchingContacts;
-      }
-
-      matchingContacts.push({ ...contact, addresses });
-      return matchingContacts;
-    }, []);
-  }, [contacts, currency.id]);
+  const contactsOnNetwork = useMemo(
+    () => filterContactsByNetwork(contacts, currency.id),
+    [contacts, currency.id],
+  );
 
   const hasSearchValue = recipientSearch.value.length > 0;
-  const showInitialState = !hasSearchValue;
+  const contactSearchResult = useMemo(() => {
+    if (!isContactsFeatureEnabled || !hasAddressBook) {
+      return undefined;
+    }
+
+    const normalizedSearchValue = recipientSearch.value.trim().toLowerCase();
+    if (!normalizedSearchValue) {
+      return undefined;
+    }
+
+    return contactsOnNetwork.find(
+      contact =>
+        contact.addresses.length > 1 && contact.name.trim().toLowerCase() === normalizedSearchValue,
+    );
+  }, [contactsOnNetwork, hasAddressBook, isContactsFeatureEnabled, recipientSearch.value]);
+  const showContactSearchResult =
+    hasSearchValue && selectedContact === undefined && contactSearchResult !== undefined;
+  const showInitialState = !hasSearchValue && selectedContact === undefined;
   const showContactsList =
     showInitialState && isContactsFeatureEnabled && hasAddressBook && contactsOnNetwork.length > 0;
   const showEmptyContactsState = useMemo(() => {
@@ -123,9 +127,20 @@ export function useRecipientAddressModalViewModel({
       const address = pickContactAddressForCurrency(contact.addresses, currency.id);
       if (address) {
         handleAddressSelect(address.address);
+        return;
       }
+
+      selectContact(contact);
     },
-    [currency.id, handleAddressSelect],
+    [currency.id, handleAddressSelect, selectContact],
+  );
+
+  const handleContactAddressSelect = useCallback(
+    (address: string) => {
+      clearSelectedContact();
+      handleAddressSelect(address);
+    },
+    [clearSelectedContact, handleAddressSelect],
   );
 
   const handleAddContact = useCallback(() => {
@@ -139,6 +154,7 @@ export function useRecipientAddressModalViewModel({
     recipientSupportsDomain,
   });
 
+  const shouldHideRegularSearchState = showContactSearchResult || selectedContact !== undefined;
   const addressBookFamilyName = mainAccount.currency.name;
   const addressMatchedSectionViewModel = useAddressMatchedSectionViewModel({
     searchResult: result,
@@ -155,14 +171,19 @@ export function useRecipientAddressModalViewModel({
 
   return {
     searchValue: recipientSearch.value,
-    isLoading,
+    isLoading: !shouldHideRegularSearchState && isLoading,
     result,
     showInitialState,
     showContactsList,
+    showContactSearchResult,
     showEmptyContactsState,
     contactsOnNetwork,
+    contactSearchResult,
+    selectedContact,
+    network: mainAccount.currency,
     handleAddressSelect,
     handleContactSelect,
+    handleContactAddressSelect,
     hasMemo,
     hasMemoValidationError,
     hasFilledMemo,
@@ -175,5 +196,17 @@ export function useRecipientAddressModalViewModel({
     memoDefaultOption,
     memoMaxLength,
     ...searchState,
+    showSearchResults: !shouldHideRegularSearchState && searchState.showSearchResults,
+    showMatchedAddress: !shouldHideRegularSearchState && searchState.showMatchedAddress,
+    showAddressValidationError:
+      !shouldHideRegularSearchState && searchState.showAddressValidationError,
+    showEmptyState: !shouldHideRegularSearchState && searchState.showEmptyState,
+    showBridgeSenderError: !shouldHideRegularSearchState && searchState.showBridgeSenderError,
+    showSanctionedBanner: !shouldHideRegularSearchState && searchState.showSanctionedBanner,
+    showBridgeRecipientError: !shouldHideRegularSearchState && searchState.showBridgeRecipientError,
+    showBridgeRecipientWarning:
+      !shouldHideRegularSearchState && searchState.showBridgeRecipientWarning,
+    isAddressComplete: !shouldHideRegularSearchState && searchState.isAddressComplete,
+    isAddressValid: !shouldHideRegularSearchState && searchState.isAddressValid,
   };
 }

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -2576,6 +2576,7 @@
     "addressBookUnsupported": "{{family}} isn't supported yet",
     "recentSendWillAppear": "Your recent send will appear here",
     "contactsWillAppear": "Contacts will appear here",
+    "selectAddress": "Select address",
     "securityInfo": {
       "title": "How to send securely?",
       "items": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4539,6 +4539,7 @@
   "send": {
     "newSendFlow": {
       "title": "Send {{currency}}",
+      "selectAddress": "Select address",
       "available": "Available {{amount}}",
       "to": "To:",
       "addressDisclaimer": {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/SendFlowOrchestrator.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/SendFlowOrchestrator.tsx
@@ -9,6 +9,7 @@ import {
 
 import { FlowStackNavigator } from "../FlowWizard/FlowStackNavigator";
 import { SendFlowProvider } from "./context/SendFlowContext";
+import { RecipientContactSelectionProvider } from "./context/RecipientContactSelectionContext";
 import { SendSignatureProvider, useSendSignature } from "./context/SendSignatureContext";
 import { SignatureOverlayHost } from "./components/SignatureOverlayHost";
 import { useSendFlowBusinessLogic } from "./hooks/useSendFlowState";
@@ -76,15 +77,17 @@ export function SendFlowOrchestrator({
 
   return (
     <SendFlowProvider value={businessContext} onClose={onClose}>
-      <SendSignatureProvider>
-        <SendFlowNavigator
-          stepRegistry={stepRegistry}
-          flowConfig={configuredFlowConfig}
-          onClose={onClose}
-        />
-        <SignatureOverlayHost />
-        {children}
-      </SendSignatureProvider>
+      <RecipientContactSelectionProvider>
+        <SendSignatureProvider>
+          <SendFlowNavigator
+            stepRegistry={stepRegistry}
+            flowConfig={configuredFlowConfig}
+            onClose={onClose}
+          />
+          <SignatureOverlayHost />
+          {children}
+        </SendSignatureProvider>
+      </RecipientContactSelectionProvider>
     </SendFlowProvider>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
@@ -236,6 +236,40 @@ describe("Send flow integration tests", () => {
     expect(await screen.findByText("Review")).toBeVisible();
   });
 
+  it("should ask which address to use when a contact has several network addresses", async () => {
+    const contacts = [
+      mockContact({
+        id: "contact-benoit",
+        name: "Benoit",
+        addresses: [
+          mockContactAddress({
+            id: "address-benoit-main",
+            currencyId: "ethereum",
+            label: "Ethereum",
+            address: VALID_ETHEREUM_RECIPIENT,
+          }),
+          mockContactAddress({
+            id: "address-benoit-coinbase",
+            currencyId: "ethereum",
+            label: "Ethereum Coinbase",
+            address: "0x1234567890123456789012345678901234567890",
+          }),
+        ],
+      }),
+    ];
+    const { user } = renderForAccount(accountEthereum, {}, { contactsEnabled: true, contacts });
+
+    await user.press(await screen.findByTestId("contacts-compact-row-contact-benoit"));
+
+    expect(await screen.findByText("Select address")).toBeVisible();
+    expect(screen.getByText("Benoit")).toBeVisible();
+    expect(screen.queryByTestId("recipient-input")).toBeNull();
+
+    await user.press(screen.getByTestId("send-recipient-contact-address-address-benoit-coinbase"));
+
+    expect(await screen.findByText("Review")).toBeVisible();
+  });
+
   it("should explain why add contact is unavailable on an unsupported network", async () => {
     const { user } = renderForAccount(accountBitcoin, {}, { contactsEnabled: true });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/context/RecipientContactSelectionContext.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/context/RecipientContactSelectionContext.tsx
@@ -1,0 +1,45 @@
+import type { Contact } from "@domain/entity-contact";
+import React, { createContext, useCallback, useContext, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+
+type RecipientContactSelectionContextValue = Readonly<{
+  selectedContact: Contact | undefined;
+  selectContact: (contact: Contact) => void;
+  clearSelectedContact: () => void;
+}>;
+
+const RecipientContactSelectionContext =
+  createContext<RecipientContactSelectionContextValue | null>(null);
+
+type RecipientContactSelectionProviderProps = Readonly<{
+  children: ReactNode;
+}>;
+
+export function RecipientContactSelectionProvider({
+  children,
+}: RecipientContactSelectionProviderProps) {
+  const [selectedContact, setSelectedContact] = useState<Contact>();
+
+  const selectContact = useCallback((contact: Contact) => setSelectedContact(contact), []);
+  const clearSelectedContact = useCallback(() => setSelectedContact(undefined), []);
+  const value = useMemo(
+    () => ({ selectedContact, selectContact, clearSelectedContact }),
+    [clearSelectedContact, selectContact, selectedContact],
+  );
+
+  return (
+    <RecipientContactSelectionContext.Provider value={value}>
+      {children}
+    </RecipientContactSelectionContext.Provider>
+  );
+}
+
+export function useRecipientContactSelection(): RecipientContactSelectionContextValue {
+  const context = useContext(RecipientContactSelectionContext);
+  if (!context) {
+    throw new Error(
+      "useRecipientContactSelection must be used within a RecipientContactSelectionProvider",
+    );
+  }
+  return context;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useSendHeaderViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useSendHeaderViewModel.test.ts
@@ -14,6 +14,8 @@ import { useSendHeaderViewModel } from "../useSendHeaderViewModel";
 import { useSelector } from "~/context/hooks";
 import { useContactsFeature } from "@features/platform-contacts";
 import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
+import { mockContact } from "@domain/entity-contact/schema.mock";
+import { useRecipientContactSelection } from "../../context/RecipientContactSelectionContext";
 
 jest.mock("@react-navigation/native", () => ({
   useNavigation: jest.fn(),
@@ -26,6 +28,7 @@ jest.mock("~/context/Locale", () => ({
 }));
 jest.mock("~/reducers/wallet");
 jest.mock("../../context/SendFlowContext");
+jest.mock("../../context/RecipientContactSelectionContext");
 jest.mock("@ledgerhq/live-common/flows/send/amount/SendAmountDisplayModeContext");
 jest.mock("../useAvailableBalance");
 jest.mock("../useCurrentSendFlowStep");
@@ -44,6 +47,7 @@ const mockedUseSendFlowActions = jest.mocked(useSendFlowActions);
 const mockedUseSendAmountDisplayMode = jest.mocked(useSendAmountDisplayMode);
 const mockedUseAvailableBalance = jest.mocked(useAvailableBalance);
 const mockedUseCurrentSendFlowStep = jest.mocked(useCurrentSendFlowStep);
+const mockedUseRecipientContactSelection = jest.mocked(useRecipientContactSelection);
 
 const mockAccount = {
   type: "Account",
@@ -65,6 +69,7 @@ describe("useSendHeaderViewModel", () => {
   const mockNavigate = jest.fn();
   const mockGoBack = jest.fn();
   const mockCanGoBack = jest.fn(() => false);
+  const mockAddListener = jest.fn(() => jest.fn());
   const mockClearRecipientSearch = jest.fn();
   const mockSetRecipientSearchValue = jest.fn();
 
@@ -75,6 +80,7 @@ describe("useSendHeaderViewModel", () => {
       canGoBack: mockCanGoBack,
       goBack: mockGoBack,
       navigate: mockNavigate,
+      addListener: mockAddListener,
     } as never);
     mockedUseMaybeAccountName.mockReturnValue("Base 1");
     mockedUseSendAmountDisplayMode.mockReturnValue({
@@ -92,6 +98,11 @@ describe("useSendHeaderViewModel", () => {
         showHeaderRight: true,
       },
     ]);
+    mockedUseRecipientContactSelection.mockReturnValue({
+      selectedContact: undefined,
+      selectContact: jest.fn(),
+      clearSelectedContact: jest.fn(),
+    });
     mockedUseSendFlowData.mockReturnValue({
       uiConfig: {
         recipientSupportsDomain: true,
@@ -135,6 +146,29 @@ describe("useSendHeaderViewModel", () => {
     expect(result.current.title).toBe("Send ETH");
     expect(result.current.descriptionText).toBe("Base 1 · $5,969.83");
     expect(mockedUseAvailableBalance).toHaveBeenCalledWith(mockAccount, "fiat");
+  });
+
+  it("shows address selection for a contact and returns to the recipient list", () => {
+    const clearSelectedContact = jest.fn();
+    mockedUseRecipientContactSelection.mockReturnValue({
+      selectedContact: mockContact({ name: "Benoit" }),
+      selectContact: jest.fn(),
+      clearSelectedContact,
+    });
+
+    const { result } = renderHook(() => useSendHeaderViewModel());
+
+    expect(result.current.title).toBe("send.newSendFlow.selectAddress");
+    expect(result.current.descriptionText).toBe("Benoit");
+    expect(result.current.showRecipientInput).toBe(false);
+    expect(result.current.showHeaderRight).toBe(false);
+    expect(result.current.canGoBack).toBe(true);
+    expect(mockAddListener).toHaveBeenCalledWith("beforeRemove", expect.any(Function));
+
+    result.current.handleBackPress();
+
+    expect(clearSelectedContact).toHaveBeenCalledTimes(1);
+    expect(mockGoBack).not.toHaveBeenCalled();
   });
 
   it("formats the header balance with the selected amount display mode", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendHeaderViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendHeaderViewModel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useNavigation } from "@react-navigation/native";
 import { BigNumber } from "bignumber.js";
 import { useTranslation } from "~/context/Locale";
@@ -27,6 +27,7 @@ import { selectContacts } from "@domain/entity-contact";
 import { useSelector } from "~/context/hooks";
 import { formatAddress } from "@ledgerhq/live-common/utils/addressUtils";
 import type { SendFlowNavigationProp } from "../types";
+import { useRecipientContactSelection } from "../context/RecipientContactSelectionContext";
 
 export type SendHeaderViewModel = {
   title: string;
@@ -74,6 +75,7 @@ export function useSendHeaderViewModel(): SendHeaderViewModel {
   const { displayMode } = useSendAmountDisplayMode();
   const { isEnabled: isContactsFeatureEnabled } = useContactsFeature("mobile");
   const contacts = useSelector(selectContacts);
+  const { selectedContact, clearSelectedContact } = useRecipientContactSelection();
 
   const accountName = useMaybeAccountName(state.account.account);
   const [currentStep, currentStepConfig] = useCurrentSendFlowStep();
@@ -81,11 +83,16 @@ export function useSendHeaderViewModel(): SendHeaderViewModel {
   const spendableBalanceText = useAvailableBalance(state.account.account, headerDisplayMode);
 
   const currencyName = state.account.currency?.ticker ?? "";
+  const isRecipientStep = currentStep === SEND_FLOW_STEP.RECIPIENT;
+  const isAmountStep = currentStep === SEND_FLOW_STEP.AMOUNT;
+  const isSelectingContactAddress = isRecipientStep && selectedContact !== undefined;
   const showTitle = currentStepConfig?.showTitle !== false;
   const isCustomFeesStep = currentStep === SEND_FLOW_STEP.CUSTOM_FEES;
   const isCoinControlStep = currentStep === SEND_FLOW_STEP.COIN_CONTROL;
   let title = "";
-  if (showTitle) {
+  if (isSelectingContactAddress) {
+    title = t("send.newSendFlow.selectAddress");
+  } else if (showTitle) {
     if (isCustomFeesStep) {
       title = t("send.newSendFlow.customFees.title");
     } else if (isCoinControlStep) {
@@ -94,16 +101,28 @@ export function useSendHeaderViewModel(): SendHeaderViewModel {
       title = t("send.newSendFlow.title", { currency: currencyName });
     }
   }
-  const descriptionText =
-    showTitle && !isCustomFeesStep
+  const descriptionText = isSelectingContactAddress
+    ? selectedContact.name
+    : showTitle && !isCustomFeesStep
       ? [accountName, spendableBalanceText].filter(Boolean).join(" · ")
       : "";
 
-  const showHeaderRight = currentStepConfig?.showHeaderRight !== false;
-  const canGoBack = Boolean(currentStepConfig?.canGoBack && navigation.canGoBack());
-  const isRecipientStep = currentStep === SEND_FLOW_STEP.RECIPIENT;
-  const isAmountStep = currentStep === SEND_FLOW_STEP.AMOUNT;
-  const showRecipientInput = Boolean(currentStepConfig?.addressInput);
+  const showHeaderRight =
+    !isSelectingContactAddress && currentStepConfig?.showHeaderRight !== false;
+  const canGoBack =
+    isSelectingContactAddress || Boolean(currentStepConfig?.canGoBack && navigation.canGoBack());
+  const showRecipientInput = Boolean(currentStepConfig?.addressInput) && !isSelectingContactAddress;
+
+  useEffect(() => {
+    if (!isSelectingContactAddress) {
+      return;
+    }
+
+    return navigation.addListener("beforeRemove", event => {
+      event.preventDefault();
+      clearSelectedContact();
+    });
+  }, [clearSelectedContact, isSelectingContactAddress, navigation]);
 
   const recipientFromTransaction = useMemo(() => {
     const address = state.transaction.transaction?.recipient;
@@ -139,6 +158,11 @@ export function useSendHeaderViewModel(): SendHeaderViewModel {
   }, [isRecipientStep, isAmountStep, recipientHeader.label, recipientSearch.value]);
 
   const handleBackPress = useCallback(() => {
+    if (isSelectingContactAddress) {
+      clearSelectedContact();
+      return;
+    }
+
     if (canGoBack) {
       if (currentStep === SEND_FLOW_STEP.AMOUNT) {
         transaction.updateTransaction(tx => ({
@@ -152,7 +176,15 @@ export function useSendHeaderViewModel(): SendHeaderViewModel {
     } else {
       close();
     }
-  }, [canGoBack, close, currentStep, navigation, transaction]);
+  }, [
+    canGoBack,
+    clearSelectedContact,
+    close,
+    currentStep,
+    isSelectingContactAddress,
+    navigation,
+    transaction,
+  ]);
 
   const handleClose = useCallback(() => {
     close();

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientContactAddressSelection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientContactAddressSelection.tsx
@@ -1,0 +1,77 @@
+import type { CryptoCurrency } from "@domain/entity-currency-crypto";
+import type { Contact } from "@domain/entity-contact";
+import { SEND_ADDRESS_FORMAT_OPTIONS } from "@ledgerhq/live-common/flows/send/utils";
+import { formatAddress } from "@ledgerhq/live-common/utils/addressUtils";
+import {
+  Box,
+  Card,
+  CardContent,
+  CardContentDescription,
+  CardContentTitle,
+  CardHeader,
+  CardLeading,
+  Text,
+} from "@ledgerhq/lumen-ui-rnative";
+import React from "react";
+import CurrencyIcon from "~/components/CurrencyIcon";
+
+type RecipientContactAddressSelectionProps = Readonly<{
+  contact: Contact;
+  network: CryptoCurrency;
+  onAddressSelect: (address: string) => void;
+}>;
+
+export function RecipientContactAddressSelection({
+  contact,
+  network,
+  onAddressSelect,
+}: RecipientContactAddressSelectionProps) {
+  return (
+    <Box
+      testID="send-recipient-contact-address-selection"
+      lx={{ gap: "s12", marginHorizontal: "s8" }}
+    >
+      <Box
+        lx={{
+          flexDirection: "row",
+          alignItems: "center",
+          gap: "s8",
+          paddingHorizontal: "s8",
+        }}
+      >
+        <CurrencyIcon currency={network} size={16} squared />
+        <Text typography="body2" lx={{ color: "muted" }}>
+          {network.name}
+        </Text>
+      </Box>
+
+      <Box lx={{ gap: "s8" }}>
+        {contact.addresses.map(address => {
+          const formattedAddress = formatAddress(address.address, SEND_ADDRESS_FORMAT_OPTIONS);
+
+          return (
+            <Card
+              key={address.id}
+              type="interactive"
+              onPress={() => onAddressSelect(address.address)}
+              accessibilityLabel={`${address.label}, ${address.address}`}
+              testID={`send-recipient-contact-address-${address.id}`}
+            >
+              <CardHeader>
+                <CardLeading>
+                  <CurrencyIcon currency={network} size={48} />
+                  <CardContent>
+                    <CardContentTitle typography="body2SemiBold">{address.label}</CardContentTitle>
+                    <CardContentDescription typography="body3">
+                      {formattedAddress}
+                    </CardContentDescription>
+                  </CardContent>
+                </CardLeading>
+              </CardHeader>
+            </Card>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientScreenView.tsx
@@ -8,6 +8,7 @@ import { AddressMatchedSection } from "./AddressMatchedSection";
 import { AddressValidationError } from "./AddressValidationError";
 import { LoadingState } from "./LoadingState";
 import { PasteFromClipboard } from "./PasteFromClipboard";
+import { RecipientContactAddressSelection } from "./RecipientContactAddressSelection";
 import { RecipientContactsList } from "./RecipientContactsList";
 import { RecipientEmptyContactsState } from "./RecipientEmptyContactsState";
 import { ValidationBanner } from "./ValidationBanner";
@@ -30,8 +31,13 @@ export const RecipientScreenView = ({ viewModel }: RecipientScreenViewProps) => 
     isLoading,
     showInitialState,
     showContactsList,
+    showContactSearchResult,
     showEmptyContactsState,
     contactsOnNetwork,
+    contactSearchResult,
+    selectedContact,
+    handleContactSelect,
+    handleContactAddressSelect,
     showBridgeSenderError,
     bridgeSenderError,
     showSanctionedBanner,
@@ -43,7 +49,6 @@ export const RecipientScreenView = ({ viewModel }: RecipientScreenViewProps) => 
     addressValidationErrorType,
     clipboardAddress,
     handlePasteFromClipboard,
-    handleContactSelect,
   } = recipient;
 
   return (
@@ -68,6 +73,21 @@ export const RecipientScreenView = ({ viewModel }: RecipientScreenViewProps) => 
             <RecipientContactsList
               contacts={contactsOnNetwork}
               onContactSelect={handleContactSelect}
+            />
+          )}
+
+          {showContactSearchResult && contactSearchResult && (
+            <RecipientContactsList
+              contacts={[contactSearchResult]}
+              onContactSelect={handleContactSelect}
+            />
+          )}
+
+          {selectedContact && (
+            <RecipientContactAddressSelection
+              contact={selectedContact}
+              network={recipient.mainAccount.currency}
+              onAddressSelect={handleContactAddressSelect}
             />
           )}
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/__tests__/RecipientContactAddressSelection.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/__tests__/RecipientContactAddressSelection.test.tsx
@@ -1,0 +1,41 @@
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { mockContact, mockContactAddress } from "@domain/entity-contact/schema.mock";
+import { render, screen } from "@tests/test-renderer";
+import React from "react";
+import { RecipientContactAddressSelection } from "../RecipientContactAddressSelection";
+
+describe("RecipientContactAddressSelection", () => {
+  it("shows compatible addresses and selects the requested address", async () => {
+    const contact = mockContact({
+      name: "Benoit",
+      addresses: [
+        mockContactAddress({
+          id: "address-main",
+          label: "Ethereum",
+          address: "0xd03f8fd01234567890abcdef123456783f0f2d19",
+        }),
+        mockContactAddress({
+          id: "address-coinbase",
+          label: "Ethereum Coinbase",
+          address: "0xabcdef01234567890abcdef1234567890abcdef0",
+        }),
+      ],
+    });
+    const onAddressSelect = jest.fn();
+    const { user } = render(
+      <RecipientContactAddressSelection
+        contact={contact}
+        network={getCryptoCurrencyById("ethereum")}
+        onAddressSelect={onAddressSelect}
+      />,
+    );
+
+    expect(screen.getAllByText("Ethereum")).toHaveLength(2);
+    expect(screen.getByText("Ethereum Coinbase")).toBeVisible();
+    expect(screen.getByText("0xd03f8f...3f0f2d19")).toBeVisible();
+
+    await user.press(screen.getByTestId("send-recipient-contact-address-address-coinbase"));
+
+    expect(onAddressSelect).toHaveBeenCalledWith("0xabcdef01234567890abcdef1234567890abcdef0");
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenView.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenView.test.ts
@@ -11,8 +11,10 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
 } from "@ledgerhq/ledger-wallet-framework/errors";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import type { AddressSearchResult } from "@ledgerhq/live-common/flows/send/recipient/types";
 import { mockContact, mockContactAddress } from "@domain/entity-contact/schema.mock";
 import { createMockAccount, createMockCurrency, createMockTokenCurrency } from "./accounts";
+import { useRecipientContactSelection } from "../../../../context/RecipientContactSelectionContext";
 
 jest.mock("../useAddressValidation");
 jest.mock("../useClipboardRecipient");
@@ -20,6 +22,7 @@ jest.mock("../../../../context/SendFlowContext");
 jest.mock("@ledgerhq/live-common/account/index");
 jest.mock("@ledgerhq/live-common/bridge/descriptor/send/features");
 jest.mock("@features/platform-contacts");
+jest.mock("../../../../context/RecipientContactSelectionContext");
 
 const mockedUseAddressValidation = jest.mocked(useAddressValidation);
 const mockedUseClipboardRecipient = jest.mocked(useClipboardRecipient);
@@ -28,6 +31,7 @@ const mockedGetMainAccount = jest.mocked(getMainAccount);
 const mockedSendFeatures = jest.mocked(sendFeatures);
 const mockedUseContacts = jest.mocked(useContacts);
 const mockedUseContactsFeature = jest.mocked(useContactsFeature);
+const mockedUseRecipientContactSelection = jest.mocked(useRecipientContactSelection);
 
 const mockAccount = createMockAccount({ id: "account_1" });
 
@@ -37,8 +41,8 @@ const mockRecipientSearch = {
   clear: jest.fn(),
 };
 
-const idleResult = {
-  status: "idle" as const,
+const idleResult: AddressSearchResult = {
+  status: "idle",
   error: null,
   bridgeErrors: {},
   bridgeWarnings: {},
@@ -55,12 +59,39 @@ const idleResult = {
   matchedContact: undefined,
 };
 
+function mockContactAddressValidation() {
+  let searchValue = "";
+  let validationResult: AddressSearchResult = idleResult;
+  const setValue = jest.fn((value: string) => {
+    searchValue = value;
+  });
+  mockedUseSendFlowData.mockImplementation(() => ({
+    recipientSearch: { ...mockRecipientSearch, value: searchValue, setValue },
+    state: {} as never,
+    uiConfig: {} as never,
+  }));
+  mockedUseAddressValidation.mockImplementation(() => ({
+    result: validationResult,
+    isLoading: false,
+    validateAddress: jest.fn(),
+  }));
+  return {
+    setValue,
+    markAddressValid() {
+      validationResult = {
+        ...idleResult,
+        status: "valid",
+        hasBridgeValidationResult: true,
+      };
+    },
+  };
+}
+
 describe("useRecipientScreenView", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedGetMainAccount.mockImplementation((account, parentAccount) => {
       if (!account) return mockAccount;
-      // getMainAccount returns the account itself if it's an Account, otherwise the parentAccount
       return account.type === "Account" ? account : parentAccount || mockAccount;
     });
     mockedUseClipboardRecipient.mockReturnValue({ clipboardAddress: null });
@@ -80,6 +111,11 @@ describe("useRecipientScreenView", () => {
       isEnabled: false,
       showNewBadge: false,
       eligibleAddressFamilies: ["evm"],
+    });
+    mockedUseRecipientContactSelection.mockReturnValue({
+      selectedContact: undefined,
+      selectContact: jest.fn(),
+      clearSelectedContact: jest.fn(),
     });
   });
 
@@ -243,8 +279,9 @@ describe("useRecipientScreenView", () => {
     });
   });
 
-  it("advances with the address matching the current currency among network addresses", () => {
+  it("validates the address matching the current currency among network addresses", () => {
     const onAddressSelected = jest.fn();
+    const { setValue, markAddressValid } = mockContactAddressValidation();
     const contact = mockContact({
       addresses: [
         mockContactAddress({
@@ -260,7 +297,7 @@ describe("useRecipientScreenView", () => {
       ],
     });
 
-    const { result } = renderHook(() =>
+    const { result, rerender } = renderHook(() =>
       useRecipientScreenView({
         account: mockAccount,
         currency: createMockTokenCurrency(),
@@ -271,19 +308,37 @@ describe("useRecipientScreenView", () => {
 
     act(() => result.current.handleContactSelect(contact));
 
+    expect(setValue).toHaveBeenCalledWith("0xusdt");
+    expect(onAddressSelected).not.toHaveBeenCalled();
+
+    markAddressValid();
+    rerender(undefined);
+
     expect(onAddressSelected).toHaveBeenCalledWith("0xusdt", undefined);
   });
 
-  it("advances with the sole address of a selected contact", () => {
+  it("validates the only compatible contact address before continuing", () => {
     const onAddressSelected = jest.fn();
+    const selectContact = jest.fn();
+    const { setValue, markAddressValid } = mockContactAddressValidation();
+    mockedUseRecipientContactSelection.mockReturnValue({
+      selectedContact: undefined,
+      selectContact,
+      clearSelectedContact: jest.fn(),
+    });
     const contact = mockContact({
-      addresses: [mockContactAddress({ address: "0x123" })],
+      addresses: [
+        mockContactAddress({
+          currencyId: "ethereum",
+          address: "0x1234567890123456789012345678901234567890",
+        }),
+      ],
     });
 
-    const { result } = renderHook(() =>
+    const { result, rerender } = renderHook(() =>
       useRecipientScreenView({
         account: mockAccount,
-        currency: mockAccount.currency,
+        currency: createMockCurrency({ id: "ethereum" }),
         onAddressSelected,
         recipientSupportsDomain: true,
       }),
@@ -291,11 +346,99 @@ describe("useRecipientScreenView", () => {
 
     act(() => result.current.handleContactSelect(contact));
 
-    expect(onAddressSelected).toHaveBeenCalledWith("0x123", undefined);
+    expect(setValue).toHaveBeenCalledWith("0x1234567890123456789012345678901234567890");
+    expect(onAddressSelected).not.toHaveBeenCalled();
+    expect(selectContact).not.toHaveBeenCalled();
+
+    markAddressValid();
+    rerender(undefined);
+
+    expect(onAddressSelected).toHaveBeenCalledWith(
+      "0x1234567890123456789012345678901234567890",
+      undefined,
+    );
   });
 
-  it("does not advance when several addresses remain without a currency match", () => {
+  it.each([
+    ["invalid", "incorrect_format"],
+    ["sanctioned", "sanctioned"],
+  ] as const)("does not continue with a %s contact address", (status, error) => {
     const onAddressSelected = jest.fn();
+    let searchValue = "";
+    const setValue = jest.fn((value: string) => {
+      searchValue = value;
+    });
+    mockedUseSendFlowData.mockImplementation(() => ({
+      recipientSearch: { ...mockRecipientSearch, value: searchValue, setValue },
+      state: {} as never,
+      uiConfig: {} as never,
+    }));
+    mockedUseAddressValidation.mockReturnValue({
+      result: { ...idleResult, status, error },
+      isLoading: false,
+      validateAddress: jest.fn(),
+    });
+    const contact = mockContact({
+      addresses: [
+        mockContactAddress({
+          currencyId: "ethereum",
+          address: "0x1234567890123456789012345678901234567890",
+        }),
+      ],
+    });
+    const { result } = renderHook(() =>
+      useRecipientScreenView({
+        account: mockAccount,
+        currency: createMockCurrency({ id: "ethereum" }),
+        onAddressSelected,
+        recipientSupportsDomain: true,
+      }),
+    );
+
+    act(() => result.current.handleContactSelect(contact));
+
+    expect(setValue).toHaveBeenCalledWith("0x1234567890123456789012345678901234567890");
+    expect(onAddressSelected).not.toHaveBeenCalled();
+  });
+
+  it("opens address selection when a contact has several compatible addresses", () => {
+    const onAddressSelected = jest.fn();
+    const selectContact = jest.fn();
+    mockedUseRecipientContactSelection.mockReturnValue({
+      selectedContact: undefined,
+      selectContact,
+      clearSelectedContact: jest.fn(),
+    });
+    const contact = mockContact({
+      addresses: [
+        mockContactAddress({ id: "address-one", currencyId: "ethereum" }),
+        mockContactAddress({ id: "address-two", currencyId: "ethereum" }),
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useRecipientScreenView({
+        account: mockAccount,
+        currency: createMockCurrency({ id: "ethereum" }),
+        onAddressSelected,
+        recipientSupportsDomain: true,
+      }),
+    );
+
+    act(() => result.current.handleContactSelect(contact));
+
+    expect(selectContact).toHaveBeenCalledWith(contact);
+    expect(onAddressSelected).not.toHaveBeenCalled();
+  });
+
+  it("opens address selection when several network addresses remain without a currency match", () => {
+    const onAddressSelected = jest.fn();
+    const selectContact = jest.fn();
+    mockedUseRecipientContactSelection.mockReturnValue({
+      selectedContact: undefined,
+      selectContact,
+      clearSelectedContact: jest.fn(),
+    });
     const contact = mockContact({
       addresses: [
         mockContactAddress({
@@ -322,7 +465,74 @@ describe("useRecipientScreenView", () => {
 
     act(() => result.current.handleContactSelect(contact));
 
+    expect(selectContact).toHaveBeenCalledWith(contact);
     expect(onAddressSelected).not.toHaveBeenCalled();
+  });
+
+  it("validates the chosen address after contact address selection", () => {
+    const onAddressSelected = jest.fn();
+    const clearSelectedContact = jest.fn();
+    const { setValue, markAddressValid } = mockContactAddressValidation();
+    mockedUseRecipientContactSelection.mockReturnValue({
+      selectedContact: undefined,
+      selectContact: jest.fn(),
+      clearSelectedContact,
+    });
+
+    const { result, rerender } = renderHook(() =>
+      useRecipientScreenView({
+        account: mockAccount,
+        currency: createMockCurrency({ id: "ethereum" }),
+        onAddressSelected,
+        recipientSupportsDomain: true,
+      }),
+    );
+
+    act(() => result.current.handleContactAddressSelect("0x456"));
+
+    expect(clearSelectedContact).toHaveBeenCalledTimes(1);
+    expect(setValue).toHaveBeenCalledWith("0x456");
+    expect(onAddressSelected).not.toHaveBeenCalled();
+
+    markAddressValid();
+    rerender(undefined);
+
+    expect(onAddressSelected).toHaveBeenCalledWith("0x456", undefined);
+  });
+
+  it("shows an exact contact search result when its network address is ambiguous", () => {
+    const contact = mockContact({
+      name: "Benoit",
+      addresses: [
+        mockContactAddress({ id: "address-one", currencyId: "ethereum" }),
+        mockContactAddress({ id: "address-two", currencyId: "ethereum" }),
+      ],
+    });
+    mockedSendFeatures.hasAddressBook.mockReturnValue(true);
+    mockedUseContactsFeature.mockReturnValue({
+      isEnabled: true,
+      showNewBadge: false,
+      eligibleAddressFamilies: ["evm"],
+    });
+    mockedUseContacts.mockReturnValue([contact]);
+    mockedUseSendFlowData.mockReturnValue({
+      recipientSearch: { ...mockRecipientSearch, value: "benoit" },
+      state: {} as never,
+      uiConfig: {} as never,
+    });
+
+    const { result } = renderHook(() =>
+      useRecipientScreenView({
+        account: mockAccount,
+        currency: createMockCurrency({ id: "ethereum" }),
+        onAddressSelected: jest.fn(),
+        recipientSupportsDomain: true,
+      }),
+    );
+
+    expect(result.current.showContactSearchResult).toBe(true);
+    expect(result.current.contactSearchResult).toEqual(contact);
+    expect(result.current.showSearchResults).toBe(false);
   });
 
   it("shows search results when search value is provided", () => {
@@ -484,7 +694,6 @@ describe("useRecipientScreenView", () => {
       }),
     );
 
-    // Self-transfer error is a bridge recipient error, so it should be shown
     expect(result.current.showBridgeRecipientError).toBe(true);
     expect(result.current.bridgeRecipientError).toBe(selfTransferError);
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenView.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenView.ts
@@ -2,15 +2,16 @@ import { useContacts, useContactsFeature } from "@features/platform-contacts";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import { useRecipientSearchState } from "@ledgerhq/live-common/flows/send/recipient/hooks/useRecipientSearchState";
+import { filterContactsByNetwork } from "@ledgerhq/live-common/flows/send/recipient/utils/filterContactsByNetwork";
 import { pickContactAddressForCurrency } from "@ledgerhq/live-common/flows/send/recipient/utils/pickContactAddressForCurrency";
-import { resolveRecipientNetworkId } from "@ledgerhq/live-common/flows/send/recipient/utils/resolveRecipientNetworkId";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import type { CryptoCurrency } from "@domain/entity-currency-crypto";
 import type { TokenCurrency } from "@domain/entity-currency-token";
 import type { Contact } from "@domain/entity-contact";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useSendFlowData } from "../../../context/SendFlowContext";
+import { useRecipientContactSelection } from "../../../context/RecipientContactSelectionContext";
 import { useAddressValidation } from "./useAddressValidation";
 import { useClipboardRecipient } from "./useClipboardRecipient";
 
@@ -34,6 +35,8 @@ export function useRecipientScreenView({
   const { recipientSearch } = useSendFlowData();
   const contacts = useContacts();
   const { isEnabled: isContactsFeatureEnabled } = useContactsFeature("mobile");
+  const { selectedContact, selectContact, clearSelectedContact } = useRecipientContactSelection();
+  const [pendingContactAddress, setPendingContactAddress] = useState<string>();
 
   const mainAccount = getMainAccount(account, parentAccount);
   const hasAddressBook = sendFeatures.hasAddressBook(currency);
@@ -49,28 +52,29 @@ export function useRecipientScreenView({
     canSearchContactsByName: isContactsFeatureEnabled && hasAddressBook,
   });
 
-  const contactsOnNetwork = useMemo(() => {
-    const networkId = resolveRecipientNetworkId(currency.id);
-
-    return contacts.reduce<Contact[]>((matchingContacts, contact) => {
-      if (contact.isMe) {
-        return matchingContacts;
-      }
-
-      const addresses = contact.addresses.filter(
-        address => resolveRecipientNetworkId(address.currencyId) === networkId,
-      );
-      if (addresses.length === 0) {
-        return matchingContacts;
-      }
-
-      matchingContacts.push({ ...contact, addresses });
-      return matchingContacts;
-    }, []);
-  }, [contacts, currency.id]);
-
+  const contactsOnNetwork = useMemo(
+    () => filterContactsByNetwork(contacts, currency.id),
+    [contacts, currency.id],
+  );
   const hasSearchValue = recipientSearch.value.length > 0;
-  const showInitialState = !hasSearchValue;
+  const contactSearchResult = useMemo(() => {
+    if (!isContactsFeatureEnabled || !hasAddressBook) {
+      return undefined;
+    }
+
+    const normalizedSearchValue = recipientSearch.value.trim().toLowerCase();
+    if (!normalizedSearchValue) {
+      return undefined;
+    }
+
+    return contactsOnNetwork.find(
+      contact =>
+        contact.addresses.length > 1 && contact.name.trim().toLowerCase() === normalizedSearchValue,
+    );
+  }, [contactsOnNetwork, hasAddressBook, isContactsFeatureEnabled, recipientSearch.value]);
+  const showContactSearchResult =
+    hasSearchValue && selectedContact === undefined && contactSearchResult !== undefined;
+  const showInitialState = !hasSearchValue && selectedContact === undefined;
   const showContactsList =
     showInitialState && isContactsFeatureEnabled && hasAddressBook && contactsOnNetwork.length > 0;
   const showEmptyContactsState = useMemo(() => {
@@ -99,19 +103,39 @@ export function useRecipientScreenView({
 
   const handleAddressSelect = useCallback(
     (address: string, ensName?: string) => {
+      setPendingContactAddress(undefined);
       onAddressSelected(address, ensName);
     },
     [onAddressSelected],
+  );
+
+  const validateContactAddress = useCallback(
+    (address: string) => {
+      setPendingContactAddress(address);
+      recipientSearch.setValue(address);
+    },
+    [recipientSearch],
   );
 
   const handleContactSelect = useCallback(
     (contact: Contact) => {
       const address = pickContactAddressForCurrency(contact.addresses, currency.id);
       if (address) {
-        handleAddressSelect(address.address);
+        validateContactAddress(address.address);
+        return;
       }
+
+      selectContact(contact);
     },
-    [currency.id, handleAddressSelect],
+    [currency.id, selectContact, validateContactAddress],
+  );
+
+  const handleContactAddressSelect = useCallback(
+    (address: string) => {
+      clearSelectedContact();
+      validateContactAddress(address);
+    },
+    [clearSelectedContact, validateContactAddress],
   );
 
   const searchState = useRecipientSearchState({
@@ -121,22 +145,59 @@ export function useRecipientScreenView({
     recipientSupportsDomain,
   });
 
+  useEffect(() => {
+    const selectedAddressIsValidated =
+      Boolean(pendingContactAddress) &&
+      pendingContactAddress === recipientSearch.value &&
+      searchState.isAddressValid &&
+      !searchState.showBridgeSenderError &&
+      !searchState.showBridgeRecipientWarning;
+    if (selectedAddressIsValidated && pendingContactAddress) {
+      handleAddressSelect(pendingContactAddress);
+    }
+  }, [
+    handleAddressSelect,
+    pendingContactAddress,
+    recipientSearch.value,
+    searchState.isAddressValid,
+    searchState.showBridgeRecipientWarning,
+    searchState.showBridgeSenderError,
+  ]);
+
+  const shouldHideRegularSearchState = showContactSearchResult || selectedContact !== undefined;
+
   return {
     searchValue: recipientSearch.value,
-    isLoading,
+    isLoading: !shouldHideRegularSearchState && isLoading,
     result,
     mainAccount,
     hasAddressBook,
     addressBookFamilyName: mainAccount.currency.name,
     showInitialState,
     showContactsList,
+    showContactSearchResult,
     showEmptyContactsState,
     contactsOnNetwork,
+    contactSearchResult,
+    selectedContact,
     clipboardAddress,
     handlePasteFromClipboard,
     handleAddressSelect,
     handleContactSelect,
+    handleContactAddressSelect,
     isContactsFeatureEnabled,
     ...searchState,
+    showSearchResults: !shouldHideRegularSearchState && searchState.showSearchResults,
+    showMatchedAddress: !shouldHideRegularSearchState && searchState.showMatchedAddress,
+    showAddressValidationError:
+      !shouldHideRegularSearchState && searchState.showAddressValidationError,
+    showEmptyState: !shouldHideRegularSearchState && searchState.showEmptyState,
+    showBridgeSenderError: !shouldHideRegularSearchState && searchState.showBridgeSenderError,
+    showSanctionedBanner: !shouldHideRegularSearchState && searchState.showSanctionedBanner,
+    showBridgeRecipientError: !shouldHideRegularSearchState && searchState.showBridgeRecipientError,
+    showBridgeRecipientWarning:
+      !shouldHideRegularSearchState && searchState.showBridgeRecipientWarning,
+    isAddressComplete: !shouldHideRegularSearchState && searchState.isAddressComplete,
+    isAddressValid: !shouldHideRegularSearchState && searchState.isAddressValid,
   };
 }

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -644,6 +644,7 @@
     "src/flows/send/recipient/hooks/useRecipientSearchState.ts",
     "src/flows/send/recipient/types.ts",
     "src/flows/send/recipient/utils/addressesMatch.ts",
+    "src/flows/send/recipient/utils/filterContactsByNetwork.ts",
     "src/flows/send/recipient/utils/findMatchedContact.ts",
     "src/flows/send/recipient/utils/getRecipientHeaderPresentation.ts",
     "src/flows/send/recipient/utils/getRecipientMatchPresentation.ts",

--- a/libs/ledger-live-common/src/flows/send/recipient/utils/__tests__/filterContactsByNetwork.test.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/utils/__tests__/filterContactsByNetwork.test.ts
@@ -1,0 +1,63 @@
+import { filterContactsByNetwork } from "../filterContactsByNetwork";
+
+describe("filterContactsByNetwork", () => {
+  const ethereumAddress = {
+    id: "address-ethereum",
+    currencyId: "ethereum",
+  };
+  const usdcAddress = {
+    id: "address-usdc",
+    currencyId: "ethereum/erc20/usd_coin",
+  };
+  const solanaAddress = {
+    id: "address-solana",
+    currencyId: "solana",
+  };
+
+  it("keeps contacts and addresses matching the recipient network", () => {
+    const contacts = [
+      {
+        id: "contact-ethereum",
+        isMe: false,
+        addresses: [ethereumAddress, usdcAddress, solanaAddress],
+      },
+      {
+        id: "contact-solana",
+        isMe: false,
+        addresses: [solanaAddress],
+      },
+    ];
+
+    expect(filterContactsByNetwork(contacts, "ethereum")).toEqual([
+      {
+        id: "contact-ethereum",
+        isMe: false,
+        addresses: [ethereumAddress, usdcAddress],
+      },
+    ]);
+  });
+
+  it("resolves a token currency to its parent network", () => {
+    const contacts = [
+      {
+        id: "contact-ethereum",
+        isMe: false,
+        addresses: [ethereumAddress, usdcAddress],
+      },
+    ];
+
+    expect(filterContactsByNetwork(contacts, "ethereum/erc20/usd_coin")).toEqual(contacts);
+  });
+
+  it("excludes the personal contact", () => {
+    const contacts = [
+      {
+        id: "contact-me",
+        isMe: true,
+        addresses: [ethereumAddress],
+      },
+    ];
+
+    expect(filterContactsByNetwork(contacts, "ethereum")).toEqual([]);
+  });
+});

--- a/libs/ledger-live-common/src/flows/send/recipient/utils/__tests__/pickContactAddressForCurrency.test.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/utils/__tests__/pickContactAddressForCurrency.test.ts
@@ -28,6 +28,18 @@ describe("pickContactAddressForCurrency", () => {
     expect(pickContactAddressForCurrency([ethAddress], "ethereum/erc20/usd_coin")).toBe(ethAddress);
   });
 
+  it("does not pick an address when several addresses share the requested currency", () => {
+    expect(
+      pickContactAddressForCurrency(
+        [
+          { id: "eth-1", currencyId: "ethereum", address: "0x123" },
+          { id: "eth-2", currencyId: "ethereum", address: "0x456" },
+        ],
+        "ethereum",
+      ),
+    ).toBeUndefined();
+  });
+
   it("does not pick an address when several candidates remain without an exact currency match", () => {
     expect(
       pickContactAddressForCurrency(

--- a/libs/ledger-live-common/src/flows/send/recipient/utils/filterContactsByNetwork.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/utils/filterContactsByNetwork.ts
@@ -1,0 +1,28 @@
+import { resolveRecipientNetworkId } from "./resolveRecipientNetworkId";
+
+type ContactWithAddresses = Readonly<{
+  isMe: boolean;
+  addresses: readonly Readonly<{ currencyId: string }>[];
+}>;
+
+export function filterContactsByNetwork<TContact extends ContactWithAddresses>(
+  contacts: readonly TContact[],
+  currencyId: string,
+): TContact[] {
+  const networkId = resolveRecipientNetworkId(currencyId);
+
+  return contacts.reduce<TContact[]>((matchingContacts, contact) => {
+    if (contact.isMe) {
+      return matchingContacts;
+    }
+
+    const addresses = contact.addresses.filter(
+      address => resolveRecipientNetworkId(address.currencyId) === networkId,
+    );
+    if (addresses.length > 0) {
+      matchingContacts.push({ ...contact, addresses } as TContact);
+    }
+
+    return matchingContacts;
+  }, []);
+}

--- a/libs/ledger-live-common/src/flows/send/recipient/utils/pickContactAddressForCurrency.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/utils/pickContactAddressForCurrency.ts
@@ -6,6 +6,10 @@ export function pickContactAddressForCurrency<T extends ContactAddress>(
   addresses: readonly T[],
   currencyId: string,
 ): T | undefined {
-  const exactCurrencyAddress = addresses.find(address => address.currencyId === currencyId);
-  return exactCurrencyAddress ?? (addresses.length === 1 ? addresses[0] : undefined);
+  const exactCurrencyAddresses = addresses.filter(address => address.currencyId === currencyId);
+  if (exactCurrencyAddresses.length === 1) {
+    return exactCurrencyAddresses[0];
+  }
+
+  return exactCurrencyAddresses.length === 0 && addresses.length === 1 ? addresses[0] : undefined;
 }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

When a contact has several addresses on the selected Send network, the recipient step now lets you pick which one receives the funds instead of auto-selecting. A unique match for the current currency (or a single compatible address) is still applied immediately

https://github.com/user-attachments/assets/6564641e-d045-4cb2-86f9-32907bf0e0c2


### 🔗 Context

- **[JIRA / GitHub issue](https://ledgerhq.atlassian.net/browse/LIVE-35806)**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
