### PR TITLE
feat(pay): sort contacts by last sent-to (LIVE-36610)

### DIFF
--- a/.changeset/itchy-tigers-obey.md
+++ b/.changeset/itchy-tigers-obey.md
@@ -1,0 +1,7 @@
+---
+"@features/platform-contacts": minor
+"@features/flow-pay-contact": minor
+"live-mobile": minor
+---
+
+Order Pay contacts by last sent-to, then last added, derived at read time from account OUT operations

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabContacts.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabContacts.ts
@@ -6,11 +6,13 @@ import { useTranslation } from "~/context/Locale";
 import { NavigatorName, ScreenName } from "~/const";
 import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { usePayTabNewPayment } from "./usePayTabNewPayment";
+import { usePayTabOutgoingOperations } from "./usePayTabOutgoingOperations";
 
 export function usePayTabContacts(): ContactsNativeProps {
   const { t } = useTranslation();
   const { open } = usePayTabNewPayment();
   const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
+  const outgoingOperations = usePayTabOutgoingOperations();
 
   const onSeeAll = useCallback(() => {
     navigation.navigate(NavigatorName.MyWallet, {
@@ -25,7 +27,8 @@ export function usePayTabContacts(): ContactsNativeProps {
       payLabel: t("payTab.contacts.pay"),
       onPay: open,
       onSeeAll,
+      outgoingOperations,
     }),
-    [t, open, onSeeAll],
+    [t, open, onSeeAll, outgoingOperations],
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabOutgoingOperations.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabOutgoingOperations.ts
@@ -1,0 +1,32 @@
+import { useMemo } from "react";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
+import type { AccountLike, Operation } from "@ledgerhq/types-live";
+import type { OutgoingOperation } from "@features/platform-contacts";
+import { useSelector } from "~/context/hooks";
+import { flattenAccountsSelector } from "~/reducers/accounts";
+
+function toOutgoingOperations(account: AccountLike): OutgoingOperation[] {
+  const currencyId = getAccountCurrency(account).id;
+  const operations: Operation[] = [...account.pendingOperations, ...account.operations];
+
+  return operations
+    .filter(operation => operation.type === "OUT")
+    .flatMap(operation =>
+      operation.recipients.map(recipientAddress => ({
+        id: operation.id,
+        recipientAddress,
+        date: operation.date.getTime(),
+        currencyId,
+      })),
+    );
+}
+
+/**
+ * Account `OUT` operations (pending included) flattened into the platform DTO, used to order the Pay
+ * contacts by last sent-to.
+ */
+export function usePayTabOutgoingOperations(): OutgoingOperation[] {
+  const accounts = useSelector(flattenAccountsSelector);
+
+  return useMemo(() => accounts.flatMap(toOutgoingOperations), [accounts]);
+}

--- a/features/flow/pay-contact/src/components/Contacts/__tests__/Contacts.native.test.tsx
+++ b/features/flow/pay-contact/src/components/Contacts/__tests__/Contacts.native.test.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 import { screen } from "@testing-library/react-native";
-import { mockContact, mockMeContact } from "@domain/entity-contact/schema.mock";
+import {
+  mockContact,
+  mockContactAddress,
+  mockContactWithAddress,
+  mockMeContact,
+} from "@domain/entity-contact/schema.mock";
+import type { OutgoingOperation } from "@features/platform-contacts";
 import { Contacts } from "../Contacts.native";
 import { makeContactsProps, renderWithContacts } from "./shared.native";
 
@@ -59,5 +65,40 @@ describe("Contacts (Native)", () => {
 
     expect(screen.getByTestId("pay-contacts-tile-7")).toBeVisible();
     expect(screen.getByTestId("pay-contacts-see-all").props.onPress).toBeUndefined();
+  });
+
+  const bobAddress = "0x1111111111111111111111111111111111111111";
+  const aliceAddress = "0x2222222222222222222222222222222222222222";
+
+  const bob = mockContactWithAddress({
+    id: "contact-bob",
+    name: "Bob",
+    addresses: [mockContactAddress({ id: "addr-bob", address: bobAddress })],
+  });
+  const alice = mockContactWithAddress({
+    id: "contact-alice",
+    name: "Alice",
+    addresses: [mockContactAddress({ id: "addr-alice", address: aliceAddress })],
+  });
+
+  it("should order the contact sent to most recently first, ahead of the one added last", () => {
+    const sentToBob: OutgoingOperation[] = [
+      { recipientAddress: bobAddress, date: 1_700_000_000_000, currencyId: "ethereum" },
+    ];
+
+    renderWithContacts(
+      [mockMeContact(), bob, alice],
+      <Contacts {...makeContactsProps({ outgoingOperations: sentToBob })} />,
+    );
+
+    expect(screen.getByTestId("pay-contacts-tile-0").props.accessibilityLabel).toBe("Bob");
+    expect(screen.getByTestId("pay-contacts-tile-1").props.accessibilityLabel).toBe("Alice");
+  });
+
+  it("should fall back to last added order when no outgoing operation matches", () => {
+    renderWithContacts([mockMeContact(), bob, alice], <Contacts {...makeContactsProps()} />);
+
+    expect(screen.getByTestId("pay-contacts-tile-0").props.accessibilityLabel).toBe("Alice");
+    expect(screen.getByTestId("pay-contacts-tile-1").props.accessibilityLabel).toBe("Bob");
   });
 });

--- a/features/flow/pay-contact/src/components/Contacts/useContactsViewModel.native.ts
+++ b/features/flow/pay-contact/src/components/Contacts/useContactsViewModel.native.ts
@@ -1,16 +1,31 @@
 import { useMemo } from "react";
-import { useContacts } from "@features/platform-contacts";
+import {
+  sortContactsByLastSentThenLastAdded,
+  summarizeOutgoingOperationsByContact,
+  useContacts,
+} from "@features/platform-contacts";
 import type { ContactsNativeProps, ContactsViewNativeProps } from "../../types";
 
 const MAX_CONTACTS_DISPLAYED = 8;
 
-export function useContactsViewModel(props: ContactsNativeProps): ContactsViewNativeProps {
+const EMPTY_OPERATIONS = [] as const;
+
+export function useContactsViewModel({
+  outgoingOperations = EMPTY_OPERATIONS,
+  ...props
+}: ContactsNativeProps): ContactsViewNativeProps {
   const contacts = useContacts();
-  const savedContacts = useMemo(() => contacts.filter(contact => !contact.isMe), [contacts]);
-  const hasMore = savedContacts.length > MAX_CONTACTS_DISPLAYED;
+  const sortedContacts = useMemo(() => {
+    const savedContacts = contacts.filter(contact => !contact.isMe);
+    const summaries = summarizeOutgoingOperationsByContact(savedContacts, outgoingOperations);
+
+    return sortContactsByLastSentThenLastAdded(savedContacts, summaries);
+  }, [contacts, outgoingOperations]);
+
+  const hasMore = sortedContacts.length > MAX_CONTACTS_DISPLAYED;
   const displayedContacts = useMemo(
-    () => savedContacts.slice(0, MAX_CONTACTS_DISPLAYED),
-    [savedContacts],
+    () => sortedContacts.slice(0, MAX_CONTACTS_DISPLAYED),
+    [sortedContacts],
   );
 
   return { ...props, contacts: displayedContacts, hasMore };

--- a/features/flow/pay-contact/src/types.ts
+++ b/features/flow/pay-contact/src/types.ts
@@ -5,6 +5,7 @@ import type {
   ContactCreationPort,
   ContactsAddContactContentLabels,
 } from "@features/flow-contacts-add-contact";
+import type { OutgoingOperation } from "@features/platform-contacts";
 
 export type EmptyStateLabels = Readonly<{
   info: string;
@@ -43,7 +44,8 @@ export type ContactsViewProps = Readonly<{
  * contacts. The Pay tile opens the Send flow. `onContactPress` is intentionally optional and left
  * unwired for now — a later ticket can pass it to turn contact tiles into Pay entry points without
  * touching the layout. `onSeeAll` opens the full contacts list when the saved contacts exceed the
- * strip cap.
+ * strip cap. `outgoingOperations` are the host's account `OUT` operations used to order contacts by
+ * last sent-to; omit for store order only.
  */
 export type ContactsNativeProps = Readonly<{
   title: string;
@@ -51,6 +53,7 @@ export type ContactsNativeProps = Readonly<{
   onPay: () => void;
   onContactPress?: (contact: Contact) => void;
   onSeeAll: () => void;
+  outgoingOperations?: readonly OutgoingOperation[];
 }>;
 
 export type ContactsViewNativeProps = ContactsNativeProps &

--- a/features/platform/contacts/src/index.native.ts
+++ b/features/platform/contacts/src/index.native.ts
@@ -1,5 +1,6 @@
 export * from "./useContacts";
 export * from "./analytics";
+export * from "./outgoingOperations";
 export * from "./utils/getContactInitial";
 export * from "./hooks/useContactsMeContact";
 export * from "./utils/formatMeDisplayName";

--- a/features/platform/contacts/src/index.ts
+++ b/features/platform/contacts/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./useContacts";
 export * from "./analytics";
+export * from "./outgoingOperations";
 export * from "./utils/getContactInitial";
 export * from "./hooks/useContactsMeContact";
 export * from "./utils/formatMeDisplayName";

--- a/features/platform/contacts/src/outgoingOperations/addressesMatch.ts
+++ b/features/platform/contacts/src/outgoingOperations/addressesMatch.ts
@@ -1,0 +1,12 @@
+/**
+ * EVM addresses (`0x` on both sides) compare case-insensitively; everything else exactly. Mirrors
+ * the Send recipient rule in `libs/ledger-live-common` without importing from `libs/`.
+ */
+export function addressesMatch(left: string, right: string): boolean {
+  const normalizedLeft = left.trim();
+  const normalizedRight = right.trim();
+
+  return normalizedLeft.startsWith("0x") && normalizedRight.startsWith("0x")
+    ? normalizedLeft.toLowerCase() === normalizedRight.toLowerCase()
+    : normalizedLeft === normalizedRight;
+}

--- a/features/platform/contacts/src/outgoingOperations/findOutgoingOperationsToAddresses.ts
+++ b/features/platform/contacts/src/outgoingOperations/findOutgoingOperationsToAddresses.ts
@@ -1,0 +1,28 @@
+import { addressesMatch } from "./addressesMatch";
+import type { OutgoingOperation } from "./types";
+
+type MatchableAddress = Readonly<{ address: string; currencyId: string }>;
+
+function matchesAddress(operation: OutgoingOperation, address: MatchableAddress): boolean {
+  return (
+    address.currencyId === operation.currencyId &&
+    addressesMatch(address.address, operation.recipientAddress)
+  );
+}
+
+/**
+ * The single matching primitive: summaries fold its result and a future History filter can reuse it.
+ * Requiring the same currency stops the same address string on two networks from colliding.
+ */
+export function findOutgoingOperationsToAddresses(
+  addresses: readonly MatchableAddress[],
+  operations: readonly OutgoingOperation[],
+): OutgoingOperation[] {
+  if (addresses.length === 0) {
+    return [];
+  }
+
+  return operations.filter(operation =>
+    addresses.some(address => matchesAddress(operation, address)),
+  );
+}

--- a/features/platform/contacts/src/outgoingOperations/findOutgoingOperationsToAddresses.web.test.ts
+++ b/features/platform/contacts/src/outgoingOperations/findOutgoingOperationsToAddresses.web.test.ts
@@ -1,0 +1,45 @@
+import { findOutgoingOperationsToAddresses } from "./findOutgoingOperationsToAddresses";
+import type { OutgoingOperation } from "./types";
+
+const ethAddress = "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034";
+const ethAddressChecksummed = "0x1AD23B2CF8D2E0591EA417EB82F7CD9746C53034";
+
+function operation(overrides: Partial<OutgoingOperation> = {}): OutgoingOperation {
+  return {
+    id: "op-1",
+    recipientAddress: ethAddress,
+    date: 1000,
+    currencyId: "ethereum",
+    ...overrides,
+  };
+}
+
+describe("findOutgoingOperationsToAddresses", () => {
+  it("matches EVM addresses case-insensitively", () => {
+    const op = operation({ recipientAddress: ethAddressChecksummed });
+
+    expect(
+      findOutgoingOperationsToAddresses([{ address: ethAddress, currencyId: "ethereum" }], [op]),
+    ).toEqual([op]);
+  });
+
+  it("ignores operations to an unknown recipient", () => {
+    const op = operation({ recipientAddress: "0xdeadbeef00000000000000000000000000000000" });
+
+    expect(
+      findOutgoingOperationsToAddresses([{ address: ethAddress, currencyId: "ethereum" }], [op]),
+    ).toEqual([]);
+  });
+
+  it("ignores a matching address on a different currency", () => {
+    const op = operation({ currencyId: "ethereum/erc20/usd_coin" });
+
+    expect(
+      findOutgoingOperationsToAddresses([{ address: ethAddress, currencyId: "ethereum" }], [op]),
+    ).toEqual([]);
+  });
+
+  it("returns no matches when the contact has no addresses", () => {
+    expect(findOutgoingOperationsToAddresses([], [operation()])).toEqual([]);
+  });
+});

--- a/features/platform/contacts/src/outgoingOperations/index.ts
+++ b/features/platform/contacts/src/outgoingOperations/index.ts
@@ -1,0 +1,5 @@
+export * from "./types";
+export * from "./addressesMatch";
+export * from "./findOutgoingOperationsToAddresses";
+export * from "./summarizeOutgoingOperationsByContact";
+export * from "./sortContactsByLastSentThenLastAdded";

--- a/features/platform/contacts/src/outgoingOperations/sortContactsByLastSentThenLastAdded.ts
+++ b/features/platform/contacts/src/outgoingOperations/sortContactsByLastSentThenLastAdded.ts
@@ -1,0 +1,26 @@
+import type { Contact } from "@domain/entity-contact";
+import type { ContactOperationsSummaries } from "./types";
+
+/**
+ * Pay order: most recently sent to first, then never-sent contacts newest added first. "Last added"
+ * relies on the input being the contacts store order, where a new contact is appended (higher index
+ * means added more recently).
+ */
+export function sortContactsByLastSentThenLastAdded(
+  contacts: readonly Contact[],
+  summaries: ContactOperationsSummaries,
+): Contact[] {
+  return contacts
+    .map((contact, index) => ({
+      contact,
+      index,
+      lastSentAt: summaries[contact.id]?.lastSentAt ?? 0,
+    }))
+    .sort((left, right) => {
+      if (left.lastSentAt !== right.lastSentAt) {
+        return right.lastSentAt - left.lastSentAt;
+      }
+      return right.index - left.index;
+    })
+    .map(({ contact }) => contact);
+}

--- a/features/platform/contacts/src/outgoingOperations/sortContactsByLastSentThenLastAdded.web.test.ts
+++ b/features/platform/contacts/src/outgoingOperations/sortContactsByLastSentThenLastAdded.web.test.ts
@@ -1,0 +1,47 @@
+import { mockContact } from "@domain/entity-contact/schema.mock";
+import { sortContactsByLastSentThenLastAdded } from "./sortContactsByLastSentThenLastAdded";
+import type { ContactOperationsSummaries } from "./types";
+
+const ada = mockContact({ id: "contact-ada", name: "Ada" });
+const ben = mockContact({ id: "contact-ben", name: "Ben" });
+const cleo = mockContact({ id: "contact-cleo", name: "Cleo" });
+
+function idsOf(contacts: readonly { id: string }[]): string[] {
+  return contacts.map(contact => contact.id);
+}
+
+describe("sortContactsByLastSentThenLastAdded", () => {
+  it("orders contacts sent to before contacts never sent to", () => {
+    const summaries: ContactOperationsSummaries = {
+      [ben.id]: { txCount: 1, lastSentAt: 5000 },
+    };
+
+    expect(idsOf(sortContactsByLastSentThenLastAdded([ada, ben, cleo], summaries))).toEqual([
+      ben.id,
+      cleo.id,
+      ada.id,
+    ]);
+  });
+
+  it("orders contacts sent to by most recent operation first", () => {
+    const summaries: ContactOperationsSummaries = {
+      [ada.id]: { txCount: 1, lastSentAt: 1000 },
+      [ben.id]: { txCount: 1, lastSentAt: 3000 },
+      [cleo.id]: { txCount: 1, lastSentAt: 2000 },
+    };
+
+    expect(idsOf(sortContactsByLastSentThenLastAdded([ada, ben, cleo], summaries))).toEqual([
+      ben.id,
+      cleo.id,
+      ada.id,
+    ]);
+  });
+
+  it("orders never-sent contacts newest added first", () => {
+    expect(idsOf(sortContactsByLastSentThenLastAdded([ada, ben, cleo], {}))).toEqual([
+      cleo.id,
+      ben.id,
+      ada.id,
+    ]);
+  });
+});

--- a/features/platform/contacts/src/outgoingOperations/summarizeOutgoingOperationsByContact.ts
+++ b/features/platform/contacts/src/outgoingOperations/summarizeOutgoingOperationsByContact.ts
@@ -1,0 +1,37 @@
+import type { Contact, ContactId } from "@domain/entity-contact";
+import { findOutgoingOperationsToAddresses } from "./findOutgoingOperationsToAddresses";
+import type {
+  ContactOperationsSummaries,
+  ContactOperationsSummary,
+  OutgoingOperation,
+} from "./types";
+
+function summarizeContact(
+  contact: Contact,
+  operations: readonly OutgoingOperation[],
+): ContactOperationsSummary {
+  const matching = findOutgoingOperationsToAddresses(contact.addresses, operations);
+
+  if (matching.length === 0) {
+    return { txCount: 0 };
+  }
+
+  return {
+    txCount: matching.length,
+    lastSentAt: matching.reduce((latest, operation) => Math.max(latest, operation.date), 0),
+  };
+}
+
+/** Every contact gets an entry; those never sent to are `{ txCount: 0 }`. */
+export function summarizeOutgoingOperationsByContact(
+  contacts: readonly Contact[],
+  operations: readonly OutgoingOperation[],
+): ContactOperationsSummaries {
+  const summaries: Record<ContactId, ContactOperationsSummary> = {};
+
+  for (const contact of contacts) {
+    summaries[contact.id] = summarizeContact(contact, operations);
+  }
+
+  return summaries;
+}

--- a/features/platform/contacts/src/outgoingOperations/summarizeOutgoingOperationsByContact.web.test.ts
+++ b/features/platform/contacts/src/outgoingOperations/summarizeOutgoingOperationsByContact.web.test.ts
@@ -1,0 +1,60 @@
+import {
+  mockContact,
+  mockContactAddress,
+  mockContactWithAddress,
+} from "@domain/entity-contact/schema.mock";
+import { summarizeOutgoingOperationsByContact } from "./summarizeOutgoingOperationsByContact";
+import type { OutgoingOperation } from "./types";
+
+const address = "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034";
+
+function operation(overrides: Partial<OutgoingOperation> = {}): OutgoingOperation {
+  return {
+    id: "op",
+    recipientAddress: address,
+    date: 1000,
+    currencyId: "ethereum",
+    ...overrides,
+  };
+}
+
+describe("summarizeOutgoingOperationsByContact", () => {
+  it("counts every matching operation and keeps the most recent date", () => {
+    const contact = mockContactWithAddress({ id: "contact-ada", name: "Ada" });
+
+    const summaries = summarizeOutgoingOperationsByContact(
+      [contact],
+      [
+        operation({ id: "op-1", date: 1000 }),
+        operation({ id: "op-2", date: 3000 }),
+        operation({ id: "op-3", date: 2000 }),
+      ],
+    );
+
+    expect(summaries[contact.id]).toEqual({ txCount: 3, lastSentAt: 3000 });
+  });
+
+  it("returns a zero summary and no lastSentAt when the contact was never sent to", () => {
+    const contact = mockContact({ id: "contact-ben", name: "Ben" });
+
+    const summaries = summarizeOutgoingOperationsByContact([contact], [operation()]);
+
+    expect(summaries[contact.id]).toEqual({ txCount: 0 });
+    expect(summaries[contact.id].lastSentAt).toBeUndefined();
+  });
+
+  it("does not count operations on a different currency than the saved address", () => {
+    const contact = mockContactWithAddress({
+      id: "contact-ada",
+      name: "Ada",
+      addresses: [mockContactAddress({ address, currencyId: "ethereum" })],
+    });
+
+    const summaries = summarizeOutgoingOperationsByContact(
+      [contact],
+      [operation({ currencyId: "ethereum/erc20/usd_coin" })],
+    );
+
+    expect(summaries[contact.id]).toEqual({ txCount: 0 });
+  });
+});

--- a/features/platform/contacts/src/outgoingOperations/types.ts
+++ b/features/platform/contacts/src/outgoingOperations/types.ts
@@ -1,0 +1,21 @@
+import type { ContactId } from "@domain/entity-contact";
+
+/**
+ * An account `OUT` reduced to what contact matching needs, so the platform layer never depends on
+ * `@ledgerhq/types-live` or the account store. `id` is unused by matching and kept only for a later
+ * History filter. `date` is epoch milliseconds.
+ */
+export type OutgoingOperation = Readonly<{
+  id?: string;
+  recipientAddress: string;
+  date: number;
+  currencyId: string;
+}>;
+
+/** `lastSentAt` is omitted when the contact was never sent to. */
+export type ContactOperationsSummary = Readonly<{
+  lastSentAt?: number;
+  txCount: number;
+}>;
+
+export type ContactOperationsSummaries = Readonly<Record<ContactId, ContactOperationsSummary>>;

--- a/features/platform/contacts/src/web.ts
+++ b/features/platform/contacts/src/web.ts
@@ -1,4 +1,5 @@
 export * from "./useContacts";
+export * from "./outgoingOperations";
 export * from "./utils/getContactInitial";
 export * from "./hooks/useContactsMeContact";
 export * from "./utils/formatMeDisplayName";


### PR DESCRIPTION
### 📝 Description

Pay tab contacts were shown in raw store order. This orders them by **last sent-to**, then **last added** (store order).

Nothing is persisted per contact (no `lastSentAt`, tx count or `createdAt`), so the data is derived at read time from account `OUT` operations matched to contact addresses:

- New pure `outgoingOperations` module in `@features/platform-contacts` (no Redux, no `live-common`): `findOutgoingOperationsToAddresses`, `summarizeOutgoingOperationsByContact`, `sortContactsByLastSentThenLastAdded`, `addressesMatch` + DTO types, with unit tests.
- The native Pay strip sorts with the derived summaries before the 8-cap; see-all preserved.
- LWM PayTab wiring: `usePayTabOutgoingOperations` maps account `OUT` (incl. pending) into the DTO and feeds `usePayTabContacts`.

The matching primitive is intentionally reusable for a future History filter by contact address (out of scope here).

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36610](https://ledgerhq.atlassian.net/browse/LIVE-36610)
- **ADR** (if any): n/a

[LIVE-36610]: https://ledgerhq.atlassian.net/browse/LIVE-36610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ