### PR TITLE
[LWDM] fix(coin-solana): match parsed txs by signature in listOperations

### DIFF
--- a/.changeset/solana-list-operations-signature-pairing.md
+++ b/.changeset/solana-list-operations-signature-pairing.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/coin-solana": patch
+---
+
+fix(coin-solana): pair each signature with its own parsed transaction in listOperations
+
+JSON-RPC batch responses are not order-guaranteed, so pairing the signature list with the parsed
+transaction batch by array position could attach another transaction's fee, feesPayer and balances
+to a signature. Transactions are now matched by their own signature.

--- a/libs/coin-modules/coin-solana/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-solana/src/logic/listOperations.ts
@@ -44,11 +44,11 @@ export async function listOperations(
 
   const sigStrings = signatures.map(s => s.signature);
   const parsed = await api.getParsedTransactions(sigStrings);
+  const txBySignature = indexTransactionsBySignature(parsed);
 
   const items: Operation[] = [];
-  for (let i = 0; i < signatures.length; i++) {
-    const sig = signatures[i];
-    const tx = parsed[i];
+  for (const sig of signatures) {
+    const tx = txBySignature.get(sig.signature);
     if (!tx?.meta || sig.blockTime === null || sig.blockTime === undefined) continue;
 
     if (minHeight > 0 && sig.slot < minHeight) continue;
@@ -64,10 +64,23 @@ export async function listOperations(
   const lastSig = signatures[signatures.length - 1];
   const hasMore = signatures.length === rpcLimit;
   const reachedMinHeightBoundary = minHeight > 0 && lastSig.slot < minHeight;
-  const next =
-    items.length > 0 && hasMore && !reachedMinHeightBoundary ? lastSig.signature : undefined;
+  const next = hasMore && !reachedMinHeightBoundary ? lastSig.signature : undefined;
 
   return { items, next };
+}
+
+/** JSON-RPC batch responses are not order-guaranteed, so pairing by array position is unsafe. */
+function indexTransactionsBySignature(
+  parsed: (ParsedTransactionWithMeta | null)[],
+): Map<string, ParsedTransactionWithMeta> {
+  const bySignature = new Map<string, ParsedTransactionWithMeta>();
+  for (const tx of parsed) {
+    if (!tx) continue;
+    for (const signature of tx.transaction.signatures) {
+      bySignature.set(signature, tx);
+    }
+  }
+  return bySignature;
 }
 
 type TxMeta = {

--- a/libs/coin-modules/coin-solana/src/logic/tests/listOperations.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/listOperations.test.ts
@@ -56,6 +56,16 @@ function makeParsedTx({
   };
 }
 
+/** A real node returns the transaction carrying the requested signature; echo it back. */
+function withSignature<T extends { transaction: { signatures: string[] } }>(
+  tx: T | null,
+  signature: string,
+): T | null {
+  return tx === null
+    ? null
+    : { ...tx, transaction: { ...tx.transaction, signatures: [signature] } };
+}
+
 describe("listOperations (MSW integration)", () => {
   it("should return empty page when no signatures found", async () => {
     server.use(
@@ -108,17 +118,20 @@ describe("listOperations (MSW integration)", () => {
             confirmationStatus: "finalized",
           },
         ],
-        getTransaction: () =>
-          makeParsedTx({
-            accountKeys: [
-              { pubkey: TEST_ADDRESS, signer: true, writable: true },
-              { pubkey: TEST_RECIPIENT, signer: false, writable: true },
-            ],
-            preBalances: [1_000_000_000, 0],
-            postBalances: [899_995_000, 100_000_000],
-            slot: 100,
-            blockTime,
-          }),
+        getTransaction: params =>
+          withSignature(
+            makeParsedTx({
+              accountKeys: [
+                { pubkey: TEST_ADDRESS, signer: true, writable: true },
+                { pubkey: TEST_RECIPIENT, signer: false, writable: true },
+              ],
+              preBalances: [1_000_000_000, 0],
+              postBalances: [899_995_000, 100_000_000],
+              slot: 100,
+              blockTime,
+            }),
+            String(params[0]),
+          ),
       }),
     );
 
@@ -158,13 +171,16 @@ describe("listOperations (MSW integration)", () => {
             confirmationStatus: "finalized",
           },
         ],
-        getTransaction: () =>
-          makeParsedTx({
-            accountKeys: [{ pubkey: TEST_ADDRESS, signer: true, writable: true }],
-            preBalances: [1_000_000],
-            postBalances: [995_000],
-            blockTime,
-          }),
+        getTransaction: params =>
+          withSignature(
+            makeParsedTx({
+              accountKeys: [{ pubkey: TEST_ADDRESS, signer: true, writable: true }],
+              preBalances: [1_000_000],
+              postBalances: [995_000],
+              blockTime,
+            }),
+            String(params[0]),
+          ),
       }),
     );
 
@@ -172,6 +188,75 @@ describe("listOperations (MSW integration)", () => {
 
     expect(result.items).toHaveLength(1);
     expect(result.items[0].tx.block.height).toBe(200);
+  });
+
+  it("should pair operations with their own transaction when the RPC batch is reordered", async () => {
+    const blockTime = 1700000000;
+    const txBySignature: Record<string, ReturnType<typeof makeParsedTx>> = {
+      sig1: makeParsedTx({
+        accountKeys: [
+          { pubkey: TEST_ADDRESS, signer: true, writable: true },
+          { pubkey: TEST_RECIPIENT, signer: false, writable: true },
+        ],
+        preBalances: [1_000_000_000, 0],
+        postBalances: [899_995_000, 100_000_000],
+        blockTime,
+      }),
+      sig2: makeParsedTx({
+        accountKeys: [{ pubkey: TEST_ADDRESS, signer: true, writable: true }],
+        preBalances: [1_000_000_000],
+        postBalances: [1_672_400_000],
+        blockTime,
+      }),
+    };
+
+    server.use(
+      http.post(TEST_ENDPOINT, async ({ request }) => {
+        const body = (await request.json()) as
+          | { method: string; params: unknown[]; id: unknown }
+          | { method: string; params: unknown[]; id: unknown }[];
+
+        if (!Array.isArray(body)) {
+          return HttpResponse.json({
+            jsonrpc: "2.0",
+            result: Object.keys(txBySignature).map(signature => ({
+              signature,
+              slot: 100,
+              blockTime,
+              err: null,
+              memo: null,
+              confirmationStatus: "finalized",
+            })),
+            id: body.id,
+          });
+        }
+
+        // Answer the getTransaction batch in reverse order, as a node is free to do.
+        const responses = body.map(req => {
+          const signature = String(req.params[0]);
+          return {
+            jsonrpc: "2.0",
+            result: withSignature(txBySignature[signature] ?? null, signature),
+            id: req.id,
+          };
+        });
+        return HttpResponse.json(responses.reverse());
+      }),
+    );
+
+    const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+    expect(result.items).toHaveLength(2);
+    expect(result.items[0]).toMatchObject({
+      tx: expect.objectContaining({ hash: "sig1" }),
+      type: "OUT",
+      value: 100_000_000n,
+    });
+    expect(result.items[1]).toMatchObject({
+      tx: expect.objectContaining({ hash: "sig2" }),
+      type: "IN",
+      value: 672_405_000n,
+    });
   });
 
   it("should throw when order is asc", async () => {
@@ -198,48 +283,64 @@ describe("listOperations (MSW integration)", () => {
               confirmationStatus: "finalized",
             },
           ],
-          getTransaction: () => ({
-            ...makeParsedTx({
-              accountKeys: [
-                { pubkey: TEST_ADDRESS, signer: true, writable: true },
-                { pubkey: TEST_RECIPIENT, signer: false, writable: true },
-              ],
-              preBalances: [1_000_000_000, 2039280],
-              postBalances: [999_995_000, 2039280],
-              blockTime,
-            }),
-            meta: {
-              fee: 5000,
-              preBalances: [1_000_000_000, 2039280],
-              postBalances: [999_995_000, 2039280],
-              err: null,
-              preTokenBalances: [
-                {
-                  accountIndex: 0,
-                  mint: USDC_MINT,
-                  owner: TEST_ADDRESS,
-                  programId: TOKEN_PROGRAM_ID,
-                  uiTokenAmount: { amount: "5000000", decimals: 6, uiAmount: 5.0 },
+          getTransaction: params =>
+            withSignature(
+              {
+                ...makeParsedTx({
+                  accountKeys: [
+                    { pubkey: TEST_ADDRESS, signer: true, writable: true },
+                    { pubkey: TEST_RECIPIENT, signer: false, writable: true },
+                  ],
+                  preBalances: [1_000_000_000, 2039280],
+                  postBalances: [999_995_000, 2039280],
+                  blockTime,
+                }),
+                meta: {
+                  fee: 5000,
+                  preBalances: [1_000_000_000, 2039280],
+                  postBalances: [999_995_000, 2039280],
+                  err: null,
+                  preTokenBalances: [
+                    {
+                      accountIndex: 0,
+                      mint: USDC_MINT,
+                      owner: TEST_ADDRESS,
+                      programId: TOKEN_PROGRAM_ID,
+                      uiTokenAmount: {
+                        amount: "5000000",
+                        decimals: 6,
+                        uiAmount: 5.0,
+                      },
+                    },
+                  ],
+                  postTokenBalances: [
+                    {
+                      accountIndex: 0,
+                      mint: USDC_MINT,
+                      owner: TEST_ADDRESS,
+                      programId: TOKEN_PROGRAM_ID,
+                      uiTokenAmount: {
+                        amount: "3000000",
+                        decimals: 6,
+                        uiAmount: 3.0,
+                      },
+                    },
+                    {
+                      accountIndex: 1,
+                      mint: USDC_MINT,
+                      owner: TEST_RECIPIENT,
+                      programId: TOKEN_PROGRAM_ID,
+                      uiTokenAmount: {
+                        amount: "2000000",
+                        decimals: 6,
+                        uiAmount: 2.0,
+                      },
+                    },
+                  ],
                 },
-              ],
-              postTokenBalances: [
-                {
-                  accountIndex: 0,
-                  mint: USDC_MINT,
-                  owner: TEST_ADDRESS,
-                  programId: TOKEN_PROGRAM_ID,
-                  uiTokenAmount: { amount: "3000000", decimals: 6, uiAmount: 3.0 },
-                },
-                {
-                  accountIndex: 1,
-                  mint: USDC_MINT,
-                  owner: TEST_RECIPIENT,
-                  programId: TOKEN_PROGRAM_ID,
-                  uiTokenAmount: { amount: "2000000", decimals: 6, uiAmount: 2.0 },
-                },
-              ],
-            },
-          }),
+              },
+              String(params[0]),
+            ),
         }),
       );
 
@@ -282,48 +383,64 @@ describe("listOperations (MSW integration)", () => {
               confirmationStatus: "finalized",
             },
           ],
-          getTransaction: () => ({
-            ...makeParsedTx({
-              accountKeys: [
-                { pubkey: TEST_RECIPIENT, signer: true, writable: true },
-                { pubkey: TEST_ADDRESS, signer: false, writable: true },
-              ],
-              preBalances: [1_000_000_000, 500_000_000],
-              postBalances: [999_995_000, 500_000_000],
-              blockTime,
-            }),
-            meta: {
-              fee: 5000,
-              preBalances: [1_000_000_000, 500_000_000],
-              postBalances: [999_995_000, 500_000_000],
-              err: null,
-              preTokenBalances: [
-                {
-                  accountIndex: 1,
-                  mint: USDC_MINT,
-                  owner: TEST_ADDRESS,
-                  programId: TOKEN_PROGRAM_ID,
-                  uiTokenAmount: { amount: "1000000", decimals: 6, uiAmount: 1.0 },
+          getTransaction: params =>
+            withSignature(
+              {
+                ...makeParsedTx({
+                  accountKeys: [
+                    { pubkey: TEST_RECIPIENT, signer: true, writable: true },
+                    { pubkey: TEST_ADDRESS, signer: false, writable: true },
+                  ],
+                  preBalances: [1_000_000_000, 500_000_000],
+                  postBalances: [999_995_000, 500_000_000],
+                  blockTime,
+                }),
+                meta: {
+                  fee: 5000,
+                  preBalances: [1_000_000_000, 500_000_000],
+                  postBalances: [999_995_000, 500_000_000],
+                  err: null,
+                  preTokenBalances: [
+                    {
+                      accountIndex: 1,
+                      mint: USDC_MINT,
+                      owner: TEST_ADDRESS,
+                      programId: TOKEN_PROGRAM_ID,
+                      uiTokenAmount: {
+                        amount: "1000000",
+                        decimals: 6,
+                        uiAmount: 1.0,
+                      },
+                    },
+                  ],
+                  postTokenBalances: [
+                    {
+                      accountIndex: 1,
+                      mint: USDC_MINT,
+                      owner: TEST_ADDRESS,
+                      programId: TOKEN_PROGRAM_ID,
+                      uiTokenAmount: {
+                        amount: "4000000",
+                        decimals: 6,
+                        uiAmount: 4.0,
+                      },
+                    },
+                    {
+                      accountIndex: 0,
+                      mint: USDC_MINT,
+                      owner: TEST_RECIPIENT,
+                      programId: TOKEN_PROGRAM_ID,
+                      uiTokenAmount: {
+                        amount: "6000000",
+                        decimals: 6,
+                        uiAmount: 6.0,
+                      },
+                    },
+                  ],
                 },
-              ],
-              postTokenBalances: [
-                {
-                  accountIndex: 1,
-                  mint: USDC_MINT,
-                  owner: TEST_ADDRESS,
-                  programId: TOKEN_PROGRAM_ID,
-                  uiTokenAmount: { amount: "4000000", decimals: 6, uiAmount: 4.0 },
-                },
-                {
-                  accountIndex: 0,
-                  mint: USDC_MINT,
-                  owner: TEST_RECIPIENT,
-                  programId: TOKEN_PROGRAM_ID,
-                  uiTokenAmount: { amount: "6000000", decimals: 6, uiAmount: 6.0 },
-                },
-              ],
-            },
-          }),
+              },
+              String(params[0]),
+            ),
         }),
       );
 
@@ -433,7 +550,10 @@ describe("listOperations (MSW integration)", () => {
         preBalances: [5_000_000_000],
         postBalances: [7_999_995_000],
         instructions: [
-          ix("stake", "withdraw", { stakeAccount: STAKE_ACCOUNT, lamports: 3_000_000_000 }),
+          ix("stake", "withdraw", {
+            stakeAccount: STAKE_ACCOUNT,
+            lamports: 3_000_000_000,
+          }),
         ],
       }),
     };
@@ -444,7 +564,8 @@ describe("listOperations (MSW integration)", () => {
       server.use(
         rpcHandler({
           getSignaturesForAddress: () => Object.keys(txMap).map(s => makeSig(s)),
-          getTransaction: (params: unknown[]) => txMap[String(params[0])] ?? null,
+          getTransaction: (params: unknown[]) =>
+            withSignature(txMap[String(params[0])] ?? null, String(params[0])),
         }),
       );
 
@@ -540,48 +661,64 @@ describe("listOperations (MSW integration)", () => {
               confirmationStatus: "finalized",
             },
           ],
-          getTransaction: () => ({
-            ...makeParsedTx({
-              accountKeys: [
-                { pubkey: TEST_ADDRESS, signer: true, writable: true },
-                { pubkey: TEST_RECIPIENT, signer: false, writable: true },
-              ],
-              preBalances: [1_000_000_000, 2039280],
-              postBalances: [999_995_000, 2039280],
-              blockTime,
-            }),
-            meta: {
-              fee: 5000,
-              preBalances: [1_000_000_000, 2039280],
-              postBalances: [999_995_000, 2039280],
-              err: null,
-              preTokenBalances: [
-                {
-                  accountIndex: 0,
-                  mint: PYUSD_MINT,
-                  owner: TEST_ADDRESS,
-                  programId: TOKEN_2022_PROGRAM_ID,
-                  uiTokenAmount: { amount: "10000000", decimals: 6, uiAmount: 10.0 },
+          getTransaction: params =>
+            withSignature(
+              {
+                ...makeParsedTx({
+                  accountKeys: [
+                    { pubkey: TEST_ADDRESS, signer: true, writable: true },
+                    { pubkey: TEST_RECIPIENT, signer: false, writable: true },
+                  ],
+                  preBalances: [1_000_000_000, 2039280],
+                  postBalances: [999_995_000, 2039280],
+                  blockTime,
+                }),
+                meta: {
+                  fee: 5000,
+                  preBalances: [1_000_000_000, 2039280],
+                  postBalances: [999_995_000, 2039280],
+                  err: null,
+                  preTokenBalances: [
+                    {
+                      accountIndex: 0,
+                      mint: PYUSD_MINT,
+                      owner: TEST_ADDRESS,
+                      programId: TOKEN_2022_PROGRAM_ID,
+                      uiTokenAmount: {
+                        amount: "10000000",
+                        decimals: 6,
+                        uiAmount: 10.0,
+                      },
+                    },
+                  ],
+                  postTokenBalances: [
+                    {
+                      accountIndex: 0,
+                      mint: PYUSD_MINT,
+                      owner: TEST_ADDRESS,
+                      programId: TOKEN_2022_PROGRAM_ID,
+                      uiTokenAmount: {
+                        amount: "5000000",
+                        decimals: 6,
+                        uiAmount: 5.0,
+                      },
+                    },
+                    {
+                      accountIndex: 1,
+                      mint: PYUSD_MINT,
+                      owner: TEST_RECIPIENT,
+                      programId: TOKEN_2022_PROGRAM_ID,
+                      uiTokenAmount: {
+                        amount: "5000000",
+                        decimals: 6,
+                        uiAmount: 5.0,
+                      },
+                    },
+                  ],
                 },
-              ],
-              postTokenBalances: [
-                {
-                  accountIndex: 0,
-                  mint: PYUSD_MINT,
-                  owner: TEST_ADDRESS,
-                  programId: TOKEN_2022_PROGRAM_ID,
-                  uiTokenAmount: { amount: "5000000", decimals: 6, uiAmount: 5.0 },
-                },
-                {
-                  accountIndex: 1,
-                  mint: PYUSD_MINT,
-                  owner: TEST_RECIPIENT,
-                  programId: TOKEN_2022_PROGRAM_ID,
-                  uiTokenAmount: { amount: "5000000", decimals: 6, uiAmount: 5.0 },
-                },
-              ],
-            },
-          }),
+              },
+              String(params[0]),
+            ),
         }),
       );
 
@@ -614,33 +751,41 @@ describe("listOperations (MSW integration)", () => {
               confirmationStatus: "finalized",
             },
           ],
-          getTransaction: () => ({
-            ...makeParsedTx({
-              accountKeys: [
-                { pubkey: TEST_RECIPIENT, signer: true, writable: true },
-                { pubkey: TEST_ADDRESS, signer: false, writable: true },
-              ],
-              preBalances: [1_000_000_000, 500_000_000],
-              postBalances: [999_995_000, 500_000_000],
-              blockTime,
-            }),
-            meta: {
-              fee: 5000,
-              preBalances: [1_000_000_000, 500_000_000],
-              postBalances: [999_995_000, 500_000_000],
-              err: null,
-              preTokenBalances: [],
-              postTokenBalances: [
-                {
-                  accountIndex: 1,
-                  mint: PYUSD_MINT,
-                  owner: TEST_ADDRESS,
-                  programId: TOKEN_2022_PROGRAM_ID,
-                  uiTokenAmount: { amount: "8000000", decimals: 6, uiAmount: 8.0 },
+          getTransaction: params =>
+            withSignature(
+              {
+                ...makeParsedTx({
+                  accountKeys: [
+                    { pubkey: TEST_RECIPIENT, signer: true, writable: true },
+                    { pubkey: TEST_ADDRESS, signer: false, writable: true },
+                  ],
+                  preBalances: [1_000_000_000, 500_000_000],
+                  postBalances: [999_995_000, 500_000_000],
+                  blockTime,
+                }),
+                meta: {
+                  fee: 5000,
+                  preBalances: [1_000_000_000, 500_000_000],
+                  postBalances: [999_995_000, 500_000_000],
+                  err: null,
+                  preTokenBalances: [],
+                  postTokenBalances: [
+                    {
+                      accountIndex: 1,
+                      mint: PYUSD_MINT,
+                      owner: TEST_ADDRESS,
+                      programId: TOKEN_2022_PROGRAM_ID,
+                      uiTokenAmount: {
+                        amount: "8000000",
+                        decimals: 6,
+                        uiAmount: 8.0,
+                      },
+                    },
+                  ],
                 },
-              ],
-            },
-          }),
+              },
+              String(params[0]),
+            ),
         }),
       );
 

--- a/libs/coin-modules/coin-solana/src/logic/tests/listOperations.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/listOperations.unit.test.ts
@@ -42,6 +42,7 @@ describe("listOperations", () => {
     mockGetParsedTransactions.mockResolvedValue([
       {
         transaction: {
+          signatures: ["sig1"],
           message: {
             accountKeys: [
               { pubkey: new PublicKey(TEST_ADDRESS) },
@@ -93,6 +94,7 @@ describe("listOperations", () => {
     mockGetParsedTransactions.mockResolvedValue([
       {
         transaction: {
+          signatures: ["sig1"],
           message: {
             accountKeys: [
               { pubkey: new PublicKey(TEST_RECIPIENT) },
@@ -128,6 +130,7 @@ describe("listOperations", () => {
     mockGetParsedTransactions.mockResolvedValue([
       {
         transaction: {
+          signatures: ["sig1"],
           message: {
             accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
             recentBlockhash: TEST_BLOCKHASH,
@@ -174,8 +177,9 @@ describe("listOperations", () => {
     }));
     mockGetSignaturesForAddress.mockResolvedValue(sigs);
 
-    const txs = sigs.map(() => ({
+    const txs = sigs.map(sig => ({
       transaction: {
+        signatures: [sig.signature],
         message: {
           accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
           recentBlockhash: TEST_BLOCKHASH,
@@ -198,6 +202,7 @@ describe("listOperations", () => {
     mockGetParsedTransactions.mockResolvedValue([
       {
         transaction: {
+          signatures: ["sig1"],
           message: {
             accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
             recentBlockhash: TEST_BLOCKHASH,
@@ -223,6 +228,7 @@ describe("listOperations", () => {
     mockGetParsedTransactions.mockResolvedValue([
       {
         transaction: {
+          signatures: ["sig-low"],
           message: {
             accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
             recentBlockhash: TEST_BLOCKHASH,
@@ -233,6 +239,7 @@ describe("listOperations", () => {
       },
       {
         transaction: {
+          signatures: ["sig-high"],
           message: {
             accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
             recentBlockhash: TEST_BLOCKHASH,
@@ -259,8 +266,9 @@ describe("listOperations", () => {
     }));
     mockGetSignaturesForAddress.mockResolvedValue(sigs);
 
-    const txs = sigs.map(() => ({
+    const txs = sigs.map(sig => ({
       transaction: {
+        signatures: [sig.signature],
         message: {
           accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
           recentBlockhash: TEST_BLOCKHASH,
@@ -286,6 +294,7 @@ describe("listOperations", () => {
     mockGetParsedTransactions.mockResolvedValue([
       {
         transaction: {
+          signatures: ["sig1"],
           message: {
             accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
             recentBlockhash: TEST_BLOCKHASH,
@@ -305,14 +314,15 @@ describe("listOperations", () => {
   it("should skip transactions with null meta", async () => {
     const blockTime = 1700000000;
     mockGetSignaturesForAddress.mockResolvedValue([
-      { signature: "sig1", slot: 100, blockTime, err: null },
-      { signature: "sig2", slot: 101, blockTime, err: null },
+      { signature: "sig1", slot: 101, blockTime, err: null },
+      { signature: "sig2", slot: 100, blockTime, err: null },
     ]);
 
     mockGetParsedTransactions.mockResolvedValue([
       null,
       {
         transaction: {
+          signatures: ["sig2"],
           message: {
             accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
             recentBlockhash: TEST_BLOCKHASH,
@@ -339,6 +349,7 @@ describe("listOperations", () => {
     mockGetParsedTransactions.mockResolvedValue([
       {
         transaction: {
+          signatures: ["sig1"],
           message: {
             accountKeys: [{ pubkey: new PublicKey(OTHER_ADDRESS) }],
             recentBlockhash: TEST_BLOCKHASH,
@@ -363,6 +374,7 @@ describe("listOperations", () => {
     mockGetParsedTransactions.mockResolvedValue([
       {
         transaction: {
+          signatures: ["sig1"],
           message: {
             accountKeys: [
               { pubkey: new PublicKey(TEST_RECIPIENT) },
@@ -397,6 +409,7 @@ describe("listOperations", () => {
     mockGetParsedTransactions.mockResolvedValue([
       {
         transaction: {
+          signatures: ["sig1"],
           message: {
             accountKeys: [
               { pubkey: new PublicKey(TEST_ADDRESS) },
@@ -432,6 +445,7 @@ describe("listOperations", () => {
     mockGetParsedTransactions.mockResolvedValue([
       {
         transaction: {
+          signatures: ["sig1"],
           message: {
             accountKeys: [
               { pubkey: new PublicKey(THIRD_ADDRESS) },
@@ -467,6 +481,7 @@ describe("listOperations", () => {
     mockGetParsedTransactions.mockResolvedValue([
       {
         transaction: {
+          signatures: ["sig1"],
           message: {
             accountKeys: [
               { pubkey: new PublicKey(TEST_ADDRESS) },
@@ -500,6 +515,7 @@ describe("listOperations", () => {
     mockGetParsedTransactions.mockResolvedValue([
       {
         transaction: {
+          signatures: ["sig1"],
           message: {
             accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
             recentBlockhash: TEST_BLOCKHASH,
@@ -523,6 +539,109 @@ describe("listOperations", () => {
     ).rejects.toThrow("RPC error");
   });
 
+  it("should match each signature with its own transaction when the RPC batch is reordered", async () => {
+    const blockTime = 1700000000;
+    mockGetSignaturesForAddress.mockResolvedValue([
+      { signature: "sig1", slot: 101, blockTime, err: null },
+      { signature: "sig2", slot: 100, blockTime, err: null },
+    ]);
+
+    const txSig1 = {
+      transaction: {
+        signatures: ["sig1"],
+        message: {
+          accountKeys: [
+            { pubkey: new PublicKey(TEST_ADDRESS) },
+            { pubkey: new PublicKey(TEST_RECIPIENT) },
+          ],
+          recentBlockhash: TEST_BLOCKHASH,
+          instructions: [],
+        },
+      },
+      meta: {
+        fee: 5000,
+        preBalances: [1_000_000_000, 0],
+        postBalances: [899_995_000, 100_000_000],
+      },
+    };
+    const txSig2 = {
+      transaction: {
+        signatures: ["sig2"],
+        message: {
+          accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
+          recentBlockhash: TEST_BLOCKHASH,
+          instructions: [],
+        },
+      },
+      meta: {
+        fee: 5000,
+        preBalances: [1_000_000_000],
+        postBalances: [1_672_400_000],
+      },
+    };
+
+    // JSON-RPC batch responses are not order-guaranteed: return them swapped.
+    mockGetParsedTransactions.mockResolvedValue([txSig2, txSig1]);
+
+    const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+    expect(result.items).toHaveLength(2);
+    expect(result.items[0]).toMatchObject({
+      tx: expect.objectContaining({ hash: "sig1" }),
+      type: "OUT",
+      value: 100_000_000n,
+    });
+    expect(result.items[1]).toMatchObject({
+      tx: expect.objectContaining({ hash: "sig2" }),
+      type: "IN",
+      value: 672_405_000n,
+    });
+  });
+
+  it("should skip signatures missing from the parsed transactions batch", async () => {
+    const blockTime = 1700000000;
+    mockGetSignaturesForAddress.mockResolvedValue([
+      { signature: "sig1", slot: 101, blockTime, err: null },
+      { signature: "sig2", slot: 100, blockTime, err: null },
+    ]);
+
+    mockGetParsedTransactions.mockResolvedValue([
+      {
+        transaction: {
+          signatures: ["sig2"],
+          message: {
+            accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
+            recentBlockhash: TEST_BLOCKHASH,
+            instructions: [],
+          },
+        },
+        meta: { fee: 5000, preBalances: [1_000_000], postBalances: [995_000] },
+      },
+    ]);
+
+    const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].tx.hash).toBe("sig2");
+  });
+
+  it("should keep the cursor when a full page yields no operation", async () => {
+    const blockTime = 1700000000;
+    const sigs = Array.from({ length: 100 }, (_, i) => ({
+      signature: `sig-${i}`,
+      slot: 200 - i,
+      blockTime,
+      err: null,
+    }));
+    mockGetSignaturesForAddress.mockResolvedValue(sigs);
+    mockGetParsedTransactions.mockResolvedValue(sigs.map(() => null));
+
+    const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
+
+    expect(result.items).toEqual([]);
+    expect(result.next).toBe("sig-99");
+  });
+
   it("should throw when order is asc", async () => {
     await expect(listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "asc" })).rejects.toThrow(
       "ascending order is not supported",
@@ -539,10 +658,16 @@ describe("listOperations", () => {
 
     function makeStakingTx(
       instructions: object[],
-      { preBalance = 10_000_000_000, postBalance = 7_000_000_000, fee = 5000 } = {},
+      {
+        preBalance = 10_000_000_000,
+        postBalance = 7_000_000_000,
+        fee = 5000,
+        signature = "sig1",
+      } = {},
     ) {
       return {
         transaction: {
+          signatures: [signature],
           message: {
             accountKeys: [{ pubkey: new PublicKey(TEST_ADDRESS) }],
             recentBlockhash: TEST_BLOCKHASH,
@@ -563,11 +688,14 @@ describe("listOperations", () => {
         { signature: "sig-delegate-create", slot: 100, blockTime, err: null },
       ]);
       mockGetParsedTransactions.mockResolvedValue([
-        makeStakingTx([
-          makeParsedIx("system", "createAccountWithSeed"),
-          makeParsedIx("stake", "initialize"),
-          makeParsedIx("stake", "delegate", { voteAccount: VOTE_ACCOUNT }),
-        ]),
+        makeStakingTx(
+          [
+            makeParsedIx("system", "createAccountWithSeed"),
+            makeParsedIx("stake", "initialize"),
+            makeParsedIx("stake", "delegate", { voteAccount: VOTE_ACCOUNT }),
+          ],
+          { signature: "sig-delegate-create" },
+        ),
       ]);
 
       const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
@@ -588,6 +716,7 @@ describe("listOperations", () => {
       ]);
       mockGetParsedTransactions.mockResolvedValue([
         makeStakingTx([makeParsedIx("stake", "delegate", { voteAccount: VOTE_ACCOUNT })], {
+          signature: "sig-delegate-solo",
           preBalance: 5_000_000_000,
           postBalance: 4_999_995_000,
         }),
@@ -611,6 +740,7 @@ describe("listOperations", () => {
       ]);
       mockGetParsedTransactions.mockResolvedValue([
         makeStakingTx([makeParsedIx("stake", "deactivate")], {
+          signature: "sig-undelegate",
           preBalance: 5_000_000_000,
           postBalance: 4_999_995_000,
         }),
@@ -639,7 +769,12 @@ describe("listOperations", () => {
               lamports: withdrawLamports,
             }),
           ],
-          { preBalance: 5_000_000_000, postBalance: 6_999_995_000, fee: 5000 },
+          {
+            signature: "sig-withdraw",
+            preBalance: 5_000_000_000,
+            postBalance: 6_999_995_000,
+            fee: 5000,
+          },
         ),
       ]);
 
@@ -660,11 +795,14 @@ describe("listOperations", () => {
         { signature: "sig-delegate-create2", slot: 100, blockTime, err: null },
       ]);
       mockGetParsedTransactions.mockResolvedValue([
-        makeStakingTx([
-          makeParsedIx("system", "createAccount"),
-          makeParsedIx("stake", "initialize"),
-          makeParsedIx("stake", "delegate", { voteAccount: VOTE_ACCOUNT }),
-        ]),
+        makeStakingTx(
+          [
+            makeParsedIx("system", "createAccount"),
+            makeParsedIx("stake", "initialize"),
+            makeParsedIx("stake", "delegate", { voteAccount: VOTE_ACCOUNT }),
+          ],
+          { signature: "sig-delegate-create2" },
+        ),
       ]);
 
       const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
@@ -679,7 +817,9 @@ describe("listOperations", () => {
         { signature: "sig-delegate", slot: 100, blockTime, err: null },
       ]);
       mockGetParsedTransactions.mockResolvedValue([
-        makeStakingTx([makeParsedIx("stake", "delegate", { voteAccount: VOTE_ACCOUNT })]),
+        makeStakingTx([makeParsedIx("stake", "delegate", { voteAccount: VOTE_ACCOUNT })], {
+          signature: "sig-delegate",
+        }),
       ]);
 
       const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
@@ -694,7 +834,9 @@ describe("listOperations", () => {
         { signature: "sig-undelegate", slot: 100, blockTime, err: null },
       ]);
       mockGetParsedTransactions.mockResolvedValue([
-        makeStakingTx([makeParsedIx("stake", "deactivate")]),
+        makeStakingTx([makeParsedIx("stake", "deactivate")], {
+          signature: "sig-undelegate",
+        }),
       ]);
 
       const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
@@ -709,12 +851,15 @@ describe("listOperations", () => {
         { signature: "sig-withdraw", slot: 100, blockTime, err: null },
       ]);
       mockGetParsedTransactions.mockResolvedValue([
-        makeStakingTx([
-          makeParsedIx("stake", "withdraw", {
-            stakeAccount: STAKE_ACCOUNT,
-            lamports: 1_000_000_000,
-          }),
-        ]),
+        makeStakingTx(
+          [
+            makeParsedIx("stake", "withdraw", {
+              stakeAccount: STAKE_ACCOUNT,
+              lamports: 1_000_000_000,
+            }),
+          ],
+          { signature: "sig-withdraw" },
+        ),
       ]);
 
       const result = await listOperations(api, TEST_ADDRESS, { minHeight: 0, order: "desc" });
@@ -731,6 +876,7 @@ describe("listOperations", () => {
       mockGetParsedTransactions.mockResolvedValue([
         {
           transaction: {
+            signatures: ["sig-out"],
             message: {
               accountKeys: [
                 { pubkey: new PublicKey(TEST_ADDRESS) },
@@ -767,6 +913,7 @@ describe("listOperations", () => {
     ) {
       return {
         transaction: {
+          signatures: ["sig1"],
           message: {
             accountKeys: accountKeys.map(k => ({ pubkey: new PublicKey(k) })),
             recentBlockhash: TEST_BLOCKHASH,
@@ -831,7 +978,11 @@ describe("listOperations", () => {
               mint: USDC_MINT,
               owner: TEST_ADDRESS, // Solana records the WALLET as owner, never the ATA
               programId: TOKEN_PROGRAM_ID_STR,
-              uiTokenAmount: { amount: "3576636", decimals: 6, uiAmount: 3.576636 },
+              uiTokenAmount: {
+                amount: "3576636",
+                decimals: 6,
+                uiAmount: 3.576636,
+              },
             },
           ],
           [
@@ -840,7 +991,11 @@ describe("listOperations", () => {
               mint: USDC_MINT,
               owner: TEST_ADDRESS,
               programId: TOKEN_PROGRAM_ID_STR,
-              uiTokenAmount: { amount: "5112194", decimals: 6, uiAmount: 5.112194 },
+              uiTokenAmount: {
+                amount: "5112194",
+                decimals: 6,
+                uiAmount: 5.112194,
+              },
             },
           ],
           [TEST_ADDRESS, TOKEN_ACCOUNT], // ATA is accountKeys[1]
@@ -848,7 +1003,10 @@ describe("listOperations", () => {
       ]);
 
       // Query by the token-account address, not the wallet.
-      const result = await listOperations(api, TOKEN_ACCOUNT, { minHeight: 0, order: "desc" });
+      const result = await listOperations(api, TOKEN_ACCOUNT, {
+        minHeight: 0,
+        order: "desc",
+      });
 
       const tokenOps = result.items.filter(op => op.asset.type !== "native");
       expect(tokenOps).toHaveLength(1);


### PR DESCRIPTION
### 📝 Description

`listOperations` paired the signature list returned by `getSignaturesForAddress` with the parsed transaction batch **by array position** (`parsed[i]` for `signatures[i]`). `ChainAPI.getParsedTransactions` delegates to web3.js `Connection.getParsedTransactions`, which issues a JSON-RPC **batch** and maps the response positionally. The JSON-RPC spec does not guarantee batch response ordering (responses must be matched by `id`), so a node or proxy that reorders replies made `parsed[i]` belong to another signature.

**Previous behaviour**: an operation kept the correct hash, slot and time (read from the signature) but took its fee, fee payer, balances and instructions from a different transaction. On the account of the ticket, 27 of the 30 native operations returned by coin-service carried another transaction's fee and fee payer, following an exact permutation of the page:

| coin-service says | on chain | coin-service returned |
| --- | --- | --- |
| `2wV7vcvemebj…` (swap 2 USDC to SOL) | native `+25674506`, USDC `-2000000` | `DELEGATE 0`, no token operation |
| `22jJe2VEX4Xw…` (transfer, account is fee payer) | delta `-5000`, fee only | `IN 1672400000` with a foreign `feesPayer` |
| `5DgWmNqJe8zv…` | delta `-20141991` | `IN 1` |

The legacy bridge path is unaffected because it re-matches transactions by signature (`network/chain/web3.ts`), which is why Ledger Live showed the correct history for the same transactions.

**Fix**: parsed transactions are indexed by their own `transaction.signatures` and looked up per signature. `hash`, `slot`, `blockTime` and `failed` still come from the signature info, which was already correct, and the descending order, `minHeight` filtering and cursor logic are unchanged. A signature whose transaction is absent from the batch is skipped instead of adopting a neighbour's data.

**Regression checks**: three new tests, each failing on the previous implementation.

- `listOperations.unit.test.ts`: batch returned in reverse order, and batch missing one entry.
- `listOperations.test.ts`: MSW test answering the JSON-RPC `getTransaction` batch in reverse order, so the guarantee is verified through the real web3.js batch path.

Beyond the ticket, flagged in review: `next` no longer depends on `items.length`, so a full page yielding no operation keeps the cursor instead of ending pagination and hiding older history.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35047](https://ledgerhq.atlassian.net/browse/LIVE-35047)
- **ADR** (if any):


[LIVE-35047]: https://ledgerhq.atlassian.net/browse/LIVE-35047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ