### PR TITLE
[LWM] fix(mobile): fix welcome screen flicker bug

### DIFF
--- a/.changeset/spotty-story-stepper.md
+++ b/.changeset/spotty-story-stepper.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix welcome screen story flicker: keep the stepper from snapping full before video durations load, rewind each story when it ends and when it comes on stage, and make the stepper follow playback even when the system asks for reduced motion

--- a/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/components/StoryProgressBar.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/components/StoryProgressBar.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import { View, StyleSheet } from "react-native";
 import Animated, {
   Easing,
+  ReduceMotion,
   useAnimatedStyle,
   useSharedValue,
   withTiming,
@@ -28,17 +29,30 @@ export function StoryProgressBar({
   const progress = useSharedValue(0);
 
   useEffect(() => {
-    progress.value = 0;
-    if (isActivated) {
-      progress.value = withTiming(100, { duration: durationMs, easing: Easing.linear });
+    // A completed story keeps a full bar, every other state starts from an empty one.
+    progress.value = isCompleted ? 100 : 0;
+
+    // durationMs is 0 until the video reports its length. Animating over 0ms would
+    // snap the bar to full, then restart it once the real duration arrives.
+    if (isActivated && !isCompleted && durationMs > 0) {
+      progress.value = withTiming(100, {
+        duration: durationMs,
+        easing: Easing.linear,
+        // The bar mirrors the video playing behind it, so it has to run even when the
+        // system asks for less motion: withTiming would otherwise jump straight to full.
+        reduceMotion: ReduceMotion.Never,
+      });
     }
   }, [durationMs, isActivated, isCompleted, progress, restartKey]);
 
+  // The width comes from the shared value alone: mixing props into the worklet makes it
+  // re-register on every story change, and the bar then keeps the previous story's width
+  // until that lands.
   const animatedStyles = useAnimatedStyle(() => {
     return {
-      width: isCompleted ? "100%" : `${progress.value}%`,
+      width: `${progress.value}%`,
     };
-  }, [progress, isCompleted]);
+  }, [progress]);
 
   return (
     <View style={styles.container} testID="welcome-progress-bar">

--- a/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/components/VideoBackground.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/components/VideoBackground.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import { StyleSheet, View } from "react-native";
 import { useTranslation } from "~/context/Locale";
 import Video, { OnLoadData, ReactVideoSource, VideoRef } from "react-native-video";
@@ -29,19 +29,34 @@ export function VideoBackground({
 }: Readonly<VideoBackgroundProps>) {
   const { t } = useTranslation();
   const videoRef = useRef<VideoRef | null>(null);
+  const hasLoadedRef = useRef(false);
   const videoMounted = !useIsAppInBackground();
 
-  useEffect(() => {
-    if (!isOnStage) {
-      videoRef.current?.seek(0);
-    }
-  }, [isOnStage]);
+  const handleLoad = useCallback(
+    (data: OnLoadData) => {
+      hasLoadedRef.current = true;
+      onVideoLoad?.(data);
+    },
+    [onVideoLoad],
+  );
 
+  // Rewind on entering the stage rather than on leaving it: a hidden player can drop a
+  // seek it was asked to perform, which would resume the story mid-clip on the next visit.
+  // A player that has not loaded yet is already at its first frame, and seeking it before
+  // it is ready leaves it stalled on a blank frame.
   useEffect(() => {
-    if (isOnStage && restartKey > 0) {
+    if (isOnStage && hasLoadedRef.current) {
       videoRef.current?.seek(0);
     }
   }, [isOnStage, restartKey]);
+
+  const handleEnd = useCallback(() => {
+    if (!isOnStage) return;
+    // Rewind while the player is still visible: a player left on its last frame reports the
+    // end again as soon as it is resumed, which skips the story on the next lap.
+    videoRef.current?.seek(0);
+    onVideoEnd?.();
+  }, [isOnStage, onVideoEnd]);
 
   return (
     <View style={[styles.container, { display: isOnStage ? "flex" : "none" }]}>
@@ -54,10 +69,8 @@ export function VideoBackground({
           repeat={!isOnStage}
           source={videoSource}
           style={[styles.backgroundVideo]}
-          onLoad={onVideoLoad}
-          onEnd={() => {
-            if (isOnStage) onVideoEnd?.();
-          }}
+          onLoad={handleLoad}
+          onEnd={handleEnd}
           paused={!isOnStage}
         />
       )}

--- a/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/components/VideoBackground.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/components/VideoBackground.tsx
@@ -40,6 +40,11 @@ export function VideoBackground({
     [onVideoLoad],
   );
 
+  useEffect(() => {
+    if (videoMounted) return;
+    hasLoadedRef.current = false;
+  }, [videoMounted]);
+
   // Rewind on entering the stage rather than on leaving it: a hidden player can drop a
   // seek it was asked to perform, which would resume the story mid-clip on the next visit.
   // A player that has not loaded yet is already at its first frame, and seeking it before

--- a/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/components/__tests__/StoryProgressBar.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/components/__tests__/StoryProgressBar.test.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { render } from "@tests/test-renderer";
+import { ReduceMotion } from "react-native-reanimated";
+import { StoryProgressBar } from "../StoryProgressBar";
+
+const mockWithTiming = jest.fn((value: unknown, _config?: unknown) => value);
+
+type SharedValueMock = { value: number; writes: number[] };
+const sharedValues: SharedValueMock[] = [];
+
+jest.mock("react-native-reanimated", () => {
+  const actualReanimated = jest.requireActual("react-native-reanimated");
+  const ReactActual = jest.requireActual<typeof import("react")>("react");
+
+  return {
+    ...actualReanimated,
+    __esModule: true,
+    // Keeps the value across renders, and records every write so tests can tell an empty
+    // bar being filled apart from a bar that was full all along.
+    useSharedValue: (initial: number) => {
+      const sharedValueRef = ReactActual.useRef<SharedValueMock | null>(null);
+
+      if (!sharedValueRef.current) {
+        const writes = [initial];
+        sharedValueRef.current = {
+          get value() {
+            return writes[writes.length - 1];
+          },
+          set value(newValue: number) {
+            writes.push(newValue);
+          },
+          writes,
+        };
+        sharedValues.push(sharedValueRef.current);
+      }
+
+      return sharedValueRef.current;
+    },
+    useAnimatedStyle: () => ({}),
+    withTiming: (value: unknown, config?: unknown) => mockWithTiming(value, config),
+  };
+});
+
+describe("StoryProgressBar", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sharedValues.length = 0;
+  });
+
+  it("should not fill the bar while the story duration is unknown", () => {
+    render(<StoryProgressBar durationMs={0} isActivated />);
+
+    expect(mockWithTiming).not.toHaveBeenCalled();
+    expect(sharedValues[0].value).toBe(0);
+  });
+
+  it("should fill the bar over the story duration once it is known", () => {
+    const { rerender } = render(<StoryProgressBar durationMs={0} isActivated />);
+
+    rerender(<StoryProgressBar durationMs={4567} isActivated />);
+
+    expect(mockWithTiming).toHaveBeenCalledTimes(1);
+    expect(mockWithTiming).toHaveBeenCalledWith(100, expect.objectContaining({ duration: 4567 }));
+  });
+
+  it("should fill the bar over the story duration even when the system asks for less motion", () => {
+    render(<StoryProgressBar durationMs={4567} isActivated />);
+
+    expect(mockWithTiming).toHaveBeenCalledWith(
+      100,
+      expect.objectContaining({ reduceMotion: ReduceMotion.Never }),
+    );
+  });
+
+  it("should keep a completed bar full instead of emptying it", () => {
+    const { rerender } = render(<StoryProgressBar durationMs={4567} isActivated />);
+
+    expect(sharedValues[0].value).toBe(100);
+
+    rerender(<StoryProgressBar durationMs={4567} isCompleted />);
+
+    expect(sharedValues[0].value).toBe(100);
+  });
+
+  it("should empty the bar of a story that is neither playing nor completed", () => {
+    const { rerender } = render(<StoryProgressBar durationMs={4567} isCompleted />);
+
+    rerender(<StoryProgressBar durationMs={4567} />);
+
+    expect(sharedValues[0].value).toBe(0);
+  });
+
+  it("should empty the bar before replaying a completed story", () => {
+    const { rerender } = render(<StoryProgressBar durationMs={4567} isCompleted />);
+
+    expect(mockWithTiming).not.toHaveBeenCalled();
+    expect(sharedValues[0].value).toBe(100);
+
+    rerender(<StoryProgressBar durationMs={4567} isActivated />);
+
+    expect(mockWithTiming).toHaveBeenCalledWith(100, expect.objectContaining({ duration: 4567 }));
+    // The animation must start from an empty bar, otherwise the story plays behind a full one.
+    expect(sharedValues[0].writes).toEqual([0, 100, 0, 100]);
+  });
+
+  it("should replay the bar when the active story is restarted", () => {
+    const { rerender } = render(<StoryProgressBar durationMs={4567} isActivated restartKey={0} />);
+
+    rerender(<StoryProgressBar durationMs={4567} isActivated restartKey={1} />);
+
+    expect(mockWithTiming).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/components/__tests__/VideoBackground.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/components/__tests__/VideoBackground.test.tsx
@@ -5,6 +5,7 @@ import videoSources from "../../assets";
 import { VideoBackground } from "../VideoBackground";
 
 const mockSeek = jest.fn();
+const mockUseIsAppInBackground = jest.fn(() => false);
 const mockPlayer: { onLoad?: (data: OnLoadData) => void; onEnd?: () => void } = {};
 
 jest.mock("react-native-video", () => {
@@ -24,10 +25,9 @@ jest.mock("react-native-video", () => {
   return { __esModule: true, default: Video };
 });
 
-// AppState is not "active" under Jest, which would keep the player unmounted.
 jest.mock("~/components/useIsAppInBackground", () => ({
   __esModule: true,
-  default: () => false,
+  default: () => mockUseIsAppInBackground(),
 }));
 
 const baseProps = {
@@ -46,6 +46,7 @@ function endVideo() {
 describe("VideoBackground", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseIsAppInBackground.mockReturnValue(false);
   });
 
   it("should not rewind a story whose player has not loaded yet", () => {
@@ -87,6 +88,20 @@ describe("VideoBackground", () => {
 
     expect(mockSeek).toHaveBeenCalledWith(0);
     expect(onVideoEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not rewind after the player remounts until it has loaded again", () => {
+    const { rerender } = render(<VideoBackground {...baseProps} isOnStage restartKey={0} />);
+    loadVideo();
+    mockSeek.mockClear();
+
+    mockUseIsAppInBackground.mockReturnValue(true);
+    rerender(<VideoBackground {...baseProps} isOnStage restartKey={0} />);
+
+    mockUseIsAppInBackground.mockReturnValue(false);
+    rerender(<VideoBackground {...baseProps} isOnStage restartKey={1} />);
+
+    expect(mockSeek).not.toHaveBeenCalled();
   });
 
   it("should ignore the end of a story that is not on stage", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/components/__tests__/VideoBackground.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/components/__tests__/VideoBackground.test.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { render } from "@tests/test-renderer";
+import type { OnLoadData } from "react-native-video";
+import videoSources from "../../assets";
+import { VideoBackground } from "../VideoBackground";
+
+const mockSeek = jest.fn();
+const mockPlayer: { onLoad?: (data: OnLoadData) => void; onEnd?: () => void } = {};
+
+jest.mock("react-native-video", () => {
+  const ReactActual = jest.requireActual<typeof import("react")>("react");
+  const { View } = jest.requireActual<typeof import("react-native")>("react-native");
+
+  const Video = ReactActual.forwardRef<
+    { seek: (time: number) => void },
+    { onLoad?: (data: OnLoadData) => void; onEnd?: () => void }
+  >((props, ref) => {
+    ReactActual.useImperativeHandle(ref, () => ({ seek: mockSeek }));
+    mockPlayer.onLoad = props.onLoad;
+    mockPlayer.onEnd = props.onEnd;
+    return ReactActual.createElement(View, { testID: "welcome-video" });
+  });
+
+  return { __esModule: true, default: Video };
+});
+
+// AppState is not "active" under Jest, which would keep the player unmounted.
+jest.mock("~/components/useIsAppInBackground", () => ({
+  __esModule: true,
+  default: () => false,
+}));
+
+const baseProps = {
+  videoSource: videoSources.welcomeBasic1,
+  titleKey: "onboarding.stepWelcome.videoTitles.0",
+};
+
+function loadVideo() {
+  mockPlayer.onLoad?.({ duration: 4.567 } as OnLoadData);
+}
+
+function endVideo() {
+  mockPlayer.onEnd?.();
+}
+
+describe("VideoBackground", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should not rewind a story whose player has not loaded yet", () => {
+    const { rerender } = render(<VideoBackground {...baseProps} isOnStage />);
+
+    rerender(<VideoBackground {...baseProps} isOnStage={false} />);
+    rerender(<VideoBackground {...baseProps} isOnStage />);
+
+    expect(mockSeek).not.toHaveBeenCalled();
+  });
+
+  it("should play the story from its first frame when it enters the stage", () => {
+    const { rerender } = render(<VideoBackground {...baseProps} isOnStage />);
+    loadVideo();
+
+    rerender(<VideoBackground {...baseProps} isOnStage={false} />);
+    expect(mockSeek).not.toHaveBeenCalled();
+
+    rerender(<VideoBackground {...baseProps} isOnStage />);
+    expect(mockSeek).toHaveBeenCalledWith(0);
+  });
+
+  it("should replay the story when it is restarted while on stage", () => {
+    const { rerender } = render(<VideoBackground {...baseProps} isOnStage restartKey={0} />);
+    loadVideo();
+
+    rerender(<VideoBackground {...baseProps} isOnStage restartKey={1} />);
+
+    expect(mockSeek).toHaveBeenCalledTimes(1);
+    expect(mockSeek).toHaveBeenCalledWith(0);
+  });
+
+  it("should rewind the player when its story ends so the next lap plays it again", () => {
+    const onVideoEnd = jest.fn();
+    render(<VideoBackground {...baseProps} isOnStage onVideoEnd={onVideoEnd} />);
+    loadVideo();
+
+    endVideo();
+
+    expect(mockSeek).toHaveBeenCalledWith(0);
+    expect(onVideoEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("should ignore the end of a story that is not on stage", () => {
+    const onVideoEnd = jest.fn();
+    render(<VideoBackground {...baseProps} isOnStage={false} onVideoEnd={onVideoEnd} />);
+    loadVideo();
+
+    endVideo();
+
+    expect(mockSeek).not.toHaveBeenCalled();
+    expect(onVideoEnd).not.toHaveBeenCalled();
+  });
+
+  it("should forward the loaded duration to the caller", () => {
+    const onVideoLoad = jest.fn();
+    render(<VideoBackground {...baseProps} isOnStage onVideoLoad={onVideoLoad} />);
+
+    loadVideo();
+
+    expect(onVideoLoad).toHaveBeenCalledWith(expect.objectContaining({ duration: 4.567 }));
+  });
+});


### PR DESCRIPTION
This pull request addresses a flicker issue on the welcome screen stories by refining how the video story stepper and playback are synchronized. The changes ensure the progress bar reflects the actual video state, avoids premature animation, and that stories reliably rewind when they end or are revisited. Comprehensive tests have been added for these behaviors.

**Welcome screen story playback and progress improvements:**

* Prevent the story progress bar from snapping to full before the video duration is known, ensuring the bar animates only after the video reports its length. The bar now always follows video playback, even when the system requests reduced motion. [[1]](diffhunk://#diff-d965a726a473527bdf61020ce9c09939ca8e697c33040793338de70826879cb2R5) [[2]](diffhunk://#diff-d965a726a473527bdf61020ce9c09939ca8e697c33040793338de70826879cb2L31-R55)
* Ensure that each story rewinds to the beginning both when it ends and when it comes back on stage, preventing playback from resuming mid-clip or skipping stories on repeat. [[1]](diffhunk://#diff-a8f09e23bd7bfc346e659112870a6bb2c456374b43f4bab498474091f3be4155L1-R1) [[2]](diffhunk://#diff-a8f09e23bd7bfc346e659112870a6bb2c456374b43f4bab498474091f3be4155R32-R60) [[3]](diffhunk://#diff-a8f09e23bd7bfc346e659112870a6bb2c456374b43f4bab498474091f3be4155L57-R73)

**Testing enhancements:**

* Added robust tests for `StoryProgressBar` to verify correct animation behavior, bar filling, and response to playback state changes.
* Added comprehensive tests for `VideoBackground` to ensure correct rewinding, handling of video load/end events, and playback synchronization.

**Changelog:**

* Updated the changeset to document the bugfix and improvements for the welcome screen story stepper and playback.