### PR TITLE
ci(support): expand hotfix permissions

### DIFF
--- a/.github/workflows/release-create-hotfix.yml
+++ b/.github/workflows/release-create-hotfix.yml
@@ -29,6 +29,7 @@ jobs:
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
+          permission-workflows: write
 
       - name: Generate ref/tag version to use during main checkout
         uses: LedgerHQ/ledger-live/tools/actions/composites/generate-tag@develop


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Adjust hotfix creation permissions to avoid issues with the github bot

When creating a hotfix the workflows diverge with develop as they are taken from release origin. With github bot permissions, there's an explicit permission that is required to modify these files, even if the resultant back-merge is essentially no-op