### PR TITLE
[LWD] fix(counter-values): refresh desktop rates on resume (LIVE-36444)

### DIFF
--- a/.changeset/rapid-otters-focus.md
+++ b/.changeset/rapid-otters-focus.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Refresh desktop countervalues when the app regains focus or network connectivity.

--- a/apps/ledger-live-desktop/src/renderer/components/CountervaluesProvider.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/CountervaluesProvider.test.tsx
@@ -1,0 +1,109 @@
+import { useCountervaluesPolling } from "@ledgerhq/live-countervalues-react";
+import React, { type ReactNode } from "react";
+import { render } from "tests/testSetup";
+import { CountervaluesBridgedProvider } from "./CountervaluesProvider";
+
+jest.mock("@ledgerhq/live-countervalues-react", () => ({
+  ...jest.requireActual("@ledgerhq/live-countervalues-react"),
+  CountervaluesProvider: ({ children }: { children: ReactNode }) => children,
+  useCountervaluesPolling: jest.fn(),
+}));
+
+jest.mock("../actions/general", () => ({
+  useCalculateCountervaluesUserSettings: jest.fn(),
+}));
+
+const mockedUseCountervaluesPolling = jest.mocked(useCountervaluesPolling);
+type WindowEventName = "blur" | "focus" | "online";
+
+describe("CountervaluesBridgedProvider", () => {
+  const poll = jest.fn();
+  const start = jest.fn();
+  const stop = jest.fn();
+  let hasFocusSpy: jest.SpyInstance | undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseCountervaluesPolling.mockReturnValue({
+      poll,
+      start,
+      stop,
+      wipe: jest.fn(),
+      pending: false,
+      error: null,
+    });
+  });
+
+  afterEach(() => {
+    hasFocusSpy?.mockRestore();
+    hasFocusSpy = undefined;
+  });
+
+  function renderProvider() {
+    return render(
+      <CountervaluesBridgedProvider initialState={{ status: {} }}>
+        <div />
+      </CountervaluesBridgedProvider>,
+    );
+  }
+
+  function dispatchWindowEvent(eventName: WindowEventName) {
+    window.dispatchEvent(new Event(eventName));
+  }
+
+  it("should stop countervalue polling when the window blurs", () => {
+    renderProvider();
+
+    dispatchWindowEvent("blur");
+
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(start).not.toHaveBeenCalled();
+    expect(poll).not.toHaveBeenCalled();
+  });
+
+  it("should restart and refresh countervalues when the window focuses", () => {
+    renderProvider();
+
+    dispatchWindowEvent("focus");
+
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(poll).toHaveBeenCalledTimes(1);
+    expect(stop).not.toHaveBeenCalled();
+    expect(start.mock.invocationCallOrder[0]).toBeLessThan(poll.mock.invocationCallOrder[0]);
+  });
+
+  it("should refresh countervalues when the network returns to a focused window", () => {
+    hasFocusSpy = jest.spyOn(document, "hasFocus").mockReturnValue(true);
+    renderProvider();
+
+    dispatchWindowEvent("online");
+
+    expect(poll).toHaveBeenCalledTimes(1);
+    expect(start).not.toHaveBeenCalled();
+    expect(stop).not.toHaveBeenCalled();
+  });
+
+  it("should not refresh countervalues when the network returns to an unfocused window", () => {
+    hasFocusSpy = jest.spyOn(document, "hasFocus").mockReturnValue(false);
+    renderProvider();
+
+    dispatchWindowEvent("online");
+
+    expect(poll).not.toHaveBeenCalled();
+    expect(start).not.toHaveBeenCalled();
+    expect(stop).not.toHaveBeenCalled();
+  });
+
+  it("should remove window listeners when unmounted", () => {
+    const { unmount } = renderProvider();
+    unmount();
+
+    dispatchWindowEvent("blur");
+    dispatchWindowEvent("focus");
+    dispatchWindowEvent("online");
+
+    expect(stop).not.toHaveBeenCalled();
+    expect(start).not.toHaveBeenCalled();
+    expect(poll).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/components/CountervaluesProvider.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/CountervaluesProvider.tsx
@@ -94,13 +94,25 @@ function useCacheManager() {
 }
 
 function usePollingManager() {
-  const { start, stop } = useCountervaluesPolling();
+  const { poll, start, stop } = useCountervaluesPolling();
   useEffect(() => {
+    const handleFocus = () => {
+      start();
+      poll();
+    };
+    const handleOnline = () => {
+      if (document.hasFocus()) {
+        poll();
+      }
+    };
+
     window.addEventListener("blur", stop);
-    window.addEventListener("focus", start);
+    window.addEventListener("focus", handleFocus);
+    window.addEventListener("online", handleOnline);
     return () => {
       window.removeEventListener("blur", stop);
-      window.removeEventListener("focus", start);
+      window.removeEventListener("focus", handleFocus);
+      window.removeEventListener("online", handleOnline);
     };
-  }, [start, stop]);
+  }, [poll, start, stop]);
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Added five renderer lifecycle tests for blur, focus, online while focused, online while unfocused, and listener cleanup.
- [x] **Impact of the changes:**
      QA should verify that Desktop refreshes portfolio countervalues immediately after refocusing the window and after network recovery while focused.

### 📝 Description

Desktop could resume its countervalue polling loop after a focus change without immediately requesting new rates, leaving portfolio values stale until the next scheduled poll or a manual refresh.

This PR triggers an immediate countervalue poll on window focus and on network recovery when the renderer is focused. Background polling remains stopped while the window is blurred.

https://github.com/user-attachments/assets/dd9bf41a-2496-4ce5-9094-db2d6d02b387


https://github.com/user-attachments/assets/25e3308c-40dd-4e7d-9fdc-3f83fca9e9a9


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-36444

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)