### PR TITLE
[LWDM] fix(LIVE-36599): migrate coin-solana to getProgramAccountsV2

### DIFF
--- a/.changeset/LIVE-36599-solana-getprogramaccountsv2.md
+++ b/.changeset/LIVE-36599-solana-getprogramaccountsv2.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/coin-solana": patch
+"@ledgerhq/live-common": patch
+---
+
+Fix Solana account synchronization failing when the RPC provider deprioritizes stake
+account discovery. Stake accounts are now enumerated with the paginated
+getProgramAccountsV2, falling back to getProgramAccounts on endpoints that do not
+implement it (devnet, testnet and the local test validator run vanilla agave).

--- a/libs/coin-modules/coin-solana/src/logic/tests/helpers/msw-rpc.mock.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/helpers/msw-rpc.mock.ts
@@ -83,7 +83,13 @@ function invokeHandler(
 }
 
 export function rpcHandler(methodHandlers: RpcMethodHandlers) {
-  const handlers = methodHandlers as Record<string, (params: unknown[]) => unknown>;
+  const handlers = { ...methodHandlers } as Record<string, (params: unknown[]) => unknown>;
+  // Stake discovery asks for the paginated getProgramAccountsV2 (see
+  // network/chain/rpc/program-accounts.ts); serve the declared V1 result as a single page.
+  const programAccounts = handlers.getProgramAccounts;
+  if (programAccounts) {
+    handlers.getProgramAccountsV2 = params => ({ accounts: programAccounts(params) });
+  }
   return http.post(TEST_ENDPOINT, async ({ request }: { request: Request }) => {
     const body = (await request.json()) as RpcRequest | RpcRequest[];
 

--- a/libs/coin-modules/coin-solana/src/network/chain/index.test.ts
+++ b/libs/coin-modules/coin-solana/src/network/chain/index.test.ts
@@ -1,6 +1,8 @@
 import { NetworkError } from "../../errors";
 import { Config, getChainAPI } from ".";
-import { Connection, SendTransactionError } from "@solana/web3.js";
+import { Connection, PublicKey, SendTransactionError, StakeProgram } from "@solana/web3.js";
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
 
 jest.mock("@solana/web3.js", () => ({
   ...jest.requireActual("@solana/web3.js"),
@@ -8,6 +10,21 @@ jest.mock("@solana/web3.js", () => ({
 }));
 
 const FAKE_CONFIG: Config = { endpoint: "http://fake-endpoint.com" };
+const FIRST_STAKE_ACCOUNT = "FirstStakeAccountPubkey11111111111111111111";
+const SECOND_STAKE_ACCOUNT = "SecondStakeAccountPubkey1111111111111111111";
+const stakeAccount = (pubkey: string) => ({
+  pubkey,
+  account: {
+    lamports: 1000,
+    owner: StakeProgram.programId.toBase58(),
+    executable: false,
+    rentEpoch: 0,
+    space: 200,
+    data: { program: "stake", parsed: { type: "uninitialized" }, space: 200 },
+  },
+});
+const rpcJson = (payload: Record<string, unknown>) =>
+  HttpResponse.json({ jsonrpc: "2.0", id: 1, ...payload });
 
 describe("index", () => {
   beforeEach(() => {
@@ -69,6 +86,84 @@ describe("index", () => {
           });
           expect(mockedConfirmTransaction).not.toHaveBeenCalled();
         }
+      });
+    });
+
+    describe("getStakeAccountsByWithdrawAuth", () => {
+      const mockServer = setupServer();
+      const authAddr = "AuthorityAddress111111111111111111111111111";
+      const filters = [{ memcmp: { offset: 44, bytes: authAddr } }];
+
+      beforeAll(() => mockServer.listen({ onUnhandledRequest: "error" }));
+      afterEach(() => mockServer.resetHandlers());
+      afterAll(() => mockServer.close());
+
+      it("follows getProgramAccountsV2 pagination", async () => {
+        const cursors: unknown[] = [];
+        mockServer.use(
+          http.post(FAKE_CONFIG.endpoint, async ({ request }) => {
+            const { params } = (await request.json()) as {
+              params: [string, { paginationKey?: string }];
+            };
+            cursors.push(params[1].paginationKey);
+            return params[1].paginationKey
+              ? rpcJson({
+                  result: { accounts: [stakeAccount(SECOND_STAKE_ACCOUNT)] },
+                })
+              : rpcJson({
+                  result: {
+                    accounts: [stakeAccount(FIRST_STAKE_ACCOUNT)],
+                    paginationKey: "page-2-cursor",
+                  },
+                });
+          }),
+        );
+
+        const result = await getChainAPI(FAKE_CONFIG).getStakeAccountsByWithdrawAuth(authAddr);
+
+        expect(result.map(({ pubkey }) => pubkey.toBase58())).toEqual([
+          FIRST_STAKE_ACCOUNT,
+          SECOND_STAKE_ACCOUNT,
+        ]);
+        // Only the cursor ends the pagination, so it has to be sent back as-is.
+        expect(cursors).toEqual([undefined, "page-2-cursor"]);
+        // The raw RPC sends base58 strings where web3.js parses PublicKeys, so both
+        // paths have to agree on the shape.
+        expect(result[0].account.owner).toBeInstanceOf(PublicKey);
+      });
+
+      it("maps an RPC error to a NetworkError", async () => {
+        mockServer.use(
+          http.post(FAKE_CONFIG.endpoint, () =>
+            rpcJson({
+              error: { code: -32005, message: "Request deprioritized" },
+            }),
+          ),
+        );
+
+        await expect(
+          getChainAPI(FAKE_CONFIG).getStakeAccountsByWithdrawAuth(authAddr),
+        ).rejects.toBeInstanceOf(NetworkError);
+      });
+
+      it("falls back to getProgramAccounts when the endpoint has no V2 method", async () => {
+        // devnet, testnet and the local test validator run vanilla agave, which does
+        // not implement getProgramAccountsV2.
+        const v1Accounts = [{ pubkey: new PublicKey(FIRST_STAKE_ACCOUNT), account: {} }];
+        const getParsedProgramAccounts = jest.fn().mockResolvedValue(v1Accounts);
+        jest
+          .mocked(Connection)
+          .mockImplementation(() => ({ getParsedProgramAccounts }) as unknown as Connection);
+        mockServer.use(
+          http.post(FAKE_CONFIG.endpoint, () =>
+            rpcJson({ error: { code: -32601, message: "Method not found" } }),
+          ),
+        );
+
+        const result = await getChainAPI(FAKE_CONFIG).getStakeAccountsByWithdrawAuth(authAddr);
+
+        expect(result).toBe(v1Accounts);
+        expect(getParsedProgramAccounts).toHaveBeenCalledWith(StakeProgram.programId, { filters });
       });
     });
   });

--- a/libs/coin-modules/coin-solana/src/network/chain/index.ts
+++ b/libs/coin-modules/coin-solana/src/network/chain/index.ts
@@ -28,6 +28,7 @@ import {
 } from "@solana/web3.js";
 import ky from "ky";
 import { getTokenAccountProgramId } from "../../helpers/token";
+import { paginatedProgramAccounts } from "./rpc/program-accounts";
 import { Awaited } from "../../logic";
 import { SolanaTokenProgram } from "../../types";
 
@@ -56,10 +57,6 @@ export type ChainAPI = Readonly<{
   getParsedToken2022AccountsByOwner: (
     address: string,
   ) => ReturnType<Connection["getParsedTokenAccountsByOwner"]>;
-
-  getStakeAccountsByStakeAuth: (
-    authAddr: string,
-  ) => ReturnType<Connection["getParsedProgramAccounts"]>;
 
   getStakeAccountsByWithdrawAuth: (
     authAddr: string,
@@ -178,6 +175,13 @@ export function getChainAPI(
     confirmTransactionInitialTimeout: getEnv("SOLANA_TX_CONFIRMATION_TIMEOUT") || 0,
   });
 
+  const programAccounts = paginatedProgramAccounts(
+    connection,
+    config.endpoint,
+    kyNoTimeout,
+    logger,
+  );
+
   return {
     getBalance: (address: string) =>
       connection.getBalance(new PublicKey(address)).catch(remapErrors),
@@ -208,21 +212,8 @@ export function getChainAPI(
         })
         .catch(remapErrors),
 
-    getStakeAccountsByStakeAuth: (authAddr: string) =>
-      connection
-        .getParsedProgramAccounts(StakeProgram.programId, {
-          filters: [
-            {
-              memcmp: {
-                offset: 12,
-                bytes: authAddr,
-              },
-            },
-          ],
-        })
-        .catch(remapErrors),
     getStakeAccountsByWithdrawAuth: (authAddr: string) =>
-      connection
+      programAccounts
         .getParsedProgramAccounts(StakeProgram.programId, {
           filters: [
             {

--- a/libs/coin-modules/coin-solana/src/network/chain/rpc/program-accounts.ts
+++ b/libs/coin-modules/coin-solana/src/network/chain/rpc/program-accounts.ts
@@ -1,0 +1,104 @@
+import { Connection, GetProgramAccountsFilter, PublicKey } from "@solana/web3.js";
+import type { KyInstance } from "ky";
+
+type ParsedProgramAccounts = Awaited<ReturnType<Connection["getParsedProgramAccounts"]>>;
+
+type ParsedAccount = ParsedProgramAccounts[number]["account"];
+
+// Same entries as V1, except the raw RPC hands back base58 strings where web3.js
+// parses PublicKeys.
+type RawAccount = {
+  pubkey: string;
+  account: Omit<ParsedAccount, "owner"> & { owner: string };
+};
+
+type V2Response =
+  | {
+      result: {
+        accounts: RawAccount[];
+        // absent on agave, null on Helius, a cursor while more pages remain
+        paginationKey?: string | null;
+      };
+      error?: undefined;
+    }
+  | { result?: undefined; error: { code: number; message: string } };
+
+// https://www.jsonrpc.org/specification#error_object
+const METHOD_NOT_FOUND = -32601;
+
+// Bounded because our ky instance has no timeout: an endpoint stuck on the same cursor
+// would otherwise hang the sync forever. Raise it if a legitimate account ever hits it.
+const MAX_PAGES = 100;
+
+/**
+ * Paginated drop-in for `Connection.getParsedProgramAccounts`.
+ *
+ * Helius deprioritizes large getProgramAccounts requests and wants the paginated
+ * getProgramAccountsV2 instead, but V2 is a Helius extension rather than standard Solana
+ * RPC: vanilla agave answers -32601, which covers devnet and testnet (clusterApiUrl, see
+ * endpointByCurrencyId), the coin tester's local validator, and any provider we fail over
+ * to through the remotely configurable rpcUrls. So we try V2 and fall back to V1.
+ * web3.js has no helper for V2, hence the raw JSON-RPC call.
+ *
+ * @see https://www.helius.dev/docs/api-reference/rpc/http/getprogramaccountsv2
+ */
+export const paginatedProgramAccounts = (
+  connection: Connection,
+  endpoint: string,
+  http: KyInstance,
+  logger?: (url: string, options: unknown) => void,
+) => ({
+  getParsedProgramAccounts: async (
+    programId: PublicKey,
+    { filters }: { filters: GetProgramAccountsFilter[] },
+  ): Promise<ParsedProgramAccounts> => {
+    const accounts: ParsedProgramAccounts = [];
+    let paginationKey: string | undefined;
+
+    for (let page = 0; page < MAX_PAGES; page++) {
+      const body = {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "getProgramAccountsV2",
+        params: [
+          programId.toBase58(),
+          {
+            encoding: "jsonParsed",
+            // Connection is built with "confirmed"; keep the raw call consistent.
+            commitment: "confirmed",
+            limit: 1000, // Helius recommends 1000-5000; one page covers any real account
+            filters,
+            paginationKey, // dropped from the JSON while undefined
+          },
+        ],
+      };
+      // Connection requests are logged through fetchMiddleware; mirror it here so this
+      // raw call still shows up in the network log (see bridge/js.ts httpRequestLogger).
+      logger?.(endpoint, { method: "POST", body: JSON.stringify(body) });
+
+      const { result, error }: V2Response = await http.post(endpoint, { json: body }).json();
+
+      if (error) {
+        // No V2 here, and V1 returns the whole set in one call.
+        if (error.code === METHOD_NOT_FOUND)
+          return connection.getParsedProgramAccounts(programId, { filters });
+        throw new Error(error.message);
+      }
+
+      accounts.push(
+        ...result.accounts.map(({ pubkey, account }) => ({
+          pubkey: new PublicKey(pubkey),
+          account: { ...account, owner: new PublicKey(account.owner) },
+        })),
+      );
+
+      // Filtering can empty a page while more remain, so the cursor is the only
+      // end-of-pagination signal.
+      paginationKey = result.paginationKey ?? undefined;
+      if (!paginationKey) return accounts;
+    }
+
+    // Never truncate silently: a partial stake list would under-report the balance.
+    throw new Error(`getProgramAccountsV2 exceeded ${MAX_PAGES} pages`);
+  },
+});

--- a/libs/ledger-live-common/src/families/solana/bridge/mock-data.ts
+++ b/libs/ledger-live-common/src/families/solana/bridge/mock-data.ts
@@ -47,11 +47,6 @@ export const getMockedMethods = (): {
     answer: { context: { slot: 131414879 }, value: 83389840 },
   },
   {
-    method: "getStakeAccountsByStakeAuth",
-    params: ["AQbkEagmPgmsdAfS4X8V8UyJnXXjVPMvjeD15etqQ3Jh"],
-    answer: [],
-  },
-  {
     method: "getStakeAccountsByWithdrawAuth",
     params: ["AQbkEagmPgmsdAfS4X8V8UyJnXXjVPMvjeD15etqQ3Jh"],
     answer: [],
@@ -375,11 +370,6 @@ export const getMockedMethods = (): {
     method: "getBalanceAndContext",
     params: ["6rEgdtB3sgjKJnRE172YEr9z6qUyr4nFW28vJokuD36A"],
     answer: { context: { slot: 131414902 }, value: 0 },
-  },
-  {
-    method: "getStakeAccountsByStakeAuth",
-    params: ["6rEgdtB3sgjKJnRE172YEr9z6qUyr4nFW28vJokuD36A"],
-    answer: [],
   },
   {
     method: "getStakeAccountsByWithdrawAuth",


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

The RPC provider now rejects getProgramAccounts for the stake program with a "Request deprioritized" error, recommending getProgramAccountsV2 with pagination. This migrates stake account discovery to that paginated call and stops a stake-discovery failure from rejecting the whole account sync Promise.all in coin-solana synchronization.

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-36599
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
