### PR TITLE
[LWDM] feat(coin-concordium): type the PLT wallet-proxy network layer

### DIFF
--- a/.changeset/concordium-plt-network-layer.md
+++ b/.changeset/concordium-plt-network-layer.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-concordium": minor
+---
+
+Type the PLT wallet-proxy responses: `accountTokens`, the `/v0/plt/tokens` and `/v0/plt/tokenInfo` clients, PLT transaction detail fields, and the raw reject reason

--- a/libs/coin-modules/coin-concordium/.unimportedrc.json
+++ b/libs/coin-modules/coin-concordium/.unimportedrc.json
@@ -20,6 +20,7 @@
   ],
   "ignoreUnimported": [
     "src/errors.ts",
+    "src/network/plt.ts",
     "src/test/concordiumTestUtils.ts",
     "src/test/fixtures.ts",
     "src/test/testHelpers.ts",

--- a/libs/coin-modules/coin-concordium/src/logic/history/listOperations.test.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/history/listOperations.test.ts
@@ -217,6 +217,7 @@ describe("listOperations", () => {
     expect(getTransactionsMock).toHaveBeenCalledWith(config, "concordium_testnet", VALID_ADDRESS, {
       limit: 100,
       order: "d",
+      includeRawRejectReason: true,
     });
     expect(result.items).toHaveLength(1);
     expect(result.items[0]).toMatchObject({
@@ -229,6 +230,21 @@ describe("listOperations", () => {
     });
     expect(result.items[0].value).toBe(String(BigInt(1000000) + BigInt(500)));
     expect(result.next).toBeUndefined();
+  });
+
+  it("should always request the raw reject reason", async () => {
+    getTransactionsMock.mockResolvedValue({
+      transactions: [],
+      count: 0,
+      limit: 100,
+      order: "descending",
+    });
+
+    await listOperations(config, VALID_ADDRESS, { minHeight: 0 }, "concordium_testnet");
+
+    // The proxy tests the parameter for presence, so `false` would enable it.
+    const [, , , params] = getTransactionsMock.mock.calls[0];
+    expect(params.includeRawRejectReason).toBe(true);
   });
 
   it("should pass blockHeightFrom when minHeight > 0", async () => {
@@ -244,6 +260,7 @@ describe("listOperations", () => {
     expect(getTransactionsMock).toHaveBeenCalledWith(config, "concordium_testnet", VALID_ADDRESS, {
       limit: 100,
       order: "d",
+      includeRawRejectReason: true,
       blockHeightFrom: 500,
     });
   });
@@ -266,6 +283,7 @@ describe("listOperations", () => {
     expect(getTransactionsMock).toHaveBeenCalledWith(config, "concordium_testnet", VALID_ADDRESS, {
       limit: 100,
       order: "d",
+      includeRawRejectReason: true,
       from: "42",
     });
   });

--- a/libs/coin-modules/coin-concordium/src/logic/history/listOperations.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/history/listOperations.ts
@@ -83,6 +83,9 @@ export async function listOperations(
   const params: TransactionQueryParams = {
     limit,
     order: options.order === "asc" ? "a" : "d",
+    // The proxy tests this parameter for presence, not value, so it must be
+    // omitted rather than set to false to disable it.
+    includeRawRejectReason: true,
   };
 
   if (options.minHeight > 0) {

--- a/libs/coin-modules/coin-concordium/src/network/plt.test.ts
+++ b/libs/coin-modules/coin-concordium/src/network/plt.test.ts
@@ -1,0 +1,162 @@
+import { getAccountListStatus, isDecodedPltState, isPltRejectReason } from "./plt";
+import type {
+  PltAccountModuleState,
+  PltAccountToken,
+  PltModuleState,
+  PltTokenAccountState,
+} from "../types";
+
+function accountToken(
+  moduleState: PltAccountToken["token"]["tokenState"]["moduleState"],
+  state?: PltTokenAccountState["state"],
+): PltAccountToken {
+  return {
+    token: {
+      tokenId: "PLT",
+      tokenState: {
+        tokenModuleRef: "ref",
+        decimals: 2,
+        totalSupply: { value: "1000", decimals: 2 },
+        moduleState,
+      },
+    },
+    tokenAccountState: {
+      balance: { value: "500", decimals: 2 },
+      ...(state === undefined ? {} : { state }),
+    },
+  };
+}
+
+describe("isDecodedPltState", () => {
+  it("accepts a decoded object", () => {
+    const state: PltModuleState = { allowList: true };
+    expect(isDecodedPltState(state)).toBe(true);
+  });
+
+  it("rejects the hex-string fallback the node emits when the CBOR does not decode", () => {
+    expect(isDecodedPltState<PltModuleState>("a1696a6c6c6f774c697374f5")).toBe(false);
+  });
+
+  it("rejects an absent state", () => {
+    expect(isDecodedPltState<PltAccountModuleState>(undefined)).toBe(false);
+  });
+
+  it("accepts an empty object", () => {
+    expect(isDecodedPltState<PltAccountModuleState>({})).toBe(true);
+  });
+
+  it("rejects an array", () => {
+    expect(isDecodedPltState([] as unknown as PltModuleState)).toBe(false);
+  });
+});
+
+describe("getAccountListStatus", () => {
+  it("allows when the token declares no list", () => {
+    expect(getAccountListStatus(accountToken({ name: "Token" }))).toBe("allowed");
+  });
+
+  it("allows an account absent from a deny list", () => {
+    expect(getAccountListStatus(accountToken({ denyList: true }, {}))).toBe("allowed");
+  });
+
+  it("allows a deny-list token when the account has no state at all", () => {
+    expect(getAccountListStatus(accountToken({ denyList: true }))).toBe("allowed");
+  });
+
+  it("blocks an account on a deny list", () => {
+    expect(getAccountListStatus(accountToken({ denyList: true }, { denyList: true }))).toBe(
+      "blocked",
+    );
+  });
+
+  it("blocks an account absent from an allow list", () => {
+    expect(getAccountListStatus(accountToken({ allowList: true }, {}))).toBe("blocked");
+  });
+
+  it("blocks an allow-list token when the account has no state, since membership requires a write", () => {
+    expect(getAccountListStatus(accountToken({ allowList: true }))).toBe("blocked");
+  });
+
+  it("allows an account on an allow list", () => {
+    expect(getAccountListStatus(accountToken({ allowList: true }, { allowList: true }))).toBe(
+      "allowed",
+    );
+  });
+
+  it("ignores an account-level flag the token does not declare", () => {
+    expect(getAccountListStatus(accountToken({}, { denyList: true }))).toBe("allowed");
+  });
+
+  it("reports unknown when the module state is undecodable", () => {
+    expect(getAccountListStatus(accountToken("a1", { denyList: true }))).toBe("unknown");
+  });
+
+  it("reports unknown when a listed token's account state is undecodable", () => {
+    expect(getAccountListStatus(accountToken({ allowList: true }, "a1"))).toBe("unknown");
+  });
+
+  it("reports unknown for a deny-list token with an undecodable account state", () => {
+    expect(getAccountListStatus(accountToken({ denyList: true }, "a1"))).toBe("unknown");
+  });
+
+  it("does not report unknown when the token declares no list, whatever the account state", () => {
+    expect(getAccountListStatus(accountToken({}, "a1"))).toBe("allowed");
+  });
+});
+
+describe("isPltRejectReason", () => {
+  it("recognises NonExistentTokenId", () => {
+    expect(isPltRejectReason({ tag: "NonExistentTokenId", contents: "PLT" })).toBe(true);
+  });
+
+  it("recognises TokenUpdateTransactionFailed", () => {
+    expect(
+      isPltRejectReason({
+        tag: "TokenUpdateTransactionFailed",
+        contents: { tokenId: "PLT", type: "tokenBalanceInsufficient" },
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects a non-PLT tag", () => {
+    expect(isPltRejectReason({ tag: "InvalidAccountReference" })).toBe(false);
+  });
+
+  it("rejects an absent reason", () => {
+    expect(isPltRejectReason(undefined)).toBe(false);
+  });
+
+  it("rejects NonExistentTokenId without a string payload", () => {
+    expect(isPltRejectReason({ tag: "NonExistentTokenId" })).toBe(false);
+    expect(isPltRejectReason({ tag: "NonExistentTokenId", contents: { tokenId: "PLT" } })).toBe(
+      false,
+    );
+  });
+
+  it("rejects TokenUpdateTransactionFailed without a module reject payload", () => {
+    expect(isPltRejectReason({ tag: "TokenUpdateTransactionFailed" })).toBe(false);
+    expect(isPltRejectReason({ tag: "TokenUpdateTransactionFailed", contents: "PLT" })).toBe(false);
+    expect(isPltRejectReason({ tag: "TokenUpdateTransactionFailed", contents: null })).toBe(false);
+  });
+
+  it("rejects a module reject payload missing tokenId or type", () => {
+    expect(
+      isPltRejectReason({ tag: "TokenUpdateTransactionFailed", contents: { tokenId: "PLT" } }),
+    ).toBe(false);
+    expect(
+      isPltRejectReason({
+        tag: "TokenUpdateTransactionFailed",
+        contents: { type: "tokenBalanceInsufficient" },
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts a module reject payload carrying optional details", () => {
+    expect(
+      isPltRejectReason({
+        tag: "TokenUpdateTransactionFailed",
+        contents: { tokenId: "PLT", type: "operationNotPermitted", details: "abcd" },
+      }),
+    ).toBe(true);
+  });
+});

--- a/libs/coin-modules/coin-concordium/src/network/plt.ts
+++ b/libs/coin-modules/coin-concordium/src/network/plt.ts
@@ -1,0 +1,94 @@
+import type {
+  PltAccountModuleState,
+  PltAccountToken,
+  PltEncodedState,
+  PltModuleState,
+  PltRejectReason,
+  PltTokenModuleRejectReason,
+  WalletProxyRawRejectReason,
+} from "../types";
+
+/**
+ * Narrows a CBOR-backed state blob to its decoded form.
+ *
+ * The node decodes these blobs, but falls back to the raw hex bytes when the
+ * CBOR does not parse. Reading a field off the hex form yields `undefined`
+ * rather than an error, which would silently read as "flag not set", so every
+ * access must go through this guard.
+ */
+export function isDecodedPltState<T extends PltModuleState | PltAccountModuleState>(
+  state: PltEncodedState<T> | undefined,
+): state is T {
+  return typeof state === "object" && state !== null && !Array.isArray(state);
+}
+
+/**
+ * Result of checking a token's allow/deny lists against one account.
+ *
+ * `unknown` is not a soft `allowed`: it means the module state or the account's
+ * membership could not be read, so nothing can be concluded. A caller gating a
+ * send must treat it as a blocker and say the restrictions could not be
+ * verified, rather than letting the transfer reach the chain to be rejected.
+ */
+export type PltListStatus = "allowed" | "blocked" | "unknown";
+
+/**
+ * Checks whether the token's own lists block this account from transacting.
+ *
+ * Mirrors the chain rule: a deny-list token blocks an account that is on the
+ * list; an allow-list token blocks an account that is not. A token that
+ * declares neither feature never blocks. The module-level flag is consulted
+ * first, since an account-level flag is only meaningful for a feature the token
+ * declares.
+ *
+ * Either state can arrive as undecodable hex instead of an object, which yields
+ * `unknown`. For an allow-list token an *absent* account state is not
+ * ambiguous: membership requires a write, so absence means "not approved".
+ *
+ * Takes an existing entry. An account that never touched the token has no entry
+ * at all, which callers must handle separately.
+ */
+export function getAccountListStatus(entry: PltAccountToken): PltListStatus {
+  const moduleState = entry.token.tokenState.moduleState;
+  if (!isDecodedPltState(moduleState)) return "unknown";
+
+  const hasAllowList = moduleState.allowList === true;
+  const hasDenyList = moduleState.denyList === true;
+  if (!hasAllowList && !hasDenyList) return "allowed";
+
+  const accountState = entry.tokenAccountState.state;
+  if (accountState !== undefined && !isDecodedPltState(accountState)) return "unknown";
+
+  if (hasDenyList && accountState?.denyList === true) return "blocked";
+  if (hasAllowList && accountState?.allowList !== true) return "blocked";
+  return "allowed";
+}
+
+function isTokenModuleRejectReason(value: unknown): value is PltTokenModuleRejectReason {
+  if (typeof value !== "object" || value === null) return false;
+  const { tokenId, type } = value as Partial<PltTokenModuleRejectReason>;
+  return typeof tokenId === "string" && typeof type === "string";
+}
+
+/**
+ * Narrows a raw reject reason to the two chain-level PLT tags.
+ *
+ * `contents` arrives as `unknown` off the wire, so a tag match alone would
+ * assert a shape that was never verified.
+ *
+ * `TokenUpdateTransactionFailed` carries a module-defined `type` string, which
+ * is open-ended: treat an unrecognised value as a generic failure rather than
+ * mapping it.
+ */
+export function isPltRejectReason(
+  reason: WalletProxyRawRejectReason | undefined,
+): reason is PltRejectReason {
+  switch (reason?.tag) {
+    case "NonExistentTokenId":
+      return typeof reason.contents === "string";
+    case "TokenUpdateTransactionFailed":
+      return isTokenModuleRejectReason(reason.contents);
+    default:
+      return false;
+  }
+}

--- a/libs/coin-modules/coin-concordium/src/network/proxyClient.test.ts
+++ b/libs/coin-modules/coin-concordium/src/network/proxyClient.test.ts
@@ -7,6 +7,8 @@ import {
   getAccountsByPublicKey,
   getAccountBalance,
   getAccountNonce,
+  getPltTokens,
+  getPltTokenInfo,
   getTransactions,
   getTransactionCost,
   submitTransfer,
@@ -257,6 +259,70 @@ describe("proxyClient", () => {
         expect.objectContaining({
           method: "GET",
           url: "https://ccd-wallet-proxy-testnet.coin.ledger-test.com/v0/accNonce/test-address",
+        }),
+      );
+    });
+  });
+
+  describe("getPltTokens", () => {
+    it("should fetch the full token info for every token", async () => {
+      const mockResponse = [
+        {
+          tokenId: "PLT",
+          tokenState: {
+            tokenModuleRef: "ref",
+            decimals: 2,
+            totalSupply: { value: "999999900", decimals: 2 },
+            moduleState: { name: "Test token", allowList: true },
+          },
+        },
+      ];
+      mockNetwork.mockResolvedValue({ data: mockResponse });
+
+      const result = await getPltTokens(config, currencyId);
+
+      expect(result).toEqual(mockResponse);
+      expect(mockNetwork).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "GET",
+          url: "https://ccd-wallet-proxy-testnet.coin.ledger-test.com/v0/plt/tokens",
+        }),
+      );
+    });
+  });
+
+  describe("getPltTokenInfo", () => {
+    it("should fetch one token info", async () => {
+      const mockResponse = {
+        tokenId: "PLT",
+        tokenState: {
+          tokenModuleRef: "ref",
+          decimals: 2,
+          totalSupply: { value: "999999900", decimals: 2 },
+          moduleState: "a1",
+        },
+      };
+      mockNetwork.mockResolvedValue({ data: mockResponse });
+
+      const result = await getPltTokenInfo(config, currencyId, "PLT");
+
+      expect(result).toEqual(mockResponse);
+      expect(mockNetwork).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "GET",
+          url: "https://ccd-wallet-proxy-testnet.coin.ledger-test.com/v0/plt/tokenInfo/PLT",
+        }),
+      );
+    });
+
+    it("should escape a token id that is not URL-safe", async () => {
+      mockNetwork.mockResolvedValue({ data: {} });
+
+      await getPltTokenInfo(config, currencyId, "a/b c");
+
+      expect(mockNetwork).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://ccd-wallet-proxy-testnet.coin.ledger-test.com/v0/plt/tokenInfo/a%2Fb%20c",
         }),
       );
     });

--- a/libs/coin-modules/coin-concordium/src/network/proxyClient.ts
+++ b/libs/coin-modules/coin-concordium/src/network/proxyClient.ts
@@ -1,14 +1,15 @@
 import network from "@ledgerhq/live-network";
 import type { LiveNetworkRequest } from "@ledgerhq/live-network/network";
 import { retry } from "@ledgerhq/coin-module-framework/promises";
-import type { ConcordiumCoinConfig } from "../types";
 import type {
   AccountBalanceResponse,
   BlockInfoResponse,
   BlocksAtHeightResponse,
   BlockTransactionEventsResponse,
+  ConcordiumCoinConfig,
   ConsensusInfoResponse,
   GetTransactionCostParams,
+  PltTokenInfo,
   TransactionsResponse,
   PublicKeyAccountsResponse,
   SubmitCredentialData,
@@ -183,6 +184,42 @@ export async function getAccountBalance(
     client.request<AccountBalanceResponse>({
       method: "GET",
       url: `/v2/accBalance/${accountAddress}`,
+    }),
+  );
+}
+
+/**
+ * List every protocol-level token on the chain.
+ * GET /v0/plt/tokens
+ *
+ * Returns full token info, not just identifiers: the proxy resolves each id
+ * before responding.
+ */
+export async function getPltTokens(
+  config: ConcordiumCoinConfig,
+  currencyId: string,
+): Promise<PltTokenInfo[]> {
+  return withClient(config, currencyId, async client =>
+    client.request<PltTokenInfo[]>({
+      method: "GET",
+      url: "/v0/plt/tokens",
+    }),
+  );
+}
+
+/**
+ * Get the global info for one protocol-level token.
+ * GET /v0/plt/tokenInfo/{tokenId}
+ */
+export async function getPltTokenInfo(
+  config: ConcordiumCoinConfig,
+  currencyId: string,
+  tokenId: string,
+): Promise<PltTokenInfo> {
+  return withClient(config, currencyId, async client =>
+    client.request<PltTokenInfo>({
+      method: "GET",
+      url: `/v0/plt/tokenInfo/${encodeURIComponent(tokenId)}`,
     }),
   );
 }

--- a/libs/coin-modules/coin-concordium/src/types/network.ts
+++ b/libs/coin-modules/coin-concordium/src/types/network.ts
@@ -219,13 +219,146 @@ export interface AccountBalanceResponse {
       }>;
       total: string;
     };
-    accountTokens: unknown[];
+    accountTokens: PltAccountToken[];
     accountEncryptedAmount?: {
       incomingAmounts: unknown[];
       selfAmount: string;
       startIndex: number;
     };
   };
+}
+
+// ============================================================================
+// Protocol-Level Token (PLT) Types
+// ============================================================================
+
+/**
+ * A PLT amount. `value` is the amount in the token's smallest unit; `decimals`
+ * is how many of its digits are fractional. The pair is self-describing, so the
+ * same shape is used for balances, supplies and transfer amounts.
+ */
+export interface PltTokenAmount {
+  value: string;
+  decimals: number;
+}
+
+/**
+ * A CBOR-backed state blob as the node renders it: the decoded object when the
+ * CBOR parses, or the raw hex-encoded bytes when it does not.
+ */
+export type PltEncodedState<T> = T | string;
+
+export interface PltTokenMetadataUrl {
+  url: string;
+  checksumSha256?: string;
+  _additional?: Record<string, unknown>;
+}
+
+export interface PltGovernanceAccount {
+  type: "account";
+  address: string;
+}
+
+/**
+ * Module-level token state.
+ *
+ * `allowList` / `denyList` here mean the token *has* that list feature. Whether
+ * a given account is on the list is {@link PltAccountModuleState}, which is a
+ * different question with the same field names.
+ *
+ * Every field is optional and is omitted rather than defaulted, so an absent
+ * flag means "not declared by the module", not `false`.
+ */
+export interface PltModuleState {
+  name?: string;
+  metadata?: PltTokenMetadataUrl;
+  governanceAccount?: PltGovernanceAccount;
+  paused?: boolean;
+  allowList?: boolean;
+  denyList?: boolean;
+  mintable?: boolean;
+  burnable?: boolean;
+  _additional?: Record<string, unknown>;
+}
+
+/**
+ * Account-level token state.
+ *
+ * `allowList` / `denyList` here mean *this account is on* that list. See
+ * {@link PltModuleState} for the module-level counterpart.
+ */
+export interface PltAccountModuleState {
+  allowList?: boolean;
+  denyList?: boolean;
+  _additional?: Record<string, unknown>;
+}
+
+/**
+ * Global state of a token. `decimals` is the canonical proxy-side value; the
+ * per-amount `decimals` on balances and transfer amounts are copies that must
+ * agree with it.
+ */
+export interface PltTokenState {
+  tokenModuleRef: string;
+  decimals: number;
+  totalSupply: PltTokenAmount;
+  moduleState: PltEncodedState<PltModuleState>;
+}
+
+/**
+ * Returned by /v0/plt/tokens and /v0/plt/tokenInfo.
+ */
+export interface PltTokenInfo {
+  tokenId: string;
+  tokenState: PltTokenState;
+}
+
+/**
+ * Per-account state of one token. `state` is absent entirely when the account
+ * has no module state, so absence is distinct from an empty object.
+ */
+export interface PltTokenAccountState {
+  balance: PltTokenAmount;
+  state?: PltEncodedState<PltAccountModuleState>;
+}
+
+/**
+ * One entry of `accountTokens` in the /v2/accBalance response.
+ *
+ * The proxy does not return the node's account-token entry verbatim: it drops
+ * the entry's `tokenId` and substitutes the full token info under `token`, so
+ * the id is reached through `token.tokenId`.
+ */
+export interface PltAccountToken {
+  token: PltTokenInfo;
+  tokenAccountState: PltTokenAccountState;
+}
+
+/**
+ * Details of a token-module rejection, carried by a `TokenUpdateTransactionFailed`
+ * reject reason. `type` is a module-defined string, not a closed set.
+ */
+export interface PltTokenModuleRejectReason {
+  tokenId: string;
+  type: string;
+  details?: unknown;
+}
+
+/**
+ * The two chain-level reject reasons a PLT transaction can produce. Every other
+ * tag is modelled by {@link WalletProxyRawRejectReason}.
+ */
+export type PltRejectReason =
+  | { tag: "NonExistentTokenId"; contents: string }
+  | { tag: "TokenUpdateTransactionFailed"; contents: PltTokenModuleRejectReason };
+
+/**
+ * Structured reject reason, returned only when the request passes
+ * `includeRawRejectReason`.
+ */
+export interface WalletProxyRawRejectReason {
+  tag: string;
+  contents?: unknown;
 }
 
 /**
@@ -238,17 +371,40 @@ export interface WalletProxyTransactionOrigin {
 
 /**
  * Wallet-proxy transaction details (varies by transaction type)
+ *
+ * A PLT transfer has `type: "tokenUpdate"`. There is no separate
+ * "with memo" type string, so a memo shows only as the presence of `memo`.
  */
 export interface WalletProxyTransactionDetails {
-  type: string; // e.g., "transfer", "transferWithMemo", "bakingReward", "encryptedTransfer", etc.
+  type: string; // e.g., "transfer", "transferWithMemo", "tokenUpdate", "bakingReward", etc.
   outcome: "success" | "reject";
   description?: string;
   events?: string[];
   transferAmount?: string;
   transferSource?: string;
   transferDestination?: string;
-  memo?: string; // Present for transferWithMemo transactions
+  memo?: string; // Present for transferWithMemo and for tokenUpdate transactions
+  tokenId?: string; // Present for tokenUpdate
+  tokenTransferAmount?: PltTokenAmount; // Present for tokenUpdate. Named `tokenAmount` by /v0/submissionStatus.
+  rejectReason?: string; // Localized prose. Not a mapping key.
+  rawRejectReason?: WalletProxyRawRejectReason; // Only when the request passes includeRawRejectReason
   [key: string]: unknown;
+}
+
+/**
+ * Details of a PLT transfer as returned by /v0/submissionStatus.
+ *
+ * This endpoint names the transferred value `tokenAmount`, where the
+ * transaction history names it `tokenTransferAmount`, and it reports only the
+ * recipient — there is no sender field.
+ */
+export interface SubmissionStatusTokenUpdateDetails {
+  outcome: "success" | "reject";
+  to?: string;
+  tokenId?: string;
+  tokenAmount?: PltTokenAmount;
+  memo?: string;
+  rejectReason?: string;
 }
 
 /**


### PR DESCRIPTION
### 📝 Description

Types every PLT-carrying wallet-proxy response in `coin-concordium`, and adds the two token-config endpoints.

`accountTokens` was typed `unknown[]` and had no consumer. It now carries a real shape, taken from the node's own JSON instances (`concordium-base`: `Concordium.Types.Queries.Tokens`, `ProtocolLevelTokens/CBOR.hs`, `Concordium.Types.Tokens`) rather than from the proxy README.

**What is here**

- PLT response types in `types/network.ts`, and `accountTokens: PltAccountToken[]`.
- `getPltTokens` (`GET /v0/plt/tokens`) and `getPltTokenInfo` (`GET /v0/plt/tokenInfo/{id}`) in `proxyClient.ts`.
- PLT fields on `WalletProxyTransactionDetails`, plus `SubmissionStatusTokenUpdateDetails`.
- `network/plt.ts`: `isDecodedPltState`, `getAccountListStatus`, `isPltRejectReason`.
- `listOperations` now sends `includeRawRejectReason`.

**Four contract details the types encode**

1. `moduleState` and `tokenAccountState.state` are CBOR on chain. The node renders each as an object when the CBOR decodes, and as a **hex string** when it does not. Both are `PltEncodedState<T> = T | string`, so no caller can read a field without narrowing first. Reading through the hex form yields `undefined`, which would pass as "flag not set".

2. `moduleState.allowList` means *the token has an allow list*. `tokenAccountState.state.allowList` means *this account is on it*. Same field name, different question. They are separate types, and `getAccountListStatus` applies the chain rule: the module flag decides whether the account flag is meaningful at all. It returns `allowed | blocked | unknown`, and `unknown` is not a soft `allowed` — it means the policy could not be read.

3. Every `moduleState` field is optional and omitted when unset. An absent `paused` is not `false`.

4. The transferred value has two names. History calls it `tokenTransferAmount`; `/v0/submissionStatus` calls it `tokenAmount` and reports no sender. Hence the separate detail type.

**`includeRawRejectReason`**

Without it a rejected transaction carries only `rejectReason`, localized prose that cannot serve as a mapping key. The proxy tests the parameter for **presence, not value**, so `false` would enable it — the client must omit it to disable. `listOperations` now sends it, which is what makes structured reject reasons available to the error mapping later.

**Notes for the reviewer**

- `src/network/plt.ts` is in `ignoreUnimported`. Its consumers arrive with the account model and the transaction status work; the entry graph does not reach it yet.
- The submission-status detail type has no client method. No `/v0/submissionStatus` call exists in this package today, and an uncalled request function would be dead code. The type is here so that whoever wires that endpoint does not reach for `tokenTransferAmount`.
- Shapes should still be confirmed against a live testnet PLT account. They are read from source, not observed on the wire.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-28331](https://ledgerhq.atlassian.net/browse/LIVE-28331)
- **ADR** (if any):


[LIVE-28331]: https://ledgerhq.atlassian.net/browse/LIVE-28331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ