### PR TITLE
[LWM] fix(accounts): keep account.request on inline add (LIVE-36323)

### DIFF
--- a/.changeset/inline-add-account-success-before-cancel.md
+++ b/.changeset/inline-add-account-success-before-cancel.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix Earn inline add-account: resolve `account.request` before popping the stack, so Wallet API success is not ignored after a premature cancel.

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/__tests__/ScanDeviceAccountsCallbacks.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/__tests__/ScanDeviceAccountsCallbacks.test.ts
@@ -154,9 +154,11 @@ describe("useScanDeviceAccountsViewModel callbacks", () => {
     expect(track).toHaveBeenCalledWith("accounts_added", expect.anything());
   });
 
-  it("closes the inline flow and calls onSuccess when importing inline", async () => {
-    const onSuccess = jest.fn();
-    const onCloseNavigation = jest.fn();
+  it("resolves inline import with onSuccess before popping and does not cancel", async () => {
+    const callOrder: string[] = [];
+    const onSuccess = jest.fn(() => callOrder.push("success"));
+    const onCloseNavigation = jest.fn(() => callOrder.push("cancel"));
+    pop.mockImplementation(() => callOrder.push("pop"));
     setRouteParams("ethereum", "device-1", { inline: true, onSuccess, onCloseNavigation });
     setScanObservable(of(makeDiscoveredEvent(createAccount())));
 
@@ -166,12 +168,14 @@ describe("useScanDeviceAccountsViewModel callbacks", () => {
 
     act(() => result.current.importAccounts());
 
-    expect(onCloseNavigation).toHaveBeenCalled();
-    expect(pop).toHaveBeenCalled();
+    expect(onCloseNavigation).not.toHaveBeenCalled();
     expect(onSuccess).toHaveBeenCalledWith(
       expect.objectContaining({ selected: expect.any(Array) }),
     );
+    expect(pop).toHaveBeenCalled();
+    expect(callOrder).toEqual(["success", "pop"]);
     expect(replace).not.toHaveBeenCalledWith(ScreenName.AddAccountsSuccess, expect.anything());
+    pop.mockReset();
   });
 
   it("pops the parent navigator on modal hide after a cancel (non-inline)", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
@@ -190,14 +190,17 @@ export default function useScanDeviceAccountsViewModel({
     [selectedIds],
   );
 
-  // Close inline flow: drawer + navigation
+  const popInlineScreens = useCallback(() => {
+    const parent = navigation.getParent<StackNavigatorNavigation<BaseNavigatorStackParamList>>();
+    parent?.pop(navigationDepth ?? 2);
+  }, [navigation, navigationDepth]);
+
   const closeInlineFlow = useCallback(() => {
     if (onCloseNavigation) {
       onCloseNavigation();
     }
-    const parent = navigation.getParent<StackNavigatorNavigation<BaseNavigatorStackParamList>>();
-    parent?.pop(navigationDepth ?? 2);
-  }, [navigation, onCloseNavigation, navigationDepth]);
+    popInlineScreens();
+  }, [onCloseNavigation, popInlineScreens]);
 
   const importAccounts = useCallback(() => {
     const accountsToAdd = scannedAccounts.filter(a => selectedIds.includes(a.id));
@@ -261,14 +264,13 @@ export default function useScanDeviceAccountsViewModel({
     const { onSuccess } = route.params;
 
     if (inline) {
-      closeInlineFlow();
-
       if (onSuccess) {
         onSuccess({
           scannedAccounts,
           selected: accountsToAdd,
         });
       }
+      popInlineScreens();
     } else
       navigation.replace(ScreenName.AddAccountsSuccess, {
         ...route.params,
@@ -299,7 +301,7 @@ export default function useScanDeviceAccountsViewModel({
     scannedAccounts,
     selectedIds,
     dispatch,
-    closeInlineFlow,
+    popInlineScreens,
     analyticsMetadata?.AccountsFound?.onContinue,
     analyticsMetadata?.AccountsFound?.onAccountsAdded,
   ]);


### PR DESCRIPTION
## Summary
- After a successful inline add-account, `ScanDeviceAccounts` called `onCloseNavigation` (Wallet API cancel) before `onSuccess`. `account.request` was marked done, so Earn never received the new ETH account and stayed on `/homescreen` instead of `/deposit`.
- Success now resolves `onSuccess` first, then pops the stack. Cancel still fires only when the user abandons the flow.
- Regression covered in `ScanDeviceAccountsCallbacks` and verified locally with `pnpm test:android earnInlineAddAccount --retries 0`.

## Test plan
- [x] Detox: `e2e/mobile/specs/earn/earnInlineAddAccount.spec.ts` (Android release, nanoX)
- [x] Jest: `ScanDeviceAccountsCallbacks`
- [ ] Confirm Earn ice-cold start → Add ETH account → deposebview (`/deposit`)
- [ ] Confirm abandoning device selection still cancels `account.request` (Buy/Earn drawer close)