### PR TITLE
fix(qr-code): render styled native QR code (LIVE-35867)

### DIFF
--- a/.changeset/rounded-qr-renderer.md
+++ b/.changeset/rounded-qr-renderer.md
@@ -1,0 +1,7 @@
+---
+"@shared/ui-qr-code": minor
+"@features/flow-contacts": minor
+---
+
+Fix the native address QR code format and present the Contacts QR code in its dedicated dark,
+framed layout.

--- a/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/ContactAddressDetailQrCode.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/ContactAddressDetailQrCode.native.tsx
@@ -1,8 +1,11 @@
 import React from "react";
 import CryptoIcon from "@ledgerhq/crypto-icons/native";
+import { Box, useTheme } from "@ledgerhq/lumen-ui-rnative";
+import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
 import { QrCode } from "@shared/ui-qr-code";
 import type { ContactAddressIconProps } from "../../model/resolveContactAddressIcon";
 
+const QR_CODE_SIZE = 200;
 const QR_ICON_SIZE = 48;
 
 type ContactAddressDetailQrCodeProps = Readonly<{
@@ -14,19 +17,38 @@ export function ContactAddressDetailQrCode({
   address,
   iconProps,
 }: ContactAddressDetailQrCodeProps): React.JSX.Element {
+  const { theme } = useTheme();
+  const styles = useStyleSheet(
+    t => ({
+      qrContainer: {
+        alignItems: "center",
+        justifyContent: "center",
+        padding: t.spacings.s24,
+        borderRadius: t.sizes.s36,
+        backgroundColor: t.colors.bg.base,
+        boxShadow: t.shadows.lg,
+      },
+    }),
+    [],
+  );
+
   return (
-    <QrCode
-      value={address}
-      testID="contacts-address-detail-qr-code"
-      centerContent={
-        <CryptoIcon
-          ledgerId={iconProps.ledgerId}
-          ticker={iconProps.ticker}
-          network={iconProps.network}
-          size={QR_ICON_SIZE}
-          shape="circle"
-        />
-      }
-    />
+    <Box testID="contacts-address-detail-qr-code" style={styles.qrContainer}>
+      <QrCode
+        value={address}
+        size={QR_CODE_SIZE}
+        foregroundColor={theme.colors.bg.interactive}
+        centerContent={
+          <CryptoIcon
+            ledgerId={iconProps.ledgerId}
+            ticker={iconProps.ticker}
+            network={iconProps.network}
+            badgePosition="bottom-end"
+            size={QR_ICON_SIZE}
+            shape="circle"
+          />
+        }
+      />
+    </Box>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17129,9 +17129,6 @@ importers:
       react-native:
         specifier: 'catalog:'
         version: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4)
-      react-native-qrcode-svg:
-        specifier: 6.1.1
-        version: 6.1.1(react-native-svg@15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       react-native-svg:
         specifier: 'catalog:'
         version: 15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
@@ -70279,14 +70276,6 @@ snapshots:
       react: 19.1.4
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
       react-native-svg: 15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-
-  react-native-qrcode-svg@6.1.1(react-native-svg@15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4):
-    dependencies:
-      prop-types: 15.8.1
-      qrcode: 1.5.4
-      react: 19.1.4
-      react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4)
-      react-native-svg: 15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
 
   react-native-randombytes@3.6.1:
     dependencies:

--- a/shared/ui-qr-code/README.md
+++ b/shared/ui-qr-code/README.md
@@ -11,19 +11,20 @@ scanning — same approach as Receive.
 
 ## Exports
 
-| Export | Description |
-| --- | --- |
-| `QrCode` | Styled QR card with an optional center overlay |
-| `QrCodeProps` | Component props |
+| Export        | Description                                      |
+| ------------- | ------------------------------------------------ |
+| `QrCode`      | Styled QR matrix with an optional center overlay |
+| `QrCodeProps` | Component props                                  |
 
 The public API is identical on web and native, so consumers never branch on platform. Only the
 renderer differs:
 
 - **web** — [`qrcode`](https://www.npmjs.com/package/qrcode) drawn on a `<canvas>`
-- **native** — [`react-native-qrcode-svg`](https://www.npmjs.com/package/react-native-qrcode-svg)
+- **native** — a `qrcode` matrix drawn with `react-native-svg`, matching the Web rounded-dot format
 
 `centerContent` is a free slot: pass any node (a `CryptoIcon`, a logo, an `<img>`, …). The package
-only provides the QR matrix and the white circular host in the center.
+only provides the QR matrix and a clear center area for the optional overlay; each consumer owns
+its surrounding card and layout.
 
 ## Usage
 
@@ -37,5 +38,5 @@ import CryptoIcon from "@ledgerhq/crypto-icons/native";
   centerContent={
     <CryptoIcon ledgerId="bitcoin" ticker="BTC" size={48} shape="circle" />
   }
-/>
+/>;
 ```

--- a/shared/ui-qr-code/package.json
+++ b/shared/ui-qr-code/package.json
@@ -2,7 +2,7 @@
   "name": "@shared/ui-qr-code",
   "version": "0.2.0",
   "private": true,
-  "description": "Shared address QR code UI for web (Pay, \u2026) and mobile (Contacts, Pay To, \u2026)",
+  "description": "Shared address QR code UI for web (Pay, …) and mobile (Contacts, Pay To, …)",
   "main": "src/index.ts",
   "react-native": "src/index.native.ts",
   "types": "src/index.ts",
@@ -28,7 +28,7 @@
     "react": ">=19.0.0",
     "react-native": ">=0.70.0",
     "@ledgerhq/lumen-ui-rnative": "catalog:",
-    "react-native-qrcode-svg": ">=6.0.0"
+    "react-native-svg": ">=13.0.0"
   },
   "peerDependenciesMeta": {
     "react-native": {
@@ -37,7 +37,7 @@
     "@ledgerhq/lumen-ui-rnative": {
       "optional": true
     },
-    "react-native-qrcode-svg": {
+    "react-native-svg": {
       "optional": true
     }
   },
@@ -59,7 +59,6 @@
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-native": "catalog:",
-    "react-native-qrcode-svg": "6.1.1",
     "react-native-svg": "catalog:",
     "react-test-renderer": "catalog:",
     "typescript": "catalog:",

--- a/shared/ui-qr-code/src/QrCode.native.test.tsx
+++ b/shared/ui-qr-code/src/QrCode.native.test.tsx
@@ -1,28 +1,67 @@
 import React from "react";
 import { render } from "@testing-library/react-native";
 import { Text } from "react-native";
+import qrcode from "qrcode";
 import { QrCode } from "./QrCode.native";
 
-jest.mock("react-native-qrcode-svg", () => {
-  const React = require("react");
-  const { Text: RNText } = require("react-native");
+jest.mock("qrcode", () => ({
+  __esModule: true,
+  default: { create: jest.fn() },
+}));
 
-  return function MockQRCode({ value }: { value: string }) {
-    return React.createElement(RNText, { testID: "mock-qr-code-value" }, value);
+jest.mock("react-native-svg", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+
+  function createMockSvgElement(testID: string) {
+    return function MockSvgElement({ children, ...props }: { children?: React.ReactNode }) {
+      return React.createElement(View, { ...props, testID }, children);
+    };
+  }
+
+  return {
+    __esModule: true,
+    default: createMockSvgElement("styled-qr-code"),
+    Circle: createMockSvgElement("styled-qr-code-dot"),
+    Rect: createMockSvgElement("styled-qr-code-finder"),
   };
 });
 
 describe("QrCode", () => {
-  it("should render the encoded address value", () => {
+  const mockCreate = qrcode.create as jest.Mock;
+
+  beforeEach(() => {
+    mockCreate.mockReset();
+    mockCreate.mockReturnValue({
+      modules: { size: 21, data: new Uint8Array(21 * 21).fill(1) },
+    });
+  });
+
+  it("should render a rounded QR code with high error correction", () => {
     const { getByTestId } = render(<QrCode value="0xabc123" testID="address-qr-code" />);
 
     expect(getByTestId("address-qr-code")).toBeTruthy();
-    expect(getByTestId("mock-qr-code-value")).toHaveTextContent("0xabc123");
+    expect(getByTestId("styled-qr-code")).toHaveProp("width", 200);
+    expect(mockCreate).toHaveBeenCalledWith("0xabc123", {
+      errorCorrectionLevel: "H",
+    });
   });
 
-  it("should render optional center content", () => {
-    const { getByText } = render(<QrCode value="0xabc123" centerContent={<Text>icon</Text>} />);
+  it("should render optional center content over a clear QR area", () => {
+    const { getByText, queryAllByTestId } = render(
+      <QrCode value="0xabc123" centerContent={<Text>icon</Text>} />,
+    );
 
     expect(getByText("icon")).toBeTruthy();
+    expect(queryAllByTestId("styled-qr-code-dot")).toHaveLength(245);
+    expect(queryAllByTestId("styled-qr-code-finder")).toHaveLength(6);
   });
+
+  it("should use the supplied foreground color", () => {
+    const { getAllByTestId } = render(<QrCode value="0xabc123" foregroundColor="#000000" />);
+
+    expect(getAllByTestId("styled-qr-code-dot")[0]).toHaveProp("fill", "#000000");
+    expect(getAllByTestId("styled-qr-code-finder")[0]).toHaveProp("stroke", "#000000");
+  });
+
 });

--- a/shared/ui-qr-code/src/QrCode.native.tsx
+++ b/shared/ui-qr-code/src/QrCode.native.tsx
@@ -1,59 +1,82 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
-import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
-import QRCode from "react-native-qrcode-svg";
+import Svg, { Circle, Rect } from "react-native-svg";
+import { createStyledQrCode, FINDER_MODULES } from "./styledQrCode";
 import type { QrCodeProps } from "./types";
 
 const DEFAULT_QR_CODE_SIZE = 200;
-const DEFAULT_CENTER_WRAPPER_SIZE = 56;
+const FOREGROUND_COLOR = "#FFFFFF";
 
 export function QrCode({
   value,
   size = DEFAULT_QR_CODE_SIZE,
+  foregroundColor = FOREGROUND_COLOR,
   centerContent,
   testID,
 }: QrCodeProps): React.JSX.Element {
-  const styles = useStyleSheet(
-    t => ({
-      qrContainer: {
-        alignItems: "center",
-        justifyContent: "center",
-        padding: t.spacings.s24,
-        borderRadius: t.sizes.s36,
-        backgroundColor: t.colors.bg.canvasOverlaySubtle,
-        borderWidth: t.borderWidth.s1,
-        borderColor: t.colors.border.base,
-      },
-      qrSurface: {
-        alignItems: "center",
-        justifyContent: "center",
-        padding: t.spacings.s16,
-        borderRadius: t.sizes.s24,
-        backgroundColor: "#FFFFFF",
-      },
-      centerWrapper: {
-        alignItems: "center",
-        justifyContent: "center",
-        width: DEFAULT_CENTER_WRAPPER_SIZE,
-        height: DEFAULT_CENTER_WRAPPER_SIZE,
-        borderRadius: DEFAULT_CENTER_WRAPPER_SIZE / 2,
-        backgroundColor: "#FFFFFF",
-      },
-    }),
-    [],
+  const hasCenterContent = centerContent !== undefined;
+  const styledQrCode = useMemo(
+    () => createStyledQrCode(value, size, hasCenterContent),
+    [value, size, hasCenterContent],
   );
 
   return (
-    <Box testID={testID} style={styles.qrContainer}>
-      <Box style={styles.qrSurface}>
-        <Box lx={{ position: "relative", alignItems: "center", justifyContent: "center" }}>
-          <QRCode size={size} value={value} ecl="H" />
-          {centerContent !== undefined ? (
-            <Box lx={{ position: "absolute" }} style={styles.centerWrapper}>
-              {centerContent}
-            </Box>
-          ) : null}
-        </Box>
+    <Box
+      testID={testID}
+      lx={{
+        position: "relative",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <Box
+        lx={{
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <Svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+          {styledQrCode.dots.map(({ cx, cy, radius }, index) => (
+            <Circle key={index} cx={cx} cy={cy} r={radius} fill={foregroundColor} />
+          ))}
+          {styledQrCode.finders.map(({ x, y, moduleSize }) => {
+            const outer = FINDER_MODULES * moduleSize;
+
+            return (
+              <React.Fragment key={`${x}-${y}`}>
+                <Rect
+                  x={x + moduleSize / 2}
+                  y={y + moduleSize / 2}
+                  width={outer - moduleSize}
+                  height={outer - moduleSize}
+                  rx={moduleSize * 2}
+                  fill="none"
+                  stroke={foregroundColor}
+                  strokeWidth={moduleSize}
+                />
+                <Rect
+                  x={x + moduleSize * 2}
+                  y={y + moduleSize * 2}
+                  width={moduleSize * 3}
+                  height={moduleSize * 3}
+                  rx={moduleSize}
+                  fill={foregroundColor}
+                />
+              </React.Fragment>
+            );
+          })}
+        </Svg>
+        {hasCenterContent ? (
+          <Box
+            lx={{
+              position: "absolute",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            {centerContent}
+          </Box>
+        ) : null}
       </Box>
     </Box>
   );

--- a/shared/ui-qr-code/src/QrCode.web.test.tsx
+++ b/shared/ui-qr-code/src/QrCode.web.test.tsx
@@ -1,30 +1,12 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import qrcode from "qrcode";
 import { QrCode } from "./QrCode.web";
 
-jest.mock("qrcode", () => ({
-  __esModule: true,
-  default: { create: jest.fn() },
-}));
-
-const mockCreate = qrcode.create as jest.Mock;
-
 describe("QrCode (web)", () => {
-  beforeEach(() => {
-    mockCreate.mockReset();
-    // A minimal QR matrix; canvas drawing is skipped under jsdom (no 2d context).
-    mockCreate.mockReturnValue({ modules: { size: 21, data: new Uint8Array(21 * 21) } });
-  });
-
-  it("should render the container and build the QR matrix from the value", () => {
+  it("should render the container", () => {
     render(<QrCode value="0xabc123" testID="address-qr-code" />);
 
     expect(screen.getByTestId("address-qr-code")).toBeInTheDocument();
-    expect(mockCreate).toHaveBeenCalledWith(
-      "0xabc123",
-      expect.objectContaining({ errorCorrectionLevel: "H" }),
-    );
   });
 
   it("should render optional center content", () => {

--- a/shared/ui-qr-code/src/QrCode.web.tsx
+++ b/shared/ui-qr-code/src/QrCode.web.tsx
@@ -7,6 +7,7 @@ const DEFAULT_QR_CODE_SIZE = 200;
 export function QrCode({
   value,
   size = DEFAULT_QR_CODE_SIZE,
+  foregroundColor,
   centerContent,
   testID,
 }: QrCodeProps): React.JSX.Element {
@@ -16,8 +17,8 @@ export function QrCode({
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
-    drawStyledQrCode(canvas, value, size, hasCenterContent);
-  }, [value, size, hasCenterContent]);
+    drawStyledQrCode(canvas, value, size, hasCenterContent, foregroundColor);
+  }, [value, size, hasCenterContent, foregroundColor]);
 
   return (
     <div data-testid={testID} className="relative flex items-center justify-center">

--- a/shared/ui-qr-code/src/qrCanvas.web.test.ts
+++ b/shared/ui-qr-code/src/qrCanvas.web.test.ts
@@ -62,6 +62,15 @@ describe("drawStyledQrCode", () => {
     expect(ctx.arc).toHaveBeenCalled();
   });
 
+  it("uses the supplied foreground color for dots and finder patterns", () => {
+    const { canvas, ctx } = createFakeCanvas();
+
+    drawStyledQrCode(canvas, "0xabc123", QR_SIZE, false, "#000000");
+
+    expect(ctx.fillStyle).toBe("#000000");
+    expect(ctx.strokeStyle).toBe("#000000");
+  });
+
   it("clears a centered, odd-sided square of modules only when there is center content", () => {
     const withoutCenter = createFakeCanvas();
     drawStyledQrCode(withoutCenter.canvas, "0xabc123", QR_SIZE, false);

--- a/shared/ui-qr-code/src/qrCanvas.web.ts
+++ b/shared/ui-qr-code/src/qrCanvas.web.ts
@@ -1,10 +1,5 @@
-import qrcode from "qrcode";
+import { createStyledQrCode, FINDER_MODULES } from "./styledQrCode";
 
-const DOT_RADIUS_RATIO = 0.42;
-const FINDER_MODULES = 7;
-// Wide enough to keep a visible margin between the overlay and the closest dots for every QR version.
-const CLEAR_ZONE_RATIO = 0.32;
-const PADDING_RATIO = 0.06;
 const FOREGROUND_COLOR = "#FFFFFF";
 
 function traceRoundedRect(
@@ -30,9 +25,10 @@ function drawFinderPattern(
   x: number,
   y: number,
   moduleSize: number,
+  foregroundColor: string,
 ): void {
-  ctx.fillStyle = FOREGROUND_COLOR;
-  ctx.strokeStyle = FOREGROUND_COLOR;
+  ctx.fillStyle = foregroundColor;
+  ctx.strokeStyle = foregroundColor;
 
   const outer = FINDER_MODULES * moduleSize;
   // Outer ring: a 1-module-thick rounded square stroke around the 7x7 finder.
@@ -58,29 +54,13 @@ function drawFinderPattern(
   ctx.fill();
 }
 
-// Module counts are always odd, so the cleared square needs an odd side too: with an even side it
-// would sit half a module off-center while the overlay is centered on the canvas.
-function getClearCount(count: number): number {
-  const raw = Math.round(count * CLEAR_ZONE_RATIO);
-  return raw % 2 === count % 2 ? raw : raw + 1;
-}
-
-function isInFinderPattern(row: number, col: number, count: number): boolean {
-  const top = row < FINDER_MODULES;
-  const bottom = row >= count - FINDER_MODULES;
-  const left = col < FINDER_MODULES;
-  const right = col >= count - FINDER_MODULES;
-  return (top && left) || (top && right) || (bottom && left);
-}
-
 export function drawStyledQrCode(
   canvas: HTMLCanvasElement,
   value: string,
   size: number,
   hasCenterContent: boolean,
+  foregroundColor = FOREGROUND_COLOR,
 ): void {
-  const { modules } = qrcode.create(value, { errorCorrectionLevel: "H" });
-
   let ctx: CanvasRenderingContext2D | null = null;
   try {
     ctx = canvas.getContext("2d");
@@ -89,8 +69,6 @@ export function drawStyledQrCode(
   }
   if (!ctx) return;
 
-  const count = modules.size;
-  const { data } = modules;
   const dpr = window.devicePixelRatio || 1;
 
   canvas.width = size * dpr;
@@ -101,38 +79,16 @@ export function drawStyledQrCode(
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
   ctx.clearRect(0, 0, size, size);
 
-  const padding = size * PADDING_RATIO;
-  const moduleSize = (size - padding * 2) / count;
-  const dotRadius = moduleSize * DOT_RADIUS_RATIO;
+  const styledQrCode = createStyledQrCode(value, size, hasCenterContent);
 
-  // Central square kept clear so the overlay sits on a clean background.
-  const clearCount = hasCenterContent ? getClearCount(count) : 0;
-  const clearStart = (count - clearCount) / 2;
-  const clearEnd = clearStart + clearCount;
-
-  ctx.fillStyle = FOREGROUND_COLOR;
-  for (let row = 0; row < count; row++) {
-    for (let col = 0; col < count; col++) {
-      if (isInFinderPattern(row, col, count)) continue;
-      if (
-        clearCount > 0 &&
-        row >= clearStart &&
-        row < clearEnd &&
-        col >= clearStart &&
-        col < clearEnd
-      ) {
-        continue;
-      }
-      if (!data[row * count + col]) continue;
-      const cx = padding + col * moduleSize + moduleSize / 2;
-      const cy = padding + row * moduleSize + moduleSize / 2;
-      ctx.beginPath();
-      ctx.arc(cx, cy, dotRadius, 0, Math.PI * 2);
-      ctx.fill();
-    }
+  ctx.fillStyle = foregroundColor;
+  for (const { cx, cy, radius } of styledQrCode.dots) {
+    ctx.beginPath();
+    ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+    ctx.fill();
   }
 
-  drawFinderPattern(ctx, padding, padding, moduleSize);
-  drawFinderPattern(ctx, padding + (count - FINDER_MODULES) * moduleSize, padding, moduleSize);
-  drawFinderPattern(ctx, padding, padding + (count - FINDER_MODULES) * moduleSize, moduleSize);
+  for (const { x, y, moduleSize } of styledQrCode.finders) {
+    drawFinderPattern(ctx, x, y, moduleSize, foregroundColor);
+  }
 }

--- a/shared/ui-qr-code/src/styledQrCode.ts
+++ b/shared/ui-qr-code/src/styledQrCode.ts
@@ -1,0 +1,88 @@
+import qrcode from "qrcode";
+
+const DOT_RADIUS_RATIO = 0.42;
+export const FINDER_MODULES = 7;
+const CLEAR_ZONE_RATIO = 0.32;
+
+type StyledQrCodeDot = Readonly<{
+  cx: number;
+  cy: number;
+  radius: number;
+}>;
+
+type StyledQrCodeFinder = Readonly<{
+  x: number;
+  y: number;
+  moduleSize: number;
+}>;
+
+export type StyledQrCode = Readonly<{
+  dots: readonly StyledQrCodeDot[];
+  finders: readonly StyledQrCodeFinder[];
+}>;
+
+function getClearCount(count: number): number {
+  const raw = Math.round(count * CLEAR_ZONE_RATIO);
+  return raw % 2 === count % 2 ? raw : raw + 1;
+}
+
+function isInFinderPattern(row: number, col: number, count: number): boolean {
+  const top = row < FINDER_MODULES;
+  const bottom = row >= count - FINDER_MODULES;
+  const left = col < FINDER_MODULES;
+  const right = col >= count - FINDER_MODULES;
+  return (top && left) || (top && right) || (bottom && left);
+}
+
+export function createStyledQrCode(
+  value: string,
+  size: number,
+  hasCenterContent: boolean,
+): StyledQrCode {
+  const { modules } = qrcode.create(value, { errorCorrectionLevel: "H" });
+  const { data, size: count } = modules;
+  const moduleSize = size / count;
+  const clearCount = hasCenterContent ? getClearCount(count) : 0;
+  const clearStart = (count - clearCount) / 2;
+  const clearEnd = clearStart + clearCount;
+  const dots: StyledQrCodeDot[] = [];
+
+  for (let row = 0; row < count; row++) {
+    for (let col = 0; col < count; col++) {
+      if (isInFinderPattern(row, col, count)) continue;
+      if (
+        clearCount > 0 &&
+        row >= clearStart &&
+        row < clearEnd &&
+        col >= clearStart &&
+        col < clearEnd
+      ) {
+        continue;
+      }
+      if (!data[row * count + col]) continue;
+
+      dots.push({
+        cx: col * moduleSize + moduleSize / 2,
+        cy: row * moduleSize + moduleSize / 2,
+        radius: moduleSize * DOT_RADIUS_RATIO,
+      });
+    }
+  }
+
+  return {
+    dots,
+    finders: [
+      { x: 0, y: 0, moduleSize },
+      {
+        x: (count - FINDER_MODULES) * moduleSize,
+        y: 0,
+        moduleSize,
+      },
+      {
+        x: 0,
+        y: (count - FINDER_MODULES) * moduleSize,
+        moduleSize,
+      },
+    ],
+  };
+}

--- a/shared/ui-qr-code/src/styledQrCode.web.test.ts
+++ b/shared/ui-qr-code/src/styledQrCode.web.test.ts
@@ -1,0 +1,31 @@
+import qrcode from "qrcode";
+import { createStyledQrCode } from "./styledQrCode";
+
+jest.mock("qrcode", () => ({
+  __esModule: true,
+  default: { create: jest.fn() },
+}));
+
+describe("createStyledQrCode", () => {
+  const mockCreate = qrcode.create as jest.Mock;
+
+  beforeEach(() => {
+    mockCreate.mockReset();
+    mockCreate.mockReturnValue({
+      modules: { size: 21, data: new Uint8Array(21 * 21).fill(1) },
+    });
+  });
+
+  it("should use the complete QR surface for finder patterns", () => {
+    const size = 200;
+    const moduleSize = size / 21;
+
+    const { finders } = createStyledQrCode("0xabc123", size, true);
+
+    expect(finders).toEqual([
+      { x: 0, y: 0, moduleSize },
+      { x: 14 * moduleSize, y: 0, moduleSize },
+      { x: 0, y: 14 * moduleSize, moduleSize },
+    ]);
+  });
+});

--- a/shared/ui-qr-code/src/types.ts
+++ b/shared/ui-qr-code/src/types.ts
@@ -3,6 +3,7 @@ import type React from "react";
 export type QrCodeProps = Readonly<{
   value: string;
   size?: number;
+  foregroundColor?: string;
   centerContent?: React.ReactNode;
   testID?: string;
 }>;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** The shared QR-code package passes its native and Web regression suites.
- [x] **Impact of the changes:**
      Validate the Contacts address QR on iOS and Android: rounded white modules, rounded finder patterns, a clear central area for the asset icon, and successful scanning. Also smoke-test the native Pay-card QR consumer.

### 📝 Description

Contacts Mobile currently renders its address QR with square black modules on a white surface, unlike the expected stylized format.

The shared native QR renderer now draws the same matrix and geometry as Web: white rounded dots, rounded finder patterns, high error correction, and a central clear zone for the supplied asset icon. It uses the existing `react-native-svg` dependency and removes the unused direct `react-native-qrcode-svg` dependency.

<img width="350" height="750" alt="Simulator Screenshot - build2 - 2026-08-28 at 14 26 22" src="https://github.com/user-attachments/assets/81c6ae76-bd81-4f7a-891e-88bdd188acd6" />
<img width="350" height="750" alt="Simulator Screenshot - build2 - 2026-08-28 at 15 36 10" src="https://github.com/user-attachments/assets/80433cc8-1655-488d-869d-9ba83f8e74e1" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-35867](https://ledgerhq.atlassian.net/browse/LIVE-35867)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-35867]: https://ledgerhq.atlassian.net/browse/LIVE-35867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ