### PR TITLE
test(coin-near): regression for withdraw fee (LIVE-36138)

### DIFF
--- a/libs/coin-modules/coin-near/src/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-near/src/getTransactionStatus.test.ts
@@ -1,4 +1,5 @@
 import BigNumber from "bignumber.js";
+import { NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import { mockServer, NEAR_BASE_URL_MOCKED } from "./network/node.mock";
 import { setCoinConfig } from "./config";
 import getTransactionStatus from "./getTransactionStatus";
@@ -50,6 +51,59 @@ describe("getTransactionStatus", () => {
         totalSpent: new BigNumber(510),
         warnings: {},
       });
+    });
+  });
+
+  // Regression test for LIVE-36138: withdrawing unstaked NEAR with a spendable balance below the
+  // gas cost silently succeeded in LWD ≤4.15.0 because the fee formula divided by 10. The fee is
+  // now the full prepaid-gas amount, so validation must block the flow before signing.
+  describe("when transaction is a 'withdraw'", () => {
+    const validatorId = "pool.near";
+    // 1 NEAR available to withdraw from the pool (funds come from the pool, not the liquid balance)
+    const availableInPool = new BigNumber("1000000000000000000000000");
+
+    const makeAccount = (spendableBalance: BigNumber): NearAccount =>
+      ({
+        spendableBalance,
+        pendingOperations: [],
+        nearResources: {
+          stakingPositions: [
+            {
+              validatorId,
+              staked: new BigNumber(0),
+              available: availableInPool,
+              pending: new BigNumber(0),
+            },
+          ],
+        },
+      }) as unknown as NearAccount;
+
+    const makeTransaction = (fees: BigNumber): Transaction =>
+      ({
+        mode: "withdraw",
+        amount: availableInPool,
+        recipient: validatorId,
+        fees,
+        useAllAmount: false,
+      }) as Transaction;
+
+    it("returns NotEnoughBalance when spendable balance is below the gas fee (LIVE-36138)", async () => {
+      // The real-world case from the bug: 0.063 NEAR spendable, ~0.2 NEAR gas fee.
+      const spendable = new BigNumber("63000000000000000000000"); // 0.063 NEAR
+      const gasFee = new BigNumber("200000000000000000000000"); // 0.2 NEAR (200 TGas × gas_price)
+
+      const result = await getTransactionStatus(makeAccount(spendable), makeTransaction(gasFee));
+
+      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+    });
+
+    it("has no balance error when spendable balance covers the gas fee", async () => {
+      const spendable = new BigNumber("500000000000000000000000"); // 0.5 NEAR
+      const gasFee = new BigNumber("200000000000000000000000"); // 0.2 NEAR
+
+      const result = await getTransactionStatus(makeAccount(spendable), makeTransaction(gasFee));
+
+      expect(result.errors.amount).toBeUndefined();
     });
   });
 });

--- a/libs/coin-modules/coin-near/src/logic.test.ts
+++ b/libs/coin-modules/coin-near/src/logic.test.ts
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js";
-import { getMaxAmount, getTotalSpent } from "./logic";
+import { getMaxAmount, getStakingFees, getTotalSpent } from "./logic";
 import { NearAccount, Transaction } from "./types";
 
 describe("getMaxAmount", () => {
@@ -269,5 +269,30 @@ describe("getTotalSpent", () => {
 
     // Then
     expect(result).toEqual(spendableBalance);
+  });
+});
+
+// Regression for LIVE-36138: the fee formula previously divided by 10, which caused a ~10x
+// underestimate and let users sign a withdraw transaction that the network then rejected.
+describe("getStakingFees", () => {
+  // Typical NEAR gas price: 10^9 yoctoNEAR per gas unit.
+  const gasPrice = new BigNumber("1000000000");
+
+  it("estimates withdraw_all fee as (175 + 25) TGas × gasPrice with no divisor", () => {
+    // 175 TGas prepaid + 25 TGas buffer = 200 TGas
+    const expected = new BigNumber("200000000000000").multipliedBy(gasPrice);
+
+    const fee = getStakingFees({ mode: "withdraw", useAllAmount: true }, gasPrice);
+
+    expect(fee).toEqual(expected);
+  });
+
+  it("estimates partial withdraw fee as (125 + 25) TGas × gasPrice with no divisor", () => {
+    // 125 TGas prepaid + 25 TGas buffer = 150 TGas
+    const expected = new BigNumber("150000000000000").multipliedBy(gasPrice);
+
+    const fee = getStakingFees({ mode: "withdraw", useAllAmount: false }, gasPrice);
+
+    expect(fee).toEqual(expected);
   });
 });


### PR DESCRIPTION
## Summary

- Adds regression tests for LIVE-36138: NEAR withdraw with insufficient spendable balance to cover the gas fee
- Verifies `getTransactionStatus` correctly returns `NotEnoughBalance` when `spendable < estimatedFees` for a `withdraw` transaction
- Verifies `getStakingFees` formula has no `/10` divisor (which was the root cause — fee was underestimated 10x in LWD ≤4.15.0)

The code fix itself was already applied in a prior refactor (`8cd36a5def5`). These tests lock in the correct behavior and prevent regression.

## Test plan

- [ ] `pnpm jest src/getTransactionStatus.test.ts src/logic.test.ts --no-coverage` passes (20 tests)
- [ ] Reverting `.dividedBy(10)` in `logic.ts:182` causes `"returns NotEnoughBalance when spendable balance is below the gas fee (LIVE-36138)"` to fail