### PR TITLE
fix(e2e): wait for the quick-action row to settle (QAA-1524)

### DIFF
--- a/.changeset/qaa-1524-quick-actions-settle.md
+++ b/.changeset/qaa-1524-quick-actions-settle.md
@@ -1,0 +1,14 @@
+---
+"ledger-live-mobile-e2e-tests": patch
+---
+
+Wait for the portfolio quick-action row to settle before tapping it (QAA-1524)
+
+`tapById` does not wait, so the quick-action taps were issued as soon as the
+portfolio rendered. The row mounts after the portfolio's own data resolves, so on
+Android CI the tap could land before it existed — `No views in hierarchy found
+matching ... quick-action-buy ... VISIBLE`, 3/5 nightlies.
+
+Each press now waits for the row's own container at 100% visibility, which proves
+the row is mounted and laid out. Anchoring the wait rather than lengthening a
+timeout or adding a retry, per `docs/add-or-update-e2e.md` rules 11 and 12.

--- a/.changeset/qaa-1524-quick-actions-settle.md
+++ b/.changeset/qaa-1524-quick-actions-settle.md
@@ -11,4 +11,4 @@ matching ... quick-action-buy ... VISIBLE`, 3/5 nightlies.
 
 Each press now waits for the row's own container at 100% visibility, which proves
 the row is mounted and laid out. Anchoring the wait rather than lengthening a
-timeout or adding a retry, per `docs/add-or-update-e2e.md` rules 11 and 12.
+timeout or adding a retry, per `e2e/mobile/docs/add-or-update-e2e.md` rules 11 and 12.

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -41,6 +41,10 @@ export default class PortfolioPage {
   fearAndGreedTitle = "fear-and-greed-title";
   bottomSheetCloseButton = "bottom-sheet-header-close-button";
   marketBannerTitle = "market-banner-title";
+  // The row's own container, from QUICK_ACTIONS_TEST_IDS.ctas.container. Waiting on this at 100%
+  // visibility is what proves the row has mounted and settled; the buttons inside it are laid out
+  // by then, so a tap cannot land on a view that is still arriving.
+  quickActionsCtasContainerId = "quick-actions-ctas";
   quickActionTransferButtonV4 = "quick-action-transfer";
   quickActionSwapButtonV4 = "quick-action-swap";
   quickActionBuyButtonV4 = "quick-action-buy";
@@ -391,18 +395,29 @@ export default class PortfolioPage {
     await waitForElementById(this.quickActionBuyButtonV4);
   }
 
+  // tapById does not wait, so these taps used to be issued the moment the portfolio rendered.
+  // The quick actions mount after the portfolio's own data resolves, which is why the tap could
+  // fail with "No views in hierarchy found matching ... quick-action-buy" (QAA-1524) — the row was
+  // not there yet, rather than being under-visible.
+  private async waitForQuickActionsSettled() {
+    await waitForFullyVisibleById(this.quickActionsCtasContainerId);
+  }
+
   @Step("Press quick action buy button")
   async pressQuickActionBuyButton() {
+    await this.waitForQuickActionsSettled();
     await tapById(this.quickActionBuyButtonV4);
   }
 
   @Step("Press quick action swap button")
   async pressQuickActionSwapButton() {
+    await this.waitForQuickActionsSettled();
     await tapById(this.quickActionSwapButtonV4);
   }
 
   @Step("Press quick action transfer button")
   async pressQuickActionTransferButton() {
+    await this.waitForQuickActionsSettled();
     await tapById(this.quickActionTransferButtonV4);
   }
   @Step("Check no balance title visibility")


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _This change is itself E2E test code, and there is no unit test for a Detox page object. It is verified by a filtered Mobile E2E run on this branch ([run 33394790416](https://github.com/LedgerHQ/ledger-live/actions/runs/33394790416), 14 specs, iOS & Android), and the standing regression detector is the nightly flake report (`e2e/mobile/scripts/flake-report.mjs`), which measured this signature at 3/5 nightlies._
- [x] **Impact of the changes:**
      - Buy entry point from the portfolio (`navigateToBuyFromPortfolioPage_BTC`) — the ticketed failure
      - Receive and deposit flows, which enter through `pressQuickActionTransferButton`
      - `wallet40Q2/portfolio.spec.ts`, the other caller of the changed page object
      - **iOS specifically:** the new wait requires 100% visibility, stricter than the 75% default. If an iOS layout leaves the quick-action row marginally clipped this would newly time out, so both platforms are in the CI run.
      - No product code is touched — only `e2e/mobile/page/wallet/portfolio.page.ts`

### Description

**Problem.** `tapById` does no waiting at all — it is `getElementById(id).tap()` — so the quick-action taps were issued the moment the portfolio rendered:

```ts
async pressQuickActionBuyButton() {
  await tapById(this.quickActionBuyButtonV4);   // no wait
}
```

The quick actions mount only after the portfolio's own data resolves, so on Android CI the tap could be matched against a hierarchy that did not contain the row yet:

```
Test Failed: No views in hierarchy found matching: View at index #0, of those matching
MATCHER(view.getTag() is "quick-action-buy" and view has effective visibility <VISIBLE>)
```

Worth reading precisely: the row was **absent from the hierarchy**, not merely under-visible. So this is not a case for a longer timeout — nothing was there to wait on being bigger.

**Solution.** Wait for the row's own container at 100% visibility before tapping.

```ts
private async waitForQuickActionsSettled() {
  await waitForFullyVisibleById(this.quickActionsCtasContainerId);   // "quick-actions-ctas"
}

async pressQuickActionBuyButton() {
  await this.waitForQuickActionsSettled();
  await tapById(this.quickActionBuyButtonV4);
}
```

The container being fully visible is the state that proves the row is mounted and laid out; the buttons inside it are positioned by then. Anchoring the wait rather than raising a timeout or adding a retry follows `e2e/mobile/docs/add-or-update-e2e.md` rules 11 and 12.

`quick-actions-ctas` already exists in product code as `QUICK_ACTIONS_TEST_IDS.ctas.container` and is rendered by `QuickActionsCtasView.tsx`, so no product-code change was needed.

Swap and transfer get the same wait as buy: same row, same bare tap. Note `pressQuickActionTransferButton` is the first step of `openReceiveDrawer`, so this also removes one source of noise from QAA-1522's failure path.

**Evidence.** 3/5 nightlies (2026-08-25, 2026-08-26, 2026-08-28), Android only, last seen 2026-08-28, and 30% of runs of the spec. The rate rose from the 2/5 at which the ticket was filed. One of the three nights (2026-08-25) is infra-suspect and should be weighed lightly; the other two are clean. `oxfmt`, `oxlint` and `pnpm typecheck` all clean.

### Context

- **JIRA or GitHub link**: [QAA-1524](https://ledgerhq.atlassian.net/browse/QAA-1524) (sub-task of [QAA-1445](https://ledgerhq.atlassian.net/browse/QAA-1445))

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1524]: https://ledgerhq.atlassian.net/browse/QAA-1524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ