### PR TITLE
fix(die): add invalid provider blocking state (LIVE-36315)

### DIFF
--- a/.changeset/tame-lions-relax.md
+++ b/.changeset/tame-lions-relax.md
@@ -1,5 +1,7 @@
 ---
+"@ledgerhq/live-dmk-shared": minor
 "ledger-live-desktop": minor
+"live-mobile": minor
 ---
 
-Show a clear "Invalid Provider" error with a "Go to settings" action in the Device Intent Executor when the configured My Ledger provider is incorrect, instead of a raw, unclear error
+Map the DMK invalid firmware metadata error to a dedicated InvalidProvider blocking state, so the Device Intent Executor shows a clear "Invalid Provider" screen with a "Go to settings" action instead of a raw error

--- a/.changeset/tame-lions-relax.md
+++ b/.changeset/tame-lions-relax.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Show a clear "Invalid Provider" error with a "Go to settings" action in the Device Intent Executor when the configured My Ledger provider is incorrect, instead of a raw, unclear error

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/DeviceContextInitializerComponentLWDView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/DeviceContextInitializerComponentLWDView.tsx
@@ -25,6 +25,7 @@ import { DeviceDeprecatedBlockingState } from "./components/DeviceDeprecatedBloc
 import { WrongDeviceForAccount } from "./components/WrongDeviceForAccount";
 import { DeviceOutOfStorageSpace } from "./components/DeviceOutOfStorageSpace";
 import { DeviceNotOnboarded } from "./components/DeviceNotOnboarded";
+import { InvalidProvider } from "./components/InvalidProvider";
 import { FinalError } from "./components/FinalError";
 
 function assertNever(value: never): never {
@@ -73,6 +74,8 @@ export function DeviceContextInitializerComponentLWDView({
       return <DeviceOutOfStorageSpace state={state} {...commonProps} />;
     case BlockingStateType.DeviceNotOnboarded:
       return <DeviceNotOnboarded state={state} {...commonProps} />;
+    case BlockingStateType.InvalidProvider:
+      return <InvalidProvider state={state} {...commonProps} />;
     case FinalStateType.Error:
       return <FinalError state={state} {...commonProps} />;
     case FinalStateType.Success:

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/__tests__/DeviceContextInitializerComponentLWDView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/__tests__/DeviceContextInitializerComponentLWDView.test.tsx
@@ -68,6 +68,7 @@ const pageByStateType: Record<EnsureAppReadyState["type"], string | undefined> =
   [BlockingStateType.WrongDeviceForAccount]: PAGE_CONNECT_APP.WrongDeviceForAccount,
   [BlockingStateType.DeviceOutOfStorageSpace]: PAGE_CONNECT_APP.OutOfStorage,
   [BlockingStateType.DeviceNotOnboarded]: PAGE_CONNECT_APP.DeviceNotOnboarded,
+  [BlockingStateType.InvalidProvider]: PAGE_CONNECT_APP.InvalidProvider,
   [FinalStateType.Error]: PAGE_CONNECT_APP.Error,
   [FinalStateType.Success]: undefined,
 };
@@ -212,6 +213,11 @@ describe("DeviceContextInitializerComponentLWDView", () => {
       label: "device not onboarded",
       state: { type: BlockingStateType.DeviceNotOnboarded },
       getElement: () => screen.getByText("Your Ledger device needs to be set up"),
+    },
+    {
+      label: "invalid provider",
+      state: { type: BlockingStateType.InvalidProvider },
+      getElement: () => screen.getByText("Invalid Provider"),
     },
     {
       label: "final error",

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceNotOnboarded/useDeviceNotOnboardedViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceNotOnboarded/useDeviceNotOnboardedViewModel.test.tsx
@@ -31,6 +31,7 @@ describe("useDeviceNotOnboardedViewModel", () => {
       openMyLedgerFirmwareUpdate: jest.fn(),
       openOnboarding,
       openSupport: jest.fn(),
+      openExperimentalSettings: jest.fn(),
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceOutOfStorageSpace/useDeviceOutOfStorageSpaceViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/DeviceOutOfStorageSpace/useDeviceOutOfStorageSpaceViewModel.test.tsx
@@ -31,6 +31,7 @@ describe("useDeviceOutOfStorageSpaceViewModel", () => {
       openMyLedgerFirmwareUpdate: jest.fn(),
       openOnboarding: jest.fn(),
       openSupport: jest.fn(),
+      openExperimentalSettings: jest.fn(),
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/FinalError/FinalErrorView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/FinalError/FinalErrorView.test.tsx
@@ -9,17 +9,20 @@ jest.mock("~/renderer/components/TranslatedError", () => ({
 }));
 
 describe("FinalErrorView", () => {
-  const renderView = () => {
+  const renderView = (isInvalidProvider = false) => {
     const onContactSupport = jest.fn();
     const onCancel = jest.fn();
+    const onGoToSettings = jest.fn();
     const { user } = render(
       <FinalErrorView
         error={new Error("unexpected")}
+        isInvalidProvider={isInvalidProvider}
         onContactSupport={onContactSupport}
         onCancel={onCancel}
+        onGoToSettings={onGoToSettings}
       />,
     );
-    return { user, onContactSupport, onCancel };
+    return { user, onContactSupport, onCancel, onGoToSettings };
   };
 
   it("GIVEN the final error view WHEN rendering THEN it shows the translated title and description", () => {
@@ -53,5 +56,27 @@ describe("FinalErrorView", () => {
     // THEN
     expect(onCancel).toHaveBeenCalledTimes(1);
     expect(onContactSupport).not.toHaveBeenCalled();
+  });
+
+  it("GIVEN an invalid provider error WHEN rendering THEN it shows a go to settings CTA instead of contact support", () => {
+    // GIVEN
+    renderView(true);
+
+    // THEN
+    expect(screen.getByRole("button", { name: "Go to settings" })).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: "Contact Ledger support" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("GIVEN an invalid provider error WHEN clicking go to settings THEN it calls onGoToSettings", async () => {
+    // GIVEN
+    const { user, onGoToSettings } = renderView(true);
+
+    // WHEN
+    await user.click(screen.getByRole("button", { name: "Go to settings" }));
+
+    // THEN
+    expect(onGoToSettings).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/FinalError/FinalErrorView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/FinalError/FinalErrorView.test.tsx
@@ -9,20 +9,17 @@ jest.mock("~/renderer/components/TranslatedError", () => ({
 }));
 
 describe("FinalErrorView", () => {
-  const renderView = (isInvalidProvider = false) => {
+  const renderView = () => {
     const onContactSupport = jest.fn();
     const onCancel = jest.fn();
-    const onGoToSettings = jest.fn();
     const { user } = render(
       <FinalErrorView
         error={new Error("unexpected")}
-        isInvalidProvider={isInvalidProvider}
         onContactSupport={onContactSupport}
         onCancel={onCancel}
-        onGoToSettings={onGoToSettings}
       />,
     );
-    return { user, onContactSupport, onCancel, onGoToSettings };
+    return { user, onContactSupport, onCancel };
   };
 
   it("GIVEN the final error view WHEN rendering THEN it shows the translated title and description", () => {
@@ -56,27 +53,5 @@ describe("FinalErrorView", () => {
     // THEN
     expect(onCancel).toHaveBeenCalledTimes(1);
     expect(onContactSupport).not.toHaveBeenCalled();
-  });
-
-  it("GIVEN an invalid provider error WHEN rendering THEN it shows a go to settings CTA instead of contact support", () => {
-    // GIVEN
-    renderView(true);
-
-    // THEN
-    expect(screen.getByRole("button", { name: "Go to settings" })).toBeVisible();
-    expect(
-      screen.queryByRole("button", { name: "Contact Ledger support" }),
-    ).not.toBeInTheDocument();
-  });
-
-  it("GIVEN an invalid provider error WHEN clicking go to settings THEN it calls onGoToSettings", async () => {
-    // GIVEN
-    const { user, onGoToSettings } = renderView(true);
-
-    // WHEN
-    await user.click(screen.getByRole("button", { name: "Go to settings" }));
-
-    // THEN
-    expect(onGoToSettings).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/FinalError/FinalErrorView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/FinalError/FinalErrorView.tsx
@@ -6,19 +6,11 @@ import TranslatedError from "~/renderer/components/TranslatedError";
 
 type FinalErrorViewProps = Readonly<{
   error: Error | DmkError;
-  isInvalidProvider: boolean;
   onCancel: () => void;
   onContactSupport: () => void;
-  onGoToSettings: () => void;
 }>;
 
-export function FinalErrorView({
-  error,
-  isInvalidProvider,
-  onCancel,
-  onContactSupport,
-  onGoToSettings,
-}: FinalErrorViewProps) {
+export function FinalErrorView({ error, onCancel, onContactSupport }: FinalErrorViewProps) {
   const { t } = useTranslation();
 
   return (
@@ -27,17 +19,10 @@ export function FinalErrorView({
       size="hug"
       title={<TranslatedError error={error} field="title" />}
       description={<TranslatedError error={error} field="description" />}
-      primaryCta={
-        isInvalidProvider
-          ? {
-              label: t("errors.InvalidGetFirmwareMetadataResponseError.goToSettingsCTA"),
-              onPress: onGoToSettings,
-            }
-          : {
-              label: t("deviceIntentExecutor.initialization.cta.contactLedgerSupport"),
-              onPress: onContactSupport,
-            }
-      }
+      primaryCta={{
+        label: t("deviceIntentExecutor.initialization.cta.contactLedgerSupport"),
+        onPress: onContactSupport,
+      }}
       secondaryCta={{
         label: t("common.close"),
         onPress: onCancel,

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/FinalError/FinalErrorView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/FinalError/FinalErrorView.tsx
@@ -6,11 +6,19 @@ import TranslatedError from "~/renderer/components/TranslatedError";
 
 type FinalErrorViewProps = Readonly<{
   error: Error | DmkError;
+  isInvalidProvider: boolean;
   onCancel: () => void;
   onContactSupport: () => void;
+  onGoToSettings: () => void;
 }>;
 
-export function FinalErrorView({ error, onCancel, onContactSupport }: FinalErrorViewProps) {
+export function FinalErrorView({
+  error,
+  isInvalidProvider,
+  onCancel,
+  onContactSupport,
+  onGoToSettings,
+}: FinalErrorViewProps) {
   const { t } = useTranslation();
 
   return (
@@ -19,10 +27,17 @@ export function FinalErrorView({ error, onCancel, onContactSupport }: FinalError
       size="hug"
       title={<TranslatedError error={error} field="title" />}
       description={<TranslatedError error={error} field="description" />}
-      primaryCta={{
-        label: t("deviceIntentExecutor.initialization.cta.contactLedgerSupport"),
-        onPress: onContactSupport,
-      }}
+      primaryCta={
+        isInvalidProvider
+          ? {
+              label: t("errors.InvalidGetFirmwareMetadataResponseError.goToSettingsCTA"),
+              onPress: onGoToSettings,
+            }
+          : {
+              label: t("deviceIntentExecutor.initialization.cta.contactLedgerSupport"),
+              onPress: onContactSupport,
+            }
+      }
       secondaryCta={{
         label: t("common.close"),
         onPress: onCancel,

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/FinalError/useFinalErrorViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/FinalError/useFinalErrorViewModel.test.tsx
@@ -4,7 +4,6 @@ import {
   DeviceIntentTrackingProvider,
   FinalStateType,
 } from "@ledgerhq/live-dmk-shared";
-import { InvalidGetFirmwareMetadataResponseError } from "@ledgerhq/device-management-kit";
 import React from "react";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
 import { initializerDevice } from "../../testUtils";
@@ -22,7 +21,6 @@ jest.mock("../../../utils/trackDeviceIntent", () => ({
 const mockedUseInitializerActions = jest.mocked(useInitializerActions);
 const mockedTrackConnectAppButtonClicked = jest.mocked(trackConnectAppButtonClicked);
 const openSupport = jest.fn();
-const openExperimentalSettings = jest.fn();
 const wrapper = ({ children }: React.PropsWithChildren) => (
   <DeviceIntentTrackingProvider value={{ sourceFlow: "my_ledger" }}>
     {children}
@@ -37,7 +35,7 @@ describe("useFinalErrorViewModel", () => {
       openMyLedgerFirmwareUpdate: jest.fn(),
       openOnboarding: jest.fn(),
       openSupport,
-      openExperimentalSettings,
+      openExperimentalSettings: jest.fn(),
     });
   });
 
@@ -105,53 +103,6 @@ describe("useFinalErrorViewModel", () => {
       sourceFlow: "my_ledger",
       modelId: initializerDevice.modelId,
       button: CONNECT_APP_BUTTON.Close,
-      extraProperties: {},
-    });
-  });
-
-  it("GIVEN an invalid provider error WHEN rendering THEN it flags it as an invalid provider error", () => {
-    // GIVEN
-    const { result } = renderHook(
-      () =>
-        useFinalErrorViewModel({
-          state: {
-            type: FinalStateType.Error,
-            error: new InvalidGetFirmwareMetadataResponseError(),
-          },
-          device: initializerDevice,
-          onCancel: jest.fn(),
-        }),
-      { wrapper },
-    );
-
-    // THEN
-    expect(result.current.isInvalidProvider).toBe(true);
-  });
-
-  it("GIVEN an invalid provider error WHEN calling onGoToSettings THEN it opens experimental settings", () => {
-    // GIVEN
-    const { result } = renderHook(
-      () =>
-        useFinalErrorViewModel({
-          state: {
-            type: FinalStateType.Error,
-            error: new InvalidGetFirmwareMetadataResponseError(),
-          },
-          device: initializerDevice,
-          onCancel: jest.fn(),
-        }),
-      { wrapper },
-    );
-
-    // WHEN
-    result.current.onGoToSettings();
-
-    // THEN
-    expect(openExperimentalSettings).toHaveBeenCalledTimes(1);
-    expect(mockedTrackConnectAppButtonClicked).toHaveBeenCalledWith({
-      sourceFlow: "my_ledger",
-      modelId: initializerDevice.modelId,
-      button: CONNECT_APP_BUTTON.GoToSettings,
       extraProperties: {},
     });
   });

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/FinalError/useFinalErrorViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/FinalError/useFinalErrorViewModel.test.tsx
@@ -4,6 +4,7 @@ import {
   DeviceIntentTrackingProvider,
   FinalStateType,
 } from "@ledgerhq/live-dmk-shared";
+import { InvalidGetFirmwareMetadataResponseError } from "@ledgerhq/device-management-kit";
 import React from "react";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
 import { initializerDevice } from "../../testUtils";
@@ -21,6 +22,7 @@ jest.mock("../../../utils/trackDeviceIntent", () => ({
 const mockedUseInitializerActions = jest.mocked(useInitializerActions);
 const mockedTrackConnectAppButtonClicked = jest.mocked(trackConnectAppButtonClicked);
 const openSupport = jest.fn();
+const openExperimentalSettings = jest.fn();
 const wrapper = ({ children }: React.PropsWithChildren) => (
   <DeviceIntentTrackingProvider value={{ sourceFlow: "my_ledger" }}>
     {children}
@@ -35,6 +37,7 @@ describe("useFinalErrorViewModel", () => {
       openMyLedgerFirmwareUpdate: jest.fn(),
       openOnboarding: jest.fn(),
       openSupport,
+      openExperimentalSettings,
     });
   });
 
@@ -102,6 +105,53 @@ describe("useFinalErrorViewModel", () => {
       sourceFlow: "my_ledger",
       modelId: initializerDevice.modelId,
       button: CONNECT_APP_BUTTON.Close,
+      extraProperties: {},
+    });
+  });
+
+  it("GIVEN an invalid provider error WHEN rendering THEN it flags it as an invalid provider error", () => {
+    // GIVEN
+    const { result } = renderHook(
+      () =>
+        useFinalErrorViewModel({
+          state: {
+            type: FinalStateType.Error,
+            error: new InvalidGetFirmwareMetadataResponseError(),
+          },
+          device: initializerDevice,
+          onCancel: jest.fn(),
+        }),
+      { wrapper },
+    );
+
+    // THEN
+    expect(result.current.isInvalidProvider).toBe(true);
+  });
+
+  it("GIVEN an invalid provider error WHEN calling onGoToSettings THEN it opens experimental settings", () => {
+    // GIVEN
+    const { result } = renderHook(
+      () =>
+        useFinalErrorViewModel({
+          state: {
+            type: FinalStateType.Error,
+            error: new InvalidGetFirmwareMetadataResponseError(),
+          },
+          device: initializerDevice,
+          onCancel: jest.fn(),
+        }),
+      { wrapper },
+    );
+
+    // WHEN
+    result.current.onGoToSettings();
+
+    // THEN
+    expect(openExperimentalSettings).toHaveBeenCalledTimes(1);
+    expect(mockedTrackConnectAppButtonClicked).toHaveBeenCalledWith({
+      sourceFlow: "my_ledger",
+      modelId: initializerDevice.modelId,
+      button: CONNECT_APP_BUTTON.GoToSettings,
       extraProperties: {},
     });
   });

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/FinalError/useFinalErrorViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/FinalError/useFinalErrorViewModel.ts
@@ -1,5 +1,9 @@
 import { useCallback } from "react";
-import { isDmkError, type DmkError } from "@ledgerhq/live-dmk-desktop";
+import {
+  isDmkError,
+  isInvalidGetFirmwareMetadataResponseError,
+  type DmkError,
+} from "@ledgerhq/live-dmk-desktop";
 import {
   useDeviceIntentTracking,
   type EnsureAppReadyState,
@@ -19,7 +23,7 @@ type Params = Readonly<{
 
 export function useFinalErrorViewModel({ state, device, onCancel }: Params) {
   const { sourceFlow, analyticsProperties } = useDeviceIntentTracking();
-  const { openSupport } = useInitializerActions();
+  const { openSupport, openExperimentalSettings } = useInitializerActions();
 
   const onCancelWithTracking = useCallback(() => {
     trackConnectAppButtonClicked({
@@ -41,10 +45,22 @@ export function useFinalErrorViewModel({ state, device, onCancel }: Params) {
     openSupport();
   }, [analyticsProperties, device.modelId, openSupport, sourceFlow]);
 
+  const onGoToSettings = useCallback(() => {
+    trackConnectAppButtonClicked({
+      sourceFlow,
+      modelId: device.modelId,
+      button: CONNECT_APP_BUTTON.GoToSettings,
+      extraProperties: analyticsProperties,
+    });
+    openExperimentalSettings();
+  }, [analyticsProperties, device.modelId, openExperimentalSettings, sourceFlow]);
+
   return {
     error: getTranslatedErrorInput(state.error),
+    isInvalidProvider: isInvalidGetFirmwareMetadataResponseError(state.error),
     onCancel: onCancelWithTracking,
     onContactSupport,
+    onGoToSettings,
   };
 }
 

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/FinalError/useFinalErrorViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/FinalError/useFinalErrorViewModel.ts
@@ -1,9 +1,5 @@
 import { useCallback } from "react";
-import {
-  isDmkError,
-  isInvalidGetFirmwareMetadataResponseError,
-  type DmkError,
-} from "@ledgerhq/live-dmk-desktop";
+import { isDmkError, type DmkError } from "@ledgerhq/live-dmk-desktop";
 import {
   useDeviceIntentTracking,
   type EnsureAppReadyState,
@@ -23,7 +19,7 @@ type Params = Readonly<{
 
 export function useFinalErrorViewModel({ state, device, onCancel }: Params) {
   const { sourceFlow, analyticsProperties } = useDeviceIntentTracking();
-  const { openSupport, openExperimentalSettings } = useInitializerActions();
+  const { openSupport } = useInitializerActions();
 
   const onCancelWithTracking = useCallback(() => {
     trackConnectAppButtonClicked({
@@ -45,22 +41,10 @@ export function useFinalErrorViewModel({ state, device, onCancel }: Params) {
     openSupport();
   }, [analyticsProperties, device.modelId, openSupport, sourceFlow]);
 
-  const onGoToSettings = useCallback(() => {
-    trackConnectAppButtonClicked({
-      sourceFlow,
-      modelId: device.modelId,
-      button: CONNECT_APP_BUTTON.GoToSettings,
-      extraProperties: analyticsProperties,
-    });
-    openExperimentalSettings();
-  }, [analyticsProperties, device.modelId, openExperimentalSettings, sourceFlow]);
-
   return {
     error: getTranslatedErrorInput(state.error),
-    isInvalidProvider: isInvalidGetFirmwareMetadataResponseError(state.error),
     onCancel: onCancelWithTracking,
     onContactSupport,
-    onGoToSettings,
   };
 }
 

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/InvalidProvider/InvalidProviderView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/InvalidProvider/InvalidProviderView.test.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { render } from "tests/testSetup";
+import { InvalidProviderView } from "./InvalidProviderView";
+
+describe("InvalidProviderView", () => {
+  const renderView = () => {
+    const onGoToSettings = jest.fn();
+    const { user } = render(<InvalidProviderView onGoToSettings={onGoToSettings} />);
+    return { user, onGoToSettings };
+  };
+
+  it("GIVEN the invalid provider view WHEN rendering THEN it shows the invalid provider copy", () => {
+    // GIVEN
+    renderView();
+
+    // THEN
+    expect(screen.getByText("Invalid Provider")).toBeVisible();
+  });
+
+  it("GIVEN the invalid provider view WHEN clicking Go to settings THEN it calls the settings action", async () => {
+    // GIVEN
+    const { user, onGoToSettings } = renderView();
+
+    // WHEN
+    await user.click(screen.getByRole("button", { name: "Go to settings" }));
+
+    // THEN
+    expect(onGoToSettings).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/InvalidProvider/InvalidProviderView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/InvalidProvider/InvalidProviderView.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { InfoState } from "@shared/ui-info-state";
+
+type InvalidProviderViewProps = Readonly<{
+  onGoToSettings: () => void;
+}>;
+
+export function InvalidProviderView({ onGoToSettings }: InvalidProviderViewProps) {
+  const { t } = useTranslation();
+
+  return (
+    <InfoState
+      preset="error"
+      size="hug"
+      title={t("deviceIntentExecutor.initialization.blocking.invalidProvider.title")}
+      description={t("deviceIntentExecutor.initialization.blocking.invalidProvider.description")}
+      primaryCta={{
+        label: t("deviceIntentExecutor.initialization.cta.goToSettings"),
+        onPress: onGoToSettings,
+      }}
+      testID="device-initializer-invalid-provider"
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/InvalidProvider/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/InvalidProvider/index.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { BlockingStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
+import { TrackDIEScreen } from "../../../components/TrackDIEScreen";
+import { PAGE_CONNECT_APP } from "../../../utils/trackDeviceIntent";
+import type { BaseInitializerStateProps } from "../../types";
+import { InvalidProviderView } from "./InvalidProviderView";
+import { useInvalidProviderViewModel } from "./useInvalidProviderViewModel";
+
+type InvalidProviderProps = BaseInitializerStateProps<
+  Extract<EnsureAppReadyState, { type: BlockingStateType.InvalidProvider }>
+>;
+
+export function InvalidProvider({ device }: InvalidProviderProps) {
+  const viewModel = useInvalidProviderViewModel({ device });
+
+  return (
+    <>
+      <TrackDIEScreen
+        category={PAGE_CONNECT_APP.InvalidProvider}
+        modelId={device.modelId}
+        refreshSource
+      />
+      <InvalidProviderView {...viewModel} />
+    </>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/InvalidProvider/useInvalidProviderViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/InvalidProvider/useInvalidProviderViewModel.test.tsx
@@ -1,0 +1,57 @@
+import { renderHook } from "@testing-library/react";
+import { DeviceIntentTrackingProvider } from "@ledgerhq/live-dmk-shared";
+import React from "react";
+import { useInitializerActions } from "../../hooks/useInitializerActions";
+import { initializerDevice } from "../../testUtils";
+import { CONNECT_APP_BUTTON, trackConnectAppButtonClicked } from "../../../utils/trackDeviceIntent";
+import { useInvalidProviderViewModel } from "./useInvalidProviderViewModel";
+
+jest.mock("../../hooks/useInitializerActions", () => ({
+  useInitializerActions: jest.fn(),
+}));
+jest.mock("../../../utils/trackDeviceIntent", () => ({
+  ...jest.requireActual("../../../utils/trackDeviceIntent"),
+  trackConnectAppButtonClicked: jest.fn(),
+}));
+
+const mockedUseInitializerActions = jest.mocked(useInitializerActions);
+const mockedTrackConnectAppButtonClicked = jest.mocked(trackConnectAppButtonClicked);
+const openExperimentalSettings = jest.fn();
+const wrapper = ({ children }: React.PropsWithChildren) => (
+  <DeviceIntentTrackingProvider value={{ sourceFlow: "my_ledger" }}>
+    {children}
+  </DeviceIntentTrackingProvider>
+);
+
+describe("useInvalidProviderViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseInitializerActions.mockReturnValue({
+      openMyLedger: jest.fn(),
+      openMyLedgerFirmwareUpdate: jest.fn(),
+      openOnboarding: jest.fn(),
+      openSupport: jest.fn(),
+      openExperimentalSettings,
+    });
+  });
+
+  it("GIVEN an invalid provider WHEN going to settings THEN it opens experimental settings", () => {
+    // GIVEN
+    const { result } = renderHook(
+      () => useInvalidProviderViewModel({ device: initializerDevice }),
+      { wrapper },
+    );
+
+    // WHEN
+    result.current.onGoToSettings();
+
+    // THEN
+    expect(openExperimentalSettings).toHaveBeenCalledTimes(1);
+    expect(mockedTrackConnectAppButtonClicked).toHaveBeenCalledWith({
+      sourceFlow: "my_ledger",
+      modelId: initializerDevice.modelId,
+      button: CONNECT_APP_BUTTON.GoToSettings,
+      extraProperties: {},
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/InvalidProvider/useInvalidProviderViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/InvalidProvider/useInvalidProviderViewModel.ts
@@ -1,0 +1,28 @@
+import { useCallback } from "react";
+import { useDeviceIntentTracking } from "@ledgerhq/live-dmk-shared";
+import { CONNECT_APP_BUTTON, trackConnectAppButtonClicked } from "../../../utils/trackDeviceIntent";
+import { useInitializerActions } from "../../hooks/useInitializerActions";
+import type { InitializerDevice } from "../../types";
+
+type Params = Readonly<{
+  device: InitializerDevice;
+}>;
+
+export function useInvalidProviderViewModel({ device }: Params) {
+  const { sourceFlow, analyticsProperties } = useDeviceIntentTracking();
+  const { openExperimentalSettings } = useInitializerActions();
+
+  const onGoToSettings = useCallback(() => {
+    trackConnectAppButtonClicked({
+      sourceFlow,
+      modelId: device.modelId,
+      button: CONNECT_APP_BUTTON.GoToSettings,
+      extraProperties: analyticsProperties,
+    });
+    openExperimentalSettings();
+  }, [analyticsProperties, device.modelId, openExperimentalSettings, sourceFlow]);
+
+  return {
+    onGoToSettings,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/OutdatedAppWarning/useOutdatedAppWarningViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/OutdatedAppWarning/useOutdatedAppWarningViewModel.test.tsx
@@ -34,6 +34,7 @@ describe("useOutdatedAppWarningViewModel", () => {
       openMyLedgerFirmwareUpdate: jest.fn(),
       openOnboarding: jest.fn(),
       openSupport: jest.fn(),
+      openExperimentalSettings: jest.fn(),
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedApplication/useUnsupportedApplicationViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedApplication/useUnsupportedApplicationViewModel.test.tsx
@@ -31,6 +31,7 @@ describe("useUnsupportedApplicationViewModel", () => {
       openMyLedgerFirmwareUpdate: jest.fn(),
       openOnboarding: jest.fn(),
       openSupport,
+      openExperimentalSettings: jest.fn(),
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedFeature/useUnsupportedFeatureViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedFeature/useUnsupportedFeatureViewModel.test.tsx
@@ -31,6 +31,7 @@ describe("useUnsupportedFeatureViewModel", () => {
       openMyLedgerFirmwareUpdate: jest.fn(),
       openOnboarding: jest.fn(),
       openSupport,
+      openExperimentalSettings: jest.fn(),
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedFirmwareVersion/useUnsupportedFirmwareVersionViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/UnsupportedFirmwareVersion/useUnsupportedFirmwareVersionViewModel.test.tsx
@@ -31,6 +31,7 @@ describe("useUnsupportedFirmwareVersionViewModel", () => {
       openMyLedgerFirmwareUpdate,
       openOnboarding: jest.fn(),
       openSupport: jest.fn(),
+      openExperimentalSettings: jest.fn(),
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/WrongDeviceForAccount/useWrongDeviceForAccountViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/components/WrongDeviceForAccount/useWrongDeviceForAccountViewModel.test.tsx
@@ -31,6 +31,7 @@ describe("useWrongDeviceForAccountViewModel", () => {
       openMyLedgerFirmwareUpdate: jest.fn(),
       openOnboarding: jest.fn(),
       openSupport,
+      openExperimentalSettings: jest.fn(),
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/hooks/useInitializerActions.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWD/hooks/useInitializerActions.ts
@@ -6,6 +6,7 @@ import { openURL } from "~/renderer/linking";
 
 const MANAGER_ROUTE = "/manager";
 const ONBOARDING_ROUTE = "/onboarding/select-device";
+const EXPERIMENTAL_SETTINGS_ROUTE = "/settings/experimental";
 
 export function useInitializerActions() {
   const navigate = useNavigate();
@@ -35,10 +36,15 @@ export function useInitializerActions() {
     openURL(contactSupportUrl);
   }, [contactSupportUrl]);
 
+  const openExperimentalSettings = useCallback(() => {
+    navigate(EXPERIMENTAL_SETTINGS_ROUTE);
+  }, [navigate]);
+
   return {
     openMyLedger,
     openMyLedgerFirmwareUpdate,
     openOnboarding,
     openSupport,
+    openExperimentalSettings,
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.test.ts
@@ -243,6 +243,7 @@ describe("trackDeviceIntent — Layer A tracking helpers", () => {
         DeviceDeprecatedBlocking: "Connect App - Device Deprecated Blocking",
         WrongDeviceForAccount: "Connect App - Wrong Device For Account",
         OutOfStorage: "Connect App - Out Of Storage",
+        InvalidProvider: "Connect App - Invalid Provider",
         Error: "Connect App - Error",
       });
     });

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
@@ -80,6 +80,7 @@ export const CONNECT_APP_BUTTON = {
   LearnMore: "Learn More",
   DiscoverUpgradeProgram: "Discover Upgrade Program",
   ManageApps: "Manage Apps",
+  GoToSettings: "Go To Settings",
 } as const;
 
 let isInTerminalConnectDeviceError = false;

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
@@ -44,6 +44,7 @@ export const PAGE_CONNECT_APP = {
   DeviceDeprecatedBlocking: "Connect App - Device Deprecated Blocking",
   WrongDeviceForAccount: "Connect App - Wrong Device For Account",
   OutOfStorage: "Connect App - Out Of Storage",
+  InvalidProvider: "Connect App - Invalid Provider",
   Error: "Connect App - Error",
 } as const;
 
@@ -93,6 +94,7 @@ const DEVICEFLOW_FAILED_CLOSE_PAGES = new Set<string>([
   PAGE_CONNECT_APP.DeviceDeprecatedBlocking,
   PAGE_CONNECT_APP.WrongDeviceForAccount,
   PAGE_CONNECT_APP.OutOfStorage,
+  PAGE_CONNECT_APP.InvalidProvider,
   PAGE_CONNECT_APP.Error,
   PAGE_DEVICE_ACTION.Disconnected,
   PAGE_DEVICE_ACTION.UnknownIntentError,

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -6988,6 +6988,11 @@
       "description": "You have to change \"My Ledger provider\" setting. To change it, open Ledger Wallet \"Settings\", select \"Experimental features\", and then select a different provider.",
       "goToSettingsCTA": "Go to settings"
     },
+    "InvalidGetFirmwareMetadataResponseError": {
+      "title": "Invalid Provider",
+      "description": "You have to change \"My Ledger provider\" setting. To change it, open Ledger Wallet \"Settings\", select \"Experimental features\", and then select a different provider.",
+      "goToSettingsCTA": "Go to settings"
+    },
     "HardResetFail": {
       "title": "Sorry, could not reset",
       "description": "Please try again or contact Ledger Support if the problem persists."

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -6988,11 +6988,6 @@
       "description": "You have to change \"My Ledger provider\" setting. To change it, open Ledger Wallet \"Settings\", select \"Experimental features\", and then select a different provider.",
       "goToSettingsCTA": "Go to settings"
     },
-    "InvalidGetFirmwareMetadataResponseError": {
-      "title": "Invalid Provider",
-      "description": "You have to change \"My Ledger provider\" setting. To change it, open Ledger Wallet \"Settings\", select \"Experimental features\", and then select a different provider.",
-      "goToSettingsCTA": "Go to settings"
-    },
     "HardResetFail": {
       "title": "Sorry, could not reset",
       "description": "Please try again or contact Ledger Support if the problem persists."
@@ -9733,6 +9728,10 @@
           "title": "Uninstall some apps to free up Ledger device memory",
           "description": "Your device doesn't have enough memory.",
           "apps": "Apps to manage: {{appNames}}"
+        },
+        "invalidProvider": {
+          "title": "Invalid Provider",
+          "description": "You have to change \"My Ledger provider\" setting. To change it, open Ledger Wallet \"Settings\", select \"Experimental features\", and then select a different provider."
         }
       },
       "cta": {
@@ -9741,7 +9740,8 @@
         "setupDevice": "Set up Ledger device",
         "updateLedgerOs": "Update Ledger OS",
         "cancelOperation": "Cancel operation",
-        "contactLedgerSupport": "Contact Ledger support"
+        "contactLedgerSupport": "Contact Ledger support",
+        "goToSettings": "Go to settings"
       }
     },
     "connectDevice": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -5177,6 +5177,10 @@
         "deviceOutOfStorageSpace": {
           "title": "Uninstall some apps to free up Ledger device memory",
           "description": "Your device doesn’t have enough memory."
+        },
+        "invalidProvider": {
+          "title": "Invalid Provider",
+          "description": "You have to change \"My Ledger provider\" setting. To change it, open Ledger Live \"Settings\", select \"Experimental features\", and then select a different provider."
         }
       },
       "cta": {
@@ -5185,7 +5189,8 @@
         "setupDevice": "Set up Ledger device",
         "updateLedgerOs": "Update Ledger OS",
         "cancelOperation": "Cancel operation",
-        "contactLedgerSupport": "Contact Ledger support"
+        "contactLedgerSupport": "Contact Ledger support",
+        "goToSettings": "Go to settings"
       }
     },
     "connectDevice": {

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/DeviceContextInitializerComponentLWMView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/DeviceContextInitializerComponentLWMView.tsx
@@ -26,6 +26,7 @@ import { DeviceDeprecatedBlockingState } from "./components/DeviceDeprecatedBloc
 import { WrongDeviceForAccount } from "./components/WrongDeviceForAccount";
 import { DeviceOutOfStorageSpace } from "./components/DeviceOutOfStorageSpace";
 import { DeviceNotOnboarded } from "./components/DeviceNotOnboarded";
+import { InvalidProvider } from "./components/InvalidProvider";
 import { FinalError } from "./components/FinalError";
 
 function assertNever(value: never): never {
@@ -77,6 +78,8 @@ export function DeviceContextInitializerComponentLWMView({
             return <DeviceOutOfStorageSpace state={state} {...commonProps} />;
           case BlockingStateType.DeviceNotOnboarded:
             return <DeviceNotOnboarded state={state} {...commonProps} />;
+          case BlockingStateType.InvalidProvider:
+            return <InvalidProvider state={state} {...commonProps} />;
           case FinalStateType.Error:
             return <FinalError state={state} {...commonProps} />;
           case FinalStateType.Success:

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceNotOnboarded/useDeviceNotOnboardedViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceNotOnboarded/useDeviceNotOnboardedViewModel.test.tsx
@@ -43,6 +43,7 @@ describe("useDeviceNotOnboardedViewModel", () => {
       openMyLedgerFirmwareUpdate: jest.fn(),
       openOnboarding,
       openSupport: jest.fn(),
+      openExperimentalSettings: jest.fn(),
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceOutOfStorageSpace/useDeviceOutOfStorageSpaceViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/DeviceOutOfStorageSpace/useDeviceOutOfStorageSpaceViewModel.test.tsx
@@ -49,6 +49,7 @@ describe("useDeviceOutOfStorageSpaceViewModel", () => {
       openMyLedgerFirmwareUpdate: jest.fn(),
       openOnboarding: jest.fn(),
       openSupport: jest.fn(),
+      openExperimentalSettings: jest.fn(),
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/FinalError/useFinalErrorViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/FinalError/useFinalErrorViewModel.test.tsx
@@ -51,6 +51,7 @@ describe("useFinalErrorViewModel", () => {
       openMyLedgerFirmwareUpdate: jest.fn(),
       openOnboarding: jest.fn(),
       openSupport,
+      openExperimentalSettings: jest.fn(),
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/InvalidProvider/InvalidProviderView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/InvalidProvider/InvalidProviderView.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Trans } from "~/context/Locale";
+import { InfoState } from "@shared/ui-info-state";
+
+type InvalidProviderViewProps = Readonly<{
+  onGoToSettings: () => void;
+}>;
+
+export function InvalidProviderView({ onGoToSettings }: InvalidProviderViewProps) {
+  return (
+    <InfoState
+      preset="error"
+      size="hug"
+      title={<Trans i18nKey="deviceIntentExecutor.initialization.blocking.invalidProvider.title" />}
+      description={
+        <Trans i18nKey="deviceIntentExecutor.initialization.blocking.invalidProvider.description" />
+      }
+      primaryCta={{
+        label: <Trans i18nKey="deviceIntentExecutor.initialization.cta.goToSettings" />,
+        onPress: onGoToSettings,
+      }}
+      testID="device-initializer-invalid-provider"
+    />
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/InvalidProvider/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/InvalidProvider/index.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { BlockingStateType, type EnsureAppReadyState } from "@ledgerhq/live-dmk-shared";
+import { TrackDIEScreen } from "../../../components/TrackDIEScreen";
+import { PAGE_CONNECT_APP } from "../../../utils/trackDeviceIntent";
+import type { BaseInitializerStateProps } from "../../types";
+import { InvalidProviderView } from "./InvalidProviderView";
+import { useInvalidProviderViewModel } from "./useInvalidProviderViewModel";
+
+type InvalidProviderProps = BaseInitializerStateProps<
+  Extract<EnsureAppReadyState, { type: BlockingStateType.InvalidProvider }>
+>;
+
+export function InvalidProvider({ device }: InvalidProviderProps) {
+  const viewModel = useInvalidProviderViewModel({ device });
+
+  return (
+    <>
+      <TrackDIEScreen
+        category={PAGE_CONNECT_APP.InvalidProvider}
+        modelId={device.modelId}
+        refreshSource
+      />
+      <InvalidProviderView {...viewModel} />
+    </>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/InvalidProvider/useInvalidProviderViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/InvalidProvider/useInvalidProviderViewModel.test.tsx
@@ -3,7 +3,7 @@ import { DeviceModelId } from "@ledgerhq/types-devices";
 import React from "react";
 import { track } from "~/analytics";
 import { useInitializerActions } from "../../hooks/useInitializerActions";
-import { useUnsupportedFeatureViewModel } from "./useUnsupportedFeatureViewModel";
+import { useInvalidProviderViewModel } from "./useInvalidProviderViewModel";
 import type { InitializerDevice } from "../../types";
 import { DeviceIntentTrackingProvider } from "../../../utils/DeviceIntentTrackingContext";
 
@@ -20,7 +20,7 @@ jest.mock("../../hooks/useInitializerActions");
 const mockedTrack = jest.mocked(track);
 const mockedUseInitializerActions = jest.mocked(useInitializerActions);
 const SOURCE_FLOW = "my_ledger";
-const openSupport = jest.fn();
+const openExperimentalSettings = jest.fn();
 const wrapper = ({ children }: React.PropsWithChildren) => (
   <DeviceIntentTrackingProvider value={{ sourceFlow: SOURCE_FLOW }}>
     {children}
@@ -35,41 +35,31 @@ const device: InitializerDevice = {
   wired: false,
 };
 
-describe("useUnsupportedFeatureViewModel", () => {
+describe("useInvalidProviderViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedUseInitializerActions.mockReturnValue({
       openMyLedger: jest.fn(),
       openMyLedgerFirmwareUpdate: jest.fn(),
       openOnboarding: jest.fn(),
-      openSupport,
-      openExperimentalSettings: jest.fn(),
+      openSupport: jest.fn(),
+      openExperimentalSettings,
     });
   });
 
-  it("GIVEN a device WHEN rendering THEN it exposes the view handlers", () => {
-    const { result } = renderHook(() => useUnsupportedFeatureViewModel({ device }), { wrapper });
-
-    expect(result.current).toEqual(
-      expect.objectContaining({
-        onContactSupport: expect.any(Function),
-      }),
-    );
-  });
-
-  it("GIVEN a device WHEN contacting support THEN it tracks Contact Ledger Support and opens support", () => {
-    const { result } = renderHook(() => useUnsupportedFeatureViewModel({ device }), { wrapper });
+  it("GIVEN a device WHEN invoking go to settings THEN it tracks Go To Settings and opens experimental settings", () => {
+    const { result } = renderHook(() => useInvalidProviderViewModel({ device }), { wrapper });
 
     act(() => {
-      result.current.onContactSupport();
+      result.current.onGoToSettings();
     });
 
     expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
       sourceFlow: "my_ledger",
       deviceUxV2: true,
       modelId: DeviceModelId.europa,
-      button: "Contact Ledger Support",
+      button: "Go To Settings",
     });
-    expect(openSupport).toHaveBeenCalledTimes(1);
+    expect(openExperimentalSettings).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/InvalidProvider/useInvalidProviderViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/InvalidProvider/useInvalidProviderViewModel.ts
@@ -1,0 +1,29 @@
+import { useCallback } from "react";
+import type { InitializerDevice } from "../../types";
+import { useInitializerActions } from "../../hooks/useInitializerActions";
+import { useDeviceIntentTracking } from "../../../utils/DeviceIntentTrackingContext";
+import { CONNECT_APP_BUTTON, trackConnectAppButtonClicked } from "../../../utils/trackDeviceIntent";
+
+type Params = Readonly<{
+  device: InitializerDevice;
+}>;
+
+export function useInvalidProviderViewModel({ device }: Params) {
+  const { sourceFlow, analyticsProperties } = useDeviceIntentTracking();
+  const { openExperimentalSettings } = useInitializerActions(device);
+  const modelId = device.modelId;
+
+  const onGoToSettings = useCallback(() => {
+    trackConnectAppButtonClicked({
+      sourceFlow,
+      modelId,
+      button: CONNECT_APP_BUTTON.GoToSettings,
+      extraProperties: analyticsProperties,
+    });
+    openExperimentalSettings();
+  }, [analyticsProperties, openExperimentalSettings, sourceFlow, modelId]);
+
+  return {
+    onGoToSettings,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/OutdatedAppWarning/useOutdatedAppWarningViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/OutdatedAppWarning/useOutdatedAppWarningViewModel.test.tsx
@@ -57,6 +57,7 @@ describe("useOutdatedAppWarningViewModel", () => {
       openMyLedgerFirmwareUpdate: jest.fn(),
       openOnboarding: jest.fn(),
       openSupport: jest.fn(),
+      openExperimentalSettings: jest.fn(),
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedApplication/useUnsupportedApplicationViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedApplication/useUnsupportedApplicationViewModel.test.tsx
@@ -43,6 +43,7 @@ describe("useUnsupportedApplicationViewModel", () => {
       openMyLedgerFirmwareUpdate: jest.fn(),
       openOnboarding: jest.fn(),
       openSupport,
+      openExperimentalSettings: jest.fn(),
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFirmwareVersion/useUnsupportedFirmwareVersionViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/UnsupportedFirmwareVersion/useUnsupportedFirmwareVersionViewModel.test.tsx
@@ -44,6 +44,7 @@ describe("useUnsupportedFirmwareVersionViewModel", () => {
       openMyLedgerFirmwareUpdate,
       openOnboarding: jest.fn(),
       openSupport: jest.fn(),
+      openExperimentalSettings: jest.fn(),
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/WrongDeviceForAccount/useWrongDeviceForAccountViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/components/WrongDeviceForAccount/useWrongDeviceForAccountViewModel.test.tsx
@@ -44,6 +44,7 @@ describe("useWrongDeviceForAccountViewModel", () => {
       openMyLedgerFirmwareUpdate: jest.fn(),
       openOnboarding: jest.fn(),
       openSupport,
+      openExperimentalSettings: jest.fn(),
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/hooks/useInitializerActions.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceContextInitializerComponentLWM/hooks/useInitializerActions.ts
@@ -55,11 +55,19 @@ export function useInitializerActions(device: InitializerDevice) {
     Linking.openURL(contactSupportUrl);
   }, [contactSupportUrl]);
 
+  const openExperimentalSettings = useCallback(() => {
+    navigation.navigate(NavigatorName.Base, {
+      screen: NavigatorName.Settings,
+      params: { screen: ScreenName.ExperimentalSettings },
+    });
+  }, [navigation]);
+
   return {
     openMyLedger,
     openMyLedgerFirmwareUpdate,
     openOnboarding,
     openSupport,
+    openExperimentalSettings,
   };
 }
 

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
@@ -56,6 +56,7 @@ export const PAGE_CONNECT_APP = {
   DeviceDeprecatedBlocking: "Connect App - Device Deprecated Blocking",
   WrongDeviceForAccount: "Connect App - Wrong Device For Account",
   OutOfStorage: "Connect App - Out Of Storage",
+  InvalidProvider: "Connect App - Invalid Provider",
   Error: "Connect App - Error",
 } as const;
 
@@ -81,6 +82,7 @@ export const CONNECT_APP_BUTTON = {
   LearnMore: "Learn More",
   DiscoverUpgradeProgram: "Discover Upgrade Program",
   ManageApps: "Manage Apps",
+  GoToSettings: "Go To Settings",
 } as const;
 
 export const DEVICE_ACTION_BUTTON = {

--- a/libs/live-dmk-shared/src/device-action/EnsureAppReady/state.test.ts
+++ b/libs/live-dmk-shared/src/device-action/EnsureAppReady/state.test.ts
@@ -41,6 +41,7 @@ describe("isRetryableState", () => {
     [BlockingStateType.WrongDeviceForAccount]: true,
     [BlockingStateType.DeviceOutOfStorageSpace]: true,
     [BlockingStateType.DeviceNotOnboarded]: true,
+    [BlockingStateType.InvalidProvider]: true,
     [FinalStateType.Error]: true,
     [FinalStateType.Success]: true,
   };

--- a/libs/live-dmk-shared/src/device-action/EnsureAppReady/state.ts
+++ b/libs/live-dmk-shared/src/device-action/EnsureAppReady/state.ts
@@ -54,6 +54,13 @@ export enum BlockingStateType {
   WrongDeviceForAccount = "blocking-wrong-device-for-account",
   /** To map to wording of error.DeviceNotOnboarded */
   DeviceNotOnboarded = "blocking-device-not-onboarded",
+  /**
+   * To use when the configured My Ledger provider cannot serve the device
+   * firmware metadata, which makes every catalog call fail.
+   *
+   * To map to wording of error.FirmwareNotRecognized
+   */
+  InvalidProvider = "blocking-invalid-provider",
 }
 
 /** For all recoverable errors (job retry will fix) */
@@ -128,6 +135,9 @@ export type EnsureAppReadyState =
     }
   | {
       type: BlockingStateType.DeviceNotOnboarded;
+    }
+  | {
+      type: BlockingStateType.InvalidProvider;
     }
   | { type: FinalStateType.Error; error: unknown }
   | { type: FinalStateType.Success; extractedContext: DeviceExtractedContext };

--- a/libs/live-dmk-shared/src/device-action/EnsureAppReady/stateMapping.test.ts
+++ b/libs/live-dmk-shared/src/device-action/EnsureAppReady/stateMapping.test.ts
@@ -531,6 +531,28 @@ describe("mapConnectAppDAErrorStatus", () => {
     expect(getCurrentDeviceState).not.toHaveBeenCalled();
   });
 
+  it("GIVEN an invalid firmware metadata error WHEN it is mapped THEN it returns a blocking invalid provider state", () => {
+    // GIVEN
+    const getCurrentDeviceState = jest.fn(() => makeSessionState());
+
+    // WHEN
+    const result = mapConnectAppDAErrorStatus({
+      state: makeErrored({
+        _tag: "InvalidGetFirmwareMetadataResponseError",
+      } as unknown as ConnectAppDAError),
+      appName,
+      getCurrentDeviceState,
+      latestInstallPlan: null,
+      retry,
+    });
+
+    // THEN
+    expect(result).toEqual({
+      type: BlockingStateType.InvalidProvider,
+    });
+    expect(getCurrentDeviceState).not.toHaveBeenCalled();
+  });
+
   it("GIVEN a locked device error WHEN it is mapped THEN it returns a retryable locked state", () => {
     // WHEN
     const result = mapConnectAppDAErrorStatus({

--- a/libs/live-dmk-shared/src/device-action/EnsureAppReady/stateMapping.ts
+++ b/libs/live-dmk-shared/src/device-action/EnsureAppReady/stateMapping.ts
@@ -204,6 +204,14 @@ export function mapConnectAppDAErrorStatus(params: {
     };
   }
 
+  // The manager API answers 404 for an unknown My Ledger provider, which DMK
+  // surfaces as this generic metadata error.
+  if (hasTag(error, "InvalidGetFirmwareMetadataResponseError")) {
+    return {
+      type: BlockingStateType.InvalidProvider,
+    };
+  }
+
   const deviceState = getCurrentDeviceState();
 
   if (error instanceof UnsupportedFirmwareDAError) {


### PR DESCRIPTION
### 📝 Description

On Ledger Wallet Desktop, connecting a device through the Device Intent Executor (DIE) with an incorrect "My Ledger" provider configured showed an unclear error:

- **Title:** `InvalidGetFirmwareMetadataResponseError`
- **Description:** "Something went wrong. Please retry or contact Ledger Support."
- **Actions:** Contact Ledger support / Close

**Root cause**: the DIE `ensureAppReady` flow has no i18n entry for `InvalidGetFirmwareMetadataResponseError`, so `TranslatedError` falls back to the generic error copy, and the final-error screen (`FinalErrorView`) always renders the same two actions (Contact support / Close) regardless of the underlying error. The legacy (non-DIE) device action flow already special-cases this exact DMK error and shows a friendly "Invalid Provider" screen with a "Go to settings" action; DIE never got the equivalent handling.

**Fix**:
- Added the missing `errors.InvalidGetFirmwareMetadataResponseError` translation key (same copy as the legacy `errors.FirmwareNotRecognized` key).
- `useFinalErrorViewModel`/`FinalErrorView` now detect this specific error and swap the primary CTA to "Go to settings", navigating to the experimental settings screen, instead of "Contact Ledger Support".
- Added `openExperimentalSettings` to `useInitializerActions`.

Now the DIE final error screen shows:

- **Title:** "Invalid Provider"
- **Description:** explains the "My Ledger provider" setting needs changing
- **Actions:** Go to settings / Close

Scoped to LWD only, matching the ticket.

| Before                        | After                         |
|-------------------------------|-------------------------------|
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA issue**: [LIVE-36315](https://ledgerhq.atlassian.net/browse/LIVE-36315)

[LIVE-36315]: https://ledgerhq.atlassian.net/browse/LIVE-36315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ