### PR TITLE
[LWM] fix(pay): show action tiles in every hero state (LIVE-36422)

### DIFF
--- a/.changeset/pay-action-tiles.md
+++ b/.changeset/pay-action-tiles.md
@@ -1,0 +1,7 @@
+---
+"@features/flow-pay-balance": minor
+"live-mobile": minor
+"ledger-live-desktop": minor
+---
+
+Show Pay action tiles in every hero state (LIVE-36422).

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
@@ -184,8 +184,8 @@ describe("PayTab integration", () => {
       expect(screen.getByText(EMPTY_TITLE)).toBeVisible();
       expect(screen.getByText(EMPTY_DESCRIPTION)).toBeVisible();
       expect(screen.queryByTestId("pay-card-balance-funded-state")).toBeNull();
-      expect(screen.queryByTestId("action-tile-deposit")).toBeNull();
-      expect(screen.queryByTestId("action-tile-request")).toBeNull();
+      expect(screen.getByTestId("action-tile-deposit")).toBeVisible();
+      expect(screen.getByTestId("action-tile-request")).toBeVisible();
     });
 
     it("should render the aggregated stablecoin balance when the user holds stablecoins", async () => {

--- a/features/flow/pay-balance/README.md
+++ b/features/flow/pay-balance/README.md
@@ -10,6 +10,9 @@ Shared Pay hero (Desktop and Mobile) for the aggregated stablecoin balance. Rend
 - **empty** — a placeholder title and description, no balance. Used when the balance is zero or
   `status` is `"error"`.
 
+Action tiles render in both modes, as a sibling of the hero so they do not remount when
+empty and funded swap.
+
 ## Usage
 
 ```tsx

--- a/features/flow/pay-balance/src/__tests__/BalanceFundedState.native.test.tsx
+++ b/features/flow/pay-balance/src/__tests__/BalanceFundedState.native.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen, userEvent } from "@testing-library/react-native";
 import { BalanceFundedState } from "../components/Hero/BalanceFundedState.native";
-import { depositActionTiles, fundedStateProps } from "./fixtures";
+import { fundedStateProps } from "./fixtures";
 
 describe("BalanceFundedState (Native)", () => {
   it("should render the funded balance and the filter select", () => {
@@ -20,11 +20,5 @@ describe("BalanceFundedState (Native)", () => {
     await user.press(screen.getByTestId("pay-card-balance-filter-pill"));
 
     expect(onOpenFilter).toHaveBeenCalledTimes(1);
-  });
-
-  it("should render the action tiles when provided", () => {
-    render(<BalanceFundedState {...fundedStateProps} actionTiles={depositActionTiles} />);
-
-    expect(screen.getByTestId("action-tile-deposit")).toBeTruthy();
   });
 });

--- a/features/flow/pay-balance/src/__tests__/BalanceFundedState.web.test.tsx
+++ b/features/flow/pay-balance/src/__tests__/BalanceFundedState.web.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { screen } from "@testing-library/react";
 import { BalanceFundedState } from "../components/Hero/BalanceFundedState.web";
-import { depositActionTiles, fundedStateProps, usdcOption } from "./fixtures";
+import { fundedStateProps, usdcOption } from "./fixtures";
 import { renderWithStyle } from "./renderWithStyle.web";
 
 describe("BalanceFundedState (Web)", () => {
@@ -26,11 +26,5 @@ describe("BalanceFundedState (Web)", () => {
     await screen.getByTestId("pay-card-balance-filter-pill").click();
 
     expect(onOpenFilter).toHaveBeenCalledTimes(1);
-  });
-
-  it("should render the action tiles when provided", () => {
-    renderWithStyle(<BalanceFundedState {...fundedStateProps} actionTiles={depositActionTiles} />);
-
-    expect(screen.getByTestId("action-tile-deposit")).toBeVisible();
   });
 });

--- a/features/flow/pay-balance/src/__tests__/BalanceView.native.test.tsx
+++ b/features/flow/pay-balance/src/__tests__/BalanceView.native.test.tsx
@@ -3,7 +3,13 @@ import { View } from "react-native";
 import { render, screen } from "@testing-library/react-native";
 import type { BalanceViewProps } from "../types";
 import { BalanceView } from "../components/Hero/BalanceView.native";
-import { emptyLabels, filterLabels, formatCountervalue, options } from "./fixtures";
+import {
+  depositActionTiles,
+  emptyLabels,
+  filterLabels,
+  formatCountervalue,
+  options,
+} from "./fixtures";
 
 jest.mock("@shared/ui-queued-bottom-sheet", () => ({
   QueuedBottomSheet: ({
@@ -60,5 +66,17 @@ describe("BalanceView (Native)", () => {
 
     expect(screen.getByTestId("pay-card-balance-funded-state")).toBeVisible();
     expect(screen.queryByTestId("pay-card-balance-empty-state")).toBeNull();
+  });
+
+  it("should render action tiles when empty", () => {
+    renderView({ displayMode: "empty", labels: emptyLabels, actionTiles: depositActionTiles });
+
+    expect(screen.getByTestId("action-tile-deposit")).toBeVisible();
+  });
+
+  it("should render action tiles when funded", () => {
+    renderView({ ...fundedProps(), actionTiles: depositActionTiles });
+
+    expect(screen.getByTestId("action-tile-deposit")).toBeVisible();
   });
 });

--- a/features/flow/pay-balance/src/__tests__/BalanceView.web.test.tsx
+++ b/features/flow/pay-balance/src/__tests__/BalanceView.web.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { screen } from "@testing-library/react";
 import { BalanceView } from "../components/Hero/BalanceView.web";
 import type { BalanceViewProps } from "../types";
-import { formatCountervalue, labels, options } from "./fixtures";
+import { depositActionTiles, formatCountervalue, labels, options } from "./fixtures";
 import { renderWithStyle } from "./renderWithStyle.web";
 
 function fundedProps(overrides: Partial<BalanceViewProps> = {}): BalanceViewProps {
@@ -38,6 +38,18 @@ describe("BalanceView (Web)", () => {
     renderView({ displayMode: "empty", labels });
 
     expect(screen.queryByTestId("pay-card-balance-funded-state")).not.toBeInTheDocument();
+  });
+
+  it("should render action tiles when empty", () => {
+    renderView({ displayMode: "empty", labels, actionTiles: depositActionTiles });
+
+    expect(screen.getByTestId("action-tile-deposit")).toBeVisible();
+  });
+
+  it("should render action tiles when funded", () => {
+    renderView(fundedProps({ actionTiles: depositActionTiles }));
+
+    expect(screen.getByTestId("action-tile-deposit")).toBeVisible();
   });
 
   it("should render the funded balance and pill when funded", () => {

--- a/features/flow/pay-balance/src/__tests__/useBalanceViewModel.web.test.ts
+++ b/features/flow/pay-balance/src/__tests__/useBalanceViewModel.web.test.ts
@@ -19,9 +19,15 @@ function buildProps(overrides: Partial<BalanceProps> = {}): BalanceProps {
 
 describe("useBalanceViewModel", () => {
   it("should be empty when the user has no balance", () => {
-    const { result } = renderHook(() => useBalanceViewModel(buildProps({ hasBalance: false })));
+    const actionTiles = { page: "Pay", tiles: [] };
+    const { result } = renderHook(() =>
+      useBalanceViewModel(buildProps({ hasBalance: false, actionTiles })),
+    );
 
-    expect(result.current.displayMode).toBe("empty");
+    expect(result.current).toMatchObject({
+      displayMode: "empty",
+      actionTiles,
+    });
   });
 
   it("should be funded when the user has balance and is ready", () => {

--- a/features/flow/pay-balance/src/components/Hero/BalanceBody.tsx
+++ b/features/flow/pay-balance/src/components/Hero/BalanceBody.tsx
@@ -5,7 +5,7 @@ import { BalanceFundedState } from "./BalanceFundedState";
 import { BalanceFilterPicker } from "../Filter/BalanceFilterPicker";
 
 export function BalanceBody(props: BalanceViewProps) {
-  if (props.displayMode !== "funded") {
+  if (props.displayMode === "empty") {
     return <BalanceEmptyState labels={props.labels} />;
   }
 
@@ -18,7 +18,6 @@ export function BalanceBody(props: BalanceViewProps) {
         allStablecoinsLabel={props.labels.allStablecoins}
         selectedOption={props.selectedOption}
         onOpenFilter={props.onOpenFilter}
-        actionTiles={props.actionTiles}
       />
       <BalanceFilterPicker
         isOpen={props.isFilterOpen}

--- a/features/flow/pay-balance/src/components/Hero/BalanceFundedState.native.tsx
+++ b/features/flow/pay-balance/src/components/Hero/BalanceFundedState.native.tsx
@@ -1,7 +1,5 @@
 import React from "react";
 import { AmountDisplay, Box } from "@ledgerhq/lumen-ui-rnative";
-import { ActionTiles } from "../ActionTiles";
-import type { ActionTilesProps } from "../ActionTiles";
 import type { FormattedValue, BalanceFilterOption } from "../../types";
 import { BalanceFilterSelect } from "../Filter/BalanceFilterSelect.native";
 
@@ -9,7 +7,6 @@ type BalanceFundedStateProps = Readonly<{
   balance: number;
   formatCountervalue: (value: number) => FormattedValue;
   isLoading: boolean;
-  actionTiles?: ActionTilesProps;
   allStablecoinsLabel: string;
   selectedOption?: BalanceFilterOption;
   onOpenFilter: () => void;
@@ -22,7 +19,6 @@ export function BalanceFundedState({
   allStablecoinsLabel,
   selectedOption,
   onOpenFilter,
-  actionTiles,
 }: BalanceFundedStateProps) {
   return (
     <Box
@@ -41,9 +37,6 @@ export function BalanceFundedState({
         selectedOption={selectedOption}
         onOpenFilter={onOpenFilter}
       />
-      <Box lx={{ marginTop: "s40", alignItems: "center", justifyContent: "center" }}>
-        {actionTiles && <ActionTiles {...actionTiles} />}
-      </Box>
     </Box>
   );
 }

--- a/features/flow/pay-balance/src/components/Hero/BalanceFundedState.web.tsx
+++ b/features/flow/pay-balance/src/components/Hero/BalanceFundedState.web.tsx
@@ -1,7 +1,5 @@
 import React from "react";
 import { AmountDisplay } from "@ledgerhq/lumen-ui-react";
-import { ActionTiles } from "../ActionTiles";
-import type { ActionTilesProps } from "../ActionTiles";
 import type { FormattedValue, BalanceFilterOption } from "../../types";
 import { BalanceFilterPill } from "../Filter/BalanceFilterPill";
 
@@ -12,7 +10,6 @@ type BalanceFundedStateProps = Readonly<{
   allStablecoinsLabel: string;
   selectedOption?: BalanceFilterOption;
   onOpenFilter: () => void;
-  actionTiles?: ActionTilesProps;
 }>;
 
 export function BalanceFundedState({
@@ -22,7 +19,6 @@ export function BalanceFundedState({
   allStablecoinsLabel,
   selectedOption,
   onOpenFilter,
-  actionTiles,
 }: BalanceFundedStateProps) {
   return (
     <div className="flex flex-col gap-24" data-testid="pay-card-balance-funded-state">
@@ -39,7 +35,6 @@ export function BalanceFundedState({
           onClick={onOpenFilter}
         />
       </div>
-      {actionTiles && <ActionTiles {...actionTiles} />}
     </div>
   );
 }

--- a/features/flow/pay-balance/src/components/Hero/BalanceView.native.tsx
+++ b/features/flow/pay-balance/src/components/Hero/BalanceView.native.tsx
@@ -1,12 +1,18 @@
 import React from "react";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import type { BalanceViewProps } from "../../types";
+import { ActionTiles } from "../ActionTiles";
 import { BalanceBody } from "./BalanceBody";
 
 export function BalanceView(props: BalanceViewProps) {
   return (
     <Box lx={{ paddingHorizontal: "s16" }} testID="pay-card-balance">
       <BalanceBody {...props} />
+      {props.actionTiles && (
+        <Box lx={{ marginTop: "s40", alignItems: "center", justifyContent: "center" }}>
+          <ActionTiles {...props.actionTiles} />
+        </Box>
+      )}
     </Box>
   );
 }

--- a/features/flow/pay-balance/src/components/Hero/BalanceView.web.tsx
+++ b/features/flow/pay-balance/src/components/Hero/BalanceView.web.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { Divider } from "@ledgerhq/lumen-ui-react";
 import type { BalanceViewProps } from "../../types";
+import { ActionTiles } from "../ActionTiles";
 import { BalanceBody } from "./BalanceBody";
 
 export function BalanceView(props: BalanceViewProps) {
   return (
     <div className="flex flex-col gap-24" data-testid="pay-card-balance">
       <BalanceBody {...props} />
+      {props.actionTiles && <ActionTiles {...props.actionTiles} />}
       <Divider orientation="horizontal" />
     </div>
   );

--- a/features/flow/pay-balance/src/components/Hero/useBalanceViewModel.ts
+++ b/features/flow/pay-balance/src/components/Hero/useBalanceViewModel.ts
@@ -41,7 +41,7 @@ export function useBalanceViewModel({
   );
 
   if (!isFunded) {
-    return { displayMode: "empty", labels };
+    return { displayMode: "empty", labels, actionTiles };
   }
 
   return {

--- a/features/flow/pay-balance/src/types.ts
+++ b/features/flow/pay-balance/src/types.ts
@@ -84,6 +84,7 @@ export type BalanceViewProps =
   | Readonly<{
       displayMode: "empty";
       labels: BalanceEmptyLabels;
+      actionTiles?: ActionTilesProps;
     }>
   | Readonly<{
       displayMode: "funded";


### PR DESCRIPTION
## Summary
- Render Pay Deposit / Request tiles in every hero state (empty and funded)
- Tiles sit as a sibling of the hero so they do not remount when chrome swaps

Follow-up: #21144 (named hero states + loaded amount).

<img width="699" height="542" alt="image" src="https://github.com/user-attachments/assets/6db9a341-9055-43af-9fa0-cf1e3d8441cd" />
<img width="448" height="811" alt="image" src="https://github.com/user-attachments/assets/3f2485a1-f349-4a2f-b86f-4cd9e8268339" />


https://ledgerhq.atlassian.net/browse/LIVE-36422