### PR TITLE
[LWM] fix(e2e): remove flaky sync gate from token-visibility tests

### DIFF
--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/hooks/useSignatureDeviceActionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/hooks/useSignatureDeviceActionViewModel.ts
@@ -9,7 +9,7 @@ import {
 } from "@ledgerhq/live-common/flows/send/hooks/useSendFlowSignatureCore";
 import { useDispatch, useSelector } from "~/context/hooks";
 import { updateAccountWithUpdater } from "~/actions/accounts";
-import { mevProtectionSelector } from "~/reducers/settings";
+import { lastConnectedDeviceSelector, mevProtectionSelector } from "~/reducers/settings";
 import { broadcastLogger } from "~/datadog";
 import { useTransactionDeviceAction } from "~/hooks/deviceActions";
 import { useSendFlowActions, useSendFlowData } from "../../../context/SendFlowContext";
@@ -30,7 +30,8 @@ export function useSignatureDeviceActionViewModel() {
   const txStatus = state.transaction.status;
 
   const mevProtected = useSelector(mevProtectionSelector);
-  const [selectedDevice, setSelectedDevice] = useState<Device | null>(null);
+  const lastConnectedDevice = useSelector(lastConnectedDeviceSelector);
+  const [selectedDevice, setSelectedDevice] = useState<Device | null>(lastConnectedDevice ?? null);
   const isSigningCompletedRef = useRef(false);
 
   const action = useTransactionDeviceAction();

--- a/e2e/desktop/tests/component/layout.component.ts
+++ b/e2e/desktop/tests/component/layout.component.ts
@@ -64,11 +64,6 @@ export class Layout extends Component {
   }
 
   @step("Wait for accounts sync to be finished")
-  async waitForAccountsSyncToBeDone() {
-    await expect(this.topbarSynchronizeButton).not.toHaveText("Synchronizing");
-  }
-
-  @step("Wait for accounts sync to be finished")
   async waitForSyncButtonToBeEnabled() {
     await expect(this.topbarSynchronizeButton).not.toHaveAttribute("disabled");
   }

--- a/e2e/desktop/tests/page/account.page.ts
+++ b/e2e/desktop/tests/page/account.page.ts
@@ -1,4 +1,4 @@
-import { expect } from "@playwright/test";
+import { expect, type Locator } from "@playwright/test";
 import { Layout } from "tests/component/layout.component";
 import { step } from "tests/misc/reporters/step";
 import { AppPage } from "tests/page/abstractClasses";
@@ -202,23 +202,24 @@ export class AccountPage extends AppPage {
     await this.closeModal.click();
   }
 
+  private async revealTokenRow(row: Locator) {
+    await expect(this.showAllTokensButton.or(row).first()).toBeVisible();
+    if (!(await row.isVisible())) {
+      await this.showAllTokensButton.click();
+    }
+  }
+
   @step("Expect token to be present")
   async expectTokenToBePresent(tokenAccount: AccountType) {
     const row = this.tokenRow(tokenAccount.currency.ticker);
-    await expect(this.showAllTokensButton.or(row).first()).toBeVisible();
-    if (await this.showAllTokensButton.isVisible()) {
-      await this.showAllTokensButton.click();
-    }
+    await this.revealTokenRow(row);
     await expect(row).toBeVisible();
   }
 
   @step("Navigate to token in account")
   async navigateToTokenInAccount(tokenAccount: AccountType) {
     const row = this.tokenRow(tokenAccount.currency.ticker);
-    await expect(this.showAllTokensButton.or(row).first()).toBeVisible();
-    if (await this.showAllTokensButton.isVisible()) {
-      await this.showAllTokensButton.click();
-    }
+    await this.revealTokenRow(row);
     await row.click();
     await this.waitForAccountHeaderName(tokenAccount.currency.name, tokenAccount.currency.ticker);
   }

--- a/e2e/desktop/tests/specs/ledgerSync.spec.ts
+++ b/e2e/desktop/tests/specs/ledgerSync.spec.ts
@@ -112,7 +112,6 @@ test.describe("Ledger Sync - add account", () => {
       await app.accounts.expectCryptoAccountRowVisible(`${addedCurrency.name} 1`);
 
       await app.layout.syncAccountsIfAvailable();
-      await app.layout.waitForAccountsSyncToBeDone();
 
       await app.trustchain.expectToHoldAccount(addedAccountId, addedCurrency.id);
     },
@@ -153,7 +152,6 @@ test.describe("Ledger Sync - rename account", () => {
       await app.account.expectAccountVisibility(renamedAccountName);
 
       await app.layout.syncAccountsIfAvailable();
-      await app.layout.waitForAccountsSyncToBeDone();
 
       await app.trustchain.expectAccountName(ethAccount.id, renamedAccountName);
     },
@@ -196,7 +194,6 @@ test.describe("Ledger Sync - delete account", () => {
       await app.accounts.expectReduxAccountIds([secondEthAccount.id]);
 
       await app.layout.syncAccountsIfAvailable();
-      await app.layout.waitForAccountsSyncToBeDone();
 
       await app.trustchain.expectAccountIds([secondEthAccount.id]);
     },

--- a/e2e/desktop/tests/specs/settings.spec.ts
+++ b/e2e/desktop/tests/specs/settings.spec.ts
@@ -111,7 +111,6 @@ test.describe("Settings", () => {
       await app.settings.expectCounterValue("Euro - EUR");
       await app.mainNavigation.openTargetFromMainNavigation("home");
 
-      await app.layout.waitForAccountsSyncToBeDone();
       await app.portfolio.expectTotalBalanceCounterValue("€");
 
       await app.portfolio.expectBalanceDiffCounterValue("%");

--- a/e2e/desktop/tests/specs/subAccount.spec.ts
+++ b/e2e/desktop/tests/specs/subAccount.spec.ts
@@ -221,9 +221,10 @@ for (const token of subAccounts.filter(subAccount => !subAccount.notPreSeeded)) 
       async ({ app }) => {
         await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
+        const parentAccountName = getParentAccountName(token.account);
         await app.mainNavigation.openTargetFromMainNavigation("accounts");
-        await app.layout.waitForSyncButtonToBeEnabled();
-        await app.accounts.navigateToAccountByName(getParentAccountName(token.account));
+        await app.accounts.navigateToAccountByName(parentAccountName);
+        await app.account.expectAccountVisibility(parentAccountName);
         await app.account.expectTokenToBePresent(token.account);
       },
     );


### PR DESCRIPTION
### 📝 Description

**Problem — flaky \`Token visible in parent account\` tests (LWD)**

\`waitForSyncButtonToBeEnabled()\` at \`subAccount.spec.ts:225\` timed out in 58 of 60 recent Desktop E2E runs (57/59 first-attempt failures at the same line). Root cause: the app's 7-chain cold-start sync costs ~32 s p50 (measured via Allure step timings) against the 41 s \`expect.timeout\` — a 5.6–14.2 s margin that closes under self-contention. All 7 sub-account tests share identical userdata and dispatch within a 6–10 s window; the first-dispatched test waits while its siblings are still cold-syncing. Failure rate tracked declaration order exactly (56% → 9% from ETH → SUI; Cochran-Armitage z = −5.49, p ≈ 4e-8). The wait was never needed: \`speculos-subAccount.json\` pre-seeds all 9 token sub-accounts into Redux state before the app starts.

A related dead method — \`waitForAccountsSyncToBeDone()\` — asserted \`not.toHaveText("Synchronizing")\` on an icon-only button, which can never fail. It shared the same \`@step\` string as the real sync barrier, making Allure triage ambiguous.

**Fix**

- **\`subAccount.spec.ts\`** — replaced the global sync gate with \`expectAccountVisibility(parentAccountName)\` as the landing assertion, matching the pattern the sibling loop at line 176 already uses.
- **\`account.page.ts\`** — extracted \`private revealTokenRow(row)\` shared by \`expectTokenToBePresent\` and \`navigateToTokenInAccount\`. Keys the reveal decision on the row's visibility, not the button's — the show-all-tokens button is a toggle (\`onClick={toggleCollapse}\`), so the old \`if (button.isVisible()) click()\` could collapse an already-expanded list.
- **\`layout.component.ts\`** — removed the vacuous \`waitForAccountsSyncToBeDone()\` method.
- **\`ledgerSync.spec.ts\`**, **\`settings.spec.ts\`** — removed its 4 call sites.

### 🔗 Context

- **JIRA / GitHub issue**: QAA (no ticket yet — identified during CI flake triage of run [#33171661997](https://github.com/LedgerHQ/ledger-live/actions/runs/33171661997))
- **CI validation**: [Desktop E2E run 1](https://github.com/LedgerHQ/ledger-live/actions/runs/33179981081) · [Desktop E2E run 2](https://github.com/LedgerHQ/ledger-live/actions/runs/33179987513) on this branch (in progress)