### PR TITLE
[LWM] fix(counter-values): show unavailable portfolio values (LIVE-36444)

### DIFF
--- a/.changeset/fresh-mobile-portfolio-values.md
+++ b/.changeset/fresh-mobile-portfolio-values.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Show unavailable portfolio and analytics values when current countervalues are incomplete.

--- a/apps/ledger-live-mobile/src/components/GraphCard.tsx
+++ b/apps/ledger-live-mobile/src/components/GraphCard.tsx
@@ -56,6 +56,8 @@ function GraphCard({
   const readOnlyModeEnabled = useSelector(readOnlyModeEnabledSelector);
 
   const { countervalueChange, balanceHistory } = portfolio;
+  const countervalueTrendComplete =
+    portfolio.countervalueComplete && countervalueChange.percentage !== null;
 
   const unit = counterValueCurrency.units[0];
 
@@ -76,7 +78,7 @@ function GraphCard({
   const mapGraphValue = useCallback((d: Item) => d.value || 0, []);
 
   const range = portfolio.range;
-  const isAvailable = portfolio.balanceAvailable;
+  const isAvailable = portfolio.balanceAvailable && countervalueTrendComplete;
 
   const rangesLabels = timeRangeItems.map(({ label }) => label);
 
@@ -128,7 +130,11 @@ function GraphCard({
                   <TransactionsPendingConfirmationWarningAllAccounts />
                 </Flex>
                 <Flex flexDirection={"row"}>
-                  {!balanceHistory ? (
+                  {!countervalueTrendComplete ? (
+                    <Text variant="large" fontWeight="semiBold" color="neutral.c70">
+                      -
+                    </Text>
+                  ) : !balanceHistory ? (
                     <>
                       <SmallPlaceholder mt="12px" />
                     </>
@@ -162,7 +168,7 @@ function GraphCard({
           </Flex>
         </Animated.View>
       </Flex>
-      {!hideGraph && (
+      {!hideGraph && countervalueTrendComplete && (
         <GraphSection
           readOnlyModeEnabled={readOnlyModeEnabled}
           onTouchEndGraph={onTouchEndGraph}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -106,6 +106,7 @@ import FeesNavigator from "./FeesNavigator";
 import { getEarnScreenOptions, getEarnScreenOptionsFromRouteParams } from "./getEarnScreenOptions";
 import SignRawTransactionNavigator from "./SignRawTransactionNavigator";
 import LiveAppModalScreen from "LLM/features/LiveAppModal";
+import { PortfolioBalanceSync } from "LLM/features/Portfolio/components/PortfolioBalanceSync";
 
 const Stack = createNativeStackNavigator<BaseNavigatorStackParamList, typeof BASE_NAVIGATOR_ID>();
 
@@ -197,6 +198,7 @@ export default function BaseNavigator() {
   return (
     <>
       <RootDrawer drawer={route.params?.drawer} />
+      <PortfolioBalanceSync />
       <Stack.Navigator id={BASE_NAVIGATOR_ID} screenOptions={nativeStackScreenOptions}>
         <Stack.Screen name={NavigatorName.Main} component={Main} options={{ headerShown: false }} />
         <Stack.Screen

--- a/apps/ledger-live-mobile/src/components/RootNavigator/PortfolioRootScreen.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/PortfolioRootScreen.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from "react";
 import { Box } from "@ledgerhq/native-ui";
 import { useWallet40Theme } from "LLM/hooks/useWallet40Theme";
-import { PortfolioBalanceSync } from "LLM/features/Portfolio/components/PortfolioBalanceSync";
 import { Portfolio, ReadOnlyPortfolio } from "LLM/features/Portfolio";
 import { useSelector } from "~/context/hooks";
 import { ScreenName } from "~/const/navigation";
@@ -32,7 +31,6 @@ export default function PortfolioRootScreen({ navigation, route }: NavigationPro
 
   return (
     <WalletTabNavigatorScrollManager currentRouteName={ScreenName.Portfolio}>
-      <PortfolioBalanceSync />
       <Box flexGrow={1} bg={backgroundColor}>
         <WalletTabBackgroundGradient />
         <PortfolioComponent navigation={navigation} route={route} />

--- a/apps/ledger-live-mobile/src/hooks/useNonBlacklistedDistribution.ts
+++ b/apps/ledger-live-mobile/src/hooks/useNonBlacklistedDistribution.ts
@@ -7,18 +7,31 @@ import type { DistributionOpts } from "@ledgerhq/live-common/portfolio/index";
 export function useNonBlacklistedDistribution(
   opts: DistributionOpts = { showEmptyAccounts: true },
 ) {
+  return useNonBlacklistedDistributionResult(opts).list;
+}
+
+export function useNonBlacklistedDistributionResult(
+  opts: DistributionOpts = { showEmptyAccounts: true },
+) {
   const distribution = useDistribution(opts);
   const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector);
   const blacklistedTokenIdsSet = useMemo(() => new Set(blacklistedTokenIds), [blacklistedTokenIds]);
 
-  return useMemo(
+  const list = useMemo(
     () =>
-      distribution.isAvailable
+      distribution.isAvailable && distribution.countervalueComplete
         ? distribution.list.filter(
             ({ currency }) =>
               currency.type !== "TokenCurrency" || !blacklistedTokenIdsSet.has(currency.id),
           )
         : [],
-    [distribution.isAvailable, distribution.list, blacklistedTokenIdsSet],
+    [
+      distribution.isAvailable,
+      distribution.countervalueComplete,
+      distribution.list,
+      blacklistedTokenIdsSet,
+    ],
   );
+
+  return useMemo(() => ({ ...distribution, list }), [distribution, list]);
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/__integrations__/analyticsMain.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/__integrations__/analyticsMain.integration.test.tsx
@@ -54,6 +54,11 @@ describe("AnalyticsMain Integration Tests", () => {
         ...state.accounts,
         active: [btcAccount, ethAccount, adaAccount],
       },
+      portfolioBalanceDisplay: {
+        ...state.portfolioBalanceDisplay,
+        isBalanceAvailable: true,
+        isCountervalueComplete: true,
+      },
     });
   };
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/__integrations__/detailedAllocation.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/__integrations__/detailedAllocation.integration.test.tsx
@@ -52,6 +52,10 @@ describe("DetailedAllocation Integration Tests", () => {
         ...state.settings,
         counterValue: "USD",
       },
+      portfolioBalanceDisplay: {
+        ...state.portfolioBalanceDisplay,
+        isCountervalueComplete: true,
+      },
     };
   };
 
@@ -68,6 +72,10 @@ describe("DetailedAllocation Integration Tests", () => {
         ...state.settings,
         counterValue: "USD",
       },
+      portfolioBalanceDisplay: {
+        ...state.portfolioBalanceDisplay,
+        isCountervalueComplete: true,
+      },
     };
   };
 
@@ -80,6 +88,10 @@ describe("DetailedAllocation Integration Tests", () => {
     settings: {
       ...state.settings,
       counterValue: "USD",
+    },
+    portfolioBalanceDisplay: {
+      ...state.portfolioBalanceDisplay,
+      isCountervalueComplete: true,
     },
   });
 
@@ -131,7 +143,15 @@ describe("DetailedAllocation Integration Tests", () => {
       return {
         ...state,
         accounts: { ...state.accounts, active: [mockEthAccountWithUSDC] },
-        settings: { ...state.settings, counterValue: "USD", blacklistedTokenIds: [usdcToken.id] },
+        settings: {
+          ...state.settings,
+          counterValue: "USD",
+          blacklistedTokenIds: [usdcToken.id],
+        },
+        portfolioBalanceDisplay: {
+          ...state.portfolioBalanceDisplay,
+          isCountervalueComplete: true,
+        },
       };
     };
     const mockStateWithNonBlacklistedToken = (state: State): State => {
@@ -139,7 +159,15 @@ describe("DetailedAllocation Integration Tests", () => {
       return {
         ...state,
         accounts: { ...state.accounts, active: [mockEthAccountWithUSDC] },
-        settings: { ...state.settings, counterValue: "USD", blacklistedTokenIds: [] },
+        settings: {
+          ...state.settings,
+          counterValue: "USD",
+          blacklistedTokenIds: [],
+        },
+        portfolioBalanceDisplay: {
+          ...state.portfolioBalanceDisplay,
+          isCountervalueComplete: true,
+        },
       };
     };
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/components/AnalyticsBalanceDisplay/__tests__/AnalyticsBalanceDisplay.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/components/AnalyticsBalanceDisplay/__tests__/AnalyticsBalanceDisplay.test.tsx
@@ -18,7 +18,10 @@ describe("AnalyticsBalanceDisplay", () => {
   describe("when balance is not yet available", () => {
     it("renders the skeleton placeholder", () => {
       render(<AnalyticsBalanceDisplay />, {
-        overrideInitialState: withBalance({ isBalanceAvailable: false }),
+        overrideInitialState: withBalance({
+          isBalanceAvailable: false,
+          isLoading: true,
+        }),
       });
 
       expect(screen.getByTestId("analytics-balance-skeleton")).toBeVisible();
@@ -26,10 +29,29 @@ describe("AnalyticsBalanceDisplay", () => {
     });
   });
 
+  describe("when countervalues are incomplete", () => {
+    it("renders an unavailable value after loading settles", () => {
+      render(<AnalyticsBalanceDisplay />, {
+        overrideInitialState: withBalance({
+          isBalanceAvailable: false,
+          isCountervalueComplete: false,
+          isLoading: false,
+        }),
+      });
+
+      expect(screen.getByTestId("analytics-balance-unavailable")).toHaveTextContent("-");
+      expect(screen.queryByTestId("analytics-balance-skeleton")).toBeNull();
+    });
+  });
+
   describe("when balance is available", () => {
     it("renders AmountDisplay with the slice balance", () => {
       render(<AnalyticsBalanceDisplay />, {
-        overrideInitialState: withBalance({ isBalanceAvailable: true, displayedBalance: 5000 }),
+        overrideInitialState: withBalance({
+          isBalanceAvailable: true,
+          isCountervalueComplete: true,
+          displayedBalance: 5000,
+        }),
       });
 
       expect(screen.getByTestId("analytics-balance-amount")).toBeVisible();
@@ -40,7 +62,11 @@ describe("AnalyticsBalanceDisplay", () => {
   describe("hoveredValue prop", () => {
     it("renders AmountDisplay when hoveredValue is provided, even if slice balance is 0", () => {
       render(<AnalyticsBalanceDisplay hoveredValue={9999} />, {
-        overrideInitialState: withBalance({ isBalanceAvailable: true, displayedBalance: 0 }),
+        overrideInitialState: withBalance({
+          isBalanceAvailable: true,
+          isCountervalueComplete: true,
+          displayedBalance: 0,
+        }),
       });
 
       expect(screen.getByTestId("analytics-balance-amount")).toBeVisible();
@@ -48,7 +74,10 @@ describe("AnalyticsBalanceDisplay", () => {
 
     it("does not show skeleton when hoveredValue is provided and balance is available", () => {
       render(<AnalyticsBalanceDisplay hoveredValue={42} />, {
-        overrideInitialState: withBalance({ isBalanceAvailable: true }),
+        overrideInitialState: withBalance({
+          isBalanceAvailable: true,
+          isCountervalueComplete: true,
+        }),
       });
 
       expect(screen.queryByTestId("analytics-balance-skeleton")).toBeNull();

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/components/AnalyticsBalanceDisplay/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/components/AnalyticsBalanceDisplay/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { AmountDisplay, Skeleton } from "@ledgerhq/lumen-ui-rnative";
+import { AmountDisplay, Skeleton, Text } from "@ledgerhq/lumen-ui-rnative";
 import { useAnalyticsBalanceDisplayViewModel } from "./useAnalyticsBalanceDisplayViewModel";
 
 type Props = {
@@ -18,10 +18,28 @@ type Props = {
  * suppressed because a historical value is already resolved.
  */
 export function AnalyticsBalanceDisplay({ hoveredValue, animate = true }: Readonly<Props>) {
-  const { value, formatter, discreet, isHovering, isLoading, isBalanceAvailable } =
-    useAnalyticsBalanceDisplayViewModel({ hoveredValue });
+  const {
+    value,
+    formatter,
+    discreet,
+    isHovering,
+    isLoading,
+    isBalanceAvailable,
+    isCountervalueComplete,
+  } = useAnalyticsBalanceDisplayViewModel({ hoveredValue });
 
-  if (!isBalanceAvailable) {
+  if (!isCountervalueComplete && !(isLoading && isBalanceAvailable)) {
+    if (!isLoading) {
+      return (
+        <Text
+          typography="heading1SemiBold"
+          lx={{ color: "base" }}
+          testID="analytics-balance-unavailable"
+        >
+          -
+        </Text>
+      );
+    }
     return <Skeleton testID="analytics-balance-skeleton" lx={{ height: "s48", width: "s256" }} />;
   }
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/components/AnalyticsBalanceDisplay/useAnalyticsBalanceDisplayViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/components/AnalyticsBalanceDisplay/useAnalyticsBalanceDisplayViewModel.ts
@@ -18,13 +18,15 @@ export type AnalyticsBalanceDisplayViewModel = {
   isHovering: boolean;
   isLoading: boolean;
   isBalanceAvailable: boolean;
+  isCountervalueComplete: boolean;
 };
 
 export function useAnalyticsBalanceDisplayViewModel({
   hoveredValue,
 }: Params): AnalyticsBalanceDisplayViewModel {
   const { locale } = useLocale();
-  const { displayedBalance, isLoading, isBalanceAvailable, unit } = usePortfolioBalanceForDisplay();
+  const { displayedBalance, isLoading, isBalanceAvailable, isCountervalueComplete, unit } =
+    usePortfolioBalanceForDisplay();
   const discreet = useSelector(discreetModeSelector);
 
   const formatter = useCallback(
@@ -46,5 +48,6 @@ export function useAnalyticsBalanceDisplayViewModel({
     isHovering,
     isLoading,
     isBalanceAvailable,
+    isCountervalueComplete,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/Allocations/__tests__/useAllocationsViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/Allocations/__tests__/useAllocationsViewModel.test.ts
@@ -36,6 +36,7 @@ function distributionRow(
 function mockAssetsDistribution(list: DistributionItem[]): DistributionResult {
   return {
     isAvailable: true,
+    countervalueComplete: true,
     showFirst: list.length,
     sum: list.reduce((acc, row) => acc + (row.countervalue ?? row.amount), 0),
     list,
@@ -77,6 +78,21 @@ describe("useAllocationsViewModel", () => {
     const { result } = renderHook(() => useAllocationsViewModel("Analytics", jest.fn()));
 
     expect(result.current.distributionListFormatted).toBe(list);
+    expect(result.current.isAvailable).toBe(true);
+  });
+
+  it.each([
+    { isLoading: true, countervalueComplete: true },
+    { isLoading: false, countervalueComplete: false },
+  ])("hides allocations for an incomplete distribution: %o", overrides => {
+    mockUseDistribution.mockReturnValue({
+      ...mockAssetsDistribution([distributionRow(mockBitcoinCurrency, 1, 1)]),
+      ...overrides,
+    });
+
+    const { result } = renderHook(() => useAllocationsViewModel("Analytics", jest.fn()));
+
+    expect(result.current.isAvailable).toBe(false);
   });
 
   it("should aggregate tail assets into an others row when more than four currencies are in the distribution", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/Allocations/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/Allocations/index.tsx
@@ -2,7 +2,7 @@ import React, { memo } from "react";
 import { TouchableOpacity } from "react-native";
 import { Flex, IconsLegacy, Text } from "@ledgerhq/native-ui";
 import RingChart from "../../../../components/RingChart";
-import { useAllocationsViewModel } from "./useAllocationsViewModel";
+import type { useAllocationsViewModel } from "./useAllocationsViewModel";
 
 const AllocationCaption = memo(
   ({ currencyTicker, currencyColor }: { currencyTicker: string; currencyColor: string }) => {
@@ -18,17 +18,19 @@ const AllocationCaption = memo(
 );
 
 type Props = Readonly<{
-  screenName: string;
-  onPress: () => void;
+  viewModel: ReturnType<typeof useAllocationsViewModel>;
 }>;
 
-function Allocations({ screenName, onPress }: Props) {
+function Allocations({ viewModel }: Props) {
   const {
+    isAvailable,
     distributionListFormatted,
     allocationColumns,
     getCurrencyColorEnsureContrast,
     goToAnalyticsAllocations,
-  } = useAllocationsViewModel(screenName, onPress);
+  } = viewModel;
+
+  if (!isAvailable) return null;
 
   return (
     <Flex flex={1}>

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/Allocations/useAllocationsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/Allocations/useAllocationsViewModel.ts
@@ -26,6 +26,8 @@ export function useAllocationsViewModel(screenName: string, onPress: () => void)
   const { theme } = useLumenTheme();
   const canvasColor = theme.colors.bg.canvas;
   const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector);
+  const isAvailable =
+    !distribution.isLoading && distribution.isAvailable && distribution.countervalueComplete;
 
   const getCurrencyColorEnsureContrast = useCallback(
     (currency: ColorableCurrency) => ensureContrast(getCurrencyColor(currency), canvasColor),
@@ -96,6 +98,7 @@ export function useAllocationsViewModel(screenName: string, onPress: () => void)
   );
 
   return {
+    isAvailable,
     distributionListFormatted,
     allocationColumns,
     getCurrencyColorEnsureContrast,

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/AssetAllocationBanner.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/AssetAllocationBanner.tsx
@@ -9,6 +9,7 @@ import { track } from "~/analytics";
 import { ANALYTICS_PAGE } from "../../../const";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { AnalyticsNavigatorParamsList } from "../../../types";
+import { useAllocationsViewModel } from "./Allocations/useAllocationsViewModel";
 
 const AssetAllocationBanner: React.FC = () => {
   const { t } = useTranslation();
@@ -25,12 +26,16 @@ const AssetAllocationBanner: React.FC = () => {
     });
   }, [navigation]);
 
+  const viewModel = useAllocationsViewModel(NavigatorName.Analytics, navigateToDetailedAllocation);
+
+  if (!viewModel.isAvailable) return null;
+
   return (
     <Box lx={Container}>
       <Text typography="heading5SemiBold" lx={TextStyle}>
         {t("analyticsAllocation.allocation.title")}
       </Text>
-      <Allocations screenName={NavigatorName.Analytics} onPress={navigateToDetailedAllocation} />
+      <Allocations viewModel={viewModel} />
     </Box>
   );
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/ChartSectionHeaderView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/ChartSectionHeaderView.tsx
@@ -15,7 +15,9 @@ export function ChartSectionHeaderView({ viewModel }: Props) {
   const {
     hoveredBalance,
     scrubDateLabel,
-    isBalanceAvailable,
+    isCountervalueComplete,
+    isTrendComplete,
+    isLoading,
     percentageValue,
     variationText,
     rangeLabel,
@@ -34,7 +36,7 @@ export function ChartSectionHeaderView({ viewModel }: Props) {
         {t("portfolio.totalBalance")}
       </Text>
       <AnalyticsBalanceDisplay hoveredValue={hoveredBalance} animate={!isScrubbing} />
-      {isBalanceAvailable && (
+      {isTrendComplete ? (
         <TrendSection
           percentage={percentageValue}
           formattedChange={variationText}
@@ -43,6 +45,10 @@ export function ChartSectionHeaderView({ viewModel }: Props) {
           trendSize="sm"
           showTrend={!discreet}
         />
+      ) : isLoading ? null : (
+        <Text typography="body2" lx={{ color: "muted" }} testID={CHART_SECTION_TEST_IDS.trend}>
+          -
+        </Text>
       )}
     </Box>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/ChartSectionView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/ChartSectionView.tsx
@@ -27,9 +27,11 @@ export function ChartSectionView({ viewModel }: Props) {
   return (
     <Box lx={containerStyle} testID={CHART_SECTION_TEST_IDS.root}>
       <ChartSectionHeaderView viewModel={header} />
-      <Box lx={chartContainerStyle}>
-        <ChartSectionChart {...chart} />
-      </Box>
+      {header.isTrendComplete && (
+        <Box lx={chartContainerStyle}>
+          <ChartSectionChart {...chart} />
+        </Box>
+      )}
     </Box>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/__tests__/ChartSection.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/__tests__/ChartSection.test.tsx
@@ -6,6 +6,14 @@ import { State } from "~/reducers/types";
 import { INITIAL_STATE as portfolioBalanceDisplayInitialState } from "~/reducers/portfolioBalanceDisplay";
 import ChartSection from "..";
 import { CHART_SECTION_TEST_IDS } from "../types";
+import { usePortfolioAllAccounts } from "~/hooks/portfolio";
+import { portfolioWithHistory } from "./fixtures";
+
+jest.mock("~/hooks/portfolio", () => ({
+  usePortfolioAllAccounts: jest.fn(),
+}));
+
+const mockUsePortfolioAllAccounts = jest.mocked(usePortfolioAllAccounts);
 
 const btcAccount = genAccount("btc-1", {
   currency: getCryptoCurrencyById("bitcoin"),
@@ -13,7 +21,11 @@ const btcAccount = genAccount("btc-1", {
 });
 
 const withChartState =
-  (balanceAvailable = true) =>
+  (
+    balanceAvailable = true,
+    countervalueComplete = balanceAvailable,
+    isLoading = !balanceAvailable,
+  ) =>
   (state: State): State =>
     withFlagOverrides({
       lwmWallet40: { params: { pnl: true } },
@@ -24,7 +36,8 @@ const withChartState =
         ...portfolioBalanceDisplayInitialState,
         displayedBalance: 5000,
         isBalanceAvailable: balanceAvailable,
-        isLoading: false,
+        isCountervalueComplete: countervalueComplete,
+        isLoading,
       },
       settings: {
         ...state.settings,
@@ -33,6 +46,10 @@ const withChartState =
     });
 
 describe("ChartSection", () => {
+  beforeEach(() => {
+    mockUsePortfolioAllAccounts.mockReturnValue(portfolioWithHistory);
+  });
+
   it("renders the balance header and chart when balance is available", () => {
     render(<ChartSection />, {
       overrideInitialState: withChartState(true),
@@ -55,5 +72,31 @@ describe("ChartSection", () => {
 
     expect(screen.getByTestId("analytics-balance-skeleton")).toBeVisible();
     expect(screen.queryByTestId(CHART_SECTION_TEST_IDS.trend)).toBeNull();
+  });
+
+  it("shows unavailable values and hides the chart after an incomplete valuation settles", () => {
+    render(<ChartSection />, {
+      overrideInitialState: withChartState(false, false, false),
+    });
+
+    expect(screen.getByTestId("analytics-balance-unavailable")).toHaveTextContent("-");
+    expect(screen.getByTestId(CHART_SECTION_TEST_IDS.trend)).toHaveTextContent("-");
+    expect(screen.queryByTestId("analytics-chart")).toBeNull();
+    expect(screen.queryByTestId("analytics-balance-skeleton")).toBeNull();
+  });
+
+  it("keeps the balance visible while hiding an incomplete historical trend", () => {
+    mockUsePortfolioAllAccounts.mockReturnValue({
+      ...portfolioWithHistory,
+      countervalueChange: { percentage: null, value: 0 },
+    });
+
+    render(<ChartSection />, {
+      overrideInitialState: withChartState(true),
+    });
+
+    expect(screen.getByTestId("analytics-balance-amount")).toBeVisible();
+    expect(screen.getByTestId(CHART_SECTION_TEST_IDS.trend)).toHaveTextContent("-");
+    expect(screen.queryByTestId("analytics-chart")).toBeNull();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/__tests__/fixtures.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/__tests__/fixtures.ts
@@ -7,6 +7,7 @@ export const portfolioWithHistory = {
   ],
   countervalueChange: { percentage: 0.2, value: 200 },
   balanceAvailable: true,
+  countervalueComplete: true,
   availableAccounts: [],
   unavailableCurrencies: [],
   accounts: [],
@@ -22,6 +23,7 @@ export const chartSectionInitialState = (state: import("~/reducers/types").State
     ...portfolioBalanceDisplayInitialState,
     displayedBalance: 1200,
     isBalanceAvailable: true,
+    isCountervalueComplete: true,
     isLoading: false,
   },
   settings: {

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/__tests__/useChartSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/__tests__/useChartSectionViewModel.test.ts
@@ -31,6 +31,8 @@ describe("useChartSectionViewModel", () => {
     expect(result.current.header.hoveredBalance).toBeNull();
     expect(result.current.header.scrubDateLabel).toBeUndefined();
     expect(result.current.header.isBalanceAvailable).toBe(true);
+    expect(result.current.header.isCountervalueComplete).toBe(true);
+    expect(result.current.header.isTrendComplete).toBe(true);
     expect(result.current.chart.showScrubberTooltip).toBe(false);
   });
 
@@ -59,7 +61,9 @@ describe("useChartSectionViewModel", () => {
     });
 
     expect(store.getState().settings.selectedTimeRange).toBe("month");
-    expect(mockTrack).toHaveBeenCalledWith("timeframe_clicked", { timeframe: "month" });
+    expect(mockTrack).toHaveBeenCalledWith("timeframe_clicked", {
+      timeframe: "month",
+    });
   });
 
   it("formats chart tooltip and variation values from smallest-unit countervalues", () => {
@@ -89,6 +93,9 @@ describe("useChartSectionViewModel", () => {
     });
 
     expect(result.current.header.percentageValue).toBeNaN();
+    expect(result.current.header.isCountervalueComplete).toBe(true);
+    expect(result.current.header.isTrendComplete).toBe(false);
+    expect(result.current.chart.series).toEqual([]);
   });
 
   it("masks the chart tooltip value when discreet mode is enabled", () => {
@@ -144,5 +151,25 @@ describe("useChartSectionViewModel", () => {
     });
 
     expect(result.current.chart).toBe(chartBeforeScrub);
+  });
+
+  it("clears a scrub selection across an incomplete then recovered trend", () => {
+    const { result, rerender } = renderHook(() => useChartSectionViewModel(), {
+      overrideInitialState: chartSectionInitialState,
+    });
+
+    act(() => result.current.chart.onScrubberPositionChange?.(0));
+    expect(result.current.header.hoveredBalance).toBe(1000);
+
+    mockUsePortfolioAllAccounts.mockReturnValue({
+      ...portfolioWithHistory,
+      countervalueChange: { percentage: null, value: 0 },
+    });
+    rerender();
+    expect(result.current.header.hoveredBalance).toBeNull();
+
+    mockUsePortfolioAllAccounts.mockReturnValue(portfolioWithHistory);
+    rerender();
+    expect(result.current.header.hoveredBalance).toBeNull();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/types.ts
@@ -5,6 +5,9 @@ export type ChartSectionHeaderViewModel = Readonly<{
   hoveredBalance: number | null;
   scrubDateLabel: string | undefined;
   isBalanceAvailable: boolean;
+  isCountervalueComplete: boolean;
+  isTrendComplete: boolean;
+  isLoading: boolean;
   percentageValue: number;
   variationText: string;
   rangeLabel: string;

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/useChartSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/useChartSectionViewModel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import BigNumber from "bignumber.js";
 import { getScrubVariation } from "@ledgerhq/live-common/market/utils/scrubVariation";
 import { useDispatch, useSelector } from "~/context/hooks";
@@ -50,7 +50,8 @@ export function useChartSectionViewModel(): ChartSectionViewModel {
   const countervalues = useCountervaluesState();
   const discreet = useSelector(discreetModeSelector);
   const portfolio = usePortfolioAllAccounts();
-  const { displayedBalance, isBalanceAvailable } = usePortfolioBalanceForDisplay();
+  const { displayedBalance, isBalanceAvailable, isCountervalueComplete, isLoading } =
+    usePortfolioBalanceForDisplay();
 
   const selectedRange = portfolioRangeToLineChartRange(selectedTimeRange);
   const fiatUnit = counterValue.units[0];
@@ -68,6 +69,12 @@ export function useChartSectionViewModel(): ChartSectionViewModel {
       }),
     [selectedTimeRange, accounts, displayedBalance, portfolio, countervalues, counterValue],
   );
+  const isTrendComplete = isCountervalueComplete && valueChange.percentage !== null;
+  const effectiveSelection = isTrendComplete ? selection : undefined;
+
+  useEffect(() => {
+    if (!isTrendComplete) setSelection(undefined);
+  }, [isTrendComplete]);
 
   const { prices, timestamps } = useMemo(() => {
     const history = portfolio.balanceHistory;
@@ -78,15 +85,18 @@ export function useChartSectionViewModel(): ChartSectionViewModel {
   }, [portfolio.balanceHistory]);
 
   const series = useMemo<LineChartSeries[]>(
-    () => [
-      {
-        id: "analytics-portfolio-balance",
-        data: prices,
-        label: t("analytics.title"),
-        stroke: "",
-      },
-    ],
-    [prices, t],
+    () =>
+      isTrendComplete
+        ? [
+            {
+              id: "analytics-portfolio-balance",
+              data: prices,
+              label: t("analytics.title"),
+              stroke: "",
+            },
+          ]
+        : [],
+    [isTrendComplete, prices, t],
   );
 
   const formatValue = useMemo<LineChartValueFormatter>(
@@ -107,10 +117,10 @@ export function useChartSectionViewModel(): ChartSectionViewModel {
   );
 
   const scrubDateLabel =
-    selection != null
-      ? dateFormatters.formatScrubHeaderDate(selection.timestamp, selectedRange)
+    effectiveSelection != null
+      ? dateFormatters.formatScrubHeaderDate(effectiveSelection.timestamp, selectedRange)
       : undefined;
-  const hoveredBalance = selection?.balance ?? null;
+  const hoveredBalance = effectiveSelection?.balance ?? null;
 
   const onScrubberPositionChange = useCallback<LineChartScrubberPositionChange>(
     index => {
@@ -140,13 +150,13 @@ export function useChartSectionViewModel(): ChartSectionViewModel {
 
   const rangePercentageValue = valueChange.percentage == null ? NaN : valueChange.percentage * 100;
   const scrubVariation = useMemo(() => {
-    if (selection == null) return undefined;
+    if (effectiveSelection == null) return undefined;
     const baselinePrice = prices[0];
     if (!Number.isFinite(baselinePrice)) return undefined;
-    return getScrubVariation(baselinePrice, selection.balance, {
+    return getScrubVariation(baselinePrice, effectiveSelection.balance, {
       percentageUnit: "percentPoints",
     });
-  }, [selection, prices]);
+  }, [effectiveSelection, prices]);
 
   const percentageValue = scrubVariation?.percentage ?? rangePercentageValue;
 
@@ -190,7 +200,11 @@ export function useChartSectionViewModel(): ChartSectionViewModel {
       showScrubberBeacons: false,
       showXAxis: false,
       showYAxis: false,
-      xAxis: buildAnalyticsChartXAxisConfig({ timestamps, selectedRange, formatDate }),
+      xAxis: buildAnalyticsChartXAxisConfig({
+        timestamps,
+        selectedRange,
+        formatDate,
+      }),
       yAxis: buildAnalyticsChartYAxisConfig(),
       points: getExtremaPointMarkers(series),
       accessibilityLabel: t("assetDetail.balanceGraph.timeframeSelector"),
@@ -216,6 +230,9 @@ export function useChartSectionViewModel(): ChartSectionViewModel {
       hoveredBalance,
       scrubDateLabel,
       isBalanceAvailable,
+      isCountervalueComplete,
+      isTrendComplete,
+      isLoading,
       percentageValue,
       variationText,
       rangeLabel,

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/__tests__/PnlSection.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/__tests__/PnlSection.integration.test.tsx
@@ -15,13 +15,25 @@ const withAccounts = (state: State): State => ({
   accounts: { ...state.accounts, active: [btcAccount] },
 });
 
+const withCompleteCountervalues = (state: State): State => ({
+  ...state,
+  portfolioBalanceDisplay: {
+    ...state.portfolioBalanceDisplay,
+    isCountervalueComplete: true,
+  },
+});
+
 const compose =
   (...transforms: Array<(state: State) => State>) =>
   (state: State): State =>
     transforms.reduce((acc, t) => t(acc), state);
 
 const withPnl = (enabled: boolean) =>
-  compose(withAccounts, withFlagOverrides({ lwmWallet40: { params: { pnl: enabled } } }));
+  compose(
+    withAccounts,
+    withCompleteCountervalues,
+    withFlagOverrides({ lwmWallet40: { params: { pnl: enabled } } }),
+  );
 
 const DRAWER_DESCRIPTION =
   "Your portfolio performance broken down into estimated unrealised and realised return.";
@@ -62,7 +74,9 @@ describe("PnlSection integration", () => {
 
   describe("drawer opening", () => {
     it("keeps the section mounted when the title is pressed to open the detail drawer", async () => {
-      const { user } = render(<PnlSection />, { overrideInitialState: withPnl(true) });
+      const { user } = render(<PnlSection />, {
+        overrideInitialState: withPnl(true),
+      });
 
       await user.press(screen.getByTestId(PNL_SECTION_TEST_IDS.title));
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/index.tsx
@@ -10,14 +10,16 @@ import { PnlCard } from "LLM/features/Pnl/components/PnlCard";
 import { PnlDetailDrawer } from "LLM/features/Pnl/components/PnlDetailDrawer";
 import { PNL_SECTION_TEST_IDS } from "./testIds";
 import { usePnlSectionViewModel } from "./usePnlSectionViewModel";
+import { usePortfolioBalanceForDisplay } from "LLM/hooks/usePortfolioBalanceForDisplay";
 
 export { PNL_SECTION_TEST_IDS };
 
 export default function PnlSection() {
+  const { isCountervalueComplete } = usePortfolioBalanceForDisplay();
   const { shouldDisplayPnl, title, unrealised, realised, openDrawer, drawer } =
     usePnlSectionViewModel();
 
-  if (!shouldDisplayPnl) return null;
+  if (!shouldDisplayPnl || !isCountervalueComplete) return null;
 
   return (
     <Box lx={{ gap: "s12", paddingHorizontal: "s16" }} testID={PNL_SECTION_TEST_IDS.root}>

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/DetailedAllocation/hooks/useDetailedAllocationViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/DetailedAllocation/hooks/useDetailedAllocationViewModel.test.ts
@@ -1,0 +1,31 @@
+import { renderHook } from "@tests/test-renderer";
+import { useNonBlacklistedDistributionResult } from "~/hooks/useNonBlacklistedDistribution";
+import { useDetailedAllocationViewModel } from "./useDetailedAllocationViewModel";
+
+jest.mock("~/hooks/useNonBlacklistedDistribution", () => ({
+  useNonBlacklistedDistributionResult: jest.fn(),
+}));
+
+const mockUseDistribution = jest.mocked(useNonBlacklistedDistributionResult);
+
+describe("useDetailedAllocationViewModel", () => {
+  it.each([
+    { isLoading: true, countervalueComplete: true, expectedLoading: true },
+    { isLoading: false, countervalueComplete: false, expectedLoading: false },
+  ])("does not expose a partial distribution: %o", config => {
+    mockUseDistribution.mockReturnValue({
+      isAvailable: true,
+      countervalueComplete: config.countervalueComplete,
+      showFirst: 0,
+      sum: 0,
+      list: [],
+      isLoading: config.isLoading,
+    });
+
+    const { result } = renderHook(() => useDetailedAllocationViewModel());
+
+    expect(result.current.isCountervalueComplete).toBe(false);
+    expect(result.current.isLoading).toBe(config.expectedLoading);
+    expect(result.current.list).toEqual([]);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/DetailedAllocation/hooks/useDetailedAllocationViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/DetailedAllocation/hooks/useDetailedAllocationViewModel.ts
@@ -1,17 +1,21 @@
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
-import { useNonBlacklistedDistribution } from "~/hooks/useNonBlacklistedDistribution";
+import { useNonBlacklistedDistributionResult } from "~/hooks/useNonBlacklistedDistribution";
 import type { DistributionItem } from "../../../types/distribution";
 
 export interface DetailedAllocationViewModelResult {
   readonly list: DistributionItem[];
+  readonly isCountervalueComplete: boolean;
+  readonly isLoading: boolean;
 }
 
 export const useDetailedAllocationViewModel = (): DetailedAllocationViewModelResult => {
   const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("mobile");
-  const list = useNonBlacklistedDistribution({
+  const distribution = useNonBlacklistedDistributionResult({
     showEmptyAccounts: true,
     groupBy: shouldDisplayAggregatedAssets ? "asset" : undefined,
   });
+  const isCountervalueComplete =
+    distribution.isAvailable && distribution.countervalueComplete && !distribution.isLoading;
 
-  return { list };
+  return { list: distribution.list, isCountervalueComplete, isLoading: distribution.isLoading };
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/DetailedAllocation/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/DetailedAllocation/index.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, memo } from "react";
 import { FlatList } from "react-native";
 import { useTranslation } from "~/context/Locale";
-import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
+import { Box, Spinner, Text } from "@ledgerhq/lumen-ui-rnative";
 import { LumenTextStyle, LumenViewStyle, useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
 import { useDetailedAllocationViewModel } from "./hooks/useDetailedAllocationViewModel";
 import { TrackScreen } from "~/analytics";
@@ -15,7 +15,7 @@ import RingChart from "../../components/RingChart";
 const size = normalize(200);
 
 function DetailedAllocation() {
-  const { list } = useDetailedAllocationViewModel();
+  const { list, isCountervalueComplete, isLoading } = useDetailedAllocationViewModel();
   const { t } = useTranslation();
 
   const styles = useStyleSheet(
@@ -34,24 +34,38 @@ function DetailedAllocation() {
   return (
     <SafeAreaView isFlex edges={["bottom"]}>
       <Box lx={Container}>
-        <Box lx={BoxContainer}>
-          <RingChart size={size} data={list} />
-          <Box lx={RingChartContainer} pointerEvents="none">
+        {isLoading ? (
+          <Box lx={{ flex: 1, justifyContent: "center" }} testID="allocation-loading">
+            <Spinner size={32} />
+          </Box>
+        ) : isCountervalueComplete ? (
+          <>
+            <Box lx={BoxContainer}>
+              <RingChart size={size} data={list} />
+              <Box lx={RingChartContainer} pointerEvents="none">
+                <Text typography="heading1" lx={Heading}>
+                  {list.length}
+                </Text>
+                <Text typography="body1" lx={Body}>
+                  {t("distribution.assets", { count: list.length })}
+                </Text>
+              </Box>
+            </Box>
+            <FlatList
+              data={list}
+              renderItem={renderItem}
+              keyExtractor={item => item.currency.id}
+              style={styles.flatList}
+              contentContainerStyle={styles.flatListContent}
+            />
+          </>
+        ) : (
+          <Box lx={{ flex: 1, justifyContent: "center" }} testID="allocation-unavailable">
             <Text typography="heading1" lx={Heading}>
-              {list.length}
-            </Text>
-            <Text typography="body1" lx={Body}>
-              {t("distribution.assets", { count: list.length })}
+              -
             </Text>
           </Box>
-        </Box>
-        <FlatList
-          data={list}
-          renderItem={renderItem}
-          keyExtractor={item => item.currency.id}
-          style={styles.flatList}
-          contentContainerStyle={styles.flatListContent}
-        />
+        )}
         <TrackScreen category="Analytics" name="Allocation" />
       </Box>
     </SafeAreaView>

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/PortfolioBalanceSectionView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/PortfolioBalanceSectionView.tsx
@@ -33,6 +33,7 @@ export const PortfolioBalanceSectionView = ({
   countervalueChange,
   unit,
   isBalanceAvailable,
+  isCountervalueComplete,
   isAnalyticPillVisible,
   isLoading,
   onToggleDiscreetMode,
@@ -54,7 +55,8 @@ export const PortfolioBalanceSectionView = ({
     if (state === "noSigner" || state === "noAccounts") {
       return `portfolio-balance-${state}`;
     }
-    return isBalanceAvailable ? "portfolio-balance-normal" : "portfolio-balance-loading";
+    if (isCountervalueComplete) return "portfolio-balance-normal";
+    return isLoading ? "portfolio-balance-loading" : "portfolio-balance-unavailable-state";
   };
 
   const renderAnalyticPill = () => {
@@ -84,7 +86,7 @@ export const PortfolioBalanceSectionView = ({
       <>
         <Pressable onPress={onToggleDiscreetMode} testID="portfolio-balance-toggle">
           <Box lx={{ flexDirection: "row", alignItems: "baseline", gap: "s14" }}>
-            {isBalanceAvailable ? (
+            {isCountervalueComplete || (isLoading && isBalanceAvailable) ? (
               <AmountDisplay
                 key={unit.code}
                 value={balance}
@@ -94,11 +96,19 @@ export const PortfolioBalanceSectionView = ({
                 loading={isLoading}
                 testID="portfolio-balance-amount"
               />
-            ) : (
+            ) : isLoading ? (
               <Skeleton
                 testID="portfolio-placeholder-balance"
                 lx={{ height: "s48", width: "s256" }}
               />
+            ) : (
+              <Text
+                typography="heading1SemiBold"
+                lx={{ color: "base" }}
+                testID="portfolio-balance-unavailable"
+              >
+                -
+              </Text>
             )}
             {discreet && <DiscreetModeIcon />}
           </Box>

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/PortfolioBalanceSectionView.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/PortfolioBalanceSectionView.test.tsx
@@ -27,6 +27,7 @@ const baseProps: PortfolioBalanceSectionViewProps = {
   countervalueChange: { percentage: 1.5, value: 150 },
   unit: usd.units[0],
   isBalanceAvailable: true,
+  isCountervalueComplete: true,
   isAnalyticPillVisible: true,
   isLoading: false,
   onToggleDiscreetMode: jest.fn(),
@@ -73,11 +74,16 @@ describe("PortfolioBalanceSectionView", () => {
   });
 
   describe("loading states", () => {
-    it("should use loading testID and hide analytics pill when balance is not available", () => {
-      renderView({ isBalanceAvailable: false, isAnalyticPillVisible: false });
+    it("should show unavailable after loading settles with an incomplete countervalue", () => {
+      renderView({
+        isBalanceAvailable: false,
+        isCountervalueComplete: false,
+        isAnalyticPillVisible: false,
+      });
 
-      expect(screen.getByTestId("portfolio-balance-loading")).toBeVisible();
-      expect(screen.getByTestId("portfolio-placeholder-balance")).toBeVisible();
+      expect(screen.getByTestId("portfolio-balance-unavailable-state")).toBeVisible();
+      expect(screen.getByTestId("portfolio-balance-unavailable")).toHaveTextContent("-");
+      expect(screen.queryByTestId("portfolio-placeholder-balance")).toBeNull();
       expect(screen.queryByTestId("portfolio-balance-amount")).toBeNull();
       expect(screen.queryByTestId("portfolio-balance-normal")).toBeNull();
       expect(screen.queryByTestId("portfolio-balance-analytics-pill")).toBeNull();
@@ -86,14 +92,15 @@ describe("PortfolioBalanceSectionView", () => {
     it("should show skeleton when balance is not available and loading", () => {
       renderView({
         isBalanceAvailable: false,
-        isAnalyticPillVisible: true,
+        isCountervalueComplete: false,
+        isAnalyticPillVisible: false,
         isLoading: true,
       });
 
       expect(screen.getByTestId("portfolio-balance-loading")).toBeVisible();
       expect(screen.getByTestId("portfolio-placeholder-balance")).toBeVisible();
       expect(screen.queryByTestId("portfolio-balance-amount")).toBeNull();
-      expect(screen.getByTestId("portfolio-balance-analytics-pill")).toBeVisible();
+      expect(screen.queryByTestId("portfolio-balance-analytics-pill")).toBeNull();
     });
 
     it("should show shimmer on amount when balance is available and loading", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/usePersistedPortfolioBalance.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/usePersistedPortfolioBalance.test.ts
@@ -9,6 +9,7 @@ let store: Record<string, unknown> = {};
 
 let getNumberSpy: jest.SpyInstance;
 let setSpy: jest.SpyInstance;
+let containsSpy: jest.SpyInstance;
 
 beforeEach(() => {
   store = {};
@@ -16,6 +17,7 @@ beforeEach(() => {
     const v = store[k];
     return typeof v === "number" ? v : undefined;
   });
+  containsSpy = jest.spyOn(mmkv, "contains").mockImplementation((k: string) => k in store);
   setSpy = jest.spyOn(mmkv, "set").mockImplementation((k: string, v: unknown) => {
     store[k] = v;
   });
@@ -24,35 +26,52 @@ beforeEach(() => {
 afterEach(() => {
   getNumberSpy.mockRestore();
   setSpy.mockRestore();
+  containsSpy.mockRestore();
 });
 
 describe("usePersistedPortfolioBalance", () => {
   it("returns latestBalance when non-zero", () => {
-    const { result } = renderHook(() => usePersistedPortfolioBalance(1500, "synced", CURRENCY));
+    const { result } = renderHook(() =>
+      usePersistedPortfolioBalance(1500, "synced", CURRENCY, true),
+    );
     expect(result.current).toBe(1500);
   });
 
-  it("falls back to MMKV cache when latestBalance is 0 during syncing", () => {
+  it("falls back to a complete MMKV cache while the live balance is incomplete during syncing", () => {
     store[KEY] = 3000;
-    const { result } = renderHook(() => usePersistedPortfolioBalance(0, "syncing", CURRENCY));
+    const { result } = renderHook(() =>
+      usePersistedPortfolioBalance(1500, "syncing", CURRENCY, false),
+    );
     expect(result.current).toBe(3000);
   });
 
-  it("returns 0 when latestBalance is 0 and no cache exists", () => {
-    const { result } = renderHook(() => usePersistedPortfolioBalance(0, "syncing", CURRENCY));
-    expect(result.current).toBe(0);
+  it("returns undefined when the live balance is incomplete and no cache exists", () => {
+    const { result } = renderHook(() =>
+      usePersistedPortfolioBalance(1500, "syncing", CURRENCY, false),
+    );
+    expect(result.current).toBeUndefined();
   });
 
-  it("returns 0 after sync completes even if cache has a stale non-zero value", () => {
+  it("does not restore a cached value after an incomplete sync settles", () => {
     store[KEY] = 3000;
-    const { result } = renderHook(() => usePersistedPortfolioBalance(0, "synced", CURRENCY));
+    const { result } = renderHook(() =>
+      usePersistedPortfolioBalance(1500, "synced", CURRENCY, false),
+    );
+    expect(result.current).toBeUndefined();
+  });
+
+  it("recognizes a cached zero as a valid complete value", () => {
+    store[KEY] = 0;
+    const { result } = renderHook(() =>
+      usePersistedPortfolioBalance(1500, "syncing", CURRENCY, false),
+    );
     expect(result.current).toBe(0);
   });
 
   it("persists balance on synced, including zero (authoritative empty portfolio)", () => {
     const { rerender } = renderHook(
       ({ balance, phase }: { balance: number; phase: SyncPhase }) =>
-        usePersistedPortfolioBalance(balance, phase, CURRENCY),
+        usePersistedPortfolioBalance(balance, phase, CURRENCY, true),
       { initialProps: { balance: 2500, phase: "syncing" as SyncPhase } },
     );
 
@@ -66,16 +85,22 @@ describe("usePersistedPortfolioBalance", () => {
     expect(store[KEY]).toBe(0);
   });
 
-  it("does not persist when syncPhase is failed", () => {
+  it("does not persist an incomplete balance", () => {
     store[KEY] = 3000;
     const { rerender } = renderHook(
-      ({ balance, phase }: { balance: number; phase: SyncPhase }) =>
-        usePersistedPortfolioBalance(balance, phase, CURRENCY),
-      { initialProps: { balance: 3000, phase: "syncing" as SyncPhase } },
+      ({ balance, phase, complete }: { balance: number; phase: SyncPhase; complete: boolean }) =>
+        usePersistedPortfolioBalance(balance, phase, CURRENCY, complete),
+      {
+        initialProps: {
+          balance: 3000,
+          phase: "syncing" as SyncPhase,
+          complete: false,
+        },
+      },
     );
 
-    act(() => rerender({ balance: 1234, phase: "failed" }));
-    expect(store[KEY]).toBe(3000); // stale cache untouched
+    act(() => rerender({ balance: 1234, phase: "synced", complete: false }));
+    expect(store[KEY]).toBe(3000);
   });
 
   it("reloads cached value from MMKV when currency switches", () => {
@@ -83,7 +108,8 @@ describe("usePersistedPortfolioBalance", () => {
     store[`portfolioLastKnownBalance_EUR`] = 900;
 
     const { result, rerender } = renderHook(
-      ({ currency }: { currency: string }) => usePersistedPortfolioBalance(0, "syncing", currency),
+      ({ currency }: { currency: string }) =>
+        usePersistedPortfolioBalance(0, "syncing", currency, false),
       { initialProps: { currency: "USD" } },
     );
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/usePortfolioBalanceSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/__tests__/usePortfolioBalanceSectionViewModel.test.ts
@@ -5,7 +5,12 @@ import type { SyncPhase } from "@ledgerhq/live-common/bridge/react/index";
 
 jest.mock("LLM/hooks/usePortfolioBalance");
 jest.mock("../usePersistedPortfolioBalance", () => ({
-  usePersistedPortfolioBalance: (b: number) => b,
+  usePersistedPortfolioBalance: (
+    b: number,
+    _phase: SyncPhase,
+    _currency: string,
+    complete: boolean,
+  ) => (complete ? b : undefined),
 }));
 
 const mockUsePortfolioBalance = jest.mocked(usePortfolioBalanceModule.usePortfolioBalance);
@@ -14,6 +19,7 @@ const defaultPortfolio = {
   balanceHistory: [{ date: new Date(), value: 1000 }],
   countervalueChange: { percentage: 0, value: 0 },
   balanceAvailable: true,
+  countervalueComplete: true,
   availableAccounts: [],
   unavailableCurrencies: [],
   accounts: [],
@@ -64,14 +70,20 @@ describe("usePortfolioBalanceSectionViewModel", () => {
   describe("state", () => {
     it("returns noSigner when readOnly, regardless of showAssets", () => {
       const { result } = renderHook(() =>
-        usePortfolioBalanceSectionViewModel({ showAssets: false, isReadOnlyMode: true }),
+        usePortfolioBalanceSectionViewModel({
+          showAssets: false,
+          isReadOnlyMode: true,
+        }),
       );
       expect(result.current.state).toBe("noSigner");
     });
 
     it("returns noAccounts when showAssets is false", () => {
       const { result } = renderHook(() =>
-        usePortfolioBalanceSectionViewModel({ showAssets: false, isReadOnlyMode: false }),
+        usePortfolioBalanceSectionViewModel({
+          showAssets: false,
+          isReadOnlyMode: false,
+        }),
       );
       expect(result.current.state).toBe("noAccounts");
     });
@@ -100,7 +112,10 @@ describe("usePortfolioBalanceSectionViewModel", () => {
     it("freezes while CVS is pending (iCvPending=true) and releases once CVS settles", () => {
       mockUsePortfolioBalance.mockReturnValue(
         makeReturn({
-          portfolio: { ...defaultPortfolio, balanceHistory: [{ date: new Date(), value: 1500 }] },
+          portfolio: {
+            ...defaultPortfolio,
+            balanceHistory: [{ date: new Date(), value: 1500 }],
+          },
         }),
       );
 
@@ -114,7 +129,10 @@ describe("usePortfolioBalanceSectionViewModel", () => {
         makeReturn({
           syncPhase: "syncing",
           isCvPending: true,
-          portfolio: { ...defaultPortfolio, balanceHistory: [{ date: new Date(), value: 2000 }] },
+          portfolio: {
+            ...defaultPortfolio,
+            balanceHistory: [{ date: new Date(), value: 2000 }],
+          },
         }),
       );
       rerender({});
@@ -127,6 +145,7 @@ describe("usePortfolioBalanceSectionViewModel", () => {
       const emptyPortfolio = {
         ...defaultPortfolio,
         balanceHistory: [{ date: new Date(), value: 0 }],
+        countervalueComplete: false,
       };
 
       mockUsePortfolioBalance.mockReturnValue(
@@ -155,7 +174,11 @@ describe("usePortfolioBalanceSectionViewModel", () => {
       expect(result.current.isBalanceAvailable).toBe(false);
 
       mockUsePortfolioBalance.mockReturnValue(
-        makeReturn({ balanceAvailable: true, syncPhase: "synced", portfolio: emptyPortfolio }),
+        makeReturn({
+          balanceAvailable: true,
+          syncPhase: "synced",
+          portfolio: { ...emptyPortfolio, countervalueComplete: true },
+        }),
       );
       rerender({});
       expect(result.current.isBalanceAvailable).toBe(true);
@@ -172,5 +195,20 @@ describe("usePortfolioBalanceSectionViewModel", () => {
       // so effectiveRawBalanceAvailable = true and balanceAvailable starts as true.
       expect(result.current.isBalanceAvailable).toBe(true);
     });
+  });
+
+  it("marks a settled partial valuation as incomplete without keeping it loading", () => {
+    mockUsePortfolioBalance.mockReturnValue(
+      makeReturn({
+        syncPhase: "synced",
+        portfolio: { ...defaultPortfolio, countervalueComplete: false },
+      }),
+    );
+
+    const { result } = renderHook(() => usePortfolioBalanceSectionViewModel(defaultProps));
+
+    expect(result.current.isCountervalueComplete).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isAnalyticPillVisible).toBe(false);
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/types.ts
@@ -14,6 +14,7 @@ export interface PortfolioBalanceSectionViewProps {
   readonly countervalueChange: ValueChange;
   readonly unit: Unit;
   readonly isBalanceAvailable: boolean;
+  readonly isCountervalueComplete: boolean;
   readonly isAnalyticPillVisible: boolean;
   readonly isLoading: boolean;
   readonly onToggleDiscreetMode: () => void;

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/usePersistedPortfolioBalance.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/usePersistedPortfolioBalance.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { mmkv } from "LLM/storage/mmkvStorageWrapper";
 import type { SyncPhase } from "@ledgerhq/live-common/bridge/react/index";
 
@@ -20,24 +20,21 @@ export function usePersistedPortfolioBalance(
   latestBalance: number,
   syncPhase: SyncPhase,
   currencyCode: string,
-): number {
+  countervalueComplete: boolean,
+): number | undefined {
   const key = `${PORTFOLIO_BALANCE_KEY}_${currencyCode}`;
-  const persistedRef = useRef<number>(mmkv.getNumber(key) ?? 0);
-
-  // When the countervalue currency changes at runtime, reload the cached value for the new currency.
-  const prevKeyRef = useRef(key);
-  if (prevKeyRef.current !== key) {
-    prevKeyRef.current = key;
-    persistedRef.current = mmkv.getNumber(key) ?? 0;
-  }
+  const persistedExists = mmkv.contains(key);
+  const persistedValue = mmkv.getNumber(key) ?? 0;
 
   useEffect(() => {
-    if (syncPhase === "synced") {
+    if (syncPhase === "synced" && countervalueComplete) {
       mmkv.set(key, latestBalance);
-      persistedRef.current = latestBalance;
     }
-  }, [key, syncPhase, latestBalance]);
+  }, [key, syncPhase, latestBalance, countervalueComplete]);
 
-  // Only substitute during syncing — once sync settles the real balance (even $0) is authoritative.
-  return syncPhase === "syncing" ? latestBalance || persistedRef.current : latestBalance;
+  if (countervalueComplete) return latestBalance;
+  if (syncPhase === "syncing" && persistedExists) {
+    return persistedValue;
+  }
+  return undefined;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/usePortfolioBalanceSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSection/usePortfolioBalanceSectionViewModel.ts
@@ -18,12 +18,7 @@ export const usePortfolioBalanceSectionViewModel = ({
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   const { toggleDiscreetMode } = useToggleDiscreetMode();
 
-  const {
-    portfolio,
-    balanceAvailable: rawBalanceAvailable,
-    syncPhase,
-    isCvPending,
-  } = usePortfolioBalance();
+  const { portfolio, syncPhase, isCvPending } = usePortfolioBalance();
 
   const { countervalueChange, balanceHistory } = portfolio;
   const lastItem = balanceHistory[balanceHistory.length - 1];
@@ -34,11 +29,11 @@ export const usePortfolioBalanceSectionViewModel = ({
     latestBalance,
     syncPhase,
     counterValueCurrency.ticker,
+    portfolio.countervalueComplete,
   );
 
-  // If MMKV has a cached balance from a previous session, treat it as available
-  // immediately so the cached value is shown at cold start instead of a skeleton.
-  const effectiveRawBalanceAvailable = rawBalanceAvailable || effectiveLatestBalance > 0;
+  const isCountervalueComplete = portfolio.countervalueComplete;
+  const effectiveRawBalanceAvailable = effectiveLatestBalance !== undefined;
 
   const {
     balanceAvailable,
@@ -47,7 +42,7 @@ export const usePortfolioBalanceSectionViewModel = ({
   } = useBalanceSyncState({
     rawBalanceAvailable: effectiveRawBalanceAvailable,
     syncPhase,
-    latestBalance: effectiveLatestBalance,
+    latestBalance: effectiveLatestBalance ?? 0,
     shouldFreezeOnSync: true,
     cvPending: isCvPending,
   });
@@ -62,7 +57,8 @@ export const usePortfolioBalanceSectionViewModel = ({
     return "normal";
   }, [isReadOnlyMode, showAssets]);
 
-  const isAnalyticPillVisible = state === "normal" && (balanceAvailable || effectiveIsLoading);
+  const isAnalyticPillVisible =
+    state === "normal" && isCountervalueComplete && (balanceAvailable || effectiveIsLoading);
 
   return {
     state,
@@ -70,6 +66,7 @@ export const usePortfolioBalanceSectionViewModel = ({
     countervalueChange,
     unit,
     isBalanceAvailable: balanceAvailable,
+    isCountervalueComplete,
     isAnalyticPillVisible,
     isLoading: effectiveIsLoading,
     onToggleDiscreetMode: toggleDiscreetMode,

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSync/__tests__/PortfolioBalanceSync.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSync/__tests__/PortfolioBalanceSync.test.tsx
@@ -8,7 +8,12 @@ import { INITIAL_STATE } from "~/reducers/portfolioBalanceDisplay";
 
 jest.mock("LLM/hooks/usePortfolioBalance");
 jest.mock("../../PortfolioBalanceSection/usePersistedPortfolioBalance", () => ({
-  usePersistedPortfolioBalance: (b: number) => b,
+  usePersistedPortfolioBalance: (
+    b: number,
+    _phase: SyncPhase,
+    _currency: string,
+    complete: boolean,
+  ) => (complete ? b : undefined),
 }));
 
 const mockUsePortfolioBalance = jest.mocked(usePortfolioBalanceModule.usePortfolioBalance);
@@ -17,6 +22,7 @@ const defaultPortfolio = {
   balanceHistory: [{ date: new Date(), value: 5000 }],
   countervalueChange: { percentage: 0, value: 0 },
   balanceAvailable: true,
+  countervalueComplete: true,
   availableAccounts: [],
   unavailableCurrencies: [],
   accounts: [],
@@ -31,6 +37,7 @@ function makeReturn(
     balanceAvailable: boolean;
     syncPhase: SyncPhase;
     isCvPending: boolean;
+    portfolio: typeof defaultPortfolio;
   }> = {},
 ) {
   return {
@@ -72,6 +79,7 @@ describe("PortfolioBalanceSync", () => {
 
     expect(state.portfolioBalanceDisplay.displayedBalance).toBe(5000);
     expect(state.portfolioBalanceDisplay.isBalanceAvailable).toBe(true);
+    expect(state.portfolioBalanceDisplay.isCountervalueComplete).toBe(true);
   });
 
   it("sets isLoading true while CVS is pending", () => {
@@ -98,7 +106,11 @@ describe("PortfolioBalanceSync", () => {
     // No cached MMKV balance (mock returns 0) and portfolio not yet available
     mockUsePortfolioBalance.mockReturnValue({
       ...makeReturn({ balanceAvailable: false, syncPhase: "syncing" }),
-      portfolio: { ...defaultPortfolio, balanceHistory: [{ date: new Date(), value: 0 }] },
+      portfolio: {
+        ...defaultPortfolio,
+        balanceHistory: [{ date: new Date(), value: 0 }],
+        countervalueComplete: false,
+      },
     });
 
     const { store } = render(<PortfolioBalanceSync />, {
@@ -112,5 +124,6 @@ describe("PortfolioBalanceSync", () => {
     // effectiveLatestBalance = 0 (mocked pass-through) → effectiveRawBalanceAvailable = false
     // useBalanceSyncState gates availability until sync settles
     expect(storeState.portfolioBalanceDisplay.isBalanceAvailable).toBe(false);
+    expect(storeState.portfolioBalanceDisplay.isCountervalueComplete).toBe(false);
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSync/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBalanceSync/index.tsx
@@ -24,12 +24,7 @@ export function PortfolioBalanceSync(): null {
   const dispatch = useDispatch();
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
 
-  const {
-    portfolio,
-    balanceAvailable: rawBalanceAvailable,
-    syncPhase,
-    isCvPending,
-  } = usePortfolioBalance();
+  const { portfolio, syncPhase, isCvPending } = usePortfolioBalance();
 
   const lastItem = portfolio.balanceHistory[portfolio.balanceHistory.length - 1];
   const latestBalance = lastItem?.value ?? 0;
@@ -38,14 +33,16 @@ export function PortfolioBalanceSync(): null {
     latestBalance,
     syncPhase,
     counterValueCurrency.ticker,
+    portfolio.countervalueComplete,
   );
 
-  const effectiveRawBalanceAvailable = rawBalanceAvailable || effectiveLatestBalance > 0;
+  const isCountervalueComplete = portfolio.countervalueComplete;
+  const effectiveRawBalanceAvailable = effectiveLatestBalance !== undefined;
 
   const { balanceAvailable, displayedBalance, isLoading } = useBalanceSyncState({
     rawBalanceAvailable: effectiveRawBalanceAvailable,
     syncPhase,
-    latestBalance: effectiveLatestBalance,
+    latestBalance: effectiveLatestBalance ?? 0,
     shouldFreezeOnSync: true,
     cvPending: isCvPending,
   });
@@ -56,9 +53,10 @@ export function PortfolioBalanceSync(): null {
         displayedBalance,
         isLoading,
         isBalanceAvailable: balanceAvailable,
+        isCountervalueComplete,
       }),
     );
-  }, [displayedBalance, isLoading, balanceAvailable, dispatch]);
+  }, [displayedBalance, isLoading, balanceAvailable, isCountervalueComplete, dispatch]);
 
   return null;
 }

--- a/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/usePortfolioBalanceForDisplay.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/usePortfolioBalanceForDisplay.test.ts
@@ -10,6 +10,7 @@ describe("usePortfolioBalanceForDisplay", () => {
     expect(result.current.displayedBalance).toBe(0);
     expect(result.current.isLoading).toBe(false);
     expect(result.current.isBalanceAvailable).toBe(false);
+    expect(result.current.isCountervalueComplete).toBe(false);
   });
 
   it("reflects displayedBalance from the slice", () => {
@@ -20,12 +21,14 @@ describe("usePortfolioBalanceForDisplay", () => {
           ...portfolioBalanceDisplayInitialState,
           displayedBalance: 98765,
           isBalanceAvailable: true,
+          isCountervalueComplete: true,
         },
       }),
     });
 
     expect(result.current.displayedBalance).toBe(98765);
     expect(result.current.isBalanceAvailable).toBe(true);
+    expect(result.current.isCountervalueComplete).toBe(true);
   });
 
   it("reflects isLoading from the slice", () => {

--- a/apps/ledger-live-mobile/src/mvvm/hooks/usePortfolioBalanceForDisplay.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/usePortfolioBalanceForDisplay.ts
@@ -12,7 +12,7 @@ import { selectPortfolioBalanceDisplay } from "~/reducers/portfolioBalanceDispla
  */
 export function usePortfolioBalanceForDisplay() {
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
-  const { displayedBalance, isLoading, isBalanceAvailable } = useSelector(
+  const { displayedBalance, isLoading, isBalanceAvailable, isCountervalueComplete } = useSelector(
     selectPortfolioBalanceDisplay,
   );
 
@@ -20,6 +20,7 @@ export function usePortfolioBalanceForDisplay() {
     displayedBalance,
     isLoading,
     isBalanceAvailable,
+    isCountervalueComplete,
     unit: counterValueCurrency.units[0],
   };
 }

--- a/apps/ledger-live-mobile/src/reducers/__tests__/portfolioBalanceDisplay.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/__tests__/portfolioBalanceDisplay.test.ts
@@ -11,21 +11,36 @@ describe("portfolioBalanceDisplay reducer", () => {
   });
 
   it("setPortfolioBalanceDisplay updates all fields", () => {
-    const payload = { displayedBalance: 42000, isLoading: true, isBalanceAvailable: true };
+    const payload = {
+      displayedBalance: 42000,
+      isLoading: true,
+      isBalanceAvailable: true,
+      isCountervalueComplete: true,
+    };
     const state = reducer(INITIAL_STATE, setPortfolioBalanceDisplay(payload));
 
     expect(state).toEqual(payload);
   });
 
   it("setPortfolioBalanceDisplay with isLoading false and balance unavailable", () => {
-    const payload = { displayedBalance: 0, isLoading: false, isBalanceAvailable: false };
+    const payload = {
+      displayedBalance: 0,
+      isLoading: false,
+      isBalanceAvailable: false,
+      isCountervalueComplete: false,
+    };
     const state = reducer(INITIAL_STATE, setPortfolioBalanceDisplay(payload));
 
     expect(state).toEqual(payload);
   });
 
   it("does not mutate initial state", () => {
-    const payload = { displayedBalance: 999, isLoading: false, isBalanceAvailable: true };
+    const payload = {
+      displayedBalance: 999,
+      isLoading: false,
+      isBalanceAvailable: true,
+      isCountervalueComplete: true,
+    };
     reducer(INITIAL_STATE, setPortfolioBalanceDisplay(payload));
 
     expect(INITIAL_STATE.displayedBalance).toBe(0);
@@ -39,6 +54,7 @@ describe("selectPortfolioBalanceDisplay", () => {
         displayedBalance: 12345,
         isLoading: false,
         isBalanceAvailable: true,
+        isCountervalueComplete: true,
       },
     } as unknown as State;
 
@@ -46,6 +62,7 @@ describe("selectPortfolioBalanceDisplay", () => {
       displayedBalance: 12345,
       isLoading: false,
       isBalanceAvailable: true,
+      isCountervalueComplete: true,
     });
   });
 

--- a/apps/ledger-live-mobile/src/reducers/portfolioBalanceDisplay.ts
+++ b/apps/ledger-live-mobile/src/reducers/portfolioBalanceDisplay.ts
@@ -5,12 +5,14 @@ export interface PortfolioBalanceDisplayState {
   displayedBalance: number;
   isLoading: boolean;
   isBalanceAvailable: boolean;
+  isCountervalueComplete: boolean;
 }
 
 export const INITIAL_STATE: PortfolioBalanceDisplayState = {
   displayedBalance: 0,
   isLoading: false,
   isBalanceAvailable: false,
+  isCountervalueComplete: false,
 };
 
 const portfolioBalanceDisplaySlice = createSlice({
@@ -21,6 +23,7 @@ const portfolioBalanceDisplaySlice = createSlice({
       state.displayedBalance = action.payload.displayedBalance;
       state.isLoading = action.payload.isLoading;
       state.isBalanceAvailable = action.payload.isBalanceAvailable;
+      state.isCountervalueComplete = action.payload.isCountervalueComplete;
     },
   },
 });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Added integration and ViewModel coverage for Mobile portfolio balance, cached balance handling, analytics totals, allocations, charts, and PnL.
- [x] **Impact of the changes:**
      When one positive-balance asset has no current rate, Mobile portfolio and analytics show an unavailable state instead of a partial total. An incomplete total is not persisted in the Mobile cache.

### 📝 Description

Mobile Portfolio and Analytics could retain or display a partial countervalue total after synchronization, notably across a fiat currency change.

This PR consumes the shared completeness contract, prevents incomplete totals from entering the persisted balance cache, and renders unavailable totals, charts, PnL, and allocations until all required current rates are available.

This PR is stacked on the countervalue completeness core PR.

| Before                        | After                         |
|-------------------------------|-------------------------------|
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA issue**: [LIVE-36444](https://ledgerhq.atlassian.net/browse/LIVE-36444)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-36444]: https://ledgerhq.atlassian.net/browse/LIVE-36444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ