### PR TITLE
[LWDM] feat(i18n): @shared/i18n provider for features (LIVE-36594)

### DIFF
--- a/.changeset/shared-i18n-provider.md
+++ b/.changeset/shared-i18n-provider.md
@@ -1,0 +1,12 @@
+---
+"@shared/i18n": minor
+"@features/flow-pay-feature-tour": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Add `@shared/i18n`, a thin i18n context bridge so `features/*` and `domain/*` components can call `useTranslation()` and render `<Trans>` instead of receiving translated strings as props.
+
+Both apps now build their i18next engine with an explicit `createInstance()` rather than the global singleton, and mount `<I18nProvider>` at their root alongside the existing `<I18nextProvider>`. Non-React call sites import the app instance (`~/renderer/i18n/init` on Desktop, `~/i18n/instance` on Mobile) instead of `i18next`, enforced by a lint rule.
+
+`@features/flow-pay-feature-tour` is the pilot: it resolves its own `payTab.featureTour.*` copy and no longer takes any copy props.

--- a/apps/ledger-live-desktop/.oxlintrc.json
+++ b/apps/ledger-live-desktop/.oxlintrc.json
@@ -66,6 +66,11 @@
             "message": "Import typed hooks from 'LLD/hooks/redux' instead of 'react-redux' to ensure proper TypeScript typing."
           },
           {
+            "name": "i18next",
+            "importNames": ["default", "t", "i18n"],
+            "message": "The app no longer initialises the i18next global singleton. Import the app instance (or its 't') from '~/renderer/i18n/init'."
+          },
+          {
             "name": "@ledgerhq/ledger-wallet-framework/types",
             "importNames": [
               "CryptoCurrency",

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -181,6 +181,7 @@
     "@shared/cloud-sync": "workspace:^",
     "@shared/env": "workspace:*",
     "@shared/feature-flags": "workspace:*",
+    "@shared/i18n": "workspace:*",
     "@shared/ui-info-state": "workspace:*",
     "@tanstack/react-query": "5.28.9",
     "@tanstack/react-query-devtools": "5.28.14",

--- a/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/index.tsx
@@ -1,4 +1,4 @@
-import { t } from "i18next";
+import { t } from "~/renderer/i18n/init";
 import { Trans } from "react-i18next";
 import React, { type ReactElement } from "react";
 import { BannerCard, Button, Flex, Icons, Link, NotificationCard, Text } from "@ledgerhq/react-ui";

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayTabFeatureTour.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayTabFeatureTour.test.ts
@@ -13,19 +13,6 @@ describe("usePayTabFeatureTour", () => {
     jest.clearAllMocks();
   });
 
-  it("should build the feature tour content with the three feature rows", () => {
-    const { result } = renderHook(() => usePayTabFeatureTour());
-
-    expect(result.current.title).toBeTruthy();
-    expect(result.current.description).toBeTruthy();
-    expect(result.current.ctaLabel).toBeTruthy();
-    expect(result.current.rows.map(row => row.icon)).toEqual(["Globe", "Chart5", "CreditCard"]);
-    result.current.rows.forEach(row => {
-      expect(row.title).toBeTruthy();
-      expect(row.description).toBeTruthy();
-    });
-  });
-
   it("should wire the tour analytics callbacks to track", () => {
     const { result } = renderHook(() => usePayTabFeatureTour());
 

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabFeatureTour.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabFeatureTour.ts
@@ -1,36 +1,13 @@
 import { useMemo } from "react";
-import { useTranslation } from "react-i18next";
 import type { FeatureTourProps } from "@features/flow-pay-feature-tour";
 import { track } from "~/renderer/analytics/segment";
 
 export function usePayTabFeatureTour(): FeatureTourProps {
-  const { t } = useTranslation();
-
   return useMemo(
     () => ({
-      title: t("payTab.featureTour.title"),
-      description: t("payTab.featureTour.description"),
-      ctaLabel: t("payTab.featureTour.cta"),
-      rows: [
-        {
-          icon: "Globe",
-          title: t("payTab.featureTour.rows.global.title"),
-          description: t("payTab.featureTour.rows.global.description"),
-        },
-        {
-          icon: "Chart5",
-          title: t("payTab.featureTour.rows.volatility.title"),
-          description: t("payTab.featureTour.rows.volatility.description"),
-        },
-        {
-          icon: "CreditCard",
-          title: t("payTab.featureTour.rows.card.title"),
-          description: t("payTab.featureTour.rows.card.description"),
-        },
-      ],
       onTrackScreen: (page: string) => track(page),
       onTrackEvent: (event: string, params: Record<string, unknown>) => track(event, params),
     }),
-    [t],
+    [],
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/__integrations__/Portfolio.integration.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { render, screen, waitFor, withFlagOverrides } from "tests/testSetup";
 import { server, http, HttpResponse } from "tests/server";
 import { MarketMockedResponse } from "tests/handlers/fixtures/market";
-import i18next from "i18next";
+import i18next from "~/renderer/i18n/init";
 import PortfolioPage from "../index";
 import type { Portfolio as PortfolioType } from "@ledgerhq/types-live";
 import { PortfolioView } from "../PortfolioView";

--- a/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/BorrowEntryPoint/__tests__/BorrowEntryPoint.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Portfolio/components/BorrowEntryPoint/__tests__/BorrowEntryPoint.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { t } from "i18next";
+import { t } from "~/renderer/i18n/init";
 import { render, screen } from "tests/testSetup";
 import { useBorrowEntryPointViewModel } from "../../../hooks/useBorrowEntryPointViewModel";
 import { BorrowEntryPoint } from "../index";

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendHeaderModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendHeaderModel.ts
@@ -1,6 +1,6 @@
 import { SendFlowStep, SEND_FLOW_STEP } from "@ledgerhq/live-common/flows/send/types";
 import { decodeURIScheme } from "@ledgerhq/live-common/currencies/index";
-import { t } from "i18next";
+import { t } from "~/renderer/i18n/init";
 import { useMemo, useCallback, useRef } from "react";
 import { useFlowWizard } from "../../FlowWizard/FlowWizardContext";
 import { getRecipientSearchPrefillValue } from "@ledgerhq/live-common/flows/send/utils";
@@ -58,6 +58,40 @@ function getRecipientPlaceholderKey({
       : "newSendFlow.placeholderNoEnsWithContacts";
   }
   return supportsDomain ? "newSendFlow.placeholder" : "newSendFlow.placeholderNoENS";
+}
+
+function resolveHeaderTitle({
+  isSelectingContactAddress,
+  showTitle,
+  titleKey,
+  currencyName,
+}: Readonly<{
+  isSelectingContactAddress: boolean;
+  showTitle: boolean;
+  titleKey: string;
+  currencyName: string;
+}>): string {
+  if (isSelectingContactAddress) return t("newSendFlow.selectAddress");
+  if (!showTitle) return "";
+  return t(titleKey, { currency: currencyName });
+}
+
+function resolveHeaderDescription({
+  isSelectingContactAddress,
+  selectedContactName,
+  showTitle,
+  showAvailable,
+  accountSummary,
+}: Readonly<{
+  isSelectingContactAddress: boolean;
+  selectedContactName: string | undefined;
+  showTitle: boolean;
+  showAvailable: boolean;
+  accountSummary: string;
+}>): string {
+  if (isSelectingContactAddress) return selectedContactName ?? "";
+  if (showTitle && showAvailable && accountSummary) return accountSummary;
+  return "";
 }
 
 export function useSendHeaderModel({
@@ -126,17 +160,20 @@ export function useSendHeaderModel({
   });
   const showAvailable = currentStepConfig?.showAvailable ?? true;
 
-  const title = isSelectingContactAddress
-    ? t("newSendFlow.selectAddress")
-    : showTitle
-      ? t(titleKey, { currency: currencyName })
-      : "";
+  const title = resolveHeaderTitle({
+    isSelectingContactAddress,
+    showTitle,
+    titleKey,
+    currencyName,
+  });
 
-  const descriptionText = isSelectingContactAddress
-    ? selectedContact.name
-    : showTitle && showAvailable && accountSummary
-      ? accountSummary
-      : "";
+  const descriptionText = resolveHeaderDescription({
+    isSelectingContactAddress,
+    selectedContactName: selectedContact?.name,
+    showTitle,
+    showAvailable,
+    accountSummary,
+  });
 
   const handleBack = useCallback(() => {
     closeScanner();

--- a/apps/ledger-live-desktop/src/renderer/App.tsx
+++ b/apps/ledger-live-desktop/src/renderer/App.tsx
@@ -32,6 +32,9 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { AppDataStorageProvider } from "~/renderer/hooks/storage-provider/useAppDataStorage";
 import { allowDebugReactQuerySelector } from "./reducers/settings";
 import { ThemeProvider } from "@ledgerhq/lumen-ui-react";
+import { I18nextProvider } from "react-i18next";
+import { I18nProvider } from "@shared/i18n";
+import i18n from "~/renderer/i18n/init";
 import { setZcashShieldedEnabled } from "@ledgerhq/live-common/families/zcash/setup";
 
 const reloadApp = (event: KeyboardEvent) => {
@@ -121,9 +124,15 @@ const InnerApp = ({ initialCountervalues }: { initialCountervalues: CounterValue
 const App = ({ store, initialCountervalues }: Props) => {
   return (
     <LiveStyleSheetManager>
-      <Provider store={store}>
-        <InnerApp initialCountervalues={initialCountervalues} />
-      </Provider>
+      {/* Two providers, one instance: `I18nextProvider` serves the app's own react-i18next call
+          sites, `I18nProvider` serves the DDD packages through `@shared/i18n`. */}
+      <I18nextProvider i18n={i18n}>
+        <I18nProvider i18n={i18n}>
+          <Provider store={store}>
+            <InnerApp initialCountervalues={initialCountervalues} />
+          </Provider>
+        </I18nProvider>
+      </I18nextProvider>
     </LiveStyleSheetManager>
   );
 };

--- a/apps/ledger-live-desktop/src/renderer/AppError.tsx
+++ b/apps/ledger-live-desktop/src/renderer/AppError.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { DefaultTheme, ThemeProvider } from "styled-components";
 import { I18nextProvider } from "react-i18next";
+import { I18nProvider } from "@shared/i18n";
 import { MemoryRouter } from "react-router";
 import theme, { colors } from "~/renderer/styles/theme";
 import i18n from "~/renderer/i18n/init";
@@ -22,11 +23,13 @@ const App = ({ error }: { error: Error }) => (
   <LiveStyleSheetManager>
     <ThemeProvider theme={lightLiveTheme}>
       <I18nextProvider i18n={i18n}>
-        <MemoryRouter>
-          <RenderError withoutAppData error={error}>
-            <TriggerAppReady />
-          </RenderError>
-        </MemoryRouter>
+        <I18nProvider i18n={i18n}>
+          <MemoryRouter>
+            <RenderError withoutAppData error={error}>
+              <TriggerAppReady />
+            </RenderError>
+          </MemoryRouter>
+        </I18nProvider>
       </I18nextProvider>
     </ThemeProvider>
   </LiveStyleSheetManager>

--- a/apps/ledger-live-desktop/src/renderer/i18n/init.ts
+++ b/apps/ledger-live-desktop/src/renderer/i18n/init.ts
@@ -1,4 +1,4 @@
-import i18n, { InitOptions } from "i18next";
+import { createInstance, type InitOptions } from "i18next";
 import { initReactI18next } from "react-i18next";
 import locales, { i18_DEFAULT_NAMESPACE } from ".";
 import { DEFAULT_LANGUAGE } from "~/config/languages";
@@ -17,6 +17,16 @@ const config: InitOptions = {
   },
 };
 
+// An explicit instance, never the i18next global singleton: it is what lets `@shared/i18n` hand
+// one engine to the DDD packages, and what will let a future module-federation remote own its own
+// without namespaces clobbering each other.
+const i18n = createInstance();
+
 i18n.use(initReactI18next).init(config);
+
+// The app instance's `t`, for the non-React call sites that used to import `t` from `i18next`.
+// i18next already binds its prototype methods at construction and never reassigns `t`, so this
+// follows language changes; `.bind` is a no-op that keeps the call site safe if that ever changes.
+export const t = i18n.t.bind(i18n);
 
 export default i18n;

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -13,14 +13,13 @@ import {
 } from "@features/flow-large-screen-upsell";
 import { restorePayCardBalanceFilter } from "@features/flow-pay-balance/state";
 import { restorePayCardFeatureTour } from "@features/flow-pay-feature-tour/state";
-import i18n from "i18next";
+import i18n from "~/renderer/i18n/init";
 import { webFrame, ipcRenderer } from "electron";
 import each from "lodash/each";
 import { reload, getKey } from "~/renderer/storage";
 import "~/renderer/styles/global";
 import { registerTransportModules } from "~/renderer/live-common-setup";
 import { getLocalStorageEnvs } from "~/renderer/experimental";
-import "~/renderer/i18n/init";
 import "~/renderer/analytics/registerTransactionObserver";
 import { hydrateCurrency } from "~/renderer/bridge/cache";
 import { setupCryptoAssetsStore } from "~/config/bridge-setup";

--- a/apps/ledger-live-desktop/src/renderer/modals/SignMessage/Components/CopyButton.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SignMessage/Components/CopyButton.test.tsx
@@ -2,21 +2,6 @@ import React from "react";
 import { render, screen, waitFor } from "tests/testSetup";
 import CopyButton from "./CopyButton";
 
-jest.mock("i18next", () => {
-  return {
-    __esModule: true,
-    t: jest.fn(key => {
-      if (key === "common.copy") return "Copy";
-      if (key === "common.copied") return "Copied";
-      return key;
-    }),
-    default: {
-      use: jest.fn().mockReturnThis(),
-      init: jest.fn(),
-    },
-  };
-});
-
 describe("CopyButton", () => {
   const testText = "Text to copy";
   beforeAll(() => {

--- a/apps/ledger-live-desktop/src/renderer/modals/SignMessage/Components/CopyButton.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SignMessage/Components/CopyButton.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from "react";
 import styled from "styled-components";
 import { Icons, Button, Flex } from "@ledgerhq/react-ui";
-import { t } from "i18next";
+import { t } from "~/renderer/i18n/init";
 
 type Props = {
   readonly text: string;

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FeesDrawerLiveApp/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FeesDrawerLiveApp/index.tsx
@@ -4,7 +4,7 @@ import { SwapTransactionType } from "@ledgerhq/live-common/exchange/swap/types";
 import { Transaction } from "@ledgerhq/live-common/generated/types";
 import { Button, Divider, Flex } from "@ledgerhq/react-ui";
 import { Account, AccountLike, FeeStrategy } from "@ledgerhq/types-live";
-import { t } from "i18next";
+import { t } from "~/renderer/i18n/init";
 import isEqual from "lodash/isEqual";
 import React, { useCallback, useRef, useState } from "react";
 import { track } from "~/renderer/analytics/segment";

--- a/apps/ledger-live-desktop/tests/testSetup.tsx
+++ b/apps/ledger-live-desktop/tests/testSetup.tsx
@@ -18,6 +18,7 @@ import {
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { I18nextProvider } from "react-i18next";
+import { I18nProvider } from "@shared/i18n";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router";
 import { config } from "react-transition-group";
@@ -171,31 +172,36 @@ function Providers({
   );
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <Provider store={store}>
-        {skipRouter ? (
-          routerContent
-        ) : (
-          <MemoryRouter initialEntries={initialRoute ? [initialRoute] : undefined}>
-            {routerContent}
-          </MemoryRouter>
-        )}
-      </Provider>
-    </QueryClientProvider>
+    // Outside the `minimal` branch on purpose: `useI18n` throws rather than falling back, so any
+    // @shared/i18n consumer in a `minimal` tree would crash. (react-i18next itself still resolves
+    // there — `initReactI18next` registers the app instance as its module default.)
+    <I18nextProvider i18n={i18n}>
+      <I18nProvider i18n={i18n}>
+        <QueryClientProvider client={queryClient}>
+          <Provider store={store}>
+            {skipRouter ? (
+              routerContent
+            ) : (
+              <MemoryRouter initialEntries={initialRoute ? [initialRoute] : undefined}>
+                {routerContent}
+              </MemoryRouter>
+            )}
+          </Provider>
+        </QueryClientProvider>
+      </I18nProvider>
+    </I18nextProvider>
   );
 }
 
 function EnhancedProviders({ children }: { children: React.ReactNode }): React.JSX.Element {
   return (
-    <I18nextProvider i18n={i18n}>
-      <DrawerProvider>
-        <StyleProvider selectedPalette="dark">
-          <LiveStyleSheetManager>
-            <ContextMenuWrapper>{children}</ContextMenuWrapper>
-          </LiveStyleSheetManager>
-        </StyleProvider>
-      </DrawerProvider>
-    </I18nextProvider>
+    <DrawerProvider>
+      <StyleProvider selectedPalette="dark">
+        <LiveStyleSheetManager>
+          <ContextMenuWrapper>{children}</ContextMenuWrapper>
+        </LiveStyleSheetManager>
+      </StyleProvider>
+    </DrawerProvider>
   );
 }
 

--- a/apps/ledger-live-mobile/.oxlintrc.json
+++ b/apps/ledger-live-mobile/.oxlintrc.json
@@ -64,6 +64,11 @@
             "message": "Use the locale hooks from '~/context/Locale' instead of 'react-i18next' to ensure correct injection of the i18n instance."
           },
           {
+            "name": "i18next",
+            "importNames": ["default", "t", "i18n"],
+            "message": "The app no longer initialises the i18next global singleton. Import the app instance from '~/i18n/instance' (or the hooks from '~/context/Locale')."
+          },
+          {
             "name": "@ledgerhq/ledger-wallet-framework/types",
             "importNames": [
               "CryptoCurrency",

--- a/apps/ledger-live-mobile/__tests__/test-renderer.tsx
+++ b/apps/ledger-live-mobile/__tests__/test-renderer.tsx
@@ -19,6 +19,7 @@ import {
 import QueuedBottomSheetsProvider from "LLM/components/QueuedDrawer/QueuedBottomSheetsProvider";
 import React, { useMemo } from "react";
 import { I18nextProvider } from "react-i18next";
+import { I18nProvider } from "@shared/i18n";
 import { Provider } from "react-redux";
 import { AnalyticsContextProvider } from "~/analytics/AnalyticsContext";
 import { i18n } from "~/context/Locale";
@@ -296,22 +297,26 @@ function Providers({
       content
     ) : (
       // For default rendering, add new providers here
-      <I18nextProvider i18n={i18n}>
-        <BottomSheetModalProvider>
-          <QueuedBottomSheetsProvider>
-            <AnalyticsContextProvider>{content}</AnalyticsContextProvider>
-          </QueuedBottomSheetsProvider>
-        </BottomSheetModalProvider>
-      </I18nextProvider>
+      <BottomSheetModalProvider>
+        <QueuedBottomSheetsProvider>
+          <AnalyticsContextProvider>{content}</AnalyticsContextProvider>
+        </QueuedBottomSheetsProvider>
+      </BottomSheetModalProvider>
     );
 
-  // General Providers needed for all render types
+  // General Providers needed for all render types. i18n belongs here rather than in the
+  // non-HOOK branch: `useI18n` throws instead of falling back, so a `renderHook` on any hook
+  // reaching @shared/i18n would crash without a provider above it.
   let providers = (
-    <Provider store={store}>
-      <CountervaluesProviders store={store}>
-        <StyleProvider selectedPalette="dark">{extraProviders}</StyleProvider>
-      </CountervaluesProviders>
-    </Provider>
+    <I18nextProvider i18n={i18n}>
+      <I18nProvider i18n={i18n}>
+        <Provider store={store}>
+          <CountervaluesProviders store={store}>
+            <StyleProvider selectedPalette="dark">{extraProviders}</StyleProvider>
+          </CountervaluesProviders>
+        </Provider>
+      </I18nProvider>
+    </I18nextProvider>
   );
 
   //if React Query is needed

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -215,6 +215,7 @@
     "@shared/cloud-sync": "workspace:^",
     "@shared/env": "workspace:*",
     "@shared/feature-flags": "workspace:*",
+    "@shared/i18n": "workspace:*",
     "@shared/ui-info-state": "workspace:*",
     "@shared/ui-queued-bottom-sheet": "workspace:*",
     "@shopify/flash-list": "2.2.0",

--- a/apps/ledger-live-mobile/src/context/Locale.tsx
+++ b/apps/ledger-live-mobile/src/context/Locale.tsx
@@ -1,8 +1,6 @@
 import React, { useMemo, useContext, useCallback, useEffect, useState } from "react";
 import type { ComponentProps } from "react";
-import i18next from "i18next";
 import {
-  initReactI18next,
   // eslint-disable-next-line no-restricted-imports
   useTranslation as useReactI18nextTranslation,
   // eslint-disable-next-line no-restricted-imports
@@ -10,12 +8,13 @@ import {
 } from "react-i18next";
 import type { TFunction } from "i18next";
 import type { UseTranslationOptions, UseTranslationResponse } from "react-i18next";
+import i18next from "~/i18n/instance";
 import { getTimeZone } from "react-native-localize";
 import storage from "LLM/storage";
 import { I18nManager } from "react-native";
 import RNRestart from "react-native-restart";
 
-import { DEFAULT_LANGUAGE_LOCALE, getDefaultLanguageLocale, locales } from "../languages";
+import { DEFAULT_LANGUAGE_LOCALE, getDefaultLanguageLocale } from "../languages";
 import { setLanguage } from "~/actions/settings";
 import { useDispatch } from "~/context/hooks";
 import { useSettings } from "~/hooks";
@@ -37,16 +36,6 @@ try {
   console.log(error);
 }
 
-i18next.use(initReactI18next).init({
-  fallbackLng: DEFAULT_LANGUAGE_LOCALE,
-  resources: locales,
-  supportedLngs: Object.keys(locales),
-  ns: ["common"],
-  defaultNS: "common",
-  interpolation: {
-    escapeValue: false, // not needed for react as it does escape per default to prevent xss!
-  },
-});
 export { i18next as i18n };
 
 // Wrapper around `useTranslation` that ensures the correct `i18next` instance is used

--- a/apps/ledger-live-mobile/src/families/algorand/ScreenEditMemoValue.tsx
+++ b/apps/ledger-live-mobile/src/families/algorand/ScreenEditMemoValue.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
 import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation } from "~/context/Locale";
-import i18next from "i18next";
+import i18next from "~/i18n/instance";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Transaction as AlgorandTransaction } from "@ledgerhq/live-common/families/algorand/types";
 import { useTheme } from "@react-navigation/native";

--- a/apps/ledger-live-mobile/src/families/bitcoin/ScreenEditCustomFees.tsx
+++ b/apps/ledger-live-mobile/src/families/bitcoin/ScreenEditCustomFees.tsx
@@ -2,7 +2,7 @@ import { BigNumber } from "bignumber.js";
 import invariant from "invariant";
 import React, { useState, useCallback } from "react";
 import { useTranslation } from "~/context/Locale";
-import i18next from "i18next";
+import i18next from "~/i18n/instance";
 import { Keyboard, StyleSheet, View } from "react-native";
 import SafeAreaView from "~/components/SafeAreaView";
 import { CompositeScreenProps, useTheme } from "@react-navigation/native";

--- a/apps/ledger-live-mobile/src/families/canton/ScreenEditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/canton/ScreenEditMemo.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
 import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation } from "~/context/Locale";
-import i18next from "i18next";
+import i18next from "~/i18n/instance";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Transaction as CantonTransaction } from "@ledgerhq/live-common/families/canton/types";
 import { useTheme } from "@react-navigation/native";

--- a/apps/ledger-live-mobile/src/families/cardano/EditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/cardano/EditMemo.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
 import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation } from "~/context/Locale";
-import i18next from "i18next";
+import i18next from "~/i18n/instance";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Transaction as CardanoTransaction } from "@ledgerhq/live-common/families/cardano/types";
 import { useTheme } from "@react-navigation/native";

--- a/apps/ledger-live-mobile/src/families/casper/ScreenEditTransferId.tsx
+++ b/apps/ledger-live-mobile/src/families/casper/ScreenEditTransferId.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useState } from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
 import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation } from "~/context/Locale";
-import i18next from "i18next";
+import i18next from "~/i18n/instance";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Transaction as CasperTransaction } from "@ledgerhq/live-common/families/casper/types";
 import { useIsFocused, useTheme } from "@react-navigation/native";

--- a/apps/ledger-live-mobile/src/families/cosmos/EditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/EditMemo.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
 import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation } from "~/context/Locale";
-import i18next from "i18next";
+import i18next from "~/i18n/instance";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Transaction as CosmosTransaction } from "@ledgerhq/live-common/families/cosmos/types";
 import { useTheme } from "@react-navigation/native";

--- a/apps/ledger-live-mobile/src/families/evm/EvmCustomFees/index.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EvmCustomFees/index.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo } from "react";
 import invariant from "invariant";
-import i18next from "i18next";
+import i18next from "~/i18n/instance";
 import { useNavigation } from "@react-navigation/native";
 import { Transaction } from "@ledgerhq/live-common/families/evm/types";
 import { SendFundsNavigatorStackParamList } from "~/components/RootNavigator/types/SendFundsNavigator";

--- a/apps/ledger-live-mobile/src/families/evm/ScreenEditGasLimit.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/ScreenEditGasLimit.tsx
@@ -1,7 +1,7 @@
 import { BigNumber } from "bignumber.js";
 import React, { useState, useCallback } from "react";
 import { useTranslation } from "~/context/Locale";
-import i18next from "i18next";
+import i18next from "~/i18n/instance";
 import { Keyboard, StyleSheet, View } from "react-native";
 import SafeAreaView from "~/components/SafeAreaView";
 import { useTheme } from "@react-navigation/native";

--- a/apps/ledger-live-mobile/src/families/hedera/EditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/EditMemo.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
 import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation } from "~/context/Locale";
-import i18next from "i18next";
+import i18next from "~/i18n/instance";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Transaction as HederaTransaction } from "@ledgerhq/live-common/families/hedera/types";
 import { useTheme } from "@react-navigation/native";

--- a/apps/ledger-live-mobile/src/families/internet_computer/ScreenEditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/internet_computer/ScreenEditMemo.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useState } from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
 import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation } from "~/context/Locale";
-import i18next from "i18next";
+import i18next from "~/i18n/instance";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Transaction as InternetComputerTransaction } from "@ledgerhq/live-common/families/internet_computer/types";
 import { useIsFocused, useTheme } from "@react-navigation/native";

--- a/apps/ledger-live-mobile/src/families/kaspa/ScreenEditCustomFees.tsx
+++ b/apps/ledger-live-mobile/src/families/kaspa/ScreenEditCustomFees.tsx
@@ -2,7 +2,7 @@ import { BigNumber } from "bignumber.js";
 import invariant from "invariant";
 import React, { useCallback, useState } from "react";
 import { useTranslation } from "~/context/Locale";
-import i18next from "i18next";
+import i18next from "~/i18n/instance";
 import { Keyboard, StyleSheet, View } from "react-native";
 import SafeAreaView from "~/components/SafeAreaView";
 import { CompositeScreenProps, useTheme } from "@react-navigation/native";

--- a/apps/ledger-live-mobile/src/families/mina/ScreenEditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/mina/ScreenEditMemo.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useState } from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
 import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation } from "~/context/Locale";
-import i18next from "i18next";
+import i18next from "~/i18n/instance";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Transaction as MinaTransaction } from "@ledgerhq/live-common/families/mina/types";
 import { useIsFocused, useTheme } from "@react-navigation/native";

--- a/apps/ledger-live-mobile/src/families/solana/ScreenEditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/ScreenEditMemo.tsx
@@ -2,7 +2,7 @@ import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge"
 import type { Transaction as SolanaTransaction } from "@ledgerhq/live-common/families/solana/types";
 import { useTheme } from "@react-navigation/native";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
-import i18next from "i18next";
+import i18next from "~/i18n/instance";
 import React, { useCallback, useState } from "react";
 import { useTranslation } from "~/context/Locale";
 import { ScrollView, StyleSheet, View } from "react-native";

--- a/apps/ledger-live-mobile/src/families/stacks/ScreenEditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/stacks/ScreenEditMemo.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useState } from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
 import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation } from "~/context/Locale";
-import i18next from "i18next";
+import i18next from "~/i18n/instance";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Transaction as StacksTransaction } from "@ledgerhq/live-common/families/stacks/types";
 import { useIsFocused, useTheme } from "@react-navigation/native";

--- a/apps/ledger-live-mobile/src/families/stellar/ScreenEditCustomFees.tsx
+++ b/apps/ledger-live-mobile/src/families/stellar/ScreenEditCustomFees.tsx
@@ -2,7 +2,7 @@ import { BigNumber } from "bignumber.js";
 import invariant from "invariant";
 import React, { useState, useCallback } from "react";
 import { useTranslation } from "~/context/Locale";
-import i18next from "i18next";
+import i18next from "~/i18n/instance";
 import { Keyboard, StyleSheet, View, ScrollView } from "react-native";
 import SafeAreaView from "~/components/SafeAreaView";
 import { useTheme } from "@react-navigation/native";

--- a/apps/ledger-live-mobile/src/families/stellar/ScreenEditMemoType.tsx
+++ b/apps/ledger-live-mobile/src/families/stellar/ScreenEditMemoType.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { View, StyleSheet } from "react-native";
 import { connect } from "react-redux";
 import { Trans } from "~/context/Locale";
-import i18next from "i18next";
+import i18next from "~/i18n/instance";
 import { StellarMemoType } from "@ledgerhq/live-common/families/stellar/types";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import LText from "~/components/LText";

--- a/apps/ledger-live-mobile/src/families/stellar/ScreenEditMemoValue.tsx
+++ b/apps/ledger-live-mobile/src/families/stellar/ScreenEditMemoValue.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useState } from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
 import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation } from "~/context/Locale";
-import i18next from "i18next";
+import i18next from "~/i18n/instance";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Transaction as StellarTransaction } from "@ledgerhq/live-common/families/stellar/types";
 import { useIsFocused, useTheme } from "@react-navigation/native";

--- a/apps/ledger-live-mobile/src/families/ton/ScreenEditComment.tsx
+++ b/apps/ledger-live-mobile/src/families/ton/ScreenEditComment.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useState } from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
 import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation } from "~/context/Locale";
-import i18next from "i18next";
+import i18next from "~/i18n/instance";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Transaction as TonTransaction } from "@ledgerhq/live-common/families/ton/types";
 import { useIsFocused, useTheme } from "@react-navigation/native";

--- a/apps/ledger-live-mobile/src/i18n/instance.ts
+++ b/apps/ledger-live-mobile/src/i18n/instance.ts
@@ -1,0 +1,29 @@
+import { createInstance } from "i18next";
+import { initReactI18next } from "react-i18next";
+import { DEFAULT_LANGUAGE_LOCALE, locales } from "../languages";
+
+/**
+ * The app's translation engine.
+ *
+ * An explicit instance, never the i18next global singleton: it is what lets `@shared/i18n` hand
+ * one engine to the DDD packages, and what will let a future module-federation remote own its own
+ * without namespaces clobbering each other.
+ *
+ * This module is a leaf on purpose — it pulls in the locale resources and nothing else — so the
+ * non-React call sites that need `i18n.t` can import it without dragging in `~/context/Locale`
+ * and its settings/storage graph.
+ */
+const i18n = createInstance();
+
+i18n.use(initReactI18next).init({
+  fallbackLng: DEFAULT_LANGUAGE_LOCALE,
+  resources: locales,
+  supportedLngs: Object.keys(locales),
+  ns: ["common"],
+  defaultNS: "common",
+  interpolation: {
+    escapeValue: false, // not needed for react as it does escape per default to prevent xss!
+  },
+});
+
+export default i18n;

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -9,6 +9,7 @@ import React, { Component, useMemo, useEffect, useRef } from "react";
 import { StyleSheet, LogBox, Appearance, AppState, View } from "react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { I18nextProvider } from "react-i18next";
+import { I18nProvider } from "@shared/i18n";
 import Transport from "@ledgerhq/hw-transport";
 import { log } from "@ledgerhq/logs";
 import { checkLibs } from "@ledgerhq/live-common/sanityChecks";
@@ -365,33 +366,38 @@ export default class Root extends Component {
               <HookDevTools />
               <TermsAndConditionMigrateLegacyData />
               <QueuedBottomSheetsProvider>
+                {/* Two providers, one instance: `I18nextProvider` serves the app's own
+                    react-i18next call sites, `I18nProvider` serves the DDD packages through
+                    `@shared/i18n`. */}
                 <I18nextProvider i18n={i18n}>
-                  <LocaleProvider>
-                    <PlatformAppProviderWrapper>
-                      <SafeAreaProvider>
-                        <ModalSystemPrimer />
-                        <StylesProvider>
-                          <StyledStatusBar />
-                          <NavBarColorHandler />
-                          <AuthPass>
-                            <GestureHandlerRootView style={styles.root}>
-                              <WaitForAppReady currencyInitialized={currencyInitialized}>
-                                <AppProviders initialCountervalues={initialCountervalues}>
-                                  <AppGeoBlocker>
-                                    <AppVersionBlocker>
-                                      <BridgeSyncProvider>
-                                        <App />
-                                      </BridgeSyncProvider>
-                                    </AppVersionBlocker>
-                                  </AppGeoBlocker>
-                                </AppProviders>
-                              </WaitForAppReady>
-                            </GestureHandlerRootView>
-                          </AuthPass>
-                        </StylesProvider>
-                      </SafeAreaProvider>
-                    </PlatformAppProviderWrapper>
-                  </LocaleProvider>
+                  <I18nProvider i18n={i18n}>
+                    <LocaleProvider>
+                      <PlatformAppProviderWrapper>
+                        <SafeAreaProvider>
+                          <ModalSystemPrimer />
+                          <StylesProvider>
+                            <StyledStatusBar />
+                            <NavBarColorHandler />
+                            <AuthPass>
+                              <GestureHandlerRootView style={styles.root}>
+                                <WaitForAppReady currencyInitialized={currencyInitialized}>
+                                  <AppProviders initialCountervalues={initialCountervalues}>
+                                    <AppGeoBlocker>
+                                      <AppVersionBlocker>
+                                        <BridgeSyncProvider>
+                                          <App />
+                                        </BridgeSyncProvider>
+                                      </AppVersionBlocker>
+                                    </AppGeoBlocker>
+                                  </AppProviders>
+                                </WaitForAppReady>
+                              </GestureHandlerRootView>
+                            </AuthPass>
+                          </StylesProvider>
+                        </SafeAreaProvider>
+                      </PlatformAppProviderWrapper>
+                    </LocaleProvider>
+                  </I18nProvider>
                 </I18nextProvider>
               </QueuedBottomSheetsProvider>
             </RebootProvider>

--- a/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/utils/index.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/utils/index.test.tsx
@@ -1,19 +1,9 @@
-import i18next from "i18next";
-import { initReactI18next } from "react-i18next";
+import i18next from "~/i18n/instance";
 import { getTimeAgoCode } from ".";
-import en from "~/locales/en/common.json";
 
-beforeAll(async () => {
-  await i18next.use(initReactI18next).init({
-    lng: "en",
-    fallbackLng: "en",
-    resources: {
-      en: {
-        translation: en,
-      },
-    },
-  });
-});
+// The app instance already carries `en/common.json`; it just has no language until
+// `LocaleProvider` picks one at runtime.
+beforeAll(() => i18next.changeLanguage("en"));
 
 describe("getTimeAgoCode", () => {
   it("returns the translated string for seconds (plural)", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/utils/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/utils/index.tsx
@@ -1,4 +1,4 @@
-import i18next from "i18next";
+import i18next from "~/i18n/instance";
 import { KeysPriceChange } from "@ledgerhq/live-common/market/utils/types";
 
 function getTimeAgoCode(date: Date): string {

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/utils/index.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/utils/index.test.ts
@@ -1,5 +1,4 @@
-import i18next from "i18next";
-import { initReactI18next } from "react-i18next";
+import i18next from "~/i18n/instance";
 import {
   counterValueFormatter,
   getDateFormatter,
@@ -8,19 +7,10 @@ import {
   getCurrentPage,
 } from ".";
 import { Order } from "@ledgerhq/live-common/market/utils/types";
-import en from "~/locales/en/common.json";
 
-beforeAll(async () => {
-  await i18next.use(initReactI18next).init({
-    lng: "en",
-    fallbackLng: "en",
-    resources: {
-      en: {
-        translation: en,
-      },
-    },
-  });
-});
+// The app instance already carries `en/common.json`; it just has no language until
+// `LocaleProvider` picks one at runtime.
+beforeAll(() => i18next.changeLanguage("en"));
 
 describe("counterValueFormatter", () => {
   describe("basic formatting", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Onboarding/components/CounterfeitWarningDrawer/__tests__/useCounterfeitWarningDrawerViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Onboarding/components/CounterfeitWarningDrawer/__tests__/useCounterfeitWarningDrawerViewModel.test.ts
@@ -1,7 +1,7 @@
 import { Linking } from "react-native";
 import { DeviceModelId } from "@ledgerhq/devices";
 import { act, renderHook } from "@testing-library/react-native";
-import i18next from "i18next";
+import i18next from "~/i18n/instance";
 import { track } from "~/analytics";
 import { urls } from "~/utils/urls";
 import {

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
@@ -60,30 +60,10 @@ export function usePayTabViewModel() {
 
   const featureTour: FeatureTourProps = useMemo(
     () => ({
-      title: t("payTab.featureTour.title"),
-      description: t("payTab.featureTour.description"),
-      ctaLabel: t("payTab.featureTour.cta"),
-      rows: [
-        {
-          icon: "Globe",
-          title: t("payTab.featureTour.rows.global.title"),
-          description: t("payTab.featureTour.rows.global.description"),
-        },
-        {
-          icon: "Chart5",
-          title: t("payTab.featureTour.rows.volatility.title"),
-          description: t("payTab.featureTour.rows.volatility.description"),
-        },
-        {
-          icon: "CreditCard",
-          title: t("payTab.featureTour.rows.card.title"),
-          description: t("payTab.featureTour.rows.card.description"),
-        },
-      ],
       onTrackScreen: (page: string) => track(page),
       onTrackEvent: (event: string, params: Record<string, unknown>) => track(event, params),
     }),
-    [t],
+    [],
   );
 
   return {

--- a/apps/ledger-live-mobile/src/screens/AccountSettings/EditAccountName.tsx
+++ b/apps/ledger-live-mobile/src/screens/AccountSettings/EditAccountName.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
-import i18next from "i18next";
+import i18next from "~/i18n/instance";
 import { Platform, StyleSheet, Keyboard } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useSelector, useDispatch } from "~/context/hooks";

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/language.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/language.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from "react";
 import { I18nManager, ScrollView } from "react-native";
 import { Trans, useLocale } from "~/context/Locale";
 import { Flex, SelectableList } from "@ledgerhq/native-ui";
-import i18next from "i18next";
+import i18next from "~/i18n/instance";
 import RNRestart from "react-native-restart";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { useAvailableLanguagesForDevice } from "@ledgerhq/live-common/manager/useAvailableLanguagesForDevice";

--- a/docs/ddd-monorepo-architecture.md
+++ b/docs/ddd-monorepo-architecture.md
@@ -39,6 +39,10 @@ See [domain/README.md](../domain/README.md) for details.
 ### `shared/`
 No business logic, no app-specific context. Pure utilities, schemas, Redux tooling. _e.g. `@shared/feature-flags`, `@shared/schema-primitives`._
 
+Cross-cutting app capabilities reach the lower layers by injection at the app root rather than by
+props-drilling — see [`@shared/i18n`](../shared/i18n) (`<I18nProvider>` + `useTranslation`), which
+lets `features/*` and `domain/*` resolve their own copy without depending on an app's i18n setup.
+
 ---
 
 ## Dependency rules (enforced by Nx)

--- a/features/flow/pay-feature-tour/README.md
+++ b/features/flow/pay-feature-tour/README.md
@@ -7,52 +7,31 @@ mobile and a dialog on desktop, shown once until the user dismisses it.
 
 ## Usage
 
-This package is **copy-agnostic**: it renders whatever strings the host passes in and never
-imports an i18n library. The app owns the translation keys and resolves them with its own
-`useTranslation()`/`t()` before mounting the tour (same pattern as `@features/flow-contacts`).
+Copy lives with the feature: the tour resolves its own strings through
+[`@shared/i18n`](../../../shared/i18n), so the host only injects analytics.
 
 ```tsx
-import {
-  FeatureTour,
-  type FeatureTourContent,
-} from "@features/flow-pay-feature-tour";
-import { useTranslation } from "~/context/Locale";
+import { FeatureTour } from "@features/flow-pay-feature-tour";
 
-const { t } = useTranslation();
-
-const content: FeatureTourContent = {
-  title: t("payCardFeatureTour.title"),
-  description: t("payCardFeatureTour.description"),
-  ctaLabel: t("payCardFeatureTour.cta"),
-  rows: [
-    {
-      icon: "Globe",
-      title: t("payCardFeatureTour.rows.global.title"),
-      description: t("payCardFeatureTour.rows.global.description"),
-    },
-    {
-      icon: "Chart5",
-      title: t("payCardFeatureTour.rows.volatility.title"),
-      description: t("payCardFeatureTour.rows.volatility.description"),
-    },
-    {
-      icon: "CreditCard",
-      title: t("payCardFeatureTour.rows.card.title"),
-      description: t("payCardFeatureTour.rows.card.description"),
-    },
-  ],
-};
-
-<FeatureTour
-  {...content}
-  onTrackScreen={trackScreen}
-  onTrackEvent={trackEvent}
-/>;
+<FeatureTour onTrackScreen={trackScreen} onTrackEvent={trackEvent} />;
 ```
 
-The `icon` field is a Lumen symbol name resolved per platform, so the app picks the glyph
-while the copy stays translatable. Translation keys and the app-side wiring live in the host
-app (tracked separately in the mount ticket), keeping this package free of hardcoded strings.
+The keys it reads, in the host app's **default** namespace (`app` on Desktop, `common` on Mobile):
+
+| Key | Rendered as |
+| --- | --- |
+| `payTab.featureTour.title` | Sheet title |
+| `payTab.featureTour.description` | Sheet subtitle |
+| `payTab.featureTour.cta` | Dismiss button |
+| `payTab.featureTour.rows.global.{title,description}` | Row 1 (`Globe`) |
+| `payTab.featureTour.rows.volatility.{title,description}` | Row 2 (`Chart5`) |
+| `payTab.featureTour.rows.card.{title,description}` | Row 3 (`CreditCard`) |
+
+Both apps must carry these keys at the same path until translation keys are colocated per feature
+(a follow-up of [LIVE-36540](https://ledgerhq.atlassian.net/browse/LIVE-36540)). The row icons are
+Lumen symbol names resolved per platform and stay owned by this package.
+
+Tests wrap the component in `I18nTestProvider` from `@shared/i18n/testing`.
 
 Visibility is derived from this flow's `payCardFeatureTour` slice (`hasSeenFeatureTour`),
 exposed through `@features/flow-pay-feature-tour/state`. Store, persistence and test
@@ -100,7 +79,7 @@ pay-feature-tour/
             ├── FeatureTourView.web.tsx        # Web presentational UI (Dialog)
             ├── index.ts                       # Barrel
             ├── payTabTour.webp                # Hero image
-            ├── types.ts                       # Public props and content types
+            ├── types.ts                       # Public props and row types
             └── useFeatureTourViewModel.ts     # Shared state and orchestration
 ```
 

--- a/features/flow/pay-feature-tour/package.json
+++ b/features/flow/pay-feature-tour/package.json
@@ -29,6 +29,7 @@
     "unimported": "pnpm knip --directory ../../.. -W features/flow/pay-feature-tour"
   },
   "dependencies": {
+    "@shared/i18n": "workspace:*",
     "@shared/ui-queued-bottom-sheet": "workspace:*",
     "@reduxjs/toolkit": "catalog:"
   },

--- a/features/flow/pay-feature-tour/src/components/FeatureTour/__tests__/FeatureTour.native.test.tsx
+++ b/features/flow/pay-feature-tour/src/components/FeatureTour/__tests__/FeatureTour.native.test.tsx
@@ -4,46 +4,26 @@ import { cleanup, render, screen, userEvent } from "@testing-library/react-nativ
 import { markPayCardFeatureTourSeen, payCardFeatureTourSlice } from "../../../state";
 import { Provider } from "react-redux";
 import { FeatureTour } from "../FeatureTour";
-import type { FeatureTourContent, FeatureTourProps } from "../types";
+import { I18nTestProvider } from "@shared/i18n/testing";
+import type { FeatureTourProps } from "../types";
+import { FEATURE_TOUR_RESOURCES } from "./fixtures";
 
 jest.mock("@shared/ui-queued-bottom-sheet", () => ({
   QueuedBottomSheet: ({ children }: { children: React.ReactNode }) => children,
 }));
 
-const CONTENT: FeatureTourContent = {
-  title: "Pay and get paid",
-  description: "Stablecoin closes the gap between crypto and real life spending",
-  ctaLabel: "Got it",
-  rows: [
-    {
-      icon: "Globe",
-      title: "Pay and get paid globally",
-      description: "Benefits from low networks fees",
-    },
-    {
-      icon: "Chart5",
-      title: "Minimal volatility",
-      description: "Stablecoin are based on fiat",
-    },
-    {
-      icon: "CreditCard",
-      title: "Spend with a card and get 1% cashback",
-      description: "Pay in USDC, USDT, BTC, ETH and more",
-    },
-  ],
-};
-
 function makeStore() {
   return configureStore({ reducer: { payCardFeatureTour: payCardFeatureTourSlice.reducer } });
 }
 
-function renderTour(props: Partial<FeatureTourProps> = {}, store = makeStore()) {
-  const merged: FeatureTourProps = { ...CONTENT, ...props };
+function renderTour(props: FeatureTourProps = {}, store = makeStore()) {
   return {
     store,
     ...render(
       <Provider store={store}>
-        <FeatureTour {...merged} />
+        <I18nTestProvider resources={FEATURE_TOUR_RESOURCES}>
+          <FeatureTour {...props} />
+        </I18nTestProvider>
       </Provider>,
     ),
   };
@@ -88,5 +68,19 @@ describe("FeatureTour (Native)", () => {
     renderTour({}, store);
 
     expect(screen.queryByText("Pay and get paid")).toBeNull();
+  });
+
+  it("resolves its copy from the mounted i18n provider, not from props", () => {
+    render(
+      <Provider store={makeStore()}>
+        <I18nTestProvider
+          resources={{ en: { translation: { payTab: { featureTour: { cta: "Compris" } } } } }}
+        >
+          <FeatureTour />
+        </I18nTestProvider>
+      </Provider>,
+    );
+
+    expect(screen.getByLabelText("Compris")).toBeTruthy();
   });
 });

--- a/features/flow/pay-feature-tour/src/components/FeatureTour/__tests__/FeatureTour.web.test.tsx
+++ b/features/flow/pay-feature-tour/src/components/FeatureTour/__tests__/FeatureTour.web.test.tsx
@@ -4,42 +4,22 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { markPayCardFeatureTourSeen, payCardFeatureTourSlice } from "../../../state";
 import { Provider } from "react-redux";
 import { FeatureTour } from "../FeatureTour";
-import type { FeatureTourContent, FeatureTourProps } from "../types";
-
-const CONTENT: FeatureTourContent = {
-  title: "Pay and get paid",
-  description: "Stablecoin closes the gap between crypto and real life spending",
-  ctaLabel: "Got it",
-  rows: [
-    {
-      icon: "Globe",
-      title: "Pay and get paid globally",
-      description: "Benefits from low networks fees",
-    },
-    {
-      icon: "Chart5",
-      title: "Minimal volatility",
-      description: "Stablecoin are based on fiat",
-    },
-    {
-      icon: "CreditCard",
-      title: "Spend with a card and get 1% cashback",
-      description: "Pay in USDC, USDT, BTC, ETH and more",
-    },
-  ],
-};
+import { I18nTestProvider } from "@shared/i18n/testing";
+import type { FeatureTourProps } from "../types";
+import { FEATURE_TOUR_RESOURCES } from "./fixtures";
 
 function makeStore() {
   return configureStore({ reducer: { payCardFeatureTour: payCardFeatureTourSlice.reducer } });
 }
 
-function renderTour(props: Partial<FeatureTourProps> = {}, store = makeStore()) {
-  const merged: FeatureTourProps = { ...CONTENT, ...props };
+function renderTour(props: FeatureTourProps = {}, store = makeStore()) {
   return {
     store,
     ...render(
       <Provider store={store}>
-        <FeatureTour {...merged} />
+        <I18nTestProvider resources={FEATURE_TOUR_RESOURCES}>
+          <FeatureTour {...props} />
+        </I18nTestProvider>
       </Provider>,
     ),
   };
@@ -83,5 +63,19 @@ describe("FeatureTour (Web)", () => {
     renderTour({}, store);
 
     expect(screen.queryByText("Spend with a card and get 1% cashback")).toBeNull();
+  });
+
+  it("resolves its copy from the mounted i18n provider, not from props", () => {
+    render(
+      <Provider store={makeStore()}>
+        <I18nTestProvider
+          resources={{ en: { translation: { payTab: { featureTour: { cta: "Compris" } } } } }}
+        >
+          <FeatureTour />
+        </I18nTestProvider>
+      </Provider>,
+    );
+
+    expect(screen.getByText("Compris")).toBeInTheDocument();
   });
 });

--- a/features/flow/pay-feature-tour/src/components/FeatureTour/__tests__/fixtures.ts
+++ b/features/flow/pay-feature-tour/src/components/FeatureTour/__tests__/fixtures.ts
@@ -1,0 +1,28 @@
+/** The `payTab.featureTour.*` copy each app ships, mirrored here for the container tests. */
+export const FEATURE_TOUR_RESOURCES = {
+  en: {
+    translation: {
+      payTab: {
+        featureTour: {
+          title: "Pay and get paid",
+          description: "Stablecoin closes the gap between crypto and real life spending",
+          cta: "Got it",
+          rows: {
+            global: {
+              title: "Pay and get paid globally",
+              description: "Benefits from low networks fees",
+            },
+            volatility: {
+              title: "Minimal volatility",
+              description: "Stablecoin are based on fiat",
+            },
+            card: {
+              title: "Spend with a card and get 1% cashback",
+              description: "Pay in USDC, USDT, BTC, ETH and more",
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/features/flow/pay-feature-tour/src/components/FeatureTour/types.ts
+++ b/features/flow/pay-feature-tour/src/components/FeatureTour/types.ts
@@ -11,18 +11,10 @@ export type FeatureTourRow = Readonly<{
 }>;
 
 /**
- * User-facing copy injected by the host app. This package stays i18n-agnostic: the app
- * resolves translations (e.g. via `t("payCardFeatureTour.title")`) and passes the strings in.
+ * Copy is resolved inside this package through `@shared/i18n`; the host only injects analytics.
+ * Keys live under `payTab.featureTour.*` in each app's default namespace.
  */
-export type FeatureTourContent = Readonly<{
-  title: string;
-  description: string;
-  ctaLabel: string;
-  rows: readonly FeatureTourRow[];
+export type FeatureTourProps = Readonly<{
+  onTrackScreen?: PayCardTrackScreen;
+  onTrackEvent?: PayCardTrackEvent;
 }>;
-
-export type FeatureTourProps = FeatureTourContent &
-  Readonly<{
-    onTrackScreen?: PayCardTrackScreen;
-    onTrackEvent?: PayCardTrackEvent;
-  }>;

--- a/features/flow/pay-feature-tour/src/components/FeatureTour/useFeatureTourViewModel.ts
+++ b/features/flow/pay-feature-tour/src/components/FeatureTour/useFeatureTourViewModel.ts
@@ -1,7 +1,8 @@
 import { useCallback, useMemo } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { useTranslation } from "@shared/i18n";
 import { markPayCardFeatureTourSeen, selectPayCardHasSeenFeatureTour } from "../../state";
-import type { FeatureTourProps, FeatureTourRow } from "./types";
+import type { FeatureTourProps, FeatureTourRow, FeatureTourRowIcon } from "./types";
 
 export type FeatureTourViewModel = Readonly<{
   isVisible: boolean;
@@ -15,14 +16,20 @@ export type FeatureTourViewModel = Readonly<{
 
 const TRACK_PAGE = "Page card feature intro";
 
+const KEY_PREFIX = "payTab.featureTour";
+
+/** Icon per row, paired with the translation sub-key that carries its copy. */
+const ROWS: readonly { icon: FeatureTourRowIcon; key: string }[] = [
+  { icon: "Globe", key: "global" },
+  { icon: "Chart5", key: "volatility" },
+  { icon: "CreditCard", key: "card" },
+];
+
 export function useFeatureTourViewModel({
-  title,
-  description,
-  ctaLabel,
-  rows,
   onTrackScreen,
   onTrackEvent,
 }: FeatureTourProps): FeatureTourViewModel {
+  const { t } = useTranslation();
   const dispatch = useDispatch();
   const hasSeenFeatureTour = useSelector(selectPayCardHasSeenFeatureTour);
 
@@ -35,16 +42,26 @@ export function useFeatureTourViewModel({
     onTrackEvent?.("button_clicked", { button: "got it", page: "$page" });
   }, [dispatch, onTrackEvent]);
 
+  const rows = useMemo(
+    () =>
+      ROWS.map(({ icon, key }) => ({
+        icon,
+        title: t(`${KEY_PREFIX}.rows.${key}.title`),
+        description: t(`${KEY_PREFIX}.rows.${key}.description`),
+      })),
+    [t],
+  );
+
   return useMemo(
     () => ({
       isVisible: !hasSeenFeatureTour,
-      title,
-      description,
+      title: t(`${KEY_PREFIX}.title`),
+      description: t(`${KEY_PREFIX}.description`),
       rows,
-      ctaLabel,
+      ctaLabel: t(`${KEY_PREFIX}.cta`),
       onShown,
       onDismiss,
     }),
-    [hasSeenFeatureTour, title, description, rows, ctaLabel, onShown, onDismiss],
+    [hasSeenFeatureTour, t, rows, onShown, onDismiss],
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1169,6 +1169,9 @@ importers:
       '@shared/feature-flags':
         specifier: workspace:*
         version: link:../../shared/feature-flags
+      '@shared/i18n':
+        specifier: workspace:*
+        version: link:../../shared/i18n
       '@shared/ui-info-state':
         specifier: workspace:*
         version: link:../../shared/ui-info-state
@@ -2047,6 +2050,9 @@ importers:
       '@shared/feature-flags':
         specifier: workspace:*
         version: link:../../shared/feature-flags
+      '@shared/i18n':
+        specifier: workspace:*
+        version: link:../../shared/i18n
       '@shared/ui-info-state':
         specifier: workspace:*
         version: link:../../shared/ui-info-state
@@ -6841,6 +6847,9 @@ importers:
       '@reduxjs/toolkit':
         specifier: 'catalog:'
         version: 2.11.2(react-redux@9.2.0(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@shared/i18n':
+        specifier: workspace:*
+        version: link:../../../shared/i18n
       '@shared/ui-queued-bottom-sheet':
         specifier: workspace:*
         version: link:../../../shared/ui-queued-bottom-sheet
@@ -16928,6 +16937,64 @@ importers:
       jest:
         specifier: 'catalog:'
         version: 30.4.1
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
+  shared/i18n:
+    dependencies:
+      i18next:
+        specifier: 'catalog:'
+        version: 25.7.3(@typescript/typescript6@6.0.2)
+      react-i18next:
+        specifier: 'catalog:'
+        version: 16.5.0(@typescript/typescript6@6.0.2)(i18next@25.7.3(@typescript/typescript6@6.0.2))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+    devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
+      '@support/jest-shared':
+        specifier: workspace:*
+        version: link:../../support/jest-shared
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@testing-library/dom':
+        specifier: 'catalog:'
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: 'catalog:'
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.0.14
+      jest:
+        specifier: 'catalog:'
+        version: 30.4.1(@types/node@24.12.0)
+      jest-environment-jsdom:
+        specifier: 'catalog:'
+        version: 30.4.1
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.64.0
+      react:
+        specifier: 19.1.4
+        version: 19.1.4
+      react-dom:
+        specifier: 19.1.4
+        version: 19.1.4(react@19.1.4)
       typescript:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
@@ -28226,7 +28293,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: '*'
+      rxjs: ^5.5.10
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -66772,7 +66839,9 @@ snapshots:
     optionalDependencies:
       metro-transform-worker: 0.81.5
     transitivePeerDependencies:
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   metro-config@0.83.3(metro-transform-worker@0.83.3):
     dependencies:

--- a/shared/i18n/README.md
+++ b/shared/i18n/README.md
@@ -1,0 +1,101 @@
+# @shared/i18n
+
+> [!CAUTION]
+> **Status: UNSTABLE** — New package; the contract is still being validated against the first
+> `features/*` migrations.
+
+A thin i18n **context bridge**. Each app mounts one `<I18nProvider>` at its root with its own
+i18next instance; `features/*`, `domain/*` and `shared/*` components then call `useTranslation()`
+and render `<Trans>` exactly like app-layer components do — no props-drilling of strings, no
+per-package translation context.
+
+This package owns **no** i18next instance, no resources, and no configuration. It only carries
+whatever the app injects.
+
+## Exports
+
+| Export | Description |
+| --- | --- |
+| `I18nProvider` | Mounted once per app root. Takes the app's i18next instance. |
+| `useTranslation` | `react-i18next`'s hook bound to the injected instance. `i18n` is not accepted in the options — the provider decides. |
+| `Trans` | `react-i18next`'s component bound to the injected instance. |
+| `useI18n` | The raw instance, for `language` / `changeLanguage` / `exists`. |
+| `I18nInstance`, `I18nNamespace`, `I18nProviderProps`, `TransProps` | Types. |
+| `MissingI18nProviderError` | Thrown when a consumer renders outside a provider. |
+| `createI18nTestInstance`, `I18nTestProvider` (`@shared/i18n/testing`) | Test-only helpers. |
+
+## App wiring
+
+```tsx
+// apps/<app>/…/i18n.ts
+import { createInstance } from "i18next";
+import { initReactI18next } from "react-i18next";
+
+export const i18n = createInstance();
+i18n.use(initReactI18next).init({ resources, defaultNS: "app", /* … */ });
+```
+
+```tsx
+// app root
+import { I18nProvider } from "@shared/i18n";
+import { I18nextProvider } from "react-i18next";
+
+<I18nextProvider i18n={i18n}>
+  <I18nProvider i18n={i18n}>
+    <App />
+  </I18nProvider>
+</I18nextProvider>;
+```
+
+Two providers, one instance, on purpose:
+
+- `I18nextProvider` serves the app's own `react-i18next` call sites (thousands of them today).
+- `I18nProvider` serves DDD packages. It deliberately does **not** re-mount `I18nextProvider`
+  itself: if a DDD package ever resolved a second physical copy of `react-i18next`, a shared
+  context would silently split in two, whereas passing the instance explicitly cannot.
+
+### The instance must be `createInstance()`
+
+Never hand `I18nProvider` the module-level `i18next` default export. A single global singleton is
+the failure mode the [Module Federation i18n guide](https://module-federation.io/integrations/practice/react/i18n-react.html)
+warns about: once host and remotes all `init()` the same object, their namespaces clobber each
+other. With an explicit instance, splitting a feature into its own remote is a wiring change and
+nothing else — feature code does not move.
+
+## Feature usage
+
+```tsx
+import { useTranslation } from "@shared/i18n";
+
+export function FeatureTour() {
+  const { t } = useTranslation();
+  return <h2>{t("payTab.featureTour.title")}</h2>;
+}
+```
+
+### Namespaces and key typing
+
+Keys are typed as `string` inside DDD packages: `react-i18next`'s `CustomTypeOptions` augmentation
+is app-owned, and a shared package cannot see either app's resource shape. Passing a namespace
+works (`useTranslation("myNamespace")`), but until translation keys are colocated per feature
+(a follow-up epic), features resolve keys in the host app's **default** namespace — `app` on
+Desktop, `common` on Mobile — so a migrated feature needs its keys present in both apps under the
+same path.
+
+## Testing
+
+`useTranslation` throws `MissingI18nProviderError` outside a provider rather than falling back to
+the global singleton. Wrap the component under test:
+
+```tsx
+import { I18nTestProvider } from "@shared/i18n/testing";
+
+render(
+  <I18nTestProvider resources={{ en: { translation: { "payTab.featureTour.title": "Pay" } } }}>
+    <FeatureTour />
+  </I18nTestProvider>,
+);
+```
+
+With no `resources`, every key resolves to itself — convenient when the assertion is about which
+key was rendered rather than its wording.

--- a/shared/i18n/jest.config.js
+++ b/shared/i18n/jest.config.js
@@ -1,0 +1,22 @@
+const { createSharedJestConfig } = require("@support/jest-shared");
+
+// React package: jsdom + tsx tests, unlike the node/`*.test.ts` default.
+module.exports = createSharedJestConfig({
+  testEnvironment: "jsdom",
+  testMatch: ["**/*.test.ts?(x)"],
+  transform: {
+    "^.+\\.(t|j)sx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+          parser: { syntax: "typescript", tsx: true },
+          transform: { react: { runtime: "automatic" } },
+        },
+      },
+    ],
+  },
+  setupFilesAfterEnv: ["@testing-library/jest-dom", "@ledgerhq/test-quarantine/jest-retries"],
+  // Pinned so a source file with no test counts as 0% instead of vanishing from the report.
+  collectCoverageFrom: ["src/**/*.{ts,tsx}", "!src/**/__tests__/**"],
+});

--- a/shared/i18n/package.json
+++ b/shared/i18n/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@shared/i18n",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Thin i18n context bridge: apps inject their i18next instance once, features/* and domain/* call useTranslation() and Trans without props-drilling strings",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./testing": "./src/testing/index.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "format": "oxfmt src",
+    "format:check": "oxfmt src --check",
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../.. -W shared/i18n"
+  },
+  "dependencies": {
+    "i18next": "catalog:",
+    "react-i18next": "catalog:"
+  },
+  "peerDependencies": {
+    "react": ">=19.0.0"
+  },
+  "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
+    "@support/jest-shared": "workspace:*",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@testing-library/dom": "catalog:",
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "jest": "catalog:",
+    "jest-environment-jsdom": "catalog:",
+    "oxfmt": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/shared/i18n/project.json
+++ b/shared/i18n/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@shared/i18n",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/shared/i18n/src/I18nProvider.tsx
+++ b/shared/i18n/src/I18nProvider.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { I18nContext } from "./context";
+import type { I18nInstance } from "./types";
+
+export type I18nProviderProps = Readonly<{
+  /**
+   * The app's translation engine. Must be an explicit `i18next.createInstance()`, never the
+   * module-level global singleton — that is what lets each future module-federation remote own
+   * its own instance without namespaces clobbering each other.
+   */
+  i18n: I18nInstance;
+  children: React.ReactNode;
+}>;
+
+/**
+ * Mounted once at each app root. Owns no i18next instance and no configuration — it only makes
+ * the injected one reachable from `features/*`, `domain/*` and `shared/*` components.
+ */
+export function I18nProvider({ i18n, children }: I18nProviderProps) {
+  return <I18nContext.Provider value={i18n}>{children}</I18nContext.Provider>;
+}

--- a/shared/i18n/src/Trans.tsx
+++ b/shared/i18n/src/Trans.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { Trans as ReactI18nextTrans } from "react-i18next";
+import { useI18n } from "./context";
+
+export type TransProps = Omit<React.ComponentProps<typeof ReactI18nextTrans>, "i18n">;
+
+/**
+ * `react-i18next`'s `Trans`, bound to the instance injected at the app root. Use it when a
+ * translation interpolates React nodes; plain strings go through `useTranslation`.
+ */
+export function Trans(props: TransProps) {
+  return <ReactI18nextTrans {...props} i18n={useI18n()} />;
+}

--- a/shared/i18n/src/__tests__/I18nProvider.test.tsx
+++ b/shared/i18n/src/__tests__/I18nProvider.test.tsx
@@ -1,0 +1,174 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { I18nextProvider, useTranslation as useReactI18nextTranslation } from "react-i18next";
+import { I18nProvider } from "../I18nProvider";
+import { MissingI18nProviderError } from "../errors";
+import { Trans } from "../Trans";
+import { useI18n } from "../context";
+import { useTranslation } from "../useTranslation";
+import { createI18nTestInstance } from "../testing";
+
+const resources = {
+  en: {
+    translation: {
+      greeting: "Hello",
+      interpolated: "Hello {{name}}",
+      rich: "Read the <1>docs</1>",
+    },
+    other: { greeting: "Hello from other" },
+  },
+  fr: { translation: { greeting: "Bonjour" } },
+};
+
+function Greeting() {
+  const { t } = useTranslation();
+  return <span>{t("greeting")}</span>;
+}
+
+function renderWithI18n(ui: React.ReactNode, i18n = createI18nTestInstance({ resources })) {
+  return { i18n, ...render(<I18nProvider i18n={i18n}>{ui}</I18nProvider>) };
+}
+
+describe("I18nProvider", () => {
+  it("resolves keys through the injected instance", () => {
+    renderWithI18n(<Greeting />);
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+  });
+
+  it("exposes the injected instance to useI18n", () => {
+    function Language() {
+      return <span>{useI18n().language}</span>;
+    }
+    renderWithI18n(<Language />, createI18nTestInstance({ resources, language: "fr" }));
+    expect(screen.getByText("fr")).toBeInTheDocument();
+  });
+
+  it("resolves against the injected instance, not the i18next global singleton", () => {
+    const scoped = createI18nTestInstance({
+      resources: { en: { translation: { greeting: "Scoped hello" } } },
+    });
+    renderWithI18n(<Greeting />, scoped);
+    expect(screen.getByText("Scoped hello")).toBeInTheDocument();
+  });
+
+  it("ignores a foreign react-i18next provider wrapped around it", () => {
+    // A UI library mounting its own <I18nextProvider> (Lumen does, for its a11y strings) must not
+    // retarget the DDD packages: this provider passes its instance explicitly on every call.
+    const foreign = createI18nTestInstance({
+      resources: { en: { common: { greeting: "Foreign" } } },
+      defaultNS: "common",
+    });
+
+    render(
+      <I18nextProvider i18n={foreign}>
+        <I18nProvider i18n={createI18nTestInstance({ resources })}>
+          <Greeting />
+        </I18nProvider>
+      </I18nextProvider>,
+    );
+
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+    expect(screen.queryByText("Foreign")).toBeNull();
+  });
+
+  it("leaves a foreign react-i18next provider nested inside it untouched", () => {
+    function ForeignGreeting() {
+      const { t } = useReactI18nextTranslation();
+      return <span>{t("greeting")}</span>;
+    }
+    const foreign = createI18nTestInstance({
+      resources: { en: { common: { greeting: "Foreign" } } },
+      defaultNS: "common",
+    });
+
+    render(
+      <I18nProvider i18n={createI18nTestInstance({ resources })}>
+        <Greeting />
+        <I18nextProvider i18n={foreign}>
+          <ForeignGreeting />
+        </I18nextProvider>
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+    expect(screen.getByText("Foreign")).toBeInTheDocument();
+  });
+
+  it("keeps two providers isolated from each other", () => {
+    const first = createI18nTestInstance({ resources: { en: { translation: { greeting: "A" } } } });
+    const second = createI18nTestInstance({
+      resources: { en: { translation: { greeting: "B" } } },
+    });
+
+    render(
+      <>
+        <I18nProvider i18n={first}>
+          <Greeting />
+        </I18nProvider>
+        <I18nProvider i18n={second}>
+          <Greeting />
+        </I18nProvider>
+      </>,
+    );
+
+    expect(screen.getByText("A")).toBeInTheDocument();
+    expect(screen.getByText("B")).toBeInTheDocument();
+  });
+});
+
+describe("useTranslation", () => {
+  it("interpolates values", () => {
+    function Interpolated() {
+      const { t } = useTranslation();
+      return <span>{t("interpolated", { name: "Satoshi" })}</span>;
+    }
+    renderWithI18n(<Interpolated />);
+    expect(screen.getByText("Hello Satoshi")).toBeInTheDocument();
+  });
+
+  it("honours an explicit namespace", () => {
+    function Other() {
+      const { t } = useTranslation("other");
+      return <span>{t("greeting")}</span>;
+    }
+    renderWithI18n(<Other />, createI18nTestInstance({ resources, defaultNS: "translation" }));
+    expect(screen.getByText("Hello from other")).toBeInTheDocument();
+  });
+
+  it("returns the injected instance as the second tuple member", () => {
+    function Tuple() {
+      const [, i18n] = useTranslation();
+      return <span>{i18n.language}</span>;
+    }
+    renderWithI18n(<Tuple />);
+    expect(screen.getByText("en")).toBeInTheDocument();
+  });
+
+  it("throws a MissingI18nProviderError with no provider mounted", () => {
+    const consoleError = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<Greeting />)).toThrow(MissingI18nProviderError);
+    consoleError.mockRestore();
+  });
+});
+
+describe("Trans", () => {
+  it("renders interpolated React nodes through the injected instance", () => {
+    function Rich() {
+      return (
+        <p>
+          <Trans i18nKey="rich">
+            Read the <a href="https://ledger.com">docs</a>
+          </Trans>
+        </p>
+      );
+    }
+    renderWithI18n(<Rich />);
+    expect(screen.getByRole("link", { name: "docs" })).toBeInTheDocument();
+  });
+
+  it("throws a MissingI18nProviderError with no provider mounted", () => {
+    const consoleError = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<Trans i18nKey="rich" />)).toThrow(MissingI18nProviderError);
+    consoleError.mockRestore();
+  });
+});

--- a/shared/i18n/src/__tests__/testing.test.tsx
+++ b/shared/i18n/src/__tests__/testing.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { getI18n } from "react-i18next";
+import { useTranslation } from "../useTranslation";
+import { I18nTestProvider, createI18nTestInstance } from "../testing";
+
+function Greeting() {
+  const { t } = useTranslation();
+  return <span>{t("some.key")}</span>;
+}
+
+describe("createI18nTestInstance", () => {
+  it("initialises synchronously", () => {
+    expect(createI18nTestInstance().isInitialized).toBe(true);
+  });
+
+  it("echoes the key back when no resource matches", () => {
+    expect(createI18nTestInstance().t("some.key")).toBe("some.key");
+  });
+
+  it("does not register itself as react-i18next's process-global instance", () => {
+    // `initReactI18next` would call `setI18n`, making a throwaway instance the default that every
+    // bare `useTranslation()` in the jest process resolves against. The provider passes the
+    // instance explicitly, so nothing here needs that.
+    const before = getI18n();
+    createI18nTestInstance({ resources: { en: { translation: { "some.key": "hijacked" } } } });
+    expect(getI18n()).toBe(before);
+  });
+});
+
+describe("I18nTestProvider", () => {
+  it("renders keys with no resources", () => {
+    render(
+      <I18nTestProvider>
+        <Greeting />
+      </I18nTestProvider>,
+    );
+    expect(screen.getByText("some.key")).toBeInTheDocument();
+  });
+
+  it("renders the resources it is given", () => {
+    render(
+      <I18nTestProvider resources={{ en: { translation: { "some.key": "Some value" } } }}>
+        <Greeting />
+      </I18nTestProvider>,
+    );
+    expect(screen.getByText("Some value")).toBeInTheDocument();
+  });
+});

--- a/shared/i18n/src/context.ts
+++ b/shared/i18n/src/context.ts
@@ -1,0 +1,18 @@
+import { createContext, useContext } from "react";
+import { MissingI18nProviderError } from "./errors";
+import type { I18nInstance } from "./types";
+
+export const I18nContext = createContext<I18nInstance | null>(null);
+
+/**
+ * The i18n instance mounted at the app root. Use it for what the `t` function does not cover —
+ * the current language, `changeLanguage`, `exists`. For translating, prefer `useTranslation`.
+ *
+ * Throws when no provider is mounted: a missing provider silently falling back to the i18next
+ * global singleton is exactly the namespace-clobbering failure this package exists to prevent.
+ */
+export function useI18n(): I18nInstance {
+  const i18n = useContext(I18nContext);
+  if (i18n === null) throw new MissingI18nProviderError("useI18n");
+  return i18n;
+}

--- a/shared/i18n/src/errors.ts
+++ b/shared/i18n/src/errors.ts
@@ -1,0 +1,9 @@
+/** Thrown when a `@shared/i18n` consumer renders outside of an `<I18nProvider>`. */
+export class MissingI18nProviderError extends Error {
+  constructor(consumer: string) {
+    super(
+      `${consumer} was called outside of an <I18nProvider>. Mount <I18nProvider i18n={appI18nInstance}> at the app root, or wrap the component under test with the provider from "@shared/i18n/testing".`,
+    );
+    this.name = "MissingI18nProviderError";
+  }
+}

--- a/shared/i18n/src/index.ts
+++ b/shared/i18n/src/index.ts
@@ -1,0 +1,6 @@
+export * from "./context";
+export * from "./errors";
+export * from "./I18nProvider";
+export * from "./Trans";
+export * from "./types";
+export * from "./useTranslation";

--- a/shared/i18n/src/testing/I18nTestProvider.tsx
+++ b/shared/i18n/src/testing/I18nTestProvider.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from "react";
+import { I18nProvider } from "../I18nProvider";
+import {
+  createI18nTestInstance,
+  type CreateI18nTestInstanceOptions,
+} from "./createI18nTestInstance";
+
+export type I18nTestProviderProps = CreateI18nTestInstanceOptions &
+  Readonly<{ children: React.ReactNode }>;
+
+/**
+ * Test-only `I18nProvider` that builds its own instance. Wrap a `features/*` component under test
+ * with it instead of hand-rolling an i18next setup in every package.
+ *
+ * The instance is created once per mount and kept in state, not memoised: it is the context value,
+ * and callers pass `resources` as an inline literal, so a `useMemo` keyed on it would hand out a
+ * fresh instance on every parent re-render and drop whatever the test had applied to the old one.
+ */
+export function I18nTestProvider({
+  children,
+  resources,
+  language,
+  defaultNS,
+}: I18nTestProviderProps) {
+  const [i18n] = useState(() => createI18nTestInstance({ resources, language, defaultNS }));
+
+  return <I18nProvider i18n={i18n}>{children}</I18nProvider>;
+}

--- a/shared/i18n/src/testing/createI18nTestInstance.ts
+++ b/shared/i18n/src/testing/createI18nTestInstance.ts
@@ -1,0 +1,41 @@
+import { createInstance, type Resource } from "i18next";
+import type { I18nInstance } from "../types";
+
+export type CreateI18nTestInstanceOptions = Readonly<{
+  /** i18next resources, e.g. `{ en: { translation: { "a.b": "Hello" } } }`. */
+  resources?: Resource;
+  /** Language to resolve against. Defaults to `en`. */
+  language?: string;
+  /** Default namespace. Defaults to `translation`. */
+  defaultNS?: string;
+}>;
+
+/**
+ * A throwaway, synchronously initialised i18next instance for tests. With no resources every key
+ * resolves to itself, which is what a `features/*` test usually wants to assert on.
+ */
+export function createI18nTestInstance({
+  resources = {},
+  language = "en",
+  defaultNS = "translation",
+}: CreateI18nTestInstanceOptions = {}): I18nInstance {
+  const instance = createInstance();
+
+  // Deliberately not `.use(initReactI18next)`: its `init` calls react-i18next's `setI18n` and
+  // `setDefaults`, which are process-global. A throwaway test instance must not become the
+  // default every bare `useTranslation()` in the jest process resolves against. The provider
+  // hands the instance over explicitly, so nothing here needs the plugin.
+  instance.init({
+    lng: language,
+    fallbackLng: language,
+    defaultNS,
+    ns: [defaultNS],
+    resources,
+    // Resolve everything in the current tick so tests never have to await init.
+    initImmediate: false,
+    interpolation: { escapeValue: false },
+    react: { useSuspense: false },
+  });
+
+  return instance;
+}

--- a/shared/i18n/src/testing/index.ts
+++ b/shared/i18n/src/testing/index.ts
@@ -1,0 +1,2 @@
+export * from "./createI18nTestInstance";
+export * from "./I18nTestProvider";

--- a/shared/i18n/src/types.ts
+++ b/shared/i18n/src/types.ts
@@ -1,0 +1,13 @@
+import type { FlatNamespace, i18n } from "i18next";
+
+/**
+ * The translation engine injected by the app. Structurally an i18next instance — this package
+ * never creates one, it only carries whatever the app root hands it.
+ */
+export type I18nInstance = i18n;
+
+/**
+ * Namespace argument accepted by {@link useTranslation}. Mirrors react-i18next's internal
+ * `$Tuple<FlatNamespace>`, which is not reachable through its `exports` map.
+ */
+export type I18nNamespace = FlatNamespace | readonly [FlatNamespace?, ...FlatNamespace[]];

--- a/shared/i18n/src/useTranslation.ts
+++ b/shared/i18n/src/useTranslation.ts
@@ -1,0 +1,24 @@
+import type { KeyPrefix } from "i18next";
+import {
+  useTranslation as useReactI18nextTranslation,
+  type FallbackNs,
+  type UseTranslationOptions,
+  type UseTranslationResponse,
+} from "react-i18next";
+import { useI18n } from "./context";
+import type { I18nNamespace } from "./types";
+
+/**
+ * `react-i18next`'s `useTranslation`, bound to the instance injected at the app root instead of
+ * the global singleton. `i18n` is not accepted in the options: the provider decides which engine
+ * resolves the keys.
+ */
+export function useTranslation<
+  const Ns extends I18nNamespace | undefined = undefined,
+  const KPrefix extends KeyPrefix<FallbackNs<Ns>> = undefined,
+>(
+  ns?: Ns,
+  options?: Omit<UseTranslationOptions<KPrefix>, "i18n">,
+): UseTranslationResponse<FallbackNs<Ns>, KPrefix> {
+  return useReactI18nextTranslation(ns, { ...options, i18n: useI18n() });
+}

--- a/shared/i18n/tsconfig.json
+++ b/shared/i18n/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "paths": { "*": ["./*"] },
+    "noEmit": true,
+    "types": ["jest", "node", "@testing-library/jest-dom"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}


### PR DESCRIPTION
> [!NOTE]
> First slice of the `@shared/i18n` epic: the package, both app roots, and one pilot feature.
> Namespace splitting and per-feature key colocation are explicitly out of scope (follow-up epic).

### 📝 Description

`features/*` and `domain/*` cannot reach translated strings today, so apps resolve them and pass
them down — deep props-drilling, or an ad-hoc context in every package. This blocks any feature
with nested UI.

`@shared/i18n` is a thin **context bridge**. It owns no i18next instance and no configuration;
each app injects its own at the root, and DDD packages then call `useTranslation()` / `<Trans>`
exactly like app-layer components do.

**What it means for you after this merges** — inside any `features/*` or `domain/*` package:

```tsx
import { useTranslation } from "@shared/i18n";

const { t } = useTranslation();
return <h2>{t("payTab.featureTour.title")}</h2>;
```

Tests wrap the component instead of hand-rolling an i18next setup:

```tsx
import { I18nTestProvider } from "@shared/i18n/testing";

render(<I18nTestProvider resources={...}><MyFeature /></I18nTestProvider>);
```

With no `resources`, every key resolves to itself — handy when the assertion is about *which*
key rendered.

#### Two providers, one instance

```tsx
<I18nextProvider i18n={i18n}>   {/* the app's own react-i18next call sites */}
  <I18nProvider i18n={i18n}>    {/* the DDD packages */}
```

`I18nProvider` deliberately does **not** re-mount `I18nextProvider`. The instance is passed
explicitly on every call, so a package resolving a second physical copy of `react-i18next`
cannot silently split the context in two — a shared React context could.

#### The engine is now an explicit instance

Both apps built their engine on the module-level `i18next` singleton. That is the shape the
[Module Federation i18n guide](https://module-federation.io/integrations/practice/react/i18n-react.html)
warns about: once host and remotes `init()` the same object, their namespaces clobber each other.
Each app now owns a `createInstance()`, which is what makes a future remote independently
splittable — with **no change to feature code**.

Consequence: non-React call sites must name the instance.

```diff
- import { t } from "i18next";                    // Desktop
+ import { t } from "~/renderer/i18n/init";

- import i18next from "i18next";                  // Mobile
+ import i18next from "~/i18n/instance";
```

A `no-restricted-imports` rule per app now blocks `default` / `t` / `i18n` from `i18next`.
`TFunction` type imports are unaffected. On Mobile, `~/i18n/instance` is a leaf module kept clear
of the settings/storage graph so family screens import it without a cycle.

#### Pilot — `@features/flow-pay-feature-tour`

Both apps already resolved an identical `payTab.featureTour.*` key set, so the tour reads them
itself now.

```diff
- <FeatureTour title={t("payTab.featureTour.title")} description={…} ctaLabel={…} rows={[…]}
-              onTrackScreen={…} onTrackEvent={…} />
+ <FeatureTour onTrackScreen={…} onTrackEvent={…} />
```

Keys stay in each app's **default** namespace (`app` on Desktop, `common` on Mobile), so a
migrated feature needs them at the same path in both apps until colocation lands.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36594](https://ledgerhq.atlassian.net/browse/LIVE-36594)
- **Epic**: [LIVE-36540](https://ledgerhq.atlassian.net/browse/LIVE-36540)
- **ADR** (if any): —


[LIVE-36540]: https://ledgerhq.atlassian.net/browse/LIVE-36540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ




[LIVE-36594]: https://ledgerhq.atlassian.net/browse/LIVE-36594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
