### PR TITLE
[LWDM] feat(earn): add simulator deeplink (LIVE-36400)

### DIFF
--- a/.changeset/earn-simulate-deeplink.md
+++ b/.changeset/earn-simulate-deeplink.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Add earn/simulate deeplink to open the rewards simulator

--- a/apps/ledger-live-desktop/deeplinks-test-page.html
+++ b/apps/ledger-live-desktop/deeplinks-test-page.html
@@ -198,6 +198,8 @@
 
     <h3>Earn</h3>
     <deeplink-button pathname="earn"></deeplink-button>
+    <deeplink-button pathname="earn/deposit?cryptoAssetId=ethereum"></deeplink-button>
+    <deeplink-button pathname="earn/simulate"></deeplink-button>
     <deeplink-button pathname="earn?action=stake"></deeplink-button>
     <deeplink-button pathname="earn?action=stake-account&accountId=1"></deeplink-button>
     <deeplink-button pathname="earn?action=get-funds&currencyId=ethereum"></deeplink-button>

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/__tests__/parseDeepLink.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/__tests__/parseDeepLink.test.ts
@@ -130,6 +130,19 @@ describe("parseDeepLink", () => {
       });
     });
 
+    it("creates earn simulate route", () => {
+      const parsed = parseDeepLink("ledgerwallet://earn/simulate");
+      const route = createRoute(parsed);
+
+      expect(route).toEqual({
+        type: "earn",
+        path: "simulate",
+        cryptoAssetId: undefined,
+        accountId: undefined,
+        search: "",
+      });
+    });
+
     it("creates borrow route", () => {
       const parsed = parseDeepLink("ledgerwallet://borrow?action=open");
       const route = createRoute(parsed);

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/earn.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/earn.handler.test.ts
@@ -85,6 +85,27 @@ describe("earn.handler", () => {
       );
     });
 
+    it("navigates with simulate intent when path is simulate", () => {
+      const context = createMockContext();
+
+      earnHandler(
+        {
+          type: "earn",
+          path: "simulate",
+          search: "?ref=campaign",
+        },
+        context,
+      );
+
+      expect(context.navigate).toHaveBeenCalledWith(
+        "/earn",
+        {
+          intent: "simulate",
+        },
+        "?ref=campaign",
+      );
+    });
+
     it("navigates without deposit intent for other paths", () => {
       const context = createMockContext();
 

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/earn.handler.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/earn.handler.ts
@@ -13,6 +13,8 @@ export const earnHandler: DeeplinkHandler<"earn"> = (route, { navigate }) => {
       },
       search,
     );
+  } else if (path === "simulate") {
+    navigate("/earn", { intent: "simulate" }, search);
   } else {
     navigate("/earn", undefined, search);
   }

--- a/apps/ledger-live-desktop/src/renderer/screens/earn/index.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/earn/index.test.tsx
@@ -147,6 +147,29 @@ describe("Earn screen", () => {
     useLocationSpy.mockRestore();
   });
 
+  it("passes simulate intent params in inputs like mobile route params", () => {
+    const useLocationSpy = jest.spyOn(require("react-router"), "useLocation").mockReturnValue({
+      pathname: "/earn",
+      search: "",
+      hash: "",
+      state: { intent: "simulate" },
+    });
+
+    render(<Earn />, {
+      initialState: withFlagOverrides({
+        ptxEarnLiveApp: { enabled: true, params: { manifest_id: "earn-manifest-id" } },
+        stakePrograms: { enabled: true, params: { list: [], redirects: {} } } as never,
+      }),
+    });
+
+    const lastCall = mockWebPlatformPlayer.mock.calls.at(-1)?.[0] as unknown as {
+      inputs: Record<string, string | undefined>;
+    };
+
+    expect(lastCall.inputs.intent).toBe("simulate");
+    useLocationSpy.mockRestore();
+  });
+
   it("passes uiVersion v3 when earn upselling is enabled", () => {
     render(<Earn />, {
       initialState: withFlagOverrides({

--- a/apps/ledger-live-mobile/docs/deeplinks.md
+++ b/apps/ledger-live-mobile/docs/deeplinks.md
@@ -117,6 +117,8 @@ When working on deeplinks, please update the **Wiki** accordingly.
 
   `ledgerlive://earn?action=get-funds&currencyId=ethereum` will open buy drawer with specified currency
 
+  `ledgerlive://earn/simulate` (or `ledgerlive://earn?action=simulate`) will open the earn rewards simulator
+
 - **_paytab_** 🠒 Pay Tab (when `lwmPayTab` is on)
 
   `ledgerlive://paytab` opens the Pay tab.

--- a/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
+++ b/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
@@ -478,6 +478,8 @@ export const DeeplinksProvider = ({
                                * * @params ?currencyId: string
                                * ie: "ledgerlive://earn?action=get-funds&currencyId=ethereum" will open buy drawer with currency
                                *
+                               * ie: "ledgerlive://earn/simulate" will open the earn rewards simulator
+                               *
                                */
                               [ScreenName.Earn]: "earn",
                             },
@@ -787,12 +789,15 @@ export const DeeplinksProvider = ({
                 searchParams.get("cryptoAssetId") || undefined,
                 searchParams.get("accountId") || undefined,
               );
-              // Handle deposit deeplink on earnLiveAppNavigator
-              // Creating own search params for deposit deeplink
               url.pathname = "";
               url.searchParams.set("action", "deposit");
               url.searchParams.set("cryptoAssetId", validatedModal.cryptoAssetId ?? "");
               url.searchParams.set("accountId", validatedModal.accountId ?? "");
+              return getStateFromPath(url.href?.split("://")[1], config);
+            }
+            if (pathname === "/simulate") {
+              url.pathname = "";
+              url.searchParams.set("action", "simulate");
               return getStateFromPath(url.href?.split("://")[1], config);
             }
           }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Campaigns and the earn live app need a stable way to open the rewards simulator. `earn?action=simulate` already existed on mobile, but `earn/simulate` was not routed, and desktop had no simulate deeplink at all.

This PR adds `ledgerlive://earn/simulate` / `ledgerwallet://earn/simulate` on both apps: mobile rewrites the path to `action=simulate` (same navigator as today), and desktop navigates to `/earn` with `intent: "simulate"` so the webview receives the same input as mobile.

Covered by desktop unit tests for parse/handler/earn screen. Mobile routing is a small path rewrite in `DeeplinksProvider`; `action=simulate` was already handled.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36400](https://ledgerhq.atlassian.net/browse/LIVE-36400)
- **ADR** (if any): N/A

### Test plan

- [ ] Desktop: open `{ledgerwallet|ledgerlive}://earn/simulate` (deeplinks test page) and confirm the rewards simulator opens
- [ ] Mobile: open `ledgerlive://earn/simulate` and confirm the rewards simulator opens
- [ ] Mobile: `ledgerlive://earn?action=simulate` still works
- [ ] Existing earn deeplinks (`earn`, `earn/deposit`, `earn?action=stake`) are unchanged

[LIVE-36400]: https://ledgerhq.atlassian.net/browse/LIVE-36400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ