### PR TITLE
[LWDM] feat(contacts): connect Desktop Ledger Sync activation (LIVE-33958)

### DIFF
--- a/.changeset/soft-contacts-mobile-ledger-sync.md
+++ b/.changeset/soft-contacts-mobile-ledger-sync.md
@@ -1,6 +1,7 @@
 ---
 "@features/flow-contacts": patch
+"ledger-live-desktop": patch
 "live-mobile": patch
 ---
 
-Connect Contacts Mobile mutations to Ledger Sync availability and activation.
+Connect Contacts mutations to Ledger Sync availability and activation on Desktop and Mobile.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -19,6 +19,8 @@ import {
   waitFor,
 } from "tests/testSetup";
 import ContactsScreen, { ContactsButton } from "LLD/features/Contacts";
+import { useActivationDrawer } from "LLD/features/LedgerSyncEntryPoints/hooks/useActivationDrawer";
+import { useContactsLedgerSyncStatus } from "LLD/features/Contacts/hooks/useContactsLedgerSyncStatus";
 import { useContactsViewModel } from "LLD/features/Contacts/screens/Contacts/useContactsViewModel";
 import ContextMenuContext from "LLD/features/MyWallet/components/ContextMenuContext";
 import { ContextMenu } from "LLD/features/MyWallet/components/ContextMenu";
@@ -29,6 +31,7 @@ const mockNavigate = jest.fn();
 const mockClose = jest.fn();
 const mockValidateAddress = jest.fn();
 const mockOpenSendFlow = jest.fn();
+const mockOpenActivationDrawer = jest.fn();
 const meContactId = mockMeContact().id;
 const savedContactId = mockContact({ id: "contact-ada" }).id;
 
@@ -40,6 +43,17 @@ jest.mock("react-router", () => ({
 jest.mock("LLD/features/Send/hooks/useOpenSendFlow", () => ({
   useOpenSendFlow: () => mockOpenSendFlow,
 }));
+
+jest.mock("LLD/features/LedgerSyncEntryPoints/hooks/useActivationDrawer", () => ({
+  useActivationDrawer: jest.fn(),
+}));
+
+jest.mock("LLD/features/Contacts/hooks/useContactsLedgerSyncStatus", () => ({
+  useContactsLedgerSyncStatus: jest.fn(),
+}));
+
+const mockedUseActivationDrawer = jest.mocked(useActivationDrawer);
+const mockedContactsLedgerSyncStatus = jest.mocked(useContactsLedgerSyncStatus);
 
 jest.mock("~/renderer/store", () => ({
   getStoreValue: jest.fn(),
@@ -154,6 +168,11 @@ function ContactsViewModelProbe({
 describe("Contacts integration", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockedContactsLedgerSyncStatus.mockReturnValue("ready");
+    mockedUseActivationDrawer.mockReturnValue({
+      openDrawer: mockOpenActivationDrawer,
+      closeDrawer: jest.fn(),
+    });
     mockValidateAddress.mockResolvedValue(true);
     jest.mocked(isAddressSanctioned).mockResolvedValue(false);
   });
@@ -294,6 +313,21 @@ describe("Contacts integration", () => {
       expect(screen.queryByTestId("contacts-add-contact-dialog")).not.toBeInTheDocument();
       expect(screen.getByText("Coinbase 1")).toBeVisible();
     });
+  });
+
+  it("should open Ledger Sync activation instead of adding a contact while sync is inactive", async () => {
+    mockedContactsLedgerSyncStatus.mockReturnValue("inactive");
+    const { user } = renderContactsScreen();
+
+    await user.click(screen.getByTestId("contacts-add-contact"));
+
+    expect(screen.queryByTestId("contacts-add-contact-dialog")).not.toBeInTheDocument();
+    expect(screen.getByRole("dialog")).toBeVisible();
+
+    await user.click(screen.getByRole("button", { name: "Turn on Ledger Sync" }));
+
+    expect(mockOpenActivationDrawer).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
   it("should block a duplicate contact name and allow a unique replacement", async () => {
@@ -658,6 +692,24 @@ describe("Contacts integration", () => {
     expect(screen.getByTestId("contacts-add-address-flow-state")).toHaveTextContent(
       "selectingCurrency:contact-me",
     );
+  });
+
+  it("should keep the Add Address session closed while Ledger Sync is inactive", async () => {
+    mockedContactsLedgerSyncStatus.mockReturnValue("inactive");
+    const { user } = render(
+      <MemoryRouter initialEntries={["/contacts"]}>
+        <ContactsViewModelProbe contactId={meContactId} contactType="me" />
+      </MemoryRouter>,
+      {
+        skipRouter: true,
+        initialState: contactsPageInitialState(),
+      },
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open contact" }));
+    await user.click(screen.getByRole("button", { name: "Start Add Address" }));
+
+    expect(screen.getByTestId("contacts-add-address-flow-state")).toHaveTextContent("closed");
   });
 
   it("should expose the Add Address session started for a saved contact", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsLedgerSyncStatus.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsLedgerSyncStatus.test.ts
@@ -1,43 +1,38 @@
 import { renderHook, withFlagOverrides } from "tests/testSetup";
-import { useWalletSyncUserState } from "LLD/features/WalletSync/components/WalletSyncContext";
+import { useLedgerSyncInfo } from "LLD/features/WalletSync/hooks/useLedgerSyncInfo";
 import { useContactsLedgerSyncStatus } from "./useContactsLedgerSyncStatus";
 
-jest.mock("LLD/features/WalletSync/components/WalletSyncContext", () => ({
-  useWalletSyncUserState: jest.fn(),
+jest.mock("LLD/features/WalletSync/hooks/useLedgerSyncInfo", () => ({
+  useLedgerSyncInfo: jest.fn(),
 }));
 
-const mockedUseWalletSyncUserState = jest.mocked(useWalletSyncUserState);
+const mockedUseLedgerSyncInfo = jest.mocked(useLedgerSyncInfo);
 
 function renderContactsLedgerSyncStatus({
   isWalletSyncEnabled = true,
-  visualPending = false,
-  walletSyncError = null,
+  isLoading = false,
+  isError = false,
   rootId,
 }: {
   isWalletSyncEnabled?: boolean;
-  visualPending?: boolean;
-  walletSyncError?: Error | null;
+  isLoading?: boolean;
+  isError?: boolean;
   rootId?: string;
 } = {}) {
-  mockedUseWalletSyncUserState.mockReturnValue({
-    visualPending,
-    walletSyncError,
-    onUserRefresh: jest.fn(),
-  });
+  mockedUseLedgerSyncInfo.mockReturnValue({
+    statusQuery: { error: isError ? new Error("Sync failed") : null, isError, isLoading },
+    trustchain: rootId
+      ? {
+          rootId,
+          applicationPath: "applicationPath",
+          walletSyncEncryptionKey: "walletSyncEncryptionKey",
+        }
+      : null,
+    walletState: {},
+  } as ReturnType<typeof useLedgerSyncInfo>);
 
   return renderHook(() => useContactsLedgerSyncStatus(), {
-    initialState: {
-      ...withFlagOverrides({ lldWalletSync: { enabled: isWalletSyncEnabled } }),
-      trustchain: {
-        trustchain: rootId
-          ? {
-              rootId,
-              applicationPath: "applicationPath",
-              walletSyncEncryptionKey: "walletSyncEncryptionKey",
-            }
-          : null,
-      },
-    },
+    initialState: withFlagOverrides({ lldWalletSync: { enabled: isWalletSyncEnabled } }),
   });
 }
 
@@ -50,16 +45,14 @@ describe("useContactsLedgerSyncStatus", () => {
     expect(result.current).toBe("unavailable");
   });
 
-  it("should be unavailable when Wallet Sync reports an error", () => {
-    const { result } = renderContactsLedgerSyncStatus({
-      walletSyncError: new Error("Sync failed"),
-    });
+  it("should be unavailable when Ledger Sync reports an error", () => {
+    const { result } = renderContactsLedgerSyncStatus({ isError: true });
 
     expect(result.current).toBe("unavailable");
   });
 
-  it("should be checking while Wallet Sync is pending", () => {
-    const { result } = renderContactsLedgerSyncStatus({ visualPending: true });
+  it("should be checking while the Ledger Sync status is loading", () => {
+    const { result } = renderContactsLedgerSyncStatus({ isLoading: true });
 
     expect(result.current).toBe("checking");
   });

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsLedgerSyncStatus.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsLedgerSyncStatus.test.ts
@@ -1,0 +1,78 @@
+import { renderHook, withFlagOverrides } from "tests/testSetup";
+import { useWalletSyncUserState } from "LLD/features/WalletSync/components/WalletSyncContext";
+import { useContactsLedgerSyncStatus } from "./useContactsLedgerSyncStatus";
+
+jest.mock("LLD/features/WalletSync/components/WalletSyncContext", () => ({
+  useWalletSyncUserState: jest.fn(),
+}));
+
+const mockedUseWalletSyncUserState = jest.mocked(useWalletSyncUserState);
+
+function renderContactsLedgerSyncStatus({
+  isWalletSyncEnabled = true,
+  visualPending = false,
+  walletSyncError = null,
+  rootId,
+}: {
+  isWalletSyncEnabled?: boolean;
+  visualPending?: boolean;
+  walletSyncError?: Error | null;
+  rootId?: string;
+} = {}) {
+  mockedUseWalletSyncUserState.mockReturnValue({
+    visualPending,
+    walletSyncError,
+    onUserRefresh: jest.fn(),
+  });
+
+  return renderHook(() => useContactsLedgerSyncStatus(), {
+    initialState: {
+      ...withFlagOverrides({ lldWalletSync: { enabled: isWalletSyncEnabled } }),
+      trustchain: {
+        trustchain: rootId
+          ? {
+              rootId,
+              applicationPath: "applicationPath",
+              walletSyncEncryptionKey: "walletSyncEncryptionKey",
+            }
+          : null,
+      },
+    },
+  });
+}
+
+describe("useContactsLedgerSyncStatus", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("should be unavailable when Wallet Sync is disabled", () => {
+    const { result } = renderContactsLedgerSyncStatus({ isWalletSyncEnabled: false });
+
+    expect(result.current).toBe("unavailable");
+  });
+
+  it("should be unavailable when Wallet Sync reports an error", () => {
+    const { result } = renderContactsLedgerSyncStatus({
+      walletSyncError: new Error("Sync failed"),
+    });
+
+    expect(result.current).toBe("unavailable");
+  });
+
+  it("should be checking while Wallet Sync is pending", () => {
+    const { result } = renderContactsLedgerSyncStatus({ visualPending: true });
+
+    expect(result.current).toBe("checking");
+  });
+
+  it("should be ready when the trustchain is initialized", () => {
+    const { result } = renderContactsLedgerSyncStatus({ rootId: "trustchain-root" });
+
+    expect(result.current).toBe("ready");
+  });
+
+  it("should be inactive when the trustchain is not initialized", () => {
+    const { result } = renderContactsLedgerSyncStatus();
+
+    expect(result.current).toBe("inactive");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsLedgerSyncStatus.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsLedgerSyncStatus.ts
@@ -1,19 +1,19 @@
-import { trustchainSelector } from "@ledgerhq/ledger-key-ring-protocol/store";
 import type { ContactsLedgerSyncStatus } from "@features/flow-contacts-introduction";
 import { useFeature } from "@features/platform-feature-flags";
-import { useSelector } from "LLD/hooks/redux";
-import { useWalletSyncUserState } from "LLD/features/WalletSync/components/WalletSyncContext";
+import { useLedgerSyncInfo } from "LLD/features/WalletSync/hooks/useLedgerSyncInfo";
 
 export function useContactsLedgerSyncStatus(): ContactsLedgerSyncStatus {
   const walletSyncFeature = useFeature("lldWalletSync");
-  const trustchain = useSelector(trustchainSelector);
-  const { visualPending, walletSyncError } = useWalletSyncUserState();
+  const {
+    statusQuery: { isError, isLoading },
+    trustchain,
+  } = useLedgerSyncInfo();
 
-  if (!walletSyncFeature?.enabled || walletSyncError) {
+  if (!walletSyncFeature?.enabled || isError) {
     return "unavailable";
   }
 
-  if (visualPending) {
+  if (isLoading) {
     return "checking";
   }
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsLedgerSyncStatus.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsLedgerSyncStatus.ts
@@ -1,0 +1,21 @@
+import { trustchainSelector } from "@ledgerhq/ledger-key-ring-protocol/store";
+import type { ContactsLedgerSyncStatus } from "@features/flow-contacts-introduction";
+import { useFeature } from "@features/platform-feature-flags";
+import { useSelector } from "LLD/hooks/redux";
+import { useWalletSyncUserState } from "LLD/features/WalletSync/components/WalletSyncContext";
+
+export function useContactsLedgerSyncStatus(): ContactsLedgerSyncStatus {
+  const walletSyncFeature = useFeature("lldWalletSync");
+  const trustchain = useSelector(trustchainSelector);
+  const { visualPending, walletSyncError } = useWalletSyncUserState();
+
+  if (!walletSyncFeature?.enabled || walletSyncError) {
+    return "unavailable";
+  }
+
+  if (visualPending) {
+    return "checking";
+  }
+
+  return trustchain?.rootId ? "ready" : "inactive";
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/index.tsx
@@ -10,7 +10,7 @@ function ContactsScreen() {
   const addContactDialog = useAddContactDialogAdapter(pageViewModel.onClearSearch);
   const viewModel = {
     ...pageViewModel,
-    onAddContact: addContactDialog.onOpen,
+    onAddContact: () => pageViewModel.onRequestAddContact(addContactDialog.onOpen),
     addContactDialog,
   };
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -25,7 +25,9 @@ import {
   CONTACTS_PAGE_PROPERTY,
   CONTACTS_TRACK_EVENTS,
   CONTACTS_TRACKING_BUTTON,
+  trackContactsLedgerSyncActivate,
   useContactsListPageAnalytics,
+  useContactsLedgerSyncMutationGuard,
   trackContactsLedgerSyncDismiss,
 } from "@features/flow-contacts";
 import {
@@ -40,9 +42,9 @@ import {
 } from "@features/flow-contacts-add-address";
 import {
   CONTACTS_FEATURE_INTRODUCTION_HIGHLIGHTS,
+  isContactsLedgerSyncActivationRequired,
   resolveContactsLedgerSyncIntroductionOpen,
   useContactsFeatureIntroductionState,
-  type ContactsLedgerSyncStatus,
 } from "@features/flow-contacts-introduction";
 import {
   createMockContactDeviceIntentsPort,
@@ -54,10 +56,12 @@ import { useContactsAnalytics, resolveContactsCurrencyAnalytics } from "../../an
 import { useContactsFeatureIntroductionPreference } from "../../hooks/useContactsFeatureIntroductionPreference";
 import { useContactsCurrencySelectionAdapter } from "../../hooks/useContactsCurrencySelectionAdapter";
 import { useContactsAddressValidationAdapter } from "../../hooks/useContactsAddressValidationAdapter";
+import { useContactsLedgerSyncStatus } from "../../hooks/useContactsLedgerSyncStatus";
 import { useContactDetailPaneAdapter } from "./useContactDetailPaneAdapter";
 import type { ContactAddressDetailActionsDialogProps } from "./useContactAddressDetailActionsAdapter";
 import { useContactDetailEditDeleteAdapter } from "./useContactDetailEditDeleteAdapter";
 import { useDispatch } from "LLD/hooks/redux";
+import { useActivationDrawer } from "LLD/features/LedgerSyncEntryPoints/hooks/useActivationDrawer";
 import type { ContactsAddAddressFlowDialogProps } from "./components/ContactsAddAddressFlowDialog";
 
 export type ContactsPageViewModel = Omit<ContactsViewProps, "onAddContact"> &
@@ -68,6 +72,7 @@ export type ContactsPageViewModel = Omit<ContactsViewProps, "onAddContact"> &
     editDeleteDialogs: ReturnType<typeof useContactDetailEditDeleteAdapter>;
     addressDetailActionsDialogs: ContactAddressDetailActionsDialogProps;
     onClearSearch: () => void;
+    onRequestAddContact: (onAllowed: () => void) => void;
   }>;
 
 export function useContactsViewModel(): ContactsPageViewModel {
@@ -75,6 +80,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const analytics = useContactsAnalytics();
+  const { openDrawer } = useActivationDrawer();
   const helpCenterUrl = useLocalizedUrl(urls.helpModal.helpCenter);
   const handleSanctionedAddressLearnMore = useCallback(() => {
     openURL(helpCenterUrl);
@@ -180,12 +186,26 @@ export function useContactsViewModel(): ContactsPageViewModel {
     },
     [closeAddAddress, completeCurrencySelection, selectCurrency],
   );
+  const ledgerSyncStatus = useContactsLedgerSyncStatus();
+  const { requestMutation, dismissPendingIntent } = useContactsLedgerSyncMutationGuard();
+  const [isLedgerSyncIntroductionDismissed, setIsLedgerSyncIntroductionDismissed] = useState(false);
   const onAddAddress = useCallback(
     (contact: AddAddressContact) => {
+      const result = requestMutation(
+        { kind: "addAddress", contactId: contact.id },
+        ledgerSyncStatus,
+      );
+      if (result.status !== "allowed") {
+        if (result.status === "blocked") {
+          setIsLedgerSyncIntroductionDismissed(false);
+        }
+        return;
+      }
+
       startAddAddress(contact);
       selectCurrencyForContact(contact.id);
     },
-    [selectCurrencyForContact, startAddAddress],
+    [ledgerSyncStatus, requestMutation, selectCurrencyForContact, startAddAddress],
   );
   const onCloseAddAddress = useCallback(() => {
     cancelCurrencySelection();
@@ -310,8 +330,6 @@ export function useContactsViewModel(): ContactsPageViewModel {
     onOpenMe,
     onOpenContact,
   } = useContactDetailPaneAdapter(onAddAddress);
-  const [isLedgerSyncIntroductionDismissed, setIsLedgerSyncIntroductionDismissed] = useState(false);
-  const [ledgerSyncStatus] = useState<ContactsLedgerSyncStatus>("ready");
   const preference = useContactsFeatureIntroductionPreference();
   const featureIntroductionState = useContactsFeatureIntroductionState({
     isContactsEntryAvailable: true,
@@ -355,14 +373,33 @@ export function useContactsViewModel(): ContactsPageViewModel {
   const onClearSearch = useCallback(() => setSearchQuery(""), []);
   const onDismissLedgerSyncIntroduction = useCallback(() => {
     trackContactsLedgerSyncDismiss(analytics);
+    dismissPendingIntent();
     setIsLedgerSyncIntroductionDismissed(true);
-  }, [analytics]);
+  }, [analytics, dismissPendingIntent]);
+  const onActivateLedgerSyncIntroduction = useCallback(() => {
+    trackContactsLedgerSyncActivate(analytics);
+    dismissPendingIntent();
+    setIsLedgerSyncIntroductionDismissed(true);
+    openDrawer();
+  }, [analytics, dismissPendingIntent, openDrawer]);
+  const onRequestAddContact = useCallback(
+    (onAllowed: () => void) => {
+      const result = requestMutation({ kind: "addContact" }, ledgerSyncStatus);
+      if (result.status === "allowed") {
+        onAllowed();
+      } else if (result.status === "blocked") {
+        setIsLedgerSyncIntroductionDismissed(false);
+      }
+    },
+    [ledgerSyncStatus, requestMutation],
+  );
 
   useEffect(() => {
-    if (ledgerSyncStatus !== "inactive") {
+    if (!isContactsLedgerSyncActivationRequired(ledgerSyncStatus)) {
+      dismissPendingIntent();
       setIsLedgerSyncIntroductionDismissed(false);
     }
-  }, [ledgerSyncStatus]);
+  }, [dismissPendingIntent, ledgerSyncStatus]);
 
   const isLedgerSyncIntroductionOpen = resolveContactsLedgerSyncIntroductionOpen({
     isFeatureIntroductionRequested: featureIntroductionState.isRequested,
@@ -396,6 +433,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
     meAvatarSrc: MY_WALLET_AVATAR_USER_URL,
     onSearchInputChange,
     onClearSearch,
+    onRequestAddContact,
     onOpenMe,
     onOpenContact,
     detail,
@@ -412,7 +450,9 @@ export function useContactsViewModel(): ContactsPageViewModel {
     ledgerSyncIntroduction: {
       isOpen: isLedgerSyncIntroductionOpen,
       description: t("contacts.ledgerSyncIntroduction.description"),
+      activateLabel: t("contacts.ledgerSyncIntroduction.activate"),
       dismissLabel: t("contacts.ledgerSyncIntroduction.dismiss"),
+      onActivate: onActivateLedgerSyncIntroduction,
       onDismiss: onDismissLedgerSyncIntroduction,
     },
   };

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9550,6 +9550,7 @@
     },
     "ledgerSyncIntroduction": {
       "description": "Your contacts are end-to-end encrypted with your Ledger and synced across your devices, only you can unlock them.",
+      "activate": "Turn on Ledger Sync",
       "dismiss": "Got it"
     },
     "featureIntroduction": {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/index.tsx
@@ -4,7 +4,7 @@ import { ContactsAddAddressFlowDrawer } from "./components/ContactsAddAddressFlo
 import { ContactAddressDetailActionsSheets } from "./components/ContactAddressDetailActionsSheets";
 import { ContactAddressDetailDialogSheet } from "./components/ContactAddressDetailDialogSheet";
 import { ContactDetailEditDeleteSheets } from "./components/ContactDetailEditDeleteSheets";
-import { ContactsLedgerSyncIntroductionSheet } from "../../components/ContactsLedgerSyncIntroductionSheet";
+import { ContactsLedgerSyncIntroductionSheet } from "LLM/features/Contacts/components/ContactsLedgerSyncIntroductionSheet";
 import { useContactDetailNavigationViewModel } from "./hooks/useContactDetailNavigationViewModel";
 import { useContactDetailScreenViewModel } from "./useContactDetailScreenViewModel";
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsPageContent/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsPageContent/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ContactsView } from "@features/flow-contacts";
-import { ContactsLedgerSyncIntroductionSheet } from "../../../../components/ContactsLedgerSyncIntroductionSheet";
+import { ContactsLedgerSyncIntroductionSheet } from "LLM/features/Contacts/components/ContactsLedgerSyncIntroductionSheet";
 import { ContactsAddContactDrawerSheet } from "../ContactsAddContactDrawerSheet";
 import { ContactsFeatureIntroductionSheet } from "../ContactsFeatureIntroductionSheet";
 import type { ContactsPageContentProps } from "../../types";

--- a/features/flow/contacts/src/ContactsView.web.test.tsx
+++ b/features/flow/contacts/src/ContactsView.web.test.tsx
@@ -51,4 +51,40 @@ describe("ContactsView", () => {
     expect(screen.queryByTestId("contacts-add-contact")).not.toBeInTheDocument();
     expect(screen.queryByTestId("contacts-add-contact-header")).not.toBeInTheDocument();
   });
+
+  it("should show the Ledger Sync introduction while sync is unavailable", () => {
+    const contacts = mockPopulatedContacts();
+    const me = contacts.find(contact => contact.isMe) ?? mockMeContact();
+
+    render(
+      <ContactsView
+        viewModel={createContactsSearchViewModel(me, contacts, "")}
+        labels={labels}
+        searchQuery=""
+        meAvatarSrc="https://example.com/black/user.png"
+        onSearchInputChange={jest.fn()}
+        onOpenMe={jest.fn()}
+        onOpenContact={jest.fn()}
+        onAddContact={jest.fn()}
+        ledgerSyncStatus="unavailable"
+        featureIntroduction={{
+          isOpen: false,
+          title: "Add contacts",
+          description: "Save recipient addresses.",
+          highlights: [],
+          primaryActionLabel: "Try contacts",
+          onComplete: jest.fn(),
+          onClose: jest.fn(),
+        }}
+        ledgerSyncIntroduction={{
+          isOpen: true,
+          description: "Keep contacts in sync.",
+          dismissLabel: "Got it",
+          onDismiss: jest.fn(),
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Keep contacts in sync.")).toBeVisible();
+  });
 });

--- a/features/flow/contacts/src/ContactsView.web.tsx
+++ b/features/flow/contacts/src/ContactsView.web.tsx
@@ -3,6 +3,7 @@ import { ContactsListView as ContactsListFlowView } from "@features/flow-contact
 import {
   ContactsFeatureIntroductionDialog,
   ContactsLedgerSyncIntroductionDialog,
+  isContactsLedgerSyncActivationRequired,
 } from "@features/flow-contacts-introduction";
 import { ContactDetailView } from "./steps/Detail/ContactDetailView.web";
 import type { ContactsViewProps } from "./ContactsView.types";
@@ -22,9 +23,14 @@ export function ContactsView({
       featureIntroduction={<ContactsFeatureIntroductionDialog {...featureIntroduction} />}
       ledgerSyncIntroduction={
         <ContactsLedgerSyncIntroductionDialog
-          open={ledgerSyncStatus === "inactive" && ledgerSyncIntroduction.isOpen}
+          open={
+            isContactsLedgerSyncActivationRequired(ledgerSyncStatus) &&
+            ledgerSyncIntroduction.isOpen
+          }
           description={ledgerSyncIntroduction.description}
+          activateLabel={ledgerSyncIntroduction.activateLabel}
           dismissLabel={ledgerSyncIntroduction.dismissLabel}
+          onActivate={ledgerSyncIntroduction.onActivate}
           onDismiss={ledgerSyncIntroduction.onDismiss}
         />
       }

--- a/features/flow/flow-contacts-introduction/src/screens/LedgerSyncIntroduction/ContactsLedgerSyncIntroductionDialog.web.test.tsx
+++ b/features/flow/flow-contacts-introduction/src/screens/LedgerSyncIntroduction/ContactsLedgerSyncIntroductionDialog.web.test.tsx
@@ -24,4 +24,24 @@ describe("ContactsLedgerSyncIntroductionDialog", () => {
 
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
+
+  it("should call the activation action when it is provided", async () => {
+    const onActivate = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+      <ContactsLedgerSyncIntroductionDialog
+        open
+        description="Ledger Sync keeps contacts up to date."
+        activateLabel="Turn on Ledger Sync"
+        dismissLabel="Not now"
+        onActivate={onActivate}
+        onDismiss={jest.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Turn on Ledger Sync" }));
+
+    expect(onActivate).toHaveBeenCalledTimes(1);
+  });
 });

--- a/features/flow/flow-contacts-introduction/src/screens/LedgerSyncIntroduction/ContactsLedgerSyncIntroductionDialog.web.tsx
+++ b/features/flow/flow-contacts-introduction/src/screens/LedgerSyncIntroduction/ContactsLedgerSyncIntroductionDialog.web.tsx
@@ -6,7 +6,9 @@ import type { ContactsLedgerSyncIntroductionDialogProps } from "./types";
 export function ContactsLedgerSyncIntroductionDialog({
   open,
   description,
+  activateLabel,
   dismissLabel,
+  onActivate,
   onDismiss,
 }: ContactsLedgerSyncIntroductionDialogProps): React.ReactNode {
   const dismiss = useSingleFireDismiss(onDismiss, open);
@@ -23,7 +25,17 @@ export function ContactsLedgerSyncIntroductionDialog({
         <DialogHeader density="compact" onClose={dismiss} />
         <DialogBody className="flex flex-col gap-24 px-24 pb-24">
           <p className="body-1 text-base">{description}</p>
-          <Button appearance="base" size="md" onClick={dismiss} className="w-full">
+          {activateLabel && onActivate ? (
+            <Button appearance="base" size="md" onClick={onActivate} className="w-full">
+              {activateLabel}
+            </Button>
+          ) : null}
+          <Button
+            appearance={activateLabel && onActivate ? "gray" : "base"}
+            size="md"
+            onClick={dismiss}
+            className="w-full"
+          >
             {dismissLabel}
           </Button>
         </DialogBody>

--- a/features/flow/flow-contacts-introduction/src/screens/LedgerSyncIntroduction/types.ts
+++ b/features/flow/flow-contacts-introduction/src/screens/LedgerSyncIntroduction/types.ts
@@ -12,6 +12,8 @@ export type ContactsLedgerSyncIntroductionContentProps = Readonly<{
 export type ContactsLedgerSyncIntroductionDialogProps = Readonly<{
   open: boolean;
   description: string;
+  activateLabel?: string;
   dismissLabel: string;
+  onActivate?: () => void;
   onDismiss: () => void;
 }>;

--- a/features/flow/flow-contacts-introduction/src/state/types.ts
+++ b/features/flow/flow-contacts-introduction/src/state/types.ts
@@ -3,7 +3,9 @@ export type ContactsLedgerSyncStatus = "ready" | "checking" | "inactive" | "unav
 export type ContactsLedgerSyncIntroduction = Readonly<{
   isOpen: boolean;
   description: string;
+  activateLabel?: string;
   dismissLabel: string;
+  onActivate?: () => void;
   onDismiss: () => void;
 }>;
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Covered the Desktop Ledger Sync status adapter, the Contacts activation CTA, the Add address guard, and the affected shared Flow UI.
- [x] **Impact of the changes:**
      Desktop Contacts stays visible but read-only while Wallet Sync is disabled, unavailable, or checking. QA should verify Add contact and Add address, the activation CTA, closure of the Contacts modal before the drawer opens, and manual retry after activation.

### 📝 Description

Extends `LIVE-33958` to Ledger Wallet Desktop. This PR is stacked on #20505.

Desktop derives the Contacts Ledger Sync status from the Wallet Sync feature flag, Trustchain, and global Wallet Sync state. Add contact and Add address are blocked until sync is ready. The Contacts introduction opens the existing Wallet Sync activation drawer and closes before it opens.

The user retries the Contacts action manually after activation; no mutation resumes automatically.

https://github.com/user-attachments/assets/2a615ed0-5b88-477f-ad39-86b54909487c




### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-36384
- **Stacked on**: https://github.com/LedgerHQ/ledger-live/pull/20505

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)