### PR TITLE
[LWM] feat(pay): cap contacts strip and add see-all (LIVE-35379)

### DIFF
--- a/.changeset/pay-contacts-see-all.md
+++ b/.changeset/pay-contacts-see-all.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-pay-contact": minor
+"live-mobile": minor
+---
+
+Cap the mobile Pay contacts strip at 8 and add a see-all control that opens the Contacts flow with a "Pay contact" page title.

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10132,7 +10132,8 @@
     },
     "contacts": {
       "title": "Pay",
-      "pay": "New"
+      "pay": "New",
+      "seeAllTitle": "Pay contact"
     }
   },
   "syncIndicator": {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageNavigationViewModel.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageNavigationViewModel.tsx
@@ -8,6 +8,7 @@ export function useContactsPageNavigationViewModel(
   addContactLabel: string,
   showAddContact: boolean,
   onAddContact: () => void,
+  title?: string,
 ) {
   const navigation =
     useNavigation<NativeStackNavigationProp<{ [key: string]: object | undefined }>>();
@@ -20,12 +21,13 @@ export function useContactsPageNavigationViewModel(
   );
 
   useLayoutEffect(() => {
-    const opts: Partial<LumenNativeStackNavigationOptions> = {
+    const options: Partial<LumenNativeStackNavigationOptions> = {
       lumenNavBar: {
         renderTrailing: showAddContact ? renderTrailing : undefined,
       },
+      ...(title !== undefined && { title }),
     };
 
-    navigation.setOptions(opts);
-  }, [navigation, renderTrailing, showAddContact]);
+    navigation.setOptions(options);
+  }, [navigation, renderTrailing, showAddContact, title]);
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/index.tsx
@@ -1,8 +1,10 @@
 import React, { useCallback, useLayoutEffect } from "react";
-import { useNavigation } from "@react-navigation/native";
+import { useNavigation, useRoute, type RouteProp } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { isContactsSearchNoResultsViewModel } from "@features/flow-contacts";
 import { useContactsFeature } from "@features/platform-contacts";
+import { ScreenName } from "~/const";
+import type { MyWalletNavigatorStackParamList } from "LLM/features/MyWallet/types";
 import { TrackScreen } from "~/analytics";
 import { ContactsPageContent } from "./components/ContactsPageContent";
 import { useContactsAddContactDrawerAdapter } from "./hooks/useContactsAddContactDrawerAdapter";
@@ -21,6 +23,8 @@ function ContactsScreenRedirect() {
 }
 
 function ContactsScreenContent() {
+  const { params } =
+    useRoute<RouteProp<MyWalletNavigatorStackParamList, typeof ScreenName.MyWalletContacts>>();
   const pageViewModel = useContactsPageViewModel();
   const { onSearchQueryChange } = pageViewModel;
   const onSaveSuccess = useCallback(() => {
@@ -40,6 +44,7 @@ function ContactsScreenContent() {
     pageViewModel.labels.addContact,
     !isContactsSearchNoResultsViewModel(pageViewModel.viewModel),
     onAddContact,
+    params?.title,
   );
 
   return <ContactsPageContent {...viewModel} />;

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/types.ts
@@ -12,6 +12,6 @@ export type MyWalletNavigatorStackParamList = {
       }
     | undefined;
   [ScreenName.MyWalletHelp]: undefined;
-  [ScreenName.MyWalletContacts]: undefined;
+  [ScreenName.MyWalletContacts]: { title?: string } | undefined;
   [ScreenName.MyWalletContactDetail]: { contactId: ContactId };
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
@@ -1,32 +1,28 @@
 import React from "react";
-import { Text, View } from "react-native";
+import { View } from "react-native";
 import Share from "react-native-share";
 import { captureRef } from "react-native-view-shot";
-import {
-  createNativeStackNavigator,
-  type NativeStackScreenProps,
-} from "@react-navigation/native-stack";
-import { render, screen, waitFor, within, withFlagOverrides } from "@tests/test-renderer";
-import { server, http, HttpResponse, delay } from "@tests/server";
-import { mockData } from "@ledgerhq/live-common/modularDrawer/__mocks__/dada.mock";
-import { mockStablecoinsResponse } from "@domain/api-aggregated-assets/mock/stablecoins";
+import { screen, waitFor, within } from "@tests/test-renderer";
 import { PAY_CARD_BALANCE_FILTER_ALL } from "@features/flow-pay-balance/state";
 import { AssetCategory } from "@domain/api-aggregated-assets";
-import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
-import { TokenCurrencySchema } from "@domain/entity-currency-token";
-import { getFiatCurrencyByTicker } from "@domain/entity-currency-fiat";
-import { importCountervalues } from "@ledgerhq/live-countervalues/logic";
-import { pairId } from "@ledgerhq/live-countervalues/helpers";
-import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { makeEmptyTokenAccount } from "@ledgerhq/ledger-wallet-framework/account/helpers";
-import { NavigatorName, ScreenName } from "~/const";
+import { ScreenName } from "~/const";
 import { track } from "~/analytics";
 import { screen as trackScreen } from "~/analytics/segment";
-import type { State } from "~/reducers/types";
-import PayTabNavigator from "LLM/features/PayTab";
-import { PayTabRequestReceiveScreen } from "LLM/features/PayTab/screens/RequestReceive";
-import type { PayTabNavigatorParamList } from "LLM/features/PayTab/types";
-import { ModularDrawerWrapper } from "LLM/features/ModularDrawer";
+import {
+  EMPTY_DESCRIPTION,
+  EMPTY_TITLE,
+  FEATURE_TOUR_CTA,
+  FEATURE_TOUR_ROW,
+  holdDada,
+  mockFullAssetCatalog,
+  payTabEthAccount,
+  renderPayTab,
+  renderRequestReceive,
+  seedContacts,
+  selectUsdcOnEthereum,
+  setDada,
+  usdc,
+} from "./shared";
 
 jest.mock("~/analytics", () => ({
   ...jest.requireActual("~/analytics"),
@@ -41,220 +37,6 @@ jest.mock("@features/flow-pay-card", () => ({
     </>
   ),
 }));
-
-const EMPTY_TITLE = "Pay and get paid";
-const EMPTY_DESCRIPTION = "Start by depositing stablecoin to your wallet";
-const FEATURE_TOUR_ROW = "Minimal volatility";
-const FEATURE_TOUR_CTA = "Got it";
-
-const ethereum = getCryptoCurrencyById("ethereum");
-const usd = getFiatCurrencyByTicker("USD");
-const usdc = TokenCurrencySchema.parse({
-  type: "TokenCurrency",
-  id: "ethereum/erc20/usd__coin",
-  parentCurrencyId: ethereum.id,
-  contractAddress: "0xA0b86991c6218b36c1D19D4a2e9Eb0cE3606eB48",
-  tokenType: "erc20",
-  ticker: "USDC",
-  name: "USD Coin",
-  units: [{ name: "USD Coin", code: "USDC", magnitude: 6 }],
-});
-const uni = TokenCurrencySchema.parse({
-  type: "TokenCurrency",
-  id: "ethereum/erc20/uniswap",
-  parentCurrencyId: ethereum.id,
-  contractAddress: "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
-  tokenType: "erc20",
-  ticker: "UNI",
-  name: "Uniswap",
-  units: [{ name: "Uniswap", code: "UNI", magnitude: 18 }],
-});
-const payTabEthAccount = genAccount("pay-tab-eth", { currency: ethereum });
-const payTabUsdcAccount = genTokenAccount(0, payTabEthAccount, usdc);
-const payTabUniAccount = genTokenAccount(0, payTabEthAccount, uni);
-
-type TestStackParamList = {
-  PayTabTest: undefined;
-  [NavigatorName.ReceiveFunds]: {
-    screen: ScreenName.ReceiveProvider;
-    params: { manifestId: string; fromMenu: boolean };
-  };
-};
-
-const Stack = createNativeStackNavigator<TestStackParamList>();
-
-function ReceiveFundsScreen({
-  route,
-}: NativeStackScreenProps<TestStackParamList, NavigatorName.ReceiveFunds>) {
-  return (
-    <Text testID="receive-funds-screen">
-      {route.params.screen}:{route.params.params.manifestId}
-    </Text>
-  );
-}
-
-const DADA_URLS = [
-  "https://dada.api.ledger-test.com/v1/assets",
-  "https://dada.api.ledger.com/v1/assets",
-];
-
-type RenderPayTabOptions = Readonly<{
-  hasSeenFeatureTour?: boolean;
-  holdsUsdc?: boolean;
-  holdsEmptyUsdc?: boolean;
-  holdsUni?: boolean;
-  cryptoOnly?: boolean;
-}>;
-
-function withUsdcHoldings(state: State): State {
-  return {
-    ...state,
-    accounts: { active: [{ ...payTabEthAccount, subAccounts: [payTabUsdcAccount] }] },
-    countervalues: {
-      ...state.countervalues,
-      countervalues: {
-        ...state.countervalues.countervalues,
-        state: importCountervalues(
-          { status: {}, [pairId({ from: usdc, to: usd })]: { latest: 1 } },
-          state.countervalues.userSettings,
-        ),
-      },
-    },
-  };
-}
-
-function withEmptyUsdcHoldings(state: State): State {
-  const emptyUsdc = makeEmptyTokenAccount(payTabEthAccount, usdc);
-  return {
-    ...state,
-    accounts: { active: [{ ...payTabEthAccount, subAccounts: [emptyUsdc] }] },
-  };
-}
-
-function withCryptoOnly(state: State): State {
-  return {
-    ...state,
-    accounts: { active: [{ ...payTabEthAccount, subAccounts: [] }] },
-  };
-}
-
-function withUniHoldings(state: State): State {
-  return {
-    ...state,
-    accounts: { active: [{ ...payTabEthAccount, subAccounts: [payTabUniAccount] }] },
-  };
-}
-
-function dadaResponse(request: Request) {
-  const categories = new URL(request.url).searchParams.get("categories");
-  if (categories === "stablecoins") return HttpResponse.json(mockStablecoinsResponse);
-  return HttpResponse.json(mockData);
-}
-
-function setDada(mode: "hang" | "error") {
-  server.use(
-    ...DADA_URLS.map(url =>
-      http.get(url, async ({ request }) => {
-        if (mode === "hang") await delay("infinite");
-        const isAmountQuery = new URL(request.url).searchParams.has("currencyIds");
-        if (isAmountQuery && mode === "error") return HttpResponse.json(null, { status: 500 });
-        return dadaResponse(request);
-      }),
-    ),
-  );
-}
-
-function holdDada() {
-  let release!: () => void;
-  const gate = new Promise<void>(resolve => {
-    release = resolve;
-  });
-  server.use(
-    ...DADA_URLS.map(url =>
-      http.get(url, async ({ request }) => {
-        await gate;
-        return dadaResponse(request);
-      }),
-    ),
-  );
-  return () => release();
-}
-
-function mockFullAssetCatalog() {
-  server.use(...DADA_URLS.map(url => http.get(url, () => HttpResponse.json(mockData))));
-}
-
-function renderPayTab({
-  hasSeenFeatureTour = true,
-  holdsUsdc = false,
-  holdsEmptyUsdc = false,
-  holdsUni = false,
-  cryptoOnly = false,
-}: RenderPayTabOptions = {}) {
-  return render(
-    <>
-      <Stack.Navigator screenOptions={{ headerShown: false, animation: "none" }}>
-        <Stack.Screen name="PayTabTest" component={PayTabNavigator} />
-        <Stack.Screen name={NavigatorName.ReceiveFunds} component={ReceiveFundsScreen} />
-      </Stack.Navigator>
-      <ModularDrawerWrapper />
-    </>,
-    {
-      overrideInitialState: withFlagOverrides(
-        {
-          llmModularDrawer: {
-            enabled: true,
-            params: { enableModularization: true, searchDebounceTime: 0 },
-          },
-        },
-        state => {
-          const next: State = {
-            ...state,
-            payCardFeatureTour: { ...state.payCardFeatureTour, hasSeenFeatureTour },
-          };
-          if (holdsUsdc) return withUsdcHoldings(next);
-          if (holdsEmptyUsdc) return withEmptyUsdcHoldings(next);
-          if (holdsUni) return withUniHoldings(next);
-          if (cryptoOnly) return withCryptoOnly(next);
-          return next;
-        },
-      ),
-    },
-  );
-}
-
-async function selectUsdcOnEthereum(user: Awaited<ReturnType<typeof renderPayTab>>["user"]) {
-  await user.press(await screen.findByTestId("action-tile-request"));
-  await user.press(await screen.findByTestId("asset-item-USDC"));
-  expect(await screen.findByText(/select network/i)).toBeVisible();
-  await user.press(await screen.findByTestId("network-item-Ethereum"));
-  expect(await screen.findByText(/select account/i)).toBeVisible();
-  await user.press(await screen.findByTestId("account-item"));
-}
-
-const RequestStack = createNativeStackNavigator<PayTabNavigatorParamList>();
-
-function renderRequestReceive(
-  params: PayTabNavigatorParamList[typeof ScreenName.PayTabRequestReceive] = {
-    accountId: payTabEthAccount.id,
-    parentId: payTabEthAccount.id,
-    currency: usdc,
-  },
-) {
-  return render(
-    <RequestStack.Navigator
-      screenOptions={{ headerShown: false, animation: "none" }}
-      initialRouteName={ScreenName.PayTabRequestReceive}
-    >
-      <RequestStack.Screen
-        name={ScreenName.PayTabRequestReceive}
-        component={PayTabRequestReceiveScreen}
-        initialParams={params}
-      />
-    </RequestStack.Navigator>,
-    { overrideInitialState: withUsdcHoldings },
-  );
-}
 
 describe("PayTab integration", () => {
   beforeEach(() => {
@@ -583,6 +365,30 @@ describe("PayTab integration", () => {
 
       expect(await screen.findByText("Request USD Coin")).toBeVisible();
       expect(screen.getByTestId("pay-card-request-receive-qr-code")).toBeVisible();
+    });
+  });
+
+  describe("contacts strip", () => {
+    it("should render the Pay tile without see-all when 8 or fewer contacts are saved", async () => {
+      renderPayTab({ contacts: seedContacts(8) });
+
+      expect(await screen.findByTestId("pay-contacts-pay-tile")).toBeVisible();
+      expect(screen.getByTestId("pay-contacts-tile-7")).toBeVisible();
+      expect(screen.queryByTestId("pay-contacts-tile-8")).toBeNull();
+      expect(screen.getByTestId("pay-contacts-see-all").props.onPress).toBeUndefined();
+    });
+
+    it("should cap the strip at 8 and open the contacts list with a Pay title via see-all", async () => {
+      const { user } = renderPayTab({ contacts: seedContacts(9) });
+
+      expect(await screen.findByTestId("pay-contacts-tile-7")).toBeVisible();
+      expect(screen.queryByTestId("pay-contacts-tile-8")).toBeNull();
+
+      await user.press(screen.getByTestId("pay-contacts-see-all"));
+
+      expect(await screen.findByTestId("my-wallet-contacts-screen")).toHaveTextContent(
+        `${ScreenName.MyWalletContacts}:Pay contact`,
+      );
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/shared.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/shared.tsx
@@ -1,0 +1,267 @@
+import React from "react";
+import { Text } from "react-native";
+import {
+  createNativeStackNavigator,
+  type NativeStackScreenProps,
+} from "@react-navigation/native-stack";
+import { render, screen, withFlagOverrides } from "@tests/test-renderer";
+import { server, http, HttpResponse, delay } from "@tests/server";
+import { mockData } from "@ledgerhq/live-common/modularDrawer/__mocks__/dada.mock";
+import { mockStablecoinsResponse } from "@domain/api-aggregated-assets/mock/stablecoins";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { TokenCurrencySchema } from "@domain/entity-currency-token";
+import { getFiatCurrencyByTicker } from "@domain/entity-currency-fiat";
+import { importCountervalues } from "@ledgerhq/live-countervalues/logic";
+import { pairId } from "@ledgerhq/live-countervalues/helpers";
+import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { makeEmptyTokenAccount } from "@ledgerhq/ledger-wallet-framework/account/helpers";
+import { NavigatorName, ScreenName } from "~/const";
+import type { State } from "~/reducers/types";
+import type { Contact } from "@domain/entity-contact";
+import { mockContact, mockMeContact } from "@domain/entity-contact/schema.mock";
+import PayTabNavigator from "LLM/features/PayTab";
+import { PayTabRequestReceiveScreen } from "LLM/features/PayTab/screens/RequestReceive";
+import type { PayTabNavigatorParamList } from "LLM/features/PayTab/types";
+import { ModularDrawerWrapper } from "LLM/features/ModularDrawer";
+
+export const EMPTY_TITLE = "Pay and get paid";
+export const EMPTY_DESCRIPTION = "Start by depositing stablecoin to your wallet";
+export const FEATURE_TOUR_ROW = "Minimal volatility";
+export const FEATURE_TOUR_CTA = "Got it";
+
+const ethereum = getCryptoCurrencyById("ethereum");
+const usd = getFiatCurrencyByTicker("USD");
+export const usdc = TokenCurrencySchema.parse({
+  type: "TokenCurrency",
+  id: "ethereum/erc20/usd__coin",
+  parentCurrencyId: ethereum.id,
+  contractAddress: "0xA0b86991c6218b36c1D19D4a2e9Eb0cE3606eB48",
+  tokenType: "erc20",
+  ticker: "USDC",
+  name: "USD Coin",
+  units: [{ name: "USD Coin", code: "USDC", magnitude: 6 }],
+});
+const uni = TokenCurrencySchema.parse({
+  type: "TokenCurrency",
+  id: "ethereum/erc20/uniswap",
+  parentCurrencyId: ethereum.id,
+  contractAddress: "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
+  tokenType: "erc20",
+  ticker: "UNI",
+  name: "Uniswap",
+  units: [{ name: "Uniswap", code: "UNI", magnitude: 18 }],
+});
+export const payTabEthAccount = genAccount("pay-tab-eth", { currency: ethereum });
+const payTabUsdcAccount = genTokenAccount(0, payTabEthAccount, usdc);
+const payTabUniAccount = genTokenAccount(0, payTabEthAccount, uni);
+
+type TestStackParamList = {
+  PayTabTest: undefined;
+  [NavigatorName.ReceiveFunds]: {
+    screen: ScreenName.ReceiveProvider;
+    params: { manifestId: string; fromMenu: boolean };
+  };
+  [NavigatorName.MyWallet]:
+    | {
+        screen: ScreenName.MyWalletContacts;
+        params?: { title?: string };
+      }
+    | undefined;
+};
+
+const Stack = createNativeStackNavigator<TestStackParamList>();
+const RequestStack = createNativeStackNavigator<PayTabNavigatorParamList>();
+
+function ReceiveFundsScreen({
+  route,
+}: NativeStackScreenProps<TestStackParamList, NavigatorName.ReceiveFunds>) {
+  return (
+    <Text testID="receive-funds-screen">
+      {route.params.screen}:{route.params.params.manifestId}
+    </Text>
+  );
+}
+
+function MyWalletContactsScreen({
+  route,
+}: NativeStackScreenProps<TestStackParamList, NavigatorName.MyWallet>) {
+  return (
+    <Text testID="my-wallet-contacts-screen">
+      {route.params?.screen}:{route.params?.params?.title}
+    </Text>
+  );
+}
+
+const DADA_URLS = [
+  "https://dada.api.ledger-test.com/v1/assets",
+  "https://dada.api.ledger.com/v1/assets",
+];
+
+type RenderPayTabOptions = Readonly<{
+  hasSeenFeatureTour?: boolean;
+  holdsUsdc?: boolean;
+  holdsEmptyUsdc?: boolean;
+  holdsUni?: boolean;
+  cryptoOnly?: boolean;
+  contacts?: Contact[];
+}>;
+
+function withUsdcHoldings(state: State): State {
+  return {
+    ...state,
+    accounts: { active: [{ ...payTabEthAccount, subAccounts: [payTabUsdcAccount] }] },
+    countervalues: {
+      ...state.countervalues,
+      countervalues: {
+        ...state.countervalues.countervalues,
+        state: importCountervalues(
+          { status: {}, [pairId({ from: usdc, to: usd })]: { latest: 1 } },
+          state.countervalues.userSettings,
+        ),
+      },
+    },
+  };
+}
+
+function withEmptyUsdcHoldings(state: State): State {
+  const emptyUsdc = makeEmptyTokenAccount(payTabEthAccount, usdc);
+  return {
+    ...state,
+    accounts: { active: [{ ...payTabEthAccount, subAccounts: [emptyUsdc] }] },
+  };
+}
+
+function withCryptoOnly(state: State): State {
+  return {
+    ...state,
+    accounts: { active: [{ ...payTabEthAccount, subAccounts: [] }] },
+  };
+}
+
+function withUniHoldings(state: State): State {
+  return {
+    ...state,
+    accounts: { active: [{ ...payTabEthAccount, subAccounts: [payTabUniAccount] }] },
+  };
+}
+
+export function seedContacts(count: number): Contact[] {
+  return [
+    mockMeContact(),
+    ...Array.from({ length: count }, (_, index) =>
+      mockContact({ id: `contact-${index}`, name: `Contact ${index}` }),
+    ),
+  ];
+}
+
+function dadaResponse(request: Request) {
+  const categories = new URL(request.url).searchParams.get("categories");
+  if (categories === "stablecoins") return HttpResponse.json(mockStablecoinsResponse);
+  return HttpResponse.json(mockData);
+}
+
+export function setDada(mode: "hang" | "error") {
+  server.use(
+    ...DADA_URLS.map(url =>
+      http.get(url, async ({ request }) => {
+        if (mode === "hang") await delay("infinite");
+        const isAmountQuery = new URL(request.url).searchParams.has("currencyIds");
+        if (isAmountQuery && mode === "error") return HttpResponse.json(null, { status: 500 });
+        return dadaResponse(request);
+      }),
+    ),
+  );
+}
+
+export function holdDada() {
+  let release!: () => void;
+  const gate = new Promise<void>(resolve => {
+    release = resolve;
+  });
+  server.use(
+    ...DADA_URLS.map(url =>
+      http.get(url, async ({ request }) => {
+        await gate;
+        return dadaResponse(request);
+      }),
+    ),
+  );
+  return () => release();
+}
+
+export function mockFullAssetCatalog() {
+  server.use(...DADA_URLS.map(url => http.get(url, () => HttpResponse.json(mockData))));
+}
+
+export function renderPayTab({
+  hasSeenFeatureTour = true,
+  holdsUsdc = false,
+  holdsEmptyUsdc = false,
+  holdsUni = false,
+  cryptoOnly = false,
+  contacts,
+}: RenderPayTabOptions = {}) {
+  return render(
+    <>
+      <Stack.Navigator screenOptions={{ headerShown: false, animation: "none" }}>
+        <Stack.Screen name="PayTabTest" component={PayTabNavigator} />
+        <Stack.Screen name={NavigatorName.ReceiveFunds} component={ReceiveFundsScreen} />
+        <Stack.Screen name={NavigatorName.MyWallet} component={MyWalletContactsScreen} />
+      </Stack.Navigator>
+      <ModularDrawerWrapper />
+    </>,
+    {
+      overrideInitialState: withFlagOverrides(
+        {
+          llmModularDrawer: {
+            enabled: true,
+            params: { enableModularization: true, searchDebounceTime: 0 },
+          },
+        },
+        state => {
+          const next: State = {
+            ...state,
+            payCardFeatureTour: { ...state.payCardFeatureTour, hasSeenFeatureTour },
+            ...(contacts ? { contacts: { contacts } } : {}),
+          };
+          if (holdsUsdc) return withUsdcHoldings(next);
+          if (holdsEmptyUsdc) return withEmptyUsdcHoldings(next);
+          if (holdsUni) return withUniHoldings(next);
+          if (cryptoOnly) return withCryptoOnly(next);
+          return next;
+        },
+      ),
+    },
+  );
+}
+
+export async function selectUsdcOnEthereum(user: Awaited<ReturnType<typeof renderPayTab>>["user"]) {
+  await user.press(await screen.findByTestId("action-tile-request"));
+  await user.press(await screen.findByTestId("asset-item-USDC"));
+  expect(await screen.findByText(/select network/i)).toBeVisible();
+  await user.press(await screen.findByTestId("network-item-Ethereum"));
+  expect(await screen.findByText(/select account/i)).toBeVisible();
+  await user.press(await screen.findByTestId("account-item"));
+}
+
+export function renderRequestReceive(
+  params: PayTabNavigatorParamList[typeof ScreenName.PayTabRequestReceive] = {
+    accountId: payTabEthAccount.id,
+    parentId: payTabEthAccount.id,
+    currency: usdc,
+  },
+) {
+  return render(
+    <RequestStack.Navigator
+      screenOptions={{ headerShown: false, animation: "none" }}
+      initialRouteName={ScreenName.PayTabRequestReceive}
+    >
+      <RequestStack.Screen
+        name={ScreenName.PayTabRequestReceive}
+        component={PayTabRequestReceiveScreen}
+        initialParams={params}
+      />
+    </RequestStack.Navigator>,
+    { overrideInitialState: withUsdcHoldings },
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/__tests__/usePayTabContacts.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/__tests__/usePayTabContacts.test.tsx
@@ -1,0 +1,42 @@
+import { act, renderHook } from "@tests/test-renderer";
+import { NavigatorName, ScreenName } from "~/const";
+import { usePayTabContacts } from "../usePayTabContacts";
+
+const mockNavigate = jest.fn();
+const mockOpen = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock("../usePayTabNewPayment", () => ({
+  usePayTabNewPayment: () => ({ open: mockOpen }),
+}));
+
+describe("usePayTabContacts", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("builds i18n labels and wires the Pay tile to the Send flow", () => {
+    const { result } = renderHook(() => usePayTabContacts());
+
+    expect(result.current.title).toBeTruthy();
+    expect(result.current.payLabel).toBeTruthy();
+
+    act(() => result.current.onPay());
+    expect(mockOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens the full contacts list from the My Wallet stack with a Pay title on see-all", () => {
+    const { result } = renderHook(() => usePayTabContacts());
+
+    act(() => result.current.onSeeAll?.());
+
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.MyWallet, {
+      screen: ScreenName.MyWalletContacts,
+      params: { title: expect.any(String) },
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabContacts.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabContacts.ts
@@ -1,18 +1,31 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
+import { useNavigation } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { ContactsNativeProps } from "@features/flow-pay-contact";
 import { useTranslation } from "~/context/Locale";
+import { NavigatorName, ScreenName } from "~/const";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { usePayTabNewPayment } from "./usePayTabNewPayment";
 
 export function usePayTabContacts(): ContactsNativeProps {
   const { t } = useTranslation();
   const { open } = usePayTabNewPayment();
+  const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
+
+  const onSeeAll = useCallback(() => {
+    navigation.navigate(NavigatorName.MyWallet, {
+      screen: ScreenName.MyWalletContacts,
+      params: { title: t("payTab.contacts.seeAllTitle") },
+    });
+  }, [navigation, t]);
 
   return useMemo(
     () => ({
       title: t("payTab.contacts.title"),
       payLabel: t("payTab.contacts.pay"),
       onPay: open,
+      onSeeAll,
     }),
-    [t, open],
+    [t, open, onSeeAll],
   );
 }

--- a/features/flow/pay-contact/README.md
+++ b/features/flow/pay-contact/README.md
@@ -35,8 +35,12 @@ tile (opens the Send flow) followed by the saved contacts. The empty state rende
 ```tsx
 import { Contacts } from "@features/flow-pay-contact";
 
-<Contacts title={title} payLabel={payLabel} onPay={openSend} />;
+<Contacts title={title} payLabel={payLabel} onPay={openSend} onSeeAll={openContactsList} />;
 ```
+
+The strip caps at 8 saved contacts. When more are saved, the section title becomes a see-all
+control that calls `onSeeAll` — the host opens the full contacts list (the mobile Contacts flow).
+The `hasMore` flag and the 8-item slice are derived by the view-model; the view is props-only.
 
 Contact tiles are display-only for now. `onContactPress` is an optional prop left unwired so a later
 ticket can turn each tile into a Pay entry point without changing the layout.

--- a/features/flow/pay-contact/src/components/Contacts/ContactsView.native.tsx
+++ b/features/flow/pay-contact/src/components/Contacts/ContactsView.native.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 import { ScrollView } from "react-native";
-import { Box, Subheader, SubheaderRow, SubheaderTitle } from "@ledgerhq/lumen-ui-rnative";
+import {
+  Box,
+  Subheader,
+  SubheaderRow,
+  SubheaderTitle,
+  SubheaderShowMore,
+} from "@ledgerhq/lumen-ui-rnative";
 import { PayTile } from "../PayTile/PayTile.native";
 import { ContactTile } from "../ContactTile/ContactTile.native";
 import type { ContactsViewNativeProps } from "../../types";
@@ -13,14 +19,21 @@ export function ContactsView({
   title,
   payLabel,
   contacts,
+  hasMore,
   onPay,
   onContactPress,
+  onSeeAll,
 }: ContactsViewNativeProps): React.JSX.Element {
   return (
     <Box testID="pay-contacts">
       <Subheader testID="pay-contacts-title">
-        <SubheaderRow lx={{ marginBottom: "s12" }}>
+        <SubheaderRow
+          lx={{ marginBottom: "s12" }}
+          onPress={hasMore ? onSeeAll : undefined}
+          testID="pay-contacts-see-all"
+        >
           <SubheaderTitle>{title}</SubheaderTitle>
+          {hasMore && <SubheaderShowMore />}
         </SubheaderRow>
       </Subheader>
 

--- a/features/flow/pay-contact/src/components/Contacts/__tests__/Contacts.native.test.tsx
+++ b/features/flow/pay-contact/src/components/Contacts/__tests__/Contacts.native.test.tsx
@@ -31,4 +31,33 @@ describe("Contacts (Native)", () => {
 
     expect(onPay).toHaveBeenCalledTimes(1);
   });
+
+  it("should cap the strip at 8 contacts and expose see-all when more are saved", () => {
+    const onSeeAll = jest.fn();
+    const savedContacts = Array.from({ length: 9 }, (_, index) =>
+      mockContact({ id: `contact-${index}`, name: `Contact ${index}` }),
+    );
+
+    renderWithContacts(
+      [mockMeContact(), ...savedContacts],
+      <Contacts {...makeContactsProps({ onSeeAll })} />,
+    );
+
+    expect(screen.getByTestId("pay-contacts-tile-7")).toBeVisible();
+    expect(screen.queryByTestId("pay-contacts-tile-8")).toBeNull();
+
+    screen.getByTestId("pay-contacts-see-all").props.onPress();
+    expect(onSeeAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not expose see-all when 8 or fewer contacts are saved", () => {
+    const savedContacts = Array.from({ length: 8 }, (_, index) =>
+      mockContact({ id: `contact-${index}`, name: `Contact ${index}` }),
+    );
+
+    renderWithContacts([mockMeContact(), ...savedContacts], <Contacts {...makeContactsProps()} />);
+
+    expect(screen.getByTestId("pay-contacts-tile-7")).toBeVisible();
+    expect(screen.getByTestId("pay-contacts-see-all").props.onPress).toBeUndefined();
+  });
 });

--- a/features/flow/pay-contact/src/components/Contacts/__tests__/ContactsView.native.test.tsx
+++ b/features/flow/pay-contact/src/components/Contacts/__tests__/ContactsView.native.test.tsx
@@ -9,7 +9,9 @@ function makeProps(overrides: Partial<ContactsViewNativeProps> = {}): ContactsVi
     title: "Pay contact",
     payLabel: "Pay",
     contacts: [],
+    hasMore: false,
     onPay: jest.fn(),
+    onSeeAll: jest.fn(),
     ...overrides,
   };
 }
@@ -69,5 +71,20 @@ describe("ContactsView (Native)", () => {
     screen.getByTestId("pay-contacts-tile-0").props.onPress();
 
     expect(onContactPress).toHaveBeenCalledWith(contacts[0]);
+  });
+
+  it("should not expose the see-all affordance when hasMore is false", () => {
+    render(<ContactsView {...makeProps({ hasMore: false })} />);
+
+    expect(screen.getByTestId("pay-contacts-see-all").props.onPress).toBeUndefined();
+  });
+
+  it("should open the full contacts list from the see-all affordance when hasMore is true", () => {
+    const onSeeAll = jest.fn();
+
+    render(<ContactsView {...makeProps({ hasMore: true, onSeeAll })} />);
+    screen.getByTestId("pay-contacts-see-all").props.onPress();
+
+    expect(onSeeAll).toHaveBeenCalledTimes(1);
   });
 });

--- a/features/flow/pay-contact/src/components/Contacts/__tests__/shared.native.tsx
+++ b/features/flow/pay-contact/src/components/Contacts/__tests__/shared.native.tsx
@@ -30,6 +30,7 @@ export function makeContactsProps(
     title: "Pay contact",
     payLabel: "Pay",
     onPay: jest.fn(),
+    onSeeAll: jest.fn(),
     ...overrides,
   };
 }

--- a/features/flow/pay-contact/src/components/Contacts/useContactsViewModel.native.ts
+++ b/features/flow/pay-contact/src/components/Contacts/useContactsViewModel.native.ts
@@ -2,9 +2,16 @@ import { useMemo } from "react";
 import { useContacts } from "@features/platform-contacts";
 import type { ContactsNativeProps, ContactsViewNativeProps } from "../../types";
 
+const MAX_CONTACTS_DISPLAYED = 8;
+
 export function useContactsViewModel(props: ContactsNativeProps): ContactsViewNativeProps {
   const contacts = useContacts();
   const savedContacts = useMemo(() => contacts.filter(contact => !contact.isMe), [contacts]);
+  const hasMore = savedContacts.length > MAX_CONTACTS_DISPLAYED;
+  const displayedContacts = useMemo(
+    () => savedContacts.slice(0, MAX_CONTACTS_DISPLAYED),
+    [savedContacts],
+  );
 
-  return { ...props, contacts: savedContacts };
+  return { ...props, contacts: displayedContacts, hasMore };
 }

--- a/features/flow/pay-contact/src/types.ts
+++ b/features/flow/pay-contact/src/types.ts
@@ -42,16 +42,19 @@ export type ContactsViewProps = Readonly<{
  * Native (Mobile) Pay contacts strip: a horizontal row with a leading Pay tile, then the saved
  * contacts. The Pay tile opens the Send flow. `onContactPress` is intentionally optional and left
  * unwired for now — a later ticket can pass it to turn contact tiles into Pay entry points without
- * touching the layout.
+ * touching the layout. `onSeeAll` opens the full contacts list when the saved contacts exceed the
+ * strip cap.
  */
 export type ContactsNativeProps = Readonly<{
   title: string;
   payLabel: string;
   onPay: () => void;
   onContactPress?: (contact: Contact) => void;
+  onSeeAll: () => void;
 }>;
 
 export type ContactsViewNativeProps = ContactsNativeProps &
   Readonly<{
     contacts: readonly Contact[];
+    hasMore: boolean;
   }>;


### PR DESCRIPTION
### 📝 Description

The Pay tab contacts strip currently lists every saved contact with no overflow path. This PR caps the strip at 8 contacts and adds a see-all control that opens the Contacts flow with a **Pay contact** title. The Contacts screen only overrides its header title when that param is set, so the default Contacts title is unchanged.

The view-model derives `hasMore` and the 8-item slice; the native view stays props-only (`onSeeAll`, `SubheaderShowMore`). Host wiring lives in `usePayTabContacts`. PayTab integration harnesses are extracted to `__integrations__/shared.tsx`.




https://github.com/user-attachments/assets/f263af3c-3e3e-47b6-9ffa-83fc0fd1616a





### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35379](https://ledgerhq.atlassian.net/browse/LIVE-35379)
- **ADR** (if any):

[LIVE-35379]: https://ledgerhq.atlassian.net/browse/LIVE-35379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ