### PR TITLE
feat(pay): mobile devtool contacts from history (LIVE-36614)

### DIFF
--- a/.changeset/quick-mice-share.md
+++ b/.changeset/quick-mice-share.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add a "Load contacts from send history" generator to the mobile Contacts devtool

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/__tests__/mockContacts.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/__tests__/mockContacts.test.ts
@@ -1,4 +1,6 @@
-import { createContactsDebugSamples } from "../mockContacts";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import type { AccountLike, Operation } from "@ledgerhq/types-live";
+import { createContactsDebugSamples, createContactsFromSendHistory } from "../mockContacts";
 
 describe("createContactsDebugSamples", () => {
   it("creates 25 saved contacts across the section index", () => {
@@ -16,5 +18,64 @@ describe("createContactsDebugSamples", () => {
     expect(contacts.flatMap(contact => contact.addresses).every(address => address.device)).toBe(
       true,
     );
+  });
+});
+
+function outOperation(id: string, recipient: string, date: string): Operation {
+  return {
+    type: "OUT",
+    id,
+    recipients: [recipient],
+    date: new Date(date),
+  } as Operation;
+}
+
+function ethereumAccount(
+  operations: Operation[],
+  pendingOperations: Operation[] = [],
+): AccountLike {
+  return {
+    type: "Account",
+    currency: getCryptoCurrencyById("ethereum"),
+    operations,
+    pendingOperations,
+  } as AccountLike;
+}
+
+describe("createContactsFromSendHistory", () => {
+  it("returns no contacts when accounts have no outgoing operations", () => {
+    const account = ethereumAccount([outOperation("in-1", "0xaaa", "2026-01-01")]);
+    account.operations[0].type = "IN";
+
+    expect(createContactsFromSendHistory([account])).toEqual([]);
+  });
+
+  it("creates one contact per distinct recipient ordered by last sent-to", () => {
+    const older = "0x1111111111111111111111111111111111111111";
+    const newer = "0x2222222222222222222222222222222222222222";
+    const account = ethereumAccount([
+      outOperation("op-1", older, "2026-01-01"),
+      outOperation("op-2", newer, "2026-03-01"),
+      outOperation("op-3", older, "2026-02-01"),
+    ]);
+
+    const contacts = createContactsFromSendHistory([account]);
+
+    expect(contacts.map(contact => contact.addresses[0]?.address)).toEqual([newer, older]);
+    expect(contacts.every(contact => !contact.isMe)).toBe(true);
+    expect(contacts.every(contact => contact.deviceCredentials !== undefined)).toBe(true);
+  });
+
+  it("keeps a pending operation as the most recent send", () => {
+    const address = "0x3333333333333333333333333333333333333333";
+    const account = ethereumAccount(
+      [outOperation("op-1", address, "2026-01-01")],
+      [outOperation("pending-1", address, "2026-05-01")],
+    );
+
+    const contacts = createContactsFromSendHistory([account]);
+
+    expect(contacts).toHaveLength(1);
+    expect(contacts[0].addresses[0]?.address).toBe(address);
   });
 });

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/components/ContactsSampleDataSection.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/components/ContactsSampleDataSection.tsx
@@ -5,6 +5,7 @@ import { SectionHeader } from "./SectionHeader";
 
 export function ContactsSampleDataSection({
   onLoadSamples,
+  onLoadFromSendHistory,
   onClearContacts,
 }: ContactsSampleDataSectionProps): React.JSX.Element {
   return (
@@ -23,6 +24,17 @@ export function ContactsSampleDataSection({
         </Text>
         <Button appearance="accent" size="sm" onPress={onLoadSamples} lx={{ marginBottom: "s12" }}>
           Load 25 sample contacts
+        </Button>
+        <Text typography="body3" lx={{ color: "muted", marginBottom: "s16" }}>
+          Replace saved contacts with one per address you sent to, newest first, for Pay ordering.
+        </Text>
+        <Button
+          appearance="accent"
+          size="sm"
+          onPress={onLoadFromSendHistory}
+          lx={{ marginBottom: "s12" }}
+        >
+          Load contacts from send history
         </Button>
         <Button appearance="base" size="sm" onPress={onClearContacts}>
           Clear saved contacts

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/index.tsx
@@ -25,6 +25,7 @@ export default function DebugContacts() {
     handleSetEligibleAddressFamilies,
     handleRestoreDefaults,
     handleLoadSamples,
+    handleLoadFromSendHistory,
     handleClearContacts,
   } = useContactsDevToolViewModel();
 
@@ -49,6 +50,7 @@ export default function DebugContacts() {
 
         <ContactsSampleDataSection
           onLoadSamples={handleLoadSamples}
+          onLoadFromSendHistory={handleLoadFromSendHistory}
           onClearContacts={handleClearContacts}
         />
 

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/mockContacts.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/mockContacts.ts
@@ -1,3 +1,5 @@
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
+import type { AccountLike } from "@ledgerhq/types-live";
 import { contact, contactAddress, type Contact } from "@domain/entity-contact";
 import {
   mockDeviceContactGroupCredentials,
@@ -58,4 +60,65 @@ export function createContactsDebugSamples(): Contact[] {
       ...(addresses.length > 0 ? { deviceCredentials: mockDeviceContactGroupCredentials() } : {}),
     });
   });
+}
+
+const MAX_SEND_HISTORY_CONTACTS = 15;
+
+type SendHistoryEntry = { address: string; currencyId: string; label: string; date: number };
+
+/**
+ * Builds one contact per distinct address the accounts have sent to, most recent first, so the Pay
+ * strip can be exercised against real `last sent-to` ordering instead of synthetic addresses that no
+ * operation targets.
+ */
+export function createContactsFromSendHistory(accounts: readonly AccountLike[]): Contact[] {
+  const latestByAddress = new Map<string, SendHistoryEntry>();
+
+  for (const account of accounts) {
+    const currency = getAccountCurrency(account);
+    const operations = [...account.pendingOperations, ...account.operations];
+
+    for (const operation of operations) {
+      if (operation.type !== "OUT") continue;
+
+      const date = operation.date.getTime();
+
+      for (const recipient of operation.recipients) {
+        const key = `${currency.id}:${recipient.toLowerCase()}`;
+        const existing = latestByAddress.get(key);
+
+        if (!existing || date > existing.date) {
+          latestByAddress.set(key, {
+            address: recipient,
+            currencyId: currency.id,
+            label: currency.ticker,
+            date,
+          });
+        }
+      }
+    }
+  }
+
+  return [...latestByAddress.values()]
+    .sort((left, right) => right.date - left.date)
+    .slice(0, MAX_SEND_HISTORY_CONTACTS)
+    .map((entry, index) => {
+      const id = `contact-send-history-${index + 1}`;
+
+      return contact({
+        id,
+        isMe: false,
+        name: `Payee ${index + 1}`,
+        addresses: [
+          contactAddress({
+            id: `${id}-address-1`,
+            currencyId: entry.currencyId,
+            label: entry.label,
+            address: entry.address,
+            device: mockExternalAddressDeviceContext(),
+          }),
+        ],
+        deviceCredentials: mockDeviceContactGroupCredentials(),
+      });
+    });
 }

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/types.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/types.ts
@@ -13,6 +13,7 @@ export type ContactsEnabledToggleProps = {
 
 export type ContactsSampleDataSectionProps = {
   readonly onLoadSamples: () => void;
+  readonly onLoadFromSendHistory: () => void;
   readonly onClearContacts: () => void;
 };
 

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/useContactsDevToolViewModel.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/useContactsDevToolViewModel.ts
@@ -9,12 +9,14 @@ import {
 import { setOverride } from "@shared/feature-flags";
 import { setHasDismissedContactsFeatureIntroduction } from "~/actions/settings";
 import { useDispatch, useSelector } from "~/context/hooks";
+import { flattenAccountsSelector } from "~/reducers/accounts";
 import { hasDismissedContactsFeatureIntroductionSelector } from "~/reducers/settings";
 import { CONTACTS_FLAG } from "./constants";
-import { createContactsDebugSamples } from "./mockContacts";
+import { createContactsDebugSamples, createContactsFromSendHistory } from "./mockContacts";
 
 export function useContactsDevToolViewModel() {
   const dispatch = useDispatch();
+  const accounts = useSelector(flattenAccountsSelector);
   const featureFlag = useFeature(CONTACTS_FLAG);
   const hasDismissedFeatureIntroduction = useSelector(
     hasDismissedContactsFeatureIntroductionSelector,
@@ -60,6 +62,10 @@ export function useContactsDevToolViewModel() {
     dispatch(setContacts(createContactsDebugSamples()));
   }, [dispatch]);
 
+  const handleLoadFromSendHistory = useCallback(() => {
+    dispatch(setContacts(createContactsFromSendHistory(accounts)));
+  }, [dispatch, accounts]);
+
   const handleClearContacts = useCallback(() => {
     dispatch(setContacts([]));
   }, [dispatch]);
@@ -80,6 +86,7 @@ export function useContactsDevToolViewModel() {
     handleSetEligibleAddressFamilies,
     handleRestoreDefaults,
     handleLoadSamples,
+    handleLoadFromSendHistory,
     handleClearContacts,
   };
 }


### PR DESCRIPTION
### 📝 Description

Adds a debug generator to the mobile Contacts devtool (Settings → Debug → Contacts) that replaces saved contacts with one contact per distinct address the user's accounts have sent to, newest first. This lets us exercise the Pay strip recency ordering against real operations instead of synthetic addresses that no operation targets.

- `createContactsFromSendHistory(accounts)` in `mockContacts.ts` + unit tests.
- `handleLoadFromSendHistory` wired in the devtool view model, with a button in the sample-data section.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36614](https://ledgerhq.atlassian.net/browse/LIVE-36614)
- **ADR** (if any): n/a
- Stacked on #21287.

[LIVE-36614]: https://ledgerhq.atlassian.net/browse/LIVE-36614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ