### PR TITLE
feat(pay): add C2S bank-transfer intro VM (LIVE-35381)

### DIFF
--- a/.changeset/pay-bank-transfer-intro-vm.md
+++ b/.changeset/pay-bank-transfer-intro-vm.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-pay-bank-transfer": minor
+---
+
+Add the shared Pay bank-transfer cash-to-stable intro view-model and props-only views (LIVE-35381).

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -132,6 +132,7 @@ features/flow/flow-contacts-list/                         @ledgerhq/wallet-xp
 features/flow/pay-card/                                  @ledgerhq/wallet-xp
 features/flow/pay-balance/                               @ledgerhq/wallet-xp
 features/flow/pay-deposit/                               @ledgerhq/wallet-xp
+features/flow/pay-bank-transfer/                         @ledgerhq/wallet-xp
 features/flow/pay-feature-tour/                          @ledgerhq/wallet-xp
 features/flow/pay-card-request/                          @ledgerhq/wallet-xp
 features/flow/pay-card-details/                          @ledgerhq/wallet-xp

--- a/features/flow/pay-bank-transfer/.eslintrc.tailwind.js
+++ b/features/flow/pay-bank-transfer/.eslintrc.tailwind.js
@@ -1,0 +1,34 @@
+/**
+ * ESLint config for better-tailwindcss only (no oxlint equivalent).
+ * Run via: pnpm lint:tailwind
+ * Applies to *.web.{ts,tsx} files only.
+ */
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+const path = require("path");
+
+module.exports = {
+  root: true,
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: "module",
+    ecmaFeatures: { jsx: true },
+  },
+  plugins: ["better-tailwindcss"],
+  extends: ["plugin:better-tailwindcss/recommended"],
+  ignorePatterns: ["*.js", "*.cjs", "*.mjs", "node_modules"],
+  rules: {
+    "better-tailwindcss/enforce-consistent-line-wrapping": "off",
+  },
+  settings: {
+    "better-tailwindcss": {
+      entryPoint: path.join(__dirname, "../../../apps/ledger-live-desktop/src/renderer/global.css"),
+      callees: ["cn"],
+    },
+  },
+  overrides: [
+    {
+      files: ["**/*.web.{ts,tsx}"],
+    },
+  ],
+};

--- a/features/flow/pay-bank-transfer/CHANGELOG.md
+++ b/features/flow/pay-bank-transfer/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @features/flow-pay-bank-transfer

--- a/features/flow/pay-bank-transfer/README.md
+++ b/features/flow/pay-bank-transfer/README.md
@@ -1,0 +1,102 @@
+# Pay Bank Transfer
+
+> [!CAUTION]
+> **Status: UNSTABLE** — In active development; API may change.
+
+Shared cash-to-stable intro for the Pay deposit **Bank transfer** row. The view-model owns
+intro content, continue / close intents, and tracking. Views are props-only. Host apps own
+sheet / dialog presentation and the partner (Noah) handoff.
+
+This is a dedicated `@features/flow-*` package because Trading owns the partner WebView, not
+the Pay card package.
+
+## Usage
+
+```tsx
+import {
+  BankTransferIntroView,
+  useBankTransferIntroAdapter,
+} from "@features/flow-pay-bank-transfer";
+
+const intro = useBankTransferIntroAdapter({
+  labels: {
+    title: t("payTab.bankTransferIntro.title"),
+    description: t("payTab.bankTransferIntro.description"),
+    continueLabel: t("payTab.bankTransferIntro.continue"),
+    rows: [
+      {
+        icon: "Bank",
+        title: t("payTab.bankTransferIntro.rows.bank.title"),
+        description: t("payTab.bankTransferIntro.rows.bank.description"),
+      },
+    ],
+  },
+  onBankTransfer: () => navigateToPartner(),
+  onTrackEvent: track,
+});
+
+// Deposit options `onSelect("bankTransfer")` → intro.open()
+<QueuedBottomSheet
+  isRequestingToBeOpened={intro.isOpen}
+  onClose={intro.onClosePress}
+>
+  <BankTransferIntroView {...intro} />
+</QueuedBottomSheet>
+```
+
+i18n stays in the app. This package is copy-agnostic.
+
+## Host intents
+
+| Intent | When | Host does |
+| --- | --- | --- |
+| `open()` | Deposit row **Bank transfer** | Open the intro overlay |
+| `onBankTransfer` | Intro **Continue** | Partner handoff (below) |
+| `onClosePress` | Overlay dismiss / close | Close the overlay; no partner |
+
+Partner UI is **not** in this package. Known in-app routes (deep link TBD):
+
+| App | Route | Partner |
+| --- | --- | --- |
+| Desktop | `/bank` | Noah `WebPlatformPlayer` (`manifestId: "noah"`) |
+| Mobile | `ReceiveFunds` / `ReceiveProvider` `{ manifestId: "noah" }` | Noah `WebReceivePlayer` |
+
+Child screens under Figma `6784:63692` are TBD.
+
+## Tracking
+
+Injected `onTrackEvent` only (Pay Tracking Plan). Deposit-row
+`button_clicked { button: "bank transfer", buttonLocation: "deposit", page }` stays in
+`@features/flow-pay-deposit`.
+
+| Event | Payload |
+| --- | --- |
+| Open intro | `Page cash to stable` `{ flow: "C2S" }` |
+| Continue | `button_clicked` `{ button: "continue", flow: "C2S", page: "cash to stable" }` |
+| Close | `button_clicked` `{ button: "close", flow: "C2S", page: "cash to stable" }` |
+
+## Platform resolution
+
+Only the view carries a platform suffix. The container, view-model, adapter, and `types.ts`
+are platform-agnostic.
+
+## Structure
+
+Every `index.*` is a pure barrel (`export *` only).
+
+```text
+pay-bank-transfer/
+├── package.json
+└── src/
+    ├── components/BankTransferIntro/
+    │   ├── BankTransferIntro.tsx
+    │   ├── useBankTransferIntroViewModel.ts
+    │   ├── useBankTransferIntroAdapter.ts
+    │   ├── BankTransferIntroView.web.tsx
+    │   ├── BankTransferIntroView.native.tsx
+    │   └── __tests__/
+    ├── types.ts
+    ├── exports.ts
+    ├── index.ts
+    └── index.native.ts
+```

--- a/features/flow/pay-bank-transfer/jest.config.js
+++ b/features/flow/pay-bank-transfer/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = require("@support/jest-features-flow").createFlowJestConfig({
+  passWithNoTests: true,
+});

--- a/features/flow/pay-bank-transfer/package.json
+++ b/features/flow/pay-bank-transfer/package.json
@@ -1,0 +1,86 @@
+{
+  "name": "@features/flow-pay-bank-transfer",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Pay cash-to-stable bank transfer intro for Ledger Wallet",
+  "main": "src/index.ts",
+  "react-native": "src/index.native.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "react-native": "./src/index.native.ts",
+      "default": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "format": "oxfmt src",
+    "format:check": "oxfmt src --check",
+    "lint": "oxlint src && pnpm lint:tailwind",
+    "lint:ci": "oxlint src --quiet && pnpm lint:tailwind",
+    "lint:fix": "oxfmt src && oxlint src --fix --quiet && pnpm lint:tailwind",
+    "lint:tailwind": "eslint --no-eslintrc --no-error-on-unmatched-pattern -c .eslintrc.tailwind.js --ext .ts,.tsx 'src/**/*.web.{ts,tsx}'",
+    "typecheck": "tsc --noEmit -p tsconfig.web.json && tsc --noEmit -p tsconfig.native.json",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../../.. -W features/flow/pay-bank-transfer"
+  },
+  "devDependencies": {
+    "@support/jest-features-flow": "workspace:*",
+    "@ledgerhq/lumen-design-core": "catalog:",
+    "@ledgerhq/lumen-ui-react": "catalog:",
+    "@ledgerhq/lumen-ui-rnative": "catalog:",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@testing-library/dom": "catalog:",
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
+    "@testing-library/react-native": "catalog:",
+    "@testing-library/user-event": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@typescript-eslint/parser": "catalog:",
+    "eslint": "8.57.0",
+    "eslint-plugin-better-tailwindcss": "catalog:",
+    "jest": "catalog:",
+    "jest-environment-jsdom": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "react-native": "catalog:",
+    "react-test-renderer": "catalog:",
+    "tailwindcss": "catalog:",
+    "typescript": "catalog:"
+  },
+  "optionalDependencies": {
+    "@oxlint/binding-darwin-arm64": "1.51.0",
+    "@oxlint/binding-darwin-x64": "1.51.0",
+    "@oxlint/binding-linux-x64-gnu": "1.51.0",
+    "@oxlint/binding-win32-x64-msvc": "1.51.0"
+  },
+  "peerDependencies": {
+    "@ledgerhq/lumen-design-core": "catalog:",
+    "@ledgerhq/lumen-ui-react": "catalog:",
+    "@ledgerhq/lumen-ui-rnative": "catalog:",
+    "react": "catalog:",
+    "react-native": "catalog:"
+  },
+  "peerDependenciesMeta": {
+    "react-native": {
+      "optional": true
+    },
+    "@ledgerhq/lumen-ui-react": {
+      "optional": true
+    },
+    "@ledgerhq/lumen-ui-rnative": {
+      "optional": true
+    },
+    "@ledgerhq/lumen-design-core": {
+      "optional": true
+    }
+  }
+}

--- a/features/flow/pay-bank-transfer/project.json
+++ b/features/flow/pay-bank-transfer/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@features/flow-pay-bank-transfer",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/features/flow/pay-bank-transfer/src/components/BankTransferIntro/BankTransferIntro.tsx
+++ b/features/flow/pay-bank-transfer/src/components/BankTransferIntro/BankTransferIntro.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { BankTransferIntroView } from "./BankTransferIntroView";
+import type { BankTransferIntroProps } from "../../types";
+import { useBankTransferIntroViewModel } from "./useBankTransferIntroViewModel";
+
+export function BankTransferIntro(props: BankTransferIntroProps) {
+  return <BankTransferIntroView {...useBankTransferIntroViewModel(props)} />;
+}

--- a/features/flow/pay-bank-transfer/src/components/BankTransferIntro/BankTransferIntroView.native.tsx
+++ b/features/flow/pay-bank-transfer/src/components/BankTransferIntro/BankTransferIntroView.native.tsx
@@ -1,0 +1,97 @@
+import React, { useCallback, useEffect, useRef } from "react";
+import {
+  BottomSheetHeader,
+  BottomSheetView,
+  Box,
+  Button,
+  ListItem,
+  ListItemContent,
+  ListItemDescription,
+  ListItemLeading,
+  ListItemTitle,
+  Text,
+} from "@ledgerhq/lumen-ui-rnative";
+import * as Icons from "@ledgerhq/lumen-ui-rnative/symbols";
+import type { BankTransferIntroViewProps } from "../../types";
+
+export function BankTransferIntroView({
+  isOpen,
+  title,
+  description,
+  continueLabel,
+  rows,
+  bottomInset,
+  onShown,
+  onContinuePress,
+}: BankTransferIntroViewProps) {
+  const acted = useRef(false);
+  const onShownRef = useRef(onShown);
+  onShownRef.current = onShown;
+
+  useEffect(() => {
+    if (isOpen) {
+      acted.current = false;
+      onShownRef.current();
+    }
+  }, [isOpen]);
+
+  const handleContinue = useCallback(() => {
+    if (acted.current) {
+      return;
+    }
+    acted.current = true;
+    onContinuePress();
+  }, [onContinuePress]);
+
+  return (
+    <BottomSheetView
+      style={{ paddingHorizontal: 0, paddingBottom: bottomInset + 24 }}
+      testID="pay-bank-transfer-intro-content"
+    >
+      {isOpen ? (
+        <>
+          <BottomSheetHeader density="expanded" />
+          <Box lx={{ paddingBottom: "s24", gap: "s16" }}>
+            <Box lx={{ flexDirection: "column", gap: "s8" }}>
+              <Text typography="heading3SemiBold" lx={{ color: "base" }}>
+                {title}
+              </Text>
+              <Text typography="body2" lx={{ color: "muted" }}>
+                {description}
+              </Text>
+            </Box>
+            <Box lx={{ flexDirection: "column" }}>
+              {rows.map((row, index) => {
+                const RowIcon = Icons[row.icon];
+                return (
+                  <ListItem
+                    key={`${row.icon}-${index}`}
+                    testID={`pay-bank-transfer-intro-row-${row.icon}-${index}`}
+                  >
+                    <ListItemLeading>
+                      {RowIcon ? <RowIcon size={24} /> : null}
+                      <ListItemContent>
+                        <ListItemTitle>{row.title}</ListItemTitle>
+                        <ListItemDescription>{row.description}</ListItemDescription>
+                      </ListItemContent>
+                    </ListItemLeading>
+                  </ListItem>
+                );
+              })}
+            </Box>
+            <Button
+              appearance="base"
+              size="lg"
+              isFull
+              onPress={handleContinue}
+              accessibilityLabel={continueLabel}
+              testID="pay-bank-transfer-intro-continue"
+            >
+              {continueLabel}
+            </Button>
+          </Box>
+        </>
+      ) : null}
+    </BottomSheetView>
+  );
+}

--- a/features/flow/pay-bank-transfer/src/components/BankTransferIntro/BankTransferIntroView.web.tsx
+++ b/features/flow/pay-bank-transfer/src/components/BankTransferIntro/BankTransferIntroView.web.tsx
@@ -1,0 +1,85 @@
+import React, { useCallback, useEffect, useRef } from "react";
+import {
+  Button,
+  ListItem,
+  ListItemContent,
+  ListItemDescription,
+  ListItemLeading,
+  ListItemTitle,
+} from "@ledgerhq/lumen-ui-react";
+import * as Icons from "@ledgerhq/lumen-ui-react/symbols";
+import type { BankTransferIntroViewProps } from "../../types";
+
+export function BankTransferIntroView({
+  isOpen,
+  title,
+  description,
+  continueLabel,
+  rows,
+  onShown,
+  onContinuePress,
+}: BankTransferIntroViewProps) {
+  const acted = useRef(false);
+  const shown = useRef(false);
+
+  useEffect(() => {
+    if (isOpen && !shown.current) {
+      shown.current = true;
+      acted.current = false;
+      onShown();
+    }
+    if (!isOpen) {
+      shown.current = false;
+    }
+  }, [isOpen, onShown]);
+
+  const handleContinue = useCallback(() => {
+    if (acted.current) {
+      return;
+    }
+    acted.current = true;
+    onContinuePress();
+  }, [onContinuePress]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-16" data-testid="pay-bank-transfer-intro-content">
+      <div className="flex flex-col gap-8">
+        <span className="heading-3-semi-bold text-base">{title}</span>
+        <span className="body-2 text-muted">{description}</span>
+      </div>
+      <div className="flex flex-col">
+        {rows.map((row, index) => {
+          const RowIcon = Icons[row.icon];
+          return (
+            <ListItem
+              key={`${row.icon}-${index}`}
+              className="px-0"
+              data-testid={`pay-bank-transfer-intro-row-${row.icon}-${index}`}
+            >
+              <ListItemLeading className="p-0">
+                {RowIcon ? <RowIcon size={24} /> : null}
+                <ListItemContent>
+                  <ListItemTitle>{row.title}</ListItemTitle>
+                  <ListItemDescription>{row.description}</ListItemDescription>
+                </ListItemContent>
+              </ListItemLeading>
+            </ListItem>
+          );
+        })}
+      </div>
+      <Button
+        appearance="base"
+        size="lg"
+        className="w-full"
+        onClick={handleContinue}
+        data-testid="pay-bank-transfer-intro-continue"
+      >
+        {continueLabel}
+      </Button>
+    </div>
+  );
+}

--- a/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/BankTransferIntro.native.test.tsx
+++ b/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/BankTransferIntro.native.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { cleanup, render, screen, userEvent } from "@testing-library/react-native";
+import { BankTransferIntro } from "../BankTransferIntro";
+import type { BankTransferIntroProps } from "../../../types";
+
+const LABELS: BankTransferIntroProps["labels"] = {
+  title: "Convert cash to stablecoins",
+  description: "Transfer USD or EUR from your bank.",
+  continueLabel: "Continue",
+  rows: [{ icon: "Bank", title: "Bank transfer", description: "Send USD or EUR." }],
+};
+
+function renderIntro(overrides: Partial<BankTransferIntroProps> = {}) {
+  const props: BankTransferIntroProps = {
+    isOpen: true,
+    labels: LABELS,
+    onBankTransfer: jest.fn(),
+    onClose: jest.fn(),
+    onTrackEvent: jest.fn(),
+    ...overrides,
+  };
+  return { props, ...render(<BankTransferIntro {...props} />) };
+}
+
+describe("BankTransferIntro (Native)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("tracks the page when opened", () => {
+    const { props } = renderIntro();
+
+    expect(props.onTrackEvent).toHaveBeenCalledWith("Page cash to stable", { flow: "C2S" });
+  });
+
+  it("tracks continue, hands off and closes", async () => {
+    const user = userEvent.setup();
+    const { props } = renderIntro();
+
+    await user.press(screen.getByTestId("pay-bank-transfer-intro-continue"));
+
+    expect(props.onTrackEvent).toHaveBeenCalledWith("button_clicked", {
+      button: "continue",
+      flow: "C2S",
+      page: "cash to stable",
+    });
+    expect(props.onBankTransfer).toHaveBeenCalledTimes(1);
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/BankTransferIntro.web.test.tsx
+++ b/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/BankTransferIntro.web.test.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { BankTransferIntro } from "../BankTransferIntro";
+import type { BankTransferIntroProps } from "../../../types";
+
+const LABELS: BankTransferIntroProps["labels"] = {
+  title: "Convert cash to stablecoins",
+  description: "Transfer USD or EUR from your bank.",
+  continueLabel: "Continue",
+  rows: [{ icon: "Bank", title: "Bank transfer", description: "Send USD or EUR." }],
+};
+
+function renderIntro(overrides: Partial<BankTransferIntroProps> = {}) {
+  const props: BankTransferIntroProps = {
+    isOpen: true,
+    labels: LABELS,
+    onBankTransfer: jest.fn(),
+    onClose: jest.fn(),
+    onTrackEvent: jest.fn(),
+    ...overrides,
+  };
+  return { props, ...render(<BankTransferIntro {...props} />) };
+}
+
+describe("BankTransferIntro (Web)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("tracks the page when opened", () => {
+    const { props } = renderIntro();
+
+    expect(props.onTrackEvent).toHaveBeenCalledWith("Page cash to stable", { flow: "C2S" });
+  });
+
+  it("tracks continue, hands off and closes", async () => {
+    const user = userEvent.setup();
+    const { props } = renderIntro();
+
+    await user.click(screen.getByTestId("pay-bank-transfer-intro-continue"));
+
+    expect(props.onTrackEvent).toHaveBeenCalledWith("button_clicked", {
+      button: "continue",
+      flow: "C2S",
+      page: "cash to stable",
+    });
+    expect(props.onBankTransfer).toHaveBeenCalledTimes(1);
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders nothing when closed", () => {
+    renderIntro({ isOpen: false });
+
+    expect(screen.queryByTestId("pay-bank-transfer-intro-content")).toBeNull();
+  });
+});

--- a/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/BankTransferIntroView.native.test.tsx
+++ b/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/BankTransferIntroView.native.test.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react-native";
+import { BankTransferIntroView } from "../BankTransferIntroView.native";
+import type { BankTransferIntroViewProps } from "../../../types";
+
+const defaultProps: BankTransferIntroViewProps = {
+  isOpen: true,
+  title: "Convert cash to stablecoins",
+  description: "Transfer USD or EUR from your bank.",
+  continueLabel: "Continue",
+  rows: [{ icon: "Bank", title: "Bank transfer", description: "Send USD or EUR." }],
+  bottomInset: 0,
+  onShown: jest.fn(),
+  onContinuePress: jest.fn(),
+  onClosePress: jest.fn(),
+};
+
+describe("BankTransferIntroView (Native)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("signals it was shown once across re-renders", () => {
+    const onShown = jest.fn();
+    const { rerender } = render(<BankTransferIntroView {...defaultProps} onShown={onShown} />);
+
+    rerender(<BankTransferIntroView {...defaultProps} onShown={onShown} />);
+
+    expect(onShown).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not signal it was shown while closed", () => {
+    const onShown = jest.fn();
+    render(<BankTransferIntroView {...defaultProps} isOpen={false} onShown={onShown} />);
+
+    expect(onShown).not.toHaveBeenCalled();
+  });
+
+  it("keeps the sheet content node mounted but hides copy while closed", () => {
+    render(<BankTransferIntroView {...defaultProps} isOpen={false} />);
+
+    expect(screen.getByTestId("pay-bank-transfer-intro-content")).toBeTruthy();
+    expect(screen.queryByText("Convert cash to stablecoins")).toBeNull();
+  });
+
+  it("renders the intro copy when open", () => {
+    render(<BankTransferIntroView {...defaultProps} />);
+
+    expect(screen.getByText("Convert cash to stablecoins")).toBeTruthy();
+    expect(screen.getByLabelText("Continue")).toBeTruthy();
+  });
+
+  it("reserves the bottom safe area so the CTA stays visible", () => {
+    render(<BankTransferIntroView {...defaultProps} bottomInset={48} />);
+
+    const content = screen.getByTestId("pay-bank-transfer-intro-content");
+    expect(content.props.style.paddingBottom).toBeGreaterThanOrEqual(48);
+  });
+
+  it("continues once even if the CTA is pressed repeatedly", () => {
+    const onContinuePress = jest.fn();
+    render(<BankTransferIntroView {...defaultProps} onContinuePress={onContinuePress} />);
+
+    const cta = screen.getByLabelText("Continue");
+    fireEvent.press(cta);
+    fireEvent.press(cta);
+
+    expect(onContinuePress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/BankTransferIntroView.web.test.tsx
+++ b/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/BankTransferIntroView.web.test.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { BankTransferIntroView } from "../BankTransferIntroView.web";
+import type { BankTransferIntroViewProps } from "../../../types";
+
+const defaultProps: BankTransferIntroViewProps = {
+  isOpen: true,
+  title: "Convert cash to stablecoins",
+  description: "Transfer USD or EUR from your bank.",
+  continueLabel: "Continue",
+  rows: [{ icon: "Bank", title: "Bank transfer", description: "Send USD or EUR." }],
+  bottomInset: 0,
+  onShown: jest.fn(),
+  onContinuePress: jest.fn(),
+  onClosePress: jest.fn(),
+};
+
+describe("BankTransferIntroView (Web)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("signals it was shown once across re-renders", () => {
+    const onShown = jest.fn();
+    const { rerender } = render(<BankTransferIntroView {...defaultProps} onShown={onShown} />);
+
+    rerender(<BankTransferIntroView {...defaultProps} onShown={onShown} />);
+
+    expect(onShown).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not signal it was shown while closed", () => {
+    const onShown = jest.fn();
+    render(<BankTransferIntroView {...defaultProps} isOpen={false} onShown={onShown} />);
+
+    expect(onShown).not.toHaveBeenCalled();
+  });
+
+  it("continues once even if the CTA is clicked repeatedly", () => {
+    const onContinuePress = jest.fn();
+    render(<BankTransferIntroView {...defaultProps} onContinuePress={onContinuePress} />);
+
+    fireEvent.click(screen.getByTestId("pay-bank-transfer-intro-continue"));
+    fireEvent.click(screen.getByTestId("pay-bank-transfer-intro-continue"));
+
+    expect(onContinuePress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/useBankTransferIntroAdapter.web.test.ts
+++ b/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/useBankTransferIntroAdapter.web.test.ts
@@ -1,0 +1,52 @@
+import { act, renderHook } from "@testing-library/react";
+import type { BankTransferIntroLabels } from "../../../types";
+import { useBankTransferIntroAdapter } from "../useBankTransferIntroAdapter";
+
+const labels: BankTransferIntroLabels = {
+  title: "Convert cash to stablecoins",
+  description: "Transfer USD or EUR from your bank.",
+  continueLabel: "Continue",
+  rows: [{ icon: "Bank", title: "Bank transfer", description: "Send USD or EUR." }],
+};
+
+describe("useBankTransferIntroAdapter", () => {
+  it("starts closed and toggles isOpen via open and onClosePress", () => {
+    const { result } = renderHook(() =>
+      useBankTransferIntroAdapter({ labels, onBankTransfer: jest.fn() }),
+    );
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.bankTransferIntro.isOpen).toBe(false);
+
+    act(() => result.current.open());
+    expect(result.current.isOpen).toBe(true);
+
+    act(() => result.current.onClosePress());
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it("passes labels, onBankTransfer and onTrackEvent through into bankTransferIntro", () => {
+    const onBankTransfer = jest.fn();
+    const onTrackEvent = jest.fn();
+
+    const { result } = renderHook(() =>
+      useBankTransferIntroAdapter({ labels, onBankTransfer, onTrackEvent }),
+    );
+
+    const { bankTransferIntro } = result.current;
+    expect(bankTransferIntro.labels).toBe(labels);
+    expect(bankTransferIntro.onBankTransfer).toBe(onBankTransfer);
+    expect(bankTransferIntro.onTrackEvent).toBe(onTrackEvent);
+  });
+
+  it("emits onBankTransfer and closes on continue", () => {
+    const onBankTransfer = jest.fn();
+    const { result } = renderHook(() => useBankTransferIntroAdapter({ labels, onBankTransfer }));
+
+    act(() => result.current.open());
+    act(() => result.current.onContinuePress());
+
+    expect(onBankTransfer).toHaveBeenCalledTimes(1);
+    expect(result.current.isOpen).toBe(false);
+  });
+});

--- a/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/useBankTransferIntroViewModel.web.test.ts
+++ b/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/useBankTransferIntroViewModel.web.test.ts
@@ -1,0 +1,82 @@
+import { renderHook } from "@testing-library/react";
+import { useBankTransferIntroViewModel } from "../useBankTransferIntroViewModel";
+import type { BankTransferIntroProps } from "../../../types";
+
+const LABELS: BankTransferIntroProps["labels"] = {
+  title: "Convert cash to stablecoins",
+  description: "Transfer USD or EUR from your bank.",
+  continueLabel: "Continue",
+  rows: [
+    { icon: "Bank", title: "Bank transfer", description: "Send USD or EUR." },
+    { icon: "Globe", title: "Receive stablecoins", description: "Get USDC or USDT." },
+    { icon: "CreditCard", title: "Spend with your card", description: "Use stablecoins anywhere." },
+  ],
+};
+
+function setup(overrides: Partial<BankTransferIntroProps> = {}) {
+  const props: BankTransferIntroProps = {
+    isOpen: true,
+    labels: LABELS,
+    onBankTransfer: jest.fn(),
+    onClose: jest.fn(),
+    onTrackEvent: jest.fn(),
+    ...overrides,
+  };
+  const { result } = renderHook(() => useBankTransferIntroViewModel(props));
+  return { props, result };
+}
+
+describe("useBankTransferIntroViewModel", () => {
+  it("exposes the injected labels", () => {
+    const { result } = setup();
+
+    expect(result.current.title).toBe(LABELS.title);
+    expect(result.current.description).toBe(LABELS.description);
+    expect(result.current.continueLabel).toBe(LABELS.continueLabel);
+    expect(result.current.rows).toEqual(LABELS.rows);
+  });
+
+  it("tracks the cash-to-stable page when shown", () => {
+    const { props, result } = setup();
+
+    result.current.onShown();
+
+    expect(props.onTrackEvent).toHaveBeenCalledWith("Page cash to stable", { flow: "C2S" });
+  });
+
+  it("tracks continue, emits onBankTransfer, then closes", () => {
+    const { props, result } = setup();
+
+    result.current.onContinuePress();
+
+    expect(props.onTrackEvent).toHaveBeenCalledWith("button_clicked", {
+      button: "continue",
+      flow: "C2S",
+      page: "cash to stable",
+    });
+    expect(props.onBankTransfer).toHaveBeenCalledTimes(1);
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("tracks close and dismisses without handing off", () => {
+    const { props, result } = setup();
+
+    result.current.onClosePress();
+
+    expect(props.onTrackEvent).toHaveBeenCalledWith("button_clicked", {
+      button: "close",
+      flow: "C2S",
+      page: "cash to stable",
+    });
+    expect(props.onBankTransfer).not.toHaveBeenCalled();
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not throw when no tracker is provided", () => {
+    const { props, result } = setup({ onTrackEvent: undefined });
+
+    expect(() => result.current.onShown()).not.toThrow();
+    expect(() => result.current.onContinuePress()).not.toThrow();
+    expect(props.onBankTransfer).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/flow/pay-bank-transfer/src/components/BankTransferIntro/index.ts
+++ b/features/flow/pay-bank-transfer/src/components/BankTransferIntro/index.ts
@@ -1,0 +1,3 @@
+export * from "./BankTransferIntro";
+export * from "./useBankTransferIntroAdapter";
+export * from "./useBankTransferIntroViewModel";

--- a/features/flow/pay-bank-transfer/src/components/BankTransferIntro/useBankTransferIntroAdapter.ts
+++ b/features/flow/pay-bank-transfer/src/components/BankTransferIntro/useBankTransferIntroAdapter.ts
@@ -1,0 +1,43 @@
+import { useCallback, useState } from "react";
+import type {
+  BankTransferIntroLabels,
+  BankTransferIntroProps,
+  BankTransferIntroViewModel,
+  PayCardTrackEvent,
+} from "../../types";
+import { useBankTransferIntroViewModel } from "./useBankTransferIntroViewModel";
+
+export type UseBankTransferIntroAdapterParams = Readonly<{
+  labels: BankTransferIntroLabels;
+  onBankTransfer: () => void;
+  onTrackEvent?: PayCardTrackEvent;
+}>;
+
+export type UseBankTransferIntroAdapter = Readonly<{
+  open: () => void;
+  bankTransferIntro: BankTransferIntroProps;
+}> &
+  BankTransferIntroViewModel;
+
+export function useBankTransferIntroAdapter({
+  labels,
+  onBankTransfer,
+  onTrackEvent,
+}: UseBankTransferIntroAdapterParams): UseBankTransferIntroAdapter {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const open = useCallback(() => setIsOpen(true), []);
+  const onClose = useCallback(() => setIsOpen(false), []);
+
+  const bankTransferIntro: BankTransferIntroProps = {
+    isOpen,
+    labels,
+    onBankTransfer,
+    onClose,
+    onTrackEvent,
+  };
+
+  const viewModel = useBankTransferIntroViewModel(bankTransferIntro);
+
+  return { open, bankTransferIntro, ...viewModel };
+}

--- a/features/flow/pay-bank-transfer/src/components/BankTransferIntro/useBankTransferIntroViewModel.ts
+++ b/features/flow/pay-bank-transfer/src/components/BankTransferIntro/useBankTransferIntroViewModel.ts
@@ -1,0 +1,58 @@
+import { useCallback } from "react";
+import type { BankTransferIntroProps, BankTransferIntroViewModel } from "../../types";
+
+export const BANK_TRANSFER_INTRO_PAGE_EVENT = "Page cash to stable";
+export const BANK_TRANSFER_INTRO_PAGE = "cash to stable";
+export const BANK_TRANSFER_INTRO_FLOW = "C2S";
+
+const TRACK_BUTTON = {
+  continue: "continue",
+  close: "close",
+} as const;
+
+export function useBankTransferIntroViewModel({
+  isOpen,
+  labels,
+  bottomInset = 0,
+  onBankTransfer,
+  onClose,
+  onTrackEvent,
+}: BankTransferIntroProps): BankTransferIntroViewModel {
+  const onShown = useCallback(() => {
+    onTrackEvent?.(BANK_TRANSFER_INTRO_PAGE_EVENT, { flow: BANK_TRANSFER_INTRO_FLOW });
+  }, [onTrackEvent]);
+
+  const trackCta = useCallback(
+    (button: (typeof TRACK_BUTTON)[keyof typeof TRACK_BUTTON]) => {
+      onTrackEvent?.("button_clicked", {
+        button,
+        flow: BANK_TRANSFER_INTRO_FLOW,
+        page: BANK_TRANSFER_INTRO_PAGE,
+      });
+    },
+    [onTrackEvent],
+  );
+
+  const onContinuePress = useCallback(() => {
+    trackCta(TRACK_BUTTON.continue);
+    onBankTransfer();
+    onClose();
+  }, [trackCta, onBankTransfer, onClose]);
+
+  const onClosePress = useCallback(() => {
+    trackCta(TRACK_BUTTON.close);
+    onClose();
+  }, [trackCta, onClose]);
+
+  return {
+    isOpen,
+    title: labels.title,
+    description: labels.description,
+    continueLabel: labels.continueLabel,
+    rows: labels.rows,
+    bottomInset,
+    onShown,
+    onContinuePress,
+    onClosePress,
+  };
+}

--- a/features/flow/pay-bank-transfer/src/exports.ts
+++ b/features/flow/pay-bank-transfer/src/exports.ts
@@ -1,0 +1,2 @@
+export * from "./components/BankTransferIntro";
+export * from "./types";

--- a/features/flow/pay-bank-transfer/src/index.native.ts
+++ b/features/flow/pay-bank-transfer/src/index.native.ts
@@ -1,0 +1,1 @@
+export * from "./exports";

--- a/features/flow/pay-bank-transfer/src/index.ts
+++ b/features/flow/pay-bank-transfer/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./exports";

--- a/features/flow/pay-bank-transfer/src/types.ts
+++ b/features/flow/pay-bank-transfer/src/types.ts
@@ -1,0 +1,40 @@
+export type PayCardTrackEvent = (event: string, params: Record<string, unknown>) => void;
+
+export type BankTransferIntroRowIcon = "Bank" | "Globe" | "CreditCard";
+
+export type BankTransferIntroRow = Readonly<{
+  icon: BankTransferIntroRowIcon;
+  title: string;
+  description: string;
+}>;
+
+export type BankTransferIntroLabels = Readonly<{
+  title: string;
+  description: string;
+  continueLabel: string;
+  rows: readonly BankTransferIntroRow[];
+}>;
+
+export type BankTransferIntroProps = Readonly<{
+  isOpen: boolean;
+  labels: BankTransferIntroLabels;
+  bottomInset?: number;
+  /** Host-owned partner handoff (Noah / Trading). This package never navigates. */
+  onBankTransfer: () => void;
+  onClose: () => void;
+  onTrackEvent?: PayCardTrackEvent;
+}>;
+
+export type BankTransferIntroViewModel = Readonly<{
+  isOpen: boolean;
+  title: string;
+  description: string;
+  continueLabel: string;
+  rows: readonly BankTransferIntroRow[];
+  bottomInset: number;
+  onShown: () => void;
+  onContinuePress: () => void;
+  onClosePress: () => void;
+}>;
+
+export type BankTransferIntroViewProps = BankTransferIntroViewModel;

--- a/features/flow/pay-bank-transfer/tsconfig.json
+++ b/features/flow/pay-bank-transfer/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "types": ["jest", "node", "@testing-library/jest-dom"]
+  },
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.web.json" },
+    { "path": "./tsconfig.native.json" }
+  ]
+}

--- a/features/flow/pay-bank-transfer/tsconfig.native.json
+++ b/features/flow/pay-bank-transfer/tsconfig.native.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleSuffixes": [".native", ""]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "src/**/*.web.*"]
+}

--- a/features/flow/pay-bank-transfer/tsconfig.test.json
+++ b/features/flow/pay-bank-transfer/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.web.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "src/**/*.native.*"]
+}

--- a/features/flow/pay-bank-transfer/tsconfig.web.json
+++ b/features/flow/pay-bank-transfer/tsconfig.web.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleSuffixes": [".web", ""]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "src/**/*.native.*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6083,6 +6083,103 @@ importers:
         specifier: 1.51.0
         version: 1.51.0
 
+  features/flow/pay-bank-transfer:
+    devDependencies:
+      '@ledgerhq/lumen-design-core':
+        specifier: 'catalog:'
+        version: 0.1.26
+      '@ledgerhq/lumen-ui-react':
+        specifier: 'catalog:'
+        version: 0.1.55(@ledgerhq/lumen-design-core@0.1.26)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@ledgerhq/lumen-ui-rnative':
+        specifier: 'catalog:'
+        version: 0.1.58(@ledgerhq/lumen-design-core@0.1.26)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@support/jest-features-flow':
+        specifier: workspace:*
+        version: link:../../../support/jest-features-flow
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@testing-library/dom':
+        specifier: 'catalog:'
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: 'catalog:'
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@testing-library/react-native':
+        specifier: 'catalog:'
+        version: 13.3.3(patch_hash=4f93e75372e62b6dc0f0b2635b62a322b37a3727637bd94a38df1ed8648e2e76)(jest@30.4.1(@types/node@24.12.0))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react-test-renderer@19.1.4(react@19.1.4))(react@19.1.4)
+      '@testing-library/user-event':
+        specifier: 'catalog:'
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.0.14
+      '@typescript-eslint/parser':
+        specifier: 'catalog:'
+        version: 8.48.1(@typescript/typescript6@6.0.2)(eslint@8.57.0)
+      eslint:
+        specifier: 8.57.0
+        version: 8.57.0
+      eslint-plugin-better-tailwindcss:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.3(@typescript/typescript6@6.0.2)(eslint@8.57.0)(tailwindcss@4.1.18)
+      jest:
+        specifier: 'catalog:'
+        version: 30.4.1(@types/node@24.12.0)
+      jest-environment-jsdom:
+        specifier: 'catalog:'
+        version: 30.4.1
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.64.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.79.0
+      react:
+        specifier: 19.1.4
+        version: 19.1.4
+      react-dom:
+        specifier: 19.1.4
+        version: 19.1.4(react@19.1.4)
+      react-native:
+        specifier: 'catalog:'
+        version: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4)
+      react-test-renderer:
+        specifier: 'catalog:'
+        version: 19.1.4(react@19.1.4)
+      tailwindcss:
+        specifier: 'catalog:'
+        version: 4.1.18
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+    optionalDependencies:
+      '@oxlint/binding-darwin-arm64':
+        specifier: 1.51.0
+        version: 1.51.0
+      '@oxlint/binding-darwin-x64':
+        specifier: 1.51.0
+        version: 1.51.0
+      '@oxlint/binding-linux-x64-gnu':
+        specifier: 1.51.0
+        version: 1.51.0
+      '@oxlint/binding-win32-x64-msvc':
+        specifier: 1.51.0
+        version: 1.51.0
+
   features/flow/pay-card:
     dependencies:
       '@features/flow-pay-card-auth':
@@ -18971,10 +19068,6 @@ packages:
     resolution: {integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.27.6':
-    resolution: {integrity: sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
@@ -21148,10 +21241,6 @@ packages:
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
-  '@jest/schemas@30.0.5':
-    resolution: {integrity: sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/schemas@30.4.1':
     resolution: {integrity: sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==}
@@ -36831,10 +36920,6 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  pretty-format@30.2.0:
-    resolution: {integrity: sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   pretty-format@30.4.1:
     resolution: {integrity: sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -44350,11 +44435,6 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@babel/types@7.27.6':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
-
   '@babel/types@7.28.5':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
@@ -47853,10 +47933,6 @@ snapshots:
   '@jest/schemas@29.6.3':
     dependencies:
       '@sinclair/typebox': 0.27.8
-
-  '@jest/schemas@30.0.5':
-    dependencies:
-      '@sinclair/typebox': 0.34.41
 
   '@jest/schemas@30.4.1':
     dependencies:
@@ -55529,7 +55605,7 @@ snapshots:
     dependencies:
       jest-matcher-utils: 30.4.1
       picocolors: 1.1.1
-      pretty-format: 30.2.0
+      pretty-format: 30.4.1
       react: 19.1.4
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
       react-test-renderer: 19.1.4(react@19.1.4)
@@ -55541,7 +55617,7 @@ snapshots:
     dependencies:
       jest-matcher-utils: 30.4.1
       picocolors: 1.1.1
-      pretty-format: 30.2.0
+      pretty-format: 30.4.1
       react: 19.1.4
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4)
       react-test-renderer: 19.1.4(react@19.1.4)
@@ -55553,7 +55629,7 @@ snapshots:
     dependencies:
       jest-matcher-utils: 30.4.1
       picocolors: 1.1.1
-      pretty-format: 30.2.0
+      pretty-format: 30.4.1
       react: 19.1.4
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4)
       react-test-renderer: 19.1.4(react@19.1.4)
@@ -55565,7 +55641,7 @@ snapshots:
     dependencies:
       jest-matcher-utils: 30.4.1
       picocolors: 1.1.1
-      pretty-format: 30.2.0
+      pretty-format: 30.4.1
       react: 19.1.4
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4)
       react-test-renderer: 19.1.4(react@19.1.4)
@@ -56013,7 +56089,7 @@ snapshots:
   '@types/jest@30.0.0':
     dependencies:
       expect: 30.4.1
-      pretty-format: 30.2.0
+      pretty-format: 30.4.1
 
   '@types/jsdom@21.1.7':
     dependencies:
@@ -59804,7 +59880,7 @@ snapshots:
 
   config-file-ts@0.2.8-rc1:
     dependencies:
-      glob: 10.4.5
+      glob: 10.5.0
       typescript: 5.9.3
 
   connect-history-api-fallback@2.0.0: {}
@@ -66595,7 +66671,9 @@ snapshots:
     optionalDependencies:
       metro-transform-worker: 0.81.5
     transitivePeerDependencies:
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   metro-config@0.83.3(metro-transform-worker@0.83.3):
     dependencies:
@@ -66748,9 +66826,9 @@ snapshots:
 
   metro-source-map@0.81.5:
     dependencies:
-      '@babel/traverse': 7.27.0
+      '@babel/traverse': 7.29.0
       '@babel/traverse--for-generate-function-map': '@babel/traverse@7.29.0'
-      '@babel/types': 7.27.0
+      '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
       metro-symbolicate: 0.81.5
@@ -66861,7 +66939,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/generator': 7.28.5
       '@babel/parser': 7.27.5
-      '@babel/types': 7.27.6
+      '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
       metro: 0.81.5
       metro-babel-transformer: 0.81.5
@@ -66903,7 +66981,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.7
+      metro: 0.83.7(metro-transform-worker@0.83.7)
       metro-babel-transformer: 0.83.7
       metro-cache: 0.83.7
       metro-cache-key: 0.83.7
@@ -66918,7 +66996,7 @@ snapshots:
 
   metro@0.81.5:
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.29.0
       '@babel/core': 7.28.5
       '@babel/generator': 7.28.5
       '@babel/parser': 7.27.0
@@ -67053,6 +67131,53 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.83.7(metro-transform-worker@0.83.7):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.28.5
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 2.0.0
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.35.0
+      image-size: 1.1.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.7
+      metro-cache: 0.83.7
+      metro-cache-key: 0.83.7
+      metro-config: 0.83.7(metro-transform-worker@0.83.7)
+      metro-core: 0.83.7
+      metro-file-map: 0.83.7
+      metro-resolver: 0.83.7
+      metro-runtime: 0.83.7
+      metro-source-map: 0.83.7
+      metro-symbolicate: 0.83.7
+      metro-transform-plugins: 0.83.7
+      metro-transform-worker: 0.83.7
+      mime-types: 3.0.1
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - metro-transform-worker
       - supports-color
       - utf-8-validate
 
@@ -69309,12 +69434,6 @@ snapshots:
   pretty-format@29.7.0:
     dependencies:
       '@jest/schemas': 29.6.3
-      ansi-styles: 5.2.0
-      react-is: 18.3.1
-
-  pretty-format@30.2.0:
-    dependencies:
-      '@jest/schemas': 30.0.5
       ansi-styles: 5.2.0
       react-is: 18.3.1
 


### PR DESCRIPTION
### 📝 Description

Pay deposit **Bank transfer** currently has no shared intro step. Desktop goes straight to `/bank` (Noah) and mobile goes straight to `ReceiveProvider`. Product wants a cash-to-stable feature intro (sheet on mobile, dialog on desktop) before partner handoff, driven by one VM.

This PR adds `@features/flow-pay-bank-transfer` with that shared VM and props-only views. Hosts own overlay presentation and `onBankTransfer` (Noah). App wiring is LIVE-35382 (mobile) / a follow-up desktop ticket.

```tsx
const intro = useBankTransferIntroAdapter({
  labels,
  onBankTransfer: () => navigateToPartner(),
  onTrackEvent: track,
});

// Deposit `onSelect("bankTransfer")` → intro.open()
<QueuedBottomSheet
  isRequestingToBeOpened={intro.isOpen}
  onClose={intro.onClosePress}
>
  <BankTransferIntroView {...intro} />
</QueuedBottomSheet>
```

Tracking via injected `onTrackEvent`:

- Open: `Page cash to stable` `{ flow: "C2S" }`
- Continue / close: `button_clicked` `{ button, flow: "C2S", page: "cash to stable" }`

Deposit-row `button_clicked { button: "bank transfer", buttonLocation: "deposit" }` stays in `@features/flow-pay-deposit`.

### 🧪 Test coverage

Package unit tests (web + native) for the adapter, view-model, and views. 22 passing. Not wired into the apps yet, so no app integration tests.

### ✔️ Checklist

- [x] I have added tests
- [x] Changeset included (`@features/flow-pay-bank-transfer` minor)

### 🔗 Context

- **JIRA**: [LIVE-35381](https://ledgerhq.atlassian.net/browse/LIVE-35381)
- **Depends on**: [LIVE-34910](https://ledgerhq.atlassian.net/browse/LIVE-34910) (Deposit options SHARED)
- **Follow-up**: [LIVE-35382](https://ledgerhq.atlassian.net/browse/LIVE-35382) (mobile PayTab wiring)
- **Stories**: [LIVE-34908](https://ledgerhq.atlassian.net/browse/LIVE-34908) / [LIVE-34909](https://ledgerhq.atlassian.net/browse/LIVE-34909)

[LIVE-35381]: https://ledgerhq.atlassian.net/browse/LIVE-35381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ