### PR TITLE
[LWM] perf(lwm): enable R8 on Android release builds (LIVE-28531)

### DIFF
--- a/.changeset/eighty-pugs-shave.md
+++ b/.changeset/eighty-pugs-shave.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Enable R8 code shrinking, optimization and resource shrinking on Android release builds (LIVE-28531)

--- a/apps/ledger-live-mobile/android/app/build.gradle
+++ b/apps/ledger-live-mobile/android/app/build.gradle
@@ -84,7 +84,7 @@ def enableSeparateBuildPerCPUArchitecture = true
 /**
  * Set this to true to Run Proguard on Release builds to minify the Java bytecode.
  */
-def enableProguardInReleaseBuilds = false
+def enableProguardInReleaseBuilds = true
 
 /**
  * The preferred build flavor of JavaScriptCore (JSC)
@@ -135,6 +135,7 @@ android {
         resValue "string", "build_config_package", "com.ledger.live"
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+        testProguardFiles "proguard-rules-androidTest.pro"
     }
 
     configurations.all {
@@ -177,8 +178,8 @@ android {
         }
         release {
             minifyEnabled enableProguardInReleaseBuilds
-            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
-            proguardFile "${rootProject.projectDir}/../node_modules/detox/android/detox/proguard-rules-app.pro"
+            shrinkResources enableProguardInReleaseBuilds
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
             matchingFallbacks = ['debug']
         }
         stagingRelease {
@@ -190,11 +191,15 @@ android {
         detox {
             initWith(buildTypes.stagingRelease)
             applicationIdSuffix ".detox"
+            proguardFile "${rootProject.projectDir}/../node_modules/detox/android/detox/proguard-rules-app.pro"
+            proguardFile "proguard-rules-detox.pro"
             matchingFallbacks = ['stagingRelease', 'release']
         }
         detoxPreRelease {
             initWith(buildTypes.release)
             signingConfig signingConfigs.stagingRelease
+            proguardFile "${rootProject.projectDir}/../node_modules/detox/android/detox/proguard-rules-app.pro"
+            proguardFile "proguard-rules-detox.pro"
             matchingFallbacks = ['release']
         }
     }

--- a/apps/ledger-live-mobile/android/app/proguard-rules-androidTest.pro
+++ b/apps/ledger-live-mobile/android/app/proguard-rules-androidTest.pro
@@ -1,0 +1,5 @@
+-dontshrink
+-dontoptimize
+-dontobfuscate
+
+-dontwarn androidx.concurrent.futures.SuspendToFutureAdapter

--- a/apps/ledger-live-mobile/android/app/proguard-rules-detox.pro
+++ b/apps/ledger-live-mobile/android/app/proguard-rules-detox.pro
@@ -1,0 +1,2 @@
+-keep class kotlin.** { *; }
+-keep class kotlinx.coroutines.** { *; }

--- a/apps/ledger-live-mobile/android/app/proguard-rules.pro
+++ b/apps/ledger-live-mobile/android/app/proguard-rules.pro
@@ -30,3 +30,5 @@
 -keep class com.brentvatne.** { *; }
 -keep class com.yqritc.** { *; }
 -keep class com.google.android.exoplayer2.** { *; }
+
+-keep class com.ledger.live.BuildConfig { *; }


### PR DESCRIPTION
### 📝 Description

Google Play flags LWM bundles as unoptimized (deadline Feb 2027). The React Native template ships `enableProguardInReleaseBuilds = false` and it was never flipped, so every AAB so far has unminified dex.

Enables R8 on `release` (inherited by `stagingRelease`): `minifyEnabled`, `shrinkResources`, and `proguard-android-optimize.txt`.

Two things needed handling:

- **`BuildConfig` keep rule.** `react-native-config` reads env via `Class.forName` + `getDeclaredFields`, so R8 saw no reference and deleted the class — every `Config.*` became empty at runtime. The app still booted, which also meant `isDatadogEnabled` was `false`, i.e. no Datadog in production.
- **Detox variants get their own rules.** The instrumentation APK isn't minified, so its bytecode links against a kotlin-stdlib that R8 may shrink, rename or inline. Enumerating classes didn't converge (three different ones broke across runs), so `detox`/`detoxPreRelease` keep `kotlin.**` + `kotlinx.coroutines.**`. Detox's own `proguard-rules-app.pro` moved off `release` onto them too — production was carrying it for no benefit. App code and libraries stay fully minified in the Detox build; only the stdlib is exempt.

`assembleRelease`, arm64-v8a:

| | before | after |
|---|---|---|
| APK | 152.2 MB | 139.5 MB |
| dex | 47.7 MB / 6 files | 12.9 MB / 2 files |

R8 adds ~1m55s per release build.

**Validation**

- CI green, including Android E2E smoke.
- Full Android E2E: 9/12 shards green. 3 of the 5 failures reproduce on `develop` and other branches without R8; the 2 remaining (`Asset aggregation [DAI]`) show the page rendering correctly and have no identified R8 mechanism.
- Signed `stagingRelease` APK installed on a physical device: no crashes, Braze and Datadog SDK load, localisation and video fine.

**Follow-up:** [LIVE-36707](https://ledgerhq.atlassian.net/browse/LIVE-36707) — upload the R8 `mapping.txt` to Datadog, otherwise Java/Kotlin stack traces arrive obfuscated. Play Console is unaffected (AGP embeds the mapping in the AAB), and JS sourcemaps already upload from `ledger-live-build`.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-28531](https://ledgerhq.atlassian.net/browse/LIVE-28531)
- [Android — Enable app optimization](https://developer.android.com/topic/performance/app-optimization/enable-app-optimization). The `optimization {}` DSL there needs AGP 9.3+; we're on 8.11.0 (pinned by `@react-native/gradle-plugin`), so this uses the legacy DSL.


[LIVE-36707]: https://ledgerhq.atlassian.net/browse/LIVE-36707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ