### PR TITLE
[LWDM] feat(test-quarantine): report flakes from live-devices jest suites

### DIFF
--- a/features/platform/device-intent/jest.config.js
+++ b/features/platform/device-intent/jest.config.js
@@ -25,5 +25,7 @@ module.exports = {
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/features/platform/device-intent/package.json
+++ b/features/platform/device-intent/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@ledgerhq/device-management-kit": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@testing-library/dom": "catalog:",

--- a/libs/device-core/jest.config.js
+++ b/libs/device-core/jest.config.js
@@ -15,5 +15,7 @@ module.exports = {
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/libs/device-core/package.json
+++ b/libs/device-core/package.json
@@ -28,6 +28,9 @@
     "semver": "catalog:"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
     "@testing-library/dom": "catalog:",
     "@testing-library/react": "catalog:",
     "@types/jest": "catalog:",
@@ -37,9 +40,7 @@
     "jest": "catalog:",
     "jest-environment-jsdom": "catalog:",
     "oxfmt": "catalog:",
-    "oxlint": "catalog:",
-    "@swc/jest": "catalog:",
-    "@swc/core": "catalog:"
+    "oxlint": "catalog:"
   },
   "scripts": {
     "clean": "rimraf lib lib-es",

--- a/libs/device-react/jest.config.js
+++ b/libs/device-react/jest.config.js
@@ -16,5 +16,7 @@ module.exports = {
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/libs/device-react/package.json
+++ b/libs/device-react/package.json
@@ -25,6 +25,9 @@
     "@ledgerhq/device-core": "workspace:^"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
     "@testing-library/dom": "catalog:",
     "@testing-library/react": "catalog:",
     "@types/jest": "catalog:",
@@ -34,9 +37,7 @@
     "oxfmt": "catalog:",
     "oxlint": "catalog:",
     "react": "catalog:",
-    "react-dom": "catalog:",
-    "@swc/jest": "catalog:",
-    "@swc/core": "catalog:"
+    "react-dom": "catalog:"
   },
   "scripts": {
     "clean": "rimraf lib lib-es",

--- a/libs/hw-transport-http/jest.config.ts
+++ b/libs/hw-transport-http/jest.config.ts
@@ -25,5 +25,7 @@ export default {
         reportedFilePath: "absolute",
       },
     ],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/libs/hw-transport-http/package.json
+++ b/libs/hw-transport-http/package.json
@@ -64,14 +64,15 @@
   },
   "gitHead": "dd0dea64b58e5a9125c8a422dcffd29e5ef6abec",
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",
     "documentation": "14.0.2",
     "jest": "catalog:",
     "rimraf": "^4.4.1",
     "source-map-support": "^0.5.21",
-    "@swc/jest": "catalog:",
-    "@swc/core": "catalog:",
     "ts-node": "^10.4.0"
   }
 }

--- a/libs/live-dmk-desktop/jest.config.js
+++ b/libs/live-dmk-desktop/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
   },
   testEnvironment: "jsdom",
   testPathIgnorePatterns: ["lib/", "lib-es/"],
-  setupFilesAfterEnv: ["<rootDir>/tests.setup.ts"],
+  setupFilesAfterEnv: ["<rootDir>/tests.setup.ts", "@ledgerhq/test-quarantine/jest-retries"],
   moduleNameMapper: {
     "^@ledgerhq/device-transport-kit-web-hid$":
       "<rootDir>/tests/__mocks__/device-transport-kit-web-hid.ts",
@@ -21,5 +21,6 @@ module.exports = {
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
 };

--- a/libs/live-dmk-desktop/package.json
+++ b/libs/live-dmk-desktop/package.json
@@ -42,6 +42,7 @@
     "@shared/env": "workspace:*"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@testing-library/dom": "catalog:",

--- a/libs/live-dmk-mobile/jest.config.js
+++ b/libs/live-dmk-mobile/jest.config.js
@@ -11,11 +11,12 @@ module.exports = {
   },
   testEnvironment: "jsdom",
   testPathIgnorePatterns: ["lib/", "lib-es/"],
-  setupFilesAfterEnv: ["<rootDir>/tests.setup.ts"],
+  setupFilesAfterEnv: ["<rootDir>/tests.setup.ts", "@ledgerhq/test-quarantine/jest-retries"],
   coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../" }], "text"],
   reporters: [
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
 };

--- a/libs/live-dmk-mobile/package.json
+++ b/libs/live-dmk-mobile/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@ledgerhq/device-transport-kit-react-native-hid": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@testing-library/dom": "catalog:",

--- a/libs/live-dmk-shared/jest.config.js
+++ b/libs/live-dmk-shared/jest.config.js
@@ -11,11 +11,12 @@ module.exports = {
   },
   testEnvironment: "jsdom",
   testPathIgnorePatterns: ["lib/", "lib-es/"],
-  setupFilesAfterEnv: ["<rootDir>/tests.setup.ts"],
+  setupFilesAfterEnv: ["<rootDir>/tests.setup.ts", "@ledgerhq/test-quarantine/jest-retries"],
   coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../" }], "text"],
   reporters: [
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
 };

--- a/libs/live-dmk-shared/package.json
+++ b/libs/live-dmk-shared/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@ledgerhq/device-management-kit": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@testing-library/dom": "catalog:",

--- a/libs/live-dmk-speculos/jest.config.js
+++ b/libs/live-dmk-speculos/jest.config.js
@@ -11,11 +11,12 @@ module.exports = {
   },
   testEnvironment: "jsdom",
   testPathIgnorePatterns: ["lib/", "lib-es/"],
-  setupFilesAfterEnv: ["<rootDir>/tests.setup.ts"],
+  setupFilesAfterEnv: ["<rootDir>/tests.setup.ts", "@ledgerhq/test-quarantine/jest-retries"],
   coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../" }], "text"],
   reporters: [
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
 };

--- a/libs/live-dmk-speculos/package.json
+++ b/libs/live-dmk-speculos/package.json
@@ -58,6 +58,7 @@
     "@shared/env": "workspace:*"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@testing-library/dom": "catalog:",

--- a/libs/live-signer-aleo/jest.config.js
+++ b/libs/live-signer-aleo/jest.config.js
@@ -17,5 +17,7 @@ module.exports = {
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/libs/live-signer-aleo/package.json
+++ b/libs/live-signer-aleo/package.json
@@ -46,12 +46,13 @@
     "coverage": "jest --coverage"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@ledgerhq/types-live": "workspace:^",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",
     "jest": "catalog:",
-    "@swc/jest": "catalog:",
-    "@swc/core": "catalog:",
     "rimraf": "^4.4.1",
     "ts-node": "^10.4.0",
     "ws": "catalog:"

--- a/libs/live-signer-canton/jest.config.js
+++ b/libs/live-signer-canton/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   testEnvironment: "node",
   testPathIgnorePatterns: ["lib/", "lib-es/"],
-  setupFilesAfterEnv: [],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
   transform: {
     "^.+\\.(ts|tsx)?$": [
       "@swc/jest",
@@ -12,5 +12,9 @@ module.exports = {
       },
     ],
   },
-  reporters: ["default", ...(process.env.CI ? ["github-actions"] : [])],
+  reporters: [
+    "default",
+    ...(process.env.CI ? ["github-actions"] : []),
+    "@ledgerhq/test-quarantine/jest",
+  ],
 };

--- a/libs/live-signer-canton/package.json
+++ b/libs/live-signer-canton/package.json
@@ -46,14 +46,15 @@
   },
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@ledgerhq/types-live": "workspace:^",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",
     "@types/semver": "catalog:",
     "jest": "catalog:",
     "rimraf": "^4.4.1",
-    "@swc/jest": "catalog:",
-    "@swc/core": "catalog:",
     "ts-node": "^10.4.0"
   },
   "exports": {

--- a/libs/live-signer-celo/jest.config.js
+++ b/libs/live-signer-celo/jest.config.js
@@ -17,5 +17,7 @@ module.exports = {
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/libs/live-signer-celo/package.json
+++ b/libs/live-signer-celo/package.json
@@ -43,13 +43,14 @@
     "coverage": "jest --coverage"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@ledgerhq/types-live": "workspace:^",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",
     "jest": "catalog:",
     "rimraf": "^4.4.1",
-    "@swc/jest": "catalog:",
-    "@swc/core": "catalog:",
     "ts-node": "^10.4.0"
   },
   "exports": {

--- a/libs/live-signer-concordium/jest.config.js
+++ b/libs/live-signer-concordium/jest.config.js
@@ -17,5 +17,7 @@ module.exports = {
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/libs/live-signer-concordium/package.json
+++ b/libs/live-signer-concordium/package.json
@@ -45,12 +45,13 @@
     "coverage": "jest --coverage"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",
     "jest": "catalog:",
     "rimraf": "^4.4.1",
-    "@swc/jest": "catalog:",
-    "@swc/core": "catalog:",
     "ts-node": "^10.4.0"
   },
   "exports": {

--- a/libs/live-signer-cosmos/jest.config.js
+++ b/libs/live-signer-cosmos/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   testEnvironment: "node",
   testPathIgnorePatterns: ["lib/", "lib-es/"],
-  setupFilesAfterEnv: ["@ledgerhq/disable-network-setup"],
+  setupFilesAfterEnv: ["@ledgerhq/disable-network-setup", "@ledgerhq/test-quarantine/jest-retries"],
   transform: {
     "^.+\\.(ts|tsx)?$": [
       "@swc/jest",
@@ -12,5 +12,9 @@ module.exports = {
       },
     ],
   },
-  reporters: ["default", ...(process.env.CI ? ["github-actions"] : [])],
+  reporters: [
+    "default",
+    ...(process.env.CI ? ["github-actions"] : []),
+    "@ledgerhq/test-quarantine/jest",
+  ],
 };

--- a/libs/live-signer-cosmos/package.json
+++ b/libs/live-signer-cosmos/package.json
@@ -47,14 +47,15 @@
   },
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@ledgerhq/types-live": "workspace:^",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",
     "@types/semver": "catalog:",
     "jest": "catalog:",
     "rimraf": "^4.4.1",
-    "@swc/jest": "catalog:",
-    "@swc/core": "catalog:",
     "ts-node": "^10.4.0"
   }
 }

--- a/libs/live-signer-evm/jest.config.js
+++ b/libs/live-signer-evm/jest.config.js
@@ -18,5 +18,10 @@ module.exports = {
       },
     ],
   },
-  reporters: ["default", ...(process.env.CI ? ["github-actions"] : [])],
+  reporters: [
+    "default",
+    ...(process.env.CI ? ["github-actions"] : []),
+    "@ledgerhq/test-quarantine/jest",
+  ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/libs/live-signer-evm/package.json
+++ b/libs/live-signer-evm/package.json
@@ -49,13 +49,14 @@
     "coverage": "jest --coverage"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@ledgerhq/types-live": "workspace:^",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",
     "jest": "catalog:",
     "rimraf": "^4.4.1",
-    "@swc/jest": "catalog:",
-    "@swc/core": "catalog:",
     "ts-node": "^10.4.0",
     "ws": "catalog:"
   },

--- a/libs/live-signer-hyperliquid/jest.config.js
+++ b/libs/live-signer-hyperliquid/jest.config.js
@@ -17,5 +17,7 @@ module.exports = {
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/libs/live-signer-hyperliquid/package.json
+++ b/libs/live-signer-hyperliquid/package.json
@@ -46,12 +46,13 @@
   },
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",
+    "@ledgerhq/test-quarantine": "workspace:*",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",
     "jest": "catalog:",
     "rimraf": "^4.4.1",
-    "@swc/jest": "catalog:",
-    "@swc/core": "catalog:",
     "ts-node": "^10.4.0"
   },
   "exports": {

--- a/libs/live-signer-solana/jest.config.js
+++ b/libs/live-signer-solana/jest.config.js
@@ -1,7 +1,11 @@
 module.exports = {
   testEnvironment: "node",
   testPathIgnorePatterns: ["lib/", "lib-es/"],
-  setupFilesAfterEnv: ["<rootDir>/jest.setup.js", "@ledgerhq/disable-network-setup"],
+  setupFilesAfterEnv: [
+    "<rootDir>/jest.setup.js",
+    "@ledgerhq/disable-network-setup",
+    "@ledgerhq/test-quarantine/jest-retries",
+  ],
   transform: {
     "^.+\\.(ts|tsx)?$": [
       "@swc/jest",
@@ -12,5 +16,9 @@ module.exports = {
       },
     ],
   },
-  reporters: ["default", ...(process.env.CI ? ["github-actions"] : [])],
+  reporters: [
+    "default",
+    ...(process.env.CI ? ["github-actions"] : []),
+    "@ledgerhq/test-quarantine/jest",
+  ],
 };

--- a/libs/live-signer-solana/package.json
+++ b/libs/live-signer-solana/package.json
@@ -55,16 +55,17 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@shared/env": "workspace:*",
     "@ledgerhq/disable-network-setup": "workspace:^",
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@ledgerhq/types-live": "workspace:^",
+    "@shared/env": "workspace:*",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",
     "@types/semver": "catalog:",
     "jest": "catalog:",
     "rimraf": "^4.4.1",
-    "@swc/jest": "catalog:",
-    "@swc/core": "catalog:",
     "ts-node": "^10.4.0"
   },
   "exports": {

--- a/libs/live-signer-zcash/jest.config.js
+++ b/libs/live-signer-zcash/jest.config.js
@@ -17,5 +17,7 @@ module.exports = {
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/libs/live-signer-zcash/package.json
+++ b/libs/live-signer-zcash/package.json
@@ -32,9 +32,10 @@
     "rxjs": "catalog:"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
     "@ledgerhq/types-live": "workspace:^",
-    "@swc/jest": "catalog:",
     "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",
     "jest": "catalog:",

--- a/libs/types-devices/jest.config.ts
+++ b/libs/types-devices/jest.config.ts
@@ -25,5 +25,7 @@ export default {
         reportedFilePath: "absolute",
       },
     ],
+    "@ledgerhq/test-quarantine/jest",
   ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
 };

--- a/libs/types-devices/package.json
+++ b/libs/types-devices/package.json
@@ -34,14 +34,15 @@
     "unimported": "unimported"
   },
   "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",
     "documentation": "14.0.2",
     "jest": "catalog:",
     "rimraf": "^4.4.1",
     "source-map-support": "^0.5.21",
-    "@swc/jest": "catalog:",
-    "@swc/core": "catalog:",
     "ts-node": "^10.4.0"
   },
   "exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6803,6 +6803,9 @@ importers:
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
         version: 1.7.1(rxjs@7.8.2)
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -10945,6 +10948,9 @@ importers:
         specifier: 'catalog:'
         version: 7.7.3
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -10988,6 +10994,9 @@ importers:
         specifier: workspace:^
         version: link:../device-core
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -11331,6 +11340,9 @@ importers:
         specifier: 'catalog:'
         version: 8.18.3
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -13884,6 +13896,9 @@ importers:
         specifier: workspace:*
         version: link:../../shared/env
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -13957,6 +13972,9 @@ importers:
       '@ledgerhq/device-transport-kit-react-native-hid':
         specifier: 'catalog:'
         version: 1.0.4(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(react@19.1.4))(rxjs@7.8.2)
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -14036,6 +14054,9 @@ importers:
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
         version: 1.7.1(rxjs@7.8.2)
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -14097,6 +14118,9 @@ importers:
         specifier: workspace:*
         version: link:../../shared/env
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -14366,6 +14390,9 @@ importers:
         specifier: 'catalog:'
         version: 7.8.2
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@ledgerhq/types-live':
         specifier: workspace:^
         version: link:../types-live
@@ -14415,6 +14442,9 @@ importers:
       '@ledgerhq/disable-network-setup':
         specifier: workspace:^
         version: link:../disable-network-setup
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@ledgerhq/types-live':
         specifier: workspace:^
         version: link:../types-live
@@ -14458,6 +14488,9 @@ importers:
         specifier: workspace:*
         version: link:../ledgerjs/packages/hw-transport
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@ledgerhq/types-live':
         specifier: workspace:^
         version: link:../types-live
@@ -14507,6 +14540,9 @@ importers:
         specifier: 'catalog:'
         version: 7.8.2
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -14556,6 +14592,9 @@ importers:
       '@ledgerhq/disable-network-setup':
         specifier: workspace:^
         version: link:../disable-network-setup
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@ledgerhq/types-live':
         specifier: workspace:^
         version: link:../types-live
@@ -14614,6 +14653,9 @@ importers:
         specifier: 'catalog:'
         version: 7.8.2
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@ledgerhq/types-live':
         specifier: workspace:^
         version: link:../types-live
@@ -14663,6 +14705,9 @@ importers:
       '@ledgerhq/disable-network-setup':
         specifier: workspace:^
         version: link:../disable-network-setup
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -14788,6 +14833,9 @@ importers:
       '@ledgerhq/disable-network-setup':
         specifier: workspace:^
         version: link:../disable-network-setup
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@ledgerhq/types-live':
         specifier: workspace:^
         version: link:../types-live
@@ -14831,6 +14879,9 @@ importers:
         specifier: 'catalog:'
         version: 7.8.2
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@ledgerhq/types-live':
         specifier: workspace:^
         version: link:../types-live
@@ -15046,6 +15097,9 @@ importers:
 
   libs/types-devices:
     devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Wires the flake reporter and CI-only retries into 18 jest packages. (continuation of https://github.com/LedgerHQ/ledger-live/pull/21058)
Note: packages also re-ordered in alphabetical

### 🔗 Context

JIRA: https://ledgerhq.atlassian.net/browse/LIVE-31261 (Part 2)
