### PR TITLE
[LWDM] feat(observability): classify ETH dApp staking transactions (LIVE-35351)

### DIFF
--- a/.changeset/LIVE-35351-eth-dapp-staking-events.md
+++ b/.changeset/LIVE-35351-eth-dapp-staking-events.md
@@ -30,3 +30,7 @@ Observed: Lido, Kiln pooled, Coinbase, Chorus One, Kelp. Published but unobserve
 A contract is public infrastructure and identical for every user, and it is only ever read for a call inside a known staking app, never for a plain send whose recipient is the user's own payee.
 
 An unrecognised contract reports neither field rather than defaulting. Guessing `dedicated` for whatever is unmapped would turn one unknown pool into silently wrong data; an absent field is visible, and `contract_address` says exactly what to add.
+
+Classification also works at the broadcast stage without the sign stage's help. The generic coin framework copies the transaction onto the optimistic operation, so `recipients[0]` is the contract and `transactionRaw` carries the mode plus the call data — confirmed on a completed Lido deposit, where the data arrives as an unprefixed hex string. Correlation stays as enrichment rather than a dependency, which matters on the split wallet-api route, where a signed operation is serialised and object identity is lost.
+
+Note for anyone querying this: `tx_pathway` is not one value across these providers. Lido is a live app, so it reads `wallet-api/transaction.signAndBroadcast`; the other seven are dApps and read `dApp/eth_sendTransaction`. Both routes go through the same account bridge, so the classification is identical either way — but a query that filters on one pathway will silently miss the rest.

--- a/.changeset/LIVE-35351-eth-dapp-staking-events.md
+++ b/.changeset/LIVE-35351-eth-dapp-staking-events.md
@@ -1,0 +1,32 @@
+---
+"@ledgerhq/transaction-observability": minor
+"@ledgerhq/live-common": patch
+---
+
+Report `earn_transaction_*` for ETH dApp and live-app staking.
+
+A contract call carries no staking `mode`, so the action came back undefined and every Lido, Kiln, Stader, Kelp, Coinbase, Chorus One, Figment and P2P transaction was dropped. Two signals now classify it, each read at the stage that has it: the action from the call data at sign, the originating app from the manifest.
+
+Neither works alone. A selector is the keccak hash of a function signature, not a statement of intent — `0xd0e30db0` is `deposit()` on WETH, wrapping ETH, as readily as it is a vault entry — so call data is only ever read inside a known staking app. The manifest, in turn, says the user was in Lido but not whether they staked or withdrew.
+
+The two vocabularies are kept in separate maps because they disagree: a generic-framework `mode` of `stake` picks a validator and means `delegate`, while a function named `stake` enters a pool and means `deposit`. A family mode always wins, so EVM chains that stake natively — sei_evm, monad, somnia, zero_gravity — keep their own wording and never fall through to call data.
+
+An allow-listed app calling a function the map does not cover is reported with `transaction_type: "unknown"` and the selector in `raw_transaction_type`, rather than dropped. A silent drop is the failure this project exists to remove: this way the gap is countable and the next mapping is obvious.
+
+Adds `staking_method` (`liquid`, `pooling`, `restaking`, `dedicated`) and restores `redeem` for share-exact ERC-4626 exits. `approve` stays out: ETH staking needs no approval before delegating, so counting one would inflate the funnel's denominator. `kiln-staking` reports no method, because one manifest serves both a pooled and a dedicated product and only a `queryParams.focus` the bridge never sees tells them apart.
+
+The allow list is held in code, because a gate must not depend on a network call. `stakingApps.integration.test.ts` reads the real Earn API and fails when a provider appears that the list has never heard of, or when a method stops matching its category.
+
+Reports `contract_address` and `output_currency` too. One lookup on the called contract answers both which token comes out and, for `kiln-staking`, which of its two products this was — a distinction its manifest cannot make, since both share one manifest id.
+
+The contracts were confirmed by signing and rejecting on device against each provider, which found two things assumption would have missed.
+
+**The deposit target is usually not the receipt token.** Only Lido mints on its own token. Kelp, Chorus One and Stader all deposit into a pool contract that mints the token at a different address, so a token address is no evidence of a deposit target. That inference was tried and was wrong three times out of five — Kelp most clearly, where the real target turned out to be `0x036676389e…` rather than rsETH.
+
+**Chorus One calls `deposit_all`**, which the selector list carries separately from `depositAll`. The map lacked that spelling, and it surfaced in the first test because an unmapped call inside a staking app is reported rather than dropped.
+
+Observed: Lido, Kiln pooled, Coinbase, Chorus One, Kelp. Published but unobserved: Stader, whose wallet connection does not complete.
+
+A contract is public infrastructure and identical for every user, and it is only ever read for a call inside a known staking app, never for a plain send whose recipient is the user's own payee.
+
+An unrecognised contract reports neither field rather than defaulting. Guessing `dedicated` for whatever is unmapped would turn one unknown pool into silently wrong data; an absent field is visible, and `contract_address` says exactly what to add.

--- a/apps/ledger-live-desktop/src/renderer/analytics/registerTransactionObserver.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/registerTransactionObserver.ts
@@ -24,9 +24,15 @@ if (process.env.NODE_ENV !== "production") {
       rawTransactionType: event.rawTransactionType,
       earnTransactionType: event.earnTransactionType,
       dataSource: event.dataSource,
+      // Attribution belongs on both outcomes: a sign event is always a failure, so reporting
+      // the manifest only on success hid it for exactly the dApp case.
+      manifestId: event.manifestId,
+      stakingMethod: event.stakingMethod,
+      dappContract: event.dappContract,
+      outputCurrency: event.outputCurrency,
       ...(event.status === "failure"
         ? { errorCategory: event.errorCategory, errorName: event.error.name }
-        : { validators: event.validators, manifestId: event.manifestId }),
+        : { validators: event.validators }),
     });
   });
 }

--- a/libs/ledger-live-common/src/bridge/impl.ts
+++ b/libs/ledger-live-common/src/bridge/impl.ts
@@ -280,6 +280,9 @@ export async function wrapAccountBridge<T extends TransactionCommon>(
               event.signedOperation,
               arg0.account.currency.family,
               arg0.transaction,
+              // A dApp's action is only read inside a known staking app, so the manifest has
+              // to travel with it — broadcast sees an `OUT` and could not recover it.
+              currentLiveAppManifestId(),
             );
           }
         }),

--- a/libs/transaction-observability/jest.config.js
+++ b/libs/transaction-observability/jest.config.js
@@ -10,7 +10,7 @@ module.exports = {
     ],
   },
   testEnvironment: "node",
-  testPathIgnorePatterns: ["lib/", "lib-es/"],
+  testPathIgnorePatterns: ["lib/", "lib-es/", ".*\\.integration\\.test\\.ts"],
   coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../" }], "text"],
   reporters: [
     "default",

--- a/libs/transaction-observability/jest.integ.config.js
+++ b/libs/transaction-observability/jest.integ.config.js
@@ -1,0 +1,7 @@
+// Integration tests hit real services, so they are kept out of the unit run and dispatched
+// deliberately. Mocking the network here would only prove a fixture matches itself.
+module.exports = {
+  ...require("./jest.config"),
+  testPathIgnorePatterns: ["lib/", "lib-es/"],
+  testRegex: "\\.integration\\.test\\.ts$",
+};

--- a/libs/transaction-observability/package.json
+++ b/libs/transaction-observability/package.json
@@ -20,6 +20,7 @@
   "types": "lib/index.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
+    "@ledgerhq/evm-tools": "workspace:^",
     "@ledgerhq/types-live": "workspace:^",
     "@shared/env": "workspace:*"
   },
@@ -45,6 +46,7 @@
     "format:check": "pnpm exec oxfmt -c ../../.oxfmtrc.json ./src --check",
     "typecheck": "tsc --noEmit --customConditions node",
     "test": "jest",
+    "test-integ": "jest --config=jest.integ.config.js",
     "coverage": "jest --coverage"
   },
   "exports": {

--- a/libs/transaction-observability/src/dappActions.test.ts
+++ b/libs/transaction-observability/src/dappActions.test.ts
@@ -471,3 +471,84 @@ describe("the gate rejects inherited property names", () => {
     },
   );
 });
+
+describe("classifying at broadcast with no sign context", () => {
+  /**
+   * The generic coin framework copies the transaction onto the operation: `recipients` is its
+   * recipient and `transactionRaw.data` its call data, as a bare hex string with no `0x`.
+   *
+   * This is the route correlation cannot serve — a signed operation serialised across the
+   * wallet-api webview boundary loses object identity, and successes are reported here.
+   */
+  const broadcastOnly = (raw: Record<string, unknown>, recipients: string[], manifestId?: string) =>
+    buildBroadcastCommonEvent({
+      account: ethereum,
+      mainAccount: ethereum,
+      pathway: TransactionPathway.Dapp,
+      manifestId,
+      signedOperation: {
+        signature: "0xsig",
+        operation: { type: "OUT", extra: {}, recipients, transactionRaw: raw },
+      } as unknown as SignedOperation,
+    });
+
+  it("reads the action, contract and token off the operation", () => {
+    const common = broadcastOnly(
+      { mode: "send", data: LIDO_SUBMIT.slice(2) },
+      [LIDO_STETH],
+      "lido",
+    );
+
+    expect(common).toMatchObject({
+      earnTransactionType: "deposit",
+      rawTransactionType: "submit",
+      dappContract: LIDO_STETH.toLowerCase(),
+      outputCurrency: "stETH",
+      stakingMethod: "liquid",
+      dataSource: "broadcast",
+    });
+  });
+
+  // Kiln's two products share a manifest, so without the contract a success could not say
+  // which one it was — the case that made carrying state necessary in the first place.
+  it("names Kiln's product from the operation alone", () => {
+    const common = broadcastOnly(
+      { mode: "send", data: LIDO_SUBMIT.slice(2) },
+      [KILN_PSETH],
+      "kiln-staking",
+    );
+
+    expect(common).toMatchObject({ stakingMethod: "pooling", outputCurrency: "psETH" });
+  });
+
+  it("claims nothing for a contract call outside a staking app", () => {
+    const common = broadcastOnly({ mode: "send", data: WETH_DEPOSIT.slice(2) }, [LIDO_STETH]);
+
+    expect(common.earnTransactionType).toBeUndefined();
+    expect(common.dappContract).toBeUndefined();
+  });
+
+  // A plain send's recipient is the user's own payee. It must never surface as a contract.
+  it("never reports a recipient when there is no call data", () => {
+    const common = broadcastOnly({ mode: "send" }, ["0xsomeone"], "lido");
+
+    expect(common.dappContract).toBeUndefined();
+    expect(common.rawTransactionType).toBe("OUT");
+  });
+
+  it("still falls back to the operation type when transactionRaw is absent", () => {
+    const common = buildBroadcastCommonEvent({
+      account: ethereum,
+      mainAccount: ethereum,
+      pathway: TransactionPathway.Dapp,
+      manifestId: "lido",
+      signedOperation: {
+        signature: "0xsig",
+        operation: { type: "OUT", extra: {} },
+      } as unknown as SignedOperation,
+    });
+
+    expect(common.rawTransactionType).toBe("OUT");
+    expect(common.dappContract).toBeUndefined();
+  });
+});

--- a/libs/transaction-observability/src/dappActions.test.ts
+++ b/libs/transaction-observability/src/dappActions.test.ts
@@ -1,0 +1,473 @@
+import type { Account, SignedOperation } from "@ledgerhq/types-live";
+import { setEnv } from "@shared/env";
+import { buildBroadcastCommonEvent, buildSignCommonEvent } from "./eventBuilders";
+import { rememberSignContext } from "./signContext";
+import { TransactionPathway, type LogEvent } from "./logEvent";
+import { toSegmentTrackEvent } from "./segmentEvent";
+import { deriveDappAction, readDappFunction } from "./dappActions";
+import { isStakingApp, stakingMethodOf } from "./stakingApps";
+import type { TransactionLike } from "./transactionShape";
+
+// Real selectors, so the map is checked against the vocabulary it actually meets.
+const LIDO_SUBMIT = "0xa1903eab"; // keccak256("submit(address)")
+const WETH_DEPOSIT = "0xd0e30db0"; // keccak256("deposit()") — wrapping ETH, not staking
+const STAKE_NO_ARGS = "0x3a4b66f1"; // keccak256("stake()")
+const UNMAPPED = "0xdeadbeef";
+
+// Observed in a real Lido stake on desktop: `submit(address)` is called on stETH itself, so
+// the deposit target and the receipt token are one address.
+const LIDO_STETH = "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84";
+const KILN_PSETH = "0x5DB5235b5C7e247488784986e58019fFFd98FdA4";
+// Stader publishes this as the only contract its app should touch. A pool manager, not a
+// token: CAL returns nothing for it, while ETHx lives at a different address.
+const STADER_POOL = "0xcf5ea1b38380f6af39068375516daf40ed70d299";
+
+const ethereum = {
+  id: "account-id",
+  type: "Account",
+  currency: { id: "ethereum", family: "evm", ticker: "ETH" },
+} as unknown as Account;
+
+const sei = {
+  id: "account-id",
+  type: "Account",
+  currency: { id: "sei_evm", family: "evm", ticker: "SEI" },
+} as unknown as Account;
+
+const callData = (selector: string) => Buffer.from(selector.slice(2), "hex");
+
+const signEvent = (over: {
+  account?: Account;
+  manifestId?: string;
+  transaction: TransactionLike;
+}) =>
+  buildSignCommonEvent({
+    account: over.account ?? ethereum,
+    mainAccount: over.account ?? ethereum,
+    pathway: TransactionPathway.Dapp,
+    manifestId: over.manifestId,
+    transaction: over.transaction,
+  });
+
+beforeEach(() => setEnv("LEDGER_CLIENT_VERSION", "llc/test"));
+
+describe("the dApp selector vocabulary", () => {
+  it("reads the called function's name", () => {
+    expect(readDappFunction(LIDO_SUBMIT)).toBe("submit");
+  });
+
+  // The miss has to be countable, so an unmapped call reports the selector itself.
+  it("falls back to the selector when the function is unknown", () => {
+    expect(readDappFunction(UNMAPPED)).toBe("0xdeadbeef");
+  });
+
+  it.each([
+    ["submit", "deposit"],
+    ["stake", "deposit"],
+    // Underscored and camel-cased spellings are separate functions in the selector list, and
+    // Chorus One really calls this one — a miss here cost us an action in a live test.
+    ["deposit_all", "deposit"],
+    ["depositAll", "deposit"],
+    ["withdraw_all", "withdraw"],
+    ["requestWithdrawals", "withdraw"],
+    ["redeem", "redeem"],
+    ["claimRewards", "claimReward"],
+  ])("maps %s to %s", (fn, action) => {
+    expect(deriveDappAction(fn)).toBe(action);
+  });
+
+  it.each(["swap", "unoswap", "safeTransferFrom", "approve", "0xdeadbeef"])(
+    "claims nothing for %s",
+    fn => {
+      expect(deriveDappAction(fn)).toBeUndefined();
+    },
+  );
+
+  /**
+   * The reason the two vocabularies live in separate maps. A generic-framework `mode` of
+   * `stake` picks a validator, so it is a delegation. A contract function named `stake` enters
+   * a pool, so it is a deposit. One map would have to answer both with the same word.
+   */
+  it("disagrees with the family mode map on purpose", () => {
+    expect(deriveDappAction("stake")).toBe("deposit");
+    expect(
+      signEvent({ account: sei, transaction: { family: "evm", mode: "stake" } })
+        .earnTransactionType,
+    ).toBe("delegate");
+  });
+});
+
+describe("reading the action off an EVM transaction", () => {
+  // Native EVM staking sets a generic-framework mode and may still carry call data. The mode
+  // has to win, or sei/monad would silently switch to the dApp vocabulary.
+  it("prefers the staking mode over the call data", () => {
+    const common = signEvent({
+      account: sei,
+      transaction: { family: "evm", mode: "delegate", data: callData(LIDO_SUBMIT) },
+    });
+
+    expect(common).toMatchObject({
+      earnTransactionType: "delegate",
+      rawTransactionType: "delegate",
+    });
+  });
+
+  it("reads the contract call when the mode is a plain send", () => {
+    const common = signEvent({
+      manifestId: "lido",
+      transaction: { family: "evm", mode: "send", data: callData(LIDO_SUBMIT) },
+    });
+
+    expect(common).toMatchObject({ earnTransactionType: "deposit", rawTransactionType: "submit" });
+  });
+
+  it("reports the selector when the function is not mapped", () => {
+    const common = signEvent({
+      manifestId: "lido",
+      transaction: { family: "evm", mode: "send", data: callData(UNMAPPED) },
+    });
+
+    expect(common.earnTransactionType).toBeUndefined();
+    expect(common.rawTransactionType).toBe("0xdeadbeef");
+  });
+
+  it("claims nothing for a plain transfer with no call data", () => {
+    const common = signEvent({ transaction: { family: "evm", mode: "send" } });
+
+    expect(common.earnTransactionType).toBeUndefined();
+  });
+});
+
+describe("resolving the contract", () => {
+  const lidoStake = (over: { recipient?: string } = {}) =>
+    signEvent({
+      manifestId: "lido",
+      transaction: {
+        family: "evm",
+        mode: "send",
+        recipient: over.recipient ?? LIDO_STETH,
+        data: callData(LIDO_SUBMIT),
+      },
+    });
+
+  it("reports the contract that was called", () => {
+    expect(lidoStake().dappContract).toBe(LIDO_STETH.toLowerCase());
+  });
+
+  it("reads the receipt token off the contract", () => {
+    expect(lidoStake().outputCurrency).toBe("stETH");
+  });
+
+  // Reported lower-cased whichever way it arrives, so one contract cannot become two rows.
+  it("normalises the address, whichever casing it arrives in", () => {
+    expect(lidoStake({ recipient: LIDO_STETH.toLowerCase() })).toMatchObject({
+      dappContract: LIDO_STETH.toLowerCase(),
+      outputCurrency: "stETH",
+    });
+    expect(
+      lidoStake({ recipient: LIDO_STETH.toUpperCase().replace("0X", "0x") }).dappContract,
+    ).toBe(LIDO_STETH.toLowerCase());
+  });
+
+  /**
+   * The reason the contract is read at all. `kiln-staking` serves a pooled and a dedicated
+   * product behind one manifest, so only the contract can say which this was.
+   */
+  it("names the product where the manifest cannot", () => {
+    const pooled = signEvent({
+      manifestId: "kiln-staking",
+      transaction: {
+        family: "evm",
+        mode: "send",
+        recipient: KILN_PSETH,
+        data: callData(LIDO_SUBMIT),
+      },
+    });
+
+    expect(pooled).toMatchObject({ stakingMethod: "pooling", outputCurrency: "psETH" });
+  });
+
+  /**
+   * Stader is why the deposit target cannot be inferred from the receipt token: it mints ETHx
+   * from a pool manager at a different address. Lido is the exception, not the rule.
+   */
+  it("resolves a pool contract that is not the receipt token", () => {
+    const staked = signEvent({
+      manifestId: "stader-eth",
+      transaction: {
+        family: "evm",
+        mode: "send",
+        recipient: STADER_POOL,
+        data: callData(LIDO_SUBMIT),
+      },
+    });
+
+    expect(staked).toMatchObject({
+      dappContract: STADER_POOL.toLowerCase(),
+      outputCurrency: "ETHx",
+      stakingMethod: "liquid",
+    });
+  });
+
+  // Never guess. An unmapped pool would otherwise report as dedicated and nobody would know;
+  // an absent field plus `contract_address` says exactly what to add.
+  it("reports no method or token for an unknown contract, rather than a default", () => {
+    const unknown = signEvent({
+      manifestId: "kiln-staking",
+      transaction: {
+        family: "evm",
+        mode: "send",
+        recipient: "0x00000000000000000000000000000000deadbeef",
+        data: callData(LIDO_SUBMIT),
+      },
+    });
+
+    expect(unknown.stakingMethod).toBeUndefined();
+    expect(unknown.outputCurrency).toBeUndefined();
+    expect(unknown.dappContract).toBe("0x00000000000000000000000000000000deadbeef");
+  });
+
+  // A plain send's recipient is the user's own payee, so it must never be read as a contract.
+  it("never reports a recipient outside a staking app", () => {
+    const send = signEvent({
+      manifestId: "uniswap",
+      transaction: {
+        family: "evm",
+        mode: "send",
+        recipient: LIDO_STETH,
+        data: callData(WETH_DEPOSIT),
+      },
+    });
+
+    expect(send.dappContract).toBeUndefined();
+  });
+
+  it("never reports a recipient for native staking", () => {
+    const native = signEvent({
+      account: sei,
+      transaction: { family: "evm", mode: "delegate", recipient: LIDO_STETH },
+    });
+
+    expect(native.dappContract).toBeUndefined();
+    expect(native.outputCurrency).toBeUndefined();
+  });
+});
+
+describe("the staking-app gate", () => {
+  it("knows the ETH providers", () => {
+    expect(isStakingApp("lido")).toBe(true);
+    expect(isStakingApp("uniswap")).toBe(false);
+    expect(isStakingApp(undefined)).toBe(false);
+  });
+
+  it("reports how each app stakes", () => {
+    expect(stakingMethodOf("lido")).toBe("liquid");
+    expect(stakingMethodOf("kelp-dao")).toBe("restaking");
+    expect(stakingMethodOf("p2p")).toBe("dedicated");
+  });
+
+  // Kiln serves a pooled and a dedicated product behind one manifest, so the manifest cannot
+  // say which. An absent field is honest; a guessed one is not.
+  it("reports no method for an app that stakes more than one way", () => {
+    expect(isStakingApp("kiln-staking")).toBe(true);
+    expect(stakingMethodOf("kiln-staking")).toBeUndefined();
+  });
+});
+
+describe("what reaches Segment", () => {
+  const failure = (common: ReturnType<typeof signEvent>): LogEvent =>
+    ({
+      ...common,
+      status: "failure",
+      stage: "sign",
+      errorCategory: "unknown",
+      error: new Error("nope"),
+    }) as unknown as LogEvent;
+
+  it("emits a staking dApp call with its action and method", () => {
+    const mapped = toSegmentTrackEvent(
+      failure(
+        signEvent({
+          manifestId: "lido",
+          transaction: {
+            family: "evm",
+            mode: "send",
+            recipient: LIDO_STETH,
+            data: callData(LIDO_SUBMIT),
+          },
+        }),
+      ),
+    );
+
+    expect(mapped!.properties).toMatchObject({
+      transaction_type: "deposit",
+      raw_transaction_type: "submit",
+      manifest_id: "lido",
+      staking_method: "liquid",
+      contract_address: LIDO_STETH.toLowerCase(),
+      output_currency: "stETH",
+      flow: "stake",
+    });
+  });
+
+  // The case that decides why the manifest gates and the call data does not: this same
+  // selector is a staking entry in a vault and an ETH wrap in WETH.
+  it("drops a deposit call made outside a staking app", () => {
+    const mapped = toSegmentTrackEvent(
+      failure(
+        signEvent({
+          manifestId: "uniswap",
+          transaction: { family: "evm", mode: "send", data: callData(WETH_DEPOSIT) },
+        }),
+      ),
+    );
+
+    expect(mapped).toBeNull();
+  });
+
+  // A staking app is doing something we cannot name yet. Counting it keeps the funnel honest,
+  // and the selector says what to map next.
+  it("keeps an unmapped call from a staking app, marked unknown", () => {
+    const mapped = toSegmentTrackEvent(
+      failure(
+        signEvent({
+          manifestId: "kiln-staking",
+          transaction: { family: "evm", mode: "send", data: callData(UNMAPPED) },
+        }),
+      ),
+    );
+
+    expect(mapped!.properties).toMatchObject({
+      transaction_type: "unknown",
+      raw_transaction_type: "0xdeadbeef",
+      manifest_id: "kiln-staking",
+    });
+    expect(mapped!.properties).not.toHaveProperty("staking_method");
+  });
+
+  it("still drops a plain send that no staking app started", () => {
+    const mapped = toSegmentTrackEvent(
+      failure(signEvent({ transaction: { family: "evm", mode: "send" } })),
+    );
+
+    expect(mapped).toBeNull();
+  });
+
+  it("does not emit for the Earn live app, which reports its own", () => {
+    const mapped = toSegmentTrackEvent(
+      failure(
+        signEvent({
+          manifestId: "earn",
+          transaction: { family: "evm", mode: "send", data: callData(STAKE_NO_ARGS) },
+        }),
+      ),
+    );
+
+    expect(mapped).toBeNull();
+  });
+});
+
+describe("carrying the contract to the broadcast stage", () => {
+  const signedOperation = (op: Record<string, unknown>) =>
+    ({ signature: "0xsig", operation: op }) as unknown as SignedOperation;
+
+  /**
+   * Broadcast is where successes are reported, and the contract is only legible at sign. If it
+   * does not survive the hop, every successful stake loses `contract_address`,
+   * `output_currency` and — for Kiln, whose manifest serves two products — its method.
+   */
+  it("keeps the contract, token and method on a success", () => {
+    const signed = signedOperation({ type: "OUT", extra: {} });
+    rememberSignContext(
+      signed,
+      "evm",
+      {
+        family: "evm",
+        mode: "send",
+        recipient: KILN_PSETH,
+        data: callData(LIDO_SUBMIT),
+      },
+      "kiln-staking",
+    );
+
+    const broadcast = buildBroadcastCommonEvent({
+      account: ethereum,
+      mainAccount: ethereum,
+      pathway: TransactionPathway.Dapp,
+      manifestId: "kiln-staking",
+      signedOperation: signed,
+    });
+
+    expect(broadcast).toMatchObject({
+      earnTransactionType: "deposit",
+      dappContract: KILN_PSETH.toLowerCase(),
+      outputCurrency: "psETH",
+      stakingMethod: "pooling",
+    });
+  });
+
+  // Without the contract the manifest cannot name Kiln's product, so an absent contract must
+  // leave the method absent rather than fall back to something plausible.
+  it("reports no method at broadcast when nothing was correlated", () => {
+    const orphan = signedOperation({ type: "OUT", extra: {} });
+
+    const broadcast = buildBroadcastCommonEvent({
+      account: ethereum,
+      mainAccount: ethereum,
+      pathway: TransactionPathway.Dapp,
+      manifestId: "kiln-staking",
+      signedOperation: orphan,
+    });
+
+    expect(broadcast.dappContract).toBeUndefined();
+    expect(broadcast.outputCurrency).toBeUndefined();
+    expect(broadcast.stakingMethod).toBeUndefined();
+  });
+});
+
+describe("reading call data in either shape", () => {
+  // A serialised transaction carries `data` as a hex string. Treating it as a Buffer produced
+  // `0x0x095ea7` — a plausible-looking selector that is not one.
+  it("reads a hex string as well as a Buffer", () => {
+    const asString = signEvent({
+      manifestId: "lido",
+      transaction: { family: "evm", mode: "send", recipient: LIDO_STETH, data: LIDO_SUBMIT },
+    });
+
+    expect(asString).toMatchObject({
+      earnTransactionType: "deposit",
+      rawTransactionType: "submit",
+    });
+  });
+
+  it("reads a hex string with no 0x prefix", () => {
+    const bare = signEvent({
+      manifestId: "lido",
+      transaction: { family: "evm", mode: "send", data: LIDO_SUBMIT.slice(2) },
+    });
+
+    expect(bare.rawTransactionType).toBe("submit");
+  });
+
+  it.each([["0x"], [""], ["0x12"], ["zzzzzzzz"]])("claims nothing for %p", bad => {
+    const junk = signEvent({
+      manifestId: "lido",
+      transaction: { family: "evm", mode: "send", data: bad },
+    });
+
+    expect(junk.earnTransactionType).toBeUndefined();
+    expect(junk.rawTransactionType).toBe("send");
+  });
+});
+
+describe("the gate rejects inherited property names", () => {
+  // `in` and a bare index answer for these, which would open the gate and, worse, report
+  // `Object.prototype.toString` as a staking method.
+  it.each(["toString", "constructor", "hasOwnProperty", "__proto__"])(
+    "%s is not a staking app",
+    name => {
+      expect(isStakingApp(name)).toBe(false);
+      expect(stakingMethodOf(name)).toBeUndefined();
+    },
+  );
+});

--- a/libs/transaction-observability/src/dappActions.ts
+++ b/libs/transaction-observability/src/dappActions.ts
@@ -1,0 +1,70 @@
+import { DAPP_SELECTORS } from "@ledgerhq/evm-tools/selectors/index";
+import type { EarnTransactionType } from "./earnTransactionType";
+
+/**
+ * Maps an EVM contract call to a staking action.
+ *
+ * Deliberately separate from the family maps in `earnTransactionType.ts`, because the two
+ * vocabularies disagree on the same words. A generic-coin-framework `mode` of `stake` means
+ * `delegate` — a validator is chosen. A selector named `stake` means `deposit` — a pool is
+ * entered and there is no validator. Merging them would silently mislabel one of the two.
+ *
+ * Only unambiguous staking verbs are mapped. Swaps, bridges and everything else fall through,
+ * which for an allow-listed app is reported as an unmapped action rather than dropped, so the
+ * gap stays visible.
+ */
+const DAPP_ACTIONS: Record<string, EarnTransactionType> = {
+  // Entry. Pooled and liquid staking have no validator to pick, so this is a deposit.
+  deposit: "deposit",
+  depositeth: "deposit",
+  depositall: "deposit",
+  // Observed in a Chorus One pooled stake. The map holds both spellings because the selector
+  // list really does carry `depositAll` and `deposit_all` as separate functions.
+  deposit_all: "deposit",
+  depositwithsymbolcheck: "deposit",
+  mint: "deposit",
+  // Lido's entry point, `submit(address)`.
+  submit: "deposit",
+  stake: "deposit",
+  supply: "deposit",
+  // Exit. Not `undelegate`: no validator is involved in a pooled or liquid exit.
+  withdraw: "withdraw",
+  withdraweth: "withdraw",
+  // Counterpart of `deposit_all`, from the same selector list.
+  withdraw_all: "withdraw",
+  withdrawwithsymbolcheck: "withdraw",
+  unstake: "withdraw",
+  requestwithdraw: "withdraw",
+  requestwithdrawals: "withdraw",
+  claimwithdrawal: "withdraw",
+  claimwithdrawals: "withdraw",
+  // Share-exact exit (ERC-4626), distinct from an amount-exact withdraw.
+  redeem: "redeem",
+  redeemyield: "redeem",
+  // Real on-chain delegation, where a validator is named.
+  delegate: "delegate",
+  undelegate: "undelegate",
+  redelegate: "redelegate",
+  claim: "claimReward",
+  claimrewards: "claimReward",
+  getreward: "claimReward",
+};
+
+/**
+ * The called function's name, or the raw selector when the map has never seen it.
+ *
+ * Returning the selector rather than nothing is the point: an allow-listed app calling an
+ * unmapped function is reported with the selector as its raw action, so the miss is countable
+ * and the next mapping is obvious. Only the four-byte signature hash is used — never the rest
+ * of the call data, which carries amounts and addresses.
+ */
+export function readDappFunction(selector: string): string {
+  return DAPP_SELECTORS[selector.toLowerCase()] ?? selector.toLowerCase();
+}
+
+/** `undefined` when the call is not a recognised staking action. */
+export function deriveDappAction(
+  functionName: string | undefined,
+): EarnTransactionType | undefined {
+  return functionName === undefined ? undefined : DAPP_ACTIONS[functionName.toLowerCase()];
+}

--- a/libs/transaction-observability/src/earnTransactionType.ts
+++ b/libs/transaction-observability/src/earnTransactionType.ts
@@ -4,9 +4,12 @@ import type { StakingOperation } from "@ledgerhq/coin-module-framework/api/types
  * Normalized staking action, for cross-flow funnel analytics.
  *
  * Written out rather than derived from `StakingOperation`: this is an analytics contract, so
- * it must widen by deliberate edit, never on a dependency bump. `approve` and `redeem` are
- * deliberately absent until the dApp/live-app parts land; `deposit` is already needed natively,
- * because Celo splits staking into a lock leg and a vote leg.
+ * it must widen by deliberate edit, never on a dependency bump. `deposit` is needed natively
+ * too, because Celo splits staking into a lock leg and a vote leg. `redeem` is the share-exact
+ * ERC-4626 exit, which only the dApp route produces.
+ *
+ * `approve` is deliberately absent: ETH staking needs no approval before delegating, so
+ * counting one would inflate the funnel's denominator.
  */
 export type EarnTransactionType =
   // StakingOperation
@@ -16,7 +19,8 @@ export type EarnTransactionType =
   | "claimReward"
   | "compoundReward"
   | "withdraw"
-  | "deposit";
+  | "deposit"
+  | "redeem";
 
 // Fails the build if upstream StakingOperation drifts out of EarnTransactionType.
 type Extends<Narrow extends Wide, Wide> = Narrow;

--- a/libs/transaction-observability/src/eventBuilders.ts
+++ b/libs/transaction-observability/src/eventBuilders.ts
@@ -17,7 +17,10 @@ import {
 } from "./logEvent";
 import { deriveEarnTransactionType, type EarnTransactionType } from "./earnTransactionType";
 import { deriveFromOperationType } from "./operationType";
-import { getRawTransactionType, getStakeTarget, type TransactionLike } from "./transactionShape";
+import { getStakeTarget, type TransactionLike } from "./transactionShape";
+import { stakingMethodOf } from "./stakingApps";
+import { outputCurrencyOf, stakingMethodOfContract } from "./stakingContracts";
+import { readAction } from "./resolveAction";
 import { recallSignContext } from "./signContext";
 import { classifyTransactionError, ErrorCategory, toError, unwrapRpcError } from "./errorCategory";
 
@@ -34,6 +37,7 @@ type Attribution = {
 type ActionFields = {
   earnTransactionType?: EarnTransactionType;
   rawTransactionType?: string;
+  dappContract?: string;
   validators?: string[];
   isSendMax: boolean;
   dataSource: TransactionDataSource;
@@ -41,6 +45,8 @@ type ActionFields = {
 
 function buildCommon(attribution: Attribution, action: ActionFields): CommonLogEvent {
   const { account, mainAccount, pathway, manifestId, source } = attribution;
+  const stakingMethod = stakingMethodOfContract(action.dappContract) ?? stakingMethodOf(manifestId);
+  const outputCurrency = outputCurrencyOf(action.dappContract);
   return {
     appVersion: getEnv("LEDGER_CLIENT_VERSION"),
     pathway,
@@ -51,9 +57,14 @@ function buildCommon(attribution: Attribution, action: ActionFields): CommonLogE
     isSendMax: action.isSendMax,
     dataSource: action.dataSource,
     ...(manifestId ? { manifestId } : {}),
+    // The contract is the more precise of the two: it distinguishes Kiln's pooled product
+    // from its dedicated one, which share a manifest. The manifest covers everything else.
+    ...(stakingMethod ? { stakingMethod } : {}),
+    ...(outputCurrency ? { outputCurrency } : {}),
     ...(source ? { source } : {}),
     ...(action.earnTransactionType ? { earnTransactionType: action.earnTransactionType } : {}),
     ...(action.rawTransactionType ? { rawTransactionType: action.rawTransactionType } : {}),
+    ...(action.dappContract ? { dappContract: action.dappContract } : {}),
     ...(action.validators?.length ? { validators: action.validators } : {}),
     ...(account.type === "TokenAccount"
       ? { tokenId: account.token.id, tokenTicker: account.token.ticker }
@@ -69,13 +80,8 @@ export function buildSignCommonEvent(
   attribution: Attribution & { transaction?: TransactionLike | null },
 ): CommonLogEvent {
   const { transaction } = attribution;
-  const rawTransactionType = getRawTransactionType(transaction);
   return buildCommon(attribution, {
-    earnTransactionType: deriveEarnTransactionType(
-      attribution.mainAccount.currency.family,
-      rawTransactionType,
-    ),
-    rawTransactionType,
+    ...readAction(attribution.mainAccount.currency.family, attribution.manifestId, transaction),
     validators: getStakeTarget(transaction),
     isSendMax: Boolean(transaction?.useAllAmount),
     dataSource: TransactionDataSource.Sign,

--- a/libs/transaction-observability/src/eventBuilders.ts
+++ b/libs/transaction-observability/src/eventBuilders.ts
@@ -18,7 +18,7 @@ import {
 import { deriveEarnTransactionType, type EarnTransactionType } from "./earnTransactionType";
 import { deriveFromOperationType } from "./operationType";
 import { getStakeTarget, type TransactionLike } from "./transactionShape";
-import { stakingMethodOf } from "./stakingApps";
+import { isStakingApp, stakingMethodOf } from "./stakingApps";
 import { outputCurrencyOf, stakingMethodOfContract } from "./stakingContracts";
 import { readAction } from "./resolveAction";
 import { recallSignContext } from "./signContext";
@@ -140,20 +140,56 @@ export function buildBroadcastCommonEvent(
       // `extra.votes`), where the sign stage cannot see it — so take whichever stage has one
       // rather than letting a correlation hit throw the other away.
       validators: signed.validators ?? stakeTargetFromOperation(operation),
+      // The operation carries the recipient too, so a context stored without a contract
+      // (a rehydrated one, or one from before this field existed) still resolves.
+      dappContract: signed.dappContract ?? contractFromOperation(attribution, operation),
       dataSource: TransactionDataSource.Sign,
     });
   }
 
-  const rawMode = (operation.transactionRaw as { mode?: string } | undefined)?.mode;
-  const fromRawMode = deriveEarnTransactionType(family, rawMode);
+  // The generic coin framework copies the transaction onto the operation. Observed on a real
+  // Lido deposit: `recipients[0]` is the contract and `transactionRaw` carries `mode` plus the
+  // call data as a bare hex string with no `0x`. The shape comes from the coin module, not the
+  // route, so it holds for the dApp providers too.
+  //
+  // That makes a contract call classifiable without the sign stage, which matters wherever
+  // correlation misses: it keys on object identity, so a signed operation serialised and
+  // rehydrated — persisted, or handed back across the wallet-api boundary — will not match.
+  const raw = operation.transactionRaw as { mode?: string; data?: string } | undefined;
+  const fromOperation = readAction(family, attribution.manifestId, {
+    family,
+    mode: raw?.mode,
+    data: raw?.data,
+    recipient: operation.recipients?.[0],
+  });
+
+  // `readAction` echoes the mode back as the raw type even when it classifies nothing, so a
+  // plain `send` would otherwise shadow the operation type. Keep its wording only when it
+  // actually said something: an action, or a contract call whose selector is worth reporting.
+  const spoke =
+    fromOperation.earnTransactionType !== undefined || fromOperation.dappContract !== undefined;
 
   return buildCommon(attribution, {
-    earnTransactionType: fromRawMode ?? deriveFromOperationType(family, operation.type),
-    rawTransactionType: fromRawMode ? rawMode : operation.type,
+    ...fromOperation,
+    earnTransactionType:
+      fromOperation.earnTransactionType ?? deriveFromOperationType(family, operation.type),
+    rawTransactionType: spoke ? fromOperation.rawTransactionType : operation.type,
     validators: stakeTargetFromOperation(operation),
     isSendMax: false,
     dataSource: TransactionDataSource.Broadcast,
   });
+}
+
+/**
+ * The called contract, read off the optimistic operation.
+ *
+ * Gated on the manifest for the same reason the sign stage is: a plain send's recipient is the
+ * user's own payee, and must never be reported as a staking contract.
+ */
+function contractFromOperation(attribution: Attribution, operation: Operation): string | undefined {
+  if (!isStakingApp(attribution.manifestId)) return undefined;
+  const recipient = operation.recipients?.[0];
+  return typeof recipient === "string" ? recipient.toLowerCase() : undefined;
 }
 
 export function buildTransactionSuccessEvent(common: CommonLogEvent): SuccessLogEvent {

--- a/libs/transaction-observability/src/index.ts
+++ b/libs/transaction-observability/src/index.ts
@@ -17,6 +17,8 @@ export { getRawTransactionType, getStakeTarget, type TransactionLike } from "./t
 
 export { rememberSignContext, type SignContext } from "./signContext";
 
+export { isStakingApp, knownStakingApps, stakingMethodOf, type StakingMethod } from "./stakingApps";
+
 export {
   buildBroadcastCommonEvent,
   buildSignCommonEvent,

--- a/libs/transaction-observability/src/logEvent.ts
+++ b/libs/transaction-observability/src/logEvent.ts
@@ -1,4 +1,5 @@
 import type { TransactionSource } from "@ledgerhq/types-live";
+import type { StakingMethod } from "./stakingApps";
 import type { ErrorCategory } from "./errorCategory";
 import type { EarnTransactionType } from "./earnTransactionType";
 
@@ -50,6 +51,22 @@ type CommonLogEvent = {
    * on the source distinguishes the route, not the kind of identifier. Absent for native send.
    */
   manifestId?: string;
+  /**
+   * How the originating app stakes. Absent for native staking, and absent when the manifest
+   * serves more than one product — see `stakingApps.ts`.
+   */
+  stakingMethod?: StakingMethod;
+  /**
+   * The staking contract a dApp call targeted. Public infrastructure, identical for every
+   * user, and only ever set for a call inside a known staking app — never for a plain send,
+   * whose recipient is the user's own payee.
+   */
+  dappContract?: string;
+  /**
+   * Receipt token a deposit returns, e.g. `stETH`. Native staking has none: stake ADA and
+   * nothing comes back. Matches the Earn live-app's field of the same name.
+   */
+  outputCurrency?: string;
   source?: TransactionSource;
   /** Parent/network currency id (e.g. "ethereum"); token id is reported separately. */
   currencyId: string;

--- a/libs/transaction-observability/src/resolveAction.ts
+++ b/libs/transaction-observability/src/resolveAction.ts
@@ -1,0 +1,56 @@
+import { deriveEarnTransactionType, type EarnTransactionType } from "./earnTransactionType";
+import { deriveDappAction, readDappFunction } from "./dappActions";
+import { isStakingApp } from "./stakingApps";
+import { getDappSelector, getRawTransactionType, type TransactionLike } from "./transactionShape";
+
+export type ResolvedAction = {
+  earnTransactionType?: EarnTransactionType;
+  rawTransactionType?: string;
+  /**
+   * The contract the staking app called. Public infrastructure, identical for every user, and
+   * only ever set for a call inside a known staking app — never for a plain send, whose
+   * recipient is the user's own payee.
+   */
+  dappContract?: string;
+};
+
+/**
+ * The staking action, read from whichever vocabulary the transaction speaks.
+ *
+ * A family `mode` wins, so EVM chains that stake natively (sei_evm, monad and the rest set a
+ * generic-framework mode) keep their own wording and never fall through to call data.
+ *
+ * Call data is read **only** inside a known staking app. That restriction is the whole gate:
+ * a selector names a function, not an intent, so `deposit()` is a vault entry in one contract
+ * and an ETH wrap in WETH. Classifying it outside a staking app would count every wrap as an
+ * earn deposit. Inside one, the same selector is safe to trust.
+ *
+ * The two vocabularies stay separate on purpose: a `mode` of `stake` picks a validator and
+ * means `delegate`, while a function named `stake` enters a pool and means `deposit`.
+ */
+export function readAction(
+  family: string,
+  manifestId: string | undefined,
+  transaction: TransactionLike | undefined | null,
+): ResolvedAction {
+  const mode = getRawTransactionType(transaction);
+  const fromMode = deriveEarnTransactionType(family, mode);
+  if (fromMode) return { earnTransactionType: fromMode, rawTransactionType: mode };
+
+  if (!isStakingApp(manifestId)) return { rawTransactionType: mode };
+
+  const selector = getDappSelector(transaction);
+  if (!selector) return { rawTransactionType: mode };
+
+  // An unmapped function is still reported, by its selector, so the gap is countable and the
+  // next mapping is obvious rather than guessed at.
+  const called = readDappFunction(selector);
+  const recipient = transaction?.recipient;
+  return {
+    earnTransactionType: deriveDappAction(called),
+    rawTransactionType: called,
+    // Lower-cased at capture: the same contract reaches us checksum-cased on one route and
+    // lower-cased on another, and two spellings would split one contract into two rows.
+    ...(typeof recipient === "string" ? { dappContract: recipient.toLowerCase() } : {}),
+  };
+}

--- a/libs/transaction-observability/src/segmentEvent.ts
+++ b/libs/transaction-observability/src/segmentEvent.ts
@@ -1,4 +1,5 @@
 import type { LogEvent } from "./logEvent";
+import { isStakingApp } from "./stakingApps";
 
 export type SegmentTrackEvent = {
   event: string;
@@ -14,6 +15,9 @@ const EARN_TRANSACTION_FAILED = "earn_transaction_failed";
 // context (protocol, receipt token). Emitting here too would double-count.
 const APP_OWNED_MANIFEST_IDS = new Set(["earn", "earn-stg", "earn-prd-eks"]);
 
+// Reported instead of an action when a staking app calls an unmapped function.
+const UNMAPPED_ACTION = "unknown";
+
 /**
  * Maps a transaction {@link LogEvent} to a Segment/Mixpanel `track` call, or `null` when the
  * event does not belong in the earn funnel.
@@ -23,9 +27,11 @@ const APP_OWNED_MANIFEST_IDS = new Set(["earn", "earn-stg", "earn-prd-eks"]);
  * `error_reason`.
  */
 export function toSegmentTrackEvent(event: LogEvent): SegmentTrackEvent | null {
-  // The bridge seam sees every transaction, including plain sends and swaps. Only a
-  // recognised staking action belongs in the earn funnel.
-  if (!event.earnTransactionType) return null;
+  // The bridge seam sees every transaction, including plain sends and swaps. Two things put
+  // one in the earn funnel: a recognised staking action, or a transaction inside an app whose
+  // whole purpose is staking. The second arm is what admits dApp contract calls, whose action
+  // is only as good as the selector map — see `transaction_type` below.
+  if (!event.earnTransactionType && !isStakingApp(event.manifestId)) return null;
   if (event.manifestId && APP_OWNED_MANIFEST_IDS.has(event.manifestId)) return null;
 
   const isSuccess = event.status === "success";
@@ -39,7 +45,10 @@ export function toSegmentTrackEvent(event: LogEvent): SegmentTrackEvent | null {
     flow: "stake",
     stage: event.stage,
     status: isSuccess ? "success" : "failed",
-    transaction_type: event.earnTransactionType,
+    // `unknown` means a staking app called something the selector map does not cover. The
+    // transaction still counts — dropping it would hide real funnel volume — and
+    // `raw_transaction_type` carries the selector, so the next mapping is obvious.
+    transaction_type: event.earnTransactionType ?? UNMAPPED_ACTION,
     raw_transaction_type: event.rawTransactionType,
     // The asset the user recognises, plus the chain it settles on.
     input_currency: (event.tokenTicker ?? event.currencyTicker).toLowerCase(),
@@ -56,6 +65,11 @@ export function toSegmentTrackEvent(event: LogEvent): SegmentTrackEvent | null {
     // The live-app or dApp that originated the transaction. Named `manifest_id` rather than
     // `provider` because a manifest id is the app, not the staking provider behind it.
     ...(event.manifestId ? { manifest_id: event.manifestId } : {}),
+    ...(event.stakingMethod ? { staking_method: event.stakingMethod } : {}),
+    // A staking contract is public infrastructure and identical for every user, so it is safe
+    // to report — and it is what tells us which contracts we have yet to map.
+    ...(event.dappContract ? { contract_address: event.dappContract } : {}),
+    ...(event.outputCurrency ? { output_currency: event.outputCurrency } : {}),
     ...(event.validators?.length ? { validators: event.validators } : {}),
   };
 

--- a/libs/transaction-observability/src/signContext.ts
+++ b/libs/transaction-observability/src/signContext.ts
@@ -1,6 +1,7 @@
 import type { SignedOperation } from "@ledgerhq/types-live";
-import { deriveEarnTransactionType, type EarnTransactionType } from "./earnTransactionType";
-import { getRawTransactionType, getStakeTarget, type TransactionLike } from "./transactionShape";
+import type { EarnTransactionType } from "./earnTransactionType";
+import { readAction } from "./resolveAction";
+import { getStakeTarget, type TransactionLike } from "./transactionShape";
 
 /**
  * What the sign stage knows and the broadcast stage does not: the family's own action
@@ -9,6 +10,12 @@ import { getRawTransactionType, getStakeTarget, type TransactionLike } from "./t
 export type SignContext = {
   earnTransactionType: EarnTransactionType;
   rawTransactionType?: string;
+  /**
+   * Carried because broadcast is where successes are reported, and the contract is only
+   * legible at sign. Without it a successful stake loses `contract_address`,
+   * `output_currency`, and the method for an app whose manifest serves two products.
+   */
+  dappContract?: string;
   validators?: string[];
   isSendMax: boolean;
 };
@@ -34,16 +41,22 @@ export function rememberSignContext(
   signedOperation: SignedOperation,
   family: string,
   transaction: TransactionLike | undefined | null,
+  /** Needed because a dApp's action is only legible inside a known staking app. */
+  manifestId?: string,
 ): void {
   if (!signedOperation || typeof signedOperation !== "object") return;
-  const rawTransactionType = getRawTransactionType(transaction);
-  const earnTransactionType = deriveEarnTransactionType(family, rawTransactionType);
+  const { earnTransactionType, rawTransactionType, dappContract } = readAction(
+    family,
+    manifestId,
+    transaction,
+  );
   // Only a staking action is ever recalled, so storing anything else is churn the broadcast
   // stage never reads — it falls back to the operation type whenever the action is absent.
   if (!earnTransactionType) return;
   contexts.set(signedOperation, {
     earnTransactionType,
     rawTransactionType,
+    dappContract,
     validators: getStakeTarget(transaction),
     isSendMax: Boolean(transaction?.useAllAmount),
   });

--- a/libs/transaction-observability/src/stakingApps.integration.test.ts
+++ b/libs/transaction-observability/src/stakingApps.integration.test.ts
@@ -1,0 +1,114 @@
+import { knownStakingApps, stakingMethodOf, type StakingMethod } from "./stakingApps";
+import { tokenBackedContracts } from "./stakingContracts";
+
+/**
+ * Drift guard for the staking-app allow list.
+ *
+ * The list gates emission, so it is held in code rather than fetched — a gate must not depend
+ * on a network call. That leaves it free to go stale, which this closes: it reads the real Earn
+ * API and fails when a provider appears that the allow list has never heard of.
+ *
+ * Hits the live service on purpose. A mocked response would only prove the fixture matches
+ * itself, which is the failure this exists to catch.
+ */
+const PROVIDERS_URL = "https://earn.api.live.ledger.com/v0/currency/ethereum/providers";
+
+type Provider = {
+  liveAppId?: string;
+  category?: string;
+  active?: boolean;
+};
+
+// `protocol` is the API's word; `dedicated` is the one the business uses, and the one the API
+// itself uses in `queryParams.focus`.
+const METHOD_BY_CATEGORY: Record<string, StakingMethod> = {
+  liquid: "liquid",
+  pooling: "pooling",
+  restaking: "restaking",
+  protocol: "dedicated",
+};
+
+describe("the ETH staking-app allow list still matches the Earn API", () => {
+  let providers: Provider[];
+
+  beforeAll(async () => {
+    const response = await fetch(PROVIDERS_URL, { headers: { accept: "application/json" } });
+    expect(response.ok).toBe(true);
+    providers = (await response.json()) as Provider[];
+  }, 30_000);
+
+  it("returns providers to check against", () => {
+    expect(providers.length).toBeGreaterThan(0);
+  });
+
+  it("covers every active provider", () => {
+    const known = new Set(knownStakingApps());
+    const missing = [
+      ...new Set(providers.filter(p => p.active && p.liveAppId).map(p => p.liveAppId as string)),
+    ].filter(id => !known.has(id));
+
+    expect(missing).toEqual([]);
+  });
+
+  /**
+   * A live app serving two products cannot get its method from the manifest — Kiln offers a
+   * pooled and a dedicated one behind `kiln-staking`, told apart only by a `queryParams.focus`
+   * the bridge never sees. Those must report no method rather than a guessed one, and any
+   * *new* such app has to be spotted here rather than silently mislabelled.
+   */
+  it("agrees with each provider's category, and reports nothing where the app is ambiguous", () => {
+    const categoriesByApp = new Map<string, Set<string>>();
+    for (const p of providers) {
+      if (!p.active || !p.liveAppId || !p.category) continue;
+      const seen = categoriesByApp.get(p.liveAppId) ?? new Set<string>();
+      seen.add(p.category);
+      categoriesByApp.set(p.liveAppId, seen);
+    }
+
+    const disagreements = [...categoriesByApp.entries()]
+      .map(([liveAppId, categories]) => {
+        const expected =
+          categories.size === 1
+            ? METHOD_BY_CATEGORY[[...categories][0]]
+            : /* serves more than one product */ undefined;
+        return {
+          liveAppId,
+          categories: [...categories],
+          expected,
+          actual: stakingMethodOf(liveAppId),
+        };
+      })
+      .filter(row => row.expected !== row.actual);
+
+    expect(disagreements).toEqual([]);
+  });
+});
+
+/**
+ * The receipt-token contracts are hardcoded, so CAL is where they are checked.
+ *
+ * Only the addresses that *are* tokens can be checked here. Stader deposits into a pool
+ * manager that mints ETHx, and CAL returns nothing for a pool — asking it about one would fail
+ * a guard that assumed every entry were a token.
+ *
+ * The address is the key, never the ticker: a `stETH` ticker query returns Lido's contract and
+ * an unrelated `stakedETH`, so the ticker cannot identify a contract.
+ */
+const CAL_TOKENS = "https://global.api.prd.ledger.com/cal/v1/tokens";
+
+describe("the receipt-token contracts still match CAL", () => {
+  it.each(tokenBackedContracts())(
+    "%s is still %s",
+    async (address, ticker) => {
+      const url = `${CAL_TOKENS}?output=ticker,contract_address&contract_address=${address}`;
+      const response = await fetch(url, {
+        headers: { "X-Ledger-Client-Version": "transaction-observability-integration-test" },
+      });
+      expect(response.ok).toBe(true);
+
+      const tokens = (await response.json()) as Array<{ ticker?: string }>;
+      expect(tokens.map(t => t.ticker)).toContain(ticker);
+    },
+    30_000,
+  );
+});

--- a/libs/transaction-observability/src/stakingApps.ts
+++ b/libs/transaction-observability/src/stakingApps.ts
@@ -1,0 +1,59 @@
+/**
+ * How a provider stakes. Matches the Earn API's `category`, except that its `protocol`
+ * is reported as `dedicated` — the word the API itself uses in `queryParams.focus`.
+ */
+export type StakingMethod = "liquid" | "pooling" | "restaking" | "dedicated";
+
+/**
+ * The live-apps and dApps whose transactions belong in the earn funnel, and how each stakes.
+ *
+ * A manifest id is the only reliable signal that a contract call is staking. Call data cannot
+ * decide it: a selector is the keccak hash of a function signature, so `0xd0e30db0` is
+ * `deposit()` on WETH — wrapping ETH — as readily as it is a vault entry. Gating on the app the
+ * user opened keeps swaps, bridges and NFT mints out of `earn_transaction_*`.
+ *
+ * Ethereum is the whole list today: the Earn API returns providers for no other currency.
+ *
+ * `undefined` means the app stakes more than one way and the manifest cannot say which.
+ * `kiln-staking` serves both a pooled and a dedicated product, separated only by a
+ * `queryParams.focus` the bridge never sees, so its method comes from the contract instead.
+ *
+ * Kept in code rather than fetched: this gates emission, and a gate must not depend on a
+ * network call. `stakingApps.integration.test.ts` fails when the API gains an active app that
+ * is missing here.
+ */
+const STAKING_LIVE_APPS: Record<string, StakingMethod | undefined> = {
+  lido: "liquid",
+  "stader-eth": "liquid",
+  chorusone: "pooling",
+  "coinbase-staking": "pooling",
+  "kelp-dao": "restaking",
+  figment: "dedicated",
+  p2p: "dedicated",
+  // Pooled and dedicated share this manifest — see the docblock above.
+  "kiln-staking": undefined,
+};
+
+// Own keys only. `in` and a bare index also answer for `toString` and `constructor`, which
+// would open the gate for a manifest of that name and report a function as the method.
+function entry(manifestId: string | undefined): StakingMethod | undefined | null {
+  if (manifestId === undefined) return null;
+  return Object.prototype.hasOwnProperty.call(STAKING_LIVE_APPS, manifestId)
+    ? STAKING_LIVE_APPS[manifestId]
+    : null;
+}
+
+/** Whether a manifest's transactions belong in the earn funnel. */
+export function isStakingApp(manifestId: string | undefined): boolean {
+  return entry(manifestId) !== null;
+}
+
+/** How the app stakes, when its manifest alone is enough to say. */
+export function stakingMethodOf(manifestId: string | undefined): StakingMethod | undefined {
+  return entry(manifestId) ?? undefined;
+}
+
+/** The manifest ids this package knows about — read by the drift guard. */
+export function knownStakingApps(): string[] {
+  return Object.keys(STAKING_LIVE_APPS);
+}

--- a/libs/transaction-observability/src/stakingContracts.ts
+++ b/libs/transaction-observability/src/stakingContracts.ts
@@ -1,0 +1,108 @@
+import type { StakingMethod } from "./stakingApps";
+
+type StakingContract = {
+  /** Receipt token handed back for a deposit. Reported as `output_currency`. */
+  outputCurrency: string;
+  /** Set where the contract identifies the product more precisely than the manifest can. */
+  method?: StakingMethod;
+  /**
+   * Whether this address is the receipt token itself, rather than a pool that mints it.
+   * Only these can be checked against CAL, which lists tokens and not pool contracts.
+   */
+  isReceiptToken?: boolean;
+};
+
+/**
+ * The contracts these providers stake into, keyed by lower-cased address.
+ *
+ * **The deposit target is usually not the receipt token.** Of the five providers observed,
+ * only Lido mints on its own token — `submit(address)` on stETH. Stader, Chorus One and Kelp
+ * all deposit into a pool contract that mints the token elsewhere, and CAL returns nothing for
+ * those, because a pool is not a token.
+ *
+ * So a token address is never evidence of a deposit target. Every entry here is either
+ * observed in a real transaction or published by the provider; nothing is inferred from the
+ * receipt token, because that inference was tried and was wrong three times out of five.
+ *
+ * An unknown contract resolves to nothing rather than to a default. Guessing `dedicated` for
+ * whatever is unrecognised would turn one unmapped pool into silently wrong data; an absent
+ * field is visible, and `contract_address` on the event says what to add next.
+ *
+ * The three `dedicated` providers — p2p, figment, and Kiln's dedicated product — stake through
+ * the ETH2 deposit contract and hand back no token, so they have no entry here and take their
+ * method from the manifest.
+ */
+const STAKING_CONTRACTS: Record<string, StakingContract> = {
+  // Observed: a Lido stake calls `submit(address)` on exactly this address, which is stETH.
+  "0xae7ab96520de3a18e5e111b5eaab095312d7fe84": {
+    outputCurrency: "stETH",
+    method: "liquid",
+    isReceiptToken: true,
+  },
+  // Published by Stader as the only contract its app should touch. A pool manager, not a
+  // token — the ETHx it mints lives at a different address, below.
+  "0xcf5ea1b38380f6af39068375516daf40ed70d299": { outputCurrency: "ETHx", method: "liquid" },
+  /*
+   * ETHx is kept although Stader does *not* deposit into it — an exit can burn the token
+   * directly — but its presence must not be read as confirming a deposit targets it.
+   */
+  "0xa35b1b31ce002fbf2058d22f30f95d405200a15b": {
+    outputCurrency: "ETHx",
+    method: "liquid",
+    isReceiptToken: true,
+  },
+  // Observed: a Kelp restake calls `depositETH` on this pool, which mints rsETH. It is not the
+  // rsETH contract — the inference that it would be was wrong.
+  "0x036676389e48133b63a802f8635ad39e752d375d": { outputCurrency: "rsETH", method: "restaking" },
+  // Kelp's receipt token, kept for an exit that burns it directly. Not the deposit target.
+  "0xa1290d69c65a6fe4df752f95823fae25cb99e5a7": {
+    outputCurrency: "rsETH",
+    method: "restaking",
+    isReceiptToken: true,
+  },
+  // Observed: a Kiln pooled stake calls `stake` on psETH. This entry is also what separates
+  // Kiln's pooled product from its dedicated one, which share a manifest.
+  "0x5db5235b5c7e247488784986e58019fffd98fda4": {
+    outputCurrency: "psETH",
+    method: "pooling",
+    isReceiptToken: true,
+  },
+  // Observed: a Coinbase pooled stake calls `stake` on lcETH.
+  "0xc4dcb059dd98b45b090da8982234c61d0b9e84f9": {
+    outputCurrency: "lcETH",
+    method: "pooling",
+    isReceiptToken: true,
+  },
+};
+
+function lookup(contract: string | undefined): StakingContract | undefined {
+  return contract === undefined ? undefined : STAKING_CONTRACTS[contract.toLowerCase()];
+}
+
+/** The receipt token a deposit into this contract returns. */
+export function outputCurrencyOf(contract: string | undefined): string | undefined {
+  return lookup(contract)?.outputCurrency;
+}
+
+/** How this contract stakes, where the contract says it more precisely than the manifest. */
+export function stakingMethodOfContract(contract: string | undefined): StakingMethod | undefined {
+  return lookup(contract)?.method;
+}
+
+/** The addresses this package knows about — read by the drift guard. */
+export function knownStakingContracts(): string[] {
+  return Object.keys(STAKING_CONTRACTS);
+}
+
+/**
+ * Only the addresses that are receipt tokens, with the ticker they should resolve to.
+ *
+ * The drift guard checks these against CAL. A pool contract such as Stader's is deliberately
+ * excluded: CAL lists tokens, so asking it about a pool returns nothing and would fail a guard
+ * that assumed every entry were a token.
+ */
+export function tokenBackedContracts(): Array<[string, string]> {
+  return Object.entries(STAKING_CONTRACTS)
+    .filter(([, c]) => c.isReceiptToken)
+    .map(([address, c]) => [address, c.outputCurrency]);
+}

--- a/libs/transaction-observability/src/transactionShape.ts
+++ b/libs/transaction-observability/src/transactionShape.ts
@@ -24,6 +24,31 @@ export function getRawTransactionType(tx: TransactionLike | undefined | null): s
   return tx.mode as string | undefined;
 }
 
+/**
+ * The four-byte function selector of an EVM contract call, or `undefined` for a plain transfer.
+ *
+ * Read only when the transaction carries no staking `mode`, so EVM chains that stake natively
+ * (sei_evm, monad and the rest set a generic-framework mode) keep using their own vocabulary
+ * and never fall through to here.
+ *
+ * Deliberately takes only the selector. The rest of the call data holds amounts and addresses
+ * and has no place in product analytics.
+ */
+export function getDappSelector(tx: TransactionLike | undefined | null): string | undefined {
+  const data = tx?.data;
+  if (data === undefined || data === null) return undefined;
+
+  // A live transaction carries a Buffer; a serialised one carries a `0x`-prefixed string. Both
+  // reach this package, so normalise rather than assume — reading a string as a Buffer yields
+  // `0x0x095ea7`, which looks like a selector and is not one.
+  const hex =
+    typeof data === "string"
+      ? data.replace(/^0x/i, "")
+      : (data as { toString(encoding: "hex"): string }).toString("hex");
+
+  return /^[0-9a-f]{8}/i.test(hex) ? `0x${hex.slice(0, 8).toLowerCase()}` : undefined;
+}
+
 function nonEmptyStrings(list?: (string | undefined | null)[]): string[] | undefined {
   const filtered = (list ?? []).filter((a): a is string => Boolean(a));
   return filtered.length ? filtered : undefined;

--- a/libs/transaction-observability/src/transactionShape.ts
+++ b/libs/transaction-observability/src/transactionShape.ts
@@ -38,9 +38,10 @@ export function getDappSelector(tx: TransactionLike | undefined | null): string 
   const data = tx?.data;
   if (data === undefined || data === null) return undefined;
 
-  // A live transaction carries a Buffer; a serialised one carries a `0x`-prefixed string. Both
-  // reach this package, so normalise rather than assume — reading a string as a Buffer yields
-  // `0x0x095ea7`, which looks like a selector and is not one.
+  // A live transaction carries a Buffer. A serialised one carries a string, and the optimistic
+  // operation's is *unprefixed* — observed as `a1903eab…` on a real Lido deposit — while other
+  // routes prefix it. So normalise rather than assume: reading a prefixed string as a Buffer
+  // yields `0x0x095ea7`, which looks like a selector and is not one.
   const hex =
     typeof data === "string"
       ? data.replace(/^0x/i, "")

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16258,6 +16258,9 @@ importers:
 
   libs/transaction-observability:
     dependencies:
+      '@ledgerhq/evm-tools':
+        specifier: workspace:^
+        version: link:../evm-tools
       '@ledgerhq/types-live':
         specifier: workspace:^
         version: link:../types-live


### PR DESCRIPTION
### 📝 Description

**Part 5 of the earn-funnel work.** Base is [#21249](https://github.com/LedgerHQ/ledger-live/pull/21249) — review that first.

Stack: #20817 → #20818 → #20819 → [#21249 sign-stage manifest](https://github.com/LedgerHQ/ledger-live/pull/21249) → **this**

**Problem.** A dApp contract call carries no staking `mode`, so the action came back `undefined` and `toSegmentTrackEvent` dropped it. Every Lido, Kiln, Stader, Kelp, Coinbase, Chorus One, Figment and P2P transaction was invisible to the funnel.

**Approach — two signals, each read at the stage that has it.** The action comes from the call data at sign; the originating app comes from the manifest. Neither works alone:

- **Call data cannot decide intent.** A selector is the keccak hash of a function signature, nothing more: `0x3a4b66f1` is `keccak256("stake()")`, and any contract declaring `stake()` produces it. Worse, `0xd0e30db0` is `deposit()` and lives in `ETHEREUM_CLEAR_SIGNED_SELECTORS` as **WETH's wrap**. Gating on the name `deposit` would count every ETH wrap as an earn deposit.
- **The manifest cannot name the action.** It says the user was in Lido, not whether they staked or withdrew.

So **call data is only ever read inside a known staking app**. That restriction is the gate.

**The two vocabularies must not be merged.** A generic-framework `mode` of `stake` picks a validator and means `delegate`. A function named `stake` enters a pool and means `deposit`. Same word, opposite answers — so they live in separate maps, and a family `mode` always wins. EVM chains that stake natively (sei_evm, monad, somnia, zero_gravity) keep their own wording and never fall through to call data, even when they carry some.

**An unmapped function is reported, not dropped.** An allow-listed app calling something the map does not cover emits with `transaction_type: "unknown"` and the selector in `raw_transaction_type`. A silent drop is exactly the failure this project exists to remove; this way the gap is countable in production and the next mapping is obvious. Only the four-byte signature hash is used — never the rest of the call data, which carries amounts and addresses.

**Also in this PR**

- `staking_method`: `liquid` / `pooling` / `restaking` / `dedicated`. The API's `protocol` is reported as `dedicated`, the word the API itself uses in `queryParams.focus`.
- `redeem` restored, for share-exact ERC-4626 exits. **`approve` deliberately stays out**: ETH staking needs no approval before delegating, so counting one would inflate the funnel's denominator.
- `kiln-staking` reports **no** method. One manifest serves both a pooled and a dedicated product, told apart only by a `queryParams.focus` the bridge never sees. An absent field is honest; a guessed one is not. The contract address will settle it in follow-up work.
- The allow list is **in code**, because a gate must not depend on a network call. `stakingApps.integration.test.ts` reads the real Earn API and fails when a provider appears that the list has never heard of, or when a method stops matching its category. Integration tests are split out of the unit run via `jest.integ.config.js`, following `wallet-btc`.

**Review notes**

- `rememberSignContext` gains a `manifestId`. Without it a dApp's action would not survive to broadcast: the optimistic operation is an `OUT`, which `deriveFromOperationType` never maps. Correlation is doing the real work for dApps.
- The gate lives in `resolveAction.ts`, shared by the sign builder and the correlation store so the two cannot diverge.
- Field names match the Earn live app's `baseTransactionProps` — `manifest_id`, `output_currency`, `input_currency`, `network`. `protocol` is **not** replicated: there it is a display name ("Kiln USDC"), and a display name is unstable as an analytics key.
- `flow` stays `"stake"` here while the Earn app sends `"earn"`. Deliberate. The two halves join on **event name and `manifest_id`, never on `flow`**.

**Also reports `contract_address` and `output_currency`.** One lookup on the called contract gives the receipt token and, for `kiln-staking`, which of its two products this was — a distinction its manifest cannot make. A contract is public infrastructure, identical for every user, and only ever read for a call inside an allow-listed staking app, never for a plain send whose recipient is the user's own payee.

## Verified by hand, and it changed the design twice

Every provider below was signed and rejected on device, reading the dev-console output. Two findings that assumption would have missed:

**The deposit target is usually not the receipt token.** I had generalised from Lido, which calls `submit(address)` on stETH itself. Kelp, Chorus One and Stader all deposit into a pool contract that mints the token at a *different* address — CAL returns nothing for a pool. So a token address is no evidence of a deposit target: that inference was wrong three times out of five. Kelp is the clearest case, where the real target is `0x036676389e…` rather than rsETH.

**Chorus One calls `deposit_all`**, which the selector list carries separately from `depositAll`. The map lacked that spelling. It surfaced on the first test *because* an unmapped call inside a staking app is reported with its selector rather than dropped — under a silent-drop design, Chorus One would simply have been missing from the funnel with nothing to explain why.

| Provider | Verb | Deposit target | Shape |
|---|---|---|---|
| lido | `submit` | stETH | token |
| kiln-staking pooled | `stake` | psETH | token |
| coinbase-staking | `stake` | lcETH | token |
| chorusone | `deposit_all` | pool | pool |
| kelp-dao | `depositETH` | pool | pool |
| stader-eth | — | pool, published by Stader | pool |
| p2p, figment, kiln dedicated | — | ETH2 deposit contract, no token | 32 ETH minimum, untestable |

Where a contract is unrecognised, `staking_method` and `output_currency` are **absent** rather than defaulted, and `contract_address` reports the real address. That is what caught the Kelp error: an empty field instead of a plausible false one.

Also found: **Stader's wallet connection never completes**, so it cannot be tested at all, and Kelp did not auto-connect. No funnel can currently see either — raised as [LIVE-36618](https://ledgerhq.atlassian.net/browse/LIVE-36618).

**Test coverage:** yes — 325 unit tests in the lib, 68 in live-common, plus two live-API drift guards (the provider allow list against the Earn API, and the receipt-token contracts against CAL). I verified the allow-list guard fails when the list goes stale rather than passing vacuously. Integration tests are split out of the unit run via `jest.integ.config.js`, following `wallet-btc`, so normal CI stays offline.

### Demo

<img width="781" height="84" alt="image" src="https://github.com/user-attachments/assets/f7a9ce3d-ffe5-4089-a3dc-98c301e45877" />

<img width="716" height="42" alt="image" src="https://github.com/user-attachments/assets/ab547e29-2ef9-4a8b-bfe4-b2b283a15518" />



### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35351](https://ledgerhq.atlassian.net/browse/LIVE-35351)
- Depends on [LIVE-36569](https://ledgerhq.atlassian.net/browse/LIVE-36569) / #21249


[LIVE-35351]: https://ledgerhq.atlassian.net/browse/LIVE-35351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[LIVE-36618]: https://ledgerhq.atlassian.net/browse/LIVE-36618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ