### PR TITLE
fix(e2e): handle Buy/Sell network drawer and widen webview wait

### DIFF
--- a/e2e/mobile/page/trade/buySell.page.ts
+++ b/e2e/mobile/page/trade/buySell.page.ts
@@ -44,9 +44,15 @@ export default class BuySellPage {
     await waitForElementById(app.common.walletApiWebview, 60000, { checkVisibility: false });
   }
 
+  // App-side CAL lookup for the Buy screen's currencies (700+ ids) measures 60-90s;
+  // 60s flakes on that alone. Latency is tracked separately, not fixed here.
+  cryptoCurrencySelectorTimeout = 120000;
+
   @Step("Expect Buy screen to be visible")
   async expectBuyScreenToBeVisible() {
-    await waitWebElementByTestId(this.cryptoCurrencySelector);
+    await waitWebElementByTestId(this.cryptoCurrencySelector, {
+      timeout: this.cryptoCurrencySelectorTimeout,
+    });
     await detoxExpect(getWebElementsByIdAndText("", "You will pay")).toExist();
     await detoxExpect(getWebElementByTestId(this.amountInputSectionId())).toExist();
     await detoxExpect(getWebElementByTestId(this.buyQuickAmountButtonId("400"))).toExist();
@@ -57,7 +63,9 @@ export default class BuySellPage {
 
   @Step("Expect Sell screen to be visible")
   async expectSellScreenToBeVisible() {
-    await waitWebElementByTestId(this.cryptoCurrencySelector);
+    await waitWebElementByTestId(this.cryptoCurrencySelector, {
+      timeout: this.cryptoCurrencySelectorTimeout,
+    });
     await detoxExpect(getWebElementsByIdAndText("", "You will sell")).toExist();
     await detoxExpect(getWebElementByTestId(this.amountInputSectionId())).toExist();
     await detoxExpect(getWebElementByTestId(this.sellPercentageButtonId("25%"))).toExist();

--- a/e2e/mobile/specs/buySell/buySell.ts
+++ b/e2e/mobile/specs/buySell/buySell.ts
@@ -98,6 +98,10 @@ export async function runNavigateToBuyFromMarketPageTest(
       await app.market.expectMarketRowTitle(buySell.crypto.currency);
       await app.market.openAssetPage(buySell.crypto.currency);
       await app.market.tapOnMarketQuickActionButton("buy");
+      await app.modularDrawer.selectNetworkIfAsked(
+        app.modularDrawer.getNetworkNameForAccount(buySell.crypto),
+      );
+      await app.modularDrawer.selectFirstAccountIfAsked();
       await app.buySell.handleBuyFlow(buySell, paymentMethod);
     });
   });
@@ -128,6 +132,10 @@ export async function runNavigateToBuyFromAssetPageTest(
         buySell.crypto.currency.id,
       );
       await app.assetAccountsPage.tapOnAssetQuickActionButton("buy");
+      await app.modularDrawer.selectNetworkIfAsked(
+        app.modularDrawer.getNetworkNameForAccount(buySell.crypto),
+      );
+      await app.modularDrawer.selectFirstAccountIfAsked();
       await app.buySell.handleBuyFlow(buySell, paymentMethod);
     });
   });


### PR DESCRIPTION
## Summary

Today's CI run ([32792369689](https://github.com/LedgerHQ/ledger-live/actions/runs/32792369689)) had Buy/Sell E2E failures on both Android and iOS, all timing out on the same assertion (`crypto-amount-option-button` not found after 60s in `BuySellPage.expectBuyScreenToBeVisible`). Two independent causes:

- **Native "Select network" drawer blocks entry for multi-network assets.** A recent product change (LIVE-34547) makes tapping Buy on the asset/market page open a native network-selection drawer first for any currency with more than one network (ETH's L2s, USDT's multi-chain variants). `runNavigateToBuyFromAssetPageTest`/`runNavigateToBuyFromMarketPageTest` never handled it, so they waited 60s for a webview that was never reached. Fixed by calling the existing `modularDrawer.selectNetworkIfAsked(...)` / `selectFirstAccountIfAsked()` helpers right after the buy quick-action tap (no-ops for single-network currencies).
- **CAL `currency.list` latency.** The Buy screen's currency list resolves 700+ token ids against CAL one HTTP call at a time; even concurrency-bounded, that measures 60-90s on its own, landing right on the 60s wait and flaking on nothing but that latency. Widened `cryptoCurrencySelectorTimeout` to 120s (precedent for 120s waits already exists elsewhere in this suite: `evmStake.page.ts`, `portfolio.page.ts`). The backend latency itself is tracked separately (QAA-1497) and is out of scope here — not touching `libs/ledger-live-common`.

## Test plan
- [x] `node ./scripts/typecheck.js` (e2e/mobile) — clean
- [x] `oxlint page/trade/buySell.page.ts specs/buySell/buySell.ts` — clean
- [x] `pnpm format` (e2e) — no outstanding diff
- [x] [CI run on this branch to confirm the previously-failing Buy/Sell specs pass](https://github.com/LedgerHQ/ledger-live/actions/runs/32833416199)