### PR TITLE
[LWDM] fix(wallet-api): tolerate failed token lookups in currency.list

### DIFF
--- a/.changeset/sharp-pandas-jog.md
+++ b/.changeset/sharp-pandas-jog.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+fix(wallet-api): handle failed token lookups without rejecting currency.list

--- a/libs/ledger-live-common/src/wallet-api/react.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.test.ts
@@ -383,6 +383,16 @@ describe("currency.list handler — token lookup concurrency", () => {
     expect(peakInFlight).toBeGreaterThan(1);
     expect(peakInFlight).toBeLessThanOrEqual(TOKEN_LOOKUP_CONCURRENCY);
   });
+
+  it("should omit failed token lookups instead of rejecting currency.list", async () => {
+    jest.mocked(getCryptoAssetsStore).mockReturnValue({
+      findTokenById: jest.fn().mockRejectedValue(new Error("bad json")),
+    } as never);
+
+    renderHook(() => useWalletAPIServer(createDefaultOptions()));
+
+    await expect(getHandler()({ currencyIds: ["ethereum/erc20/usd__coin"] })).resolves.toEqual([]);
+  });
 });
 
 describe("account.request handler", () => {

--- a/libs/ledger-live-common/src/wallet-api/react.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.ts
@@ -479,8 +479,12 @@ export function useWalletAPIServer({
           TOKEN_LOOKUP_CONCURRENCY,
           [...specificTokenIds],
           async tokenId => {
-            const token = await getCryptoAssetsStore().findTokenById(tokenId);
-            return token ? currencyToWalletAPICurrency(token) : null;
+            try {
+              const token = await getCryptoAssetsStore().findTokenById(tokenId);
+              return token ? currencyToWalletAPICurrency(token) : null;
+            } catch {
+              return null;
+            }
           },
         );
         specificTokens.push(...resolvedTokens.filter((t): t is WalletAPICurrency => t !== null));


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

On-ramp widgets call `currency.list` with many token ids. A single failed CAL lookup used to reject the whole call (`-32000`) and prevent the widget from loading. Failed lookups are now skipped so the list still returns the tokens that resolved.

### 🔗 Context

- **[JIRA / GitHub issue](https://ledgerhq.atlassian.net/browse/LIVE-36531)**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
