### PR TITLE
[LWD] feat(perps): add the transaction signed screen (LIVE-35329)

### DIFF
--- a/.changeset/perps-transaction-signed.md
+++ b/.changeset/perps-transaction-signed.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Close the Perps deposit flow with a transaction signed screen, from which the user can follow the deposit: the swap status when the deposit went through a swap, the operation details otherwise.

--- a/.changeset/perps-transaction-signed.md
+++ b/.changeset/perps-transaction-signed.md
@@ -2,4 +2,4 @@
 "ledger-live-desktop": minor
 ---
 
-Close the Perps deposit flow with a transaction signed screen, from which the user can follow the deposit: the swap status when the deposit went through a swap, the operation details otherwise.
+Close the Perps deposit flow with a transaction signed screen, from which the user can follow the deposit on the status of the swap that funds it.

--- a/apps/ledger-live-desktop/src/mvvm/features/GlobalDialogs/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GlobalDialogs/index.tsx
@@ -14,6 +14,9 @@ const PerpsReviewRoot = lazy(
 const PerpsDepositSignRoot = lazy(
   () => import("LLD/features/Perps/screens/PerpsDepositSign/PerpsDepositSignDialog"),
 );
+const PerpsTransactionSignedRoot = lazy(
+  () => import("LLD/features/Perps/screens/PerpsTransactionSigned/PerpsTransactionSignedDialog"),
+);
 const ReleaseNotes = lazy(() => import("LLD/features/ReleaseNotes"));
 const BuyDevice = lazy(() => import("LLD/features/BuyDevice"));
 const FinishOnboardingDialog = lazy(
@@ -46,6 +49,9 @@ const GlobalDialogs = () => (
     </Suspense>
     <Suspense fallback={null}>
       <PerpsDepositSignRoot />
+    </Suspense>
+    <Suspense fallback={null}>
+      <PerpsTransactionSignedRoot />
     </Suspense>
     <ActionConfirmationDialog />
     <Suspense fallback={null}>

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/__tests__/usePerpsDepositExecution.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/__tests__/usePerpsDepositExecution.test.ts
@@ -9,6 +9,11 @@ jest.mock("@ledgerhq/live-common/wallet-api/Exchange/executeSwap", () => ({
   executeSwap: (deps: unknown, params: unknown) => mockExecuteSwap(deps, params),
 }));
 
+const mockOpenPerpsTransactionSigned = jest.fn();
+jest.mock("LLD/features/Perps/screens/PerpsTransactionSigned/PerpsTransactionSignedDialog", () => ({
+  openPerpsTransactionSigned: (data: unknown) => mockOpenPerpsTransactionSigned(data),
+}));
+
 const mockBroadcast = jest.fn();
 jest.mock("@ledgerhq/live-common/hooks/useBroadcast", () => ({
   useBroadcast: () => mockBroadcast,
@@ -178,6 +183,13 @@ describe("usePerpsDepositExecution", () => {
 
     expect(mockBroadcast).toHaveBeenCalledWith({ operation });
     expect(onSwapSuccess).toHaveBeenCalledWith({ operationHash: "0xhash", swapId: "swap-1" });
+    expect(mockOpenPerpsTransactionSigned).toHaveBeenCalledWith({
+      operationId: "operation-1",
+      accountId: "funding-1",
+      receiveCurrencyTicker: "ETH",
+      swapId: "swap-1",
+      provider: "swapkit_hyperliquid",
+    });
     expect(onDone).toHaveBeenCalled();
   });
 
@@ -190,6 +202,7 @@ describe("usePerpsDepositExecution", () => {
       kind: "error",
       error: new Error("signature failed"),
     });
+    expect(mockOpenPerpsTransactionSigned).not.toHaveBeenCalled();
     expect(onDone).not.toHaveBeenCalled();
     expect(onRefused).not.toHaveBeenCalled();
   });

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/__tests__/usePerpsDepositExecution.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/__tests__/usePerpsDepositExecution.test.ts
@@ -184,8 +184,6 @@ describe("usePerpsDepositExecution", () => {
     expect(mockBroadcast).toHaveBeenCalledWith({ operation });
     expect(onSwapSuccess).toHaveBeenCalledWith({ operationHash: "0xhash", swapId: "swap-1" });
     expect(mockOpenPerpsTransactionSigned).toHaveBeenCalledWith({
-      operationId: "operation-1",
-      accountId: "funding-1",
       receiveCurrencyTicker: "ETH",
       swapId: "swap-1",
       provider: "swapkit_hyperliquid",

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/usePerpsDepositExecution.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/usePerpsDepositExecution.ts
@@ -215,7 +215,6 @@ export function usePerpsDepositExecution(
 
       const depositCurrency = getAccountCurrency(depositAccount);
       const receiveCurrency = getAccountCurrency(receiverAccount);
-      const mainFromAccount = getMainAccount(depositAccount, fromParentAccount);
 
       let signed: Awaited<ReturnType<typeof confirmSignAndBroadcast>> | undefined;
 
@@ -270,8 +269,6 @@ export function usePerpsDepositExecution(
       if (!signed) return;
 
       openPerpsTransactionSigned({
-        operationId: signed.operation.id,
-        accountId: mainFromAccount.id,
         receiveCurrencyTicker: receiveCurrency.ticker,
         swapId: signed.swapId,
         provider: PERPS_DEPOSIT_QUOTE_PROVIDER,

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/usePerpsDepositExecution.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/usePerpsDepositExecution.ts
@@ -29,6 +29,7 @@ import { shallowAccountsSelector } from "~/renderer/reducers/accounts";
 import { mevProtectionSelector } from "~/renderer/reducers/settings";
 import { useStartExchangeAction, useTransactionAction } from "~/renderer/hooks/useConnectAppAction";
 import type { States } from "~/renderer/components/DeviceAction";
+import { openPerpsTransactionSigned } from "LLD/features/Perps/screens/PerpsTransactionSigned/PerpsTransactionSignedDialog";
 import { broadcastLogger } from "~/datadog/logs";
 import { track } from "~/renderer/analytics/segment";
 import { isUserRefusal } from "../utils/isUserRefusal";
@@ -213,6 +214,8 @@ export function usePerpsDepositExecution(
       setWalletApiIdForAccountId(receiverAccount.id);
 
       const depositCurrency = getAccountCurrency(depositAccount);
+      const receiveCurrency = getAccountCurrency(receiverAccount);
+      const mainFromAccount = getMainAccount(depositAccount, fromParentAccount);
 
       let signed: Awaited<ReturnType<typeof confirmSignAndBroadcast>> | undefined;
 
@@ -266,6 +269,13 @@ export function usePerpsDepositExecution(
 
       if (!signed) return;
 
+      openPerpsTransactionSigned({
+        operationId: signed.operation.id,
+        accountId: mainFromAccount.id,
+        receiveCurrencyTicker: receiveCurrency.ticker,
+        swapId: signed.swapId,
+        provider: PERPS_DEPOSIT_QUOTE_PROVIDER,
+      });
       onDone();
     } catch (e) {
       if (isUserRefusal(e)) {

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsTransactionSigned/PerpsTransactionSignedDialog.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsTransactionSigned/PerpsTransactionSignedDialog.tsx
@@ -1,0 +1,65 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { Dialog, DialogContent } from "@ledgerhq/lumen-ui-react";
+import {
+  usePerpsTransactionSignedViewModel,
+  type PerpsTransactionSignedData,
+} from "./usePerpsTransactionSignedViewModel";
+import { PerpsTransactionSignedView } from "./PerpsTransactionSignedView";
+
+let _opener: ((data: PerpsTransactionSignedData) => void) | null = null;
+
+function registerPerpsTransactionSignedOpener(
+  fn: (data: PerpsTransactionSignedData) => void,
+): () => void {
+  _opener = fn;
+  return () => {
+    _opener = null;
+  };
+}
+
+export function openPerpsTransactionSigned(data: PerpsTransactionSignedData) {
+  _opener?.(data);
+}
+
+function PerpsTransactionSignedBody({
+  data,
+  onClose,
+}: Readonly<{ data: PerpsTransactionSignedData; onClose: () => void }>) {
+  const viewModel = usePerpsTransactionSignedViewModel(data, onClose);
+  return <PerpsTransactionSignedView {...viewModel} />;
+}
+
+function PerpsTransactionSignedInnerDialog({
+  data,
+  onClose,
+}: Readonly<{ data: PerpsTransactionSignedData | null; onClose: () => void }>) {
+  const isOpen = data !== null;
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) onClose();
+    },
+    [onClose],
+  );
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange} height="fit">
+      <DialogContent
+        aria-describedby={undefined}
+        className="w-[400px] bg-base p-0"
+        onInteractOutside={e => e.preventDefault()}
+      >
+        {data ? <PerpsTransactionSignedBody data={data} onClose={onClose} /> : null}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default function PerpsTransactionSignedRoot() {
+  const [data, setData] = useState<PerpsTransactionSignedData | null>(null);
+  const close = useCallback(() => setData(null), []);
+
+  useEffect(() => registerPerpsTransactionSignedOpener(setData), []);
+
+  return <PerpsTransactionSignedInnerDialog data={data} onClose={close} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsTransactionSigned/PerpsTransactionSignedView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsTransactionSigned/PerpsTransactionSignedView.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { DialogBody, DialogHeader } from "@ledgerhq/lumen-ui-react";
+import { DialogBackgroundToneProvider } from "LLD/components/DialogBackgroundGradient";
+import { InfoState } from "LLD/components/InfoState";
+import type { PerpsTransactionSignedViewModel } from "./usePerpsTransactionSignedViewModel";
+
+export function PerpsTransactionSignedView({
+  receiveCurrencyTicker,
+  handleViewTransaction,
+  handleClose,
+}: Readonly<PerpsTransactionSignedViewModel>) {
+  const { t } = useTranslation();
+
+  return (
+    <DialogBackgroundToneProvider>
+      <DialogHeader density="compact" onClose={handleClose} className="!mb-0" />
+      <DialogBody className="!mb-0 flex min-h-0 flex-col px-24 pb-24">
+        <InfoState
+          preset="success"
+          size="hug"
+          title={t("perpsTransactionSigned.title")}
+          description={t("perpsTransactionSigned.description", { currency: receiveCurrencyTicker })}
+          primaryCta={{
+            label: t("perpsTransactionSigned.viewTransaction"),
+            onPress: handleViewTransaction,
+            testID: "perps-transaction-signed-cta",
+          }}
+        />
+      </DialogBody>
+    </DialogBackgroundToneProvider>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsTransactionSigned/__integrations__/perpsTransactionSigned.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsTransactionSigned/__integrations__/perpsTransactionSigned.integration.test.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { act, render, screen } from "tests/testSetup";
+import PerpsTransactionSignedRoot, {
+  openPerpsTransactionSigned,
+} from "../PerpsTransactionSignedDialog";
+import type { PerpsTransactionSignedData } from "../usePerpsTransactionSignedViewModel";
+
+const mockOpenSwapTransactionStatusDialog = jest.fn(() => ({ type: "swap/openTransactionStatus" }));
+jest.mock("LLD/features/SwapTransactionStatusDialog/swapTransactionStatusDialog", () => ({
+  openSwapTransactionStatusDialog: (params: unknown) => mockOpenSwapTransactionStatusDialog(params),
+}));
+
+const signedData: PerpsTransactionSignedData = {
+  receiveCurrencyTicker: "USDC",
+  swapId: "swap-1",
+  provider: "swapkit_hyperliquid",
+};
+
+describe("PerpsTransactionSigned integration", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("should not render the confirmation until a deposit is signed", () => {
+    render(<PerpsTransactionSignedRoot />);
+
+    expect(screen.queryByTestId("perps-transaction-signed-cta")).not.toBeInTheDocument();
+  });
+
+  it("should name the currency the holder is waiting on once opened", () => {
+    render(<PerpsTransactionSignedRoot />);
+
+    act(() => openPerpsTransactionSigned(signedData));
+
+    expect(screen.getByText("Transaction signed")).toBeVisible();
+    expect(screen.getByText(/USDC/)).toBeVisible();
+    expect(screen.getByTestId("perps-transaction-signed-cta")).toBeEnabled();
+  });
+
+  it("should follow the deposit swap when the transaction is opened", async () => {
+    const { user } = render(<PerpsTransactionSignedRoot />);
+
+    act(() => openPerpsTransactionSigned(signedData));
+    await user.click(screen.getByTestId("perps-transaction-signed-cta"));
+
+    // The deposit is funded by a swap, so its status is where the holder follows it.
+    expect(mockOpenSwapTransactionStatusDialog).toHaveBeenCalledWith({
+      swapId: "swap-1",
+      provider: "swapkit_hyperliquid",
+    });
+    expect(screen.queryByTestId("perps-transaction-signed-cta")).not.toBeInTheDocument();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsTransactionSigned/usePerpsTransactionSignedViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsTransactionSigned/usePerpsTransactionSignedViewModel.ts
@@ -1,12 +1,8 @@
 import { useCallback } from "react";
 import { useDispatch } from "LLD/hooks/redux";
 import { openSwapTransactionStatusDialog } from "LLD/features/SwapTransactionStatusDialog/swapTransactionStatusDialog";
-import { OperationDetails } from "~/renderer/drawers/OperationDetails";
-import { setDrawer } from "~/renderer/drawers/Provider";
 
 export type PerpsTransactionSignedData = {
-  operationId: string;
-  accountId: string;
   receiveCurrencyTicker: string;
   swapId?: string;
   provider?: string;
@@ -22,19 +18,13 @@ export function usePerpsTransactionSignedViewModel(
   data: PerpsTransactionSignedData,
   onClose: () => void,
 ): PerpsTransactionSignedViewModel {
-  const { operationId, accountId, receiveCurrencyTicker, swapId, provider } = data;
+  const { receiveCurrencyTicker, swapId, provider } = data;
   const dispatch = useDispatch();
 
   const handleViewTransaction = useCallback(() => {
     onClose();
-
-    if (swapId) {
-      dispatch(openSwapTransactionStatusDialog({ swapId, provider }));
-      return;
-    }
-
-    setDrawer(OperationDetails, { operationId, accountId });
-  }, [onClose, dispatch, swapId, provider, operationId, accountId]);
+    if (swapId) dispatch(openSwapTransactionStatusDialog({ swapId, provider }));
+  }, [onClose, dispatch, swapId, provider]);
 
   return {
     receiveCurrencyTicker,

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsTransactionSigned/usePerpsTransactionSignedViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsTransactionSigned/usePerpsTransactionSignedViewModel.ts
@@ -1,0 +1,44 @@
+import { useCallback } from "react";
+import { useDispatch } from "LLD/hooks/redux";
+import { openSwapTransactionStatusDialog } from "LLD/features/SwapTransactionStatusDialog/swapTransactionStatusDialog";
+import { OperationDetails } from "~/renderer/drawers/OperationDetails";
+import { setDrawer } from "~/renderer/drawers/Provider";
+
+export type PerpsTransactionSignedData = {
+  operationId: string;
+  accountId: string;
+  receiveCurrencyTicker: string;
+  swapId?: string;
+  provider?: string;
+};
+
+export type PerpsTransactionSignedViewModel = {
+  receiveCurrencyTicker: string;
+  handleViewTransaction: () => void;
+  handleClose: () => void;
+};
+
+export function usePerpsTransactionSignedViewModel(
+  data: PerpsTransactionSignedData,
+  onClose: () => void,
+): PerpsTransactionSignedViewModel {
+  const { operationId, accountId, receiveCurrencyTicker, swapId, provider } = data;
+  const dispatch = useDispatch();
+
+  const handleViewTransaction = useCallback(() => {
+    onClose();
+
+    if (swapId) {
+      dispatch(openSwapTransactionStatusDialog({ swapId, provider }));
+      return;
+    }
+
+    setDrawer(OperationDetails, { operationId, accountId });
+  }, [onClose, dispatch, swapId, provider, operationId, accountId]);
+
+  return {
+    receiveCurrencyTicker,
+    handleViewTransaction,
+    handleClose: onClose,
+  };
+}

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9888,5 +9888,10 @@
   "perpsDepositSign": {
     "a11yTitle": "Deposit signing",
     "terms": "By signing this transaction, I accept <termsLink>SwapKit by NEAR Intents T&C</termsLink>"
+  },
+  "perpsTransactionSigned": {
+    "title": "Transaction signed",
+    "description": "You'll receive your {{currency}} once confirmed on the blockchain",
+    "viewTransaction": "View transaction"
   }
 }


### PR DESCRIPTION
## Summary

- Closes the desktop Perps deposit with a transaction signed screen.
- "View transaction" opens the swap status when the deposit swapped.

<img width="3056" height="2034" alt="image" src="https://github.com/user-attachments/assets/ba5d8080-1f4b-4052-93ed-fca6f62b358e" />

## Test plan

- [ ] Deposit on Perps, sign on device, land on the signed screen.
- [ ] "View transaction" opens the swap status dialog.

Stacked on #21246.