### PR TITLE
[LWDM] feat(contacts): register Wallet Sync persistence (LIVE-33960)

### DIFF
--- a/.changeset/fresh-contacts-persist.md
+++ b/.changeset/fresh-contacts-persist.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-wallet": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Persist Contacts locally and synchronize them through Ledger Sync.

--- a/apps/ledger-live-desktop/src/main/db/index.ts
+++ b/apps/ledger-live-desktop/src/main/db/index.ts
@@ -12,6 +12,7 @@ import {
   exportWalletState,
   initialState as walletInitialState,
 } from "~/renderer/reducers/wallet.core";
+import { contactsInitialState } from "@domain/entity-contact";
 import { LARGE_SCREEN_UPSELL_MODAL } from "@features/flow-large-screen-upsell";
 import { encryptData, decryptData } from "~/main/db/crypto";
 import { readFile, writeFile } from "~/main/db/fsHelper";
@@ -164,7 +165,7 @@ type EncryptedAppKeyPath = (typeof encryptedDataPaths)[number][1];
 const ENCRYPTION_PATH_DEFAULTS: Record<EncryptedAppKeyPath, unknown> = {
   accounts: [],
   trustchain: trustchainInitialState,
-  wallet: exportWalletState(walletInitialState),
+  wallet: exportWalletState(walletInitialState, contactsInitialState),
 };
 
 for (const [, keyPath] of encryptedDataPaths) {

--- a/apps/ledger-live-desktop/src/main/db/index.ts
+++ b/apps/ledger-live-desktop/src/main/db/index.ts
@@ -165,7 +165,7 @@ type EncryptedAppKeyPath = (typeof encryptedDataPaths)[number][1];
 const ENCRYPTION_PATH_DEFAULTS: Record<EncryptedAppKeyPath, unknown> = {
   accounts: [],
   trustchain: trustchainInitialState,
-  wallet: exportWalletState(walletInitialState, contactsInitialState),
+  wallet: exportWalletState({ wallet: walletInitialState, contacts: contactsInitialState }),
 };
 
 for (const [, keyPath] of encryptedDataPaths) {

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useWatchWalletSync.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useWatchWalletSync.ts
@@ -9,6 +9,7 @@ import {
   makeLocalIncrementalUpdate,
 } from "@features/platform-wallet-sync";
 import { bulkSetAccountNames } from "@domain/entity-account-name";
+import { selectContacts, setContacts } from "@domain/entity-contact";
 import { updateRecentAddresses } from "@domain/entity-recent-addresses";
 import { setNonImportedAccounts } from "@ledgerhq/live-wallet/accounts";
 import {
@@ -72,6 +73,7 @@ function localStateSelector(state: State): LocalState {
       nonImportedAccountInfos: state.wallet.nonImportedAccountInfos,
     },
     accountNames: state.wallet.accountNames,
+    contacts: selectContacts(state),
     recentAddresses: state.wallet.recentAddresses,
   };
 }
@@ -86,6 +88,7 @@ async function save(
   if (newLocalState) {
     dispatch(setNonImportedAccounts(newLocalState.accounts.nonImportedAccountInfos));
     dispatch(bulkSetAccountNames(newLocalState.accountNames));
+    dispatch(setContacts(newLocalState.contacts));
     dispatch(updateRecentAddresses(newLocalState.recentAddresses));
     dispatch(replaceAccounts(newLocalState.accounts.list));
   }

--- a/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
@@ -163,10 +163,7 @@ const DBMiddleware: Middleware<object, State> = store => next => action => {
     }
   }
 
-  if (
-    oldState.wallet &&
-    walletStateExportShouldDiffer(oldState, newState)
-  ) {
+  if (oldState.wallet && walletStateExportShouldDiffer(oldState, newState)) {
     setKey("app", "wallet", exportWalletState(newState));
   }
 

--- a/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
@@ -165,14 +165,9 @@ const DBMiddleware: Middleware<object, State> = store => next => action => {
 
   if (
     oldState.wallet &&
-    walletStateExportShouldDiffer(
-      oldState.wallet,
-      newState.wallet,
-      oldState.contacts,
-      newState.contacts,
-    )
+    walletStateExportShouldDiffer(oldState, newState)
   ) {
-    setKey("app", "wallet", exportWalletState(newState.wallet, newState.contacts));
+    setKey("app", "wallet", exportWalletState(newState));
   }
 
   if (accountsPersistedStateChanged(oldState.accounts, newState.accounts)) {

--- a/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
@@ -163,8 +163,16 @@ const DBMiddleware: Middleware<object, State> = store => next => action => {
     }
   }
 
-  if (oldState.wallet && walletStateExportShouldDiffer(oldState.wallet, newState.wallet)) {
-    setKey("app", "wallet", exportWalletState(newState.wallet));
+  if (
+    oldState.wallet &&
+    walletStateExportShouldDiffer(
+      oldState.wallet,
+      newState.wallet,
+      oldState.contacts,
+      newState.contacts,
+    )
+  ) {
+    setKey("app", "wallet", exportWalletState(newState.wallet, newState.contacts));
   }
 
   if (accountsPersistedStateChanged(oldState.accounts, newState.accounts)) {

--- a/apps/ledger-live-desktop/src/renderer/reducers/__tests__/wallet.core.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/__tests__/wallet.core.test.ts
@@ -13,7 +13,9 @@ describe("wallet persistence", () => {
   };
 
   it("exports Contacts with the wallet state", () => {
-    expect(exportWalletState({ wallet: initialState, contacts }).contacts).toEqual(contacts.contacts);
+    expect(exportWalletState({ wallet: initialState, contacts }).contacts).toEqual(
+      contacts.contacts,
+    );
   });
 
   it("persists when Contacts change", () => {

--- a/apps/ledger-live-desktop/src/renderer/reducers/__tests__/wallet.core.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/__tests__/wallet.core.test.ts
@@ -1,0 +1,37 @@
+import { setContacts } from "@domain/entity-contact";
+import { mockContact, mockEmptyContacts } from "@domain/entity-contact/schema.mock";
+import {
+  exportWalletState,
+  importWalletState,
+  initialState,
+  walletStateExportShouldDiffer,
+} from "../wallet.core";
+
+describe("wallet persistence", () => {
+  const contacts = {
+    contacts: [...mockEmptyContacts(), mockContact({ id: "contact-ada", name: "Ada" })],
+  };
+
+  it("exports Contacts with the wallet state", () => {
+    expect(exportWalletState(initialState, contacts).contacts).toEqual(contacts.contacts);
+  });
+
+  it("persists when Contacts change", () => {
+    expect(
+      walletStateExportShouldDiffer(
+        initialState,
+        initialState,
+        { contacts: mockEmptyContacts() },
+        contacts,
+      ),
+    ).toBe(true);
+  });
+
+  it("restores persisted Contacts", () => {
+    const dispatch = jest.fn();
+
+    importWalletState({ contacts: contacts.contacts })(dispatch);
+
+    expect(dispatch).toHaveBeenCalledWith(setContacts(contacts.contacts));
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/reducers/__tests__/wallet.core.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/__tests__/wallet.core.test.ts
@@ -13,16 +13,14 @@ describe("wallet persistence", () => {
   };
 
   it("exports Contacts with the wallet state", () => {
-    expect(exportWalletState(initialState, contacts).contacts).toEqual(contacts.contacts);
+    expect(exportWalletState({ wallet: initialState, contacts }).contacts).toEqual(contacts.contacts);
   });
 
   it("persists when Contacts change", () => {
     expect(
       walletStateExportShouldDiffer(
-        initialState,
-        initialState,
-        { contacts: mockEmptyContacts() },
-        contacts,
+        { wallet: initialState, contacts: { contacts: mockEmptyContacts() } },
+        { wallet: initialState, contacts },
       ),
     ).toBe(true);
   });

--- a/apps/ledger-live-desktop/src/renderer/reducers/wallet.core.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/wallet.core.ts
@@ -13,6 +13,7 @@ import {
   updateRecentAddresses,
   type RecentAddressesState,
 } from "@domain/entity-recent-addresses";
+import type { State } from ".";
 
 export const walletReducer = combineReducers({
   accountNames: accountNamesSlice.reducer,
@@ -37,32 +38,29 @@ export type ExportedWalletState = {
   recentAddresses: RecentAddressesState;
 };
 
-export const exportWalletState = (
-  state: WalletState,
-  contacts: ContactsState,
-): ExportedWalletState => ({
-  walletSyncState: state.walletSync.walletSyncState,
-  nonImportedAccountInfos: state.nonImportedAccountInfos,
+type WalletPersistenceState = Pick<State, "wallet" | "contacts">;
+
+export const exportWalletState = (state: WalletPersistenceState): ExportedWalletState => ({
+  walletSyncState: state.wallet.walletSync.walletSyncState,
+  nonImportedAccountInfos: state.wallet.nonImportedAccountInfos,
   accountsData: {
-    accountNames: Array.from(state.accountNames),
-    starredAccountIds: Array.from(state.starredAccountIds),
+    accountNames: Array.from(state.wallet.accountNames),
+    starredAccountIds: Array.from(state.wallet.starredAccountIds),
   },
-  contacts: contacts.contacts,
-  recentAddresses: state.recentAddresses,
+  contacts: state.contacts.contacts,
+  recentAddresses: state.wallet.recentAddresses,
 });
 
 export const walletStateExportShouldDiffer = (
-  a: WalletState,
-  b: WalletState,
-  aContacts: ContactsState,
-  bContacts: ContactsState,
+  a: WalletPersistenceState,
+  b: WalletPersistenceState,
 ): boolean =>
-  a.walletSync.walletSyncState !== b.walletSync.walletSyncState ||
-  a.nonImportedAccountInfos !== b.nonImportedAccountInfos ||
-  a.accountNames !== b.accountNames ||
-  a.starredAccountIds !== b.starredAccountIds ||
-  aContacts.contacts !== bContacts.contacts ||
-  a.recentAddresses !== b.recentAddresses;
+  a.wallet.walletSync.walletSyncState !== b.wallet.walletSync.walletSyncState ||
+  a.wallet.nonImportedAccountInfos !== b.wallet.nonImportedAccountInfos ||
+  a.wallet.accountNames !== b.wallet.accountNames ||
+  a.wallet.starredAccountIds !== b.wallet.starredAccountIds ||
+  a.contacts.contacts !== b.contacts.contacts ||
+  a.wallet.recentAddresses !== b.wallet.recentAddresses;
 
 export const importWalletState =
   (payload: Partial<ExportedWalletState>) =>

--- a/apps/ledger-live-desktop/src/renderer/reducers/wallet.core.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/wallet.core.ts
@@ -1,5 +1,6 @@
 import { combineReducers, type Dispatch } from "@reduxjs/toolkit";
 import { accountNamesSlice, initFromUserData } from "@domain/entity-account-name";
+import { setContacts, type ContactsState } from "@domain/entity-contact";
 import { starredAccountsSlice, initStarredFromIds } from "@domain/entity-starred-account";
 import { walletSyncSlice, walletSyncUpdate, type WSState } from "@domain/entity-wallet-sync";
 import {
@@ -32,24 +33,35 @@ export type ExportedWalletState = {
     accountNames: Array<[string, string]>;
     starredAccountIds: string[];
   };
+  contacts: ContactsState["contacts"];
   recentAddresses: RecentAddressesState;
 };
 
-export const exportWalletState = (state: WalletState): ExportedWalletState => ({
+export const exportWalletState = (
+  state: WalletState,
+  contacts: ContactsState,
+): ExportedWalletState => ({
   walletSyncState: state.walletSync.walletSyncState,
   nonImportedAccountInfos: state.nonImportedAccountInfos,
   accountsData: {
     accountNames: Array.from(state.accountNames),
     starredAccountIds: Array.from(state.starredAccountIds),
   },
+  contacts: contacts.contacts,
   recentAddresses: state.recentAddresses,
 });
 
-export const walletStateExportShouldDiffer = (a: WalletState, b: WalletState): boolean =>
+export const walletStateExportShouldDiffer = (
+  a: WalletState,
+  b: WalletState,
+  aContacts: ContactsState,
+  bContacts: ContactsState,
+): boolean =>
   a.walletSync.walletSyncState !== b.walletSync.walletSyncState ||
   a.nonImportedAccountInfos !== b.nonImportedAccountInfos ||
   a.accountNames !== b.accountNames ||
   a.starredAccountIds !== b.starredAccountIds ||
+  aContacts.contacts !== bContacts.contacts ||
   a.recentAddresses !== b.recentAddresses;
 
 export const importWalletState =
@@ -68,6 +80,9 @@ export const importWalletState =
     }
     if (payload.nonImportedAccountInfos !== undefined) {
       dispatch(setNonImportedAccounts(payload.nonImportedAccountInfos));
+    }
+    if (payload.contacts !== undefined) {
+      dispatch(setContacts(payload.contacts));
     }
     if (payload.recentAddresses !== undefined) {
       dispatch(updateRecentAddresses(payload.recentAddresses));

--- a/apps/ledger-live-mobile/src/components/DBSave.ts
+++ b/apps/ledger-live-mobile/src/components/DBSave.ts
@@ -4,7 +4,6 @@ import { postOnboardingSelector } from "@ledgerhq/live-common/postOnboarding/red
 import {
   exportWalletState,
   walletStateExportShouldDiffer,
-  walletSelector,
 } from "~/reducers/wallet";
 import isEqual from "lodash/isEqual";
 import throttleFn from "lodash/throttle";
@@ -142,10 +141,6 @@ function useFlushMechanism({ flush, cancel }: { flush: () => void; cancel: () =>
   }, [flush]);
 }
 
-function walletExportSelector(state: State) {
-  return exportWalletState(walletSelector(state), state.contacts);
-}
-
 const getSettingsChanged = (a: State, b: State) => a.settings !== b.settings;
 const getAccountsChanged = (
   oldState: State,
@@ -206,8 +201,6 @@ const payCardDbSaveSliceSelector = createSelector(
 const payCardPersistedNotEquals = (a: State, b: State) =>
   !isEqual(payCardPersistedSelector(a), payCardPersistedSelector(b));
 const trustchainNotEquals = (a: State, b: State) => a.trustchain !== b.trustchain;
-const compareWalletState = (a: State, b: State) =>
-  walletStateExportShouldDiffer(a.wallet, b.wallet, a.contacts, b.contacts);
 const largeMoverNotEquals = (a: State, b: State) => a.largeMover !== b.largeMover;
 
 const cryptoAssetsNotEquals = (a: State, b: State) =>
@@ -334,8 +327,8 @@ export const ConfigureDBSaveEffects = () => {
     stateSelector: walletDbSaveSliceSelector,
     save: saveWalletExportState,
     throttle: 500,
-    getChangesStats: compareWalletState,
-    lense: walletExportSelector,
+    getChangesStats: walletStateExportShouldDiffer,
+    lense: exportWalletState,
   });
 
   useDBSaveEffect({

--- a/apps/ledger-live-mobile/src/components/DBSave.ts
+++ b/apps/ledger-live-mobile/src/components/DBSave.ts
@@ -1,10 +1,7 @@
 import { trustchainStoreSelector } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { largeScreenUpsellModalSelector } from "@ledgerhq/live-engagement/largeScreenUpsellModal";
 import { postOnboardingSelector } from "@ledgerhq/live-common/postOnboarding/reducer";
-import {
-  exportWalletState,
-  walletStateExportShouldDiffer,
-} from "~/reducers/wallet";
+import { exportWalletState, walletStateExportShouldDiffer } from "~/reducers/wallet";
 import isEqual from "lodash/isEqual";
 import throttleFn from "lodash/throttle";
 import { useCallback, useEffect, useMemo, useRef } from "react";

--- a/apps/ledger-live-mobile/src/components/DBSave.ts
+++ b/apps/ledger-live-mobile/src/components/DBSave.ts
@@ -143,7 +143,7 @@ function useFlushMechanism({ flush, cancel }: { flush: () => void; cancel: () =>
 }
 
 function walletExportSelector(state: State) {
-  return exportWalletState(walletSelector(state));
+  return exportWalletState(walletSelector(state), state.contacts);
 }
 
 const getSettingsChanged = (a: State, b: State) => a.settings !== b.settings;
@@ -176,6 +176,11 @@ const accountsDbSaveSliceSelector = createSelector(
   (state: State) => state.wallet,
   (accounts, wallet) => ({ accounts, wallet }),
 );
+const walletDbSaveSliceSelector = createSelector(
+  (state: State) => state.wallet,
+  (state: State) => state.contacts,
+  (wallet, contacts) => ({ wallet, contacts }),
+);
 const bleNotEquals = (a: State, b: State) => a.ble !== b.ble;
 const knownDevicesNotEquals = (a: State, b: State) => a.knownDevices !== b.knownDevices;
 
@@ -202,7 +207,7 @@ const payCardPersistedNotEquals = (a: State, b: State) =>
   !isEqual(payCardPersistedSelector(a), payCardPersistedSelector(b));
 const trustchainNotEquals = (a: State, b: State) => a.trustchain !== b.trustchain;
 const compareWalletState = (a: State, b: State) =>
-  walletStateExportShouldDiffer(a.wallet, b.wallet);
+  walletStateExportShouldDiffer(a.wallet, b.wallet, a.contacts, b.contacts);
 const largeMoverNotEquals = (a: State, b: State) => a.largeMover !== b.largeMover;
 
 const cryptoAssetsNotEquals = (a: State, b: State) =>
@@ -326,7 +331,7 @@ export const ConfigureDBSaveEffects = () => {
   });
 
   useDBSaveEffect({
-    stateSelector: (state: State) => state.wallet,
+    stateSelector: walletDbSaveSliceSelector,
     save: saveWalletExportState,
     throttle: 500,
     getChangesStats: compareWalletState,

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useWatchWalletSync.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useWatchWalletSync.ts
@@ -9,6 +9,7 @@ import {
   makeLocalIncrementalUpdate,
 } from "@features/platform-wallet-sync";
 import { bulkSetAccountNames } from "@domain/entity-account-name";
+import { selectContacts, setContacts } from "@domain/entity-contact";
 import { updateRecentAddresses } from "@domain/entity-recent-addresses";
 import { setNonImportedAccounts } from "@ledgerhq/live-wallet/accounts";
 import {
@@ -72,6 +73,7 @@ function localStateSelector(state: State) {
       nonImportedAccountInfos: state.wallet.nonImportedAccountInfos,
     },
     accountNames: state.wallet.accountNames,
+    contacts: selectContacts(state),
     recentAddresses: state.wallet.recentAddresses,
   };
 }
@@ -86,6 +88,7 @@ async function save(
   if (newLocalState) {
     dispatch(setNonImportedAccounts(newLocalState.accounts.nonImportedAccountInfos));
     dispatch(bulkSetAccountNames(newLocalState.accountNames));
+    dispatch(setContacts(newLocalState.contacts));
     dispatch(updateRecentAddresses(newLocalState.recentAddresses));
     dispatch(replaceAccounts(newLocalState.accounts.list)); // IMPORTANT: keep this one last, it's doing the DB:* trigger to save the data
   }

--- a/apps/ledger-live-mobile/src/reducers/wallet.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/wallet.test.ts
@@ -13,16 +13,14 @@ describe("wallet persistence", () => {
   };
 
   it("exports Contacts with the wallet state", () => {
-    expect(exportWalletState(INITIAL_STATE, contacts).contacts).toEqual(contacts.contacts);
+    expect(exportWalletState({ wallet: INITIAL_STATE, contacts }).contacts).toEqual(contacts.contacts);
   });
 
   it("persists when Contacts change", () => {
     expect(
       walletStateExportShouldDiffer(
-        INITIAL_STATE,
-        INITIAL_STATE,
-        { contacts: mockEmptyContacts() },
-        contacts,
+        { wallet: INITIAL_STATE, contacts: { contacts: mockEmptyContacts() } },
+        { wallet: INITIAL_STATE, contacts },
       ),
     ).toBe(true);
   });

--- a/apps/ledger-live-mobile/src/reducers/wallet.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/wallet.test.ts
@@ -13,7 +13,9 @@ describe("wallet persistence", () => {
   };
 
   it("exports Contacts with the wallet state", () => {
-    expect(exportWalletState({ wallet: INITIAL_STATE, contacts }).contacts).toEqual(contacts.contacts);
+    expect(exportWalletState({ wallet: INITIAL_STATE, contacts }).contacts).toEqual(
+      contacts.contacts,
+    );
   });
 
   it("persists when Contacts change", () => {

--- a/apps/ledger-live-mobile/src/reducers/wallet.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/wallet.test.ts
@@ -1,0 +1,37 @@
+import { setContacts } from "@domain/entity-contact";
+import { mockContact, mockEmptyContacts } from "@domain/entity-contact/schema.mock";
+import {
+  exportWalletState,
+  importWalletState,
+  INITIAL_STATE,
+  walletStateExportShouldDiffer,
+} from "./wallet";
+
+describe("wallet persistence", () => {
+  const contacts = {
+    contacts: [...mockEmptyContacts(), mockContact({ id: "contact-ada", name: "Ada" })],
+  };
+
+  it("exports Contacts with the wallet state", () => {
+    expect(exportWalletState(INITIAL_STATE, contacts).contacts).toEqual(contacts.contacts);
+  });
+
+  it("persists when Contacts change", () => {
+    expect(
+      walletStateExportShouldDiffer(
+        INITIAL_STATE,
+        INITIAL_STATE,
+        { contacts: mockEmptyContacts() },
+        contacts,
+      ),
+    ).toBe(true);
+  });
+
+  it("restores persisted Contacts", () => {
+    const dispatch = jest.fn();
+
+    importWalletState({ contacts: contacts.contacts })(dispatch);
+
+    expect(dispatch).toHaveBeenCalledWith(setContacts(contacts.contacts));
+  });
+});

--- a/apps/ledger-live-mobile/src/reducers/wallet.ts
+++ b/apps/ledger-live-mobile/src/reducers/wallet.ts
@@ -55,32 +55,29 @@ export type ExportedWalletState = {
   recentAddresses: RecentAddressesState;
 };
 
-export const exportWalletState = (
-  state: WalletState,
-  contacts: ContactsState,
-): ExportedWalletState => ({
-  walletSyncState: state.walletSync.walletSyncState,
-  nonImportedAccountInfos: state.nonImportedAccountInfos,
+type WalletPersistenceState = Pick<State, "wallet" | "contacts">;
+
+export const exportWalletState = (state: WalletPersistenceState): ExportedWalletState => ({
+  walletSyncState: state.wallet.walletSync.walletSyncState,
+  nonImportedAccountInfos: state.wallet.nonImportedAccountInfos,
   accountsData: {
-    accountNames: Array.from(state.accountNames),
-    starredAccountIds: Array.from(state.starredAccountIds),
+    accountNames: Array.from(state.wallet.accountNames),
+    starredAccountIds: Array.from(state.wallet.starredAccountIds),
   },
-  contacts: contacts.contacts,
-  recentAddresses: state.recentAddresses,
+  contacts: state.contacts.contacts,
+  recentAddresses: state.wallet.recentAddresses,
 });
 
 export const walletStateExportShouldDiffer = (
-  a: WalletState,
-  b: WalletState,
-  aContacts: ContactsState,
-  bContacts: ContactsState,
+  a: WalletPersistenceState,
+  b: WalletPersistenceState,
 ): boolean =>
-  a.walletSync.walletSyncState !== b.walletSync.walletSyncState ||
-  a.nonImportedAccountInfos !== b.nonImportedAccountInfos ||
-  a.accountNames !== b.accountNames ||
-  a.starredAccountIds !== b.starredAccountIds ||
-  aContacts.contacts !== bContacts.contacts ||
-  a.recentAddresses !== b.recentAddresses;
+  a.wallet.walletSync.walletSyncState !== b.wallet.walletSync.walletSyncState ||
+  a.wallet.nonImportedAccountInfos !== b.wallet.nonImportedAccountInfos ||
+  a.wallet.accountNames !== b.wallet.accountNames ||
+  a.wallet.starredAccountIds !== b.wallet.starredAccountIds ||
+  a.contacts.contacts !== b.contacts.contacts ||
+  a.wallet.recentAddresses !== b.wallet.recentAddresses;
 
 export const importWalletState =
   (payload: Partial<ExportedWalletState>) =>

--- a/apps/ledger-live-mobile/src/reducers/wallet.ts
+++ b/apps/ledger-live-mobile/src/reducers/wallet.ts
@@ -7,6 +7,7 @@ import {
   setAccountName as setAccountNameRTK,
   initFromUserData,
 } from "@domain/entity-account-name";
+import { setContacts, type ContactsState } from "@domain/entity-contact";
 import {
   starredAccountsSlice,
   isStarredAccountSelector as entityIsStarredAccount,
@@ -50,24 +51,35 @@ export type ExportedWalletState = {
     accountNames: Array<[string, string]>;
     starredAccountIds: string[];
   };
+  contacts: ContactsState["contacts"];
   recentAddresses: RecentAddressesState;
 };
 
-export const exportWalletState = (state: WalletState): ExportedWalletState => ({
+export const exportWalletState = (
+  state: WalletState,
+  contacts: ContactsState,
+): ExportedWalletState => ({
   walletSyncState: state.walletSync.walletSyncState,
   nonImportedAccountInfos: state.nonImportedAccountInfos,
   accountsData: {
     accountNames: Array.from(state.accountNames),
     starredAccountIds: Array.from(state.starredAccountIds),
   },
+  contacts: contacts.contacts,
   recentAddresses: state.recentAddresses,
 });
 
-export const walletStateExportShouldDiffer = (a: WalletState, b: WalletState): boolean =>
+export const walletStateExportShouldDiffer = (
+  a: WalletState,
+  b: WalletState,
+  aContacts: ContactsState,
+  bContacts: ContactsState,
+): boolean =>
   a.walletSync.walletSyncState !== b.walletSync.walletSyncState ||
   a.nonImportedAccountInfos !== b.nonImportedAccountInfos ||
   a.accountNames !== b.accountNames ||
   a.starredAccountIds !== b.starredAccountIds ||
+  aContacts.contacts !== bContacts.contacts ||
   a.recentAddresses !== b.recentAddresses;
 
 export const importWalletState =
@@ -86,6 +98,9 @@ export const importWalletState =
     }
     if (payload.nonImportedAccountInfos !== undefined) {
       dispatch(setNonImportedAccounts(payload.nonImportedAccountInfos));
+    }
+    if (payload.contacts !== undefined) {
+      dispatch(setContacts(payload.contacts));
     }
     if (payload.recentAddresses !== undefined) {
       dispatch(updateRecentAddresses(payload.recentAddresses));

--- a/docs/ledger-sync/scenarios.md
+++ b/docs/ledger-sync/scenarios.md
@@ -52,6 +52,7 @@ so they stay **linked** (📹) to their Confluence page — the behaviour and it
 | Adding accounts is propagated to other members. | [📹](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/4895866941) | `__tests__/modules/accounts.test.ts`, QA |
 | Removing an account is propagated to other members. | [📹](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/4896849973) | `accounts.test.ts`, QA |
 | Renaming an account is propagated to other members. | [📹](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/4896161884) | `__tests__/modules/accountNames.test.ts`, QA |
+| Creating, updating, or removing Contacts is propagated to other members and restored after an app restart. | — | `domain/entity/contact/src/cloudSync/module.test.ts`, `walletSyncComposition.test.ts`, QA |
 | Wallet Sync recovers after being removed; history reconciliates. | [📹](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/4895965222) | QA |
 | Wallet Sync works even when Ledger Wallet doesn't support a received account (unsupported currency, sync issues): the account is queued, not lost. | [📹](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/4896161894) | `accounts.test.ts` (nonImportedAccountInfos) |
 | Wallet Sync preserves non-imported accounts and restores them when available (backoff retry). | [📹](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/4896620635) | `accounts.test.ts`; see [accounts module](./05-wallet-sync-data-manager.md#the-accounts-module) |

--- a/libs/live-wallet/README.md
+++ b/libs/live-wallet/README.md
@@ -8,7 +8,7 @@ Wallet sync for the account list. This package is scoped to that single concern:
 | Path | Role |
 |---|---|
 | [`src/accounts/`](src/accounts/) | Account list sync module + the `nonImportedAccountInfos` state |
-| [`src/walletSyncComposition.ts`](src/walletSyncComposition.ts) | Assembles the `accounts`, `accountNames` and `recentAddresses` modules into the wallet-sync schema |
+| [`src/walletSyncComposition.ts`](src/walletSyncComposition.ts) | Assembles the `accounts`, `accountNames`, `contacts` and `recentAddresses` modules into the wallet-sync schema |
 
 **Full Ledger Sync stack documentation:** [`docs/ledger-sync`](../../docs/ledger-sync/README.md)
 

--- a/libs/live-wallet/package.json
+++ b/libs/live-wallet/package.json
@@ -20,6 +20,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@domain/entity-account-name": "workspace:*",
+    "@domain/entity-contact": "workspace:*",
     "@domain/entity-currency-crypto": "workspace:*",
     "@domain/entity-recent-addresses": "workspace:*",
     "@ledgerhq/ledger-wallet-framework": "workspace:^",

--- a/libs/live-wallet/src/__tests__/walletSyncComposition.test.ts
+++ b/libs/live-wallet/src/__tests__/walletSyncComposition.test.ts
@@ -1,4 +1,5 @@
 import { of } from "rxjs";
+import { contact, contactsInitialState } from "@domain/entity-contact";
 import type { Account } from "@ledgerhq/types-live";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import {
@@ -23,6 +24,7 @@ function makeLocalState(overrides: Partial<WalletSyncLocalState> = {}): WalletSy
   return {
     accounts: { list: [account1], nonImportedAccountInfos: [] },
     accountNames: new Map([[account1.id, "Local name"]]),
+    contacts: [...contactsInitialState.contacts],
     recentAddresses: { bitcoin: [{ address: "bc1local", lastUsed: 1000 }] },
     ...overrides,
   } as WalletSyncLocalState;
@@ -31,6 +33,7 @@ function makeLocalState(overrides: Partial<WalletSyncLocalState> = {}): WalletSy
 const emptyLocalState = {
   accounts: { list: [], nonImportedAccountInfos: [] },
   accountNames: new Map<string, string>(),
+  contacts: [...contactsInitialState.contacts],
   recentAddresses: {},
 } as unknown as WalletSyncLocalState;
 
@@ -144,6 +147,49 @@ describe("walletsync composition", () => {
       expect(nextState.recentAddresses).toEqual({
         bitcoin: "corrupted by some other app version",
       });
+    });
+  });
+
+  describe("Contacts Wallet Sync registration", () => {
+    const contacts = [
+      ...contactsInitialState.contacts,
+      contact({ id: "contact-ada", isMe: false, name: "Ada", addresses: [] }),
+    ];
+
+    it("serializes and resolves Contacts through the wallet-sync aggregate", async () => {
+      const distant = walletsync.diffLocalToDistant(
+        { ...emptyLocalState, contacts },
+        null,
+      ).nextState;
+
+      expect(distant.contacts).toMatchObject({
+        me: { name: "Me" },
+        contactGroups: [{ id: "contact-ada", name: "Ada" }],
+      });
+
+      await expect(
+        walletsync.resolveIncrementalUpdate(emptyLocalState, null, distant),
+      ).resolves.toMatchObject({
+        hasChanges: true,
+        update: { contacts: { hasChanges: true, update: contacts } },
+      });
+    });
+
+    it("quarantines a corrupted Contacts slice without blocking healthy modules", async () => {
+      const distant = {
+        accountNames: { [account2.id]: "Distant name" },
+        contacts: { me: { name: "Me" }, contactGroups: "invalid" },
+      };
+      const resolved = await walletsync.resolveIncrementalUpdate(makeLocalState(), null, distant);
+
+      expect(resolved).toMatchObject({
+        hasChanges: true,
+        update: {
+          accountNames: { hasChanges: true },
+          contacts: { hasChanges: false },
+        },
+      });
+      expect(onModuleError).toHaveBeenCalledWith("contacts", expect.anything());
     });
   });
 

--- a/libs/live-wallet/src/walletSyncComposition.ts
+++ b/libs/live-wallet/src/walletSyncComposition.ts
@@ -7,6 +7,7 @@ export type {
   DistantDocument,
 } from "@shared/cloud-sync-module";
 import { accountNamesSyncModule } from "@domain/entity-account-name";
+import { contactsSyncModule } from "@domain/entity-contact";
 import { recentAddressesSyncModule } from "@domain/entity-recent-addresses";
 import {
   accountsSyncModule,
@@ -18,6 +19,7 @@ import {
 export const walletSyncSchema = z.object({
   accounts: z.optional(accountsSyncModule.schema),
   accountNames: z.optional(accountNamesSyncModule.schema),
+  contacts: z.optional(contactsSyncModule.schema),
   recentAddresses: z.optional(recentAddressesSyncModule.schema),
 });
 
@@ -29,6 +31,7 @@ export function createWalletsync(
     {
       accounts: bindCtx(ctx),
       accountNames: accountNamesSyncModule,
+      contacts: contactsSyncModule,
       recentAddresses: recentAddressesSyncModule,
     },
     options,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14589,6 +14589,9 @@ importers:
       '@domain/entity-account-name':
         specifier: workspace:*
         version: link:../../domain/entity/account-name
+      '@domain/entity-contact':
+        specifier: workspace:*
+        version: link:../../domain/entity/contact
       '@domain/entity-currency-crypto':
         specifier: workspace:*
         version: link:../../domain/entity/currency-crypto


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Focused Wallet Sync, Desktop reducer, and Mobile reducer tests cover registration, quarantine, and local persistence.
- [x] **Impact of the changes:**
      QA should create, edit, and remove Contacts across Desktop and Mobile Wallet Sync members, then restart each app to confirm Contacts are restored. Invalid Contacts payloads must be quarantined without blocking other Wallet Sync modules.

### 📝 Description

LIVE-33960 registers Contacts in the Wallet Sync aggregate after the module-isolation work in #20555.

Contacts are selected through the public selector, applied with `setContacts` on Desktop and Mobile, and persisted with the Wallet Sync metadata to prevent an app restart from overwriting the distant state. The Desktop encrypted default now includes the Contacts state.

The aggregate test proves Contacts round-trip normally and that an invalid Contacts slice is quarantined while a healthy module continues syncing.

https://github.com/user-attachments/assets/9e994f06-29cf-4975-8d9a-aca5031f5360

https://github.com/user-attachments/assets/1cd17c45-eeb0-4093-ba00-cdc5fd77c4d6

https://github.com/user-attachments/assets/0b47b5f8-609a-4af0-b81e-d27d09f2912d


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-33960
- **Depends on**: #20555 (Wallet Sync module isolation / quarantine)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)