### PR TITLE
[LWDM] refactor(hedera): fetch validators on demand

### DIFF
--- a/.changeset/tidy-plums-hunt.md
+++ b/.changeset/tidy-plums-hunt.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-hedera": minor
+---
+
+refactor: fetch validators on demand in coin-hedera module

--- a/libs/coin-modules/coin-hedera/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/getTransactionStatus.test.ts
@@ -25,7 +25,6 @@ import * as logicUtils from "../logic/utils";
 import { HEDERA_MAX_MEMO_SIZE } from "../logic/validateMemo";
 import { rpcClient } from "../network/rpc";
 import * as networkUtils from "../network/utils";
-import * as preloadData from "../preload-data";
 import { getMockedAccount, getMockedTokenAccount } from "../test/fixtures/account.fixture";
 import { getMockedConfig } from "../test/fixtures/config.fixture";
 import {
@@ -33,7 +32,7 @@ import {
   getMockedHTSTokenCurrency,
 } from "../test/fixtures/currency.fixture";
 import { getMockedTransaction } from "../test/fixtures/transaction.fixture";
-import type { EstimateFeesResult, HederaPreloadData, Transaction } from "../types";
+import type { EstimateFeesResult, HederaValidator, Transaction } from "../types";
 
 // Mock modules before importing
 jest.mock("../logic/estimateFees", () => ({
@@ -49,6 +48,7 @@ jest.mock("../network/utils", () => ({
   ...jest.requireActual("../network/utils"),
   getCurrencyToUSDRate: jest.fn(),
   checkAccountTokenAssociationStatus: jest.fn(),
+  getHederaValidators: jest.fn(),
 }));
 
 jest.mock("@ledgerhq/ledger-wallet-framework/account", () => {
@@ -58,11 +58,6 @@ jest.mock("@ledgerhq/ledger-wallet-framework/account", () => {
     findSubAccountById: jest.fn(actual.findSubAccountById),
   };
 });
-
-jest.mock("../preload-data", () => ({
-  ...jest.requireActual("../preload-data"),
-  getCurrentHederaPreloadData: jest.fn(),
-}));
 
 jest.mock("../network/rpc", () => ({
   rpcClient: require("../test/fixtures/rpc.fixture").getMockedRpcClient(),
@@ -75,14 +70,14 @@ const mockGetCurrencyToUSDRate = networkUtils.getCurrencyToUSDRate as unknown as
 const mockResolveConfig = logicUtils.resolveConfig as jest.Mock;
 const mockCheckAccountTokenAssociationStatus =
   networkUtils.checkAccountTokenAssociationStatus as unknown as jest.Mock;
-const mockGetCurrentHederaPreloadData = preloadData.getCurrentHederaPreloadData as jest.Mock;
+const mockGetHederaValidators = networkUtils.getHederaValidators as unknown as jest.Mock;
 const mockFindSubAccountById = accountHelpers.findSubAccountById as jest.Mock;
 
 describe("getTransactionStatus", () => {
   const mockConfig = getMockedConfig();
   const mockedEstimatedFee: EstimateFeesResult = { tinybars: new BigNumber(1) };
   const mockedUsdRate = new BigNumber(1);
-  const mockPreload = { validators: [{ id: "1" }, { id: "2" }] } as HederaPreloadData;
+  const mockValidators = [{ id: "1" }, { id: "2" }] as HederaValidator[];
   const validRecipientAddress = "0.0.1234567";
   const validRecipientAddressWithChecksum = "0.0.1234567-ylkls";
 
@@ -93,7 +88,7 @@ describe("getTransactionStatus", () => {
     mockResolveConfig.mockReturnValue(mockConfig);
     mockEstimateFees.mockResolvedValue(mockedEstimatedFee);
     mockGetCurrencyToUSDRate.mockResolvedValue(mockedUsdRate);
-    mockGetCurrentHederaPreloadData.mockReturnValue(mockPreload);
+    mockGetHederaValidators.mockResolvedValue(mockValidators);
     // Default: association is verified
     mockCheckAccountTokenAssociationStatus.mockResolvedValue(true);
     // Reset findSubAccountById to use actual implementation
@@ -504,6 +499,67 @@ describe("getTransactionStatus", () => {
     const result = await getTransactionStatus(account, transaction);
 
     expect(result.errors.missingStakingNodeId).toBeInstanceOf(HederaInvalidStakingNodeIdError);
+  });
+
+  it("resolves with errors.validators instead of rejecting when validators fetch fails", async () => {
+    mockGetHederaValidators.mockRejectedValueOnce(new Error("network down"));
+    const account = getMockedAccount();
+    const transaction = getMockedTransaction({
+      mode: HEDERA_TRANSACTION_MODES.Delegate,
+      properties: { stakingNodeId: 1 },
+    });
+
+    const result = await getTransactionStatus(account, transaction);
+
+    expect(result.errors.validators).toBeInstanceOf(Error);
+    expect(result.errors.stakingNodeId).toBeUndefined();
+  });
+
+  it("wraps a non-Error rejection from the validators fetch into an Error", async () => {
+    mockGetHederaValidators.mockRejectedValueOnce("network down");
+    const account = getMockedAccount();
+    const transaction = getMockedTransaction({
+      mode: HEDERA_TRANSACTION_MODES.Delegate,
+      properties: { stakingNodeId: 1 },
+    });
+
+    const result = await getTransactionStatus(account, transaction);
+
+    expect(result.errors.validators).toBeInstanceOf(Error);
+    expect(result.errors.validators?.message).toBe("network down");
+  });
+
+  const hederaResourcesWithRewards = {
+    maxAutomaticTokenAssociations: 0,
+    isAutoTokenAssociationEnabled: false,
+    delegation: {
+      nodeId: 1,
+      pendingReward: new BigNumber(10),
+      delegated: new BigNumber(1000),
+    },
+  };
+
+  it("does not fetch validators when undelegating", async () => {
+    const account = getMockedAccount({ hederaResources: hederaResourcesWithRewards });
+    const transaction = getMockedTransaction({
+      mode: HEDERA_TRANSACTION_MODES.Undelegate,
+      properties: { stakingNodeId: null },
+    });
+
+    const result = await getTransactionStatus(account, transaction);
+
+    expect(mockGetHederaValidators).not.toHaveBeenCalled();
+    expect(result.errors.validators).toBeUndefined();
+  });
+
+  it("does not fetch validators when claiming rewards", async () => {
+    const account = getMockedAccount({ hederaResources: hederaResourcesWithRewards });
+    const transaction = getMockedTransaction({ mode: HEDERA_TRANSACTION_MODES.ClaimRewards });
+
+    const result = await getTransactionStatus(account, transaction);
+
+    expect(mockGetHederaValidators).not.toHaveBeenCalled();
+    expect(result.errors.validators).toBeUndefined();
   });
 
   it("adds error for delegation with invalid staking node id", async () => {

--- a/libs/coin-modules/coin-hedera/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/getTransactionStatus.ts
@@ -31,9 +31,9 @@ import { validateMemo } from "../logic/validateMemo";
 import {
   getCurrencyToUSDRate,
   checkAccountTokenAssociationStatus,
+  getHederaValidators,
   safeParseAccountId,
 } from "../network/utils";
-import { getCurrentHederaPreloadData } from "../preload-data";
 import type {
   HederaAccount,
   Transaction,
@@ -283,22 +283,35 @@ async function handleStakingTransaction(account: HederaAccount, transaction: Tra
 
   const errors: Record<string, Error> = {};
   const warnings: Record<string, Error> = {};
-  const { validators } = getCurrentHederaPreloadData(account.currency);
-  const estimatedFees = await estimateFees({
-    operationType: HEDERA_OPERATION_TYPES.CryptoUpdate,
-    currencyId: account.currency.id,
-  });
+
+  // undelegating and claiming rewards don't have to be blocked when the fetch fails
+  const needsValidators =
+    transaction.mode === HEDERA_TRANSACTION_MODES.Delegate ||
+    transaction.mode === HEDERA_TRANSACTION_MODES.Redelegate;
+
+  const [validators, estimatedFees] = await Promise.all([
+    needsValidators
+      ? getHederaValidators(account.currency.id).catch(error =>
+          error instanceof Error ? error : new Error(String(error)),
+        )
+      : undefined,
+    estimateFees({
+      operationType: HEDERA_OPERATION_TYPES.CryptoUpdate,
+      currencyId: account.currency.id,
+    }),
+  ]);
   const amount = BigNumber(0);
   const totalSpent = amount.plus(estimatedFees.tinybars);
+
+  if (validators instanceof Error) {
+    errors.validators = validators;
+  }
 
   if (!validateMemo(transaction.memo)) {
     errors.transaction = new HederaMemoExceededSizeError();
   }
 
-  if (
-    transaction.mode === HEDERA_TRANSACTION_MODES.Delegate ||
-    transaction.mode === HEDERA_TRANSACTION_MODES.Redelegate
-  ) {
+  if (Array.isArray(validators)) {
     if (typeof transaction.properties?.stakingNodeId === "number") {
       const isValid = validators.some(validator => {
         return validator.id === String(transaction.properties?.stakingNodeId);

--- a/libs/coin-modules/coin-hedera/src/constants.ts
+++ b/libs/coin-modules/coin-hedera/src/constants.ts
@@ -36,6 +36,8 @@ export enum HEDERA_OPERATION_TYPES {
 
 export const HEDERA_DUMMY_ADDRESS = "0.0.163372";
 
+export const HEDERA_VALIDATORS_CACHE_MINUTES = 15;
+
 export const TINYBAR_SCALE = 8;
 
 // old value moved from https://github.com/LedgerHQ/ledger-live/blob/8447b68b7c6f1e7ccd4aa9db4da0e6c8de36a88e/libs/coin-modules/coin-hedera/src/bridge/utils.ts#L77

--- a/libs/coin-modules/coin-hedera/src/logic/getValidators.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getValidators.ts
@@ -1,7 +1,7 @@
 import type { Cursor, Page, Validator } from "@ledgerhq/coin-module-framework/api/types";
 import { apiClient } from "../network/api";
-import { calculateAPY, extractCompanyFromNodeDescription } from "./utils";
 import type { HederaCoinConfig } from "../types";
+import { calculateAPY, extractCompanyFromNodeDescription } from "./utils";
 
 export async function getValidators({
   configOrCurrencyId,

--- a/libs/coin-modules/coin-hedera/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/utils.test.ts
@@ -12,16 +12,6 @@ import {
   STAKING_REWARD_HASH_SUFFIX,
 } from "../constants";
 import { rpcClient } from "../network/rpc";
-
-// Mock preloadData module before importing
-jest.mock("../preload-data", () => ({
-  ...jest.requireActual("../preload-data"),
-  getCurrentHederaPreloadData: jest.fn(),
-}));
-
-import * as preloadData from "../preload-data";
-
-const mockGetCurrentHederaPreloadData = preloadData.getCurrentHederaPreloadData as jest.Mock;
 import { getMockedAccount, getMockedTokenAccount } from "../test/fixtures/account.fixture";
 import { getMockedConfig } from "../test/fixtures/config.fixture";
 import { getMockedEnrichedERC20Transfer } from "../test/fixtures/common.fixture";
@@ -31,15 +21,8 @@ import {
 } from "../test/fixtures/currency.fixture";
 import { getMockedMirrorTransaction } from "../test/fixtures/mirror.fixture";
 import { getMockedOperation } from "../test/fixtures/operation.fixture";
-import { getMockedValidator } from "../test/fixtures/validator.fixture";
-import type {
-  HederaAccount,
-  HederaMemo,
-  HederaPreloadData,
-  HederaTxData,
-  HederaValidator,
-  Transaction,
-} from "../types";
+import { getMockedMirrorNode, getMockedValidator } from "../test/fixtures/validator.fixture";
+import type { HederaMemo, HederaTxData, HederaValidator, Transaction } from "../types";
 import {
   serializeSignature,
   deserializeSignature,
@@ -63,7 +46,6 @@ import {
   isStakingTransaction,
   extractCompanyFromNodeDescription,
   sortValidators,
-  getValidatorFromAccount,
   getDefaultValidator,
   getDelegationStatus,
   filterValidatorBySearchTerm,
@@ -82,6 +64,7 @@ import {
   resolveConfig,
   base64ToUrlSafeBase64,
   getHederaTransactionBodyBytes,
+  mapMirrorNodesToValidators,
 } from "./utils";
 
 jest.mock("../config");
@@ -729,32 +712,64 @@ describe("logic utils", () => {
     });
   });
 
-  describe("getValidatorFromAccount", () => {
-    const mockValidator = { id: "1" };
-    const mockPreload = { validators: [mockValidator] } as HederaPreloadData;
+  describe("mapMirrorNodesToValidators", () => {
+    it("maps mirror nodes to validators", () => {
+      const [validator] = mapMirrorNodesToValidators([getMockedMirrorNode()], "1");
 
-    beforeEach(() => {
-      jest.clearAllMocks();
-
-      mockGetCurrentHederaPreloadData.mockReturnValue(mockPreload);
+      expect(validator).toMatchObject({
+        id: "0",
+        address: "0.0.3",
+        minStake: new BigNumber(1000),
+        maxStake: new BigNumber(100000),
+        activeStake: new BigNumber(30000),
+        overstaked: false,
+        isLedgerNode: false,
+      });
     });
 
-    it("returns validator matching delegation nodeId", () => {
-      const mockAccount = {
-        currency: "hedera",
-        hederaResources: { delegation: { nodeId: 1 } },
-      } as unknown as HederaAccount;
+    it("sets isLedgerNode for the configured node id and clears it otherwise", () => {
+      const validators = mapMirrorNodesToValidators(
+        [
+          getMockedMirrorNode({ node_id: 0 }),
+          getMockedMirrorNode({ node_id: 1, node_account_id: "0.0.4" }),
+        ],
+        "1",
+      );
 
-      expect(getValidatorFromAccount(mockAccount)).toEqual(mockValidator);
+      expect(validators.find(v => v.id === "0")?.isLedgerNode).toBe(false);
+      expect(validators.find(v => v.id === "1")?.isLedgerNode).toBe(true);
     });
 
-    it("returns null if no delegation", () => {
-      const mockAccount = {
-        currency: "hedera",
-        hederaResources: {},
-      } as unknown as HederaAccount;
+    it("sets activeStakePercentage to 0 when maxStake is 0", () => {
+      const [validator] = mapMirrorNodesToValidators(
+        [getMockedMirrorNode({ max_stake: 0, stake_rewarded: 0 })],
+        "1",
+      );
 
-      expect(getValidatorFromAccount(mockAccount)).toBeNull();
+      expect(validator.activeStakePercentage).toEqual(new BigNumber(0));
+    });
+
+    it("rounds activeStakePercentage up (ROUND_CEIL)", () => {
+      const [validator] = mapMirrorNodesToValidators(
+        [getMockedMirrorNode({ max_stake: 300, stake_rewarded: 100 })],
+        "1",
+      );
+
+      // 100 / 300 * 100 = 33.33... -> rounds up to 34
+      expect(validator.activeStakePercentage).toEqual(new BigNumber(34));
+    });
+
+    it("marks validator as overstaked when activeStake >= maxStake", () => {
+      const [validator] = mapMirrorNodesToValidators(
+        [getMockedMirrorNode({ max_stake: 1000, stake_rewarded: 2000 })],
+        "1",
+      );
+
+      expect(validator.overstaked).toBe(true);
+    });
+
+    it("returns an empty array for an empty node list", () => {
+      expect(mapMirrorNodesToValidators([], "1")).toEqual([]);
     });
   });
 

--- a/libs/coin-modules/coin-hedera/src/logic/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/utils.ts
@@ -13,6 +13,7 @@ import type { AccountLike, Operation as LiveOperation } from "@ledgerhq/types-li
 import BigNumber from "bignumber.js";
 import invariant from "invariant";
 import coinConfig from "../config";
+import type { HederaMirrorNode } from "../types/mirror";
 import {
   HEDERA_DELEGATION_STATUS,
   HEDERA_OPERATION_TYPES,
@@ -23,7 +24,6 @@ import {
   HEDERA_TRANSACTION_NAMES,
   STAKING_REWARD_HASH_SUFFIX,
 } from "../constants";
-import { getCurrentHederaPreloadData } from "../preload-data";
 import type {
   HederaCoinConfig,
   EnrichedERC20Transfer,
@@ -362,6 +362,36 @@ export const extractCompanyFromNodeDescription = (description: string): string =
     .trim();
 };
 
+export function mapMirrorNodesToValidators(
+  nodes: HederaMirrorNode[],
+  ledgerNodeId: string,
+): HederaValidator[] {
+  const validators: HederaValidator[] = nodes.map(mirrorNode => {
+    const id = mirrorNode.node_id.toString();
+    const minStake = new BigNumber(mirrorNode.min_stake);
+    const maxStake = new BigNumber(mirrorNode.max_stake);
+    const activeStake = new BigNumber(mirrorNode.stake_rewarded);
+    const activeStakePercentage = maxStake.gt(0)
+      ? activeStake.dividedBy(maxStake).multipliedBy(100).dp(0, BigNumber.ROUND_CEIL)
+      : new BigNumber(0);
+
+    return {
+      id,
+      address: mirrorNode.node_account_id,
+      addressChecksum: getChecksum(mirrorNode.node_account_id),
+      name: extractCompanyFromNodeDescription(mirrorNode.description),
+      minStake,
+      maxStake,
+      activeStake,
+      activeStakePercentage,
+      overstaked: activeStake.gte(maxStake),
+      isLedgerNode: id === ledgerNodeId,
+    };
+  });
+
+  return sortValidators(validators);
+}
+
 export const sortValidators = (validators: HederaValidator[]): HederaValidator[] => {
   // sort validators by active stake in DESC order, with Ledger node first if it exists
   return [...validators].sort((a, b) => {
@@ -386,19 +416,6 @@ export const filterValidatorBySearchTerm = (
     validator.name.toLowerCase().includes(lowercaseSearch) ||
     addressWithChecksum.toLowerCase().includes(lowercaseSearch)
   );
-};
-
-export const getValidatorFromAccount = (account: HederaAccount): HederaValidator | null => {
-  const { delegation } = account.hederaResources ?? {};
-
-  if (!delegation) {
-    return null;
-  }
-
-  const validators = getCurrentHederaPreloadData(account.currency);
-  const validator = validators.validators.find(v => v.id === String(delegation.nodeId)) ?? null;
-
-  return validator;
 };
 
 export const getDefaultValidator = (validators: HederaValidator[]): HederaValidator | null => {

--- a/libs/coin-modules/coin-hedera/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.test.ts
@@ -16,6 +16,7 @@ import {
   getMockedMirrorAccount,
 } from "../test/fixtures/mirror.fixture";
 import { getMockedConfig } from "../test/fixtures/config.fixture";
+import { getMockedMirrorNode } from "../test/fixtures/validator.fixture";
 import hederaCoinConfig from "../config";
 import type { HederaMirrorCoinTransfer, HederaMirrorTransaction } from "../types";
 import { apiClient } from "./api";
@@ -28,6 +29,7 @@ import {
   createTransactionId,
   enrichERC20Transfers,
   getERC20BalancesForAccountV2,
+  getHederaValidators,
   parseTransfers,
   safeParseAccountId,
   toEVMAddress,
@@ -461,6 +463,51 @@ describe("network utils", () => {
       expect(result).toEqual([]);
       expect(apiClient.getContractCallResult).not.toHaveBeenCalled();
       expect(apiClient.findTransactionByContractCallV2).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getHederaValidators", () => {
+    const mockGetNodes = jest.mocked(apiClient.getNodes);
+
+    beforeAll(() => {
+      hederaCoinConfig.setCoinConfig(() => getMockedConfig({ ledgerNodeId: 0 }));
+    });
+
+    beforeEach(() => {
+      getHederaValidators.reset();
+      jest.clearAllMocks();
+      mockGetNodes.mockResolvedValue({ nodes: [getMockedMirrorNode()], nextCursor: null });
+    });
+
+    it("calls getNodes with fetchAllPages=true and maps the result", async () => {
+      const validators = await getHederaValidators(mockCurrency.id);
+
+      expect(mockGetNodes).toHaveBeenCalledWith({
+        configOrCurrencyId: mockCurrency.id,
+        fetchAllPages: true,
+      });
+      expect(validators).toHaveLength(1);
+      expect(validators[0]).toMatchObject({ id: "0", isLedgerNode: true });
+    });
+
+    it("hits the network once for two consecutive calls, and again after clear()", async () => {
+      await getHederaValidators(mockCurrency.id);
+      await getHederaValidators(mockCurrency.id);
+
+      expect(mockGetNodes).toHaveBeenCalledTimes(1);
+
+      getHederaValidators.clear(mockCurrency.id);
+      await getHederaValidators(mockCurrency.id);
+
+      expect(mockGetNodes).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not cache a failed fetch, so the next call retries", async () => {
+      mockGetNodes.mockRejectedValueOnce(new Error("network unavailable"));
+
+      await expect(getHederaValidators(mockCurrency.id)).rejects.toThrow("network unavailable");
+      await expect(getHederaValidators(mockCurrency.id)).resolves.toHaveLength(1);
+      expect(mockGetNodes).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/libs/coin-modules/coin-hedera/src/network/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.ts
@@ -3,7 +3,7 @@ import { AccountId, TransactionId } from "@hashgraph/sdk";
 import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
 import { InvalidAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 import cvsApi from "@ledgerhq/live-countervalues/api/index";
-import { makeLRUCache, seconds } from "@ledgerhq/live-network/cache";
+import { makeLRUCache, minutes, seconds } from "@ledgerhq/live-network/cache";
 import type {
   FiatCurrency,
   TokenCurrency,
@@ -11,9 +11,16 @@ import type {
 } from "@ledgerhq/ledger-wallet-framework/types";
 import type { Operation, OperationType } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
-import { STAKING_REWARD_ACCOUNT_ID } from "../constants";
+import { HEDERA_VALIDATORS_CACHE_MINUTES, STAKING_REWARD_ACCOUNT_ID } from "../constants";
 import { HederaRecipientInvalidChecksum } from "../errors";
-import { getChecksum, nanosToSeconds, toEntityId, toTimestamp } from "../logic/utils";
+import {
+  getChecksum,
+  mapMirrorNodesToValidators,
+  nanosToSeconds,
+  resolveConfig,
+  toEntityId,
+  toTimestamp,
+} from "../logic/utils";
 import type {
   HederaMirrorTokenTransfer,
   HederaMirrorCoinTransfer,
@@ -21,6 +28,7 @@ import type {
   ERC20TokenTransfer,
   EnrichedERC20Transfer,
   HederaMirrorTransaction,
+  HederaValidator,
   StakingAnalysis,
   HederaCoinConfig,
 } from "../types";
@@ -221,6 +229,20 @@ export const getCurrencyToUSDRate = makeLRUCache(
   },
   currency => currency.ticker,
   seconds(3),
+);
+
+export const getHederaValidators = makeLRUCache(
+  async (currencyId: string): Promise<HederaValidator[]> => {
+    const ledgerNodeId = String(resolveConfig(currencyId).ledgerNodeId);
+    const result = await apiClient.getNodes({
+      configOrCurrencyId: currencyId,
+      fetchAllPages: true,
+    });
+
+    return mapMirrorNodesToValidators(result.nodes, ledgerNodeId);
+  },
+  (currencyId: string) => currencyId,
+  minutes(HEDERA_VALIDATORS_CACHE_MINUTES),
 );
 
 export const checkAccountTokenAssociationStatus = makeLRUCache(

--- a/libs/coin-modules/coin-hedera/src/preload.ts
+++ b/libs/coin-modules/coin-hedera/src/preload.ts
@@ -1,12 +1,7 @@
 import { log } from "@ledgerhq/logs";
 import type { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import BigNumber from "bignumber.js";
-import {
-  extractCompanyFromNodeDescription,
-  getChecksum,
-  resolveConfig,
-  sortValidators,
-} from "./logic/utils";
+import { mapMirrorNodesToValidators, resolveConfig } from "./logic/utils";
 import { apiClient } from "./network/api";
 import { setHederaPreloadData } from "./preload-data";
 import type { HederaPreloadData, HederaValidator, HederaValidatorRaw } from "./types";
@@ -18,35 +13,9 @@ export const getPreloadStrategy = () => ({
 export async function preload(currency: CryptoCurrency): Promise<HederaPreloadData> {
   log("hedera/preload", "preloading hedera data...");
   const result = await apiClient.getNodes({ configOrCurrencyId: currency.id, fetchAllPages: true });
-  const config = resolveConfig(currency.id);
-  const ledgerNodeId = String(config.ledgerNodeId);
-
-  const validators: HederaValidator[] = result.nodes.map(mirrorNode => {
-    const id = mirrorNode.node_id.toString();
-    const minStake = new BigNumber(mirrorNode.min_stake);
-    const maxStake = new BigNumber(mirrorNode.max_stake);
-    const activeStake = new BigNumber(mirrorNode.stake_rewarded);
-    const activeStakePercentage = maxStake.gt(0)
-      ? activeStake.dividedBy(maxStake).multipliedBy(100).dp(0, BigNumber.ROUND_CEIL)
-      : new BigNumber(0);
-
-    return {
-      id,
-      address: mirrorNode.node_account_id,
-      addressChecksum: getChecksum(mirrorNode.node_account_id),
-      name: extractCompanyFromNodeDescription(mirrorNode.description),
-      minStake,
-      maxStake,
-      activeStake,
-      activeStakePercentage,
-      overstaked: activeStake.gte(maxStake),
-      isLedgerNode: id === ledgerNodeId,
-    };
-  });
-
-  const sortedValidators = sortValidators(validators);
+  const ledgerNodeId = String(resolveConfig(currency.id).ledgerNodeId);
   const data: HederaPreloadData = {
-    validators: sortedValidators,
+    validators: mapMirrorNodesToValidators(result.nodes, ledgerNodeId),
   };
 
   setHederaPreloadData(data, currency);

--- a/libs/coin-modules/coin-hedera/src/test/fixtures/validator.fixture.ts
+++ b/libs/coin-modules/coin-hedera/src/test/fixtures/validator.fixture.ts
@@ -1,5 +1,6 @@
 import BigNumber from "bignumber.js";
 import type { HederaValidator } from "../../types";
+import type { HederaMirrorNode } from "../../types/mirror";
 
 export const getMockedValidator = (overrides?: Partial<HederaValidator>): HederaValidator => {
   return {
@@ -16,3 +17,15 @@ export const getMockedValidator = (overrides?: Partial<HederaValidator>): Hedera
     ...overrides,
   };
 };
+
+export const getMockedMirrorNode = (overrides?: Partial<HederaMirrorNode>): HederaMirrorNode => ({
+  node_id: 0,
+  node_account_id: "0.0.3",
+  description: "Hedera | 0 | Hosted by Hedera",
+  min_stake: 1000,
+  max_stake: 100000,
+  stake: 50000,
+  stake_rewarded: 30000,
+  reward_rate_start: 0,
+  ...overrides,
+});


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR moves validator fetching in the Hedera module off the preload cache and onto an on-demand cached call. Staking transactions now fetch the validator list directly when building a delegate or redelegate transaction, instead of reading it from data set by a separate preload step, and cache it for fifteen minutes. Validator mapping logic is shared between preload and the new on-demand fetch instead of being duplicated. If the validator fetch fails, only delegate and redelegate flows are blocked with an error, since undelegating and claiming rewards don't need the validator list.

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- https://ledgerhq.atlassian.net/browse/LIVE-36153
