### PR TITLE
fix(e2e): bridge signing-to-confirmation race in old send flow

### DIFF
--- a/e2e/desktop/tests/page/modal/send.modal.ts
+++ b/e2e/desktop/tests/page/modal/send.modal.ts
@@ -11,7 +11,7 @@ export class SendModal extends Modal {
   private checkDeviceLabel = this.page.locator(
     "text=Double-check the transaction details on your Ledger device before signing.",
   );
-  private checkTransactionbroadcastLabel = this.page.locator("text=Transaction sent");
+  private readonly checkTransactionbroadcastLabel = this.page.getByTestId("success-message-label");
   private recipientAddressDisplayedValue = this.page.getByTestId("recipient-address");
   private recipientEnsDisplayed = this.page.getByTestId("transaction-recipient-ens");
   private amountDisplayedValue = this.page.getByTestId("transaction-amount");
@@ -94,6 +94,7 @@ export class SendModal extends Modal {
 
   @step("Verify tx sent text")
   async expectTxSent() {
+    await this.checkDeviceLabel.waitFor({ state: "hidden" });
     await expect(this.checkTransactionbroadcastLabel).toBeVisible();
   }
 


### PR DESCRIPTION
### 📝 Description

**Problem**: `expectTxSent()` in the old send flow POM asserted `text=Transaction sent` immediately after `signSendTransaction()` returns. Speculos button presses complete before LLD has finished processing the signed response — it still needs to call `broadcast()`, call `transitionTo("confirmation")`, and re-render `SuccessDisplay`. The assertion fired into that gap and timed out, causing flaky failures on KASPA, ATOM, ETH/Base, and any other coin where signing takes variable time.

**Fix**:
- `expectTxSent()` now awaits `checkDeviceLabel.waitFor({ state: "hidden" })` before asserting the success label. The "Double-check the transaction details on your Ledger device before signing." label is rendered throughout the device-interaction phase and disappears exactly when `transitionTo("confirmation")` fires — a deterministic synchronisation point with no hardcoded timeouts.
- The broadcast label locator is switched from `text=Transaction sent` (fragile i18n text match) to `getByTestId("success-message-label")`.

Validated locally: old-flow and new-flow KAS tests run concurrently (2 workers, same account) and both pass in 40 s.

### 🔗 Context

- **Related PR**: #21173 — added `disableBroadcast: true` to old send flow dual-flow coins; the race condition in `expectTxSent()` was the remaining failure exposed after that fix landed.
- **CI run**: https://github.com/LedgerHQ/ledger-live/actions/runs/33059715897