### PR TITLE
ci(e2e): rebuild AVD cache, stop false death reports (QAA-1509)

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -425,7 +425,12 @@ jobs:
           echo "android_js_key=${PREFIX}${HEAD_SHA}-detox-js-android" >> $GITHUB_OUTPUT
           echo "android_timing_cache_key=${PREFIX}android-e2e-timing-${{ hashFiles('e2e/mobile/specs') }}-2" >> $GITHUB_OUTPUT
           echo "ios_timing_cache_key=${PREFIX}ios-e2e-timing-${{ hashFiles('e2e/mobile/specs') }}-2" >> $GITHUB_OUTPUT
-          echo "avd_cache_key=${{ runner.os }}-detox-avd-${{ env.AVD_NAME }}_5-${{ env.AVD_PROFILE }}-${{ env.AVD_TARGET }}-${{ env.AVD_API }}-${{ env.AVD_ARCH }}-${{ env.AVD_CORES }}-${{ env.AVD_RAM_SIZE }}-${{ env.AVD_HEAP_SIZE }}-r2-v8" >> $GITHUB_OUTPUT
+          # QAA-1509: this cache carries /usr/local/lib/android/sdk/emulator/, so the
+          # emulator binary every shard runs is whichever one sdkmanager installed the
+          # last time this key changed -- the setup job is skipped while the object
+          # exists. Bump the trailing version to force a rebuild onto a current
+          # emulator; the one pinned since AVD_API went to 36 segfaults mid-run.
+          echo "avd_cache_key=${{ runner.os }}-detox-avd-${{ env.AVD_NAME }}_5-${{ env.AVD_PROFILE }}-${{ env.AVD_TARGET }}-${{ env.AVD_API }}-${{ env.AVD_ARCH }}-${{ env.AVD_CORES }}-${{ env.AVD_RAM_SIZE }}-${{ env.AVD_HEAP_SIZE }}-r2-v9" >> $GITHUB_OUTPUT
 
       - name: Prepare test filter
         id: test-filter

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -1080,13 +1080,40 @@ jobs:
           fi
 
           DEATHS="${{ env.MOBILE_ARTIFACTS_ROOT }}/emulator-deaths.log"
+          WATCHLOG="${{ env.MOBILE_ARTIFACTS_ROOT }}/emulator-watchdog.log"
+          CORES="${{ env.MOBILE_ARTIFACTS_ROOT }}/crash-backtraces/coredumpctl-list.txt"
           if [ -s "$DEATHS" ]; then
+            LOST="$(awk '{print $2}' "$DEATHS" | sort -u | tr '\n' ' ')"
+            # Same default as the boot/watch scripts, which is what actually ran.
+            TOTAL="$(wc -w <<<"${EMULATOR_SERIALS:-emulator-5554 emulator-5556 emulator-5558}" | tr -d ' ')"
             {
               echo "### ❌ Emulator died during this shard"
+              echo "**Lost:** \`${LOST}\`  |  **Devices affected:** $(awk '{print $2}' "$DEATHS" | sort -u | wc -l | tr -d ' ') of ${TOTAL}"
+              echo
               echo '```'
               cat "$DEATHS"
               echo '```'
+              # The watchdog only writes here after a loss survives several polls with no
+              # stop file, so this is a real mid-run death and not the shard's teardown.
+              if [ -s "$CORES" ] && grep -qi SIGSEGV "$CORES"; then
+                echo "**Coredumps:** SIGSEGV recorded - qemu crashed (QAA-1509)."
+              elif [ -s "$CORES" ]; then
+                echo "**Coredumps:** none recorded, so the device was lost without a qemu crash."
+              else
+                echo "_Re-run with \`emulator_diagnostics: true\` for coredumps and host forensics._"
+              fi
+              echo
               echo "Test failures after this point are not meaningful - see QAA-1497."
+              if [ -s "$WATCHLOG" ]; then
+                echo
+                echo "<details><summary>Watchdog log (last 20 lines)</summary>"
+                echo
+                echo '```'
+                tail -20 "$WATCHLOG"
+                echo '```'
+                echo
+                echo "</details>"
+              fi
             } >> "$GITHUB_STEP_SUMMARY"
             while read -r line; do
               echo "::error title=Emulator died (QAA-1497)::$line"

--- a/tools/scripts/watch-android-emulators-ci.sh
+++ b/tools/scripts/watch-android-emulators-ci.sh
@@ -23,6 +23,7 @@
 #                       (default: "emulator-5554 emulator-5556 emulator-5558")
 #   WATCH_INTERVAL    - seconds between polls (default: 5)
 #   WATCH_STOP_FILE   - watcher exits once this file exists (workflow writes it after Detox)
+#   WATCH_CONFIRM_POLLS - polls a serial must stay missing to count as a death (default: 3)
 #   WATCH_DIAGNOSTICS - any non-empty value enables the opt-in tier
 #
 # Requires: adb on PATH. Never exits non-zero: this must not be able to fail a shard.
@@ -36,6 +37,8 @@ readonly DIAG_DIR="${ARTIFACTS_DIR}/host-diagnostics"
 readonly TREND_LOG="${DIAG_DIR}/host-trend.tsv"
 readonly INTERVAL="${WATCH_INTERVAL:-5}"
 readonly STOP_FILE="${WATCH_STOP_FILE:-${ARTIFACTS_DIR}/.watchdog-stop}"
+# Polls a serial must stay missing before it counts as a death rather than teardown.
+readonly CONFIRM_POLLS="${WATCH_CONFIRM_POLLS:-3}"
 readonly DIAGNOSTICS="${WATCH_DIAGNOSTICS:-}"
 read -r -a SERIALS <<<"${EMULATOR_SERIALS:-emulator-5554 emulator-5556 emulator-5558}"
 
@@ -183,9 +186,26 @@ diag_label="off"
 log "watching ${SERIALS[*]} every ${INTERVAL}s (diagnostics: ${diag_label})"
 declare -A alive=()      # serial has been seen up at least once
 declare -A reported=()
+declare -A pending=()    # serial -> timestamp it first looked gone
+declare -A misses=()     # serial -> consecutive polls it has been missing
+
+# Discard every unconfirmed loss: the stop file proves we are in teardown.
+drop_pending_as_teardown() {
+  local serial
+  for serial in "${!pending[@]}"; do
+    [ -n "${pending[$serial]:-}" ] &&
+      log "$serial went away at ${pending[$serial]} and the stop file followed — teardown, not a death"
+    pending[$serial]=""
+    misses[$serial]=0
+  done
+}
 
 while true; do
-  [ -f "$STOP_FILE" ] && { log "stop file present — exiting"; break; }
+  if [ -f "$STOP_FILE" ]; then
+    drop_pending_as_teardown
+    log "stop file present — exiting"
+    break
+  fi
 
   [ -n "$DIAGNOSTICS" ] && trend
   [ -n "$DIAGNOSTICS" ] && check_wedges
@@ -195,14 +215,30 @@ while true; do
     if grep -q "^${serial}[[:space:]]*device" <<<"$online"; then
       alive[$serial]=1
       reported[$serial]=""
+      pending[$serial]=""
+      misses[$serial]=0
     elif [ -n "${alive[$serial]:-}" ] && [ -z "${reported[$serial]:-}" ]; then
       # Only a serial that was previously UP can have "disappeared". Without this gate the
       # first polls, before the emulators finish booting, report three phantom deaths.
-      reported[$serial]=1
-      stamp="$(date -u +%Y%m%dT%H%M%SZ)"
-      log "❌ $serial is GONE at ${stamp}"
-      echo "${stamp} ${serial} disappeared from adb devices" >>"$DEATH_LOG"
-      [ -n "$DIAGNOSTICS" ] && capture_diagnostics "$serial" "$stamp"
+      #
+      # Do not report on first sight. Detox tears the emulators down inside its own step,
+      # seconds before the workflow can write the stop file, so at this instant a normal
+      # teardown is indistinguishable from a real death -- and reporting immediately turned
+      # every shard's shutdown into three "deaths" in the job summary. Hold the loss until
+      # it survives CONFIRM_POLLS polls with no stop file. A real death is permanent, so
+      # the delay costs nothing; qemu spends 2-4 minutes writing its core either way.
+      misses[$serial]=$(( ${misses[$serial]:-0} + 1 ))
+      if [ -z "${pending[$serial]:-}" ]; then
+        pending[$serial]="$(date -u +%Y%m%dT%H%M%SZ)"
+        log "⏳ $serial not in adb devices — confirming over $((CONFIRM_POLLS * INTERVAL))s"
+      elif [ "${misses[$serial]}" -ge "$CONFIRM_POLLS" ]; then
+        stamp="${pending[$serial]}"
+        reported[$serial]=1
+        pending[$serial]=""
+        log "❌ $serial is GONE at ${stamp} (confirmed after ${misses[$serial]} polls)"
+        echo "${stamp} ${serial} disappeared from adb devices" >>"$DEATH_LOG"
+        [ -n "$DIAGNOSTICS" ] && capture_diagnostics "$serial" "$stamp"
+      fi
     fi
   done
   sleep "$INTERVAL"


### PR DESCRIPTION
### Checklist

- [ ] `npx changeset` was attached. _Not applicable: this touches only `.github/workflows` and `tools/scripts`, so no package version is affected._
- [ ] **Covered by automatic tests.** _The watchdog is a CI shell script with no test harness in the repo. The teardown-vs-death logic was verified manually against a faked `adb`: teardown (all serials vanish, stop file follows) logged **0** deaths and classified 2 losses as teardown; a real death (one serial vanishes, another survives, no stop file) logged exactly **1**. The cache-key change is verified by CI itself — see Validation._
- [x] **Impact of the changes:**
      - Android E2E only. No app, library or product code is touched.
      - The AVD cache is rebuilt once on first run after merge (adds ~7 min to that run only; every later run hits the cache as before).
      - Emulator boot, rendering and device stability on the Android E2E fleet.
      - The "Emulator died during this shard" job-summary banner and its `::error` annotations.

### Description

**Problem 1 — we pinned a four-month-old emulator without realising it.**

`tools/actions/composites/setup-android-avd` uploads `/usr/local/lib/android/sdk/emulator/` to R2, and every shard unpacks that tarball at `/`, which **overwrites the emulator the runner image ships**. The job that rebuilds the cache is gated `if: ... avd_exists != 'true'`, so it only runs on a cache miss. The key's last meaningful change was `AVD_API` going to 36 on 2026-04-15, so the qemu binary had been frozen since April.

That binary segfaults mid-run ([QAA-1509](https://ledgerhq.atlassian.net/browse/QAA-1509)): `SIGSEGV`, a ~1 GB core written over 2–4 minutes, `adb` loses the serial, and every later spec on that worker fails with a misleading assertion timeout.

Bumping the trailing token of the cache key forces the miss and rebuilds onto a current emulator:

| | Emulator | build_id |
| --- | --- | --- |
| Before (frozen cache) | 36.5.10.0 | 15081367 |
| After (rebuilt) | **37.1.11.0** | 15917651 |

**Problem 2 — the watchdog reported normal teardown as an emulator death.**

Detox tears the emulators down *inside* its own step, seconds before the workflow can write the watchdog stop file. The watchdog checked that file once per 5s cycle, so it polled into the gap, saw all three serials gone at once, and logged three deaths. Shard 1 of run 32823980620:

```
08:27:16  [EMU1/2/3] Netsim Wifi … is gone due to Stream removed (CANCELLED)   ← graceful shutdown
08:27:17  watchdog: ❌ emulator-5554/5556/5558 is GONE                          ← logged as deaths
08:27:22  watchdog: stop file present — exiting                                 ← 5s too late
```

The result was a red **"❌ Emulator died during this shard"** banner plus `::error` annotations on nearly every shard, for a normal shutdown — which trains everyone to ignore the one signal the watchdog exists to provide.

A suspected loss is now held for `WATCH_CONFIRM_POLLS` polls (default 3 = 15s) and discarded if the stop file arrives meanwhile. A real death is permanent, so the delay costs nothing; qemu spends 2–4 minutes writing its core either way.

The banner is also worth reading when it does fire — which serials were lost out of how many, whether a SIGSEGV coredump was recorded (this separates "qemu crashed" from "device lost without a crash", two different problems that looked identical before), and the watchdog log tail in a collapsed section:

```
### ❌ Emulator died during this shard
**Lost:** `emulator-5556`  |  **Devices affected:** 1 of 3

20260825T082717Z emulator-5556 disappeared from adb devices

**Coredumps:** SIGSEGV recorded - qemu crashed (QAA-1509).

Test failures after this point are not meaningful - see QAA-1497.

<details><summary>Watchdog log (last 20 lines)</summary> …
```

### Validation

| Run | Result |
| --- | --- |
| [Full Android, this branch](https://github.com/LedgerHQ/ledger-live/actions/runs/32831553949) | 🔄 in progress — the summaries to eyeball for the banner fix |
| [Full Android, cache bump only](https://github.com/LedgerHQ/ledger-live/actions/runs/32823980620) | Emulator moved 36.5.10.0 → **37.1.11.0**; **292/311 passed**; `coredumpctl`: `No coredumps found.` on every shard |
| [Post-merge nightly, old emulator](https://github.com/LedgerHQ/ledger-live/actions/runs/32792369689) | Baseline for comparison: 16 never-passed, mean shard 24.5 min |

The 292/311 result is the one that matters for the cache bump. Both previously-tried workarounds — `-gpu guest` and `-feature -Vulkan` — also stopped the segfaults, but only by breaking rendering so completely that nothing ran (24 of 24 failures were the identical render error). 37.1.11.0 does not: the suite renders and passes.

**Scope note for reviewers — do not close QAA-1509 on this PR.** The cache bump is **not** proven to fix the segfault. The comparison nightly ran the same shard lengths (mean 24.5 min vs 22.6 min here) on the **old** emulator and also recorded zero segfault-induced device losses, so the bug was not reproducing in the baseline either. The change is justified on its own merits — a silently-pinned four-month-old emulator is bad hygiene, and 37.1.11.0 demonstrably runs the suite clean — but it is hygiene, not a demonstrated fix.

One consequence worth flagging: the **"7 of 12 shards lost an emulator"** figure quoted in earlier QAA-1497/1509 analysis was measured with the banner bug present, so some of those were teardown. The genuine deaths are the ones backed by SIGSEGV coredumps, and that evidence is unaffected.

### Context

- **JIRA or GitHub link**: [QAA-1509](https://ledgerhq.atlassian.net/browse/QAA-1509)
- Parent epic: [QAA-1497](https://ledgerhq.atlassian.net/browse/QAA-1497)
- Full investigation: [The Android Nightly Investigation](https://claude.ai/code/artifact/b75482ca-2615-41e9-b9f2-8fa6661fe6b2)

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-1509]: https://ledgerhq.atlassian.net/browse/QAA-1509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ