### PR TITLE
fix(e2e): disable broadcast on old send flow for dual-flow coins

### DIFF
--- a/e2e/desktop/tests/specs/send.tx.spec.ts
+++ b/e2e/desktop/tests/specs/send.tx.spec.ts
@@ -182,54 +182,66 @@ const transactionE2E = [
     transaction: new Transaction(Account.POL_1, Account.POL_2, "0.001", Fee.SLOW),
     xrayTicket: "B2CQA-2807",
     bugTickets: ["LIVE-28070"],
+    disableBroadcast: true,
   },
   {
     transaction: new Transaction(Account.DOGE_1, Account.DOGE_2, "0.01", Fee.SLOW),
     xrayTicket: "B2CQA-2573",
+    disableBroadcast: true,
   },
   {
     transaction: new Transaction(Account.BCH_1, Account.BCH_2, "0.0001", Fee.SLOW),
     xrayTicket: "B2CQA-2808",
+    disableBroadcast: true,
   },
   {
     transaction: new Transaction(Account.DOT_1, Account.DOT_2, "0.0001"),
     xrayTicket: "B2CQA-2809",
+    disableBroadcast: true,
   },
   {
     transaction: new Transaction(Account.ALGO_1, Account.ALGO_2, "0.001"),
     xrayTicket: "B2CQA-2810",
+    disableBroadcast: true,
     teamOwner: Team.BST,
   },
   {
     transaction: new Transaction(Account.SOL_1, Account.SOL_2, "0.000001", undefined, "noTag"),
     xrayTicket: "B2CQA-2811",
+    disableBroadcast: true,
   },
   {
     transaction: new Transaction(Account.TRX_1, Account.TRX_2, "0.01"),
     xrayTicket: "B2CQA-2812",
+    disableBroadcast: true,
   },
   {
     transaction: new Transaction(Account.XLM_1, Account.XLM_2, "0.0001", undefined, "noTag"),
     xrayTicket: "B2CQA-2813",
     bugTickets: ["LIVE-24214", "LIVE-29554"],
+    disableBroadcast: true,
   },
   {
     transaction: new Transaction(Account.ATOM_1, Account.ATOM_2, "0.00001", undefined, "noTag"),
     xrayTicket: "B2CQA-2814",
+    disableBroadcast: true,
   },
   {
     transaction: new Transaction(Account.ADA_1, Account.ADA_2, "1", undefined, "noTag"),
     xrayTicket: "B2CQA-2815",
+    disableBroadcast: true,
     teamOwner: Team.BST,
   },
   {
     transaction: new Transaction(Account.XRP_1, Account.XRP_2, "0.0001", undefined, "noTag"),
     xrayTicket: "B2CQA-2816",
+    disableBroadcast: true,
     teamOwner: Team.BST,
   },
   {
     transaction: new Transaction(Account.APTOS_1, Account.APTOS_2, "0.0001"),
     xrayTicket: "B2CQA-2920",
+    disableBroadcast: true,
     teamOwner: Team.BST,
   },
   {
@@ -240,29 +252,35 @@ const transactionE2E = [
       Fee.MEDIUM,
     ),
     xrayTicket: "B2CQA-3925",
+    disableBroadcast: true,
   },
   {
     transaction: new Transaction(Account.ETH_1, Account.ETH_3, "0.0001", Fee.SLOW),
     xrayTicket: "B2CQA-3924",
+    disableBroadcast: true,
   },
   {
     transaction: new Transaction(Account.KASPA_1, Account.KASPA_2, "0.2"),
     xrayTicket: "B2CQA-3840",
+    disableBroadcast: true,
     teamOwner: Team.BST,
   },
   {
     transaction: new Transaction(Account.SUI_1, Account.SUI_2, "0.0001", undefined),
     xrayTicket: "B2CQA-3802",
+    disableBroadcast: true,
     teamOwner: Team.BST,
   },
   {
     transaction: new Transaction(Account.BASE_1, Account.BASE_2, "0.000001"),
     xrayTicket: "B2CQA-4225",
+    disableBroadcast: true,
     bugTickets: ["LIVE-28070"],
   },
   {
     transaction: new Transaction(Account.VET_1, Account.VET_2, "0.1"),
     xrayTicket: "B2CQA-4247",
+    disableBroadcast: true,
     teamOwner: Team.BST,
   },
   {
@@ -274,11 +292,13 @@ const transactionE2E = [
   {
     transaction: new Transaction(Account.HEDERA_1, Account.HEDERA_2, "0.00001", undefined, "noTag"),
     xrayTicket: "B2CQA-4284",
+    disableBroadcast: true,
     teamOwner: Team.BST,
   },
   {
     transaction: new Transaction(Account.ICP_1, Account.ICP_2, "0.001"),
     xrayTicket: "B2CQA-4742",
+    disableBroadcast: true,
     teamOwner: Team.BST,
   },
   {


### PR DESCRIPTION
### 📝 Description

**Previous behaviour:** Old send flow (`send.tx.spec.ts`) and new send flow (`newSendFlow.tx.spec.ts`) tests run in parallel in CI (`fullyParallel: true`, `workers: 100%`). Both target the same sender accounts on the real network, so they race to spend the same UTXOs/balance. The faster new-flow test (fewer UI steps) broadcasts first; the old-flow test gets a double-spend rejection and the UI shows an error modal — causing `expectTxSent()` to time out.

**Fix:** Apply `disableBroadcast: true` to every entry in `transactionE2E` (old send flow) whose coin also appears in `newSendFlow.tx.spec.ts`. The new send flow retains the broadcast and proves the full network round-trip. The old send flow still exercises the complete UI path and device signing — it just skips the network submit via `DISABLE_TRANSACTION_BROADCAST=1`.

Coins updated: POL, DOGE, BCH, DOT, ALGO, SOL, TRX, XLM, ATOM, ADA, XRP, APTOS, BTC\_NATIVE\_SEGWIT, ETH, KASPA, SUI, BASE, VET, HEDERA, ICP.
ZEC was already set. ALEO has no new-flow counterpart and keeps broadcasting.

This fix does not affect any production code — it is test-file only.

### 🔗 Context

- **JIRA / GitHub issue**: N/A (nightly flake fix — KASPA double-spend race in CI)
- **Slack thread**: https://ledger.slack.com/archives/C05FKJ7DFAP/p1787737733069379?thread_ts=1787709351.772839&cid=C05FKJ7DFAP
- **CI run** (LWD · newSendFlow · broadcast ON): https://github.com/LedgerHQ/ledger-live/actions/runs/32974097654

🤖 Generated with [Claude Code](https://claude.com/claude-code)