### PR TITLE
[LWD] fix(counter-values): show unavailable asset values (LIVE-36444)

### DIFF
--- a/.changeset/clear-desktop-asset-values.md
+++ b/.changeset/clear-desktop-asset-values.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Show unavailable asset, account, and address values when current countervalues are missing.

--- a/apps/ledger-live-desktop/src/mvvm/components/Cells/CounterValueCell/__tests__/useCounterValueCellViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/Cells/CounterValueCell/__tests__/useCounterValueCellViewModel.test.ts
@@ -91,6 +91,21 @@ describe("useCounterValueCellViewModel", () => {
     expect(mockedFormatCurrencyUnit).not.toHaveBeenCalled();
   });
 
+  it("formats a real zero even when no rate is available", () => {
+    mockedUseCalculate.mockReturnValue(undefined);
+
+    const { result } = renderHook(() => useCounterValueCellViewModel(mockCurrency, 0), {
+      initialState,
+    });
+
+    expect(mockedFormatCurrencyUnit).toHaveBeenCalledWith(
+      expect.anything(),
+      new BigNumber(0),
+      expect.objectContaining({ showCode: true }),
+    );
+    expect(result.current.formattedCounterValue).toBe("$50,000.00");
+  });
+
   it("should return '-' when counterValue is null", () => {
     mockedUseCalculate.mockReturnValue(null);
 

--- a/apps/ledger-live-desktop/src/mvvm/components/Cells/CounterValueCell/useCounterValueCellViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/Cells/CounterValueCell/useCounterValueCellViewModel.ts
@@ -27,14 +27,15 @@ export function useCounterValueCellViewModel(
     disableRounding: true,
     date: options?.date,
   });
+  const resolvedCounterValue = numericValue === 0 ? 0 : counterValue;
 
-  if (typeof counterValue !== "number") {
+  if (typeof resolvedCounterValue !== "number") {
     return { formattedCounterValue: "-" };
   }
 
   const formattedCounterValue = formatCurrencyUnit(
     counterValueCurrency.units[0],
-    new BigNumber(counterValue),
+    new BigNumber(resolvedCounterValue),
     { showCode: true, alwaysShowSign: options?.alwaysShowSign, locale, discreet },
   );
 

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/__integrations__/AssetDetail.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/__integrations__/AssetDetail.integration.test.tsx
@@ -283,6 +283,26 @@ describe("AssetDetail integration", () => {
       },
     );
 
+    it("shows an unavailable portfolio value without hiding market data", async () => {
+      mockMarket.withData(MarketMockedResponse.bitcoinDetail);
+      const account = genAccount("asset-detail-missing-countervalue", { currency: btc });
+      const item = buildDistributionItem({
+        accounts: [account],
+        amount: 100_000_000,
+        countervalue: undefined,
+      });
+      setupRoute("bitcoin", { bySlug: { bitcoin: item }, list: [item] });
+
+      renderWithMockedCounterValuesProvider(<AssetDetail />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("asset-detail-total-balance")).toBeVisible();
+        expect(screen.getByTestId("asset-detail-fiat-balance")).toHaveTextContent("-");
+        expectMarketView();
+      });
+      await waitForMarketPriceSectionShowsQuote();
+    });
+
     it("hides the staking section when the asset is not stakeable", async () => {
       mockMarket.withData(MarketMockedResponse.bitcoinDetail);
       setupRoute("bitcoin", OWNED_ASSETS[0].buildDistribution());

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/PnL/__tests__/index.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/PnL/__tests__/index.test.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { buildDistributionItem } from "tests/utils/distributionTestUtils";
+import { PnLSection } from "../index";
+
+jest.mock("../PnLSection", () => ({
+  PnLSection: () => <div data-testid="asset-detail-pnl-content" />,
+}));
+
+describe("PnLSection", () => {
+  it("hides PnL when a positive asset has no current countervalue", () => {
+    const distributionItem = buildDistributionItem({
+      amount: 100_000_000,
+      countervalue: undefined,
+    });
+
+    render(<PnLSection distributionItem={distributionItem} isLoading={false} />);
+
+    expect(screen.queryByTestId("asset-detail-pnl-content")).not.toBeInTheDocument();
+  });
+
+  it("keeps a real zero valuation available", () => {
+    const distributionItem = buildDistributionItem({ amount: 0, countervalue: 0 });
+
+    render(<PnLSection distributionItem={distributionItem} isLoading={false} />);
+
+    expect(screen.getByTestId("asset-detail-pnl-content")).toBeVisible();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/PnL/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/PnL/index.tsx
@@ -19,7 +19,12 @@ export function PnLSection({ distributionItem, isLoading }: PnLSectionProps) {
     );
   }
 
-  if (!distributionItem) return null;
+  if (
+    !distributionItem ||
+    (distributionItem.amount > 0 && distributionItem.countervalue == null)
+  ) {
+    return null;
+  }
 
   return <PnLSectionComponent distributionItem={distributionItem} />;
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/__tests__/useStakingSectionViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/__tests__/useStakingSectionViewModel.test.ts
@@ -171,6 +171,31 @@ describe("useStakingSectionViewModel", () => {
     }
   });
 
+  it("shows unavailable fiat balances when an earn deposit exists without a countervalue", () => {
+    mockGetCanStakeCurrency.mockReturnValue(true);
+    const account = genAccount("staking-btc-missing-countervalue", {
+      currency: btc,
+    });
+    account.balance = new BigNumber(10);
+    account.spendableBalance = new BigNumber(0);
+    const item = buildDistributionItem({
+      currency: btc,
+      accounts: [account],
+      amount: 10,
+      countervalue: undefined,
+    });
+
+    const { result } = renderHook(() => useStakingSectionViewModel(item), {
+      initialState: defaultSettingsState,
+    });
+
+    expect(result.current.state).toEqual({
+      type: "staked",
+      formattedAvailable: "-",
+      formattedDeposit: "-",
+    });
+  });
+
   it("masks staked balances when discreet mode is enabled", () => {
     mockGetCanStakeCurrency.mockReturnValue(true);
     const account = genAccount("staking-btc-discreet", { currency: btc });
@@ -214,7 +239,7 @@ describe("useStakingSectionViewModel", () => {
       new BigNumber(10),
       new BigNumber(6),
     );
-    expect(earnDepositFiat.toNumber()).toBe(60_000);
+    expect(earnDepositFiat?.toNumber()).toBe(60_000);
 
     const { result } = renderHook(() => useStakingSectionViewModel(item), {
       initialState: defaultSettingsState,

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/useStakingSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/StakingSection/useStakingSectionViewModel.ts
@@ -64,14 +64,20 @@ export function useStakingSectionViewModel(distributionItem: DistributionItem) {
       );
       return {
         type: "staked",
-        formattedAvailable: formatFiatBalanceForDisplay(fiatUnit, availableFiat, {
-          locale,
-          discreet,
-        }),
-        formattedDeposit: formatFiatBalanceForDisplay(fiatUnit, earnDepositFiat, {
-          locale,
-          discreet,
-        }),
+        formattedAvailable:
+          availableFiat == null
+            ? "-"
+            : formatFiatBalanceForDisplay(fiatUnit, availableFiat, {
+                locale,
+                discreet,
+              }),
+        formattedDeposit:
+          earnDepositFiat == null
+            ? "-"
+            : formatFiatBalanceForDisplay(fiatUnit, earnDepositFiat, {
+                locale,
+                discreet,
+              }),
       };
     };
 

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TotalBalance/TotalBalanceView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TotalBalance/TotalBalanceView.tsx
@@ -3,6 +3,7 @@ import React from "react";
 export type TotalBalanceViewProps = Readonly<{
   totalBalanceLabel: string;
   fiatAriaLabel: string;
+  fiatAvailable: boolean;
   prefixSymbol: string | null;
   suffixSymbol: string | null;
   hasDecimals: boolean;
@@ -15,6 +16,7 @@ export type TotalBalanceViewProps = Readonly<{
 export function TotalBalanceView({
   totalBalanceLabel,
   fiatAriaLabel,
+  fiatAvailable,
   prefixSymbol,
   suffixSymbol,
   hasDecimals,
@@ -33,15 +35,21 @@ export function TotalBalanceView({
           data-testid="asset-detail-fiat-balance"
           aria-label={fiatAriaLabel}
         >
-          {prefixSymbol ? <span className="me-4">{prefixSymbol}</span> : null}
-          <span>{integerPart}</span>
-          {hasDecimals ? (
+          {fiatAvailable ? (
             <>
-              <span>{decimalSeparator}</span>
-              <span>{decimalPart}</span>
+              {prefixSymbol ? <span className="me-4">{prefixSymbol}</span> : null}
+              <span>{integerPart}</span>
+              {hasDecimals ? (
+                <>
+                  <span>{decimalSeparator}</span>
+                  <span>{decimalPart}</span>
+                </>
+              ) : null}
+              {suffixSymbol ? <span className="ms-4">{suffixSymbol}</span> : null}
             </>
-          ) : null}
-          {suffixSymbol ? <span className="ms-4">{suffixSymbol}</span> : null}
+          ) : (
+            "-"
+          )}
         </span>
         <span className="body-2 select-none text-muted" aria-hidden>
           /

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TotalBalance/__tests__/TotalBalanceView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TotalBalance/__tests__/TotalBalanceView.test.tsx
@@ -5,6 +5,7 @@ import { TotalBalanceView } from "../TotalBalanceView";
 const baseProps = {
   totalBalanceLabel: "Total balance",
   fiatAriaLabel: "$ 1234.56",
+  fiatAvailable: true,
   prefixSymbol: "$",
   suffixSymbol: null,
   hasDecimals: true,
@@ -39,5 +40,14 @@ describe("TotalBalanceView", () => {
     expect(fiatBalance).toHaveTextContent("***");
     expect(fiatBalance).not.toHaveTextContent("1234");
     expect(fiatBalance).toHaveAttribute("aria-label", "Total balance");
+  });
+
+  it("renders an unavailable placeholder while preserving the crypto balance", () => {
+    render(
+      <TotalBalanceView {...baseProps} fiatAvailable={false} cryptoBalance={<span>1 BTC</span>} />,
+    );
+
+    expect(screen.getByTestId("asset-detail-fiat-balance")).toHaveTextContent("-");
+    expect(screen.getByText("1 BTC")).toBeVisible();
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TotalBalance/__tests__/useTotalBalanceViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TotalBalance/__tests__/useTotalBalanceViewModel.test.ts
@@ -31,30 +31,37 @@ describe("useTotalBalanceViewModel", () => {
 
   it("exposes the translated total balance label", () => {
     const { result } = renderHook(
-      () => useTotalBalanceViewModel(buildDistributionItem({ currency: btc })),
+      () => useTotalBalanceViewModel(buildDistributionItem({ currency: btc, countervalue: 0 })),
       { initialState },
     );
 
     expect(result.current.totalBalanceLabel).toBe("Total balance");
   });
 
-  it("formats countervalue 0 when countervalue is undefined", () => {
-    renderHook(() => useTotalBalanceViewModel(buildDistributionItem({ countervalue: undefined })), {
-      initialState,
-    });
-
-    expect(mockedFormatCurrencyUnitFragment).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ toString: expect.any(Function) }),
-      expect.objectContaining({ locale: "en-US", showCode: true }),
+  it("does not format a missing countervalue as zero", () => {
+    const { result } = renderHook(
+      () => useTotalBalanceViewModel(buildDistributionItem({ countervalue: undefined })),
+      { initialState },
     );
-    expect(mockedFormatCurrencyUnitFragment.mock.calls[0][1].toString()).toBe("0");
+
+    expect(mockedFormatCurrencyUnitFragment).not.toHaveBeenCalled();
+    expect(result.current.fiatAvailable).toBe(false);
+    expect(result.current.fiatAriaLabel).toBe("-");
   });
 
   it("forwards locale, discreet and full precision options in the fragment formatter", () => {
-    renderHook(() => useTotalBalanceViewModel(buildDistributionItem({ currency: btc })), {
-      initialState: { settings: { counterValue: "USD", locale: "de-DE", discreetMode: true } },
-    });
+    renderHook(
+      () => useTotalBalanceViewModel(buildDistributionItem({ currency: btc, countervalue: 0 })),
+      {
+        initialState: {
+          settings: {
+            counterValue: "USD",
+            locale: "de-DE",
+            discreetMode: true,
+          },
+        },
+      },
+    );
 
     expect(mockedFormatCurrencyUnitFragment).toHaveBeenCalledWith(
       expect.anything(),
@@ -70,16 +77,27 @@ describe("useTotalBalanceViewModel", () => {
   });
 
   it("uses the total balance label as fiat aria label when discreet mode is enabled", () => {
-    const { result } = renderHook(() => useTotalBalanceViewModel(buildDistributionItem()), {
-      initialState: { settings: { counterValue: "USD", locale: "en-US", discreetMode: true } },
-    });
+    const { result } = renderHook(
+      () => useTotalBalanceViewModel(buildDistributionItem({ countervalue: 0 })),
+      {
+        initialState: {
+          settings: {
+            counterValue: "USD",
+            locale: "en-US",
+            discreetMode: true,
+          },
+        },
+      },
+    );
 
     expect(result.current.fiatAriaLabel).toBe("Total balance");
   });
 
   it("exposes amount and crypto unit from the distribution item", () => {
     const item = buildDistributionItem({ amount: 15_000_000, currency: btc });
-    const { result } = renderHook(() => useTotalBalanceViewModel(item), { initialState });
+    const { result } = renderHook(() => useTotalBalanceViewModel(item), {
+      initialState,
+    });
 
     expect(result.current.amount).toBe(15_000_000);
     expect(result.current.cryptoUnit).toBe(btc.units[0]);

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TotalBalance/useTotalBalanceViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TotalBalance/useTotalBalanceViewModel.ts
@@ -20,10 +20,12 @@ export function useTotalBalanceViewModel(distributionItem: DistributionItem) {
   const fiatUnit = fiatCurrency.units[0];
   const { currency: assetCurrency, amount, countervalue: totalCountervalue } = distributionItem;
   const cryptoUnit = assetCurrency.units[0];
-  const fiatValue = totalCountervalue ?? 0;
+  const fiatAvailable = totalCountervalue != null;
 
   const fiatParts = useMemo(() => {
-    const fragment = formatCurrencyUnitFragment(fiatUnit, new BigNumber(fiatValue), {
+    if (!fiatAvailable) return undefined;
+
+    const fragment = formatCurrencyUnitFragment(fiatUnit, new BigNumber(totalCountervalue), {
       locale,
       discreet,
       showCode: true,
@@ -31,17 +33,25 @@ export function useTotalBalanceViewModel(distributionItem: DistributionItem) {
       showAllDigits: true,
     });
     return parseCurrencyUnitFragment(fragment);
-  }, [discreet, fiatUnit, fiatValue, locale]);
+  }, [discreet, fiatAvailable, fiatUnit, locale, totalCountervalue]);
 
   const totalBalanceLabel = t("assetDetails.totalBalance");
-  const fiatAriaLabel = discreet
-    ? totalBalanceLabel
-    : formatFiatBalanceForDisplay(fiatUnit, fiatValue, { locale });
+  const fiatAriaLabel = !fiatAvailable
+    ? "-"
+    : discreet
+      ? totalBalanceLabel
+      : formatFiatBalanceForDisplay(fiatUnit, totalCountervalue, { locale });
 
   return {
     totalBalanceLabel,
     fiatAriaLabel,
-    ...fiatParts,
+    fiatAvailable,
+    prefixSymbol: fiatParts?.prefixSymbol ?? null,
+    suffixSymbol: fiatParts?.suffixSymbol ?? null,
+    hasDecimals: fiatParts?.hasDecimals ?? false,
+    integerPart: fiatParts?.integerPart ?? "",
+    decimalSeparator: fiatParts?.decimalSeparator ?? "",
+    decimalPart: fiatParts?.decimalPart,
     amount,
     cryptoUnit,
   };

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/utils/__tests__/computeFiatPortionsFromDistribution.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/utils/__tests__/computeFiatPortionsFromDistribution.test.ts
@@ -2,15 +2,15 @@ import BigNumber from "bignumber.js";
 import { computeFiatPortionsFromDistribution } from "../computeFiatPortionsFromDistribution";
 
 describe("computeFiatPortionsFromDistribution", () => {
-  it("returns zero fiat when countervalue is missing", () => {
+  it("returns unavailable fiat when countervalue is missing", () => {
     const result = computeFiatPortionsFromDistribution(
       { amount: 100, countervalue: undefined },
       new BigNumber(40),
       new BigNumber(60),
     );
 
-    expect(result.availableFiat.toNumber()).toBe(0);
-    expect(result.earnDepositFiat.toNumber()).toBe(0);
+    expect(result.availableFiat).toBeUndefined();
+    expect(result.earnDepositFiat).toBeUndefined();
   });
 
   it("splits countervalue proportionally to crypto balances", () => {
@@ -20,8 +20,8 @@ describe("computeFiatPortionsFromDistribution", () => {
       new BigNumber(6),
     );
 
-    expect(result.availableFiat.toNumber()).toBe(100_000);
-    expect(result.earnDepositFiat.toNumber()).toBe(60_000);
+    expect(result.availableFiat?.toNumber()).toBe(100_000);
+    expect(result.earnDepositFiat?.toNumber()).toBe(60_000);
   });
 
   it("uses available plus earn deposit as denominator when amount is zero", () => {
@@ -31,7 +31,7 @@ describe("computeFiatPortionsFromDistribution", () => {
       new BigNumber(6),
     );
 
-    expect(result.availableFiat.toNumber()).toBe(8_000);
-    expect(result.earnDepositFiat.toNumber()).toBe(12_000);
+    expect(result.availableFiat?.toNumber()).toBe(8_000);
+    expect(result.earnDepositFiat?.toNumber()).toBe(12_000);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/utils/computeFiatPortionsFromDistribution.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/utils/computeFiatPortionsFromDistribution.ts
@@ -5,16 +5,28 @@ export function computeFiatPortionsFromDistribution(
   distributionItem: Pick<DistributionItem, "amount" | "countervalue">,
   availableBalance: BigNumber,
   earnDeposit: BigNumber,
-): { availableFiat: BigNumber; earnDepositFiat: BigNumber } {
-  const totalFiat = distributionItem.countervalue ?? 0;
+): {
+  availableFiat: BigNumber | undefined;
+  earnDepositFiat: BigNumber | undefined;
+} {
+  const totalFiat = distributionItem.countervalue;
+  if (totalFiat == null) {
+    return { availableFiat: undefined, earnDepositFiat: undefined };
+  }
   if (totalFiat === 0) {
-    return { availableFiat: new BigNumber(0), earnDepositFiat: new BigNumber(0) };
+    return {
+      availableFiat: new BigNumber(0),
+      earnDepositFiat: new BigNumber(0),
+    };
   }
 
   const totalCrypto = new BigNumber(distributionItem.amount ?? 0);
   const denominator = totalCrypto.gt(0) ? totalCrypto : availableBalance.plus(earnDeposit);
   if (denominator.isZero()) {
-    return { availableFiat: new BigNumber(0), earnDepositFiat: new BigNumber(0) };
+    return {
+      availableFiat: new BigNumber(0),
+      earnDepositFiat: new BigNumber(0),
+    };
   }
 
   const totalFiatBn = new BigNumber(totalFiat);

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/__tests__/useAllCurrencyTrends.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/__tests__/useAllCurrencyTrends.test.ts
@@ -65,11 +65,16 @@ describe("useAllCurrencyTrends", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedUseCountervaluesState.mockReturnValue(mockCountervaluesState);
-    mockedGetCurrentBalanceCountervalueChange.mockReturnValue({ value: 0, percentage: null });
+    mockedGetCurrentBalanceCountervalueChange.mockReturnValue({
+      value: 0,
+      percentage: null,
+    });
   });
 
   it("should compute trends for all real items with one shared countervalues subscription", () => {
-    const bitcoinAccount = genAccount("btc-trend", { currency: getCryptoCurrencyById("bitcoin") });
+    const bitcoinAccount = genAccount("btc-trend", {
+      currency: getCryptoCurrencyById("bitcoin"),
+    });
     const ethereumAccount = genAccount("eth-trend", {
       currency: getCryptoCurrencyById("ethereum"),
     });
@@ -102,7 +107,9 @@ describe("useAllCurrencyTrends", () => {
     mockedGetCurrencyPortfolio.mockReturnValueOnce(makePortfolio(-5.67));
 
     const range = "week" as const;
-    const { result } = renderHook(() => useAllCurrencyTrends(items, range), { initialState });
+    const { result } = renderHook(() => useAllCurrencyTrends(items, range), {
+      initialState,
+    });
 
     expect(mockedUseCountervaluesState).toHaveBeenCalledTimes(1);
     expect(mockedGetCurrencyPortfolio).toHaveBeenCalledTimes(2);
@@ -133,7 +140,10 @@ describe("useAllCurrencyTrends", () => {
     });
 
     mockedGetCurrencyPortfolio.mockReturnValueOnce(makePortfolio(undefined));
-    mockedGetCurrentBalanceCountervalueChange.mockReturnValueOnce({ value: 0, percentage: null });
+    mockedGetCurrentBalanceCountervalueChange.mockReturnValueOnce({
+      value: 0,
+      percentage: null,
+    });
 
     const { result } = renderHook(
       () =>
@@ -160,7 +170,10 @@ describe("useAllCurrencyTrends", () => {
     const bitcoinAccounts = [bitcoinAccount];
 
     mockedGetCurrencyPortfolio.mockReturnValueOnce(makePortfolio(undefined));
-    mockedGetCurrentBalanceCountervalueChange.mockReturnValueOnce({ value: 42, percentage: 3.21 });
+    mockedGetCurrentBalanceCountervalueChange.mockReturnValueOnce({
+      value: 42,
+      percentage: 3.21,
+    });
 
     const range = "day" as const;
     const { result } = renderHook(
@@ -187,7 +200,7 @@ describe("useAllCurrencyTrends", () => {
     expect(result.current.get(BITCOIN_ASSET.currency.id)).toBe(3.21);
   });
 
-  it("should return zero trend for zero-value assets without using the balance fallback", () => {
+  it("should return unavailable trend for positive-balance assets with a missing value", () => {
     const bitcoinAccount = genAccount("btc-zero-value-trend", {
       currency: getCryptoCurrencyById("bitcoin"),
     });
@@ -199,6 +212,31 @@ describe("useAllCurrencyTrends", () => {
             makeAssetItem({
               accounts: [bitcoinAccount],
               balance: 100,
+              value: undefined,
+            }),
+          ],
+          "day",
+        ),
+      { initialState },
+    );
+
+    expect(mockedGetCurrencyPortfolio).not.toHaveBeenCalled();
+    expect(mockedGetCurrentBalanceCountervalueChange).not.toHaveBeenCalled();
+    expect(result.current.get(BITCOIN_ASSET.currency.id)).toBeNull();
+  });
+
+  it("should return zero trend for zero-balance assets", () => {
+    const bitcoinAccount = genAccount("btc-zero-balance-trend", {
+      currency: getCryptoCurrencyById("bitcoin"),
+    });
+
+    const { result } = renderHook(
+      () =>
+        useAllCurrencyTrends(
+          [
+            makeAssetItem({
+              accounts: [bitcoinAccount],
+              balance: 0,
               value: 0,
             }),
           ],

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/__tests__/useTable.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/__tests__/useTable.test.tsx
@@ -1,4 +1,7 @@
-import { renderHook } from "tests/testSetup";
+import React from "react";
+import { flexRender } from "@tanstack/react-table";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { render, renderHook, screen } from "tests/testSetup";
 import { useTable } from "../useTable";
 
 describe("useTable", () => {
@@ -12,5 +15,30 @@ describe("useTable", () => {
     const { result } = renderHook(() => useTable([]));
     const trendCol = result.current.getAllColumns().find(c => c.id === "trend");
     expect(trendCol?.columnDef.meta?.headerTrailingContent).toBeDefined();
+  });
+
+  it("renders an unavailable precomputed value instead of recalculating an aggregated row", () => {
+    const bitcoin = getCryptoCurrencyById("bitcoin");
+    const { result } = renderHook(() =>
+      useTable([
+        {
+          currency: bitcoin,
+          balance: 100_000_000,
+          value: undefined,
+          distribution: 0,
+          accounts: [],
+          isPlaceholder: false,
+        },
+      ]),
+    );
+    const cell = result.current
+      .getRowModel()
+      .rows[0].getVisibleCells()
+      .find(({ column }) => column.id === "value");
+    if (!cell) throw new Error("Missing value cell");
+
+    render(<>{flexRender(cell.column.columnDef.cell, cell.getContext())}</>);
+
+    expect(screen.getByTestId("w40-asset-row-value-bitcoin-bitcoin")).toHaveTextContent("-");
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useAllCurrencyTrends.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useAllCurrencyTrends.ts
@@ -31,8 +31,12 @@ export function useAllCurrencyTrends(
         map.set(item.currency.id, null);
         continue;
       }
-      if (item.value <= 0) {
+      if (item.balance <= 0) {
         map.set(item.currency.id, 0);
+        continue;
+      }
+      if (item.value == null) {
+        map.set(item.currency.id, null);
         continue;
       }
       const accounts = item.accounts as AccountLike[];

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useTable.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useTable.tsx
@@ -18,11 +18,14 @@ import { CryptoIcon } from "@ledgerhq/crypto-icons";
 import { getValidCryptoIconSize } from "~/renderer/utils/cryptoIconSize";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "LLD/hooks/redux";
-import { counterValueCurrencySelector } from "~/renderer/reducers/settings";
+import {
+  counterValueCurrencySelector,
+  discreetModeSelector,
+  localeSelector,
+} from "~/renderer/reducers/settings";
 import { ColumnDef } from "@tanstack/react-table";
 import { PriceCell } from "../components/Cells/PriceCell";
 import { BalanceCell } from "LLD/components/Cells/BalanceCell";
-import { CounterValueCell } from "LLD/components/Cells/CounterValueCell";
 import { TrendCell } from "../components/Cells/TrendCell";
 import { TruncatedText } from "LLD/components/TruncatedText";
 import { sanitizeAssetNameForTestId } from "../utils/assetTableHelpers";
@@ -38,6 +41,8 @@ export const useTable = (assets: AssetTableItem[], options?: UseAssetTableOption
   const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("desktop");
   const { t } = useTranslation();
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const locale = useSelector(localeSelector);
+  const discreet = useSelector(discreetModeSelector);
 
   const emptyFiatValue = useMemo(
     () => formatCurrencyUnit(counterValueCurrency.units[0], new BigNumber(0), { showCode: true }),
@@ -103,6 +108,14 @@ export const useTable = (assets: AssetTableItem[], options?: UseAssetTableOption
           const assetValueTestId = sanitizeAssetNameForTestId(
             `${row.original.currency.name}-${row.original.currency.id}`,
           );
+          const formattedValue =
+            row.original.value == null
+              ? "-"
+              : formatCurrencyUnit(
+                  counterValueCurrency.units[0],
+                  new BigNumber(row.original.value),
+                  { showCode: true, locale, discreet },
+                );
           return row.original.isPlaceholder ? (
             <div data-testid={`w40-asset-row-value-${assetValueTestId}`}>
               <TableCellItem align="end">
@@ -113,7 +126,11 @@ export const useTable = (assets: AssetTableItem[], options?: UseAssetTableOption
             </div>
           ) : (
             <div data-testid={`w40-asset-row-value-${assetValueTestId}`}>
-              <CounterValueCell currency={row.original.currency} balance={row.original.balance} />
+              <TableCellItem align="end">
+                <TableCellContent>
+                  <TableCellContentTitle>{formattedValue}</TableCellContentTitle>
+                </TableCellContent>
+              </TableCellItem>
             </div>
           );
         },
@@ -152,7 +169,15 @@ export const useTable = (assets: AssetTableItem[], options?: UseAssetTableOption
         },
       },
     ],
-    [t, emptyFiatValue, showTrendColumnTooltip, shouldDisplayAggregatedAssets],
+    [
+      t,
+      emptyFiatValue,
+      showTrendColumnTooltip,
+      shouldDisplayAggregatedAssets,
+      counterValueCurrency,
+      locale,
+      discreet,
+    ],
   );
 
   const table = useLumenDataTable({

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AggregatedAccountValueCell.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AggregatedAccountValueCell.tsx
@@ -10,7 +10,7 @@ import {
 } from "~/renderer/reducers/settings";
 
 type AggregatedAccountValueCellProps = {
-  readonly aggregatedCountervalue: BigNumber;
+  readonly aggregatedCountervalue?: BigNumber;
 };
 
 export function AggregatedAccountValueCell({
@@ -20,11 +20,13 @@ export function AggregatedAccountValueCell({
   const locale = useSelector(localeSelector);
   const discreet = useSelector(discreetModeSelector);
 
-  const formattedValue = formatCurrencyUnit(counterValueCurrency.units[0], aggregatedCountervalue, {
-    showCode: true,
-    locale,
-    discreet,
-  });
+  const formattedValue = aggregatedCountervalue != null
+    ? formatCurrencyUnit(counterValueCurrency.units[0], aggregatedCountervalue, {
+        showCode: true,
+        locale,
+        discreet,
+      })
+    : "-";
 
   return (
     <TableCellItem align="end">

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/__tests__/AggregatedAccountValueCell.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/__tests__/AggregatedAccountValueCell.test.tsx
@@ -10,4 +10,10 @@ describe("AggregatedAccountValueCell", () => {
     expect(screen.getByText(/1,000\.00/)).toBeVisible();
     expect(screen.queryByText(/asset/)).not.toBeInTheDocument();
   });
+
+  it("renders an unavailable placeholder when the aggregated countervalue is missing", () => {
+    render(<AggregatedAccountValueCell aggregatedCountervalue={undefined} />);
+
+    expect(screen.getByText("-")).toBeVisible();
+  });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/hooks/useCryptoDataTable.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/hooks/useCryptoDataTable.tsx
@@ -128,9 +128,7 @@ export function useCryptoDataTable({
         cell: ({ row }) => {
           const entry = aggregatedDataByAccountId?.get(row.original.id);
           return shouldDisplayAggregatedAssets && aggregatedDataByAccountId ? (
-            <AggregatedAccountValueCell
-              aggregatedCountervalue={entry?.countervalue ?? new BigNumber(0)}
-            />
+            <AggregatedAccountValueCell aggregatedCountervalue={entry?.countervalue} />
           ) : (
             <AccountValueCell account={row.original} />
           );

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/utils/__tests__/aggregateAccounts.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/utils/__tests__/aggregateAccounts.test.ts
@@ -30,9 +30,17 @@ describe("computeBalanceSortCountervalueByAccountId", () => {
     expect(map.get(b.id)?.toString()).toBe("500");
   });
 
-  it("defaults to zero when countervalue is not available", () => {
+  it("preserves an unavailable countervalue for a positive balance", () => {
     calculateCountervalue.mockReturnValueOnce(null);
     const account = withBalance(BTC_ACCOUNT, new BigNumber(100));
+    const map = computeBalanceSortCountervalueByAccountId([account], calculateCountervalue);
+    expect(map.has(account.id)).toBe(true);
+    expect(map.get(account.id)).toBeUndefined();
+  });
+
+  it("keeps a true zero when a zero balance has no countervalue", () => {
+    calculateCountervalue.mockReturnValueOnce(null);
+    const account = withBalance(BTC_ACCOUNT, new BigNumber(0));
     const map = computeBalanceSortCountervalueByAccountId([account], calculateCountervalue);
     expect(map.get(account.id)?.toString()).toBe("0");
   });

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/utils/aggregateAccounts.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/utils/aggregateAccounts.ts
@@ -11,11 +11,17 @@ export type CalculateCountervalue = (
 export function computeBalanceSortCountervalueByAccountId(
   rows: readonly AccountLike[],
   calculateCountervalue: CalculateCountervalue,
-): Map<string, BigNumber> {
-  const map = new Map<string, BigNumber>();
+): Map<string, BigNumber | undefined> {
+  const map = new Map<string, BigNumber | undefined>();
   for (const account of rows) {
     const currency = getAccountCurrency(account);
-    map.set(account.id, calculateCountervalue(currency, account.balance) ?? new BigNumber(0));
+    const countervalue = calculateCountervalue(currency, account.balance);
+    map.set(
+      account.id,
+      account.balance.isGreaterThan(0) && countervalue == null
+        ? undefined
+        : new BigNumber(countervalue ?? 0),
+    );
   }
   return map;
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Added focused tests for countervalue cells, asset table rows, Asset Detail, staking, PnL, and Crypto Addresses aggregation.
- [x] **Impact of the changes:**
      When a current rate is unavailable, Desktop asset rows, details, and addresses retain the crypto balance but display `-` for unavailable fiat values and trends. Genuine zero values remain `$0`.

### 📝 Description

Individual Desktop asset surfaces previously converted a missing countervalue into `$0` or left a trend visible without a current valuation.

This PR uses the shared completeness contract to render unavailable fiat values consistently in Assets, Asset Detail, staking/PnL, and Crypto Addresses. It does not remove the user’s crypto balance or hide assets.

This PR is stacked on the countervalue completeness core PR.

| Before                        | After                         |
|-------------------------------|-------------------------------|
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA issue**: [LIVE-36444](https://ledgerhq.atlassian.net/browse/LIVE-36444)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-36444]: https://ledgerhq.atlassian.net/browse/LIVE-36444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ