### PR TITLE
test(e2e-mobile): fix borrow open-loan nightly failures

### DIFF
--- a/e2e/mobile/page/trade/borrow.page.ts
+++ b/e2e/mobile/page/trade/borrow.page.ts
@@ -173,7 +173,7 @@ export default class BorrowPage {
   }
 
   private async expectStepDone(doneId: string) {
-    await device.disableSynchronization();
+    await app.common.disableSynchronizationForiOS();
     try {
       await waitWebElementByTestId(doneId, { timeout: EXECUTION_STEP_TIMEOUT_MS });
     } catch {
@@ -184,7 +184,7 @@ export default class BorrowPage {
           : `Borrow step "${doneId}" did not complete within ${EXECUTION_STEP_TIMEOUT_MS}ms. ${MAINNET_FUNDING_HINT}`,
       );
     } finally {
-      await device.enableSynchronization();
+      await app.common.enableSynchronization();
     }
   }
 

--- a/e2e/mobile/specs/borrow/borrow.openLoan.spec.ts
+++ b/e2e/mobile/specs/borrow/borrow.openLoan.spec.ts
@@ -1,13 +1,15 @@
-import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
+import { Account, TokenAccount } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { swapSetup } from "@e2e/bridge/server";
 import { DEFAULT_LOAN, resetLoanState } from "@ledgerhq/live-e2e-shared/borrow/borrowSetup";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { setTeamOwner } from "@e2e/helpers/allure/allure-helper";
 import { BroadcastFlow, shouldRunBroadcastFlow } from "@e2e/helpers/broadcastRotation";
+import { resetCollateralAllowance } from "@e2e/utils/borrowUtils";
 import { NANO_APP_CATALOG_PATH } from "@e2e/utils/constants";
 import { FF_BORROW_ENABLED } from "@e2e/utils/featureFlagUtils";
 
 const loanAccount = Account.ETH_4;
+const collateralAccount = TokenAccount.ETH_WBTC_4;
 const COLLATERAL_SYMBOL = "wBTC";
 const EXPECTED_LTV = "50%";
 
@@ -19,72 +21,82 @@ const borrowSetupOptions = { nanoAppCatalogPath: NANO_APP_CATALOG_PATH };
  * Opening a loan is three mainnet transactions on a shared account, so it runs only on the
  * broadcast lane and only on the one platform this run assigns it.
  */
-(shouldRunBroadcastFlow(BroadcastFlow.BORROW) ? describe : describe.skip)(
-  "Borrow - Open loan",
-  () => {
-    beforeAll(async () => {
+const runHere = shouldRunBroadcastFlow(BroadcastFlow.BORROW);
+if (!runHere) {
+  const broadcastEnabled = process.env.DISABLE_TRANSACTION_BROADCAST === "0";
+  const bothPlatformsBroadcast = process.env.E2E_BROADCAST_BOTH_MOBILE_PLATFORMS === "true";
+  console.warn(
+    broadcastEnabled && bothPlatformsBroadcast
+      ? "[borrow.openLoan.spec] Skipping — rotated to the other platform for this run (avoids shared-account broadcast race)"
+      : "[borrow.openLoan.spec] Skipping — requires DISABLE_TRANSACTION_BROADCAST=0",
+  );
+}
+(runHere ? describe : describe.skip)("Borrow - Open loan", () => {
+  beforeAll(async () => {
+    await resetLoanState(borrowSetupOptions);
+    await app.init({
+      userdata: "skip-onboarding-with-last-seen-device",
+      speculosApp: loanAccount.currency.speculosApp,
+      featureFlags: FF_BORROW_ENABLED,
+      cliCommandsOnApp: [
+        {
+          app: loanAccount.currency.speculosApp,
+          cmd: liveDataWithAddressCommand(loanAccount),
+        },
+      ],
+    });
+    // Sets SWAP_DISABLE_APPS_INSTALL: without it connectApp quits the Ethereum app to reach the
+    // dashboard, which terminates the single-app Speculos container.
+    await swapSetup();
+    // Needs the address app.init resolves, and runs after the reset because closing a
+    // position can itself re-approve the collateral.
+    await resetCollateralAllowance(collateralAccount);
+    await app.mainNavigation.openPortfolioViaDeeplink();
+  }, BORROW_TIMEOUT_MS);
+
+  afterAll(async () => {
+    try {
       await resetLoanState(borrowSetupOptions);
-      await app.init({
-        userdata: "skip-onboarding-with-last-seen-device",
-        speculosApp: loanAccount.currency.speculosApp,
-        featureFlags: FF_BORROW_ENABLED,
-        cliCommandsOnApp: [
-          {
-            app: loanAccount.currency.speculosApp,
-            cmd: liveDataWithAddressCommand(loanAccount),
-          },
-        ],
-      });
-      // Sets SWAP_DISABLE_APPS_INSTALL: without it connectApp quits the Ethereum app to reach the
-      // dashboard, which terminates the single-app Speculos container.
-      await swapSetup();
-      await app.mainNavigation.openPortfolioViaDeeplink();
-    }, BORROW_TIMEOUT_MS);
+    } catch (error) {
+      console.error(
+        `[borrow] open-loan cleanup failed — ${loanAccount.accountName} may still hold a position:`,
+        error,
+      );
+    }
+  }, BORROW_TIMEOUT_MS);
 
-    afterAll(async () => {
-      try {
-        await resetLoanState(borrowSetupOptions);
-      } catch (error) {
-        console.error(
-          `[borrow] open-loan cleanup failed — ${loanAccount.accountName} may still hold a position:`,
-          error,
-        );
-      }
-    }, BORROW_TIMEOUT_MS);
+  setTeamOwner(Team.EARN);
+  $TmsLink("B2CQA-6065");
+  ["@NanoSP", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@ethereum", "@family-evm"].forEach(tag =>
+    $Tag(tag),
+  );
 
-    setTeamOwner(Team.EARN);
-    $TmsLink("B2CQA-6065");
-    ["@NanoSP", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@ethereum", "@family-evm"].forEach(tag =>
-      $Tag(tag),
-    );
+  it(
+    "should open a loan with wBTC collateral through approval, deposit and borrow",
+    async () => {
+      await app.portfolio.expectBorrowEntryPointVisible();
+      await app.portfolio.clickBorrowEntryPoint();
+      await app.borrow.expectBorrowScreenVisible();
 
-    it(
-      "should open a loan with wBTC collateral through approval, deposit and borrow",
-      async () => {
-        await app.portfolio.expectBorrowEntryPointVisible();
-        await app.portfolio.clickBorrowEntryPoint();
-        await app.borrow.expectBorrowScreenVisible();
+      await app.borrow.expectIntroModal();
+      await app.borrow.clickSimulateMyLoan();
+      await app.borrow.expectSimulateLoanScreen();
 
-        await app.borrow.expectIntroModal();
-        await app.borrow.clickSimulateMyLoan();
-        await app.borrow.expectSimulateLoanScreen();
+      await app.borrow.typeLoanAmount(DEFAULT_LOAN);
+      await app.borrow.expectCollateral(COLLATERAL_SYMBOL);
+      await app.borrow.expectLoanToValue(EXPECTED_LTV);
 
-        await app.borrow.typeLoanAmount(DEFAULT_LOAN);
-        await app.borrow.expectCollateral(COLLATERAL_SYMBOL);
-        await app.borrow.expectLoanToValue(EXPECTED_LTV);
+      await app.borrow.clickContinue();
+      await app.borrow.expectExecutionScreen();
 
-        await app.borrow.clickContinue();
-        await app.borrow.expectExecutionScreen();
+      await app.borrow.completeApprovalStep();
+      await app.borrow.authorizeDeposit();
+      await app.borrow.authorizeBorrow();
 
-        await app.borrow.completeApprovalStep();
-        await app.borrow.authorizeDeposit();
-        await app.borrow.authorizeBorrow();
-
-        await app.borrow.clickViewMyLoan();
-        await app.borrow.expectLoansDashboard();
-        await expect(app.borrow.expectLoanDashboardRow()).resolves.toBeUndefined();
-      },
-      BORROW_TIMEOUT_MS,
-    );
-  },
-);
+      await app.borrow.clickViewMyLoan();
+      await app.borrow.expectLoansDashboard();
+      await expect(app.borrow.expectLoanDashboardRow()).resolves.toBeUndefined();
+    },
+    BORROW_TIMEOUT_MS,
+  );
+});

--- a/e2e/mobile/utils/borrowUtils.ts
+++ b/e2e/mobile/utils/borrowUtils.ts
@@ -1,0 +1,41 @@
+import { TokenAccount } from "@ledgerhq/live-e2e-shared/enum/Account";
+import { resolveCollateralSpender } from "@ledgerhq/live-e2e-shared/borrow/borrowApi";
+import { DEFAULT_COLLATERAL } from "@ledgerhq/live-e2e-shared/borrow/borrowSetup";
+import { allure } from "jest-allure2-reporter/api";
+import { getEnv } from "@shared/env";
+import { deleteSpeculos, launchSpeculos, registerSpeculos } from "@e2e/utils/speculosUtils";
+
+/**
+ * Leaves the collateral allowance at zero so the "Give approval" step is always required.
+ * The partner approves an exact amount, so a run that approves and then fails before
+ * supplying leaves a residue behind, and `resetLoanState` only closes positions.
+ *
+ * Broadcasts; gated by the caller's `shouldRunBroadcastFlow`.
+ */
+export async function resetCollateralAllowance(collateralAccount: TokenAccount) {
+  const owner = collateralAccount.parentAccount ?? collateralAccount;
+  const ownerAddress = await getAccountAddress(owner);
+
+  const spender = await resolveCollateralSpender(ownerAddress, DEFAULT_COLLATERAL);
+  let allowance = await getTokenAllowanceCommand(collateralAccount, spender);
+  if (allowance !== "0") {
+    const previousSpeculosPort = getEnv("SPECULOS_API_PORT");
+    const speculos = await launchSpeculos(collateralAccount.currency.speculosApp.name);
+    await registerSpeculos(speculos.port);
+    try {
+      const result = await revokeTokenCommand(collateralAccount, spender);
+      await allure.description(`Collateral allowance revoke result:\n\n ${result}`);
+    } finally {
+      await deleteSpeculos(speculos.id);
+      if (previousSpeculosPort > 0) {
+        await registerSpeculos(previousSpeculosPort);
+      }
+    }
+    allowance = await getTokenAllowanceCommand(collateralAccount, spender);
+  }
+  if (allowance !== "0") {
+    throw new Error(
+      `Collateral allowance revoke did not settle for ${spender}: expected "0", got "${allowance}"`,
+    );
+  }
+}

--- a/libs/live-e2e-shared/src/borrow/borrowApi.ts
+++ b/libs/live-e2e-shared/src/borrow/borrowApi.ts
@@ -1,4 +1,11 @@
-import type { BorrowAction, OpenLoan, PartnerActionResponse, PartnerActionStep } from "./types";
+import { Interface } from "ethers";
+import type {
+  BorrowAction,
+  EvmSignablePayload,
+  OpenLoan,
+  PartnerActionResponse,
+  PartnerActionStep,
+} from "./types";
 
 /** Staging only — the staging Borrow API is keyless (reads and actions). */
 const BASE_URL = "https://global.api.stg.ledger-test.com/borrow";
@@ -16,6 +23,8 @@ export const ETHEREUM_CHAIN_ID = 1;
  */
 export const DEFAULT_MARKET_ID =
   "morpho-blue-borrow-ethereum-wbtc-usdt-0xa921ef34e2fc7a27ccc50ae7e4b154e16c9799d3387076c421423ef52ac4df99";
+
+const ERC20 = new Interface(["function approve(address spender, uint256 value)"]);
 
 function get(v: unknown, key: string): unknown {
   return v !== null && typeof v === "object" ? Reflect.get(v, key) : undefined;
@@ -57,6 +66,16 @@ function normalizeStep(raw: unknown, index: number): PartnerActionStep {
   return { transactionId, signablePayload, actionType: actionType.toLowerCase() };
 }
 
+function parseStepPayload(step: PartnerActionStep, index: number): EvmSignablePayload {
+  try {
+    return JSON.parse(step.signablePayload);
+  } catch {
+    throw new Error(
+      `Malformed signablePayload on partner step[${index}] (${step.actionType}): ${step.signablePayload}`,
+    );
+  }
+}
+
 /** `POST /v1/positions` — returns the raw `{ positions, errors, metadata }`. */
 export async function getPositions(address: string): Promise<unknown> {
   const res = await post("/v1/positions", [{ network: ETHEREUM_NETWORK, address }]);
@@ -76,6 +95,33 @@ export async function postAction(body: ActionRequest): Promise<PartnerActionResp
     throw new Error(`Partner returned no steps[] (actionId ${actionId})`);
   }
   return { actionId, steps: steps.map((step, i) => normalizeStep(step, i)) };
+}
+
+/**
+ * Address the collateral allowance is granted to, read from the `supply` approve step
+ * the partner builds. It is an adapter the partner can redeploy, so it is resolved rather
+ * than pinned. Building an action does not broadcast anything.
+ *
+ * The approve step is found by decoding calldata rather than by matching `step.actionType`,
+ * because the spender is an argument of that calldata: one decode both identifies the step
+ * and yields the value. `actionType` is an undocumented partner label — an open `string`
+ * with no union and no other consumer — so it is reported on failure, not matched on.
+ */
+export async function resolveCollateralSpender(
+  address: string,
+  amount: string,
+  marketId: string = DEFAULT_MARKET_ID,
+): Promise<string> {
+  const { steps } = await postAction({ address, action: "supply", args: { marketId, amount } });
+  for (const [index, step] of steps.entries()) {
+    const { data } = parseStepPayload(step, index);
+    const approve = data ? ERC20.parseTransaction({ data }) : null;
+    if (approve?.name === "approve") return approve.args.getValue("spender");
+  }
+  const actionTypes = steps.map(step => step.actionType).join(", ");
+  throw new Error(
+    `Partner supply for ${marketId} returned no ERC-20 approve step (actionTypes: ${actionTypes})`,
+  );
 }
 
 /** Best-effort notify; the state we act on is the on-chain confirmation, not this. */

--- a/libs/live-e2e-shared/src/enum/Account.ts
+++ b/libs/live-e2e-shared/src/enum/Account.ts
@@ -404,6 +404,15 @@ export class TokenAccount extends Account {
     Account.ETH_3,
   );
 
+  static readonly ETH_WBTC_4 = new TokenAccount(
+    Currency.ETH_WBTC,
+    "(Ethereum) Wrapped Bitcoin 4",
+    3,
+    Account.ETH_4.accountPath,
+    TokenType.ERC20,
+    Account.ETH_4,
+  );
+
   static readonly SOL_GIGA_1 = new TokenAccount(
     Currency.SOL_GIGA,
     "(Solana) GIGACHAD 1",

--- a/libs/live-e2e-shared/src/enum/Currency.ts
+++ b/libs/live-e2e-shared/src/enum/Currency.ts
@@ -142,6 +142,13 @@ export class Currency {
     ],
     "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
   );
+  static readonly ETH_WBTC = new Currency(
+    "Wrapped Bitcoin",
+    "WBTC",
+    "ethereum/erc20/wrapped_bitcoin",
+    AppInfos.ETHEREUM,
+    [Network.ETHEREUM],
+  );
   static readonly ETH_LIDO = new Currency(
     "LIDO Staked ETH",
     "STETH",
@@ -267,6 +274,7 @@ const CURRENCY_TEST_LABELS = new Map<Currency, string>([
   [Currency.BASE, "ETH (Base)"],
   [Currency.ETH_USDT, "USDT (Ethereum)"],
   [Currency.ETH_USDC, "USDC (Ethereum)"],
+  [Currency.ETH_WBTC, "WBTC (Ethereum)"],
   [Currency.ETH_LIDO, "STETH (Ethereum)"],
   [Currency.XLM_USDC, "USDC (Stellar)"],
   [Currency.ALGO_USDT, "USDT (Algorand)"],


### PR DESCRIPTION
## Context

The Android broadcast nightly ([run 33137517669](https://github.com/LedgerHQ/ledger-live/actions/runs/33137517669), [Slack thread](https://ledger.slack.com/archives/C05FKJ7DFAP/p1787903486181589)) fails on `should open a loan with wBTC collateral through approval, deposit and borrow`. Borrow runs only on the broadcast lane — Wed for iOS, Fri for Android — so this is the Friday Android leg.

The `android-ai-analysis` artifact shows two distinct defects across the three retries.

### 1. Stale collateral allowance

`Ethereum 4` is shared, and the partner approves an **exact** amount (`0.0002 wBTC` = 20000 units), not unlimited. A run that approves and then fails before supplying leaves a residue behind, and `resetLoanState` only closes positions — it never clears an allowance.

The execution flow then treats step 1 as already approved, so `authorizeStep`'s assertion that the step-done marker is absent throws:

```
'<[]>' doesn't match: [{"ELEMENT":…}]   at borrow.page.ts:155
```

Verified on-chain — this was sitting on the account while investigating:

```
allowance(ETH_4 → 0x3D12e577…) = 2541
```

Confirmed by reproduction: clearing it made the test pass, and leaving it made the **deposit** step fail too (`borrow-step-2-deposit-done` timing out at 240s), since the remaining allowance is below the supply amount.

The before-hook now resets the allowance so every run starts needing approval, keeping the approval path genuinely covered rather than skipped.

**The spender is resolved, not pinned.** It is a partner adapter (`0x3D12e577…`), not Morpho Blue, and the partner can redeploy it. A hardcoded address would revoke nothing while still reading back `"0"` — the assertion cannot catch that — so `resolveCollateralSpender` reads it from the partner's own approve step. Building an action does not broadcast.

### 2. `ReferenceError: device is not defined`

Hit on the one retry that got past the first defect:

```
ReferenceError: device is not defined   at borrow.page.ts:176
```

`detox.config.js:83` sets `behavior.init.exposeGlobals: false`, so `device` is undefined at runtime in every file — every other file imports it from `detox`. It typechecks because `detox/globals.d.ts` declares the globals ambiently, so only a real run catches it.

Fixed by using the existing `app.common.disableSynchronizationForiOS()` / `enableSynchronization()` helpers, as the equally webview-heavy swap specs do. These are deliberately iOS-only, so Android keeps synchronization on and a real ANR still fails the test — the previous code disabled it on both platforms.

## Verification

Local `android.emu.release`, broadcast enabled:

```
✓ should open a loan with wBTC collateral through approval, deposit and borrow  (201s)
✓ should show the Introducing Crypto Loan modal from the portfolio entry point   (30s)
Tests: 2 passed, 2 total
```

### CI

Mobile E2E dispatched on this branch, scoped to borrow only, with broadcast **on** — the flow is real
mainnet transactions and the describe is skipped without it:

| Workflow | Scope | Run |
|---|---|---|
| [Mobile] E2E Only | `test_filter=specs/borrow/`, `tests_type=Android Only`, `speculos_device=nanoX`, `enable_broadcast=true` | [run 33180224945](https://github.com/LedgerHQ/ledger-live/actions/runs/33180224945) |

The filter resolves to a single shard and iOS is skipped, so only the borrow specs execute.

`Android Only` is deliberate: `iOS & Android` sets `E2E_BROADCAST_BOTH_MOBILE_PLATFORMS=true`, and the
rotation in `shouldRunBroadcastFlow` would then pin borrow to one platform and skip the other. The
filter is `specs/borrow/` rather than the single spec path so `borrow.coldStart.spec.ts` runs too.

## Notes for review

- `Currency.ETH_WBTC` and `TokenAccount.ETH_WBTC_4` are additive; no existing entry changes. `revokeTokenCommand` needs a `TokenAccount`, and index `3` matches `Account.ETH_4`.
- `resetCollateralAllowance` mirrors swap's `revokeTokenApproval` (`e2e/mobile/utils/swapUtils.ts`), including the Speculos save/restore. It runs after `app.init` because it needs the address `liveDataWithAddressCommand` resolves.
- Desktop is unaffected: it already handles the already-approved case with a conditional (`completeGiveApprovalIfRequired`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
