### PR TITLE
[LWDM] fix(counter-values): schedule shared countervalue refreshes (LIVE-36444)

### DIFF
--- a/.changeset/calm-sparrows-schedule.md
+++ b/.changeset/calm-sparrows-schedule.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-countervalues-react": patch
+---
+
+Schedule countervalue refreshes without dropping requests in flight

--- a/libs/live-countervalues-react/src/index.tsx
+++ b/libs/live-countervalues-react/src/index.tsx
@@ -23,6 +23,9 @@ import React, {
   useContext,
   useEffect,
   useMemo,
+  useRef,
+  useState,
+  type MutableRefObject,
 } from "react";
 
 export interface PollingState {
@@ -68,6 +71,8 @@ export type Polling = {
   error: Error | null | undefined;
 };
 
+type PollingActions = Pick<Polling, "poll" | "start" | "stop">;
+
 export type Props = {
   /** Bridge enabling platform-specific persistence of countervalues state. */
   bridge: CountervaluesBridge;
@@ -85,6 +90,7 @@ export type Props = {
  * Base Countervalues Context to use without polling logic.
  */
 export const CountervaluesContext = createContext<CountervaluesBridge | null>(null);
+const PollingActionsContext = createContext<PollingActions | null>(null);
 
 function useCountervaluesBridgeContext() {
   const bridge = useContext(CountervaluesContext);
@@ -111,7 +117,10 @@ function Effect({
   savedState,
   debounceDelay = 1000,
   pollInitDelay = 3 * 1000,
-}: Pick<Props, "autopollInterval" | "bridge" | "debounceDelay" | "pollInitDelay" | "savedState">) {
+  pollingActionsRef,
+}: Pick<Props, "autopollInterval" | "bridge" | "debounceDelay" | "pollInitDelay" | "savedState"> & {
+  pollingActionsRef: MutableRefObject<PollingActions | null>;
+}) {
   const userSettings = bridge.useUserSettings();
   const { refreshRate, marketCapBatchingAfterRank } = userSettings;
 
@@ -136,40 +145,163 @@ function Effect({
     [marketCapBatchingAfterRank, marketcapIds],
   );
 
-  // flag used to trigger a loadCountervalues
-  const triggerLoad = bridge.usePollingTriggerLoad();
-
-  // trigger poll only when userSettings changes in a debounced way
-  useEffect(() => {
-    bridge.setPollingTriggerLoad(true);
-  }, [bridge, debouncedUserSettings]);
-
-  // loadCountervalues logic
   const currentState = bridge.useState();
   const pending = bridge.useStatePending();
+  const isPolling = bridge.usePollingIsPolling();
+  const pollingTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const pendingRef = useRef(pending);
+  const isPollingRef = useRef(isPolling);
+  const isLoadingRef = useRef(false);
+  const isPollScheduledRef = useRef(false);
+  const hasQueuedPollRef = useRef(false);
+  const isMountedRef = useRef(true);
+  const hasInitializedSettingsRef = useRef(false);
+  const [pollRequest, setPollRequest] = useState(0);
 
-  // loadCountervalues logic using bridge
+  pendingRef.current = pending;
+
+  const clearPollingTimeout = useCallback(() => {
+    if (pollingTimeoutRef.current === undefined) return;
+    clearTimeout(pollingTimeoutRef.current);
+    pollingTimeoutRef.current = undefined;
+  }, []);
+
+  const requestPoll = useCallback(() => {
+    clearPollingTimeout();
+
+    if (!isPollingRef.current) return;
+
+    if (isLoadingRef.current || pendingRef.current) {
+      hasQueuedPollRef.current = true;
+      return;
+    }
+
+    if (isPollScheduledRef.current) return;
+
+    isPollScheduledRef.current = true;
+    setPollRequest(request => request + 1);
+  }, [clearPollingTimeout]);
+
+  const schedulePoll = useCallback(
+    (delay: number) => {
+      clearPollingTimeout();
+
+      if (!isPollingRef.current) return;
+
+      pollingTimeoutRef.current = setTimeout(() => {
+        pollingTimeoutRef.current = undefined;
+        requestPoll();
+      }, delay);
+    },
+    [clearPollingTimeout, requestPoll],
+  );
+
+  const startPolling = useCallback(() => {
+    isPollingRef.current = true;
+    bridge.setPollingIsPolling(true);
+
+    if (!isLoadingRef.current && !isPollScheduledRef.current && !hasQueuedPollRef.current) {
+      schedulePoll(pollInitDelay);
+    }
+  }, [bridge, pollInitDelay, schedulePoll]);
+
+  const stopPolling = useCallback(() => {
+    isPollingRef.current = false;
+    hasQueuedPollRef.current = false;
+    isPollScheduledRef.current = false;
+    clearPollingTimeout();
+    bridge.setPollingIsPolling(false);
+  }, [bridge, clearPollingTimeout]);
+
+  pollingActionsRef.current = {
+    poll: requestPoll,
+    start: startPolling,
+    stop: stopPolling,
+  };
+
   useEffect(() => {
-    if (pending || !triggerLoad) return;
-    bridge.setPollingTriggerLoad(false);
+    isPollingRef.current = isPolling;
 
+    if (!isPolling) {
+      hasQueuedPollRef.current = false;
+      isPollScheduledRef.current = false;
+      clearPollingTimeout();
+      return;
+    }
+
+    if (!isLoadingRef.current && !isPollScheduledRef.current && !hasQueuedPollRef.current) {
+      schedulePoll(pollInitDelay);
+    }
+  }, [clearPollingTimeout, isPolling, pollInitDelay, schedulePoll]);
+
+  useEffect(() => {
+    if (!hasInitializedSettingsRef.current) {
+      hasInitializedSettingsRef.current = true;
+      return;
+    }
+
+    requestPoll();
+  }, [debouncedUserSettings, requestPoll]);
+
+  useEffect(() => {
+    if (pollRequest === 0 || !isPollScheduledRef.current) return;
+
+    isPollScheduledRef.current = false;
+
+    if (!isPollingRef.current) return;
+
+    if (isLoadingRef.current || pendingRef.current) {
+      hasQueuedPollRef.current = true;
+      return;
+    }
+
+    isLoadingRef.current = true;
+    pendingRef.current = true;
     bridge.setStatePending(true);
     loadCountervalues(
       currentState,
       filteredUserSettings,
       batchStrategySolver,
       filteredUserSettings.granularitiesRates,
-    ).then(
-      s => {
-        bridge.setState(s);
-        bridge.setStatePending(false);
-      },
-      e => {
-        bridge.setStateError(e);
-        bridge.setStatePending(false);
-      },
-    );
-  }, [pending, currentState, filteredUserSettings, triggerLoad, batchStrategySolver, bridge]);
+    )
+      .then(
+        s => {
+          bridge.setState(s);
+          pendingRef.current = false;
+          bridge.setStatePending(false);
+        },
+        e => {
+          bridge.setStateError(e);
+          pendingRef.current = false;
+          bridge.setStatePending(false);
+        },
+      )
+      .finally(() => {
+        isLoadingRef.current = false;
+
+        if (!isMountedRef.current || !isPollingRef.current) {
+          hasQueuedPollRef.current = false;
+          return;
+        }
+
+        if (hasQueuedPollRef.current) {
+          hasQueuedPollRef.current = false;
+          requestPoll();
+          return;
+        }
+
+        schedulePoll(refreshRate);
+      });
+  }, [
+    batchStrategySolver,
+    bridge,
+    currentState,
+    filteredUserSettings,
+    pollRequest,
+    refreshRate,
+    requestPoll,
+    schedulePoll,
+  ]);
 
   // restore state from persisted raw (history only so we know it's first run and check holes)
   useEffect(() => {
@@ -178,18 +310,20 @@ function Effect({
     bridge.setState(importCountervalues(savedState, userSettings));
   }, [bridge, savedState, userSettings]);
 
-  // manage the auto polling loop
-  const isPolling = bridge.usePollingIsPolling();
   useEffect(() => {
-    if (!isPolling) return;
-    let pollingTimeout: ReturnType<typeof setTimeout>;
-    function pollingLoop() {
-      bridge.setPollingTriggerLoad(true);
-      pollingTimeout = setTimeout(pollingLoop, refreshRate);
-    }
-    pollingTimeout = setTimeout(pollingLoop, pollInitDelay);
-    return () => clearTimeout(pollingTimeout);
-  }, [refreshRate, pollInitDelay, isPolling, bridge]);
+    isMountedRef.current = true;
+    pollingActionsRef.current = {
+      poll: requestPoll,
+      start: startPolling,
+      stop: stopPolling,
+    };
+
+    return () => {
+      isMountedRef.current = false;
+      clearPollingTimeout();
+      pollingActionsRef.current = null;
+    };
+  }, [clearPollingTimeout, pollingActionsRef, requestPoll, startPolling, stopPolling]);
 
   return null;
 }
@@ -198,10 +332,22 @@ function Effect({
  * Root countervalues provider (polling + calculation).
  */
 export function CountervaluesProvider({ children, bridge, ...rest }: Props): ReactElement {
+  const pollingActionsRef = useRef<PollingActions | null>(null);
+  const pollingActions = useMemo<PollingActions>(
+    () => ({
+      poll: () => pollingActionsRef.current?.poll(),
+      start: () => pollingActionsRef.current?.start(),
+      stop: () => pollingActionsRef.current?.stop(),
+    }),
+    [],
+  );
+
   return (
     <CountervaluesContext.Provider value={bridge}>
-      <Effect {...rest} bridge={bridge} />
-      {children}
+      <PollingActionsContext.Provider value={pollingActions}>
+        <Effect {...rest} bridge={bridge} pollingActionsRef={pollingActionsRef} />
+        {children}
+      </PollingActionsContext.Provider>
     </CountervaluesContext.Provider>
   );
 }
@@ -214,18 +360,22 @@ export function useCountervaluesState(): CounterValuesState {
 /** Allows consumer to access the countervalues polling control object */
 export function useCountervaluesPolling(): Polling {
   const bridge = useCountervaluesBridgeContext();
+  const pollingActions = useContext(PollingActionsContext);
   const pending = bridge.useStatePending();
   const error = bridge.useStateError();
+
+  if (!pollingActions) {
+    throw new Error("'useCountervaluesPolling' must be used within a 'CountervaluesProvider'");
+  }
+
   return useMemo(
     () => ({
-      poll: () => bridge.setPollingTriggerLoad(true),
-      start: () => bridge.setPollingIsPolling(true),
-      stop: () => bridge.setPollingIsPolling(false),
+      ...pollingActions,
       wipe: () => bridge.wipe(),
       pending,
       error,
     }),
-    [bridge, error, pending],
+    [bridge, error, pending, pollingActions],
   );
 }
 

--- a/libs/live-countervalues-react/src/react.test.ts
+++ b/libs/live-countervalues-react/src/react.test.ts
@@ -1,5 +1,10 @@
 import React from "react";
-import { CountervaluesProvider, useTrackingPairForAccounts, type CountervaluesBridge } from ".";
+import {
+  CountervaluesProvider,
+  useCountervaluesPolling,
+  useTrackingPairForAccounts,
+  type CountervaluesBridge,
+} from ".";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { renderHook, act, render, waitFor } from "@testing-library/react";
 import {
@@ -176,13 +181,19 @@ describe("CountervaluesProvider", () => {
     mockLoadCountervalues.mockResolvedValue(initialState);
   });
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it("should filter unsupported tracking pairs before polling when marketcap ids are loaded", async () => {
     const bridge = createBridge({
       marketcapIds: [bitcoin.id],
       trackingPairs: [supportedPair, unsupportedPair],
     });
 
-    render(React.createElement(CountervaluesProvider, { bridge, children: null }));
+    render(
+      React.createElement(CountervaluesProvider, { bridge, children: null, pollInitDelay: 0 }),
+    );
 
     await waitFor(() => expect(mockLoadCountervalues).toHaveBeenCalledTimes(1));
     expect(mockLoadCountervalues.mock.calls[0][1].trackingPairs).toEqual([supportedPair]);
@@ -192,10 +203,140 @@ describe("CountervaluesProvider", () => {
     const trackingPairs = [supportedPair, unsupportedPair];
     const bridge = createBridge({ marketcapIds: [], trackingPairs });
 
-    render(React.createElement(CountervaluesProvider, { bridge, children: null }));
+    render(
+      React.createElement(CountervaluesProvider, { bridge, children: null, pollInitDelay: 0 }),
+    );
 
     await waitFor(() => expect(mockLoadCountervalues).toHaveBeenCalledTimes(1));
     expect(mockLoadCountervalues.mock.calls[0][1].trackingPairs).toBe(trackingPairs);
+  });
+
+  it("should perform an explicit poll immediately and wait a refresh interval before polling again", async () => {
+    jest.useFakeTimers();
+    const bridge = createBridge({ marketcapIds: [], trackingPairs: [supportedPair] });
+    const { result, unmount } = renderPolling(bridge);
+
+    act(() => {
+      result.current.poll();
+    });
+
+    await waitFor(() => expect(mockLoadCountervalues).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(3_000);
+    });
+
+    expect(mockLoadCountervalues).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(57_000);
+    });
+
+    expect(mockLoadCountervalues).toHaveBeenCalledTimes(2);
+    unmount();
+  });
+
+  it("should coalesce polls requested while a countervalue request is in flight", async () => {
+    const bridge = createBridge({ marketcapIds: [], trackingPairs: [supportedPair] });
+    const inFlightLoad = deferred<CounterValuesState>();
+    mockLoadCountervalues
+      .mockResolvedValueOnce(initialState)
+      .mockReturnValueOnce(inFlightLoad.promise);
+    const { result, unmount } = renderPolling(bridge);
+
+    act(() => {
+      result.current.poll();
+    });
+    await waitFor(() => expect(mockLoadCountervalues).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      result.current.poll();
+    });
+    await waitFor(() => expect(mockLoadCountervalues).toHaveBeenCalledTimes(2));
+
+    act(() => {
+      result.current.poll();
+      result.current.poll();
+    });
+
+    await act(async () => {
+      inFlightLoad.resolve(initialState);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(mockLoadCountervalues).toHaveBeenCalledTimes(3));
+    unmount();
+  });
+
+  it("should not run a queued poll after polling stops", async () => {
+    const bridge = createBridge({ marketcapIds: [], trackingPairs: [supportedPair] });
+    const inFlightLoad = deferred<CounterValuesState>();
+    mockLoadCountervalues.mockReturnValueOnce(inFlightLoad.promise);
+    const { result, unmount } = renderPolling(bridge);
+
+    act(() => {
+      result.current.poll();
+    });
+    await waitFor(() => expect(mockLoadCountervalues).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      result.current.poll();
+      result.current.stop();
+    });
+
+    await act(async () => {
+      inFlightLoad.resolve(initialState);
+      await Promise.resolve();
+    });
+
+    expect(mockLoadCountervalues).toHaveBeenCalledTimes(1);
+    expect(bridge.setPollingIsPolling).toHaveBeenLastCalledWith(false);
+    unmount();
+  });
+
+  it("should start automatic polling after the initial delay", async () => {
+    jest.useFakeTimers();
+    const bridge = createBridge({ marketcapIds: [], trackingPairs: [supportedPair] });
+    const { unmount } = renderPolling(bridge, 3_000);
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(2_999);
+    });
+
+    expect(mockLoadCountervalues).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(1);
+    });
+
+    expect(mockLoadCountervalues).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it("should retry at the refresh interval after a failed poll", async () => {
+    jest.useFakeTimers();
+    const bridge = createBridge({ marketcapIds: [], trackingPairs: [supportedPair] });
+    mockLoadCountervalues.mockRejectedValueOnce(new Error("countervalues unavailable"));
+    const { unmount } = renderPolling(bridge, 0);
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(0);
+    });
+
+    expect(mockLoadCountervalues).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(59_999);
+    });
+
+    expect(mockLoadCountervalues).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(1);
+    });
+
+    expect(mockLoadCountervalues).toHaveBeenCalledTimes(2);
+    unmount();
   });
 });
 
@@ -225,7 +366,7 @@ function createBridge({
     setStateError: jest.fn(),
     setStatePending: jest.fn(),
     useMarketcapIds: () => marketcapIds,
-    usePollingIsPolling: () => false,
+    usePollingIsPolling: () => true,
     usePollingTriggerLoad: () => true,
     useStateError: () => null,
     useStatePending: () => false,
@@ -233,4 +374,20 @@ function createBridge({
     useUserSettings: () => settings,
     wipe: jest.fn(),
   };
+}
+
+function renderPolling(bridge: CountervaluesBridge, pollInitDelay = 0) {
+  return renderHook(() => useCountervaluesPolling(), {
+    wrapper: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(CountervaluesProvider, { bridge, pollInitDelay, children }),
+  });
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void;
+  const promise = new Promise<T>(resolvePromise => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve: resolve! };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Scheduler tests cover immediate requests, coalescing during an in-flight request, stop behavior, initial delay, and retry cadence.
- [x] **Impact of the changes:**
      Countervalue refresh requests are serialized and scheduled from the configured refresh interval after each result.

### 📝 Description

A boolean polling trigger can lose the intent to refresh when another countervalue request is already pending, and an automatic poll can follow an explicit refresh after the initial delay.

This PR moves scheduling into `@ledgerhq/live-countervalues-react`. The existing `poll()`, `start()`, and `stop()` API remains unchanged. One request runs at a time; concurrent requests coalesce into one follow-up request; and automatic polling resumes after `refreshRate`.

```ts
poll(); // immediate request, or one queued follow-up when a request is in flight
```

### ❓ Context

- **JIRA or GitHub link**: [LIVE-36444](https://ledgerhq.atlassian.net/browse/LIVE-36444)
- **Related Mobile lifecycle PR**: #21150

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-36444]: https://ledgerhq.atlassian.net/browse/LIVE-36444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ