### PR TITLE
[LWDM] feat(pay): add @features/flow-pay-card orchestrator package

### DIFF
--- a/.changeset/pay-card-parent-package.md
+++ b/.changeset/pay-card-parent-package.md
@@ -1,0 +1,9 @@
+---
+"@features/flow-pay-card": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Add `@features/flow-pay-card`, a Contacts-style orchestrator that aggregates the Pay Card leaf flows behind a single `Card` entry point. It follows the app MVVM split — a `Card` container wires a shared `useCardViewModel` to the platform `CardView` — and composes the card face from `@features/flow-pay-card-details` (`CardVisual` with the balance overlay, or the bare `CardArtwork`) with the authentication controls (`CardLogin` / `CardLogout` from `@features/flow-pay-card-auth`), each of which still decides on its own whether it belongs on screen.
+
+The flow owns the (currently mocked) card balance and assembles the overlay itself, so hosts no longer pass a pre-built visual: they hand over only what they alone know — `formatCountervalue` (needs the app's locale and counter-value currency) and `balanceLabel` (i18n). Both apps now mount `Card` instead of wiring `CardLogin` / `CardLogout` directly: desktop in the Pay tab's right panel, mobile in the Pay tab body. The package composes rather than re-exports: apps that need a single leaf or its Redux state (`@features/flow-pay-card-auth/state`) keep importing that leaf directly.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -126,6 +126,7 @@ features/flow/flow-contacts-introduction/                @ledgerhq/wallet-xp
 features/flow/flow-contacts-list/                         @ledgerhq/wallet-xp
 
 # Wallet — Pay Card
+features/flow/pay-card/                                  @ledgerhq/wallet-xp
 features/flow/pay-card-balance/                          @ledgerhq/wallet-xp
 features/flow/pay-card-deposit/                          @ledgerhq/wallet-xp
 features/flow/pay-card-feature-tour/                     @ledgerhq/wallet-xp

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -97,6 +97,7 @@
     "@features/flow-contacts-list": "workspace:^",
     "@features/flow-fear-and-greed": "workspace:^",
     "@features/flow-large-screen-upsell": "workspace:^",
+    "@features/flow-pay-card": "workspace:^",
     "@features/flow-pay-card-auth": "workspace:^",
     "@features/flow-pay-card-balance": "workspace:^",
     "@features/flow-pay-card-deposit": "workspace:^",

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/Card/CardView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/Card/CardView.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { CardVisual } from "@features/flow-pay-card-details";
+import { Card as PayCard } from "@features/flow-pay-card";
 import PayCardContainer from "LLD/features/PayTab/components/PayCardContainer";
 import type { CardViewModel } from "./types";
 
@@ -9,17 +9,18 @@ export interface CardViewProps {
 
 /**
  * CardView
- * Right-panel content for the Pay tab: the Pay Card container framing the card visual.
+ * Right-panel content for the Pay tab: the Pay Card container framing the card visual and the
+ * authentication controls.
  */
 export const CardView = ({ viewModel }: CardViewProps) => {
-  const { balance, formatCountervalue, balanceLabel } = viewModel;
+  const { formatCountervalue, balanceLabel, oauthConfig } = viewModel;
 
   return (
     <div className="flex h-full flex-col pb-32">
       <PayCardContainer>
         <div className="p-16">
-          <CardVisual
-            balance={balance}
+          <PayCard
+            oauthConfig={oauthConfig}
             formatCountervalue={formatCountervalue}
             balanceLabel={balanceLabel}
           />

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/Card/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/Card/types.ts
@@ -1,7 +1,8 @@
+import type { CardProps as PayCardProps } from "@features/flow-pay-card";
 import type { FormattedValue } from "@features/flow-pay-card-details";
 
 export interface CardViewModel {
-  readonly balance: number;
   readonly formatCountervalue: (value: number) => FormattedValue;
   readonly balanceLabel: string;
+  readonly oauthConfig: PayCardProps["oauthConfig"];
 }

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/Card/useCardViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/Card/useCardViewModel.ts
@@ -1,14 +1,12 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import BigNumber from "bignumber.js";
 import { useTranslation } from "react-i18next";
 import { formatCurrencyUnitFragment } from "@ledgerhq/live-common/currencies/index";
 import type { FormattedValue } from "@features/flow-pay-card-details";
+import { getEnv } from "@shared/env";
 import { useSelector } from "LLD/hooks/redux";
 import { counterValueCurrencySelector, localeSelector } from "~/renderer/reducers/settings";
 import type { CardViewModel } from "./types";
-
-/** Mock card balance shown until the real balance API is wired (see LIVE-35427 follow-up). */
-const MOCK_CARD_BALANCE = 100;
 
 export function useCardViewModel(): CardViewModel {
   const { t } = useTranslation();
@@ -22,9 +20,20 @@ export function useCardViewModel(): CardViewModel {
     [unit, locale],
   );
 
+  // Baanx uses the same value for the client key header and the OAuth `client_id`.
+  const oauthConfig: CardViewModel["oauthConfig"] = useMemo(
+    () => ({
+      apiUrl: getEnv("CARD_API_URL"),
+      clientId: getEnv("CARD_BAANX_CLIENT_KEY"),
+      // No `deepLink`: the user's own browser opens the page, and it reports nothing back (LIVE-34740).
+      redirectUri: getEnv("CARD_OAUTH_REDIRECT_URI"),
+    }),
+    [],
+  );
+
   return {
-    balance: MOCK_CARD_BALANCE,
     formatCountervalue,
     balanceLabel: t("payTab.card.balanceLabel"),
+    oauthConfig,
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
@@ -63,11 +63,6 @@ function mockFundedPayStablecoins() {
   });
 }
 
-jest.mock("@features/flow-pay-card-auth", () => ({
-  CardLogin: () => <button type="button">Login</button>,
-  CardLogout: () => null,
-}));
-
 type CapturedExecutor = {
   sourceFlow: string;
   intent: { input: { expectedAddress: string } };
@@ -181,12 +176,13 @@ describe("PayTab integration", () => {
     );
   });
 
-  it("should still render the card login block below the hero", async () => {
+  it("should leave the card and its login to the right panel", async () => {
     renderWithMockedCounterValuesProvider(<PayTab />, {
       initialState: { ...onboardedState, ...tourSeenState, accounts: [BTC_ACCOUNT] },
     });
 
-    expect(await screen.findByRole("button", { name: "Login" })).toBeVisible();
+    expect(await screen.findByText(EMPTY_TITLE)).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Login" })).not.toBeInTheDocument();
   });
 
   it("should open the balance filter dialog from the hero pill and track the interaction", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/index.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { CardLogin, CardLogout, type CardLoginOauthConfig } from "@features/flow-pay-card-auth";
 import { Balance } from "@features/flow-pay-card-balance";
 import { DepositOptions } from "@features/flow-pay-card-deposit";
 import { RequestReceive, VerifyAddress } from "@features/flow-pay-card-request";
-import { getEnv } from "@shared/env";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import PayTabHeader from "./components/PayTabHeader";
 import { usePayCardBalance } from "./hooks/usePayCardBalance";
@@ -15,14 +13,6 @@ import { usePayTabRequestReceive } from "./hooks/usePayTabRequestReceive";
 import { usePayTabNewPayment } from "./hooks/usePayTabNewPayment";
 import { usePayTabVerifyAddress } from "./hooks/usePayTabVerifyAddress";
 import { VerifyAddressExecutorLWD } from "./verifyAddressIntent/VerifyAddressExecutorLWD";
-
-// Baanx uses the same value for the client key header and the OAuth `client_id`.
-const oauthConfig: CardLoginOauthConfig = {
-  apiUrl: getEnv("CARD_API_URL"),
-  clientId: getEnv("CARD_BAANX_CLIENT_KEY"),
-  // No `deepLink`: the user's own browser opens the page, and it reports nothing back (LIVE-34740).
-  redirectUri: getEnv("CARD_OAUTH_REDIRECT_URI"),
-};
 
 const PayTab = () => {
   const balance = usePayCardBalance();
@@ -54,10 +44,6 @@ const PayTab = () => {
           onExit={verify.deviceIntent.onExit}
         />
       )}
-      {/* Each one decides whether it belongs on screen: the login while nobody is signed in, and
-          the logout once somebody is. */}
-      <CardLogin oauthConfig={oauthConfig} />
-      <CardLogout />
       <FeatureTour {...featureTour} />
     </div>
   );

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -112,6 +112,7 @@
     "@domain/entity-wallet-sync": "workspace:^",
     "@features/flow-analytics-consent": "workspace:*",
     "@features/flow-app-lock": "workspace:*",
+    "@features/flow-pay-card": "workspace:^",
     "@features/flow-pay-card-auth": "workspace:^",
     "@features/flow-pay-card-balance": "workspace:^",
     "@features/flow-pay-card-deposit": "workspace:^",

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
@@ -25,12 +25,15 @@ jest.mock("~/analytics", () => ({
   track: (...args: unknown[]) => mockTrack(...args),
 }));
 
-jest.mock("@features/flow-pay-card-auth", () => {
+jest.mock("@features/flow-pay-card", () => {
   const ReactModule = require("react");
   const { View } = require("react-native");
   return {
-    CardLogin: () => ReactModule.createElement(View, { testID: "card-login" }),
-    CardLogout: () => ReactModule.createElement(View, { testID: "card-logout" }),
+    Card: () =>
+      ReactModule.createElement(ReactModule.Fragment, null, [
+        ReactModule.createElement(View, { testID: "card-login", key: "login" }),
+        ReactModule.createElement(View, { testID: "card-logout", key: "logout" }),
+      ]),
   };
 });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/PayTabView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/PayTabView.tsx
@@ -1,10 +1,5 @@
 import React from "react";
-import {
-  CardLogin,
-  CardLogout,
-  type CardLoginOauthConfig,
-  type PayCardAuthCallback,
-} from "@features/flow-pay-card-auth";
+import { Card, type CardProps } from "@features/flow-pay-card";
 import { FeatureTour, type FeatureTourProps } from "@features/flow-pay-card-feature-tour";
 import {
   Balance,
@@ -19,8 +14,8 @@ import { TrackScreen } from "~/analytics";
 
 type PayTabViewProps = {
   readonly top: number;
-  readonly oauthConfig: CardLoginOauthConfig;
-  readonly callback: PayCardAuthCallback | null;
+  readonly oauthConfig: CardProps["oauthConfig"];
+  readonly callback: CardProps["callback"];
   readonly featureTour: FeatureTourProps;
   readonly balance: BalanceData;
   readonly balanceLabels: BalanceLabels;
@@ -50,8 +45,7 @@ export function PayTabView({
       <Balance {...balance} labels={balanceLabels} actionTiles={actionTiles} />
       <DepositOptions {...depositOptions} />
       <RequestReceive {...requestReceive} />
-      <CardLogin oauthConfig={oauthConfig} callback={callback} />
-      <CardLogout />
+      <Card oauthConfig={oauthConfig} callback={callback} />
       <FeatureTour {...featureTour} />
     </Box>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
@@ -3,7 +3,7 @@ import { useRoute, type RouteProp } from "@react-navigation/native";
 import { getEnv } from "@shared/env";
 import { useTranslation } from "~/context/Locale";
 import type { ScreenName } from "~/const";
-import type { CardLoginOauthConfig, PayCardAuthCallback } from "@features/flow-pay-card-auth";
+import type { CardProps } from "@features/flow-pay-card";
 import type { PayTabNavigatorParamList } from "LLM/features/PayTab/types";
 import type { FeatureTourProps } from "@features/flow-pay-card-feature-tour";
 import type { BalanceLabels } from "@features/flow-pay-card-balance";
@@ -39,7 +39,7 @@ export function usePayTabViewModel() {
   );
 
   // Baanx uses the same value for the client key header and the OAuth `client_id`.
-  const oauthConfig: CardLoginOauthConfig = useMemo(
+  const oauthConfig: CardProps["oauthConfig"] = useMemo(
     () => ({
       apiUrl: getEnv("CARD_API_URL"),
       clientId: getEnv("CARD_BAANX_CLIENT_KEY"),
@@ -51,7 +51,7 @@ export function usePayTabViewModel() {
 
   // The OAuth redirect, when the deep link brought one. The code is the whole of it: PKCE ties it to
   // the verifier on disk, so nothing else has to be echoed back.
-  const callback: PayCardAuthCallback | null = useMemo(
+  const callback: CardProps["callback"] = useMemo(
     () => (params?.code ? { code: params.code } : null),
     [params?.code],
   );

--- a/features/flow/pay-card/.eslintrc.tailwind.js
+++ b/features/flow/pay-card/.eslintrc.tailwind.js
@@ -1,0 +1,34 @@
+/**
+ * ESLint config for better-tailwindcss only (no oxlint equivalent).
+ * Run via: pnpm lint:tailwind
+ * Applies to *.web.{ts,tsx} files only.
+ */
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+const path = require("path");
+
+module.exports = {
+  root: true,
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: "module",
+    ecmaFeatures: { jsx: true },
+  },
+  plugins: ["better-tailwindcss"],
+  extends: ["plugin:better-tailwindcss/recommended"],
+  ignorePatterns: ["*.js", "*.cjs", "*.mjs", "node_modules"],
+  rules: {
+    "better-tailwindcss/enforce-consistent-line-wrapping": "off",
+  },
+  settings: {
+    "better-tailwindcss": {
+      entryPoint: path.join(__dirname, "../../../apps/ledger-live-desktop/src/renderer/global.css"),
+      callees: ["cn"],
+    },
+  },
+  overrides: [
+    {
+      files: ["**/*.web.{ts,tsx}"],
+    },
+  ],
+};

--- a/features/flow/pay-card/.oxfmtrc.json
+++ b/features/flow/pay-card/.oxfmtrc.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "printWidth": 100,
+  "trailingComma": "all",
+  "arrowParens": "avoid",
+  "sortPackageJson": false,
+  "ignorePatterns": [
+    "**/*.md",
+    "**/*.json"
+  ]
+}

--- a/features/flow/pay-card/.oxlintrc.json
+++ b/features/flow/pay-card/.oxlintrc.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "env": {
+    "browser": true,
+    "es6": true,
+    "node": true
+  },
+  "plugins": [
+    "eslint",
+    "import",
+    "oxc",
+    "unicorn",
+    "typescript",
+    "react",
+    "jest",
+    "jsx-a11y"
+  ],
+  "ignorePatterns": ["*.js", "*.cjs", "*.mjs", "node_modules"],
+  "categories": {
+    "correctness": "error",
+    "suspicious": "warn",
+    "pedantic": "off"
+  },
+  "rules": {
+    "eslint/no-unused-vars": "warn",
+    "eslint/no-empty-pattern": "warn",
+    "eslint/no-constant-binary-expression": "warn",
+    "eslint/no-shadow": "off",
+    "eslint/no-unused-expressions": "warn",
+    "eslint/no-unsafe-optional-chaining": "off",
+    "eslint/no-useless-rename": "warn",
+    "eslint/no-console": ["error", { "allow": ["warn", "error"] }],
+    "eslint/no-restricted-imports": [
+      "error",
+      {
+        "paths": ["lodash"],
+        "patterns": [
+          {
+            "group": [
+              "@ledgerhq/live-common/lib/**",
+              "@ledgerhq/live-common/lib-es/**"
+            ],
+            "message": "Please remove the /lib import from live-common import."
+          }
+        ]
+      }
+    ],
+    "import/no-duplicates": "error",
+    "import/no-named-as-default": "off",
+    "typescript/no-explicit-any": "error",
+    "typescript/no-non-null-assertion": "off",
+    "typescript/no-deprecated": "error",
+    "react/no-did-mount-set-state": "warn",
+    "react/jsx-key": "warn",
+    "react/display-name": "off",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": [
+      "error",
+      {
+        "additionalHooks": "(useInViewContext|useAnimatedStyle|useDerivedValue|useAnimatedProps)"
+      }
+    ],
+    "unicorn/no-useless-fallback-in-spread": "off",
+    "unicorn/no-useless-spread": "off",
+    "unicorn/no-new-array": "off",
+    "unicorn/no-array-sort": "off",
+    "jest/no-conditional-expect": "warn",
+    "jest/expect-expect": "warn",
+    "jest/require-to-throw-message": "warn",
+    "jest/valid-title": "warn",
+    "jest/no-disabled-tests": "warn",
+    "oxc/const-comparisons": "warn",
+    "jsx-a11y/no-autofocus": "off",
+    "jsx-a11y/anchor-is-valid": "off"
+  },
+  "overrides": [
+    {
+      "files": ["**/*.test.{ts,tsx}", "**/__tests__/**"],
+      "env": { "jest": true },
+      "plugins": ["jest"],
+      "rules": {
+        "typescript/no-explicit-any": "warn"
+      }
+    }
+  ]
+}

--- a/features/flow/pay-card/README.md
+++ b/features/flow/pay-card/README.md
@@ -1,0 +1,80 @@
+# @features/flow-pay-card
+
+> [!CAUTION]
+> **Status: UNSTABLE** — In active development; API may change.
+
+Pay Card flow orchestrator for Ledger Wallet Desktop and Mobile. It composes the independent Pay
+Card leaf flows into a single entry point, mirroring the Contacts aggregate (`@features/flow-contacts`).
+
+## Usage
+
+```tsx
+import { Card } from "@features/flow-pay-card";
+
+<Card
+  oauthConfig={oauthConfig}
+  callback={callback}
+  formatCountervalue={formatCountervalue}
+  balanceLabel={balanceLabel}
+/>;
+```
+
+`Card` mounts the card visual and the authentication controls together:
+
+- The card face from [`@features/flow-pay-card-details`](../pay-card-details/README.md): `CardVisual`
+  once the host provides a countervalue formatter and a balance label, the bare `CardArtwork` otherwise.
+- `CardLogin` / `CardLogout` from [`@features/flow-pay-card-auth`](../pay-card-auth/README.md) — each
+  decides on its own whether it belongs on screen: the login while nobody is signed in, and the
+  logout once somebody is.
+
+The flow owns the (currently mocked) card balance, so hosts no longer assemble the visual themselves.
+They pass only the two things the flow cannot know: `formatCountervalue` (needs the app's locale and
+counter-value currency) and `balanceLabel` (i18n stays with the host). `oauthConfig` and `callback`
+come from `@features/flow-pay-card-auth`. Desktop mounts this flow in the Pay tab's right panel.
+
+## MVVM
+
+The flow follows the app MVVM split so both platforms share the logic and differ only in markup:
+
+- `useCardViewModel` (shared) turns the host `CardProps` into the resolved `CardViewProps` — chiefly
+  building the balance overlay (or leaving it `undefined` for the bare artwork).
+- `CardView.web.tsx` / `CardView.native.tsx` are the presentational views; they render what the view
+  model resolved and nothing more.
+- `Card` is the container: it wires the hook to the platform view (`<CardView {...useCardViewModel(props)} />`).
+
+## Public API vs leaves
+
+This package **composes**; it does not re-export its leaves. Each leaf keeps its own public API and is
+imported directly when an app needs a single piece or its Redux state:
+
+- Auth-only runtime state (`payCardAuth`) stays behind `@features/flow-pay-card-auth/state`.
+- Other Pay Card surfaces (`Balance`, `DepositOptions`, `RequestReceive`, `FeatureTour`) remain
+  independent `@features/flow-pay-card-*` leaves that the app assembles on its Pay tab; they are not
+  pulled into this orchestrator.
+
+## Platform resolution
+
+`Card.tsx` imports the view suffix-free (`./CardView`); the bundlers (Rspack `resolve.extensions`,
+Metro platform extensions) and the package's own `tsconfig` `moduleSuffixes` pick `CardView.web.tsx`
+or `CardView.native.tsx` per platform. The `exports` condition in `package.json` selects the barrel
+(`index.ts` for web, `index.native.ts` for React Native); both re-export the shared `./Card`
+container. The leaf packages resolve their own Web / React Native implementations the same way.
+
+## Structure
+
+Every `index.*` is a pure barrel (`export *` only).
+
+```text
+pay-card/
+├── package.json
+└── src/
+    ├── Card.tsx                  # Container: wires the view model to the platform view
+    ├── Card.types.ts            # CardProps (host input) + CardViewProps (resolved view props)
+    ├── useCardViewModel.ts      # Shared view model: builds the card visual from host inputs
+    ├── CardView.web.tsx         # Presentational view (web)
+    ├── CardView.native.tsx      # Presentational view (native)
+    ├── Card.web.test.tsx
+    ├── Card.native.test.tsx
+    ├── index.ts                 # Web public API barrel → ./Card
+    └── index.native.ts          # Native public API barrel → ./Card
+```

--- a/features/flow/pay-card/jest.config.js
+++ b/features/flow/pay-card/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require("@support/jest-features-flow").createFlowJestConfig();

--- a/features/flow/pay-card/knip.native.config.mjs
+++ b/features/flow/pay-card/knip.native.config.mjs
@@ -1,0 +1,8 @@
+import { createDualPlatformKnipConfig } from "../../../knip.config.base.mjs";
+
+export default createDualPlatformKnipConfig({
+  packagePath: "features/flow/pay-card",
+  platform: "native",
+  entry: ["src/index.native.ts"],
+  additionalProjectExcludes: ["src/index.ts"],
+});

--- a/features/flow/pay-card/knip.web.config.mjs
+++ b/features/flow/pay-card/knip.web.config.mjs
@@ -1,0 +1,7 @@
+import { createDualPlatformKnipConfig } from "../../../knip.config.base.mjs";
+
+export default createDualPlatformKnipConfig({
+  packagePath: "features/flow/pay-card",
+  platform: "web",
+  entry: ["src/index.ts"],
+});

--- a/features/flow/pay-card/package.json
+++ b/features/flow/pay-card/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@features/flow-pay-card",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Pay Card flow orchestrator: composes the Pay Card auth and details leaves for Ledger Wallet",
+  "main": "src/index.ts",
+  "react-native": "src/index.native.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "react-native": "./src/index.native.ts",
+      "default": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "format": "oxfmt src",
+    "format:check": "oxfmt src --check",
+    "typecheck": "tsc --noEmit -p tsconfig.web.json && tsc --noEmit -p tsconfig.native.json",
+    "lint": "oxlint src && pnpm lint:tailwind",
+    "lint:fix": "oxfmt src && oxlint src --fix --quiet && pnpm lint:tailwind",
+    "lint:tailwind": "eslint --no-eslintrc -c .eslintrc.tailwind.js --ext .ts,.tsx 'src/**/*.web.{ts,tsx}'",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../../.. -c features/flow/pay-card/knip.web.config.mjs -W features/flow/pay-card --tsConfig tsconfig.web.json && pnpm knip --directory ../../.. -c features/flow/pay-card/knip.native.config.mjs -W features/flow/pay-card --tsConfig tsconfig.native.json"
+  },
+  "dependencies": {
+    "@features/flow-pay-card-auth": "workspace:^",
+    "@features/flow-pay-card-details": "workspace:^"
+  },
+  "devDependencies": {
+    "@support/jest-features-flow": "workspace:*",
+    "@ledgerhq/lumen-ui-react": "catalog:",
+    "@ledgerhq/lumen-ui-rnative": "catalog:",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@testing-library/dom": "catalog:",
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
+    "@testing-library/react-native": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "jest": "catalog:",
+    "jest-environment-jsdom": "catalog:",
+    "oxfmt": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "react-native": "catalog:",
+    "react-test-renderer": "catalog:",
+    "typescript": "catalog:"
+  },
+  "peerDependencies": {
+    "react": "catalog:",
+    "react-native": "catalog:"
+  },
+  "peerDependenciesMeta": {
+    "react-native": {
+      "optional": true
+    }
+  }
+}

--- a/features/flow/pay-card/project.json
+++ b/features/flow/pay-card/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@features/flow-pay-card",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/features/flow/pay-card/src/Card.native.test.tsx
+++ b/features/flow/pay-card/src/Card.native.test.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { render, screen } from "@testing-library/react-native";
+import { View } from "react-native";
+import type { CardProps } from "./Card.types";
+
+jest.mock("@features/flow-pay-card-auth", () => ({
+  CardLogin: () => <View testID="card-login" />,
+  CardLogout: () => <View testID="card-logout" />,
+}));
+
+jest.mock("@features/flow-pay-card-details", () => ({
+  CardArtwork: () => <View testID="card-artwork" />,
+  CardVisual: () => <View testID="card-visual" />,
+}));
+
+import { Card } from "./Card";
+
+const oauthConfig: CardProps["oauthConfig"] = {
+  apiUrl: "https://card.example",
+  clientId: "client-id",
+  redirectUri: "https://card.example/callback",
+};
+
+const formatCountervalue: CardProps["formatCountervalue"] = (value: number) => ({
+  integerPart: String(value),
+  decimalPart: "00",
+  currencyText: "$",
+  decimalSeparator: ".",
+  currencyPosition: "start",
+});
+
+describe("Card (native)", () => {
+  it("composes the bare artwork with the auth login and logout", () => {
+    render(<Card oauthConfig={oauthConfig} />);
+
+    expect(screen.getByTestId("card-artwork")).toBeTruthy();
+    expect(screen.getByTestId("card-login")).toBeTruthy();
+    expect(screen.getByTestId("card-logout")).toBeTruthy();
+  });
+
+  it("swaps the bare artwork for the card visual once the host provides a formatter and label", () => {
+    render(
+      <Card
+        oauthConfig={oauthConfig}
+        formatCountervalue={formatCountervalue}
+        balanceLabel="Balance"
+      />,
+    );
+
+    expect(screen.getByTestId("card-visual")).toBeTruthy();
+    expect(screen.queryByTestId("card-artwork")).toBeNull();
+    expect(screen.getByTestId("card-login")).toBeTruthy();
+    expect(screen.getByTestId("card-logout")).toBeTruthy();
+  });
+});

--- a/features/flow/pay-card/src/Card.tsx
+++ b/features/flow/pay-card/src/Card.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { CardView } from "./CardView";
+import type { CardProps } from "./Card.types";
+import { useCardViewModel } from "./useCardViewModel";
+
+export function Card(props: CardProps) {
+  return <CardView {...useCardViewModel(props)} />;
+}

--- a/features/flow/pay-card/src/Card.types.ts
+++ b/features/flow/pay-card/src/Card.types.ts
@@ -1,0 +1,28 @@
+import type { CardLoginOauthConfig, PayCardAuthCallback } from "@features/flow-pay-card-auth";
+import type { CardVisualProps, FormattedValue } from "@features/flow-pay-card-details";
+
+/** Host input for the Pay Card flow. */
+export type CardProps = {
+  readonly oauthConfig: CardLoginOauthConfig;
+  /**
+   * The OAuth redirect the app already parsed, when it has one. The app's router owns the deep link,
+   * so it hands the flow the `code` it received.
+   */
+  readonly callback?: PayCardAuthCallback | null;
+  /**
+   * Turns the (flow-owned) card balance into a value `AmountDisplay` can render. This is the one bit
+   * the flow cannot build itself: it needs the app's locale and counter-value currency. Omit it and
+   * the card falls back to the bare artwork.
+   */
+  readonly formatCountervalue?: (value: number) => FormattedValue;
+  /** Localized caption shown above the balance. i18n stays with the host, so the app passes the string. */
+  readonly balanceLabel?: string;
+};
+
+/** Props the presentational view renders, resolved by {@link useCardViewModel}. */
+export type CardViewProps = {
+  readonly oauthConfig: CardLoginOauthConfig;
+  readonly callback?: PayCardAuthCallback | null;
+  /** Balance overlay for the card face, or `undefined` to show the bare artwork. */
+  readonly cardVisual?: CardVisualProps;
+};

--- a/features/flow/pay-card/src/Card.web.test.tsx
+++ b/features/flow/pay-card/src/Card.web.test.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import type { CardProps } from "./Card.types";
+
+jest.mock("@features/flow-pay-card-auth", () => ({
+  CardLogin: () => <div data-testid="card-login" />,
+  CardLogout: () => <div data-testid="card-logout" />,
+}));
+
+jest.mock("@features/flow-pay-card-details", () => ({
+  CardArtwork: () => <div data-testid="card-artwork" />,
+  CardVisual: () => <div data-testid="card-visual" />,
+}));
+
+import { Card } from "./Card";
+
+const oauthConfig: CardProps["oauthConfig"] = {
+  apiUrl: "https://card.example",
+  clientId: "client-id",
+  redirectUri: "https://card.example/callback",
+};
+
+const formatCountervalue: CardProps["formatCountervalue"] = (value: number) => ({
+  integerPart: String(value),
+  decimalPart: "00",
+  currencyText: "$",
+  decimalSeparator: ".",
+  currencyPosition: "start",
+});
+
+describe("Card (web)", () => {
+  it("composes the bare artwork with the auth login and logout", () => {
+    render(<Card oauthConfig={oauthConfig} />);
+
+    expect(screen.getByTestId("card-artwork")).toBeVisible();
+    expect(screen.getByTestId("card-login")).toBeVisible();
+    expect(screen.getByTestId("card-logout")).toBeVisible();
+  });
+
+  it("swaps the bare artwork for the card visual once the host provides a formatter and label", () => {
+    render(
+      <Card
+        oauthConfig={oauthConfig}
+        formatCountervalue={formatCountervalue}
+        balanceLabel="Balance"
+      />,
+    );
+
+    expect(screen.getByTestId("card-visual")).toBeVisible();
+    expect(screen.queryByTestId("card-artwork")).not.toBeInTheDocument();
+    expect(screen.getByTestId("card-login")).toBeVisible();
+    expect(screen.getByTestId("card-logout")).toBeVisible();
+  });
+});

--- a/features/flow/pay-card/src/CardView.native.tsx
+++ b/features/flow/pay-card/src/CardView.native.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { CardLogin, CardLogout } from "@features/flow-pay-card-auth";
+import { CardArtwork, CardVisual } from "@features/flow-pay-card-details";
+import type { CardViewProps } from "./Card.types";
+
+export function CardView({ oauthConfig, callback, cardVisual }: CardViewProps) {
+  return (
+    <>
+      {/* TODO: orchestrate the display state here. These pieces are mutually exclusive: the card
+          face shows once the holder is signed in and has a card, while the login shows only while
+          nobody is signed in. Right now each child decides on its own, so they can overlap. */}
+      {cardVisual ? <CardVisual {...cardVisual} /> : <CardArtwork />}
+      <CardLogin oauthConfig={oauthConfig} callback={callback} />
+      <CardLogout />
+    </>
+  );
+}

--- a/features/flow/pay-card/src/CardView.web.tsx
+++ b/features/flow/pay-card/src/CardView.web.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { CardLogin, CardLogout } from "@features/flow-pay-card-auth";
+import { CardArtwork, CardVisual } from "@features/flow-pay-card-details";
+import { Divider } from "@ledgerhq/lumen-ui-react";
+import type { CardViewProps } from "./Card.types";
+
+export function CardView({ oauthConfig, callback, cardVisual }: CardViewProps) {
+  return (
+    <div className="flex flex-col gap-16">
+      {/* TODO: orchestrate the display state here. These pieces are mutually exclusive: the card
+          face shows once the holder is signed in and has a card, while the login shows only while
+          nobody is signed in. Right now each child decides on its own, so they can overlap. */}
+      {cardVisual ? <CardVisual {...cardVisual} /> : <CardArtwork />}
+      <Divider />
+      <CardLogin oauthConfig={oauthConfig} callback={callback} />
+      <CardLogout />
+    </div>
+  );
+}

--- a/features/flow/pay-card/src/assets.d.ts
+++ b/features/flow/pay-card/src/assets.d.ts
@@ -1,0 +1,8 @@
+// The details leaf imports its Figma-exported `*.svg` assets as URL strings (bundler
+// `asset/resource`). This package is the first to compile that source across the package boundary,
+// so it re-declares the ambient module here to keep `tsc` happy — mirroring
+// `features/flow/pay-card-details/src/assets.d.ts`.
+declare module "*.svg" {
+  const src: string;
+  export default src;
+}

--- a/features/flow/pay-card/src/index.native.ts
+++ b/features/flow/pay-card/src/index.native.ts
@@ -1,0 +1,2 @@
+export * from "./Card";
+export type * from "./Card.types";

--- a/features/flow/pay-card/src/index.ts
+++ b/features/flow/pay-card/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./Card";
+export type * from "./Card.types";

--- a/features/flow/pay-card/src/useCardViewModel.ts
+++ b/features/flow/pay-card/src/useCardViewModel.ts
@@ -1,0 +1,25 @@
+import { useMemo } from "react";
+import type { CardProps, CardViewProps } from "./Card.types";
+
+/** Mock card balance shown until the real balance API is wired (see LIVE-35427 follow-up). */
+const MOCK_CARD_BALANCE = 100;
+
+/**
+ * View model for the Pay Card flow. The flow owns the (currently mocked) balance, so hosts no longer
+ * assemble the card visual themselves; they only hand over the two things the flow cannot know — the
+ * countervalue formatter (locale + counter-value currency) and the localized label. Without both, the
+ * card falls back to the bare artwork.
+ */
+export function useCardViewModel({
+  oauthConfig,
+  callback,
+  formatCountervalue,
+  balanceLabel,
+}: CardProps): CardViewProps {
+  const cardVisual = useMemo<CardViewProps["cardVisual"]>(() => {
+    if (!formatCountervalue || balanceLabel === undefined) return undefined;
+    return { balance: MOCK_CARD_BALANCE, formatCountervalue, balanceLabel };
+  }, [formatCountervalue, balanceLabel]);
+
+  return { oauthConfig, callback, cardVisual };
+}

--- a/features/flow/pay-card/tsconfig.json
+++ b/features/flow/pay-card/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "types": ["jest", "node", "@testing-library/jest-dom"]
+  },
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.web.json" },
+    { "path": "./tsconfig.native.json" }
+  ]
+}

--- a/features/flow/pay-card/tsconfig.native.json
+++ b/features/flow/pay-card/tsconfig.native.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleSuffixes": [".native", ""]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "src/**/*.web.*", "src/index.ts"]
+}

--- a/features/flow/pay-card/tsconfig.test.json
+++ b/features/flow/pay-card/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.web.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "src/**/*.native.*"]
+}

--- a/features/flow/pay-card/tsconfig.web.json
+++ b/features/flow/pay-card/tsconfig.web.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleSuffixes": [".web", ""]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "src/**/*.native.*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -961,6 +961,9 @@ importers:
       '@features/flow-large-screen-upsell':
         specifier: workspace:^
         version: link:../../features/flow/large-screen-upsell
+      '@features/flow-pay-card':
+        specifier: workspace:^
+        version: link:../../features/flow/pay-card
       '@features/flow-pay-card-auth':
         specifier: workspace:^
         version: link:../../features/flow/pay-card-auth
@@ -1782,6 +1785,9 @@ importers:
       '@features/flow-lazy-onboarding-banner':
         specifier: workspace:^
         version: link:../../features/flow/lazy-onboarding-banner
+      '@features/flow-pay-card':
+        specifier: workspace:^
+        version: link:../../features/flow/pay-card
       '@features/flow-pay-card-auth':
         specifier: workspace:^
         version: link:../../features/flow/pay-card-auth
@@ -5822,6 +5828,79 @@ importers:
       '@oxlint/binding-win32-x64-msvc':
         specifier: 1.51.0
         version: 1.51.0
+
+  features/flow/pay-card:
+    dependencies:
+      '@features/flow-pay-card-auth':
+        specifier: workspace:^
+        version: link:../pay-card-auth
+      '@features/flow-pay-card-details':
+        specifier: workspace:^
+        version: link:../pay-card-details
+    devDependencies:
+      '@ledgerhq/lumen-ui-react':
+        specifier: 'catalog:'
+        version: 0.1.55(@ledgerhq/lumen-design-core@0.1.26)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@ledgerhq/lumen-ui-rnative':
+        specifier: 'catalog:'
+        version: 0.1.58(@ledgerhq/lumen-design-core@0.1.26)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@support/jest-features-flow':
+        specifier: workspace:*
+        version: link:../../../support/jest-features-flow
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@testing-library/dom':
+        specifier: 'catalog:'
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: 'catalog:'
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.1(@testing-library/dom@10.4.1)(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@testing-library/react-native':
+        specifier: 'catalog:'
+        version: 13.3.3(patch_hash=4f93e75372e62b6dc0f0b2635b62a322b37a3727637bd94a38df1ed8648e2e76)(jest@30.2.0(@types/node@24.12.0))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react-test-renderer@19.1.4(react@19.1.4))(react@19.1.4)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.0.14
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.0.0(@types/react@19.0.14)
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0(@types/node@24.12.0)
+      jest-environment-jsdom:
+        specifier: 'catalog:'
+        version: 30.2.0
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.64.0
+      react:
+        specifier: 19.1.4
+        version: 19.1.4
+      react-dom:
+        specifier: 19.1.4
+        version: 19.1.4(react@19.1.4)
+      react-native:
+        specifier: 'catalog:'
+        version: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
+      react-test-renderer:
+        specifier: 'catalog:'
+        version: 19.1.4(react@19.1.4)
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
 
   features/flow/pay-card-auth:
     dependencies:
@@ -28014,7 +28093,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: '*'
+      rxjs: ^5.5.10
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -32182,7 +32261,7 @@ packages:
   git-raw-commits@2.0.11:
     resolution: {integrity: sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==}
     engines: {node: '>=10'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-up@7.0.0:
@@ -37268,6 +37347,7 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qrcode-terminal@0.11.0:


### PR DESCRIPTION
### 📝 Description

Introduces `@features/flow-pay-card`, a Contacts-style **orchestrator** that aggregates the Pay Card leaf flows behind a single `Card` entry point, so the apps stop wiring the individual leaves (`CardLogin` / `CardLogout`, card visual) by hand.

**Problem**: The Pay Card surface was assembled ad-hoc in each app — desktop mounted `CardLogin` / `CardLogout` and built the card visual in its own view model, mobile did its own wiring. There was no single, shared entry point for the card, and the balance overlay assembly leaked into the hosts.

**Solution**: A new flow package following the app **MVVM** split:

- `Card` (container) wires a shared `useCardViewModel` to the platform `CardView` (`CardView.web.tsx` / `CardView.native.tsx`).
- The flow **owns** the (currently mocked) card balance and assembles the balance overlay itself. Hosts pass only what they alone can know: `formatCountervalue` (needs the app's locale + counter-value currency) and `balanceLabel` (i18n stays with the host). Without them, the card falls back to the bare artwork.
- It composes the card face from `@features/flow-pay-card-details` (`CardVisual` / `CardArtwork`) with `CardLogin` / `CardLogout` from `@features/flow-pay-card-auth`. It **composes rather than re-exports**: apps needing a single leaf or its Redux state keep importing that leaf directly.

Both apps now mount `Card`: desktop in the Pay tab's right panel, mobile in the Pay tab body.

Usage:

```tsx
import { Card } from "@features/flow-pay-card";

<Card
  oauthConfig={oauthConfig}
  callback={callback}
  formatCountervalue={formatCountervalue}
  balanceLabel={balanceLabel}
/>;
```

**Validation**: package typecheck, tests (100% coverage), `lint:structure`, knip, plus desktop RightPanel + PayTab and mobile PayTab integration tests all pass.

### 🔗 Context

- **JIRA issue**: [LIVE-36442](https://ledgerhq.atlassian.net/browse/LIVE-36442) (epic [LIVE-33492](https://ledgerhq.atlassian.net/browse/LIVE-33492))
- Builds on [LIVE-35429](https://ledgerhq.atlassian.net/browse/LIVE-35429) (card key info / card visual)

[LIVE-36442]: https://ledgerhq.atlassian.net/browse/LIVE-36442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ