### PR TITLE
[LWDM] feat(test-quarantine): roll flake reporting out to jest packages

### DIFF
--- a/apps/ledger-live-desktop/jest.config.js
+++ b/apps/ledger-live-desktop/jest.config.js
@@ -136,6 +136,7 @@ module.exports = {
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
   silent: false,
   verbose: true,
@@ -148,11 +149,19 @@ module.exports = {
         "(/__tests__/.*|(\\.|/)react\\.test|spec)\\.tsx",
       ],
       testMatch: ["**/src/**/*.test.(ts|tsx)"],
+      setupFilesAfterEnv: [
+        ...commonConfig.setupFilesAfterEnv,
+        "@ledgerhq/test-quarantine/jest-retries",
+      ],
     },
     {
       ...commonConfig,
       displayName: "dom",
       testRegex: "(/__tests__/.*|(\\.|/)react\\.test|spec)\\.tsx",
+      setupFilesAfterEnv: [
+        ...commonConfig.setupFilesAfterEnv,
+        "@ledgerhq/test-quarantine/jest-retries",
+      ],
     },
   ],
 };

--- a/apps/ledger-live-mobile/jest.config.js
+++ b/apps/ledger-live-mobile/jest.config.js
@@ -70,6 +70,7 @@ module.exports = {
   setupFilesAfterEnv: [
     "./node_modules/react-native-gesture-handler/jestSetup.js",
     "./__tests__/jest-setup.js",
+    "@ledgerhq/test-quarantine/jest-retries",
   ],
   testMatch: ["**/src/**/*.test.(ts|tsx)"],
   transform: {
@@ -132,6 +133,7 @@ module.exports = {
     // string reporter's annotations would otherwise be dropped on the floor.
     ...(process.env.CI ? [["<rootDir>/scripts/jestGithubActionsReporter.js", {}]] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
   resolver: "<rootDir>/scripts/resolver.js",
   moduleNameMapper: {

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -326,6 +326,7 @@
     "@ledgerhq/live-e2e-shared": "workspace:^",
     "@ledgerhq/speculos-transport": "workspace:^",
     "@ledgerhq/coin-cardano": "workspace:^",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@ledgerhq/test-utils": "workspace:^",
     "@react-native-community/cli": "catalog:",
     "@react-native-community/cli-platform-android": "catalog:",

--- a/apps/web-tools/jest.config.js
+++ b/apps/web-tools/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
     ...(process.env.CI ? ["github-actions"] : []),
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/apps/web-tools/package.json
+++ b/apps/web-tools/package.json
@@ -106,6 +106,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@rsbuild/core": "catalog:",
     "@rsbuild/plugin-node-polyfill": "catalog:",
     "@rsbuild/plugin-react": "catalog:",

--- a/devtools/bindings/jest.config.js
+++ b/devtools/bindings/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   testEnvironment: "jsdom",
   roots: ["<rootDir>/src"],
-  setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.js", "@ledgerhq/test-quarantine/jest-retries"],
   testMatch: ["**/*.test.ts?(x)"],
   transform: {
     "^.+\\.(t|j)sx?$": [
@@ -19,5 +19,6 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
 };

--- a/devtools/bindings/package.json
+++ b/devtools/bindings/package.json
@@ -29,6 +29,7 @@
     "react-redux": ">=9.0.0"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@reduxjs/toolkit": "catalog:",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",

--- a/devtools/protocols/jest.config.js
+++ b/devtools/protocols/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/devtools/protocols/package.json
+++ b/devtools/protocols/package.json
@@ -20,6 +20,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "typescript": "catalog:",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",

--- a/devtools/relay/jest.config.js
+++ b/devtools/relay/jest.config.js
@@ -21,5 +21,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/devtools/relay/package.json
+++ b/devtools/relay/package.json
@@ -18,6 +18,7 @@
     "ws": "catalog:"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@devtools/protocols": "workspace:*",
     "@swc/jest": "catalog:",

--- a/devtools/transport/jest.config.js
+++ b/devtools/transport/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/devtools/transport/package.json
+++ b/devtools/transport/package.json
@@ -14,6 +14,7 @@
     "coverage": "jest --config jest.config.js --coverage"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/devtools/wire/jest.config.js
+++ b/devtools/wire/jest.config.js
@@ -17,5 +17,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/devtools/wire/package.json
+++ b/devtools/wire/package.json
@@ -18,6 +18,7 @@
     "@devtools/transport": "workspace:*"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/domain/api/aggregated-assets/jest.config.js
+++ b/domain/api/aggregated-assets/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/domain/api/aggregated-assets/package.json
+++ b/domain/api/aggregated-assets/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@jest/globals": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/domain/api/altcoins-sentiment/jest.config.js
+++ b/domain/api/altcoins-sentiment/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/domain/api/altcoins-sentiment/package.json
+++ b/domain/api/altcoins-sentiment/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@jest/globals": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/domain/api/currency-fiat/jest.config.js
+++ b/domain/api/currency-fiat/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/domain/api/currency-fiat/package.json
+++ b/domain/api/currency-fiat/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@jest/globals": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/domain/api/market-sentiment/jest.config.js
+++ b/domain/api/market-sentiment/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/domain/api/market-sentiment/package.json
+++ b/domain/api/market-sentiment/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@jest/globals": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/domain/api/push-devices/jest.config.js
+++ b/domain/api/push-devices/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/domain/api/push-devices/package.json
+++ b/domain/api/push-devices/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@jest/globals": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/domain/api/swap-quotes/jest.config.js
+++ b/domain/api/swap-quotes/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/domain/api/swap-quotes/package.json
+++ b/domain/api/swap-quotes/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@jest/globals": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/domain/entity/account-name/jest.config.js
+++ b/domain/entity/account-name/jest.config.js
@@ -10,5 +10,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/domain/entity/account-name/package.json
+++ b/domain/entity/account-name/package.json
@@ -26,6 +26,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/domain/entity/aggregated-asset/jest.config.js
+++ b/domain/entity/aggregated-asset/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/domain/entity/aggregated-asset/package.json
+++ b/domain/entity/aggregated-asset/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@jest/globals": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/domain/entity/altcoins-sentiment/jest.config.js
+++ b/domain/entity/altcoins-sentiment/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/domain/entity/altcoins-sentiment/package.json
+++ b/domain/entity/altcoins-sentiment/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@jest/globals": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/domain/entity/analytics-consent/jest.config.js
+++ b/domain/entity/analytics-consent/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/domain/entity/analytics-consent/package.json
+++ b/domain/entity/analytics-consent/package.json
@@ -23,6 +23,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/domain/entity/client-identity/jest.config.js
+++ b/domain/entity/client-identity/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/domain/entity/client-identity/package.json
+++ b/domain/entity/client-identity/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@jest/globals": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@types/node": "catalog:",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",

--- a/domain/entity/contact/jest.config.js
+++ b/domain/entity/contact/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/domain/entity/contact/package.json
+++ b/domain/entity/contact/package.json
@@ -29,6 +29,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/domain/entity/currency-crypto/jest.config.js
+++ b/domain/entity/currency-crypto/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/domain/entity/currency-crypto/package.json
+++ b/domain/entity/currency-crypto/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@jest/globals": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/domain/entity/currency-fiat/jest.config.js
+++ b/domain/entity/currency-fiat/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/domain/entity/currency-fiat/package.json
+++ b/domain/entity/currency-fiat/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@jest/globals": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/domain/entity/currency-unit/jest.config.js
+++ b/domain/entity/currency-unit/jest.config.js
@@ -18,5 +18,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/domain/entity/currency-unit/package.json
+++ b/domain/entity/currency-unit/package.json
@@ -22,6 +22,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/domain/entity/currency/jest.config.js
+++ b/domain/entity/currency/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/domain/entity/currency/package.json
+++ b/domain/entity/currency/package.json
@@ -24,6 +24,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/domain/entity/interest-rate/jest.config.js
+++ b/domain/entity/interest-rate/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/domain/entity/interest-rate/package.json
+++ b/domain/entity/interest-rate/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@jest/globals": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/domain/entity/market-sentiment/jest.config.js
+++ b/domain/entity/market-sentiment/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/domain/entity/market-sentiment/package.json
+++ b/domain/entity/market-sentiment/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@jest/globals": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/domain/entity/recent-addresses/jest.config.js
+++ b/domain/entity/recent-addresses/jest.config.js
@@ -10,5 +10,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/domain/entity/recent-addresses/package.json
+++ b/domain/entity/recent-addresses/package.json
@@ -23,6 +23,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/domain/entity/starred-account/jest.config.js
+++ b/domain/entity/starred-account/jest.config.js
@@ -10,5 +10,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/domain/entity/starred-account/package.json
+++ b/domain/entity/starred-account/package.json
@@ -22,6 +22,7 @@
     "immer": "^11.0.0"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/domain/entity/wallet-sync/jest.config.js
+++ b/domain/entity/wallet-sync/jest.config.js
@@ -10,5 +10,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/domain/entity/wallet-sync/package.json
+++ b/domain/entity/wallet-sync/package.json
@@ -22,6 +22,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/features/flow/analytics-consent/jest.config.js
+++ b/features/flow/analytics-consent/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/features/flow/analytics-consent/package.json
+++ b/features/flow/analytics-consent/package.json
@@ -26,6 +26,7 @@
     "react": ">=19.0.0"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/features/flow/fear-and-greed/jest.config.js
+++ b/features/flow/fear-and-greed/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/features/flow/fear-and-greed/package.json
+++ b/features/flow/fear-and-greed/package.json
@@ -20,6 +20,7 @@
   "dependencies": {},
   "devDependencies": {
     "@jest/globals": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/features/flow/large-screen-upsell/jest.config.js
+++ b/features/flow/large-screen-upsell/jest.config.js
@@ -18,5 +18,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/features/flow/large-screen-upsell/package.json
+++ b/features/flow/large-screen-upsell/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "@ledgerhq/lumen-design-core": "catalog:",
     "@ledgerhq/lumen-ui-react": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@testing-library/dom": "catalog:",

--- a/features/flow/lazy-onboarding-banner/jest.config.js
+++ b/features/flow/lazy-onboarding-banner/jest.config.js
@@ -17,5 +17,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/features/flow/lazy-onboarding-banner/package.json
+++ b/features/flow/lazy-onboarding-banner/package.json
@@ -50,6 +50,7 @@
   "devDependencies": {
     "@ledgerhq/lumen-design-core": "catalog:",
     "@ledgerhq/lumen-ui-rnative": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/features/platform/aggregated-assets/jest.config.js
+++ b/features/platform/aggregated-assets/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   testEnvironment: "jsdom",
   roots: ["<rootDir>/src"],
   testMatch: ["**/*.test.ts?(x)"],
-  setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.js", "@ledgerhq/test-quarantine/jest-retries"],
   transform: {
     "^.+\\.(t|j)sx?$": [
       "@swc/jest",
@@ -19,5 +19,6 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
 };

--- a/features/platform/aggregated-assets/package.json
+++ b/features/platform/aggregated-assets/package.json
@@ -31,6 +31,7 @@
     "react-redux": ">=9.0.0"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@shared/env": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",

--- a/features/platform/app-lock/jest.config.js
+++ b/features/platform/app-lock/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/features/platform/app-lock/package.json
+++ b/features/platform/app-lock/package.json
@@ -23,6 +23,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/features/platform/currencies/jest.config.js
+++ b/features/platform/currencies/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   testEnvironment: "jsdom",
   roots: ["<rootDir>/src"],
   testMatch: ["**/*.test.ts?(x)"],
-  setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.js", "@ledgerhq/test-quarantine/jest-retries"],
   transform: {
     "^.+\\.(t|j)sx?$": [
       "@swc/jest",
@@ -19,5 +19,6 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
 };

--- a/features/platform/currencies/package.json
+++ b/features/platform/currencies/package.json
@@ -33,6 +33,7 @@
     "react-redux": ">=9.0.0"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@shared/feature-flags": "workspace:^",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",

--- a/features/platform/feature-flags/jest.config.js
+++ b/features/platform/feature-flags/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   testEnvironment: "jsdom",
   roots: ["<rootDir>/src"],
   testMatch: ["**/*.test.ts?(x)"],
-  setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.js", "@ledgerhq/test-quarantine/jest-retries"],
   transform: {
     "^.+\\.(t|j)sx?$": [
       "@swc/jest",
@@ -19,5 +19,6 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
 };

--- a/features/platform/feature-flags/package.json
+++ b/features/platform/feature-flags/package.json
@@ -26,6 +26,7 @@
     "react-redux": ">=9.0.0"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@reduxjs/toolkit": "catalog:",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",

--- a/features/platform/style/jest.config.js
+++ b/features/platform/style/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   testEnvironment: "jsdom",
   roots: ["<rootDir>/src"],
   testMatch: ["**/*.test.ts?(x)"],
-  setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.js", "@ledgerhq/test-quarantine/jest-retries"],
   transform: {
     "^.+\\.(t|j)sx?$": [
       "@swc/jest",
@@ -22,5 +22,6 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
 };

--- a/features/platform/style/package.json
+++ b/features/platform/style/package.json
@@ -31,6 +31,7 @@
     "styled-components": ">=6"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@testing-library/dom": "catalog:",

--- a/features/platform/wallet-sync/jest.config.js
+++ b/features/platform/wallet-sync/jest.config.js
@@ -10,5 +10,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/features/platform/wallet-sync/package.json
+++ b/features/platform/wallet-sync/package.json
@@ -23,6 +23,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/libs/asset-aggregation/jest.config.js
+++ b/libs/asset-aggregation/jest.config.js
@@ -15,5 +15,7 @@ module.exports = {
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/libs/asset-aggregation/package.json
+++ b/libs/asset-aggregation/package.json
@@ -37,6 +37,7 @@
     }
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/libs/asset-detail/jest.config.js
+++ b/libs/asset-detail/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.js", "@ledgerhq/test-quarantine/jest-retries"],
   transform: {
     "^.+\\.(t|j)sx?$": [
       "@swc/jest",
@@ -16,5 +16,6 @@ module.exports = {
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
 };

--- a/libs/asset-detail/package.json
+++ b/libs/asset-detail/package.json
@@ -30,6 +30,7 @@
     "react": ">=19"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@shared/env": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",

--- a/libs/disable-network-setup/jest.config.js
+++ b/libs/disable-network-setup/jest.config.js
@@ -1,7 +1,7 @@
 export default {
   testEnvironment: "node",
   testRegex: ".test.ts$",
-  setupFilesAfterEnv: ["./src/index.ts"],
+  setupFilesAfterEnv: ["./src/index.ts", "@ledgerhq/test-quarantine/jest-retries"],
   transform: {
     "^.+\\.(t|j)sx?$": [
       "@swc/jest",
@@ -17,5 +17,6 @@ export default {
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
 };

--- a/libs/disable-network-setup/package.json
+++ b/libs/disable-network-setup/package.json
@@ -17,6 +17,7 @@
     "coverage": "jest --coverage"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@types/node": "catalog:",
     "@types/jest": "catalog:",
     "axios": "catalog:",

--- a/libs/env/jest.config.js
+++ b/libs/env/jest.config.js
@@ -7,5 +7,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/libs/env/package.json
+++ b/libs/env/package.json
@@ -22,6 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {},
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@types/jest": "catalog:",
     "jest": "catalog:",
     "oxfmt": "catalog:",

--- a/libs/hw-ledger-key-ring-protocol/jest.config.js
+++ b/libs/hw-ledger-key-ring-protocol/jest.config.js
@@ -15,5 +15,7 @@ module.exports = {
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/libs/hw-ledger-key-ring-protocol/package.json
+++ b/libs/hw-ledger-key-ring-protocol/package.json
@@ -25,6 +25,7 @@
     "create-hmac": "^1.1.7"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@types/lodash": "catalog:",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",

--- a/libs/ledger-auth/jest.config.js
+++ b/libs/ledger-auth/jest.config.js
@@ -19,5 +19,7 @@ module.exports = {
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/libs/ledger-auth/package.json
+++ b/libs/ledger-auth/package.json
@@ -35,6 +35,7 @@
     "coverage": "jest --coverage"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/libs/ledger-key-ring-protocol/jest.config.js
+++ b/libs/ledger-key-ring-protocol/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  setupFilesAfterEnv: ["./jest.setup.js"],
+  setupFilesAfterEnv: ["./jest.setup.js", "@ledgerhq/test-quarantine/jest-retries"],
   transform: {
     "^.+\\.(t|j)sx?$": [
       "@swc/jest",
@@ -16,5 +16,6 @@ module.exports = {
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
 };

--- a/libs/ledger-key-ring-protocol/package.json
+++ b/libs/ledger-key-ring-protocol/package.json
@@ -72,6 +72,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@reduxjs/toolkit": "catalog:",
     "@shared/env": "workspace:*",
     "@types/jest": "catalog:",

--- a/libs/ledger-live-common/jest.config.ts
+++ b/libs/ledger-live-common/jest.config.ts
@@ -68,6 +68,7 @@ const reporters = [
       reportedFilePath: "absolute",
     },
   ],
+  "@ledgerhq/test-quarantine/jest",
 ];
 if (process.env.CI) {
   reporters.push("github-actions");
@@ -83,6 +84,7 @@ const defaultConfig = {
   setupFilesAfterEnv: [
     "@ledgerhq/wallet-framework-test-setup",
     "<rootDir>/src/__tests__/test-helpers/setup-registry.ts",
+    "@ledgerhq/test-quarantine/jest-retries",
   ],
   coveragePathIgnorePatterns: ["src/__tests__/test-helpers", "src/wallet-api/SmartWebsocket.ts"], // Type issue with event in SmartWebsocket.ts breaking coverage report
   modulePathIgnorePatterns: [

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -427,6 +427,7 @@
   "devDependencies": {
     "@features/platform-currencies": "workspace:^",
     "@ledgerhq/device-react": "workspace:^",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@ledgerhq/types-devices": "workspace:^",
     "@ledgerhq/types-live": "workspace:^",
     "@ledgerhq/wallet-framework-test-setup": "workspace:^",

--- a/libs/live-countervalues-react/jest.config.js
+++ b/libs/live-countervalues-react/jest.config.js
@@ -16,6 +16,10 @@ module.exports = {
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
-  setupFilesAfterEnv: ["@ledgerhq/wallet-framework-test-setup"],
+  setupFilesAfterEnv: [
+    "@ledgerhq/wallet-framework-test-setup",
+    "@ledgerhq/test-quarantine/jest-retries",
+  ],
 };

--- a/libs/live-countervalues-react/package.json
+++ b/libs/live-countervalues-react/package.json
@@ -31,6 +31,7 @@
     "bignumber.js": "9"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@ledgerhq/wallet-framework-test-setup": "workspace:^",
     "@types/node": "catalog:",
     "@types/jest": "catalog:",

--- a/libs/live-countervalues/jest.config.js
+++ b/libs/live-countervalues/jest.config.js
@@ -1,6 +1,10 @@
 module.exports = {
   globalSetup: "<rootDir>/jest-global-setup.js",
-  setupFilesAfterEnv: ["@ledgerhq/wallet-framework-test-setup", "<rootDir>/jest-setup.ts"],
+  setupFilesAfterEnv: [
+    "@ledgerhq/wallet-framework-test-setup",
+    "<rootDir>/jest-setup.ts",
+    "@ledgerhq/test-quarantine/jest-retries",
+  ],
   transform: {
     "^.+\\.(ts|tsx)?$": [
       "@swc/jest",
@@ -17,5 +21,6 @@ module.exports = {
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
 };

--- a/libs/live-countervalues/package.json
+++ b/libs/live-countervalues/package.json
@@ -29,6 +29,7 @@
     "@ledgerhq/live-env": "workspace:*"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@ledgerhq/wallet-framework-test-setup": "workspace:^",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",

--- a/libs/live-currency-format/jest.config.js
+++ b/libs/live-currency-format/jest.config.js
@@ -12,11 +12,12 @@ module.exports = {
   },
   testPathIgnorePatterns: ["lib/", "lib-es/"],
   setupFiles: ["<rootDir>/jest-env-setup.js"],
-  setupFilesAfterEnv: ["<rootDir>/src/setup.ts"],
+  setupFilesAfterEnv: ["<rootDir>/src/setup.ts", "@ledgerhq/test-quarantine/jest-retries"],
   coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../" }], "text"],
   reporters: [
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
 };

--- a/libs/live-currency-format/package.json
+++ b/libs/live-currency-format/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@domain/entity-currency-crypto": "workspace:*",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@types/node": "catalog:",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",

--- a/libs/live-engagement/jest.config.js
+++ b/libs/live-engagement/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/libs/live-engagement/package.json
+++ b/libs/live-engagement/package.json
@@ -11,6 +11,7 @@
     "@reduxjs/toolkit": "catalog:"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/libs/live-hooks/jest.config.js
+++ b/libs/live-hooks/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/libs/live-hooks/package.json
+++ b/libs/live-hooks/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@types/node": "catalog:",
     "@types/jest": "catalog:",
     "@testing-library/dom": "catalog:",

--- a/libs/live-signer-icp/jest.config.js
+++ b/libs/live-signer-icp/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   testEnvironment: "node",
   testPathIgnorePatterns: ["lib/", "lib-es/"],
-  setupFilesAfterEnv: ["@ledgerhq/disable-network-setup"],
+  setupFilesAfterEnv: ["@ledgerhq/disable-network-setup", "@ledgerhq/test-quarantine/jest-retries"],
   transform: {
     "^.+\\.(ts|tsx)?$": [
       "@swc/jest",
@@ -18,5 +18,6 @@ module.exports = {
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
 };

--- a/libs/live-signer-icp/package.json
+++ b/libs/live-signer-icp/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@ledgerhq/types-live": "workspace:^",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",

--- a/libs/live-wallet/jest.config.js
+++ b/libs/live-wallet/jest.config.js
@@ -16,6 +16,10 @@ module.exports = {
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
-  setupFilesAfterEnv: ["@ledgerhq/wallet-framework-test-setup"],
+  setupFilesAfterEnv: [
+    "@ledgerhq/wallet-framework-test-setup",
+    "@ledgerhq/test-quarantine/jest-retries",
+  ],
 };

--- a/libs/live-wallet/package.json
+++ b/libs/live-wallet/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@ledgerhq/hw-transport-mocker": "workspace:^",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@ledgerhq/wallet-framework-test-setup": "workspace:^",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",

--- a/libs/promise/jest.config.js
+++ b/libs/promise/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/libs/promise/package.json
+++ b/libs/promise/package.json
@@ -24,6 +24,7 @@
     "@ledgerhq/logs": "catalog:"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@types/jest": "catalog:",
     "jest": "catalog:",
     "@swc/jest": "catalog:",

--- a/libs/types-live/jest.config.ts
+++ b/libs/types-live/jest.config.ts
@@ -25,5 +25,7 @@ export default {
         reportedFilePath: "absolute",
       },
     ],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/libs/types-live/package.json
+++ b/libs/types-live/package.json
@@ -25,6 +25,7 @@
     "rxjs": "catalog:"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@ledgerhq/types-devices": "workspace:^",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",

--- a/libs/wallet-analytics/jest.config.js
+++ b/libs/wallet-analytics/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.js", "@ledgerhq/test-quarantine/jest-retries"],
   transform: {
     "^.+\\.(ts|tsx)?$": [
       "@swc/jest",
@@ -17,5 +17,6 @@ module.exports = {
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
 };

--- a/libs/wallet-analytics/package.json
+++ b/libs/wallet-analytics/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@domain/entity-currency-crypto": "workspace:*",
     "@domain/entity-currency-fiat": "workspace:*",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@shared/env": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",

--- a/libs/wallet-pnl/jest.config.js
+++ b/libs/wallet-pnl/jest.config.js
@@ -22,5 +22,7 @@ module.exports = {
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/libs/wallet-pnl/package.json
+++ b/libs/wallet-pnl/package.json
@@ -37,6 +37,7 @@
     }
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@shared/env": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2389,6 +2389,9 @@ importers:
       '@ledgerhq/speculos-transport':
         specifier: workspace:^
         version: link:../../libs/speculos-transport
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@ledgerhq/test-utils':
         specifier: workspace:^
         version: link:../../libs/test-utils
@@ -3020,6 +3023,9 @@ importers:
         specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@rsbuild/core':
         specifier: 'catalog:'
         version: 2.0.9
@@ -3120,6 +3126,9 @@ importers:
         specifier: workspace:*
         version: link:../../shared/feature-flags
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@reduxjs/toolkit':
         specifier: 'catalog:'
         version: 2.11.2(react-redux@9.2.0(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
@@ -3440,6 +3449,9 @@ importers:
         specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -3496,6 +3508,9 @@ importers:
       '@devtools/protocols':
         specifier: workspace:*
         version: link:../protocols
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -3674,6 +3689,9 @@ importers:
 
   devtools/transport:
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -3832,6 +3850,9 @@ importers:
         specifier: workspace:*
         version: link:../transport
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -3881,6 +3902,9 @@ importers:
       '@jest/globals':
         specifier: 'catalog:'
         version: 30.2.0
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -3924,6 +3948,9 @@ importers:
       '@jest/globals':
         specifier: 'catalog:'
         version: 30.2.0
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -4010,6 +4037,9 @@ importers:
       '@jest/globals':
         specifier: 'catalog:'
         version: 30.2.0
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -4108,6 +4138,9 @@ importers:
       '@jest/globals':
         specifier: 'catalog:'
         version: 30.2.0
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -4148,6 +4181,9 @@ importers:
       '@jest/globals':
         specifier: 'catalog:'
         version: 30.2.0
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -4191,6 +4227,9 @@ importers:
       '@jest/globals':
         specifier: 'catalog:'
         version: 30.2.0
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -4228,6 +4267,9 @@ importers:
         specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -4256,6 +4298,9 @@ importers:
       '@jest/globals':
         specifier: 'catalog:'
         version: 30.2.0
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -4281,6 +4326,9 @@ importers:
       '@jest/globals':
         specifier: 'catalog:'
         version: 30.2.0
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -4306,6 +4354,9 @@ importers:
         specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -4334,6 +4385,9 @@ importers:
       '@jest/globals':
         specifier: 'catalog:'
         version: 30.2.0
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -4377,6 +4431,9 @@ importers:
         specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -4411,6 +4468,9 @@ importers:
         specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -4439,6 +4499,9 @@ importers:
       '@jest/globals':
         specifier: 'catalog:'
         version: 30.2.0
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -4470,6 +4533,9 @@ importers:
       '@jest/globals':
         specifier: 'catalog:'
         version: 30.2.0
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -4523,6 +4589,9 @@ importers:
         specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -4551,6 +4620,9 @@ importers:
       '@jest/globals':
         specifier: 'catalog:'
         version: 30.2.0
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -4576,6 +4648,9 @@ importers:
       '@jest/globals':
         specifier: 'catalog:'
         version: 30.2.0
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -4604,6 +4679,9 @@ importers:
         specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -4632,6 +4710,9 @@ importers:
         specifier: ^11.0.0
         version: 11.1.3
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -4657,6 +4738,9 @@ importers:
         specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -4947,6 +5031,9 @@ importers:
         specifier: workspace:^
         version: link:../../platform/feature-flags
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -5162,6 +5249,9 @@ importers:
       '@jest/globals':
         specifier: 'catalog:'
         version: 30.2.0
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -5527,6 +5617,9 @@ importers:
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
         version: 0.1.53(@ledgerhq/lumen-design-core@0.1.25)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -5578,6 +5671,9 @@ importers:
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
         version: 0.1.57(@ledgerhq/lumen-design-core@0.1.25)(@types/react@19.0.14)(react-native-svg@15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -6316,6 +6412,9 @@ importers:
         specifier: 'catalog:'
         version: 4.17.21
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@shared/env':
         specifier: workspace:*
         version: link:../../../shared/env
@@ -6368,6 +6467,9 @@ importers:
         specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -6533,6 +6635,9 @@ importers:
         specifier: workspace:^
         version: link:../../../shared/api-services
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@shared/feature-flags':
         specifier: workspace:^
         version: link:../../../shared/feature-flags
@@ -6659,6 +6764,9 @@ importers:
         specifier: 'catalog:'
         version: 4.17.21
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@reduxjs/toolkit':
         specifier: 'catalog:'
         version: 2.11.2(react-redux@9.2.0(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
@@ -6723,6 +6831,9 @@ importers:
         specifier: 'catalog:'
         version: 3.4.0
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -6806,6 +6917,9 @@ importers:
         specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -6852,6 +6966,9 @@ importers:
         specifier: 9.1.2
         version: 9.1.2
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -6898,6 +7015,9 @@ importers:
         specifier: workspace:*
         version: link:../ledger-live-common
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@shared/env':
         specifier: workspace:*
         version: link:../../shared/env
@@ -10797,6 +10917,9 @@ importers:
 
   libs/disable-network-setup:
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -10888,6 +11011,9 @@ importers:
 
   libs/env:
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -11049,6 +11175,9 @@ importers:
         specifier: ^1.1.7
         version: 1.1.7
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -11129,6 +11258,9 @@ importers:
         specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -11199,6 +11331,9 @@ importers:
         specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@reduxjs/toolkit':
         specifier: 'catalog:'
         version: 2.11.2
@@ -11737,6 +11872,9 @@ importers:
       '@ledgerhq/device-react':
         specifier: workspace:^
         version: link:../device-react
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@ledgerhq/types-devices':
         specifier: workspace:^
         version: link:../types-devices
@@ -13498,6 +13636,9 @@ importers:
         specifier: workspace:*
         version: link:../types-live
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@ledgerhq/wallet-framework-test-setup':
         specifier: workspace:^
         version: link:../wallet-framework-test-setup
@@ -13538,6 +13679,9 @@ importers:
         specifier: 9.1.2
         version: 9.1.2
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@ledgerhq/wallet-framework-test-setup':
         specifier: workspace:^
         version: link:../wallet-framework-test-setup
@@ -13584,6 +13728,9 @@ importers:
       '@domain/entity-currency-crypto':
         specifier: workspace:*
         version: link:../../domain/entity/currency-crypto
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -13999,6 +14146,9 @@ importers:
         specifier: 'catalog:'
         version: 2.11.2
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -14014,6 +14164,9 @@ importers:
 
   libs/live-hooks:
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -14440,6 +14593,9 @@ importers:
       '@ledgerhq/disable-network-setup':
         specifier: workspace:^
         version: link:../disable-network-setup
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@ledgerhq/types-live':
         specifier: workspace:^
         version: link:../types-live
@@ -14626,6 +14782,9 @@ importers:
       '@ledgerhq/hw-transport-mocker':
         specifier: workspace:^
         version: link:../ledgerjs/packages/hw-transport-mocker
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@ledgerhq/wallet-framework-test-setup':
         specifier: workspace:^
         version: link:../wallet-framework-test-setup
@@ -14666,6 +14825,9 @@ importers:
         specifier: 'catalog:'
         version: 6.17.0
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -14808,6 +14970,9 @@ importers:
         specifier: 'catalog:'
         version: 7.8.2
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@ledgerhq/types-devices':
         specifier: workspace:^
         version: link:../types-devices
@@ -15501,6 +15666,9 @@ importers:
       '@domain/entity-currency-fiat':
         specifier: workspace:*
         version: link:../../domain/entity/currency-fiat
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@shared/env':
         specifier: workspace:*
         version: link:../../shared/env
@@ -15708,6 +15876,9 @@ importers:
         specifier: 9.1.2
         version: 9.1.2
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@shared/env':
         specifier: workspace:*
         version: link:../../shared/env
@@ -15766,6 +15937,9 @@ importers:
       '@jest/globals':
         specifier: 'catalog:'
         version: 30.2.0
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -15800,6 +15974,9 @@ importers:
         specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -15852,6 +16029,9 @@ importers:
       '@jest/globals':
         specifier: 'catalog:'
         version: 30.2.0
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -15886,6 +16066,9 @@ importers:
         specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -15914,6 +16097,9 @@ importers:
       '@jest/globals':
         specifier: 'catalog:'
         version: 30.2.0
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -15945,6 +16131,9 @@ importers:
       '@jest/globals':
         specifier: 'catalog:'
         version: 30.2.0
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -15966,6 +16155,9 @@ importers:
 
   shared/password-verifier:
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -15994,6 +16186,9 @@ importers:
       '@jest/globals':
         specifier: 'catalog:'
         version: 30.2.0
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -16019,6 +16214,9 @@ importers:
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
         version: 0.1.57(@ledgerhq/lumen-design-core@0.1.25)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native-svg@15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -31711,7 +31909,7 @@ packages:
   git-raw-commits@2.0.11:
     resolution: {integrity: sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==}
     engines: {node: '>=10'}
-    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-up@7.0.0:
@@ -45066,7 +45264,7 @@ snapshots:
 
   '@cosmjs/encoding@0.37.0':
     dependencies:
-      '@scure/base': 2.0.0
+      '@scure/base': 2.3.0
       base64-js: 1.5.1
       readonly-date: 1.0.0
 
@@ -68554,7 +68752,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3
+      metro: 0.83.3(metro-transform-worker@0.83.3)
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -68678,6 +68876,54 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.83.3(metro-transform-worker@0.83.3):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.28.5
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 1.3.8
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.32.0
+      image-size: 1.1.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0(metro@0.83.3)
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.3
+      metro-cache: 0.83.3
+      metro-cache-key: 0.83.3
+      metro-config: 0.83.3(metro-transform-worker@0.83.3)
+      metro-core: 0.83.3
+      metro-file-map: 0.83.3(metro@0.83.3)
+      metro-resolver: 0.83.3
+      metro-runtime: 0.83.3
+      metro-source-map: 0.83.3
+      metro-symbolicate: 0.83.3
+      metro-transform-plugins: 0.83.3
+      metro-transform-worker: 0.83.3
+      mime-types: 2.1.35
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - metro-transform-worker
       - supports-color
       - utf-8-validate
 

--- a/shared/api-services/jest.config.js
+++ b/shared/api-services/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/shared/api-services/package.json
+++ b/shared/api-services/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@jest/globals": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/shared/auth/jest.config.js
+++ b/shared/auth/jest.config.js
@@ -19,5 +19,7 @@ module.exports = {
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/shared/auth/package.json
+++ b/shared/auth/package.json
@@ -26,6 +26,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/shared/cloud-sync-module/jest.config.js
+++ b/shared/cloud-sync-module/jest.config.js
@@ -10,5 +10,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/shared/cloud-sync-module/package.json
+++ b/shared/cloud-sync-module/package.json
@@ -22,6 +22,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/shared/cloud-sync/jest.config.js
+++ b/shared/cloud-sync/jest.config.js
@@ -10,5 +10,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/shared/cloud-sync/package.json
+++ b/shared/cloud-sync/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@jest/globals": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/shared/env/jest.config.js
+++ b/shared/env/jest.config.js
@@ -20,5 +20,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/shared/env/package.json
+++ b/shared/env/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@jest/globals": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/shared/feature-flags/jest.config.js
+++ b/shared/feature-flags/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/shared/feature-flags/package.json
+++ b/shared/feature-flags/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@jest/globals": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@types/semver": "catalog:",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",

--- a/shared/password-verifier/jest.config.js
+++ b/shared/password-verifier/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/shared/password-verifier/package.json
+++ b/shared/password-verifier/package.json
@@ -20,6 +20,7 @@
     "unimported": "pnpm knip --directory ../.. -W shared/password-verifier"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/shared/schema-primitives/jest.config.js
+++ b/shared/schema-primitives/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/shared/schema-primitives/package.json
+++ b/shared/schema-primitives/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@jest/globals": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",

--- a/shared/ui-qr-code/jest.config.js
+++ b/shared/ui-qr-code/jest.config.js
@@ -32,6 +32,7 @@ module.exports = {
   reporters: [
     "default",
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
   projects: [
     {
@@ -40,7 +41,7 @@ module.exports = {
       testEnvironment: "jsdom",
       moduleFileExtensions: platformExtensions("web"),
       testMatch: ["**/*.web.test.ts?(x)", "**/*.web.spec.ts?(x)"],
-      setupFilesAfterEnv: ["@testing-library/jest-dom"],
+      setupFilesAfterEnv: ["@testing-library/jest-dom", "@ledgerhq/test-quarantine/jest-retries"],
     },
     {
       ...base,
@@ -58,6 +59,7 @@ module.exports = {
           "jest/mocks/passthrough-native.js",
         ),
       },
+      setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
     },
   ],
 };

--- a/shared/ui-qr-code/package.json
+++ b/shared/ui-qr-code/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@ledgerhq/lumen-ui-rnative": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@testing-library/dom": "catalog:",


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Wires the jest flake reporter and CI-only retries into 67 packages owned by @ledgerhq/engagement, @ledgerhq/wallet-xp and @ledgerhq/platform, following the pattern established for the ptx packages in #21004.

Each package gains the reporter plus the shared jest-retries setup file, so retries stay CI-only and keep logErrorsBeforeRetry: a failure is still printed before the second attempt, and a test failing both attempts still fails the build.

### 🔗 Context

Note. This is part of a phased rollout of the reporters. 2 batches have been completed thus far with a further set of batches to be concluded. It is not intended to cover all test scopes
