### PR TITLE
[LWM] feat(analytics): log identify in the mobile overlay (LIVE-35845)

### DIFF
--- a/.changeset/calm-identify-overlay.md
+++ b/.changeset/calm-identify-overlay.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Log Segment identify calls (enqueued or failed) in the mobile analytics debug overlay

--- a/apps/ledger-live-mobile/src/analytics/__tests__/segment.deliveryAndFlush.test.ts
+++ b/apps/ledger-live-mobile/src/analytics/__tests__/segment.deliveryAndFlush.test.ts
@@ -16,8 +16,10 @@ jest.mock("@datadog/mobile-react-native", () => ({
 
 const segmentSdk = require("@segment/analytics-react-native") as {
   createClient: jest.Mock;
+  _identifyMock: jest.Mock;
   _trackMock: jest.Mock;
 };
+const mockIdentify = segmentSdk._identifyMock;
 const mockTrack = segmentSdk._trackMock;
 const mockDdWarn = jest.mocked(DdLogs.warn);
 
@@ -260,6 +262,89 @@ describe("segment analytics delivery", () => {
           deliveryStatus: "failed",
         }),
       ]);
+    });
+  });
+
+  describe("identify overlay", () => {
+    it("should log [Identify] next to Start when analytics starts with tracking on", async () => {
+      store.dispatch(setAnalytics(true));
+      logged.length = 0;
+
+      await segment.start(store);
+
+      expect(logged.map(event => event.eventName)).toEqual(["[Identify]", "Start"]);
+      expect(logged[0]).toEqual(
+        expect.objectContaining({
+          eventName: "[Identify]",
+          eventProperties: { userIdPresent: expect.any(Boolean) },
+          deliveryStatus: "enqueued",
+        }),
+      );
+      expect(logged[1]).toEqual(
+        expect.objectContaining({
+          eventName: "Start",
+          deliveryStatus: "enqueued",
+        }),
+      );
+    });
+
+    it("should keep track, screen and flush overlay entries after identify", async () => {
+      await startWithTracking();
+      pendingEvents.mockResolvedValue(2);
+
+      await segment.updateIdentify();
+      await segment.track("TestEvent", { foo: "bar" });
+      await segment.screen("Portfolio", "Detail");
+      await segment.flush();
+
+      expect(logged.map(event => event.eventName)).toEqual([
+        "[Identify]",
+        "TestEvent",
+        "Page Portfolio Detail",
+        "[Flush]",
+      ]);
+    });
+
+    it("should log [Identify] as enqueued after a successful identify", async () => {
+      await startWithTracking();
+      mockIdentify.mockClear();
+
+      await segment.updateIdentify();
+
+      expect(mockIdentify).toHaveBeenCalledTimes(1);
+      expect(logged).toEqual([
+        expect.objectContaining({
+          eventName: "[Identify]",
+          eventProperties: { userIdPresent: expect.any(Boolean) },
+          deliveryStatus: "enqueued",
+        }),
+      ]);
+    });
+
+    it("should log [Identify] as failed and not throw when the Segment client rejects", async () => {
+      await startWithTracking();
+      mockIdentify.mockRejectedValueOnce(new Error("sdk down"));
+
+      await expect(segment.updateIdentify()).resolves.toBeUndefined();
+
+      expect(logged).toEqual([
+        expect.objectContaining({
+          eventName: "[Identify]",
+          eventProperties: { userIdPresent: expect.any(Boolean) },
+          deliveryStatus: "failed",
+        }),
+      ]);
+    });
+
+    it("should not log [Identify] when tracking consent is off", async () => {
+      await segment.start(store);
+      jest.clearAllMocks();
+      logged.length = 0;
+
+      await segment.updateIdentify();
+
+      expect(mockIdentify).not.toHaveBeenCalled();
+      expect(logged).toEqual([]);
     });
   });
 

--- a/apps/ledger-live-mobile/src/analytics/__tests__/segment.noStore.test.ts
+++ b/apps/ledger-live-mobile/src/analytics/__tests__/segment.noStore.test.ts
@@ -31,6 +31,12 @@ describe("segment before start()", () => {
     ]);
   });
 
+  it("should not log [Identify] when the store is not initialised", async () => {
+    await segment.updateIdentify();
+
+    expect(logged).toEqual([]);
+  });
+
   it("should log screen as skipped_no_store when the store is not initialised", async () => {
     await segment.screen("Portfolio", "Detail");
 

--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -601,10 +601,27 @@ export const updateIdentify = async (additionalProperties?: UserTraits, mandator
     : baseProperties;
   if (ANALYTICS_LOGS) console.log("analytics:identify", allProperties);
   if (!token) return;
+  if (!segmentClient) return;
   const segmentUserId = shouldIncludeSegmentIdentity(state)
     ? userExtraProperties.userId
     : undefined;
-  await segmentClient?.identify(segmentUserId, allProperties);
+  const overlayProperties = { userIdPresent: Boolean(segmentUserId) };
+  try {
+    await segmentClient.identify(segmentUserId, allProperties);
+    trackSubject.next({
+      eventName: "[Identify]",
+      eventProperties: overlayProperties,
+      date: new Date(),
+      deliveryStatus: "enqueued",
+    });
+  } catch {
+    trackSubject.next({
+      eventName: "[Identify]",
+      eventProperties: overlayProperties,
+      date: new Date(),
+      deliveryStatus: "failed",
+    });
+  }
 };
 
 type Properties = Error | Record<string, unknown> | null;


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

The mobile analytics debug overlay already shows `track`, `screen`, and `[Flush]`, but `updateIdentify` called Segment without publishing anything to `trackSubject`. When debugging why a user's traits do not match their events, there was no way to see whether identify ran, or in which order relative to tracks.

`updateIdentify` now publishes an overlay entry after the Segment call:

- `[Identify]` with `enqueued`, or `failed` if the SDK rejects (previously the rejection propagated and nothing was shown)
- properties are limited to `{ userIdPresent }` — never traits or the user id itself, since the overlay is on screen
- still silent on the early returns: no store, tracking disabled, no token, no client

Nothing changes in what is sent to Segment: same traits, same user id, same timing, same Braze debounce. The overlay only exists behind the `ANALYTICS_CONSOLE` debug env, so there is no impact on users.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35845](https://ledgerhq.atlassian.net/browse/LIVE-35845)
- **ADR** (if any): n/a

### Test plan

Covered by unit tests in `src/analytics/__tests__`:

- [x] `[Identify]` is logged as `enqueued` after a successful identify
- [x] `[Identify]` is logged as `failed` when the Segment client rejects, without throwing
- [x] `[Identify]` appears alongside `Start` when analytics starts with tracking on
- [x] `track`, `screen` and `[Flush]` overlay entries are unaffected
- [x] no overlay entry when tracking is off or the store is not initialised

Manual check:

- [ ] Enable the analytics console (Settings → Debug) and confirm `[Identify]` shows up next to tracks

[LIVE-35845]: https://ledgerhq.atlassian.net/browse/LIVE-35845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ