### PR TITLE
[LWD] fix(lld): stop reporting non-Error values to Datadog (LIVE-36596)

### DIFF
--- a/.changeset/dirty-pumas-repeat.md
+++ b/.changeset/dirty-pumas-repeat.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Stop `logger.critical` from reporting non-Error values to Datadog, where they collapsed into unsearchable `"null"` and `"[object Object]"` issues merged across unrelated callers. Such values are still kept in the local logs.

--- a/apps/ledger-live-desktop/src/renderer/logger/index.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/logger/index.test.ts
@@ -29,9 +29,19 @@ describe("renderer logger", () => {
       });
     });
 
-    it("should wrap non-Error values in Error and still call captureException", () => {
+    it("should wrap string values in Error and still call captureException", () => {
       logger.critical("string error");
       expect(datadogRenderer.captureException).toHaveBeenCalledWith(new Error("string error"));
+    });
+
+    it.each([
+      ["null", null],
+      ["undefined", undefined],
+      ["a plain object", { code: 42 }],
+      ["a DMK tagged error", { _tag: "DeviceLockedError" }],
+    ])("should keep %s local instead of reporting it to Datadog", (_label, value) => {
+      logger.critical(value);
+      expect(datadogRenderer.captureException).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/ledger-live-desktop/src/renderer/logger/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/logger/index.ts
@@ -326,7 +326,11 @@ export default {
       stack: err.stack,
       ...err,
     });
-    datadog.captureException(err);
+    // anything else has no type and no stack of its own: in Datadog it becomes an unsearchable
+    // "null" / "[object Object]" issue merged with every other caller, so we keep it local
+    if (error instanceof Error || typeof error === "string") {
+      datadog.captureException(err);
+    }
   },
   add,
   onLog: (log: LogEntry | string) => {


### PR DESCRIPTION
### 📝 Description

`logger.critical` folded any non-Error input into `new Error(String(value))`. `String(null)` becomes `"null"`, `String({})` becomes `"[object Object]"` — the Error that reached Datadog had no type, no original stack, and a message that could not be searched or attributed to a caller. Error Tracking then grouped every unrelated caller into the same few buckets: six of the top eight open desktop issues, roughly 5,000 distinct users combined, all named `"null"` or `"[object Object]"`.

Such values are no longer sent to Datadog. They are still written to the winston memory transport, so they remain in the Ctrl+E log export for support. Errors and strings are reported exactly as before.

```diff
   const err = error instanceof Error ? error : new Error(String(error));
   logger.log("error", err.message, { stack: err.stack, ...err });
-  datadog.captureException(err);
+  if (error instanceof Error || typeof error === "string") {
+    datadog.captureException(err);
+  }
```

Nothing changes for callers — the signature stays `(error: unknown, context?: string)` and all ~85 call sites are untouched. Covered by `src/renderer/logger/index.test.ts` for `null`, `undefined`, a plain object and a DMK tagged error.

> [!NOTE]
> A narrower `(error: Error | string)` signature was tried first. It typechecks against only 7 call sites, but it reveals that most of the values arriving as `null` / `[object Object]` come from sites already *typed* as `Error` — bridge and promise rejections that lie about their type. Filtering at the sink is what actually stops the noise; the individual call sites are follow-up work (see below).

### Known remaining sources, out of scope here

These are now silent but still worth their own tickets:

- `renderer/modals/UpdateFirmwareModal/index.tsx:85` — `setError(e: Error | null)` calls `logger.critical(e)` unconditionally, and `setError(null)` is called in three places purely to clear the error. A top source of the `Error "null"` issues.
- `renderer/families/bitcoin/ZCashExportKeyFlowModal/index.tsx:79` — the guard is `error?.name === "UserRefusedOnDevice"`, inverted compared to `Send/Body.tsx`, `Receive/index.tsx` and `useSendFlowOperation.ts` which all use `!==`. It reports the expected user refusal and swallows genuine export failures.
- `renderer/components/TranslatedError/TranslatedError.tsx:72` — reports every non-`Error` value, including the DMK errors it deliberately handles a few lines below. It passes a string, so it is unaffected by this PR and its two issues (~1,525 users) remain open.
- `renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx:555` — `onSwapWebviewError`'s `error` param is vestigial: its only caller passes no argument. A real `SwapLiveError` is a plain object (it crosses `JSON.stringify` → `postMessage` → `JSON.parse` from the live app, so the `Error` prototype is stripped) and would need converting before it can be reported usefully.

Also out of scope, per the ticket: expected user/device conditions reported as errors, and the missing source maps on 4.17.x.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36596](https://ledgerhq.atlassian.net/browse/LIVE-36596)
- **ADR** (if any): n/a


[LIVE-36596]: https://ledgerhq.atlassian.net/browse/LIVE-36596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ