### PR TITLE
[LWD] feat(desktop): add QA device simulation dev tool (LIVE-33171)

### DIFF
--- a/.changeset/device-simulation-dev-tool.md
+++ b/.changeset/device-simulation-dev-tool.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add inline QA device simulation dev tool in Developer settings (LIVE-33171)

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/constants/qaDeviceModels.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/constants/qaDeviceModels.ts
@@ -1,0 +1,15 @@
+import { DeviceModelId } from "@ledgerhq/devices";
+
+export const QA_NANO_MODELS = [
+  { id: DeviceModelId.nanoS, labelKey: "nanoS" },
+  { id: DeviceModelId.nanoSP, labelKey: "nanoSP" },
+  { id: DeviceModelId.nanoX, labelKey: "nanoX" },
+] as const;
+
+export const QA_TOUCHSCREEN_MODELS = [
+  { id: DeviceModelId.stax, labelKey: "stax" },
+  { id: DeviceModelId.europa, labelKey: "europa" },
+  { id: DeviceModelId.apex, labelKey: "apex" },
+] as const;
+
+export const QA_DEVICE_MODELS = [...QA_NANO_MODELS, ...QA_TOUCHSCREEN_MODELS] as const;

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/screens/LargeScreenUpsellQa/useLargeScreenUpsellQaViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/screens/LargeScreenUpsellQa/useLargeScreenUpsellQaViewModel.ts
@@ -34,21 +34,12 @@ import {
   pastCooldownOffsetDays,
   resolveParamBaseline,
 } from "./utils";
+import { QA_NANO_MODELS, QA_TOUCHSCREEN_MODELS } from "../../constants/qaDeviceModels";
 import { COPY, formatLastSeenDisplay, formatOnboardingDisplay, GATE_LABELS } from "./copy";
 
 const FLAG_KEY = "largeScreenUpsell";
 
-export const QA_NANO_MODELS = [
-  { id: DeviceModelId.nanoS, labelKey: "nanoS" },
-  { id: DeviceModelId.nanoSP, labelKey: "nanoSP" },
-  { id: DeviceModelId.nanoX, labelKey: "nanoX" },
-] as const;
-
-export const QA_TOUCHSCREEN_MODELS = [
-  { id: DeviceModelId.stax, labelKey: "stax" },
-  { id: DeviceModelId.europa, labelKey: "europa" },
-  { id: DeviceModelId.apex, labelKey: "apex" },
-] as const;
+export { QA_NANO_MODELS, QA_TOUCHSCREEN_MODELS };
 
 function handleReload() {
   window.api?.reloadRenderer();

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceSimulationDevTool/DeviceSimulationDevToolContent.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceSimulationDevTool/DeviceSimulationDevToolContent.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@ledgerhq/lumen-ui-react";
+import { DeveloperToggleRow } from "../components/DeveloperToggleRow";
+import type { DeviceSimulationDevToolViewModel } from "./useDeviceSimulationDevToolViewModel";
+
+const DEVICE_LABEL_I18N_KEYS = {
+  nanoS: "settings.developer.deviceSimulationDevTool.devices.nanoS",
+  nanoSP: "settings.developer.deviceSimulationDevTool.devices.nanoSP",
+  nanoX: "settings.developer.deviceSimulationDevTool.devices.nanoX",
+  stax: "settings.developer.deviceSimulationDevTool.devices.stax",
+  europa: "settings.developer.deviceSimulationDevTool.devices.europa",
+  apex: "settings.developer.deviceSimulationDevTool.devices.apex",
+} as const;
+
+type Props = Readonly<
+  DeviceSimulationDevToolViewModel & {
+    expanded: boolean;
+  }
+>;
+
+export function DeviceSimulationDevToolContent({
+  expanded,
+  deviceModels,
+  currentHistoryLabels,
+  isResetEnabled,
+  isDeviceSeen,
+  toggleDevice,
+  resetDevices,
+}: Props) {
+  const { t } = useTranslation();
+
+  const currentHistoryDisplay =
+    currentHistoryLabels.length > 0
+      ? currentHistoryLabels.map(labelKey => t(DEVICE_LABEL_I18N_KEYS[labelKey])).join(", ")
+      : t("settings.developer.deviceSimulationDevTool.none");
+
+  return (
+    <div className="flex flex-col gap-2 pt-2">
+      <p className="text-muted">{t("settings.developer.deviceSimulationDevTool.description")}</p>
+      <p className="body-3 text-muted" data-testid="device-simulation-current-history">
+        {t("settings.developer.deviceSimulationDevTool.currentHistory", {
+          devices: currentHistoryDisplay,
+        })}
+      </p>
+
+      {expanded ? (
+        <div className="mt-4 flex flex-col gap-6">
+          <p className="body-3 text-muted">
+            {t("settings.developer.deviceSimulationDevTool.resetWarning")}
+          </p>
+
+          <div className="flex flex-col gap-4">
+            {deviceModels.map(model => (
+              <DeveloperToggleRow
+                key={model.id}
+                name={`device-simulation-${model.id}`}
+                label={t(DEVICE_LABEL_I18N_KEYS[model.labelKey])}
+                selected={isDeviceSeen(model.id)}
+                onChange={() => toggleDevice(model.id, !isDeviceSeen(model.id))}
+              />
+            ))}
+          </div>
+
+          <div className="flex">
+            <Button
+              appearance="accent"
+              size="sm"
+              onClick={resetDevices}
+              disabled={!isResetEnabled}
+              data-testid="device-simulation-reset"
+            >
+              {t("settings.developer.deviceSimulationDevTool.reset")}
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceSimulationDevTool/__tests__/DeviceSimulationDevTool.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceSimulationDevTool/__tests__/DeviceSimulationDevTool.test.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { DeviceModelId } from "@ledgerhq/devices";
+import { render, screen } from "tests/testSetup";
+import DeviceSimulationDevTool from "../index";
+
+describe("DeviceSimulationDevTool", () => {
+  it("should show the active QA devices summary when collapsed", () => {
+    render(<DeviceSimulationDevTool />);
+
+    expect(
+      screen.getByText(
+        "Simulate device history to test Nano-user upsell surfaces without physical devices.",
+      ),
+    ).toBeVisible();
+    expect(screen.getByTestId("device-simulation-current-history")).toHaveTextContent(
+      "Active QA devices: none",
+    );
+    expect(screen.queryAllByRole("switch")).toHaveLength(0);
+    expect(screen.queryByTestId("device-simulation-reset")).not.toBeInTheDocument();
+  });
+
+  it("should expand and collapse the device simulation controls", async () => {
+    const { user } = render(<DeviceSimulationDevTool />);
+
+    await user.click(screen.getByRole("button", { name: "Show" }));
+
+    expect(screen.getByTestId("device-simulation-current-history")).toHaveTextContent(
+      "Active QA devices: none",
+    );
+    expect(screen.getAllByRole("switch")).toHaveLength(6);
+
+    await user.click(screen.getByRole("button", { name: "Hide" }));
+
+    expect(screen.getByTestId("device-simulation-current-history")).toHaveTextContent(
+      "Active QA devices: none",
+    );
+    expect(screen.queryAllByRole("switch")).toHaveLength(0);
+    expect(screen.queryByTestId("device-simulation-reset")).not.toBeInTheDocument();
+  });
+
+  it("should display translated device names and reset the history", async () => {
+    const { user, store } = render(<DeviceSimulationDevTool />, {
+      initialState: {
+        settings: {
+          devicesModelList: [DeviceModelId.nanoSP, DeviceModelId.stax],
+        },
+      },
+    });
+
+    expect(screen.getByTestId("device-simulation-current-history")).toHaveTextContent(
+      "Active QA devices: Nano S Plus, Ledger Stax",
+    );
+
+    await user.click(screen.getByRole("button", { name: "Show" }));
+
+    const resetButton = screen.getByRole("button", { name: "Reset device history" });
+    expect(resetButton).toBeEnabled();
+    await user.click(resetButton);
+
+    expect(store.getState().settings.devicesModelList).toEqual([]);
+    expect(screen.getByTestId("device-simulation-current-history")).toHaveTextContent(
+      "Active QA devices: none",
+    );
+    expect(resetButton).toBeDisabled();
+  });
+
+  it("should update device history when toggled on", async () => {
+    const { user, store } = render(<DeviceSimulationDevTool />);
+
+    await user.click(screen.getByRole("button", { name: "Show" }));
+
+    const switches = screen.getAllByRole("switch");
+    await user.click(switches[0]);
+
+    expect(store.getState().settings.devicesModelList).toEqual([DeviceModelId.nanoS]);
+    expect(screen.getByTestId("device-simulation-current-history")).toHaveTextContent(
+      "Active QA devices: Nano S",
+    );
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceSimulationDevTool/__tests__/useDeviceSimulationDevToolViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceSimulationDevTool/__tests__/useDeviceSimulationDevToolViewModel.test.ts
@@ -1,0 +1,77 @@
+import { DeviceModelId } from "@ledgerhq/devices";
+import { act, renderHook } from "tests/testSetup";
+import { useDeviceSimulationDevToolViewModel } from "../useDeviceSimulationDevToolViewModel";
+
+describe("useDeviceSimulationDevToolViewModel", () => {
+  it("should expose empty device history by default", () => {
+    const { result } = renderHook(() => useDeviceSimulationDevToolViewModel());
+
+    expect(result.current.devicesModelList).toEqual([]);
+    expect(result.current.currentHistoryLabels).toEqual([]);
+    expect(result.current.isResetEnabled).toBe(false);
+  });
+
+  it("should add a device model when toggled on", () => {
+    const { result, store } = renderHook(() => useDeviceSimulationDevToolViewModel());
+
+    act(() => {
+      result.current.toggleDevice(DeviceModelId.nanoS, true);
+    });
+
+    expect(store.getState().settings.devicesModelList).toEqual([DeviceModelId.nanoS]);
+    expect(result.current.isDeviceSeen(DeviceModelId.nanoS)).toBe(true);
+    expect(result.current.currentHistoryLabels).toEqual(["nanoS"]);
+    expect(result.current.isResetEnabled).toBe(true);
+  });
+
+  it("should remove a device model when toggled off", () => {
+    const { result, store } = renderHook(() => useDeviceSimulationDevToolViewModel(), {
+      initialState: {
+        settings: {
+          devicesModelList: [DeviceModelId.nanoS, DeviceModelId.nanoX],
+        },
+      },
+    });
+
+    act(() => {
+      result.current.toggleDevice(DeviceModelId.nanoS, false);
+    });
+
+    expect(store.getState().settings.devicesModelList).toEqual([DeviceModelId.nanoX]);
+    expect(result.current.currentHistoryLabels).toEqual(["nanoX"]);
+  });
+
+  it("should not duplicate a device model when toggled on twice", () => {
+    const { result, store } = renderHook(() => useDeviceSimulationDevToolViewModel(), {
+      initialState: {
+        settings: {
+          devicesModelList: [DeviceModelId.nanoS],
+        },
+      },
+    });
+
+    act(() => {
+      result.current.toggleDevice(DeviceModelId.nanoS, true);
+    });
+
+    expect(store.getState().settings.devicesModelList).toEqual([DeviceModelId.nanoS]);
+  });
+
+  it("should clear device history on reset", () => {
+    const { result, store } = renderHook(() => useDeviceSimulationDevToolViewModel(), {
+      initialState: {
+        settings: {
+          devicesModelList: [DeviceModelId.nanoS, DeviceModelId.stax],
+        },
+      },
+    });
+
+    act(() => {
+      result.current.resetDevices();
+    });
+
+    expect(store.getState().settings.devicesModelList).toEqual([]);
+    expect(result.current.currentHistoryLabels).toEqual([]);
+    expect(result.current.isResetEnabled).toBe(false);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceSimulationDevTool/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceSimulationDevTool/index.tsx
@@ -1,0 +1,33 @@
+import React, { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { SettingsSectionRow as Row } from "../../../SettingsSection";
+import { Button } from "@ledgerhq/lumen-ui-react";
+import { DeviceSimulationDevToolContent } from "./DeviceSimulationDevToolContent";
+import { useDeviceSimulationDevToolViewModel } from "./useDeviceSimulationDevToolViewModel";
+
+const DeviceSimulationDevTool = () => {
+  const { t } = useTranslation();
+  const [contentExpanded, setContentExpanded] = useState(false);
+  const viewModel = useDeviceSimulationDevToolViewModel();
+
+  const toggleContentVisibility = useCallback(() => {
+    setContentExpanded(prev => !prev);
+  }, []);
+
+  return (
+    <Row
+      title={t("settings.developer.deviceSimulationDevTool.title")}
+      dataTestId="device-simulation-dev-tool"
+      descContainerStyle={{ maxWidth: undefined }}
+      contentContainerStyle={{ marginRight: 0 }}
+      childrenContainerStyle={{ alignSelf: "flex-start" }}
+      desc={<DeviceSimulationDevToolContent expanded={contentExpanded} {...viewModel} />}
+    >
+      <Button appearance="accent" size="sm" onClick={toggleContentVisibility}>
+        {contentExpanded ? t("settings.developer.hide") : t("settings.developer.show")}
+      </Button>
+    </Row>
+  );
+};
+
+export default DeviceSimulationDevTool;

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceSimulationDevTool/useDeviceSimulationDevToolViewModel.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/DeviceSimulationDevTool/useDeviceSimulationDevToolViewModel.ts
@@ -1,0 +1,63 @@
+import { useCallback, useMemo } from "react";
+import { DeviceModelId } from "@ledgerhq/devices";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
+import { saveSettings } from "~/renderer/actions/settings";
+import { devicesModelListSelector } from "~/renderer/reducers/settings";
+import { QA_DEVICE_MODELS } from "LLD/features/LargeScreenUpsell/constants/qaDeviceModels";
+
+export function useDeviceSimulationDevToolViewModel() {
+  const dispatch = useDispatch();
+  const devicesModelList = useSelector(devicesModelListSelector);
+
+  const isDeviceSeen = useCallback(
+    (modelId: DeviceModelId) => devicesModelList.includes(modelId),
+    [devicesModelList],
+  );
+
+  const toggleDevice = useCallback(
+    (modelId: DeviceModelId, seen: boolean) => {
+      if (seen) {
+        const next = devicesModelList.includes(modelId)
+          ? devicesModelList
+          : [...devicesModelList, modelId];
+        dispatch(saveSettings({ devicesModelList: next }));
+        return;
+      }
+
+      dispatch(
+        saveSettings({
+          devicesModelList: devicesModelList.filter(id => id !== modelId),
+        }),
+      );
+    },
+    [devicesModelList, dispatch],
+  );
+
+  const resetDevices = useCallback(() => {
+    dispatch(saveSettings({ devicesModelList: [] }));
+  }, [dispatch]);
+
+  const currentHistoryLabels = useMemo(
+    () =>
+      QA_DEVICE_MODELS.filter(model => devicesModelList.includes(model.id)).map(
+        model => model.labelKey,
+      ),
+    [devicesModelList],
+  );
+
+  const isResetEnabled = devicesModelList.length > 0;
+
+  return {
+    deviceModels: QA_DEVICE_MODELS,
+    devicesModelList,
+    currentHistoryLabels,
+    isResetEnabled,
+    isDeviceSeen,
+    toggleDevice,
+    resetDevices,
+  };
+}
+
+export type DeviceSimulationDevToolViewModel = ReturnType<
+  typeof useDeviceSimulationDevToolViewModel
+>;

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/index.tsx
@@ -50,6 +50,7 @@ import DeviceActionContentDevTool from "./DeviceActionContentDevTool";
 import DeviceActionContentDevScreen from "./DeviceActionContentDevTool/screens/DeviceActionContentDevScreen";
 import DeviceIntentExecutorDevTool from "./DeviceIntentExecutorDevTool";
 import DeviceIntentExecutorDevScreen from "./DeviceIntentExecutorDevTool/screens/DeviceIntentExecutorDevScreen";
+import DeviceSimulationDevTool from "./DeviceSimulationDevTool";
 import LargeScreenUpsellDevTool from "./LargeScreenUpsellDevTool";
 import { LargeScreenUpsellQa } from "LLD/features/LargeScreenUpsell";
 
@@ -159,6 +160,7 @@ const Default = () => {
       <FeaturesAndFlowsDevTool />
       <AnalyticsConsentOptInDevTool />
       <GenericAwarenessModalDevTool />
+      <DeviceSimulationDevTool />
       <LargeScreenUpsellDevTool />
       <InfoStateDevTool />
       <DeviceActionContentDevTool />

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -5340,6 +5340,22 @@
           "willShow": "Will show on Contacts until dismissed."
         }
       },
+      "deviceSimulationDevTool": {
+        "title": "Device simulation (QA)",
+        "description": "Simulate device history to test Nano-user upsell surfaces without physical devices.",
+        "currentHistory": "Active QA devices: {{devices}}",
+        "resetWarning": "Reset clears the simulated QA device list only. Real device history cannot be restored without the simulation engine.",
+        "reset": "Reset device history",
+        "none": "none",
+        "devices": {
+          "nanoS": "Nano S",
+          "nanoSP": "Nano S Plus",
+          "nanoX": "Nano X",
+          "stax": "Ledger Stax",
+          "europa": "Ledger Flex",
+          "apex": "Ledger Flex Plus"
+        }
+      },
       "cryptoAssetsList": {
         "title": "Crypto Assets List",
         "description": "Browse and manage crypto assets from the Crypto Assets List (CAL) service.",


### PR DESCRIPTION
### 📝 Description

This PR adds an inline **Device simulation (QA)** dev tool under Settings → Developer on desktop, so QA can test Nano-user upsell surfaces (banners, modal, BackupHub CTA, hardware carousel) without physical devices.

**Problem**: QA had no quick way to compose device history states (LNS-only, all-Nano, touchscreen control) from Developer settings. The existing large-screen upsell QA screen is upsell-specific and requires navigating to a sub-route.

**Solution**:
- Expandable dev tool with Show/Hide, matching other Developer QA rows
- **Active QA devices** summary visible while collapsed
- Expanded controls: 6 device toggles (`nanoS`, `nanoSP`, `nanoX`, `stax`, `europa`, `apex`) and **Reset device history**
- Personalized recommendations opt-in is **not** in this tool — use **Large-screen upsell (QA)** for upsell copy QA
- Lives in Settings → Developer (same gate as other QA tools: Developer mode)

**Known limitation** (UI-minimal scope): reset clears `devicesModelList` to `[]` but does not restore pre-simulation real device history (engine LIVE-33167 abandoned). Documented in-tool copy.

### 📸 Screenshots

<img width="1196" height="789" alt="image" src="https://github.com/user-attachments/assets/4f543268-c79b-4e58-b0fd-561d06fc9a8b" />

### 🧪 Test plan

- [x] Enable Developer mode → Settings → Developer → find **Device simulation (QA)**
- [x] While collapsed, verify description + **Active QA devices: …** summary are visible
- [x] Click **Show** → verify reset warning, 6 device toggles, and Reset button
- [x] Toggle `nanoS` only → verify upsell surfaces react (banner / BackupHub CTA per flags)
- [x] Add `stax` → Nano upsell should hide
- [x] Reset enabled when history non-empty; disabled when `none`; reset clears toggles
- [x] Click **Hide** → summary stays visible; toggles and reset are hidden
- [x] Tool is visible in nightly/internal builds with Developer mode on

### 🔗 Context

- **JIRA issue**: [LIVE-33171](https://ledgerhq.atlassian.net/browse/LIVE-33171)
- **Epic**: [LIVE-32079](https://ledgerhq.atlassian.net/browse/LIVE-32079)

Made with [Cursor](https://cursor.com)

[LIVE-33171]: https://ledgerhq.atlassian.net/browse/LIVE-33171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ