### PR TITLE
[LWDM] feat(env): make getEnv throw on missing injected definition

### DIFF
--- a/.changeset/silent-tiger-throw.md
+++ b/.changeset/silent-tiger-throw.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-env": minor
+---
+
+Make getEnv and getEnvDefault throw when the name is not in injected definitions

--- a/libs/env/src/env.test.ts
+++ b/libs/env/src/env.test.ts
@@ -50,10 +50,18 @@ describe("live-env guard", () => {
     expect(getEnv("MY_STR")).toBe("hello");
   });
 
+  it("throws for prototype-chain names not in definitions (e.g. toString)", () => {
+    injectDefinitions(testDefs);
+    expect(() => getEnv("toString")).toThrow(
+      `[live-env] "toString" is not in injected definitions`,
+    );
+  });
+
   it("injectDefinitions is idempotent (second call ignored)", () => {
     injectDefinitions(testDefs);
     injectDefinitions({ OTHER: { def: 99, parser: intParser, desc: "" } });
-    expect(getEnv("OTHER")).toBeUndefined();
+    // "OTHER" was not in the first injectDefinitions call; second call is ignored
+    expect(() => getEnv("OTHER")).toThrow(`[live-env] "OTHER" is not in injected definitions`);
   });
 });
 

--- a/libs/env/src/env.ts
+++ b/libs/env/src/env.ts
@@ -257,13 +257,13 @@ export const getAllEnvs = (): Record<string, unknown> => ({ ...configured().env 
 export function getEnv<K extends EnvName>(name: K): EnvTypes[K];
 export function getEnv(name: string): unknown;
 export function getEnv(name: string): unknown {
-  return configured().env[name];
+  return configured(name).env[name];
 }
 
 export function getEnvDefault<K extends EnvName>(name: K): EnvTypes[K];
 export function getEnvDefault(name: string): unknown;
 export function getEnvDefault(name: string): unknown {
-  return configured().defaults[name];
+  return configured(name).defaults[name];
 }
 
 export const isEnvDefault = (name: string): boolean => {

--- a/libs/env/src/state.ts
+++ b/libs/env/src/state.ts
@@ -49,8 +49,15 @@ export function injectDefinitions(defs: EnvDefs): void {
   g.__ledgerLiveEnvState = { definitions: defs, env: { ...defaults }, defaults };
 }
 
-export function configured(): State {
+export function configured(name?: string): State {
   if (g.__ledgerLiveEnvState === undefined)
     throw new Error("[live-env] Call injectDefinitions() before using live-env");
+  if (
+    name !== undefined &&
+    !Object.prototype.hasOwnProperty.call(g.__ledgerLiveEnvState.definitions, name)
+  )
+    throw new Error(
+      `[live-env] "${name}" is not in injected definitions. Add it to your injectDefinitions() call.`,
+    );
   return g.__ledgerLiveEnvState;
 }

--- a/libs/ledger-live-common/src/env.test.ts
+++ b/libs/ledger-live-common/src/env.test.ts
@@ -1,7 +1,7 @@
 import { getEnv } from "@shared/env";
 
 // @ts-expect-error – "yolo" is not a valid env key
-getEnv("yolo");
+if (false as boolean) getEnv("yolo");
 
 test("typecheck env", () => {
   expect(true).toBe(true);


### PR DESCRIPTION
### 📝 Description

`getEnv(name)` and `getEnvDefault(name)` previously returned `undefined` when `name` was absent from the definitions map — silently, with no error. This happened when `injectDefinitions()` was called with a partial set (e.g. coin-service calling it but missing some coin-module variables).

**Fix:** `configured(name?)` in `state.ts` now accepts an optional name and throws immediately if that name is not in `definitions`:

```ts
// state.ts
export function configured(name?: string): State {
  if (g.__ledgerLiveEnvState === undefined)
    throw new Error("[live-env] Call injectDefinitions() before using live-env");
  if (name !== undefined && !(name in g.__ledgerLiveEnvState.definitions))
    throw new Error(`[live-env] "${name}" is not in injected definitions. Add it to your injectDefinitions() call.`);
  return g.__ledgerLiveEnvState;
}
```

`getEnv` and `getEnvDefault` both pass `name` through to `configured(name)`. No behavioural change for correctly-configured environments.

**Effect:** any consumer (e.g. coin-service) that calls `injectDefinitions()` with an incomplete set will now get a loud throw at the first `getEnv` call — caught in CI rather than silently broken in production.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36458](https://ledgerhq.atlassian.net/browse/LIVE-36458)
- **ADR** (if any): N/A

[LIVE-36458]: https://ledgerhq.atlassian.net/browse/LIVE-36458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ