### PR TITLE
[LWDM] feat(coin-celo): add USAT as a fee currency

### DIFF
--- a/.changeset/celo-usat-gas-token.md
+++ b/.changeset/celo-usat-gas-token.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-celo": minor
+---
+
+add USAT to the Celo fee currency allowlist; paying gas in USAT additionally requires the cLabs-signed device token descriptor, which is not published yet

--- a/libs/coin-modules/coin-celo/src/__tests__/constants.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/constants.test.ts
@@ -6,11 +6,12 @@ import {
 } from "../constants";
 
 describe("celo fee currency constants", () => {
-  it("includes CELO, USDT and USDC as fee currency options", () => {
+  it("includes CELO, USDT, USDC and USAT as fee currency options", () => {
     const names = FEE_CURRENCY_OPTIONS.map(option => option.name);
     expect(names).toContain("CELO");
     expect(names).toContain("USDT");
     expect(names).toContain("USDC");
+    expect(names).toContain("USAT");
   });
 
   it("lists all expected fee currency tokens", () => {
@@ -19,6 +20,7 @@ describe("celo fee currency constants", () => {
       "CELO",
       "USDT",
       "USDC",
+      "USAT",
       "PHPm",
       "KESm",
       "ZARm",
@@ -39,13 +41,13 @@ describe("celo fee currency constants", () => {
   });
 
   it("keeps adapter address distinct from token contract for 6 decimals stablecoins", () => {
-    const usdc = FEE_CURRENCY_OPTIONS.find(option => option.name === "USDC");
-    const usdt = FEE_CURRENCY_OPTIONS.find(option => option.name === "USDT");
+    const sixDecimalNames = ["USDT", "USDC", "USAT"];
 
-    expect(usdc?.adapterAddress).toEqual(expect.any(String));
-    expect(usdt?.adapterAddress).toEqual(expect.any(String));
-    expect(usdc?.adapterAddress).not.toEqual(usdc?.contractAddress);
-    expect(usdt?.adapterAddress).not.toEqual(usdt?.contractAddress);
+    for (const name of sixDecimalNames) {
+      const option = FEE_CURRENCY_OPTIONS.find(o => o.name === name);
+      expect(option?.adapterAddress).toEqual(expect.any(String));
+      expect(option?.adapterAddress).not.toEqual(option?.contractAddress);
+    }
   });
 
   it("supports case-insensitive lookup by token contract address", () => {

--- a/libs/coin-modules/coin-celo/src/api/feeCurrency.test.ts
+++ b/libs/coin-modules/coin-celo/src/api/feeCurrency.test.ts
@@ -5,6 +5,10 @@ import { resolveFeeCurrency } from "./feeCurrency";
 const USDC_CONTRACT = "0xcebA9300f2b948710d2653dD7B07f33A8B32118C";
 const USDC_ADAPTER = "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B";
 
+// USAT (Tether America USD), also 6 decimals.
+const USAT_CONTRACT = "0xD2ab3C9A02DBBAB236BfEC45D1d755DF4267F771";
+const USAT_ADAPTER = "0x0357EE22278c922e1D36cFe6b899269b161880C4";
+
 describe("resolveFeeCurrency", () => {
   it("returns undefined when nothing is selected (native CELO gas)", () => {
     expect(resolveFeeCurrency(undefined)).toBeUndefined();
@@ -20,6 +24,11 @@ describe("resolveFeeCurrency", () => {
 
   it("matches addresses case-insensitively", () => {
     expect(resolveFeeCurrency(USDC_CONTRACT.toLowerCase())).toBe(USDC_ADAPTER);
+  });
+
+  it("resolves USAT from either its token contract or its adapter", () => {
+    expect(resolveFeeCurrency(USAT_CONTRACT)).toBe(USAT_ADAPTER);
+    expect(resolveFeeCurrency(USAT_ADAPTER)).toBe(USAT_ADAPTER);
   });
 
   it("returns undefined for an address that is not an allowlisted fee currency", () => {

--- a/libs/coin-modules/coin-celo/src/constants.ts
+++ b/libs/coin-modules/coin-celo/src/constants.ts
@@ -37,7 +37,7 @@ export const CELO_STAKING_FALLBACK_GAS_LIMIT = 1_000_000n;
  * Celo's protocol allows users to pay gas in tokens other than the native CELO.
  * The on-chain allowlist is managed by `FeeCurrencyDirectory.sol`.
  *
- * Tokens with fewer than 18 decimals (USDC, USDT) use an **adapter** contract
+ * Tokens with fewer than 18 decimals (USDT, USDC, USAT) use an **adapter** contract
  * instead of the token address for `feeCurrency`. The adapter normalizes values
  * to 18 decimals so the protocol can price gas consistently. For these tokens:
  *   - `feeCurrency` on the transaction → adapter address
@@ -46,7 +46,7 @@ export const CELO_STAKING_FALLBACK_GAS_LIMIT = 1_000_000n;
  * Tokens that are natively 18-decimal do not need an adapter and use their own
  * token address for both purposes.
  * This list contains the tokens that are currently supported as fee currencies
- * (CELO, USDT, USDC, and many others). Native 18-decimal tokens such as cUSD or cEUR are not
+ * (CELO, USDT, USDC, USAT, and many others). Native 18-decimal tokens such as cUSD or cEUR are not
  * included in the current allowlist.
  *
  * Reference: https://docs.celo.org/protocol/transaction/eip1559
@@ -70,6 +70,11 @@ export const FEE_CURRENCY_OPTIONS: {
     name: "USDC",
     adapterAddress: "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
     contractAddress: "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+  },
+  {
+    name: "USAT",
+    adapterAddress: "0x0357EE22278c922e1D36cFe6b899269b161880C4",
+    contractAddress: "0xD2ab3C9A02DBBAB236BfEC45D1d755DF4267F771",
   },
   {
     name: "PHPm",


### PR DESCRIPTION
### 📝 Description

Adds USAT (Tether America USD) to the Celo CIP-64 fee-currency allowlist, making it selectable in "Pay fees in".

`FEE_CURRENCY_OPTIONS` in `coin-celo` is the single source for that list — the live-common fee-asset descriptor, `resolveFeeCurrency`, and the LLD/LLM screens all read it. So the change is one entry:

```ts
{
  name: "USAT",
  adapterAddress: "0x0357EE22278c922e1D36cFe6b899269b161880C4",
  contractAddress: "0xD2ab3C9A02DBBAB236BfEC45D1d755DF4267F771",
},
```

USAT has 6 decimals, so like USDT/USDC it uses an adapter for `feeCurrency` while the token address stays the transfer target. Both addresses were read from chain (`FeeCurrencyDirectory.getCurrencies()`, adapter `getAdaptedToken()`); the token is in CAL on test and prod.

**Signing is not yet possible.** `app-celo-spender` throws `SW_ERROR_IN_DATA` for a `feeCurrency` it has no provisioned descriptor for. That descriptor comes from the cLabs-signed blob in `hw-app-celo/.../data.ts`, which bypasses CAL — and USAT is absent from it and from `celo-ledger-token-signer` upstream. Needs cLabs to publish a descriptor for the adapter (decimals `18`, chainId `42220`). Worth a call on holding this PR vs. gating the release.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36459](https://ledgerhq.atlassian.net/browse/LIVE-36459)


[LIVE-36459]: https://ledgerhq.atlassian.net/browse/LIVE-36459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ