### PR TITLE
fix(pay): wrap action tiles on narrow desktop (LIVE-36467)

### DIFF
--- a/.changeset/tame-pandas-truncate.md
+++ b/.changeset/tame-pandas-truncate.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-pay-balance": minor
+---
+
+Wrap the Pay action tiles onto a second line when the hero column is too narrow, instead of shrinking the buttons and breaking their labels over two lines

--- a/features/flow/pay-balance/src/components/ActionTiles/ActionTilesView.web.tsx
+++ b/features/flow/pay-balance/src/components/ActionTiles/ActionTilesView.web.tsx
@@ -14,7 +14,7 @@ const ICONS: Record<ActionTileId, TileIcon> = {
 
 export function ActionTilesView({ tiles }: ActionTilesViewProps) {
   return (
-    <div className="flex gap-8" data-testid="action-tiles">
+    <div className="flex flex-wrap gap-8" data-testid="action-tiles">
       {tiles.map(tile => (
         <Button
           appearance={tile.appearance}
@@ -23,6 +23,7 @@ export function ActionTilesView({ tiles }: ActionTilesViewProps) {
           onClick={tile.onPress}
           data-testid={`action-tile-${tile.id}`}
           size="sm"
+          className="shrink-0"
         >
           {tile.label}
         </Button>


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

On a narrow desktop Pay tab, the three quick-action buttons (Add stablecoin, Request, New payment) shrink as flex items. Lumen's `Button` then wraps each label onto two lines inside the button (`line-clamp-2`), so "New payment" and "Add stablecoin" stack vertically and the row looks broken.

This PR keeps each button at its natural width (`shrink-0`) and lets the row wrap (`flex-wrap`) onto a second line instead. Labels stay fully readable at every width; there is no icon-only fallback.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36467](https://ledgerhq.atlassian.net/browse/LIVE-36467)

### 🧪 Test coverage

Unit tests in `@features/flow-pay-card-balance` lock `flex-wrap` on the row and `shrink-0` on the buttons. The visual wrap itself is CSS and is not asserted in jsdom.

### 👀 QA

- Pay tab, funded state (action tiles visible)
- Desktop window at a small width with the sidebar **collapsed**
- Same window with the sidebar **open**
- Confirm labels stay on one line inside each button, and the row wraps onto two lines when there is not enough horizontal space
- Confirm Request / New payment / Add stablecoin still open the expected flows


[LIVE-36467]: https://ledgerhq.atlassian.net/browse/LIVE-36467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ