### PR TITLE
[LWD] fix(market-banner): handle null market change percentages

### DIFF
--- a/.changeset/strange-turtles-occur.md
+++ b/.changeset/strange-turtles-occur.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix Market Banner crash when a price-change percentage is missing. The desktop trending tile now uses `getChangePercentage` like mobile, which treats null or undefined values as 0 instead of calling `.toFixed` on them.

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/PerformanceIndicator.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/PerformanceIndicator.test.tsx
@@ -1,36 +1,37 @@
 import React from "react";
 import { render, screen } from "tests/testSetup";
+import { createMockMarketPerformer } from "@ledgerhq/live-common/market/utils/fixtures";
 import { PerformanceIndicator } from "../components/PerformanceIndicator";
 
 describe("PerformanceIndicator", () => {
   it("should render positive percentage with + sign and success color", () => {
-    const value = { priceChangePercentage24h: 5.234 };
-    const { container } = render(<PerformanceIndicator value={value} />);
+    const item = createMockMarketPerformer({ priceChangePercentage24h: 5.234 });
+    const { container } = render(<PerformanceIndicator item={item} />);
 
-    expect(screen.getByText("+5.23%")).toBeInTheDocument();
+    expect(screen.getByText("+5.23%")).toBeVisible();
     expect(container.firstChild).toHaveClass("text-success");
   });
 
   it("should render negative percentage without + sign and error color", () => {
-    const value = { priceChangePercentage24h: -3.456 };
-    const { container } = render(<PerformanceIndicator value={value} />);
+    const item = createMockMarketPerformer({ priceChangePercentage24h: -3.456 });
+    const { container } = render(<PerformanceIndicator item={item} />);
 
-    expect(screen.getByText("-3.46%")).toBeInTheDocument();
+    expect(screen.getByText("-3.46%")).toBeVisible();
     expect(container.firstChild).toHaveClass("text-error");
   });
 
-  it("should render zero percentage with + sign and success color", () => {
-    const value = { priceChangePercentage24h: 0 };
-    const { container } = render(<PerformanceIndicator value={value} />);
+  it("should render zero percentage with + sign and neutral color", () => {
+    const item = createMockMarketPerformer({ priceChangePercentage24h: 0 });
+    const { container } = render(<PerformanceIndicator item={item} />);
 
-    expect(screen.getByText("+0.00%")).toBeInTheDocument();
-    expect(container.firstChild).toHaveClass("text-success");
+    expect(screen.getByText("+0.00%")).toBeVisible();
+    expect(container.firstChild).toHaveClass("text-muted");
   });
 
   it("should format percentage to 2 decimal places", () => {
-    const value = { priceChangePercentage24h: 12.3456789 };
-    render(<PerformanceIndicator value={value} />);
+    const item = createMockMarketPerformer({ priceChangePercentage24h: 12.3456789 });
+    render(<PerformanceIndicator item={item} />);
 
-    expect(screen.getByText("+12.35%")).toBeInTheDocument();
+    expect(screen.getByText("+12.35%")).toBeVisible();
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/PerformanceIndicator.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/PerformanceIndicator.tsx
@@ -1,17 +1,26 @@
 import React from "react";
+import { TIME_RANGE } from "@ledgerhq/live-common/market/constants";
+import { getChangePercentage } from "@ledgerhq/live-common/market/utils/index";
 import { MarketItemPerformer } from "@ledgerhq/live-common/market/utils/types";
+import { trendPercentageBody3Styles } from "LLD/shared/trendPercentageStyles";
 
 type PerformanceIndicatorProps = {
-  value: Pick<MarketItemPerformer, "priceChangePercentage24h">;
+  item: MarketItemPerformer;
 };
 
-export const PerformanceIndicator = ({ value }: PerformanceIndicatorProps) => {
-  const textColorClass = value.priceChangePercentage24h >= 0 ? "text-success" : "text-error";
+export const PerformanceIndicator = ({ item }: PerformanceIndicatorProps) => {
+  const change = getChangePercentage(item, TIME_RANGE);
+
+  if (!Number.isFinite(change)) {
+    return <div className={trendPercentageBody3Styles({ variant: "neutral" })}>—</div>;
+  }
+
+  const variant = change > 0 ? "positive" : change < 0 ? "negative" : "neutral";
 
   return (
-    <div className={`${textColorClass} body-3`}>
-      {value.priceChangePercentage24h >= 0 ? "+" : ""}
-      {value.priceChangePercentage24h.toFixed(2)}%
+    <div className={trendPercentageBody3Styles({ variant })}>
+      {change >= 0 ? "+" : ""}
+      {change.toFixed(2)}%
     </div>
   );
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/TrendingAssetTile.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/TrendingAssetTile.tsx
@@ -37,7 +37,7 @@ const TrendingAssetTileComponent = ({ item, onNavigate }: TrendingAssetTileProps
       <Spot size={40} appearance="icon" icon={renderIcon} />
       <TileContent>
         <TileTitle>{capitalizedTicker}</TileTitle>
-        <PerformanceIndicator value={item} />
+        <PerformanceIndicator item={item} />
       </TileContent>
     </Tile>
   );


### PR DESCRIPTION
### 📝 Description

The desktop Market Banner trending tile crashed when a price-change percentage was missing. `PerformanceIndicator` read `item.priceChangePercentage24h` and called `.toFixed(2)` on it directly, so a `null` coming from the markets API (which can happen even when `price` is present) threw at render.

**Fix:**
- `PerformanceIndicator` now reads the percentage through `getChangePercentage(item, TIME_RANGE)` from `@ledgerhq/live-common`, the same helper the mobile `MarketTile` already uses. Missing values fall back to `0` instead of throwing, so both apps stay consistent.
- Non-finite values (`NaN`, `Infinity`) render a neutral `—` placeholder rather than `NaN%`.
- Colors go through the shared `trendPercentageBody3Styles` variants instead of a hand-rolled class string. Side effect: an exact `0%` is now neutral (muted) instead of green, matching the Asset detail pages.
- Tests use the shared `createMockMarketPerformer` fixture and `toBeVisible()`.

No changes in `@ledgerhq/live-common`: `getChangePercentage` already handled `null` and `undefined`. Scope is desktop only.

https://github.com/user-attachments/assets/7876517a-9166-4140-9b88-39e9b61afaeb

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36454](https://ledgerhq.atlassian.net/browse/LIVE-36454)
- **ADR** (if any): N/A


[LIVE-36454]: https://ledgerhq.atlassian.net/browse/LIVE-36454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ