### PR TITLE
[LWDM] feat(contacts): rename contact intent (LIVE-35702)

### DIFF
--- a/.changeset/contacts-rename-contact-ui.md
+++ b/.changeset/contacts-rename-contact-ui.md
@@ -1,6 +1,0 @@
----
-"ledger-live-desktop": patch
-"live-mobile": patch
----
-
-Render the Contacts "rename contact" device intent. Both apps replace the placeholder renderer with the same screens as register external address — `ContinueOnDevice` while the user confirms, and an `InfoState` per failure: rejection, wrong device, invalid data, OS version too low, and a generic error. A rejection keeps the job open so the user can retry on the same device.

--- a/.changeset/contacts-rename-contact-ui.md
+++ b/.changeset/contacts-rename-contact-ui.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Render the Contacts "rename contact" device intent. Both apps replace the placeholder renderer with the same screens as register external address — `ContinueOnDevice` while the user confirms, and an `InfoState` per failure: rejection, wrong device, invalid data, OS version too low, and a generic error. A rejection keeps the job open so the user can retry on the same device.

--- a/.changeset/contacts-rename-contact.md
+++ b/.changeset/contacts-rename-contact.md
@@ -1,0 +1,9 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@features/platform-contacts": patch
+---
+
+Replace the stubbed Contacts "rename contact" device intent job with a real call into `@ledgerhq/device-contacts-kit`'s `ContactsManager.renameContact()`, which returns the rotated contact-level name proof to persist.
+
+Rename is a blockchain-agnostic dashboard operation, so the intent initializes on the dashboard (`BOLOS`) instead of a coin app: the kit's device action navigates there itself and enforces the Contacts minimum OS version. Two consequences follow — a contact with no address is now renameable, and an outdated device surfaces as an OS-update screen rather than an app-update one.

--- a/.changeset/contacts-rename-contact.md
+++ b/.changeset/contacts-rename-contact.md
@@ -4,6 +4,6 @@
 "@features/platform-contacts": patch
 ---
 
-Replace the stubbed Contacts "rename contact" device intent job with a real call into `@ledgerhq/device-contacts-kit`'s `ContactsManager.renameContact()`, which returns the rotated contact-level name proof to persist.
+Rename a contact on the device from Contacts. The device intent now calls `@ledgerhq/device-contacts-kit`'s `ContactsManager.renameContact()`, which returns the rotated name proof to persist, and both apps render the confirmation step and one `InfoState` per failure. A rejection keeps the job open so the user can retry on the same device.
 
-Rename is a blockchain-agnostic dashboard operation, so the intent initializes on the dashboard (`BOLOS`) instead of a coin app: the kit's device action navigates there itself and enforces the Contacts minimum OS version. Two consequences follow — a contact with no address is now renameable, and an outdated device surfaces as an OS-update screen rather than an app-update one.
+Rename is a blockchain-agnostic dashboard operation, so it initializes on the dashboard (`BOLOS`) rather than a coin app: a contact with no address is renameable, and an outdated device surfaces as an OS-update screen instead of an app-update one.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/deviceIntents/renameContactIntent/componentLWD.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/deviceIntents/renameContactIntent/componentLWD.test.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { DeviceModelId } from "@ledgerhq/device-management-kit";
+import type { RenameContactJobState } from "@features/platform-contacts/device/intents";
+import { RenameContactComponentLWD } from "./componentLWD";
+
+const COPY = {
+  pending: "Preparing your Ledger device",
+  continueOnDevice: "Continue on your Ledger Stax",
+  rejected: "Operation rejected on Ledger device",
+  wrongDevice: "Use the same Ledger device you used to add this contact",
+  invalidData: "This address can't be saved",
+  osVersionTooLow: "Ledger OS update required",
+  genericError: "Unknown error",
+} as const;
+
+const CLOSE_CTA = "contacts-rename-contact-close";
+const RETRY_CTA = "contacts-rename-contact-retry";
+
+const failure = (type: string): RenameContactJobState =>
+  ({ type, error: new Error("boom") }) as RenameContactJobState;
+
+function renderComponent(jobState: RenameContactJobState | undefined) {
+  const onClose = jest.fn();
+  const { user } = render(
+    <RenameContactComponentLWD jobState={jobState} extraProps={undefined} onClose={onClose} />,
+  );
+
+  return { user, onClose };
+}
+
+describe("RenameContactComponentLWD", () => {
+  /** `completed` is terminal: hold the spinner for the frame before the host unmounts the executor. */
+  it.each([
+    ["undefined", undefined],
+    ["pending", { type: "pending" } as const],
+    ["completed", { type: "completed" } as const],
+  ])("should show the pending screen when the job state is %s", (_, jobState) => {
+    renderComponent(jobState);
+
+    expect(screen.getByText(COPY.pending)).toBeVisible();
+  });
+
+  it("should ask the user to continue on the device it reports", () => {
+    renderComponent({
+      type: "awaiting-device-confirmation",
+      deviceModelId: DeviceModelId.STAX,
+      deviceName: "Lily's Ledger",
+    });
+
+    expect(screen.getByText(COPY.continueOnDevice)).toBeVisible();
+    expect(screen.getByText("Lily's Ledger")).toBeVisible();
+  });
+
+  /**
+   * Rename is served from the dashboard, so the kit's version guard gates on the
+   * OS: the shared failure state is `app-version-too-low`, but the copy is not.
+   */
+  it.each([
+    ["device-rejected", COPY.rejected],
+    ["existing-group-verification-failed", COPY.wrongDevice],
+    ["invalid-input", COPY.invalidData],
+    ["unsupported-operation", COPY.invalidData],
+    ["app-version-too-low", COPY.osVersionTooLow],
+    ["failed", COPY.genericError],
+  ])("should show its error screen when the job state is %s", (type, title) => {
+    renderComponent(failure(type));
+
+    expect(screen.getByText(title)).toBeVisible();
+  });
+
+  it("should let the user replay the device action when the rejection carries a retry", async () => {
+    const retry = jest.fn();
+    const { user } = renderComponent({
+      type: "device-rejected",
+      error: new Error("SWO_INCORRECT_DATA"),
+      retry,
+    });
+
+    await user.click(screen.getByTestId(RETRY_CTA));
+
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not offer a retry when the rejection carries none", () => {
+    renderComponent(failure("device-rejected"));
+
+    expect(screen.queryByTestId(RETRY_CTA)).not.toBeInTheDocument();
+  });
+
+  it("should hand the flow back when the user closes an error", async () => {
+    const { user, onClose } = renderComponent(failure("failed"));
+
+    await user.click(screen.getByTestId(CLOSE_CTA));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/deviceIntents/renameContactIntent/componentLWD.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/deviceIntents/renameContactIntent/componentLWD.tsx
@@ -28,7 +28,6 @@ export function RenameContactComponentLWD({ jobState, onClose }: RenameContactCo
     testID: "contacts-rename-contact-close",
   };
 
-  // The executor mounts this component before the job emits its first state.
   if (jobState === undefined) {
     return (
       <LoadingContent
@@ -40,8 +39,6 @@ export function RenameContactComponentLWD({ jobState, onClose }: RenameContactCo
 
   switch (jobState.type) {
     case "pending":
-    // `completed` is terminal: the orchestrator resolves its promise and drops
-    // the executor on the next tick, so hold the spinner until it unmounts.
     case "completed":
       return (
         <LoadingContent
@@ -59,10 +56,6 @@ export function RenameContactComponentLWD({ jobState, onClose }: RenameContactCo
         />
       );
 
-    // 0x6A80 buckets user rejection together with malformed TLV, so this reads
-    // as a rejection: it is the only outcome a user can actually cause.
-    // The job keeps itself open here, so the retry replays the device action
-    // rather than restarting the whole Contacts flow.
     case "device-rejected": {
       const retry = jobState.retry;
       return (
@@ -85,10 +78,6 @@ export function RenameContactComponentLWD({ jobState, onClose }: RenameContactCo
       );
     }
 
-    // Rename always replays the group's existing name proof, so a proof
-    // mismatch here means the contact belongs to another device.
-    // Its "Connect a different device" CTA needs a recovery path the executor
-    // does not expose yet — LIVE-36562.
     case "existing-group-verification-failed":
       return (
         <InfoState
@@ -118,10 +107,6 @@ export function RenameContactComponentLWD({ jobState, onClose }: RenameContactCo
         />
       );
 
-    // Rename is served from the dashboard, so the kit's version guard gates on
-    // the OS rather than a coin app — the shared failure state is the same, only
-    // the copy differs. Nothing gates this before the device action runs, so
-    // unlike register this screen is the normal way an outdated OS surfaces.
     case "app-version-too-low":
       return (
         <InfoState

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/deviceIntents/renameContactIntent/componentLWD.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/deviceIntents/renameContactIntent/componentLWD.tsx
@@ -1,5 +1,10 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
+import { dmkToLedgerDeviceIdMap } from "@ledgerhq/live-dmk-shared";
 import type { RenameContactJobState } from "@features/platform-contacts/device/intents";
+import { ContinueOnDevice } from "LLD/components/DeviceIntentExecutor/components/DeviceGenericStates/ContinueOnDevice";
+import { LoadingContent } from "LLD/components/DeviceIntentExecutor/components/DeviceGenericStates/LoadingContent";
+import { InfoState } from "@shared/ui-info-state";
 
 type RenameContactComponentLWDProps = Readonly<{
   jobState: RenameContactJobState | undefined;
@@ -7,17 +12,144 @@ type RenameContactComponentLWDProps = Readonly<{
   onClose: () => void;
 }>;
 
-// Temporary minimal renderer until the production Contacts UI lands.
-export function RenameContactComponentLWD({ jobState }: RenameContactComponentLWDProps) {
-  return (
-    <div className="flex w-full flex-col gap-8 p-16">
-      <p className="body-2 text-base">
-        {jobState === undefined
-          ? "Preparing Contacts operation"
-          : jobState.type === "awaiting-device-confirmation"
-            ? "Confirm on your Ledger"
-            : jobState.type}
-      </p>
-    </div>
-  );
+/**
+ * Desktop renderer for the rename-contact intent.
+ *
+ * A rejection leaves the job open, so that screen can replay the device action.
+ * Every other failure is terminal — the job completes right after emitting one —
+ * so those screens only offer a way out.
+ */
+export function RenameContactComponentLWD({ jobState, onClose }: RenameContactComponentLWDProps) {
+  const { t } = useTranslation();
+
+  const closeCta = {
+    label: t("common.close"),
+    onPress: onClose,
+    testID: "contacts-rename-contact-close",
+  };
+
+  // The executor mounts this component before the job emits its first state.
+  if (jobState === undefined) {
+    return (
+      <LoadingContent
+        title={t("contacts.deviceIntents.renameContact.pending.title")}
+        testID="contacts-rename-contact-pending"
+      />
+    );
+  }
+
+  switch (jobState.type) {
+    case "pending":
+    // `completed` is terminal: the orchestrator resolves its promise and drops
+    // the executor on the next tick, so hold the spinner until it unmounts.
+    case "completed":
+      return (
+        <LoadingContent
+          title={t("contacts.deviceIntents.renameContact.pending.title")}
+          testID="contacts-rename-contact-pending"
+        />
+      );
+
+    case "awaiting-device-confirmation":
+      return (
+        <ContinueOnDevice
+          deviceModelId={dmkToLedgerDeviceIdMap[jobState.deviceModelId]}
+          deviceName={jobState.deviceName}
+          testID="contacts-rename-contact-continue-on-device"
+        />
+      );
+
+    // 0x6A80 buckets user rejection together with malformed TLV, so this reads
+    // as a rejection: it is the only outcome a user can actually cause.
+    // The job keeps itself open here, so the retry replays the device action
+    // rather than restarting the whole Contacts flow.
+    case "device-rejected": {
+      const retry = jobState.retry;
+      return (
+        <InfoState
+          preset="info"
+          size="hug"
+          title={t("deviceIntentExecutor.initialization.retryable.userRefused.title")}
+          primaryCta={closeCta}
+          secondaryCta={
+            retry
+              ? {
+                  label: t("common.retry"),
+                  onPress: retry,
+                  testID: "contacts-rename-contact-retry",
+                }
+              : undefined
+          }
+          testID="contacts-rename-contact-rejected"
+        />
+      );
+    }
+
+    // Rename always replays the group's existing name proof, so a proof
+    // mismatch here means the contact belongs to another device.
+    // Its "Connect a different device" CTA needs a recovery path the executor
+    // does not expose yet — LIVE-36562.
+    case "existing-group-verification-failed":
+      return (
+        <InfoState
+          preset="info"
+          size="hug"
+          title={t("contacts.deviceIntents.errors.wrongDevice.title")}
+          description={t("contacts.deviceIntents.errors.wrongDevice.description")}
+          primaryCta={{
+            label: t("common.cancel"),
+            onPress: onClose,
+            testID: "contacts-rename-contact-wrong-device-cancel",
+          }}
+          testID="contacts-rename-contact-wrong-device"
+        />
+      );
+
+    case "invalid-input":
+    case "unsupported-operation":
+      return (
+        <InfoState
+          preset="error"
+          size="hug"
+          title={t("contacts.deviceIntents.errors.invalidData.title")}
+          description={t("contacts.deviceIntents.errors.invalidData.description")}
+          primaryCta={closeCta}
+          testID="contacts-rename-contact-invalid-data"
+        />
+      );
+
+    // Rename is served from the dashboard, so the kit's version guard gates on
+    // the OS rather than a coin app — the shared failure state is the same, only
+    // the copy differs. Nothing gates this before the device action runs, so
+    // unlike register this screen is the normal way an outdated OS surfaces.
+    case "app-version-too-low":
+      return (
+        <InfoState
+          preset="error"
+          size="hug"
+          title={t("contacts.deviceIntents.errors.osVersionTooLow.title")}
+          description={t("contacts.deviceIntents.errors.osVersionTooLow.description")}
+          primaryCta={closeCta}
+          testID="contacts-rename-contact-os-version-too-low"
+        />
+      );
+
+    case "failed":
+      return (
+        <InfoState
+          preset="error"
+          size="hug"
+          title={t("deviceIntentExecutor.errors.intentError.title")}
+          description={t("deviceIntentExecutor.errors.intentError.description")}
+          primaryCta={closeCta}
+          testID="contacts-rename-contact-error"
+        />
+      );
+    default:
+      return assertNever(jobState);
+  }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled rename contact intent state: ${JSON.stringify(value)}`);
 }

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9552,6 +9552,11 @@
           "title": "Preparing your Ledger device"
         }
       },
+      "renameContact": {
+        "pending": {
+          "title": "Preparing your Ledger device"
+        }
+      },
       "errors": {
         "wrongDevice": {
           "title": "Use the same Ledger device you used to add this contact",
@@ -9564,6 +9569,10 @@
         "appVersionTooLow": {
           "title": "App update required",
           "description": "Update the app on your Ledger device to save contacts, then try again."
+        },
+        "osVersionTooLow": {
+          "title": "Ledger OS update required",
+          "description": "Update your Ledger device's operating system to rename contacts, then try again."
         }
       }
     },

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10429,6 +10429,11 @@
           "title": "Preparing your Ledger device"
         }
       },
+      "renameContact": {
+        "pending": {
+          "title": "Preparing your Ledger device"
+        }
+      },
       "errors": {
         "wrongDevice": {
           "title": "Use the same Ledger device you used to add this contact",
@@ -10441,6 +10446,10 @@
         "appVersionTooLow": {
           "title": "App update required",
           "description": "Update the app on your Ledger device to save contacts, then try again."
+        },
+        "osVersionTooLow": {
+          "title": "Ledger OS update required",
+          "description": "Update your Ledger device's operating system to rename contacts, then try again."
         }
       }
     },

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/deviceIntents/renameContactIntent/componentLWM.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/deviceIntents/renameContactIntent/componentLWM.test.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { DeviceModelId } from "@ledgerhq/device-management-kit";
+import type { RenameContactJobState } from "@features/platform-contacts/device/intents";
+import { RenameContactComponentLWM } from "./componentLWM";
+
+const COPY = {
+  pending: "Preparing your Ledger device",
+  continueOnDevice: "Continue on your Ledger Stax",
+  rejected: "Operation rejected on Ledger device",
+  wrongDevice: "Use the same Ledger device you used to add this contact",
+  invalidData: "This address can't be saved",
+  osVersionTooLow: "Ledger OS update required",
+  genericError: "Unknown error",
+} as const;
+
+const failure = (type: string): RenameContactJobState =>
+  ({ type, error: new Error("boom") }) as RenameContactJobState;
+
+function renderComponent(jobState: RenameContactJobState | undefined) {
+  const onClose = jest.fn();
+  const { user } = render(
+    <RenameContactComponentLWM jobState={jobState} extraProps={undefined} onClose={onClose} />,
+  );
+
+  return { user, onClose };
+}
+
+describe("RenameContactComponentLWM", () => {
+  /** `completed` is terminal: hold the spinner for the frame before the host unmounts the executor. */
+  it.each([
+    ["undefined", undefined],
+    ["pending", { type: "pending" } as const],
+    ["completed", { type: "completed" } as const],
+  ])("should show the pending screen when the job state is %s", (_, jobState) => {
+    renderComponent(jobState);
+
+    expect(screen.getByText(COPY.pending)).toBeVisible();
+  });
+
+  it("should ask the user to continue on the device it reports", () => {
+    renderComponent({
+      type: "awaiting-device-confirmation",
+      deviceModelId: DeviceModelId.STAX,
+      deviceName: "Lily's Ledger",
+    });
+
+    expect(screen.getByText(COPY.continueOnDevice)).toBeVisible();
+    expect(screen.getByText("Lily's Ledger")).toBeVisible();
+  });
+
+  /**
+   * Rename is served from the dashboard, so the kit's version guard gates on the
+   * OS: the shared failure state is `app-version-too-low`, but the copy is not.
+   */
+  it.each([
+    ["device-rejected", COPY.rejected],
+    ["existing-group-verification-failed", COPY.wrongDevice],
+    ["invalid-input", COPY.invalidData],
+    ["unsupported-operation", COPY.invalidData],
+    ["app-version-too-low", COPY.osVersionTooLow],
+    ["failed", COPY.genericError],
+  ])("should show its error screen when the job state is %s", (type, title) => {
+    renderComponent(failure(type));
+
+    expect(screen.getByText(title)).toBeVisible();
+  });
+
+  it("should let the user replay the device action when the rejection carries a retry", async () => {
+    const retry = jest.fn();
+    const { user } = renderComponent({
+      type: "device-rejected",
+      error: new Error("SWO_INCORRECT_DATA"),
+      retry,
+    });
+
+    await user.press(screen.getByText("Retry"));
+
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not offer a retry when the rejection carries none", () => {
+    renderComponent(failure("device-rejected"));
+
+    expect(screen.queryByText("Retry")).toBeNull();
+  });
+
+  it("should hand the flow back when the user closes an error", async () => {
+    const { user, onClose } = renderComponent(failure("failed"));
+
+    await user.press(screen.getByText("Close"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/deviceIntents/renameContactIntent/componentLWM.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/deviceIntents/renameContactIntent/componentLWM.tsx
@@ -33,13 +33,10 @@ export function RenameContactComponentLWM({ jobState, onClose }: RenameContactCo
     />
   );
 
-  // The executor mounts this component before the job emits its first state.
   if (jobState === undefined) return pending;
 
   switch (jobState.type) {
     case "pending":
-    // `completed` is terminal: the orchestrator resolves its promise and drops
-    // the executor on the next tick, so hold the spinner until it unmounts.
     case "completed":
       return pending;
 
@@ -52,10 +49,6 @@ export function RenameContactComponentLWM({ jobState, onClose }: RenameContactCo
         />
       );
 
-    // 0x6A80 buckets user rejection together with malformed TLV, so this reads
-    // as a rejection: it is the only outcome a user can actually cause.
-    // The job keeps itself open here, so the retry replays the device action
-    // rather than restarting the whole Contacts flow.
     case "device-rejected": {
       const retry = jobState.retry;
       return (
@@ -80,10 +73,6 @@ export function RenameContactComponentLWM({ jobState, onClose }: RenameContactCo
       );
     }
 
-    // Rename always replays the group's existing name proof, so a proof
-    // mismatch here means the contact belongs to another device.
-    // Its "Connect a different device" CTA needs a recovery path the executor
-    // does not expose yet — LIVE-36562.
     case "existing-group-verification-failed":
       return (
         <InfoState
@@ -113,10 +102,6 @@ export function RenameContactComponentLWM({ jobState, onClose }: RenameContactCo
         />
       );
 
-    // Rename is served from the dashboard, so the kit's version guard gates on
-    // the OS rather than a coin app — the shared failure state is the same, only
-    // the copy differs. Nothing gates this before the device action runs, so
-    // unlike register this screen is the normal way an outdated OS surfaces.
     case "app-version-too-low":
       return (
         <InfoState

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/deviceIntents/renameContactIntent/componentLWM.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/deviceIntents/renameContactIntent/componentLWM.tsx
@@ -1,6 +1,10 @@
 import React from "react";
-import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
+import { dmkToLedgerDeviceIdMap } from "@ledgerhq/live-dmk-shared";
 import type { RenameContactJobState } from "@features/platform-contacts/device/intents";
+import { Trans } from "~/context/Locale";
+import { ContinueOnDevice } from "LLM/components/DeviceIntentExecutor/components/DeviceGenericStates/ContinueOnDevice";
+import { LoadingContent } from "LLM/components/DeviceIntentExecutor/components/DeviceGenericStates/LoadingContent";
+import { InfoState } from "@shared/ui-info-state";
 
 type RenameContactComponentLWMProps = Readonly<{
   jobState: RenameContactJobState | undefined;
@@ -8,20 +12,141 @@ type RenameContactComponentLWMProps = Readonly<{
   onClose: () => void;
 }>;
 
-// Temporary minimal renderer until the production Contacts UI lands.
-export function RenameContactComponentLWM({ jobState }: RenameContactComponentLWMProps) {
-  const message =
-    jobState === undefined
-      ? "Preparing Contacts operation"
-      : jobState.type === "awaiting-device-confirmation"
-        ? "Confirm on your Ledger"
-        : jobState.type;
+/**
+ * Mobile renderer for the rename-contact intent.
+ *
+ * A rejection leaves the job open, so that screen can replay the device action.
+ * Every other failure is terminal — the job completes right after emitting one —
+ * so those screens only offer a way out.
+ */
+export function RenameContactComponentLWM({ jobState, onClose }: RenameContactComponentLWMProps) {
+  const closeCta = {
+    label: <Trans i18nKey="common.close" />,
+    onPress: onClose,
+    testID: "contacts-rename-contact-close",
+  };
 
-  return (
-    <Box lx={{ gap: "s8", padding: "s16" }}>
-      <Text typography="body2" lx={{ color: "base" }}>
-        {message}
-      </Text>
-    </Box>
+  const pending = (
+    <LoadingContent
+      title={<Trans i18nKey="contacts.deviceIntents.renameContact.pending.title" />}
+      testID="contacts-rename-contact-pending"
+    />
   );
+
+  // The executor mounts this component before the job emits its first state.
+  if (jobState === undefined) return pending;
+
+  switch (jobState.type) {
+    case "pending":
+    // `completed` is terminal: the orchestrator resolves its promise and drops
+    // the executor on the next tick, so hold the spinner until it unmounts.
+    case "completed":
+      return pending;
+
+    case "awaiting-device-confirmation":
+      return (
+        <ContinueOnDevice
+          deviceModelId={dmkToLedgerDeviceIdMap[jobState.deviceModelId]}
+          deviceName={jobState.deviceName}
+          testID="contacts-rename-contact-continue-on-device"
+        />
+      );
+
+    // 0x6A80 buckets user rejection together with malformed TLV, so this reads
+    // as a rejection: it is the only outcome a user can actually cause.
+    // The job keeps itself open here, so the retry replays the device action
+    // rather than restarting the whole Contacts flow.
+    case "device-rejected": {
+      const retry = jobState.retry;
+      return (
+        <InfoState
+          preset="info"
+          size="hug"
+          title={
+            <Trans i18nKey="deviceIntentExecutor.initialization.retryable.userRefused.title" />
+          }
+          primaryCta={closeCta}
+          secondaryCta={
+            retry
+              ? {
+                  label: <Trans i18nKey="common.retry" />,
+                  onPress: retry,
+                  testID: "contacts-rename-contact-retry",
+                }
+              : undefined
+          }
+          testID="contacts-rename-contact-rejected"
+        />
+      );
+    }
+
+    // Rename always replays the group's existing name proof, so a proof
+    // mismatch here means the contact belongs to another device.
+    // Its "Connect a different device" CTA needs a recovery path the executor
+    // does not expose yet — LIVE-36562.
+    case "existing-group-verification-failed":
+      return (
+        <InfoState
+          preset="info"
+          size="hug"
+          title={<Trans i18nKey="contacts.deviceIntents.errors.wrongDevice.title" />}
+          description={<Trans i18nKey="contacts.deviceIntents.errors.wrongDevice.description" />}
+          primaryCta={{
+            label: <Trans i18nKey="common.cancel" />,
+            onPress: onClose,
+            testID: "contacts-rename-contact-wrong-device-cancel",
+          }}
+          testID="contacts-rename-contact-wrong-device"
+        />
+      );
+
+    case "invalid-input":
+    case "unsupported-operation":
+      return (
+        <InfoState
+          preset="error"
+          size="hug"
+          title={<Trans i18nKey="contacts.deviceIntents.errors.invalidData.title" />}
+          description={<Trans i18nKey="contacts.deviceIntents.errors.invalidData.description" />}
+          primaryCta={closeCta}
+          testID="contacts-rename-contact-invalid-data"
+        />
+      );
+
+    // Rename is served from the dashboard, so the kit's version guard gates on
+    // the OS rather than a coin app — the shared failure state is the same, only
+    // the copy differs. Nothing gates this before the device action runs, so
+    // unlike register this screen is the normal way an outdated OS surfaces.
+    case "app-version-too-low":
+      return (
+        <InfoState
+          preset="error"
+          size="hug"
+          title={<Trans i18nKey="contacts.deviceIntents.errors.osVersionTooLow.title" />}
+          description={
+            <Trans i18nKey="contacts.deviceIntents.errors.osVersionTooLow.description" />
+          }
+          primaryCta={closeCta}
+          testID="contacts-rename-contact-os-version-too-low"
+        />
+      );
+
+    case "failed":
+      return (
+        <InfoState
+          preset="error"
+          size="hug"
+          title={<Trans i18nKey="deviceIntentExecutor.errors.intentError.title" />}
+          description={<Trans i18nKey="deviceIntentExecutor.errors.intentError.description" />}
+          primaryCta={closeCta}
+          testID="contacts-rename-contact-error"
+        />
+      );
+    default:
+      return assertNever(jobState);
+  }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled rename contact intent state: ${JSON.stringify(value)}`);
 }

--- a/features/platform/contacts/src/device/contactsDeviceActionFailure.test.ts
+++ b/features/platform/contacts/src/device/contactsDeviceActionFailure.test.ts
@@ -70,9 +70,6 @@ describe("mapDeviceActionErrorToFailureJobState", () => {
     expect(result.type).toBe("invalid-input");
   });
 
-  // Refusing on the device yields 0x5501 from the kit's global error table, not
-  // a ContactsCommandError -- so it has to be recognised by its own tag or it
-  // falls through to the generic `failed` screen.
   it("GIVEN an ActionRefusedError WHEN mapping THEN it returns device-rejected", () => {
     // WHEN
     const result = mapDeviceActionErrorToFailureJobState({

--- a/features/platform/contacts/src/device/contactsDeviceActionFailure.test.ts
+++ b/features/platform/contacts/src/device/contactsDeviceActionFailure.test.ts
@@ -70,6 +70,22 @@ describe("mapDeviceActionErrorToFailureJobState", () => {
     expect(result.type).toBe("invalid-input");
   });
 
+  // Refusing on the device yields 0x5501 from the kit's global error table, not
+  // a ContactsCommandError -- so it has to be recognised by its own tag or it
+  // falls through to the generic `failed` screen.
+  it("GIVEN an ActionRefusedError WHEN mapping THEN it returns device-rejected", () => {
+    // WHEN
+    const result = mapDeviceActionErrorToFailureJobState({
+      _tag: "ActionRefusedError",
+      errorCode: "5501",
+      message: "Action refused on device.",
+    });
+
+    // THEN
+    expect(result.type).toBe("device-rejected");
+    expect(result.error.message).toBe("Action refused on device.");
+  });
+
   it.each([
     ["6a80", "device-rejected"],
     ["6982", "existing-group-verification-failed"],

--- a/features/platform/contacts/src/device/contactsDeviceActionFailure.ts
+++ b/features/platform/contacts/src/device/contactsDeviceActionFailure.ts
@@ -9,8 +9,17 @@ export type ContactDeviceIntentFailureJobState =
   | { readonly type: "app-version-too-low"; readonly error: Error }
   | { readonly type: "invalid-input"; readonly error: Error }
   /**
-   * 0x6A80 (SWO_INCORRECT_DATA): malformed TLV, invalid group handle, or user
-   * rejection — one bucket, by firmware design.
+   * The user refused the prompt on the device. Which status word carries that
+   * depends on who served the prompt, so both map here:
+   *
+   * - 0x5501 (`ActionRefusedError`), from the kit's *global* error table — the
+   *   dashboard-owned operations, i.e. contact rename.
+   * - 0x6A80 (SWO_INCORRECT_DATA), from the Contacts *app* error table — the
+   *   app-owned operations, i.e. register and edit an external address. The app
+   *   buckets malformed TLV and an invalid group handle under that same status
+   *   word, so a refusal cannot be told apart from bad data there.
+   *
+   * The kit documents neither; both are confirmed against a device.
    */
   | { readonly type: "device-rejected"; readonly error: Error; readonly retry?: () => void }
   /** 0x6982 (SWO_SECURITY_CONDITION_NOT_SATISFIED): HMAC_PROOF/HMAC_REST verification failed — only reachable when replaying an existing group. */
@@ -55,6 +64,12 @@ export function mapDeviceActionErrorToFailureJobState(
   }
   if (tag === "ContactsValidationError") {
     return { type: "invalid-input", error: mappedError };
+  }
+  // 0x5501, from the DMK's own GLOBAL_ERRORS table rather than the Contacts
+  // app's: refusing the prompt is a device-level outcome, so it arrives tagged
+  // by the kit's global handler and never reaches the app error table below.
+  if (tag === "ActionRefusedError") {
+    return { type: "device-rejected", error: mappedError };
   }
   if (tag === "ContactsCommandError") {
     const errorCode = (error as { errorCode?: unknown }).errorCode;

--- a/features/platform/contacts/src/device/contactsDeviceActionFailure.ts
+++ b/features/platform/contacts/src/device/contactsDeviceActionFailure.ts
@@ -8,19 +8,7 @@ export type ContactDeviceIntentFailureJobState =
    */
   | { readonly type: "app-version-too-low"; readonly error: Error }
   | { readonly type: "invalid-input"; readonly error: Error }
-  /**
-   * The user refused the prompt on the device. Which status word carries that
-   * depends on who served the prompt, so both map here:
-   *
-   * - 0x5501 (`ActionRefusedError`), from the kit's *global* error table — the
-   *   dashboard-owned operations, i.e. contact rename.
-   * - 0x6A80 (SWO_INCORRECT_DATA), from the Contacts *app* error table — the
-   *   app-owned operations, i.e. register and edit an external address. The app
-   *   buckets malformed TLV and an invalid group handle under that same status
-   *   word, so a refusal cannot be told apart from bad data there.
-   *
-   * The kit documents neither; both are confirmed against a device.
-   */
+  /** 0x5501 (`ActionRefusedError`) from the dashboard, or 0x6A80 (SWO_INCORRECT_DATA) from the Contacts app, which buckets a refusal with malformed TLV and an invalid group handle. */
   | { readonly type: "device-rejected"; readonly error: Error; readonly retry?: () => void }
   /** 0x6982 (SWO_SECURITY_CONDITION_NOT_SATISFIED): HMAC_PROOF/HMAC_REST verification failed — only reachable when replaying an existing group. */
   | { readonly type: "existing-group-verification-failed"; readonly error: Error }
@@ -65,9 +53,6 @@ export function mapDeviceActionErrorToFailureJobState(
   if (tag === "ContactsValidationError") {
     return { type: "invalid-input", error: mappedError };
   }
-  // 0x5501, from the DMK's own GLOBAL_ERRORS table rather than the Contacts
-  // app's: refusing the prompt is a device-level outcome, so it arrives tagged
-  // by the kit's global handler and never reaches the app error table below.
   if (tag === "ActionRefusedError") {
     return { type: "device-rejected", error: mappedError };
   }

--- a/features/platform/contacts/src/device/contactsDeviceActionFailure.ts
+++ b/features/platform/contacts/src/device/contactsDeviceActionFailure.ts
@@ -1,4 +1,11 @@
 export type ContactDeviceIntentFailureJobState =
+  /**
+   * The kit's version guard refused the device. Which version it refused
+   * depends on who serves the operation: an embedded coin app for the
+   * app-owned intents, the device OS for the dashboard-owned ones (contact
+   * rename). The kit reports both as one error, so each renderer supplies the
+   * copy that matches its own intent.
+   */
   | { readonly type: "app-version-too-low"; readonly error: Error }
   | { readonly type: "invalid-input"; readonly error: Error }
   /**

--- a/features/platform/contacts/src/device/intents/renameContactIntent/job.test.ts
+++ b/features/platform/contacts/src/device/intents/renameContactIntent/job.test.ts
@@ -1,0 +1,454 @@
+import { ContactsManagerBuilder } from "@ledgerhq/device-contacts-kit";
+import {
+  DeviceActionStatus,
+  DeviceModelId,
+  UserInteractionRequired,
+} from "@ledgerhq/device-management-kit";
+import { Subject } from "rxjs";
+import { ContactDeviceIntentCancelledError } from "../../errors";
+import { renameContactIntentJob } from "./job";
+import type { RenameContactIntentInput, RenameContactJobState } from "./types";
+
+jest.mock("@ledgerhq/device-contacts-kit", () => ({
+  ContactsManagerBuilder: jest.fn(),
+}));
+
+const mockedContactsManagerBuilder = ContactsManagerBuilder as unknown as jest.Mock;
+
+const INPUT: RenameContactIntentInput = {
+  previousContactName: "Alice",
+  newContactName: "Alice Cooper",
+  groupHandle: "0x0102",
+  hmacProof: "0x0304",
+};
+
+function startJob(input: RenameContactIntentInput = INPUT) {
+  const subject = new Subject<unknown>();
+  const cancel = jest.fn();
+  const renameContact = jest.fn(() => ({ observable: subject.asObservable(), cancel }));
+  const registerExternalAddress = jest.fn();
+  const build = jest.fn(() => ({ renameContact, registerExternalAddress }));
+  mockedContactsManagerBuilder.mockImplementation(() => ({ build }));
+
+  const states: RenameContactJobState[] = [];
+  const onResult = jest.fn();
+  let error: unknown;
+  let completed = false;
+
+  const subscription = renameContactIntentJob({
+    deviceConnectionResult: {
+      dmk: { id: "mock-dmk" } as never,
+      sessionId: "session-1",
+      connectedDevice: { modelId: DeviceModelId.STAX } as never,
+      compatDeviceId: "compat-1",
+      compatDeviceName: "Ledger Stax",
+      compatDeviceWired: true,
+    },
+    deviceExtractedContext: {
+      currentOsVersion: "1.0.0",
+      osUpdateAvailable: false,
+      // Rename runs from the dashboard, so BOLOS is what Phase 2 leaves running.
+      currentAppName: "BOLOS",
+      currentAppVersion: "1.0.0",
+    },
+    input,
+    onResult,
+  }).subscribe({
+    next: state => states.push(state),
+    error: e => {
+      error = e;
+    },
+    complete: () => {
+      completed = true;
+    },
+  });
+
+  return {
+    states,
+    onResult,
+    cancel,
+    renameContact,
+    registerExternalAddress,
+    subscription,
+    emit: (state: unknown) => subject.next(state),
+    fail: (err: unknown) => subject.error(err),
+    isCompleted: () => completed,
+    getError: () => error,
+  };
+}
+
+const COMPLETION = {
+  status: DeviceActionStatus.Completed,
+  output: {
+    previousContactName: "Alice",
+    contactName: "Alice Cooper",
+    groupHandle: new Uint8Array([0x01, 0x02]),
+    hmacProof: new Uint8Array([0x05, 0x06]),
+  },
+};
+
+const REJECTION = {
+  status: DeviceActionStatus.Error,
+  error: {
+    _tag: "ContactsCommandError",
+    errorCode: "6a80",
+    message: "SWO_INCORRECT_DATA",
+  },
+};
+
+function lastRejection(job: ReturnType<typeof startJob>) {
+  const state = [...job.states].reverse().find(s => s.type === "device-rejected");
+  if (state === undefined) throw new Error("Expected the job to have reported a rejection");
+  return state;
+}
+
+describe("renameContactIntentJob", () => {
+  it("GIVEN a rename WHEN the device completes THEN it reports the rotated proof hex-encoded", () => {
+    // GIVEN
+    const job = startJob();
+
+    // WHEN
+    job.emit(COMPLETION);
+
+    // THEN
+    expect(job.states).toContainEqual({ type: "completed" });
+    expect(job.onResult).toHaveBeenCalledWith({
+      type: "success",
+      result: {
+        previousContactName: "Alice",
+        contactName: "Alice Cooper",
+        groupHandle: "0x0102",
+        // Replaces the input proof: the device rotates `hmac_name` on rename.
+        hmacProof: "0x0506",
+      },
+    });
+    expect(job.isCompleted()).toBe(true);
+  });
+
+  it("GIVEN a rename WHEN starting THEN it decodes the hex handle and proof for the kit call", () => {
+    // WHEN
+    const job = startJob();
+
+    // THEN
+    expect(job.renameContact).toHaveBeenCalledWith({
+      previousContactName: "Alice",
+      newContactName: "Alice Cooper",
+      groupHandle: new Uint8Array([0x01, 0x02]),
+      hmacProof: new Uint8Array([0x03, 0x04]),
+    });
+  });
+
+  it("GIVEN a rename WHEN starting THEN it never asks the kit to open or skip a coin app", () => {
+    // WHEN
+    const job = startJob();
+
+    // THEN
+    // Rename is a dashboard operation: the device action goes to the dashboard
+    // itself, so the job passes no app-opening switch of any kind.
+    const [deviceActionInput] = job.renameContact.mock.calls[0] as unknown as [
+      Record<string, unknown>,
+    ];
+    expect(deviceActionInput).not.toHaveProperty("skipOpenApp");
+    expect(deviceActionInput).not.toHaveProperty("blockchainFamily");
+    expect(deviceActionInput).not.toHaveProperty("chainId");
+    expect(job.registerExternalAddress).not.toHaveBeenCalled();
+  });
+
+  it("GIVEN the device requires wallet confirmation WHEN pending THEN it reports awaiting-device-confirmation", () => {
+    // GIVEN
+    const job = startJob();
+
+    // WHEN
+    job.emit({
+      status: DeviceActionStatus.Pending,
+      intermediateValue: { requiredUserInteraction: UserInteractionRequired.RegisterWallet },
+    });
+
+    // THEN
+    expect(job.states).toContainEqual({
+      type: "awaiting-device-confirmation",
+      deviceModelId: DeviceModelId.STAX,
+      deviceName: "Ledger Stax",
+    });
+  });
+
+  it("GIVEN the device action has not started yet WHEN reported THEN it reports pending", () => {
+    // GIVEN
+    const job = startJob();
+
+    // WHEN
+    job.emit({ status: DeviceActionStatus.NotStarted });
+
+    // THEN
+    expect(job.states).toContainEqual({ type: "pending" });
+  });
+
+  it("GIVEN a go-to-dashboard interaction WHEN pending THEN it reports pending", () => {
+    // GIVEN
+    const job = startJob();
+
+    // WHEN
+    // The device action walks to the dashboard before asking for approval; the
+    // executor owns those screens, so the job just holds the spinner.
+    job.emit({
+      status: DeviceActionStatus.Pending,
+      intermediateValue: { requiredUserInteraction: UserInteractionRequired.UnlockDevice },
+    });
+
+    // THEN
+    expect(job.states).toContainEqual({ type: "pending" });
+  });
+
+  it("GIVEN an unsupported OS WHEN the device action errors THEN it reports the version failure", () => {
+    // GIVEN
+    const job = startJob();
+    // Rename is OS-gated: the device action raises this after going to the
+    // dashboard, since nothing gates the OS floor before it runs.
+    const error = { _tag: "ContactsVersionRequirementError" };
+
+    // WHEN
+    job.emit({ status: DeviceActionStatus.Error, error });
+
+    // THEN
+    expect(job.onResult).toHaveBeenCalledWith({
+      type: "failure",
+      error: expect.objectContaining({ message: "ContactsVersionRequirementError" }),
+    });
+    expect(job.states).toContainEqual({
+      type: "app-version-too-low",
+      error: expect.objectContaining({ message: "ContactsVersionRequirementError" }),
+    });
+    expect(job.isCompleted()).toBe(true);
+  });
+
+  it("GIVEN a validation device error WHEN the device action errors THEN it reports invalid-input", () => {
+    // GIVEN
+    const job = startJob();
+    const error = { _tag: "ContactsValidationError", message: "contact name too long" };
+
+    // WHEN
+    job.emit({ status: DeviceActionStatus.Error, error });
+
+    // THEN
+    expect(job.states).toContainEqual({
+      type: "invalid-input",
+      error: expect.objectContaining({ message: "contact name too long" }),
+    });
+  });
+
+  it("GIVEN status word 0x6a80 WHEN the device action errors THEN it reports device-rejected", () => {
+    // GIVEN
+    const job = startJob();
+
+    // WHEN
+    job.emit(REJECTION);
+
+    // THEN
+    expect(job.states).toContainEqual({
+      type: "device-rejected",
+      error: expect.objectContaining({ message: "SWO_INCORRECT_DATA" }),
+      retry: expect.any(Function),
+    });
+  });
+
+  it("GIVEN a rejection WHEN it is reported THEN the job stays open so the user can retry", () => {
+    // GIVEN
+    const job = startJob();
+
+    // WHEN
+    job.emit(REJECTION);
+
+    // THEN
+    expect(job.isCompleted()).toBe(false);
+    expect(job.onResult).not.toHaveBeenCalled();
+  });
+
+  it("GIVEN a rejection WHEN the user retries THEN it replays the device action", () => {
+    // GIVEN
+    const job = startJob();
+    job.emit(REJECTION);
+
+    // WHEN
+    lastRejection(job).retry?.();
+
+    // THEN
+    expect(job.renameContact).toHaveBeenCalledTimes(2);
+    expect(job.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("GIVEN a retried rejection WHEN the device confirms THEN it reports success and completes", () => {
+    // GIVEN
+    const job = startJob();
+    job.emit(REJECTION);
+    lastRejection(job).retry?.();
+
+    // WHEN
+    job.emit(COMPLETION);
+
+    // THEN
+    expect(job.onResult).toHaveBeenCalledWith({
+      type: "success",
+      result: expect.objectContaining({ contactName: "Alice Cooper", hmacProof: "0x0506" }),
+    });
+    expect(job.states).toContainEqual({ type: "completed" });
+    expect(job.isCompleted()).toBe(true);
+  });
+
+  it("GIVEN a rejection WHEN the user gives up instead THEN it settles as a cancellation", () => {
+    // GIVEN
+    const job = startJob();
+    job.emit(REJECTION);
+
+    // WHEN
+    job.subscription.unsubscribe();
+
+    // THEN
+    expect(job.onResult).toHaveBeenCalledWith({
+      type: "failure",
+      error: expect.any(ContactDeviceIntentCancelledError),
+    });
+  });
+
+  it("GIVEN status word 0x6982 WHEN the device action errors THEN it reports existing-group-verification-failed", () => {
+    // GIVEN
+    const job = startJob();
+    // Rename always replays the group's existing name proof, so this is how a
+    // proof bound to another device surfaces.
+    const error = {
+      _tag: "ContactsCommandError",
+      errorCode: "6982",
+      message: "SWO_SECURITY_CONDITION_NOT_SATISFIED",
+    };
+
+    // WHEN
+    job.emit({ status: DeviceActionStatus.Error, error });
+
+    // THEN
+    expect(job.states).toContainEqual({
+      type: "existing-group-verification-failed",
+      error: expect.objectContaining({ message: "SWO_SECURITY_CONDITION_NOT_SATISFIED" }),
+    });
+  });
+
+  it("GIVEN status word 0x6984 WHEN the device action errors THEN it reports unsupported-operation", () => {
+    // GIVEN
+    const job = startJob();
+    const error = {
+      _tag: "ContactsCommandError",
+      errorCode: "6984",
+      message: "SWO_CONDITIONS_NOT_SATISFIED",
+    };
+
+    // WHEN
+    job.emit({ status: DeviceActionStatus.Error, error });
+
+    // THEN
+    expect(job.states).toContainEqual({
+      type: "unsupported-operation",
+      error: expect.objectContaining({ message: "SWO_CONDITIONS_NOT_SATISFIED" }),
+    });
+  });
+
+  it("GIVEN an unrecognized status word WHEN the device action errors THEN it reports failed", () => {
+    // GIVEN
+    const job = startJob();
+    const error = {
+      _tag: "ContactsCommandError",
+      errorCode: "6b00",
+      message: "SWO_WRONG_PARAMETER_VALUE",
+    };
+
+    // WHEN
+    job.emit({ status: DeviceActionStatus.Error, error });
+
+    // THEN
+    expect(job.states).toContainEqual({
+      type: "failed",
+      error: expect.objectContaining({ message: "SWO_WRONG_PARAMETER_VALUE" }),
+    });
+  });
+
+  it("GIVEN an untagged device error WHEN the device action errors THEN it reports failed", () => {
+    // GIVEN
+    const job = startJob();
+    const error = { _tag: "UnknownDAError" };
+
+    // WHEN
+    job.emit({ status: DeviceActionStatus.Error, error });
+
+    // THEN
+    expect(job.states).toContainEqual({
+      type: "failed",
+      error: expect.objectContaining({ message: "UnknownDAError" }),
+    });
+  });
+
+  it("GIVEN an invalid group handle WHEN starting THEN it fails immediately without calling the kit", () => {
+    // GIVEN
+    const input: RenameContactIntentInput = { ...INPUT, groupHandle: "not-hex" };
+
+    // WHEN
+    const job = startJob(input);
+
+    // THEN
+    expect(job.renameContact).not.toHaveBeenCalled();
+    expect(job.onResult).toHaveBeenCalledWith({ type: "failure", error: expect.any(Error) });
+    expect(job.states).toContainEqual({ type: "invalid-input", error: expect.any(Error) });
+    expect(job.isCompleted()).toBe(true);
+  });
+
+  it("GIVEN an invalid hmac proof WHEN starting THEN it fails immediately without calling the kit", () => {
+    // GIVEN
+    const input: RenameContactIntentInput = { ...INPUT, hmacProof: "not-hex" };
+
+    // WHEN
+    const job = startJob(input);
+
+    // THEN
+    expect(job.renameContact).not.toHaveBeenCalled();
+    expect(job.onResult).toHaveBeenCalledWith({ type: "failure", error: expect.any(Error) });
+    expect(job.states).toContainEqual({ type: "invalid-input", error: expect.any(Error) });
+  });
+
+  it("GIVEN an active rename WHEN the caller unsubscribes before completion THEN it cancels the device action and reports cancellation", () => {
+    // GIVEN
+    const job = startJob();
+
+    // WHEN
+    job.subscription.unsubscribe();
+
+    // THEN
+    expect(job.cancel).toHaveBeenCalled();
+    expect(job.onResult).toHaveBeenCalledWith({
+      type: "failure",
+      error: expect.any(ContactDeviceIntentCancelledError),
+    });
+  });
+
+  it("GIVEN the device action is stopped WHEN reported THEN it reports failure", () => {
+    // GIVEN
+    const job = startJob();
+
+    // WHEN
+    job.emit({ status: DeviceActionStatus.Stopped });
+
+    // THEN
+    expect(job.onResult).toHaveBeenCalledWith({ type: "failure", error: expect.any(Error) });
+    expect(job.states).toContainEqual({ type: "failed", error: expect.any(Error) });
+  });
+
+  it("GIVEN the device action observable errors WHEN reported THEN it reports failure and errors the job observable", () => {
+    // GIVEN
+    const job = startJob();
+
+    // WHEN
+    job.fail(new Error("transport disconnected"));
+
+    // THEN
+    expect(job.onResult).toHaveBeenCalledWith({
+      type: "failure",
+      error: expect.objectContaining({ message: "transport disconnected" }),
+    });
+    expect(job.getError()).toEqual(expect.objectContaining({ message: "transport disconnected" }));
+  });
+});

--- a/features/platform/contacts/src/device/intents/renameContactIntent/job.test.ts
+++ b/features/platform/contacts/src/device/intents/renameContactIntent/job.test.ts
@@ -437,7 +437,7 @@ describe("renameContactIntentJob", () => {
     expect(job.states).toContainEqual({ type: "failed", error: expect.any(Error) });
   });
 
-  it("GIVEN the device action observable errors WHEN reported THEN it reports failure and errors the job observable", () => {
+  it("GIVEN the device action observable errors WHEN reported THEN it reports failure with a terminal failed state", () => {
     // GIVEN
     const job = startJob();
 
@@ -449,6 +449,11 @@ describe("renameContactIntentJob", () => {
       type: "failure",
       error: expect.objectContaining({ message: "transport disconnected" }),
     });
-    expect(job.getError()).toEqual(expect.objectContaining({ message: "transport disconnected" }));
+    expect(job.states).toContainEqual({
+      type: "failed",
+      error: expect.objectContaining({ message: "transport disconnected" }),
+    });
+    expect(job.isCompleted()).toBe(true);
+    expect(job.getError()).toBeUndefined();
   });
 });

--- a/features/platform/contacts/src/device/intents/renameContactIntent/job.ts
+++ b/features/platform/contacts/src/device/intents/renameContactIntent/job.ts
@@ -1,6 +1,7 @@
 import type { Job } from "@features/platform-device-intent";
 import { DeviceActionStatus, UserInteractionRequired } from "@ledgerhq/device-management-kit";
 import { ContactsManagerBuilder } from "@ledgerhq/device-contacts-kit";
+import type { RenameContactInput as RenameContactKitInput } from "@ledgerhq/device-contacts-kit";
 import type {
   RenameContactDAOutput,
   RenameContactDAState,
@@ -16,7 +17,6 @@ import {
   switchMap,
   takeWhile,
   tap,
-  throwError,
 } from "rxjs";
 import {
   mapDeviceActionErrorToFailureJobState,
@@ -139,7 +139,7 @@ export const renameContactIntentJob: Job<
   const toOutcome = createOutcomeMapper({ awaitingConfirmation, retry });
 
   return defer(() => {
-    let deviceActionInput;
+    let deviceActionInput: RenameContactKitInput;
     try {
       deviceActionInput = {
         previousContactName: input.previousContactName,
@@ -181,10 +181,16 @@ export const renameContactIntentJob: Job<
       tap(outcome => outcome.report && reporter.report(outcome.report)),
       takeWhile(outcome => !outcome.terminal, true),
       map(({ jobState }) => jobState),
+      // A transport-level failure errors the kit's observable directly (no
+      // DeviceActionStatus.Error to map), so this is the only place that can
+      // catch it. Per the Device Intent Executor contract, jobs report their
+      // own failures as a terminal JobState instead of erroring the job
+      // observable, which would push the executor into its generic fallback
+      // state instead of this intent's own InfoState.
       catchError((error: unknown) => {
         const mapped = mapDmkErrorToError(error);
         reporter.report({ type: "failure", error: mapped });
-        return throwError(() => mapped);
+        return of<RenameContactJobState>({ type: "failed", error: mapped });
       }),
     );
   }).pipe(reporter.cancelOnUnsubscribe());

--- a/features/platform/contacts/src/device/intents/renameContactIntent/job.ts
+++ b/features/platform/contacts/src/device/intents/renameContactIntent/job.ts
@@ -1,33 +1,191 @@
 import type { Job } from "@features/platform-device-intent";
-import { ExternalContactNameProofSchema } from "@domain/entity-contact";
-import { concat, ignoreElements, of, tap, timer } from "rxjs";
+import { DeviceActionStatus, UserInteractionRequired } from "@ledgerhq/device-management-kit";
+import { ContactsManagerBuilder } from "@ledgerhq/device-contacts-kit";
+import type {
+  RenameContactDAOutput,
+  RenameContactDAState,
+} from "@ledgerhq/device-contacts-kit/api/app-binder/RenameContactDeviceActionTypes.js";
+import {
+  catchError,
+  defer,
+  map,
+  Observable,
+  of,
+  startWith,
+  Subject,
+  switchMap,
+  takeWhile,
+  tap,
+  throwError,
+} from "rxjs";
+import {
+  mapDeviceActionErrorToFailureJobState,
+  mapDmkErrorToError,
+} from "../../contactsDeviceActionFailure";
+import {
+  mapBytesToGroupHandle,
+  mapBytesToProof,
+  mapGroupHandleToBytes,
+  mapProofToBytes,
+} from "../../contactsKitMappers";
 import { createContactIntentResultReporter, type ContactIntentResult } from "../resultReporter";
 import type { RenameContactIntentInput, RenameContactJobState, RenameContactResult } from "./types";
 
-// Temporary deterministic stub until the ContactsManager integration lands.
+function mapDeviceActionOutputToResult(output: RenameContactDAOutput): RenameContactResult {
+  // Unlike register, nothing here needs echoing back from the caller's input:
+  // rename carries no family/chainId taxonomy, and the names are plain strings
+  // the device hands back verbatim.
+  return {
+    previousContactName: output.previousContactName,
+    contactName: output.contactName,
+    groupHandle: mapBytesToGroupHandle(output.groupHandle),
+    hmacProof: mapBytesToProof(output.hmacProof),
+  };
+}
+
+type Outcome = Readonly<{
+  jobState: RenameContactJobState;
+  /** Terminal outcomes complete the job.*/
+  terminal: boolean;
+  /** Settles the port promise. Absent while the job is still running. */
+  report?: ContactIntentResult<RenameContactResult>;
+}>;
+
+/**
+ * Builds the mapper for one job run. Everything that varies — the connected
+ * device and the replay handle — is captured once here, so every branch of the
+ * device action lands in one place and the pipeline below stays free of
+ * conditionals.
+ */
+function createOutcomeMapper(
+  params: Readonly<{
+    awaitingConfirmation: RenameContactJobState;
+    retry: () => void;
+  }>,
+): (state: RenameContactDAState) => Outcome {
+  return state => {
+    switch (state.status) {
+      case DeviceActionStatus.NotStarted:
+        return { jobState: { type: "pending" }, terminal: false };
+
+      case DeviceActionStatus.Pending:
+        // The device action walks to the dashboard before asking for approval,
+        // so every interaction other than the approval prompt (unlocking,
+        // allowing the secure connection, closing the running app) stays on the
+        // spinner — the executor owns those screens.
+        return {
+          jobState:
+            state.intermediateValue.requiredUserInteraction ===
+            UserInteractionRequired.RegisterWallet
+              ? params.awaitingConfirmation
+              : { type: "pending" },
+          terminal: false,
+        };
+
+      case DeviceActionStatus.Completed: {
+        const result = mapDeviceActionOutputToResult(state.output);
+        return {
+          jobState: { type: "completed" },
+          terminal: true,
+          report: { type: "success", result },
+        };
+      }
+
+      case DeviceActionStatus.Stopped: {
+        const error = new Error("Rename contact was stopped");
+        return {
+          jobState: { type: "failed", error },
+          terminal: true,
+          report: { type: "failure", error },
+        };
+      }
+
+      case DeviceActionStatus.Error: {
+        const jobState = mapDeviceActionErrorToFailureJobState(state.error);
+
+        // A rejection is the one failure the user can undo, so it stays open and
+        // carries the replay handle instead of settling the port promise.
+        return jobState.type === "device-rejected"
+          ? { jobState: { ...jobState, retry: params.retry }, terminal: false }
+          : { jobState, terminal: true, report: { type: "failure", error: jobState.error } };
+      }
+    }
+  };
+}
+
+/**
+ * Rename a contact group on the device via the Contacts kit's
+ * `ContactsManager.renameContact()`.
+ *
+ * Rename is a blockchain-agnostic dashboard operation: the device action walks
+ * to the dashboard itself and gates on the Contacts minimum OS version, so this
+ * job never opens a coin app and never applies an app-version floor of its own.
+ */
 export const renameContactIntentJob: Job<
   RenameContactJobState,
   RenameContactIntentInput,
   ContactIntentResult<RenameContactResult>
-> = ({ input, onResult }) => {
+> = ({ deviceConnectionResult, deviceExtractedContext, input, onResult }) => {
   const reporter = createContactIntentResultReporter(onResult);
-  const result: RenameContactResult = {
-    previousContactName: input.previousContactName,
-    contactName: input.newContactName,
-    groupHandle: input.groupHandle,
-    hmacProof: ExternalContactNameProofSchema.parse(
-      "mock-external-contact-name-proof-after-rename",
-    ),
+  const retries = new Subject<void>();
+  const retry = () => retries.next();
+
+  const awaitingConfirmation: RenameContactJobState = {
+    type: "awaiting-device-confirmation",
+    deviceModelId: deviceConnectionResult.connectedDevice.modelId,
+    deviceName: deviceConnectionResult.compatDeviceName,
   };
 
-  return concat(
-    of({ type: "pending" } as const),
-    of({ type: "awaiting-device-confirmation" } as const),
-    timer(2_000).pipe(ignoreElements()),
-    of({ type: "completed" } as const).pipe(
-      tap(() => {
-        reporter.report({ type: "success", result });
+  const toOutcome = createOutcomeMapper({ awaitingConfirmation, retry });
+
+  return defer(() => {
+    let deviceActionInput;
+    try {
+      deviceActionInput = {
+        previousContactName: input.previousContactName,
+        newContactName: input.newContactName,
+        groupHandle: mapGroupHandleToBytes(input.groupHandle),
+        hmacProof: mapProofToBytes(input.hmacProof),
+      };
+    } catch (error) {
+      const failure = { type: "invalid-input", error: mapDmkErrorToError(error) } as const;
+      reporter.report({ type: "failure", error: failure.error });
+      return of<RenameContactJobState>(failure);
+    }
+
+    const contactsManager = new ContactsManagerBuilder({
+      dmk: deviceConnectionResult.dmk,
+      sessionId: deviceConnectionResult.sessionId,
+      // The manager needs an app name to build, but rename is served by the OS:
+      // the device action ignores it and goes to the dashboard instead.
+      appName: deviceExtractedContext.currentAppName,
+    }).build();
+
+    /** Pairs the kit's `cancel` with unsubscription, so teardown is one concern. */
+    const deviceAction = new Observable<RenameContactDAState>(subscriber => {
+      const { observable, cancel } = contactsManager.renameContact(deviceActionInput);
+      const subscription = observable.subscribe(subscriber);
+
+      return () => {
+        subscription.unsubscribe();
+        cancel();
+      };
+    });
+
+    return retries.pipe(
+      startWith(undefined),
+      // switchMap tears down the superseded attempt before starting the next,
+      // so replaying on retry needs no run bookkeeping of its own.
+      switchMap(() => deviceAction),
+      map(toOutcome),
+      tap(outcome => outcome.report && reporter.report(outcome.report)),
+      takeWhile(outcome => !outcome.terminal, true),
+      map(({ jobState }) => jobState),
+      catchError((error: unknown) => {
+        const mapped = mapDmkErrorToError(error);
+        reporter.report({ type: "failure", error: mapped });
+        return throwError(() => mapped);
       }),
-    ),
-  ).pipe(reporter.cancelOnUnsubscribe());
+    );
+  }).pipe(reporter.cancelOnUnsubscribe());
 };

--- a/features/platform/contacts/src/device/intents/renameContactIntent/types.ts
+++ b/features/platform/contacts/src/device/intents/renameContactIntent/types.ts
@@ -1,8 +1,10 @@
+import type { DeviceModelId } from "@ledgerhq/device-management-kit";
 import type {
   Intent,
   IntentDefinition,
   IntentPlatformDefinition,
 } from "@features/platform-device-intent";
+import type { ContactDeviceIntentFailureJobState } from "../../contactsDeviceActionFailure";
 import type { ContactIntentResult } from "../resultReporter";
 
 type GroupHandle = string;
@@ -24,9 +26,18 @@ export type RenameContactResult = Readonly<{
 
 export type RenameContactJobState =
   | { readonly type: "pending" }
-  | { readonly type: "awaiting-device-confirmation" }
+  /**
+   * Carries the connected device so the renderer can name the product and pick
+   * the matching animation: the executor hands intent components only the job
+   * state, so the job is what publishes the device.
+   */
+  | {
+      readonly type: "awaiting-device-confirmation";
+      readonly deviceModelId: DeviceModelId;
+      readonly deviceName: string;
+    }
   | { readonly type: "completed" }
-  | { readonly type: "failed"; readonly error: Error };
+  | ContactDeviceIntentFailureJobState;
 
 export type RenameContactIntentDefinition = IntentDefinition<
   RenameContactJobState,

--- a/features/platform/contacts/src/device/operations/renameExternalContact.test.ts
+++ b/features/platform/contacts/src/device/operations/renameExternalContact.test.ts
@@ -1,6 +1,10 @@
 import type { IntentPlatformDefinition } from "@features/platform-device-intent";
 import { ContactNameSchema } from "@domain/entity-contact";
-import { mockContact, mockContactWithAddress } from "@domain/entity-contact/schema.mock";
+import {
+  mockContact,
+  mockContactWithAddress,
+  mockDeviceContactGroupCredentials,
+} from "@domain/entity-contact/schema.mock";
 import type {
   ContactIntentResult,
   RenameContactIntentInput,
@@ -19,18 +23,6 @@ describe("createRenameExternalContactOperation", () => {
     ContactIntentResult<RenameContactResult>
   >;
 
-  it("GIVEN a contact without an address WHEN creating a rename THEN it throws", () => {
-    expect(() =>
-      createRenameExternalContactOperation(
-        {
-          contact: mockContact(),
-          name: updatedName,
-        },
-        intentDefinition,
-      ),
-    ).toThrow("A contact with device credentials and an address is required");
-  });
-
   it("GIVEN a contact without credentials WHEN creating a rename THEN it throws", () => {
     expect(() =>
       createRenameExternalContactOperation(
@@ -40,7 +32,38 @@ describe("createRenameExternalContactOperation", () => {
         },
         intentDefinition,
       ),
-    ).toThrow("A contact with device credentials and an address is required");
+    ).toThrow("A contact with device credentials is required");
+  });
+
+  it("GIVEN a credentialed contact without an address WHEN creating a rename THEN it builds the device intent", () => {
+    const addresslessContact = mockContact({
+      deviceCredentials: mockDeviceContactGroupCredentials(),
+    });
+
+    const operation = createRenameExternalContactOperation(
+      { contact: addresslessContact, name: updatedName },
+      intentDefinition,
+    );
+
+    expect(operation.intentInput).toEqual({
+      previousContactName: addresslessContact.name,
+      newContactName: updatedName,
+      groupHandle: addresslessContact.deviceCredentials?.groupHandle,
+      hmacProof: addresslessContact.deviceCredentials?.hmacProof,
+    });
+  });
+
+  it("GIVEN any contact WHEN creating a rename THEN it initializes on the dashboard, never a coin app", () => {
+    const operation = createRenameExternalContactOperation(
+      { contact, name: updatedName },
+      intentDefinition,
+    );
+
+    expect(operation.initializationInput).toEqual({
+      appName: "BOLOS",
+      dependencies: [],
+      requireLatestFirmware: false,
+    });
   });
 
   it("GIVEN a valid contact WHEN creating a rename THEN it builds the device intent", () => {

--- a/features/platform/contacts/src/device/operations/renameExternalContact.ts
+++ b/features/platform/contacts/src/device/operations/renameExternalContact.ts
@@ -9,7 +9,7 @@ import {
   type RenameContactJobState,
   type RenameContactResult as RenameContactIntentResult,
 } from "../intents";
-import { resolveContactDeviceContext } from "../resolveContactDeviceContext";
+import { CONTACTS_DASHBOARD_INITIALIZATION_INPUT } from "../resolveContactDeviceContext";
 import type { ContactOperation } from "../types";
 import type { IntentPlatformDefinition } from "@features/platform-device-intent";
 
@@ -40,11 +40,12 @@ export function createRenameExternalContactOperation(
   IntentResult,
   RenameExternalContactResult
 > {
-  const address = input.contact.addresses[0];
   const credentials = input.contact.deviceCredentials;
 
-  if (address === undefined || credentials === undefined) {
-    throw new Error("A contact with device credentials and an address is required");
+  // Rename is name-only and blockchain-agnostic: the group's own credentials are
+  // the whole input, so a contact with no address is still renameable.
+  if (credentials === undefined) {
+    throw new Error("A contact with device credentials is required");
   }
 
   return {
@@ -55,7 +56,7 @@ export function createRenameExternalContactOperation(
       groupHandle: credentials.groupHandle,
       hmacProof: credentials.hmacProof,
     },
-    initializationInput: resolveContactDeviceContext(address.currencyId).initializationInput,
+    initializationInput: CONTACTS_DASHBOARD_INITIALIZATION_INPUT,
     mapIntentResultToResult,
   };
 }

--- a/features/platform/contacts/src/device/resolveContactDeviceContext.ts
+++ b/features/platform/contacts/src/device/resolveContactDeviceContext.ts
@@ -18,6 +18,22 @@ export type ContactDeviceContext = Readonly<{
   initializationInput: ContactsDeviceInitializationInput;
 }>;
 
+/**
+ * Device initialization input for the Contacts operations the device OS serves
+ * from the dashboard (contact rename), rather than an embedded coin app.
+ *
+ * `BOLOS` is the dashboard's own app name, which makes DIE Phase 2 skip its
+ * open-app step: with no dependencies and no firmware floor, initialization
+ * narrows to connecting, unlocking and onboarding checks. The kit's device
+ * action then walks to the dashboard itself and enforces the minimum OS
+ * version, so there is nothing left for the host to gate on here.
+ */
+export const CONTACTS_DASHBOARD_INITIALIZATION_INPUT: ContactsDeviceInitializationInput = {
+  appName: "BOLOS",
+  dependencies: [],
+  requireLatestFirmware: false,
+};
+
 export function resolveContactDeviceContext(
   currencyId: ContactAddress["currencyId"],
 ): ContactDeviceContext {

--- a/features/platform/contacts/src/device/resolveContactDeviceContext.ts
+++ b/features/platform/contacts/src/device/resolveContactDeviceContext.ts
@@ -18,16 +18,6 @@ export type ContactDeviceContext = Readonly<{
   initializationInput: ContactsDeviceInitializationInput;
 }>;
 
-/**
- * Device initialization input for the Contacts operations the device OS serves
- * from the dashboard (contact rename), rather than an embedded coin app.
- *
- * `BOLOS` is the dashboard's own app name, which makes DIE Phase 2 skip its
- * open-app step: with no dependencies and no firmware floor, initialization
- * narrows to connecting, unlocking and onboarding checks. The kit's device
- * action then walks to the dashboard itself and enforces the minimum OS
- * version, so there is nothing left for the host to gate on here.
- */
 export const CONTACTS_DASHBOARD_INITIALIZATION_INPUT: ContactsDeviceInitializationInput = {
   appName: "BOLOS",
   dependencies: [],

--- a/features/platform/contacts/src/device/useContactsIntentsOrchestrator.ts
+++ b/features/platform/contacts/src/device/useContactsIntentsOrchestrator.ts
@@ -83,42 +83,64 @@ export function useContactsIntentsOrchestrator({
       operation: ContactOperation<JobState, Input, IntentResult, Result>,
     ): Promise<Result> =>
       new Promise<Result>((resolve, reject) => {
-        let hasReportedResult = false;
+        let hasSettled = false;
+
+        /**
+         * Fails the flow's promise and leaves the DIE alone. Whatever the
+         * executor has on screen — the intent's own failure state, or its
+         * generic fallback — is the error UI, so it has to stay up until the
+         * user dismisses it.
+         */
+        const fail = (error: unknown) => {
+          if (hasSettled) {
+            return;
+          }
+          hasSettled = true;
+          reject(error);
+        };
+
         const intent = createContactIntent(operation.intentDefinition, operation.intentInput, {
-          onResult: result => {
-            if (hasReportedResult) {
+          /**
+           * The job's result reporter reports exactly once per run and covers
+           * every outcome — success, each failure `JobState`, and teardown — so
+           * this is the only listener carrying flow semantics.
+           * `mapIntentResultToResult` throws on a reported failure, which is
+           * what separates the two branches below.
+           */
+          onResult: report => {
+            if (hasSettled) {
               return;
             }
-            hasReportedResult = true;
+            let result: Result;
             try {
-              resolve(operation.mapIntentResultToResult(result));
+              result = operation.mapIntentResultToResult(report);
             } catch (error) {
-              reject(error);
+              fail(error);
+              return;
             }
-          },
-          onJobComplete: () => {
-            if (!hasReportedResult) {
-              hasReportedResult = true;
-              reject(new ContactDeviceIntentMissingResultError());
-            }
+            hasSettled = true;
+            resolve(result);
+            // Success is the only outcome with nothing left to show: the flow
+            // advances and owns the UI from here. Every other ending keeps the
+            // DIE mounted, so this is the one place that dismisses it on the
+            // job's behalf.
             setActiveIntent(undefined);
           },
-          onJobError: error => {
-            hasReportedResult = true;
-            reject(error);
-            setActiveIntent(undefined);
-          },
+          // A job that completes without reporting, or that lets its observable
+          // error, has broken the reporter's contract. Neither is reachable for
+          // a job built on `createContactIntentResultReporter`, but rejecting
+          // keeps such a bug from hanging the caller's promise forever.
+          onJobComplete: () => fail(new ContactDeviceIntentMissingResultError()),
+          onJobError: fail,
         });
 
         setActiveIntent({
           intent: intent as unknown as ContactDeviceIntent,
           initializationInput: operation.initializationInput,
-          cancel: () => {
-            if (!hasReportedResult) {
-              hasReportedResult = true;
-              reject(new ContactDeviceIntentCancelledError());
-            }
-          },
+          // Dismissed (or unmounted) before the job settled: nothing else will
+          // settle the promise. Clearing `activeIntent` is the dismissal's own
+          // job, not this callback's.
+          cancel: () => fail(new ContactDeviceIntentCancelledError()),
         });
       }),
     [],

--- a/features/platform/contacts/src/device/useContactsIntentsOrchestrator.ts
+++ b/features/platform/contacts/src/device/useContactsIntentsOrchestrator.ts
@@ -85,7 +85,13 @@ export function useContactsIntentsOrchestrator({
       new Promise<Result>((resolve, reject) => {
         let hasSettled = false;
 
-        const failWithoutDismissingExecutor = (error: unknown) => {
+        /**
+         * Fails the flow's promise and leaves the DIE alone. Whatever the
+         * executor has on screen — the intent's own failure state, or its
+         * generic fallback — is the error UI, so it has to stay up until the
+         * user dismisses it.
+         */
+        const fail = (error: unknown) => {
           if (hasSettled) {
             return;
           }
@@ -94,6 +100,13 @@ export function useContactsIntentsOrchestrator({
         };
 
         const intent = createContactIntent(operation.intentDefinition, operation.intentInput, {
+          /**
+           * The job's result reporter reports exactly once per run and covers
+           * every outcome — success, each failure `JobState`, and teardown — so
+           * this is the only listener carrying flow semantics.
+           * `mapIntentResultToResult` throws on a reported failure, which is
+           * what separates the two branches below.
+           */
           onResult: report => {
             if (hasSettled) {
               return;
@@ -102,22 +115,32 @@ export function useContactsIntentsOrchestrator({
             try {
               result = operation.mapIntentResultToResult(report);
             } catch (error) {
-              failWithoutDismissingExecutor(error);
+              fail(error);
               return;
             }
             hasSettled = true;
             resolve(result);
+            // Success is the only outcome with nothing left to show: the flow
+            // advances and owns the UI from here. Every other ending keeps the
+            // DIE mounted, so this is the one place that dismisses it on the
+            // job's behalf.
             setActiveIntent(undefined);
           },
-          onJobComplete: () =>
-            failWithoutDismissingExecutor(new ContactDeviceIntentMissingResultError()),
-          onJobError: failWithoutDismissingExecutor,
+          // A job that completes without reporting, or that lets its observable
+          // error, has broken the reporter's contract. Neither is reachable for
+          // a job built on `createContactIntentResultReporter`, but rejecting
+          // keeps such a bug from hanging the caller's promise forever.
+          onJobComplete: () => fail(new ContactDeviceIntentMissingResultError()),
+          onJobError: fail,
         });
 
         setActiveIntent({
           intent: intent as unknown as ContactDeviceIntent,
           initializationInput: operation.initializationInput,
-          cancel: () => failWithoutDismissingExecutor(new ContactDeviceIntentCancelledError()),
+          // Dismissed (or unmounted) before the job settled: nothing else will
+          // settle the promise. Clearing `activeIntent` is the dismissal's own
+          // job, not this callback's.
+          cancel: () => fail(new ContactDeviceIntentCancelledError()),
         });
       }),
     [],

--- a/features/platform/contacts/src/device/useContactsIntentsOrchestrator.ts
+++ b/features/platform/contacts/src/device/useContactsIntentsOrchestrator.ts
@@ -85,13 +85,7 @@ export function useContactsIntentsOrchestrator({
       new Promise<Result>((resolve, reject) => {
         let hasSettled = false;
 
-        /**
-         * Fails the flow's promise and leaves the DIE alone. Whatever the
-         * executor has on screen — the intent's own failure state, or its
-         * generic fallback — is the error UI, so it has to stay up until the
-         * user dismisses it.
-         */
-        const fail = (error: unknown) => {
+        const failWithoutDismissingExecutor = (error: unknown) => {
           if (hasSettled) {
             return;
           }
@@ -100,13 +94,6 @@ export function useContactsIntentsOrchestrator({
         };
 
         const intent = createContactIntent(operation.intentDefinition, operation.intentInput, {
-          /**
-           * The job's result reporter reports exactly once per run and covers
-           * every outcome — success, each failure `JobState`, and teardown — so
-           * this is the only listener carrying flow semantics.
-           * `mapIntentResultToResult` throws on a reported failure, which is
-           * what separates the two branches below.
-           */
           onResult: report => {
             if (hasSettled) {
               return;
@@ -115,32 +102,22 @@ export function useContactsIntentsOrchestrator({
             try {
               result = operation.mapIntentResultToResult(report);
             } catch (error) {
-              fail(error);
+              failWithoutDismissingExecutor(error);
               return;
             }
             hasSettled = true;
             resolve(result);
-            // Success is the only outcome with nothing left to show: the flow
-            // advances and owns the UI from here. Every other ending keeps the
-            // DIE mounted, so this is the one place that dismisses it on the
-            // job's behalf.
             setActiveIntent(undefined);
           },
-          // A job that completes without reporting, or that lets its observable
-          // error, has broken the reporter's contract. Neither is reachable for
-          // a job built on `createContactIntentResultReporter`, but rejecting
-          // keeps such a bug from hanging the caller's promise forever.
-          onJobComplete: () => fail(new ContactDeviceIntentMissingResultError()),
-          onJobError: fail,
+          onJobComplete: () =>
+            failWithoutDismissingExecutor(new ContactDeviceIntentMissingResultError()),
+          onJobError: failWithoutDismissingExecutor,
         });
 
         setActiveIntent({
           intent: intent as unknown as ContactDeviceIntent,
           initializationInput: operation.initializationInput,
-          // Dismissed (or unmounted) before the job settled: nothing else will
-          // settle the promise. Clearing `activeIntent` is the dismissal's own
-          // job, not this callback's.
-          cancel: () => fail(new ContactDeviceIntentCancelledError()),
+          cancel: () => failWithoutDismissingExecutor(new ContactDeviceIntentCancelledError()),
         });
       }),
     [],

--- a/features/platform/contacts/src/device/useContactsIntentsOrchestrator.web.test.ts
+++ b/features/platform/contacts/src/device/useContactsIntentsOrchestrator.web.test.ts
@@ -113,7 +113,7 @@ describe("useContactsIntentsOrchestrator", () => {
     expect(result.current.dieProps).toBeUndefined();
   });
 
-  it("GIVEN an active operation WHEN its intent reports failure THEN it rejects with that failure", async () => {
+  it("GIVEN an active operation WHEN its intent reports failure THEN it rejects with that failure and keeps the DIE open", async () => {
     // GIVEN
     const { result } = renderHook(() => useContactsIntentsOrchestrator({ intents }));
     let request!: ReturnType<typeof startRegisterExternalAddress>;
@@ -131,6 +131,54 @@ describe("useContactsIntentsOrchestrator", () => {
 
     // THEN
     await expect(request.promise).rejects.toBe(error);
+    // The failure's own JobState is the user-facing error screen, rendered by
+    // the executor while idle (lastIntentSnapshot) -- the DIE must stay mounted
+    // so it actually gets a chance to show, instead of vanishing instantly.
+    expect(result.current.dieProps).toBeDefined();
+  });
+
+  it("GIVEN an active operation whose intent reported failure WHEN its observable also errors THEN it still keeps the DIE open", async () => {
+    // GIVEN
+    const { result } = renderHook(() => useContactsIntentsOrchestrator({ intents }));
+    let request!: ReturnType<typeof startRegisterExternalAddress>;
+    act(() => {
+      request = startRegisterExternalAddress(result.current);
+    });
+    const dieProps = getActiveDieProps(result.current);
+    const error = new Error("registration failed");
+
+    // WHEN -- a buggy job could report a failure and still let its observable
+    // error afterward instead of completing; the already-showing failure
+    // screen must not be ripped away because of that contract violation.
+    act(() => {
+      dieProps.intent.onResult?.({ type: "failure", error });
+      dieProps.intent.onJobError?.(new Error("late observable error"));
+    });
+
+    // THEN
+    await expect(request.promise).rejects.toBe(error);
+    expect(result.current.dieProps).toBeDefined();
+  });
+
+  it("GIVEN an active operation whose intent reported failure WHEN the user dismisses the error screen THEN it closes the DIE", async () => {
+    // GIVEN
+    const { result } = renderHook(() => useContactsIntentsOrchestrator({ intents }));
+    let request!: ReturnType<typeof startRegisterExternalAddress>;
+    act(() => {
+      request = startRegisterExternalAddress(result.current);
+    });
+    const dieProps = getActiveDieProps(result.current);
+    const error = new Error("registration failed");
+    act(() => {
+      dieProps.intent.onResult?.({ type: "failure", error });
+      dieProps.intent.onJobComplete?.();
+    });
+    await expect(request.promise).rejects.toBe(error);
+
+    // WHEN
+    act(() => getActiveDieProps(result.current).onUserCancel());
+
+    // THEN
     expect(result.current.dieProps).toBeUndefined();
   });
 
@@ -197,10 +245,13 @@ describe("useContactsIntentsOrchestrator", () => {
 
     // THEN
     await expect(request.promise).rejects.toBeInstanceOf(ContactDeviceIntentMissingResultError);
-    expect(result.current.dieProps).toBeUndefined();
+    // Success is the only ending that dismisses the DIE on the job's behalf, so
+    // this contract violation leaves it up for the user to close, same as any
+    // other failure.
+    expect(result.current.dieProps).toBeDefined();
   });
 
-  it("GIVEN an active operation WHEN its observable errors THEN it rejects with the fallback error", async () => {
+  it("GIVEN an active operation WHEN its observable errors THEN it rejects with the fallback error and keeps the DIE open", async () => {
     // GIVEN
     const { result } = renderHook(() => useContactsIntentsOrchestrator({ intents }));
     let request!: ReturnType<typeof startRegisterExternalAddress>;
@@ -217,6 +268,29 @@ describe("useContactsIntentsOrchestrator", () => {
 
     // THEN
     await expect(request.promise).rejects.toBe(error);
+    // The executor falls back to its generic IntentErrorComponent (retry/close)
+    // for an observable error -- the DIE must stay mounted for it to be seen.
+    expect(result.current.dieProps).toBeDefined();
+  });
+
+  it("GIVEN an active operation whose observable errored WHEN the user dismisses the fallback screen THEN it closes the DIE", async () => {
+    // GIVEN
+    const { result } = renderHook(() => useContactsIntentsOrchestrator({ intents }));
+    let request!: ReturnType<typeof startRegisterExternalAddress>;
+    act(() => {
+      request = startRegisterExternalAddress(result.current);
+    });
+    const dieProps = getActiveDieProps(result.current);
+    const error = new Error("unexpected observable error");
+    act(() => {
+      dieProps.intent.onJobError?.(error);
+    });
+    await expect(request.promise).rejects.toBe(error);
+
+    // WHEN
+    act(() => getActiveDieProps(result.current).onUserCancel());
+
+    // THEN
     expect(result.current.dieProps).toBeUndefined();
   });
 

--- a/features/platform/contacts/src/device/useContactsIntentsOrchestrator.web.test.ts
+++ b/features/platform/contacts/src/device/useContactsIntentsOrchestrator.web.test.ts
@@ -131,6 +131,9 @@ describe("useContactsIntentsOrchestrator", () => {
 
     // THEN
     await expect(request.promise).rejects.toBe(error);
+    // The failure's own JobState is the user-facing error screen, rendered by
+    // the executor while idle (lastIntentSnapshot) -- the DIE must stay mounted
+    // so it actually gets a chance to show, instead of vanishing instantly.
     expect(result.current.dieProps).toBeDefined();
   });
 
@@ -144,7 +147,9 @@ describe("useContactsIntentsOrchestrator", () => {
     const dieProps = getActiveDieProps(result.current);
     const error = new Error("registration failed");
 
-    // WHEN
+    // WHEN -- a buggy job could report a failure and still let its observable
+    // error afterward instead of completing; the already-showing failure
+    // screen must not be ripped away because of that contract violation.
     act(() => {
       dieProps.intent.onResult?.({ type: "failure", error });
       dieProps.intent.onJobError?.(new Error("late observable error"));
@@ -240,6 +245,9 @@ describe("useContactsIntentsOrchestrator", () => {
 
     // THEN
     await expect(request.promise).rejects.toBeInstanceOf(ContactDeviceIntentMissingResultError);
+    // Success is the only ending that dismisses the DIE on the job's behalf, so
+    // this contract violation leaves it up for the user to close, same as any
+    // other failure.
     expect(result.current.dieProps).toBeDefined();
   });
 
@@ -260,6 +268,8 @@ describe("useContactsIntentsOrchestrator", () => {
 
     // THEN
     await expect(request.promise).rejects.toBe(error);
+    // The executor falls back to its generic IntentErrorComponent (retry/close)
+    // for an observable error -- the DIE must stay mounted for it to be seen.
     expect(result.current.dieProps).toBeDefined();
   });
 

--- a/features/platform/contacts/src/device/useContactsIntentsOrchestrator.web.test.ts
+++ b/features/platform/contacts/src/device/useContactsIntentsOrchestrator.web.test.ts
@@ -131,9 +131,6 @@ describe("useContactsIntentsOrchestrator", () => {
 
     // THEN
     await expect(request.promise).rejects.toBe(error);
-    // The failure's own JobState is the user-facing error screen, rendered by
-    // the executor while idle (lastIntentSnapshot) -- the DIE must stay mounted
-    // so it actually gets a chance to show, instead of vanishing instantly.
     expect(result.current.dieProps).toBeDefined();
   });
 
@@ -147,9 +144,7 @@ describe("useContactsIntentsOrchestrator", () => {
     const dieProps = getActiveDieProps(result.current);
     const error = new Error("registration failed");
 
-    // WHEN -- a buggy job could report a failure and still let its observable
-    // error afterward instead of completing; the already-showing failure
-    // screen must not be ripped away because of that contract violation.
+    // WHEN
     act(() => {
       dieProps.intent.onResult?.({ type: "failure", error });
       dieProps.intent.onJobError?.(new Error("late observable error"));
@@ -245,9 +240,6 @@ describe("useContactsIntentsOrchestrator", () => {
 
     // THEN
     await expect(request.promise).rejects.toBeInstanceOf(ContactDeviceIntentMissingResultError);
-    // Success is the only ending that dismisses the DIE on the job's behalf, so
-    // this contract violation leaves it up for the user to close, same as any
-    // other failure.
     expect(result.current.dieProps).toBeDefined();
   });
 
@@ -268,8 +260,6 @@ describe("useContactsIntentsOrchestrator", () => {
 
     // THEN
     await expect(request.promise).rejects.toBe(error);
-    // The executor falls back to its generic IntentErrorComponent (retry/close)
-    // for an observable error -- the DIE must stay mounted for it to be seen.
     expect(result.current.dieProps).toBeDefined();
   });
 


### PR DESCRIPTION
<!-- #21236 (register external address) has merged, so this PR now targets develop directly. #21248 (edit external address) is stacked on top of it. -->

### 📝 Description

Implements the Contacts "rename contact" device intent end to end.

- Replace the stubbed `renameContactIntentJob` with a real `ContactsManager.renameContact()` call (device command `EDIT CONTACT NAME`), mirroring `registerExternalAddressIntent`'s job shape: one outcome mapper, a `switchMap` replay so a rejection keeps the job open behind a retry handle, and the shared result reporter.
- Rename is a dashboard operation rather than app-owned: it initializes with `appName: "BOLOS"` so DIE Phase 2 never opens a coin app, and a contact with no address is now renameable since only the group's credentials are required.
- Map a device refusal reported as 0x5501 (`ActionRefusedError`, from the kit's global error table rather than the Contacts app's) onto the same `device-rejected` failure state as register's 0x6A80, so both surface the same retry screen.
- UI: both apps map the job state to `ContinueOnDevice` while the user confirms, and to an `InfoState` per failure. Any failure now keeps the Device Intent Executor mounted until the user dismisses it, instead of tearing it down before the failure screen can render.

Builds against the released `@ledgerhq/device-contacts-kit@0.3.0` already in develop's catalog, so this PR carries no dependency changes.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35702] (renaming a contact)
- **ADR**: [Contacts Device Intents](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7299039425/ADR+Contacts+Device+Intents)

[LIVE-35702]: https://ledgerhq.atlassian.net/browse/LIVE-35702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
