### PR TITLE
[LWDM] fix(upsell): align Touchscreen Upgrade Program tracking (LIVE-36494)

### DIFF
--- a/.changeset/backups-upsell-tracking.md
+++ b/.changeset/backups-upsell-tracking.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Add missing Touchscreen Upgrade Program tracking for Backup Hub Recovery Key upsell and Lazy Onboarding Banner (LIVE-36494)

--- a/apps/ledger-live-desktop/src/mvvm/features/BackupHub/__integrations__/BackupHub.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/BackupHub/__integrations__/BackupHub.integration.test.tsx
@@ -16,13 +16,15 @@ import { setRecoverState } from "~/renderer/reducers/recoverState";
 import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
 import { isModalOpened } from "~/renderer/reducers/modals";
 import { openURL } from "~/renderer/linking";
-import { track } from "~/renderer/analytics/segment";
+import { track, trackPage } from "~/renderer/analytics/segment";
 import { ContextMenu } from "LLD/features/MyWallet/components/ContextMenu";
 import { RECOVER_NOTIFICATION_DOT_TEST_ID } from "LLD/features/BackupHub/components/ShieldCheckNotificationIcon";
 import {
   BACKUP_HUB_RECOVER_DEEPLINK_QUERY,
   BACKUP_HUB_TRACKING_BUTTON,
   BACKUP_HUB_TRACKING_PAGE_NAME,
+  BACKUP_HUB_UPSELL_TRACKING_BUTTON,
+  BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME,
   RECOVER_DEEPLINK_BASE,
 } from "LLD/features/BackupHub/constants";
 
@@ -323,12 +325,30 @@ describe("BackupHub", () => {
       DeviceModelId.nanoX,
     );
 
+    const upsellAnalyticsProps = {
+      deviceModel: NANO_UPSELL_DEVICE_MODEL[DeviceModelId.nanoX],
+      personalRecoOptIn: false,
+      offerType: "none",
+      platform: "lwd",
+    };
+    expect(trackPage).toHaveBeenCalledWith(
+      BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME,
+      undefined,
+      {
+        name: BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME,
+        ...upsellAnalyticsProps,
+      },
+      true,
+      false,
+    );
+
     await user.click(screen.getByTestId("backup-hub-physical-row-recovery-key"));
 
     expect(track).toHaveBeenCalledWith(
       "button_clicked",
       expect.objectContaining({
-        button: BACKUP_HUB_TRACKING_BUTTON.recoveryKey,
+        button: BACKUP_HUB_UPSELL_TRACKING_BUTTON,
+        page: BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME,
         deviceModel: NANO_UPSELL_DEVICE_MODEL[DeviceModelId.nanoX],
       }),
     );
@@ -360,13 +380,23 @@ describe("BackupHub", () => {
         offerType: "none",
         platform: "lwd",
       };
+      expect(trackPage).toHaveBeenCalledWith(
+        BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME,
+        undefined,
+        {
+          name: BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME,
+          ...upsellAnalyticsProps,
+        },
+        true,
+        false,
+      );
       expect(track).toHaveBeenCalledWith("button_clicked", {
-        button: BACKUP_HUB_TRACKING_BUTTON.recoveryKey,
-        page: BACKUP_HUB_TRACKING_PAGE_NAME,
+        button: BACKUP_HUB_UPSELL_TRACKING_BUTTON,
+        page: BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME,
         ...upsellAnalyticsProps,
       });
       expect(track).toHaveBeenCalledWith("deeplink_clicked", {
-        page: BACKUP_HUB_TRACKING_PAGE_NAME,
+        page: BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME,
         deeplinkSource: LARGE_SCREEN_UPSELL_UTM_SOURCE_BY_PLATFORM.desktop,
         deeplinkMedium: LARGE_SCREEN_UPSELL_UTM_MEDIUM,
         deeplinkCampaign: LARGE_SCREEN_UPSELL_UTM_CAMPAIGN,

--- a/apps/ledger-live-desktop/src/mvvm/features/BackupHub/constants.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/BackupHub/constants.ts
@@ -1,5 +1,10 @@
 export const BACKUP_HUB_TRACKING_PAGE_NAME = "Backup hub";
 
+/** Touchscreen Upgrade Program page when the Recovery Key upsell CTA is shown. */
+export const BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME = "Backups";
+
+export const BACKUP_HUB_UPSELL_TRACKING_BUTTON = "upgrade";
+
 export const BACKUP_HUB_TRACKING_BUTTON = {
   back: "Back",
   recover: "Ledger Recover",

--- a/apps/ledger-live-desktop/src/mvvm/features/BackupHub/useBackupHubViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/BackupHub/useBackupHubViewModel.ts
@@ -11,7 +11,7 @@ import {
 } from "@features/flow-large-screen-upsell";
 import { useSelector } from "LLD/hooks/redux";
 import { toLargeScreenUpsellDeviceModelAnalyticsValue } from "LLD/features/LargeScreenUpsell/analytics";
-import { track } from "~/renderer/analytics/segment";
+import { track, trackPage } from "~/renderer/analytics/segment";
 import { openURL } from "~/renderer/linking";
 import { urls } from "~/config/urls";
 import { useLocalizedUrl } from "~/renderer/hooks/useLocalizedUrls";
@@ -26,6 +26,8 @@ import { getBackupBucket } from "./utils/getBackupBucket";
 import {
   BACKUP_HUB_TRACKING_BUTTON,
   BACKUP_HUB_TRACKING_PAGE_NAME,
+  BACKUP_HUB_UPSELL_TRACKING_BUTTON,
+  BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME,
   BACKUP_HUB_RECOVER_DEEPLINK_QUERY,
   BACKUP_HUB_UPSELL_FALLBACK_LINK,
   RECOVER_DEEPLINK_BASE,
@@ -85,9 +87,39 @@ export function useBackupHubViewModel({ onBack, onClose }: BackupHubParams): Bac
     );
   }, [largeScreenUpsell?.params, personalRecoOptIn]);
 
+  const upsellSharedAnalyticsProps = useMemo(
+    () =>
+      incompatibleModel
+        ? {
+            deviceModel: toLargeScreenUpsellDeviceModelAnalyticsValue(incompatibleModel),
+            personalRecoOptIn,
+            offerType: personalRecoOptIn ? ("discount" as const) : ("none" as const),
+            platform: "lwd" as const,
+          }
+        : undefined,
+    [incompatibleModel, personalRecoOptIn],
+  );
+
   useEffect(() => {
     track("page_viewed", { page: BACKUP_HUB_TRACKING_PAGE_NAME });
   }, []);
+
+  useEffect(() => {
+    if (!upsellSharedAnalyticsProps) {
+      return;
+    }
+
+    trackPage(
+      BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME,
+      undefined,
+      {
+        name: BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME,
+        ...upsellSharedAnalyticsProps,
+      },
+      true,
+      false,
+    );
+  }, [upsellSharedAnalyticsProps]);
 
   const handleBack = useCallback(() => {
     track("button_clicked", {
@@ -130,28 +162,32 @@ export function useBackupHubViewModel({ onBack, onClose }: BackupHubParams): Bac
       return;
     }
 
-    const sharedProps = {
-      deviceModel: toLargeScreenUpsellDeviceModelAnalyticsValue(incompatibleModel),
-      personalRecoOptIn,
-      offerType: personalRecoOptIn ? ("discount" as const) : ("none" as const),
-      platform: "lwd" as const,
-    };
+    if (!upsellSharedAnalyticsProps) {
+      return;
+    }
 
     track("button_clicked", {
-      button: BACKUP_HUB_TRACKING_BUTTON.recoveryKey,
-      page: BACKUP_HUB_TRACKING_PAGE_NAME,
-      ...sharedProps,
+      button: BACKUP_HUB_UPSELL_TRACKING_BUTTON,
+      page: BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME,
+      ...upsellSharedAnalyticsProps,
     });
     track("deeplink_clicked", {
-      page: BACKUP_HUB_TRACKING_PAGE_NAME,
+      page: BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME,
       deeplinkSource: LARGE_SCREEN_UPSELL_UTM_SOURCE_BY_PLATFORM.desktop,
       deeplinkMedium: LARGE_SCREEN_UPSELL_UTM_MEDIUM,
       deeplinkCampaign: LARGE_SCREEN_UPSELL_UTM_CAMPAIGN,
-      ...sharedProps,
+      ...upsellSharedAnalyticsProps,
     });
     openURL(upsellLink);
     onClose();
-  }, [incompatibleModel, onClose, openShop, personalRecoOptIn, recoveryKeyUrl, upsellLink]);
+  }, [
+    incompatibleModel,
+    onClose,
+    openShop,
+    recoveryKeyUrl,
+    upsellLink,
+    upsellSharedAnalyticsProps,
+  ]);
 
   const physicalRows = useMemo<readonly PhysicalRowData[]>(
     () => [

--- a/apps/ledger-live-mobile/src/mvvm/features/BackupHub/__integrations__/BackupHub.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/BackupHub/__integrations__/BackupHub.integration.test.tsx
@@ -12,7 +12,7 @@ import {
   LARGE_SCREEN_UPSELL_UTM_SOURCE_BY_PLATFORM,
 } from "@features/flow-large-screen-upsell/utils/upsellCta";
 import { render, screen, withFlagOverrides } from "@tests/test-renderer";
-import { track } from "~/analytics";
+import { screen as analyticsScreen, track } from "~/analytics";
 import { ScreenName } from "~/const";
 import type { State } from "~/reducers/types";
 import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
@@ -24,6 +24,8 @@ import {
   BACKUP_HUB_RECOVER_ONE_MONTH_FREE_DEEPLINK,
   BACKUP_HUB_TRACKING_BUTTON,
   BACKUP_HUB_TRACKING_PAGE_NAME,
+  BACKUP_HUB_UPSELL_TRACKING_BUTTON,
+  BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME,
   RECOVER_DEEPLINK_BASE,
 } from "../constants";
 import { RECOVER_NOTIFICATION_DOT_TEST_ID } from "../components/ShieldCheckNotificationIcon";
@@ -294,12 +296,29 @@ describe("BackupHub screen (mobile)", () => {
       ),
     });
 
+    const upsellAnalyticsProps = {
+      deviceModel: NANO_UPSELL_DEVICE_MODEL[DeviceModelId.nanoX],
+      personalRecoOptIn: false,
+      offerType: "none",
+      platform: "lwm",
+    };
+    expect(analyticsScreen).toHaveBeenCalledWith(
+      BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME,
+      undefined,
+      {
+        name: BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME,
+        ...upsellAnalyticsProps,
+      },
+      false,
+    );
+
     await user.press(await screen.findByTestId("backup-hub-physical-row-recovery-key"));
 
     expect(track).toHaveBeenCalledWith(
       "button_clicked",
       expect.objectContaining({
-        button: BACKUP_HUB_TRACKING_BUTTON.recoveryKey,
+        button: BACKUP_HUB_UPSELL_TRACKING_BUTTON,
+        page: BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME,
         deviceModel: NANO_UPSELL_DEVICE_MODEL[DeviceModelId.nanoX],
       }),
     );
@@ -337,13 +356,22 @@ describe("BackupHub screen (mobile)", () => {
         offerType: "none",
         platform: "lwm",
       };
+      expect(analyticsScreen).toHaveBeenCalledWith(
+        BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME,
+        undefined,
+        {
+          name: BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME,
+          ...upsellAnalyticsProps,
+        },
+        false,
+      );
       expect(track).toHaveBeenCalledWith("button_clicked", {
-        button: BACKUP_HUB_TRACKING_BUTTON.recoveryKey,
-        page: BACKUP_HUB_TRACKING_PAGE_NAME,
+        button: BACKUP_HUB_UPSELL_TRACKING_BUTTON,
+        page: BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME,
         ...upsellAnalyticsProps,
       });
       expect(track).toHaveBeenCalledWith("deeplink_clicked", {
-        page: BACKUP_HUB_TRACKING_PAGE_NAME,
+        page: BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME,
         deeplinkSource: LARGE_SCREEN_UPSELL_UTM_SOURCE_BY_PLATFORM.mobile,
         deeplinkMedium: LARGE_SCREEN_UPSELL_UTM_MEDIUM,
         deeplinkCampaign: LARGE_SCREEN_UPSELL_UTM_CAMPAIGN,

--- a/apps/ledger-live-mobile/src/mvvm/features/BackupHub/constants.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/BackupHub/constants.ts
@@ -2,6 +2,11 @@ import type { BackupBucket } from "./types";
 
 export const BACKUP_HUB_TRACKING_PAGE_NAME = "Backup hub";
 
+/** Touchscreen Upgrade Program page when the Recovery Key upsell CTA is shown. */
+export const BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME = "Backups";
+
+export const BACKUP_HUB_UPSELL_TRACKING_BUTTON = "upgrade";
+
 export const BACKUP_HUB_UPSELL_FALLBACK_LINK =
   "https://shop.ledger.com/pages/ledger-nano-upgrade-program";
 

--- a/apps/ledger-live-mobile/src/mvvm/features/BackupHub/screens/BackupHubScreen/useBackupHubScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/BackupHub/screens/BackupHubScreen/useBackupHubScreenViewModel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { Linking, type ImageSourcePropType } from "react-native";
 import { getNanoOnlyDeviceModel } from "@features/flow-large-screen-upsell/utils/getNanoOnlyDeviceModel";
 import { isLargeScreenUpsellBannerEnabled } from "@features/flow-large-screen-upsell/utils/isLargeScreenUpsellBannerEnabled";
@@ -16,7 +16,7 @@ import {
   toLargeScreenUpsellDeviceModelAnalyticsValue,
   type LargeScreenUpsellNanoDeviceModelId,
 } from "LLM/features/LargeScreenUpsell/analytics";
-import { track } from "~/analytics";
+import { screen, track } from "~/analytics";
 import useRecoverBannerState from "LLM/features/Portfolio/hooks/useRecoverBannerState";
 import { useRecoverEntry } from "LLM/hooks/useRecoverEntry";
 import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
@@ -31,6 +31,8 @@ import { getBackupBucket } from "../../utils/getBackupBucket";
 import {
   BACKUP_HUB_TRACKING_BUTTON,
   BACKUP_HUB_TRACKING_PAGE_NAME,
+  BACKUP_HUB_UPSELL_TRACKING_BUTTON,
+  BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME,
   BACKUP_HUB_RECOVER_DEEPLINK_QUERY,
   BACKUP_HUB_RECOVER_ONE_MONTH_FREE_DEEPLINK,
   BACKUP_HUB_RECOVER_TRACKING_STATUS,
@@ -100,6 +102,37 @@ export function useBackupHubScreenViewModel(): BackupHubScreenViewModel {
     );
   }, [largeScreenUpsell?.params, personalRecoOptIn]);
 
+  const upsellSharedAnalyticsProps = useMemo(
+    () =>
+      incompatibleModel
+        ? {
+            deviceModel: toLargeScreenUpsellDeviceModelAnalyticsValue(
+              incompatibleModel as LargeScreenUpsellNanoDeviceModelId,
+            ),
+            personalRecoOptIn,
+            offerType: personalRecoOptIn ? ("discount" as const) : ("none" as const),
+            platform: "lwm" as const,
+          }
+        : undefined,
+    [incompatibleModel, personalRecoOptIn],
+  );
+
+  useEffect(() => {
+    if (!upsellSharedAnalyticsProps) {
+      return;
+    }
+
+    screen(
+      BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME,
+      undefined,
+      {
+        name: BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME,
+        ...upsellSharedAnalyticsProps,
+      },
+      false,
+    );
+  }, [upsellSharedAnalyticsProps]);
+
   const onRecoverPress = useCallback(() => {
     markRecoverSeen();
     track("button_clicked", {
@@ -141,29 +174,24 @@ export function useBackupHubScreenViewModel(): BackupHubScreenViewModel {
       return;
     }
 
-    const sharedProps = {
-      deviceModel: toLargeScreenUpsellDeviceModelAnalyticsValue(
-        incompatibleModel as LargeScreenUpsellNanoDeviceModelId,
-      ),
-      personalRecoOptIn,
-      offerType: personalRecoOptIn ? ("discount" as const) : ("none" as const),
-      platform: "lwm" as const,
-    };
+    if (!upsellSharedAnalyticsProps) {
+      return;
+    }
 
     track("button_clicked", {
-      button: BACKUP_HUB_TRACKING_BUTTON.recoveryKey,
-      page: BACKUP_HUB_TRACKING_PAGE_NAME,
-      ...sharedProps,
+      button: BACKUP_HUB_UPSELL_TRACKING_BUTTON,
+      page: BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME,
+      ...upsellSharedAnalyticsProps,
     });
     track("deeplink_clicked", {
-      page: BACKUP_HUB_TRACKING_PAGE_NAME,
+      page: BACKUP_HUB_UPSELL_TRACKING_PAGE_NAME,
       deeplinkSource: LARGE_SCREEN_UPSELL_UTM_SOURCE_BY_PLATFORM.mobile,
       deeplinkMedium: LARGE_SCREEN_UPSELL_UTM_MEDIUM,
       deeplinkCampaign: LARGE_SCREEN_UPSELL_UTM_CAMPAIGN,
-      ...sharedProps,
+      ...upsellSharedAnalyticsProps,
     });
     Linking.openURL(upsellLink);
-  }, [incompatibleModel, openShop, personalRecoOptIn, recoveryKeyUrl, upsellLink]);
+  }, [incompatibleModel, openShop, recoveryKeyUrl, upsellLink, upsellSharedAnalyticsProps]);
 
   const physicalRows = useMemo<readonly PhysicalRowData[]>(
     () => [

--- a/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/__integrations__/LazyOnboardingBanner.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/__integrations__/LazyOnboardingBanner.integration.test.tsx
@@ -3,8 +3,16 @@ import { Linking } from "react-native";
 import { resetLazyOnboardingBannerSession } from "@features/flow-lazy-onboarding-banner/testing";
 import { DeviceModelId } from "@ledgerhq/devices";
 import { fireEvent, render, screen, waitFor, withFlagOverrides } from "@tests/test-renderer";
-import { track } from "~/analytics";
+import { screen as analyticsScreen, track } from "~/analytics";
 import type { State } from "~/reducers/types";
+import {
+  LAZY_ONBOARDING_BANNER_BUTTON,
+  LAZY_ONBOARDING_BANNER_PAGE,
+  LAZY_ONBOARDING_BANNER_PAGE_NAME,
+  LAZY_ONBOARDING_FEATURE_INTRO_PAGE,
+  LAZY_ONBOARDING_FEATURE_INTRO_PAGE_NAME,
+  LAZY_ONBOARDING_SOURCE_FLOW,
+} from "../analyticsConstants";
 import {
   __resetLazyOnboardingTourControllerForTests,
   LazyOnboardingTourPortfolioMount,
@@ -86,6 +94,14 @@ async function openTourFromBanner(user: Awaited<ReturnType<typeof renderBanner>>
   expect(await screen.findByText(SLIDE_TITLES[0])).toBeVisible();
 }
 
+const lazyOnboardingBannerAnalyticsProps = {
+  hasConnectedDevice: false as const,
+  deviceModel: "none" as const,
+  personalRecoOptIn: false,
+  offerType: "none" as const,
+  platform: "lwm" as const,
+};
+
 describe("LazyOnboardingBanner", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -99,11 +115,24 @@ describe("LazyOnboardingBanner", () => {
     expect(screen.getByText("Why millions choose Ledger?")).toBeVisible();
     expect(screen.getByText("To have peace of mind every time they transact.")).toBeVisible();
 
+    expect(analyticsScreen).toHaveBeenCalledWith(
+      LAZY_ONBOARDING_BANNER_PAGE,
+      undefined,
+      {
+        name: LAZY_ONBOARDING_BANNER_PAGE_NAME,
+        ...lazyOnboardingBannerAnalyticsProps,
+        abLazyBannerFlow: "shop direct",
+      },
+      false,
+    );
+
     await user.press(screen.getByTestId("lazy-onboarding-banner"));
 
     expect(track).toHaveBeenCalledWith("button_clicked", {
-      button: "Product tour lazy onboarding",
-      page: "Wallet",
+      button: LAZY_ONBOARDING_BANNER_BUTTON,
+      page: LAZY_ONBOARDING_BANNER_PAGE,
+      ...lazyOnboardingBannerAnalyticsProps,
+      abLazyBannerFlow: "shop direct",
     });
     expect(Linking.openURL).toHaveBeenCalledTimes(1);
     const openedUrl = new URL(jest.mocked(Linking.openURL).mock.calls[0][0]);
@@ -129,7 +158,37 @@ describe("LazyOnboardingBanner", () => {
 
   it("should open the tour instead of the shop in feature_intro mode", async () => {
     const { user } = renderBanner({ mode: "feature_intro", withTourMount: true });
+
+    expect(analyticsScreen).toHaveBeenCalledWith(
+      LAZY_ONBOARDING_BANNER_PAGE,
+      undefined,
+      {
+        name: LAZY_ONBOARDING_BANNER_PAGE_NAME,
+        ...lazyOnboardingBannerAnalyticsProps,
+        abLazyBannerFlow: "feature intro",
+      },
+      false,
+    );
+
     await openTourFromBanner(user);
+
+    expect(track).toHaveBeenCalledWith("button_clicked", {
+      button: LAZY_ONBOARDING_BANNER_BUTTON,
+      page: LAZY_ONBOARDING_BANNER_PAGE,
+      ...lazyOnboardingBannerAnalyticsProps,
+      abLazyBannerFlow: "feature intro",
+    });
+    expect(analyticsScreen).toHaveBeenCalledWith(
+      LAZY_ONBOARDING_FEATURE_INTRO_PAGE,
+      undefined,
+      {
+        name: LAZY_ONBOARDING_FEATURE_INTRO_PAGE_NAME,
+        sourceFlow: LAZY_ONBOARDING_SOURCE_FLOW,
+        ...lazyOnboardingBannerAnalyticsProps,
+        abLazyBannerFlow: "feature intro",
+      },
+      false,
+    );
     expect(Linking.openURL).not.toHaveBeenCalled();
   });
 
@@ -239,7 +298,8 @@ describe("LazyOnboardingTour", () => {
         button: "Continue",
         page: LAZY_ONBOARDING_TOUR_PAGE,
         card: 1,
-        mode: "feature_intro",
+        abLazyBannerFlow: "feature intro",
+        platform: "lwm",
       }),
     );
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/analyticsConstants.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/analyticsConstants.ts
@@ -1,0 +1,42 @@
+import type { LazyOnboardingBannerMode } from "@features/flow-lazy-onboarding-banner";
+
+export const LAZY_ONBOARDING_BANNER_PAGE = "banner lazy onboarding upgrade";
+
+export const LAZY_ONBOARDING_BANNER_PAGE_NAME = "banner lazy onboarding upgrade";
+
+export const LAZY_ONBOARDING_BANNER_BUTTON = "upgrade to touchscreen";
+
+export const LAZY_ONBOARDING_FEATURE_INTRO_PAGE = "Feature intro";
+
+export const LAZY_ONBOARDING_FEATURE_INTRO_PAGE_NAME = "Feature intro";
+
+export const LAZY_ONBOARDING_SOURCE_FLOW = "lazy onboarding";
+
+export type LazyOnboardingAbBannerFlow = "feature intro" | "shop direct";
+
+export type LazyOnboardingSharedAnalyticsProps = Readonly<{
+  hasConnectedDevice: false;
+  abLazyBannerFlow: LazyOnboardingAbBannerFlow;
+  deviceModel: "none";
+  personalRecoOptIn: boolean;
+  offerType: "discount" | "none";
+  platform: "lwm";
+}>;
+
+export function toAbLazyBannerFlow(mode: LazyOnboardingBannerMode): LazyOnboardingAbBannerFlow {
+  return mode === "feature_intro" ? "feature intro" : "shop direct";
+}
+
+export function buildLazyOnboardingSharedAnalyticsProps(
+  mode: LazyOnboardingBannerMode,
+  personalRecoOptIn: boolean,
+): LazyOnboardingSharedAnalyticsProps {
+  return {
+    hasConnectedDevice: false,
+    abLazyBannerFlow: toAbLazyBannerFlow(mode),
+    deviceModel: "none",
+    personalRecoOptIn,
+    offerType: personalRecoOptIn ? "discount" : "none",
+    platform: "lwm",
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingBanner/analytics.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingBanner/analytics.ts
@@ -1,9 +1,33 @@
-import { track } from "~/analytics";
+import type { LazyOnboardingBannerMode } from "@features/flow-lazy-onboarding-banner";
+import { screen, track } from "~/analytics";
+import {
+  buildLazyOnboardingSharedAnalyticsProps,
+  LAZY_ONBOARDING_BANNER_BUTTON,
+  LAZY_ONBOARDING_BANNER_PAGE,
+  LAZY_ONBOARDING_BANNER_PAGE_NAME,
+  type LazyOnboardingSharedAnalyticsProps,
+} from "../../analyticsConstants";
 
-export const trackLazyOnboardingBannerPressed = () => {
+export const trackLazyOnboardingBannerShown = (sharedProps: LazyOnboardingSharedAnalyticsProps) => {
+  screen(
+    LAZY_ONBOARDING_BANNER_PAGE,
+    undefined,
+    {
+      name: LAZY_ONBOARDING_BANNER_PAGE_NAME,
+      ...sharedProps,
+    },
+    false,
+  );
+};
+
+export const trackLazyOnboardingBannerPressed = (
+  mode: LazyOnboardingBannerMode,
+  personalRecoOptIn: boolean,
+) => {
   track("button_clicked", {
-    button: "Product tour lazy onboarding",
-    page: "Wallet",
+    button: LAZY_ONBOARDING_BANNER_BUTTON,
+    page: LAZY_ONBOARDING_BANNER_PAGE,
+    ...buildLazyOnboardingSharedAnalyticsProps(mode, personalRecoOptIn),
   });
 };
 

--- a/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingBanner/useLazyOnboardingBannerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingBanner/useLazyOnboardingBannerViewModel.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { Linking } from "react-native";
 import {
   buildLazyOnboardingBannerLink,
@@ -6,17 +6,43 @@ import {
   type LazyOnboardingBannerViewProps,
 } from "@features/flow-lazy-onboarding-banner";
 import { useTranslation } from "~/context/Locale";
+import { useSelector } from "~/context/hooks";
+import { personalizedRecommendationsEnabledSelector } from "~/reducers/settings";
+import { buildLazyOnboardingSharedAnalyticsProps } from "../../analyticsConstants";
 import { lazyOnboardingTourController } from "../LazyOnboardingTour/lazyOnboardingTourController";
 import { useLazyOnboardingBannerState } from "../../hooks/useLazyOnboardingBannerState";
-import { trackLazyOnboardingBannerDismissed, trackLazyOnboardingBannerPressed } from "./analytics";
+import {
+  trackLazyOnboardingBannerDismissed,
+  trackLazyOnboardingBannerPressed,
+  trackLazyOnboardingBannerShown,
+} from "./analytics";
 
 export function useLazyOnboardingBannerViewModel(): LazyOnboardingBannerViewProps {
   const { t } = useTranslation();
   const { isShown, link, mode, dismiss } = useLazyOnboardingBannerState();
+  const personalizedRecommendationsEnabled = useSelector(
+    personalizedRecommendationsEnabledSelector,
+  );
   const shopLink = buildLazyOnboardingBannerLink(link, "mobile");
 
+  const sharedAnalyticsProps = useMemo(
+    () =>
+      isShown
+        ? buildLazyOnboardingSharedAnalyticsProps(mode, personalizedRecommendationsEnabled)
+        : null,
+    [isShown, mode, personalizedRecommendationsEnabled],
+  );
+
+  useEffect(() => {
+    if (!sharedAnalyticsProps) {
+      return;
+    }
+
+    trackLazyOnboardingBannerShown(sharedAnalyticsProps);
+  }, [sharedAnalyticsProps]);
+
   const onPress = useCallback(() => {
-    trackLazyOnboardingBannerPressed();
+    trackLazyOnboardingBannerPressed(mode, personalizedRecommendationsEnabled);
     const action = resolveLazyOnboardingBannerTapAction(mode);
 
     if (action === "open_feature_intro_tour") {
@@ -25,7 +51,7 @@ export function useLazyOnboardingBannerViewModel(): LazyOnboardingBannerViewProp
     }
 
     void Linking.openURL(shopLink);
-  }, [mode, shopLink]);
+  }, [mode, personalizedRecommendationsEnabled, shopLink]);
 
   const onClose = useCallback(() => {
     trackLazyOnboardingBannerDismissed();

--- a/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/__tests__/analytics.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/__tests__/analytics.test.ts
@@ -1,5 +1,10 @@
 import { screen, track } from "~/analytics";
 import {
+  LAZY_ONBOARDING_FEATURE_INTRO_PAGE,
+  LAZY_ONBOARDING_FEATURE_INTRO_PAGE_NAME,
+  LAZY_ONBOARDING_SOURCE_FLOW,
+} from "../../analyticsConstants";
+import {
   trackLazyOnboardingTourBuyClicked,
   trackLazyOnboardingTourCloseClicked,
   trackLazyOnboardingTourContinueClicked,
@@ -20,10 +25,10 @@ jest.mock("~/analytics", () => ({
 const sharedProps: LazyOnboardingTourSharedAnalyticsProps = {
   hasConnectedDevice: false,
   personalRecoOptIn: true,
-  offerType: "none",
-  platform: "llm",
-  source: "lazy onboarding",
-  mode: "feature_intro",
+  offerType: "discount",
+  platform: "lwm",
+  deviceModel: "none",
+  abLazyBannerFlow: "feature intro",
 };
 
 describe("LazyOnboardingTour analytics", () => {
@@ -33,11 +38,16 @@ describe("LazyOnboardingTour analytics", () => {
 
   it("tracks tour open once and ignores duplicate opens", () => {
     expect(trackLazyOnboardingTourOpened(sharedProps, false)).toBe(true);
-    expect(screen).toHaveBeenCalledWith(LAZY_ONBOARDING_TOUR_PAGE, undefined, {
-      name: "lazy onboarding tour",
-      card: 1,
-      ...sharedProps,
-    });
+    expect(screen).toHaveBeenCalledWith(
+      LAZY_ONBOARDING_FEATURE_INTRO_PAGE,
+      undefined,
+      {
+        name: LAZY_ONBOARDING_FEATURE_INTRO_PAGE_NAME,
+        sourceFlow: LAZY_ONBOARDING_SOURCE_FLOW,
+        ...sharedProps,
+      },
+      false,
+    );
 
     expect(trackLazyOnboardingTourOpened(sharedProps, true)).toBe(false);
     expect(screen).toHaveBeenCalledTimes(1);

--- a/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/__tests__/analytics.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/__tests__/analytics.test.ts
@@ -3,7 +3,7 @@ import {
   LAZY_ONBOARDING_FEATURE_INTRO_PAGE,
   LAZY_ONBOARDING_FEATURE_INTRO_PAGE_NAME,
   LAZY_ONBOARDING_SOURCE_FLOW,
-} from "../../analyticsConstants";
+} from "../../../analyticsConstants";
 import {
   trackLazyOnboardingTourBuyClicked,
   trackLazyOnboardingTourCloseClicked,

--- a/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/__tests__/useLazyOnboardingTourDrawerViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/__tests__/useLazyOnboardingTourDrawerViewModel.test.ts
@@ -1,6 +1,11 @@
 import { Linking } from "react-native";
 import { act, renderHook, withFlagOverrides } from "@tests/test-renderer";
 import { screen, track } from "~/analytics";
+import {
+  LAZY_ONBOARDING_FEATURE_INTRO_PAGE,
+  LAZY_ONBOARDING_FEATURE_INTRO_PAGE_NAME,
+  LAZY_ONBOARDING_SOURCE_FLOW,
+} from "../../analyticsConstants";
 import { LAZY_ONBOARDING_TOUR_PAGE, LAZY_ONBOARDING_TOUR_SHOP_PAGE } from "../const";
 import {
   __resetLazyOnboardingTourControllerForTests,
@@ -50,9 +55,8 @@ describe("useLazyOnboardingTourDrawerViewModel dismiss analytics", () => {
       expect.objectContaining({
         page: LAZY_ONBOARDING_TOUR_PAGE,
         card: 1,
-        source: "lazy onboarding",
-        mode: "feature_intro",
-        platform: "llm",
+        abLazyBannerFlow: "feature intro",
+        platform: "lwm",
       }),
     );
     expect(result.current?.isOpen).toBe(false);
@@ -119,9 +123,14 @@ describe("useLazyOnboardingTourDrawerViewModel dismiss analytics", () => {
     });
 
     expect(screen).toHaveBeenCalledWith(
-      LAZY_ONBOARDING_TOUR_PAGE,
+      LAZY_ONBOARDING_FEATURE_INTRO_PAGE,
       undefined,
-      expect.objectContaining({ name: "lazy onboarding tour", card: 1 }),
+      expect.objectContaining({
+        name: LAZY_ONBOARDING_FEATURE_INTRO_PAGE_NAME,
+        sourceFlow: LAZY_ONBOARDING_SOURCE_FLOW,
+        abLazyBannerFlow: "feature intro",
+      }),
+      false,
     );
 
     act(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/__tests__/useLazyOnboardingTourDrawerViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/__tests__/useLazyOnboardingTourDrawerViewModel.test.ts
@@ -5,7 +5,7 @@ import {
   LAZY_ONBOARDING_FEATURE_INTRO_PAGE,
   LAZY_ONBOARDING_FEATURE_INTRO_PAGE_NAME,
   LAZY_ONBOARDING_SOURCE_FLOW,
-} from "../../analyticsConstants";
+} from "../../../analyticsConstants";
 import { LAZY_ONBOARDING_TOUR_PAGE, LAZY_ONBOARDING_TOUR_SHOP_PAGE } from "../const";
 import {
   __resetLazyOnboardingTourControllerForTests,

--- a/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/analytics.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/analytics.ts
@@ -1,14 +1,13 @@
 import { screen, track } from "~/analytics";
+import {
+  LAZY_ONBOARDING_FEATURE_INTRO_PAGE,
+  LAZY_ONBOARDING_FEATURE_INTRO_PAGE_NAME,
+  LAZY_ONBOARDING_SOURCE_FLOW,
+  type LazyOnboardingSharedAnalyticsProps,
+} from "../../analyticsConstants";
 import { LAZY_ONBOARDING_TOUR_PAGE, LAZY_ONBOARDING_TOUR_SHOP_PAGE } from "./const";
 
-export type LazyOnboardingTourSharedAnalyticsProps = Readonly<{
-  hasConnectedDevice: false;
-  personalRecoOptIn: boolean;
-  offerType: "none";
-  platform: "llm";
-  source: "lazy onboarding";
-  mode: "feature_intro";
-}>;
+export type LazyOnboardingTourSharedAnalyticsProps = LazyOnboardingSharedAnalyticsProps;
 
 /** Convert 0-based slide index to 1-based analytics card. */
 const toCard = (slideIndex: number) => slideIndex + 1;
@@ -21,11 +20,16 @@ export const trackLazyOnboardingTourOpened = (
     return false;
   }
 
-  screen(LAZY_ONBOARDING_TOUR_PAGE, undefined, {
-    name: "lazy onboarding tour",
-    card: 1,
-    ...sharedProps,
-  });
+  screen(
+    LAZY_ONBOARDING_FEATURE_INTRO_PAGE,
+    undefined,
+    {
+      name: LAZY_ONBOARDING_FEATURE_INTRO_PAGE_NAME,
+      sourceFlow: LAZY_ONBOARDING_SOURCE_FLOW,
+      ...sharedProps,
+    },
+    false,
+  );
 
   return true;
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/useLazyOnboardingTourDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/useLazyOnboardingTourDrawerViewModel.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Linking } from "react-native";
 import { buildLazyOnboardingBannerLink } from "@features/flow-lazy-onboarding-banner";
+import { buildLazyOnboardingSharedAnalyticsProps } from "../../analyticsConstants";
 import { useFeature } from "@features/platform-feature-flags";
 import { useSelector } from "~/context/hooks";
 import { personalizedRecommendationsEnabledSelector } from "~/reducers/settings";
@@ -47,14 +48,8 @@ export function useLazyOnboardingTourDrawerViewModel(): LazyOnboardingTourDrawer
   const shopLink = buildLazyOnboardingBannerLink(link, "mobile");
 
   const sharedAnalyticsProps = useMemo(
-    (): LazyOnboardingTourSharedAnalyticsProps => ({
-      hasConnectedDevice: false,
-      personalRecoOptIn: personalizedRecommendationsEnabled,
-      offerType: "none",
-      platform: "llm",
-      source: "lazy onboarding",
-      mode: "feature_intro",
-    }),
+    (): LazyOnboardingTourSharedAnalyticsProps =>
+      buildLazyOnboardingSharedAnalyticsProps("feature_intro", personalizedRecommendationsEnabled),
     [personalizedRecommendationsEnabled],
   );
 


### PR DESCRIPTION
### 📝 Description

This PR aligns missing analytics events for the **Touchscreen Upgrade Program** with the [Tracking Plan](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7317815469/Touchscreen+Upgrade+Program+-+Tracking+Plan).

**Problem**: Backup Hub Recovery Key upsell and Lazy Onboarding Banner were emitting incorrect or incomplete Segment events (wrong page names, button labels, missing page impressions, and outdated shared properties such as `platform: "llm"`).

**Solution**:

**Backup Hub upsell CTA (desktop + mobile)**
- Track page impression `Backups` when the Recovery Key upsell CTA is visible (Nano S/SP/X + flag enabled)
- Track upgrade click with `button: "upgrade"`, `page: "Backups"`, and deeplink UTMs (`backups_cta`)

**Lazy Onboarding Banner (mobile only)**
- Track banner impression on `banner lazy onboarding upgrade` with `abLazyBannerFlow`, `deviceModel: "none"`, `platform: "lwm"`, etc.
- Track banner tap with `button: "upgrade to touchscreen"`
- Track Feature intro display with `screen("Feature intro", { sourceFlow: "lazy onboarding", ... })` when the tour opens

Integration and unit tests updated for both flows.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36494](https://ledgerhq.atlassian.net/browse/LIVE-36494)
- **Tracking plan**: [Touchscreen Upgrade Program - Tracking Plan](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7317815469/Touchscreen+Upgrade+Program+-+Tracking+Plan)

### ✅ Test plan

- [ ] Desktop Backup Hub: with Nano S/SP/X + `backup-hub-recovery-key-text-warning`, verify `Backups` page impression and upgrade click + deeplink UTMs in Segment debugger
- [ ] Mobile Backup Hub: same checks as desktop on Recovery Key upsell row
- [ ] Mobile Lazy Onboarding Banner (`shop_direct`): verify banner impression + `upgrade to touchscreen` click with `abLazyBannerFlow: "shop direct"`
- [ ] Mobile Lazy Onboarding Banner (`feature_intro`): verify banner impression, click, and `Feature intro` screen on tour open
- [ ] Automated: Backup Hub + Lazy Onboarding integration/unit tests pass in CI

Made with [Cursor](https://cursor.com)

[LIVE-36494]: https://ledgerhq.atlassian.net/browse/LIVE-36494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ