### PR TITLE
chore(perps): assign perps app code to the ptx team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -322,6 +322,10 @@ apps/ledger-live-mobile/src/mvvm/features/Borrow/                               
 apps/ledger-live-mobile/src/mvvm/features/WalletAssets/views/BorrowSection/             @ledgerhq/ptx
 apps/ledger-live-desktop/src/mvvm/features/Borrow/							            @ledgerhq/ptx
 apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/BorrowEntryPoint/       @ledgerhq/ptx
+apps/ledger-live-desktop/src/mvvm/features/Perps/                                       @ledgerhq/ptx
+apps/ledger-live-mobile/src/mvvm/features/Perps/                                        @ledgerhq/ptx
+apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/PerpsEntryPoint/        @ledgerhq/ptx
+apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioPerpsEntryPoint/ @ledgerhq/ptx
 
 # wallet-cli
 apps/wallet-cli/                                                              @ledgerhq/agentic-core


### PR DESCRIPTION
Perps had no CODEOWNERS rule, so it fell through the `src/mvvm/` catch-all to `@ledgerhq/wallet-xp`. Assigns the perps folders and Portfolio entry points to `@ledgerhq/ptx`, same as Swap/Stake/Card/Borrow. Placed at the end of the PTX section because last-match-wins.

Excludes `libs/ledger-live-common/src/wallet-api/Perps/` — line 342 gives that whole tree to @ledgerhq/coin-integration and would override it. (Same reason the existing `wallet-api/Exchange/` rule on line 272 is already dead.)

Verified: all 31 perps files now resolve to `@ledgerhq/ptx` via `.agents/skills/codeownership/resolve-codeowners.js`.

- [ ] @ledgerhq/ptx confirms ownership
- [ ] @ledgerhq/platform approves (owns CODEOWNERS)