### PR TITLE
[LWD] fix(e2e): stabilize desktop flaky checks

### DIFF
--- a/.changeset/stabilize-desktop-e2e-flakes.md
+++ b/.changeset/stabilize-desktop-e2e-flakes.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Stabilize desktop Playwright settings and DevTools checks.

--- a/apps/ledger-live-desktop/tests/models/LiveAppWebview.ts
+++ b/apps/ledger-live-desktop/tests/models/LiveAppWebview.ts
@@ -116,17 +116,6 @@ export class LiveAppWebview {
   }
 
   async checkDevToolsClosed() {
-    const all = this.electronApp.windows();
-    const titles = await Promise.all(all.map(page => page.title().catch(() => "")));
-    const devToolsIndex = titles.findIndex(title => title === "DevTools");
-    const devtools = devToolsIndex !== -1 ? all[devToolsIndex] : undefined;
-
-    if (devtools) {
-      await devtools.waitForEvent("close", {
-        timeout: this.defaultWebViewTimeout,
-      });
-    }
-
     await expect
       .poll(
         async () => {

--- a/apps/ledger-live-desktop/tests/models/LiveAppWebview.ts
+++ b/apps/ledger-live-desktop/tests/models/LiveAppWebview.ts
@@ -1,10 +1,6 @@
 import { WebviewTag } from "~/renderer/components/Web3AppWebview/types";
 import { ElectronApplication, Locator, Page, expect } from "@playwright/test";
-import {
-  getLiveAppManifest,
-  startDummyServer,
-  stopDummyServer,
-} from "@ledgerhq/test-utils";
+import { getLiveAppManifest, startDummyServer, stopDummyServer } from "@ledgerhq/test-utils";
 import { AppManifest } from "@ledgerhq/live-common/wallet-api/types";
 
 export class LiveAppWebview {
@@ -27,15 +23,13 @@ export class LiveAppWebview {
     this.liveAppDevtools = page.getByTestId("live-app-devtools");
     this.liveAppClose = page.getByTestId("live-app-close");
     this.liveAppLoadingSpinner = page.getByTestId("live-app-loading-spinner");
-    this.selectAssetSearchBar = page.getByTestId(
-      "modular-asset-dialog-search-input"
-    );
+    this.selectAssetSearchBar = page.getByTestId("modular-asset-dialog-search-input");
   }
 
   static async startLiveApp(
     liveAppDirectory: string,
     liveAppManifest: Partial<AppManifest> & Pick<AppManifest, "id">,
-    options: { csp?: string } = {}
+    options: { csp?: string } = {},
   ) {
     try {
       const port = await startDummyServer(`${liveAppDirectory}`, 0, options);
@@ -44,12 +38,10 @@ export class LiveAppWebview {
       const response = await fetch(url);
       if (response.ok) {
         // eslint-disable-next-line no-console
-        console.info(
-          `========> Live app successfully running on port ${port}! <=========`
-        );
+        console.info(`========> Live app successfully running on port ${port}! <=========`);
 
         process.env.MOCK_REMOTE_LIVE_MANIFEST = JSON.stringify(
-          getLiveAppManifest({ ...liveAppManifest, url: url })
+          getLiveAppManifest({ ...liveAppManifest, url: url }),
         );
         return true;
       } else {
@@ -128,9 +120,9 @@ export class LiveAppWebview {
       .poll(
         async () => {
           const windows = this.electronApp.windows();
-          return Promise.all(windows.map((w) => w.title().catch(() => "")));
+          return Promise.all(windows.map(w => w.title().catch(() => "")));
         },
-        { timeout: this.defaultWebViewTimeout }
+        { timeout: this.defaultWebViewTimeout },
       )
       .not.toContain("DevTools");
 
@@ -146,7 +138,7 @@ export class LiveAppWebview {
       const src = await this.webview.getAttribute("src");
       const url = new URL(src ?? "");
       const { dappUrl }: { dappUrl: string | null } = JSON.parse(
-        url.searchParams.get("params") ?? ""
+        url.searchParams.get("params") ?? "",
       );
       return dappUrl;
     } catch {
@@ -331,7 +323,7 @@ export class LiveAppWebview {
       })()
     `;
 
-    return this.page.evaluate((functionToExecute) => {
+    return this.page.evaluate(functionToExecute => {
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       const webview = document.querySelector("webview") as WebviewTag;
       return webview.executeJavaScript(functionToExecute);

--- a/apps/ledger-live-desktop/tests/models/LiveAppWebview.ts
+++ b/apps/ledger-live-desktop/tests/models/LiveAppWebview.ts
@@ -1,6 +1,10 @@
 import { WebviewTag } from "~/renderer/components/Web3AppWebview/types";
 import { ElectronApplication, Locator, Page, expect } from "@playwright/test";
-import { getLiveAppManifest, startDummyServer, stopDummyServer } from "@ledgerhq/test-utils";
+import {
+  getLiveAppManifest,
+  startDummyServer,
+  stopDummyServer,
+} from "@ledgerhq/test-utils";
 import { AppManifest } from "@ledgerhq/live-common/wallet-api/types";
 
 export class LiveAppWebview {
@@ -23,13 +27,15 @@ export class LiveAppWebview {
     this.liveAppDevtools = page.getByTestId("live-app-devtools");
     this.liveAppClose = page.getByTestId("live-app-close");
     this.liveAppLoadingSpinner = page.getByTestId("live-app-loading-spinner");
-    this.selectAssetSearchBar = page.getByTestId("modular-asset-dialog-search-input");
+    this.selectAssetSearchBar = page.getByTestId(
+      "modular-asset-dialog-search-input"
+    );
   }
 
   static async startLiveApp(
     liveAppDirectory: string,
     liveAppManifest: Partial<AppManifest> & Pick<AppManifest, "id">,
-    options: { csp?: string } = {},
+    options: { csp?: string } = {}
   ) {
     try {
       const port = await startDummyServer(`${liveAppDirectory}`, 0, options);
@@ -38,10 +44,12 @@ export class LiveAppWebview {
       const response = await fetch(url);
       if (response.ok) {
         // eslint-disable-next-line no-console
-        console.info(`========> Live app successfully running on port ${port}! <=========`);
+        console.info(
+          `========> Live app successfully running on port ${port}! <=========`
+        );
 
         process.env.MOCK_REMOTE_LIVE_MANIFEST = JSON.stringify(
-          getLiveAppManifest({ ...liveAppManifest, url: url }),
+          getLiveAppManifest({ ...liveAppManifest, url: url })
         );
         return true;
       } else {
@@ -120,9 +128,9 @@ export class LiveAppWebview {
       .poll(
         async () => {
           const windows = this.electronApp.windows();
-          return Promise.all(windows.map(w => w.title().catch(() => "")));
+          return Promise.all(windows.map((w) => w.title().catch(() => "")));
         },
-        { timeout: this.defaultWebViewTimeout },
+        { timeout: this.defaultWebViewTimeout }
       )
       .not.toContain("DevTools");
 
@@ -138,7 +146,7 @@ export class LiveAppWebview {
       const src = await this.webview.getAttribute("src");
       const url = new URL(src ?? "");
       const { dappUrl }: { dappUrl: string | null } = JSON.parse(
-        url.searchParams.get("params") ?? "",
+        url.searchParams.get("params") ?? ""
       );
       return dappUrl;
     } catch {
@@ -323,7 +331,7 @@ export class LiveAppWebview {
       })()
     `;
 
-    return this.page.evaluate(functionToExecute => {
+    return this.page.evaluate((functionToExecute) => {
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       const webview = document.querySelector("webview") as WebviewTag;
       return webview.executeJavaScript(functionToExecute);

--- a/apps/ledger-live-desktop/tests/page/settings.page.ts
+++ b/apps/ledger-live-desktop/tests/page/settings.page.ts
@@ -8,34 +8,46 @@ export class SettingsPage extends AppPage {
   private helpTab = this.page.getByTestId("settings-help-tab");
   readonly experimentalTab = this.page.getByTestId("settings-experimental-tab");
   private developerTab = this.page.getByTestId("settings-developer-tab");
-  private experimentalDevModeToggle = this.page.getByTestId("MANAGER_DEV_MODE-button");
+  private experimentalDevModeToggle = this.page.getByTestId(
+    "MANAGER_DEV_MODE-button"
+  );
   private accountsSection = this.page.getByTestId("hideEmptyTokenAccounts");
   private aboutSection = this.page.getByTestId("version-row");
   private helpSection = this.page.getByTestId("reset-button");
-  private experimentalSection = this.page.locator('[data-e2e="experimental_section_title"]');
+  private experimentalSection = this.page.locator(
+    '[data-e2e="experimental_section_title"]'
+  );
 
   readonly counterValueSelector = this.page.locator(
-    "[data-testid='setting-countervalue-dropDown'] .select__value-container",
+    "[data-testid='setting-countervalue-dropDown'] .select__value-container"
   );
   private counterValueSearchBar = this.page.locator('[placeholder="Search"]');
   private counterValueropdownChoiceEuro = this.page.locator(".select__option");
   readonly languageSelector = this.page.locator(
-    "[data-testid='setting-language-dropDown'] .select__value-container",
+    "[data-testid='setting-language-dropDown'] .select__value-container"
   );
   readonly themeSelector = this.page.locator(
-    "[data-testid='setting-theme-dropDown'] .select__value-container",
+    "[data-testid='setting-theme-dropDown'] .select__value-container"
   );
   private themeChoiceLight = this.page.locator("text='Clair'");
   private versionRow = this.page.getByTestId("version-row");
-  private deviceLanguagesDrawer = this.page.getByTestId("device-language-installation-container");
-  readonly openLocalManifestFormButton = this.page.getByTestId("settings-open-local-manifest-form");
-  readonly exportLocalManifestButton = this.page.getByTestId("settings-export-local-manifest");
-  readonly createLocalManifestButton = this.page.getByTestId("create-local-manifest");
+  private deviceLanguagesDrawer = this.page.getByTestId(
+    "device-language-installation-container"
+  );
+  readonly openLocalManifestFormButton = this.page.getByTestId(
+    "settings-open-local-manifest-form"
+  );
+  readonly exportLocalManifestButton = this.page.getByTestId(
+    "settings-export-local-manifest"
+  );
+  readonly createLocalManifestButton = this.page.getByTestId(
+    "create-local-manifest"
+  );
   readonly neverAskAgainSkipMemoSwitch = this.page.getByTestId(
-    "settings-never-ask-again-skip-memo-switch",
+    "settings-never-ask-again-skip-memo-switch"
   );
   readonly filterTokenOperationsZeroAmountToggle = this.page.getByTestId(
-    "switch-filter-token-operations-zero-amount",
+    "switch-filter-token-operations-zero-amount"
   );
 
   @step("Go to Settings Accounts tab")
@@ -76,7 +88,9 @@ export class SettingsPage extends AppPage {
   }
 
   async isFilterTokenOperationsZeroAmountToggleChecked() {
-    return await this.filterTokenOperationsZeroAmountToggle.locator("input").isChecked();
+    return await this.filterTokenOperationsZeroAmountToggle
+      .locator("input")
+      .isChecked();
   }
 
   @step("Change counter value to $0")
@@ -102,7 +116,9 @@ export class SettingsPage extends AppPage {
   }
 
   async waitForDeviceLanguagesLoaded() {
-    await this.page.waitForSelector('[aria-label="Select language"]', { state: "attached" });
+    await this.page.waitForSelector('[aria-label="Select language"]', {
+      state: "attached",
+    });
   }
 
   async waitForDeviceLauguagesDrawer() {

--- a/apps/ledger-live-desktop/tests/page/settings.page.ts
+++ b/apps/ledger-live-desktop/tests/page/settings.page.ts
@@ -8,46 +8,34 @@ export class SettingsPage extends AppPage {
   private helpTab = this.page.getByTestId("settings-help-tab");
   readonly experimentalTab = this.page.getByTestId("settings-experimental-tab");
   private developerTab = this.page.getByTestId("settings-developer-tab");
-  private experimentalDevModeToggle = this.page.getByTestId(
-    "MANAGER_DEV_MODE-button"
-  );
+  private experimentalDevModeToggle = this.page.getByTestId("MANAGER_DEV_MODE-button");
   private accountsSection = this.page.getByTestId("hideEmptyTokenAccounts");
   private aboutSection = this.page.getByTestId("version-row");
   private helpSection = this.page.getByTestId("reset-button");
-  private experimentalSection = this.page.locator(
-    '[data-e2e="experimental_section_title"]'
-  );
+  private experimentalSection = this.page.locator('[data-e2e="experimental_section_title"]');
 
   readonly counterValueSelector = this.page.locator(
-    "[data-testid='setting-countervalue-dropDown'] .select__value-container"
+    "[data-testid='setting-countervalue-dropDown'] .select__value-container",
   );
   private counterValueSearchBar = this.page.locator('[placeholder="Search"]');
   private counterValueropdownChoiceEuro = this.page.locator(".select__option");
   readonly languageSelector = this.page.locator(
-    "[data-testid='setting-language-dropDown'] .select__value-container"
+    "[data-testid='setting-language-dropDown'] .select__value-container",
   );
   readonly themeSelector = this.page.locator(
-    "[data-testid='setting-theme-dropDown'] .select__value-container"
+    "[data-testid='setting-theme-dropDown'] .select__value-container",
   );
   private themeChoiceLight = this.page.locator("text='Clair'");
   private versionRow = this.page.getByTestId("version-row");
-  private deviceLanguagesDrawer = this.page.getByTestId(
-    "device-language-installation-container"
-  );
-  readonly openLocalManifestFormButton = this.page.getByTestId(
-    "settings-open-local-manifest-form"
-  );
-  readonly exportLocalManifestButton = this.page.getByTestId(
-    "settings-export-local-manifest"
-  );
-  readonly createLocalManifestButton = this.page.getByTestId(
-    "create-local-manifest"
-  );
+  private deviceLanguagesDrawer = this.page.getByTestId("device-language-installation-container");
+  readonly openLocalManifestFormButton = this.page.getByTestId("settings-open-local-manifest-form");
+  readonly exportLocalManifestButton = this.page.getByTestId("settings-export-local-manifest");
+  readonly createLocalManifestButton = this.page.getByTestId("create-local-manifest");
   readonly neverAskAgainSkipMemoSwitch = this.page.getByTestId(
-    "settings-never-ask-again-skip-memo-switch"
+    "settings-never-ask-again-skip-memo-switch",
   );
   readonly filterTokenOperationsZeroAmountToggle = this.page.getByTestId(
-    "switch-filter-token-operations-zero-amount"
+    "switch-filter-token-operations-zero-amount",
   );
 
   @step("Go to Settings Accounts tab")
@@ -88,9 +76,7 @@ export class SettingsPage extends AppPage {
   }
 
   async isFilterTokenOperationsZeroAmountToggleChecked() {
-    return await this.filterTokenOperationsZeroAmountToggle
-      .locator("input")
-      .isChecked();
+    return await this.filterTokenOperationsZeroAmountToggle.locator("input").isChecked();
   }
 
   @step("Change counter value to $0")

--- a/apps/ledger-live-desktop/tests/page/settings.page.ts
+++ b/apps/ledger-live-desktop/tests/page/settings.page.ts
@@ -9,6 +9,10 @@ export class SettingsPage extends AppPage {
   readonly experimentalTab = this.page.getByTestId("settings-experimental-tab");
   private developerTab = this.page.getByTestId("settings-developer-tab");
   private experimentalDevModeToggle = this.page.getByTestId("MANAGER_DEV_MODE-button");
+  private accountsSection = this.page.getByTestId("hideEmptyTokenAccounts");
+  private aboutSection = this.page.getByTestId("version-row");
+  private helpSection = this.page.getByTestId("reset-button");
+  private experimentalSection = this.page.locator('[data-e2e="experimental_section_title"]');
 
   readonly counterValueSelector = this.page.locator(
     "[data-testid='setting-countervalue-dropDown'] .select__value-container",
@@ -37,21 +41,25 @@ export class SettingsPage extends AppPage {
   @step("Go to Settings Accounts tab")
   async goToAccountsTab() {
     await this.accountsTab.click();
+    await this.accountsSection.waitFor({ state: "visible" });
   }
 
   @step("Go to Settings About tab")
   async goToAboutTab() {
     await this.aboutTab.click();
+    await this.aboutSection.waitFor({ state: "visible" });
   }
 
   @step("Go to Settings Help tab")
   async goToHelpTab() {
     await this.helpTab.click();
+    await this.helpSection.waitFor({ state: "visible" });
   }
 
   @step("Go to Settings Experimental tab")
   async goToExperimentalTab() {
     await this.experimentalTab.click();
+    await this.experimentalSection.waitFor({ state: "visible" });
   }
 
   async changeLanguage(fromLanguage: string, toLanguage: string) {

--- a/apps/ledger-live-desktop/tests/specs/settings/modal-create-manifest.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/settings/modal-create-manifest.spec.ts
@@ -28,9 +28,7 @@ test("Settings", async ({ page }) => {
 
   await test.step("create local manifest", async () => {
     await settingsPage.createLocalManifestButton.click();
-    await expect(page.getByText("ReplaceAppName", { exact: true })).toBeVisible(
-      { timeout: 60000 }
-    );
+    await expect(page.getByText("ReplaceAppName", { exact: true })).toBeVisible({ timeout: 60000 });
   });
 
   await test.step("export the local manifest", async () => {

--- a/apps/ledger-live-desktop/tests/specs/settings/modal-create-manifest.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/settings/modal-create-manifest.spec.ts
@@ -27,7 +27,7 @@ test("Settings", async ({ page }) => {
   await test.step("create local manifest", async () => {
     await settingsPage.createLocalManifestButton.click();
     await expect(
-      page.getByText("ReplaceAppName").or(page.locator('input[value="ReplaceAppName"]')),
+      page.getByText("ReplaceAppName", { exact: true }),
     ).toBeVisible({ timeout: 60000 });
   });
 

--- a/apps/ledger-live-desktop/tests/specs/settings/modal-create-manifest.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/settings/modal-create-manifest.spec.ts
@@ -19,16 +19,18 @@ test("Settings", async ({ page }) => {
   });
 
   await test.step("open modal local manifest form creation", async () => {
-    await settingsPage.openLocalManifestFormButton.waitFor({ state: "visible" });
+    await settingsPage.openLocalManifestFormButton.waitFor({
+      state: "visible",
+    });
     await settingsPage.openLocalManifestFormButton.click();
     await settingsPage.createLocalManifestButton.waitFor({ state: "visible" });
   });
 
   await test.step("create local manifest", async () => {
     await settingsPage.createLocalManifestButton.click();
-    await expect(
-      page.getByText("ReplaceAppName", { exact: true }),
-    ).toBeVisible({ timeout: 60000 });
+    await expect(page.getByText("ReplaceAppName", { exact: true })).toBeVisible(
+      { timeout: 60000 }
+    );
   });
 
   await test.step("export the local manifest", async () => {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** The Settings and local manifest Playwright scenarios pass when run serially; the DevTools scenario also passes after building the dummy Wallet API app.
- [x] **Impact of the changes:**
      Stabilizes Desktop Playwright checks for Settings tab screenshots, local manifest creation, and Live App DevTools closure.

### 📝 Description

This PR addresses three flaky Desktop Playwright checks reported by the flake triage tool.

It waits for each Settings pane before taking screenshots, uses a strict locator for the created local manifest, and verifies DevTools closure by polling the observable window state rather than waiting for an event that may already have fired.

### ❓ Context

- **JIRA or GitHub link**: N/A — Flake triage report.

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the flake triage report.
- **The PR description clearly documents the changes** made and explains the test synchronization choices.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and the affected scenarios have been exercised locally.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)