### PR TITLE
feat(trustchain): add agent intent to known applications

### DIFF
--- a/.changeset/witty-agents-select.md
+++ b/.changeset/witty-agents-select.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/web-tools": minor
+---
+
+Add application 18 (Agent Intent) to the known applications of the trustchain tool

--- a/apps/web-tools/src/trustchain/components/AppSetApplicationId.tsx
+++ b/apps/web-tools/src/trustchain/components/AppSetApplicationId.tsx
@@ -4,6 +4,7 @@ import { Actionable } from "./Actionable";
 const KNOWN_APPLICATIONS: { id: number; label: string }[] = [
   { id: 16, label: "16 — Ledger Sync" },
   { id: 17, label: "17 — wallet-cli ring" },
+  { id: 18, label: "18 — Agent Intent" },
 ];
 
 export function AppSetApplicationId({


### PR DESCRIPTION
### 📝 Description

Adds application `18 — Agent Intent` to the list of known applications in the web-tools trustchain playground, so it can be selected from the dropdown instead of being typed manually as a custom id.

The list is purely a convenience for the tool's application selector — the custom id input already accepted `18`, this only surfaces it alongside `16 — Ledger Sync` and `17 — wallet-cli ring`.

### 🔗 Context

- **JIRA / GitHub issue**: n/a
- **ADR** (if any): n/a
