### PR TITLE
[LWD] fix(counter-values): show unavailable portfolio values (LIVE-36444)

### DIFF
--- a/.changeset/calm-desktop-portfolio-values.md
+++ b/.changeset/calm-desktop-portfolio-values.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Show unavailable portfolio and analytics values when current countervalues are incomplete.

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/__fixtures__/allocationFixtures.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/__fixtures__/allocationFixtures.ts
@@ -15,6 +15,7 @@ export function makeAllocationViewProps(
 ): AllocationViewProps {
   return {
     items: allocationItems,
+    countervalueComplete: true,
     hasMore: false,
     showMore: jest.fn(),
     onItemClick: jest.fn(),

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/__integrations__/Analytics.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/__integrations__/Analytics.test.tsx
@@ -30,7 +30,11 @@ const originalIntersectionObserver = window.IntersectionObserver;
 beforeEach(() => {
   window.IntersectionObserver = jest.fn(cb => {
     intersectionCallback = cb;
-    return { observe: mockObserve, disconnect: mockDisconnect, unobserve: jest.fn() };
+    return {
+      observe: mockObserve,
+      disconnect: mockDisconnect,
+      unobserve: jest.fn(),
+    };
   }) as unknown as typeof IntersectionObserver;
 });
 
@@ -117,6 +121,22 @@ describe("Analytics", () => {
     expect(screen.getByText("ETH")).toBeVisible();
   });
 
+  it("should hide the allocation section when countervalues are incomplete", () => {
+    mockedUseAnalyticsViewModel.mockReturnValue({
+      ...defaultViewModel,
+      shouldDisplayAssetSection: true,
+    });
+    mockedUseAllocationData.mockReturnValue({
+      ...populatedAllocation,
+      countervalueComplete: false,
+    });
+
+    render(<Analytics />);
+
+    expect(screen.queryByText("Asset allocation")).not.toBeInTheDocument();
+    expect(screen.queryByText("Bitcoin")).not.toBeInTheDocument();
+  });
+
   it("should render column headers in allocation table", () => {
     mockedUseAnalyticsViewModel.mockReturnValue({
       ...defaultViewModel,
@@ -150,7 +170,10 @@ describe("Analytics", () => {
       ...defaultViewModel,
       shouldDisplayAssetSection: true,
     });
-    mockedUseAllocationData.mockReturnValue({ ...populatedAllocation, hasMore: true });
+    mockedUseAllocationData.mockReturnValue({
+      ...populatedAllocation,
+      hasMore: true,
+    });
 
     render(<Analytics />);
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/Allocation/AllocationView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/Allocation/AllocationView.tsx
@@ -4,6 +4,8 @@ import { AllocationTable } from "./AllocationTable";
 import type { AllocationViewProps } from "../../types";
 
 export const AllocationView = (props: AllocationViewProps) => {
+  if (!props.countervalueComplete) return null;
+
   return (
     <div className="flex flex-col gap-12">
       <AllocationSubheader />

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/ChartSectionHeaderView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/ChartSectionHeaderView.tsx
@@ -12,6 +12,8 @@ export function ChartSectionHeaderView({ viewModel }: ChartSectionHeaderViewProp
     totalBalanceLabel,
     balance,
     balanceAvailable,
+    countervalueComplete,
+    countervalueTrendComplete,
     isLoading,
     balanceFormatter,
     discreet,
@@ -30,26 +32,40 @@ export function ChartSectionHeaderView({ viewModel }: ChartSectionHeaderViewProp
       </span>
       <div className="flex items-end gap-12">
         {balanceAvailable ? (
-          <AmountDisplay
-            value={balance}
-            formatter={balanceFormatter}
-            hidden={discreet}
-            loading={isLoading}
-            animate={!isScrubbing}
-            data-testid="analytics-balance-amount"
-          />
+          countervalueComplete ? (
+            <AmountDisplay
+              value={balance}
+              formatter={balanceFormatter}
+              hidden={discreet}
+              loading={isLoading}
+              animate={!isScrubbing}
+              data-testid="analytics-balance-amount"
+            />
+          ) : (
+            <span
+              className="heading-1-semi-bold text-base"
+              data-testid="analytics-balance-unavailable"
+            >
+              -
+            </span>
+          )
         ) : (
           <Skeleton className="h-48 w-256 rounded-md" data-testid="analytics-balance-skeleton" />
         )}
-        {balanceAvailable && (
-          <ChartSectionHeaderVariation
-            percentageValue={percentageValue}
-            discreet={discreet}
-            variationText={variationText}
-            timeLabel={scrubDateLabel ?? rangeLabel}
-            isScrubbing={isScrubbing}
-          />
-        )}
+        {balanceAvailable &&
+          (countervalueTrendComplete ? (
+            <ChartSectionHeaderVariation
+              percentageValue={percentageValue}
+              discreet={discreet}
+              variationText={variationText}
+              timeLabel={scrubDateLabel ?? rangeLabel}
+              isScrubbing={isScrubbing}
+            />
+          ) : (
+            <span className="body-2 text-muted" data-testid="analytics-variation-unavailable">
+              -
+            </span>
+          ))}
       </div>
     </div>
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/__tests__/ChartSectionHeaderView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/__tests__/ChartSectionHeaderView.test.tsx
@@ -8,6 +8,8 @@ const baseViewModel: ChartSectionHeaderViewModel = {
   totalBalanceLabel: "Total balance",
   balance: mockPortfolioBalanceInfo.totalBalance,
   balanceAvailable: true,
+  countervalueComplete: true,
+  countervalueTrendComplete: true,
   isLoading: false,
   balanceFormatter: value => ({
     currencyText: "$",
@@ -40,5 +42,32 @@ describe("ChartSectionHeaderView", () => {
 
     expect(screen.getByTestId("analytics-balance-skeleton")).toBeVisible();
     expect(screen.queryByTestId("analytics-balance-trend")).not.toBeInTheDocument();
+  });
+
+  it("shows unavailable values instead of a skeleton when countervalues are incomplete", () => {
+    render(
+      <ChartSectionHeaderView
+        viewModel={{
+          ...baseViewModel,
+          countervalueComplete: false,
+          countervalueTrendComplete: false,
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("analytics-balance-unavailable")).toHaveTextContent("-");
+    expect(screen.getByTestId("analytics-variation-unavailable")).toHaveTextContent("-");
+    expect(screen.queryByTestId("analytics-balance-skeleton")).not.toBeInTheDocument();
+  });
+
+  it("keeps the current balance visible when only the trend is incomplete", () => {
+    render(
+      <ChartSectionHeaderView
+        viewModel={{ ...baseViewModel, countervalueTrendComplete: false }}
+      />,
+    );
+
+    expect(screen.getByTestId("analytics-balance-amount")).toBeVisible();
+    expect(screen.getByTestId("analytics-variation-unavailable")).toHaveTextContent("-");
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/__tests__/useChartSectionHeaderViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/__tests__/useChartSectionHeaderViewModel.test.ts
@@ -14,6 +14,7 @@ describe("useChartSectionHeaderViewModel", () => {
             ...mockPortfolioBalanceInfo,
             valueChange: { percentage: 0.1234, value: 567 },
           },
+          countervalueTrendComplete: true,
           chartPrices,
           isLoading: false,
         }),
@@ -25,6 +26,7 @@ describe("useChartSectionHeaderViewModel", () => {
     expect(result.current.rangeLabel).toBe("1 week");
     expect(result.current.scrubDateLabel).toBeUndefined();
     expect(result.current.percentageValue).toBe(12.34);
+    expect(result.current.countervalueTrendComplete).toBe(true);
   });
 
   it("formats the variation from a smallest-atom countervalue without a x100 shift", () => {
@@ -35,6 +37,7 @@ describe("useChartSectionHeaderViewModel", () => {
             ...mockPortfolioBalanceInfo,
             valueChange: { percentage: 0.1, value: 1300 },
           },
+          countervalueTrendComplete: true,
           chartPrices,
           isLoading: false,
         }),
@@ -49,6 +52,7 @@ describe("useChartSectionHeaderViewModel", () => {
       () =>
         useChartSectionHeaderViewModel({
           balanceInfo: mockPortfolioBalanceInfo,
+          countervalueTrendComplete: true,
           scrubSelection: {
             balance: 1000,
             timestamp: portfolioWithHistory.balanceHistory[0].date.getTime(),
@@ -72,6 +76,7 @@ describe("useChartSectionHeaderViewModel", () => {
       () =>
         useChartSectionHeaderViewModel({
           balanceInfo: mockPortfolioBalanceInfo,
+          countervalueTrendComplete: true,
           chartPrices,
           isLoading: true,
         }),
@@ -79,5 +84,24 @@ describe("useChartSectionHeaderViewModel", () => {
     );
 
     expect(result.current.isLoading).toBe(true);
+  });
+
+  it("marks only the trend incomplete when its historical percentage is unavailable", () => {
+    const { result } = renderHook(
+      () =>
+        useChartSectionHeaderViewModel({
+          balanceInfo: {
+            ...mockPortfolioBalanceInfo,
+            valueChange: { percentage: null, value: 0 },
+          },
+          countervalueTrendComplete: false,
+          chartPrices,
+          isLoading: false,
+        }),
+      { initialState: chartSectionHeaderInitialState },
+    );
+
+    expect(result.current.countervalueComplete).toBe(true);
+    expect(result.current.countervalueTrendComplete).toBe(false);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/types.ts
@@ -4,6 +4,8 @@ export type ChartSectionHeaderViewModel = Readonly<{
   totalBalanceLabel: string;
   balance: number;
   balanceAvailable: boolean;
+  countervalueComplete: boolean;
+  countervalueTrendComplete: boolean;
   isLoading: boolean;
   balanceFormatter: (value: number) => FormattedValue;
   discreet: boolean;

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/useChartSectionHeaderViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionHeader/useChartSectionHeaderViewModel.ts
@@ -21,6 +21,7 @@ import type { ChartSectionHeaderViewModel } from "./types";
 
 export function useChartSectionHeaderViewModel({
   balanceInfo,
+  countervalueTrendComplete,
   scrubSelection,
   chartPrices,
   isLoading,
@@ -79,6 +80,8 @@ export function useChartSectionHeaderViewModel({
     totalBalanceLabel: t("assetDetails.totalBalance"),
     balance,
     balanceAvailable: balanceInfo.isAvailable,
+    countervalueComplete: balanceInfo.countervalueComplete,
+    countervalueTrendComplete,
     isLoading: isLoading && !isScrubbing,
     balanceFormatter,
     discreet,

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/ChartSectionView.tsx
@@ -22,7 +22,7 @@ export function ChartSectionView({ viewModel }: ChartSectionViewProps) {
   return (
     <div className="flex flex-col gap-24" data-testid="analytics-chart-section">
       <ChartSectionHeader {...header} />
-      <ChartSectionChart {...chart} />
+      {chart ? <ChartSectionChart {...chart} /> : null}
     </div>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/__tests__/ChartSection.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/__tests__/ChartSection.test.tsx
@@ -47,4 +47,36 @@ describe("ChartSection", () => {
     expect(screen.getByTestId("analytics-balance-skeleton")).toBeVisible();
     expect(screen.queryByTestId("analytics-balance-trend")).not.toBeInTheDocument();
   });
+
+  it("hides the chart and shows unavailable values when countervalues are incomplete", () => {
+    render(
+      <ChartSection
+        balanceInfo={mockPortfolioBalanceInfo}
+        portfolio={{ ...portfolioWithHistory, countervalueComplete: false }}
+        isLoading={false}
+      />,
+      { initialState: chartSectionInitialState },
+    );
+
+    expect(screen.getByTestId("analytics-balance-unavailable")).toBeVisible();
+    expect(screen.queryByTestId("line-chart-range-1w")).not.toBeInTheDocument();
+  });
+
+  it("keeps the balance visible but hides an incomplete historical trend", () => {
+    render(
+      <ChartSection
+        balanceInfo={mockPortfolioBalanceInfo}
+        portfolio={{
+          ...portfolioWithHistory,
+          countervalueChange: { percentage: null, value: 0 },
+        }}
+        isLoading={false}
+      />,
+      { initialState: chartSectionInitialState },
+    );
+
+    expect(screen.getByTestId("analytics-balance-amount")).toBeVisible();
+    expect(screen.getByTestId("analytics-variation-unavailable")).toHaveTextContent("-");
+    expect(screen.queryByTestId("line-chart-range-1w")).not.toBeInTheDocument();
+  });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/__tests__/useChartSectionViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/__tests__/useChartSectionViewModel.test.ts
@@ -29,11 +29,11 @@ describe("useChartSectionViewModel", () => {
   it("builds chart series from portfolio balance history and maps the selected range", () => {
     const { result } = renderChartSectionViewModel();
 
-    expect(result.current.chart.series[0].data).toEqual([1000, 1200]);
-    expect(result.current.chart.selectedRange).toBe("1w");
-    expect(result.current.header.balanceInfo).toBe(mockPortfolioBalanceInfo);
+    expect(result.current.chart?.series[0].data).toEqual([1000, 1200]);
+    expect(result.current.chart?.selectedRange).toBe("1w");
+    expect(result.current.header.balanceInfo).toEqual(mockPortfolioBalanceInfo);
     expect(result.current.header.scrubSelection).toBeUndefined();
-    expect(result.current.chart.showScrubberTooltip).toBe(false);
+    expect(result.current.chart?.showScrubberTooltip).toBe(false);
   });
 
   it("uses balanceInfo availability for the chart loading state", () => {
@@ -47,18 +47,20 @@ describe("useChartSectionViewModel", () => {
       { initialState: chartSectionInitialState },
     );
 
-    expect(result.current.chart.isLoading).toBe(true);
+    expect(result.current.chart?.isLoading).toBe(true);
   });
 
   it("dispatches the portfolio range and tracks when the chart range changes", () => {
     const { result, store } = renderChartSectionViewModel();
 
     act(() => {
-      result.current.chart.onRangeChange("1m");
+      result.current.chart?.onRangeChange("1m");
     });
 
     expect(store.getState().settings.selectedTimeRange).toBe("month");
-    expect(mockTrack).toHaveBeenCalledWith("timeframe_clicked", { timeframe: "month" });
+    expect(mockTrack).toHaveBeenCalledWith("timeframe_clicked", {
+      timeframe: "month",
+    });
   });
 
   it("masks the chart tooltip value when discreet mode is enabled", () => {
@@ -71,19 +73,22 @@ describe("useChartSectionViewModel", () => {
         }),
       {
         initialState: {
-          settings: { ...chartSectionInitialState.settings, discreetMode: true },
+          settings: {
+            ...chartSectionInitialState.settings,
+            discreetMode: true,
+          },
         },
       },
     );
 
-    expect(result.current.chart.formatValue?.(1000)).toBe("$***");
+    expect(result.current.chart?.formatValue?.(1000)).toBe("$***");
   });
 
   it("updates scrub selection when scrubbing the chart", () => {
     const { result } = renderChartSectionViewModel();
 
     act(() => {
-      result.current.chart.onScrubberPositionChange?.(0);
+      result.current.chart?.onScrubberPositionChange?.(0);
     });
     expect(result.current.header.scrubSelection).toEqual({
       balance: 1000,
@@ -91,7 +96,7 @@ describe("useChartSectionViewModel", () => {
     });
 
     act(() => {
-      result.current.chart.onScrubberPositionChange?.(undefined);
+      result.current.chart?.onScrubberPositionChange?.(undefined);
     });
     expect(result.current.header.scrubSelection).toBeUndefined();
   });
@@ -102,9 +107,71 @@ describe("useChartSectionViewModel", () => {
     const chartBeforeScrub = result.current.chart;
 
     act(() => {
-      result.current.chart.onScrubberPositionChange?.(0);
+      result.current.chart?.onScrubberPositionChange?.(0);
     });
 
     expect(result.current.chart).toBe(chartBeforeScrub);
+  });
+
+  it("clears a scrub selection across an incomplete then recovered trend", () => {
+    const { result, rerender } = renderHook(
+      ({ portfolio }) =>
+        useChartSectionViewModel({
+          balanceInfo: mockPortfolioBalanceInfo,
+          portfolio,
+          isLoading: false,
+        }),
+      {
+        initialProps: { portfolio: portfolioWithHistory },
+        initialState: chartSectionInitialState,
+      },
+    );
+
+    act(() => result.current.chart?.onScrubberPositionChange?.(0));
+    expect(result.current.header.scrubSelection).toBeDefined();
+
+    rerender({
+      portfolio: {
+        ...portfolioWithHistory,
+        countervalueChange: { value: 0, percentage: null },
+      },
+    });
+    expect(result.current.header.scrubSelection).toBeUndefined();
+
+    rerender({ portfolio: portfolioWithHistory });
+    expect(result.current.header.scrubSelection).toBeUndefined();
+  });
+
+  it("does not expose a chart after a settled incomplete countervalue calculation", () => {
+    const { result } = renderHook(
+      () =>
+        useChartSectionViewModel({
+          balanceInfo: mockPortfolioBalanceInfo,
+          portfolio: { ...portfolioWithHistory, countervalueComplete: false },
+          isLoading: false,
+        }),
+      { initialState: chartSectionInitialState },
+    );
+
+    expect(result.current.chart).toBeUndefined();
+    expect(result.current.header.balanceInfo.countervalueComplete).toBe(false);
+  });
+
+  it("keeps the current balance complete but hides a chart with incomplete history", () => {
+    const { result } = renderHook(
+      () =>
+        useChartSectionViewModel({
+          balanceInfo: mockPortfolioBalanceInfo,
+          portfolio: {
+            ...portfolioWithHistory,
+            countervalueChange: { percentage: null, value: 0 },
+          },
+          isLoading: false,
+        }),
+      { initialState: chartSectionInitialState },
+    );
+
+    expect(result.current.chart).toBeUndefined();
+    expect(result.current.header.balanceInfo.countervalueComplete).toBe(true);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/types.ts
@@ -5,6 +5,7 @@ export type ScrubSelection = Readonly<{ balance: number; timestamp: number }>;
 
 export type ChartSectionHeaderInput = Readonly<{
   balanceInfo: PortfolioBalanceInfo;
+  countervalueTrendComplete: boolean;
   scrubSelection?: ScrubSelection;
   chartPrices: readonly number[];
   isLoading: boolean;
@@ -12,5 +13,5 @@ export type ChartSectionHeaderInput = Readonly<{
 
 export type ChartSectionViewModelResult = Readonly<{
   header: ChartSectionHeaderInput;
-  chart: LineChartProps;
+  chart?: LineChartProps;
 }>;

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/useChartSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/ChartSection/useChartSectionViewModel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import type { Portfolio } from "@ledgerhq/types-live";
@@ -53,6 +53,18 @@ export function useChartSectionViewModel({
   const selectedRange = portfolioRangeToLineChartRange(selectedTimeRange);
   const fiatUnit = counterValue.units[0];
   const [scrubSelection, setScrubSelection] = useState<ScrubSelection | undefined>(undefined);
+  const countervalueComplete = balanceInfo.countervalueComplete && portfolio.countervalueComplete;
+  const countervalueTrendComplete =
+    countervalueComplete && portfolio.countervalueChange.percentage !== null;
+  const effectiveScrubSelection = countervalueTrendComplete ? scrubSelection : undefined;
+
+  useEffect(() => {
+    if (!countervalueTrendComplete) setScrubSelection(undefined);
+  }, [countervalueTrendComplete]);
+  const displayBalanceInfo = useMemo(
+    () => ({ ...balanceInfo, countervalueComplete }),
+    [balanceInfo, countervalueComplete],
+  );
 
   const { prices, timestamps } = useMemo(() => {
     const history = portfolio.balanceHistory;
@@ -63,15 +75,18 @@ export function useChartSectionViewModel({
   }, [portfolio.balanceHistory]);
 
   const series = useMemo<LineChartSeries[]>(
-    () => [
-      {
-        id: "analytics-portfolio-balance",
-        data: prices,
-        label: t("dashboard.header"),
-        stroke: "",
-      },
-    ],
-    [prices, t],
+    () =>
+      countervalueTrendComplete
+        ? [
+            {
+              id: "analytics-portfolio-balance",
+              data: prices,
+              label: t("dashboard.header"),
+              stroke: "",
+            },
+          ]
+        : [],
+    [countervalueTrendComplete, prices, t],
   );
 
   const rangePercentageValue =
@@ -121,8 +136,10 @@ export function useChartSectionViewModel({
     [dispatch, selectedTimeRange],
   );
 
-  const chart = useMemo(
-    (): LineChartProps => ({
+  const chart = useMemo((): LineChartProps | undefined => {
+    if (balanceInfo.isAvailable && !countervalueTrendComplete) return undefined;
+
+    return {
       series,
       selectedRange,
       onRangeChange,
@@ -138,25 +155,26 @@ export function useChartSectionViewModel({
       yAxis,
       points,
       ranges: ANALYTICS_CHART_RANGES,
-    }),
-    [
-      series,
-      selectedRange,
-      onRangeChange,
-      rangePercentageValue,
-      balanceInfo.isAvailable,
-      formatValue,
-      onScrubberPositionChange,
-      xAxis,
-      yAxis,
-      points,
-    ],
-  );
+    };
+  }, [
+    series,
+    selectedRange,
+    onRangeChange,
+    rangePercentageValue,
+    balanceInfo.isAvailable,
+    countervalueTrendComplete,
+    formatValue,
+    onScrubberPositionChange,
+    xAxis,
+    yAxis,
+    points,
+  ]);
 
   return {
     header: {
-      balanceInfo,
-      scrubSelection,
+      balanceInfo: displayBalanceInfo,
+      countervalueTrendComplete,
+      scrubSelection: effectiveScrubSelection,
       chartPrices: prices,
       isLoading,
     },

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/PnL/PnLSection.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/components/PnL/PnLSection.tsx
@@ -3,10 +3,14 @@ import { PnLSection as SharedPnLSection } from "LLD/features/PnL/components/PnLS
 import { PnlSubHeader } from "../PnlSubHeader";
 import { usePortfolioPnlViewModel } from "./usePortfolioPnlViewModel";
 
-export function PnLSection() {
+export function PnLSection({
+  countervalueComplete = true,
+}: {
+  readonly countervalueComplete?: boolean;
+}) {
   const viewModel = usePortfolioPnlViewModel();
 
-  if (!viewModel.shouldDisplayPnl) return null;
+  if (!countervalueComplete || !viewModel.shouldDisplayPnl) return null;
 
   return (
     <div className="flex flex-col gap-12">

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/hooks/__tests__/useAllocationData.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/hooks/__tests__/useAllocationData.test.ts
@@ -29,6 +29,7 @@ function makeDistribution(
 ): AssetsDistribution {
   return {
     isAvailable: true,
+    countervalueComplete: true,
     list: items.map(i => ({
       currency: i.currency,
       amount: i.amount,
@@ -47,9 +48,24 @@ describe("useAllocationData", () => {
     mockedUseNavigate.mockReturnValue(mockNavigate);
     mockUseDistribution.mockReturnValue(
       makeDistribution([
-        { currency: bitcoin, amount: 100000, distribution: 0.6, countervalue: 60000 },
-        { currency: ethereum, amount: 50000, distribution: 0.3, countervalue: 30000 },
-        { currency: solana, amount: 10000, distribution: 0.1, countervalue: 10000 },
+        {
+          currency: bitcoin,
+          amount: 100000,
+          distribution: 0.6,
+          countervalue: 60000,
+        },
+        {
+          currency: ethereum,
+          amount: 50000,
+          distribution: 0.3,
+          countervalue: 30000,
+        },
+        {
+          currency: solana,
+          amount: 10000,
+          distribution: 0.1,
+          countervalue: 10000,
+        },
       ]),
     );
   });
@@ -70,7 +86,12 @@ describe("useAllocationData", () => {
   it("should floor distribution percentage to two decimal places", () => {
     mockUseDistribution.mockReturnValue(
       makeDistribution([
-        { currency: bitcoin, amount: 100000, distribution: 0.33339, countervalue: 33339 },
+        {
+          currency: bitcoin,
+          amount: 100000,
+          distribution: 0.33339,
+          countervalue: 33339,
+        },
       ]),
     );
 
@@ -84,6 +105,7 @@ describe("useAllocationData", () => {
   it("should default to 0 when distribution is undefined", () => {
     mockUseDistribution.mockReturnValue({
       isAvailable: true,
+      countervalueComplete: true,
       list: [
         {
           currency: bitcoin,
@@ -115,6 +137,34 @@ describe("useAllocationData", () => {
     expect(result.current.items.find(i => i.currency.id === "ethereum")).toBeUndefined();
   });
 
+  it("should expose an incomplete distribution without treating it as loading", () => {
+    mockUseDistribution.mockReturnValue({
+      ...makeDistribution([
+        {
+          currency: bitcoin,
+          amount: 100000,
+          distribution: 0,
+          countervalue: 60000,
+        },
+        {
+          currency: solana,
+          amount: 10000,
+          distribution: 0,
+          countervalue: undefined,
+        },
+      ]),
+      countervalueComplete: false,
+      sum: 0,
+    });
+
+    const { result } = renderHook(() => useAllocationData(), {
+      initialState: { settings: { ...INITIAL_STATE } },
+    });
+
+    expect(result.current.countervalueComplete).toBe(false);
+    expect(result.current.items).toHaveLength(2);
+  });
+
   it("should pass hideEmptyTokenAccount setting to useDistribution", () => {
     renderHook(() => useAllocationData(), {
       initialState: {
@@ -122,14 +172,20 @@ describe("useAllocationData", () => {
       },
     });
 
-    expect(mockUseDistribution).toHaveBeenCalledWith({ hideEmptyTokenAccount: true });
+    expect(mockUseDistribution).toHaveBeenCalledWith({
+      hideEmptyTokenAccount: true,
+    });
   });
 
   it("should show at most 6 items initially and expose hasMore when there are more", () => {
     const currencies = [bitcoin, ethereum, solana, bitcoin, ethereum, solana, bitcoin, ethereum];
     mockUseDistribution.mockReturnValue(
       makeDistribution(
-        currencies.map((c, i) => ({ currency: c, amount: 1000 * (i + 1), distribution: 0.1 })),
+        currencies.map((c, i) => ({
+          currency: c,
+          amount: 1000 * (i + 1),
+          distribution: 0.1,
+        })),
       ),
     );
 
@@ -145,7 +201,11 @@ describe("useAllocationData", () => {
     const currencies = [bitcoin, ethereum, solana, bitcoin, ethereum, solana, bitcoin, ethereum];
     mockUseDistribution.mockReturnValue(
       makeDistribution(
-        currencies.map((c, i) => ({ currency: c, amount: 1000 * (i + 1), distribution: 0.1 })),
+        currencies.map((c, i) => ({
+          currency: c,
+          amount: 1000 * (i + 1),
+          distribution: 0.1,
+        })),
       ),
     );
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/hooks/useAllocationData.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/hooks/useAllocationData.ts
@@ -52,5 +52,11 @@ export function useAllocationData(): AllocationViewProps {
     [navigate],
   );
 
-  return { items, hasMore, showMore, onItemClick };
+  return {
+    items,
+    countervalueComplete: distribution.countervalueComplete,
+    hasMore,
+    showMore,
+    onItemClick,
+  };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/index.tsx
@@ -52,7 +52,7 @@ function AnalyticsView({ viewModel }: { readonly viewModel: AnalyticsViewModel }
         )}
       </div>
 
-      <PnLSection />
+      <PnLSection countervalueComplete={balanceInfo.countervalueComplete} />
 
       {shouldDisplayAssetSection && <AllocationSection />}
     </div>

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/types.ts
@@ -10,6 +10,7 @@ export type AllocationTableItem = {
 
 export type AllocationViewProps = {
   readonly items: AllocationTableItem[];
+  readonly countervalueComplete: boolean;
   readonly hasMore: boolean;
   readonly showMore: () => void;
   readonly onItemClick: (item: AllocationTableItem) => void;

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
@@ -143,6 +143,7 @@ const createPortfolioMock = (countervalueChange: {
 }): PortfolioType => ({
   balanceHistory: [{ date: new Date(), value: 100000 }],
   balanceAvailable: true,
+  countervalueComplete: true,
   availableAccounts: [],
   unavailableCurrencies: [],
   accounts: [],
@@ -234,6 +235,12 @@ describe("PortfolioView", () => {
     });
 
     it("should render BalanceView when user has accounts but no funds", () => {
+      mockUsePortfolioThrottled.mockReturnValue({
+        ...defaultPortfolioMock,
+        countervalueComplete: true,
+        balanceHistory: [{ date: new Date(), value: 0 }],
+      });
+
       render(<PortfolioView {...defaultProps} />, {
         initialState: {
           accounts: [EMPTY_BTC_ACCOUNT],
@@ -242,6 +249,8 @@ describe("PortfolioView", () => {
       });
 
       expect(screen.queryByTestId("portfolio-balance")).toBeVisible();
+      expect(screen.getByTestId("portfolio-total-balance")).toBeVisible();
+      expect(screen.queryByTestId("portfolio-unavailable-balance")).not.toBeInTheDocument();
     });
 
     it("should render NoDeviceView when no device has been onboarded", () => {
@@ -357,9 +366,45 @@ describe("PortfolioView", () => {
       expect(screen.getByTestId("portfolio-placeholder-balance")).toBeVisible();
       expect(screen.queryByTestId("portfolio-trend")).toBeNull();
     });
+
+    it("should display unavailable values after an incomplete countervalue calculation", () => {
+      mockUsePortfolioThrottled.mockReturnValue({
+        ...defaultPortfolioMock,
+        countervalueComplete: false,
+        balanceHistory: [{ date: new Date(), value: 0 }],
+        countervalueChange: { value: 0, percentage: null },
+      });
+
+      render(<PortfolioView {...defaultProps} />, {
+        initialState: {
+          accounts: [BTC_ACCOUNT],
+          settings: AFTER_ONBOARDING_STATE,
+        },
+      });
+
+      expect(screen.getByTestId("portfolio-unavailable-balance")).toHaveTextContent("-");
+      expect(screen.getByTestId("portfolio-unavailable-trend")).toHaveTextContent("-");
+      expect(screen.queryByTestId("portfolio-placeholder-balance")).not.toBeInTheDocument();
+    });
   });
 
   describe("Trend", () => {
+    it("keeps the current balance visible when the historical trend is unavailable", () => {
+      mockUsePortfolioThrottled.mockReturnValue(
+        createPortfolioMock({ percentage: null, value: 0 }),
+      );
+
+      render(<PortfolioView {...defaultProps} />, {
+        initialState: {
+          accounts: [BTC_ACCOUNT],
+          settings: AFTER_ONBOARDING_STATE,
+        },
+      });
+
+      expect(screen.getByTestId("portfolio-total-balance")).toBeVisible();
+      expect(screen.getByTestId("portfolio-unavailable-trend")).toHaveTextContent("-");
+    });
+
     it("should render Trend with positive percentage and display separator with Today label", () => {
       mockUsePortfolioThrottled.mockReturnValue(
         createPortfolioMock({ percentage: 0.0542, value: 5000 }),

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/BalanceView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/BalanceView.tsx
@@ -9,6 +9,7 @@ const showPlaceholder = (balanceAvailable: boolean) => !balanceAvailable;
 export const BalanceView = ({
   balance,
   balanceAvailable,
+  countervalueComplete,
   formatter,
   discreet,
   valueChange,
@@ -17,6 +18,9 @@ export const BalanceView = ({
   isLoading,
   theme,
 }: BalanceViewProps) => {
+  const countervalueTrendComplete =
+    countervalueComplete && valueChange.percentage !== null;
+
   return (
     <button
       type="button"
@@ -35,6 +39,13 @@ export const BalanceView = ({
       >
         {showPlaceholder(balanceAvailable) ? (
           <Skeleton data-testid="portfolio-placeholder-balance" className="h-48 w-256 rounded-md" />
+        ) : !countervalueComplete ? (
+          <span
+            className="heading-1-semi-bold text-base"
+            data-testid="portfolio-unavailable-balance"
+          >
+            -
+          </span>
         ) : (
           <AmountDisplay
             value={balance}
@@ -45,7 +56,14 @@ export const BalanceView = ({
             data-testid="portfolio-total-balance"
           />
         )}
-        {balanceAvailable && <Trend valueChange={valueChange} />}
+        {balanceAvailable &&
+          (countervalueTrendComplete ? (
+            <Trend valueChange={valueChange} />
+          ) : (
+            <span className="body-2 text-muted" data-testid="portfolio-unavailable-trend">
+              -
+            </span>
+          ))}
       </span>
     </button>
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/Balance/types.ts
@@ -4,6 +4,7 @@ import type { FormattedValue } from "@ledgerhq/lumen-ui-react";
 export interface BalanceViewProps {
   readonly balance: number;
   readonly balanceAvailable: boolean;
+  readonly countervalueComplete: boolean;
   readonly formatter: (value: number) => FormattedValue;
   readonly discreet: boolean;
   readonly valueChange: ValueChange;

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBalanceViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/hooks/useBalanceViewModel.ts
@@ -31,8 +31,15 @@ export const useBalanceViewModel = (
   const theme = useSelector(themeSelector);
   const { hasAccount } = useAccountStatus();
 
-  const { counterValue, displayedBalance, balanceAvailable, isLoading, isColdStart, valueChange } =
-    usePortfolioBalanceDisplayState(options);
+  const {
+    counterValue,
+    displayedBalance,
+    balanceAvailable,
+    countervalueComplete,
+    isLoading,
+    isColdStart,
+    valueChange,
+  } = usePortfolioBalanceDisplayState(options);
 
   const unit = counterValue.units[0];
 
@@ -67,6 +74,7 @@ export const useBalanceViewModel = (
   return {
     balance: displayedBalance,
     balanceAvailable,
+    countervalueComplete,
     formatter,
     discreet,
     valueChange,

--- a/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/fixtures.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/fixtures.ts
@@ -30,12 +30,21 @@ export const mockCounterValue = {
   type: "FiatCurrency" as const,
   ticker: "USD",
   name: "US Dollar",
-  units: [{ name: "US Dollar", code: "$", magnitude: 2, showAllDigits: true, prefixCode: true }],
+  units: [
+    {
+      name: "US Dollar",
+      code: "$",
+      magnitude: 2,
+      showAllDigits: true,
+      prefixCode: true,
+    },
+  ],
 };
 
 export const defaultPortfolio: Portfolio = {
   balanceHistory: [],
   balanceAvailable: true,
+  countervalueComplete: true,
   availableAccounts: [],
   unavailableCurrencies: [],
   accounts: [],
@@ -49,6 +58,7 @@ export const defaultPortfolio: Portfolio = {
 export const mockPortfolioBalanceInfo = {
   totalBalance: 9000,
   isAvailable: true,
+  countervalueComplete: true,
   valueChange: { percentage: 12.34, value: 567 },
 };
 

--- a/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/usePortfolioBalanceDisplayState.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/usePortfolioBalanceDisplayState.test.ts
@@ -35,7 +35,9 @@ describe("usePortfolioBalanceDisplayState", () => {
   it("should request the Portfolio V4 day range by default", () => {
     renderHook(() => usePortfolioBalanceDisplayState(), { initialState });
 
-    expect(mockUsePortfolioBalance).toHaveBeenCalledWith({ legacyRange: false });
+    expect(mockUsePortfolioBalance).toHaveBeenCalledWith({
+      legacyRange: false,
+    });
   });
 
   it("should expose the display balance and value change as balanceInfo", () => {
@@ -44,20 +46,53 @@ describe("usePortfolioBalanceDisplayState", () => {
         portfolio: {
           ...defaultPortfolio,
           balanceHistory: [
-            { date: new Date("2026-05-21"), value: mockPortfolioBalanceInfo.totalBalance },
+            {
+              date: new Date("2026-05-21"),
+              value: mockPortfolioBalanceInfo.totalBalance,
+            },
           ],
           countervalueChange: mockPortfolioBalanceInfo.valueChange,
         },
       }),
     );
 
-    const { result } = renderHook(() => usePortfolioBalanceDisplayState(), { initialState });
+    const { result } = renderHook(() => usePortfolioBalanceDisplayState(), {
+      initialState,
+    });
 
     expect(result.current.balanceInfo).toEqual(mockPortfolioBalanceInfo);
   });
 
+  it("should expose a settled incomplete countervalue separately from loading availability", () => {
+    mockUsePortfolioBalance.mockReturnValue(
+      makePortfolioBalanceReturn({
+        portfolio: {
+          ...defaultPortfolio,
+          balanceAvailable: true,
+          countervalueComplete: false,
+          balanceHistory: [{ date: new Date("2026-05-21"), value: 0 }],
+        },
+      }),
+    );
+
+    const { result } = renderHook(() => usePortfolioBalanceDisplayState(), {
+      initialState,
+    });
+
+    expect(result.current.balanceAvailable).toBe(true);
+    expect(result.current.countervalueComplete).toBe(false);
+    expect(result.current.balanceInfo).toEqual(
+      expect.objectContaining({
+        isAvailable: true,
+        countervalueComplete: false,
+      }),
+    );
+  });
+
   it("should pass legacyRange through when explicitly requested", () => {
-    renderHook(() => usePortfolioBalanceDisplayState({ legacyRange: true }), { initialState });
+    renderHook(() => usePortfolioBalanceDisplayState({ legacyRange: true }), {
+      initialState,
+    });
 
     expect(mockUsePortfolioBalance).toHaveBeenCalledWith({ legacyRange: true });
   });

--- a/apps/ledger-live-desktop/src/mvvm/hooks/usePortfolioBalanceDisplayState.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/usePortfolioBalanceDisplayState.ts
@@ -12,6 +12,7 @@ export interface UsePortfolioBalanceDisplayStateOptions {
 export interface PortfolioBalanceInfo {
   readonly totalBalance: number;
   readonly isAvailable: boolean;
+  readonly countervalueComplete: boolean;
   readonly valueChange: ValueChange;
 }
 
@@ -20,6 +21,7 @@ export interface PortfolioBalanceDisplayState {
   readonly counterValue: Currency;
   readonly displayedBalance: number;
   readonly balanceAvailable: boolean;
+  readonly countervalueComplete: boolean;
   readonly isLoading: boolean;
   readonly isColdStart: boolean;
   readonly isCvPending: boolean;
@@ -52,13 +54,15 @@ export function usePortfolioBalanceDisplayState(
   });
 
   const valueChange = portfolio.countervalueChange;
+  const countervalueComplete = portfolio.countervalueComplete;
   const balanceInfo = useMemo(
     () => ({
       totalBalance: displayedBalance,
       isAvailable: balanceAvailable,
+      countervalueComplete,
       valueChange,
     }),
-    [displayedBalance, balanceAvailable, valueChange],
+    [displayedBalance, balanceAvailable, countervalueComplete, valueChange],
   );
 
   return useMemo(
@@ -67,6 +71,7 @@ export function usePortfolioBalanceDisplayState(
       counterValue,
       displayedBalance,
       balanceAvailable,
+      countervalueComplete,
       isLoading,
       isColdStart,
       isCvPending,
@@ -79,6 +84,7 @@ export function usePortfolioBalanceDisplayState(
       counterValue,
       displayedBalance,
       balanceAvailable,
+      countervalueComplete,
       isLoading,
       isColdStart,
       isCvPending,

--- a/apps/ledger-live-desktop/src/renderer/components/BalanceInfos/index.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/BalanceInfos/index.test.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { mockCounterValue } from "LLD/hooks/__tests__/fixtures";
+import { BalanceDiff, BalanceTotal } from "./index";
+
+const unit = mockCounterValue.units[0];
+
+describe("BalanceInfos", () => {
+  it("should show an unavailable total instead of zero after an incomplete calculation", () => {
+    render(<BalanceTotal unit={unit} totalBalance={0} isAvailable countervalueComplete={false} />);
+
+    expect(screen.getByTestId("total-balance-unavailable")).toHaveTextContent("-");
+    expect(screen.queryByTestId("total-balance")).not.toBeInTheDocument();
+  });
+
+  it("should preserve a true zero total when countervalues are complete", () => {
+    render(<BalanceTotal unit={unit} totalBalance={0} isAvailable countervalueComplete />);
+
+    expect(screen.getByTestId("total-balance")).toBeVisible();
+    expect(screen.queryByTestId("total-balance-unavailable")).not.toBeInTheDocument();
+  });
+
+  it("should show an unavailable trend after an incomplete calculation", () => {
+    render(
+      <BalanceDiff
+        unit={unit}
+        totalBalance={0}
+        isAvailable
+        countervalueComplete={false}
+        valueChange={{ value: 0, percentage: null }}
+      />,
+    );
+
+    expect(screen.getByTestId("balance-diff-unavailable")).toHaveTextContent("-");
+    expect(screen.queryByTestId("balance-diff")).not.toBeInTheDocument();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/components/BalanceInfos/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/BalanceInfos/index.tsx
@@ -24,11 +24,13 @@ type BalanceSinceProps = {
   valueChange: ValueChange;
   totalBalance: number;
   isAvailable: boolean;
+  countervalueComplete?: boolean;
 };
 type BalanceTotalProps = {
   children?: React.ReactNode;
   unit?: Unit;
   isAvailable: boolean;
+  countervalueComplete?: boolean;
   totalBalance: number;
   showCryptoEvenIfNotAvailable?: boolean;
   account?: AccountLike;
@@ -41,8 +43,23 @@ type Props = {
   unit: Unit;
   counterValueId?: string;
 } & BalanceSinceProps;
-export function BalanceDiff({ valueChange, unit, isAvailable, ...boxProps }: Props) {
+export function BalanceDiff({
+  valueChange,
+  unit,
+  isAvailable,
+  countervalueComplete = true,
+  ...boxProps
+}: Props) {
   if (!isAvailable) return null;
+  if (!countervalueComplete) {
+    return (
+      <Box horizontal {...boxProps}>
+        <Text color="neutral.c100" data-testid="balance-diff-unavailable">
+          -
+        </Text>
+      </Box>
+    );
+  }
   return (
     <Box horizontal {...boxProps}>
       <Box
@@ -87,6 +104,7 @@ export function BalanceTotal({
   unit,
   totalBalance,
   isAvailable,
+  countervalueComplete = true,
   showCryptoEvenIfNotAvailable,
   children = null,
   withTransactionsPendingConfirmationWarning,
@@ -100,6 +118,10 @@ export function BalanceTotal({
         <Box horizontal>
           {!isAvailable && !showCryptoEvenIfNotAvailable ? (
             <PlaceholderLine width={150} />
+          ) : !countervalueComplete ? (
+            <span className="heading-1-semi-bold text-base" data-testid="total-balance-unavailable">
+              -
+            </span>
           ) : (
             <FormattedVal
               inline
@@ -126,6 +148,7 @@ export default function BalanceInfos({
   totalBalance,
   valueChange,
   isAvailable,
+  countervalueComplete = true,
   unit,
   counterValueId,
 }: Props) {
@@ -193,6 +216,7 @@ export default function BalanceInfos({
           withTransactionsPendingConfirmationWarning
           unit={unit}
           isAvailable={isAvailable}
+          countervalueComplete={countervalueComplete}
           totalBalance={totalBalance}
         />
 
@@ -223,6 +247,7 @@ export default function BalanceInfos({
         valueChange={valueChange}
         unit={unit}
         isAvailable={isAvailable}
+        countervalueComplete={countervalueComplete && valueChange.percentage !== null}
       />
     </Box>
   );

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/AssetDistribution/Row.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/AssetDistribution/Row.test.tsx
@@ -61,6 +61,16 @@ describe("AssetDistribution Row", () => {
     expect(screen.getByText("45.67%")).toBeVisible();
   });
 
+  it("should hide partial allocation when the distribution is incomplete", () => {
+    render(
+      <Row item={makeItem({ distribution: 0.4567 })} isVisible distributionAvailable={false} />,
+    );
+
+    expect(screen.getByText("-")).toBeVisible();
+    expect(screen.queryByText("45.67%")).not.toBeInTheDocument();
+    expect(screen.getByTestId("asset-countervalue")).toBeVisible();
+  });
+
   it("should render the currency name", () => {
     render(<Row item={makeItem()} isVisible={false} />);
 

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/AssetDistribution/Row.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/AssetDistribution/Row.tsx
@@ -21,6 +21,7 @@ import { DistributionItem } from "@ledgerhq/types-live";
 type Props = {
   item: DistributionItem;
   isVisible: boolean;
+  distributionAvailable?: boolean;
 };
 
 const Wrapper = styled.div`
@@ -118,7 +119,11 @@ const Value = styled.div`
 
   ${valueResponsiveStyles}
 `;
-const Row = ({ item: { currency, amount, distribution }, isVisible }: Props) => {
+const Row = ({
+  item: { currency, amount, distribution },
+  isVisible,
+  distributionAvailable = true,
+}: Props) => {
   const theme = useTheme();
   const navigate = useNavigate();
   const locale = useSelector(localeSelector);
@@ -148,12 +153,14 @@ const Row = ({ item: { currency, amount, distribution }, isVisible }: Props) => 
       </PriceSection>
       <Distribution>
         <Text ff="Inter" color="neutral.c100" fontSize={3}>
-          {`${percentageWording}%`}
+          {distributionAvailable ? `${percentageWording}%` : "-"}
         </Text>
-        <Bar
-          progress={!getEnv("PLAYWRIGHT_RUN") && isVisible ? percentage : 0}
-          progressColor={color}
-        />
+        {distributionAvailable ? (
+          <Bar
+            progress={!getEnv("PLAYWRIGHT_RUN") && isVisible ? percentage : 0}
+            progressColor={color}
+          />
+        ) : null}
       </Distribution>
       <Amount>
         <Ellipsis>

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/AssetDistribution/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/AssetDistribution/index.tsx
@@ -73,7 +73,12 @@ export default function AssetDistribution() {
         <Header />
         <div ref={cardRef}>
           {subList.map(item => (
-            <Row key={item.currency.id} item={item} isVisible={isVisible} />
+            <Row
+              key={item.currency.id}
+              item={item}
+              isVisible={isVisible}
+              distributionAvailable={distribution.countervalueComplete}
+            />
           ))}
         </div>
         {!almostAll && (

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/GlobalSummary.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/GlobalSummary.test.tsx
@@ -26,11 +26,12 @@ jest.mock("~/renderer/components/Chart", () => ({
 
 jest.mock("~/renderer/components/BalanceInfos", () => ({
   __esModule: true,
-  default: jest.fn(({ totalBalance, isAvailable, valueChange }) => (
+  default: jest.fn(({ totalBalance, isAvailable, countervalueComplete, valueChange }) => (
     <div
       data-testid="balance-infos"
       data-total-balance={totalBalance}
       data-is-available={String(isAvailable)}
+      data-countervalue-complete={String(countervalueComplete)}
       data-value-change={valueChange.value}
       data-percentage={valueChange.percentage}
     />
@@ -93,5 +94,29 @@ describe("PortfolioBalanceSummary", () => {
     expect(screen.getByTestId("balance-infos")).toHaveAttribute("data-total-balance", "200");
     expect(screen.getByTestId("balance-infos")).toHaveAttribute("data-value-change", "2");
     expect(screen.getByTestId("balance-infos")).toHaveAttribute("data-percentage", "1");
+  });
+
+  it("should hide the chart and expose a settled incomplete valuation", () => {
+    mockUsePortfolio.mockReturnValue({
+      ...defaultPortfolio,
+      balanceAvailable: true,
+      countervalueComplete: false,
+      balanceHistory: [{ date: new Date("2026-05-21"), value: 0 }],
+    });
+
+    render(
+      <PortfolioBalanceSummary
+        counterValue={mockCounterValue}
+        chartColor="#000"
+        range="month"
+        isWallet40
+      />,
+    );
+
+    expect(screen.getByTestId("balance-infos")).toHaveAttribute(
+      "data-countervalue-complete",
+      "false",
+    );
+    expect(screen.queryByTestId("chart")).not.toBeInTheDocument();
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/GlobalSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/GlobalSummary.tsx
@@ -57,12 +57,14 @@ export default function PortfolioBalanceSummary({
       balanceInfo ?? {
         totalBalance: portfolio.balanceHistory[portfolio.balanceHistory.length - 1]?.value ?? 0,
         isAvailable: portfolio.balanceAvailable,
+        countervalueComplete: portfolio.countervalueComplete,
         valueChange: portfolio.countervalueChange,
       },
     [
       balanceInfo,
       portfolio.balanceHistory,
       portfolio.balanceAvailable,
+      portfolio.countervalueComplete,
       portfolio.countervalueChange,
     ],
   );
@@ -74,6 +76,7 @@ export default function PortfolioBalanceSummary({
           counterValueId={counterValue.type !== "FiatCurrency" ? counterValue.id : undefined}
           unit={counterValue.units[0]}
           isAvailable={displayBalanceInfo.isAvailable}
+          countervalueComplete={displayBalanceInfo.countervalueComplete}
           valueChange={displayBalanceInfo.valueChange}
           totalBalance={displayBalanceInfo.totalBalance}
         />
@@ -89,7 +92,11 @@ export default function PortfolioBalanceSummary({
           overflow: "visible",
         }}
       >
-        {portfolio.balanceAvailable ? (
+        {displayBalanceInfo.isAvailable &&
+        displayBalanceInfo.countervalueComplete &&
+        portfolio.balanceAvailable &&
+        portfolio.countervalueComplete &&
+        portfolio.countervalueChange.percentage !== null ? (
           <Chart
             magnitude={counterValue.units[0].magnitude}
             color={chartColor}
@@ -102,13 +109,13 @@ export default function PortfolioBalanceSummary({
             suggestedMin={suggestedMin}
             screenName={GraphTrackingScreenName.Portfolio}
           />
-        ) : (
+        ) : !displayBalanceInfo.isAvailable || !portfolio.balanceAvailable ? (
           <PlaceholderChart
             magnitude={counterValue.units[0].magnitude}
             data={portfolio.balanceHistory}
             tickXScale={range}
           />
-        )}
+        ) : null}
       </Box>
     </>
   );


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Added integration and ViewModel coverage for Desktop portfolio totals, allocations, charts, analytics, and cached balance display states.
- [x] **Impact of the changes:**
      When one positive-balance asset has no current rate, Desktop portfolio totals, charts, PnL, and allocations display an unavailable state rather than a partial value. Real empty portfolios continue to display `$0`.

### 📝 Description

Desktop Portfolio and Analytics could display partial fiat totals when a current countervalue was missing. This is misleading because it looks like a complete portfolio valuation.

This PR consumes the shared completeness contract and shows an unavailable state for incomplete totals, allocations, charts, and PnL while preserving valid crypto balances and genuine zero values.

This PR is stacked on the countervalue completeness core PR.

| Before                        | After                         |
|-------------------------------|-------------------------------|
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA issue**: [LIVE-36444](https://ledgerhq.atlassian.net/browse/LIVE-36444)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-36444]: https://ledgerhq.atlassian.net/browse/LIVE-36444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ