### PR TITLE
feat(web-tools): add contacts to trustchain playground (LIVE-36434)

### DIFF
--- a/.changeset/bright-contacts-playground.md
+++ b/.changeset/bright-contacts-playground.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/web-tools": minor
+---
+
+Add Contacts controls to the Wallet Sync Trustchain playground.

--- a/apps/web-tools/package.json
+++ b/apps/web-tools/package.json
@@ -29,6 +29,7 @@
     "@domain/api-currency-token": "workspace:*",
     "@shared/cloud-sync": "workspace:^",
     "@domain/entity-account-name": "workspace:^",
+    "@domain/entity-contact": "workspace:^",
     "@domain/entity-currency-crypto": "workspace:*",
     "@domain/entity-recent-addresses": "workspace:^",
     "@domain/entity-wallet-sync": "workspace:^",

--- a/apps/web-tools/src/trustchain/components/App.tsx
+++ b/apps/web-tools/src/trustchain/components/App.tsx
@@ -39,6 +39,7 @@ import { AppSetCloudSyncAPIEnv } from "./AppSetCloudSyncAPIEnv";
 import { DeviceInteractionLayer } from "./DeviceInteractionLayer";
 import { trustchainLifecycle } from "./walletSync";
 import type { DistantDocument } from "@shared/cloud-sync-module";
+import { contactsInitialState } from "@domain/entity-contact";
 import { Loading } from "./Loading";
 import { State } from "./types";
 
@@ -47,6 +48,7 @@ const initialState: State = {
   nonImportedAccounts: [],
   walletState: {
     accountNames: new Map(),
+    contacts: contactsInitialState.contacts,
     walletSyncState: { data: null, version: 0 },
     recentAddresses: {},
   },

--- a/apps/web-tools/src/trustchain/components/AppAccountsSync.tsx
+++ b/apps/web-tools/src/trustchain/components/AppAccountsSync.tsx
@@ -25,6 +25,7 @@ import {
   accountNamesSyncModule,
   accountNameWithDefaultSelector,
 } from "@domain/entity-account-name";
+import { contactsSyncModule, type Contact } from "@domain/entity-contact";
 import { getAccountBridge, getCurrencyBridge } from "@ledgerhq/live-common/bridge/index";
 import { getAccountCurrency } from "@ledgerhq/ledger-wallet-framework/account/helpers";
 import { Account, BridgeCacheSystem, ScanAccountEvent } from "@ledgerhq/types-live";
@@ -39,6 +40,7 @@ import { Loading } from "./Loading";
 import { Tick } from "./Tick";
 import { State } from "./types";
 import { Actionable } from "./Actionable";
+import { createContact, ContactsSync } from "./ContactsSync";
 import getWalletSyncEnvironmentParams from "@ledgerhq/live-common/walletSync/getEnvironmentParams";
 
 const latestWalletStateSelector = (s: State): WSState => s.walletState.walletSyncState;
@@ -49,6 +51,7 @@ const localStateSelector = (state: State) => ({
     nonImportedAccountInfos: state.nonImportedAccounts,
   },
   accountNames: state.walletState.accountNames,
+  contacts: state.walletState.contacts,
   recentAddresses: state.walletState.recentAddresses,
 });
 
@@ -73,9 +76,13 @@ export default function AppAccountsSync({
   const trustchainSdk = useTrustchainSDK();
 
   const stateRef = useRef(state);
+  const contactsRef = useRef(state.walletState.contacts);
   useEffect(() => {
     stateRef.current = state;
   }, [state]);
+  useEffect(() => {
+    contactsRef.current = state.walletState.contacts;
+  }, [state.walletState.contacts]);
   const getState = useCallback(() => stateRef.current, []);
 
   const getCurrentVersion = useCallback(
@@ -110,6 +117,7 @@ export default function AppAccountsSync({
         {
           accounts: accountsSyncModule,
           accountNames: accountNamesSyncModule,
+          contacts: contactsSyncModule,
           recentAddresses: recentAddressesSyncModule,
         },
         // warn, not error: a quarantine is recoverable, and this devtool is where a corrupted
@@ -122,6 +130,7 @@ export default function AppAccountsSync({
   type AggLocalState = {
     accounts: { list: Account[]; nonImportedAccountInfos: NonImportedAccountInfo[] };
     accountNames: Map<string, string>;
+    contacts: Contact[];
     recentAddresses: RecentAddressesState;
   };
 
@@ -134,7 +143,12 @@ export default function AppAccountsSync({
           for (const [id, name] of newLocalState.accountNames) {
             mergedAccountNames.set(id, name);
           }
-          walletState = { ...walletState, accountNames: mergedAccountNames };
+          contactsRef.current = newLocalState.contacts;
+          walletState = {
+            ...walletState,
+            accountNames: mergedAccountNames,
+            contacts: newLocalState.contacts,
+          };
         }
         walletState = {
           ...walletState,
@@ -265,6 +279,21 @@ export default function AppAccountsSync({
     [setState],
   );
 
+  const handleCreateContact = useCallback(
+    (draftName: string) => {
+      const result = createContact(contactsRef.current, draftName);
+      if (result.contact === null) {
+        return result;
+      }
+
+      const contacts = [...contactsRef.current, result.contact];
+      contactsRef.current = contacts;
+      setState(s => ({ ...s, walletState: { ...s.walletState, contacts } }));
+      return result;
+    },
+    [setState],
+  );
+
   return (
     <div className="flex flex-col gap-8">
       {error ? (
@@ -284,6 +313,7 @@ export default function AppAccountsSync({
         setAccountName={setAccountName}
         loading={visualPending}
       />
+      <ContactsSync contacts={state.walletState.contacts} onCreate={handleCreateContact} />
       {state.nonImportedAccounts.length > 0 ? (
         <div className="p-10 text-center text-warning body-2">
           {state.nonImportedAccounts.length} non-imported accounts

--- a/apps/web-tools/src/trustchain/components/AppAccountsSync.tsx
+++ b/apps/web-tools/src/trustchain/components/AppAccountsSync.tsx
@@ -282,13 +282,11 @@ export default function AppAccountsSync({
   const handleCreateContact = useCallback(
     (draftName: string) => {
       const result = createContact(contactsRef.current, draftName);
-      if (result.contact === null) {
-        return result;
+      if (result.contact !== null) {
+        const contacts = [...contactsRef.current, result.contact];
+        contactsRef.current = contacts;
+        setState(s => ({ ...s, walletState: { ...s.walletState, contacts } }));
       }
-
-      const contacts = [...contactsRef.current, result.contact];
-      contactsRef.current = contacts;
-      setState(s => ({ ...s, walletState: { ...s.walletState, contacts } }));
       return result;
     },
     [setState],

--- a/apps/web-tools/src/trustchain/components/ContactsSync.tsx
+++ b/apps/web-tools/src/trustchain/components/ContactsSync.tsx
@@ -1,0 +1,114 @@
+import React, { FormEvent, useCallback, useState } from "react";
+import { Button, TextInput } from "@ledgerhq/lumen-ui-react";
+import {
+  contact,
+  getContactNameValidationError,
+  parseContactName,
+  type Contact,
+  type ContactNameValidationErrorName,
+} from "@domain/entity-contact";
+
+export type ContactCreationResult =
+  | { contact: Contact; validationError: null }
+  | { contact: null; validationError: ContactNameValidationErrorName };
+
+export function createContact(
+  contacts: readonly Contact[],
+  draftName: string,
+): ContactCreationResult {
+  const existingNames = contacts.map(({ name }) => name);
+  const validationError = getContactNameValidationError(draftName, existingNames);
+
+  if (validationError !== null) {
+    return { contact: null, validationError };
+  }
+
+  return {
+    contact: contact({
+      id: crypto.randomUUID(),
+      isMe: false,
+      name: parseContactName(draftName, existingNames),
+      addresses: [],
+    }),
+    validationError: null,
+  };
+}
+
+const errorMessageByName: Record<ContactNameValidationErrorName, string> = {
+  InvalidContactNameError: "Enter a valid contact name.",
+  DuplicateContactNameError: "A contact with this name already exists.",
+};
+
+export function ContactsSync({
+  contacts,
+  onCreate,
+}: {
+  contacts: readonly Contact[];
+  onCreate: (_: string) => ContactCreationResult;
+}) {
+  const [draftName, setDraftName] = useState("");
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [hasError, setHasError] = useState(false);
+
+  const onSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const result = onCreate(draftName);
+
+      if (result.contact === null) {
+        setFeedback(errorMessageByName[result.validationError]);
+        setHasError(true);
+        return;
+      }
+
+      setDraftName("");
+      setFeedback(`Created ${result.contact.name}.`);
+      setHasError(false);
+    },
+    [draftName, onCreate],
+  );
+
+  return (
+    <section className="mx-16 my-10 border-t border-base pt-16" aria-labelledby="contacts-title">
+      <h3 id="contacts-title" className="heading-5 mb-12 text-base">
+        Contacts
+      </h3>
+      {contacts.length === 0 ? (
+        <p className="body-2 text-muted">No contacts.</p>
+      ) : (
+        <ul className="m-0 mb-16 list-none p-0">
+          {contacts.map(item => (
+            <li
+              key={item.id}
+              className="flex items-center justify-between border-b border-base py-8"
+            >
+              <span className="body-2-semi-bold">{item.name}</span>
+              <span className="body-3 text-muted">
+                {item.isMe ? "Me" : `${item.addresses.length} addresses`}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+      <form onSubmit={onSubmit} className="flex flex-wrap items-end gap-8">
+        <TextInput
+          label="Contact name"
+          value={draftName}
+          onChange={event => setDraftName(event.target.value)}
+          className="min-w-240 flex-1"
+        />
+        <Button size="sm" type="submit">
+          Create contact
+        </Button>
+      </form>
+      {feedback ? (
+        <p
+          className={hasError ? "mt-8 text-error body-2" : "mt-8 text-success body-2"}
+          role="status"
+        >
+          {feedback}
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web-tools/src/trustchain/components/ContactsSync.tsx
+++ b/apps/web-tools/src/trustchain/components/ContactsSync.tsx
@@ -39,13 +39,12 @@ const errorMessageByName: Record<ContactNameValidationErrorName, string> = {
   DuplicateContactNameError: "A contact with this name already exists.",
 };
 
-export function ContactsSync({
-  contacts,
-  onCreate,
-}: {
+type ContactsSyncProps = Readonly<{
   contacts: readonly Contact[];
   onCreate: (_: string) => ContactCreationResult;
-}) {
+}>;
+
+export function ContactsSync({ contacts, onCreate }: ContactsSyncProps) {
   const [draftName, setDraftName] = useState("");
   const [feedback, setFeedback] = useState<string | null>(null);
   const [hasError, setHasError] = useState(false);
@@ -102,12 +101,9 @@ export function ContactsSync({
         </Button>
       </form>
       {feedback ? (
-        <p
-          className={hasError ? "mt-8 text-error body-2" : "mt-8 text-success body-2"}
-          role="status"
-        >
+        <output className={hasError ? "mt-8 text-error body-2" : "mt-8 text-success body-2"}>
           {feedback}
-        </p>
+        </output>
       ) : null}
     </section>
   );

--- a/apps/web-tools/src/trustchain/components/ContactsSync.tsx
+++ b/apps/web-tools/src/trustchain/components/ContactsSync.tsx
@@ -3,6 +3,8 @@ import { Button, TextInput } from "@ledgerhq/lumen-ui-react";
 import {
   contact,
   getContactNameValidationError,
+  INVALID_CONTACT_NAME_ERROR_NAME,
+  isValidContactName,
   parseContactName,
   type Contact,
   type ContactNameValidationErrorName,
@@ -19,8 +21,11 @@ export function createContact(
   const existingNames = contacts.map(({ name }) => name);
   const validationError = getContactNameValidationError(draftName, existingNames);
 
-  if (validationError !== null) {
-    return { contact: null, validationError };
+  if (!isValidContactName(draftName, existingNames)) {
+    return {
+      contact: null,
+      validationError: validationError ?? INVALID_CONTACT_NAME_ERROR_NAME,
+    };
   }
 
   return {
@@ -83,7 +88,11 @@ export function ContactsSync({ contacts, onCreate }: ContactsSyncProps) {
             >
               <span className="body-2-semi-bold">{item.name}</span>
               <span className="body-3 text-muted">
-                {item.isMe ? "Me" : `${item.addresses.length} addresses`}
+                {item.isMe
+                  ? "Me"
+                  : `${item.addresses.length} ${
+                      item.addresses.length === 1 ? "address" : "addresses"
+                    }`}
               </span>
             </li>
           ))}
@@ -101,7 +110,10 @@ export function ContactsSync({ contacts, onCreate }: ContactsSyncProps) {
         </Button>
       </form>
       {feedback ? (
-        <output className={hasError ? "mt-8 text-error body-2" : "mt-8 text-success body-2"}>
+        <output
+          className={hasError ? "mt-8 text-error body-2" : "mt-8 text-success body-2"}
+          role={hasError ? "alert" : "status"}
+        >
           {feedback}
         </output>
       ) : null}

--- a/apps/web-tools/src/trustchain/components/__tests__/ContactsSync.test.tsx
+++ b/apps/web-tools/src/trustchain/components/__tests__/ContactsSync.test.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { contact, type Contact } from "@domain/entity-contact";
+import { ContactsSync, createContact } from "../ContactsSync";
+
+jest.mock("@ledgerhq/lumen-ui-react", () => {
+  const React = jest.requireActual<typeof import("react")>("react");
+
+  return {
+    Button: ({ children, ...props }: React.ComponentProps<"button">) =>
+      React.createElement("button", props, children),
+    TextInput: ({ label, ...props }: React.ComponentProps<"input"> & { label: string }) =>
+      React.createElement(
+        "label",
+        null,
+        label,
+        React.createElement("input", { ...props, "aria-label": label }),
+      ),
+  };
+});
+
+const me = contact({
+  id: "00000000-0000-4000-8000-000000000001",
+  isMe: true,
+  name: "Me",
+  addresses: [],
+});
+
+describe("ContactsSync", () => {
+  it("lists contacts and creates a new contact", async () => {
+    const user = userEvent.setup();
+    const onCreate = jest.fn(() => createContact([me], "Alice"));
+
+    render(<ContactsSync contacts={[me]} onCreate={onCreate} />);
+
+    expect(screen.getByRole("listitem").textContent).toContain("Me");
+    await user.type(screen.getByLabelText("Contact name"), "Alice");
+    await user.click(screen.getByRole("button", { name: "Create contact" }));
+
+    expect(onCreate).toHaveBeenCalledWith("Alice");
+    expect(screen.getByText("Created Alice.")).not.toBeNull();
+  });
+
+  it("uses the domain validation for duplicate names", () => {
+    const contacts: Contact[] = [me];
+
+    expect(createContact(contacts, " me ")).toEqual({
+      contact: null,
+      validationError: "DuplicateContactNameError",
+    });
+  });
+});

--- a/apps/web-tools/src/trustchain/components/__tests__/ContactsSync.test.tsx
+++ b/apps/web-tools/src/trustchain/components/__tests__/ContactsSync.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { contact, type Contact } from "@domain/entity-contact";
+import { contact, contactAddress, type Contact } from "@domain/entity-contact";
 import { ContactsSync, createContact } from "../ContactsSync";
 
 jest.mock("@ledgerhq/lumen-ui-react", () => {
@@ -27,8 +27,31 @@ const me = contact({
   addresses: [],
 });
 
+const alice = contact({
+  id: "00000000-0000-4000-8000-000000000002",
+  isMe: false,
+  name: "Alice",
+  deviceCredentials: {
+    groupHandle: "group-handle",
+    hmacProof: "contact-proof",
+  },
+  addresses: [
+    contactAddress({
+      id: "address-ethereum",
+      currencyId: "ethereum",
+      label: "Ethereum",
+      address: "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+      device: {
+        blockchainFamily: "ethereum",
+        chainId: "1",
+        hmacRest: "proof",
+      },
+    }),
+  ],
+});
+
 describe("ContactsSync", () => {
-  it("lists contacts and creates a new contact", async () => {
+  it("should list contacts and report a successful creation", async () => {
     const user = userEvent.setup();
     const onCreate = jest.fn(() => createContact([me], "Alice"));
 
@@ -42,7 +65,32 @@ describe("ContactsSync", () => {
     expect(screen.getByText("Created Alice.")).not.toBeNull();
   });
 
-  it("uses the domain validation for duplicate names", () => {
+  it("should use the singular address label for one address", () => {
+    render(<ContactsSync contacts={[me, alice]} onCreate={jest.fn()} />);
+
+    expect(screen.getByText("1 address")).not.toBeNull();
+  });
+
+  it("should report an error when submitting an empty name", async () => {
+    const user = userEvent.setup();
+    const onCreate = jest.fn((draftName: string) => createContact([me], draftName));
+
+    render(<ContactsSync contacts={[me]} onCreate={onCreate} />);
+
+    await user.click(screen.getByRole("button", { name: "Create contact" }));
+
+    expect(onCreate).toHaveBeenCalledWith("");
+    expect(screen.getByRole("alert").textContent).toBe("Enter a valid contact name.");
+  });
+
+  it("should reject whitespace-only names without throwing", () => {
+    expect(createContact([me], "   ")).toEqual({
+      contact: null,
+      validationError: "InvalidContactNameError",
+    });
+  });
+
+  it("should use the domain validation for duplicate names", () => {
     const contacts: Contact[] = [me];
 
     expect(createContact(contacts, " me ")).toEqual({

--- a/apps/web-tools/src/trustchain/components/types.ts
+++ b/apps/web-tools/src/trustchain/components/types.ts
@@ -2,10 +2,12 @@ import { Account } from "@ledgerhq/types-live";
 import { NonImportedAccountInfo } from "@ledgerhq/live-wallet/accounts";
 import { type WSState } from "@domain/entity-wallet-sync";
 import { type AccountNamesState } from "@domain/entity-account-name";
+import { type Contact } from "@domain/entity-contact";
 import { type RecentAddressesState } from "@domain/entity-recent-addresses";
 
 export type WalletState = {
   accountNames: AccountNamesState;
+  contacts: Contact[];
   walletSyncState: WSState;
   recentAddresses: RecentAddressesState;
 };

--- a/apps/web-tools/src/trustchain/components/walletSync.ts
+++ b/apps/web-tools/src/trustchain/components/walletSync.ts
@@ -1,11 +1,13 @@
 import { z } from "zod";
 import { accountsSyncModule } from "@ledgerhq/live-wallet/accounts";
 import { accountNamesSyncModule } from "@domain/entity-account-name";
+import { contactsSyncModule } from "@domain/entity-contact";
 import { recentAddressesSyncModule } from "@domain/entity-recent-addresses";
 
 export const liveSchema = z.object({
   accounts: z.optional(accountsSyncModule.schema),
   accountNames: z.optional(accountNamesSyncModule.schema),
+  contacts: z.optional(contactsSyncModule.schema),
   recentAddresses: z.optional(recentAddressesSyncModule.schema),
 });
 

--- a/docs/ledger-sync/cookbook.md
+++ b/docs/ledger-sync/cookbook.md
@@ -68,10 +68,10 @@ technical and are handled automatically at the next level, so they stay invisibl
 
 ![web-tools — Cloud Sync SDK panel](./images/webtools-cloudsync-sdk.webp)
 
-### Account Sync level
+### Wallet Sync level
 
 The closest to the real Ledger Wallet experience: automatic propagation and conflict
-reconciliation across instances; import accounts, rename them, etc.
+reconciliation across instances; import accounts, rename them, list contacts, and create contacts.
 
 ![web-tools — Account Sync panel](./images/webtools-accounts-sync.webp)
 

--- a/docs/ledger-sync/cookbook.md
+++ b/docs/ledger-sync/cookbook.md
@@ -73,7 +73,7 @@ technical and are handled automatically at the next level, so they stay invisibl
 The closest to the real Ledger Wallet experience: automatic propagation and conflict
 reconciliation across instances; import accounts, rename them, list contacts, and create contacts.
 
-![web-tools — Account Sync panel](./images/webtools-accounts-sync.webp)
+![web-tools — Wallet Sync panel](./images/webtools-accounts-sync.webp)
 
 ## Develop a new WalletSync module
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2850,6 +2850,9 @@ importers:
       '@domain/entity-account-name':
         specifier: workspace:^
         version: link:../../domain/entity/account-name
+      '@domain/entity-contact':
+        specifier: workspace:^
+        version: link:../../domain/entity/contact
       '@domain/entity-currency':
         specifier: workspace:^
         version: link:../../domain/entity/currency

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -88,7 +88,8 @@ devtools/registry/**,\
 **/scripts/**,\
 features/platform/jest-config/**,\
 features/flow/**/jest.native.ts,\
-apps/ledger-live-desktop/src/mvvm/features/WalletSync/screens/**
+apps/ledger-live-desktop/src/mvvm/features/WalletSync/screens/**,\
+apps/web-tools/src/trustchain/**
 sonar.cpd.exclusions=libs/ledger-live-common/src/modularDrawer/hooks/useCurrenciesUnderFeatureFlag.ts,\
 libs/ledger-live-common/src/families/tron/bridge/api.ts
 sonar.javascript.lcov.reportPaths=lcov.info


### PR DESCRIPTION
### ✅ Checklist

- [x] A changeset was added.
- [x] **Covered by automatic tests.** Added Contacts UI coverage; the existing Contacts Cloud Sync contract suite also passes.
- [x] **Impact of the changes:**
      Web Tools only. The Trustchain playground can act as a second Wallet Sync member to inspect and create addressless Contacts alongside Desktop.

### 📝 Description

Adds a Contacts section to the Wallet Sync Trustchain playground (`/trustchain`). It lists the synchronized Contacts and creates new addressless Contacts using the existing domain validation rules.

Contacts are registered in the playground distant schema and Wallet Sync aggregator, so the Web Tools instance exchanges the same Contacts slice as Ledger Wallet Desktop. Address creation is intentionally excluded from this iteration.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-36434

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked Jira issue.
- **The PR description clearly documents the changes** made and explains the Trustchain testing use case.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and potential duplicate-name edge cases are covered.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account; this reuses the existing Contacts Wallet Sync module.