### PR TITLE
[LWDM] fix(zcash): stabilise expiry boundary tests (LIVE-36465)

### DIFF
--- a/.changeset/live-36465-coin-zcash-flaky-timer-test.md
+++ b/.changeset/live-36465-coin-zcash-flaky-timer-test.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-zcash": patch
+---
+
+Fix flaky note-reservation boundary test by using fake timers

--- a/libs/coin-modules/coin-zcash/src/bridge/note-reservation.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/note-reservation.test.ts
@@ -203,18 +203,29 @@ describe("releaseRetiredReservations", () => {
     expect(getSessionReservedNullifiers(ACCOUNT_A).size).toBe(2);
   });
 
-  it("holds a reservation right up to the end of the optimistic window", () => {
-    reserveNotes(ACCOUNT_A, OP_1, [NF1]);
-    releaseRetiredReservations(ACCOUNT_A, new Set(), Date.now() + RETENTION - 1);
-    expect(getSessionReservedNullifiers(ACCOUNT_A).has(NF1)).toBe(true);
-  });
+  // Fake timers freeze Date.now() so reserveNotes and the releaseRetiredReservations
+  // call read the same clock value — the boundary arithmetic is exact, not race-prone.
+  describe("expiry boundary", () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+    afterEach(() => {
+      jest.useRealTimers();
+    });
 
-  // Past that window Ledger Wallet drops the optimistic operation itself, so a
-  // broadcast that never confirmed stops holding notes at the same moment.
-  it("releases a reservation that outlived the optimistic window", () => {
-    reserveNotes(ACCOUNT_A, OP_1, [NF1]);
-    releaseRetiredReservations(ACCOUNT_A, new Set(), Date.now() + RETENTION + 1);
-    expect(getSessionReservedNullifiers(ACCOUNT_A).size).toBe(0);
+    it("holds a reservation right up to the end of the optimistic window", () => {
+      reserveNotes(ACCOUNT_A, OP_1, [NF1]);
+      releaseRetiredReservations(ACCOUNT_A, new Set(), Date.now() + RETENTION - 1);
+      expect(getSessionReservedNullifiers(ACCOUNT_A).has(NF1)).toBe(true);
+    });
+
+    // Past that window Ledger Wallet drops the optimistic operation itself, so a
+    // broadcast that never confirmed stops holding notes at the same moment.
+    it("releases a reservation that outlived the optimistic window", () => {
+      reserveNotes(ACCOUNT_A, OP_1, [NF1]);
+      releaseRetiredReservations(ACCOUNT_A, new Set(), Date.now() + RETENTION + 1);
+      expect(getSessionReservedNullifiers(ACCOUNT_A).size).toBe(0);
+    });
   });
 
   it("is a no-op on an unknown account (no throw)", () => {


### PR DESCRIPTION
### 📝 Description

Two boundary tests in `note-reservation.test.ts` read `Date.now()` twice in
separate statements: once inside `reserveNotes` (stamping `reservedAt`) and
once in the test body to compute the `now` argument passed to
`releaseRetiredReservations`. The expiry check is `now - reservedAt >= retention`,
so any real elapsed time between the two calls shifts the arithmetic — the
`RETENTION - 1` test fails whenever ≥1ms passes between those statements.

Fix: wrap both boundary tests in a nested `describe("expiry boundary")` block
with `jest.useFakeTimers()` / `jest.useRealTimers()`. With the clock frozen,
both `Date.now()` calls return the same value and the boundary arithmetic is exact.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36465](https://ledgerhq.atlassian.net/browse/LIVE-36465)
- **ADR** (if any): N/A

[LIVE-36465]: https://ledgerhq.atlassian.net/browse/LIVE-36465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ