### PR TITLE
[LWD] feat(paytab): show the card background on pay (LIVE-36542)

### DIFF
--- a/.changeset/olive-hoops-shine.md
+++ b/.changeset/olive-hoops-shine.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Show the Card page background on the Pay page

--- a/apps/ledger-live-desktop/src/mvvm/components/Page/backgrounds.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/Page/backgrounds.ts
@@ -8,6 +8,7 @@ export const PAGE_BACKGROUNDS: Record<string, string> = {
   "/": homeBg,
   "/earn": earnBg,
   "/card-new-wallet": cardBg,
+  "/paytab": cardBg,
   "/swap": swapBg,
   "/exchange": swapBg,
 } as const;


### PR DESCRIPTION
### 📝 Description

The Pay page shipped with a plain background, while the Card page it sits next to shows the Wallet 4.0 card artwork. This aligns the two.

`/paytab` is now mapped to the existing `cardBg` entry in `PAGE_BACKGROUNDS`. No new asset is introduced — `/card-new-wallet` already points at the same image, and the light-theme fallback is handled by `getPageBackground`, so nothing else needed to change.


<img width="1624" height="964" alt="Screenshot 2026-08-27 at 11 18 55" src="https://github.com/user-attachments/assets/f22eca0f-ad0a-4323-b202-8117a26db9c0" />

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36542](https://ledgerhq.atlassian.net/browse/LIVE-36542) (epic [LIVE-33492](https://ledgerhq.atlassian.net/browse/LIVE-33492))
- **ADR** (if any): n/a

[LIVE-36542]: https://ledgerhq.atlassian.net/browse/LIVE-36542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-33492]: https://ledgerhq.atlassian.net/browse/LIVE-33492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ