### PR TITLE
[LWM] test(mobile): E2E post-onboarding hub full mock flow

### DIFF
--- a/.changeset/LIVE-31323-post-onboarding-hub-e2e.md
+++ b/.changeset/LIVE-31323-post-onboarding-hub-e2e.md
@@ -1,0 +1,7 @@
+---
+"live-mobile": patch
+"ledger-live-mobile-e2e-tests": patch
+"@ledgerhq/live-e2e-shared": patch
+---
+
+Add mobile E2E for the post-onboarding hub mock flow (LIVE-31323).

--- a/apps/ledger-live-mobile/src/e2e/bridge/client.ts
+++ b/apps/ledger-live-mobile/src/e2e/bridge/client.ts
@@ -11,6 +11,7 @@ import {
 } from "@shared/feature-flags";
 import { importStore as importAccountsRaw } from "~/actions/accounts";
 import { importTrustchainStoreState } from "@ledgerhq/ledger-key-ring-protocol/store";
+import { importPostOnboardingState } from "@ledgerhq/live-common/postOnboarding/actions";
 import { exportSelector as accountsExportSelector } from "~/reducers/accounts";
 import { saveAccounts } from "~/db";
 import { acceptGeneralTerms } from "~/logic/terms";
@@ -135,6 +136,10 @@ async function onMessage(event: WebSocketMessageEvent) {
       }
       case "importBle": {
         store.dispatch(importBle(msg.payload));
+        break;
+      }
+      case "importPostOnboarding": {
+        store.dispatch(importPostOnboardingState({ newState: msg.payload }));
         break;
       }
       case "overrideFeatureFlags": {

--- a/apps/ledger-live-mobile/src/e2e/bridge/types.ts
+++ b/apps/ledger-live-mobile/src/e2e/bridge/types.ts
@@ -1,6 +1,6 @@
 import { Event as AppEvent } from "@ledgerhq/live-common/hw/actions/app";
 import { DescriptorEventType } from "@ledgerhq/hw-transport";
-import { AccountRaw } from "@ledgerhq/types-live";
+import { AccountRaw, type PostOnboardingState } from "@ledgerhq/types-live";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { BleState, SettingsState } from "~/reducers/types";
 import type { TrustchainStore } from "@ledgerhq/ledger-key-ring-protocol/store";
@@ -83,6 +83,7 @@ export type MessageData =
     }
   | { type: "importTrustchain"; id: string; payload: TrustchainStore }
   | { type: "importBle"; id: string; payload: BleState }
+  | { type: "importPostOnboarding"; id: string; payload: Partial<PostOnboardingState> }
   | { type: "overrideFeatureFlags"; id: string; payload: PartialFeatures }
   | { type: "overrideFeatureFlag"; id: string; payload: OverrideFeatureFlagPayload }
   | { type: "setGlobals"; id: string; payload: { [key: string]: unknown } }

--- a/apps/ledger-live-mobile/src/mvvm/features/PostOnboardingHubDrawer/PostOnboardingHubDrawerView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PostOnboardingHubDrawer/PostOnboardingHubDrawerView.tsx
@@ -109,8 +109,14 @@ export function PostOnboardingHubDrawerView({
       ))}
 
       {areAllPostOnboardingActionsCompleted ? (
-        <Box lx={{ marginTop: "s24" }}>
-          <Button appearance="base" size="lg" isFull onPress={onRequestExit}>
+        <Box lx={{ marginTop: "s24" }} style={{ marginBottom: bottomInset }}>
+          <Button
+            appearance="base"
+            size="lg"
+            isFull
+            onPress={onRequestExit}
+            testID="post-onboarding-hub-complete-button"
+          >
             {t("postOnboarding.drawer.primaryLabel")}
           </Button>
         </Box>

--- a/apps/ledger-live-mobile/src/mvvm/features/PostOnboardingHubDrawer/PostOnboardingHubDrawerView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PostOnboardingHubDrawer/PostOnboardingHubDrawerView.tsx
@@ -109,7 +109,7 @@ export function PostOnboardingHubDrawerView({
       ))}
 
       {areAllPostOnboardingActionsCompleted ? (
-        <Box lx={{ marginTop: "s24" }} style={{ marginBottom: bottomInset }}>
+        <Box lx={{ marginTop: "s24" }}>
           <Button
             appearance="base"
             size="lg"

--- a/apps/ledger-live-mobile/src/mvvm/features/PostOnboardingHubDrawer/components/HubActionItem/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PostOnboardingHubDrawer/components/HubActionItem/index.tsx
@@ -5,7 +5,7 @@ import { HubStepRow } from "../HubStepRow";
 import { type HubActionItemProps, useHubActionItemViewModel } from "./useHubActionItemViewModel";
 
 export function HubActionItem(props: HubActionItemProps) {
-  const { Icon } = props;
+  const { Icon, id } = props;
   const {
     titleText,
     descriptionText,
@@ -35,6 +35,7 @@ export function HubActionItem(props: HubActionItemProps) {
 
   return (
     <Pressable
+      testID={`post-onboarding-hub-action-${id}`}
       lx={{ alignSelf: "stretch" }}
       onPress={isDisabled ? undefined : handleRowPress}
       disabled={isDisabled}

--- a/apps/ledger-live-mobile/src/screens/PostOnboarding/PostOnboardingMockActionScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/PostOnboarding/PostOnboardingMockActionScreen.tsx
@@ -52,7 +52,12 @@ const PostOnboardingMockActionScreen = ({ navigation, route }: NavigationProps) 
         <Button mt={6} type="main" onPress={handleCompleteAndGoToWallet}>
           Complete action & go to Wallet
         </Button>
-        <Button mt={6} type="main" onPress={handleCompleteAndGoToHub}>
+        <Button
+          mt={6}
+          type="main"
+          onPress={handleCompleteAndGoToHub}
+          testID="post-onboarding-mock-complete-and-back-to-hub"
+        >
           Complete action & go back to onboarding hub
         </Button>
       </Flex>

--- a/e2e/mobile/bridge/server.ts
+++ b/e2e/mobile/bridge/server.ts
@@ -120,6 +120,10 @@ export async function loadConfig(fileName: string, agreed: true = true): Promise
     postMessage({ type: "importTrustchain", id: uniqueId(), payload: data.trustchain });
   }
 
+  if (data.postOnboarding) {
+    postMessage({ type: "importPostOnboarding", id: uniqueId(), payload: data.postOnboarding });
+  }
+
   if (data.featureFlags?.overrides) {
     await setFeatureFlags(data.featureFlags.overrides);
   }

--- a/e2e/mobile/docs/add-or-update-e2e.md
+++ b/e2e/mobile/docs/add-or-update-e2e.md
@@ -31,7 +31,8 @@ reach it as `app.<name>`.
 2. **Arrange state in fixtures and flags, not in UI steps.** Dismissed introductions, onboarding and
    settings belong in `userdata/*.json`; entry-point flags belong in the test function file, combined
    with a preset from [`utils/featureFlagUtils`](../utils/featureFlagUtils.ts). `loadConfig` imports
-   only `data.settings` and `data.accounts` — domain entities cannot be seeded this way.
+   `data.settings`, `data.accounts`, and `data.postOnboarding` when present — other domain entities
+   cannot be seeded this way.
 
 3. **No conditional steps.** Never `completeXIfVisible`: it costs time on every run and hides the
    regression when the thing stops appearing. Remove the blocker via rule 2 instead.

--- a/e2e/mobile/docs/add-or-update-e2e.md
+++ b/e2e/mobile/docs/add-or-update-e2e.md
@@ -31,8 +31,8 @@ reach it as `app.<name>`.
 2. **Arrange state in fixtures and flags, not in UI steps.** Dismissed introductions, onboarding and
    settings belong in `userdata/*.json`; entry-point flags belong in the test function file, combined
    with a preset from [`utils/featureFlagUtils`](../utils/featureFlagUtils.ts). `loadConfig` imports
-   `data.settings`, `data.accounts`, and `data.postOnboarding` when present — other domain entities
-   cannot be seeded this way.
+   `data.settings`, `data.accounts`, `data.trustchain`, and `data.postOnboarding` when present — other
+   domain entities cannot be seeded this way.
 
 3. **No conditional steps.** Never `completeXIfVisible`: it costs time on every run and hides the
    regression when the thing stops appearing. Remove the blocker via rule 2 instead.

--- a/e2e/mobile/page/index.ts
+++ b/e2e/mobile/page/index.ts
@@ -12,6 +12,7 @@ import TrustchainPage from "@e2e/page/trustchain.page";
 import ManagerPage from "@e2e/page/manager/manager.page";
 import MarketPage from "@e2e/page/market/market.page";
 import OnboardingStepsPage from "@e2e/page/onboarding/onboardingSteps.page";
+import PostOnboardingHubPage from "@e2e/page/postOnboarding/postOnboardingHub.page";
 import OperationDetailsPage from "@e2e/page/trade/operationDetails.page";
 import PasswordEntryPage from "@e2e/page/passwordEntry.page";
 import PortfolioEmptyStatePage from "@e2e/page/wallet/portfolioEmptyState.page";
@@ -77,6 +78,7 @@ export class Application {
   private managerPageInstance = lazyInit(ManagerPage);
   private marketPageInstance = lazyInit(MarketPage);
   private onboardingPageInstance = lazyInit(OnboardingStepsPage);
+  private postOnboardingHubPageInstance = lazyInit(PostOnboardingHubPage);
   private operationDetailsPageInstance = lazyInit(OperationDetailsPage);
   private passwordEntryPageInstance = lazyInit(PasswordEntryPage);
   private portfolioEmptyStatePageInstance = lazyInit(PortfolioEmptyStatePage);
@@ -171,6 +173,10 @@ export class Application {
 
   public get onboarding() {
     return this.onboardingPageInstance();
+  }
+
+  public get postOnboardingHub() {
+    return this.postOnboardingHubPageInstance();
   }
 
   public get operationDetails() {

--- a/e2e/mobile/page/postOnboarding/postOnboardingHub.page.ts
+++ b/e2e/mobile/page/postOnboarding/postOnboardingHub.page.ts
@@ -1,0 +1,70 @@
+import { Step } from "jest-allure2-reporter/api";
+
+export default class PostOnboardingHubPage {
+  onboardingWidgetId = "onboarding-widget";
+  hubContainerId = "post-onboarding-hub-container";
+  mockCompleteAndBackToHubId = "post-onboarding-mock-complete-and-back-to-hub";
+  hubCompleteButtonId = "post-onboarding-hub-complete-button";
+
+  hubActionId = (actionId: string) => `post-onboarding-hub-action-${actionId}`;
+
+  @Step("Expect onboarding widget to be visible")
+  async expectWidgetVisible(): Promise<void> {
+    await waitForElementById(this.onboardingWidgetId);
+    await detoxExpect(getElementById(this.onboardingWidgetId)).toBeVisible();
+  }
+
+  @Step("Expect onboarding widget to be hidden")
+  async expectWidgetHidden(): Promise<void> {
+    await waitForElementNotVisible(this.onboardingWidgetId);
+    await detoxExpect(getElementById(this.onboardingWidgetId)).not.toBeVisible();
+  }
+
+  @Step("Open post-onboarding hub from portfolio widget")
+  async openHubFromWidget(): Promise<void> {
+    await tapById(this.onboardingWidgetId);
+    await waitForFullyVisibleById(this.hubContainerId);
+  }
+
+  @Step("Expect post-onboarding hub drawer to be visible")
+  async expectHubVisible(): Promise<void> {
+    await waitForFullyVisibleById(this.hubContainerId);
+    await detoxExpect(getElementById(this.hubContainerId)).toBeVisible();
+  }
+
+  @Step("Expect hub action {{0}} to be pending")
+  async expectActionPending(actionId: string): Promise<void> {
+    await waitForFullyVisibleById(this.hubActionId(actionId));
+    await detoxExpect(getElementById(this.hubActionId(actionId))).toBeVisible();
+  }
+
+  @Step("Tap post-onboarding hub action {{0}}")
+  async tapAction(actionId: string): Promise<void> {
+    await tapById(this.hubActionId(actionId));
+  }
+
+  @Step("Complete mock action and return to post-onboarding hub")
+  async completeMockActionAndReturnToHub(): Promise<void> {
+    await waitForElementById(this.mockCompleteAndBackToHubId);
+    await tapById(this.mockCompleteAndBackToHubId);
+    await waitForFullyVisibleById(this.hubContainerId);
+  }
+
+  @Step("Expect hub action {{0}} to be completed")
+  async expectActionCompleted(actionId: string, completedLabel: string): Promise<void> {
+    await detoxExpect(
+      getElementByIdWithDescendantTexts(this.hubActionId(actionId), completedLabel),
+    ).toBeVisible();
+  }
+
+  @Step("Expect all post-onboarding hub actions to be completed")
+  async expectAllActionsCompleted(): Promise<void> {
+    await waitForElementById(this.hubCompleteButtonId);
+    await detoxExpect(getElementById(this.hubCompleteButtonId)).toBeVisible();
+  }
+
+  @Step("Tap post-onboarding hub complete button")
+  async tapCompleteButton(): Promise<void> {
+    await tapById(this.hubCompleteButtonId);
+  }
+}

--- a/e2e/mobile/page/postOnboarding/postOnboardingHub.page.ts
+++ b/e2e/mobile/page/postOnboarding/postOnboardingHub.page.ts
@@ -10,14 +10,12 @@ export default class PostOnboardingHubPage {
 
   @Step("Expect onboarding widget to be visible")
   async expectWidgetVisible(): Promise<void> {
-    await waitForElementById(this.onboardingWidgetId);
-    await detoxExpect(getElementById(this.onboardingWidgetId)).toBeVisible();
+    await waitForFullyVisibleById(this.onboardingWidgetId);
   }
 
   @Step("Expect onboarding widget to be hidden")
   async expectWidgetHidden(): Promise<void> {
     await waitForElementNotVisible(this.onboardingWidgetId);
-    await detoxExpect(getElementById(this.onboardingWidgetId)).not.toBeVisible();
   }
 
   @Step("Open post-onboarding hub from portfolio widget")
@@ -26,16 +24,9 @@ export default class PostOnboardingHubPage {
     await waitForFullyVisibleById(this.hubContainerId);
   }
 
-  @Step("Expect post-onboarding hub drawer to be visible")
-  async expectHubVisible(): Promise<void> {
-    await waitForFullyVisibleById(this.hubContainerId);
-    await detoxExpect(getElementById(this.hubContainerId)).toBeVisible();
-  }
-
   @Step("Expect hub action {{0}} to be pending")
   async expectActionPending(actionId: string): Promise<void> {
     await waitForFullyVisibleById(this.hubActionId(actionId));
-    await detoxExpect(getElementById(this.hubActionId(actionId))).toBeVisible();
   }
 
   @Step("Tap post-onboarding hub action {{0}}")
@@ -45,13 +36,14 @@ export default class PostOnboardingHubPage {
 
   @Step("Complete mock action and return to post-onboarding hub")
   async completeMockActionAndReturnToHub(): Promise<void> {
-    await waitForElementById(this.mockCompleteAndBackToHubId);
+    await waitForFullyVisibleById(this.mockCompleteAndBackToHubId);
     await tapById(this.mockCompleteAndBackToHubId);
     await waitForFullyVisibleById(this.hubContainerId);
   }
 
   @Step("Expect hub action {{0}} to be completed")
   async expectActionCompleted(actionId: string, completedLabel: string): Promise<void> {
+    await waitForFullyVisibleById(this.hubActionId(actionId));
     await detoxExpect(
       getElementByIdWithDescendantTexts(this.hubActionId(actionId), completedLabel),
     ).toBeVisible();
@@ -59,8 +51,7 @@ export default class PostOnboardingHubPage {
 
   @Step("Expect all post-onboarding hub actions to be completed")
   async expectAllActionsCompleted(): Promise<void> {
-    await waitForElementById(this.hubCompleteButtonId);
-    await detoxExpect(getElementById(this.hubCompleteButtonId)).toBeVisible();
+    await waitForFullyVisibleById(this.hubCompleteButtonId);
   }
 
   @Step("Tap post-onboarding hub complete button")

--- a/e2e/mobile/specs/postOnboarding/postOnboardingHub.ts
+++ b/e2e/mobile/specs/postOnboarding/postOnboardingHub.ts
@@ -1,0 +1,61 @@
+import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
+import { setTeamOwner } from "helpers/allure/allure-helper";
+
+import type { ApplicationOptions } from "page";
+import type { OptionalFeatureMap } from "@shared/feature-flags";
+
+export const MOCK_ACTIONS = [
+  "assetsTransferMock",
+  "syncAccountsMock",
+  "discoverWalletMock",
+] as const;
+
+// Wallet 4.0 + onboardingWidget come from E2E defaults; only pin flags that would block the widget.
+export const POST_ONBOARDING_FLAGS: OptionalFeatureMap = {
+  protectServicesMobile: { enabled: false },
+  lwmProductTour: { enabled: false },
+  llmLedgerSyncEntryPoints: { enabled: false },
+};
+
+export const POST_ONBOARDING_USERDATA = "post-onboarding-hub-flow";
+
+// i18n `postOnboarding.drawer.actionCompletedLabel`
+export const ACTION_COMPLETED_LABEL = "Complete";
+
+async function initApp(options: ApplicationOptions = {}) {
+  await app.init({
+    userdata: options.userdata ?? POST_ONBOARDING_USERDATA,
+    featureFlags: { ...POST_ONBOARDING_FLAGS, ...options.featureFlags },
+  });
+  await app.mainNavigation.waitForWallet40Ready();
+}
+
+export function runPostOnboardingHubFlowTest(tmsLinks: string[], tags: string[]) {
+  describe("Post-onboarding hub", () => {
+    beforeAll(async () => {
+      await initApp();
+    });
+
+    setTeamOwner(Team.ENGAGEMENT);
+    tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
+    tags.forEach(tag => $Tag(tag));
+
+    it("Full post-onboarding hub flow — all mock steps", async () => {
+      expect(MOCK_ACTIONS).toHaveLength(3);
+
+      await app.postOnboardingHub.expectWidgetVisible();
+      await app.postOnboardingHub.openHubFromWidget();
+
+      for (const actionId of MOCK_ACTIONS) {
+        await app.postOnboardingHub.expectActionPending(actionId);
+        await app.postOnboardingHub.tapAction(actionId);
+        await app.postOnboardingHub.completeMockActionAndReturnToHub();
+        await app.postOnboardingHub.expectActionCompleted(actionId, ACTION_COMPLETED_LABEL);
+      }
+
+      await app.postOnboardingHub.expectAllActionsCompleted();
+      await app.postOnboardingHub.tapCompleteButton();
+      await app.postOnboardingHub.expectWidgetHidden();
+    });
+  });
+}

--- a/e2e/mobile/specs/postOnboarding/postOnboardingHub.ts
+++ b/e2e/mobile/specs/postOnboarding/postOnboardingHub.ts
@@ -1,9 +1,10 @@
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
-import { setTeamOwner } from "helpers/allure/allure-helper";
+import { setTeamOwner } from "@e2e/helpers/allure/allure-helper";
 
-import type { ApplicationOptions } from "page";
+import type { ApplicationOptions } from "@e2e/page/index";
 import type { OptionalFeatureMap } from "@shared/feature-flags";
 
+/** Must stay in sync with `postOnboarding.actionsToComplete` in userdata/post-onboarding-hub-flow.json. */
 export const MOCK_ACTIONS = [
   "assetsTransferMock",
   "syncAccountsMock",
@@ -30,6 +31,10 @@ async function initApp(options: ApplicationOptions = {}) {
   await app.mainNavigation.waitForWallet40Ready();
 }
 
+/**
+ * B2CQA-6545. Mock post-onboarding hub flow — no Speculos; each step completes via
+ * PostOnboardingMockActionScreen.
+ */
 export function runPostOnboardingHubFlowTest(tmsLinks: string[], tags: string[]) {
   describe("Post-onboarding hub", () => {
     beforeAll(async () => {
@@ -41,8 +46,6 @@ export function runPostOnboardingHubFlowTest(tmsLinks: string[], tags: string[])
     tags.forEach(tag => $Tag(tag));
 
     it("Full post-onboarding hub flow — all mock steps", async () => {
-      expect(MOCK_ACTIONS).toHaveLength(3);
-
       await app.postOnboardingHub.expectWidgetVisible();
       await app.postOnboardingHub.openHubFromWidget();
 

--- a/e2e/mobile/specs/postOnboarding/postOnboardingHubFlow.spec.ts
+++ b/e2e/mobile/specs/postOnboarding/postOnboardingHubFlow.spec.ts
@@ -1,6 +1,8 @@
-import { runPostOnboardingHubFlowTest } from "./postOnboardingHub";
+import { runPostOnboardingHubFlowTest } from "@e2e/specs/postOnboarding/postOnboardingHub";
 
-runPostOnboardingHubFlowTest(
-  ["B2CQA-6545"],
-  ["@postOnboarding", "@NanoSP", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],
-);
+const testConfig = {
+  tmsLinks: ["B2CQA-6545"],
+  tags: ["@postOnboarding", "@NanoSP", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],
+};
+
+runPostOnboardingHubFlowTest(testConfig.tmsLinks, testConfig.tags);

--- a/e2e/mobile/specs/postOnboarding/postOnboardingHubFlow.spec.ts
+++ b/e2e/mobile/specs/postOnboarding/postOnboardingHubFlow.spec.ts
@@ -1,0 +1,6 @@
+import { runPostOnboardingHubFlowTest } from "./postOnboardingHub";
+
+runPostOnboardingHubFlowTest(
+  ["B2CQA-6545"],
+  ["@postOnboarding", "@NanoSP", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],
+);

--- a/e2e/mobile/userdata/post-onboarding-hub-flow.json
+++ b/e2e/mobile/userdata/post-onboarding-hub-flow.json
@@ -7,7 +7,6 @@
     },
     "settings": {
       "hasCompletedOnboarding": true,
-      "onboardingCompletionDate": "2026-08-20T10:00:00.000Z",
       "hasBeenRedirectedToPostOnboarding": true,
       "counterValue": "USD",
       "language": "en",
@@ -59,7 +58,7 @@
     "postOnboarding": {
       "deviceModelId": "stax",
       "walletEntryPointDismissed": false,
-      "entryPointFirstDisplayedDate": "2026-08-20T10:00:00.000Z",
+      "entryPointFirstDisplayedDate": null,
       "walletEntryPointEligibleForPortfolio": true,
       "actionsToComplete": ["assetsTransferMock", "syncAccountsMock", "discoverWalletMock"],
       "actionsCompleted": {
@@ -69,7 +68,7 @@
       },
       "lastActionCompleted": null,
       "postOnboardingInProgress": true,
-      "onboardingDate": "2026-08-20T10:00:00.000Z"
+      "onboardingDate": null
     },
     "featureFlags": {
       "overrides": {},

--- a/e2e/mobile/userdata/post-onboarding-hub-flow.json
+++ b/e2e/mobile/userdata/post-onboarding-hub-flow.json
@@ -1,0 +1,79 @@
+{
+  "data": {
+    "SPECTRON_RUN": {
+      "localStorage": {
+        "acceptedTermsVersion": "2019-12-04"
+      }
+    },
+    "settings": {
+      "hasCompletedOnboarding": true,
+      "onboardingCompletionDate": "2026-08-20T10:00:00.000Z",
+      "hasBeenRedirectedToPostOnboarding": true,
+      "counterValue": "USD",
+      "language": "en",
+      "theme": "light",
+      "region": null,
+      "locale": "en-US",
+      "orderAccounts": "balance|desc",
+      "countervalueFirst": false,
+      "autoLockTimeout": 10,
+      "marketIndicator": "western",
+      "currenciesSettings": {},
+      "pairExchanges": {},
+      "developerMode": false,
+      "loaded": true,
+      "shareAnalytics": false,
+      "sharePersonalizedRecommandations": false,
+      "hasSeenAnalyticsOptInPrompt": true,
+      "analyticsEnabled": false,
+      "personalizedRecommendationsEnabled": false,
+      "trackingEnabled": false,
+      "sentryLogs": true,
+      "readOnlyModeEnabled": false,
+      "hasOrderedNano": true,
+      "lastUsedVersion": "99.99.99",
+      "dismissedBanners": [],
+      "accountsViewMode": "list",
+      "showAccountsHelperBanner": true,
+      "hideEmptyTokenAccounts": false,
+      "sidebarCollapsed": false,
+      "discreetMode": false,
+      "preferredDeviceModel": "stax",
+      "hasInstalledApps": true,
+      "dismissedDynamicCards": [],
+      "seenDevices": [],
+      "blacklistedTokenIds": [],
+      "swapAcceptedProviderIds": [],
+      "deepLinkUrl": null,
+      "firstTimeLend": false,
+      "swapProviders": [],
+      "showClearCacheBanner": false,
+      "starredAccountIds": [],
+      "hasPassword": false
+    },
+    "user": {
+      "id": "08cf3393-c5eb-4ea7-92de-0deea22e3971"
+    },
+    "accounts": [],
+    "countervalues": {},
+    "postOnboarding": {
+      "deviceModelId": "stax",
+      "walletEntryPointDismissed": false,
+      "entryPointFirstDisplayedDate": "2026-08-20T10:00:00.000Z",
+      "walletEntryPointEligibleForPortfolio": true,
+      "actionsToComplete": ["assetsTransferMock", "syncAccountsMock", "discoverWalletMock"],
+      "actionsCompleted": {
+        "assetsTransferMock": false,
+        "syncAccountsMock": false,
+        "discoverWalletMock": false
+      },
+      "lastActionCompleted": null,
+      "postOnboardingInProgress": true,
+      "onboardingDate": "2026-08-20T10:00:00.000Z"
+    },
+    "featureFlags": {
+      "overrides": {},
+      "bannerVisible": false
+    }
+  }
+}

--- a/libs/live-e2e-shared/src/enum/Team.ts
+++ b/libs/live-e2e-shared/src/enum/Team.ts
@@ -5,4 +5,5 @@ export enum Team {
   BUY_AND_SELL = "BuyAndSell",
   EARN = "Earn",
   BST = "BST",
+  ENGAGEMENT = "Engagement",
 }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Add mobile E2E coverage for the full post-onboarding hub flow [B2CQA-6545](https://ledgerhq.atlassian.net/browse/B2CQA-6545)): widget → hub → 3 mock steps → complete → widget dismissed. Includes testIDs, userdata fixture, page object, and E2E bridge support for postOnboarding state import.

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-31323]<!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[B2CQA-6545]: https://ledgerhq.atlassian.net/browse/B2CQA-6545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-31323]: https://ledgerhq.atlassian.net/browse/LIVE-31323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ