### PR TITLE
[LWD] feat(pay): show desktop Pay contacts table (LIVE-35380)

### DIFF
--- a/.changeset/pay-contacts-desktop-list.md
+++ b/.changeset/pay-contacts-desktop-list.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-pay-contact": minor
+"ledger-live-desktop": minor
+---
+
+Display the full list of saved contacts on the desktop Pay tab, ordered by last sent-to then last added

--- a/apps/ledger-live-desktop/src/mvvm/components/CryptoIconStack/__tests__/CryptoIconStack.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/CryptoIconStack/__tests__/CryptoIconStack.test.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { CryptoIcon } from "@ledgerhq/crypto-icons";
+import { render, screen } from "tests/testSetup";
+import { CryptoIconStack } from "../index";
+
+jest.mock("@ledgerhq/crypto-icons", () => ({
+  CryptoIcon: jest.fn(({ ledgerId, ticker }) => (
+    <span data-testid={`crypto-icon-${ledgerId}`}>{ticker}</span>
+  )),
+}));
+
+const mockedCryptoIcon = jest.mocked(CryptoIcon);
+
+const ethereum = { ledgerId: "ethereum", ticker: "ETH" };
+const bitcoin = { ledgerId: "bitcoin", ticker: "BTC" };
+
+describe("CryptoIconStack", () => {
+  beforeEach(() => {
+    mockedCryptoIcon.mockClear();
+  });
+
+  it("should render nothing when there are no items", () => {
+    const { container } = render(<CryptoIconStack size={24} items={[]} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("should render a CryptoIcon for each item", () => {
+    render(
+      <CryptoIconStack
+        size={24}
+        items={[ethereum, bitcoin]}
+        testID="crypto-icon-stack"
+        overflowTestID="crypto-icon-stack-overflow"
+      />,
+    );
+
+    expect(screen.getByTestId("crypto-icon-ethereum")).toBeVisible();
+    expect(screen.getByTestId("crypto-icon-bitcoin")).toBeVisible();
+    expect(mockedCryptoIcon).toHaveBeenCalledWith(
+      expect.objectContaining({ ledgerId: "ethereum", ticker: "ETH", size: 24 }),
+      undefined,
+    );
+  });
+
+  it("should show a tooltip with all tickers on hover", async () => {
+    const { user } = render(
+      <CryptoIconStack size={24} items={[ethereum, bitcoin]} testID="crypto-icon-stack" />,
+    );
+
+    await user.hover(screen.getByTestId("crypto-icon-stack"));
+
+    expect(await screen.findByRole("tooltip", { name: "ETH, BTC" })).toBeVisible();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/CryptoIconStack/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/CryptoIconStack/index.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { CryptoIcon } from "@ledgerhq/crypto-icons";
+import type { CryptoIconSize } from "LLD/components/SquaredCryptoIcon";
+import { IconStack, type IconStackProps } from "LLD/components/IconStack";
+
+export type CryptoIconStackItem = Readonly<{
+  ledgerId: string;
+  ticker: string;
+}>;
+
+export type CryptoIconStackProps = Omit<
+  IconStackProps<CryptoIconStackItem>,
+  "renderItem" | "getItemKey" | "getTooltipContent" | "size"
+> &
+  Readonly<{
+    size: CryptoIconSize;
+    getTooltipContent?: IconStackProps<CryptoIconStackItem>["getTooltipContent"];
+  }>;
+
+function formatTickers(items: readonly CryptoIconStackItem[]) {
+  return items.map(item => item.ticker).join(", ");
+}
+
+export function CryptoIconStack({
+  items,
+  size,
+  borderRadius = "50%",
+  getTooltipContent = formatTickers,
+  ...iconStackProps
+}: CryptoIconStackProps) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <IconStack
+      {...iconStackProps}
+      items={items}
+      size={size}
+      borderRadius={borderRadius}
+      getItemKey={item => item.ledgerId}
+      renderItem={item => <CryptoIcon ledgerId={item.ledgerId} ticker={item.ticker} size={size} />}
+      getTooltipContent={getTooltipContent}
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AccountAssetsCellView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AccountAssetsCellView.tsx
@@ -1,35 +1,22 @@
 import React from "react";
-import { CryptoIcon } from "@ledgerhq/crypto-icons";
 import { TableCellItem, TableCellContent, TableCellContentTitle } from "@ledgerhq/lumen-ui-react";
 import type { CryptoIconSize } from "LLD/components/SquaredCryptoIcon";
-import { IconStack } from "LLD/components/IconStack";
-import type { AccountAssetCurrency } from "LLD/features/CryptoAddresses/utils/getAccountAssetsCurrencies";
+import { CryptoIconStack, type CryptoIconStackItem } from "LLD/components/CryptoIconStack";
 
 type AccountAssetsCellViewProps = {
   readonly iconSize: CryptoIconSize;
-  readonly items: readonly AccountAssetCurrency[];
-  readonly tooltipContent: string;
+  readonly items: readonly CryptoIconStackItem[];
 };
 
-export function AccountAssetsCellView({
-  iconSize,
-  items,
-  tooltipContent,
-}: AccountAssetsCellViewProps) {
+export function AccountAssetsCellView({ iconSize, items }: AccountAssetsCellViewProps) {
   return (
     <TableCellItem align="end">
       <TableCellContent>
         <TableCellContentTitle>
-          <IconStack
+          <CryptoIconStack
             size={iconSize}
-            borderRadius="50%"
-            testID="account-assets-cell"
             items={items}
-            getItemKey={currency => currency.id}
-            renderItem={currency => (
-              <CryptoIcon ledgerId={currency.id} ticker={currency.ticker} size={iconSize} />
-            )}
-            getTooltipContent={() => tooltipContent}
+            testID="account-assets-cell"
             overflowTestID="account-assets-overflow"
           />
         </TableCellContentTitle>

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/useAccountAssetsCellViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/useAccountAssetsCellViewModel.ts
@@ -1,22 +1,20 @@
 import { useMemo } from "react";
 import type { CryptoIconSize } from "LLD/components/SquaredCryptoIcon";
+import type { CryptoIconStackItem } from "LLD/components/CryptoIconStack";
 import type { AccountAssetCurrency } from "LLD/features/CryptoAddresses/utils/getAccountAssetsCurrencies";
 import { getValidCryptoIconSize } from "~/renderer/utils/cryptoIconSize";
 
 const ICON_SIZE: CryptoIconSize = getValidCryptoIconSize(24);
 
 export function useAccountAssetsCellViewModel(currencies: readonly AccountAssetCurrency[]) {
-  const isEmpty = currencies.length === 0;
-
-  const tooltipContent = useMemo(
-    () => currencies.map(currency => currency.ticker).join(", "),
+  const items = useMemo<readonly CryptoIconStackItem[]>(
+    () => currencies.map(currency => ({ ledgerId: currency.id, ticker: currency.ticker })),
     [currencies],
   );
 
   return {
-    isEmpty,
+    isEmpty: items.length === 0,
     iconSize: ICON_SIZE,
-    items: currencies,
-    tooltipContent,
+    items,
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/components/PayContactAddresses.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/components/PayContactAddresses.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import type { Contact } from "@domain/entity-contact";
+import { CryptoIconStack, type CryptoIconStackItem } from "LLD/components/CryptoIconStack";
+
+const ICON_SIZE = 24;
+
+function uniqueAddressCurrencies(addresses: Contact["addresses"]): CryptoIconStackItem[] {
+  const byLedgerId = new Map<string, CryptoIconStackItem>();
+
+  for (const { currencyId, label } of addresses) {
+    const currency = findCryptoCurrencyById(currencyId);
+    const ledgerId = currency?.id ?? currencyId;
+    if (!byLedgerId.has(ledgerId)) {
+      byLedgerId.set(ledgerId, { ledgerId, ticker: currency?.ticker ?? label });
+    }
+  }
+
+  return [...byLedgerId.values()];
+}
+
+export function PayContactAddresses({ addresses }: { addresses: Contact["addresses"] }) {
+  return (
+    <CryptoIconStack
+      size={ICON_SIZE}
+      items={uniqueAddressCurrencies(addresses)}
+      testID="pay-contacts-address-icons"
+      overflowTestID="pay-contacts-address-overflow"
+    />
+  );
+}
+
+export function renderPayContactAddresses(addresses: Contact["addresses"]) {
+  return <PayContactAddresses addresses={addresses} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/components/__tests__/PayContactAddresses.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/components/__tests__/PayContactAddresses.test.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { mockContactAddress } from "@domain/entity-contact/schema.mock";
+import { PayContactAddresses } from "../PayContactAddresses";
+
+describe("PayContactAddresses", () => {
+  it("should render nothing when there are no addresses", () => {
+    const { container } = render(<PayContactAddresses addresses={[]} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("should show one icon per unique currency", () => {
+    render(
+      <PayContactAddresses
+        addresses={[
+          mockContactAddress({ id: "address-eth-1", currencyId: "ethereum", label: "Ethereum" }),
+          mockContactAddress({ id: "address-eth-2", currencyId: "ethereum", label: "Ethereum" }),
+          mockContactAddress({ id: "address-btc", currencyId: "bitcoin", label: "Bitcoin" }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId("pay-contacts-address-icons")).toBeVisible();
+    expect(screen.getByLabelText("ETH, BTC")).toBeVisible();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabContacts.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabContacts.ts
@@ -21,6 +21,9 @@ import { useDispatch } from "LLD/hooks/redux";
 import { useActivationDrawer } from "LLD/features/LedgerSyncEntryPoints/hooks/useActivationDrawer";
 import { useContactsAnalytics } from "LLD/features/Contacts/analytics";
 import { useContactsLedgerSyncStatus } from "LLD/features/Contacts/hooks/useContactsLedgerSyncStatus";
+import { usePayTabOutgoingOperations } from "./usePayTabOutgoingOperations";
+import { usePayTabNewPayment } from "./usePayTabNewPayment";
+import { renderPayContactAddresses } from "../components/PayContactAddresses";
 
 export type UsePayTabContactsResult = Readonly<{
   contacts: ContactsProps;
@@ -34,6 +37,8 @@ export function usePayTabContacts(): UsePayTabContactsResult {
   const { openDrawer } = useActivationDrawer();
   const ledgerSyncStatus = useContactsLedgerSyncStatus();
   const { requestMutation, dismissPendingIntent } = useContactsLedgerSyncMutationGuard();
+  const outgoingOperations = usePayTabOutgoingOperations();
+  const { open: openNewPayment } = usePayTabNewPayment();
   const [isLedgerSyncIntroductionRequested, setIsLedgerSyncIntroductionRequested] = useState(false);
   const contactCreation = useMemo(
     () => createContactCreationPort({ dispatch, generateId: uuid }),
@@ -94,6 +99,17 @@ export function usePayTabContacts(): UsePayTabContactsResult {
           onSaveSuccess,
           callbacks,
         },
+        labels: {
+          name: t("payTab.contacts.table.name"),
+          addresses: t("payTab.contacts.table.addresses"),
+          transactions: t("payTab.contacts.table.transactions"),
+          formatTransactionCount: count => t("payTab.contacts.table.transactionCount", { count }),
+          payAction: t("payTab.contacts.actions.pay"),
+          moreAction: t("payTab.contacts.actions.more"),
+        },
+        renderAddresses: renderPayContactAddresses,
+        onPayContact: () => openNewPayment(),
+        outgoingOperations,
       },
       ledgerSyncIntroduction: {
         open: isLedgerSyncIntroductionOpen,
@@ -111,6 +127,8 @@ export function usePayTabContacts(): UsePayTabContactsResult {
       onRequestAddContact,
       onSaveSuccess,
       callbacks,
+      outgoingOperations,
+      openNewPayment,
       isLedgerSyncIntroductionOpen,
       onActivateLedgerSyncIntroduction,
       onDismissLedgerSyncIntroduction,

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabOutgoingOperations.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabOutgoingOperations.ts
@@ -1,0 +1,27 @@
+import { useMemo } from "react";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
+import type { AccountLike } from "@ledgerhq/types-live";
+import type { OutgoingOperation } from "@features/platform-contacts";
+import { useSelector } from "LLD/hooks/redux";
+import { flattenAccountsSelector } from "~/renderer/reducers/accounts";
+
+function toOutgoingOperations(account: AccountLike): OutgoingOperation[] {
+  const currencyId = getAccountCurrency(account).id;
+
+  return [...account.pendingOperations, ...account.operations].flatMap(operation =>
+    operation.type !== "OUT"
+      ? []
+      : operation.recipients.map(recipientAddress => ({
+          id: operation.id,
+          recipientAddress,
+          date: operation.date.getTime(),
+          currencyId,
+        })),
+  );
+}
+
+export function usePayTabOutgoingOperations(): OutgoingOperation[] {
+  const accounts = useSelector(flattenAccountsSelector);
+
+  return useMemo(() => accounts.flatMap(toOutgoingOperations), [accounts]);
+}

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -910,6 +910,18 @@
       "empty": {
         "info": "You don’t have contact yet",
         "addContact": "Add contact"
+      },
+      "table": {
+        "name": "Name",
+        "addresses": "Addresses",
+        "transactions": "Transactions",
+        "transactionCount_zero": "No transaction",
+        "transactionCount_one": "{{count}} transaction",
+        "transactionCount_other": "{{count}} transactions"
+      },
+      "actions": {
+        "pay": "Send to contact",
+        "more": "More options"
       }
     },
     "actions": {

--- a/features/flow/pay-contact/README.md
+++ b/features/flow/pay-contact/README.md
@@ -3,12 +3,13 @@
 > [!CAUTION]
 > **Status: UNSTABLE** — In active development; API may change.
 
-Pay-tab contacts section: a title, an empty state with an **Add contact** CTA, and the shared Add
-contact dialog from `@features/flow-contacts-add-contact`.
+Pay-tab contacts. Web is a table of saved contacts; native is a horizontal strip with a leading
+Pay tile. Both exclude the `me` contact.
 
-The package reads the contacts, derives the empty state, and owns the dialog. The host injects the
-copy, the Add contact `labels`, a `ContactCreationPort`, optional analytics `callbacks` /
-`onSaveSuccess`, and `onRequestAddContact` — a gate (e.g. Ledger Sync) the CTA runs before opening.
+Mount `Contacts` under a Redux `Provider` with `contactsSlice`. Desktop adapter:
+`usePayTabContacts`.
+
+## Web
 
 ```tsx
 import { Contacts } from "@features/flow-pay-contact";
@@ -17,20 +18,17 @@ import { Contacts } from "@features/flow-pay-contact";
   title={title}
   emptyState={{ info, addContactLabel }}
   addContact={{ labels, contactCreation, onRequestAddContact, onSaveSuccess, callbacks }}
+  labels={{ name, addresses, transactions, formatTransactionCount, payAction, moreAction }}
+  renderAddresses={addresses => <PayContactAddresses addresses={addresses} />}
+  onPayContact={openNewPayment}
+  outgoingOperations={outgoingOperations}
 />;
 ```
 
-Desktop's `usePayTabContacts` is the reference adapter: it builds the labels and creation port,
-reuses the Contacts analytics callbacks, and gates the CTA through the Ledger Sync mutation guard.
-The Ledger Sync activation UI stays app-owned and is mounted next to `Contacts` by the Pay tab.
+`renderAddresses` is app-owned (e.g. `IconStack`). Optional `outgoingOperations` sort by last
+sent-to and fill the transaction count.
 
-Hosts must render `Contacts` under a Redux `Provider` with the `contactsSlice` reducer.
-
-## Native (Mobile)
-
-The native barrel exposes a different `Contacts` surface: a horizontal strip with a leading **Pay**
-tile (opens the Send flow) followed by the saved contacts. The empty state renders no contact tiles
-— only the Pay tile remains.
+## Native
 
 ```tsx
 import { Contacts } from "@features/flow-pay-contact";
@@ -38,9 +36,5 @@ import { Contacts } from "@features/flow-pay-contact";
 <Contacts title={title} payLabel={payLabel} onPay={openSend} onSeeAll={openContactsList} />;
 ```
 
-The strip caps at 8 saved contacts. When more are saved, the section title becomes a see-all
-control that calls `onSeeAll` — the host opens the full contacts list (the mobile Contacts flow).
-The `hasMore` flag and the 8-item slice are derived by the view-model; the view is props-only.
-
-Contact tiles are display-only for now. `onContactPress` is an optional prop left unwired so a later
-ticket can turn each tile into a Pay entry point without changing the layout.
+Caps at 8 contacts. `onSeeAll` opens the full list when there are more. `onContactPress` is optional
+and unused for now.

--- a/features/flow/pay-contact/src/components/ContactTile/ContactTile.web.tsx
+++ b/features/flow/pay-contact/src/components/ContactTile/ContactTile.web.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import {
+  IconButton,
+  TableCell,
+  TableCellContent,
+  TableCellContentTitle,
+  TableCellItem,
+  TableRow,
+} from "@ledgerhq/lumen-ui-react";
+import { MoreHorizontal, Telegram } from "@ledgerhq/lumen-ui-react/symbols";
+import { ContactAvatar } from "@features/platform-contacts";
+import type { Contact } from "@domain/entity-contact";
+import type { ContactsTableLabels } from "../../types";
+
+type ContactTileProps = Readonly<{
+  contact: Contact;
+  transactionCount: number;
+  labels: ContactsTableLabels;
+  renderAddresses: (addresses: Contact["addresses"]) => React.ReactNode;
+  onPay?: (contact: Contact) => void;
+  onMore?: (contact: Contact) => void;
+}>;
+
+export function ContactTile({
+  contact,
+  transactionCount,
+  labels,
+  renderAddresses,
+  onPay,
+  onMore,
+}: ContactTileProps) {
+  return (
+    <TableRow data-testid={`pay-contacts-tile-${contact.id}`}>
+      <TableCell>
+        <TableCellItem>
+          <ContactAvatar contactId={contact.id} name={contact.name} size="sm" ariaHidden />
+          <TableCellContent>
+            <TableCellContentTitle>{contact.name}</TableCellContentTitle>
+          </TableCellContent>
+        </TableCellItem>
+      </TableCell>
+      <TableCell align="end">{renderAddresses(contact.addresses)}</TableCell>
+      <TableCell align="end">{labels.formatTransactionCount(transactionCount)}</TableCell>
+      <TableCell align="end">
+        <div className="flex items-center justify-end gap-8">
+          <IconButton
+            appearance="gray"
+            size="sm"
+            icon={Telegram}
+            aria-label={labels.payAction}
+            disabled={!onPay}
+            onClick={() => onPay?.(contact)}
+            data-testid={`pay-contacts-pay-action-${contact.id}`}
+          />
+          <IconButton
+            appearance="gray"
+            size="sm"
+            icon={MoreHorizontal}
+            aria-label={labels.moreAction}
+            disabled={!onMore}
+            onClick={() => onMore?.(contact)}
+            data-testid={`pay-contacts-more-action-${contact.id}`}
+          />
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/features/flow/pay-contact/src/components/Contacts/ContactsView.web.tsx
+++ b/features/flow/pay-contact/src/components/Contacts/ContactsView.web.tsx
@@ -1,13 +1,20 @@
 import React from "react";
 import { ContactsAddContactDialog } from "@features/flow-contacts-add-contact";
 import { EmptyState } from "../EmptyState/EmptyState.web";
+import { ContactsTable } from "../ContactsTable/ContactsTable.web";
 import type { ContactsViewProps } from "../../types";
 
-export function ContactsView({ title, isEmpty, emptyState, addContactDialog }: ContactsViewProps) {
+export function ContactsView({
+  title,
+  isEmpty,
+  emptyState,
+  addContactDialog,
+  ...table
+}: ContactsViewProps) {
   return (
     <div className="mt-40 flex flex-col" data-testid="pay-contacts">
       <p className="mb-12 heading-5-semi-bold text-base">{title}</p>
-      {isEmpty ? <EmptyState {...emptyState} /> : null}
+      {isEmpty ? <EmptyState {...emptyState} /> : <ContactsTable {...table} />}
       <ContactsAddContactDialog {...addContactDialog} />
     </div>
   );

--- a/features/flow/pay-contact/src/components/Contacts/__tests__/Contacts.web.test.tsx
+++ b/features/flow/pay-contact/src/components/Contacts/__tests__/Contacts.web.test.tsx
@@ -4,13 +4,14 @@ import userEvent from "@testing-library/user-event";
 import { mockContact, mockMeContact } from "@domain/entity-contact/schema.mock";
 import { createContactCreationPort } from "@features/flow-contacts-add-contact";
 import { Contacts } from "../Contacts.web";
-import { makeAddContactProps, makeContactsStore, renderWithContacts } from "./shared";
-import type { ContactsProps } from "../../../types";
-
-const emptyState: ContactsProps["emptyState"] = {
-  info: "You don’t have contact yet",
-  addContactLabel: "Add contact",
-};
+import {
+  emptyStateLabels,
+  makeAddContactProps,
+  makeContactsStore,
+  renderAddresses,
+  renderWithContacts,
+  tableLabels,
+} from "./shared";
 
 function renderContacts(
   contacts: Parameters<typeof renderWithContacts>[0],
@@ -19,7 +20,13 @@ function renderContacts(
 ) {
   return renderWithContacts(
     contacts,
-    <Contacts title="Pay contact" emptyState={emptyState} addContact={addContact} />,
+    <Contacts
+      title="Pay contact"
+      emptyState={emptyStateLabels}
+      addContact={addContact}
+      labels={tableLabels}
+      renderAddresses={renderAddresses}
+    />,
     store,
   );
 }
@@ -30,7 +37,7 @@ describe("Contacts (Web)", () => {
 
     expect(screen.getByTestId("pay-contacts-empty-state")).toBeVisible();
     expect(screen.getByText("You don’t have contact yet")).toBeVisible();
-    expect(screen.queryByTestId("contacts-table")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("pay-contacts-list")).not.toBeInTheDocument();
   });
 
   it("should open the add-contact dialog from the empty-state CTA", async () => {
@@ -79,9 +86,10 @@ describe("Contacts (Web)", () => {
     expect(store.getState().contacts.contacts.some(c => c.name === "Coinbase 1")).toBe(true);
   });
 
-  it("should not render the empty state when a saved contact exists", () => {
+  it("should list saved contacts when they exist", () => {
     renderContacts([mockMeContact(), mockContact({ id: "contact-ada", name: "Ada" })]);
 
     expect(screen.queryByTestId("pay-contacts-empty-state")).not.toBeInTheDocument();
+    expect(screen.getByTestId("pay-contacts-tile-contact-ada")).toBeVisible();
   });
 });

--- a/features/flow/pay-contact/src/components/Contacts/__tests__/ContactsView.web.test.tsx
+++ b/features/flow/pay-contact/src/components/Contacts/__tests__/ContactsView.web.test.tsx
@@ -1,47 +1,12 @@
 import React from "react";
 import { screen } from "@testing-library/react";
+import { mockContact } from "@domain/entity-contact/schema.mock";
 import { ContactsView } from "../ContactsView.web";
-import { renderWithContacts } from "./shared";
+import { makeContactsViewProps, renderWithContacts } from "./shared";
 import type { ContactsViewProps } from "../../../types";
 
-const emptyState: ContactsViewProps["emptyState"] = {
-  info: "You don’t have contact yet",
-  addContactLabel: "Add contact",
-  onAddContact: jest.fn(),
-};
-
-const addContactDialog: ContactsViewProps["addContactDialog"] = {
-  isOpen: false,
-  isConfirmEnabled: false,
-  isSaving: false,
-  draftName: "",
-  avatarInitial: "",
-  invalidNameError: null,
-  labels: {
-    title: "Add contact",
-    namePlaceholder: "Contact name",
-    namingDisclaimer: "Use a nickname.",
-    confirmName: "Add contact",
-    nameValidationErrors: {},
-  } as ContactsViewProps["addContactDialog"]["labels"],
-  onDraftNameChange: jest.fn(),
-  onConfirm: jest.fn(),
-  reset: jest.fn(),
-  onOpen: jest.fn(),
-  onClose: jest.fn(),
-};
-
 function renderView(props: Partial<ContactsViewProps> = {}) {
-  return renderWithContacts(
-    [],
-    <ContactsView
-      title="Pay contact"
-      isEmpty
-      emptyState={emptyState}
-      addContactDialog={addContactDialog}
-      {...props}
-    />,
-  );
+  return renderWithContacts([], <ContactsView {...makeContactsViewProps(props)} />);
 }
 
 describe("ContactsView (Web)", () => {
@@ -56,13 +21,28 @@ describe("ContactsView (Web)", () => {
     renderView();
 
     expect(screen.getByTestId("pay-contacts-empty-state")).toBeVisible();
-    expect(screen.queryByTestId("contacts-table")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("pay-contacts-list")).not.toBeInTheDocument();
   });
 
   it("should not render the empty state when isEmpty is false", () => {
     renderView({ isEmpty: false });
 
     expect(screen.queryByTestId("pay-contacts-empty-state")).not.toBeInTheDocument();
+  });
+
+  it("should render a table row for each contact when not empty", () => {
+    renderView({
+      isEmpty: false,
+      rows: [
+        { contact: mockContact({ id: "contact-ada", name: "Ada" }), transactionCount: 0 },
+        { contact: mockContact({ id: "contact-bob", name: "Bob" }), transactionCount: 0 },
+      ],
+    });
+
+    expect(screen.getByTestId("pay-contacts-list")).toBeVisible();
+    expect(screen.getByText("Ada")).toBeVisible();
+    expect(screen.getByText("Bob")).toBeVisible();
+    expect(screen.getAllByTestId(/^pay-contacts-tile-/)).toHaveLength(2);
   });
 
   it("should render the closed add-contact dialog without showing it", () => {

--- a/features/flow/pay-contact/src/components/Contacts/__tests__/shared.web.tsx
+++ b/features/flow/pay-contact/src/components/Contacts/__tests__/shared.web.tsx
@@ -12,7 +12,12 @@ import {
 } from "@domain/entity-contact";
 import type { AddContactDialogViewModel } from "@features/flow-contacts-add-contact";
 import { StyleProvider } from "@features/platform-style";
-import type { ContactsProps, ContactsViewProps, PayAddContactProps } from "../../../types";
+import type {
+  ContactsProps,
+  ContactsTableLabels,
+  ContactsViewProps,
+  PayAddContactProps,
+} from "../../../types";
 
 export function makeContactsStore(contacts: Contact[]) {
   return configureStore({
@@ -51,6 +56,19 @@ export const emptyStateLabels: ContactsProps["emptyState"] = {
   addContactLabel: "Add contact",
 };
 
+export const tableLabels: ContactsTableLabels = {
+  name: "Name",
+  addresses: "Addresses",
+  transactions: "Transactions",
+  formatTransactionCount: count => `${count} transaction`,
+  payAction: "Pay",
+  moreAction: "More",
+};
+
+export function renderAddresses() {
+  return null;
+}
+
 export function makeAddContactProps(
   overrides: Partial<PayAddContactProps> = {},
 ): PayAddContactProps {
@@ -79,6 +97,8 @@ export function makeContactsProps(overrides: Partial<ContactsProps> = {}): Conta
     title: "Pay contact",
     emptyState: emptyStateLabels,
     addContact: makeAddContactProps(),
+    labels: tableLabels,
+    renderAddresses,
     ...overrides,
   };
 }
@@ -109,6 +129,9 @@ export function makeContactsViewProps(
   return {
     title: "Pay contact",
     isEmpty: true,
+    rows: [],
+    labels: tableLabels,
+    renderAddresses,
     emptyState: { ...emptyStateLabels, onAddContact: jest.fn() },
     addContactDialog: makeAddContactDialogViewModel(),
     ...overrides,

--- a/features/flow/pay-contact/src/components/Contacts/__tests__/useContactsViewModel.web.test.tsx
+++ b/features/flow/pay-contact/src/components/Contacts/__tests__/useContactsViewModel.web.test.tsx
@@ -1,5 +1,11 @@
 import { act, renderHook } from "@testing-library/react";
-import { mockContact, mockMeContact } from "@domain/entity-contact/schema.mock";
+import {
+  mockContact,
+  mockContactAddress,
+  mockContactWithAddress,
+  mockMeContact,
+} from "@domain/entity-contact/schema.mock";
+import type { OutgoingOperation } from "@features/platform-contacts";
 import { useContactsViewModel } from "../useContactsViewModel";
 import { makeAddContactProps, makeContactsProps, makeContactsWrapper } from "./shared";
 
@@ -25,13 +31,44 @@ describe("useContactsViewModel", () => {
     expect(result.current.isEmpty).toBe(true);
   });
 
-  it("should not be empty when a saved contact exists", () => {
-    const { result } = renderViewModel([
-      mockMeContact(),
-      mockContact({ id: "contact-ada", name: "Ada" }),
-    ]);
+  it("should exclude the me contact and expose every saved contact without a cap", () => {
+    const savedContacts = Array.from({ length: 9 }, (_, index) =>
+      mockContact({ id: `contact-${index}`, name: `Contact ${index}` }),
+    );
+    const { result } = renderViewModel([mockMeContact(), ...savedContacts]);
 
     expect(result.current.isEmpty).toBe(false);
+    expect(result.current.rows).toHaveLength(9);
+    expect(result.current.rows.every(row => !row.contact.isMe)).toBe(true);
+  });
+
+  it("should order contacts by last sent-to, then last added", () => {
+    const bobAddress = "0x1111111111111111111111111111111111111111";
+    const bob = mockContactWithAddress({
+      id: "contact-bob",
+      name: "Bob",
+      addresses: [mockContactAddress({ id: "addr-bob", address: bobAddress })],
+    });
+    const alice = mockContactWithAddress({
+      id: "contact-alice",
+      name: "Alice",
+      addresses: [
+        mockContactAddress({
+          id: "addr-alice",
+          address: "0x2222222222222222222222222222222222222222",
+        }),
+      ],
+    });
+    const sentToBob: OutgoingOperation[] = [
+      { recipientAddress: bobAddress, date: 1_700_000_000_000, currencyId: "ethereum" },
+    ];
+    const { result } = renderViewModel(
+      [mockMeContact(), bob, alice],
+      makeContactsProps({ outgoingOperations: sentToBob }),
+    );
+
+    expect(result.current.rows.map(row => row.contact.name)).toEqual(["Bob", "Alice"]);
+    expect(result.current.rows.map(row => row.transactionCount)).toEqual([1, 0]);
   });
 
   it("should request add contact with the dialog open handler", () => {

--- a/features/flow/pay-contact/src/components/Contacts/useContactsViewModel.web.ts
+++ b/features/flow/pay-contact/src/components/Contacts/useContactsViewModel.web.ts
@@ -1,17 +1,31 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { useAddContactDialogViewModel } from "@features/flow-contacts-add-contact";
-import { useContacts } from "@features/platform-contacts";
-import type { ContactsProps, ContactsViewProps } from "../../types";
+import {
+  sortContactsByLastSentThenLastAdded,
+  summarizeOutgoingOperationsByContact,
+  useContacts,
+} from "@features/platform-contacts";
+import type { ContactRowViewModel, ContactsProps, ContactsViewProps } from "../../types";
 
 const noop = () => undefined;
+const EMPTY_OPERATIONS = [] as const;
 
 export function useContactsViewModel({
-  title,
   emptyState,
   addContact,
+  outgoingOperations = EMPTY_OPERATIONS,
+  ...props
 }: ContactsProps): ContactsViewProps {
   const contacts = useContacts();
-  const isEmpty = contacts.every(contact => contact.isMe);
+  const rows = useMemo<readonly ContactRowViewModel[]>(() => {
+    const savedContacts = contacts.filter(contact => !contact.isMe);
+    const summaries = summarizeOutgoingOperationsByContact(savedContacts, outgoingOperations);
+
+    return sortContactsByLastSentThenLastAdded(savedContacts, summaries).map(contact => ({
+      contact,
+      transactionCount: summaries[contact.id]?.txCount ?? 0,
+    }));
+  }, [contacts, outgoingOperations]);
   const { labels, contactCreation, onRequestAddContact, onSaveSuccess, callbacks } = addContact;
   const addContactDialog = useAddContactDialogViewModel({
     contactCreation,
@@ -25,8 +39,9 @@ export function useContactsViewModel({
   );
 
   return {
-    title,
-    isEmpty,
+    ...props,
+    isEmpty: rows.length === 0,
+    rows,
     emptyState: { ...emptyState, onAddContact },
     addContactDialog,
   };

--- a/features/flow/pay-contact/src/components/ContactsTable/ContactsTable.web.tsx
+++ b/features/flow/pay-contact/src/components/ContactsTable/ContactsTable.web.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import {
+  Table,
+  TableBody,
+  TableHeader,
+  TableHeaderCell,
+  TableHeaderRow,
+  TableRoot,
+} from "@ledgerhq/lumen-ui-react";
+import { ContactTile } from "../ContactTile/ContactTile.web";
+import type { ContactsViewProps } from "../../types";
+
+type ContactsTableProps = Pick<
+  ContactsViewProps,
+  "rows" | "labels" | "renderAddresses" | "onPayContact" | "onContactMore"
+>;
+
+export function ContactsTable({
+  rows,
+  labels,
+  renderAddresses,
+  onPayContact,
+  onContactMore,
+}: ContactsTableProps) {
+  return (
+    <TableRoot appearance="plain" data-testid="pay-contacts-list">
+      <Table>
+        <TableHeader>
+          <TableHeaderRow>
+            <TableHeaderCell>{labels.name}</TableHeaderCell>
+            <TableHeaderCell align="end">{labels.addresses}</TableHeaderCell>
+            <TableHeaderCell align="end">{labels.transactions}</TableHeaderCell>
+            <TableHeaderCell align="end" />
+          </TableHeaderRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map(({ contact, transactionCount }) => (
+            <ContactTile
+              key={contact.id}
+              contact={contact}
+              transactionCount={transactionCount}
+              labels={labels}
+              renderAddresses={renderAddresses}
+              onPay={onPayContact}
+              onMore={onContactMore}
+            />
+          ))}
+        </TableBody>
+      </Table>
+    </TableRoot>
+  );
+}

--- a/features/flow/pay-contact/src/types.ts
+++ b/features/flow/pay-contact/src/types.ts
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import type { Contact } from "@domain/entity-contact";
 import type {
   AddContactDialogLifecycleCallbacks,
@@ -14,10 +15,6 @@ export type EmptyStateLabels = Readonly<{
 
 export type EmptyStateProps = EmptyStateLabels & Readonly<{ onAddContact: () => void }>;
 
-/**
- * Everything the host injects so the Pay contacts section can open the shared Add contact dialog.
- * `onRequestAddContact` lets the host gate the CTA (e.g. Ledger Sync) before the dialog opens.
- */
 export type PayAddContactProps = Readonly<{
   labels: ContactsAddContactContentLabels;
   contactCreation: ContactCreationPort;
@@ -26,27 +23,42 @@ export type PayAddContactProps = Readonly<{
   callbacks?: AddContactDialogLifecycleCallbacks;
 }>;
 
+export type ContactsTableLabels = Readonly<{
+  name: string;
+  addresses: string;
+  transactions: string;
+  formatTransactionCount: (count: number) => string;
+  payAction: string;
+  moreAction: string;
+}>;
+
 export type ContactsProps = Readonly<{
   title: string;
   emptyState: EmptyStateLabels;
   addContact: PayAddContactProps;
+  labels: ContactsTableLabels;
+  renderAddresses: (addresses: Contact["addresses"]) => ReactNode;
+  onPayContact?: (contact: Contact) => void;
+  onContactMore?: (contact: Contact) => void;
+  outgoingOperations?: readonly OutgoingOperation[];
 }>;
 
-export type ContactsViewProps = Readonly<{
-  title: string;
-  isEmpty: boolean;
-  emptyState: EmptyStateProps;
-  addContactDialog: AddContactDialogViewModel;
+export type ContactRowViewModel = Readonly<{
+  contact: Contact;
+  transactionCount: number;
 }>;
 
-/**
- * Native (Mobile) Pay contacts strip: a horizontal row with a leading Pay tile, then the saved
- * contacts. The Pay tile opens the Send flow. `onContactPress` is intentionally optional and left
- * unwired for now — a later ticket can pass it to turn contact tiles into Pay entry points without
- * touching the layout. `onSeeAll` opens the full contacts list when the saved contacts exceed the
- * strip cap. `outgoingOperations` are the host's account `OUT` operations used to order contacts by
- * last sent-to; omit for store order only.
- */
+export type ContactsViewProps = Pick<
+  ContactsProps,
+  "title" | "labels" | "renderAddresses" | "onPayContact" | "onContactMore"
+> &
+  Readonly<{
+    isEmpty: boolean;
+    rows: readonly ContactRowViewModel[];
+    emptyState: EmptyStateProps;
+    addContactDialog: AddContactDialogViewModel;
+  }>;
+
 export type ContactsNativeProps = Readonly<{
   title: string;
   payLabel: string;


### PR DESCRIPTION
### 📝 Description

The desktop Pay tab only showed the contacts empty state. Saved contacts had no table, address icons, transaction counts, or send action.

This PR mounts the full contacts table in `@features/flow-pay-contact` (web): name, overlapping address icons, transaction count, and a send action that opens new payment. Rows are ordered by last sent-to, then last added, using the host’s outgoing operations. Address icons go through a shared `CryptoIconStack` (also used by the Crypto Addresses assets cell). The overflow (`…`) control is present but unwired; View contact and View transactions stay on follow-up tickets.


https://github.com/user-attachments/assets/79ffc57e-9386-4aed-a39f-553d3e580e38



### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35380](https://ledgerhq.atlassian.net/browse/LIVE-35380)
- **Figma**: [Pay contacts table](https://www.figma.com/design/WYQQwem0QyG2fTuaAKAe3Y/Pay-%E2%80%A2-Production?node-id=7731-42425&m=dev)

[LIVE-35380]: https://ledgerhq.atlassian.net/browse/LIVE-35380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ