### PR TITLE
[LWD] fix(webview): guard Live App calls on a detached guest (LIVE-36595)

### DIFF
--- a/.changeset/smooth-webviews-guard.md
+++ b/.changeset/smooth-webviews-guard.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Guard Live App webview calls against a detached Electron guest so top bar actions and the network error retry no-op instead of throwing

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -30,7 +30,7 @@ import { flattenAccountsSelector } from "~/renderer/reducers/accounts";
 import BigSpinner from "../BigSpinner";
 import { NetworkErrorScreen } from "./NetworkError";
 import { DappAccountGate } from "./DappAccountGate";
-import { useWebviewState } from "./helpers";
+import { getAttachedWebview, useWebviewState } from "./helpers";
 import { Loader as StyledLoader } from "./styled";
 import { WebviewAPI, WebviewProps, WebviewTag } from "./types";
 import { HOOKS_TRACKING_LOCATIONS } from "~/renderer/analytics/hooks/variables";
@@ -316,7 +316,7 @@ function useWebView(
 
   const webviewHook = useMemo(() => {
     return {
-      reload: () => webviewRef.current?.reloadIgnoringCache(),
+      reload: () => getAttachedWebview(webviewRef)?.reloadIgnoringCache(),
       postMessage: (message: string) => {
         const webview = webviewRef.current;
         if (webview) {

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.test.ts
@@ -1,8 +1,9 @@
 import { act, renderHook } from "tests/testSetup";
-import { useWebviewState } from "./helpers";
+import { getAttachedWebview, useWebviewState } from "./helpers";
 import { getInitialURL } from "@ledgerhq/live-common/wallet-api/helpers";
 import type { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
-import type { WebviewTag } from "./types";
+import type { WebviewAPI, WebviewTag } from "./types";
+import type { RefObject } from "react";
 
 jest.mock("@ledgerhq/live-common/wallet-api/helpers", () => ({
   getInitialURL: jest.fn(),
@@ -13,7 +14,7 @@ jest.mock("@ledgerhq/live-common/wallet-api/manifestDomainUtils", () => ({
 }));
 
 jest.mock("@ledgerhq/live-common/wallet-api/react", () => ({
-  safeGetRefValue: jest.fn(),
+  useDAppManifestCurrencyIds: jest.fn(() => []),
 }));
 
 const mockManifest: LiveAppManifest = {
@@ -41,6 +42,41 @@ const mockManifest: LiveAppManifest = {
 };
 
 const mockGetInitialURL = jest.mocked(getInitialURL);
+
+const createWebview = (getWebContentsId: () => number) =>
+  ({
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    getWebContentsId,
+    reload: jest.fn(),
+    goBack: jest.fn(),
+    goForward: jest.fn(),
+    openDevTools: jest.fn(),
+    clearHistory: jest.fn(),
+    loadURL: jest.fn(() => Promise.resolve()),
+  }) as unknown as WebviewTag;
+
+describe("getAttachedWebview", () => {
+  it("returns null when the ref holds no node", () => {
+    expect(getAttachedWebview({ current: null })).toBeNull();
+  });
+
+  it("returns the node while its guest is attached", () => {
+    const webview = createWebview(() => 42);
+
+    expect(getAttachedWebview({ current: webview })).toBe(webview);
+  });
+
+  it("returns null once Electron dropped the guest", () => {
+    const webview = createWebview(() => {
+      throw new Error(
+        "The WebView must be attached to the DOM and the dom-ready event emitted before this method can be called.",
+      );
+    });
+
+    expect(getAttachedWebview({ current: webview })).toBeNull();
+  });
+});
 
 describe("useWebviewState", () => {
   beforeEach(() => {
@@ -125,6 +161,96 @@ describe("useWebviewState", () => {
       const { result } = renderHook(() => useWebviewState({ manifest: manifestWithCache }, null));
 
       expect(result.current.webviewPartition).toEqual({ partition: "persist:myapp-2" });
+    });
+  });
+
+  describe("guest liveness guard", () => {
+    const attached = () => createWebview(() => 42);
+    const detached = () =>
+      createWebview(() => {
+        throw new Error(
+          "The WebView must be attached to the DOM and the dom-ready event emitted before this method can be called.",
+        );
+      });
+
+    const renderWithWebview = (webview: WebviewTag) => {
+      mockGetInitialURL.mockReturnValue("https://example.com/");
+      const webviewAPIRef: RefObject<WebviewAPI | null> = { current: null };
+
+      const { result } = renderHook(() =>
+        useWebviewState({ manifest: mockManifest }, webviewAPIRef),
+      );
+
+      act(() => {
+        result.current.setWebviewRef(webview);
+      });
+
+      return { result, webviewAPIRef };
+    };
+
+    it("drives the webview while its guest is attached", async () => {
+      const webview = attached();
+      const { result, webviewAPIRef } = renderWithWebview(webview);
+
+      webviewAPIRef.current?.reload();
+      webviewAPIRef.current?.goBack();
+      webviewAPIRef.current?.goForward();
+      webviewAPIRef.current?.openDevTools();
+      result.current.handleRefresh();
+      await expect(
+        webviewAPIRef.current?.loadURL("https://example.com/x"),
+      ).resolves.toBeUndefined();
+
+      expect(webview.reload).toHaveBeenCalledTimes(2);
+      expect(webview.goBack).toHaveBeenCalledTimes(1);
+      expect(webview.goForward).toHaveBeenCalledTimes(1);
+      expect(webview.openDevTools).toHaveBeenCalledTimes(1);
+      expect(webview.loadURL).toHaveBeenCalledWith("https://example.com/x");
+    });
+
+    it("no-ops instead of throwing once the element left the DOM", () => {
+      // Electron drops the guest on detach, so every forwarded call throws. A top bar
+      // button or the network error retry can still reach the node during teardown.
+      const webview = detached();
+      const { result, webviewAPIRef } = renderWithWebview(webview);
+
+      expect(() => webviewAPIRef.current?.reload()).not.toThrow();
+      expect(() => webviewAPIRef.current?.goBack()).not.toThrow();
+      expect(() => webviewAPIRef.current?.goForward()).not.toThrow();
+      expect(() => webviewAPIRef.current?.openDevTools()).not.toThrow();
+      expect(() => webviewAPIRef.current?.clearHistory()).not.toThrow();
+      expect(() => result.current.handleRefresh()).not.toThrow();
+
+      expect(webview.reload).not.toHaveBeenCalled();
+      expect(webview.goBack).not.toHaveBeenCalled();
+      expect(webview.goForward).not.toHaveBeenCalled();
+      expect(webview.openDevTools).not.toHaveBeenCalled();
+      expect(webview.clearHistory).not.toHaveBeenCalled();
+    });
+
+    it("no-ops before the ref holds a node at all", async () => {
+      mockGetInitialURL.mockReturnValue("https://example.com/");
+      const webviewAPIRef: RefObject<WebviewAPI | null> = { current: null };
+
+      const { result } = renderHook(() =>
+        useWebviewState({ manifest: mockManifest }, webviewAPIRef),
+      );
+
+      expect(() => webviewAPIRef.current?.reload()).not.toThrow();
+      expect(() => result.current.handleRefresh()).not.toThrow();
+      await expect(webviewAPIRef.current?.loadURL("https://example.com/x")).rejects.toThrow(
+        "Webview is not attached",
+      );
+    });
+
+    it("rejects loadURL when detached so callers keep their fallback", async () => {
+      const webview = detached();
+      const { webviewAPIRef } = renderWithWebview(webview);
+
+      await expect(webviewAPIRef.current?.loadURL("https://example.com/x")).rejects.toThrow(
+        "Webview is not attached",
+      );
+      expect(webview.loadURL).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.ts
@@ -13,7 +13,6 @@ import { getInitialURL } from "@ledgerhq/live-common/wallet-api/helpers";
 import { isUrlAllowedByManifestDomains } from "@ledgerhq/live-common/wallet-api/manifestDomainUtils";
 import {
   SetCurrentAccountHistDb,
-  safeGetRefValue,
   useDAppManifestCurrencyIds,
 } from "@ledgerhq/live-common/wallet-api/react";
 import { WalletAPIServer } from "@ledgerhq/live-common/wallet-api/types";
@@ -46,6 +45,29 @@ type UseWebviewStateParams = {
 type WebviewPartition = {
   partition?: string;
 };
+
+/**
+ * Electron drops a `<webview>`'s guest as soon as the element leaves the DOM, and every
+ * guest-forwarded method then throws "The WebView must be attached to the DOM and the
+ * dom-ready event emitted before this method can be called." A holder of the ref (a top
+ * bar button, the network error retry, the wallet-api reload hook) can still reach the
+ * node during a teardown race, so probe liveness with `getWebContentsId` — the cheapest
+ * forwarded call — and let callers no-op instead of throwing.
+ */
+export function getAttachedWebview(ref: RefObject<WebviewTag | null>): WebviewTag | null {
+  const webview = ref.current;
+  if (!webview) {
+    return null;
+  }
+
+  try {
+    webview.getWebContentsId();
+  } catch {
+    return null;
+  }
+
+  return webview;
+}
 
 type UseWebviewStateReturn = {
   webviewState: WebviewState;
@@ -89,24 +111,16 @@ export function useWebviewState(
   useImperativeHandle(webviewAPIRef, () => {
     return {
       reload: () => {
-        const webview = safeGetRefValue(webviewRef);
-
-        webview.reload();
+        getAttachedWebview(webviewRef)?.reload();
       },
       goBack: () => {
-        const webview = safeGetRefValue(webviewRef);
-
-        webview.goBack();
+        getAttachedWebview(webviewRef)?.goBack();
       },
       goForward: () => {
-        const webview = safeGetRefValue(webviewRef);
-
-        webview.goForward();
+        getAttachedWebview(webviewRef)?.goForward();
       },
       openDevTools: () => {
-        const webview = safeGetRefValue(webviewRef);
-
-        webview.openDevTools();
+        getAttachedWebview(webviewRef)?.openDevTools();
       },
       loadURL: (url: string): Promise<void> => {
         if (
@@ -115,14 +129,16 @@ export function useWebviewState(
         ) {
           return Promise.reject(new Error("URL not allowed by manifest domains"));
         }
-        const webview = safeGetRefValue(webviewRef);
+        const webview = getAttachedWebview(webviewRef);
+        if (!webview) {
+          // Callers fall back to router navigation when the webview cannot be driven.
+          return Promise.reject(new Error("Webview is not attached"));
+        }
 
         return webview.loadURL(url);
       },
       clearHistory: () => {
-        const webview = safeGetRefValue(webviewRef);
-
-        webview.clearHistory();
+        getAttachedWebview(webviewRef)?.clearHistory();
       },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       notify: (method: `event.${string}`, params: any) => {
@@ -252,8 +268,7 @@ export function useWebviewState(
   }, []);
 
   const handleRefresh = useCallback(() => {
-    const webview = safeGetRefValue(webviewRef);
-    webview.reload();
+    getAttachedWebview(webviewRef)?.reload();
   }, [webviewRef]);
 
   useEffect(() => {


### PR DESCRIPTION
### 📝 Description

Datadog RUM reports uncaught `The WebView must be attached to the DOM and the dom-ready event emitted before this method can be called.` on `ledger-live-desktop`.

Every `<webview>` method forwarded to the guest (`reload`, `goBack`, `goForward`, `loadURL`, `clearHistory`, `openDevTools`, …) resolves `getWebContentsId()` first, which throws that message when the element has no attached guest. Verified against Electron 43.1.1 — the version we ship: the guest is dropped **only** when the element leaves the DOM; `display:none` on the element or an ancestor, and a guest renderer crash (`render-process-gone`), do not drop it. So the previous behaviour was an uncaught throw whenever a ref holder (a top bar button, the network error retry, the wallet-api reload hook) reached the node during a teardown race, and the button silently did nothing.

`getAttachedWebview()` now probes liveness with `getWebContentsId()` before each forwarded call — the same pattern already used in `useRestoreFocusOnDialogClose` — so those calls no-op instead of throwing. `loadURL` rejects rather than resolving, which keeps `WebPTXPlayer/TopBar` hitting its `BACK_FALLBACK_ROUTES` fallback.

`safeGetRefValue` is dropped from these paths: it only asserted `ref.current != null`, which was never the failing condition.

Regression cover in `helpers.test.ts`: attached still drives the webview, detached no-ops without throwing, and `loadURL` keeps its rejection contract.

> [!NOTE]
> Deliberately not added to `datadog/ignoreErrors.ts` — with the guard in place the throw is gone at the source, and leaving the message un-ignored means a future regression that drives a dead webview still surfaces.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36595](https://ledgerhq.atlassian.net/browse/LIVE-36595)
- **ADR** (if any): n/a


[LIVE-36595]: https://ledgerhq.atlassian.net/browse/LIVE-36595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ