### PR TITLE
[LWM] chore(build): upgrade rsbuild 2.1.13 and rspack 2.1.10

### DIFF
--- a/.changeset/brave-wolves-jump.md
+++ b/.changeset/brave-wolves-jump.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": patch
+"@ledgerhq/web-tools": patch
+"live-mobile": patch
+---
+
+Upgrade rsbuild to 2.1.13, rspack to 2.1.10, and rslib to 0.23.2

--- a/apps/ledger-live-mobile/ios/Podfile.lock
+++ b/apps/ledger-live-mobile/ios/Podfile.lock
@@ -3588,7 +3588,7 @@ DEPENDENCIES:
   - "boost (from `../../../node_modules/.pnpm/react-native@0.81.6_patch_hash=fbb22f6ab81c7336_40b065189c08febd012a31e10dcb1091/node_modules/react-native/third-party-podspecs/boost.podspec`)"
   - "braze-react-native-sdk (from `../../../node_modules/.pnpm/@braze+react-native-sdk@18.0.0/node_modules/@braze/react-native-sdk`)"
   - "BVLinearGradient (from `../../../node_modules/.pnpm/react-native-linear-gradient@2.8.3_react-native_45c4068ade6ad1d4746621cb55d5ba26/node_modules/react-native-linear-gradient`)"
-  - "callstack-repack (from `../../../node_modules/.pnpm/@callstack+repack@5.2.5_patch_hash=8d7db4e65c89_00713b80130f4838a29bcb8bdfc97858/node_modules/@callstack/repack`)"
+  - "callstack-repack (from `../../../node_modules/.pnpm/@callstack+repack@5.2.5_patch_hash=8d7db4e65c89_f3ec7a086ef8b13b8963365d684ac5a0/node_modules/@callstack/repack`)"
   - "DatadogSDKReactNative (from `../../../node_modules/.pnpm/@datadog+mobile-react-native@2.8.2_react-native_818183bc1b1503a912a95bd8f582ae9c/node_modules/@datadog/mobile-react-native`)"
   - "DoubleConversion (from `../../../node_modules/.pnpm/react-native@0.81.6_patch_hash=fbb22f6ab81c7336_40b065189c08febd012a31e10dcb1091/node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)"
   - "EXConstants (from `../../../node_modules/.pnpm/expo-constants@18.0.13_expo-modules-core@3.0.29_390ed063156ff5b1c2354b18f03b68ba/node_modules/expo-constants/ios`)"
@@ -3771,7 +3771,7 @@ EXTERNAL SOURCES:
   BVLinearGradient:
     :path: "../../../node_modules/.pnpm/react-native-linear-gradient@2.8.3_react-native_45c4068ade6ad1d4746621cb55d5ba26/node_modules/react-native-linear-gradient"
   callstack-repack:
-    :path: "../../../node_modules/.pnpm/@callstack+repack@5.2.5_patch_hash=8d7db4e65c89_00713b80130f4838a29bcb8bdfc97858/node_modules/@callstack/repack"
+    :path: "../../../node_modules/.pnpm/@callstack+repack@5.2.5_patch_hash=8d7db4e65c89_f3ec7a086ef8b13b8963365d684ac5a0/node_modules/@callstack/repack"
   DatadogSDKReactNative:
     :path: "../../../node_modules/.pnpm/@datadog+mobile-react-native@2.8.2_react-native_818183bc1b1503a912a95bd8f582ae9c/node_modules/@datadog/mobile-react-native"
   DoubleConversion:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,14 +196,14 @@ catalogs:
       specifier: 2.11.2
       version: 2.11.2
     '@rsbuild/core':
-      specifier: 2.0.9
-      version: 2.0.9
+      specifier: 2.1.13
+      version: 2.1.13
     '@rsbuild/plugin-node-polyfill':
-      specifier: 1.4.5
-      version: 1.4.5
+      specifier: 1.4.6
+      version: 1.4.6
     '@rsbuild/plugin-react':
-      specifier: 2.0.1
-      version: 2.0.1
+      specifier: 2.1.0
+      version: 2.1.0
     '@rsbuild/plugin-styled-components':
       specifier: 1.6.2
       version: 1.6.2
@@ -211,20 +211,20 @@ catalogs:
       specifier: 2.0.0-alpha.0
       version: 2.0.0-alpha.0
     '@rslib/core':
-      specifier: 0.22.0
-      version: 0.22.0
+      specifier: 0.23.2
+      version: 0.23.2
     '@rspack/cli':
-      specifier: 2.0.5
-      version: 2.0.5
+      specifier: 2.1.10
+      version: 2.1.10
     '@rspack/core':
-      specifier: 2.0.5
-      version: 2.0.5
+      specifier: 2.1.10
+      version: 2.1.10
     '@rspack/dev-server':
-      specifier: 2.0.3
-      version: 2.0.3
+      specifier: 2.1.0
+      version: 2.1.0
     '@rspack/plugin-react-refresh':
-      specifier: 2.0.1
-      version: 2.0.1
+      specifier: 2.0.2
+      version: 2.0.2
     '@solana/spl-token':
       specifier: ^0.4.14
       version: 0.4.14
@@ -814,7 +814,7 @@ importers:
         version: 1000.0.6
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.22.0(@typescript/typescript6@6.0.2)
+        version: 0.23.2(@typescript/typescript6@6.0.2)
       '@types/command-line-args':
         specifier: 5.2.3
         version: 5.2.3
@@ -1432,28 +1432,28 @@ importers:
         version: 1.60.0
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.0.9
+        version: 2.1.13
       '@rsbuild/plugin-node-polyfill':
         specifier: 'catalog:'
-        version: 1.4.5(@rsbuild/core@2.0.9)
+        version: 1.4.6(@rsbuild/core@2.1.13)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
+        version: 2.1.0(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)
       '@rsdoctor/rspack-plugin':
         specifier: 'catalog:'
-        version: 2.0.0-alpha.0(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
+        version: 2.0.0-alpha.0(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)
       '@rspack/cli':
         specifier: 'catalog:'
-        version: 2.0.5(@rspack/core@2.0.5)(@rspack/dev-server@2.0.3(@rspack/core@2.0.5))
+        version: 2.1.10(@rspack/core@2.1.10)(@rspack/dev-server@2.1.0(@rspack/core@2.1.10))
       '@rspack/core':
         specifier: 'catalog:'
-        version: 2.0.5
+        version: 2.1.10
       '@rspack/dev-server':
         specifier: 'catalog:'
-        version: 2.0.3(@rspack/core@2.0.5)
+        version: 2.1.0(@rspack/core@2.1.10)
       '@rspack/plugin-react-refresh':
         specifier: 'catalog:'
-        version: 2.0.1(@rspack/core@2.0.5)(react-refresh@0.18.0)
+        version: 2.0.2(@rspack/core@2.1.10)(react-refresh@0.18.0)
       '@storybook/global':
         specifier: 'catalog:'
         version: 5.0.0
@@ -1621,7 +1621,7 @@ importers:
         version: 8.5.6
       postcss-loader:
         specifier: 8.2.0
-        version: 8.2.0(@rspack/core@2.0.5)(@typescript/typescript6@6.0.2)(postcss@8.5.6)
+        version: 8.2.0(@rspack/core@2.1.10)(@typescript/typescript6@6.0.2)(postcss@8.5.6)
       prebuild-install:
         specifier: 7.1.3
         version: 7.1.3
@@ -1639,7 +1639,7 @@ importers:
         version: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       storybook-react-rsbuild:
         specifier: 'catalog:'
-        version: 3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(@typescript/typescript6@6.0.2)(msw@2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
+        version: 3.3.4(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(@typescript/typescript6@6.0.2)(msw@2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
       tailwindcss:
         specifier: 'catalog:'
         version: 4.1.18
@@ -2373,13 +2373,13 @@ importers:
         version: 7.28.4
       '@callstack/repack':
         specifier: 5.2.5
-        version: 5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.0.5(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(tslib@2.6.2)
+        version: 5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.1.10(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(tslib@2.6.2)
       '@callstack/repack-plugin-expo-modules':
         specifier: 5.2.5
-        version: 5.2.5(@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.0.5(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(tslib@2.6.2))
+        version: 5.2.5(@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.1.10(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(tslib@2.6.2))
       '@callstack/repack-plugin-reanimated':
         specifier: 5.2.5
-        version: 5.2.5(@babel/core@7.28.5)(@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.0.5(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(tslib@2.6.2))
+        version: 5.2.5(@babel/core@7.28.5)(@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.1.10(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(tslib@2.6.2))
       '@features/flow-market-banner':
         specifier: workspace:^
         version: link:../../features/flow/market-banner
@@ -2442,13 +2442,13 @@ importers:
         version: 1.2.0(@types/react@19.0.14)(react-native-get-random-values@1.11.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react-redux@9.2.0(@types/react@19.0.14)(react@19.1.4)(redux@5.0.1))(react@19.1.4)(redux@5.0.1)
       '@rozenite/repack':
         specifier: 1.2.0
-        version: 1.2.0(@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.0.5(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(tslib@2.6.2))
+        version: 1.2.0(@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.1.10(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(tslib@2.6.2))
       '@rsdoctor/rspack-plugin':
         specifier: 'catalog:'
-        version: 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
+        version: 2.0.0-alpha.0(@rspack/core@2.1.10(@swc/helpers@0.5.23))
       '@rspack/core':
         specifier: 'catalog:'
-        version: 2.0.5(@swc/helpers@0.5.23)
+        version: 2.1.10(@swc/helpers@0.5.23)
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11(@swc/helpers@0.5.23)
@@ -3043,19 +3043,19 @@ importers:
         version: link:../../support/test-quarantine
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.0.9
+        version: 2.1.13
       '@rsbuild/plugin-node-polyfill':
         specifier: 'catalog:'
-        version: 1.4.5(@rsbuild/core@2.0.9)
+        version: 1.4.6(@rsbuild/core@2.1.13)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
+        version: 2.1.0(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)
       '@rsbuild/plugin-styled-components':
         specifier: 'catalog:'
-        version: 1.6.2(@rsbuild/core@2.0.9)
+        version: 1.6.2(@rsbuild/core@2.1.13)
       '@rspack/core':
         specifier: 'catalog:'
-        version: 2.0.5
+        version: 2.1.10
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -7282,7 +7282,7 @@ importers:
         version: link:../wallet-framework-test-setup
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.22.0(@typescript/typescript6@6.0.2)
+        version: 0.23.2(@typescript/typescript6@6.0.2)
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -11236,10 +11236,10 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 'catalog:'
-        version: 2.0.5(@rspack/core@2.0.5)
+        version: 2.1.10(@rspack/core@2.1.10)
       '@rspack/core':
         specifier: 'catalog:'
-        version: 2.0.5
+        version: 2.1.10
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -15236,7 +15236,7 @@ importers:
     devDependencies:
       '@rspack/core':
         specifier: 'catalog:'
-        version: 2.0.5
+        version: 2.1.10
       '@svgr/core':
         specifier: ^5.5.0
         version: 5.5.0(@svgr/plugin-svgo@5.5.0)
@@ -15360,10 +15360,10 @@ importers:
         version: 0.81.6(@babel/core@7.28.5)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.0.9
+        version: 2.1.13
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.0.9)
+        version: 2.1.0(@rsbuild/core@2.1.13)
       '@storybook/addon-links':
         specifier: 'catalog:'
         version: 10.4.1(@types/react@19.0.14)(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
@@ -15573,7 +15573,7 @@ importers:
         version: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       storybook-react-rsbuild:
         specifier: 'catalog:'
-        version: 3.3.4(@rsbuild/core@2.0.9)(@types/react@19.0.14)(@typescript/typescript6@6.0.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
+        version: 3.3.4(@rsbuild/core@2.1.13)(@types/react@19.0.14)(@typescript/typescript6@6.0.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
       styled-components:
         specifier: 'catalog:'
         version: 6.1.19(patch_hash=810073718ccefe69fd016893be54d80d86cc6e5ee521455028b93c7cbf3103d7)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
@@ -15685,16 +15685,16 @@ importers:
         version: 1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@rsbuild/core':
         specifier: 'catalog:'
-        version: 2.0.9
+        version: 2.1.13
       '@rsbuild/plugin-node-polyfill':
         specifier: 'catalog:'
-        version: 1.4.5(@rsbuild/core@2.0.9)
+        version: 1.4.6(@rsbuild/core@2.1.13)
       '@rsbuild/plugin-react':
         specifier: 'catalog:'
-        version: 2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
+        version: 2.1.0(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)
       '@rspack/core':
         specifier: 'catalog:'
-        version: 2.0.5
+        version: 2.1.10
       '@storybook/addon-docs':
         specifier: 'catalog:'
         version: 10.4.1(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
@@ -15805,7 +15805,7 @@ importers:
         version: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       storybook-react-rsbuild:
         specifier: 'catalog:'
-        version: 3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(@typescript/typescript6@6.0.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
+        version: 3.3.4(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(@typescript/typescript6@6.0.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
       styled-components:
         specifier: ^5.3.3
         version: 5.3.11(@babel/core@7.28.5)(react-dom@19.1.4(react@19.1.4))(react-is@17.0.2)(react@19.1.4)
@@ -15838,7 +15838,7 @@ importers:
     devDependencies:
       '@rspack/core':
         specifier: 'catalog:'
-        version: 2.0.5
+        version: 2.1.10
       tiny-glob:
         specifier: ^0.2.9
         version: 0.2.9
@@ -16629,10 +16629,10 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 'catalog:'
-        version: 2.0.5(@rspack/core@2.0.5)
+        version: 2.1.10(@rspack/core@2.1.10)
       '@rspack/core':
         specifier: 'catalog:'
-        version: 2.0.5
+        version: 2.1.10
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.0
@@ -16690,10 +16690,10 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 'catalog:'
-        version: 2.0.5(@rspack/core@2.0.5)
+        version: 2.1.10(@rspack/core@2.1.10)
       '@rspack/core':
         specifier: 'catalog:'
-        version: 2.0.5
+        version: 2.1.10
       '@types/jest':
         specifier: 'catalog:'
         version: 30.0.0
@@ -16745,7 +16745,7 @@ importers:
         version: 6.0.0
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.22.0(@typescript/typescript6@6.0.2)
+        version: 0.23.2(@typescript/typescript6@6.0.2)
       '@types/stream-json':
         specifier: 1.7.7
         version: 1.7.7
@@ -16772,7 +16772,7 @@ importers:
         version: 6.0.0
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.22.0(@typescript/typescript6@6.0.2)
+        version: 0.23.2(@typescript/typescript6@6.0.2)
 
   tools/actions/desktop-report-build:
     devDependencies:
@@ -16784,7 +16784,7 @@ importers:
         version: 6.0.0
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.22.0(@typescript/typescript6@6.0.2)
+        version: 0.23.2(@typescript/typescript6@6.0.2)
       node-fetch:
         specifier: 3.3.2
         version: 3.3.2
@@ -16799,7 +16799,7 @@ importers:
         version: 6.0.0
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.22.0(@typescript/typescript6@6.0.2)
+        version: 0.23.2(@typescript/typescript6@6.0.2)
       semver:
         specifier: 'catalog:'
         version: 7.7.3
@@ -16814,7 +16814,7 @@ importers:
         version: 6.0.0
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.22.0(@typescript/typescript6@6.0.2)
+        version: 0.23.2(@typescript/typescript6@6.0.2)
       semver:
         specifier: 'catalog:'
         version: 7.7.3
@@ -16829,7 +16829,7 @@ importers:
         version: 6.0.0
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.22.0(@typescript/typescript6@6.0.2)
+        version: 0.23.2(@typescript/typescript6@6.0.2)
 
   tools/actions/submit-bot-report:
     devDependencies:
@@ -16841,7 +16841,7 @@ importers:
         version: 6.0.0
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.22.0(@typescript/typescript6@6.0.2)
+        version: 0.23.2(@typescript/typescript6@6.0.2)
       node-fetch:
         specifier: 3.3.2
         version: 3.3.2
@@ -16859,7 +16859,7 @@ importers:
         version: 3.540.0
       '@rslib/core':
         specifier: 'catalog:'
-        version: 0.22.0(@typescript/typescript6@6.0.2)
+        version: 0.23.2(@typescript/typescript6@6.0.2)
 
   tools/create-release-hash: {}
 
@@ -19330,20 +19330,20 @@ packages:
     resolution: {integrity: sha512-fKpv9kg4SPmt+hY7SVBnIYULE9QJl8L3sCfcBsnqbJwwBwAeTLokJ9TRt9y7bK0JAzIW2y78TVVjvnQEms/yyA==}
     engines: {node: '>=16.4'}
 
-  '@emnapi/core@1.10.0':
-    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
-
   '@emnapi/core@1.11.2':
     resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+
+  '@emnapi/core@1.11.3':
+    resolution: {integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==}
 
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
 
-  '@emnapi/runtime@1.10.0':
-    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
-
   '@emnapi/runtime@1.11.2':
     resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@emnapi/runtime@1.9.2':
     resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
@@ -19353,6 +19353,9 @@ packages:
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@emnapi/wasi-threads@1.2.3':
+    resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
 
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
@@ -21710,8 +21713,8 @@ packages:
   '@napi-rs/wasm-runtime@0.2.4':
     resolution: {integrity: sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==}
 
-  '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
@@ -24009,8 +24012,8 @@ packages:
   '@rozenite/tools@1.2.0':
     resolution: {integrity: sha512-I5E4az+EWq2xRf9aKDg02bubm+2l6fvbQG63DmIOykjQtQ50uFR9t65UMv0/nvdwDlK2aSIyXCr8aJF/O6GA6g==}
 
-  '@rsbuild/core@2.0.9':
-    resolution: {integrity: sha512-lK2bMNuwh3TuLXLskS7nG3fnQk+6eaLeeZiquJWcna4JZx9iaI59JSd+iLcg5TeZLjEVygkwn/HcE+yuYDQRAw==}
+  '@rsbuild/core@2.1.13':
+    resolution: {integrity: sha512-Z+6MzmjOio4+bFZQ24k+7ge/oNCOdXIunAssrswTNE8AIf6mcyXpJZevRXRiOEMZasRPA8VNyh+9JngQLg729Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -24027,18 +24030,18 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rsbuild/plugin-node-polyfill@1.4.5':
-    resolution: {integrity: sha512-mUyOIVhYu+IPjPY5SoUa4r3SrP/am/LBEUnb5C2RAVdL0QFbi7bAMM5YuRMOBtkU0s+I86hVZIkgCGi3LzX6zw==}
+  '@rsbuild/plugin-node-polyfill@1.4.6':
+    resolution: {integrity: sha512-uJHDmfinJe00h9JvZfzOeiYYpIkAOorMsX2nv9c6n+YQBFgQalJZ3O2q2CLoqtwspQl5Pa8WU1hsUvzRi1Ro3g==}
     peerDependencies:
-      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
+      '@rsbuild/core': ^1.0.0 || ^2.0.0
     peerDependenciesMeta:
       '@rsbuild/core':
         optional: true
 
-  '@rsbuild/plugin-react@2.0.1':
-    resolution: {integrity: sha512-n5m3VxEm6m3Dv1VkI0WnxsildySJ6M+QjGIzkZDy5UebRCIJ1Q/hlQVyhofBL6C+AcsF9fGjlHQkeiteXJSr3Q==}
+  '@rsbuild/plugin-react@2.1.0':
+    resolution: {integrity: sha512-RQTIAWB/CwPjoWt9iAl+8HixeQVgZ7kEIBrWPCixfITyHdiD84h0YpUTpEUuz6kGHw1KXT9mHZ3Rwy6WG7aRDA==}
     peerDependencies:
-      '@rsbuild/core': ^2.0.0-0
+      '@rsbuild/core': ^2.0.0
     peerDependenciesMeta:
       '@rsbuild/core':
         optional: true
@@ -24090,77 +24093,101 @@ packages:
   '@rsdoctor/utils@2.0.0-alpha.0':
     resolution: {integrity: sha512-RPwNhwZthQNx/5W+wRCuTPHMyZaCCXgiD4tgKfoArbSaixuhIO5CnUlMJSB8F0SX69QEVLy5Bpa+Rx6bRUSnRw==}
 
-  '@rslib/core@0.22.0':
-    resolution: {integrity: sha512-DGTMBDTSdILac0SmeBWvdYf/ZDn09vXgbJQ3/N1J7i6vBpFGWCCKjARoz1R5jYqr1Z9tLJ1OfOVZktbNY/XXuA==}
+  '@rslib/core@0.23.2':
+    resolution: {integrity: sha512-KxSp+/y0BJ1O4oKwxX4ydBY7/ZVeJCUpWAmQniCIct8mTxIQFPGO/ibKbKq2IxZYqRuRpM8g+Dtyq0VbEQf9HQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@microsoft/api-extractor': ^7
-      typescript: ^5 || ^6
+      typescript: ^5 || ^6 || ^7.0.1-0
     peerDependenciesMeta:
       '@microsoft/api-extractor':
         optional: true
       typescript:
         optional: true
 
-  '@rspack/binding-darwin-arm64@2.0.5':
-    resolution: {integrity: sha512-++wjLQjQ20GcR0DwbzQmVXg9qy4XCX5NlfSzkzj2icHoDxr3KkrXhyVrQkdWuNG6l/bQrGLPnvLEAqkroC2Y7A==}
+  '@rspack/binding-darwin-arm64@2.1.10':
+    resolution: {integrity: sha512-DZlcTpbIb2mjeS1aSG4k01UH33Zj7T+k8ZylPK6HmsKs4JvK4wgpWFC78WVv3p/Aj3MZS6DwtDLwpZ2Ihj/fpg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@2.0.5':
-    resolution: {integrity: sha512-JBD5mCN3JKjV64Mh9nDYx8lLUrWDfEl5tLBuMkREUnqEKbo+z4nfwotyqHHM8/XgZwL+Gr7ps4GLWuQQrZB8+Q==}
+  '@rspack/binding-darwin-x64@2.1.10':
+    resolution: {integrity: sha512-my/0h2LwxCRT6cg3oDDC2e0ZOxQLVajAdIcv0fqnQk5JRNvVuL89PuTutitnSqie1A0/JSL8OQz5XHwmoS3kow==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@2.0.5':
-    resolution: {integrity: sha512-JI8+//woanJPNsfL7iGjX39zyiWumnrKHznWQM/7lEtE5nPmk+j+X7TYXxczSWC9zfZegiqI74D3L5JPDC84Fw==}
+  '@rspack/binding-linux-arm64-gnu@2.1.10':
+    resolution: {integrity: sha512-laevn9g+E5PAUEGqiKe6Ju5KApsuQYp+bPI17XS3Lkl8eqL5pS/BmHYU7QMlst4GzV8+wlruVTMh//+st6Vqzg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-arm64-musl@2.0.5':
-    resolution: {integrity: sha512-5LujilxLtJFRiiPz5i5iWcWJriK9oy4gN7gZtTo8YRB7wwmwA8LMypTjjO0GLbkPS4/KeCfY4fDfTC29KmK+tA==}
+  '@rspack/binding-linux-arm64-musl@2.1.10':
+    resolution: {integrity: sha512-V71+Qz5G72+ROZXrJn5zxOszdG1AEbO8pcC/itXXtf4yRR6a3bVHKNKGhipBNxb8eI6cnD/01FH1h3ZG655jLw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-x64-gnu@2.0.5':
-    resolution: {integrity: sha512-241wqE132jh+/U/pn97qUPV4KpIy4bSrTH0tqfzQCocgw+8hrUj02GqNG+3MXVC3qtwaQeJFYgEBy3TqFKsrIQ==}
+  '@rspack/binding-linux-ppc64-gnu@2.1.10':
+    resolution: {integrity: sha512-U7HlNzHcDtZ+LYOtOJmtx67kHEybZzUUAaP7aEXjGYO5WTCgh/176sW2UYP0rmZLrgUNFUuzn+B98RLaClNaVg==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-riscv64-gnu@2.1.10':
+    resolution: {integrity: sha512-GMGTJpy9/ecE+5F5IfxZH4bXv0Wx/b2TiehTlCbTksbL+pKpLHYy0rwGdjWDKbmBkhxMMqPiC7PDnn9LbdnnLA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-riscv64-musl@2.1.10':
+    resolution: {integrity: sha512-rkurnAWc04vIbzG1QCrPBWSJadZvaOt1mazFH3EdiJO8VUiu0I1T9zdiwuDOPrd50lOKIZlcTXbd5aaAkWEnvQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-linux-s390x-gnu@2.1.10':
+    resolution: {integrity: sha512-X+DyxkriZEAF/wihI7ERDv+CAS0mbMv36aEuQ+vXzTlvS6cSmpou/r29AHbvIF3NlG1UeAbDVlOs9QrMBZjpUQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-x64-gnu@2.1.10':
+    resolution: {integrity: sha512-Fat09V6jUuyo9qG7Wyj9cQ31VDfLmokXyBtGqKxY5OvSWHereB7QUub5btbPXHwbp6Iq4aAQyUbbLTzvR1YaBw==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-x64-musl@2.0.5':
-    resolution: {integrity: sha512-BhaXZD064Lci3Kia0kLDAb4TyxO2C+0UidMlj44e8+ctasxIfFZgnrhCJrhTFHAtOiAwqhU3FHun2UuxPqX0Eg==}
+  '@rspack/binding-linux-x64-musl@2.1.10':
+    resolution: {integrity: sha512-lhHOnIJ4ClpIlA1f1L8aoxEZivYLjnjq5A6jKKz7BKsm+cHK8kqqEm6lO5KqA5xQT0Lonq1o28bmKHEj6JHInw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-wasm32-wasi@2.0.5':
-    resolution: {integrity: sha512-duEkRoXrl9SW8uGHv7JURJ5lgKu87qFDQ4Exy6UQPvsUJVXhtRXTfvMHCb/CejVJuW2Bw2D632/axZq3qRSuBQ==}
+  '@rspack/binding-wasm32-wasi@2.1.10':
+    resolution: {integrity: sha512-KY5YbWbuvYcoaLXnV+vzZOvGRCeb6jt4EpVpKdph1h1IJjwX/ju15EQ+GOe3iecZEdf0OttQcNVcwBkLkFT9ag==}
     cpu: [wasm32]
 
-  '@rspack/binding-win32-arm64-msvc@2.0.5':
-    resolution: {integrity: sha512-q2WT3HFoWL+2g84l3s2kY7CiE1gEZ1bwB3txx3eZzQQ6YKP7bE82z6sl6S/pTOHGjHdAO4snQXpSaHwUt3LX5g==}
+  '@rspack/binding-win32-arm64-msvc@2.1.10':
+    resolution: {integrity: sha512-z4GWzMLofaDGpAt9Z+MlN88LlUBDm+zM6R2GdOOPM6/4g/h3/+47OP7casmSL3AwTGYBEJqogwt08sRSosB6Cg==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@2.0.5':
-    resolution: {integrity: sha512-nMJGIY7kvgbyMolEE7tXDe+Z9jSItDshTIqMQQkkD3WTHdjlBQozHxk4kBtKLsunO+3NkCLe5Oa3hXg1yyStIg==}
+  '@rspack/binding-win32-ia32-msvc@2.1.10':
+    resolution: {integrity: sha512-7qcWdsZ+GuGtzKjqgy7wTN7Dso/ezIY8yhx1r2yIbcczdmXj4FhaEampMDp/25HwtKwIGBBoh6HHSt3JWxpTUg==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@2.0.5':
-    resolution: {integrity: sha512-vP0BR6fxdPL9cb02HAuZATg/CjR07aecWel3s1vqRwW1aDffgXh9PVmqEKIHTgyaNsNR55kSKNJsB9AcQ8/QrA==}
+  '@rspack/binding-win32-x64-msvc@2.1.10':
+    resolution: {integrity: sha512-pgp23pLrzfhGnKycxzr7ifP17lAbWZEfnx1bX8gXtYrnpJ66DRNyTKSzxB6sa/HBWjS1L8PX5TjMZ44WfPydqQ==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@2.0.5':
-    resolution: {integrity: sha512-Ta1y4WXJA87wM1OstqaMddoPsBGv7Cu779bYToKxEAqR/Yy9DxLkp7bdgBaAx2JH++BwVjV+toWts2V9AaiTFQ==}
+  '@rspack/binding@2.1.10':
+    resolution: {integrity: sha512-vnu/UP5HnrND15lO9+VeG6eUrbTyycHNQNQ3XEiRiFojuoiGZkIZC3Hbzr8qQH44C6vScPODEPvvIVvLcO2LpQ==}
 
-  '@rspack/cli@2.0.5':
-    resolution: {integrity: sha512-AAyuY/8sfegb0IcsFEhn5gLOTxy1uDmwjP49RY81PENz2pCk/7NU0zDdt0ke5wmpOH5s6IxS+Kw4aWdvl8FGpQ==}
+  '@rspack/cli@2.1.10':
+    resolution: {integrity: sha512-qkuQQ3PzD2sTS2tBAWyWNeOeZmPxRBzB+eNDBhCZmbm8DoMPujW2VQj0k9CulrkBq9sBxU8fQ+5Z/ELzbz5S8g==}
     hasBin: true
     peerDependencies:
       '@rspack/core': ^2.0.0-0
@@ -24169,8 +24196,8 @@ packages:
       '@rspack/dev-server':
         optional: true
 
-  '@rspack/core@2.0.5':
-    resolution: {integrity: sha512-9tv2HAnSiTote5WPH2tmz1hLZ1zKbzkiZc1eYp7LP/8jcsiJBuf40ihiWidAgbbuYtJo3kWET6q+qOm5UhNiGA==}
+  '@rspack/core@2.1.10':
+    resolution: {integrity: sha512-YSS2/Xxz8uiG/KXDkqOoA3dTetNo/vysk7bAexQOrU8iuq7JuzDTTAwLKvWZnwmvME8M8m5wcM4YvfIwYmidHA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -24181,20 +24208,20 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@rspack/dev-middleware@2.0.2':
-    resolution: {integrity: sha512-vYdJq4AEEOxeTvlr8tEqgcVrNm0JOiOalmB6fc63Obu3RKYD4JAWj9oR+n7/nAd1x4GXjyGWivfel+/jZ+olvQ==}
+  '@rspack/dev-middleware@2.0.3':
+    resolution: {integrity: sha512-GxnGj9jy76G3eCPyZei81fwKLAMLZaPEEqFz1/QDYquhwi/qYZX5fekFJ1XVpuwxGEK9KSX3hxZylfwrs4cmLA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      '@rspack/core': ^2.0.0-0
+      '@rspack/core': ^2.0.0
     peerDependenciesMeta:
       '@rspack/core':
         optional: true
 
-  '@rspack/dev-server@2.0.3':
-    resolution: {integrity: sha512-S29nOxXQS9o+0uGNe7SgND2dAKnte5ZTD5tiT3/B4lKbviqpXD4tbH7NZWA3hGwlSkmOIbFlysYPL1bVHuBcSg==}
+  '@rspack/dev-server@2.1.0':
+    resolution: {integrity: sha512-WkCi6bWThVX5Ziv04srPaRoCoUY5FJolO4gqzE7xPO0XbXShsGnwn0vGD0DFfnYFcw9VSsxlmeCDV799lNYclA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      '@rspack/core': ^2.0.0-0
+      '@rspack/core': ^2.0.0
       selfsigned: ^5.0.0
     peerDependenciesMeta:
       selfsigned:
@@ -24211,19 +24238,10 @@ packages:
       react-refresh:
         optional: true
 
-  '@rspack/plugin-react-refresh@2.0.0':
-    resolution: {integrity: sha512-Cf6CxBStNDJbiXMc/GmsvG1G8PRlUpa0MSfWsMTI+e8npzuTN/p8nwLs3shriBZOLciqgkSZpBtPTd10BLpj1g==}
+  '@rspack/plugin-react-refresh@2.0.2':
+    resolution: {integrity: sha512-dGNZiCxQxgAUI9sah7gd8u+O7OJZRCmqtEJNDOd8xW5RqcieC86F7p5qcShyw6onH5pKf57evpr2VjGbaFGkZg==}
     peerDependencies:
-      '@rspack/core': ^2.0.0-0
-      react-refresh: '>=0.10.0 <1.0.0'
-    peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
-
-  '@rspack/plugin-react-refresh@2.0.1':
-    resolution: {integrity: sha512-rYmxHJeDhN9/neZJgEjSFqG20A2Mu1mKv8+15kgwyuIDFSd3cgP3OVxwXLz5UmZSmWAfSzayDmmU1tBT0j1Nxw==}
-    peerDependencies:
-      '@rspack/core': ^2.0.0-0
+      '@rspack/core': ^2.0.0
       react-refresh: '>=0.10.0 <1.0.0'
     peerDependenciesMeta:
       '@rspack/core':
@@ -26456,9 +26474,6 @@ packages:
 
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
-
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -38464,14 +38479,14 @@ packages:
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
-  rsbuild-plugin-dts@0.22.0:
-    resolution: {integrity: sha512-Oyiu5oJDHWOnBv7yRr8eAGfoEddwxfPqUbAX6HvcJxrnR/h6Zd0VgTBWVTgqALYhLcL2ZdyZ2vwnqfhan4krwA==}
+  rsbuild-plugin-dts@0.23.2:
+    resolution: {integrity: sha512-Ve8WOSPyTBjxH40O/6fChJtflL7yqcUtt5zbF0eHDM4hIt35jqLocRlSdCxFJdQm0blTjl6+hkmPa/vNI06ArA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@microsoft/api-extractor': ^7
       '@rsbuild/core': ^1.0.0 || ^2.0.0-0
-      '@typescript/native-preview': 7.x
-      typescript: ^5 || ^6
+      '@typescript/native-preview': ^7.0.0-0
+      typescript: ^5 || ^6 || ^7.0.1-0
     peerDependenciesMeta:
       '@microsoft/api-extractor':
         optional: true
@@ -45111,17 +45126,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@callstack/repack-plugin-expo-modules@5.2.5(@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.0.5(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(tslib@2.6.2))':
+  '@callstack/repack-plugin-expo-modules@5.2.5(@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.1.10(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(tslib@2.6.2))':
     dependencies:
-      '@callstack/repack': 5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.0.5(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(tslib@2.6.2)
+      '@callstack/repack': 5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.1.10(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(tslib@2.6.2)
 
-  '@callstack/repack-plugin-reanimated@5.2.5(@babel/core@7.28.5)(@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.0.5(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(tslib@2.6.2))':
+  '@callstack/repack-plugin-reanimated@5.2.5(@babel/core@7.28.5)(@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.1.10(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(tslib@2.6.2))':
     dependencies:
       '@babel/core': 7.28.5
-      '@callstack/repack': 5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.0.5(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(tslib@2.6.2)
+      '@callstack/repack': 5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.1.10(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(tslib@2.6.2)
       semver: 7.8.1
 
-  '@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.0.5(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(tslib@2.6.2)':
+  '@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.1.10(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(tslib@2.6.2)':
     dependencies:
       '@callstack/repack-dev-server': 5.2.5
       '@discoveryjs/json-ext': 0.5.7
@@ -45150,7 +45165,7 @@ snapshots:
       throttleit: 2.1.0
       webpack-merge: 6.0.1
     optionalDependencies:
-      '@rspack/core': 2.0.5(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.10(@swc/helpers@0.5.23)
     transitivePeerDependencies:
       - '@babel/core'
       - '@swc/core'
@@ -46137,14 +46152,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@emnapi/core@1.10.0':
-    dependencies:
-      '@emnapi/wasi-threads': 1.2.1
-      tslib: 2.6.2
-
   '@emnapi/core@1.11.2':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.6.2
+
+  '@emnapi/core@1.11.3':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.3
       tslib: 2.6.2
     optional: true
 
@@ -46154,11 +46169,11 @@ snapshots:
       tslib: 2.6.2
     optional: true
 
-  '@emnapi/runtime@1.10.0':
+  '@emnapi/runtime@1.11.2':
     dependencies:
       tslib: 2.6.2
 
-  '@emnapi/runtime@1.11.2':
+  '@emnapi/runtime@1.11.3':
     dependencies:
       tslib: 2.6.2
     optional: true
@@ -46171,8 +46186,13 @@ snapshots:
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.6.2
+    optional: true
 
   '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.6.2
+
+  '@emnapi/wasi-threads@1.2.3':
     dependencies:
       tslib: 2.6.2
     optional: true
@@ -50606,20 +50626,20 @@ snapshots:
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
 
   '@napi-rs/wasm-runtime@0.2.4':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
       '@tybys/wasm-util': 0.9.0
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -53892,9 +53912,9 @@ snapshots:
       - tedious
       - utf-8-validate
 
-  '@rozenite/repack@1.2.0(@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.0.5(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(tslib@2.6.2))':
+  '@rozenite/repack@1.2.0(@callstack/repack@5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.1.10(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(tslib@2.6.2))':
     dependencies:
-      '@callstack/repack': 5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.0.5(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(tslib@2.6.2)
+      '@callstack/repack': 5.2.5(patch_hash=8d7db4e65c8982b51b689b97af043f6e2c411605b19084c3781cb5ec5e635b60)(@babel/core@7.28.5)(@rspack/core@2.1.10(@swc/helpers@0.5.23))(@swc/core@1.15.11(@swc/helpers@0.5.23))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(tslib@2.6.2)
       '@rozenite/middleware': 1.2.0
       '@rozenite/tools': 1.2.0
       semver: 7.8.1
@@ -53908,9 +53928,9 @@ snapshots:
 
   '@rozenite/tools@1.2.0': {}
 
-  '@rsbuild/core@2.0.9':
+  '@rsbuild/core@2.1.13':
     dependencies:
-      '@rspack/core': 2.0.5(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.10(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
@@ -53923,7 +53943,7 @@ snapshots:
       picocolors: 1.1.1
       source-map: 0.7.6
 
-  '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@2.0.9)':
+  '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@2.1.13)':
     dependencies:
       acorn: 8.15.0
       browserslist-to-es-version: 1.4.1
@@ -53931,9 +53951,9 @@ snapshots:
       picocolors: 1.1.1
       source-map: 0.7.6
     optionalDependencies:
-      '@rsbuild/core': 2.0.9
+      '@rsbuild/core': 2.1.13
 
-  '@rsbuild/plugin-node-polyfill@1.4.5(@rsbuild/core@2.0.9)':
+  '@rsbuild/plugin-node-polyfill@1.4.6(@rsbuild/core@2.1.13)':
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -53959,54 +53979,54 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.0.9
+      '@rsbuild/core': 2.1.13
 
-  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.0.9)':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.13)':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.0(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.2(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.9
+      '@rsbuild/core': 2.1.13
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-react@2.0.1(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.5)(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.10)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.9
+      '@rsbuild/core': 2.1.13
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-styled-components@1.6.2(@rsbuild/core@2.0.9)':
+  '@rsbuild/plugin-styled-components@1.6.2(@rsbuild/core@2.1.13)':
     dependencies:
       '@swc/plugin-styled-components': 12.12.0
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.0.9
+      '@rsbuild/core': 2.1.13
 
-  '@rsbuild/plugin-type-check@1.3.5(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(@typescript/typescript6@6.0.2)':
+  '@rsbuild/plugin-type-check@1.3.5(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)(@typescript/typescript6@6.0.2)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
-      ts-checker-rspack-plugin: 1.3.1(@rspack/core@2.0.5)(@typescript/typescript6@6.0.2)
+      ts-checker-rspack-plugin: 1.3.1(@rspack/core@2.1.10)(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      '@rsbuild/core': 2.0.9
+      '@rsbuild/core': 2.1.13
     transitivePeerDependencies:
       - '@rspack/core'
       - tslib
       - typescript
 
-  '@rsbuild/plugin-type-check@1.3.5(@rsbuild/core@2.0.9)(@typescript/typescript6@6.0.2)':
+  '@rsbuild/plugin-type-check@1.3.5(@rsbuild/core@2.1.13)(@typescript/typescript6@6.0.2)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
       ts-checker-rspack-plugin: 1.3.1(@typescript/typescript6@6.0.2)
     optionalDependencies:
-      '@rsbuild/core': 2.0.9
+      '@rsbuild/core': 2.1.13
     transitivePeerDependencies:
       - '@rspack/core'
       - tslib
@@ -54014,13 +54034,13 @@ snapshots:
 
   '@rsdoctor/client@2.0.0-alpha.0': {}
 
-  '@rsdoctor/core@2.0.0-alpha.0(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)':
+  '@rsdoctor/core@2.0.0-alpha.0(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)':
     dependencies:
-      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.0.9)
-      '@rsdoctor/graph': 2.0.0-alpha.0(@rspack/core@2.0.5)
-      '@rsdoctor/sdk': 2.0.0-alpha.0(@rspack/core@2.0.5)
-      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.0.5)
-      '@rsdoctor/utils': 2.0.0-alpha.0(@rspack/core@2.0.5)
+      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.1.13)
+      '@rsdoctor/graph': 2.0.0-alpha.0(@rspack/core@2.1.10)
+      '@rsdoctor/sdk': 2.0.0-alpha.0(@rspack/core@2.1.10)
+      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.1.10)
+      '@rsdoctor/utils': 2.0.0-alpha.0(@rspack/core@2.1.10)
       '@rspack/resolver': 0.2.8
       browserslist-load-config: 1.0.1
       es-toolkit: 1.47.0
@@ -54036,13 +54056,13 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@rsdoctor/core@2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))':
+  '@rsdoctor/core@2.0.0-alpha.0(@rspack/core@2.1.10(@swc/helpers@0.5.23))':
     dependencies:
       '@rsbuild/plugin-check-syntax': 1.6.1
-      '@rsdoctor/graph': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
-      '@rsdoctor/sdk': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
-      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
-      '@rsdoctor/utils': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
+      '@rsdoctor/graph': 2.0.0-alpha.0(@rspack/core@2.1.10(@swc/helpers@0.5.23))
+      '@rsdoctor/sdk': 2.0.0-alpha.0(@rspack/core@2.1.10(@swc/helpers@0.5.23))
+      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.1.10(@swc/helpers@0.5.23))
+      '@rsdoctor/utils': 2.0.0-alpha.0(@rspack/core@2.1.10(@swc/helpers@0.5.23))
       '@rspack/resolver': 0.2.8
       browserslist-load-config: 1.0.1
       es-toolkit: 1.47.0
@@ -54058,35 +54078,35 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@rsdoctor/graph@2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))':
+  '@rsdoctor/graph@2.0.0-alpha.0(@rspack/core@2.1.10(@swc/helpers@0.5.23))':
     dependencies:
-      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
-      '@rsdoctor/utils': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
+      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.1.10(@swc/helpers@0.5.23))
+      '@rsdoctor/utils': 2.0.0-alpha.0(@rspack/core@2.1.10(@swc/helpers@0.5.23))
       es-toolkit: 1.47.0
       path-browserify: 1.0.1
       source-map: 0.7.6
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsdoctor/graph@2.0.0-alpha.0(@rspack/core@2.0.5)':
+  '@rsdoctor/graph@2.0.0-alpha.0(@rspack/core@2.1.10)':
     dependencies:
-      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.0.5)
-      '@rsdoctor/utils': 2.0.0-alpha.0(@rspack/core@2.0.5)
+      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.1.10)
+      '@rsdoctor/utils': 2.0.0-alpha.0(@rspack/core@2.1.10)
       es-toolkit: 1.47.0
       path-browserify: 1.0.1
       source-map: 0.7.6
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsdoctor/rspack-plugin@2.0.0-alpha.0(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)':
+  '@rsdoctor/rspack-plugin@2.0.0-alpha.0(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)':
     dependencies:
-      '@rsdoctor/core': 2.0.0-alpha.0(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)
-      '@rsdoctor/graph': 2.0.0-alpha.0(@rspack/core@2.0.5)
-      '@rsdoctor/sdk': 2.0.0-alpha.0(@rspack/core@2.0.5)
-      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.0.5)
-      '@rsdoctor/utils': 2.0.0-alpha.0(@rspack/core@2.0.5)
+      '@rsdoctor/core': 2.0.0-alpha.0(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)
+      '@rsdoctor/graph': 2.0.0-alpha.0(@rspack/core@2.1.10)
+      '@rsdoctor/sdk': 2.0.0-alpha.0(@rspack/core@2.1.10)
+      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.1.10)
+      '@rsdoctor/utils': 2.0.0-alpha.0(@rspack/core@2.1.10)
     optionalDependencies:
-      '@rspack/core': 2.0.5
+      '@rspack/core': 2.1.10
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -54094,15 +54114,15 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@rsdoctor/rspack-plugin@2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))':
+  '@rsdoctor/rspack-plugin@2.0.0-alpha.0(@rspack/core@2.1.10(@swc/helpers@0.5.23))':
     dependencies:
-      '@rsdoctor/core': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
-      '@rsdoctor/graph': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
-      '@rsdoctor/sdk': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
-      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
-      '@rsdoctor/utils': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
+      '@rsdoctor/core': 2.0.0-alpha.0(@rspack/core@2.1.10(@swc/helpers@0.5.23))
+      '@rsdoctor/graph': 2.0.0-alpha.0(@rspack/core@2.1.10(@swc/helpers@0.5.23))
+      '@rsdoctor/sdk': 2.0.0-alpha.0(@rspack/core@2.1.10(@swc/helpers@0.5.23))
+      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.1.10(@swc/helpers@0.5.23))
+      '@rsdoctor/utils': 2.0.0-alpha.0(@rspack/core@2.1.10(@swc/helpers@0.5.23))
     optionalDependencies:
-      '@rspack/core': 2.0.5(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.10(@swc/helpers@0.5.23)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -54110,12 +54130,12 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@rsdoctor/sdk@2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))':
+  '@rsdoctor/sdk@2.0.0-alpha.0(@rspack/core@2.1.10(@swc/helpers@0.5.23))':
     dependencies:
       '@rsdoctor/client': 2.0.0-alpha.0
-      '@rsdoctor/graph': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
-      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
-      '@rsdoctor/utils': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
+      '@rsdoctor/graph': 2.0.0-alpha.0(@rspack/core@2.1.10(@swc/helpers@0.5.23))
+      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.1.10(@swc/helpers@0.5.23))
+      '@rsdoctor/utils': 2.0.0-alpha.0(@rspack/core@2.1.10(@swc/helpers@0.5.23))
       launch-editor: 2.14.0
       safer-buffer: 2.1.2
       tapable: 2.3.3
@@ -54125,12 +54145,12 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@rsdoctor/sdk@2.0.0-alpha.0(@rspack/core@2.0.5)':
+  '@rsdoctor/sdk@2.0.0-alpha.0(@rspack/core@2.1.10)':
     dependencies:
       '@rsdoctor/client': 2.0.0-alpha.0
-      '@rsdoctor/graph': 2.0.0-alpha.0(@rspack/core@2.0.5)
-      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.0.5)
-      '@rsdoctor/utils': 2.0.0-alpha.0(@rspack/core@2.0.5)
+      '@rsdoctor/graph': 2.0.0-alpha.0(@rspack/core@2.1.10)
+      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.1.10)
+      '@rsdoctor/utils': 2.0.0-alpha.0(@rspack/core@2.1.10)
       launch-editor: 2.14.0
       safer-buffer: 2.1.2
       tapable: 2.3.3
@@ -54140,28 +54160,28 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@rsdoctor/types@2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))':
+  '@rsdoctor/types@2.0.0-alpha.0(@rspack/core@2.1.10(@swc/helpers@0.5.23))':
     dependencies:
       '@types/connect': 3.4.38
       '@types/estree': 1.0.5
       '@types/tapable': 2.3.0
       source-map: 0.7.6
     optionalDependencies:
-      '@rspack/core': 2.0.5(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.10(@swc/helpers@0.5.23)
 
-  '@rsdoctor/types@2.0.0-alpha.0(@rspack/core@2.0.5)':
+  '@rsdoctor/types@2.0.0-alpha.0(@rspack/core@2.1.10)':
     dependencies:
       '@types/connect': 3.4.38
       '@types/estree': 1.0.5
       '@types/tapable': 2.3.0
       source-map: 0.7.6
     optionalDependencies:
-      '@rspack/core': 2.0.5
+      '@rspack/core': 2.1.10
 
-  '@rsdoctor/utils@2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))':
+  '@rsdoctor/utils@2.0.0-alpha.0(@rspack/core@2.1.10(@swc/helpers@0.5.23))':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))
+      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.1.10(@swc/helpers@0.5.23))
       '@types/estree': 1.0.5
       acorn: 8.15.0
       acorn-import-attributes: 1.9.5(acorn@8.15.0)
@@ -54178,10 +54198,10 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsdoctor/utils@2.0.0-alpha.0(@rspack/core@2.0.5)':
+  '@rsdoctor/utils@2.0.0-alpha.0(@rspack/core@2.1.10)':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.0.5)
+      '@rsdoctor/types': 2.0.0-alpha.0(@rspack/core@2.1.10)
       '@types/estree': 1.0.5
       acorn: 8.15.0
       acorn-import-attributes: 1.9.5(acorn@8.15.0)
@@ -54198,10 +54218,10 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rslib/core@0.22.0(@typescript/typescript6@6.0.2)':
+  '@rslib/core@0.23.2(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@rsbuild/core': 2.0.9
-      rsbuild-plugin-dts: 0.22.0(@rsbuild/core@2.0.9)(@typescript/typescript6@6.0.2)
+      '@rsbuild/core': 2.1.13
+      rsbuild-plugin-dts: 0.23.2(@rsbuild/core@2.1.13)(@typescript/typescript6@6.0.2)
     optionalDependencies:
       typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
@@ -54209,81 +54229,97 @@ snapshots:
       - '@typescript/native-preview'
       - core-js
 
-  '@rspack/binding-darwin-arm64@2.0.5':
+  '@rspack/binding-darwin-arm64@2.1.10':
     optional: true
 
-  '@rspack/binding-darwin-x64@2.0.5':
+  '@rspack/binding-darwin-x64@2.1.10':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@2.0.5':
+  '@rspack/binding-linux-arm64-gnu@2.1.10':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@2.0.5':
+  '@rspack/binding-linux-arm64-musl@2.1.10':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@2.0.5':
+  '@rspack/binding-linux-ppc64-gnu@2.1.10':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@2.0.5':
+  '@rspack/binding-linux-riscv64-gnu@2.1.10':
     optional: true
 
-  '@rspack/binding-wasm32-wasi@2.0.5':
+  '@rspack/binding-linux-riscv64-musl@2.1.10':
+    optional: true
+
+  '@rspack/binding-linux-s390x-gnu@2.1.10':
+    optional: true
+
+  '@rspack/binding-linux-x64-gnu@2.1.10':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.1.10':
+    optional: true
+
+  '@rspack/binding-wasm32-wasi@2.1.10':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.0.5':
+  '@rspack/binding-win32-arm64-msvc@2.1.10':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@2.0.5':
+  '@rspack/binding-win32-ia32-msvc@2.1.10':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@2.0.5':
+  '@rspack/binding-win32-x64-msvc@2.1.10':
     optional: true
 
-  '@rspack/binding@2.0.5':
+  '@rspack/binding@2.1.10':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.0.5
-      '@rspack/binding-darwin-x64': 2.0.5
-      '@rspack/binding-linux-arm64-gnu': 2.0.5
-      '@rspack/binding-linux-arm64-musl': 2.0.5
-      '@rspack/binding-linux-x64-gnu': 2.0.5
-      '@rspack/binding-linux-x64-musl': 2.0.5
-      '@rspack/binding-wasm32-wasi': 2.0.5
-      '@rspack/binding-win32-arm64-msvc': 2.0.5
-      '@rspack/binding-win32-ia32-msvc': 2.0.5
-      '@rspack/binding-win32-x64-msvc': 2.0.5
+      '@rspack/binding-darwin-arm64': 2.1.10
+      '@rspack/binding-darwin-x64': 2.1.10
+      '@rspack/binding-linux-arm64-gnu': 2.1.10
+      '@rspack/binding-linux-arm64-musl': 2.1.10
+      '@rspack/binding-linux-ppc64-gnu': 2.1.10
+      '@rspack/binding-linux-riscv64-gnu': 2.1.10
+      '@rspack/binding-linux-riscv64-musl': 2.1.10
+      '@rspack/binding-linux-s390x-gnu': 2.1.10
+      '@rspack/binding-linux-x64-gnu': 2.1.10
+      '@rspack/binding-linux-x64-musl': 2.1.10
+      '@rspack/binding-wasm32-wasi': 2.1.10
+      '@rspack/binding-win32-arm64-msvc': 2.1.10
+      '@rspack/binding-win32-ia32-msvc': 2.1.10
+      '@rspack/binding-win32-x64-msvc': 2.1.10
 
-  '@rspack/cli@2.0.5(@rspack/core@2.0.5)':
+  '@rspack/cli@2.1.10(@rspack/core@2.1.10)':
     dependencies:
-      '@rspack/core': 2.0.5
+      '@rspack/core': 2.1.10
 
-  '@rspack/cli@2.0.5(@rspack/core@2.0.5)(@rspack/dev-server@2.0.3(@rspack/core@2.0.5))':
+  '@rspack/cli@2.1.10(@rspack/core@2.1.10)(@rspack/dev-server@2.1.0(@rspack/core@2.1.10))':
     dependencies:
-      '@rspack/core': 2.0.5
+      '@rspack/core': 2.1.10
     optionalDependencies:
-      '@rspack/dev-server': 2.0.3(@rspack/core@2.0.5)
+      '@rspack/dev-server': 2.1.0(@rspack/core@2.1.10)
 
-  '@rspack/core@2.0.5':
+  '@rspack/core@2.1.10':
     dependencies:
-      '@rspack/binding': 2.0.5
+      '@rspack/binding': 2.1.10
 
-  '@rspack/core@2.0.5(@swc/helpers@0.5.23)':
+  '@rspack/core@2.1.10(@swc/helpers@0.5.23)':
     dependencies:
-      '@rspack/binding': 2.0.5
+      '@rspack/binding': 2.1.10
     optionalDependencies:
       '@swc/helpers': 0.5.23
 
-  '@rspack/dev-middleware@2.0.2(@rspack/core@2.0.5)':
+  '@rspack/dev-middleware@2.0.3(@rspack/core@2.1.10)':
     optionalDependencies:
-      '@rspack/core': 2.0.5
+      '@rspack/core': 2.1.10
 
-  '@rspack/dev-server@2.0.3(@rspack/core@2.0.5)':
+  '@rspack/dev-server@2.1.0(@rspack/core@2.1.10)':
     dependencies:
-      '@rspack/core': 2.0.5
-      '@rspack/dev-middleware': 2.0.2(@rspack/core@2.0.5)
+      '@rspack/core': 2.1.10
+      '@rspack/dev-middleware': 2.0.3(@rspack/core@2.1.10)
 
   '@rspack/lite-tapable@1.1.0': {}
 
@@ -54294,21 +54330,15 @@ snapshots:
     optionalDependencies:
       react-refresh: 0.14.2
 
-  '@rspack/plugin-react-refresh@2.0.0(@rspack/core@2.0.5)(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.10)(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.0.5
+      '@rspack/core': 2.1.10
 
-  '@rspack/plugin-react-refresh@2.0.0(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.2(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
-
-  '@rspack/plugin-react-refresh@2.0.1(@rspack/core@2.0.5)(react-refresh@0.18.0)':
-    dependencies:
-      react-refresh: 0.18.0
-    optionalDependencies:
-      '@rspack/core': 2.0.5
 
   '@rspack/resolver-binding-darwin-arm64@0.2.8':
     optional: true
@@ -57373,14 +57403,9 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
-  '@tybys/wasm-util@0.10.1':
-    dependencies:
-      tslib: 2.6.2
-
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.6.2
-    optional: true
 
   '@tybys/wasm-util@0.9.0':
     dependencies:
@@ -71286,7 +71311,7 @@ snapshots:
     transitivePeerDependencies:
       - browserslist
 
-  postcss-loader@8.2.0(@rspack/core@2.0.5)(@typescript/typescript6@6.0.2)(postcss@8.5.6):
+  postcss-loader@8.2.0(@rspack/core@2.1.10)(@typescript/typescript6@6.0.2)(postcss@8.5.6):
     dependencies:
       cosmiconfig: 9.0.0(@typescript/typescript6@6.0.2)
       jiti: 2.6.1
@@ -71296,7 +71321,7 @@ snapshots:
       postcss-preset-env: 7.8.3(postcss@8.5.6)
       semver: 7.8.1
     optionalDependencies:
-      '@rspack/core': 2.0.5
+      '@rspack/core': 2.1.10
     transitivePeerDependencies:
       - browserslist
       - typescript
@@ -73526,19 +73551,19 @@ snapshots:
 
   rrweb-cssom@0.8.0: {}
 
-  rsbuild-plugin-dts@0.22.0(@rsbuild/core@2.0.9)(@typescript/typescript6@6.0.2):
+  rsbuild-plugin-dts@0.23.2(@rsbuild/core@2.1.13)(@typescript/typescript6@6.0.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.0.9
+      '@rsbuild/core': 2.1.13
     optionalDependencies:
       typescript: '@typescript/typescript6@6.0.2'
 
-  rsbuild-plugin-html-minifier-terser@1.1.3(@rsbuild/core@2.0.9):
+  rsbuild-plugin-html-minifier-terser@1.1.3(@rsbuild/core@2.1.13):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.9
+      '@rsbuild/core': 2.1.13
 
   rslog@2.1.2: {}
 
@@ -74336,10 +74361,10 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(@typescript/typescript6@6.0.2)(msw@2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)):
+  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)(@typescript/typescript6@6.0.2)(msw@2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)):
     dependencies:
-      '@rsbuild/core': 2.0.9
-      '@rsbuild/plugin-type-check': 1.3.5(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(@typescript/typescript6@6.0.2)
+      '@rsbuild/core': 2.1.13
+      '@rsbuild/plugin-type-check': 1.3.5(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)(@typescript/typescript6@6.0.2)
       '@vitest/mocker': 3.2.4(msw@2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2))
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -74351,7 +74376,7 @@ snapshots:
       path-browserify: 1.0.1
       picocolors: 1.1.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.0.9)
+      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.1.13)
       sirv: 2.0.4
       storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       ts-dedent: 2.2.0
@@ -74368,10 +74393,10 @@ snapshots:
       - tslib
       - vite
 
-  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(@typescript/typescript6@6.0.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)):
+  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)(@typescript/typescript6@6.0.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)):
     dependencies:
-      '@rsbuild/core': 2.0.9
-      '@rsbuild/plugin-type-check': 1.3.5(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(@typescript/typescript6@6.0.2)
+      '@rsbuild/core': 2.1.13
+      '@rsbuild/plugin-type-check': 1.3.5(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)(@typescript/typescript6@6.0.2)
       '@vitest/mocker': 3.2.4
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -74383,7 +74408,7 @@ snapshots:
       path-browserify: 1.0.1
       picocolors: 1.1.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.0.9)
+      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.1.13)
       sirv: 2.0.4
       storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       ts-dedent: 2.2.0
@@ -74400,10 +74425,10 @@ snapshots:
       - tslib
       - vite
 
-  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.0.9)(@typescript/typescript6@6.0.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)):
+  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.1.13)(@typescript/typescript6@6.0.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)):
     dependencies:
-      '@rsbuild/core': 2.0.9
-      '@rsbuild/plugin-type-check': 1.3.5(@rsbuild/core@2.0.9)(@typescript/typescript6@6.0.2)
+      '@rsbuild/core': 2.1.13
+      '@rsbuild/plugin-type-check': 1.3.5(@rsbuild/core@2.1.13)(@typescript/typescript6@6.0.2)
       '@vitest/mocker': 3.2.4
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -74415,7 +74440,7 @@ snapshots:
       path-browserify: 1.0.1
       picocolors: 1.1.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.0.9)
+      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.1.13)
       sirv: 2.0.4
       storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       ts-dedent: 2.2.0
@@ -74432,10 +74457,10 @@ snapshots:
       - tslib
       - vite
 
-  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(@typescript/typescript6@6.0.2)(msw@2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)):
+  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(@typescript/typescript6@6.0.2)(msw@2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)):
     dependencies:
       '@rollup/pluginutils': 5.3.0
-      '@rsbuild/core': 2.0.9
+      '@rsbuild/core': 2.1.13
       '@storybook/react': 10.4.1(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(@typescript/typescript6@6.0.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
       '@storybook/react-docgen-typescript-plugin': 1.0.1(@typescript/typescript6@6.0.2)
       find-up: 5.0.0
@@ -74446,7 +74471,7 @@ snapshots:
       react-dom: 19.1.4(react@19.1.4)
       resolve: 1.22.12
       storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(@typescript/typescript6@6.0.2)(msw@2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)(@typescript/typescript6@6.0.2)(msw@2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: '@typescript/typescript6@6.0.2'
@@ -74461,10 +74486,10 @@ snapshots:
       - vite
       - webpack
 
-  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(@typescript/typescript6@6.0.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)):
+  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(@typescript/typescript6@6.0.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)):
     dependencies:
       '@rollup/pluginutils': 5.3.0
-      '@rsbuild/core': 2.0.9
+      '@rsbuild/core': 2.1.13
       '@storybook/react': 10.4.1(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(@typescript/typescript6@6.0.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
       '@storybook/react-docgen-typescript-plugin': 1.0.1(@typescript/typescript6@6.0.2)
       find-up: 5.0.0
@@ -74475,7 +74500,7 @@ snapshots:
       react-dom: 19.1.4(react@19.1.4)
       resolve: 1.22.12
       storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.9)(@rspack/core@2.0.5)(@typescript/typescript6@6.0.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)(@typescript/typescript6@6.0.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: '@typescript/typescript6@6.0.2'
@@ -74490,10 +74515,10 @@ snapshots:
       - vite
       - webpack
 
-  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.0.9)(@types/react@19.0.14)(@typescript/typescript6@6.0.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)):
+  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.1.13)(@types/react@19.0.14)(@typescript/typescript6@6.0.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)):
     dependencies:
       '@rollup/pluginutils': 5.3.0
-      '@rsbuild/core': 2.0.9
+      '@rsbuild/core': 2.1.13
       '@storybook/react': 10.4.1(@types/react@19.0.14)(@typescript/typescript6@6.0.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
       '@storybook/react-docgen-typescript-plugin': 1.0.1(@typescript/typescript6@6.0.2)
       find-up: 5.0.0
@@ -74504,7 +74529,7 @@ snapshots:
       react-dom: 19.1.4(react@19.1.4)
       resolve: 1.22.12
       storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.0.9)(@typescript/typescript6@6.0.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.13)(@typescript/typescript6@6.0.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: '@typescript/typescript6@6.0.2'
@@ -75472,7 +75497,7 @@ snapshots:
     dependencies:
       typescript: '@typescript/typescript6@6.0.2'
 
-  ts-checker-rspack-plugin@1.3.1(@rspack/core@2.0.5)(@typescript/typescript6@6.0.2):
+  ts-checker-rspack-plugin@1.3.1(@rspack/core@2.1.10)(@typescript/typescript6@6.0.2):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
       chokidar: 3.6.0
@@ -75480,7 +75505,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: '@typescript/typescript6@6.0.2'
     optionalDependencies:
-      '@rspack/core': 2.0.5
+      '@rspack/core': 2.1.10
     transitivePeerDependencies:
       - tslib
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -86,16 +86,16 @@ catalog:
   "@jest/reporters": 30.2.0
   "@jest/test-result": 30.2.0
   "@reduxjs/toolkit": 2.11.2
-  "@rsbuild/core": 2.0.9
-  "@rsbuild/plugin-node-polyfill": 1.4.5
-  "@rsbuild/plugin-react": 2.0.1
+  "@rsbuild/core": 2.1.13
+  "@rsbuild/plugin-node-polyfill": 1.4.6
+  "@rsbuild/plugin-react": 2.1.0
   "@rsbuild/plugin-styled-components": 1.6.2
   "@rsdoctor/rspack-plugin": "2.0.0-alpha.0"
-  "@rspack/cli": 2.0.5
-  "@rspack/core": 2.0.5
-  "@rspack/dev-server": 2.0.3
-  "@rspack/plugin-react-refresh": 2.0.1
-  "@rslib/core": 0.22.0
+  "@rspack/cli": 2.1.10
+  "@rspack/core": 2.1.10
+  "@rspack/dev-server": 2.1.0
+  "@rspack/plugin-react-refresh": 2.0.2
+  "@rslib/core": 0.23.2
   react-refresh: 0.18.0
   storybook: 10.4.1
   "@storybook/react": 10.4.1


### PR DESCRIPTION
### 📝 Description

Bumps the rsbuild/rspack toolchain from 2.0.x to 2.1.x across the catalog in `pnpm-workspace.yaml`.

| Package | Before | After | Notes |
|---|---|---|---|
| `@rsbuild/core` | 2.0.9 | **2.1.13** | |
| `@rsbuild/plugin-react` | 2.0.1 | **2.1.0** | |
| `@rsbuild/plugin-node-polyfill` | 1.4.5 | **1.4.6** | |
| `@rspack/core` | 2.0.5 | **2.1.10** | |
| `@rspack/cli` | 2.0.5 | **2.1.10** | |
| `@rspack/dev-server` | 2.0.3 | **2.1.0** | |
| `@rspack/plugin-react-refresh` | 2.0.1 | **2.0.2** | no 2.1.x released yet |
| `@rslib/core` | 0.22.0 | **0.23.2** | 0.23.x depends on `@rsbuild/core ~2.1.4`, eliminates residual 2.0.x copies from the lockfile |

> [!NOTE]
> `@rsbuild/plugin-styled-components` stays at 1.6.2 — 1.7.0 was published the same day and pnpm's `minimumReleaseAge` safety check blocks same-day installs.

No config changes were needed — the one 2.1.x breaking change (`cache.storage.directory` → `cache.storage.location`) did not apply to this project.

**Bundle size:** renderer bundle is +1.4% (16.33 MB → 16.56 MB). Source sizes are unchanged — the delta is entirely in the parsed (minified) output due to SWC minifier heuristic differences between 2.0.x and 2.1.x. Some files grew slightly, others shrank (e.g. react-router -12.46 KB).

**iOS:** `Podfile.lock` regenerated with CocoaPods 1.14.3 (matching CI) — `callstack-repack` path hash changed because it peer-resolves against `@rspack/core`.

Desktop production build verified locally (`pnpm desktop build:js`, Rspack 2.1.10, all 7 bundles ✅).

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36432](https://ledgerhq.atlassian.net/browse/LIVE-36432)
- **ADR** (if any): N/A


[LIVE-36432]: https://ledgerhq.atlassian.net/browse/LIVE-36432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ