### PR TITLE
feat(pay): add card visual balance overlay (LIVE-36404)

### DIFF
--- a/.changeset/pay-card-visual-balance.md
+++ b/.changeset/pay-card-visual-balance.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-pay-card-details": minor
+---
+
+Add `CardVisual`: the card artwork with a balance overlay (localized caption + `AmountDisplay` amount), cross-platform (web + native). Props-only and i18n-agnostic.

--- a/features/flow/pay-card-details/README.md
+++ b/features/flow/pay-card-details/README.md
@@ -3,19 +3,21 @@
 > [!CAUTION]
 > **Status: UNSTABLE** — In active development; API may change.
 
-Dual-platform flow package for the Pay tab **card visual** for Ledger Wallet. This first slice ships
-the physical card face (`CardArtwork`): a dark gradient with the halftone artwork and the network
-logo. The balance overlay is added on top in a follow-up.
+Dual-platform flow package for the Pay tab **card visual** for Ledger Wallet: the physical card
+face (dark gradient + halftone artwork + network logo) and, on top of it, the card balance overlay.
 
 Props-only and i18n-agnostic — the host owns data fetching, currency formatting and labels.
 
 ## Usage
 
 ```tsx
-import { CardArtwork } from "@features/flow-pay-card-details";
+import { CardVisual } from "@features/flow-pay-card-details";
 
-<CardArtwork />;
+<CardVisual balance={100} formatCountervalue={format} balanceLabel="Balance" />;
 ```
+
+`CardVisual` composes the `CardArtwork` (card face) with the balance overlay. `CardArtwork` is also
+exported on its own for consumers that only need the card face.
 
 ## Platform resolution
 
@@ -24,7 +26,8 @@ import without a suffix; TypeScript `moduleSuffixes`, the bundlers (Rspack / Met
 preset resolve the right side. Each view has a test importing it through its full platform filename.
 
 The desktop artwork renders the halftone SVGs exported from Figma (imported as URLs via the bundler
-`asset/resource` rule). Native `CardArtwork` is an empty stub until an LWM design lands.
+`asset/resource` rule). Native `CardArtwork` and `CardVisualView` are empty stubs until an LWM
+design lands.
 
 ## Structure
 
@@ -36,12 +39,21 @@ pay-card-details/
 └── src/
     ├── assets.d.ts                            # `*.svg` module declaration (URL default export)
     ├── components/
-    │   └── CardArtwork/
-    │       ├── CardArtwork.web.tsx            # Card face + halftone artwork + Visa logo
-│       ├── CardArtwork.native.tsx         # Empty stub until LWM design
-│       ├── assets/                        # Figma-exported SVGs
-│       ├── CardArtwork.web.test.tsx
-│       └── CardArtwork.native.test.tsx
+    │   ├── CardArtwork/
+    │   │   ├── CardArtwork.web.tsx            # Card face + halftone artwork + Visa logo
+    │   │   ├── CardArtwork.native.tsx         # Empty stub until LWM design
+    │   │   ├── assets/                        # Figma-exported SVGs
+    │   │   ├── CardArtwork.web.test.tsx
+    │   │   └── CardArtwork.native.test.tsx
+    │   └── CardVisual/
+    │       ├── CardVisual.tsx                 # Container (props → view)
+    │       ├── CardVisualView.web.tsx         # Artwork + balance overlay
+    │       ├── CardVisualView.native.tsx      # Empty stub until LWM design
+    │       ├── CardVisual.web.test.tsx
+    │       ├── CardVisual.native.test.tsx
+    │       ├── CardVisualView.web.test.tsx
+    │       └── CardVisualView.native.test.tsx
+    ├── types.ts                               # Public props / view-model types
     ├── exports.ts                             # Public surface
     ├── index.ts                              # Public API barrel → ./exports
     └── index.native.ts                       # Native public API barrel → ./exports

--- a/features/flow/pay-card-details/package.json
+++ b/features/flow/pay-card-details/package.json
@@ -27,7 +27,9 @@
     "coverage": "jest --coverage",
     "unimported": "pnpm knip --directory ../../.. -c features/flow/pay-card-details/knip.web.config.mjs -W features/flow/pay-card-details --tsConfig tsconfig.web.json && pnpm knip --directory ../../.. -c features/flow/pay-card-details/knip.native.config.mjs -W features/flow/pay-card-details --tsConfig tsconfig.native.json"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@ledgerhq/lumen-utils-shared": "catalog:"
+  },
   "devDependencies": {
     "@features/platform-style": "workspace:*",
     "@ledgerhq/lumen-design-core": "catalog:",

--- a/features/flow/pay-card-details/src/components/CardVisual/CardVisual.native.test.tsx
+++ b/features/flow/pay-card-details/src/components/CardVisual/CardVisual.native.test.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { render, screen } from "@testing-library/react-native";
+import { CardVisual } from "./CardVisual";
+import type { FormattedValue } from "../../types";
+
+const formatCountervalue = (value: number): FormattedValue => ({
+  integerPart: String(Math.trunc(value)),
+  decimalPart: "00",
+  currencyText: "$",
+  decimalSeparator: ".",
+  currencyPosition: "start",
+});
+
+describe("CardVisual (native)", () => {
+  it("renders nothing until the native card visual ships", () => {
+    render(
+      <CardVisual balance={100} formatCountervalue={formatCountervalue} balanceLabel="Balance" />,
+    );
+
+    expect(screen.queryByTestId("card-visual")).toBeNull();
+  });
+});

--- a/features/flow/pay-card-details/src/components/CardVisual/CardVisual.tsx
+++ b/features/flow/pay-card-details/src/components/CardVisual/CardVisual.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+import { CardVisualView } from "./CardVisualView";
+import type { CardVisualProps } from "../../types";
+
+export function CardVisual(props: CardVisualProps) {
+  return <CardVisualView {...props} />;
+}

--- a/features/flow/pay-card-details/src/components/CardVisual/CardVisual.web.test.tsx
+++ b/features/flow/pay-card-details/src/components/CardVisual/CardVisual.web.test.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { CardVisual } from "./CardVisual";
+import type { FormattedValue } from "../../types";
+
+const formatCountervalue = (value: number): FormattedValue => ({
+  integerPart: String(Math.trunc(value)),
+  decimalPart: "00",
+  currencyText: "$",
+  decimalSeparator: ".",
+  currencyPosition: "start",
+});
+
+describe("CardVisual (web)", () => {
+  it("renders the card artwork with the balance caption and amount", () => {
+    render(
+      <CardVisual balance={100} formatCountervalue={formatCountervalue} balanceLabel="Balance" />,
+    );
+
+    expect(screen.getByTestId("card-visual")).toBeVisible();
+    expect(screen.getByTestId("card-artwork")).toBeVisible();
+    expect(screen.getByText("Balance")).toBeVisible();
+    expect(screen.getByTestId("card-visual-amount")).toBeVisible();
+  });
+});

--- a/features/flow/pay-card-details/src/components/CardVisual/CardVisualView.native.test.tsx
+++ b/features/flow/pay-card-details/src/components/CardVisual/CardVisualView.native.test.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { render, screen } from "@testing-library/react-native";
+import { CardVisualView } from "./CardVisualView.native";
+import type { FormattedValue } from "../../types";
+
+const formatCountervalue = (value: number): FormattedValue => ({
+  integerPart: String(Math.trunc(value)),
+  decimalPart: "00",
+  currencyText: "$",
+  decimalSeparator: ".",
+  currencyPosition: "start",
+});
+
+describe("CardVisualView (native)", () => {
+  it("renders nothing until the native card visual ships", () => {
+    render(
+      <CardVisualView
+        balance={100}
+        formatCountervalue={formatCountervalue}
+        balanceLabel="Balance"
+        isLoading={false}
+      />,
+    );
+
+    expect(screen.queryByTestId("card-visual")).toBeNull();
+  });
+});

--- a/features/flow/pay-card-details/src/components/CardVisual/CardVisualView.native.tsx
+++ b/features/flow/pay-card-details/src/components/CardVisual/CardVisualView.native.tsx
@@ -1,0 +1,5 @@
+import type { CardVisualViewProps } from "../../types";
+
+export function CardVisualView(_props: CardVisualViewProps): null {
+  return null;
+}

--- a/features/flow/pay-card-details/src/components/CardVisual/CardVisualView.web.test.tsx
+++ b/features/flow/pay-card-details/src/components/CardVisual/CardVisualView.web.test.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { CardVisualView } from "./CardVisualView";
+import type { FormattedValue } from "../../types";
+
+const formatCountervalue = (value: number): FormattedValue => ({
+  integerPart: String(Math.trunc(value)),
+  decimalPart: "00",
+  currencyText: "$",
+  decimalSeparator: ".",
+  currencyPosition: "start",
+});
+
+describe("CardVisualView (web)", () => {
+  it("renders the card artwork with the balance caption and amount", () => {
+    render(
+      <CardVisualView
+        balance={100}
+        formatCountervalue={formatCountervalue}
+        balanceLabel="Balance"
+        isLoading={false}
+      />,
+    );
+
+    expect(screen.getByTestId("card-visual")).toBeVisible();
+    expect(screen.getByTestId("card-artwork")).toBeVisible();
+    expect(screen.getByText("Balance")).toBeVisible();
+    expect(screen.getByTestId("card-visual-amount")).toBeVisible();
+  });
+});

--- a/features/flow/pay-card-details/src/components/CardVisual/CardVisualView.web.tsx
+++ b/features/flow/pay-card-details/src/components/CardVisual/CardVisualView.web.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { AmountDisplay } from "@ledgerhq/lumen-ui-react";
+import { CardArtwork } from "../CardArtwork/CardArtwork";
+import type { CardVisualViewProps } from "../../types";
+
+/**
+ * The card face with the balance overlay. The card is always dark, so the overlay is scoped to the
+ * `dark` color-scheme class to keep the caption and amount legible whatever the app theme is.
+ */
+export function CardVisualView({
+  balance,
+  formatCountervalue,
+  balanceLabel,
+  isLoading = false,
+}: CardVisualViewProps) {
+  return (
+    <div className="dark relative w-full" data-testid="card-visual">
+      <CardArtwork />
+      <div className="absolute inset-x-0 top-0 flex flex-col gap-4 p-20">
+        <span className="body-3 text-muted">{balanceLabel}</span>
+        <AmountDisplay
+          value={balance}
+          formatter={formatCountervalue}
+          loading={isLoading}
+          size="sm"
+          data-testid="card-visual-amount"
+        />
+      </div>
+    </div>
+  );
+}

--- a/features/flow/pay-card-details/src/exports.ts
+++ b/features/flow/pay-card-details/src/exports.ts
@@ -1,1 +1,3 @@
 export * from "./components/CardArtwork/CardArtwork";
+export * from "./components/CardVisual/CardVisual";
+export * from "./types";

--- a/features/flow/pay-card-details/src/types.ts
+++ b/features/flow/pay-card-details/src/types.ts
@@ -1,0 +1,17 @@
+import type { FormattedValue } from "@ledgerhq/lumen-utils-shared";
+
+// Shared with the host (`AmountDisplay` formatter contract).
+export type { FormattedValue };
+
+/** Host props for the card visual (artwork + balance overlay). Props-only, i18n-agnostic. */
+export type CardVisualProps = Readonly<{
+  /** Raw countervalue amount (e.g. 100). Formatting is delegated to {@link formatCountervalue}. */
+  balance: number;
+  /** Turns a raw number into a {@link FormattedValue} for `AmountDisplay`. */
+  formatCountervalue: (value: number) => FormattedValue;
+
+  balanceLabel: string;
+  isLoading?: boolean;
+}>;
+
+export type CardVisualViewProps = CardVisualProps;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6172,6 +6172,10 @@ importers:
         version: 1.51.0
 
   features/flow/pay-card-details:
+    dependencies:
+      '@ledgerhq/lumen-utils-shared':
+        specifier: 'catalog:'
+        version: 0.1.11(react@19.1.4)
     devDependencies:
       '@features/platform-style':
         specifier: workspace:*
@@ -22290,19 +22294,9 @@ packages:
   '@oxc-project/types@0.143.0':
     resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
 
-  '@oxc-resolver/binding-android-arm-eabi@11.20.0':
-    resolution: {integrity: sha512-IjfWOXRgJFNdORDl+Uf1aibNgZY2guOD3zmOhx1BGVb/MIiqlFTdmjpQNplSN58lhWehnX4UNqC3QwpUo8pjJg==}
-    cpu: [arm]
-    os: [android]
-
   '@oxc-resolver/binding-android-arm-eabi@11.24.2':
     resolution: {integrity: sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==}
     cpu: [arm]
-    os: [android]
-
-  '@oxc-resolver/binding-android-arm64@11.20.0':
-    resolution: {integrity: sha512-QqslZAuFQG8Q9xm7JuIn8JUbvywhSBMVhuQHtYW+auirZJloS41oxUUaBXk7uUhZJgp44c5zQLeVvmFaDQB+2Q==}
-    cpu: [arm64]
     os: [android]
 
   '@oxc-resolver/binding-android-arm64@11.24.2':
@@ -22310,19 +22304,9 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@oxc-resolver/binding-darwin-arm64@11.20.0':
-    resolution: {integrity: sha512-MUcavykj2ewlR+kc5arpg4tC2RvzJkUxWtNv74pf7lcNk00GpIpN43vXMj+j6r4eMmfZhlb8hueKoIb8e9kAGQ==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@oxc-resolver/binding-darwin-arm64@11.24.2':
     resolution: {integrity: sha512-At29QEMF6HajbQvgY8K6OXnHD1x9rad74xBEfmCB6ZqCGsdq75aK7tOYcTbOanMy8qdIBrfL3SMr3p/lfSlb9w==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@oxc-resolver/binding-darwin-x64@11.20.0':
-    resolution: {integrity: sha512-BGB16nRUK5Etiv//ihPyzj8Lj1px0mhh4YIfe0FDf045ywknfSm0GEbiRESpr6Q4K82AvnyaRIhhluHByvS4bg==}
-    cpu: [x64]
     os: [darwin]
 
   '@oxc-resolver/binding-darwin-x64@11.24.2':
@@ -22330,28 +22314,13 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@oxc-resolver/binding-freebsd-x64@11.20.0':
-    resolution: {integrity: sha512-JZgtePaqj3qmD5XFHJaSLWzHRxQu0LaPkdoM1KJXYADvAaa83ijXHclV3ej3CueeW0wxfIAbGCZVP45J0CA7uQ==}
-    cpu: [x64]
-    os: [freebsd]
-
   '@oxc-resolver/binding-freebsd-x64@11.24.2':
     resolution: {integrity: sha512-R5xkRBRRz7ceH/P5Jrc6G7FmdUdgpLYyESFAUDVTNQ9K0sGPxcp4ljiwEwEqsvNcQ4sYbMRrWcHHBCu7ksAJVw==}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxc-resolver/binding-linux-arm-gnueabihf@11.20.0':
-    resolution: {integrity: sha512-hOQ/p3ry3v3SchUBXicrrnszaI/UmYzM4wtS4RGfwgVUX7a+HbyQSzJ5aOzu+o6XZkFkS3ZXN4PZAzhOb77OSg==}
-    cpu: [arm]
-    os: [linux]
-
   '@oxc-resolver/binding-linux-arm-gnueabihf@11.24.2':
     resolution: {integrity: sha512-k/RuYL4L/R58IBn3wT5ma3Wh4k62bp1eYCFRWCmMsasUOqL+H6sW0VGFadEzKWXFFlz+2uIMoeMk9ySSZJHgbg==}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxc-resolver/binding-linux-arm-musleabihf@11.20.0':
-    resolution: {integrity: sha512-2ArPksaw0AqeuGBfoS715VF+JvJQAhD2niWgjE5hVO+L+nAfikVQopvngCMX9x4BD8itWoQ3dnikrQyl5Ho5Jg==}
     cpu: [arm]
     os: [linux]
 
@@ -22360,23 +22329,11 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@oxc-resolver/binding-linux-arm64-gnu@11.20.0':
-    resolution: {integrity: sha512-0bJnmYFp62JdZ4nVMDUZ/C58BCZOCcqgKtnUlp7L9Ojf/czIN+3j72YlLPeWLkzlr6SlYvIQA4SGV/HyO0d+qg==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   '@oxc-resolver/binding-linux-arm64-gnu@11.24.2':
     resolution: {integrity: sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
-
-  '@oxc-resolver/binding-linux-arm64-musl@11.20.0':
-    resolution: {integrity: sha512-wKHHzPKZo7Ufhv/Bt6yxT7FOgnIgW4gwXcJUipkShGp68W3wGVqvr1Sr0fY65lN0Oy6y41+g2kIDvkgZaMMUkw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.24.2':
     resolution: {integrity: sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==}
@@ -22384,21 +22341,9 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@oxc-resolver/binding-linux-ppc64-gnu@11.20.0':
-    resolution: {integrity: sha512-RN8goF7Ie0B79L4i4G6OeBocTgSC56vJbQ65VJje+oXnldVpLnOU7j/AQ/dP94TcCS+Yh6WG8u3Qt4ETteXFNQ==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@oxc-resolver/binding-linux-ppc64-gnu@11.24.2':
     resolution: {integrity: sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==}
     cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-resolver/binding-linux-riscv64-gnu@11.20.0':
-    resolution: {integrity: sha512-5l1yU6/xQEqLZRzxqmMxJfWPslpwCmBsdDGaBvABPehxquCXDC7dd7oraNdKSJUMDXSM7VvVj8H2D2FTjU7oWw==}
-    cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
@@ -22408,33 +22353,15 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
-    resolution: {integrity: sha512-xHEvkbgz6UC+A3JOyDQy76LkUaxsNSfIr3/GV8slwZsnuooJiIB34gzJfsyvR4JdCYNUUPsRJc/w/oWkODu+hg==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
   '@oxc-resolver/binding-linux-riscv64-musl@11.24.2':
     resolution: {integrity: sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxc-resolver/binding-linux-s390x-gnu@11.20.0':
-    resolution: {integrity: sha512-aWPDUUmSeyHvlW+SoEUd+JIJsQhVhu6a5tBpDRMu058naPAchTgAVGCFy35zjbnFlt0i8hLWziff6HX0D3LU4g==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@oxc-resolver/binding-linux-s390x-gnu@11.24.2':
     resolution: {integrity: sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==}
     cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-resolver/binding-linux-x64-gnu@11.20.0':
-    resolution: {integrity: sha512-x2YeSimvhJjKLVD8KSu8f/rqU1potcdEMkApIPJqjZWN7c2Fpt4g2X32WDg1p+XDAmyT7nuQGe0vnhvXeLbH+g==}
-    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -22444,51 +22371,25 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-resolver/binding-linux-x64-musl@11.20.0':
-    resolution: {integrity: sha512-kcRLEIxpZefeYfLChjpgFf3ilBzRDZ+yobMrpRsQlSrxuFGtm3U6PMU7AaEpMqo3NfDGVyJJseAjnRLzMFHjwQ==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@oxc-resolver/binding-linux-x64-musl@11.24.2':
     resolution: {integrity: sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxc-resolver/binding-openharmony-arm64@11.20.0':
-    resolution: {integrity: sha512-HHcfnApSZGtKhTiHqe8OZruOZe5XuFQH5/E0Yhj3u8fnFvzkM4/k6WjacUf4SvA0SPEAbfbgYmVPuo0VX/fIBQ==}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@oxc-resolver/binding-openharmony-arm64@11.24.2':
     resolution: {integrity: sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==}
     cpu: [arm64]
     os: [openharmony]
-
-  '@oxc-resolver/binding-wasm32-wasi@11.20.0':
-    resolution: {integrity: sha512-Tn0y1XOFYHNfK1wp1Z5QK8Rcld/bsOwRISQXfqAZ5IBpv8Gz1IvV39fUWNprqNdRizgcvFhOzWwFun2zkJsyBg==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
 
   '@oxc-resolver/binding-wasm32-wasi@11.24.2':
     resolution: {integrity: sha512-vHcssMPwO08RTvj/c0iOBz90attxyG3wQJ0dTcyEQK43LRpcdLWZlV5feBhv6Isn6ahbQIzHbCgfa81+RiML0Q==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@oxc-resolver/binding-win32-arm64-msvc@11.20.0':
-    resolution: {integrity: sha512-qPi25YNPe4YenS8MgsQU2+bIFHxxpLx1LVna2444cEHqNPhNjvWf9zqj4aWE43H9LpAsTmkkAlA3eL5ElBU3mA==}
-    cpu: [arm64]
-    os: [win32]
-
   '@oxc-resolver/binding-win32-arm64-msvc@11.24.2':
     resolution: {integrity: sha512-uokJqro2iBqkFvJdKQLP7d8/BUmFwESQFVmIJUQKj1Xn1a/LysJoe1vmeECLF5b3jsV8CAL5sEMJXX6SdK9Nhg==}
     cpu: [arm64]
-    os: [win32]
-
-  '@oxc-resolver/binding-win32-x64-msvc@11.20.0':
-    resolution: {integrity: sha512-Wb14jWEW8huH6It9F6sXd9vrYmIS7pMrgkU6sxpLxkP+9z+wRgs71hUEhRpcn8FOXAFa27FVWfY2tRpbfTzfLw==}
-    cpu: [x64]
     os: [win32]
 
   '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
@@ -25791,7 +25692,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.1.4
       react-dom: 19.1.4
-      webpack: '*'
+      webpack: ^5.89.0
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -36225,9 +36126,6 @@ packages:
     resolution: {integrity: sha512-ov0NzaDCOInknS7mP1cwKdJERt3utPW8ldjtdUXQ8Ty0GEFD08wk422vCUN0d7pST6kqtV7dxoI9w1Zi0l/9TA==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  oxc-resolver@11.20.0:
-    resolution: {integrity: sha512-CblytBiV/a/ZXY34dsVU2NxhIOxMXst8CvDCtyBelVITgd7PLrKzbEbA6oKLdPjvDKDzCiW48qzmzZ+mYaqn+g==}
-
   oxc-resolver@11.24.2:
     resolution: {integrity: sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==}
 
@@ -36565,10 +36463,6 @@ packages:
   picomatch@3.0.1:
     resolution: {integrity: sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==}
     engines: {node: '>=10'}
-
-  picomatch@4.0.4:
-    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
-    engines: {node: '>=12'}
 
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
@@ -39767,10 +39661,6 @@ packages:
 
   tinycolor2@1.6.0:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
-
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
@@ -50352,7 +50242,7 @@ snapshots:
     dependencies:
       '@ledgerhq/wallet-api-core': 2.0.0(@ton/crypto@3.3.0)
       bignumber.js: 9.1.2
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     transitivePeerDependencies:
       - '@ton/crypto'
       - encoding
@@ -50635,29 +50525,29 @@ snapshots:
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.9.0
 
-  '@napi-rs/wasm-runtime@1.1.4':
-    dependencies:
-      '@tybys/wasm-util': 0.10.1
-    optional: true
-
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+  '@napi-rs/wasm-runtime@1.2.3':
     dependencies:
-      '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
-      '@tybys/wasm-util': 0.10.1
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -51220,7 +51110,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.9.2
       '@emnapi/runtime': 1.9.2
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
     optional: true
 
   '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
@@ -51245,107 +51135,52 @@ snapshots:
 
   '@oxc-project/types@0.143.0': {}
 
-  '@oxc-resolver/binding-android-arm-eabi@11.20.0':
-    optional: true
-
   '@oxc-resolver/binding-android-arm-eabi@11.24.2':
-    optional: true
-
-  '@oxc-resolver/binding-android-arm64@11.20.0':
     optional: true
 
   '@oxc-resolver/binding-android-arm64@11.24.2':
     optional: true
 
-  '@oxc-resolver/binding-darwin-arm64@11.20.0':
-    optional: true
-
   '@oxc-resolver/binding-darwin-arm64@11.24.2':
-    optional: true
-
-  '@oxc-resolver/binding-darwin-x64@11.20.0':
     optional: true
 
   '@oxc-resolver/binding-darwin-x64@11.24.2':
     optional: true
 
-  '@oxc-resolver/binding-freebsd-x64@11.20.0':
-    optional: true
-
   '@oxc-resolver/binding-freebsd-x64@11.24.2':
-    optional: true
-
-  '@oxc-resolver/binding-linux-arm-gnueabihf@11.20.0':
     optional: true
 
   '@oxc-resolver/binding-linux-arm-gnueabihf@11.24.2':
     optional: true
 
-  '@oxc-resolver/binding-linux-arm-musleabihf@11.20.0':
-    optional: true
-
   '@oxc-resolver/binding-linux-arm-musleabihf@11.24.2':
-    optional: true
-
-  '@oxc-resolver/binding-linux-arm64-gnu@11.20.0':
     optional: true
 
   '@oxc-resolver/binding-linux-arm64-gnu@11.24.2':
     optional: true
 
-  '@oxc-resolver/binding-linux-arm64-musl@11.20.0':
-    optional: true
-
   '@oxc-resolver/binding-linux-arm64-musl@11.24.2':
-    optional: true
-
-  '@oxc-resolver/binding-linux-ppc64-gnu@11.20.0':
     optional: true
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.24.2':
     optional: true
 
-  '@oxc-resolver/binding-linux-riscv64-gnu@11.20.0':
-    optional: true
-
   '@oxc-resolver/binding-linux-riscv64-gnu@11.24.2':
-    optional: true
-
-  '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
     optional: true
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.24.2':
     optional: true
 
-  '@oxc-resolver/binding-linux-s390x-gnu@11.20.0':
-    optional: true
-
   '@oxc-resolver/binding-linux-s390x-gnu@11.24.2':
-    optional: true
-
-  '@oxc-resolver/binding-linux-x64-gnu@11.20.0':
     optional: true
 
   '@oxc-resolver/binding-linux-x64-gnu@11.24.2':
     optional: true
 
-  '@oxc-resolver/binding-linux-x64-musl@11.20.0':
-    optional: true
-
   '@oxc-resolver/binding-linux-x64-musl@11.24.2':
     optional: true
 
-  '@oxc-resolver/binding-openharmony-arm64@11.20.0':
-    optional: true
-
   '@oxc-resolver/binding-openharmony-arm64@11.24.2':
-    optional: true
-
-  '@oxc-resolver/binding-wasm32-wasi@11.20.0':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@oxc-resolver/binding-wasm32-wasi@11.24.2':
@@ -51355,13 +51190,7 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
-  '@oxc-resolver/binding-win32-arm64-msvc@11.20.0':
-    optional: true
-
   '@oxc-resolver/binding-win32-arm64-msvc@11.24.2':
-    optional: true
-
-  '@oxc-resolver/binding-win32-x64-msvc@11.20.0':
     optional: true
 
   '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
@@ -53905,7 +53734,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   '@rozenite/middleware@1.2.0':
     dependencies:
@@ -54410,7 +54239,7 @@ snapshots:
 
   '@rspack/resolver-binding-wasm32-wasi@0.2.8':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4
+      '@napi-rs/wasm-runtime': 1.2.3
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -58217,7 +58046,7 @@ snapshots:
       debug: 4.4.3
       minimatch: 9.0.5
       semver: 7.8.1
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       ts-api-utils: 2.1.0(@typescript/typescript6@6.0.2)
       typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
@@ -64343,10 +64172,6 @@ snapshots:
     dependencies:
       pend: 1.2.0
 
-  fdir@6.5.0(picomatch@4.0.4):
-    optionalDependencies:
-      picomatch: 4.0.4
-
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
@@ -67154,7 +66979,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 4.3.1
       graceful-fs: 4.2.11
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   jest-validate@29.7.0:
     dependencies:
@@ -69301,7 +69126,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.7(metro-transform-worker@0.83.7)
+      metro: 0.83.7
       metro-babel-transformer: 0.83.7
       metro-cache: 0.83.7
       metro-cache-key: 0.83.7
@@ -69451,53 +69276,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro@0.83.7(metro-transform-worker@0.83.7):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 2.0.0
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.35.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0(metro@0.83.7)
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.7
-      metro-cache: 0.83.7
-      metro-cache-key: 0.83.7
-      metro-config: 0.83.7(metro-transform-worker@0.83.7)
-      metro-core: 0.83.7
-      metro-file-map: 0.83.7(metro@0.83.7)
-      metro-resolver: 0.83.7
-      metro-runtime: 0.83.7
-      metro-source-map: 0.83.7
-      metro-symbolicate: 0.83.7
-      metro-transform-plugins: 0.83.7
-      metro-transform-worker: 0.83.7
-      mime-types: 3.0.1
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 
@@ -70777,28 +70555,6 @@ snapshots:
       '@oxc-parser/binding-win32-ia32-msvc': 0.143.0
       '@oxc-parser/binding-win32-x64-msvc': 0.143.0
 
-  oxc-resolver@11.20.0:
-    optionalDependencies:
-      '@oxc-resolver/binding-android-arm-eabi': 11.20.0
-      '@oxc-resolver/binding-android-arm64': 11.20.0
-      '@oxc-resolver/binding-darwin-arm64': 11.20.0
-      '@oxc-resolver/binding-darwin-x64': 11.20.0
-      '@oxc-resolver/binding-freebsd-x64': 11.20.0
-      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.20.0
-      '@oxc-resolver/binding-linux-arm-musleabihf': 11.20.0
-      '@oxc-resolver/binding-linux-arm64-gnu': 11.20.0
-      '@oxc-resolver/binding-linux-arm64-musl': 11.20.0
-      '@oxc-resolver/binding-linux-ppc64-gnu': 11.20.0
-      '@oxc-resolver/binding-linux-riscv64-gnu': 11.20.0
-      '@oxc-resolver/binding-linux-riscv64-musl': 11.20.0
-      '@oxc-resolver/binding-linux-s390x-gnu': 11.20.0
-      '@oxc-resolver/binding-linux-x64-gnu': 11.20.0
-      '@oxc-resolver/binding-linux-x64-musl': 11.20.0
-      '@oxc-resolver/binding-openharmony-arm64': 11.20.0
-      '@oxc-resolver/binding-wasm32-wasi': 11.20.0
-      '@oxc-resolver/binding-win32-arm64-msvc': 11.20.0
-      '@oxc-resolver/binding-win32-x64-msvc': 11.20.0
-
   oxc-resolver@11.24.2:
     optionalDependencies:
       '@oxc-resolver/binding-android-arm-eabi': 11.24.2
@@ -71158,8 +70914,6 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@3.0.1: {}
-
-  picomatch@4.0.4: {}
 
   picomatch@4.0.5: {}
 
@@ -74686,7 +74440,7 @@ snapshots:
       esbuild: 0.25.5
       open: 10.2.0
       oxc-parser: 0.127.0
-      oxc-resolver: 11.20.0
+      oxc-resolver: 11.24.2
       recast: 0.23.11
       semver: 7.8.1
       use-sync-external-store: 1.6.0(react@19.1.4)
@@ -75081,7 +74835,7 @@ snapshots:
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.7
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       ts-interface-checker: 0.1.13
 
   sudo-prompt@8.2.5: {}
@@ -75440,11 +75194,6 @@ snapshots:
   tiny-typed-emitter@2.1.0: {}
 
   tinycolor2@1.6.0: {}
-
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
 
   tinyglobby@0.2.17:
     dependencies:
@@ -76176,7 +75925,7 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       acorn: 8.15.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
 
   unquote@1.1.1: {}


### PR DESCRIPTION
### 📝 Description

Adds **`CardVisual`** to `@features/flow-pay-card-details`: the card artwork with a balance overlay on top.

- Composes `CardArtwork` with a localized "Balance" caption and Lumen `AmountDisplay` for the amount.
- MVVM structure: `CardVisual` (container) → `useCardVisualViewModel` → `CardVisualView` (`.web` / `.native`).
- Props-only and i18n-agnostic: the host provides `balance`, a `formatCountervalue` formatter and the `balanceLabel`.
- Adds `@ledgerhq/lumen-utils-shared` for the `FormattedValue` formatter contract.

```tsx
import { CardVisual } from "@features/flow-pay-card-details";

<CardVisual balance={100} formatCountervalue={format} balanceLabel="Balance" />;
```

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36404](https://ledgerhq.atlassian.net/browse/LIVE-36404)
- Stacked on [#21079](https://github.com/LedgerHQ/ledger-live/pull/21079) (LIVE-35427). Review/merge that first.

[LIVE-36404]: https://ledgerhq.atlassian.net/browse/LIVE-36404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ