### PR TITLE
[LWDM] fix(mobile): add missing tracking for touchscreen upsell

### DIFF
--- a/.changeset/quick-ladybugs-fly.md
+++ b/.changeset/quick-ladybugs-fly.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add missing tracking events for touchscreen upsell placements

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/__tests__/useContentCardsCategoryViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/__tests__/useContentCardsCategoryViewModel.test.tsx
@@ -159,7 +159,7 @@ describe("useContentCardsCategoryViewModel", () => {
     const openedUrl = new URL(jest.mocked(openURL).mock.calls[0]![0] as string);
     expect(openedUrl.origin + openedUrl.pathname).toBe("https://shop.ledger.com/products");
     expect(openedUrl.searchParams.get("utm_source")).toBe("ledger_wallet_desktop");
-    expect(openedUrl.searchParams.get("utm_medium")).toBe("ledger_live");
+    expect(openedUrl.searchParams.get("utm_medium")).toBe("in_app_placements");
     expect(openedUrl.searchParams.get("utm_campaign")).toBe("nano_upgrade_program");
     expect(openedUrl.searchParams.get("utm_content")).toBe("hardware_carousel");
     expect(mockNavigate).not.toHaveBeenCalled();

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
@@ -262,7 +262,7 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
       "https://shop.ledger.com/pages/opted-out-offer",
     );
     expect(openedUrl.searchParams.get("utm_source")).toBe("ledger_wallet_desktop");
-    expect(openedUrl.searchParams.get("utm_medium")).toBe("ledger_live");
+    expect(openedUrl.searchParams.get("utm_medium")).toBe("in_app_placements");
     expect(openedUrl.searchParams.get("utm_campaign")).toBe("nano_upgrade_program");
     expect(openedUrl.searchParams.get("utm_content")).toBe("app_start_modal");
     expect(store.getState().largeScreenUpsellModal.retriesModal).toBe(0);
@@ -313,7 +313,7 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
       "https://shop.ledger.com/pages/opted-in-offer",
     );
     expect(openedUrl.searchParams.get("utm_source")).toBe("ledger_wallet_desktop");
-    expect(openedUrl.searchParams.get("utm_medium")).toBe("ledger_live");
+    expect(openedUrl.searchParams.get("utm_medium")).toBe("in_app_placements");
     expect(openedUrl.searchParams.get("utm_campaign")).toBe("nano_upgrade_program");
     expect(openedUrl.searchParams.get("utm_content")).toBe("app_start_modal");
     expect(track).toHaveBeenCalledWith("button_clicked", {

--- a/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.test.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.test.tsx
@@ -233,10 +233,11 @@ describe("ContentCardsCategory Layout", () => {
         "ledger flex",
         mockHardwareCarouselProps,
       );
-      expect(trackContentCardEvent).toHaveBeenCalledWith(
-        ContentCardEvent.Clicked,
-        expectedTrackingBase,
-      );
+      expect(trackContentCardEvent).toHaveBeenCalledWith(ContentCardEvent.Clicked, {
+        ...expectedTrackingBase,
+        title: "Ledger Flex",
+        contentcard: "Ledger Flex",
+      });
     });
 
     it("should track Stax device click when title contains stax", async () => {
@@ -306,10 +307,11 @@ describe("ContentCardsCategory Layout", () => {
       await user.press(screen.getByTestId("card-click"));
 
       expect(trackHardwareCarouselDeviceClick).not.toHaveBeenCalled();
-      expect(trackContentCardEvent).toHaveBeenCalledWith(
-        ContentCardEvent.Clicked,
-        expectedTrackingBase,
-      );
+      expect(trackContentCardEvent).toHaveBeenCalledWith(ContentCardEvent.Clicked, {
+        ...expectedTrackingBase,
+        title: "Other Device",
+        contentcard: "Other Device",
+      });
     });
 
     it("should track card dismiss when hardware carousel props are provided", async () => {
@@ -325,10 +327,11 @@ describe("ContentCardsCategory Layout", () => {
       await user.press(screen.getByTestId("card-dismiss"));
 
       expect(trackHardwareCarouselCardDismiss).toHaveBeenCalledWith(mockHardwareCarouselProps);
-      expect(trackContentCardEvent).toHaveBeenCalledWith(
-        ContentCardEvent.Dismissed,
-        expectedTrackingBase,
-      );
+      expect(trackContentCardEvent).toHaveBeenCalledWith(ContentCardEvent.Dismissed, {
+        ...expectedTrackingBase,
+        title: "Ledger Stax",
+        contentcard: "Ledger Stax",
+      });
     });
 
     it("should not track hardware carousel events without props", async () => {
@@ -338,10 +341,11 @@ describe("ContentCardsCategory Layout", () => {
       await user.press(screen.getByTestId("card-click"));
 
       expect(trackHardwareCarouselDeviceClick).not.toHaveBeenCalled();
-      expect(trackContentCardEvent).toHaveBeenCalledWith(
-        ContentCardEvent.Clicked,
-        expectedTrackingBase,
-      );
+      expect(trackContentCardEvent).toHaveBeenCalledWith(ContentCardEvent.Clicked, {
+        ...expectedTrackingBase,
+        title: "Ledger Flex",
+        contentcard: "Ledger Flex",
+      });
     });
   });
 });

--- a/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.test.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.test.tsx
@@ -13,9 +13,17 @@ import {
 } from "~/dynamicContent/types";
 import useDynamicContent from "../useDynamicContent";
 import Layout from "./Layout";
+import {
+  trackHardwareCarouselDeviceClick,
+  trackHardwareCarouselCardDismiss,
+} from "~/dynamicContent/hardwareCarousel/analytics";
 
 jest.mock("../useDynamicContent");
 jest.mock("@features/platform-feature-flags");
+jest.mock("~/dynamicContent/hardwareCarousel/analytics", () => ({
+  trackHardwareCarouselDeviceClick: jest.fn(),
+  trackHardwareCarouselCardDismiss: jest.fn(),
+}));
 jest.mock("LLM/features/DynamicContent/components/LogContentCardWrapper", () => ({
   __esModule: true,
   default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -199,5 +207,141 @@ describe("ContentCardsCategory Layout", () => {
     expect(screen.getByTestId("mock-carousel")).toBeVisible();
     expect(screen.getByTestId("upsell-leading")).toBeVisible();
     expect(screen.getByTestId("carousel-item-count")).toHaveTextContent("1");
+  });
+
+  describe("hardware carousel tracking", () => {
+    const mockHardwareCarouselProps = {
+      deviceModel: "lnx" as const,
+      personalRecoOptIn: true,
+      offerType: "discount" as const,
+      platform: "lwm" as const,
+    };
+
+    it("should track Flex device click when hardware carousel props are provided", async () => {
+      const card = createBrazeActionCard({ title: "Ledger Flex" });
+      const { user } = render(
+        <Layout
+          category={topWalletCategory}
+          cards={[card]}
+          hardwareCarouselSharedProps={mockHardwareCarouselProps}
+        />,
+      );
+
+      await user.press(screen.getByTestId("card-click"));
+
+      expect(trackHardwareCarouselDeviceClick).toHaveBeenCalledWith(
+        "ledger flex",
+        mockHardwareCarouselProps,
+      );
+      expect(trackContentCardEvent).toHaveBeenCalledWith(
+        ContentCardEvent.Clicked,
+        expectedTrackingBase,
+      );
+    });
+
+    it("should track Stax device click when title contains stax", async () => {
+      const card = createBrazeActionCard({ title: "Ledger Stax" });
+      const { user } = render(
+        <Layout
+          category={topWalletCategory}
+          cards={[card]}
+          hardwareCarouselSharedProps={mockHardwareCarouselProps}
+        />,
+      );
+
+      await user.press(screen.getByTestId("card-click"));
+
+      expect(trackHardwareCarouselDeviceClick).toHaveBeenCalledWith(
+        "ledger stax",
+        mockHardwareCarouselProps,
+      );
+    });
+
+    it("should track Gen5 device click when title contains gen5", async () => {
+      const card = createBrazeActionCard({ title: "Ledger Gen5" });
+      const { user } = render(
+        <Layout
+          category={topWalletCategory}
+          cards={[card]}
+          hardwareCarouselSharedProps={mockHardwareCarouselProps}
+        />,
+      );
+
+      await user.press(screen.getByTestId("card-click"));
+
+      expect(trackHardwareCarouselDeviceClick).toHaveBeenCalledWith(
+        "ledger gen5",
+        mockHardwareCarouselProps,
+      );
+    });
+
+    it("should track Gen5 device click when title contains 'gen 5' with space", async () => {
+      const card = createBrazeActionCard({ title: "Ledger Gen 5" });
+      const { user } = render(
+        <Layout
+          category={topWalletCategory}
+          cards={[card]}
+          hardwareCarouselSharedProps={mockHardwareCarouselProps}
+        />,
+      );
+
+      await user.press(screen.getByTestId("card-click"));
+
+      expect(trackHardwareCarouselDeviceClick).toHaveBeenCalledWith(
+        "ledger gen5",
+        mockHardwareCarouselProps,
+      );
+    });
+
+    it("should not track device click when title does not match any device", async () => {
+      const card = createBrazeActionCard({ title: "Other Device" });
+      const { user } = render(
+        <Layout
+          category={topWalletCategory}
+          cards={[card]}
+          hardwareCarouselSharedProps={mockHardwareCarouselProps}
+        />,
+      );
+
+      await user.press(screen.getByTestId("card-click"));
+
+      expect(trackHardwareCarouselDeviceClick).not.toHaveBeenCalled();
+      expect(trackContentCardEvent).toHaveBeenCalledWith(
+        ContentCardEvent.Clicked,
+        expectedTrackingBase,
+      );
+    });
+
+    it("should track card dismiss when hardware carousel props are provided", async () => {
+      const card = createBrazeActionCard({ title: "Ledger Stax" });
+      const { user } = render(
+        <Layout
+          category={topWalletCategory}
+          cards={[card]}
+          hardwareCarouselSharedProps={mockHardwareCarouselProps}
+        />,
+      );
+
+      await user.press(screen.getByTestId("card-dismiss"));
+
+      expect(trackHardwareCarouselCardDismiss).toHaveBeenCalledWith(mockHardwareCarouselProps);
+      expect(trackContentCardEvent).toHaveBeenCalledWith(
+        ContentCardEvent.Dismissed,
+        expectedTrackingBase,
+      );
+    });
+
+    it("should not track hardware carousel events without props", async () => {
+      const card = createBrazeActionCard({ title: "Ledger Flex" });
+      const { user } = render(<Layout category={topWalletCategory} cards={[card]} />);
+
+      await user.press(screen.getByTestId("card-click"));
+
+      expect(trackHardwareCarouselDeviceClick).not.toHaveBeenCalled();
+      expect(trackContentCardEvent).toHaveBeenCalledWith(
+        ContentCardEvent.Clicked,
+        expectedTrackingBase,
+      );
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.tsx
@@ -33,6 +33,29 @@ import Grid from "~/contentCards/layouts/grid";
 import VerticalCard from "~/contentCards/cards/vertical";
 import HeroCard from "~/contentCards/cards/hero";
 import LogContentCardWrapper from "LLM/features/DynamicContent/components/LogContentCardWrapper";
+import {
+  trackHardwareCarouselDeviceClick,
+  trackHardwareCarouselCardDismiss,
+  type HardwareCarouselDevice,
+  type HardwareCarouselSharedAnalyticsProps,
+} from "~/dynamicContent/hardwareCarousel/analytics";
+
+function extractDeviceType(title?: string): HardwareCarouselDevice | null {
+  if (!title) return null;
+
+  const titleLower = title.toLowerCase();
+  if (titleLower.includes("gen5") || titleLower.includes("gen 5")) {
+    return "ledger gen5";
+  }
+  if (titleLower.includes("flex")) {
+    return "ledger flex";
+  }
+  if (titleLower.includes("stax")) {
+    return "ledger stax";
+  }
+
+  return null;
+}
 
 // TODO : Better type to remove any (maybe use AnyContentCard)
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -73,11 +96,12 @@ type LayoutProps = {
   category: CategoryContentCard;
   cards: BrazeContentCard[];
   leadingSlide?: React.ReactNode;
+  hardwareCarouselSharedProps?: HardwareCarouselSharedAnalyticsProps;
 };
 
 type LayoutCardItemProps = ContentCardProps & { widthFactor?: number };
 
-const Layout = ({ category, cards, leadingSlide }: LayoutProps) => {
+const Layout = ({ category, cards, leadingSlide, hardwareCarouselSharedProps }: LayoutProps) => {
   const { logClickCard, dismissCard, trackContentCardEvent } = useDynamicContent();
   const isTopWallet = category.location === ContentCardLocation.TopWallet;
   const { shouldDisplayBrazePlacement } = useWalletFeaturesConfig("mobile");
@@ -92,6 +116,13 @@ const Layout = ({ category, cards, leadingSlide }: LayoutProps) => {
     : contentCardsType.contentCardComponent;
 
   const onCardClick = async (card: AnyContentCard, displayedPosition: number) => {
+    if (hardwareCarouselSharedProps) {
+      const deviceType = extractDeviceType(card.title);
+      if (deviceType) {
+        trackHardwareCarouselDeviceClick(deviceType, hardwareCarouselSharedProps);
+      }
+    }
+
     await trackContentCardEvent(ContentCardEvent.Clicked, {
       ...buildContentCardTrackingProperties({
         cardExtras: card.extras,
@@ -115,6 +146,10 @@ const Layout = ({ category, cards, leadingSlide }: LayoutProps) => {
   };
 
   const onCardDismiss = (card: AnyContentCard, displayedPosition: number) => {
+    if (hardwareCarouselSharedProps) {
+      trackHardwareCarouselCardDismiss(hardwareCarouselSharedProps);
+    }
+
     trackContentCardEvent(ContentCardEvent.Dismissed, {
       ...buildContentCardTrackingProperties({
         cardExtras: card.extras,

--- a/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/index.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/index.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import LogContentCardWrapper from "LLM/features/DynamicContent/components/LogContentCardWrapper";
 import { shouldShowHardwareCarouselCloseAll } from "~/dynamicContent/hardwareCarousel/shouldShowHardwareCarouselCloseAll";
+import { useHardwareCarouselPageTracking } from "~/dynamicContent/hardwareCarousel/useHardwareCarouselPageTracking";
 import { CategoryContentCard, BrazeContentCard } from "../types";
 import Header from "./Header";
 import Layout from "./Layout";
@@ -13,13 +14,16 @@ type Props = {
 };
 
 const ContentCardsCategory = ({ category, categoryContentCards, leadingSlide }: Props) => {
+  const isHardwareCarousel = shouldShowHardwareCarouselCloseAll(category);
+  const hardwareCarouselSharedProps = useHardwareCarouselPageTracking(isHardwareCarousel);
+
   const closeAllCardIds = useMemo(() => {
-    if (!shouldShowHardwareCarouselCloseAll(category)) {
+    if (!isHardwareCarousel) {
       return undefined;
     }
 
     return categoryContentCards.map(card => card.id);
-  }, [category, categoryContentCards]);
+  }, [isHardwareCarousel, categoryContentCards]);
 
   return (
     <LogContentCardWrapper id={category.id} location={category.location}>
@@ -32,7 +36,12 @@ const ContentCardsCategory = ({ category, categoryContentCards, leadingSlide }: 
           centered={category.centeredText}
           closeAllCardIds={closeAllCardIds}
         />
-        <Layout category={category} cards={categoryContentCards} leadingSlide={leadingSlide} />
+        <Layout
+          category={category}
+          cards={categoryContentCards}
+          leadingSlide={leadingSlide}
+          hardwareCarouselSharedProps={isHardwareCarousel ? hardwareCarouselSharedProps : undefined}
+        />
       </Box>
     </LogContentCardWrapper>
   );

--- a/apps/ledger-live-mobile/src/dynamicContent/hardwareCarousel/analytics.test.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/hardwareCarousel/analytics.test.ts
@@ -1,0 +1,94 @@
+import { screen, track } from "~/analytics";
+import {
+  HARDWARE_CAROUSEL_PAGE,
+  trackHardwareCarouselShown,
+  trackHardwareCarouselDeviceClick,
+  trackHardwareCarouselCardDismiss,
+  trackHardwareCarouselCloseAll,
+  type HardwareCarouselSharedAnalyticsProps,
+} from "./analytics";
+
+jest.mock("~/analytics", () => ({
+  screen: jest.fn(),
+  track: jest.fn(),
+}));
+
+const mockSharedProps: HardwareCarouselSharedAnalyticsProps = {
+  deviceModel: "lnx",
+  personalRecoOptIn: true,
+  offerType: "discount",
+  platform: "lwm",
+};
+
+describe("hardware carousel analytics", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("trackHardwareCarouselShown", () => {
+    it("should call screen with correct page name and props", () => {
+      trackHardwareCarouselShown(mockSharedProps);
+
+      expect(screen).toHaveBeenCalledWith(HARDWARE_CAROUSEL_PAGE, undefined, {
+        name: HARDWARE_CAROUSEL_PAGE,
+        ...mockSharedProps,
+      });
+    });
+  });
+
+  describe("trackHardwareCarouselDeviceClick", () => {
+    it("should track Gen5 device click", () => {
+      trackHardwareCarouselDeviceClick("ledger gen5", mockSharedProps);
+
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "ledger gen5",
+        page: HARDWARE_CAROUSEL_PAGE,
+        ...mockSharedProps,
+      });
+    });
+
+    it("should track Flex device click", () => {
+      trackHardwareCarouselDeviceClick("ledger flex", mockSharedProps);
+
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "ledger flex",
+        page: HARDWARE_CAROUSEL_PAGE,
+        ...mockSharedProps,
+      });
+    });
+
+    it("should track Stax device click", () => {
+      trackHardwareCarouselDeviceClick("ledger stax", mockSharedProps);
+
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "ledger stax",
+        page: HARDWARE_CAROUSEL_PAGE,
+        ...mockSharedProps,
+      });
+    });
+  });
+
+  describe("trackHardwareCarouselCardDismiss", () => {
+    it("should track close button click", () => {
+      trackHardwareCarouselCardDismiss(mockSharedProps);
+
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "close",
+        page: HARDWARE_CAROUSEL_PAGE,
+        ...mockSharedProps,
+      });
+    });
+  });
+
+  describe("trackHardwareCarouselCloseAll", () => {
+    it("should track close all button click", () => {
+      trackHardwareCarouselCloseAll(mockSharedProps);
+
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "close all",
+        page: HARDWARE_CAROUSEL_PAGE,
+        ...mockSharedProps,
+      });
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/dynamicContent/hardwareCarousel/analytics.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/hardwareCarousel/analytics.ts
@@ -8,7 +8,7 @@ export type HardwareCarouselSharedAnalyticsProps = Readonly<{
   deviceModel: HardwareCarouselDeviceModel;
   personalRecoOptIn: boolean;
   offerType: "discount" | "none";
-  platform: "llm";
+  platform: "lwm";
 }>;
 
 export type HardwareCarouselDevice = "ledger gen5" | "ledger flex" | "ledger stax";

--- a/apps/ledger-live-mobile/src/dynamicContent/hardwareCarousel/analytics.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/hardwareCarousel/analytics.ts
@@ -1,6 +1,6 @@
-import { track } from "~/analytics";
+import { screen, track } from "~/analytics";
 
-export const HARDWARE_CAROUSEL_PAGE = "hardware carousel";
+export const HARDWARE_CAROUSEL_PAGE = "carousel hardware";
 
 export type HardwareCarouselDeviceModel = "lnx" | "lnsp";
 
@@ -10,6 +10,38 @@ export type HardwareCarouselSharedAnalyticsProps = Readonly<{
   offerType: "discount" | "none";
   platform: "llm";
 }>;
+
+export type HardwareCarouselDevice = "ledger gen5" | "ledger flex" | "ledger stax";
+
+export function trackHardwareCarouselShown(
+  sharedProps: HardwareCarouselSharedAnalyticsProps,
+): void {
+  screen(HARDWARE_CAROUSEL_PAGE, undefined, {
+    name: HARDWARE_CAROUSEL_PAGE,
+    ...sharedProps,
+  });
+}
+
+export function trackHardwareCarouselDeviceClick(
+  device: HardwareCarouselDevice,
+  sharedProps: HardwareCarouselSharedAnalyticsProps,
+): void {
+  track("button_clicked", {
+    button: device,
+    page: HARDWARE_CAROUSEL_PAGE,
+    ...sharedProps,
+  });
+}
+
+export function trackHardwareCarouselCardDismiss(
+  sharedProps: HardwareCarouselSharedAnalyticsProps,
+): void {
+  track("button_clicked", {
+    button: "close",
+    page: HARDWARE_CAROUSEL_PAGE,
+    ...sharedProps,
+  });
+}
 
 export function trackHardwareCarouselCloseAll(
   sharedProps: HardwareCarouselSharedAnalyticsProps,

--- a/apps/ledger-live-mobile/src/dynamicContent/hardwareCarousel/useHardwareCarouselCloseAll.test.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/hardwareCarousel/useHardwareCarouselCloseAll.test.ts
@@ -50,7 +50,7 @@ describe("useHardwareCarouselCloseAll", () => {
       deviceModel: "lnx",
       personalRecoOptIn: true,
       offerType: "discount",
-      platform: "llm",
+      platform: "lwm",
     });
   });
 

--- a/apps/ledger-live-mobile/src/dynamicContent/hardwareCarousel/useHardwareCarouselCloseAll.test.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/hardwareCarousel/useHardwareCarouselCloseAll.test.ts
@@ -65,4 +65,25 @@ describe("useHardwareCarouselCloseAll", () => {
     expect(mockDismissCards).toHaveBeenCalledWith(["card-1"]);
     expect(trackHardwareCarouselCloseAll).not.toHaveBeenCalled();
   });
+
+  it("does not track analytics when no known device models exist", () => {
+    mockDismissCards.mockReturnValue(true);
+    const { result } = renderHook(() => useHardwareCarouselCloseAll(["card-1"]), {
+      overrideInitialState: (state: State) => ({
+        ...state,
+        settings: {
+          ...state.settings,
+          knownDeviceModelIds: {},
+          personalizedRecommendationsEnabled: true,
+        },
+      }),
+    });
+
+    act(() => {
+      result.current();
+    });
+
+    expect(mockDismissCards).toHaveBeenCalledWith(["card-1"]);
+    expect(trackHardwareCarouselCloseAll).not.toHaveBeenCalled();
+  });
 });

--- a/apps/ledger-live-mobile/src/dynamicContent/hardwareCarousel/useHardwareCarouselCloseAll.test.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/hardwareCarousel/useHardwareCarouselCloseAll.test.ts
@@ -73,7 +73,11 @@ describe("useHardwareCarouselCloseAll", () => {
         ...state,
         settings: {
           ...state.settings,
-          knownDeviceModelIds: {},
+          knownDeviceModelIds: {
+            ...state.settings.knownDeviceModelIds,
+            [DeviceModelId.nanoX]: false,
+            [DeviceModelId.nanoSP]: false,
+          },
           personalizedRecommendationsEnabled: true,
         },
       }),

--- a/apps/ledger-live-mobile/src/dynamicContent/hardwareCarousel/useHardwareCarouselCloseAll.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/hardwareCarousel/useHardwareCarouselCloseAll.ts
@@ -14,12 +14,16 @@ import {
 
 function resolveHardwareCarouselDeviceModel(
   knownDeviceModelIds: Record<DeviceModelId, boolean>,
-): HardwareCarouselDeviceModel {
+): HardwareCarouselDeviceModel | undefined {
   if (knownDeviceModelIds[DeviceModelId.nanoX]) {
     return "lnx";
   }
 
-  return "lnsp";
+  if (knownDeviceModelIds[DeviceModelId.nanoSP]) {
+    return "lnsp";
+  }
+
+  return undefined;
 }
 
 export function useHardwareCarouselCloseAll(cardIds: readonly string[]) {
@@ -27,18 +31,22 @@ export function useHardwareCarouselCloseAll(cardIds: readonly string[]) {
   const knownDeviceModelIds = useSelector(knownDeviceModelIdsSelector);
   const personalRecoOptIn = useSelector(personalizedRecommendationsEnabledSelector);
 
-  const sharedAnalyticsProps: HardwareCarouselSharedAnalyticsProps = useMemo(
-    () => ({
-      deviceModel: resolveHardwareCarouselDeviceModel(knownDeviceModelIds),
+  const sharedAnalyticsProps: HardwareCarouselSharedAnalyticsProps | undefined = useMemo(() => {
+    const deviceModel = resolveHardwareCarouselDeviceModel(knownDeviceModelIds);
+    if (!deviceModel) {
+      return undefined;
+    }
+
+    return {
+      deviceModel,
       personalRecoOptIn,
       offerType: personalRecoOptIn ? "discount" : "none",
       platform: "llm",
-    }),
-    [knownDeviceModelIds, personalRecoOptIn],
-  );
+    };
+  }, [knownDeviceModelIds, personalRecoOptIn]);
 
   const handleCloseAll = useCallback(() => {
-    if (!dismissCards(cardIds)) {
+    if (!dismissCards(cardIds) || !sharedAnalyticsProps) {
       return;
     }
 

--- a/apps/ledger-live-mobile/src/dynamicContent/hardwareCarousel/useHardwareCarouselCloseAll.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/hardwareCarousel/useHardwareCarouselCloseAll.ts
@@ -41,7 +41,7 @@ export function useHardwareCarouselCloseAll(cardIds: readonly string[]) {
       deviceModel,
       personalRecoOptIn,
       offerType: personalRecoOptIn ? "discount" : "none",
-      platform: "llm",
+      platform: "lwm",
     };
   }, [knownDeviceModelIds, personalRecoOptIn]);
 

--- a/apps/ledger-live-mobile/src/dynamicContent/hardwareCarousel/useHardwareCarouselPageTracking.test.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/hardwareCarousel/useHardwareCarouselPageTracking.test.ts
@@ -1,0 +1,159 @@
+import { renderHook } from "@tests/test-renderer";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { State } from "~/reducers/types";
+import { useHardwareCarouselPageTracking } from "./useHardwareCarouselPageTracking";
+import { trackHardwareCarouselShown } from "./analytics";
+
+jest.mock("./analytics", () => ({
+  trackHardwareCarouselShown: jest.fn(),
+}));
+
+describe("useHardwareCarouselPageTracking", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should track when shouldTrack is true and Nano X is known", () => {
+    renderHook(() => useHardwareCarouselPageTracking(true), {
+      overrideInitialState: (state: State) => ({
+        ...state,
+        settings: {
+          ...state.settings,
+          knownDeviceModelIds: {
+            ...state.settings.knownDeviceModelIds,
+            [DeviceModelId.nanoX]: true,
+          },
+          personalizedRecommendationsEnabled: true,
+        },
+      }),
+    });
+
+    expect(trackHardwareCarouselShown).toHaveBeenCalledWith({
+      deviceModel: "lnx",
+      personalRecoOptIn: true,
+      offerType: "discount",
+      platform: "lwm",
+    });
+  });
+
+  it("should track when shouldTrack is true and Nano S Plus is known", () => {
+    renderHook(() => useHardwareCarouselPageTracking(true), {
+      overrideInitialState: (state: State) => ({
+        ...state,
+        settings: {
+          ...state.settings,
+          knownDeviceModelIds: {
+            ...state.settings.knownDeviceModelIds,
+            [DeviceModelId.nanoSP]: true,
+          },
+          personalizedRecommendationsEnabled: false,
+        },
+      }),
+    });
+
+    expect(trackHardwareCarouselShown).toHaveBeenCalledWith({
+      deviceModel: "lnsp",
+      personalRecoOptIn: false,
+      offerType: "none",
+      platform: "lwm",
+    });
+  });
+
+  it("should not track when shouldTrack is false", () => {
+    renderHook(() => useHardwareCarouselPageTracking(false), {
+      overrideInitialState: (state: State) => ({
+        ...state,
+        settings: {
+          ...state.settings,
+          knownDeviceModelIds: {
+            ...state.settings.knownDeviceModelIds,
+            [DeviceModelId.nanoX]: true,
+          },
+          personalizedRecommendationsEnabled: true,
+        },
+      }),
+    });
+
+    expect(trackHardwareCarouselShown).not.toHaveBeenCalled();
+  });
+
+  it("should not track when no known device models exist", () => {
+    renderHook(() => useHardwareCarouselPageTracking(true), {
+      overrideInitialState: (state: State) => ({
+        ...state,
+        settings: {
+          ...state.settings,
+          knownDeviceModelIds: {
+            ...state.settings.knownDeviceModelIds,
+            [DeviceModelId.nanoX]: false,
+            [DeviceModelId.nanoSP]: false,
+          },
+          personalizedRecommendationsEnabled: true,
+        },
+      }),
+    });
+
+    expect(trackHardwareCarouselShown).not.toHaveBeenCalled();
+  });
+
+  it("should return shared props when device model is known", () => {
+    const { result } = renderHook(() => useHardwareCarouselPageTracking(false), {
+      overrideInitialState: (state: State) => ({
+        ...state,
+        settings: {
+          ...state.settings,
+          knownDeviceModelIds: {
+            ...state.settings.knownDeviceModelIds,
+            [DeviceModelId.nanoX]: true,
+          },
+          personalizedRecommendationsEnabled: true,
+        },
+      }),
+    });
+
+    expect(result.current).toEqual({
+      deviceModel: "lnx",
+      personalRecoOptIn: true,
+      offerType: "discount",
+      platform: "lwm",
+    });
+  });
+
+  it("should return undefined when no device model is known", () => {
+    const { result } = renderHook(() => useHardwareCarouselPageTracking(false), {
+      overrideInitialState: (state: State) => ({
+        ...state,
+        settings: {
+          ...state.settings,
+          knownDeviceModelIds: {
+            ...state.settings.knownDeviceModelIds,
+            [DeviceModelId.nanoX]: false,
+            [DeviceModelId.nanoSP]: false,
+          },
+          personalizedRecommendationsEnabled: true,
+        },
+      }),
+    });
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it("should prefer Nano X over Nano S Plus when both are known", () => {
+    const { result } = renderHook(() => useHardwareCarouselPageTracking(false), {
+      overrideInitialState: (state: State) => ({
+        ...state,
+        settings: {
+          ...state.settings,
+          knownDeviceModelIds: {
+            ...state.settings.knownDeviceModelIds,
+            [DeviceModelId.nanoX]: true,
+            [DeviceModelId.nanoSP]: true,
+          },
+          personalizedRecommendationsEnabled: true,
+        },
+      }),
+    });
+
+    expect(result.current?.deviceModel).toBe("lnx");
+  });
+});

--- a/apps/ledger-live-mobile/src/dynamicContent/hardwareCarousel/useHardwareCarouselPageTracking.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/hardwareCarousel/useHardwareCarouselPageTracking.ts
@@ -39,7 +39,7 @@ export function useHardwareCarouselPageTracking(shouldTrack: boolean) {
       deviceModel,
       personalRecoOptIn,
       offerType: personalRecoOptIn ? "discount" : "none",
-      platform: "llm",
+      platform: "lwm",
     };
   }, [knownDeviceModelIds, personalRecoOptIn]);
 

--- a/apps/ledger-live-mobile/src/dynamicContent/hardwareCarousel/useHardwareCarouselPageTracking.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/hardwareCarousel/useHardwareCarouselPageTracking.ts
@@ -13,30 +13,38 @@ import {
 
 function resolveHardwareCarouselDeviceModel(
   knownDeviceModelIds: Record<DeviceModelId, boolean>,
-): HardwareCarouselDeviceModel {
+): HardwareCarouselDeviceModel | undefined {
   if (knownDeviceModelIds[DeviceModelId.nanoX]) {
     return "lnx";
   }
 
-  return "lnsp";
+  if (knownDeviceModelIds[DeviceModelId.nanoSP]) {
+    return "lnsp";
+  }
+
+  return undefined;
 }
 
 export function useHardwareCarouselPageTracking(shouldTrack: boolean) {
   const knownDeviceModelIds = useSelector(knownDeviceModelIdsSelector);
   const personalRecoOptIn = useSelector(personalizedRecommendationsEnabledSelector);
 
-  const sharedAnalyticsProps: HardwareCarouselSharedAnalyticsProps = useMemo(
-    () => ({
-      deviceModel: resolveHardwareCarouselDeviceModel(knownDeviceModelIds),
+  const sharedAnalyticsProps: HardwareCarouselSharedAnalyticsProps | undefined = useMemo(() => {
+    const deviceModel = resolveHardwareCarouselDeviceModel(knownDeviceModelIds);
+    if (!deviceModel) {
+      return undefined;
+    }
+
+    return {
+      deviceModel,
       personalRecoOptIn,
       offerType: personalRecoOptIn ? "discount" : "none",
       platform: "llm",
-    }),
-    [knownDeviceModelIds, personalRecoOptIn],
-  );
+    };
+  }, [knownDeviceModelIds, personalRecoOptIn]);
 
   useEffect(() => {
-    if (shouldTrack) {
+    if (shouldTrack && sharedAnalyticsProps) {
       trackHardwareCarouselShown(sharedAnalyticsProps);
     }
   }, [shouldTrack, sharedAnalyticsProps]);

--- a/apps/ledger-live-mobile/src/dynamicContent/hardwareCarousel/useHardwareCarouselPageTracking.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/hardwareCarousel/useHardwareCarouselPageTracking.ts
@@ -1,0 +1,45 @@
+import { useEffect, useMemo } from "react";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { useSelector } from "~/context/hooks";
+import {
+  knownDeviceModelIdsSelector,
+  personalizedRecommendationsEnabledSelector,
+} from "~/reducers/settings";
+import {
+  trackHardwareCarouselShown,
+  type HardwareCarouselDeviceModel,
+  type HardwareCarouselSharedAnalyticsProps,
+} from "./analytics";
+
+function resolveHardwareCarouselDeviceModel(
+  knownDeviceModelIds: Record<DeviceModelId, boolean>,
+): HardwareCarouselDeviceModel {
+  if (knownDeviceModelIds[DeviceModelId.nanoX]) {
+    return "lnx";
+  }
+
+  return "lnsp";
+}
+
+export function useHardwareCarouselPageTracking(shouldTrack: boolean) {
+  const knownDeviceModelIds = useSelector(knownDeviceModelIdsSelector);
+  const personalRecoOptIn = useSelector(personalizedRecommendationsEnabledSelector);
+
+  const sharedAnalyticsProps: HardwareCarouselSharedAnalyticsProps = useMemo(
+    () => ({
+      deviceModel: resolveHardwareCarouselDeviceModel(knownDeviceModelIds),
+      personalRecoOptIn,
+      offerType: personalRecoOptIn ? "discount" : "none",
+      platform: "llm",
+    }),
+    [knownDeviceModelIds, personalRecoOptIn],
+  );
+
+  useEffect(() => {
+    if (shouldTrack) {
+      trackHardwareCarouselShown(sharedAnalyticsProps);
+    }
+  }, [shouldTrack, sharedAnalyticsProps]);
+
+  return sharedAnalyticsProps;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/LNUpsell/components/LNUpsellBanner/LNUpsellBanner.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LNUpsell/components/LNUpsellBanner/LNUpsellBanner.test.tsx
@@ -66,13 +66,16 @@ describe("LNUpsellBanner", () => {
       renderBanner({ ctaLink: "  https://example.com/trimmedCta  " });
       fireEvent.press(screen.getByText(t(`lnsUpsell.opted_in.cta`)));
 
-      expect(Linking.openURL).toHaveBeenCalledWith("https://example.com/trimmedCta");
-      expect(track).toHaveBeenCalledWith("button_clicked", {
-        button: "Level up wallet",
-        deviceModel: "lns",
-        link: "https://example.com/trimmedCta",
-        page,
-      });
+      const trimmedUrl = new URL(String(jest.mocked(Linking.openURL).mock.calls[0][0]));
+      expect(trimmedUrl.origin + trimmedUrl.pathname).toBe("https://example.com/trimmedCta");
+      expect(track).toHaveBeenCalledWith(
+        "button_clicked",
+        expect.objectContaining({
+          button: "upgrade",
+          deviceModel: "lns",
+        }),
+      );
+      expect(track).toHaveBeenCalledWith("deeplink_clicked", expect.any(Object));
     });
 
     it.each([DeviceModelId.nanoSP, DeviceModelId.nanoX])(
@@ -98,12 +101,14 @@ describe("LNUpsellBanner", () => {
         });
         fireEvent.press(screen.getByText(t(`lnsUpsell.opted_in.cta`)));
 
-        expect(track).toHaveBeenCalledWith("button_clicked", {
-          button: "Level up wallet",
-          deviceModel: analyticsValue,
-          link: "https://example.com/optInCta",
-          page,
-        });
+        expect(track).toHaveBeenCalledWith(
+          "button_clicked",
+          expect.objectContaining({
+            button: "upgrade",
+            deviceModel: analyticsValue,
+          }),
+        );
+        expect(track).toHaveBeenCalledWith("deeplink_clicked", expect.any(Object));
       },
     );
 
@@ -134,14 +139,17 @@ describe("LNUpsellBanner", () => {
       fireEvent.press(screen.getByText(t(`lnsUpsell.opted_in.cta`)));
 
       expect(Linking.openURL).toHaveBeenCalledTimes(1);
-      expect(Linking.openURL).toHaveBeenCalledWith("https://example.com/optInCta");
-      expect(track).toHaveBeenCalledTimes(1);
-      expect(track).toHaveBeenCalledWith("button_clicked", {
-        button: "Level up wallet",
-        deviceModel: "lns",
-        link: "https://example.com/optInCta",
-        page,
-      });
+      const openedUrl = new URL(String(jest.mocked(Linking.openURL).mock.calls[0][0]));
+      expect(openedUrl.origin + openedUrl.pathname).toBe("https://example.com/optInCta");
+      expect(track).toHaveBeenCalledTimes(2);
+      expect(track).toHaveBeenCalledWith(
+        "button_clicked",
+        expect.objectContaining({
+          button: "upgrade",
+          deviceModel: "lns",
+        }),
+      );
+      expect(track).toHaveBeenCalledWith("deeplink_clicked", expect.any(Object));
     });
 
     it("should render Lumen MediaBanner and track press when lwmWallet40 brazePlacement is on", () => {
@@ -149,13 +157,16 @@ describe("LNUpsellBanner", () => {
       fireEvent.press(screen.getByTestId("lns-upsell-media-banner"));
 
       expect(Linking.openURL).toHaveBeenCalledTimes(1);
-      expect(Linking.openURL).toHaveBeenCalledWith("https://example.com/optInCta");
-      expect(track).toHaveBeenCalledWith("button_clicked", {
-        button: "Level up wallet",
-        deviceModel: "lns",
-        link: "https://example.com/optInCta",
-        page,
-      });
+      const openedUrl = new URL(String(jest.mocked(Linking.openURL).mock.calls[0][0]));
+      expect(openedUrl.origin + openedUrl.pathname).toBe("https://example.com/optInCta");
+      expect(track).toHaveBeenCalledWith(
+        "button_clicked",
+        expect.objectContaining({
+          button: "upgrade",
+          deviceModel: "lns",
+        }),
+      );
+      expect(track).toHaveBeenCalledWith("deeplink_clicked", expect.any(Object));
     });
 
     it("should render the banner for opted out users", () => {
@@ -163,14 +174,17 @@ describe("LNUpsellBanner", () => {
       fireEvent.press(screen.getByText(t(`lnsUpsell.opted_out.cta`)));
 
       expect(Linking.openURL).toHaveBeenCalledTimes(1);
-      expect(Linking.openURL).toHaveBeenCalledWith("https://example.com/optOutCta");
-      expect(track).toHaveBeenCalledTimes(1);
-      expect(track).toHaveBeenCalledWith("button_clicked", {
-        button: "Level up wallet",
-        deviceModel: "lns",
-        link: "https://example.com/optOutCta",
-        page,
-      });
+      const openedUrl = new URL(String(jest.mocked(Linking.openURL).mock.calls[0][0]));
+      expect(openedUrl.origin + openedUrl.pathname).toBe("https://example.com/optOutCta");
+      expect(track).toHaveBeenCalledTimes(2);
+      expect(track).toHaveBeenCalledWith(
+        "button_clicked",
+        expect.objectContaining({
+          button: "upgrade",
+          deviceModel: "lns",
+        }),
+      );
+      expect(track).toHaveBeenCalledWith("deeplink_clicked", expect.any(Object));
     });
 
     it("should render for opted out users regardless of content cards state", () => {
@@ -178,14 +192,17 @@ describe("LNUpsellBanner", () => {
       fireEvent.press(screen.getByText(t(`lnsUpsell.opted_out.cta`)));
 
       expect(Linking.openURL).toHaveBeenCalledTimes(1);
-      expect(Linking.openURL).toHaveBeenCalledWith("https://example.com/optOutCta");
-      expect(track).toHaveBeenCalledTimes(1);
-      expect(track).toHaveBeenCalledWith("button_clicked", {
-        button: "Level up wallet",
-        deviceModel: "lns",
-        link: "https://example.com/optOutCta",
-        page,
-      });
+      const openedUrl = new URL(String(jest.mocked(Linking.openURL).mock.calls[0][0]));
+      expect(openedUrl.origin + openedUrl.pathname).toBe("https://example.com/optOutCta");
+      expect(track).toHaveBeenCalledTimes(2);
+      expect(track).toHaveBeenCalledWith(
+        "button_clicked",
+        expect.objectContaining({
+          button: "upgrade",
+          deviceModel: "lns",
+        }),
+      );
+      expect(track).toHaveBeenCalledWith("deeplink_clicked", expect.any(Object));
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/LNUpsell/components/LNUpsellBanner/useLNUpsellBannerModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LNUpsell/components/LNUpsellBanner/useLNUpsellBannerModel.ts
@@ -3,6 +3,7 @@ import { Image, Linking } from "react-native";
 import {
   LARGE_SCREEN_UPSELL_UTM,
   buildLargeScreenUpsellCtaLink,
+  type LargeScreenUpsellUtmContent,
 } from "@features/flow-large-screen-upsell/utils/upsellCta";
 import {
   toLargeScreenUpsellDeviceModelAnalyticsValue,
@@ -128,7 +129,7 @@ const BannerPageEventNameMap: Partial<Record<LNBannerLocation, string>> = {
   manager: "banner upsell my ledger",
 } as const;
 
-const UTMContentMap: Record<LNBannerLocation, string> = {
+const UTMContentMap: Record<LNBannerLocation, LargeScreenUpsellUtmContent> = {
   wallet: LARGE_SCREEN_UPSELL_UTM.content.portfolio_banner,
   notification_center: LARGE_SCREEN_UPSELL_UTM.content.notif_banner,
   manager: LARGE_SCREEN_UPSELL_UTM.content.my_ledger_banner,

--- a/apps/ledger-live-mobile/src/mvvm/features/LNUpsell/components/LNUpsellBanner/useLNUpsellBannerModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LNUpsell/components/LNUpsellBanner/useLNUpsellBannerModel.ts
@@ -30,12 +30,14 @@ const lnUpsellImageByLocation: Record<LNBannerLocation, string> = {
 const PROFILE_PAGE = "Profile";
 const PROFILE_UPGRADE_BUTTON = "upgrade";
 
-type ProfileSharedAnalyticsProps = Readonly<{
+type SharedAnalyticsProps = Readonly<{
   deviceModel: LargeScreenUpsellDeviceModelAnalyticsValue;
   personalRecoOptIn: boolean;
   offerType: "discount" | "none";
   platform: "lwm";
 }>;
+
+type ProfileSharedAnalyticsProps = SharedAnalyticsProps;
 
 export function useLNUpsellBannerModel(location: LNBannerLocation): LNBannerModel {
   const { isShown, ctaLink, discount, deviceModelId, tracking } = useLNUpsellBannerState(location);
@@ -44,7 +46,7 @@ export function useLNUpsellBannerModel(location: LNBannerLocation): LNBannerMode
     ? toLargeScreenUpsellDeviceModelAnalyticsValue(deviceModelId)
     : undefined;
   const personalRecoOptIn = tracking === "opted_in";
-  const profileAnalyticsProps = useMemo(
+  const sharedAnalyticsProps = useMemo(
     () =>
       deviceModel
         ? {
@@ -58,27 +60,41 @@ export function useLNUpsellBannerModel(location: LNBannerLocation): LNBannerMode
   );
 
   useEffect(() => {
-    if (location !== "profile" || !isShown || !profileAnalyticsProps) return;
-    trackProfilePageViewed(profileAnalyticsProps);
-  }, [isShown, location, profileAnalyticsProps]);
-
-  const handleCTAPress = useCallback(() => {
-    if (!ctaLink) return;
+    if (!isShown || !sharedAnalyticsProps) return;
 
     if (location === "profile") {
-      if (!profileAnalyticsProps) return;
-      openProfileUpsell(ctaLink, profileAnalyticsProps);
-      return;
+      trackProfilePageViewed(sharedAnalyticsProps);
+    } else {
+      const bannerPageName = BannerPageEventNameMap[location];
+      if (bannerPageName) {
+        trackBannerPageViewed(bannerPageName, sharedAnalyticsProps);
+      }
     }
+  }, [isShown, location, sharedAnalyticsProps]);
+
+  const handleCTAPress = useCallback(() => {
+    if (!ctaLink || !sharedAnalyticsProps) return;
+
+    const utmContent = UTMContentMap[location];
+    const upsellLink = buildLargeScreenUpsellCtaLink(ctaLink, "mobile", utmContent);
+    const pageName = BannerPageEventNameMap[location] || analyticsPage;
 
     track("button_clicked", {
-      button: "Level up wallet",
-      ...(deviceModel ? { deviceModel } : {}),
-      link: ctaLink,
-      page: analyticsPage,
+      button: "upgrade",
+      page: pageName,
+      ...sharedAnalyticsProps,
     });
-    Linking.openURL(ctaLink);
-  }, [analyticsPage, ctaLink, deviceModel, location, profileAnalyticsProps]);
+
+    track("deeplink_clicked", {
+      page: pageName,
+      deeplinkSource: LARGE_SCREEN_UPSELL_UTM.sourceByPlatform.mobile,
+      deeplinkMedium: LARGE_SCREEN_UPSELL_UTM.medium,
+      deeplinkCampaign: LARGE_SCREEN_UPSELL_UTM.campaign,
+      ...sharedAnalyticsProps,
+    });
+
+    Linking.openURL(upsellLink);
+  }, [analyticsPage, ctaLink, location, sharedAnalyticsProps]);
 
   return {
     location,
@@ -94,27 +110,8 @@ function trackProfilePageViewed(sharedProps: ProfileSharedAnalyticsProps) {
   screen(PROFILE_PAGE, undefined, { name: PROFILE_PAGE, ...sharedProps }, false);
 }
 
-function openProfileUpsell(ctaLink: string, sharedProps: ProfileSharedAnalyticsProps) {
-  const upsellLink = buildLargeScreenUpsellCtaLink(
-    ctaLink,
-    "mobile",
-    LARGE_SCREEN_UPSELL_UTM.content.profile_cta,
-  );
-
-  track("button_clicked", {
-    button: PROFILE_UPGRADE_BUTTON,
-    page: PROFILE_PAGE,
-    ...sharedProps,
-  });
-  track("deeplink_clicked", {
-    page: PROFILE_PAGE,
-    deeplinkSource: LARGE_SCREEN_UPSELL_UTM.sourceByPlatform.mobile,
-    deeplinkMedium: LARGE_SCREEN_UPSELL_UTM.medium,
-    deeplinkCampaign: LARGE_SCREEN_UPSELL_UTM.campaign,
-    ...sharedProps,
-  });
-
-  Linking.openURL(upsellLink);
+function trackBannerPageViewed(pageName: string, sharedProps: SharedAnalyticsProps) {
+  screen(pageName, undefined, { name: pageName, ...sharedProps }, false);
 }
 
 const AnalyticsPageMap = {
@@ -124,3 +121,17 @@ const AnalyticsPageMap = {
   wallet: "Wallet",
   profile: PROFILE_PAGE,
 } as const satisfies Record<LNBannerLocation, unknown>;
+
+const BannerPageEventNameMap: Partial<Record<LNBannerLocation, string>> = {
+  wallet: "banner upsell portfolio",
+  notification_center: "banner upsell notification center",
+  manager: "banner upsell my ledger",
+} as const;
+
+const UTMContentMap: Record<LNBannerLocation, string> = {
+  wallet: LARGE_SCREEN_UPSELL_UTM.content.portfolio_banner,
+  notification_center: LARGE_SCREEN_UPSELL_UTM.content.notif_banner,
+  manager: LARGE_SCREEN_UPSELL_UTM.content.my_ledger_banner,
+  accounts: LARGE_SCREEN_UPSELL_UTM.content.portfolio_banner,
+  profile: LARGE_SCREEN_UPSELL_UTM.content.profile_cta,
+} as const;

--- a/apps/ledger-live-mobile/src/mvvm/features/LNUpsell/components/LNUpsellBanner/useLNUpsellBannerModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LNUpsell/components/LNUpsellBanner/useLNUpsellBannerModel.ts
@@ -29,7 +29,6 @@ const lnUpsellImageByLocation: Record<LNBannerLocation, string> = {
 /* eslint-enable @typescript-eslint/no-require-imports */
 
 const PROFILE_PAGE = "Profile";
-const PROFILE_UPGRADE_BUTTON = "upgrade";
 
 type SharedAnalyticsProps = Readonly<{
   deviceModel: LargeScreenUpsellDeviceModelAnalyticsValue;
@@ -127,6 +126,7 @@ const BannerPageEventNameMap: Partial<Record<LNBannerLocation, string>> = {
   wallet: "banner upsell portfolio",
   notification_center: "banner upsell notification center",
   manager: "banner upsell my ledger",
+  accounts: "banner upsell portfolio",
 } as const;
 
 const UTMContentMap: Record<LNBannerLocation, LargeScreenUpsellUtmContent> = {

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/utils/__tests__/upsellCta.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/utils/__tests__/upsellCta.test.ts
@@ -1,14 +1,33 @@
 import { buildLargeScreenUpsellCtaLink } from "../upsellCta";
 
 describe("buildLargeScreenUpsellCtaLink", () => {
-  it("should append expected UTM parameters", () => {
+  it("should append expected UTM parameters with default values", () => {
     const result = buildLargeScreenUpsellCtaLink("https://example.com/offer");
     const url = new URL(result);
 
     expect(url.searchParams.get("utm_source")).toBe("ledger_wallet_mobile");
-    expect(url.searchParams.get("utm_medium")).toBe("ledger_live");
+    expect(url.searchParams.get("utm_medium")).toBe("in_app_placements");
     expect(url.searchParams.get("utm_campaign")).toBe("nano_upgrade_program");
     expect(url.searchParams.get("utm_content")).toBe("app_start_modal");
+  });
+
+  it("should support custom platform parameter", () => {
+    const result = buildLargeScreenUpsellCtaLink("https://example.com/offer", "desktop");
+    const url = new URL(result);
+
+    expect(url.searchParams.get("utm_source")).toBe("ledger_wallet_desktop");
+    expect(url.searchParams.get("utm_medium")).toBe("in_app_placements");
+  });
+
+  it("should support custom utm_content parameter", () => {
+    const result = buildLargeScreenUpsellCtaLink(
+      "https://example.com/offer",
+      "mobile",
+      "portfolio_banner",
+    );
+    const url = new URL(result);
+
+    expect(url.searchParams.get("utm_content")).toBe("portfolio_banner");
   });
 
   it("should preserve existing query params while setting UTM values", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/utils/upsellCta.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/utils/upsellCta.ts
@@ -1,9 +1,26 @@
-const UPSELL_UTM_SOURCE = "ledger_wallet_mobile";
-const UPSELL_UTM_MEDIUM = "ledger_live";
-const UPSELL_UTM_CAMPAIGN = "nano_upgrade_program";
-const UPSELL_UTM_CONTENT = "app_start_modal";
+export const LARGE_SCREEN_UPSELL_UTM = {
+  sourceByPlatform: {
+    mobile: "ledger_wallet_mobile",
+    desktop: "ledger_wallet_desktop",
+  },
+  medium: "in_app_placements",
+  campaign: "nano_upgrade_program",
+  content: {
+    app_start_modal: "app_start_modal",
+    portfolio_banner: "portfolio_banner",
+    notif_banner: "notif_banner",
+    my_ledger_banner: "my_ledger_banner",
+    hardware_carousel: "hardware_carousel",
+    profile_cta: "profile_cta",
+    backups_cta: "backups_cta",
+  },
+} as const;
 
-export function buildLargeScreenUpsellCtaLink(link: string): string {
+export function buildLargeScreenUpsellCtaLink(
+  link: string,
+  platform: "mobile" | "desktop" = "mobile",
+  utmContent: string = LARGE_SCREEN_UPSELL_UTM.content.app_start_modal,
+): string {
   const trimmedLink = link.trim();
   if (!trimmedLink) {
     return "";
@@ -11,10 +28,10 @@ export function buildLargeScreenUpsellCtaLink(link: string): string {
 
   try {
     const url = new URL(trimmedLink);
-    url.searchParams.set("utm_source", UPSELL_UTM_SOURCE);
-    url.searchParams.set("utm_medium", UPSELL_UTM_MEDIUM);
-    url.searchParams.set("utm_campaign", UPSELL_UTM_CAMPAIGN);
-    url.searchParams.set("utm_content", UPSELL_UTM_CONTENT);
+    url.searchParams.set("utm_source", LARGE_SCREEN_UPSELL_UTM.sourceByPlatform[platform]);
+    url.searchParams.set("utm_medium", LARGE_SCREEN_UPSELL_UTM.medium);
+    url.searchParams.set("utm_campaign", LARGE_SCREEN_UPSELL_UTM.campaign);
+    url.searchParams.set("utm_content", utmContent);
     return url.toString();
   } catch {
     return trimmedLink;

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/utils/upsellCta.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/utils/upsellCta.ts
@@ -13,13 +13,21 @@ export const LARGE_SCREEN_UPSELL_UTM = {
     hardware_carousel: "hardware_carousel",
     profile_cta: "profile_cta",
     backups_cta: "backups_cta",
+    earn_trigger: "earn_trigger",
+    recover_trigger: "recover_trigger",
+    l_sync_trigger: "l_sync_trigger",
+    swap_trigger: "swap_trigger",
+    lazy_onboarding_banner: "lazy_onboarding_banner",
   },
 } as const;
+
+export type LargeScreenUpsellUtmContent =
+  (typeof LARGE_SCREEN_UPSELL_UTM.content)[keyof typeof LARGE_SCREEN_UPSELL_UTM.content];
 
 export function buildLargeScreenUpsellCtaLink(
   link: string,
   platform: "mobile" | "desktop" = "mobile",
-  utmContent: string = LARGE_SCREEN_UPSELL_UTM.content.app_start_modal,
+  utmContent: LargeScreenUpsellUtmContent = LARGE_SCREEN_UPSELL_UTM.content.app_start_modal,
 ): string {
   const trimmedLink = link.trim();
   if (!trimmedLink) {

--- a/features/flow/large-screen-upsell/src/utils/upsellCta.ts
+++ b/features/flow/large-screen-upsell/src/utils/upsellCta.ts
@@ -1,5 +1,5 @@
 export const LARGE_SCREEN_UPSELL_UTM = {
-  medium: "ledger_live",
+  medium: "in_app_placements",
   campaign: "nano_upgrade_program",
   sourceByPlatform: {
     mobile: "ledger_wallet_mobile",
@@ -7,10 +7,17 @@ export const LARGE_SCREEN_UPSELL_UTM = {
   },
   content: {
     app_start_modal: "app_start_modal",
-    backups_cta: "backups_cta",
-    profile_cta: "profile_cta",
-    recover_trigger: "recover_trigger",
+    portfolio_banner: "portfolio_banner",
+    notif_banner: "notif_banner",
+    my_ledger_banner: "my_ledger_banner",
     hardware_carousel: "hardware_carousel",
+    profile_cta: "profile_cta",
+    backups_cta: "backups_cta",
+    earn_trigger: "earn_trigger",
+    recover_trigger: "recover_trigger",
+    l_sync_trigger: "l_sync_trigger",
+    swap_trigger: "swap_trigger",
+    lazy_onboarding_banner: "lazy_onboarding_banner",
   },
 } as const;
 


### PR DESCRIPTION
### 📝 Description

This PR fixes missing tracking events for touchscreen upsell placements in mobile app, as reported in LIVE-36378. The implementation follows the validated [Touchscreen Upgrade Program - Tracking Plan](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7317815469/Touchscreen+Upgrade+Program+-+Tracking+Plan).

**Problem**: Analytics overlay was missing several critical tracking events:
- Banner impressions (portfolio, notification center, my ledger) were not being tracked
- Button click events had incorrect shape (`"Level up wallet"` instead of `"upgrade"`)
- No `deeplink_clicked` events when opening shop links
- Hardware carousel impression was not tracked
- Device-specific clicks (Gen5/Flex/Stax) and individual card dismissals were not tracked

**Solution**: 
- Added page impression events for all banner placements with proper naming convention
- Updated button tracking to use `button: "upgrade"` and included all shared analytics props
- Added `deeplink_clicked` events with proper UTM parameters
- Fixed UTM medium from `"ledger_live"` to `"in_app_placements"` to match tracking plan
- Added hardware carousel page impression tracking
- Added device-specific click tracking for Gen5/Flex/Stax
- Added individual card dismiss tracking
- Updated all tests to match new tracking behavior

All events now include proper shared analytics properties:
- `deviceModel` (lnx | lnsp | none)
- `personalRecoOptIn` (boolean)
- `offerType` (discount | none)
- `platform` (lwm)

### ❓ Context

- **JIRA issue**: [LIVE-36378](https://ledgerhq.atlassian.net/browse/LIVE-36378)
- **Tracking plan**: [Touchscreen Upgrade Program - Tracking Plan](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7317815469)

### ✅ Checklist

- [x] Test coverage updated (banner tests + upsellCta tests)
- [x] Changeset added
- [ ] QA: Verify events appear correctly in Analytics overlay
- [ ] QA: Test all banner placements (portfolio, notification center, my ledger)
- [ ] QA: Test hardware carousel impression + device clicks + dismiss
- [ ] QA: Verify UTM parameters in opened shop links

Made with [Cursor](https://cursor.com)

[LIVE-36378]: https://ledgerhq.atlassian.net/browse/LIVE-36378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ