### PR TITLE
fix(e2e): use earn-app-container DOM signal instead of console listener

### DIFF
--- a/e2e/desktop/tests/page/earn.base.page.ts
+++ b/e2e/desktop/tests/page/earn.base.page.ts
@@ -1,63 +1,15 @@
-import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { step } from "tests/misc/reporters/step";
 import { WebViewAppPage } from "./webViewApp.page";
 
 export abstract class EarnBasePage extends WebViewAppPage {
   protected readonly webviewIdentifier = "earn";
-  private readonly loadingSkeletonTestId = "loading-skeleton";
+  private readonly earnAppContainer = this.page.getByTestId("earn-app-container");
 
   @step("Go and wait for Earn app to be ready")
   async goAndWaitForEarnToBeReady(earnFunction: () => Promise<void>) {
-    const appReadyPromise = new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(
-        () => reject(new Error("Earn Live App did not load within 30s")),
-        30000,
-      );
-      this.page.on("console", msg => {
-        if (msg.type() === "info" && msg.text().includes("Earn Live App Loaded")) {
-          clearTimeout(timeout);
-          resolve();
-        }
-      });
-    });
-
+    this._webviewPage = undefined;
     await earnFunction();
-    await appReadyPromise;
-
-    const webview = await this.getWebView();
-    await webview.getByTestId(this.loadingSkeletonTestId).first().waitFor({ state: "hidden" });
-  }
-
-  @step("Verify provider URL")
-  async verifyProviderURL(selectedProvider: string, account: Account) {
-    const newWindow = await this.waitForNewWindow();
-    const url = newWindow.url();
-
-    switch (selectedProvider) {
-      case "Lido": {
-        await this.expectUrlToContainAll(url, [account.currency.id, "stake.lido.fi"]);
-        break;
-      }
-      case "Stader Labs": {
-        const expectedStringArray = [
-          account.currency.id,
-          `staderlabs.com/${account.currency.ticker}`,
-          ...(account.address ? [account.address] : []),
-        ];
-        await this.expectUrlToContainAll(url, expectedStringArray);
-        break;
-      }
-      case "Kiln staking Pool": {
-        await this.expectUrlToContainAll(url, [
-          account.currency.id,
-          "ledger-staking.widget.kiln.fi/earn",
-          "focus=pooled",
-          account.address!,
-        ]);
-        break;
-      }
-      default:
-        throw new Error(`Unknown provider: ${selectedProvider}`);
-    }
+    await this.earnAppContainer.waitFor();
+    await this.getWebView();
   }
 }


### PR DESCRIPTION
### 📝 Description

The earn nightly CI was failing with _"Earn Live App did not load within 30s"_ consistently.

**Root cause:** \`goAndWaitForEarnToBeReady\` used a 30s hardcoded \`setTimeout\` on the _main_ LLD page's console listener. Two problems:
1. The \`console.info("Earn Live App Loaded")\` event is emitted from the earn **webview** page — a different Electron context. It only reaches the main page when LLD explicitly forwards webview console events, which is unreliable.
2. The 30s timeout fired ~10s _before_ the earn webview even started making network requests (T+30s timeout vs T+40s first earn API call, per Allure network logs).

**Fix:** Adopt the same mechanism already used by the swap live app (\`goAndWaitForSwapToBeReady\`):

1. Reset \`_webviewPage\` before navigation (forces \`getWebView()\` to re-scan)
2. \`await earnAppContainer.waitFor()\` — the \`earn-app-container\` testId is on the \`<Box>\` wrapping \`WebPlatformPlayer\` in \`apps/ledger-live-desktop/src/renderer/screens/earn/index.tsx\`; it only renders when the manifest is resolved, i.e. when LLD is actively mounting the webview
3. \`await this.getWebView()\` — polls \`electronApp.windows()\` for the earn window

This is a pure DOM-based wait with no hardcoded timeouts, matching exactly how the swap live app signals readiness.

### 🔗 Context

- Swap reference: \`goAndWaitForSwapToBeReady\` in \`e2e/desktop/tests/page/swap.page.ts\`
- Earn container: \`data-testid="earn-app-container"\` in \`apps/ledger-live-desktop/src/renderer/screens/earn/index.tsx:130\` (pre-existing, not modified by this PR)

### 🤖 CI

https://github.com/LedgerHQ/ledger-live/actions/runs/33075134849

### ✅ Tests

Full LWD e2e suite.