### PR TITLE
feat(pay): keep hero empty vs funded from holdings (LIVE-36422)

### DIFF
--- a/.changeset/pay-hero-no-flash.md
+++ b/.changeset/pay-hero-no-flash.md
@@ -1,0 +1,7 @@
+---
+"@features/flow-pay-balance": minor
+"live-mobile": minor
+"ledger-live-desktop": minor
+---
+
+Keep Pay hero empty vs funded from cached holdings; skeleton the amount only when funded (LIVE-36422).

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/PayTab.hero.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/PayTab.hero.integration.test.tsx
@@ -4,7 +4,6 @@ import { mockStablecoinsResponse } from "@domain/api-aggregated-assets/mock/stab
 import { renderWithMockedCounterValuesProvider, screen } from "tests/testSetup";
 import { server, http, HttpResponse } from "tests/server";
 import { genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { TokenCurrencySchema } from "@domain/entity-currency-token";
 import type { Account } from "@ledgerhq/types-live";
 import PayTab from "LLD/features/PayTab";
 import {
@@ -12,15 +11,7 @@ import {
   ETH_ACCOUNT,
   ETH_ACCOUNT_WITH_USDC,
 } from "LLD/features/__mocks__/accounts.mock";
-import { onboardedState, tourSeenState } from "./fixtures";
-
-jest.mock(
-  "@features/platform-device-action-content",
-  () => ({
-    getDeviceActionAnimation: jest.fn(),
-  }),
-  { virtual: true },
-);
+import { onboardedState, tourSeenState, UNISWAP } from "./fixtures";
 
 const DADA_URLS = [
   "https://dada.api.ledger-test.com/v1/assets",
@@ -29,20 +20,9 @@ const DADA_URLS = [
 
 const ethWithoutTokens: Account = { ...ETH_ACCOUNT, subAccounts: [] };
 
-const uni = TokenCurrencySchema.parse({
-  type: "TokenCurrency",
-  id: "ethereum/erc20/uniswap",
-  parentCurrencyId: ETH_ACCOUNT.currency.id,
-  contractAddress: "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
-  tokenType: "erc20",
-  ticker: "UNI",
-  name: "Uniswap",
-  units: [{ name: "Uniswap", code: "UNI", magnitude: 18 }],
-});
-
-const ethWithUni: Account = {
+const ethWithUniswap: Account = {
   ...ethWithoutTokens,
-  subAccounts: [genTokenAccount(0, ethWithoutTokens, uni)],
+  subAccounts: [genTokenAccount(0, ethWithoutTokens, UNISWAP)],
 };
 
 function renderHero(accounts: Account[]) {
@@ -161,7 +141,7 @@ describe("PayTab hero integration", () => {
 
   it("should be funded while DADA hangs if the user holds UNI, then empty when it resolves", async () => {
     const release = holdDada();
-    renderHero([ethWithUni]);
+    renderHero([ethWithUniswap]);
 
     await expectFundedHero();
     release();

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/PayTab.hero.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/PayTab.hero.integration.test.tsx
@@ -1,0 +1,170 @@
+import React from "react";
+import { delay } from "msw";
+import { mockStablecoinsResponse } from "@domain/api-aggregated-assets/mock/stablecoins";
+import { renderWithMockedCounterValuesProvider, screen } from "tests/testSetup";
+import { server, http, HttpResponse } from "tests/server";
+import { genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { TokenCurrencySchema } from "@domain/entity-currency-token";
+import type { Account } from "@ledgerhq/types-live";
+import PayTab from "LLD/features/PayTab";
+import {
+  BTC_ACCOUNT,
+  ETH_ACCOUNT,
+  ETH_ACCOUNT_WITH_USDC,
+} from "LLD/features/__mocks__/accounts.mock";
+import { onboardedState, tourSeenState } from "./fixtures";
+
+jest.mock(
+  "@features/platform-device-action-content",
+  () => ({
+    getDeviceActionAnimation: jest.fn(),
+  }),
+  { virtual: true },
+);
+
+const DADA_URLS = [
+  "https://dada.api.ledger-test.com/v1/assets",
+  "https://dada.api.ledger.com/v1/assets",
+];
+
+const ethWithoutTokens: Account = { ...ETH_ACCOUNT, subAccounts: [] };
+
+const uni = TokenCurrencySchema.parse({
+  type: "TokenCurrency",
+  id: "ethereum/erc20/uniswap",
+  parentCurrencyId: ETH_ACCOUNT.currency.id,
+  contractAddress: "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
+  tokenType: "erc20",
+  ticker: "UNI",
+  name: "Uniswap",
+  units: [{ name: "Uniswap", code: "UNI", magnitude: 18 }],
+});
+
+const ethWithUni: Account = {
+  ...ethWithoutTokens,
+  subAccounts: [genTokenAccount(0, ethWithoutTokens, uni)],
+};
+
+function renderHero(accounts: Account[]) {
+  return renderWithMockedCounterValuesProvider(<PayTab />, {
+    initialState: { ...onboardedState, ...tourSeenState, accounts },
+  });
+}
+
+async function expectEmptyHero() {
+  expect(await screen.findByTestId("pay-card-balance-empty-state")).toBeVisible();
+  expect(screen.queryByTestId("pay-card-balance-funded-state")).not.toBeInTheDocument();
+}
+
+async function expectFundedHero() {
+  expect(await screen.findByTestId("pay-card-balance-funded-state")).toBeVisible();
+  expect(screen.queryByTestId("pay-card-balance-empty-state")).not.toBeInTheDocument();
+}
+
+function dadaResponse() {
+  return HttpResponse.json(mockStablecoinsResponse);
+}
+
+function setDada(mode: "hang" | "error") {
+  server.use(
+    ...DADA_URLS.map(url =>
+      http.get(url, async ({ request }) => {
+        if (mode === "hang") await delay("infinite");
+        const isAmountQuery = new URL(request.url).searchParams.has("currencyIds");
+        if (isAmountQuery && mode === "error") return HttpResponse.json(null, { status: 500 });
+        return dadaResponse();
+      }),
+    ),
+  );
+}
+
+function holdDada() {
+  let release!: () => void;
+  const gate = new Promise<void>(resolve => {
+    release = resolve;
+  });
+  server.use(
+    ...DADA_URLS.map(url =>
+      http.get(url, async () => {
+        await gate;
+        return dadaResponse();
+      }),
+    ),
+  );
+  return () => release();
+}
+
+describe("PayTab hero integration", () => {
+  it("should be empty when there are no accounts", async () => {
+    renderHero([]);
+
+    await expectEmptyHero();
+  });
+
+  it("should be empty when accounts hold only crypto", async () => {
+    renderHero([ethWithoutTokens, BTC_ACCOUNT]);
+
+    await expectEmptyHero();
+  });
+
+  it("should be funded when accounts hold USDC", async () => {
+    renderHero([ETH_ACCOUNT_WITH_USDC]);
+
+    await expectFundedHero();
+  });
+
+  it("should stay empty while DADA hangs if the user holds no stablecoins", async () => {
+    setDada("hang");
+    renderHero([ethWithoutTokens, BTC_ACCOUNT]);
+
+    await expectEmptyHero();
+  });
+
+  it("should stay funded while the catalog hangs if the user holds USDC", async () => {
+    setDada("hang");
+    renderHero([ETH_ACCOUNT_WITH_USDC]);
+
+    await expectFundedHero();
+  });
+
+  it("should stay empty when DADA fails if the user holds no stablecoins", async () => {
+    setDada("error");
+    renderHero([ethWithoutTokens, BTC_ACCOUNT]);
+
+    await expectEmptyHero();
+  });
+
+  it("should stay funded when DADA fails if the user holds USDC", async () => {
+    setDada("error");
+    renderHero([ETH_ACCOUNT_WITH_USDC]);
+
+    await expectFundedHero();
+  });
+
+  it("should stay funded when DADA resolves a USDC holding", async () => {
+    const release = holdDada();
+    renderHero([ETH_ACCOUNT_WITH_USDC]);
+
+    await expectFundedHero();
+    release();
+    await expectFundedHero();
+  });
+
+  it("should stay empty when DADA resolves with no stablecoin holding", async () => {
+    const release = holdDada();
+    renderHero([ethWithoutTokens, BTC_ACCOUNT]);
+
+    await expectEmptyHero();
+    release();
+    await expectEmptyHero();
+  });
+
+  it("should be funded while DADA hangs if the user holds UNI, then empty when it resolves", async () => {
+    const release = holdDada();
+    renderHero([ethWithUni]);
+
+    await expectFundedHero();
+    release();
+    await expectEmptyHero();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/fixtures.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/fixtures.ts
@@ -1,6 +1,11 @@
 import type { TokenAccount } from "@ledgerhq/types-live";
+import { TokenCurrencySchema } from "@domain/entity-currency-token";
 import type { InitializationInput } from "LLD/components/DeviceIntentExecutor";
-import { BTC_ACCOUNT, ETH_ACCOUNT_WITH_USDC } from "LLD/features/__mocks__/accounts.mock";
+import {
+  BTC_ACCOUNT,
+  ETH_ACCOUNT,
+  ETH_ACCOUNT_WITH_USDC,
+} from "LLD/features/__mocks__/accounts.mock";
 import { payCardFeatureTourInitialState } from "@features/flow-pay-feature-tour/state";
 import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
 import { withFlagOverrides } from "tests/testSetup";
@@ -45,3 +50,14 @@ export const defaultPayStablecoins: PayStablecoins = {
 export const INIT_INPUT = { appName: "Ethereum" } as InitializationInput;
 
 export const USDC_TOKEN = ETH_ACCOUNT_WITH_USDC.subAccounts![0] as TokenAccount;
+
+export const UNISWAP = TokenCurrencySchema.parse({
+  type: "TokenCurrency",
+  id: "ethereum/erc20/uniswap",
+  parentCurrencyId: ETH_ACCOUNT.currency.id,
+  contractAddress: "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
+  tokenType: "erc20",
+  ticker: "UNI",
+  name: "Uniswap",
+  units: [{ name: "Uniswap", code: "UNI", magnitude: 18 }],
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayStablecoins.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayStablecoins.ts
@@ -1,33 +1,57 @@
 import { useMemo } from "react";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
+import type { AccountLike } from "@ledgerhq/types-live";
 import { useDistribution } from "~/renderer/actions/general";
 import {
   useStablecoinTickers,
   useDefaultStablecoins,
   type DefaultStablecoin,
 } from "@features/platform-aggregated-assets";
+import { useCategorizedAssets } from "@ledgerhq/asset-aggregation/assetCategorization/index";
 import {
-  useCategorizedAssets,
-  type CategorizedAssetItem,
-} from "@ledgerhq/asset-aggregation/assetCategorization/index";
+  buildStablecoinHoldings,
+  type HeldAccount,
+  type StablecoinItem,
+} from "@features/flow-pay-balance";
 import { useSelector } from "LLD/hooks/redux";
+import { flattenAccountsSelector } from "~/renderer/reducers/accounts";
 import {
   blacklistedTokenIdsSelector,
   hideEmptyTokenAccountsSelector,
 } from "~/renderer/reducers/settings";
 
 export type PayStablecoins = Readonly<{
-  stablecoins: CategorizedAssetItem[];
+  stablecoins: StablecoinItem[];
   defaultStablecoins: DefaultStablecoin[];
   isLoading: boolean;
   isError: boolean;
 }>;
 
+function toHeldAccount(account: AccountLike): HeldAccount {
+  const currency = getAccountCurrency(account);
+  return {
+    type: account.type,
+    balance: account.balance.toNumber(),
+    currency: {
+      id: currency.id,
+      name: currency.name,
+      ticker: currency.ticker,
+      units: currency.units.map(unit => ({
+        name: unit.name,
+        code: unit.code,
+        magnitude: unit.magnitude,
+      })),
+    },
+  };
+}
+
 export function usePayStablecoins(): PayStablecoins {
   const hideEmptyTokenAccount = useSelector(hideEmptyTokenAccountsSelector);
   const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector);
+  const heldAccounts = useSelector(flattenAccountsSelector);
 
-  // Force cross-chain asset grouping so each stablecoin is a single aggregated item,
-  // independent of the aggregatedAssets wallet flag.
+  // groupBy: "asset" aggregates each ticker across chains into one row.
+  // This path does not read the aggregatedAssets wallet flag.
   const distribution = useDistribution({
     showEmptyAccounts: true,
     hideEmptyTokenAccount,
@@ -46,12 +70,25 @@ export function usePayStablecoins(): PayStablecoins {
     isError: isDefaultStablecoinsError,
   } = useDefaultStablecoins("lld", __APP_VERSION__);
 
-  const categorized = useCategorizedAssets(distribution, stablecoinTickers);
+  const { stablecoins: catalogStablecoins } = useCategorizedAssets(distribution, stablecoinTickers);
 
-  const stablecoins = useMemo(() => {
-    const blacklist = new Set(blacklistedTokenIds ?? []);
-    return categorized.stablecoins.filter(({ currency }) => !blacklist.has(currency.id));
-  }, [categorized.stablecoins, blacklistedTokenIds]);
+  const stablecoins = useMemo(
+    () =>
+      buildStablecoinHoldings({
+        catalog: catalogStablecoins,
+        heldAccounts: heldAccounts.map(toHeldAccount),
+        blacklistedTokenIds,
+        stablecoinTickers,
+        isLoadingStablecoinTickers,
+      }),
+    [
+      catalogStablecoins,
+      heldAccounts,
+      blacklistedTokenIds,
+      stablecoinTickers,
+      isLoadingStablecoinTickers,
+    ],
+  );
 
   return {
     stablecoins,

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
@@ -7,6 +7,9 @@ import {
   type NativeStackScreenProps,
 } from "@react-navigation/native-stack";
 import { render, screen, waitFor, within } from "@tests/test-renderer";
+import { server, http, HttpResponse, delay } from "@tests/server";
+import { mockData } from "@ledgerhq/live-common/modularDrawer/__mocks__/dada.mock";
+import { mockStablecoinsResponse } from "@domain/api-aggregated-assets/mock/stablecoins";
 import { PAY_CARD_BALANCE_FILTER_ALL } from "@features/flow-pay-balance/state";
 import { AssetCategory } from "@domain/api-aggregated-assets";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
@@ -54,8 +57,19 @@ const usdc = TokenCurrencySchema.parse({
   name: "USD Coin",
   units: [{ name: "USD Coin", code: "USDC", magnitude: 6 }],
 });
+const uni = TokenCurrencySchema.parse({
+  type: "TokenCurrency",
+  id: "ethereum/erc20/uniswap",
+  parentCurrencyId: ethereum.id,
+  contractAddress: "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
+  tokenType: "erc20",
+  ticker: "UNI",
+  name: "Uniswap",
+  units: [{ name: "Uniswap", code: "UNI", magnitude: 18 }],
+});
 const payTabEthAccount = genAccount("pay-tab-eth", { currency: ethereum });
 const payTabUsdcAccount = genTokenAccount(0, payTabEthAccount, usdc);
+const payTabUniAccount = genTokenAccount(0, payTabEthAccount, uni);
 
 type TestStackParamList = {
   PayTabTest: undefined;
@@ -77,9 +91,16 @@ function ReceiveFundsScreen({
   );
 }
 
+const DADA_URLS = [
+  "https://dada.api.ledger-test.com/v1/assets",
+  "https://dada.api.ledger.com/v1/assets",
+];
+
 type RenderPayTabOptions = Readonly<{
   hasSeenFeatureTour?: boolean;
   holdsUsdc?: boolean;
+  holdsUni?: boolean;
+  cryptoOnly?: boolean;
 }>;
 
 function withUsdcHoldings(state: State): State {
@@ -99,7 +120,61 @@ function withUsdcHoldings(state: State): State {
   };
 }
 
-function renderPayTab({ hasSeenFeatureTour = true, holdsUsdc = false }: RenderPayTabOptions = {}) {
+function withCryptoOnly(state: State): State {
+  return {
+    ...state,
+    accounts: { active: [{ ...payTabEthAccount, subAccounts: [] }] },
+  };
+}
+
+function withUniHoldings(state: State): State {
+  return {
+    ...state,
+    accounts: { active: [{ ...payTabEthAccount, subAccounts: [payTabUniAccount] }] },
+  };
+}
+
+function dadaResponse(request: Request) {
+  const categories = new URL(request.url).searchParams.get("categories");
+  if (categories === "stablecoins") return HttpResponse.json(mockStablecoinsResponse);
+  return HttpResponse.json(mockData);
+}
+
+function setDada(mode: "hang" | "error") {
+  server.use(
+    ...DADA_URLS.map(url =>
+      http.get(url, async ({ request }) => {
+        if (mode === "hang") await delay("infinite");
+        const isAmountQuery = new URL(request.url).searchParams.has("currencyIds");
+        if (isAmountQuery && mode === "error") return HttpResponse.json(null, { status: 500 });
+        return dadaResponse(request);
+      }),
+    ),
+  );
+}
+
+function holdDada() {
+  let release!: () => void;
+  const gate = new Promise<void>(resolve => {
+    release = resolve;
+  });
+  server.use(
+    ...DADA_URLS.map(url =>
+      http.get(url, async ({ request }) => {
+        await gate;
+        return dadaResponse(request);
+      }),
+    ),
+  );
+  return () => release();
+}
+
+function renderPayTab({
+  hasSeenFeatureTour = true,
+  holdsUsdc = false,
+  holdsUni = false,
+  cryptoOnly = false,
+}: RenderPayTabOptions = {}) {
   return render(
     <Stack.Navigator screenOptions={{ headerShown: false, animation: "none" }}>
       <Stack.Screen name="PayTabTest" component={PayTabNavigator} />
@@ -111,7 +186,10 @@ function renderPayTab({ hasSeenFeatureTour = true, holdsUsdc = false }: RenderPa
           ...state,
           payCardFeatureTour: { ...state.payCardFeatureTour, hasSeenFeatureTour },
         };
-        return holdsUsdc ? withUsdcHoldings(next) : next;
+        if (holdsUsdc) return withUsdcHoldings(next);
+        if (holdsUni) return withUniHoldings(next);
+        if (cryptoOnly) return withCryptoOnly(next);
+        return next;
       },
     },
   );
@@ -193,6 +271,76 @@ describe("PayTab integration", () => {
 
       expect(await screen.findByTestId("pay-card-balance-funded-state")).toBeVisible();
       expect(screen.queryByTestId("pay-card-balance-empty-state")).toBeNull();
+    });
+
+    it("should render the empty hero when accounts hold only crypto", async () => {
+      renderPayTab({ cryptoOnly: true });
+
+      expect(await screen.findByTestId("pay-card-balance-empty-state")).toBeVisible();
+      expect(screen.queryByTestId("pay-card-balance-funded-state")).toBeNull();
+    });
+
+    it("should stay empty while DADA hangs if the user holds no stablecoins", async () => {
+      setDada("hang");
+      renderPayTab({ cryptoOnly: true });
+
+      expect(await screen.findByTestId("pay-card-balance-empty-state")).toBeVisible();
+      expect(screen.queryByTestId("pay-card-balance-funded-state")).toBeNull();
+    });
+
+    it("should stay funded while the catalog hangs if the user holds USDC", async () => {
+      setDada("hang");
+      renderPayTab({ holdsUsdc: true });
+
+      expect(await screen.findByTestId("pay-card-balance-funded-state")).toBeVisible();
+      expect(screen.queryByTestId("pay-card-balance-empty-state")).toBeNull();
+    });
+
+    it("should stay empty when DADA fails if the user holds no stablecoins", async () => {
+      setDada("error");
+      renderPayTab({ cryptoOnly: true });
+
+      expect(await screen.findByTestId("pay-card-balance-empty-state")).toBeVisible();
+      expect(screen.queryByTestId("pay-card-balance-funded-state")).toBeNull();
+    });
+
+    it("should stay funded when DADA fails if the user holds USDC", async () => {
+      setDada("error");
+      renderPayTab({ holdsUsdc: true });
+
+      expect(await screen.findByTestId("pay-card-balance-funded-state")).toBeVisible();
+      expect(screen.queryByTestId("pay-card-balance-empty-state")).toBeNull();
+    });
+
+    it("should become funded when DADA resolves a USDC holding", async () => {
+      const release = holdDada();
+      renderPayTab({ holdsUsdc: true });
+
+      expect(await screen.findByTestId("pay-card-balance-funded-state")).toBeVisible();
+      release();
+      expect(await screen.findByTestId("pay-card-balance-funded-state")).toBeVisible();
+      expect(screen.queryByTestId("pay-card-balance-empty-state")).toBeNull();
+    });
+
+    it("should stay empty when DADA resolves with no stablecoin holding", async () => {
+      const release = holdDada();
+      renderPayTab({ cryptoOnly: true });
+
+      expect(await screen.findByTestId("pay-card-balance-empty-state")).toBeVisible();
+      release();
+      expect(await screen.findByTestId("pay-card-balance-empty-state")).toBeVisible();
+      expect(screen.queryByTestId("pay-card-balance-funded-state")).toBeNull();
+    });
+
+    it("should be funded while DADA hangs if the user holds UNI, then empty when it resolves", async () => {
+      const release = holdDada();
+      renderPayTab({ holdsUni: true });
+
+      expect(await screen.findByTestId("pay-card-balance-funded-state")).toBeVisible();
+      expect(screen.queryByTestId("pay-card-balance-empty-state")).toBeNull();
+      release();
+      expect(await screen.findByTestId("pay-card-balance-empty-state")).toBeVisible();
+      expect(screen.queryByTestId("pay-card-balance-funded-state")).toBeNull();
     });
 
     it("should render Deposit and Request action tiles when the hero is funded", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayStablecoins.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayStablecoins.ts
@@ -1,31 +1,57 @@
 import { useMemo } from "react";
 import VersionNumber from "react-native-version-number";
 import useEnv from "@features/platform-env";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
+import type { AccountLike } from "@ledgerhq/types-live";
 import {
   useStablecoinTickers,
   useDefaultStablecoins,
   type DefaultStablecoin,
 } from "@features/platform-aggregated-assets";
+import { useCategorizedAssets } from "@ledgerhq/asset-aggregation/assetCategorization/index";
 import {
-  useCategorizedAssets,
-  type CategorizedAssetItem,
-} from "@ledgerhq/asset-aggregation/assetCategorization/index";
+  buildStablecoinHoldings,
+  type HeldAccount,
+  type StablecoinItem,
+} from "@features/flow-pay-balance";
 import { useDistribution } from "~/actions/general";
 import { useSelector } from "~/context/hooks";
+import { flattenAccountsSelector } from "~/reducers/accounts";
 import { blacklistedTokenIdsSelector } from "~/reducers/settings";
 
 export type PayStablecoins = Readonly<{
-  stablecoins: CategorizedAssetItem[];
+  stablecoins: StablecoinItem[];
   defaultStablecoins: DefaultStablecoin[];
   isLoading: boolean;
   isError: boolean;
 }>;
 
+function toHeldAccount(account: AccountLike): HeldAccount {
+  const currency = getAccountCurrency(account);
+  return {
+    type: account.type,
+    balance: account.balance.toNumber(),
+    currency: {
+      id: currency.id,
+      name: currency.name,
+      ticker: currency.ticker,
+      units: currency.units.map(unit => ({
+        name: unit.name,
+        code: unit.code,
+        magnitude: unit.magnitude,
+      })),
+    },
+  };
+}
+
 export function usePayStablecoins(): PayStablecoins {
   const hideEmptyTokenAccount = useEnv("HIDE_EMPTY_TOKEN_ACCOUNTS");
   const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector);
+  const heldAccounts = useSelector(flattenAccountsSelector);
   const version = VersionNumber.appVersion ?? "";
 
+  // groupBy: "asset" aggregates each ticker across chains into one row.
+  // This path does not read the aggregatedAssets wallet flag.
   const distribution = useDistribution({
     showEmptyAccounts: true,
     hideEmptyTokenAccount,
@@ -44,12 +70,25 @@ export function usePayStablecoins(): PayStablecoins {
     isError: isDefaultStablecoinsError,
   } = useDefaultStablecoins("llm", version);
 
-  const categorized = useCategorizedAssets(distribution, stablecoinTickers);
+  const { stablecoins: catalogStablecoins } = useCategorizedAssets(distribution, stablecoinTickers);
 
-  const stablecoins = useMemo(() => {
-    const blacklist = new Set(blacklistedTokenIds ?? []);
-    return categorized.stablecoins.filter(({ currency }) => !blacklist.has(currency.id));
-  }, [categorized.stablecoins, blacklistedTokenIds]);
+  const stablecoins = useMemo(
+    () =>
+      buildStablecoinHoldings({
+        catalog: catalogStablecoins,
+        heldAccounts: heldAccounts.map(toHeldAccount),
+        blacklistedTokenIds,
+        stablecoinTickers,
+        isLoadingStablecoinTickers,
+      }),
+    [
+      catalogStablecoins,
+      heldAccounts,
+      blacklistedTokenIds,
+      stablecoinTickers,
+      isLoadingStablecoinTickers,
+    ],
+  );
 
   return {
     stablecoins,

--- a/features/flow/pay-balance/README.md
+++ b/features/flow/pay-balance/README.md
@@ -2,13 +2,13 @@
 
 > [!CAUTION] > **Status: UNSTABLE** — In active development; API may change.
 
-Shared Pay hero (Desktop and Mobile) for the aggregated stablecoin balance. Renders two states:
+Shared Pay hero (Desktop and Mobile) for the aggregated stablecoin balance. Chrome follows
+the held-stablecoin list:
 
-- **funded** — the aggregated stable balance formatted as a countervalue. While `status` is
-  `"loading"` this state renders its amount skeleton, so the empty placeholder never flashes before
-  the balance resolves.
-- **empty** — a placeholder title and description, no balance. Used when the balance is zero or
-  `status` is `"error"`.
+- **funded** — the list has a positive crypto or countervalue amount. While `status` is
+  `"loading"` this state keeps the funded chrome and skeletons the amount.
+- **empty** — the list has no positive amount. Loading and catalog errors do not switch
+  this to funded.
 
 Action tiles render in both modes, as a sibling of the hero so they do not remount when
 empty and funded swap.
@@ -120,9 +120,10 @@ pay-balance/
     ├── hooks/
     │   └── useBalanceData.ts                 # Host-facing data hook
     ├── logic/                                # Platform-agnostic logic (no suffix)
-    │   ├── aggregateBalance.ts               # Filter + sum + status mapping
+    │   ├── aggregateBalance.ts               # Filter + sum + funded flag + status
     │   ├── buildBalanceFilterOptions.ts      # Filter option rows
     │   ├── buildBalanceData.ts               # build + aggregate + reset decision
+    │   ├── buildStablecoinHoldings.ts        # Catalog rows, else held accounts
     │   └── resolveSelection.ts               # Heal a stale persisted filter
     ├── state/                                # UI-free Redux slice (`./state` export)
     ├── types.ts                              # Component + port contracts

--- a/features/flow/pay-balance/src/__tests__/aggregateBalance.web.test.ts
+++ b/features/flow/pay-balance/src/__tests__/aggregateBalance.web.test.ts
@@ -47,14 +47,23 @@ function buildPort(overrides: Partial<PortfolioPort> = {}): PortfolioPort {
   };
 }
 
-const usdc = { currency: { id: "ethereum/erc20/usdc", ticker: "USDC" }, value: 1000 };
-const usdt = { currency: { id: "ethereum/erc20/usdt", ticker: "USDT" }, value: 250.5 };
+const usdc = {
+  currency: { id: "ethereum/erc20/usdc", ticker: "USDC" },
+  value: 1000,
+  balance: 1_000_000,
+};
+const usdt = {
+  currency: { id: "ethereum/erc20/usdt", ticker: "USDT" },
+  value: 250.5,
+  balance: 250_500,
+};
 
 describe("aggregateBalance", () => {
   it("should sum every stablecoin countervalue when the filter is all", () => {
     const data = aggregateBalance(buildPort({ stablecoins: [usdc, usdt] }));
 
     expect(data.stableBalance).toBe(1250.5);
+    expect(data.hasBalance).toBe(true);
     expect(data.status).toBe("ready");
     expect(data.filter).toBe("all");
   });
@@ -99,16 +108,48 @@ describe("aggregateBalance", () => {
     expect(data.status).toBe("error");
   });
 
+  it("should report a balance when a holding has a crypto amount and no countervalue", () => {
+    const data = aggregateBalance(
+      buildPort({
+        stablecoins: [
+          { currency: { id: "ethereum/erc20/usdc", ticker: "USDC" }, value: 0, balance: 1_000_000 },
+        ],
+      }),
+    );
+
+    expect(data.hasBalance).toBe(true);
+    expect(data.stableBalance).toBe(0);
+  });
+
+  it("should stay empty when every holding is zero", () => {
+    const data = aggregateBalance(
+      buildPort({
+        stablecoins: [
+          { currency: { id: "ethereum/erc20/usdc", ticker: "USDC" }, value: 0, balance: 0 },
+        ],
+      }),
+    );
+
+    expect(data.hasBalance).toBe(false);
+  });
+
+  it("should keep hasBalance from all holdings, not the active filter", () => {
+    const data = aggregateBalance(
+      buildPort({
+        stablecoins: [usdc, { ...usdt, value: 0, balance: 0 }],
+        filter: "ethereum/erc20/usdt",
+        filterOptions: filterOptionsWithStablecoins,
+      }),
+    );
+
+    expect(data.stableBalance).toBe(0);
+    expect(data.hasBalance).toBe(true);
+  });
+
   it("should forward the countervalue formatter untouched", () => {
     const data = aggregateBalance(buildPort());
 
     expect(data.formatCountervalue).toBe(formatCountervalue);
-  });
-
-  it("should report hasBalance when any stablecoin has a positive value", () => {
-    const data = aggregateBalance(buildPort({ stablecoins: [usdc] }));
-
-    expect(data.hasBalance).toBe(true);
   });
 
   it("should forward filterOptions and onConfirmFilter", () => {

--- a/features/flow/pay-balance/src/__tests__/buildBalanceData.web.test.ts
+++ b/features/flow/pay-balance/src/__tests__/buildBalanceData.web.test.ts
@@ -97,10 +97,23 @@ describe("buildBalanceData", () => {
     expect(shouldResetFilter).toBe(false);
   });
 
-  it("should report no balance when the user holds no stablecoins", () => {
-    const { data } = build();
+  it("should report a balance when a held stablecoin has a crypto amount and no countervalue", () => {
+    const { data } = build({
+      stablecoins: [
+        {
+          currency: {
+            id: "ethereum/erc20/usd__coin",
+            name: "USD Coin",
+            ticker: "USDC",
+            units: [{ name: "USD Coin", code: "USDC", magnitude: 6 }],
+          },
+          balance: 1_000_000,
+          value: 0,
+        },
+      ],
+    });
 
-    expect(data.hasBalance).toBe(false);
+    expect(data.hasBalance).toBe(true);
   });
 
   it("should always expose the all option first, followed by the defaults", () => {

--- a/features/flow/pay-balance/src/__tests__/buildStablecoinHoldings.web.test.ts
+++ b/features/flow/pay-balance/src/__tests__/buildStablecoinHoldings.web.test.ts
@@ -1,0 +1,111 @@
+import {
+  buildStablecoinHoldings,
+  type BuildStablecoinHoldingsParams,
+  type HeldAccount,
+} from "../logic/buildStablecoinHoldings";
+import type { StablecoinItem } from "../logic/buildBalanceFilterOptions";
+
+const USDC_CURRENCY: StablecoinItem["currency"] = {
+  id: "ethereum/erc20/usd__coin",
+  name: "USD Coin",
+  ticker: "USDC",
+  units: [{ name: "USD Coin", code: "USDC", magnitude: 6 }],
+};
+
+const USDT_CURRENCY: StablecoinItem["currency"] = {
+  id: "ethereum/erc20/usd_tether__erc20_",
+  name: "Tether USD",
+  ticker: "USDT",
+  units: [{ name: "Tether USD", code: "USDT", magnitude: 6 }],
+};
+
+const ETH_CURRENCY: StablecoinItem["currency"] = {
+  id: "ethereum",
+  name: "Ethereum",
+  ticker: "ETH",
+  units: [{ name: "Ether", code: "ETH", magnitude: 18 }],
+};
+
+const UNI_CURRENCY: StablecoinItem["currency"] = {
+  id: "ethereum/erc20/uniswap",
+  name: "Uniswap",
+  ticker: "UNI",
+  units: [{ name: "Uniswap", code: "UNI", magnitude: 18 }],
+};
+
+const usdcCatalog: StablecoinItem = {
+  currency: USDC_CURRENCY,
+  balance: 1_000_000_000,
+  value: 1000,
+};
+const usdtCatalog: StablecoinItem = { currency: USDT_CURRENCY, balance: 250_000_000, value: 250 };
+
+const usdcHeld: HeldAccount = {
+  type: "TokenAccount",
+  balance: 1_000_000,
+  currency: USDC_CURRENCY,
+};
+
+const ethHeld: HeldAccount = {
+  type: "Account",
+  balance: 1_000_000_000_000_000_000,
+  currency: ETH_CURRENCY,
+};
+
+const uniHeld: HeldAccount = {
+  type: "TokenAccount",
+  balance: 1_000_000,
+  currency: UNI_CURRENCY,
+};
+
+function build(overrides: Partial<BuildStablecoinHoldingsParams> = {}) {
+  return buildStablecoinHoldings({
+    catalog: [],
+    heldAccounts: [],
+    blacklistedTokenIds: [],
+    stablecoinTickers: new Set(),
+    isLoadingStablecoinTickers: false,
+    ...overrides,
+  });
+}
+
+describe("buildStablecoinHoldings", () => {
+  it("should return catalog rows when DADA has classified holdings", () => {
+    expect(
+      build({
+        catalog: [usdcCatalog],
+        heldAccounts: [usdcHeld],
+        stablecoinTickers: new Set(["USDC"]),
+      }),
+    ).toEqual([usdcCatalog]);
+  });
+
+  it("should treat a held token as a stablecoin while tickers are still loading", () => {
+    expect(build({ heldAccounts: [usdcHeld], isLoadingStablecoinTickers: true })).toEqual([
+      { currency: USDC_CURRENCY, balance: 1_000_000, value: 0 },
+    ]);
+  });
+
+  it("should ignore a native account while tickers are still loading", () => {
+    expect(build({ heldAccounts: [ethHeld], isLoadingStablecoinTickers: true })).toEqual([]);
+  });
+
+  it("should keep a held account whose ticker is in the catalog", () => {
+    expect(build({ heldAccounts: [usdcHeld], stablecoinTickers: new Set(["USDC"]) })).toEqual([
+      { currency: USDC_CURRENCY, balance: 1_000_000, value: 0 },
+    ]);
+  });
+
+  it("should omit a held token whose ticker is not a stablecoin", () => {
+    expect(build({ heldAccounts: [uniHeld], stablecoinTickers: new Set(["USDC"]) })).toEqual([]);
+  });
+
+  it("should omit blacklisted catalog rows", () => {
+    expect(
+      build({
+        catalog: [usdcCatalog, usdtCatalog],
+        blacklistedTokenIds: [USDC_CURRENCY.id],
+      }),
+    ).toEqual([usdtCatalog]);
+  });
+});

--- a/features/flow/pay-balance/src/__tests__/useBalanceViewModel.web.test.ts
+++ b/features/flow/pay-balance/src/__tests__/useBalanceViewModel.web.test.ts
@@ -43,17 +43,43 @@ describe("useBalanceViewModel", () => {
     });
   });
 
-  it("should be funded and loading while data loads", () => {
+  it("should keep funded chrome and skeleton the amount while funded data loads", () => {
+    const { result } = renderHook(() =>
+      useBalanceViewModel(
+        buildProps({ status: "loading", hasBalance: true, stableBalance: 1250.5 }),
+      ),
+    );
+
+    expect(result.current).toMatchObject({
+      displayMode: "funded",
+      balance: 1250.5,
+      isLoading: true,
+    });
+  });
+
+  it("should stay empty while data loads if the user has no balance", () => {
     const { result } = renderHook(() =>
       useBalanceViewModel(buildProps({ status: "loading", hasBalance: false })),
     );
 
-    expect(result.current).toMatchObject({ displayMode: "funded", isLoading: true });
+    expect(result.current.displayMode).toBe("empty");
   });
 
-  it("should be empty on error", () => {
+  it("should stay funded on error if the user has a balance", () => {
     const { result } = renderHook(() =>
-      useBalanceViewModel(buildProps({ status: "error", hasBalance: true })),
+      useBalanceViewModel(buildProps({ status: "error", hasBalance: true, stableBalance: 1250.5 })),
+    );
+
+    expect(result.current).toMatchObject({
+      displayMode: "funded",
+      balance: 1250.5,
+      isLoading: false,
+    });
+  });
+
+  it("should stay empty on error if the user has no balance", () => {
+    const { result } = renderHook(() =>
+      useBalanceViewModel(buildProps({ status: "error", hasBalance: false })),
     );
 
     expect(result.current.displayMode).toBe("empty");

--- a/features/flow/pay-balance/src/components/Hero/useBalanceViewModel.ts
+++ b/features/flow/pay-balance/src/components/Hero/useBalanceViewModel.ts
@@ -15,9 +15,6 @@ export function useBalanceViewModel({
   actionTiles,
   labels,
 }: BalanceProps): BalanceViewProps {
-  const isLoading = status === "loading";
-  const isFunded = isLoading || (status === "ready" && hasBalance);
-
   const optionIds = useMemo(() => filterOptions.map(option => option.id), [filterOptions]);
   const effectiveFilter = resolveSelection(filter, optionIds);
 
@@ -40,7 +37,7 @@ export function useBalanceViewModel({
     [effectiveFilter, filterOptions],
   );
 
-  if (!isFunded) {
+  if (!hasBalance) {
     return { displayMode: "empty", labels, actionTiles };
   }
 
@@ -48,7 +45,7 @@ export function useBalanceViewModel({
     displayMode: "funded",
     balance: stableBalance,
     formatCountervalue,
-    isLoading,
+    isLoading: status === "loading",
     labels,
     filter: effectiveFilter,
     options: filterOptions,

--- a/features/flow/pay-balance/src/exports.ts
+++ b/features/flow/pay-balance/src/exports.ts
@@ -4,6 +4,7 @@ export * from "./hooks/useBalanceData";
 export * from "./logic/aggregateBalance";
 export * from "./logic/buildBalanceFilterOptions";
 export * from "./logic/buildBalanceData";
+export * from "./logic/buildStablecoinHoldings";
 export * from "./logic/resolveSelection";
 export * from "./types";
 export * from "./state";

--- a/features/flow/pay-balance/src/logic/aggregateBalance.ts
+++ b/features/flow/pay-balance/src/logic/aggregateBalance.ts
@@ -3,8 +3,7 @@ import { tickerForFilter } from "./buildBalanceFilterOptions";
 import { resolveSelection } from "./resolveSelection";
 import type { BalanceData, BalanceStatus, PortfolioPort, Stablecoin } from "../types";
 
-// Filters stablecoins by the active filter, sums their
-// countervalues and maps the loading/error flags to a single status.
+// Filters the displayed total, maps status, and whether any holding is funded.
 export function aggregateBalance({
   stablecoins,
   filter,
@@ -39,8 +38,6 @@ export function aggregateBalance({
     .filter(matchesFilter)
     .reduce((total, { value }) => total + value, 0);
 
-  const hasBalance = stablecoins.some(({ value }) => value > 0);
-
   let status: BalanceStatus = "ready";
   if (isError) {
     status = "error";
@@ -51,8 +48,8 @@ export function aggregateBalance({
   return {
     status,
     stableBalance,
+    hasBalance: stablecoins.some(item => item.value > 0 || item.balance > 0),
     filter: effectiveFilter,
-    hasBalance,
     filterOptions,
     formatCountervalue,
     onConfirmFilter,

--- a/features/flow/pay-balance/src/logic/buildStablecoinHoldings.ts
+++ b/features/flow/pay-balance/src/logic/buildStablecoinHoldings.ts
@@ -14,6 +14,10 @@ export type BuildStablecoinHoldingsParams = Readonly<{
   isLoadingStablecoinTickers: boolean;
 }>;
 
+/**
+ * Builds the Pay holdings list.
+ * Uses DADA catalog rows when any exist. Otherwise maps held accounts.
+ */
 export function buildStablecoinHoldings({
   catalog,
   heldAccounts,
@@ -23,8 +27,10 @@ export function buildStablecoinHoldings({
 }: BuildStablecoinHoldingsParams): StablecoinItem[] {
   const blacklist = new Set(blacklistedTokenIds ?? []);
   const catalogRows = catalog.filter(row => !blacklist.has(row.currency.id));
+  // Catalog classified at least one holding. That list is the source of truth.
   if (catalogRows.length > 0) return catalogRows;
 
+  // Catalog empty: still loading or failed. Infer from accounts.
   return heldAccounts.flatMap(account =>
     toHeldStablecoinRow(account, blacklist, stablecoinTickers, isLoadingStablecoinTickers),
   );
@@ -36,14 +42,21 @@ function toHeldStablecoinRow(
   stablecoinTickers: ReadonlySet<string>,
   isLoadingStablecoinTickers: boolean,
 ): StablecoinItem[] {
+  // No positive amount. $0 USDC is empty chrome, not funded.
   if (account.balance <= 0) return [];
 
   const tickersKnown = stablecoinTickers.size > 0;
+  // USDC is a TokenAccount. Native ETH/BTC are not. Keep natives out while tickers load.
   const isLoadingToken = isLoadingStablecoinTickers && account.type === "TokenAccount";
+  // Tickers unknown and this is not a loading token: skip. UNI also matches TokenAccount
+  // here, so it looks funded until tickers arrive (follow-up of LIVE-36422).
   if (!tickersKnown && !isLoadingToken) return [];
 
+  // User hid this token.
   if (blacklist.has(account.currency.id)) return [];
+  // Tickers arrived. Drop holdings whose ticker is not a stablecoin.
   if (tickersKnown && !stablecoinTickers.has(account.currency.ticker.toUpperCase())) return [];
 
+  // Countervalue unknown on this path. hasBalance reads balance, not value.
   return [{ currency: account.currency, balance: account.balance, value: 0 }];
 }

--- a/features/flow/pay-balance/src/logic/buildStablecoinHoldings.ts
+++ b/features/flow/pay-balance/src/logic/buildStablecoinHoldings.ts
@@ -1,0 +1,49 @@
+import type { StablecoinItem } from "./buildBalanceFilterOptions";
+
+export type HeldAccount = Readonly<{
+  type: string;
+  balance: number;
+  currency: StablecoinItem["currency"];
+}>;
+
+export type BuildStablecoinHoldingsParams = Readonly<{
+  catalog: readonly StablecoinItem[];
+  heldAccounts: readonly HeldAccount[];
+  blacklistedTokenIds: readonly string[] | null | undefined;
+  stablecoinTickers: ReadonlySet<string>;
+  isLoadingStablecoinTickers: boolean;
+}>;
+
+export function buildStablecoinHoldings({
+  catalog,
+  heldAccounts,
+  blacklistedTokenIds,
+  stablecoinTickers,
+  isLoadingStablecoinTickers,
+}: BuildStablecoinHoldingsParams): StablecoinItem[] {
+  const blacklist = new Set(blacklistedTokenIds ?? []);
+  const catalogRows = catalog.filter(row => !blacklist.has(row.currency.id));
+  if (catalogRows.length > 0) return catalogRows;
+
+  return heldAccounts.flatMap(account =>
+    toHeldStablecoinRow(account, blacklist, stablecoinTickers, isLoadingStablecoinTickers),
+  );
+}
+
+function toHeldStablecoinRow(
+  account: HeldAccount,
+  blacklist: Set<string>,
+  stablecoinTickers: ReadonlySet<string>,
+  isLoadingStablecoinTickers: boolean,
+): StablecoinItem[] {
+  if (account.balance <= 0) return [];
+
+  const tickersKnown = stablecoinTickers.size > 0;
+  const isLoadingToken = isLoadingStablecoinTickers && account.type === "TokenAccount";
+  if (!tickersKnown && !isLoadingToken) return [];
+
+  if (blacklist.has(account.currency.id)) return [];
+  if (tickersKnown && !stablecoinTickers.has(account.currency.ticker.toUpperCase())) return [];
+
+  return [{ currency: account.currency, balance: account.balance, value: 0 }];
+}

--- a/features/flow/pay-balance/src/types.ts
+++ b/features/flow/pay-balance/src/types.ts
@@ -40,6 +40,7 @@ export type BalanceFilterOption = Readonly<{
 export type Stablecoin = Readonly<{
   currency: Readonly<{ id: string; ticker: string }>;
   value: number;
+  balance: number;
 }>;
 
 /** Platform-agnostic input for {@link aggregateBalance}. */
@@ -55,13 +56,13 @@ export type PortfolioPort = Readonly<{
   onTrackEvent?: (event: string, params: Record<string, unknown>) => void;
 }>;
 
-/** Result of {@link aggregateBalance}: filtered total + status. */
+/** Result of {@link aggregateBalance}: filtered total, funded flag, and status. */
 export type BalanceAggregate = Readonly<{
   status: BalanceStatus;
   stableBalance: number;
-  filter: BalanceFilter;
-  /** Whether the user holds any stablecoin balance. Drives funded vs empty. */
+  /** Any positive crypto or countervalue holding. Drives funded vs empty. */
   hasBalance: boolean;
+  filter: BalanceFilter;
   formatCountervalue: (value: number) => FormattedValue;
 }>;
 


### PR DESCRIPTION
### 📝 Description

On cold start, Pay showed the wrong hero:
- USDC wallet: empty, then funded
- crypto-only wallet: funded `$0`, then empty

The hero now follows what you hold, not whether the catalog has loaded:
- **empty** — no positive stablecoin. Loading and catalog errors stay empty.
- **funded** — a positive stablecoin. While data loads, keep this screen and skeleton the amount.

Action tiles stay on both screens (#21175).

Error state and the rest will be handled later.

MOBILE
<table>
<tr>
 <td>no account
 <td>accounts but no stablecoin
 <td>stable balance > 0
<td>video
<tr>
 <td><img width="317" height="666" alt="image" src="https://github.com/user-attachments/assets/57e1f109-7feb-4d21-9d4d-ec06c83f9d6c" />
 <td><img width="374" height="734" alt="image" src="https://github.com/user-attachments/assets/7c717add-c0d7-490b-9e8e-d34abf1159f4" />
 <td><img width="365" height="743" alt="image" src="https://github.com/user-attachments/assets/d85f271f-710e-4c49-854b-a15f188497a3" />
<td><video src="https://github.com/user-attachments/assets/d29b55ce-71ba-440b-a073-0da5bcb7b973" />
</table>

DESKTOP
<table>
<tr>
 <td>no account
 <td>account but not stablecoins
 <td>stablecoins
<td>video
<tr>
 <td><img width="1112" height="949" alt="image" src="https://github.com/user-attachments/assets/8bc37309-f6b8-4cad-8cea-d1e10e8df98c" />
 <td><img width="1114" height="949" alt="image" src="https://github.com/user-attachments/assets/f368c523-2ee9-425d-b327-0e7c3e396d51" />
 <td><img width="1106" height="951" alt="image" src="https://github.com/user-attachments/assets/c426eedc-f105-44f1-a162-44c523f9fc4c" />
<td><video src="https://github.com/user-attachments/assets/805bd90f-7258-458c-845b-615738833eee" />
</table>

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36422](https://ledgerhq.atlassian.net/browse/LIVE-36422)
- **Related**: [LIVE-36508](https://ledgerhq.atlassian.net/browse/LIVE-36508)
- **ADR** (if any):

### Test plan

- [ ] No accounts → empty copy + tiles
- [ ] Crypto only → empty copy, no `$0` flash
- [ ] USDC while catalog hangs → funded chrome, skeleton amount
- [ ] USDC after catalog → funded with the live amount
- [ ] Catalog error + USDC → stays funded
- [ ] Catalog error + no stables → empty
- [ ] Cold start, open Pay with USDC → no empty → funded flash

[LIVE-36422]: https://ledgerhq.atlassian.net/browse/LIVE-36422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ