### PR TITLE
test(chore): Use PartialFeatures type for feature flag typing

### DIFF
--- a/e2e/desktop/tests/fixtures/common.ts
+++ b/e2e/desktop/tests/fixtures/common.ts
@@ -3,7 +3,7 @@ import { execFileSync } from "node:child_process";
 import { mkdir, readFile, writeFile } from "fs/promises";
 import merge from "lodash/merge";
 import * as path from "path";
-import type { OptionalFeatureMap } from "@shared/feature-flags";
+import type { PartialFeatures } from "@shared/feature-flags";
 import { setEnv } from "@shared/env";
 
 import { Application } from "tests/page";
@@ -53,7 +53,7 @@ type TestFixtures = {
   env: Record<string, string>;
   electronApp: ElectronApplication;
   page: Page;
-  featureFlags: OptionalFeatureMap;
+  featureFlags: PartialFeatures;
   simulateCamera: string;
   app: Application;
   cliCommands?: CliCommand[];

--- a/e2e/desktop/tests/specs/ledgerSync.spec.ts
+++ b/e2e/desktop/tests/specs/ledgerSync.spec.ts
@@ -291,7 +291,14 @@ function unactivatedFeatureFlags() {
       },
       lldLedgerSyncEntryPoints: {
         enabled: true,
-        params: { settings: true },
+        params: {
+          manager: true,
+          accounts: true,
+          settings: true,
+          onboarding: true,
+          postOnboarding: true,
+          sendFlow: false,
+        },
       },
       lwdLedgerSyncOptimisation: { enabled: true },
     },

--- a/e2e/desktop/tests/specs/myWallet.spec.ts
+++ b/e2e/desktop/tests/specs/myWallet.spec.ts
@@ -14,7 +14,7 @@ test.describe("My Wallet", () => {
       protectServicesDesktop: { enabled: true },
       referralProgramDesktopSidebar: {
         enabled: true,
-        params: { path: "/refer-a-friend" },
+        params: { path: "/refer-a-friend", isNew: true, amount: "$20" },
       },
       lwdBackupHub: { enabled: false },
     },

--- a/e2e/desktop/tests/specs/send.tx.spec.ts
+++ b/e2e/desktop/tests/specs/send.tx.spec.ts
@@ -656,7 +656,7 @@ test.describe("Send", () => {
       featureFlags: {
         ...FF_NEW_SEND_FLOW_DISABLED,
         currencyConcordiumTestnet: { enabled: true },
-        analyticsOptIn: { enabled: true, params: { policyVersion: 1, consentValidityDays: 365 } },
+        analyticsOptIn: { enabled: true, params: { policyVersion: 1 } },
       },
     });
 

--- a/e2e/desktop/tests/utils/featureFlagUtils.ts
+++ b/e2e/desktop/tests/utils/featureFlagUtils.ts
@@ -7,7 +7,7 @@ export const getFeatureFlags = async (page: Page): Promise<PartialFeatures> => {
   const featureFlags = await page.evaluate(() => {
     return window.getAllFeatureFlags("en");
   });
-  return featureFlags;
+  return featureFlags as PartialFeatures;
 };
 
 const getLwdWallet40Params = async (page: Page) => {

--- a/e2e/desktop/tests/utils/featureFlagUtils.ts
+++ b/e2e/desktop/tests/utils/featureFlagUtils.ts
@@ -1,21 +1,18 @@
 import { parseExtraFeatureFlags } from "@ledgerhq/live-e2e-shared/featureFlagsJsonUtils";
 import { Page } from "@playwright/test";
 
-import type { OptionalFeatureMap, Features } from "@shared/feature-flags";
+import type { PartialFeatures } from "@shared/feature-flags";
 
-export const getFeatureFlags = async (page: Page): Promise<OptionalFeatureMap> => {
+export const getFeatureFlags = async (page: Page): Promise<PartialFeatures> => {
   const featureFlags = await page.evaluate(() => {
     return window.getAllFeatureFlags("en");
   });
   return featureFlags;
 };
 
-const getLwdWallet40Params = async (
-  page: Page,
-): Promise<Features["lwdWallet40"]["params"] | undefined> => {
+const getLwdWallet40Params = async (page: Page) => {
   const featureFlags = await getFeatureFlags(page);
-  const lwdWallet40 = featureFlags.lwdWallet40 as Features["lwdWallet40"];
-  return lwdWallet40?.params;
+  return featureFlags.lwdWallet40?.params;
 };
 
 export const isAssetSectionEnabled = async (page: Page): Promise<boolean> =>
@@ -39,7 +36,8 @@ const FF_LWD_WALLET_40_Q1 = {
   lwdWallet40: {
     enabled: true,
     params: {
-      newReceiveDialog: true,
+      tour: false,
+      q2Tour: false,
       lazyOnboarding: true,
       assetSection: false,
       brazePlacement: true,
@@ -49,18 +47,17 @@ const FF_LWD_WALLET_40_Q1 = {
       pnl: false,
       earnUpselling: false,
       earnSimulator: false,
-      finishOnboardingWidget: false,
       assetDiscoverability: false,
-      q2Tour: false,
     },
   },
-} satisfies OptionalFeatureMap;
+} satisfies PartialFeatures;
 
 export const FF_LWD_WALLET_40_Q2 = {
   lwdWallet40: {
     enabled: true,
     params: {
-      newReceiveDialog: true,
+      tour: false,
+      q2Tour: false,
       lazyOnboarding: true,
       assetSection: true,
       brazePlacement: true,
@@ -70,25 +67,24 @@ export const FF_LWD_WALLET_40_Q2 = {
       pnl: true,
       earnUpselling: true,
       earnSimulator: true,
-      finishOnboardingWidget: true,
       assetDiscoverability: true,
     },
   },
-} satisfies OptionalFeatureMap;
+} satisfies PartialFeatures;
 
 // Wallet 4.0 Q2 flags with the analytics consent dialog forced OFF, so the
 // "Help us improve Ledger" prompt never interrupts portfolio-landing E2E flows.
 export const FF_LWD_WALLET_40_Q2_NO_ANALYTICS_CONSENT = {
   ...FF_LWD_WALLET_40_Q2,
   analyticsOptIn: { enabled: false },
-} satisfies OptionalFeatureMap;
+} satisfies PartialFeatures;
 
 export const FF_BORROW_DESKTOP = {
   ptxBorrowLiveApp: {
     enabled: true,
     params: { manifest_id: "borrow" },
   },
-} satisfies OptionalFeatureMap;
+} satisfies PartialFeatures;
 
 export const FF_EARN_V2_DESKTOP = {
   ...(useLocalEarnManifest && {
@@ -98,12 +94,12 @@ export const FF_EARN_V2_DESKTOP = {
     },
   }),
   ptxEarnUi: { enabled: true, params: { value: "v2" } },
-} satisfies OptionalFeatureMap;
+} satisfies PartialFeatures;
 
 export const FF_EARN_V2_DESKTOP_WITH_SIMULATOR = {
   ...FF_EARN_V2_DESKTOP,
   ...FF_LWD_WALLET_40_Q2_NO_ANALYTICS_CONSENT,
-} satisfies OptionalFeatureMap;
+} satisfies PartialFeatures;
 
 export const FF_STAKE_PROGRAMS_MODAL = {
   stakePrograms: {
@@ -132,7 +128,7 @@ export const FF_STAKE_PROGRAMS_MODAL = {
       },
     },
   },
-} satisfies OptionalFeatureMap;
+} satisfies PartialFeatures;
 
 export const FF_NEW_SEND_FLOW_DISABLED = {
   newSendFlow: {
@@ -142,16 +138,16 @@ export const FF_NEW_SEND_FLOW_DISABLED = {
       excludedCurrencyIds: [],
     },
   },
-} satisfies OptionalFeatureMap;
+} satisfies PartialFeatures;
 
 export const FF_NEW_SEND_FLOW_FIRST_INTERACTION_BANNER_ENABLED = {
   newSendFlowFirstInteractionBanner: { enabled: true },
-} satisfies OptionalFeatureMap;
+} satisfies PartialFeatures;
 
 export const getMergedFeatureFlags = ({
   testFlags,
-}: { testFlags?: OptionalFeatureMap } = {}): OptionalFeatureMap => {
-  const ffPresetMap: Record<string, OptionalFeatureMap> = {
+}: { testFlags?: PartialFeatures } = {}): PartialFeatures => {
+  const ffPresetMap: Record<string, PartialFeatures> = {
     /*
      * The keys here are the values of the `E2E_DESKTOP_FEATURE_FLAGS` environment variable.
      * We can add more mappings here in the future to test different feature flag combinations.
@@ -162,14 +158,14 @@ export const getMergedFeatureFlags = ({
     "wallet40-q1": FF_LWD_WALLET_40_Q1,
   };
 
-  const defaultFlags: OptionalFeatureMap = {
+  const defaultFlags: PartialFeatures = {
     // explicit defaults
+    onboardingWidget: { enabled: true },
     largeScreenUpsell: { enabled: false },
     lldModularDrawer: {
       enabled: true,
       params: {
         add_account: true,
-        earn_flow: true,
         live_app: true,
         receive_flow: false,
         send_flow: false,
@@ -189,7 +185,7 @@ export const getMergedFeatureFlags = ({
   };
 
   // parse JSON override flags for any overrides
-  const jsonOverrideFlags: OptionalFeatureMap = parseExtraFeatureFlags(
+  const jsonOverrideFlags: PartialFeatures = parseExtraFeatureFlags<PartialFeatures>(
     process.env.E2E_FEATURE_FLAGS_JSON,
   );
 

--- a/e2e/mobile/bridge/server.ts
+++ b/e2e/mobile/bridge/server.ts
@@ -6,7 +6,7 @@ import merge from "lodash/merge";
 
 import { NavigatorName } from "~/const";
 import type { MessageData, OverrideFeatureFlagPayload, ServerData } from "~/e2e/bridge/types";
-import type { OptionalFeatureMap, FeatureId } from "@shared/feature-flags";
+import type { PartialFeatures, FeatureId } from "@shared/feature-flags";
 import { FeatureIdSchema } from "@shared/feature-flags";
 import { log as detoxLog } from "detox";
 import { getSpeculosModel } from "@ledgerhq/live-e2e-shared/speculosAppVersion";
@@ -129,7 +129,7 @@ export async function loadConfig(fileName: string, agreed: true = true): Promise
   }
 }
 
-export async function setFeatureFlags(flags: OptionalFeatureMap) {
+export async function setFeatureFlags(flags: PartialFeatures) {
   for (const id in flags) {
     if (isFeatureId(id)) {
       setFeatureFlag({ id, value: flags[id] });

--- a/e2e/mobile/helpers/ledgerSyncHelpers.ts
+++ b/e2e/mobile/helpers/ledgerSyncHelpers.ts
@@ -1,12 +1,12 @@
 import { ledgerSyncEnvironment } from "@ledgerhq/live-e2e-shared/ledgerSync/environment";
 
-import type { OptionalFeatureMap } from "@shared/feature-flags";
+import type { PartialFeatures } from "@shared/feature-flags";
 
 /**
  * Every suite that boots into a pre-seeded trustchain needs this flag on: the app reads the
  * environment from it to build its trustchain SDK, and Ledger Sync stays unavailable without it.
  */
-export const LEDGER_SYNC_FEATURE_FLAGS: OptionalFeatureMap = {
+export const LEDGER_SYNC_FEATURE_FLAGS: PartialFeatures = {
   llmWalletSync: {
     enabled: true,
     params: {

--- a/e2e/mobile/page/common.page.ts
+++ b/e2e/mobile/page/common.page.ts
@@ -84,7 +84,7 @@ export default class CommonPage {
       await openDeeplink(`asset/${currencyId}`);
       await waitForElementById(scrollViewId);
       const itemId = `asset-detail-address-item-${accountId}`;
-      await scrollToId(itemId, scrollViewId);
+      await revealForTap(itemId, { container: scrollViewId });
       await tapByElement(getElementById(itemId));
     } else {
       await scrollToId(this.accountItemRegExp(accountId), this.assetScreenFlatlistId);

--- a/e2e/mobile/specs/contacts/contacts.ts
+++ b/e2e/mobile/specs/contacts/contacts.ts
@@ -10,10 +10,10 @@ import {
 import { FF_LWM_WALLET_40_Q2 } from "@e2e/utils/featureFlagUtils";
 
 import type { ApplicationOptions } from "@e2e/page/index";
-import type { OptionalFeatureMap } from "@shared/feature-flags";
+import type { PartialFeatures } from "@shared/feature-flags";
 
 // Pinned: the Contacts entry point lives on My Wallet, which the Q1 preset turns off.
-const CONTACTS_FEATURE_FLAGS: OptionalFeatureMap = {
+const CONTACTS_FEATURE_FLAGS: PartialFeatures = {
   lwmContacts: {
     enabled: true,
     params: { newBadge: false, eligibleAddressFamilies: ["evm"] },

--- a/e2e/mobile/specs/earn/earnV2.ts
+++ b/e2e/mobile/specs/earn/earnV2.ts
@@ -6,13 +6,13 @@ import { setTeamOwner } from "@e2e/helpers/allure/allure-helper";
 import { FF_LWM_WALLET_40_Q2 } from "@e2e/utils/featureFlagUtils";
 
 import type { ApplicationOptions } from "@e2e/page/index";
-import type { OptionalFeatureMap, PartialFeatures } from "@shared/feature-flags";
+import type { PartialFeatures } from "@shared/feature-flags";
 
 setEnv("DISABLE_TRANSACTION_BROADCAST", true);
 
 // Pinned so E2E_MOBILE_FEATURE_FLAGS can't downgrade earnUpselling and change the earn UI.
 // https://ledgerhq.atlassian.net/browse/LIVE-35026
-const EARN_V2_FLAGS: OptionalFeatureMap = {
+const EARN_V2_FLAGS: PartialFeatures = {
   ptxEarnUi: { enabled: true, params: { value: "v2" } },
   ...FF_LWM_WALLET_40_Q2,
 };

--- a/e2e/mobile/specs/postOnboarding/postOnboardingHub.ts
+++ b/e2e/mobile/specs/postOnboarding/postOnboardingHub.ts
@@ -2,7 +2,7 @@ import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { setTeamOwner } from "@e2e/helpers/allure/allure-helper";
 
 import type { ApplicationOptions } from "@e2e/page/index";
-import type { OptionalFeatureMap } from "@shared/feature-flags";
+import type { PartialFeatures } from "@shared/feature-flags";
 
 /** Must stay in sync with `postOnboarding.actionsToComplete` in userdata/post-onboarding-hub-flow.json. */
 export const MOCK_ACTIONS = [
@@ -12,7 +12,7 @@ export const MOCK_ACTIONS = [
 ] as const;
 
 // Wallet 4.0 + onboardingWidget come from E2E defaults; only pin flags that would block the widget.
-export const POST_ONBOARDING_FLAGS: OptionalFeatureMap = {
+export const POST_ONBOARDING_FLAGS: PartialFeatures = {
   protectServicesMobile: { enabled: false },
   lwmProductTour: { enabled: false },
   llmLedgerSyncEntryPoints: { enabled: false },

--- a/e2e/mobile/utils/featureFlagUtils.ts
+++ b/e2e/mobile/utils/featureFlagUtils.ts
@@ -1,7 +1,7 @@
 import { parseExtraFeatureFlags } from "@ledgerhq/live-e2e-shared/featureFlagsJsonUtils";
 import { getFlags } from "@e2e/bridge/server";
 
-import type { OptionalFeatureMap, Features } from "@shared/feature-flags";
+import type { PartialFeatures, Features } from "@shared/feature-flags";
 
 const FF_LWM_WALLET_40_Q1 = {
   lwmWallet40: {
@@ -14,14 +14,14 @@ const FF_LWM_WALLET_40_Q1 = {
       operationsList: false,
       aggregatedAssets: false,
       myWallet: false,
+      pnl: false,
       earnUpselling: false,
       earnSimulator: false,
-      onboardingWidget: false,
       assetDiscoverability: false,
       q2Tour: false,
     },
   },
-} satisfies OptionalFeatureMap;
+} satisfies PartialFeatures;
 
 export const FF_LWM_WALLET_40_Q2 = {
   lwmWallet40: {
@@ -34,14 +34,14 @@ export const FF_LWM_WALLET_40_Q2 = {
       operationsList: true,
       aggregatedAssets: true,
       myWallet: true,
+      pnl: true,
       earnUpselling: true,
       earnSimulator: true,
-      onboardingWidget: true,
       assetDiscoverability: true,
       q2Tour: false,
     },
   },
-} satisfies OptionalFeatureMap;
+} satisfies PartialFeatures;
 
 export const FF_BORROW_ENABLED = {
   ...FF_LWM_WALLET_40_Q2,
@@ -57,15 +57,15 @@ export const FF_BORROW_ENABLED = {
   lwmWallet40: {
     ...FF_LWM_WALLET_40_Q2.lwmWallet40,
     params: {
-      ...FF_LWM_WALLET_40_Q2.lwmWallet40?.params,
+      ...FF_LWM_WALLET_40_Q2.lwmWallet40.params,
       pnl: true,
     },
   },
-} satisfies OptionalFeatureMap;
+} satisfies PartialFeatures;
 
 export const FF_NEW_SEND_FLOW_FIRST_INTERACTION_BANNER_ENABLED = {
   newSendFlowFirstInteractionBanner: { enabled: true },
-} satisfies OptionalFeatureMap;
+} satisfies PartialFeatures;
 
 export const FF_NEW_SEND_FLOW_ENABLED = {
   newSendFlow: {
@@ -77,12 +77,12 @@ export const FF_NEW_SEND_FLOW_ENABLED = {
   },
   useDeviceActionSignatureSend: { enabled: true }, // Note: Prevent usage of DIE, which is not Speculos ready yet.
   ...FF_NEW_SEND_FLOW_FIRST_INTERACTION_BANNER_ENABLED,
-} satisfies OptionalFeatureMap;
+} satisfies PartialFeatures;
 
 export const getMergedFeatureFlags = ({
   testFlags,
-}: { testFlags?: OptionalFeatureMap } = {}): OptionalFeatureMap => {
-  const ffPresetMap: Record<string, OptionalFeatureMap> = {
+}: { testFlags?: PartialFeatures } = {}): PartialFeatures => {
+  const ffPresetMap: Record<string, PartialFeatures> = {
     /*
      * The keys here are the values of the `E2E_MOBILE_FEATURE_FLAGS` environment variable.
      * We can add more mappings here in the future to test different feature flag combinations.
@@ -93,7 +93,7 @@ export const getMergedFeatureFlags = ({
     "wallet40-q1": FF_LWM_WALLET_40_Q1,
   };
 
-  const defaultFlags: OptionalFeatureMap = {
+  const defaultFlags: PartialFeatures = {
     // explicit defaults
     onboardingWidget: {
       enabled: true,
@@ -120,7 +120,7 @@ export const getMergedFeatureFlags = ({
   };
 
   // parse JSON override flags for any overrides
-  const jsonOverrideFlags: OptionalFeatureMap = parseExtraFeatureFlags(
+  const jsonOverrideFlags: PartialFeatures = parseExtraFeatureFlags<PartialFeatures>(
     process.env.E2E_FEATURE_FLAGS_JSON,
   );
 
@@ -133,7 +133,7 @@ export const getMergedFeatureFlags = ({
 };
 
 const getLwmWallet40StaticFlag = (): Features["lwmWallet40"] | undefined =>
-  getMergedFeatureFlags().lwmWallet40 as Features["lwmWallet40"] | undefined;
+  getMergedFeatureFlags().lwmWallet40;
 
 export const isQ2WithAggregatedAssets = (): boolean => {
   const lwmWallet40 = getLwmWallet40StaticFlag();
@@ -147,10 +147,8 @@ export const isQ2WithOperationsList = (): boolean => {
 
 const getLwmFlag = async (): Promise<Features["lwmWallet40"] | undefined> => {
   const flags = await getFlags();
-  if (!flags.trim()) {
-    return undefined; // avoid parse errors
-  }
-  return JSON.parse(flags).lwmWallet40 as Features["lwmWallet40"];
+  const parsed = parseExtraFeatureFlags<PartialFeatures>(flags);
+  return parsed.lwmWallet40;
 };
 
 export const isAssetDiscoverabilityEnabled = async (): Promise<boolean> => {

--- a/e2e/mobile/utils/initUtil.ts
+++ b/e2e/mobile/utils/initUtil.ts
@@ -15,7 +15,7 @@ import {
 import { waitForSpeculosReady } from "@ledgerhq/live-e2e-shared/speculosCI";
 import { sanitizeError } from "@ledgerhq/live-e2e-shared/index";
 
-import type { Features, OptionalFeatureMap } from "@shared/feature-flags";
+import type { PartialFeatures } from "@shared/feature-flags";
 
 function checkTestFailed(): void {
   if (globalThis.IS_FAILED) {
@@ -41,7 +41,7 @@ export type InitOptions = {
   }[];
   userdata?: string;
   testedCurrencies?: string[];
-  featureFlags?: OptionalFeatureMap;
+  featureFlags?: PartialFeatures;
   speculosForSetupOnly?: boolean;
 };
 
@@ -376,9 +376,9 @@ export class InitializationManager {
     await loadConfig(userdataSpeculos, true);
   }
 
-  static async setFeatureFlags(featureFlags: OptionalFeatureMap) {
+  static async setFeatureFlags(featureFlags: PartialFeatures) {
     const mergedFeatureFlags = getMergedFeatureFlags({ testFlags: featureFlags });
-    const wallet40 = mergedFeatureFlags.lwmWallet40 as Features["lwmWallet40"];
+    const wallet40 = mergedFeatureFlags.lwmWallet40;
     isMyWalletEnabled = Boolean(wallet40?.enabled && wallet40?.params?.myWallet);
 
     await allure.attachment(

--- a/shared/feature-flags/src/define.ts
+++ b/shared/feature-flags/src/define.ts
@@ -36,7 +36,9 @@ export function flagWith<P extends z.ZodRawShape>(
   return FeatureSchema.extend({ params: z.object(params).optional() }).default({
     enabled: false,
     ...defaults,
-  });
+  }) as z.ZodDefault<
+    z.ZodType<z.infer<typeof FeatureSchema> & { params?: z.output<z.ZodObject<P>> }>
+  >;
 }
 
 /**


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR improves feature-flag typing by switching E2E utilities/tests to use PartialFeatures (keyed by FeatureId → correct per-flag type), and updates the flagWith helper typing so Zod-inferred flag types preserve the params shape more accurately.

### 🔗 Context

- E2E Desktop [Run](https://github.com/LedgerHQ/ledger-live/actions/runs/33367779824)
- E2E Mobile [Run](https://github.com/LedgerHQ/ledger-live/actions/runs/33367745707)
