### PR TITLE
[LWM] feat(paytab): show the card background on pay tab (LIVE-36543)

### DIFF
--- a/.changeset/quiet-moons-repeat.md
+++ b/.changeset/quiet-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Show the Card screen background on the Pay tab

--- a/apps/ledger-live-mobile/src/mvvm/components/Wallet40Background/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/Wallet40Background/index.tsx
@@ -3,6 +3,7 @@ import { Animated, ImageBackground, View } from "react-native";
 import { useTheme, useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
 import swapBackgroundDark from "~/images/liveApps/swap/MOBILE_SWAP_LW_V4_BG.webp";
 import earnBackgroundDark from "~/images/liveApps/earn/background-dark.webp";
+import cardBackgroundDark from "~/images/card/card-bg.webp";
 import wallet40BackgroundLight from "~/images/portfolio/v4-light.webp";
 
 const FADE_DISTANCE = 150;
@@ -10,17 +11,18 @@ const FADE_DISTANCE = 150;
 const darkBackgrounds = {
   swap: swapBackgroundDark,
   earn: earnBackgroundDark,
+  pay: cardBackgroundDark,
 } as const;
 
-type LiveAppBackgroundType = keyof typeof darkBackgrounds;
+type Wallet40BackgroundType = keyof typeof darkBackgrounds;
 
 type Props = {
-  type: LiveAppBackgroundType;
+  type: Wallet40BackgroundType;
   scrollY?: Animated.Value;
   fadeDistance?: number;
 };
 
-function LiveAppBackgroundComponent({ type, scrollY, fadeDistance }: Props) {
+function Wallet40BackgroundComponent({ type, scrollY, fadeDistance }: Props) {
   const { colorScheme } = useTheme();
   const styles = useStyleSheet(
     theme => ({
@@ -68,4 +70,4 @@ function LiveAppBackgroundComponent({ type, scrollY, fadeDistance }: Props) {
   );
 }
 
-export const LiveAppBackground = memo(LiveAppBackgroundComponent);
+export const Wallet40Background = memo(Wallet40BackgroundComponent);

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/PayTabView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/PayTabView.tsx
@@ -9,6 +9,7 @@ import {
 } from "@features/flow-pay-balance";
 import { DepositOptions, type DepositOptionsProps } from "@features/flow-pay-deposit";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
+import { Wallet40Background } from "LLM/components/Wallet40Background";
 import { TrackScreen } from "~/analytics";
 
 type PayTabViewProps = {
@@ -33,16 +34,15 @@ export function PayTabView({
   depositOptions,
 }: PayTabViewProps) {
   return (
-    <Box
-      lx={{ flex: 1, backgroundColor: "canvas" }}
-      style={{ paddingTop: top }}
-      testID="paytab-screen"
-    >
-      <TrackScreen category="Pay" balance_filter={balance.filter} />
-      <Balance {...balance} labels={balanceLabels} actionTiles={actionTiles} />
-      <DepositOptions {...depositOptions} />
-      <Card oauthConfig={oauthConfig} callback={callback} />
-      <FeatureTour {...featureTour} />
+    <Box lx={{ flex: 1 }} testID="paytab-screen">
+      <Wallet40Background type="pay" />
+      <Box style={{ flex: 1, paddingTop: top }}>
+        <TrackScreen category="Pay" balance_filter={balance.filter} />
+        <Balance {...balance} labels={balanceLabels} actionTiles={actionTiles} />
+        <DepositOptions {...depositOptions} />
+        <Card oauthConfig={oauthConfig} callback={callback} />
+        <FeatureTour {...featureTour} />
+      </Box>
     </Box>
   );
 }

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/__tests__/EarnV2Webview.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/__tests__/EarnV2Webview.test.tsx
@@ -40,9 +40,9 @@ jest.mock("../../EarnWebview", () => {
   };
 });
 
-jest.mock("LLM/components/LiveAppBackground", () => {
+jest.mock("LLM/components/Wallet40Background", () => {
   const { View } = require("react-native");
-  return { LiveAppBackground: () => <View testID="live-app-background" /> };
+  return { Wallet40Background: () => <View testID="wallet40-background" /> };
 });
 
 const STUB_MANIFEST: LiveAppManifest = {
@@ -74,37 +74,37 @@ describe("EarnV2Webview", () => {
     mockSetOptions.mockClear();
   });
 
-  it("renders LiveAppBackground when ptxEarnUi is v2", () => {
+  it("renders Wallet40Background when ptxEarnUi is v2", () => {
     render(<EarnV2Webview manifest={STUB_MANIFEST} appManifestNotFoundError={ERROR} />, {
       overrideInitialState: withFlagOverrides({
         ptxEarnUi: { enabled: true, params: { value: "v2" } },
       }),
     });
 
-    expect(screen.getByTestId("live-app-background")).toBeTruthy();
+    expect(screen.getByTestId("wallet40-background")).toBeTruthy();
   });
 
-  it("renders LiveAppBackground when ptxEarnUi is v3 (minimum v2 check)", () => {
+  it("renders Wallet40Background when ptxEarnUi is v3 (minimum v2 check)", () => {
     render(<EarnV2Webview manifest={STUB_MANIFEST} appManifestNotFoundError={ERROR} />, {
       overrideInitialState: withFlagOverrides({
         ptxEarnUi: { enabled: true, params: { value: "v3" } },
       }),
     });
 
-    expect(screen.getByTestId("live-app-background")).toBeTruthy();
+    expect(screen.getByTestId("wallet40-background")).toBeTruthy();
   });
 
-  it("does not render LiveAppBackground when ptxEarnUi is v1", () => {
+  it("does not render Wallet40Background when ptxEarnUi is v1", () => {
     render(<EarnV2Webview manifest={STUB_MANIFEST} appManifestNotFoundError={ERROR} />, {
       overrideInitialState: withFlagOverrides({
         ptxEarnUi: { enabled: true, params: { value: "v1" } },
       }),
     });
 
-    expect(screen.queryByTestId("live-app-background")).toBeNull();
+    expect(screen.queryByTestId("wallet40-background")).toBeNull();
   });
 
-  it("does not render LiveAppBackground when hideMainNavigator is true", () => {
+  it("does not render Wallet40Background when hideMainNavigator is true", () => {
     render(
       <EarnV2Webview manifest={STUB_MANIFEST} appManifestNotFoundError={ERROR} hideMainNavigator />,
       {
@@ -114,10 +114,10 @@ describe("EarnV2Webview", () => {
       },
     );
 
-    expect(screen.queryByTestId("live-app-background")).toBeNull();
+    expect(screen.queryByTestId("wallet40-background")).toBeNull();
   });
 
-  it("keeps LiveAppBackground hidden while the webview is on a deposit URL", () => {
+  it("keeps Wallet40Background hidden while the webview is on a deposit URL", () => {
     mockWebviewUrl = "https://earn.test/v2/android/deposit?intent=deposit&uiVersion=v4";
 
     render(
@@ -129,10 +129,10 @@ describe("EarnV2Webview", () => {
       },
     );
 
-    expect(screen.queryByTestId("live-app-background")).toBeNull();
+    expect(screen.queryByTestId("wallet40-background")).toBeNull();
   });
 
-  it("restores LiveAppBackground when the webview navigates back to the dashboard despite a stale deposit intent", () => {
+  it("restores Wallet40Background when the webview navigates back to the dashboard despite a stale deposit intent", () => {
     mockWebviewUrl = "https://earn.test/v2/android/homescreen?uiVersion=v4";
 
     render(
@@ -144,7 +144,7 @@ describe("EarnV2Webview", () => {
       },
     );
 
-    expect(screen.getByTestId("live-app-background")).toBeTruthy();
+    expect(screen.getByTestId("wallet40-background")).toBeTruthy();
   });
 
   it("returns to the Earn dashboard tab when the intent flow webview navigates out of the intent route", () => {
@@ -236,7 +236,7 @@ describe("EarnV2Webview", () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it("keeps LiveAppBackground hidden while the webview URL is still unknown (intent flow first paint)", () => {
+  it("keeps Wallet40Background hidden while the webview URL is still unknown (intent flow first paint)", () => {
     mockWebviewUrl = "";
 
     render(
@@ -248,7 +248,7 @@ describe("EarnV2Webview", () => {
       },
     );
 
-    expect(screen.queryByTestId("live-app-background")).toBeNull();
+    expect(screen.queryByTestId("wallet40-background")).toBeNull();
   });
 
   it.each(["about:blank", "data:text/html,<html></html>"])(
@@ -273,7 +273,7 @@ describe("EarnV2Webview", () => {
       );
 
       expect(mockNavigate).not.toHaveBeenCalled();
-      expect(screen.queryByTestId("live-app-background")).toBeNull();
+      expect(screen.queryByTestId("wallet40-background")).toBeNull();
     },
   );
 

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/index.tsx
@@ -11,7 +11,7 @@ import { TrackScreen } from "~/analytics";
 import GenericErrorView from "~/components/GenericErrorView";
 import { useNavigationBarHeights } from "LLM/hooks/useNavigationBarHeights";
 import { EarnWebview } from "../EarnWebview";
-import { LiveAppBackground } from "LLM/components/LiveAppBackground";
+import { Wallet40Background } from "LLM/components/Wallet40Background";
 import { useTheme as useLumenTheme } from "@ledgerhq/lumen-ui-rnative/styles";
 import { computeEarnUiVersion } from "@ledgerhq/live-common/domain/computeEarnUiVersion";
 import type { WebviewState } from "~/components/Web3AppWebview/types";
@@ -107,7 +107,7 @@ export const EarnV2Webview = ({
       testID="earn-screen"
       style={[styles.container, displayBackgroundCanvas && { backgroundColor: canvasColor }]}
     >
-      {showsBackground && <LiveAppBackground type="earn" scrollY={scrollY} />}
+      {showsBackground && <Wallet40Background type="earn" scrollY={scrollY} />}
       <View style={styles.contentContainer} pointerEvents="box-none">
         {manifest ? (
           <Fragment>

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/SwapLiveAppWallet40.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/SwapLiveAppWallet40.tsx
@@ -16,7 +16,7 @@ import { useSwapWebviewProps } from "./hooks/useSwapWebviewProps";
 import { DefaultAccountSwapParamList } from "../types";
 import { useSwapWallet40HeaderStateUpdater } from "./navigationHandlers/wallet40/useSwapWallet40HeaderState";
 import { useSwapAndroidHardwareBackPress } from "./navigationHandlers/useSwapAndroidHardwareBackPress";
-import { LiveAppBackground } from "LLM/components/LiveAppBackground";
+import { Wallet40Background } from "LLM/components/Wallet40Background";
 
 type SwapWebviewContentProps = {
   manifest: LiveAppManifest;
@@ -107,7 +107,7 @@ export function SwapLiveAppWallet40({
 
   return (
     <View style={containerStyle}>
-      <LiveAppBackground type="swap" />
+      <Wallet40Background type="swap" />
       <View style={styles.contentContainer} pointerEvents="box-none">
         {manifest && (
           <SwapWebviewContent


### PR DESCRIPTION
### 📝 Description

The Pay tab shipped with a plain background, while the Card screen it replaces shows the Wallet 4.0 card artwork. This aligns the two.

The Pay tab now renders the shared Wallet 4.0 background with a new `card` variant: `card-bg.webp` in dark and `v4-light.webp` in light, the same pair the Card screen uses.

Two side effects worth calling out for review:

- The shared component was named `LiveAppBackground`, but the Pay tab is a native screen assembled from `@features/flow-pay-*` components — there is no webview involved, so the name was misleading. It is renamed to `Wallet40Background`, which is what it actually is (a Wallet 4.0 screen background with a per-section dark image and a common light one). The Swap and Earn call sites follow, and the Earn test mock and its `testID` were updated accordingly. The directory move is recorded as a rename so history is preserved.
- `backgroundColor: "canvas"` was removed from the Pay tab container, because `Wallet40Background` already paints a full-surface `bg.base` — the same base colour the Card screen uses. Keeping `canvas` would have left a dead style and a base colour that differs from Card.

**Validation** — lint is clean on all touched files and no reference to the old name remains. The Jest suites (`EarnV2Webview`, `mvvm/features/PayTab`) were not run locally; they need a check in CI.

<img width="508" height="967" alt="Screenshot 2026-08-27 at 11 38 19" src="https://github.com/user-attachments/assets/bc1e2fad-93c4-47f0-8f90-ba691d438689" />



### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36543](https://ledgerhq.atlassian.net/browse/LIVE-36543) (epic [LIVE-33490](https://ledgerhq.atlassian.net/browse/LIVE-33490))
- **ADR** (if any): n/a

[LIVE-36543]: https://ledgerhq.atlassian.net/browse/LIVE-36543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ