### PR TITLE
[LWD] feat(pay): render pay card visual with balance (LIVE-35429)

### DIFF
--- a/.changeset/pay-card-wiring.md
+++ b/.changeset/pay-card-wiring.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Render the Pay card visual with a mock balance in the Pay tab right panel, wiring the new `@features/flow-pay-card-details` `CardVisual` through an MVVM view model.

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -99,6 +99,7 @@
     "@features/flow-pay-card-auth": "workspace:^",
     "@features/flow-pay-card-balance": "workspace:^",
     "@features/flow-pay-card-deposit": "workspace:^",
+    "@features/flow-pay-card-details": "workspace:^",
     "@features/flow-pay-card-feature-tour": "workspace:^",
     "@features/flow-pay-card-request": "workspace:^",
     "@features/platform-aggregated-assets": "workspace:*",

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/Card/Card.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/Card/Card.tsx
@@ -1,14 +1,13 @@
 import React from "react";
-import PayCardContainer from "LLD/features/PayTab/components/PayCardContainer";
+import { CardView } from "./CardView";
+import { useCardViewModel } from "./useCardViewModel";
 
 /**
  * Card
- * Right-panel content for the Pay tab: the Pay Card container frame.
+ * Right-panel content for the Pay tab: the Pay Card visual with a mock balance.
  */
 export const Card = () => {
-  return (
-    <div className="flex h-full flex-col pb-32">
-      <PayCardContainer />
-    </div>
-  );
+  const viewModel = useCardViewModel();
+
+  return <CardView viewModel={viewModel} />;
 };

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/Card/CardView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/Card/CardView.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { CardVisual } from "@features/flow-pay-card-details";
+import PayCardContainer from "LLD/features/PayTab/components/PayCardContainer";
+import type { CardViewModel } from "./types";
+
+export interface CardViewProps {
+  readonly viewModel: CardViewModel;
+}
+
+/**
+ * CardView
+ * Right-panel content for the Pay tab: the Pay Card container framing the card visual.
+ */
+export const CardView = ({ viewModel }: CardViewProps) => {
+  const { balance, formatCountervalue, balanceLabel } = viewModel;
+
+  return (
+    <div className="flex h-full flex-col pb-32">
+      <PayCardContainer>
+        <div className="p-16">
+          <CardVisual
+            balance={balance}
+            formatCountervalue={formatCountervalue}
+            balanceLabel={balanceLabel}
+          />
+        </div>
+      </PayCardContainer>
+    </div>
+  );
+};

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/Card/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/Card/types.ts
@@ -1,0 +1,7 @@
+import type { FormattedValue } from "@features/flow-pay-card-details";
+
+export interface CardViewModel {
+  readonly balance: number;
+  readonly formatCountervalue: (value: number) => FormattedValue;
+  readonly balanceLabel: string;
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/Card/useCardViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/Card/useCardViewModel.ts
@@ -1,0 +1,30 @@
+import { useCallback } from "react";
+import BigNumber from "bignumber.js";
+import { useTranslation } from "react-i18next";
+import { formatCurrencyUnitFragment } from "@ledgerhq/live-common/currencies/index";
+import type { FormattedValue } from "@features/flow-pay-card-details";
+import { useSelector } from "LLD/hooks/redux";
+import { counterValueCurrencySelector, localeSelector } from "~/renderer/reducers/settings";
+import type { CardViewModel } from "./types";
+
+/** Mock card balance shown until the real balance API is wired (see LIVE-35427 follow-up). */
+const MOCK_CARD_BALANCE = 100;
+
+export function useCardViewModel(): CardViewModel {
+  const { t } = useTranslation();
+  const locale = useSelector(localeSelector);
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const unit = counterValueCurrency.units[0];
+
+  const formatCountervalue = useCallback(
+    (value: number): FormattedValue =>
+      formatCurrencyUnitFragment(unit, new BigNumber(value), { locale, showCode: true }),
+    [unit, locale],
+  );
+
+  return {
+    balance: MOCK_CARD_BALANCE,
+    formatCountervalue,
+    balanceLabel: t("payTab.card.balanceLabel"),
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/__tests__/index.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/__tests__/index.test.tsx
@@ -82,10 +82,13 @@ describe("RightPanel", () => {
   });
 
   describe("card variant", () => {
-    it("renders the Pay Card container frame and no swap webview", () => {
+    it("renders the Pay Card visual with the mock balance and no swap webview", () => {
       render(<RightPanel variant="card" />);
 
       expect(screen.getByTestId("pay-card-container")).toBeVisible();
+      expect(screen.getByTestId("card-visual")).toBeVisible();
+      expect(screen.getByTestId("card-visual-amount")).toBeVisible();
+      expect(screen.getByText("Balance")).toBeVisible();
       expect(screen.queryByTestId("swap-webview-embedded")).not.toBeInTheDocument();
       expect(mockUseSwapViewModel).not.toHaveBeenCalled();
     });

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -901,6 +901,9 @@
         "confirm": "Confirm"
       }
     },
+    "card": {
+      "balanceLabel": "Balance"
+    },
     "actions": {
       "deposit": "Add stablecoin",
       "request": "Request",

--- a/features/flow/pay-card-details/README.md
+++ b/features/flow/pay-card-details/README.md
@@ -26,8 +26,7 @@ import without a suffix; TypeScript `moduleSuffixes`, the bundlers (Rspack / Met
 preset resolve the right side. Each view has a test importing it through its full platform filename.
 
 The desktop artwork renders the halftone SVGs exported from Figma (imported as URLs via the bundler
-`asset/resource` rule). Native `CardArtwork` and `CardVisualView` are empty stubs until an LWM
-design lands.
+`asset/resource` rule). The native side is a minimal dark frame until an LWM design lands.
 
 ## Structure
 
@@ -46,7 +45,7 @@ pay-card-details/
     │   │   ├── CardArtwork.web.test.tsx
     │   │   └── CardArtwork.native.test.tsx
     │   └── CardVisual/
-    │       ├── CardVisual.tsx                 # Container (props → view)
+    │       ├── CardVisual.tsx
     │       ├── CardVisualView.web.tsx         # Artwork + balance overlay
     │       ├── CardVisualView.native.tsx      # Empty stub until LWM design
     │       ├── CardVisual.web.test.tsx

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -967,6 +967,9 @@ importers:
       '@features/flow-pay-card-deposit':
         specifier: workspace:^
         version: link:../../features/flow/pay-card-deposit
+      '@features/flow-pay-card-details':
+        specifier: workspace:^
+        version: link:../../features/flow/pay-card-details
       '@features/flow-pay-card-feature-tour':
         specifier: workspace:^
         version: link:../../features/flow/pay-card-feature-tour


### PR DESCRIPTION
### 📝 Description

Wires the new `CardVisual` into the Ledger Live Desktop Pay tab right panel with a **mock balance**.

- Refactors `RightPanel/Card` into MVVM: `Card` → `useCardViewModel` → `CardView`, rendering `CardVisual` inside the existing `PayCardContainer`.
- `useCardViewModel` provides a mock balance (`100`) and a `formatCountervalue` formatter built from the user's counter-value currency + locale (`formatCurrencyUnitFragment`). The real balance API is a follow-up.
- Adds the `payTab.card.balanceLabel` i18n key and the `@features/flow-pay-card-details` dependency.
- Updates the RightPanel test to assert the card visual + mock balance render.


<img width="1624" height="964" alt="Screenshot 2026-08-24 at 17 37 02" src="https://github.com/user-attachments/assets/c25cc153-c83a-4ce6-aef4-c9a4257bbd91" />



### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35429](https://ledgerhq.atlassian.net/browse/LIVE-35429)
- Final of 3 stacked PRs. Stacked on [#21081](https://github.com/LedgerHQ/ledger-live/pull/21081) (LIVE-36404) → [#21079](https://github.com/LedgerHQ/ledger-live/pull/21079) (LIVE-35427). Review/merge those first.

[LIVE-35429]: https://ledgerhq.atlassian.net/browse/LIVE-35429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ