### PR TITLE
fix(knip): use compilers for platform-specific files

### DIFF
--- a/knip.config.base.mjs
+++ b/knip.config.base.mjs
@@ -29,13 +29,14 @@ export function createDualPlatformKnipConfig({
   additionalIgnoreDependencies = [],
 }) {
   const platformProjectExclude = platform === "web" ? "!src/**/*.native.*" : "!src/**/*.web.*";
-  // Platform-specific files (*.web.* / *.native.*) are resolved by the bundler
-  // through platform resolution (e.g. `import "./component"` → `./component.web.tsx`).
-  // Knip can't trace that, so we add them as entry points to avoid false "unused file" reports.
-  const platformEntry = platform === "web" ? "src/**/*.web.{ts,tsx}" : "src/**/*.native.{ts,tsx}";
+  const passThrough = source => source;
+  const compilers =
+    platform === "web"
+      ? { "web.ts": passThrough, "web.tsx": passThrough }
+      : { "native.ts": passThrough, "native.tsx": passThrough };
   const workspace = {
     ...rootConfig.workspaces[packagePath],
-    entry: [...entry, platformEntry],
+    entry,
     project: [
       "src/**/*",
       platformProjectExclude,
@@ -52,6 +53,7 @@ export function createDualPlatformKnipConfig({
 
   return {
     ...rootConfig,
+    compilers,
     ignoreWorkspaces: ["apps/ledger-live-mobile"],
     workspaces: {
       [packagePath]: workspace,


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description
## Summary

Switches `createDualPlatformKnipConfig` in `knip.config.base.mjs` from adding
platform-specific globs as entry points to using Knip's `compilers` API with
identity pass-through functions, so `.web.ts(x)` / `.native.ts(x)` files are
processed natively by Knip rather than forced in as synthetic entry points.

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
