### PR TITLE
[LWDM] fix(tron): respect custom TRC-20 fee limit override

### DIFF
--- a/.changeset/cyan-insects-report.md
+++ b/.changeset/cyan-insects-report.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/coin-tester-tron": minor
+"@ledgerhq/coin-tron": minor
+---
+
+Respect a custom fee limit passed to a TRC-20 `craftTransaction` instead of flooring it to `DEFAULT_TRC20_FEES_LIMIT` (LIVE-36391).
+
+The generic coin framework migration started raising any override below 50M sun (and `0`) to the default, so a caller-chosen `fee_limit` was silently ignored. The value now passes straight through; the default applies only when no custom fee is provided.

--- a/libs/coin-modules/coin-tron/src/logic/craftTransaction.integ.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/craftTransaction.integ.test.ts
@@ -123,7 +123,7 @@ describe("Testing craftTransaction function", () => {
     );
   });
 
-  it("should raise a 0 fee estimate to the fee-limit ceiling for a TRC20 transaction", async () => {
+  it("should pass a 0 custom fee straight through for a TRC20 transaction", async () => {
     const amount = BigInt(20);
     const sender = "TRqkRnAj6ceJFYAn2p1eE7aWrgBBwtdhS9";
     const recipient = "TPswDDCAWhJAZGdHPidFg5nEf8TkNToDX1";
@@ -165,10 +165,12 @@ describe("Testing craftTransaction function", () => {
         }),
       }),
     );
-    expect(decodeResult.raw_data.fee_limit).toBe(DEFAULT_TRC20_FEES_LIMIT);
+    // A `0` cap serialises to no `fee_limit` field: protobuf omits zero scalars and the decoder
+    // (`utils.ts`) only surfaces `fee_limit` when `getFeeLimit()` is truthy.
+    expect(decodeResult.raw_data.fee_limit).toBeUndefined();
   });
 
-  it("should raise a fee estimate below the ceiling for a TRC20 transaction", async () => {
+  it("should pass a custom fee below the default straight through for a TRC20 transaction", async () => {
     const amount = BigInt(20);
     const sender = "TRqkRnAj6ceJFYAn2p1eE7aWrgBBwtdhS9";
     const recipient = "TPswDDCAWhJAZGdHPidFg5nEf8TkNToDX1";
@@ -195,7 +197,7 @@ describe("Testing craftTransaction function", () => {
     expect(decodeResult).toEqual(
       expect.objectContaining({
         raw_data: expect.objectContaining({
-          fee_limit: DEFAULT_TRC20_FEES_LIMIT,
+          fee_limit: 99,
         }),
       }),
     );

--- a/libs/coin-modules/coin-tron/src/logic/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/craftTransaction.test.ts
@@ -110,7 +110,7 @@ describe("craftTransaction", () => {
       "recipient",
       "sender",
       new BigNumber(1000),
-      50000000,
+      undefined,
       undefined,
     );
     expect(result).toBe("extendedRawDataHex");
@@ -141,7 +141,7 @@ describe("craftTransaction", () => {
     expect(result).toBe("extendedRawDataHex");
   });
 
-  it("should raise a 0 fee estimate to the fee-limit ceiling for a TRC20 transaction", async () => {
+  it("should pass a 0 custom fee straight through for a TRC20 transaction", async () => {
     const customFees = 0n;
     const amount = 1000;
     const transactionIntent = {
@@ -166,12 +166,12 @@ describe("craftTransaction", () => {
       undefined,
       undefined,
       BigNumber(amount),
-      50000000,
+      0,
       undefined,
     );
   });
 
-  it("should raise a fee estimate below the ceiling for crafting a TRC20 transaction", async () => {
+  it("should pass a custom fee below the default straight through for a TRC20 transaction", async () => {
     const customFees: bigint = 99n;
     const amount: number = 1000;
     const transactionIntent = {
@@ -196,12 +196,42 @@ describe("craftTransaction", () => {
       undefined,
       undefined,
       BigNumber(amount),
-      50000000,
+      99,
       undefined,
     );
   });
 
-  it("should use the fee-limit ceiling when no fee estimate is provided for a TRC20 transaction", async () => {
+  it("should pass a custom fee above the default straight through for a TRC20 transaction", async () => {
+    const customFees: bigint = 60_000_000n;
+    const amount: number = 1000;
+    const transactionIntent = {
+      intentType: "transaction",
+      type: "send",
+      asset: {
+        type: "trc20",
+        assetReference: "contractAddress",
+      },
+      amount: BigInt(amount),
+    } as TronIntent;
+
+    (decode58Check as jest.Mock).mockImplementation(_address => undefined);
+    (craftTrc20Transaction as jest.Mock).mockResolvedValue({
+      raw_data_hex: "extendedRawDataHex",
+    });
+
+    await craftTransaction(mockConfig, transactionIntent, { value: customFees });
+    expect(craftTrc20Transaction).toHaveBeenCalledWith(
+      mockConfig,
+      "contractAddress",
+      undefined,
+      undefined,
+      BigNumber(amount),
+      60_000_000,
+      undefined,
+    );
+  });
+
+  it("should leave the fee limit to the network default when no custom fee is provided for a TRC20 transaction", async () => {
     const amount = 1000;
     const transactionIntent = {
       intentType: "transaction",
@@ -219,13 +249,15 @@ describe("craftTransaction", () => {
     });
 
     await craftTransaction(mockConfig, transactionIntent);
+    // `undefined` here, not the default: `craftTrc20Transaction` owns the `?? DEFAULT_TRC20_FEES_LIMIT`
+    // fallback, so the default is asserted in the network + integ tests, not mocked away here.
     expect(craftTrc20Transaction).toHaveBeenCalledWith(
       mockConfig,
       "contractAddress",
       undefined,
       undefined,
       BigNumber(amount),
-      50000000,
+      undefined,
       undefined,
     );
   });

--- a/libs/coin-modules/coin-tron/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-tron/src/logic/craftTransaction.ts
@@ -6,7 +6,6 @@ import {
 import BigNumber from "bignumber.js";
 import type { TronCoinConfig } from "../config";
 import {
-  DEFAULT_TRC20_FEES_LIMIT,
   claimRewardTronTransaction,
   craftStandardTransaction,
   craftTrc20Transaction,
@@ -113,14 +112,13 @@ async function craftSend(
       throw new Error("Memo cannot be used with smart contract transactions");
     }
 
-    // `fee_limit` caps what the TVM may burn, it is not a charge: whatever the contract call leaves
-    // unused is never taken. What arrives here is an *estimate* of the cost rather than a cap anyone
-    // chose — Tron's fee descriptor is `hasCustom: false`, so nothing in the app can set one. Capping
-    // at the estimate turns any under-estimate into an OUT_OF_ENERGY revert with the fee still burned,
-    // and a USDT transfer costs roughly twice as much when it has to activate the recipient's token
-    // balance — a state that can flip between estimating and broadcasting. So the cap only ratchets
-    // up from `DEFAULT_TRC20_FEES_LIMIT`, still clearing an estimate above it.
-    const feeLimit = Math.max(feesToNumber(fees) ?? 0, DEFAULT_TRC20_FEES_LIMIT);
+    // `fee_limit` caps what the TVM may burn, not a charge — unused energy is never taken. When the
+    // caller passes a custom fee we honour it verbatim, including a value below
+    // `DEFAULT_TRC20_FEES_LIMIT` or `0`: a low cap can OUT_OF_ENERGY-revert with the fee still burned,
+    // but that trade-off is the caller's to make and the coin module must not silently override it
+    // (LIVE-36391). Only when no custom fee is given does the default apply, and `craftTrc20Transaction`
+    // owns that fallback (`customFees ?? DEFAULT_TRC20_FEES_LIMIT`).
+    const feeLimit = feesToNumber(fees);
 
     return toCrafted(
       await craftTrc20Transaction(

--- a/libs/coin-tester-modules/coin-tester-tron/src/scenarii/tron.ts
+++ b/libs/coin-tester-modules/coin-tester-tron/src/scenarii/tron.ts
@@ -54,6 +54,15 @@ const FROZEN_SUN = 50_000_000; // 50 TRX
  * raises it — and comfortably above a TRC-20 transfer's actual energy cost either way.
  */
 const CUSTOM_FEE_LIMIT_SUN = 100_000_000; // 100 TRX
+/**
+ * A custom fee limit *below* `DEFAULT_TRC20_FEES_LIMIT` (50 TRX), for the LIVE-36391 regression guard
+ * row. Comfortably above a TRC-20 transfer's actual energy cost so the transfer still succeeds (the
+ * balance-delta assertions stay valid), but below the default so a reintroduced floor would raise it —
+ * which the on-chain `fee_limit` readback catches.
+ */
+const BELOW_DEFAULT_FEE_LIMIT_SUN = 30_000_000; // 30 TRX
+/** tx hash → on-chain `fee_limit`, recorded by `mockIndexer` for the guard row to assert against. */
+const onChainFeeLimitByHash = new Map<string, number | undefined>();
 
 /**
  * The transaction the wallet hands the bridge for Tron: the generic shape with `mode` widened to
@@ -194,6 +203,28 @@ function makeTransactions(): Tx[] {
     },
   };
 
+  const sendTrc20WithBelowDefaultFee: Tx = {
+    name: `Send 1 ${trc20.symbol} (TRC20) with a below-default custom fee limit`,
+    amount: new BigNumber(1_000_000),
+    recipient: recipient.address,
+    subAccountId: trc20SubAccountId,
+    // LIVE-36391 regression guard: the below-default cap must reach the chain verbatim, not be floored
+    // to the default. The on-chain `fee_limit` readback (from mockIndexer) proves the override survived
+    // craft → sign → broadcast through the shipping generic-coin-framework bridge.
+    customFees: { parameters: { fees: new BigNumber(BELOW_DEFAULT_FEE_LIMIT_SUN) } },
+    expect: (prev, curr) => {
+      const sub = curr.subAccounts?.find(s => s.id === trc20SubAccountId);
+      const prevSub = prev.subAccounts?.find(s => s.id === trc20SubAccountId);
+      expect(sub).toBeDefined();
+      expect(sub!.balance).toStrictEqual((prevSub?.balance ?? new BigNumber(0)).minus(1_000_000));
+
+      const [latestOp] = sub!.operations;
+      expect(latestOp.type).toBe("OUT");
+      expect(latestOp.recipients).toContain(recipient.address);
+      expect(onChainFeeLimitByHash.get(latestOp.hash)).toBe(BELOW_DEFAULT_FEE_LIMIT_SUN);
+    },
+  };
+
   const sendMaxTrc20: Tx = {
     name: `Send max ${trc20.symbol} (TRC20)`,
     useAllAmount: true,
@@ -305,6 +336,7 @@ function makeTransactions(): Tx[] {
     sendMaxTrc10,
     sendTrc20,
     sendTrc20WithCustomFees,
+    sendTrc20WithBelowDefaultFee,
     sendMaxTrc20,
     freeze,
     vote,
@@ -385,6 +417,24 @@ export const scenarioTron: Scenario<GenericTransaction, Account> = {
 
   mockIndexer: async (_account, optimistic) => {
     await waitForOperationInclusion(optimistic.hash);
+    // Record each broadcast transaction's on-chain `fee_limit` so the LIVE-36391 guard row can assert
+    // the custom value reached the chain (non-TRC-20 sends carry none; the guard reads only its own tx).
+    // Records `undefined` rather than throwing on any lookup failure — a rejected fetch, a non-2xx,
+    // or bad JSON. This runs for every row, so a blip must not fail unrelated ones; a miss surfaces
+    // as the guard row's own assertion instead.
+    let feeLimit: number | undefined;
+    try {
+      const res = await fetch(`${TRON_LOCAL_RPC}/wallet/gettransactionbyid`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ value: optimistic.hash }),
+      });
+      const tx = res.ok ? ((await res.json()) as { raw_data?: { fee_limit?: number } }) : undefined;
+      feeLimit = tx?.raw_data?.fee_limit;
+    } catch {
+      feeLimit = undefined;
+    }
+    onChainFeeLimitByHash.set(optimistic.hash, feeLimit);
   },
 
   beforeAll: account => {
@@ -402,6 +452,7 @@ export const scenarioTron: Scenario<GenericTransaction, Account> = {
     closeMsw?.();
     closeMsw = null;
     resetIndexer();
+    onChainFeeLimitByHash.clear();
     await killTronbox();
   },
 };


### PR DESCRIPTION
### 📝 Description

The generic coin framework migration (585d8d7) began flooring the TRC-20 `fee_limit` with `Math.max(fee, DEFAULT_TRC20_FEES_LIMIT)`, so any caller-supplied fee below 50 TRX — including `0` — was silently raised to the default and the override was lost. This caused the LES P0 incident (TSD-11634).

The floor is removed: a custom fee now passes straight through to the node, and the 50 TRX default applies only when no fee is provided (that fallback already lives in `craftTrc20Transaction`). This is a verbatim restore of the pre-migration behaviour. `fee_limit` is a burn cap, not a charge, so honouring a low value — even one that may OUT_OF_ENERGY-revert — is the caller's trade-off to make, not ours to override.

Regression coverage: unit + integ tests assert pass-through for `0`, below-default, and above-default fees; a coin-tester guard row drives a 30 TRX override through craft → sign → broadcast on the devnet and reads the on-chain `fee_limit` back to prove it survived the shipping bridge.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36391](https://ledgerhq.atlassian.net/browse/LIVE-36391)
- **ADR** (if any): n/a

[LIVE-36391]: https://ledgerhq.atlassian.net/browse/LIVE-36391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ