### PR TITLE
fix(ci): remove stale Vercel storybook secrets from push workflow

### DIFF
--- a/.github/workflows/build-and-test-push.yml
+++ b/.github/workflows/build-and-test-push.yml
@@ -227,8 +227,6 @@ jobs:
       NX_KEY: ${{ secrets.NX_KEY }}
       VERCEL_LEDGER_WALLET_TEAM_ID: ${{ secrets.VERCEL_LEDGER_WALLET_TEAM_ID }}
       VERCEL_LEDGER_WALLET_TOKEN: ${{ secrets.VERCEL_LEDGER_WALLET_TOKEN }}
-      VERCEL_PROJECT_NATIVE_STORYBOOK: ${{ secrets.VERCEL_PROJECT_NATIVE_STORYBOOK }}
-      VERCEL_PROJECT_REACT_STORYBOOK: ${{ secrets.VERCEL_PROJECT_REACT_STORYBOOK }}
       VERCEL_PROJECT_WEBTOOLS: ${{ secrets.VERCEL_PROJECT_WEBTOOLS }}
     with:
       vercel-production: ${{ github.ref_name == 'develop' && 'true' || 'false' }}


### PR DESCRIPTION

Hotfix for the broken `build-and-test-push.yml` workflow after #21219 was merged.

The push workflow was passing `VERCEL_PROJECT_NATIVE_STORYBOOK` and `VERCEL_PROJECT_REACT_STORYBOOK` secrets to `build-web-tools-reusable.yml`, which no longer declares them as inputs after the Storybook removal. GitHub rejects the workflow: https://github.com/LedgerHQ/ledger-live/actions/runs/33074358898
