### PR TITLE
fix(pay): tighten spacing between contact tiles (LIVE-36590)

### DIFF
--- a/.changeset/olive-pandas-shave.md
+++ b/.changeset/olive-pandas-shave.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-pay-contact": patch
+---
+
+Tighten the spacing between the Pay tab contact tiles and align their avatar and label with the design

--- a/features/flow/pay-contact/src/components/ContactTile/ContactTile.native.tsx
+++ b/features/flow/pay-contact/src/components/ContactTile/ContactTile.native.tsx
@@ -14,16 +14,15 @@ export function ContactTile({ contact, index, onPress }: ContactTileProps): Reac
 
   return (
     <Tile
-      appearance="card"
       onPress={onPress ? handlePress : undefined}
-      lx={{ width: "s96", flexGrow: 1, marginLeft: "s8" }}
+      lx={{ width: "s96", flexGrow: 1, marginLeft: "-s8" }}
       testID={`pay-contacts-tile-${index}`}
       accessibilityRole={onPress ? "button" : undefined}
       accessibilityLabel={contact.name}
     >
-      <ContactAvatar contactId={contact.id} name={contact.name} size="md" />
+      <ContactAvatar contactId={contact.id} name={contact.name} size="lg" />
       <TileContent>
-        <TileTitle>{contact.name}</TileTitle>
+        <TileTitle lx={{ color: "muted" }}>{contact.name}</TileTitle>
       </TileContent>
     </Tile>
   );

--- a/features/flow/pay-contact/src/components/PayTile/PayTile.native.tsx
+++ b/features/flow/pay-contact/src/components/PayTile/PayTile.native.tsx
@@ -11,7 +11,7 @@ export function PayTile({ label, onPress }: PayTileProps): React.JSX.Element {
   return (
     <Tile
       onPress={onPress}
-      lx={{ width: "s96", flexGrow: 1 }}
+      lx={{ width: "s96", flexGrow: 1, marginLeft: "-s8" }}
       testID="pay-contacts-pay-tile"
       accessibilityRole="button"
       accessibilityLabel={label}


### PR DESCRIPTION
### 📝 Description

The contact tiles in the Pay tab were spaced too far apart, and the tile visuals had drifted from the design.

Each `ContactTile` carried a `marginLeft: "s8"`, so tiles sat 8px apart. Both `PayTile` and `ContactTile` now use `marginLeft: "-s8"`, which tightens the horizontal strip. A negative margin is used rather than a smaller `gap`, since `gap` cannot go below 0 in React Native.

Alongside the spacing, the tiles were aligned with the design: the contact avatar goes from `md` to `lg`, the tile label uses the `muted` colour, and the `card` appearance is dropped so the tiles sit flat on the Pay background.

No API change: `ContactTile` and `PayTile` keep the same props, and the horizontal `ScrollView` still bleeds edge to edge through its negative horizontal margin.

### 📸 Screenshots

<img width="506" height="964" alt="Screenshot 2026-08-28 at 12 20 59" src="https://github.com/user-attachments/assets/c4faab81-df11-444a-946a-908d794993be" />

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36590](https://ledgerhq.atlassian.net/browse/LIVE-36590)


[LIVE-36590]: https://ledgerhq.atlassian.net/browse/LIVE-36590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ