### PR TITLE
[LWDM] feat(coin-celo): add USAT as a fee currency (LIVE-36459)

### DIFF
--- a/.changeset/lucky-otters-wander.md
+++ b/.changeset/lucky-otters-wander.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-celo": minor
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Celo: add USAT (Tether America USD) to the fee currencies that can be selected to pay gas

--- a/libs/coin-modules/coin-celo/src/__tests__/constants.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/constants.test.ts
@@ -19,6 +19,7 @@ describe("celo fee currency constants", () => {
       "CELO",
       "USDT",
       "USDC",
+      "USAT",
       "PHPm",
       "KESm",
       "ZARm",
@@ -41,11 +42,14 @@ describe("celo fee currency constants", () => {
   it("keeps adapter address distinct from token contract for 6 decimals stablecoins", () => {
     const usdc = FEE_CURRENCY_OPTIONS.find(option => option.name === "USDC");
     const usdt = FEE_CURRENCY_OPTIONS.find(option => option.name === "USDT");
+    const usat = FEE_CURRENCY_OPTIONS.find(option => option.name === "USAT");
 
     expect(usdc?.adapterAddress).toEqual(expect.any(String));
     expect(usdt?.adapterAddress).toEqual(expect.any(String));
+    expect(usat?.adapterAddress).toEqual(expect.any(String));
     expect(usdc?.adapterAddress).not.toEqual(usdc?.contractAddress);
     expect(usdt?.adapterAddress).not.toEqual(usdt?.contractAddress);
+    expect(usat?.adapterAddress).not.toEqual(usat?.contractAddress);
   });
 
   it("supports case-insensitive lookup by token contract address", () => {

--- a/libs/coin-modules/coin-celo/src/constants.ts
+++ b/libs/coin-modules/coin-celo/src/constants.ts
@@ -37,7 +37,7 @@ export const CELO_STAKING_FALLBACK_GAS_LIMIT = 1_000_000n;
  * Celo's protocol allows users to pay gas in tokens other than the native CELO.
  * The on-chain allowlist is managed by `FeeCurrencyDirectory.sol`.
  *
- * Tokens with fewer than 18 decimals (USDC, USDT) use an **adapter** contract
+ * Tokens with fewer than 18 decimals (USDC, USDT, USAT) use an **adapter** contract
  * instead of the token address for `feeCurrency`. The adapter normalizes values
  * to 18 decimals so the protocol can price gas consistently. For these tokens:
  *   - `feeCurrency` on the transaction → adapter address
@@ -70,6 +70,11 @@ export const FEE_CURRENCY_OPTIONS: {
     name: "USDC",
     adapterAddress: "0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B",
     contractAddress: "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+  },
+  {
+    name: "USAT",
+    adapterAddress: "0x0357EE22278c922e1D36cFe6b899269b161880C4",
+    contractAddress: "0xD2ab3C9A02DBBAB236BfEC45D1d755DF4267F771",
   },
   {
     name: "PHPm",


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Adds USAT (Tether America USD) to Celo's fee-currency allowlist, so holders can pay gas in USAT alongside CELO, USDC and USDT. `FEE_CURRENCY_OPTIONS` is the single source — the "Pay fees in" selector and CIP-64 transaction building both derive from it.

The ticket supplies only the token address, and USAT is 6-decimal, so CIP-64 needs a separate adapter contract for `tx.feeCurrency`; that pair is the thing worth checking in review. Both were resolved against Celo mainnet: adapter `0x0357EE22278c922e1D36cFe6b899269b161880C4` is the address `FeeCurrencyDirectory.getCurrencies()` registers, its storage points back at token `0xD2ab…F771` with a 1e12 scale factor, and the directory returns a live exchange rate for it. USAT is already in CAL, so nothing is blocked there.

The exact-list assertion is updated and the adapter≠token check now covers USAT; the coin-celo suite passes. Verified on-chain and by unit tests — not yet exercised end-to-end in the app.

Out of scope: `XAUt0`, the other directory entry LL does not list.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36459](https://ledgerhq.atlassian.net/browse/LIVE-36459?atlOrigin=eyJpIjoiODNhMWExOGViODYyNGEzYWE3YTRlNGNhM2IyOTJhOTgiLCJwIjoiaiJ9)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-36459]: https://ledgerhq.atlassian.net/browse/LIVE-36459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ