### PR TITLE
feat(pay): desktop devtool contacts from history (LIVE-36615)

### DIFF
--- a/.changeset/calm-owls-hunt.md
+++ b/.changeset/calm-owls-hunt.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add a "Load contacts from send history" generator to the desktop Contacts devtool

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/ContactsDevToolContent.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/ContactsDevToolContent.tsx
@@ -24,6 +24,7 @@ export const ContactsDevToolContent = ({ expanded }: ContactsDevToolContentProps
     setCustomFamiliesInput,
     handleApplyCustomFamilies,
     handleLoadPopulatedContacts,
+    handleLoadFromSendHistory,
     handleResetContacts,
     handleResetOverride,
     hasDismissedFeatureIntroduction,
@@ -110,6 +111,9 @@ export const ContactsDevToolContent = ({ expanded }: ContactsDevToolContentProps
             <div className="flex flex-wrap items-center gap-4 pt-8">
               <Button appearance="accent" size="sm" onClick={handleLoadPopulatedContacts}>
                 {t("settings.developer.contactsDevTool.loadPopulatedContacts")}
+              </Button>
+              <Button appearance="accent" size="sm" onClick={handleLoadFromSendHistory}>
+                {t("settings.developer.contactsDevTool.loadFromSendHistory")}
               </Button>
               <Button appearance="transparent" size="sm" onClick={handleResetContacts}>
                 {t("settings.developer.contactsDevTool.resetContacts")}

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/createContactsFromSendHistory.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/createContactsFromSendHistory.ts
@@ -1,0 +1,68 @@
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
+import type { AccountLike } from "@ledgerhq/types-live";
+import { contact, contactAddress, type Contact } from "@domain/entity-contact";
+import {
+  mockDeviceContactGroupCredentials,
+  mockExternalAddressDeviceContext,
+} from "@domain/entity-contact/schema.mock";
+
+const MAX_SEND_HISTORY_CONTACTS = 15;
+
+type SendHistoryEntry = { address: string; currencyId: string; label: string; date: number };
+
+/**
+ * Builds one contact per distinct address the accounts have sent to, most recent first, so the Pay
+ * contacts list can be exercised against real `last sent-to` ordering instead of synthetic addresses
+ * that no operation targets.
+ */
+export function createContactsFromSendHistory(accounts: readonly AccountLike[]): Contact[] {
+  const latestByAddress = new Map<string, SendHistoryEntry>();
+
+  for (const account of accounts) {
+    const currency = getAccountCurrency(account);
+    const operations = [...account.pendingOperations, ...account.operations];
+
+    for (const operation of operations) {
+      if (operation.type !== "OUT") continue;
+
+      const date = operation.date.getTime();
+
+      for (const recipient of operation.recipients) {
+        const key = `${currency.id}:${recipient.toLowerCase()}`;
+        const existing = latestByAddress.get(key);
+
+        if (!existing || date > existing.date) {
+          latestByAddress.set(key, {
+            address: recipient,
+            currencyId: currency.id,
+            label: currency.ticker,
+            date,
+          });
+        }
+      }
+    }
+  }
+
+  return [...latestByAddress.values()]
+    .sort((left, right) => right.date - left.date)
+    .slice(0, MAX_SEND_HISTORY_CONTACTS)
+    .map((entry, index) => {
+      const id = `contact-send-history-${index + 1}`;
+
+      return contact({
+        id,
+        isMe: false,
+        name: `Payee ${index + 1}`,
+        addresses: [
+          contactAddress({
+            id: `${id}-address-1`,
+            currencyId: entry.currencyId,
+            label: entry.label,
+            address: entry.address,
+            device: mockExternalAddressDeviceContext(),
+          }),
+        ],
+        deviceCredentials: mockDeviceContactGroupCredentials(),
+      });
+    });
+}

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/hooks/useContactsDevToolViewModel.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/hooks/useContactsDevToolViewModel.ts
@@ -11,12 +11,15 @@ import {
 import { setOverride } from "@shared/feature-flags";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { setHasDismissedContactsFeatureIntroduction } from "~/renderer/actions/settings";
+import { flattenAccountsSelector } from "~/renderer/reducers/accounts";
 import { hasDismissedContactsFeatureIntroductionSelector } from "~/renderer/reducers/settings";
 import { CONTACTS_FLAG } from "../constants";
+import { createContactsFromSendHistory } from "../createContactsFromSendHistory";
 import { ContactsDevToolViewModel } from "../types";
 
 export const useContactsDevToolViewModel = (): ContactsDevToolViewModel => {
   const dispatch = useDispatch();
+  const accounts = useSelector(flattenAccountsSelector);
   const featureFlag = useFeature(CONTACTS_FLAG);
   const hasDismissedFeatureIntroduction = useSelector(
     hasDismissedContactsFeatureIntroductionSelector,
@@ -68,6 +71,10 @@ export const useContactsDevToolViewModel = (): ContactsDevToolViewModel => {
     dispatch(setContacts(mockPopulatedContacts()));
   }, [dispatch]);
 
+  const handleLoadFromSendHistory = useCallback(() => {
+    dispatch(setContacts(createContactsFromSendHistory(accounts)));
+  }, [dispatch, accounts]);
+
   const handleResetContacts = useCallback(() => {
     dispatch(setContacts(mockEmptyContacts()));
   }, [dispatch]);
@@ -93,6 +100,7 @@ export const useContactsDevToolViewModel = (): ContactsDevToolViewModel => {
     setCustomFamiliesInput,
     handleApplyCustomFamilies,
     handleLoadPopulatedContacts,
+    handleLoadFromSendHistory,
     handleResetContacts,
     handleResetOverride,
   };

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/types.ts
@@ -17,6 +17,7 @@ export interface ContactsDevToolViewModel {
   readonly setCustomFamiliesInput: (value: string) => void;
   readonly handleApplyCustomFamilies: () => void;
   readonly handleLoadPopulatedContacts: () => void;
+  readonly handleLoadFromSendHistory: () => void;
   readonly handleResetContacts: () => void;
   readonly handleResetOverride: () => void;
 }

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -5332,6 +5332,7 @@
         "applyFamilies": "Apply",
         "contactsData": "Contacts data",
         "loadPopulatedContacts": "Load populated contacts",
+        "loadFromSendHistory": "Load contacts from send history",
         "resetContacts": "Reset contacts",
         "resetOverride": "Reset override",
         "featureIntroduction": {


### PR DESCRIPTION
### 📝 Description

Mirrors the mobile generator on desktop. Adds a "Load contacts from send history" action to the desktop Contacts devtool (Settings → Developer → Contacts) that replaces saved contacts with one per distinct address the accounts have sent to, newest first.

- `createContactsFromSendHistory(accounts)` helper.
- `handleLoadFromSendHistory` wired in the devtool view model, with the button and the `en` translation key.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36615](https://ledgerhq.atlassian.net/browse/LIVE-36615)
- **ADR** (if any): n/a
- Stacked on #21288.

[LIVE-36615]: https://ledgerhq.atlassian.net/browse/LIVE-36615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ