### PR TITLE
[LWDM] chore(tooling): bump msw to 2.15.0 (LIVE-36360)

### DIFF
--- a/libs/coin-modules/coin-mina/src/test/helpers/msw-rosetta.mock.ts
+++ b/libs/coin-modules/coin-mina/src/test/helpers/msw-rosetta.mock.ts
@@ -1,4 +1,4 @@
-import { http, HttpResponse } from "msw";
+import { http, HttpResponse, type JsonBodyType, type StrictResponse } from "msw";
 import { type SetupServer, setupServer } from "msw/node";
 import type {
   FetchAccountBalanceResponse,
@@ -50,7 +50,7 @@ function invokeRouteHandler(
   handler: ((body: unknown) => unknown) | undefined,
   route: string,
   body: unknown,
-): HttpResponse {
+): StrictResponse<JsonBodyType> {
   if (!handler) {
     return HttpResponse.json(
       { code: 404, message: `No handler for route: ${route}`, retriable: false },
@@ -58,7 +58,7 @@ function invokeRouteHandler(
     );
   }
   try {
-    return HttpResponse.json(handler(body));
+    return HttpResponse.json(handler(body) as JsonBodyType);
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
     return HttpResponse.json({ code: 500, message, retriable: false }, { status: 500 });

--- a/libs/coin-tester-modules/coin-tester-evm/src/indexer.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/indexer.ts
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js";
-import { SetupServerApi, setupServer } from "msw/node";
+import { SetupServer, setupServer } from "msw/node";
 import { http, HttpResponse } from "msw";
 import { AbiCoder, ethers } from "ethers";
 import { ERC20_ABI, ERC721_ABI, ERC1155_ABI } from "@ledgerhq/coin-evm/abis/index";
@@ -761,7 +761,7 @@ const getEtherscanOpsMap = (action: string) => {
   }
 };
 
-let server: SetupServerApi;
+let server: SetupServer;
 export const initMswHandlers = (currencyConfig: EvmConfigInfo) => {
   const handlers = [
     http.get("https://global.api.prd.ledger.com/cal/v1/currencies", ({ request }) => {

--- a/libs/coin-tester-modules/coin-tester-near/src/indexer.ts
+++ b/libs/coin-tester-modules/coin-tester-near/src/indexer.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from "msw";
-import { setupServer, type SetupServerApi } from "msw/node";
+import { setupServer, type SetupServer } from "msw/node";
 import type { NearTransaction } from "@ledgerhq/coin-near/network/sdk.types";
 import { INDEXER_URL, POOL_ID } from "./fixtures";
 
@@ -130,7 +130,7 @@ async function historyFor(rpc: RpcCall, address: string, limit: number) {
   return transactions;
 }
 
-export function startIndexer(rpc: RpcCall): SetupServerApi {
+export function startIndexer(rpc: RpcCall): SetupServer {
   const server = setupServer(
     http.get(`${INDEXER_URL}/v3/accounts/:address/txns`, async ({ params, request }) => {
       const limit = Number(new URL(request.url).searchParams.get("limit") ?? 25);

--- a/libs/coin-tester-modules/coin-tester-near/src/scenarii/near.ts
+++ b/libs/coin-tester-modules/coin-tester-near/src/scenarii/near.ts
@@ -3,7 +3,7 @@ import type { Account } from "@ledgerhq/types-live";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import type { Scenario, ScenarioTransaction } from "@ledgerhq/coin-tester/main";
 import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
-import type { SetupServerApi } from "msw/node";
+import type { SetupServer } from "msw/node";
 import {
   EPOCHS_TO_UNLOCK_BLOCKS,
   IMPLICIT_RECIPIENT_ID,
@@ -23,7 +23,7 @@ import { buildSigners, randomKeyPair } from "../signer";
 import { deployStakingPool, pingPool } from "../stakingPool";
 
 let sandbox: SandboxHandle | undefined;
-let indexer: SetupServerApi | undefined;
+let indexer: SetupServer | undefined;
 
 /** Index of the next transaction, so the unstake lock can be skipped before the withdrawal. */
 let step = 0;

--- a/libs/ledger-auth/src/__tests__/authSDK.integration.test.ts
+++ b/libs/ledger-auth/src/__tests__/authSDK.integration.test.ts
@@ -1,5 +1,5 @@
 import { HttpResponse, http } from "msw";
-import { setupServer, type SetupServerApi } from "msw/node";
+import { setupServer, type SetupServer } from "msw/node";
 import { AuthSDK } from "../authSDK";
 import { bytesToBase64Url, stringToBytes } from "../utils";
 import { CustomIdentityProvider } from "./__mocks__/CustomIdentityProvider.mock";
@@ -24,7 +24,7 @@ const EXPECTED_JWT = "integration-jwt-token";
 
 describe("AuthSDK (integration, MSW)", () => {
   let keyPair: CryptoKeyPair;
-  let server: SetupServerApi;
+  let server: SetupServer;
 
   const queryFn = jest.fn().mockResolvedValue({ ok: true });
 
@@ -94,7 +94,7 @@ describe("AuthSDK (integration, MSW)", () => {
   });
 });
 
-function initServer(publicKey: CryptoKey): SetupServerApi {
+function initServer(publicKey: CryptoKey): SetupServer {
   const sessionStore = new Map<string, { codeChallenge?: string }>();
   let pendingCodeChallenge: string | undefined;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -442,8 +442,8 @@ catalogs:
       specifier: 4.17.21
       version: 4.17.21
     msw:
-      specifier: ^2.7.3
-      version: 2.7.3
+      specifier: 2.15.0
+      version: 2.15.0
     oxfmt:
       specifier: 0.36.0
       version: 0.36.0
@@ -1534,7 +1534,7 @@ importers:
         version: 8.48.1(@typescript/typescript6@6.0.2)(eslint@8.57.0)
       '@vitest/mocker':
         specifier: 4.0.17
-        version: 4.0.17(msw@2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2))
+        version: 4.0.17(msw@2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2))
       allure-playwright:
         specifier: 'catalog:'
         version: 3.9.0(@playwright/test@1.60.0)
@@ -1597,7 +1597,7 @@ importers:
         version: 4.2.1
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       nock:
         specifier: 13.5.4
         version: 13.5.4
@@ -1630,7 +1630,7 @@ importers:
         version: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       storybook-react-rsbuild:
         specifier: 'catalog:'
-        version: 3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(@typescript/typescript6@6.0.2)(msw@2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
+        version: 3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(@typescript/typescript6@6.0.2)(msw@2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
       tailwindcss:
         specifier: 'catalog:'
         version: 4.1.18
@@ -2544,7 +2544,7 @@ importers:
         version: 0.83.3
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       oxfmt:
         specifier: 'catalog:'
         version: 0.36.0
@@ -4205,7 +4205,7 @@ importers:
         version: 30.2.0(@types/node@24.12.0)
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
@@ -7886,7 +7886,7 @@ importers:
         version: 30.2.0(@types/node@24.12.0)
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       oxfmt:
         specifier: 'catalog:'
         version: 0.36.0
@@ -7962,7 +7962,7 @@ importers:
         version: 1.1.3
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       oxfmt:
         specifier: 'catalog:'
         version: 0.36.0
@@ -8387,7 +8387,7 @@ importers:
         version: 0.2.16
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       oxfmt:
         specifier: 'catalog:'
         version: 0.36.0
@@ -8466,7 +8466,7 @@ importers:
         version: 4.0.0
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       oxfmt:
         specifier: 'catalog:'
         version: 0.36.0
@@ -8624,7 +8624,7 @@ importers:
         version: 30.2.0(@types/node@24.12.0)
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       oxfmt:
         specifier: 'catalog:'
         version: 0.36.0
@@ -8685,7 +8685,7 @@ importers:
         version: 30.2.0(@types/node@24.12.0)
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       oxfmt:
         specifier: 'catalog:'
         version: 0.36.0
@@ -8782,7 +8782,7 @@ importers:
         version: 1.1.3
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       oxfmt:
         specifier: 'catalog:'
         version: 0.36.0
@@ -8891,7 +8891,7 @@ importers:
         version: 30.2.0(@types/node@24.12.0)
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       oxfmt:
         specifier: 'catalog:'
         version: 0.36.0
@@ -8979,7 +8979,7 @@ importers:
         version: 30.2.0(@types/node@24.12.0)
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       oxfmt:
         specifier: 'catalog:'
         version: 0.36.0
@@ -9121,7 +9121,7 @@ importers:
         version: 4.17.21
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2
@@ -9304,7 +9304,7 @@ importers:
         version: 30.2.0(@types/node@24.12.0)
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       oxfmt:
         specifier: 'catalog:'
         version: 0.36.0
@@ -9492,7 +9492,7 @@ importers:
         version: 1.1.0
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
     devDependencies:
       '@ledgerhq/wallet-framework-test-setup':
         specifier: workspace:^
@@ -9565,7 +9565,7 @@ importers:
         version: 3.1.0
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
     devDependencies:
       '@bloxbean/yaci-devkit':
         specifier: 0.10.6
@@ -9632,7 +9632,7 @@ importers:
         version: 1.1.0
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2
@@ -9714,7 +9714,7 @@ importers:
         version: 1.1.0
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
     devDependencies:
       '@ledgerhq/wallet-framework-test-setup':
         specifier: workspace:^
@@ -9787,7 +9787,7 @@ importers:
         version: 6.15.0
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
     devDependencies:
       '@ledgerhq/wallet-framework-test-setup':
         specifier: workspace:^
@@ -9866,7 +9866,7 @@ importers:
         version: 1.1.0
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
     devDependencies:
       '@ledgerhq/wallet-framework-test-setup':
         specifier: workspace:^
@@ -9936,7 +9936,7 @@ importers:
         version: 1.1.0
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
     devDependencies:
       '@ledgerhq/wallet-framework-test-setup':
         specifier: workspace:^
@@ -9994,7 +9994,7 @@ importers:
         version: 9.1.2
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       near-api-js:
         specifier: ^3.0.2
         version: 3.0.2
@@ -10070,7 +10070,7 @@ importers:
         version: 30.2.0
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
     devDependencies:
       '@ledgerhq/wallet-framework-test-setup':
         specifier: workspace:^
@@ -10149,7 +10149,7 @@ importers:
         version: 1.3.0
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
     devDependencies:
       '@ledgerhq/wallet-framework-test-setup':
         specifier: workspace:^
@@ -10219,7 +10219,7 @@ importers:
         version: 4.1.2
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
     devDependencies:
       '@ledgerhq/wallet-framework-test-setup':
         specifier: workspace:^
@@ -10298,7 +10298,7 @@ importers:
         version: 1.1.0
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
     devDependencies:
       '@ledgerhq/wallet-framework-test-setup':
         specifier: workspace:^
@@ -10377,7 +10377,7 @@ importers:
         version: 1.1.0
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
     devDependencies:
       '@ledgerhq/wallet-framework-test-setup':
         specifier: workspace:^
@@ -10453,7 +10453,7 @@ importers:
         version: 1.1.0
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       tronweb:
         specifier: 6.2.0
         version: 6.2.0
@@ -10526,7 +10526,7 @@ importers:
         version: 1.1.0
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
     devDependencies:
       '@ledgerhq/wallet-framework-test-setup':
         specifier: workspace:^
@@ -10596,7 +10596,7 @@ importers:
         version: 1.1.0
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       ripple-binary-codec:
         specifier: ^1.3.0
         version: 1.11.0
@@ -11140,7 +11140,7 @@ importers:
         version: 30.2.0(@types/node@24.12.0)
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       oxfmt:
         specifier: 'catalog:'
         version: 0.36.0
@@ -11225,7 +11225,7 @@ importers:
         version: 30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(@typescript/typescript6@6.0.2))
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       oxfmt:
         specifier: 'catalog:'
         version: 0.36.0
@@ -11823,7 +11823,7 @@ importers:
         version: 0.7.0
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       nock:
         specifier: ^13.0.5
         version: 13.5.4
@@ -11915,7 +11915,7 @@ importers:
         version: 30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(@typescript/typescript6@6.0.2))
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       oxfmt:
         specifier: 'catalog:'
         version: 0.36.0
@@ -11958,7 +11958,7 @@ importers:
         version: 30.2.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(@typescript/typescript6@6.0.2))
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       oxfmt:
         specifier: 'catalog:'
         version: 0.36.0
@@ -14643,7 +14643,7 @@ importers:
         version: 30.2.0(@types/node@24.12.0)
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       timemachine:
         specifier: ^0.3.2
         version: 0.3.2
@@ -15808,7 +15808,7 @@ importers:
         version: 30.2.0(@types/node@24.12.0)
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       oxfmt:
         specifier: 'catalog:'
         version: 0.36.0
@@ -15866,7 +15866,7 @@ importers:
         version: 30.2.0(@types/node@24.12.0)
       msw:
         specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+        version: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
@@ -18270,15 +18270,6 @@ packages:
   '@braze/web-sdk@6.4.0':
     resolution: {integrity: sha512-eBbFfGF9PUPowFsBmgqJmKs9T+qkh8LRm5T41mZsQCeNUjXjME6q1sXxXtjV2R3evsk4sN+d+xHSDF4B++HG7Q==}
 
-  '@bundled-es-modules/cookie@2.0.1':
-    resolution: {integrity: sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==}
-
-  '@bundled-es-modules/statuses@1.0.1':
-    resolution: {integrity: sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==}
-
-  '@bundled-es-modules/tough-cookie@0.1.6':
-    resolution: {integrity: sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==}
-
   '@bunli/core@0.9.1':
     resolution: {integrity: sha512-R4VbiNnevyr3acPi0VXd1OOo9enc4JgTb8fQTp2F1uXDclHfnI2azznsWmFQL5tinxeB3eKzMB7FeWk212FoCQ==}
     engines: {bun: '>=1.0.0'}
@@ -20311,31 +20302,35 @@ packages:
     resolution: {integrity: sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==}
     deprecated: Use @eslint/object-schema instead
 
-  '@inquirer/confirm@5.1.7':
-    resolution: {integrity: sha512-Xrfbrw9eSiHb+GsesO8TQIeHSMTP0xyvTCeeYevgZ4sKW+iz9w/47bgfG9b0niQm+xaLY2EWPBINUPldLwvYiw==}
-    engines: {node: '>=18'}
+  '@inquirer/ansi@2.0.7':
+    resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
+  '@inquirer/confirm@6.2.0':
+    resolution: {integrity: sha512-SKXarWrYhtpqOEctf9XGCGy29QjsvJAM0Aq9ZR9z4Ns94OmpqudOly+aSEfNqUf9SwsQaUgY9+Z8hyzG0xX8fw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/core@10.1.8':
-    resolution: {integrity: sha512-HpAqR8y715zPpM9e/9Q+N88bnGwqqL8ePgZ0SMv/s3673JLMv3bIkoivGmjPqXlEgisUksSXibweQccUwEx4qQ==}
-    engines: {node: '>=18'}
+  '@inquirer/core@12.0.0':
+    resolution: {integrity: sha512-+nnvFEXIB08CZNVXpvW3B+zHW96QXvGUjNKJ8NJIPqAZi5Kd4WhYt2S3C234ReepG1qw2HOlEUbjYVHBowXObA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/figures@1.0.11':
-    resolution: {integrity: sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==}
-    engines: {node: '>=18'}
+  '@inquirer/figures@2.0.8':
+    resolution: {integrity: sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
 
-  '@inquirer/type@3.0.5':
-    resolution: {integrity: sha512-ZJpeIYYueOz/i/ONzrfof8g89kNdO2hjGuvULROo3O8rlB2CRtSseE5KeirnyE4t/thAn/EwvS/vuQeJCn+NZg==}
-    engines: {node: '>=18'}
+  '@inquirer/type@4.0.7':
+    resolution: {integrity: sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -21170,12 +21165,12 @@ packages:
     resolution: {integrity: sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==}
     engines: {node: '>= 18'}
 
-  '@mswjs/interceptors@0.37.6':
-    resolution: {integrity: sha512-wK+5pLK5XFmgtH3aQ2YVvA3HohS3xqV/OxuVOdNx9Wpnz7VE/fnC+e1A7ln6LFYeck7gOJ/dsZV6OLplOtAJ2w==}
-    engines: {node: '>=18'}
-
   '@mswjs/interceptors@0.38.3':
     resolution: {integrity: sha512-3AMc2fTnX4q3qyO6K/LKwWXjUAFc3COC3bo5YCROIyQYJ8g/++5Col5fSIglIyUdBN787CTbL+c04KRwaaZ/UA==}
+    engines: {node: '>=18'}
+
+  '@mswjs/interceptors@0.41.9':
+    resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
     engines: {node: '>=18'}
 
   '@multiversx/sdk-bls-wasm@0.3.5':
@@ -21657,6 +21652,9 @@ packages:
 
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/deferred-promise@3.0.0':
+    resolution: {integrity: sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==}
 
   '@open-draft/logger@0.3.0':
     resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
@@ -25981,9 +25979,6 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
-  '@types/cookie@0.6.0':
-    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
-
   '@types/cors@2.8.17':
     resolution: {integrity: sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==}
 
@@ -26446,6 +26441,9 @@ packages:
   '@types/serve-static@1.15.5':
     resolution: {integrity: sha512-PDRk21MnK70hja/YF8AHfC7yIsiQHn1rcXx7ijCFBX/k+XQJhQT/gw3xekXKJvx+5SXaMMS8oqQy09Mzvz2TuQ==}
 
+  '@types/set-cookie-parser@2.4.10':
+    resolution: {integrity: sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==}
+
   '@types/sha.js@2.4.4':
     resolution: {integrity: sha512-Qukd+D6S2Hm0wLVt2Vh+/eWBIoUt+wF8jWjBsG4F8EFQRwKtYvtXCPcNl2OEUQ1R+eTr3xuSaBYUyM3WD1x/Qw==}
 
@@ -26458,8 +26456,8 @@ packages:
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
 
-  '@types/statuses@2.0.5':
-    resolution: {integrity: sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==}
+  '@types/statuses@2.0.6':
+    resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
 
   '@types/stream-chain@2.0.4':
     resolution: {integrity: sha512-V7TsWLHrx79KumkHqSD7F8eR6POpEuWb6PuXJ7s/dRHAf3uVst3Jkp1yZ5XqIfECZLQ4a28vBVstTErmsMBvaQ==}
@@ -31153,11 +31151,20 @@ packages:
   fast-stable-stringify@1.0.0:
     resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.0.3:
     resolution: {integrity: sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==}
 
   fast-url-parser@1.1.3:
     resolution: {integrity: sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
   fast-xml-builder@1.1.4:
     resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
@@ -32016,8 +32023,8 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
 
-  headers-polyfill@4.0.3:
-    resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
+  headers-polyfill@5.0.1:
+    resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
 
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
@@ -35085,8 +35092,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msw@2.7.3:
-    resolution: {integrity: sha512-+mycXv8l2fEAjFZ5sjrtjJDmm2ceKGjrNbBr1durRg6VkU9fNUE/gsmQ51hWbHqs+l35W1iM+ZsmOD9Fd6lspw==}
+  msw@2.15.0:
+    resolution: {integrity: sha512-2wQAmKkQKxRuXvYJxVhPGG0wZNBQyD06oJvxqw90XqLvptdqxdlHrFUfEteKkpaNORX3Xzc+HtEl/q0nfmN2wQ==}
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
@@ -35122,9 +35129,9 @@ packages:
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
-  mute-stream@2.0.0:
-    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
-    engines: {node: ^18.17.0 || >=20.5.0}
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   mv@2.1.1:
     resolution: {integrity: sha512-at/ZndSy3xEGJ8i0ygALh8ru9qy7gWW1cmkaqBN29JmMlIvM//MEO9y1sk/avxuwnPcfhkejkLsuPxH81BrkSg==}
@@ -36814,9 +36821,6 @@ packages:
     resolution: {integrity: sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==}
     engines: {node: '>=0.4.x'}
 
-  querystringify@2.2.0:
-    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
-
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -37801,6 +37805,9 @@ packages:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
 
+  rettime@0.11.11:
+    resolution: {integrity: sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==}
+
   reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -38145,6 +38152,9 @@ packages:
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  set-cookie-parser@3.1.2:
+    resolution: {integrity: sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -38524,6 +38534,10 @@ packages:
 
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
   stop-iteration-iterator@1.1.0:
@@ -39289,10 +39303,6 @@ packages:
     resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
     engines: {node: '>=0.8'}
 
-  tough-cookie@4.1.4:
-    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
-    engines: {node: '>=6'}
-
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
@@ -39506,10 +39516,6 @@ packages:
   type-fest@2.19.0:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
     engines: {node: '>=12.20'}
-
-  type-fest@4.40.0:
-    resolution: {integrity: sha512-ABHZ2/tS2JkvH1PEjxFDTUWC8dB5OsIGZP4IFLhR293GqT5Y5qB1WwL2kMPYhQW9DVgVD8Hd7I8gjwPIf5GFkw==}
-    engines: {node: '>=16'}
 
   type-fest@5.7.0:
     resolution: {integrity: sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==}
@@ -39780,10 +39786,6 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
-  universalify@0.2.0:
-    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
-    engines: {node: '>= 4.0.0'}
-
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -39868,6 +39870,9 @@ packages:
       uploadthing:
         optional: true
 
+  until-async@3.0.2:
+    resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
+
   unused-filename@4.0.1:
     resolution: {integrity: sha512-ZX6U1J04K1FoSUeoX1OicAhw4d0aro2qo+L8RhJkiGTNtBNkd/Fi1Wxoc9HzcVu6HfOzm0si/N15JjxFmD1z6A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -39905,9 +39910,6 @@ packages:
 
   url-join@4.0.1:
     resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
-
-  url-parse@1.5.10:
-    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
   url@0.11.3:
     resolution: {integrity: sha512-6hxOLGfZASQK/cijlZnZJTq8OXAkt/3YGfQX45vvMYXpZoo8NdWZcY73K108Jf759lS1Bv/8wXnHDTSz17dSRw==}
@@ -40729,10 +40731,6 @@ packages:
   yocto-spinner@0.2.0:
     resolution: {integrity: sha512-Qu6WAqNLGleB687CCGcmgHIo8l+J19MX/32UrSMfbf/4L8gLoxjpOYoiHT1asiWyqvjRZbgvOhLlvne6E5Tbdw==}
     engines: {node: '>=18.19'}
-
-  yoctocolors-cjs@2.1.2:
-    resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
-    engines: {node: '>=18'}
 
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
@@ -44404,19 +44402,6 @@ snapshots:
 
   '@braze/web-sdk@6.4.0': {}
 
-  '@bundled-es-modules/cookie@2.0.1':
-    dependencies:
-      cookie: 0.7.2
-
-  '@bundled-es-modules/statuses@1.0.1':
-    dependencies:
-      statuses: 2.0.1
-
-  '@bundled-es-modules/tough-cookie@0.1.6':
-    dependencies:
-      '@types/tough-cookie': 4.0.5
-      tough-cookie: 4.1.4
-
   '@bunli/core@0.9.1(patch_hash=fbe5c853111cb92eab35c575f445da139fd7664c9be9bbca5ebbadfb0f292565)(@typescript/typescript6@6.0.2)(react@19.1.4)':
     dependencies:
       '@bunli/runtime': 0.3.2(@typescript/typescript6@6.0.2)(react@19.1.4)
@@ -47971,29 +47956,30 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.2': {}
 
-  '@inquirer/confirm@5.1.7(@types/node@24.12.0)':
+  '@inquirer/ansi@2.0.7': {}
+
+  '@inquirer/confirm@6.2.0(@types/node@24.12.0)':
     dependencies:
-      '@inquirer/core': 10.1.8(@types/node@24.12.0)
-      '@inquirer/type': 3.0.5(@types/node@24.12.0)
+      '@inquirer/core': 12.0.0(@types/node@24.12.0)
+      '@inquirer/type': 4.0.7(@types/node@24.12.0)
     optionalDependencies:
       '@types/node': 24.12.0
 
-  '@inquirer/core@10.1.8(@types/node@24.12.0)':
+  '@inquirer/core@12.0.0(@types/node@24.12.0)':
     dependencies:
-      '@inquirer/figures': 1.0.11
-      '@inquirer/type': 3.0.5(@types/node@24.12.0)
-      ansi-escapes: 4.3.2
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.8
+      '@inquirer/type': 4.0.7(@types/node@24.12.0)
       cli-width: 4.1.0
-      mute-stream: 2.0.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
       signal-exit: 4.1.0
-      wrap-ansi: 6.2.0
-      yoctocolors-cjs: 2.1.2
     optionalDependencies:
       '@types/node': 24.12.0
 
-  '@inquirer/figures@1.0.11': {}
+  '@inquirer/figures@2.0.8': {}
 
-  '@inquirer/type@3.0.5(@types/node@24.12.0)':
+  '@inquirer/type@4.0.7(@types/node@24.12.0)':
     optionalDependencies:
       '@types/node': 24.12.0
 
@@ -49841,15 +49827,6 @@ snapshots:
 
   '@msgpack/msgpack@3.1.3': {}
 
-  '@mswjs/interceptors@0.37.6':
-    dependencies:
-      '@open-draft/deferred-promise': 2.2.0
-      '@open-draft/logger': 0.3.0
-      '@open-draft/until': 2.1.0
-      is-node-process: 1.2.0
-      outvariant: 1.4.3
-      strict-event-emitter: 0.5.1
-
   '@mswjs/interceptors@0.38.3':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -49864,6 +49841,15 @@ snapshots:
       - canvas
       - supports-color
       - utf-8-validate
+
+  '@mswjs/interceptors@0.41.9':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
 
   '@multiversx/sdk-bls-wasm@0.3.5':
     optional: true
@@ -50439,6 +50425,8 @@ snapshots:
       '@octokit/openapi-types': 24.2.0
 
   '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/deferred-promise@3.0.0': {}
 
   '@open-draft/logger@0.3.0':
     dependencies:
@@ -56830,8 +56818,6 @@ snapshots:
     dependencies:
       '@types/node': 24.12.0
 
-  '@types/cookie@0.6.0': {}
-
   '@types/cors@2.8.17':
     dependencies:
       '@types/node': 24.12.0
@@ -57296,6 +57282,10 @@ snapshots:
       '@types/mime': 3.0.4
       '@types/node': 24.12.0
 
+  '@types/set-cookie-parser@2.4.10':
+    dependencies:
+      '@types/node': 24.12.0
+
   '@types/sha.js@2.4.4':
     dependencies:
       '@types/node': 24.12.0
@@ -57308,7 +57298,7 @@ snapshots:
 
   '@types/stack-utils@2.0.3': {}
 
-  '@types/statuses@2.0.5': {}
+  '@types/statuses@2.0.6': {}
 
   '@types/stream-chain@2.0.4':
     dependencies:
@@ -57740,13 +57730,13 @@ snapshots:
       estree-walker: 3.0.3
       magic-string: 0.30.21
 
-  '@vitest/mocker@3.2.4(msw@2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2))':
+  '@vitest/mocker@3.2.4(msw@2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+      msw: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
 
   '@vitest/mocker@4.0.17':
     dependencies:
@@ -57754,13 +57744,13 @@ snapshots:
       estree-walker: 3.0.3
       magic-string: 0.30.21
 
-  '@vitest/mocker@4.0.17(msw@2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2))':
+  '@vitest/mocker@4.0.17(msw@2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2))':
     dependencies:
       '@vitest/spy': 4.0.17
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+      msw: 2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
 
   '@vitest/pretty-format@2.0.5':
     dependencies:
@@ -63395,7 +63385,7 @@ snapshots:
       send: 0.19.1
       serve-static: 1.16.2
       setprototypeof: 1.2.0
-      statuses: 2.0.1
+      statuses: 2.0.2
       type-is: 1.6.18
       utils-merge: 1.0.1
       vary: 1.1.2
@@ -63529,11 +63519,21 @@ snapshots:
 
   fast-stable-stringify@1.0.0: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.0.3: {}
 
   fast-url-parser@1.1.3:
     dependencies:
       punycode: 1.4.1
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fast-xml-builder@1.1.4:
     dependencies:
@@ -63713,7 +63713,7 @@ snapshots:
       escape-html: 1.0.3
       on-finished: 2.4.1
       parseurl: 1.3.3
-      statuses: 2.0.1
+      statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -64664,7 +64664,10 @@ snapshots:
 
   he@1.2.0: {}
 
-  headers-polyfill@4.0.3: {}
+  headers-polyfill@5.0.1:
+    dependencies:
+      '@types/set-cookie-parser': 2.4.10
+      set-cookie-parser: 3.1.2
 
   help-me@5.0.0: {}
 
@@ -69248,25 +69251,25 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2):
+  msw@2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2):
     dependencies:
-      '@bundled-es-modules/cookie': 2.0.1
-      '@bundled-es-modules/statuses': 1.0.1
-      '@bundled-es-modules/tough-cookie': 0.1.6
-      '@inquirer/confirm': 5.1.7(@types/node@24.12.0)
-      '@mswjs/interceptors': 0.37.6
-      '@open-draft/deferred-promise': 2.2.0
-      '@open-draft/until': 2.1.0
-      '@types/cookie': 0.6.0
-      '@types/statuses': 2.0.5
+      '@inquirer/confirm': 6.2.0(@types/node@24.12.0)
+      '@mswjs/interceptors': 0.41.9
+      '@open-draft/deferred-promise': 3.0.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
       graphql: 16.14.2
-      headers-polyfill: 4.0.3
+      headers-polyfill: 5.0.1
       is-node-process: 1.2.0
       outvariant: 1.4.3
       path-to-regexp: 6.3.0
       picocolors: 1.1.1
+      rettime: 0.11.11
+      statuses: 2.0.2
       strict-event-emitter: 0.5.1
-      type-fest: 4.40.0
+      tough-cookie: 6.0.1
+      type-fest: 5.7.0
+      until-async: 3.0.2
       yargs: 17.7.2
     optionalDependencies:
       typescript: '@typescript/typescript6@6.0.2'
@@ -69295,7 +69298,7 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
-  mute-stream@2.0.0: {}
+  mute-stream@3.0.0: {}
 
   mv@2.1.1:
     dependencies:
@@ -71274,8 +71277,6 @@ snapshots:
 
   querystring-es3@0.2.1: {}
 
-  querystringify@2.2.0: {}
-
   queue-microtask@1.2.3: {}
 
   queue-tick@1.0.1: {}
@@ -72732,6 +72733,8 @@ snapshots:
 
   retry@0.13.1: {}
 
+  rettime@0.11.11: {}
+
   reusify@1.0.4: {}
 
   rfc4648@1.5.3: {}
@@ -73080,7 +73083,7 @@ snapshots:
       ms: 2.1.3
       on-finished: 2.4.1
       range-parser: 1.2.1
-      statuses: 2.0.1
+      statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -73164,6 +73167,8 @@ snapshots:
   set-blocking@2.0.0: {}
 
   set-cookie-parser@2.7.2: {}
+
+  set-cookie-parser@3.1.2: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -73655,16 +73660,18 @@ snapshots:
 
   statuses@2.0.1: {}
 
+  statuses@2.0.2: {}
+
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(@typescript/typescript6@6.0.2)(msw@2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)):
+  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(@typescript/typescript6@6.0.2)(msw@2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)):
     dependencies:
       '@rsbuild/core': 2.0.9
       '@rsbuild/plugin-type-check': 1.3.5(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(@typescript/typescript6@6.0.2)
-      '@vitest/mocker': 3.2.4(msw@2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2))
+      '@vitest/mocker': 3.2.4(msw@2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2))
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 2.2.0
@@ -73756,7 +73763,7 @@ snapshots:
       - tslib
       - vite
 
-  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(@typescript/typescript6@6.0.2)(msw@2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)):
+  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(@typescript/typescript6@6.0.2)(msw@2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)):
     dependencies:
       '@rollup/pluginutils': 5.3.0
       '@rsbuild/core': 2.0.9
@@ -73770,7 +73777,7 @@ snapshots:
       react-dom: 19.1.4(react@19.1.4)
       resolve: 1.22.12
       storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(@typescript/typescript6@6.0.2)(msw@2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(@typescript/typescript6@6.0.2)(msw@2.15.0(@types/node@24.12.0)(@typescript/typescript6@6.0.2))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: '@typescript/typescript6@6.0.2'
@@ -74710,13 +74717,6 @@ snapshots:
       psl: 1.9.0
       punycode: 2.3.1
 
-  tough-cookie@4.1.4:
-    dependencies:
-      psl: 1.9.0
-      punycode: 2.3.1
-      universalify: 0.2.0
-      url-parse: 1.5.10
-
   tough-cookie@5.1.2:
     dependencies:
       tldts: 6.1.75
@@ -75023,8 +75023,6 @@ snapshots:
 
   type-fest@2.19.0: {}
 
-  type-fest@4.40.0: {}
-
   type-fest@5.7.0:
     dependencies:
       tagged-tag: 1.0.0
@@ -75326,8 +75324,6 @@ snapshots:
 
   universalify@0.1.2: {}
 
-  universalify@0.2.0: {}
-
   universalify@2.0.1: {}
 
   unlimited-timeout@0.1.0: {}
@@ -75380,6 +75376,8 @@ snapshots:
     optionalDependencies:
       idb-keyval: 6.2.1
 
+  until-async@3.0.2: {}
+
   unused-filename@4.0.1:
     dependencies:
       escape-string-regexp: 5.0.0
@@ -75427,11 +75425,6 @@ snapshots:
   urijs@1.19.11: {}
 
   url-join@4.0.1: {}
-
-  url-parse@1.5.10:
-    dependencies:
-      querystringify: 2.2.0
-      requires-port: 1.0.0
 
   url@0.11.3:
     dependencies:
@@ -76353,8 +76346,6 @@ snapshots:
   yocto-spinner@0.2.0:
     dependencies:
       yoctocolors: 2.1.2
-
-  yoctocolors-cjs@2.1.2: {}
 
   yoctocolors@2.1.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -165,7 +165,7 @@ catalog:
   i18next: 25.7.3
   isomorphic-ws: 5.0.0
   lodash: 4.17.21
-  msw: ^2.7.3
+  msw: 2.15.0
   jest: 30.2.0
   jest-circus: 30.2.0
   jest-docblock: 30.2.0

--- a/shared/auth/src/createAuthenticatedBaseQuery.test.ts
+++ b/shared/auth/src/createAuthenticatedBaseQuery.test.ts
@@ -1,7 +1,7 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { createApi } from "@reduxjs/toolkit/query";
 import { HttpResponse, http } from "msw";
-import { setupServer, type SetupServerApi } from "msw/node";
+import { setupServer, type SetupServer } from "msw/node";
 import { createAuthenticatedBaseQuery } from "./createAuthenticatedBaseQuery";
 import type { AuthProvider } from "./types";
 
@@ -80,7 +80,7 @@ describe("createAuthenticatedBaseQuery", () => {
     public: jest.fn().mockReturnValue(HttpResponse.json({ ok: true })),
     private: jest.fn().mockReturnValue(HttpResponse.json({ ok: true })),
   };
-  const server: SetupServerApi = setupServer(
+  const server: SetupServer = setupServer(
     // API endpoints:
     http.all(`${API_BASE_URL}/public`, endpoints.public),
     http.all(`${API_BASE_URL}/private`, endpoints.private),


### PR DESCRIPTION
### 📝 Description

Bumps the `msw` catalog entry from `^2.7.3` to `2.15.0` (current latest) and refreshes the lockfile accordingly.

`msw` is a test-only devDependency used for mocking network requests across the apps and libs. The 2.x line has had **no breaking changes since 2.0.0** — everything from 2.8 → 2.15 is bug fixes and additive features (WebSocket/SSE listener-leak fixes, `finalize` handler-cleanup API, `ws.onUpgrade`, cookie-forwarding correctness, `resetHandlers()` generator-state reset, plus a RegExp DoS security patch in a transitive dep). The public API our tests rely on (`setupServer`, `http.*`, `HttpResponse`) is unchanged.

No shipped package output changes, so an empty changeset is included to signal "no release needed". The lockfile diff is limited to `msw` and its transitive dependencies.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36360](https://ledgerhq.atlassian.net/browse/LIVE-36360)

[LIVE-36360]: https://ledgerhq.atlassian.net/browse/LIVE-36360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ