### PR TITLE
[LWDM] feat(concordium): adopt the PLT-capable signer (LIVE-33626)

### DIFF
--- a/.changeset/concordium-plt-capable-signer.md
+++ b/.changeset/concordium-plt-capable-signer.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-signer-concordium": minor
+"@ledgerhq/coin-concordium": minor
+---
+
+Adopt the PLT-capable Concordium signer and map the PLT status words to typed errors

--- a/libs/coin-modules/coin-concordium/src/types/errors.test.ts
+++ b/libs/coin-modules/coin-concordium/src/types/errors.test.ts
@@ -1,0 +1,33 @@
+import {
+  ConcordiumAppOutdatedError,
+  ConcordiumInvalidPltPayloadError,
+  ConcordiumSignerProtocolError,
+} from "./errors";
+
+// The PLT signer errors are constructed in live-signer-concordium, a separate
+// package, so nothing in this package exercises them.
+describe("types/errors — PLT signer errors", () => {
+  const cases = [
+    ["ConcordiumInvalidPltPayloadError", ConcordiumInvalidPltPayloadError],
+    ["ConcordiumSignerProtocolError", ConcordiumSignerProtocolError],
+    ["ConcordiumAppOutdatedError", ConcordiumAppOutdatedError],
+  ] as const;
+
+  it.each(cases)("%s defaults its message to its own name", (name, ErrorClass) => {
+    const error = new ErrorClass();
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe(name);
+    expect(error.message).toBe(name);
+  });
+
+  it.each(cases)("%s keeps the message it is given", (_name, ErrorClass) => {
+    expect(new ErrorClass("device said no").message).toBe("device said no");
+  });
+
+  it.each(cases)("%s copies extra fields onto the instance", (_name, ErrorClass) => {
+    const error = new ErrorClass("device said no", { errorCode: "6b0d" });
+
+    expect(error).toHaveProperty("errorCode", "6b0d");
+  });
+});

--- a/libs/coin-modules/coin-concordium/src/types/errors.ts
+++ b/libs/coin-modules/coin-concordium/src/types/errors.ts
@@ -61,3 +61,42 @@ export class SimulationError extends Error {
     if (fields) Object.assign(this, fields);
   }
 }
+
+/**
+ * The device refused the PLT payload the wallet built, or the signer refused it
+ * before sending. The user did nothing wrong, so this is reported as a defect
+ * rather than as a rejected transaction.
+ */
+export class ConcordiumInvalidPltPayloadError extends Error {
+  override name = "ConcordiumInvalidPltPayloadError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message ?? "ConcordiumInvalidPltPayloadError");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+/**
+ * The signer and the device app disagree on the APDU contract: wrong P1/P2,
+ * unexpected state, malformed parameter or derivation path, or a device-side
+ * buffer or crypto failure.
+ */
+export class ConcordiumSignerProtocolError extends Error {
+  override name = "ConcordiumSignerProtocolError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message ?? "ConcordiumSignerProtocolError");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+/**
+ * The installed Concordium app predates PLT support. Kept distinct from the
+ * other signer errors so the send flow can offer an app update instead of
+ * reporting a signing failure.
+ */
+export class ConcordiumAppOutdatedError extends Error {
+  override name = "ConcordiumAppOutdatedError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message ?? "ConcordiumAppOutdatedError");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/live-signer-concordium/src/DmkSignerConcordium.ts
+++ b/libs/live-signer-concordium/src/DmkSignerConcordium.ts
@@ -17,7 +17,10 @@ import {
 } from "@ledgerhq/device-management-kit";
 import {
   ConcordiumAddressVerificationFailedError,
+  ConcordiumAppOutdatedError,
   ConcordiumInvalidMaxFeeError,
+  ConcordiumInvalidPltPayloadError,
+  ConcordiumSignerProtocolError,
   ConcordiumTrustedMetadataServiceError,
 } from "@ledgerhq/coin-concordium/types";
 import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
@@ -151,6 +154,29 @@ export class DmkSignerConcordium implements ConcordiumSigner {
         return new ConcordiumAddressVerificationFailedError(originalMessage);
       case "invalid_max_fee":
         return new ConcordiumInvalidMaxFeeError(originalMessage);
+      case "6b04":
+      case "6b0d":
+      case "6b0e":
+      case "6b0f":
+      case "6b10":
+      case "6b11":
+      case "invalid_plt_transaction":
+        return new ConcordiumInvalidPltPayloadError(originalMessage);
+      case "6b00":
+      case "6b01":
+      case "6b02":
+      case "6b03":
+      case "6b06":
+      case "6b07":
+      case "unsupported_transaction_type":
+        return new ConcordiumSignerProtocolError(originalMessage);
+      // 6d00 means the app does not know the instruction at all, which is how a
+      // pre-PLT app answers INS 0x27. It is treated as an outdated app rather
+      // than a protocol defect, so the version guard still works if the shipped
+      // app version differs from the one the signer pins.
+      case "6d00":
+      case "unsupported_app_version":
+        return new ConcordiumAppOutdatedError(originalMessage);
       default:
         return new Error(this.formatGenericMessage(error._tag, originalMessage));
     }

--- a/libs/live-signer-concordium/tests/DmkSignerConcordium.test.ts
+++ b/libs/live-signer-concordium/tests/DmkSignerConcordium.test.ts
@@ -1,7 +1,10 @@
 import { DeviceActionStatus, DeviceManagementKit } from "@ledgerhq/device-management-kit";
 import {
   ConcordiumAddressVerificationFailedError,
+  ConcordiumAppOutdatedError,
   ConcordiumInvalidMaxFeeError,
+  ConcordiumInvalidPltPayloadError,
+  ConcordiumSignerProtocolError,
   ConcordiumTrustedMetadataServiceError,
 } from "@ledgerhq/coin-concordium/types";
 import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
@@ -243,6 +246,96 @@ describe("DmkSignerConcordium", () => {
       await expect(signer.signTransaction(mockTx, mockPath, mockMaxFee)).rejects.toThrow(
         ConcordiumInvalidMaxFeeError,
       );
+    });
+
+    describe("PLT error mapping", () => {
+      const expectMappedError = async (errorCode: string, expected: new () => Error) => {
+        // toThrow(undefined) matches any thrown value, so a class that resolves
+        // to undefined (a stale coin-concordium build, a renamed export) would
+        // let every case below pass without asserting anything.
+        expect(expected).toEqual(expect.any(Function));
+
+        mockSignerConcordium.signTransaction.mockReturnValue({
+          observable: of({
+            status: DeviceActionStatus.Error,
+            error: { _tag: "ConcordiumAppCommandError", errorCode },
+          }),
+        });
+
+        await expect(signer.signTransaction(mockTx, mockPath, mockMaxFee)).rejects.toBeInstanceOf(
+          expected,
+        );
+      };
+
+      it.each(["6b04", "6b0d", "6b0e", "6b0f", "6b10", "6b11", "invalid_plt_transaction"])(
+        "should map %s to ConcordiumInvalidPltPayloadError",
+        async errorCode => {
+          await expectMappedError(errorCode, ConcordiumInvalidPltPayloadError);
+        },
+      );
+
+      it.each(["6b00", "6b01", "6b02", "6b03", "6b06", "6b07", "unsupported_transaction_type"])(
+        "should map %s to ConcordiumSignerProtocolError",
+        async errorCode => {
+          await expectMappedError(errorCode, ConcordiumSignerProtocolError);
+        },
+      );
+
+      it.each(["unsupported_app_version", "6d00"])(
+        "should map %s to ConcordiumAppOutdatedError",
+        async errorCode => {
+          await expectMappedError(errorCode, ConcordiumAppOutdatedError);
+        },
+      );
+
+      it("should carry the original error message through the mapped error", async () => {
+        mockSignerConcordium.signTransaction.mockReturnValue({
+          observable: of({
+            status: DeviceActionStatus.Error,
+            error: {
+              _tag: "ConcordiumAppCommandError",
+              errorCode: "6b0d",
+              originalError: new Error("PLT CBOR error"),
+            },
+          }),
+        });
+
+        await expect(signer.signTransaction(mockTx, mockPath, mockMaxFee)).rejects.toThrow(
+          "PLT CBOR error",
+        );
+      });
+
+      // mapError is shared by every flow, so the codes above also change what
+      // the non-PLT flows throw.
+      it("should map 6d00 to ConcordiumAppOutdatedError on getPublicKey", async () => {
+        mockSignerConcordium.getPublicKey.mockReturnValue({
+          observable: of({
+            status: DeviceActionStatus.Error,
+            error: { _tag: "ConcordiumAppCommandError", errorCode: "6d00" },
+          }),
+        });
+
+        await expect(signer.getPublicKey(mockPath)).rejects.toBeInstanceOf(
+          ConcordiumAppOutdatedError,
+        );
+      });
+
+      it("should map 6b02 to ConcordiumSignerProtocolError on verifyAddress", async () => {
+        mockSignerConcordium.verifyAddress.mockReturnValue({
+          observable: of({
+            status: DeviceActionStatus.Error,
+            error: { _tag: "ConcordiumAppCommandError", errorCode: "6b02" },
+          }),
+        });
+
+        await expect(
+          signer.verifyAddress(
+            mockPath,
+            "3kBx2h5Y2veb4hZgAJWPrr8RyQESKm5TjzF3ti1QQ4VSYLwK1G",
+            "mainnet",
+          ),
+        ).rejects.toBeInstanceOf(ConcordiumSignerProtocolError);
+      });
     });
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ catalogs:
       specifier: 0.4.0
       version: 0.4.0
     '@ledgerhq/device-signer-kit-concordium':
-      specifier: 0.4.0
-      version: 0.4.0
+      specifier: 0.5.0
+      version: 0.5.0
     '@ledgerhq/device-signer-kit-cosmos':
       specifier: 1.0.1
       version: 1.0.1
@@ -15603,7 +15603,7 @@ importers:
         version: 1.9.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-concordium':
         specifier: 'catalog:'
-        version: 0.4.0(@ledgerhq/context-module@2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
+        version: 0.5.0(@ledgerhq/context-module@2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../ledgerjs/packages/hw-transport
@@ -22161,11 +22161,11 @@ packages:
       '@ledgerhq/context-module': 2.5.0
       '@ledgerhq/device-management-kit': ^1.6.0
 
-  '@ledgerhq/device-signer-kit-concordium@0.4.0':
-    resolution: {integrity: sha512-jqVp8232dkI34ZVbsQOcGpjK9J+g8BzGD9+/0Ezy7nGtMUfX8c6AhEmn79kj3w96kJ0z1YkakaClCHxicFWtKQ==}
+  '@ledgerhq/device-signer-kit-concordium@0.5.0':
+    resolution: {integrity: sha512-INuy0FEnfnsPwiXvozJnH3SlsA1srtYgyu8lRY19w+4pi5i34Yz/Ou9b9SPU1q6qR0VqD9x2D1CpV13Dg80VSA==}
     peerDependencies:
       '@ledgerhq/context-module': 2.5.0
-      '@ledgerhq/device-management-kit': ^1.5.0
+      '@ledgerhq/device-management-kit': ^1.9.0
 
   '@ledgerhq/device-signer-kit-cosmos@1.0.1':
     resolution: {integrity: sha512-822hk0ef7/ELTTi+mIPO+hX5MHLiZ6M8oMWz1eQOfoemcGiVxtiqLsodDKJ60GVmOVP6X6eoqihdrAomS6EvZQ==}
@@ -48695,7 +48695,7 @@ snapshots:
       reflect-metadata: 0.2.2
       xstate: 5.19.2
 
-  '@ledgerhq/device-signer-kit-concordium@0.4.0(@ledgerhq/context-module@2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-concordium@0.5.0(@ledgerhq/context-module@2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))':
     dependencies:
       '@ledgerhq/context-module': 2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@ledgerhq/device-management-kit': 1.9.0(rxjs@7.8.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,7 +28,7 @@ catalog:
   "@ledgerhq/device-management-kit": 1.9.0
   "@ledgerhq/dmk-ledger-wallet": 0.5.0
   "@ledgerhq/device-signer-kit-aleo": 0.4.0
-  "@ledgerhq/device-signer-kit-concordium": 0.4.0
+  "@ledgerhq/device-signer-kit-concordium": 0.5.0
   "@ledgerhq/device-signer-kit-ethereum": 1.18.0
   "@ledgerhq/device-signer-kit-hyperliquid": 0.0.0-hyperliquid-unified-20260728150448
   "@ledgerhq/device-signer-kit-solana": 1.13.0


### PR DESCRIPTION
### 📝 Description

Adopts the PLT-capable Concordium signer and maps its new error codes to typed wallet errors.

`@ledgerhq/device-signer-kit-concordium` now supports PLT (Protocol Level Token) signing over `INS 0x27`. Its new status words had no mapping and reached the UI as generic `Error`s. This PR bumps the catalog pin from `0.4.0` to `0.5.0` and routes each code to a typed class in the existing `Concordium*Error` family, grouped by cause:

| Codes | Class | Cause |
| --- | --- | --- |
| `6b04`, `6b0d`–`6b11`, `invalid_plt_transaction` | `ConcordiumInvalidPltPayloadError` | The device refused the payload the wallet built. Reportable as a defect, not a user rejection. |
| `6b00`–`6b03`, `6b06`, `6b07`, `unsupported_transaction_type` | `ConcordiumSignerProtocolError` | Signer and device app disagree on the APDU contract. |
| `unsupported_app_version`, `6d00` | `ConcordiumAppOutdatedError` | Installed app predates PLT support; the send flow can offer an app update. |

`6d00` (INS not supported) is grouped with the version guard because that is how a pre-PLT app answers `INS 0x27`. This keeps the update path working if the shipped app version differs from the one the signer pins.

`6b11` (`ERROR_PLT_UNSUPPORTED_DECIMALS`) is the newest of these. The device rejects an amount whose exponent magnitude exceeds 18 at CBOR parse time — an app display limit, while the chain itself permits 0 to 255 decimals. It is grouped with the payload errors rather than given its own class: a payload with more than 18 decimals is something the wallet built and the user cannot act on, which is exactly what `ConcordiumInvalidPltPayloadError` documents.

CCD signing behaviour is unchanged. `mapError` is shared by all four signer flows, so the tests cover the PLT path plus two non-PLT flows.

Note: `config_nanoapp_concordium.minVersion` is deliberately left at `5.6.0`. PLT is gated by the signer's own version check rather than the app-install gate, so users on 5.6.x keep full CCD functionality.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-33626](https://ledgerhq.atlassian.net/browse/LIVE-33626)
- **ADR** (if any): n/a


[LIVE-33626]: https://ledgerhq.atlassian.net/browse/LIVE-33626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-28334]: https://ledgerhq.atlassian.net/browse/LIVE-28334
[LIVE-36749]: https://ledgerhq.atlassian.net/browse/LIVE-36749
