### PR TITLE
[LWD] feat(pay-contact): add contacts empty-state UI (LIVE-36501)

### DIFF
--- a/.changeset/pay-contacts-empty-state-ui.md
+++ b/.changeset/pay-contacts-empty-state-ui.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-pay-contact": minor
+"ledger-live-desktop": minor
+---
+
+Add a web `Contacts` section (title + empty state with an Add contact CTA) and mount it on the desktop Pay tab. The package reads the contacts and derives the empty state itself; the host injects the copy and an `onAddContact` handler. The add-contact flow and the Ledger Sync gate land in a follow-up.

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -102,6 +102,7 @@
     "@features/flow-pay-card": "workspace:^",
     "@features/flow-pay-card-auth": "workspace:^",
     "@features/flow-pay-balance": "workspace:^",
+    "@features/flow-pay-contact": "workspace:^",
     "@features/flow-pay-deposit": "workspace:^",
     "@features/flow-pay-card-details": "workspace:^",
     "@features/flow-pay-feature-tour": "workspace:^",

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabContacts.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabContacts.ts
@@ -1,0 +1,21 @@
+import { useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import type { ContactsProps } from "@features/flow-pay-contact";
+
+export function usePayTabContacts(): ContactsProps {
+  const { t } = useTranslation();
+
+  const onAddContact = useCallback(() => undefined, []);
+
+  return useMemo(
+    () => ({
+      title: t("payTab.contacts.title"),
+      emptyState: {
+        info: t("payTab.contacts.empty.info"),
+        addContactLabel: t("payTab.contacts.empty.addContact"),
+        onAddContact,
+      },
+    }),
+    [t, onAddContact],
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Balance } from "@features/flow-pay-balance";
+import { Contacts } from "@features/flow-pay-contact";
 import { DepositOptions } from "@features/flow-pay-deposit";
 import { RequestReceive, VerifyAddress } from "@features/flow-pay-card-request";
 import TrackPage from "~/renderer/analytics/TrackPage";
@@ -8,6 +9,7 @@ import { usePayCardBalance } from "./hooks/usePayCardBalance";
 import { FeatureTour } from "@features/flow-pay-feature-tour";
 import { usePayTabFeatureTour } from "./hooks/usePayTabFeatureTour";
 import { usePayTabActionTiles } from "./hooks/usePayTabActionTiles";
+import { usePayTabContacts } from "./hooks/usePayTabContacts";
 import { usePayTabDepositOptions } from "./hooks/usePayTabDepositOptions";
 import { usePayTabRequestReceive } from "./hooks/usePayTabRequestReceive";
 import { usePayTabNewPayment } from "./hooks/usePayTabNewPayment";
@@ -27,6 +29,7 @@ const PayTab = () => {
     request.open,
     newPayment.open,
   );
+  const contacts = usePayTabContacts();
 
   return (
     <div className="flex flex-col gap-24">
@@ -34,8 +37,12 @@ const PayTab = () => {
       {verify.phase === "intro" && <TrackPage category="Request Address Verification" />}
       <PayTabHeader />
       <Balance {...balance} actionTiles={actionTiles} />
+
+      <Contacts {...contacts} />
+
       <DepositOptions {...deposit.depositOptions} />
       <RequestReceive {...request.requestReceive} />
+
       <VerifyAddress {...verify.verifyAddress} />
       {verify.deviceIntent.active && verify.deviceIntent.selection && (
         <VerifyAddressExecutorLWD

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -904,6 +904,13 @@
     "card": {
       "balanceLabel": "Balance"
     },
+    "contacts": {
+      "title": "Pay contact",
+      "empty": {
+        "info": "You don’t have contact yet",
+        "addContact": "Add contact"
+      }
+    },
     "actions": {
       "deposit": "Add stablecoin",
       "request": "Request",

--- a/features/flow/pay-contact/README.md
+++ b/features/flow/pay-contact/README.md
@@ -1,37 +1,23 @@
 # @features/flow-pay-contact
 
 > [!CAUTION]
-> **Status: UNSTABLE** — In active development; API may change.
+> **Status: UNSTABLE** — In active development; API may change. Web only for now.
 
-Pay tab contact flow for Ledger Wallet Desktop and Mobile. It will hold the Pay tab contacts
-strip/table presentation and its shared view-model (stablecoin-filtered list, empty state, and the
-press intent that hands off to the Send flow with `source: Pay`).
+Pay-tab contacts section: a title and an empty state with an **Add contact** CTA.
 
-The package is currently a scaffold with an empty public API; the view-model and platform
-presentations are added in follow-up tickets (LIVE-35378 for the shared view-model, plus the
-LWD/LWM mount tickets).
+The package reads the contacts and derives the empty state itself. The host injects the copy and the
+`onAddContact` handler.
 
-## Public API vs leaves
+```tsx
+import { Contacts } from "@features/flow-pay-contact";
 
-This package owns the Pay-tab contact flow; it does **not** re-export the generic Contacts
-packages. Apps that need contacts data or the contacts management UI keep importing
-`@features/flow-contacts` / `@features/platform-contacts` directly.
-
-## Platform resolution
-
-Only views carry a platform suffix (`.web` / `.native`). The `exports` condition in `package.json`
-selects the barrel (`index.ts` for web, `index.native.ts` for React Native); both re-export the
-shared `./exports` public surface.
-
-## Structure
-
-Every `index.*` is a pure barrel (`export *` only).
-
-```text
-pay-contact/
-├── package.json
-└── src/
-    ├── index.ts          # Web public API barrel → ./exports
-    ├── index.native.ts   # Native public API barrel → ./exports
-    └── exports.ts        # Shared public surface (empty for now)
+<Contacts title={title} emptyState={{ info, addContactLabel, onAddContact }} />;
 ```
+
+Desktop's `usePayTabContacts` is the reference adapter. Hosts must render `Contacts` under a Redux
+`Provider` with the `contactsSlice` reducer.
+
+The add-contact dialog and the Ledger Sync gate behind the CTA land in a follow-up; until then the
+host passes a no-op `onAddContact`.
+
+Do not mount this package on Mobile yet. Native views land in LIVE-36500.

--- a/features/flow/pay-contact/package.json
+++ b/features/flow/pay-contact/package.json
@@ -27,9 +27,14 @@
     "coverage": "jest --coverage",
     "unimported": "pnpm knip --directory ../../.. -W features/flow/pay-contact"
   },
+  "dependencies": {
+    "@features/platform-contacts": "workspace:^"
+  },
   "devDependencies": {
+    "@domain/entity-contact": "workspace:*",
     "@features/platform-style": "workspace:*",
     "@ledgerhq/lumen-design-core": "catalog:",
+    "@reduxjs/toolkit": "catalog:",
     "@ledgerhq/lumen-ui-react": "catalog:",
     "@ledgerhq/lumen-ui-rnative": "catalog:",
     "@support/jest-features-flow": "workspace:*",
@@ -53,6 +58,7 @@
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-native": "catalog:",
+    "react-redux": "catalog:",
     "react-test-renderer": "catalog:",
     "tailwindcss": "catalog:",
     "typescript": "catalog:"
@@ -68,7 +74,8 @@
     "@ledgerhq/lumen-ui-react": "catalog:",
     "@ledgerhq/lumen-ui-rnative": "catalog:",
     "react": "catalog:",
-    "react-native": "catalog:"
+    "react-native": "catalog:",
+    "react-redux": ">=9.0.0"
   },
   "peerDependenciesMeta": {
     "react-native": {

--- a/features/flow/pay-contact/src/components/Contacts/Contacts.web.tsx
+++ b/features/flow/pay-contact/src/components/Contacts/Contacts.web.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { ContactsView } from "./ContactsView.web";
+import { useContactsViewModel } from "./useContactsViewModel";
+import type { ContactsProps } from "../../types";
+
+export function Contacts(props: ContactsProps) {
+  const { isEmpty } = useContactsViewModel();
+
+  return <ContactsView {...props} isEmpty={isEmpty} />;
+}

--- a/features/flow/pay-contact/src/components/Contacts/ContactsView.web.tsx
+++ b/features/flow/pay-contact/src/components/Contacts/ContactsView.web.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { EmptyState } from "../EmptyState/EmptyState.web";
+import type { ContactsViewProps } from "../../types";
+
+export function ContactsView({ title, isEmpty, emptyState }: ContactsViewProps) {
+  return (
+    <div className="mt-40 flex flex-col" data-testid="pay-contacts">
+      <p className="mb-12 heading-5-semi-bold text-base">{title}</p>
+      {isEmpty ? <EmptyState {...emptyState} /> : null}
+    </div>
+  );
+}

--- a/features/flow/pay-contact/src/components/Contacts/__tests__/Contacts.web.test.tsx
+++ b/features/flow/pay-contact/src/components/Contacts/__tests__/Contacts.web.test.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { mockMeContact } from "@domain/entity-contact/schema.mock";
+import { Contacts } from "../Contacts.web";
+import { renderWithContacts } from "./shared";
+import type { ContactsProps } from "../../../types";
+
+const emptyState: ContactsProps["emptyState"] = {
+  info: "You don’t have contact yet",
+  addContactLabel: "Add contact",
+  onAddContact: jest.fn(),
+};
+
+function renderContacts(contacts: Parameters<typeof renderWithContacts>[0]) {
+  return renderWithContacts(contacts, <Contacts title="Pay contact" emptyState={emptyState} />);
+}
+
+describe("Contacts (Web)", () => {
+  it("should render the empty state when the store holds no saved contact", () => {
+    renderContacts([mockMeContact()]);
+
+    expect(screen.getByTestId("pay-contacts-empty-state")).toBeVisible();
+    expect(screen.getByText("You don’t have contact yet")).toBeVisible();
+    expect(screen.queryByTestId("contacts-table")).not.toBeInTheDocument();
+  });
+});

--- a/features/flow/pay-contact/src/components/Contacts/__tests__/ContactsView.web.test.tsx
+++ b/features/flow/pay-contact/src/components/Contacts/__tests__/ContactsView.web.test.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { ContactsView } from "../ContactsView.web";
+import { renderWithStyle } from "./shared";
+import type { ContactsViewProps } from "../../../types";
+
+const emptyState: ContactsViewProps["emptyState"] = {
+  info: "You don’t have contact yet",
+  addContactLabel: "Add contact",
+  onAddContact: jest.fn(),
+};
+
+describe("ContactsView (Web)", () => {
+  it("should always render the section title", () => {
+    renderWithStyle(<ContactsView title="Pay contact" isEmpty emptyState={emptyState} />);
+
+    expect(screen.getByTestId("pay-contacts")).toBeVisible();
+    expect(screen.getByText("Pay contact")).toBeVisible();
+  });
+
+  it("should render the empty state when isEmpty is true", () => {
+    renderWithStyle(<ContactsView title="Pay contact" isEmpty emptyState={emptyState} />);
+
+    expect(screen.getByTestId("pay-contacts-empty-state")).toBeVisible();
+    expect(screen.queryByTestId("contacts-table")).not.toBeInTheDocument();
+  });
+
+  it("should not render the empty state when isEmpty is false", () => {
+    renderWithStyle(<ContactsView title="Pay contact" isEmpty={false} emptyState={emptyState} />);
+
+    expect(screen.queryByTestId("pay-contacts-empty-state")).not.toBeInTheDocument();
+  });
+});

--- a/features/flow/pay-contact/src/components/Contacts/__tests__/shared.web.tsx
+++ b/features/flow/pay-contact/src/components/Contacts/__tests__/shared.web.tsx
@@ -1,0 +1,29 @@
+import React, { type FC, type ReactElement, type ReactNode } from "react";
+import { configureStore } from "@reduxjs/toolkit";
+import { render } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { contactsSlice, type Contact } from "@domain/entity-contact";
+import { StyleProvider } from "@features/platform-style";
+
+export function makeContactsWrapper(contacts: Contact[]): FC<{ children: ReactNode }> {
+  const store = configureStore({
+    reducer: { contacts: contactsSlice.reducer },
+    preloadedState: { contacts: { contacts } },
+  });
+
+  return ({ children }) => <Provider store={store}>{children}</Provider>;
+}
+
+export function renderWithStyle(ui: ReactElement) {
+  return render(<StyleProvider colorScheme="dark">{ui}</StyleProvider>);
+}
+
+export function renderWithContacts(contacts: Contact[], ui: ReactElement) {
+  const Wrapper = makeContactsWrapper(contacts);
+
+  return render(
+    <Wrapper>
+      <StyleProvider colorScheme="dark">{ui}</StyleProvider>
+    </Wrapper>,
+  );
+}

--- a/features/flow/pay-contact/src/components/Contacts/__tests__/useContactsViewModel.web.test.tsx
+++ b/features/flow/pay-contact/src/components/Contacts/__tests__/useContactsViewModel.web.test.tsx
@@ -1,0 +1,33 @@
+import { renderHook } from "@testing-library/react";
+import { mockContact, mockMeContact } from "@domain/entity-contact/schema.mock";
+import { useContactsViewModel } from "../useContactsViewModel";
+import { makeContactsWrapper } from "./shared";
+
+describe("useContactsViewModel", () => {
+  it("should be empty when the store holds no contact", () => {
+    const { result } = renderHook(() => useContactsViewModel(), {
+      wrapper: makeContactsWrapper([]),
+    });
+
+    expect(result.current.isEmpty).toBe(true);
+  });
+
+  it("should be empty when the me contact is the only one", () => {
+    const { result } = renderHook(() => useContactsViewModel(), {
+      wrapper: makeContactsWrapper([mockMeContact()]),
+    });
+
+    expect(result.current.isEmpty).toBe(true);
+  });
+
+  it("should not be empty when a saved contact exists", () => {
+    const { result } = renderHook(() => useContactsViewModel(), {
+      wrapper: makeContactsWrapper([
+        mockMeContact(),
+        mockContact({ id: "contact-ada", name: "Ada" }),
+      ]),
+    });
+
+    expect(result.current.isEmpty).toBe(false);
+  });
+});

--- a/features/flow/pay-contact/src/components/Contacts/useContactsViewModel.ts
+++ b/features/flow/pay-contact/src/components/Contacts/useContactsViewModel.ts
@@ -1,0 +1,8 @@
+import { useMemo } from "react";
+import { useContacts } from "@features/platform-contacts";
+
+export function useContactsViewModel(): Readonly<{ isEmpty: boolean }> {
+  const contacts = useContacts();
+
+  return useMemo(() => ({ isEmpty: contacts.every(contact => contact.isMe) }), [contacts]);
+}

--- a/features/flow/pay-contact/src/components/EmptyState/EmptyState.web.tsx
+++ b/features/flow/pay-contact/src/components/EmptyState/EmptyState.web.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { Button, Spot } from "@ledgerhq/lumen-ui-react";
+import { Contact } from "@ledgerhq/lumen-ui-react/symbols";
+import type { EmptyStateProps } from "../../types";
+
+export function EmptyState({ info, addContactLabel, onAddContact }: EmptyStateProps) {
+  return (
+    <div
+      className="flex flex-col items-center gap-24 text-center"
+      data-testid="pay-contacts-empty-state"
+    >
+      <Spot appearance="icon" icon={Contact} size={72} />
+      <p className="heading-4-semi-bold text-base">{info}</p>
+
+      <Button onClick={onAddContact} size="sm" data-testid="pay-contacts-add-contact">
+        {addContactLabel}
+      </Button>
+    </div>
+  );
+}

--- a/features/flow/pay-contact/src/components/EmptyState/__tests__/EmptyState.web.test.tsx
+++ b/features/flow/pay-contact/src/components/EmptyState/__tests__/EmptyState.web.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { StyleProvider } from "@features/platform-style";
+import { EmptyState } from "../EmptyState.web";
+import type { EmptyStateProps } from "../../../types";
+
+function renderWithStyle(ui: React.ReactElement) {
+  return render(<StyleProvider colorScheme="dark">{ui}</StyleProvider>);
+}
+
+const defaultProps: EmptyStateProps = {
+  info: "No contacts yet",
+  addContactLabel: "Add contact",
+  onAddContact: jest.fn(),
+};
+
+describe("EmptyState (Web)", () => {
+  it("should render the empty info and CTA", () => {
+    renderWithStyle(<EmptyState {...defaultProps} />);
+
+    expect(screen.getByTestId("pay-contacts-empty-state")).toBeVisible();
+    expect(screen.getByText("No contacts yet")).toBeVisible();
+    expect(screen.getByText("Add contact")).toBeVisible();
+  });
+
+  it("should call onAddContact when the CTA is clicked", () => {
+    const onAddContact = jest.fn();
+    renderWithStyle(<EmptyState {...defaultProps} onAddContact={onAddContact} />);
+
+    fireEvent.click(screen.getByTestId("pay-contacts-add-contact"));
+
+    expect(onAddContact).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/flow/pay-contact/src/exports.ts
+++ b/features/flow/pay-contact/src/exports.ts
@@ -1,1 +1,1 @@
-export const PLACEHOLDER_PACKAGE = "@features/flow-pay-contact";
+export * from "./types";

--- a/features/flow/pay-contact/src/index.ts
+++ b/features/flow/pay-contact/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./exports";
+export * from "./components/Contacts/Contacts.web";

--- a/features/flow/pay-contact/src/types.ts
+++ b/features/flow/pay-contact/src/types.ts
@@ -1,0 +1,17 @@
+export type EmptyStateLabels = Readonly<{
+  info: string;
+  addContactLabel: string;
+}>;
+
+export type EmptyStateProps = EmptyStateLabels & Readonly<{ onAddContact: () => void }>;
+
+export type ContactsProps = Readonly<{
+  title: string;
+  emptyState: EmptyStateProps;
+}>;
+
+export type ContactsViewProps = Readonly<{
+  title: string;
+  isEmpty: boolean;
+  emptyState: EmptyStateProps;
+}>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -982,6 +982,9 @@ importers:
       '@features/flow-pay-card-request':
         specifier: workspace:^
         version: link:../../features/flow/pay-card-request
+      '@features/flow-pay-contact':
+        specifier: workspace:^
+        version: link:../../features/flow/pay-contact
       '@features/flow-pay-deposit':
         specifier: workspace:^
         version: link:../../features/flow/pay-deposit
@@ -6546,7 +6549,14 @@ importers:
         version: 1.51.0
 
   features/flow/pay-contact:
+    dependencies:
+      '@features/platform-contacts':
+        specifier: workspace:^
+        version: link:../../platform/contacts
     devDependencies:
+      '@domain/entity-contact':
+        specifier: workspace:*
+        version: link:../../../domain/entity/contact
       '@features/platform-style':
         specifier: workspace:*
         version: link:../../platform/style
@@ -6559,6 +6569,9 @@ importers:
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
         version: 0.1.58(@ledgerhq/lumen-design-core@0.1.26)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@reduxjs/toolkit':
+        specifier: 'catalog:'
+        version: 2.11.2(react-redux@9.2.0(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@support/jest-features-flow':
         specifier: workspace:*
         version: link:../../../support/jest-features-flow
@@ -6622,6 +6635,9 @@ importers:
       react-native:
         specifier: 'catalog:'
         version: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
+      react-redux:
+        specifier: 'catalog:'
+        version: 9.2.0(@types/react@19.0.14)(react@19.1.4)
       react-test-renderer:
         specifier: 'catalog:'
         version: 19.1.4(react@19.1.4)
@@ -26442,7 +26458,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.1.4
       react-dom: 19.1.4
-      webpack: ^5.89.0
+      webpack: '*'
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -38017,6 +38033,7 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qrcode-terminal@0.11.0:
@@ -69911,7 +69928,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3(metro-transform-worker@0.83.3)
+      metro: 0.83.3
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -70035,54 +70052,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro@0.83.3(metro-transform-worker@0.83.3):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 1.3.8
-      chalk: 4.1.2
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.32.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0(metro@0.83.3)
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.3
-      metro-cache: 0.83.3
-      metro-cache-key: 0.83.3
-      metro-config: 0.83.3(metro-transform-worker@0.83.3)
-      metro-core: 0.83.3
-      metro-file-map: 0.83.3(metro@0.83.3)
-      metro-resolver: 0.83.3
-      metro-runtime: 0.83.3
-      metro-source-map: 0.83.3
-      metro-symbolicate: 0.83.3
-      metro-transform-plugins: 0.83.3
-      metro-transform-worker: 0.83.3
-      mime-types: 2.1.35
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Adds the web `Contacts` section for the Pay tab in `@features/flow-pay-contact` and mounts it on the desktop Pay tab.

The section renders a title and an empty state (with an **Add contact** CTA) when there is no saved contact. The package derives emptiness from the contacts store; the host only injects the copy and an `onAddContact` handler.

This PR covers the UI only. The contact logic (the add-contact flow and the Ledger Sync gate behind the CTA) lands in a follow-up ticket, so the desktop adapter wires a no-op `onAddContact` for now.

Usage:

```tsx
import { Contacts } from "@features/flow-pay-contact";

<Contacts title={title} emptyState={{ info, addContactLabel, onAddContact }} />;
```

`Contacts` must be rendered under a Redux `Provider` with the `contactsSlice` reducer.

### 📸 Screenshot

<img width="939" height="715" alt="Screenshot 2026-08-27 at 09 42 18" src="https://github.com/user-attachments/assets/dfb34fe2-0d34-4292-8159-4ff5586bf10f" />


### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36501](https://ledgerhq.atlassian.net/browse/LIVE-36501)
- **ADR** (if any): N/A