### PR TITLE
[LWM] fix(counter-values): show unavailable asset values (LIVE-36444)

### DIFF
--- a/.changeset/steady-mobile-asset-values.md
+++ b/.changeset/steady-mobile-asset-values.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Show unavailable asset, account, and address values when current countervalues are missing.

--- a/apps/ledger-live-mobile/src/components/AssetCentricGraphCard.tsx
+++ b/apps/ledger-live-mobile/src/components/AssetCentricGraphCard.tsx
@@ -64,8 +64,10 @@ function AssetCentricGraphCard({
   const { colors } = useTheme();
   const [, setTimeRange, timeRangeItems] = useTimeRange();
   const { countervalueChange, balanceHistory } = assetPortfolio;
+  const countervalueTrendComplete =
+    assetPortfolio.countervalueComplete && countervalueChange.percentage !== null;
 
-  const currencyUnitValue = balanceHistory[balanceHistory.length - 1];
+  const currencyUnitValue = balanceHistory.at(-1);
 
   const unit = counterValueCurrency.units[0];
 
@@ -78,8 +80,17 @@ function AssetCentricGraphCard({
     if (accountsEmpty) {
       return { value: 0, countervalue: 0 };
     }
-    return { value: currencyBalance, countervalue: currencyUnitValue.value };
-  }, [hoveredItem, accountsEmpty, currencyBalance, currencyUnitValue]);
+    return {
+      value: currencyBalance,
+      countervalue: assetPortfolio.countervalueComplete ? currencyUnitValue?.value : undefined,
+    };
+  }, [
+    hoveredItem,
+    accountsEmpty,
+    currencyBalance,
+    currencyUnitValue,
+    assetPortfolio.countervalueComplete,
+  ]);
 
   const items = [
     {
@@ -106,7 +117,7 @@ function AssetCentricGraphCard({
   const mapCounterValue = useCallback((d: Item) => d.value || 0, []);
 
   const range = assetPortfolio.range;
-  const isAvailable = assetPortfolio.balanceAvailable;
+  const isAvailable = assetPortfolio.balanceAvailable && countervalueTrendComplete;
 
   const rangesLabels = timeRangeItems.map(({ label }) => label);
 
@@ -149,7 +160,7 @@ function AssetCentricGraphCard({
             <CurrencyIcon size={32} currency={currency} />
             <Flex alignItems="center">
               <Flex>
-                {!balanceHistory ? (
+                {!assetPortfolio.balanceAvailable ? (
                   <BigPlaceholder mt="8px" />
                 ) : (
                   <Flex alignItems="center">
@@ -159,8 +170,9 @@ function AssetCentricGraphCard({
                       color={"neutral.c80"}
                       mt={3}
                       minHeight={25}
+                      testID="asset-graph-countervalue"
                     >
-                      {items[1].value ? (
+                      {items[1].value !== undefined ? (
                         <CurrencyUnitValue {...items[1]} />
                       ) : (
                         <NoCountervaluePlaceholder />
@@ -186,8 +198,12 @@ function AssetCentricGraphCard({
                 <TransactionsPendingConfirmationWarningAllAccounts />
               </Flex>
               <Flex flexDirection={"row"}>
-                {!balanceHistory ? (
+                {!assetPortfolio.balanceAvailable ? (
                   <SmallPlaceholder mt={4} />
+                ) : !countervalueTrendComplete ? (
+                  <Text color="neutral.c70" testID="asset-graph-trend-unavailable">
+                    -
+                  </Text>
                 ) : (
                   <Flex flexDirection="row" alignItems="center">
                     {hoveredItem && hoveredItem.date ? (
@@ -213,7 +229,7 @@ function AssetCentricGraphCard({
           </Flex>
         </Animated.View>
       </Flex>
-      {accountsEmpty ? null : (
+      {accountsEmpty || !countervalueTrendComplete ? null : (
         <>
           {currency.type === "TokenCurrency" && tokensWithUnsupportedGraph.includes(currency.id) ? (
             <GraphPlaceholder />

--- a/apps/ledger-live-mobile/src/components/AssetRowLayout.tsx
+++ b/apps/ledger-live-mobile/src/components/AssetRowLayout.tsx
@@ -17,6 +17,9 @@ type Props = {
   currency: Currency;
   currencyUnit?: Unit;
   countervalueChange?: ValueChange;
+  countervalue?: number;
+  countervalueUnit?: Unit;
+  countervalueUnavailable?: boolean;
   name: string;
   tag?: string | null | boolean;
   onPress?: TouchableOpacityProps["onPress"];
@@ -36,6 +39,9 @@ const AssetRowLayout = ({
   topLink,
   bottomLink,
   countervalueChange,
+  countervalue,
+  countervalueUnit,
+  countervalueUnavailable,
   tag,
 }: Props) => {
   const { colors, space } = useTheme();
@@ -81,7 +87,22 @@ const AssetRowLayout = ({
                 color="neutral.c100"
                 testID="asset-balance"
               >
-                <CounterValue currency={currency} value={balance} joinFragmentsSeparator="" />
+                {countervalueUnavailable ? (
+                  "-"
+                ) : countervalue !== undefined && countervalueUnit ? (
+                  <CurrencyUnitValue
+                    unit={countervalueUnit}
+                    value={countervalue}
+                    joinFragmentsSeparator=""
+                  />
+                ) : (
+                  <CounterValue
+                    currency={currency}
+                    value={balance}
+                    joinFragmentsSeparator=""
+                    withPlaceholder
+                  />
+                )}
               </Text>
             </Flex>
           </Flex>
@@ -91,14 +112,19 @@ const AssetRowLayout = ({
                 <CurrencyUnitValue showCode unit={currencyUnit} value={balance} />
               ) : null}
             </Text>
-            {!hideDelta && countervalueChange && (
-              <Delta
-                percent
-                show0Delta={balance.toNumber() !== 0}
-                fallbackToPercentPlaceholder
-                valueChange={countervalueChange}
-              />
-            )}
+            {!hideDelta &&
+              (countervalueChange ? (
+                <Delta
+                  percent
+                  show0Delta
+                  fallbackToPercentPlaceholder
+                  valueChange={countervalueChange}
+                />
+              ) : balance.isGreaterThan(0) ? (
+                <Text variant="body" fontWeight="medium" color="neutral.c70">
+                  -
+                </Text>
+              ) : null)}
           </Flex>
         </Flex>
       </Flex>

--- a/apps/ledger-live-mobile/src/components/CounterValue.tsx
+++ b/apps/ledger-live-mobile/src/components/CounterValue.tsx
@@ -101,13 +101,18 @@ export default function CounterValue({
     [currency, counterValueCurrency, valueProp, date],
   );
   const countervalue = useCalculate(param);
+  const resolvedCountervalue = param.value === 0 ? 0 : countervalue;
 
-  if (typeof countervalue !== "number") {
+  if (typeof resolvedCountervalue !== "number") {
     return withPlaceholder ? <NoCountervaluePlaceholder /> : null;
   }
 
   const inner = (
-    <CurrencyUnitValue {...props} unit={counterValueCurrency.units[0]} value={countervalue} />
+    <CurrencyUnitValue
+      {...props}
+      unit={counterValueCurrency.units[0]}
+      value={resolvedCountervalue}
+    />
   );
 
   if (Wrapper) {

--- a/apps/ledger-live-mobile/src/components/__tests__/AssetCentricGraphCard.test.tsx
+++ b/apps/ledger-live-mobile/src/components/__tests__/AssetCentricGraphCard.test.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { Text } from "react-native";
+import type { SharedValue } from "react-native-reanimated";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { getFiatCurrencyByTicker } from "@domain/entity-currency-fiat";
+import type { Portfolio } from "@ledgerhq/types-live";
+import { render, screen } from "@tests/test-renderer";
+import AssetCentricGraphCard from "../AssetCentricGraphCard";
+
+jest.mock("../Graph", () => () => <Text testID="asset-graph" />);
+jest.mock("../CurrencyIcon", () => () => null);
+jest.mock("../CurrencyUnitValue", () => ({ value }: { value: number }) => (
+  <Text>{String(value)}</Text>
+));
+jest.mock("../CounterValue", () => ({
+  NoCountervaluePlaceholder: () => <Text>-</Text>,
+}));
+
+const bitcoin = getCryptoCurrencyById("bitcoin");
+const usd = getFiatCurrencyByTicker("USD");
+const currentPositionY = { value: 0 } as SharedValue<number>;
+
+const makePortfolio = (overrides: Partial<Portfolio> = {}): Portfolio => ({
+  balanceHistory: [{ date: new Date("2026-08-26T00:00:00.000Z"), value: 100 }],
+  balanceAvailable: true,
+  countervalueComplete: true,
+  availableAccounts: [],
+  unavailableCurrencies: [],
+  accounts: [],
+  range: "day",
+  histories: [],
+  countervalueReceiveSum: 0,
+  countervalueSendSum: 0,
+  countervalueChange: { value: 0, percentage: 0 },
+  ...overrides,
+});
+
+const renderCard = (assetPortfolio: Portfolio, currencyBalance = 1) =>
+  render(
+    <AssetCentricGraphCard
+      assetPortfolio={assetPortfolio}
+      counterValueCurrency={usd}
+      currentPositionY={currentPositionY}
+      graphCardEndPosition={100}
+      currency={bitcoin}
+      currencyBalance={currencyBalance}
+    />,
+  );
+
+describe("AssetCentricGraphCard", () => {
+  it("keeps the crypto balance but hides fiat, trend and graph when the current rate is missing", () => {
+    renderCard(
+      makePortfolio({
+        countervalueComplete: false,
+        countervalueChange: { value: 0, percentage: null },
+      }),
+    );
+
+    expect(screen.getByTestId("asset-graph-balance")).toHaveTextContent("1");
+    expect(screen.getByTestId("asset-graph-countervalue")).toHaveTextContent("-");
+    expect(screen.getByTestId("asset-graph-trend-unavailable")).toHaveTextContent("-");
+    expect(screen.queryByTestId("asset-graph")).toBeNull();
+  });
+
+  it("renders a real zero value and a flat graph", () => {
+    renderCard(makePortfolio({ balanceHistory: [{ date: new Date(), value: 0 }] }), 0);
+
+    expect(screen.getByTestId("asset-graph-countervalue")).toHaveTextContent("0");
+    expect(screen.getByTestId("asset-graph-balance")).toHaveTextContent("0");
+    expect(screen.getByTestId("asset-graph")).toBeVisible();
+  });
+});

--- a/apps/ledger-live-mobile/src/components/__tests__/CounterValue.test.tsx
+++ b/apps/ledger-live-mobile/src/components/__tests__/CounterValue.test.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { Text } from "react-native";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { useCalculate } from "@ledgerhq/live-countervalues-react";
+import { render, screen } from "@tests/test-renderer";
+import CounterValue from "../CounterValue";
+
+jest.mock("@ledgerhq/live-countervalues-react", () => ({
+  ...jest.requireActual("@ledgerhq/live-countervalues-react"),
+  useCalculate: jest.fn(),
+  useCountervaluesPolling: () => ({ poll: jest.fn() }),
+}));
+
+jest.mock("~/actions/general", () => ({
+  useTrackingPairs: () => [],
+  addExtraSessionTrackingPair: jest.fn(),
+}));
+
+jest.mock("../CurrencyUnitValue", () => ({ value }: { value: number }) => (
+  <Text testID="countervalue-value">{String(value)}</Text>
+));
+
+describe("CounterValue", () => {
+  it("renders a real zero even when no rate is available", () => {
+    jest.mocked(useCalculate).mockReturnValue(undefined);
+
+    render(<CounterValue currency={getCryptoCurrencyById("bitcoin")} value={0} withPlaceholder />);
+
+    expect(screen.getByTestId("countervalue-value")).toHaveTextContent("0");
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/__tests__/AssetListItem.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/__tests__/AssetListItem.test.tsx
@@ -59,9 +59,10 @@ describe("AssetListItem", () => {
       expect(screen.getByText("$45.00")).toBeVisible();
     });
 
-    it("should not render the counter value when null", () => {
+    it("should render a placeholder when the counter value is null", () => {
       renderView({ formattedCounterValue: null });
       expect(screen.queryByText("$45.00")).toBeNull();
+      expect(screen.getByTestId("assetItem-Bitcoin-countervalue")).toHaveTextContent("-");
     });
 
     it("should render the delta for a positive change", () => {
@@ -74,9 +75,10 @@ describe("AssetListItem", () => {
       expect(screen.getByText(/1\.20%/)).toBeVisible();
     });
 
-    it("should not render the delta when countervalueChange is null", () => {
+    it("should render a placeholder when countervalueChange is null", () => {
       renderView({ countervalueChange: null });
       expect(screen.queryByText(/%/)).toBeNull();
+      expect(screen.getByTestId("asset-trend-unavailable")).toHaveTextContent("-");
     });
 
     it("renders the 1D price fallback through the delta when it is supplied as the change", () => {

--- a/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/__tests__/usePrecomputedAssetListData.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/__tests__/usePrecomputedAssetListData.test.ts
@@ -39,7 +39,11 @@ const mockedGetCurrencyPortfolio = jest.mocked(getCurrencyPortfolio);
 const mockedGetCurrentBalanceChange = jest.mocked(getCurrentBalanceCountervalueChange);
 const mockedFormatCurrencyUnit = jest.mocked(formatCurrencyUnit);
 
-const mockState: ReturnType<typeof useCountervaluesState> = { data: {}, status: {}, cache: {} };
+const mockState: ReturnType<typeof useCountervaluesState> = {
+  data: {},
+  status: {},
+  cache: {},
+};
 
 const makePortfolio = (percentage: number | null) =>
   ({
@@ -59,12 +63,19 @@ describe("usePrecomputedAssetListData", () => {
     mockedCalculate.mockReturnValue(5000000);
     mockedFormatCurrencyUnit.mockReturnValue("$50,000.00");
     mockedGetCurrencyPortfolio.mockReturnValue(makePortfolio(0.035));
-    mockedGetCurrentBalanceChange.mockReturnValue({ value: 0, percentage: null });
+    mockedGetCurrentBalanceChange.mockReturnValue({
+      value: 0,
+      percentage: null,
+    });
   });
 
   it("should batch-compute data with a single countervalues subscription", () => {
-    const btcAccount = genAccount("btc", { currency: getCryptoCurrencyById("bitcoin") });
-    const ethAccount = genAccount("eth", { currency: getCryptoCurrencyById("ethereum") });
+    const btcAccount = genAccount("btc", {
+      currency: getCryptoCurrencyById("bitcoin"),
+    });
+    const ethAccount = genAccount("eth", {
+      currency: getCryptoCurrencyById("ethereum"),
+    });
 
     const assets: Asset[] = [
       { ...createCryptoAsset(bitcoin, 100_000), accounts: [btcAccount] },
@@ -80,14 +91,19 @@ describe("usePrecomputedAssetListData", () => {
     const btcData = result.current.get(bitcoin.id);
     expect(btcData).toBeDefined();
     expect(btcData?.formattedCounterValue).toBe("$50,000.00");
-    expect(btcData?.countervalueChange).toEqual({ percentage: 0.035, value: 0 });
+    expect(btcData?.countervalueChange).toEqual({
+      percentage: 0.035,
+      value: 0,
+    });
 
     const ethData = result.current.get(ethereum.id);
     expect(ethData).toBeDefined();
   });
 
   it("should always pass 'day' as the range to getCurrencyPortfolio regardless of global time range", () => {
-    const btcAccount = genAccount("btc-range", { currency: getCryptoCurrencyById("bitcoin") });
+    const btcAccount = genAccount("btc-range", {
+      currency: getCryptoCurrencyById("bitcoin"),
+    });
 
     const assets: Asset[] = [{ ...createCryptoAsset(bitcoin, 100_000), accounts: [btcAccount] }];
 
@@ -191,8 +207,34 @@ describe("usePrecomputedAssetListData", () => {
     expect(mockedCalculate).toHaveBeenCalledTimes(1);
   });
 
+  it("preserves an explicitly unavailable aggregated countervalue", () => {
+    const btcAccount = genAccount("btc-incomplete", {
+      currency: getCryptoCurrencyById("bitcoin"),
+    });
+    const assets: Asset[] = [
+      {
+        ...createCryptoAsset(bitcoin, 100_000),
+        accounts: [btcAccount],
+        countervalue: undefined,
+      },
+    ];
+
+    const { result } = renderHook(() => usePrecomputedAssetListData(assets));
+
+    expect(mockedCalculate).not.toHaveBeenCalled();
+    expect(mockedGetCurrencyPortfolio).not.toHaveBeenCalled();
+    expect(result.current.get(bitcoin.id)).toEqual(
+      expect.objectContaining({
+        formattedCounterValue: null,
+        countervalueChange: null,
+      }),
+    );
+  });
+
   it("should pass through negative countervalueChange", () => {
-    const btcAccount = genAccount("btc-neg", { currency: getCryptoCurrencyById("bitcoin") });
+    const btcAccount = genAccount("btc-neg", {
+      currency: getCryptoCurrencyById("bitcoin"),
+    });
     mockedGetCurrencyPortfolio.mockReturnValue(makePortfolio(-0.012));
 
     const assets: Asset[] = [{ ...createCryptoAsset(bitcoin, 100_000), accounts: [btcAccount] }];
@@ -206,7 +248,9 @@ describe("usePrecomputedAssetListData", () => {
   });
 
   it("should pass through zero countervalueChange", () => {
-    const btcAccount = genAccount("btc-zero", { currency: getCryptoCurrencyById("bitcoin") });
+    const btcAccount = genAccount("btc-zero", {
+      currency: getCryptoCurrencyById("bitcoin"),
+    });
     mockedGetCurrencyPortfolio.mockReturnValue(makePortfolio(0));
 
     const assets: Asset[] = [{ ...createCryptoAsset(bitcoin, 100_000), accounts: [btcAccount] }];
@@ -229,9 +273,14 @@ describe("usePrecomputedAssetListData", () => {
 
   describe("1D price fallback", () => {
     it("uses the local price change for positive-balance assets when the portfolio change is unavailable", () => {
-      const btcAccount = genAccount("btc-mkt", { currency: getCryptoCurrencyById("bitcoin") });
+      const btcAccount = genAccount("btc-mkt", {
+        currency: getCryptoCurrencyById("bitcoin"),
+      });
       mockedGetCurrencyPortfolio.mockReturnValue(makePortfolio(null));
-      mockedGetCurrentBalanceChange.mockReturnValue({ value: 12, percentage: 0.012 });
+      mockedGetCurrentBalanceChange.mockReturnValue({
+        value: 12,
+        percentage: 0.012,
+      });
       const assets: Asset[] = [{ ...createCryptoAsset(bitcoin, 100_000), accounts: [btcAccount] }];
 
       const { result } = renderHook(() => usePrecomputedAssetListData(assets));
@@ -249,9 +298,14 @@ describe("usePrecomputedAssetListData", () => {
     });
 
     it("returns a zero change for zero-amount assets instead of using the local price change", () => {
-      const btcAccount = genAccount("btc-empty", { currency: getCryptoCurrencyById("bitcoin") });
+      const btcAccount = genAccount("btc-empty", {
+        currency: getCryptoCurrencyById("bitcoin"),
+      });
       mockedGetCurrencyPortfolio.mockReturnValue(makePortfolio(null));
-      mockedGetCurrentBalanceChange.mockReturnValue({ value: -12, percentage: -0.0159 });
+      mockedGetCurrentBalanceChange.mockReturnValue({
+        value: -12,
+        percentage: -0.0159,
+      });
       const assets: Asset[] = [{ ...createCryptoAsset(bitcoin, 0), accounts: [btcAccount] }];
 
       const { result } = renderHook(() => usePrecomputedAssetListData(assets));
@@ -264,27 +318,29 @@ describe("usePrecomputedAssetListData", () => {
       });
     });
 
-    it("returns a zero change for positive-amount assets with a zero countervalue", () => {
+    it("returns an unavailable change for positive-amount assets with a zero countervalue", () => {
       const btcAccount = genAccount("btc-zero-countervalue", {
         currency: getCryptoCurrencyById("bitcoin"),
       });
       mockedCalculate.mockReturnValue(0);
       mockedGetCurrencyPortfolio.mockReturnValue(makePortfolio(null));
-      mockedGetCurrentBalanceChange.mockReturnValue({ value: -12, percentage: -0.0159 });
+      mockedGetCurrentBalanceChange.mockReturnValue({
+        value: -12,
+        percentage: -0.0159,
+      });
       const assets: Asset[] = [{ ...createCryptoAsset(bitcoin, 1), accounts: [btcAccount] }];
 
       const { result } = renderHook(() => usePrecomputedAssetListData(assets));
 
       expect(mockedGetCurrencyPortfolio).not.toHaveBeenCalled();
       expect(mockedGetCurrentBalanceChange).not.toHaveBeenCalled();
-      expect(result.current.get(bitcoin.id)?.countervalueChange).toEqual({
-        value: 0,
-        percentage: 0,
-      });
+      expect(result.current.get(bitcoin.id)?.countervalueChange).toBeNull();
     });
 
     it("keeps the portfolio change when it is available", () => {
-      const btcAccount = genAccount("btc-held", { currency: getCryptoCurrencyById("bitcoin") });
+      const btcAccount = genAccount("btc-held", {
+        currency: getCryptoCurrencyById("bitcoin"),
+      });
       mockedGetCurrencyPortfolio.mockReturnValue(makePortfolio(0.035));
       const assets: Asset[] = [{ ...createCryptoAsset(bitcoin, 100_000), accounts: [btcAccount] }];
 

--- a/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/components/AssetListItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/components/AssetListItem.tsx
@@ -59,16 +59,14 @@ const PortfolioRow = memo(({ asset, onPress, precomputed, lx, hideNetwork }: Por
       </ListItemLeading>
       <ListItemTrailing>
         <Box lx={trailingStyle}>
-          {formattedCounterValue != null && (
-            <Text
-              typography="body2SemiBold"
-              lx={{ color: "base" }}
-              testID={`assetItem-${asset.currency.name}-countervalue`}
-            >
-              {formattedCounterValue}
-            </Text>
-          )}
-          {countervalueChange && (
+          <Text
+            typography="body2SemiBold"
+            lx={{ color: "base" }}
+            testID={`assetItem-${asset.currency.name}-countervalue`}
+          >
+            {formattedCounterValue ?? "-"}
+          </Text>
+          {countervalueChange ? (
             <Delta
               valueChange={countervalueChange}
               percent
@@ -76,6 +74,10 @@ const PortfolioRow = memo(({ asset, onPress, precomputed, lx, hideNetwork }: Por
               fallbackToPercentPlaceholder
               isArrowDisplayed
             />
+          ) : (
+            <Text typography="body3" lx={{ color: "muted" }} testID="asset-trend-unavailable">
+              -
+            </Text>
           )}
         </Box>
       </ListItemTrailing>

--- a/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/usePrecomputedAssetListData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/AssetListItem/usePrecomputedAssetListData.ts
@@ -51,8 +51,11 @@ function getCounterValue(
     return 0;
   }
 
-  if (asset.countervalue !== undefined) {
-    return asset.countervalue;
+  // Aggregated assets deliberately expose an explicit `undefined` when one of
+  // their positive-balance networks has no current rate. Do not recompute a
+  // partial value from the representative currency in that case.
+  if ("countervalue" in asset) {
+    return asset.countervalue ?? null;
   }
 
   const cv = calculate(cvState, {
@@ -82,9 +85,10 @@ function getCountervalueChange(
   currentCounterValue: number | null,
 ): ValueChange | null {
   if (asset.isPlaceholder || asset.accounts.length === 0) return null;
-  if (asset.amount <= 0 || (currentCounterValue != null && currentCounterValue <= 0)) {
+  if (asset.amount <= 0) {
     return { value: 0, percentage: 0 };
   }
+  if (currentCounterValue == null || currentCounterValue <= 0) return null;
 
   const { countervalueChange } = getCurrencyPortfolio(
     asset.accounts,
@@ -109,7 +113,11 @@ function getCountervalueChange(
 
 function computeAssetItemData(asset: Asset, state: SharedState): AssetListItemViewModelResult {
   const balance = BigNumber(asset.amount);
-  const fmtOpts: FmtOpts = { locale: state.locale, showCode: true, discreet: state.discreet };
+  const fmtOpts: FmtOpts = {
+    locale: state.locale,
+    showCode: true,
+    discreet: state.discreet,
+  };
 
   const unit = asset.currency.units?.[0];
   const formattedBalance = unit ? formatCurrencyUnit(unit, balance, fmtOpts) : "";

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/components/AllAddressesDrawer.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/Addresses/components/AllAddressesDrawer.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useMemo } from "react";
 import { ListRenderItemInfo } from "react-native";
-import BigNumber from "bignumber.js";
 import { Account } from "@ledgerhq/types-live";
 import { BottomSheetFlatList, BottomSheetHeader } from "@ledgerhq/lumen-ui-rnative";
 import type { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
@@ -39,7 +38,7 @@ export function AllAddressesDrawer({ isOpen, onClose, accountIds }: Props) {
       return (
         <CryptoAddressesListItem
           account={item}
-          aggregatedCountervalue={data?.countervalue ?? new BigNumber(0)}
+          aggregatedCountervalue={data?.countervalue}
           subAccountsCount={data?.subAccountsCount ?? 0}
           onPress={handleAccountPress}
           lx={LIST_ITEM_NEGATIVE_OFFSET}

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/TotalBalanceView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/TotalBalanceView.tsx
@@ -29,13 +29,21 @@ export function TotalBalanceView({
         <Text typography="body3" lx={{ color: "muted" }}>
           {t("assetDetail.balanceDetails.totalBalance")}
         </Text>
-        {counterValue != null && (
+        {counterValue != null ? (
           <AmountDisplay
             value={counterValue}
             formatter={counterValueFormatter}
             hidden={discreet}
             size="sm"
           />
+        ) : (
+          <Text
+            typography="heading3SemiBold"
+            lx={{ color: "base" }}
+            testID="asset-total-unavailable"
+          >
+            -
+          </Text>
         )}
         <Text
           typography="body3"

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/__tests__/TotalBalanceView.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/__tests__/TotalBalanceView.test.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { TotalBalanceView } from "../TotalBalanceView";
+
+const baseProps = {
+  discreet: false,
+  counterValueFormatter: jest.fn(),
+  formattedTotalBalance: "1 BTC",
+  onTransferPress: jest.fn(),
+};
+
+describe("TotalBalanceView", () => {
+  it("shows unavailable fiat while keeping the crypto balance visible", () => {
+    render(<TotalBalanceView {...baseProps} counterValue={undefined} />);
+
+    expect(screen.getByTestId("asset-total-unavailable")).toHaveTextContent("-");
+    expect(screen.getByText("1 BTC")).toBeVisible();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/__tests__/useBalanceDetailsViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/__tests__/useBalanceDetailsViewModel.test.ts
@@ -96,6 +96,21 @@ describe("useBalanceDetailsViewModel", () => {
     expect(result.current.formattedTotalBalance.length).toBeGreaterThan(0);
   });
 
+  it("keeps the fiat total unavailable when the distribution has no countervalue", () => {
+    const btcAccount = genAccount("bitcoin-missing-rate", {
+      currency: mockBtcCryptoCurrency,
+      operationsSize: 0,
+    });
+    btcAccount.balance = new BigNumber(1_000_000_000);
+    const item = buildDistributionItem(mockBtcCryptoCurrency, [btcAccount]);
+    item.countervalue = undefined;
+
+    const { result } = renderHook(() => useBalanceDetailsViewModel(mockBtcCryptoCurrency, item));
+
+    expect(result.current.counterValue).toBeUndefined();
+    expect(result.current.formattedTotalBalance.length).toBeGreaterThan(0);
+  });
+
   it("sums balances across sibling networks via the aggregated distributionItem", () => {
     const algorandCurrency = getCryptoCurrencyById("algorand");
     const usdtEthToken: TokenCurrency = {
@@ -339,7 +354,9 @@ describe("useBalanceDetailsViewModel", () => {
 
       act(() => result.current.onTransferPress());
 
-      expect(mockOpenDrawer).toHaveBeenCalledWith({ sourceScreenName: "Asset Detail" });
+      expect(mockOpenDrawer).toHaveBeenCalledWith({
+        sourceScreenName: "Asset Detail",
+      });
       expect(track).toHaveBeenCalledWith("button_clicked", {
         button: "transfer",
         currency: "bitcoin",

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/useBalanceDetailsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/BalanceDetails/useBalanceDetailsViewModel.ts
@@ -67,7 +67,7 @@ export function useBalanceDetailsViewModel(
 
   const counterValueUnit = counterValueCurrency.units[0];
 
-  const counterValue = hasAccounts ? (distributionItem?.countervalue ?? 0) : undefined;
+  const counterValue = hasAccounts ? distributionItem?.countervalue : undefined;
 
   const counterValueFormatter = useCallback(
     (value: number): FormattedValue =>
@@ -100,7 +100,10 @@ export function useBalanceDetailsViewModel(
           showCode: true,
           discreet,
         }),
-        formattedDeposit: formatCurrencyUnit(unit, earnDeposit, { showCode: true, discreet }),
+        formattedDeposit: formatCurrencyUnit(unit, earnDeposit, {
+          showCode: true,
+          discreet,
+        }),
       };
     }
 

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/index.tsx
@@ -22,7 +22,12 @@ export function PnLSection({ distributionItem, isLoading }: Props) {
     return <SectionSkeleton rows={1} rowHeight="s56" />;
   }
 
-  if (!enabled || !distributionItem) return null;
+  if (
+    !enabled ||
+    !distributionItem ||
+    (distributionItem.amount > 0 && distributionItem.countervalue == null)
+  )
+    return null;
 
   return <PnLSectionContent distributionItem={distributionItem} enabled={enabled} />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/components/CryptoAddressesListItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/components/CryptoAddressesListItem.tsx
@@ -21,7 +21,7 @@ import { useTranslation } from "~/context/Locale";
 
 type Props = Readonly<{
   account: Account;
-  aggregatedCountervalue: BigNumber;
+  aggregatedCountervalue?: BigNumber;
   subAccountsCount: number;
   onPress: (account: Account) => void;
   lx?: LumenViewStyle;
@@ -41,11 +41,13 @@ export default function CryptoAddressesListItem({
 
   const handlePress = useCallback(() => onPress(account), [account, onPress]);
 
-  const formattedBalance = formatCurrencyUnit(
-    counterValueCurrency.units[0],
-    aggregatedCountervalue,
-    { showCode: true, locale, discreet },
-  );
+  const formattedBalance = aggregatedCountervalue
+    ? formatCurrencyUnit(counterValueCurrency.units[0], aggregatedCountervalue, {
+        showCode: true,
+        locale,
+        discreet,
+      })
+    : "-";
 
   const displayedAssetsCount = subAccountsCount + 1;
 

--- a/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/components/__tests__/CryptoAddressesListItem.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/components/__tests__/CryptoAddressesListItem.test.tsx
@@ -90,4 +90,17 @@ describe("CryptoAddressesListItem", () => {
 
     expect(screen.getByTestId("assets-count")).toHaveTextContent("4 assets");
   });
+
+  it("shows unavailable when the aggregated countervalue is incomplete", () => {
+    render(
+      <CryptoAddressesListItem
+        account={mockAccount}
+        aggregatedCountervalue={undefined}
+        subAccountsCount={0}
+        onPress={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText("-")).toBeVisible();
+  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/CryptoAddresses/screens/CryptoAddressesScreen/index.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useMemo } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { FlashList, FlashListProps, ListRenderItemInfo } from "@shopify/flash-list";
 import { Account } from "@ledgerhq/types-live";
-import BigNumber from "bignumber.js";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { TrackScreen } from "~/analytics";
@@ -50,7 +49,7 @@ function CryptoAddressesView({
       return (
         <CryptoAddressesListItem
           account={item}
-          aggregatedCountervalue={data?.countervalue ?? new BigNumber(0)}
+          aggregatedCountervalue={data?.countervalue}
           subAccountsCount={data?.subAccountsCount ?? 0}
           onPress={onAccountPress}
         />

--- a/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useCategorizedAssetsFromPortfolio.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useCategorizedAssetsFromPortfolio.test.ts
@@ -55,7 +55,12 @@ const makeItem = (name: string, id: string, type: "CryptoCurrency" | "TokenCurre
 describe("useCategorizedAssetsFromPortfolio", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseDistribution.mockReturnValue({ isAvailable: true, list: [], isLoading: false });
+    mockUseDistribution.mockReturnValue({
+      isAvailable: true,
+      countervalueComplete: true,
+      list: [],
+      isLoading: false,
+    });
     mockUseStablecoinTickers.mockReturnValue({
       tickers: new Set<string>(),
       isLoading: false,
@@ -73,9 +78,14 @@ describe("useCategorizedAssetsFromPortfolio", () => {
     it("removes blacklisted CryptoCurrency parents from cryptos", () => {
       const btc = makeItem("Bitcoin", "bitcoin", "CryptoCurrency");
       const eth = makeItem("Ethereum", "ethereum", "CryptoCurrency");
-      mockUseCategorizedAssets.mockReturnValue({ cryptos: [btc, eth], stablecoins: [] });
+      mockUseCategorizedAssets.mockReturnValue({
+        cryptos: [btc, eth],
+        stablecoins: [],
+      });
 
-      const { result } = renderCategorized({ blacklistedTokenIds: ["ethereum"] });
+      const { result } = renderCategorized({
+        blacklistedTokenIds: ["ethereum"],
+      });
 
       expect(result.current.categorizedAssets.cryptos).toHaveLength(1);
       expect(result.current.categorizedAssets.cryptos[0].currency.id).toBe("bitcoin");
@@ -84,9 +94,14 @@ describe("useCategorizedAssetsFromPortfolio", () => {
     it("removes blacklisted TokenCurrency entries from stablecoins", () => {
       const usdc = makeItem("USDC", "usdc-token", "TokenCurrency");
       const usdt = makeItem("USDT", "usdt-token", "TokenCurrency");
-      mockUseCategorizedAssets.mockReturnValue({ cryptos: [], stablecoins: [usdc, usdt] });
+      mockUseCategorizedAssets.mockReturnValue({
+        cryptos: [],
+        stablecoins: [usdc, usdt],
+      });
 
-      const { result } = renderCategorized({ blacklistedTokenIds: ["usdc-token"] });
+      const { result } = renderCategorized({
+        blacklistedTokenIds: ["usdc-token"],
+      });
 
       expect(result.current.categorizedAssets.stablecoins).toHaveLength(1);
       expect(result.current.categorizedAssets.stablecoins[0].currency.id).toBe("usdt-token");
@@ -95,7 +110,10 @@ describe("useCategorizedAssetsFromPortfolio", () => {
     it("keeps cryptos and stablecoins when no token is blacklisted", () => {
       const btc = makeItem("Bitcoin", "bitcoin", "CryptoCurrency");
       const usdc = makeItem("USDC", "usdc-token", "TokenCurrency");
-      mockUseCategorizedAssets.mockReturnValue({ cryptos: [btc], stablecoins: [usdc] });
+      mockUseCategorizedAssets.mockReturnValue({
+        cryptos: [btc],
+        stablecoins: [usdc],
+      });
 
       const { result } = renderCategorized();
 
@@ -111,7 +129,10 @@ describe("useCategorizedAssetsFromPortfolio", () => {
     it("moves held stocks out of cryptos by DADA currency id", () => {
       const btc = makeItem("Bitcoin", "bitcoin", "CryptoCurrency");
       const aapl = makeItem("Apple xStock", "aapl-x", "TokenCurrency");
-      mockUseCategorizedAssets.mockReturnValue({ cryptos: [btc, aapl], stablecoins: [] });
+      mockUseCategorizedAssets.mockReturnValue({
+        cryptos: [btc, aapl],
+        stablecoins: [],
+      });
       mockUseStockAssetIds.mockReturnValue({
         ids: new Set(["aapl-x"]),
         isLoading: false,
@@ -126,7 +147,10 @@ describe("useCategorizedAssetsFromPortfolio", () => {
 
     it("does not miscategorize a crypto whose ticker collides with a stock symbol", () => {
       const ton = makeItem("Toncoin", "ton", "CryptoCurrency");
-      mockUseCategorizedAssets.mockReturnValue({ cryptos: [ton], stablecoins: [] });
+      mockUseCategorizedAssets.mockReturnValue({
+        cryptos: [ton],
+        stablecoins: [],
+      });
       mockUseStockAssetIds.mockReturnValue({
         ids: new Set(["some-tokenized-stock"]),
         isLoading: false,
@@ -141,7 +165,10 @@ describe("useCategorizedAssetsFromPortfolio", () => {
 
     it("leaves cryptos untouched and stocks empty when no id matches", () => {
       const btc = makeItem("Bitcoin", "bitcoin", "CryptoCurrency");
-      mockUseCategorizedAssets.mockReturnValue({ cryptos: [btc], stablecoins: [] });
+      mockUseCategorizedAssets.mockReturnValue({
+        cryptos: [btc],
+        stablecoins: [],
+      });
 
       const { result } = renderCategorized();
 
@@ -152,7 +179,10 @@ describe("useCategorizedAssetsFromPortfolio", () => {
     it("keeps stocks under cryptos when assetDiscoverability is off", () => {
       const btc = makeItem("Bitcoin", "bitcoin", "CryptoCurrency");
       const aapl = makeItem("Apple xStock", "aapl-x", "TokenCurrency");
-      mockUseCategorizedAssets.mockReturnValue({ cryptos: [btc, aapl], stablecoins: [] });
+      mockUseCategorizedAssets.mockReturnValue({
+        cryptos: [btc, aapl],
+        stablecoins: [],
+      });
       mockUseStockAssetIds.mockReturnValue({
         ids: new Set(["aapl-x"]),
         isLoading: false,
@@ -171,7 +201,12 @@ describe("useCategorizedAssetsFromPortfolio", () => {
 
   describe("loading state", () => {
     it("reports loading when distribution is loading", () => {
-      mockUseDistribution.mockReturnValue({ isAvailable: true, list: [], isLoading: true });
+      mockUseDistribution.mockReturnValue({
+        isAvailable: true,
+        countervalueComplete: true,
+        list: [],
+        isLoading: true,
+      });
 
       const { result } = renderCategorized();
 

--- a/apps/ledger-live-mobile/src/screens/WalletCentricAsset/AssetRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/WalletCentricAsset/AssetRow.tsx
@@ -8,6 +8,8 @@ import { usePortfolioForAccounts } from "~/hooks/portfolio";
 import AssetRowLayout from "~/components/AssetRowLayout";
 import { track } from "~/analytics";
 import { Asset } from "~/types/asset";
+import { useSelector } from "~/context/hooks";
+import { counterValueCurrencySelector } from "~/reducers/settings";
 import { useAssetDetailNavigation } from "LLM/features/AssetDetail/hooks/useAssetDetailNavigation";
 
 type Props = {
@@ -24,9 +26,16 @@ const AssetRow = ({ asset, hideDelta, topLink, bottomLink }: Props) => {
   const name = currency.name;
   const unit = currency.units[0];
   const { openFromAsset } = useAssetDetailNavigation();
+  const countervalueUnit = useSelector(counterValueCurrencySelector).units[0];
 
   // TODO: implement a much lighter hook to get this simple value
-  const { countervalueChange } = usePortfolioForAccounts(asset.accounts);
+  const { countervalueChange, countervalueComplete } = usePortfolioForAccounts(asset.accounts);
+  const displayedCountervalueChange =
+    asset.amount <= 0
+      ? { value: 0, percentage: 0 }
+      : countervalueComplete && countervalueChange.percentage !== null
+        ? countervalueChange
+        : undefined;
 
   const onAssetPress = useCallback(
     (_uiEvent: GestureResponderEvent) => {
@@ -50,7 +59,7 @@ const AssetRow = ({ asset, hideDelta, topLink, bottomLink }: Props) => {
    * Not a small optimisation as that component can take several milliseconds to
    * render, and it's meant to be rendered in a list.
    *  */
-  const balance = useMemo(() => BigNumber(asset.amount), [asset.amount]);
+  const balance = useMemo(() => new BigNumber(asset.amount), [asset.amount]);
 
   return (
     <AssetRowLayout
@@ -59,7 +68,10 @@ const AssetRow = ({ asset, hideDelta, topLink, bottomLink }: Props) => {
       currencyUnit={unit}
       balance={balance}
       name={name}
-      countervalueChange={countervalueChange}
+      countervalueChange={displayedCountervalueChange}
+      countervalue={asset.countervalue}
+      countervalueUnit={countervalueUnit}
+      countervalueUnavailable={"countervalue" in asset && asset.countervalue === undefined}
       topLink={topLink}
       bottomLink={bottomLink}
       hideDelta={hideDelta}

--- a/apps/ledger-live-mobile/src/screens/WalletCentricAsset/Header.tsx
+++ b/apps/ledger-live-mobile/src/screens/WalletCentricAsset/Header.tsx
@@ -143,7 +143,7 @@ function Header({
                 numberOfLines={1}
               >
                 {shouldUseCounterValue ? (
-                  <CounterValue currency={currency} value={currencyBalance} />
+                  <CounterValue currency={currency} value={currencyBalance} withPlaceholder />
                 ) : (
                   <CurrencyUnitValue showCode unit={currency.units[0]} value={currencyBalance} />
                 )}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Added focused tests for current and legacy asset rows, Asset Detail, PnL, countervalue cells, charts, and Crypto Addresses.
- [x] **Impact of the changes:**
      When a current rate is unavailable, Mobile asset and address screens retain the crypto balance but render unavailable fiat values and trends as `-`. Genuine zero values remain `$0`.

### 📝 Description

Mobile asset surfaces could render missing countervalues as zero or mix an unavailable current value with a historical trend.

This PR consumes the shared completeness contract across current and legacy asset lists, Asset Detail, Crypto Addresses, and asset charts. It keeps the crypto balance visible and makes only the unavailable fiat information explicit.

This PR is stacked on the countervalue completeness core PR.

| Before                        | After                         |
|-------------------------------|-------------------------------|
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA issue**: [LIVE-36444](https://ledgerhq.atlassian.net/browse/LIVE-36444)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-36444]: https://ledgerhq.atlassian.net/browse/LIVE-36444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ