### PR TITLE
[LWDM] fix(live-common): keep device signature alive on account refresh

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/components/TransactionConfirm/ConfirmAlert.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/TransactionConfirm/ConfirmAlert.tsx
@@ -32,7 +32,7 @@ const ConfirmAlert = ({ t, transaction, typeTransaction, fields }: Props) => {
       : "approve.limited";
   }
   return (
-    <Alert type="primary" mb={26}>
+    <Alert type="primary" mb={26} data-testid="device-signature-notice">
       <Trans
         i18nKey={alertContentKey}
         values={{

--- a/apps/ledger-live-desktop/src/renderer/components/TransactionRawConfirm/ConfirmAlert.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/TransactionRawConfirm/ConfirmAlert.tsx
@@ -10,7 +10,7 @@ const ConfirmAlert = (_props: Props) => {
   const { t } = useTranslation();
 
   return (
-    <Alert type="primary" mb={26}>
+    <Alert type="primary" mb={26} data-testid="device-signature-notice">
       <Trans
         i18nKey={"TransactionConfirm.doubleCheck"}
         values={{

--- a/e2e/desktop/tests/page/modal/send.modal.ts
+++ b/e2e/desktop/tests/page/modal/send.modal.ts
@@ -8,9 +8,7 @@ export class SendModal extends Modal {
   private accountDebitInput = this.page.locator("#account-debit-placeholder input");
   readonly recipientInput = this.page.getByTestId("send-recipient-input");
   readonly tagInput = this.page.getByTestId("memo-tag-input");
-  private checkDeviceLabel = this.page.locator(
-    "text=Double-check the transaction details on your Ledger device before signing.",
-  );
+  private readonly checkDeviceLabel = this.page.getByTestId("device-signature-notice");
   private readonly checkTransactionbroadcastLabel = this.page.getByTestId("success-message-label");
   private recipientAddressDisplayedValue = this.page.getByTestId("recipient-address");
   private recipientEnsDisplayed = this.page.getByTestId("transaction-recipient-ens");

--- a/e2e/desktop/tests/page/modal/send.modal.ts
+++ b/e2e/desktop/tests/page/modal/send.modal.ts
@@ -9,7 +9,7 @@ export class SendModal extends Modal {
   readonly recipientInput = this.page.getByTestId("send-recipient-input");
   readonly tagInput = this.page.getByTestId("memo-tag-input");
   private readonly checkDeviceLabel = this.page.getByTestId("device-signature-notice");
-  private readonly checkTransactionbroadcastLabel = this.page.getByTestId("success-message-label");
+  private readonly checkTransactionbroadcastLabel = this.page.locator("text=Transaction sent");
   private recipientAddressDisplayedValue = this.page.getByTestId("recipient-address");
   private recipientEnsDisplayed = this.page.getByTestId("transaction-recipient-ens");
   private amountDisplayedValue = this.page.getByTestId("transaction-amount");
@@ -92,7 +92,6 @@ export class SendModal extends Modal {
 
   @step("Verify tx sent text")
   async expectTxSent() {
-    await this.checkDeviceLabel.waitFor({ state: "hidden" });
     await expect(this.checkTransactionbroadcastLabel).toBeVisible();
   }
 

--- a/e2e/desktop/tests/utils/allureUtils.ts
+++ b/e2e/desktop/tests/utils/allureUtils.ts
@@ -202,9 +202,7 @@ export async function captureArtifacts(
   if (isLastRetry(testInfo)) {
     const filePath = `tests/artifacts/${testInfo.title.replace(/[^a-zA-Z0-9]/g, " ")}.json`;
 
-    await page.evaluate(filePath => {
-      window.saveLogs(filePath);
-    }, filePath);
+    await page.evaluate(filePath => window.saveLogs(filePath), filePath);
 
     await testInfo.attach("Test logs", {
       path: filePath,

--- a/libs/ledger-live-common/src/hw/actions/transaction.ts
+++ b/libs/ledger-live-common/src/hw/actions/transaction.ts
@@ -147,6 +147,16 @@ export const createAction = (
       isACRE,
     } = txRequest;
     const mainAccount = getMainAccount(txRequest.account, txRequest.parentAccount);
+    // A background account sync hands down a new account object with the same id. Tearing down an
+    // in-flight device signature request over that identity change abandons a prompt the device is
+    // still showing: the approval the user then gives lands on a closed subscriber, and the fresh
+    // request asks them to sign all over again. Keyed on the id, with the live object read via ref.
+    const mainAccountRef = useRef(mainAccount);
+    useEffect(() => {
+      mainAccountRef.current = mainAccount;
+    }, [mainAccount]);
+    const mainAccountId = mainAccount.id;
+
     const appState = createAppAction(connectAppExec).useHook(reduxDevice, {
       account: isACRE ? undefined : mainAccount, // Bypass derivation check with ACRE as we can use other addresses than the freshest
       appName,
@@ -213,14 +223,15 @@ export const createAction = (
       let cancelled = false;
       let sub: { unsubscribe: () => void } | undefined;
       (async () => {
+        const signingAccount = mainAccountRef.current;
         const bridge = isACRE
           ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
             (ACREBridge.accountBridge as unknown as AccountBridge<any>)
-          : await getAccountBridge(mainAccount);
+          : await getAccountBridge(signingAccount);
         if (cancelled) return;
         sub = bridge
           .signOperation({
-            account: mainAccount,
+            account: signingAccount,
             transaction,
             deviceId: device.deviceId,
             deviceModelId: device.modelId,
@@ -241,7 +252,7 @@ export const createAction = (
         cancelled = true;
         sub?.unsubscribe();
       };
-    }, [device, mainAccount, transaction, opened, inWrongDeviceForAccount, error, isACRE]);
+    }, [device, mainAccountId, transaction, opened, inWrongDeviceForAccount, error, isACRE]);
     return {
       ...appState,
       ...state,


### PR DESCRIPTION
Fixes `[KAS] - Send`, which has failed on every `develop` Desktop E2E run since 2026-08-21, and the `[TRX]` / `[ETH (Base)]` / `[ATOM]` / `[APT]` sends that flake with the identical error. They are all one bug.

## Root cause

`hw/actions/transaction.ts` subscribes `bridge.signOperation` from a `useEffect` whose dependency array contained `mainAccount` — **compared by object identity**. Its cleanup calls `sub?.unsubscribe()` with no in-flight guard, and coin `signOperation` observables return no teardown, so the abandoned attempt keeps driving the device while its `signed` event lands on a closed subscriber.

Since a56baa8d0b7 (#20949) the send modal forwards every store account replacement into `useBridgeTransaction` at **any** step, including the device step:

```js
// Send/Body.tsx
const liveAccount = liveAccounts.find(a => a.id === account.id);
if (liveAccount && liveAccount !== account) updateAccount(liveAccount);
```

That comment reasons correctly about *which* account is swapped and about the transaction being untouched. Both are true. What it misses is that swapping the account **object identity** is by itself enough to restart the in-flight signature.

Straight from CI run `33034009061`:

```
02:56:26.179  device-signature-requested   #1
02:56:28.446  UPDATE_ACCOUNT
02:56:28.450  SyncSession finished reason=initial, duration=10.751s
02:56:28.505  device-signature-requested   #2      ← 59 ms after the account was replaced
02:56:41.463  the first attempt's blocking APDU finally returns, into a dead subscriber
02:56:42.119  POST /apdu ... "pending": true       ← nobody answers the second prompt
```

The initial sync takes ~10.7s in CI and lands inside the device step. Locally it finishes first, which is why this never reproduced on a dev machine.

## The fix

Key the subscription on `mainAccount.id` and read the live object through a ref. Safe precisely because the refresh above only ever swaps in a **same-id** account, so the id is stable while `signOperation` still receives the freshest object. Nothing is lost, and the zcash feature that effect exists for keeps working.

## Verification

Reproduced locally for the first time with a temporary harness that clones the account on a timer — the same thing `UPDATE_ACCOUNT` does — giving a byte-identical failure, then an A/B:

| | probe trace | result |
|---|---|---|
| `develop` + 1 forced account churn | `SUBSCRIBE #1 → #2 → #3`, all `changedDeps=[mainAccount]`, no `signed` | **fail** |
| this branch + 3 forced churns | `SUBSCRIBE #1` only → `granted` → `signed` | **pass** |

### Desktop E2E

| Run | Device | `[KAS] - Send` | failed | passed |
|---|---|---|---|---|
| [33079035137](https://github.com/LedgerHQ/ledger-live/actions/runs/33079035137) `develop` | nanoSP | failed 3/3 | 2 | 313 |
| [33139951566](https://github.com/LedgerHQ/ledger-live/actions/runs/33139951566) `develop` | nanoGen5 | failed | 2 | 313 |
| [33153665774](https://github.com/LedgerHQ/ledger-live/actions/runs/33153665774) `develop` | nanoSP | flaky | 8 | 310 |
| [33160396054](https://github.com/LedgerHQ/ledger-live/actions/runs/33160396054) **this branch** | nanoSP | **passed, 1st try** | 5 | 311 |
| [33159000681](https://github.com/LedgerHQ/ledger-live/actions/runs/33159000681) **this branch** | flex | **passed, 1st try** | 1 | 315 |

`33153665774` is the tightest control — `develop`, same device, same morning. The flex run additionally covers the touch-device path, which matters because `sendKaspa` branches on `isTouchDevice()` and takes a `HOLD_TO_SIGN` route nanoSP never exercises.

**The whole send matrix is green on `33160396054`.** Every `send.tx.spec.ts` case passes — KAS, TRX, ATOM, APT, ETH, ETH (Base), BTC, ADA, SOL, XRP, XLM, VET, HBAR, SUI, ZEC, ICP, ALEO, POL, DOGE, DOT, BCH, ALGO, CCD — as does every new-send-flow and token send, with the single exception of `[USDT (Tron)] - Send (new send flow)`, which fails on `develop` too.

Of that run's 5 failures, 4 are present on the `develop` control (`receive.address [TRX]`, `subAccount:160 [USDT (Tron)]`, `newSendFlowUtils [USDT (Tron)]` as failures, `delegate [ADA]` as a flake). The fifth, `send.swap [BTC-LTC]`, fails on `best-value-info-icon` never rendering — the same no-quotes-returned symptom as `numberFormat.swap`; that `develop` run had five swap failures of its own.

The flex run was on `4f8f51ca6a4`, one commit ahead of the current head. That commit touched no send or signing code (`git diff` between the heads is confined to `TopBar` and `layout.component.ts`), so its KAS result carries over.

## Reverts #21215

#21215 made `expectTxSent` wait for the device notice to hide before asserting the success label. That was chasing a symptom — the modal was stuck because the signature request had restarted — and all it bought was a 120s locator timeout in place of a 41s one, with no clue as to why. Reverted now that the cause is fixed.

It also reverts that PR's success-label locator: `success-message-label` is the testId on the shared `SuccessDisplay` title, so it matches *any* success screen, whereas `text=Transaction sent` asserts the one this test is about. The `private readonly` modifier it added is kept.

## Also in here

- **A testId on the device signature notice.** The suite matched it by its English sentence, which breaks quietly: `waitFor({state:"hidden"})` on a locator that matches nothing resolves instantly. Added to the raw-transaction variant too, since both render the same string.
- **`window.saveLogs` promise was dropped** inside `page.evaluate`, so the `Test logs` attachment was 41KB in one run and 0 bytes in the next from identical code. The `UPDATE_ACCOUNT` evidence above came from a run that happened to win that race. Now awaited.

## Review notes

- `libs/ledger-live-common/src/hw/actions/transaction.ts` is shared device-action code used by send, swap, earn and wallet-api — kept as its own commit so it can be split out if you'd rather it went separately.
- **User impact is modest**: the second prompt is live, so a user just signs twice and the first approval is wasted. Not a lost-funds or dead-end scenario.
- **Known limitation**: the `transaction` dep is still identity-compared, so a future transaction-object churn would reopen the same race.
- a56baa8d0b7 is deliberately **not** reverted — this fix makes its effect harmless while keeping the zcash shielded-balance behaviour it exists for.

## Not fixed here

All of these also fail on `develop` [33153665774](https://github.com/LedgerHQ/ledger-live/actions/runs/33153665774) (nanoSP, same morning), so they are out of scope:

- **The Tron cluster** — `receive.address [TRX] - Verify address` and `subAccount:160 [USDT (Tron)]` fail with `Element with text "Approve" not found`. The device walks `"Verify Tron address" → "Address TSWtMAvb…" → "Confirm" → "Cancel"`: it says **"Confirm"**, but `receiveConfirm` in `deviceLabelsData.ts` has no Tron override and falls through to the default `"Approve"`. These passed on `develop` nanoSP the previous day, so a Tron nano-app update changed the label. One-line fix, and it does not reproduce on flex — the app binary differs per device.
- `newSendFlowUtils [USDT (Tron)] - Send (new send flow)` — `send-review-button` stays disabled for 41s, i.e. Tron send estimation, not signing.
- `subAccount:208 Token visible in parent account` — flakes on *"Account sync took longer than expected on first attempt"*. The full fixture wallet genuinely takes longer than the 41s expect timeout to sync, and the test waits on a global indicator when it only needs one account. Needs its own change at the right granularity.
- `numberFormat.swap` English — `TEST_AMOUNT` is `1234.56` ETH (~$3.1M) against a 0.085 ETH fixture account, so the swap app shows "Insufficient balance" and returns no quotes, and `best-value-info-icon` never renders. `Team.SWAP` owned.
- `send.swap` provider rejections — backend returns `AMOUNT_OFF_LIMITS` with `min 0 / max unknown` for `moonpay_trade`.
