### PR TITLE
[LWM] fix(counter-values): guarantee refresh after resume (LIVE-36444)

### DIFF
--- a/.changeset/calm-geckos-refresh.md
+++ b/.changeset/calm-geckos-refresh.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Refresh countervalues when the mobile app resumes or reconnects

--- a/apps/ledger-live-mobile/src/components/CountervaluesProvider.tsx
+++ b/apps/ledger-live-mobile/src/components/CountervaluesProvider.tsx
@@ -1,13 +1,9 @@
-import {
-  CountervaluesBridge,
-  CountervaluesProvider,
-  useCountervaluesPolling,
-} from "@ledgerhq/live-countervalues-react";
+import { CountervaluesBridge, CountervaluesProvider } from "@ledgerhq/live-countervalues-react";
 import { CounterValuesStateRaw } from "@ledgerhq/live-countervalues/types";
 import { useGetCounterValueIdsPolling } from "@ledgerhq/live-common/counterValues/state-manager/useGetCounterValueIdsPolling";
 import { flow } from "lodash/fp";
-import React, { useEffect, useMemo, useRef, useState } from "react";
-import { AppState, AppStateStatus } from "react-native";
+import React, { useMemo } from "react";
+import { useCountervaluesPollingLifecycle } from "LLM/hooks/useCountervaluesPollingLifecycle";
 import { useDispatch } from "~/context/hooks";
 import { useUserSettings } from "~/actions/general";
 import {
@@ -30,7 +26,7 @@ import {
  * Call side effects outside of the primary render tree, avoiding costly child re-renders
  */
 function Effect() {
-  usePollingManager();
+  useCountervaluesPollingLifecycle();
   return null;
 }
 
@@ -73,31 +69,4 @@ export function CountervaluesBridgedProvider({
       {children}
     </CountervaluesProvider>
   );
-}
-
-function usePollingManager() {
-  const { start, stop } = useCountervaluesPolling();
-  const appState = useRef(AppState.currentState ?? "");
-  const [isActive, setIsActive] = useState<boolean>(!!appState.current);
-  useEffect(() => {
-    function handleChange(nextAppState: AppStateStatus) {
-      setIsActive(
-        (appState.current.match(/inactive|background/) && nextAppState === "active") || false,
-      );
-      appState.current = nextAppState;
-    }
-
-    const sub = AppState.addEventListener("change", handleChange);
-    return () => {
-      sub.remove();
-    };
-  }, []);
-  useEffect(() => {
-    if (!isActive) {
-      stop();
-      return;
-    }
-
-    start();
-  }, [isActive, start, stop]);
 }

--- a/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useCountervaluesPollingLifecycle.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useCountervaluesPollingLifecycle.test.ts
@@ -1,0 +1,252 @@
+import NetInfo, {
+  NetInfoStateType,
+  type NetInfoChangeHandler,
+  type NetInfoNoConnectionState,
+  type NetInfoOtherState,
+  type NetInfoState,
+  type NetInfoUnknownState,
+} from "@react-native-community/netinfo";
+import { type Polling, useCountervaluesPolling } from "@ledgerhq/live-countervalues-react";
+import { act, renderHook } from "@testing-library/react-native";
+import { AppState, type AppStateStatus } from "react-native";
+import { useCountervaluesPollingLifecycle } from "../useCountervaluesPollingLifecycle";
+
+jest.mock("@ledgerhq/live-countervalues-react", () => ({
+  useCountervaluesPolling: jest.fn(),
+}));
+
+const mockedUseCountervaluesPolling = jest.mocked(useCountervaluesPolling);
+const originalAppStateDescriptor = Object.getOwnPropertyDescriptor(AppState, "currentState");
+
+function buildNetInfoState(status: "online" | "offline" | "unknown"): NetInfoState {
+  if (status === "online") {
+    const state: NetInfoOtherState = {
+      type: NetInfoStateType.other,
+      isConnected: true,
+      isInternetReachable: true,
+      details: { isConnectionExpensive: false },
+    };
+
+    return state;
+  }
+
+  if (status === "offline") {
+    const state: NetInfoNoConnectionState = {
+      type: NetInfoStateType.none,
+      isConnected: false,
+      isInternetReachable: false,
+      details: null,
+    };
+
+    return state;
+  }
+
+  const state: NetInfoUnknownState = {
+    type: NetInfoStateType.unknown,
+    isConnected: null,
+    isInternetReachable: null,
+    details: null,
+  };
+
+  return state;
+}
+
+function setCurrentAppState(state: AppStateStatus | null): void {
+  Object.defineProperty(AppState, "currentState", {
+    configurable: true,
+    value: state,
+  });
+}
+
+function createPolling(): Polling {
+  return {
+    error: null,
+    pending: false,
+    poll: jest.fn(),
+    start: jest.fn(),
+    stop: jest.fn(),
+    wipe: jest.fn(),
+  };
+}
+
+describe("useCountervaluesPollingLifecycle", () => {
+  let appStateListener: ((state: AppStateStatus) => void) | undefined;
+  let netInfoListener: NetInfoChangeHandler | undefined;
+  let removeAppStateListener: jest.Mock;
+  let unsubscribeNetInfo: jest.Mock;
+  let appStateAddEventListenerSpy: jest.SpiedFunction<typeof AppState.addEventListener>;
+  let polling: Polling;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    appStateListener = undefined;
+    netInfoListener = undefined;
+    removeAppStateListener = jest.fn();
+    unsubscribeNetInfo = jest.fn();
+    polling = createPolling();
+    mockedUseCountervaluesPolling.mockReturnValue(polling);
+
+    appStateAddEventListenerSpy = jest
+      .spyOn(AppState, "addEventListener")
+      .mockImplementation((_event, listener) => {
+        appStateListener = listener;
+        return { remove: removeAppStateListener };
+      });
+
+    jest.mocked(NetInfo.addEventListener).mockImplementation(listener => {
+      netInfoListener = listener;
+      return unsubscribeNetInfo;
+    });
+  });
+
+  afterEach(() => {
+    appStateAddEventListenerSpy.mockRestore();
+    if (originalAppStateDescriptor) {
+      Object.defineProperty(AppState, "currentState", originalAppStateDescriptor);
+    } else {
+      Reflect.deleteProperty(AppState, "currentState");
+    }
+  });
+
+  it("should start polling without an immediate poll when mounted active", () => {
+    setCurrentAppState("active");
+
+    renderHook(() => useCountervaluesPollingLifecycle());
+
+    expect(polling.start).toHaveBeenCalledTimes(1);
+    expect(polling.poll).not.toHaveBeenCalled();
+    expect(polling.stop).not.toHaveBeenCalled();
+  });
+
+  it.each(["background", "inactive", null] as const)(
+    "should stop polling when mounted in %s state",
+    initialState => {
+      setCurrentAppState(initialState);
+
+      renderHook(() => useCountervaluesPollingLifecycle());
+
+      expect(polling.stop).toHaveBeenCalledTimes(1);
+      expect(polling.start).not.toHaveBeenCalled();
+      expect(polling.poll).not.toHaveBeenCalled();
+    },
+  );
+
+  it("should ignore duplicate lifecycle events while stopping and resuming", () => {
+    setCurrentAppState("active");
+    renderHook(() => useCountervaluesPollingLifecycle());
+    jest.clearAllMocks();
+
+    act(() => {
+      // React Native can emit duplicate notifications while transitioning.
+      appStateListener?.("background");
+      appStateListener?.("background");
+      appStateListener?.("inactive");
+    });
+
+    expect(polling.stop).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      // A repeated active event must not schedule another refresh.
+      appStateListener?.("active");
+      appStateListener?.("active");
+    });
+
+    expect(polling.start).toHaveBeenCalledTimes(1);
+    expect(polling.poll).toHaveBeenCalledTimes(1);
+    expect(jest.mocked(polling.start).mock.invocationCallOrder[0]).toBeLessThan(
+      jest.mocked(polling.poll).mock.invocationCallOrder[0],
+    );
+  });
+
+  it("should resume polling from an initially unknown app state", () => {
+    setCurrentAppState(null);
+    renderHook(() => useCountervaluesPollingLifecycle());
+    jest.clearAllMocks();
+
+    act(() => {
+      appStateListener?.("active");
+    });
+
+    expect(polling.start).toHaveBeenCalledTimes(1);
+    expect(polling.poll).toHaveBeenCalledTimes(1);
+  });
+
+  it("should ignore the initial network update", () => {
+    setCurrentAppState("active");
+    renderHook(() => useCountervaluesPollingLifecycle());
+    jest.clearAllMocks();
+
+    act(() => {
+      netInfoListener?.(buildNetInfoState("offline"));
+    });
+
+    expect(polling.poll).not.toHaveBeenCalled();
+  });
+
+  it("should poll once when the network transitions from offline to online while active", () => {
+    setCurrentAppState("active");
+    renderHook(() => useCountervaluesPollingLifecycle());
+    jest.clearAllMocks();
+
+    act(() => {
+      netInfoListener?.(buildNetInfoState("offline"));
+      netInfoListener?.(buildNetInfoState("unknown"));
+      netInfoListener?.(buildNetInfoState("online"));
+      netInfoListener?.(buildNetInfoState("online"));
+    });
+
+    expect(polling.poll).toHaveBeenCalledTimes(1);
+    expect(polling.start).not.toHaveBeenCalled();
+    expect(polling.stop).not.toHaveBeenCalled();
+  });
+
+  it("should not poll on reconnection while in background", () => {
+    setCurrentAppState("active");
+    renderHook(() => useCountervaluesPollingLifecycle());
+    jest.clearAllMocks();
+
+    act(() => {
+      netInfoListener?.(buildNetInfoState("offline"));
+      appStateListener?.("background");
+      netInfoListener?.(buildNetInfoState("online"));
+    });
+
+    expect(polling.poll).not.toHaveBeenCalled();
+  });
+
+  it("should keep listeners stable and use the latest polling actions after rerender", () => {
+    setCurrentAppState("active");
+    const { rerender } = renderHook(() => useCountervaluesPollingLifecycle());
+    const nextPolling = createPolling();
+
+    mockedUseCountervaluesPolling.mockReturnValue(nextPolling);
+    rerender(undefined);
+    jest.mocked(polling.start).mockClear();
+    jest.mocked(polling.stop).mockClear();
+    jest.mocked(polling.poll).mockClear();
+
+    act(() => {
+      appStateListener?.("background");
+      appStateListener?.("active");
+    });
+
+    expect(appStateAddEventListenerSpy).toHaveBeenCalledTimes(1);
+    expect(NetInfo.addEventListener).toHaveBeenCalledTimes(1);
+    expect(polling.start).not.toHaveBeenCalled();
+    expect(polling.stop).not.toHaveBeenCalled();
+    expect(polling.poll).not.toHaveBeenCalled();
+    expect(nextPolling.stop).toHaveBeenCalledTimes(1);
+    expect(nextPolling.start).toHaveBeenCalledTimes(1);
+    expect(nextPolling.poll).toHaveBeenCalledTimes(1);
+  });
+
+  it("should remove app state and network listeners when unmounted", () => {
+    setCurrentAppState("active");
+    const { unmount } = renderHook(() => useCountervaluesPollingLifecycle());
+
+    unmount();
+
+    expect(removeAppStateListener).toHaveBeenCalledTimes(1);
+    expect(unsubscribeNetInfo).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/hooks/useCountervaluesPollingLifecycle.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/useCountervaluesPollingLifecycle.ts
@@ -18,6 +18,33 @@ function getNetworkStatus(state: NetInfoState): NetworkStatus {
   return "unknown";
 }
 
+function createNetworkChangeHandler(
+  getAppState: () => AppStateStatus | null,
+  poll: () => void,
+): (state: NetInfoState) => void {
+  let previousNetworkStatus: NetworkStatus | null = null;
+  let isFirstNetworkUpdate = true;
+
+  return state => {
+    const networkStatus = getNetworkStatus(state);
+
+    if (isFirstNetworkUpdate) {
+      isFirstNetworkUpdate = false;
+      previousNetworkStatus = networkStatus;
+      return;
+    }
+
+    if (networkStatus === "unknown") return;
+
+    const wasOffline = previousNetworkStatus === "offline";
+    previousNetworkStatus = networkStatus;
+
+    if (wasOffline && networkStatus === "online" && getAppState() === "active") {
+      poll();
+    }
+  };
+}
+
 export function useCountervaluesPollingLifecycle(): void {
   const { poll, start, stop } = useCountervaluesPolling();
   const pollingActionsRef = useRef<PollingActions>({ poll, start, stop });
@@ -28,8 +55,6 @@ export function useCountervaluesPollingLifecycle(): void {
 
   useEffect(() => {
     let currentAppState = AppState.currentState;
-    let previousNetworkStatus: NetworkStatus | null = null;
-    let isFirstNetworkUpdate = true;
 
     if (currentAppState === "active") {
       pollingActionsRef.current.start();
@@ -56,24 +81,12 @@ export function useCountervaluesPollingLifecycle(): void {
       },
     );
 
-    const unsubscribeNetInfo = NetInfo.addEventListener(state => {
-      const networkStatus = getNetworkStatus(state);
-
-      if (isFirstNetworkUpdate) {
-        isFirstNetworkUpdate = false;
-        previousNetworkStatus = networkStatus;
-        return;
-      }
-
-      if (networkStatus === "unknown") return;
-
-      const wasOffline = previousNetworkStatus === "offline";
-      previousNetworkStatus = networkStatus;
-
-      if (wasOffline && networkStatus === "online" && currentAppState === "active") {
-        pollingActionsRef.current.poll();
-      }
-    });
+    const unsubscribeNetInfo = NetInfo.addEventListener(
+      createNetworkChangeHandler(
+        () => currentAppState,
+        () => pollingActionsRef.current.poll(),
+      ),
+    );
 
     return () => {
       appStateSubscription.remove();

--- a/apps/ledger-live-mobile/src/mvvm/hooks/useCountervaluesPollingLifecycle.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/useCountervaluesPollingLifecycle.ts
@@ -1,0 +1,83 @@
+import NetInfo, { type NetInfoState } from "@react-native-community/netinfo";
+import { type Polling, useCountervaluesPolling } from "@ledgerhq/live-countervalues-react";
+import { useEffect, useRef } from "react";
+import { AppState, type AppStateStatus } from "react-native";
+
+type PollingActions = Pick<Polling, "poll" | "start" | "stop">;
+type NetworkStatus = "online" | "offline" | "unknown";
+
+function getNetworkStatus(state: NetInfoState): NetworkStatus {
+  if (state.isConnected === false || state.isInternetReachable === false) {
+    return "offline";
+  }
+
+  if (state.isConnected === true && state.isInternetReachable === true) {
+    return "online";
+  }
+
+  return "unknown";
+}
+
+export function useCountervaluesPollingLifecycle(): void {
+  const { poll, start, stop } = useCountervaluesPolling();
+  const pollingActionsRef = useRef<PollingActions>({ poll, start, stop });
+
+  useEffect(() => {
+    pollingActionsRef.current = { poll, start, stop };
+  }, [poll, start, stop]);
+
+  useEffect(() => {
+    let currentAppState = AppState.currentState;
+    let previousNetworkStatus: NetworkStatus | null = null;
+    let isFirstNetworkUpdate = true;
+
+    if (currentAppState === "active") {
+      pollingActionsRef.current.start();
+    } else {
+      pollingActionsRef.current.stop();
+    }
+
+    const appStateSubscription = AppState.addEventListener(
+      "change",
+      (nextAppState: AppStateStatus) => {
+        const wasActive = currentAppState === "active";
+        const isActive = nextAppState === "active";
+
+        currentAppState = nextAppState;
+
+        if (wasActive === isActive) return;
+
+        if (isActive) {
+          pollingActionsRef.current.start();
+          pollingActionsRef.current.poll();
+        } else {
+          pollingActionsRef.current.stop();
+        }
+      },
+    );
+
+    const unsubscribeNetInfo = NetInfo.addEventListener(state => {
+      const networkStatus = getNetworkStatus(state);
+
+      if (isFirstNetworkUpdate) {
+        isFirstNetworkUpdate = false;
+        previousNetworkStatus = networkStatus;
+        return;
+      }
+
+      if (networkStatus === "unknown") return;
+
+      const wasOffline = previousNetworkStatus === "offline";
+      previousNetworkStatus = networkStatus;
+
+      if (wasOffline && networkStatus === "online" && currentAppState === "active") {
+        pollingActionsRef.current.poll();
+      }
+    });
+
+    return () => {
+      appStateSubscription.remove();
+      unsubscribeNetInfo();
+    };
+  }, []);
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** AppState and NetInfo lifecycle transitions are covered, including duplicate callbacks and listener cleanup.
- [x] **Impact of the changes:**
      Countervalues are refreshed immediately when Ledger Wallet Mobile resumes or reconnects, without enabling polling in the background.

### 📝 Description

Countervalue polling stopped when the mobile application moved to the background but did not immediately request updated rates when the application became active again.

This PR adds a Mobile-only lifecycle adapter. It starts polling and requests rates on an AppState transition to `active`, requests rates after a confirmed offline-to-online NetInfo transition while active, and stops polling for every other state. It does not trigger account or Wallet Sync refreshes.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-36444](https://ledgerhq.atlassian.net/browse/LIVE-36444)
- **Related Desktop fix**: #21111
- **Follow-up scheduler PR**: created separately from this PR.

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-36444]: https://ledgerhq.atlassian.net/browse/LIVE-36444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ