### PR TITLE
test(e2e): skip contacts suite behind ledger sync (B2CQA-6238)

### DIFF
--- a/e2e/mobile/specs/contacts/createRenameDeleteContact.skip.spec.ts
+++ b/e2e/mobile/specs/contacts/createRenameDeleteContact.skip.spec.ts
@@ -1,5 +1,7 @@
 import { runCreateRenameDeleteContactTest } from "./contacts";
 
+// TODO: Unskip once the Ledger Sync activation prompt is automated — Contacts now opens behind a
+// popup asking to turn Ledger Sync on, and the suite has no way past it.
 const testConfig = {
   tmsLinks: ["B2CQA-6238"],
   tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],


### PR DESCRIPTION
### 📝 Description

`runCreateRenameDeleteContactTest` is skipped for now: opening Contacts raises a popup asking to turn Ledger Sync on, and the suite has no way past it.

Renaming the spec to `.skip.spec.ts` drops it from collection in both places that matter:

- `testPathIgnorePatterns` in `e2e/mobile/jest.config.js`
- the CI shard script, `apps/ledger-live-mobile/scripts/shard-tests.mjs`

The test body is untouched — this is a pure rename plus a `TODO` recording the unskip condition, matching the convention already used by the two skipped swap specs. Verified locally with `jest --listTests`: 242 specs still collected, 0 of them contacts.

To unskip once the Ledger Sync activation prompt is automated.

### 🔗 Context

- **JIRA / GitHub issue**: B2CQA-6238
- **ADR** (if any): n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)