### PR TITLE
[LWDM] feat(contacts): inject the EVM address book (DSDK-1457)

### DIFF
--- a/.changeset/tidy-contacts-clear-sign.md
+++ b/.changeset/tidy-contacts-clear-sign.md
@@ -1,0 +1,12 @@
+---
+"@features/platform-contacts": minor
+"@ledgerhq/live-signer-evm": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Provide the EVM address book to the DMK Ethereum signer, so registered contacts can be clear-signed.
+
+`toEvmAddressBook` maps the Contacts state to an `EvmAddressBook` snapshot, keeping EVM-family addresses only. Each app registers it on `evmAddressBookProvider` at its composition root, and `DmkSignerEth` reads it once per instance, so the recipient and the signing account are matched against the same snapshot. Records whose proof material does not decode are dropped, and signing is left untouched when no contact is usable.
+
+Ledger account contacts are not provided yet: the snapshot always carries an empty `ledgerAccounts`.

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -151,6 +151,7 @@
     "@ledgerhq/live-currency-format": "workspace:^",
     "@ledgerhq/live-dmk-desktop": "workspace:^",
     "@ledgerhq/live-dmk-shared": "workspace:^",
+    "@ledgerhq/live-signer-evm": "workspace:^",
     "@ledgerhq/live-dmk-speculos": "workspace:^",
     "@ledgerhq/live-network": "workspace:^",
     "@ledgerhq/live-wallet": "workspace:^",

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -46,6 +46,9 @@ import {
   migrateLegacyCryptoCounterValue,
 } from "~/renderer/reducers/settings";
 import { liveBlindSigningReporter } from "@ledgerhq/live-dmk-shared";
+import { evmAddressBookProvider } from "@ledgerhq/live-signer-evm";
+import { toEvmAddressBook } from "@features/platform-contacts";
+import { selectContacts } from "@domain/entity-contact";
 import ReactRoot from "~/renderer/ReactRoot";
 import AppError from "~/renderer/AppError";
 import { expectOperatingSystemSupportStatus } from "~/support/os";
@@ -182,6 +185,7 @@ async function init() {
   const initialSettings = (await getKey("app", "settings")) || {};
 
   liveBlindSigningReporter.setConsentSource(() => trackingEnabledSelector(store.getState()));
+  evmAddressBookProvider.setSource(() => toEvmAddressBook(selectContacts(store.getState())));
 
   const settingsToLoad = { ...initialSettings };
 

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -174,6 +174,7 @@
     "@ledgerhq/live-currency-format": "workspace:^",
     "@ledgerhq/live-dmk-mobile": "workspace:^",
     "@ledgerhq/live-dmk-shared": "workspace:^",
+    "@ledgerhq/live-signer-evm": "workspace:^",
     "@ledgerhq/live-dmk-speculos": "workspace:^",
     "@ledgerhq/live-engagement": "workspace:^",
     "@ledgerhq/live-hooks": "workspace:^",

--- a/apps/ledger-live-mobile/src/components/EvmAddressBookSetup.tsx
+++ b/apps/ledger-live-mobile/src/components/EvmAddressBookSetup.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from "react";
+import { selectContacts } from "@domain/entity-contact";
+import { toEvmAddressBook } from "@features/platform-contacts";
+import { evmAddressBookProvider } from "@ledgerhq/live-signer-evm";
+import { useStore } from "~/context/hooks";
+
+/**
+ * Lets the DMK Ethereum signer clear-sign registered contacts by giving it a
+ * reader for the address book. The signer lives in a legacy package that cannot
+ * import the Contacts domain, so the wiring belongs here, at the composition
+ * root.
+ */
+const EvmAddressBookSetup = (): null => {
+  const store = useStore();
+
+  useEffect(() => {
+    evmAddressBookProvider.setSource(() => toEvmAddressBook(selectContacts(store.getState())));
+
+    return () => evmAddressBookProvider.clearSource();
+  }, [store]);
+
+  return null;
+};
+
+export default EvmAddressBookSetup;

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -39,6 +39,7 @@ import AnalyticsConsole from "~/components/AnalyticsConsole";
 import DebugTheme from "~/components/DebugTheme";
 import SyncNewAccounts from "~/bridge/SyncNewAccounts";
 import SegmentSetup from "~/analytics/SegmentSetup";
+import EvmAddressBookSetup from "~/components/EvmAddressBookSetup";
 import HookNotifications from "~/notifications/HookNotifications";
 import RootNavigator from "~/components/RootNavigator";
 import SetEnvsFromSettings from "~/components/SetEnvsFromSettings";
@@ -360,6 +361,7 @@ export default class Root extends Component {
             <RebootProvider>
               <SetEnvsFromSettings />
               <SegmentSetup />
+              <EvmAddressBookSetup />
               <HookNotifications />
               <HookDynamicContentCards />
               <HookDevTools />

--- a/features/platform/contacts/package.json
+++ b/features/platform/contacts/package.json
@@ -35,6 +35,7 @@
     "@shared/feature-flags": "workspace:^",
     "@features/platform-device-intent": "workspace:*",
     "@ledgerhq/device-contacts-kit": "catalog:",
+    "@ledgerhq/device-signer-kit-ethereum": "catalog:",
     "rxjs": "catalog:",
     "semver": "catalog:"
   },

--- a/features/platform/contacts/src/device/addressBook/toEvmAddressBook.test.ts
+++ b/features/platform/contacts/src/device/addressBook/toEvmAddressBook.test.ts
@@ -1,0 +1,225 @@
+import {
+  contact,
+  contactAddress,
+  type Contact,
+  type ContactAddressInput,
+  type ContactInput,
+} from "@domain/entity-contact";
+import { toEvmAddressBook } from "./toEvmAddressBook";
+
+const GROUP_HANDLE_HEX = "ab".repeat(64);
+const HMAC_PROOF_HEX = "cd".repeat(32);
+const HMAC_REST_HEX = "ef".repeat(32);
+
+const ADDRESS = "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034";
+
+function evmAddress(overrides: Partial<ContactAddressInput> = {}) {
+  return contactAddress({
+    id: "address-ethereum",
+    currencyId: "ethereum",
+    label: "Ethereum",
+    address: ADDRESS,
+    device: { blockchainFamily: "evm", chainId: 1, hmacRest: HMAC_REST_HEX },
+    ...overrides,
+  });
+}
+
+function evmContact(overrides: Partial<ContactInput> = {}): Contact {
+  return contact({
+    id: "contact-ben",
+    isMe: false,
+    name: "Ben",
+    deviceCredentials: { groupHandle: GROUP_HANDLE_HEX, hmacProof: HMAC_PROOF_HEX },
+    addresses: [evmAddress()],
+    ...overrides,
+  });
+}
+
+describe("toEvmAddressBook", () => {
+  it("maps a contact and its address into a nested snapshot", () => {
+    const book = toEvmAddressBook([evmContact()]);
+
+    expect(book).toEqual({
+      ledgerAccounts: [],
+      contactGroups: [
+        {
+          contactName: "Ben",
+          groupHandle: new Uint8Array(64).fill(0xab),
+          hmacProof: new Uint8Array(32).fill(0xcd),
+          externalAddresses: [
+            {
+              scope: "Ethereum",
+              address: ADDRESS,
+              chainId: 1n,
+              hmacRest: new Uint8Array(32).fill(0xef),
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("uses the address label as the device-side scope", () => {
+    const book = toEvmAddressBook([
+      evmContact({ addresses: [evmAddress({ label: "My Coinbase USDT" })] }),
+    ]);
+
+    expect(book?.contactGroups[0]?.externalAddresses[0]?.scope).toBe("My Coinbase USDT");
+  });
+
+  it("keeps token addresses, reading the chain from the stored device context", () => {
+    const book = toEvmAddressBook([
+      evmContact({
+        addresses: [
+          evmAddress({
+            id: "address-arbitrum-usdc",
+            currencyId: "arbitrum/erc20/usd_coin",
+            label: "USDC",
+            device: { blockchainFamily: "evm", chainId: 42161, hmacRest: HMAC_REST_HEX },
+          }),
+        ],
+      }),
+    ]);
+
+    expect(book?.contactGroups[0]?.externalAddresses[0]?.chainId).toBe(42161n);
+  });
+
+  it("keeps every address of a group across different chains", () => {
+    const book = toEvmAddressBook([
+      evmContact({
+        addresses: [
+          evmAddress({ id: "address-ethereum" }),
+          evmAddress({
+            id: "address-base",
+            currencyId: "base",
+            label: "Base",
+            device: { blockchainFamily: "evm", chainId: 8453, hmacRest: HMAC_REST_HEX },
+          }),
+        ],
+      }),
+    ]);
+
+    expect(book?.contactGroups).toHaveLength(1);
+    expect(book?.contactGroups[0]?.externalAddresses.map(address => address.chainId)).toEqual([
+      1n,
+      8453n,
+    ]);
+  });
+
+  it("maps the Me contact like any other group", () => {
+    const book = toEvmAddressBook([
+      contact({
+        id: "contact-me",
+        isMe: true,
+        name: "Me",
+        deviceCredentials: { groupHandle: GROUP_HANDLE_HEX, hmacProof: HMAC_PROOF_HEX },
+        addresses: [evmAddress()],
+      }),
+    ]);
+
+    expect(book?.contactGroups[0]?.contactName).toBe("Me");
+  });
+
+  it("accepts uppercase hex proof material", () => {
+    const book = toEvmAddressBook([
+      evmContact({
+        deviceCredentials: {
+          groupHandle: GROUP_HANDLE_HEX.toUpperCase(),
+          hmacProof: HMAC_PROOF_HEX.toUpperCase(),
+        },
+      }),
+    ]);
+
+    expect(book?.contactGroups[0]?.groupHandle).toEqual(new Uint8Array(64).fill(0xab));
+  });
+
+  it("drops addresses from another blockchain family", () => {
+    const book = toEvmAddressBook([
+      evmContact({
+        addresses: [
+          evmAddress({
+            currencyId: "tron",
+            label: "Tron",
+            device: { blockchainFamily: "tron", chainId: 195, hmacRest: HMAC_REST_HEX },
+          }),
+        ],
+      }),
+    ]);
+
+    expect(book).toBeUndefined();
+  });
+
+  it("drops a contact that has no address", () => {
+    expect(toEvmAddressBook([evmContact({ addresses: [] })])).toBeUndefined();
+  });
+
+  it.each([
+    ["a non-hex group handle", { groupHandle: "mock-contact-group-handle" }],
+    ["a non-hex name proof", { hmacProof: "mock-external-contact-name-proof" }],
+    ["an odd-length group handle", { groupHandle: "abc" }],
+  ])("drops a group with %s", (_label, credentials) => {
+    const book = toEvmAddressBook([
+      evmContact({
+        deviceCredentials: {
+          groupHandle: GROUP_HANDLE_HEX,
+          hmacProof: HMAC_PROOF_HEX,
+          ...credentials,
+        },
+      }),
+    ]);
+
+    expect(book).toBeUndefined();
+  });
+
+  it.each([
+    ["a non-hex address proof", { hmacRest: "mock-external-address-proof" }],
+    ["an unparsable chain id", { chainId: "mock-chain-id" }],
+    ["a zero chain id", { chainId: 0 }],
+  ])("drops an address with %s", (_label, device) => {
+    const book = toEvmAddressBook([
+      evmContact({
+        addresses: [
+          evmAddress({
+            device: { blockchainFamily: "evm", chainId: 1, hmacRest: HMAC_REST_HEX, ...device },
+          }),
+        ],
+      }),
+    ]);
+
+    expect(book).toBeUndefined();
+  });
+
+  it.each([
+    ["is not 0x-prefixed", "1ad23b2cf8d2e0591ea417eb82f7cd9746c53034"],
+    ["is too short", "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c530"],
+    ["is not hexadecimal", "0xZad23b2cf8d2e0591ea417eb82f7cd9746c53034"],
+  ])("drops an address that %s", (_label, address) => {
+    expect(
+      toEvmAddressBook([evmContact({ addresses: [evmAddress({ address })] })]),
+    ).toBeUndefined();
+  });
+
+  it("keeps the valid addresses of a group and drops only the broken ones", () => {
+    const book = toEvmAddressBook([
+      evmContact({
+        addresses: [
+          evmAddress({
+            id: "address-broken",
+            device: { blockchainFamily: "evm", chainId: 1, hmacRest: "not-hex" },
+          }),
+          evmAddress({ id: "address-ethereum" }),
+        ],
+      }),
+    ]);
+
+    expect(book?.contactGroups[0]?.externalAddresses).toHaveLength(1);
+  });
+
+  it("returns undefined for an empty contact list", () => {
+    expect(toEvmAddressBook([])).toBeUndefined();
+  });
+
+  it("never emits Ledger account contacts", () => {
+    expect(toEvmAddressBook([evmContact()])?.ledgerAccounts).toEqual([]);
+  });
+});

--- a/features/platform/contacts/src/device/addressBook/toEvmAddressBook.ts
+++ b/features/platform/contacts/src/device/addressBook/toEvmAddressBook.ts
@@ -1,0 +1,91 @@
+import type { Contact, ContactAddress } from "@domain/entity-contact";
+import type {
+  EvmAddressBook,
+  EvmContactGroup,
+  EvmExternalAddress,
+} from "@ledgerhq/device-signer-kit-ethereum";
+
+/**
+ * Contacts persist `currency.family` in their device context. Only this family
+ * belongs in an EVM address book; Tron and any later family are filtered out
+ * here so the signer's matching never needs a family discriminator.
+ */
+const EVM_BLOCKCHAIN_FAMILY = "evm";
+
+const HEX_PATTERN = /^[0-9a-f]+$/;
+const EVM_ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/;
+
+/**
+ * Build the EVM address-book snapshot the Ethereum signer clear-signs against.
+ *
+ * Every record is validated on the way through and silently dropped when it
+ * does not decode: proof material is opaque to Ledger Wallet, so a malformed or
+ * still-unregistered entry must cost the user a contact name, never a
+ * signature. Returns `undefined` when nothing survives, letting the caller skip
+ * `withAddressBook` entirely and leave signing untouched.
+ */
+export function toEvmAddressBook(contacts: readonly Contact[]): EvmAddressBook | undefined {
+  const contactGroups = contacts.flatMap(toEvmContactGroup);
+
+  return contactGroups.length === 0 ? undefined : { contactGroups, ledgerAccounts: [] };
+}
+
+function toEvmContactGroup(contact: Contact): EvmContactGroup[] {
+  const credentials = contact.deviceCredentials;
+  if (credentials === undefined) return [];
+
+  const groupHandle = hexToBytes(credentials.groupHandle);
+  const hmacProof = hexToBytes(credentials.hmacProof);
+  if (groupHandle === null || hmacProof === null) return [];
+
+  const externalAddresses = contact.addresses.flatMap(toEvmExternalAddress);
+  if (externalAddresses.length === 0) return [];
+
+  return [{ contactName: contact.name, groupHandle, hmacProof, externalAddresses }];
+}
+
+function toEvmExternalAddress(address: ContactAddress): EvmExternalAddress[] {
+  const { blockchainFamily, chainId, hmacRest } = address.device;
+  if (blockchainFamily !== EVM_BLOCKCHAIN_FAMILY) return [];
+
+  const proof = hexToBytes(hmacRest);
+  const parsedChainId = toChainId(chainId);
+  if (proof === null || parsedChainId === null || !isEvmAddress(address.address)) return [];
+
+  return [
+    {
+      // The address label is what was registered as the device-side scope.
+      scope: address.label,
+      address: address.address,
+      chainId: parsedChainId,
+      hmacRest: proof,
+    },
+  ];
+}
+
+function isEvmAddress(value: string): value is `0x${string}` {
+  return EVM_ADDRESS_PATTERN.test(value);
+}
+
+function toChainId(value: string | number): bigint | null {
+  try {
+    const chainId = BigInt(value);
+    return chainId > 0n ? chainId : null;
+  } catch {
+    return null;
+  }
+}
+
+function hexToBytes(value: string): Uint8Array | null {
+  const normalized = value.toLowerCase();
+  if (normalized.length === 0 || normalized.length % 2 !== 0 || !HEX_PATTERN.test(normalized)) {
+    return null;
+  }
+
+  const bytes = new Uint8Array(normalized.length / 2);
+  for (let index = 0; index < bytes.length; index++) {
+    bytes[index] = Number.parseInt(normalized.slice(index * 2, index * 2 + 2), 16);
+  }
+
+  return bytes;
+}

--- a/features/platform/contacts/src/index.native.ts
+++ b/features/platform/contacts/src/index.native.ts
@@ -8,6 +8,7 @@ export * from "./featureFlags";
 export * from "./utils/resolveEligibleAddressCurrencyIds";
 export * from "./components/ContactAvatar/index.native";
 export * from "./contactDeviceIntentsPort";
+export * from "./device/addressBook/toEvmAddressBook";
 export * from "./addressEntry/types";
 export * from "./addressEntry/validation";
 export * from "./addressEntry/state";

--- a/features/platform/contacts/src/index.ts
+++ b/features/platform/contacts/src/index.ts
@@ -5,6 +5,7 @@ export * from "./hooks/useContactsMeContact";
 export * from "./utils/formatMeDisplayName";
 export * from "./utils/resolveMeContactDisplayName";
 export * from "./contactDeviceIntentsPort";
+export * from "./device/addressBook/toEvmAddressBook";
 export * from "./featureFlags";
 export * from "./utils/resolveEligibleAddressCurrencyIds";
 export * from "./components/ContactAvatar";

--- a/libs/live-signer-evm/src/DmkSignerEth.ts
+++ b/libs/live-signer-evm/src/DmkSignerEth.ts
@@ -27,6 +27,7 @@ import {
   buildDefaultHttpBlindSigningReporter,
   liveBlindSigningReporter,
 } from "@ledgerhq/live-dmk-shared";
+import { evmAddressBookProvider } from "./addressBook/evmAddressBookProvider";
 
 export type DAError =
   | GetAddressDAError
@@ -62,13 +63,20 @@ export class DmkSignerEth implements EvmSigner {
       .setChain(ContextModuleChainID.Ethereum)
       .setCalConfig({ url: `${calUrl}/v1`, mode: calMode, branch: "main" })
       .build();
-    this.signer = new SignerEthBuilder({
+    const builder = new SignerEthBuilder({
       dmk,
       sessionId,
       originToken,
-    })
-      .withContextModule(contextModule)
-      .build();
+    }).withContextModule(contextModule);
+
+    // Snapshot the address book for this signer's lifetime, so the recipient
+    // and the signing account are matched against the same contacts.
+    const addressBook = evmAddressBookProvider.getAddressBook();
+    if (addressBook !== undefined) {
+      builder.withAddressBook(addressBook);
+    }
+
+    this.signer = builder.build();
   }
 
   private _mapError<E extends DAError>(error: E): Error {

--- a/libs/live-signer-evm/src/addressBook/evmAddressBookProvider.ts
+++ b/libs/live-signer-evm/src/addressBook/evmAddressBookProvider.ts
@@ -1,0 +1,53 @@
+import type { EvmAddressBook } from "@ledgerhq/device-signer-kit-ethereum";
+
+export type EvmAddressBookSource = () => EvmAddressBook | undefined;
+
+/**
+ * Injection seam for the EVM address book the Ethereum signer clear-signs
+ * against.
+ *
+ * Building the snapshot needs the Contacts domain, which this legacy package
+ * must not import, so the app composition root registers a source instead. It
+ * is a thunk because the store does not exist when this module loads.
+ *
+ * The signer calls it once per instance: within one signing flow the recipient
+ * and the signing account are matched against the same snapshot.
+ */
+export class EvmAddressBookProvider {
+  private static _instance: EvmAddressBookProvider | null = null;
+
+  private source: EvmAddressBookSource | null = null;
+
+  private constructor() {}
+
+  static getInstance(): EvmAddressBookProvider {
+    if (!EvmAddressBookProvider._instance) {
+      EvmAddressBookProvider._instance = new EvmAddressBookProvider();
+    }
+    return EvmAddressBookProvider._instance;
+  }
+
+  setSource(source: EvmAddressBookSource) {
+    this.source = source;
+  }
+
+  clearSource() {
+    this.source = null;
+  }
+
+  /**
+   * Never throws: a host that registered no source, or whose source fails,
+   * must lose contact names rather than the ability to sign.
+   */
+  getAddressBook(): EvmAddressBook | undefined {
+    if (!this.source) return undefined;
+
+    try {
+      return this.source();
+    } catch {
+      return undefined;
+    }
+  }
+}
+
+export const evmAddressBookProvider = EvmAddressBookProvider.getInstance();

--- a/libs/live-signer-evm/src/index.ts
+++ b/libs/live-signer-evm/src/index.ts
@@ -2,3 +2,4 @@ export * from "./DmkSignerEth";
 export * from "./LegacySignerEth";
 export * from "./errors";
 export * from "./types";
+export * from "./addressBook/evmAddressBookProvider";

--- a/libs/live-signer-evm/tests/DmkSignerEth.test.ts
+++ b/libs/live-signer-evm/tests/DmkSignerEth.test.ts
@@ -2,7 +2,8 @@ import { DeviceActionStatus, DeviceManagementKit } from "@ledgerhq/device-manage
 import { EIP712Message } from "@ledgerhq/types-live";
 import { lastValueFrom, of } from "rxjs";
 import { DmkSignerEth } from "../src/DmkSignerEth";
-import { SignTransactionDAStep } from "@ledgerhq/device-signer-kit-ethereum";
+import { SignerEthBuilder, SignTransactionDAStep } from "@ledgerhq/device-signer-kit-ethereum";
+import { evmAddressBookProvider } from "../src/addressBook/evmAddressBookProvider";
 import { getEnv } from "@ledgerhq/live-env";
 import { ContextModuleBuilder } from "@ledgerhq/context-module";
 
@@ -676,6 +677,64 @@ describe("DmkSignerEth", () => {
         mode: "test",
         branch: "main",
       });
+    });
+  });
+  describe("address book", () => {
+    const addressBook = {
+      ledgerAccounts: [],
+      contactGroups: [
+        {
+          contactName: "Ben",
+          groupHandle: new Uint8Array(64).fill(0xab),
+          hmacProof: new Uint8Array(32).fill(0xcd),
+          externalAddresses: [],
+        },
+      ],
+    };
+    let withAddressBookSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      withAddressBookSpy = jest.spyOn(SignerEthBuilder.prototype, "withAddressBook");
+    });
+
+    afterEach(() => {
+      withAddressBookSpy.mockRestore();
+      evmAddressBookProvider.clearSource();
+    });
+
+    it("does not provide an address book when no source is registered", () => {
+      new DmkSignerEth(dmkMock as unknown as DeviceManagementKit, "sessionId");
+
+      expect(withAddressBookSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not provide an address book when the source has nothing to give", () => {
+      evmAddressBookProvider.setSource(() => undefined);
+
+      new DmkSignerEth(dmkMock as unknown as DeviceManagementKit, "sessionId");
+
+      expect(withAddressBookSpy).not.toHaveBeenCalled();
+    });
+
+    it("keeps building the signer when the source throws", () => {
+      evmAddressBookProvider.setSource(() => {
+        throw new Error("store is not ready");
+      });
+
+      const signer = new DmkSignerEth(dmkMock as unknown as DeviceManagementKit, "sessionId");
+
+      expect(signer.signer).toBeDefined();
+      expect(withAddressBookSpy).not.toHaveBeenCalled();
+    });
+
+    it("reads the source once and hands the snapshot to the builder", () => {
+      const source = jest.fn(() => addressBook);
+      evmAddressBookProvider.setSource(source);
+
+      new DmkSignerEth(dmkMock as unknown as DeviceManagementKit, "sessionId");
+
+      expect(source).toHaveBeenCalledTimes(1);
+      expect(withAddressBookSpy).toHaveBeenCalledWith(addressBook);
     });
   });
 });

--- a/libs/live-signer-evm/tests/evmAddressBookProvider.test.ts
+++ b/libs/live-signer-evm/tests/evmAddressBookProvider.test.ts
@@ -1,0 +1,45 @@
+import type { EvmAddressBook } from "@ledgerhq/device-signer-kit-ethereum";
+import { evmAddressBookProvider } from "../src/addressBook/evmAddressBookProvider";
+
+const addressBook: EvmAddressBook = { contactGroups: [], ledgerAccounts: [] };
+
+describe("evmAddressBookProvider", () => {
+  afterEach(() => {
+    evmAddressBookProvider.clearSource();
+  });
+
+  it("has no address book until a host registers a source", () => {
+    expect(evmAddressBookProvider.getAddressBook()).toBeUndefined();
+  });
+
+  it("reads the registered source on every call", () => {
+    const source = jest.fn(() => addressBook);
+    evmAddressBookProvider.setSource(source);
+
+    expect(evmAddressBookProvider.getAddressBook()).toBe(addressBook);
+    expect(evmAddressBookProvider.getAddressBook()).toBe(addressBook);
+    expect(source).toHaveBeenCalledTimes(2);
+  });
+
+  it("replaces a previously registered source", () => {
+    evmAddressBookProvider.setSource(() => addressBook);
+    evmAddressBookProvider.setSource(() => undefined);
+
+    expect(evmAddressBookProvider.getAddressBook()).toBeUndefined();
+  });
+
+  it("degrades to no address book when the source throws, so signing is never broken", () => {
+    evmAddressBookProvider.setSource(() => {
+      throw new Error("contacts slice is not mounted");
+    });
+
+    expect(evmAddressBookProvider.getAddressBook()).toBeUndefined();
+  });
+
+  it("stops reading a cleared source", () => {
+    evmAddressBookProvider.setSource(() => addressBook);
+    evmAddressBookProvider.clearSource();
+
+    expect(evmAddressBookProvider.getAddressBook()).toBeUndefined();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1088,6 +1088,9 @@ importers:
       '@ledgerhq/live-network':
         specifier: workspace:^
         version: link:../../libs/live-network
+      '@ledgerhq/live-signer-evm':
+        specifier: workspace:^
+        version: link:../../libs/live-signer-evm
       '@ledgerhq/live-wallet':
         specifier: workspace:^
         version: link:../../libs/live-wallet
@@ -1939,6 +1942,9 @@ importers:
       '@ledgerhq/live-network':
         specifier: workspace:^
         version: link:../../libs/live-network
+      '@ledgerhq/live-signer-evm':
+        specifier: workspace:^
+        version: link:../../libs/live-signer-evm
       '@ledgerhq/live-wallet':
         specifier: workspace:^
         version: link:../../libs/live-wallet
@@ -7402,6 +7408,9 @@ importers:
       '@ledgerhq/device-contacts-kit':
         specifier: 'catalog:'
         version: 0.2.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+      '@ledgerhq/device-signer-kit-ethereum':
+        specifier: 'catalog:'
+        version: 1.17.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
       '@shared/feature-flags':
         specifier: workspace:^
         version: link:../../../shared/feature-flags
@@ -49110,6 +49119,20 @@ snapshots:
   '@ledgerhq/device-signer-kit-ethereum@1.17.0(@ledgerhq/context-module@2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))':
     dependencies:
       '@ledgerhq/context-module': 2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+      '@ledgerhq/device-management-kit': 1.8.0(rxjs@7.8.2)
+      '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+      ethers: 6.15.0
+      inversify: 7.5.1(reflect-metadata@0.2.2)
+      purify-ts: 2.1.0
+      reflect-metadata: 0.2.2
+      semver: 7.7.2
+      xstate: 5.19.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@ledgerhq/device-signer-kit-ethereum@1.17.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))':
+    dependencies:
       '@ledgerhq/device-management-kit': 1.8.0(rxjs@7.8.2)
       '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
       ethers: 6.15.0


### PR DESCRIPTION
### 📝 Description

This is the host side of [DSDK-1386](https://ledgerhq.atlassian.net/browse/DSDK-1386). It builds the EVM address book from the Contacts state and gives it to the DMK Ethereum signer. The signer can then clear-sign registered contacts once it matches them ([DSDK-1387](https://ledgerhq.atlassian.net/browse/DSDK-1387) and [DSDK-1388](https://ledgerhq.atlassian.net/browse/DSDK-1388)).

**How the parts connect**

`createSigner(transport)` builds `DmkSignerEth` in `libs/ledger-live-common/src/families/evm/{signer,setup}.ts`. This factory has no access to the store. It also sits in a legacy package that must not import the Contacts domain. Thus the work is split along the layer boundary:

| Part | Package | Reason |
| --- | --- | --- |
| `toEvmAddressBook(contacts)` | `@features/platform-contacts` | It owns the Contacts knowledge and can depend on `@domain/entity-contact`. |
| `evmAddressBookProvider` | `@ledgerhq/live-signer-evm` | It is only an injection seam, typed against `EvmAddressBook`. |
| The wiring | Desktop `init.tsx`, Mobile `EvmAddressBookSetup` | *"Inject private new-architecture packages into published legacy packages at the app composition root."* |

This structure copies the `liveBlindSigningReporter.setConsentSource(...)` pattern that is already in the same constructor. `lint:structure` and `lint:boundaries` pass, thus no legacy package imports a feature package.

The source is a function because the store does not exist when the module loads. `DmkSignerEth` calls the function one time for each instance and gives the result to `withAddressBook`. Thus the signer matches the recipient and the signing account against the same address book.

**Out of scope**

- Ledger account contacts. `ledgerAccounts` is always empty. Ledger Wallet has no data source for it today. `LedgerAccountNameProof` is unused, and account names are a plain `Map<accountId, string>`. The Ledger-account intents connect to no port or persistence. This needs its own ticket before DSDK-1388 can land on the host side.
- The `blockchainFamily` value. The mapper keeps addresses whose family is `"evm"`, which is the value that Ledger Wallet stores. The kit knows the names `bitcoin`, `ethereum`, `solana`, `polkadot`, `cosmos` and `cardano`. DSDK-1457 tracks this difference. This pull request does not depend on it, because `EvmAddressBook` carries no family value.
- Seed binding. `getExpectedSignerId()` is still a mock port and `ContactSchema` has no field for it. Thus the snapshot cannot be limited to the connected seed.

Registration is still a stub. Thus every stored proof is a placeholder today, and the address book stays empty until real registration lands.

**Dependencies**

This pull request changed no dependency version. An earlier revision pinned all 16 DMK dependencies to the snapshot `0.0.0-dsdk-1386-20260827153633`, because `withAddressBook` was not released yet. `@ledgerhq/device-signer-kit-ethereum@1.17.0` contains it and is already the catalog version on `develop`, thus the branch is rebased and every pin is removed.

The only lockfile change is the three new dependency edges that this pull request adds: `@ledgerhq/live-signer-evm` for each app, and the catalog reference to `@ledgerhq/device-signer-kit-ethereum` for `@features/platform-contacts`. `pnpm-workspace.yaml` and `libs/live-signer-zcash/package.json` match `develop` byte for byte.

**Verification**

- `toEvmAddressBook`: 20 unit tests. They cover the EVM filter, token `currencyId` values, groups with several chains, and the "Me" contact.
- `DmkSignerEth`: 4 new tests, with the 46 tests that already exist.
- `evmAddressBookProvider`: 5 unit tests.
- `typecheck` passes for Ledger Live Desktop and Ledger Live Mobile against the released signer.
- `@ledgerhq/live-signer-evm` builds against `device-signer-kit-ethereum@1.17.0`, thus `withAddressBook` resolves.
- `lint:structure`, `lint:boundaries`, `oxfmt`, `gitleaks` and `commitlint` pass.

I did no manual test on a device. End-to-end clear signing needs the ContactsManager registration, which is still a stub.

### 🔗 Context

- **JIRA / GitHub issue**: [DSDK-1457](https://ledgerhq.atlassian.net/browse/DSDK-1457). [DSDK-1386](https://ledgerhq.atlassian.net/browse/DSDK-1386) blocked it ([device-sdk-ts#1805](https://github.com/LedgerHQ/device-sdk-ts/pull/1805)); that work is released in `device-signer-kit-ethereum@1.17.0`, thus nothing blocks this pull request now.
- **ADR** (if any): —


[DSDK-1386]: https://ledgerhq.atlassian.net/browse/DSDK-1386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DSDK-1387]: https://ledgerhq.atlassian.net/browse/DSDK-1387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DSDK-1388]: https://ledgerhq.atlassian.net/browse/DSDK-1388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DSDK-1457]: https://ledgerhq.atlassian.net/browse/DSDK-1457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
