### PR TITLE
PoC: [LWM] perf(lwm): lazy-load navigator screens with getComponent

### DIFF
--- a/apps/ledger-live-mobile/src/components/RootNavigator/AccountsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/AccountsNavigator.tsx
@@ -8,23 +8,10 @@ import { useTheme as useLumenTheme } from "@ledgerhq/lumen-ui-rnative/styles";
 import { useSelector } from "~/context/hooks";
 import { readOnlyModeEnabledSelector } from "~/reducers/settings";
 import { ScreenName } from "~/const";
-import Accounts from "~/screens/Accounts";
-import Account from "~/screens/Account";
 import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
 import { getStackNavigationConfigV4 } from "LLM/components/Navigation/getStackNavigationConfigV4";
-import ReadOnlyAccounts from "~/screens/Accounts/ReadOnly/ReadOnlyAccounts";
-import ReadOnlyAssets from "~/screens/Portfolio/ReadOnlyAssets";
-
-import Asset from "~/screens/WalletCentricAsset";
-import ReadOnlyAsset from "~/screens/WalletCentricAsset/ReadOnly";
-import Assets from "~/screens/Assets";
-
-import ReadOnlyAccount from "~/screens/Account/ReadOnly/ReadOnlyAccount";
-
 import type { AccountsNavigatorParamList } from "./types/AccountsNavigator";
 import { hasNoAccountsSelector } from "~/reducers/accounts";
-import AccountsList from "LLM/features/Accounts/screens/AccountsList";
-import { CryptoScreen } from "LLM/features/Crypto";
 import { useFeature } from "@features/platform-feature-flags";
 import { NavigationHeaderBackButton } from "../NavigationHeaderBackButton";
 import { track } from "~/analytics";
@@ -37,9 +24,9 @@ import {
 } from "@react-navigation/native";
 import { TrackingEvent } from "LLM/features/Accounts/enums";
 import AccountsListHeaderRight from "LLM/features/LedgerSyncEntryPoint/components/AccountsListHeaderRight";
-import { CryptoAddressesScreen } from "LLM/features/CryptoAddresses";
 import { useTranslation } from "~/context/Locale";
 import type { LumenNavBarScreenOptions } from "LLM/components/Navigation";
+import { lazyNamed, lazyScreen } from "./lazyScreen";
 
 const Stack = createNativeStackNavigator<AccountsNavigatorParamList>();
 
@@ -133,7 +120,14 @@ export default function AccountsNavigator() {
     <Stack.Navigator>
       <Stack.Screen
         name={ScreenName.Accounts}
-        component={readOnlyModeEnabled ? ReadOnlyAccounts : Accounts}
+        getComponent={
+          readOnlyModeEnabled
+            ? lazyScreen(
+                () =>
+                  require("~/screens/Accounts/ReadOnly/ReadOnlyAccounts") as typeof import("~/screens/Accounts/ReadOnly/ReadOnlyAccounts"),
+              )
+            : lazyScreen(() => require("~/screens/Accounts") as typeof import("~/screens/Accounts"))
+        }
         options={{
           ...stackNavConfig,
           headerShown: false,
@@ -141,7 +135,14 @@ export default function AccountsNavigator() {
       />
       <Stack.Screen
         name={ScreenName.Account}
-        component={readOnlyModeEnabled ? ReadOnlyAccount : Account}
+        getComponent={
+          readOnlyModeEnabled
+            ? lazyScreen(
+                () =>
+                  require("~/screens/Account/ReadOnly/ReadOnlyAccount") as typeof import("~/screens/Account/ReadOnly/ReadOnlyAccount"),
+              )
+            : lazyScreen(() => require("~/screens/Account") as typeof import("~/screens/Account"))
+        }
         options={{
           ...stackNavConfig,
           headerShown: false,
@@ -149,7 +150,14 @@ export default function AccountsNavigator() {
       />
       <Stack.Screen
         name={ScreenName.Assets}
-        component={readOnlyModeEnabled ? ReadOnlyAssets : Assets}
+        getComponent={
+          readOnlyModeEnabled
+            ? lazyScreen(
+                () =>
+                  require("~/screens/Portfolio/ReadOnlyAssets") as typeof import("~/screens/Portfolio/ReadOnlyAssets"),
+              )
+            : lazyScreen(() => require("~/screens/Assets") as typeof import("~/screens/Assets"))
+        }
         options={{
           ...stackNavConfig,
           headerShown: false,
@@ -158,7 +166,10 @@ export default function AccountsNavigator() {
       {accountListUIFF?.enabled && (
         <Stack.Screen
           name={ScreenName.AccountsList}
-          component={AccountsList}
+          getComponent={lazyScreen(
+            () =>
+              require("LLM/features/Accounts/screens/AccountsList") as typeof import("LLM/features/Accounts/screens/AccountsList"),
+          )}
           options={{
             ...stackNavConfig,
             headerTitle: "",
@@ -169,17 +180,35 @@ export default function AccountsNavigator() {
       )}
       <Stack.Screen
         name={ScreenName.CryptoAddresses}
-        component={CryptoAddressesScreen}
+        getComponent={lazyNamed(
+          () =>
+            (
+              require("LLM/features/CryptoAddresses") as typeof import("LLM/features/CryptoAddresses")
+            ).CryptoAddressesScreen,
+        )}
         options={cryptoAddressesScreenOptions}
       />
       <Stack.Screen
         name={ScreenName.Crypto}
-        component={CryptoScreen}
+        getComponent={lazyNamed(
+          () =>
+            (require("LLM/features/Crypto") as typeof import("LLM/features/Crypto")).CryptoScreen,
+        )}
         options={getCryptoScreenOptions}
       />
       <Stack.Screen
         name={ScreenName.Asset}
-        component={readOnlyModeEnabled ? ReadOnlyAsset : Asset}
+        getComponent={
+          readOnlyModeEnabled
+            ? lazyScreen(
+                () =>
+                  require("~/screens/WalletCentricAsset/ReadOnly") as typeof import("~/screens/WalletCentricAsset/ReadOnly"),
+              )
+            : lazyScreen(
+                () =>
+                  require("~/screens/WalletCentricAsset") as typeof import("~/screens/WalletCentricAsset"),
+              )
+        }
         options={{
           ...stackNavConfig,
           headerShown: false,

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -8,104 +8,28 @@ import { RouteProp, useRoute } from "@react-navigation/native";
 import { useTheme } from "styled-components/native";
 import { useSelector } from "~/context/hooks";
 import { ScreenName, NavigatorName, BASE_NAVIGATOR_ID } from "~/const";
-import * as families from "~/families";
-import OperationDetails from "~/screens/OperationDetails";
-import EditDeviceName from "~/screens/EditDeviceName";
-import ScanRecipient from "~/screens/SendFunds/ScanRecipient";
+import type * as FamilyScreens from "~/families";
 import Main from "./MainNavigator";
-import SettingsNavigator from "./SettingsNavigator";
-import BuyDeviceNavigator from "./BuyDeviceNavigator";
-import ReceiveFundsNavigator from "./ReceiveFundsNavigator";
-import SendFundsNavigator from "./SendFundsNavigator";
-import SignMessageNavigator from "./SignMessageNavigator";
-import SignTransactionNavigator from "./SignTransactionNavigator";
-import FreezeNavigator from "./FreezeNavigator";
-import UnfreezeNavigator from "./UnfreezeNavigator";
-import ClaimRewardsNavigator from "./ClaimRewardsNavigator";
-import ExchangeLiveAppNavigator from "./ExchangeLiveAppNavigator";
-import { CardLiveAppNavigator } from "LLM/features/Card";
 import { useTheme as useLumenTheme } from "@ledgerhq/lumen-ui-rnative/styles";
-import BorrowLiveAppNavigator from "./BorrowLiveAppNavigator";
-import EarnLiveAppNavigator from "./EarnLiveAppNavigator";
-import PlatformExchangeNavigator from "./PlatformExchangeNavigator";
-import AccountSettingsNavigator from "./AccountSettingsNavigator";
-import PasswordAddFlowNavigator from "./PasswordAddFlowNavigator";
-import PasswordModifyFlowNavigator from "./PasswordModifyFlowNavigator";
-import SwapNavigator from "./SwapNavigator";
-import SwapSubScreensNavigator from "./SwapSubScreensNavigator";
-import PerpsNavigator from "./PerpsNavigator";
-import GlobalSearchNavigator from "LLM/features/GlobalSearch/Navigator";
-import NotificationCenterNavigator from "./NotificationCenterNavigator";
-import AnalyticsOperations from "~/screens/Analytics/Operations";
 import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
-import Account from "~/screens/Account";
-import ReadOnlyAccount from "~/screens/Account/ReadOnly/ReadOnlyAccount";
 import TransparentHeaderNavigationOptions from "~/navigation/TransparentHeaderNavigationOptions";
 import styles from "~/navigation/styles";
 import StepHeader from "../StepHeader";
-import PortfolioHistory from "~/screens/Portfolio/PortfolioHistory";
-import RequestAccountNavigator from "./RequestAccountNavigator";
-import VerifyAccount from "~/screens/VerifyAccount";
-import { LiveApp } from "~/screens/Platform";
-import AccountsNavigator from "./AccountsNavigator";
-import MarketNavigator from "LLM/features/Market/Navigator";
-import SendWorkflow from "LLM/features/Send";
-import {
-  BleDevicePairingFlow,
-  bleDevicePairingFlowHeaderOptions,
-} from "~/screens/BleDevicePairingFlow";
-import PostBuyDeviceScreen from "LLM/features/Reborn/screens/PostBuySuccess";
 import { useNoNanoBuyNanoWallScreenOptions } from "~/context/NoNanoBuyNanoWall";
-import PostBuyDeviceSetupNanoWallScreen from "~/screens/PostBuyDeviceSetupNanoWallScreen";
-import CurrencySettings from "~/screens/Settings/CryptoAssets/Currencies/CurrencySettings";
-import WalletConnectLiveAppNavigator from "./WalletConnectLiveAppNavigator";
-import CustomImageNavigator from "./CustomImageNavigator";
-import PostOnboardingNavigator from "./PostOnboardingNavigator";
 import { readOnlyModeEnabledSelector } from "~/reducers/settings";
 import { hasNoAccountsSelector, accountScreenSelector } from "~/reducers/accounts";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { getOperationTypeI18nKey } from "~/logic/operationTypeName";
 import { BaseNavigatorStackParamList } from "./types/BaseNavigator";
-import DeviceConnect, { deviceConnectHeaderOptions } from "~/screens/DeviceConnect";
-import PerpsSign from "LLM/features/Perps/screens/PerpsSign/PerpsSignScreen";
-import NoFundsFlowNavigator from "./NoFundsFlowNavigator";
-import StakeFlowNavigator from "./StakeFlowNavigator";
-import { RecoverPlayer } from "~/screens/Protect/Player";
-import { RedirectToOnboardingRecoverFlowScreen } from "~/screens/Protect/RedirectToOnboardingRecoverFlow";
-import { NavigationHeaderBackButton } from "~/components/NavigationHeaderBackButton";
 import {
   NavigationHeaderCloseButton,
   NavigationHeaderCloseButtonAdvanced,
 } from "../NavigationHeaderCloseButton";
+import { NavigationHeaderBackButton } from "~/components/NavigationHeaderBackButton";
 import { RootDrawer } from "../RootDrawer/RootDrawer";
-import EditTransactionNavigator from "~/families/evm/EditTransactionFlow/EditTransactionNavigator";
-import BitcoinEditTransactionNavigator from "~/families/bitcoin/EditTransactionFlow/EditTransactionNavigator";
 import { DrawerProps } from "../RootDrawer/types";
-import AnalyticsOptInPromptNavigator from "./AnalyticsOptInPromptNavigator";
-import LandingPagesNavigator from "./LandingPagesNavigator";
-import FirmwareUpdateScreen from "~/screens/FirmwareUpdate";
-import EditCurrencyUnits from "~/screens/Settings/CryptoAssets/Currencies/EditCurrencyUnits";
-import CustomErrorNavigator from "./CustomErrorNavigator";
-import WalletSyncNavigator from "LLM/features/WalletSync/WalletSyncNavigator";
-import { LedgerSyncDeepLinkHandler } from "LLM/features/WalletSync/LedgerSyncDeepLinkHandler";
-import { DeviceSelectionScreen as DeeplinkInstallAppDeviceSelection } from "LLM/features/DeeplinkInstallApp";
-import Web3HubNavigator from "LLM/features/Web3Hub/Navigator";
-import Web3HubTabNavigator from "LLM/features/Web3Hub/TabNavigator";
-import { useFeature } from "@features/platform-feature-flags";
-import MyLedgerNavigator from "./MyLedgerNavigator";
-import MyWalletNavigator from "LLM/features/MyWallet/Navigator";
-import BackupHubNavigator from "LLM/features/BackupHub/Navigator";
-import DiscoverNavigator from "./DiscoverNavigator";
-import AddAccountsV2Navigator from "LLM/features/Accounts/Navigator";
-import DeviceSelectionNavigator from "LLM/features/DeviceSelection/Navigator";
-import AssetDetailNavigator from "LLM/features/AssetDetail/Navigator";
-import AssetsListNavigator from "LLM/features/Assets/Navigator";
-import AnalyticsNavigator from "LLM/features/Analytics/Navigator";
-import OperationsHistoryNavigator from "LLM/features/OperationsHistory/Navigator";
-import FeesNavigator from "./FeesNavigator";
-import { getEarnScreenOptions, getEarnScreenOptionsFromRouteParams } from "./getEarnScreenOptions";
-import SignRawTransactionNavigator from "./SignRawTransactionNavigator";
-import LiveAppModalScreen from "LLM/features/LiveAppModal";
+import { useFeature, useWalletFeaturesConfig } from "@features/platform-feature-flags";
+import { getEarnScreenOptionsFromRouteParams } from "./getEarnScreenOptions";
 
 const Stack = createNativeStackNavigator<BaseNavigatorStackParamList, typeof BASE_NAVIGATOR_ID>();
 
@@ -170,6 +94,116 @@ function FirmwareUpdateHeaderRight() {
   return <NavigationHeaderCloseButton />;
 }
 
+// ponytail: static names so BaseNavigator does not import ~/families at startup.
+// Add new family navigator exports here. Upgrade: generate from families/index.
+const FAMILY_SCREEN_NAMES = [
+  "AlgorandEditMemo",
+  "AlgorandClaimRewardsFlow",
+  "AlgorandOptInFlow",
+  "BitcoinEditCustomFees",
+  "CardanoEditMemo",
+  "CardanoDelegationFlow",
+  "CardanoUndelegationFlow",
+  "CeloManageAssetsNavigator",
+  "CeloRegistrationFlow",
+  "CeloLockFlow",
+  "CeloUnlockFlow",
+  "CeloVoteFlow",
+  "CeloActivateFlow",
+  "CeloRevokeFlow",
+  "CeloWithdrawFlow",
+  "CosmosDelegationFlow",
+  "CosmosRedelegationFlow",
+  "CosmosUndelegationFlow",
+  "CosmosClaimRewardsFlow",
+  "CosmosFamilyEditMemo",
+  "MultiversXClaimRewardsFlow",
+  "MultiversXDelegationFlow",
+  "MultiversXUndelegationFlow",
+  "MultiversXWithdrawFlow",
+  "EvmEditGasLimit",
+  "EvmCustomFees",
+  "EvmDelegationFlow",
+  "EvmUndelegationFlow",
+  "EvmClaimRewardsFlow",
+  "EvmWithdrawFlow",
+  "HederaEditMemo",
+  "HederaAssociateTokenFlow",
+  "HederaDelegationFlow",
+  "HederaUndelegationFlow",
+  "HederaRedelegationFlow",
+  "HederaClaimRewardsFlow",
+  "InternetComputerEditMemo",
+  "InternetComputerStakingFlow",
+  "InternetComputerNeuronManageFlow",
+  "KaspaEditCustomFees",
+  "MinaEditMemo",
+  "NearStakingFlow",
+  "NearUnstakingFlow",
+  "NearWithdrawingFlow",
+  "PolkadotBondFlow",
+  "PolkadotRebondFlow",
+  "PolkadotUnbondFlow",
+  "PolkadotNominateFlow",
+  "PolkadotSimpleOperationFlow",
+  "XrpEditTag",
+  "SolanaEditMemo",
+  "SolanaDelegationFlow",
+  "StacksEditMemo",
+  "CasperEditTransferId",
+  "StellarEditMemoValue",
+  "StellarEditMemoType",
+  "StellarEditCustomFees",
+  "StellarAddAssetFlow",
+  "TezosDelegationFlow",
+  "TezosStakeFlow",
+  "TezosUnstakeFlow",
+  "TronVoteFlow",
+  "TonEditComment",
+  "SuiDelegationFlow",
+  "SuiUndelegateFlow",
+  "CantonOnboard",
+  "CantonEditMemo",
+  "ConcordiumOnboard",
+] as const satisfies ReadonlyArray<keyof typeof FamilyScreens>;
+
+type WallScreenOptions =
+  | {
+      component: React.ComponentType;
+      options: NativeStackNavigationOptions;
+    }
+  | object;
+
+function isWallActive(
+  wall: WallScreenOptions,
+): wall is { component: React.ComponentType; options: NativeStackNavigationOptions } {
+  return "component" in wall && typeof wall.component === "function";
+}
+
+function lazyOrWall({
+  name,
+  getComponent,
+  options,
+  listeners,
+  wall,
+}: {
+  name: keyof BaseNavigatorStackParamList;
+  getComponent: () => React.ComponentType;
+  options?:
+    | NativeStackNavigationOptions
+    | ((props: { route: RouteProp<BaseNavigatorStackParamList> }) => NativeStackNavigationOptions);
+  listeners?: object | ((props: { route: RouteProp<BaseNavigatorStackParamList> }) => object);
+  wall: WallScreenOptions;
+}) {
+  if (isWallActive(wall)) {
+    return <Stack.Screen name={name} component={wall.component} options={wall.options} />;
+  }
+
+  return (
+    <Stack.Screen name={name} getComponent={getComponent} options={options} listeners={listeners} />
+  );
+}
+
 export default function BaseNavigator() {
   const { t } = useTranslation();
   const route = useRoute<
@@ -193,6 +227,7 @@ export default function BaseNavigator() {
   const llmAccountListUI = useFeature("llmAccountListUI");
   const swapToEarnFlag = useFeature("swapToEarn");
   const isSwapToEarnEnabled = swapToEarnFlag?.enabled ?? false;
+  const { shouldDisplayAssetDiscoverability } = useWalletFeaturesConfig("mobile");
 
   return (
     <>
@@ -201,50 +236,50 @@ export default function BaseNavigator() {
         <Stack.Screen name={NavigatorName.Main} component={Main} options={{ headerShown: false }} />
         <Stack.Screen
           name={NavigatorName.MyLedger}
-          component={MyLedgerNavigator}
+          getComponent={() => require("./MyLedgerNavigator").default}
           options={{ headerShown: false }}
         />
         <Stack.Screen
           name={NavigatorName.MyWallet}
-          component={MyWalletNavigator}
+          getComponent={() => require("LLM/features/MyWallet/Navigator").default}
           options={{ headerShown: false }}
         />
 
         <Stack.Screen
           name={NavigatorName.BackupHub}
-          component={BackupHubNavigator}
+          getComponent={() => require("LLM/features/BackupHub/Navigator").default}
           options={{ headerShown: false }}
         />
 
         {web3hub?.enabled ? (
           <Stack.Screen
             name={NavigatorName.Web3HubTab}
-            component={Web3HubTabNavigator}
+            getComponent={() => require("LLM/features/Web3Hub/TabNavigator").default}
             options={{ headerShown: false }}
           />
         ) : (
           <Stack.Screen
             name={NavigatorName.Discover}
-            component={DiscoverNavigator}
+            getComponent={() => require("./DiscoverNavigator").default}
             options={{ headerShown: false }}
           />
         )}
         <Stack.Screen
           name={NavigatorName.BuyDevice}
-          component={BuyDeviceNavigator}
+          getComponent={() => require("./BuyDeviceNavigator").default}
           options={{
             headerShown: false,
             animation: "slide_from_bottom",
           }}
         />
-        <Stack.Screen
-          name={ScreenName.NoDeviceWallScreen}
-          component={PostBuyDeviceSetupNanoWallScreen}
-          {...noNanoBuyNanoWallScreenOptions}
-        />
+        {lazyOrWall({
+          name: ScreenName.NoDeviceWallScreen,
+          getComponent: () => require("~/screens/PostBuyDeviceSetupNanoWallScreen").default,
+          wall: noNanoBuyNanoWallScreenOptions,
+        })}
         <Stack.Screen
           name={ScreenName.PostBuyDeviceSetupNanoWallScreen}
-          component={PostBuyDeviceSetupNanoWallScreen}
+          getComponent={() => require("~/screens/PostBuyDeviceSetupNanoWallScreen").default}
           options={{
             headerShown: false,
             gestureEnabled: true,
@@ -257,7 +292,7 @@ export default function BaseNavigator() {
         />
         <Stack.Screen
           name={ScreenName.PostBuyDeviceScreen}
-          component={PostBuyDeviceScreen}
+          getComponent={() => require("LLM/features/Reborn/screens/PostBuySuccess").default}
           options={{
             title: t("postBuyDevice.headerTitle"),
             headerLeft: () => null,
@@ -265,62 +300,65 @@ export default function BaseNavigator() {
         />
         <Stack.Screen
           name={NavigatorName.Settings}
-          component={SettingsNavigator}
+          getComponent={() => require("./SettingsNavigator").default}
           options={{ headerShown: false }}
         />
-        <Stack.Screen
-          name={ScreenName.CurrencySettings}
-          component={CurrencySettings}
-          options={({ route }) => ({
-            title: route.params.headerTitle,
+        {lazyOrWall({
+          name: ScreenName.CurrencySettings,
+          getComponent: () =>
+            require("~/screens/Settings/CryptoAssets/Currencies/CurrencySettings").default,
+          options: ({ route }) => ({
+            title: (route.params as { headerTitle?: string }).headerTitle,
             headerRight: () => null,
-          })}
-          {...noNanoBuyNanoWallScreenOptions}
-        />
+          }),
+          wall: noNanoBuyNanoWallScreenOptions,
+        })}
         <Stack.Screen
           name={ScreenName.EditCurrencyUnits}
-          component={EditCurrencyUnits}
+          getComponent={() =>
+            require("~/screens/Settings/CryptoAssets/Currencies/EditCurrencyUnits").default
+          }
           options={{
             title: t("account.settings.accountUnits.title"),
           }}
         />
-        <Stack.Screen
-          name={NavigatorName.ReceiveFunds}
-          component={ReceiveFundsNavigator}
-          options={{ headerShown: false }}
-          {...noNanoBuyNanoWallScreenOptions}
-        />
+        {lazyOrWall({
+          name: NavigatorName.ReceiveFunds,
+          getComponent: () => require("./ReceiveFundsNavigator").default,
+          options: { headerShown: false },
+          wall: noNanoBuyNanoWallScreenOptions,
+        })}
         <Stack.Screen
           name={NavigatorName.SendFunds}
-          component={SendFundsNavigator}
+          getComponent={() => require("./SendFundsNavigator").default}
           options={{ headerShown: false }}
         />
         <Stack.Screen
           name={NavigatorName.SendFlow}
-          component={SendWorkflow}
+          getComponent={() => require("LLM/features/Send").default}
           options={{ headerShown: false }}
         />
         {web3hub?.enabled ? (
           <Stack.Screen
             name={NavigatorName.Web3Hub}
-            component={Web3HubNavigator}
+            getComponent={() => require("LLM/features/Web3Hub/Navigator").default}
             options={{ headerShown: false }}
           />
         ) : null}
         <Stack.Screen
           name={ScreenName.PlatformApp}
-          component={LiveApp}
+          getComponent={() => require("~/screens/Platform").LiveApp}
           options={{ headerStyle: styles.headerNoShadow }}
         />
-        <Stack.Screen
-          name={ScreenName.Recover}
-          component={RecoverPlayer}
-          options={{ headerStyle: styles.headerNoShadow }}
-          {...noNanoBuyNanoWallScreenOptions}
-        />
+        {lazyOrWall({
+          name: ScreenName.Recover,
+          getComponent: () => require("~/screens/Protect/Player").RecoverPlayer,
+          options: { headerStyle: styles.headerNoShadow },
+          wall: noNanoBuyNanoWallScreenOptions,
+        })}
         <Stack.Screen
           name={NavigatorName.SignMessage}
-          component={SignMessageNavigator}
+          getComponent={() => require("./SignMessageNavigator").default}
           options={{ headerShown: false }}
           listeners={({ route }) => ({
             beforeRemove: () => {
@@ -333,7 +371,7 @@ export default function BaseNavigator() {
         />
         <Stack.Screen
           name={NavigatorName.SignTransaction}
-          component={SignTransactionNavigator}
+          getComponent={() => require("./SignTransactionNavigator").default}
           options={{ headerShown: false }}
           listeners={({ route }) => ({
             beforeRemove: () => {
@@ -343,7 +381,7 @@ export default function BaseNavigator() {
         />
         <Stack.Screen
           name={NavigatorName.SignRawTransaction}
-          component={SignRawTransactionNavigator}
+          getComponent={() => require("./SignRawTransactionNavigator").default}
           options={{ headerShown: false }}
           listeners={({ route }) => ({
             beforeRemove: () => {
@@ -353,49 +391,49 @@ export default function BaseNavigator() {
         />
         <Stack.Screen
           name={NavigatorName.Swap}
-          component={SwapNavigator}
+          getComponent={() => require("./SwapNavigator").default}
           options={{ headerShown: false }}
         />
 
         <Stack.Screen
           name={NavigatorName.SwapSubScreens}
-          component={SwapSubScreensNavigator}
+          getComponent={() => require("./SwapSubScreensNavigator").default}
           options={{ headerShown: false }}
         />
 
         <Stack.Screen
           name={NavigatorName.Perps}
-          component={PerpsNavigator}
+          getComponent={() => require("./PerpsNavigator").default}
           options={{ headerShown: false }}
         />
         <Stack.Screen
           name={NavigatorName.GlobalSearch}
-          component={GlobalSearchNavigator}
+          getComponent={() => require("LLM/features/GlobalSearch/Navigator").default}
           options={{ headerShown: false, animation: "fade" }}
         />
         <Stack.Screen
           name={NavigatorName.Freeze}
-          component={FreezeNavigator}
+          getComponent={() => require("./FreezeNavigator").default}
           options={{ headerShown: false }}
         />
         <Stack.Screen
           name={NavigatorName.Unfreeze}
-          component={UnfreezeNavigator}
+          getComponent={() => require("./UnfreezeNavigator").default}
           options={{ headerShown: false }}
         />
         <Stack.Screen
           name={NavigatorName.ClaimRewards}
-          component={ClaimRewardsNavigator}
+          getComponent={() => require("./ClaimRewardsNavigator").default}
           options={{ headerShown: false }}
         />
         <Stack.Screen
           name={NavigatorName.Fees}
-          component={FeesNavigator}
+          getComponent={() => require("./FeesNavigator").default}
           options={{ headerShown: false }}
         />
         <Stack.Screen
           name={NavigatorName.RequestAccount}
-          component={RequestAccountNavigator}
+          getComponent={() => require("./RequestAccountNavigator").default}
           options={{
             headerShown: false,
           }}
@@ -405,7 +443,7 @@ export default function BaseNavigator() {
         />
         <Stack.Screen
           name={ScreenName.VerifyAccount}
-          component={VerifyAccount}
+          getComponent={() => require("~/screens/VerifyAccount").default}
           options={{
             headerLeft: () => null,
             title: t("transfer.receive.headerTitle"),
@@ -416,30 +454,33 @@ export default function BaseNavigator() {
         />
         <Stack.Screen
           name={NavigatorName.Card}
-          component={CardLiveAppNavigator}
+          getComponent={() =>
+            (require("LLM/features/Card") as typeof import("LLM/features/Card"))
+              .CardLiveAppNavigator
+          }
           options={{ headerShown: false }}
         />
-        <Stack.Screen
-          name={NavigatorName.Exchange}
-          component={ExchangeLiveAppNavigator}
-          options={{ headerShown: false }}
-          {...noNanoBuyNanoWallScreenOptions}
-        />
-        <Stack.Screen
-          name={NavigatorName.PlatformExchange}
-          component={PlatformExchangeNavigator}
-          options={{ headerShown: false }}
-          {...noNanoBuyNanoWallScreenOptions}
-        />
-        <Stack.Screen
-          name={NavigatorName.CustomError}
-          component={CustomErrorNavigator}
-          options={{ title: "" }}
-          {...noNanoBuyNanoWallScreenOptions}
-        />
+        {lazyOrWall({
+          name: NavigatorName.Exchange,
+          getComponent: () => require("./ExchangeLiveAppNavigator").default,
+          options: { headerShown: false },
+          wall: noNanoBuyNanoWallScreenOptions,
+        })}
+        {lazyOrWall({
+          name: NavigatorName.PlatformExchange,
+          getComponent: () => require("./PlatformExchangeNavigator").default,
+          options: { headerShown: false },
+          wall: noNanoBuyNanoWallScreenOptions,
+        })}
+        {lazyOrWall({
+          name: NavigatorName.CustomError,
+          getComponent: () => require("./CustomErrorNavigator").default,
+          options: { title: "" },
+          wall: noNanoBuyNanoWallScreenOptions,
+        })}
         <Stack.Screen
           name={ScreenName.OperationDetails}
-          component={OperationDetails}
+          getComponent={() => require("~/screens/OperationDetails").default}
           options={{
             headerTitle: OperationDetailsHeaderTitle,
             headerLeft: OperationDetailsHeaderLeft,
@@ -449,12 +490,12 @@ export default function BaseNavigator() {
         />
         <Stack.Screen
           name={NavigatorName.AccountSettings}
-          component={AccountSettingsNavigator}
+          getComponent={() => require("./AccountSettingsNavigator").default}
           options={{ headerShown: false }}
         />
         <Stack.Screen
           name={ScreenName.EditDeviceName}
-          component={EditDeviceName}
+          getComponent={() => require("~/screens/EditDeviceName").default}
           options={{
             title: t("EditDeviceName.title"),
             headerLeft: () => null,
@@ -462,17 +503,17 @@ export default function BaseNavigator() {
         />
         <Stack.Screen
           name={NavigatorName.PasswordAddFlow}
-          component={PasswordAddFlowNavigator}
+          getComponent={() => require("./PasswordAddFlowNavigator").default}
           options={{ headerShown: false }}
         />
         <Stack.Screen
           name={NavigatorName.PasswordModifyFlow}
-          component={PasswordModifyFlowNavigator}
+          getComponent={() => require("./PasswordModifyFlowNavigator").default}
           options={{ headerShown: false }}
         />
         <Stack.Screen
           name={ScreenName.AnalyticsOperations}
-          component={AnalyticsOperations}
+          getComponent={() => require("~/screens/Analytics/Operations").default}
           options={{
             title: t("analytics.operations.title"),
             headerRight: () => null,
@@ -480,18 +521,64 @@ export default function BaseNavigator() {
         />
         <Stack.Screen
           name={NavigatorName.WalletSync}
-          component={WalletSyncNavigator}
+          getComponent={() => require("LLM/features/WalletSync/WalletSyncNavigator").default}
           options={{ headerShown: false }}
         />
         <Stack.Screen
           name={ScreenName.LedgerSyncDeepLinkHandler}
-          component={LedgerSyncDeepLinkHandler}
+          getComponent={() =>
+            require("LLM/features/WalletSync/LedgerSyncDeepLinkHandler").LedgerSyncDeepLinkHandler
+          }
           options={{ headerShown: false }}
         />
-        {MarketNavigator({ Stack })}
+        <Stack.Screen
+          name={ScreenName.MarketList}
+          getComponent={() =>
+            shouldDisplayAssetDiscoverability
+              ? require("LLM/features/Market/screens/MarketScreen").default
+              : require("LLM/features/Market/screens/MarketList").default
+          }
+          options={() => {
+            if (shouldDisplayAssetDiscoverability) {
+              const { getStackNavigationConfigV4 } =
+                require("LLM/components/Navigation") as typeof import("LLM/components/Navigation");
+              return {
+                ...getStackNavigationConfigV4(lumenTheme),
+                title: t("market.title"),
+                headerLeft: undefined,
+                headerRight: () => null,
+              };
+            }
+            const { MarketListHeaderTitle, MarketListHeaderLeft } =
+              require("LLM/features/Market/components/MarketListHeader") as typeof import("LLM/features/Market/components/MarketListHeader");
+            return {
+              title: t("market.title"),
+              headerShown: true,
+              headerTitle: MarketListHeaderTitle,
+              headerTransparent: true,
+              headerLeft: MarketListHeaderLeft,
+              headerRight: () => null,
+            };
+          }}
+        />
+        <Stack.Screen
+          name={ScreenName.MarketCurrencySelect}
+          getComponent={() => require("LLM/features/Market/screens/MarketCurrencySelect").default}
+          options={{
+            title: t("market.filters.currency"),
+            headerLeft: () => null,
+          }}
+        />
+        <Stack.Screen
+          name={ScreenName.MarketDetail}
+          getComponent={() => require("LLM/features/Market/screens/MarketDetail").default}
+          options={{
+            headerShown: false,
+          }}
+        />
         <Stack.Screen
           name={ScreenName.PortfolioOperationHistory}
-          component={PortfolioHistory}
+          getComponent={() => require("~/screens/Portfolio/PortfolioHistory").default}
           options={{
             headerTitle: t("analytics.operations.title"),
             headerRight: () => null,
@@ -499,12 +586,16 @@ export default function BaseNavigator() {
         />
         <Stack.Screen
           name={ScreenName.Account}
-          component={readOnlyModeEnabled ? ReadOnlyAccount : Account}
+          getComponent={() =>
+            readOnlyModeEnabled
+              ? require("~/screens/Account/ReadOnly/ReadOnlyAccount").default
+              : require("~/screens/Account").default
+          }
           options={{ headerShown: false }}
         />
         <Stack.Screen
           name={ScreenName.ScanRecipient}
-          component={ScanRecipient}
+          getComponent={() => require("~/screens/SendFunds/ScanRecipient").default}
           options={{
             ...TransparentHeaderNavigationOptions,
             title: t("send.scan.title"),
@@ -512,81 +603,88 @@ export default function BaseNavigator() {
             headerLeft: renderNullHeader,
           }}
         />
-        <Stack.Screen
-          name={NavigatorName.WalletConnect}
-          component={WalletConnectLiveAppNavigator}
-          options={{
-            headerShown: false,
-          }}
-          {...noNanoBuyNanoWallScreenOptions}
-        />
+        {lazyOrWall({
+          name: NavigatorName.WalletConnect,
+          getComponent: () => require("./WalletConnectLiveAppNavigator").default,
+          options: { headerShown: false },
+          wall: noNanoBuyNanoWallScreenOptions,
+        })}
         <Stack.Screen
           name={NavigatorName.NotificationCenter}
-          component={NotificationCenterNavigator}
+          getComponent={() => require("./NotificationCenterNavigator").default}
           options={{ headerShown: false }}
         />
         <Stack.Screen
           name={NavigatorName.Accounts}
-          component={AccountsNavigator}
+          getComponent={() => require("./AccountsNavigator").default}
           options={{ headerShown: false }}
         />
         <Stack.Screen
           name={NavigatorName.CustomImage}
-          component={CustomImageNavigator}
+          getComponent={() => require("./CustomImageNavigator").default}
           options={{ headerShown: false }}
         />
-        {/* This is a freaking hack… */}
-        {Object.keys(families).map(name => {
-          /* eslint-disable @typescript-eslint/consistent-type-assertions */
-          const { component, options } = families[name as keyof typeof families];
+        {FAMILY_SCREEN_NAMES.map(name => {
           const screenName = name as keyof BaseNavigatorStackParamList;
-          const screenComponent = component as React.ComponentType;
-          const screenOptions = options as NativeStackNavigationOptions;
-          /* eslint-enable @typescript-eslint/consistent-type-assertions */
-
           return (
             <Stack.Screen
               key={name}
               name={screenName}
-              component={screenComponent}
-              options={screenOptions}
+              getComponent={() => {
+                const families = require("~/families") as typeof FamilyScreens;
+                return families[name].component as React.ComponentType;
+              }}
+              options={() => {
+                const families = require("~/families") as typeof FamilyScreens;
+                return (families[name] as { options?: NativeStackNavigationOptions }).options ?? {};
+              }}
             />
           );
         })}
         <Stack.Screen
           name={ScreenName.BleDevicePairingFlow}
-          component={BleDevicePairingFlow}
-          options={bleDevicePairingFlowHeaderOptions}
+          getComponent={() => require("~/screens/BleDevicePairingFlow").BleDevicePairingFlow}
+          options={() =>
+            (
+              require("~/screens/BleDevicePairingFlow") as typeof import("~/screens/BleDevicePairingFlow")
+            ).bleDevicePairingFlowHeaderOptions
+          }
         />
         <Stack.Screen
           name={NavigatorName.PostOnboarding}
           options={{ headerShown: false }}
-          component={PostOnboardingNavigator}
+          getComponent={() => require("./PostOnboardingNavigator").default}
         />
         <Stack.Screen
           name={ScreenName.DeviceConnect}
-          component={DeviceConnect}
-          options={useMemo(() => deviceConnectHeaderOptions(t), [t])}
+          getComponent={() => require("~/screens/DeviceConnect").default}
+          options={() =>
+            (
+              require("~/screens/DeviceConnect") as typeof import("~/screens/DeviceConnect")
+            ).deviceConnectHeaderOptions(t)
+          }
           listeners={({ route }) => ({
             beforeRemove: () => handleOnClose(route),
           })}
         />
         <Stack.Screen
           name={ScreenName.PerpsSign}
-          component={PerpsSign}
+          getComponent={() =>
+            require("LLM/features/Perps/screens/PerpsSign/PerpsSignScreen").default
+          }
           options={{ headerShown: false }}
         />
         <Stack.Screen
           name={ScreenName.RedirectToOnboardingRecoverFlow}
           options={{ ...TransparentHeaderNavigationOptions, title: "" }}
-          component={RedirectToOnboardingRecoverFlowScreen}
+          getComponent={() =>
+            require("~/screens/Protect/RedirectToOnboardingRecoverFlow")
+              .RedirectToOnboardingRecoverFlowScreen
+          }
         />
         <Stack.Screen
           name={NavigatorName.Earn}
-          component={EarnLiveAppNavigator}
-          // Initial header from the entry `intent` param (first paint). Once the live-app loads,
-          // `useEarnIntentFlowPresentation` becomes the live owner and overrides this imperatively
-          // via `getParent(BASE_NAVIGATOR_ID).setOptions` as the webview route changes.
+          getComponent={() => require("./EarnLiveAppNavigator").default}
           options={props =>
             getEarnScreenOptionsFromRouteParams(
               props.route?.params?.params,
@@ -598,12 +696,12 @@ export default function BaseNavigator() {
         />
         <Stack.Screen
           name={NavigatorName.Borrow}
-          component={BorrowLiveAppNavigator}
+          getComponent={() => require("./BorrowLiveAppNavigator").default}
           options={{ headerShown: false }}
         />
         <Stack.Screen
           name={NavigatorName.NoFundsFlow}
-          component={NoFundsFlowNavigator}
+          getComponent={() => require("./NoFundsFlowNavigator").default}
           options={{
             ...TransparentHeaderNavigationOptions,
             headerRight: FlowHeaderCloseButton,
@@ -612,7 +710,7 @@ export default function BaseNavigator() {
         />
         <Stack.Screen
           name={NavigatorName.StakeFlow}
-          component={StakeFlowNavigator}
+          getComponent={() => require("./StakeFlowNavigator").default}
           options={{
             ...TransparentHeaderNavigationOptions,
             headerRight: FlowHeaderCloseButton,
@@ -622,26 +720,30 @@ export default function BaseNavigator() {
         <Stack.Screen
           name={NavigatorName.EvmEditTransaction}
           options={{ headerShown: false }}
-          component={EditTransactionNavigator}
+          getComponent={() =>
+            require("~/families/evm/EditTransactionFlow/EditTransactionNavigator").default
+          }
         />
         <Stack.Screen
           name={NavigatorName.BitcoinEditTransaction}
           options={{ headerShown: false }}
-          component={BitcoinEditTransactionNavigator}
+          getComponent={() =>
+            require("~/families/bitcoin/EditTransactionFlow/EditTransactionNavigator").default
+          }
         />
         <Stack.Screen
           name={NavigatorName.AnalyticsOptInPrompt}
           options={{ headerShown: false }}
-          component={AnalyticsOptInPromptNavigator}
+          getComponent={() => require("./AnalyticsOptInPromptNavigator").default}
         />
         <Stack.Screen
           name={NavigatorName.LandingPages}
           options={{ headerShown: false }}
-          component={LandingPagesNavigator}
+          getComponent={() => require("./LandingPagesNavigator").default}
         />
         <Stack.Screen
           name={ScreenName.FirmwareUpdate}
-          component={FirmwareUpdateScreen}
+          getComponent={() => require("~/screens/FirmwareUpdate").default}
           options={{
             gestureEnabled: false,
             headerTitle: FirmwareUpdateHeaderTitle,
@@ -652,51 +754,51 @@ export default function BaseNavigator() {
         />
         <Stack.Screen
           name={NavigatorName.AddAccounts}
-          component={AddAccountsV2Navigator}
+          getComponent={() => require("LLM/features/Accounts/Navigator").default}
           options={{ headerShown: false }}
         />
 
         <Stack.Screen
           name={NavigatorName.DeviceSelection}
-          component={DeviceSelectionNavigator}
+          getComponent={() => require("LLM/features/DeviceSelection/Navigator").default}
           options={{ headerShown: false }}
         />
 
         <Stack.Screen
           name={ScreenName.DeeplinkInstallAppDeviceSelection}
-          component={DeeplinkInstallAppDeviceSelection}
+          getComponent={() => require("LLM/features/DeeplinkInstallApp").DeviceSelectionScreen}
           options={{ headerShown: false }}
         />
 
         {llmAccountListUI?.enabled && (
           <Stack.Screen
             name={NavigatorName.Assets}
-            component={AssetsListNavigator}
+            getComponent={() => require("LLM/features/Assets/Navigator").default}
             options={{ headerShown: false }}
           />
         )}
 
         <Stack.Screen
           name={NavigatorName.AssetDetail}
-          component={AssetDetailNavigator}
+          getComponent={() => require("LLM/features/AssetDetail/Navigator").default}
           options={{ headerShown: false }}
         />
 
         <Stack.Screen
           name={NavigatorName.Analytics}
-          component={AnalyticsNavigator}
+          getComponent={() => require("LLM/features/Analytics/Navigator").default}
           options={{ headerShown: false }}
         />
 
         <Stack.Screen
           name={NavigatorName.OperationsHistory}
-          component={OperationsHistoryNavigator}
+          getComponent={() => require("LLM/features/OperationsHistory/Navigator").default}
           options={{ headerShown: false }}
         />
 
         <Stack.Screen
           name={ScreenName.LiveAppModal}
-          component={LiveAppModalScreen}
+          getComponent={() => require("LLM/features/LiveAppModal").default}
           options={{
             headerShown: false,
             gestureEnabled: true,
@@ -707,15 +809,6 @@ export default function BaseNavigator() {
   );
 }
 
-/**
- * Handle the onClose callback for the route
- *
- * If the route has a onClose callback, call it
- * If the route has a nested route with a onClose callback, call it
- *
- * @param route
- * The route object
- */
 function handleOnClose(route: object) {
   if (route == null || !("params" in route)) return;
   const params = route.params;
@@ -729,22 +822,10 @@ function handleOnClose(route: object) {
   }
 }
 
-/**
- * Check if the route has a onClose callback
- *
- * @param params
- * The route params
- */
 function isRouteWithCloseCallback(params: object): params is Readonly<WithCloseCallback> {
   return "onClose" in params && typeof params.onClose === "function";
 }
 
-/**
- * Check if the route has a nested route with a onClose callback
- *
- * @param params
- * The route params
- */
 function isNestedRouteWithCloseCallback(params: object): params is { params: WithCloseCallback } {
   if (!("params" in params)) return false;
   const nestedParams = params.params;

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseOnboardingNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseOnboardingNavigator.tsx
@@ -3,19 +3,9 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTranslation } from "~/context/Locale";
 import { useTheme } from "styled-components/native";
 import { ScreenName, NavigatorName } from "~/const";
-import EditDeviceName from "~/screens/EditDeviceName";
-import OnboardingNavigator from "./OnboardingNavigator";
-import { SyncOnboardingNavigator } from "./SyncOnboardingNavigator";
-import PasswordAddFlowNavigator from "./PasswordAddFlowNavigator";
-import PasswordModifyFlowNavigator from "./PasswordModifyFlowNavigator";
 import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
-import BuyDeviceNavigator from "./BuyDeviceNavigator";
 import { BaseOnboardingNavigatorParamList } from "./types/BaseOnboardingNavigator";
-import WalletSyncNavigator from "LLM/features/WalletSync/WalletSyncNavigator";
-import ReceiveFundsNavigator from "./ReceiveFundsNavigator";
-import DeviceSelectionNavigator from "LLM/features/DeviceSelection/Navigator";
-import AddAccountsV2Navigator from "LLM/features/Accounts/Navigator";
-import AccountSettingsNavigator from "./AccountSettingsNavigator";
+import { lazyNamed, lazyScreen } from "./lazyScreen";
 
 export default function BaseOnboardingNavigator() {
   const { t } = useTranslation();
@@ -32,54 +22,93 @@ export default function BaseOnboardingNavigator() {
         headerShown: false,
       }}
     >
-      <Stack.Screen name={NavigatorName.Onboarding} component={OnboardingNavigator} />
-      <Stack.Screen name={NavigatorName.SyncOnboarding} component={SyncOnboardingNavigator} />
+      <Stack.Screen
+        name={NavigatorName.Onboarding}
+        getComponent={lazyScreen(
+          () => require("./OnboardingNavigator") as typeof import("./OnboardingNavigator"),
+        )}
+      />
+      <Stack.Screen
+        name={NavigatorName.SyncOnboarding}
+        getComponent={lazyNamed(
+          () =>
+            (require("./SyncOnboardingNavigator") as typeof import("./SyncOnboardingNavigator"))
+              .SyncOnboardingNavigator,
+        )}
+      />
       <Stack.Screen
         name={NavigatorName.BuyDevice}
-        component={BuyDeviceNavigator}
+        getComponent={lazyScreen(
+          () => require("./BuyDeviceNavigator") as typeof import("./BuyDeviceNavigator"),
+        )}
         options={{
           headerShown: false,
         }}
       />
       <Stack.Screen
         name={NavigatorName.ReceiveFunds}
-        component={ReceiveFundsNavigator}
+        getComponent={lazyScreen(
+          () => require("./ReceiveFundsNavigator") as typeof import("./ReceiveFundsNavigator"),
+        )}
         options={{
           headerShown: false,
         }}
       />
       <Stack.Screen
         name={NavigatorName.AccountSettings}
-        component={AccountSettingsNavigator}
+        getComponent={lazyScreen(
+          () =>
+            require("./AccountSettingsNavigator") as typeof import("./AccountSettingsNavigator"),
+        )}
         options={{ headerShown: false }}
       />
       <Stack.Screen
         name={NavigatorName.AddAccounts}
-        component={AddAccountsV2Navigator}
+        getComponent={lazyScreen(
+          () =>
+            require("LLM/features/Accounts/Navigator") as typeof import("LLM/features/Accounts/Navigator"),
+        )}
         options={{ headerShown: false }}
       />
       <Stack.Screen
         name={NavigatorName.DeviceSelection}
-        component={DeviceSelectionNavigator}
+        getComponent={lazyScreen(
+          () =>
+            require("LLM/features/DeviceSelection/Navigator") as typeof import("LLM/features/DeviceSelection/Navigator"),
+        )}
         options={{ headerShown: false }}
       />
       <Stack.Screen
         name={ScreenName.EditDeviceName}
-        component={EditDeviceName}
+        getComponent={lazyScreen(
+          () => require("~/screens/EditDeviceName") as typeof import("~/screens/EditDeviceName"),
+        )}
         options={{
           title: t("EditDeviceName.title"),
           headerLeft: () => null,
           headerShown: true,
         }}
       />
-      <Stack.Screen name={NavigatorName.PasswordAddFlow} component={PasswordAddFlowNavigator} />
+      <Stack.Screen
+        name={NavigatorName.PasswordAddFlow}
+        getComponent={lazyScreen(
+          () =>
+            require("./PasswordAddFlowNavigator") as typeof import("./PasswordAddFlowNavigator"),
+        )}
+      />
       <Stack.Screen
         name={NavigatorName.PasswordModifyFlow}
-        component={PasswordModifyFlowNavigator}
+        getComponent={lazyScreen(
+          () =>
+            require("./PasswordModifyFlowNavigator") as typeof import("./PasswordModifyFlowNavigator"),
+        )}
       />
       <Stack.Screen
         name={NavigatorName.WalletSync}
-        component={WalletSyncNavigator}
+        getComponent={lazyScreen(
+          () =>
+            require("LLM/features/WalletSync/WalletSyncNavigator") as typeof import("LLM/features/WalletSync/WalletSyncNavigator"),
+        )}
         options={{ headerShown: false, gestureEnabled: false }}
       />
     </Stack.Navigator>

--- a/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator/SwapAwareTabBar.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator/SwapAwareTabBar.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { Platform } from "react-native";
+import type { BottomTabBarProps } from "@react-navigation/bottom-tabs";
+import { MainTabBar } from "LLM/components/MainTabBar";
+import { useSwapWallet40HeaderState } from "~/screens/Swap/LiveApp/navigationHandlers/wallet40/useSwapWallet40HeaderState";
+
+type Props = BottomTabBarProps & {
+  isMainNavigatorVisible: boolean;
+  isKeyboardVisible: boolean;
+};
+
+export function SwapAwareTabBar({
+  isMainNavigatorVisible,
+  isKeyboardVisible,
+  ...props
+}: Props): React.JSX.Element {
+  const swapWallet40HeaderState = useSwapWallet40HeaderState();
+  const hideTabBarOnAndroid = isKeyboardVisible && Platform.OS === "android";
+  const hideSwapWallet40TabBar = swapWallet40HeaderState.headerStyle !== "transparent";
+  const hideTabBar = !isMainNavigatorVisible || hideSwapWallet40TabBar;
+
+  return <MainTabBar {...props} hideTabBar={hideTabBar || hideTabBarOnAndroid} />;
+}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator/Wallet40TabNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator/Wallet40TabNavigator.tsx
@@ -1,17 +1,19 @@
 import React from "react";
 import { NavigatorName } from "~/const";
 import PortfolioNavigator from "../PortfolioNavigator";
-import SwapNavigator from "../SwapNavigator";
-import EarnLiveAppNavigator from "../EarnLiveAppNavigator";
-import CardLandingNavigator from "LLM/features/Card";
-import PayTabNavigator, { getPayTabScreenOptions } from "LLM/features/PayTab";
 import { Tab } from "./tabNavigator";
 import type { Wallet40TabNavigatorProps } from "./types";
-import { SwapWallet40Header } from "~/screens/Swap/LiveApp/components/SwapWallet40Header";
-import { resetSwapWallet40HeaderState } from "~/screens/Swap/LiveApp/navigationHandlers/wallet40/useSwapWallet40HeaderState";
 
 function Wallet40SwapTabHeader() {
+  const { SwapWallet40Header } =
+    require("~/screens/Swap/LiveApp/components/SwapWallet40Header") as typeof import("~/screens/Swap/LiveApp/components/SwapWallet40Header");
   return <SwapWallet40Header />;
+}
+
+function resetSwapWallet40HeaderStateOnTabPress() {
+  (
+    require("~/screens/Swap/LiveApp/navigationHandlers/wallet40/useSwapWallet40HeaderState") as typeof import("~/screens/Swap/LiveApp/navigationHandlers/wallet40/useSwapWallet40HeaderState")
+  ).resetSwapWallet40HeaderState();
 }
 
 export function Wallet40TabNavigator({
@@ -24,24 +26,33 @@ export function Wallet40TabNavigator({
       <Tab.Screen name={NavigatorName.Portfolio} component={PortfolioNavigator} />
       <Tab.Screen
         name={NavigatorName.Swap}
-        component={SwapNavigator}
+        getComponent={() => require("../SwapNavigator").default}
         options={{
           header: Wallet40SwapTabHeader,
         }}
         listeners={() => ({
-          // Prevent stale opaque header state when re-entering the Swap tab.
-          tabPress: resetSwapWallet40HeaderState,
+          tabPress: resetSwapWallet40HeaderStateOnTabPress,
         })}
       />
-      <Tab.Screen name={NavigatorName.Earn} component={EarnLiveAppNavigator} />
+      <Tab.Screen
+        name={NavigatorName.Earn}
+        getComponent={() => require("../EarnLiveAppNavigator").default}
+      />
       {isPayTabEnabled ? (
         <Tab.Screen
           name={NavigatorName.PayTab}
-          component={PayTabNavigator}
-          options={getPayTabScreenOptions}
+          getComponent={() => require("LLM/features/PayTab").default}
+          options={props =>
+            (
+              require("LLM/features/PayTab/getPayTabScreenOptions") as typeof import("LLM/features/PayTab/getPayTabScreenOptions")
+            ).getPayTabScreenOptions(props)
+          }
         />
       ) : (
-        <Tab.Screen name={NavigatorName.CardTab} component={CardLandingNavigator} />
+        <Tab.Screen
+          name={NavigatorName.CardTab}
+          getComponent={() => require("LLM/features/Card").default}
+        />
       )}
     </Tab.Navigator>
   );

--- a/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator/useTabBar.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator/useTabBar.tsx
@@ -1,10 +1,8 @@
 import React, { useMemo } from "react";
-import { Platform } from "react-native";
 import type { BottomTabBarProps } from "@react-navigation/bottom-tabs";
 import { MainTabBar } from "LLM/components/MainTabBar";
 import { useKeyboardVisible } from "~/logic/keyboardVisible";
 import { NavigatorName } from "~/const";
-import { useSwapWallet40HeaderState } from "~/screens/Swap/LiveApp/navigationHandlers/wallet40/useSwapWallet40HeaderState";
 
 type Params = {
   isMainNavigatorVisible: boolean;
@@ -13,21 +11,26 @@ type Params = {
 export function useTabBar({
   isMainNavigatorVisible,
 }: Params): (props: BottomTabBarProps) => React.JSX.Element {
-  const swapWallet40HeaderState = useSwapWallet40HeaderState();
   const { isKeyboardVisible } = useKeyboardVisible();
 
   return useMemo(
     () =>
       ({ ...props }: BottomTabBarProps): React.ReactElement => {
         const isSwapTabFocused = props.state.routes[props.state.index]?.name === NavigatorName.Swap;
-        const hideTabBarOnAndroid =
-          isSwapTabFocused && isKeyboardVisible && Platform.OS === "android";
-        const hideSwapWallet40TabBar =
-          isSwapTabFocused && swapWallet40HeaderState.headerStyle !== "transparent";
-        const hideTabBar = !isMainNavigatorVisible || hideSwapWallet40TabBar;
+        if (isSwapTabFocused) {
+          const { SwapAwareTabBar } =
+            require("./SwapAwareTabBar") as typeof import("./SwapAwareTabBar");
+          return (
+            <SwapAwareTabBar
+              {...props}
+              isMainNavigatorVisible={isMainNavigatorVisible}
+              isKeyboardVisible={isKeyboardVisible}
+            />
+          );
+        }
 
-        return <MainTabBar {...props} hideTabBar={hideTabBar || hideTabBarOnAndroid} />;
+        return <MainTabBar {...props} hideTabBar={!isMainNavigatorVisible} />;
       },
-    [isMainNavigatorVisible, isKeyboardVisible, swapWallet40HeaderState.headerStyle],
+    [isMainNavigatorVisible, isKeyboardVisible],
   );
 }

--- a/apps/ledger-live-mobile/src/components/RootNavigator/OnboardingNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/OnboardingNavigator.tsx
@@ -9,44 +9,16 @@ import { Theme } from "@ledgerhq/native-ui/styles/theme";
 import { useTranslation } from "~/context/Locale";
 import { useTheme } from "styled-components/native";
 import { ScreenName, NavigatorName } from "~/const";
-import PasswordAddFlowNavigator from "./PasswordAddFlowNavigator";
 import OnboardingWelcome from "LLM/features/WelcomePage";
-import OnboardingLanguage from "~/screens/Onboarding/steps/language";
-import OnboardingTerms from "~/screens/Onboarding/steps/terms";
-import OnboardingDeviceSelection from "~/screens/Onboarding/steps/deviceSelection";
-import OnboardingUseCase from "~/screens/Onboarding/steps/useCaseSelection";
-import OnboardingNewDeviceInfo from "~/screens/Onboarding/steps/newDeviceInfo";
-import OnboardingNewDevice from "~/screens/Onboarding/steps/setupDevice";
-import OnboardingRecoveryPhrase from "~/screens/Onboarding/steps/recoveryPhrase";
-import OnboardingInfoModal from "../OnboardingStepperView/OnboardingInfoModal";
-
-import OnboardingBleDevicePairingFlow from "~/screens/Onboarding/steps/BleDevicePairingFlow";
-import OnboardingPairNew from "~/screens/Onboarding/steps/PairNew";
-import OnboardingPreQuizModal from "~/screens/Onboarding/steps/setupDevice/drawers/OnboardingPreQuizModal";
-import OnboardingQuiz from "~/screens/Onboarding/OnboardingQuiz";
-import OnboardingQuizFinal from "~/screens/Onboarding/OnboardingQuizFinal";
 import NavigationHeader from "../NavigationHeader";
 import NavigationModalContainer from "../NavigationModalContainer";
-import OnboardingSetupDeviceInformation from "~/screens/Onboarding/steps/setupDevice/drawers/SecurePinCode";
-import OnboardingSetupDeviceRecoveryPhrase from "~/screens/Onboarding/steps/setupDevice/drawers/SecureRecoveryPhrase";
-import OnboardingGeneralInformation from "~/screens/Onboarding/steps/setupDevice/drawers/GeneralInformation";
-import OnboardingBluetoothInformation from "~/screens/Onboarding/steps/setupDevice/drawers/BluetoothConnection";
-import PostWelcomeSelection from "~/screens/Onboarding/steps/postWelcomeSelection";
-import OnboardingProtectFlow from "~/screens/Onboarding/steps/protectFlow";
-
 import {
   OnboardingNavigatorParamList,
   OnboardingPreQuizModalNavigatorParamList,
 } from "./types/OnboardingNavigator";
 import { StackNavigatorProps } from "./types/helpers";
-import ProtectConnectionInformationModal from "~/screens/Onboarding/steps/setupDevice/drawers/ProtectConnectionInformationModal";
 import { NavigationHeaderBackButton } from "../NavigationHeaderBackButton";
-import AccessExistingWallet from "~/screens/Onboarding/steps/accessExistingWallet";
-import OnboardingSecureYourCrypto from "~/screens/Onboarding/OnboardingSecureYourCrypto";
-import AnalyticsOptInPromptNavigator from "./AnalyticsOptInPromptNavigator";
-import LandingPagesNavigator from "./LandingPagesNavigator";
-import OnboardingFundSuccess from "~/screens/Onboarding/OnboardingFundSuccess";
-import NotificationsOptIn from "LLM/features/NotificationsOptIn";
+import { lazyScreen } from "./lazyScreen";
 
 const Stack = createNativeStackNavigator<OnboardingNavigatorParamList>();
 const OnboardingPreQuizModalStack =
@@ -56,10 +28,13 @@ function OnboardingPreQuizModalNavigator(
   props: StackNavigatorProps<OnboardingNavigatorParamList, NavigatorName.OnboardingPreQuiz>,
 ) {
   const options: Partial<NativeStackNavigationOptions> = {
-    header: props => (
-      // TODO: Replace this value with constant.purple as soon as the value is fixed in the theme
+    header: headerProps => (
       <Flex bg="constant.purple">
-        <NavigationHeader {...props} hideBack containerProps={{ backgroundColor: "transparent" }} />
+        <NavigationHeader
+          {...headerProps}
+          hideBack
+          containerProps={{ backgroundColor: "transparent" }}
+        />
       </Flex>
     ),
     headerStyle: {},
@@ -71,9 +46,11 @@ function OnboardingPreQuizModalNavigator(
       <OnboardingPreQuizModalStack.Navigator>
         <OnboardingPreQuizModalStack.Screen
           name={ScreenName.OnboardingPreQuizModal}
-          component={OnboardingPreQuizModal}
+          getComponent={lazyScreen(
+            () =>
+              require("~/screens/Onboarding/steps/setupDevice/drawers/OnboardingPreQuizModal") as typeof import("~/screens/Onboarding/steps/setupDevice/drawers/OnboardingPreQuizModal"),
+          )}
           options={{ title: "", ...options }}
-          // initialParams={props.route.params}
         />
       </OnboardingPreQuizModalStack.Navigator>
     </NavigationModalContainer>
@@ -108,7 +85,10 @@ export default function OnboardingNavigator() {
       <Stack.Screen name={ScreenName.OnboardingWelcome} component={OnboardingWelcome} />
       <Stack.Screen
         name={ScreenName.OnboardingPostWelcomeSelection}
-        component={PostWelcomeSelection}
+        getComponent={lazyScreen(
+          () =>
+            require("~/screens/Onboarding/steps/postWelcomeSelection") as typeof import("~/screens/Onboarding/steps/postWelcomeSelection"),
+        )}
         options={{
           headerShown: true,
           headerLeft: () => <NavigationHeaderBackButton />,
@@ -116,12 +96,18 @@ export default function OnboardingNavigator() {
       />
       <Stack.Screen
         name={ScreenName.OnboardingNotificationsOptIn}
-        component={NotificationsOptIn}
+        getComponent={lazyScreen(
+          () =>
+            require("LLM/features/NotificationsOptIn") as typeof import("LLM/features/NotificationsOptIn"),
+        )}
         options={{ headerShown: false }}
       />
       <Stack.Screen
         name={ScreenName.OnboardingWelcomeBack}
-        component={AccessExistingWallet}
+        getComponent={lazyScreen(
+          () =>
+            require("~/screens/Onboarding/steps/accessExistingWallet") as typeof import("~/screens/Onboarding/steps/accessExistingWallet"),
+        )}
         options={{
           headerShown: true,
           headerLeft: () => <NavigationHeaderBackButton />,
@@ -129,16 +115,28 @@ export default function OnboardingNavigator() {
       />
       <Stack.Screen
         name={ScreenName.OnboardingLanguage}
-        component={OnboardingLanguage}
+        getComponent={lazyScreen(
+          () =>
+            require("~/screens/Onboarding/steps/language") as typeof import("~/screens/Onboarding/steps/language"),
+        )}
         options={{
           ...infoModalOptions({ theme }),
           headerTitle: t("onboarding.stepLanguage.title"),
         }}
       />
-      <Stack.Screen name={ScreenName.OnboardingTermsOfUse} component={OnboardingTerms} />
+      <Stack.Screen
+        name={ScreenName.OnboardingTermsOfUse}
+        getComponent={lazyScreen(
+          () =>
+            require("~/screens/Onboarding/steps/terms") as typeof import("~/screens/Onboarding/steps/terms"),
+        )}
+      />
       <Stack.Screen
         name={ScreenName.OnboardingDeviceSelection}
-        component={OnboardingDeviceSelection}
+        getComponent={lazyScreen(
+          () =>
+            require("~/screens/Onboarding/steps/deviceSelection") as typeof import("~/screens/Onboarding/steps/deviceSelection"),
+        )}
         options={{
           headerShown: true,
           headerLeft: () => <NavigationHeaderBackButton />,
@@ -146,7 +144,10 @@ export default function OnboardingNavigator() {
       />
       <Stack.Screen
         name={ScreenName.OnboardingBleDevicePairingFlow}
-        component={OnboardingBleDevicePairingFlow}
+        getComponent={lazyScreen(
+          () =>
+            require("~/screens/Onboarding/steps/BleDevicePairingFlow") as typeof import("~/screens/Onboarding/steps/BleDevicePairingFlow"),
+        )}
         options={{
           headerShown: true,
           headerLeft: () => <NavigationHeaderBackButton />,
@@ -154,7 +155,10 @@ export default function OnboardingNavigator() {
       />
       <Stack.Screen
         name={ScreenName.OnboardingUseCase}
-        component={OnboardingUseCase}
+        getComponent={lazyScreen(
+          () =>
+            require("~/screens/Onboarding/steps/useCaseSelection") as typeof import("~/screens/Onboarding/steps/useCaseSelection"),
+        )}
         options={{
           headerShown: true,
           headerLeft: () => <NavigationHeaderBackButton />,
@@ -167,68 +171,136 @@ export default function OnboardingNavigator() {
       />
       <Stack.Screen
         name={ScreenName.OnboardingModalSetupNewDevice}
-        component={OnboardingNewDeviceInfo}
+        getComponent={lazyScreen(
+          () =>
+            require("~/screens/Onboarding/steps/newDeviceInfo") as typeof import("~/screens/Onboarding/steps/newDeviceInfo"),
+        )}
       />
       <Stack.Screen
         name={ScreenName.OnboardingSetupDeviceInformation}
-        component={OnboardingSetupDeviceInformation}
+        getComponent={lazyScreen(
+          () =>
+            require("~/screens/Onboarding/steps/setupDevice/drawers/SecurePinCode") as typeof import("~/screens/Onboarding/steps/setupDevice/drawers/SecurePinCode"),
+        )}
         options={infoModalOptions({ theme })}
       />
       <Stack.Screen
         name={ScreenName.OnboardingModalSetupSecureRecovery}
-        component={OnboardingSetupDeviceRecoveryPhrase}
+        getComponent={lazyScreen(
+          () =>
+            require("~/screens/Onboarding/steps/setupDevice/drawers/SecureRecoveryPhrase") as typeof import("~/screens/Onboarding/steps/setupDevice/drawers/SecureRecoveryPhrase"),
+        )}
         options={infoModalOptions({ theme })}
       />
       <Stack.Screen
         name={ScreenName.OnboardingGeneralInformation}
-        component={OnboardingGeneralInformation}
+        getComponent={lazyScreen(
+          () =>
+            require("~/screens/Onboarding/steps/setupDevice/drawers/GeneralInformation") as typeof import("~/screens/Onboarding/steps/setupDevice/drawers/GeneralInformation"),
+        )}
         options={infoModalOptions({ theme })}
       />
       <Stack.Screen
         name={ScreenName.OnboardingBluetoothInformation}
-        component={OnboardingBluetoothInformation}
+        getComponent={lazyScreen(
+          () =>
+            require("~/screens/Onboarding/steps/setupDevice/drawers/BluetoothConnection") as typeof import("~/screens/Onboarding/steps/setupDevice/drawers/BluetoothConnection"),
+        )}
         options={infoModalOptions({ theme })}
       />
       <Stack.Screen
         name={ScreenName.OnboardingProtectionConnectionInformation}
-        component={ProtectConnectionInformationModal}
+        getComponent={lazyScreen(
+          () =>
+            require("~/screens/Onboarding/steps/setupDevice/drawers/ProtectConnectionInformationModal") as typeof import("~/screens/Onboarding/steps/setupDevice/drawers/ProtectConnectionInformationModal"),
+        )}
         options={infoModalOptions({ theme })}
       />
-      <Stack.Screen name={ScreenName.OnboardingSetNewDevice} component={OnboardingNewDevice} />
-
+      <Stack.Screen
+        name={ScreenName.OnboardingSetNewDevice}
+        getComponent={lazyScreen(
+          () =>
+            require("~/screens/Onboarding/steps/setupDevice") as typeof import("~/screens/Onboarding/steps/setupDevice"),
+        )}
+      />
       <Stack.Screen
         name={ScreenName.OnboardingRecoveryPhrase}
-        component={OnboardingRecoveryPhrase}
+        getComponent={lazyScreen(
+          () =>
+            require("~/screens/Onboarding/steps/recoveryPhrase") as typeof import("~/screens/Onboarding/steps/recoveryPhrase"),
+        )}
       />
-
       <Stack.Screen
         name={ScreenName.OnboardingInfoModal}
-        component={OnboardingInfoModal}
+        getComponent={lazyScreen(
+          () =>
+            require("../OnboardingStepperView/OnboardingInfoModal") as typeof import("../OnboardingStepperView/OnboardingInfoModal"),
+        )}
         options={{ animation: "slide_from_bottom" }}
       />
-
-      <Stack.Screen name={ScreenName.OnboardingPairNew} component={OnboardingPairNew} />
-
-      <Stack.Screen name={ScreenName.OnboardingProtectFlow} component={OnboardingProtectFlow} />
-
-      <Stack.Screen name={NavigatorName.PasswordAddFlow} component={PasswordAddFlowNavigator} />
-
-      <Stack.Screen name={ScreenName.OnboardingQuiz} component={OnboardingQuiz} />
-
-      <Stack.Screen name={ScreenName.OnboardingQuizFinal} component={OnboardingQuizFinal} />
+      <Stack.Screen
+        name={ScreenName.OnboardingPairNew}
+        getComponent={lazyScreen(
+          () =>
+            require("~/screens/Onboarding/steps/PairNew") as typeof import("~/screens/Onboarding/steps/PairNew"),
+        )}
+      />
+      <Stack.Screen
+        name={ScreenName.OnboardingProtectFlow}
+        getComponent={lazyScreen(
+          () =>
+            require("~/screens/Onboarding/steps/protectFlow") as typeof import("~/screens/Onboarding/steps/protectFlow"),
+        )}
+      />
+      <Stack.Screen
+        name={NavigatorName.PasswordAddFlow}
+        getComponent={lazyScreen(
+          () =>
+            require("./PasswordAddFlowNavigator") as typeof import("./PasswordAddFlowNavigator"),
+        )}
+      />
+      <Stack.Screen
+        name={ScreenName.OnboardingQuiz}
+        getComponent={lazyScreen(
+          () =>
+            require("~/screens/Onboarding/OnboardingQuiz") as typeof import("~/screens/Onboarding/OnboardingQuiz"),
+        )}
+      />
+      <Stack.Screen
+        name={ScreenName.OnboardingQuizFinal}
+        getComponent={lazyScreen(
+          () =>
+            require("~/screens/Onboarding/OnboardingQuizFinal") as typeof import("~/screens/Onboarding/OnboardingQuizFinal"),
+        )}
+      />
       <Stack.Screen
         name={ScreenName.OnboardingSecureYourCrypto}
-        component={OnboardingSecureYourCrypto}
+        getComponent={lazyScreen(
+          () =>
+            require("~/screens/Onboarding/OnboardingSecureYourCrypto") as typeof import("~/screens/Onboarding/OnboardingSecureYourCrypto"),
+        )}
       />
-
-      <Stack.Screen name={ScreenName.OnboardingFundSuccess} component={OnboardingFundSuccess} />
-
+      <Stack.Screen
+        name={ScreenName.OnboardingFundSuccess}
+        getComponent={lazyScreen(
+          () =>
+            require("~/screens/Onboarding/OnboardingFundSuccess") as typeof import("~/screens/Onboarding/OnboardingFundSuccess"),
+        )}
+      />
       <Stack.Screen
         name={NavigatorName.AnalyticsOptInPrompt}
         options={{ headerShown: false }}
-        component={AnalyticsOptInPromptNavigator}
+        getComponent={lazyScreen(
+          () =>
+            require("./AnalyticsOptInPromptNavigator") as typeof import("./AnalyticsOptInPromptNavigator"),
+        )}
       />
-      <Stack.Screen name={NavigatorName.LandingPages} component={LandingPagesNavigator} />
+      <Stack.Screen
+        name={NavigatorName.LandingPages}
+        getComponent={lazyScreen(
+          () => require("./LandingPagesNavigator") as typeof import("./LandingPagesNavigator"),
+        )}
+      />
     </Stack.Navigator>
   );
 }

--- a/apps/ledger-live-mobile/src/components/RootNavigator/PortfolioNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/PortfolioNavigator.tsx
@@ -2,10 +2,10 @@ import React, { useMemo } from "react";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "styled-components/native";
 import { NavigatorName, ScreenName } from "~/const";
-import AccountsNavigator from "./AccountsNavigator";
 import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
 import PortfolioRootScreen from "./PortfolioRootScreen";
 import { PortfolioNavigatorStackParamList } from "./types/PortfolioNavigator";
+import { lazyScreen } from "./lazyScreen";
 
 const Stack = createNativeStackNavigator<PortfolioNavigatorStackParamList>();
 
@@ -24,7 +24,9 @@ export default function PortfolioNavigator() {
       />
       <Stack.Screen
         name={NavigatorName.PortfolioAccounts}
-        component={AccountsNavigator}
+        getComponent={lazyScreen(
+          () => require("./AccountsNavigator") as typeof import("./AccountsNavigator"),
+        )}
         options={{ headerShown: false }}
       />
     </Stack.Navigator>

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
@@ -3,96 +3,11 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTranslation } from "~/context/Locale";
 import { useTheme } from "styled-components/native";
 import { ScreenName } from "~/const";
-import DebugBenchmarkQRStream from "~/screens/Settings/Debug/Broken/BenchmarkQRStream";
-import DebugConfiguration from "~/screens/Settings/Debug/Configuration";
-import DebugConnectivity, {
-  connectivityHeaderOptions,
-} from "~/screens/Settings/Debug/Connectivity";
-import DebugCrash from "~/screens/Settings/Debug/Debugging/Crashes";
-import DebugCustomImageGraphics from "~/screens/Settings/Debug/Features/CustomImageGraphics";
-import DebugDebugging from "~/screens/Settings/Debug/Debugging";
-import DebugDeviceIntentExecutor from "~/screens/Settings/Debug/Features/DeviceIntentExecutor";
-import DebugEnv from "~/screens/Settings/Debug/Configuration/DebugEnv";
-import DebugLargeScreenUpsell from "LLM/features/LargeScreenUpsell/Debug";
-import DebugFeatureFlags from "~/screens/FeatureFlagsSettings";
-import DebugFeatures from "~/screens/Settings/Debug/Features";
-import DebugFetchCustomImage, {
-  debugFetchCustomImageHeaderOptions,
-} from "~/screens/Settings/Debug/Features/FetchCustomImage";
-import DebugFirmwareUpdate from "~/screens/Settings/Debug/Features/FirmwareUpdate";
-import DebugGenerators from "~/screens/Settings/Debug/Generators";
-import DebugContentCards from "~/screens/Settings/Debug/ContentCards";
-import DebugHttpTransport from "~/screens/Settings/Debug/Connectivity/DebugHttpTransport";
-import DebugInformation from "~/screens/Settings/Debug/Information";
-import DebugInstallSetOfApps from "~/screens/Settings/Debug/Features/InstallSetOfApps";
-import DebugPerformance from "~/screens/Settings/Debug/Performance";
-import DebugLogs from "~/screens/Settings/Debug/Debugging/Logs";
-import DebugLottie from "~/screens/Settings/Debug/Features/Lottie";
-import DebugWallet40 from "~/screens/Settings/Debug/Debugging/Wallet40";
-import DebugContacts from "~/screens/Settings/Debug/Debugging/Contacts";
-import DebugDevTools from "LLM/features/DevTools/screens/DevToolsScreen";
-import DebugNetwork from "~/screens/Settings/Debug/Debugging/Network";
-import DebugCommandSender from "~/screens/Settings/Debug/Connectivity/CommandSender";
-import DebugPlayground from "~/screens/Settings/Debug/Playground";
-import DebugBluetoothAndLocationServices from "~/screens/Settings/Debug/Debugging/BluetoothAndLocationServices";
-import DebugSettings from "~/screens/Settings/Debug";
-import DebugAnalyticsConsentQA from "~/screens/Settings/Debug/AnalyticsConsentQA";
-import DebugNotificationsPromptQA from "~/screens/Settings/Debug/NotificationsPromptQA";
-import DebugSnackbars from "~/screens/Settings/Debug/Features/Snackbars";
-import DebugTransactionsAlerts from "~/screens/Settings/Debug/Features/TransactionsAlerts";
-import DebugStore from "~/screens/Settings/Debug/Debugging/Store";
-import DebugSwap from "~/screens/Settings/Debug/Features/Swap";
-import DebugVideos from "~/screens/Settings/Debug/Features/Videos";
-import TooltipDemo from "~/screens/Settings/Debug/Features/TooltipDemo";
-import DebugDeviceActionContentScreen from "~/screens/Settings/Debug/Features/DeviceIntentExecutor/DeviceActionContentScreen";
-import DebugInfoStateScreen from "~/screens/Settings/Debug/Features/DeviceIntentExecutor/InfoStateScreen";
-import DebugConnectDeviceScreen from "~/screens/Settings/Debug/Features/DeviceIntentExecutor/ConnectDeviceScreen";
-import DebugDeviceIntentExecutorContactsValidation from "~/screens/Settings/Debug/Features/DeviceIntentExecutor/ContactsValidationScreen";
-import DebugDeviceIntentExecutorInitialization from "~/screens/Settings/Debug/Features/DeviceIntentExecutor/InitializationScreen";
-import DebugInitializerStatesScreen from "~/screens/Settings/Debug/Features/DeviceIntentExecutor/InitializerStatesScreen";
-import DebugDeviceIntentExecutorOrchestration from "~/screens/Settings/Debug/Features/DeviceIntentExecutor/OrchestrationScreen";
-import Settings from "~/screens/Settings";
-import AccountsSettings from "~/screens/Settings/Accounts";
-import AboutSettings from "~/screens/Settings/About";
-import Resources from "~/screens/Settings/Resources";
-import GeneralSettings from "~/screens/Settings/General";
-import AnalyticsPreferencesSettings from "~/screens/Settings/AnalyticsPreferencesSettings";
-import CountervalueSettings from "~/screens/Settings/General/CountervalueSettings";
-import NotificationsSettings from "~/screens/Settings/Notifications";
-import HelpSettings from "~/screens/Settings/Help";
-import CurrenciesList from "~/screens/Settings/CryptoAssets/Currencies/CurrenciesList";
-import CurrencySettings from "~/screens/Settings/CryptoAssets/Currencies/CurrencySettings";
-import ExperimentalSettings from "~/screens/Settings/Experimental";
-import DeveloperSettings, {
-  DeveloperCustomManifest,
-  ExchangeDeveloperMode,
-} from "~/screens/Settings/Developer";
 import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
 import HelpButton from "~/screens/Settings/HelpButton";
-import OnboardingStepLanguage from "~/screens/Onboarding/steps/language";
-import { GenerateMockAccountSelectScreen } from "~/screens/Settings/Debug/Generators/GenerateMockAccountsSelect";
-import GenerateMockAccountsByType from "~/screens/Settings/Debug/Generators/GenerateMockAccountsByType";
+import CurrencySettings from "~/screens/Settings/CryptoAssets/Currencies/CurrencySettings";
 import { useNoNanoBuyNanoWallScreenOptions } from "~/context/NoNanoBuyNanoWall";
-import PostOnboardingDebugScreen from "~/screens/PostOnboarding/PostOnboardingDebugScreen";
 import { SettingsNavigatorStackParamList } from "./types/SettingsNavigator";
-import DebugTermsOfUse from "~/screens/Settings/Debug/Features/TermsOfUse";
-import CameraPermissions from "~/screens/Settings/Debug/Debugging/CameraPermissions";
-import BleEDevicePairingScreen from "~/screens/Settings/Debug/Features/BleDevicePairingScreen";
-import EditCurrencyUnits from "~/screens/Settings/CryptoAssets/Currencies/EditCurrencyUnits";
-import {
-  EmptyScreen,
-  MainTestScreen,
-  TestScreenWithDrawerForcingToBeOpened,
-  TestScreenWithDrawerRequestingToBeOpened,
-} from "LLM/components/QueuedDrawer/TestScreens";
-import { LargeMoverLandingPage } from "LLM/features/LandingPages/screens/LargeMoverLandingPage";
-import SwiperScreenDebug from "~/screens/Settings/Debug/Features/SwiperScreenDebug";
-import { DebugStorageMigration } from "~/screens/Settings/Debug/Debugging/StorageMigration";
-import CustomCALRefInput from "~/screens/Settings/Developer/CustomCALRefInput";
-import ModularDrawerScreenDebug from "LLM/features/ModularDrawer/Debug";
-import WalletV4TourScreenDebug from "LLM/features/WalletV4Tour/Debug";
-import ProductTourScreenDebug from "LLM/features/ProductTour/Debug";
-import Q2WalletV4TourScreenDebug from "LLM/features/Q2WalletV4Tour/Debug";
 import { UnmountOnBlur } from "./utils/UnmountOnBlur";
 
 const Stack = createNativeStackNavigator<SettingsNavigatorStackParamList>();
@@ -111,7 +26,7 @@ export default function SettingsNavigator() {
     <Stack.Navigator screenOptions={stackNavConfig}>
       <Stack.Screen
         name={ScreenName.SettingsScreen}
-        component={Settings}
+        getComponent={() => require("~/screens/Settings").default}
         options={{
           title: t("settings.header"),
           headerRight: () => <HelpButton />,
@@ -119,14 +34,14 @@ export default function SettingsNavigator() {
       />
       <Stack.Screen
         name={ScreenName.CountervalueSettings}
-        component={CountervalueSettings}
+        getComponent={() => require("~/screens/Settings/General/CountervalueSettings").default}
         options={{
           title: t("settings.display.counterValue"),
         }}
       />
       <Stack.Screen
         name={ScreenName.GeneralSettings}
-        component={GeneralSettings}
+        getComponent={() => require("~/screens/Settings/General").default}
         layout={unmountOnBlur}
         options={{
           title: t("settings.display.title"),
@@ -134,7 +49,7 @@ export default function SettingsNavigator() {
       />
       <Stack.Screen
         name={ScreenName.AnalyticsPreferencesSettings}
-        component={AnalyticsPreferencesSettings}
+        getComponent={() => require("~/screens/Settings/AnalyticsPreferencesSettings").default}
         options={{
           title: "",
           headerStyle: {
@@ -144,40 +59,42 @@ export default function SettingsNavigator() {
       />
       <Stack.Screen
         name={ScreenName.AccountsSettings}
-        component={AccountsSettings}
+        getComponent={() => require("~/screens/Settings/Accounts").default}
         options={{
           title: t("settings.accounts.title"),
         }}
       />
       <Stack.Screen
         name={ScreenName.AboutSettings}
-        component={AboutSettings}
+        getComponent={() => require("~/screens/Settings/About").default}
         options={{
           title: t("settings.about.title"),
         }}
       />
       <Stack.Screen
         name={ScreenName.NotificationsSettings}
-        component={NotificationsSettings}
+        getComponent={() => require("~/screens/Settings/Notifications").default}
         options={{
           title: t("settings.notifications.title"),
         }}
       />
       <Stack.Screen
         name={ScreenName.HelpSettings}
-        component={HelpSettings}
+        getComponent={() => require("~/screens/Settings/Help").default}
         options={{
           title: t("settings.help.header"),
         }}
       />
       <Stack.Screen
         name={ScreenName.Resources}
-        component={Resources}
+        getComponent={() => require("~/screens/Settings/Resources").default}
         options={{ title: t("settings.resources") }}
       />
       <Stack.Screen
         name={ScreenName.CryptoAssetsSettings}
-        component={CurrenciesList}
+        getComponent={() =>
+          require("~/screens/Settings/CryptoAssets/Currencies/CurrenciesList").default
+        }
         options={{ title: t("settings.accounts.cryptoAssets.header") }}
       />
       <Stack.Screen
@@ -192,7 +109,9 @@ export default function SettingsNavigator() {
 
       <Stack.Screen
         name={ScreenName.EditCurrencyUnits}
-        component={EditCurrencyUnits}
+        getComponent={() =>
+          require("~/screens/Settings/CryptoAssets/Currencies/EditCurrencyUnits").default
+        }
         options={{
           title: t("account.settings.accountUnits.title"),
         }}
@@ -200,376 +119,414 @@ export default function SettingsNavigator() {
 
       <Stack.Screen
         name={ScreenName.ExperimentalSettings}
-        component={ExperimentalSettings}
+        getComponent={() => require("~/screens/Settings/Experimental").default}
         options={{
           title: t("settings.experimental.title"),
         }}
       />
       <Stack.Screen
         name={ScreenName.DeveloperSettings}
-        component={DeveloperSettings}
+        getComponent={() => require("~/screens/Settings/Developer").default}
         options={{
           title: t("settings.developer.title"),
         }}
       />
       <Stack.Screen
         name={ScreenName.DeveloperCustomManifest}
-        component={DeveloperCustomManifest}
+        getComponent={() => require("~/screens/Settings/Developer").DeveloperCustomManifest}
         options={{
           title: t("settings.developer.customManifest.title"),
-          // headerTitleStyle width not supported in native-stack; rely on default layout
         }}
       />
       <Stack.Screen
         name={ScreenName.ExchangeDeveloperMode}
-        component={ExchangeDeveloperMode}
+        getComponent={() => require("~/screens/Settings/Developer").ExchangeDeveloperMode}
         options={{
           title: t("settings.developer.exchangeDeveloperMode.title"),
-          // headerTitleStyle width not supported in native-stack; rely on default layout
         }}
       />
       <Stack.Screen
         name={ScreenName.CustomCALRefInput}
-        component={CustomCALRefInput}
+        getComponent={() => require("~/screens/Settings/Developer/CustomCALRefInput").default}
         options={{
           title: t("settings.developer.customCALRef.title"),
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugSettings}
-        component={DebugSettings}
+        getComponent={() => require("~/screens/Settings/Debug").default}
         options={{
           title: "Debug",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugAnalyticsConsentQA}
-        component={DebugAnalyticsConsentQA}
+        getComponent={() => require("~/screens/Settings/Debug/AnalyticsConsentQA").default}
         options={{
           title: "Analytics consent QA",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugNotificationsPromptQA}
-        component={DebugNotificationsPromptQA}
+        getComponent={() => require("~/screens/Settings/Debug/NotificationsPromptQA").default}
         options={{
           title: "Notifications prompt — QA",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugNetwork}
-        component={DebugNetwork}
+        getComponent={() => require("~/screens/Settings/Debug/Debugging/Network").default}
         options={{
           title: "Network",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugConfiguration}
-        component={DebugConfiguration}
+        getComponent={() => require("~/screens/Settings/Debug/Configuration").default}
         options={{
           title: "Configuration",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugDebugging}
-        component={DebugDebugging}
+        getComponent={() => require("~/screens/Settings/Debug/Debugging").default}
         options={{
           title: "Debugging",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugInformation}
-        component={DebugInformation}
+        getComponent={() => require("~/screens/Settings/Debug/Information").default}
         options={{
           title: "Information",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugGenerators}
-        component={DebugGenerators}
+        getComponent={() => require("~/screens/Settings/Debug/Generators").default}
         options={{
           title: "Generators and Destructors",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugContentCards}
-        component={DebugContentCards}
+        getComponent={() => require("~/screens/Settings/Debug/ContentCards").default}
         options={{
           title: t("settings.debug.contentCards.title"),
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugConnectivity}
-        component={DebugConnectivity}
-        options={connectivityHeaderOptions}
+        getComponent={() => require("~/screens/Settings/Debug/Connectivity").default}
+        options={() => require("~/screens/Settings/Debug/Connectivity").connectivityHeaderOptions}
       />
       <Stack.Screen
         name={ScreenName.DebugFeatures}
-        component={DebugFeatures}
+        getComponent={() => require("~/screens/Settings/Debug/Features").default}
         options={{
           title: "Features",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugDeviceIntentExecutor}
-        component={DebugDeviceIntentExecutor}
+        getComponent={() =>
+          require("~/screens/Settings/Debug/Features/DeviceIntentExecutor").default
+        }
         options={{
           title: "Device Intent Executor",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugDeviceIntentExecutorContent}
-        component={DebugDeviceActionContentScreen}
+        getComponent={() =>
+          require("~/screens/Settings/Debug/Features/DeviceIntentExecutor/DeviceActionContentScreen")
+            .default
+        }
         options={{
           title: "DIE Device Action Content",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugDeviceIntentExecutorInfoState}
-        component={DebugInfoStateScreen}
+        getComponent={() =>
+          require("~/screens/Settings/Debug/Features/DeviceIntentExecutor/InfoStateScreen").default
+        }
         options={{
           title: "DIE Info State",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugDeviceIntentExecutorConnectDevice}
-        component={DebugConnectDeviceScreen}
+        getComponent={() =>
+          require("~/screens/Settings/Debug/Features/DeviceIntentExecutor/ConnectDeviceScreen")
+            .default
+        }
         options={{
           title: "DIE Connect Device",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugDeviceIntentExecutorContactsValidation}
-        component={DebugDeviceIntentExecutorContactsValidation}
+        getComponent={() =>
+          require("~/screens/Settings/Debug/Features/DeviceIntentExecutor/ContactsValidationScreen")
+            .default
+        }
         options={{
           title: "DIE Contacts validation",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugDeviceIntentExecutorInitialization}
-        component={DebugDeviceIntentExecutorInitialization}
+        getComponent={() =>
+          require("~/screens/Settings/Debug/Features/DeviceIntentExecutor/InitializationScreen")
+            .default
+        }
         options={{
           title: "DIE Initialization",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugDeviceIntentExecutorInitializerStates}
-        component={DebugInitializerStatesScreen}
+        getComponent={() =>
+          require("~/screens/Settings/Debug/Features/DeviceIntentExecutor/InitializerStatesScreen")
+            .default
+        }
         options={{
           title: "DIE Initializer States",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugDeviceIntentExecutorOrchestration}
-        component={DebugDeviceIntentExecutorOrchestration}
+        getComponent={() =>
+          require("~/screens/Settings/Debug/Features/DeviceIntentExecutor/OrchestrationScreen")
+            .default
+        }
         options={{
           title: "DIE Orchestration",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugFeatureFlags}
-        component={DebugFeatureFlags}
+        getComponent={() => require("~/screens/FeatureFlagsSettings").default}
         options={{
           title: "Feature Flags",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugLargeScreenUpsell}
-        component={DebugLargeScreenUpsell}
+        getComponent={() => require("LLM/features/LargeScreenUpsell/Debug").default}
         options={{
           title: "Large-screen upsell",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugInstallSetOfApps}
-        component={DebugInstallSetOfApps}
+        getComponent={() => require("~/screens/Settings/Debug/Features/InstallSetOfApps").default}
         options={{
           title: "Install set of apps",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugMockGenerateAccounts}
-        component={GenerateMockAccountSelectScreen}
+        getComponent={() =>
+          require("~/screens/Settings/Debug/Generators/GenerateMockAccountsSelect")
+            .GenerateMockAccountSelectScreen
+        }
         options={{
           title: "Generate mock accounts",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugMockGenerateAccountsByType}
-        component={GenerateMockAccountsByType}
+        getComponent={() =>
+          require("~/screens/Settings/Debug/Generators/GenerateMockAccountsByType").default
+        }
         options={{
           title: "Generate accounts by type",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugPlayground}
-        component={DebugPlayground}
+        getComponent={() => require("~/screens/Settings/Debug/Playground").default}
         options={{
           title: "Playground",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugWallet40}
-        component={DebugWallet40}
+        getComponent={() => require("~/screens/Settings/Debug/Debugging/Wallet40").default}
         options={{
           title: "Wallet 4.0",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugContacts}
-        component={DebugContacts}
+        getComponent={() => require("~/screens/Settings/Debug/Debugging/Contacts").default}
         options={{
           title: "Contacts",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugDevTools}
-        component={DebugDevTools}
+        getComponent={() => require("LLM/features/DevTools/screens/DevToolsScreen").default}
         options={{
           headerShown: false,
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugBluetoothAndLocationServices}
-        component={DebugBluetoothAndLocationServices}
+        getComponent={() =>
+          require("~/screens/Settings/Debug/Debugging/BluetoothAndLocationServices").default
+        }
         options={{
           title: "Bluetooth and location services",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugStorageMigration}
-        component={DebugStorageMigration}
+        getComponent={() =>
+          require("~/screens/Settings/Debug/Debugging/StorageMigration").DebugStorageMigration
+        }
         options={{
           title: "Storage migration",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugSwap}
-        component={DebugSwap}
+        getComponent={() => require("~/screens/Settings/Debug/Features/Swap").default}
         options={{
           title: "Swap",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugBLEDevicePairing}
-        component={BleEDevicePairingScreen}
+        getComponent={() =>
+          require("~/screens/Settings/Debug/Features/BleDevicePairingScreen").default
+        }
         options={{
           title: "Debug Ble Pairing Flow",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugCommandSender}
-        component={DebugCommandSender}
+        getComponent={() => require("~/screens/Settings/Debug/Connectivity/CommandSender").default}
         options={{
           title: "Command Sender",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugCrash}
-        component={DebugCrash}
+        getComponent={() => require("~/screens/Settings/Debug/Debugging/Crashes").default}
         options={{
           title: "Errors and crashes",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugStore}
-        component={DebugStore}
+        getComponent={() => require("~/screens/Settings/Debug/Debugging/Store").default}
         options={{
           title: "Application state",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugEnv}
-        component={DebugEnv}
+        getComponent={() => require("~/screens/Settings/Debug/Configuration/DebugEnv").default}
         options={{
           title: "Environment Variables",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugHttpTransport}
-        component={DebugHttpTransport}
+        getComponent={() =>
+          require("~/screens/Settings/Debug/Connectivity/DebugHttpTransport").default
+        }
         options={{
           title: "HTTP Transport",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugLogs}
-        component={DebugLogs}
+        getComponent={() => require("~/screens/Settings/Debug/Debugging/Logs").default}
         options={{
           title: "Logs",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugLottie}
-        component={DebugLottie}
+        getComponent={() => require("~/screens/Settings/Debug/Features/Lottie").default}
         options={{
           title: "Debug Lottie",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugVideos}
-        component={DebugVideos}
+        getComponent={() => require("~/screens/Settings/Debug/Features/Videos").default}
         options={{
           title: "Debug Videos",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugTooltip}
-        component={TooltipDemo}
+        getComponent={() => require("~/screens/Settings/Debug/Features/TooltipDemo").default}
         options={{
           title: "Debug Tooltip",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugFetchCustomImage}
-        component={DebugFetchCustomImage}
-        options={debugFetchCustomImageHeaderOptions}
+        getComponent={() => require("~/screens/Settings/Debug/Features/FetchCustomImage").default}
+        options={() =>
+          require("~/screens/Settings/Debug/Features/FetchCustomImage")
+            .debugFetchCustomImageHeaderOptions
+        }
       />
       <Stack.Screen
         name={ScreenName.DebugFirmwareUpdate}
-        component={DebugFirmwareUpdate}
+        getComponent={() => require("~/screens/Settings/Debug/Features/FirmwareUpdate").default}
         options={{
           title: "Debug Firmware update",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugCustomImageGraphics}
-        component={DebugCustomImageGraphics}
+        getComponent={() =>
+          require("~/screens/Settings/Debug/Features/CustomImageGraphics").default
+        }
         options={{
           title: "Custom image graphics",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugSnackbars}
-        component={DebugSnackbars}
+        getComponent={() => require("~/screens/Settings/Debug/Features/Snackbars").default}
         options={{
           title: "Debug snackbars",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugTransactionsAlerts}
-        component={DebugTransactionsAlerts}
+        getComponent={() => require("~/screens/Settings/Debug/Features/TransactionsAlerts").default}
         options={{
           title: "Debug transactions alerts",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugTermsOfUse}
-        component={DebugTermsOfUse}
+        getComponent={() => require("~/screens/Settings/Debug/Features/TermsOfUse").default}
         options={{
           title: "Debug Terms of Use",
         }}
       />
       <Stack.Screen
         name={ScreenName.BenchmarkQRStream}
-        component={DebugBenchmarkQRStream}
+        getComponent={() => require("~/screens/Settings/Debug/Broken/BenchmarkQRStream").default}
         options={{
           title: "Benchmark QRStream",
         }}
       />
       <Stack.Screen
         name={ScreenName.OnboardingLanguage}
-        component={OnboardingStepLanguage}
+        getComponent={() => require("~/screens/Onboarding/steps/language").default}
         options={{
           presentation: "transparentModal",
           animation: "slide_from_bottom",
@@ -579,54 +536,64 @@ export default function SettingsNavigator() {
       />
       <Stack.Screen
         name={ScreenName.PostOnboardingDebugScreen}
-        component={PostOnboardingDebugScreen}
+        getComponent={() => require("~/screens/PostOnboarding/PostOnboardingDebugScreen").default}
       />
-      <Stack.Screen name={ScreenName.DebugCameraPermissions} component={CameraPermissions} />
+      <Stack.Screen
+        name={ScreenName.DebugCameraPermissions}
+        getComponent={() => require("~/screens/Settings/Debug/Debugging/CameraPermissions").default}
+      />
       <Stack.Screen
         name={ScreenName.DebugPerformance}
-        component={DebugPerformance}
+        getComponent={() => require("~/screens/Settings/Debug/Performance").default}
         options={{
           title: "Performance",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugQueuedDrawers}
-        component={MainTestScreen}
+        getComponent={() => require("LLM/components/QueuedDrawer/TestScreens").MainTestScreen}
         options={{
           title: "QueuedDrawers",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugQueuedDrawerScreen0}
-        component={EmptyScreen}
+        getComponent={() => require("LLM/components/QueuedDrawer/TestScreens").EmptyScreen}
         options={{
           title: "Empty screen",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugQueuedDrawerScreen1}
-        component={TestScreenWithDrawerRequestingToBeOpened}
+        getComponent={() =>
+          require("LLM/components/QueuedDrawer/TestScreens")
+            .TestScreenWithDrawerRequestingToBeOpened
+        }
         options={{
           title: "QueuedDrawers (Auto open)",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugQueuedDrawerScreen2}
-        component={TestScreenWithDrawerForcingToBeOpened}
+        getComponent={() =>
+          require("LLM/components/QueuedDrawer/TestScreens").TestScreenWithDrawerForcingToBeOpened
+        }
         options={{
           title: "QueuedDrawers (Auto force open)",
         }}
       />
       <Stack.Screen
         name={ScreenName.LargeMoverLandingPage}
-        component={LargeMoverLandingPage}
+        getComponent={() =>
+          require("LLM/features/LandingPages/screens/LargeMoverLandingPage").LargeMoverLandingPage
+        }
         options={{
           headerShown: false,
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugSwipe}
-        component={SwiperScreenDebug}
+        getComponent={() => require("~/screens/Settings/Debug/Features/SwiperScreenDebug").default}
         options={{
           title: "Swiper Screen Debug",
         }}
@@ -634,28 +601,28 @@ export default function SettingsNavigator() {
 
       <Stack.Screen
         name={ScreenName.DebugModularAssetDrawer}
-        component={ModularDrawerScreenDebug}
+        getComponent={() => require("LLM/features/ModularDrawer/Debug").default}
         options={{
           title: "ModularAssetDrawer Screen Debug",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugWalletV4Tour}
-        component={WalletV4TourScreenDebug}
+        getComponent={() => require("LLM/features/WalletV4Tour/Debug").default}
         options={{
           title: "Wallet V4 Tour",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugProductTour}
-        component={ProductTourScreenDebug}
+        getComponent={() => require("LLM/features/ProductTour/Debug").default}
         options={{
           title: "Product Tour",
         }}
       />
       <Stack.Screen
         name={ScreenName.DebugQ2WalletV4Tour}
-        component={Q2WalletV4TourScreenDebug}
+        getComponent={() => require("LLM/features/Q2WalletV4Tour/Debug").default}
         options={{
           title: "Q2 Wallet V4 Tour",
         }}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
@@ -5,7 +5,6 @@ import { useTheme } from "styled-components/native";
 import { ScreenName } from "~/const";
 import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
 import HelpButton from "~/screens/Settings/HelpButton";
-import CurrencySettings from "~/screens/Settings/CryptoAssets/Currencies/CurrencySettings";
 import { useNoNanoBuyNanoWallScreenOptions } from "~/context/NoNanoBuyNanoWall";
 import { SettingsNavigatorStackParamList } from "./types/SettingsNavigator";
 import { UnmountOnBlur } from "./utils/UnmountOnBlur";
@@ -99,7 +98,9 @@ export default function SettingsNavigator() {
       />
       <Stack.Screen
         name={ScreenName.CurrencySettings}
-        component={CurrencySettings}
+        getComponent={() =>
+          require("~/screens/Settings/CryptoAssets/Currencies/CurrencySettings").default
+        }
         options={({ route }) => ({
           title: route.params?.headerTitle,
           headerRight: undefined,

--- a/apps/ledger-live-mobile/src/components/RootNavigator/index.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/index.tsx
@@ -4,11 +4,11 @@ import Config from "react-native-config";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { NavigatorName } from "~/const";
 import { hasCompletedOnboardingSelector } from "~/reducers/settings";
-import BaseNavigator from "./BaseNavigator";
 import { RootStackParamList } from "./types/RootNavigator";
 import { AnalyticsContextProvider } from "~/analytics/AnalyticsContext";
 import { StartupTimeMarker } from "../../StartupTimeMarker";
 import { useSuppressQ2TourForNewUsers } from "LLM/features/Q2WalletV4Tour/hooks/useSuppressQ2TourForNewUsers";
+import { lazyScreen } from "./lazyScreen";
 
 export default function RootNavigator() {
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
@@ -24,18 +24,37 @@ export default function RootNavigator() {
           }}
         >
           {goToOnboarding ? (
-            <Stack.Screen
-              name={NavigatorName.BaseOnboarding}
-              getComponent={() => require("./BaseOnboardingNavigator").default}
-            />
-          ) : null}
-          <Stack.Screen name={NavigatorName.Base} component={BaseNavigator} />
-          {hasCompletedOnboarding ? (
-            <Stack.Screen
-              name={NavigatorName.BaseOnboarding}
-              getComponent={() => require("./BaseOnboardingNavigator").default}
-            />
-          ) : null}
+            <>
+              <Stack.Screen
+                name={NavigatorName.BaseOnboarding}
+                component={
+                  (
+                    require("./BaseOnboardingNavigator") as typeof import("./BaseOnboardingNavigator")
+                  ).default
+                }
+              />
+              <Stack.Screen
+                name={NavigatorName.Base}
+                getComponent={lazyScreen(
+                  () => require("./BaseNavigator") as typeof import("./BaseNavigator"),
+                )}
+              />
+            </>
+          ) : (
+            <>
+              <Stack.Screen
+                name={NavigatorName.Base}
+                component={(require("./BaseNavigator") as typeof import("./BaseNavigator")).default}
+              />
+              <Stack.Screen
+                name={NavigatorName.BaseOnboarding}
+                getComponent={lazyScreen(
+                  () =>
+                    require("./BaseOnboardingNavigator") as typeof import("./BaseOnboardingNavigator"),
+                )}
+              />
+            </>
+          )}
         </Stack.Navigator>
       </AnalyticsContextProvider>
     </StartupTimeMarker>

--- a/apps/ledger-live-mobile/src/components/RootNavigator/index.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/index.tsx
@@ -5,7 +5,6 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { NavigatorName } from "~/const";
 import { hasCompletedOnboardingSelector } from "~/reducers/settings";
 import BaseNavigator from "./BaseNavigator";
-import BaseOnboardingNavigator from "./BaseOnboardingNavigator";
 import { RootStackParamList } from "./types/RootNavigator";
 import { AnalyticsContextProvider } from "~/analytics/AnalyticsContext";
 import { StartupTimeMarker } from "../../StartupTimeMarker";
@@ -25,11 +24,17 @@ export default function RootNavigator() {
           }}
         >
           {goToOnboarding ? (
-            <Stack.Screen name={NavigatorName.BaseOnboarding} component={BaseOnboardingNavigator} />
+            <Stack.Screen
+              name={NavigatorName.BaseOnboarding}
+              getComponent={() => require("./BaseOnboardingNavigator").default}
+            />
           ) : null}
           <Stack.Screen name={NavigatorName.Base} component={BaseNavigator} />
           {hasCompletedOnboarding ? (
-            <Stack.Screen name={NavigatorName.BaseOnboarding} component={BaseOnboardingNavigator} />
+            <Stack.Screen
+              name={NavigatorName.BaseOnboarding}
+              getComponent={() => require("./BaseOnboardingNavigator").default}
+            />
           ) : null}
         </Stack.Navigator>
       </AnalyticsContextProvider>

--- a/apps/ledger-live-mobile/src/components/RootNavigator/lazyScreen.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/lazyScreen.ts
@@ -1,0 +1,26 @@
+import type { ComponentType } from "react";
+
+// oxlint-disable-next-line typescript/no-explicit-any
+type AnyComponent = ComponentType<any>;
+
+type ModuleWithDefault<T extends AnyComponent> = { default: T };
+
+export function lazyScreen<T extends AnyComponent>(load: () => ModuleWithDefault<T>): () => T {
+  return () => load().default;
+}
+
+export function lazyNamed<T extends AnyComponent>(load: () => T): () => T {
+  return load;
+}
+
+export function preloadBaseNavigator(): void {
+  void (require("./BaseNavigator") as typeof import("./BaseNavigator"));
+}
+
+export function preloadRootNavigator(): void {
+  void (require("./index") as typeof import("./index"));
+}
+
+export function preloadSettingsNavigator(): void {
+  void (require("./SettingsNavigator") as typeof import("./SettingsNavigator"));
+}

--- a/apps/ledger-live-mobile/src/components/WebRecoverPlayer/index.tsx
+++ b/apps/ledger-live-mobile/src/components/WebRecoverPlayer/index.tsx
@@ -86,6 +86,7 @@ const WebRecoverPlayer = ({ manifest, inputs }: Props) => {
   }, [headerShown, manifest, navigation, webviewState]);
 
   const handleBypassOnboarding = useCallback(() => {
+    require("~/components/RootNavigator/lazyScreen").preloadBaseNavigator();
     dispatch(completeOnboarding());
     dispatch(setReadOnlyMode(false));
     dispatch(setHasOrderedNano(false));

--- a/apps/ledger-live-mobile/src/context/LedgerStore.tsx
+++ b/apps/ledger-live-mobile/src/context/LedgerStore.tsx
@@ -55,6 +55,8 @@ import { initHistory } from "~/reducers/history";
 import { restoreTokensToCache, parsePersistedCAL } from "@domain/api-currency-token";
 import { setAllOverrides, setBannerVisible, type PartialFeatures } from "@shared/feature-flags";
 import { initIdentities } from "../helpers/identities";
+import { preloadBaseNavigator, preloadRootNavigator } from "~/components/RootNavigator/lazyScreen";
+import Config from "react-native-config";
 
 interface Props {
   onInitFinished: () => void;
@@ -93,6 +95,13 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
     try {
       const readStorageStart = Date.now();
       mmkvStorageWrapper.monitor(true);
+      const settingsPromise = retry(getSettings, MAX_RETRIES, RETRY_DELAY);
+      void settingsPromise.then(settings => {
+        if (settings.hasCompletedOnboarding || Config.SKIP_ONBOARDING) {
+          preloadRootNavigator();
+          preloadBaseNavigator();
+        }
+      });
       const [
         bleData,
         persistedKnownDevices,
@@ -117,7 +126,7 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
       ] = await Promise.all([
         retry(getBle, MAX_RETRIES, RETRY_DELAY),
         retry(getKnownDevices, MAX_RETRIES, RETRY_DELAY),
-        retry(getSettings, MAX_RETRIES, RETRY_DELAY),
+        settingsPromise,
         retry(getAccounts, MAX_RETRIES, RETRY_DELAY),
         retry(getPostOnboardingState, MAX_RETRIES, RETRY_DELAY),
         retry(getLargeScreenUpsellModalState, MAX_RETRIES, RETRY_DELAY),

--- a/apps/ledger-live-mobile/src/context/NoNanoBuyNanoWall.tsx
+++ b/apps/ledger-live-mobile/src/context/NoNanoBuyNanoWall.tsx
@@ -1,12 +1,10 @@
 import { useSelector } from "~/context/hooks";
 import { NativeStackNavigationOptions } from "@react-navigation/native-stack";
-import BuyDeviceNavigator from "~/components/RootNavigator/BuyDeviceNavigator";
 import {
   hasCompletedOnboardingSelector,
   hasOrderedNanoSelector,
   readOnlyModeEnabledSelector,
 } from "~/reducers/settings";
-import PostBuyDeviceSetupNanoWallScreen from "~/screens/PostBuyDeviceSetupNanoWallScreen";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 
 /**
@@ -33,7 +31,7 @@ export const useNoNanoBuyNanoWallScreenOptions = ():
 
   if (!hasOrderedNano) {
     return {
-      component: BuyDeviceNavigator,
+      component: require("~/components/RootNavigator/BuyDeviceNavigator").default,
       options: {
         headerShown: false,
         presentation: "transparentModal",
@@ -43,7 +41,7 @@ export const useNoNanoBuyNanoWallScreenOptions = ():
   }
 
   return {
-    component: PostBuyDeviceSetupNanoWallScreen,
+    component: require("~/screens/PostBuyDeviceSetupNanoWallScreen").default,
     options: {
       headerShown: false,
       presentation: "transparentModal",

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/__tests__/useTopBarViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/__tests__/useTopBarViewModel.test.ts
@@ -16,6 +16,10 @@ jest.mock("@react-navigation/native", () => ({
 
 jest.mock("../hooks/useSyncIndicator");
 
+jest.mock("~/components/RootNavigator/lazyScreen", () => ({
+  preloadSettingsNavigator: jest.fn(),
+}));
+
 const mockedUseSyncIndicator = jest.mocked(useSyncIndicator);
 
 const defaultSyncState = {

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/useTopBarViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/useTopBarViewModel.ts
@@ -12,6 +12,7 @@ import { useFeature, useWalletFeaturesConfig } from "@features/platform-feature-
 import { useRebornFlow } from "LLM/features/Reborn/hooks/useRebornFlow";
 import { useSyncIndicator } from "./hooks/useSyncIndicator";
 import { usePortfolioBalance } from "LLM/hooks/usePortfolioBalance";
+import { preloadSettingsNavigator } from "~/components/RootNavigator/lazyScreen";
 
 const BUTTON_CLICKED_EVENT = "button_clicked";
 
@@ -108,6 +109,7 @@ export function useTopBarViewModel(
 
   const onSettingsPress = useCallback(() => {
     track(BUTTON_CLICKED_EVENT, { button: "Settings", page });
+    preloadSettingsNavigator();
     navigation.navigate(NavigatorName.Settings);
   }, [navigation, page]);
 

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/Header/__tests__/useMyWalletHeaderViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/Header/__tests__/useMyWalletHeaderViewModel.test.ts
@@ -20,6 +20,10 @@ jest.mock("~/dynamicContent/useDynamicContent", () => ({
   default: () => ({ notificationCards: mockNotificationCards }),
 }));
 
+jest.mock("~/components/RootNavigator/lazyScreen", () => ({
+  preloadSettingsNavigator: jest.fn(),
+}));
+
 describe("useMyWalletHeaderViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/Header/useMyWalletHeaderViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/Header/useMyWalletHeaderViewModel.ts
@@ -5,6 +5,7 @@ import { NavigatorName, ScreenName } from "~/const";
 import { track } from "~/analytics";
 import { MY_WALLET_TRACKING_PAGE_NAME } from "../../constants";
 import useDynamicContent from "~/dynamicContent/useDynamicContent";
+import { preloadSettingsNavigator } from "~/components/RootNavigator/lazyScreen";
 
 export function useMyWalletHeaderViewModel() {
   const navigation =
@@ -29,6 +30,7 @@ export function useMyWalletHeaderViewModel() {
 
   const onSettingsPress = useCallback(() => {
     track("button_clicked", { button: "Settings", page: MY_WALLET_TRACKING_PAGE_NAME });
+    preloadSettingsNavigator();
     navigation.navigate(NavigatorName.Settings);
   }, [navigation]);
 

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsOptIn/hooks/useCompleteLazyOnboarding.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsOptIn/hooks/useCompleteLazyOnboarding.ts
@@ -40,6 +40,7 @@ export function useCompleteLazyOnboarding() {
           },
         };
 
+      require("~/components/RootNavigator/lazyScreen").preloadBaseNavigator();
       dispatch(completeOnboarding());
       dispatch(setOnboardingHasDevice(false));
       dispatch(setReadOnlyMode(true));

--- a/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/components/TwoStepSyncOnboardingCompanion/useTwoStepSyncOnboardingCompanionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/components/TwoStepSyncOnboardingCompanion/useTwoStepSyncOnboardingCompanionViewModel.ts
@@ -63,6 +63,7 @@ export const useTwoStepSyncOnboardingCompanionViewModel = ({
   const handleOnboardingDoneState = useCallback(() => {
     dispatchRedux(setReadOnlyMode(false));
     dispatchRedux(setHasOrderedNano(false));
+    require("~/components/RootNavigator/lazyScreen").preloadBaseNavigator();
     dispatchRedux(completeOnboarding());
   }, [dispatchRedux]);
 

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/Activation/ActivationLoading.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/Activation/ActivationLoading.tsx
@@ -41,6 +41,7 @@ export function ActivationLoading({ route }: Props) {
 
   useEffect(() => {
     if (!hasCompletedOnboarding && onboardingType !== OnboardingType.setupNew) {
+      require("~/components/RootNavigator/lazyScreen").preloadBaseNavigator();
       dispatch(completeOnboarding());
     }
     dispatch(setOnboardingHasDevice(true));

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/PairNew.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/PairNew.tsx
@@ -112,6 +112,7 @@ export default memo(function () {
     if (!hasCompletedOnboarding) {
       dispatch(setOnboardingHasDevice(true));
     }
+    require("~/components/RootNavigator/lazyScreen").preloadBaseNavigator();
     dispatch(completeOnboarding());
 
     const parentNav =

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/protectFlow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/protectFlow.tsx
@@ -60,6 +60,7 @@ function OnboardingStepProtectFlow({ navigation, route }: NavigationProps) {
   );
 
   const onFinish = useCallback(() => {
+    require("~/components/RootNavigator/lazyScreen").preloadBaseNavigator();
     dispatch(completeOnboarding());
 
     if (protectFeature?.enabled && (lastConnectedDevice || !hasCompletedOnboarding)) {

--- a/apps/ledger-live-mobile/src/screens/PurchaseDevice/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PurchaseDevice/index.tsx
@@ -53,6 +53,7 @@ const PurchaseDevice = () => {
     (data: PurchaseMessage) => {
       if (data.type === "ledgerLiveOrderSuccess") {
         dispatch(setReadOnlyMode(true));
+        require("~/components/RootNavigator/lazyScreen").preloadBaseNavigator();
         dispatch(completeOnboarding());
       }
     },

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/CompletionScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/CompletionScreen.tsx
@@ -83,6 +83,7 @@ const CompletionScreen = ({ route }: Props) => {
   );
 
   useEffect(() => {
+    require("~/components/RootNavigator/lazyScreen").preloadBaseNavigator();
     if (!hasCompletedOnboarding) {
       dispatch(setOnboardingHasDevice(true));
     }


### PR DESCRIPTION
### 📝 Description

**Problem:** at launch the app loads almost every screen, even ones you never open. Startup and the first Settings tap are slower than they need to be.

**Change:** only load a screen when you open it (`getComponent` + `require`). Home (Main / Base) still loads at start, on purpose.

Mobile-only spike. No changeset. No public API change.

### 📦 Dogfood builds

Two production builds. Install **both** if you want an A/B. Artifacts are on each run (ipa / apk).

| | What it is | SHA | Android | iOS |
|---|---|---|---|---|
| **Baseline** | First getComponent POC only: unused Base screens, Settings screens, Swap/Earn/Pay/Card tabs. Home still eager. | `7d8b34aee40` | [33011512760](https://github.com/LedgerHQ/ledger-live-build/actions/runs/33011512760) | [33011516412](https://github.com/LedgerHQ/ledger-live-build/actions/runs/33011516412) |
| **Latest** | Baseline **plus** lazy unused parent navigators (onboarding vs Base by role), Accounts/Asset JS off Home, CurrencySettings off first Settings open, Settings preload on gear, Swap tab chrome off Portfolio. | `11bcc84489f` | [33056585484](https://github.com/LedgerHQ/ledger-live-build/actions/runs/33056585484) | [33056588240](https://github.com/LedgerHQ/ledger-live-build/actions/runs/33056588240) |

- **Baseline** — compare against this. iOS + Android already green.
- **Latest** — current HEAD. iOS is ready (`ledgerlivemobile-4.17.0-sha.11bcc844.ipa`). Android still running.

### ⚠️ Caveat

This is fully vibe-coded. Treat it as a spike, not something to merge as-is.

The navigator wiring is rough, we can pick screens more carefully, and we can measure better. The numbers below are still enough to say what works and what to try next.

https://github.com/user-attachments/assets/f3cd8a50-c48e-40ef-930c-f43e25fb9cdb

### 📊 Results

iPhone 16 Pro, Metro debug, 3 runs. Times in ms. Bold = average. Compare **deltas**, not raw times (settle includes a 500 ms quiet window). These numbers are the **baseline** POC (`7d8b34a`), not Latest.

#### Startup (Settings → Debug → Performance)

App becomes usable **~470 ms sooner**. `After js` does not move; the win is splash / App started.

| | After js | Splash faded | App started |
|---|---|---|---|
| WITHOUT | 508 / 518 / 506 → **511** | 2688 / 2725 / 2636 → **2683** | 3101 / 3138 / 3045 → **3095** |
| WITH | 594 / 497 / 573 → **555** | 2482 / 2407 / 2581 → **2490** | 2590 / 2587 / 2695 → **2624** |
| delta | +44 (noise) | **−193** | **−471** |

#### Opening a screen (`press --settle`)

First Settings tap is **~360 ms faster**. Swap / Earn are webviews, so this does not help them. Inner screens are already as fast as the animation.

| | WITHOUT | WITH | delta |
|---|---|---|---|
| Settings (first open) | 1617 / 1613 / 1603 → **1611** | 1252 / 1246 / 1255 → **1251** | **−360** |
| Accounts (inner) | 1088 | 1116 | noise |
| Debug | 1147 | 1166 | noise |
| Swap (first open) | 954 / 1874 | 1002 / 1861 | webview noise |
| Swap (second open) | 682 | 695 | same |
| Earn (first open) | 1985 | 2027 | live-app, same |

### Leads

1. Keep this for heavy native screens (Settings and similar). That is the UX win.
2. Do not expect the same gain on Swap / Earn (they wait on a webview, not our JS).
3. Clean up navigator wiring and screen choice before a real PR.

### Next steps

1. Re-run the same measurements on **production Android and iOS builds** (not Metro debug) and compare with the table above.
2. Investigate more screens that are worth moving to `getComponent`.
3. Write a guideline: **default to `component`**. Only switch to `getComponent` when there is a measured reason (heavy native screen, first-open cost). Do not lazy-load everything by default.
4. Keep **DX and type safety**. `require()` inside `getComponent` is easy to get wrong and drops types. Find a pattern that stays easy to write and still type-checks (typed helper, no untyped `require`). Same for **preloading screens**: calling `require()` / `preloadX()` on every navigate is easy to miss and ugly. Need a DX so preload is one typed call (or tied to the navigate site) without scattering raw `require`s.
5. **New users should not load the onboarded app.** Today `RootNavigator` always static-imports `BaseNavigator` (Main / Portfolio / Settings / …) even during onboarding. Skip `Base` for new users; preload it only on the last onboarding step, before `completeOnboarding`. Keep `Base` eager for returning users. Measure a fresh install.
6. **Returning users should not load first-run onboarding.** That means welcome / terms / use-case (`OnboardingNavigator`), not later device pairing (`SyncOnboarding`). This POC already `getComponent`s `BaseOnboarding`, but that navigator still bundles both flows — so opening “add device” can pull first-run screens. Split them: never load first-run onboarding after `hasCompletedOnboarding`; lazy device onboarding and preload it only on the add-device / pair tap.

### 🔗 Context

- **JIRA / GitHub issue**: n/a (POC)
- **ADR** (if any): n/a