### PR TITLE
[LWM] feat(backup-hub): replace recover sheet with deeplink (LIVE-36073)

### DIFF
--- a/.changeset/swift-sheets-vanish.md
+++ b/.changeset/swift-sheets-vanish.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Open the Ledger Recover deeplink instead of the intro bottom sheet when tapping Ledger Recover in the Backup hub

--- a/apps/ledger-live-mobile/src/mvvm/features/BackupHub/__integrations__/BackupHub.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/BackupHub/__integrations__/BackupHub.integration.test.tsx
@@ -12,19 +12,16 @@ import {
   LARGE_SCREEN_UPSELL_UTM_SOURCE_BY_PLATFORM,
 } from "@features/flow-large-screen-upsell/utils/upsellCta";
 import { render, screen, withFlagOverrides } from "@tests/test-renderer";
-import { screen as analyticsScreen, track } from "~/analytics";
+import { track } from "~/analytics";
 import { ScreenName } from "~/const";
 import type { State } from "~/reducers/types";
 import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
 import { urls } from "~/utils/urls";
 import { BackupHubScreen } from "../screens/BackupHubScreen";
-import {
-  BACKUP_HUB_FEATURE_INTRO_PAGE,
-  BACKUP_HUB_FEATURE_INTRO_SOURCE,
-  resetBackupHubFeatureIntroViewTracking,
-} from "../analytics";
+import { resetBackupHubFeatureIntroViewTracking } from "../analytics";
 import {
   BACKUP_HUB_RECOVER_DEEPLINK_QUERY,
+  BACKUP_HUB_RECOVER_ONE_MONTH_FREE_DEEPLINK,
   BACKUP_HUB_TRACKING_BUTTON,
   BACKUP_HUB_TRACKING_PAGE_NAME,
   RECOVER_DEEPLINK_BASE,
@@ -113,7 +110,8 @@ describe("BackupHub screen (mobile)", () => {
     resetBackupHubFeatureIntroViewTracking();
   });
 
-  it("renders the not-subscribed variant with a discover CTA that opens the Feature Intro", async () => {
+  it("renders the not-subscribed variant with a discover CTA that opens the one-month-free Recover deeplink", async () => {
+    const openURLSpy = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
     const { user, store } = render(<BackupHubTestNavigator />, {
       overrideInitialState: overrideWith(LedgerRecoverSubscriptionStateEnum.NO_SUBSCRIPTION),
     });
@@ -125,26 +123,15 @@ describe("BackupHub screen (mobile)", () => {
     const cta = screen.getByTestId("backup-hub-recover-cta");
     await user.press(cta);
 
-    expect(store.getState().backupHubFeatureIntro.isOpen).toBe(true);
-    expect(screen.queryByText("RECOVER_SCREEN")).toBeNull();
+    expect(store.getState().backupHubFeatureIntro.isOpen).toBe(false);
+    expect(openURLSpy).toHaveBeenCalledWith(
+      `${RECOVER_DEEPLINK_BASE}/${PROTECT_ID}?redirectTo=${BACKUP_HUB_RECOVER_ONE_MONTH_FREE_DEEPLINK.redirectTo}&source=${BACKUP_HUB_RECOVER_ONE_MONTH_FREE_DEEPLINK.source}&ajs_recover_source=${BACKUP_HUB_RECOVER_ONE_MONTH_FREE_DEEPLINK.source}&ajs_recover_campaign=${BACKUP_HUB_RECOVER_ONE_MONTH_FREE_DEEPLINK.campaign}&ajs_prop_source=${BACKUP_HUB_RECOVER_ONE_MONTH_FREE_DEEPLINK.source}&ajs_prop_campaign=${BACKUP_HUB_RECOVER_ONE_MONTH_FREE_DEEPLINK.campaign}`,
+    );
     expect(track).toHaveBeenCalledWith("button_clicked", {
       button: "Ledger Recover",
       page: BACKUP_HUB_TRACKING_PAGE_NAME,
       status: "New",
     });
-    expect(jest.mocked(analyticsScreen)).toHaveBeenCalledWith(
-      BACKUP_HUB_FEATURE_INTRO_PAGE,
-      undefined,
-      {
-        name: BACKUP_HUB_FEATURE_INTRO_PAGE,
-        source: BACKUP_HUB_FEATURE_INTRO_SOURCE,
-      },
-    );
-    expect(
-      jest
-        .mocked(analyticsScreen)
-        .mock.calls.filter(([page]) => page === BACKUP_HUB_FEATURE_INTRO_PAGE),
-    ).toHaveLength(1);
   });
 
   it("opens the ongoing-subscription Recover deeplink for the in-progress variant", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/BackupHub/components/RecoverIntroDrawer/useRecoverIntroDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/BackupHub/components/RecoverIntroDrawer/useRecoverIntroDrawerViewModel.ts
@@ -23,6 +23,7 @@ import {
   trackBackupHubFeatureIntroViewed,
   resetBackupHubFeatureIntroViewTracking,
 } from "../../analytics";
+import { BACKUP_HUB_RECOVER_ONE_MONTH_FREE_DEEPLINK } from "../../constants";
 
 const BACKUP_HUB_FEATURE_INTRO_ID = "backup-hub-feature-intro";
 
@@ -55,9 +56,9 @@ export function useRecoverIntroDrawerViewModel(): UseRecoverIntroDrawerViewModel
 
   const primaryButtonLink = useCustomURI(
     recoverServices,
-    "resumeActivate",
-    "llm-bottom-sheet",
-    "llm-bottom-sheet-native",
+    BACKUP_HUB_RECOVER_ONE_MONTH_FREE_DEEPLINK.redirectTo,
+    BACKUP_HUB_RECOVER_ONE_MONTH_FREE_DEEPLINK.source,
+    BACKUP_HUB_RECOVER_ONE_MONTH_FREE_DEEPLINK.campaign,
   );
   const secondaryButtonLink = useCustomURI(
     recoverServices,

--- a/apps/ledger-live-mobile/src/mvvm/features/BackupHub/constants.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/BackupHub/constants.ts
@@ -25,3 +25,9 @@ export const BACKUP_HUB_RECOVER_DEEPLINK_QUERY = {
     "redirectTo=resumeActivate&source=llm-entry-point-backup-up&ajs_recover_source=llm-entry-point-backup-up&ajs_recover_campaign=native-llm-ongoing-subscription",
   done: "source=llm-entry-point-backup-up&ajs_prop_source=llm-entry-point-backup-up&ajs_prop_campaign=native-llm-subscribed",
 } as const;
+
+export const BACKUP_HUB_RECOVER_ONE_MONTH_FREE_DEEPLINK = {
+  redirectTo: "resumeActivate",
+  source: "llm-bottom-sheet",
+  campaign: "llm-bottom-sheet-native",
+} as const;

--- a/apps/ledger-live-mobile/src/mvvm/features/BackupHub/screens/BackupHubScreen/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/BackupHub/screens/BackupHubScreen/index.tsx
@@ -1,14 +1,8 @@
 import React from "react";
 import { BackupHubScreenView } from "./BackupHubScreenView";
 import { useBackupHubScreenViewModel } from "./useBackupHubScreenViewModel";
-import { RecoverIntroDrawer } from "../../components/RecoverIntroDrawer";
 
 export function BackupHubScreen() {
   const viewModel = useBackupHubScreenViewModel();
-  return (
-    <>
-      <BackupHubScreenView {...viewModel} />
-      <RecoverIntroDrawer />
-    </>
-  );
+  return <BackupHubScreenView {...viewModel} />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/BackupHub/screens/BackupHubScreen/useBackupHubScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/BackupHub/screens/BackupHubScreen/useBackupHubScreenViewModel.ts
@@ -9,8 +9,9 @@ import {
   LARGE_SCREEN_UPSELL_UTM_SOURCE_BY_PLATFORM,
   buildLargeScreenUpsellCtaLink,
 } from "@features/flow-large-screen-upsell/utils/upsellCta";
-import { useFeature } from "@features/platform-feature-flags";
 import { DeviceModelId } from "@ledgerhq/types-devices";
+import { useCustomURI } from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
+import { useFeature } from "@features/platform-feature-flags";
 import {
   toLargeScreenUpsellDeviceModelAnalyticsValue,
   type LargeScreenUpsellNanoDeviceModelId,
@@ -19,8 +20,7 @@ import { track } from "~/analytics";
 import useRecoverBannerState from "LLM/features/Portfolio/hooks/useRecoverBannerState";
 import { useRecoverEntry } from "LLM/hooks/useRecoverEntry";
 import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
-import { useDispatch, useSelector } from "~/context/hooks";
-import { openBackupHubFeatureIntro } from "~/reducers/backupHubFeatureIntro";
+import { useSelector } from "~/context/hooks";
 import {
   knownDeviceModelIdsSelector,
   lastSeenDeviceSelector,
@@ -32,6 +32,7 @@ import {
   BACKUP_HUB_TRACKING_BUTTON,
   BACKUP_HUB_TRACKING_PAGE_NAME,
   BACKUP_HUB_RECOVER_DEEPLINK_QUERY,
+  BACKUP_HUB_RECOVER_ONE_MONTH_FREE_DEEPLINK,
   BACKUP_HUB_RECOVER_TRACKING_STATUS,
   BACKUP_HUB_UPSELL_FALLBACK_LINK,
   RECOVER_DEEPLINK_BASE,
@@ -55,8 +56,14 @@ export type BackupHubScreenViewModel = {
 };
 
 export function useBackupHubScreenViewModel(): BackupHubScreenViewModel {
-  const dispatch = useDispatch();
   const { protectId, markRecoverSeen } = useRecoverEntry();
+  const recoverServices = useFeature("protectServicesMobile");
+  const recoverOneMonthFreeLink = useCustomURI(
+    recoverServices,
+    BACKUP_HUB_RECOVER_ONE_MONTH_FREE_DEEPLINK.redirectTo,
+    BACKUP_HUB_RECOVER_ONE_MONTH_FREE_DEEPLINK.source,
+    BACKUP_HUB_RECOVER_ONE_MONTH_FREE_DEEPLINK.campaign,
+  );
 
   const { data } = useRecoverBannerState(protectId);
   const bucket = getBackupBucket(data.subscriptionState);
@@ -113,8 +120,11 @@ export function useBackupHubScreenViewModel(): BackupHubScreenViewModel {
       );
       return;
     }
-    dispatch(openBackupHubFeatureIntro());
-  }, [bucket, protectId, markRecoverSeen, dispatch]);
+    if (!recoverOneMonthFreeLink) {
+      return;
+    }
+    Linking.openURL(recoverOneMonthFreeLink);
+  }, [bucket, protectId, markRecoverSeen, recoverOneMonthFreeLink]);
 
   const openShop = useCallback((url: string, button: string) => {
     track("button_clicked", { button, page: BACKUP_HUB_TRACKING_PAGE_NAME });


### PR DESCRIPTION
### 📝 Description

When the user taps **Ledger Recover** in the Backup hub and has not started Recover yet, we used to open the Recover feature-intro bottom sheet. The sheet's UI does not work well and we want more flexibility on the content shown, so the tap now triggers a deeplink instead.

**Previous behaviour**: `not-subscribed` dispatched `openBackupHubFeatureIntro()` and the bottom sheet was shown.

**New behaviour**: `not-subscribed` opens the exact same deeplink as the sheet's "Try 1 month free" CTA (`redirectTo=resumeActivate`, `source=llm-bottom-sheet`, campaign `llm-bottom-sheet-native`), built through `useCustomURI` so the `protectId` and analytics params stay consistent. The params are shared in `BACKUP_HUB_RECOVER_ONE_MONTH_FREE_DEEPLINK` so the row and the sheet cannot drift apart.

The other two states are untouched: `in-progress` still opens the "complete activation" deeplink and `done` still opens the "manage your backup" one.

The bottom sheet itself is intentionally **not** deleted: it is still the destination of the `ledgerlive://backup-hub` deeplink (mounted on Portfolio and ReadOnly) and it is still counted as a competing modal by the Large screen upsell. Only the mount on the Backup hub screen, which existed solely to serve this tap, is removed.

Regression cover: the `not-subscribed` case in `BackupHub.integration.test.tsx` now asserts the opened deeplink and that `backupHubFeatureIntro.isOpen` stays `false`.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36073](https://ledgerhq.atlassian.net/browse/LIVE-36073)
- **ADR** (if any): n/a

### 📸 Screenshots

Tapping **Ledger Recover** in the Backup hub now goes straight to the Recover activation flow, with no bottom sheet in between.

<!-- Drag & drop backup-hub-recover.mp4 right below this line -->


[LIVE-36073]: https://ledgerhq.atlassian.net/browse/LIVE-36073?atlOrigin=eyJpIjo

https://github.com/user-attachments/assets/22744cc6-08e5-4650-8408-e204fe9b9dcd

iNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
