### PR TITLE
feat(solana): persist staking resources on generic bridge (LIVE-35886)

### DIFF
--- a/.changeset/quiet-otters-repeat.md
+++ b/.changeset/quiet-otters-repeat.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Persist Solana `stakingResources` through the generic coin framework, and revive accounts still holding the legacy `solanaResources` blob

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -783,6 +783,7 @@
     "src/families/near/coinModuleApi.ts",
     "src/families/near/config.ts",
     "src/families/polkadot/config.ts",
+    "src/families/solana/accountRawAssign.ts",
     "src/families/solana/bridge/api.ts",
     "src/families/solana/coinModuleApi.ts",
     "src/families/solana/config.ts",

--- a/libs/ledger-live-common/src/coin-modules/loaders.ts
+++ b/libs/ledger-live-common/src/coin-modules/loaders.ts
@@ -337,6 +337,7 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
     loadMockBridge: () => import("../families/solana/bridge/mock").then(m => m.default),
     loadSigner: () => import("../families/solana/signer").then(m => m.default),
     loadBridgeApi: () => import("../families/solana/bridge/api").then(m => m.default),
+    loadAccountRawAssign: () => import("../families/solana/accountRawAssign").then(m => m.default),
   },
   {
     family: "stacks",

--- a/libs/ledger-live-common/src/families/solana/accountRawAssign.ts
+++ b/libs/ledger-live-common/src/families/solana/accountRawAssign.ts
@@ -1,0 +1,19 @@
+import {
+  assignFromAccountRaw,
+  assignToAccountRaw,
+  fromOperationExtraRaw,
+  toOperationExtraRaw,
+} from "@ledgerhq/coin-solana/serialization";
+
+/**
+ * Solana-specific hooks that persist `stakingResources` (and revive accounts still holding the
+ * older `solanaResources` blob) plus the staking amounts on `Operation.extra`, through the
+ * `fromAccountRaw` / `toAccountRaw` cycle — the generic coin framework pipeline is
+ * family-agnostic and serializes neither.
+ */
+export default {
+  assignFromAccountRaw,
+  assignToAccountRaw,
+  fromOperationExtraRaw,
+  toOperationExtraRaw,
+};


### PR DESCRIPTION
### 📝 Description

`StakingResources` are not serialized on the generic coin framework path, so a Solana account synced through it comes back from disk with an empty delegation list until the next full sync.

The framework pipeline is family-agnostic and serializes neither `stakingResources` nor the family bits of `Operation.extra`; families opt in through a `loadAccountRawAssign` entry, as evm, tezos and tron already do (`coin-modules/loaders.ts:224,385,409`). Solana had none.

Everything needed already existed and is simply wired up here:

- `assignStakingResourcesTo/FromAccountRaw` in `ledger-wallet-framework/src/serialization/staking.ts` — the shared implementation the ticket asks for
- `assignTo/FromAccountRaw` in `@ledgerhq/coin-solana/serialization`, which call it

`assignFromAccountRaw` also carries the revival of accounts persisted by the legacy bridge, which still hold the older `solanaResources` blob — it degrades to empty resources rather than throwing, so a corrupted or older blob cannot block an account from loading.

### ✅ Tests

`live-common` `src/coin-modules` + `src/families/solana`: 334 passing.

Acceptance is behavioural and best checked as described in the ticket: sync an account with stakes, then confirm `stakingResources` is present in `app.json`.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35886](https://ledgerhq.atlassian.net/browse/LIVE-35886) — epic [LIVE-29820](https://ledgerhq.atlassian.net/browse/LIVE-29820)

### 📌 Note

Split out of [#21231](https://github.com/LedgerHQ/ledger-live/pull/21231) so it can land on its own — it is independent of the framework staking work there, and of the coin-modules release that PR waits on.

[LIVE-35886]: https://ledgerhq.atlassian.net/browse/LIVE-35886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ