### PR TITLE
[LWM] fix(lwm): fix tracking filter for the new send flow

### DIFF
--- a/.changeset/hip-bats-protect.md
+++ b/.changeset/hip-bats-protect.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix(lwm): fix tracking filter for the new send flow

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/__integrations__/TransferDrawer.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/__integrations__/TransferDrawer.integration.test.tsx
@@ -134,6 +134,94 @@ describe("TransferDrawer Navigation", () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
+  it("tracks newSendFlow as true when the asset family is allowed by the flag", () => {
+    const currency = getCryptoCurrencyById("ethereum");
+    const { result } = renderHook(() => useTransferDrawerViewModel({ currency }), {
+      overrideInitialState: withFlagOverrides(
+        {
+          newSendFlow: {
+            enabled: true,
+            params: { families: ["evm"], excludedCurrencyIds: [] },
+          },
+        },
+        overrideWithOpenDrawer,
+      ),
+    });
+
+    findAction(result, "send").onPress();
+
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({ button: "send", newSendFlow: true }),
+    );
+  });
+
+  it("tracks newSendFlow as false when the asset family is not allowed by the flag", () => {
+    const currency = getCryptoCurrencyById("solana");
+    const { result } = renderHook(() => useTransferDrawerViewModel({ currency }), {
+      overrideInitialState: withFlagOverrides(
+        {
+          newSendFlow: {
+            enabled: true,
+            params: { families: ["evm", "bitcoin", "tron"], excludedCurrencyIds: [] },
+          },
+        },
+        overrideWithOpenDrawer,
+      ),
+    });
+
+    findAction(result, "send").onPress();
+
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({ button: "send", newSendFlow: false }),
+    );
+  });
+
+  it("tracks newSendFlow as false when the asset currency is excluded by the flag", () => {
+    const currency = getCryptoCurrencyById("dash");
+    const { result } = renderHook(() => useTransferDrawerViewModel({ currency }), {
+      overrideInitialState: withFlagOverrides(
+        {
+          newSendFlow: {
+            enabled: true,
+            params: { families: ["bitcoin"], excludedCurrencyIds: ["dash"] },
+          },
+        },
+        overrideWithOpenDrawer,
+      ),
+    });
+
+    findAction(result, "send").onPress();
+
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({ button: "send", newSendFlow: false }),
+    );
+  });
+
+  it("tracks newSendFlow as false when the drawer has no currency to open the new send flow", () => {
+    const { result } = renderHook(() => useTransferDrawerViewModel(), {
+      overrideInitialState: withFlagOverrides(
+        {
+          newSendFlow: {
+            enabled: true,
+            params: { families: ["evm"], excludedCurrencyIds: [] },
+          },
+        },
+        overrideWithOpenDrawer,
+      ),
+    });
+
+    findAction(result, "send").onPress();
+
+    expect(mockHandleOpenSendFlow).not.toHaveBeenCalled();
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({ button: "send", newSendFlow: false }),
+    );
+  });
+
   it("bank_transfer navigates to ReceiveFunds/ReceiveProvider with noah manifest and tracks", () => {
     const { result } = renderViewModel();
 

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/useTransferDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/useTransferDrawerViewModel.ts
@@ -11,6 +11,7 @@ import { languageSelector, readOnlyModeEnabledSelector } from "~/reducers/settin
 import { accountsCountSelector, useAreAccountsEmpty } from "~/reducers/accounts";
 import { useFeature } from "@features/platform-feature-flags";
 import { resolveRemoteCopy } from "@ledgerhq/live-common/analytics/remoteABTesting/resolveRemoteCopy";
+import { getFamilyByCurrencyId } from "@ledgerhq/live-common/currencies/index";
 import { track } from "~/analytics";
 import { useTransferDrawerController } from "../../hooks/useTransferDrawerController";
 import { useOpenReceiveDrawer } from "LLM/features/Receive";
@@ -88,15 +89,28 @@ export const useTransferDrawerViewModel = ({
     handleOpenReceiveDrawer();
   }, [closeDrawer, handleOpenReceiveDrawer, sourceScreenName]);
 
-  const { isEnabled: isNewSendFlowEnabled } = useNewSendFlowFeature();
+  const { isEnabled: isNewSendFlowEnabled, isEnabledForFamily } = useNewSendFlowFeature();
   const { handleOpenSendFlow } = useOpenSendFlow({
     currency,
     currencyIds: ledgerIds,
     sourceScreenName,
   });
+
+  // The flag also filters on family / excluded currency, so a globally enabled
+  // flag does not mean the asset at hand actually lands in the new send flow.
+  const assetCurrencyId =
+    currency?.type === "TokenCurrency" ? currency.parentCurrencyId : currency?.id;
+  const assetFamily = useMemo(
+    () => (assetCurrencyId ? getFamilyByCurrencyId(assetCurrencyId) : undefined),
+    [assetCurrencyId],
+  );
+  const canOpenNewSendFlowFromEntry = Boolean(currency || ledgerIds?.length);
+  const isNewSendFlowEnabledForAsset =
+    canOpenNewSendFlowFromEntry && isEnabledForFamily(assetFamily, assetCurrencyId);
+
   const trackingProperties = useMemo(() => {
-    return getSendFlowTrackingProperties(null, null, isNewSendFlowEnabled);
-  }, [isNewSendFlowEnabled]);
+    return getSendFlowTrackingProperties(null, null, isNewSendFlowEnabledForAsset);
+  }, [isNewSendFlowEnabledForAsset]);
 
   const handleSendPress = useCallback(() => {
     track("button_clicked", {
@@ -106,7 +120,7 @@ export const useTransferDrawerViewModel = ({
       page: sourceScreenName,
     });
     closeDrawer();
-    if (isNewSendFlowEnabled && (currency || ledgerIds?.length)) {
+    if (isNewSendFlowEnabled && canOpenNewSendFlowFromEntry) {
       handleOpenSendFlow();
       return;
     }
@@ -125,6 +139,7 @@ export const useTransferDrawerViewModel = ({
       });
     }
   }, [
+    canOpenNewSendFlowFromEntry,
     closeDrawer,
     currency,
     handleOpenSendFlow,


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

The Transfer drawer Send button reported `newSendFlow: true` whenever the flag was globally enabled, even for families that are not in `params.families` (e.g. Solana). It now evaluates `isEnabledForFamily` from the current asset so analytics match the flow actually used. Integration tests cover allowed families, disallowed families, and excluded currencies.
### 🔗 Context

- **[JIRA / GitHub issue](https://ledgerhq.atlassian.net/browse/LIVE-36477)** <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
