### PR TITLE
test(jest-features-flow): polyfill Encoding API for jsdom (LIVE-36655)

### DIFF
--- a/support/jest-features-flow/README.md
+++ b/support/jest-features-flow/README.md
@@ -38,6 +38,14 @@ As a result:
 
 Tests therefore assert on your own layout/view-model wiring, not on real Lumen internals.
 
+## Web environment polyfills
+
+`setup/web.js` polyfills the Encoding API (`TextEncoder` / `TextDecoder`) on the jsdom global.
+jsdom doesn't implement it, unlike every runtime this code ships to (browsers, React Native,
+Node), so a package reading `TextEncoder` at module-eval time — `@ledgerhq/device-contacts-kit`
+does — throws `ReferenceError` the moment a web test imports it, even transitively.
+It also mocks `window.matchMedia`.
+
 ## Usage
 
 ```js

--- a/support/jest-features-flow/setup/web.js
+++ b/support/jest-features-flow/setup/web.js
@@ -1,5 +1,13 @@
 // Web (jsdom) setup shared across features/flow packages.
 
+// jsdom doesn't implement the Encoding API, unlike every runtime this code ships to
+// (browsers, React Native, Node). Packages reading TextEncoder at module-eval time
+// (e.g. @ledgerhq/device-contacts-kit) throw on import without it.
+const { TextEncoder, TextDecoder } = require("node:util");
+
+global.TextEncoder ??= TextEncoder;
+global.TextDecoder ??= TextDecoder;
+
 // Mock window.matchMedia for components that read it.
 Object.defineProperty(window, "matchMedia", {
   writable: true,


### PR DESCRIPTION
### 📝 Description

jsdom doesn't implement the Encoding API, so `TextEncoder` / `TextDecoder` are undefined in the `web` project of `createFlowJestConfig()` — unlike every runtime this code ships to. A package reading `TextEncoder` at module-eval time (`@ledgerhq/device-contacts-kit` does) throws `ReferenceError` as soon as a web test imports it, even transitively. Defining both on the jsdom global in `setup/web.js` lets consumers keep the shared one-liner config instead of appending their own `setupFilesAfterEnv` entry, as #21236 had to.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36655](https://ledgerhq.atlassian.net/browse/LIVE-36655) — unblocks #21236

[LIVE-36655]: https://ledgerhq.atlassian.net/browse/LIVE-36655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ