### PR TITLE
[LWDM] chore(send): remove addressbook property from the coin descriptor

### DIFF
--- a/.changeset/sharp-brooms-grin.md
+++ b/.changeset/sharp-brooms-grin.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+chore(send): remove addressBook property from the coin descriptor

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useSendHeaderModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useSendHeaderModel.test.tsx
@@ -21,14 +21,11 @@ jest.mock("~/renderer/analytics/segment", () => ({
 }));
 jest.mock("LLD/hooks/redux");
 jest.mock("@features/platform-contacts", () => ({
-  useContactsFeature: jest.fn(() => ({ isEnabled: false })),
+  useContactsFeature: jest.fn(() => ({ isEnabled: false, eligibleAddressFamilies: ["evm"] })),
 }));
 jest.mock("@ledgerhq/live-common/currencies/index", () => ({
   ...jest.requireActual("@ledgerhq/live-common/currencies/index"),
   decodeURIScheme: jest.fn(),
-}));
-jest.mock("@ledgerhq/live-common/bridge/descriptor/send/features", () => ({
-  sendFeatures: { hasAddressBook: jest.fn(() => false) },
 }));
 jest.mock("../../context/RecipientContactSelectionContext", () => ({
   useRecipientContactSelection: jest.fn(),
@@ -48,7 +45,6 @@ import { decodeURIScheme } from "@ledgerhq/live-common/currencies/index";
 import { RecipientScannerProvider } from "../../context/RecipientScannerContext";
 import { useSelector } from "LLD/hooks/redux";
 import { useContactsFeature } from "@features/platform-contacts";
-import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import { useRecipientContactSelection } from "../../context/RecipientContactSelectionContext";
 import { useAddNewContactHeaderState } from "../../context/AddNewContactHeaderContext";
 
@@ -221,19 +217,29 @@ describe("useSendHeaderModel", () => {
   describe("recipient input placeholder", () => {
     const renderOnRecipientStep = ({
       supportsDomain,
-      hasAddressBook,
       isContactsFeatureEnabled,
+      eligibleAddressFamilies = ["evm"],
     }: {
       supportsDomain: boolean;
-      hasAddressBook: boolean;
       isContactsFeatureEnabled: boolean;
+      eligibleAddressFamilies?: string[];
     }) => {
-      jest.mocked(sendFeatures.hasAddressBook).mockReturnValue(hasAddressBook);
-      (useContactsFeature as jest.Mock).mockReturnValue({ isEnabled: isContactsFeatureEnabled });
+      (useContactsFeature as jest.Mock).mockReturnValue({
+        isEnabled: isContactsFeatureEnabled,
+        eligibleAddressFamilies,
+      });
       mockActions();
       mockData(
         {
-          account: { currency: { ticker: "ETH", id: "ethereum" }, account: {} },
+          account: {
+            currency: {
+              type: "CryptoCurrency",
+              ticker: "ETH",
+              id: "ethereum",
+              family: "evm",
+            },
+            account: {},
+          },
           recipient: null,
           transaction: { status: {} },
         },
@@ -251,7 +257,6 @@ describe("useSendHeaderModel", () => {
     it("mentions contacts and ENS when the network supports both", () => {
       renderOnRecipientStep({
         supportsDomain: true,
-        hasAddressBook: true,
         isContactsFeatureEnabled: true,
       });
 
@@ -261,18 +266,17 @@ describe("useSendHeaderModel", () => {
     it("mentions contacts only when the network has no ENS support", () => {
       renderOnRecipientStep({
         supportsDomain: false,
-        hasAddressBook: true,
         isContactsFeatureEnabled: true,
       });
 
       expect(latestVM?.recipientPlaceholder).toBe("Enter address or contact");
     });
 
-    it("keeps the default placeholder when the network has no address book", () => {
+    it("keeps the default placeholder when the currency family is not eligible", () => {
       renderOnRecipientStep({
         supportsDomain: true,
-        hasAddressBook: false,
         isContactsFeatureEnabled: true,
+        eligibleAddressFamilies: ["bitcoin"],
       });
 
       expect(latestVM?.recipientPlaceholder).toBe("Enter address or ENS");
@@ -281,7 +285,6 @@ describe("useSendHeaderModel", () => {
     it("keeps the default placeholder when the contacts feature is disabled", () => {
       renderOnRecipientStep({
         supportsDomain: false,
-        hasAddressBook: true,
         isContactsFeatureEnabled: false,
       });
 
@@ -302,7 +305,10 @@ describe("useSendHeaderModel", () => {
       mockNavigation();
       mockActions();
       mockData({
-        account: { currency: { ticker: "ETH", id: "ethereum" }, account: {} },
+        account: {
+          currency: { type: "CryptoCurrency", ticker: "ETH", id: "ethereum", family: "evm" },
+          account: {},
+        },
         recipient: { address: ADDRESS },
         transaction: { status: {} },
       });
@@ -311,7 +317,10 @@ describe("useSendHeaderModel", () => {
     };
 
     it("shows the contact name when the recipient is a contact", () => {
-      (useContactsFeature as jest.Mock).mockReturnValue({ isEnabled: true });
+      (useContactsFeature as jest.Mock).mockReturnValue({
+        isEnabled: true,
+        eligibleAddressFamilies: ["evm"],
+      });
       jest.mocked(useSelector).mockReturnValue([CONTACT] as never);
 
       renderOnAmountStep();
@@ -324,7 +333,10 @@ describe("useSendHeaderModel", () => {
     });
 
     it("shows the formatted address when the recipient is not a contact", () => {
-      (useContactsFeature as jest.Mock).mockReturnValue({ isEnabled: true });
+      (useContactsFeature as jest.Mock).mockReturnValue({
+        isEnabled: true,
+        eligibleAddressFamilies: ["evm"],
+      });
       jest.mocked(useSelector).mockReturnValue([] as never);
 
       renderOnAmountStep();
@@ -334,7 +346,10 @@ describe("useSendHeaderModel", () => {
     });
 
     it("shows the formatted address when the contacts feature is disabled", () => {
-      (useContactsFeature as jest.Mock).mockReturnValue({ isEnabled: false });
+      (useContactsFeature as jest.Mock).mockReturnValue({
+        isEnabled: false,
+        eligibleAddressFamilies: ["evm"],
+      });
       jest.mocked(useSelector).mockReturnValue([CONTACT] as never);
 
       renderOnAmountStep();

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendHeaderModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendHeaderModel.ts
@@ -1,5 +1,4 @@
 import { SendFlowStep, SEND_FLOW_STEP } from "@ledgerhq/live-common/flows/send/types";
-import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import { decodeURIScheme } from "@ledgerhq/live-common/currencies/index";
 import { t } from "i18next";
 import { useMemo, useCallback, useRef } from "react";
@@ -7,6 +6,7 @@ import { useFlowWizard } from "../../FlowWizard/FlowWizardContext";
 import { getRecipientSearchPrefillValue } from "@ledgerhq/live-common/flows/send/utils";
 import { getRecipientHeaderPresentation } from "@ledgerhq/live-common/flows/send/recipient/utils/getRecipientHeaderPresentation";
 import type { RecipientHeaderContact } from "@ledgerhq/live-common/flows/send/recipient/utils/getRecipientHeaderPresentation";
+import { isEligibleAddressCurrency } from "@ledgerhq/live-common/flows/send/recipient/utils/isEligibleAddressCurrency";
 import { useContactsFeature } from "@features/platform-contacts";
 import { selectContacts } from "@domain/entity-contact";
 import { useSelector } from "LLD/hooks/redux";
@@ -70,7 +70,8 @@ export function useSendHeaderModel({
   const { isScannerOpen, closeScanner, toggleScanner } = useRecipientScanner();
   const { selectedContact, clearSelectedContact } = useRecipientContactSelection();
   const addNewContactHeader = useAddNewContactHeaderState();
-  const { isEnabled: isContactsFeatureEnabled } = useContactsFeature("desktop");
+  const { isEnabled: isContactsFeatureEnabled, eligibleAddressFamilies } =
+    useContactsFeature("desktop");
   const contacts = useSelector(selectContacts);
 
   const currencyName = state.account.currency?.ticker ?? "";
@@ -254,7 +255,8 @@ export function useSendHeaderModel({
   const transactionErrorName = transactionError?.name;
 
   const canSearchContacts =
-    isContactsFeatureEnabled && sendFeatures.hasAddressBook(state.account.currency ?? undefined);
+    isContactsFeatureEnabled &&
+    isEligibleAddressCurrency(eligibleAddressFamilies, state.account.currency ?? undefined);
   const recipientPlaceholder = t(
     getRecipientPlaceholderKey({
       supportsDomain: uiConfig.recipientSupportsDomain,

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/__integrations__/__fixtures__/accounts.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/__integrations__/__fixtures__/accounts.ts
@@ -11,12 +11,12 @@ import {
 type CurrencyOverrides = Partial<Omit<CryptoCurrency, "id">> & { id?: string };
 
 export const createMockCurrency = (overrides?: CurrencyOverrides): CryptoCurrency => {
-  const currency = getCryptoCurrencyById("bitcoin");
   const { id, ...rest } = overrides ?? {};
+  const currency = getCryptoCurrencyById(id ?? "bitcoin");
   return {
     ...currency,
-    ...(id !== undefined ? { id: CryptoCurrencyIdSchema.parse(id) } : {}),
     ...rest,
+    ...(id !== undefined ? { id: CryptoCurrencyIdSchema.parse(id) } : {}),
   };
 };
 
@@ -35,6 +35,7 @@ export const createMockTokenCurrency = (overrides?: Partial<TokenCurrency>): Tok
         magnitude: 6,
       },
     ],
+    parentCurrencyId: "ethereum",
     ...overrides,
   }) as TokenCurrency;
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientAddressModalViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientAddressModalViewModel.test.ts
@@ -31,7 +31,10 @@ jest.mock("../../../../../FlowWizard/FlowWizardContext", () => ({
 }));
 jest.mock("@ledgerhq/live-common/account/index");
 jest.mock("@ledgerhq/live-common/bridge/descriptor/send/features");
-jest.mock("@features/platform-contacts");
+jest.mock("@features/platform-contacts", () => ({
+  useContacts: jest.fn(),
+  useContactsFeature: jest.fn(),
+}));
 jest.mock("../../../../context/RecipientContactSelectionContext");
 jest.mock("~/renderer/reducers/wallet", () => ({
   useMaybeAccountName: jest.fn(),
@@ -48,7 +51,10 @@ const mockedUseContacts = jest.mocked(useContacts);
 const mockedUseContactsFeature = jest.mocked(useContactsFeature);
 const mockedUseRecipientContactSelection = jest.mocked(useRecipientContactSelection);
 
-const mockAccount = createMockAccount({ id: "account_1" });
+const mockAccount = createMockAccount({
+  id: "account_1",
+  currency: createMockCurrency({ id: "ethereum", family: "evm" }),
+});
 
 const mockRecipientSearch = {
   value: "",
@@ -95,7 +101,6 @@ describe("useRecipientAddressModalViewModel", () => {
       return account.type === "Account" ? account : parentAccount || mockAccount;
     });
     mockedSendFeatures.hasMemo.mockReturnValue(false);
-    mockedSendFeatures.hasAddressBook.mockReturnValue(false);
     mockedUseContacts.mockReturnValue([]);
     mockedUseContactsFeature.mockReturnValue({
       isEnabled: false,
@@ -142,8 +147,7 @@ describe("useRecipientAddressModalViewModel", () => {
     expect(result.current.showSearchResults).toBe(false);
   });
 
-  it("shows empty contacts state when address book is enabled and no contact matches the network", () => {
-    mockedSendFeatures.hasAddressBook.mockReturnValue(true);
+  it("shows empty contacts state when the contacts feature is enabled and no contact matches the network", () => {
     mockedUseContactsFeature.mockReturnValue({
       isEnabled: true,
       showNewBadge: false,
@@ -180,8 +184,7 @@ describe("useRecipientAddressModalViewModel", () => {
     );
   });
 
-  it("does not show empty contacts state when address book is not supported", () => {
-    mockedSendFeatures.hasAddressBook.mockReturnValue(false);
+  it("does not show empty contacts state when the currency family is not eligible", () => {
     mockedUseContactsFeature.mockReturnValue({
       isEnabled: true,
       showNewBadge: false,
@@ -206,7 +209,6 @@ describe("useRecipientAddressModalViewModel", () => {
   });
 
   it("does not show empty contacts state when a contact matches the network", () => {
-    mockedSendFeatures.hasAddressBook.mockReturnValue(true);
     mockedUseContactsFeature.mockReturnValue({
       isEnabled: true,
       showNewBadge: false,
@@ -242,7 +244,6 @@ describe("useRecipientAddressModalViewModel", () => {
   });
 
   it("only exposes saved contact addresses from the selected network", () => {
-    mockedSendFeatures.hasAddressBook.mockReturnValue(true);
     mockedUseContactsFeature.mockReturnValue({
       isEnabled: true,
       showNewBadge: false,
@@ -328,7 +329,6 @@ describe("useRecipientAddressModalViewModel", () => {
         mockContactAddress({ id: "address-2", address: "0x456", currencyId: "ethereum" }),
       ],
     });
-    mockedSendFeatures.hasAddressBook.mockReturnValue(true);
     mockedUseContactsFeature.mockReturnValue({
       isEnabled: true,
       showNewBadge: false,

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientAddressModalViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientAddressModalViewModel.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from "react";
 import { useContacts, useContactsFeature } from "@features/platform-contacts";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { isEligibleAddressCurrency } from "@ledgerhq/live-common/flows/send/recipient/utils/isEligibleAddressCurrency";
 import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import { useRecipientSearchState } from "@ledgerhq/live-common/flows/send/recipient/hooks/useRecipientSearchState";
 import { filterContactsByNetwork } from "@ledgerhq/live-common/flows/send/recipient/utils/filterContactsByNetwork";
@@ -35,12 +36,13 @@ export function useRecipientAddressModalViewModel({
 }: UseRecipientAddressModalViewModelProps) {
   const { recipientSearch, state } = useSendFlowData();
   const contacts = useContacts();
-  const { isEnabled: isContactsFeatureEnabled } = useContactsFeature("desktop");
+  const { isEnabled: isContactsFeatureEnabled, eligibleAddressFamilies } =
+    useContactsFeature("desktop");
   const { selectedContact, selectContact, clearSelectedContact } = useRecipientContactSelection();
   const { navigation } = useFlowWizard<SendFlowStep>();
 
   const mainAccount = getMainAccount(account, parentAccount);
-  const hasAddressBook = sendFeatures.hasAddressBook(currency);
+  const hasAddressBook = isEligibleAddressCurrency(eligibleAddressFamilies, currency);
   const sendFlowTrackingProperties = useMemo(
     () => getSendFlowTrackingProperties(account, parentAccount),
     [account, parentAccount],
@@ -155,7 +157,6 @@ export function useRecipientAddressModalViewModel({
   });
 
   const shouldHideRegularSearchState = showContactSearchResult || selectedContact !== undefined;
-  const addressBookFamilyName = mainAccount.currency.name;
   const addressMatchedSectionViewModel = useAddressMatchedSectionViewModel({
     searchResult: result,
     searchValue: recipientSearch.value,
@@ -166,7 +167,7 @@ export function useRecipientAddressModalViewModel({
     hasBridgeError: searchState.showBridgeRecipientError,
     isContactsFeatureEnabled,
     hasAddressBook,
-    addressBookFamilyName,
+    addressBookFamilyName: mainAccount.currency.name,
   });
 
   return {
@@ -188,8 +189,6 @@ export function useRecipientAddressModalViewModel({
     hasMemoValidationError,
     hasFilledMemo,
     isContactsFeatureEnabled,
-    hasAddressBook,
-    addressBookFamilyName,
     addressMatchedSectionViewModel,
     memoType,
     memoTypeOptions,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useSendHeaderViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useSendHeaderViewModel.test.ts
@@ -13,7 +13,6 @@ import { useCurrentSendFlowStep } from "../useCurrentSendFlowStep";
 import { useSendHeaderViewModel } from "../useSendHeaderViewModel";
 import { useSelector } from "~/context/hooks";
 import { useContactsFeature } from "@features/platform-contacts";
-import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import { mockContact } from "@domain/entity-contact/schema.mock";
 import { useRecipientContactSelection } from "../../context/RecipientContactSelectionContext";
 
@@ -34,12 +33,8 @@ jest.mock("../useAvailableBalance");
 jest.mock("../useCurrentSendFlowStep");
 jest.mock("~/context/hooks");
 jest.mock("@features/platform-contacts", () => ({
-  useContactsFeature: jest.fn(() => ({ isEnabled: false })),
+  useContactsFeature: jest.fn(() => ({ isEnabled: false, eligibleAddressFamilies: ["evm"] })),
 }));
-jest.mock("@ledgerhq/live-common/bridge/descriptor/send/features", () => ({
-  sendFeatures: { hasAddressBook: jest.fn(() => false) },
-}));
-
 const mockedUseNavigation = jest.mocked(useNavigation);
 const mockedUseMaybeAccountName = jest.mocked(useMaybeAccountName);
 const mockedUseSendFlowData = jest.mocked(useSendFlowData);
@@ -53,6 +48,9 @@ const mockAccount = {
   type: "Account",
   id: "base-account-1",
   currency: {
+    type: "CryptoCurrency",
+    id: "ethereum",
+    family: "evm",
     ticker: "ETH",
   },
   balance: new BigNumber(7_000_000),
@@ -298,17 +296,16 @@ describe("useSendHeaderViewModel", () => {
   describe("recipient input placeholder", () => {
     const mockRecipientStep = ({
       supportsDomain,
-      hasAddressBook,
       isContactsFeatureEnabled,
+      eligibleAddressFamilies = ["evm"],
     }: {
       supportsDomain: boolean;
-      hasAddressBook: boolean;
       isContactsFeatureEnabled: boolean;
+      eligibleAddressFamilies?: string[];
     }) => {
-      jest.mocked(sendFeatures.hasAddressBook).mockReturnValue(hasAddressBook);
       jest
         .mocked(useContactsFeature)
-        .mockReturnValue({ isEnabled: isContactsFeatureEnabled } as never);
+        .mockReturnValue({ isEnabled: isContactsFeatureEnabled, eligibleAddressFamilies } as never);
       mockedUseSendFlowData.mockReturnValue({
         uiConfig: { recipientSupportsDomain: supportsDomain },
         recipientSearch: mockRecipientSearch,
@@ -327,7 +324,6 @@ describe("useSendHeaderViewModel", () => {
     it("mentions contacts and ENS when the network supports both", () => {
       mockRecipientStep({
         supportsDomain: true,
-        hasAddressBook: true,
         isContactsFeatureEnabled: true,
       });
 
@@ -339,7 +335,6 @@ describe("useSendHeaderViewModel", () => {
     it("mentions contacts only when the network has no ENS support", () => {
       mockRecipientStep({
         supportsDomain: false,
-        hasAddressBook: true,
         isContactsFeatureEnabled: true,
       });
 
@@ -350,11 +345,11 @@ describe("useSendHeaderViewModel", () => {
       );
     });
 
-    it("keeps the default placeholder when the network has no address book", () => {
+    it("keeps the default placeholder when the currency family is not eligible", () => {
       mockRecipientStep({
         supportsDomain: true,
-        hasAddressBook: false,
         isContactsFeatureEnabled: true,
+        eligibleAddressFamilies: ["bitcoin"],
       });
 
       const { result } = renderHook(() => useSendHeaderViewModel());
@@ -365,7 +360,6 @@ describe("useSendHeaderViewModel", () => {
     it("keeps the default placeholder when the contacts feature is disabled", () => {
       mockRecipientStep({
         supportsDomain: false,
-        hasAddressBook: true,
         isContactsFeatureEnabled: false,
       });
 
@@ -411,7 +405,9 @@ describe("useSendHeaderViewModel", () => {
     };
 
     it("shows the contact name when the recipient is a contact", () => {
-      jest.mocked(useContactsFeature).mockReturnValue({ isEnabled: true } as never);
+      jest
+        .mocked(useContactsFeature)
+        .mockReturnValue({ isEnabled: true, eligibleAddressFamilies: ["evm"] } as never);
       jest.mocked(useSelector).mockReturnValue([CONTACT] as never);
       mockAmountStep();
 
@@ -425,7 +421,9 @@ describe("useSendHeaderViewModel", () => {
     });
 
     it("shows the formatted address when the recipient is not a contact", () => {
-      jest.mocked(useContactsFeature).mockReturnValue({ isEnabled: true } as never);
+      jest
+        .mocked(useContactsFeature)
+        .mockReturnValue({ isEnabled: true, eligibleAddressFamilies: ["evm"] } as never);
       jest.mocked(useSelector).mockReturnValue([] as never);
       mockAmountStep();
 
@@ -436,7 +434,9 @@ describe("useSendHeaderViewModel", () => {
     });
 
     it("shows the formatted address when the contacts feature is disabled", () => {
-      jest.mocked(useContactsFeature).mockReturnValue({ isEnabled: false } as never);
+      jest
+        .mocked(useContactsFeature)
+        .mockReturnValue({ isEnabled: false, eligibleAddressFamilies: ["evm"] } as never);
       jest.mocked(useSelector).mockReturnValue([CONTACT] as never);
       mockAmountStep();
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendHeaderViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendHeaderViewModel.ts
@@ -7,7 +7,6 @@ import { ScreenName } from "~/const";
 import type { BaseNavigationComposite } from "~/components/RootNavigator/types/helpers";
 
 import { SEND_FLOW_STEP } from "@ledgerhq/live-common/flows/send/types";
-import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import { useSendAmountDisplayMode } from "@ledgerhq/live-common/flows/send/amount/SendAmountDisplayModeContext";
 import {
   buildTransactionPatchFromURIScheme,
@@ -22,6 +21,7 @@ import {
 } from "@ledgerhq/live-common/flows/send/utils";
 import { getRecipientHeaderPresentation } from "@ledgerhq/live-common/flows/send/recipient/utils/getRecipientHeaderPresentation";
 import type { RecipientHeaderContact } from "@ledgerhq/live-common/flows/send/recipient/utils/getRecipientHeaderPresentation";
+import { isEligibleAddressCurrency } from "@ledgerhq/live-common/flows/send/recipient/utils/isEligibleAddressCurrency";
 import { useContactsFeature } from "@features/platform-contacts";
 import { selectContacts } from "@domain/entity-contact";
 import { useSelector } from "~/context/hooks";
@@ -73,7 +73,8 @@ export function useSendHeaderViewModel(): SendHeaderViewModel {
   const { close, transaction, setRecipientSearchValue, clearRecipientSearch } =
     useSendFlowActions();
   const { displayMode } = useSendAmountDisplayMode();
-  const { isEnabled: isContactsFeatureEnabled } = useContactsFeature("mobile");
+  const { isEnabled: isContactsFeatureEnabled, eligibleAddressFamilies } =
+    useContactsFeature("mobile");
   const contacts = useSelector(selectContacts);
   const { selectedContact, clearSelectedContact } = useRecipientContactSelection();
 
@@ -240,7 +241,8 @@ export function useSendHeaderViewModel(): SendHeaderViewModel {
   ]);
 
   const canSearchContacts =
-    isContactsFeatureEnabled && sendFeatures.hasAddressBook(state.account.currency ?? undefined);
+    isContactsFeatureEnabled &&
+    isEligibleAddressCurrency(eligibleAddressFamilies, state.account.currency ?? undefined);
   const recipientPlaceholder = t(
     getRecipientPlaceholderKey({
       supportsDomain: uiConfig.recipientSupportsDomain,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/__tests__/AddressMatchedSection.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/__tests__/AddressMatchedSection.test.tsx
@@ -182,7 +182,7 @@ describe("AddressMatchedSection", () => {
     expect(onSelect).toHaveBeenCalledWith(address, "vitalik.eth");
   });
 
-  it("keeps add contact enabled when the address book is supported", () => {
+  it("keeps add contact enabled when the contacts feature is enabled", () => {
     render(
       <AddressMatchedSectionContainer
         result={{

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/accounts.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/accounts.ts
@@ -19,8 +19,8 @@ type TokenCurrencyOverrides = Omit<Partial<TokenCurrency>, "id" | "parentCurrenc
 };
 
 export const createMockCurrency = (overrides?: CryptoCurrencyOverrides): CryptoCurrency => {
-  const currency = getCryptoCurrencyById("bitcoin");
   const { id: rawId, ...rest } = overrides ?? {};
+  const currency = getCryptoCurrencyById(rawId ?? "bitcoin");
   const id = rawId != null ? CryptoCurrencyIdSchema.parse(rawId) : currency.id;
   return {
     ...currency,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenContentViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenContentViewModel.test.ts
@@ -127,6 +127,7 @@ describe("useRecipientScreenContentViewModel", () => {
     });
     expect(mockedUseAddressMatchedSectionViewModel).toHaveBeenCalledWith(
       expect.objectContaining({
+        isContactsFeatureEnabled: true,
         hasAddressBook: false,
         addressBookFamilyName: "Bitcoin",
       }),

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenView.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenView.test.ts
@@ -4,7 +4,6 @@ import { useAddressValidation } from "../useAddressValidation";
 import { useClipboardRecipient } from "../useClipboardRecipient";
 import { useSendFlowData } from "../../../../context/SendFlowContext";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import { useContacts, useContactsFeature } from "@features/platform-contacts";
 import {
   InvalidAddress,
@@ -20,20 +19,24 @@ jest.mock("../useAddressValidation");
 jest.mock("../useClipboardRecipient");
 jest.mock("../../../../context/SendFlowContext");
 jest.mock("@ledgerhq/live-common/account/index");
-jest.mock("@ledgerhq/live-common/bridge/descriptor/send/features");
-jest.mock("@features/platform-contacts");
+jest.mock("@features/platform-contacts", () => ({
+  useContacts: jest.fn(),
+  useContactsFeature: jest.fn(),
+}));
 jest.mock("../../../../context/RecipientContactSelectionContext");
 
 const mockedUseAddressValidation = jest.mocked(useAddressValidation);
 const mockedUseClipboardRecipient = jest.mocked(useClipboardRecipient);
 const mockedUseSendFlowData = jest.mocked(useSendFlowData);
 const mockedGetMainAccount = jest.mocked(getMainAccount);
-const mockedSendFeatures = jest.mocked(sendFeatures);
 const mockedUseContacts = jest.mocked(useContacts);
 const mockedUseContactsFeature = jest.mocked(useContactsFeature);
 const mockedUseRecipientContactSelection = jest.mocked(useRecipientContactSelection);
 
-const mockAccount = createMockAccount({ id: "account_1" });
+const mockAccount = createMockAccount({
+  id: "account_1",
+  currency: createMockCurrency({ id: "ethereum", family: "evm" }),
+});
 
 const mockRecipientSearch = {
   value: "",
@@ -105,7 +108,6 @@ describe("useRecipientScreenView", () => {
       isLoading: false,
       validateAddress: jest.fn(),
     });
-    mockedSendFeatures.hasAddressBook.mockReturnValue(false);
     mockedUseContacts.mockReturnValue([]);
     mockedUseContactsFeature.mockReturnValue({
       isEnabled: false,
@@ -134,8 +136,7 @@ describe("useRecipientScreenView", () => {
     expect(result.current.showSearchResults).toBe(false);
   });
 
-  it("shows empty contacts state when address book is enabled and no contact matches the network", () => {
-    mockedSendFeatures.hasAddressBook.mockReturnValue(true);
+  it("shows empty contacts state when the contacts feature is enabled and no contact matches the network", () => {
     mockedUseContactsFeature.mockReturnValue({
       isEnabled: true,
       showNewBadge: false,
@@ -172,8 +173,7 @@ describe("useRecipientScreenView", () => {
     );
   });
 
-  it("does not show empty contacts state when address book is not supported", () => {
-    mockedSendFeatures.hasAddressBook.mockReturnValue(false);
+  it("does not show empty contacts state when the currency family is not eligible", () => {
     mockedUseContactsFeature.mockReturnValue({
       isEnabled: true,
       showNewBadge: false,
@@ -198,7 +198,6 @@ describe("useRecipientScreenView", () => {
   });
 
   it("does not show empty contacts state when a contact matches the network", () => {
-    mockedSendFeatures.hasAddressBook.mockReturnValue(true);
     mockedUseContactsFeature.mockReturnValue({
       isEnabled: true,
       showNewBadge: false,
@@ -234,7 +233,6 @@ describe("useRecipientScreenView", () => {
   });
 
   it("only exposes saved contact addresses from the selected network", () => {
-    mockedSendFeatures.hasAddressBook.mockReturnValue(true);
     mockedUseContactsFeature.mockReturnValue({
       isEnabled: true,
       showNewBadge: false,
@@ -508,7 +506,6 @@ describe("useRecipientScreenView", () => {
         mockContactAddress({ id: "address-two", currencyId: "ethereum" }),
       ],
     });
-    mockedSendFeatures.hasAddressBook.mockReturnValue(true);
     mockedUseContactsFeature.mockReturnValue({
       isEnabled: true,
       showNewBadge: false,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenView.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenView.ts
@@ -1,6 +1,6 @@
 import { useContacts, useContactsFeature } from "@features/platform-contacts";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
+import { isEligibleAddressCurrency } from "@ledgerhq/live-common/flows/send/recipient/utils/isEligibleAddressCurrency";
 import { useRecipientSearchState } from "@ledgerhq/live-common/flows/send/recipient/hooks/useRecipientSearchState";
 import { filterContactsByNetwork } from "@ledgerhq/live-common/flows/send/recipient/utils/filterContactsByNetwork";
 import { pickContactAddressForCurrency } from "@ledgerhq/live-common/flows/send/recipient/utils/pickContactAddressForCurrency";
@@ -34,12 +34,13 @@ export function useRecipientScreenView({
 }: UseRecipientScreenViewProps) {
   const { recipientSearch } = useSendFlowData();
   const contacts = useContacts();
-  const { isEnabled: isContactsFeatureEnabled } = useContactsFeature("mobile");
+  const { isEnabled: isContactsFeatureEnabled, eligibleAddressFamilies } =
+    useContactsFeature("mobile");
   const { selectedContact, selectContact, clearSelectedContact } = useRecipientContactSelection();
   const [pendingContactAddress, setPendingContactAddress] = useState<string>();
 
   const mainAccount = getMainAccount(account, parentAccount);
-  const hasAddressBook = sendFeatures.hasAddressBook(currency);
+  const hasAddressBook = isEligibleAddressCurrency(eligibleAddressFamilies, currency);
 
   const { result, isLoading } = useAddressValidation({
     searchValue: recipientSearch.value,

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -651,6 +651,7 @@
     "src/flows/send/recipient/utils/getRecipientHeaderPresentation.ts",
     "src/flows/send/recipient/utils/getRecipientMatchPresentation.ts",
     "src/flows/send/recipient/utils/hasContactsOnNetwork.ts",
+    "src/flows/send/recipient/utils/isEligibleAddressCurrency.ts",
     "src/flows/send/recipient/utils/memoValue.ts",
     "src/flows/send/recipient/utils/pickContactAddressForCurrency.ts",
     "src/flows/send/recipient/utils/resolveRecipientNetworkId.ts",

--- a/libs/ledger-live-common/src/bridge/descriptor.test.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor.test.ts
@@ -60,7 +60,6 @@ describe("getDescriptor", () => {
     const descriptor = getDescriptor(currency);
     expect(descriptor).toMatchObject({
       send: {
-        addressBook: true,
         inputs: { recipientSupportsDomain: true },
         fees: {
           hasPresets: true,
@@ -656,20 +655,6 @@ describe("sendFeatures", () => {
 
   it("should return impossible as default self transfer policy", () => {
     expect(sendFeatures.getSelfTransferPolicy(undefined)).toBe("impossible");
-  });
-
-  it.each([
-    ["ethereum", true],
-    ["tron", false],
-    ["bitcoin", false],
-    ["solana", false],
-  ])("should get address book support for %s", (currencyId, expected) => {
-    const currency = getCryptoCurrencyById(currencyId);
-    expect(sendFeatures.hasAddressBook(currency)).toBe(expected);
-  });
-
-  it("should return false for address book support when currency is undefined", () => {
-    expect(sendFeatures.hasAddressBook(undefined)).toBe(false);
   });
 
   it.each([

--- a/libs/ledger-live-common/src/bridge/descriptor/send/features.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor/send/features.ts
@@ -116,7 +116,6 @@ export const sendFeatures = {
   getMemoOptions: fromDescriptor(d => d.inputs.memo?.options, undefined),
   getMemoDefaultOption: fromDescriptor(d => d.inputs.memo?.defaultOption, undefined),
   supportsDomain: fromDescriptor(d => d.inputs.recipientSupportsDomain, false),
-  hasAddressBook: fromDescriptor(d => d.addressBook, false),
   getSelfTransferPolicy: fromDescriptor(d => d.selfTransfer, defaultSelfTransferPolicy),
   getUserRefusedTransactionErrorName: fromDescriptor(
     d => d.errors?.userRefusedTransaction,

--- a/libs/ledger-live-common/src/bridge/descriptor/types.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor/types.ts
@@ -356,7 +356,6 @@ export type SendDescriptor = {
   };
   fees: FeeDescriptor;
   amount?: SendAmountDescriptor;
-  addressBook?: boolean;
   selfTransfer?: SelfTransferPolicy; // Policy for sending to self (same address), defaults to "impossible"
   errors?: ErrorRegistry; // Registry of error class names for this coin
 };

--- a/libs/ledger-live-common/src/families/evm/descriptor/send/descriptor.ts
+++ b/libs/ledger-live-common/src/families/evm/descriptor/send/descriptor.ts
@@ -22,7 +22,6 @@ function getEstimatedMs(strategy: string): number {
 }
 
 export const evmSendDescriptor: SendDescriptor = {
-  addressBook: true,
   inputs: {
     recipientSupportsDomain: true,
   },

--- a/libs/ledger-live-common/src/families/tron/descriptor/index.test.ts
+++ b/libs/ledger-live-common/src/families/tron/descriptor/index.test.ts
@@ -37,10 +37,6 @@ describe("tron descriptor", () => {
     expect(descriptor.send.fees.hasCustom).toBe(false);
     expect(descriptor.send.fees.hasCoinControl).toBeUndefined();
   });
-
-  it("does not declare address book support until contacts supports Tron", () => {
-    expect(descriptor.send.addressBook).toBe(false);
-  });
 });
 
 describe("tron descriptor - getNetworkFeesInfo", () => {

--- a/libs/ledger-live-common/src/families/tron/descriptor/index.ts
+++ b/libs/ledger-live-common/src/families/tron/descriptor/index.ts
@@ -68,7 +68,6 @@ function getNetworkFeesInfo({
 
 export const descriptor: CoinDescriptor = {
   send: {
-    addressBook: false,
     inputs: {},
     fees: {
       hasPresets: false,

--- a/libs/ledger-live-common/src/flows/send/recipient/utils/__tests__/isEligibleAddressCurrency.test.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/utils/__tests__/isEligibleAddressCurrency.test.ts
@@ -1,0 +1,32 @@
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { mockTokenCurrency } from "@domain/entity-currency-token/schema.mock";
+import { isEligibleAddressCurrency } from "../isEligibleAddressCurrency";
+
+const ETHEREUM = getCryptoCurrencyById("ethereum");
+const BITCOIN = getCryptoCurrencyById("bitcoin");
+
+describe("isEligibleAddressCurrency", () => {
+  it("accepts a network whose family is eligible", () => {
+    expect(isEligibleAddressCurrency(["evm"], ETHEREUM)).toBe(true);
+  });
+
+  it("rejects a network whose family is not eligible", () => {
+    expect(isEligibleAddressCurrency(["evm"], BITCOIN)).toBe(false);
+  });
+
+  it("resolves a token through the family of its parent network", () => {
+    const token = mockTokenCurrency({ parentCurrencyId: ETHEREUM.id });
+
+    expect(isEligibleAddressCurrency(["evm"], token)).toBe(true);
+    expect(isEligibleAddressCurrency(["bitcoin"], token)).toBe(false);
+  });
+
+  it("rejects a missing currency", () => {
+    expect(isEligibleAddressCurrency(["evm"], null)).toBe(false);
+    expect(isEligibleAddressCurrency(["evm"], undefined)).toBe(false);
+  });
+
+  it("rejects every currency when no family is eligible", () => {
+    expect(isEligibleAddressCurrency([], ETHEREUM)).toBe(false);
+  });
+});

--- a/libs/ledger-live-common/src/flows/send/recipient/utils/isEligibleAddressCurrency.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/utils/isEligibleAddressCurrency.ts
@@ -1,0 +1,18 @@
+import { findCryptoCurrencyById, type CryptoCurrency } from "@domain/entity-currency-crypto";
+import type { TokenCurrency } from "@domain/entity-currency-token";
+
+export function isEligibleAddressCurrency(
+  eligibleFamilies: readonly string[],
+  currency: CryptoCurrency | TokenCurrency | null | undefined,
+): boolean {
+  if (!currency) {
+    return false;
+  }
+
+  const network =
+    currency.type === "TokenCurrency"
+      ? findCryptoCurrencyById(currency.parentCurrencyId)
+      : currency;
+
+  return network !== undefined && eligibleFamilies.includes(network.family);
+}


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Removes the per-coin `addressBook` flag from the send descriptor. Address book availability in the send flow now comes from the contacts feature’s `eligibleAddressFamilies`, via a shared `isEligibleAddressCurrency` helper that also covers tokens through their parent network.

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
