### PR TITLE
fix(e2e): dismiss analytics drawer in waitForWallet40Ready (QAA-1515)

### DIFF
--- a/e2e/mobile/page/drawer/wallet40Drawers.drawer.ts
+++ b/e2e/mobile/page/drawer/wallet40Drawers.drawer.ts
@@ -5,9 +5,12 @@ import {
   VISIBILITY_PROBE_TIMEOUT,
 } from "../../helpers/elementHelpers";
 
+export const ANALYTICS_CONSENT_DRAWER_ID = "analytics-consent-drawer";
+export const ANALYTICS_CONSENT_REFUSE_ALL_BUTTON_ID = "analytics-consent-drawer-secondary-button";
+
 export default class Wallet40DrawersPage {
-  analyticsConsentDrawerId = "analytics-consent-drawer";
-  analyticsConsentRefuseAllButtonId = "analytics-consent-drawer-secondary-button";
+  analyticsConsentDrawerId = ANALYTICS_CONSENT_DRAWER_ID;
+  analyticsConsentRefuseAllButtonId = ANALYTICS_CONSENT_REFUSE_ALL_BUTTON_ID;
 
   @Step("Close analytics consent drawer if visible")
   async closeAnalyticsConsentDrawerIfVisible(timeout = VISIBILITY_PROBE_TIMEOUT): Promise<boolean> {

--- a/e2e/mobile/page/wallet/mainNavigation.page.ts
+++ b/e2e/mobile/page/wallet/mainNavigation.page.ts
@@ -47,9 +47,11 @@ export default class MainNavigationPage {
   async waitForWallet40Ready(timeout = 60000) {
     await retryUntilTimeout(
       async () => {
-        if (isAndroid() && (await IsIdVisible(ANALYTICS_CONSENT_REFUSE_ALL_BUTTON_ID, 500))) {
-          await tapById(ANALYTICS_CONSENT_REFUSE_ALL_BUTTON_ID);
-          await waitForElementNotVisible(ANALYTICS_CONSENT_DRAWER_ID);
+        if (isAndroid() && (await IsIdVisible(ANALYTICS_CONSENT_DRAWER_ID, 500))) {
+          if (await IsIdVisible(ANALYTICS_CONSENT_REFUSE_ALL_BUTTON_ID, 1000)) {
+            await tapById(ANALYTICS_CONSENT_REFUSE_ALL_BUTTON_ID);
+          }
+          throw new Error("analytics consent drawer still present");
         }
         if (!(await IsIdVisible(this.topBarDiscoverId, 500))) {
           throw new Error(`"${this.topBarDiscoverId}" not visible yet`);

--- a/e2e/mobile/page/wallet/mainNavigation.page.ts
+++ b/e2e/mobile/page/wallet/mainNavigation.page.ts
@@ -1,7 +1,12 @@
 import { element, by } from "detox";
 import { Step } from "jest-allure2-reporter/api";
-import { openDeeplink } from "../../helpers/commonHelpers";
+import { openDeeplink, isAndroid } from "../../helpers/commonHelpers";
+import { retryUntilTimeout } from "../../utils/retry";
 import { isMyWalletEnabled } from "../../utils/initUtil";
+import {
+  ANALYTICS_CONSENT_DRAWER_ID,
+  ANALYTICS_CONSENT_REFUSE_ALL_BUTTON_ID,
+} from "../drawer/wallet40Drawers.drawer";
 
 type Wallet40TabName = "home" | "swap" | "earn" | "card";
 
@@ -40,7 +45,19 @@ export default class MainNavigationPage {
 
   @Step("Wait for Wallet 4.0 navigation to be ready")
   async waitForWallet40Ready(timeout = 60000) {
-    await waitForElementById(this.topBarDiscoverId, timeout);
+    await retryUntilTimeout(
+      async () => {
+        if (isAndroid() && (await IsIdVisible(ANALYTICS_CONSENT_REFUSE_ALL_BUTTON_ID, 500))) {
+          await tapById(ANALYTICS_CONSENT_REFUSE_ALL_BUTTON_ID);
+          await waitForElementNotVisible(ANALYTICS_CONSENT_DRAWER_ID);
+        }
+        if (!(await IsIdVisible(this.topBarDiscoverId, 500))) {
+          throw new Error(`"${this.topBarDiscoverId}" not visible yet`);
+        }
+      },
+      timeout,
+      600,
+    );
   }
 
   @Step("Wait for Legacy navigation to be ready")

--- a/e2e/mobile/specs/marketBanner.spec.ts
+++ b/e2e/mobile/specs/marketBanner.spec.ts
@@ -31,6 +31,7 @@ describe("Market banner", () => {
   });
 
   it(`[${CURRENCY.testLabel}] - Market banner elements, interactions and navigation`, async () => {
+    // NOSONAR typescript:S2699
     await app.portfolio.expectMarketBannerVisible();
 
     await app.portfolio.expectFearAndGreedCardVisible();

--- a/e2e/mobile/specs/marketBanner.spec.ts
+++ b/e2e/mobile/specs/marketBanner.spec.ts
@@ -26,7 +26,6 @@ describe("Market banner", () => {
     await app.init({
       userdata: "1AccountBTC1AccountETHReadOnlyFalse",
     });
-    await app.wallet40Drawers.closeWallet40BlockingDrawersIfVisible(10_000);
     await app.mainNavigation.waitForWallet40Ready();
     await app.wallet40Drawers.closeWallet40BlockingDrawersIfVisible();
   });

--- a/e2e/mobile/specs/marketBanner.spec.ts
+++ b/e2e/mobile/specs/marketBanner.spec.ts
@@ -31,7 +31,6 @@ describe("Market banner", () => {
   });
 
   it(`[${CURRENCY.testLabel}] - Market banner elements, interactions and navigation`, async () => {
-    // NOSONAR typescript:S2699
     await app.portfolio.expectMarketBannerVisible();
 
     await app.portfolio.expectFearAndGreedCardVisible();

--- a/e2e/mobile/specs/wallet40Q2/assetAggregationMarketDetail.spec.ts
+++ b/e2e/mobile/specs/wallet40Q2/assetAggregationMarketDetail.spec.ts
@@ -96,7 +96,6 @@ describe("Asset aggregation", () => {
       userdata: WALLET_40_STABLECOINS_FIXTURE,
       featureFlags: ASSET_AGGREGATION_FEATURE_FLAGS,
     });
-    await app.wallet40Drawers.closeWallet40BlockingDrawersIfVisible(10_000);
     await app.mainNavigation.waitForWallet40Ready();
     await app.wallet40Drawers.closeWallet40BlockingDrawersIfVisible();
   });

--- a/e2e/mobile/specs/wallet40Q2/operationsHistory.spec.ts
+++ b/e2e/mobile/specs/wallet40Q2/operationsHistory.spec.ts
@@ -34,6 +34,7 @@ describe("Operations history", () => {
   });
 
   it("Open transaction history from the top bar", async () => {
+    // NOSONAR typescript:S2699
     await app.mainNavigation.tapTopBarTransactionHistory();
     await app.operation.expectOperationsListVisible();
     await app.operation.expectSectionHeaderVisible();
@@ -41,6 +42,7 @@ describe("Operations history", () => {
   });
 
   it("Navigate to operation details from a transaction row", async () => {
+    // NOSONAR typescript:S2699
     await app.mainNavigation.openPortfolioViaDeeplink();
     await app.mainNavigation.tapTopBarTransactionHistory();
     await app.operation.expectOperationsListVisible();
@@ -49,6 +51,7 @@ describe("Operations history", () => {
   });
 
   it("Open transaction history from an asset page", async () => {
+    // NOSONAR typescript:S2699
     await app.mainNavigation.openPortfolioViaDeeplink();
     await app.portfolio.goToAccounts(CURRENCY.name);
     await app.common.pressOnSeeAllOperationsButtonFromAssetPage();

--- a/e2e/mobile/specs/wallet40Q2/operationsHistory.spec.ts
+++ b/e2e/mobile/specs/wallet40Q2/operationsHistory.spec.ts
@@ -34,7 +34,6 @@ describe("Operations history", () => {
   });
 
   it("Open transaction history from the top bar", async () => {
-    // NOSONAR typescript:S2699
     await app.mainNavigation.tapTopBarTransactionHistory();
     await app.operation.expectOperationsListVisible();
     await app.operation.expectSectionHeaderVisible();
@@ -42,7 +41,6 @@ describe("Operations history", () => {
   });
 
   it("Navigate to operation details from a transaction row", async () => {
-    // NOSONAR typescript:S2699
     await app.mainNavigation.openPortfolioViaDeeplink();
     await app.mainNavigation.tapTopBarTransactionHistory();
     await app.operation.expectOperationsListVisible();
@@ -51,7 +49,6 @@ describe("Operations history", () => {
   });
 
   it("Open transaction history from an asset page", async () => {
-    // NOSONAR typescript:S2699
     await app.mainNavigation.openPortfolioViaDeeplink();
     await app.portfolio.goToAccounts(CURRENCY.name);
     await app.common.pressOnSeeAllOperationsButtonFromAssetPage();

--- a/e2e/mobile/specs/wallet40Q2/operationsHistory.spec.ts
+++ b/e2e/mobile/specs/wallet40Q2/operationsHistory.spec.ts
@@ -29,7 +29,6 @@ describe("Operations history", () => {
       userdata: "speculos-x-other-account",
       featureFlags: FF_OPERATION_HISTORY,
     });
-    await app.wallet40Drawers.closeWallet40BlockingDrawersIfVisible(10_000);
     await app.mainNavigation.waitForWallet40Ready();
     await app.wallet40Drawers.closeWallet40BlockingDrawersIfVisible();
   });

--- a/e2e/mobile/specs/wallet40Q2/walletAssets.spec.ts
+++ b/e2e/mobile/specs/wallet40Q2/walletAssets.spec.ts
@@ -34,7 +34,6 @@ describe("Wallet assets", () => {
   TAGS.forEach(tag => $Tag(tag));
 
   it(`[${currency.testLabel}] - Wallet assets empty state shows placeholders and add account CTA`, async () => {
-    // NOSONAR typescript:S2699
     await app.portfolio.checkCryptosListSectionVisible(4, true);
     await app.portfolio.checkStablecoinsListSectionVisible(2, true);
     await app.portfolio.checkTotalAssetItemCount(6);
@@ -42,7 +41,6 @@ describe("Wallet assets", () => {
   });
 
   it(`[${currency.testLabel}] - Selecting an asset redirects to its market page`, async () => {
-    // NOSONAR typescript:S2699
     await app.portfolio.tapFirstAssetItemW40();
     await app.market.expectAssetPageVisible();
     await app.market.leaveAssetPage();
@@ -67,7 +65,6 @@ describe("Wallet assets", () => {
   TAGS.forEach(tag => $Tag(tag));
 
   it(`[${Currency.BTC.testLabel}] - Wallet assets section with fewer than 6 cryptos and stablecoins`, async () => {
-    // NOSONAR typescript:S2699
     await app.portfolio.checkCryptosListSectionVisible(4);
     await app.portfolio.checkStablecoinsListSectionVisible(2);
     await app.portfolio.checkTotalAssetItemCount(6);
@@ -92,7 +89,6 @@ describe("Wallet assets", () => {
   TAGS.forEach(tag => $Tag(tag));
 
   it("Wallet assets section caps cryptos at 6", async () => {
-    // NOSONAR typescript:S2699
     await app.portfolio.checkCryptosListSectionVisible(6);
     await app.portfolio.checkCryptosSectionAssetItemCount(6);
     await app.portfolio.checkAssetVisible("Ethereum");
@@ -104,7 +100,6 @@ describe("Wallet assets", () => {
   });
 
   it("Wallet assets section caps stablecoins at 6", async () => {
-    // NOSONAR typescript:S2699
     await app.portfolio.checkStablecoinsListSectionVisible(6);
     await app.portfolio.checkStablecoinsSectionAssetItemCount(6);
     await app.portfolio.checkAssetVisible("Tether USD");

--- a/e2e/mobile/specs/wallet40Q2/walletAssets.spec.ts
+++ b/e2e/mobile/specs/wallet40Q2/walletAssets.spec.ts
@@ -34,6 +34,7 @@ describe("Wallet assets", () => {
   TAGS.forEach(tag => $Tag(tag));
 
   it(`[${currency.testLabel}] - Wallet assets empty state shows placeholders and add account CTA`, async () => {
+    // NOSONAR typescript:S2699
     await app.portfolio.checkCryptosListSectionVisible(4, true);
     await app.portfolio.checkStablecoinsListSectionVisible(2, true);
     await app.portfolio.checkTotalAssetItemCount(6);
@@ -41,6 +42,7 @@ describe("Wallet assets", () => {
   });
 
   it(`[${currency.testLabel}] - Selecting an asset redirects to its market page`, async () => {
+    // NOSONAR typescript:S2699
     await app.portfolio.tapFirstAssetItemW40();
     await app.market.expectAssetPageVisible();
     await app.market.leaveAssetPage();
@@ -65,6 +67,7 @@ describe("Wallet assets", () => {
   TAGS.forEach(tag => $Tag(tag));
 
   it(`[${Currency.BTC.testLabel}] - Wallet assets section with fewer than 6 cryptos and stablecoins`, async () => {
+    // NOSONAR typescript:S2699
     await app.portfolio.checkCryptosListSectionVisible(4);
     await app.portfolio.checkStablecoinsListSectionVisible(2);
     await app.portfolio.checkTotalAssetItemCount(6);
@@ -89,6 +92,7 @@ describe("Wallet assets", () => {
   TAGS.forEach(tag => $Tag(tag));
 
   it("Wallet assets section caps cryptos at 6", async () => {
+    // NOSONAR typescript:S2699
     await app.portfolio.checkCryptosListSectionVisible(6);
     await app.portfolio.checkCryptosSectionAssetItemCount(6);
     await app.portfolio.checkAssetVisible("Ethereum");
@@ -100,6 +104,7 @@ describe("Wallet assets", () => {
   });
 
   it("Wallet assets section caps stablecoins at 6", async () => {
+    // NOSONAR typescript:S2699
     await app.portfolio.checkStablecoinsListSectionVisible(6);
     await app.portfolio.checkStablecoinsSectionAssetItemCount(6);
     await app.portfolio.checkAssetVisible("Tether USD");

--- a/e2e/mobile/specs/wallet40Q2/walletAssets.spec.ts
+++ b/e2e/mobile/specs/wallet40Q2/walletAssets.spec.ts
@@ -26,7 +26,6 @@ describe("Wallet assets", () => {
       speculosApp: currency.speculosApp,
       featureFlags: FF_WALLET_ASSETS,
     });
-    await app.wallet40Drawers.closeWallet40BlockingDrawersIfVisible(10_000);
     await app.mainNavigation.waitForWallet40Ready();
     await app.wallet40Drawers.closeWallet40BlockingDrawersIfVisible();
   });
@@ -58,7 +57,6 @@ describe("Wallet assets", () => {
       userdata: "wallet40-btc-only",
       featureFlags: FF_WALLET_ASSETS,
     });
-    await app.wallet40Drawers.closeWallet40BlockingDrawersIfVisible(10_000);
     await app.mainNavigation.waitForWallet40Ready();
     await app.wallet40Drawers.closeWallet40BlockingDrawersIfVisible();
   });
@@ -83,7 +81,6 @@ describe("Wallet assets", () => {
       userdata: "wallet40-many-stablecoins",
       featureFlags: FF_WALLET_ASSETS,
     });
-    await app.wallet40Drawers.closeWallet40BlockingDrawersIfVisible(10_000);
     await app.mainNavigation.waitForWallet40Ready();
     await app.wallet40Drawers.closeWallet40BlockingDrawersIfVisible();
   });


### PR DESCRIPTION
### 📝 Description

On Android, the analytics consent drawer can appear at any point during a cold app start and occlude the `topbar-discover` button in the fixed top bar. Detox's `toBeVisible()` on Android requires ≥ 75% of the element area to be inside `getGlobalVisibleRect()`; the drawer alone is enough to drop `topbar-discover` below this threshold and cause the 60 s timeout in `waitForWallet40Ready` to fire. On retry the drawer is already dismissed, so the element passes. This explains the 5 nightly wallet40Q2 failures that always recovered on first retry.

**Fix**: rewrote `waitForWallet40Ready` to poll concurrently instead of sequentially. On each 600 ms tick it checks for the analytics consent drawer and dismisses it before asserting `topbar-discover` visibility. This eliminates the race entirely — no matter when the drawer appears during startup, the next poll iteration dismisses it and succeeds. The pre-`waitForWallet40Ready` `closeWallet40BlockingDrawersIfVisible(10_000)` calls in the affected spec `beforeAll` hooks were redundant (couldn't win the race) and are removed.

Exported the drawer element IDs as named constants from `wallet40Drawers.drawer.ts` so they are the single source of truth for both the page object and the navigation page.

Verified locally: `mainNavigation.spec.ts` — 9/9 tests passed on first run (Android cold start), typecheck clean.

### 🔗 Context

- **JIRA issue**: [QAA-1515](https://ledgerhq.atlassian.net/browse/QAA-1515)


[QAA-1515]: https://ledgerhq.atlassian.net/browse/QAA-1515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ