### PR TITLE
[LWM] fix(contacts): delay add contact input focus until drawer fully opens

### DIFF
--- a/.changeset/LIVE-35860-contacts-add-contact-focus.md
+++ b/.changeset/LIVE-35860-contacts-add-contact-focus.md
@@ -1,0 +1,8 @@
+---
+"@shared/ui-queued-bottom-sheet": minor
+"@features/platform-contacts": minor
+"@features/flow-contacts-add-contact": minor
+"live-mobile": minor
+---
+
+Fix the odd Add contact transition on Mobile by focusing the contact name field only once the drawer has finished opening, so the keyboard no longer resizes the dynamically sized drawer mid-animation. Adds an onOpened callback to QueuedBottomSheet and makes ContactNameInput focus reactively rather than only on mount.

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/ContactsAddContactDrawerSheet.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/ContactsAddContactDrawerSheet.test.tsx
@@ -2,7 +2,9 @@ import React, { useState } from "react";
 import { Platform } from "react-native";
 import { BottomSheetView } from "@ledgerhq/lumen-ui-rnative";
 import type { AddContactAppAdapterResult } from "@features/flow-contacts";
-import { fireEvent, render, screen } from "@tests/test-renderer";
+import { ContactsAddContactContent } from "@features/flow-contacts-add-contact";
+import { QueuedBottomSheet } from "@shared/ui-queued-bottom-sheet";
+import { act, fireEvent, render, screen } from "@tests/test-renderer";
 import { ContactsAddContactDrawerSheet } from ".";
 
 const mockUseKeyboardVisible = jest.fn();
@@ -76,7 +78,16 @@ describe("ContactsAddContactDrawerSheet", () => {
     expect(screen.getByText(/For privacy, avoid full names and surnames/)).toBeVisible();
     expect(screen.getByText("0/32")).toBeVisible();
     expect(screen.getByRole("button", { name: "Confirm name" })).toBeDisabled();
-    expect(screen.getByTestId("contacts-add-contact-name-input")).toHaveProp("autoFocus", true);
+  });
+
+  it("should hold the name field focus back until the drawer has finished opening", () => {
+    render(<ContactsAddContactDrawerSheet {...createViewModel()} />);
+
+    expect(screen.UNSAFE_getByType(ContactsAddContactContent).props.autoFocus).toBe(false);
+
+    act(() => screen.UNSAFE_getByType(QueuedBottomSheet).props.onOpened());
+
+    expect(screen.UNSAFE_getByType(ContactsAddContactContent).props.autoFocus).toBe(true);
   });
 
   it("should cap the contact name at 32 characters", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useState } from "react";
 import { Platform } from "react-native";
 import { BottomSheetHeader, BottomSheetView, Box } from "@ledgerhq/lumen-ui-rnative";
 import { ContactsAddContactContent } from "@features/flow-contacts-add-contact";
@@ -20,11 +20,18 @@ export function ContactsAddContactDrawerSheet({
   const keyboardInset = shouldUseKeyboardAvoidance(Platform.OS, Platform.Version)
     ? keyboardHeight
     : 0;
+  const [hasOpened, setHasOpened] = useState(false);
+  const handleOpened = useCallback(() => setHasOpened(true), []);
+  const handleClose = useCallback(() => {
+    setHasOpened(false);
+    onClose();
+  }, [onClose]);
 
   return (
     <QueuedBottomSheet
       isRequestingToBeOpened={isOpen}
-      onClose={onClose}
+      onOpened={handleOpened}
+      onClose={handleClose}
       testID="contacts-add-contact-drawer"
       enableDynamicSizing
     >
@@ -32,7 +39,7 @@ export function ContactsAddContactDrawerSheet({
         {isOpen ? (
           <Box lx={{ gap: "s24" }}>
             <BottomSheetHeader />
-            <ContactsAddContactContent {...contentProps} />
+            <ContactsAddContactContent {...contentProps} autoFocus={hasOpened} />
           </Box>
         ) : null}
       </BottomSheetView>

--- a/features/flow/flow-contacts-add-contact/src/screens/AddContact/ContactsAddContactContent.native.tsx
+++ b/features/flow/flow-contacts-add-contact/src/screens/AddContact/ContactsAddContactContent.native.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Banner, Box, Button, Text } from "@ledgerhq/lumen-ui-rnative";
 import { ContactNameInput } from "@features/platform-contacts";
-import type { ContactsAddContactContentProps } from "./types";
+import type { ContactsAddContactContentNativeProps } from "./types";
 
 export function ContactsAddContactContent({
   isConfirmEnabled,
@@ -9,9 +9,10 @@ export function ContactsAddContactContent({
   draftName,
   invalidNameError,
   labels,
+  autoFocus,
   onDraftNameChange,
   onConfirm,
-}: ContactsAddContactContentProps): React.JSX.Element {
+}: ContactsAddContactContentNativeProps): React.JSX.Element {
   const nameValidationError =
     invalidNameError === null ? undefined : labels.nameValidationErrors[invalidNameError];
 
@@ -26,6 +27,7 @@ export function ContactsAddContactContent({
           placeholder={labels.namePlaceholder}
           errorMessage={nameValidationError}
           isEditable={!isSaving}
+          autoFocus={autoFocus}
           onChangeText={onDraftNameChange}
         />
         <Banner appearance="info" description={labels.namingDisclaimer} />

--- a/features/flow/flow-contacts-add-contact/src/screens/AddContact/types.ts
+++ b/features/flow/flow-contacts-add-contact/src/screens/AddContact/types.ts
@@ -29,3 +29,9 @@ export type ContactsAddContactContentProps = AddContactContentViewModel &
   Readonly<{
     labels: ContactsAddContactContentLabels;
   }>;
+
+export type ContactsAddContactContentNativeProps = ContactsAddContactContentProps &
+  Readonly<{
+    /** Lets the host drawer hold the keyboard back until it has finished opening. */
+    autoFocus?: boolean;
+  }>;

--- a/features/platform/contacts/src/components/ContactNameInput/ContactNameInput.native.test.tsx
+++ b/features/platform/contacts/src/components/ContactNameInput/ContactNameInput.native.test.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { render, screen } from "@testing-library/react-native";
+import { ContactNameInput } from ".";
+
+const mockFocus = jest.fn();
+
+// The shared Lumen passthrough renders host elements whose refs stay null, so the focus call is
+// unobservable. Override just TextInput to expose a controllable imperative handle.
+jest.mock("@ledgerhq/lumen-ui-rnative", () => {
+  const actual = jest.requireActual<Record<string, unknown>>("@ledgerhq/lumen-ui-rnative");
+  const ReactActual = jest.requireActual<typeof import("react")>("react");
+
+  return new Proxy(actual, {
+    get(target, prop) {
+      if (prop !== "TextInput") {
+        return target[prop as string];
+      }
+
+      return ({ ref, ...props }: { ref?: React.Ref<{ focus: () => void }> }) => {
+        ReactActual.useImperativeHandle(ref, () => ({ focus: mockFocus }));
+        return ReactActual.createElement("TextInput", props);
+      };
+    },
+  });
+});
+
+describe("ContactNameInput", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should render the name field with its character count", () => {
+    render(<ContactNameInput value="Ada" placeholder="Contact name" onChangeText={jest.fn()} />);
+
+    expect(screen.getByTestId("contacts-add-contact-name-input")).toHaveProp("value", "Ada");
+    expect(screen.getByPlaceholderText("Contact name")).toBeVisible();
+    expect(screen.getByText("3/32")).toBeVisible();
+  });
+
+  it("should focus on mount by default", () => {
+    render(<ContactNameInput value="" placeholder="Contact name" onChangeText={jest.fn()} />);
+
+    expect(mockFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it("should stay unfocused while the host withholds focus, then focus once it is granted", () => {
+    const { rerender } = render(
+      <ContactNameInput
+        value=""
+        placeholder="Contact name"
+        autoFocus={false}
+        onChangeText={jest.fn()}
+      />,
+    );
+
+    expect(mockFocus).not.toHaveBeenCalled();
+
+    rerender(
+      <ContactNameInput value="" placeholder="Contact name" autoFocus onChangeText={jest.fn()} />,
+    );
+
+    expect(mockFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it("should surface the validation error and namespace its test ids", () => {
+    render(
+      <ContactNameInput
+        value="Ada@1"
+        placeholder="Contact name"
+        errorMessage="Special characters are not allowed."
+        testIDPrefix="contacts-rename-contact"
+        onChangeText={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("contacts-rename-contact-name-error")).toHaveTextContent(
+      "Special characters are not allowed.",
+    );
+    expect(screen.getByTestId("contacts-rename-contact-name-count")).toBeVisible();
+  });
+});

--- a/features/platform/contacts/src/components/ContactNameInput/ContactNameInput.native.tsx
+++ b/features/platform/contacts/src/components/ContactNameInput/ContactNameInput.native.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
+import type { TextInput as NativeTextInput } from "react-native";
 import { CONTACT_NAME_MAX_LENGTH } from "@domain/entity-contact";
 import { Box, Text, TextInput } from "@ledgerhq/lumen-ui-rnative";
 import { DeleteCircleFill } from "@ledgerhq/lumen-ui-rnative/symbols";
@@ -8,6 +9,12 @@ type ContactNameInputProps = Readonly<{
   placeholder: string;
   errorMessage?: string;
   isEditable?: boolean;
+  /**
+   * Focuses the field whenever this turns true, rather than only on mount. Hosts inside an
+   * animating drawer can keep it false until the drawer has settled, so the keyboard does not
+   * resize the drawer while it is still opening.
+   */
+  autoFocus?: boolean;
   /** Namespaces the test ids, so each host drawer identifies its own input. */
   testIDPrefix?: string;
   onChangeText: (name: string) => void;
@@ -18,16 +25,24 @@ export function ContactNameInput({
   placeholder,
   errorMessage,
   isEditable = true,
+  autoFocus = true,
   testIDPrefix = "contacts-add-contact",
   onChangeText,
 }: ContactNameInputProps): React.JSX.Element {
   const isAtNameLengthLimit = value.length === CONTACT_NAME_MAX_LENGTH;
+  const inputRef = useRef<NativeTextInput>(null);
+
+  useEffect(() => {
+    if (autoFocus) {
+      inputRef.current?.focus();
+    }
+  }, [autoFocus]);
 
   return (
     <Box lx={{ gap: "s8" }}>
       <TextInput
+        ref={inputRef}
         testID={`${testIDPrefix}-name-input`}
-        autoFocus
         placeholder={placeholder}
         value={value}
         onChangeText={onChangeText}

--- a/shared/ui-queued-bottom-sheet/src/components/QueuedBottomSheet/QueuedBottomSheet.native.tsx
+++ b/shared/ui-queued-bottom-sheet/src/components/QueuedBottomSheet/QueuedBottomSheet.native.tsx
@@ -18,6 +18,7 @@ export function QueuedBottomSheet({
   onBackdropPress,
   onBack,
   hasBackButton,
+  onOpened,
   onModalHide,
   noCloseButton,
   preventBackdropClick,
@@ -69,6 +70,7 @@ export function QueuedBottomSheet({
       onBack={hasBackButton ? hookOnBack : undefined}
       onHeaderClosePressed={handleHeaderClosePressed}
       onAnimate={handleAnimate}
+      onOpen={onOpened}
       onDismiss={handleDismiss}
       backdropPressBehavior={preventBackdropClick || areBottomSheetsLocked ? "none" : "close"}
       onBackdropPress={handleBackdropPress}

--- a/shared/ui-queued-bottom-sheet/src/components/QueuedBottomSheet/types.ts
+++ b/shared/ui-queued-bottom-sheet/src/components/QueuedBottomSheet/types.ts
@@ -27,6 +27,12 @@ export type QueuedBottomSheetProps = Readonly<{
    * drawer is dismissed. Use it to track close intent accurately.
    */
   onBackdropPress?: () => void;
+  /**
+   * Callback after the drawer has finished animating open and settled on its snap point. Use it to
+   * defer work that would otherwise compete with the opening animation, such as focusing an input
+   * (which raises the keyboard and, with {@link enableDynamicSizing}, resizes the drawer mid-flight).
+   */
+  onOpened?: () => void;
   /** Callback after the drawer is fully hidden. */
   onModalHide?: () => void;
   /** Prevent closing via backdrop press. */


### PR DESCRIPTION
### 📝 Description

Tapping **Add contact** on Mobile played an odd two-stage transition: the drawer rose to a short height, then jumped taller mid-flight.

The drawer is a dynamically sized `QueuedBottomSheet`. `ContactNameInput` had `autoFocus`, so the open animation and the keyboard started together. Keyboard padding then grew the measured height, gorhom recomputed detents, and a second animation ran on top of the first.

This sequences the two: the drawer opens at a stable height, then the name field is focused once `onOpened` fires (Lumen `onOpen` / gorhom `onChange` at index 0). `ContactNameInput` now focuses through a ref effect so that can happen after mount. `autoFocus` still defaults to `true`, so rename contact and other consumers are unchanged.

Regression coverage: `ContactsAddContactDrawerSheet` asserts the name field stays unfocused until `onOpened`, and `ContactNameInput.native.test.tsx` covers both focus branches.


https://github.com/user-attachments/assets/e55c0e8f-acc6-4d9b-84bc-de7824511bf7



### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35860](https://ledgerhq.atlassian.net/browse/LIVE-35860)
- **ADR** (if any):

[LIVE-35860]: https://ledgerhq.atlassian.net/browse/LIVE-35860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ