### PR TITLE
fix(e2e): wait for the transfer bottom sheet to settle (QAA-1522)

### DIFF
--- a/.changeset/qaa-1522-transfer-drawer-settle.md
+++ b/.changeset/qaa-1522-transfer-drawer-settle.md
@@ -1,0 +1,17 @@
+---
+"ledger-live-mobile-e2e-tests": patch
+---
+
+Wait for the transfer bottom sheet to settle before tapping it (QAA-1522)
+
+`tapById` does not wait, and `openReceiveDrawer` tapped the sheet's receive button
+immediately after asking the sheet to open. `toBeVisible()` is satisfied at 75%,
+which a bottom sheet meets while still sliding, so on Android CI the tap landed
+either on a moving view — Espresso refusing the action with `target view does not
+match one or more of the following constraints` — or before the button had
+mounted at all. 3/5 nightlies, still failing in the latest.
+
+Each of the three sheet taps now waits for the sheet's own container
+(`transfer-drawer`) at 100% visibility, per `docs/add-or-update-e2e.md` rules 11
+and 12: anchor on the state that proves the sheet is at rest rather than adding a
+retry or lengthening a timeout.

--- a/.changeset/qaa-1522-transfer-drawer-settle.md
+++ b/.changeset/qaa-1522-transfer-drawer-settle.md
@@ -12,6 +12,6 @@ match one or more of the following constraints` — or before the button had
 mounted at all. 3/5 nightlies, still failing in the latest.
 
 Each of the three sheet taps now waits for the sheet's own container
-(`transfer-drawer`) at 100% visibility, per `docs/add-or-update-e2e.md` rules 11
+(`transfer-drawer`) at 100% visibility, per `e2e/mobile/docs/add-or-update-e2e.md` rules 11
 and 12: anchor on the state that proves the sheet is at rest rather than adding a
 retry or lengthening a timeout.

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -50,6 +50,10 @@ export default class PortfolioPage {
   portfolioBalanceAnalyticsPill = "portfolio-balance-analytics-pill";
   portfolioBalanceDelta = "portfolio-balance-delta";
   borrowEntryPointId = "portfolio-borrow-entry-point";
+  // The sheet's own container, from QUICK_ACTIONS_TEST_IDS.transferDrawer.container. This is the
+  // anchor to wait on rather than a control inside it: the controls mount before the sheet is
+  // presented, so they are matchable while it is still sliding into place.
+  transferDrawerContainerId = "transfer-drawer";
   transferBottomSheetReceiveButton = "transfer-action-receive";
   transferBottomSheetSendButton = "transfer-action-send";
   transferBottomSheetBankTransferButton = "transfer-action-bank-transfer";
@@ -440,8 +444,18 @@ export default class PortfolioPage {
     await detoxExpect(getElementById(this.transferBottomSheetBankTransferButton)).toBeVisible();
   }
 
+  // tapById does not wait, so these taps used to be issued the instant the sheet was asked to open.
+  // toBeVisible() is satisfied at 75%, which a bottom sheet meets while still sliding, so the tap
+  // could land on a moving view and Espresso refused the action ("target view does not match one or
+  // more of the following constraints"), or the button was not mounted yet at all ("No views in
+  // hierarchy found matching ... transfer-action-receive"). Both are QAA-1522.
+  private async waitForTransferDrawerSettled() {
+    await waitForFullyVisibleById(this.transferDrawerContainerId);
+  }
+
   @Step("Press transfer bottom sheet receive button")
   async pressTransferBottomSheetReceiveButton() {
+    await this.waitForTransferDrawerSettled();
     await tapById(this.transferBottomSheetReceiveButton);
   }
 
@@ -453,11 +467,13 @@ export default class PortfolioPage {
 
   @Step("Press transfer bottom sheet send button")
   async pressTransferBottomSheetSendButton() {
+    await this.waitForTransferDrawerSettled();
     await tapById(this.transferBottomSheetSendButton);
   }
 
   @Step("Press transfer bottom sheet bank transfer button")
   async pressTransferBottomSheetBankTransferButton() {
+    await this.waitForTransferDrawerSettled();
     await tapById(this.transferBottomSheetBankTransferButton);
   }
 


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _This change is itself E2E test code, and there is no unit test for a Detox page object. It is verified by a filtered Mobile E2E run on this branch ([run 33394787463](https://github.com/LedgerHQ/ledger-live/actions/runs/33394787463), 13 specs, iOS & Android), and the standing regression detector is the nightly flake report (`e2e/mobile/scripts/flake-report.mjs`), which measured this signature at 3/5 nightlies._
- [x] **Impact of the changes:**
      - Receive flows reached from the portfolio transfer bottom sheet (`createAccount`, `importCurrency`, `readOnlyFlows`)
      - Deposit flows, which enter through the same sheet
      - `wallet40Q2/portfolio.spec.ts`, the other caller of the changed page object
      - **iOS specifically:** the new wait requires 100% visibility, stricter than the 75% default. If an iOS layout leaves the sheet container marginally clipped this would newly time out, so both platforms are in the CI run.
      - No product code is touched — only `e2e/mobile/page/wallet/portfolio.page.ts`

### Description

**Problem.** `tapById` does no waiting at all — it is `getElementById(id).tap()`. `openReceiveDrawer` tapped the sheet's receive button on the line immediately after asking the sheet to open, so the tap raced the sheet's presentation animation. `toBeVisible()` is satisfied at **75%**, which a bottom sheet meets while it is still sliding.

That produced two different failures from one defect, both seen in the nightlies:

- `Test Failed: Action will not be performed because the target view does not match one or more of the following constraints:` — the button was present but still moving, so Espresso refused the action.
- `Test Failed: No views in hierarchy found matching: ... view.getTag() is "transfer-action-receive" and view has effective visibility <VISIBLE>` — the button had not mounted yet at all.

**Solution.** Wait for the sheet's own container at 100% visibility before tapping.

```ts
// before
async pressTransferBottomSheetReceiveButton() {
  await tapById(this.transferBottomSheetReceiveButton);
}

// after
private async waitForTransferDrawerSettled() {
  await waitForFullyVisibleById(this.transferDrawerContainerId);   // "transfer-drawer"
}

async pressTransferBottomSheetReceiveButton() {
  await this.waitForTransferDrawerSettled();
  await tapById(this.transferBottomSheetReceiveButton);
}
```

The **container** is the anchor rather than a control inside it, because the controls mount before the sheet is presented and so are matchable too early. This follows `e2e/mobile/docs/add-or-update-e2e.md` rule 11, and rule 12 is why this is a wait rather than a retry or a longer timeout.

`transfer-drawer` already exists in product code as `QUICK_ACTIONS_TEST_IDS.transferDrawer.container` and is rendered by `TransferDrawerView.tsx`, so no product-code change was needed.

Send and bank transfer get the same wait as receive: same sheet, same bare tap. Only receive has a nightly observation, but fixing one of three identical defects would simply get the other two re-reported.

**Evidence.** 3/5 nightlies (2026-08-26, 2026-08-28, 2026-08-31), Android only, still failing in the latest nightly. None of the three is the infra-suspect 2026-08-25 night, so the evidence carries no emulator-wedge doubt. `oxfmt`, `oxlint` and `pnpm typecheck` all clean.

### Context

- **JIRA or GitHub link**: [QAA-1522](https://ledgerhq.atlassian.net/browse/QAA-1522) (sub-task of [QAA-1445](https://ledgerhq.atlassian.net/browse/QAA-1445))

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1522]: https://ledgerhq.atlassian.net/browse/QAA-1522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ