### PR TITLE
fix(pay-card): forget the cached user when a 401 ends the session

### DIFF
--- a/.changeset/pay-card-forget-user-on-session-end.md
+++ b/.changeset/pay-card-forget-user-on-session-end.md
@@ -1,0 +1,11 @@
+---
+"@features/flow-pay-card-auth": patch
+---
+
+Forget the cached Card user when a 401 ends the session, not only on an explicit logout.
+
+- The logout already dispatched `resetApiState()`; the involuntary path cleared the keychain session
+  and left the RTK cache behind.
+- That cache holds the holder name, PAN last 4 and verification state, so the next person to sign in
+  on the device could be served the previous holder's data before a refetch landed.
+- `forgetUser` is now a login port too, called wherever the session is cleared.

--- a/features/flow/pay-card-auth/src/state/__tests__/machine.native.test.ts
+++ b/features/flow/pay-card-auth/src/state/__tests__/machine.native.test.ts
@@ -34,6 +34,7 @@ function stubPorts(overrides: Partial<Ports> = {}): Ports {
     hasSession: jest.fn(async () => false),
     persistSession: jest.fn(async () => undefined),
     clearSession: jest.fn(async () => undefined),
+    forgetUser: jest.fn(),
     exchangeAuthorizationCode: jest.fn(async () => session),
     getUser: jest.fn(async () => user),
     setSignedIn: jest.fn(),
@@ -327,6 +328,28 @@ describe("cardLoginMachine failures", () => {
     await settledAt(actor, "idle");
     expect(ports.clearSession).toHaveBeenCalledTimes(1);
     expect(actor.getSnapshot().context.errorKind).toBeNull();
+  });
+
+  it("forgets the cached user when a 401 ends the session", async () => {
+    const ports = stubPorts({
+      hasSession: jest.fn(async () => true),
+      getUser: jest.fn(async () => Promise.reject({ status: 401 })),
+    });
+
+    const actor = start(ports);
+
+    await settledAt(actor, "idle");
+    expect(ports.forgetUser).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the cached user when the attempt is cleared without ending the session", async () => {
+    const ports = stubPorts();
+
+    const actor = start(ports);
+    await settledAt(actor, "idle");
+
+    expect(ports.clearSession).not.toHaveBeenCalled();
+    expect(ports.forgetUser).not.toHaveBeenCalled();
   });
 
   it("does not bounce back to authenticated after a 401 on a resumed session", async () => {

--- a/features/flow/pay-card-auth/src/state/actors.ts
+++ b/features/flow/pay-card-auth/src/state/actors.ts
@@ -122,6 +122,7 @@ export const clearAttempt = fromPromise(
     await input.ports.clearAttempt().catch(() => undefined);
     if (input.clearSession) {
       await input.ports.clearSession().catch(() => undefined);
+      input.ports.forgetUser();
     }
   },
 );

--- a/features/flow/pay-card-auth/src/state/createCardLoginPorts.ts
+++ b/features/flow/pay-card-auth/src/state/createCardLoginPorts.ts
@@ -33,6 +33,9 @@ export function createCardLoginPorts({
     hasSession: async () => Boolean(await getCardSessionToken()),
     persistSession: session => cardSession.set(session),
     clearSession: () => cardSession.clear(),
+    forgetUser: () => {
+      dispatch(cardManagementApi.util.resetApiState());
+    },
     exchangeAuthorizationCode: request =>
       dispatch(cardManagementApi.endpoints.exchangeAuthorizationCode.initiate(request)).unwrap(),
     getUser: async () => {

--- a/features/flow/pay-card-auth/src/state/types.ts
+++ b/features/flow/pay-card-auth/src/state/types.ts
@@ -86,6 +86,8 @@ export type CardLoginPorts = Readonly<{
   hasSession: () => Promise<boolean>;
   persistSession: (session: PayCardSession) => Promise<void>;
   clearSession: () => Promise<void>;
+  /** Removes the cached Card user, so no other screen shows whoever just left. */
+  forgetUser: () => void;
   exchangeAuthorizationCode: (request: PayCardAuthorizationCodeRequest) => Promise<PayCardSession>;
   /** Fills the RTK Query cache, so every other screen sees the user too. */
   getUser: () => Promise<PayCardUser>;


### PR DESCRIPTION
<!-- stac-man:stack-start -->
**Stack** _(managed by [stac-man](https://github.com/bluegardenproject/stac-man))_

- #20999 feat/LIVE-34773-card-wallet-endpoints
- #21000 feat/LIVE-34772-card-linked-wallet-balances
- **#21115 fix/pay-card-forget-user-on-session-end ← this PR**
- #21163 feat/LIVE-34784-card-freeze-unfreeze
<!-- stac-man:stack-end -->

The logout ports already dispatch `resetApiState()`, but a session that ends on
a 401 only cleared the keychain. The RTK cache it filled stayed: `getUser` holds
the id and verification state, `getCardStatus` the holder name, PAN last 4 and
expiry. With no custom `keepUnusedDataFor`, RTK keeps those entries for 60s
after the last subscriber and indefinitely while the Pay tab is mounted, so the
next person to sign in on the device can be served the previous holder's data
before the refetch lands.

`forgetUser` becomes a login port as well, mirroring the logout side rather than
folding the reset into `clearSession` — ending a session and forgetting who held
it stay two separate statements of intent.