### PR TITLE
[LWDM] fix(coin-cardano): don't inject vote cert or withdrawal on sends

### DIFF
--- a/.changeset/eight-lemons-vanish.md
+++ b/.changeset/eight-lemons-vanish.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-cardano": minor
+---
+
+cardano: stop injecting an ABSTAIN vote-delegation certificate (and an automatic reward withdrawal) into plain send transactions. The Conway `ConwayWdrlNotDelegatedToDRep` rule constrains only a transaction that withdraws rewards, so a send that does not touch the reward account is valid with zero certificates and zero withdrawals regardless of unclaimed rewards — injecting either silently changed the user's governance state and broke swaps (the device swap policy rejects any certificate or withdrawal). These reward/governance obligations now apply only to the delegate/undelegate flows, which are unchanged. Fixes Cardano swaps failing on accounts that hold staking rewards. Applies to both the account bridge (`buildTransaction`) and the CoinModule API (`craftTransaction`) paths.

--- a/libs/coin-modules/coin-cardano/src/buildTransaction.test.ts
+++ b/libs/coin-modules/coin-cardano/src/buildTransaction.test.ts
@@ -50,7 +50,11 @@ describe("buildTransaction", () => {
       expect(certificates).toEqual([]);
     });
 
-    it("should add abstain when drepHex is absent and rewards is available", async () => {
+    // The Conway rule ConwayWdrlNotDelegatedToDRep is enforced only over a transaction's withdrawal
+    // set, so a send that does not touch the reward account is valid with zero certificates even
+    // when rewards are unclaimed and no dRep is set. Injecting the cert here also breaks swaps (the
+    // firmware swap policy denies num_certificates != 0).
+    it("should not add an abstain vote on a send when rewards exist but no dRep is set", async () => {
       const account = getCardanoAccountFixture({
         delegation: {
           dRepHex: undefined, // drepHex absent
@@ -59,13 +63,7 @@ describe("buildTransaction", () => {
       });
       const transaction = await buildTransaction(account, txPayload);
       const certificates = transaction.getCertificates();
-      expect(
-        certificates.some(
-          c =>
-            c.type === TyphonTypes.CertificateType.VOTE_DELEGATION &&
-            c.cert.dRep.type === TyphonTypes.DRepType.ABSTAIN,
-        ),
-      ).toBe(true);
+      expect(certificates).toEqual([]);
     });
   });
 
@@ -100,7 +98,9 @@ describe("buildTransaction", () => {
       expect(withdrawals.length).toBe(0);
     });
 
-    it("should add withdrawal when dRepHex and rewards both are available", async () => {
+    // A send must not silently sweep staking rewards either: the withdrawal changes the amount the
+    // user (or a swap) agreed to, and the firmware swap policy denies num_withdrawals != 0.
+    it("should not sweep rewards via a withdrawal on a send when delegated to a dRep", async () => {
       const account = getCardanoAccountFixture({
         delegation: {
           dRepHex: "drepHex", // drepHex present
@@ -109,7 +109,37 @@ describe("buildTransaction", () => {
       });
       const transaction = await buildTransaction(account, txPayload);
       const withdrawals = transaction.getWithdrawals();
-      expect(withdrawals.length).toBe(1);
+      expect(withdrawals.length).toBe(0);
+    });
+
+    it("should not sweep rewards via a withdrawal on a token send when delegated to a dRep", async () => {
+      const policyId = "a".repeat(56);
+      const assetName = "74657374";
+      const tokenId = `cardano/native/${policyId}${assetName}`;
+      const baseUtxos = getCardanoAccountFixture({ delegation: undefined }).cardanoResources.utxos;
+      const tokenUtxos = baseUtxos.map(u => ({
+        ...u,
+        tokens: [{ policyId, assetName, amount: new BigNumber(1000) }],
+      }));
+      const account = getCardanoAccountFixture({
+        delegation: { dRepHex: "drepHex", rewards: new BigNumber(10e6) },
+        utxos: tokenUtxos,
+      });
+      account.cardanoResources.protocolParams = getProtocolParamsFixture();
+      account.subAccounts = [
+        {
+          type: "TokenAccount",
+          id: "token-account-1",
+          token: { id: tokenId },
+          balance: new BigNumber(1000),
+        } as any,
+      ];
+      const transaction = await buildTransaction(account, {
+        ...txPayload,
+        subAccountId: "token-account-1",
+        amount: new BigNumber(500),
+      });
+      expect(transaction.getWithdrawals().length).toBe(0);
     });
   });
 
@@ -182,6 +212,28 @@ describe("buildTransaction", () => {
         account.cardanoResources.delegation?.deposit,
       );
     });
+
+    // Deregistering a stake key requires the account's rewards to be withdrawn in the same
+    // transaction, so undelegate still sweeps them.
+    it("should still sweep rewards via a withdrawal on undelegate when delegated to a dRep", async () => {
+      const account = getCardanoAccountFixture({
+        delegation: {
+          status: true,
+          deposit: (2e6).toString(),
+          dRepHex: "drepHex",
+          rewards: new BigNumber(10e6),
+        },
+      });
+      const transaction = await buildTransaction(account, {
+        family: "cardano",
+        recipient: "",
+        amount: new BigNumber(0),
+        mode: "undelegate",
+        poolId: undefined,
+        protocolParams: getProtocolParamsFixture(),
+      });
+      expect(transaction.getWithdrawals().length).toBe(1);
+    });
   });
 
   describe("delegate transaction", () => {
@@ -235,6 +287,33 @@ describe("buildTransaction", () => {
         | undefined;
 
       expect(registerCertificate).toBeUndefined();
+    });
+
+    it("should still add the abstain vote on delegate when rewards exist but no dRep is set", async () => {
+      const account = getCardanoAccountFixture({
+        delegation: {
+          status: true,
+          deposit: (2e6).toString(),
+          dRepHex: undefined,
+          rewards: new BigNumber(10e6),
+        },
+      });
+      const transaction = await buildTransaction(account, {
+        family: "cardano",
+        recipient: "",
+        amount: new BigNumber(0),
+        mode: "delegate",
+        poolId: "7df262feae9201d1b2e32d4c825ca91b29fbafb2b8e556f6efb7f549",
+        protocolParams: getProtocolParamsFixture(),
+      });
+      const hasAbstain = transaction
+        .getCertificates()
+        .some(
+          c =>
+            c.type === TyphonTypes.CertificateType.VOTE_DELEGATION &&
+            c.cert.dRep.type === TyphonTypes.DRepType.ABSTAIN,
+        );
+      expect(hasAbstain).toBe(true);
     });
   });
 

--- a/libs/coin-modules/coin-cardano/src/buildTransaction.ts
+++ b/libs/coin-modules/coin-cardano/src/buildTransaction.ts
@@ -153,9 +153,6 @@ const buildSendTokenTransaction = async ({
     typhonTx.addInput(getTyphonInputFromUtxo(u));
   }
 
-  const rewardsWithdrawalCertificate = getRewardWithdrawalCertificate(account);
-  if (rewardsWithdrawalCertificate) typhonTx.addWithdrawal(rewardsWithdrawalCertificate);
-
   typhonTx.addOutput({
     address: receiverAddress,
     amount: requiredMinAdaForTokens,
@@ -207,9 +204,6 @@ const buildSendAdaTransaction = async ({
         tokens: tokenBalance,
       });
     }
-
-    const rewardsWithdrawalCertificate = getRewardWithdrawalCertificate(account);
-    if (rewardsWithdrawalCertificate) typhonTx.addWithdrawal(rewardsWithdrawalCertificate);
 
     // Send Max: compute the fee + recipient amount explicitly instead of routing the recipient
     // through Typhon's change mechanism, whose <2 ADA dust guard would fold the whole low balance
@@ -270,9 +264,6 @@ const buildSendAdaTransaction = async ({
     selectedUtxos.push(utxo);
     usedUtxoAdaAmount = usedUtxoAdaAmount.plus(transactionInput.amount);
   }
-
-  const rewardsWithdrawalCertificate = getRewardWithdrawalCertificate(account);
-  if (rewardsWithdrawalCertificate) typhonTx.addWithdrawal(rewardsWithdrawalCertificate);
 
   // If any selected UTXOs carry native tokens, those tokens must appear in
   // outputs or Typhon will throw "Not enough tokens". We send them back to
@@ -450,8 +441,15 @@ export const buildTransaction = async (
   const ttl = getTTL(account.currency.id);
   typhonTx.setTTL(ttl);
 
-  // add ABSTAIN vote certificate when account has rewards but not the vote delegation
+  // Conway governance opt-in for the staking flows only: when an account has unclaimed rewards but
+  // no dRep, a delegate/undelegate registers an ABSTAIN vote-delegation certificate so future
+  // reward withdrawals stay valid. A plain send must NOT carry this — the Conway
+  // ConwayWdrlNotDelegatedToDRep rule constrains only a tx that withdraws, so a send with no
+  // withdrawal is valid with zero certificates, and injecting one breaks swaps (the device swap
+  // policy denies num_certificates != 0). Gated as an explicit staking-mode allowlist (not
+  // `!== "send"`) so a future mode can't silently inherit the injection.
   if (
+    (transaction.mode === "delegate" || transaction.mode === "undelegate") &&
     account.cardanoResources.delegation?.rewards.gt(0) &&
     !account.cardanoResources.delegation.dRepHex
   ) {

--- a/libs/coin-modules/coin-cardano/src/logic/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/craftTransaction.test.ts
@@ -381,19 +381,21 @@ describe("buildUnsignedTransaction — staking", () => {
   });
 });
 
-describe("buildUnsignedTransaction — account obligations (Conway)", () => {
-  it("sweeps claimable rewards via a withdrawal when delegated to a dRep", async () => {
+describe("buildUnsignedTransaction — account obligations are staking-only (swap-safe)", () => {
+  // The Conway ConwayWdrlNotDelegatedToDRep rule only constrains a tx that withdraws, and the
+  // firmware swap policy denies any certificate or withdrawal on a swap.
+  it("should not sweep rewards on a send even when delegated to a dRep", async () => {
     mockGetDelegation.mockResolvedValue(
       registeredDelegation({ dRepHex: "drep1abc", rewards: new BigNumber("1500000") }),
     );
 
     const tx = await buildUnsignedTransaction(currency, sendIntent());
 
-    expect(tx.getWithdrawals()).toHaveLength(1);
-    expect(tx.getWithdrawals()[0].amount).toEqual(new BigNumber("1500000"));
+    expect(tx.getWithdrawals()).toHaveLength(0);
+    expect(tx.getCertificates()).toHaveLength(0);
   });
 
-  it("adds an ABSTAIN vote certificate when rewards exist but no dRep is set", async () => {
+  it("should not add an abstain vote on a send when rewards exist but no dRep is set", async () => {
     mockGetDelegation.mockResolvedValue(
       registeredDelegation({ dRepHex: undefined, rewards: new BigNumber("1500000") }),
     );
@@ -401,9 +403,39 @@ describe("buildUnsignedTransaction — account obligations (Conway)", () => {
     const tx = await buildUnsignedTransaction(currency, sendIntent());
 
     expect(tx.getWithdrawals()).toHaveLength(0);
-    expect(tx.getCertificates().map(c => c.type)).toEqual([
-      TyphonTypes.CertificateType.VOTE_DELEGATION,
-    ]);
+    expect(tx.getCertificates()).toHaveLength(0);
+  });
+
+  it("should still sweep claimable rewards via a withdrawal on a staking intent when delegated to a dRep", async () => {
+    mockGetDelegation.mockResolvedValue(
+      registeredDelegation({ dRepHex: "drep1abc", rewards: new BigNumber("1500000") }),
+    );
+
+    const tx = await buildUnsignedTransaction(
+      currency,
+      stakeIntent({ mode: "undelegate", type: "undelegate" }),
+    );
+
+    expect(tx.getWithdrawals()).toHaveLength(1);
+    expect(tx.getWithdrawals()[0].amount).toEqual(new BigNumber("1500000"));
+  });
+
+  it("should still add the abstain vote on a staking intent when rewards exist but no dRep is set", async () => {
+    mockGetDelegation.mockResolvedValue(
+      registeredDelegation({ dRepHex: undefined, rewards: new BigNumber("1500000") }),
+    );
+
+    const tx = await buildUnsignedTransaction(currency, stakeIntent());
+
+    expect(
+      tx
+        .getCertificates()
+        .some(
+          c =>
+            c.type === TyphonTypes.CertificateType.VOTE_DELEGATION &&
+            c.cert.dRep.type === TyphonTypes.DRepType.ABSTAIN,
+        ),
+    ).toBe(true);
   });
 });
 

--- a/libs/coin-modules/coin-cardano/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/craftTransaction.ts
@@ -84,10 +84,13 @@ function stakeHashCredential(stakeKey: string): TyphonTypes.HashCredential {
 }
 
 /**
- * Account-level obligations that the legacy builder attaches to every transaction:
- * sweep claimable rewards (only withdrawable once delegated to a dRep — Conway rule) and,
- * when rewards exist but no dRep is set, add the ABSTAIN vote-delegation certificate the
- * Conway era requires before such a transaction is valid.
+ * Account-level reward/governance obligations for the staking flows (delegate/undelegate): sweep
+ * claimable rewards via a withdrawal (only withdrawable once delegated to a dRep — the Conway
+ * ConwayWdrlNotDelegatedToDRep rule) and, when rewards exist but no dRep is set, opt the account
+ * into governance with an ABSTAIN vote-delegation certificate so future withdrawals stay valid.
+ * Deliberately NOT run for a plain send/token transfer: a transfer that does not withdraw needs
+ * neither, and injecting either breaks swaps (the device swap policy denies any certificate or
+ * withdrawal).
  */
 function addAccountObligations(
   typhonTx: TyphonTransaction,
@@ -328,12 +331,6 @@ export async function buildUnsignedTransaction(
     throw new Error("No spendable UTXOs for sender address");
   }
 
-  // Account-level reward/vote obligations (Conway) plus, for staking, the certificates;
-  // both require the stake credential carried by the sender address.
-  if (stakeKey && delegation) {
-    addAccountObligations(typhonTx, currency, stakeKey, delegation);
-  }
-
   // changeAddress is the sender for fixed-amount sends/staking; for a send-all it is the recipient
   // (the send-all branch below sends the balance minus fee there as an explicit output).
   let changeAddress: TyphonTypes.CardanoAddress = senderAddress;
@@ -342,6 +339,10 @@ export async function buildUnsignedTransaction(
 
   if (intent.intentType === "staking") {
     if (!stakeKey) throw new Error("Sender address has no stake credential");
+    // Account-level reward/vote obligations (Conway) belong to the staking flows only.
+    if (delegation) {
+      addAccountObligations(typhonTx, currency, stakeKey, delegation);
+    }
     addStakingCertificates(
       typhonTx,
       intent as StakingTransactionIntent<StringMemo>,


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

When a Cardano account has staking rewards, the wallet silently added a governance obligation to **every** transaction, not just staking ones — an ABSTAIN vote-delegation certificate (or a reward withdrawal, if a dRep was set). This forces the account to abstain from Cardano voting without consent, and blocks the app-cardano-new migration: the hardened app correctly refuses to sign a swap carrying a certificate or withdrawal, so swaps fail. The bug is wallet-side; the firmware refusal is correct.

Per the Conway `ConwayWdrlNotDelegatedToDRep` rule, only a transaction that withdraws rewards needs a dRep delegation — a plain transfer is valid with zero certificates and withdrawals. These obligations now run only on delegate/undelegate; send and token-send craft a pure transfer, in both builders (`buildTransaction`, `craftTransaction`).

Regression: unit tests assert send/token-send emit nothing while delegate/undelegate still do; verified on a Yaci devnet in coin-tester.

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-36525
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
