### PR TITLE
[LWDM] fix(counter-values): track incomplete valuations (LIVE-36444)

### DIFF
--- a/.changeset/bright-values-completeness-core.md
+++ b/.changeset/bright-values-completeness-core.md
@@ -1,0 +1,10 @@
+---
+"@ledgerhq/types-live": patch
+"@ledgerhq/live-countervalues": patch
+"@ledgerhq/live-countervalues-react": patch
+"@ledgerhq/live-common": patch
+"@ledgerhq/asset-aggregation": patch
+"@ledgerhq/wallet-analytics": patch
+---
+
+Track incomplete countervalues through portfolio, distribution, categorization, and analytics computations.

--- a/libs/asset-aggregation/src/assetAggregation/__tests__/computeAggregatedAccountsData.test.ts
+++ b/libs/asset-aggregation/src/assetAggregation/__tests__/computeAggregatedAccountsData.test.ts
@@ -43,7 +43,7 @@ describe("computeAggregatedAccountsData", () => {
   it("computes countervalue for a main account with no sub-accounts", () => {
     const account = withBalance(BTC_ACCOUNT, new BigNumber(100));
     const map = computeAggregatedAccountsData([account], calculateCountervalue);
-    expect(map.get(account.id)?.countervalue.toString()).toBe("200");
+    expect(map.get(account.id)?.countervalue?.toString()).toBe("200");
     expect(map.get(account.id)?.subAccountsCount).toBe(0);
   });
 
@@ -56,7 +56,7 @@ describe("computeAggregatedAccountsData", () => {
     };
 
     const map = computeAggregatedAccountsData([parent], calculateCountervalue);
-    expect(map.get(parent.id)?.countervalue.toString()).toBe("300");
+    expect(map.get(parent.id)?.countervalue?.toString()).toBe("300");
     expect(map.get(parent.id)?.subAccountsCount).toBe(1);
   });
 
@@ -69,11 +69,11 @@ describe("computeAggregatedAccountsData", () => {
     };
 
     const map = computeAggregatedAccountsData([parent], calculateCountervalue);
-    expect(map.get(parent.id)?.countervalue.toString()).toBe("100");
+    expect(map.get(parent.id)?.countervalue?.toString()).toBe("100");
     expect(map.get(parent.id)?.subAccountsCount).toBe(1);
   });
 
-  it("treats null/undefined countervalues as zero", () => {
+  it("marks an aggregate unavailable when a positive main or sub-account is unpriced", () => {
     calculateCountervalue.mockReturnValueOnce(null).mockReturnValueOnce(undefined);
     const usdc = createFixtureTokenAccount("usdc1", usdcToken);
     const parent: Account = {
@@ -83,6 +83,19 @@ describe("computeAggregatedAccountsData", () => {
     };
 
     const map = computeAggregatedAccountsData([parent], calculateCountervalue);
-    expect(map.get(parent.id)?.countervalue.toString()).toBe("0");
+    expect(map.get(parent.id)?.countervalue).toBeUndefined();
+  });
+
+  it("does not require a countervalue for a zero-balance account", () => {
+    calculateCountervalue.mockReturnValueOnce(undefined).mockReturnValueOnce(new BigNumber(100));
+    const usdc = createFixtureTokenAccount("usdc1", usdcToken);
+    const parent: Account = {
+      ...ETH_ACCOUNT,
+      balance: new BigNumber(0),
+      subAccounts: [{ ...usdc, balance: new BigNumber(50) }],
+    };
+
+    const map = computeAggregatedAccountsData([parent], calculateCountervalue);
+    expect(map.get(parent.id)?.countervalue?.toString()).toBe("100");
   });
 });

--- a/libs/asset-aggregation/src/assetAggregation/computeAggregatedAccountsData.ts
+++ b/libs/asset-aggregation/src/assetAggregation/computeAggregatedAccountsData.ts
@@ -8,7 +8,7 @@ export type CalculateCountervalue = (
 ) => BigNumber | null | undefined;
 
 export type AggregatedAccountEntry = {
-  countervalue: BigNumber;
+  countervalue?: BigNumber;
   subAccountsCount: number;
 };
 
@@ -22,12 +22,17 @@ export function computeAggregatedAccountsData(
     if (account.type !== "Account") continue;
 
     const mainCv = calculateCountervalue(account.currency, account.balance);
-    let countervalue = new BigNumber(mainCv ?? 0);
+    let countervalue =
+      account.balance.isGreaterThan(0) && mainCv == null ? undefined : new BigNumber(mainCv ?? 0);
 
     const subs = account.subAccounts ?? [];
     for (const sub of subs) {
       const subCv = calculateCountervalue(sub.token, sub.balance);
-      countervalue = countervalue.plus(subCv ?? 0);
+      if (sub.balance.isGreaterThan(0) && subCv == null) {
+        countervalue = undefined;
+      } else if (countervalue) {
+        countervalue = countervalue.plus(subCv ?? 0);
+      }
     }
 
     map.set(account.id, { countervalue, subAccountsCount: subs.length });

--- a/libs/asset-aggregation/src/assetCategorization/__tests__/categorizeAssets.test.ts
+++ b/libs/asset-aggregation/src/assetCategorization/__tests__/categorizeAssets.test.ts
@@ -58,9 +58,9 @@ describe("categorizeAssets", () => {
     expect(result.stablecoins).toHaveLength(0);
   });
 
-  it("should default undefined countervalue to 0", () => {
+  it("should preserve an unavailable countervalue", () => {
     const item = [makeDistItem(btc, { distribution: 1, amount: 1e8, countervalue: undefined })];
-    expect(categorizeAssets(item, stablecoinTickers).cryptos[0].value).toBe(0);
+    expect(categorizeAssets(item, stablecoinTickers).cryptos[0].value).toBeUndefined();
   });
 
   it("should preserve accounts for single-chain assets", () => {

--- a/libs/asset-aggregation/src/assetCategorization/categorizeAssets.ts
+++ b/libs/asset-aggregation/src/assetCategorization/categorizeAssets.ts
@@ -14,7 +14,7 @@ export function categorizeAssets(
       currency: item.currency,
       marketId: item.marketId,
       balance: item.amount,
-      value: item.countervalue ?? 0,
+      value: item.countervalue,
       distribution: item.distribution,
       accounts: item.accounts,
     };

--- a/libs/asset-aggregation/src/assetCategorization/types.ts
+++ b/libs/asset-aggregation/src/assetCategorization/types.ts
@@ -6,7 +6,7 @@ export type CategorizedAssetItem = {
   currency: CryptoCurrency | TokenCurrency;
   marketId?: string;
   balance: number;
-  value: number;
+  value: number | undefined;
   distribution: number;
   accounts: AccountLike[];
 };

--- a/libs/asset-aggregation/src/assetDistribution/__tests__/buildAssetDistribution.test.ts
+++ b/libs/asset-aggregation/src/assetDistribution/__tests__/buildAssetDistribution.test.ts
@@ -4,6 +4,7 @@ import type { Account } from "@ledgerhq/types-live";
 import type { CryptoCurrency } from "@domain/entity-currency-crypto";
 import BigNumber from "bignumber.js";
 import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+import { calculate } from "@ledgerhq/live-countervalues/logic";
 
 const mockFindCryptoCurrencyById = jest.fn();
 
@@ -14,6 +15,8 @@ jest.mock("@domain/entity-currency-crypto", () => ({
 jest.mock("@ledgerhq/live-countervalues/logic", () => ({
   calculate: jest.fn((_state, { value }: { value: number }) => value * 2),
 }));
+
+const mockCalculate = jest.mocked(calculate);
 
 function makeCurrency(id: string, name = id, magnitude = 8): CryptoCurrency {
   return {
@@ -47,6 +50,7 @@ describe("buildAssetDistribution", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockCalculate.mockImplementation((_state, { value }) => value * 2);
     mockFindCryptoCurrencyById.mockImplementation((id: string) => {
       if (id === "ethereum") return ethMainnet;
       return undefined;
@@ -179,7 +183,49 @@ describe("buildAssetDistribution", () => {
     const result = distribute([]);
 
     expect(result.isAvailable).toBe(false);
+    expect(result.countervalueComplete).toBe(true);
     expect(result.list).toHaveLength(0);
+  });
+
+  it("marks the whole distribution incomplete when one positive network is unpriced", () => {
+    mockCalculate.mockImplementation((_state, { value, from }) =>
+      from === ethArbitrum ? undefined : value * 2,
+    );
+
+    const result = distribute([
+      makeAccount("eth-1", ethMainnet, 1000),
+      makeAccount("arb-1", ethArbitrum, 500),
+      makeAccount("btc-1", btcCurrency, 2000),
+    ]);
+    const ethereum = result.list.find(item => item.currency.id === "ethereum");
+    const bitcoin = result.list.find(item => item.currency.id === "bitcoin");
+
+    expect(result.isAvailable).toBe(true);
+    expect(result.countervalueComplete).toBe(false);
+    expect(result.sum).toBe(0);
+    expect(result.list.every(item => item.distribution === 0)).toBe(true);
+    expect(ethereum?.countervalue).toBeUndefined();
+    expect(
+      ethereum?.networks?.find(network => network.currency.id === "ethereum")?.countervalue,
+    ).toBe(2000);
+    expect(
+      ethereum?.networks?.find(network => network.currency.id === "arbitrum")?.countervalue,
+    ).toBeUndefined();
+    expect(bitcoin?.countervalue).toBe(4000);
+  });
+
+  it("keeps a zero-balance distribution complete without requiring a rate", () => {
+    mockCalculate.mockReturnValue(undefined);
+
+    const result = distribute([makeAccount("eth-1", ethMainnet, 0)], {
+      showEmptyAccounts: true,
+    });
+
+    expect(result.countervalueComplete).toBe(true);
+    expect(result.sum).toBe(0);
+    expect(result.list[0].countervalue).toBe(0);
+    expect(result.list[0].distribution).toBe(1);
+    expect(mockCalculate).not.toHaveBeenCalled();
   });
 
   it("should sort by countervalue descending", () => {

--- a/libs/asset-aggregation/src/assetDistribution/buildAssetDistribution.ts
+++ b/libs/asset-aggregation/src/assetDistribution/buildAssetDistribution.ts
@@ -86,6 +86,7 @@ function sumNetworkAmountsAtReferenceMagnitude(
 
 const EMPTY_DISTRIBUTION: AssetsDistribution = Object.freeze({
   isAvailable: false,
+  countervalueComplete: true,
   list: [],
   showFirst: 0,
   sum: 0,
@@ -148,7 +149,8 @@ export function buildAssetDistribution(
 
   if (groups.size === 0) return EMPTY_DISTRIBUTION;
 
-  let sum = 0;
+  let calculatedSum = 0;
+  let countervalueComplete = true;
   for (const group of groups.values()) {
     const primaryAssetId = primaryAssets[group.metaCurrencyId];
     const normalizedCurrency = resolveNormalizedCurrency(
@@ -167,26 +169,37 @@ export function buildAssetDistribution(
     const referenceMagnitude = group.currency.units[0]?.magnitude ?? 0;
     group.amount = sumNetworkAmountsAtReferenceMagnitude(group.networks, referenceMagnitude);
 
-    let groupCountervalue = 0;
+    let groupCountervalue: number | undefined = 0;
     for (const network of group.networks.values()) {
       const countervalue =
-        calculate(cvState, { value: network.amount, from: network.currency, to }) ?? 0;
-      network.countervalue = countervalue;
-      groupCountervalue += countervalue;
+        network.amount > 0
+          ? calculate(cvState, { value: network.amount, from: network.currency, to })
+          : 0;
+      network.countervalue = countervalue ?? undefined;
+      if (countervalue == null) {
+        groupCountervalue = undefined;
+        countervalueComplete = false;
+      } else if (groupCountervalue != null) {
+        groupCountervalue += countervalue;
+      }
     }
     group.countervalue = groupCountervalue;
-    sum += groupCountervalue;
+    if (groupCountervalue != null) calculatedSum += groupCountervalue;
   }
 
-  const isAvailable = sum !== 0 || showEmptyAccounts;
-  const uniformDistribution = isAvailable ? 1 / groups.size : 0;
+  const sum = countervalueComplete ? calculatedSum : 0;
+  const isAvailable = true;
+  const uniformDistribution = countervalueComplete ? 1 / groups.size : 0;
 
   const list: DistributionItem[] = Array.from(groups.values())
     .map(group => ({
       currency: group.currency,
       countervalue: group.countervalue,
       amount: group.amount,
-      distribution: computeDistribution(group.countervalue, sum, uniformDistribution),
+      distribution:
+        countervalueComplete && group.countervalue != null
+          ? computeDistribution(group.countervalue, sum, uniformDistribution)
+          : 0,
       accounts: group.accounts,
       metaCurrencyId: group.metaCurrencyId,
       networks: Array.from(group.networks.values()),
@@ -194,8 +207,17 @@ export function buildAssetDistribution(
       slug: toSlug(group.metaCurrencyId),
     }))
     .sort(
-      (a, b) => b.countervalue - a.countervalue || a.currency.name.localeCompare(b.currency.name),
+      (a, b) =>
+        (b.countervalue ?? 0) - (a.countervalue ?? 0) ||
+        a.currency.name.localeCompare(b.currency.name),
     );
 
-  return { isAvailable, list, showFirst: list.length, sum, bySlug: buildSlugIndex(list) };
+  return {
+    isAvailable,
+    countervalueComplete,
+    list,
+    showFirst: list.length,
+    sum,
+    bySlug: buildSlugIndex(list),
+  };
 }

--- a/libs/asset-aggregation/src/assetDistribution/types.ts
+++ b/libs/asset-aggregation/src/assetDistribution/types.ts
@@ -31,7 +31,7 @@ export type MetaGroup = {
   metaCurrencyId: string;
   currency: CryptoCurrency | TokenCurrency;
   accounts: AccountLike[];
-  countervalue: number;
+  countervalue?: number;
   amount: number;
   networks: Map<string, NetworkDistributionDetail>;
   marketId?: string;

--- a/libs/ledger-live-common/src/portfolio/__tests__/useAssetDistribution.test.ts
+++ b/libs/ledger-live-common/src/portfolio/__tests__/useAssetDistribution.test.ts
@@ -47,6 +47,7 @@ const baseOpts = { accounts, to: usd, product: "lld" as const, version: "1.0.0" 
 
 const assetResult: AssetsDistribution = {
   isAvailable: true,
+  countervalueComplete: true,
   list: [
     {
       currency: btc,
@@ -81,7 +82,11 @@ describe("useAssetDistribution", () => {
 
     const { result } = renderHook(() => useAssetDistribution(baseOpts));
 
-    expect(result.current.distribution).toMatchObject({ isAvailable: false, list: [] });
+    expect(result.current.distribution).toMatchObject({
+      isAvailable: false,
+      countervalueComplete: false,
+      list: [],
+    });
     expect(result.current.isLoading).toBe(true);
     expect(mockUseChunkedAssetsData).toHaveBeenCalledWith(
       expect.objectContaining({ product: "lld", version: "1.0.0", skip: false }),

--- a/libs/ledger-live-common/src/portfolio/useAssetDistribution.ts
+++ b/libs/ledger-live-common/src/portfolio/useAssetDistribution.ts
@@ -31,6 +31,7 @@ export type UseAssetDistributionOpts = {
 
 const emptyDistribution: AssetsDistribution = {
   isAvailable: false,
+  countervalueComplete: false,
   list: [],
   showFirst: 0,
   sum: 0,

--- a/libs/live-countervalues-react/src/portfolio.test.tsx
+++ b/libs/live-countervalues-react/src/portfolio.test.tsx
@@ -1,0 +1,81 @@
+import { useEffect } from "react";
+import { act, renderHook } from "@testing-library/react";
+import type { FiatCurrency } from "@ledgerhq/ledger-wallet-framework/types";
+import { getPortfolio } from "@ledgerhq/live-countervalues/portfolio";
+import { usePortfolioThrottled } from "./portfolio";
+
+jest.mock(".", () => {
+  const state = { data: {}, status: {}, cache: {} };
+  return { useCountervaluesState: jest.fn(() => state) };
+});
+
+jest.mock("@ledgerhq/live-hooks/useThrottledFunction", () => ({
+  useThrottledValues: (values: unknown[]) => {
+    const React = jest.requireActual<typeof import("react")>("react");
+    return React.useMemo(() => values, [values[0], values[1]]);
+  },
+}));
+
+jest.mock("@ledgerhq/live-countervalues/portfolio", () => ({
+  ...jest.requireActual("@ledgerhq/live-countervalues/portfolio"),
+  getPortfolio: jest.fn(),
+}));
+
+const usd: FiatCurrency = {
+  type: "FiatCurrency",
+  name: "US Dollar",
+  ticker: "USD",
+  symbol: "$",
+  units: [{ name: "dollar", code: "USD", magnitude: 2, showAllDigits: true, prefixCode: true }],
+};
+
+const eur: FiatCurrency = {
+  type: "FiatCurrency",
+  name: "Euro",
+  ticker: "EUR",
+  symbol: "€",
+  units: [{ name: "euro", code: "EUR", magnitude: 2, showAllDigits: true, prefixCode: true }],
+};
+
+const mockGetPortfolio = jest.mocked(getPortfolio);
+const accounts: never[] = [];
+
+describe("usePortfolioThrottled", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetPortfolio.mockImplementation((_accounts, _range, _state, to) => ({
+      balanceHistory: [{ date: new Date(), value: to === usd ? 100 : 90 }],
+      balanceAvailable: true,
+      countervalueComplete: true,
+      availableAccounts: [],
+      unavailableCurrencies: [],
+      accounts: [],
+      range: "day",
+      histories: [],
+      countervalueReceiveSum: 0,
+      countervalueSendSum: 0,
+      countervalueChange: { value: 0, percentage: 0 },
+    }));
+  });
+
+  it("never exposes the previous fiat portfolio under the new currency", () => {
+    const observed: string[] = [];
+    const { rerender } = renderHook(
+      ({ to }: { to: FiatCurrency }) => {
+        const portfolio = usePortfolioThrottled({ accounts, range: "day", to });
+        const value = portfolio.balanceHistory.at(-1)?.value;
+        useEffect(() => {
+          observed.push(`${to.ticker}:${value}`);
+        }, [to, value]);
+        return portfolio;
+      },
+      { initialProps: { to: usd } },
+    );
+
+    act(() => rerender({ to: eur }));
+
+    expect(observed).toContain("USD:100");
+    expect(observed).toContain("EUR:90");
+    expect(observed).not.toContain("EUR:100");
+  });
+});

--- a/libs/live-countervalues-react/src/portfolio.tsx
+++ b/libs/live-countervalues-react/src/portfolio.tsx
@@ -70,6 +70,9 @@ const lowThrottleDelay = 100;
  * keep an intermediate throttle until some additional data is available
  */
 const intermediateThrottleDelay = 300;
+
+const getCurrencyKey = (currency: Currency): string =>
+  currency.type === "FiatCurrency" ? currency.ticker : currency.id;
 /**
  * Computes the data necessary to plot of a graph of the user's balance.
  * It throttles that expensive computation by throttling the `accounts` and
@@ -110,9 +113,11 @@ export function usePortfolioThrottled({
    * time.
    * */
   const opts = useRef(options);
-  const [portfolio, setPortfolio] = useState(() =>
-    getPortfolio(throttledAccounts, range, throttledCVState, to, opts.current),
-  );
+  const toKey = getCurrencyKey(to);
+  const [computed, setComputed] = useState(() => ({
+    portfolio: getPortfolio(throttledAccounts, range, throttledCVState, to, opts.current),
+    toKey,
+  }));
 
   const ignoreUseEffectFirstCall = useRef(true);
   useEffect(() => {
@@ -123,13 +128,15 @@ export function usePortfolioThrottled({
       return;
     }
     const portfolio = getPortfolio(throttledAccounts, range, throttledCVState, to, opts.current);
-    setPortfolio(portfolio);
+    setComputed({ portfolio, toKey });
     if (portfolio.balanceAvailable) setVariableThrottleDelay(intermediateThrottleDelay);
     if (throttledAccounts.length > 0 && portfolio.availableAccounts.length > 0)
       setVariableThrottleDelay(stableThrottleDelay);
-  }, [throttledAccounts, range, throttledCVState, to, stableThrottleDelay]);
+  }, [throttledAccounts, range, throttledCVState, to, toKey, stableThrottleDelay]);
 
-  return portfolio;
+  if (computed.toKey === toKey) return computed.portfolio;
+
+  return getPortfolio(throttledAccounts, range, throttledCVState, to, opts.current);
 }
 
 export function useCurrencyPortfolio({
@@ -150,6 +157,7 @@ export function useCurrencyPortfolio({
 
 const emptyDistribution: AssetsDistribution = {
   isAvailable: false,
+  countervalueComplete: false,
   list: [],
   showFirst: 0,
   sum: 0,

--- a/libs/live-countervalues/src/__snapshots__/portfolio.test.ts.snap
+++ b/libs/live-countervalues/src/__snapshots__/portfolio.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Portfolio getAssetsDistribution snapshot 1`] = `
 {
+  "countervalueComplete": true,
   "isAvailable": true,
   "list": [
     {
@@ -6392,6 +6393,7 @@ exports[`Portfolio getPortfolio snapshot 1`] = `
     "percentage": 323.64,
     "value": 16182,
   },
+  "countervalueComplete": true,
   "countervalueReceiveSum": 0,
   "countervalueSendSum": 0,
   "histories": [

--- a/libs/live-countervalues/src/portfolio.test.ts
+++ b/libs/live-countervalues/src/portfolio.test.ts
@@ -2,7 +2,7 @@ import "@ledgerhq/ledger-wallet-framework/test-helpers/staticTime";
 
 import { getFiatCurrencyByTicker, getCryptoCurrencyById } from "./tests/currencies";
 import { initialState, loadCountervalues, inferTrackingPairForAccounts } from "./logic";
-import { pairId } from "./helpers";
+import { formatCounterValueHour, pairId } from "./helpers";
 import {
   getPortfolioCount,
   getBalanceHistory,
@@ -115,6 +115,16 @@ describe("Portfolio", () => {
       const cv = getBalanceHistoryWithCountervalue(account, range, count, state, to);
       expect(cv).toMatchSnapshot();
     });
+    it("does not report historical-only data as a current countervalue", async () => {
+      const { state, to } = await loadCV(account);
+      const stateWithoutLatest = withoutLatestRate(state, account, to);
+
+      const cv = getBalanceHistoryWithCountervalue(account, range, count, stateWithoutLatest, to);
+
+      expect(cv.history.some(point => point.countervalue != null)).toBe(true);
+      expect(cv.countervalueAvailable).toBe(false);
+      expect(cv.countervalueChange).toEqual({ value: 0, percentage: null });
+    });
   });
   describe("getPortfolio", () => {
     const account = genAccountBitcoin();
@@ -123,6 +133,7 @@ describe("Portfolio", () => {
       const { state, to } = await loadCV(account);
       const portfolio = getPortfolio([account], range, state, to);
       expect(portfolio.balanceAvailable).toBe(true);
+      expect(portfolio.countervalueComplete).toBe(true);
       expect(portfolio.availableAccounts).toMatchObject([account]);
     });
     test("balanceAvailable should be false and return as unavilableCurrenccies when the latest countervalue does NOT exists", async () => {
@@ -131,6 +142,7 @@ describe("Portfolio", () => {
       const portfolio = getPortfolio([account], range, state, to);
       expect(portfolio.unavailableCurrencies).toMatchObject([getAccountCurrency(account)]);
       expect(portfolio.balanceAvailable).toBe(false);
+      expect(portfolio.countervalueComplete).toBe(false);
     });
     test("balanceAvailable should be true when the only account is empty (no rate to fetch)", () => {
       const to = getFiatCurrencyByTicker("USD");
@@ -146,6 +158,23 @@ describe("Portfolio", () => {
       const state = { ...initialState, data: {} };
       const portfolio = getPortfolio([emptyAccount], range, state, to);
       expect(portfolio.balanceAvailable).toBe(true);
+      expect(portfolio.countervalueComplete).toBe(true);
+    });
+    test("balanceAvailable should be true for a zero balance account with historical operations", () => {
+      const to = getFiatCurrencyByTicker("USD");
+      const zero = account.balance.minus(account.balance);
+      const zeroBalanceAccount: Account = {
+        ...account,
+        balance: zero,
+        spendableBalance: zero,
+        operationsCount: Math.max(account.operationsCount, 1),
+      };
+      const state = { ...initialState, data: {} };
+      const portfolio = getPortfolio([zeroBalanceAccount], range, state, to);
+
+      expect(portfolio.balanceHistory.at(-1)?.value).toBe(0);
+      expect(portfolio.balanceAvailable).toBe(true);
+      expect(portfolio.countervalueComplete).toBe(true);
     });
     test("balanceAvailable should be false when a non-empty account is still unpriced", () => {
       const to = getFiatCurrencyByTicker("USD");
@@ -162,6 +191,57 @@ describe("Portfolio", () => {
       const state = { ...initialState, data: {} };
       const portfolio = getPortfolio([emptyAccount, nonEmptyUnpriced], range, state, to);
       expect(portfolio.balanceAvailable).toBe(false);
+      expect(portfolio.countervalueComplete).toBe(false);
+      expect(portfolio.countervalueChange).toEqual({ value: 0, percentage: null });
+    });
+    it("keeps priced rows but marks a mixed portfolio incomplete", async () => {
+      const ethereum = genAccount("ethereum_1", {
+        currency: getCryptoCurrencyById("ethereum"),
+      });
+      const { state, to } = await loadCV([account, ethereum]);
+      const stateWithoutEthereumLatest = withoutLatestRate(state, ethereum, to);
+
+      const portfolio = getPortfolio([account, ethereum], range, stateWithoutEthereumLatest, to);
+
+      expect(portfolio.availableAccounts).toContain(account);
+      expect(portfolio.availableAccounts).not.toContain(ethereum);
+      expect(portfolio.countervalueComplete).toBe(false);
+      expect(portfolio.countervalueChange).toEqual({ value: 0, percentage: null });
+    });
+    it("does not use historical rates as current availability", async () => {
+      const { state, to } = await loadCV(account);
+      const stateWithoutLatest = withoutLatestRate(state, account, to);
+
+      const portfolio = getPortfolio([account], range, stateWithoutLatest, to);
+
+      expect(
+        stateWithoutLatest.cache[pairId({ from: account.currency, to })]?.map.size,
+      ).toBeGreaterThan(0);
+      expect(portfolio.countervalueComplete).toBe(false);
+      expect(portfolio.balanceAvailable).toBe(false);
+    });
+    it("neutralizes the trend when an intermediate historical rate is missing", () => {
+      const flatAccount = genFlatBalanceAccount();
+      const to = getFiatCurrencyByTicker("USD");
+      const missingIndex = Math.floor(count / 2);
+      const state = stateWithHourlyRates(flatAccount, to, range, missingIndex);
+
+      const portfolio = getPortfolio([flatAccount], range, state, to);
+
+      expect(portfolio.countervalueComplete).toBe(true);
+      expect(portfolio.histories[0][missingIndex].countervalue).toBeUndefined();
+      expect(portfolio.countervalueChange).toEqual({ value: 0, percentage: null });
+    });
+    it("reports a real 0% trend for a flat priced portfolio", () => {
+      const flatAccount = genFlatBalanceAccount();
+      const to = getFiatCurrencyByTicker("USD");
+      const state = stateWithHourlyRates(flatAccount, to, range);
+
+      const portfolio = getPortfolio([flatAccount], range, state, to);
+
+      expect(portfolio.countervalueComplete).toBe(true);
+      expect(portfolio.countervalueChange.value).toBe(0);
+      expect(portfolio.countervalueChange.percentage).toBe(0);
     });
     it("should have history identical to the account history", async () => {
       const account2 = genAccountBitcoin("bitcoin_2");
@@ -224,6 +304,27 @@ describe("Portfolio", () => {
       const portfolio = getCurrencyPortfolio([account], range, state, to);
       expect(portfolio.countervalueAvailable).toBe(false);
     });
+    it("neutralizes the trend when only historical rates remain", async () => {
+      const { state, to } = await loadCV(account);
+      const stateWithoutLatest = withoutLatestRate(state, account, to);
+
+      const portfolio = getCurrencyPortfolio([account], range, stateWithoutLatest, to);
+
+      expect(portfolio.countervalueAvailable).toBe(false);
+      expect(portfolio.countervalueChange).toEqual({ value: 0, percentage: null });
+    });
+    it("neutralizes the trend when an intermediate historical rate is missing", () => {
+      const flatAccount = genFlatBalanceAccount();
+      const to = getFiatCurrencyByTicker("USD");
+      const missingIndex = Math.floor(count / 2);
+      const state = stateWithHourlyRates(flatAccount, to, range, missingIndex);
+
+      const portfolio = getCurrencyPortfolio([flatAccount], range, state, to);
+
+      expect(portfolio.countervalueAvailable).toBe(true);
+      expect(portfolio.histories[0][missingIndex].countervalue).toBeUndefined();
+      expect(portfolio.countervalueChange).toEqual({ value: 0, percentage: null });
+    });
     it("should have history identical to the account history", async () => {
       const account2 = genAccountBitcoin("bitcoin_2");
       const { state, to } = await loadCV(account);
@@ -256,21 +357,6 @@ describe("Portfolio", () => {
     const range: PortfolioRange = "day";
     // Builds an account whose hourly balance history is flat (= current balance) over the range,
     // so getCurrencyPortfolio (historical balance) reduces to the same price-only change.
-    function genFlatBalanceAccount(id = "bitcoin_1"): Account {
-      const account = genAccountBitcoin(id);
-      const balance = account.balance.toNumber();
-      return {
-        ...account,
-        balanceHistoryCache: {
-          ...account.balanceHistoryCache,
-          HOUR: {
-            latestDate: startOfHour(new Date()).getTime(),
-            balances: new Array(8 * 24).fill(balance),
-          },
-        },
-      };
-    }
-
     it("returns a neutral change for an empty accounts list", () => {
       const to = getFiatCurrencyByTicker("USD");
       const state = { ...initialState, data: {} };
@@ -367,14 +453,65 @@ describe("Portfolio", () => {
       const change = getCurrentBalanceCountervalueChange([account], range, state, to);
       expect(change).toEqual({ value: 0, percentage: null });
     });
+
+    it("neutralizes a currency portfolio trend when only the historical start rate is missing", () => {
+      const account = genFlatBalanceAccount();
+      const to = getFiatCurrencyByTicker("USD");
+      const state = stateWithRates({ now: 100, then: undefined });
+      const id = pairId({ from: account.currency, to });
+      const pairCache = state.cache[id];
+      const recentHistoryDate = new Date(Date.now() - 60 * 60 * 1000);
+      const recentHistoryKey = formatCounterValueHour(recentHistoryDate);
+      pairCache.map.set(recentHistoryKey, 90);
+      pairCache.stats.earliest = recentHistoryKey;
+      pairCache.stats.earliestDate = recentHistoryDate;
+
+      const portfolio = getCurrencyPortfolio([account], range, state, to);
+
+      expect(portfolio.countervalueAvailable).toBe(true);
+      expect(portfolio.histories[0][0].countervalue).toBeUndefined();
+      expect(portfolio.histories[0].at(-1)?.countervalue).toBeDefined();
+      expect(portfolio.countervalueChange).toEqual({ value: 0, percentage: null });
+    });
   });
 
   describe("getAssetsDistribution", () => {
+    it("treats a computed empty distribution as complete", () => {
+      const assets = getAssetsDistribution([], initialState, getFiatCurrencyByTicker("USD"));
+
+      expect(assets).toMatchObject({
+        isAvailable: false,
+        countervalueComplete: true,
+        sum: 0,
+        list: [],
+      });
+    });
+
     it("snapshot", async () => {
       const account = genAccountBitcoin();
       const { state, to } = await loadCV(account);
       const assets = getAssetsDistribution([account], state, to);
       expect(assets).toMatchSnapshot();
+    });
+
+    it("keeps individual priced rows but invalidates totals and allocations", async () => {
+      const bitcoin = genAccountBitcoin();
+      const ethereum = genAccount("ethereum_1", {
+        currency: getCryptoCurrencyById("ethereum"),
+      });
+      const { state, to } = await loadCV([bitcoin, ethereum]);
+      const stateWithoutEthereumLatest = withoutLatestRate(state, ethereum, to);
+
+      const assets = getAssetsDistribution([bitcoin, ethereum], stateWithoutEthereumLatest, to);
+      const bitcoinItem = assets.list.find(item => item.currency.id === "bitcoin");
+      const ethereumItem = assets.list.find(item => item.currency.id === "ethereum");
+
+      expect(assets.isAvailable).toBe(true);
+      expect(assets.countervalueComplete).toBe(false);
+      expect(assets.sum).toBe(0);
+      expect(assets.list.every(item => item.distribution === 0)).toBe(true);
+      expect(bitcoinItem?.countervalue).toBeDefined();
+      expect(ethereumItem?.countervalue).toBeUndefined();
     });
 
     it("should include an asset with a countervalue of 0 in the distribution", async () => {
@@ -394,6 +531,7 @@ describe("Portfolio", () => {
       });
 
       expect(assets.isAvailable).toBe(true);
+      expect(assets.countervalueComplete).toBe(true);
       expect(assets.list.length).toBeGreaterThan(0);
 
       const btcEntry = assets.list.find(a => a.currency.id === "bitcoin");
@@ -476,6 +614,54 @@ function genAccountBitcoin(id = "bitcoin_1") {
   });
 }
 
+function genFlatBalanceAccount(id = "bitcoin_1"): Account {
+  const account = genAccountBitcoin(id);
+  const balance = account.balance.toNumber();
+  return {
+    ...account,
+    balanceHistoryCache: {
+      ...account.balanceHistoryCache,
+      HOUR: {
+        latestDate: startOfHour(new Date()).getTime(),
+        balances: new Array(8 * 24).fill(balance),
+      },
+    },
+  };
+}
+
+function stateWithHourlyRates(
+  account: Account,
+  to: ReturnType<typeof getFiatCurrencyByTicker>,
+  range: PortfolioRange,
+  missingIndex?: number,
+) {
+  const dates = getDates(range, getPortfolioCount([account], range));
+  const historicalKeys = dates.slice(0, -1).map(formatCounterValueHour);
+  const map = new Map<string, number>(historicalKeys.map(key => [key, 100]));
+  map.set("latest", 100);
+  if (missingIndex != null) map.delete(formatCounterValueHour(dates[missingIndex]));
+
+  const oldest = historicalKeys[0];
+  const earliest = historicalKeys.at(-1);
+  const id = pairId({ from: account.currency, to });
+
+  return {
+    ...initialState,
+    cache: {
+      [id]: {
+        map,
+        stats: {
+          oldest,
+          earliest,
+          oldestDate: oldest ? new Date(`${oldest}:00:00.000Z`) : null,
+          earliestDate: earliest ? new Date(`${earliest}:00:00.000Z`) : null,
+          earliestStableDate: earliest ? new Date(`${earliest}:00:00.000Z`) : null,
+        },
+      },
+    },
+  };
+}
+
 async function loadCV(a: Account | Account[], cvTicker = "USD") {
   const to = getFiatCurrencyByTicker(cvTicker);
   const accounts = Array.isArray(a) ? a : [a];
@@ -488,5 +674,24 @@ async function loadCV(a: Account | Account[], cvTicker = "USD") {
   return {
     state,
     to,
+  };
+}
+
+function withoutLatestRate(
+  state: Awaited<ReturnType<typeof loadCV>>["state"],
+  account: Account,
+  to: ReturnType<typeof getFiatCurrencyByTicker>,
+) {
+  const id = pairId({ from: account.currency, to });
+  const pairCache = state.cache[id];
+  if (!pairCache) throw new Error(`Missing countervalue cache for ${id}`);
+  const map = new Map(pairCache.map);
+  map.delete("latest");
+  return {
+    ...state,
+    cache: {
+      ...state.cache,
+      [id]: { ...pairCache, map },
+    },
   };
 }

--- a/libs/live-countervalues/src/portfolio.ts
+++ b/libs/live-countervalues/src/portfolio.ts
@@ -4,7 +4,6 @@ import {
   flattenAccounts,
   getAccountCurrency,
   getAccountHistoryBalances,
-  isAccountEmpty,
 } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { getEnv } from "@ledgerhq/live-env";
 import type {
@@ -175,7 +174,6 @@ function getBalanceHistoryWithChanges(
     from: currency,
     to: cvCurrency,
   });
-  let countervalueAvailable = false;
   const history: Array<{
     date: Date;
     value: number;
@@ -185,9 +183,6 @@ function getBalanceHistoryWithChanges(
   for (let i = 0; i < balanceHistory.length; i++) {
     const { date, value } = balanceHistory[i];
     const countervalue = counterValues[i];
-    if (countervalue !== undefined && countervalue !== null) {
-      countervalueAvailable = true;
-    }
     history.push({
       date,
       value,
@@ -198,6 +193,8 @@ function getBalanceHistoryWithChanges(
   function calcChanges(start = 0) {
     const from = history.at(start) ?? { value: 0, countervalue: 0 };
     const to = history.at(-1) ?? { value: 0, countervalue: 0 };
+    const countervalueChangeComplete =
+      (from.value <= 0 || from.countervalue != null) && (to.value <= 0 || to.countervalue != null);
     return {
       countervalueReceiveSum: 0,
       // not available here
@@ -206,19 +203,27 @@ function getBalanceHistoryWithChanges(
         value: to.value - from.value,
         percentage: null,
       },
-      countervalueChange: {
-        value: (to.countervalue || 0) - (from.countervalue || 0),
-        percentage: meaningfulPercentage(
-          (to.countervalue || 0) - (from.countervalue || 0),
-          from.countervalue,
-        ),
-      },
+      countervalueChange: countervalueChangeComplete
+        ? {
+            value: (to.countervalue || 0) - (from.countervalue || 0),
+            percentage: meaningfulPercentage(
+              (to.countervalue || 0) - (from.countervalue || 0),
+              from.countervalue,
+            ),
+          }
+        : { value: 0, percentage: null },
     };
   }
 
   return {
     history,
-    countervalueAvailable,
+    countervalueAvailable:
+      calculate(cvState, {
+        value: account.balance.toNumber(),
+        from: currency,
+        to: cvCurrency,
+        disableRounding: true,
+      }) != null,
     changes: calcChanges,
   };
 }
@@ -228,6 +233,10 @@ export function meaningfulPercentage(
   balanceDivider: number | null | undefined,
   percentageHighThreshold = 100000,
 ): number | null | undefined {
+  if (deltaChange === 0 && balanceDivider != null && balanceDivider !== 0) {
+    return 0;
+  }
+
   if (deltaChange && balanceDivider && balanceDivider !== 0) {
     const percent = deltaChange / balanceDivider;
 
@@ -308,10 +317,30 @@ export function getPortfolio(
       : countervalueReceiveSum
     : firstSignificantHistoryValue;
 
+  const countervalueComplete = accounts.every(account => {
+    if (!account.balance.isGreaterThan(0)) return true;
+    return (
+      calculate(cvState, {
+        value: account.balance.toNumber(),
+        from: getAccountCurrency(account),
+        to: cvCurrency,
+        disableRounding: true,
+      }) != null
+    );
+  });
+  const countervalueChangeComplete =
+    countervalueComplete &&
+    availables.every(({ history }) =>
+      history.every(point => point.value <= 0 || point.countervalue != null),
+    );
+
   return {
     balanceHistory,
     balanceAvailable:
-      accounts.length === 0 || availables.length > 0 || unavailableAccounts.every(isAccountEmpty),
+      accounts.length === 0 ||
+      availables.length > 0 ||
+      unavailableAccounts.every(account => !account.balance.isGreaterThan(0)),
+    countervalueComplete,
     availableAccounts: availables.map(a => a.account),
     unavailableCurrencies: [...new Set(unavailableAccounts.map(a => getAccountCurrency(a)))],
     accounts,
@@ -319,10 +348,12 @@ export function getPortfolio(
     histories,
     countervalueReceiveSum,
     countervalueSendSum,
-    countervalueChange: {
-      percentage: meaningfulPercentage(countervalueChangeValue, balanceDivider),
-      value: countervalueChangeValue,
-    },
+    countervalueChange: countervalueChangeComplete
+      ? {
+          percentage: meaningfulPercentage(countervalueChangeValue, balanceDivider),
+          value: countervalueChangeValue,
+        }
+      : { value: 0, percentage: null },
   };
 }
 
@@ -355,13 +386,20 @@ export function getCurrencyPortfolio(
     value: to.value - from.value,
     percentage: null,
   };
-  const countervalueChange = {
-    value: (to.countervalue || 0) - (from.countervalue || 0),
-    percentage: meaningfulPercentage(
-      (to.countervalue || 0) - (from.countervalue || 0),
-      from.countervalue,
-    ),
-  };
+  const countervalueChangeComplete =
+    countervalueAvailable &&
+    histories.every(history =>
+      history.every(point => point.value <= 0 || point.countervalue != null),
+    );
+  const countervalueChange = countervalueChangeComplete
+    ? {
+        value: (to.countervalue || 0) - (from.countervalue || 0),
+        percentage: meaningfulPercentage(
+          (to.countervalue || 0) - (from.countervalue || 0),
+          from.countervalue,
+        ),
+      }
+    : { value: 0, percentage: null };
   return {
     history,
     countervalueAvailable,
@@ -465,16 +503,20 @@ export function getAssetsDistribution(
   }
 
   const idCountervalues: Record<string, number | undefined> = {};
-  let sum = 0;
+  let calculatedSum = 0;
 
   for (const [id, value] of Object.entries(idBalances)) {
+    if (value <= 0) {
+      idCountervalues[id] = 0;
+      continue;
+    }
     const cv = calculate(cvState, {
       value: Number(value),
       from: idCurrencies[id],
       to: cvCurrency,
     });
-    if (cv) {
-      sum += cv;
+    if (cv != null) {
+      calculatedSum += cv;
       idCountervalues[id] = cv;
     }
   }
@@ -485,27 +527,31 @@ export function getAssetsDistribution(
     return assetsDistributionNotAvailable;
   }
 
-  const isAvailable = sum !== 0 || showEmptyAccounts;
+  const countervalueComplete = idCurrenciesKeys.every(
+    id => idBalances[id] <= 0 || idCountervalues[id] != null,
+  );
+  const sum = countervalueComplete ? calculatedSum : 0;
+  const isAvailable = true;
   const list = idCurrenciesKeys
     .map(id => {
       const currency = idCurrencies[id];
       const amount = idBalances[id];
-      const countervalue = idCountervalues[id] ?? 0;
+      const countervalue = idCountervalues[id];
       const currencyAccounts = currenciesAccounts[id];
       return {
         currency,
         countervalue,
         amount,
-        distribution: isAvailable
+        distribution: countervalueComplete
           ? sum !== 0
-            ? countervalue / sum
+            ? (countervalue ?? 0) / sum
             : 1 / idCurrenciesKeys.length
           : 0,
         accounts: currencyAccounts,
       };
     })
     .sort((a, b) => {
-      const diff = b.countervalue - a.countervalue;
+      const diff = (b.countervalue ?? 0) - (a.countervalue ?? 0);
       return diff === 0 ? a.currency.name.localeCompare(b.currency.name) : diff;
     });
   let i;
@@ -522,6 +568,7 @@ export function getAssetsDistribution(
   const showFirst = Math.max(minShowFirst, i);
   const data = {
     isAvailable,
+    countervalueComplete,
     list,
     showFirst,
     sum,
@@ -530,6 +577,7 @@ export function getAssetsDistribution(
 }
 const assetsDistributionNotAvailable: AssetsDistribution = {
   isAvailable: false,
+  countervalueComplete: true,
   list: [],
   showFirst: 0,
   sum: 0,

--- a/libs/types-live/src/portfolio.ts
+++ b/libs/types-live/src/portfolio.ts
@@ -66,6 +66,7 @@ export type CurrencyPortfolio = {
 export type Portfolio = {
   balanceHistory: BalanceHistory;
   balanceAvailable: boolean;
+  countervalueComplete: boolean;
   availableAccounts: AccountLike[];
   unavailableCurrencies: (CryptoCurrency | TokenCurrency)[];
   accounts: AccountLike[];
@@ -114,8 +115,10 @@ export type DistributionItem = {
  *
  */
 export type AssetsDistribution = {
-  // false if no distribution can be done (sum is zero)
+  // false when no distribution list can be built
   isAvailable: boolean;
+  // false when at least one positive balance has no current countervalue
+  countervalueComplete: boolean;
   // a sorted list of assets with data
   list: DistributionItem[];
   // number of accounts to show first (before the see all)

--- a/libs/wallet-analytics/src/__tests__/resolveAnalyticsValueChange.test.ts
+++ b/libs/wallet-analytics/src/__tests__/resolveAnalyticsValueChange.test.ts
@@ -9,6 +9,7 @@ const defaultPortfolio = {
   balanceHistory: [],
   countervalueChange: { percentage: 0.12, value: 120 },
   balanceAvailable: true,
+  countervalueComplete: true,
   availableAccounts: [],
   unavailableCurrencies: [],
   accounts: [],
@@ -38,6 +39,19 @@ describe("resolveAnalyticsValueChange", () => {
       accounts: [],
       currentBalance: 1000,
       portfolio: defaultPortfolio,
+      cvState: mockCvState,
+      counterValue: mockCounterValue,
+    });
+
+    expect(result).toEqual({ value: 0, percentage: null });
+  });
+
+  it("returns a neutral change when the current valuation is incomplete", () => {
+    const result = resolveAnalyticsValueChange({
+      selectedTimeRange: "week",
+      accounts: [],
+      currentBalance: 1000,
+      portfolio: { ...defaultPortfolio, countervalueComplete: false },
       cvState: mockCvState,
       counterValue: mockCounterValue,
     });

--- a/libs/wallet-analytics/src/resolveAnalyticsValueChange.ts
+++ b/libs/wallet-analytics/src/resolveAnalyticsValueChange.ts
@@ -18,6 +18,10 @@ export function resolveAnalyticsValueChange({
   readonly cvState: CounterValuesState;
   readonly counterValue: Currency;
 }): ValueChange {
+  if (!portfolio.countervalueComplete) {
+    return { value: 0, percentage: null };
+  }
+
   if (selectedTimeRange === "all") {
     return computeAllTimeValueChangeFromFirstReceive(
       accounts,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Added coverage for incomplete current and historical countervalues, real zero balances, asset aggregation, distribution completeness, fiat changes, and analytics trend neutrality.
- [x] **Impact of the changes:**
      Simulate a spot response omitting one positive-balance asset. The priced rows remain available, while portfolio totals, allocations, and trends report incomplete data until a complete response arrives.

### 📝 Description

The current countervalue model could represent a missing rate as a usable zero or a partial total. This makes client views unable to distinguish a real zero balance from an incomplete valuation.

This PR adds explicit completeness through portfolio, distributions, categorization, cross-network aggregation, and analytics. Historical points no longer stand in for a missing current rate, and a true zero balance remains a complete `$0` result.

This PR is stacked on #21149, which ensures incomplete spot responses remove the corresponding current rate.

### ❓ Context

- **JIRA issue**: [LIVE-36444](https://ledgerhq.atlassian.net/browse/LIVE-36444)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-36444]: https://ledgerhq.atlassian.net/browse/LIVE-36444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ