### PR TITLE
[LWD] fix(e2e): wait for local manifest validation

### DIFF
--- a/.changeset/stabilize-local-manifest-creation.md
+++ b/.changeset/stabilize-local-manifest-creation.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Stabilize local manifest creation in desktop Playwright tests.

--- a/apps/ledger-live-desktop/tests/specs/settings/modal-create-manifest.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/settings/modal-create-manifest.spec.ts
@@ -27,7 +27,7 @@ test("Settings", async ({ page }) => {
   });
 
   await test.step("create local manifest", async () => {
-    await expect(settingsPage.createLocalManifestButton).toBeEnabled();
+    await expect(settingsPage.createLocalManifestButton).toBeEnabled({ timeout: 60000 });
     await settingsPage.createLocalManifestButton.click();
     await expect(page.getByText("ReplaceAppName", { exact: true })).toBeVisible({ timeout: 60000 });
   });

--- a/apps/ledger-live-desktop/tests/specs/settings/modal-create-manifest.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/settings/modal-create-manifest.spec.ts
@@ -27,6 +27,7 @@ test("Settings", async ({ page }) => {
   });
 
   await test.step("create local manifest", async () => {
+    await expect(settingsPage.createLocalManifestButton).toBeEnabled();
     await settingsPage.createLocalManifestButton.click();
     await expect(page.getByText("ReplaceAppName", { exact: true })).toBeVisible({ timeout: 60000 });
   });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** The targeted Playwright scenario could not complete locally because develop cannot build with missing Contacts and Send imports; CI will validate it.
- [x] **Impact of the changes:**
      Wait for the local-manifest form to become valid before submitting it in the Desktop Playwright test.

### 📝 Description

Stabilizes local manifest creation by explicitly waiting for the Create button to be enabled before clicking it. The scenario retains its assertion on the newly created manifest, so it verifies the actual submission result.

### ❓ Context

- **JIRA or GitHub link**: Flake reported by the internal triage system after a successful retry; no stable failing GitHub Actions run is available.

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)