### PR TITLE
[LWDM] feat(aleo): staking details endpoints (LIVE-32273)

### DIFF
--- a/.changeset/wild-pianos-listen.md
+++ b/.changeset/wild-pianos-listen.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+aleo: read staking positions from the credits.aleo bonded, unbonding and withdraw mappings

--- a/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
@@ -1,4 +1,5 @@
 import BigNumber from "bignumber.js";
+import { log } from "@ledgerhq/logs";
 import type { TransactionIntent } from "@ledgerhq/coin-module-framework/api/types";
 import aleoConfig from "../config";
 import {
@@ -110,6 +111,7 @@ import {
   isTokenRecord,
   classifyAleoTokenType,
   resolvePrivacyContext,
+  toStakingPosition,
 } from "./utils";
 
 jest.mock("../config");
@@ -2964,6 +2966,118 @@ describe("staking rates", () => {
       const rate = estimateNetRate({ ...baseParams, commissionPercent: new BigNumber(-1) });
 
       expect(rate).toBeNull();
+    });
+  });
+});
+
+describe("toStakingPosition", () => {
+  const ADDRESS = "aleo1d37xxnms3sq5qxcnnh3dtvzr35xemjzas4jcytjr8uvymfetnu9salav5n";
+  const BONDED_RAW = `{\n  validator: ${ADDRESS},\n  microcredits: 39339243096u64\n}`;
+  const UNBONDING_RAW = "{\n  microcredits: 39339243096u64,\n  height: 7654321u32\n}";
+  const WITHDRAW_RAW = "aleo1g5wrxvgyvckgtuceg36eg6pf024x3p6nex05lcefz0h6576rmgrs22dr4w";
+
+  const noEntries = { bondedRaw: null, unbondingRaw: null, withdrawRaw: null };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("reads a zero position for an address that never bonded", () => {
+    // Absent is not zero on chain, but it is the honest reading here — and must not throw.
+    const position = toStakingPosition(noEntries);
+
+    expect(position.bondedBalance.toString()).toBe("0");
+    expect(position.bondedValidator).toBeNull();
+    expect(position.unbondingBalance.toString()).toBe("0");
+    expect(position.unbondingHeight).toBeNull();
+    expect(position.withdrawalAddress).toBeNull();
+  });
+
+  it("reads an empty mapping body as absent rather than unparseable", () => {
+    // The node answers 200 + JSON null today, but `res.data` is an unchecked cast — an empty
+    // body must not read as a failed parse and kill the sync for an address with no stake.
+    const position = toStakingPosition({ bondedRaw: "", unbondingRaw: "", withdrawRaw: "" });
+
+    expect(position.bondedBalance.toString()).toBe("0");
+    expect(position.withdrawalAddress).toBeNull();
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("parses a bonded-only address", () => {
+    const position = toStakingPosition({
+      ...noEntries,
+      bondedRaw: BONDED_RAW,
+      withdrawRaw: WITHDRAW_RAW,
+    });
+
+    expect(position.bondedBalance.toString()).toBe("39339243096");
+    expect(position.bondedValidator).toBe(ADDRESS);
+    expect(position.unbondingBalance.toString()).toBe("0");
+    expect(position.unbondingHeight).toBeNull();
+    expect(position.withdrawalAddress).toBe(WITHDRAW_RAW);
+  });
+
+  it("parses a bonded-plus-unbonding address", () => {
+    const position = toStakingPosition({
+      bondedRaw: BONDED_RAW,
+      unbondingRaw: UNBONDING_RAW,
+      withdrawRaw: WITHDRAW_RAW,
+    });
+
+    expect(position.bondedBalance.toString()).toBe("39339243096");
+    expect(position.bondedValidator).toBe(ADDRESS);
+    expect(position.unbondingBalance.toString()).toBe("39339243096");
+    expect(position.unbondingHeight).toBe(7654321);
+    expect(position.withdrawalAddress).toBe(WITHDRAW_RAW);
+  });
+
+  it("returns the withdrawal address even once nothing is bonded", () => {
+    const position = toStakingPosition({ ...noEntries, withdrawRaw: WITHDRAW_RAW });
+
+    expect(position.bondedBalance.toString()).toBe("0");
+    expect(position.withdrawalAddress).toBe(WITHDRAW_RAW);
+  });
+
+  it("keeps precision on a position above Number.MAX_SAFE_INTEGER", () => {
+    const huge = "9007199254740993"; // 2^53 + 1
+    const position = toStakingPosition({
+      ...noEntries,
+      bondedRaw: `{\n  validator: ${ADDRESS},\n  microcredits: ${huge}u64\n}`,
+    });
+
+    expect(position.bondedBalance.toFixed()).toBe(huge);
+  });
+
+  describe("unparseable values", () => {
+    const cases = [
+      ["bonded", { bondedRaw: "{ garbage }" }],
+      ["unbonding", { unbondingRaw: "{ garbage }" }],
+      ["withdraw", { withdrawRaw: "not-an-address" }],
+      // Half-parsed is worse than unparsed: a validator with a zero stake, or an
+      // unbonding amount with no height, would both read as a real position.
+      ["bonded", { bondedRaw: `{\n  validator: ${ADDRESS}\n}` }],
+      ["unbonding", { unbondingRaw: "{\n  microcredits: 39339243096u64\n}" }],
+    ] as const;
+
+    it.each(cases)("throws rather than reporting a zero position for %s", (mapping, mocks) => {
+      // A zero position here would silently hide a real stake, so this must be loud.
+      expect(() => toStakingPosition({ ...noEntries, ...mocks })).toThrow(
+        `aleo: unparseable ${mapping} mapping value`,
+      );
+    });
+
+    it.each(cases)("logs the raw %s value that failed to parse", (mapping, mocks) => {
+      expect(() => toStakingPosition({ ...noEntries, ...mocks })).toThrow(
+        `aleo: unparseable ${mapping} mapping value`,
+      );
+
+      // The raw value is the whole point of the log line: without it the failure is undiagnosable.
+      expect(log).toHaveBeenCalledTimes(1);
+      expect(log).toHaveBeenCalledWith(
+        "aleo/stakingPosition",
+        `unparseable ${mapping} mapping value`,
+        { raw: Object.values(mocks)[0] },
+      );
     });
   });
 });

--- a/libs/coin-modules/coin-aleo/src/logic/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.ts
@@ -1,5 +1,6 @@
 import BigNumber from "bignumber.js";
 import invariant from "invariant";
+import { log } from "@ledgerhq/logs";
 import { findCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
 import type {
   Account,
@@ -63,6 +64,7 @@ import type {
   AleoTokenDetails,
   AleoTokenType,
   EnrichedPrivateRecord,
+  AleoStakingPosition,
 } from "../types";
 
 const MICROCREDITS_REGEX = /^(\d+)u\d+$/;
@@ -89,6 +91,70 @@ export function parseMicrocredits(microcredits: string): string {
 export function parseAmount(raw: string | null): BigNumber {
   if (!raw) return new BigNumber(0);
   return new BigNumber(matchAleoPlaintextAmount(raw) ?? 0);
+}
+
+const VALIDATOR_FIELD_REGEX = /validator:\s*(aleo1[0-9a-z]+)/;
+const MICROCREDITS_FIELD_REGEX = /microcredits:\s*(\d+u64)/;
+const HEIGHT_FIELD_REGEX = /height:\s*(\d+)u32/;
+const ADDRESS_PLAINTEXT_REGEX = /^(aleo1[0-9a-z]+)$/;
+
+function parseBondedMapping(raw: string): { validator: string; microcredits: BigNumber } | null {
+  const validator = VALIDATOR_FIELD_REGEX.exec(raw)?.[1];
+  const microcredits = MICROCREDITS_FIELD_REGEX.exec(raw)?.[1];
+  if (!validator || !microcredits) return null;
+
+  return { validator, microcredits: parseAmount(microcredits) };
+}
+
+function parseUnbondingMapping(raw: string): { microcredits: BigNumber; height: number } | null {
+  const microcredits = MICROCREDITS_FIELD_REGEX.exec(raw)?.[1];
+  const height = HEIGHT_FIELD_REGEX.exec(raw)?.[1];
+  if (!microcredits || !height) return null;
+
+  return { microcredits: parseAmount(microcredits), height: Number(height) };
+}
+
+function parseWithdrawMapping(raw: string): string | null {
+  return ADDRESS_PLAINTEXT_REGEX.exec(normalizeAleoPlaintext(raw))?.[1] ?? null;
+}
+
+function parseStakingMapping<T>(
+  mapping: string,
+  raw: string | null,
+  parse: (raw: string) => T | null,
+): T | null {
+  // `res.data` is an unchecked cast, so treat any empty value as "no entry" rather than
+  // trusting the declared `string | null` — the node answers 200 + JSON null for that case.
+  if (!raw) return null;
+
+  const parsed = parse(raw);
+  if (parsed === null) {
+    log("aleo/stakingPosition", `unparseable ${mapping} mapping value`, { raw });
+    throw new Error(`aleo: unparseable ${mapping} mapping value`);
+  }
+
+  return parsed;
+}
+
+export function toStakingPosition({
+  bondedRaw,
+  unbondingRaw,
+  withdrawRaw,
+}: {
+  bondedRaw: string | null;
+  unbondingRaw: string | null;
+  withdrawRaw: string | null;
+}): AleoStakingPosition {
+  const bonded = parseStakingMapping("bonded", bondedRaw, parseBondedMapping);
+  const unbonding = parseStakingMapping("unbonding", unbondingRaw, parseUnbondingMapping);
+
+  return {
+    bondedBalance: bonded?.microcredits ?? new BigNumber(0),
+    bondedValidator: bonded?.validator ?? null,
+    unbondingBalance: unbonding?.microcredits ?? new BigNumber(0),
+    unbondingHeight: unbonding?.height ?? null,
+    withdrawalAddress: parseStakingMapping("withdraw", withdrawRaw, parseWithdrawMapping),
+  };
 }
 
 export function isTokenRecord(record: AleoPrivateRecord): boolean {

--- a/libs/coin-modules/coin-aleo/src/network/api.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/api.test.ts
@@ -1285,4 +1285,47 @@ describe("apiClient", () => {
       });
     });
   });
+
+  describe("staking mappings", () => {
+    const mappings = [
+      ["getBondedMapping", "bonded"],
+      ["getUnbondingMapping", "unbonding"],
+      ["getWithdrawMapping", "withdraw"],
+    ] as const;
+
+    it.each(mappings)("%s reads from the configured network", async (method, mapping) => {
+      for (const config of [mockConfig, testnetConfig]) {
+        jest.mocked(network).mockClear().mockResolvedValue({ data: null, status: 200 });
+
+        await apiClient[method](config, MOCK_ALEO_ADDRESS);
+
+        expect(network).toHaveBeenCalledTimes(1);
+        expect(network).toHaveBeenCalledWith({
+          method: "GET",
+          url: `${config.apiUrls.node}/v2/${config.networkType}/program/credits.aleo/mapping/${mapping}/${MOCK_ALEO_ADDRESS}`,
+        });
+      }
+    });
+
+    it.each(mappings)("%s passes the raw plaintext through untouched", async method => {
+      const raw = "{\n  microcredits: 111468399u64\n}";
+      jest.mocked(network).mockResolvedValue({ data: raw, status: 200 });
+
+      await expect(apiClient[method](mockConfig, MOCK_ALEO_ADDRESS)).resolves.toBe(raw);
+    });
+
+    it.each(mappings)("%s returns null for an address with no entry", async method => {
+      jest.mocked(network).mockResolvedValue({ data: null, status: 200 });
+
+      await expect(apiClient[method](mockConfig, MOCK_ALEO_ADDRESS)).resolves.toBeNull();
+    });
+
+    it.each(mappings)("%s propagates network failures", async method => {
+      jest.mocked(network).mockRejectedValue(new Error("Network error"));
+
+      await expect(apiClient[method](mockConfig, MOCK_ALEO_ADDRESS)).rejects.toThrow(
+        "Network error",
+      );
+    });
+  });
 });

--- a/libs/coin-modules/coin-aleo/src/network/api.ts
+++ b/libs/coin-modules/coin-aleo/src/network/api.ts
@@ -41,6 +41,42 @@ async function getAccountBalance(config: AleoCoinConfig, address: string): Promi
   return res.data;
 }
 
+async function getBondedMapping(config: AleoCoinConfig, address: string): Promise<string | null> {
+  const { apiUrls, networkType } = config;
+
+  const res = await network<string | null>({
+    method: "GET",
+    url: `${apiUrls.node}/v2/${networkType}/program/${PROGRAM_ID.CREDITS}/mapping/bonded/${address}`,
+  });
+
+  return res.data;
+}
+
+async function getUnbondingMapping(
+  config: AleoCoinConfig,
+  address: string,
+): Promise<string | null> {
+  const { apiUrls, networkType } = config;
+
+  const res = await network<string | null>({
+    method: "GET",
+    url: `${apiUrls.node}/v2/${networkType}/program/${PROGRAM_ID.CREDITS}/mapping/unbonding/${address}`,
+  });
+
+  return res.data;
+}
+
+async function getWithdrawMapping(config: AleoCoinConfig, address: string): Promise<string | null> {
+  const { apiUrls, networkType } = config;
+
+  const res = await network<string | null>({
+    method: "GET",
+    url: `${apiUrls.node}/v2/${networkType}/program/${PROGRAM_ID.CREDITS}/mapping/withdraw/${address}`,
+  });
+
+  return res.data;
+}
+
 async function getCommittee(config: AleoCoinConfig): Promise<AleoCommitteeResponse> {
   const { apiUrls, networkType } = config;
 
@@ -365,6 +401,9 @@ async function submitEncryptedDelegatedProvingRequest({
 export const apiClient = {
   getLatestBlock,
   getAccountBalance,
+  getBondedMapping,
+  getUnbondingMapping,
+  getWithdrawMapping,
   getCommittee,
   getValidatorMetadata,
   getTotalSupply,

--- a/libs/coin-modules/coin-aleo/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.test.ts
@@ -35,6 +35,7 @@ import {
   accessProvableApi,
   decryptRecordAmount,
   sumUnspentRecords,
+  getStakingPosition,
 } from "./utils";
 
 jest.mock("./api");
@@ -3350,5 +3351,49 @@ describe("network/utils", () => {
         }),
       );
     });
+  });
+});
+
+describe("getStakingPosition", () => {
+  const config = getMockedConfig("mainnet");
+  const ADDRESS = "aleo1d37xxnms3sq5qxcnnh3dtvzr35xemjzas4jcytjr8uvymfetnu9salav5n";
+  const BONDED_RAW = `{\n  validator: ${ADDRESS},\n  microcredits: 39339243096u64\n}`;
+  const WITHDRAW_RAW = "aleo1g5wrxvgyvckgtuceg36eg6pf024x3p6nex05lcefz0h6576rmgrs22dr4w";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(apiClient.getBondedMapping).mockResolvedValue(null);
+    jest.mocked(apiClient.getUnbondingMapping).mockResolvedValue(null);
+    jest.mocked(apiClient.getWithdrawMapping).mockResolvedValue(null);
+  });
+
+  it("reads all three mappings for the address", async () => {
+    await getStakingPosition(config, ADDRESS);
+
+    expect(apiClient.getBondedMapping).toHaveBeenCalledTimes(1);
+    expect(apiClient.getBondedMapping).toHaveBeenCalledWith(config, ADDRESS);
+    expect(apiClient.getUnbondingMapping).toHaveBeenCalledTimes(1);
+    expect(apiClient.getUnbondingMapping).toHaveBeenCalledWith(config, ADDRESS);
+    expect(apiClient.getWithdrawMapping).toHaveBeenCalledTimes(1);
+    expect(apiClient.getWithdrawMapping).toHaveBeenCalledWith(config, ADDRESS);
+  });
+
+  it("returns the assembled position", async () => {
+    jest.mocked(apiClient.getBondedMapping).mockResolvedValue(BONDED_RAW);
+    jest.mocked(apiClient.getWithdrawMapping).mockResolvedValue(WITHDRAW_RAW);
+
+    const position = await getStakingPosition(config, ADDRESS);
+
+    expect(position.bondedBalance.toString()).toBe("39339243096");
+    expect(position.bondedValidator).toBe(ADDRESS);
+    expect(position.withdrawalAddress).toBe(WITHDRAW_RAW);
+  });
+
+  it("propagates a failure on any one of the three reads", async () => {
+    jest
+      .mocked(apiClient.getWithdrawMapping)
+      .mockRejectedValue(new LedgerAPI5xx("Internal Server Error"));
+
+    await expect(getStakingPosition(config, ADDRESS)).rejects.toThrow("Internal Server Error");
   });
 });

--- a/libs/coin-modules/coin-aleo/src/network/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.ts
@@ -23,6 +23,7 @@ import type {
   AleoTokenDetails,
   AleoTransitionCursor,
   AleoExactTransitionCursor,
+  AleoStakingPosition,
 } from "../types";
 import {
   hasPublicAddress,
@@ -30,9 +31,23 @@ import {
   isParsableTransferFunction,
   parseAmount,
   parseMicrocredits,
+  toStakingPosition,
 } from "../logic/utils";
 import { register } from "../logic/register";
 import { apiClient } from "./api";
+
+export async function getStakingPosition(
+  config: AleoCoinConfig,
+  address: string,
+): Promise<AleoStakingPosition> {
+  const [bondedRaw, unbondingRaw, withdrawRaw] = await Promise.all([
+    apiClient.getBondedMapping(config, address),
+    apiClient.getUnbondingMapping(config, address),
+    apiClient.getWithdrawMapping(config, address),
+  ]);
+
+  return toStakingPosition({ bondedRaw, unbondingRaw, withdrawRaw });
+}
 
 export async function decryptRecordAmount(
   config: AleoCoinConfig,

--- a/libs/coin-modules/coin-aleo/src/types/logic.ts
+++ b/libs/coin-modules/coin-aleo/src/types/logic.ts
@@ -62,6 +62,14 @@ export type AleoValidator = {
   estimatedYearlyRewardsRate?: number;
 };
 
+export type AleoStakingPosition = {
+  bondedBalance: BigNumber;
+  bondedValidator: string | null;
+  unbondingBalance: BigNumber;
+  unbondingHeight: number | null;
+  withdrawalAddress: string | null;
+};
+
 /** `<maxBlockHeight>:<blockNumber>:<transitionId>` — the pinned ceiling, then the row to resume after. */
 export type OperationsCursor = {
   maxBlockHeight: number;


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Groundwork for Aleo staking: reads a delegator's staking position from the three
`credits.aleo` mappings and assembles it into one typed value.

Read-only and **not yet wired into `sync`** — no user-visible change in this PR.
It exists so the staking UI work can build on a settled data shape.

**What's added**

| Layer | Addition |
| --- | --- |
| `network/api.ts` | `getBondedMapping`, `getUnbondingMapping`, `getWithdrawMapping` — `GET /v2/{network}/program/credits.aleo/mapping/{name}/{address}` |
| `network/utils.ts` | `getStakingPosition(config, address)` — fans the three reads out with `Promise.all` |
| `logic/utils.ts` | `toStakingPosition({ bondedRaw, unbondingRaw, withdrawRaw })` — pure parsing of the Leo struct plaintexts |
| `types/logic.ts` | `AleoStakingPosition` |

**Usage**

```ts
import { getStakingPosition } from "./network/utils";

const position = await getStakingPosition(config, address);
// {
//   bondedBalance:      BigNumber("39339243096"),  // microcredits
//   bondedValidator:    "aleo1d37xx…",
//   unbondingBalance:   BigNumber(0),
//   unbondingHeight:    null,                      // block height the claim unlocks at
//   withdrawalAddress:  "aleo1g5wrx…",
// }
```

**Notes for reviewers**

- **Parse failures throw, they don't degrade to zero.** The mappings carry the whole
  position, so a silent `0` would hide a real stake behind a healthy-looking UI. A
  half-parsed value counts as a failure too — a validator with no amount, or an unbonding
  amount with no height, would both read as a real position. The raw value goes to `log()`
  before the throw, since it's the only thing that makes the failure diagnosable.
- **Absent ≠ unparseable.** The node answers `200` + JSON `null` for an address with no
  entry (verified against mainnet), which reads as a zero position. Since `res.data` is an
  unchecked cast, any empty value is treated the same way rather than trusting the declared
  `string | null`.
- **`withdrawalAddress` outlives the stake** — it stays set after everything is unbonded,
  and is read independently of the bonded mapping for that reason.
- **Amounts stay `BigNumber` end to end**, never `Number` — `u64` microcredits exceed
  `Number.MAX_SAFE_INTEGER` and there's a regression test pinning that.

**Testing**

31 unit tests, no integ test (these are plain reads with no signing path):
`toStakingPosition` 16 · `apiClient` staking mappings 12 · `getStakingPosition` 3.
Full `coin-aleo` suite green (1113 passed / 37 suites).


### 🔗 Context

- **JIRA / GitHub issue**: [https://ledgerhq.atlassian.net/browse/LIVE-32273](https://ledgerhq.atlassian.net/browse/LIVE-32273)
