### PR TITLE
[LWM] fix(contacts): animate QR scanner from bottom (LIVE-35884)

### DIFF
--- a/.changeset/smooth-scanner-transition.md
+++ b/.changeset/smooth-scanner-transition.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix the QR scanner opening animation on mobile.

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -507,6 +507,7 @@ export default function BaseNavigator() {
           component={ScanRecipient}
           options={{
             ...TransparentHeaderNavigationOptions,
+            animation: "slide_from_bottom",
             title: t("send.scan.title"),
             headerRight: ScanRecipientHeaderRight,
             headerLeft: renderNullHeader,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Contacts scan integration passes; the native transition itself requires visual verification on iOS and Android.
- [x] **Impact of the changes:**
      Verify that the QR scanner opens and closes smoothly from the bottom in Contacts and Send.

### 📝 Description

The shared Mobile QR scanner used the default native-stack transition, which made the Contacts add-address flow open unexpectedly.

This change applies the native `slide_from_bottom` transition to the shared `ScanRecipient` route while preserving its full-screen scanner, header, callbacks, and close behavior.

| Before | After |
| --- | --- |
| Default route transition | Smooth bottom-up transition |

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-35884

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)