### PR TITLE
[LWM] fix(contacts): add address drawer close button (LIVE-35863)

### DIFF
--- a/.changeset/closeable-contacts-addresses.md
+++ b/.changeset/closeable-contacts-addresses.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add explicit close controls to Contacts address entry forms on mobile.

--- a/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawerFlow/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/QueuedDrawerFlow/types.ts
@@ -12,6 +12,7 @@ export type QueuedDrawerFlowOptions = Readonly<
     | "hideHandle"
     | "maxDynamicContentSize"
     | "noCloseButton"
+    | "onHeaderClosePressed"
     | "preventBackdropClick"
     | "snapPoints"
   >

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -823,6 +823,45 @@ describe("Contacts integration", () => {
     });
   });
 
+  it.each(["address", "name"] as const)("should close Add Address from the %s step", async step => {
+    const contact = mockContact({ id: "contact-benoit", name: "Benoit" });
+    const { user } = render(<ContactDetailAddressEntryTestApp />, {
+      navigationInitialState: savedContactDetailNavigationState,
+      overrideInitialState: withContactsPageReadyState(evmOnlyContactsFeatureFlag, state => ({
+        ...state,
+        contacts: { contacts: [mockMeContact(), contact] },
+      })),
+    });
+
+    await user.press(screen.getByTestId("contacts-detail-add-address"));
+    await user.press(screen.getByTestId("contacts-address-entry-select-currency"));
+
+    const addressInput = await screen.findByTestId("contacts-add-address-input");
+
+    if (step === "name") {
+      await user.type(addressInput, SCANNED_ADDRESS);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("contacts-add-address-confirm")).toBeEnabled();
+      });
+
+      await user.press(screen.getByTestId("contacts-add-address-confirm"));
+      expect(await screen.findByTestId("contacts-add-address-name-input")).toBeVisible();
+    } else {
+      expect(addressInput).toBeVisible();
+    }
+
+    const closeButton = screen.getByTestId("bottom-sheet-header-close-button");
+    expect(closeButton).toBeVisible();
+
+    await user.press(closeButton);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("contacts-add-address-flow-drawer")).toBeNull();
+      expect(screen.getByTestId("contacts-detail-screen")).toBeVisible();
+    });
+  });
+
   it("should keep the currency selector usable when searching for a network", async () => {
     const { user } = render(<ContactDetailAddressEntryTestApp />, {
       navigationInitialState: contactDetailNavigationState,

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/ContactsAddAddressFlowContentView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/ContactsAddAddressFlowContentView.tsx
@@ -13,9 +13,8 @@ const FLOW_OPTIONS = {
   snapPoints: [FLOW_SNAP_POINT],
 } as const satisfies QueuedDrawerFlowOptions;
 
-const LOCKED_STEP_OPTIONS = {
+const FORM_STEP_OPTIONS = {
   hasBackButton: true,
-  noCloseButton: true,
   hideHandle: true,
   preventBackdropClick: true,
   enablePanDownToClose: false,
@@ -29,6 +28,7 @@ export function ContactsAddAddressFlowContentView({
   isOpen,
   onBack,
   onClose,
+  onHeaderClosePressed,
 }: ContactsAddAddressFlowContentViewModel): React.JSX.Element {
   const flowContentProps = { addressEntryProps, addressNameProps };
   const screens: QueuedDrawerFlowScreenRegistry<ContactsAddAddressDrawerStep> = {
@@ -41,11 +41,11 @@ export function ContactsAddAddressFlowContentView({
     },
     address: {
       content: <ContactsAddAddressFlowContent {...flowContentProps} step="address" />,
-      options: LOCKED_STEP_OPTIONS,
+      options: { ...FORM_STEP_OPTIONS, onHeaderClosePressed },
     },
     name: {
       content: <ContactsAddAddressFlowContent {...flowContentProps} step="name" />,
-      options: LOCKED_STEP_OPTIONS,
+      options: { ...FORM_STEP_OPTIONS, onHeaderClosePressed },
     },
   };
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowContentViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowContentViewModel.ts
@@ -13,7 +13,7 @@ export function useContactsAddAddressFlowContentViewModel({
   viewModel,
   currencyShell,
 }: UseContactsAddAddressFlowContentViewModelOptions) {
-  const { currentStep, onBack: onFlowBack } = viewModel;
+  const { currentStep, onBack: onFlowBack, onFlowClose } = viewModel;
   const {
     hasBackButton: hasCurrencyBackButton,
     onBack: onCurrencyBack,
@@ -34,6 +34,12 @@ export function useContactsAddAddressFlowContentViewModel({
     }
   }, [currentStep, onCurrencyClose]);
 
+  const handleHeaderClosePressed = useCallback(() => {
+    if (currentStep === "currency") return;
+
+    onFlowClose();
+  }, [currentStep, onFlowClose]);
+
   useFocusEffect(
     useCallback(() => {
       if (Platform.OS !== "android") return;
@@ -52,6 +58,7 @@ export function useContactsAddAddressFlowContentViewModel({
     currencyShell,
     onBack: handleBack,
     onClose: handleClose,
+    onHeaderClosePressed: handleHeaderClosePressed,
   } as const;
 }
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowDrawerViewModel.ts
@@ -119,6 +119,7 @@ export function useContactsAddAddressFlowDrawerViewModel({
     currentStep: resolveDrawerStep(state.status),
     isOpen: state.status !== "closed" && state.status !== "success",
     onBack,
+    onFlowClose: onClose,
   } as const;
 }
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** The Mobile Contacts integration suite covers closing the drawer from both address-entry and address-name steps.
- [x] **Impact of the changes:**
      Explicit close controls are available in Contacts Add Address forms on mobile, while backdrop and gesture dismissal remain disabled.

### 📝 Description

The Contacts Add Address drawer did not offer an explicit way to leave the address-entry form, and attempting to pull it down produced an inconsistent experience.

This fix exposes the standard Lumen header close control on the address and address-name steps. It closes the Contacts flow only after an intentional header action, preserving the in-progress flow when navigating to scan a QR code.


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-35863

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
