### PR TITLE
fix(contacts): restore wallet address background (LIVE-35876)

### DIFF
--- a/.changeset/clear-addresses-restore.md
+++ b/.changeset/clear-addresses-restore.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": minor
+---
+
+Restore the Ledger Wallet addresses entry background on Desktop.

--- a/features/flow/contacts/src/steps/Detail/components/LedgerWalletAddressesCard.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/LedgerWalletAddressesCard.web.tsx
@@ -21,7 +21,11 @@ export function LedgerWalletAddressesCard({
   onPress,
 }: LedgerWalletAddressesCardProps): React.ReactNode {
   return (
-    <ListItem onClick={() => onPress(intent)} data-testid="contacts-detail-ledger-wallet-addresses">
+    <ListItem
+      onClick={() => onPress(intent)}
+      className="bg-surface"
+      data-testid="contacts-detail-ledger-wallet-addresses"
+    >
       <ListItemLeading>
         <Wallet size={20} aria-hidden />
         <ListItemContent>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Focused Contacts Flow Web test passed (8 tests).
- [x] **Impact of the changes:**
      Verify Contacts > Me in Desktop: the Ledger Wallet addresses entry has an opaque surface in light and dark themes, and still opens the Wallet addresses screen.

### 📝 Description

The Ledger Wallet addresses entry in the Desktop Contacts detail for Me used Lumen's transparent ListItem background, making its surface disappear against the detail pane.

This PR applies the existing `bg-surface` ListItem treatment used by address rows, restoring the intended background without changing navigation or interaction behavior.

### ❓ Context

- **JIRA issue**: [LIVE-35876](https://ledgerhq.atlassian.net/browse/LIVE-35876)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-35876]: https://ledgerhq.atlassian.net/browse/LIVE-35876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ