### PR TITLE
[LWM] fix(mobile): improve keyboard transition in contact drawers (LIVE-35861)

### DIFF
--- a/.changeset/LIVE-35861-contacts-keyboard-transition.md
+++ b/.changeset/LIVE-35861-contacts-keyboard-transition.md
@@ -1,0 +1,9 @@
+---
+"@features/platform-contacts": patch
+"@features/flow-contacts-edit-contact": patch
+"live-mobile": patch
+---
+
+Fix the keyboard flickering open and shut on the Mobile edit contact drawer, which focused its name field as soon as it mounted and so raised the keyboard into a drawer that was still animating. The field now waits for its drawer to settle before taking focus, as the add contact drawer already did, and focus is opt-in so no other drawer can raise the keyboard by accident.
+
+Also give the add contact, edit contact and Send add new contact drawers the same keyboard clearance as the add address and edit address drawers, so every contact drawer leaves the same gap above the keyboard on iOS instead of sitting flush against it.

--- a/apps/ledger-live-mobile/src/logic/keyboardVisible.test.ts
+++ b/apps/ledger-live-mobile/src/logic/keyboardVisible.test.ts
@@ -1,6 +1,10 @@
 import { act, renderHook } from "@tests/test-renderer";
 import { Keyboard, type KeyboardEvent } from "react-native";
-import { shouldUseKeyboardAvoidance, useKeyboardVisible } from "./keyboardVisible";
+import {
+  resolveKeyboardBottomOffset,
+  shouldUseKeyboardAvoidance,
+  useKeyboardVisible,
+} from "./keyboardVisible";
 
 describe("shouldUseKeyboardAvoidance", () => {
   it("should enable JavaScript keyboard avoidance on iOS and Android 35+", () => {
@@ -10,6 +14,52 @@ describe("shouldUseKeyboardAvoidance", () => {
 
   it("should keep native Android resize below API 35", () => {
     expect(shouldUseKeyboardAvoidance("android", 34)).toBe(false);
+  });
+});
+
+describe("resolveKeyboardBottomOffset", () => {
+  it("should add the iOS gap when the keyboard is visible", () => {
+    expect(
+      resolveKeyboardBottomOffset({
+        isKeyboardVisible: true,
+        keyboardHeight: 300,
+        platform: "ios",
+        version: "18.0",
+      }),
+    ).toBe(332);
+  });
+
+  it("should use the keyboard height without a gap on Android 35+", () => {
+    expect(
+      resolveKeyboardBottomOffset({
+        isKeyboardVisible: true,
+        keyboardHeight: 300,
+        platform: "android",
+        version: 35,
+      }),
+    ).toBe(300);
+  });
+
+  it("should reserve nothing when the keyboard is hidden", () => {
+    expect(
+      resolveKeyboardBottomOffset({
+        isKeyboardVisible: false,
+        keyboardHeight: 300,
+        platform: "ios",
+        version: "18.0",
+      }),
+    ).toBe(0);
+  });
+
+  it("should reserve nothing when native Android resize handles the keyboard", () => {
+    expect(
+      resolveKeyboardBottomOffset({
+        isKeyboardVisible: true,
+        keyboardHeight: 300,
+        platform: "android",
+        version: 34,
+      }),
+    ).toBe(0);
   });
 });
 

--- a/apps/ledger-live-mobile/src/logic/keyboardVisible.ts
+++ b/apps/ledger-live-mobile/src/logic/keyboardVisible.ts
@@ -19,6 +19,30 @@ export function shouldUseKeyboardAvoidance(
   return platform === "ios" || (platform === "android" && Number(version) >= 35);
 }
 
+const IOS_KEYBOARD_GAP = 32;
+
+export function resolveKeyboardBottomOffset({
+  isKeyboardVisible,
+  keyboardHeight,
+  platform,
+  version,
+}: Readonly<{
+  isKeyboardVisible: boolean;
+  keyboardHeight: number;
+  platform: PlatformOSType;
+  version: number | string;
+}>): number {
+  if (!isKeyboardVisible || !shouldUseKeyboardAvoidance(platform, version)) {
+    return 0;
+  }
+
+  if (platform === "ios") {
+    return keyboardHeight + IOS_KEYBOARD_GAP;
+  }
+
+  return keyboardHeight;
+}
+
 export function useKeyboardVisible({
   eventTiming = "did",
 }: UseKeyboardVisibleOptions = {}): KeyboardVisibility {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactDetailEditDeleteSheets/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactDetailEditDeleteSheets/index.tsx
@@ -8,7 +8,7 @@ import {
 } from "@features/flow-contacts";
 import { ContactsRenameContactDrawer } from "@features/flow-contacts-edit-contact";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { shouldUseKeyboardAvoidance, useKeyboardVisible } from "~/logic/keyboardVisible";
+import { resolveKeyboardBottomOffset, useKeyboardVisible } from "~/logic/keyboardVisible";
 import { QueuedBottomSheet } from "@shared/ui-queued-bottom-sheet";
 import type { ContactDetailEditDeleteFlowProps } from "../../hooks/useContactDetailEditDeleteAdapter";
 
@@ -25,11 +25,12 @@ export function ContactDetailEditDeleteSheets({
   const { isKeyboardVisible, keyboardHeight } = useKeyboardVisible({
     eventTiming: Platform.OS === "ios" ? "will" : "did",
   });
-  const iosKeyboardGap = 32;
-  const keyboardInset =
-    isKeyboardVisible && shouldUseKeyboardAvoidance(Platform.OS, Platform.Version)
-      ? keyboardHeight + (Platform.OS === "ios" ? iosKeyboardGap : 0)
-      : 0;
+  const keyboardInset = resolveKeyboardBottomOffset({
+    isKeyboardVisible,
+    keyboardHeight,
+    platform: Platform.OS,
+    version: Platform.Version,
+  });
   const [hasRenameOpened, setHasRenameOpened] = useState(false);
   const onRenameOpened = useCallback(() => setHasRenameOpened(true), []);
   const onCloseRename = useCallback(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactDetailEditDeleteSheets/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactDetailEditDeleteSheets/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
 import { Platform } from "react-native";
 import {
   ContactDetailActionsMenu,
@@ -22,12 +22,20 @@ export function ContactDetailEditDeleteSheets({
   signerMismatchSheet,
 }: ContactDetailEditDeleteSheetsProps): React.JSX.Element {
   const { bottom: bottomInset } = useSafeAreaInsets();
-  const { keyboardHeight } = useKeyboardVisible({
+  const { isKeyboardVisible, keyboardHeight } = useKeyboardVisible({
     eventTiming: Platform.OS === "ios" ? "will" : "did",
   });
-  const keyboardInset = shouldUseKeyboardAvoidance(Platform.OS, Platform.Version)
-    ? keyboardHeight
-    : 0;
+  const iosKeyboardGap = 32;
+  const keyboardInset =
+    isKeyboardVisible && shouldUseKeyboardAvoidance(Platform.OS, Platform.Version)
+      ? keyboardHeight + (Platform.OS === "ios" ? iosKeyboardGap : 0)
+      : 0;
+  const [hasRenameOpened, setHasRenameOpened] = useState(false);
+  const onRenameOpened = useCallback(() => setHasRenameOpened(true), []);
+  const onCloseRename = useCallback(() => {
+    setHasRenameOpened(false);
+    renameDrawer.onClose();
+  }, [renameDrawer]);
   const { onClose: onCloseActionsMenuFromMenu, ...actionsMenuProps } = actionsMenu;
   const onCloseActionsMenu = useCallback(() => {
     onCloseActionsMenuFromMenu();
@@ -55,7 +63,8 @@ export function ContactDetailEditDeleteSheets({
       <QueuedBottomSheet
         isRequestingToBeOpened={renameDrawer.isOpen}
         isForcingToBeOpened={renameDrawer.isOpen}
-        onClose={renameDrawer.onClose}
+        onOpened={onRenameOpened}
+        onClose={onCloseRename}
         testID="contacts-rename-contact-sheet"
         enableDynamicSizing
       >
@@ -63,6 +72,7 @@ export function ContactDetailEditDeleteSheets({
           {...renameDrawer}
           bottomInset={bottomInset}
           keyboardInset={keyboardInset}
+          autoFocus={hasRenameOpened}
         />
       </QueuedBottomSheet>
       <QueuedBottomSheet

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/ContactsAddContactDrawerSheet.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/ContactsAddContactDrawerSheet.test.tsx
@@ -8,13 +8,18 @@ import { act, fireEvent, render, screen } from "@tests/test-renderer";
 import { ContactsAddContactDrawerSheet } from ".";
 
 const mockUseKeyboardVisible = jest.fn();
-const mockShouldUseKeyboardAvoidance = jest.fn();
 const originalPlatform = Platform.OS;
+const originalVersion = Object.getOwnPropertyDescriptor(Platform, "Version");
 
-jest.mock("~/logic/keyboardVisible", () => ({
-  useKeyboardVisible: (...args: unknown[]) => mockUseKeyboardVisible(...args),
-  shouldUseKeyboardAvoidance: (...args: unknown[]) => mockShouldUseKeyboardAvoidance(...args),
-}));
+jest.mock("~/logic/keyboardVisible", () => {
+  const actual =
+    jest.requireActual<typeof import("~/logic/keyboardVisible")>("~/logic/keyboardVisible");
+
+  return {
+    ...actual,
+    useKeyboardVisible: (...args: unknown[]) => mockUseKeyboardVisible(...args),
+  };
+});
 
 function createViewModel(
   overrides: Partial<AddContactAppAdapterResult> = {},
@@ -64,11 +69,13 @@ describe("ContactsAddContactDrawerSheet", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseKeyboardVisible.mockReturnValue({ isKeyboardVisible: false, keyboardHeight: 0 });
-    mockShouldUseKeyboardAvoidance.mockReturnValue(true);
   });
 
   afterEach(() => {
     Platform.OS = originalPlatform;
+    if (originalVersion) {
+      Object.defineProperty(Platform, "Version", originalVersion);
+    }
   });
 
   it("should render the name form with the Figma copy and character limit", () => {
@@ -173,6 +180,7 @@ describe("ContactsAddContactDrawerSheet", () => {
 
   it("should pass the shared keyboard inset without the iOS gap on Android", () => {
     Platform.OS = "android";
+    Object.defineProperty(Platform, "Version", { value: 35 });
     mockUseKeyboardVisible.mockReturnValue({ isKeyboardVisible: true, keyboardHeight: 300 });
 
     render(<ContactsAddContactDrawerSheet {...createViewModel()} />);
@@ -189,8 +197,9 @@ describe("ContactsAddContactDrawerSheet", () => {
   });
 
   it("should omit the keyboard inset when native resize handles the keyboard", () => {
+    Platform.OS = "android";
+    Object.defineProperty(Platform, "Version", { value: 34 });
     mockUseKeyboardVisible.mockReturnValue({ isKeyboardVisible: true, keyboardHeight: 300 });
-    mockShouldUseKeyboardAvoidance.mockReturnValue(false);
 
     render(<ContactsAddContactDrawerSheet {...createViewModel()} />);
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/ContactsAddContactDrawerSheet.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/ContactsAddContactDrawerSheet.test.tsx
@@ -162,12 +162,30 @@ describe("ContactsAddContactDrawerSheet", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("should pass the shared keyboard inset to the dynamic drawer", () => {
+  it("should clear the keyboard by the same gap the other contact drawers leave on iOS", () => {
+    Platform.OS = "ios";
+    mockUseKeyboardVisible.mockReturnValue({ isKeyboardVisible: true, keyboardHeight: 300 });
+
+    render(<ContactsAddContactDrawerSheet {...createViewModel()} />);
+
+    expect(screen.UNSAFE_getByType(BottomSheetView).props.style).toEqual({ paddingBottom: 356 });
+  });
+
+  it("should pass the shared keyboard inset without the iOS gap on Android", () => {
+    Platform.OS = "android";
     mockUseKeyboardVisible.mockReturnValue({ isKeyboardVisible: true, keyboardHeight: 300 });
 
     render(<ContactsAddContactDrawerSheet {...createViewModel()} />);
 
     expect(screen.UNSAFE_getByType(BottomSheetView).props.style).toEqual({ paddingBottom: 324 });
+  });
+
+  it("should reserve no keyboard room while the keyboard is hidden", () => {
+    mockUseKeyboardVisible.mockReturnValue({ isKeyboardVisible: false, keyboardHeight: 0 });
+
+    render(<ContactsAddContactDrawerSheet {...createViewModel()} />);
+
+    expect(screen.UNSAFE_getByType(BottomSheetView).props.style).toEqual({ paddingBottom: 24 });
   });
 
   it("should omit the keyboard inset when native resize handles the keyboard", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/index.tsx
@@ -4,7 +4,7 @@ import { BottomSheetHeader, BottomSheetView, Box } from "@ledgerhq/lumen-ui-rnat
 import { ContactsAddContactContent } from "@features/flow-contacts-add-contact";
 import type { AddContactAppAdapterResult } from "@features/flow-contacts";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { shouldUseKeyboardAvoidance, useKeyboardVisible } from "~/logic/keyboardVisible";
+import { resolveKeyboardBottomOffset, useKeyboardVisible } from "~/logic/keyboardVisible";
 import { QueuedBottomSheet } from "@shared/ui-queued-bottom-sheet";
 
 export function ContactsAddContactDrawerSheet({
@@ -17,11 +17,12 @@ export function ContactsAddContactDrawerSheet({
   const { isKeyboardVisible, keyboardHeight } = useKeyboardVisible({
     eventTiming: Platform.OS === "ios" ? "will" : "did",
   });
-  const iosKeyboardGap = 32;
-  const keyboardInset =
-    isKeyboardVisible && shouldUseKeyboardAvoidance(Platform.OS, Platform.Version)
-      ? keyboardHeight + (Platform.OS === "ios" ? iosKeyboardGap : 0)
-      : 0;
+  const keyboardInset = resolveKeyboardBottomOffset({
+    isKeyboardVisible,
+    keyboardHeight,
+    platform: Platform.OS,
+    version: Platform.Version,
+  });
   const [hasOpened, setHasOpened] = useState(false);
   const handleOpened = useCallback(() => setHasOpened(true), []);
   const handleClose = useCallback(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/index.tsx
@@ -14,12 +14,14 @@ export function ContactsAddContactDrawerSheet({
   ...contentProps
 }: AddContactAppAdapterResult): React.JSX.Element {
   const { bottom: bottomInset } = useSafeAreaInsets();
-  const { keyboardHeight } = useKeyboardVisible({
+  const { isKeyboardVisible, keyboardHeight } = useKeyboardVisible({
     eventTiming: Platform.OS === "ios" ? "will" : "did",
   });
-  const keyboardInset = shouldUseKeyboardAvoidance(Platform.OS, Platform.Version)
-    ? keyboardHeight
-    : 0;
+  const iosKeyboardGap = 32;
+  const keyboardInset =
+    isKeyboardVisible && shouldUseKeyboardAvoidance(Platform.OS, Platform.Version)
+      ? keyboardHeight + (Platform.OS === "ios" ? iosKeyboardGap : 0)
+      : 0;
   const [hasOpened, setHasOpened] = useState(false);
   const handleOpened = useCallback(() => setHasOpened(true), []);
   const handleClose = useCallback(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/AddNewContact/hooks/useAddNewContactViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/AddNewContact/hooks/useAddNewContactViewModel.ts
@@ -76,9 +76,10 @@ export function useAddNewContactViewModel(): AddNewContactViewModel {
   const { isKeyboardVisible, keyboardHeight } = useKeyboardVisible({
     eventTiming: Platform.OS === "ios" ? "will" : "did",
   });
+  const iosKeyboardGap = 32;
   const keyboardBottomOffset =
     isKeyboardVisible && shouldUseKeyboardAvoidance(Platform.OS, Platform.Version)
-      ? keyboardHeight
+      ? keyboardHeight + (Platform.OS === "ios" ? iosKeyboardGap : 0)
       : 0;
   const [drawerOrigin, setDrawerOrigin] = useState<AddContactDrawerOrigin | null>(null);
   const closeAfterSave = useCallback(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/AddNewContact/hooks/useAddNewContactViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/AddNewContact/hooks/useAddNewContactViewModel.ts
@@ -8,7 +8,7 @@ import {
   type SendPrefillAddAddressPhase,
 } from "LLM/features/Send/hooks/useSendPrefillAddAddressFlow";
 import { useAddToExistingContactViewModel } from "LLM/features/Send/screens/AddToExistingContact/hooks/useAddToExistingContactViewModel";
-import { shouldUseKeyboardAvoidance, useKeyboardVisible } from "~/logic/keyboardVisible";
+import { resolveKeyboardBottomOffset, useKeyboardVisible } from "~/logic/keyboardVisible";
 import { useTranslation } from "~/context/Locale";
 
 export type AddNewContactAddressPhase = SendPrefillAddAddressPhase;
@@ -76,11 +76,12 @@ export function useAddNewContactViewModel(): AddNewContactViewModel {
   const { isKeyboardVisible, keyboardHeight } = useKeyboardVisible({
     eventTiming: Platform.OS === "ios" ? "will" : "did",
   });
-  const iosKeyboardGap = 32;
-  const keyboardBottomOffset =
-    isKeyboardVisible && shouldUseKeyboardAvoidance(Platform.OS, Platform.Version)
-      ? keyboardHeight + (Platform.OS === "ios" ? iosKeyboardGap : 0)
-      : 0;
+  const keyboardBottomOffset = resolveKeyboardBottomOffset({
+    isKeyboardVisible,
+    keyboardHeight,
+    platform: Platform.OS,
+    version: Platform.Version,
+  });
   const [drawerOrigin, setDrawerOrigin] = useState<AddContactDrawerOrigin | null>(null);
   const closeAfterSave = useCallback(() => {
     setDrawerOrigin(null);

--- a/features/flow/flow-contacts-edit-contact/src/ContactsRenameContactDrawer.native.test.tsx
+++ b/features/flow/flow-contacts-edit-contact/src/ContactsRenameContactDrawer.native.test.tsx
@@ -7,6 +7,28 @@ import {
 import { ContactsRenameContactDrawer } from ".";
 import type { ContactsRenameContactDrawerProps } from "./types";
 
+const mockFocus = jest.fn();
+
+// The shared Lumen passthrough renders host elements whose refs stay null, so the focus call is
+// unobservable. Override just TextInput to expose a controllable imperative handle.
+jest.mock("@ledgerhq/lumen-ui-rnative", () => {
+  const actual = jest.requireActual<Record<string, unknown>>("@ledgerhq/lumen-ui-rnative");
+  const ReactActual = jest.requireActual<typeof import("react")>("react");
+
+  return new Proxy(actual, {
+    get(target, prop) {
+      if (prop !== "TextInput") {
+        return target[prop as string];
+      }
+
+      return ({ ref, ...props }: { ref?: React.Ref<{ focus: () => void }> }) => {
+        ReactActual.useImperativeHandle(ref, () => ({ focus: mockFocus }));
+        return ReactActual.createElement("TextInput", props);
+      };
+    },
+  });
+});
+
 function createViewModel(
   overrides: Partial<ContactsRenameContactDrawerProps> = {},
 ): ContactsRenameContactDrawerProps {
@@ -80,6 +102,16 @@ describe("ContactsRenameContactDrawer", () => {
 
     expect(onDraftNameChange).toHaveBeenCalledWith("Ada Lovelace");
     expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("should withhold focus until the host grants it", () => {
+    const { rerender } = render(<ContactsRenameContactDrawer {...createViewModel()} />);
+
+    expect(mockFocus).not.toHaveBeenCalled();
+
+    rerender(<ContactsRenameContactDrawer {...createViewModel({ autoFocus: true })} />);
+
+    expect(mockFocus).toHaveBeenCalledTimes(1);
   });
 
   it("should not render its content while closed", () => {

--- a/features/flow/flow-contacts-edit-contact/src/ContactsRenameContactDrawer.native.tsx
+++ b/features/flow/flow-contacts-edit-contact/src/ContactsRenameContactDrawer.native.tsx
@@ -18,6 +18,7 @@ export function ContactsRenameContactDrawer({
   invalidNameError,
   bottomInset = 0,
   keyboardInset = 0,
+  autoFocus = false,
   labels,
   onDraftNameChange,
   onConfirm,
@@ -39,6 +40,7 @@ export function ContactsRenameContactDrawer({
               value={draftName}
               placeholder={labels.namePlaceholder}
               errorMessage={nameValidationError}
+              autoFocus={autoFocus}
               onChangeText={onDraftNameChange}
             />
             <Banner appearance="info" description={labels.namingDisclaimer} />

--- a/features/flow/flow-contacts-edit-contact/src/types.ts
+++ b/features/flow/flow-contacts-edit-contact/src/types.ts
@@ -46,5 +46,7 @@ export type ContactsRenameContactDrawerProps = RenameContactDialogViewModel &
   Readonly<{
     bottomInset?: number;
     keyboardInset?: number;
+    /** Set once the hosting drawer has settled, so the keyboard does not interrupt it opening. */
+    autoFocus?: boolean;
     labels: ContactsRenameContactLabels;
   }>;

--- a/features/platform/contacts/src/components/ContactNameInput/ContactNameInput.native.test.tsx
+++ b/features/platform/contacts/src/components/ContactNameInput/ContactNameInput.native.test.tsx
@@ -37,10 +37,10 @@ describe("ContactNameInput", () => {
     expect(screen.getByText("3/32")).toBeVisible();
   });
 
-  it("should focus on mount by default", () => {
+  it("should leave the field unfocused unless a host asks for focus", () => {
     render(<ContactNameInput value="" placeholder="Contact name" onChangeText={jest.fn()} />);
 
-    expect(mockFocus).toHaveBeenCalledTimes(1);
+    expect(mockFocus).not.toHaveBeenCalled();
   });
 
   it("should stay unfocused while the host withholds focus, then focus once it is granted", () => {

--- a/features/platform/contacts/src/components/ContactNameInput/ContactNameInput.native.tsx
+++ b/features/platform/contacts/src/components/ContactNameInput/ContactNameInput.native.tsx
@@ -10,9 +10,9 @@ type ContactNameInputProps = Readonly<{
   errorMessage?: string;
   isEditable?: boolean;
   /**
-   * Focuses the field whenever this turns true, rather than only on mount. Hosts inside an
-   * animating drawer can keep it false until the drawer has settled, so the keyboard does not
-   * resize the drawer while it is still opening.
+   * Focuses the field whenever this turns true, rather than only on mount. Defaults to off so a
+   * host inside an animating drawer never raises the keyboard by accident: it opts in once the
+   * drawer has settled, instead of the keyboard fighting the drawer's opening animation.
    */
   autoFocus?: boolean;
   /** Namespaces the test ids, so each host drawer identifies its own input. */
@@ -25,7 +25,7 @@ export function ContactNameInput({
   placeholder,
   errorMessage,
   isEditable = true,
-  autoFocus = true,
+  autoFocus = false,
   testIDPrefix = "contacts-add-contact",
   onChangeText,
 }: ContactNameInputProps): React.JSX.Element {


### PR DESCRIPTION
### 📝 Description

The Mobile edit contact drawer raised and dismissed the keyboard on its own, with no user input.

**Previous behaviour.** `ContactNameInput` defaulted `autoFocus` to `true`, and `ContactsRenameContactDrawer` never passed the prop, so the field focused the moment it mounted. That threw the keyboard at a bottom sheet still animating open, and the two animations fought: the keyboard appeared and then disappeared again. The add contact drawer avoided this only because it happened to pass `autoFocus` explicitly, deferring focus until the sheet had settled.

**Fix.** `autoFocus` now defaults to `false`, so focusing inside an animating drawer is something a host opts into rather than something it gets by accident. The edit contact drawer opts in from its host's `onOpened`, the same way the add contact drawer already did, so the sheet settles first and the keyboard then rises against a stationary drawer.

Separately, the add contact, edit contact and Send add new contact drawers padded themselves by the raw keyboard height, leaving their inputs flush against the keyboard, while the add address and edit address drawers already left a 32pt gap on iOS. All five now compute the same clearance.

**Regression cover.**
- `ContactNameInput.native.test.tsx` asserts the field stays unfocused unless a host asks for focus.
- `ContactsRenameContactDrawer.native.test.tsx` asserts the drawer withholds focus until the host grants it, which is the forwarding step that was missing here.
- `ContactsAddContactDrawerSheet.test.tsx` pins the iOS clearance, the Android clearance without the iOS gap, and that no room is reserved while the keyboard is hidden.


https://github.com/user-attachments/assets/f51438c8-6e29-4faa-b678-bfb531320963



### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35861](https://ledgerhq.atlassian.net/browse/LIVE-35861)
- **ADR** (if any): n/a

[LIVE-35861]: https://ledgerhq.atlassian.net/browse/LIVE-35861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ