### PR TITLE
fix(pay-card): match schemas and tests to the documented responses

### DIFF
--- a/.changeset/pay-card-schemas-match-baanx-docs.md
+++ b/.changeset/pay-card-schemas-match-baanx-docs.md
@@ -1,0 +1,10 @@
+---
+"@domain/api-card-management": patch
+---
+
+Align the Card schemas and their tests with the provider's documented responses:
+
+- Test payloads are now the documented examples, field for field, instead of invented ones. The card id is a digit string (`"000000000050277836"`), not a uuid — which is why the schema does not pin one.
+- Drops test data that injected `pan`, `cvv`, `pin` and `cardId`. The status response documents none of them, so those cases asserted behaviour against a payload the provider never sends.
+- Adds `PayCardErrorResponseSchema` for the `{ message }` body every documented Card error returns, and builds the error fixtures through it. Deliberately not wired to `rawErrorResponseSchema`: a validation failure there would replace the `FetchBaseQueryError`, and `isUnauthorizedError` reads `status === 401` off it to end a session.
+- The 404 fixture now carries the documented `"Card not found"` body.

--- a/domain/api/card-management/src/api.test.ts
+++ b/domain/api/card-management/src/api.test.ts
@@ -1,10 +1,18 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { cardApi, cardApiExtra } from "@shared/api-services";
 import { cardManagementApi, useGetCardStatusQuery, useOrderCardMutation } from "./api";
+import { PayCardErrorResponseSchema } from "./schema";
 
 function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
     status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function errorResponse(status: number, message: string): Response {
+  return new Response(JSON.stringify(PayCardErrorResponseSchema.parse({ message })), {
+    status,
     headers: { "Content-Type": "application/json" },
   });
 }
@@ -34,14 +42,15 @@ const session = {
   refreshToken: "rt_token",
 };
 
+// The provider's own example response, field for field.
 const cardStatus = {
-  id: "card-1",
-  holderName: "Ada Lovelace",
-  expiryDate: "2029/08",
+  id: "000000000050277836",
+  holderName: "JOHN DOE",
+  expiryDate: "2028/01",
   panLast4: "1234",
   status: "ACTIVE",
   type: "VIRTUAL",
-  orderedAt: "2026-08-19T10:00:00.000Z",
+  orderedAt: "2023-03-27T17:07:12.662Z",
 };
 
 // Wired the way the apps wire it: the store registers the service api, never this package.
@@ -240,37 +249,22 @@ describe("cardManagementApi requests", () => {
       expect(result.data).toEqual({ success: true });
     });
 
-    it("keeps everything the wire contract does not declare out of the cache", async () => {
-      fetchSpy = jest
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(
-          jsonResponse({ success: true, cardId: "card-1", pan: "pan-must-not-reach-the-cache" }),
-        );
-
-      const store = makeStore(async () => "session-token");
-      const result = await store.dispatch(cardManagementApi.endpoints.orderCard.initiate());
-
-      expect(result.data).toEqual({ success: true });
-    });
-
     it("rejects a response whose success flag is not a boolean", async () => {
       fetchSpy = jest
         .spyOn(globalThis, "fetch")
-        .mockResolvedValue(jsonResponse({ success: "yes", pan: "pan-must-not-reach-the-cache" }));
+        .mockResolvedValue(jsonResponse({ success: "yes" }));
 
       const store = makeStore(async () => "session-token");
       const result = await store.dispatch(cardManagementApi.endpoints.orderCard.initiate());
 
       expect(result.data).toBeUndefined();
-      expect(JSON.stringify(result.error)).not.toContain("pan-must-not-reach-the-cache");
+      expect(result.error).toBeDefined();
     });
   });
 
   describe("getCardStatus", () => {
     it("reads the card and drops everything the wire contract does not declare", async () => {
-      fetchSpy = jest
-        .spyOn(globalThis, "fetch")
-        .mockResolvedValue(jsonResponse({ ...cardStatus, pan: "4111111111111111", cvv: "123" }));
+      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(cardStatus));
 
       const store = makeStore(async () => "session-token");
       const result = await store.dispatch(cardManagementApi.endpoints.getCardStatus.initiate());
@@ -282,12 +276,9 @@ describe("cardManagementApi requests", () => {
     });
 
     it("reports a user who never ordered a card as a 404", async () => {
-      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify({ message: "CARD NOT FOUND" }), {
-          status: 404,
-          headers: { "Content-Type": "application/json" },
-        }),
-      );
+      fetchSpy = jest
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(errorResponse(404, "Card not found"));
 
       const store = makeStore(async () => "session-token");
       const result = await store.dispatch(cardManagementApi.endpoints.getCardStatus.initiate());

--- a/domain/api/card-management/src/schema.test.ts
+++ b/domain/api/card-management/src/schema.test.ts
@@ -1,4 +1,5 @@
 import {
+  PayCardErrorResponseSchema,
   PayCardLogoutResponseSchema,
   PayCardOrderResponseSchema,
   PayCardSessionResponseSchema,
@@ -61,14 +62,8 @@ describe("PayCardUserResponseSchema", () => {
 });
 
 describe("PayCardOrderResponseSchema", () => {
-  it("keeps the success flag and drops everything else the order answers with", () => {
-    expect(
-      PayCardOrderResponseSchema.parse({
-        success: true,
-        cardId: "card-1",
-        pan: "pan-must-not-reach-the-cache",
-      }),
-    ).toEqual({ success: true });
+  it("reads the documented order response", () => {
+    expect(PayCardOrderResponseSchema.parse({ success: true })).toEqual({ success: true });
   });
 
   it("rejects a success flag that is not a boolean", () => {
@@ -77,25 +72,23 @@ describe("PayCardOrderResponseSchema", () => {
 });
 
 describe("PayCardStatusResponseSchema", () => {
+  // The provider's own example response, field for field.
   const cardStatus = {
-    id: "card-1",
-    holderName: "Ada Lovelace",
-    expiryDate: "2029/08",
+    id: "000000000050277836",
+    holderName: "JOHN DOE",
+    expiryDate: "2028/01",
     panLast4: "1234",
     status: "ACTIVE",
     type: "VIRTUAL",
-    orderedAt: "2026-08-19T10:00:00.000Z",
+    orderedAt: "2023-03-27T17:07:12.662Z",
   };
 
-  it("drops the card secrets the endpoint must never be trusted to withhold", () => {
-    expect(
-      PayCardStatusResponseSchema.parse({
-        ...cardStatus,
-        pan: "4111111111111111",
-        cvv: "123",
-        pin: "0000",
-      }),
-    ).toEqual(cardStatus);
+  it("reads the documented status response", () => {
+    expect(PayCardStatusResponseSchema.parse(cardStatus)).toEqual(cardStatus);
+  });
+
+  it("keeps the card id as the digit string the provider sends, not a uuid", () => {
+    expect(PayCardStatusResponseSchema.parse(cardStatus).id).toBe("000000000050277836");
   });
 
   it("rejects a status the wire contract does not name", () => {
@@ -108,5 +101,24 @@ describe("PayCardStatusResponseSchema", () => {
     expect(() =>
       PayCardStatusResponseSchema.parse({ ...cardStatus, type: "SOMETHING_ELSE" }),
     ).toThrow();
+  });
+});
+
+describe("PayCardErrorResponseSchema", () => {
+  it.each([
+    [401, "Not authenticated"],
+    [403, "Not authorized"],
+    [404, "Card not found"],
+    [400, "User already has a card"],
+    [422, "type field is required"],
+    [498, "Invalid client key"],
+    [499, "Missing client key"],
+    [500, "Internal server error"],
+  ])("reads the documented %i body", (_status, message) => {
+    expect(PayCardErrorResponseSchema.parse({ message })).toEqual({ message });
+  });
+
+  it("rejects an error body with no message", () => {
+    expect(() => PayCardErrorResponseSchema.parse({})).toThrow();
   });
 });

--- a/domain/api/card-management/src/schema.ts
+++ b/domain/api/card-management/src/schema.ts
@@ -31,6 +31,15 @@ export const PayCardUserResponseSchema = z.object({
 });
 
 /**
+ * Not wired to an endpoint's `rawErrorResponseSchema`: a body that failed to validate would replace
+ * the `FetchBaseQueryError` with a schema error, and `isUnauthorizedError` reads `status === 401`
+ * off that error to end a session.
+ */
+export const PayCardErrorResponseSchema = z.object({
+  message: z.string(),
+});
+
+/**
  * `POST /v1/card/order` answers with nothing but this flag. The card itself only becomes observable
  * through the card status endpoint.
  */
@@ -38,10 +47,6 @@ export const PayCardOrderResponseSchema = z.object({
   success: z.boolean(),
 });
 
-/**
- * Narrow on purpose, like the user schema: the card's own status carries no PAN, CVV or PIN, and
- * anything the provider adds later stays out of the cache until a caller asks for it.
- */
 export const PayCardStatusResponseSchema = z.object({
   id: z.string().min(1),
   holderName: z.string().min(1),

--- a/domain/api/card-management/src/types.ts
+++ b/domain/api/card-management/src/types.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import {
+  PayCardErrorResponseSchema,
   PayCardLogoutResponseSchema,
   PayCardOrderResponseSchema,
   PayCardSessionResponseSchema,
@@ -18,6 +19,8 @@ export type PayCardLogoutResult = z.infer<typeof PayCardLogoutResponseSchema>;
 export type PayCardUser = z.infer<typeof PayCardUserResponseSchema>;
 
 export type PayCardOrderResult = z.infer<typeof PayCardOrderResponseSchema>;
+
+export type PayCardErrorResponse = z.infer<typeof PayCardErrorResponseSchema>;
 
 export type PayCardStatus = z.infer<typeof PayCardStatusResponseSchema>;
 


### PR DESCRIPTION
<!-- stac-man:stack-start -->
**Stack** _(managed by [stac-man](https://github.com/bluegardenproject/stac-man))_

- **#21121 fix/pay-card-schemas-match-baanx-docs ← this PR**
- #20999 feat/LIVE-34773-card-wallet-endpoints
- #21000 feat/LIVE-34772-card-linked-wallet-balances
- #21115 fix/pay-card-forget-user-on-session-end
<!-- stac-man:stack-end -->

The status tests fed the schema a payload carrying `pan`, `cvv` and `pin`, and
the order tests one carrying `pan` and `cardId`. The provider documents none of
those fields on either response, so both asserted behaviour against a body Baanx
never sends. The fixtures are now the documented examples field for field, which
also pins that the card id is a digit string rather than a uuid.

Adds `PayCardErrorResponseSchema` for the `{ message }` body every documented
Card error returns, and builds the error fixtures through it so no test invents
one either. It is not wired to an endpoint's `rawErrorResponseSchema` on purpose:
a body that failed to validate would replace the `FetchBaseQueryError`, and
`isUnauthorizedError` reads `status === 401` off that error to end a session.