### PR TITLE
[LWM] feat(contacts): explain unavailable currency options (LIVE-36641)

### DIFF
--- a/.changeset/quiet-disabled-tooltips.md
+++ b/.changeset/quiet-disabled-tooltips.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Explain unavailable assets and networks in Contacts currency selection

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -9730,6 +9730,14 @@
     "accountCount_other": "{{count}} accounts",
     "emptyAccounts": "You don't have {{network}} accounts yet. Please add one to continue",
     "addAccount": "Add account",
+    "unsupportedAssetTooltip": {
+      "title": "{{asset}} isn't supported yet",
+      "description": "You can't add a {{asset}} address to your contacts yet. We're adding more cryptos over time."
+    },
+    "unsupportedNetworkTooltip": {
+      "title": "{{network}} Network isn't supported yet",
+      "description": "You can't select {{network}} network for {{asset}}. We're adding more networks over time."
+    },
     "errors": {
       "title": "Connection failed",
       "backend": "Something went wrong on our end. Please try again later",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -9730,11 +9730,11 @@
     "accountCount_other": "{{count}} accounts",
     "emptyAccounts": "You don't have {{network}} accounts yet. Please add one to continue",
     "addAccount": "Add account",
-    "unsupportedAssetTooltip": {
+    "unsupportedAssetExplanation": {
       "title": "{{asset}} isn't supported yet",
       "description": "You can't add a {{asset}} address to your contacts yet. We're adding more cryptos over time."
     },
-    "unsupportedNetworkTooltip": {
+    "unsupportedNetworkExplanation": {
       "title": "{{network}} Network isn't supported yet",
       "description": "You can't select {{network}} network for {{asset}}. We're adding more networks over time."
     },

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -888,7 +888,7 @@ describe("Contacts integration", () => {
 
     await user.press(screen.getByTestId("contacts-detail-add-address"));
 
-    const bitcoinAsset = await screen.findByTestId("asset-item-tooltip-BTC");
+    const bitcoinAsset = await screen.findByTestId("asset-item-explanation-BTC");
     const tetherAsset = screen.getByTestId("asset-item-USDT");
     expect(bitcoinAsset).toBeEnabled();
     expect(tetherAsset).toBeEnabled();
@@ -918,7 +918,7 @@ describe("Contacts integration", () => {
 
     await user.press(tetherAsset);
 
-    const solanaNetwork = await screen.findByTestId("network-item-tooltip-Solana");
+    const solanaNetwork = await screen.findByTestId("network-item-explanation-Solana");
     const ethereumNetwork = screen.getByTestId("network-item-Ethereum");
     expect(solanaNetwork).toBeEnabled();
     expect(ethereumNetwork).toBeEnabled();

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -888,24 +888,65 @@ describe("Contacts integration", () => {
 
     await user.press(screen.getByTestId("contacts-detail-add-address"));
 
-    const bitcoinAsset = await screen.findByTestId("asset-item-BTC");
+    const bitcoinAsset = await screen.findByTestId("asset-item-tooltip-BTC");
     const tetherAsset = screen.getByTestId("asset-item-USDT");
-    expect(bitcoinAsset).toBeDisabled();
+    expect(bitcoinAsset).toBeEnabled();
     expect(tetherAsset).toBeEnabled();
+
+    await user.press(bitcoinAsset);
+
+    await waitFor(() => {
+      expect(screen.getByText("Bitcoin isn't supported yet")).toBeVisible();
+      expect(
+        screen.getByText(
+          "You can't add a Bitcoin address to your contacts yet. We're adding more cryptos over time.",
+        ),
+      ).toBeVisible();
+    });
+    expect(screen.queryByTestId("contacts-add-address-input")).toBeNull();
+
+    await user.press(screen.getByRole("button", { name: "Got it" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Bitcoin isn't supported yet")).toBeNull();
+    });
+    expect(
+      screen.getByLabelText("Bitcoin isn't supported yet", {
+        exact: true,
+      }),
+    ).toBeVisible();
 
     await user.press(tetherAsset);
 
-    const solanaNetwork = await screen.findByTestId("network-item-Solana");
+    const solanaNetwork = await screen.findByTestId("network-item-tooltip-Solana");
     const ethereumNetwork = screen.getByTestId("network-item-Ethereum");
-    expect(solanaNetwork).toBeDisabled();
+    expect(solanaNetwork).toBeEnabled();
     expect(ethereumNetwork).toBeEnabled();
+
+    await user.press(solanaNetwork);
+
+    await waitFor(() => {
+      expect(screen.getByText("Solana Network isn't supported yet")).toBeVisible();
+      expect(
+        screen.getByText(
+          "You can't select Solana network for Tether USD. We're adding more networks over time.",
+        ),
+      ).toBeVisible();
+    });
+    expect(screen.queryByTestId("contacts-add-address-input")).toBeNull();
+
+    await user.press(screen.getByRole("button", { name: "Got it" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Solana Network isn't supported yet")).toBeNull();
+    });
 
     await user.press(ethereumNetwork);
 
     await waitFor(() => {
       expect(screen.getByTestId("contacts-add-address-input")).toBeVisible();
     });
-  });
+  }, 10_000);
 
   it("should return to currency selection without removing the contact detail route", async () => {
     const { user } = render(<ContactDetailAddressEntryTestApp />, {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
@@ -68,12 +68,12 @@ export function useContactsCurrencySelectionAdapter({
   const disabledItemsExplanation = useMemo<DisabledItemsExplanation>(
     () => ({
       asset: assetName => ({
-        title: t("modularDrawer.unsupportedAssetTooltip.title", { asset: assetName }),
-        content: t("modularDrawer.unsupportedAssetTooltip.description", { asset: assetName }),
+        title: t("modularDrawer.unsupportedAssetExplanation.title", { asset: assetName }),
+        content: t("modularDrawer.unsupportedAssetExplanation.description", { asset: assetName }),
       }),
       network: (networkName, assetName) => ({
-        title: t("modularDrawer.unsupportedNetworkTooltip.title", { network: networkName }),
-        content: t("modularDrawer.unsupportedNetworkTooltip.description", {
+        title: t("modularDrawer.unsupportedNetworkExplanation.title", { network: networkName }),
+        content: t("modularDrawer.unsupportedNetworkExplanation.description", {
           network: networkName,
           asset: assetName,
         }),

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
@@ -1,9 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ContactCurrencyIdSchema } from "@domain/entity-contact";
 import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import type { AddAddressCurrencySelection } from "@features/flow-contacts-add-address";
 import { ScreenName } from "~/const";
+import { useTranslation } from "~/context/Locale";
 import {
+  type DisabledItemsTooltip,
+  type DisabledItemTooltip,
   type ModularDrawerFlowProps,
   useModularDrawerController,
 } from "LLM/features/ModularDrawer";
@@ -24,6 +27,8 @@ type UseContactsCurrencySelectionAdapterOptions = Readonly<{
 
 export type ContactsCurrencySelectionAdapter = Readonly<{
   flowProps: Omit<ModularDrawerFlowProps, "children">;
+  unsupportedItemTooltip: DisabledItemTooltip | null;
+  dismissUnsupportedItemTooltip: () => void;
 }>;
 
 function resolveContactCurrencySelection(
@@ -44,6 +49,10 @@ export function useContactsCurrencySelectionAdapter({
   onCurrencySelected,
   onSelectionCancelled,
 }: UseContactsCurrencySelectionAdapterOptions): ContactsCurrencySelectionAdapter {
+  const { t } = useTranslation();
+  const [unsupportedItemTooltip, setUnsupportedItemTooltip] = useState<DisabledItemTooltip | null>(
+    null,
+  );
   const selectionStartedRef = useRef(false);
   const closeDrawerRef = useRef<() => void>(() => undefined);
   const {
@@ -57,6 +66,23 @@ export function useContactsCurrencySelectionAdapter({
     uiUseCase,
     useCase,
   } = useModularDrawerController();
+  const disabledItemsTooltip = useMemo<DisabledItemsTooltip>(
+    () => ({
+      asset: assetName => ({
+        title: t("modularDrawer.unsupportedAssetTooltip.title", { asset: assetName }),
+        content: t("modularDrawer.unsupportedAssetTooltip.description", { asset: assetName }),
+      }),
+      network: (networkName, assetName) => ({
+        title: t("modularDrawer.unsupportedNetworkTooltip.title", { network: networkName }),
+        content: t("modularDrawer.unsupportedNetworkTooltip.description", {
+          network: networkName,
+          asset: assetName,
+        }),
+      }),
+      onPress: setUnsupportedItemTooltip,
+    }),
+    [t],
+  );
   const completeSelection = useCallback(
     (currency: CryptoOrTokenCurrency | null) => {
       const selection = resolveContactCurrencySelection(currency);
@@ -86,6 +112,7 @@ export function useContactsCurrencySelectionAdapter({
   useEffect(() => {
     if (!isOpen) {
       selectionStartedRef.current = false;
+      setUnsupportedItemTooltip(null);
       return;
     }
     if (selectionStartedRef.current) {
@@ -117,6 +144,7 @@ export function useContactsCurrencySelectionAdapter({
       uiUseCase,
       useCase,
       selectableNetworkIds: networkIds,
+      disabledItemsTooltip,
     }),
     [
       areCurrenciesFiltered,
@@ -128,8 +156,11 @@ export function useContactsCurrencySelectionAdapter({
       preselectedCurrencies,
       uiUseCase,
       useCase,
+      disabledItemsTooltip,
     ],
   );
 
-  return { flowProps };
+  const dismissUnsupportedItemTooltip = useCallback(() => setUnsupportedItemTooltip(null), []);
+
+  return { flowProps, unsupportedItemTooltip, dismissUnsupportedItemTooltip };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
@@ -5,8 +5,8 @@ import type { AddAddressCurrencySelection } from "@features/flow-contacts-add-ad
 import { ScreenName } from "~/const";
 import { useTranslation } from "~/context/Locale";
 import {
-  type DisabledItemsTooltip,
-  type DisabledItemTooltip,
+  type DisabledItemsExplanation,
+  type DisabledItemExplanation,
   type ModularDrawerFlowProps,
   useModularDrawerController,
 } from "LLM/features/ModularDrawer";
@@ -27,8 +27,8 @@ type UseContactsCurrencySelectionAdapterOptions = Readonly<{
 
 export type ContactsCurrencySelectionAdapter = Readonly<{
   flowProps: Omit<ModularDrawerFlowProps, "children">;
-  unsupportedItemTooltip: DisabledItemTooltip | null;
-  dismissUnsupportedItemTooltip: () => void;
+  unsupportedItemExplanation: DisabledItemExplanation | null;
+  dismissUnsupportedItemExplanation: () => void;
 }>;
 
 function resolveContactCurrencySelection(
@@ -50,9 +50,8 @@ export function useContactsCurrencySelectionAdapter({
   onSelectionCancelled,
 }: UseContactsCurrencySelectionAdapterOptions): ContactsCurrencySelectionAdapter {
   const { t } = useTranslation();
-  const [unsupportedItemTooltip, setUnsupportedItemTooltip] = useState<DisabledItemTooltip | null>(
-    null,
-  );
+  const [unsupportedItemExplanation, setUnsupportedItemExplanation] =
+    useState<DisabledItemExplanation | null>(null);
   const selectionStartedRef = useRef(false);
   const closeDrawerRef = useRef<() => void>(() => undefined);
   const {
@@ -66,7 +65,7 @@ export function useContactsCurrencySelectionAdapter({
     uiUseCase,
     useCase,
   } = useModularDrawerController();
-  const disabledItemsTooltip = useMemo<DisabledItemsTooltip>(
+  const disabledItemsExplanation = useMemo<DisabledItemsExplanation>(
     () => ({
       asset: assetName => ({
         title: t("modularDrawer.unsupportedAssetTooltip.title", { asset: assetName }),
@@ -79,7 +78,7 @@ export function useContactsCurrencySelectionAdapter({
           asset: assetName,
         }),
       }),
-      onPress: setUnsupportedItemTooltip,
+      onPress: setUnsupportedItemExplanation,
     }),
     [t],
   );
@@ -112,7 +111,7 @@ export function useContactsCurrencySelectionAdapter({
   useEffect(() => {
     if (!isOpen) {
       selectionStartedRef.current = false;
-      setUnsupportedItemTooltip(null);
+      setUnsupportedItemExplanation(null);
       return;
     }
     if (selectionStartedRef.current) {
@@ -144,7 +143,7 @@ export function useContactsCurrencySelectionAdapter({
       uiUseCase,
       useCase,
       selectableNetworkIds: networkIds,
-      disabledItemsTooltip,
+      disabledItemsExplanation,
     }),
     [
       areCurrenciesFiltered,
@@ -156,11 +155,14 @@ export function useContactsCurrencySelectionAdapter({
       preselectedCurrencies,
       uiUseCase,
       useCase,
-      disabledItemsTooltip,
+      disabledItemsExplanation,
     ],
   );
 
-  const dismissUnsupportedItemTooltip = useCallback(() => setUnsupportedItemTooltip(null), []);
+  const dismissUnsupportedItemExplanation = useCallback(
+    () => setUnsupportedItemExplanation(null),
+    [],
+  );
 
-  return { flowProps, unsupportedItemTooltip, dismissUnsupportedItemTooltip };
+  return { flowProps, unsupportedItemExplanation, dismissUnsupportedItemExplanation };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/ContactsAddAddressFlowDrawerView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/ContactsAddAddressFlowDrawerView.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { ModularDrawerFlow } from "LLM/features/ModularDrawer";
 import { ContactsAddAddressFlowDrawerContent } from "./ContactsAddAddressFlowDrawerContent";
 import type { ContactsAddAddressFlowDrawerViewModel } from "./useContactsAddAddressFlowDrawerViewModel";
-import { UnsupportedSelectionTooltipSheet } from "./UnsupportedSelectionTooltipSheet";
+import { UnsupportedSelectionSheet } from "./UnsupportedSelectionSheet";
 
 export function ContactsAddAddressFlowDrawerView(
   viewModel: ContactsAddAddressFlowDrawerViewModel,
@@ -17,9 +17,9 @@ export function ContactsAddAddressFlowDrawerView(
           />
         )}
       </ModularDrawerFlow>
-      <UnsupportedSelectionTooltipSheet
-        tooltip={viewModel.currencySelection.unsupportedItemTooltip}
-        onClose={viewModel.currencySelection.dismissUnsupportedItemTooltip}
+      <UnsupportedSelectionSheet
+        explanation={viewModel.currencySelection.unsupportedItemExplanation}
+        onClose={viewModel.currencySelection.dismissUnsupportedItemExplanation}
       />
     </>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/ContactsAddAddressFlowDrawerView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/ContactsAddAddressFlowDrawerView.tsx
@@ -2,15 +2,25 @@ import React from "react";
 import { ModularDrawerFlow } from "LLM/features/ModularDrawer";
 import { ContactsAddAddressFlowDrawerContent } from "./ContactsAddAddressFlowDrawerContent";
 import type { ContactsAddAddressFlowDrawerViewModel } from "./useContactsAddAddressFlowDrawerViewModel";
+import { UnsupportedSelectionTooltipSheet } from "./UnsupportedSelectionTooltipSheet";
 
 export function ContactsAddAddressFlowDrawerView(
   viewModel: ContactsAddAddressFlowDrawerViewModel,
 ): React.JSX.Element {
   return (
-    <ModularDrawerFlow {...viewModel.currencySelection.flowProps}>
-      {currencyShell => (
-        <ContactsAddAddressFlowDrawerContent viewModel={viewModel} currencyShell={currencyShell} />
-      )}
-    </ModularDrawerFlow>
+    <>
+      <ModularDrawerFlow {...viewModel.currencySelection.flowProps}>
+        {currencyShell => (
+          <ContactsAddAddressFlowDrawerContent
+            viewModel={viewModel}
+            currencyShell={currencyShell}
+          />
+        )}
+      </ModularDrawerFlow>
+      <UnsupportedSelectionTooltipSheet
+        tooltip={viewModel.currencySelection.unsupportedItemTooltip}
+        onClose={viewModel.currencySelection.dismissUnsupportedItemTooltip}
+      />
+    </>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/UnsupportedSelectionSheet.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/UnsupportedSelectionSheet.tsx
@@ -10,31 +10,31 @@ import {
   useBottomSheetRef,
 } from "@ledgerhq/lumen-ui-rnative";
 import { InformationFill } from "@ledgerhq/lumen-ui-rnative/symbols";
-import type { DisabledItemTooltip } from "LLM/features/ModularDrawer";
+import type { DisabledItemExplanation } from "LLM/features/ModularDrawer";
 import { BottomSheetInfoGradient } from "LLM/components/BottomSheetGradient";
 import { useTranslation } from "~/context/Locale";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 type Props = Readonly<{
-  tooltip: DisabledItemTooltip | null;
+  explanation: DisabledItemExplanation | null;
   onClose: () => void;
 }>;
 
-export function UnsupportedSelectionTooltipSheet({ tooltip, onClose }: Props): React.JSX.Element {
+export function UnsupportedSelectionSheet({ explanation, onClose }: Props): React.JSX.Element {
   const { t } = useTranslation();
   const { bottom: bottomInset } = useSafeAreaInsets();
   const bottomSheetRef = useBottomSheetRef();
   const isClosingRef = useRef(true);
 
   useEffect(() => {
-    if (tooltip) {
+    if (explanation) {
       isClosingRef.current = false;
       bottomSheetRef.current?.present();
     } else {
       isClosingRef.current = true;
       bottomSheetRef.current?.dismiss();
     }
-  }, [bottomSheetRef, tooltip]);
+  }, [bottomSheetRef, explanation]);
 
   const handleClose = useCallback(() => {
     if (isClosingRef.current) return;
@@ -54,19 +54,19 @@ export function UnsupportedSelectionTooltipSheet({ tooltip, onClose }: Props): R
       backgroundComponent={BottomSheetInfoGradient}
       onClose={handleClose}
       enablePanDownToClose
-      testID="contacts-unsupported-selection-tooltip"
+      testID="contacts-unsupported-selection-sheet"
     >
-      {tooltip ? (
+      {explanation ? (
         <BottomSheetView style={{ paddingBottom: bottomInset + 24 }}>
           <BottomSheetHeader density="compact" />
           <Box lx={{ alignItems: "center", gap: "s24", paddingHorizontal: "s16" }}>
             <Spot appearance="icon" icon={InformationFill} size={56} />
             <Box lx={{ alignItems: "center", gap: "s8" }}>
               <Text typography="heading3SemiBold" lx={{ color: "base", textAlign: "center" }}>
-                {tooltip.title}
+                {explanation.title}
               </Text>
               <Text typography="body2" lx={{ color: "muted", textAlign: "center" }}>
-                {tooltip.content}
+                {explanation.content}
               </Text>
             </Box>
             <Button appearance="base" size="lg" isFull onPress={handleClose}>

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/UnsupportedSelectionTooltipSheet.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/UnsupportedSelectionTooltipSheet.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import {
   BottomSheet,
   BottomSheetHeader,
@@ -24,16 +24,22 @@ export function UnsupportedSelectionTooltipSheet({ tooltip, onClose }: Props): R
   const { t } = useTranslation();
   const { bottom: bottomInset } = useSafeAreaInsets();
   const bottomSheetRef = useBottomSheetRef();
+  const isClosingRef = useRef(true);
 
   useEffect(() => {
     if (tooltip) {
+      isClosingRef.current = false;
       bottomSheetRef.current?.present();
     } else {
+      isClosingRef.current = true;
       bottomSheetRef.current?.dismiss();
     }
   }, [bottomSheetRef, tooltip]);
 
   const handleClose = useCallback(() => {
+    if (isClosingRef.current) return;
+
+    isClosingRef.current = true;
     onClose();
     bottomSheetRef.current?.dismiss();
   }, [bottomSheetRef, onClose]);
@@ -46,7 +52,7 @@ export function UnsupportedSelectionTooltipSheet({ tooltip, onClose }: Props): R
       maxDynamicContentSize="fullWithOffset"
       backdropPressBehavior="close"
       backgroundComponent={BottomSheetInfoGradient}
-      onClose={onClose}
+      onClose={handleClose}
       enablePanDownToClose
       testID="contacts-unsupported-selection-tooltip"
     >

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/UnsupportedSelectionTooltipSheet.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/UnsupportedSelectionTooltipSheet.tsx
@@ -1,0 +1,72 @@
+import React, { useCallback, useEffect } from "react";
+import {
+  BottomSheet,
+  BottomSheetHeader,
+  BottomSheetView,
+  Box,
+  Button,
+  Spot,
+  Text,
+  useBottomSheetRef,
+} from "@ledgerhq/lumen-ui-rnative";
+import { InformationFill } from "@ledgerhq/lumen-ui-rnative/symbols";
+import type { DisabledItemTooltip } from "LLM/features/ModularDrawer";
+import { useTranslation } from "~/context/Locale";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+type Props = Readonly<{
+  tooltip: DisabledItemTooltip | null;
+  onClose: () => void;
+}>;
+
+export function UnsupportedSelectionTooltipSheet({ tooltip, onClose }: Props): React.JSX.Element {
+  const { t } = useTranslation();
+  const { bottom: bottomInset } = useSafeAreaInsets();
+  const bottomSheetRef = useBottomSheetRef();
+
+  useEffect(() => {
+    if (tooltip) {
+      bottomSheetRef.current?.present();
+    } else {
+      bottomSheetRef.current?.dismiss();
+    }
+  }, [bottomSheetRef, tooltip]);
+
+  const handleClose = useCallback(() => {
+    onClose();
+    bottomSheetRef.current?.dismiss();
+  }, [bottomSheetRef, onClose]);
+
+  return (
+    <BottomSheet
+      ref={bottomSheetRef}
+      snapPoints={null}
+      enableDynamicSizing
+      maxDynamicContentSize="fullWithOffset"
+      backdropPressBehavior="close"
+      onClose={onClose}
+      enablePanDownToClose
+      testID="contacts-unsupported-selection-tooltip"
+    >
+      {tooltip ? (
+        <BottomSheetView style={{ paddingBottom: bottomInset + 24 }}>
+          <BottomSheetHeader density="compact" />
+          <Box lx={{ alignItems: "center", gap: "s24", paddingHorizontal: "s16" }}>
+            <Spot appearance="icon" icon={InformationFill} size={56} />
+            <Box lx={{ alignItems: "center", gap: "s8" }}>
+              <Text typography="heading3SemiBold" lx={{ color: "base", textAlign: "center" }}>
+                {tooltip.title}
+              </Text>
+              <Text typography="body2" lx={{ color: "muted", textAlign: "center" }}>
+                {tooltip.content}
+              </Text>
+            </Box>
+            <Button appearance="base" size="lg" isFull onPress={handleClose}>
+              {t("common.gotit")}
+            </Button>
+          </Box>
+        </BottomSheetView>
+      ) : null}
+    </BottomSheet>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/UnsupportedSelectionTooltipSheet.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/UnsupportedSelectionTooltipSheet.tsx
@@ -11,6 +11,7 @@ import {
 } from "@ledgerhq/lumen-ui-rnative";
 import { InformationFill } from "@ledgerhq/lumen-ui-rnative/symbols";
 import type { DisabledItemTooltip } from "LLM/features/ModularDrawer";
+import { BottomSheetInfoGradient } from "LLM/components/BottomSheetGradient";
 import { useTranslation } from "~/context/Locale";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -44,6 +45,7 @@ export function UnsupportedSelectionTooltipSheet({ tooltip, onClose }: Props): R
       enableDynamicSizing
       maxDynamicContentSize="fullWithOffset"
       backdropPressBehavior="close"
+      backgroundComponent={BottomSheetInfoGradient}
       onClose={onClose}
       enablePanDownToClose
       testID="contacts-unsupported-selection-tooltip"

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawerFlow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawerFlow.tsx
@@ -13,6 +13,7 @@ import {
 import ModularDrawerFlowManager from "./ModularDrawerFlowManager";
 import { useAssets } from "./hooks/useAssets";
 import { useModularDrawerState } from "./hooks/useModularDrawerState";
+import type { DisabledItemsTooltip } from "./types";
 
 export type ModularDrawerFlowRenderProps = Readonly<{
   /** Existing Modular Drawer flow to render in the chosen presentation shell */
@@ -60,6 +61,8 @@ export type ModularDrawerFlowProps = Readonly<{
   areCurrenciesFiltered?: boolean;
   /** Network IDs that remain selectable while all MAD rows stay visible. */
   selectableNetworkIds?: readonly string[];
+  /** Optional explanations displayed when an unavailable asset or network is pressed. */
+  disabledItemsTooltip?: DisabledItemsTooltip;
 
   /** Renders the Modular Drawer flow inside a presentation shell */
   children: (props: ModularDrawerFlowRenderProps) => React.ReactNode;
@@ -79,6 +82,7 @@ export function ModularDrawerFlow({
   uiUseCase,
   areCurrenciesFiltered,
   selectableNetworkIds,
+  disabledItemsTooltip,
   children,
 }: ModularDrawerFlowProps): React.JSX.Element {
   const {
@@ -105,6 +109,7 @@ export function ModularDrawerFlow({
 
   const {
     accountCurrency,
+    selectedAssetName,
     handleAsset,
     handleNetwork,
     handleBackButton,
@@ -139,12 +144,17 @@ export function ModularDrawerFlow({
         assetsSorted,
         uiUseCase,
         selectableNetworkIds,
+        disabledAssetTooltip: disabledItemsTooltip?.asset,
+        onDisabledAssetPress: disabledItemsTooltip?.onPress,
       }}
       networksViewModel={{
         onNetworkSelected: handleNetwork,
         availableNetworks,
         networksConfiguration: networkConfigurationSanitized,
         selectableNetworkIds,
+        disabledNetworkTooltip: disabledItemsTooltip?.network,
+        onDisabledNetworkPress: disabledItemsTooltip?.onPress,
+        selectedAssetName,
       }}
       accountsViewModel={{
         onAddNewAccount,

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawerFlow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawerFlow.tsx
@@ -13,7 +13,7 @@ import {
 import ModularDrawerFlowManager from "./ModularDrawerFlowManager";
 import { useAssets } from "./hooks/useAssets";
 import { useModularDrawerState } from "./hooks/useModularDrawerState";
-import type { DisabledItemsTooltip } from "./types";
+import type { DisabledItemsExplanation } from "./types";
 
 export type ModularDrawerFlowRenderProps = Readonly<{
   /** Existing Modular Drawer flow to render in the chosen presentation shell */
@@ -62,7 +62,7 @@ export type ModularDrawerFlowProps = Readonly<{
   /** Network IDs that remain selectable while all MAD rows stay visible. */
   selectableNetworkIds?: readonly string[];
   /** Optional explanations displayed when an unavailable asset or network is pressed. */
-  disabledItemsTooltip?: DisabledItemsTooltip;
+  disabledItemsExplanation?: DisabledItemsExplanation;
 
   /** Renders the Modular Drawer flow inside a presentation shell */
   children: (props: ModularDrawerFlowRenderProps) => React.ReactNode;
@@ -82,7 +82,7 @@ export function ModularDrawerFlow({
   uiUseCase,
   areCurrenciesFiltered,
   selectableNetworkIds,
-  disabledItemsTooltip,
+  disabledItemsExplanation,
   children,
 }: ModularDrawerFlowProps): React.JSX.Element {
   const {
@@ -144,16 +144,16 @@ export function ModularDrawerFlow({
         assetsSorted,
         uiUseCase,
         selectableNetworkIds,
-        disabledAssetTooltip: disabledItemsTooltip?.asset,
-        onDisabledAssetPress: disabledItemsTooltip?.onPress,
+        disabledAssetExplanation: disabledItemsExplanation?.asset,
+        onDisabledAssetPress: disabledItemsExplanation?.onPress,
       }}
       networksViewModel={{
         onNetworkSelected: handleNetwork,
         availableNetworks,
         networksConfiguration: networkConfigurationSanitized,
         selectableNetworkIds,
-        disabledNetworkTooltip: disabledItemsTooltip?.network,
-        onDisabledNetworkPress: disabledItemsTooltip?.onPress,
+        disabledNetworkExplanation: disabledItemsExplanation?.network,
+        onDisabledNetworkPress: disabledItemsExplanation?.onPress,
         selectedAssetName,
       }}
       accountsViewModel={{

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerState.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerState.ts
@@ -209,6 +209,7 @@ export function useModularDrawerState({
 
   return {
     accountCurrency,
+    selectedAssetName: asset?.name,
     network,
     availableNetworks,
     shouldShowBackButton,

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/index.ts
@@ -1,14 +1,11 @@
 import { ModularDrawer } from "LLM/features/ModularDrawer/ModularDrawer";
-import {
-  ModularDrawerStep,
-  type DisabledItemsTooltip,
-  type DisabledItemTooltip,
-} from "LLM/features/ModularDrawer/types";
+import { ModularDrawerStep } from "LLM/features/ModularDrawer/types";
 import { useModularDrawerController } from "LLM/features/ModularDrawer/hooks/useModularDrawerController";
 import { ModularDrawerWrapper } from "LLM/features/ModularDrawer/ModularDrawerWrapper";
 import { ModularDrawerLocation } from "@ledgerhq/live-common/modularDrawer/enums";
 
 export { handleModularDrawerDeeplink } from "./handleModularDrawerDeeplink";
+export type { DisabledItemsTooltip, DisabledItemTooltip } from "./types";
 export {
   ModularDrawerFlow,
   type ModularDrawerFlowProps,
@@ -17,8 +14,6 @@ export {
 
 export {
   ModularDrawer,
-  type DisabledItemTooltip,
-  type DisabledItemsTooltip,
   ModularDrawerStep,
   useModularDrawerController,
   ModularDrawerWrapper,

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/index.ts
@@ -1,5 +1,9 @@
 import { ModularDrawer } from "LLM/features/ModularDrawer/ModularDrawer";
-import { ModularDrawerStep } from "LLM/features/ModularDrawer/types";
+import {
+  ModularDrawerStep,
+  type DisabledItemsTooltip,
+  type DisabledItemTooltip,
+} from "LLM/features/ModularDrawer/types";
 import { useModularDrawerController } from "LLM/features/ModularDrawer/hooks/useModularDrawerController";
 import { ModularDrawerWrapper } from "LLM/features/ModularDrawer/ModularDrawerWrapper";
 import { ModularDrawerLocation } from "@ledgerhq/live-common/modularDrawer/enums";
@@ -13,6 +17,8 @@ export {
 
 export {
   ModularDrawer,
+  type DisabledItemTooltip,
+  type DisabledItemsTooltip,
   ModularDrawerStep,
   useModularDrawerController,
   ModularDrawerWrapper,

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/index.ts
@@ -5,7 +5,7 @@ import { ModularDrawerWrapper } from "LLM/features/ModularDrawer/ModularDrawerWr
 import { ModularDrawerLocation } from "@ledgerhq/live-common/modularDrawer/enums";
 
 export { handleModularDrawerDeeplink } from "./handleModularDrawerDeeplink";
-export type { DisabledItemsTooltip, DisabledItemTooltip } from "./types";
+export type { DisabledItemsExplanation, DisabledItemExplanation } from "./types";
 export {
   ModularDrawerFlow,
   type ModularDrawerFlowProps,

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AssetSelection/components/AssetRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AssetSelection/components/AssetRow.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+import { Pressable } from "react-native";
 import {
+  Box,
   ListItem,
   ListItemContent,
   ListItemContentRow,
@@ -10,6 +12,7 @@ import {
 } from "@ledgerhq/lumen-ui-rnative";
 import { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import Icon from "@ledgerhq/crypto-icons/native";
+import type { DisabledItemTooltip } from "../../../types";
 
 export type AssetRowData = {
   id: string;
@@ -22,6 +25,8 @@ export type AssetRowData = {
 
 type Props = AssetRowData & {
   onClick: (asset: AssetRowData) => void;
+  disabledTooltip?: DisabledItemTooltip;
+  onDisabledPress?: (tooltip: DisabledItemTooltip) => void;
 };
 
 const NEGATIVE_MARGIN_OFFSET: LumenViewStyle = { marginHorizontal: "-s8" };
@@ -34,23 +39,49 @@ export const AssetRow = ({
   rightElement,
   onClick,
   disabled,
-}: Props) => (
-  <ListItem
-    disabled={disabled}
-    onPress={() => onClick({ id, name, ticker, disabled })}
-    testID={`asset-item-${ticker}`}
-    lx={NEGATIVE_MARGIN_OFFSET}
-  >
-    <ListItemLeading>
-      <Icon ledgerId={id} ticker={ticker} size={48} />
-      <ListItemContent style={{ flex: 1, minWidth: 0 }}>
-        <ListItemTitle numberOfLines={1}>{name}</ListItemTitle>
-        <ListItemContentRow>
-          <ListItemDescription numberOfLines={1}>{ticker}</ListItemDescription>
-          {leftElement}
-        </ListItemContentRow>
-      </ListItemContent>
-    </ListItemLeading>
-    {rightElement ? <ListItemTrailing>{rightElement}</ListItemTrailing> : null}
-  </ListItem>
-);
+  disabledTooltip,
+  onDisabledPress,
+}: Props) => {
+  const listItem = (
+    <ListItem
+      disabled={disabled}
+      onPress={disabled ? undefined : () => onClick({ id, name, ticker, disabled })}
+      testID={`asset-item-${ticker}`}
+      lx={NEGATIVE_MARGIN_OFFSET}
+    >
+      <ListItemLeading>
+        <Icon ledgerId={id} ticker={ticker} size={48} />
+        <ListItemContent style={{ flex: 1, minWidth: 0 }}>
+          <ListItemTitle numberOfLines={1}>{name}</ListItemTitle>
+          <ListItemContentRow>
+            <ListItemDescription numberOfLines={1}>{ticker}</ListItemDescription>
+            {leftElement}
+          </ListItemContentRow>
+        </ListItemContent>
+      </ListItemLeading>
+      {rightElement ? <ListItemTrailing>{rightElement}</ListItemTrailing> : null}
+    </ListItem>
+  );
+
+  if (!disabledTooltip || !onDisabledPress) return listItem;
+
+  return (
+    <Pressable
+      accessible
+      accessibilityRole="button"
+      accessibilityLabel={disabledTooltip.title}
+      accessibilityHint={disabledTooltip.content}
+      style={{ width: "100%" }}
+      testID={`asset-item-tooltip-${ticker}`}
+      onPress={() => onDisabledPress(disabledTooltip)}
+    >
+      <Box
+        pointerEvents="none"
+        accessibilityElementsHidden
+        importantForAccessibility="no-hide-descendants"
+      >
+        {listItem}
+      </Box>
+    </Pressable>
+  );
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AssetSelection/components/AssetRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AssetSelection/components/AssetRow.tsx
@@ -12,7 +12,7 @@ import {
 } from "@ledgerhq/lumen-ui-rnative";
 import { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import Icon from "@ledgerhq/crypto-icons/native";
-import type { DisabledItemTooltip } from "../../../types";
+import type { DisabledItemExplanation } from "../../../types";
 
 export type AssetRowData = {
   id: string;
@@ -25,8 +25,8 @@ export type AssetRowData = {
 
 type Props = AssetRowData & {
   onClick: (asset: AssetRowData) => void;
-  disabledTooltip?: DisabledItemTooltip;
-  onDisabledPress?: (tooltip: DisabledItemTooltip) => void;
+  disabledExplanation?: DisabledItemExplanation;
+  onDisabledPress?: (explanation: DisabledItemExplanation) => void;
 };
 
 const NEGATIVE_MARGIN_OFFSET: LumenViewStyle = { marginHorizontal: "-s8" };
@@ -39,7 +39,7 @@ export const AssetRow = ({
   rightElement,
   onClick,
   disabled,
-  disabledTooltip,
+  disabledExplanation,
   onDisabledPress,
 }: Props) => {
   const listItem = (
@@ -63,17 +63,17 @@ export const AssetRow = ({
     </ListItem>
   );
 
-  if (!disabled || !disabledTooltip || !onDisabledPress) return listItem;
+  if (!disabled || !disabledExplanation || !onDisabledPress) return listItem;
 
   return (
     <Pressable
       accessible
       accessibilityRole="button"
-      accessibilityLabel={disabledTooltip.title}
-      accessibilityHint={disabledTooltip.content}
+      accessibilityLabel={disabledExplanation.title}
+      accessibilityHint={disabledExplanation.content}
       style={{ width: "100%" }}
-      testID={`asset-item-tooltip-${ticker}`}
-      onPress={() => onDisabledPress(disabledTooltip)}
+      testID={`asset-item-explanation-${ticker}`}
+      onPress={() => onDisabledPress(disabledExplanation)}
     >
       <Box
         pointerEvents="none"

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AssetSelection/components/AssetRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AssetSelection/components/AssetRow.tsx
@@ -63,7 +63,7 @@ export const AssetRow = ({
     </ListItem>
   );
 
-  if (!disabledTooltip || !onDisabledPress) return listItem;
+  if (!disabled || !disabledTooltip || !onDisabledPress) return listItem;
 
   return (
     <Pressable

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AssetSelection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AssetSelection/index.tsx
@@ -36,6 +36,7 @@ import {
   getPerpsUiUseCase,
   PERPS_UI_USE_CASE,
 } from "@ledgerhq/live-common/wallet-api/ModularDrawer/uiUseCase";
+import type { DisabledItemTooltip, DisabledItemsTooltip } from "../../types";
 
 export type AssetSelectionStepProps = {
   isOpen: boolean;
@@ -49,6 +50,8 @@ export type AssetSelectionStepProps = {
   assetsSorted?: AssetData[];
   uiUseCase?: string;
   selectableNetworkIds?: readonly string[];
+  disabledAssetTooltip?: DisabledItemsTooltip["asset"];
+  onDisabledAssetPress?: (tooltip: DisabledItemTooltip) => void;
 };
 
 const SAFE_MARGIN_BOTTOM = 48;
@@ -65,6 +68,8 @@ const AssetSelection = ({
   assetsSorted,
   uiUseCase,
   selectableNetworkIds,
+  disabledAssetTooltip,
+  onDisabledAssetPress,
 }: Readonly<AssetSelectionStepProps>) => {
   const { t } = useTranslation();
   const { isInternetReachable } = useNetInfo();
@@ -152,8 +157,15 @@ const AssetSelection = ({
   );
 
   const renderItem = useCallback(
-    ({ item }: { item: AssetRowData }) => <AssetRow {...item} onClick={handleAssetClick} />,
-    [handleAssetClick],
+    ({ item }: { item: AssetRowData }) => (
+      <AssetRow
+        {...item}
+        onClick={handleAssetClick}
+        disabledTooltip={item.disabled ? disabledAssetTooltip?.(item.name) : undefined}
+        onDisabledPress={onDisabledAssetPress}
+      />
+    ),
+    [disabledAssetTooltip, handleAssetClick, onDisabledAssetPress],
   );
 
   const renderContent = () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AssetSelection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AssetSelection/index.tsx
@@ -36,7 +36,7 @@ import {
   getPerpsUiUseCase,
   PERPS_UI_USE_CASE,
 } from "@ledgerhq/live-common/wallet-api/ModularDrawer/uiUseCase";
-import type { DisabledItemTooltip, DisabledItemsTooltip } from "../../types";
+import type { DisabledItemExplanation, DisabledItemsExplanation } from "../../types";
 
 export type AssetSelectionStepProps = {
   isOpen: boolean;
@@ -50,8 +50,8 @@ export type AssetSelectionStepProps = {
   assetsSorted?: AssetData[];
   uiUseCase?: string;
   selectableNetworkIds?: readonly string[];
-  disabledAssetTooltip?: DisabledItemsTooltip["asset"];
-  onDisabledAssetPress?: (tooltip: DisabledItemTooltip) => void;
+  disabledAssetExplanation?: DisabledItemsExplanation["asset"];
+  onDisabledAssetPress?: (explanation: DisabledItemExplanation) => void;
 };
 
 const SAFE_MARGIN_BOTTOM = 48;
@@ -68,7 +68,7 @@ const AssetSelection = ({
   assetsSorted,
   uiUseCase,
   selectableNetworkIds,
-  disabledAssetTooltip,
+  disabledAssetExplanation,
   onDisabledAssetPress,
 }: Readonly<AssetSelectionStepProps>) => {
   const { t } = useTranslation();
@@ -161,11 +161,11 @@ const AssetSelection = ({
       <AssetRow
         {...item}
         onClick={handleAssetClick}
-        disabledTooltip={item.disabled ? disabledAssetTooltip?.(item.name) : undefined}
+        disabledExplanation={item.disabled ? disabledAssetExplanation?.(item.name) : undefined}
         onDisabledPress={onDisabledAssetPress}
       />
     ),
-    [disabledAssetTooltip, handleAssetClick, onDisabledAssetPress],
+    [disabledAssetExplanation, handleAssetClick, onDisabledAssetPress],
   );
 
   const renderContent = () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/NetworkSelection/components/NetworkRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/NetworkSelection/components/NetworkRow.tsx
@@ -59,7 +59,7 @@ export const NetworkRow = ({
     </ListItem>
   );
 
-  if (!disabledTooltip || !onDisabledPress) return listItem;
+  if (!disabled || !disabledTooltip || !onDisabledPress) return listItem;
 
   return (
     <Pressable

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/NetworkSelection/components/NetworkRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/NetworkSelection/components/NetworkRow.tsx
@@ -11,7 +11,7 @@ import {
 } from "@ledgerhq/lumen-ui-rnative";
 import { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import Icon from "@ledgerhq/crypto-icons/native";
-import type { DisabledItemTooltip } from "../../../types";
+import type { DisabledItemExplanation } from "../../../types";
 
 export type NetworkRowData = {
   id: string;
@@ -24,8 +24,8 @@ export type NetworkRowData = {
 
 type Props = NetworkRowData & {
   onClick: () => void;
-  disabledTooltip?: DisabledItemTooltip;
-  onDisabledPress?: (tooltip: DisabledItemTooltip) => void;
+  disabledExplanation?: DisabledItemExplanation;
+  onDisabledPress?: (explanation: DisabledItemExplanation) => void;
 };
 
 const NEGATIVE_MARGIN_OFFSET: LumenViewStyle = { marginHorizontal: "-s8" };
@@ -38,7 +38,7 @@ export const NetworkRow = ({
   rightElement,
   onClick,
   disabled,
-  disabledTooltip,
+  disabledExplanation,
   onDisabledPress,
 }: Props) => {
   const listItem = (
@@ -59,17 +59,17 @@ export const NetworkRow = ({
     </ListItem>
   );
 
-  if (!disabled || !disabledTooltip || !onDisabledPress) return listItem;
+  if (!disabled || !disabledExplanation || !onDisabledPress) return listItem;
 
   return (
     <Pressable
       accessible
       accessibilityRole="button"
-      accessibilityLabel={disabledTooltip.title}
-      accessibilityHint={disabledTooltip.content}
+      accessibilityLabel={disabledExplanation.title}
+      accessibilityHint={disabledExplanation.content}
       style={{ width: "100%" }}
-      testID={`network-item-tooltip-${name}`}
-      onPress={() => onDisabledPress(disabledTooltip)}
+      testID={`network-item-explanation-${name}`}
+      onPress={() => onDisabledPress(disabledExplanation)}
     >
       <Box
         pointerEvents="none"

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/NetworkSelection/components/NetworkRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/NetworkSelection/components/NetworkRow.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+import { Pressable } from "react-native";
 import {
+  Box,
   ListItem,
   ListItemContent,
   ListItemContentRow,
@@ -9,6 +11,7 @@ import {
 } from "@ledgerhq/lumen-ui-rnative";
 import { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import Icon from "@ledgerhq/crypto-icons/native";
+import type { DisabledItemTooltip } from "../../../types";
 
 export type NetworkRowData = {
   id: string;
@@ -21,6 +24,8 @@ export type NetworkRowData = {
 
 type Props = NetworkRowData & {
   onClick: () => void;
+  disabledTooltip?: DisabledItemTooltip;
+  onDisabledPress?: (tooltip: DisabledItemTooltip) => void;
 };
 
 const NEGATIVE_MARGIN_OFFSET: LumenViewStyle = { marginHorizontal: "-s8" };
@@ -33,20 +38,46 @@ export const NetworkRow = ({
   rightElement,
   onClick,
   disabled,
-}: Props) => (
-  <ListItem
-    disabled={disabled}
-    onPress={onClick}
-    testID={`network-item-${name}`}
-    lx={NEGATIVE_MARGIN_OFFSET}
-  >
-    <ListItemLeading>
-      <Icon ledgerId={id} ticker={ticker} size={48} shape="square" />
-      <ListItemContent style={{ flex: 1, minWidth: 0 }}>
-        <ListItemTitle numberOfLines={1}>{name}</ListItemTitle>
-        {leftElement ? <ListItemContentRow>{leftElement}</ListItemContentRow> : null}
-      </ListItemContent>
-    </ListItemLeading>
-    {rightElement ? <ListItemTrailing>{rightElement}</ListItemTrailing> : null}
-  </ListItem>
-);
+  disabledTooltip,
+  onDisabledPress,
+}: Props) => {
+  const listItem = (
+    <ListItem
+      disabled={disabled}
+      onPress={disabled ? undefined : onClick}
+      testID={`network-item-${name}`}
+      lx={NEGATIVE_MARGIN_OFFSET}
+    >
+      <ListItemLeading>
+        <Icon ledgerId={id} ticker={ticker} size={48} shape="square" />
+        <ListItemContent style={{ flex: 1, minWidth: 0 }}>
+          <ListItemTitle numberOfLines={1}>{name}</ListItemTitle>
+          {leftElement ? <ListItemContentRow>{leftElement}</ListItemContentRow> : null}
+        </ListItemContent>
+      </ListItemLeading>
+      {rightElement ? <ListItemTrailing>{rightElement}</ListItemTrailing> : null}
+    </ListItem>
+  );
+
+  if (!disabledTooltip || !onDisabledPress) return listItem;
+
+  return (
+    <Pressable
+      accessible
+      accessibilityRole="button"
+      accessibilityLabel={disabledTooltip.title}
+      accessibilityHint={disabledTooltip.content}
+      style={{ width: "100%" }}
+      testID={`network-item-tooltip-${name}`}
+      onPress={() => onDisabledPress(disabledTooltip)}
+    >
+      <Box
+        pointerEvents="none"
+        accessibilityElementsHidden
+        importantForAccessibility="no-hide-descendants"
+      >
+        {listItem}
+      </Box>
+    </Pressable>
+  );
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/NetworkSelection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/NetworkSelection/index.tsx
@@ -21,15 +21,15 @@ import { useBalanceDeps } from "../../hooks/useBalanceDeps";
 import { useSelector } from "~/context/hooks";
 import { modularDrawerFlowSelector, modularDrawerSourceSelector } from "~/reducers/modularDrawer";
 import { withDiscreetMode } from "~/context/DiscreetModeContext";
-import type { DisabledItemTooltip, DisabledItemsTooltip } from "../../types";
+import type { DisabledItemExplanation, DisabledItemsExplanation } from "../../types";
 
 export type NetworkSelectionStepProps = {
   availableNetworks: CryptoOrTokenCurrency[];
   onNetworkSelected: (asset: CryptoOrTokenCurrency) => void;
   networksConfiguration?: EnhancedModularDrawerConfiguration["networks"];
   selectableNetworkIds?: readonly string[];
-  disabledNetworkTooltip?: DisabledItemsTooltip["network"];
-  onDisabledNetworkPress?: (tooltip: DisabledItemTooltip) => void;
+  disabledNetworkExplanation?: DisabledItemsExplanation["network"];
+  onDisabledNetworkPress?: (explanation: DisabledItemExplanation) => void;
   selectedAssetName?: string;
 };
 
@@ -40,7 +40,7 @@ const NetworkSelection = ({
   onNetworkSelected,
   networksConfiguration,
   selectableNetworkIds,
-  disabledNetworkTooltip,
+  disabledNetworkExplanation,
   onDisabledNetworkPress,
   selectedAssetName,
 }: Readonly<NetworkSelectionStepProps>) => {
@@ -132,9 +132,9 @@ const NetworkSelection = ({
             {...item}
             disabled={isSelectableNetwork(item.id) ? undefined : true}
             onClick={() => handleNetworkClick(item.id)}
-            disabledTooltip={
+            disabledExplanation={
               !isSelectableNetwork(item.id) && selectedAssetName
-                ? disabledNetworkTooltip?.(item.name, selectedAssetName)
+                ? disabledNetworkExplanation?.(item.name, selectedAssetName)
                 : undefined
             }
             onDisabledPress={onDisabledNetworkPress}

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/NetworkSelection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/NetworkSelection/index.tsx
@@ -21,12 +21,16 @@ import { useBalanceDeps } from "../../hooks/useBalanceDeps";
 import { useSelector } from "~/context/hooks";
 import { modularDrawerFlowSelector, modularDrawerSourceSelector } from "~/reducers/modularDrawer";
 import { withDiscreetMode } from "~/context/DiscreetModeContext";
+import type { DisabledItemTooltip, DisabledItemsTooltip } from "../../types";
 
 export type NetworkSelectionStepProps = {
   availableNetworks: CryptoOrTokenCurrency[];
   onNetworkSelected: (asset: CryptoOrTokenCurrency) => void;
   networksConfiguration?: EnhancedModularDrawerConfiguration["networks"];
   selectableNetworkIds?: readonly string[];
+  disabledNetworkTooltip?: DisabledItemsTooltip["network"];
+  onDisabledNetworkPress?: (tooltip: DisabledItemTooltip) => void;
+  selectedAssetName?: string;
 };
 
 const SAFE_MARGIN_BOTTOM = 48;
@@ -36,6 +40,9 @@ const NetworkSelection = ({
   onNetworkSelected,
   networksConfiguration,
   selectableNetworkIds,
+  disabledNetworkTooltip,
+  onDisabledNetworkPress,
+  selectedAssetName,
 }: Readonly<NetworkSelectionStepProps>) => {
   const { t } = useTranslation();
   const flow = useSelector(modularDrawerFlowSelector);
@@ -125,6 +132,12 @@ const NetworkSelection = ({
             {...item}
             disabled={isSelectableNetwork(item.id) ? undefined : true}
             onClick={() => handleNetworkClick(item.id)}
+            disabledTooltip={
+              !isSelectableNetwork(item.id) && selectedAssetName
+                ? disabledNetworkTooltip?.(item.name, selectedAssetName)
+                : undefined
+            }
+            onDisabledPress={onDisabledNetworkPress}
           />
         )}
         contentContainerStyle={{

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/types.ts
@@ -9,15 +9,15 @@ export enum ModularDrawerStep {
   Account = "Account",
 }
 
-export type DisabledItemTooltip = Readonly<{
+export type DisabledItemExplanation = Readonly<{
   title: string;
   content: string;
 }>;
 
-export type DisabledItemsTooltip = Readonly<{
-  asset: (assetName: string) => DisabledItemTooltip;
-  network: (networkName: string, assetName: string) => DisabledItemTooltip;
-  onPress: (tooltip: DisabledItemTooltip) => void;
+export type DisabledItemsExplanation = Readonly<{
+  asset: (assetName: string) => DisabledItemExplanation;
+  network: (networkName: string, assetName: string) => DisabledItemExplanation;
+  onPress: (explanation: DisabledItemExplanation) => void;
 }>;
 
 export const MODULAR_DRAWER_KEY = "modularDrawer";

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/types.ts
@@ -9,6 +9,17 @@ export enum ModularDrawerStep {
   Account = "Account",
 }
 
+export type DisabledItemTooltip = Readonly<{
+  title: string;
+  content: string;
+}>;
+
+export type DisabledItemsTooltip = Readonly<{
+  asset: (assetName: string) => DisabledItemTooltip;
+  network: (networkName: string, assetName: string) => DisabledItemTooltip;
+  onPress: (tooltip: DisabledItemTooltip) => void;
+}>;
+
 export const MODULAR_DRAWER_KEY = "modularDrawer";
 
 export type ModularDrawerCompletionMode = "currency";


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Contacts integration tests cover unavailable assets and networks, sheet dismissal, and the normal eligible-selection path.
- [x] **Impact of the changes:**
      Contacts → Add address → Select asset/network:
      - Tap an unavailable option to see its explanation.
      - Dismiss it with `Got it`.
      - Select an eligible network as before.

### 📝 Description

Adds Figma-aligned explanations for unavailable assets and networks in Mobile Contacts currency selection. Disabled rows remain unavailable; tapping them opens an information sheet with dynamic currency context and a `Got it` action.

<img width="350" height="750" alt="Simulator Screenshot - build2 - 2026-08-31 at 14 10 15" src="https://github.com/user-attachments/assets/e824c0e4-1e06-424c-903f-7d8383a6a5a5" />
<img width="350" height="750" alt="simulator_screenshot_A2262074-409B-41D9-8ACF-2CD89715A25A" src="https://github.com/user-attachments/assets/b7d162c6-aea3-4597-9ffc-c8d2d4c7c6e5" />

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-36641

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
