### PR TITLE
fix(contacts): reduce mobile list bottom spacing

### DIFF
--- a/.changeset/fresh-contacts-spacing.md
+++ b/.changeset/fresh-contacts-spacing.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts-list": patch
+---
+
+Keep consistent spacing after the last mobile contact.

--- a/features/flow/flow-contacts-list/src/ContactsListView.native.tsx
+++ b/features/flow/flow-contacts-list/src/ContactsListView.native.tsx
@@ -86,7 +86,7 @@ export function ContactsListView({
           contentContainerStyle={{
             paddingHorizontal: 16,
             paddingTop: 8,
-            paddingBottom: 24,
+            paddingBottom: 8,
           }}
           showsVerticalScrollIndicator={false}
           keyboardDismissMode="on-drag"


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Existing Contacts flow and Mobile integration suites pass; no test was added or modified.
- [x] **Impact of the changes:**
      Mobile Contacts lists now retain 8 px below the final contact, matching the section rhythm.

### 📝 Description

The mobile Contacts SectionList added 24 px after its final item, making the last contact appear to have extra spacing.

This PR reduces the terminal padding to 8 px. No contact row or section-header spacing changes.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-36638

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)