### PR TITLE
[LWD] fix(live-dmk-desktop): wait for an available device (LIVE-35022)

### DIFF
--- a/.changeset/dmk-desktop-empty-device-list-guard.md
+++ b/.changeset/dmk-desktop-empty-device-list-guard.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-dmk-desktop": minor
+"ledger-live-desktop": minor
+---
+
+Fix the DMK desktop transport connecting to an undefined device when no device is available yet

--- a/apps/ledger-live-desktop/src/renderer/live-common-setup.ts
+++ b/apps/ledger-live-desktop/src/renderer/live-common-setup.ts
@@ -90,7 +90,7 @@ export function registerTransportModules(store: Store<State>) {
         },
       });
 
-      return DeviceManagementKitTransport.open();
+      return DeviceManagementKitTransport.open(timeoutMs);
     },
 
     disconnect: () => Promise.resolve(),

--- a/libs/live-dmk-desktop/src/transport/DeviceManagementKitTransport.test.ts
+++ b/libs/live-dmk-desktop/src/transport/DeviceManagementKitTransport.test.ts
@@ -1,4 +1,4 @@
-import { of, Subject, Observable } from "rxjs";
+import { BehaviorSubject, of, Subject, Observable } from "rxjs";
 import {
   ConnectedDevice,
   DeviceModelId,
@@ -7,6 +7,8 @@ import {
   DeviceSessionState,
   DeviceManagementKit,
 } from "@ledgerhq/device-management-kit";
+import { CantOpenDevice } from "@ledgerhq/hw-transport/errors";
+import { activeDeviceSessionSubject } from "@ledgerhq/live-dmk-shared";
 import { DeviceManagementKitTransport } from "./DeviceManagementKitTransport";
 import { getDeviceManagementKit } from "../hooks/useDeviceManagementKit";
 
@@ -271,5 +273,42 @@ describe("DeviceManagementKitTransport", () => {
         device: testDevice2,
       }),
     );
+  });
+
+  // Mirrors the real WebHID transport, whose device list starts as an empty array.
+  describe("open with no device available yet", () => {
+    let availableDevices: BehaviorSubject<DiscoveredDevice[]>;
+
+    beforeEach(() => {
+      activeDeviceSessionSubject.next(null);
+      availableDevices = new BehaviorSubject<DiscoveredDevice[]>([]);
+      jest
+        .spyOn(deviceManagementKit, "listenToAvailableDevices")
+        .mockReturnValue(availableDevices.asObservable());
+      jest
+        .spyOn(deviceManagementKit, "getDeviceSessionState")
+        .mockReturnValue(new Subject<DeviceSessionState>());
+    });
+
+    afterEach(() => {
+      activeDeviceSessionSubject.next(null);
+    });
+
+    it("should skip the empty list and connect to the first device that shows up", async () => {
+      const connect = jest.spyOn(deviceManagementKit, "connect").mockResolvedValue("session-456");
+
+      const opening = DeviceManagementKitTransport.open();
+      availableDevices.next([testDevice1]);
+
+      await expect(opening).resolves.toBeInstanceOf(DeviceManagementKitTransport);
+      expect(connect).toHaveBeenCalledWith(expect.objectContaining({ device: testDevice1 }));
+    });
+
+    it("should throw CantOpenDevice instead of connecting to an undefined device", async () => {
+      const connect = jest.spyOn(deviceManagementKit, "connect");
+
+      await expect(DeviceManagementKitTransport.open(10)).rejects.toBeInstanceOf(CantOpenDevice);
+      expect(connect).not.toHaveBeenCalled();
+    });
   });
 });

--- a/libs/live-dmk-desktop/src/transport/DeviceManagementKitTransport.ts
+++ b/libs/live-dmk-desktop/src/transport/DeviceManagementKitTransport.ts
@@ -6,12 +6,47 @@ import {
   DiscoveredDevice,
 } from "@ledgerhq/device-management-kit";
 import Transport, { type DescriptorEvent } from "@ledgerhq/hw-transport";
+import { CantOpenDevice, DisconnectedDevice } from "@ledgerhq/hw-transport/errors";
 import { dmkToLedgerDeviceIdMap, activeDeviceSessionSubject } from "@ledgerhq/live-dmk-shared";
 import { LocalTracer } from "@ledgerhq/logs";
-import { firstValueFrom, Observer, startWith, pairwise, map, Subscription } from "rxjs";
+import {
+  firstValueFrom,
+  first,
+  Observer,
+  startWith,
+  pairwise,
+  map,
+  Subscription,
+  timeout,
+} from "rxjs";
 import { getDeviceManagementKit } from "../hooks/useDeviceManagementKit";
 
 const tracer = new LocalTracer("live-dmk-tracer", { function: "DeviceManagementKitTransport" });
+
+const DEFAULT_DISCOVERY_TIMEOUT_MS = 5000;
+
+/**
+ * Waits for the first non empty list of available devices.
+ *
+ * `listenToAvailableDevices` is backed by a BehaviorSubject seeded with an empty array and
+ * populated asynchronously, so its first emission is `[]` as long as no device has been
+ * enumerated yet. Taking that emission blindly hands `undefined` to `dmk.connect`, which then
+ * fails with a `TypeError` instead of a device error.
+ */
+const discoverFirstAvailableDevice = async (
+  timeoutMs: number = DEFAULT_DISCOVERY_TIMEOUT_MS,
+): Promise<DiscoveredDevice> => {
+  const devices = await firstValueFrom(
+    getDeviceManagementKit()
+      .listenToAvailableDevices({})
+      .pipe(
+        first(availableDevices => availableDevices.length > 0),
+        timeout(timeoutMs),
+      ),
+  );
+
+  return devices[0];
+};
 
 export class DeviceManagementKitTransport extends Transport {
   sessionId: string;
@@ -47,7 +82,7 @@ export class DeviceManagementKitTransport extends Transport {
     return subscription;
   };
 
-  static async open(): Promise<DeviceManagementKitTransport> {
+  static async open(timeoutMs?: number): Promise<DeviceManagementKitTransport> {
     const activeSessionId = activeDeviceSessionSubject.value?.sessionId;
 
     if (activeSessionId) {
@@ -69,9 +104,11 @@ export class DeviceManagementKitTransport extends Transport {
     }
 
     tracer.trace("[open] No active session found, starting discovery");
-    const [discoveredDevice] = await firstValueFrom(
-      getDeviceManagementKit().listenToAvailableDevices({}),
-    );
+    const discoveredDevice = await discoverFirstAvailableDevice(timeoutMs).catch(error => {
+      tracer.trace("[open] no available device found", { error });
+      throw new CantOpenDevice("No available device found");
+    });
+
     const connectedSessionId = await getDeviceManagementKit().connect({
       device: discoveredDevice,
       sessionRefresherOptions: { isRefresherDisabled: true },
@@ -262,9 +299,11 @@ export class DeviceManagementKitTransport extends Transport {
 
     // If the device is not connected, connect to new session
     if (!devices.some(device => device.sessionId === this.sessionId)) {
-      const [discoveredDevice] = await firstValueFrom(
-        getDeviceManagementKit().listenToAvailableDevices({}),
-      );
+      const discoveredDevice = await discoverFirstAvailableDevice().catch(error => {
+        tracer.trace("[exchange] no available device found", { error });
+        throw new DisconnectedDevice();
+      });
+
       const connectedSessionId = await getDeviceManagementKit().connect({
         device: discoveredDevice,
         sessionRefresherOptions: { isRefresherDisabled: true },


### PR DESCRIPTION
### 📝 Description

`DeviceManagementKitTransport.open()` took the **first** emission of `dmk.listenToAvailableDevices({})` and destructured `[discoveredDevice]` out of it. On desktop that observable is backed by a `BehaviorSubject` seeded with an empty array and populated asynchronously from `navigator.hid.getDevices()`, so its first emission is `[]` whenever no Ledger has been enumerated yet. `dmk.connect({ device: undefined })` then throws inside `ConnectUseCase.execute`, which reads `device.transport`:

```
TypeError: Cannot read properties of undefined (reading 'transport')
  at nW.execute   → ConnectUseCase.execute        (reads device.transport)
  at aI.connect   → DeviceManagementKit.connect
  at ed.open      → DeviceManagementKitTransport.open
```

`withDevice` in `hw/deviceAccess.ts` `console.error`s that `TypeError` before re-throwing it as `CantOpenDevice`, which is how it reaches Datadog error tracking. It accounts for ~635k of the ~670k errors reported for `ledger-live-desktop` over the last 7 days (≈95% of all error volume), ~2.9M occurrences over 30 days, and it is still firing on 4.17.1.

**Previous behaviour** — with no device plugged in, or before the HID device list has been populated, `open()` failed immediately with `TypeError: Cannot read properties of undefined (reading 'transport')`.

**Fix** — wait for the first non-empty device list, bounded by a timeout, and surface a real device error (`CantOpenDevice` in `open`, `DisconnectedDevice` in `exchange`) when nothing shows up. This is the guard every other DMK transport in the repo already had:

| Transport | Guard |
| --- | --- |
| `live-dmk-mobile` HID | `first(devices => devices.length > 0)` + `timeout(timeoutMs)` |
| `live-dmk-mobile` HTTP proxy | `filter(list => list.length > 0)` + `timeout(10_000)` |
| `live-dmk-speculos` | `filter(deviceList => deviceList.length > 0)` + `rxTimeout(timeout)` |
| `live-dmk-desktop` | *(none — this PR)* |

`open()` now also accepts the `timeoutMs` that the registered transport module already receives and used to drop, so callers passing `openTimeoutMs` get their deadline honoured inside the transport instead of only in the outer `Promise.race`.

**Regression check** — two unit tests in `DeviceManagementKitTransport.test.ts`. The existing suite mocked `listenToAvailableDevices` with `of([device])`, a single non-empty emission, which is why this was never caught; the new tests drive it from a `BehaviorSubject` seeded with `[]`, like the real WebHID transport.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35022](https://ledgerhq.atlassian.net/browse/LIVE-35022) — twin ticket [PROD-12576](https://ledgerhq.atlassian.net/browse/PROD-12576)
- Datadog issues covered by this fix (same root cause, split fingerprints):
  - [`7ab9e882`](https://app.datadoghq.eu/error-tracking/issue/7ab9e882-7c50-11f1-997f-da7ad0900005) — `ConnectUseCase.execute`
  - [`bb1b0ed8`](https://app.datadoghq.eu/error-tracking/issue/bb1b0ed8-9569-11f1-8f98-da7ad0900005) — `DeviceManagementKitTransport.open` (4.15+)
  - [`d035fa04`](https://app.datadoghq.eu/error-tracking/issue/d035fa04-7c3b-11f1-8796-da7ad0900005) — `DeviceManagementKitTransport.open` (4.10+)
  - [`2db3b9be`](https://app.datadoghq.eu/error-tracking/issue/2db3b9be-88a8-11f1-9a8d-da7ad0900005) — `DeviceManagementKitTransport.exchange`

### 📦 Builds

| Platform | Run |
|---|---|
| Desktop (macOS / Linux / Windows) | [run 33173098756](https://github.com/LedgerHQ/ledger-live-build/actions/runs/33173098756) |

Dispatched on `ledger-live-build` for `fix/live-dmk-LIVE-35022-guard-empty-device-list` at commit 4ed252494bf. Artifacts are attached to the run on completion. Desktop only — the diff is confined to `apps/ledger-live-desktop/**` and `libs/live-dmk-desktop/**`.

[LIVE-35022]: https://ledgerhq.atlassian.net/browse/LIVE-35022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
