### PR TITLE
[LWDM] feat(aleo): get validators list

### DIFF
--- a/.changeset/soft-mice-tickle.md
+++ b/.changeset/soft-mice-tickle.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-aleo": minor
+"@ledgerhq/live-common": minor
+---
+
+aleo: expose the validator committee with an estimated staking rate through a shared hook

--- a/libs/coin-modules/coin-aleo/src/constants.ts
+++ b/libs/coin-modules/coin-aleo/src/constants.ts
@@ -94,3 +94,15 @@ export const BALANCED_PRIVATE_RECORDS_PER_TRANSACTION = 8;
 
 // The estimated time in milliseconds it takes to sign a single record during transaction signing.
 export const SINGLE_CALL_SIGNING_TIME = 12500;
+
+export const MICROCREDITS_PER_CREDIT = 1_000_000;
+
+// Below this bonded total the protocol pays a delegator nothing at all.
+export const MIN_DELEGATOR_STAKE_MICROCREDITS = 10_000 * MICROCREDITS_PER_CREDIT;
+
+// snarkVM `block_reward_v2` adds a coinbase share and transaction fees on top, so
+// rates derived from this alone are a lower bound.
+export const ANNUAL_INFLATION_RATE = 0.05;
+
+// A validator above this share of total stake earns zero, not a reduced rate.
+export const MAX_VALIDATOR_STAKE_SHARE = 0.25;

--- a/libs/coin-modules/coin-aleo/src/logic/getValidators.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getValidators.test.ts
@@ -1,0 +1,139 @@
+import { apiClient } from "../network/api";
+import type { AleoCommitteeResponse } from "../types/api";
+import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
+import coinConfig from "../config";
+import { getValidators } from "./getValidators";
+
+jest.mock("../network/api");
+
+const OPEN_HIGH_STAKE = "aleo1open_high";
+const OPEN_LOW_STAKE = "aleo1open_low";
+const CLOSED_HIGH_STAKE = "aleo1closed_high";
+
+// Supply equal to the staked total makes the gross rate exactly the inflation rate
+// (0.05 * S / S), so each expectation below stays readable.
+const TOTAL_SUPPLY_CREDITS = 100;
+const GROSS_RATE = 0.05;
+const committee: AleoCommitteeResponse = {
+  total_stake: 100 * 1_000_000,
+  members: {
+    [CLOSED_HIGH_STAKE]: [50 * 1_000_000, false, 0],
+    [OPEN_LOW_STAKE]: [10 * 1_000_000, true, 50],
+    [OPEN_HIGH_STAKE]: [20 * 1_000_000, true, 0],
+  },
+};
+
+const CURRENCY_ID = "aleo";
+
+describe("getValidators", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getValidators.reset();
+    coinConfig.setCoinConfig(() => getMockedConfig("mainnet"));
+
+    jest.mocked(apiClient.getCommittee).mockResolvedValue(committee);
+    jest.mocked(apiClient.getValidatorMetadata).mockResolvedValue({
+      [OPEN_HIGH_STAKE]: "High Stake Validator",
+    });
+    jest.mocked(apiClient.getTotalSupply).mockResolvedValue(TOTAL_SUPPLY_CREDITS);
+  });
+
+  it("orders open validators first, then by descending stake", async () => {
+    const validators = await getValidators(CURRENCY_ID);
+
+    expect(validators.map(v => v.address)).toEqual([
+      OPEN_HIGH_STAKE,
+      OPEN_LOW_STAKE,
+      CLOSED_HIGH_STAKE,
+    ]);
+  });
+
+  it("resolves names where metadata has one and leaves the rest unnamed", async () => {
+    const validators = await getValidators(CURRENCY_ID);
+
+    expect(validators.find(v => v.address === OPEN_HIGH_STAKE)?.name).toBe("High Stake Validator");
+    expect(validators.find(v => v.address === OPEN_LOW_STAKE)?.name).toBeUndefined();
+  });
+
+  it("keeps the whole gross rate at zero commission and half of it at 50%", async () => {
+    const validators = await getValidators(CURRENCY_ID);
+
+    expect(validators.find(v => v.address === OPEN_HIGH_STAKE)?.estimatedYearlyRewardsRate).toBe(
+      GROSS_RATE,
+    );
+    expect(validators.find(v => v.address === OPEN_LOW_STAKE)?.estimatedYearlyRewardsRate).toBe(
+      GROSS_RATE / 2,
+    );
+  });
+
+  it("reports a zero rate over the 25% concentration cap, even at zero commission", async () => {
+    const validators = await getValidators(CURRENCY_ID);
+
+    expect(validators.find(v => v.address === CLOSED_HIGH_STAKE)?.estimatedYearlyRewardsRate).toBe(
+      0,
+    );
+  });
+
+  it("fetches committee, names and supply concurrently", async () => {
+    await getValidators(CURRENCY_ID);
+
+    expect(apiClient.getCommittee).toHaveBeenCalledTimes(1);
+    expect(apiClient.getValidatorMetadata).toHaveBeenCalledTimes(1);
+    expect(apiClient.getTotalSupply).toHaveBeenCalledTimes(1);
+  });
+
+  describe("degraded responses", () => {
+    it("still returns a usable list when the names fetch fails", async () => {
+      jest.mocked(apiClient.getValidatorMetadata).mockRejectedValue(new Error("boom"));
+
+      const validators = await getValidators(CURRENCY_ID);
+
+      expect(validators).toHaveLength(3);
+      expect(validators.every(v => v.name === undefined)).toBe(true);
+    });
+
+    it("ignores a malformed names payload rather than ingesting junk", async () => {
+      jest
+        .mocked(apiClient.getValidatorMetadata)
+        .mockResolvedValue({ [OPEN_HIGH_STAKE]: 42 } as never);
+
+      const validators = await getValidators(CURRENCY_ID);
+
+      expect(validators.every(v => v.name === undefined)).toBe(true);
+    });
+
+    it("omits the rate — rather than reporting zero — when the supply fetch fails", async () => {
+      jest.mocked(apiClient.getTotalSupply).mockRejectedValue(new Error("boom"));
+
+      const validators = await getValidators(CURRENCY_ID);
+
+      expect(validators).toHaveLength(3);
+      expect(validators.every(v => v.estimatedYearlyRewardsRate === undefined)).toBe(true);
+    });
+
+    it("omits the rate when the committee reports no total stake", async () => {
+      jest.mocked(apiClient.getCommittee).mockResolvedValue({ members: committee.members });
+
+      const validators = await getValidators(CURRENCY_ID);
+
+      expect(validators.every(v => v.estimatedYearlyRewardsRate === undefined)).toBe(true);
+    });
+
+    it.each([
+      ["a malformed member tuple", { members: { bad: [1, 2] } }],
+      ["no members at all", {}],
+      ["an error envelope", { error: "upstream unavailable" }],
+      ["members sent as an array", { members: [[50 * 1_000_000, true, 0]] }],
+      ["a NaN stake", { members: { [OPEN_HIGH_STAKE]: [NaN, true, 0] } }],
+      ["an infinite stake", { members: { [OPEN_HIGH_STAKE]: [Infinity, true, 0] } }],
+      ["a negative stake", { members: { [OPEN_HIGH_STAKE]: [-1, true, 0] } }],
+      ["a NaN commission", { members: { [OPEN_HIGH_STAKE]: [10 * 1_000_000, true, NaN] } }],
+      ["a negative commission", { members: { [OPEN_HIGH_STAKE]: [10 * 1_000_000, true, -1] } }],
+      ["a commission above 100%", { members: { [OPEN_HIGH_STAKE]: [10 * 1_000_000, true, 101] } }],
+    ])("throws on %s rather than caching an empty list", async (_label, response) => {
+      jest.mocked(apiClient.getCommittee).mockResolvedValue(response as never);
+
+      await expect(getValidators(CURRENCY_ID)).rejects.toThrow("invalid committee response");
+    });
+  });
+});

--- a/libs/coin-modules/coin-aleo/src/logic/getValidators.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getValidators.ts
@@ -1,0 +1,111 @@
+import BigNumber from "bignumber.js";
+import { log } from "@ledgerhq/logs";
+import { makeLRUCache, minutes } from "@ledgerhq/live-network/cache";
+import { apiClient } from "../network/api";
+import { estimateNetRate, isRecord, parseTotalSupply, resolveConfig } from "./utils";
+import type {
+  AleoCommitteeMember,
+  AleoCommitteeResponse,
+  AleoValidatorMetadataResponse,
+} from "../types/api";
+import type { AleoValidator } from "../types";
+
+// Short enough that a validator that has just closed is not offered for long.
+const VALIDATORS_CACHE = minutes(5, 2);
+
+const isStakeMicrocredits = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value) && value >= 0;
+
+const isCommissionPercent = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 100;
+
+function isValidCommitteeMember(value: unknown): value is AleoCommitteeMember {
+  return (
+    Array.isArray(value) &&
+    value.length === 3 &&
+    isStakeMicrocredits(value[0]) &&
+    typeof value[1] === "boolean" &&
+    isCommissionPercent(value[2])
+  );
+}
+
+function isValidCommitteeResponse(value: unknown): value is AleoCommitteeResponse {
+  if (!isRecord(value)) return false;
+  // The protocol always has a committee, so absent `members` is an error envelope
+  // rather than an empty list — accepting it would cache emptiness for a whole TTL.
+  if (!isRecord(value.members)) return false;
+
+  return Object.values(value.members).every(isValidCommitteeMember);
+}
+
+function isValidValidatorMetadataResponse(value: unknown): value is AleoValidatorMetadataResponse {
+  if (!isRecord(value)) return false;
+
+  return Object.values(value).every(entry => typeof entry === "string");
+}
+
+/**
+ * The validator committee for `currencyId`'s configured network, ordered for a picker.
+ *
+ * Only the committee is required. Names and total supply are best-effort, so losing
+ * either degrades a field rather than failing the list the bond flow depends on.
+ */
+export const getValidators = makeLRUCache(
+  async (currencyId: string): Promise<AleoValidator[]> => {
+    const config = resolveConfig(currencyId);
+
+    const [committee, metadata, totalSupply] = await Promise.all([
+      apiClient.getCommittee(config),
+      apiClient.getValidatorMetadata(config).catch(() => null),
+      apiClient.getTotalSupply(config).catch(() => null),
+    ]);
+
+    if (!isValidCommitteeResponse(committee)) {
+      throw new Error("Unable to fetch Aleo validators: invalid committee response");
+    }
+
+    const safeMetadata = metadata && isValidValidatorMetadataResponse(metadata) ? metadata : {};
+
+    const totalSupplyCredits = parseTotalSupply(totalSupply);
+    const totalStakeMicrocredits =
+      committee.total_stake === undefined ? null : new BigNumber(committee.total_stake);
+
+    if (totalSupplyCredits === null || totalStakeMicrocredits === null) {
+      log("aleo/getValidators", "no estimated rate: missing total supply or total stake", {
+        hasTotalSupply: totalSupplyCredits !== null,
+        hasTotalStake: totalStakeMicrocredits !== null,
+      });
+    }
+
+    return Object.entries(committee.members)
+      .map(([address, [stakeMicrocredits, isOpen, commissionPercent]]) => {
+        const rate =
+          totalSupplyCredits === null || totalStakeMicrocredits === null
+            ? null
+            : estimateNetRate({
+                totalSupplyCredits,
+                totalStakeMicrocredits,
+                validatorStakeMicrocredits: new BigNumber(stakeMicrocredits),
+                commissionPercent: new BigNumber(commissionPercent),
+              });
+
+        return {
+          address,
+          name: safeMetadata[address],
+          stakeMicrocredits,
+          isOpen,
+          commissionPercent,
+          ...(rate !== null && { estimatedYearlyRewardsRate: rate.toNumber() }),
+        };
+      })
+      .sort((left, right) => {
+        if (left.isOpen !== right.isOpen) {
+          return left.isOpen ? -1 : 1;
+        }
+
+        return right.stakeMicrocredits - left.stakeMicrocredits;
+      });
+  },
+  currencyId => currencyId,
+  VALIDATORS_CACHE,
+);

--- a/libs/coin-modules/coin-aleo/src/logic/index.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/index.ts
@@ -4,6 +4,8 @@ export { craftTransaction } from "./craftTransaction";
 export { estimateFees } from "./estimateFees";
 export { getAccountInfo } from "./getAccountInfo";
 export { getBalance } from "./getBalance";
+export { getValidators } from "./getValidators";
+export { estimateNetRate } from "./utils";
 export { lastBlock } from "./lastBlock";
 export { register } from "./register";
 export { validateIntent } from "./validateIntent";

--- a/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
@@ -5,6 +5,8 @@ import {
   EXPLORER_TRANSFER_TYPES,
   MAX_PRIVATE_RECORDS_PER_TRANSACTION,
   MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION,
+  MICROCREDITS_PER_CREDIT,
+  MIN_DELEGATOR_STAKE_MICROCREDITS,
   PROGRAM_ID,
   TRANSACTION_TYPE,
 } from "../constants";
@@ -55,6 +57,9 @@ import type {
   ProvableApi,
 } from "../types";
 import {
+  estimateGrossRate,
+  estimateNetRate,
+  parseTotalSupply,
   parseMicrocredits,
   parseAmount,
   normalizeAleoPlaintext,
@@ -2818,5 +2823,147 @@ describe("resolvePrivacyContext", () => {
     };
 
     expect(() => resolvePrivacyContext(context)).toThrow("aleo: viewKey is missing");
+  });
+});
+
+describe("staking rates", () => {
+  const toMicrocredits = (credits: number) =>
+    new BigNumber(credits).multipliedBy(MICROCREDITS_PER_CREDIT);
+
+  // Observed on mainnet 2026-08-24, quoted in LIVE-32275 as the reference point.
+  const MAINNET_TOTAL_SUPPLY_CREDITS = new BigNumber(2_056_277_710);
+  const MAINNET_TOTAL_STAKE_CREDITS = 1_323_101_922;
+
+  describe("parseTotalSupply", () => {
+    it("accepts a JSON number", () => {
+      expect(parseTotalSupply(2_056_277_710)?.toNumber()).toBe(2_056_277_710);
+    });
+
+    it("accepts a numeric string, since the endpoint's scalar form is not guaranteed", () => {
+      expect(parseTotalSupply("2056277710")?.toNumber()).toBe(2_056_277_710);
+    });
+
+    it.each([
+      ["null", null],
+      ["undefined", undefined],
+      ["a non-numeric string", "not-a-number"],
+      ["an object", { total: 1 }],
+      ["an array", [1]],
+      ["zero", 0],
+      ["a negative supply", -1],
+      ["NaN", NaN],
+      ["Infinity", Infinity],
+    ])("rejects %s", (_label, value) => {
+      expect(parseTotalSupply(value)).toBeNull();
+    });
+  });
+
+  describe("estimateGrossRate", () => {
+    it("matches the rate observed on mainnet", () => {
+      const rate = estimateGrossRate(
+        MAINNET_TOTAL_SUPPLY_CREDITS,
+        toMicrocredits(MAINNET_TOTAL_STAKE_CREDITS),
+      );
+
+      expect(rate?.toNumber()).toBeCloseTo(0.0777, 4);
+    });
+
+    it("converts microcredits to credits before dividing, rather than inflating by 1e6", () => {
+      const rate = estimateGrossRate(new BigNumber(1_000), toMicrocredits(1_000));
+
+      expect(rate?.toNumber()).toBe(0.05);
+    });
+
+    it.each([
+      ["zero total stake", new BigNumber(100), new BigNumber(0)],
+      ["negative total stake", new BigNumber(100), new BigNumber(-1)],
+      ["zero total supply", new BigNumber(0), new BigNumber(100)],
+      ["a non-finite total supply", new BigNumber(NaN), new BigNumber(100)],
+      ["a non-finite total stake", new BigNumber(100), new BigNumber(NaN)],
+    ])("returns null for %s", (_label, supply, stake) => {
+      expect(estimateGrossRate(supply, stake)).toBeNull();
+    });
+  });
+
+  describe("estimateNetRate", () => {
+    const baseParams = {
+      totalSupplyCredits: MAINNET_TOTAL_SUPPLY_CREDITS,
+      totalStakeMicrocredits: toMicrocredits(MAINNET_TOTAL_STAKE_CREDITS),
+      // Comfortably under the 25% concentration cap.
+      validatorStakeMicrocredits: toMicrocredits(10_000_000),
+      commissionPercent: new BigNumber(10),
+    };
+
+    it("matches the net rate observed on mainnet at 10% commission", () => {
+      expect(estimateNetRate(baseParams)?.toNumber()).toBeCloseTo(0.0699, 4);
+    });
+
+    it("equals the gross rate at zero commission", () => {
+      const net = estimateNetRate({ ...baseParams, commissionPercent: new BigNumber(0) });
+      const gross = estimateGrossRate(
+        baseParams.totalSupplyCredits,
+        baseParams.totalStakeMicrocredits,
+      );
+
+      expect(net?.toNumber()).toBe(gross?.toNumber());
+    });
+
+    it("returns zero when the validator holds more than 25% of total stake", () => {
+      const rate = estimateNetRate({
+        ...baseParams,
+        validatorStakeMicrocredits: toMicrocredits(MAINNET_TOTAL_STAKE_CREDITS * 0.26),
+      });
+
+      expect(rate?.toNumber()).toBe(0);
+    });
+
+    it("still pays a validator sitting exactly at the 25% cap", () => {
+      const rate = estimateNetRate({
+        ...baseParams,
+        validatorStakeMicrocredits: toMicrocredits(MAINNET_TOTAL_STAKE_CREDITS * 0.25),
+      });
+
+      expect(rate?.toNumber()).toBeGreaterThan(0);
+    });
+
+    it("returns zero for a delegator below the protocol minimum", () => {
+      const rate = estimateNetRate({
+        ...baseParams,
+        delegatorStakeMicrocredits: new BigNumber(MIN_DELEGATOR_STAKE_MICROCREDITS).minus(1),
+      });
+
+      expect(rate?.toNumber()).toBe(0);
+    });
+
+    it("pays a delegator sitting exactly at the protocol minimum", () => {
+      const rate = estimateNetRate({
+        ...baseParams,
+        delegatorStakeMicrocredits: new BigNumber(MIN_DELEGATOR_STAKE_MICROCREDITS),
+      });
+
+      expect(rate?.toNumber()).toBeGreaterThan(0);
+    });
+
+    it("ignores the delegator minimum when no delegator stake is given", () => {
+      expect(estimateNetRate(baseParams)?.toNumber()).toBeGreaterThan(0);
+    });
+
+    it("clamps a commission above 100% to zero instead of going negative", () => {
+      const rate = estimateNetRate({ ...baseParams, commissionPercent: new BigNumber(150) });
+
+      expect(rate?.toNumber()).toBe(0);
+    });
+
+    it("returns null — not zero — when the rate cannot be derived", () => {
+      const rate = estimateNetRate({ ...baseParams, totalStakeMicrocredits: new BigNumber(0) });
+
+      expect(rate).toBeNull();
+    });
+
+    it("returns null for a negative commission", () => {
+      const rate = estimateNetRate({ ...baseParams, commissionPercent: new BigNumber(-1) });
+
+      expect(rate).toBeNull();
+    });
   });
 });

--- a/libs/coin-modules/coin-aleo/src/logic/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.ts
@@ -22,11 +22,15 @@ import {
 import { decodeOperationId, encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import aleoConfig from "../config";
 import {
+  ANNUAL_INFLATION_RATE,
   BALANCED_PRIVATE_RECORDS_PER_TRANSACTION,
   EXPLORER_TRANSFER_TYPES,
   FAST_PRIVATE_RECORDS_PER_TRANSACTION,
   MAX_PRIVATE_RECORDS_PER_TRANSACTION,
   MAX_PRIVATE_TOKEN_RECORDS_PER_TRANSACTION,
+  MAX_VALIDATOR_STAKE_SHARE,
+  MICROCREDITS_PER_CREDIT,
+  MIN_DELEGATOR_STAKE_MICROCREDITS,
   PRIVATE_TRANSFER_FUNCTIONS,
   PROGRAM_ID,
   SINGLE_CALL_SIGNING_TIME,
@@ -62,6 +66,10 @@ import type {
 } from "../types";
 
 const MICROCREDITS_REGEX = /^(\d+)u\d+$/;
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
 export function normalizeAleoPlaintext(v: string): string {
   return v.trim().replace(/\.(private|public|constant)$/, "");
@@ -597,12 +605,7 @@ export function findBestRecordForFee({
 
 function isPrivateOperation(operation: Operation): boolean {
   const { extra } = operation;
-  return (
-    typeof extra === "object" &&
-    extra !== null &&
-    "transactionType" in extra &&
-    extra.transactionType === "private"
-  );
+  return isRecord(extra) && "transactionType" in extra && extra.transactionType === "private";
 }
 
 export function splitPrivateAndPublicOperations(
@@ -1293,4 +1296,72 @@ export function findTransferArguments(plaintexts: (string | null)[]): {
   }
 
   return null;
+}
+
+/** `latest/totalSupply` is untrusted JSON: a bare scalar, in **credits**. */
+export function parseTotalSupply(value: unknown): BigNumber | null {
+  if (typeof value !== "number" && typeof value !== "string") return null;
+  const parsed = new BigNumber(value);
+
+  return parsed.isFinite() && parsed.isGreaterThan(0) ? parsed : null;
+}
+
+/**
+ * The network-wide gross staking rate before any validator commission, as a fraction
+ * (0.078 = 7.8%), or null when the inputs cannot yield one.
+ *
+ * Derived from the delegator's `block_reward * stake / total_stake` share in snarkVM
+ * (synthesizer/src/vm/helpers/rewards.rs).
+ */
+export function estimateGrossRate(
+  totalSupplyCredits: BigNumber,
+  totalStakeMicrocredits: BigNumber,
+): BigNumber | null {
+  if (!totalSupplyCredits.isFinite() || totalSupplyCredits.isLessThanOrEqualTo(0)) return null;
+  if (!totalStakeMicrocredits.isFinite() || totalStakeMicrocredits.isLessThanOrEqualTo(0)) {
+    return null;
+  }
+
+  const totalStakeCredits = totalStakeMicrocredits.dividedBy(MICROCREDITS_PER_CREDIT);
+
+  return totalSupplyCredits.multipliedBy(ANNUAL_INFLATION_RATE).dividedBy(totalStakeCredits);
+}
+
+/**
+ * What a delegator can expect from one validator: the gross network rate less that
+ * validator's commission, as a fraction (0.07 = 7%). A **lower bound** — every surface
+ * showing it must label it an estimate.
+ *
+ * Null means "cannot be derived", zero means "earns nothing"; not interchangeable.
+ */
+export function estimateNetRate({
+  totalSupplyCredits,
+  totalStakeMicrocredits,
+  validatorStakeMicrocredits,
+  commissionPercent,
+  delegatorStakeMicrocredits,
+}: {
+  totalSupplyCredits: BigNumber;
+  totalStakeMicrocredits: BigNumber;
+  validatorStakeMicrocredits: BigNumber;
+  commissionPercent: BigNumber;
+  /** The delegator's own position. Omit for the generic rate a picker shows. */
+  delegatorStakeMicrocredits?: BigNumber;
+}): BigNumber | null {
+  const grossRate = estimateGrossRate(totalSupplyCredits, totalStakeMicrocredits);
+  if (grossRate === null) return null;
+
+  if (!commissionPercent.isFinite() || commissionPercent.isLessThan(0)) return null;
+
+  const validatorOverConcentrated = validatorStakeMicrocredits
+    .dividedBy(totalStakeMicrocredits)
+    .isGreaterThan(MAX_VALIDATOR_STAKE_SHARE);
+  const delegatorBelowMinimum =
+    delegatorStakeMicrocredits !== undefined &&
+    delegatorStakeMicrocredits.isLessThan(MIN_DELEGATOR_STAKE_MICROCREDITS);
+  if (validatorOverConcentrated || delegatorBelowMinimum) return new BigNumber(0);
+
+  const keptShare = BigNumber.maximum(new BigNumber(1).minus(commissionPercent.dividedBy(100)), 0);
+
+  return grossRate.multipliedBy(keptShare);
 }

--- a/libs/coin-modules/coin-aleo/src/network/api.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/api.test.ts
@@ -1255,4 +1255,34 @@ describe("apiClient", () => {
       );
     });
   });
+
+  describe("staking endpoints", () => {
+    const endpoints = [
+      ["getCommittee", "committee/latest", { members: {}, total_stake: 0 }],
+      ["getValidatorMetadata", "committee/validator-metadata", {}],
+      ["getTotalSupply", "latest/totalSupply", 2_056_277_710],
+    ] as const;
+
+    it.each(endpoints)("%s targets mainnet when configured for it", async (method, path, body) => {
+      jest.mocked(network).mockResolvedValue({ data: body, status: 200 });
+
+      await expect(apiClient[method](mockConfig)).resolves.toEqual(body);
+      expect(network).toHaveBeenCalledTimes(1);
+      expect(network).toHaveBeenCalledWith({
+        method: "GET",
+        url: `https://node.example.com/v2/mainnet/${path}`,
+      });
+    });
+
+    it.each(endpoints)("%s targets testnet when configured for it", async (method, path, body) => {
+      jest.mocked(network).mockResolvedValue({ data: body, status: 200 });
+
+      await expect(apiClient[method](testnetConfig)).resolves.toEqual(body);
+      expect(network).toHaveBeenCalledTimes(1);
+      expect(network).toHaveBeenCalledWith({
+        method: "GET",
+        url: `https://node.example.com/v2/testnet/${path}`,
+      });
+    });
+  });
 });

--- a/libs/coin-modules/coin-aleo/src/network/api.ts
+++ b/libs/coin-modules/coin-aleo/src/network/api.ts
@@ -12,6 +12,9 @@ import type {
   AleoPrivateRecord,
   DelegatedProvingResponse,
   AleoTransitionCursor,
+  AleoCommitteeResponse,
+  AleoValidatorMetadataResponse,
+  AleoTotalSupplyResponse,
 } from "../types/api";
 import type { AleoCoinConfig } from "../types";
 import { MAX_TRANSITIONS_PER_PAGE, PROGRAM_ID } from "../constants";
@@ -33,6 +36,41 @@ async function getAccountBalance(config: AleoCoinConfig, address: string): Promi
   const res = await network<string | null>({
     method: "GET",
     url: `${apiUrls.node}/v2/${networkType}/program/${PROGRAM_ID.CREDITS}/mapping/account/${address}`,
+  });
+
+  return res.data;
+}
+
+async function getCommittee(config: AleoCoinConfig): Promise<AleoCommitteeResponse> {
+  const { apiUrls, networkType } = config;
+
+  const res = await network<AleoCommitteeResponse>({
+    method: "GET",
+    url: `${apiUrls.node}/v2/${networkType}/committee/latest`,
+  });
+
+  return res.data;
+}
+
+async function getValidatorMetadata(
+  config: AleoCoinConfig,
+): Promise<AleoValidatorMetadataResponse> {
+  const { apiUrls, networkType } = config;
+
+  const res = await network<AleoValidatorMetadataResponse>({
+    method: "GET",
+    url: `${apiUrls.node}/v2/${networkType}/committee/validator-metadata`,
+  });
+
+  return res.data;
+}
+
+async function getTotalSupply(config: AleoCoinConfig): Promise<AleoTotalSupplyResponse> {
+  const { apiUrls, networkType } = config;
+
+  const res = await network<AleoTotalSupplyResponse>({
+    method: "GET",
+    url: `${apiUrls.node}/v2/${networkType}/latest/totalSupply`,
   });
 
   return res.data;
@@ -327,6 +365,9 @@ async function submitEncryptedDelegatedProvingRequest({
 export const apiClient = {
   getLatestBlock,
   getAccountBalance,
+  getCommittee,
+  getValidatorMetadata,
+  getTotalSupply,
   getTokenBalance,
   getTokens,
   getTransactionById,

--- a/libs/coin-modules/coin-aleo/src/types/api.ts
+++ b/libs/coin-modules/coin-aleo/src/types/api.ts
@@ -1,5 +1,27 @@
 export type AleoTransactionType = "public" | "private";
 
+export type AleoCommitteeMember = [
+  stakeMicrocredits: number,
+  isOpen: boolean,
+  commissionPercent: number,
+];
+
+export interface AleoCommitteeResponse {
+  id?: string;
+  starting_round?: number;
+  members: Record<string, AleoCommitteeMember>;
+  total_stake?: number;
+}
+
+/** Address -> display name. Not every committee member is listed. */
+export type AleoValidatorMetadataResponse = Record<string, string>;
+
+/**
+ * Total circulating supply, a bare JSON scalar. Unlike every other amount in this
+ * API it is denominated in **credits**, not microcredits.
+ */
+export type AleoTotalSupplyResponse = number | string;
+
 export type AleoTransitionValue =
   | {
       id: string;

--- a/libs/coin-modules/coin-aleo/src/types/logic.ts
+++ b/libs/coin-modules/coin-aleo/src/types/logic.ts
@@ -49,6 +49,19 @@ export type AleoAccountInfo = {
   scannedHeight: number;
 };
 
+export type AleoValidator = {
+  address: string;
+  name?: string;
+  stakeMicrocredits: number;
+  isOpen: boolean;
+  commissionPercent: number;
+  /**
+   * Estimated net yearly rate as a fraction (0.07 = 7%). Absent when it could not be
+   * derived; `0` is a real value meaning "earns nothing".
+   */
+  estimatedYearlyRewardsRate?: number;
+};
+
 /** `<maxBlockHeight>:<blockNumber>:<transitionId>` — the pinned ceiling, then the row to resume after. */
 export type OperationsCursor = {
   maxBlockHeight: number;

--- a/libs/ledger-live-common/src/families/aleo/react.test.ts
+++ b/libs/ledger-live-common/src/families/aleo/react.test.ts
@@ -3,7 +3,7 @@
  */
 import "../../__tests__/test-helpers/dom-polyfill";
 import React from "react";
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, act, waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { configureStore } from "@reduxjs/toolkit";
 import { Subject } from "rxjs";
@@ -21,7 +21,9 @@ import {
   buildAccountsWithViewKeys,
   useAleoPrivateSync,
   useAleoQuickAmountSelector,
+  useAleoValidators,
 } from "./react";
+import { getValidators } from "@ledgerhq/coin-aleo/logic";
 import { ALEO_ACCOUNT_1, makeAleoAccount } from "./__mocks__/account.mock";
 
 const mockCreateAction = jest.fn();
@@ -50,6 +52,8 @@ jest.mock("./utils", () => ({
     id: `${account.id}:patched:${viewKey}`,
   })),
 }));
+
+jest.mock("@ledgerhq/coin-aleo/logic", () => ({ getValidators: jest.fn() }));
 
 const { useFeature } = jest.requireMock("@features/platform-feature-flags");
 const { getViewKeyExec } = jest.requireMock("./hw/getViewKey/index");
@@ -1379,5 +1383,127 @@ describe("useAleoQuickAmountSelector", () => {
     result.current.selectStrategy(result.current.strategyData[2]);
 
     expect(updateTransaction).not.toHaveBeenCalled();
+  });
+});
+
+describe("useAleoValidators", () => {
+  const validator = {
+    address: "aleo1validator",
+    name: "Validator One",
+    stakeMicrocredits: 20_000_000,
+    isOpen: true,
+    commissionPercent: 10,
+    estimatedYearlyRewardsRate: 0.07,
+  };
+
+  // The hook keeps a module-level render seed per currency id, so every test needs
+  // its own id or it would be handed the previous test's seed instead of loading.
+  let currencyIdCounter = 0;
+  const freshCurrency = () =>
+    ({ id: `aleo_test_${currencyIdCounter++}`, type: "CryptoCurrency" }) as CryptoCurrency;
+
+  beforeEach(() => {
+    jest.mocked(getValidators).mockReset();
+  });
+
+  it("starts loading with an empty list, then resolves to the fetched committee", async () => {
+    jest.mocked(getValidators).mockResolvedValue([validator]);
+    const currency = freshCurrency();
+
+    const { result } = renderHook(() => useAleoValidators(currency));
+
+    expect(result.current).toEqual({ validators: [], loading: true, error: null });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current).toEqual({ validators: [validator], loading: false, error: null });
+  });
+
+  it("seeds a remount with the last-seen list so the picker does not flash empty", async () => {
+    jest.mocked(getValidators).mockResolvedValue([validator]);
+    const currency = freshCurrency();
+
+    const first = renderHook(() => useAleoValidators(currency));
+    await waitFor(() => expect(first.result.current.loading).toBe(false));
+    first.unmount();
+
+    const second = renderHook(() => useAleoValidators(currency));
+
+    expect(second.result.current).toEqual({
+      validators: [validator],
+      loading: false,
+      error: null,
+    });
+
+    // Let the background refetch settle inside act, so its setState does not
+    // land after the test has finished.
+    await act(async () => {});
+  });
+
+  it("hands each mount its own list, so a picker sorting in place cannot corrupt the cache", async () => {
+    const second = { ...validator, address: "aleo1second" };
+    const arrayHeldByTheCoinModuleCache = [validator, second];
+    // A separate snapshot: asserting against the array under mutation would pass
+    // whether or not the hook copies.
+    const expectedOrder = [validator, second];
+    jest.mocked(getValidators).mockResolvedValue(arrayHeldByTheCoinModuleCache);
+    const currency = freshCurrency();
+
+    const first = renderHook(() => useAleoValidators(currency));
+    await waitFor(() => expect(first.result.current.loading).toBe(false));
+
+    first.result.current.validators.reverse();
+    first.unmount();
+
+    const remount = renderHook(() => useAleoValidators(currency));
+
+    expect(remount.result.current.validators).toEqual(expectedOrder);
+
+    await act(async () => {});
+    expect(remount.result.current.validators).toEqual(expectedOrder);
+  });
+
+  it("surfaces a fetch failure as an empty list when there is no seed to fall back on", async () => {
+    const error = new Error("offline");
+    jest.mocked(getValidators).mockRejectedValue(error);
+    const currency = freshCurrency();
+
+    const { result } = renderHook(() => useAleoValidators(currency));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe(error);
+    expect(result.current.validators).toEqual([]);
+  });
+
+  it("keeps the last-seen list when a later refetch fails, so offline degrades to stale", async () => {
+    const error = new Error("offline");
+    jest.mocked(getValidators).mockResolvedValue([validator]);
+    const currency = freshCurrency();
+
+    const first = renderHook(() => useAleoValidators(currency));
+    await waitFor(() => expect(first.result.current.loading).toBe(false));
+    first.unmount();
+
+    jest.mocked(getValidators).mockRejectedValue(error);
+    const second = renderHook(() => useAleoValidators(currency));
+
+    await waitFor(() => expect(second.result.current.error).toBe(error));
+    expect(second.result.current.validators).toEqual([validator]);
+    expect(second.result.current.loading).toBe(false);
+  });
+
+  it("refetches and never shows the previous network's committee on a currency switch", async () => {
+    const testnetValidator = { ...validator, address: "aleo1testnet" };
+    jest.mocked(getValidators).mockResolvedValue([validator]);
+
+    const { result, rerender } = renderHook(({ currency }) => useAleoValidators(currency), {
+      initialProps: { currency: freshCurrency() },
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    jest.mocked(getValidators).mockResolvedValue([testnetValidator]);
+    rerender({ currency: freshCurrency() });
+
+    expect(result.current.validators).toEqual([]);
+    await waitFor(() => expect(result.current.validators).toEqual([testnetValidator]));
   });
 });

--- a/libs/ledger-live-common/src/families/aleo/react.ts
+++ b/libs/ledger-live-common/src/families/aleo/react.ts
@@ -28,7 +28,14 @@ import {
   patchAccountWithViewKey,
   sumPrivateRecords,
 } from "./utils";
-import type { AleoAccount, AleoTokenAccount, AleoUnspentRecord, SigningStrategy } from "./types";
+import type {
+  AleoAccount,
+  AleoTokenAccount,
+  AleoUnspentRecord,
+  AleoValidator,
+  SigningStrategy,
+} from "./types";
+import { getValidators } from "@ledgerhq/coin-aleo/logic";
 import { aleoPrivateSyncProgress$ } from "./privateSyncProgress";
 import { MANDATORY_SYNC_POLLING_DELAY, PROGRESS_THROTTLE_INTERVAL_MS } from "./constants";
 
@@ -569,3 +576,48 @@ export const useAleoPrivateSync = ({
 
   return { isSyncing, progress, error, start, stop };
 };
+
+const lastSeenValidators: Record<string, AleoValidator[]> = {};
+
+export interface UseAleoValidatorsResult {
+  validators: AleoValidator[];
+  loading: boolean;
+  error: Error | null;
+}
+
+export function useAleoValidators(currency: CryptoCurrency): UseAleoValidatorsResult {
+  const currencyId = currency.id;
+  const [validators, setValidators] = useState<AleoValidator[]>(() => [
+    ...(lastSeenValidators[currencyId] ?? []),
+  ]);
+  const [loading, setLoading] = useState(() => lastSeenValidators[currencyId] === undefined);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const seed = lastSeenValidators[currencyId];
+    setValidators([...(seed ?? [])]);
+    setLoading(seed === undefined);
+    setError(null);
+
+    getValidators(currencyId)
+      .then(next => {
+        if (cancelled) return;
+        lastSeenValidators[currencyId] = next;
+        setValidators([...next]);
+        setLoading(false);
+      })
+      .catch((err: Error) => {
+        if (cancelled) return;
+        setError(err);
+        setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [currencyId]);
+
+  return { validators, loading, error };
+}


### PR DESCRIPTION
### 📝 Description

Adds the Aleo validator committee as a shared, cached data source so the upcoming bond flow has a validator picker to build on. Nothing is wired into the UI yet — this PR only exposes the logic and the hook.

**Coin module (`@ledgerhq/coin-aleo`)**

- Three new node endpoints in `network/api.ts`:
  - `GET /v2/{network}/committee/latest` — the committee (stake, open/closed, commission per validator)
  - `GET /v2/{network}/committee/validator-metadata` — address → display name (partial coverage)
  - `GET /v2/{network}/latest/totalSupply` — a bare scalar, and the only amount in this API denominated in **credits** rather than microcredits
- `logic/getValidators.ts` — fetches the three concurrently, validates each untrusted payload, and returns `AleoValidator[]` ordered for a picker (open validators first, then descending stake). LRU-cached for 5 minutes so a validator that has just closed is not offered for long.
- Only the committee is required. Names and total supply are best-effort: losing either degrades a field instead of failing the list the bond flow depends on.
- `logic/utils.ts` — `estimateGrossRate` / `estimateNetRate`, derived from the delegator's `block_reward * stake / total_stake` share in snarkVM (`synthesizer/src/vm/helpers/rewards.rs`). Handles the 25% validator concentration cap and the 10k-credit delegator minimum, both of which pay **zero**, not a reduced rate.

**live-common**

- `useAleoValidators(currency)` in `families/aleo/react.ts`, shared by Desktop and Mobile so the picker is not built twice.
- Keeps a last-seen committee per currency so a remount paints instantly instead of flashing an empty picker, and a failed refetch degrades to stale rather than to empty.
- Each mount gets its own array copy — `getValidators` is LRU-cached on the promise, so a picker sorting in place would otherwise reorder the list for every other screen.
- Deliberately not `CurrencyBridge.preload`/`hydrate`: that mechanism is deprecated here and Polkadot, the closest staking analogue, has already migrated off it.

**Note for consumers:** `estimatedYearlyRewardsRate` is a **lower bound** — snarkVM's `block_reward_v2` adds a coinbase share and transaction fees on top. Every surface showing it must label it an estimate. `undefined` means "could not be derived"; `0` is a real value meaning "earns nothing". The two are not interchangeable.

**Usage**

```ts
import { useAleoValidators } from "@ledgerhq/live-common/families/aleo/react";

const { validators, loading, error } = useAleoValidators(currency);
// validators: { address, name?, stakeMicrocredits, isOpen, commissionPercent, estimatedYearlyRewardsRate? }[]
```

**Tests**

37 new unit tests covering ordering, name resolution, concurrent fetching, and every degraded-response path (names fetch fails, malformed names payload, supply fetch fails, committee reports no total stake); rate maths checked against values observed on mainnet, plus the concentration cap, delegator minimum, boundary cases and the null-vs-zero distinction; and the hook's seeding, per-mount isolation, stale-on-failure and currency-switch behaviour.

### 🔗 Context

- **JIRA / GitHub issue**: [https://ledgerhq.atlassian.net/browse/LIVE-32275](https://ledgerhq.atlassian.net/browse/LIVE-32275)
