### PR TITLE
refactor(pay): drop card suffix from receive save helpers (LIVE-36586)

### DIFF
--- a/.changeset/pretty-cycles-tickle.md
+++ b/.changeset/pretty-cycles-tickle.md
@@ -1,0 +1,7 @@
+---
+"@features/flow-pay-card-request": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Rename the request receive save helpers and the summary test id to drop their redundant "card" suffix

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/saveRequestReceive.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/saveRequestReceive.test.ts
@@ -1,7 +1,7 @@
 import { ipcRenderer } from "electron";
 import { toPng } from "html-to-image";
 import logger from "~/renderer/logger";
-import { saveRequestReceiveCard } from "../saveRequestReceiveCard";
+import { saveRequestReceive } from "../saveRequestReceive";
 
 jest.mock("electron", () => ({
   ipcRenderer: {
@@ -20,13 +20,13 @@ const mockedToPng = jest.mocked(toPng);
 const mockedInvoke = jest.mocked(ipcRenderer.invoke);
 const mockedLoggerError = jest.mocked(logger.error);
 
-const CARD_HTML = '<div data-testid="pay-card-request-receive-card">card</div>';
+const SUMMARY_HTML = '<div data-testid="pay-card-request-receive-summary">card</div>';
 const DATA_URL = "data:image/png;base64,ABC123";
 
-describe("saveRequestReceiveCard", () => {
+describe("saveRequestReceive", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    document.body.innerHTML = CARD_HTML;
+    document.body.innerHTML = SUMMARY_HTML;
     mockedToPng.mockResolvedValue(DATA_URL);
   });
 
@@ -37,7 +37,7 @@ describe("saveRequestReceiveCard", () => {
   it("should invoke save-png with dialog options and base64 when capturing succeeds", async () => {
     mockedInvoke.mockResolvedValueOnce(true);
 
-    await saveRequestReceiveCard("USDC", "Save request card");
+    await saveRequestReceive("USDC", "Save request card");
 
     expect(mockedInvoke).toHaveBeenCalledTimes(1);
     expect(mockedInvoke).toHaveBeenCalledWith(
@@ -55,7 +55,7 @@ describe("saveRequestReceiveCard", () => {
   it("should do nothing when the card node is missing", async () => {
     document.body.innerHTML = "";
 
-    await saveRequestReceiveCard("USDC", "Save request card");
+    await saveRequestReceive("USDC", "Save request card");
 
     expect(mockedToPng).not.toHaveBeenCalled();
     expect(mockedInvoke).not.toHaveBeenCalled();
@@ -65,7 +65,7 @@ describe("saveRequestReceiveCard", () => {
     const error = new Error("capture failed");
     mockedToPng.mockRejectedValueOnce(error);
 
-    await saveRequestReceiveCard("USDC", "Save request card");
+    await saveRequestReceive("USDC", "Save request card");
 
     expect(mockedInvoke).not.toHaveBeenCalled();
     expect(mockedLoggerError).toHaveBeenCalledWith(error);

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/saveRequestReceive.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/saveRequestReceive.ts
@@ -2,7 +2,7 @@ import { ipcRenderer } from "electron";
 import { toPng } from "html-to-image";
 import logger from "~/renderer/logger";
 
-const CARD_SELECTOR = '[data-testid="pay-card-request-receive-card"]';
+const SUMMARY_SELECTOR = '[data-testid="pay-card-request-receive-summary"]';
 const BASE64_PNG_PREFIX = /^data:image\/png;base64,/;
 
 /**
@@ -10,9 +10,9 @@ const BASE64_PNG_PREFIX = /^data:image\/png;base64,/;
  * native OS save dialog. The image write happens in the main process (see the `save-png` handler)
  * so the renderer never touches the filesystem directly.
  */
-export async function saveRequestReceiveCard(ticker: string, dialogTitle: string): Promise<void> {
+export async function saveRequestReceive(ticker: string, dialogTitle: string): Promise<void> {
   try {
-    const node = document.querySelector<HTMLElement>(CARD_SELECTOR);
+    const node = document.querySelector<HTMLElement>(SUMMARY_SELECTOR);
     if (!node) {
       return;
     }

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabRequestReceive.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabRequestReceive.ts
@@ -6,7 +6,7 @@ import type { PayCardTrackEvent, RequestReceiveProps } from "@features/flow-pay-
 import { useCopyToClipboard } from "../../../hooks/useCopyToClipboard";
 import { useOpenAssetAndAccount } from "../../ModularDialog/Web3AppWebview/AssetAndAccountDrawer";
 import { deriveRequestReceiveData } from "./deriveRequestReceiveData";
-import { useSaveRequestReceiveCard } from "./useSaveRequestReceiveCard";
+import { useSaveRequestReceive } from "./useSaveRequestReceive";
 import type { PayVerifySelection } from "./usePayTabVerifyAddress";
 
 const REQUEST_PAGE = "Pay";
@@ -59,7 +59,7 @@ export function usePayTabRequestReceive(
     [selection],
   );
 
-  const saveCard = useSaveRequestReceiveCard(data?.asset.ticker ?? "");
+  const saveCard = useSaveRequestReceive(data?.asset.ticker ?? "");
 
   const labels = useMemo(
     () => ({

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/useSaveRequestReceive.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/useSaveRequestReceive.ts
@@ -1,12 +1,12 @@
 import { useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import { saveRequestReceiveCard } from "./saveRequestReceiveCard";
+import { saveRequestReceive } from "./saveRequestReceive";
 
 /**
  * Returns a guarded callback that saves the request card as a PNG. The guard prevents a second
  * capture from starting while the OS save dialog of a first one is still open.
  */
-export function useSaveRequestReceiveCard(ticker: string): () => void {
+export function useSaveRequestReceive(ticker: string): () => void {
   const { t } = useTranslation();
   const savingRef = useRef(false);
 
@@ -15,7 +15,7 @@ export function useSaveRequestReceiveCard(ticker: string): () => void {
       return;
     }
     savingRef.current = true;
-    void saveRequestReceiveCard(ticker, t("payTab.request.saveDialogTitle")).finally(() => {
+    void saveRequestReceive(ticker, t("payTab.request.saveDialogTitle")).finally(() => {
       savingRef.current = false;
     });
   }, [ticker, t]);

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
@@ -546,7 +546,7 @@ describe("PayTab integration", () => {
 
       expect(await screen.findByText("Request USD Coin")).toBeVisible();
       expect(screen.getByTestId("pay-card-request-receive")).toBeVisible();
-      expect(screen.getByTestId("pay-card-request-receive-card")).toBeVisible();
+      expect(screen.getByTestId("pay-card-request-receive-summary")).toBeVisible();
       expect(screen.getByText("Share")).toBeVisible();
     });
 

--- a/features/flow/pay-card-request/src/components/RequestReceive/RequestReceiveSummary.native.tsx
+++ b/features/flow/pay-card-request/src/components/RequestReceive/RequestReceiveSummary.native.tsx
@@ -43,7 +43,7 @@ export function RequestReceiveSummary({
         padding: "s24",
         width: "full",
       }}
-      testID="pay-card-request-receive-card"
+      testID="pay-card-request-receive-summary"
     >
       <Box lx={{ alignItems: "center", gap: "s8" }}>
         <Text typography="heading3SemiBold" lx={{ color: "base", textAlign: "center" }}>

--- a/features/flow/pay-card-request/src/components/RequestReceive/RequestReceiveSummary.web.tsx
+++ b/features/flow/pay-card-request/src/components/RequestReceive/RequestReceiveSummary.web.tsx
@@ -28,7 +28,7 @@ export function RequestReceiveSummary({
   return (
     <div
       className="flex flex-col items-center gap-32 bg-surface p-24 rounded-2xl"
-      data-testid="pay-card-request-receive-card"
+      data-testid="pay-card-request-receive-summary"
     >
       <div className="flex flex-col items-center gap-8">
         <span className="heading-3-semi-bold text-base">{title}</span>

--- a/features/flow/pay-card-request/src/components/RequestReceive/__tests__/RequestReceiveView.native.test.tsx
+++ b/features/flow/pay-card-request/src/components/RequestReceive/__tests__/RequestReceiveView.native.test.tsx
@@ -20,7 +20,7 @@ describe("RequestReceiveView (Native)", () => {
 
     expect(screen.getByTestId("pay-card-request-receive")).toBeVisible();
     expect(screen.getByTestId("pay-card-request-receive-close")).toBeVisible();
-    expect(screen.getByTestId("pay-card-request-receive-card")).toBeVisible();
+    expect(screen.getByTestId("pay-card-request-receive-summary")).toBeVisible();
     expect(screen.getByText(REQUEST_RECEIVE_LABELS.title)).toBeVisible();
     expect(screen.getByTestId("pay-card-request-receive-qr-code")).toBeVisible();
     expect(screen.getByTestId("pay-card-request-receive-address")).toBeVisible();


### PR DESCRIPTION
### 📝 Description

The save helpers and the summary test id in the Pay request-receive flow carried a redundant `Card` / `-card` suffix, even though everything in `@features/flow-pay-card-request` is already about the card request.

This PR drops that suffix in the receive package and in both apps:

| Before | After |
|---|---|
| `saveRequestReceiveCard()` / `saveRequestReceiveCard.ts` | `saveRequestReceive()` / `saveRequestReceive.ts` |
| `useSaveRequestReceiveCard()` / `useSaveRequestReceiveCard.ts` | `useSaveRequestReceive()` / `useSaveRequestReceive.ts` |
| `CARD_SELECTOR` / `CARD_HTML` | `SUMMARY_SELECTOR` / `SUMMARY_HTML` |
| test id `pay-card-request-receive-card` | test id `pay-card-request-receive-summary` |

The summary test id became `-summary` rather than the bare `pay-card-request-receive`, because that id is already taken by the root container of the request-receive view on both platforms. Reusing it would put the same id on two nested nodes, breaking `getByTestId` and making the desktop `document.querySelector` capture the whole dialog instead of the card.

No behaviour change: the desktop PNG capture still targets the same node, and the mobile and web views render the same markup.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36586](https://ledgerhq.atlassian.net/browse/LIVE-36586)

[LIVE-36586]: https://ledgerhq.atlassian.net/browse/LIVE-36586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ