### PR TITLE
[LWD] fix(earn): reset to dashboard on Earn sidebar re-click (LIVE-36490)

### DIFF
--- a/.changeset/earn-tab-back-to-dashboard.md
+++ b/.changeset/earn-tab-back-to-dashboard.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Reload the Earn live app on its dashboard when the user clicks the Earn sidebar entry while already inside the Earn tab (LIVE-36490).

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/__tests__/useSideBarViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/__tests__/useSideBarViewModel.test.ts
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router";
 import { useSideBarViewModel } from "../useSideBarViewModel";
 import { SIDEBAR_VALUE_TO_PATH, SIDEBAR_VALUE_TO_TRACK_ENTRY } from "../utils/constants";
 import { SCROLL_TO_TOP_EVENT } from "LLD/components/Page/constants";
+import { EARN_GO_TO_DASHBOARD_EVENT } from "~/renderer/screens/earn/constants";
 import * as segment from "~/renderer/analytics/segment";
 import type { SideBarViewModel } from "../types";
 import { defaultInitialState, withFeatureFlags } from "./testUtils";
@@ -350,6 +351,40 @@ describe("useSideBarViewModel", () => {
           type: SCROLL_TO_TOP_EVENT,
         }),
       );
+      dispatchEventSpy.mockRestore();
+    });
+
+    it("should dispatch EARN_GO_TO_DASHBOARD_EVENT when clicking Earn while already on earn", () => {
+      const dispatchEventSpy = jest.spyOn(window, "dispatchEvent");
+      const { result } = renderHook(() => useSideBarViewModel(), {
+        initialState: defaultInitialState,
+        minimal: false,
+        initialRoute: SIDEBAR_VALUE_TO_PATH.earn,
+      });
+
+      act(() => result.current.handleActiveChange("earn"));
+
+      expect(dispatchEventSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: EARN_GO_TO_DASHBOARD_EVENT,
+        }),
+      );
+      expect(mockNavigate).not.toHaveBeenCalled();
+      dispatchEventSpy.mockRestore();
+    });
+
+    it("should not dispatch EARN_GO_TO_DASHBOARD_EVENT when clicking Earn from another screen", () => {
+      const dispatchEventSpy = jest.spyOn(window, "dispatchEvent");
+      const { result } = renderViewModel();
+
+      act(() => result.current.handleActiveChange("earn"));
+
+      expect(dispatchEventSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: EARN_GO_TO_DASHBOARD_EVENT,
+        }),
+      );
+      expect(mockNavigate).toHaveBeenCalledWith(SIDEBAR_VALUE_TO_PATH.earn);
       dispatchEventSpy.mockRestore();
     });
   });

--- a/apps/ledger-live-desktop/src/mvvm/components/SideBar/useSideBarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/SideBar/useSideBarViewModel.ts
@@ -27,6 +27,7 @@ import {
   getAccountsSidebarPath,
 } from "./utils";
 import { SCROLL_TO_TOP_EVENT } from "LLD/components/Page/constants";
+import { EARN_GO_TO_DASHBOARD_EVENT } from "~/renderer/screens/earn/constants";
 import type { SideBarViewModel } from "./types";
 
 const MAX_STARRED_ACCOUNTS_DISPLAYED_IN_SMALL_SCREEN = 3;
@@ -224,6 +225,11 @@ export function useSideBarViewModel(): SideBarViewModel {
     globalThis.dispatchEvent(new CustomEvent(SCROLL_TO_TOP_EVENT));
   }, []);
 
+  /** Notifies the Earn screen to send its live app back to the dashboard (user clicked Earn while already on /earn). */
+  const handleEarnGoToDashboard = useCallback(() => {
+    globalThis.dispatchEvent(new CustomEvent(EARN_GO_TO_DASHBOARD_EVENT));
+  }, []);
+
   const handleClickRefer = useCallback(() => {
     if (referralProgramConfig?.enabled && referralProgramConfig?.params?.path) {
       push(referralProgramConfig.params.path);
@@ -310,6 +316,9 @@ export function useSideBarViewModel(): SideBarViewModel {
         if (value === "home" && location.pathname === SIDEBAR_VALUE_TO_PATH.home) {
           handleScrollToTop();
         }
+        if (value === "earn" && location.pathname === SIDEBAR_VALUE_TO_PATH.earn) {
+          handleEarnGoToDashboard();
+        }
         const path = value === "accounts" ? accountsSidebarPath : SIDEBAR_VALUE_TO_PATH[value];
         push(path);
         trackEntry(SIDEBAR_VALUE_TO_TRACK_ENTRY[value]);
@@ -319,6 +328,7 @@ export function useSideBarViewModel(): SideBarViewModel {
       handleClickRefer,
       handleClickRecover,
       handleScrollToTop,
+      handleEarnGoToDashboard,
       push,
       trackEntry,
       location.pathname,

--- a/apps/ledger-live-desktop/src/renderer/screens/earn/constants.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/earn/constants.ts
@@ -1,0 +1,5 @@
+/**
+ * Custom event name dispatched when the user clicks the Earn sidebar entry while already on /earn.
+ * useDashboardReset listens for it and reloads the Earn live app on its dashboard.
+ */
+export const EARN_GO_TO_DASHBOARD_EVENT = "ledger-live:earn-go-to-dashboard";

--- a/apps/ledger-live-desktop/src/renderer/screens/earn/index.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/earn/index.test.tsx
@@ -1,11 +1,12 @@
 import React from "react";
-import { render, screen, withFlagOverrides } from "tests/testSetup";
+import { act, render, screen, withFlagOverrides } from "tests/testSetup";
 import {
   useRemoteLiveAppContext,
   useRemoteLiveAppManifest,
 } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
 import { useLocalLiveAppManifest } from "@ledgerhq/live-common/wallet-api/LocalLiveAppProvider/index";
 import { useDeepLinkListener } from "./useDeepLinkListener";
+import { EARN_GO_TO_DASHBOARD_EVENT } from "./constants";
 import Earn from ".";
 
 const mockWebPlatformPlayer = jest.fn((_props: unknown) => (
@@ -220,6 +221,36 @@ describe("Earn screen", () => {
     };
 
     expect(lastCall.inputs.swapToEarn).toBe(JSON.stringify({ enabled: false }));
+  });
+
+  it("remounts the live app without the deposit intent on a dashboard reset", () => {
+    const useLocationSpy = jest.spyOn(require("react-router"), "useLocation").mockReturnValue({
+      pathname: "/earn",
+      search: "",
+      hash: "",
+      state: { intent: "deposit", cryptoAssetId: "bitcoin" },
+    });
+
+    render(<Earn />, {
+      initialState: withFlagOverrides({
+        ptxEarnLiveApp: { enabled: true, params: { manifest_id: "earn-manifest-id" } },
+        stakePrograms: { enabled: true, params: { list: [], redirects: {} } } as never,
+      }),
+    });
+
+    useLocationSpy.mockReturnValue({ pathname: "/earn", search: "", hash: "", state: null });
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(EARN_GO_TO_DASHBOARD_EVENT));
+    });
+
+    const lastCall = mockWebPlatformPlayer.mock.calls.at(-1)?.[0] as unknown as {
+      inputs: Record<string, string | undefined>;
+    };
+
+    expect(lastCall.inputs.intent).toBeUndefined();
+    expect(lastCall.inputs.cryptoAssetId).toBeUndefined();
+    useLocationSpy.mockRestore();
   });
 
   it("passes uiVersion v4 when earn simulator is enabled", () => {

--- a/apps/ledger-live-desktop/src/renderer/screens/earn/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/earn/index.tsx
@@ -28,6 +28,7 @@ import { NetworkErrorScreen } from "~/renderer/components/Web3AppWebview/Network
 import Box from "~/renderer/components/Box";
 import { computeEarnUiVersion } from "@ledgerhq/live-common/domain/computeEarnUiVersion";
 import { buildEarnGoToURL } from "./buildEarnGoToURL";
+import { useDashboardReset } from "./useDashboardReset";
 
 const DEFAULT_MANIFEST_ID =
   process.env.DEFAULT_EARN_MANIFEST_ID || FEATURE_FLAGS_DEFAULTS.ptxEarnLiveApp.params?.manifest_id;
@@ -57,6 +58,7 @@ const Earn = () => {
   });
 
   useDeepLinkListener();
+  const { resetKey, onWebviewStateChange } = useDashboardReset();
 
   const stakePrograms = useVersionedStakePrograms();
   const { stakeProgramsParam, stakeCurrenciesParam } = useMemo(
@@ -129,6 +131,7 @@ const Earn = () => {
   return (
     <Box grow style={{ overflow: "hidden" }} data-testid="earn-app-container">
       <WebPlatformPlayer
+        key={resetKey}
         config={{
           topBarConfig: {
             shouldDisplayName: false,
@@ -139,6 +142,7 @@ const Earn = () => {
         }}
         manifest={manifest}
         inputs={inputs}
+        onStateChange={onWebviewStateChange}
       />
     </Box>
   );

--- a/apps/ledger-live-desktop/src/renderer/screens/earn/isOnEarnDashboard.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/earn/isOnEarnDashboard.test.ts
@@ -1,0 +1,34 @@
+import { isOnEarnDashboard } from "./isOnEarnDashboard";
+
+describe("isOnEarnDashboard", () => {
+  it("accepts the app root carrying its init params", () => {
+    expect(isOnEarnDashboard("https://earn.example/?theme=dark&lang=en&uiVersion=v4")).toBe(true);
+  });
+
+  it("accepts a dashboard living under a path of its own", () => {
+    expect(isOnEarnDashboard("https://earn.example/en/dashboard?theme=dark")).toBe(true);
+  });
+
+  it("rejects the intent flows by path", () => {
+    expect(isOnEarnDashboard("https://earn.example/deposit?cryptoAssetId=eth")).toBe(false);
+    expect(isOnEarnDashboard("https://earn.example/withdraw")).toBe(false);
+    expect(isOnEarnDashboard("https://earn.example/earn-simulator")).toBe(false);
+  });
+
+  it("rejects the intent flows by query param", () => {
+    expect(isOnEarnDashboard("https://earn.example/?intent=deposit")).toBe(false);
+    expect(isOnEarnDashboard("https://earn.example/?intent=withdraw")).toBe(false);
+    expect(isOnEarnDashboard("https://earn.example/?intent=simulate")).toBe(false);
+  });
+
+  it("ignores an unknown intent value", () => {
+    expect(isOnEarnDashboard("https://earn.example/?intent=whatever")).toBe(true);
+  });
+
+  it("rejects a URL that is not a loaded page yet", () => {
+    expect(isOnEarnDashboard(undefined)).toBe(false);
+    expect(isOnEarnDashboard("")).toBe(false);
+    expect(isOnEarnDashboard("about:blank")).toBe(false);
+    expect(isOnEarnDashboard("not-a-url")).toBe(false);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/screens/earn/isOnEarnDashboard.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/earn/isOnEarnDashboard.ts
@@ -1,0 +1,32 @@
+import { safeUrl } from "@ledgerhq/live-common/wallet-api/helpers";
+
+const INTENTS = new Set(["deposit", "withdraw", "simulate"]);
+const INTENT_PATHS = ["/deposit", "/withdraw", "/earn-simulator"];
+
+/**
+ * Tells whether the Earn live app sits on its dashboard rather than inside a deposit, withdraw or
+ * simulator flow, so a dashboard reset can skip reloading it.
+ *
+ * Mirrors the mobile detection in ledger-live-mobile screens/PTX/Earn/getWebviewIntent.ts: the
+ * dashboard has no fixed URL, so flows are recognised by their intent query param or path instead
+ * of by comparing against the manifest URL.
+ *
+ * Returns false when the URL is unknown or not a real page yet (e.g. about:blank during load), so
+ * that a reset still reloads rather than wrongly assuming the user is already home.
+ */
+export function isOnEarnDashboard(webviewUrl?: string): boolean {
+  if (!webviewUrl) {
+    return false;
+  }
+
+  const url = safeUrl(webviewUrl);
+  if (!url || (url.protocol !== "http:" && url.protocol !== "https:")) {
+    return false;
+  }
+
+  if (INTENTS.has(url.searchParams.get("intent") ?? "")) {
+    return false;
+  }
+
+  return !INTENT_PATHS.some(path => url.pathname.includes(path));
+}

--- a/apps/ledger-live-desktop/src/renderer/screens/earn/useDashboardReset.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/earn/useDashboardReset.test.ts
@@ -1,0 +1,113 @@
+import { renderHook, act } from "tests/testSetup";
+import { useLocation, useNavigate } from "react-router";
+import { EARN_GO_TO_DASHBOARD_EVENT } from "./constants";
+import { useDashboardReset } from "./useDashboardReset";
+
+const DASHBOARD_URL = "https://earn.example/en/dashboard?theme=dark";
+const DEPOSIT_URL = "https://earn.example/en/deposit?cryptoAssetId=eth";
+
+const mockNavigate = jest.fn();
+
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
+  useNavigate: jest.fn(),
+  useLocation: jest.fn(),
+}));
+
+const mockedUseNavigate = jest.mocked(useNavigate);
+const mockedUseLocation = jest.mocked(useLocation);
+
+const mockLocationState = (state: unknown) => {
+  mockedUseLocation.mockReturnValue({
+    pathname: "/earn",
+    search: "",
+    hash: "",
+    state,
+    key: "test",
+  });
+};
+
+const dispatchReset = () =>
+  act(() => {
+    window.dispatchEvent(new CustomEvent(EARN_GO_TO_DASHBOARD_EVENT));
+  });
+
+describe("useDashboardReset", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseNavigate.mockReturnValue(mockNavigate);
+    mockLocationState(null);
+  });
+
+  it("bumps the remount key when the live app is inside an intent flow", () => {
+    const { result } = renderHook(() => useDashboardReset());
+    const initialKey = result.current.resetKey;
+
+    act(() => result.current.onWebviewStateChange({ url: DEPOSIT_URL } as never));
+    dispatchReset();
+
+    expect(result.current.resetKey).not.toBe(initialKey);
+  });
+
+  it("skips the remount when the live app already sits on its dashboard", () => {
+    const { result } = renderHook(() => useDashboardReset());
+    const initialKey = result.current.resetKey;
+
+    act(() => result.current.onWebviewStateChange({ url: DASHBOARD_URL } as never));
+    dispatchReset();
+
+    expect(result.current.resetKey).toBe(initialKey);
+  });
+
+  it("bumps the remount key while the webview URL is still unknown", () => {
+    const { result } = renderHook(() => useDashboardReset());
+    const initialKey = result.current.resetKey;
+
+    dispatchReset();
+
+    expect(result.current.resetKey).not.toBe(initialKey);
+  });
+
+  it("clears a deeplink route state even when no reload is needed", () => {
+    mockLocationState({ intent: "deposit", cryptoAssetId: "bitcoin" });
+    const { result } = renderHook(() => useDashboardReset());
+
+    act(() => result.current.onWebviewStateChange({ url: DASHBOARD_URL } as never));
+    dispatchReset();
+
+    expect(mockNavigate).toHaveBeenCalledWith("/earn", { replace: true, state: null });
+    expect(result.current.resetKey).toBe(0);
+  });
+
+  it("does not touch the history when there is no route state to clear", () => {
+    const { result } = renderHook(() => useDashboardReset());
+
+    act(() => result.current.onWebviewStateChange({ url: DEPOSIT_URL } as never));
+    dispatchReset();
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("bumps a different key on every reset", () => {
+    const { result } = renderHook(() => useDashboardReset());
+    const keys = new Set([result.current.resetKey]);
+
+    dispatchReset();
+    keys.add(result.current.resetKey);
+
+    dispatchReset();
+    keys.add(result.current.resetKey);
+
+    expect(keys.size).toBe(3);
+  });
+
+  it("stops listening once unmounted", () => {
+    mockLocationState({ intent: "deposit" });
+    const { unmount } = renderHook(() => useDashboardReset());
+
+    unmount();
+    dispatchReset();
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/screens/earn/useDashboardReset.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/earn/useDashboardReset.ts
@@ -1,0 +1,45 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useLocation, useNavigate } from "react-router";
+import type { WebviewState } from "~/renderer/components/Web3AppWebview/types";
+import { EARN_GO_TO_DASHBOARD_EVENT } from "./constants";
+import { isOnEarnDashboard } from "./isOnEarnDashboard";
+
+/**
+ * Handles the sidebar asking for a dashboard reset. `resetKey` remounts the Earn live app, which is
+ * the only reliable way to move it: it navigates inside the webview without the host knowing, so
+ * recomputing the same `src` would be a no-op prop update. Tracking the webview URL lets us skip
+ * that reload when the app already sits on its dashboard.
+ */
+export const useDashboardReset = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [resetKey, setResetKey] = useState(0);
+  const webviewUrlRef = useRef<string | undefined>(undefined);
+
+  const onWebviewStateChange = useCallback((state: WebviewState) => {
+    webviewUrlRef.current = state.url;
+  }, []);
+
+  const hasRouteState = !!location.state && Object.keys(location.state).length > 0;
+
+  useEffect(() => {
+    const handler = () => {
+      // Deeplink params must go even when no reload is needed, otherwise a later input change
+      // (theme, discreet mode) would recompute the webview src and replay the deposit flow.
+      if (hasRouteState) {
+        navigate("/earn", { replace: true, state: null });
+      }
+
+      if (isOnEarnDashboard(webviewUrlRef.current)) {
+        return;
+      }
+
+      setResetKey(key => key + 1);
+    };
+
+    globalThis.addEventListener(EARN_GO_TO_DASHBOARD_EVENT, handler);
+    return () => globalThis.removeEventListener(EARN_GO_TO_DASHBOARD_EVENT, handler);
+  }, [navigate, hasRouteState]);
+
+  return { resetKey, onWebviewStateChange };
+};


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Clicking Earn in the desktop sidebar while already on `/earn` currently does nothing, so users stuck in deposit, withdraw or simulator cannot return to the Earn dashboard the way they can on mobile.

This PR dispatches a custom event when Earn is clicked again, remounts the live app (skipping the reload if it is already on the dashboard), and clears leftover deeplink route state so later input changes do not replay the deposit flow.

### Demo


https://github.com/user-attachments/assets/1a8a5996-7734-4e41-aa96-df58815f108a



### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36490](https://ledgerhq.atlassian.net/browse/LIVE-36490)
- **ADR** (if any): N/A

Made with [Cursor](https://cursor.com)

[LIVE-36490]: https://ledgerhq.atlassian.net/browse/LIVE-36490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ