### PR TITLE
[LWD] feat(perps): title the transaction detail dialog (LIVE-35330)

### DIFF
--- a/.changeset/perps-transaction-detail.md
+++ b/.changeset/perps-transaction-detail.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Title the transaction detail dialog for Perps deposits: the dialog is named "Transaction detail" and its header leads with the deposit being funded, keeping the swapped pair on its own line. Swap opens the same dialog unchanged.

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/__tests__/usePerpsDepositExecution.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/__tests__/usePerpsDepositExecution.test.ts
@@ -34,9 +34,11 @@ jest.mock("@ledgerhq/live-common/exchange/platform/completeExchange", () => ({
 }));
 
 // The account updater needs a full swap exchange to build its updaters; the
-// deposit only cares that the broadcast reached the signed dialog.
+// deposit only cares about what it is told the swap is worth.
+const mockGetUpdateAccountWithUpdaterParams = jest.fn(() => []);
 jest.mock("@ledgerhq/live-common/exchange/swap/getUpdateAccountWithUpdaterParams", () => ({
-  getUpdateAccountWithUpdaterParams: () => [],
+  getUpdateAccountWithUpdaterParams: (params: unknown) =>
+    mockGetUpdateAccountWithUpdaterParams(params as never),
 }));
 
 const ethereum = getCryptoCurrencyById("ethereum");
@@ -97,7 +99,7 @@ async function signWith(signResult: unknown) {
   });
 
   await answerDeviceStep(execution.result.current.deviceStep, {
-    completeExchangeResult: { family: "ethereum" },
+    completeExchangeResult: { family: "ethereum", amount: new BigNumber("20000000000000000") },
   });
   await answerDeviceStep(execution.result.current.deviceStep, signResult);
 
@@ -175,7 +177,7 @@ describe("usePerpsDepositExecution", () => {
     // Exchange app's payload check.
     expect(result.current.deviceStep).toMatchObject({ stepId: "confirm" });
     await answerDeviceStep(result.current.deviceStep, {
-      completeExchangeResult: { family: "ethereum" },
+      completeExchangeResult: { family: "ethereum", amount: new BigNumber("20000000000000000") },
     });
 
     expect(result.current.deviceStep).toMatchObject({ stepId: "sign" });
@@ -189,6 +191,16 @@ describe("usePerpsDepositExecution", () => {
       provider: "swapkit_hyperliquid",
     });
     expect(onDone).toHaveBeenCalled();
+  });
+
+  it("records the swap at the quoted price, not the one the payload implies", async () => {
+    await signWith({ signedOperation: { operation } });
+
+    // The payload states its payout in the provider's own precision, so pricing
+    // the history from it would misreport the deposit once it is displayed.
+    expect(mockGetUpdateAccountWithUpdaterParams).toHaveBeenCalledWith(
+      expect.objectContaining({ magnitudeAwareRate: new BigNumber("0.95") }),
+    );
   });
 
   it("surfaces a failed signature instead of spinning", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/usePerpsDepositExecution.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/hooks/usePerpsDepositExecution.ts
@@ -100,10 +100,15 @@ export function usePerpsDepositExecution(
   const signAction = useTransactionAction();
   const completeAction = useMemo(() => createCompleteExchangeAction(completeExchange), []);
 
-  const { depositAccount, receiverAccount, amountSent, quoteId } = params;
+  const { depositAccount, receiverAccount, amountSent, amountTo, quoteId } = params;
   const fromParentAccount = useMemo(
     () => getParentAccount(depositAccount, accounts),
     [depositAccount, accounts],
+  );
+
+  const quotedReceiveAmount = useMemo(
+    () => parseCurrencyUnit(getAccountCurrency(receiverAccount).units[0], amountTo),
+    [amountTo, receiverAccount],
   );
 
   const broadcastConfig = useMemo(
@@ -183,7 +188,9 @@ export function usePerpsDepositExecution(
           result: { operation, swapId },
           exchange: exchangeParams.exchange as ExchangeSwap,
           transaction: finalTransaction,
-          magnitudeAwareRate: exchangeParams.magnitudeAwareRate ?? new BigNumber(0),
+          magnitudeAwareRate: finalTransaction.amount.isZero()
+            ? new BigNumber(0)
+            : quotedReceiveAmount.div(finalTransaction.amount),
           provider: PERPS_DEPOSIT_QUOTE_PROVIDER,
         });
         if (updateParams.length) {
@@ -199,6 +206,7 @@ export function usePerpsDepositExecution(
       depositAccount,
       dispatch,
       fromParentAccount,
+      quotedReceiveAmount,
       runDeviceStep,
       signAction,
     ],

--- a/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsTransactionSigned/usePerpsTransactionSignedViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Perps/screens/PerpsTransactionSigned/usePerpsTransactionSignedViewModel.ts
@@ -23,7 +23,7 @@ export function usePerpsTransactionSignedViewModel(
 
   const handleViewTransaction = useCallback(() => {
     onClose();
-    if (swapId) dispatch(openSwapTransactionStatusDialog({ swapId, provider }));
+    if (swapId) dispatch(openSwapTransactionStatusDialog({ swapId, provider, origin: "perps" }));
   }, [onClose, dispatch, swapId, provider]);
 
   return {

--- a/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/__integrations__/SwapTransactionStatusDialog.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/__integrations__/SwapTransactionStatusDialog.integration.test.tsx
@@ -104,6 +104,33 @@ describe("SwapTransactionStatusDialog Integration", () => {
     expect(screen.getByRole("button", { name: "View in explorer" })).toBeVisible();
   });
 
+  it("should title the dialog when perps opens it", async () => {
+    const { store } = render(<SwapTransactionStatusDialog />);
+
+    act(() => {
+      store.dispatch(
+        openSwapTransactionStatusDialog({ swapId: "swap-1", provider: "lifi", origin: "perps" }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toHaveAccessibleName("Transaction detail");
+    });
+  });
+
+  it("should leave the dialog untitled when swap opens it", async () => {
+    const { store } = render(<SwapTransactionStatusDialog />);
+
+    act(() => {
+      store.dispatch(openSwapTransactionStatusDialog({ swapId: "swap-1", provider: "lifi" }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeVisible();
+    });
+    expect(screen.getByRole("dialog")).toHaveAccessibleName("");
+  });
+
   it("should remount transaction content when opening another swap while already open", async () => {
     mockedUseSwapTransactionStatusViewModel.mockImplementation(useViewModelWithMountedSwapId);
     const { store } = render(<SwapTransactionStatusDialog />);

--- a/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/__tests__/TransactionHeader.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/__tests__/TransactionHeader.test.tsx
@@ -61,6 +61,21 @@ describe("TransactionHeader", () => {
     expect(screen.getByText(formatCreatedAt(createdAt, "en-US"))).toBeVisible();
   });
 
+  it("should name the perps deposit and keep the swapped pair on its own line", () => {
+    render(
+      <TransactionHeader
+        sendCurrency={bitcoin}
+        receiveCurrency={ethereum}
+        createdAt={new Date(2024, 0, 2, 15, 4).getTime()}
+        locale="en-US"
+        origin="perps"
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Fund Perpetuals BTC → ETH" })).toBeVisible();
+    expect(screen.queryByText("Swap BTC → ETH")).not.toBeInTheDocument();
+  });
+
   it("should render token icons without a parent network badge", () => {
     render(
       <TransactionHeader

--- a/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/components/SwapTransactionStatusDialogView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/components/SwapTransactionStatusDialogView.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import { Dialog, DialogBody, DialogContent, DialogHeader } from "@ledgerhq/lumen-ui-react";
 import { useSwapTransactionStatusViewModel } from "../hooks/useSwapTransactionStatusViewModel";
 import { SwapTransactionStatusView } from "./SwapTransactionStatusView";
@@ -13,7 +14,7 @@ type SwapTransactionStatusDialogViewProps = Readonly<SwapTransactionStatusDialog
 function SwapTransactionStatusDialogContent({ params }: SwapTransactionStatusDialogContentProps) {
   const viewModel = useSwapTransactionStatusViewModel(params);
 
-  return <SwapTransactionStatusView {...viewModel} />;
+  return <SwapTransactionStatusView {...viewModel} origin={params.origin} />;
 }
 
 export function SwapTransactionStatusDialogView({
@@ -22,8 +23,11 @@ export function SwapTransactionStatusDialogView({
   onClose,
   onOpenChange,
 }: SwapTransactionStatusDialogViewProps) {
+  const { t } = useTranslation();
+
   if (!isOpen || !params) return null;
   const contentKey = `${params.provider ?? ""}:${params.swapId}`;
+  const title = params.origin === "perps" ? t("perpsTransactionStatus.dialogTitle") : undefined;
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange} height="fit">
@@ -31,7 +35,7 @@ export function SwapTransactionStatusDialogView({
         data-testid="swap-transaction-status-dialog"
         className="max-h-[calc(100vh-16px)] w-[400px] bg-canvas-sheet p-0 pb-24"
       >
-        <DialogHeader density="compact" onClose={onClose} />
+        <DialogHeader density="compact" title={title} onClose={onClose} />
         <DialogBody className="flex flex-col px-24 gap-24">
           <SwapTransactionStatusDialogContent key={contentKey} params={params} />
         </DialogBody>

--- a/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/components/SwapTransactionStatusView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/components/SwapTransactionStatusView.tsx
@@ -1,9 +1,14 @@
 import React from "react";
 import type { SwapTransactionStatusViewModel } from "../hooks/useSwapTransactionStatusViewModel";
+import type { SwapTransactionStatusOrigin } from "../types";
 import { TransactionHeader } from "./TransactionHeader";
 import { StatusSection } from "./Status/StatusSection";
 import { DetailsSection } from "./Details/DetailsSection";
 import { FooterSection } from "./Footer/FooterSection";
+
+type SwapTransactionStatusViewProps = Readonly<
+  SwapTransactionStatusViewModel & { origin?: SwapTransactionStatusOrigin }
+>;
 
 export function SwapTransactionStatusView({
   sendCurrency,
@@ -23,7 +28,8 @@ export function SwapTransactionStatusView({
   explorerUrl,
   isStatusSectionLoading,
   isFooterLoading,
-}: Readonly<SwapTransactionStatusViewModel>) {
+  origin,
+}: SwapTransactionStatusViewProps) {
   return (
     <>
       <TransactionHeader
@@ -31,6 +37,7 @@ export function SwapTransactionStatusView({
         receiveCurrency={receiveCurrency}
         createdAt={createdAt}
         locale={locale}
+        origin={origin}
       />
 
       <StatusSection

--- a/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/components/TransactionHeader.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/components/TransactionHeader.tsx
@@ -4,6 +4,7 @@ import { Skeleton } from "@ledgerhq/lumen-ui-react";
 import { CryptoIcon } from "@ledgerhq/crypto-icons";
 import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import { getValidCryptoIconSize } from "~/renderer/utils/cryptoIconSize";
+import type { SwapTransactionStatusOrigin } from "../types";
 import { formatCreatedAt } from "../utils";
 
 type TransactionHeaderProps = Readonly<{
@@ -11,6 +12,13 @@ type TransactionHeaderProps = Readonly<{
   receiveCurrency?: CryptoOrTokenCurrency;
   createdAt?: number;
   locale: string;
+  origin?: SwapTransactionStatusOrigin;
+}>;
+
+type HeaderTitleProps = Readonly<{
+  origin?: SwapTransactionStatusOrigin;
+  sendTicker: string;
+  receiveTicker: string;
 }>;
 
 function HeaderCurrencyIcon({
@@ -26,13 +34,38 @@ function HeaderCurrencyIcon({
   );
 }
 
+/** Perps leads with the deposit it is funding, and keeps the swapped pair on its own line. */
+function HeaderTitle({ origin, sendTicker, receiveTicker }: HeaderTitleProps) {
+  const { t } = useTranslation();
+
+  if (origin === "perps") {
+    return (
+      <h2
+        data-testid="swap-transaction-title"
+        className="heading-4-semi-bold text-base text-center"
+      >
+        <span className="block">{t("perpsTransactionStatus.title")}</span>
+        <span className="block">
+          {t("perpsTransactionStatus.currencies", { sendTicker, receiveTicker })}
+        </span>
+      </h2>
+    );
+  }
+
+  return (
+    <h2 data-testid="swap-transaction-title" className="heading-4-semi-bold text-base">
+      {t("swap2.modals.transactionStatus.title", { sendTicker, receiveTicker })}
+    </h2>
+  );
+}
+
 export function TransactionHeader({
   sendCurrency,
   receiveCurrency,
   createdAt,
   locale,
+  origin,
 }: TransactionHeaderProps) {
-  const { t } = useTranslation();
   const hasCurrencies = sendCurrency !== undefined && receiveCurrency !== undefined;
 
   return (
@@ -51,12 +84,11 @@ export function TransactionHeader({
         {hasCurrencies ? null : <Skeleton className="size-48 rounded-full" />}
       </div>
       {hasCurrencies ? (
-        <h2 data-testid="swap-transaction-title" className="heading-4-semi-bold text-base">
-          {t("swap2.modals.transactionStatus.title", {
-            sendTicker: sendCurrency.ticker,
-            receiveTicker: receiveCurrency.ticker,
-          })}
-        </h2>
+        <HeaderTitle
+          origin={origin}
+          sendTicker={sendCurrency.ticker}
+          receiveTicker={receiveCurrency.ticker}
+        />
       ) : (
         <Skeleton className="h-24 w-176 rounded-sm" />
       )}

--- a/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/swapTransactionStatusDialog.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/swapTransactionStatusDialog.ts
@@ -1,4 +1,4 @@
-import type { SwapTransactionStatusParams } from "@ledgerhq/live-common/exchange/swapTransactionStatus/index";
+import type { SwapTransactionStatusDialogParams } from "./types";
 import {
   closeDialogWithData,
   openDialogWithData,
@@ -10,7 +10,7 @@ import type { State } from "~/renderer/reducers";
 
 const DIALOG_ID = "SWAP_TRANSACTION_STATUS" satisfies DialogWithDataId;
 
-export const openSwapTransactionStatusDialog = (params: SwapTransactionStatusParams) =>
+export const openSwapTransactionStatusDialog = (params: SwapTransactionStatusDialogParams) =>
   openDialogWithData({ id: DIALOG_ID, data: params });
 
 export const closeSwapTransactionStatusDialog = () => closeDialogWithData(DIALOG_ID);

--- a/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/SwapTransactionStatusDialog/types.ts
@@ -1,0 +1,7 @@
+import type { SwapTransactionStatusParams } from "@ledgerhq/live-common/exchange/swapTransactionStatus/index";
+
+export type SwapTransactionStatusOrigin = "swap" | "perps";
+
+export type SwapTransactionStatusDialogParams = SwapTransactionStatusParams & {
+  origin?: SwapTransactionStatusOrigin;
+};

--- a/apps/ledger-live-desktop/src/renderer/reducers/dialogsWithData.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/dialogsWithData.ts
@@ -1,5 +1,5 @@
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
-import type { SwapTransactionStatusParams } from "@ledgerhq/live-common/exchange/swapTransactionStatus/index";
+import type { SwapTransactionStatusDialogParams } from "LLD/features/SwapTransactionStatusDialog/types";
 import type { Reducer } from "redux";
 import type { State } from "~/renderer/reducers";
 
@@ -7,7 +7,7 @@ export const DIALOGS_WITH_DATA_IDS = ["SWAP_TRANSACTION_STATUS"] as const;
 export type DialogWithDataId = (typeof DIALOGS_WITH_DATA_IDS)[number];
 
 export type DialogWithDataPayloadById = {
-  SWAP_TRANSACTION_STATUS: SwapTransactionStatusParams;
+  SWAP_TRANSACTION_STATUS: SwapTransactionStatusDialogParams;
 };
 
 type DialogWithDataEntry<Id extends DialogWithDataId> = {

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9893,5 +9893,10 @@
     "title": "Transaction signed",
     "description": "You'll receive your {{currency}} once confirmed on the blockchain",
     "viewTransaction": "View transaction"
+  },
+  "perpsTransactionStatus": {
+    "dialogTitle": "Transaction detail",
+    "title": "Fund Perpetuals",
+    "currencies": "{{sendTicker}} → {{receiveTicker}}"
   }
 }


### PR DESCRIPTION
## Summary

- The swap transaction status dialog now takes the flow that opened it.
- A Perps deposit names the dialog "Transaction detail" and leads its header with "Fund Perpetuals", keeping the swapped pair on its own line.
- Swap opens the same dialog unchanged.

<img width="3144" height="2122" alt="image" src="https://github.com/user-attachments/assets/8d901aa0-d427-4915-b1dd-89b20d7e1914" />

<img width="3056" height="2034" alt="image" src="https://github.com/user-attachments/assets/3dd3208c-dbcf-4cdf-b7cb-4e4367d95447" />


## Test plan

- [ ] From the Perps signed screen, "View transaction" shows the Perps wording.
- [ ] From swap history, the dialog is untitled and keeps "Swap X → Y".

Stacked on #21260.