### PR TITLE
[LWDM] feat(gonka): add Gonka (GNK) currency metadata (LIVE-36009)

### DIFF
--- a/.changeset/add-gonka-currency.md
+++ b/.changeset/add-gonka-currency.md
@@ -1,0 +1,5 @@
+---
+"@domain/entity-currency-crypto": minor
+---
+
+add Gonka (GNK) as a new Cosmos-family currency with coin type 1200

--- a/domain/entity/currency-crypto/src/currencies/gonka.ts
+++ b/domain/entity/currency-crypto/src/currencies/gonka.ts
@@ -1,0 +1,31 @@
+import { currency } from "../define";
+
+export const gonka = currency({
+  type: "CryptoCurrency",
+  id: "gonka",
+  coinType: 1200,
+  name: "Gonka",
+  managerAppName: "Cosmos",
+  ticker: "GNK",
+  scheme: "gonka",
+  color: "#242424",
+  family: "cosmos",
+  units: [
+    {
+      name: "GNK",
+      code: "GNK",
+      magnitude: 9,
+    },
+    {
+      name: "ngonka",
+      code: "ngonka",
+      magnitude: 0,
+    },
+  ],
+  explorerViews: [
+    {
+      tx: "https://gonka.hyperfusion.io/dashboard/gonka/tx/$hash",
+      address: "https://gonka.hyperfusion.io/dashboard/gonka/account/$address",
+    },
+  ],
+});

--- a/domain/entity/currency-crypto/src/currencies/index.ts
+++ b/domain/entity/currency-crypto/src/currencies/index.ts
@@ -84,6 +84,7 @@ export * from "./flare";
 export * from "./flow";
 export * from "./game_credits";
 export * from "./gochain";
+export * from "./gonka";
 export * from "./groestcoin";
 export * from "./hedera";
 export * from "./hedera_testnet";

--- a/libs/live-currency-format/src/__snapshots__/formatCurrencyUnit.test.ts.snap
+++ b/libs/live-currency-format/src/__snapshots__/formatCurrencyUnit.test.ts.snap
@@ -164,6 +164,8 @@ exports[`formatCurrencyUnit with custom options with locale de-DE should correct
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format GoChain unit (GO) 1`] = `"123.456.789,00000000- -GO"`;
 
+exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Gonka unit (GNK) 1`] = `"12.345.678,900000000- -GNK"`;
+
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Gram unit (GRAM) 1`] = `"12.345.678,900000000- -GRAM"`;
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Groestlcoin unit (GRS) 1`] = `"123.456.789,00000000- -GRS"`;
@@ -565,6 +567,8 @@ exports[`formatCurrencyUnit with custom options with locale en-US should correct
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format GameCredits unit (GAME) 1`] = `"123,456,789.00000000- -GAME"`;
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format GoChain unit (GO) 1`] = `"123,456,789.00000000- -GO"`;
+
+exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Gonka unit (GNK) 1`] = `"12,345,678.900000000- -GNK"`;
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Gram unit (GRAM) 1`] = `"12,345,678.900000000- -GRAM"`;
 
@@ -968,6 +972,8 @@ exports[`formatCurrencyUnit with custom options with locale es-ES should correct
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format GoChain unit (GO) 1`] = `"123.456.789,00000000- -GO"`;
 
+exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Gonka unit (GNK) 1`] = `"12.345.678,900000000- -GNK"`;
+
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Gram unit (GRAM) 1`] = `"12.345.678,900000000- -GRAM"`;
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Groestlcoin unit (GRS) 1`] = `"123.456.789,00000000- -GRS"`;
@@ -1369,6 +1375,8 @@ exports[`formatCurrencyUnit with custom options with locale fr-FR should correct
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format GameCredits unit (GAME) 1`] = `"123 456 789,00000000- -GAME"`;
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format GoChain unit (GO) 1`] = `"123 456 789,00000000- -GO"`;
+
+exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Gonka unit (GNK) 1`] = `"12 345 678,900000000- -GNK"`;
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Gram unit (GRAM) 1`] = `"12 345 678,900000000- -GRAM"`;
 
@@ -1772,6 +1780,8 @@ exports[`formatCurrencyUnit with custom options with locale ja-JP should correct
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format GoChain unit (GO) 1`] = `"123,456,789.00000000- -GO"`;
 
+exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Gonka unit (GNK) 1`] = `"12,345,678.900000000- -GNK"`;
+
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Gram unit (GRAM) 1`] = `"12,345,678.900000000- -GRAM"`;
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Groestlcoin unit (GRS) 1`] = `"123,456,789.00000000- -GRS"`;
@@ -2173,6 +2183,8 @@ exports[`formatCurrencyUnit with custom options with locale ko-KR should correct
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format GameCredits unit (GAME) 1`] = `"123,456,789.00000000- -GAME"`;
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format GoChain unit (GO) 1`] = `"123,456,789.00000000- -GO"`;
+
+exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Gonka unit (GNK) 1`] = `"12,345,678.900000000- -GNK"`;
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Gram unit (GRAM) 1`] = `"12,345,678.900000000- -GRAM"`;
 
@@ -2576,6 +2588,8 @@ exports[`formatCurrencyUnit with custom options with locale pt-BR should correct
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format GoChain unit (GO) 1`] = `"123.456.789,00000000- -GO"`;
 
+exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Gonka unit (GNK) 1`] = `"12.345.678,900000000- -GNK"`;
+
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Gram unit (GRAM) 1`] = `"12.345.678,900000000- -GRAM"`;
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Groestlcoin unit (GRS) 1`] = `"123.456.789,00000000- -GRS"`;
@@ -2977,6 +2991,8 @@ exports[`formatCurrencyUnit with custom options with locale ru-RU should correct
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format GameCredits unit (GAME) 1`] = `"123 456 789,00000000- -GAME"`;
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format GoChain unit (GO) 1`] = `"123 456 789,00000000- -GO"`;
+
+exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Gonka unit (GNK) 1`] = `"12 345 678,900000000- -GNK"`;
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Gram unit (GRAM) 1`] = `"12 345 678,900000000- -GRAM"`;
 
@@ -3380,6 +3396,8 @@ exports[`formatCurrencyUnit with custom options with locale tr-TR should correct
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format GoChain unit (GO) 1`] = `"123.456.789,00000000- -GO"`;
 
+exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Gonka unit (GNK) 1`] = `"12.345.678,900000000- -GNK"`;
+
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Gram unit (GRAM) 1`] = `"12.345.678,900000000- -GRAM"`;
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Groestlcoin unit (GRS) 1`] = `"123.456.789,00000000- -GRS"`;
@@ -3782,6 +3800,8 @@ exports[`formatCurrencyUnit with custom options with locale zh-CN should correct
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format GoChain unit (GO) 1`] = `"123,456,789.00000000- -GO"`;
 
+exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Gonka unit (GNK) 1`] = `"12,345,678.900000000- -GNK"`;
+
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Gram unit (GRAM) 1`] = `"12,345,678.900000000- -GRAM"`;
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Groestlcoin unit (GRS) 1`] = `"123,456,789.00000000- -GRS"`;
@@ -4183,6 +4203,8 @@ exports[`formatCurrencyUnit with default options should correctly format Flow un
 exports[`formatCurrencyUnit with default options should correctly format GameCredits unit (GAME) 1`] = `"123,456,789"`;
 
 exports[`formatCurrencyUnit with default options should correctly format GoChain unit (GO) 1`] = `"123,456,789"`;
+
+exports[`formatCurrencyUnit with default options should correctly format Gonka unit (GNK) 1`] = `"12,345,678"`;
 
 exports[`formatCurrencyUnit with default options should correctly format Gram unit (GRAM) 1`] = `"12,345,678"`;
 


### PR DESCRIPTION
### 📝 Description

Adds Gonka (GNK) as a new Cosmos-family currency to `@domain/entity-currency-crypto`.

**Changes:**
- New file `domain/entity/currency-crypto/src/currencies/gonka.ts`
- Exported alphabetically in `index.ts` (between `gochain` and `groestcoin`)
- `@ledgerhq/live-currency-format` snapshots regenerated (11 new GNK locale entries)

Two values intentionally differ from the Cosmos-family defaults:
- **`coinType: 1200`** — Gonka's SLIP-0044 registered value. Shipping 118 would silently derive a different address than Keplr and the chain's own keyring; the chain's registry entry has no `alternative_slip44s` listing 118 as a fallback (unlike Secret Network).
- **magnitude 9** (not 6) — matches the chain registry `assetlist.json` `denom_units`.

`managerAppName: "Cosmos"` is shared with Cosmos Hub and is safe: `cosmos` sorts before `gonka` in `index.ts`, so `findByManagerApp("Cosmos")` still resolves to Cosmos Hub first.

Coin-module addition and feature flag are in separate PRs; this definition is gated until the Cosmos app release (coin type 1200 support) ships.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36009](https://ledgerhq.atlassian.net/browse/LIVE-36009)
- **ADR** (if any): N/A

[LIVE-36009]: https://ledgerhq.atlassian.net/browse/LIVE-36009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ