### PR TITLE
[LWDM] feat(concordium): add PLT CBOR encoding (LIVE-28330)

### DIFF
--- a/.changeset/concordium-core-plt-cbor.md
+++ b/.changeset/concordium-core-plt-cbor.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/concordium-core": minor
+"@ledgerhq/coin-concordium": patch
+---
+
+Add Protocol-Level Token (PLT) support: TransactionType.TokenUpdate, CIS-7 CBOR encoding, and flat wire serialization

--- a/libs/coin-modules/coin-concordium/src/logic/transaction/craftRawTransaction.test.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/transaction/craftRawTransaction.test.ts
@@ -1,5 +1,6 @@
 import {
   TransactionType,
+  type Transaction,
   AccountAddress,
   deserializeTransaction,
   serializeTransfer,
@@ -16,7 +17,7 @@ const PUBLIC_KEY = "aa".repeat(32);
 
 // Helper to create a valid serialized Transfer transaction
 function createSerializedTransfer(sender: string, nonce: bigint): string {
-  const tx = {
+  const tx: Transaction = {
     type: TransactionType.Transfer,
     header: {
       sender: AccountAddress.fromBase58(sender),
@@ -35,7 +36,7 @@ function createSerializedTransfer(sender: string, nonce: bigint): string {
 
 // Helper to create a valid serialized TransferWithMemo transaction
 function createSerializedTransferWithMemo(sender: string, nonce: bigint): string {
-  const tx = {
+  const tx: Transaction = {
     type: TransactionType.TransferWithMemo,
     header: {
       sender: AccountAddress.fromBase58(sender),

--- a/libs/concordium-core/README.md
+++ b/libs/concordium-core/README.md
@@ -18,11 +18,15 @@ live-signer-concordium ←── @ledgerhq/concordium-core ──→ coin-concor
 ### Types (`src/types.ts`)
 
 - `SchemeId` — Ed25519 cryptographic scheme identifier
-- `TransactionType` — Transaction type discriminators (Transfer, TransferWithMemo)
-- `Transaction` — Transaction structure for signing
+- `TransactionType` — Transaction type discriminators (Transfer, TransferWithMemo, TokenUpdate)
+- `Transaction` — CCD transaction structure for signing
+- `TransactionHeader` — Account transaction header, common to every type
 - `TransferPayload` — Simple transfer payload
 - `TransferWithMemoPayload` — Transfer with memo payload
-- `TransactionPayload` — Union of transfer payload types
+- `TransactionPayload` — Union of CCD transfer payload types
+- `TokenUpdatePayload` — PLT payload: token id plus a CBOR operations blob
+- `TokenUpdateTransaction` — PLT transaction structure for signing
+- `AnyTransaction` — `Transaction | TokenUpdateTransaction`
 - `CredentialDeploymentTransaction` — Credential deployment in device format
 - `IdOwnershipProofs` — ID ownership proofs from Concordium ID App
 - `Address` — Address response from device
@@ -42,7 +46,34 @@ live-signer-concordium ←── @ledgerhq/concordium-core ──→ coin-concor
 - `memoEncodedSize(memo: string): number` — CBOR-encoded byte length without allocating (useful for size checks before encoding)
 - `decodeMemoFromCbor(cborEncoded: Buffer): string` — Decode CBOR-encoded memo
 - `MAX_MEMO_LENGTH` — Maximum memo length before CBOR encoding (254 bytes)
-- `MAX_CBOR_SIZE` — Maximum CBOR-encoded memo size (256 bytes)
+- `MAX_CBOR_SIZE` — Maximum CBOR-encoded CCD memo size (256 bytes)
+- `PLT_CBOR_MAX_SIZE` — Maximum PLT operations blob (512 bytes)
+- `PLT_TOKEN_ID_MIN_LENGTH` / `PLT_TOKEN_ID_MAX_LENGTH` — Token id bounds (1..128 bytes)
+
+Generic CBOR primitives, added for PLT payloads. Each emits the shortest head, so
+output is deterministic:
+
+- `encodeCborUnsigned` / `encodeCborNegative` / `encodeCborInteger`
+- `encodeCborByteString` / `encodeCborTextString`
+- `encodeCborArray` / `encodeCborMap`
+- `encodeCborMapDeterministic` — map with keys in bytewise order of their encoding, matching the chain's own encoder
+- `encodeCborTag`
+
+### PLT (`src/plt.ts`)
+
+CIS-7 Protocol-Level Token payload encoding. Output must satisfy both the chain,
+which defines the canonical wire format, and the Ledger device, which is stricter
+in places; the tighter bound wins.
+
+- `PltTransfer` — A PLT transfer in wallet terms: recipient, amount, decimals, optional memo
+- `encodePltTransferOperations(transfer): Buffer` — The CBOR operations blob, `array(1) [ map(1) { "transfer": … } ]`
+- `encodePltAmount(amount, decimals): Buffer` — `tag 4([-decimals, amount])`
+- `encodePltAddress(address, includeCoinInfo?): Buffer` — `tag 40307({? 1: tag 40305({1: 919}), 3: bstr(32)})`
+- `encodePltMemo(memo, tagged?): Buffer` — Bare byte string, or wrapped in tag 24
+
+> [!IMPORTANT]
+> A PLT memo is **bytes**, not text. Do not use `encodeMemoToCbor`, which is the
+> CCD memo helper and emits a CBOR text string.
 
 ### Utils (`src/utils.ts`)
 
@@ -57,7 +88,21 @@ live-signer-concordium ←── @ledgerhq/concordium-core ──→ coin-concor
 
 - `serializeTransfer(tx): Buffer` — Serialize a Transfer transaction
 - `serializeTransferWithMemo(tx): Buffer` — Serialize a TransferWithMemo transaction
+- `serializeTokenUpdate(tx): Buffer` — Serialize a TokenUpdate (PLT) transaction
+- `deserializeTokenUpdate(buffer): TokenUpdateTransaction` — Decode a TokenUpdate transaction; `operations` stays CBOR-encoded
+- `isTokenUpdateTransaction(tx): boolean` — Type guard narrowing `AnyTransaction` to the PLT shape
 - `serializeTransaction(tx): Buffer` — Serialize any supported transaction type
+
+The TokenUpdate wire layout is the flat transaction the chain accepts and the
+device hashes; the signer re-splits it into APDU frames:
+
+```
+[header:60][type:1 = 0x1B][token_id_length:1][token_id:N][cbor_length:4 BE][cbor:M]
+```
+
+`deserializeTransaction` handles CCD types only. Production never decodes a PLT
+payload — history comes from the wallet proxy as JSON — so it directs PLT callers
+to `deserializeTokenUpdate`.
 - `deserializeTransfer(buffer): Transaction` — Deserialize Transfer from buffer
 - `deserializeTransferWithMemo(buffer): Transaction` — Deserialize TransferWithMemo from buffer
 - `deserializeTransaction(buffer): Transaction` — Deserialize any transaction by auto-detecting type

--- a/libs/concordium-core/src/cbor.test.ts
+++ b/libs/concordium-core/src/cbor.test.ts
@@ -1,4 +1,17 @@
-import { encodeMemoToCbor, decodeMemoFromCbor, memoEncodedSize } from "./cbor";
+import {
+  decodeMemoFromCbor,
+  encodeCborArray,
+  encodeCborByteString,
+  encodeCborInteger,
+  encodeCborMap,
+  encodeCborMapDeterministic,
+  encodeCborNegative,
+  encodeCborTag,
+  encodeCborTextString,
+  encodeCborUnsigned,
+  encodeMemoToCbor,
+  memoEncodedSize,
+} from "./cbor";
 
 describe("CBOR memo encoding/decoding", () => {
   describe("encodeMemoToCbor", () => {
@@ -232,5 +245,187 @@ describe("CBOR memo encoding/decoding", () => {
         expect(decoded).toBe(memo);
       }
     });
+  });
+});
+
+describe("cbor primitives", () => {
+  describe("encodeCborUnsigned", () => {
+    // Boundaries between the five head forms. A regression here shifts every
+    // downstream byte, so pin each transition explicitly.
+    it.each([
+      [0n, "00"],
+      [23n, "17"],
+      [24n, "1818"],
+      [255n, "18ff"],
+      [256n, "190100"],
+      [65535n, "19ffff"],
+      [65536n, "1a00010000"],
+      [4294967295n, "1affffffff"],
+      [4294967296n, "1b0000000100000000"],
+      [18446744073709551615n, "1bffffffffffffffff"],
+    ])("encodes %s using the shortest head", (value, expected) => {
+      expect(encodeCborUnsigned(value).toString("hex")).toBe(expected);
+    });
+
+    it("rejects a value beyond 64 bits", () => {
+      expect(() => encodeCborUnsigned(2n ** 64n)).toThrow(/exceeds 64 bits/);
+    });
+
+    it("rejects a negative value", () => {
+      expect(() => encodeCborUnsigned(-1n)).toThrow(/non-negative/);
+    });
+  });
+
+  describe("encodeCborNegative", () => {
+    it.each([
+      [-1n, "20"],
+      [-24n, "37"],
+      [-25n, "3818"],
+      [-256n, "38ff"],
+      [-257n, "390100"],
+    ])("encodes %s as -1 - n", (value, expected) => {
+      expect(encodeCborNegative(value).toString("hex")).toBe(expected);
+    });
+
+    it("rejects a non-negative value", () => {
+      expect(() => encodeCborNegative(0n)).toThrow(/negative integer/);
+    });
+  });
+
+  describe("encodeCborInteger", () => {
+    it("picks major type 0 for zero and above", () => {
+      expect(encodeCborInteger(0).toString("hex")).toBe("00");
+    });
+
+    it("picks major type 1 below zero", () => {
+      expect(encodeCborInteger(-6).toString("hex")).toBe("25");
+    });
+  });
+
+  describe("encodeCborByteString and encodeCborTextString", () => {
+    it("encodes a byte string with a major type 2 head", () => {
+      expect(encodeCborByteString(Buffer.from([1, 2, 3])).toString("hex")).toBe("43010203");
+    });
+
+    it("encodes an empty byte string", () => {
+      expect(encodeCborByteString(Buffer.alloc(0)).toString("hex")).toBe("40");
+    });
+
+    it("encodes a text string with a major type 3 head", () => {
+      expect(encodeCborTextString("amount").toString("hex")).toBe("66616d6f756e74");
+    });
+
+    it("measures text length in UTF-8 bytes, not code points", () => {
+      expect(encodeCborTextString("é").toString("hex")).toBe("62c3a9");
+    });
+  });
+
+  describe("encodeCborArray and encodeCborMap", () => {
+    it("encodes an array with its item count", () => {
+      expect(encodeCborArray([encodeCborUnsigned(1), encodeCborUnsigned(2)]).toString("hex")).toBe(
+        "820102",
+      );
+    });
+
+    it("encodes an empty array", () => {
+      expect(encodeCborArray([]).toString("hex")).toBe("80");
+    });
+
+    it("encodes a map with its entry count and preserves the given order", () => {
+      const encoded = encodeCborMap([
+        [encodeCborUnsigned(3), encodeCborUnsigned(4)],
+        [encodeCborUnsigned(1), encodeCborUnsigned(2)],
+      ]);
+
+      expect(encoded.toString("hex")).toBe("a203040102");
+    });
+  });
+
+  describe("encodeCborTag", () => {
+    // Tag 24 needs the 1-byte argument form: 0xd8 0x18, not a bare 0xd8.
+    it("encodes tag 24 with a one-byte argument", () => {
+      expect(encodeCborTag(24, encodeCborByteString(Buffer.from([0xff]))).toString("hex")).toBe(
+        "d81841ff",
+      );
+    });
+
+    it("encodes a tag below 24 in a single byte", () => {
+      expect(encodeCborTag(4, encodeCborArray([])).toString("hex")).toBe("c480");
+    });
+
+    it("encodes a two-byte tag number", () => {
+      expect(encodeCborTag(40307, encodeCborUnsigned(0)).toString("hex")).toBe("d99d7300");
+    });
+  });
+
+  describe("encodeCborMapDeterministic", () => {
+    // Bytewise on the encoded key. For text keys the length sits in the head
+    // byte, so shorter keys sort first regardless of their content.
+    it("sorts integer keys ascending", () => {
+      const encoded = encodeCborMapDeterministic([
+        [encodeCborUnsigned(3), encodeCborUnsigned(30)],
+        [encodeCborUnsigned(1), encodeCborUnsigned(10)],
+      ]);
+
+      expect(encoded.toString("hex")).toBe("a2010a03181e");
+    });
+
+    it("sorts text keys by encoded bytes, so shorter keys come first", () => {
+      const encoded = encodeCborMapDeterministic([
+        [encodeCborTextString("recipient"), encodeCborUnsigned(3)],
+        [encodeCborTextString("amount"), encodeCborUnsigned(1)],
+        [encodeCborTextString("memo"), encodeCborUnsigned(2)],
+      ]);
+
+      const hex = encoded.toString("hex");
+      expect(hex.indexOf("646d656d6f")).toBeLessThan(hex.indexOf("66616d6f756e74"));
+      expect(hex.indexOf("66616d6f756e74")).toBeLessThan(hex.indexOf("69726563697069656e74"));
+    });
+
+    it("does not mutate the caller's entry array", () => {
+      const entries: [Buffer, Buffer][] = [
+        [encodeCborUnsigned(3), encodeCborUnsigned(30)],
+        [encodeCborUnsigned(1), encodeCborUnsigned(10)],
+      ];
+
+      encodeCborMapDeterministic(entries);
+
+      expect(entries[0][0].toString("hex")).toBe("03");
+    });
+
+    it("rejects a duplicate key", () => {
+      expect(() =>
+        encodeCborMapDeterministic([
+          [encodeCborUnsigned(1), encodeCborUnsigned(10)],
+          [encodeCborUnsigned(1), encodeCborUnsigned(20)],
+        ]),
+      ).toThrow(/duplicate key/);
+    });
+  });
+});
+
+describe("cbor integer safety", () => {
+  // A literal past 2^53 is already rounded before it reaches the encoder, so
+  // encoding it would silently emit a different number.
+  it("rejects an unsafe number for an unsigned integer", () => {
+    expect(() => encodeCborUnsigned(9007199254740993)).toThrow(/safe JavaScript integer/);
+  });
+
+  it("rejects an unsafe number for a negative integer", () => {
+    expect(() => encodeCborNegative(-9007199254740993)).toThrow(/safe JavaScript integer/);
+  });
+
+  // Number.MAX_SAFE_INTEGER is 2^53 - 1, so 2^53 itself is already unsafe.
+  it("accepts the largest safe number and rejects the next one", () => {
+    expect(() => encodeCborInteger(Number.MAX_SAFE_INTEGER)).not.toThrow();
+    expect(() => encodeCborInteger(2 ** 53)).toThrow(/safe JavaScript integer/);
+  });
+
+  it("rejects an unsafe number as a tag", () => {
+    expect(() => encodeCborTag(2 ** 53, encodeCborUnsigned(0))).toThrow(/safe JavaScript integer/);
+  });
+
+  it("still accepts the full 64-bit range as a bigint", () => {
+    expect(encodeCborUnsigned(2n ** 64n - 1n).toString("hex")).toBe("1bffffffffffffffff");
   });
 });

--- a/libs/concordium-core/src/cbor.ts
+++ b/libs/concordium-core/src/cbor.ts
@@ -1,11 +1,15 @@
 /**
- * CBOR encoding/decoding utilities for Concordium memos.
+ * CBOR encoding/decoding utilities.
  *
- * Concordium memos must be CBOR-encoded text strings before transmission to the device.
- * The device firmware expects CBOR and decodes it for display during signing.
+ * Two groups, in order:
  *
- * This is a minimal CBOR implementation supporting only text strings (major type 3),
- * which is all that's needed for Concordium memos.
+ * - The CCD memo helpers. A memo is a CBOR text string, and the device decodes
+ *   it for display during signing.
+ * - Generic CBOR primitives (RFC 8949), added for Protocol-Level Token payloads,
+ *   which are structured CBOR rather than a single text string.
+ *
+ * This is a hand-rolled encoder covering only what those two flows need, not a
+ * general-purpose CBOR library. It has no decoder beyond the memo one.
  * @private
  */
 
@@ -19,8 +23,8 @@ const CBOR_TEXT_STRING_1BYTE = 0x78;
 const CBOR_TEXT_STRING_2BYTE = 0x79;
 
 /**
- * Maximum memo length in bytes (UTF-8 encoded) before CBOR encoding.
- * The device firmware enforces a 256-byte limit on CBOR-encoded data.
+ * Maximum CCD memo length in bytes (UTF-8 encoded) before CBOR encoding.
+ * The device firmware enforces a 256-byte limit on an encoded CCD memo.
  * CBOR text string encoding adds 2 bytes overhead for lengths 24-254,
  * so the maximum UTF-8 text is 254 bytes.
  */
@@ -28,9 +32,28 @@ export const MAX_MEMO_LENGTH = 254;
 
 /**
  * Maximum CBOR-encoded memo size (including CBOR overhead).
- * This is the device firmware limit.
+ *
+ * This is the CCD memo limit (`MAX_CBOR_BLOB_SIZE` in the device app), not a
+ * global CBOR limit. PLT payloads have their own, larger budget — see
+ * {@link PLT_CBOR_MAX_SIZE}.
  */
 export const MAX_CBOR_SIZE = 256;
+
+/**
+ * Maximum PLT CBOR operations blob the device will buffer.
+ *
+ * Mirrors `APP_PLT_CBOR_MAX` in the device app. Distinct from
+ * {@link MAX_CBOR_SIZE}, which is the CCD memo limit.
+ */
+export const PLT_CBOR_MAX_SIZE = 512;
+
+/**
+ * Inclusive bounds on a PLT token id, in bytes.
+ *
+ * Mirrors `PLT_TOKEN_ID_MAX` in the device app and CIS-7 §3.
+ */
+export const PLT_TOKEN_ID_MIN_LENGTH = 1;
+export const PLT_TOKEN_ID_MAX_LENGTH = 128;
 
 /**
  * Encodes a memo string to CBOR text string format.
@@ -150,4 +173,186 @@ export function decodeMemoFromCbor(cborEncoded: Buffer): string {
   // Extract and decode the text data
   const textData = cborEncoded.subarray(dataStart, dataStart + length);
   return textData.toString("utf-8");
+}
+
+/*
+ * Generic CBOR primitives (RFC 8949).
+ *
+ * Added for Protocol-Level Token (PLT) payloads, which are structured CBOR
+ * rather than the single text string a CCD memo needs. Every encoder below
+ * emits the shortest possible head. Neither the device nor the chain requires
+ * that on decode, but it is what makes our output reproducible and
+ * byte-comparable against the chain's own deterministic encoder.
+ */
+
+/**
+ * CBOR major types, pre-shifted into the head byte's high three bits: each
+ * value is `majorType << 5`.
+ * @private
+ */
+const CborMajor = {
+  Unsigned: 0x00,
+  Negative: 0x20,
+  ByteString: 0x40,
+  TextString: 0x60,
+  Array: 0x80,
+  Map: 0xa0,
+  Tag: 0xc0,
+} as const;
+
+/** @private */
+type CborMajor = (typeof CborMajor)[keyof typeof CborMajor];
+
+/**
+ * Encodes a CBOR head: the major type plus an argument, using the shortest
+ * form that fits.
+ * @private
+ */
+function encodeCborHead(major: CborMajor, argument: bigint): Buffer {
+  if (argument < 0n) {
+    throw new Error(`CBOR argument must be non-negative, got ${argument}`);
+  }
+
+  if (argument < 24n) {
+    return Buffer.from([major | Number(argument)]);
+  }
+  if (argument <= 0xffn) {
+    return Buffer.from([major | 24, Number(argument)]);
+  }
+  if (argument <= 0xffffn) {
+    const buf = Buffer.alloc(3);
+    buf.writeUInt8(major | 25, 0);
+    buf.writeUInt16BE(Number(argument), 1);
+    return buf;
+  }
+  if (argument <= 0xffffffffn) {
+    const buf = Buffer.alloc(5);
+    buf.writeUInt8(major | 26, 0);
+    buf.writeUInt32BE(Number(argument), 1);
+    return buf;
+  }
+  if (argument <= 0xffffffffffffffffn) {
+    const buf = Buffer.alloc(9);
+    buf.writeUInt8(major | 27, 0);
+    buf.writeBigUInt64BE(argument, 1);
+    return buf;
+  }
+
+  throw new Error(`CBOR argument exceeds 64 bits: ${argument}`);
+}
+
+/**
+ * Rejects a `number` that cannot represent the caller's intent exactly.
+ *
+ * A literal beyond 2^53 is already rounded by the time it reaches here, so
+ * encoding it would silently emit a different value. Callers needing the full
+ * 64-bit range must pass a `bigint`.
+ * @private
+ */
+function toExactBigInt(value: bigint | number): bigint {
+  if (typeof value === "number" && !Number.isSafeInteger(value)) {
+    throw new TypeError(`CBOR integer ${value} is not a safe JavaScript integer; pass a bigint`);
+  }
+  return BigInt(value);
+}
+
+/**
+ * Encodes an unsigned integer (major type 0).
+ *
+ * @param value Non-negative integer, up to 2^64 - 1. Values above 2^53 must be `bigint`.
+ */
+export function encodeCborUnsigned(value: bigint | number): Buffer {
+  return encodeCborHead(CborMajor.Unsigned, toExactBigInt(value));
+}
+
+/**
+ * Encodes a negative integer (major type 1).
+ *
+ * CBOR stores -1 - n, so -1 encodes as argument 0.
+ *
+ * @param value Negative integer, down to -2^64
+ */
+export function encodeCborNegative(value: bigint | number): Buffer {
+  const asBigInt = toExactBigInt(value);
+  if (asBigInt >= 0n) {
+    throw new Error(`Expected a negative integer, got ${asBigInt}`);
+  }
+  return encodeCborHead(CborMajor.Negative, -asBigInt - 1n);
+}
+
+/**
+ * Encodes an integer of either sign, picking major type 0 or 1.
+ */
+export function encodeCborInteger(value: bigint | number): Buffer {
+  const asBigInt = toExactBigInt(value);
+  return asBigInt < 0n ? encodeCborNegative(asBigInt) : encodeCborUnsigned(asBigInt);
+}
+
+/**
+ * Encodes a byte string (major type 2).
+ */
+export function encodeCborByteString(value: Buffer): Buffer {
+  return Buffer.concat([encodeCborHead(CborMajor.ByteString, BigInt(value.length)), value]);
+}
+
+/**
+ * Encodes a UTF-8 text string (major type 3).
+ *
+ * Distinct from {@link encodeMemoToCbor}, which is the CCD memo helper and
+ * carries that flow's length limit.
+ */
+export function encodeCborTextString(value: string): Buffer {
+  const bytes = Buffer.from(value, "utf-8");
+  return Buffer.concat([encodeCborHead(CborMajor.TextString, BigInt(bytes.length)), bytes]);
+}
+
+/**
+ * Encodes a definite-length array (major type 4) from already-encoded items.
+ */
+export function encodeCborArray(items: Buffer[]): Buffer {
+  return Buffer.concat([encodeCborHead(CborMajor.Array, BigInt(items.length)), ...items]);
+}
+
+/**
+ * Encodes a definite-length map (major type 5) from already-encoded entries.
+ *
+ * Entries are emitted in the order given. Callers that need deterministic
+ * output must pass them already ordered; this function does not sort, because
+ * CIS-7 maps are keyed on both integers and strings and the callers know their
+ * own canonical order.
+ */
+export function encodeCborMap(entries: [Buffer, Buffer][]): Buffer {
+  const flattened = entries.flatMap(([key, value]) => [key, value]);
+  return Buffer.concat([encodeCborHead(CborMajor.Map, BigInt(entries.length)), ...flattened]);
+}
+
+/**
+ * Wraps an already-encoded value in a semantic tag (major type 6).
+ *
+ * @param tag Tag number, up to 2^64 - 1. Values above 2^53 must be `bigint`.
+ */
+export function encodeCborTag(tag: bigint | number, value: Buffer): Buffer {
+  return Buffer.concat([encodeCborHead(CborMajor.Tag, toExactBigInt(tag)), value]);
+}
+
+/**
+ * Encodes a definite-length map with keys in bytewise lexicographic order of
+ * their encoded form.
+ *
+ * This is the deterministic encoding the chain itself emits, so our output is
+ * byte-identical to what the chain produces. For short text keys it coincides
+ * with RFC 8949 canonical ordering, because the length lives in the head byte:
+ * `"memo"` (`0x64…`) sorts before `"amount"` (`0x66…`) before `"recipient"`
+ * (`0x69…`).
+ */
+export function encodeCborMapDeterministic(entries: [Buffer, Buffer][]): Buffer {
+  const sorted = [...entries].sort(([a], [b]) => Buffer.compare(a, b));
+
+  for (let i = 1; i < sorted.length; i++) {
+    if (Buffer.compare(sorted[i - 1][0], sorted[i][0]) === 0) {
+      throw new Error("CBOR map contains a duplicate key");
+    }
+  }
+
+  return encodeCborMap(sorted);
 }

--- a/libs/concordium-core/src/index.ts
+++ b/libs/concordium-core/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./types";
 export * from "./address";
 export * from "./cbor";
+export * from "./plt";
 export * from "./utils";
 export * from "./serialization";

--- a/libs/concordium-core/src/plt.test.ts
+++ b/libs/concordium-core/src/plt.test.ts
@@ -1,0 +1,220 @@
+import { AccountAddress } from "./address";
+import { PLT_CBOR_MAX_SIZE } from "./cbor";
+import {
+  encodePltAddress,
+  encodePltAmount,
+  encodePltMemo,
+  encodePltTransferOperations,
+} from "./plt";
+
+// The expected byte strings below were derived independently of this
+// implementation, from the device and chain CBOR encoders, so they catch an
+// encoder that is merely self-consistent.
+const ZERO_ADDRESS = AccountAddress.fromBuffer(Buffer.alloc(32));
+const SEQ_ADDRESS = AccountAddress.fromBuffer(Buffer.from(Array.from({ length: 32 }, (_, i) => i)));
+
+const SEQ_HEX = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+
+describe("plt/encodePltAmount", () => {
+  it("encodes a 6-decimal amount as tag 4 with a negative exponent", () => {
+    expect(encodePltAmount(1_000_000n, 6).toString("hex")).toBe("c482251a000f4240");
+  });
+
+  it("encodes a zero amount with zero decimals", () => {
+    expect(encodePltAmount(0n, 0).toString("hex")).toBe("c4820000");
+  });
+
+  it("encodes the maximum unsigned 64-bit significand", () => {
+    expect(encodePltAmount(0xffffffffffffffffn, 6).toString("hex")).toBe(
+      "c482251bffffffffffffffff",
+    );
+  });
+
+  it.each([
+    ["negative amount", -1n, 6],
+    ["amount above the 64-bit range", 2n ** 64n, 6],
+  ])("rejects a %s", (_label, amount, decimals) => {
+    expect(() => encodePltAmount(amount, decimals)).toThrow();
+  });
+
+  it.each([-1, 129, 256, 1.5])("rejects decimals of %s", decimals => {
+    expect(() => encodePltAmount(1n, decimals)).toThrow();
+  });
+
+  // The device holds the exponent in an int8_t and rejects a raw negative
+  // argument above 127, capping decimals at 128 — tighter than the chain's 255.
+  it("accepts 128 decimals, the device's ceiling", () => {
+    expect(encodePltAmount(1n, 128).toString("hex")).toBe("c482387f01");
+  });
+
+  it("rejects 129 decimals, which the chain allows but the device does not", () => {
+    expect(() => encodePltAmount(1n, 129)).toThrow(/0\.\.128/);
+  });
+});
+
+describe("plt/encodePltAddress", () => {
+  it("wraps the address in a tag 40307 map keyed on 3", () => {
+    expect(encodePltAddress(SEQ_ADDRESS).toString("hex")).toBe(`d99d73a1035820${SEQ_HEX}`);
+  });
+
+  it("includes the coin info when asked, keyed on 1 and ordered before the data", () => {
+    expect(encodePltAddress(SEQ_ADDRESS, true).toString("hex")).toBe(
+      `d99d73a201d99d71a101190397035820${SEQ_HEX}`,
+    );
+  });
+
+  it("costs 9 bytes more with coin info than without", () => {
+    expect(encodePltAddress(SEQ_ADDRESS, true).length - encodePltAddress(SEQ_ADDRESS).length).toBe(
+      9,
+    );
+  });
+
+  // The device parses a bare byte string as an error, and so does the chain.
+  // Guard the shape explicitly: a regression here is silent and expensive.
+  it("never emits a bare byte string inside the tag", () => {
+    const encoded = encodePltAddress(SEQ_ADDRESS);
+    // d9 9d 73 = tag(40307); the next byte must open a map (major type 5).
+    expect(encoded[3] & 0xe0).toBe(0xa0);
+  });
+});
+
+describe("plt/encodePltMemo", () => {
+  it("encodes a memo as a bare byte string by default", () => {
+    expect(encodePltMemo(Buffer.from("Hello")).toString("hex")).toBe("4548656c6c6f");
+  });
+
+  it("wraps the memo in tag 24 when asked", () => {
+    expect(encodePltMemo(Buffer.from("Hello"), true).toString("hex")).toBe("d8184548656c6c6f");
+  });
+
+  it("encodes an empty memo as a zero-length byte string", () => {
+    expect(encodePltMemo(Buffer.alloc(0)).toString("hex")).toBe("40");
+  });
+
+  // The chain caps the memo independently of the CBOR budget: a 400-byte memo
+  // fits the budget and still fails on chain.
+  it("accepts a memo at the chain's 256-byte limit", () => {
+    expect(() => encodePltMemo(Buffer.alloc(256))).not.toThrow();
+  });
+
+  it("rejects a memo above the chain's 256-byte limit", () => {
+    expect(() => encodePltMemo(Buffer.alloc(257))).toThrow(/exceeding the chain limit/);
+  });
+
+  it("rejects an oversized memo through the transfer encoder too", () => {
+    expect(() =>
+      encodePltTransferOperations({
+        recipient: SEQ_ADDRESS,
+        amount: 1n,
+        decimals: 6,
+        memo: Buffer.alloc(400),
+      }),
+    ).toThrow(/exceeding the chain limit/);
+  });
+});
+
+describe("plt/encodePltTransferOperations", () => {
+  it("matches the reference encoding for a plain transfer", () => {
+    const encoded = encodePltTransferOperations({
+      recipient: ZERO_ADDRESS,
+      amount: 1_000_000n,
+      decimals: 6,
+    });
+
+    expect(encoded.toString("hex")).toBe(
+      "81a1687472616e73666572a266616d6f756e74c482251a000f424069726563697069656e74d99d73a10358200000000000000000000000000000000000000000000000000000000000000000",
+    );
+  });
+
+  it("matches the reference encoding with a memo", () => {
+    const encoded = encodePltTransferOperations({
+      recipient: SEQ_ADDRESS,
+      amount: 500_000n,
+      decimals: 6,
+      memo: Buffer.from("Hello"),
+    });
+
+    expect(encoded.toString("hex")).toBe(
+      `81a1687472616e73666572a3646d656d6f4548656c6c6f66616d6f756e74c482251a0007a12069726563697069656e74d99d73a1035820${SEQ_HEX}`,
+    );
+  });
+
+  it("matches the reference encoding with an empty memo", () => {
+    const encoded = encodePltTransferOperations({
+      recipient: SEQ_ADDRESS,
+      amount: 1_000_000n,
+      decimals: 6,
+      memo: Buffer.alloc(0),
+    });
+
+    expect(encoded.toString("hex")).toBe(
+      `81a1687472616e73666572a3646d656d6f4066616d6f756e74c482251a000f424069726563697069656e74d99d73a1035820${SEQ_HEX}`,
+    );
+  });
+
+  it("matches the reference encoding with coin info", () => {
+    const encoded = encodePltTransferOperations({
+      recipient: SEQ_ADDRESS,
+      amount: 1_000_000n,
+      decimals: 6,
+      includeCoinInfo: true,
+    });
+
+    expect(encoded.toString("hex")).toBe(
+      `81a1687472616e73666572a266616d6f756e74c482251a000f424069726563697069656e74d99d73a201d99d71a101190397035820${SEQ_HEX}`,
+    );
+  });
+
+  // Key order is bytewise on the encoded key, so the length in the head byte
+  // dominates: "memo" (0x64) then "amount" (0x66) then "recipient" (0x69).
+  it("orders the operation fields deterministically, memo first", () => {
+    const encoded = encodePltTransferOperations({
+      recipient: SEQ_ADDRESS,
+      amount: 1n,
+      decimals: 6,
+      memo: Buffer.from("x"),
+    }).toString("hex");
+
+    expect(encoded.indexOf("646d656d6f")).toBeLessThan(encoded.indexOf("66616d6f756e74"));
+    expect(encoded.indexOf("66616d6f756e74")).toBeLessThan(encoded.indexOf("69726563697069656e74"));
+  });
+
+  it("wraps exactly one operation in the outer array", () => {
+    const encoded = encodePltTransferOperations({
+      recipient: SEQ_ADDRESS,
+      amount: 1n,
+      decimals: 6,
+    });
+
+    // 0x81 = array of length 1. The device rejects a second element with 0x6B10.
+    expect(encoded[0]).toBe(0x81);
+  });
+
+  it("produces identical bytes across runs", () => {
+    const build = () =>
+      encodePltTransferOperations({
+        recipient: SEQ_ADDRESS,
+        amount: 42n,
+        decimals: 2,
+        memo: Buffer.from("determinism"),
+      });
+
+    expect(build().toString("hex")).toBe(build().toString("hex"));
+  });
+
+  // With the memo capped at 256 the blob cannot reach 512 through this encoder,
+  // so the budget guard inside it is a backstop for future operation types
+  // rather than a reachable path. The reachable check is in serializeTokenUpdate,
+  // which takes the blob as opaque bytes.
+  it("stays well inside the device CBOR budget at the worst case", () => {
+    const encoded = encodePltTransferOperations({
+      recipient: SEQ_ADDRESS,
+      amount: 1_000_000n,
+      decimals: 6,
+      memo: Buffer.alloc(256),
+      includeCoinInfo: true,
+    });
+
+    expect(encoded.length).toBeLessThanOrEqual(PLT_CBOR_MAX_SIZE);
+  });
+});

--- a/libs/concordium-core/src/plt.ts
+++ b/libs/concordium-core/src/plt.ts
@@ -1,0 +1,221 @@
+/**
+ * CIS-7 Protocol-Level Token (PLT) payload encoding.
+ *
+ * A `TokenUpdate` transaction carries a token id and a CBOR-encoded list of
+ * token operations. The wallet only ever emits a single `transfer`.
+ *
+ * Two independent consumers constrain the output: the chain, which defines the
+ * canonical wire format, and the Ledger device, which is stricter in places. The
+ * tighter of the two bounds wins. Checks live here where the value is built; the
+ * single-operation check is in `serializeTokenUpdate`, which sees the blob.
+ */
+
+import type { AccountAddress } from "./address";
+import {
+  encodeCborArray,
+  encodeCborByteString,
+  encodeCborInteger,
+  encodeCborMapDeterministic,
+  encodeCborTag,
+  encodeCborTextString,
+  encodeCborUnsigned,
+  PLT_CBOR_MAX_SIZE,
+} from "./cbor";
+
+/**
+ * CBOR tag for a decimal fraction, `[exponent, significand]` (RFC 8949 §3.4.4).
+ * CIS-7 uses it for token amounts.
+ */
+const CBOR_TAG_DECIMAL_FRACTION = 4;
+
+/**
+ * CBOR tag marking a byte string as embedded CBOR (RFC 8949 §3.4.5.1).
+ * CIS-7 allows a memo to be tagged with it, or left as a bare byte string.
+ */
+const CBOR_TAG_EMBEDDED_CBOR = 24;
+
+/** CBOR tag for a `tagged-coininfo` (BCR-2020-007). */
+const CBOR_TAG_COININFO = 40305;
+
+/** CBOR tag for a `tagged-address` (BCR-2020-009). */
+const CBOR_TAG_ADDRESS = 40307;
+
+/** Map key inside a `tagged-coininfo`: the SLIP-44 coin type. */
+const COININFO_KEY_TYPE = 1;
+
+/** Map keys inside a `tagged-address`: optional coin info, and the address bytes. */
+const ADDRESS_KEY_INFO = 1;
+const ADDRESS_KEY_DATA = 3;
+
+/** SLIP-44 coin type for CCD, the only value CIS-7 permits in a coin info. */
+const CCD_COIN_TYPE = 919;
+
+/** Largest significand a token amount can carry: an unsigned 64-bit integer. */
+const MAX_SIGNIFICAND = 2n ** 64n - 1n;
+
+/**
+ * Largest PLT memo, in bytes.
+ *
+ * The chain caps this independently of the CBOR budget, so the 512-byte budget
+ * is not a sufficient check: a 400-byte memo fits it and still fails on chain.
+ */
+const MAX_MEMO_SIZE = 256;
+
+/**
+ * Largest number of decimals a PLT amount may carry.
+ *
+ * The chain accepts up to 255, but the device is tighter: it holds the exponent
+ * in a signed byte and rejects a raw negative-integer argument above 127, which
+ * caps the exponent at -128. Take the tighter bound, so a payload we accept
+ * locally is one both sides accept.
+ */
+const MAX_DECIMALS = 128;
+
+/**
+ * A PLT transfer, in the terms the wallet holds it.
+ */
+export interface PltTransfer {
+  /** Recipient account. */
+  recipient: AccountAddress;
+  /**
+   * Amount in the token's smallest unit, as an unsigned 64-bit integer. Paired
+   * with `decimals`, this is the decimal fraction the chain executes.
+   */
+  amount: bigint;
+  /**
+   * The token's decimal places, 0 to 128.
+   *
+   * Must equal the token's registered decimals. The chain compares the two and
+   * rejects a mismatch with `deserializationFailure` rather than rescaling, and
+   * this package cannot check it — CAL is the source of truth and lives in the
+   * coin module. Callers must pass the CAL unit magnitude, not a guess.
+   */
+  decimals: number;
+  /**
+   * Optional memo, as raw bytes, at most 256. Distinct from the CCD memo, which
+   * is a CBOR text string — do not use `encodeMemoToCbor` here.
+   */
+  memo?: Buffer;
+  /**
+   * Emit the optional coin info alongside the recipient address. Off by default:
+   * its absence means "a Concordium address" to both the chain and the device,
+   * and omitting it saves 9 bytes of the PLT CBOR budget.
+   */
+  includeCoinInfo?: boolean;
+}
+
+/**
+ * Encodes a CIS-7 token amount: `tag 4([exponent, significand])`.
+ *
+ * The exponent is the negated decimals, so it is always `<= 0`. Both the device
+ * and the chain reject a positive exponent.
+ *
+ * @throws If `amount` is negative or exceeds 64 bits, or `decimals` is outside 0..128
+ */
+export function encodePltAmount(amount: bigint, decimals: number): Buffer {
+  if (amount < 0n) {
+    throw new Error(`PLT amount must not be negative, got ${amount}`);
+  }
+  if (amount > MAX_SIGNIFICAND) {
+    throw new Error(`PLT amount ${amount} exceeds the unsigned 64-bit range`);
+  }
+  if (!Number.isInteger(decimals) || decimals < 0 || decimals > MAX_DECIMALS) {
+    throw new Error(`PLT decimals must be an integer in 0..${MAX_DECIMALS}, got ${decimals}`);
+  }
+
+  return encodeCborTag(
+    CBOR_TAG_DECIMAL_FRACTION,
+    encodeCborArray([encodeCborInteger(-decimals), encodeCborUnsigned(amount)]),
+  );
+}
+
+/**
+ * Encodes a CIS-7 account address: `tag 40307({? 1: tag 40305({1: 919}), 3: bstr(32)})`.
+ *
+ * The map is not optional: the chain rejects a bare byte string inside the tag.
+ */
+export function encodePltAddress(address: AccountAddress, includeCoinInfo = false): Buffer {
+  const entries: [Buffer, Buffer][] = [
+    [encodeCborUnsigned(ADDRESS_KEY_DATA), encodeCborByteString(address.toBuffer())],
+  ];
+
+  if (includeCoinInfo) {
+    entries.push([
+      encodeCborUnsigned(ADDRESS_KEY_INFO),
+      encodeCborTag(
+        CBOR_TAG_COININFO,
+        encodeCborMapDeterministic([
+          [encodeCborUnsigned(COININFO_KEY_TYPE), encodeCborUnsigned(CCD_COIN_TYPE)],
+        ]),
+      ),
+    ]);
+  }
+
+  return encodeCborTag(CBOR_TAG_ADDRESS, encodeCborMapDeterministic(entries));
+}
+
+/**
+ * Encodes a CIS-7 memo, as a bare byte string or wrapped in tag 24.
+ *
+ * The chain's `TaggableMemo` accepts either and strips the tag; the device
+ * accepts either too. The untagged form is the default because it is two bytes
+ * shorter and is what the device's own fixtures use.
+ *
+ * @throws If the memo exceeds the chain's 256-byte limit
+ */
+export function encodePltMemo(memo: Buffer, tagged = false): Buffer {
+  if (memo.length > MAX_MEMO_SIZE) {
+    throw new Error(
+      `PLT memo is ${memo.length} bytes, exceeding the chain limit of ${MAX_MEMO_SIZE}`,
+    );
+  }
+
+  const encoded = encodeCborByteString(memo);
+  return tagged ? encodeCborTag(CBOR_TAG_EMBEDDED_CBOR, encoded) : encoded;
+}
+
+/**
+ * Encodes the operations blob for a PLT transfer:
+ * `array(1) [ map(1) { "transfer": map { fields } } ]`.
+ *
+ * Exactly one operation. The device rejects a second element with `0x6B10`, and
+ * the chain charges per operation, so the wallet never batches.
+ *
+ * Map keys are emitted in the chain's deterministic order — bytewise on the
+ * encoded key, which puts `memo` before `amount` before `recipient`. Neither
+ * the device nor the chain requires this on decode; it makes our output
+ * reproducible and byte-comparable against the reference encoder.
+ *
+ * @throws If the amount, decimals or memo is out of range
+ */
+export function encodePltTransferOperations(transfer: PltTransfer): Buffer {
+  const fields: [Buffer, Buffer][] = [
+    [encodeCborTextString("amount"), encodePltAmount(transfer.amount, transfer.decimals)],
+    [
+      encodeCborTextString("recipient"),
+      encodePltAddress(transfer.recipient, transfer.includeCoinInfo),
+    ],
+  ];
+
+  if (transfer.memo !== undefined) {
+    fields.push([encodeCborTextString("memo"), encodePltMemo(transfer.memo)]);
+  }
+
+  const operations = encodeCborArray([
+    encodeCborMapDeterministic([
+      [encodeCborTextString("transfer"), encodeCborMapDeterministic(fields)],
+    ]),
+  ]);
+
+  // Unreachable while `transfer` is the only operation and the memo is capped at
+  // 256: the worst case lands near 350 bytes. Kept as a backstop for future
+  // operation types, which is why it is excluded from coverage.
+  /* istanbul ignore next */
+  if (operations.length > PLT_CBOR_MAX_SIZE) {
+    throw new Error(
+      `PLT operations blob is ${operations.length} bytes, exceeding the device limit of ${PLT_CBOR_MAX_SIZE}`,
+    );
+  }
+
+  return operations;
+}

--- a/libs/concordium-core/src/serialization.test.ts
+++ b/libs/concordium-core/src/serialization.test.ts
@@ -8,11 +8,16 @@ import {
   serializeTransaction,
   getTransactionType,
   insertAccountOwnershipProofs,
+  serializeTokenUpdate,
+  deserializeTokenUpdate,
+  isTokenUpdateTransaction,
 } from "./serialization";
+import { encodePltTransferOperations } from "./plt";
 import { AccountAddress } from "./address";
 import { TransactionType } from "./types";
 import type {
   CredentialDeploymentTransaction,
+  TokenUpdateTransaction,
   Transaction,
   TransferWithMemoPayload,
 } from "./types";
@@ -1119,6 +1124,286 @@ describe("serialization", () => {
       const countOffset = 64 + 48 + 32;
       expect(buf.readUInt32BE(countOffset)).toBe(2);
       expect(buf.readUInt32BE(countOffset + 4)).toBe(0); // First entry index is 0
+    });
+  });
+});
+
+describe("serialization: TokenUpdate (PLT)", () => {
+  const SENDER = AccountAddress.fromBuffer(Buffer.alloc(32, 0xaa));
+  const RECIPIENT = AccountAddress.fromBuffer(Buffer.alloc(32, 0xbb));
+
+  const header = {
+    sender: SENDER,
+    nonce: 10n,
+    energyAmount: 100n,
+    expiry: 1675432871n,
+  };
+
+  const buildTransaction = (
+    overrides: Partial<TokenUpdateTransaction["payload"]> = {},
+  ): TokenUpdateTransaction => ({
+    header,
+    type: TransactionType.TokenUpdate,
+    payload: {
+      tokenId: Buffer.from("PLT", "utf-8"),
+      operations: encodePltTransferOperations({
+        recipient: RECIPIENT,
+        amount: 1_000_000n,
+        decimals: 6,
+      }),
+      ...overrides,
+    },
+  });
+
+  describe("serializeTokenUpdate", () => {
+    it("lays out the flat wire transaction the device hashes", () => {
+      const tx = buildTransaction();
+      const serialized = serializeTokenUpdate(tx);
+
+      const { tokenId, operations } = tx.payload;
+      const cborLengthOffset = 60 + 1 + 1 + tokenId.length;
+
+      expect(serialized.subarray(0, 32)).toEqual(SENDER.toBuffer());
+      // The kind byte lands at offset 60, which is what keeps the existing
+      // TYPE_OFFSET dispatch working in both this package and the signer.
+      expect(serialized.readUInt8(60)).toBe(0x1b);
+      expect(serialized.readUInt8(61)).toBe(tokenId.length);
+      expect(serialized.subarray(62, 62 + tokenId.length)).toEqual(tokenId);
+      expect(serialized.readUInt32BE(cborLengthOffset)).toBe(operations.length);
+      expect(serialized.subarray(cborLengthOffset + 4)).toEqual(operations);
+    });
+
+    it("counts the kind byte in the header payload size", () => {
+      const tx = buildTransaction();
+      const serialized = serializeTokenUpdate(tx);
+      const payloadLength = 1 + 1 + tx.payload.tokenId.length + 4 + tx.payload.operations.length;
+
+      expect(serialized.readUInt32BE(48)).toBe(payloadLength);
+    });
+
+    it("accepts the shortest and longest token id the device allows", () => {
+      expect(() =>
+        serializeTokenUpdate(buildTransaction({ tokenId: Buffer.alloc(1) })),
+      ).not.toThrow();
+      expect(() =>
+        serializeTokenUpdate(buildTransaction({ tokenId: Buffer.alloc(128) })),
+      ).not.toThrow();
+    });
+
+    it.each([
+      ["an empty token id", Buffer.alloc(0)],
+      ["a token id above 128 bytes", Buffer.alloc(129)],
+    ])("rejects %s", (_label, tokenId) => {
+      expect(() => serializeTokenUpdate(buildTransaction({ tokenId }))).toThrow(
+        /Token id length .* outside the device range/,
+      );
+    });
+
+    it("rejects an empty operations blob", () => {
+      expect(() => serializeTokenUpdate(buildTransaction({ operations: Buffer.alloc(0) }))).toThrow(
+        /must not be empty/,
+      );
+    });
+
+    it("rejects an operations blob above the device CBOR budget", () => {
+      expect(() =>
+        serializeTokenUpdate(buildTransaction({ operations: Buffer.alloc(513) })),
+      ).toThrow(/exceeding the device limit/);
+    });
+
+    // The blob is opaque bytes here, so nothing stops a caller skipping
+    // encodePltTransferOperations. The device answers a second operation with
+    // 0x6B10 only after the user has been prompted, so reject it locally.
+    it("rejects a multi-operation array smuggled in as raw bytes", () => {
+      const single = buildTransaction().payload.operations;
+      const twoOps = Buffer.concat([Buffer.from([0x82]), single.subarray(1), single.subarray(1)]);
+
+      expect(() => serializeTokenUpdate(buildTransaction({ operations: twoOps }))).toThrow(
+        /single-element CBOR array/,
+      );
+    });
+
+    it("rejects an operations blob that is not a CBOR array at all", () => {
+      expect(() =>
+        serializeTokenUpdate(buildTransaction({ operations: Buffer.from([0x00]) })),
+      ).toThrow(/single-element CBOR array/);
+    });
+
+    it("rejects a TokenUpdate carrying a CCD payload", () => {
+      const mislabelled = {
+        header,
+        type: TransactionType.TokenUpdate,
+        payload: { toAddress: RECIPIENT, amount: 5000n },
+      } as unknown as TokenUpdateTransaction;
+
+      expect(() => serializeTokenUpdate(mislabelled)).toThrow(
+        /must contain tokenId and operations/,
+      );
+    });
+
+    it("rejects a transaction of the wrong type", () => {
+      const wrongType = {
+        ...buildTransaction(),
+        type: TransactionType.Transfer,
+      } as unknown as TokenUpdateTransaction;
+
+      expect(() => serializeTokenUpdate(wrongType)).toThrow(/must be TokenUpdate type/);
+    });
+  });
+
+  describe("deserializeTokenUpdate", () => {
+    it("round-trips a transaction", () => {
+      const tx = buildTransaction();
+      const decoded = deserializeTokenUpdate(serializeTokenUpdate(tx));
+
+      expect(decoded.type).toBe(TransactionType.TokenUpdate);
+      expect(decoded.header.nonce).toBe(10n);
+      expect(decoded.header.energyAmount).toBe(100n);
+      expect(decoded.header.expiry).toBe(1675432871n);
+      expect(decoded.header.sender.toBuffer()).toEqual(SENDER.toBuffer());
+      expect(decoded.payload.tokenId).toEqual(tx.payload.tokenId);
+      expect(decoded.payload.operations).toEqual(tx.payload.operations);
+    });
+
+    it("round-trips a 128-byte token id", () => {
+      const tokenId = Buffer.alloc(128, 0x7a);
+      const decoded = deserializeTokenUpdate(serializeTokenUpdate(buildTransaction({ tokenId })));
+
+      expect(decoded.payload.tokenId).toEqual(tokenId);
+    });
+
+    it("rejects a buffer that is too short", () => {
+      expect(() => deserializeTokenUpdate(Buffer.alloc(60))).toThrow(/too short/);
+    });
+
+    it("rejects a buffer whose kind byte is not TokenUpdate", () => {
+      const serialized = serializeTokenUpdate(buildTransaction());
+      serialized.writeUInt8(TransactionType.Transfer, 60);
+
+      expect(() => deserializeTokenUpdate(serialized)).toThrow(/Expected TokenUpdate type/);
+    });
+
+    it("rejects a declared CBOR length that disagrees with the remaining bytes", () => {
+      const serialized = serializeTokenUpdate(buildTransaction());
+      const cborLengthOffset = 60 + 2 + 3;
+      // Inside the device range, so this exercises the mismatch check rather
+      // than the bounds check below.
+      serialized.writeUInt32BE(500, cborLengthOffset);
+
+      expect(() => deserializeTokenUpdate(serialized)).toThrow(/does not match/);
+    });
+
+    it.each([0, 513])("rejects a declared CBOR length of %s", cborLength => {
+      const serialized = serializeTokenUpdate(buildTransaction());
+      serialized.writeUInt32BE(cborLength, 60 + 2 + 3);
+
+      expect(() => deserializeTokenUpdate(serialized)).toThrow(
+        /outside the device range of 1\.\.512/,
+      );
+    });
+
+    it("rejects a header payloadSize that disagrees with the payload", () => {
+      const serialized = serializeTokenUpdate(buildTransaction());
+      serialized.writeUInt32BE(999, 48);
+
+      expect(() => deserializeTokenUpdate(serialized)).toThrow(/Invalid payload size/);
+    });
+  });
+
+  describe("dispatchers", () => {
+    it("reports TokenUpdate from getTransactionType", () => {
+      const serialized = serializeTokenUpdate(buildTransaction());
+
+      expect(getTransactionType(serialized)).toBe(TransactionType.TokenUpdate);
+    });
+
+    it("routes TokenUpdate through serializeTransaction", () => {
+      const tx = buildTransaction();
+
+      expect(serializeTransaction(tx)).toEqual(serializeTokenUpdate(tx));
+    });
+
+    it("narrows a TokenUpdate transaction", () => {
+      expect(isTokenUpdateTransaction(buildTransaction())).toBe(true);
+    });
+
+    // An unsafe cast can produce a CCD-shaped object that claims to be
+    // TokenUpdate. The guard must not wave it through to the PLT serializer.
+    it("does not narrow a CCD payload mislabelled as TokenUpdate", () => {
+      const mislabelled = {
+        header,
+        type: TransactionType.TokenUpdate,
+        payload: { toAddress: RECIPIENT, amount: 5000n },
+      } as unknown as Transaction;
+
+      expect(isTokenUpdateTransaction(mislabelled)).toBe(false);
+    });
+
+    // A JS caller or an unsafe cast can supply these; the guard must return
+    // false rather than throw on the `in` operator.
+    it.each([
+      ["a null payload", null],
+      ["an undefined payload", undefined],
+      ["a primitive payload", 42],
+    ])("does not narrow %s", (_label, payload) => {
+      const malformed = {
+        header,
+        type: TransactionType.TokenUpdate,
+        payload,
+      } as unknown as Transaction;
+
+      expect(() => isTokenUpdateTransaction(malformed)).not.toThrow();
+      expect(isTokenUpdateTransaction(malformed)).toBe(false);
+    });
+
+    // Presence alone is not enough: a payload with the right keys but the wrong
+    // field types would reach serializeTokenUpdate and fail on readUInt8.
+    it("does not narrow a payload whose fields are not Buffers", () => {
+      const wrongTypes = {
+        header,
+        type: TransactionType.TokenUpdate,
+        payload: { tokenId: "PLT", operations: "deadbeef" },
+      } as unknown as Transaction;
+
+      expect(isTokenUpdateTransaction(wrongTypes)).toBe(false);
+      expect(() => serializeTransaction(wrongTypes)).toThrow(
+        /Unsupported transaction type for serialization/,
+      );
+    });
+
+    it("does not narrow a CCD transfer", () => {
+      const transfer: Transaction = {
+        header,
+        type: TransactionType.Transfer,
+        payload: { toAddress: RECIPIENT, amount: 5000n },
+      };
+
+      expect(isTokenUpdateTransaction(transfer)).toBe(false);
+    });
+
+    // deserializeTransaction stays CCD-only: production never decodes a PLT
+    // payload, so it points the caller at the explicit function instead of
+    // returning a widened type that would defeat narrowing at every CCD site.
+    it("refuses TokenUpdate in deserializeTransaction with a directed message", () => {
+      const serialized = serializeTokenUpdate(buildTransaction());
+
+      expect(() => deserializeTransaction(serialized)).toThrow(/use deserializeTokenUpdate/);
+    });
+  });
+
+  describe("CCD paths are unaffected", () => {
+    it("still serializes a Transfer identically", () => {
+      const transfer: Transaction = {
+        header,
+        type: TransactionType.Transfer,
+        payload: { toAddress: RECIPIENT, amount: 5000n },
+      };
+
+      const serialized = serializeTransfer(transfer);
+
+      expect(serialized.readUInt8(60)).toBe(TransactionType.Transfer);
+      expect(serialized).toHaveLength(101);
+      expect(deserializeTransaction(serialized).type).toBe(TransactionType.Transfer);
     });
   });
 });

--- a/libs/concordium-core/src/serialization.ts
+++ b/libs/concordium-core/src/serialization.ts
@@ -1,6 +1,10 @@
 import {
   TransactionType,
+  type AnyTransaction,
   type Transaction,
+  type TokenUpdatePayload,
+  type TokenUpdateTransaction,
+  type TransactionHeader,
   type CredentialDeploymentTransaction,
   type IdOwnershipProofs,
 } from "./types";
@@ -18,7 +22,12 @@ import {
   serializeYearMonth,
 } from "./utils";
 import { AccountAddress } from "./address";
-import { MAX_CBOR_SIZE } from "./cbor";
+import {
+  MAX_CBOR_SIZE,
+  PLT_CBOR_MAX_SIZE,
+  PLT_TOKEN_ID_MAX_LENGTH,
+  PLT_TOKEN_ID_MIN_LENGTH,
+} from "./cbor";
 
 /**
  * Serializes transaction header common to all account transaction types.
@@ -26,7 +35,7 @@ import { MAX_CBOR_SIZE } from "./cbor";
  * Format: [sender:32][nonce:8][energyAmount:8][payloadSize:4][expiry:8]
  * @private
  */
-function serializeTransactionHeader(tx: Transaction, payload: Buffer): Buffer {
+function serializeTransactionHeader(tx: { header: TransactionHeader }, payload: Buffer): Buffer {
   const serializedSender = tx.header.sender.toBuffer();
   const serializedNonce = encodeWord64(tx.header.nonce);
   const serializedEnergyAmount = encodeWord64(tx.header.energyAmount);
@@ -104,6 +113,197 @@ export const serializeTransferWithMemo = (tx: Transaction): Buffer => {
   const serializedType = Buffer.from([tx.type]);
 
   return Buffer.concat([serializedHeader, serializedType, serializedPayload]);
+};
+
+/**
+ * CBOR head for a definite-length array of exactly one item. CIS-7 allows an
+ * array of operations; the device accepts only one element.
+ * @private
+ */
+const CBOR_SINGLE_ELEMENT_ARRAY = 0x81;
+
+/**
+ * Narrows a transaction to the PLT shape.
+ *
+ * The type discriminator alone is not enough: a JS caller or an unsafe cast can
+ * produce an object that claims to be `TokenUpdate` while carrying a CCD
+ * payload. The payload checks reject that instead of letting it reach the PLT
+ * serializer.
+ */
+export function isTokenUpdateTransaction(
+  transaction: AnyTransaction,
+): transaction is TokenUpdateTransaction {
+  return (
+    transaction?.type === TransactionType.TokenUpdate && hasTokenUpdatePayload(transaction.payload)
+  );
+}
+
+/**
+ * The `in` operator throws on a null or primitive operand, so the object check
+ * comes first: the public type guard above must return false for a malformed
+ * input rather than throw.
+ *
+ * Presence alone would let a payload with string fields satisfy the guard and
+ * reach the serializer, where it fails on `readUInt8` only after passing the
+ * length bounds.
+ * @private
+ */
+function hasTokenUpdatePayload(payload: unknown): payload is TokenUpdatePayload {
+  return (
+    typeof payload === "object" &&
+    payload !== null &&
+    "tokenId" in payload &&
+    "operations" in payload &&
+    Buffer.isBuffer(payload.tokenId) &&
+    Buffer.isBuffer(payload.operations)
+  );
+}
+
+/**
+ * Serializes a TokenUpdate transaction — a Protocol-Level Token (PLT) operation.
+ *
+ * Output format:
+ * `[sender:32][nonce:8][energyAmount:8][payloadSize:4][expiry:8][type:1][token_id_length:1][token_id:N][cbor_length:4][cbor:M]`
+ *
+ * All multi-byte fields are big-endian.
+ *
+ * This is the flat wire transaction: the same bytes the chain accepts and the
+ * device hashes. The signer re-splits it into APDU frames, so nothing else needs
+ * to know the framing.
+ *
+ * Every bound checked here mirrors one the device enforces. Failing locally
+ * turns an opaque status word mid-signing into a clear error before the user is
+ * prompted.
+ *
+ * @param tx TokenUpdate transaction
+ * @returns Serialized transaction ready for signing and network submission
+ * @throws If the payload is not a PLT payload, or the token id or operations blob is outside the device's limits
+ */
+export const serializeTokenUpdate = (tx: TokenUpdateTransaction): Buffer => {
+  if (tx.type !== TransactionType.TokenUpdate) {
+    throw new Error("Transaction must be TokenUpdate type");
+  }
+
+  if (!hasTokenUpdatePayload(tx.payload)) {
+    throw new Error("TokenUpdate payload must contain tokenId and operations");
+  }
+
+  const { tokenId, operations } = tx.payload;
+
+  if (tokenId.length < PLT_TOKEN_ID_MIN_LENGTH || tokenId.length > PLT_TOKEN_ID_MAX_LENGTH) {
+    throw new Error(
+      `Token id length ${tokenId.length} is outside the device range of ${PLT_TOKEN_ID_MIN_LENGTH}..${PLT_TOKEN_ID_MAX_LENGTH} bytes`,
+    );
+  }
+
+  if (operations.length === 0) {
+    throw new Error("TokenUpdate operations blob must not be empty");
+  }
+
+  if (operations.length > PLT_CBOR_MAX_SIZE) {
+    throw new Error(
+      `TokenUpdate operations blob is ${operations.length} bytes, exceeding the device limit of ${PLT_CBOR_MAX_SIZE} bytes`,
+    );
+  }
+
+  // The blob arrives as opaque bytes, so a caller can bypass
+  // encodePltTransferOperations and hand over a multi-operation array. The
+  // device answers that with 0x6B10 after the user has already been prompted,
+  // so check the outer array header here: 0x81 is "array of exactly one".
+  if (operations.readUInt8(0) !== CBOR_SINGLE_ELEMENT_ARRAY) {
+    throw new Error(
+      `TokenUpdate operations must be a single-element CBOR array (0x${CBOR_SINGLE_ELEMENT_ARRAY.toString(16)}), got 0x${operations.readUInt8(0).toString(16)}`,
+    );
+  }
+
+  const serializedPayload = Buffer.concat([
+    encodeWord8(tokenId.length),
+    tokenId,
+    encodeWord32(operations.length),
+    operations,
+  ]);
+
+  const serializedHeader = serializeTransactionHeader(tx, serializedPayload);
+  const serializedType = Buffer.from([tx.type]);
+
+  return Buffer.concat([serializedHeader, serializedType, serializedPayload]);
+};
+
+/**
+ * Deserializes a TokenUpdate transaction.
+ *
+ * Provided for round-trip testing and for symmetry with the other transaction
+ * types. The send flow never needs it: PLT history arrives from the wallet proxy
+ * as JSON, so nothing in production decodes a PLT payload. The CBOR operations
+ * blob is returned as raw bytes rather than parsed.
+ *
+ * @param buffer Serialized TokenUpdate transaction
+ * @returns The deserialized transaction, with `operations` still CBOR-encoded
+ */
+export const deserializeTokenUpdate = (buffer: Buffer): TokenUpdateTransaction => {
+  const TYPE_OFFSET = 60;
+  const MIN_LENGTH = TYPE_OFFSET + 1 + 1 + PLT_TOKEN_ID_MIN_LENGTH + 4 + 1;
+
+  if (buffer.length < MIN_LENGTH) {
+    throw new Error(
+      `TokenUpdate buffer too short: expected at least ${MIN_LENGTH} bytes, got ${buffer.length}`,
+    );
+  }
+
+  const sender = AccountAddress.fromBuffer(buffer.subarray(0, 32));
+  const nonce = decodeWord64(buffer, 32);
+  const energyAmount = decodeWord64(buffer, 40);
+  const expiry = decodeWord64(buffer, 52);
+
+  const type = buffer.readUInt8(TYPE_OFFSET);
+  if (type !== TransactionType.TokenUpdate) {
+    throw new Error(`Expected TokenUpdate type ${TransactionType.TokenUpdate}, got ${type}`);
+  }
+
+  const tokenIdLength = buffer.readUInt8(TYPE_OFFSET + 1);
+  if (tokenIdLength < PLT_TOKEN_ID_MIN_LENGTH || tokenIdLength > PLT_TOKEN_ID_MAX_LENGTH) {
+    throw new Error(
+      `Token id length ${tokenIdLength} is outside the device range of ${PLT_TOKEN_ID_MIN_LENGTH}..${PLT_TOKEN_ID_MAX_LENGTH} bytes`,
+    );
+  }
+
+  const tokenIdOffset = TYPE_OFFSET + 2;
+  const cborLengthOffset = tokenIdOffset + tokenIdLength;
+  if (buffer.length < cborLengthOffset + 4) {
+    throw new Error("TokenUpdate buffer truncated before the CBOR length field");
+  }
+
+  const tokenId = Buffer.from(buffer.subarray(tokenIdOffset, cborLengthOffset));
+  const cborLength = decodeWord32(buffer, cborLengthOffset);
+  const operations = Buffer.from(buffer.subarray(cborLengthOffset + 4));
+
+  if (cborLength < 1 || cborLength > PLT_CBOR_MAX_SIZE) {
+    throw new Error(
+      `Declared CBOR length ${cborLength} is outside the device range of 1..${PLT_CBOR_MAX_SIZE} bytes`,
+    );
+  }
+
+  if (operations.length !== cborLength) {
+    throw new Error(
+      `Declared CBOR length ${cborLength} does not match the ${operations.length} remaining bytes`,
+    );
+  }
+
+  // payloadSize covers the kind byte and everything after it, the same rule
+  // serializeTransactionHeader applies and deserializeTransfer checks.
+  const payloadSize = decodeWord32(buffer, 48);
+  const expectedPayloadSize = 1 + 1 + tokenIdLength + 4 + cborLength;
+  if (payloadSize !== expectedPayloadSize) {
+    throw new Error(
+      `Invalid payload size for TokenUpdate: expected ${expectedPayloadSize}, got ${payloadSize}`,
+    );
+  }
+
+  return {
+    header: { sender, nonce, expiry, energyAmount },
+    type: TransactionType.TokenUpdate,
+    payload: { tokenId, operations },
+  };
 };
 
 /**
@@ -445,6 +645,7 @@ export const deserializeTransferWithMemo = (buffer: Buffer): Transaction => {
  * Payload structure varies by type:
  * - Transfer (0x03): [recipient:32][amount:8]
  * - TransferWithMemo (0x16): [recipient:32][memo_length:2][memo:N][amount:8]
+ * - TokenUpdate (0x1B): [token_id_length:1][token_id:N][cbor_length:4][cbor:M]
  *
  * @param buffer - Serialized transaction buffer
  * @returns The transaction type
@@ -461,9 +662,13 @@ export function getTransactionType(buffer: Buffer): TransactionType {
 
   const type = buffer.readUInt8(TYPE_OFFSET);
 
-  if (type !== TransactionType.Transfer && type !== TransactionType.TransferWithMemo) {
+  if (
+    type !== TransactionType.Transfer &&
+    type !== TransactionType.TransferWithMemo &&
+    type !== TransactionType.TokenUpdate
+  ) {
     throw new Error(
-      `Unsupported transaction type: ${type} (0x${type.toString(16)}). Expected Transfer (${TransactionType.Transfer}) or TransferWithMemo (${TransactionType.TransferWithMemo})`,
+      `Unsupported transaction type: ${type} (0x${type.toString(16)}). Expected Transfer (${TransactionType.Transfer}), TransferWithMemo (${TransactionType.TransferWithMemo}) or TokenUpdate (${TransactionType.TokenUpdate})`,
     );
   }
 
@@ -471,11 +676,14 @@ export function getTransactionType(buffer: Buffer): TransactionType {
 }
 
 /**
- * Deserializes a transaction buffer by automatically detecting its type.
+ * Deserializes a CCD transaction buffer by automatically detecting its type.
+ *
+ * TokenUpdate is detected but rejected: PLT transactions deserialize through
+ * {@link deserializeTokenUpdate}.
  *
  * @param buffer - Serialized transaction buffer
  * @returns The deserialized transaction
- * @throws Error if buffer is invalid or type is unsupported
+ * @throws Error if the buffer is invalid, carries a TokenUpdate, or has an unsupported type
  */
 export function deserializeTransaction(buffer: Buffer): Transaction {
   const type = getTransactionType(buffer);
@@ -485,6 +693,10 @@ export function deserializeTransaction(buffer: Buffer): Transaction {
       return deserializeTransfer(buffer);
     case TransactionType.TransferWithMemo:
       return deserializeTransferWithMemo(buffer);
+    case TransactionType.TokenUpdate:
+      throw new Error(
+        "TokenUpdate transactions are not handled by deserializeTransaction; use deserializeTokenUpdate",
+      );
     default:
       // This should never happen since getTransactionType validates the type
       /* istanbul ignore next */
@@ -499,14 +711,21 @@ export function deserializeTransaction(buffer: Buffer): Transaction {
  * @returns The serialized transaction buffer
  * @throws Error if transaction type is unsupported
  */
-export function serializeTransaction(transaction: Transaction): Buffer {
+export function serializeTransaction(transaction: AnyTransaction): Buffer {
+  if (isTokenUpdateTransaction(transaction)) {
+    return serializeTokenUpdate(transaction);
+  }
+
   switch (transaction.type) {
     case TransactionType.Transfer:
       return serializeTransfer(transaction);
     case TransactionType.TransferWithMemo:
       return serializeTransferWithMemo(transaction);
-    /* istanbul ignore next */
+    // The narrowed discriminator makes this unreachable for a well-typed caller,
+    // but it still catches a malformed object from JS or a cast.
     default:
-      throw new Error(`Unsupported transaction type for serialization: ${transaction.type}`);
+      throw new Error(
+        `Unsupported transaction type for serialization: ${(transaction as AnyTransaction).type}`,
+      );
   }
 }

--- a/libs/concordium-core/src/types.ts
+++ b/libs/concordium-core/src/types.ts
@@ -60,6 +60,7 @@ export enum SchemeId {
 export enum TransactionType {
   Transfer = 3,
   TransferWithMemo = 22,
+  TokenUpdate = 27,
 }
 
 /**
@@ -90,6 +91,52 @@ export interface TransferWithMemoPayload {
 }
 
 /**
+ * Account transaction header, common to every transaction type.
+ */
+export interface TransactionHeader {
+  /** Sender's Concordium address */
+  sender: AccountAddressType;
+  /** Account nonce / sequence number */
+  nonce: bigint;
+  /** Transaction expiry time (epoch seconds) */
+  expiry: bigint;
+  /** Maximum energy (gas) for transaction execution */
+  energyAmount: bigint;
+}
+
+/**
+ * TokenUpdate transaction payload — a Protocol-Level Token (PLT) operation.
+ *
+ * The token id is a sibling of the operations blob on the wire, not a field
+ * inside it. Build `operations` with `encodePltTransferOperations`.
+ */
+export interface TokenUpdatePayload {
+  /** Token id as raw bytes, 1 to 128 bytes. Resolved from CAL, not from chain data. */
+  tokenId: Buffer;
+  /** CBOR-encoded CIS-7 operations array, holding exactly one operation. */
+  operations: Buffer;
+}
+
+/**
+ * A TokenUpdate (PLT) transaction.
+ *
+ * Kept separate from {@link Transaction} rather than folded into its payload
+ * union: `Transaction.payload` is narrowed by property checks across the coin
+ * module, and widening the union would silently defeat that narrowing at every
+ * existing call site.
+ */
+export interface TokenUpdateTransaction {
+  header: TransactionHeader;
+  type: TransactionType.TokenUpdate;
+  payload: TokenUpdatePayload;
+}
+
+/**
+ * Any transaction this package can serialize.
+ */
+export type AnyTransaction = Transaction | TokenUpdateTransaction;
+
+/**
  * Union type of all supported transaction payloads.
  */
 export type TransactionPayload = TransferPayload | TransferWithMemoPayload;
@@ -102,20 +149,15 @@ export type TransactionPayload = TransferPayload | TransferWithMemoPayload;
  * The type field determines which payload structure is expected:
  * - TransactionType.Transfer → TransferPayload
  * - TransactionType.TransferWithMemo → TransferWithMemoPayload
+ *
+ * TransactionType.TokenUpdate is absent by construction, so a PLT transaction
+ * cannot be built here. PLT uses {@link TokenUpdateTransaction};
+ * {@link AnyTransaction} is the discriminated union of both.
  */
 export interface Transaction {
-  header: {
-    /** Sender's Concordium address */
-    sender: AccountAddressType;
-    /** Account nonce / sequence number */
-    nonce: bigint;
-    /** Transaction expiry time (epoch seconds) */
-    expiry: bigint;
-    /** Maximum energy (gas) for transaction execution */
-    energyAmount: bigint;
-  };
+  header: TransactionHeader;
   /** Transaction type discriminator */
-  type: TransactionType;
+  type: TransactionType.Transfer | TransactionType.TransferWithMemo;
   /** Type-safe payload (structure depends on type field) */
   payload: TransactionPayload;
 }


### PR DESCRIPTION
### 📝 Description

Adds Protocol-Level Token (PLT) support to `@ledgerhq/concordium-core`: `TransactionType.TokenUpdate` (`27` / `0x1B`), a CIS-7 CBOR encoder, and flat wire serialization. Prerequisite for LIVE-28335 and LIVE-28337. CCD behaviour is unchanged.

**Wire format**

```
[header:60][0x1B][token_id_length:1][token_id:N][cbor_length:4 BE][cbor:M]
```

These are the bytes the device hashes and the chain accepts, so one buffer both signs and broadcasts. The kind byte at offset 60 means the existing `TYPE_OFFSET` dispatch extends with one enum member. The token id is a sibling of the CBOR blob, not a field inside it.

**CBOR contract**

| Field | Encoding |
| --- | --- |
| operations | `array(1) [ map(1) { "transfer": map { … } } ]` |
| `amount` | tag 4 `[exponent, significand]`, exponent `<= 0`, unsigned 64-bit significand |
| `recipient` | tag 40307 wrapping `{? 1: 40305({1: 919}), 3: bstr(32)}` |
| `memo` | bare byte string, or tag 24; bytes, not text |

Keys are emitted in the chain's deterministic order, making the output byte-identical to `encodeTokenTransfer` in `concordium-base`.

**Validated before signing**

Each bound mirrors a device or chain rejection, so it surfaces locally instead of as a status word after the user has been prompted:

| Bound | Value | Otherwise |
| --- | --- | --- |
| operations | exactly one | device `0x6B10` |
| operations blob | 1..512 | device `0x6B0E` |
| token id | 1..128 | device `0x6B0F` |
| amount decimals | 0..128 | device `0x6B0D` |
| memo | <= 256 | chain rejects |

Two are tighter than the chain's: the device holds the exponent in an `int8_t`, capping decimals at 128 rather than 255; and a 400-byte memo fits the CBOR budget but fails on chain at `maxMemoSize = 256`.

**Codec.** `cbor.ts` handled text strings only. It gains generic primitives and `encodeCborMapDeterministic`, with no new dependency. Also corrects `MAX_CBOR_SIZE = 256`, documented as the device limit when it is the CCD memo limit; `PLT_CBOR_MAX_SIZE = 512` added alongside.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-28330](https://ledgerhq.atlassian.net/browse/LIVE-28330)
- **ADR** (if any): n/a

<details>
<summary>Reviewer notes</summary>

**PLT has its own transaction type rather than joining `TransactionPayload`.** Widening that union broke narrowing at 16 sites, 14 in existing CCD tests — `Transaction.type` is the wide enum, so it never narrowed the payload and those tests only compiled because the members shared a shape. `TokenUpdateTransaction` is separate, with `AnyTransaction` for the dispatchers and an `isTokenUpdateTransaction` guard that checks payload shape, not just the type byte.

**`deserializeTransaction` stays CCD-only.** Routing PLT through it forced a widened return type that re-broke those tests. Production never decodes a PLT payload — history comes from the wallet proxy as JSON — so it throws a message naming `deserializeTokenUpdate`. `getTransactionType` does accept `27`, since the signer's factory dispatches on that byte.

**Not enforced here:** the chain requires the exponent to equal the token's registered decimals. CAL is the source of truth and lives in the coin module, so that check belongs to LIVE-28332 / LIVE-28337.
</details>


[LIVE-28330]: https://ledgerhq.atlassian.net/browse/LIVE-28330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ