### PR TITLE
feat(pay-card): add the exchange fund transaction manager client

### DIFF
--- a/.changeset/exchange-fund-api.md
+++ b/.changeset/exchange-fund-api.md
@@ -1,0 +1,13 @@
+---
+"@domain/api-exchange-fund": minor
+"@shared/api-services": minor
+"@shared/env": minor
+---
+
+Add the exchange transaction manager client, which brokers the signed payload a card top-up is clear-signed from:
+
+- `remitFundCard` exchanges a device nonce for the payin address and the provider's signed payload.
+- `confirmFund` and `cancelFund` close the order out once the transaction is broadcast or refused.
+- New `exchangeFundApi` service and an `EXCHANGE_FUND_API_URL` env var, defaulting to the production transaction manager.
+
+No caller yet: the device intent that consumes the payload lands next.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -275,7 +275,9 @@ libs/transaction-observability/                                           @ledge
 features/flow/pay-card-auth/                                             @ledgerhq/ptx
 features/platform/card/                                                  @ledgerhq/ptx
 domain/api/card-management/                                              @ledgerhq/ptx
+domain/api/exchange-fund/                                                @ledgerhq/ptx
 /shared/api-services/src/services/card/                                  @ledgerhq/ptx
+/shared/api-services/src/services/exchange-fund/                         @ledgerhq/ptx
 apps/cli/src/commands/ptx                                            					@ledgerhq/ptx
 apps/ledger-live-desktop/src/renderer/components/ProviderIcon/       					@ledgerhq/ptx
 apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/       					@ledgerhq/ptx

--- a/domain/api/exchange-fund/README.md
+++ b/domain/api/exchange-fund/README.md
@@ -1,0 +1,34 @@
+# @domain/api-exchange-fund
+
+> [!CAUTION]
+> **Status: UNSTABLE** — Part of the emerging DDD layer; under active development.
+
+Domain API client for the **exchange transaction manager**, the Ledger service that brokers a signed
+fund payload from the provider. Injects its endpoints into the shared `exchangeFundApi` service
+(`@shared/api-services`, `services/exchange-fund`) rather than declaring its own `createApi`.
+
+| Endpoint | Method | Path | Purpose |
+| -------- | ------ | ---- | ------- |
+| `remitFundCard` | POST | `/exchange/v1/fund/card/remit` | Exchange a device nonce for the payin address and the provider's signed payload |
+| `confirmFund` | POST | `/history/webhook/v1/transaction/{quoteId}/accepted` | Report the top-up as broadcast |
+| `cancelFund` | POST | `/history/webhook/v1/transaction/{quoteId}/cancelled` | Report the top-up as abandoned |
+
+## Why the payload matters
+
+`remitFundCard` answers with `providerSig`, which the device verifies against the partner key CAL
+endorsed before it renders the top-up. That is what lets the device show *"Fund card: 50 USDC"*
+rather than an address the user cannot check. Neither `payload` nor `signature` is decoded here — the
+device is the only consumer that needs their contents.
+
+`payinAddress` comes back from this call. It is not read from the provider's own API, so the address
+the transaction pays and the address inside the signed payload have a single source.
+
+## Order of operations
+
+```
+startExchange(device)              → nonce
+remitFundCard({ nonce, … })        → payinAddress + providerSig
+completeExchange(payload, signature)  device renders and signs
+confirmFund({ quoteId })           on broadcast
+cancelFund({ quoteId, … })         on refusal or failure
+```

--- a/domain/api/exchange-fund/jest.config.js
+++ b/domain/api/exchange-fund/jest.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  testEnvironment: "node",
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.(t|j)sx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+        },
+      },
+    ],
+  },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
+  ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
+};

--- a/domain/api/exchange-fund/package.json
+++ b/domain/api/exchange-fund/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@domain/api-exchange-fund",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Domain API client for the exchange transaction manager: fund remit, confirm and cancel",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../../.. -W domain/api/exchange-fund"
+  },
+  "dependencies": {
+    "@shared/api-services": "workspace:*",
+    "@reduxjs/toolkit": "catalog:",
+    "zod": "catalog:"
+  },
+  "peerDependencies": {
+    "react": ">=19.0.0",
+    "react-redux": ">=9.0.0"
+  },
+  "devDependencies": {
+    "@jest/globals": "catalog:",
+    "@ledgerhq/test-quarantine": "workspace:*",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "jest": "catalog:",
+    "react": "catalog:",
+    "react-redux": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/domain/api/exchange-fund/src/api.test.ts
+++ b/domain/api/exchange-fund/src/api.test.ts
@@ -1,0 +1,169 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { exchangeFundApi, exchangeFundApiExtra } from "@shared/api-services";
+import { exchangeFundManagementApi } from "./api";
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function request(spy: jest.SpyInstance): Request {
+  return spy.mock.calls[0][0] as Request;
+}
+
+const remitResponse = {
+  sellId: "5b8e7f2c-6c39-4f0e-9d5a-2f6d1b0c7a91",
+  payinAddress: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb4",
+  providerSig: {
+    payload: "CgtjYXJkLXVzZXItMRIJQ2FyZCAxMjM0",
+    signature: "MEUCIQDXK5Z9hQ0nJ3f2p1lRr8yVQe6mVYh4tXlA2c8Kk9rWpAIgH1s",
+  },
+};
+
+const remitRequest = {
+  quoteId: "quote-1",
+  provider: "baanx",
+  fromCurrency: "ethereum/erc20/usd__coin",
+  toCurrency: "ethereum/erc20/usd__coin",
+  refundAddress: "0x9f2c1a4b8d3e5f6071829304a5b6c7d8e9f01234",
+  amountFrom: 50,
+  amountTo: 50,
+  nonce: "b7d4e1a09c3f",
+};
+
+const makeStore = () =>
+  configureStore({
+    reducer: { [exchangeFundApi.reducerPath]: exchangeFundApi.reducer },
+    middleware: gdm =>
+      gdm({
+        thunk: {
+          extraArgument: exchangeFundApiExtra({
+            exchangeFundApiBaseUrl: "https://exchange.test",
+            ledgerClientVersion: "llm/1.2.3",
+          }),
+        },
+      }).concat(exchangeFundApi.middleware),
+  });
+
+let fetchSpy: jest.SpyInstance;
+
+afterEach(() => {
+  fetchSpy?.mockRestore();
+});
+
+describe("remitFundCard", () => {
+  it("posts the fund request and returns the signed payload", async () => {
+    fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(remitResponse));
+
+    const store = makeStore();
+    const result = await store.dispatch(
+      exchangeFundManagementApi.endpoints.remitFundCard.initiate(remitRequest),
+    );
+
+    expect(request(fetchSpy).url).toBe("https://exchange.test/exchange/v1/fund/card/remit");
+    expect(request(fetchSpy).method).toBe("POST");
+    expect(request(fetchSpy).headers.get("x-ledger-client-version")).toBe("llm/1.2.3");
+    expect(JSON.parse(await request(fetchSpy).clone().text())).toEqual(remitRequest);
+    expect(result.data).toEqual(remitResponse);
+  });
+
+  it("sends the device nonce, which binds the payload to this device", async () => {
+    fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(remitResponse));
+
+    const store = makeStore();
+    await store.dispatch(exchangeFundManagementApi.endpoints.remitFundCard.initiate(remitRequest));
+
+    const body = JSON.parse(await request(fetchSpy).clone().text());
+    expect(body.nonce).toBe("b7d4e1a09c3f");
+  });
+
+  it("omits the quote id when the caller has none", async () => {
+    fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(remitResponse));
+    const { quoteId: _quoteId, ...withoutQuote } = remitRequest;
+
+    const store = makeStore();
+    const result = await store.dispatch(
+      exchangeFundManagementApi.endpoints.remitFundCard.initiate(withoutQuote),
+    );
+
+    const body = JSON.parse(await request(fetchSpy).clone().text());
+    expect(body).not.toHaveProperty("quoteId");
+    expect(result.data).toEqual(remitResponse);
+  });
+
+  it("rejects a response with no provider signature", async () => {
+    fetchSpy = jest
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        jsonResponse({ sellId: remitResponse.sellId, payinAddress: remitResponse.payinAddress }),
+      );
+
+    const store = makeStore();
+    const result = await store.dispatch(
+      exchangeFundManagementApi.endpoints.remitFundCard.initiate(remitRequest),
+    );
+
+    expect(result.data).toBeUndefined();
+    expect(result.error).toBeDefined();
+  });
+
+  it("rejects a response with no payin address, which would leave nowhere to send", async () => {
+    fetchSpy = jest
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse({ ...remitResponse, payinAddress: "" }));
+
+    const store = makeStore();
+    const result = await store.dispatch(
+      exchangeFundManagementApi.endpoints.remitFundCard.initiate(remitRequest),
+    );
+
+    expect(result.data).toBeUndefined();
+    expect(result.error).toBeDefined();
+  });
+});
+
+describe("confirmFund", () => {
+  it("posts the accepted webhook for the quote", async () => {
+    fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({}));
+
+    const store = makeStore();
+    await store.dispatch(
+      exchangeFundManagementApi.endpoints.confirmFund.initiate({
+        quoteId: "quote-1",
+        provider: "baanx",
+      }),
+    );
+
+    expect(request(fetchSpy).url).toBe(
+      "https://exchange.test/history/webhook/v1/transaction/quote-1/accepted",
+    );
+    expect(request(fetchSpy).method).toBe("POST");
+  });
+});
+
+describe("cancelFund", () => {
+  it("posts the cancelled webhook with the failure that caused it", async () => {
+    fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({}));
+
+    const store = makeStore();
+    await store.dispatch(
+      exchangeFundManagementApi.endpoints.cancelFund.initiate({
+        quoteId: "quote-1",
+        provider: "baanx",
+        statusCode: "UserRefusedOnDevice",
+        errorMessage: "Transaction refused on device",
+      }),
+    );
+
+    expect(request(fetchSpy).url).toBe(
+      "https://exchange.test/history/webhook/v1/transaction/quote-1/cancelled",
+    );
+    expect(JSON.parse(await request(fetchSpy).clone().text())).toEqual({
+      provider: "baanx",
+      statusCode: "UserRefusedOnDevice",
+      errorMessage: "Transaction refused on device",
+    });
+  });
+});

--- a/domain/api/exchange-fund/src/api.ts
+++ b/domain/api/exchange-fund/src/api.ts
@@ -1,0 +1,43 @@
+import { exchangeFundApi } from "@shared/api-services";
+import { FUND_CARD_REMIT_PATH, fundOutcomePath } from "./constants";
+import { FundRemitResponseSchema } from "./schema";
+import type {
+  FundCancelRequest,
+  FundOutcomeRequest,
+  FundRemitRequest,
+  FundRemitResponse,
+} from "./types";
+
+export const exchangeFundManagementApi = exchangeFundApi.injectEndpoints({
+  endpoints: build => ({
+    remitFundCard: build.mutation<FundRemitResponse, FundRemitRequest>({
+      query: body => ({
+        url: FUND_CARD_REMIT_PATH,
+        method: "POST",
+        body,
+      }),
+      responseSchema: FundRemitResponseSchema,
+    }),
+
+    confirmFund: build.mutation<void, FundOutcomeRequest>({
+      query: ({ quoteId, provider }) => ({
+        url: fundOutcomePath(quoteId, "accepted"),
+        method: "POST",
+        body: { provider },
+      }),
+    }),
+
+    cancelFund: build.mutation<void, FundCancelRequest>({
+      query: ({ quoteId, provider, statusCode, errorMessage }) => ({
+        url: fundOutcomePath(quoteId, "cancelled"),
+        method: "POST",
+        body: { provider, statusCode, errorMessage },
+      }),
+    }),
+  }),
+});
+
+export type ExchangeFundManagementApi = typeof exchangeFundManagementApi;
+
+export const { useRemitFundCardMutation, useConfirmFundMutation, useCancelFundMutation } =
+  exchangeFundManagementApi;

--- a/domain/api/exchange-fund/src/constants.ts
+++ b/domain/api/exchange-fund/src/constants.ts
@@ -1,0 +1,5 @@
+/** Card is the only product the transaction manager exposes a fund remit for. */
+export const FUND_CARD_REMIT_PATH = "/exchange/v1/fund/card/remit";
+
+export const fundOutcomePath = (quoteId: string, outcome: "accepted" | "cancelled") =>
+  `/history/webhook/v1/transaction/${quoteId}/${outcome}`;

--- a/domain/api/exchange-fund/src/index.ts
+++ b/domain/api/exchange-fund/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./constants";
+export * from "./schema";
+export * from "./types";
+export * from "./api";

--- a/domain/api/exchange-fund/src/schema.test.ts
+++ b/domain/api/exchange-fund/src/schema.test.ts
@@ -1,0 +1,47 @@
+import { ExchangeProviderSignatureSchema, FundRemitResponseSchema } from "./schema";
+
+const remitResponse = {
+  sellId: "5b8e7f2c-6c39-4f0e-9d5a-2f6d1b0c7a91",
+  payinAddress: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb4",
+  providerSig: {
+    payload: "CgtjYXJkLXVzZXItMRIJQ2FyZCAxMjM0",
+    signature: "MEUCIQDXK5Z9hQ0nJ3f2p1lRr8yVQe6mVYh4tXlA2c8Kk9rWpAIgH1s",
+  },
+};
+
+describe("FundRemitResponseSchema", () => {
+  it("reads the remit response", () => {
+    expect(FundRemitResponseSchema.parse(remitResponse)).toEqual(remitResponse);
+  });
+
+  it("drops the keys the wire contract does not declare", () => {
+    const parsed = FundRemitResponseSchema.parse({
+      ...remitResponse,
+      createdAt: "2026-08-26T09:00:00.000Z",
+      providerFees: "0.1",
+    });
+
+    expect(parsed).toEqual(remitResponse);
+  });
+
+  it("rejects an empty payin address", () => {
+    expect(() => FundRemitResponseSchema.parse({ ...remitResponse, payinAddress: "" })).toThrow();
+  });
+
+  it("rejects a signature with no payload to verify", () => {
+    expect(() =>
+      FundRemitResponseSchema.parse({
+        ...remitResponse,
+        providerSig: { payload: "", signature: remitResponse.providerSig.signature },
+      }),
+    ).toThrow();
+  });
+});
+
+describe("ExchangeProviderSignatureSchema", () => {
+  it("keeps the payload and signature as the strings the device checks", () => {
+    expect(ExchangeProviderSignatureSchema.parse(remitResponse.providerSig)).toEqual(
+      remitResponse.providerSig,
+    );
+  });
+});

--- a/domain/api/exchange-fund/src/schema.ts
+++ b/domain/api/exchange-fund/src/schema.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+/**
+ * The partner's signed attestation of the top-up. `payload` is what the device renders and
+ * `signature` is what it checks against the partner key CAL endorsed, so neither is decoded here.
+ */
+export const ExchangeProviderSignatureSchema = z.object({
+  payload: z.string().min(1),
+  signature: z.string().min(1),
+});
+
+/**
+ * `sellId` names the fund order, not a sale — the transaction manager shares one response shape
+ * across sell and fund.
+ */
+export const FundRemitResponseSchema = z.object({
+  sellId: z.string().min(1),
+  payinAddress: z.string().min(1),
+  providerSig: ExchangeProviderSignatureSchema,
+});

--- a/domain/api/exchange-fund/src/types.ts
+++ b/domain/api/exchange-fund/src/types.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+import { ExchangeProviderSignatureSchema, FundRemitResponseSchema } from "./schema";
+
+export type ExchangeProviderSignature = z.infer<typeof ExchangeProviderSignatureSchema>;
+
+export type FundRemitResponse = z.infer<typeof FundRemitResponseSchema>;
+
+export type FundRemitRequest = {
+  /** Optional: the transaction manager accepts a remit without one. */
+  readonly quoteId?: string;
+  readonly provider: string;
+  /** Ledger currency ids, as the user's account reports them. */
+  readonly fromCurrency: string;
+  readonly toCurrency: string;
+  /** The user's own address on the funding account. */
+  readonly refundAddress: string;
+  readonly amountFrom: number;
+  readonly amountTo: number;
+  /** The `device_transaction_id` returned by `startExchange`, which binds the payload to this device. */
+  readonly nonce: string;
+};
+
+export type FundOutcomeRequest = {
+  readonly quoteId: string;
+  readonly provider: string;
+};
+
+export type FundCancelRequest = FundOutcomeRequest & {
+  readonly statusCode: string;
+  readonly errorMessage: string;
+};

--- a/domain/api/exchange-fund/tsconfig.json
+++ b/domain/api/exchange-fund/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4471,6 +4471,49 @@ importers:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
 
+  domain/api/exchange-fund:
+    dependencies:
+      '@reduxjs/toolkit':
+        specifier: 'catalog:'
+        version: 2.11.2(react-redux@9.2.0(react@19.1.4))(react@19.1.4)
+      '@shared/api-services':
+        specifier: workspace:*
+        version: link:../../../shared/api-services
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+    devDependencies:
+      '@jest/globals':
+        specifier: 'catalog:'
+        version: 30.5.0
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.5.0(@types/node@24.12.0)
+      react:
+        specifier: 19.1.4
+        version: 19.1.4
+      react-redux:
+        specifier: 'catalog:'
+        version: 9.2.0(react@19.1.4)
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
   domain/api/market-sentiment:
     dependencies:
       '@domain/entity-market-sentiment':
@@ -28864,7 +28907,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: ^5.5.10
+      rxjs: '*'
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -31775,8 +31818,8 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
-  es-module-lexer@2.3.2:
-    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -37046,6 +37089,10 @@ packages:
   picomatch@3.0.1:
     resolution: {integrity: sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==}
     engines: {node: '>=10'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
 
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
@@ -51162,7 +51209,7 @@ snapshots:
       detect-libc: 2.1.2
       is-glob: 4.0.3
       node-addon-api: 7.1.1
-      picomatch: 4.0.5
+      picomatch: 4.0.4
     optionalDependencies:
       '@parcel/watcher-android-arm64': 2.6.0
       '@parcel/watcher-darwin-arm64': 2.6.0
@@ -62360,7 +62407,7 @@ snapshots:
 
   es-module-lexer@1.7.0: {}
 
-  es-module-lexer@2.3.2: {}
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -63186,6 +63233,10 @@ snapshots:
   fd-slicer@1.1.0:
     dependencies:
       pend: 1.2.0
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -65673,12 +65724,12 @@ snapshots:
       '@types/node': 24.12.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
-      fdir: 6.5.0(picomatch@4.0.5)
+      fdir: 6.5.0(picomatch@4.0.4)
       graceful-fs: 4.2.11
       jest-regex-util: 30.5.0
       jest-util: 30.5.0
       jest-worker: 30.5.0
-      picomatch: 4.0.5
+      picomatch: 4.0.4
 
   jest-leak-detector@30.5.0:
     dependencies:
@@ -65700,7 +65751,7 @@ snapshots:
       chalk: 4.1.2
       graceful-fs: 4.2.11
       jest-util: 30.5.0
-      picomatch: 4.0.5
+      picomatch: 4.0.4
       pretty-format: 30.5.0
       slash: 3.0.0
       stack-utils: 2.0.6
@@ -65824,7 +65875,7 @@ snapshots:
       chalk: 4.1.2
       cjs-module-lexer: 2.2.0
       collect-v8-coverage: 1.0.2
-      es-module-lexer: 2.3.2
+      es-module-lexer: 2.1.0
       glob: 13.0.6
       graceful-fs: 4.2.11
       jest-haste-map: 30.5.0
@@ -65877,7 +65928,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 4.3.1
       graceful-fs: 4.2.11
-      picomatch: 4.0.5
+      picomatch: 4.0.4
 
   jest-validate@29.7.0:
     dependencies:
@@ -67554,7 +67605,9 @@ snapshots:
     optionalDependencies:
       metro-transform-worker: 0.81.5
     transitivePeerDependencies:
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   metro-config@0.83.3(metro-transform-worker@0.83.3):
     dependencies:
@@ -69635,6 +69688,8 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@3.0.1: {}
+
+  picomatch@4.0.4: {}
 
   picomatch@4.0.5: {}
 

--- a/shared/api-services/src/services/exchange-fund/api.ts
+++ b/shared/api-services/src/services/exchange-fund/api.ts
@@ -1,0 +1,54 @@
+import {
+  createApi,
+  fetchBaseQuery,
+  type BaseQueryFn,
+  type FetchArgs,
+  type FetchBaseQueryError,
+} from "@reduxjs/toolkit/query/react";
+import { EXCHANGE_FUND_REDUCER_PATH, HEADER_X_LEDGER_CLIENT_VERSION } from "./constants";
+import { ExchangeFundApiExtraSchema } from "./schema";
+import type { ExchangeFundApiExtra } from "./types";
+
+/**
+ * Builds this service's slice of the thunk `extraArgument`. RTK leaves `extraArgument` untyped, so
+ * this is the one compile- and runtime-checked entry point: `parse` fails fast at app init if the
+ * config is incomplete (e.g. an env var resolved to an empty string).
+ */
+export function exchangeFundApiExtra(extra: ExchangeFundApiExtra): ExchangeFundApiExtra {
+  return ExchangeFundApiExtraSchema.parse(extra);
+}
+
+/** Extracts the {@link ExchangeFundApiExtra} from the `extraArgument` of the api. */
+export function getExchangeFundExtra(api: { extra: unknown }): ExchangeFundApiExtra {
+  return api.extra as ExchangeFundApiExtra;
+}
+
+const exchangeFundBaseQuery: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError> = (
+  args,
+  api,
+  extraOptions,
+) => {
+  const extra = getExchangeFundExtra(api);
+  return fetchBaseQuery({
+    baseUrl: extra.exchangeFundApiBaseUrl,
+    prepareHeaders: headers => {
+      headers.set("Content-Type", "application/json");
+      headers.set(HEADER_X_LEDGER_CLIENT_VERSION, extra.ledgerClientVersion);
+      return headers;
+    },
+  })(args, api, extraOptions);
+};
+
+/**
+ * Endpoint-less exchange transaction manager api. Register it in the store; use cases add endpoints
+ * and tags to this same object — see
+ * {@link https://github.com/LedgerHQ/ledger-live/blob/develop/shared/api-services/README.md}.
+ */
+export const exchangeFundApi = createApi({
+  reducerPath: EXCHANGE_FUND_REDUCER_PATH,
+  baseQuery: exchangeFundBaseQuery,
+  tagTypes: [],
+  endpoints: () => ({}),
+});
+
+export type ExchangeFundApi = typeof exchangeFundApi;

--- a/shared/api-services/src/services/exchange-fund/constants.ts
+++ b/shared/api-services/src/services/exchange-fund/constants.ts
@@ -1,0 +1,5 @@
+/** RTK Query reducer path for the exchange transaction manager — stable; it keys the store slice. */
+export const EXCHANGE_FUND_REDUCER_PATH = "exchangeFundApi";
+
+/** Header carrying the wallet build identifier, which the transaction manager logs per request. */
+export const HEADER_X_LEDGER_CLIENT_VERSION = "X-Ledger-Client-Version";

--- a/shared/api-services/src/services/exchange-fund/index.ts
+++ b/shared/api-services/src/services/exchange-fund/index.ts
@@ -1,0 +1,3 @@
+export * from "./api";
+export * from "./schema";
+export * from "./types";

--- a/shared/api-services/src/services/exchange-fund/schema.ts
+++ b/shared/api-services/src/services/exchange-fund/schema.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+/**
+ * Thunk `extraArgument` contract for the exchange transaction manager. The app supplies the resolved
+ * values at store configuration time, so this package owns no env/config dependency.
+ */
+export const ExchangeFundApiExtraSchema = z.object({
+  exchangeFundApiBaseUrl: z.string().min(1),
+  ledgerClientVersion: z.string().min(1),
+});

--- a/shared/api-services/src/services/exchange-fund/types.ts
+++ b/shared/api-services/src/services/exchange-fund/types.ts
@@ -1,0 +1,5 @@
+import type { z } from "zod";
+import type { ExchangeFundApiExtraSchema } from "./schema";
+
+/** Slice of the Redux thunk `extraArgument` owned by the exchange transaction manager. */
+export type ExchangeFundApiExtra = z.infer<typeof ExchangeFundApiExtraSchema>;

--- a/shared/api-services/src/services/index.ts
+++ b/shared/api-services/src/services/index.ts
@@ -3,5 +3,6 @@ export * from "./card";
 export * from "./coinmarketcap";
 export * from "./countervalues";
 export * from "./dada";
+export * from "./exchange-fund";
 export * from "./push-devices";
 export * from "./swap";

--- a/shared/env/src/definitions/team-ptx/index.ts
+++ b/shared/env/src/definitions/team-ptx/index.ts
@@ -1,6 +1,11 @@
 import { boolParser, stringParser } from "@ledgerhq/live-env";
 
 const teamPtx = {
+  EXCHANGE_FUND_API_URL: {
+    def: "https://exchange-tx-manager.ledger.com",
+    parser: stringParser,
+    desc: "Exchange transaction manager, which brokers signed fund payloads from the provider",
+  },
   SWAP_API_BASE: {
     def: "https://swap.ledger.com/v5",
     parser: stringParser,


### PR DESCRIPTION
A card top-up is clear-signed from a payload the provider signs, and the
transaction manager is what brokers it: `remitFundCard` exchanges the device
nonce from `startExchange` for the payin address and that signed payload, which
`completeExchange` then hands to the device.

The payin address comes back from the same call, so the address the transaction
pays and the address inside the signed payload have a single source rather than
being read separately from the provider's own API.

`confirmFund` and `cancelFund` close the order out once the transaction is
broadcast or refused; both are keyed on the quote id.

No caller yet — the device intent that consumes the payload lands next.