### PR TITLE
[LWD] feat(analytics): log identify in the desktop overlay (LIVE-35849)

### DIFF
--- a/.changeset/quiet-identify-overlay.md
+++ b/.changeset/quiet-identify-overlay.md
@@ -2,4 +2,4 @@
 "ledger-live-desktop": patch
 ---
 
-Log Segment identify calls in the desktop analytics debug overlay
+Log Segment identify calls (success or failed) in the desktop analytics debug overlay

--- a/.changeset/quiet-identify-overlay.md
+++ b/.changeset/quiet-identify-overlay.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Log Segment identify calls in the desktop analytics debug overlay

--- a/apps/ledger-live-desktop/src/renderer/analytics/__tests__/segment.identifyOverlay.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/__tests__/segment.identifyOverlay.test.ts
@@ -24,6 +24,7 @@ jest.mock("~/renderer/logger", () => ({
 }));
 
 import type { Subscription } from "rxjs";
+import { waitFor } from "tests/testSetup";
 import createStore from "~/state-manager/configureStore";
 import type { State } from "~/renderer/reducers";
 import { INITIAL_STATE as SETTINGS_INITIAL_STATE } from "~/renderer/reducers/settings";
@@ -64,18 +65,19 @@ describe("segment identify overlay (LIVE-35849)", () => {
     await startAnalytics(createStoreWithAnalytics(true));
 
     expect(mockIdentify).toHaveBeenCalled();
-    expect(logged).toEqual([expect.objectContaining(identifyOverlayEvent)]);
+    await waitFor(() => expect(logged).toEqual([expect.objectContaining(identifyOverlayEvent)]));
   });
 
   it("should log [Identify] after updateIdentify when tracking is on and the client is ready", async () => {
     await startAnalytics(createStoreWithAnalytics(true));
+    await waitFor(() => expect(logged.length).toBeGreaterThan(0));
     mockIdentify.mockClear();
     logged.length = 0;
 
     await updateIdentify();
 
     expect(mockIdentify).toHaveBeenCalledTimes(1);
-    expect(logged).toEqual([expect.objectContaining(identifyOverlayEvent)]);
+    await waitFor(() => expect(logged).toEqual([expect.objectContaining(identifyOverlayEvent)]));
   });
 
   it("should not log [Identify] when tracking is off and identify does not run", async () => {
@@ -97,6 +99,27 @@ describe("segment identify overlay (LIVE-35849)", () => {
     await updateIdentify({ force: true });
 
     expect(mockIdentify).toHaveBeenCalled();
-    expect(logged).toEqual([expect.objectContaining(identifyOverlayEvent)]);
+    await waitFor(() => expect(logged).toEqual([expect.objectContaining(identifyOverlayEvent)]));
+  });
+
+  it("should log [Identify] with failed when the Segment identify promise rejects", async () => {
+    await startAnalytics(createStoreWithAnalytics(true));
+    await waitFor(() => expect(logged.length).toBeGreaterThan(0));
+    mockIdentify.mockClear();
+    logged.length = 0;
+    mockIdentify.mockRejectedValueOnce(new Error("sdk down"));
+
+    await updateIdentify();
+
+    expect(mockIdentify).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(logged).toEqual([
+        expect.objectContaining({
+          eventName: "[Identify]",
+          eventProperties: { userIdPresent: expect.any(Boolean), failed: true },
+          eventPropertiesWithoutExtra: { userIdPresent: expect.any(Boolean), failed: true },
+        }),
+      ]),
+    );
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/analytics/__tests__/segment.identifyOverlay.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/__tests__/segment.identifyOverlay.test.ts
@@ -1,0 +1,102 @@
+jest.unmock("../segment");
+jest.unmock("~/renderer/analytics/segment");
+jest.unmock("src/renderer/analytics/segment");
+
+const mockIdentify = jest.fn();
+
+jest.mock("@segment/analytics-next", () => ({
+  AnalyticsBrowser: {
+    load: jest.fn(() => ({
+      identify: mockIdentify,
+      track: jest.fn(),
+    })),
+  },
+}));
+
+jest.mock("~/renderer/logger", () => ({
+  __esModule: true,
+  default: {
+    analyticsPage: jest.fn(),
+    analyticsStart: jest.fn(),
+    analyticsTrack: jest.fn(),
+    onReduxAction: jest.fn(),
+  },
+}));
+
+import type { Subscription } from "rxjs";
+import createStore from "~/state-manager/configureStore";
+import type { State } from "~/renderer/reducers";
+import { INITIAL_STATE as SETTINGS_INITIAL_STATE } from "~/renderer/reducers/settings";
+import { startAnalytics, trackSubject, updateIdentify, type LoggableEvent } from "../segment";
+
+const identifyOverlayEvent = {
+  eventName: "[Identify]",
+  eventProperties: { userIdPresent: expect.any(Boolean) },
+  eventPropertiesWithoutExtra: { userIdPresent: expect.any(Boolean) },
+};
+
+const createStoreWithAnalytics = (shareAnalytics: boolean) =>
+  createStore({
+    state: {
+      settings: {
+        ...SETTINGS_INITIAL_STATE,
+        shareAnalytics,
+        sharePersonalizedRecommandations: false,
+      },
+    } as State,
+    fetchRemoteFlags: null,
+  });
+
+describe("segment identify overlay (LIVE-35849)", () => {
+  let logged: LoggableEvent[];
+  let subscription: Subscription;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    logged = [];
+    subscription = trackSubject.subscribe(event => logged.push(event));
+    logged.length = 0;
+  });
+
+  afterEach(() => subscription.unsubscribe());
+
+  it("should log [Identify] when analytics starts with tracking on", async () => {
+    await startAnalytics(createStoreWithAnalytics(true));
+
+    expect(mockIdentify).toHaveBeenCalled();
+    expect(logged).toEqual([expect.objectContaining(identifyOverlayEvent)]);
+  });
+
+  it("should log [Identify] after updateIdentify when tracking is on and the client is ready", async () => {
+    await startAnalytics(createStoreWithAnalytics(true));
+    mockIdentify.mockClear();
+    logged.length = 0;
+
+    await updateIdentify();
+
+    expect(mockIdentify).toHaveBeenCalledTimes(1);
+    expect(logged).toEqual([expect.objectContaining(identifyOverlayEvent)]);
+  });
+
+  it("should not log [Identify] when tracking is off and identify does not run", async () => {
+    await startAnalytics(createStoreWithAnalytics(false));
+    mockIdentify.mockClear();
+    logged.length = 0;
+
+    await updateIdentify();
+
+    expect(mockIdentify).not.toHaveBeenCalled();
+    expect(logged).toEqual([]);
+  });
+
+  it("should log [Identify] when updateIdentify is forced while tracking is off", async () => {
+    await startAnalytics(createStoreWithAnalytics(false));
+    mockIdentify.mockClear();
+    logged.length = 0;
+
+    await updateIdentify({ force: true });
+
+    expect(mockIdentify).toHaveBeenCalled();
+    expect(logged).toEqual([expect.objectContaining(identifyOverlayEvent)]);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/analytics/__tests__/segment.identifyOverlay.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/__tests__/segment.identifyOverlay.test.ts
@@ -102,6 +102,29 @@ describe("segment identify overlay (LIVE-35849)", () => {
     await waitFor(() => expect(logged).toEqual([expect.objectContaining(identifyOverlayEvent)]));
   });
 
+  it("should log [Identify] with failed when identify throws synchronously", async () => {
+    await startAnalytics(createStoreWithAnalytics(true));
+    await waitFor(() => expect(logged.length).toBeGreaterThan(0));
+    mockIdentify.mockClear();
+    logged.length = 0;
+    mockIdentify.mockImplementationOnce(() => {
+      throw new Error("sdk down");
+    });
+
+    await expect(updateIdentify()).resolves.toBeUndefined();
+
+    expect(mockIdentify).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(logged).toEqual([
+        expect.objectContaining({
+          eventName: "[Identify]",
+          eventProperties: { userIdPresent: expect.any(Boolean), failed: true },
+          eventPropertiesWithoutExtra: { userIdPresent: expect.any(Boolean), failed: true },
+        }),
+      ]),
+    );
+  });
+
   it("should log [Identify] with failed when the Segment identify promise rejects", async () => {
     await startAnalytics(createStoreWithAnalytics(true));
     await waitFor(() => expect(logged.length).toBeGreaterThan(0));

--- a/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
@@ -438,16 +438,7 @@ export const startAnalytics = async (store: ReduxStore) => {
     braze_external_id: id, // Needed for braze with this exact name
   };
   logger.analyticsStart(id, allProperties);
-  analytics.identify(id, allProperties, {
-    context: getContext(),
-  });
-  const overlayProperties = { userIdPresent: Boolean(id) };
-  trackSubject.next({
-    eventName: "[Identify]",
-    eventProperties: overlayProperties,
-    eventPropertiesWithoutExtra: overlayProperties,
-    date: new Date(),
-  });
+  identifyAndLogOverlay(analytics, id, allProperties);
 };
 type Properties = Error | Record<string, unknown> | null;
 export type LoggableEvent = {
@@ -457,6 +448,32 @@ export type LoggableEvent = {
   date: Date;
 };
 export const trackSubject = new ReplaySubject<LoggableEvent>(30);
+
+const publishIdentifyOverlay = (userIdPresent: boolean, failed: boolean) => {
+  const overlayProperties = failed ? { userIdPresent, failed: true } : { userIdPresent };
+  trackSubject.next({
+    eventName: "[Identify]",
+    eventProperties: overlayProperties,
+    eventPropertiesWithoutExtra: overlayProperties,
+    date: new Date(),
+  });
+};
+
+const identifyAndLogOverlay = (
+  analytics: AnalyticsBrowser,
+  id: string | undefined,
+  allProperties: Record<string, unknown>,
+) => {
+  void Promise.resolve(
+    analytics.identify(id, allProperties, {
+      context: getContext(),
+    }),
+  ).then(
+    () => publishIdentifyOverlay(Boolean(id), false),
+    () => publishIdentifyOverlay(Boolean(id), true),
+  );
+};
+
 function sendTrack(event: string, properties: object | undefined | null) {
   const analytics = getAnalytics();
   if (!analytics) return;
@@ -531,16 +548,7 @@ export const updateIdentify = async ({ force }: UpdateIdentifyOptions = { force:
     ...extraProperties(storeInstance),
     ...(id ? { userId: id, braze_external_id: id } : {}),
   };
-  analytics.identify(id, allProperties, {
-    context: getContext(),
-  });
-  const overlayProperties = { userIdPresent: Boolean(id) };
-  trackSubject.next({
-    eventName: "[Identify]",
-    eventProperties: overlayProperties,
-    eventPropertiesWithoutExtra: overlayProperties,
-    date: new Date(),
-  });
+  identifyAndLogOverlay(analytics, id, allProperties);
 };
 /** Ensure PTX flag attributes are set as soon as feature flags load */
 runOnceWhen(() => !!analyticsFeatureFlagMethod && !!getAnalytics(), updateIdentify);

--- a/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
@@ -464,14 +464,16 @@ const identifyAndLogOverlay = (
   id: string | undefined,
   allProperties: Record<string, unknown>,
 ) => {
-  void Promise.resolve(
-    analytics.identify(id, allProperties, {
-      context: getContext(),
-    }),
-  ).then(
-    () => publishIdentifyOverlay(Boolean(id), false),
-    () => publishIdentifyOverlay(Boolean(id), true),
-  );
+  void Promise.resolve()
+    .then(() =>
+      analytics.identify(id, allProperties, {
+        context: getContext(),
+      }),
+    )
+    .then(
+      () => publishIdentifyOverlay(Boolean(id), false),
+      () => publishIdentifyOverlay(Boolean(id), true),
+    );
 };
 
 function sendTrack(event: string, properties: object | undefined | null) {

--- a/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
@@ -441,6 +441,13 @@ export const startAnalytics = async (store: ReduxStore) => {
   analytics.identify(id, allProperties, {
     context: getContext(),
   });
+  const overlayProperties = { userIdPresent: Boolean(id) };
+  trackSubject.next({
+    eventName: "[Identify]",
+    eventProperties: overlayProperties,
+    eventPropertiesWithoutExtra: overlayProperties,
+    date: new Date(),
+  });
 };
 type Properties = Error | Record<string, unknown> | null;
 export type LoggableEvent = {
@@ -526,6 +533,13 @@ export const updateIdentify = async ({ force }: UpdateIdentifyOptions = { force:
   };
   analytics.identify(id, allProperties, {
     context: getContext(),
+  });
+  const overlayProperties = { userIdPresent: Boolean(id) };
+  trackSubject.next({
+    eventName: "[Identify]",
+    eventProperties: overlayProperties,
+    eventPropertiesWithoutExtra: overlayProperties,
+    date: new Date(),
   });
 };
 /** Ensure PTX flag attributes are set as soon as feature flags load */


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

The desktop analytics debug overlay already shows `track` and `trackPage` via `trackSubject`, but `startAnalytics` and `updateIdentify` called Segment identify without publishing anything. When debugging why a user's traits do not match their events, there was no way to see whether identify ran, or in which order relative to tracks.

After `analytics.identify` actually runs, both call sites now publish an overlay entry:

- `eventName: "[Identify]"` (same label as mobile)
- properties limited to `{ userIdPresent }` on both property bags so the overlay shows it without Extra props
- still silent on the existing early returns: no store, tracking off (unless `force`), no analytics client

Identify arguments, frequency, and fire-and-forget behaviour are unchanged. No flush port, no SDK bump. The overlay only exists behind `ANALYTICS_CONSOLE`, so there is no impact on users.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35849](https://ledgerhq.atlassian.net/browse/LIVE-35849)
- Related: [LIVE-35845](https://ledgerhq.atlassian.net/browse/LIVE-35845) (mobile identify overlay)
- **ADR** (if any): n/a

### Test plan

Covered by unit tests in `src/renderer/analytics/__tests__/segment.identifyOverlay.test.ts`:

- [x] `[Identify]` is logged when analytics starts with tracking on
- [x] `[Identify]` is logged after `updateIdentify` with tracking on and client ready
- [x] no overlay entry when tracking is off and identify does not run
- [x] `[Identify]` is logged when `updateIdentify({ force: true })` runs while tracking is off

Manual check:

- [ ] Enable the analytics console (`ANALYTICS_CONSOLE`) and confirm `[Identify]` shows up next to tracks

Made with [Cursor](https://cursor.com)

[LIVE-35849]: https://ledgerhq.atlassian.net/browse/LIVE-35849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ