### PR TITLE
[LWDM] feat(observability): attribute sign-stage failures to their live app

### DIFF
--- a/.changeset/LIVE-36569-sign-stage-manifest-id.md
+++ b/.changeset/LIVE-36569-sign-stage-manifest-id.md
@@ -1,0 +1,13 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Report the originating live-app or dApp on sign-stage `earn_transaction_failed` events.
+
+`manifestId` came only from `broadcastConfig.source`, which does not exist at the sign stage. So the Earn live-app skip in `toSegmentTrackEvent` — which keys on the manifest — could never fire there, and every device rejection inside the Earn app was counted twice: once by the Earn app, once by the seam. Successes were unaffected, because success is reported at broadcast where the skip works.
+
+`withLiveAppContext` already scopes the manifest id around every wallet-api and dApp signing call, so the seam reads it instead of changing the bridge signature. That choice is deliberate rather than lazy: mobile's legacy wallet-api path never forwards the manifest to the device action, so an argument would have missed that route entirely.
+
+The route *type* still waits for broadcast — the context carries an id, not a source — so the sign stage keeps `tx_pathway: "unknown"`.
+
+The context is a singleton restored around an `await`, not an `AsyncLocalStorage`, so two overlapping signatures would misattribute the second. Device signing serialises today, one device and one prompt, and a test pins the restore behaviour. LIVE-36571 removes the dependency by passing the source explicitly.

--- a/libs/ledger-live-common/src/bridge/impl.ts
+++ b/libs/ledger-live-common/src/bridge/impl.ts
@@ -27,6 +27,7 @@ import {
 } from "../coin-modules/registry";
 import { defaultBridgeExtensions } from "./defaultBridgeExtensions";
 import { isZcashShieldedEnabled } from "./zcashRouting";
+import { liveBlindSigningReporter } from "@ledgerhq/live-dmk-shared";
 import { throwError } from "rxjs";
 import { catchError, tap } from "rxjs/operators";
 import {
@@ -220,6 +221,25 @@ function attributeBroadcastSource(source?: TransactionSource): {
   }
 }
 
+/**
+ * The live-app or dApp that started this signature, when there is one.
+ *
+ * `broadcastConfig` does not exist at the sign stage, so the route is otherwise unknown until
+ * broadcast — which leaves the Earn live-app skip in `toSegmentTrackEvent` unable to fire, and
+ * double-counts its sign-stage failures. `withLiveAppContext` already scopes the manifest id
+ * around every wallet-api and dApp signing call, so reading it here attributes the stage
+ * without changing the bridge signature. That matters: mobile's legacy wallet-api path never
+ * forwards the manifest to the device action, so an argument would not cover every route.
+ *
+ * The store is a singleton set and restored around an `await`, not an `AsyncLocalStorage`, so
+ * two overlapping signatures would misattribute the second. Device signing serialises — one
+ * device, one prompt — so that holds today. LIVE-36571 replaces this by passing the source
+ * explicitly. Note the singleton now has two consumers, this and the blind-signing reporter.
+ */
+function currentLiveAppManifestId(): string | undefined {
+  return liveBlindSigningReporter.getContext().liveAppContext ?? undefined;
+}
+
 // Exported for unit testing the transaction-observability seam.
 export async function wrapAccountBridge<T extends TransactionCommon>(
   bridge: AccountBridge<T>,
@@ -246,8 +266,9 @@ export async function wrapAccountBridge<T extends TransactionCommon>(
      * the funnel cares about, and abandoning the prompt is an unsubscribe rather than an
      * error, so the device-action layer reports that instead.
      *
-     * The rich transaction is available (hence the exact action and the validators) but
-     * `broadcastConfig` is not, so the originating route is unknown until broadcast.
+     * The rich transaction is available (hence the exact action and the validators).
+     * `broadcastConfig` is not, so the route *type* stays unknown until broadcast — but the
+     * originating manifest comes from the live-app context, see below.
      */
     signOperation: (arg0: Parameters<typeof bridge.signOperation>[0]) =>
       bridge.signOperation(arg0).pipe(
@@ -268,7 +289,9 @@ export async function wrapAccountBridge<T extends TransactionCommon>(
               buildSignCommonEvent({
                 account: arg0.account,
                 mainAccount: arg0.account,
+                // The manifest names the origin; the route type still needs `broadcastConfig`.
                 pathway: TransactionPathway.Unknown,
+                manifestId: currentLiveAppManifestId(),
                 transaction: arg0.transaction,
               }),
               { stage: TransactionStage.Sign, error },

--- a/libs/ledger-live-common/src/bridge/wrapAccountBridge.observability.test.ts
+++ b/libs/ledger-live-common/src/bridge/wrapAccountBridge.observability.test.ts
@@ -10,11 +10,14 @@ jest.mock("../coin-modules/registry", () => ({
 }));
 
 import { wrapAccountBridge } from "./impl";
+import { withLiveAppContext } from "../wallet-api/blindSigningContext";
+import type { AppManifest } from "../wallet-api/types";
 import {
   setTransactionObserver,
   resetTransactionObservers,
   ErrorCategory,
   TransactionStage,
+  toSegmentTrackEvent,
   type LogEvent,
 } from "@ledgerhq/transaction-observability";
 
@@ -167,6 +170,72 @@ describe("wrapAccountBridge — transaction observability seam", () => {
     });
     // Signing never completed, so there is no payload to report.
     expect(events[0]).not.toHaveProperty("txPayload");
+  });
+
+  describe("sign-stage attribution from the live-app context", () => {
+    // `withLiveAppContext` holds the manifest for the whole signing call, so the seam can name
+    // the origin at a stage that has no `broadcastConfig`.
+    const manifest = (id: string) => ({ id }) as AppManifest;
+
+    const signFailure = async (): Promise<void> => {
+      const error = Object.assign(new Error(""), { name: "UserRefusedOnDevice" });
+      const bridge = makeBridge({
+        signOperation: jest.fn().mockReturnValue(throwError(() => error)),
+      });
+      const wrapped = await wrapAccountBridge(bridge, "cardano");
+      await expect(
+        lastValueFrom(
+          wrapped.signOperation({
+            account,
+            transaction: { family: "cardano", mode: "delegate" } as never,
+            deviceId: "device",
+          }),
+        ),
+      ).rejects.toBe(error);
+    };
+
+    test("reports the manifest that started the signature", async () => {
+      await withLiveAppContext(manifest("lido"), signFailure);
+
+      expect(events[0]).toMatchObject({ stage: TransactionStage.Sign, manifestId: "lido" });
+    });
+
+    test("reports no manifest for a native in-app signature", async () => {
+      await signFailure();
+
+      expect(events[0]).toMatchObject({ stage: TransactionStage.Sign });
+      expect(events[0].manifestId).toBeUndefined();
+    });
+
+    // The reason this PR exists: the Earn live-app skip keys on the manifest, so without one it
+    // could never fire at the sign stage and every device rejection was counted twice.
+    test("an Earn live-app sign failure maps to no Segment event", async () => {
+      await withLiveAppContext(manifest("earn"), signFailure);
+
+      expect(events[0].manifestId).toBe("earn");
+      expect(toSegmentTrackEvent(events[0])).toBeNull();
+    });
+
+    test("the same failure outside the Earn app still maps to an event", async () => {
+      await withLiveAppContext(manifest("lido"), signFailure);
+
+      expect(toSegmentTrackEvent(events[0])).toMatchObject({
+        event: "earn_transaction_failed",
+        properties: expect.objectContaining({ manifest_id: "lido" }),
+      });
+    });
+
+    // The context is a singleton restored around an await, not an AsyncLocalStorage. Pin the
+    // restore, because attribution silently follows whatever it holds. See LIVE-36571.
+    test("a nested context restores the outer manifest", async () => {
+      await withLiveAppContext(manifest("outer"), async () => {
+        await withLiveAppContext(manifest("inner"), signFailure);
+        await signFailure();
+      });
+      await signFailure();
+
+      expect(events.map(e => e.manifestId)).toEqual(["inner", "outer", undefined]);
+    });
   });
 
   // Solana is the case that only works because of correlation: its stake actions become a

--- a/libs/ledger-live-common/src/wallet-api/blindSigningContext.ts
+++ b/libs/ledger-live-common/src/wallet-api/blindSigningContext.ts
@@ -8,6 +8,10 @@ import { AppManifest } from "./types";
  *
  * Use this around any `uiHook["transaction.sign" | "message.sign" | ...]` or
  * `bridge.signOperation` invocation triggered on behalf of a live app.
+ *
+ * Two consumers read this now: the blind-signing reporter, and the earn funnel's sign stage
+ * (`bridge/impl.ts`), which uses it to attribute a signature to its live app. Changing the
+ * scope or lifetime here changes both. LIVE-36571 removes the funnel's dependency on it.
  */
 export async function withLiveAppContext<T>(
   manifest: AppManifest,


### PR DESCRIPTION
### 📝 Description

**Fixes a defect that is live on `develop` today, and unblocks [LIVE-35351](https://ledgerhq.atlassian.net/browse/LIVE-35351) (ETH dApp events).**

**Problem.** `manifestId` is read from `broadcastConfig.source`, which does not exist at the sign stage. The Earn live-app skip in `toSegmentTrackEvent` keys on the manifest, so it could never fire there.

A user who starts native staking inside the Earn live app and rejects on the device produces **two** `earn_transaction_failed` events — one from the Earn app, one from this seam. Successes were never affected, because success is reported at broadcast where the skip works. Until this lands, a funnel query must filter `stage == "broadcast"` to count each transaction once.

It also blocks the dApp work: that gates on the manifest and derives the action from call data, and the action is only legible at sign.

**Approach.** The plumbing already existed. [`withLiveAppContext`](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/ledger-live-common/src/wallet-api/blindSigningContext.ts) scopes a manifest id around a signing call, and its own docblock says to use it around `bridge.signOperation`. It already wraps all three routes:

| Route | Call site |
|---|---|
| dApp `eth_sendTransaction` | `wallet-api/useDappLogic.ts:522` |
| live-app `transaction.sign` | `wallet-api/logic.ts:99` |
| live-app raw sign | `wallet-api/logic.ts:161` |

So the seam reads it. About five lines, no API change, no call-site changes.

**Why read a context instead of passing an argument.** An explicit `manifestId` on `SignOperationArg0` looks cleaner, and at `hw/actions/transaction.ts:222` the value is already in scope. But it would not cover every route: desktop threads the manifest through, mobile's device-intent path passes it, and **mobile's legacy path drops it** at `Web3AppWebview/helpers.ts:675` when it navigates. The context covers all three, because the wrapper holds scope until `onSuccess` fires — across the whole signing, navigation included.

`getAccountBridge` cannot import from `wallet-api` (that direction already exists and would cycle), so the reader lives in `impl.ts` and reads `live-dmk-shared` directly. That package has no live-common dependency.

**What did not change.** The route *type* still waits for broadcast — the context carries an id, not a source — so the sign stage keeps `tx_pathway: "unknown"`. The manifest is deliberately **not** put into the correlation `WeakMap`: broadcast has its own and that one is authoritative. Native in-app staking is untouched.

**Known weakness, stated on purpose.** The store is a mutable singleton set and restored around an `await`, not an `AsyncLocalStorage`. Two overlapping signatures would misattribute the second. Device signing serialises — one device, one prompt, and the live app sits behind the signing screen — so it holds today. Mitigations in this PR: a comment that says the assumption out loud, a note at the setter that it now has two consumers, and a test pinning the restore. [LIVE-36571](https://ledgerhq.atlassian.net/browse/LIVE-36571) removes the dependency by passing the source explicitly.

**Review notes**

- The four new tests fail without the one-line change (verified: 4 failed / 12 passed with it removed), so they prove the behaviour rather than restate it.
- The nested-context test is the one guarding the weakness above — it is not incidental coverage.
- Local `pnpm typecheck` reports 16 errors in `families/aleo`, `families/solana`, `families/hedera`, `families/evm` and `mock/account.ts`. These are stale sibling builds in a local `node_modules`, not this change: e.g. `listSolanaStakingPositions` exists in `coin-solana/src` but not in its built `lib/`. No file in this diff appears.

**Test coverage:** yes, 16 seam tests pass. No UI changes.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36569](https://ledgerhq.atlassian.net/browse/LIVE-36569)
- Follows the merged stack: #20817 → #20818 → #20819
- Blocks [LIVE-35351](https://ledgerhq.atlassian.net/browse/LIVE-35351)
- Follow-up: [LIVE-36571](https://ledgerhq.atlassian.net/browse/LIVE-36571)


[LIVE-35351]: https://ledgerhq.atlassian.net/browse/LIVE-35351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-36571]: https://ledgerhq.atlassian.net/browse/LIVE-36571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ