### PR TITLE
[LWM] fix(fastlane): reduce play edits when inferring android version code

### DIFF
--- a/apps/ledger-live-mobile/fastlane/Fastfile
+++ b/apps/ledger-live-mobile/fastlane/Fastfile
@@ -25,15 +25,19 @@ IPA_DIRECTORY = "#{OUTPUT_DIRECTORY}/#{PROJECT_NAME}.ipa"
 default_platform(:ios)
 package = load_json(json_path: "./package.json")
 
+# Every track CI uploads to must be listed here: Play permanently reserves each
+# version code ever uploaded. One Play edit per track, and creating them in quick
+# succession gets throttled, so keep this minimal.
+ANDROID_VERSION_CODE_TRACKS = ["internal", "production"].freeze
+
 def infer_android_version_code
-  # Checks all relevant tracks in the play console and take the highest (plus one).
-  ["Nightly", "internal", "beta", "alpha", "production", "Recover Beta"].map { |track|
+  @android_version_code ||= ANDROID_VERSION_CODE_TRACKS.map { |track|
     google_play_track_version_codes(
       package_name: "com.ledger.live",
       track: track,
       json_key_data: ENV["ANDROID_SERVICE_KEY_CONTENT"]
     ).map(&:to_i).max
-  }.max + 1
+  }.compact.max + 1
 end
 
 def trim_version_number(version)


### PR DESCRIPTION
The nightly Android build died on "Google Api Error: Invalid request - Daily edit creation quota exceeded". Despite the message this is a burst throttle on androidpublisher.edits.insert, not a daily budget: the same error recovered on retry ~1s later in other runs, and both nightly attempts failed on the 6th call either side of the midnight-PT reset.

infer_android_version_code created one Play edit per track across six tracks, and was called twice per build (bump_version_code and build), so every Android build burned 12 edits in ~10s just to read version codes.

Prune the track list to the two that can hold the highest code, and memoise so both call sites share one lookup: 12 edits -> 2.

- internal is the only track CI uploads to, and holds the global max
- production is kept as a promotion/rollback backstop
- alpha is dead (36176133, ~14M behind the current code)
- beta is promotion-only and mints no codes
- Nightly and Recover Beta have no CI writer; nightly ships via Firebase App Distribution and never uploads to Play

Memoising also stops the gradle versionCode and the exported ANDROID_BUILD_NUMBER drifting apart when a Play upload lands between the two lookups. Add .compact so a shorter list cannot raise on a track with no active release.

Test run: https://github.com/LedgerHQ/ledger-live-build/actions/runs/33056542687/job/98464642670