### PR TITLE
[LWDM] refactor(hedera): migrate desktop staking to the validators query

### DIFF
--- a/.changeset/hedera-desktop-validators-query.md
+++ b/.changeset/hedera-desktop-validators-query.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-hedera": minor
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": minor
+---
+
+feat: read Hedera staking validators through an on-demand query on desktop, with loading and fetch-error states

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/ClaimRewardsFlowModal/__integrations__/claimRewardsFlowModal.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/ClaimRewardsFlowModal/__integrations__/claimRewardsFlowModal.integ.test.tsx
@@ -13,8 +13,13 @@ import {
 } from "../../__mocks__/flowHelpers";
 
 jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
-  useHederaValidators: jest.fn(() => []),
-  useHederaEnrichedDelegation: jest.fn(
+  hederaQueries: {
+    validatorsList: () => ({
+      queryKey: ["mock-hedera-validators"],
+      queryFn: () => Promise.resolve([]),
+    }),
+  },
+  useHederaEnrichedDelegationV2: jest.fn(
     () => require("../../__mocks__/delegation.mock").mockEnrichedDelegation,
   ),
 }));

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/ClaimRewardsFlowModal/steps/StepRewards.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/ClaimRewardsFlowModal/steps/StepRewards.tsx
@@ -3,7 +3,7 @@ import invariant from "invariant";
 import { Trans } from "react-i18next";
 import { useSelector } from "LLD/hooks/redux";
 import { formatCurrencyUnit } from "@ledgerhq/coin-module-framework/currencies/formatCurrencyUnit";
-import { useHederaEnrichedDelegation } from "@ledgerhq/live-common/families/hedera/react";
+import { useHederaEnrichedDelegationV2 } from "@ledgerhq/live-common/families/hedera/react";
 import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account/helpers";
 import Alert from "~/renderer/components/Alert";
 import Box from "~/renderer/components/Box";
@@ -27,7 +27,7 @@ function StepRewards({ account, parentAccount, transaction, status, error }: Rea
   const discreet = useDiscreetMode();
   const locale = useSelector(localeSelector);
   const unit = useAccountUnit(account);
-  const enrichedDelegation = useHederaEnrichedDelegation(account, delegation);
+  const enrichedDelegation = useHederaEnrichedDelegationV2(account, delegation);
 
   const claimableRewards = enrichedDelegation.pendingReward;
   const formatConfig = {
@@ -96,6 +96,7 @@ export function StepRewardsFooter({
       </Button>
       <Button
         id="claim-rewards-continue-button"
+        isLoading={bridgePending}
         disabled={!canNext}
         primary
         onClick={() => transitionTo("connectDevice")}

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/DelegatedPositions/Row.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/DelegatedPositions/Row.tsx
@@ -15,6 +15,7 @@ import CheckCircle from "~/renderer/icons/CheckCircle";
 import ExclamationCircleThin from "~/renderer/icons/ExclamationCircleThin";
 import ToolTip from "~/renderer/components/Tooltip";
 import Text from "~/renderer/components/Text";
+import { PlaceholderLine } from "~/renderer/components/Placeholder";
 import Discreet, { useDiscreetMode } from "~/renderer/components/Discreet";
 import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import { localeSelector } from "~/renderer/reducers/settings";
@@ -30,6 +31,7 @@ const Wrapper = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  min-height: 24px;
   padding: 16px 20px;
 `;
 
@@ -91,6 +93,18 @@ const ManageDropDownItem = ({
   );
 };
 
+const FetchErrorIcon = () => (
+  <Box color="alertRed" pl={2}>
+    <ToolTip
+      content={
+        <Trans i18nKey="hedera.account.bodyHeader.delegatedPositions.columns.fetchErrorTooltip" />
+      }
+    >
+      <ExclamationCircleThin size={14} />
+    </ToolTip>
+  </Box>
+);
+
 const DelegationStatus = ({ status }: { status: HEDERA_DELEGATION_STATUS }) => {
   if (status === HEDERA_DELEGATION_STATUS.Inactive) {
     return (
@@ -150,7 +164,7 @@ export function Row({
   const locale = useSelector(localeSelector);
   const unit = useAccountUnit(account);
 
-  const isValidatorRemoved =
+  const validatorRemoved =
     !enrichedDelegation.validator.address && typeof enrichedDelegation.nodeId === "number";
 
   const formatConfig = {
@@ -196,27 +210,46 @@ export function Row({
     [onManageAction],
   );
 
+  let statusColumn: React.ReactNode;
+  let validatorColumn: React.ReactNode;
+
+  if (enrichedDelegation.loading) {
+    validatorColumn = (
+      <Column>
+        <PlaceholderLine width={80} />
+      </Column>
+    );
+  } else if (enrichedDelegation.error || validatorRemoved) {
+    validatorColumn = <Column />;
+  } else {
+    validatorColumn = (
+      <Column
+        strong
+        clickable
+        onClick={() => {
+          onExternalLink(enrichedDelegation);
+        }}
+      >
+        <Box mr={2}>
+          <ValidatorIcon validator={enrichedDelegation.validator} />
+        </Box>
+        <Ellipsis>{enrichedDelegation.validator.name}</Ellipsis>
+      </Column>
+    );
+  }
+
+  if (enrichedDelegation.loading) {
+    statusColumn = <PlaceholderLine width={14} height={14} />;
+  } else if (enrichedDelegation.error) {
+    statusColumn = <FetchErrorIcon />;
+  } else {
+    statusColumn = <DelegationStatus status={enrichedDelegation.status} />;
+  }
+
   return (
     <Wrapper>
-      {isValidatorRemoved ? (
-        <Column />
-      ) : (
-        <Column
-          strong
-          clickable
-          onClick={() => {
-            onExternalLink(enrichedDelegation);
-          }}
-        >
-          <Box mr={2}>
-            <ValidatorIcon validator={enrichedDelegation.validator} />
-          </Box>
-          <Ellipsis>{enrichedDelegation.validator.name}</Ellipsis>
-        </Column>
-      )}
-      <Column>
-        <DelegationStatus status={enrichedDelegation.status} />
-      </Column>
+      {validatorColumn}
+      <Column>{statusColumn}</Column>
       <Column>
         <Ellipsis>
           <Discreet>{formattedDelegatedAssets}</Discreet>

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/DelegatedPositions/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/DelegatedPositions/index.tsx
@@ -8,7 +8,7 @@ import type {
   HederaDelegation,
   HederaEnrichedDelegation,
 } from "@ledgerhq/live-common/families/hedera/types";
-import { useHederaEnrichedDelegation } from "@ledgerhq/live-common/families/hedera/react";
+import { useHederaEnrichedDelegationV2 } from "@ledgerhq/live-common/families/hedera/react";
 import { useStake } from "LLD/hooks/useStake";
 import type { TokenAccount } from "@ledgerhq/types-live";
 import { openURL } from "~/renderer/linking";
@@ -34,7 +34,7 @@ const Delegations = ({
   delegatedPosition: HederaDelegation;
 }) => {
   const dispatch = useDispatch();
-  const enrichedDelegation = useHederaEnrichedDelegation(account, delegatedPosition);
+  const enrichedDelegation = useHederaEnrichedDelegationV2(account, delegatedPosition);
 
   const onClaimRewards = useCallback(() => {
     dispatch(openModal("MODAL_HEDERA_CLAIM_REWARDS", { account }));

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/Body.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect, useMemo } from "react";
 import { compose } from "redux";
 import { connect } from "react-redux";
 import { useDispatch } from "LLD/hooks/redux";
@@ -6,8 +6,9 @@ import { Trans, withTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import type { Account, Operation } from "@ledgerhq/types-live";
+import { useQuery } from "@tanstack/react-query";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
-import { useHederaValidators } from "@ledgerhq/live-common/families/hedera/react";
+import { hederaQueries } from "@ledgerhq/live-common/families/hedera/react";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
 import type { HederaAccount, Transaction } from "@ledgerhq/live-common/families/hedera/types";
 import { getDefaultValidator } from "@ledgerhq/live-common/families/hedera/utils";
@@ -92,7 +93,8 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
-  const validators = useHederaValidators(account.currency);
+  const queryValidators = useQuery(hederaQueries.validatorsList(account.currency.id));
+  const validators = useMemo(() => queryValidators.data ?? [], [queryValidators.data]);
   const bridge = useAccountBridge<Transaction>(account);
   const { transaction, setTransaction, updateTransaction, status, bridgeError, bridgePending } =
     useBridgeTransaction(bridge, () => {
@@ -112,6 +114,26 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
         transaction,
       };
     });
+
+  // Validators load asynchronously, so on mount the lazy initializer above runs before any
+  // are available and stores stakingNodeId: null. Once the fetch resolves, backfill the
+  // default here, unless the user already picked a validator in the meantime.
+  useEffect(() => {
+    if (transaction?.mode !== HEDERA_TRANSACTION_MODES.Delegate) return;
+
+    const hasSelectedValidator = typeof transaction.properties?.stakingNodeId === "number";
+    if (hasSelectedValidator || validators.length === 0) return;
+
+    const defaultValidator = getDefaultValidator(validators);
+    if (!defaultValidator) return;
+
+    updateTransaction(tx =>
+      bridge.updateTransaction(tx, {
+        mode: HEDERA_TRANSACTION_MODES.Delegate,
+        properties: { stakingNodeId: Number(defaultValidator.id) },
+      }),
+    );
+  }, [validators, transaction, updateTransaction, bridge]);
 
   const handleStepChange = useCallback(
     (e: St) => {

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/__integrations__/delegationFlowModal.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/__integrations__/delegationFlowModal.integ.test.tsx
@@ -11,24 +11,35 @@ import {
   setupHederaModalTest,
   cleanupHederaModalTest,
   clickContinueWhenEnabled,
+  DEFAULT_TX_STATUS,
 } from "../../__mocks__/flowHelpers";
 
+const mockValidators = [
+  {
+    id: "0",
+    name: "Hedera Node 0",
+    address: "0.0.3",
+    addressChecksum: null,
+    minStake: new BigNumber(0),
+    maxStake: new BigNumber(250_000_000_000_000_000),
+    activeStake: new BigNumber(0),
+    activeStakePercentage: new BigNumber(0),
+    overstaked: false,
+    isLedgerNode: true,
+  },
+];
+
+let queryFn: () => Promise<unknown> = () => Promise.resolve(mockValidators);
+
 jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
-  useHederaValidators: jest.fn(() => [
-    {
-      id: "0",
-      name: "Hedera Node 0",
-      address: "0.0.3",
-      addressChecksum: null,
-      minStake: new BigNumber(0),
-      maxStake: new BigNumber(250_000_000_000_000_000),
-      activeStake: new BigNumber(0),
-      activeStakePercentage: new BigNumber(0),
-      overstaked: false,
-      isLedgerNode: true,
-    },
-  ]),
-  useHederaEnrichedDelegation: jest.fn(() => null),
+  hederaQueries: {
+    validatorsList: () => ({
+      queryKey: ["mock-hedera-validators"],
+      queryFn: () => queryFn(),
+      retry: false,
+    }),
+  },
+  useHederaEnrichedDelegationV2: jest.fn(() => null),
 }));
 
 jest.mock("@ledgerhq/live-common/hw/actions/app", () => ({
@@ -49,6 +60,7 @@ jest.mock("@ledgerhq/live-common/bridge/impl", () => ({
 }));
 
 beforeEach(async () => {
+  queryFn = () => Promise.resolve(mockValidators);
   await setupHederaModalTest();
 });
 
@@ -100,5 +112,18 @@ describe("Hedera DelegationFlowModal (integration)", () => {
     });
 
     await waitFor(() => expect(screen.getByRole("button", { name: /retry/i })).toBeVisible());
+  });
+
+  it("keeps Continue disabled and shows the fetch error when the validators fetch fails", async () => {
+    queryFn = () => Promise.reject(new Error("network down"));
+    await setupHederaModalTest({
+      ...DEFAULT_TX_STATUS,
+      errors: { validators: new Error("network down") },
+    });
+
+    setupModal();
+
+    await waitFor(() => expect(screen.getByText(/network down/i)).toBeVisible());
+    expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/steps/StepValidator.tsx
@@ -82,6 +82,7 @@ export function StepValidatorFooter({
       </Button>
       <Button
         id="stake-continue-button"
+        isLoading={bridgePending}
         disabled={!canNext}
         primary
         onClick={() => transitionTo("amount")}

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/__integrations__/redelegationFlowModal.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/__integrations__/redelegationFlowModal.integ.test.tsx
@@ -13,36 +13,45 @@ import {
   cleanupHederaModalTest,
   clickContinueWhenEnabled,
 } from "../../__mocks__/flowHelpers";
+import { useHederaEnrichedDelegationV2 } from "@ledgerhq/live-common/families/hedera/react";
 
 jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
-  useHederaValidators: jest.fn(() => [
-    {
-      id: "0",
-      name: "Hedera Node 0",
-      address: "0.0.3",
-      addressChecksum: null,
-      minStake: new BigNumber(0),
-      maxStake: new BigNumber(250_000_000_000_000_000),
-      activeStake: new BigNumber(0),
-      activeStakePercentage: new BigNumber(0),
-      overstaked: false,
-    },
-    {
-      id: "5",
-      name: "Hedera Node 5",
-      address: "0.0.5",
-      addressChecksum: null,
-      minStake: new BigNumber(0),
-      maxStake: new BigNumber(250_000_000_000_000_000),
-      activeStake: new BigNumber(0),
-      activeStakePercentage: new BigNumber(0),
-      overstaked: false,
-    },
-  ]),
-  useHederaEnrichedDelegation: jest.fn(() => ({
+  hederaQueries: {
+    validatorsList: () => ({
+      queryKey: ["mock-hedera-validators"],
+      queryFn: () =>
+        Promise.resolve([
+          {
+            id: "0",
+            name: "Hedera Node 0",
+            address: "0.0.3",
+            addressChecksum: null,
+            minStake: new BigNumber(0),
+            maxStake: new BigNumber(250_000_000_000_000_000),
+            activeStake: new BigNumber(0),
+            activeStakePercentage: new BigNumber(0),
+            overstaked: false,
+          },
+          {
+            id: "5",
+            name: "Hedera Node 5",
+            address: "0.0.5",
+            addressChecksum: null,
+            minStake: new BigNumber(0),
+            maxStake: new BigNumber(250_000_000_000_000_000),
+            activeStake: new BigNumber(0),
+            activeStakePercentage: new BigNumber(0),
+            overstaked: false,
+          },
+        ]),
+    }),
+  },
+  useHederaEnrichedDelegationV2: jest.fn(() => ({
     nodeId: 0,
     delegated: new BigNumber(5_000_000_000),
     pendingReward: new BigNumber(500_000),
+    loading: false,
+    error: null,
     status: HEDERA_DELEGATION_STATUS.Active,
     validator: {
       id: "0",
@@ -74,6 +83,9 @@ jest.mock("@ledgerhq/live-common/bridge/impl", () => ({
   getAccountBridge: () => require("../../__mocks__/bridge.mock").resolvedAccountBridge,
   getCurrencyBridge: () => require("../../__mocks__/bridge.mock").resolvedCurrencyBridge,
 }));
+
+const mockUseHederaEnrichedDelegation = jest.mocked(useHederaEnrichedDelegationV2);
+
 beforeEach(async () => {
   await setupHederaModalTest();
 });
@@ -124,5 +136,36 @@ describe("Hedera RedelegationFlowModal (integration)", () => {
     });
 
     await waitFor(() => expect(screen.getByRole("button", { name: /retry/i })).toBeVisible());
+  });
+
+  it("does not show the removed-validator placeholder when the validators fetch fails", async () => {
+    mockUseHederaEnrichedDelegation.mockReturnValueOnce({
+      nodeId: 0,
+      delegated: new BigNumber(5_000_000_000),
+      pendingReward: new BigNumber(500_000),
+      loading: false,
+      error: new Error("network down"),
+      status: HEDERA_DELEGATION_STATUS.Inactive,
+      validator: {
+        id: "0",
+        name: "",
+        address: "",
+        addressChecksum: null,
+        minStake: new BigNumber(0),
+        maxStake: new BigNumber(0),
+        activeStake: new BigNumber(0),
+        activeStakePercentage: new BigNumber(0),
+        overstaked: false,
+        isLedgerNode: false,
+      },
+    });
+
+    setupModal();
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/previously selected validator is no longer available/i),
+      ).not.toBeInTheDocument(),
+    );
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/__tests__/StepValidators.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/__tests__/StepValidators.test.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { render, screen, waitFor } from "tests/testSetup";
+import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
+import type { HederaAccount } from "@ledgerhq/live-common/families/hedera/types";
+import { makeHederaAccount } from "../../__mocks__/account.mock";
+import { makeHederaTransaction } from "../../__mocks__/transaction.mock";
+import StepValidators from "../steps/StepValidators";
+import type { StepProps } from "../types";
+
+let queryFn: () => Promise<unknown>;
+
+jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
+  hederaQueries: {
+    validatorsList: () => ({
+      queryKey: ["mock-hedera-validators"],
+      queryFn: () => queryFn(),
+      retry: false,
+    }),
+  },
+  useHederaEnrichedDelegationV2: () => ({
+    loading: false,
+    error: null,
+    validator: { id: "3", address: "0.0.3" },
+  }),
+}));
+
+jest.mock("@ledgerhq/live-common/bridge/impl", () => ({
+  __esModule: true,
+  getAccountBridge: () => require("../../__mocks__/bridge.mock").resolvedAccountBridge,
+  getCurrencyBridge: () => require("../../__mocks__/bridge.mock").resolvedCurrencyBridge,
+}));
+
+const defaultState = { settings: AFTER_ONBOARDING_STATE };
+
+const makeAccount = (): HederaAccount =>
+  makeHederaAccount({
+    delegation: { nodeId: 3, delegated: new BigNumber(0), pendingReward: new BigNumber(0) },
+  });
+
+const makeProps = (): StepProps =>
+  ({
+    t: (key: string) => key,
+    account: makeAccount(),
+    parentAccount: null,
+    transaction: makeHederaTransaction({ mode: HEDERA_TRANSACTION_MODES.Redelegate }),
+    status: { errors: {}, warnings: {} },
+    error: null,
+    onUpdateTransaction: jest.fn(),
+  }) as unknown as StepProps;
+
+describe("RedelegationFlowModal/StepValidators", () => {
+  it("shows the fetch error only once when both selects hit a failing fetch", async () => {
+    queryFn = () => Promise.reject(new Error("network down"));
+
+    render(<StepValidators {...makeProps()} />, { initialState: defaultState });
+
+    await waitFor(() => expect(screen.getAllByText(/network down/i)).toHaveLength(1));
+    expect(screen.getAllByText(/unable to load validators/i)).toHaveLength(2);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/steps/StepValidators.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/steps/StepValidators.tsx
@@ -1,7 +1,7 @@
 import invariant from "invariant";
 import React from "react";
 import { Trans } from "react-i18next";
-import { useHederaEnrichedDelegation } from "@ledgerhq/live-common/families/hedera/react";
+import { useHederaEnrichedDelegationV2 } from "@ledgerhq/live-common/families/hedera/react";
 import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account/helpers";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { HederaValidator, Transaction } from "@ledgerhq/live-common/families/hedera/types";
@@ -18,6 +18,7 @@ import CurrencyDownStatusAlert from "~/renderer/components/CurrencyDownStatusAle
 import TranslatedError from "~/renderer/components/TranslatedError";
 import ValidatorsSelect from "~/renderer/families/hedera/shared/staking/ValidatorsSelect";
 import AmountField from "../../shared/staking/AmountField";
+import { isValidatorRemoved } from "../../shared/utils";
 import type { StepProps } from "../types";
 
 function StepValidators({
@@ -37,10 +38,14 @@ function StepValidators({
   const stakingNodeId = transaction.properties?.stakingNodeId;
   const selectedValidatorId = typeof stakingNodeId === "number" ? String(stakingNodeId) : null;
   const mainAccount = account ? getMainAccount(account, parentAccount) : null;
-  const enrichedDelegation = useHederaEnrichedDelegation(account, delegation);
+  const enrichedDelegation = useHederaEnrichedDelegationV2(account, delegation);
   const feeError = status.errors.fee;
-  const isValidatorRemoved =
-    !enrichedDelegation.validator.address && typeof delegation.nodeId === "number";
+  const validatorRemoved = isValidatorRemoved({
+    loading: enrichedDelegation.loading,
+    error: enrichedDelegation.error,
+    hasValidator: !!enrichedDelegation.validator.address,
+    nodeId: delegation.nodeId,
+  });
 
   const bridge = useAccountBridge<Transaction>(account, parentAccount);
   const updateValidator = (validator: HederaValidator | null) => {
@@ -67,7 +72,7 @@ function StepValidators({
           disabled
           account={account}
           selectedValidatorId={enrichedDelegation.validator.id}
-          showRemovedPlaceholder={isValidatorRemoved}
+          showRemovedPlaceholder={validatorRemoved}
         />
       </Box>
       <StepRecipientSeparator />
@@ -121,6 +126,7 @@ export function StepValidatorsFooter({
       </Button>
       <Button
         id="redelegation-continue-button"
+        isLoading={bridgePending}
         disabled={!canNext}
         primary
         onClick={() => transitionTo("connectDevice")}

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/__integrations__/undelegationFlowModal.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/__integrations__/undelegationFlowModal.integ.test.tsx
@@ -14,20 +14,26 @@ import {
 } from "../../__mocks__/flowHelpers";
 
 jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
-  useHederaValidators: jest.fn(() => [
-    {
-      id: "0",
-      name: "Hedera Node 0",
-      address: "0.0.3",
-      addressChecksum: null,
-      minStake: new BigNumber(0),
-      maxStake: new BigNumber(250_000_000_000_000_000),
-      activeStake: new BigNumber(0),
-      activeStakePercentage: new BigNumber(0),
-      overstaked: false,
-    },
-  ]),
-  useHederaEnrichedDelegation: jest.fn(
+  hederaQueries: {
+    validatorsList: () => ({
+      queryKey: ["mock-hedera-validators"],
+      queryFn: () =>
+        Promise.resolve([
+          {
+            id: "0",
+            name: "Hedera Node 0",
+            address: "0.0.3",
+            addressChecksum: null,
+            minStake: new BigNumber(0),
+            maxStake: new BigNumber(250_000_000_000_000_000),
+            activeStake: new BigNumber(0),
+            activeStakePercentage: new BigNumber(0),
+            overstaked: false,
+          },
+        ]),
+    }),
+  },
+  useHederaEnrichedDelegationV2: jest.fn(
     () => require("../../__mocks__/delegation.mock").mockEnrichedDelegation,
   ),
 }));

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/__tests__/StepSummary.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/__tests__/StepSummary.test.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { render, screen, waitFor } from "tests/testSetup";
+import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+import type { HederaAccount } from "@ledgerhq/live-common/families/hedera/types";
+import { makeHederaAccount } from "../../__mocks__/account.mock";
+import type { StepProps } from "../types";
+
+let queryFn: () => Promise<unknown>;
+
+jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
+  hederaQueries: {
+    validatorsList: () => ({
+      queryKey: ["mock-hedera-validators"],
+      queryFn: () => queryFn(),
+      retry: false,
+    }),
+  },
+}));
+
+import StepSummary from "../steps/StepSummary";
+
+const defaultState = { settings: AFTER_ONBOARDING_STATE };
+
+const validator = {
+  id: "3",
+  name: "Hedera Node 3",
+  address: "0.0.3",
+  addressChecksum: null,
+  minStake: new BigNumber(0),
+  maxStake: new BigNumber(0),
+  activeStake: new BigNumber(0),
+  activeStakePercentage: new BigNumber(0),
+  overstaked: false,
+  isLedgerNode: false,
+};
+
+const makeAccount = (): HederaAccount =>
+  makeHederaAccount({
+    delegation: { nodeId: 3, delegated: new BigNumber(0), pendingReward: new BigNumber(0) },
+  });
+
+const makeProps = (): StepProps =>
+  ({
+    t: (key: string) => key,
+    account: makeAccount(),
+    parentAccount: null,
+    transaction: {},
+    status: { errors: {}, warnings: {} },
+    error: null,
+  }) as unknown as StepProps;
+
+describe("UndelegationFlowModal/StepSummary", () => {
+  it("does not show the removed-validator placeholder while the validator list fetch is still failing", async () => {
+    queryFn = () => Promise.reject(new Error("network down"));
+
+    render(<StepSummary {...makeProps()} />, { initialState: defaultState });
+
+    await waitFor(() => expect(screen.getByText(/unable to load validators/i)).toBeVisible());
+    expect(
+      screen.queryByText(/previously selected validator is no longer available/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the removed-validator placeholder once the fetch succeeds and the validator is gone", async () => {
+    queryFn = () => Promise.resolve([]);
+
+    render(<StepSummary {...makeProps()} />, { initialState: defaultState });
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/previously selected validator is no longer available/i),
+      ).toBeVisible(),
+    );
+  });
+
+  it("shows the validator name once the fetch succeeds and the validator is still present", async () => {
+    queryFn = () => Promise.resolve([validator]);
+
+    render(<StepSummary {...makeProps()} />, { initialState: defaultState });
+
+    await waitFor(() => expect(screen.getByText("Hedera Node 3")).toBeVisible());
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/steps/StepSummary.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { Trans } from "react-i18next";
 import invariant from "invariant";
-import { useHederaValidators } from "@ledgerhq/live-common/families/hedera/react";
+import { useQuery } from "@tanstack/react-query";
+import { hederaQueries } from "@ledgerhq/live-common/families/hedera/react";
 import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account/helpers";
 import { urls } from "~/config/urls";
 import Alert from "~/renderer/components/Alert";
@@ -14,6 +15,7 @@ import TranslatedError from "~/renderer/components/TranslatedError";
 import type { StepProps } from "../types";
 import AmountField from "../../shared/staking/AmountField";
 import ValidatorsSelect from "../../shared/staking/ValidatorsSelect";
+import { isValidatorRemoved } from "../../shared/utils";
 
 function StepSummary({
   t,
@@ -26,9 +28,14 @@ function StepSummary({
   invariant(account && transaction, "hedera: account and transaction required");
   const mainAccount = account ? getMainAccount(account, parentAccount) : null;
   const currentValidatorNodeId = account.hederaResources?.delegation?.nodeId;
-  const validators = useHederaValidators(account.currency);
-  const validator = validators.find(v => v.id === String(currentValidatorNodeId));
-  const isValidatorRemoved = !validator && typeof currentValidatorNodeId === "number";
+  const queryValidators = useQuery(hederaQueries.validatorsList(account.currency.id));
+  const validator = queryValidators.data?.find(v => v.id === String(currentValidatorNodeId));
+  const validatorRemoved = isValidatorRemoved({
+    loading: queryValidators.isLoading,
+    error: queryValidators.isLoadingError,
+    hasValidator: !!validator,
+    nodeId: currentValidatorNodeId,
+  });
   const feeError = status.errors.fee;
 
   return (
@@ -43,7 +50,7 @@ function StepSummary({
           disabled
           account={account}
           selectedValidatorId={validator?.id ?? null}
-          showRemovedPlaceholder={isValidatorRemoved}
+          showRemovedPlaceholder={validatorRemoved}
         />
       </Box>
       <Box>
@@ -85,6 +92,7 @@ export function StepSummaryFooter({
       </Button>
       <Button
         id="undelegation-continue-button"
+        isLoading={bridgePending}
         disabled={!canNext}
         primary
         onClick={() => transitionTo("connectDevice")}

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/__mocks__/delegation.mock.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/__mocks__/delegation.mock.ts
@@ -12,6 +12,8 @@ export const mockEnrichedDelegation: HederaEnrichedDelegation = {
   nodeId: 3,
   delegated: new BigNumber(50_000_000),
   pendingReward: new BigNumber(10_000),
+  loading: false,
+  error: null,
   status: HEDERA_DELEGATION_STATUS.Active,
   validator: {
     id: "3",

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/__tests__/DelegatedPositions.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/__tests__/DelegatedPositions.test.tsx
@@ -4,7 +4,7 @@ import { render, screen, userEvent } from "tests/testSetup";
 import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
 import { openModal } from "~/renderer/actions/modals";
 import { useStake } from "LLD/hooks/useStake";
-import { useHederaEnrichedDelegation } from "@ledgerhq/live-common/families/hedera/react";
+import { useHederaEnrichedDelegationV2 } from "@ledgerhq/live-common/families/hedera/react";
 import type { TokenAccount } from "@ledgerhq/types-live";
 import DelegatedPositions from "../DelegatedPositions/index";
 import { HEDERA_ACCOUNT_1, makeHederaAccount } from "../__mocks__/account.mock";
@@ -13,7 +13,7 @@ import { mockDelegation, mockEnrichedDelegation } from "../__mocks__/delegation.
 jest.mock("LLD/hooks/useStake", () => ({ useStake: jest.fn() }));
 
 jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
-  useHederaEnrichedDelegation: jest.fn(),
+  useHederaEnrichedDelegationV2: jest.fn(),
 }));
 
 jest.mock("~/renderer/actions/modals", () => ({
@@ -53,7 +53,7 @@ jest.mock("~/renderer/families/hedera/DelegatedPositions/Header", () => ({
 }));
 
 const mockUseStake = jest.mocked(useStake);
-const mockUseHederaEnrichedDelegation = jest.mocked(useHederaEnrichedDelegation);
+const mockUseHederaEnrichedDelegation = jest.mocked(useHederaEnrichedDelegationV2);
 const mockOpenModal = jest.mocked(openModal);
 
 const makeTokenAccount = (): TokenAccount =>

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/__tests__/DelegatedPositionsRow.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/__tests__/DelegatedPositionsRow.test.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { render, screen } from "tests/testSetup";
+import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+import { HEDERA_DELEGATION_STATUS } from "@ledgerhq/live-common/families/hedera/constants";
+import { Row } from "../DelegatedPositions/Row";
+import { makeHederaAccount } from "../__mocks__/account.mock";
+import { mockEnrichedDelegation } from "../__mocks__/delegation.mock";
+
+const defaultState = { settings: AFTER_ONBOARDING_STATE };
+const account = makeHederaAccount();
+const onManageAction = jest.fn();
+const onExternalLink = jest.fn();
+
+describe("DelegatedPositions Row", () => {
+  it("shows a placeholder while loading", () => {
+    render(
+      <Row
+        account={account}
+        enrichedDelegation={{ ...mockEnrichedDelegation, loading: true }}
+        onManageAction={onManageAction}
+        onExternalLink={onExternalLink}
+      />,
+      { initialState: defaultState },
+    );
+    expect(screen.queryByText(mockEnrichedDelegation.validator.name)).not.toBeInTheDocument();
+  });
+
+  it("hides the validator name and status icon when the fetch failed", () => {
+    render(
+      <Row
+        account={account}
+        enrichedDelegation={{ ...mockEnrichedDelegation, error: new Error("failed") }}
+        onManageAction={onManageAction}
+        onExternalLink={onExternalLink}
+      />,
+      { initialState: defaultState },
+    );
+    expect(screen.queryByText(mockEnrichedDelegation.validator.name)).not.toBeInTheDocument();
+  });
+
+  it("hides the validator name when the validator has been removed", () => {
+    render(
+      <Row
+        account={account}
+        enrichedDelegation={{
+          ...mockEnrichedDelegation,
+          validator: { ...mockEnrichedDelegation.validator, address: "" },
+        }}
+        onManageAction={onManageAction}
+        onExternalLink={onExternalLink}
+      />,
+      { initialState: defaultState },
+    );
+    expect(screen.queryByText(mockEnrichedDelegation.validator.name)).not.toBeInTheDocument();
+  });
+
+  it("shows the validator name and status when data is loaded successfully", () => {
+    render(
+      <Row
+        account={account}
+        enrichedDelegation={mockEnrichedDelegation}
+        onManageAction={onManageAction}
+        onExternalLink={onExternalLink}
+      />,
+      { initialState: defaultState },
+    );
+    expect(screen.getByText(mockEnrichedDelegation.validator.name)).toBeVisible();
+  });
+
+  it("shows an overstaked warning icon when the validator is overstaked", () => {
+    render(
+      <Row
+        account={account}
+        enrichedDelegation={{
+          ...mockEnrichedDelegation,
+          status: HEDERA_DELEGATION_STATUS.Overstaked,
+        }}
+        onManageAction={onManageAction}
+        onExternalLink={onExternalLink}
+      />,
+      { initialState: defaultState },
+    );
+    expect(screen.getByText(mockEnrichedDelegation.validator.name)).toBeVisible();
+  });
+
+  it("disables the claim rewards action when there is no pending reward", () => {
+    render(
+      <Row
+        account={account}
+        enrichedDelegation={{ ...mockEnrichedDelegation, pendingReward: new BigNumber(0) }}
+        onManageAction={onManageAction}
+        onExternalLink={onExternalLink}
+      />,
+      { initialState: defaultState },
+    );
+    expect(screen.getByText(mockEnrichedDelegation.validator.name)).toBeVisible();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/shared/__tests__/utils.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/shared/__tests__/utils.test.ts
@@ -1,0 +1,44 @@
+import { isValidatorRemoved } from "../utils";
+
+describe("isValidatorRemoved", () => {
+  it("returns true when done loading, without error, no validator and a numeric nodeId", () => {
+    expect(
+      isValidatorRemoved({ loading: false, error: null, hasValidator: false, nodeId: 3 }),
+    ).toBe(true);
+  });
+
+  it("returns false while loading", () => {
+    expect(isValidatorRemoved({ loading: true, error: null, hasValidator: false, nodeId: 3 })).toBe(
+      false,
+    );
+  });
+
+  it("returns false when the validators fetch failed", () => {
+    expect(
+      isValidatorRemoved({
+        loading: false,
+        error: new Error("network down"),
+        hasValidator: false,
+        nodeId: 3,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when the validator is present", () => {
+    expect(isValidatorRemoved({ loading: false, error: null, hasValidator: true, nodeId: 3 })).toBe(
+      false,
+    );
+  });
+
+  it("returns false when there is no delegated nodeId", () => {
+    expect(
+      isValidatorRemoved({ loading: false, error: null, hasValidator: false, nodeId: undefined }),
+    ).toBe(false);
+  });
+
+  it("returns true when loading is undefined, without error, no validator and a numeric nodeId", () => {
+    expect(
+      isValidatorRemoved({ loading: undefined, error: null, hasValidator: false, nodeId: 3 }),
+    ).toBe(true);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/shared/staking/ValidatorsListField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/shared/staking/ValidatorsListField.tsx
@@ -1,12 +1,18 @@
 import React, { useState, useCallback } from "react";
 import { Trans } from "react-i18next";
+import { useQuery } from "@tanstack/react-query";
 import styled from "styled-components";
 import type { Account } from "@ledgerhq/types-live";
-import { useHederaValidators } from "@ledgerhq/live-common/families/hedera/react";
+import { hederaQueries } from "@ledgerhq/live-common/families/hedera/react";
 import type { HederaValidator } from "@ledgerhq/live-common/families/hedera/types";
-import { getDefaultValidator } from "@ledgerhq/live-common/families/hedera/utils";
+import {
+  getDefaultValidator,
+  filterValidatorBySearchTerm,
+} from "@ledgerhq/live-common/families/hedera/utils";
 import Box from "~/renderer/components/Box";
 import Text from "~/renderer/components/Text";
+import TranslatedError from "~/renderer/components/TranslatedError";
+import Spinner from "~/renderer/components/Spinner";
 import ScrollLoadingList from "~/renderer/components/ScrollLoadingList";
 import ValidatorSearchInput, {
   NoResultPlaceholder,
@@ -25,7 +31,11 @@ const ValidatorsListField = ({ account, selectedValidatorId, onChangeValidator }
   const [search, setSearch] = useState("");
   const [showAll, setShowAll] = useState(true);
   const unit = useAccountUnit(account);
-  const validators = useHederaValidators(account.currency, search);
+  const queryValidators = useQuery({
+    ...hederaQueries.validatorsList(account.currency.id),
+    select: data => (search ? data.filter(v => filterValidatorBySearchTerm(v, search)) : data),
+  });
+  const validators = queryValidators.data ?? [];
 
   const defaultValidator = getDefaultValidator(validators);
   const selectedValidator = validators.find(v => v.id === selectedValidatorId);
@@ -52,26 +62,43 @@ const ValidatorsListField = ({ account, selectedValidatorId, onChangeValidator }
   const getDisplayedValidators = () => {
     if (showAll) return validators;
     if (value) return [value];
-    return [validators[0]];
+    return validators.length > 0 ? [validators[0]] : [];
   };
 
   return (
     <>
-      {showAll && <ValidatorSearchInput noMargin={true} search={search} onSearch={onSearch} />}
+      {queryValidators.isLoadingError && (
+        <Box mb={2}>
+          <Text color="pearl">
+            <TranslatedError error={queryValidators.error} />
+          </Text>
+        </Box>
+      )}
+      {showAll && !queryValidators.isLoadingError && (
+        <ValidatorSearchInput noMargin={true} search={search} onSearch={onSearch} />
+      )}
       <ValidatorsFieldContainer>
         <Box p={1} data-testid="validator-list">
-          <ScrollLoadingList
-            data={getDisplayedValidators()}
-            style={{
-              flex: showAll ? "1 0 256px" : "1 0 64px",
-              marginBottom: 0,
-              paddingLeft: 0,
-            }}
-            renderItem={renderItem}
-            noResultPlaceholder={
-              validators.length <= 0 && search.length > 0 && <NoResultPlaceholder search={search} />
-            }
-          />
+          {queryValidators.isLoading ? (
+            <Box p={4} alignItems="center" justifyContent="center">
+              <Spinner size={24} />
+            </Box>
+          ) : (
+            <ScrollLoadingList
+              data={getDisplayedValidators()}
+              style={{
+                flex: showAll ? "1 0 256px" : "1 0 64px",
+                marginBottom: 0,
+                paddingLeft: 0,
+              }}
+              renderItem={renderItem}
+              noResultPlaceholder={
+                !queryValidators.isLoadingError &&
+                validators.length <= 0 &&
+                search.length > 0 && <NoResultPlaceholder search={search} />
+              }
+            />
+          )}
         </Box>
         <SeeAllButton expanded={showAll} onClick={() => setShowAll(shown => !shown)}>
           <Text color="wallet" ff="Inter|SemiBold" fontSize={4}>

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/shared/staking/ValidatorsSelect.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/shared/staking/ValidatorsSelect.tsx
@@ -3,10 +3,11 @@ import { useTranslation } from "react-i18next";
 // FilterOptionOption type for react-select v5 filter callback
 type FilterOptionOption<T> = { label: string; value: string; data: T };
 import styled from "styled-components";
+import { useQuery } from "@tanstack/react-query";
 import { Box } from "@ledgerhq/react-ui";
 import type { HederaAccount, HederaValidator } from "@ledgerhq/live-common/families/hedera/types";
 import { filterValidatorBySearchTerm } from "@ledgerhq/live-common/families/hedera/utils";
-import { useHederaValidators } from "@ledgerhq/live-common/families/hedera/react";
+import { hederaQueries } from "@ledgerhq/live-common/families/hedera/react";
 import Select from "~/renderer/components/Select";
 import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import ValidatorOption from "~/renderer/families/hedera/shared/staking/ValidatorOption";
@@ -34,7 +35,8 @@ export default function ValidatorsSelect({
   const [query, setQuery] = useState<string>();
   const { t } = useTranslation();
   const unit = useAccountUnit(account);
-  const options = useHederaValidators(account.currency);
+  const queryValidators = useQuery(hederaQueries.validatorsList(account.currency.id));
+  const options = useMemo(() => queryValidators.data ?? [], [queryValidators.data]);
 
   const renderItem = useCallback(
     (item: { data: HederaValidator; isDisabled: boolean }) => {
@@ -55,11 +57,31 @@ export default function ValidatorsSelect({
     return options.find(v => v.id === selectedValidatorId) ?? null;
   }, [selectedValidatorId, options]);
 
+  const hasNoDataError = queryValidators.data === undefined && !!queryValidators.error;
+  const fetchError = hasNoDataError && !disabled ? queryValidators.error : undefined;
+  const displayError = error ?? fetchError;
+
+  const getPlaceholder = () => {
+    if (hasNoDataError) {
+      return t("hedera.redelegation.flow.steps.validators.unableToLoadSelectPlaceholder");
+    }
+
+    if (queryValidators.isLoading) {
+      return t("hedera.redelegation.flow.steps.validators.loadingValidatorPlaceholder");
+    }
+
+    if (showRemovedPlaceholder) {
+      return t("hedera.redelegation.flow.steps.validators.removedValidatorSelectPlaceholder");
+    }
+
+    return t("hedera.redelegation.flow.steps.validators.newValidatorSelectPlaceholder");
+  };
+
   const renderErrorMessage = () => {
-    if (error) {
+    if (displayError) {
       return (
         <ErrorDisplay id="input-error">
-          <TranslatedError error={error} />
+          <TranslatedError error={displayError} />
         </ErrorDisplay>
       );
     }
@@ -80,7 +102,7 @@ export default function ValidatorsSelect({
       <Select
         key={selectedValidatorId}
         value={value}
-        error={error}
+        error={displayError}
         options={options}
         getOptionValue={option => option.address}
         renderValue={renderItem}
@@ -88,12 +110,9 @@ export default function ValidatorsSelect({
         onInputChange={setQuery}
         filterOption={filterOptions}
         inputValue={query}
+        isLoading={queryValidators.isLoading}
         isDisabled={disabled || options.length <= 1}
-        placeholder={
-          showRemovedPlaceholder
-            ? t("hedera.redelegation.flow.steps.validators.removedValidatorSelectPlaceholder")
-            : t("hedera.redelegation.flow.steps.validators.newValidatorSelectPlaceholder")
-        }
+        placeholder={getPlaceholder()}
         noOptionsMessage={({ inputValue }) =>
           t("hedera.redelegation.flow.steps.validators.newValidatorSelectNoOption", {
             validatorName: inputValue,
@@ -103,7 +122,7 @@ export default function ValidatorsSelect({
           onChangeValidator?.(validator ?? null);
         }}
       />
-      <ErrorContainer hasError={error || warning}>{renderErrorMessage()}</ErrorContainer>
+      <ErrorContainer hasError={displayError || warning}>{renderErrorMessage()}</ErrorContainer>
     </>
   );
 }

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/shared/staking/__tests__/ValidatorsListField.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/shared/staking/__tests__/ValidatorsListField.test.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+import { render, screen, userEvent, waitFor } from "tests/testSetup";
+import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+import ValidatorsListField from "../ValidatorsListField";
+import { makeHederaAccount } from "../../../__mocks__/account.mock";
+
+let queryFn: () => Promise<unknown>;
+
+jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
+  hederaQueries: {
+    validatorsList: () => ({
+      queryKey: ["mock-hedera-validators"],
+      queryFn: () => queryFn(),
+      retry: false,
+    }),
+  },
+}));
+
+const defaultState = { settings: AFTER_ONBOARDING_STATE };
+const account = makeHederaAccount();
+const onChangeValidator = jest.fn();
+
+describe("ValidatorsListField", () => {
+  it("shows the fetch error text and keeps the list mounted", async () => {
+    queryFn = () => Promise.reject(new Error("network down"));
+
+    render(
+      <ValidatorsListField
+        account={account}
+        selectedValidatorId={null}
+        onChangeValidator={onChangeValidator}
+      />,
+      { initialState: defaultState },
+    );
+
+    await waitFor(() => expect(screen.getByText(/network down/i)).toBeVisible());
+    expect(screen.getByTestId("validator-list")).toBeVisible();
+  });
+
+  it("hides the search input while the fetch has never succeeded", async () => {
+    queryFn = () => Promise.reject(new Error("network down"));
+
+    render(
+      <ValidatorsListField
+        account={account}
+        selectedValidatorId={null}
+        onChangeValidator={onChangeValidator}
+      />,
+      { initialState: defaultState },
+    );
+
+    await waitFor(() => expect(screen.getByText(/network down/i)).toBeVisible());
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("does not show an error when the fetch succeeds", async () => {
+    queryFn = () => Promise.resolve([]);
+
+    render(
+      <ValidatorsListField
+        account={account}
+        selectedValidatorId={null}
+        onChangeValidator={onChangeValidator}
+      />,
+      { initialState: defaultState },
+    );
+
+    await waitFor(() => expect(screen.getByTestId("validator-list")).toBeVisible());
+    expect(screen.queryByText(/network down/i)).not.toBeInTheDocument();
+  });
+
+  it("shows a spinner and no list while the fetch is pending", async () => {
+    queryFn = () => new Promise(() => {});
+
+    render(
+      <ValidatorsListField
+        account={account}
+        selectedValidatorId={null}
+        onChangeValidator={onChangeValidator}
+      />,
+      { initialState: defaultState },
+    );
+
+    await waitFor(() => expect(screen.getByTestId("loading-spinner")).toBeVisible());
+  });
+
+  it("does not crash clicking 'Show less' with an empty list from a failed fetch", async () => {
+    queryFn = () => Promise.reject(new Error("network down"));
+
+    render(
+      <ValidatorsListField
+        account={account}
+        selectedValidatorId={null}
+        onChangeValidator={onChangeValidator}
+      />,
+      { initialState: defaultState },
+    );
+
+    await waitFor(() => expect(screen.getByText(/network down/i)).toBeVisible());
+    await userEvent.click(screen.getByText(/show less/i));
+
+    expect(screen.getByTestId("validator-list")).toBeVisible();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/shared/staking/__tests__/ValidatorsSelect.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/shared/staking/__tests__/ValidatorsSelect.test.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { render, screen, waitFor } from "tests/testSetup";
+import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+import ValidatorsSelect from "../ValidatorsSelect";
+import { makeHederaAccount } from "../../../__mocks__/account.mock";
+
+let queryFn: () => Promise<unknown>;
+
+jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
+  hederaQueries: {
+    validatorsList: () => ({
+      queryKey: ["mock-hedera-validators"],
+      queryFn: () => queryFn(),
+      retry: false,
+    }),
+  },
+}));
+
+const defaultState = { settings: AFTER_ONBOARDING_STATE };
+const account = makeHederaAccount();
+
+describe("ValidatorsSelect", () => {
+  it("shows the fetch error text and keeps the select mounted", async () => {
+    queryFn = () => Promise.reject(new Error("network down"));
+
+    render(<ValidatorsSelect account={account} selectedValidatorId={null} />, {
+      initialState: defaultState,
+    });
+
+    await waitFor(() => expect(screen.getByText(/network down/i)).toBeVisible());
+    expect(screen.getByText(/unable to load validators/i)).toBeVisible();
+  });
+
+  it("does not show the generic 'select validator' placeholder when the fetch fails", async () => {
+    queryFn = () => Promise.reject(new Error("network down"));
+
+    render(<ValidatorsSelect account={account} selectedValidatorId={null} />, {
+      initialState: defaultState,
+    });
+
+    await waitFor(() => expect(screen.getByText(/network down/i)).toBeVisible());
+    expect(screen.queryByText(/^select validator$/i)).not.toBeInTheDocument();
+  });
+
+  it("does not show the removed-validator placeholder when the fetch fails", async () => {
+    queryFn = () => Promise.reject(new Error("network down"));
+
+    render(
+      <ValidatorsSelect account={account} selectedValidatorId={null} showRemovedPlaceholder />,
+      { initialState: defaultState },
+    );
+
+    await waitFor(() => expect(screen.getByText(/network down/i)).toBeVisible());
+    expect(
+      screen.queryByText(/previously selected validator is no longer available/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not show an error when the fetch succeeds", async () => {
+    queryFn = () => Promise.resolve([]);
+
+    render(<ValidatorsSelect account={account} selectedValidatorId={null} />, {
+      initialState: defaultState,
+    });
+
+    await waitFor(() => expect(screen.queryByText(/network down/i)).not.toBeInTheDocument());
+  });
+
+  it("shows the loading placeholder and disables the select while the fetch is pending", async () => {
+    queryFn = () => new Promise(() => {});
+
+    render(<ValidatorsSelect account={account} selectedValidatorId={null} />, {
+      initialState: defaultState,
+    });
+
+    await waitFor(() => expect(screen.getByText(/loading validators/i)).toBeVisible());
+    expect(screen.getByText(/loading validators/i).closest(".select__control")).toHaveClass(
+      "select__control--is-disabled",
+    );
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/shared/utils.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/shared/utils.ts
@@ -1,0 +1,13 @@
+export function isValidatorRemoved({
+  loading,
+  error,
+  hasValidator,
+  nodeId,
+}: {
+  loading?: boolean;
+  error: unknown;
+  hasValidator: boolean;
+  nodeId: unknown;
+}): boolean {
+  return !loading && !error && !hasValidator && typeof nodeId === "number";
+}

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8198,6 +8198,7 @@
             "inactiveTooltip": "Validator not found",
             "overstakedTooltip": "This node is overstaked, APY is lower than optimal",
             "activeTooltip": "Delegated amount generates rewards",
+            "fetchErrorTooltip": "Couldn't load validator data. Please try again.",
             "delegated": "Delegated",
             "rewards": "Rewards"
           },
@@ -8276,6 +8277,8 @@
             "newValidatorLabel": "New delegation",
             "newValidatorSelectPlaceholder": "Select validator",
             "removedValidatorSelectPlaceholder": "Previously selected validator is no longer available",
+            "unableToLoadSelectPlaceholder": "Unable to load validators",
+            "loadingValidatorPlaceholder": "Loading validators...",
             "newValidatorSelectNoOption": "No validator matching \"{{validatorName}}\"",
             "amountLabel": "Amount to redelegate",
             "alert": "When staking on Hedera, your entire balance is staked. It remains fully liquid and is not exposed to lockup period or slashing risks. You may need to wait up to 48 hours for staking rewards to start.",

--- a/libs/coin-modules/coin-hedera/src/types/bridge.ts
+++ b/libs/coin-modules/coin-hedera/src/types/bridge.ts
@@ -132,6 +132,9 @@ export interface HederaDelegation {
 export interface HederaEnrichedDelegation extends HederaDelegation {
   status: HEDERA_DELEGATION_STATUS;
   validator: HederaValidator;
+  // set by useHederaEnrichedDelegationV2 only; required once the legacy hook is gone
+  loading?: boolean;
+  error?: Error | null;
 }
 
 interface HederaDelegationRaw {
@@ -188,6 +191,7 @@ export type HederaValidator = {
   isLedgerNode: boolean;
 };
 
+// kept alive for the legacy preload layer, removed with it
 export type HederaValidatorRaw = {
   id: string;
   minStake: string;

--- a/libs/ledger-live-common/src/families/hedera/react.test.ts
+++ b/libs/ledger-live-common/src/families/hedera/react.test.ts
@@ -2,17 +2,21 @@
  * @jest-environment jsdom
  */
 import "../../__tests__/test-helpers/dom-polyfill";
+import React from "react";
 import BigNumber from "bignumber.js";
 import invariant from "invariant";
+import hederaCoinConfig from "@ledgerhq/coin-hedera/config";
 import { getCurrentHederaPreloadData } from "@ledgerhq/coin-hedera/preload-data";
+import { getHederaValidators } from "@ledgerhq/coin-hedera/network/utils";
 import { apiClient } from "@ledgerhq/coin-hedera/network/api";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
-import { renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
 import { makeBridgeCacheSystem } from "../../bridge/cache";
 import { liveConfig } from "../../config/sharedConfig";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import * as hooks from "./react";
-import type { HederaAccount, HederaDelegation } from "./types";
+import type { HederaAccount, HederaDelegation, HederaValidator } from "./types";
 
 const localCache: Record<string, unknown> = {};
 const cache = makeBridgeCacheSystem({
@@ -25,11 +29,36 @@ const cache = makeBridgeCacheSystem({
   },
 });
 
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
 describe("hedera/react", () => {
   const currency = getCryptoCurrencyById("hedera");
 
   beforeAll(() => {
     LiveConfig.setConfig(liveConfig);
+    hederaCoinConfig.setCoinConfig(() => ({
+      status: { type: "active" },
+      useNetworkTimestamp: false,
+      networkType: "mainnet",
+      claimRewardsRecipient: "0.0.163372",
+      ledgerNodeId: -1,
+      tokenAssociationMinUsd: 0.05,
+      apiUrls: {
+        hgraph: "https://hedera-indexer-mainnet.coin.ledger.com/v1/graphql",
+        mirrorNode: "https://hedera.coin.ledger.com",
+      },
+    }));
+  });
+
+  beforeEach(() => {
+    getHederaValidators.reset();
     jest.spyOn(apiClient, "getNodes").mockResolvedValue({
       nodes: [
         {
@@ -260,6 +289,249 @@ describe("hedera/react", () => {
       );
 
       expect(result.current.pendingReward).toEqual(new BigNumber(1500));
+    });
+  });
+  describe("hederaQueries.validatorsList", () => {
+    it("should return all validators", async () => {
+      const { result } = renderHook(
+        () => useQuery(hooks.hederaQueries.validatorsList(currency.id)),
+        {
+          wrapper: createWrapper(),
+        },
+      );
+
+      await waitFor(() => expect(result.current.data).toHaveLength(3));
+      // sortValidators puts the Ledger node first, then orders by active stake descending
+      expect(result.current.data?.map(validator => validator.id)).toEqual(["1", "0", "3"]);
+    });
+
+    it("should surface an error when the validators fetch fails", async () => {
+      jest.spyOn(apiClient, "getNodes").mockRejectedValueOnce(new Error("network down"));
+
+      const { result } = renderHook(
+        () => useQuery(hooks.hederaQueries.validatorsList(currency.id)),
+        {
+          wrapper: createWrapper(),
+        },
+      );
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.error).toBeInstanceOf(Error);
+      expect(result.current.data).toBeUndefined();
+    });
+  });
+
+  describe("useHederaEnrichedDelegationV2", () => {
+    const mockAccount = {
+      type: "Account",
+      id: "mock-account-id",
+      currency,
+      balance: new BigNumber(1000000),
+      spendableBalance: new BigNumber(1000000),
+      hederaResources: {
+        delegation: null,
+      },
+    } as unknown as HederaAccount;
+
+    let validators: HederaValidator[];
+
+    beforeEach(async () => {
+      validators = await getHederaValidators(currency.id);
+    });
+
+    it("should report loading:true before validators resolve, then loading:false once they do", async () => {
+      const delegation: HederaDelegation = {
+        nodeId: 999999,
+        delegated: new BigNumber(100000),
+        pendingReward: new BigNumber(500),
+      };
+
+      const { result } = renderHook(
+        () => hooks.useHederaEnrichedDelegationV2(mockAccount, delegation),
+        {
+          wrapper: createWrapper(),
+        },
+      );
+
+      expect(result.current.loading).toBe(true);
+      await waitFor(() => expect(result.current.loading).toBe(false));
+    });
+
+    it("should enrich delegation with validator data", async () => {
+      const validator = validators[0];
+      invariant(validator, "No validators available for test");
+
+      const delegation: HederaDelegation = {
+        nodeId: Number(validator.id),
+        delegated: new BigNumber(100000),
+        pendingReward: new BigNumber(500),
+      };
+
+      const { result } = renderHook(
+        () => hooks.useHederaEnrichedDelegationV2(mockAccount, delegation),
+        {
+          wrapper: createWrapper(),
+        },
+      );
+
+      await waitFor(() =>
+        expect(result.current).toEqual({
+          nodeId: delegation.nodeId,
+          delegated: delegation.delegated,
+          pendingReward: delegation.pendingReward,
+          loading: false,
+          error: null,
+          status: "overstaked",
+          validator: {
+            name: validator.name,
+            address: validator.address,
+            addressChecksum: validator.addressChecksum,
+            id: validator.id,
+            minStake: validator.minStake,
+            maxStake: validator.maxStake,
+            activeStake: validator.activeStake,
+            activeStakePercentage: validator.activeStakePercentage,
+            overstaked: validator.overstaked,
+            isLedgerNode: validator.isLedgerNode,
+          },
+        }),
+      );
+    });
+
+    it("should handle delegation with non-existent validator", async () => {
+      const delegation: HederaDelegation = {
+        nodeId: 999999,
+        delegated: new BigNumber(100000),
+        pendingReward: new BigNumber(500),
+      };
+
+      const { result } = renderHook(
+        () => hooks.useHederaEnrichedDelegationV2(mockAccount, delegation),
+        {
+          wrapper: createWrapper(),
+        },
+      );
+
+      await waitFor(() =>
+        expect(result.current).toEqual({
+          nodeId: delegation.nodeId,
+          delegated: delegation.delegated,
+          pendingReward: delegation.pendingReward,
+          loading: false,
+          error: null,
+          status: "inactive",
+          validator: {
+            name: "",
+            address: "",
+            addressChecksum: null,
+            id: String(delegation.nodeId),
+            minStake: new BigNumber(0),
+            maxStake: new BigNumber(0),
+            activeStake: new BigNumber(0),
+            activeStakePercentage: new BigNumber(0),
+            overstaked: false,
+            isLedgerNode: false,
+          },
+        }),
+      );
+    });
+
+    it("should handle delegation with zero staked amount", async () => {
+      const validator = validators[0];
+      invariant(validator, "No validators available for test");
+
+      const delegation: HederaDelegation = {
+        nodeId: Number(validator.id),
+        delegated: new BigNumber(0),
+        pendingReward: new BigNumber(0),
+      };
+
+      const { result } = renderHook(
+        () => hooks.useHederaEnrichedDelegationV2(mockAccount, delegation),
+        {
+          wrapper: createWrapper(),
+        },
+      );
+
+      await waitFor(() => expect(result.current.validator.id).toEqual(validator.id));
+      expect(result.current.delegated).toEqual(new BigNumber(0));
+    });
+
+    it("surfaces the error when the fetch fails before anything is cached", async () => {
+      jest.spyOn(apiClient, "getNodes").mockRejectedValue(new Error("network down"));
+      // the beforeEach above warms the LRU, so drop it or the hook just reads the cached list
+      getHederaValidators.clear(currency.id);
+
+      const delegation: HederaDelegation = {
+        nodeId: 0,
+        delegated: new BigNumber(100000),
+        pendingReward: new BigNumber(500),
+      };
+
+      const { result } = renderHook(
+        () => hooks.useHederaEnrichedDelegationV2(mockAccount, delegation),
+        {
+          wrapper: createWrapper(),
+        },
+      );
+
+      await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+      expect(result.current.status).toBe("inactive");
+      expect(result.current.validator.name).toBe("");
+    });
+
+    it("does not surface a refetch error when previously fetched validators are still cached", async () => {
+      const validator = validators[0];
+      invariant(validator, "No validators available for test");
+
+      const delegation: HederaDelegation = {
+        nodeId: Number(validator.id),
+        delegated: new BigNumber(100000),
+        pendingReward: new BigNumber(500),
+      };
+
+      const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      const wrapper = ({ children }: { children: React.ReactNode }) =>
+        React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+      const { result } = renderHook(
+        () => hooks.useHederaEnrichedDelegationV2(mockAccount, delegation),
+        { wrapper },
+      );
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.validator.id).toEqual(validator.id);
+      expect(result.current.error).toBeNull();
+
+      jest.spyOn(apiClient, "getNodes").mockRejectedValueOnce(new Error("network down"));
+      // without this the queryFn just replays the cached promise and the refetch never fails
+      getHederaValidators.clear(currency.id);
+      await queryClient.refetchQueries({
+        queryKey: [...hooks.hederaQueries.all(), "validators", currency.id],
+      });
+
+      await waitFor(() => expect(result.current.error).toBeNull());
+      expect(result.current.validator.id).toEqual(validator.id);
+    });
+
+    it("should handle delegation with pending rewards", async () => {
+      const validator = validators[0];
+      invariant(validator, "No validators available for test");
+
+      const delegation: HederaDelegation = {
+        nodeId: Number(validator.id),
+        delegated: new BigNumber(100000),
+        pendingReward: new BigNumber(1500),
+      };
+
+      const { result } = renderHook(
+        () => hooks.useHederaEnrichedDelegationV2(mockAccount, delegation),
+        {
+          wrapper: createWrapper(),
+        },
+      );
+
+      await waitFor(() => expect(result.current.pendingReward).toEqual(new BigNumber(1500)));
     });
   });
 });

--- a/libs/ledger-live-common/src/families/hedera/react.ts
+++ b/libs/ledger-live-common/src/families/hedera/react.ts
@@ -1,6 +1,9 @@
 import BigNumber from "bignumber.js";
 import type { CryptoCurrency } from "@domain/entity-currency-crypto";
 import { useMemo } from "react";
+import { queryOptions, useQuery } from "@tanstack/react-query";
+import { getHederaValidators } from "@ledgerhq/coin-hedera/network/utils";
+import { HEDERA_VALIDATORS_CACHE_MINUTES } from "@ledgerhq/coin-hedera/constants";
 import {
   getCurrentHederaPreloadData,
   getHederaPreloadData,
@@ -47,6 +50,53 @@ export function useHederaEnrichedDelegation(
 
   return {
     ...delegation,
+    status: getDelegationStatus(validator),
+    validator: {
+      name: validator?.name ?? "",
+      address: validator?.address ?? "",
+      addressChecksum: validator?.addressChecksum ?? null,
+      id: String(delegation.nodeId),
+      minStake: validator?.minStake ?? new BigNumber(0),
+      maxStake: validator?.maxStake ?? new BigNumber(0),
+      activeStake: validator?.activeStake ?? new BigNumber(0),
+      activeStakePercentage: validator?.activeStakePercentage ?? new BigNumber(0),
+      overstaked: validator?.overstaked ?? false,
+      isLedgerNode: validator?.isLedgerNode ?? false,
+    },
+  };
+}
+
+const HEDERA_VALIDATORS_CACHE_TTL_MS = HEDERA_VALIDATORS_CACHE_MINUTES * 60 * 1000;
+
+export const hederaQueries = {
+  all: () => ["hedera"] as const,
+  validatorsList: (currencyId: string) =>
+    queryOptions({
+      queryKey: [...hederaQueries.all(), "validators", currencyId],
+      // getHederaValidators owns the TTL and is the same data that getTransactionStatus validates against.
+      // staleTime stays 0 to keep both reading one entry.
+      // side effect: refetch and invalidateQueries are no-ops, call .clear() to force a refresh.
+      queryFn: (): Promise<HederaValidator[]> => getHederaValidators(currencyId),
+      retry: false,
+      staleTime: 0,
+      gcTime: HEDERA_VALIDATORS_CACHE_TTL_MS,
+    }),
+};
+
+// replaces useHederaEnrichedDelegation once mobile migrates off the preload layer
+export function useHederaEnrichedDelegationV2(
+  account: HederaAccount,
+  delegation: HederaDelegation,
+): HederaEnrichedDelegation {
+  const queryValidators = useQuery(hederaQueries.validatorsList(account.currency.id));
+  const validators = queryValidators.data ?? [];
+  const validatorById = new Map(validators.map(v => [v.id, v]));
+  const validator = validatorById.get(String(delegation.nodeId)) ?? null;
+
+  return {
+    ...delegation,
+    loading: queryValidators.isLoading,
+    error: queryValidators.data === undefined ? queryValidators.error : null,
     status: getDelegationStatus(validator),
     validator: {
       name: validator?.name ?? "",


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR migrates the desktop Hedera staking flows off the old preload-based validator list and onto an on-demand React Query fetch, part of a larger effort to remove Hedera's preload layer. 
- Validators are now fetched lazily through a shared cached query instead of being loaded eagerly for every account, and every screen that reads them (delegate, redelegate, undelegate, claim rewards, delegated positions list) now handles loading and fetch-error states explicitly instead of assuming the data is already there. 
- Transaction status validation was updated to only require a validators fetch for delegate and redelegate modes, so undelegating or claiming rewards no longer blocks on it, and a fetch failure surfaces as a validation error rather than throwing. 
- The delegated positions row also gets a placeholder skeleton while validators are loading and an error icon with tooltip if the fetch fails, and the continue buttons across these flows now show a loading state while the bridge transaction status is pending.

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->


Loading and error handling in account details view
| <img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/dd95fce6-c541-429f-b781-14406b3de827" /> | <img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/46e7d952-2254-40a5-a3de-4ec0cc9630c4" /> |
|---|--|

Loading and error handling in delegate flow
| <img width="1800" height="1169" alt="SCR-20260831-kotu" src="https://github.com/user-attachments/assets/b3a7e4a0-81fc-4d43-867e-2381fb307e56" /> | <img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/61f95a54-5681-4516-b187-9b4e260d6b01" /> |
|---|--|

Loading and error handling in redelegate flow
| <img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/c55a3e1d-1196-4aea-b1ff-2e42ba8c824d" /> | <img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/9b690876-9523-47b6-b6a3-3508c00385e1" /> |
|---|--|

Loading and error handling in undelegate flow
| <img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/07779bcc-a36b-4ac0-888e-c1f4cb089690" /> | <img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/e5bd6b5d-8d5f-4d36-8dca-6a511d344e19" /> |
|---|--|

Loading and error handling in claim rewards flow
| <img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/bf5bc41f-c056-440a-b8fc-1b8a3fd05f74" /> | <img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/33afad7d-6ab2-4b9d-8434-1736ce7779d0" /> |
|---|--|

### 🔗 Context
- https://ledgerhq.atlassian.net/browse/LIVE-36153
