### PR TITLE
[LWDM] feat(hedera): framework signer

### DIFF
--- a/.changeset/orange-impalas-grin.md
+++ b/.changeset/orange-impalas-grin.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-hedera": minor
+"@ledgerhq/live-common": minor
+---
+
+feat: hedera framework signer

--- a/libs/coin-modules/coin-hedera/src/signer/frameworkSigner.test.ts
+++ b/libs/coin-modules/coin-hedera/src/signer/frameworkSigner.test.ts
@@ -1,0 +1,102 @@
+import { PrivateKey } from "@hashgraph/sdk";
+import type { TransactionIntent } from "@ledgerhq/coin-module-framework/api/index";
+import { HEDERA_TRANSACTION_MODES, TINYBAR_SCALE } from "../constants";
+import { combine } from "../logic/combine";
+import { craftTransaction } from "../logic/craftTransaction";
+import {
+  deserializeTransaction,
+  getHederaTransactionBodyBytes,
+  serializeSignature,
+  serializeTransaction,
+} from "../logic/utils";
+import { getMockedConfig } from "../test/fixtures/config.fixture";
+import type { HederaMemo, HederaSigner } from "../types";
+import { createFrameworkSigner } from "./frameworkSigner";
+
+jest.mock("../network/rpc", () => ({
+  rpcClient: require("../test/fixtures/rpc.fixture").getMockedRpcClient(),
+}));
+
+const PATH = "44'/3030'/0'/0'/0'";
+
+const makeIntent = (): TransactionIntent<HederaMemo> => ({
+  intentType: "transaction",
+  type: HEDERA_TRANSACTION_MODES.Send,
+  amount: BigInt(1 * 10 ** TINYBAR_SCALE),
+  recipient: "0.0.12345",
+  sender: "0.0.54321",
+  asset: { type: "native" },
+  memo: { kind: "text", type: "string", value: "Hbar transfer" },
+});
+
+const makeSigner = (overrides: Partial<HederaSigner> = {}): HederaSigner => ({
+  getPublicKey: jest.fn().mockResolvedValue("aabbcc"),
+  signTransaction: jest.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
+  ...overrides,
+});
+
+describe("createFrameworkSigner.getAddress", () => {
+  it("returns the device public key as both address and publicKey", async () => {
+    const device = makeSigner({ getPublicKey: jest.fn().mockResolvedValue("abcd1234") });
+    const framework = createFrameworkSigner(device);
+
+    const result = await framework.getAddress(PATH);
+
+    expect(device.getPublicKey).toHaveBeenCalledTimes(1);
+    expect(device.getPublicKey).toHaveBeenCalledWith(PATH);
+    expect(result).toEqual({ path: PATH, address: "abcd1234", publicKey: "abcd1234" });
+  });
+});
+
+describe("createFrameworkSigner.signTransaction", () => {
+  it("signs the transaction body bytes, not the envelope, dropping path and options", async () => {
+    const { serializedTx } = await craftTransaction({
+      configOrCurrencyId: getMockedConfig(),
+      txIntent: makeIntent(),
+    });
+    const expectedBodyBytes = getHederaTransactionBodyBytes(deserializeTransaction(serializedTx));
+    const signature = new Uint8Array([9, 9, 9]);
+    const device = makeSigner({ signTransaction: jest.fn().mockResolvedValue(signature) });
+    const framework = createFrameworkSigner(device);
+
+    const result = await framework.signTransaction(PATH, serializedTx);
+
+    expect(device.signTransaction).toHaveBeenCalledTimes(1);
+    expect(device.signTransaction).toHaveBeenCalledWith(expectedBodyBytes);
+    expect(result).toBe(serializeSignature(signature));
+  });
+});
+
+describe("createFrameworkSigner byte-identical parity with the legacy bridge", () => {
+  it("produces the same combined transaction as the legacy signOperation path", async () => {
+    // Craft exactly once: TransactionId.generate uses Timestamp.generate(hasJitter = true),
+    // so crafting twice would never yield byte-identical transactions to compare.
+    const { tx, serializedTx } = await craftTransaction({
+      configOrCurrencyId: getMockedConfig(),
+      txIntent: makeIntent(),
+    });
+
+    const publicKey = PrivateKey.generateED25519().publicKey.toStringRaw();
+    const signatureBytes = new Uint8Array(64).fill(7);
+    const device: HederaSigner = {
+      getPublicKey: jest.fn().mockResolvedValue(publicKey),
+      signTransaction: jest.fn().mockResolvedValue(signatureBytes),
+    };
+    const framework = createFrameworkSigner(device);
+
+    const legacy = combine(
+      serializeTransaction(tx),
+      [serializeSignature(await device.signTransaction(getHederaTransactionBodyBytes(tx)))],
+      publicKey,
+    );
+
+    const { publicKey: frameworkPublicKey } = await framework.getAddress(PATH);
+    const generic = combine(
+      serializedTx,
+      [await framework.signTransaction(PATH, serializedTx)],
+      frameworkPublicKey,
+    );
+
+    expect(generic).toBe(legacy);
+  });
+});

--- a/libs/coin-modules/coin-hedera/src/signer/frameworkSigner.ts
+++ b/libs/coin-modules/coin-hedera/src/signer/frameworkSigner.ts
@@ -1,0 +1,29 @@
+import {
+  deserializeTransaction,
+  getHederaTransactionBodyBytes,
+  serializeSignature,
+} from "../logic/utils";
+import type { HederaSigner } from "../types";
+
+export type HederaFrameworkSigner = {
+  getAddress(path: string): Promise<{ path: string; address: string; publicKey: string }>;
+  signTransaction(path: string, unsignedTxHex: string): Promise<string>;
+};
+
+/** Adapts the device-level {@link HederaSigner} to the generic framework. */
+export function createFrameworkSigner(signer: HederaSigner): HederaFrameworkSigner {
+  return {
+    async getAddress(path) {
+      const publicKey = await signer.getPublicKey(path);
+      // Hedera has no derivable address; the 0.0.x id comes from the discovery scan.
+      return { path, address: publicKey, publicKey };
+    },
+    // The framework passes a path and an options object; hw-app-hedera takes neither and signs
+    // from account index 0 only (device-app limit), so both are dropped — as in the legacy bridge.
+    async signTransaction(_path, unsignedTxHex) {
+      const tx = deserializeTransaction(unsignedTxHex);
+      const signature = await signer.signTransaction(getHederaTransactionBodyBytes(tx));
+      return serializeSignature(signature);
+    },
+  };
+}

--- a/libs/coin-modules/coin-hedera/src/signer/index.ts
+++ b/libs/coin-modules/coin-hedera/src/signer/index.ts
@@ -1,3 +1,4 @@
 import resolver from "./getAddress";
 
 export default resolver;
+export { createFrameworkSigner, type HederaFrameworkSigner } from "./frameworkSigner";

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -129,6 +129,7 @@
     "src/families/filecoin/deviceTransactionConfig.ts",
     "src/families/filecoin/types.ts",
     "src/families/hedera/types.ts",
+    "src/families/hedera/signer.ts",
     "src/families/internet_computer/react.ts",
     "src/families/internet_computer/types.ts",
     "src/families/mina/types.ts",

--- a/libs/ledger-live-common/src/coin-modules/loaders.ts
+++ b/libs/ledger-live-common/src/coin-modules/loaders.ts
@@ -239,6 +239,7 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
     loadTransaction: () => import("@ledgerhq/coin-hedera/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-hedera/deviceTransactionConfig").then(m => m.default),
+    loadSigner: () => import("../families/hedera/signer").then(m => m.default),
   },
   {
     // HyperCore (generic framework): eth-format address, no send. setup/signer only derive the

--- a/libs/ledger-live-common/src/families/hedera/signer.test.ts
+++ b/libs/ledger-live-common/src/families/hedera/signer.test.ts
@@ -1,0 +1,63 @@
+import Hedera from "@ledgerhq/hw-app-hedera";
+import Transport from "@ledgerhq/hw-transport";
+import type { GetAddressOptions } from "@ledgerhq/ledger-wallet-framework/derivation";
+import { getSigner } from "../../bridge/generic-coin-framework/signer";
+import { coinModuleLoaders } from "../../coin-modules/loaders";
+import hederaSigner, { createSigner, hederaGetAddress } from "./signer";
+
+jest.mock("@ledgerhq/hw-app-hedera");
+
+const MockedHedera = Hedera as jest.MockedClass<typeof Hedera>;
+const mockTransport = {} as Transport;
+
+describe("createSigner (Hedera)", () => {
+  let getPublicKey: jest.Mock;
+  let signTransaction: jest.Mock;
+
+  beforeEach(() => {
+    getPublicKey = jest.fn().mockResolvedValue("aabbcc");
+    signTransaction = jest.fn();
+    MockedHedera.mockImplementation(() => ({ getPublicKey, signTransaction }) as unknown as Hedera);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("wires the transport through to hw-app-hedera", () => {
+    createSigner(mockTransport);
+
+    expect(MockedHedera).toHaveBeenCalledTimes(1);
+    expect(MockedHedera).toHaveBeenCalledWith(mockTransport);
+  });
+
+  it("getAddress resolves through the signer context", async () => {
+    const signer = createSigner(mockTransport);
+    const context = <U>(_deviceId: string, fn: (s: ReturnType<typeof createSigner>) => U) =>
+      Promise.resolve(fn(signer));
+
+    const result = await hederaGetAddress(context)("deviceId", {
+      path: "44'/3030'/0'/0'/0'",
+    } as GetAddressOptions);
+
+    expect(getPublicKey).toHaveBeenCalledTimes(1);
+    expect(getPublicKey).toHaveBeenCalledWith("44'/3030'/0'/0'/0'");
+    expect(result).toEqual({
+      path: "44'/3030'/0'/0'/0'",
+      address: "aabbcc",
+      publicKey: "aabbcc",
+    });
+  });
+});
+
+describe("hedera signer registration", () => {
+  it("registers a loadSigner on the hedera coin-module loader", () => {
+    const loader = coinModuleLoaders.find(l => l.family === "hedera");
+
+    expect(loader?.loadSigner).toBeDefined();
+  });
+
+  it("resolves through getSigner so the generic coin framework can reach it", async () => {
+    await expect(getSigner("hedera")).resolves.toBe(hederaSigner);
+  });
+});

--- a/libs/ledger-live-common/src/families/hedera/signer.ts
+++ b/libs/ledger-live-common/src/families/hedera/signer.ts
@@ -1,0 +1,22 @@
+import type Transport from "@ledgerhq/hw-transport";
+import Hedera from "@ledgerhq/hw-app-hedera";
+import { createFrameworkSigner, type HederaFrameworkSigner } from "@ledgerhq/coin-hedera/signer";
+import type { GetAddressFn } from "@ledgerhq/ledger-wallet-framework/bridge/getAddressWrapper";
+import type { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
+import type { CoinFrameworkSigner } from "../../bridge/generic-coin-framework/types";
+import { executeWithSigner, type CreateSigner } from "../../bridge/setup";
+
+export const createSigner: CreateSigner<HederaFrameworkSigner> = (transport: Transport) =>
+  createFrameworkSigner(new Hedera(transport));
+
+export const hederaGetAddress =
+  (ctx: SignerContext<HederaFrameworkSigner>): GetAddressFn =>
+  (deviceId, { path }) =>
+    ctx(deviceId, signer => signer.getAddress(path));
+
+const context = executeWithSigner(createSigner);
+
+export default {
+  context,
+  getAddress: hederaGetAddress(context),
+} satisfies CoinFrameworkSigner;


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR adds `createFrameworkSigner` in `@ledgerhq/coin-hedera`. It adapts the device-level `HederaSigner` (getPublicKey/signTransaction) to the generic coin-framework's `getAddress`/`signTransaction(path, unsignedTxHex)` shape.

`hedera` is not yet in `genericCoinFrameworkFamilies.json`, so this only exposes the signer for framework consumers (e.g. `getSigner("hedera")`) - the legacy bridge's `signOperation` is untouched and still owns the live send path. Path and options are intentionally dropped in `signTransaction`: the Hedera BOLOS app only supports signing from account index 0 and has no display/verify flag, matching the legacy bridge's behavior.

### 🔗 Context

- https://ledgerhq.atlassian.net/browse/LIVE-36144