### PR TITLE
[LWDM] feat(perps): sign desktop deposits through the exchange swap flow

### DIFF
--- a/.changeset/perps-deposit-signing.md
+++ b/.changeset/perps-deposit-signing.md
@@ -3,4 +3,4 @@
 "@ledgerhq/live-common": minor
 ---
 
-Add the Perps deposit signing step on desktop, reached from the review screen. It runs on the same swap orchestration as the `custom.exchange.swap` handler — now extracted into a shared `executeSwap` — behind the perps screens, and executes against the quote the review priced against.
+Add the Perps deposit signing step on desktop, reached from the review screen. It runs on the same swap orchestration as the `custom.exchange.swap` handler — now extracted into a shared `executeSwap` — behind the perps screens, and executes against the quote the review priced against. Declining a device prompt returns to the review with the entered amount intact, rather than raising an error screen.

--- a/.changeset/perps-deposit-signing.md
+++ b/.changeset/perps-deposit-signing.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Add the Perps deposit signing step on desktop and mobile, reached from the review screen. It runs on the same swap orchestration as the `custom.exchange.swap` handler — now extracted into a shared `executeSwap` — behind the perps screens, and executes against the quote the review priced against.

--- a/.changeset/perps-deposit-signing.md
+++ b/.changeset/perps-deposit-signing.md
@@ -1,7 +1,6 @@
 ---
 "ledger-live-desktop": minor
-"live-mobile": minor
 "@ledgerhq/live-common": minor
 ---
 
-Add the Perps deposit signing step on desktop and mobile, reached from the review screen. It runs on the same swap orchestration as the `custom.exchange.swap` handler — now extracted into a shared `executeSwap` — behind the perps screens, and executes against the quote the review priced against.
+Add the Perps deposit signing step on desktop, reached from the review screen. It runs on the same swap orchestration as the `custom.exchange.swap` handler — now extracted into a shared `executeSwap` — behind the perps screens, and executes against the quote the review priced against.

--- a/apps/ledger-live-desktop/src/mvvm/features/GlobalDialogs/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GlobalDialogs/index.tsx
@@ -8,7 +8,12 @@ const PerpsSignRoot = lazy(() => import("LLD/features/Perps/screens/PerpsSign/Pe
 const PerpsDepositRoot = lazy(
   () => import("LLD/features/Perps/screens/PerpsDeposit/PerpsDepositDialog"),
 );
-const PerpsReviewRoot = lazy(() => import("LLD/features/Perps/screens/PerpsReview/PerpsReviewDialog"));
+const PerpsReviewRoot = lazy(
+  () => import("LLD/features/Perps/screens/PerpsReview/PerpsReviewDialog"),
+);
+const PerpsDepositSignRoot = lazy(
+  () => import("LLD/features/Perps/screens/PerpsDepositSign/PerpsDepositSignDialog"),
+);
 const ReleaseNotes = lazy(() => import("LLD/features/ReleaseNotes"));
 const BuyDevice = lazy(() => import("LLD/features/BuyDevice"));
 const FinishOnboardingDialog = lazy(
@@ -38,6 +43,9 @@ const GlobalDialogs = () => (
     </Suspense>
     <Suspense fallback={null}>
       <PerpsReviewRoot />
+    </Suspense>
+    <Suspense fallback={null}>
+      <PerpsDepositSignRoot />
     </Suspense>
     <ActionConfirmationDialog />
     <Suspense fallback={null}>

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/__tests__/usePerpsDepositExecution.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/__tests__/usePerpsDepositExecution.test.ts
@@ -142,10 +142,7 @@ describe("usePerpsDepositExecution", () => {
     });
 
     // Nonce: the Exchange app opens and returns a device transaction id.
-    expect(result.current.deviceStep).toMatchObject({
-      stepId: "start",
-      isPerpsConfirmation: false,
-    });
+    expect(result.current.deviceStep).toMatchObject({ stepId: "start" });
     await answerDeviceStep(result.current.deviceStep, {
       startExchangeResult: { nonce: "nonce-1", device: { modelId: "stax" } },
     });
@@ -153,15 +150,12 @@ describe("usePerpsDepositExecution", () => {
 
     // Confirm, sign, broadcast: the perps confirmation screen only shows on the
     // Exchange app's payload check.
-    expect(result.current.deviceStep).toMatchObject({
-      stepId: "confirm",
-      isPerpsConfirmation: true,
-    });
+    expect(result.current.deviceStep).toMatchObject({ stepId: "confirm" });
     await answerDeviceStep(result.current.deviceStep, {
       completeExchangeResult: { family: "ethereum" },
     });
 
-    expect(result.current.deviceStep).toMatchObject({ stepId: "sign", isPerpsConfirmation: false });
+    expect(result.current.deviceStep).toMatchObject({ stepId: "sign" });
     await answerDeviceStep(result.current.deviceStep, { signedOperation: { operation } });
 
     expect(mockBroadcast).toHaveBeenCalledWith({ operation });

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/__tests__/usePerpsDepositExecution.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/__tests__/usePerpsDepositExecution.test.ts
@@ -1,0 +1,201 @@
+import BigNumber from "bignumber.js";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import type { AccountLike } from "@ledgerhq/types-live";
+import { act, renderHook } from "tests/testSetup";
+import { usePerpsDepositExecution, type PerpsDepositDeviceStep } from "../usePerpsDepositExecution";
+
+const mockExecuteSwap = jest.fn();
+jest.mock("@ledgerhq/live-common/wallet-api/Exchange/executeSwap", () => ({
+  executeSwap: (deps: unknown, params: unknown) => mockExecuteSwap(deps, params),
+}));
+
+const mockBroadcast = jest.fn();
+jest.mock("@ledgerhq/live-common/hooks/useBroadcast", () => ({
+  useBroadcast: () => mockBroadcast,
+}));
+
+jest.mock("~/renderer/hooks/useConnectAppAction", () => ({
+  useStartExchangeAction: () => "start-action",
+  useTransactionAction: () => "sign-action",
+}));
+
+jest.mock("@ledgerhq/live-common/hw/actions/completeExchange", () => ({
+  createAction: () => "complete-action",
+}));
+
+jest.mock("@ledgerhq/live-common/exchange/platform/completeExchange", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+// The account updater needs a full swap exchange to build its updaters; the
+// deposit only cares that the broadcast reached the signed dialog.
+jest.mock("@ledgerhq/live-common/exchange/swap/getUpdateAccountWithUpdaterParams", () => ({
+  getUpdateAccountWithUpdaterParams: () => [],
+}));
+
+function createAccount(id: string, currencyId: string): AccountLike {
+  return {
+    type: "Account",
+    id,
+    currency: getCryptoCurrencyById(currencyId),
+    spendableBalance: new BigNumber(0),
+    balance: new BigNumber(0),
+  } as AccountLike;
+}
+
+const depositAccount = createAccount("funding-1", "ethereum");
+const receiverAccount = createAccount("receiver-1", "ethereum");
+
+const params = {
+  depositAccount,
+  receiverAccount,
+  amountSent: "0.02",
+  amountTo: "0.019",
+  quoteId: "quote-1",
+};
+
+const swapUiRequest = {
+  provider: "swapkit_hyperliquid",
+  transaction: { family: "ethereum" },
+  binaryPayload: "payload",
+  signature: "signature",
+  exchange: { fromAccount: depositAccount, toAccount: receiverAccount },
+  swapId: "swap-1",
+  magnitudeAwareRate: new BigNumber(1),
+};
+
+const operation = { id: "operation-1", hash: "0xhash" };
+
+/** Answers the device action the hook is currently waiting on. */
+function answerDeviceStep(deviceStep: PerpsDepositDeviceStep, result: unknown) {
+  if (deviceStep.kind !== "device")
+    throw new Error(`expected a device step, got ${deviceStep.kind}`);
+  return act(async () => {
+    deviceStep.withDeviceAction(binding => binding.onResult(result as never));
+  });
+}
+
+function renderExecution(onDone = jest.fn()) {
+  const { result } = renderHook(() => usePerpsDepositExecution(params, onDone));
+  return { result, onDone };
+}
+
+describe("usePerpsDepositExecution", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockBroadcast.mockResolvedValue(operation);
+  });
+
+  it("quotes the deposit as a swap against the perps provider, at the price the review showed", async () => {
+    mockExecuteSwap.mockResolvedValue({ operationHash: operation.hash, swapId: "swap-1" });
+    const { result } = renderExecution();
+
+    await act(async () => {
+      await result.current.executeDeposit();
+    });
+
+    expect(mockExecuteSwap).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        exchangeType: "SWAP",
+        provider: "swapkit_hyperliquid",
+        fromAmount: "0.02",
+        fromAmountAtomic: new BigNumber("20000000000000000"),
+        quoteId: "quote-1",
+        feeStrategy: "medium",
+      }),
+    );
+  });
+
+  it("drives every device step and hands off to the signed dialog", async () => {
+    const onStartSuccess = jest.fn();
+    const onSwapSuccess = jest.fn();
+    mockExecuteSwap.mockImplementation(async deps => {
+      const nonce = await new Promise<string>((resolve, reject) =>
+        deps.uiHooks["custom.exchange.start"]({
+          exchangeParams: { exchangeType: "SWAP", provider: "swapkit_hyperliquid", exchange: {} },
+          onSuccess: (...args: unknown[]) => {
+            onStartSuccess(...args);
+            resolve(args[0] as string);
+          },
+          onCancel: reject,
+        }),
+      );
+      expect(nonce).toBe("nonce-1");
+
+      await new Promise<void>((resolve, reject) =>
+        deps.uiHooks["custom.exchange.swap"]({
+          exchangeParams: swapUiRequest,
+          onSuccess: (...args: unknown[]) => {
+            onSwapSuccess(...args);
+            resolve();
+          },
+          onCancel: reject,
+        }),
+      );
+    });
+
+    const { result, onDone } = renderExecution();
+    act(() => {
+      void result.current.executeDeposit();
+    });
+
+    // Nonce: the Exchange app opens and returns a device transaction id.
+    expect(result.current.deviceStep).toMatchObject({
+      stepId: "start",
+      isPerpsConfirmation: false,
+    });
+    await answerDeviceStep(result.current.deviceStep, {
+      startExchangeResult: { nonce: "nonce-1", device: { modelId: "stax" } },
+    });
+    expect(onStartSuccess).toHaveBeenCalledWith("nonce-1", { modelId: "stax" });
+
+    // Confirm, sign, broadcast: the perps confirmation screen only shows on the
+    // Exchange app's payload check.
+    expect(result.current.deviceStep).toMatchObject({
+      stepId: "confirm",
+      isPerpsConfirmation: true,
+    });
+    await answerDeviceStep(result.current.deviceStep, {
+      completeExchangeResult: { family: "ethereum" },
+    });
+
+    expect(result.current.deviceStep).toMatchObject({ stepId: "sign", isPerpsConfirmation: false });
+    await answerDeviceStep(result.current.deviceStep, { signedOperation: { operation } });
+
+    expect(mockBroadcast).toHaveBeenCalledWith({ operation });
+    expect(onSwapSuccess).toHaveBeenCalledWith({ operationHash: "0xhash", swapId: "swap-1" });
+    expect(onDone).toHaveBeenCalled();
+  });
+
+  it("surfaces a refused signature instead of spinning", async () => {
+    mockExecuteSwap.mockImplementation(async (deps, _params) => {
+      await new Promise<void>((resolve, reject) => {
+        deps.uiHooks["custom.exchange.swap"]({
+          exchangeParams: swapUiRequest,
+          onSuccess: () => resolve(),
+          onCancel: reject,
+        });
+      });
+    });
+
+    const { result, onDone } = renderExecution();
+    act(() => {
+      void result.current.executeDeposit();
+    });
+
+    await answerDeviceStep(result.current.deviceStep, {
+      completeExchangeResult: { family: "ethereum" },
+    });
+    await answerDeviceStep(result.current.deviceStep, {
+      transactionSignError: new Error("refused on device"),
+    });
+
+    expect(result.current.deviceStep).toEqual({
+      kind: "error",
+      error: new Error("refused on device"),
+    });
+    expect(onDone).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/__tests__/usePerpsDepositExecution.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/__tests__/usePerpsDepositExecution.test.ts
@@ -1,6 +1,6 @@
 import BigNumber from "bignumber.js";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
-import type { AccountLike } from "@ledgerhq/types-live";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { act, renderHook } from "tests/testSetup";
 import { usePerpsDepositExecution, type PerpsDepositDeviceStep } from "../usePerpsDepositExecution";
 
@@ -34,18 +34,9 @@ jest.mock("@ledgerhq/live-common/exchange/swap/getUpdateAccountWithUpdaterParams
   getUpdateAccountWithUpdaterParams: () => [],
 }));
 
-function createAccount(id: string, currencyId: string): AccountLike {
-  return {
-    type: "Account",
-    id,
-    currency: getCryptoCurrencyById(currencyId),
-    spendableBalance: new BigNumber(0),
-    balance: new BigNumber(0),
-  } as AccountLike;
-}
-
-const depositAccount = createAccount("funding-1", "ethereum");
-const receiverAccount = createAccount("receiver-1", "ethereum");
+const ethereum = getCryptoCurrencyById("ethereum");
+const depositAccount = genAccount("funding-1", { currency: ethereum, operationsSize: 0 });
+const receiverAccount = genAccount("receiver-1", { currency: ethereum, operationsSize: 0 });
 
 const params = {
   depositAccount,

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/__tests__/usePerpsDepositExecution.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/__tests__/usePerpsDepositExecution.test.ts
@@ -76,9 +76,36 @@ function answerDeviceStep(deviceStep: PerpsDepositDeviceStep, result: unknown) {
   });
 }
 
-function renderExecution(onDone = jest.fn()) {
-  const { result } = renderHook(() => usePerpsDepositExecution(params, onDone));
-  return { result, onDone };
+function renderExecution() {
+  const onDone = jest.fn();
+  const onRefused = jest.fn();
+  const { result } = renderHook(() => usePerpsDepositExecution(params, { onDone, onRefused }));
+  return { result, onDone, onRefused };
+}
+
+/** Runs the deposit up to the coin-app signature and answers it with `signResult`. */
+async function signWith(signResult: unknown) {
+  mockExecuteSwap.mockImplementation(async deps => {
+    await new Promise<void>((resolve, reject) => {
+      deps.uiHooks["custom.exchange.swap"]({
+        exchangeParams: swapUiRequest,
+        onSuccess: () => resolve(),
+        onCancel: reject,
+      });
+    });
+  });
+
+  const execution = renderExecution();
+  act(() => {
+    void execution.result.current.executeDeposit();
+  });
+
+  await answerDeviceStep(execution.result.current.deviceStep, {
+    completeExchangeResult: { family: "ethereum" },
+  });
+  await answerDeviceStep(execution.result.current.deviceStep, signResult);
+
+  return execution;
 }
 
 describe("usePerpsDepositExecution", () => {
@@ -163,33 +190,42 @@ describe("usePerpsDepositExecution", () => {
     expect(onDone).toHaveBeenCalled();
   });
 
-  it("surfaces a refused signature instead of spinning", async () => {
-    mockExecuteSwap.mockImplementation(async (deps, _params) => {
-      await new Promise<void>((resolve, reject) => {
-        deps.uiHooks["custom.exchange.swap"]({
-          exchangeParams: swapUiRequest,
-          onSuccess: () => resolve(),
-          onCancel: reject,
-        });
-      });
-    });
-
-    const { result, onDone } = renderExecution();
-    act(() => {
-      void result.current.executeDeposit();
-    });
-
-    await answerDeviceStep(result.current.deviceStep, {
-      completeExchangeResult: { family: "ethereum" },
-    });
-    await answerDeviceStep(result.current.deviceStep, {
-      transactionSignError: new Error("refused on device"),
+  it("surfaces a failed signature instead of spinning", async () => {
+    const { result, onDone, onRefused } = await signWith({
+      transactionSignError: new Error("signature failed"),
     });
 
     expect(result.current.deviceStep).toEqual({
       kind: "error",
-      error: new Error("refused on device"),
+      error: new Error("signature failed"),
     });
+    expect(onDone).not.toHaveBeenCalled();
+    expect(onRefused).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      "the coin app prompt",
+      Object.assign(new Error("refused"), { name: "TransactionRefusedOnDevice" }),
+    ],
+    [
+      "a signer naming it itself",
+      Object.assign(new Error("refused"), { name: "UserRefusedOnDevice" }),
+    ],
+    [
+      "the Exchange app's own error",
+      Object.assign(new Error("User refused"), {
+        name: "CompleteExchangeError",
+        title: "userRefused",
+      }),
+    ],
+  ])("reports a decline reported by %s rather than an error", async (_case, error) => {
+    const { result, onDone, onRefused } = await signWith({ transactionSignError: error });
+
+    // Declining is a decision: the caller sends the holder back to the summary,
+    // so no error screen is raised here.
+    expect(onRefused).toHaveBeenCalled();
+    expect(result.current.deviceStep).toEqual({ kind: "processing" });
     expect(onDone).not.toHaveBeenCalled();
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/usePerpsDepositExecution.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/usePerpsDepositExecution.ts
@@ -1,0 +1,314 @@
+import { useCallback, useMemo, useState } from "react";
+import BigNumber from "bignumber.js";
+import type { SignedOperation } from "@ledgerhq/types-live";
+import {
+  addPendingOperation,
+  getAccountCurrency,
+  getMainAccount,
+  getParentAccount,
+} from "@ledgerhq/live-common/account/index";
+import { parseCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import { getUpdateAccountWithUpdaterParams } from "@ledgerhq/live-common/exchange/swap/getUpdateAccountWithUpdaterParams";
+import type { ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
+import { ExchangeType } from "@ledgerhq/live-common/wallet-api/react";
+import { executeSwap } from "@ledgerhq/live-common/wallet-api/Exchange/executeSwap";
+import trackingWrapper from "@ledgerhq/live-common/wallet-api/Exchange/tracking";
+import type { SwapUiRequest } from "@ledgerhq/live-common/wallet-api/Exchange/server";
+import {
+  getWalletApiIdFromAccountId,
+  setWalletApiIdForAccountId,
+} from "@ledgerhq/live-common/wallet-api/converters";
+import { PERPS_DEPOSIT_QUOTE_PROVIDER } from "@ledgerhq/live-common/wallet-api/Perps/depositQuote";
+import type { PerpsDepositReviewParams } from "@ledgerhq/live-common/wallet-api/Perps/server";
+import { createAction as createCompleteExchangeAction } from "@ledgerhq/live-common/hw/actions/completeExchange";
+import type { Action } from "@ledgerhq/live-common/hw/actions/types";
+import completeExchange from "@ledgerhq/live-common/exchange/platform/completeExchange";
+import { useBroadcast } from "@ledgerhq/live-common/hooks/useBroadcast";
+import type { Result as StartExchangeResult } from "@ledgerhq/live-common/hw/actions/startExchange";
+import type { Result as CompleteExchangeResult } from "@ledgerhq/live-common/hw/actions/completeExchange";
+import { useFeatureFlags } from "@features/platform-feature-flags";
+import type { Feature, FeatureId } from "@shared/feature-flags";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
+import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
+import { shallowAccountsSelector } from "~/renderer/reducers/accounts";
+import { mevProtectionSelector } from "~/renderer/reducers/settings";
+import { useStartExchangeAction, useTransactionAction } from "~/renderer/hooks/useConnectAppAction";
+import type { States } from "~/renderer/components/DeviceAction";
+import { broadcastLogger } from "~/datadog/logs";
+import { track } from "~/renderer/analytics/segment";
+
+type StartResult = StartExchangeResult;
+type CompleteResult = CompleteExchangeResult;
+type SignResult = { signedOperation: SignedOperation } | { transactionSignError: Error };
+
+export type PerpsDepositDeviceStep =
+  | { kind: "processing" }
+  | { kind: "error"; error: Error }
+  | {
+      kind: "device";
+      stepId: "start" | "confirm" | "sign";
+      isPerpsConfirmation: boolean;
+      withDeviceAction: <T>(
+        render: <R, H extends States, P>(binding: {
+          action: Action<R, H, P>;
+          request: R;
+          onResult: (result: P) => void;
+        }) => T,
+      ) => T;
+    };
+
+type PerpsDepositDevicePhase = Extract<PerpsDepositDeviceStep, { kind: "device" }>;
+
+const PROCESSING_STEP: PerpsDepositDeviceStep = { kind: "processing" };
+
+export type PerpsDepositExecution = Readonly<{
+  deviceStep: PerpsDepositDeviceStep;
+  executeDeposit: () => Promise<void>;
+  retry: () => void;
+}>;
+
+const EXCHANGE_APP_NAME = "Exchange";
+const FEE_STRATEGY = "medium";
+
+/** The swap orchestration's analytics sink, pointed at the perps flow. */
+const tracking = trackingWrapper((eventName, properties, mandatory) =>
+  track(eventName, { ...properties, flowInitiatedFrom: "Perps" }, mandatory),
+);
+
+/**
+ * Drives a perps deposit through the shared swap orchestration, rendering each
+ * device step in the perps signing dialog rather than the live-app drawer.
+ *
+ * The sequence itself — nonce, provider payload, funding transaction — belongs to
+ * `executeSwap`; this hook only supplies the screens and the app-state updates
+ * that follow the broadcast.
+ */
+export function usePerpsDepositExecution(
+  params: PerpsDepositReviewParams,
+  onDone: () => void,
+): PerpsDepositExecution {
+  const [deviceStep, setDeviceStep] = useState<PerpsDepositDeviceStep>(PROCESSING_STEP);
+
+  const dispatch = useDispatch();
+  const accounts = useSelector(shallowAccountsSelector);
+  const mevProtected = useSelector(mevProtectionSelector);
+
+  const featureFlagsMap = useFeatureFlags();
+  const getFeature = useCallback(
+    (id: FeatureId): Feature | null => featureFlagsMap[id] ?? null,
+    [featureFlagsMap],
+  );
+
+  const startAction = useStartExchangeAction();
+  const signAction = useTransactionAction();
+  const completeAction = useMemo(() => createCompleteExchangeAction(completeExchange), []);
+
+  const { depositAccount, receiverAccount, amountSent, quoteId } = params;
+  const fromParentAccount = useMemo(
+    () => getParentAccount(depositAccount, accounts),
+    [depositAccount, accounts],
+  );
+
+  const broadcastConfig = useMemo(
+    () => ({ mevProtected, source: { type: "swap" as const, name: "perps-deposit" } }),
+    [mevProtected],
+  );
+  const broadcast = useBroadcast({
+    account: depositAccount,
+    parentAccount: fromParentAccount,
+    broadcastConfig,
+    logger: broadcastLogger,
+  });
+
+  const runDeviceStep = useCallback(
+    <R>(build: (onResult: (result: R) => void) => PerpsDepositDevicePhase): Promise<R> =>
+      new Promise<R>(resolve => setDeviceStep(build(resolve))).finally(() =>
+        setDeviceStep(PROCESSING_STEP),
+      ),
+    [],
+  );
+
+  /**
+   * Confirms the provider payload on the Exchange app, signs the funding
+   * transaction with the coin app, then broadcasts it.
+   */
+  const confirmSignAndBroadcast = useCallback(
+    async (exchangeParams: SwapUiRequest) => {
+      const completeResult = await runDeviceStep<CompleteResult>(onResult => ({
+        kind: "device",
+        stepId: "confirm",
+        isPerpsConfirmation: true,
+        withDeviceAction: render =>
+          render({
+            action: completeAction,
+            request: {
+              provider: exchangeParams.provider ?? PERPS_DEPOSIT_QUOTE_PROVIDER,
+              transaction: exchangeParams.transaction,
+              binaryPayload: exchangeParams.binaryPayload,
+              signature: exchangeParams.signature,
+              exchange: exchangeParams.exchange,
+              exchangeType: ExchangeType.SWAP,
+            },
+            onResult,
+          }),
+      }));
+      if ("completeExchangeError" in completeResult) {
+        throw completeResult.completeExchangeError;
+      }
+      const finalTransaction = completeResult.completeExchangeResult;
+
+      const tokenCurrency =
+        depositAccount.type === "TokenAccount" ? depositAccount.token : undefined;
+      const signResult = await runDeviceStep<SignResult>(onResult => ({
+        kind: "device",
+        stepId: "sign",
+        isPerpsConfirmation: false,
+        withDeviceAction: render =>
+          render({
+            action: signAction,
+            request: {
+              tokenCurrency,
+              parentAccount: fromParentAccount,
+              account: depositAccount,
+              transaction: finalTransaction,
+              appName: EXCHANGE_APP_NAME,
+            },
+            onResult,
+          }),
+      }));
+      if ("transactionSignError" in signResult) {
+        throw signResult.transactionSignError;
+      }
+
+      const operation = await broadcast(signResult.signedOperation);
+
+      const swapId = exchangeParams.swapId;
+      if (swapId) {
+        const updateParams = getUpdateAccountWithUpdaterParams({
+          result: { operation, swapId },
+          exchange: exchangeParams.exchange as ExchangeSwap,
+          transaction: finalTransaction,
+          magnitudeAwareRate: exchangeParams.magnitudeAwareRate ?? new BigNumber(0),
+          provider: PERPS_DEPOSIT_QUOTE_PROVIDER,
+        });
+        if (updateParams.length) {
+          dispatch(updateAccountWithUpdater(...updateParams));
+        }
+      } else {
+        const mainFromAccount = getMainAccount(depositAccount, fromParentAccount);
+        dispatch(
+          updateAccountWithUpdater(mainFromAccount.id, account =>
+            addPendingOperation(account, operation),
+          ),
+        );
+      }
+
+      return { operation, swapId };
+    },
+    [
+      broadcast,
+      completeAction,
+      depositAccount,
+      dispatch,
+      fromParentAccount,
+      runDeviceStep,
+      signAction,
+    ],
+  );
+
+  const executeDeposit = useCallback(async () => {
+    try {
+      // Reset to the loading state on every run (including retry after an error).
+      setDeviceStep(PROCESSING_STEP);
+
+      // `executeSwap` resolves both accounts by their wallet-api id.
+      setWalletApiIdForAccountId(depositAccount.id);
+      setWalletApiIdForAccountId(receiverAccount.id);
+
+      const depositCurrency = getAccountCurrency(depositAccount);
+
+      let signed: Awaited<ReturnType<typeof confirmSignAndBroadcast>> | undefined;
+
+      await executeSwap(
+        {
+          accounts,
+          tracking,
+          getFeature,
+          uiHooks: {
+            "custom.exchange.start": ({ exchangeParams, onSuccess, onCancel }) => {
+              void runDeviceStep<StartResult>(onResult => ({
+                kind: "device",
+                stepId: "start",
+                isPerpsConfirmation: false,
+                withDeviceAction: render =>
+                  render({
+                    action: startAction,
+                    request: {
+                      ...exchangeParams,
+                      exchangeType: ExchangeType[exchangeParams.exchangeType],
+                    },
+                    onResult,
+                  }),
+              })).then(result =>
+                "startExchangeError" in result
+                  ? onCancel(result.startExchangeError.error)
+                  : onSuccess(result.startExchangeResult.nonce, result.startExchangeResult.device),
+              );
+            },
+            "custom.exchange.swap": ({ exchangeParams, onSuccess, onCancel }) => {
+              void confirmSignAndBroadcast(exchangeParams).then(result => {
+                signed = result;
+                onSuccess({ operationHash: result.operation.hash, swapId: result.swapId ?? "" });
+              }, onCancel);
+            },
+            // The signing dialog renders errors itself, so there is no separate
+            // error screen to open — reject and let the catch below take over.
+            "custom.exchange.error": ({ onCancel }) => onCancel(),
+          },
+        },
+        {
+          exchangeType: "SWAP",
+          provider: PERPS_DEPOSIT_QUOTE_PROVIDER,
+          fromAccountId: getWalletApiIdFromAccountId(depositAccount.id),
+          toAccountId: getWalletApiIdFromAccountId(receiverAccount.id),
+          fromAmount: amountSent,
+          fromAmountAtomic: parseCurrencyUnit(depositCurrency.units[0], amountSent),
+          quoteId,
+          feeStrategy: FEE_STRATEGY,
+        },
+      );
+
+      if (!signed) return;
+
+      onDone();
+    } catch (e) {
+      // Device connection errors (lock / disconnect / wrong app) are rendered and
+      // retried in-place by <DeviceAction>, so they never reach here. What lands
+      // here is a result-variant error it delegates to us — a user cancel/refusal
+      // or a business failure — so we surface it (with retry) instead of spinning.
+      setDeviceStep({ kind: "error", error: e instanceof Error ? e : new Error(String(e)) });
+    }
+  }, [
+    accounts,
+    amountSent,
+    confirmSignAndBroadcast,
+    depositAccount,
+    fromParentAccount,
+    getFeature,
+    onDone,
+    quoteId,
+    receiverAccount,
+    runDeviceStep,
+    startAction,
+  ]);
+
+  const retry = useCallback(() => {
+    void executeDeposit();
+  }, [executeDeposit]);
+
+  return {
+    deviceStep,
+    executeDeposit,
+    retry,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/usePerpsDepositExecution.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/usePerpsDepositExecution.ts
@@ -47,7 +47,6 @@ export type PerpsDepositDeviceStep =
   | {
       kind: "device";
       stepId: "start" | "confirm" | "sign";
-      isPerpsConfirmation: boolean;
       withDeviceAction: <T>(
         render: <R, H extends States, P>(binding: {
           action: Action<R, H, P>;
@@ -137,7 +136,6 @@ export function usePerpsDepositExecution(
       const completeResult = await runDeviceStep<CompleteResult>(onResult => ({
         kind: "device",
         stepId: "confirm",
-        isPerpsConfirmation: true,
         withDeviceAction: render =>
           render({
             action: completeAction,
@@ -162,7 +160,6 @@ export function usePerpsDepositExecution(
       const signResult = await runDeviceStep<SignResult>(onResult => ({
         kind: "device",
         stepId: "sign",
-        isPerpsConfirmation: false,
         withDeviceAction: render =>
           render({
             action: signAction,
@@ -239,7 +236,6 @@ export function usePerpsDepositExecution(
               void runDeviceStep<StartResult>(onResult => ({
                 kind: "device",
                 stepId: "start",
-                isPerpsConfirmation: false,
                 withDeviceAction: render =>
                   render({
                     action: startAction,

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/usePerpsDepositExecution.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/usePerpsDepositExecution.ts
@@ -31,6 +31,7 @@ import { useStartExchangeAction, useTransactionAction } from "~/renderer/hooks/u
 import type { States } from "~/renderer/components/DeviceAction";
 import { broadcastLogger } from "~/datadog/logs";
 import { track } from "~/renderer/analytics/segment";
+import { isUserRefusal } from "../utils/isUserRefusal";
 
 type StartResult = StartExchangeResult;
 type CompleteResult = CompleteExchangeResult;
@@ -61,6 +62,11 @@ export type PerpsDepositExecution = Readonly<{
   retry: () => void;
 }>;
 
+export type PerpsDepositExecutionCallbacks = Readonly<{
+  onDone: () => void;
+  onRefused: () => void;
+}>;
+
 const EXCHANGE_APP_NAME = "Exchange";
 const FEE_STRATEGY = "medium";
 
@@ -70,16 +76,12 @@ const tracking = trackingWrapper((eventName, properties, mandatory) =>
 );
 
 /**
- * Drives a perps deposit through the shared swap orchestration, rendering each
- * device step in the perps signing dialog rather than the live-app drawer.
- *
- * The sequence itself — nonce, provider payload, funding transaction — belongs to
- * `executeSwap`; this hook only supplies the screens and the app-state updates
- * that follow the broadcast.
+ * Runs a perps deposit through `executeSwap`, which owns the sequence, and
+ * renders its device steps in the perps dialog rather than the live-app drawer.
  */
 export function usePerpsDepositExecution(
   params: PerpsDepositReviewParams,
-  onDone: () => void,
+  { onDone, onRefused }: PerpsDepositExecutionCallbacks,
 ): PerpsDepositExecution {
   const [deviceStep, setDeviceStep] = useState<PerpsDepositDeviceStep>(PROCESSING_STEP);
 
@@ -266,10 +268,10 @@ export function usePerpsDepositExecution(
 
       onDone();
     } catch (e) {
-      // Device connection errors (lock / disconnect / wrong app) are rendered and
-      // retried in-place by <DeviceAction>, so they never reach here. What lands
-      // here is a result-variant error it delegates to us — a user cancel/refusal
-      // or a business failure — so we surface it (with retry) instead of spinning.
+      if (isUserRefusal(e)) {
+        onRefused();
+        return;
+      }
       setDeviceStep({ kind: "error", error: e instanceof Error ? e : new Error(String(e)) });
     }
   }, [
@@ -279,6 +281,7 @@ export function usePerpsDepositExecution(
     depositAccount,
     getFeature,
     onDone,
+    onRefused,
     quoteId,
     receiverAccount,
     runDeviceStep,

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/usePerpsDepositExecution.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/usePerpsDepositExecution.ts
@@ -1,12 +1,7 @@
 import { useCallback, useMemo, useState } from "react";
 import BigNumber from "bignumber.js";
 import type { SignedOperation } from "@ledgerhq/types-live";
-import {
-  addPendingOperation,
-  getAccountCurrency,
-  getMainAccount,
-  getParentAccount,
-} from "@ledgerhq/live-common/account/index";
+import { getAccountCurrency, getParentAccount } from "@ledgerhq/live-common/account/index";
 import { parseCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { getUpdateAccountWithUpdaterParams } from "@ledgerhq/live-common/exchange/swap/getUpdateAccountWithUpdaterParams";
 import type { ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
@@ -191,13 +186,6 @@ export function usePerpsDepositExecution(
         if (updateParams.length) {
           dispatch(updateAccountWithUpdater(...updateParams));
         }
-      } else {
-        const mainFromAccount = getMainAccount(depositAccount, fromParentAccount);
-        dispatch(
-          updateAccountWithUpdater(mainFromAccount.id, account =>
-            addPendingOperation(account, operation),
-          ),
-        );
       }
 
       return { operation, swapId };
@@ -289,7 +277,6 @@ export function usePerpsDepositExecution(
     amountSent,
     confirmSignAndBroadcast,
     depositAccount,
-    fromParentAccount,
     getFeature,
     onDone,
     quoteId,

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/PerpsDepositSignDialog.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/PerpsDepositSignDialog.tsx
@@ -1,0 +1,62 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { Dialog, DialogContent } from "@ledgerhq/lumen-ui-react";
+import {
+  usePerpsDepositSignViewModel,
+  type PerpsDepositSignData,
+} from "./usePerpsDepositSignViewModel";
+import { PerpsDepositSignView } from "./PerpsDepositSignView";
+
+let _opener: ((data: PerpsDepositSignData) => void) | null = null;
+
+function registerPerpsDepositSignOpener(fn: (data: PerpsDepositSignData) => void): () => void {
+  _opener = fn;
+  return () => {
+    _opener = null;
+  };
+}
+
+export function openPerpsDepositSign(data: PerpsDepositSignData) {
+  _opener?.(data);
+}
+
+function PerpsDepositSignBody({
+  data,
+  onClose,
+}: Readonly<{ data: PerpsDepositSignData; onClose: () => void }>) {
+  const viewModel = usePerpsDepositSignViewModel(data, onClose);
+  return <PerpsDepositSignView {...viewModel} />;
+}
+
+function PerpsDepositSignInnerDialog({
+  data,
+  onClose,
+}: Readonly<{ data: PerpsDepositSignData | null; onClose: () => void }>) {
+  const isOpen = data !== null;
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) onClose();
+    },
+    [onClose],
+  );
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent
+        onInteractOutside={e => e.preventDefault()}
+        onEscapeKeyDown={e => e.preventDefault()}
+      >
+        {data ? <PerpsDepositSignBody data={data} onClose={onClose} /> : null}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default function PerpsDepositSignRoot() {
+  const [data, setData] = useState<PerpsDepositSignData | null>(null);
+  const close = useCallback(() => setData(null), []);
+
+  useEffect(() => registerPerpsDepositSignOpener(setData), []);
+
+  return <PerpsDepositSignInnerDialog data={data} onClose={close} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/PerpsDepositSignView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/PerpsDepositSignView.tsx
@@ -9,7 +9,11 @@ import type { PerpsDepositSignViewModel } from "./usePerpsDepositSignViewModel";
 
 type PerpsDepositSignViewProps = Readonly<PerpsDepositSignViewModel>;
 
-export function PerpsDepositSignView({ deviceStep, retry }: PerpsDepositSignViewProps) {
+export function PerpsDepositSignView({
+  deviceStep,
+  retry,
+  onDeviceError,
+}: PerpsDepositSignViewProps) {
   const { t } = useTranslation();
 
   if (deviceStep.kind === "error")
@@ -28,6 +32,7 @@ export function PerpsDepositSignView({ deviceStep, retry }: PerpsDepositSignView
             action={action}
             request={request}
             onResult={onResult}
+            onError={onDeviceError}
             renderExchangeConfirmation={
               deviceStep.stepId === "confirm" ? () => <PerpsDepositConfirmation /> : undefined
             }

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/PerpsDepositSignView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/PerpsDepositSignView.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { Title as DialogTitle } from "@radix-ui/react-dialog";
+import { useTranslation } from "react-i18next";
+import { DialogBody } from "@ledgerhq/lumen-ui-react";
+import DeviceAction from "~/renderer/components/DeviceAction";
+import { renderError, renderLoading } from "~/renderer/components/DeviceAction/rendering";
+import type { PerpsDepositSignViewModel } from "./usePerpsDepositSignViewModel";
+
+type PerpsDepositSignViewProps = Readonly<PerpsDepositSignViewModel>;
+
+export function PerpsDepositSignView({ deviceStep, retry }: PerpsDepositSignViewProps) {
+  const { t } = useTranslation();
+
+  // A result-variant error (user cancel / refusal / business failure) that
+  // <DeviceAction> hands back to us — show its own error screen, with retry.
+  if (deviceStep.kind === "error")
+    return renderError({ error: deviceStep.error, t, onRetry: retry });
+
+  // Off-device phases (quote / payload fetch / broadcast) have no device action to
+  // render, so we show <DeviceAction>'s own loader for a consistent look.
+  if (deviceStep.kind !== "device") return renderLoading();
+
+  return (
+    <>
+      <DialogTitle className="sr-only">{t("perpsDepositSign.a11yTitle")}</DialogTitle>
+
+      <DialogBody>
+        <div className="flex w-full flex-col items-center gap-24 px-16 pb-24 pt-24">
+          {deviceStep.withDeviceAction(({ action, request, onResult }) => (
+            <DeviceAction
+              key={deviceStep.stepId}
+              action={action}
+              request={request}
+              onResult={onResult}
+              isPerpsConfirmation={deviceStep.isPerpsConfirmation}
+            />
+          ))}
+        </div>
+      </DialogBody>
+    </>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/PerpsDepositSignView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/PerpsDepositSignView.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { DialogBody } from "@ledgerhq/lumen-ui-react";
 import DeviceAction from "~/renderer/components/DeviceAction";
 import { renderError, renderLoading } from "~/renderer/components/DeviceAction/rendering";
+import { PerpsDepositConfirmation } from "./components/PerpsDepositConfirmation";
 import type { PerpsDepositSignViewModel } from "./usePerpsDepositSignViewModel";
 
 type PerpsDepositSignViewProps = Readonly<PerpsDepositSignViewModel>;
@@ -11,31 +12,27 @@ type PerpsDepositSignViewProps = Readonly<PerpsDepositSignViewModel>;
 export function PerpsDepositSignView({ deviceStep, retry }: PerpsDepositSignViewProps) {
   const { t } = useTranslation();
 
-  // A result-variant error (user cancel / refusal / business failure) that
-  // <DeviceAction> hands back to us — show its own error screen, with retry.
   if (deviceStep.kind === "error")
     return renderError({ error: deviceStep.error, t, onRetry: retry });
 
-  // Off-device phases (quote / payload fetch / broadcast) have no device action to
-  // render, so we show <DeviceAction>'s own loader for a consistent look.
   if (deviceStep.kind !== "device") return renderLoading();
 
   return (
     <>
       <DialogTitle className="sr-only">{t("perpsDepositSign.a11yTitle")}</DialogTitle>
 
-      <DialogBody>
-        <div className="flex w-full flex-col items-center gap-24 px-16 pb-24 pt-24">
-          {deviceStep.withDeviceAction(({ action, request, onResult }) => (
-            <DeviceAction
-              key={deviceStep.stepId}
-              action={action}
-              request={request}
-              onResult={onResult}
-              isPerpsConfirmation={deviceStep.isPerpsConfirmation}
-            />
-          ))}
-        </div>
+      <DialogBody className="flex w-full flex-col items-center gap-24 px-16 pb-24 pt-24">
+        {deviceStep.withDeviceAction(({ action, request, onResult }) => (
+          <DeviceAction
+            key={deviceStep.stepId}
+            action={action}
+            request={request}
+            onResult={onResult}
+            renderExchangeConfirmation={
+              deviceStep.stepId === "confirm" ? () => <PerpsDepositConfirmation /> : undefined
+            }
+          />
+        ))}
       </DialogBody>
     </>
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/__integrations__/perpsDepositSign.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/__integrations__/perpsDepositSign.integration.test.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { act, render, screen } from "tests/testSetup";
+import PerpsDepositSignRoot, { openPerpsDepositSign } from "../PerpsDepositSignDialog";
+import type { PerpsDepositSignData } from "../usePerpsDepositSignViewModel";
+
+const mockExecuteSwap = jest.fn();
+jest.mock("@ledgerhq/live-common/wallet-api/Exchange/executeSwap", () => ({
+  executeSwap: (deps: unknown, params: unknown) => mockExecuteSwap(deps, params),
+}));
+
+const mockOpenPerpsReview = jest.fn();
+jest.mock("../../PerpsReview/PerpsReviewDialog", () => ({
+  openPerpsReview: (data: unknown) => mockOpenPerpsReview(data),
+}));
+
+const ethereum = getCryptoCurrencyById("ethereum");
+const depositAccount = genAccount("funding-1", { currency: ethereum, operationsSize: 0 });
+const receiverAccount = genAccount("receiver-1", { currency: ethereum, operationsSize: 0 });
+
+const signData: PerpsDepositSignData = {
+  depositAccount,
+  receiverAccount,
+  amountSent: "0.02",
+  amountTo: "0.019",
+  quoteId: "quote-1",
+  draft: { depositAccount, depositAmount: 20 },
+};
+
+/** A deposit that has begun and is waiting on the first device prompt. */
+const pendingSwap = () => new Promise<void>(() => {});
+
+describe("PerpsDepositSign integration", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockExecuteSwap.mockImplementation(pendingSwap);
+  });
+
+  it("should not render the signing dialog until a deposit is handed over", () => {
+    render(<PerpsDepositSignRoot />);
+
+    expect(screen.queryByTestId("device-action-loader")).not.toBeInTheDocument();
+    expect(mockExecuteSwap).not.toHaveBeenCalled();
+  });
+
+  it("should start the deposit and wait on it once opened", () => {
+    render(<PerpsDepositSignRoot />);
+
+    act(() => openPerpsDepositSign(signData));
+
+    // Nothing is asked of the holder yet, so the dialog holds a spinner.
+    expect(screen.getByTestId("device-action-loader")).toBeVisible();
+    expect(mockExecuteSwap).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ quoteId: "quote-1", fromAmount: "0.02" }),
+    );
+  });
+
+  it("should title the dialog for screen readers once a device prompt is reached", () => {
+    mockExecuteSwap.mockImplementation(deps => {
+      deps.uiHooks["custom.exchange.start"]({
+        exchangeParams: { exchangeType: "SWAP" },
+        onSuccess: jest.fn(),
+        onCancel: jest.fn(),
+      });
+      return pendingSwap();
+    });
+    render(<PerpsDepositSignRoot />);
+
+    act(() => openPerpsDepositSign(signData));
+
+    expect(screen.getByRole("dialog", { name: "Deposit signing" })).toBeVisible();
+    expect(screen.queryByTestId("device-action-loader")).not.toBeInTheDocument();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/__tests__/usePerpsDepositSignViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/__tests__/usePerpsDepositSignViewModel.test.ts
@@ -1,0 +1,95 @@
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { renderHook } from "tests/testSetup";
+import type { PerpsDepositExecutionCallbacks } from "LLD/features/Perps/hooks/usePerpsDepositExecution";
+import {
+  usePerpsDepositSignViewModel,
+  type PerpsDepositSignData,
+} from "../usePerpsDepositSignViewModel";
+
+const mockOpenPerpsReview = jest.fn();
+jest.mock("../../PerpsReview/PerpsReviewDialog", () => ({
+  openPerpsReview: (data: unknown) => mockOpenPerpsReview(data),
+}));
+
+let capturedCallbacks: PerpsDepositExecutionCallbacks | undefined;
+const mockExecuteDeposit = jest.fn();
+jest.mock("LLD/features/Perps/hooks/usePerpsDepositExecution", () => ({
+  usePerpsDepositExecution: (_params: unknown, callbacks: PerpsDepositExecutionCallbacks) => {
+    capturedCallbacks = callbacks;
+    return {
+      deviceStep: { kind: "processing" },
+      executeDeposit: mockExecuteDeposit,
+      retry: jest.fn(),
+    };
+  },
+}));
+
+const ethereum = getCryptoCurrencyById("ethereum");
+const depositAccount = genAccount("funding-1", { currency: ethereum, operationsSize: 0 });
+const receiverAccount = genAccount("receiver-1", { currency: ethereum, operationsSize: 0 });
+
+const data: PerpsDepositSignData = {
+  depositAccount,
+  receiverAccount,
+  amountSent: "0.02",
+  amountTo: "0.019",
+  quoteId: "quote-1",
+  draft: { depositAccount, depositAmount: 20 },
+};
+
+describe("usePerpsDepositSignViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedCallbacks = undefined;
+  });
+
+  it("should start the deposit as soon as the dialog opens", () => {
+    renderHook(() => usePerpsDepositSignViewModel(data, jest.fn()));
+
+    expect(mockExecuteDeposit).toHaveBeenCalledTimes(1);
+  });
+
+  it("should reopen the review, draft and all, when the deposit is declined on the device", () => {
+    const onClose = jest.fn();
+    renderHook(() => usePerpsDepositSignViewModel(data, onClose));
+
+    capturedCallbacks?.onRefused();
+
+    // The summary comes back exactly as it was left, so the amount survives the decline.
+    expect(mockOpenPerpsReview).toHaveBeenCalledWith(data);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("should reopen the review when the manager prompt is declined, which fails the connection", () => {
+    const onClose = jest.fn();
+    const { result } = renderHook(() => usePerpsDepositSignViewModel(data, onClose));
+
+    result.current.onDeviceError(
+      Object.assign(new Error("refused"), { name: "UserRefusedAllowManager" }),
+    );
+
+    expect(mockOpenPerpsReview).toHaveBeenCalledWith(data);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("should leave a connection failure to the device action, which retries in place", () => {
+    const onClose = jest.fn();
+    const { result } = renderHook(() => usePerpsDepositSignViewModel(data, onClose));
+
+    result.current.onDeviceError(new Error("device is locked"));
+
+    expect(mockOpenPerpsReview).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("should close without reopening the review once the deposit goes through", () => {
+    const onClose = jest.fn();
+    renderHook(() => usePerpsDepositSignViewModel(data, onClose));
+
+    capturedCallbacks?.onDone();
+
+    expect(onClose).toHaveBeenCalled();
+    expect(mockOpenPerpsReview).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/components/PerpsDepositConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/components/PerpsDepositConfirmation.tsx
@@ -5,13 +5,7 @@ import { getCurrentDevice } from "~/renderer/reducers/devices";
 import { ContinueOnDevice } from "LLD/components/DeviceIntentExecutor/components/DeviceGenericStates/ContinueOnDevice";
 import { PerpsDepositSignTerms } from "./PerpsDepositSignTerms";
 
-/**
- * The single "continue on your device" screen for the perps deposit: the on-device
- * prompt plus the SwapKit terms. Rendered both between device steps (the flow's
- * fallback) and as the completeExchange confirmation (via <DeviceAction>), so the
- * terms always travel with this screen instead of living in the view.
- */
-export function PerpsDepositContinueOnDevice() {
+export function PerpsDepositConfirmation() {
   const device = useSelector(getCurrentDevice);
   const deviceModelId = device?.modelId ?? DeviceModelId.stax;
   const deviceName = device?.deviceName || getProductName(deviceModelId);

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/components/PerpsDepositContinueOnDevice.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/components/PerpsDepositContinueOnDevice.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { DeviceModelId, getProductName } from "@ledgerhq/devices";
+import { useSelector } from "LLD/hooks/redux";
+import { getCurrentDevice } from "~/renderer/reducers/devices";
+import { ContinueOnDevice } from "LLD/components/DeviceIntentExecutor/components/DeviceGenericStates/ContinueOnDevice";
+import { PerpsDepositSignTerms } from "./PerpsDepositSignTerms";
+
+/**
+ * The single "continue on your device" screen for the perps deposit: the on-device
+ * prompt plus the SwapKit terms. Rendered both between device steps (the flow's
+ * fallback) and as the completeExchange confirmation (via <DeviceAction>), so the
+ * terms always travel with this screen instead of living in the view.
+ */
+export function PerpsDepositContinueOnDevice() {
+  const device = useSelector(getCurrentDevice);
+  const deviceModelId = device?.modelId ?? DeviceModelId.stax;
+  const deviceName = device?.deviceName || getProductName(deviceModelId);
+
+  return (
+    <div className="flex w-full flex-col items-center gap-24">
+      <ContinueOnDevice deviceModelId={deviceModelId} deviceName={deviceName} />
+      <PerpsDepositSignTerms />
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/components/PerpsDepositSignTerms.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/components/PerpsDepositSignTerms.tsx
@@ -10,7 +10,11 @@ export const PerpsDepositSignTerms = () => (
       i18nKey="perpsDepositSign.terms"
       components={{
         termsLink: (
-          <span className="cursor-pointer underline" onClick={() => openURL(SWAPKIT_TERMS_URL)} />
+          <button
+            type="button"
+            className="inline cursor-pointer border-0 bg-transparent p-0 underline body-4 text-muted"
+            onClick={() => openURL(SWAPKIT_TERMS_URL)}
+          />
         ),
       }}
     />

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/components/PerpsDepositSignTerms.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/components/PerpsDepositSignTerms.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { Trans } from "react-i18next";
+import { openURL } from "~/renderer/linking";
+
+const SWAPKIT_TERMS_URL = "https://swapkit.dev/terms-of-service/";
+
+export const PerpsDepositSignTerms = () => (
+  <p className="body-4 text-muted text-center">
+    <Trans
+      i18nKey="perpsDepositSign.terms"
+      components={{
+        termsLink: (
+          <span className="cursor-pointer underline" onClick={() => openURL(SWAPKIT_TERMS_URL)} />
+        ),
+      }}
+    />
+  </p>
+);

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/usePerpsDepositSignViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/usePerpsDepositSignViewModel.ts
@@ -1,23 +1,42 @@
-import { useEffect, useRef } from "react";
-import type { PerpsDepositReviewParams } from "@ledgerhq/live-common/wallet-api/Perps/server";
+import { useCallback, useEffect, useRef } from "react";
 import {
   usePerpsDepositExecution,
   type PerpsDepositDeviceStep,
 } from "LLD/features/Perps/hooks/usePerpsDepositExecution";
+import { isUserRefusal } from "LLD/features/Perps/utils/isUserRefusal";
+import { openPerpsReview } from "../PerpsReview/PerpsReviewDialog";
+import type { PerpsReviewData } from "../PerpsReview/usePerpsReviewViewModel";
 
-export type PerpsDepositSignData = PerpsDepositReviewParams;
+export type PerpsDepositSignData = PerpsReviewData;
 
 export type PerpsDepositSignViewModel = {
   deviceStep: PerpsDepositDeviceStep;
   retry: () => void;
   onClose: () => void;
+  /** Errors raised while connecting to the device, which never reach the execution. */
+  onDeviceError: (error: Error) => void;
 };
 
 export function usePerpsDepositSignViewModel(
   data: PerpsDepositSignData,
   onClose: () => void,
 ): PerpsDepositSignViewModel {
-  const { deviceStep, executeDeposit, retry } = usePerpsDepositExecution(data, onClose);
+  const handleRefused = useCallback(() => {
+    openPerpsReview(data);
+    onClose();
+  }, [data, onClose]);
+
+  const { deviceStep, executeDeposit, retry } = usePerpsDepositExecution(data, {
+    onDone: onClose,
+    onRefused: handleRefused,
+  });
+
+  const onDeviceError = useCallback(
+    (error: Error) => {
+      if (isUserRefusal(error)) handleRefused();
+    },
+    [handleRefused],
+  );
 
   const startedRef = useRef(false);
   useEffect(() => {
@@ -30,5 +49,6 @@ export function usePerpsDepositSignViewModel(
     deviceStep,
     retry,
     onClose,
+    onDeviceError,
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/usePerpsDepositSignViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsDepositSign/usePerpsDepositSignViewModel.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from "react";
+import type { PerpsDepositReviewParams } from "@ledgerhq/live-common/wallet-api/Perps/server";
+import {
+  usePerpsDepositExecution,
+  type PerpsDepositDeviceStep,
+} from "LLD/features/Perps/hooks/usePerpsDepositExecution";
+
+export type PerpsDepositSignData = PerpsDepositReviewParams;
+
+export type PerpsDepositSignViewModel = {
+  deviceStep: PerpsDepositDeviceStep;
+  retry: () => void;
+  onClose: () => void;
+};
+
+export function usePerpsDepositSignViewModel(
+  data: PerpsDepositSignData,
+  onClose: () => void,
+): PerpsDepositSignViewModel {
+  const { deviceStep, executeDeposit, retry } = usePerpsDepositExecution(data, onClose);
+
+  const startedRef = useRef(false);
+  useEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+    void executeDeposit();
+  }, [executeDeposit]);
+
+  return {
+    deviceStep,
+    retry,
+    onClose,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/__tests__/usePerpsReviewViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/__tests__/usePerpsReviewViewModel.test.ts
@@ -77,22 +77,22 @@ describe("usePerpsReviewViewModel", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it("should hand the signing dialog the quote the review priced against", () => {
+  it("should hand the signing dialog the quote the review priced against, and the draft behind it", () => {
     const onClose = jest.fn();
-    const data = createData({
-      quoteId: "quote-1",
-      draft: { depositAccount, depositAmount: 20 },
-    });
+    const draft = { depositAccount, depositAmount: 20 };
+    const data = createData({ quoteId: "quote-1", draft });
     const { result } = renderHook(() => usePerpsReviewViewModel(data, onClose));
 
     result.current.handleDeposit();
 
+    // The draft travels with the quote so a decline on the device can come back here.
     expect(mockOpenPerpsDepositSign).toHaveBeenCalledWith({
       depositAccount,
       receiverAccount,
       amountSent: data.amountSent,
       amountTo: data.amountTo,
       quoteId: "quote-1",
+      draft,
     });
     expect(onClose).toHaveBeenCalled();
     expect(mockOpenPerpsDeposit).not.toHaveBeenCalled();

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/__tests__/usePerpsReviewViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/__tests__/usePerpsReviewViewModel.test.ts
@@ -8,6 +8,11 @@ jest.mock("../../PerpsDeposit/PerpsDepositDialog", () => ({
   openPerpsDeposit: (data: unknown) => mockOpenPerpsDeposit(data),
 }));
 
+const mockOpenPerpsDepositSign = jest.fn();
+jest.mock("../../PerpsDepositSign/PerpsDepositSignDialog", () => ({
+  openPerpsDepositSign: (data: unknown) => mockOpenPerpsDepositSign(data),
+}));
+
 const ethereum = getCryptoCurrencyById("ethereum");
 const depositAccount = genAccount("funding-1", { currency: ethereum, operationsSize: 0 });
 const receiverAccount = genAccount("receiver-1", { currency: ethereum, operationsSize: 0 });
@@ -72,12 +77,23 @@ describe("usePerpsReviewViewModel", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it("should close the review when confirming the deposit", () => {
+  it("should hand the signing dialog the quote the review priced against", () => {
     const onClose = jest.fn();
-    const { result } = renderHook(() => usePerpsReviewViewModel(createData(), onClose));
+    const data = createData({
+      quoteId: "quote-1",
+      draft: { depositAccount, depositAmount: 20 },
+    });
+    const { result } = renderHook(() => usePerpsReviewViewModel(data, onClose));
 
     result.current.handleDeposit();
 
+    expect(mockOpenPerpsDepositSign).toHaveBeenCalledWith({
+      depositAccount,
+      receiverAccount,
+      amountSent: data.amountSent,
+      amountTo: data.amountTo,
+      quoteId: "quote-1",
+    });
     expect(onClose).toHaveBeenCalled();
     expect(mockOpenPerpsDeposit).not.toHaveBeenCalled();
   });

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/usePerpsReviewViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/usePerpsReviewViewModel.ts
@@ -7,6 +7,7 @@ import { useSelector } from "LLD/hooks/redux";
 import { accountNameWithDefaultSelector, walletSelector } from "~/renderer/reducers/wallet";
 import { openPerpsDeposit } from "../PerpsDeposit/PerpsDepositDialog";
 import type { PerpsDepositDraft } from "../PerpsDeposit/usePerpsDepositViewModel";
+import { openPerpsDepositSign } from "../PerpsDepositSign/PerpsDepositSignDialog";
 export type PerpsReviewData = PerpsDepositReviewParams & {
   draft?: PerpsDepositDraft;
 };
@@ -98,10 +99,23 @@ export function usePerpsReviewViewModel(
     onClose();
   }, [data.draft, data.receiverAccount, onClose]);
 
-  // The signing dialog is not built yet, so confirming just closes the review.
   const handleDeposit = useCallback(() => {
+    openPerpsDepositSign({
+      receiverAccount: data.receiverAccount,
+      depositAccount: data.depositAccount,
+      amountSent: data.amountSent,
+      amountTo: data.amountTo,
+      quoteId: data.quoteId,
+    });
     onClose();
-  }, [onClose]);
+  }, [
+    data.amountTo,
+    data.amountSent,
+    data.depositAccount,
+    data.quoteId,
+    data.receiverAccount,
+    onClose,
+  ]);
 
   return {
     swapDetails,

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/usePerpsReviewViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsReview/usePerpsReviewViewModel.ts
@@ -106,12 +106,14 @@ export function usePerpsReviewViewModel(
       amountSent: data.amountSent,
       amountTo: data.amountTo,
       quoteId: data.quoteId,
+      draft: data.draft,
     });
     onClose();
   }, [
     data.amountTo,
     data.amountSent,
     data.depositAccount,
+    data.draft,
     data.quoteId,
     data.receiverAccount,
     onClose,

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/utils/__tests__/isUserRefusal.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/utils/__tests__/isUserRefusal.test.ts
@@ -1,0 +1,32 @@
+import { isUserRefusal } from "../isUserRefusal";
+
+describe("isUserRefusal", () => {
+  it.each([
+    ["the coin app prompt, normalized by the transaction action", "TransactionRefusedOnDevice"],
+    ["a signer that names the refusal itself", "UserRefusedOnDevice"],
+    ["the manager allowance prompt, raised while resolving apps", "UserRefusedAllowManager"],
+  ])("recognises a decline reported by %s", (_case, name) => {
+    expect(isUserRefusal(Object.assign(new Error("refused"), { name }))).toBe(true);
+  });
+
+  it("recognises a decline on the Exchange app prompt, which survives only as a title", () => {
+    const error = Object.assign(new Error("refused"), {
+      name: "CompleteExchangeError",
+      title: "userRefused",
+    });
+
+    expect(isUserRefusal(error)).toBe(true);
+  });
+
+  it.each([
+    ["a plain failure", new Error("boom")],
+    [
+      "an Exchange failure that is not a decline",
+      Object.assign(new Error("boom"), { name: "CompleteExchangeError", title: "internalError" }),
+    ],
+    ["nothing at all", undefined],
+    ["a string", "userRefused"],
+  ])("does not mistake %s for a decline", (_case, error) => {
+    expect(isUserRefusal(error)).toBe(false);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/utils/isUserRefusal.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/utils/isUserRefusal.ts
@@ -1,0 +1,19 @@
+/** Every name or title a decline arrives under, one per prompt a deposit raises. */
+const REFUSAL_MARKERS = new Set([
+  "TransactionRefusedOnDevice",
+  "UserRefusedOnDevice",
+  "UserRefusedAllowManager",
+  "userRefused",
+]);
+
+/** Tells a decline apart from a failure. Duck-typed, as `instanceof` is unreliable here. */
+export function isUserRefusal(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+
+  const { name, title } = error as Record<"name" | "title", unknown>;
+
+  return (
+    (typeof name === "string" && REFUSAL_MARKERS.has(name)) ||
+    (typeof title === "string" && REFUSAL_MARKERS.has(title))
+  );
+}

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -77,7 +77,6 @@ import { useTrackTransactionChecksFlow } from "~/renderer/analytics/hooks/useTra
 import { useTrackDmkErrorsEvents } from "~/renderer/analytics/hooks/useTrackDmkErrorsEvents";
 import { identitiesSlice, DeviceId } from "@domain/entity-client-identity";
 import { useBuyDeviceIntercept } from "~/renderer/hooks/useBuyDeviceIntercept";
-import { PerpsDepositContinueOnDevice } from "LLD/features/Perps/screens/PerpsDepositSign/components/PerpsDepositContinueOnDevice";
 import {
   DeviceDeprecationScreen,
   DeviceDeprecationScreens,
@@ -169,9 +168,9 @@ type InnerProps<P> = {
   overridesPreferredDeviceModel?: DeviceModelId;
   inlineRetry?: boolean; // Set to false if the retry mechanism is handled externally.
   location?: HOOKS_TRACKING_LOCATIONS;
-  // Marks a perps deposit device action so its swap confirmation renders the
-  // perps "continue on your device" screen instead of the generic swap summary.
-  isPerpsConfirmation?: boolean;
+  // Replaces the on-device exchange confirmation with a caller-owned screen, for
+  // flows that reuse the exchange behind their own design.
+  renderExchangeConfirmation?: () => React.ReactNode;
 };
 
 type Props<H extends States, P> = InnerProps<P> & {
@@ -204,7 +203,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
   inlineRetry = true,
   analyticsPropertyFlow,
   location,
-  isPerpsConfirmation,
+  renderExchangeConfirmation,
 }: Props<H, P> & {
   request?: R;
 }) => {
@@ -517,11 +516,10 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
   }
 
   if (completeExchangeStarted && !completeExchangeResult && !completeExchangeError && !isLoading) {
-    // Perps deposit is a FUND, but keeps its own "continue on your device" screen
-    // regardless of exchange type — handle it before the swap/sell/fund switch.
-    if (isPerpsConfirmation) {
-      return <PerpsDepositContinueOnDevice />;
+    if (renderExchangeConfirmation) {
+      return renderExchangeConfirmation();
     }
+
     const { exchangeType } = request as { exchangeType: number };
 
     // FIXME: could use a TS enum (when LLD will be in TS) or a JS object instead of raw numbers for switch values for clarity
@@ -557,7 +555,6 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
           estimatedFees: estimatedFees?.toString() ?? undefined,
           stateSettings,
           walletState,
-          isPerpsConfirmation,
         });
       }
 

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -77,6 +77,7 @@ import { useTrackTransactionChecksFlow } from "~/renderer/analytics/hooks/useTra
 import { useTrackDmkErrorsEvents } from "~/renderer/analytics/hooks/useTrackDmkErrorsEvents";
 import { identitiesSlice, DeviceId } from "@domain/entity-client-identity";
 import { useBuyDeviceIntercept } from "~/renderer/hooks/useBuyDeviceIntercept";
+import { PerpsDepositContinueOnDevice } from "LLD/features/Perps/screens/PerpsDepositSign/components/PerpsDepositContinueOnDevice";
 import {
   DeviceDeprecationScreen,
   DeviceDeprecationScreens,
@@ -88,7 +89,7 @@ type PartialNullable<T> = {
   [P in keyof T]?: T[P] | null;
 };
 
-type States = PartialNullable<{
+export type States = PartialNullable<{
   appAndVersion: AppAndVersion;
   device: Device;
   unresponsive: boolean;
@@ -168,6 +169,9 @@ type InnerProps<P> = {
   overridesPreferredDeviceModel?: DeviceModelId;
   inlineRetry?: boolean; // Set to false if the retry mechanism is handled externally.
   location?: HOOKS_TRACKING_LOCATIONS;
+  // Marks a perps deposit device action so its swap confirmation renders the
+  // perps "continue on your device" screen instead of the generic swap summary.
+  isPerpsConfirmation?: boolean;
 };
 
 type Props<H extends States, P> = InnerProps<P> & {
@@ -200,6 +204,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
   inlineRetry = true,
   analyticsPropertyFlow,
   location,
+  isPerpsConfirmation,
 }: Props<H, P> & {
   request?: R;
 }) => {
@@ -512,6 +517,11 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
   }
 
   if (completeExchangeStarted && !completeExchangeResult && !completeExchangeError && !isLoading) {
+    // Perps deposit is a FUND, but keeps its own "continue on your device" screen
+    // regardless of exchange type — handle it before the swap/sell/fund switch.
+    if (isPerpsConfirmation) {
+      return <PerpsDepositContinueOnDevice />;
+    }
     const { exchangeType } = request as { exchangeType: number };
 
     // FIXME: could use a TS enum (when LLD will be in TS) or a JS object instead of raw numbers for switch values for clarity
@@ -547,6 +557,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
           estimatedFees: estimatedFees?.toString() ?? undefined,
           stateSettings,
           walletState,
+          isPerpsConfirmation,
         });
       }
 

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -12,6 +12,7 @@ import { CryptoCurrency } from "@domain/entity-currency-crypto";
 import { TokenCurrency } from "@domain/entity-currency-token";
 import { Account, ABTestingVariants } from "@ledgerhq/types-live";
 import { DeviceModelId, getDeviceModel } from "@ledgerhq/devices";
+import { PerpsDepositContinueOnDevice } from "LLD/features/Perps/screens/PerpsDepositSign/components/PerpsDepositContinueOnDevice";
 import {
   Button as ButtonV3,
   Flex,
@@ -1306,6 +1307,12 @@ interface SwapConfirmationProps {
   swapDefaultTrack: Record<string, string | boolean>;
   stateSettings: SettingsState;
   walletState: WalletState;
+  /**
+   * Perps deposit funds via the swap exchange flow, but shows the design's
+   * "continue on your device" confirmation instead of the generic swap summary.
+   * Set by the perps <DeviceAction>; leaves every other swap flow unchanged.
+   */
+  isPerpsConfirmation?: boolean;
 }
 
 const SwapConfirmationDetailedView: React.FC<{
@@ -1506,9 +1513,12 @@ const SwapDeviceConfirmation: React.FC<SwapConfirmationProps> = ({
   );
 };
 
-export const renderSwapDeviceConfirmation = (props: SwapConfirmationProps) => (
-  <SwapDeviceConfirmation {...props} />
-);
+export const renderSwapDeviceConfirmation = (props: SwapConfirmationProps) =>
+  props.isPerpsConfirmation ? (
+    <PerpsDepositContinueOnDevice />
+  ) : (
+    <SwapDeviceConfirmation {...props} />
+  );
 
 export const renderSecureTransferDeviceConfirmation = ({
   exchangeType,

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -12,7 +12,6 @@ import { CryptoCurrency } from "@domain/entity-currency-crypto";
 import { TokenCurrency } from "@domain/entity-currency-token";
 import { Account, ABTestingVariants } from "@ledgerhq/types-live";
 import { DeviceModelId, getDeviceModel } from "@ledgerhq/devices";
-import { PerpsDepositContinueOnDevice } from "LLD/features/Perps/screens/PerpsDepositSign/components/PerpsDepositContinueOnDevice";
 import {
   Button as ButtonV3,
   Flex,
@@ -1307,12 +1306,6 @@ interface SwapConfirmationProps {
   swapDefaultTrack: Record<string, string | boolean>;
   stateSettings: SettingsState;
   walletState: WalletState;
-  /**
-   * Perps deposit funds via the swap exchange flow, but shows the design's
-   * "continue on your device" confirmation instead of the generic swap summary.
-   * Set by the perps <DeviceAction>; leaves every other swap flow unchanged.
-   */
-  isPerpsConfirmation?: boolean;
 }
 
 const SwapConfirmationDetailedView: React.FC<{
@@ -1513,12 +1506,9 @@ const SwapDeviceConfirmation: React.FC<SwapConfirmationProps> = ({
   );
 };
 
-export const renderSwapDeviceConfirmation = (props: SwapConfirmationProps) =>
-  props.isPerpsConfirmation ? (
-    <PerpsDepositContinueOnDevice />
-  ) : (
-    <SwapDeviceConfirmation {...props} />
-  );
+export const renderSwapDeviceConfirmation = (props: SwapConfirmationProps) => (
+  <SwapDeviceConfirmation {...props} />
+);
 
 export const renderSecureTransferDeviceConfirmation = ({
   exchangeType,

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9884,5 +9884,9 @@
       "amountExceedsBalance": "Insufficient balance",
       "quoteUnavailable": "We can’t get a quote from {{provider}}, try with a different asset or come back later."
     }
+  },
+  "perpsDepositSign": {
+    "a11yTitle": "Deposit signing",
+    "terms": "By signing this transaction, I accept <termsLink>Swapkit by NEAR intent T&C</termsLink>"
   }
 }

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9887,6 +9887,6 @@
   },
   "perpsDepositSign": {
     "a11yTitle": "Deposit signing",
-    "terms": "By signing this transaction, I accept <termsLink>Swapkit by NEAR intent T&C</termsLink>"
+    "terms": "By signing this transaction, I accept <termsLink>SwapKit by NEAR Intents T&C</termsLink>"
   }
 }

--- a/libs/ledger-live-common/src/hw/actions/completeExchange.ts
+++ b/libs/ledger-live-common/src/hw/actions/completeExchange.ts
@@ -32,7 +32,7 @@ type CompleteExchangeRequest = {
   rate?: number;
   amountExpectedTo?: number;
 };
-type Result =
+export type Result =
   | {
       completeExchangeResult: Transaction;
     }

--- a/libs/ledger-live-common/src/wallet-api/Exchange/executeSwap.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/executeSwap.ts
@@ -18,7 +18,7 @@ import {
 } from "@ledgerhq/wallet-api-exchange-module";
 import { BigNumber } from "bignumber.js";
 import get from "lodash/get";
-import { Transaction as EvmTransaction } from "@ledgerhq/coin-evm/types/index";
+import type { Transaction as EvmTransaction } from "../../families/evm/types";
 import { padHexString } from "@ledgerhq/hw-app-eth";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { getAccountBridge } from "../../bridge";

--- a/libs/ledger-live-common/src/wallet-api/Exchange/executeSwap.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/executeSwap.ts
@@ -1,0 +1,523 @@
+import {
+  getMainAccount,
+  getParentAccount,
+  makeEmptyTokenAccount,
+} from "@ledgerhq/ledger-wallet-framework/account/index";
+import { getCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
+import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { CryptoOrTokenCurrency } from "@domain/entity-currency";
+import { decodeSwapPayload } from "@ledgerhq/hw-app-exchange";
+import { Account, AccountLike, getCurrencyForAccount } from "@ledgerhq/types-live";
+import { createAccountNotFound, ServerError } from "@ledgerhq/wallet-api-core";
+import {
+  ExchangeStartResult,
+  ExchangeStartSwapParams,
+  ExchangeSwapParams,
+  ExchangeType,
+  SwapResult,
+} from "@ledgerhq/wallet-api-exchange-module";
+import { BigNumber } from "bignumber.js";
+import get from "lodash/get";
+import { Transaction as EvmTransaction } from "@ledgerhq/coin-evm/types/index";
+import { padHexString } from "@ledgerhq/hw-app-eth";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { getAccountBridge } from "../../bridge";
+import { Transaction } from "../../coin-modules/transaction-types";
+import { CompleteExchangeError, getErrorDetails, getSwapStepFromError } from "../../exchange/error";
+import { postSwapCancelled } from "../../exchange/swap";
+import { retrieveSwapPayload } from "../../exchange/swap/api/v5/actions";
+import { setBroadcastTransaction } from "../../exchange/swap/setBroadcastTransaction";
+import { transactionStrategy } from "../../exchange/swap/transactionStrategies";
+import { FeatureFlags } from "../../exchange/swap/types";
+import { getAccountIdFromWalletAccountId } from "../converters";
+import type { GetFeatureFn } from "../FeatureFlags/resolver";
+import { createAccounIdNotFound, createWrongSwapParams, ExchangeError } from "./error";
+import { handleErrors } from "./handleSwapErrors";
+import { createStepError, StepError, toError } from "./parser";
+import { SwapError } from "./SwapError";
+import { TrackingAPI } from "./tracking";
+import type {
+  ExchangeStartParamsUiRequest,
+  ExchangeUiHooks,
+  SwapStartParamsUiRequest,
+} from "./uiRequests";
+
+/**
+ * Everything the swap needs that the wallet-api handler factory would otherwise
+ * capture. The hooks are the only host-specific part: whoever calls this decides
+ * which screens drive the device steps.
+ */
+export type SwapDeps = {
+  accounts: AccountLike[];
+  tracking: TrackingAPI;
+  flags?: FeatureFlags;
+  getFeature?: GetFeatureFn;
+  uiHooks: Pick<
+    ExchangeUiHooks,
+    "custom.exchange.start" | "custom.exchange.swap" | "custom.exchange.error"
+  >;
+};
+
+/**
+ * Runs a swap end to end: nonce on device, provider payload, funding
+ * transaction, then the device confirmation / signature / broadcast the caller's
+ * `custom.exchange.swap` hook is responsible for.
+ *
+ * Shared by the `custom.exchange.swap` RPC handler (live apps) and by in-app
+ * flows that need the same sequence behind their own screens, so the two can't
+ * drift apart.
+ */
+export async function executeSwap(
+  { accounts, tracking, flags, getFeature, uiHooks }: SwapDeps,
+  params: ExchangeSwapParams,
+): Promise<SwapResult> {
+  const {
+    "custom.exchange.start": uiExchangeStart,
+    "custom.exchange.swap": uiSwap,
+    "custom.exchange.error": uiError,
+  } = uiHooks;
+
+  try {
+    const {
+      provider,
+      fromAmount,
+      fromAmountAtomic,
+      quoteId,
+      toNewTokenId,
+      customFeeConfig,
+      swapAppVersion,
+      sponsored,
+      isEmbedded,
+      swapEntryPoint,
+      correlationId,
+    } = params;
+
+    const trackingParams = {
+      provider: params.provider,
+      exchangeType: params.exchangeType,
+      isEmbeddedSwap: isEmbedded,
+      swapEntryPoint,
+    };
+
+    tracking.startExchangeRequested(trackingParams);
+
+    const exchangeStartParams: ExchangeStartParamsUiRequest = (await extractSwapStartParam(
+      params,
+      accounts,
+    )) as SwapStartParamsUiRequest;
+
+    const {
+      fromCurrency,
+      fromAccount,
+      fromParentAccount,
+      toCurrency,
+      toAccount,
+      toParentAccount,
+    } = exchangeStartParams.exchange;
+
+    if (!fromAccount || !fromCurrency) {
+      throw new ServerError(createAccountNotFound(params.fromAccountId));
+    }
+
+    const fromAccountAddress = fromParentAccount
+      ? fromParentAccount.freshAddress
+      : (fromAccount as Account).freshAddress;
+
+    const toAccountAddress = toParentAccount
+      ? toParentAccount.freshAddress
+      : (toAccount as Account).freshAddress;
+
+    // Step 1: Open the drawer and open exchange app
+    const startExchange = async () => {
+      return new Promise<{ transactionId: string; device?: ExchangeStartResult["device"] }>(
+        (resolve, reject) => {
+          uiExchangeStart({
+            exchangeParams: exchangeStartParams,
+            onSuccess: (nonce, device) => {
+              tracking.startExchangeSuccess(trackingParams);
+              resolve({ transactionId: nonce, device });
+            },
+            onCancel: error => {
+              tracking.startExchangeFail(trackingParams);
+              reject(error);
+            },
+          });
+        },
+      );
+    };
+
+    let transactionId: string;
+    let deviceInfo: ExchangeStartResult["device"];
+
+    try {
+      const result = await startExchange();
+      transactionId = result.transactionId;
+      deviceInfo = result.device;
+    } catch (error) {
+      const rawError = get(error, "response.data.error", error);
+      const wrappedError = createStepError({
+        error: toError(rawError),
+        step: StepError.NONCE,
+        correlationId: params?.correlationId,
+      });
+      throw wrappedError;
+    }
+
+    tracking.swapPayloadRequested({
+      provider,
+      transactionId,
+      fromAccountAddress,
+      toAccountAddress,
+      fromCurrencyId: fromCurrency!.id,
+      toCurrencyId: toCurrency?.id,
+      fromAmount,
+      quoteId,
+    });
+
+    const {
+      binaryPayload,
+      signature,
+      payinAddress,
+      swapId,
+      payinExtraId,
+      extraTransactionParameters,
+    } = await retrieveSwapPayload({
+      provider,
+      deviceTransactionId: transactionId,
+      fromAccountAddress,
+      toAccountAddress,
+      fromAccountCurrency: fromCurrency!.id,
+      toAccountCurrency: toCurrency!.id,
+      amount: fromAmount,
+      amountInAtomicUnit: fromAmountAtomic,
+      quoteId,
+      toNewTokenId,
+      flags,
+      correlationId,
+    }).catch((error: Error) => {
+      const wrappedError = createStepError({
+        error: get(error, "response.data.error", error),
+        step: StepError.PAYLOAD,
+        correlationId: params?.correlationId,
+      });
+      throw wrappedError;
+    });
+
+    tracking.swapResponseRetrieved({
+      binaryPayload,
+      signature,
+      payinAddress,
+      swapId,
+      payinExtraId,
+      extraTransactionParameters,
+    });
+
+    tracking.completeExchangeRequested(trackingParams);
+
+    const strategyData = {
+      recipient: payinAddress,
+      amount: fromAmountAtomic,
+      currency: fromCurrency as CryptoOrTokenCurrency,
+      customFeeConfig: customFeeConfig ?? {},
+      payinExtraId,
+      extraTransactionParameters,
+      sponsored,
+    };
+
+    const transaction: Transaction = await getStrategy(strategyData, "swap", getFeature);
+
+    const mainFromAccount = getMainAccount(fromAccount, fromParentAccount);
+
+    if (transaction.family !== mainFromAccount.currency.family) {
+      return Promise.reject(
+        new Error(
+          `Account and transaction must be from the same family. Account family: ${mainFromAccount.currency.family}, Transaction family: ${transaction.family}`,
+        ),
+      );
+    }
+
+    const accountBridge = await getAccountBridge(fromAccount, fromParentAccount);
+
+    /**
+     * 'subAccountId' is used for ETH and it's ERC-20 tokens.
+     * This field is ignored for BTC
+     */
+    const subAccountId =
+      fromParentAccount && fromParentAccount.id !== fromAccount.id ? fromAccount.id : undefined;
+
+    const bridgeTx = accountBridge.createTransaction(fromAccount);
+    /**
+     * We append the `recipient` to the tx created from `createTransaction`
+     * to avoid having userGasLimit reset to null for ETH txs
+     * cf. libs/ledger-live-common/src/families/ethereum/updateTransaction.ts
+     */
+    const tx = accountBridge.updateTransaction(
+      {
+        ...bridgeTx,
+        recipient: transaction.recipient,
+      },
+      {
+        ...transaction,
+        feesStrategy: params.feeStrategy.toLowerCase(),
+        subAccountId,
+      },
+    );
+
+    // Get amountExpectedTo and magnitudeAwareRate from binary payload
+    const decodePayload = await decodeSwapPayload(binaryPayload);
+    const amountExpectedTo = new BigNumber(decodePayload.amountToWallet.toString());
+    const magnitudeAwareRate = tx.amount && amountExpectedTo.dividedBy(tx.amount);
+    const refundAddress = decodePayload.refundAddress;
+    const payoutAddress = decodePayload.payoutAddress;
+
+    // tx.amount should be BigNumber
+    tx.amount = new BigNumber(tx.amount);
+
+    return new Promise((resolve, reject) =>
+      uiSwap({
+        exchangeParams: {
+          exchangeType: ExchangeType.SWAP,
+          provider: params.provider,
+          transaction: tx,
+          signature: signature,
+          binaryPayload: binaryPayload,
+          exchange: {
+            fromAccount,
+            fromParentAccount,
+            toAccount,
+            toParentAccount,
+            fromCurrency: fromCurrency!,
+            toCurrency: toCurrency!,
+          },
+          feesStrategy: params.feeStrategy,
+          swapId: swapId,
+          amountExpectedTo: amountExpectedTo.toNumber(),
+          magnitudeAwareRate,
+          refundAddress,
+          payoutAddress,
+          sponsored,
+          isEmbeddedSwap: isEmbedded,
+          swapEntryPoint,
+          ...(correlationId && { correlationId }),
+        },
+        onSuccess: ({ operationHash, swapId }: { operationHash: string; swapId: string }) => {
+          tracking.completeExchangeSuccess({
+            ...trackingParams,
+            currency: transaction.family,
+          });
+
+          setBroadcastTransaction({
+            provider,
+            result: { operation: operationHash, swapId },
+            sourceCurrencyId: fromCurrency.id,
+            targetCurrencyId: toCurrency?.id,
+            hardwareWalletType: deviceInfo?.modelId as DeviceModelId,
+            swapAppVersion,
+            fromAccountAddress,
+            toAccountAddress,
+            fromAmount,
+            flags,
+          });
+
+          resolve({ operationHash, swapId });
+        },
+        onCancel: error => {
+          const {
+            name: rawErrorName,
+            message: rawErrorMessage,
+            cause: rawErrorCause,
+          } = getErrorDetails(error);
+          const causeSuffix = rawErrorCause ? `, ${JSON.stringify(rawErrorCause)}` : "";
+          const errorMessageWithCause = rawErrorMessage + causeSuffix;
+
+          const completeExchangeError =
+            // step provided in libs/ledger-live-common/src/exchange/platform/transfer/completeExchange.ts
+            error instanceof CompleteExchangeError
+              ? error
+              : new CompleteExchangeError("INIT", rawErrorName, errorMessageWithCause);
+
+          postSwapCancelled({
+            provider: provider,
+            swapId: swapId,
+            swapStep: getSwapStepFromError(completeExchangeError),
+            statusCode: completeExchangeError.title || completeExchangeError.name,
+            errorMessage: completeExchangeError.message || errorMessageWithCause,
+            sourceCurrencyId: fromCurrency.id,
+            targetCurrencyId: toCurrency?.id,
+            hardwareWalletType: deviceInfo?.modelId as DeviceModelId,
+            swapType: quoteId ? "fixed" : "float",
+            swapAppVersion,
+            fromAccountAddress,
+            toAccountAddress,
+            refundAddress,
+            payoutAddress,
+            fromAmount,
+            seedIdFrom: mainFromAccount.seedIdentifier,
+            seedIdTo: toParentAccount?.seedIdentifier || (toAccount as Account)?.seedIdentifier,
+            data: (transaction as EvmTransaction).data
+              ? `0x${padHexString((transaction as EvmTransaction).data?.toString("hex") || "")}`
+              : "0x",
+            flags,
+          });
+
+          reject(completeExchangeError);
+        },
+      }),
+    );
+  } catch (error) {
+    // Skip DrawerClosedError
+    // do not redirect to the error screen
+    if (isDrawerClosedError(error)) {
+      throw error;
+    }
+
+    // Global catch for any errors during the swap process
+    // moved out as sonarcloud suggested to avoid 4 level nested functions
+    const createErrorRejector = (error: SwapError, reject: (error: SwapError) => void) => {
+      return () => reject(error);
+    };
+
+    const displayError = (error: SwapError): Promise<void> =>
+      new Promise((resolve, reject) => {
+        const rejectWithError = createErrorRejector(error, reject);
+        uiError({
+          error,
+          onSuccess: rejectWithError,
+          onCancel: rejectWithError,
+        });
+      });
+
+    handleErrors(error, {
+      onDisplayError: displayError,
+    });
+
+    throw error;
+  }
+}
+
+export async function extractSwapStartParam(
+  params: ExchangeStartSwapParams,
+  accounts: AccountLike[],
+): Promise<ExchangeStartParamsUiRequest> {
+  if (!("fromAccountId" in params && "toAccountId" in params)) {
+    throw new ExchangeError(createWrongSwapParams(params));
+  }
+
+  const realFromAccountId = getAccountIdFromWalletAccountId(params.fromAccountId);
+  if (!realFromAccountId) {
+    throw new ExchangeError(createAccounIdNotFound(params.fromAccountId));
+  }
+
+  const fromAccount = accounts.find(acc => acc.id === realFromAccountId);
+  if (!fromAccount) {
+    throw new ServerError(createAccountNotFound(params.fromAccountId));
+  }
+
+  let toAccount;
+
+  if (params.exchangeType === "SWAP" && params.toAccountId) {
+    const realToAccountId = getAccountIdFromWalletAccountId(params.toAccountId);
+    if (!realToAccountId) {
+      throw new ExchangeError(createAccounIdNotFound(params.toAccountId));
+    }
+
+    toAccount = accounts.find(a => a.id === realToAccountId);
+
+    if (!toAccount) {
+      throw new ServerError(createAccountNotFound(params.toAccountId));
+    }
+  }
+
+  const fromParentAccount = getParentAccount(fromAccount, accounts);
+  const toParentAccount = toAccount ? getParentAccount(toAccount, accounts) : undefined;
+
+  const currency = params.tokenCurrency
+    ? await getCryptoAssetsStore().findTokenById(params.tokenCurrency)
+    : null;
+  const newTokenAccount = currency ? makeEmptyTokenAccount(toAccount, currency) : null;
+
+  return {
+    exchangeType: params.exchangeType,
+    provider: params.provider,
+    exchange: {
+      fromAccount,
+      fromParentAccount,
+      fromCurrency: getCurrencyForAccount(fromAccount),
+      toAccount: newTokenAccount ? newTokenAccount : toAccount,
+      toParentAccount: toParentAccount,
+      toCurrency: getCurrencyForAccount(newTokenAccount ? newTokenAccount : toAccount),
+    },
+  };
+}
+
+interface StrategyParams {
+  recipient: string;
+  amount: BigNumber | number | string;
+  currency: CryptoOrTokenCurrency;
+  customFeeConfig?: Record<string, unknown>;
+  payinExtraId?: string;
+  extraTransactionParameters?: string;
+  sponsored?: boolean;
+}
+
+async function getStrategy(
+  {
+    recipient,
+    amount,
+    currency,
+    customFeeConfig,
+    payinExtraId,
+    extraTransactionParameters,
+    sponsored,
+  }: StrategyParams,
+  customErrorType?: any,
+  getFeature?: GetFeatureFn,
+): Promise<Transaction> {
+  const family =
+    currency.type === "TokenCurrency"
+      ? findCryptoCurrencyById(currency.parentCurrencyId)?.family
+      : currency.family;
+
+  if (!family) {
+    throw new Error(`TokenCurrency missing parentCurrency family: ${currency.id}`);
+  }
+
+  // Remove unsupported utxoStrategy for now
+  if (customFeeConfig?.utxoStrategy) {
+    delete customFeeConfig.utxoStrategy;
+  }
+
+  const strategy = transactionStrategy?.[family];
+
+  if (!strategy) {
+    throw new Error(`No transaction strategy found for family: ${family}`);
+  }
+
+  // Convert customFeeConfig values to BigNumber
+  const convertedCustomFeeConfig: { [key: string]: BigNumber } = {};
+  if (customFeeConfig) {
+    for (const [key, value] of Object.entries(customFeeConfig)) {
+      convertedCustomFeeConfig[key] = new BigNumber(value?.toString() || 0);
+    }
+  }
+
+  return strategy(
+    {
+      family,
+      amount: new BigNumber(amount),
+      recipient,
+      customFeeConfig: convertedCustomFeeConfig,
+      payinExtraId,
+      extraTransactionParameters,
+      customErrorType,
+      sponsored,
+    },
+    getFeature,
+  );
+}
+
+function isDrawerClosedError(error: unknown) {
+  if (!error || typeof error !== "object") return false;
+  const details = getErrorDetails(error);
+  return details.name === "DrawerClosedError" || details.cause?.name === "DrawerClosedError";
+}

--- a/libs/ledger-live-common/src/wallet-api/Exchange/server.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/server.ts
@@ -5,10 +5,9 @@ import {
   makeEmptyTokenAccount,
 } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { getCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
-import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import { decodeSwapPayload } from "@ledgerhq/hw-app-exchange";
-import { Account, AccountLike, getCurrencyForAccount, TokenAccount } from "@ledgerhq/types-live";
+import { AccountLike, getCurrencyForAccount, TokenAccount } from "@ledgerhq/types-live";
 import {
   createAccountNotFound,
   createCurrencyNotFound,
@@ -34,35 +33,20 @@ import {
 import { customWrapper, RPCHandler } from "@ledgerhq/wallet-api-server";
 import { BigNumber } from "bignumber.js";
 import { getAccountBridge } from "../../bridge";
-import { retrieveSwapPayload } from "../../exchange/swap/api/v5/actions";
-import { transactionStrategy } from "../../exchange/swap/transactionStrategies";
 import type { GetFeatureFn } from "../FeatureFlags/resolver";
-import { ExchangeSwap, FeatureFlags } from "../../exchange/swap/types";
+import { FeatureFlags } from "../../exchange/swap/types";
 import { Exchange } from "../../exchange/types";
-import { Transaction } from "../../coin-modules/transaction-types";
-import {
-  getAccountIdFromWalletAccountId,
-  getWalletAPITransactionSignFlowInfos,
-} from "../converters";
+import { getAccountIdFromWalletAccountId, getWalletAPITransactionSignFlowInfos } from "../converters";
 import { AppManifest } from "../types";
 import {
   createAccounIdNotFound,
   createWrongSellParams,
-  createWrongSwapParams,
   createWrongFundParams,
   ExchangeError,
 } from "./error";
+import { executeSwap, extractSwapStartParam } from "./executeSwap";
 import { TrackingAPI } from "./tracking";
-import { CompleteExchangeError, getErrorDetails, getSwapStepFromError } from "../../exchange/error";
-import { postSwapCancelled } from "../../exchange/swap";
 import { DeviceModelId } from "@ledgerhq/types-devices";
-import { setBroadcastTransaction } from "../../exchange/swap/setBroadcastTransaction";
-import type { Transaction as EvmTransaction } from "../../families/evm/types";
-import { padHexString } from "@ledgerhq/hw-app-eth";
-import { createStepError, StepError, toError } from "./parser";
-import { handleErrors } from "./handleSwapErrors";
-import get from "lodash/get";
-import { SwapError } from "./SwapError";
 import { getQuotes } from "./quotes";
 import { resolveQuotesInput } from "./quotes/resolveQuotesInput";
 import { fetchSpotPrices } from "./quotes/service/fetchSpotPrices";
@@ -71,6 +55,12 @@ import {
   type GetTransactionStatusResponse,
   type GetTransactionStatusWireArgs,
 } from "./transactionStatus";
+import type {
+  CompleteExchangeUiRequest,
+  ExchangeStartParamsUiRequest,
+  ExchangeUiHooks,
+  SwapUiRequest,
+} from "./uiRequests";
 
 export { ExchangeType };
 
@@ -90,77 +80,7 @@ type Handlers = {
   >;
 };
 
-export type CompleteExchangeUiRequest = {
-  provider: string;
-  exchange: Exchange;
-  transaction: Transaction;
-  binaryPayload: string;
-  signature: string;
-  feesStrategy: string;
-  exchangeType: number;
-  swapId?: string;
-  amountExpectedTo?: number;
-  magnitudeAwareRate?: BigNumber;
-  refundAddress?: string;
-  payoutAddress?: string;
-  sponsored?: boolean;
-  isEmbeddedSwap?: boolean;
-  swapEntryPoint?: string;
-};
-type FundStartParamsUiRequest = {
-  exchangeType: "FUND";
-  provider: string;
-  exchange: Partial<Exchange> | undefined;
-};
-
-type SellStartParamsUiRequest = {
-  exchangeType: "SELL";
-  provider: string;
-  exchange: Partial<Exchange> | undefined;
-};
-
-type SwapStartParamsUiRequest = {
-  exchangeType: "SWAP";
-  provider: string;
-  exchange: Partial<ExchangeSwap>;
-};
-
-type ExchangeStartParamsUiRequest =
-  | FundStartParamsUiRequest
-  | SellStartParamsUiRequest
-  | SwapStartParamsUiRequest;
-
-export type SwapUiRequest = CompleteExchangeUiRequest & {
-  provider?: string;
-  fromAccountId?: string;
-  toAccountId?: string;
-  tokenCurrency?: string;
-  correlationId?: string;
-};
-
-type ExchangeUiHooks = {
-  "custom.exchange.start": (params: {
-    exchangeParams: ExchangeStartParamsUiRequest;
-    onSuccess: (nonce: string, device?: ExchangeStartResult["device"]) => void;
-    onCancel: (error: Error, device?: ExchangeStartResult["device"]) => void;
-  }) => void;
-  "custom.exchange.complete": (params: {
-    exchangeParams: CompleteExchangeUiRequest;
-    onSuccess: (hash: string) => void;
-    onCancel: (error: Error) => void;
-  }) => void;
-  "custom.exchange.error": (params: {
-    error: SwapLiveError | undefined;
-    onSuccess: () => void;
-    onCancel: () => void;
-  }) => void;
-  "custom.isReady": (params: { onSuccess: () => void; onCancel: () => void }) => void;
-  "custom.exchange.swap": (params: {
-    exchangeParams: SwapUiRequest;
-    onSuccess: ({ operationHash, swapId }: { operationHash: string; swapId: string }) => void;
-    onCancel: (error: Error) => void;
-  }) => void;
-};
+export type { CompleteExchangeUiRequest, SwapUiRequest };
 
 /**
  * Build the wallet-api exchange handlers for a given wallet instance.
@@ -443,327 +363,25 @@ export const handlers = ({
       );
     }),
     "custom.exchange.swap": customWrapper<ExchangeSwapParams, SwapResult>(async params => {
-      try {
-        if (!params) {
-          tracking.startExchangeNoParams(manifest);
-          throw new ServerError(createUnknownError({ message: "params is undefined" }));
-        }
-
-        const {
-          provider,
-          fromAmount,
-          fromAmountAtomic,
-          quoteId,
-          toNewTokenId,
-          customFeeConfig,
-          swapAppVersion,
-          sponsored,
-          isEmbedded,
-          swapEntryPoint,
-          correlationId,
-        } = params;
-
-        const trackingParams = {
-          provider: params.provider,
-          exchangeType: params.exchangeType,
-          isEmbeddedSwap: isEmbedded,
-          swapEntryPoint,
-        };
-
-        tracking.startExchangeRequested(trackingParams);
-
-        const exchangeStartParams: ExchangeStartParamsUiRequest = (await extractSwapStartParam(
-          params,
-          accounts,
-        )) as SwapStartParamsUiRequest;
-
-        const {
-          fromCurrency,
-          fromAccount,
-          fromParentAccount,
-          toCurrency,
-          toAccount,
-          toParentAccount,
-        } = exchangeStartParams.exchange;
-
-        if (!fromAccount || !fromCurrency) {
-          throw new ServerError(createAccountNotFound(params.fromAccountId));
-        }
-
-        const fromAccountAddress = fromParentAccount
-          ? fromParentAccount.freshAddress
-          : (fromAccount as Account).freshAddress;
-
-        const toAccountAddress = toParentAccount
-          ? toParentAccount.freshAddress
-          : (toAccount as Account).freshAddress;
-
-        // Step 1: Open the drawer and open exchange app
-        const startExchange = async () => {
-          return new Promise<{ transactionId: string; device?: ExchangeStartResult["device"] }>(
-            (resolve, reject) => {
-              uiExchangeStart({
-                exchangeParams: exchangeStartParams,
-                onSuccess: (nonce, device) => {
-                  tracking.startExchangeSuccess(trackingParams);
-                  resolve({ transactionId: nonce, device });
-                },
-                onCancel: error => {
-                  tracking.startExchangeFail(trackingParams);
-                  reject(error);
-                },
-              });
-            },
-          );
-        };
-
-        let transactionId: string;
-        let deviceInfo: ExchangeStartResult["device"];
-
-        try {
-          const result = await startExchange();
-          transactionId = result.transactionId;
-          deviceInfo = result.device;
-        } catch (error) {
-          const rawError = get(error, "response.data.error", error);
-          const wrappedError = createStepError({
-            error: toError(rawError),
-            step: StepError.NONCE,
-            correlationId: params?.correlationId,
-          });
-          throw wrappedError;
-        }
-
-        tracking.swapPayloadRequested({
-          provider,
-          transactionId,
-          fromAccountAddress,
-          toAccountAddress,
-          fromCurrencyId: fromCurrency!.id,
-          toCurrencyId: toCurrency?.id,
-          fromAmount,
-          quoteId,
-        });
-
-        const {
-          binaryPayload,
-          signature,
-          payinAddress,
-          swapId,
-          payinExtraId,
-          extraTransactionParameters,
-        } = await retrieveSwapPayload({
-          provider,
-          deviceTransactionId: transactionId,
-          fromAccountAddress,
-          toAccountAddress,
-          fromAccountCurrency: fromCurrency!.id,
-          toAccountCurrency: toCurrency!.id,
-          amount: fromAmount,
-          amountInAtomicUnit: fromAmountAtomic,
-          quoteId,
-          toNewTokenId,
-          flags,
-          correlationId,
-        }).catch((error: Error) => {
-          const wrappedError = createStepError({
-            error: get(error, "response.data.error", error),
-            step: StepError.PAYLOAD,
-            correlationId: params?.correlationId,
-          });
-          throw wrappedError;
-        });
-
-        tracking.swapResponseRetrieved({
-          binaryPayload,
-          signature,
-          payinAddress,
-          swapId,
-          payinExtraId,
-          extraTransactionParameters,
-        });
-
-        tracking.completeExchangeRequested(trackingParams);
-
-        const strategyData = {
-          recipient: payinAddress,
-          amount: fromAmountAtomic,
-          currency: fromCurrency as CryptoOrTokenCurrency,
-          customFeeConfig: customFeeConfig ?? {},
-          payinExtraId,
-          extraTransactionParameters,
-          sponsored,
-        };
-
-        const transaction: Transaction = await getStrategy(strategyData, "swap", getFeature);
-
-        const mainFromAccount = getMainAccount(fromAccount, fromParentAccount);
-
-        if (transaction.family !== mainFromAccount.currency.family) {
-          return Promise.reject(
-            new Error(
-              `Account and transaction must be from the same family. Account family: ${mainFromAccount.currency.family}, Transaction family: ${transaction.family}`,
-            ),
-          );
-        }
-
-        const accountBridge = await getAccountBridge(fromAccount, fromParentAccount);
-
-        /**
-         * 'subAccountId' is used for ETH and it's ERC-20 tokens.
-         * This field is ignored for BTC
-         */
-        const subAccountId =
-          fromParentAccount && fromParentAccount.id !== fromAccount.id ? fromAccount.id : undefined;
-
-        const bridgeTx = accountBridge.createTransaction(fromAccount);
-        /**
-         * We append the `recipient` to the tx created from `createTransaction`
-         * to avoid having userGasLimit reset to null for ETH txs
-         * cf. libs/ledger-live-common/src/families/ethereum/updateTransaction.ts
-         */
-        const tx = accountBridge.updateTransaction(
-          {
-            ...bridgeTx,
-            recipient: transaction.recipient,
-          },
-          {
-            ...transaction,
-            feesStrategy: params.feeStrategy.toLowerCase(),
-            subAccountId,
-          },
-        );
-
-        // Get amountExpectedTo and magnitudeAwareRate from binary payload
-        const decodePayload = await decodeSwapPayload(binaryPayload);
-        const amountExpectedTo = new BigNumber(decodePayload.amountToWallet.toString());
-        const magnitudeAwareRate = tx.amount && amountExpectedTo.dividedBy(tx.amount);
-        const refundAddress = decodePayload.refundAddress;
-        const payoutAddress = decodePayload.payoutAddress;
-
-        // tx.amount should be BigNumber
-        tx.amount = new BigNumber(tx.amount);
-
-        return new Promise((resolve, reject) =>
-          uiSwap({
-            exchangeParams: {
-              exchangeType: ExchangeType.SWAP,
-              provider: params.provider,
-              transaction: tx,
-              signature: signature,
-              binaryPayload: binaryPayload,
-              exchange: {
-                fromAccount,
-                fromParentAccount,
-                toAccount,
-                toParentAccount,
-                fromCurrency: fromCurrency!,
-                toCurrency: toCurrency!,
-              },
-              feesStrategy: params.feeStrategy,
-              swapId: swapId,
-              amountExpectedTo: amountExpectedTo.toNumber(),
-              magnitudeAwareRate,
-              refundAddress,
-              payoutAddress,
-              sponsored,
-              isEmbeddedSwap: isEmbedded,
-              swapEntryPoint,
-              ...(correlationId && { correlationId }),
-            },
-            onSuccess: ({ operationHash, swapId }: { operationHash: string; swapId: string }) => {
-              tracking.completeExchangeSuccess({
-                ...trackingParams,
-                currency: transaction.family,
-              });
-
-              setBroadcastTransaction({
-                provider,
-                result: { operation: operationHash, swapId },
-                sourceCurrencyId: fromCurrency.id,
-                targetCurrencyId: toCurrency?.id,
-                hardwareWalletType: deviceInfo?.modelId as DeviceModelId,
-                swapAppVersion,
-                fromAccountAddress,
-                toAccountAddress,
-                fromAmount,
-                flags,
-              });
-
-              resolve({ operationHash, swapId });
-            },
-            onCancel: error => {
-              const {
-                name: rawErrorName,
-                message: rawErrorMessage,
-                cause: rawErrorCause,
-              } = getErrorDetails(error);
-              const causeSuffix = rawErrorCause ? `, ${JSON.stringify(rawErrorCause)}` : "";
-              const errorMessageWithCause = rawErrorMessage + causeSuffix;
-
-              const completeExchangeError =
-                // step provided in libs/ledger-live-common/src/exchange/platform/transfer/completeExchange.ts
-                error instanceof CompleteExchangeError
-                  ? error
-                  : new CompleteExchangeError("INIT", rawErrorName, errorMessageWithCause);
-
-              postSwapCancelled({
-                provider: provider,
-                swapId: swapId,
-                swapStep: getSwapStepFromError(completeExchangeError),
-                statusCode: completeExchangeError.title || completeExchangeError.name,
-                errorMessage: completeExchangeError.message || errorMessageWithCause,
-                sourceCurrencyId: fromCurrency.id,
-                targetCurrencyId: toCurrency?.id,
-                hardwareWalletType: deviceInfo?.modelId as DeviceModelId,
-                swapType: quoteId ? "fixed" : "float",
-                swapAppVersion,
-                fromAccountAddress,
-                toAccountAddress,
-                refundAddress,
-                payoutAddress,
-                fromAmount,
-                seedIdFrom: mainFromAccount.seedIdentifier,
-                seedIdTo: toParentAccount?.seedIdentifier || (toAccount as Account)?.seedIdentifier,
-                data: (transaction as EvmTransaction).data
-                  ? `0x${padHexString((transaction as EvmTransaction).data?.toString("hex") || "")}`
-                  : "0x",
-                flags,
-              });
-
-              reject(completeExchangeError);
-            },
-          }),
-        );
-      } catch (error) {
-        // Skip DrawerClosedError
-        // do not redirect to the error screen
-        if (isDrawerClosedError(error)) {
-          throw error;
-        }
-
-        // Global catch for any errors during the swap process
-        // moved out as sonarcloud suggested to avoid 4 level nested functions
-        const createErrorRejector = (error: SwapError, reject: (error: SwapError) => void) => {
-          return () => reject(error);
-        };
-
-        const displayError = (error: SwapError): Promise<void> =>
-          new Promise((resolve, reject) => {
-            const rejectWithError = createErrorRejector(error, reject);
-            uiError({
-              error,
-              onSuccess: rejectWithError,
-              onCancel: rejectWithError,
-            });
-          });
-
-        handleErrors(error, {
-          onDisplayError: displayError,
-        });
-
-        throw error;
+      if (!params) {
+        tracking.startExchangeNoParams(manifest);
+        throw new ServerError(createUnknownError({ message: "params is undefined" }));
       }
+
+      return executeSwap(
+        {
+          accounts,
+          tracking,
+          flags,
+          getFeature,
+          uiHooks: {
+            "custom.exchange.start": uiExchangeStart,
+            "custom.exchange.swap": uiSwap,
+            "custom.exchange.error": uiError,
+          },
+        },
+        params,
+      );
     }),
 
     "custom.isReady": customWrapper<void, void>(async () => {
@@ -818,61 +436,6 @@ export const handlers = ({
       return getTransactionStatus(params, { accounts });
     }),
   }) as const satisfies Handlers;
-
-async function extractSwapStartParam(
-  params: ExchangeStartSwapParams,
-  accounts: AccountLike[],
-): Promise<ExchangeStartParamsUiRequest> {
-  if (!("fromAccountId" in params && "toAccountId" in params)) {
-    throw new ExchangeError(createWrongSwapParams(params));
-  }
-
-  const realFromAccountId = getAccountIdFromWalletAccountId(params.fromAccountId);
-  if (!realFromAccountId) {
-    throw new ExchangeError(createAccounIdNotFound(params.fromAccountId));
-  }
-
-  const fromAccount = accounts.find(acc => acc.id === realFromAccountId);
-  if (!fromAccount) {
-    throw new ServerError(createAccountNotFound(params.fromAccountId));
-  }
-
-  let toAccount;
-
-  if (params.exchangeType === "SWAP" && params.toAccountId) {
-    const realToAccountId = getAccountIdFromWalletAccountId(params.toAccountId);
-    if (!realToAccountId) {
-      throw new ExchangeError(createAccounIdNotFound(params.toAccountId));
-    }
-
-    toAccount = accounts.find(a => a.id === realToAccountId);
-
-    if (!toAccount) {
-      throw new ServerError(createAccountNotFound(params.toAccountId));
-    }
-  }
-
-  const fromParentAccount = getParentAccount(fromAccount, accounts);
-  const toParentAccount = toAccount ? getParentAccount(toAccount, accounts) : undefined;
-
-  const currency = params.tokenCurrency
-    ? await getCryptoAssetsStore().findTokenById(params.tokenCurrency)
-    : null;
-  const newTokenAccount = currency ? makeEmptyTokenAccount(toAccount, currency) : null;
-
-  return {
-    exchangeType: params.exchangeType,
-    provider: params.provider,
-    exchange: {
-      fromAccount,
-      fromParentAccount,
-      fromCurrency: getCurrencyForAccount(fromAccount),
-      toAccount: newTokenAccount ? newTokenAccount : toAccount,
-      toParentAccount: toParentAccount,
-      toCurrency: getCurrencyForAccount(newTokenAccount ? newTokenAccount : toAccount),
-    },
-  };
-}
 
 function extractSellStartParam(
   params: ExchangeStartSellParams,
@@ -974,76 +537,4 @@ async function getToCurrency(
   }
 
   return newTokenAccount?.token ?? getCurrencyForAccount(toAccount);
-}
-
-interface StrategyParams {
-  recipient: string;
-  amount: BigNumber | number | string;
-  currency: CryptoOrTokenCurrency;
-  customFeeConfig?: Record<string, unknown>;
-  payinExtraId?: string;
-  extraTransactionParameters?: string;
-  sponsored?: boolean;
-}
-
-async function getStrategy(
-  {
-    recipient,
-    amount,
-    currency,
-    customFeeConfig,
-    payinExtraId,
-    extraTransactionParameters,
-    sponsored,
-  }: StrategyParams,
-  customErrorType?: any,
-  getFeature?: GetFeatureFn,
-): Promise<Transaction> {
-  const family =
-    currency.type === "TokenCurrency"
-      ? findCryptoCurrencyById(currency.parentCurrencyId)?.family
-      : currency.family;
-
-  if (!family) {
-    throw new Error(`TokenCurrency missing parentCurrency family: ${currency.id}`);
-  }
-
-  // Remove unsupported utxoStrategy for now
-  if (customFeeConfig?.utxoStrategy) {
-    delete customFeeConfig.utxoStrategy;
-  }
-
-  const strategy = transactionStrategy?.[family];
-
-  if (!strategy) {
-    throw new Error(`No transaction strategy found for family: ${family}`);
-  }
-
-  // Convert customFeeConfig values to BigNumber
-  const convertedCustomFeeConfig: { [key: string]: BigNumber } = {};
-  if (customFeeConfig) {
-    for (const [key, value] of Object.entries(customFeeConfig)) {
-      convertedCustomFeeConfig[key] = new BigNumber(value?.toString() || 0);
-    }
-  }
-
-  return strategy(
-    {
-      family,
-      amount: new BigNumber(amount),
-      recipient,
-      customFeeConfig: convertedCustomFeeConfig,
-      payinExtraId,
-      extraTransactionParameters,
-      customErrorType,
-      sponsored,
-    },
-    getFeature,
-  );
-}
-
-function isDrawerClosedError(error: unknown) {
-  if (!error || typeof error !== "object") return false;
-  const details = getErrorDetails(error);
-  return details.name === "DrawerClosedError" || details.cause?.name === "DrawerClosedError";
 }

--- a/libs/ledger-live-common/src/wallet-api/Exchange/uiRequests.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/uiRequests.ts
@@ -1,0 +1,78 @@
+import { ExchangeStartResult, SwapLiveError } from "@ledgerhq/wallet-api-exchange-module";
+import { BigNumber } from "bignumber.js";
+import { ExchangeSwap } from "../../exchange/swap/types";
+import { Exchange } from "../../exchange/types";
+import { Transaction } from "../../coin-modules/transaction-types";
+
+export type CompleteExchangeUiRequest = {
+  provider: string;
+  exchange: Exchange;
+  transaction: Transaction;
+  binaryPayload: string;
+  signature: string;
+  feesStrategy: string;
+  exchangeType: number;
+  swapId?: string;
+  amountExpectedTo?: number;
+  magnitudeAwareRate?: BigNumber;
+  refundAddress?: string;
+  payoutAddress?: string;
+  sponsored?: boolean;
+  isEmbeddedSwap?: boolean;
+  swapEntryPoint?: string;
+};
+
+type FundStartParamsUiRequest = {
+  exchangeType: "FUND";
+  provider: string;
+  exchange: Partial<Exchange> | undefined;
+};
+
+type SellStartParamsUiRequest = {
+  exchangeType: "SELL";
+  provider: string;
+  exchange: Partial<Exchange> | undefined;
+};
+
+export type SwapStartParamsUiRequest = {
+  exchangeType: "SWAP";
+  provider: string;
+  exchange: Partial<ExchangeSwap>;
+};
+
+export type ExchangeStartParamsUiRequest =
+  | FundStartParamsUiRequest
+  | SellStartParamsUiRequest
+  | SwapStartParamsUiRequest;
+
+export type SwapUiRequest = CompleteExchangeUiRequest & {
+  provider?: string;
+  fromAccountId?: string;
+  toAccountId?: string;
+  tokenCurrency?: string;
+  correlationId?: string;
+};
+
+export type ExchangeUiHooks = {
+  "custom.exchange.start": (params: {
+    exchangeParams: ExchangeStartParamsUiRequest;
+    onSuccess: (nonce: string, device?: ExchangeStartResult["device"]) => void;
+    onCancel: (error: Error, device?: ExchangeStartResult["device"]) => void;
+  }) => void;
+  "custom.exchange.complete": (params: {
+    exchangeParams: CompleteExchangeUiRequest;
+    onSuccess: (hash: string) => void;
+    onCancel: (error: Error) => void;
+  }) => void;
+  "custom.exchange.error": (params: {
+    error: SwapLiveError | undefined;
+    onSuccess: () => void;
+    onCancel: () => void;
+  }) => void;
+  "custom.isReady": (params: { onSuccess: () => void; onCancel: () => void }) => void;
+  "custom.exchange.swap": (params: {
+    exchangeParams: SwapUiRequest;
+    onSuccess: ({ operationHash, swapId }: { operationHash: string; swapId: string }) => void;
+    onCancel: (error: Error) => void;
+  }) => void;
+};


### PR DESCRIPTION
[LIVE-35328](https://ledgerhq.atlassian.net/browse/LIVE-35328)

## What

- Extract `executeSwap` from the swap RPC handler so it runs outside the live-app drawer.
- Drive the perps deposit through it: start (nonce) → confirm → sign → broadcast, in the perps dialog.

## Test

`pnpm --filter ledger-live-desktop test:jest -- --testPathPatterns "mvvm/features/Perps"` — 63 pass.

[LIVE-35328]: https://ledgerhq.atlassian.net/browse/LIVE-35328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="3056" height="2034" alt="image" src="https://github.com/user-attachments/assets/07cbe5f4-82b6-41c1-b9bd-8d18a78c2615" />
