### PR TITLE
[LWDM] feat(coin-casper): wire generic adapter integration (LIVE-35914)

### DIFF
--- a/.changeset/brave-dogs-hide.md
+++ b/.changeset/brave-dogs-hide.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-casper": minor
+"@ledgerhq/live-common": minor
+---
+
+Wire craftTransactionData in CoinModuleApi and propagate transferId through the generic adapter

--- a/apps/ledger-live-desktop/src/mvvm/features/MemoTag/__tests__/utils.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MemoTag/__tests__/utils.test.ts
@@ -38,6 +38,19 @@ describe("getMemoTagValueByTransactionFamily", () => {
     expect(getMemoTagValueByTransactionFamily(transaction)).toBe("Solana memo");
   });
 
+  it("should return memoValue for casper family", () => {
+    const transaction: Transaction = {
+      family: "casper",
+      memoValue: "9007199254740993",
+    } as Transaction;
+    expect(getMemoTagValueByTransactionFamily(transaction)).toBe("9007199254740993");
+  });
+
+  it("should return undefined when casper memoValue is absent", () => {
+    const transaction: Transaction = { family: "casper" } as Transaction;
+    expect(getMemoTagValueByTransactionFamily(transaction)).toBeUndefined();
+  });
+
   it("should return memo for default case", () => {
     const transaction: Transaction = { family: "cosmos", memo: "Default memo" } as Transaction & {
       memo: string;

--- a/apps/ledger-live-desktop/src/mvvm/features/MemoTag/utils.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MemoTag/utils.ts
@@ -28,7 +28,7 @@ export const getMemoTagValueByTransactionFamily = (transaction: Transaction) => 
         }
       )?.model.uiState.memo;
     case "casper":
-      return transaction?.transferId;
+      return transaction?.memoValue ?? undefined;
     default:
       return (transaction as Transaction & { memo: string })?.memo;
   }

--- a/apps/ledger-live-desktop/src/renderer/families/casper/MemoField.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/casper/MemoField.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from "react";
+import { render, screen, fireEvent } from "tests/testSetup";
+import BigNumber from "bignumber.js";
+import type { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/casper/types";
+import MemoField from "./MemoField";
+
+const mockUpdateTransaction = jest.fn((t, patch) => ({ ...t, ...patch }));
+
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  useAccountBridge: () => ({ updateTransaction: mockUpdateTransaction }),
+}));
+
+jest.mock("react-i18next", () => ({
+  ...jest.requireActual("react-i18next"),
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const baseTransaction: Transaction = {
+  family: "casper",
+  amount: new BigNumber(0),
+  fees: new BigNumber(0),
+  recipient: "",
+  useAllAmount: false,
+  memoType: null,
+  memoValue: null,
+};
+
+const baseStatus: TransactionStatus = {
+  amount: new BigNumber(0),
+  estimatedFees: new BigNumber(0),
+  totalSpent: new BigNumber(0),
+  errors: {},
+  warnings: {},
+};
+
+const mockAccount = { id: "casper-account" } as any;
+const mockOnChange = jest.fn();
+
+describe("MemoField (casper)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the memo tag input", () => {
+    render(
+      <MemoField
+        onChange={mockOnChange}
+        account={mockAccount}
+        transaction={baseTransaction}
+        status={baseStatus}
+        autoFocus={false}
+      />,
+    );
+    expect(screen.getByTestId("memo-tag-input")).toBeInTheDocument();
+  });
+
+  it("strips non-digit characters and calls onChange with transferId set", () => {
+    render(
+      <MemoField
+        onChange={mockOnChange}
+        account={mockAccount}
+        transaction={baseTransaction}
+        status={baseStatus}
+        autoFocus={false}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId("memo-tag-input"), { target: { value: "abc123" } });
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    const updated = mockOnChange.mock.calls[0][0];
+    expect(updated.transferId).toBe("123");
+    expect(updated.memoType).toBe("transferId");
+    expect(updated.memoValue).toBe("123");
+  });
+
+  it("clears transferId when input contains only non-digit characters", () => {
+    render(
+      <MemoField
+        onChange={mockOnChange}
+        account={mockAccount}
+        transaction={baseTransaction}
+        status={baseStatus}
+        autoFocus={false}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId("memo-tag-input"), { target: { value: "abc" } });
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    const updated = mockOnChange.mock.calls[0][0];
+    expect(updated.transferId).toBeUndefined();
+    expect(updated.memoType).toBeNull();
+    expect(updated.memoValue).toBeNull();
+  });
+
+  it("uses the existing memoValue as the input value", () => {
+    render(
+      <MemoField
+        onChange={mockOnChange}
+        account={mockAccount}
+        transaction={{ ...baseTransaction, memoValue: "9876" }}
+        status={baseStatus}
+        autoFocus={false}
+      />,
+    );
+    expect(screen.getByTestId("memo-tag-input")).toHaveValue("9876");
+  });
+
+  it("displays error from status.errors.sender when present", () => {
+    const error = new Error("sender error");
+    render(
+      <MemoField
+        onChange={mockOnChange}
+        account={mockAccount}
+        transaction={baseTransaction}
+        status={{ ...baseStatus, errors: { sender: error } }}
+        autoFocus={false}
+      />,
+    );
+    expect(screen.getByTestId("memo-tag-input")).toBeInTheDocument();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/casper/MemoField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/casper/MemoField.tsx
@@ -1,32 +1,19 @@
-import React, { useCallback } from "react";
-import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
-import invariant from "invariant";
+import React from "react";
 import { useTranslation } from "react-i18next";
 import MemoTagField from "LLD/features/MemoTag/components/MemoTagField";
 import { MemoTagFieldProps } from "./types";
-import type { Transaction } from "@ledgerhq/live-common/families/casper/types";
+import { useTransferIdChange } from "./useTransferIdChange";
 
 const MemoField = ({ onChange, account, transaction, status, autoFocus }: MemoTagFieldProps) => {
-  invariant(transaction.family === "casper", "TransferIdField: casper family expected");
-
   const { t } = useTranslation();
 
-  const bridge = useAccountBridge<Transaction>(account);
-
-  const onTransferIdFieldChange = useCallback(
-    (value: string) => {
-      value = value.replace(/\D/g, "");
-      if (value !== "") onChange(bridge.updateTransaction(transaction, { transferId: value }));
-      else onChange(bridge.updateTransaction(transaction, { transferId: undefined }));
-    },
-    [onChange, transaction, bridge],
-  );
+  const onTransferIdFieldChange = useTransferIdChange(account, transaction, onChange);
 
   return (
     <MemoTagField
       warning={status.warnings.transaction}
       error={status.errors.transaction || status.errors.sender}
-      value={transaction.transferId ?? ""}
+      value={transaction.memoValue ?? ""}
       placeholder={t("families.casper.transferIdPlaceholder")}
       label={t("families.casper.transferId")}
       tooltipText={t("families.casper.transferIdWarningText")}

--- a/apps/ledger-live-desktop/src/renderer/families/casper/SendAmountFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/casper/SendAmountFields.tsx
@@ -52,5 +52,5 @@ const Root = (props: Props) => {
 export default {
   component: Root,
   // Transaction is used here to prevent user to forward
-  fields: ["transferId", "transaction"],
+  fields: ["memoValue", "transaction"],
 };

--- a/apps/ledger-live-desktop/src/renderer/families/casper/StepSummaryAdditionalRows.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/casper/StepSummaryAdditionalRows.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import BigNumber from "bignumber.js";
+import type { Transaction } from "@ledgerhq/live-common/families/casper/types";
+import StepSummaryAdditionalRows from "./StepSummaryAdditionalRows";
+
+jest.mock("@features/platform-feature-flags", () => ({
+  useFeature: jest.fn(),
+}));
+
+const { useFeature } = jest.requireMock("@features/platform-feature-flags");
+
+const baseTransaction: Transaction = {
+  family: "casper",
+  amount: new BigNumber(0),
+  fees: new BigNumber(0),
+  recipient: "",
+  useAllAmount: false,
+  memoType: null,
+  memoValue: null,
+};
+
+describe("StepSummaryAdditionalRows", () => {
+  beforeEach(() => {
+    useFeature.mockReturnValue({ enabled: false });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders nothing when lldMemoTag feature is enabled", () => {
+    useFeature.mockReturnValue({ enabled: true });
+    const { container } = render(
+      <StepSummaryAdditionalRows transaction={{ ...baseTransaction, memoValue: "12345" }} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it.each([null, undefined])("renders nothing when memoValue is %s", memoValue => {
+    const { container } = render(
+      <StepSummaryAdditionalRows transaction={{ ...baseTransaction, memoValue }} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the transferId value when memoValue is set and flag is off", () => {
+    render(
+      <StepSummaryAdditionalRows
+        transaction={{ ...baseTransaction, memoValue: "9007199254740993" }}
+      />,
+    );
+    expect(screen.getByText("9007199254740993")).toBeInTheDocument();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/casper/StepSummaryAdditionalRows.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/casper/StepSummaryAdditionalRows.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { Trans } from "react-i18next";
+import type { Transaction } from "@ledgerhq/live-common/families/casper/types";
+import Text from "~/renderer/components/Text";
+import Box from "~/renderer/components/Box";
+import { useFeature } from "@features/platform-feature-flags";
+
+type Props = {
+  transaction: Transaction;
+};
+
+const StepSummaryAdditionalRows = ({ transaction }: Props) => {
+  const lldMemoTag = useFeature("lldMemoTag");
+
+  // When lldMemoTag is enabled the generic memo section in StepSummary already shows
+  // the value via getMemoTagValueByTransactionFamily → memoValue, so skip here.
+  if (lldMemoTag?.enabled) return null;
+
+  const transferId = transaction.memoValue;
+  if (!transferId) return null;
+
+  return (
+    <Box horizontal justifyContent="space-between" alignItems="center" mt={10}>
+      <Text ff="Inter|Medium" color="neutral.c60" fontSize={4}>
+        <Trans i18nKey="families.casper.transferId" />
+      </Text>
+      <Text ff="Inter|SemiBold" color="neutral.c100" fontSize={4}>
+        {transferId}
+      </Text>
+    </Box>
+  );
+};
+
+export default StepSummaryAdditionalRows;

--- a/apps/ledger-live-desktop/src/renderer/families/casper/TransferIdField.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/casper/TransferIdField.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from "react";
+import { render, screen, fireEvent } from "tests/testSetup";
+import BigNumber from "bignumber.js";
+import type { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/casper/types";
+import TransferIdField from "./TransferIdField";
+
+const mockUpdateTransaction = jest.fn((t, patch) => ({ ...t, ...patch }));
+
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  useAccountBridge: () => ({ updateTransaction: mockUpdateTransaction }),
+}));
+
+jest.mock("react-i18next", () => ({
+  ...jest.requireActual("react-i18next"),
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const baseTransaction: Transaction = {
+  family: "casper",
+  amount: new BigNumber(0),
+  fees: new BigNumber(0),
+  recipient: "",
+  useAllAmount: false,
+  memoType: null,
+  memoValue: null,
+};
+
+const baseStatus: TransactionStatus = {
+  amount: new BigNumber(0),
+  estimatedFees: new BigNumber(0),
+  totalSpent: new BigNumber(0),
+  errors: {},
+  warnings: {},
+};
+
+const mockAccount = { id: "casper-account" } as any;
+const mockOnChange = jest.fn();
+
+describe("TransferIdField (casper)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders an input element", () => {
+    render(
+      <TransferIdField
+        onChange={mockOnChange}
+        account={mockAccount}
+        transaction={baseTransaction}
+        status={baseStatus}
+      />,
+    );
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  it("strips non-digits and calls onChange with transferId set", () => {
+    render(
+      <TransferIdField
+        onChange={mockOnChange}
+        account={mockAccount}
+        transaction={baseTransaction}
+        status={baseStatus}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "abc456" } });
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    const updated = mockOnChange.mock.calls[0][0];
+    expect(updated.transferId).toBe("456");
+    expect(updated.memoType).toBe("transferId");
+    expect(updated.memoValue).toBe("456");
+  });
+
+  it("clears transferId when only non-digit characters are entered", () => {
+    render(
+      <TransferIdField
+        onChange={mockOnChange}
+        account={mockAccount}
+        transaction={baseTransaction}
+        status={baseStatus}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "xyz" } });
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    const updated = mockOnChange.mock.calls[0][0];
+    expect(updated.transferId).toBeUndefined();
+    expect(updated.memoType).toBeNull();
+    expect(updated.memoValue).toBeNull();
+  });
+
+  it("shows the existing memoValue as the current input value", () => {
+    render(
+      <TransferIdField
+        onChange={mockOnChange}
+        account={mockAccount}
+        transaction={{ ...baseTransaction, memoValue: "5555" }}
+        status={baseStatus}
+      />,
+    );
+    expect(screen.getByRole("textbox")).toHaveValue("5555");
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/casper/TransferIdField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/casper/TransferIdField.tsx
@@ -1,12 +1,11 @@
-import React, { useCallback } from "react";
-import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import React from "react";
 import Input from "~/renderer/components/Input";
-import invariant from "invariant";
 import type { Account } from "@ledgerhq/types-live";
 import type { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/casper/types";
 import { useTranslation } from "react-i18next";
+import { useTransferIdChange } from "./useTransferIdChange";
 
-const TranferIdField = ({
+const TransferIdField = ({
   onChange,
   account,
   transaction,
@@ -17,26 +16,15 @@ const TranferIdField = ({
   transaction: Transaction;
   status: TransactionStatus;
 }) => {
-  invariant(transaction.family === "casper", "TransferIdField: casper family expected");
-
   const { t } = useTranslation();
 
-  const bridge = useAccountBridge<Transaction>(account);
-
-  const onTransferIdFieldChange = useCallback(
-    (value: string) => {
-      value = value.replace(/\D/g, "");
-      if (value !== "") onChange(bridge.updateTransaction(transaction, { transferId: value }));
-      else onChange(bridge.updateTransaction(transaction, { transferId: undefined }));
-    },
-    [onChange, transaction, bridge],
-  );
+  const onTransferIdFieldChange = useTransferIdChange(account, transaction, onChange);
 
   return (
     <Input
       warning={status.warnings.transaction}
       error={status.errors.transaction}
-      value={transaction.transferId ?? ""}
+      value={transaction.memoValue ?? ""}
       placeholder={t("families.casper.transferIdPlaceholder")}
       onChange={onTransferIdFieldChange}
       spellCheck="false"
@@ -44,4 +32,4 @@ const TranferIdField = ({
   );
 };
 
-export default TranferIdField;
+export default TransferIdField;

--- a/apps/ledger-live-desktop/src/renderer/families/casper/__tests__/operationDetails.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/casper/__tests__/operationDetails.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import BigNumber from "bignumber.js";
+import type { CasperOperation } from "@ledgerhq/live-common/families/casper/types";
+import operationDetails from "../operationDetails";
+
+const { OperationDetailsExtra } = operationDetails;
+
+const baseOperation: CasperOperation = {
+  id: "casper--OUT",
+  hash: "",
+  type: "OUT",
+  value: new BigNumber(0),
+  fee: new BigNumber(0),
+  blockHash: null,
+  blockHeight: null,
+  senders: [],
+  recipients: [],
+  accountId: "casper-account",
+  date: new Date(),
+  extra: {},
+};
+
+const mockAccount = { id: "casper-account" } as any;
+
+describe("OperationDetailsExtra", () => {
+  it("renders the transferId when present in extra", () => {
+    render(
+      <OperationDetailsExtra
+        account={mockAccount}
+        operation={{ ...baseOperation, extra: { transferId: "9007199254740993" } }}
+        type="OUT"
+      />,
+    );
+    expect(screen.getByText("9007199254740993")).toBeInTheDocument();
+  });
+
+  it("renders nothing when transferId is absent from extra", () => {
+    const { container } = render(
+      <OperationDetailsExtra account={mockAccount} operation={baseOperation} type="OUT" />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/casper/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/casper/index.ts
@@ -10,6 +10,7 @@ import AccountSubHeader from "./AccountSubHeader";
 import sendAmountFields from "./SendAmountFields";
 import transactionConfirmFields from "./TransactionConfirmFields";
 import sendRecipientFields from "./SendRecipientFields";
+import StepSummaryAdditionalRows from "./StepSummaryAdditionalRows";
 
 const family: LLDCoinFamily<CasperAccount, Transaction, TransactionStatus, CasperOperation> = {
   operationDetails,
@@ -17,6 +18,7 @@ const family: LLDCoinFamily<CasperAccount, Transaction, TransactionStatus, Caspe
   sendRecipientFields,
   sendAmountFields,
   transactionConfirmFields,
+  StepSummaryAdditionalRows,
 };
 
 export default family;

--- a/apps/ledger-live-desktop/src/renderer/families/casper/operationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/casper/operationDetails.tsx
@@ -15,22 +15,16 @@ const OperationDetailsExtra = ({
 }: OperationDetailsExtraProps<CasperAccount, CasperOperation>) => {
   return (
     <>
-      {Object.keys(o.extra).map(key => {
-        if (o.extra.transferId) {
-          return (
-            <OpDetailsSection key={key}>
-              <OpDetailsTitle>
-                <Trans i18nKey={`families.casper.${key}`} defaults={key} />
-              </OpDetailsTitle>
-              <OpDetailsData>
-                <Ellipsis>{o.extra.transferId ?? "-"}</Ellipsis>
-              </OpDetailsData>
-            </OpDetailsSection>
-          );
-        }
-
-        return null;
-      })}
+      {o.extra.transferId && (
+        <OpDetailsSection>
+          <OpDetailsTitle>
+            <Trans i18nKey="families.casper.transferId" />
+          </OpDetailsTitle>
+          <OpDetailsData>
+            <Ellipsis>{o.extra.transferId}</Ellipsis>
+          </OpDetailsData>
+        </OpDetailsSection>
+      )}
     </>
   );
 };

--- a/apps/ledger-live-desktop/src/renderer/families/casper/useTransferIdChange.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/casper/useTransferIdChange.ts
@@ -1,0 +1,29 @@
+import { useCallback } from "react";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import invariant from "invariant";
+import type { Transaction } from "@ledgerhq/live-common/families/casper/types";
+import type { Account } from "@ledgerhq/types-live";
+
+export function useTransferIdChange(
+  account: Account,
+  transaction: Transaction,
+  onChange: (t: Transaction) => void,
+) {
+  invariant(transaction.family === "casper", "TransferIdField: casper family expected");
+
+  const bridge = useAccountBridge<Transaction>(account);
+
+  return useCallback(
+    (value: string) => {
+      const id = value.replace(/\D/g, "");
+      onChange(
+        bridge.updateTransaction(transaction, {
+          transferId: id || undefined,
+          memoType: id ? "transferId" : null,
+          memoValue: id || null,
+        }),
+      );
+    },
+    [onChange, transaction, bridge],
+  );
+}

--- a/apps/ledger-live-mobile/src/families/casper/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/casper/MemoTagInput.tsx
@@ -11,7 +11,12 @@ export default (props: MemoTagInputProps<CasperTransaction>) => {
     <GenericMemoTagInput
       {...props}
       textToValue={text => text.replace(/\D/g, "")}
-      valueToTxPatch={value => tx => ({ ...tx, transferId: value || undefined })}
+      valueToTxPatch={value => tx => ({
+        ...tx,
+        transferId: value || undefined,
+        memoType: value ? "transferId" : null,
+        memoValue: value || null,
+      })}
       placeholder={t("send.summary.transferId")}
     />
   );

--- a/apps/ledger-live-mobile/src/families/casper/ScreenEditTransferId.tsx
+++ b/apps/ledger-live-mobile/src/families/casper/ScreenEditTransferId.tsx
@@ -32,7 +32,7 @@ function CasperEditTransferId({ navigation, route }: NavigationProps) {
   const { account } = useAccountScreen(route);
   invariant(account, "account is required");
   const bridge = useAccountBridge<CasperTransaction>(account);
-  const [transferId, setTransferId] = useState(route.params?.transaction.transferId);
+  const [transferId, setTransferId] = useState(route.params?.transaction.memoValue);
   const onChangeTransferIdValue = useCallback((str: string) => {
     let value: string = str;
     value = str.replace(/\D/g, "");
@@ -44,7 +44,9 @@ function CasperEditTransferId({ navigation, route }: NavigationProps) {
     popToScreen(navigation, ScreenName.SendSummary, {
       accountId: account.id,
       transaction: bridge.updateTransaction(transaction, {
-        transferId: transferId && transferId.toString(),
+        transferId: transferId ? transferId.toString() : undefined,
+        memoType: transferId ? "transferId" : null,
+        memoValue: transferId ? transferId.toString() : null,
       }),
     });
   }, [navigation, route.params, account, bridge, transferId]);

--- a/apps/ledger-live-mobile/src/families/casper/SendRowTransferId.tsx
+++ b/apps/ledger-live-mobile/src/families/casper/SendRowTransferId.tsx
@@ -18,11 +18,11 @@ type Navigation = BaseComposite<
   | StackNavigatorProps<SwapNavigatorParamList, ScreenName.SwapSelectFees>
 >;
 
-type Props = {
+type Props = Readonly<{
   account: Account;
   transaction: Transaction;
-} & Navigation;
-export default function StacksMemoRow({ account, transaction }: Props) {
+}>;
+export default function CasperSendRowTransferId({ account, transaction }: Props) {
   const { colors } = useTheme();
   const navigation = useNavigation<Navigation["navigation"]>();
   const route = useRoute<Navigation["route"]>();
@@ -35,7 +35,7 @@ export default function StacksMemoRow({ account, transaction }: Props) {
       transaction,
     });
   }, [navigation, route.params, account, transaction]);
-  const transferId = transaction.transferId;
+  const transferId = transaction.memoValue;
   return (
     <View>
       {!transferId ? (
@@ -54,7 +54,7 @@ export default function StacksMemoRow({ account, transaction }: Props) {
           </LText>
         </SummaryRow>
       ) : (
-        <SummaryRow title={<Trans i18nKey="common.edit" />} onPress={editTransferId}>
+        <SummaryRow title={<Trans i18nKey="send.summary.transferId" />} onPress={editTransferId}>
           <LText semiBold style={styles.tagText} onPress={editTransferId}>
             {String(transferId)}
           </LText>
@@ -64,9 +64,6 @@ export default function StacksMemoRow({ account, transaction }: Props) {
   );
 }
 const styles = StyleSheet.create({
-  memoContainer: {
-    flexDirection: "row",
-  },
   tagText: {
     fontSize: 14,
   },
@@ -74,8 +71,5 @@ const styles = StyleSheet.create({
     textDecorationStyle: "solid",
     textDecorationLine: "underline",
     marginLeft: 8,
-  },
-  memo: {
-    marginBottom: 10,
   },
 });

--- a/apps/ledger-live-mobile/src/families/casper/SendRowsCustom.tsx
+++ b/apps/ledger-live-mobile/src/families/casper/SendRowsCustom.tsx
@@ -19,11 +19,10 @@ type Props = {
   transaction: Transaction;
   account: Account;
 } & Navigation;
-export default function CasperSendRowsCustom(props: Props) {
-  const { transaction, ...rest } = props;
+export default function CasperSendRowsCustom({ account, transaction }: Props) {
   return (
     <>
-      <SendRowTransferId {...rest} transaction={transaction as CasperTransaction} />
+      <SendRowTransferId account={account} transaction={transaction as CasperTransaction} />
     </>
   );
 }

--- a/apps/ledger-live-mobile/src/families/casper/__tests__/MemoTagInput.test.tsx
+++ b/apps/ledger-live-mobile/src/families/casper/__tests__/MemoTagInput.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import MemoTagInput from "../MemoTagInput";
+
+jest.mock("~/context/Locale", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe("MemoTagInput (Casper)", () => {
+  const onChange = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the memo tag input", () => {
+    render(<MemoTagInput onChange={onChange} />);
+    expect(screen.getByTestId("memo-tag-input")).toBeDefined();
+  });
+
+  it("strips non-digit characters and calls onChange with the patch", async () => {
+    const { user } = render(<MemoTagInput onChange={onChange} />);
+
+    await user.type(screen.getByTestId("memo-tag-input"), "abc123");
+
+    expect(onChange).toHaveBeenCalledTimes(6);
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+    expect(lastCall.value).toBe("123");
+
+    const tx = { family: "casper", transferId: undefined, memoType: null, memoValue: null };
+    const patched = lastCall.patch(tx);
+    expect(patched.transferId).toBe("123");
+    expect(patched.memoType).toBe("transferId");
+    expect(patched.memoValue).toBe("123");
+  });
+
+  it("sets transferId to undefined when no digits remain", async () => {
+    const { user } = render(<MemoTagInput onChange={onChange} />);
+
+    await user.type(screen.getByTestId("memo-tag-input"), "a");
+    await user.clear(screen.getByTestId("memo-tag-input"));
+
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+    const tx = { family: "casper", transferId: "99", memoType: "transferId", memoValue: "99" };
+    const patched = lastCall.patch(tx);
+    expect(patched.transferId).toBeUndefined();
+    expect(patched.memoType).toBeNull();
+    expect(patched.memoValue).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/families/casper/__tests__/ScreenEditTransferId.test.tsx
+++ b/apps/ledger-live-mobile/src/families/casper/__tests__/ScreenEditTransferId.test.tsx
@@ -1,0 +1,119 @@
+import React from "react";
+import { render, screen, fireEvent } from "@tests/test-renderer";
+import BigNumber from "bignumber.js";
+import type { Transaction } from "@ledgerhq/live-common/families/casper/types";
+import { component as CasperEditTransferId } from "../ScreenEditTransferId";
+
+const mockUpdateTransaction = jest.fn((t, patch) => ({ ...t, ...patch }));
+const mockPopToScreen = jest.fn();
+const mockNavigate = jest.fn();
+
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  useAccountBridge: () => ({ updateTransaction: mockUpdateTransaction }),
+}));
+
+jest.mock("LLM/hooks/useAccountScreen", () => ({
+  useAccountScreen: () => ({ account: { id: "casper-account", type: "Account" } }),
+}));
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useIsFocused: () => true,
+  useTheme: () => ({ colors: { background: "#fff", darkBlue: "#142533" } }),
+}));
+
+jest.mock("~/context/Locale", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock("~/helpers/navigationHelpers", () => ({
+  popToScreen: (...args: unknown[]) => mockPopToScreen(...args),
+}));
+
+jest.mock("~/components/SafeAreaView", () => {
+  const { View } = jest.requireActual("react-native");
+  return ({ children, style }: { children: React.ReactNode; style?: object }) => (
+    <View style={style}>{children}</View>
+  );
+});
+
+jest.mock("~/components/KeyboardView", () => {
+  const { View } = jest.requireActual("react-native");
+  return ({ children, style }: { children: React.ReactNode; style?: object }) => (
+    <View style={style}>{children}</View>
+  );
+});
+
+jest.mock("~/components/Button", () => {
+  const { TouchableOpacity, Text } = jest.requireActual("react-native");
+  return ({ onPress, title, event }: { onPress: () => void; title?: string; event?: string }) => (
+    <TouchableOpacity testID={event} onPress={onPress}>
+      <Text>{title}</Text>
+    </TouchableOpacity>
+  );
+});
+
+jest.mock("~/components/FocusedTextInput", () => {
+  const { TextInput } = jest.requireActual("react-native");
+  return (props: object) => <TextInput testID="transfer-id-input" {...props} />;
+});
+
+const baseTransaction: Transaction = {
+  family: "casper",
+  amount: new BigNumber(0),
+  fees: new BigNumber(0),
+  recipient: "",
+  useAllAmount: false,
+  memoType: null,
+  memoValue: "42",
+};
+
+const makeProps = (txOverrides: Partial<Transaction> = {}) =>
+  ({
+    navigation: { navigate: mockNavigate },
+    route: {
+      params: {
+        accountId: "casper-account",
+        transaction: { ...baseTransaction, ...txOverrides },
+      },
+    },
+  }) as any;
+
+describe("CasperEditTransferId", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the text input and validate button", () => {
+    render(<CasperEditTransferId {...makeProps()} />);
+    expect(screen.getByTestId("transfer-id-input")).toBeDefined();
+    expect(screen.getByTestId("CasperEditTransferId")).toBeDefined();
+  });
+
+  it("strips non-digits when the user types", () => {
+    render(<CasperEditTransferId {...makeProps({ memoValue: null })} />);
+    const input = screen.getByTestId("transfer-id-input");
+    fireEvent.changeText(input, "abc123");
+    expect(input.props.value).toBe("123");
+  });
+
+  it("calls popToScreen with the updated transaction on validate", () => {
+    render(<CasperEditTransferId {...makeProps()} />);
+    fireEvent.press(screen.getByTestId("CasperEditTransferId"));
+    expect(mockPopToScreen).toHaveBeenCalledTimes(1);
+    const [, , params] = mockPopToScreen.mock.calls[0];
+    expect(params.transaction.transferId).toBe("42");
+    expect(params.transaction.memoType).toBe("transferId");
+    expect(params.transaction.memoValue).toBe("42");
+  });
+
+  it("clears transferId when the input is emptied before validating", () => {
+    render(<CasperEditTransferId {...makeProps()} />);
+    fireEvent.changeText(screen.getByTestId("transfer-id-input"), "");
+    fireEvent.press(screen.getByTestId("CasperEditTransferId"));
+    const [, , params] = mockPopToScreen.mock.calls[0];
+    expect(params.transaction.transferId).toBeUndefined();
+    expect(params.transaction.memoType).toBeNull();
+    expect(params.transaction.memoValue).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/families/casper/__tests__/SendRowTransferId.test.tsx
+++ b/apps/ledger-live-mobile/src/families/casper/__tests__/SendRowTransferId.test.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { render, screen, fireEvent } from "@tests/test-renderer";
+import BigNumber from "bignumber.js";
+import type { Transaction } from "@ledgerhq/live-common/families/casper/types";
+import SendRowTransferId from "../SendRowTransferId";
+
+const mockNavigate = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+  useRoute: () => ({ params: { accountId: "casper-account" } }),
+  useTheme: () => ({ colors: { live: "#627EEA", darkBlue: "#142533" } }),
+}));
+
+jest.mock("~/context/Locale", () => {
+  const { Text } = jest.requireActual("react-native");
+  return { Trans: ({ i18nKey }: { i18nKey: string }) => <Text>{i18nKey}</Text> };
+});
+
+jest.mock("~/screens/SendFunds/SummaryRow", () => {
+  const { TouchableOpacity, View } = jest.requireActual("react-native");
+  return ({
+    title,
+    onPress,
+    children,
+  }: {
+    title: React.ReactNode;
+    onPress?: () => void;
+    children?: React.ReactNode;
+  }) => (
+    <TouchableOpacity testID="summary-row" onPress={onPress}>
+      <View>{title}</View>
+      <View>{children}</View>
+    </TouchableOpacity>
+  );
+});
+
+const baseTransaction: Transaction = {
+  family: "casper",
+  amount: new BigNumber(0),
+  fees: new BigNumber(0),
+  recipient: "",
+  useAllAmount: false,
+  memoType: null,
+  memoValue: null,
+};
+
+const mockAccount = { id: "casper-account" } as any;
+
+const baseProps = {
+  account: mockAccount,
+  transaction: baseTransaction,
+};
+
+describe("SendRowTransferId (Casper)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows the edit link when no transferId is set", () => {
+    render(<SendRowTransferId {...baseProps} />);
+    expect(screen.getByText("send.summary.transferId")).toBeDefined();
+    expect(screen.getByText("common.edit")).toBeDefined();
+  });
+
+  it("shows the transferId value when it is set", () => {
+    render(
+      <SendRowTransferId {...baseProps} transaction={{ ...baseTransaction, memoValue: "12345" }} />,
+    );
+    expect(screen.getByText("12345")).toBeDefined();
+  });
+
+  it("navigates to CasperEditTransferId on press", () => {
+    render(<SendRowTransferId {...baseProps} />);
+    fireEvent.press(screen.getByText("common.edit"));
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(
+      "CasperEditTransferId",
+      expect.objectContaining({ accountId: mockAccount.id }),
+    );
+  });
+});

--- a/libs/coin-modules/coin-casper/src/__tests__/fixtures/transaction.fixture.ts
+++ b/libs/coin-modules/coin-casper/src/__tests__/fixtures/transaction.fixture.ts
@@ -13,8 +13,11 @@ import { TEST_ADDRESSES, TEST_TRANSFER_IDS } from "./addresses.fixture";
 
 export const createMockTransaction = (options?: Partial<Transaction>): Transaction => {
   const defaultFees = getEstimatedFees();
+  const transferId = options?.transferId;
+  const memoValue = options?.memoValue ?? transferId ?? null;
+  const memoType = options?.memoType ?? (memoValue !== null ? "transferId" : null);
 
-  const transaction: Transaction = {
+  return {
     family: "casper",
     amount:
       options?.amount instanceof BigNumber
@@ -22,11 +25,11 @@ export const createMockTransaction = (options?: Partial<Transaction>): Transacti
         : new BigNumber(options?.amount || CASPER_MINIMUM_VALID_AMOUNT_MOTES),
     recipient: options?.recipient || TEST_ADDRESSES.RECIPIENT_SECP256K1,
     fees: options?.fees instanceof BigNumber ? options.fees : defaultFees,
-    ...(options?.transferId !== undefined && { transferId: options.transferId }),
+    memoType,
+    memoValue,
+    ...(transferId !== undefined && { transferId }),
     useAllAmount: options?.useAllAmount || false,
   };
-
-  return { ...transaction, ...options };
 };
 
 export const createMockTransactionSet = (): Transaction[] => {

--- a/libs/coin-modules/coin-casper/src/api/index.test.ts
+++ b/libs/coin-modules/coin-casper/src/api/index.test.ts
@@ -1,9 +1,5 @@
 import type { Balance, TransactionIntent } from "@ledgerhq/coin-module-framework/api/index";
-import {
-  isNotSupportedStub,
-  requiredApiKeys,
-  withDefaults,
-} from "@ledgerhq/coin-module-framework/api/index";
+import { requiredApiKeys, withDefaults } from "@ledgerhq/coin-module-framework/api/index";
 import { CASPER_FEES_MOTES } from "../constants";
 import { TEST_ADDRESSES } from "../__tests__/fixtures/addresses.fixture";
 import type { CasperContext, CasperMemo } from "../types";
@@ -56,12 +52,6 @@ describe("createApi", () => {
     }
   });
 
-  // `craftTransactionData` is the one unsupported method the contract requires, so it cannot
-  // be omitted — it stays declared, and stays visible for what it is.
-  it("declares craftTransactionData as unsupported", () => {
-    expect(isNotSupportedStub(api.craftTransactionData)).toBe(true);
-  });
-
   describe("validateIntent", () => {
     it("validates a send intent through the api surface", async () => {
       const result = await api.validateIntent(context, sendIntent, balances, {
@@ -96,6 +86,12 @@ describe("createApi", () => {
   describe("getNextSequence", () => {
     it("resolves to 0n instead of throwing, as Casper has no account nonce", async () => {
       await expect(api.getNextSequence(context, validEd25519)).resolves.toBe(0n);
+    });
+  });
+
+  describe("craftTransactionData", () => {
+    it("reports no transaction data — Casper carries none, the transfer id travels on the intent memo", () => {
+      expect(api.craftTransactionData(context, sendIntent)).toEqual({ type: "none" });
     });
   });
 });

--- a/libs/coin-modules/coin-casper/src/api/index.ts
+++ b/libs/coin-modules/coin-casper/src/api/index.ts
@@ -3,8 +3,8 @@ import type {
   BalanceOptions,
   CoinModuleImpl,
 } from "@ledgerhq/coin-module-framework/api/index";
-import { notSupported } from "@ledgerhq/coin-module-framework/api/index";
 import { rejectBalanceOptions } from "@ledgerhq/coin-module-framework/api/getBalance/rejectBalanceOptions";
+import { craftTransactionData } from "@ledgerhq/coin-module-framework/logic/craftTransactionData";
 import { broadcast } from "../logic/broadcast";
 import { combine } from "../logic/combine";
 import { craftTransaction } from "../logic/craftTransaction";
@@ -16,24 +16,17 @@ import { validateIntent } from "../logic/validateIntent";
 import { validateAddress } from "../bridge/validateAddress";
 import type { CasperConfig, CasperContext, CasperMemo } from "../types";
 
-// The caller builds the {@link CasperContext} (config + logger) and passes it to each method (ADR-019).
-//
-// Casper supports everything the contract requires but `craftTransactionData`, so it declares
-// the authoring type and omits its unsupported *capabilities* — block queries, `call`,
-// `register`, staking and raw crafting — rather than stubbing each one. That distinction is
-// the point: eight omissions are capabilities this chain does not expose, while the stub
-// below is a required method this module does not implement, which the type will not let us
-// omit and which therefore stays visible here.
+// ADR-019: caller builds {@link CasperContext} and passes it to each method.
+// `satisfies` (not `as`) preserves the concrete return types of each method for callers.
 export function createApi() {
   return {
     lastBlock,
-    getBalance(
+    getBalance: (
       context: CasperContext,
       address: string,
       options?: BalanceOptions,
-    ): Promise<Balance[]> {
-      return rejectBalanceOptions(() => getAccountBalance(context, address), options);
-    },
+    ): Promise<Balance[]> =>
+      rejectBalanceOptions(() => getAccountBalance(context, address), options),
     listOperations,
     craftTransaction: (_context, transactionIntent, options?) =>
       craftTransaction(transactionIntent, options?.customFees),
@@ -46,6 +39,6 @@ export function createApi() {
     // per-account nonce, so getNextSequence has no meaningful value here.
     getNextSequence: async (_context: CasperContext, _address: string) => 0n,
     validateAddress: (_context, address, parameters) => validateAddress(address, parameters),
-    craftTransactionData: notSupported("craftTransactionData"),
+    craftTransactionData: (_context, intent) => craftTransactionData(intent),
   } satisfies CoinModuleImpl<CasperConfig, CasperMemo>;
 }

--- a/libs/coin-modules/coin-casper/src/bridge/buildOptimisticOperation.test.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/buildOptimisticOperation.test.ts
@@ -65,7 +65,7 @@ describe("buildOptimisticOperation", () => {
   test("should include transferId in the extra field when present", () => {
     const txWithTransferId = {
       ...mockTransaction,
-      transferId: TEST_TRANSFER_IDS.VALID,
+      memoValue: TEST_TRANSFER_IDS.VALID,
     };
 
     const operation = buildOptimisticOperation(mockAccount, txWithTransferId, mockHash);

--- a/libs/coin-modules/coin-casper/src/bridge/buildOptimisticOperation.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/buildOptimisticOperation.ts
@@ -25,7 +25,7 @@ export const buildOptimisticOperation = (
     blockHeight: null,
     date: new Date(),
     extra: {
-      ...(transaction.transferId !== undefined && { transferId: transaction.transferId }),
+      ...(typeof transaction.memoValue === "string" && { transferId: transaction.memoValue }),
     },
     nftOperations: [],
     subOperations: [],

--- a/libs/coin-modules/coin-casper/src/bridge/createTransaction.test.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/createTransaction.test.ts
@@ -12,6 +12,8 @@ describe("createTransaction", () => {
       fees: new BigNumber(0),
       recipient: "",
       useAllAmount: false,
+      memoType: null,
+      memoValue: null,
     };
     expect(transaction).toEqual(expectedTransaction);
   });

--- a/libs/coin-modules/coin-casper/src/bridge/createTransaction.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/createTransaction.ts
@@ -11,5 +11,7 @@ export const createTransaction: AccountBridge<Transaction>["createTransaction"] 
     fees: new BigNumber(0),
     recipient: "",
     useAllAmount: false,
+    memoType: null,
+    memoValue: null,
   };
 };

--- a/libs/coin-modules/coin-casper/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/getTransactionStatus.test.ts
@@ -267,12 +267,12 @@ describe("getTransactionStatus", () => {
     const account = { spendableBalance: BigNumber(1) } as CasperAccount;
     const transaction = {
       amount: BigNumber(1),
-      transferId: "random transfer id for unit test",
+      memoValue: "random transfer id for unit test",
     } as Transaction;
     const status = await getTransactionStatus(account, transaction);
     expect(status.errors.transaction).not.toBeDefined();
 
-    expect(spiedValidateMemo).toHaveBeenCalledWith(transaction.transferId);
+    expect(spiedValidateMemo).toHaveBeenCalledWith(transaction.memoValue);
   });
 
   it("should set error on transaction when transfer id is invalidated", async () => {
@@ -282,11 +282,11 @@ describe("getTransactionStatus", () => {
     const account = { spendableBalance: BigNumber(1) } as CasperAccount;
     const transaction = {
       amount: BigNumber(1),
-      transferId: "random transfer id for unit test",
+      memoValue: "random transfer id for unit test",
     } as Transaction;
     const status = await getTransactionStatus(account, transaction);
     expect(status.errors.transaction).toBeInstanceOf(CasperInvalidTransferId);
 
-    expect(spiedValidateMemo).toHaveBeenCalledWith(transaction.transferId);
+    expect(spiedValidateMemo).toHaveBeenCalledWith(transaction.memoValue);
   });
 });

--- a/libs/coin-modules/coin-casper/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/getTransactionStatus.ts
@@ -45,7 +45,7 @@ export const getTransactionStatus: AccountBridge<
     errors.sender = new InvalidAddress("", {
       currencyName: account.currency.name,
     });
-  } else if (!validateMemo(transaction.transferId)) {
+  } else if (!validateMemo(transaction.memoValue ?? undefined)) {
     errors.sender = new CasperInvalidTransferId("", {
       maxTransferId: CASPER_MAX_TRANSFER_ID,
     });

--- a/libs/coin-modules/coin-casper/src/bridge/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/prepareTransaction.test.ts
@@ -41,6 +41,8 @@ describe("prepareTransaction", () => {
     expect(updateTransaction).toHaveBeenCalledWith(mockTransaction, {
       fees: mockEstimatedFees,
       amount: mockTransaction.amount,
+      memoValue: mockTransaction.memoValue,
+      memoType: mockTransaction.memoType,
     });
 
     expect(result).toEqual({
@@ -62,6 +64,8 @@ describe("prepareTransaction", () => {
     expect(updateTransaction).toHaveBeenCalledWith(useAllAmountTx, {
       fees: mockEstimatedFees,
       amount: expectedAmount,
+      memoValue: useAllAmountTx.memoValue,
+      memoType: useAllAmountTx.memoType,
     });
 
     expect(result).toEqual({

--- a/libs/coin-modules/coin-casper/src/bridge/prepareTransaction.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/prepareTransaction.ts
@@ -14,6 +14,10 @@ export const prepareTransaction: AccountBridge<Transaction>["prepareTransaction"
     ? account.spendableBalance.minus(fees)
     : transaction.amount;
 
+  // Back-compat: legacy callers may set only `transferId`; normalize to memoValue/memoType here.
+  const memoValue = transaction.memoValue ?? transaction.transferId ?? null;
+  const memoType = transaction.memoType ?? (memoValue !== null ? "transferId" : null);
+
   // log("debug", "[prepareTransaction] finish fn");
-  return updateTransaction(transaction, { fees, amount });
+  return updateTransaction(transaction, { fees, amount, memoValue, memoType });
 };

--- a/libs/coin-modules/coin-casper/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/signOperation.ts
@@ -19,7 +19,7 @@ export const buildSignOperation =
       async function main() {
         // log("debug", "[signOperation] start fn");
 
-        const { recipient, amount, fees, transferId } = transaction;
+        const { recipient, amount, fees, memoValue } = transaction;
         const { address, derivationPath } = getAddress(account);
 
         const crafted = await craftTransaction(
@@ -30,8 +30,8 @@ export const buildSignOperation =
             recipient,
             amount: BigInt(amount.toFixed(0)),
             asset: { type: "native" },
-            ...(transferId !== undefined && {
-              memo: { type: "string" as const, kind: "transferId" as const, value: transferId },
+            ...(typeof memoValue === "string" && {
+              memo: { type: "string" as const, kind: "transferId" as const, value: memoValue },
             }),
           },
           { value: BigInt(fees.toFixed(0)) },

--- a/libs/coin-modules/coin-casper/src/bridge/transaction.test.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/transaction.test.ts
@@ -100,7 +100,8 @@ describe("transaction", () => {
         useAllAmount: false,
         amount: "50000000",
         fees: "1000000",
-        transferId: TEST_TRANSFER_IDS.VALID,
+        memoType: "transferId",
+        memoValue: TEST_TRANSFER_IDS.VALID,
       };
 
       const result = fromTransactionRaw(raw);
@@ -109,7 +110,8 @@ describe("transaction", () => {
       expect(result.useAllAmount).toBe(false);
       expect(result.amount).toEqual(new BigNumber(50000000));
       expect(result.fees).toEqual(new BigNumber(1000000));
-      expect(result.transferId).toBe(TEST_TRANSFER_IDS.VALID);
+      expect(result.memoValue).toBe(TEST_TRANSFER_IDS.VALID);
+      expect(result.memoType).toBe("transferId");
     });
 
     test("should handle transaction raw without optional fields", () => {
@@ -123,7 +125,38 @@ describe("transaction", () => {
 
       const result = fromTransactionRaw(raw);
       expect(result.family).toBe("casper");
-      expect(result.transferId).toBeUndefined();
+      expect(result.memoValue).toBeNull();
+      expect(result.memoType).toBeNull();
+    });
+
+    test("normalizes a legacy transferId payload into memoValue", () => {
+      const raw: TransactionRaw = {
+        family: "casper",
+        recipient: TEST_ADDRESSES.RECIPIENT_SECP256K1,
+        useAllAmount: false,
+        amount: "50000000",
+        fees: "1000000",
+        transferId: TEST_TRANSFER_IDS.VALID,
+      };
+
+      const result = fromTransactionRaw(raw);
+      expect(result.memoValue).toBe(TEST_TRANSFER_IDS.VALID);
+      expect(result.memoType).toBe("transferId");
+    });
+
+    test("prefers memoValue over legacy transferId when both are present", () => {
+      const raw: TransactionRaw = {
+        family: "casper",
+        recipient: TEST_ADDRESSES.RECIPIENT_SECP256K1,
+        useAllAmount: false,
+        amount: "50000000",
+        fees: "1000000",
+        transferId: "42",
+        memoValue: TEST_TRANSFER_IDS.VALID,
+      };
+
+      const result = fromTransactionRaw(raw);
+      expect(result.memoValue).toBe(TEST_TRANSFER_IDS.VALID);
     });
   });
 
@@ -143,10 +176,12 @@ describe("transaction", () => {
       expect(result.useAllAmount).toBe(false);
       expect(result.amount).toBe("50000000");
       expect(result.fees).toBe("1000000");
-      expect(result.transferId).toBe(TEST_TRANSFER_IDS.VALID);
+      expect(result.memoValue).toBe(TEST_TRANSFER_IDS.VALID);
+      expect(result.memoType).toBe("transferId");
+      expect(result.transferId).toBeUndefined();
     });
 
-    test("should handle transaction without optional fields", () => {
+    test("should handle transaction without memo", () => {
       const tx = createMockTransaction({
         recipient: TEST_ADDRESSES.RECIPIENT_SECP256K1,
         useAllAmount: false,
@@ -155,6 +190,8 @@ describe("transaction", () => {
       });
 
       const result = transaction.toTransactionRaw(tx);
+      expect(result.memoValue).toBeNull();
+      expect(result.memoType).toBeNull();
       expect(result.transferId).toBeUndefined();
     });
 

--- a/libs/coin-modules/coin-casper/src/bridge/transaction.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/transaction.ts
@@ -30,24 +30,34 @@ TO ${recipient}`;
 
 export const fromTransactionRaw = (tr: TransactionRaw): Transaction => {
   const common = fromTransactionCommonRaw(tr);
+
+  // Back-compat: legacy payloads may carry only `transferId`; normalize to memoValue.
+  const memoValue = tr.memoValue ?? tr.transferId ?? null;
+
   return {
     ...common,
     family: tr.family,
     fees: new BigNumber(tr.fees),
     amount: new BigNumber(tr.amount),
-    ...(tr.transferId !== undefined && { transferId: tr.transferId }),
+    memoType: memoValue !== null ? "transferId" : (tr.memoType ?? null),
+    memoValue,
   };
 };
 
 const toTransactionRaw = (t: Transaction): TransactionRaw => {
   const common = toTransactionCommonRaw(t);
 
+  // Back-compat: callers that set only `transferId` still serialize correctly.
+  const memoValue: string | null = t.memoValue ?? t.transferId ?? null;
+  const memoType: string | null = memoValue !== null ? "transferId" : (t.memoType ?? null);
+
   return {
     ...common,
     family: t.family,
     amount: t.amount.toFixed(),
     fees: t.fees.toString(),
-    ...(t.transferId !== undefined && { transferId: t.transferId }),
+    memoType,
+    memoValue,
   };
 };
 

--- a/libs/coin-modules/coin-casper/src/deviceTransactionConfig.test.ts
+++ b/libs/coin-modules/coin-casper/src/deviceTransactionConfig.test.ts
@@ -64,6 +64,18 @@ describe("getDeviceTransactionConfig", () => {
     expect(fields[4]).toEqual({ type: "text", label: "Transfer ID", value: TRANSFER_ID });
   });
 
+  test("should include transferId field when provided via memoValue (generic-adapter path)", async () => {
+    const mockTransaction = createMockTransaction({
+      amount: MOCK_AMOUNT,
+      memoType: "transferId",
+      memoValue: TRANSFER_ID,
+    });
+    const fields = await getConfigFields(mockTransaction);
+
+    expect(fields).toHaveLength(5);
+    expect(fields[4]).toEqual({ type: "text", label: "Transfer ID", value: TRANSFER_ID });
+  });
+
   test("should not include transferId field when undefined in transaction", async () => {
     const mockTransaction = createMockTransaction({ amount: MOCK_AMOUNT });
     const fields = await getConfigFields(mockTransaction);

--- a/libs/coin-modules/coin-casper/src/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-casper/src/deviceTransactionConfig.ts
@@ -29,11 +29,12 @@ async function getDeviceTransactionConfig({
     { type: "casper.extendedAmount", label: "Amount", value: transaction.amount },
   ];
 
-  if (transaction.transferId) {
+  const { memoValue } = transaction;
+  if (memoValue) {
     fields.push({
       type: "text",
       label: "Transfer ID",
-      value: transaction.transferId,
+      value: memoValue,
     });
   }
 

--- a/libs/coin-modules/coin-casper/src/logic/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-casper/src/logic/craftTransaction.test.ts
@@ -57,21 +57,6 @@ describe("craftTransaction", () => {
     expect(idArg?.option?.value()?.ui64?.toString()).toBe(TEST_TRANSFER_IDS.VALID);
   });
 
-  it("includes the transfer id from the generic-adapter memo shape (type=transferId)", async () => {
-    const idSpy = jest.spyOn(NativeTransferBuilder.prototype, "id");
-
-    const { transaction } = await craftTransaction({
-      ...baseIntent(),
-      memo: { type: "transferId", value: TEST_TRANSFER_IDS.VALID },
-    } as TransactionIntent<CasperMemo>);
-
-    expect(idSpy).toHaveBeenCalledTimes(1);
-    expect(idSpy).toHaveBeenCalledWith(TEST_TRANSFER_IDS.VALID);
-    const idArg = getArgs(transaction).getByName("id");
-    expect(idArg?.option?.isEmpty()).toBe(false);
-    expect(idArg?.option?.value()?.ui64?.toString()).toBe(TEST_TRANSFER_IDS.VALID);
-  });
-
   it.each([
     ["no memo is provided", undefined],
     ["the transfer id is an empty string", ""],

--- a/libs/coin-modules/coin-casper/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-casper/src/logic/listOperations.ts
@@ -77,6 +77,22 @@ function toApiOperations(tx: NativeTransfer, accountHash: string): Operation[] {
   return ops;
 }
 
+// Heights are near-descending (deploy timestamp order), so a whole page must fall below minHeight.
+function processPage(
+  data: ITxnHistoryData[],
+  minHeight: number,
+  accountHash: string,
+  items: Operation[],
+): "empty" | "done" | "continue" {
+  if (data.length === 0) return "empty";
+  for (const tx of data) {
+    if (tx.block_height >= minHeight && isNativeTransfer(tx)) {
+      items.push(...toApiOperations(tx, accountHash));
+    }
+  }
+  return data.every(tx => tx.block_height < minHeight) ? "done" : "continue";
+}
+
 /**
  * List an account's native CSPR transfers, newest first, down to `minHeight`.
  *
@@ -100,20 +116,8 @@ export async function listOperations(
 
   for (let page = 1; ; page++) {
     const { data, page_count } = await fetchTxsPage(config, address, page);
-    if (data.length === 0) return { items };
-
-    for (const tx of data) {
-      if (tx.block_height < minHeight) continue;
-      if (isNativeTransfer(tx)) items.push(...toApiOperations(tx, accountHash));
-    }
-
-    if (page >= page_count) return { items };
-    // Ordered by deploy timestamp, so heights are only near-descending: a whole page has to fall
-    // below `minHeight` before the rest of the feed can be written off. That the feed is
-    // newest-first at all is the indexer's behaviour, not a guarantee we can request — its
-    // `order_by` / `order_direction` params are accepted and ignored — so an integration test
-    // asserts it daily against mainnet.
-    if (data.every(tx => tx.block_height < minHeight)) return { items };
+    const status = processPage(data, minHeight, accountHash, items);
+    if (status !== "continue" || page >= page_count) return { items };
   }
 }
 

--- a/libs/coin-modules/coin-casper/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-casper/src/logic/utils.test.ts
@@ -104,11 +104,6 @@ describe("Casper utils", () => {
         { type: "string", kind: "transferId", value: "12345" } as CasperMemo,
         "12345",
       ],
-      [
-        "generic-adapter memo { type: 'transferId' }",
-        { type: "transferId", value: "9007199254740993" } as CasperMemo,
-        "9007199254740993",
-      ],
     ])("returns correct transferId for %s", (_desc, memo, expected) => {
       expect(getTransferIdFromMemo(memo)).toBe(expected);
     });

--- a/libs/coin-modules/coin-casper/src/logic/utils.ts
+++ b/libs/coin-modules/coin-casper/src/logic/utils.ts
@@ -57,10 +57,8 @@ export function toSafeNumber(value: bigint): number {
   return Number(value);
 }
 
-// Two memo shapes coexist until LIVE-35735 unifies them.
 export function getTransferIdFromMemo(memo: CasperMemo | undefined): string | undefined {
   if (!memo) return undefined;
   if (memo.type === "string" && memo.kind === "transferId") return memo.value;
-  if (memo.type === "transferId") return memo.value;
   return undefined;
 }

--- a/libs/coin-modules/coin-casper/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-casper/src/logic/validateIntent.test.ts
@@ -79,7 +79,7 @@ const buildTransaction = (c: Case): Transaction =>
     amount: new BigNumber(c.amount.toString()),
     useAllAmount: !!c.useAllAmount,
     fees: new BigNumber(FEES.toString()),
-    transferId: c.transferId,
+    memoValue: c.transferId ?? null,
   }) as unknown as Transaction;
 
 const validate = (c: Case, customFees: FeeEstimation = { value: FEES }) =>
@@ -133,32 +133,6 @@ describe("validateIntent", () => {
 
     expect(errors.sender).toBeInstanceOf(CasperInvalidTransferId);
     expect(errors.transaction).toBeInstanceOf(CasperInvalidTransferId);
-  });
-
-  describe("framework memo shape { type: 'transferId' }", () => {
-    it("accepts a valid transfer id", () => {
-      const intent: TransactionIntent<CasperMemo> = {
-        ...buildIntent(sendCase()),
-        memo: { type: "transferId", value: "42" },
-      };
-
-      const { errors } = validateIntent(intent, buildBalances(sendCase()), { value: FEES });
-
-      expect(errors.sender).toBeUndefined();
-      expect(errors.transaction).toBeUndefined();
-    });
-
-    it("rejects an out-of-range transfer id", () => {
-      const intent: TransactionIntent<CasperMemo> = {
-        ...buildIntent(sendCase()),
-        memo: { type: "transferId", value: OUT_OF_RANGE_TRANSFER_ID },
-      };
-
-      const { errors } = validateIntent(intent, buildBalances(sendCase()), { value: FEES });
-
-      expect(errors.sender).toBeInstanceOf(CasperInvalidTransferId);
-      expect(errors.transaction).toBeInstanceOf(CasperInvalidTransferId);
-    });
   });
 
   it("reduces the accepted useAllAmount by the locked funds", () => {

--- a/libs/coin-modules/coin-casper/src/types/bridge.ts
+++ b/libs/coin-modules/coin-casper/src/types/bridge.ts
@@ -15,6 +15,9 @@ export type CasperAccount = Account;
 export type Transaction = TransactionCommon & {
   family: FamilyType;
   fees: BigNumber;
+  memoType?: string | null;
+  memoValue?: string | null;
+  /** @deprecated Use `memoValue` instead; normalized by `prepareTransaction`. */
   transferId?: string;
 };
 
@@ -26,8 +29,11 @@ interface CasperOperationExtra {
 
 export type TransactionRaw = TransactionCommonRaw & {
   family: FamilyType;
-  transferId?: string;
   fees: string;
+  memoType?: string | null;
+  memoValue?: string | null;
+  /** @deprecated Accepted on inbound payloads; normalized in `fromTransactionRaw`. */
+  transferId?: string;
 };
 
 export type TransactionStatus = TransactionStatusCommon;

--- a/libs/coin-modules/coin-casper/src/types/coinframework.ts
+++ b/libs/coin-modules/coin-casper/src/types/coinframework.ts
@@ -1,9 +1,3 @@
 import { MemoNotSupported, StringMemo } from "@ledgerhq/coin-module-framework/api/types";
 
-// TODO: remove after LIVE-35735 — generic adapter will produce StringMemo<"transferId"> directly
-export interface FrameworkTransferIdMemo {
-  type: "transferId";
-  value: string;
-}
-
-export type CasperMemo = MemoNotSupported | StringMemo<"transferId"> | FrameworkTransferIdMemo;
+export type CasperMemo = MemoNotSupported | StringMemo<"transferId">;

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -750,6 +750,7 @@
     "src/families/cardano/bridge/api.ts",
     "src/families/cardano/coinModuleApi.ts",
     "src/families/cardano/config.ts",
+    "src/families/casper/coinModuleApi.ts",
     "src/families/casper/config.ts",
     "src/families/casper/deviceSigner.ts",
     "src/families/casper/signer.ts",

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
@@ -568,9 +568,7 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
     );
     const syncHash = await getSyncHash(currency.id, syncConfig.blacklistedTokenIds);
     const syncFromScratch = !initialAccount?.blockHeight || initialAccount?.syncHash !== syncHash;
-    // Resume position across syncs: `minHeight` alone, derived from the newest stored operation.
-    // It is non-volatile by construction and already persisted, unlike a module cursor (coin-hypercore
-    // documents its own as volatile). Only the cursor varies from page to page below.
+    // Resume position is `minHeight` (derived from the newest persisted op), not a stored cursor.
     const minHeight = syncFromScratch ? 0 : (oldOps[0]?.blockHeight ?? 0) + 1;
 
     const newCoreOps = await paginateOperations(cursor =>
@@ -580,9 +578,7 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
         order: "desc",
       }),
     );
-    // Same hooks the persist/restore path uses, so the family bag on a freshly-synced operation ends
-    // up in the shape a restored one has — the family's `fromOperationExtraRaw` is the single
-    // definition of it. Loaded per sync rather than per operation; the registry caches the import.
+    // Same hook as the persist/restore path so a freshly-synced operation has the same shape.
     const { fromOperationExtraRaw: reviveFamilyExtra } = await getAccountRawAssignHooks(network);
     const newOps = newCoreOps
       .filter(op => !isNftCoreOp(op) && (!isIncomingCoreOp(op) || !op.tx.failed))

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/paginateOperations.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/paginateOperations.test.ts
@@ -25,7 +25,7 @@ describe("paginateOperations", () => {
     expect(calls).toEqual([undefined]);
   });
 
-  it("stops on an empty-string cursor (coin-evm's Ledger explorer arm, coin-algorand)", async () => {
+  it('stops on an empty-string cursor (some modules return "" instead of omitting next)', async () => {
     const items = await paginateOperations(pages({ items: [op("a")], next: "" }));
 
     expect(items.map(o => o.tx.hash)).toEqual(["a"]);
@@ -67,7 +67,7 @@ describe("paginateOperations", () => {
     expect(calls).toEqual([undefined, "c1", "c2"]);
   });
 
-  it("stops on an empty page handed back with a cursor (coin-vechain's early return)", async () => {
+  it("stops on an empty page even when the module returns a cursor alongside it", async () => {
     const items = await paginateOperations(
       pages({ items: [op("a")], next: "c1" }, { items: [], next: "c2" }),
     );

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
@@ -34,9 +34,7 @@ jest.mock("../bridge", () => ({
   getBridgeApi: (...a: any[]) => getBridgeApiMock(...a),
 }));
 
-// Keeps the dummy addresses below out of the real A4 indexer (LIVE-36423): the sync fires a
-// fire-and-forget registration that is *not* routed through the `../api` mock, so it reaches
-// production the moment LiveConfig holds a config — which is exactly what the suite next door does.
+// A4 registration is fire-and-forget and bypasses the `../api` mock — mock it to avoid hitting production (LIVE-36423).
 jest.mock("../a4/client/registration", () => ({
   ensureA4Registered: jest.fn(),
   clearA4RegistrationCache: jest.fn(),
@@ -446,9 +444,7 @@ describe("genericGetAccountShape", () => {
           {
             minHeight: expectedPagination.minHeight,
             order: expectedPagination.order,
-            // The first page is always requested cursor-less: the resume position across syncs is
-            // `minHeight`, never a cursor read back off a stored operation's `extra`.
-            cursor: undefined,
+            cursor: undefined, // resume position is minHeight, not a stored cursor
           },
         );
 

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
@@ -595,6 +595,55 @@ describe("coin-framework utils", () => {
       expect(operation.type).toBe("STAKE");
       expect(operation.value).toEqual(new BigNumber(100));
     });
+
+    it("copies memoType=transferId into extra.transferId (Casper pattern)", () => {
+      const operation = buildOptimisticOperation(
+        { id: "parent-account-id", freshAddress: "account-address" } as Account,
+        {
+          family: "casper",
+          mode: "send",
+          amount: new BigNumber(100),
+          recipient: "recipient-address",
+          fees: new BigNumber(100_000_000),
+          memoType: "transferId",
+          memoValue: "9007199254740993",
+        } as GenericTransaction,
+        0n,
+      );
+
+      expect((operation.extra as Record<string, unknown>).transferId).toBe("9007199254740993");
+    });
+
+    it("does not set extra.transferId when memoType is absent or is not transferId", () => {
+      const withoutMemo = buildOptimisticOperation(
+        { id: "parent-account-id", freshAddress: "account-address" } as Account,
+        {
+          family: "familyx",
+          mode: "send",
+          amount: new BigNumber(100),
+          recipient: "recipient-address",
+          fees: new BigNumber(100),
+        } as GenericTransaction,
+        0n,
+      );
+
+      const withOtherMemo = buildOptimisticOperation(
+        { id: "parent-account-id", freshAddress: "account-address" } as Account,
+        {
+          family: "familyx",
+          mode: "send",
+          amount: new BigNumber(100),
+          recipient: "recipient-address",
+          fees: new BigNumber(100),
+          memoType: "text",
+          memoValue: "hello",
+        } as GenericTransaction,
+        0n,
+      );
+
+      expect("transferId" in (withoutMemo.extra as Record<string, unknown>)).toBe(false);
+      expect("transferId" in (withOtherMemo.extra as Record<string, unknown>)).toBe(false);
+    });
   });
 
   describe("cleanedOperation", () => {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
@@ -540,9 +540,6 @@ type FrameworkOperationExtra = {
  * Every key of the above. The family bag lands flat beside these, so a collision is dropped rather
  * than merged: each framework key is written *conditionally*, so a surviving family key would supply
  * the framework's own answer on an operation where the framework wrote none.
- *
- * `satisfies Record<…, true>` keeps this list honest: adding a field to `FrameworkOperationExtra`
- * without reserving it here fails to compile.
  */
 const FRAMEWORK_RESERVED_EXTRA_KEYS: ReadonlySet<string> = new Set(
   Object.keys({
@@ -1071,13 +1068,16 @@ export const buildOptimisticOperation = (
         : {}),
     }),
     extra: {
-      // Reserved keys stripped and the framework's own spread last — the same contract
-      // `adaptCoreOperationToLiveOperation` applies to a family bag arriving from a sync. `blockTime`
-      // and `index` are this path's alone, which is why they are not in the reserved set.
+      // Same contract as `adaptCoreOperationToLiveOperation`: strip reserved keys from the family
+      // bag, then write framework-owned keys last so they win. `blockTime`/`index` are this path's
+      // alone, so they are not in the reserved set.
       ...(described?.extra ? stripFrameworkReservedKeys(described.extra) : {}),
       ledgerOpType: type,
       blockTime: new Date(),
       index: "0",
+      // Mirror memoType==="transferId" into extra.transferId to match what buildOperationExtra writes.
+      ...(transaction.memoType === "transferId" &&
+        transaction.memoValue && { transferId: transaction.memoValue }),
     },
   };
 

--- a/libs/ledger-live-common/src/coin-modules/loaders.ts
+++ b/libs/ledger-live-common/src/coin-modules/loaders.ts
@@ -85,6 +85,8 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
     family: "casper",
     supportedCoins: ["casper"],
     loadSetup: () => import("../families/casper/setup"),
+    loadLocalApi: () =>
+      import("../families/casper/coinModuleApi").then(m => m.createLocalCasperApi),
     loadTransaction: () => import("@ledgerhq/coin-casper/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-casper/deviceTransactionConfig").then(m => m.default),

--- a/libs/ledger-live-common/src/families/casper/coinModuleApi.test.ts
+++ b/libs/ledger-live-common/src/families/casper/coinModuleApi.test.ts
@@ -1,0 +1,20 @@
+import { createLocalCasperApi } from "./coinModuleApi";
+
+const mockApi = {
+  getBalance: jest.fn(),
+  listOperations: jest.fn(),
+};
+
+jest.mock("@ledgerhq/coin-casper/api", () => ({
+  createApi: () => mockApi,
+}));
+
+describe("createLocalCasperApi", () => {
+  it("delegates to createApi and ignores the currencyId argument", () => {
+    const api1 = createLocalCasperApi("casper");
+    const api2 = createLocalCasperApi("any-other-id");
+
+    expect(api1).toBe(mockApi);
+    expect(api2).toBe(mockApi);
+  });
+});

--- a/libs/ledger-live-common/src/families/casper/coinModuleApi.ts
+++ b/libs/ledger-live-common/src/families/casper/coinModuleApi.ts
@@ -1,0 +1,7 @@
+import { createApi as createCasperApi } from "@ledgerhq/coin-casper/api";
+import type { CoinModuleApi } from "@ledgerhq/coin-module-framework/api/types";
+import type { BridgeApi } from "@ledgerhq/ledger-wallet-framework/api/types";
+
+export function createLocalCasperApi(_currencyId: string): CoinModuleApi<any> & BridgeApi {
+  return createCasperApi() as CoinModuleApi<any> & BridgeApi;
+}

--- a/libs/ledger-live-common/src/families/casper/signer.ts
+++ b/libs/ledger-live-common/src/families/casper/signer.ts
@@ -9,9 +9,7 @@ import { createDeviceSigner } from "./deviceSigner";
 export const createSigner: CreateSigner<CasperFrameworkSigner> = (transport: Transport) =>
   createFrameworkSigner(createDeviceSigner(transport));
 
-export const casperGetAddress = (
-  signerContext: SignerContext<CasperFrameworkSigner>,
-): GetAddressFn => {
+const casperGetAddress = (signerContext: SignerContext<CasperFrameworkSigner>): GetAddressFn => {
   return (deviceId, { path, verify }) =>
     signerContext(deviceId, signer => signer.getAddress(path, { verify }));
 };

--- a/libs/ledger-live-common/src/flows/send/recipient/utils/__tests__/memoValue.test.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/utils/__tests__/memoValue.test.ts
@@ -24,7 +24,37 @@ describe("sanitizeMemoValue", () => {
     expect(sanitizeMemoValue({ value: "", memoType: "tag", memoMaxValue: 100 })).toBe("");
   });
 
-  it("clamps correctly with a bigint memoMaxValue (u64 upper bound)", () => {
+  it("clamps to max when digit count exceeds max string length", () => {
+    expect(
+      sanitizeMemoValue({ value: "100000000000", memoType: "tag", memoMaxValue: 4294967295 }),
+    ).toBe("4294967295");
+  });
+
+  it("does not clamp a zero-padded value that is numerically under max", () => {
+    expect(
+      sanitizeMemoValue({ value: "000000000001", memoType: "tag", memoMaxValue: 4294967295 }),
+    ).toBe("000000000001");
+  });
+
+  it("does not clamp at exactly max", () => {
+    expect(
+      sanitizeMemoValue({ value: "4294967295", memoType: "tag", memoMaxValue: 4294967295 }),
+    ).toBe("4294967295");
+  });
+
+  it("clamps just above max at equal digit count", () => {
+    expect(
+      sanitizeMemoValue({ value: "4294967296", memoType: "tag", memoMaxValue: 4294967295 }),
+    ).toBe("4294967295");
+  });
+
+  it("does not clamp a zero-padded value that equals max", () => {
+    expect(
+      sanitizeMemoValue({ value: "0004294967295", memoType: "tag", memoMaxValue: 4294967295 }),
+    ).toBe("0004294967295");
+  });
+
+  it("clamps correctly with a bigint memoMaxValue", () => {
     const U64_MAX = BigInt("18446744073709551615");
     expect(sanitizeMemoValue({ value: "0", memoType: "tag", memoMaxValue: U64_MAX })).toBe("0");
     expect(
@@ -40,5 +70,9 @@ describe("sanitizeMemoValue", () => {
     expect(
       sanitizeMemoValue({ value: "9007199254740993", memoType: "tag", memoMaxValue: U64_MAX }),
     ).toBe("9007199254740993");
+    // zero-padded value that is numerically under max
+    expect(
+      sanitizeMemoValue({ value: "00000000000000000001", memoType: "tag", memoMaxValue: U64_MAX }),
+    ).toBe("00000000000000000001");
   });
 });


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Wire craftTransactionData in CoinModuleApi and propagate transferId through the generic adapter.

### 🔗 Context

- https://ledgerhq.atlassian.net/browse/LIVE-35914
- https://ledgerhq.atlassian.net/browse/LIVE-36397
- https://ledgerhq.atlassian.net/browse/LIVE-36398
