### PR TITLE
fix(e2e): split borrow withdraw flow into its own describe block

### DIFF
--- a/e2e/desktop/tests/page/borrow.page.ts
+++ b/e2e/desktop/tests/page/borrow.page.ts
@@ -318,6 +318,12 @@ export class BorrowPage extends WebViewAppPage {
 
   @step("Click Authorize withdrawal")
   async clickAuthorizeWithdraw() {
+    const webview = await this.getWebView();
+    if (await webview.getByTestId(this.executionErrorDialog).isVisible()) {
+      throw new Error(
+        `borrow-execution-error dialog is visible before authorize withdraw — Speculos or provider state is inconsistent. ${FUNDING_HINT}`,
+      );
+    }
     await this.clickWhenEnabled(this.authorizeWithdraw);
   }
 

--- a/e2e/desktop/tests/page/borrow.page.ts
+++ b/e2e/desktop/tests/page/borrow.page.ts
@@ -319,12 +319,14 @@ export class BorrowPage extends WebViewAppPage {
   @step("Click Authorize withdrawal")
   async clickAuthorizeWithdraw() {
     const webview = await this.getWebView();
-    if (await webview.getByTestId(this.executionErrorDialog).isVisible()) {
+    if (await webview.getByTestId(this.executionErrorDialog).first().isVisible()) {
       throw new Error(
         `borrow-execution-error dialog is visible before authorize withdraw — Speculos or provider state is inconsistent. ${FUNDING_HINT}`,
       );
     }
-    await this.clickWhenEnabled(this.authorizeWithdraw);
+    const button = webview.getByTestId(this.authorizeWithdraw);
+    await expect(button).toBeEnabled();
+    await button.click();
   }
 
   @step("Click Continue on host sign modal")

--- a/e2e/desktop/tests/specs/borrow.spec.ts
+++ b/e2e/desktop/tests/specs/borrow.spec.ts
@@ -167,7 +167,7 @@ test.describe("Borrow", () => {
 });
 
 test.describe("Borrow", () => {
-  useBorrowOnChain("Repay/withdraw flows");
+  useBorrowOnChain("Repay flow");
 
   test.beforeAll(async () => {
     test.setTimeout(BORROW_HOOK_TIMEOUT_MS * 2);
@@ -224,6 +224,20 @@ test.describe("Borrow", () => {
       await app.borrow.expectRepaySuccess();
     },
   );
+});
+
+test.describe("Borrow", () => {
+  useBorrowOnChain("Withdraw flow");
+
+  test.beforeAll(async () => {
+    test.setTimeout(BORROW_HOOK_TIMEOUT_MS * 2);
+    await ensureWithdrawReadyForUi({ nanoAppCatalogPath: NANO_APP_CATALOG });
+  });
+
+  test.afterAll(async () => {
+    test.setTimeout(BORROW_HOOK_TIMEOUT_MS);
+    await resetLoanState({ nanoAppCatalogPath: NANO_APP_CATALOG });
+  });
 
   test(
     `[${openLoanAccount.currency.testLabel}] - Borrow hot start routes a repaid loan to withdraw and completes collateral withdrawal`,
@@ -234,8 +248,6 @@ test.describe("Borrow", () => {
     async ({ app }) => {
       test.setTimeout(BORROW_TEST_TIMEOUT_MS);
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
-      await ensureWithdrawReadyForUi({ nanoAppCatalogPath: NANO_APP_CATALOG });
 
       await app.mainNavigation.openTargetFromMainNavigation("home");
       await app.portfolio.expectBorrowEntryPointVisible();


### PR DESCRIPTION
### 📝 Description

`[ETH] - Borrow hot start routes a repaid loan to withdraw and completes collateral withdrawal` was flaking on CI with `ECONNREFUSED` on the Speculos port during the withdraw signing step.

**Root cause:** `ensureWithdrawReadyForUi()` was called inside the test body. When the position still had debt, this function booted a Speculos instance to repay on-chain, then tore it down — immediately before `completeHostDeviceSignature(signWithdrawOnDevice)` booted a second Speculos instance. The rapid teardown → re-boot cycle caused connection refusals, which made the borrow live app display a provider error dialog that blocked all further UI interaction until the 60 s timeout expired.

**Fix:** Split the shared `"Repay/withdraw flows"` describe block into two independent describe blocks:
- `"Repay flow"` — `beforeAll: ensureRepayTestPrecondition()` (unchanged logic)
- `"Withdraw flow"` — `beforeAll: ensureWithdrawReadyForUi()`, removing the in-test call

All Speculos setup is now confined to `beforeAll`, before Playwright starts the app, eliminating the lifecycle race.

Also added a fast-fail guard in `clickAuthorizeWithdraw()`: if `borrow-execution-error` is already visible, throw a descriptive error immediately rather than silently retrying for 60 s.

### 🔗 Context

- **JIRA / GitHub issue**: [qaa-flaky-tests #109](https://github.com/LedgerHQ/qaa-flaky-tests/issues/109)

---

## 🧪 Triggered test workflows

Manually dispatched on `fix/e2e-QAA-flaky-109-borrow-withdraw` (commit `475e71f`), scoped to borrow tests:

| Workflow | Scope | Run |
|---|---|---|
| [Desktop] E2E Only | `Borrow` title filter, Speculos nanoSP | [run 32729946106](https://github.com/LedgerHQ/ledger-live/actions/runs/32729946106) |

Scope rationale: change is desktop-only (two files under `e2e/desktop/tests/`). No mobile or Coin Tester needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)