### PR TITLE
[LWD] feat(modular-dialog): add disabled row tooltips

### DIFF
--- a/.changeset/gentle-otters-tooltip.md
+++ b/.changeset/gentle-otters-tooltip.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add explanations for unsupported assets and networks in the modular dialog

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/__tests__/selectNetworkFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/__tests__/selectNetworkFlow.test.tsx
@@ -99,17 +99,16 @@ describe("ModularDialogFlowManager - Select Network Flow", () => {
     const bitcoinAsset = screen.getByTestId("asset-item-ticker-btc");
     expect(bitcoinAsset).toHaveAttribute("aria-disabled", "true");
 
+    await user.click(bitcoinAsset);
+
+    expect(mockOnAssetSelected).not.toHaveBeenCalled();
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Bitcoin isn't supported yet.");
+
     bitcoinAsset.parentElement?.focus();
 
     expect(bitcoinAsset.parentElement).toHaveFocus();
     expect(bitcoinAsset.parentElement).toHaveAttribute("role", "button");
     expect(bitcoinAsset.parentElement).toHaveAttribute("aria-disabled", "true");
-
-    expect(await screen.findByRole("tooltip")).toHaveTextContent("Bitcoin isn't supported yet.");
-
-    await user.click(bitcoinAsset);
-
-    expect(mockOnAssetSelected).not.toHaveBeenCalled();
   });
 
   it("should allow eligible assets to reach the full network list", async () => {
@@ -128,15 +127,18 @@ describe("ModularDialogFlowManager - Select Network Flow", () => {
     const arbitrumNetwork = screen.getByTestId("network-item-name-Arbitrum");
     expect(arbitrumNetwork).toHaveAttribute("aria-disabled", "true");
 
+    await user.click(arbitrumNetwork);
+
+    expect(mockOnAssetSelected).not.toHaveBeenCalled();
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Arbitrum network isn't supported yet.",
+    );
+
     arbitrumNetwork.parentElement?.focus();
 
     expect(arbitrumNetwork.parentElement).toHaveFocus();
     expect(arbitrumNetwork.parentElement).toHaveAttribute("role", "button");
     expect(arbitrumNetwork.parentElement).toHaveAttribute("aria-disabled", "true");
-
-    expect(await screen.findByRole("tooltip")).toHaveTextContent(
-      "Arbitrum network isn't supported yet.",
-    );
 
     await user.click(ethereumNetwork);
 

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/__tests__/selectNetworkFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/__tests__/selectNetworkFlow.test.tsx
@@ -99,6 +99,14 @@ describe("ModularDialogFlowManager - Select Network Flow", () => {
     const bitcoinAsset = screen.getByTestId("asset-item-ticker-btc");
     expect(bitcoinAsset).toHaveAttribute("aria-disabled", "true");
 
+    bitcoinAsset.parentElement?.focus();
+
+    expect(bitcoinAsset.parentElement).toHaveFocus();
+    expect(bitcoinAsset.parentElement).toHaveAttribute("role", "button");
+    expect(bitcoinAsset.parentElement).toHaveAttribute("aria-disabled", "true");
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Bitcoin isn't supported yet.");
+
     await user.click(bitcoinAsset);
 
     expect(mockOnAssetSelected).not.toHaveBeenCalled();
@@ -119,6 +127,16 @@ describe("ModularDialogFlowManager - Select Network Flow", () => {
     const ethereumNetwork = screen.getByTestId("network-item-name-Ethereum");
     const arbitrumNetwork = screen.getByTestId("network-item-name-Arbitrum");
     expect(arbitrumNetwork).toHaveAttribute("aria-disabled", "true");
+
+    arbitrumNetwork.parentElement?.focus();
+
+    expect(arbitrumNetwork.parentElement).toHaveFocus();
+    expect(arbitrumNetwork.parentElement).toHaveAttribute("role", "button");
+    expect(arbitrumNetwork.parentElement).toHaveAttribute("aria-disabled", "true");
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Arbitrum network isn't supported yet.",
+    );
 
     await user.click(ethereumNetwork);
 

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AssetSelector/components/AssetListItem/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AssetSelector/components/AssetListItem/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useState, type KeyboardEvent } from "react";
 import { CryptoIcon } from "@ledgerhq/crypto-icons";
 import {
   ListItem,
@@ -71,6 +71,15 @@ export const AssetListItem = ({
     setIsTooltipOpen(true);
   }, []);
 
+  const handleDisabledItemKeyDown = useCallback((event: KeyboardEvent<HTMLSpanElement>) => {
+    if (event.key !== "Enter" && event.key !== " ") {
+      return;
+    }
+
+    event.preventDefault();
+    setIsTooltipOpen(true);
+  }, []);
+
   const handleClick = () => {
     if (disabled) return;
     onClick({ name, ticker, id });
@@ -80,9 +89,9 @@ export const AssetListItem = ({
     <ListItem
       className="-outline-offset-2"
       disabled={disabled}
-      onClick={handleClick}
+      onClick={disabled ? undefined : handleClick}
       data-testid={`asset-item-ticker-${ticker.toLowerCase()}`}
-      aria-hidden={disabled || undefined}
+      aria-disabled={disabled || undefined}
     >
       <ListItemLeading>
         <CryptoIcon size={48} ledgerId={id} ticker={ticker} />
@@ -115,8 +124,8 @@ export const AssetListItem = ({
           tabIndex={0}
           role="button"
           aria-disabled
-          aria-label={name}
           onClick={handleDisabledItemClick}
+          onKeyDown={handleDisabledItemKeyDown}
         >
           {listItem}
         </span>

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AssetSelector/components/AssetListItem/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AssetSelector/components/AssetListItem/index.tsx
@@ -7,7 +7,11 @@ import {
   ListItemTitle,
   ListItemDescription,
   ListItemTrailing,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from "@ledgerhq/lumen-ui-react";
+import { useTranslation } from "react-i18next";
 import { AssetType } from "../../../../types";
 
 const copyToClipboard = async (text: string) => {
@@ -60,17 +64,20 @@ export const AssetListItem = ({
   shouldDisplayId,
   disabled,
 }: AssetListItemProps) => {
+  const { t } = useTranslation();
+
   const handleClick = () => {
     if (disabled) return;
     onClick({ name, ticker, id });
   };
 
-  return (
+  const listItem = (
     <ListItem
       className="-outline-offset-2"
       disabled={disabled}
       onClick={handleClick}
       data-testid={`asset-item-ticker-${ticker.toLowerCase()}`}
+      aria-hidden={disabled || undefined}
     >
       <ListItemLeading>
         <CryptoIcon size={48} ledgerId={id} ticker={ticker} />
@@ -89,5 +96,28 @@ export const AssetListItem = ({
       </ListItemLeading>
       <ListItemTrailing>{rightElement}</ListItemTrailing>
     </ListItem>
+  );
+
+  if (!disabled) {
+    return listItem;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="block focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus"
+          tabIndex={0}
+          role="button"
+          aria-disabled
+          aria-label={name}
+        >
+          {listItem}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>
+        {t("modularAssetDrawer.unsupportedAssetTooltip", { asset: name })}
+      </TooltipContent>
+    </Tooltip>
   );
 };

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AssetSelector/components/AssetListItem/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/AssetSelector/components/AssetListItem/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useState } from "react";
 import { CryptoIcon } from "@ledgerhq/crypto-icons";
 import {
   ListItem,
@@ -65,6 +65,11 @@ export const AssetListItem = ({
   disabled,
 }: AssetListItemProps) => {
   const { t } = useTranslation();
+  const [isTooltipOpen, setIsTooltipOpen] = useState(false);
+
+  const handleDisabledItemClick = useCallback(() => {
+    setIsTooltipOpen(true);
+  }, []);
 
   const handleClick = () => {
     if (disabled) return;
@@ -103,7 +108,7 @@ export const AssetListItem = ({
   }
 
   return (
-    <Tooltip>
+    <Tooltip open={isTooltipOpen} onOpenChange={setIsTooltipOpen}>
       <TooltipTrigger asChild>
         <span
           className="block focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus"
@@ -111,6 +116,7 @@ export const AssetListItem = ({
           role="button"
           aria-disabled
           aria-label={name}
+          onClick={handleDisabledItemClick}
         >
           {listItem}
         </span>

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/components/NetworkListItem/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/components/NetworkListItem/index.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useState } from "react";
+import React, {
+  useCallback,
+  useState,
+  type KeyboardEvent,
+  type ReactElement,
+  type ReactNode,
+} from "react";
 import {
   ListItem,
   ListItemTitle,
@@ -13,7 +19,6 @@ import {
 import { SquaredCryptoIcon } from "LLD/components/SquaredCryptoIcon";
 import { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import { useTranslation } from "react-i18next";
-import type { ReactElement, ReactNode } from "react";
 
 export type NetworkListItemData = {
   currency: CryptoOrTokenCurrency;
@@ -42,6 +47,15 @@ export const NetworkListItem = ({
     setIsTooltipOpen(true);
   }, []);
 
+  const handleDisabledItemKeyDown = useCallback((event: KeyboardEvent<HTMLSpanElement>) => {
+    if (event.key !== "Enter" && event.key !== " ") {
+      return;
+    }
+
+    event.preventDefault();
+    setIsTooltipOpen(true);
+  }, []);
+
   const listItem = (
     <ListItem
       onClick={disabled ? undefined : onClick}
@@ -49,7 +63,6 @@ export const NetworkListItem = ({
       aria-disabled={disabled || undefined}
       data-testid={`network-item-name-${currency.name}`}
       className="-outline-offset-2"
-      aria-hidden={disabled || undefined}
     >
       <ListItemLeading>
         <SquaredCryptoIcon size={48} ledgerId={currency.id} ticker={currency.ticker} />
@@ -77,8 +90,8 @@ export const NetworkListItem = ({
           tabIndex={0}
           role="button"
           aria-disabled
-          aria-label={currency.name}
           onClick={handleDisabledItemClick}
+          onKeyDown={handleDisabledItemKeyDown}
         >
           {listItem}
         </span>

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/components/NetworkListItem/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/components/NetworkListItem/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useState } from "react";
 import {
   ListItem,
   ListItemTitle,
@@ -36,6 +36,11 @@ export const NetworkListItem = ({
   disabled,
 }: NetworkListItemProps) => {
   const { t } = useTranslation();
+  const [isTooltipOpen, setIsTooltipOpen] = useState(false);
+
+  const handleDisabledItemClick = useCallback(() => {
+    setIsTooltipOpen(true);
+  }, []);
 
   const listItem = (
     <ListItem
@@ -65,7 +70,7 @@ export const NetworkListItem = ({
   }
 
   return (
-    <Tooltip>
+    <Tooltip open={isTooltipOpen} onOpenChange={setIsTooltipOpen}>
       <TooltipTrigger asChild>
         <span
           className="block focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus"
@@ -73,6 +78,7 @@ export const NetworkListItem = ({
           role="button"
           aria-disabled
           aria-label={currency.name}
+          onClick={handleDisabledItemClick}
         >
           {listItem}
         </span>

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/components/NetworkListItem/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/screens/NetworkSelector/components/NetworkListItem/index.tsx
@@ -6,9 +6,13 @@ import {
   ListItemDescription,
   ListItemLeading,
   ListItemTrailing,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from "@ledgerhq/lumen-ui-react";
 import { SquaredCryptoIcon } from "LLD/components/SquaredCryptoIcon";
 import { CryptoOrTokenCurrency } from "@domain/entity-currency";
+import { useTranslation } from "react-i18next";
 import type { ReactElement, ReactNode } from "react";
 
 export type NetworkListItemData = {
@@ -31,13 +35,16 @@ export const NetworkListItem = ({
   onClick,
   disabled,
 }: NetworkListItemProps) => {
-  return (
+  const { t } = useTranslation();
+
+  const listItem = (
     <ListItem
       onClick={disabled ? undefined : onClick}
       disabled={disabled}
       aria-disabled={disabled || undefined}
       data-testid={`network-item-name-${currency.name}`}
       className="-outline-offset-2"
+      aria-hidden={disabled || undefined}
     >
       <ListItemLeading>
         <SquaredCryptoIcon size={48} ledgerId={currency.id} ticker={currency.ticker} />
@@ -51,5 +58,28 @@ export const NetworkListItem = ({
       </ListItemLeading>
       <ListItemTrailing>{rightElement}</ListItemTrailing>
     </ListItem>
+  );
+
+  if (!disabled) {
+    return listItem;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="block focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus"
+          tabIndex={0}
+          role="button"
+          aria-disabled
+          aria-label={currency.name}
+        >
+          {listItem}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>
+        {t("modularAssetDrawer.unsupportedNetworkTooltip", { network: currency.name })}
+      </TooltipContent>
+    </Tooltip>
   );
 };

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8838,6 +8838,8 @@
     "emptyAssetList": "No assets found",
     "selectAsset": "Select asset",
     "selectNetwork": "Select network",
+    "unsupportedAssetTooltip": "{{asset}} isn't supported yet.",
+    "unsupportedNetworkTooltip": "{{network}} network isn't supported yet.",
     "selectAccount": "Select account",
     "selectAccountPerpsTitle": "Select Hyperliquid account",
     "selectAccountPerpsDescription": "To fund your perps, you need a Hyperliquid account. Add one to continue.",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Focused ModularDialog Jest coverage verifies disabled asset and network rows expose their tooltip on click and keyboard focus while remaining unselectable.
- [x] **Impact of the changes:**
      QA should verify the asset and network selectors in Contacts: disabled rows display the matching tooltip above the row on hover, focus or click, eligible rows remain directly selectable, and disabled rows do not trigger a selection.

### 📝 Description

Disabled asset and network rows in the Desktop Modular Asset Dialog did not explain why they could not be selected.

This PR adds accessible Lumen tooltips for disabled rows, with dynamic English copy for unsupported assets and networks. It keeps the behavior in the reusable dialog used by Contacts and preserves the existing eligibility guards.

<img width="529" height="608" alt="image" src="https://github.com/user-attachments/assets/c94f0342-9bec-4f44-bd0f-4621d52d68f3" />
<img width="493" height="693" alt="image" src="https://github.com/user-attachments/assets/a750cd14-a2eb-4b6d-bf8b-a4a09f0c135f" />


### ❓ Context

- **JIRA or GitHub link**: Jira ticket to be created from the prepared content in this task.
- **Figma**: https://www.figma.com/design/9kuJiSsYpP9nImhPWXzWPF/Contacts-%E2%80%A2-Production?node-id=754-170037&m=dev

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
