### PR TITLE
[LWM] fix(mobile): Improve keyboard behavior for bottom sheets (LIVE-35853)

### DIFF
--- a/.changeset/quiet-sheets-rise.md
+++ b/.changeset/quiet-sheets-rise.md
@@ -1,0 +1,7 @@
+---
+"@features/flow-contacts-edit-address": minor
+"@shared/ui-queued-bottom-sheet": minor
+"live-mobile": minor
+---
+
+Fix the mobile Contacts edit address sheet staying hidden behind the keyboard, and retract the keyboard when a bottom sheet starts closing so the sheet can be reopened afterwards.

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -1061,6 +1061,35 @@ describe("Contacts integration", () => {
     });
   });
 
+  it("should reopen the edit address sheet after closing it", async () => {
+    const { user } = render(<MyWalletNavigator />, {
+      overrideInitialState: withContactsPageReadyState(
+        { lwmContacts: { enabled: true, params: { newBadge: false } } },
+        state => ({ ...state, contacts: { contacts: mockPopulatedContacts() } }),
+      ),
+    });
+
+    await user.press(screen.getByTestId("my-wallet-contacts-button"));
+    await user.press(await screen.findByTestId("contacts-saved-contact-contact-ben"));
+    await user.press(await screen.findByTestId("contacts-detail-address-row-address-ethereum"));
+    await user.press(await screen.findByText("Edit"));
+
+    expect(await screen.findByTestId("contacts-rename-address-confirm")).toBeVisible();
+
+    // The address detail sheet stays mounted behind the edit sheet, which is rendered last.
+    const closeButtons = screen.getAllByTestId("bottom-sheet-header-close-button");
+    await user.press(closeButtons[closeButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("contacts-rename-address-confirm")).toBeNull();
+    });
+
+    await user.press(await screen.findByTestId("contacts-detail-address-row-address-ethereum"));
+    await user.press(await screen.findByText("Edit"));
+
+    expect(await screen.findByTestId("contacts-rename-address-confirm")).toBeVisible();
+  });
+
   it("should rename an address after confirming on the signer sheet", async () => {
     const { user } = render(<MyWalletNavigator />, {
       overrideInitialState: withContactsPageReadyState(

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactAddressDetailActionsSheets/ContactAddressDetailActionsSheets.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactAddressDetailActionsSheets/ContactAddressDetailActionsSheets.test.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { Platform } from "react-native";
+import { BottomSheetView } from "@ledgerhq/lumen-ui-rnative";
+import {
+  createInactiveContactAddressDetailActionsUiState,
+  resolveContactAddressDetailActionsLabels,
+} from "@features/flow-contacts";
+import { render, screen } from "@tests/test-renderer";
+import type { ContactAddressDetailActionsFlowProps } from "LLM/features/Contacts";
+import { ContactAddressDetailActionsSheets } from ".";
+
+const mockUseKeyboardVisible = jest.fn();
+const mockShouldUseKeyboardAvoidance = jest.fn();
+const originalPlatform = Platform.OS;
+
+jest.mock("~/logic/keyboardVisible", () => ({
+  useKeyboardVisible: (...args: unknown[]) => mockUseKeyboardVisible(...args),
+  shouldUseKeyboardAvoidance: (...args: unknown[]) => mockShouldUseKeyboardAvoidance(...args),
+}));
+
+type SheetsProps = Pick<
+  ContactAddressDetailActionsFlowProps,
+  "deleteSheet" | "renameSheet" | "signerSheet" | "signerMismatchSheet"
+>;
+
+function createProps(isRenameOpen = true): SheetsProps {
+  const uiState = createInactiveContactAddressDetailActionsUiState(
+    resolveContactAddressDetailActionsLabels({ t: key => key }),
+  );
+
+  return {
+    deleteSheet: uiState.delete,
+    renameSheet: { ...uiState.rename, isOpen: isRenameOpen },
+    signerSheet: uiState.signer,
+    signerMismatchSheet: uiState.signerMismatch,
+  };
+}
+
+function renameSheetPaddings(): unknown[] {
+  return screen.UNSAFE_getAllByType(BottomSheetView).map(view => view.props.style?.paddingBottom);
+}
+
+describe("ContactAddressDetailActionsSheets", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseKeyboardVisible.mockReturnValue({ isKeyboardVisible: false, keyboardHeight: 0 });
+    mockShouldUseKeyboardAvoidance.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    Platform.OS = originalPlatform;
+  });
+
+  it("should keep the edit address form above the keyboard", () => {
+    mockUseKeyboardVisible.mockReturnValue({ isKeyboardVisible: true, keyboardHeight: 300 });
+
+    render(<ContactAddressDetailActionsSheets {...createProps()} />);
+
+    expect(renameSheetPaddings()).toContain(324);
+  });
+
+  it("should omit the keyboard inset when native resize handles the keyboard", () => {
+    mockUseKeyboardVisible.mockReturnValue({ isKeyboardVisible: true, keyboardHeight: 300 });
+    mockShouldUseKeyboardAvoidance.mockReturnValue(false);
+
+    render(<ContactAddressDetailActionsSheets {...createProps()} />);
+
+    expect(renameSheetPaddings()).not.toContain(324);
+  });
+
+  it("should use will events on iOS", () => {
+    Platform.OS = "ios";
+
+    render(<ContactAddressDetailActionsSheets {...createProps()} />);
+
+    expect(mockUseKeyboardVisible).toHaveBeenCalledWith({ eventTiming: "will" });
+  });
+
+  it("should use did events on Android", () => {
+    Platform.OS = "android";
+
+    render(<ContactAddressDetailActionsSheets {...createProps()} />);
+
+    expect(mockUseKeyboardVisible).toHaveBeenCalledWith({ eventTiming: "did" });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactAddressDetailActionsSheets/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactAddressDetailActionsSheets/index.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from "react";
+import { Platform } from "react-native";
 import {
   ContactsDeleteAddressDialog,
   ContactsEditSignerDialog,
@@ -6,6 +7,7 @@ import {
 } from "@features/flow-contacts";
 import { ContactsRenameAddressDialog } from "@features/flow-contacts-edit-address";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { shouldUseKeyboardAvoidance, useKeyboardVisible } from "~/logic/keyboardVisible";
 import { QueuedBottomSheet } from "@shared/ui-queued-bottom-sheet";
 import type { ContactAddressDetailActionsFlowProps } from "LLM/features/Contacts";
 
@@ -21,6 +23,12 @@ export function ContactAddressDetailActionsSheets({
   signerMismatchSheet,
 }: ContactAddressDetailActionsSheetsProps): React.JSX.Element {
   const { bottom: bottomInset } = useSafeAreaInsets();
+  const { keyboardHeight } = useKeyboardVisible({
+    eventTiming: Platform.OS === "ios" ? "will" : "did",
+  });
+  const keyboardInset = shouldUseKeyboardAvoidance(Platform.OS, Platform.Version)
+    ? keyboardHeight
+    : 0;
   const onCloseDelete = useCallback(() => {
     deleteSheet.onCancel();
   }, [deleteSheet]);
@@ -67,7 +75,11 @@ export function ContactAddressDetailActionsSheets({
         testID="contacts-rename-address-sheet"
         enableDynamicSizing
       >
-        <ContactsRenameAddressDialog {...renameSheet} bottomInset={bottomInset} />
+        <ContactsRenameAddressDialog
+          {...renameSheet}
+          bottomInset={bottomInset}
+          keyboardInset={keyboardInset}
+        />
       </QueuedBottomSheet>
     </>
   );

--- a/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDrawer.native.test.tsx
+++ b/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDrawer.native.test.tsx
@@ -96,4 +96,12 @@ describe("ContactsRenameAddressDrawer", () => {
 
     expect(screen.queryByText("Edit address")).not.toBeOnTheScreen();
   });
+
+  it("should reserve room for the keyboard so the form stays above it", () => {
+    const { toJSON } = render(
+      <ContactsRenameAddressDialog {...createViewModel({ bottomInset: 8, keyboardInset: 300 })} />,
+    );
+
+    expect(toJSON()).toMatchObject({ props: { style: { paddingBottom: 332 } } });
+  });
 });

--- a/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDrawer.native.tsx
+++ b/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDrawer.native.tsx
@@ -20,6 +20,7 @@ export function ContactsRenameAddressDialog({
   draftLabel,
   invalidLabelError,
   bottomInset = 0,
+  keyboardInset = 0,
   labels,
   onDraftLabelChange,
   onAddressChange,
@@ -35,7 +36,7 @@ export function ContactsRenameAddressDialog({
   });
 
   return (
-    <BottomSheetView style={{ paddingBottom: bottomInset + 24 }}>
+    <BottomSheetView style={{ paddingBottom: bottomInset + 24 + keyboardInset }}>
       {isOpen ? (
         <Box lx={{ gap: "s24" }}>
           <BottomSheetHeader density="expanded" title={labels.title} />

--- a/features/flow/flow-contacts-edit-address/src/types.ts
+++ b/features/flow/flow-contacts-edit-address/src/types.ts
@@ -98,6 +98,7 @@ export type ContactsRenameAddressDialogProps = RenameAddressDialogViewModel &
 export type ContactsRenameAddressDrawerProps = RenameAddressDialogViewModel &
   Readonly<{
     bottomInset?: number;
+    keyboardInset?: number;
     labels: ContactsRenameAddressLabels;
   }>;
 

--- a/shared/ui-queued-bottom-sheet/src/internals/useQueuedBottomSheet.native.test.ts
+++ b/shared/ui-queued-bottom-sheet/src/internals/useQueuedBottomSheet.native.test.ts
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Keyboard } from "react-native";
 import { renderHook, act } from "@testing-library/react-native";
 import { useQueuedBottomSheet } from "./useQueuedBottomSheet";
 import type { BottomSheetStateHandlers } from "../contexts/QueuedBottomSheetsContext";
@@ -24,6 +25,8 @@ jest.mock("../contexts/QueuedBottomSheetsContext", () => ({
     _clearQueueDIRTYDONOTUSE: jest.fn(),
   }),
 }));
+
+type HookResult = ReturnType<typeof useQueuedBottomSheet>;
 
 function setupBottomSheetStateCapture() {
   let stateHandlers: BottomSheetStateHandlers | undefined;
@@ -51,6 +54,10 @@ function setupBottomSheetStateCapture() {
 describe("useQueuedBottomSheet", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it("calls present() when the queue signals the drawer to open", () => {
@@ -652,6 +659,40 @@ describe("useQueuedBottomSheet", () => {
     });
 
     expect(mockAddBottomSheetToQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["the close animation starts", (result: HookResult) => result.handleAnimate(0, -1)],
+    ["the header close is pressed", (result: HookResult) => result.handleHeaderClosePressed()],
+    ["the backdrop is pressed", (result: HookResult) => result.handleBackdropPress()],
+  ])("retracts the keyboard as soon as %s", (_description, startClose) => {
+    const dismissKeyboard = jest.spyOn(Keyboard, "dismiss");
+    jest.spyOn(Keyboard, "isVisible").mockReturnValue(true);
+    const { signalOpen } = setupBottomSheetStateCapture();
+
+    const { result } = renderHook(() => useQueuedBottomSheet({ isRequestingToBeOpened: true }));
+
+    signalOpen();
+    expect(dismissKeyboard).not.toHaveBeenCalled();
+
+    act(() => {
+      startClose(result.current);
+    });
+
+    expect(dismissKeyboard).toHaveBeenCalled();
+  });
+
+  it("retracts the keyboard when the queue closes the drawer", () => {
+    const dismissKeyboard = jest.spyOn(Keyboard, "dismiss");
+    jest.spyOn(Keyboard, "isVisible").mockReturnValue(true);
+    const { signalOpen, signalClose } = setupBottomSheetStateCapture();
+
+    renderHook(() => useQueuedBottomSheet({ isRequestingToBeOpened: true }));
+
+    signalOpen();
+    signalClose();
+
+    expect(dismissKeyboard).toHaveBeenCalled();
   });
 
   it("does not reopen after dismiss when it is no longer requested (normal close)", () => {

--- a/shared/ui-queued-bottom-sheet/src/internals/useQueuedBottomSheet.native.ts
+++ b/shared/ui-queued-bottom-sheet/src/internals/useQueuedBottomSheet.native.ts
@@ -113,6 +113,16 @@ export function useQueuedBottomSheet({
     }, DISMISS_FALLBACK_DELAY_MS);
   }, [cleanupQueue, clearDismissFallback, logBottomSheet, settleClosed]);
 
+  // Hiding the keyboard resizes the sheet container. Doing it while the sheet is already animating
+  // out makes the underlying bottom sheet re-evaluate its position mid-close, which can leave it
+  // mounted at the closed position. Retracting the keyboard as soon as a close begins keeps the
+  // closing layout stable.
+  const dismissKeyboard = useCallback(() => {
+    if (Keyboard.isVisible()) {
+      Keyboard.dismiss();
+    }
+  }, []);
+
   // Closing a sheet often also clears the reason the sheet queued behind it wanted to be open, so
   // by the time the queue promotes us our consumer may no longer want us. Presenting anyway leaves
   // an empty sheet on screen that swallows the next tap, so decline the promotion instead.
@@ -147,10 +157,11 @@ export function useQueuedBottomSheet({
 
     logBottomSheet("Closing drawer");
     beginDismissing();
+    dismissKeyboard();
 
     bottomSheetRef.current?.dismiss();
     onCloseRef.current?.();
-  }, [beginDismissing, bottomSheetRef, cleanupQueue, logBottomSheet]);
+  }, [beginDismissing, bottomSheetRef, cleanupQueue, dismissKeyboard, logBottomSheet]);
 
   // Adds this drawer to the queue. The queue decides when to actually open/close it via the
   // open/close state handlers.
@@ -165,8 +176,9 @@ export function useQueuedBottomSheet({
 
   const handleUserClose = useCallback(() => {
     logBottomSheet("User initiated close");
+    dismissKeyboard();
     bottomSheetRef.current?.dismiss();
-  }, [bottomSheetRef, logBottomSheet]);
+  }, [bottomSheetRef, dismissKeyboard, logBottomSheet]);
 
   // Notifies the consumer of the explicit backdrop press before dismissing. Unlike onClose
   // (which fires for any closing reason), this reflects a real user close interaction.
@@ -181,9 +193,10 @@ export function useQueuedBottomSheet({
 
     logBottomSheet("Header close pressed");
     beginDismissing();
+    dismissKeyboard();
     onHeaderClosePressedRef.current?.();
     onCloseRef.current?.();
-  }, [beginDismissing, logBottomSheet]);
+  }, [beginDismissing, dismissKeyboard, logBottomSheet]);
 
   // Fired at the START of an animation. A close animation targets index -1, so this is the
   // earliest deterministic signal that the sheet is closing — for the X (close) button, the
@@ -206,18 +219,17 @@ export function useQueuedBottomSheet({
       if (toIndex === -1 && stateRef.current === "open") {
         logBottomSheet("Close animation started");
         beginDismissing();
+        dismissKeyboard();
         onCloseRef.current?.();
       }
     },
-    [beginDismissing, bottomSheetRef, logBottomSheet],
+    [beginDismissing, bottomSheetRef, dismissKeyboard, logBottomSheet],
   );
 
   const handleDismiss = useCallback(() => {
     logBottomSheet("BottomSheet dismissed (onDismiss)");
 
-    if (Keyboard.isVisible()) {
-      Keyboard.dismiss();
-    }
+    dismissKeyboard();
 
     // Fallback for dismissals that bypass the close animation (and thus handleAnimate).
     if (stateRef.current === "open") {
@@ -233,7 +245,7 @@ export function useQueuedBottomSheet({
     // isRequestingToBeOpened reflects the user's true intent — false for a normal backdrop close,
     // true only if the consumer genuinely re-requested while the sheet was closing.
     setReopenCheckSignal(s => s + 1);
-  }, [logBottomSheet, settleClosed]);
+  }, [dismissKeyboard, logBottomSheet, settleClosed]);
 
   useEffect(() => {
     if (!isFocused && (isRequestingToBeOpened || isForcingToBeOpened)) {


### PR DESCRIPTION
### 📝 Description

On mobile, two keyboard issues made Contacts “edit address” (and other queued bottom sheets) unusable:

1. **Form hidden behind the keyboard** — the rename-address sheet only padded for the safe-area inset, so the input and confirm action sat under the keyboard.
2. **Sheet could not be reopened after close** — dismissing the keyboard only after the sheet had finished closing caused the Gorhom sheet to re-layout mid-close and stay mounted at the closed index.

This PR:
- Passes a `keyboardInset` into `ContactsRenameAddressDialog` so the form stays above the keyboard (iOS `will` events, Android `did` events; skipped when native resize already handles the keyboard).
- Dismisses the keyboard as soon as a queued bottom sheet starts closing (close animation, header X, backdrop, or queue-driven close), so the closing layout stays stable and the sheet can be opened again.

Regression coverage:
- Unit tests for keyboard inset on the rename dialog and `ContactAddressDetailActionsSheets`
- Unit tests that `useQueuedBottomSheet` retracts the keyboard at the start of close
- Contacts integration test that reopens the edit-address sheet after closing it


https://github.com/user-attachments/assets/baed8d58-84c8-47e8-84d3-6154e7439aee



### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35853](https://ledgerhq.atlassian.net/browse/LIVE-35853)
- **ADR** (if any): N/A

[LIVE-35853]: https://ledgerhq.atlassian.net/browse/LIVE-35853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ