### PR TITLE
[LWM] chore(fastlane): drop unused android recover build lane

### DIFF
--- a/apps/ledger-live-mobile/fastlane/Fastfile
+++ b/apps/ledger-live-mobile/fastlane/Fastfile
@@ -495,14 +495,14 @@ platform :android do
   private_lane :upload do |options|
     if(options[:ci])
       upload_to_play_store(
-        track: options[:nightly] ? 'Nightly' : options[:recover] ? 'Recover Beta' : "internal",
+        track: options[:nightly] ? 'Nightly' : "internal",
         package_name: ENV["APP_IDENTIFIER"],
         json_key_data: ENV["ANDROID_SERVICE_KEY_CONTENT"],
         skip_upload_apk: true
       )
     else
       upload_to_play_store(
-        track: options[:nightly] ? 'Nightly' : options[:recover] ? 'Recover Beta' : "internal",
+        track: options[:nightly] ? 'Nightly' : "internal",
         package_name: ENV["APP_IDENTIFIER"],
         json_key: ENV["ANDROID_SERVICE_KEY_PATH"],
         skip_upload_apk: true
@@ -560,19 +560,6 @@ platform :android do
       type: "Release",
       ci: true,
       apk_and_aab: true
-    )
-  end
-
-  desc "build recover version"
-  lane :ci_recover do
-    prepare_android_internal
-    build(
-      type: "Release",
-      ci: true
-    )
-    upload(
-      recover: true,
-      ci: true
     )
   end
 

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -48,7 +48,6 @@
     "android:ci:playstore": "bundle exec fastlane android ci_playstore --env android.release",
     "android:ci:build": "bundle exec fastlane android ci_build --env android.release",
     "android:ci:pre": "bundle exec fastlane android ci_playstore dry_run:true --env android.prerelease",
-    "android:ci:recover": "bundle exec fastlane android ci_recover --env android.prerelease",
     "preandroid:ci:nightly": "bundle install",
     "android:ci:nightly": "bundle exec fastlane android ci_nightly --env android.nightly",
     "android:hermes:staging": "export HERMES_ENABLED_ANDROID=true && pnpm android:staging",


### PR DESCRIPTION
The `ci_recover` lane and its `android:ci:recover` entrypoint are the only writers to the `Recover Beta` Play track, and no workflow in ledger-live or ledger-live-build invokes either. Confirmed dead.

Removing the lane also makes `options[:recover]` unreachable in the `upload` lane, so the track ternary loses that branch.

The `Recover Beta` entry in the version-code track list is removed separately, by the track pruning in the play-quota fix.

Test run: https://github.com/LedgerHQ/ledger-live-build/actions/runs/33066198457/job/98496753697
Ticket: https://ledgerhq.atlassian.net/browse/LIVE-36541