### PR TITLE
feat(pay-contact): scaffold empty flow package (LIVE-36463)

### DIFF
--- a/.changeset/pay-contact-scaffold.md
+++ b/.changeset/pay-contact-scaffold.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-pay-contact": minor
+---
+
+Scaffold the @features/flow-pay-contact dual-platform flow package (empty public API) so the Pay tab contacts strip/table component and view-model can be added in follow-up tickets.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -133,6 +133,7 @@ features/flow/pay-card-deposit/                          @ledgerhq/wallet-xp
 features/flow/pay-card-feature-tour/                     @ledgerhq/wallet-xp
 features/flow/pay-card-request/                          @ledgerhq/wallet-xp
 features/flow/pay-card-details/                          @ledgerhq/wallet-xp
+features/flow/pay-contact/                               @ledgerhq/wallet-xp
 
 # Wallet — Intents
 features/platform/verify-address-intent/                 @ledgerhq/wallet-xp

--- a/features/flow/pay-contact/.eslintrc.tailwind.js
+++ b/features/flow/pay-contact/.eslintrc.tailwind.js
@@ -1,0 +1,34 @@
+/**
+ * ESLint config for better-tailwindcss only (no oxlint equivalent).
+ * Run via: pnpm lint:tailwind
+ * Applies to *.web.{ts,tsx} files only.
+ */
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+const path = require("path");
+
+module.exports = {
+  root: true,
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: "module",
+    ecmaFeatures: { jsx: true },
+  },
+  plugins: ["better-tailwindcss"],
+  extends: ["plugin:better-tailwindcss/recommended"],
+  ignorePatterns: ["*.js", "*.cjs", "*.mjs", "node_modules"],
+  rules: {
+    "better-tailwindcss/enforce-consistent-line-wrapping": "off",
+  },
+  settings: {
+    "better-tailwindcss": {
+      entryPoint: path.join(__dirname, "../../../apps/ledger-live-desktop/src/renderer/global.css"),
+      callees: ["cn"],
+    },
+  },
+  overrides: [
+    {
+      files: ["**/*.web.{ts,tsx}"],
+    },
+  ],
+};

--- a/features/flow/pay-contact/.oxfmtrc.json
+++ b/features/flow/pay-contact/.oxfmtrc.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "printWidth": 100,
+  "trailingComma": "all",
+  "arrowParens": "avoid",
+  "sortPackageJson": false,
+  "ignorePatterns": [
+    "**/*.md",
+    "**/*.json"
+  ]
+}

--- a/features/flow/pay-contact/.oxlintrc.json
+++ b/features/flow/pay-contact/.oxlintrc.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "env": {
+    "browser": true,
+    "es6": true,
+    "node": true
+  },
+  "plugins": [
+    "eslint",
+    "import",
+    "oxc",
+    "unicorn",
+    "typescript",
+    "react",
+    "jest",
+    "jsx-a11y"
+  ],
+  "ignorePatterns": ["*.js", "*.cjs", "*.mjs", "node_modules"],
+  "categories": {
+    "correctness": "error",
+    "suspicious": "warn",
+    "pedantic": "off"
+  },
+  "rules": {
+    "eslint/no-unused-vars": "warn",
+    "eslint/no-empty-pattern": "warn",
+    "eslint/no-constant-binary-expression": "warn",
+    "eslint/no-shadow": "off",
+    "react/globals": "warn",
+    "react/immutability": "warn",
+    "react/preserve-manual-memoization": "warn",
+    "react/purity": "warn",
+    "react/refs": "warn",
+    "react/set-state-in-effect": "warn",
+    "react/set-state-in-render": "warn",
+    "react/static-components": "warn",
+    "react/use-memo": "warn",
+    "import/namespace": "warn",
+    "eslint/no-unused-expressions": "warn",
+    "eslint/no-unsafe-optional-chaining": "off",
+    "eslint/no-useless-rename": "warn",
+    "eslint/no-console": ["error", { "allow": ["warn", "error"] }],
+    "eslint/no-restricted-imports": [
+      "error",
+      {
+        "paths": ["lodash"],
+        "patterns": [
+          {
+            "group": [
+              "@ledgerhq/live-common/lib/**",
+              "@ledgerhq/live-common/lib-es/**"
+            ],
+            "message": "Please remove the /lib import from live-common import."
+          }
+        ]
+      }
+    ],
+    "import/no-duplicates": "error",
+    "import/no-named-as-default": "off",
+    "typescript/no-explicit-any": "error",
+    "typescript/no-non-null-assertion": "off",
+    "typescript/no-deprecated": "error",
+    "react/no-did-mount-set-state": "warn",
+    "react/jsx-key": "warn",
+    "react/display-name": "off",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": [
+      "error",
+      {
+        "additionalHooks": "(useInViewContext|useAnimatedStyle|useDerivedValue|useAnimatedProps)"
+      }
+    ],
+    "unicorn/no-useless-fallback-in-spread": "off",
+    "unicorn/no-useless-spread": "off",
+    "unicorn/no-new-array": "off",
+    "unicorn/no-array-sort": "off",
+    "jest/no-conditional-expect": "warn",
+    "jest/expect-expect": "warn",
+    "jest/require-to-throw-message": "warn",
+    "jest/valid-title": "warn",
+    "jest/no-disabled-tests": "warn",
+    "oxc/const-comparisons": "warn",
+    "jsx-a11y/no-autofocus": "off",
+    "jsx-a11y/anchor-is-valid": "off"
+  },
+  "overrides": [
+    {
+      "files": ["**/*.test.{ts,tsx}", "**/__tests__/**"],
+      "env": { "jest": true },
+      "plugins": ["jest"],
+      "rules": {
+        "typescript/no-explicit-any": "warn"
+      }
+    }
+  ]
+}

--- a/features/flow/pay-contact/README.md
+++ b/features/flow/pay-contact/README.md
@@ -1,0 +1,37 @@
+# @features/flow-pay-contact
+
+> [!CAUTION]
+> **Status: UNSTABLE** — In active development; API may change.
+
+Pay tab contact flow for Ledger Wallet Desktop and Mobile. It will hold the Pay tab contacts
+strip/table presentation and its shared view-model (stablecoin-filtered list, empty state, and the
+press intent that hands off to the Send flow with `source: Pay`).
+
+The package is currently a scaffold with an empty public API; the view-model and platform
+presentations are added in follow-up tickets (LIVE-35378 for the shared view-model, plus the
+LWD/LWM mount tickets).
+
+## Public API vs leaves
+
+This package owns the Pay-tab contact flow; it does **not** re-export the generic Contacts
+packages. Apps that need contacts data or the contacts management UI keep importing
+`@features/flow-contacts` / `@features/platform-contacts` directly.
+
+## Platform resolution
+
+Only views carry a platform suffix (`.web` / `.native`). The `exports` condition in `package.json`
+selects the barrel (`index.ts` for web, `index.native.ts` for React Native); both re-export the
+shared `./exports` public surface.
+
+## Structure
+
+Every `index.*` is a pure barrel (`export *` only).
+
+```text
+pay-contact/
+├── package.json
+└── src/
+    ├── index.ts          # Web public API barrel → ./exports
+    ├── index.native.ts   # Native public API barrel → ./exports
+    └── exports.ts        # Shared public surface (empty for now)
+```

--- a/features/flow/pay-contact/jest.config.js
+++ b/features/flow/pay-contact/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = require("@support/jest-features-flow").createFlowJestConfig({
+  passWithNoTests: true,
+});

--- a/features/flow/pay-contact/package.json
+++ b/features/flow/pay-contact/package.json
@@ -1,0 +1,87 @@
+{
+  "name": "@features/flow-pay-contact",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Pay tab contact flow for Ledger Wallet",
+  "main": "src/index.ts",
+  "react-native": "src/index.native.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "react-native": "./src/index.native.ts",
+      "default": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "format": "oxfmt src",
+    "format:check": "oxfmt src --check",
+    "lint": "oxlint src && pnpm lint:tailwind",
+    "lint:ci": "oxlint src --quiet && pnpm lint:tailwind",
+    "lint:fix": "oxfmt src && oxlint src --fix --quiet && pnpm lint:tailwind",
+    "lint:tailwind": "eslint --no-eslintrc --no-error-on-unmatched-pattern -c .eslintrc.tailwind.js --ext .ts,.tsx 'src/**/*.web.{ts,tsx}'",
+    "typecheck": "tsc --noEmit -p tsconfig.web.json && tsc --noEmit -p tsconfig.native.json",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../../.. -W features/flow/pay-contact"
+  },
+  "devDependencies": {
+    "@features/platform-style": "workspace:*",
+    "@ledgerhq/lumen-design-core": "catalog:",
+    "@ledgerhq/lumen-ui-react": "catalog:",
+    "@ledgerhq/lumen-ui-rnative": "catalog:",
+    "@support/jest-features-flow": "workspace:*",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@testing-library/dom": "catalog:",
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
+    "@testing-library/react-native": "catalog:",
+    "@testing-library/user-event": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@typescript-eslint/parser": "catalog:",
+    "eslint": "8.57.0",
+    "eslint-plugin-better-tailwindcss": "catalog:",
+    "jest": "catalog:",
+    "jest-environment-jsdom": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "react-native": "catalog:",
+    "react-test-renderer": "catalog:",
+    "tailwindcss": "catalog:",
+    "typescript": "catalog:"
+  },
+  "optionalDependencies": {
+    "@oxlint/binding-darwin-arm64": "1.51.0",
+    "@oxlint/binding-darwin-x64": "1.51.0",
+    "@oxlint/binding-linux-x64-gnu": "1.51.0",
+    "@oxlint/binding-win32-x64-msvc": "1.51.0"
+  },
+  "peerDependencies": {
+    "@ledgerhq/lumen-design-core": "catalog:",
+    "@ledgerhq/lumen-ui-react": "catalog:",
+    "@ledgerhq/lumen-ui-rnative": "catalog:",
+    "react": "catalog:",
+    "react-native": "catalog:"
+  },
+  "peerDependenciesMeta": {
+    "react-native": {
+      "optional": true
+    },
+    "@ledgerhq/lumen-ui-react": {
+      "optional": true
+    },
+    "@ledgerhq/lumen-ui-rnative": {
+      "optional": true
+    },
+    "@ledgerhq/lumen-design-core": {
+      "optional": true
+    }
+  }
+}

--- a/features/flow/pay-contact/project.json
+++ b/features/flow/pay-contact/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@features/flow-pay-contact",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/features/flow/pay-contact/src/exports.ts
+++ b/features/flow/pay-contact/src/exports.ts
@@ -1,0 +1,1 @@
+export const PLACEHOLDER_PACKAGE = "@features/flow-pay-contact";

--- a/features/flow/pay-contact/src/index.native.ts
+++ b/features/flow/pay-contact/src/index.native.ts
@@ -1,0 +1,1 @@
+export * from "./exports";

--- a/features/flow/pay-contact/src/index.ts
+++ b/features/flow/pay-contact/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./exports";

--- a/features/flow/pay-contact/tsconfig.json
+++ b/features/flow/pay-contact/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "types": ["jest", "node", "@testing-library/jest-dom"]
+  },
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.web.json" },
+    { "path": "./tsconfig.native.json" }
+  ]
+}

--- a/features/flow/pay-contact/tsconfig.native.json
+++ b/features/flow/pay-contact/tsconfig.native.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleSuffixes": [".native", ""]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "src/**/*.web.*"]
+}

--- a/features/flow/pay-contact/tsconfig.test.json
+++ b/features/flow/pay-contact/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.web.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "src/**/*.native.*"]
+}

--- a/features/flow/pay-contact/tsconfig.web.json
+++ b/features/flow/pay-contact/tsconfig.web.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleSuffixes": [".web", ""]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "src/**/*.native.*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6665,6 +6665,106 @@ importers:
         specifier: 1.51.0
         version: 1.51.0
 
+  features/flow/pay-contact:
+    devDependencies:
+      '@features/platform-style':
+        specifier: workspace:*
+        version: link:../../platform/style
+      '@ledgerhq/lumen-design-core':
+        specifier: 'catalog:'
+        version: 0.1.26
+      '@ledgerhq/lumen-ui-react':
+        specifier: 'catalog:'
+        version: 0.1.55(@ledgerhq/lumen-design-core@0.1.26)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@ledgerhq/lumen-ui-rnative':
+        specifier: 'catalog:'
+        version: 0.1.58(@ledgerhq/lumen-design-core@0.1.26)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@support/jest-features-flow':
+        specifier: workspace:*
+        version: link:../../../support/jest-features-flow
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@testing-library/dom':
+        specifier: 'catalog:'
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: 'catalog:'
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@testing-library/react-native':
+        specifier: 'catalog:'
+        version: 13.3.3(patch_hash=4f93e75372e62b6dc0f0b2635b62a322b37a3727637bd94a38df1ed8648e2e76)(jest@30.2.0(@types/node@24.12.0))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react-test-renderer@19.1.4(react@19.1.4))(react@19.1.4)
+      '@testing-library/user-event':
+        specifier: 'catalog:'
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.0.14
+      '@typescript-eslint/parser':
+        specifier: 'catalog:'
+        version: 8.48.1(@typescript/typescript6@6.0.2)(eslint@8.57.0)
+      eslint:
+        specifier: 8.57.0
+        version: 8.57.0
+      eslint-plugin-better-tailwindcss:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.3(@typescript/typescript6@6.0.2)(eslint@8.57.0)(tailwindcss@4.1.18)
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0(@types/node@24.12.0)
+      jest-environment-jsdom:
+        specifier: 'catalog:'
+        version: 30.2.0
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.64.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.79.0
+      react:
+        specifier: 19.1.4
+        version: 19.1.4
+      react-dom:
+        specifier: 19.1.4
+        version: 19.1.4(react@19.1.4)
+      react-native:
+        specifier: 'catalog:'
+        version: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
+      react-test-renderer:
+        specifier: 'catalog:'
+        version: 19.1.4(react@19.1.4)
+      tailwindcss:
+        specifier: 'catalog:'
+        version: 4.1.18
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+    optionalDependencies:
+      '@oxlint/binding-darwin-arm64':
+        specifier: 1.51.0
+        version: 1.51.0
+      '@oxlint/binding-darwin-x64':
+        specifier: 1.51.0
+        version: 1.51.0
+      '@oxlint/binding-linux-x64-gnu':
+        specifier: 1.51.0
+        version: 1.51.0
+      '@oxlint/binding-win32-x64-msvc':
+        specifier: 1.51.0
+        version: 1.51.0
+
   features/platform/aggregated-assets:
     dependencies:
       '@domain/api-aggregated-assets':
@@ -28424,7 +28524,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: ^5.5.10
+      rxjs: '*'
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -69536,7 +69636,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3
+      metro: 0.83.3(metro-transform-worker@0.83.3)
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -69556,7 +69656,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.7
+      metro: 0.83.7(metro-transform-worker@0.83.7)
       metro-babel-transformer: 0.83.7
       metro-cache: 0.83.7
       metro-cache-key: 0.83.7
@@ -69663,6 +69763,54 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  metro@0.83.3(metro-transform-worker@0.83.3):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.28.5
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 1.3.8
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.32.0
+      image-size: 1.1.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0(metro@0.83.3)
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.3
+      metro-cache: 0.83.3
+      metro-cache-key: 0.83.3
+      metro-config: 0.83.3(metro-transform-worker@0.83.3)
+      metro-core: 0.83.3
+      metro-file-map: 0.83.3(metro@0.83.3)
+      metro-resolver: 0.83.3
+      metro-runtime: 0.83.3
+      metro-source-map: 0.83.3
+      metro-symbolicate: 0.83.3
+      metro-transform-plugins: 0.83.3
+      metro-transform-worker: 0.83.3
+      mime-types: 2.1.35
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - metro-transform-worker
+      - supports-color
+      - utf-8-validate
+
   metro@0.83.7:
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -69706,6 +69854,53 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.83.7(metro-transform-worker@0.83.7):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.28.5
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 2.0.0
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.35.0
+      image-size: 1.1.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0(metro@0.83.7)
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.7
+      metro-cache: 0.83.7
+      metro-cache-key: 0.83.7
+      metro-config: 0.83.7(metro-transform-worker@0.83.7)
+      metro-core: 0.83.7
+      metro-file-map: 0.83.7(metro@0.83.7)
+      metro-resolver: 0.83.7
+      metro-runtime: 0.83.7
+      metro-source-map: 0.83.7
+      metro-symbolicate: 0.83.7
+      metro-transform-plugins: 0.83.7
+      metro-transform-worker: 0.83.7
+      mime-types: 3.0.1
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
### 📝 Description

Scaffolds `@features/flow-pay-contact`, a new dual-platform flow package under `features/flow/`, following the existing Pay Card leaf init pattern (`pay-card-request` / `pay-card-deposit`).

**Problem**: The Pay tab "Pay a contact" experience needs a dedicated flow package to own the contacts strip/table presentation and its shared view-model, but no package exists yet.

**Solution**: Add an init-only package with an empty public API so follow-up tickets can drop in the view-model and platform presentations without re-scaffolding:

- `package.json` (`@features/flow-pay-contact`, private, source-only `exports` with `react-native` + `default` conditions), `project.json` (`nx:noop` build)
- `tsconfig.json` + `.web` / `.native` / `.test`, `jest.config.js` (`passWithNoTests`), `.oxlintrc.json`, `.oxfmtrc.json`, `.eslintrc.tailwind.js`
- `src/index.ts` + `src/index.native.ts` pure barrels re-exporting `src/exports.ts` (placeholder export until the VM/components land)
- `README.md` (UNSTABLE status marker), `CODEOWNERS` entry (`@ledgerhq/wallet-xp`), changeset

The package composes rather than re-exports: it does not re-export `@features/flow-contacts` / `@features/platform-contacts`.

Validated locally: typecheck (web + native), lint (oxlint + tailwind), and test all pass.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36463](https://ledgerhq.atlassian.net/browse/LIVE-36463) 

[LIVE-36463]: https://ledgerhq.atlassian.net/browse/LIVE-36463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ