### PR TITLE
feat(devtools): add knip platform-split config to devtools packages

### DIFF
--- a/.changeset/lazy-tiger-jump.md
+++ b/.changeset/lazy-tiger-jump.md
@@ -1,0 +1,8 @@
+---
+"@devtools/shell": patch
+"@devtools/feature-flags": patch
+"@devtools/pay-card": patch
+"@devtools/transport-panel": patch
+---
+
+Add platform-split knip configs for dead-code detection on web and native targets

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -71,10 +71,7 @@ libs/ledger-auth/                                        @ledgerhq/platform
 libs/oxc-live-libs/                                      @ledgerhq/platform
 
 # Platform — devtools
-devtools/transport/                                      @ledgerhq/platform
-devtools/protocols/                                      @ledgerhq/platform
-devtools/wire/                                           @ledgerhq/platform
-devtools/relay/                                          @ledgerhq/platform
+devtools/                                                @ledgerhq/platform
 tools/nx-plugins/generators/                             @ledgerhq/platform
 
 # Platform — support

--- a/devtools/feature-flags/knip.native.ts
+++ b/devtools/feature-flags/knip.native.ts
@@ -1,0 +1,23 @@
+import { createRequire } from "module";
+import type { KnipConfig } from "knip";
+
+const require = createRequire(import.meta.url);
+const rootConfig = require("../../knip.json");
+
+const config: KnipConfig = {
+  ...rootConfig,
+  ignore: [...rootConfig.ignore, "src/**/*.web.*"],
+  ignoreWorkspaces: ["apps/ledger-live-mobile"],
+  compilers: {
+    "native.ts": (source: string) => source,
+    "native.tsx": (source: string) => source,
+  },
+  workspaces: {
+    "devtools/feature-flags": {
+      entry: ["src/index.native.ts"],
+      project: ["src/**/*", "!src/**/*.web.*"],
+    },
+  },
+};
+
+export default config;

--- a/devtools/feature-flags/knip.web.ts
+++ b/devtools/feature-flags/knip.web.ts
@@ -1,0 +1,23 @@
+import { createRequire } from "module";
+import type { KnipConfig } from "knip";
+
+const require = createRequire(import.meta.url);
+const rootConfig = require("../../knip.json");
+
+const config: KnipConfig = {
+  ...rootConfig,
+  ignore: [...rootConfig.ignore, "src/**/*.native.*"],
+  ignoreWorkspaces: ["apps/ledger-live-mobile"],
+  compilers: {
+    "web.ts": (source: string) => source,
+    "web.tsx": (source: string) => source,
+  },
+  workspaces: {
+    "devtools/feature-flags": {
+      entry: ["src/index.ts"],
+      project: ["src/**/*", "!src/**/*.native.*"],
+    },
+  },
+};
+
+export default config;

--- a/devtools/feature-flags/package.json
+++ b/devtools/feature-flags/package.json
@@ -18,7 +18,8 @@
     "coverage": "pnpm run coverage:web && pnpm run coverage:native && bash -c 'cat coverage/lcov.native.info >> coverage/lcov.info' --",
     "coverage:web": "jest --config jest.config.js --coverage",
     "coverage:native": "jest --config jest.native.config.js --coverage",
-    "lint": "oxlint src"
+    "lint": "oxlint src",
+    "unimported": "pnpm knip --directory ../.. -c devtools/feature-flags/knip.web.ts -W devtools/feature-flags --tsConfig tsconfig.web.json && pnpm knip --directory ../.. -c devtools/feature-flags/knip.native.ts -W devtools/feature-flags --tsConfig tsconfig.native.json"
   },
   "dependencies": {
     "@shared/feature-flags": "workspace:^"

--- a/devtools/feature-flags/src/components/index.web.ts
+++ b/devtools/feature-flags/src/components/index.web.ts
@@ -1,10 +1,3 @@
 export { Pill } from "./pill/Pill";
-export type { PillVariant, PillProps } from "./pill/Pill";
 export { FlagRow } from "./flagRow/FlagRow";
 export { FlagList } from "./flagList/FlagList";
-export { FlagEnableIndicator } from "./flagEnableIndicator/FlagEnableIndicator";
-export { FlagListSummary } from "./flagListSummary/FlagListSummary";
-export { FlagDetailsDialog } from "./flagDetailsDialog/FlagDetailsDialog";
-export { FlagJsonEditor } from "./flagJsonEditor/flagJsonEditor";
-export { FlagDiffView } from "./flagDiffView/FlagDiffView";
-export { ToolBar } from "./toolBar/ToolBar";

--- a/devtools/feature-flags/src/feature-flags/FeatureFlags.native.tsx
+++ b/devtools/feature-flags/src/feature-flags/FeatureFlags.native.tsx
@@ -3,7 +3,7 @@ import { FeatureFlagsToolProvider, FlagSelectionProvider } from "../context";
 import { FlagList } from "../components";
 import { BottomSheetModalProvider } from "@ledgerhq/lumen-ui-rnative";
 
-export function FeatureFlags(props: Readonly<FeatureFlagsToolProps>) {
+function FeatureFlags(props: Readonly<FeatureFlagsToolProps>) {
   return (
     <BottomSheetModalProvider>
       <FeatureFlagsToolProvider {...props}>

--- a/devtools/feature-flags/src/feature-flags/FeatureFlags.web.test.tsx
+++ b/devtools/feature-flags/src/feature-flags/FeatureFlags.web.test.tsx
@@ -1,6 +1,6 @@
 import { render } from "@support/jest-devtools/web";
 import { FEATURE_FLAGS_INITIAL_STATE } from "@shared/feature-flags";
-import { FeatureFlags } from "./FeatureFlags";
+import FeatureFlags from "./FeatureFlags";
 import type { FeatureFlagsToolProps } from "../types";
 
 const { resolved } = FEATURE_FLAGS_INITIAL_STATE;

--- a/devtools/feature-flags/src/feature-flags/FeatureFlags.web.tsx
+++ b/devtools/feature-flags/src/feature-flags/FeatureFlags.web.tsx
@@ -1,7 +1,7 @@
 import { FlagList } from "../components";
 import type { FeatureFlagsToolProps } from "../types";
 
-export const FeatureFlags = (props: FeatureFlagsToolProps) => (
+const FeatureFlags = (props: FeatureFlagsToolProps) => (
   <div>
     <FlagList {...props} />
   </div>

--- a/devtools/feature-flags/src/hooks/index.ts
+++ b/devtools/feature-flags/src/hooks/index.ts
@@ -5,18 +5,6 @@ export {
   type FeatureFlagsFiltersState,
   type FeatureFlagsFiltersInput,
 } from "./useFeatureFlagsFilters";
-export { useFlagSelection, type FlagSelectionState } from "./useFlagSelection";
-export {
-  useSortFlag,
-  SORT_CATEGORIES,
-  type SortCategory,
-  type SortDirection,
-  type SortFlagState,
-  type SortFlagProps,
-} from "./useSortFlag";
-export {
-  useJsonEditor,
-  type JsonEditorPropsState,
-  type JsonEditorProps,
-  type DiffBaseline,
-} from "./useJsonEditor";
+export { useFlagSelection } from "./useFlagSelection";
+export { useSortFlag, type SortCategory, type SortDirection } from "./useSortFlag";
+export { useJsonEditor, type DiffBaseline } from "./useJsonEditor";

--- a/devtools/feature-flags/src/utils/index.ts
+++ b/devtools/feature-flags/src/utils/index.ts
@@ -1,8 +1,6 @@
-export { diffJsonLines, canonicalJson } from "./diff";
+export { diffJsonLines } from "./diff";
 export type { DiffState, DiffLine } from "./diff";
-export type { OverridesExport } from "./exportOverrides";
 export { buildOverridesExport } from "./exportOverrides";
-export type { OverridesImport } from "./importOverrides";
 export { parseOverridesImport } from "./importOverrides";
 export { saveFile } from "./saveFile";
 export { readFile } from "./readFile";

--- a/devtools/pay-card/knip.native.ts
+++ b/devtools/pay-card/knip.native.ts
@@ -1,0 +1,23 @@
+import { createRequire } from "module";
+import type { KnipConfig } from "knip";
+
+const require = createRequire(import.meta.url);
+const rootConfig = require("../../knip.json");
+
+const config: KnipConfig = {
+  ...rootConfig,
+  ignore: [...rootConfig.ignore, "src/**/*.web.*"],
+  ignoreWorkspaces: ["apps/ledger-live-mobile"],
+  compilers: {
+    "native.ts": (source: string) => source,
+    "native.tsx": (source: string) => source,
+  },
+  workspaces: {
+    "devtools/pay-card": {
+      entry: ["src/index.native.ts"],
+      project: ["src/**/*", "!src/**/*.web.*"],
+    },
+  },
+};
+
+export default config;

--- a/devtools/pay-card/knip.web.ts
+++ b/devtools/pay-card/knip.web.ts
@@ -1,0 +1,23 @@
+import { createRequire } from "module";
+import type { KnipConfig } from "knip";
+
+const require = createRequire(import.meta.url);
+const rootConfig = require("../../knip.json");
+
+const config: KnipConfig = {
+  ...rootConfig,
+  ignore: [...rootConfig.ignore, "src/**/*.native.*"],
+  ignoreWorkspaces: ["apps/ledger-live-mobile"],
+  compilers: {
+    "web.ts": (source: string) => source,
+    "web.tsx": (source: string) => source,
+  },
+  workspaces: {
+    "devtools/pay-card": {
+      entry: ["src/index.ts"],
+      project: ["src/**/*", "!src/**/*.native.*"],
+    },
+  },
+};
+
+export default config;

--- a/devtools/pay-card/package.json
+++ b/devtools/pay-card/package.json
@@ -18,7 +18,8 @@
     "coverage": "pnpm run coverage:web && pnpm run coverage:native && bash -c 'cat coverage/lcov.native.info >> coverage/lcov.info' --",
     "coverage:web": "jest --config jest.config.js --coverage",
     "coverage:native": "jest --config jest.native.config.js --coverage",
-    "lint": "oxlint src"
+    "lint": "oxlint src",
+    "unimported": "pnpm knip --directory ../.. -c devtools/pay-card/knip.web.ts -W devtools/pay-card --tsConfig tsconfig.web.json && pnpm knip --directory ../.. -c devtools/pay-card/knip.native.ts -W devtools/pay-card --tsConfig tsconfig.native.json"
   },
   "devDependencies": {
     "@support/jest-devtools": "workspace:*",

--- a/devtools/pay-card/src/pay-card/PayCard.native.tsx
+++ b/devtools/pay-card/src/pay-card/PayCard.native.tsx
@@ -6,7 +6,7 @@ import { ToggleRow } from "../components/ToggleRow/ToggleRow";
 
 const BUTTON_ROW_STYLE = { flexDirection: "row", flexWrap: "wrap", gap: 8 } as const;
 
-export function PayCard(props: Readonly<PayCardToolProps>) {
+function PayCard(props: Readonly<PayCardToolProps>) {
   const { flags, onboarding, hasSeenFeatureTour, resetPayCardFeatureTourSeen } = props;
 
   return (

--- a/devtools/pay-card/src/pay-card/PayCard.web.tsx
+++ b/devtools/pay-card/src/pay-card/PayCard.web.tsx
@@ -3,7 +3,7 @@ import type { PayCardToolProps } from "../types";
 import { Section } from "../components/Section/Section";
 import { ToggleRow } from "../components/ToggleRow/ToggleRow";
 
-export function PayCard(props: Readonly<PayCardToolProps>) {
+function PayCard(props: Readonly<PayCardToolProps>) {
   const { flags, onboarding, hasSeenFeatureTour, resetPayCardFeatureTourSeen } = props;
 
   return (

--- a/devtools/shell/knip.native.ts
+++ b/devtools/shell/knip.native.ts
@@ -1,0 +1,23 @@
+import { createRequire } from "module";
+import type { KnipConfig } from "knip";
+
+const require = createRequire(import.meta.url);
+const rootConfig = require("../../knip.json");
+
+const config: KnipConfig = {
+  ...rootConfig,
+  ignore: [...rootConfig.ignore, "src/**/*.web.*"],
+  ignoreWorkspaces: ["apps/ledger-live-mobile"],
+  compilers: {
+    "native.ts": (source: string) => source,
+    "native.tsx": (source: string) => source,
+  },
+  workspaces: {
+    "devtools/shell": {
+      entry: ["src/index.native.ts"],
+      project: ["src/**/*", "!src/**/*.web.*"],
+    },
+  },
+};
+
+export default config;

--- a/devtools/shell/knip.web.ts
+++ b/devtools/shell/knip.web.ts
@@ -1,0 +1,23 @@
+import { createRequire } from "module";
+import type { KnipConfig } from "knip";
+
+const require = createRequire(import.meta.url);
+const rootConfig = require("../../knip.json");
+
+const config: KnipConfig = {
+  ...rootConfig,
+  ignore: [...rootConfig.ignore, "src/**/*.native.*"],
+  ignoreWorkspaces: ["apps/ledger-live-mobile"],
+  compilers: {
+    "web.ts": (source: string) => source,
+    "web.tsx": (source: string) => source,
+  },
+  workspaces: {
+    "devtools/shell": {
+      entry: ["src/index.ts"],
+      project: ["src/**/*", "!src/**/*.native.*"],
+    },
+  },
+};
+
+export default config;

--- a/devtools/shell/package.json
+++ b/devtools/shell/package.json
@@ -25,7 +25,8 @@
     "coverage": "pnpm run coverage:web && pnpm run coverage:native && bash -c 'cat coverage/lcov.native.info >> coverage/lcov.info' --",
     "coverage:web": "jest --config jest.config.js --coverage",
     "coverage:native": "jest --config jest.native.config.js --coverage",
-    "lint": "oxlint src"
+    "lint": "oxlint src",
+    "unimported": "pnpm knip --directory ../.. -c devtools/shell/knip.web.ts -W devtools/shell --tsConfig tsconfig.web.json && pnpm knip --directory ../.. -c devtools/shell/knip.native.ts -W devtools/shell --tsConfig tsconfig.native.json"
   },
   "dependencies": {
     "@devtools/registry": "workspace:*"

--- a/devtools/shell/src/DevTools/DevTools.native.tsx
+++ b/devtools/shell/src/DevTools/DevTools.native.tsx
@@ -34,5 +34,3 @@ export function DevTools({ config = [], footer, screenOptions }: DevToolsProps) 
     </BottomSheetModalProvider>
   );
 }
-
-export default DevTools;

--- a/devtools/shell/src/DevTools/screens/CategoriesScreen.native.tsx
+++ b/devtools/shell/src/DevTools/screens/CategoriesScreen.native.tsx
@@ -17,5 +17,3 @@ export function CategoriesScreen(props: CategoriesScreenProps) {
     </Box>
   );
 }
-
-export default CategoriesScreen;

--- a/devtools/shell/src/DevTools/screens/ToolScreen.native.tsx
+++ b/devtools/shell/src/DevTools/screens/ToolScreen.native.tsx
@@ -10,5 +10,3 @@ export function ToolScreen(props: ToolScreenProps) {
 
   return <ToolShell tool={tool} />;
 }
-
-export default ToolScreen;

--- a/devtools/shell/src/DevTools/screens/ToolsScreen.native.tsx
+++ b/devtools/shell/src/DevTools/screens/ToolsScreen.native.tsx
@@ -17,5 +17,3 @@ export function ToolsScreen(props: ToolsScreenProps) {
     </Box>
   );
 }
-
-export default ToolsScreen;

--- a/devtools/shell/src/DevTools/useDevToolsViewModel.web.ts
+++ b/devtools/shell/src/DevTools/useDevToolsViewModel.web.ts
@@ -1,4 +1,5 @@
-import { useToolsFromConfig, useDevToolsStorage } from "../hooks";
+import { useToolsFromConfig } from "../hooks";
+import { useDevToolsStorage } from "../hooks/useDevToolsStorage";
 import type { Category, DevToolsConfig, Tool, ToolId } from "@devtools/registry";
 import type { ReactNode } from "react";
 

--- a/devtools/shell/src/components/Catalog/Catalog.native.tsx
+++ b/devtools/shell/src/components/Catalog/Catalog.native.tsx
@@ -28,5 +28,3 @@ export function Catalog({ items }: CatalogProps) {
     </ScrollView>
   );
 }
-
-export default Catalog;

--- a/devtools/shell/src/components/ToolShell/ToolShell.native.tsx
+++ b/devtools/shell/src/components/ToolShell/ToolShell.native.tsx
@@ -20,5 +20,3 @@ export function ToolShell({ tool }: ToolShellProps) {
     </Box>
   );
 }
-
-export default ToolShell;

--- a/devtools/shell/src/components/WarningBanner/WarningBanner.native.tsx
+++ b/devtools/shell/src/components/WarningBanner/WarningBanner.native.tsx
@@ -22,5 +22,3 @@ export function WarningBanner() {
     </Box>
   );
 }
-
-export default WarningBanner;

--- a/devtools/shell/src/components/index.native.ts
+++ b/devtools/shell/src/components/index.native.ts
@@ -1,7 +1,4 @@
 export { Catalog } from "./Catalog/Catalog";
 export type { CatalogItem } from "./Catalog/Catalog";
-export { CatalogRow } from "./CatalogRow/CatalogRow";
-export type { CatalogRowProps } from "./CatalogRow/CatalogRow";
-export { Loading } from "./Loading/Loading";
 export { ToolShell } from "./ToolShell/ToolShell";
 export { WarningBanner } from "./WarningBanner/WarningBanner";

--- a/devtools/shell/src/components/index.web.ts
+++ b/devtools/shell/src/components/index.web.ts
@@ -1,9 +1,3 @@
-export { ToolRowItem } from "./ToolRowItem/ToolRowItem";
-export { CategoryRow } from "./CategoryRow/CategoryRow";
-export { CategoryCard } from "./CategoryCard/CategoryCard";
-export { ToolCard } from "./ToolCard/ToolCard";
-export { IconSquare } from "./IconSquare/IconSquare";
-export { SectionHeader } from "./SectionHeader/SectionHeader";
 export { Sidebar } from "./Sidebar/Sidebar";
 export { ToolShell } from "./ToolShell/ToolShell";
 export { Overview } from "./Overview/Overview";

--- a/devtools/shell/src/context/index.ts
+++ b/devtools/shell/src/context/index.ts
@@ -1,8 +1,7 @@
-export type { DevToolsConfig } from "@devtools/registry";
 export { DevToolsProvider, useToolProps } from "./context";
 export {
   DevToolsShellProvider,
   useDevToolsShell,
-  type CategoryGroup,
   type DevToolsShellValue,
+  type CategoryGroup,
 } from "./shellContext";

--- a/devtools/shell/src/hooks/index.ts
+++ b/devtools/shell/src/hooks/index.ts
@@ -1,3 +1,2 @@
 export { useAccordion } from "./useAccordion";
-export { useDevToolsNavigation } from "./useDevToolsNavigation";
 export { useToolsFromConfig } from "./useToolsFromConfig";

--- a/devtools/shell/src/hooks/index.web.ts
+++ b/devtools/shell/src/hooks/index.web.ts
@@ -1,4 +1,0 @@
-export { useAccordion } from "./useAccordion";
-export { useDevToolsNavigation } from "./useDevToolsNavigation";
-export { useToolsFromConfig } from "./useToolsFromConfig";
-export { useDevToolsStorage } from "./useDevToolsStorage";

--- a/devtools/shell/src/utils/index.ts
+++ b/devtools/shell/src/utils/index.ts
@@ -5,11 +5,4 @@ export {
   toolsForCategory,
   findCategoryForToolId,
 } from "./toolsUtils";
-export {
-  STORAGE_KEY,
-  MAX_RECENT_TOOLS,
-  serialize,
-  deserialize,
-  addToRecent,
-} from "./devToolsStorageUtils";
-export type { DevToolsPersistedState } from "./devToolsStorageUtils";
+export { STORAGE_KEY, serialize, deserialize, addToRecent } from "./devToolsStorageUtils";

--- a/devtools/transport-panel/knip.native.ts
+++ b/devtools/transport-panel/knip.native.ts
@@ -1,0 +1,23 @@
+import { createRequire } from "module";
+import type { KnipConfig } from "knip";
+
+const require = createRequire(import.meta.url);
+const rootConfig = require("../../knip.json");
+
+const config: KnipConfig = {
+  ...rootConfig,
+  ignore: [...rootConfig.ignore, "src/**/*.web.*"],
+  ignoreWorkspaces: ["apps/ledger-live-mobile"],
+  compilers: {
+    "native.ts": (source: string) => source,
+    "native.tsx": (source: string) => source,
+  },
+  workspaces: {
+    "devtools/transport-panel": {
+      entry: ["src/index.native.ts"],
+      project: ["src/**/*", "!src/**/*.web.*"],
+    },
+  },
+};
+
+export default config;

--- a/devtools/transport-panel/knip.web.ts
+++ b/devtools/transport-panel/knip.web.ts
@@ -1,0 +1,23 @@
+import { createRequire } from "module";
+import type { KnipConfig } from "knip";
+
+const require = createRequire(import.meta.url);
+const rootConfig = require("../../knip.json");
+
+const config: KnipConfig = {
+  ...rootConfig,
+  ignore: [...rootConfig.ignore, "src/**/*.native.*"],
+  ignoreWorkspaces: ["apps/ledger-live-mobile"],
+  compilers: {
+    "web.ts": (source: string) => source,
+    "web.tsx": (source: string) => source,
+  },
+  workspaces: {
+    "devtools/transport-panel": {
+      entry: ["src/index.web.ts"],
+      project: ["src/**/*", "!src/**/*.native.*"],
+    },
+  },
+};
+
+export default config;

--- a/devtools/transport-panel/package.json
+++ b/devtools/transport-panel/package.json
@@ -25,7 +25,8 @@
     "coverage": "pnpm run coverage:web && pnpm run coverage:native && bash -c 'cat coverage/lcov.native.info >> coverage/lcov.info' --",
     "coverage:web": "jest --config jest.config.js --coverage",
     "coverage:native": "jest --config jest.native.config.js --coverage",
-    "lint": "oxlint src"
+    "lint": "oxlint src",
+    "unimported": "pnpm knip --directory ../.. -c devtools/transport-panel/knip.web.ts -W devtools/transport-panel --tsConfig tsconfig.web.json && pnpm knip --directory ../.. -c devtools/transport-panel/knip.native.ts -W devtools/transport-panel --tsConfig tsconfig.native.json"
   },
   "dependencies": {
     "@devtools/transport": "workspace:*"

--- a/devtools/transport-panel/src/components/HistoryLine/index.native.ts
+++ b/devtools/transport-panel/src/components/HistoryLine/index.native.ts
@@ -1,1 +1,0 @@
-export { HistoryLine } from "./HistoryLine";

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,6 +11,7 @@ sonar.exclusions=.pnpm/**,\
 **/.webpack/**/*,\
 **/jest.config.js,\
 **/jest.config.ts,\
+**/knip*.ts,\
 **/jest.native.config.js,\
 **/jest.setup.js,\
 **/jest-setup.js,\


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

## Summary

Adds platform-aware knip configurations to four devtools packages (`feature-flags`, `pay-card`, `shell`, `transport-panel`), enabling dead-code analysis to run separately for web and native platforms.

### What changed

Each package gets two new knip config files and an `unimported` script:

- **`knip.native.ts`** — ignores `*.web.*` files, enables `.native.ts/.tsx` compilers, scopes the project glob to native sources only.
- **`knip.web.ts`** — ignores `*.native.*` files, enables `.web.ts/.tsx` compilers, scopes the project glob to web sources only.
- **`package.json`** — adds an `unimported` script that runs both configs sequentially:
  ```
  pnpm knip -c knip.web.ts ... && pnpm knip -c knip.native.ts ...
  ```

This mirrors the pattern established for the `knip` migration across the devtools scope and makes it possible to catch platform-specific dead exports without false positives from cross-platform file exclusions.


This solution does not fix everything, we have a different warnings that we can avoid if we avoid barrels files or only add to barrels files that are used on both web and native. (For example, we have index.ts that reexport hooks, one hook is used by web but not native. Web will see that the export is used but no native files import the export hence warn it.) This is not mandatory so not harmful but create some noise. But at least, knip doesn't completely confuse web and native files

I'll also point that we can't make a single knip file, as good as it sound, if a file have both a web and native version, one of them will be erased from knip hence flagging it unused.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36502](https://ledgerhq.atlassian.net/browse/LIVE-36502)<!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-36502]: https://ledgerhq.atlassian.net/browse/LIVE-36502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ