### PR TITLE
[LWDM] feat(coin-casper): transferId in the generic adapter (LIVE-35912)

### DIFF
--- a/.changeset/good-rats-build.md
+++ b/.changeset/good-rats-build.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/coin-casper": minor
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Preserve transferId through the generic adapter for Casper

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useSendFlowTransaction.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useSendFlowTransaction.test.ts
@@ -183,7 +183,7 @@ describe("useSendFlowTransaction", () => {
       });
     });
 
-    it("should apply transferId for casper", () => {
+    it("should apply memo for casper", () => {
       const casperTransaction = {
         family: "casper",
         recipient: "",
@@ -218,6 +218,8 @@ describe("useSendFlowTransaction", () => {
       expect(mockUpdateTransaction).toHaveBeenCalledWith(casperTransaction, {
         recipient: "casper-address",
         transferId: "transfer-id-123",
+        memoType: "transferId",
+        memoValue: "transfer-id-123",
       });
     });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/Memo/MemoValueInput.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/Memo/MemoValueInput.tsx
@@ -11,8 +11,8 @@ type MemoValueInputProps = Readonly<{
   maxLength?: number;
   /** When "tag", input is restricted to digits only (ex XRP, Casper). */
   memoType?: string;
-  /** Max numeric value when memoType is "tag" (ex XRP UINT32_MAX). */
-  memoMaxValue?: number;
+  /** Max numeric value when memoType is "tag" (ex XRP UINT32_MAX, Casper UINT64_MAX). */
+  memoMaxValue?: number | bigint;
   /** Full error for correct i18n interpolation (ex Casper maxTransferId). */
   transactionError?: Error;
   /** Fallback when transactionError is not passed (no interpolation). */

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/MemoValueInput.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/MemoValueInput.tsx
@@ -20,7 +20,7 @@ type MemoValueInputProps = Readonly<{
   value: string;
   maxLength?: number;
   memoType?: string;
-  memoMaxValue?: number;
+  memoMaxValue?: number | bigint;
   transactionError?: Error;
   onChange: (value: string) => void;
 }>;

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useSendFlowTransaction.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useSendFlowTransaction.test.ts
@@ -182,7 +182,7 @@ describe("useSendFlowTransaction", () => {
       });
     });
 
-    it("should apply transferId for casper", () => {
+    it("should apply memo for casper", () => {
       const casperTransaction = {
         family: "casper",
         recipient: "",
@@ -217,6 +217,8 @@ describe("useSendFlowTransaction", () => {
       expect(mockUpdateTransaction).toHaveBeenCalledWith(casperTransaction, {
         recipient: "casper-address",
         transferId: "transfer-id-123",
+        memoType: "transferId",
+        memoValue: "transfer-id-123",
       });
     });
 

--- a/libs/coin-modules/coin-casper/src/logic/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-casper/src/logic/craftTransaction.test.ts
@@ -50,6 +50,22 @@ describe("craftTransaction", () => {
       }),
     );
 
+    expect(idSpy).toHaveBeenCalledTimes(1);
+    expect(idSpy).toHaveBeenCalledWith(TEST_TRANSFER_IDS.VALID);
+    const idArg = getArgs(transaction).getByName("id");
+    expect(idArg?.option?.isEmpty()).toBe(false);
+    expect(idArg?.option?.value()?.ui64?.toString()).toBe(TEST_TRANSFER_IDS.VALID);
+  });
+
+  it("includes the transfer id from the generic-adapter memo shape (type=transferId)", async () => {
+    const idSpy = jest.spyOn(NativeTransferBuilder.prototype, "id");
+
+    const { transaction } = await craftTransaction({
+      ...baseIntent(),
+      memo: { type: "transferId", value: TEST_TRANSFER_IDS.VALID },
+    } as TransactionIntent<CasperMemo>);
+
+    expect(idSpy).toHaveBeenCalledTimes(1);
     expect(idSpy).toHaveBeenCalledWith(TEST_TRANSFER_IDS.VALID);
     const idArg = getArgs(transaction).getByName("id");
     expect(idArg?.option?.isEmpty()).toBe(false);
@@ -134,6 +150,7 @@ describe("craftTransaction", () => {
 
     await craftTransaction(baseIntent(), { value: 999_000_000n });
 
+    expect(paymentSpy).toHaveBeenCalledTimes(1);
     expect(paymentSpy).toHaveBeenCalledWith(999_000_000);
   });
 
@@ -142,6 +159,7 @@ describe("craftTransaction", () => {
 
     await craftTransaction(baseIntent());
 
+    expect(paymentSpy).toHaveBeenCalledTimes(1);
     expect(paymentSpy).toHaveBeenCalledWith(CASPER_FEES_MOTES);
   });
 });

--- a/libs/coin-modules/coin-casper/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-casper/src/logic/craftTransaction.ts
@@ -10,7 +10,7 @@ import { CASPER_DEFAULT_TTL, CASPER_MAX_TRANSFER_ID, CASPER_NETWORK } from "../c
 import { CasperInvalidTransferId } from "../errors";
 import type { CasperMemo } from "../types";
 import { getEstimatedFees } from "./estimateFees";
-import { toSafeNumber } from "./utils";
+import { getTransferIdFromMemo, toSafeNumber } from "./utils";
 import { isAddressValid } from "./validateAddress";
 import { validateMemo } from "./validateMemo";
 
@@ -35,8 +35,9 @@ export async function craftTransaction(
     throw new InvalidAddress(`Invalid recipient Address ${recipient}`);
   }
 
-  const memo = "memo" in transactionIntent ? transactionIntent.memo : undefined;
-  const transferId = memo?.type === "string" && memo.kind === "transferId" ? memo.value : undefined;
+  const transferId = getTransferIdFromMemo(
+    "memo" in transactionIntent ? transactionIntent.memo : undefined,
+  );
 
   if (typeof transferId === "string" && transferId.length > 0 && !validateMemo(transferId)) {
     throw new CasperInvalidTransferId("", {

--- a/libs/coin-modules/coin-casper/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-casper/src/logic/utils.test.ts
@@ -5,7 +5,9 @@ import {
   methodToString,
   getRandomTransferID,
   toSafeNumber,
+  getTransferIdFromMemo,
 } from "./utils";
+import type { CasperMemo } from "../types";
 
 describe("Casper utils", () => {
   describe("isNoErrorReturnCode", () => {
@@ -90,6 +92,25 @@ describe("Casper utils", () => {
 
     test("should throw for a value below the safe integer range", () => {
       expect(() => toSafeNumber(BigInt(Number.MIN_SAFE_INTEGER) - 1n)).toThrow(RangeError);
+    });
+  });
+
+  describe("getTransferIdFromMemo", () => {
+    it.each([
+      ["undefined memo", undefined, undefined],
+      ["MemoNotSupported", { type: "none" } as CasperMemo, undefined],
+      [
+        "StringMemo<'transferId'>",
+        { type: "string", kind: "transferId", value: "12345" } as CasperMemo,
+        "12345",
+      ],
+      [
+        "generic-adapter memo { type: 'transferId' }",
+        { type: "transferId", value: "9007199254740993" } as CasperMemo,
+        "9007199254740993",
+      ],
+    ])("returns correct transferId for %s", (_desc, memo, expected) => {
+      expect(getTransferIdFromMemo(memo)).toBe(expected);
     });
   });
 });

--- a/libs/coin-modules/coin-casper/src/logic/utils.ts
+++ b/libs/coin-modules/coin-casper/src/logic/utils.ts
@@ -1,4 +1,5 @@
 import BigNumber from "bignumber.js";
+import type { CasperMemo } from "../types";
 
 const validHexRegExp = new RegExp(/[0-9A-Fa-f]{6}/g);
 const validBase64RegExp = new RegExp(
@@ -54,4 +55,12 @@ export function toSafeNumber(value: bigint): number {
   }
 
   return Number(value);
+}
+
+// Two memo shapes coexist until LIVE-35735 unifies them.
+export function getTransferIdFromMemo(memo: CasperMemo | undefined): string | undefined {
+  if (!memo) return undefined;
+  if (memo.type === "string" && memo.kind === "transferId") return memo.value;
+  if (memo.type === "transferId") return memo.value;
+  return undefined;
 }

--- a/libs/coin-modules/coin-casper/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-casper/src/logic/validateIntent.test.ts
@@ -135,6 +135,32 @@ describe("validateIntent", () => {
     expect(errors.transaction).toBeInstanceOf(CasperInvalidTransferId);
   });
 
+  describe("framework memo shape { type: 'transferId' }", () => {
+    it("accepts a valid transfer id", () => {
+      const intent: TransactionIntent<CasperMemo> = {
+        ...buildIntent(sendCase()),
+        memo: { type: "transferId", value: "42" },
+      };
+
+      const { errors } = validateIntent(intent, buildBalances(sendCase()), { value: FEES });
+
+      expect(errors.sender).toBeUndefined();
+      expect(errors.transaction).toBeUndefined();
+    });
+
+    it("rejects an out-of-range transfer id", () => {
+      const intent: TransactionIntent<CasperMemo> = {
+        ...buildIntent(sendCase()),
+        memo: { type: "transferId", value: OUT_OF_RANGE_TRANSFER_ID },
+      };
+
+      const { errors } = validateIntent(intent, buildBalances(sendCase()), { value: FEES });
+
+      expect(errors.sender).toBeInstanceOf(CasperInvalidTransferId);
+      expect(errors.transaction).toBeInstanceOf(CasperInvalidTransferId);
+    });
+  });
+
   it("reduces the accepted useAllAmount by the locked funds", () => {
     const locked = 10_000_000_000n;
 

--- a/libs/coin-modules/coin-casper/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-casper/src/logic/validateIntent.ts
@@ -20,6 +20,7 @@ import {
 } from "../constants";
 import { CasperInvalidTransferId } from "../errors";
 import type { CasperMemo } from "../types";
+import { getTransferIdFromMemo } from "./utils";
 import { isAddressValid } from "./validateAddress";
 import { validateMemo } from "./validateMemo";
 
@@ -109,8 +110,7 @@ export function validateIntent(
   const balance = nativeBalance?.value ?? 0n;
   const spendableBalance = balance - (nativeBalance?.locked ?? 0n);
 
-  const memo = "memo" in intent ? intent.memo : undefined;
-  const transferId = memo?.type === "string" && memo.kind === "transferId" ? memo.value : undefined;
+  const transferId = getTransferIdFromMemo("memo" in intent ? intent.memo : undefined);
 
   validateRecipient(recipient, sender, currencyName, errors);
   validateSender(sender, transferId, currencyName, errors);

--- a/libs/coin-modules/coin-casper/src/types/coinframework.ts
+++ b/libs/coin-modules/coin-casper/src/types/coinframework.ts
@@ -1,3 +1,9 @@
 import { MemoNotSupported, StringMemo } from "@ledgerhq/coin-module-framework/api/types";
 
-export type CasperMemo = MemoNotSupported | StringMemo<"transferId">;
+// TODO: remove after LIVE-35735 — generic adapter will produce StringMemo<"transferId"> directly
+export interface FrameworkTransferIdMemo {
+  type: "transferId";
+  value: string;
+}
+
+export type CasperMemo = MemoNotSupported | StringMemo<"transferId"> | FrameworkTransferIdMemo;

--- a/libs/ledger-live-common/src/bridge/descriptor.test.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor.test.ts
@@ -614,7 +614,7 @@ describe("sendFeatures", () => {
     describe("special field names", () => {
       it("should apply transferId for casper", () => {
         const result = applyMemoToTransaction("casper", "12345");
-        expect(result).toEqual({ transferId: "12345" });
+        expect(result).toEqual({ transferId: "12345", memoType: "transferId", memoValue: "12345" });
       });
 
       it("should apply numeric tag for xrp", () => {

--- a/libs/ledger-live-common/src/bridge/descriptor/send/memo.test.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor/send/memo.test.ts
@@ -6,8 +6,12 @@ describe("applyMemoToTransaction", () => {
       expect(applyMemoToTransaction("xrp", "")).toEqual({ tag: undefined });
     });
 
-    it("casper: empty string clears the transferId", () => {
-      expect(applyMemoToTransaction("casper", "")).toEqual({ transferId: undefined });
+    it("casper: empty string clears the memo", () => {
+      expect(applyMemoToTransaction("casper", "")).toEqual({
+        transferId: undefined,
+        memoType: "transferId",
+        memoValue: undefined,
+      });
     });
 
     it("solana: empty string clears the memo", () => {
@@ -32,8 +36,12 @@ describe("applyMemoToTransaction", () => {
       expect(applyMemoToTransaction("xrp", "123")).toEqual({ tag: 123 });
     });
 
-    it("casper: transferId", () => {
-      expect(applyMemoToTransaction("casper", "42")).toEqual({ transferId: "42" });
+    it("casper: sets transferId/memoType/memoValue", () => {
+      expect(applyMemoToTransaction("casper", "42")).toEqual({
+        transferId: "42",
+        memoType: "transferId",
+        memoValue: "42",
+      });
     });
 
     it("stellar: forwards value and type", () => {

--- a/libs/ledger-live-common/src/bridge/descriptor/send/memo.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor/send/memo.ts
@@ -27,7 +27,7 @@ const memoApplicationRegistry: Record<string, MemoApplicationFn> = {
       },
     };
   },
-  casper: memo => ({ transferId: memo }),
+  casper: memo => ({ transferId: memo, memoType: "transferId", memoValue: memo }),
   xrp: memo => {
     if (typeof memo === "number") return { tag: memo };
     if (typeof memo === "string") return { tag: Number(memo) };

--- a/libs/ledger-live-common/src/bridge/descriptor/types.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor/types.ts
@@ -22,7 +22,7 @@ export type InputFieldType = "text" | "number" | "tag" | "typed";
 export type InputDescriptor = Readonly<{
   type: InputFieldType;
   maxLength?: number;
-  maxValue?: number;
+  maxValue?: number | bigint;
   options?: readonly string[];
   defaultOption?: string;
   supportsDomain?: boolean; // Whether the field supports domain names (ENS for EVM)

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
@@ -1547,6 +1547,17 @@ describe("coin-framework utils", () => {
 
       expect(result.transactionSequenceNumber).toEqual(expected);
     });
+
+    it("maps details.transferId to extra.transferId", () => {
+      const op = { ...baseOp, details: { transferId: "12345" } };
+      const result = adaptCoreOperationToLiveOperation(accountId, op);
+      expect((result.extra as Record<string, unknown>).transferId).toBe("12345");
+    });
+
+    it("does not set extra.transferId when details.transferId is absent", () => {
+      const result = adaptCoreOperationToLiveOperation(accountId, baseOp);
+      expect("transferId" in (result.extra as Record<string, unknown>)).toBe(false);
+    });
   });
 
   describe("nextSequenceWithPending", () => {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
@@ -528,6 +528,7 @@ type FrameworkOperationExtra = {
   internal?: boolean;
   feePayer?: string;
   stake?: { address: string; amount: BigNumber };
+  transferId?: string;
 };
 
 /**
@@ -552,6 +553,7 @@ const FRAMEWORK_RESERVED_EXTRA_KEYS: ReadonlySet<string> = new Set(
     internal: true,
     feePayer: true,
     stake: true,
+    transferId: true,
   } satisfies Record<keyof FrameworkOperationExtra, true>),
 );
 
@@ -665,6 +667,10 @@ function buildOperationExtra(op: CoreOperation): FrameworkOperationExtra {
   const stake = buildStakeExtra(op.details?.stake);
   if (stake) {
     extra.stake = stake;
+  }
+
+  if (op.details?.transferId !== undefined) {
+    extra.transferId = op.details.transferId as string;
   }
 
   return extra;

--- a/libs/ledger-live-common/src/families/casper/descriptor/memo.ts
+++ b/libs/ledger-live-common/src/families/casper/descriptor/memo.ts
@@ -1,5 +1,7 @@
+import { CASPER_MAX_TRANSFER_ID } from "@ledgerhq/coin-casper/constants";
 import type { InputDescriptor } from "../../../bridge/descriptor/types";
 
 export const memo: InputDescriptor = {
   type: "tag",
+  maxValue: BigInt(CASPER_MAX_TRANSFER_ID) - 1n,
 };

--- a/libs/ledger-live-common/src/flows/send/recipient/utils/__tests__/memoValue.test.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/utils/__tests__/memoValue.test.ts
@@ -23,4 +23,22 @@ describe("sanitizeMemoValue", () => {
   it("keeps an empty string when no digits remain", () => {
     expect(sanitizeMemoValue({ value: "", memoType: "tag", memoMaxValue: 100 })).toBe("");
   });
+
+  it("clamps correctly with a bigint memoMaxValue (u64 upper bound)", () => {
+    const U64_MAX = BigInt("18446744073709551615");
+    expect(sanitizeMemoValue({ value: "0", memoType: "tag", memoMaxValue: U64_MAX })).toBe("0");
+    expect(
+      sanitizeMemoValue({ value: "18446744073709551615", memoType: "tag", memoMaxValue: U64_MAX }),
+    ).toBe("18446744073709551615");
+    expect(
+      sanitizeMemoValue({ value: "18446744073709551616", memoType: "tag", memoMaxValue: U64_MAX }),
+    ).toBe("18446744073709551615");
+    expect(
+      sanitizeMemoValue({ value: "99999999999999999999", memoType: "tag", memoMaxValue: U64_MAX }),
+    ).toBe("18446744073709551615");
+    // value just above Number.MAX_SAFE_INTEGER stays exact (no rounding)
+    expect(
+      sanitizeMemoValue({ value: "9007199254740993", memoType: "tag", memoMaxValue: U64_MAX }),
+    ).toBe("9007199254740993");
+  });
 });

--- a/libs/ledger-live-common/src/flows/send/recipient/utils/memoValue.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/utils/memoValue.ts
@@ -2,8 +2,8 @@ type SanitizeMemoValueArgs = Readonly<{
   value: string;
   /** Memo input kind coming from the send descriptor (ex "tag" restricts to digits). */
   memoType?: string;
-  /** Max numeric value when memoType is "tag" (ex UINT32_MAX), from the send descriptor. */
-  memoMaxValue?: number;
+  /** Max numeric value for tag memos, from the send descriptor. */
+  memoMaxValue?: number | bigint;
 }>;
 
 /**
@@ -21,6 +21,7 @@ export function sanitizeMemoValue({
   const digitsOnly = value.replace(/\D/g, "");
   if (memoMaxValue === undefined || digitsOnly === "") return digitsOnly;
 
-  const num = Number(digitsOnly);
-  return num > memoMaxValue ? String(memoMaxValue) : digitsOnly;
+  const maxBig = BigInt(memoMaxValue);
+  const valueBig = BigInt(digitsOnly);
+  return valueBig > maxBig ? String(memoMaxValue) : digitsOnly;
 }

--- a/libs/ledger-live-common/src/flows/send/types.ts
+++ b/libs/ledger-live-common/src/flows/send/types.ts
@@ -31,7 +31,7 @@ export type SendFlowUiConfig = Readonly<{
   hasMemo: boolean;
   memoType?: string;
   memoMaxLength?: number;
-  memoMaxValue?: number;
+  memoMaxValue?: number | bigint;
   memoOptions?: readonly string[];
   recipientSupportsDomain: boolean;
   hasFeePresets: boolean;


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Preserve transferId through the generic adapter for Casper.

### 🔗 Context

https://ledgerhq.atlassian.net/browse/LIVE-35912
