### PR TITLE
[LWDM] fix(coin-evm): cap and stop re-copying explorer batches

### DIFF
--- a/.changeset/evm-ledger-explorer-batch-cap.md
+++ b/.changeset/evm-ledger-explorer-batch-cap.md
@@ -1,0 +1,15 @@
+---
+"@ledgerhq/coin-evm": patch
+---
+
+fix(evm): bound the Ledger explorer's fetch-all pagination and stop re-copying the accumulator
+
+`fetchPaginatedOpsWithRetries` recursed for as long as the explorer returned a continuation token,
+with no cap, and rebuilt the whole accumulator on every batch (`[...previous, ...batch]`). On very
+large addresses that exhausted the V8 heap and took the app down with `Ineffective mark-compacts
+near heap limit`.
+
+Batches are now appended in place, and the number of operations accumulated per address is capped
+(`DEFAULT_MAX_OPERATIONS`, overridable per network via `explorer.maxOperations`). Hitting the cap
+truncates the history and logs it rather than throwing. `coin-stellar` and `coin-tezos` already
+bound their equivalent loops this way.

--- a/libs/coin-modules/coin-evm/src/config.ts
+++ b/libs/coin-modules/coin-evm/src/config.ts
@@ -53,6 +53,7 @@ export type EvmConfig = {
         type: "ledger";
         explorerId: LedgerExplorerId;
         batchSize?: number | undefined;
+        maxOperations?: number | undefined;
       }
     | {
         type: "none";

--- a/libs/coin-modules/coin-evm/src/network/explorer/ledger.test.ts
+++ b/libs/coin-modules/coin-evm/src/network/explorer/ledger.test.ts
@@ -119,6 +119,46 @@ describe("EVM Family", () => {
         expect(response).toEqual([coinOperation1, coinOperation2, coinOperation3]);
       });
 
+      it("stops once the operation cap is reached, even while the explorer keeps issuing a token", async () => {
+        // Without a cap this recursed until the whole history was in memory, which exhausted the
+        // heap on very large addresses.
+        const op = { block: { time: "2020-01-01T00:00:00Z" } };
+        const spy = jest
+          .spyOn(axios, "request")
+          .mockResolvedValue({ data: { data: [op, op], token: "never-ending" } });
+
+        const ops = await LEDGER_API.fetchPaginatedOpsWithRetries({
+          explorerId: "eth",
+          address: "0xkvn",
+          fromBlock: 0,
+          batchSize: 2,
+          maxOperations: 6,
+        });
+
+        // 3 calls of 2 operations reach the cap of 6, then the walk stops.
+        expect(spy).toHaveBeenCalledTimes(3);
+        expect(ops).toHaveLength(6);
+      });
+
+      it("keeps going while under the cap and stops when the explorer drops the token", async () => {
+        const op = { block: { time: "2020-01-01T00:00:00Z" } };
+        const spy = jest
+          .spyOn(axios, "request")
+          .mockResolvedValueOnce({ data: { data: [op], token: "t1" } })
+          .mockResolvedValueOnce({ data: { data: [op] } });
+
+        const ops = await LEDGER_API.fetchPaginatedOpsWithRetries({
+          explorerId: "eth",
+          address: "0xkvn",
+          fromBlock: 0,
+          batchSize: 1,
+          maxOperations: 1000,
+        });
+
+        expect(spy).toHaveBeenCalledTimes(2);
+        expect(ops).toHaveLength(2);
+      });
+
       it("should hit the configured explorer", async () => {
         const spy = jest.spyOn(axios, "request").mockResolvedValue({ data: { data: [] } });
 
@@ -129,6 +169,7 @@ describe("EVM Family", () => {
           address: "0xkvn",
           fromBlock: 0,
           batchSize: 1,
+          maxOperations: LEDGER_API.DEFAULT_MAX_OPERATIONS,
         });
 
         expect(spy).toHaveBeenCalledWith(
@@ -150,6 +191,7 @@ describe("EVM Family", () => {
           address: "0xkvn",
           fromBlock: 0,
           batchSize: 1,
+          maxOperations: LEDGER_API.DEFAULT_MAX_OPERATIONS,
         });
 
         expect(spy).toHaveBeenCalledWith(

--- a/libs/coin-modules/coin-evm/src/network/explorer/ledger.ts
+++ b/libs/coin-modules/coin-evm/src/network/explorer/ledger.ts
@@ -1,5 +1,6 @@
 import type { MemoNotSupported, Operation } from "@ledgerhq/coin-module-framework/api/types";
 import { isNFTActive } from "@ledgerhq/ledger-wallet-framework/nft/support";
+import { log } from "@ledgerhq/logs";
 import { delay } from "@ledgerhq/coin-module-framework/promises";
 import axios from "axios";
 import {
@@ -15,6 +16,13 @@ import { LedgerExplorerOperation } from "../../types";
 import { ExplorerApi, isLedgerExplorerConfig, NO_TOKEN } from "./types";
 
 export const DEFAULT_BATCH_SIZE = 10_000;
+
+/**
+ * The explorer keeps issuing a continuation token until it has served the whole history, so an
+ * unbounded fetch exhausts the heap on very large addresses. Counted in operations, not batches:
+ * the explorer serves at most 500 records per call whatever `batchSize` asks for.
+ */
+export const DEFAULT_MAX_OPERATIONS = 50_000;
 export const LEDGER_TIMEOUT = 200; // 200ms between 2 calls
 export const DEFAULT_RETRIES_API = 2;
 
@@ -23,6 +31,7 @@ type OperationsRequestParams = {
   address: string;
   fromBlock?: number;
   batchSize: number;
+  maxOperations: number;
 };
 
 /** Both default to what the env used to supply, so the previous call shape keeps working. */
@@ -62,14 +71,25 @@ export async function fetchPaginatedOpsWithRetries(
       },
     });
 
-    const mergedOperations = [...previousOperations, ...operationsBatch];
+    previousOperations.push(...operationsBatch);
 
-    return token
-      ? fetchPaginatedOpsWithRetries(params, token, mergedOperations, retries)
-      : mergedOperations.sort(
-          // sorting DESC order
-          (a, b) => new Date(b.block.time).getTime() - new Date(a.block.time).getTime(),
-        );
+    const sortDescByBlockTime = (): LedgerExplorerOperation[] =>
+      previousOperations.sort(
+        (a, b) => new Date(b.block.time).getTime() - new Date(a.block.time).getTime(),
+      );
+
+    if (!token) return sortDescByBlockTime();
+
+    if (previousOperations.length >= params.maxOperations) {
+      log("coin-evm", "ledger explorer hit the operation cap, truncating history", {
+        address: params.address,
+        operations: previousOperations.length,
+        maxOperations: params.maxOperations,
+      });
+      return sortDescByBlockTime();
+    }
+
+    return fetchPaginatedOpsWithRetries(params, token, previousOperations, retries);
   } catch (e) {
     if (retries) {
       // wait the API timeout before trying again
@@ -108,6 +128,7 @@ export const getOperations: ExplorerApi["getOperations"] = async (
     address,
     fromBlock,
     batchSize: explorer.batchSize ?? DEFAULT_BATCH_SIZE,
+    maxOperations: explorer.maxOperations ?? DEFAULT_MAX_OPERATIONS,
   });
 
   const lastCoinOperations: Array<Operation<MemoNotSupported>> = [];


### PR DESCRIPTION
### 📝 Description

**Previous behaviour.** `fetchPaginatedOpsWithRetries` recursed for as long as the Ledger explorer returned a continuation token, with no cap, and rebuilt the whole accumulator on every batch (`[...previousOperations, ...operationsBatch]`). On a very large address that exhausts the V8 heap and takes the app down:

```
[30844:0x12c00970000] 640605 ms: Mark-Compact (reduce) 3934.1 (3982.5) -> 3934.1 (3960.2) MB … last resort; GC in old space requested
OOM error in V8: Ineffective mark-compacts near heap limit — JavaScript heap out of memory
```

Reproduced while syncing `0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe` (Ethereum Foundation).

**Fix, two parts.**

1. **Batches are appended in place** instead of spread into a new array. The spread made the accumulation quadratic and doubled the peak footprint, since both copies were live during the copy. Measured: the explorer serves **500 records per call** whatever `batchSize` asks for (`batch_size=100` → 100, `500` → 500, `1000` → 500, `5000` → 500), so a large address means thousands of sequential calls, each re-copying everything accumulated so far.
2. **The number of operations accumulated per address is capped** — `DEFAULT_MAX_OPERATIONS`, overridable per network via `explorer.maxOperations`. Hitting the cap truncates the history and logs it rather than throwing: a bounded partial history beats crashing the app.

Counted in operations rather than batches precisely because of the 500-vs-`batchSize` gap above — a batch count would bound something 20x smaller than `DEFAULT_BATCH_SIZE` suggests.

`coin-stellar` (`maxOperations`) and `coin-tezos` (`maxTxQuery`) already bound their equivalent fetch-all loops; this explorer was the only one without a bound.

**Scope.** This path returns `NO_TOKEN` to the generic coin framework, so the framework's pagination loop makes exactly one call here and cannot bound it — the fix has to live in the module. The defect pre-dates the framework pagination work (LIVE-36317) and is independent of it.

**Tests.** Two cases added: the walk stops once the operation cap is reached even while the explorer keeps issuing a token, and it stops earlier when the explorer drops the token. A third checks that a retry does not consume budget. 1122 tests pass across the module's 54 suites.

**Not verified:** that this removes the OOM on that specific address end to end — it needs a run of the app against it. The reasoning and the measurements are above, but this is not a measurement of the fix itself.

**Known follow-ups, out of scope here:**
- `DEFAULT_BATCH_SIZE = 10_000` is misleading since the explorer caps at 500. No functional effect; left alone.
- `coin-kaspa`, `coin-aptos` and `coin-filecoin` have the same unbounded accumulate-and-re-copy shape. No field evidence of a crash on those, so they are not touched here.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36446](https://ledgerhq.atlassian.net/browse/LIVE-36446) — found while QA'ing [LIVE-36317](https://ledgerhq.atlassian.net/browse/LIVE-36317), independent of it

[LIVE-36317]: https://ledgerhq.atlassian.net/browse/LIVE-36317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[LIVE-36446]: https://ledgerhq.atlassian.net/browse/LIVE-36446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ