### PR TITLE
[LWDM] fix(zcash): make shielded-sync stop actually stick (LIVE-36511)

### DIFF
--- a/.changeset/quiet-otters-sync.md
+++ b/.changeset/quiet-otters-sync.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/coin-zcash": patch
+"ledger-live-desktop": patch
+---
+
+Fix the Zcash shielded-balance "Stop sync" action, which previously did nothing when the
+running sync was started automatically by the standard wallet sync rather than by the
+manual start button, and could resume on its own shortly after a manual stop otherwise
+succeeded.

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/AccountBalanceSummaryFooter.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/AccountBalanceSummaryFooter.test.tsx
@@ -440,6 +440,40 @@ describe("Bitcoin Account Balance Summary Footer", () => {
     expect(store.getState().shieldedSyncSubscriptions).toEqual([]);
   });
 
+  it("stops a running sync when clicking stop even for the very first sync, which the automatic wallet sync started without ever tracking a subscription", async () => {
+    mockedUseAccountUnit.mockReturnValue({
+      code: "ZEC",
+      name: "Zcash",
+      magnitude: 8,
+    });
+
+    const { user } = render(
+      <AccountBalanceSummaryFooter
+        account={{
+          ...account,
+          currency: { id: "zcash" } as CryptoCurrency,
+          privateInfo: {
+            ...DEFAULT_ZCASH_PRIVATE_INFO,
+            syncState: "running",
+          },
+        }}
+      />,
+      {
+        initialState: {
+          ...withFlagOverrides({ zcashShielded: { enabled: true } }),
+          shieldedSyncSubscriptions: [],
+        },
+      },
+    );
+
+    await user.click(screen.getByTestId("stop-sync-button"));
+
+    expect(mockedSyncStateUpdater).toHaveBeenCalledWith(
+      expect.objectContaining({ id: account.id }),
+      { syncState: "stopped", progress: 0, lastSyncError: null },
+    );
+  });
+
   it("shows only the ironwoodBalance as the private balance, excluding the deprecated Orchard/Sapling pools", async () => {
     mockedUseAccountUnit.mockReturnValue({
       code: "ZEC",

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/useZcashShieldedSync.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/useZcashShieldedSync.test.ts
@@ -122,7 +122,7 @@ describe("useZcashShieldedSync", () => {
     expect(store.getState().shieldedSyncSubscriptions).toEqual([]);
   });
 
-  it("does not report a stopped state when there is no tracked subscription to actually stop", () => {
+  it("still reports a stopped state when the running sync was never tracked here (started by the automatic wallet sync, not this hook)", () => {
     const account = buildAccount({ syncState: "running" });
 
     const { result, store } = renderHook(() => useZcashShieldedSync(account), {
@@ -133,7 +133,17 @@ describe("useZcashShieldedSync", () => {
       result.current.stopShieldedSync();
     });
 
-    expect(mockedSyncStateUpdater).not.toHaveBeenCalled();
+    // The Stop button only renders while syncState is "running", so reaching this point
+    // means a real sync is running -- whether or not this hook's own startShieldedSync is
+    // the one that started it -- and clicking Stop must always take effect.
+    expect(mockedSyncStateUpdater).toHaveBeenCalledWith(
+      expect.objectContaining({ id: account.id }),
+      {
+        syncState: "stopped",
+        progress: 0,
+        lastSyncError: null,
+      },
+    );
     expect(store.getState().shieldedSyncSubscriptions).toEqual([]);
   });
 
@@ -203,8 +213,35 @@ describe("useZcashShieldedSync", () => {
     expect(unsubscribe).toHaveBeenCalledTimes(1);
     expect(mockedSyncStateUpdater).toHaveBeenCalledWith(
       expect.objectContaining({ id: account.id }),
-      { syncState: "stopped", progress: 0 },
+      { syncState: "stopped", progress: 0, lastSyncError: null },
     );
     expect(store.getState().shieldedSyncSubscriptions).toEqual([]);
+  });
+
+  it("clears a prior lastSyncError when the user stops, so the automatic wallet sync does not retry it", () => {
+    const account = buildAccount({ syncState: "running", lastSyncError: "engine down" });
+    const unsubscribe = jest.fn();
+
+    const { result } = renderHook(() => useZcashShieldedSync(account), {
+      initialState: {
+        shieldedSyncSubscriptions: [{ accountId: account.id, subscription: { unsubscribe } }],
+      },
+    });
+
+    act(() => {
+      result.current.stopShieldedSync();
+    });
+
+    // A stale lastSyncError left over from before this stop would make coin-zcash's
+    // buildExtraSyncObservable treat this "stopped" as error-driven and eligible for the
+    // automatic wallet sync to retry it on its next tick -- exactly what stopping should prevent.
+    expect(mockedSyncStateUpdater).toHaveBeenCalledWith(
+      expect.objectContaining({ id: account.id }),
+      {
+        syncState: "stopped",
+        progress: 0,
+        lastSyncError: null,
+      },
+    );
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/useZcashShieldedSync.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/useZcashShieldedSync.ts
@@ -103,11 +103,20 @@ export function useZcashShieldedSync(account: ZcashAccount) {
     const currentAccount = currentAccountOf(account);
     if (currentAccount.type !== "Account" || (currentAccount.currency.id as Currency) !== "zcash")
       return;
-    if (!isSubscribedTo(currentAccount.id)) return;
 
+    // No early return when nothing is tracked here: the very first sync after enabling
+    // private balance runs unattended, driven by the automatic wallet sync (syncState
+    // "ready" already makes coin-zcash build the shielded leg -- see buildExtraSyncObservable
+    // -- so nothing ever calls startShieldedSync to register a subscription). The Stop button
+    // only renders while syncState is "running" (see AccountBalanceSummaryFooter), so reaching
+    // this callback at all means the user is looking at a real running sync and clicking Stop
+    // must always take effect, whether or not this hook is the one that started it.
     clearExistingSubscription();
-    saveSyncState({ syncState: "stopped", progress: 0 });
-  }, [account, currentAccountOf, isSubscribedTo, saveSyncState, clearExistingSubscription]);
+    // Explicitly null lastSyncError so this "stopped" is unambiguous: coin-zcash's
+    // buildExtraSyncObservable only lets the automatic wallet sync rebuild a "stopped"
+    // shielded leg when lastSyncError is set, i.e. it degraded on its own and should retry.
+    saveSyncState({ syncState: "stopped", progress: 0, lastSyncError: null });
+  }, [account, currentAccountOf, saveSyncState, clearExistingSubscription]);
 
   return { saveSyncState, startShieldedSync, stopShieldedSync };
 }

--- a/libs/coin-modules/coin-zcash/src/bridge/sync.transparent.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/sync.transparent.test.ts
@@ -509,7 +509,7 @@ describe("buildExtraSyncObservable", () => {
     ).toBe(undefined);
   });
 
-  it.each(["ready", "running", "stopped", "outdated", "complete"])(
+  it.each(["ready", "running", "outdated", "complete"])(
     "scans an account whose shielded state is %s",
     async syncState => {
       getZCashClient.mockResolvedValue({
@@ -542,6 +542,58 @@ describe("buildExtraSyncObservable", () => {
       });
     },
   );
+
+  it("scans an account whose shielded state is stopped after a prior error, to retry it", async () => {
+    getZCashClient.mockResolvedValue({
+      syncShielded: () =>
+        of({
+          transactions: [],
+          processedBlocks: 5,
+          remainingBlocks: 0,
+          lastProcessedBlock: 5,
+        }),
+      findBlockHeight: jest.fn(),
+    });
+    const observable = buildExtraSyncObservable(
+      info({
+        initialAccount: {
+          id: "js:2:zcash:xpub6DZ:",
+          operations: [],
+          privateInfo: privateInfo({
+            syncState: "stopped",
+            lastSyncError: "engine down",
+            lastProcessedBlock: 1,
+          }),
+        },
+      }),
+      { syncType: SYNC_TYPE_SHIELDED } as SyncConfig,
+    );
+
+    expect((await firstValueFrom(observable!)).privateInfo).toMatchObject({
+      syncState: "complete",
+      progress: 100,
+      lastProcessedBlock: 5,
+    });
+  });
+
+  it("stays out when the shielded state is stopped by the user rather than by an error", () => {
+    // No lastSyncError set -- this is what useZcashShieldedSync's stopShieldedSync writes.
+    // The automatic wallet sync always requests the shielded leg for zcash accounts, so this
+    // must return undefined or a manual stop would never stick: the next tick would rebuild
+    // the leg and flip syncState back to "running" on its own.
+    expect(
+      buildExtraSyncObservable(
+        info({
+          initialAccount: {
+            id: "js:2:zcash:xpub6DZ:",
+            operations: [],
+            privateInfo: privateInfo({ syncState: "stopped", lastProcessedBlock: 1 }),
+          },
+        }),
+        { syncType: SYNC_TYPE_SHIELDED } as SyncConfig,
+      ),
+    ).toBe(undefined);
+  });
 
   it("degrades to a stopped state instead of propagating when the shielded leg errors", async () => {
     getZCashClient.mockResolvedValue({

--- a/libs/coin-modules/coin-zcash/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/sync.ts
@@ -923,11 +923,18 @@ export function buildExtraSyncObservable(
     !!zcashInitialAccount.privateInfo?.ufvk &&
     zcashInitialAccount.privateInfo.ufvk.length > 0;
 
+  // "stopped" is overloaded: the leg sets it on its own after an error/timeout (see the
+  // catchError below, which also sets lastSyncError) so the next automatic tick can retry,
+  // but useZcashShieldedSync's manual stop sets the same value to mean "leave it alone until
+  // the user restarts it" -- without checking lastSyncError, the automatic wallet sync (which
+  // always requests the shielded leg for zcash, see BridgeSync.tsx) would rebuild it on its
+  // next tick and flip syncState back to "running", making a manual stop never stick.
   const syncStateIsEnabled =
     !!zcashInitialAccount &&
     (zcashInitialAccount.privateInfo?.syncState === "ready" ||
       zcashInitialAccount.privateInfo?.syncState === "running" ||
-      zcashInitialAccount.privateInfo?.syncState === "stopped" ||
+      (zcashInitialAccount.privateInfo?.syncState === "stopped" &&
+        !!zcashInitialAccount.privateInfo?.lastSyncError) ||
       zcashInitialAccount.privateInfo?.syncState === "outdated" ||
       zcashInitialAccount.privateInfo?.syncState === "complete");
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Fixes the Zcash shielded-balance "Stop sync" action, which previously either did nothing or appeared to work only briefly before resuming on its own.

Previous behaviour: `stopShieldedSync` only acted when a subscription was tracked by this same hook — but the shielded leg is now also driven by the automatic wallet sync (folded in by a previous change), which never registers such a subscription. The very first sync after enabling private balance is always driven that way, so clicking Stop on it did nothing at all. Even when a manual subscription existed and Stop appeared to work, `syncState: "stopped"` was still treated as eligible for the automatic wallet sync to rebuild the shielded leg on its next tick, flipping the state back to "running" on its own shortly after.

Fix: `buildExtraSyncObservable` (coin-zcash) now only lets the automatic wallet sync rebuild a "stopped" shielded leg when `lastSyncError` is set, i.e. it degraded on its own and should retry — a user-initiated stop clears that field, so it is left alone. `stopShieldedSync` no longer requires a locally tracked subscription to act, since the Stop button is only reachable while a sync is genuinely running, regardless of which mechanism started it.

Automated check preventing regression: new/updated tests in `sync.transparent.test.ts`, `useZcashShieldedSync.test.ts`, and `AccountBalanceSummaryFooter.test.tsx` cover both the "stopped after an error, retried automatically" and "stopped by the user, left alone" cases, plus clicking Stop with no locally tracked subscription.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36511](https://ledgerhq.atlassian.net/browse/LIVE-36511)
- **ADR** (if any): none


[LIVE-36511]: https://ledgerhq.atlassian.net/browse/LIVE-36511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ