### PR TITLE
fix(e2e): add TRON receiveConfirm label for non-touchscreen devices

### DIFF
--- a/e2e/desktop/tests/specs/add.account.spec.ts
+++ b/e2e/desktop/tests/specs/add.account.spec.ts
@@ -31,11 +31,19 @@ const currencies: AddAccountTestCase[] = [
   { currency: Currency.ADA, xrayTicket: "B2CQA-2500, B2CQA-2650, B2CQA-2678", teamOwner: Team.BST },
   { currency: Currency.XLM, xrayTicket: "B2CQA-2506, B2CQA-2651, B2CQA-2679" },
   { currency: Currency.BCH, xrayTicket: "B2CQA-2498, B2CQA-2652, B2CQA-2680" },
-  { currency: Currency.ALGO, xrayTicket: "B2CQA-2497, B2CQA-2653, B2CQA-2681", teamOwner: Team.BST },
+  {
+    currency: Currency.ALGO,
+    xrayTicket: "B2CQA-2497, B2CQA-2653, B2CQA-2681",
+    teamOwner: Team.BST,
+  },
   { currency: Currency.ATOM, xrayTicket: "B2CQA-2501, B2CQA-2654, B2CQA-2682" },
   { currency: Currency.XTZ, xrayTicket: "B2CQA-2507, B2CQA-2655, B2CQA-2683", teamOwner: Team.BST },
   { currency: Currency.SOL, xrayTicket: "B2CQA-2642, B2CQA-2656, B2CQA-2684" },
-  { currency: Currency.GRAM, xrayTicket: "B2CQA-2643, B2CQA-2657, B2CQA-2685", teamOwner: Team.BST },
+  {
+    currency: Currency.GRAM,
+    xrayTicket: "B2CQA-2643, B2CQA-2657, B2CQA-2685",
+    teamOwner: Team.BST,
+  },
   { currency: Currency.APT, xrayTicket: "B2CQA-3644, B2CQA-3645, B2CQA-3646", teamOwner: Team.BST },
   {
     currency: Currency.BASE,

--- a/e2e/desktop/tests/specs/add.account.spec.ts
+++ b/e2e/desktop/tests/specs/add.account.spec.ts
@@ -11,6 +11,7 @@ type AddAccountTestCase = {
   readonly currency: Currency;
   readonly xrayTicket: string;
   readonly portfolioAssetName?: string;
+  readonly teamOwner?: Team;
 };
 
 const currencies: AddAccountTestCase[] = [
@@ -20,34 +21,34 @@ const currencies: AddAccountTestCase[] = [
   },
   { currency: Currency.ETH, xrayTicket: "B2CQA-2503, B2CQA-929, B2CQA-2645, B2CQA-2673" },
   { currency: Currency.ETC, xrayTicket: "B2CQA-2502, B2CQA-2646, B2CQA-2674" },
-  { currency: Currency.XRP, xrayTicket: "B2CQA-2505, B2CQA-2647, B2CQA-2675" },
+  { currency: Currency.XRP, xrayTicket: "B2CQA-2505, B2CQA-2647, B2CQA-2675", teamOwner: Team.BST },
   {
     currency: Currency.DOT,
     xrayTicket: "B2CQA-2504, B2CQA-2648, B2CQA-2676",
     portfolioAssetName: Currency.DOT.name,
   },
   { currency: Currency.TRX, xrayTicket: "B2CQA-2508, B2CQA-2649, B2CQA-2677" },
-  { currency: Currency.ADA, xrayTicket: "B2CQA-2500, B2CQA-2650, B2CQA-2678" },
+  { currency: Currency.ADA, xrayTicket: "B2CQA-2500, B2CQA-2650, B2CQA-2678", teamOwner: Team.BST },
   { currency: Currency.XLM, xrayTicket: "B2CQA-2506, B2CQA-2651, B2CQA-2679" },
   { currency: Currency.BCH, xrayTicket: "B2CQA-2498, B2CQA-2652, B2CQA-2680" },
-  { currency: Currency.ALGO, xrayTicket: "B2CQA-2497, B2CQA-2653, B2CQA-2681" },
+  { currency: Currency.ALGO, xrayTicket: "B2CQA-2497, B2CQA-2653, B2CQA-2681", teamOwner: Team.BST },
   { currency: Currency.ATOM, xrayTicket: "B2CQA-2501, B2CQA-2654, B2CQA-2682" },
-  { currency: Currency.XTZ, xrayTicket: "B2CQA-2507, B2CQA-2655, B2CQA-2683" },
+  { currency: Currency.XTZ, xrayTicket: "B2CQA-2507, B2CQA-2655, B2CQA-2683", teamOwner: Team.BST },
   { currency: Currency.SOL, xrayTicket: "B2CQA-2642, B2CQA-2656, B2CQA-2684" },
-  { currency: Currency.GRAM, xrayTicket: "B2CQA-2643, B2CQA-2657, B2CQA-2685" },
-  { currency: Currency.APT, xrayTicket: "B2CQA-3644, B2CQA-3645, B2CQA-3646" },
+  { currency: Currency.GRAM, xrayTicket: "B2CQA-2643, B2CQA-2657, B2CQA-2685", teamOwner: Team.BST },
+  { currency: Currency.APT, xrayTicket: "B2CQA-3644, B2CQA-3645, B2CQA-3646", teamOwner: Team.BST },
   {
     currency: Currency.BASE,
     xrayTicket: "B2CQA-4226, B2CQA-4227, B2CQA-4228",
     portfolioAssetName: Currency.ETH.name,
   },
-  { currency: Currency.ZEC, xrayTicket: "B2CQA-4296, B2CQA-4297, B2CQA-4298" },
+  { currency: Currency.ZEC, xrayTicket: "B2CQA-4296, B2CQA-4297, B2CQA-4298", teamOwner: Team.BST },
 ];
 
 for (const currency of currencies) {
   test.describe("Add account", () => {
     test.use({
-      teamOwner: Team.WALLET_XP,
+      teamOwner: currency.teamOwner ?? Team.COIN_INTEGRATION,
       userdata: "skip-onboarding-with-last-seen-device",
       speculosApp: currency.currency.speculosApp,
     });
@@ -119,7 +120,7 @@ for (const currency of currencies) {
 
 test.describe("Add account", () => {
   test.use({
-    teamOwner: Team.WALLET_XP,
+    teamOwner: Team.BST,
     userdata: "skip-onboarding-with-last-seen-device",
     speculosApp: Currency.ALEO.speculosApp,
     featureFlags: {

--- a/e2e/desktop/tests/specs/receive.address.spec.ts
+++ b/e2e/desktop/tests/specs/receive.address.spec.ts
@@ -14,16 +14,22 @@ import {
 } from "@ledgerhq/live-e2e-shared/cliCommandsUtils";
 import { buildTags } from "tests/utils/tagsUtils";
 
-const nativeAccounts = [
+type ReceiveTestCase = {
+  account: Account;
+  xrayTicket: string;
+  teamOwner?: Team;
+};
+
+const nativeAccounts: ReceiveTestCase[] = [
   { account: Account.BTC_NATIVE_SEGWIT_1, xrayTicket: "B2CQA-2559, B2CQA-2687" },
   { account: Account.ETH_1, xrayTicket: "B2CQA-2561, B2CQA-2688, B2CQA-2697" },
   { account: Account.SOL_1, xrayTicket: "B2CQA-2563, B2CQA-2689" },
   { account: Account.TRX_1, xrayTicket: "B2CQA-2565, B2CQA-2690, B2CQA-2699" },
   { account: Account.DOT_1, xrayTicket: "B2CQA-2562, B2CQA-2691" },
-  { account: Account.XRP_1, xrayTicket: "B2CQA-2566, B2CQA-2692" },
+  { account: Account.XRP_1, xrayTicket: "B2CQA-2566, B2CQA-2692", teamOwner: Team.BST },
   { account: Account.BCH_1, xrayTicket: "B2CQA-2558, B2CQA-2693" },
   { account: Account.ATOM_1, xrayTicket: "B2CQA-2560, B2CQA-2694" },
-  { account: Account.XTZ_1, xrayTicket: "B2CQA-2564, B2CQA-2695" },
+  { account: Account.XTZ_1, xrayTicket: "B2CQA-2564, B2CQA-2695", teamOwner: Team.BST },
   { account: Account.BSC_1, xrayTicket: "B2CQA-2686, B2CQA-2696, B2CQA-2698" },
 ];
 
@@ -48,7 +54,7 @@ async function verifySendCurrencyTokensWarning(app: Application, account: Accoun
 for (const receive of nativeAccounts) {
   test.describe("Receive", () => {
     test.use({
-      teamOwner: Team.WALLET_XP,
+      teamOwner: receive.teamOwner ?? Team.COIN_INTEGRATION,
       userdata: "skip-onboarding-with-last-seen-device",
       speculosApp: receive.account.currency.speculosApp,
       cliCommands: [liveDataCommand(receive.account)],
@@ -86,7 +92,7 @@ for (const receive of nativeAccounts) {
 test.describe("Receive", () => {
   const account = Account.TRX_3;
   test.use({
-    teamOwner: Team.WALLET_XP,
+    teamOwner: Team.COIN_INTEGRATION,
     userdata: "skip-onboarding-with-last-seen-device",
     speculosApp: account.currency.speculosApp,
     cliCommands: [addEmptyAccountCommand(account)],
@@ -116,7 +122,7 @@ test.describe("Receive", () => {
 
 test.describe("Receive", () => {
   test.use({
-    teamOwner: Team.WALLET_XP,
+    teamOwner: Team.COIN_INTEGRATION,
     userdata: "speculos-subAccount",
     speculosApp: tokenAccount.account.currency.speculosApp,
   });

--- a/e2e/mobile/specs/verifyAddress/receivePerTest/createAccount.spec.ts
+++ b/e2e/mobile/specs/verifyAddress/receivePerTest/createAccount.spec.ts
@@ -6,7 +6,7 @@ import { initReceiveApp } from "@e2e/specs/verifyAddress/receivePerTest/initRece
 
 const isSmokeTestRun = process.env.INPUTS_TEST_FILTER?.includes("@smoke");
 
-setTeamOwner(Team.WALLET_XP);
+setTeamOwner(Team.COIN_INTEGRATION);
 describe("Receive - create an account", () => {
   beforeAll(initReceiveApp);
   beforeEach(() => app.portfolio.openReceiveDrawer());

--- a/e2e/mobile/specs/verifyAddress/receivePerTest/importCurrency.spec.ts
+++ b/e2e/mobile/specs/verifyAddress/receivePerTest/importCurrency.spec.ts
@@ -6,7 +6,7 @@ import { initReceiveApp } from "@e2e/specs/verifyAddress/receivePerTest/initRece
 
 const isSmokeTestRun = process.env.INPUTS_TEST_FILTER?.includes("@smoke");
 
-setTeamOwner(Team.WALLET_XP);
+setTeamOwner(Team.COIN_INTEGRATION);
 describe("Receive - import a currency", () => {
   beforeAll(initReceiveApp);
   beforeEach(() => app.portfolio.openReceiveDrawer());

--- a/e2e/mobile/specs/verifyAddress/receivePerTest/readOnlyFlows.spec.ts
+++ b/e2e/mobile/specs/verifyAddress/receivePerTest/readOnlyFlows.spec.ts
@@ -9,7 +9,7 @@ const isSmokeTestRun = process.env.INPUTS_TEST_FILTER?.includes("@smoke");
 // These three only read account state, so they can share one app instance. The tests that add
 // an account keep their own spec, where a fresh instance is what makes the count assertions
 // meaningful.
-setTeamOwner(Team.WALLET_XP);
+setTeamOwner(Team.COIN_INTEGRATION);
 describe("Receive - read-only flows", () => {
   beforeAll(initReceiveApp);
   beforeEach(() => app.portfolio.openReceiveDrawer());

--- a/libs/live-e2e-shared/src/data/deviceLabelsData.ts
+++ b/libs/live-e2e-shared/src/data/deviceLabelsData.ts
@@ -78,6 +78,7 @@ export const DEVICE_LABELS_CONFIG: DeviceLabelsConfig = {
     receiveConfirm: {
       [AppInfos.COSMOS.name]: DeviceLabels.CAPS_APPROVE,
       [AppInfos.POLKADOT.name]: DeviceLabels.CAPS_APPROVE,
+      [AppInfos.TRON.name]: DeviceLabels.CONFIRM,
       [AppInfos.ZCASH.name]: DeviceLabels.CONFIRM,
       default: DeviceLabels.APPROVE,
     },
@@ -149,6 +150,7 @@ export const DEVICE_LABELS_CONFIG: DeviceLabelsConfig = {
       [AppInfos.POLYGON.name]: DeviceLabels.CONFIRM,
       [AppInfos.RIPPLE.name]: DeviceLabels.CONFIRM,
       [AppInfos.SOLANA.name]: DeviceLabels.CONFIRM,
+      [AppInfos.TRON.name]: DeviceLabels.CONFIRM,
       [AppInfos.ZCASH.name]: DeviceLabels.CONFIRM,
       [AppInfos.SUI.name]: DeviceLabels.CONFIRM,
       default: DeviceLabels.APPROVE,


### PR DESCRIPTION
## Summary

### Fix: `[TRX] - Verify address` failing on non-touchscreen devices

- Root cause: Tron app 0.7.7 shows "Confirm" during the receive/verify flow, but the `nanoS` and `default` device label configs had `receiveConfirm.default = APPROVE` with no Tron-specific override
- Touchscreen devices (Stax, Flex, Apex) already worked — `TOUCHSCREEN_DEVICE_CONFIG` defaults to `CONFIRM`
- Fix: added `[AppInfos.TRON.name]: DeviceLabels.CONFIRM` to both `nanoS.receiveConfirm` and `default.receiveConfirm` in `deviceLabelsData.ts`

### Chore: transfer Add Account and Receive test ownership to Coin Integration / BST

Per team alignment (Coin Integration now owns Add Account, Send, and Receive tests):

| File | Change |
|---|---|
| LWD `add.account.spec.ts` | CI coins → `Team.COIN_INTEGRATION`; BST coins (XRP, ADA, ALGO, XTZ, TON, APT, ZEC, ALEO) → `Team.BST` |
| LWD `receive.address.spec.ts` | XRP/XTZ → `Team.BST`; all others → `Team.COIN_INTEGRATION` |
| Mobile `receivePerTest` (3 specs) | `Team.WALLET_XP` → `Team.COIN_INTEGRATION` |

> Mobile add-account and verifyAddress specs are unchanged — ownership already resolved dynamically via `BST_ADD_ACCOUNT_CURRENCIES` / `BST_VERIFY_ADDRESS_CURRENCIES` helpers.

Jira: [LIVE-36579](https://ledgerhq.atlassian.net/browse/LIVE-36579)

[LIVE-36579]: https://ledgerhq.atlassian.net/browse/LIVE-36579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ