### PR TITLE
[LWD] feat(dynamic-content): add type and layout on carousel impressions

### DIFF
--- a/.changeset/tidy-carousel-impressions.md
+++ b/.changeset/tidy-carousel-impressions.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add type and layout on hardware carousel content card impressions

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/Layout.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/Layout.tsx
@@ -29,6 +29,7 @@ export default function Layout({
       id={slide.card.id}
       displayedPosition={slide.displayedPosition}
       location={slide.card.location ?? category.location}
+      additionalProps={{ type: category.cardsType, layout: category.cardsLayout }}
     >
       <SmallSquareCard
         title={slide.card.title}

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/__tests__/Layout.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/__tests__/Layout.test.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import {
+  ContentCardsLayout,
+  ContentCardsType,
+  LocationContentCard,
+  type CategoryContentCard,
+} from "~/types/dynamicContent";
+import Layout from "../Layout";
+import type { MappedCategorySlide } from "../useContentCardsCategoryViewModel";
+
+jest.mock("../../LogContentCardWrapper", () => ({
+  __esModule: true,
+  default: ({
+    additionalProps,
+    location,
+    children,
+  }: {
+    additionalProps?: { type?: string; layout?: string };
+    location?: string;
+    children: React.ReactNode;
+  }) => (
+    <div
+      data-testid="log-content-card-wrapper"
+      data-type={additionalProps?.type}
+      data-layout={additionalProps?.layout}
+      data-location={location}
+    >
+      {children}
+    </div>
+  ),
+}));
+
+jest.mock("../CategoryCarousel", () => ({
+  __esModule: true,
+  default: ({ slides }: { slides: React.ReactNode[] }) => (
+    <div data-testid="category-carousel">{slides}</div>
+  ),
+}));
+
+const CATEGORY: CategoryContentCard = {
+  id: "category-1",
+  categoryId: "alwayson",
+  title: "Discover our devices",
+  description: "",
+  location: LocationContentCard.Portfolio,
+  cardsLayout: ContentCardsLayout.carousel,
+  cardsType: ContentCardsType.smallSquare,
+  type: ContentCardsType.category,
+  created: new Date("2026-01-01"),
+  isDismissable: true,
+};
+
+const SLIDES: MappedCategorySlide[] = [
+  {
+    displayedPosition: 0,
+    card: {
+      id: "child-1",
+      title: "Ledger Flex",
+      media: "https://example.com/flex.png",
+      location: LocationContentCard.Portfolio,
+      created: null,
+      extras: {
+        type: ContentCardsType.smallSquare,
+        categoryId: "alwayson",
+      },
+    },
+  },
+];
+
+describe("ContentCardsCategory Layout", () => {
+  it("passes carousel type and layout for impressions", () => {
+    render(
+      <Layout
+        category={CATEGORY}
+        slides={SLIDES}
+        isDismissable
+        onCardClick={jest.fn()}
+        onCardDismiss={jest.fn()}
+      />,
+    );
+
+    const wrapper = screen.getByTestId("log-content-card-wrapper");
+    expect(wrapper).toHaveAttribute("data-type", ContentCardsType.smallSquare);
+    expect(wrapper).toHaveAttribute("data-layout", ContentCardsLayout.carousel);
+    expect(wrapper).toHaveAttribute("data-location", LocationContentCard.Portfolio);
+  });
+});


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

add type and layout on LWD hardware carousel impressions

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35395]<!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-35395]: https://ledgerhq.atlassian.net/browse/LIVE-35395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ