### PR TITLE
feat(card): add the freezeCard and unfreezeCard mutations

### DIFF
--- a/.changeset/pay-card-freeze-unfreeze.md
+++ b/.changeset/pay-card-freeze-unfreeze.md
@@ -1,0 +1,10 @@
+---
+"@domain/api-card-management": minor
+---
+
+Add `freezeCard` and `unfreezeCard` for `POST /v1/card/freeze` and `POST /v1/card/unfreeze`.
+
+- Mutations taking no argument: the provider documents no request body for either.
+- Both invalidate `CardStatus`, so the status refetches itself after the card moves between `ACTIVE` and `FROZEN` — no caller has to sequence the two.
+- Each carries its own documented 400: `Card is already frozen` on freeze, `Card is not frozen` on unfreeze.
+- Drops the README row for `initiateAuthorize`, which the endpoint table still listed after that endpoint was removed.

--- a/domain/api/card-management/README.md
+++ b/domain/api/card-management/README.md
@@ -18,8 +18,8 @@ shape and the reasons.
 
 | Endpoint | Method | Path | Purpose |
 | -------- | ------ | ---- | ------- |
-| `exchangeAuthorizationCode` | POST | `/v1/auth/oauth/token` | Exchange the authorization code for a session |
-| `refreshSession` | POST | `/v1/auth/oauth/token` | Same endpoint, `refresh_token` grant |
+| `exchangeAuthorizationCode` | POST | `/v1/auth/oauth2/token` | Exchange the authorization code for a session |
+| `refreshSession` | POST | `/v1/auth/oauth2/token` | Same endpoint, `refresh_token` grant |
 | `logout` | POST | `/v1/auth/logout` | End the session |
 | `getUser` | GET | `/v1/user` | Read the account id and verification state |
 | `orderCard` | POST | `/v1/card/order` | Order a virtual card |

--- a/domain/api/card-management/README.md
+++ b/domain/api/card-management/README.md
@@ -18,13 +18,14 @@ shape and the reasons.
 
 | Endpoint | Method | Path | Purpose |
 | -------- | ------ | ---- | ------- |
-| `initiateAuthorize` | GET | `/v1/auth/oauth/authorize/initiate` | Start a login and get the hosted login URL |
 | `exchangeAuthorizationCode` | POST | `/v1/auth/oauth/token` | Exchange the authorization code for a session |
 | `refreshSession` | POST | `/v1/auth/oauth/token` | Same endpoint, `refresh_token` grant |
 | `logout` | POST | `/v1/auth/logout` | End the session |
 | `getUser` | GET | `/v1/user` | Read the account id and verification state |
 | `orderCard` | POST | `/v1/card/order` | Order a virtual card |
 | `getCardStatus` | GET | `/v1/card/status` | Read the ordered card's state and preview fields |
+| `freezeCard` | POST | `/v1/card/freeze` | Move an active card to `FROZEN` |
+| `unfreezeCard` | POST | `/v1/card/unfreeze` | Move a frozen card back to `ACTIVE` |
 | `getInternalWallets` | GET | `/v1/wallet/internal` | Read every custodial wallet, with balances |
 | `getCardLinkedWallets` | GET | `/v1/wallet/internal/card_linked` | Read the wallets funding the card, in charging order |
 

--- a/domain/api/card-management/src/api.test.ts
+++ b/domain/api/card-management/src/api.test.ts
@@ -2,11 +2,13 @@ import { configureStore } from "@reduxjs/toolkit";
 import { cardApi, cardApiExtra } from "@shared/api-services";
 import {
   cardManagementApi,
+  useFreezeCardMutation,
   useGetCardLinkedWalletsQuery,
   useGetCardStatusQuery,
   useLazyGetCardStatusQuery,
   useGetInternalWalletsQuery,
   useOrderCardMutation,
+  useUnfreezeCardMutation,
 } from "./api";
 import { PayCardErrorResponseSchema } from "./schema";
 
@@ -133,6 +135,7 @@ describe("cardManagementApi configuration", () => {
   it("injects exactly its own endpoints", () => {
     expect(Object.keys(cardManagementApi.endpoints).sort()).toEqual([
       "exchangeAuthorizationCode",
+      "freezeCard",
       "getCardLinkedWallets",
       "getCardStatus",
       "getInternalWallets",
@@ -140,6 +143,7 @@ describe("cardManagementApi configuration", () => {
       "logout",
       "orderCard",
       "refreshSession",
+      "unfreezeCard",
     ]);
   });
 
@@ -153,6 +157,13 @@ describe("cardManagementApi configuration", () => {
     expect(useGetCardStatusQuery).toBeDefined();
     // The devtool fetches on press, not on mount, so the lazy hook is part of the surface too.
     expect(useLazyGetCardStatusQuery).toBeDefined();
+  });
+
+  it("exposes the freeze endpoints and their hooks", () => {
+    expect(cardManagementApi.endpoints.freezeCard).toBeDefined();
+    expect(useFreezeCardMutation).toBeDefined();
+    expect(cardManagementApi.endpoints.unfreezeCard).toBeDefined();
+    expect(useUnfreezeCardMutation).toBeDefined();
   });
 
   it("exposes the wallet endpoints and their hooks", () => {
@@ -376,6 +387,110 @@ describe("cardManagementApi requests", () => {
       );
       await status;
       await store.dispatch(cardManagementApi.endpoints.orderCard.initiate());
+      await flushPendingRequests();
+
+      const statusRequests = fetchSpy.mock.calls.filter(
+        ([input]) => new URL((input as Request).url).pathname === "/v1/card/status",
+      );
+      expect(statusRequests).toHaveLength(2);
+
+      status.unsubscribe();
+    });
+  });
+
+  describe("freezeCard", () => {
+    it("posts the freeze with the session bearer token and the client key", async () => {
+      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ success: true }));
+
+      const store = makeStore(async () => "session-token");
+      const result = await store.dispatch(cardManagementApi.endpoints.freezeCard.initiate());
+
+      expect(request(fetchSpy).url).toBe("https://card.test/v1/card/freeze");
+      expect(request(fetchSpy).method).toBe("POST");
+      expect(request(fetchSpy).headers.get("authorization")).toBe("Bearer session-token");
+      expect(request(fetchSpy).headers.get("x-client-key")).toBe("client-key");
+      expect(result.data).toEqual({ success: true });
+    });
+
+    it("surfaces a card that is already frozen as a 400", async () => {
+      fetchSpy = jest
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(errorResponse(400, "Card is already frozen"));
+
+      const store = makeStore(async () => "session-token");
+      const result = await store.dispatch(cardManagementApi.endpoints.freezeCard.initiate());
+
+      expect(result.data).toBeUndefined();
+      expect(result.error).toMatchObject({ status: 400 });
+    });
+
+    it("refetches the card status, because freezing moves it to FROZEN", async () => {
+      fetchSpy = jest
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(async (input: RequestInfo | URL) =>
+          new URL((input as Request).url).pathname === "/v1/card/freeze"
+            ? jsonResponse({ success: true })
+            : jsonResponse(cardStatus),
+        );
+
+      const store = makeStore(async () => "session-token");
+      const status = store.dispatch(
+        cardManagementApi.endpoints.getCardStatus.initiate(undefined, { subscribe: true }),
+      );
+      await status;
+      await store.dispatch(cardManagementApi.endpoints.freezeCard.initiate());
+      await flushPendingRequests();
+
+      const statusRequests = fetchSpy.mock.calls.filter(
+        ([input]) => new URL((input as Request).url).pathname === "/v1/card/status",
+      );
+      expect(statusRequests).toHaveLength(2);
+
+      status.unsubscribe();
+    });
+  });
+
+  describe("unfreezeCard", () => {
+    it("posts the unfreeze with the session bearer token and the client key", async () => {
+      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ success: true }));
+
+      const store = makeStore(async () => "session-token");
+      const result = await store.dispatch(cardManagementApi.endpoints.unfreezeCard.initiate());
+
+      expect(request(fetchSpy).url).toBe("https://card.test/v1/card/unfreeze");
+      expect(request(fetchSpy).method).toBe("POST");
+      expect(request(fetchSpy).headers.get("authorization")).toBe("Bearer session-token");
+      expect(request(fetchSpy).headers.get("x-client-key")).toBe("client-key");
+      expect(result.data).toEqual({ success: true });
+    });
+
+    it("surfaces a card that is not frozen as a 400", async () => {
+      fetchSpy = jest
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(errorResponse(400, "Card is not frozen"));
+
+      const store = makeStore(async () => "session-token");
+      const result = await store.dispatch(cardManagementApi.endpoints.unfreezeCard.initiate());
+
+      expect(result.data).toBeUndefined();
+      expect(result.error).toMatchObject({ status: 400 });
+    });
+
+    it("refetches the card status, because unfreezing moves it back to ACTIVE", async () => {
+      fetchSpy = jest
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(async (input: RequestInfo | URL) =>
+          new URL((input as Request).url).pathname === "/v1/card/unfreeze"
+            ? jsonResponse({ success: true })
+            : jsonResponse({ ...cardStatus, status: "FROZEN" }),
+        );
+
+      const store = makeStore(async () => "session-token");
+      const status = store.dispatch(
+        cardManagementApi.endpoints.getCardStatus.initiate(undefined, { subscribe: true }),
+      );
+      await status;
+      await store.dispatch(cardManagementApi.endpoints.unfreezeCard.initiate());
       await flushPendingRequests();
 
       const statusRequests = fetchSpy.mock.calls.filter(

--- a/domain/api/card-management/src/api.test.ts
+++ b/domain/api/card-management/src/api.test.ts
@@ -111,7 +111,7 @@ const makeStore = (
 ) =>
   configureStore({
     reducer: {
-      [cardApi.reducerPath]: cardApi.reducer,
+      [cardManagementApi.reducerPath]: cardManagementApi.reducer,
     },
     middleware: gdm =>
       gdm({
@@ -123,7 +123,7 @@ const makeStore = (
             refreshCardSession: () => Promise.resolve(null),
           }),
         },
-      }).concat(cardApi.middleware),
+      }).concat(cardManagementApi.middleware),
   });
 
 describe("cardManagementApi configuration", () => {
@@ -421,23 +421,29 @@ describe("cardManagementApi requests", () => {
       const result = await store.dispatch(cardManagementApi.endpoints.freezeCard.initiate());
 
       expect(result.data).toBeUndefined();
-      expect(result.error).toMatchObject({ status: 400 });
+      expect(result.error).toMatchObject({
+        status: 400,
+        data: { message: "Card is already frozen" },
+      });
     });
 
     it("refetches the card status, because freezing moves it to FROZEN", async () => {
+      let cardState = "ACTIVE";
       fetchSpy = jest
         .spyOn(globalThis, "fetch")
-        .mockImplementation(async (input: RequestInfo | URL) =>
-          new URL((input as Request).url).pathname === "/v1/card/freeze"
-            ? jsonResponse({ success: true })
-            : jsonResponse(cardStatus),
-        );
+        .mockImplementation(async (input: RequestInfo | URL) => {
+          if (new URL((input as Request).url).pathname === "/v1/card/freeze") {
+            cardState = "FROZEN";
+            return jsonResponse({ success: true });
+          }
+          return jsonResponse({ ...cardStatus, status: cardState });
+        });
 
       const store = makeStore(async () => "session-token");
-      const status = store.dispatch(
+      const subscription = store.dispatch(
         cardManagementApi.endpoints.getCardStatus.initiate(undefined, { subscribe: true }),
       );
-      await status;
+      await subscription;
       await store.dispatch(cardManagementApi.endpoints.freezeCard.initiate());
       await flushPendingRequests();
 
@@ -445,8 +451,11 @@ describe("cardManagementApi requests", () => {
         ([input]) => new URL((input as Request).url).pathname === "/v1/card/status",
       );
       expect(statusRequests).toHaveLength(2);
+      expect(
+        cardManagementApi.endpoints.getCardStatus.select()(store.getState()).data?.status,
+      ).toBe("FROZEN");
 
-      status.unsubscribe();
+      subscription.unsubscribe();
     });
   });
 
@@ -473,23 +482,26 @@ describe("cardManagementApi requests", () => {
       const result = await store.dispatch(cardManagementApi.endpoints.unfreezeCard.initiate());
 
       expect(result.data).toBeUndefined();
-      expect(result.error).toMatchObject({ status: 400 });
+      expect(result.error).toMatchObject({ status: 400, data: { message: "Card is not frozen" } });
     });
 
     it("refetches the card status, because unfreezing moves it back to ACTIVE", async () => {
+      let cardState = "FROZEN";
       fetchSpy = jest
         .spyOn(globalThis, "fetch")
-        .mockImplementation(async (input: RequestInfo | URL) =>
-          new URL((input as Request).url).pathname === "/v1/card/unfreeze"
-            ? jsonResponse({ success: true })
-            : jsonResponse({ ...cardStatus, status: "FROZEN" }),
-        );
+        .mockImplementation(async (input: RequestInfo | URL) => {
+          if (new URL((input as Request).url).pathname === "/v1/card/unfreeze") {
+            cardState = "ACTIVE";
+            return jsonResponse({ success: true });
+          }
+          return jsonResponse({ ...cardStatus, status: cardState });
+        });
 
       const store = makeStore(async () => "session-token");
-      const status = store.dispatch(
+      const subscription = store.dispatch(
         cardManagementApi.endpoints.getCardStatus.initiate(undefined, { subscribe: true }),
       );
-      await status;
+      await subscription;
       await store.dispatch(cardManagementApi.endpoints.unfreezeCard.initiate());
       await flushPendingRequests();
 
@@ -497,8 +509,11 @@ describe("cardManagementApi requests", () => {
         ([input]) => new URL((input as Request).url).pathname === "/v1/card/status",
       );
       expect(statusRequests).toHaveLength(2);
+      expect(
+        cardManagementApi.endpoints.getCardStatus.select()(store.getState()).data?.status,
+      ).toBe("ACTIVE");
 
-      status.unsubscribe();
+      subscription.unsubscribe();
     });
   });
 

--- a/domain/api/card-management/src/api.ts
+++ b/domain/api/card-management/src/api.ts
@@ -1,7 +1,7 @@
 import { cardApi } from "@shared/api-services";
 import { CARD_MANAGEMENT_TAGS } from "./constants";
 import {
-  PayCardFreezeResponseSchema,
+  PayCardFreezeStateResponseSchema,
   PayCardInternalWalletsResponseSchema,
   PayCardLinkedWalletsResponseSchema,
   PayCardLogoutResponseSchema,
@@ -14,7 +14,7 @@ import {
 import { transformPayCardSessionResponse } from "./transforms";
 import type {
   PayCardAuthorizationCodeRequest,
-  PayCardFreezeResult,
+  PayCardFreezeStateResult,
   PayCardInternalWallet,
   PayCardLinkedWallet,
   PayCardLogoutResult,
@@ -100,21 +100,21 @@ export const cardManagementApi = cardApi
         providesTags: ["CardStatus"],
       }),
 
-      freezeCard: build.mutation<PayCardFreezeResult, void>({
+      freezeCard: build.mutation<PayCardFreezeStateResult, void>({
         query: () => ({
           url: "/v1/card/freeze",
           method: "POST",
         }),
-        responseSchema: PayCardFreezeResponseSchema,
+        responseSchema: PayCardFreezeStateResponseSchema,
         invalidatesTags: ["CardStatus"],
       }),
 
-      unfreezeCard: build.mutation<PayCardFreezeResult, void>({
+      unfreezeCard: build.mutation<PayCardFreezeStateResult, void>({
         query: () => ({
           url: "/v1/card/unfreeze",
           method: "POST",
         }),
-        responseSchema: PayCardFreezeResponseSchema,
+        responseSchema: PayCardFreezeStateResponseSchema,
         invalidatesTags: ["CardStatus"],
       }),
 

--- a/domain/api/card-management/src/api.ts
+++ b/domain/api/card-management/src/api.ts
@@ -1,6 +1,7 @@
 import { cardApi } from "@shared/api-services";
 import { CARD_MANAGEMENT_TAGS } from "./constants";
 import {
+  PayCardFreezeResponseSchema,
   PayCardInternalWalletsResponseSchema,
   PayCardLinkedWalletsResponseSchema,
   PayCardLogoutResponseSchema,
@@ -13,6 +14,7 @@ import {
 import { transformPayCardSessionResponse } from "./transforms";
 import type {
   PayCardAuthorizationCodeRequest,
+  PayCardFreezeResult,
   PayCardInternalWallet,
   PayCardLinkedWallet,
   PayCardLogoutResult,
@@ -98,6 +100,24 @@ export const cardManagementApi = cardApi
         providesTags: ["CardStatus"],
       }),
 
+      freezeCard: build.mutation<PayCardFreezeResult, void>({
+        query: () => ({
+          url: "/v1/card/freeze",
+          method: "POST",
+        }),
+        responseSchema: PayCardFreezeResponseSchema,
+        invalidatesTags: ["CardStatus"],
+      }),
+
+      unfreezeCard: build.mutation<PayCardFreezeResult, void>({
+        query: () => ({
+          url: "/v1/card/unfreeze",
+          method: "POST",
+        }),
+        responseSchema: PayCardFreezeResponseSchema,
+        invalidatesTags: ["CardStatus"],
+      }),
+
       getInternalWallets: build.query<PayCardInternalWallet[], void>({
         query: () => ({
           url: "/v1/wallet/internal",
@@ -126,6 +146,8 @@ export const {
   useOrderCardMutation,
   useGetCardStatusQuery,
   useLazyGetCardStatusQuery,
+  useFreezeCardMutation,
+  useUnfreezeCardMutation,
   useGetInternalWalletsQuery,
   useGetCardLinkedWalletsQuery,
 } = cardManagementApi;

--- a/domain/api/card-management/src/schema.test.ts
+++ b/domain/api/card-management/src/schema.test.ts
@@ -1,6 +1,6 @@
 import {
   PayCardErrorResponseSchema,
-  PayCardFreezeResponseSchema,
+  PayCardFreezeStateResponseSchema,
   PayCardInternalWalletSchema,
   PayCardLinkedWalletSchema,
   PayCardLogoutResponseSchema,
@@ -74,9 +74,14 @@ describe("PayCardOrderResponseSchema", () => {
   });
 });
 
-describe("PayCardFreezeResponseSchema", () => {
-  it("reads the documented freeze response", () => {
-    expect(PayCardFreezeResponseSchema.parse({ success: true })).toEqual({ success: true });
+describe("PayCardFreezeStateResponseSchema", () => {
+  it("reads the documented response, which freeze and unfreeze share", () => {
+    expect(PayCardFreezeStateResponseSchema.parse({ success: true })).toEqual({ success: true });
+    expect(PayCardFreezeStateResponseSchema.parse({ success: false })).toEqual({ success: false });
+  });
+
+  it("rejects a success the provider sent as anything but a boolean", () => {
+    expect(() => PayCardFreezeStateResponseSchema.parse({ success: "yes" })).toThrow();
   });
 });
 

--- a/domain/api/card-management/src/schema.test.ts
+++ b/domain/api/card-management/src/schema.test.ts
@@ -1,5 +1,6 @@
 import {
   PayCardErrorResponseSchema,
+  PayCardFreezeResponseSchema,
   PayCardInternalWalletSchema,
   PayCardLinkedWalletSchema,
   PayCardLogoutResponseSchema,
@@ -70,6 +71,12 @@ describe("PayCardOrderResponseSchema", () => {
 
   it("rejects a success flag that is not a boolean", () => {
     expect(() => PayCardOrderResponseSchema.parse({ success: "yes" })).toThrow();
+  });
+});
+
+describe("PayCardFreezeResponseSchema", () => {
+  it("reads the documented freeze response", () => {
+    expect(PayCardFreezeResponseSchema.parse({ success: true })).toEqual({ success: true });
   });
 });
 

--- a/domain/api/card-management/src/schema.ts
+++ b/domain/api/card-management/src/schema.ts
@@ -42,6 +42,10 @@ export const PayCardOrderResponseSchema = z.object({
   success: z.boolean(),
 });
 
+export const PayCardFreezeResponseSchema = z.object({
+  success: z.boolean(),
+});
+
 export const PayCardStatusResponseSchema = z.object({
   id: z.string().min(1),
   holderName: z.string().min(1),

--- a/domain/api/card-management/src/schema.ts
+++ b/domain/api/card-management/src/schema.ts
@@ -42,7 +42,7 @@ export const PayCardOrderResponseSchema = z.object({
   success: z.boolean(),
 });
 
-export const PayCardFreezeResponseSchema = z.object({
+export const PayCardFreezeStateResponseSchema = z.object({
   success: z.boolean(),
 });
 

--- a/domain/api/card-management/src/types.ts
+++ b/domain/api/card-management/src/types.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import {
   PayCardErrorResponseSchema,
+  PayCardFreezeResponseSchema,
   PayCardInternalWalletSchema,
   PayCardLinkedWalletSchema,
   PayCardLogoutResponseSchema,
@@ -21,6 +22,8 @@ export type PayCardLogoutResult = z.infer<typeof PayCardLogoutResponseSchema>;
 export type PayCardUser = z.infer<typeof PayCardUserResponseSchema>;
 
 export type PayCardOrderResult = z.infer<typeof PayCardOrderResponseSchema>;
+
+export type PayCardFreezeResult = z.infer<typeof PayCardFreezeResponseSchema>;
 
 export type PayCardErrorResponse = z.infer<typeof PayCardErrorResponseSchema>;
 

--- a/domain/api/card-management/src/types.ts
+++ b/domain/api/card-management/src/types.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import {
   PayCardErrorResponseSchema,
-  PayCardFreezeResponseSchema,
+  PayCardFreezeStateResponseSchema,
   PayCardInternalWalletSchema,
   PayCardLinkedWalletSchema,
   PayCardLogoutResponseSchema,
@@ -23,7 +23,7 @@ export type PayCardUser = z.infer<typeof PayCardUserResponseSchema>;
 
 export type PayCardOrderResult = z.infer<typeof PayCardOrderResponseSchema>;
 
-export type PayCardFreezeResult = z.infer<typeof PayCardFreezeResponseSchema>;
+export type PayCardFreezeStateResult = z.infer<typeof PayCardFreezeStateResponseSchema>;
 
 export type PayCardErrorResponse = z.infer<typeof PayCardErrorResponseSchema>;
 


### PR DESCRIPTION
<!-- stac-man:stack-start -->
**Stack** _(managed by [stac-man](https://github.com/bluegardenproject/stac-man))_

- **#21163 feat/LIVE-34784-card-freeze-unfreeze ← this PR**
- #21399 feat/LIVE-35428-native-card-visual
- #21425 feat/LIVE-34772-card-balance-from-linked-wallets
- #21445 fix/pay-card-schema-failure-detail
- #21448 feat/pay-card-devtools-balance
- #21467 feat/LIVE-34778-card-details-token
- #21468 feat/pay-card-devtools-card-details
- #21495 feat/LIVE-34792-link-unlink-card-wallet
- #21533 feat/pay-card-devtools-freeze-unfreeze
<!-- stac-man:stack-end -->

Freezing is the only card state change the provider exposes: it moves an
`ACTIVE` card to `FROZEN` and back, and blocked cards accept neither. Both take
no request body and answer `{ success: true }`.

Both invalidate `CardStatus`, so the status a screen already holds refetches
itself once the card moves. Each endpoint carries its own documented 400 —
`Card is already frozen` and `Card is not frozen` — which the tests pin.

The README's endpoint table also still listed `initiateAuthorize`, removed when
the login started opening the authorize page directly. Dropped.

### 🔗 Context

- **JIRA**: [LIVE-34784 — freeze and unfreeze card](https://ledgerhq.atlassian.net/browse/LIVE-34784)
- **Epic**: [LIVE-35974 — Frontend Adapter to Baanx API](https://ledgerhq.atlassian.net/browse/LIVE-35974)
- **Baanx**: [`POST /v1/card/freeze`](https://docs.baanx.com/api-reference/card/freeze) · [`POST /v1/card/unfreeze`](https://docs.baanx.com/api-reference/card/unfreeze)

Freeze is the only card state change the provider exposes. A `BLOCKED` card accepts neither call —
that transition is system-initiated and irreversible, so there is nothing to add for it here.
