### PR TITLE
[LWM] fix(LIVE-36333): remove quotes list nav title

### DIFF
--- a/.changeset/LIVE-36333-swap-remove-quotes-list-native-title.md
+++ b/.changeset/LIVE-36333-swap-remove-quotes-list-native-title.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Remove native navbar title on Select Quote page in Swap wallet40 header

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/navigationHandlers/wallet40/__tests__/parseSwapWallet40Route.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/navigationHandlers/wallet40/__tests__/parseSwapWallet40Route.test.ts
@@ -14,7 +14,7 @@ describe("parseSwapWallet40Route", () => {
     expect(parseSwapWallet40Route("https://swap.live.app/?tab=QUOTES_LIST")).toEqual({
       routeName: "quotesList",
       headerStyle: "opaque",
-      titleKey: "transfer.swap2.quotesList.title",
+      titleKey: null,
       isTransactionComplete: false,
     });
   });

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/navigationHandlers/wallet40/parseSwapWallet40Route.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/navigationHandlers/wallet40/parseSwapWallet40Route.ts
@@ -59,7 +59,7 @@ export function parseSwapWallet40Route(url: string): SwapWallet40ParsedRoute {
         return {
           routeName: "quotesList",
           headerStyle: "opaque",
-          titleKey: "transfer.swap2.quotesList.title",
+          titleKey: null,
           isTransactionComplete: false,
         };
       }

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/navigationHandlers/wallet40/parseSwapWallet40Route.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/navigationHandlers/wallet40/parseSwapWallet40Route.ts
@@ -32,7 +32,7 @@ function normalizePathname(pathname: string): string {
  *   maps to the completed two-step title key.
  *
  * Header mapping:
- * - `/` + `tab=QUOTES_LIST` -> `quotesList`, opaque header, quotes title
+ * - `/` + `tab=QUOTES_LIST` -> `quotesList`, opaque header, no title (title rendered inside the live app)
  * - `/` (any other tab/missing tab) -> `home`, transparent header, no title
  * - `/multi-step-transaction` -> `multiStepTransaction`, opaque header, two-step title
  * - `/dev-settings` -> `devSettings`, opaque header, Dev Settings title
@@ -40,7 +40,7 @@ function normalizePathname(pathname: string): string {
  *
  * Examples:
  * - `https://swap.live.app/?tab=QUOTES_LIST`
- *   -> `{ routeName: "quotesList", headerStyle: "opaque", titleKey: "transfer.swap2.quotesList.title" }`
+ *   -> `{ routeName: "quotesList", headerStyle: "opaque", titleKey: null }`
  * - `https://swap.live.app/multi-step-transaction?transactionStatus=complete`
  *   -> `{ routeName: "multiStepTransaction", headerStyle: "opaque", titleKey: "transfer.swap2.twoStepApproval.completedTitle" }`
  * - `https://swap.live.app/anything-else`


### PR DESCRIPTION
### 📝 Description

Removes the "Select quote" title from the native navbar on the quotes list page in the Swap wallet40 flow. The title is now rendered inside the swap live app (webview) itself, so the native navbar title would cause a duplicate. This change takes effect from 4.18.0 — users on older versions retain the existing behaviour.

Regression covered by the updated unit test in `parseSwapWallet40Route.test.ts`.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36333]
- **ADR** (if any): —


[LIVE-36333]: https://ledgerhq.atlassian.net/browse/LIVE-36333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ