### PR TITLE
[LWDM] feat(pay-card): show crypto card title (LIVE-36567)

### DIFF
--- a/.changeset/calm-cards-title.md
+++ b/.changeset/calm-cards-title.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@features/flow-pay-card": minor
+---
+
+Show a host-provided Crypto card title on the Pay Card web and native views

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/Card/CardView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/Card/CardView.tsx
@@ -13,13 +13,14 @@ export interface CardViewProps {
  * authentication controls.
  */
 export const CardView = ({ viewModel }: CardViewProps) => {
-  const { formatCountervalue, balanceLabel, oauthConfig } = viewModel;
+  const { title, formatCountervalue, balanceLabel, oauthConfig } = viewModel;
 
   return (
     <div className="flex h-full flex-col pb-32">
       <PayCardContainer>
         <div className="p-16">
           <PayCard
+            title={title}
             oauthConfig={oauthConfig}
             formatCountervalue={formatCountervalue}
             balanceLabel={balanceLabel}

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/Card/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/Card/types.ts
@@ -2,6 +2,7 @@ import type { CardProps as PayCardProps } from "@features/flow-pay-card";
 import type { FormattedValue } from "@features/flow-pay-card-details";
 
 export interface CardViewModel {
+  readonly title: string;
   readonly formatCountervalue: (value: number) => FormattedValue;
   readonly balanceLabel: string;
   readonly oauthConfig: PayCardProps["oauthConfig"];

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/Card/useCardViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/Card/useCardViewModel.ts
@@ -32,8 +32,9 @@ export function useCardViewModel(): CardViewModel {
   );
 
   return {
-    formatCountervalue,
+    title: t("payTab.card.title"),
     balanceLabel: t("payTab.card.balanceLabel"),
+    formatCountervalue,
     oauthConfig,
   };
 }

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -902,6 +902,7 @@
       }
     },
     "card": {
+      "title": "Crypto card",
       "balanceLabel": "Balance"
     },
     "contacts": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10091,6 +10091,9 @@
         "confirm": "Confirm"
       }
     },
+    "card": {
+      "title": "Crypto card"
+    },
     "actions": {
       "deposit": "Add stablecoin",
       "request": "Request"

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/PayTabView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/PayTabView.tsx
@@ -14,6 +14,7 @@ import { TrackScreen } from "~/analytics";
 
 type PayTabViewProps = {
   readonly top: number;
+  readonly cardTitle: string;
   readonly oauthConfig: CardProps["oauthConfig"];
   readonly callback: CardProps["callback"];
   readonly featureTour: FeatureTourProps;
@@ -25,6 +26,7 @@ type PayTabViewProps = {
 
 export function PayTabView({
   top,
+  cardTitle,
   oauthConfig,
   callback,
   featureTour,
@@ -40,7 +42,7 @@ export function PayTabView({
         <TrackScreen category="Pay" balance_filter={balance.filter} />
         <Balance {...balance} labels={balanceLabels} actionTiles={actionTiles} />
         <DepositOptions {...depositOptions} />
-        <Card oauthConfig={oauthConfig} callback={callback} />
+        <Card title={cardTitle} oauthConfig={oauthConfig} callback={callback} />
         <FeatureTour {...featureTour} />
       </Box>
     </Box>

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
@@ -86,6 +86,7 @@ export function usePayTabViewModel() {
 
   return {
     top,
+    cardTitle: t("payTab.card.title"),
     oauthConfig,
     callback,
     featureTour,

--- a/features/flow/pay-card/src/Card.native.test.tsx
+++ b/features/flow/pay-card/src/Card.native.test.tsx
@@ -15,6 +15,8 @@ jest.mock("@features/flow-pay-card-details", () => ({
 
 import { Card } from "./Card";
 
+const title = "Crypto card";
+
 const oauthConfig: CardProps["oauthConfig"] = {
   apiUrl: "https://card.example",
   clientId: "client-id",
@@ -31,7 +33,7 @@ const formatCountervalue: CardProps["formatCountervalue"] = (value: number) => (
 
 describe("Card (native)", () => {
   it("composes the bare artwork with the auth login and logout", () => {
-    render(<Card oauthConfig={oauthConfig} />);
+    render(<Card title={title} oauthConfig={oauthConfig} />);
 
     expect(screen.getByTestId("card-artwork")).toBeTruthy();
     expect(screen.getByTestId("card-login")).toBeTruthy();
@@ -41,6 +43,7 @@ describe("Card (native)", () => {
   it("swaps the bare artwork for the card visual once the host provides a formatter and label", () => {
     render(
       <Card
+        title={title}
         oauthConfig={oauthConfig}
         formatCountervalue={formatCountervalue}
         balanceLabel="Balance"

--- a/features/flow/pay-card/src/Card.native.test.tsx
+++ b/features/flow/pay-card/src/Card.native.test.tsx
@@ -35,9 +35,10 @@ describe("Card (native)", () => {
   it("composes the bare artwork with the auth login and logout", () => {
     render(<Card title={title} oauthConfig={oauthConfig} />);
 
-    expect(screen.getByTestId("card-artwork")).toBeTruthy();
-    expect(screen.getByTestId("card-login")).toBeTruthy();
-    expect(screen.getByTestId("card-logout")).toBeTruthy();
+    expect(screen.getByText(title)).toBeVisible();
+    expect(screen.getByTestId("card-artwork")).toBeVisible();
+    expect(screen.getByTestId("card-login")).toBeVisible();
+    expect(screen.getByTestId("card-logout")).toBeVisible();
   });
 
   it("swaps the bare artwork for the card visual once the host provides a formatter and label", () => {
@@ -50,9 +51,9 @@ describe("Card (native)", () => {
       />,
     );
 
-    expect(screen.getByTestId("card-visual")).toBeTruthy();
+    expect(screen.getByTestId("card-visual")).toBeVisible();
     expect(screen.queryByTestId("card-artwork")).toBeNull();
-    expect(screen.getByTestId("card-login")).toBeTruthy();
-    expect(screen.getByTestId("card-logout")).toBeTruthy();
+    expect(screen.getByTestId("card-login")).toBeVisible();
+    expect(screen.getByTestId("card-logout")).toBeVisible();
   });
 });

--- a/features/flow/pay-card/src/Card.types.ts
+++ b/features/flow/pay-card/src/Card.types.ts
@@ -3,6 +3,7 @@ import type { CardVisualProps, FormattedValue } from "@features/flow-pay-card-de
 
 /** Host input for the Pay Card flow. */
 export type CardProps = {
+  readonly title: string;
   readonly oauthConfig: CardLoginOauthConfig;
   /**
    * The OAuth redirect the app already parsed, when it has one. The app's router owns the deep link,
@@ -21,6 +22,7 @@ export type CardProps = {
 
 /** Props the presentational view renders, resolved by {@link useCardViewModel}. */
 export type CardViewProps = {
+  readonly title: string;
   readonly oauthConfig: CardLoginOauthConfig;
   readonly callback?: PayCardAuthCallback | null;
   /** Balance overlay for the card face, or `undefined` to show the bare artwork. */

--- a/features/flow/pay-card/src/Card.web.test.tsx
+++ b/features/flow/pay-card/src/Card.web.test.tsx
@@ -14,6 +14,8 @@ jest.mock("@features/flow-pay-card-details", () => ({
 
 import { Card } from "./Card";
 
+const title = "Crypto card";
+
 const oauthConfig: CardProps["oauthConfig"] = {
   apiUrl: "https://card.example",
   clientId: "client-id",
@@ -29,8 +31,14 @@ const formatCountervalue: CardProps["formatCountervalue"] = (value: number) => (
 });
 
 describe("Card (web)", () => {
+  it("renders the host title", () => {
+    render(<Card title={title} oauthConfig={oauthConfig} />);
+
+    expect(screen.getByText(title)).toBeVisible();
+  });
+
   it("composes the bare artwork with the auth login and logout", () => {
-    render(<Card oauthConfig={oauthConfig} />);
+    render(<Card title={title} oauthConfig={oauthConfig} />);
 
     expect(screen.getByTestId("card-artwork")).toBeVisible();
     expect(screen.getByTestId("card-login")).toBeVisible();
@@ -40,6 +48,7 @@ describe("Card (web)", () => {
   it("swaps the bare artwork for the card visual once the host provides a formatter and label", () => {
     render(
       <Card
+        title={title}
         oauthConfig={oauthConfig}
         formatCountervalue={formatCountervalue}
         balanceLabel="Balance"

--- a/features/flow/pay-card/src/CardView.native.tsx
+++ b/features/flow/pay-card/src/CardView.native.tsx
@@ -1,17 +1,23 @@
 import React from "react";
+import { Subheader, SubheaderRow, SubheaderTitle, Box } from "@ledgerhq/lumen-ui-rnative";
 import { CardLogin, CardLogout } from "@features/flow-pay-card-auth";
 import { CardArtwork, CardVisual } from "@features/flow-pay-card-details";
 import type { CardViewProps } from "./Card.types";
 
-export function CardView({ oauthConfig, callback, cardVisual }: CardViewProps) {
+export function CardView({ title, oauthConfig, callback, cardVisual }: CardViewProps) {
   return (
-    <>
+    <Box lx={{ flex: 1, gap: "s16" }}>
+      <Subheader>
+        <SubheaderRow>
+          <SubheaderTitle>{title}</SubheaderTitle>
+        </SubheaderRow>
+      </Subheader>
       {/* TODO: orchestrate the display state here. These pieces are mutually exclusive: the card
           face shows once the holder is signed in and has a card, while the login shows only while
           nobody is signed in. Right now each child decides on its own, so they can overlap. */}
       {cardVisual ? <CardVisual {...cardVisual} /> : <CardArtwork />}
       <CardLogin oauthConfig={oauthConfig} callback={callback} />
       <CardLogout />
-    </>
+    </Box>
   );
 }

--- a/features/flow/pay-card/src/CardView.web.tsx
+++ b/features/flow/pay-card/src/CardView.web.tsx
@@ -4,9 +4,10 @@ import { CardArtwork, CardVisual } from "@features/flow-pay-card-details";
 import { Divider } from "@ledgerhq/lumen-ui-react";
 import type { CardViewProps } from "./Card.types";
 
-export function CardView({ oauthConfig, callback, cardVisual }: CardViewProps) {
+export function CardView({ title, oauthConfig, callback, cardVisual }: CardViewProps) {
   return (
     <div className="flex flex-col gap-16">
+      <p className="heading-5-semi-bold text-base">{title}</p>
       {/* TODO: orchestrate the display state here. These pieces are mutually exclusive: the card
           face shows once the holder is signed in and has a card, while the login shows only while
           nobody is signed in. Right now each child decides on its own, so they can overlap. */}

--- a/features/flow/pay-card/src/useCardViewModel.ts
+++ b/features/flow/pay-card/src/useCardViewModel.ts
@@ -11,6 +11,7 @@ const MOCK_CARD_BALANCE = 100;
  * card falls back to the bare artwork.
  */
 export function useCardViewModel({
+  title,
   oauthConfig,
   callback,
   formatCountervalue,
@@ -21,5 +22,5 @@ export function useCardViewModel({
     return { balance: MOCK_CARD_BALANCE, formatCountervalue, balanceLabel };
   }, [formatCountervalue, balanceLabel]);
 
-  return { oauthConfig, callback, cardVisual };
+  return { title, oauthConfig, callback, cardVisual };
 }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

The Pay Card block had no heading. This adds a host-provided `title` on `@features/flow-pay-card` and renders **"Crypto card"** above the artwork on desktop (web) and mobile (native).


### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36567](https://ledgerhq.atlassian.net/browse/LIVE-36567) 
- **ADR** (if any): —

[LIVE-36567]: https://ledgerhq.atlassian.net/browse/LIVE-36567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ