### PR TITLE
fix(e2e): indent mobile App logs attachment (QAA-1514)

### DIFF
--- a/e2e/mobile/utils/loggingUtils.ts
+++ b/e2e/mobile/utils/loggingUtils.ts
@@ -141,7 +141,7 @@ export async function attachFailureLogsToAllure(logsPayload: string): Promise<vo
 
   await allure.attachment(
     "App logs",
-    JSON.stringify(parsed.appLogs ?? logsPayload),
+    JSON.stringify(parsed.appLogs ?? logsPayload, null, 2),
     "application/json",
   );
   parsed.appLogs = undefined;


### PR DESCRIPTION
### Checklist

- [x] No changeset needed — only `e2e/mobile` test tooling is touched; no published package changes.
- [ ] **Covered by automatic tests.** _No unit-test harness covers these Allure attachment helpers. Verified by reproducing the serialisation path locally (1 line → indented JSON), plus `oxlint` (0 errors) and `typecheck` (116 errors before **and** after — zero introduced; they are pre-existing module-resolution errors in this package)._
- [x] **Impact of the changes:**
  - The **"App logs"** attachment on a failed Mobile E2E test should now render as indented, readable JSON instead of one long single-line blob.
  - No other attachment, and no test behaviour, is affected — this only changes how the payload is serialised for the report.

### Description

When a Mobile E2E test fails we attach the app's in-memory logs to Allure as **"App logs"**. It was serialised with a bare `JSON.stringify(...)`, so the whole log dump rendered as a single unreadable line:

```json
[{"type":"db","id":"49","date":"2026-08-25T00:36:50.412Z","message":"saved 0 accounts"},{"type":"bridge","id":"47",...
```

This adds the standard 2-space indent, so it reads as:

```json
[
  {
    "type": "db",
    "id": "49",
    "date": "2026-08-25T00:36:50.412Z",
    "message": "saved 0 accounts"
  },
  ...
]
```

`"App logs"` was the **only** attachment in `attachFailureLogsToAllure` stringified without `null, 2` — its five siblings (Webview Network Logs, Ledger Wallet Network Logs, Ledger Wallet Network Summary, Webview Load Errors) all already pass it, so this simply makes it consistent.

This is the first, smallest step of QAA-1514 (the mobile counterpart of QAA-1433, which cleaned up the Desktop Allure attachments). The remaining items in that ticket — porting the network-noise filter to mobile, trimming webview console logs to warnings/errors, attaching Merged Feature Flags on failures only, and aligning attachment names with Desktop — are intentionally **not** in this PR and will follow separately.

### Context

- **JIRA or GitHub link**: [QAA-1514](https://ledgerhq.atlassian.net/browse/QAA-1514)
- Related: [QAA-1433](https://ledgerhq.atlassian.net/browse/QAA-1433) — the Desktop equivalent (#20768)

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-1514]: https://ledgerhq.atlassian.net/browse/QAA-1514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ