### PR TITLE
fix(lwd): add missing touchscreen upsell placement tracking

### DIFF
--- a/.changeset/lwd-upsell-placement-tracking.md
+++ b/.changeset/lwd-upsell-placement-tracking.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add missing tracking for touchscreen upsell placements on desktop (LIVE-36428)

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/ContentCardsCategory.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/ContentCardsCategory.test.tsx
@@ -5,7 +5,7 @@ import { logCardDismissal, logContentCardClick, ClassicCard } from "@braze/web-s
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { LARGE_SCREEN_UPSELL_UTM } from "@features/flow-large-screen-upsell";
 import { fireEvent, render, screen } from "tests/testSetup";
-import { track } from "~/renderer/analytics/segment";
+import { track, trackPage } from "~/renderer/analytics/segment";
 import { ContentCardEvent } from "@ledgerhq/live-common/braze/contentCardExtras";
 import { openURL } from "~/renderer/linking";
 import {
@@ -40,6 +40,7 @@ jest.mock("@braze/web-sdk", () => {
 jest.mock("~/renderer/analytics/segment", () => ({
   ...jest.requireActual("~/renderer/analytics/segment"),
   track: jest.fn(),
+  trackPage: jest.fn(),
 }));
 
 jest.mock("~/renderer/linking", () => ({
@@ -105,7 +106,10 @@ const hardwareCarouselState = {
     localCategoriesCards: [CATEGORY],
     localCategoryChildCards: CHILD_CARDS,
   },
-  settings: trackedUserSettings,
+  settings: {
+    ...trackedUserSettings,
+    devicesModelList: [DeviceModelId.nanoX],
+  },
 };
 
 beforeEach(() => {
@@ -230,6 +234,66 @@ describe("ContentCardsLocation", () => {
     );
   });
 
+  test("tracks hardware carousel page impression when the category is shown", async () => {
+    render(<ContentCardsLocation locationId={LocationContentCard.Portfolio} />, {
+      initialState: hardwareCarouselState,
+    });
+
+    await screen.findByText("Discover our devices");
+
+    expect(trackPage).toHaveBeenCalledWith(
+      "carousel hardware",
+      undefined,
+      {
+        name: "carousel hardware",
+        deviceModel: "lnx",
+        personalRecoOptIn: true,
+        offerType: "discount",
+        platform: "lwd",
+      },
+      true,
+      false,
+    );
+  });
+
+  test("tracks hardware carousel device click when a device card is clicked", async () => {
+    render(<ContentCardsLocation locationId={LocationContentCard.Portfolio} />, {
+      initialState: hardwareCarouselState,
+    });
+
+    fireEvent.click(await screen.findByText("Ledger Flex™"));
+
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({
+        button: "ledger flex",
+        page: "carousel hardware",
+        deviceModel: "lnx",
+        platform: "lwd",
+      }),
+    );
+  });
+
+  test("tracks hardware carousel card dismiss when a child card is dismissed", async () => {
+    const { user } = render(<ContentCardsLocation locationId={LocationContentCard.Portfolio} />, {
+      initialState: hardwareCarouselState,
+    });
+
+    await screen.findByText("Nano Pod");
+    const closeButtons = screen.getAllByTestId("small-square-card-close");
+    await user.click(closeButtons[0]);
+
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({
+        button: "close",
+        page: "carousel hardware",
+        deviceModel: "lnx",
+        platform: "lwd",
+      }),
+    );
+  });
+
   test("renders the close all link for dismissable hardware carousel categories", async () => {
     render(<ContentCardsLocation locationId={LocationContentCard.Portfolio} />, {
       initialState: hardwareCarouselState,
@@ -263,11 +327,11 @@ describe("ContentCardsLocation", () => {
       "button_clicked",
       expect.objectContaining({
         button: "close all",
-        page: "hardware carousel",
+        page: "carousel hardware",
         deviceModel: "lnx",
         personalRecoOptIn: true,
         offerType: "discount",
-        platform: "lld",
+        platform: "lwd",
       }),
     );
     expect(track).not.toHaveBeenCalledWith(ContentCardEvent.Dismissed, expect.anything());

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/ContentCardsCategory.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/ContentCardsCategory.test.tsx
@@ -274,6 +274,24 @@ describe("ContentCardsLocation", () => {
     );
   });
 
+  test("tracks Gen5 device click for Nano Pod carousel titles", async () => {
+    render(<ContentCardsLocation locationId={LocationContentCard.Portfolio} />, {
+      initialState: hardwareCarouselState,
+    });
+
+    fireEvent.click(await screen.findByText("Nano Pod"));
+
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({
+        button: "ledger gen5",
+        page: "carousel hardware",
+        deviceModel: "lnx",
+        platform: "lwd",
+      }),
+    );
+  });
+
   test("tracks hardware carousel card dismiss when a child card is dismissed", async () => {
     const { user } = render(<ContentCardsLocation locationId={LocationContentCard.Portfolio} />, {
       initialState: hardwareCarouselState,

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/index.tsx
@@ -2,6 +2,8 @@ import React, { useCallback } from "react";
 import type { Card as BrazeCard } from "@braze/web-sdk";
 import type { CategoryContentCard } from "~/types/dynamicContent";
 import LogContentCardWrapper from "../LogContentCardWrapper";
+import { shouldShowHardwareCarouselCloseAll } from "../../hardwareCarousel/shouldShowHardwareCarouselCloseAll";
+import { useHardwareCarouselPageTracking } from "../../hardwareCarousel/useHardwareCarouselPageTracking";
 import Header from "./Header";
 import Layout from "./Layout";
 import {
@@ -22,6 +24,9 @@ function ContentCardsCategory({
   categoryContentCards,
   leadingSlide,
 }: ContentCardsCategoryProps) {
+  const isHardwareCarousel = shouldShowHardwareCarouselCloseAll(category);
+  const hardwareCarouselSharedProps = useHardwareCarouselPageTracking(isHardwareCarousel);
+
   const {
     title,
     cta,
@@ -37,6 +42,7 @@ function ContentCardsCategory({
     category,
     categoryContentCards,
     leadingSlide,
+    hardwareCarouselSharedProps: isHardwareCarousel ? hardwareCarouselSharedProps : undefined,
   });
 
   const handleCardClick = useCallback(

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/useContentCardsCategoryViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/useContentCardsCategoryViewModel.ts
@@ -20,9 +20,9 @@ import { useDynamicContent } from "../../hooks/useDynamicContent";
 import {
   trackHardwareCarouselCardDismiss,
   trackHardwareCarouselDeviceClick,
-  type HardwareCarouselDevice,
   type HardwareCarouselSharedAnalyticsProps,
 } from "../../hardwareCarousel/analytics";
+import { extractHardwareCarouselDevice } from "../../hardwareCarousel/extractHardwareCarouselDevice";
 import { shouldShowHardwareCarouselCloseAll } from "../../hardwareCarousel/shouldShowHardwareCarouselCloseAll";
 import { getRenderableSmallSquareSlides } from "../../utils/getRenderableSmallSquareSlides";
 import type { SmallSquareContentCard } from "../../utils/mapSmallSquareContentCard";
@@ -59,25 +59,6 @@ function resolveHardwareCarouselCardLink(link: string): string {
     "desktop",
     LARGE_SCREEN_UPSELL_UTM.content.hardware_carousel,
   );
-}
-
-function extractDeviceType(title?: string): HardwareCarouselDevice | null {
-  if (!title) {
-    return null;
-  }
-
-  const titleLower = title.toLowerCase();
-  if (titleLower.includes("gen5") || titleLower.includes("gen 5")) {
-    return "ledger gen5";
-  }
-  if (titleLower.includes("flex")) {
-    return "ledger flex";
-  }
-  if (titleLower.includes("stax")) {
-    return "ledger stax";
-  }
-
-  return null;
 }
 
 export type MappedCategorySlide = {
@@ -174,7 +155,7 @@ export function useContentCardsCategoryViewModel({
       }
 
       if (hardwareCarouselSharedProps) {
-        const deviceType = extractDeviceType(card.title);
+        const deviceType = extractHardwareCarouselDevice(card.title);
         if (deviceType) {
           trackHardwareCarouselDeviceClick(deviceType, hardwareCarouselSharedProps);
         }

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/useContentCardsCategoryViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/ContentCardsCategory/useContentCardsCategoryViewModel.ts
@@ -17,6 +17,12 @@ import { openURL } from "~/renderer/linking";
 import type { CategoryContentCard } from "~/types/dynamicContent";
 import { LocationContentCard } from "~/types/dynamicContent";
 import { useDynamicContent } from "../../hooks/useDynamicContent";
+import {
+  trackHardwareCarouselCardDismiss,
+  trackHardwareCarouselDeviceClick,
+  type HardwareCarouselDevice,
+  type HardwareCarouselSharedAnalyticsProps,
+} from "../../hardwareCarousel/analytics";
 import { shouldShowHardwareCarouselCloseAll } from "../../hardwareCarousel/shouldShowHardwareCarouselCloseAll";
 import { getRenderableSmallSquareSlides } from "../../utils/getRenderableSmallSquareSlides";
 import type { SmallSquareContentCard } from "../../utils/mapSmallSquareContentCard";
@@ -55,6 +61,25 @@ function resolveHardwareCarouselCardLink(link: string): string {
   );
 }
 
+function extractDeviceType(title?: string): HardwareCarouselDevice | null {
+  if (!title) {
+    return null;
+  }
+
+  const titleLower = title.toLowerCase();
+  if (titleLower.includes("gen5") || titleLower.includes("gen 5")) {
+    return "ledger gen5";
+  }
+  if (titleLower.includes("flex")) {
+    return "ledger flex";
+  }
+  if (titleLower.includes("stax")) {
+    return "ledger stax";
+  }
+
+  return null;
+}
+
 export type MappedCategorySlide = {
   card: SmallSquareContentCard;
   displayedPosition: number;
@@ -64,6 +89,7 @@ export type UseContentCardsCategoryViewModelArgs = Readonly<{
   category: CategoryContentCard;
   categoryContentCards: BrazeCard[];
   leadingSlide?: React.ReactNode;
+  hardwareCarouselSharedProps?: HardwareCarouselSharedAnalyticsProps;
 }>;
 
 export type UseContentCardsCategoryViewModelResult = Readonly<{
@@ -84,6 +110,7 @@ export function useContentCardsCategoryViewModel({
   category,
   categoryContentCards,
   leadingSlide,
+  hardwareCarouselSharedProps,
 }: UseContentCardsCategoryViewModelArgs): UseContentCardsCategoryViewModelResult {
   const navigate = useNavigate();
   const { dismissCard, logClickCard, trackContentCardEvent } = useDynamicContent();
@@ -145,6 +172,14 @@ export function useContentCardsCategoryViewModel({
       if (!card.link) {
         return;
       }
+
+      if (hardwareCarouselSharedProps) {
+        const deviceType = extractDeviceType(card.title);
+        if (deviceType) {
+          trackHardwareCarouselDeviceClick(deviceType, hardwareCarouselSharedProps);
+        }
+      }
+
       trackCategoryEvent(ContentCardEvent.Clicked, card, displayedPosition);
       logClickCard(card.id);
       openContentCardLink(
@@ -154,16 +189,20 @@ export function useContentCardsCategoryViewModel({
         navigate,
       );
     },
-    [category, logClickCard, navigate, trackCategoryEvent],
+    [category, hardwareCarouselSharedProps, logClickCard, navigate, trackCategoryEvent],
   );
 
   const onCardDismiss = useCallback(
     (card: SmallSquareContentCard, displayedPosition: number) => {
       if (dismissCard(card.id)) {
+        if (hardwareCarouselSharedProps) {
+          trackHardwareCarouselCardDismiss(hardwareCarouselSharedProps);
+        }
+
         trackCategoryEvent(ContentCardEvent.Dismissed, card, displayedPosition);
       }
     },
-    [dismissCard, trackCategoryEvent],
+    [dismissCard, hardwareCarouselSharedProps, trackCategoryEvent],
   );
 
   return {

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/analytics.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/analytics.test.ts
@@ -1,0 +1,101 @@
+import { track, trackPage } from "~/renderer/analytics/segment";
+import {
+  HARDWARE_CAROUSEL_PAGE,
+  trackHardwareCarouselShown,
+  trackHardwareCarouselDeviceClick,
+  trackHardwareCarouselCardDismiss,
+  trackHardwareCarouselCloseAll,
+  type HardwareCarouselSharedAnalyticsProps,
+} from "./analytics";
+
+jest.mock("~/renderer/analytics/segment", () => ({
+  ...jest.requireActual("~/renderer/analytics/segment"),
+  track: jest.fn(),
+  trackPage: jest.fn(),
+}));
+
+const mockSharedProps: HardwareCarouselSharedAnalyticsProps = {
+  deviceModel: "lnx",
+  personalRecoOptIn: true,
+  offerType: "discount",
+  platform: "lwd",
+};
+
+describe("hardware carousel analytics", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("trackHardwareCarouselShown", () => {
+    it("should call trackPage with correct page name and props", () => {
+      trackHardwareCarouselShown(mockSharedProps);
+
+      expect(trackPage).toHaveBeenCalledWith(
+        HARDWARE_CAROUSEL_PAGE,
+        undefined,
+        {
+          name: HARDWARE_CAROUSEL_PAGE,
+          ...mockSharedProps,
+        },
+        true,
+        false,
+      );
+    });
+  });
+
+  describe("trackHardwareCarouselDeviceClick", () => {
+    it("should track Gen5 device click", () => {
+      trackHardwareCarouselDeviceClick("ledger gen5", mockSharedProps);
+
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "ledger gen5",
+        page: HARDWARE_CAROUSEL_PAGE,
+        ...mockSharedProps,
+      });
+    });
+
+    it("should track Flex device click", () => {
+      trackHardwareCarouselDeviceClick("ledger flex", mockSharedProps);
+
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "ledger flex",
+        page: HARDWARE_CAROUSEL_PAGE,
+        ...mockSharedProps,
+      });
+    });
+
+    it("should track Stax device click", () => {
+      trackHardwareCarouselDeviceClick("ledger stax", mockSharedProps);
+
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "ledger stax",
+        page: HARDWARE_CAROUSEL_PAGE,
+        ...mockSharedProps,
+      });
+    });
+  });
+
+  describe("trackHardwareCarouselCardDismiss", () => {
+    it("should track close button click", () => {
+      trackHardwareCarouselCardDismiss(mockSharedProps);
+
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "close",
+        page: HARDWARE_CAROUSEL_PAGE,
+        ...mockSharedProps,
+      });
+    });
+  });
+
+  describe("trackHardwareCarouselCloseAll", () => {
+    it("should track close all button click", () => {
+      trackHardwareCarouselCloseAll(mockSharedProps);
+
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "close all",
+        page: HARDWARE_CAROUSEL_PAGE,
+        ...mockSharedProps,
+      });
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/analytics.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/analytics.ts
@@ -13,16 +13,35 @@ export type HardwareCarouselSharedAnalyticsProps = Readonly<{
 
 export type HardwareCarouselDevice = "ledger gen5" | "ledger flex" | "ledger stax";
 
+type HardwareCarouselButton = HardwareCarouselDevice | "close" | "close all";
+
+function buildHardwareCarouselPageEventProperties(
+  sharedProps: HardwareCarouselSharedAnalyticsProps,
+) {
+  return {
+    name: HARDWARE_CAROUSEL_PAGE,
+    ...sharedProps,
+  };
+}
+
+function trackHardwareCarouselButtonClick(
+  button: HardwareCarouselButton,
+  sharedProps: HardwareCarouselSharedAnalyticsProps,
+): void {
+  track("button_clicked", {
+    button,
+    page: HARDWARE_CAROUSEL_PAGE,
+    ...sharedProps,
+  });
+}
+
 export function trackHardwareCarouselShown(
   sharedProps: HardwareCarouselSharedAnalyticsProps,
 ): void {
   trackPage(
     HARDWARE_CAROUSEL_PAGE,
     undefined,
-    {
-      name: HARDWARE_CAROUSEL_PAGE,
-      ...sharedProps,
-    },
+    buildHardwareCarouselPageEventProperties(sharedProps),
     true,
     false,
   );
@@ -32,29 +51,17 @@ export function trackHardwareCarouselDeviceClick(
   device: HardwareCarouselDevice,
   sharedProps: HardwareCarouselSharedAnalyticsProps,
 ): void {
-  track("button_clicked", {
-    button: device,
-    page: HARDWARE_CAROUSEL_PAGE,
-    ...sharedProps,
-  });
+  trackHardwareCarouselButtonClick(device, sharedProps);
 }
 
 export function trackHardwareCarouselCardDismiss(
   sharedProps: HardwareCarouselSharedAnalyticsProps,
 ): void {
-  track("button_clicked", {
-    button: "close",
-    page: HARDWARE_CAROUSEL_PAGE,
-    ...sharedProps,
-  });
+  trackHardwareCarouselButtonClick("close", sharedProps);
 }
 
 export function trackHardwareCarouselCloseAll(
   sharedProps: HardwareCarouselSharedAnalyticsProps,
 ): void {
-  track("button_clicked", {
-    button: "close all",
-    page: HARDWARE_CAROUSEL_PAGE,
-    ...sharedProps,
-  });
+  trackHardwareCarouselButtonClick("close all", sharedProps);
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/analytics.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/analytics.ts
@@ -1,6 +1,6 @@
-import { track } from "~/renderer/analytics/segment";
+import { track, trackPage } from "~/renderer/analytics/segment";
 
-export const HARDWARE_CAROUSEL_PAGE = "hardware carousel";
+export const HARDWARE_CAROUSEL_PAGE = "carousel hardware";
 
 export type HardwareCarouselDeviceModel = "lnx" | "lnsp";
 
@@ -8,8 +8,46 @@ export type HardwareCarouselSharedAnalyticsProps = Readonly<{
   deviceModel: HardwareCarouselDeviceModel;
   personalRecoOptIn: boolean;
   offerType: "discount" | "none";
-  platform: "lld";
+  platform: "lwd";
 }>;
+
+export type HardwareCarouselDevice = "ledger gen5" | "ledger flex" | "ledger stax";
+
+export function trackHardwareCarouselShown(
+  sharedProps: HardwareCarouselSharedAnalyticsProps,
+): void {
+  trackPage(
+    HARDWARE_CAROUSEL_PAGE,
+    undefined,
+    {
+      name: HARDWARE_CAROUSEL_PAGE,
+      ...sharedProps,
+    },
+    true,
+    false,
+  );
+}
+
+export function trackHardwareCarouselDeviceClick(
+  device: HardwareCarouselDevice,
+  sharedProps: HardwareCarouselSharedAnalyticsProps,
+): void {
+  track("button_clicked", {
+    button: device,
+    page: HARDWARE_CAROUSEL_PAGE,
+    ...sharedProps,
+  });
+}
+
+export function trackHardwareCarouselCardDismiss(
+  sharedProps: HardwareCarouselSharedAnalyticsProps,
+): void {
+  track("button_clicked", {
+    button: "close",
+    page: HARDWARE_CAROUSEL_PAGE,
+    ...sharedProps,
+  });
+}
 
 export function trackHardwareCarouselCloseAll(
   sharedProps: HardwareCarouselSharedAnalyticsProps,

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/extractHardwareCarouselDevice.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/extractHardwareCarouselDevice.test.ts
@@ -1,0 +1,16 @@
+import { extractHardwareCarouselDevice } from "./extractHardwareCarouselDevice";
+
+describe("extractHardwareCarouselDevice", () => {
+  it.each([
+    { title: "Ledger Gen5", expected: "ledger gen5" },
+    { title: "Nano Pod", expected: "ledger gen5" },
+    { title: "Ledger Flex™", expected: "ledger flex" },
+    { title: "Ledger Stax", expected: "ledger stax" },
+  ])("maps $title to $expected", ({ title, expected }) => {
+    expect(extractHardwareCarouselDevice(title)).toBe(expected);
+  });
+
+  it("returns null for unknown titles", () => {
+    expect(extractHardwareCarouselDevice("Nano Case")).toBeNull();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/extractHardwareCarouselDevice.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/extractHardwareCarouselDevice.ts
@@ -1,0 +1,24 @@
+import type { HardwareCarouselDevice } from "./analytics";
+
+export function extractHardwareCarouselDevice(title?: string): HardwareCarouselDevice | null {
+  if (!title) {
+    return null;
+  }
+
+  const titleLower = title.toLowerCase();
+  if (
+    titleLower.includes("gen5") ||
+    titleLower.includes("gen 5") ||
+    titleLower.includes("nano pod")
+  ) {
+    return "ledger gen5";
+  }
+  if (titleLower.includes("flex")) {
+    return "ledger flex";
+  }
+  if (titleLower.includes("stax")) {
+    return "ledger stax";
+  }
+
+  return null;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/sharedAnalyticsProps.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/sharedAnalyticsProps.ts
@@ -1,0 +1,37 @@
+import { DeviceModelId } from "@ledgerhq/types-devices";
+
+import type {
+  HardwareCarouselDeviceModel,
+  HardwareCarouselSharedAnalyticsProps,
+} from "./analytics";
+
+export function resolveHardwareCarouselDeviceModel(
+  devicesModelList: readonly DeviceModelId[],
+): HardwareCarouselDeviceModel | undefined {
+  if (devicesModelList.includes(DeviceModelId.nanoX)) {
+    return "lnx";
+  }
+
+  if (devicesModelList.includes(DeviceModelId.nanoSP)) {
+    return "lnsp";
+  }
+
+  return undefined;
+}
+
+export function buildHardwareCarouselSharedAnalyticsProps(
+  devicesModelList: readonly DeviceModelId[],
+  personalRecoOptIn: boolean,
+): HardwareCarouselSharedAnalyticsProps | undefined {
+  const deviceModel = resolveHardwareCarouselDeviceModel(devicesModelList);
+  if (!deviceModel) {
+    return undefined;
+  }
+
+  return {
+    deviceModel,
+    personalRecoOptIn,
+    offerType: personalRecoOptIn ? "discount" : "none",
+    platform: "lwd",
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/useHardwareCarouselCloseAll.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/useHardwareCarouselCloseAll.test.ts
@@ -59,4 +59,23 @@ describe("useHardwareCarouselCloseAll", () => {
     expect(mockDismissCards).toHaveBeenCalledWith(["card-1"]);
     expect(trackHardwareCarouselCloseAll).not.toHaveBeenCalled();
   });
+
+  it("does not track analytics when the user has no eligible device model", () => {
+    mockDismissCards.mockReturnValue(true);
+    const { result } = renderHook(() => useHardwareCarouselCloseAll(["card-1"]), {
+      initialState: {
+        settings: {
+          devicesModelList: [DeviceModelId.nanoS],
+          sharePersonalizedRecommandations: true,
+        },
+      },
+    });
+
+    act(() => {
+      result.current();
+    });
+
+    expect(mockDismissCards).toHaveBeenCalledWith(["card-1"]);
+    expect(trackHardwareCarouselCloseAll).not.toHaveBeenCalled();
+  });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/useHardwareCarouselCloseAll.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/useHardwareCarouselCloseAll.test.ts
@@ -44,7 +44,7 @@ describe("useHardwareCarouselCloseAll", () => {
       deviceModel: "lnx",
       personalRecoOptIn: true,
       offerType: "discount",
-      platform: "lld",
+      platform: "lwd",
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/useHardwareCarouselCloseAll.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/useHardwareCarouselCloseAll.ts
@@ -1,47 +1,27 @@
 import { useCallback, useMemo } from "react";
 import { useSelector } from "LLD/hooks/redux";
-import { DeviceModelId } from "@ledgerhq/types-devices";
-
 import {
   devicesModelListSelector,
   sharePersonalizedRecommendationsSelector,
 } from "~/renderer/reducers/settings";
 import { useDynamicContent } from "../hooks/useDynamicContent";
-import {
-  trackHardwareCarouselCloseAll,
-  type HardwareCarouselDeviceModel,
-  type HardwareCarouselSharedAnalyticsProps,
-} from "./analytics";
+import { trackHardwareCarouselCloseAll } from "./analytics";
+import { buildHardwareCarouselSharedAnalyticsProps } from "./sharedAnalyticsProps";
 
-const EMPTY_DEVICES_MODEL_LIST: DeviceModelId[] = [];
-
-function resolveHardwareCarouselDeviceModel(
-  devicesModelList: DeviceModelId[],
-): HardwareCarouselDeviceModel {
-  if (devicesModelList.includes(DeviceModelId.nanoX)) {
-    return "lnx";
-  }
-
-  return "lnsp";
-}
+const EMPTY_DEVICES_MODEL_LIST: [] = [];
 
 export function useHardwareCarouselCloseAll(cardIds: readonly string[]) {
   const { dismissCards } = useDynamicContent();
   const devicesModelList = useSelector(devicesModelListSelector) ?? EMPTY_DEVICES_MODEL_LIST;
   const personalRecoOptIn = useSelector(sharePersonalizedRecommendationsSelector);
 
-  const sharedAnalyticsProps: HardwareCarouselSharedAnalyticsProps = useMemo(
-    () => ({
-      deviceModel: resolveHardwareCarouselDeviceModel(devicesModelList),
-      personalRecoOptIn,
-      offerType: personalRecoOptIn ? "discount" : "none",
-      platform: "lwd",
-    }),
+  const sharedAnalyticsProps = useMemo(
+    () => buildHardwareCarouselSharedAnalyticsProps(devicesModelList, personalRecoOptIn),
     [devicesModelList, personalRecoOptIn],
   );
 
   const handleCloseAll = useCallback(() => {
-    if (!dismissCards(cardIds)) {
+    if (!dismissCards(cardIds) || !sharedAnalyticsProps) {
       return;
     }
 

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/useHardwareCarouselCloseAll.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/useHardwareCarouselCloseAll.ts
@@ -35,7 +35,7 @@ export function useHardwareCarouselCloseAll(cardIds: readonly string[]) {
       deviceModel: resolveHardwareCarouselDeviceModel(devicesModelList),
       personalRecoOptIn,
       offerType: personalRecoOptIn ? "discount" : "none",
-      platform: "lld",
+      platform: "lwd",
     }),
     [devicesModelList, personalRecoOptIn],
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/useHardwareCarouselPageTracking.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/useHardwareCarouselPageTracking.test.ts
@@ -1,0 +1,120 @@
+import { act, renderHook } from "tests/testSetup";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { useHardwareCarouselPageTracking } from "./useHardwareCarouselPageTracking";
+import { trackHardwareCarouselShown } from "./analytics";
+
+jest.mock("./analytics", () => ({
+  trackHardwareCarouselShown: jest.fn(),
+}));
+
+describe("useHardwareCarouselPageTracking", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should track when shouldTrack is true and Nano X is known", () => {
+    renderHook(() => useHardwareCarouselPageTracking(true), {
+      initialState: {
+        settings: {
+          devicesModelList: [DeviceModelId.nanoX],
+          sharePersonalizedRecommandations: true,
+        },
+      },
+    });
+
+    expect(trackHardwareCarouselShown).toHaveBeenCalledWith({
+      deviceModel: "lnx",
+      personalRecoOptIn: true,
+      offerType: "discount",
+      platform: "lwd",
+    });
+  });
+
+  it("should track when shouldTrack is true and Nano S Plus is known", () => {
+    renderHook(() => useHardwareCarouselPageTracking(true), {
+      initialState: {
+        settings: {
+          devicesModelList: [DeviceModelId.nanoSP],
+          sharePersonalizedRecommandations: false,
+        },
+      },
+    });
+
+    expect(trackHardwareCarouselShown).toHaveBeenCalledWith({
+      deviceModel: "lnsp",
+      personalRecoOptIn: false,
+      offerType: "none",
+      platform: "lwd",
+    });
+  });
+
+  it("should not track when shouldTrack is false", () => {
+    renderHook(() => useHardwareCarouselPageTracking(false), {
+      initialState: {
+        settings: {
+          devicesModelList: [DeviceModelId.nanoX],
+          sharePersonalizedRecommandations: true,
+        },
+      },
+    });
+
+    expect(trackHardwareCarouselShown).not.toHaveBeenCalled();
+  });
+
+  it("should not track when no eligible device models exist", () => {
+    renderHook(() => useHardwareCarouselPageTracking(true), {
+      initialState: {
+        settings: {
+          devicesModelList: [DeviceModelId.nanoS],
+          sharePersonalizedRecommandations: true,
+        },
+      },
+    });
+
+    expect(trackHardwareCarouselShown).not.toHaveBeenCalled();
+  });
+
+  it("should return shared props when device model is known", () => {
+    const { result } = renderHook(() => useHardwareCarouselPageTracking(false), {
+      initialState: {
+        settings: {
+          devicesModelList: [DeviceModelId.nanoX],
+          sharePersonalizedRecommandations: true,
+        },
+      },
+    });
+
+    expect(result.current).toEqual({
+      deviceModel: "lnx",
+      personalRecoOptIn: true,
+      offerType: "discount",
+      platform: "lwd",
+    });
+  });
+
+  it("should return undefined when no device model is known", () => {
+    const { result } = renderHook(() => useHardwareCarouselPageTracking(false), {
+      initialState: {
+        settings: {
+          devicesModelList: [DeviceModelId.nanoS],
+          sharePersonalizedRecommandations: true,
+        },
+      },
+    });
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it("should prefer Nano X over Nano S Plus when both are known", () => {
+    const { result } = renderHook(() => useHardwareCarouselPageTracking(false), {
+      initialState: {
+        settings: {
+          devicesModelList: [DeviceModelId.nanoSP, DeviceModelId.nanoX],
+          sharePersonalizedRecommandations: true,
+        },
+      },
+    });
+
+    expect(result.current?.deviceModel).toBe("lnx");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/useHardwareCarouselPageTracking.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/useHardwareCarouselPageTracking.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "tests/testSetup";
+import { renderHook } from "tests/testSetup";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { useHardwareCarouselPageTracking } from "./useHardwareCarouselPageTracking";
 import { trackHardwareCarouselShown } from "./analytics";

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/useHardwareCarouselPageTracking.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/useHardwareCarouselPageTracking.ts
@@ -1,49 +1,22 @@
 import { useEffect, useMemo } from "react";
-import { DeviceModelId } from "@ledgerhq/types-devices";
 import { useSelector } from "LLD/hooks/redux";
 import {
   devicesModelListSelector,
   sharePersonalizedRecommendationsSelector,
 } from "~/renderer/reducers/settings";
-import {
-  trackHardwareCarouselShown,
-  type HardwareCarouselDeviceModel,
-  type HardwareCarouselSharedAnalyticsProps,
-} from "./analytics";
+import { trackHardwareCarouselShown, type HardwareCarouselSharedAnalyticsProps } from "./analytics";
+import { buildHardwareCarouselSharedAnalyticsProps } from "./sharedAnalyticsProps";
 
-const EMPTY_DEVICES_MODEL_LIST: DeviceModelId[] = [];
-
-function resolveHardwareCarouselDeviceModel(
-  devicesModelList: DeviceModelId[],
-): HardwareCarouselDeviceModel | undefined {
-  if (devicesModelList.includes(DeviceModelId.nanoX)) {
-    return "lnx";
-  }
-
-  if (devicesModelList.includes(DeviceModelId.nanoSP)) {
-    return "lnsp";
-  }
-
-  return undefined;
-}
+const EMPTY_DEVICES_MODEL_LIST: [] = [];
 
 export function useHardwareCarouselPageTracking(shouldTrack: boolean) {
   const devicesModelList = useSelector(devicesModelListSelector) ?? EMPTY_DEVICES_MODEL_LIST;
   const personalRecoOptIn = useSelector(sharePersonalizedRecommendationsSelector);
 
-  const sharedAnalyticsProps: HardwareCarouselSharedAnalyticsProps | undefined = useMemo(() => {
-    const deviceModel = resolveHardwareCarouselDeviceModel(devicesModelList);
-    if (!deviceModel) {
-      return undefined;
-    }
-
-    return {
-      deviceModel,
-      personalRecoOptIn,
-      offerType: personalRecoOptIn ? "discount" : "none",
-      platform: "lwd",
-    };
-  }, [devicesModelList, personalRecoOptIn]);
+  const sharedAnalyticsProps: HardwareCarouselSharedAnalyticsProps | undefined = useMemo(
+    () => buildHardwareCarouselSharedAnalyticsProps(devicesModelList, personalRecoOptIn),
+    [devicesModelList, personalRecoOptIn],
+  );
 
   useEffect(() => {
     if (shouldTrack && sharedAnalyticsProps) {

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/useHardwareCarouselPageTracking.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hardwareCarousel/useHardwareCarouselPageTracking.ts
@@ -1,0 +1,55 @@
+import { useEffect, useMemo } from "react";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { useSelector } from "LLD/hooks/redux";
+import {
+  devicesModelListSelector,
+  sharePersonalizedRecommendationsSelector,
+} from "~/renderer/reducers/settings";
+import {
+  trackHardwareCarouselShown,
+  type HardwareCarouselDeviceModel,
+  type HardwareCarouselSharedAnalyticsProps,
+} from "./analytics";
+
+const EMPTY_DEVICES_MODEL_LIST: DeviceModelId[] = [];
+
+function resolveHardwareCarouselDeviceModel(
+  devicesModelList: DeviceModelId[],
+): HardwareCarouselDeviceModel | undefined {
+  if (devicesModelList.includes(DeviceModelId.nanoX)) {
+    return "lnx";
+  }
+
+  if (devicesModelList.includes(DeviceModelId.nanoSP)) {
+    return "lnsp";
+  }
+
+  return undefined;
+}
+
+export function useHardwareCarouselPageTracking(shouldTrack: boolean) {
+  const devicesModelList = useSelector(devicesModelListSelector) ?? EMPTY_DEVICES_MODEL_LIST;
+  const personalRecoOptIn = useSelector(sharePersonalizedRecommendationsSelector);
+
+  const sharedAnalyticsProps: HardwareCarouselSharedAnalyticsProps | undefined = useMemo(() => {
+    const deviceModel = resolveHardwareCarouselDeviceModel(devicesModelList);
+    if (!deviceModel) {
+      return undefined;
+    }
+
+    return {
+      deviceModel,
+      personalRecoOptIn,
+      offerType: personalRecoOptIn ? "discount" : "none",
+      platform: "lwd",
+    };
+  }, [devicesModelList, personalRecoOptIn]);
+
+  useEffect(() => {
+    if (shouldTrack && sharedAnalyticsProps) {
+      trackHardwareCarouselShown(sharedAnalyticsProps);
+    }
+  }, [shouldTrack, sharedAnalyticsProps]);
+
+  return sharedAnalyticsProps;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/LNSUpsellBanner.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/LNSUpsellBanner.test.tsx
@@ -3,11 +3,12 @@
  */
 
 import { FEATURE_FLAGS_DEFAULTS } from "@shared/feature-flags";
+import { LARGE_SCREEN_UPSELL_UTM } from "@features/flow-large-screen-upsell";
 import React from "react";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { render, screen, fireEvent, withFlagOverrides } from "tests/testSetup";
 import { openURL } from "~/renderer/linking";
-import { track } from "~/renderer/analytics/segment";
+import { track, trackPage } from "~/renderer/analytics/segment";
 import { BANNER_PLACEMENT_BY_LOCATION } from "LLD/features/LNSUpsell/types";
 import { LNSUpsellBanner } from ".";
 
@@ -17,11 +18,26 @@ jest.mock("~/renderer/linking", () => ({
 jest.mock("~/renderer/analytics/segment", () => ({
   ...jest.requireActual("~/renderer/analytics/segment"),
   track: jest.fn(),
+  trackPage: jest.fn(),
 }));
 
 const DEFAULT_DISCOUNT_PERCENT = Math.round(
   (FEATURE_FLAGS_DEFAULTS.largeScreenUpsell.params?.discount ?? 0) * 100,
 );
+
+const OPTED_IN_ANALYTICS_PROPS = {
+  deviceModel: "lns",
+  personalRecoOptIn: true,
+  offerType: "discount",
+  platform: "lwd",
+} as const;
+
+const OPTED_OUT_ANALYTICS_PROPS = {
+  deviceModel: "lns",
+  personalRecoOptIn: false,
+  offerType: "none",
+  platform: "lwd",
+} as const;
 
 function daysAgoIso(days: number): string {
   const date = new Date();
@@ -29,18 +45,57 @@ function daysAgoIso(days: number): string {
   return date.toISOString();
 }
 
+function expectUpgradeClickTracking(
+  pageName: string,
+  sharedProps: typeof OPTED_IN_ANALYTICS_PROPS,
+) {
+  expect(track).toHaveBeenCalledWith("button_clicked", {
+    button: "upgrade",
+    page: pageName,
+    ...sharedProps,
+  });
+  expect(track).toHaveBeenCalledWith("deeplink_clicked", {
+    page: pageName,
+    deeplinkSource: LARGE_SCREEN_UPSELL_UTM.sourceByPlatform.desktop,
+    deeplinkMedium: LARGE_SCREEN_UPSELL_UTM.medium,
+    deeplinkCampaign: LARGE_SCREEN_UPSELL_UTM.campaign,
+    ...sharedProps,
+  });
+}
+
 describe("LNSUpsellBanner", () => {
   beforeEach(() => {
     jest.mocked(openURL).mockClear();
     jest.mocked(track).mockClear();
+    jest.mocked(trackPage).mockClear();
   });
 
   describe.each([
-    { location: "accounts", page: "Accounts" },
-    { location: "manager", page: "Manager" },
-    { location: "portfolio", page: "Portfolio" },
-    { location: "notification_center", page: "NotificationPanel" },
-  ] as const)("on the $page page", ({ location, page }) => {
+    {
+      location: "accounts",
+      page: "Accounts",
+      bannerPageName: "banner upsell portfolio",
+      utmContent: LARGE_SCREEN_UPSELL_UTM.content.portfolio_banner,
+    },
+    {
+      location: "manager",
+      page: "Manager",
+      bannerPageName: "banner upsell my ledger",
+      utmContent: LARGE_SCREEN_UPSELL_UTM.content.my_ledger_banner,
+    },
+    {
+      location: "portfolio",
+      page: "Portfolio",
+      bannerPageName: "banner upsell portfolio",
+      utmContent: LARGE_SCREEN_UPSELL_UTM.content.portfolio_banner,
+    },
+    {
+      location: "notification_center",
+      page: "NotificationPanel",
+      bannerPageName: "banner upsell notification center",
+      utmContent: LARGE_SCREEN_UPSELL_UTM.content.notif_banner,
+    },
+  ] as const)("on the $page page", ({ location, bannerPageName, utmContent }) => {
     it("should not render if the feature flag is disabled", () => {
       renderBanner({ ffEnabled: false });
       expect(screen.queryByText("Upgrade my Ledger")).toBeNull();
@@ -79,11 +134,9 @@ describe("LNSUpsellBanner", () => {
         });
         fireEvent.click(screen.getByText("Upgrade my Ledger"));
 
-        expect(track).toHaveBeenCalledWith("button_clicked", {
-          button: "Level up wallet",
+        expectUpgradeClickTracking(bannerPageName, {
+          ...OPTED_IN_ANALYTICS_PROPS,
           deviceModel: analyticsValue,
-          link: "https://example.com/optInCta",
-          page,
         });
       },
     );
@@ -112,11 +165,9 @@ describe("LNSUpsellBanner", () => {
       });
       fireEvent.click(screen.getByText("Upgrade my Ledger"));
 
-      expect(track).toHaveBeenCalledWith("button_clicked", {
-        button: "Level up wallet",
+      expectUpgradeClickTracking(bannerPageName, {
+        ...OPTED_IN_ANALYTICS_PROPS,
         deviceModel: "lnx",
-        link: "https://example.com/optInCta",
-        page,
       });
     });
 
@@ -130,19 +181,31 @@ describe("LNSUpsellBanner", () => {
       expect(screen.queryByText("Upgrade my Ledger")).toBeNull();
     });
 
+    it("should fire a banner page event when the banner is shown", () => {
+      renderBanner({});
+
+      expect(trackPage).toHaveBeenCalledWith(
+        bannerPageName,
+        undefined,
+        {
+          name: bannerPageName,
+          ...OPTED_IN_ANALYTICS_PROPS,
+        },
+        true,
+        false,
+      );
+    });
+
     it("should track click on the cta", () => {
       renderBanner({});
       fireEvent.click(screen.getByText("Upgrade my Ledger"));
 
       expect(openURL).toHaveBeenCalledTimes(1);
-      expect(openURL).toHaveBeenCalledWith("https://example.com/optInCta");
-      expect(track).toHaveBeenCalledTimes(1);
-      expect(track).toHaveBeenCalledWith("button_clicked", {
-        button: "Level up wallet",
-        deviceModel: "lns",
-        link: "https://example.com/optInCta",
-        page,
-      });
+      const openedUrl = new URL(String(jest.mocked(openURL).mock.calls[0][0]));
+      expect(openedUrl.origin + openedUrl.pathname).toBe("https://example.com/optInCta");
+      expect(openedUrl.searchParams.get("utm_content")).toBe(utmContent);
+      expect(track).toHaveBeenCalledTimes(2);
+      expectUpgradeClickTracking(bannerPageName, OPTED_IN_ANALYTICS_PROPS);
     });
 
     it("should render Lumen MediaBanner and track click when lwdWallet40 brazePlacement is on", () => {
@@ -154,13 +217,7 @@ describe("LNSUpsellBanner", () => {
       fireEvent.click(screen.getByTestId("lns-upsell-media-banner"));
 
       expect(openURL).toHaveBeenCalledTimes(1);
-      expect(openURL).toHaveBeenCalledWith("https://example.com/optInCta");
-      expect(track).toHaveBeenCalledWith("button_clicked", {
-        button: "Level up wallet",
-        deviceModel: "lns",
-        link: "https://example.com/optInCta",
-        page,
-      });
+      expectUpgradeClickTracking(bannerPageName, OPTED_IN_ANALYTICS_PROPS);
     });
 
     it("should render opted-out MediaBanner copy when lwdWallet40 brazePlacement is on", () => {
@@ -175,14 +232,10 @@ describe("LNSUpsellBanner", () => {
       fireEvent.click(screen.getByText("Learn more"));
 
       expect(openURL).toHaveBeenCalledTimes(1);
-      expect(openURL).toHaveBeenCalledWith("https://example.com/optOutCta");
-      expect(track).toHaveBeenCalledTimes(1);
-      expect(track).toHaveBeenCalledWith("button_clicked", {
-        button: "Level up wallet",
-        deviceModel: "lns",
-        link: "https://example.com/optOutCta",
-        page,
-      });
+      const openedUrl = new URL(String(jest.mocked(openURL).mock.calls[0][0]));
+      expect(openedUrl.origin + openedUrl.pathname).toBe("https://example.com/optOutCta");
+      expect(track).toHaveBeenCalledTimes(2);
+      expectUpgradeClickTracking(bannerPageName, OPTED_OUT_ANALYTICS_PROPS);
     });
 
     it("should render for opted out users regardless of content cards state", () => {
@@ -190,14 +243,8 @@ describe("LNSUpsellBanner", () => {
       fireEvent.click(screen.getByText("Learn more"));
 
       expect(openURL).toHaveBeenCalledTimes(1);
-      expect(openURL).toHaveBeenCalledWith("https://example.com/optOutCta");
-      expect(track).toHaveBeenCalledTimes(1);
-      expect(track).toHaveBeenCalledWith("button_clicked", {
-        button: "Level up wallet",
-        deviceModel: "lns",
-        link: "https://example.com/optOutCta",
-        page,
-      });
+      expect(track).toHaveBeenCalledTimes(2);
+      expectUpgradeClickTracking(bannerPageName, OPTED_OUT_ANALYTICS_PROPS);
     });
 
     function renderBanner({
@@ -321,6 +368,10 @@ describe("LNSUpsellBanner", () => {
     });
 
     fireEvent.click(screen.getByTestId("lns-upsell-media-banner"));
-    expect(openURL).toHaveBeenCalledWith("https://example.com/optInCta");
+    const openedUrl = new URL(String(jest.mocked(openURL).mock.calls[0][0]));
+    expect(openedUrl.origin + openedUrl.pathname).toBe("https://example.com/optInCta");
+    expect(openedUrl.searchParams.get("utm_content")).toBe(
+      LARGE_SCREEN_UPSELL_UTM.content.portfolio_banner,
+    );
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/LNSUpsellBanner.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/LNSUpsellBanner.test.tsx
@@ -39,16 +39,20 @@ const OPTED_OUT_ANALYTICS_PROPS = {
   platform: "lwd",
 } as const;
 
+type SharedAnalyticsProps = {
+  deviceModel: "lns" | "lnsp" | "lnx";
+  personalRecoOptIn: boolean;
+  offerType: "discount" | "none";
+  platform: "lwd";
+};
+
 function daysAgoIso(days: number): string {
   const date = new Date();
   date.setDate(date.getDate() - days);
   return date.toISOString();
 }
 
-function expectUpgradeClickTracking(
-  pageName: string,
-  sharedProps: typeof OPTED_IN_ANALYTICS_PROPS,
-) {
+function expectUpgradeClickTracking(pageName: string, sharedProps: SharedAnalyticsProps) {
   expect(track).toHaveBeenCalledWith("button_clicked", {
     button: "upgrade",
     page: pageName,
@@ -123,8 +127,8 @@ describe("LNSUpsellBanner", () => {
     );
 
     it.each([
-      { deviceModelId: DeviceModelId.nanoSP, analyticsValue: "lnsp" },
-      { deviceModelId: DeviceModelId.nanoX, analyticsValue: "lnx" },
+      { deviceModelId: DeviceModelId.nanoSP, analyticsValue: "lnsp" as const },
+      { deviceModelId: DeviceModelId.nanoX, analyticsValue: "lnx" as const },
     ])(
       "should render for $deviceModelId once its cooldown has elapsed",
       ({ deviceModelId, analyticsValue }) => {

--- a/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/useLNSUpsellBannerModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/useLNSUpsellBannerModel.ts
@@ -1,12 +1,17 @@
+import { useCallback, useEffect, useMemo } from "react";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import {
   LARGE_SCREEN_UPSELL_UTM,
   buildLargeScreenUpsellCtaLink,
+  type LargeScreenUpsellUtmContent,
 } from "@features/flow-large-screen-upsell";
 import { useLNSUpsellBannerState } from "LLD/features/LNSUpsell/hooks/useLNSUpsellBannerState";
 import type { LNSBannerLocation, LNSBannerState } from "LLD/features/LNSUpsell/types";
-import { toLargeScreenUpsellDeviceModelAnalyticsValue } from "LLD/features/LargeScreenUpsell/analytics";
-import { track } from "~/renderer/analytics/segment";
+import {
+  toLargeScreenUpsellDeviceModelAnalyticsValue,
+  type LargeScreenUpsellDeviceModelAnalyticsValue,
+} from "LLD/features/LargeScreenUpsell/analytics";
+import { track, trackPage } from "~/renderer/analytics/segment";
 import { openURL } from "~/renderer/linking";
 import lnsUpsellPortfolioImageUrl from "~/renderer/images/lns-upsell-banner-portfolio.webp";
 import lnsUpsellManagerImageUrl from "~/renderer/images/lns-upsell-banner-manager.webp";
@@ -22,6 +27,15 @@ const lnsUpsellImageByLocation: Record<LNSBannerLocation, string> = {
   profile: lnsUpsellNotificationCenterImageUrl,
 };
 
+const PROFILE_PAGE = "Profile";
+
+type SharedAnalyticsProps = Readonly<{
+  deviceModel: LargeScreenUpsellDeviceModelAnalyticsValue;
+  personalRecoOptIn: boolean;
+  offerType: "discount" | "none";
+  platform: "lwd";
+}>;
+
 export function useLNSUpsellBannerModel(location: LNSBannerLocation): LNSBannerModel {
   const state = useLNSUpsellBannerState(location);
   const { shouldDisplayBrazePlacement } = useWalletFeaturesConfig("desktop");
@@ -32,41 +46,63 @@ export function useLNSUpsellBannerModel(location: LNSBannerLocation): LNSBannerM
   const deviceModel = deviceModelId
     ? toLargeScreenUpsellDeviceModelAnalyticsValue(deviceModelId)
     : undefined;
-  const resolvedCtaLink = resolveCtaLink(location, ctaLink);
+  const personalRecoOptIn = tracking === "opted_in";
+  const sharedAnalyticsProps = useMemo(
+    () =>
+      deviceModel
+        ? {
+            deviceModel,
+            personalRecoOptIn,
+            offerType: personalRecoOptIn ? ("discount" as const) : ("none" as const),
+            platform: "lwd" as const,
+          }
+        : undefined,
+    [deviceModel, personalRecoOptIn],
+  );
 
-  const handleCTAClick = () => {
-    if (location === "profile") {
-      const personalRecoOptIn = tracking === "opted_in";
-      const sharedProps = {
-        ...(deviceModel ? { deviceModel } : {}),
-        personalRecoOptIn,
-        offerType: personalRecoOptIn ? ("discount" as const) : ("none" as const),
-        platform: "lwd" as const,
-      };
-
-      track("button_clicked", {
-        button: PROFILE_ANALYTICS_BUTTON,
-        page: analyticsPage,
-        ...sharedProps,
-      });
-      track("deeplink_clicked", {
-        page: analyticsPage,
-        deeplinkSource: LARGE_SCREEN_UPSELL_UTM.sourceByPlatform.desktop,
-        deeplinkMedium: LARGE_SCREEN_UPSELL_UTM.medium,
-        deeplinkCampaign: LARGE_SCREEN_UPSELL_UTM.campaign,
-        ...sharedProps,
-      });
-    } else {
-      track("button_clicked", {
-        button: ANALYTICS_BUTTON_CLICK,
-        ...(deviceModel ? { deviceModel } : {}),
-        link: resolvedCtaLink,
-        page: analyticsPage,
-      });
+  useEffect(() => {
+    if (!state.isShown || !sharedAnalyticsProps) {
+      return;
     }
 
-    if (resolvedCtaLink) openURL(resolvedCtaLink);
-  };
+    if (location === "profile") {
+      trackProfilePageViewed(sharedAnalyticsProps);
+      return;
+    }
+
+    const bannerPageName = BannerPageEventNameMap[location];
+    if (bannerPageName) {
+      trackBannerPageViewed(bannerPageName, sharedAnalyticsProps);
+    }
+  }, [location, sharedAnalyticsProps, state.isShown]);
+
+  const handleCTAClick = useCallback(() => {
+    if (!ctaLink || !sharedAnalyticsProps) {
+      return;
+    }
+
+    const utmContent = UTMContentMap[location];
+    const upsellLink = buildLargeScreenUpsellCtaLink(ctaLink, "desktop", utmContent);
+    const pageName = BannerPageEventNameMap[location] || analyticsPage;
+
+    track("button_clicked", {
+      button: "upgrade",
+      page: pageName,
+      ...sharedAnalyticsProps,
+    });
+
+    track("deeplink_clicked", {
+      page: pageName,
+      deeplinkSource: LARGE_SCREEN_UPSELL_UTM.sourceByPlatform.desktop,
+      deeplinkMedium: LARGE_SCREEN_UPSELL_UTM.medium,
+      deeplinkCampaign: LARGE_SCREEN_UPSELL_UTM.campaign,
+      ...sharedAnalyticsProps,
+    });
+
+    if (upsellLink) {
+      openURL(upsellLink);
+    }
+  }, [analyticsPage, ctaLink, location, sharedAnalyticsProps]);
 
   const variant = getVariant(location, state);
 
@@ -81,27 +117,36 @@ export function useLNSUpsellBannerModel(location: LNSBannerLocation): LNSBannerM
   };
 }
 
-const ANALYTICS_BUTTON_CLICK = "Level up wallet";
-const PROFILE_ANALYTICS_BUTTON = "upgrade";
+function trackProfilePageViewed(sharedProps: SharedAnalyticsProps) {
+  trackPage(PROFILE_PAGE, undefined, { name: PROFILE_PAGE, ...sharedProps }, true, false);
+}
+
+function trackBannerPageViewed(pageName: string, sharedProps: SharedAnalyticsProps) {
+  trackPage(pageName, undefined, { name: pageName, ...sharedProps }, true, false);
+}
 
 const AnalyticsPageMap = {
   manager: "Manager",
   accounts: "Accounts",
   portfolio: "Portfolio",
   notification_center: "NotificationPanel",
-  profile: "Profile",
+  profile: PROFILE_PAGE,
 } as const satisfies Record<LNSBannerLocation, unknown>;
 
-function resolveCtaLink(location: LNSBannerLocation, ctaLink?: string): string | undefined {
-  if (!ctaLink) return undefined;
-  if (location !== "profile") return ctaLink;
+const BannerPageEventNameMap: Partial<Record<LNSBannerLocation, string>> = {
+  portfolio: "banner upsell portfolio",
+  notification_center: "banner upsell notification center",
+  manager: "banner upsell my ledger",
+  accounts: "banner upsell portfolio",
+} as const;
 
-  return buildLargeScreenUpsellCtaLink(
-    ctaLink,
-    "desktop",
-    LARGE_SCREEN_UPSELL_UTM.content.profile_cta,
-  );
-}
+const UTMContentMap: Record<LNSBannerLocation, LargeScreenUpsellUtmContent> = {
+  portfolio: LARGE_SCREEN_UPSELL_UTM.content.portfolio_banner,
+  notification_center: LARGE_SCREEN_UPSELL_UTM.content.notif_banner,
+  manager: LARGE_SCREEN_UPSELL_UTM.content.my_ledger_banner,
+  accounts: LARGE_SCREEN_UPSELL_UTM.content.portfolio_banner,
+  profile: LARGE_SCREEN_UPSELL_UTM.content.profile_cta,
+} as const;
 
 function getVariant(location: LNSBannerLocation, state: LNSBannerState): LNSBannerModel["variant"] {
   if (!state.isShown) return { type: "none" };

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/__integrations__/LNSUpsellProfileBanner.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/__integrations__/LNSUpsellProfileBanner.integration.test.tsx
@@ -3,7 +3,7 @@ import { DeviceModelId } from "@ledgerhq/types-devices";
 import { FEATURE_FLAGS_DEFAULTS } from "@shared/feature-flags";
 import { LARGE_SCREEN_UPSELL_UTM } from "@features/flow-large-screen-upsell";
 import { render, screen, waitFor, withFlagOverrides } from "tests/testSetup";
-import { track } from "~/renderer/analytics/segment";
+import { track, trackPage } from "~/renderer/analytics/segment";
 import { openURL } from "~/renderer/linking";
 import { ContextMenu } from "../components/ContextMenu";
 
@@ -137,6 +137,24 @@ describe("My Wallet LNS upsell profile banner", () => {
     expect(screen.getByText("Learn more about security features.")).toBeVisible();
     expect(screen.getByRole("button", { name: "Explore" })).toBeVisible();
     expect(screen.queryByText("Explore all Ledger devices")).toBeNull();
+  });
+
+  it("should fire a Profile page event when the banner is shown", async () => {
+    await renderMyWalletProfile();
+
+    expect(trackPage).toHaveBeenCalledWith(
+      "Profile",
+      undefined,
+      {
+        name: "Profile",
+        deviceModel: "lns",
+        personalRecoOptIn: true,
+        offerType: "discount",
+        platform: "lwd",
+      },
+      true,
+      false,
+    );
   });
 
   it("should open the opted_out URL and fire opted-out tracking when personalized recommendations are off", async () => {


### PR DESCRIPTION
### 📝 Description

**Problem**: Desktop touchscreen upsell placements (banners, hardware carousel) were missing analytics events required by the [Touchscreen Upgrade Program Tracking Plan](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7317815469/Touchscreen+Upgrade+Program+-+Tracking+Plan). Mobile parity was added in LIVE-36378; desktop tracking was incomplete.

**Solution**: Align LWD placement tracking with mobile and the tracking plan:

- **Banner placements** (Portfolio, My Ledger, Notification Center, Accounts, Profile): emit page impressions (`trackPage`) when shown; unified `upgrade` + `deeplink_clicked` events with UTMs on CTA click; platform set to `lwd`
- **Hardware carousel**: page impression on show (`carousel hardware`), device card click, individual dismiss, and close-all events; platform standardized from `lld` to `lwd`

**Test coverage**: Unit and integration tests updated/added for banner model, hardware carousel analytics, page tracking hook, and ContentCardsCategory integration.

**QA focus**: Verify Analytics Console events on Portfolio banner, My Ledger banner, Notification Center, Profile CTA, and hardware carousel (show, click, dismiss, close all).

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36428](https://ledgerhq.atlassian.net/browse/LIVE-36428)
- **Related**: Mobile tracking [LIVE-36378](https://ledgerhq.atlassian.net/browse/LIVE-36378)
- **ADR** (if any): N/A

[LIVE-36428]: https://ledgerhq.atlassian.net/browse/LIVE-36428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ