### PR TITLE
[LWM] refactor(hedera): migrate mobile staking to the validators query

### DIFF
--- a/.changeset/hedera-mobile-validators-query.md
+++ b/.changeset/hedera-mobile-validators-query.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+refactor: read Hedera staking validators through an on-demand query on mobile, with loading and fetch-error states

--- a/apps/ledger-live-mobile/src/families/hedera/ClaimRewardsFlow/__integrations__/claimRewardsFlow.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/ClaimRewardsFlow/__integrations__/claimRewardsFlow.integration.test.tsx
@@ -63,7 +63,7 @@ function ClaimRewardsFlowHarness() {
   );
 }
 
-function renderFlow() {
+function renderFlow(selectedDelegation = mockEnrichedDelegation) {
   return render(<ClaimRewardsFlowHarness />, {
     navigationInitialState: {
       index: 0,
@@ -77,7 +77,7 @@ function renderFlow() {
                 name: ScreenName.HederaClaimRewardsClaim,
                 params: {
                   accountId: HEDERA_ACCOUNT_1.id,
-                  selectedDelegation: mockEnrichedDelegation,
+                  selectedDelegation,
                 },
               },
             ],
@@ -133,5 +133,18 @@ describe("Hedera ClaimRewardsFlow (integration)", () => {
 
     await waitFor(() => expect(screen.getByText("Retry")).toBeVisible(), { timeout: 15000 });
     expect(screen.queryByTestId("validate-success-screen")).toBeNull();
+  });
+
+  it("renders without crashing when the enriched delegation has a fetch error and blank validator name", async () => {
+    renderFlow({
+      ...mockEnrichedDelegation,
+      error: new Error("network down"),
+      validator: { ...mockEnrichedDelegation.validator, name: "" },
+    });
+
+    await waitFor(
+      () => expect(screen.getByTestId("enabled-hedera-claim-continue-button")).toBeVisible(),
+      { timeout: 10000 },
+    );
   });
 });

--- a/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/SelectValidator.test.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/SelectValidator.test.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { Spinner } from "@ledgerhq/lumen-ui-rnative";
+import { renderWithReactQuery as render, screen, waitFor } from "@tests/test-renderer";
+import { ScreenName } from "~/const";
+import type { State } from "~/reducers/types";
+import SelectValidator from "./SelectValidator";
+import { HEDERA_ACCOUNT_1 } from "../__mocks__/account.mock";
+
+let validatorsQueryFn: () => Promise<unknown>;
+
+jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
+  hederaQueries: {
+    validatorsList: () => ({
+      queryKey: ["mock-hedera-validators"],
+      queryFn: () => validatorsQueryFn(),
+      retry: false,
+    }),
+  },
+}));
+
+const mockNavigate = jest.fn();
+const mockNavigation = { navigate: mockNavigate } as never;
+const mockRoute = {
+  key: "test",
+  name: ScreenName.HederaDelegationSelectValidator,
+  params: { accountId: HEDERA_ACCOUNT_1.id },
+} as never;
+
+const validator = {
+  id: "0",
+  name: "Hedera Node 0",
+  address: "0.0.3",
+  addressChecksum: null,
+  minStake: new BigNumber(0),
+  maxStake: new BigNumber(250_000_000_000_000_000),
+  activeStake: new BigNumber(0),
+  activeStakePercentage: new BigNumber(0),
+  overstaked: false,
+};
+
+const overrideInitialState = (state: State): State => ({
+  ...state,
+  accounts: { ...state.accounts, active: [HEDERA_ACCOUNT_1] },
+});
+
+describe("DelegationFlow SelectValidator", () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it("shows a spinner and no validator row while the validators query is loading", () => {
+    validatorsQueryFn = () => new Promise(() => {});
+
+    render(<SelectValidator navigation={mockNavigation} route={mockRoute} />, {
+      overrideInitialState,
+    });
+
+    expect(screen.UNSAFE_getByType(Spinner)).toBeTruthy();
+    expect(screen.queryByText("Hedera Node 0")).toBeNull();
+  });
+
+  it("shows the fetch error text and keeps the list mounted", async () => {
+    validatorsQueryFn = () => Promise.reject(new Error("network down"));
+
+    render(<SelectValidator navigation={mockNavigation} route={mockRoute} />, {
+      overrideInitialState,
+    });
+
+    await waitFor(() => expect(screen.getByText(/network down/i)).toBeVisible());
+  });
+
+  it("does not show an error and navigates to Summary when a validator is selected", async () => {
+    validatorsQueryFn = () => Promise.resolve([validator]);
+
+    const { user } = render(<SelectValidator navigation={mockNavigation} route={mockRoute} />, {
+      overrideInitialState,
+    });
+
+    await waitFor(() => expect(screen.getByText("Hedera Node 0")).toBeVisible());
+    expect(screen.queryByText(/network down/i)).toBeNull();
+
+    await user.press(screen.getByText("Hedera Node 0"));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      ScreenName.HederaDelegationSummary,
+      expect.objectContaining({ validator }),
+    );
+  });
+});

--- a/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/SelectValidator.tsx
@@ -1,11 +1,10 @@
 import React, { useCallback, useState } from "react";
 import { Trans } from "~/context/Locale";
 import SafeAreaView from "~/components/SafeAreaView";
-import { FlatList, StyleSheet, View } from "react-native";
+import { StyleSheet, View } from "react-native";
 import invariant from "invariant";
 import { useTheme } from "@react-navigation/native";
-import { Text } from "@ledgerhq/native-ui";
-import { useHederaValidators } from "@ledgerhq/live-common/families/hedera/react";
+import { Text } from "@ledgerhq/lumen-ui-rnative";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
 import type { HederaValidator } from "@ledgerhq/live-common/families/hedera/types";
 import { TrackScreen } from "~/analytics";
@@ -13,14 +12,12 @@ import type { BaseComposite, StackNavigatorProps } from "~/components/RootNaviga
 import { ScreenName } from "~/const";
 import SelectValidatorSearchBox from "~/families/tron/VoteFlow/01-SelectValidator/SearchBox";
 import type { HederaDelegationFlowParamList } from "./types";
-import ValidatorRow from "../shared/ValidatorRow";
+import ValidatorsList from "../shared/ValidatorsList";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
 type Props = BaseComposite<
   StackNavigatorProps<HederaDelegationFlowParamList, ScreenName.HederaDelegationSelectValidator>
 >;
-
-const keyExtractor = (v: HederaValidator) => v.id;
 
 export default function SelectValidator({ navigation, route }: Props) {
   const { colors } = useTheme();
@@ -30,8 +27,6 @@ export default function SelectValidator({ navigation, route }: Props) {
   invariant(account, "account must be defined");
   invariant(account.type === "Account", "account must be of type Account");
 
-  const validators = useHederaValidators(account.currency, searchQuery);
-
   const onItemPress = useCallback(
     (validator: HederaValidator) => {
       navigation.navigate(ScreenName.HederaDelegationSummary, {
@@ -40,13 +35,6 @@ export default function SelectValidator({ navigation, route }: Props) {
       });
     },
     [navigation, route.params],
-  );
-
-  const renderItem = useCallback(
-    (data: { item: HederaValidator }) => (
-      <ValidatorRow account={account} validator={data.item} onPress={onItemPress} />
-    ),
-    [onItemPress, account],
   );
 
   return (
@@ -59,14 +47,15 @@ export default function SelectValidator({ navigation, route }: Props) {
         currency="hedera"
       />
       <SelectValidatorSearchBox searchQuery={searchQuery} setSearchQuery={setSearchQuery} />
-      <View style={styles.header}>
-        <ValidatorHead />
-      </View>
-      <FlatList
-        contentContainerStyle={styles.list}
-        data={validators}
-        keyExtractor={keyExtractor}
-        renderItem={renderItem}
+      <ValidatorsList
+        account={account}
+        searchQuery={searchQuery}
+        onItemPress={onItemPress}
+        header={
+          <View style={styles.header}>
+            <ValidatorHead />
+          </View>
+        }
       />
     </SafeAreaView>
   );
@@ -74,11 +63,11 @@ export default function SelectValidator({ navigation, route }: Props) {
 
 const ValidatorHead = () => (
   <View style={styles.validatorHead}>
-    <Text style={styles.validatorHeadText} color="smoke" numberOfLines={1} fontWeight="semiBold">
+    <Text typography="body2SemiBold" lx={{ color: "muted" }} numberOfLines={1}>
       <Trans i18nKey="delegation.validator" />
     </Text>
     <View style={styles.validatorHeadContainer}>
-      <Text style={styles.validatorHeadText} color="smoke" numberOfLines={1} fontWeight="semiBold">
+      <Text typography="body2SemiBold" lx={{ color: "muted" }} numberOfLines={1}>
         <Trans i18nKey="hedera.delegation.steps.validator.totalStake" />
       </Text>
     </View>
@@ -92,22 +81,10 @@ const styles = StyleSheet.create({
   header: {
     padding: 16,
   },
-  list: {
-    paddingHorizontal: 16,
-  },
-  center: {
-    flex: 1,
-    flexDirection: "column",
-    alignItems: "center",
-    justifyContent: "center",
-  },
   validatorHead: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
-  },
-  validatorHeadText: {
-    fontSize: 14,
   },
   validatorHeadContainer: {
     flexDirection: "row",

--- a/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/Summary.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode, useCallback, useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { formatCurrencyUnit, getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
@@ -7,7 +8,7 @@ import {
   getDefaultValidator,
   isStakingTransaction,
 } from "@ledgerhq/live-common/families/hedera/utils";
-import { useHederaValidators } from "@ledgerhq/live-common/families/hedera/react";
+import { hederaQueries } from "@ledgerhq/live-common/families/hedera/react";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
 import type { HederaValidator, Transaction } from "@ledgerhq/live-common/families/hedera/types";
 import type { AccountBridge, AccountLike } from "@ledgerhq/types-live";
@@ -17,6 +18,7 @@ import invariant from "invariant";
 import { Trans, useTranslation } from "~/context/Locale";
 import { Animated, StyleSheet, View, TextStyle, StyleProp } from "react-native";
 import SafeAreaView from "~/components/SafeAreaView";
+import Skeleton from "~/components/Skeleton";
 import { TrackScreen } from "~/analytics";
 import Button from "~/components/Button";
 import Circle from "~/components/Circle";
@@ -46,7 +48,8 @@ export default function DelegationSummary({ navigation, route }: Readonly<Props>
   invariant(account.type === "Account", "account type must be Account");
 
   const bridge: AccountBridge<Transaction> = useAccountBridge(account);
-  const validators = useHederaValidators(account.currency);
+  const queryValidators = useQuery(hederaQueries.validatorsList(account.currency.id));
+  const validators = queryValidators.data ?? [];
   const defaultValidator = getDefaultValidator(validators);
 
   const { transaction, updateTransaction, status, bridgePending, bridgeError } =
@@ -133,13 +136,15 @@ export default function DelegationSummary({ navigation, route }: Readonly<Props>
           right={
             <Touchable event="DelegationFlowSummaryChangeCircleBtn" onPress={onChangeDelegator}>
               <Circle size={70} style={[styles.validatorCircle, { borderColor: colors.primary }]}>
-                <Animated.View
-                  style={{
-                    transform: [{ rotate }],
-                  }}
-                >
-                  <ValidatorIcon validator={selectedValidator} />
-                </Animated.View>
+                <Skeleton loading={queryValidators.isLoading} style={styles.validatorIconSkeleton}>
+                  <Animated.View
+                    style={{
+                      transform: [{ rotate }],
+                    }}
+                  >
+                    <ValidatorIcon validator={selectedValidator} />
+                  </Animated.View>
+                </Skeleton>
                 <ChangeDelegator />
               </Circle>
             </Touchable>
@@ -150,8 +155,16 @@ export default function DelegationSummary({ navigation, route }: Readonly<Props>
             onChangeValidator={onChangeDelegator}
             validator={selectedValidator}
             account={account}
+            isLoadingValidator={queryValidators.isLoading}
           />
         </View>
+        {queryValidators.isLoadingError && (
+          <View style={styles.fetchError}>
+            <Text color="error.c50" textAlign="center">
+              <TranslatedError error={queryValidators.error} />
+            </Text>
+          </View>
+        )}
         <View style={styles.alert}>
           <Alert
             type="primary"
@@ -187,10 +200,12 @@ function SummaryWords({
   validator,
   account,
   onChangeValidator,
+  isLoadingValidator,
 }: Readonly<{
   validator?: HederaValidator;
   account: AccountLike;
   onChangeValidator: () => void;
+  isLoadingValidator: boolean;
 }>) {
   const { t } = useTranslation();
   const unit = useAccountUnit(account);
@@ -213,14 +228,16 @@ function SummaryWords({
           <Trans i18nKey="hedera.delegation.steps.summary.to" />
         </Words>
         <Touchable onPress={onChangeValidator}>
-          <Selectable
-            name={
-              validator
-                ? t("hedera.delegation.nodeName", { index: validator.id, name: validator.name })
-                : ""
-            }
-            testID="hedera-delegation-summary-validator"
-          />
+          <Skeleton loading={isLoadingValidator} style={styles.validatorNameSkeleton}>
+            <Selectable
+              name={
+                validator
+                  ? t("hedera.delegation.nodeName", { index: validator.id, name: validator.name })
+                  : ""
+              }
+              testID="hedera-delegation-summary-validator"
+            />
+          </Skeleton>
         </Touchable>
       </Line>
     </>
@@ -362,6 +379,19 @@ const styles = StyleSheet.create({
   },
   alert: {
     marginBottom: 16,
+  },
+  fetchError: {
+    marginBottom: 12,
+  },
+  validatorIconSkeleton: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+  },
+  validatorNameSkeleton: {
+    width: 120,
+    height: 40,
+    borderRadius: 4,
   },
   validatorSelection: {
     flexDirection: "row",

--- a/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/__integrations__/delegationFlow.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/__integrations__/delegationFlow.integration.test.tsx
@@ -4,7 +4,7 @@ import BigNumber from "bignumber.js";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import type { SignOperationEvent } from "@ledgerhq/types-live";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
-import { render, screen, waitFor } from "@tests/test-renderer";
+import { renderWithReactQuery as render, screen, waitFor } from "@tests/test-renderer";
 import { NavigatorName, ScreenName } from "~/const";
 import { component } from "../index";
 import { HEDERA_ACCOUNT_1, overrideWithHederaAccount1 } from "../../__mocks__/account.mock";
@@ -14,8 +14,8 @@ jest.mock("LLM/features/NotificationsPrompt", () => ({
   useNotificationsPrompt: () => ({ notifyFlowCompleted: jest.fn() }),
 }));
 
-jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
-  useHederaValidators: jest.fn(() => [
+let validatorsQueryFn = () =>
+  Promise.resolve([
     {
       id: "0",
       name: "Hedera Node 0",
@@ -27,8 +27,17 @@ jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
       activeStakePercentage: new BigNumber(0),
       overstaked: false,
     },
-  ]),
-  useHederaEnrichedDelegation: jest.fn(() => null),
+  ]);
+
+jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
+  hederaQueries: {
+    validatorsList: () => ({
+      queryKey: ["mock-hedera-validators"],
+      queryFn: () => validatorsQueryFn(),
+      retry: false,
+    }),
+  },
+  useHederaEnrichedDelegationV2: jest.fn(() => null),
 }));
 
 jest.mock(
@@ -56,7 +65,7 @@ jest.mock("~/datadog", () => ({
   broadcastLogger: jest.fn(),
 }));
 
-const mockAccountBridge = makeMockAccountBridge(HEDERA_TRANSACTION_MODES.Delegate, {
+let mockAccountBridge = makeMockAccountBridge(HEDERA_TRANSACTION_MODES.Delegate, {
   stakingNodeId: 0,
 });
 
@@ -106,8 +115,23 @@ function renderFlow() {
 }
 describe("Hedera DelegationFlow (integration)", () => {
   beforeEach(() => {
-    mockAccountBridge.createTransaction.mockClear();
-    mockAccountBridge.signOperation.mockClear();
+    mockAccountBridge = makeMockAccountBridge(HEDERA_TRANSACTION_MODES.Delegate, {
+      stakingNodeId: 0,
+    });
+    validatorsQueryFn = () =>
+      Promise.resolve([
+        {
+          id: "0",
+          name: "Hedera Node 0",
+          address: "0.0.3",
+          addressChecksum: null,
+          minStake: new BigNumber(0),
+          maxStake: new BigNumber(250_000_000_000_000_000),
+          activeStake: new BigNumber(0),
+          activeStakePercentage: new BigNumber(0),
+          overstaked: false,
+        },
+      ]);
   });
 
   it("completes the happy path: Summary → SelectDevice → ConnectDevice → ValidationSuccess", async () => {
@@ -149,5 +173,21 @@ describe("Hedera DelegationFlow (integration)", () => {
 
     await waitFor(() => expect(screen.getByText("Retry")).toBeVisible(), { timeout: 15000 });
     expect(screen.queryByTestId("validate-success-screen")).toBeNull();
+  });
+
+  it("blocks Continue and shows the error when the validator list fails to load", async () => {
+    validatorsQueryFn = () => Promise.reject(new Error("network down"));
+    mockAccountBridge = makeMockAccountBridge(
+      HEDERA_TRANSACTION_MODES.Delegate,
+      { stakingNodeId: 0 },
+      { validators: new Error("network down") },
+    );
+
+    renderFlow();
+
+    await waitFor(() => expect(screen.getByText(/network down/i)).toBeVisible(), {
+      timeout: 10000,
+    });
+    expect(screen.getByTestId("disabled-hedera-summary-continue-button")).toBeVisible();
   });
 });

--- a/apps/ledger-live-mobile/src/families/hedera/Delegations/Row.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/Delegations/Row.tsx
@@ -9,6 +9,7 @@ import { Text } from "@ledgerhq/native-ui";
 import { useTheme } from "@react-navigation/native";
 import CounterValue from "~/components/CounterValue";
 import ArrowRight from "~/icons/ArrowRight";
+import Skeleton from "~/components/Skeleton";
 import ValidatorIcon from "../shared/ValidatorIcon";
 
 type Props = {
@@ -28,6 +29,7 @@ export default function DelegationRow({
 }: Readonly<Props>) {
   const { t } = useTranslation();
   const { colors } = useTheme();
+  const isLoadingValidators = enrichedDelegation.loading ?? false;
 
   return (
     <TouchableOpacity
@@ -42,14 +44,16 @@ export default function DelegationRow({
       </View>
       <View style={styles.nameWrapper}>
         <View style={styles.row}>
-          <Text
-            fontWeight="semiBold"
-            numberOfLines={1}
-            ellipsizeMode="middle"
-            style={{ marginRight: 5 }}
-          >
-            {enrichedDelegation.validator.name}
-          </Text>
+          <Skeleton loading={isLoadingValidators} style={styles.nameSkeleton}>
+            <Text
+              fontWeight="semiBold"
+              numberOfLines={1}
+              ellipsizeMode="middle"
+              style={{ marginRight: 5 }}
+            >
+              {enrichedDelegation.validator.name}
+            </Text>
+          </Skeleton>
         </View>
         <View style={styles.row}>
           <Text style={styles.seeMore} color="live">
@@ -102,6 +106,11 @@ const styles = StyleSheet.create({
   nameWrapper: {
     flex: 1,
     marginRight: 8,
+  },
+  nameSkeleton: {
+    width: 100,
+    height: 16,
+    borderRadius: 4,
   },
   rightWrapper: {
     alignItems: "flex-end",

--- a/apps/ledger-live-mobile/src/families/hedera/Delegations/__tests__/index.test.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/Delegations/__tests__/index.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import BigNumber from "bignumber.js";
 import { fireEvent, render, screen } from "@tests/test-renderer";
 import { useStake } from "LLM/hooks/useStake/useStake";
-import { useHederaEnrichedDelegation } from "@ledgerhq/live-common/families/hedera/react";
+import { useHederaEnrichedDelegationV2 } from "@ledgerhq/live-common/families/hedera/react";
 import { NavigatorName, ScreenName } from "~/const";
 import HederaDelegations from "../index";
 import {
@@ -17,7 +17,7 @@ const mockNavigate = jest.fn();
 jest.mock("LLM/hooks/useStake/useStake", () => ({ useStake: jest.fn() }));
 
 jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
-  useHederaEnrichedDelegation: jest.fn(),
+  useHederaEnrichedDelegationV2: jest.fn(),
 }));
 
 jest.mock("@react-navigation/native", () => ({
@@ -32,14 +32,19 @@ jest.mock("~/components/DelegationDrawer", () => {
   const { View, Text, TouchableOpacity } = require("react-native");
   return ({
     isOpen,
+    data,
     actions,
   }: {
     isOpen: boolean;
+    data?: Array<{ label: string; Component: React.ReactNode }>;
     actions?: Array<{ label: string; disabled?: boolean; onPress: () => void }>;
   }) => {
     if (!isOpen) return null;
     return (
       <View testID="delegation-drawer">
+        {data?.map((item, i) => (
+          <View key={i}>{item.Component}</View>
+        ))}
         {actions?.map((action, i) => (
           <TouchableOpacity
             key={i}
@@ -64,7 +69,7 @@ jest.mock("~/families/hedera/shared/DelegationStatusModal", () => ({
 jest.mock("~/families/hedera/shared/ValidatorIcon", () => () => null);
 
 const mockUseStake = jest.mocked(useStake);
-const mockUseHederaEnrichedDelegation = jest.mocked(useHederaEnrichedDelegation);
+const mockUseHederaEnrichedDelegation = jest.mocked(useHederaEnrichedDelegationV2);
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -188,6 +193,53 @@ describe("HederaDelegations", () => {
       expect(screen.getByTestId("drawer-action-1")).toHaveProp("accessibilityState", {
         disabled: true,
       });
+    });
+
+    it("disables every drawer action while the validators query is loading", () => {
+      const account = buildAccount();
+
+      mockUseHederaEnrichedDelegation.mockReturnValue({
+        ...mockEnrichedDelegation,
+        loading: true,
+      } as never);
+
+      render(<HederaDelegations account={account} />, {
+        overrideInitialState: s => ({
+          ...s,
+          accounts: { ...s.accounts, active: [account] },
+        }),
+      });
+
+      // the validator name is behind a skeleton while loading, so open the drawer via "See more"
+      fireEvent.press(screen.getByText("See more"));
+
+      for (const testId of ["drawer-action-0", "drawer-action-1", "drawer-action-2"]) {
+        expect(screen.getByTestId(testId)).toBeDisabled();
+      }
+    });
+
+    it("shows the fetchError status label and keeps every drawer action enabled when the fetch failed", () => {
+      const account = buildAccount();
+
+      mockUseHederaEnrichedDelegation.mockReturnValue({
+        ...mockEnrichedDelegation,
+        error: new Error("network down"),
+      } as never);
+
+      render(<HederaDelegations account={account} />, {
+        overrideInitialState: s => ({
+          ...s,
+          accounts: { ...s.accounts, active: [account] },
+        }),
+      });
+
+      fireEvent.press(screen.getByText("Hedera Node 3"));
+
+      expect(screen.getByText("Unable to load")).toBeVisible();
+
+      for (const testId of ["drawer-action-0", "drawer-action-1", "drawer-action-2"]) {
+        expect(screen.getByTestId(testId)).toBeEnabled();
+      }
     });
 
     it("navigates to HederaRedelegationFlow with correct params when Redelegate is pressed", () => {

--- a/apps/ledger-live-mobile/src/families/hedera/Delegations/index.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/Delegations/index.tsx
@@ -11,7 +11,7 @@ import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { getAddressExplorer, getDefaultExplorerView } from "@ledgerhq/live-common/explorers";
 import type { HederaAccount, HederaDelegation } from "@ledgerhq/live-common/families/hedera/types";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
-import { useHederaEnrichedDelegation } from "@ledgerhq/live-common/families/hedera/react";
+import { useHederaEnrichedDelegationV2 } from "@ledgerhq/live-common/families/hedera/react";
 import type { AccountLike, TokenAccount } from "@ledgerhq/types-live";
 import { Box, Flex, Text } from "@ledgerhq/native-ui";
 import AccountSectionLabel from "~/components/AccountSectionLabel";
@@ -22,6 +22,7 @@ import { NavigatorName, ScreenName } from "~/const";
 import DelegationStatusIcon from "~/families/hedera/Delegations/DelegationStatusIcon";
 import { DelegationStatusModal } from "~/families/hedera/shared/DelegationStatusModal";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
+import Skeleton from "~/components/Skeleton";
 import { useAccountName } from "~/reducers/wallet";
 import { useStake } from "LLM/hooks/useStake/useStake";
 import { rgba } from "../../../colors";
@@ -46,8 +47,9 @@ function Delegations({ account, delegatedPosition }: Readonly<Props>) {
   const { t } = useTranslation();
   const navigation = useNavigation();
   const accountName = useAccountName(account);
-  const enrichedDelegation = useHederaEnrichedDelegation(account, delegatedPosition);
+  const enrichedDelegation = useHederaEnrichedDelegationV2(account, delegatedPosition);
   const unit = useAccountUnit(account);
+  const isLoadingValidators = enrichedDelegation.loading ?? false;
 
   const currency = getAccountCurrency(account);
   const formattedClaimableRewards = formatCurrencyUnit(unit, enrichedDelegation.pendingReward, {
@@ -88,15 +90,17 @@ function Delegations({ account, delegatedPosition }: Readonly<Props>) {
       {
         label: t("delegation.validator"),
         Component: (
-          <Text
-            numberOfLines={1}
-            fontWeight="semiBold"
-            ellipsizeMode="middle"
-            style={[styles.valueText]}
-            color="live"
-          >
-            {enrichedDelegation.validator.name}
-          </Text>
+          <Skeleton loading={isLoadingValidators} style={styles.statusSkeleton}>
+            <Text
+              numberOfLines={1}
+              fontWeight="semiBold"
+              ellipsizeMode="middle"
+              style={[styles.valueText]}
+              color="live"
+            >
+              {enrichedDelegation.validator.name}
+            </Text>
+          </Skeleton>
         ),
       },
       {
@@ -133,20 +137,24 @@ function Delegations({ account, delegatedPosition }: Readonly<Props>) {
         label: t("hedera.delegatedPositions.details.status.title"),
         Component: (
           <Touchable event="DelegationOpenStatusModal" onPress={openStatusModal}>
-            <Flex flexDirection="row" alignItems="center" columnGap={4}>
-              <DelegationStatusIcon status={enrichedDelegation.status} color={colors.live} />
-              <Text
-                numberOfLines={1}
-                fontWeight="semiBold"
-                ellipsizeMode="middle"
-                style={styles.valueText}
-                color="live"
-              >
-                <Trans
-                  i18nKey={`hedera.delegatedPositions.details.status.${enrichedDelegation.status}`}
-                />
-              </Text>
-            </Flex>
+            <Skeleton loading={isLoadingValidators} style={styles.statusSkeleton}>
+              <Flex flexDirection="row" alignItems="center" columnGap={4}>
+                <DelegationStatusIcon status={enrichedDelegation.status} color={colors.live} />
+                <Text
+                  numberOfLines={1}
+                  fontWeight="semiBold"
+                  ellipsizeMode="middle"
+                  style={styles.valueText}
+                  color="live"
+                >
+                  <Trans
+                    i18nKey={`hedera.delegatedPositions.details.status.${
+                      enrichedDelegation.error ? "fetchError" : enrichedDelegation.status
+                    }`}
+                  />
+                </Text>
+              </Flex>
+            </Skeleton>
           </Touchable>
         ),
       },
@@ -167,6 +175,7 @@ function Delegations({ account, delegatedPosition }: Readonly<Props>) {
   }, [
     openStatusModal,
     enrichedDelegation,
+    isLoadingValidators,
     accountName,
     formattedClaimableRewards,
     colors.live,
@@ -182,9 +191,10 @@ function Delegations({ account, delegatedPosition }: Readonly<Props>) {
     ] satisfies HEDERA_TRANSACTION_MODES[];
 
     const mapStakeActionToDisabled = {
-      [HEDERA_TRANSACTION_MODES.Redelegate]: false,
-      [HEDERA_TRANSACTION_MODES.ClaimRewards]: enrichedDelegation.pendingReward.isZero(),
-      [HEDERA_TRANSACTION_MODES.Undelegate]: false,
+      [HEDERA_TRANSACTION_MODES.Redelegate]: isLoadingValidators,
+      [HEDERA_TRANSACTION_MODES.ClaimRewards]:
+        isLoadingValidators || enrichedDelegation.pendingReward.isZero(),
+      [HEDERA_TRANSACTION_MODES.Undelegate]: isLoadingValidators,
     } as const satisfies Record<(typeof allStakeActions)[number], boolean>;
 
     const mapStakeActionToColor = {
@@ -247,7 +257,16 @@ function Delegations({ account, delegatedPosition }: Readonly<Props>) {
 
       return drawerAction;
     });
-  }, [account.id, colors.fog, colors.alert, colors.yellow, navigation, enrichedDelegation, t]);
+  }, [
+    account.id,
+    colors.fog,
+    colors.alert,
+    colors.yellow,
+    navigation,
+    enrichedDelegation,
+    isLoadingValidators,
+    t,
+  ]);
 
   return (
     <View style={styles.root}>
@@ -264,6 +283,7 @@ function Delegations({ account, delegatedPosition }: Readonly<Props>) {
       />
       <DelegationStatusModal
         status={enrichedDelegation.status}
+        error={!!enrichedDelegation.error}
         isOpen={isStatusModalOpen}
         onClose={onCloseStatusModal}
       />
@@ -327,6 +347,11 @@ const styles = StyleSheet.create({
     flexDirection: "column",
   },
   delegationsWrapper: {
+    borderRadius: 4,
+  },
+  statusSkeleton: {
+    width: 90,
+    height: 16,
     borderRadius: 4,
   },
   valueText: {

--- a/apps/ledger-live-mobile/src/families/hedera/RedelegationFlow/SelectValidator.test.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/RedelegationFlow/SelectValidator.test.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { Spinner } from "@ledgerhq/lumen-ui-rnative";
+import { renderWithReactQuery as render, screen, waitFor } from "@tests/test-renderer";
+import { ScreenName } from "~/const";
+import type { State } from "~/reducers/types";
+import RedelegationSelectValidator from "./SelectValidator";
+import { HEDERA_ACCOUNT_1 } from "../__mocks__/account.mock";
+
+let validatorsQueryFn: () => Promise<unknown>;
+
+jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
+  hederaQueries: {
+    validatorsList: () => ({
+      queryKey: ["mock-hedera-validators"],
+      queryFn: () => validatorsQueryFn(),
+      retry: false,
+    }),
+  },
+}));
+
+const mockNavigate = jest.fn();
+const mockNavigation = { navigate: mockNavigate } as never;
+const mockRoute = {
+  key: "test",
+  name: ScreenName.HederaRedelegationSelectValidator,
+  params: { accountId: HEDERA_ACCOUNT_1.id },
+} as never;
+
+const validator = {
+  id: "0",
+  name: "Hedera Node 0",
+  address: "0.0.3",
+  addressChecksum: null,
+  minStake: new BigNumber(0),
+  maxStake: new BigNumber(250_000_000_000_000_000),
+  activeStake: new BigNumber(0),
+  activeStakePercentage: new BigNumber(0),
+  overstaked: false,
+};
+
+const overrideInitialState = (state: State): State => ({
+  ...state,
+  accounts: { ...state.accounts, active: [HEDERA_ACCOUNT_1] },
+});
+
+describe("RedelegationFlow SelectValidator", () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it("shows a spinner and no validator row while the validators query is loading", () => {
+    validatorsQueryFn = () => new Promise(() => {});
+
+    render(<RedelegationSelectValidator navigation={mockNavigation} route={mockRoute} />, {
+      overrideInitialState,
+    });
+
+    expect(screen.UNSAFE_getByType(Spinner)).toBeTruthy();
+    expect(screen.queryByText("Hedera Node 0")).toBeNull();
+  });
+
+  it("shows the fetch error text and keeps the list mounted", async () => {
+    validatorsQueryFn = () => Promise.reject(new Error("network down"));
+
+    render(<RedelegationSelectValidator navigation={mockNavigation} route={mockRoute} />, {
+      overrideInitialState,
+    });
+
+    await waitFor(() => expect(screen.getByText(/network down/i)).toBeVisible());
+  });
+
+  it("does not show an error and navigates to Amount when a validator is selected", async () => {
+    validatorsQueryFn = () => Promise.resolve([validator]);
+
+    const { user } = render(
+      <RedelegationSelectValidator navigation={mockNavigation} route={mockRoute} />,
+      { overrideInitialState },
+    );
+
+    await waitFor(() => expect(screen.getByText("Hedera Node 0")).toBeVisible());
+    expect(screen.queryByText(/network down/i)).toBeNull();
+
+    await user.press(screen.getByText("Hedera Node 0"));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      ScreenName.HederaRedelegationAmount,
+      expect.objectContaining({ selectedValidator: validator }),
+    );
+  });
+});

--- a/apps/ledger-live-mobile/src/families/hedera/RedelegationFlow/SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/RedelegationFlow/SelectValidator.tsx
@@ -1,24 +1,21 @@
 import React, { useCallback, useState } from "react";
 import SafeAreaView from "~/components/SafeAreaView";
-import { FlatList, StyleSheet } from "react-native";
+import { StyleSheet } from "react-native";
 import invariant from "invariant";
 import { useTheme } from "@react-navigation/native";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
-import { useHederaValidators } from "@ledgerhq/live-common/families/hedera/react";
 import type { HederaValidator } from "@ledgerhq/live-common/families/hedera/types";
 import { TrackScreen } from "~/analytics";
 import type { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { ScreenName } from "~/const";
 import SelectValidatorSearchBox from "~/families/tron/VoteFlow/01-SelectValidator/SearchBox";
 import type { HederaRedelegationFlowParamList } from "./types";
-import ValidatorRow from "../shared/ValidatorRow";
+import ValidatorsList from "../shared/ValidatorsList";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
 type Props = BaseComposite<
   StackNavigatorProps<HederaRedelegationFlowParamList, ScreenName.HederaRedelegationSelectValidator>
 >;
-
-const keyExtractor = (v: HederaValidator) => v.id;
 
 export default function RedelegationSelectValidator({ navigation, route }: Props) {
   const { colors } = useTheme();
@@ -28,8 +25,6 @@ export default function RedelegationSelectValidator({ navigation, route }: Props
   invariant(account, "account must be defined");
   invariant(account.type === "Account", "account must be of type Account");
 
-  const validators = useHederaValidators(account.currency, searchQuery);
-
   const onItemPress = useCallback(
     (validator: HederaValidator) => {
       navigation.navigate(ScreenName.HederaRedelegationAmount, {
@@ -38,13 +33,6 @@ export default function RedelegationSelectValidator({ navigation, route }: Props
       });
     },
     [navigation, route.params],
-  );
-
-  const renderItem = useCallback(
-    (data: { item: HederaValidator }) => (
-      <ValidatorRow account={account} validator={data.item} onPress={onItemPress} />
-    ),
-    [onItemPress, account],
   );
 
   return (
@@ -57,12 +45,7 @@ export default function RedelegationSelectValidator({ navigation, route }: Props
         currency="hedera"
       />
       <SelectValidatorSearchBox searchQuery={searchQuery} setSearchQuery={setSearchQuery} />
-      <FlatList
-        contentContainerStyle={styles.list}
-        data={validators}
-        keyExtractor={keyExtractor}
-        renderItem={renderItem}
-      />
+      <ValidatorsList account={account} searchQuery={searchQuery} onItemPress={onItemPress} />
     </SafeAreaView>
   );
 }
@@ -70,8 +53,5 @@ export default function RedelegationSelectValidator({ navigation, route }: Props
 const styles = StyleSheet.create({
   root: {
     flex: 1,
-  },
-  list: {
-    paddingHorizontal: 16,
   },
 });

--- a/apps/ledger-live-mobile/src/families/hedera/UndelegationFlow/__integrations__/undelegationFlow.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/UndelegationFlow/__integrations__/undelegationFlow.integration.test.tsx
@@ -63,7 +63,7 @@ function UndelegationFlowHarness() {
   );
 }
 
-function renderFlow() {
+function renderFlow(enrichedDelegation = mockEnrichedDelegation) {
   return render(<UndelegationFlowHarness />, {
     navigationInitialState: {
       index: 0,
@@ -77,7 +77,7 @@ function renderFlow() {
                 name: ScreenName.HederaUndelegationAmount,
                 params: {
                   accountId: HEDERA_ACCOUNT_1.id,
-                  enrichedDelegation: mockEnrichedDelegation,
+                  enrichedDelegation,
                 },
               },
             ],
@@ -133,5 +133,18 @@ describe("Hedera UndelegationFlow (integration)", () => {
 
     await waitFor(() => expect(screen.getByText("Retry")).toBeVisible(), { timeout: 15000 });
     expect(screen.queryByTestId("validate-success-screen")).toBeNull();
+  });
+
+  it("renders without crashing when the enriched delegation has a fetch error and blank validator name", async () => {
+    renderFlow({
+      ...mockEnrichedDelegation,
+      error: new Error("network down"),
+      validator: { ...mockEnrichedDelegation.validator, name: "" },
+    });
+
+    await waitFor(
+      () => expect(screen.getByTestId("enabled-hedera-amount-continue-button")).toBeVisible(),
+      { timeout: 10000 },
+    );
   });
 });

--- a/apps/ledger-live-mobile/src/families/hedera/__mocks__/bridge.mock.ts
+++ b/apps/ledger-live-mobile/src/families/hedera/__mocks__/bridge.mock.ts
@@ -26,6 +26,7 @@ export const mockSignedOperation = {
 export function makeMockAccountBridge(
   mode: Transaction["mode"],
   properties?: Record<string, unknown>,
+  errors: Record<string, Error> = {},
 ) {
   return {
     createTransaction: jest.fn((_account: AccountLike) => ({
@@ -39,7 +40,7 @@ export function makeMockAccountBridge(
     updateTransaction: jest.fn((tx: object, patch: object) => ({ ...tx, ...patch })),
     prepareTransaction: async (_account: AccountLike, tx: unknown) => tx,
     getTransactionStatus: async () => ({
-      errors: {},
+      errors,
       warnings: {},
       estimatedFees: new BigNumber(1000),
       amount: new BigNumber(0),

--- a/apps/ledger-live-mobile/src/families/hedera/__mocks__/delegation.mock.ts
+++ b/apps/ledger-live-mobile/src/families/hedera/__mocks__/delegation.mock.ts
@@ -12,6 +12,8 @@ export const mockEnrichedDelegation: HederaEnrichedDelegation = {
   nodeId: 3,
   delegated: new BigNumber(50_000_000),
   pendingReward: new BigNumber(10_000),
+  loading: false,
+  error: null,
   status: HEDERA_DELEGATION_STATUS.Active,
   validator: {
     id: "3",

--- a/apps/ledger-live-mobile/src/families/hedera/shared/DelegationStatusModal.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/shared/DelegationStatusModal.tsx
@@ -5,19 +5,21 @@ import QueuedDrawer from "~/components/QueuedDrawer";
 
 interface Props {
   status: HEDERA_DELEGATION_STATUS;
+  error?: boolean;
   isOpen?: boolean;
   onClose(): void;
 }
 
-export function DelegationStatusModal({ status, isOpen, onClose }: Readonly<Props>) {
+export function DelegationStatusModal({ status, error, isOpen, onClose }: Readonly<Props>) {
   const { t } = useTranslation();
+  const statusKey = error ? "fetchError" : status;
 
   return (
     <QueuedDrawer
       isRequestingToBeOpened={!!isOpen}
       onClose={onClose}
-      title={t(`hedera.delegatedPositions.details.status.${status}`)}
-      description={t(`hedera.delegatedPositions.details.status.${status}Tooltip`)}
+      title={t(`hedera.delegatedPositions.details.status.${statusKey}`)}
+      description={t(`hedera.delegatedPositions.details.status.${statusKey}Tooltip`)}
     />
   );
 }

--- a/apps/ledger-live-mobile/src/families/hedera/shared/ValidatorsFetchError.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/shared/ValidatorsFetchError.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import { Text } from "@ledgerhq/lumen-ui-rnative";
+import TranslatedError from "~/components/TranslatedError";
+
+type Props = {
+  error: Error | null | undefined;
+};
+
+export default function ValidatorsFetchError({ error }: Readonly<Props>) {
+  return (
+    <View style={styles.container}>
+      <Text typography="body2" lx={{ color: "error", textAlign: "center" }}>
+        <TranslatedError error={error} />
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 16,
+    paddingVertical: 16,
+  },
+});

--- a/apps/ledger-live-mobile/src/families/hedera/shared/ValidatorsList.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/shared/ValidatorsList.tsx
@@ -1,0 +1,73 @@
+import React, { useCallback } from "react";
+import { FlatList, StyleSheet, View } from "react-native";
+import { useQuery } from "@tanstack/react-query";
+import { Spinner } from "@ledgerhq/lumen-ui-rnative";
+import { hederaQueries } from "@ledgerhq/live-common/families/hedera/react";
+import { filterValidatorBySearchTerm } from "@ledgerhq/live-common/families/hedera/utils";
+import type { HederaValidator } from "@ledgerhq/live-common/families/hedera/types";
+import type { Account } from "@ledgerhq/types-live";
+import ValidatorRow from "./ValidatorRow";
+import ValidatorsFetchError from "./ValidatorsFetchError";
+
+type Props = {
+  account: Account;
+  searchQuery: string;
+  onItemPress: (validator: HederaValidator) => void;
+  header?: React.ReactNode;
+};
+
+const keyExtractor = (v: HederaValidator) => v.id;
+
+export default function ValidatorsList({
+  account,
+  searchQuery,
+  onItemPress,
+  header,
+}: Readonly<Props>) {
+  const queryValidators = useQuery({
+    ...hederaQueries.validatorsList(account.currency.id),
+    select: data =>
+      searchQuery ? data.filter(v => filterValidatorBySearchTerm(v, searchQuery)) : data,
+  });
+  const validators = queryValidators.data ?? [];
+
+  const renderItem = useCallback(
+    (data: { item: HederaValidator }) => (
+      <ValidatorRow account={account} validator={data.item} onPress={onItemPress} />
+    ),
+    [onItemPress, account],
+  );
+
+  if (queryValidators.isLoading) {
+    return (
+      <View style={styles.center}>
+        <Spinner size={32} />
+      </View>
+    );
+  }
+
+  return (
+    <>
+      {header}
+      {queryValidators.isLoadingError && <ValidatorsFetchError error={queryValidators.error} />}
+      <FlatList
+        contentContainerStyle={styles.list}
+        data={validators}
+        keyExtractor={keyExtractor}
+        renderItem={renderItem}
+      />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  list: {
+    paddingHorizontal: 16,
+  },
+  center: {
+    flex: 1,
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});

--- a/apps/ledger-live-mobile/src/families/hedera/shared/__tests__/DelegationStatusModal.test.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/shared/__tests__/DelegationStatusModal.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { HEDERA_DELEGATION_STATUS } from "@ledgerhq/live-common/families/hedera/constants";
+import { DelegationStatusModal } from "../DelegationStatusModal";
+
+describe("DelegationStatusModal", () => {
+  it("shows the status title and tooltip when there is no fetch error", () => {
+    render(
+      <DelegationStatusModal
+        status={HEDERA_DELEGATION_STATUS.Active}
+        error={false}
+        isOpen
+        onClose={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Active")).toBeVisible();
+    expect(screen.getByText("Delegated amount generates rewards")).toBeVisible();
+  });
+
+  it("shows the fetch error title and tooltip when error is set", () => {
+    render(
+      <DelegationStatusModal
+        status={HEDERA_DELEGATION_STATUS.Active}
+        error
+        isOpen
+        onClose={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Unable to load")).toBeVisible();
+    expect(screen.getByText("Couldn't load validator data. Please try again.")).toBeVisible();
+  });
+});

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8694,7 +8694,9 @@
           "inactive": "Inactive",
           "inactiveTooltip": "Validator not found",
           "overstaked": "Overstaked",
-          "overstakedTooltip": "This node is overstaked, APY is lower than optimal"
+          "overstakedTooltip": "This node is overstaked, APY is lower than optimal",
+          "fetchError": "Unable to load",
+          "fetchErrorTooltip": "Couldn't load validator data. Please try again."
         },
         "rewards": "Rewards",
         "actions": {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR migrates the mobile Hedera staking screens off the legacy preload-backed validator hooks and onto the new react-query based validators query, mirroring the equivalent desktop migration from the previous part of this refactor. The delegation, redelegation, undelegation and summary screens now read validators through `hederaQueries.validatorsList` instead of `useHederaValidators`/`useHederaEnrichedDelegation`, and the shared validator list is pulled into a new component so both the delegation and redelegation flows share the same fetching, filtering and rendering logic. Because the query can now be loading or in an error state (unlike the old synchronous preload cache), the UI adds skeleton placeholders and inline fetch-error messaging, and disables stake actions while validators are still loading.

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

Loading and error handling on account details screen
| <img width="1206" height="2622" alt="details-loading-1" src="https://github.com/user-attachments/assets/c1154b64-ed20-4309-8378-7afb0f4242ae" /> | <img width="1206" height="2622" alt="details-loading-2" src="https://github.com/user-attachments/assets/c76bcfbd-f41d-4e5a-b5d2-e9b291d78786" /> | <img width="1206" height="2622" alt="details-error-1" src="https://github.com/user-attachments/assets/de0640e2-617d-4cf6-8904-6b86837a24a4" /> | <img width="1206" height="2622" alt="details-error-2" src="https://github.com/user-attachments/assets/8bba1143-c368-4fba-8223-a5e97c32cce6" /> |
|---|--|--|--|

Loading and error handling in delegate flow
| <img width="1206" height="2622" alt="delegate-loading-1" src="https://github.com/user-attachments/assets/63783702-e4a4-4227-a818-3ad4b5b8b242" /> | <img width="1206" height="2622" alt="delegate-loading-2" src="https://github.com/user-attachments/assets/eb439fb4-872a-4e03-8828-4e8dc4c6c965" /> | <img width="1206" height="2622" alt="delegate-error-1" src="https://github.com/user-attachments/assets/01b14b70-9363-4cdd-8679-b3fc8ceb21f5" /> | <img width="1206" height="2622" alt="delegate-error-2" src="https://github.com/user-attachments/assets/d6b4a931-c91a-43fb-8b4c-8aef87c7a96c" /> |
|---|--|--|--|

Loading and error handling in redelegate flow
| <img width="1206" height="2622" alt="redelegate-loading" src="https://github.com/user-attachments/assets/914efeeb-5b02-4ac8-9bdd-bfd6c0d7d489" /> | <img width="1206" height="2622" alt="redelegate-error" src="https://github.com/user-attachments/assets/3717aa5a-32c0-4cfd-9e68-3b0afb3eb3c8" /> |
|---|--|

Error handling in undelegate flow
| <img width="1206" height="2622" alt="undelegate-error" src="https://github.com/user-attachments/assets/9a924244-d20c-41d7-a9ee-cf40ffbbb39e" /> |
|---|

Error handling in claim rewards flow
| <img width="1206" height="2622" alt="claim-rewards-error-1" src="https://github.com/user-attachments/assets/124e47f0-a711-4a19-8cf7-703ee3ae1ae8" /> | <img width="1206" height="2622" alt="claim-rewards-error-2" src="https://github.com/user-attachments/assets/51142969-e4bf-4225-9ff9-d8139d5d768b" /> |
|---|--|

### 🔗 Context

- https://ledgerhq.atlassian.net/browse/LIVE-36153
