### PR TITLE
test(e2e-mobile): add borrow open-loan e2e test (QAA-1477)

### DIFF
--- a/e2e/mobile/helpers/broadcastRotation.ts
+++ b/e2e/mobile/helpers/broadcastRotation.ts
@@ -8,7 +8,7 @@
 
 const PLATFORM_SLOTS = ["ios", "android"] as const;
 
-export const BroadcastFlow = { APPROVAL: 0, REAPPROVAL: 1 } as const;
+export const BroadcastFlow = { APPROVAL: 0, REAPPROVAL: 1, BORROW: 2 } as const;
 export type BroadcastFlow = (typeof BroadcastFlow)[keyof typeof BroadcastFlow];
 
 const MONDAY_EPOCH_UTC_MS = Date.UTC(2024, 0, 1);

--- a/e2e/mobile/page/trade/borrow.page.ts
+++ b/e2e/mobile/page/trade/borrow.page.ts
@@ -1,5 +1,4 @@
 import { Step } from "jest-allure2-reporter/api";
-import { delay } from "../../helpers/commonHelpers";
 import { WebElementHelpers } from "../../helpers/elementHelpers";
 import { retryUntilTimeout } from "../../utils/retry";
 
@@ -8,7 +7,6 @@ const CONTINUE_READY_TIMEOUT_MS = 30_000;
 /** The partner prepares each transaction server-side, so the CTA stays disabled meanwhile. */
 const EXECUTION_STEP_TIMEOUT_MS = 240_000;
 const PROBE_TIMEOUT_MS = 2_000;
-const POLL_INTERVAL_MS = 500;
 
 const MAINNET_FUNDING_HINT =
   "Ensure the test account holds enough wBTC collateral and ETH for mainnet gas.";
@@ -94,7 +92,7 @@ export default class BorrowPage {
         (el: HTMLElement) => el.innerText,
       ),
     );
-    if (!new RegExp(`Loan to Value[^\\d]*${percentage}`).test(screenText)) {
+    if (!new RegExp(String.raw`Loan to Value[^\d]*${percentage}`).test(screenText)) {
       throw new Error(
         `Expected a loan to value of ${percentage} but the simulate-loan screen showed: ${screenText.replace(/\n+/g, " | ")}`,
       );
@@ -175,21 +173,19 @@ export default class BorrowPage {
   }
 
   private async expectStepDone(doneId: string) {
-    const deadline = Date.now() + EXECUTION_STEP_TIMEOUT_MS;
-    while (Date.now() < deadline) {
-      if (await this.isPresent(doneId)) return;
-      if (await this.isExecutionErrorVisible()) {
-        throw new Error(`Borrow execution failed before "${doneId}". ${MAINNET_FUNDING_HINT}`);
-      }
-      await delay(POLL_INTERVAL_MS);
+    await device.disableSynchronization();
+    try {
+      await waitWebElementByTestId(doneId, { timeout: EXECUTION_STEP_TIMEOUT_MS });
+    } catch {
+      const executionFailed = await this.isExecutionErrorVisible();
+      throw new Error(
+        executionFailed
+          ? `Borrow execution failed before "${doneId}". ${MAINNET_FUNDING_HINT}`
+          : `Borrow step "${doneId}" did not complete within ${EXECUTION_STEP_TIMEOUT_MS}ms. ${MAINNET_FUNDING_HINT}`,
+      );
+    } finally {
+      await device.enableSynchronization();
     }
-    throw new Error(
-      `Borrow step "${doneId}" did not complete within ${EXECUTION_STEP_TIMEOUT_MS}ms. ${MAINNET_FUNDING_HINT}`,
-    );
-  }
-
-  private async isPresent(testId: string): Promise<boolean> {
-    return !!(await waitWebElement(getWebElementByTestId(testId), PROBE_TIMEOUT_MS, false));
   }
 
   private async isExecutionErrorVisible(): Promise<boolean> {

--- a/e2e/mobile/page/trade/borrow.page.ts
+++ b/e2e/mobile/page/trade/borrow.page.ts
@@ -1,11 +1,45 @@
 import { Step } from "jest-allure2-reporter/api";
+import { delay } from "../../helpers/commonHelpers";
+import { WebElementHelpers } from "../../helpers/elementHelpers";
+import { retryUntilTimeout } from "../../utils/retry";
+
+const MODAL_DISMISS_TIMEOUT_MS = 30_000;
+const CONTINUE_READY_TIMEOUT_MS = 30_000;
+/** The partner prepares each transaction server-side, so the CTA stays disabled meanwhile. */
+const EXECUTION_STEP_TIMEOUT_MS = 240_000;
+const PROBE_TIMEOUT_MS = 2_000;
+const POLL_INTERVAL_MS = 500;
+
+const MAINNET_FUNDING_HINT =
+  "Ensure the test account holds enough wBTC collateral and ETH for mainnet gas.";
 
 export default class BorrowPage {
   private readonly borrowScreenId = "borrow-screen";
-
-  // Mirrors borrow-live-app packages/features/src/testIds.ts
   private readonly introModalId = "borrow-intro-modal";
   private readonly introModalTitleId = "borrow-intro-modal-title";
+  private readonly simulateMyLoanButtonId = "borrow-simulate-my-loan-button";
+  private readonly simulateLoanScreenId = "borrow-simulate-loan-screen";
+  private readonly loanAmountInputId = "borrow-loan-amount-input";
+  private readonly simulateContinueButtonId = "borrow-simulate-continue-button";
+  private readonly loanExecutionScreenId = "borrow-loan-execution-screen";
+  private readonly giveApprovalButtonId = "give-approval-button";
+  private readonly authorizeDepositingButtonId = "borrow-authorize-depositing-button";
+  private readonly authorizeBorrowingButtonId = "borrow-authorize-borrowing-button";
+  private readonly step1AccessApprovedId = "borrow-step-1-access-approved";
+  private readonly step2DepositDoneId = "borrow-step-2-deposit-done";
+  private readonly loanCompletionCardId = "borrow-loan-completion-card";
+  private readonly viewMyLoanButtonId = "borrow-view-my-loan-button";
+  private readonly yourLoansTitleId = "borrow-your-loans-title";
+  private readonly loansDashboardId = "borrow-loans-dashboard";
+  private readonly loanDashboardRowId = "borrow-loan-dashboard-row";
+  private readonly executionErrorLocator =
+    '[data-testid="borrow-execution-error"], [data-testid="borrow-on-chain-failed-message"]';
+
+  /** The collateral row carries no test id, so it is matched on its symbol. */
+  private readonly symbolButtonXpath = (symbol: string) =>
+    `//*[(self::button or @role='button') and normalize-space(.)='${symbol}']`;
+
+  private readonly keypadDigitTestId = (digit: string) => `custom-keyboard-key-${digit}`;
 
   @Step("Expect borrow native screen visible")
   async expectBorrowScreenVisible() {
@@ -17,7 +51,152 @@ export default class BorrowPage {
   @Step("Expect the Introducing Crypto Loan modal")
   async expectIntroModal() {
     await waitWebElementByTestId(this.introModalId);
-    await detoxExpect(getWebElementByTestId(this.introModalId)).toExist();
-    await detoxExpect(getWebElementByTestId(this.introModalTitleId)).toExist();
+    await waitWebElementByTestId(this.introModalTitleId);
+  }
+
+  @Step("Click Simulate my loan on the intro modal")
+  async clickSimulateMyLoan() {
+    await this.revealAndTap(this.simulateMyLoanButtonId);
+    await retryUntilTimeout(
+      () => expectWebElementNotVisible(this.introModalId),
+      MODAL_DISMISS_TIMEOUT_MS,
+    );
+  }
+
+  @Step("Expect the simulate-loan screen")
+  async expectSimulateLoanScreen() {
+    await waitForCurrentWebviewUrlToContain("/loan/simulate-loan");
+    await waitWebElementByTestId(this.simulateLoanScreenId);
+    await waitWebElementByTestId(this.loanAmountInputId);
+  }
+
+  /** The amount input is read-only; the value is driven by the keypad. */
+  @Step("Type loan amount")
+  async typeLoanAmount(amount: string) {
+    await waitWebElementByTestId(this.simulateLoanScreenId);
+    for (const digit of amount) {
+      await this.revealAndTap(this.keypadDigitTestId(digit));
+    }
+    await waitForWebElementToBeEnabled(this.simulateContinueButtonId, CONTINUE_READY_TIMEOUT_MS);
+  }
+
+  @Step("Expect the required collateral")
+  async expectCollateral(symbol: string) {
+    await waitWebElement(getWebElementByXpath(this.symbolButtonXpath(symbol)));
+  }
+
+  /** The LTV row carries no test id, so it is read off the rendered simulate-loan text. */
+  @Step("Expect the loan to value")
+  async expectLoanToValue(percentage: string) {
+    await waitWebElementByTestId(this.simulateLoanScreenId);
+    const screenText = String(
+      await WebElementHelpers.getWebElementByTag("body").runScript(
+        (el: HTMLElement) => el.innerText,
+      ),
+    );
+    if (!new RegExp(`Loan to Value[^\\d]*${percentage}`).test(screenText)) {
+      throw new Error(
+        `Expected a loan to value of ${percentage} but the simulate-loan screen showed: ${screenText.replace(/\n+/g, " | ")}`,
+      );
+    }
+  }
+
+  @Step("Click Continue on the simulate-loan screen")
+  async clickContinue() {
+    await this.revealAndTap(this.simulateContinueButtonId, CONTINUE_READY_TIMEOUT_MS);
+  }
+
+  @Step("Expect the loan execution screen")
+  async expectExecutionScreen() {
+    await waitForCurrentWebviewUrlToContain("/loan/loan-execution");
+    await waitWebElementByTestId(this.loanExecutionScreenId);
+  }
+
+  @Step("Give approval and sign on device")
+  async completeApprovalStep() {
+    await this.authorizeStep(this.giveApprovalButtonId, this.step1AccessApprovedId, () =>
+      this.signContractTransaction(),
+    );
+  }
+
+  @Step("Authorize depositing and sign on device")
+  async authorizeDeposit() {
+    await this.authorizeStep(this.authorizeDepositingButtonId, this.step2DepositDoneId, () =>
+      this.signContractTransaction(),
+    );
+  }
+
+  /** Completing the last step leaves the execution screen, so the terminal card is the marker. */
+  @Step("Authorize borrowing and sign on device")
+  async authorizeBorrow() {
+    await this.authorizeStep(this.authorizeBorrowingButtonId, this.loanCompletionCardId, () =>
+      this.signContractTransaction(),
+    );
+    await waitWebElementByTestId(this.viewMyLoanButtonId);
+  }
+
+  @Step("Click View my loan")
+  async clickViewMyLoan() {
+    await this.revealAndTap(this.viewMyLoanButtonId);
+  }
+
+  @Step("Expect loans dashboard visible")
+  async expectLoansDashboard() {
+    await waitWebElementByTestId(this.yourLoansTitleId);
+    await waitWebElementByTestId(this.loansDashboardId);
+  }
+
+  @Step("Expect at least one loan row on the dashboard")
+  async expectLoanDashboardRow() {
+    await waitWebElementByTestId(this.loanDashboardRowId);
+  }
+
+  /** Asserting the marker is absent first makes the wait afterwards proof that the step ran. */
+  private async authorizeStep(buttonId: string, doneId: string, sign: () => Promise<void>) {
+    await waitWebElementByTestId(this.loanExecutionScreenId);
+    await expectWebElementNotVisible(doneId);
+    await this.revealAndTap(buttonId, EXECUTION_STEP_TIMEOUT_MS);
+    await waitForElementById(app.send.summaryContinueEnabledButtonId);
+    await app.send.summaryContinue();
+    await sign();
+    await this.expectStepDone(doneId);
+  }
+
+  private async signContractTransaction() {
+    await app.speculos.acceptEnableTransactionCheck();
+    await app.speculos.signEvmContractTransaction();
+  }
+
+  /** Scrolls the target into view before tapping, so a partly-offscreen CTA is never tapped. */
+  private async revealAndTap(testId: string, timeout?: number) {
+    await waitForWebElementToBeEnabled(testId, timeout);
+    await scrollToWebElement(getWebElementByTestId(testId));
+    await tapWebElementByTestId(testId);
+  }
+
+  private async expectStepDone(doneId: string) {
+    const deadline = Date.now() + EXECUTION_STEP_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      if (await this.isPresent(doneId)) return;
+      if (await this.isExecutionErrorVisible()) {
+        throw new Error(`Borrow execution failed before "${doneId}". ${MAINNET_FUNDING_HINT}`);
+      }
+      await delay(POLL_INTERVAL_MS);
+    }
+    throw new Error(
+      `Borrow step "${doneId}" did not complete within ${EXECUTION_STEP_TIMEOUT_MS}ms. ${MAINNET_FUNDING_HINT}`,
+    );
+  }
+
+  private async isPresent(testId: string): Promise<boolean> {
+    return !!(await waitWebElement(getWebElementByTestId(testId), PROBE_TIMEOUT_MS, false));
+  }
+
+  private async isExecutionErrorVisible(): Promise<boolean> {
+    return !!(await waitWebElement(
+      getWebElementByCssSelector(this.executionErrorLocator),
+      PROBE_TIMEOUT_MS,
+      false,
+    ));
   }
 }

--- a/e2e/mobile/specs/borrow/borrow.openLoan.spec.ts
+++ b/e2e/mobile/specs/borrow/borrow.openLoan.spec.ts
@@ -1,0 +1,90 @@
+import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
+import { swapSetup } from "../../bridge/server";
+import { DEFAULT_LOAN, resetLoanState } from "@ledgerhq/live-e2e-shared/borrow/borrowSetup";
+import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
+import { setTeamOwner } from "../../helpers/allure/allure-helper";
+import { BroadcastFlow, shouldRunBroadcastFlow } from "../../helpers/broadcastRotation";
+import { NANO_APP_CATALOG_PATH } from "../../utils/constants";
+import { FF_BORROW_ENABLED } from "../../utils/featureFlagUtils";
+
+const loanAccount = Account.ETH_4;
+const COLLATERAL_SYMBOL = "wBTC";
+const EXPECTED_LTV = "50%";
+
+/** Three mainnet transactions, each with its own on-chain budget, exceed the 360s jest default. */
+const BORROW_TIMEOUT_MS = 600_000;
+const borrowSetupOptions = { nanoAppCatalogPath: NANO_APP_CATALOG_PATH };
+
+/**
+ * Opening a loan is three mainnet transactions on a shared account, so it runs only on the
+ * broadcast lane and only on the one platform this run assigns it.
+ */
+(shouldRunBroadcastFlow(BroadcastFlow.BORROW) ? describe : describe.skip)(
+  "Borrow - Open loan",
+  () => {
+    beforeAll(async () => {
+      await resetLoanState(borrowSetupOptions);
+      await app.init({
+        userdata: "skip-onboarding-with-last-seen-device",
+        speculosApp: loanAccount.currency.speculosApp,
+        featureFlags: FF_BORROW_ENABLED,
+        cliCommandsOnApp: [
+          {
+            app: loanAccount.currency.speculosApp,
+            cmd: liveDataWithAddressCommand(loanAccount),
+          },
+        ],
+      });
+      // Sets SWAP_DISABLE_APPS_INSTALL: without it connectApp quits the Ethereum app to reach the
+      // dashboard, which terminates the single-app Speculos container.
+      await swapSetup();
+      await app.mainNavigation.openPortfolioViaDeeplink();
+    }, BORROW_TIMEOUT_MS);
+
+    afterAll(async () => {
+      try {
+        await resetLoanState(borrowSetupOptions);
+      } catch (error) {
+        console.error(
+          `[borrow] open-loan cleanup failed — ${loanAccount.accountName} may still hold a position:`,
+          error,
+        );
+      }
+    }, BORROW_TIMEOUT_MS);
+
+    setTeamOwner(Team.EARN);
+    $TmsLink("B2CQA-6065");
+    ["@NanoSP", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@ethereum", "@family-evm"].forEach(tag =>
+      $Tag(tag),
+    );
+
+    it(
+      "should open a loan with wBTC collateral through approval, deposit and borrow",
+      async () => {
+        await app.portfolio.expectBorrowEntryPointVisible();
+        await app.portfolio.clickBorrowEntryPoint();
+        await app.borrow.expectBorrowScreenVisible();
+
+        await app.borrow.expectIntroModal();
+        await app.borrow.clickSimulateMyLoan();
+        await app.borrow.expectSimulateLoanScreen();
+
+        await app.borrow.typeLoanAmount(DEFAULT_LOAN);
+        await app.borrow.expectCollateral(COLLATERAL_SYMBOL);
+        await app.borrow.expectLoanToValue(EXPECTED_LTV);
+
+        await app.borrow.clickContinue();
+        await app.borrow.expectExecutionScreen();
+
+        await app.borrow.completeApprovalStep();
+        await app.borrow.authorizeDeposit();
+        await app.borrow.authorizeBorrow();
+
+        await app.borrow.clickViewMyLoan();
+        await app.borrow.expectLoansDashboard();
+        await app.borrow.expectLoanDashboardRow();
+      },
+      BORROW_TIMEOUT_MS,
+    );
+  },
+);

--- a/e2e/mobile/specs/borrow/borrow.openLoan.spec.ts
+++ b/e2e/mobile/specs/borrow/borrow.openLoan.spec.ts
@@ -82,7 +82,7 @@ const borrowSetupOptions = { nanoAppCatalogPath: NANO_APP_CATALOG_PATH };
 
         await app.borrow.clickViewMyLoan();
         await app.borrow.expectLoansDashboard();
-        await app.borrow.expectLoanDashboardRow();
+        await expect(app.borrow.expectLoanDashboardRow()).resolves.toBeUndefined();
       },
       BORROW_TIMEOUT_MS,
     );

--- a/e2e/mobile/utils/featureFlagUtils.ts
+++ b/e2e/mobile/utils/featureFlagUtils.ts
@@ -49,6 +49,11 @@ export const FF_BORROW_ENABLED = {
     enabled: true,
     params: { manifest_id: "borrow" },
   },
+  largeScreenUpsell: { enabled: false },
+  // Note: Prevent usage of DIE, which is not Speculos ready yet. The device-intent drawer bypasses
+  // the SignTransaction screens, so it also ignores the SWAP_DISABLE_APPS_INSTALL bypass swapSetup
+  // installs; leaving this to Firebase would make signing non-deterministic.
+  llmWalletApiDeviceIntentSign: { enabled: false },
   lwmWallet40: {
     ...FF_LWM_WALLET_40_Q2.lwmWallet40,
     params: {


### PR DESCRIPTION
## Summary

Adds the mobile E2E spec for the borrow open-loan flow (B2CQA-6065), bringing LWM to parity with the existing LWD `borrow.spec.ts`.

### What the test covers

1. **Entry** — scrolls to the borrow card on portfolio and taps it via `revealForTap`
2. **Simulate-loan screen** — types the loan amount via the keypad, asserts collateral symbol (wBTC) and LTV (50%)
3. **Execution flow** — three on-chain steps, each: CTA → SignTransaction summary → Speculos sign
   - Step 1: token approval (`acceptEnableTransactionCheck` + `signEvmContractTransaction`)
   - Step 2: authorize depositing collateral
   - Step 3: authorize borrowing USDT
4. **View my loan** — taps the completion-card CTA, asserts the loans dashboard (`borrow-your-loans-title`, `borrow-loans-dashboard`, `borrow-loan-dashboard-row`)

### Supporting changes

| File | Change |
|---|---|
| `broadcastRotation.ts` | Added `BORROW: 2` so the flow rotates between iOS and Android in mixed-platform runs |
| `featureFlagUtils.ts` | Added `largeScreenUpsell: false` and `llmWalletApiDeviceIntentSign: false` to `FF_BORROW_ENABLED` — DIE bypasses the `SWAP_DISABLE_APPS_INSTALL` guard set by `swapSetup()` |
| `borrow.page.ts` | Full page object for the open-loan flow |

### Hooks

- **beforeAll** — `resetLoanState` closes any leftover position on ETH\_4, then inits the app with Speculos + FF overrides + `swapSetup`
- **afterAll** — `resetLoanState` cleans up the opened position (repay + withdraw via e2e-cli)

### Run results (local, `DISABLE_TRANSACTION_BROADCAST=0`, nanoSP)

| Platform | Result | Duration |
|---|---|---|
| iOS (sim debug) | ✅ PASS | 366 s |
| Android (emu release) | ✅ PASS | 301 s |

Relates to [QAA-1477](https://ledgerhq.atlassian.net/browse/QAA-1477) · TMS: B2CQA-6065

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[QAA-1477]: https://ledgerhq.atlassian.net/browse/QAA-1477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## 🧪 CI run

| Workflow | Scope | Run |
|---|---|---|
| [Mobile] E2E Only | `@family-evm`, iOS & Android, nanoSP, broadcast enabled | [run 32731755988](https://github.com/LedgerHQ/ledger-live/actions/runs/32731755988) |