### PR TITLE
[LWDM] fix(coin-casper): wire craftTransactionData via framework (LIVE-36398)

### DIFF
--- a/.changeset/fair-pears-attack.md
+++ b/.changeset/fair-pears-attack.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-casper": patch
+---
+
+Wire craftTransactionData to the framework's generic implementation; Casper carries no transaction data, so it returns `{ type: "none" }` instead of throwing.

--- a/libs/coin-modules/coin-casper/src/api/index.test.ts
+++ b/libs/coin-modules/coin-casper/src/api/index.test.ts
@@ -1,9 +1,5 @@
 import type { Balance, TransactionIntent } from "@ledgerhq/coin-module-framework/api/index";
-import {
-  isNotSupportedStub,
-  requiredApiKeys,
-  withDefaults,
-} from "@ledgerhq/coin-module-framework/api/index";
+import { requiredApiKeys, withDefaults } from "@ledgerhq/coin-module-framework/api/index";
 import { CASPER_FEES_MOTES } from "../constants";
 import { TEST_ADDRESSES } from "../__tests__/fixtures/addresses.fixture";
 import type { CasperContext, CasperMemo } from "../types";
@@ -56,12 +52,6 @@ describe("createApi", () => {
     }
   });
 
-  // `craftTransactionData` is the one unsupported method the contract requires, so it cannot
-  // be omitted — it stays declared, and stays visible for what it is.
-  it("declares craftTransactionData as unsupported", () => {
-    expect(isNotSupportedStub(api.craftTransactionData)).toBe(true);
-  });
-
   describe("validateIntent", () => {
     it("validates a send intent through the api surface", async () => {
       const result = await api.validateIntent(context, sendIntent, balances, {
@@ -96,6 +86,12 @@ describe("createApi", () => {
   describe("getNextSequence", () => {
     it("resolves to 0n instead of throwing, as Casper has no account nonce", async () => {
       await expect(api.getNextSequence(context, validEd25519)).resolves.toBe(0n);
+    });
+  });
+
+  describe("craftTransactionData", () => {
+    it("reports no transaction data — Casper carries none, the transfer id travels on the intent memo", () => {
+      expect(api.craftTransactionData(context, sendIntent)).toEqual({ type: "none" });
     });
   });
 });

--- a/libs/coin-modules/coin-casper/src/api/index.ts
+++ b/libs/coin-modules/coin-casper/src/api/index.ts
@@ -3,8 +3,8 @@ import type {
   BalanceOptions,
   CoinModuleImpl,
 } from "@ledgerhq/coin-module-framework/api/index";
-import { notSupported } from "@ledgerhq/coin-module-framework/api/index";
 import { rejectBalanceOptions } from "@ledgerhq/coin-module-framework/api/getBalance/rejectBalanceOptions";
+import { craftTransactionData } from "@ledgerhq/coin-module-framework/logic/craftTransactionData";
 import { broadcast } from "../logic/broadcast";
 import { combine } from "../logic/combine";
 import { craftTransaction } from "../logic/craftTransaction";
@@ -16,14 +16,8 @@ import { validateIntent } from "../logic/validateIntent";
 import { validateAddress } from "../bridge/validateAddress";
 import type { CasperConfig, CasperContext, CasperMemo } from "../types";
 
-// The caller builds the {@link CasperContext} (config + logger) and passes it to each method (ADR-019).
-//
-// Casper supports everything the contract requires but `craftTransactionData`, so it declares
-// the authoring type and omits its unsupported *capabilities* — block queries, `call`,
-// `register`, staking and raw crafting — rather than stubbing each one. That distinction is
-// the point: eight omissions are capabilities this chain does not expose, while the stub
-// below is a required method this module does not implement, which the type will not let us
-// omit and which therefore stays visible here.
+// ADR-019: caller builds {@link CasperContext} and passes it to each method.
+// `satisfies` (not `as`) preserves the concrete return types of each method for callers.
 export function createApi() {
   return {
     lastBlock,
@@ -46,6 +40,6 @@ export function createApi() {
     // per-account nonce, so getNextSequence has no meaningful value here.
     getNextSequence: async (_context: CasperContext, _address: string) => 0n,
     validateAddress: (_context, address, parameters) => validateAddress(address, parameters),
-    craftTransactionData: notSupported("craftTransactionData"),
+    craftTransactionData: (_context, intent) => craftTransactionData(intent),
   } satisfies CoinModuleImpl<CasperConfig, CasperMemo>;
 }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Wire craftTransactionData to the framework's generic implementation; Casper carries no transaction data, so it returns `{ type: "none" }` instead of throwing

### 🔗 Context

https://ledgerhq.atlassian.net/browse/LIVE-36398
