### PR TITLE
[LWDM] fix(counter-values): reject incomplete spot rates (LIVE-36444)

### DIFF
--- a/.changeset/calm-rates-validate.md
+++ b/.changeset/calm-rates-validate.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-countervalues": patch
+---
+
+Reject incomplete or invalid latest countervalue rates

--- a/libs/live-countervalues/src/api/api.test.ts
+++ b/libs/live-countervalues/src/api/api.test.ts
@@ -1,0 +1,92 @@
+import { getEnv } from "@ledgerhq/live-env";
+import { log } from "@ledgerhq/logs";
+import network from "@ledgerhq/live-network";
+import api from "./api";
+import { getCryptoCurrencyById, getFiatCurrencyByTicker } from "../tests/currencies";
+import type { TrackingPair } from "../types";
+
+jest.mock("@ledgerhq/live-env");
+jest.mock("@ledgerhq/logs");
+jest.mock("@ledgerhq/live-network");
+
+const mockedGetEnv = jest.mocked(getEnv);
+const mockedLog = jest.mocked(log);
+const mockedNetwork = jest.mocked(network);
+
+const bitcoin = getCryptoCurrencyById("bitcoin");
+const ethereum = getCryptoCurrencyById("ethereum");
+const usd = getFiatCurrencyByTicker("USD");
+const eur = getFiatCurrencyByTicker("EUR");
+const startDate = new Date("2026-01-01T00:00:00.000Z");
+
+function pair(from: TrackingPair["from"], to: TrackingPair["to"] = usd): TrackingPair {
+  return { from, to, startDate };
+}
+
+function requestUrl(callIndex: number): URL {
+  const request = mockedNetwork.mock.calls[callIndex]?.[0] as { url: string } | undefined;
+  if (!request) throw new Error(`No network request at index ${callIndex}`);
+  return new URL(request.url);
+}
+
+describe("countervalues latest API", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetEnv.mockReturnValue("https://countervalues.example.com");
+  });
+
+  it("should preserve pair order across target currency batches", async () => {
+    mockedNetwork
+      .mockResolvedValueOnce({
+        data: { bitcoin: 80658, ethereum: 2471.2 },
+        status: 200,
+      })
+      .mockResolvedValueOnce({ data: { bitcoin: 68250 }, status: 200 });
+
+    const result = await api.fetchLatest([
+      pair(bitcoin, usd),
+      pair(ethereum, usd),
+      pair(bitcoin, eur),
+    ]);
+
+    expect(result).toEqual([80658, 2471.2, 68250]);
+    expect(requestUrl(0).searchParams.get("to")).toBe("USD");
+    expect(requestUrl(0).searchParams.get("froms")).toBe("bitcoin,ethereum");
+    expect(requestUrl(1).searchParams.get("to")).toBe("EUR");
+    expect(requestUrl(1).searchParams.get("froms")).toBe("bitcoin");
+    expect(mockedLog).not.toHaveBeenCalled();
+  });
+
+  it("should preserve undefined and log identifiers for incomplete batches", async () => {
+    mockedNetwork.mockResolvedValue({ data: { bitcoin: 0 }, status: 200 });
+
+    const result = await api.fetchLatest([pair(bitcoin), pair(ethereum)]);
+
+    expect(result).toEqual([undefined, undefined]);
+    expect(mockedLog).toHaveBeenCalledWith(
+      "countervalues-error",
+      "Incomplete latest rates batch: to=USD requested=bitcoin,ethereum missing=ethereum invalid=bitcoin",
+    );
+  });
+
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY, null, "80658"])(
+    "should reject the invalid latest rate %p",
+    async value => {
+      mockedNetwork.mockResolvedValue({
+        data: { bitcoin: value },
+        status: 200,
+      });
+
+      await expect(api.fetchLatest([pair(bitcoin)])).resolves.toEqual([undefined]);
+      expect(mockedLog).toHaveBeenCalledWith(
+        "countervalues-error",
+        "Incomplete latest rates batch: to=USD requested=bitcoin missing= invalid=bitcoin",
+      );
+    },
+  );
+
+  it("should not call the network for an empty pair list", async () => {
+    await expect(api.fetchLatest([])).resolves.toEqual([]);
+    expect(mockedNetwork).not.toHaveBeenCalled();
+  });
+});

--- a/libs/live-countervalues/src/api/api.ts
+++ b/libs/live-countervalues/src/api/api.ts
@@ -1,6 +1,7 @@
 import network from "@ledgerhq/live-network";
 import URL from "url";
 import { getEnv } from "@ledgerhq/live-env";
+import { log } from "@ledgerhq/logs";
 import { promiseAllBatched } from "@ledgerhq/live-promise";
 import { formatPerGranularity, inferCurrencyAPIID, pairId } from "../helpers";
 import type { BatchStrategySolver, CounterValuesAPI, TrackingPair } from "../types";
@@ -53,14 +54,17 @@ const api: CounterValuesAPI = {
         end: corrected_end_date,
       },
     });
-    const { data } = await network<Record<string, number>>({ method: "GET", url });
+    const { data } = await network<Record<string, number>>({
+      method: "GET",
+      url,
+    });
     return data;
   },
 
   fetchLatest: async (
     pairs: TrackingPair[],
     batchStrategySolver?: BatchStrategySolver,
-  ): Promise<number[]> => {
+  ): Promise<Array<number | undefined>> => {
     if (pairs.length === 0) return [];
 
     const shouldBatchCurrencyFrom = batchStrategySolver?.shouldBatchCurrencyFrom || (() => true);
@@ -92,29 +96,56 @@ const api: CounterValuesAPI = {
     batches.push(batch);
     const allBatches = batches.concat(singles);
 
-    const map = new Map();
+    const map = new Map<string, number | undefined>();
     await promiseAllBatched(4, allBatches, async ([froms, to]) => {
       const fromIds = froms.map(inferCurrencyAPIID);
+      const toId = inferCurrencyAPIID(to);
       const url = URL.format({
         pathname: `${baseURL()}/v3/spot/simple`,
         query: {
-          to: inferCurrencyAPIID(to),
+          to: toId,
           froms: fromIds.join(","),
         },
       });
 
-      const { data } = await network<Record<string, number>>({ method: "GET", url });
+      const { data } = await network<Record<string, unknown>>({
+        method: "GET",
+        url,
+      });
+      const response = data && typeof data === "object" ? data : {};
+      const missingIds: string[] = [];
+      const invalidIds: string[] = [];
 
       // store all countervalues in a global map
       for (let i = 0; i < fromIds.length; i++) {
         const from = froms[i];
-        const value = data[fromIds[i]];
-        map.set(pairId({ from, to }), value);
+        const fromId = fromIds[i];
+        const hasValue = Object.prototype.hasOwnProperty.call(response, fromId);
+        const value = response[fromId];
+
+        if (!hasValue) {
+          missingIds.push(fromId);
+          map.set(pairId({ from, to }), undefined);
+        } else if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+          invalidIds.push(fromId);
+          map.set(pairId({ from, to }), undefined);
+        } else {
+          map.set(pairId({ from, to }), value);
+        }
+      }
+
+      if (missingIds.length > 0 || invalidIds.length > 0) {
+        log(
+          "countervalues-error",
+          `Incomplete latest rates batch: to=${toId} requested=${fromIds.join(
+            ",",
+          )} missing=${missingIds.join(",")} invalid=${invalidIds.join(",")}`,
+        );
       }
     });
 
     // we return the result in the same order as the input pairs
-    const data = pairs.map(pair => map.get(pairId(pair)) || 0);
+    const data = pairs.map(pair => map.get(pairId(pair)));
 
     return data;
   },

--- a/libs/live-countervalues/src/logic.test.ts
+++ b/libs/live-countervalues/src/logic.test.ts
@@ -1,6 +1,17 @@
+import { log } from "@ledgerhq/logs";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import {
+  CryptoCurrencyIdSchema,
+  TokenCurrencyIdSchema,
+} from "@ledgerhq/ledger-wallet-framework/types";
+import type {
+  CryptoCurrency,
+  Currency,
+  TokenCurrency,
+} from "@ledgerhq/ledger-wallet-framework/types";
 import { getCryptoCurrencyById, getFiatCurrencyByTicker } from "./tests/currencies";
 import {
+  calculate,
   inferTrackingPairForAccounts,
   exportCountervalues,
   filterSupportedTrackingPairs,
@@ -9,17 +20,13 @@ import {
   initialState,
   loadCountervalues,
 } from "./logic";
+import api from "./api";
 import type { CounterValuesState, TrackingPair } from "./types";
 import { datapointRetention, formatCounterValueDay, formatCounterValueHour } from "./helpers";
-import type {
-  CryptoCurrency,
-  Currency,
-  TokenCurrency,
-} from "@ledgerhq/ledger-wallet-framework/types";
-import {
-  CryptoCurrencyIdSchema,
-  TokenCurrencyIdSchema,
-} from "@ledgerhq/ledger-wallet-framework/types";
+
+jest.mock("@ledgerhq/logs");
+
+const mockedLog = jest.mocked(log);
 
 describe("inferTrackingPairForAccounts", () => {
   const accounts = Array(20)
@@ -35,14 +42,20 @@ describe("inferTrackingPairForAccounts", () => {
   });
 
   test("trackingPairs with same from and to are filtered out", () => {
-    const first = genAccount("test1", { currency: getCryptoCurrencyById("bitcoin") });
+    const first = genAccount("test1", {
+      currency: getCryptoCurrencyById("bitcoin"),
+    });
     const trackingPairs = inferTrackingPairForAccounts([first], first.currency);
     expect(trackingPairs).toEqual([]);
   });
 
   test("trackingPairs with 2 accounts of same coin yield one tracking pair", () => {
-    const first = genAccount("test1", { currency: getCryptoCurrencyById("bitcoin") });
-    const second = genAccount("test2", { currency: getCryptoCurrencyById("bitcoin") });
+    const first = genAccount("test1", {
+      currency: getCryptoCurrencyById("bitcoin"),
+    });
+    const second = genAccount("test2", {
+      currency: getCryptoCurrencyById("bitcoin"),
+    });
     const trackingPairs = inferTrackingPairForAccounts([first, second], usd);
     expect(trackingPairs.length).toBe(1);
   });
@@ -100,7 +113,13 @@ describe("filterSupportedTrackingPairs", () => {
   });
 
   test("should keep fiat source pairs", () => {
-    const pairs = [{ from: usd, to: bitcoin, startDate: new Date("2026-06-19T00:00:00.000Z") }];
+    const pairs = [
+      {
+        from: usd,
+        to: bitcoin,
+        startDate: new Date("2026-06-19T00:00:00.000Z"),
+      },
+    ];
 
     expect(filterSupportedTrackingPairs(pairs, ["bitcoin"])).toBe(pairs);
   });
@@ -419,5 +438,266 @@ describe("checkHolesOnNextLoad", () => {
       disableAutoRecoverErrors: true,
     });
     expect(result.checkHolesOnNextLoad).toBe(false);
+  });
+});
+
+describe("latest rate integrity", () => {
+  const bitcoin = getCryptoCurrencyById("bitcoin");
+  const ethereum = getCryptoCurrencyById("ethereum");
+  const usd = getFiatCurrencyByTicker("USD");
+  const eur = getFiatCurrencyByTicker("EUR");
+  const historicalDate = "2026-01-01";
+  const startDate = new Date();
+
+  const trackingPair = (from: Currency, to: Currency = usd): TrackingPair => ({
+    from,
+    to,
+    startDate,
+  });
+
+  const settings = (trackingPairs: TrackingPair[], autofillGaps = true) => ({
+    trackingPairs,
+    autofillGaps,
+    refreshRate: 60000,
+    marketCapBatchingAfterRank: 20,
+  });
+  let fetchHistoricalSpy: jest.SpiedFunction<typeof api.fetchHistorical>;
+  let fetchLatestSpy: jest.SpiedFunction<typeof api.fetchLatest>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchHistoricalSpy = jest.spyOn(api, "fetchHistorical").mockResolvedValue({});
+    fetchLatestSpy = jest.spyOn(api, "fetchLatest").mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    fetchHistoricalSpy.mockRestore();
+    fetchLatestSpy.mockRestore();
+  });
+
+  test("removes an old latest rate after a successful partial response without mutating input", async () => {
+    const key = "USD bitcoin";
+    const originalMap = new Map([
+      ["latest", 50000],
+      [historicalDate, 49000],
+      ["2026-01-02", 49500],
+    ]);
+    const state: CounterValuesState = {
+      data: { [key]: originalMap },
+      cache: {},
+      status: {},
+    };
+    fetchLatestSpy.mockResolvedValue([undefined]);
+
+    const result = await loadCountervalues(state, settings([trackingPair(bitcoin)]));
+
+    expect(result.data[key]).not.toBe(originalMap);
+    expect(result.data[key].get("latest")).toBeUndefined();
+    expect(result.data[key].get(historicalDate)).toBe(49000);
+    expect(result.data[key].get("2026-01-02")).toBe(49500);
+    expect(result.cache[key].map.get("latest")).toBeUndefined();
+    expect(originalMap.get("latest")).toBe(50000);
+    expect(calculate(result, { value: 100000000, from: bitcoin, to: usd })).toBeUndefined();
+    expect(
+      calculate(result, {
+        value: 100000000,
+        from: bitcoin,
+        to: usd,
+        date: new Date(`${historicalDate}T00:00:00.000Z`),
+      }),
+    ).toBe(4900000);
+  });
+
+  test("does not synthesize latest from historical data when autofilling gaps", () => {
+    const imported = importCountervalues(
+      {
+        status: {},
+        "USD bitcoin": { [historicalDate]: 49000 },
+      },
+      settings([trackingPair(bitcoin)]),
+    );
+
+    expect(imported.data["USD bitcoin"].get("latest")).toBeUndefined();
+    expect(imported.cache["USD bitcoin"].map.get("latest")).toBeUndefined();
+    expect(imported.cache["USD bitcoin"].map.get("2026-01-02")).toBe(49000);
+    expect(calculate(imported, { value: 100000000, from: bitcoin, to: usd })).toBeUndefined();
+  });
+
+  test("removes a latest rate synthesized in an existing cache", async () => {
+    const key = "USD bitcoin";
+    const history = new Map([[historicalDate, 49000]]);
+    const state: CounterValuesState = {
+      data: { [key]: history },
+      cache: {
+        [key]: {
+          map: new Map([
+            [historicalDate, 49000],
+            ["latest", 49000],
+          ]),
+          fallback: 49000,
+          stats: {
+            oldest: historicalDate,
+            earliest: historicalDate,
+            oldestDate: new Date(`${historicalDate}T00:00:00.000Z`),
+            earliestDate: new Date(`${historicalDate}T00:00:00.000Z`),
+            earliestStableDate: new Date(`${historicalDate}T00:00:00.000Z`),
+          },
+        },
+      },
+      status: {},
+    };
+    fetchLatestSpy.mockResolvedValue([undefined]);
+
+    const result = await loadCountervalues(state, settings([trackingPair(bitcoin)]));
+
+    expect(result.cache[key].map.has("latest")).toBe(false);
+    expect(state.cache[key].map.get("latest")).toBe(49000);
+  });
+
+  test("ignores a legacy latest value during import", () => {
+    const imported = importCountervalues(
+      {
+        status: {},
+        "USD bitcoin": { latest: 50000, [historicalDate]: 49000 },
+      },
+      settings([trackingPair(bitcoin)]),
+    );
+
+    expect(imported.data["USD bitcoin"].has("latest")).toBe(false);
+    expect(imported.cache["USD bitcoin"].map.has("latest")).toBe(false);
+    expect(imported.data["USD bitcoin"].get(historicalDate)).toBe(49000);
+  });
+
+  test.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY, null, undefined])(
+    "removes latest when the API returns %p",
+    async latest => {
+      const key = "USD bitcoin";
+      const state: CounterValuesState = {
+        data: { [key]: new Map([["latest", 50000]]) },
+        cache: {},
+        status: {},
+      };
+      fetchLatestSpy.mockResolvedValue([latest]);
+
+      const result = await loadCountervalues(state, settings([trackingPair(bitcoin)]));
+
+      expect(result.data[key].has("latest")).toBe(false);
+      expect(state.data[key].get("latest")).toBe(50000);
+    },
+  );
+
+  test("removes an invalid latest rate when the response repeats it", async () => {
+    const key = "USD bitcoin";
+    const state: CounterValuesState = {
+      data: { [key]: new Map([["latest", 0]]) },
+      cache: {
+        [key]: {
+          map: new Map([["latest", 0]]),
+          stats: {
+            oldest: undefined,
+            earliest: undefined,
+            oldestDate: null,
+            earliestDate: null,
+            earliestStableDate: null,
+          },
+        },
+      },
+      status: {},
+    };
+    fetchLatestSpy.mockResolvedValue([0]);
+
+    const result = await loadCountervalues(state, settings([trackingPair(bitcoin)]));
+
+    expect(result.data[key].has("latest")).toBe(false);
+    expect(result.cache[key].map.has("latest")).toBe(false);
+  });
+
+  test("clears only the selected fiat pair during a currency switch", async () => {
+    const usdKey = "USD bitcoin";
+    const eurKey = "EUR bitcoin";
+    const usdMap = new Map([["latest", 80658]]);
+    const eurMap = new Map([["latest", 68250]]);
+    const state: CounterValuesState = {
+      data: { [usdKey]: usdMap, [eurKey]: eurMap },
+      cache: {},
+      status: {},
+    };
+    fetchLatestSpy.mockResolvedValue([undefined]);
+
+    const result = await loadCountervalues(state, settings([trackingPair(bitcoin, eur)]));
+
+    expect(result.data[usdKey]).toBe(usdMap);
+    expect(result.data[usdKey].get("latest")).toBe(80658);
+    expect(result.data[eurKey].has("latest")).toBe(false);
+  });
+
+  test("updates valid pairs while clearing missing pairs from the same response", async () => {
+    const bitcoinMap = new Map([["latest", 50000]]);
+    const ethereumMap = new Map([["latest", 3000]]);
+    const state: CounterValuesState = {
+      data: { "USD bitcoin": bitcoinMap, "USD ethereum": ethereumMap },
+      cache: {},
+      status: {},
+    };
+    fetchLatestSpy.mockResolvedValue([51000, undefined]);
+
+    const result = await loadCountervalues(
+      state,
+      settings([trackingPair(bitcoin), trackingPair(ethereum)]),
+    );
+
+    expect(result.data["USD bitcoin"].get("latest")).toBe(51000);
+    expect(result.data["USD ethereum"].has("latest")).toBe(false);
+    expect(bitcoinMap.get("latest")).toBe(50000);
+    expect(ethereumMap.get("latest")).toBe(3000);
+  });
+
+  test("restores calculation when a later poll returns a valid rate", async () => {
+    const pair = trackingPair(bitcoin);
+    const fetchLatest = fetchLatestSpy
+      .mockResolvedValueOnce([undefined])
+      .mockResolvedValueOnce([55000]);
+    const state: CounterValuesState = {
+      data: { "USD bitcoin": new Map([["latest", 50000]]) },
+      cache: {},
+      status: {},
+    };
+
+    const incomplete = await loadCountervalues(state, settings([pair]));
+    const recovered = await loadCountervalues(incomplete, settings([pair]));
+
+    expect(fetchLatest).toHaveBeenCalledTimes(2);
+    expect(incomplete.data["USD bitcoin"].has("latest")).toBe(false);
+    expect(recovered.data["USD bitcoin"].get("latest")).toBe(55000);
+    expect(calculate(recovered, { value: 100000000, from: bitcoin, to: usd })).toBe(5500000);
+  });
+
+  test("retains existing latest rates when the complete latest request fails", async () => {
+    const bitcoinMap = new Map([["latest", 50000]]);
+    const ethereumMap = new Map([["latest", 3000]]);
+    const state: CounterValuesState = {
+      data: { "USD bitcoin": bitcoinMap, "USD ethereum": ethereumMap },
+      cache: {},
+      status: {},
+    };
+    const fetchLatest = fetchLatestSpy
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockResolvedValueOnce([51000, 3100]);
+    const pairs = [trackingPair(bitcoin), trackingPair(ethereum)];
+
+    const failed = await loadCountervalues(state, settings(pairs));
+    const recovered = await loadCountervalues(failed, settings(pairs));
+
+    expect(fetchLatest).toHaveBeenCalledTimes(2);
+    expect(failed.data["USD bitcoin"]).toBe(bitcoinMap);
+    expect(failed.data["USD ethereum"]).toBe(ethereumMap);
+    expect(failed.data["USD bitcoin"].get("latest")).toBe(50000);
+    expect(failed.data["USD ethereum"].get("latest")).toBe(3000);
+    expect(recovered.data["USD bitcoin"].get("latest")).toBe(51000);
+    expect(recovered.data["USD ethereum"].get("latest")).toBe(3100);
+    expect(mockedLog).toHaveBeenCalledWith(
+      "countervalues-error",
+      expect.stringContaining("Failed to fetch latest for BTC-USD,ETH-USD Error: network down"),
+    );
   });
 });

--- a/libs/live-countervalues/src/logic.ts
+++ b/libs/live-countervalues/src/logic.ts
@@ -104,6 +104,7 @@ export function importCountervalues(
     const map = new Map<string, number>();
 
     for (const k in obj) {
+      if (k === "latest") continue;
       map.set(k, obj[k]);
     }
 
@@ -321,10 +322,20 @@ export async function loadCountervalues(
         let hasData = false;
         latestToFetch.forEach((pair, i) => {
           const key = pairId(pair);
-          const latest = rates[i];
-          if (data[key]?.get("latest") === latest) return;
+          const rate = rates[i];
+          const latest =
+            typeof rate === "number" && Number.isFinite(rate) && rate > 0 ? rate : undefined;
+          const hasLatestInData = data[key]?.has("latest") === true;
+          const hasLatestInCache = cache[key]?.map.has("latest") === true;
+          if (
+            hasLatestInData === hasLatestInCache &&
+            data[key]?.get("latest") === latest &&
+            cache[key]?.map.get("latest") === latest
+          ) {
+            return;
+          }
           out[key] = {
-            latest: rates[i],
+            latest,
           };
           hasData = true;
         });
@@ -361,11 +372,17 @@ export async function loadCountervalues(
 
       if (!data[key]) {
         data[key] = new Map();
+      } else if (data[key] === state.data[key]) {
+        data[key] = new Map(data[key]);
       }
 
       const map = data[key];
       Object.entries(patch[key]).forEach(([k, v]) => {
-        if (typeof v === "number") map.set(k, v);
+        if (k === "latest" && (typeof v !== "number" || !Number.isFinite(v) || v <= 0)) {
+          map.delete(k);
+        } else if (typeof v === "number") {
+          map.set(k, v);
+        }
       });
     });
   });
@@ -534,10 +551,6 @@ function generateCache(
           shiftingValue = map.get(k) || 0;
         }
       }
-    }
-
-    if (!map.get("latest") && settings.autofillGaps) {
-      map.set("latest", shiftingValue);
     }
   } else {
     if (settings.autofillGaps) {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Added API and state-logic coverage for complete, partial, invalid, recovered, persisted-history, and full-failure responses.
- [x] **Impact of the changes:**
      Verify USD and EUR portfolios when one requested asset is omitted or invalid in a successful spot response; valid pairs must still update, the missing pair must become unavailable, and a later complete poll must restore it.

### 📝 Description

Validates every latest countervalue rate as a finite, strictly positive number. Successful partial responses now preserve `undefined` for missing or invalid pairs, remove any previous in-memory `latest` for those pairs with copy-on-write semantics, and regenerate their cache without synthesizing a current rate from historical data.

Complete network or HTTP failures still retain the last explicitly received in-session latest rates so polling can retry without creating a transient outage. Persisted history never restores a latest rate. Batch diagnostics include only the target and requested, missing, and invalid identifiers; they never include rates, balances, or user data.

This intentionally cannot detect a positive but stale value returned by the backend because the endpoint exposes no freshness metadata.

No UI changes.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-36444

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
