### PR TITLE
fix(ci): detect skipped shards as missing in e2e mobile

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -795,7 +795,7 @@ jobs:
           retention-days: 7
 
       - name: Setup iOS Shard timing artifacts
-        if: (!cancelled() || steps.run-ios.outcome == 'cancelled')
+        if: (!cancelled() || steps.run-ios.outcome == 'cancelled') && steps.run-ios.outcome != 'skipped'
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           path: ${{ env.MOBILE_ARTIFACTS_ROOT }}/${{ env.E2E_TEST_RESULTS_PREFIX_IOS }}-${{ matrix.shard }}.json
@@ -1197,7 +1197,7 @@ jobs:
           retention-days: 7
 
       - name: Setup Android Shard timing artifacts
-        if: (!cancelled() || steps.run-android.outcome == 'cancelled')
+        if: (!cancelled() || steps.run-android.outcome == 'cancelled') && steps.run-android.outcome != 'skipped'
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           path: ${{ env.MOBILE_ARTIFACTS_ROOT }}/${{ env.E2E_TEST_RESULTS_PREFIX_ANDROID }}-${{ matrix.shard }}.json

--- a/tools/actions/composites/aggregate-shard-results/action.yml
+++ b/tools/actions/composites/aggregate-shard-results/action.yml
@@ -82,7 +82,7 @@ runs:
           shardNum=$((i + 1))
           status="${statuses[$i]}"
 
-          if [ -z "$status" ]; then
+          if [ -z "$status" ] || [ "$status" = "skipped" ]; then
             missingShards+=("$shardNum")
           elif [ "$status" != "success" ]; then
             finalStatus="failure"


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

When a shard's setup step fails (e.g. Detox Post Install), the run-ios/run-android step is skipped. The set-output step still runs (it has if: !cancelled()) and writes status_N=skipped — a non-empty value — so aggregate-shard-results never added it to missingShards, silently dropping test coverage from the Slack report. (ex: [link](https://github.com/LedgerHQ/ledger-live/actions/runs/31757397298/job/94636275269))

- Treat skipped as a missing shard in aggregate-shard-results so the  warning fires correctly
- Guard timing artifact upload steps on run-ios/run-android outcome != skipped to avoid upload errors when no artifact was produced

For the Detox Post Install step failure :
The root cause was --no-frozen-lockfile allowing silent use of a stale VM pnpm store. That's already been fixed [here](https://github.com/LedgerHQ/ledger-live/pull/21020). 

### 🔗 Context

- Smoke [tests](https://github.com/LedgerHQ/ledger-live/actions/runs/32980553503)
- Full E2E [tests](https://github.com/LedgerHQ/ledger-live/actions/runs/32980585752)
- [Run](https://github.com/LedgerHQ/ledger-live/actions/runs/32985965427) with skipped shards

<img width="664" height="395" alt="Screenshot 2026-08-27 at 08 17 40" src="https://github.com/user-attachments/assets/bc4b40f5-364c-4679-94f6-9869004b2a89" />