### PR TITLE
[LWDM] fix(live-common): honor framework memo union in transactionToIntent

### DIFF
--- a/.changeset/honest-jars-relax.md
+++ b/.changeset/honest-jars-relax.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/coin-tester-tron": minor
+"@ledgerhq/coin-tron": minor
+"@ledgerhq/live-common": minor
+---
+
+Stop the generic coin framework silently dropping typed memos (LIVE-35735). Shared `transactionToIntent` emitted a memo shape that predated the framework's memo union — `{ type: memoType, value }` with no `kind`, and `{ type: "NO_MEMO" }` — so a family declaring a typed memo received one its `type === "string" && kind === "…"` guard rejected: the memo resolved to `undefined` and never reached the chain, with no error, which is why it survived the type checker and the migration's unit tests. It now emits the framework's own `StringMemo` (with `memoType` as the `kind`) and `MemoNotSupported` (`{ type: "none" }`), so the note survives for Tron today and for the Cardano, Concordium, Casper and Algorand migrations that read the same shape. The external, pre-union coin-stellar reads `memo.type` as its own Stellar memo kind with a `NO_MEMO` sentinel; its family adapter (`families/stellar/coinModuleApi.ts`) translates the union onto that flat shape at the call boundary, so the shared layer needs no family-specific memo branch.
+
+For Tron this also prices and surfaces the memo now that it reaches the chain: `estimateFees` reads the `getMemoFee` chain parameter (TIP-387) and adds it — along with the memo's bytes to the bandwidth size — for a memo-bearing native or TRC-10 send, falling back to 1 TRX only when chain parameters are unreachable; and sync decodes the memo back out of `raw_data.data` onto the operation's `extra.memo` so it appears in history.

--- a/libs/coin-modules/coin-tron/src/logic/constants.ts
+++ b/libs/coin-modules/coin-tron/src/logic/constants.ts
@@ -5,6 +5,10 @@ export const STANDARD_FEES_NATIVE = new BigNumber(270000);
 export const ACTIVATION_FEES = ONE_TRX.multipliedBy(1.1); // ONE TRX fee + 0.1 TRX activation cost
 export const STANDARD_FEES_TRC_20 = ONE_TRX.multipliedBy(13.7409);
 
+// The memo fee is a chain parameter (`getMemoFee`, TIP-387) read live from the chain; this is the
+// pessimistic stand-in used only when chain parameters are unreachable, set to mainnet's 1 TRX.
+export const MEMO_FEE_PESSIMISTIC = ONE_TRX;
+
 // `withdrawBalance` claims the whole accrued reward and then locks the account for 24h. Read by both
 // `validateIntent` (which rejects a premature claim) and `getStakes` (which offers `claim_reward`).
 export const REWARD_WITHDRAW_COOLDOWN_MS = 24 * 60 * 60 * 1000;

--- a/libs/coin-modules/coin-tron/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/estimateFees.test.ts
@@ -12,7 +12,12 @@ import type { AccountTronAPI, ChainParameters } from "../network/types";
 import { abiEncodeTrc20Transfer } from "../network/utils";
 import type { NetworkInfo } from "../types";
 import type { TronMemo, TronTxData } from "../types";
-import { ACTIVATION_FEES, STANDARD_FEES_NATIVE, STANDARD_FEES_TRC_20 } from "./constants";
+import {
+  ACTIVATION_FEES,
+  MEMO_FEE_PESSIMISTIC,
+  STANDARD_FEES_NATIVE,
+  STANDARD_FEES_TRC_20,
+} from "./constants";
 import {
   computeBandwidthFee,
   computeEnergyFee,
@@ -56,6 +61,7 @@ const chainParams: ChainParameters = {
   transactionFee: 1000,
   createAccountFee: 100_000,
   createNewAccountFeeInSystemContract: 1_000_000,
+  memoFee: 1_000_000, // 1 TRX, mainnet's value
 };
 
 const activeRecipient: AccountTronAPI[] = [{ address: "recipient", trc20: [] }];
@@ -77,6 +83,12 @@ const sendNative: TransactionIntent<TronMemo, TronTxData> = {
   data: { type: "tron" },
 };
 
+const MEMO = "ledger-e2e"; // 10 UTF-8 bytes
+const sendNativeWithMemo: TransactionIntent<TronMemo, TronTxData> = {
+  ...sendNative,
+  memo: { type: "string", kind: "memo", value: MEMO },
+};
+
 const sendTrc10: TransactionIntent<TronMemo, TronTxData> = {
   intentType: "transaction",
   type: "send",
@@ -85,6 +97,11 @@ const sendTrc10: TransactionIntent<TronMemo, TronTxData> = {
   amount: BigInt(1000),
   asset: { type: "trc10", assetReference: "1002000" },
   data: { type: "tron" },
+};
+
+const sendTrc10WithMemo: TransactionIntent<TronMemo, TronTxData> = {
+  ...sendTrc10,
+  memo: { type: "string", kind: "memo", value: MEMO },
 };
 
 const sendTrc20: TransactionIntent<TronMemo, TronTxData> = {
@@ -168,6 +185,63 @@ describe("estimateFees", () => {
 
       expect(result.value).toBe(
         BigInt(chainParams.createAccountFee + chainParams.createNewAccountFeeInSystemContract),
+      );
+    });
+  });
+
+  describe("memo fee (TIP-387)", () => {
+    it("adds the chain memo fee on top when a native send carries a memo", async () => {
+      // Enough free bandwidth to cover the (slightly larger) memo'd transaction, so the whole fee is
+      // the flat memo fee.
+      mockGetTronAccountNetwork.mockResolvedValue(
+        buildNetworkInfo({ freeNetLimit: new BigNumber(5000) }),
+      );
+      mockFetchTronAccount.mockResolvedValue(activeRecipient);
+
+      const result = await estimateFees(mockConfig, sendNativeWithMemo);
+
+      expect(result.value).toBe(BigInt(chainParams.memoFee));
+    });
+
+    it("grows the bandwidth requirement by the memo's byte length", async () => {
+      mockGetTronAccountNetwork.mockResolvedValue(buildNetworkInfo());
+      mockFetchTronAccount.mockResolvedValue(activeRecipient);
+
+      const result = await estimateFees(mockConfig, sendNativeWithMemo);
+
+      expect(result.value).toBe(
+        BigInt(
+          (270 + Buffer.byteLength(MEMO, "utf8")) * chainParams.transactionFee +
+            chainParams.memoFee,
+        ),
+      );
+    });
+
+    it("charges no memo fee on a chain that never activated the parameter (getMemoFee = 0)", async () => {
+      mockGetChainParameters.mockResolvedValue({ ...chainParams, memoFee: 0 });
+      mockGetTronAccountNetwork.mockResolvedValue(
+        buildNetworkInfo({ freeNetLimit: new BigNumber(5000) }),
+      );
+      mockFetchTronAccount.mockResolvedValue(activeRecipient);
+
+      const result = await estimateFees(mockConfig, sendNativeWithMemo);
+
+      expect(result.value).toBe(0n);
+    });
+
+    it("prices a memo on a TRC-10 send too (size grows, memo fee added)", async () => {
+      mockGetTronAccountNetwork.mockResolvedValue(buildNetworkInfo());
+      mockFetchTronAccount.mockResolvedValue(activeRecipient);
+
+      const result = await estimateFees(mockConfig, sendTrc10WithMemo);
+
+      // A TRC-10 transfer carries its memo in `raw_data.data` and pays TIP-387's memo fee the same
+      // as a native send.
+      expect(result.value).toBe(
+        BigInt(
+          (285 + Buffer.byteLength(MEMO, "utf8")) * chainParams.transactionFee +
+            chainParams.memoFee,
+        ),
       );
     });
   });
@@ -484,6 +558,16 @@ describe("estimateFees", () => {
       const result = await estimateFees(mockConfig, sendTrc20);
 
       expect(result.value).toBe(BigInt(STANDARD_FEES_TRC_20.toString()));
+    });
+
+    it("adds a pessimistic memo fee to the native fallback when the send carries a memo", async () => {
+      mockGetTronAccountNetwork.mockRejectedValue(new Error("network down"));
+
+      const result = await estimateFees(mockConfig, sendNativeWithMemo);
+
+      expect(result.value).toBe(
+        BigInt(ACTIVATION_FEES.plus(STANDARD_FEES_NATIVE).plus(MEMO_FEE_PESSIMISTIC).toString()),
+      );
     });
 
     it("reports a non-zero requirement against an unknown pool so the tooltip cannot claim coverage", async () => {

--- a/libs/coin-modules/coin-tron/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-tron/src/logic/estimateFees.ts
@@ -12,7 +12,12 @@ import { decode58Check } from "../network/format";
 import type { AccountTronAPI, ChainParameters } from "../network/types";
 import { abiEncodeTrc20Transfer } from "../network/utils";
 import type { NetworkInfo, TronMemo, TronTxData } from "../types";
-import { ACTIVATION_FEES, STANDARD_FEES_NATIVE, STANDARD_FEES_TRC_20 } from "./constants";
+import {
+  ACTIVATION_FEES,
+  MEMO_FEE_PESSIMISTIC,
+  STANDARD_FEES_NATIVE,
+  STANDARD_FEES_TRC_20,
+} from "./constants";
 import { getBalance } from "./getBalance";
 import { findBalance } from "./utils";
 
@@ -36,15 +41,30 @@ export type TronResourceBreakdown = {
   energyEstimated: boolean;
 };
 
+// UTF-8 byte length of a memo that will land in `raw_data.data`. A memo only reaches the chain on a
+// native or TRC-10 send (`craftSend` rejects it for TRC-20), so it is zero everywhere else. The
+// `kind === "memo"` guard mirrors `craftSend` exactly: pricing a memo the crafter would drop would
+// over-quote it.
+const memoByteLength = (intent: TronIntent): number => {
+  if (intent.type !== "send" || intent.asset.type === "trc20") return 0;
+  const memo =
+    "memo" in intent && intent.memo?.type === "string" && intent.memo.kind === "memo"
+      ? intent.memo.value
+      : "";
+  return memo ? Buffer.byteLength(memo, "utf8") : 0;
+};
+
 // Byte sizes of the fully signed transaction (raw_data + signature + protobuf wrapping).
 // craftTransaction's raw_data_hex alone would underestimate by ~50%: it excludes the signature and
 // the outer envelope.
 export const estimatedTxSize = (intent: TronIntent): number => {
   switch (intent.type) {
     case "send":
-      if (intent.asset.type === "trc10") return 285; // TransferAssetContract
+      // A memo rides in `raw_data.data`, so it grows the serialized size (and thus any bandwidth burn)
+      // by its byte length; the few-byte protobuf field overhead is negligible against these estimates.
+      if (intent.asset.type === "trc10") return 285 + memoByteLength(intent); // TransferAssetContract
       if (intent.asset.type === "trc20") return 350; // TriggerSmartContract
-      return 270; // TransferContract
+      return 270 + memoByteLength(intent); // TransferContract
     case "freeze":
     case "unfreeze":
     case "claimReward":
@@ -177,12 +197,14 @@ const computeActivationFee = (
 };
 
 // Pessimistic fallback when on-chain estimation fails — over-estimates rather than failing.
-// Native/TRC10 worst case: activation fee (recipient inactive) + standard bandwidth burn.
+// Native/TRC10 worst case: activation fee (recipient inactive) + standard bandwidth burn, plus the
+// memo fee when a memo is present (its live value is unknowable here, so assume the 1 TRX mainnet one).
 const fallbackFee = (intent: TronIntent): bigint => {
   if (isTrc20Send(intent)) {
     return BigInt(STANDARD_FEES_TRC_20.toString());
   }
-  return BigInt(ACTIVATION_FEES.plus(STANDARD_FEES_NATIVE).toString());
+  const memoFee = memoByteLength(intent) > 0 ? MEMO_FEE_PESSIMISTIC : new BigNumber(0);
+  return BigInt(ACTIVATION_FEES.plus(STANDARD_FEES_NATIVE).plus(memoFee).toString());
 };
 
 const isTrc20Send = (intent: TronIntent): boolean =>
@@ -241,9 +263,16 @@ export async function estimateFees(
       return withBreakdown(BigInt(STANDARD_FEES_TRC_20.toString()), breakdown);
     }
 
+    // A memo burns a flat, chain-configured fee on top of bandwidth (TIP-387), charged independently of
+    // the bandwidth burn. java-tron charges it whenever `raw_data.data` is non-empty regardless of
+    // contract type (`Manager#consumeMemoFee`), so native and TRC-10 both pay it; 0 on pre-TIP-387 chains.
+    const memoFee =
+      memoByteLength(transactionIntent) > 0 ? new BigNumber(chainParams.memoFee) : new BigNumber(0);
+
     const total = computeBandwidthFee(size, networkInfo, chainParams)
       .plus(computeEnergyFee(energyRequired.toNumber(), networkInfo, chainParams))
-      .plus(computeActivationFee(transactionIntent, recipientAccount, chainParams));
+      .plus(computeActivationFee(transactionIntent, recipientAccount, chainParams))
+      .plus(memoFee);
 
     return withBreakdown(BigInt(total.integerValue(BigNumber.ROUND_CEIL).toFixed()), breakdown);
   } catch (err) {

--- a/libs/coin-modules/coin-tron/src/network/format.test.ts
+++ b/libs/coin-modules/coin-tron/src/network/format.test.ts
@@ -211,6 +211,60 @@ describe("formatTrongridTxResponse", () => {
     });
   });
 
+  it("decodes the memo carried in raw_data.data", async () => {
+    const memo = "ledger-e2e";
+    const contract: TransactionTronAPI["raw_data"]["contract"][0] = {
+      type: "TransferContract",
+      parameter: {
+        type_url: "",
+        value: { owner_address: ownerHex, to_address: toHex, amount: 1_000_000 },
+      },
+    };
+    const tx = baseTransactionTronApi(contract, {
+      raw_data: {
+        contract: [contract],
+        ref_block_bytes: "",
+        ref_block_hash: "",
+        expiration: 0,
+        data: Buffer.from(memo).toString("hex"),
+      },
+    });
+
+    const result = await formatTrongridTxResponse(tx, () => Promise.resolve(null));
+
+    expect(result?.memo).toBe(memo);
+  });
+
+  it("does not surface raw_data.data as a memo for a non-transfer contract type", async () => {
+    // A TriggerSmartContract's `data` is the ABI-encoded call, not a user memo — decoding it as UTF-8
+    // would surface binary garbage, so only transfer contracts are decoded.
+    const contract: TransactionTronAPI["raw_data"]["contract"][0] = {
+      type: "TriggerSmartContract",
+      parameter: {
+        type_url: "",
+        value: {
+          owner_address: ownerHex,
+          to_address: toHex,
+          contract_address: trc20ContractHex,
+          amount: 0,
+        },
+      },
+    };
+    const tx = baseTransactionTronApi(contract, {
+      raw_data: {
+        contract: [contract],
+        ref_block_bytes: "",
+        ref_block_hash: "",
+        expiration: 0,
+        data: Buffer.from("not-a-memo").toString("hex"),
+      },
+    });
+
+    const result = await formatTrongridTxResponse(tx, () => Promise.resolve(null));
+
+    expect(result?.memo).toBeUndefined();
+  });
+
   it("should set hasFailed when contract execution did not succeed", async () => {
     const tx = baseTransactionTronApi(
       {

--- a/libs/coin-modules/coin-tron/src/network/format.ts
+++ b/libs/coin-modules/coin-tron/src/network/format.ts
@@ -114,6 +114,12 @@ export const formatTrongridTxResponse = async (
     const isTrc20 = type === "TriggerSmartContract" && contract_address;
     const isTrc10 = type === "TransferAssetContract";
     const tokenType = isTrc10 ? "trc10" : isTrc20 ? "trc20" : undefined;
+    // The memo the sender attached rides hex-encoded in `raw_data.data`; decode it back to UTF-8 so
+    // synced history can surface it (the mirror of the write path's `extra_data`). Only a native or
+    // TRC-10 transfer carries a user memo there, so decoding `data` on any other type would be garbage.
+    const isTransfer = type === "TransferContract" || type === "TransferAssetContract";
+    const rawMemo = isTransfer ? tx.raw_data.data : undefined;
+    const memo = rawMemo ? Buffer.from(rawMemo, "hex").toString("utf8") : undefined;
     const txInfo: TrongridTxInfo = {
       txID,
       date,
@@ -129,6 +135,7 @@ export const formatTrongridTxResponse = async (
       blockHeight,
       hasFailed,
       feesPayer: from,
+      memo,
     };
 
     const getExtra = async (): Promise<TrongridExtraTxInfo | null | undefined> => {

--- a/libs/coin-modules/coin-tron/src/network/index.test.ts
+++ b/libs/coin-modules/coin-tron/src/network/index.test.ts
@@ -921,11 +921,12 @@ describe("getChainParameters", () => {
       { key: "getTransactionFee", value: 1000 },
       { key: "getCreateAccountFee", value: 100_000 },
       { key: "getCreateNewAccountFeeInSystemContract", value: 1_000_000 },
+      { key: "getMemoFee", value: 1_000_000 },
       { key: "getMaintenanceTimeInterval", value: 21_600_000 },
     ],
   };
 
-  it("parses the four governance-voted parameters used for fee estimation", async () => {
+  it("parses the governance-voted parameters used for fee estimation", async () => {
     mockedNetwork.mockResolvedValueOnce(mockResponse(fullParams));
 
     const params = await getChainParameters(mockConfig);
@@ -935,6 +936,7 @@ describe("getChainParameters", () => {
       transactionFee: 1000,
       createAccountFee: 100_000,
       createNewAccountFeeInSystemContract: 1_000_000,
+      memoFee: 1_000_000,
     });
   });
 
@@ -954,6 +956,7 @@ describe("getChainParameters", () => {
     expect(params.energyFee).toBe(100); // fallback
     expect(params.createAccountFee).toBe(100_000); // fallback
     expect(params.createNewAccountFeeInSystemContract).toBe(1_000_000); // fallback
+    expect(params.memoFee).toBe(0); // fallback: absent key ⇒ chain predates TIP-387 ⇒ no memo fee
   });
 
   it("caches the result across calls (no second HTTP request)", async () => {

--- a/libs/coin-modules/coin-tron/src/network/index.ts
+++ b/libs/coin-modules/coin-tron/src/network/index.ts
@@ -267,6 +267,7 @@ const CHAIN_PARAMETER_KEYS = {
   transactionFee: "getTransactionFee",
   createAccountFee: "getCreateAccountFee",
   createNewAccountFeeInSystemContract: "getCreateNewAccountFeeInSystemContract",
+  memoFee: "getMemoFee",
 } as const;
 
 const FALLBACK_CHAIN_PARAMETERS: ChainParameters = {
@@ -274,6 +275,10 @@ const FALLBACK_CHAIN_PARAMETERS: ChainParameters = {
   transactionFee: 1000,
   createAccountFee: 100_000,
   createNewAccountFeeInSystemContract: 1_000_000,
+  // A node that returns the other parameters but not `getMemoFee` predates TIP-387 and charges no
+  // memo fee, so the correct fallback here is 0 — not a pessimistic 1 TRX, which would over-quote a
+  // memo send on such a chain. The network-down path below quotes pessimistically instead.
+  memoFee: 0,
 };
 
 const fetchChainParameters = async (config: TronCoinConfig): Promise<ChainParameters> => {

--- a/libs/coin-modules/coin-tron/src/network/trongrid/trongrid-adapters.test.ts
+++ b/libs/coin-modules/coin-tron/src/network/trongrid/trongrid-adapters.test.ts
@@ -61,6 +61,16 @@ describe("fromTrongridTxInfoToOperation", () => {
     });
   });
 
+  it("carries a decoded memo onto details.memo so it round-trips into extra.memo", () => {
+    const result = fromTrongridTxInfoToOperation(
+      { ...mockTrongridTxInfo, memo: "ledger-e2e" },
+      mockBlock,
+      mockUserAddress,
+    );
+
+    expect(result.details).toMatchObject({ memo: "ledger-e2e" });
+  });
+
   it("should return IN operation type when the user address is the recipient", () => {
     const txInfo = {
       ...mockTrongridTxInfo,

--- a/libs/coin-modules/coin-tron/src/network/trongrid/trongrid-adapters.ts
+++ b/libs/coin-modules/coin-tron/src/network/trongrid/trongrid-adapters.ts
@@ -46,6 +46,12 @@ export function fromTrongridTxInfoToOperation(
     operation.details = { ...operation.details, familyExtra: trongridTxInfo.extra };
   }
 
+  // `memo` is a framework-reserved `details` key: the generic layer copies it onto `Operation.extra.memo`,
+  // so the sender's note round-trips into synced history.
+  if (trongridTxInfo.memo) {
+    operation.details = { ...operation.details, memo: trongridTxInfo.memo };
+  }
+
   return operation;
 }
 

--- a/libs/coin-modules/coin-tron/src/network/types.ts
+++ b/libs/coin-modules/coin-tron/src/network/types.ts
@@ -238,6 +238,9 @@ export type ChainParameters = {
   transactionFee: number;
   createAccountFee: number;
   createNewAccountFeeInSystemContract: number;
+  // Flat fee burned when a transaction carries a memo (`raw_data.data`), regardless of contract type
+  // (TIP-387). 0 on chains that predate the feature.
+  memoFee: number;
 };
 
 //-- Trigger constant contract

--- a/libs/coin-modules/coin-tron/src/types/bridge.ts
+++ b/libs/coin-modules/coin-tron/src/types/bridge.ts
@@ -65,6 +65,8 @@ export type TrongridTxInfo = {
   extra?: TrongridExtraTxInfo;
   hasFailed: boolean;
   feesPayer?: string;
+  /** Decoded UTF-8 memo carried in the transaction's `raw_data.data`, when present. */
+  memo?: string;
 };
 
 export type TronOperation = Operation<TrongridExtraTxInfo>;

--- a/libs/coin-tester-modules/coin-tester-tron/README.md
+++ b/libs/coin-tester-modules/coin-tester-tron/README.md
@@ -30,7 +30,7 @@ order:
 | 3 | Send max LTT (TRC10) | subAccount drained to 0 |
 | 4 | Send 1 USDT (TRC20) | `fee > 0` (no frozen energy → TRX is burned for the TVM call). Uses a bit-for-bit copy of mainnet USDT (`TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t`). |
 | 5 | Send max USDT (TRC20) | subAccount drained to 0 |
-| 6 | Send 5 TRX with a memo | characterisation only — the memo is dropped before crafting, so `extra.memo` is absent and no `memoFee` is charged (see the comment on that row) |
+| 6 | Send 5 TRX with a memo | the memo survives the round-trip — it is crafted into `raw_data.data`, broadcast, and decoded back onto `extra.memo` (LIVE-35735). `fee == 0` here because the devnet does not charge TIP-387's `memoFee` (`getMemoFee` is 0 on `tronbox/tre`) and the memo still fits the free bandwidth quota |
 | 7 | Send 1 USDT with a custom fee limit | `0 < fee <= CUSTOM_FEE_LIMIT_SUN`, subAccount balance delta matches |
 | 8 | Freeze 50 TRX for BANDWIDTH | `tronResources.frozen.bandwidth` grows by exactly the frozen amount; op type `FREEZE`, no native value |
 | 9 | Vote 1 for the devnet witness | `tronResources.votes` contains the witness; op type `VOTE` |

--- a/libs/coin-tester-modules/coin-tester-tron/src/scenarii/tron.ts
+++ b/libs/coin-tester-modules/coin-tester-tron/src/scenarii/tron.ts
@@ -93,15 +93,13 @@ function makeTransactions(): Tx[] {
       expect(latestOp.type).toBe("OUT");
       expect(latestOp.recipients).toContain(recipient.address);
 
-      // CHARACTERISATION TEST — pins a known defect, not an endorsement: shared `transactionToIntent`
-      // emits a pre-Memo-union shape — `{ type: memoType, value }`, with no `kind`; coin-tron's
-      // `craftSend` requires `kind === "memo"`, so the memo is silently dropped and never reaches the
-      // chain. When fixed upstream THIS ASSERTION FAILS — that is the point: flip it to assert the
-      // memo survives. A dropped memo also means TRON's 1 TRX `memoFee` is never charged, so once it
-      // lands this row's fee expectation must account for it. `craftSend`'s memo branch is the
-      // receiving half of that fix — unreachable from the app until then, not dead code.
+      // The memo survives end-to-end (LIVE-35735): shared `transactionToIntent` emits the framework's
+      // `StringMemo`, `craftSend` writes it into `raw_data.data`, and sync decodes it back onto `extra.memo`.
       const extra = latestOp.extra as { memo?: string };
-      expect(extra.memo).toBeUndefined();
+      expect(extra.memo).toBe("ledger-e2e");
+      // TIP-387's memo fee is a chain parameter left at its 0 default on the devnet, and a native send
+      // fits the free bandwidth quota — so the memo costs nothing here, and `estimateFees` reads the
+      // same 0 from the chain, keeping estimate and actual in agreement.
       expect(latestOp.fee).toStrictEqual(new BigNumber(0));
     },
   };

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/api/index.unit.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/api/index.unit.test.ts
@@ -93,7 +93,6 @@ describe("getCoinModuleApi", () => {
   // need the currency id (evm, cardano) forward it, the rest take no arguments.
   const testCases = [
     { network: "xrp", module: xrpModule, label: "XRP", params: [] as unknown[] },
-    { network: "stellar", module: stellarModule, label: "Stellar", params: [] as unknown[] },
     { network: "tron", module: tronModule, label: "Tron", params: [] as unknown[] },
     { network: "canton", module: cantonModule, label: "Canton", params: [] as unknown[] },
     {
@@ -117,6 +116,16 @@ describe("getCoinModuleApi", () => {
       expect(result).toEqual(mockApiInstance);
       expect(module.createApi).toHaveBeenCalledWith(...params);
     });
+  });
+
+  // Stellar wraps its local api to translate the framework memo union onto coin-stellar's flat
+  // memo shape (LIVE-35735), so it does not pass the base api through verbatim like the others.
+  it('should return a memo-adapting Stellar API for network "stellar" and kind "local"', async () => {
+    const result = await getCoinModuleApi("stellar", "local");
+    expect(stellarModule.createApi).toHaveBeenCalledWith();
+    expect(result).toMatchObject(mockApiInstance);
+    expect(typeof (result as { craftTransaction: unknown }).craftTransaction).toBe("function");
+    expect(typeof (result as { validateIntent: unknown }).validateIntent).toBe("function");
   });
 
   it("should return network API for kind !== 'local'", async () => {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
@@ -835,9 +835,9 @@ describe("coin-framework utils", () => {
     describe("memo", () => {
       const account = { currency: { name: "ethereum", units: [{}] } } as Account;
 
-      it("defaults to NO_MEMO when no memo or tag is provided", () => {
+      it("defaults to the framework's MemoNotSupported when no memo or tag is provided", () => {
         const intent = transactionToIntent(account, {} as GenericTransaction);
-        expect(intent.memo).toEqual({ type: "NO_MEMO" });
+        expect(intent.memo).toEqual({ type: "none" });
       });
 
       it.each([
@@ -851,12 +851,12 @@ describe("coin-framework utils", () => {
         });
       });
 
-      it("maps memoType/memoValue to a typed memo", () => {
+      it("maps memoType/memoValue to a StringMemo with memoType as its kind", () => {
         const intent = transactionToIntent(account, {
           memoType: "memo-type",
           memoValue: "memo-value",
         } as GenericTransaction);
-        expect(intent.memo).toEqual({ type: "memo-type", value: "memo-value" });
+        expect(intent.memo).toEqual({ type: "string", kind: "memo-type", value: "memo-value" });
       });
 
       it("prefers tag over memoType/memoValue when both are set", () => {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
@@ -18,7 +18,10 @@ import type {
   Balance,
   Operation as CoreOperation,
   FeeEstimation,
+  MapMemo,
+  MemoNotSupported,
   StakingOperation,
+  StringMemo,
   TransactionIntent,
   TxData,
 } from "@ledgerhq/coin-module-framework/api/types";
@@ -437,9 +440,11 @@ function isDelegationMode(mode: GenericTransaction["mode"]): mode is StakingOper
   );
 }
 
-type GenericCoinFrameworkMemo =
-  | { type: string; value?: string }
-  | { type: "map"; memos: Map<string, string> };
+// Reuse the framework's own memo union rather than a parallel shape: a `StringMemo` for typed memos,
+// `MemoNotSupported` for none, and a `MapMemo` for a numeric destination tag. Emitting anything else
+// (e.g. `{ type: memoType, value }`, which drops the `kind`) type-checks against the base `Memo` but
+// is silently dropped by every coin module's `kind === "…"` guard (LIVE-35735).
+type GenericCoinFrameworkMemo = MemoNotSupported | StringMemo<string> | MapMemo<string, string>;
 type GenericCoinFrameworkTxData = { type: string; value?: unknown };
 type GenericCoinFrameworkTransactionIntent = TransactionIntent & {
   memo?: GenericCoinFrameworkMemo;
@@ -781,7 +786,7 @@ function defaultComputeIntentType(transaction: GenericTransaction): string {
  * @returns A `TransactionIntent` object containing the standardized representation of the transaction.
  *   - Includes details such as type, sender, recipient, amount, fees, asset, and an optional memo.
  *   - If `assetReference` and `assetOwner` are provided, the asset is represented as a token.
- *   - If `memoType` and `memoValue` are provided, a memo is included; otherwise, a default memo of type "NO_MEMO" is added.
+ *   - If `memoType` and `memoValue` are provided, a `StringMemo` is included (with `memoType` as its `kind`); otherwise the framework's `MemoNotSupported` (`{ type: "none" }`) is used.
  *
  * @throws An error if the transaction mode is unsupported.
  */
@@ -836,12 +841,15 @@ export function transactionToIntent(
       memos: new Map([["destinationTag", String(transaction.tag)]]),
     };
   } else if (transaction.memoType && transaction.memoValue) {
+    // The family's declared `kind` travels in `memoType` (Tron "memo", Casper "transferId", …); emit
+    // the union's `StringMemo` so the coin module's `type === "string" && kind === "…"` guard matches.
     res.memo = {
-      type: transaction.memoType,
+      type: "string",
+      kind: transaction.memoType,
       value: transaction.memoValue,
     };
   } else {
-    res.memo = { type: "NO_MEMO" };
+    res.memo = { type: "none" };
   }
 
   res.data = resolveIntentData(transaction, res, craftTransactionData, buildIntentData);

--- a/libs/ledger-live-common/src/families/stellar/coinModuleApi.test.ts
+++ b/libs/ledger-live-common/src/families/stellar/coinModuleApi.test.ts
@@ -1,0 +1,63 @@
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+import { createLocalStellarApi } from "./coinModuleApi";
+import { createApi as createStellarApi } from "@ledgerhq/coin-stellar/api/index";
+
+jest.mock("@ledgerhq/coin-stellar/api/index", () => ({
+  createApi: jest.fn(),
+}));
+
+const mockCreateStellarApi = createStellarApi as jest.Mock;
+
+describe("stellar coinModuleApi memo adapter", () => {
+  const craftTransaction = jest.fn();
+  const validateIntent = jest.fn();
+  const context = {} as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateStellarApi.mockReturnValue({ craftTransaction, validateIntent });
+  });
+
+  it("translates a StringMemo to Stellar's { type: kind, value } for craftTransaction", () => {
+    createLocalStellarApi("stellar").craftTransaction(context, {
+      memo: { type: "string", kind: "MEMO_TEXT", value: "hello" },
+    } as any);
+
+    expect(craftTransaction).toHaveBeenCalledWith(
+      context,
+      expect.objectContaining({ memo: { type: "MEMO_TEXT", value: "hello" } }),
+      undefined,
+    );
+  });
+
+  it("translates MemoNotSupported to Stellar's NO_MEMO sentinel for validateIntent", () => {
+    createLocalStellarApi("stellar").validateIntent(context, { memo: { type: "none" } } as any, []);
+
+    expect(validateIntent).toHaveBeenCalledWith(
+      context,
+      expect.objectContaining({ memo: { type: "NO_MEMO" } }),
+      [],
+      undefined,
+    );
+  });
+
+  it("leaves every non-memo intent field intact", () => {
+    createLocalStellarApi("stellar").craftTransaction(context, {
+      sender: "GABC",
+      recipient: "GDEF",
+      amount: 1n,
+      memo: { type: "string", kind: "MEMO_ID", value: "42" },
+    } as any);
+
+    expect(craftTransaction).toHaveBeenCalledWith(
+      context,
+      {
+        sender: "GABC",
+        recipient: "GDEF",
+        amount: 1n,
+        memo: { type: "MEMO_ID", value: "42" },
+      },
+      undefined,
+    );
+  });
+});

--- a/libs/ledger-live-common/src/families/stellar/coinModuleApi.ts
+++ b/libs/ledger-live-common/src/families/stellar/coinModuleApi.ts
@@ -1,8 +1,42 @@
 import { createApi as createStellarApi } from "@ledgerhq/coin-stellar/api/index";
-import type { CoinModuleApi } from "@ledgerhq/coin-module-framework/api/types";
+import type { CoinModuleApi, Memo, StringMemo } from "@ledgerhq/coin-module-framework/api/types";
 import type { BridgeApi } from "@ledgerhq/ledger-wallet-framework/api/types";
+
+// The shared generic-coin-framework emits the framework memo union: `StringMemo`
+// (`{ type: "string", kind, value }`) for a typed memo, `MemoNotSupported` (`{ type: "none" }`) for
+// none. coin-stellar predates that union — it reads `memo.type` as its own Stellar memo kind and
+// validates a `NO_MEMO` sentinel. Translating at this boundary keeps that quirk inside the stellar
+// family, so the shared layer stays memo-union-only with no family-name branch leaking in (LIVE-35735).
+// Stellar never sets a numeric tag, so the union's `MapMemo` never reaches here.
+// coin-stellar's flat wire shape — `type` is the Stellar memo kind (or `NO_MEMO`), not the union's discriminant.
+type StellarWireMemo = { type: string; value?: string };
+
+function toStellarMemo(memo: Memo): StellarWireMemo {
+  if (memo.type === "string") {
+    const { kind, value } = memo as StringMemo<string>;
+    return { type: kind, value };
+  }
+  return { type: "NO_MEMO" };
+}
+
+// Typed loosely because this is the seam between the two memo conventions; `toStellarMemo` is the
+// typed part.
+function withStellarMemo<I>(intent: I): I {
+  const memo = (intent as { memo?: Memo }).memo;
+  return memo === undefined ? intent : ({ ...intent, memo: toStellarMemo(memo) } as I);
+}
 
 // Config is resolved from the Context bound in getCoinModuleApi (framework v6), so createApi() takes none.
 export function createLocalStellarApi(_currencyId: string): CoinModuleApi<any> & BridgeApi {
-  return createStellarApi() as CoinModuleApi<any> & BridgeApi;
+  const api = createStellarApi() as CoinModuleApi<any> & BridgeApi;
+  // `craftTransaction` and `validateIntent` are the only methods that read the intent memo in
+  // coin-stellar@9.0.0 (`estimateFees` ignores the intent, `craftTransactionData` returns `none`) —
+  // re-verify this set on a coin-stellar upgrade.
+  return {
+    ...api,
+    craftTransaction: (context, intent, options) =>
+      api.craftTransaction(context, withStellarMemo(intent), options),
+    validateIntent: (context, intent, balances, options) =>
+      api.validateIntent(context, withStellarMemo(intent), balances, options),
+  };
 }


### PR DESCRIPTION
### 📝 Description

The generic coin framework's shared `transactionToIntent` emitted a memo shape that predated the framework's memo union (`{ type: memoType, value }`, no `kind`), so any family declaring a typed memo hit its own `type === "string" && kind === "…"` guard, the memo resolved to `undefined`, and it silently never reached the chain — no error, which is why the type checker and the migration's unit tests missed it.

`transactionToIntent` now emits the framework's own union — `StringMemo` (with `memoType` as the `kind`) for typed memos, `MemoNotSupported` (`{ type: "none" }`) for none — so the memo survives for Tron today and for the Cardano, Concordium, Casper and Algorand migrations that read the same shape. The one exception is the external, unmodifiable coin-stellar, which predates the union and reads `memo.type` as its own Stellar memo kind with a `NO_MEMO` sentinel, so it keeps its flat shape.

For Tron the memo now reaches the chain, so it is also priced and surfaced: `estimateFees` adds the `getMemoFee` chain parameter (TIP-387) plus the memo's bytes for a memo-bearing native or TRC-10 send, and sync decodes the memo back onto the operation's `extra.memo` for history.

Regression coverage: `generic-coin-framework/utils.test.ts` pins the per-family memo shapes (union vs. Stellar's flat shape); the Tron and Stellar coin-testers exercise the end-to-end signing paths.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35735](https://ledgerhq.atlassian.net/browse/LIVE-35735)
- **ADR** (if any): n/a

[LIVE-35735]: https://ledgerhq.atlassian.net/browse/LIVE-35735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ