### PR TITLE
fix(desktop): stabilize manifest submission and send validation

### DIFF
--- a/.changeset/semantic-button-validation.md
+++ b/.changeset/semantic-button-validation.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Use a reliable manifest submit handler and wait for recipient validation before send assertions.

--- a/apps/ledger-live-desktop/src/renderer/modals/CreateLocalManifest/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/CreateLocalManifest/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
-import React, { useCallback, useMemo, useState } from "react";
+import React, { FormEvent, MouseEvent, useCallback, useMemo, useState } from "react";
 import { Trans } from "react-i18next";
 import Button from "~/renderer/components/Button";
 import Modal, { ModalBody } from "~/renderer/components/Modal";
@@ -85,16 +85,13 @@ function FormLocalManifest({
     });
   }, []);
 
-  const submitHandler = (
-    e?: React.MouseEvent<HTMLButtonElement> | React.SyntheticEvent<HTMLFormElement>,
-  ) => {
-    if (e) {
-      e.preventDefault();
-    }
-    if (formIsValid) {
-      addLocalManifest(form);
-      onClose();
-    }
+  const submitHandler = (event: FormEvent<HTMLFormElement> | MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+
+    if (!LiveAppManifestSchema.safeParse(form).success) return;
+
+    addLocalManifest(form);
+    onClose();
   };
 
   const contentInput = useCallback(() => {
@@ -253,7 +250,7 @@ function FormLocalManifest({
   );
 
   return (
-    <form style={{ width: "90%", margin: "auto" }}>
+    <form noValidate onSubmit={submitHandler} style={{ width: "90%", margin: "auto" }}>
       <ModalBody
         onClose={onClose}
         title={<Trans i18nKey={`settings.developer.createLocalAppModal.title.create`} />}
@@ -378,6 +375,7 @@ function FormLocalManifest({
               <Flex width={"100%"} flexDirection={"row"} columnGap={3} justifyContent={"center"}>
                 <Button
                   small
+                  type="submit"
                   disabled={!formIsValid}
                   primary
                   onClick={submitHandler}

--- a/apps/ledger-live-desktop/tests/specs/send/newSendFlow.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/send/newSendFlow.spec.ts
@@ -195,6 +195,7 @@ test.describe("New Send Flow", () => {
 
       await test.step("Type an address not present in account OUT operations", async () => {
         await app.newSendFlow.typeAddress(TEST_ADDRESSES.newAddress);
+        await app.newSendFlow.waitForRecipientValidation();
       });
 
       await test.step("Verify recent history warning card is visible", async () => {

--- a/apps/ledger-live-desktop/tests/specs/settings/modal-create-manifest.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/settings/modal-create-manifest.spec.ts
@@ -29,6 +29,7 @@ test("Settings", async ({ page }) => {
   await test.step("create local manifest", async () => {
     await expect(settingsPage.createLocalManifestButton).toBeEnabled({ timeout: 60000 });
     await settingsPage.createLocalManifestButton.click();
+    await expect(settingsPage.createLocalManifestButton).toBeHidden({ timeout: 60000 });
     await expect(page.getByText("ReplaceAppName", { exact: true })).toBeVisible({ timeout: 60000 });
   });
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Targeted Desktop Playwright scenarios cover manifest creation and the recent-history warning.
- [x] **Impact of the changes:**
      Local manifest creation uses a single reliable submit handler for click and keyboard; the Send warning waits for completed recipient validation.

### 📝 Description

This PR stabilizes two Desktop E2E flows whose retries exposed missing synchronization or an ambiguous submission path.

The local-manifest modal now uses the same submit handler for the form and its CTA. A CTA click prevents the browser default and runs the handler once; Enter still follows the native form path. Both validate the schema before persisting and closing. The E2E test checks the modal closes before asserting the created manifest row.

The Send scenario waits for recipient validation before asserting the recent-history warning, rather than relying on a fixed assertion window.

### ❓ Context

- **GitHub Actions runs**: [32837409130](https://github.com/LedgerHQ/ledger-live/actions/runs/32837409130), [33065235119](https://github.com/LedgerHQ/ledger-live/actions/runs/33065235119), [33160382708](https://github.com/LedgerHQ/ledger-live/actions/runs/33160382708), [33095629795](https://github.com/LedgerHQ/ledger-live/actions/runs/33095629795), [33173855633](https://github.com/LedgerHQ/ledger-live/actions/runs/33173855633)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked GitHub Actions runs.
- **The PR description clearly documents the changes** made and explains the common submit-handler decision.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)