### PR TITLE
[LWDM] feat(signer-xrp): add DMK signer behind ldmkXrpSigner (DSDK-1453)

### DIFF
--- a/.changeset/tidy-signers-ripple.md
+++ b/.changeset/tidy-signers-ripple.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/live-signer-xrp": minor
+"@ledgerhq/live-common": minor
+"@ledgerhq/types-live": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Drive the XRP app through the Device Management Kit behind the `ldmkXrpSigner` feature flag, keeping `hw-app-xrp` as the fallback

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -75,6 +75,7 @@ shared-lib:
   - libs/live-signer-canton/**/*
   - libs/live-signer-evm/**/*
   - libs/live-signer-solana/**/*
+  - libs/live-signer-xrp/**/*
   - libs/live-wallet/**/*
   - libs/promise/**/*
   - libs/psbtv2/**/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -432,6 +432,7 @@ libs/live-signer-zcash/                                            @ledgerhq/liv
 libs/live-signer-celo/                                             @ledgerhq/live-devices
 libs/live-signer-cosmos/                                           @ledgerhq/live-devices
 libs/live-signer-hyperliquid/                                      @ledgerhq/live-devices
+libs/live-signer-xrp/                                              @ledgerhq/live-devices
 libs/ledgerjs/packages/hw-transport/                               @ledgerhq/live-devices
 libs/live-dmk-speculos/                                            @ledgerhq/live-devices
 apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/manager.handler.ts  @ledgerhq/live-devices

--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -67,6 +67,7 @@ import {
   setSolanaTxcEnabled,
 } from "@ledgerhq/live-common/families/solana/setup";
 import { setCosmosLdmkEnabled } from "@ledgerhq/live-common/families/cosmos/setup";
+import { setXrpLdmkEnabled } from "@ledgerhq/live-common/families/xrp/setup";
 import { resolveSuiTransport, setSuiTransport } from "@ledgerhq/live-common/families/sui/setup";
 import { themeSelector } from "./actions/general";
 import useCheckAccountWithFunds from "./components/PostOnboardingHub/logic/useCheckAccountWithFunds";
@@ -385,6 +386,7 @@ export default function Default() {
   const ldmkSolanaSignerFeatureFlag = useFeature("ldmkSolanaSigner");
   const ldmkSolanaSignerIsTxcActiveFeatureFlag = useFeature("ldmkSolanaSignerIsTxcActive");
   const ldmkCosmosSignerFeatureFlag = useFeature("ldmkCosmosSigner");
+  const ldmkXrpSignerFeatureFlag = useFeature("ldmkXrpSigner");
   const suiTransportFeatureFlag = useFeature("suiTransport");
 
   const dmk = useDeviceManagementKit();
@@ -419,6 +421,12 @@ export default function Default() {
       setCosmosLdmkEnabled(ldmkCosmosSignerFeatureFlag.enabled);
     }
   }, [ldmkCosmosSignerFeatureFlag]);
+
+  useEffect(() => {
+    if (typeof ldmkXrpSignerFeatureFlag?.enabled === "boolean") {
+      setXrpLdmkEnabled(ldmkXrpSignerFeatureFlag.enabled);
+    }
+  }, [ldmkXrpSignerFeatureFlag]);
 
   useEffect(() => {
     setSuiTransport(resolveSuiTransport(suiTransportFeatureFlag));

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -102,6 +102,7 @@ import {
   setSolanaTxcEnabled,
 } from "@ledgerhq/live-common/families/solana/setup";
 import { setCosmosLdmkEnabled } from "@ledgerhq/live-common/families/cosmos/setup";
+import { setXrpLdmkEnabled } from "@ledgerhq/live-common/families/xrp/setup";
 import { resolveSuiTransport, setSuiTransport } from "@ledgerhq/live-common/families/sui/setup";
 import useCheckAccountWithFunds from "./logic/postOnboarding/useCheckAccountWithFunds";
 import { useAutoFinishPostOnboarding } from "LLM/features/PostOnboarding/hooks/useAutoFinishPostOnboarding";
@@ -149,6 +150,7 @@ function App() {
   const ldmkSolanaSignerFeatureFlag = useFeature("ldmkSolanaSigner");
   const ldmkSolanaSignerIsTxcActiveFeatureFlag = useFeature("ldmkSolanaSignerIsTxcActive");
   const ldmkCosmosSignerFeatureFlag = useFeature("ldmkCosmosSigner");
+  const ldmkXrpSignerFeatureFlag = useFeature("ldmkXrpSigner");
   const suiTransportFeatureFlag = useFeature("suiTransport");
   const datadogAutoInstrumentation: AutoInstrumentationConfiguration = useMemo(
     () => ({
@@ -185,6 +187,12 @@ function App() {
       setCosmosLdmkEnabled(ldmkCosmosSignerFeatureFlag.enabled);
     }
   }, [ldmkCosmosSignerFeatureFlag]);
+
+  useEffect(() => {
+    if (typeof ldmkXrpSignerFeatureFlag?.enabled === "boolean") {
+      setXrpLdmkEnabled(ldmkXrpSignerFeatureFlag.enabled);
+    }
+  }, [ldmkXrpSignerFeatureFlag]);
 
   useEffect(() => {
     setSuiTransport(resolveSuiTransport(suiTransportFeatureFlag));

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -857,6 +857,7 @@
     "@ledgerhq/live-signer-evm",
     "@ledgerhq/live-signer-icp",
     "@ledgerhq/live-signer-solana",
+    "@ledgerhq/live-signer-xrp",
     "@ledgerhq/live-signer-zcash",
     "@reduxjs/toolkit",
     "@stellar/stellar-sdk",

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -360,6 +360,7 @@
     "@ledgerhq/live-signer-hyperliquid": "workspace:^",
     "@ledgerhq/live-signer-icp": "workspace:^",
     "@ledgerhq/live-signer-solana": "workspace:^",
+    "@ledgerhq/live-signer-xrp": "workspace:^",
     "@ledgerhq/live-signer-zcash": "workspace:^",
     "@ledgerhq/logs": "catalog:",
     "@ledgerhq/speculos-transport": "workspace:^",

--- a/libs/ledger-live-common/src/families/xrp/setup.test.ts
+++ b/libs/ledger-live-common/src/families/xrp/setup.test.ts
@@ -1,0 +1,52 @@
+import Transport from "@ledgerhq/hw-transport";
+import { DmkSignerXrp, LegacySignerXrp } from "@ledgerhq/live-signer-xrp";
+import { createSigner, setXrpLdmkEnabled } from "./setup";
+
+jest.mock("@ledgerhq/live-signer-xrp", () => ({
+  DmkSignerXrp: jest.fn(),
+  LegacySignerXrp: jest.fn(),
+}));
+
+const legacyTransport = {} as Transport;
+const dmkTransport = { dmk: { id: "dmk" }, sessionId: "session-1" } as unknown as Transport;
+
+describe("createSigner (XRP)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setXrpLdmkEnabled(false);
+  });
+
+  afterAll(() => setXrpLdmkEnabled(false));
+
+  it("uses the legacy signer on a legacy transport, flag off", () => {
+    createSigner(legacyTransport);
+
+    expect(LegacySignerXrp).toHaveBeenCalledWith(legacyTransport);
+    expect(DmkSignerXrp).not.toHaveBeenCalled();
+  });
+
+  it("uses the legacy signer on a legacy transport, flag on", () => {
+    setXrpLdmkEnabled(true);
+
+    createSigner(legacyTransport);
+
+    expect(LegacySignerXrp).toHaveBeenCalledWith(legacyTransport);
+    expect(DmkSignerXrp).not.toHaveBeenCalled();
+  });
+
+  it("keeps a DMK transport on the legacy signer while the flag is off", () => {
+    createSigner(dmkTransport);
+
+    expect(LegacySignerXrp).toHaveBeenCalledWith(dmkTransport);
+    expect(DmkSignerXrp).not.toHaveBeenCalled();
+  });
+
+  it("uses the DMK signer on a DMK transport once the flag is on", () => {
+    setXrpLdmkEnabled(true);
+
+    createSigner(dmkTransport);
+
+    expect(DmkSignerXrp).toHaveBeenCalledWith({ id: "dmk" }, "session-1");
+    expect(LegacySignerXrp).not.toHaveBeenCalled();
+  });
+});

--- a/libs/ledger-live-common/src/families/xrp/setup.ts
+++ b/libs/ledger-live-common/src/families/xrp/setup.ts
@@ -1,13 +1,26 @@
 // Goal of this file is to inject all necessary device/signer dependency to coin-modules
 
-import Xrp from "@ledgerhq/hw-app-xrp";
 import Transport from "@ledgerhq/hw-transport";
+import { DmkSignerXrp, LegacySignerXrp } from "@ledgerhq/live-signer-xrp";
 import xrpResolver from "./getAddress";
+import { XrpSigner } from "./types";
 import { CreateSigner, createResolver } from "../../bridge/setup";
 import { Resolver } from "../../hw/getAddress/types";
+import { isDmkTransport } from "../../hw/dmkUtils";
 
-const createSigner: CreateSigner<Xrp> = (transport: Transport) => {
-  return new Xrp(transport);
+let _xrpLdmkFFEnabled: boolean = false;
+
+// temporary solution to dynamically enable/disable the XRP DMK signer,
+// to be removed together with useFeature("ldmkXrpSigner")
+export const setXrpLdmkEnabled = (enabled: boolean): void => {
+  _xrpLdmkFFEnabled = enabled;
+};
+
+export const createSigner: CreateSigner<XrpSigner> = (transport: Transport) => {
+  if (isDmkTransport(transport) && _xrpLdmkFFEnabled) {
+    return new DmkSignerXrp(transport.dmk, transport.sessionId);
+  }
+  return new LegacySignerXrp(transport);
 };
 
 const resolver: Resolver = createResolver(createSigner, xrpResolver);

--- a/libs/ledger-live-common/src/families/xrp/signer.test.ts
+++ b/libs/ledger-live-common/src/families/xrp/signer.test.ts
@@ -37,7 +37,7 @@ describe("createSigner (XRP)", () => {
 
       await signer.getAddress("44'/144'/0'/0/0", { derivationMode: "xrp" });
 
-      expect(mockGetAddress).toHaveBeenCalledWith("44'/144'/0'/0/0", false);
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/144'/0'/0/0", false, undefined, undefined);
     });
 
     it("should NOT display address on device when called without options", async () => {
@@ -45,7 +45,7 @@ describe("createSigner (XRP)", () => {
 
       await signer.getAddress("44'/144'/0'/0/0");
 
-      expect(mockGetAddress).toHaveBeenCalledWith("44'/144'/0'/0/0", false);
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/144'/0'/0/0", false, undefined, undefined);
     });
 
     it("should NOT display address on device when called with verify: false", async () => {
@@ -53,7 +53,7 @@ describe("createSigner (XRP)", () => {
 
       await signer.getAddress("44'/144'/0'/0/0", { verify: false });
 
-      expect(mockGetAddress).toHaveBeenCalledWith("44'/144'/0'/0/0", false);
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/144'/0'/0/0", false, undefined, undefined);
     });
 
     it("should display address on device when called with boolean true (receive flow)", async () => {
@@ -61,7 +61,7 @@ describe("createSigner (XRP)", () => {
 
       await signer.getAddress("44'/144'/0'/0/0", true);
 
-      expect(mockGetAddress).toHaveBeenCalledWith("44'/144'/0'/0/0", true);
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/144'/0'/0/0", true, undefined, undefined);
     });
 
     it("should display address on device when called with verify: true", async () => {
@@ -69,7 +69,7 @@ describe("createSigner (XRP)", () => {
 
       await signer.getAddress("44'/144'/0'/0/0", { verify: true });
 
-      expect(mockGetAddress).toHaveBeenCalledWith("44'/144'/0'/0/0", true);
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/144'/0'/0/0", true, undefined, undefined);
     });
 
     it("should forward chainCode arg to the underlying signer (receive flow)", async () => {
@@ -77,7 +77,7 @@ describe("createSigner (XRP)", () => {
 
       await signer.getAddress("44'/144'/0'/0/0", true, false);
 
-      expect(mockGetAddress).toHaveBeenCalledWith("44'/144'/0'/0/0", true, false);
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/144'/0'/0/0", true, false, undefined);
     });
   });
 

--- a/libs/ledger-live-common/src/families/xrp/signer.ts
+++ b/libs/ledger-live-common/src/families/xrp/signer.ts
@@ -1,13 +1,17 @@
+import Transport from "@ledgerhq/hw-transport";
 import resolver from "./getAddress";
+import { createSigner as createXrpSigner } from "./setup";
 import { executeWithSigner } from "../../bridge/setup";
 import type { CoinFrameworkSigner } from "../../bridge/generic-coin-framework/types";
-import Xrp from "@ledgerhq/hw-app-xrp";
-import Transport from "@ledgerhq/hw-transport";
 
+/**
+ * Adapts the shapes the generic coin framework calls with onto the `XrpSigner` contract:
+ * `getAddress` receives `boolean | { verify?, derivationMode? }` where the signer wants a
+ * `display` flag, and `signTransaction` receives the framework's device-options object where
+ * the signer wants `ed25519`. Which signer is behind it — DMK or legacy — is `setup.ts`'s call.
+ */
 export const createSigner = (transport: Transport) => {
-  const xrp = new Xrp(transport);
-  const originalGetAddress = xrp.getAddress.bind(xrp);
-  const originalSignTransaction = xrp.signTransaction.bind(xrp);
+  const xrp = createXrpSigner(transport);
   return {
     getAddress: async (
       path: string,
@@ -16,8 +20,7 @@ export const createSigner = (transport: Transport) => {
       ed25519?: boolean,
     ) => {
       const display = typeof options === "boolean" ? options : Boolean(options?.verify);
-      const extra = [chainCode, ed25519].filter((v): v is boolean => v !== undefined);
-      return originalGetAddress(path, display, ...(extra as [boolean?, boolean?]));
+      return xrp.getAddress(path, display, chainCode, ed25519);
     },
     signTransaction: async (
       path: string,
@@ -25,7 +28,7 @@ export const createSigner = (transport: Transport) => {
       options?: boolean | { derivationMode?: string },
     ) => {
       const ed25519 = typeof options === "boolean" ? options : undefined;
-      return originalSignTransaction(path, rawTxHex, ed25519);
+      return xrp.signTransaction(path, rawTxHex, ed25519);
     },
   };
 };

--- a/libs/live-signer-xrp/README.md
+++ b/libs/live-signer-xrp/README.md
@@ -1,0 +1,23 @@
+<img src="https://user-images.githubusercontent.com/4631227/191834116-59cf590e-25cc-4956-ae5c-812ea464f324.png" height="100" />
+
+[GitHub](https://github.com/LedgerHQ/ledger-live/),
+[Ledger Devs Discord](https://developers.ledger.com/discord-pro),
+[Developer Portal](https://developers.ledger.com/)
+
+## @ledgerhq/live-signer-xrp
+
+> [!NOTE]
+> **Status: EXPERIMENTAL** — The DMK path is behind the `ldmkXrpSigner` feature flag; the legacy path is the fallback.
+
+Ledger Hardware Wallet XRP JavaScript bindings, integrating [`@ledgerhq/device-signer-kit-xrp`](https://github.com/LedgerHQ/device-sdk-ts/tree/develop/packages/signer/signer-xrp) from the Device Management Kit alongside legacy `hw-app-xrp`.
+
+Both `DmkSignerXrp` and `LegacySignerXrp` implement the same `XrpSigner` interface, so
+`families/xrp/setup.ts` can pick one or the other from the feature flag without the coin
+framework knowing which is in use.
+
+### Curve support
+
+The XRP application can sign on secp256k1 or ed25519, selected through the APDU's `p2`. The
+signer kit only drives secp256k1 today, so `DmkSignerXrp` throws on `ed25519 = true` rather
+than silently signing with the wrong curve. Ledger Live never asks for ed25519 — the generic
+coin framework passes an options object, not a boolean — so this only guards direct callers.

--- a/libs/live-signer-xrp/jest.config.js
+++ b/libs/live-signer-xrp/jest.config.js
@@ -1,0 +1,23 @@
+module.exports = {
+  testEnvironment: "node",
+  testPathIgnorePatterns: ["lib/", "lib-es/"],
+  setupFilesAfterEnv: ["@ledgerhq/disable-network-setup", "@ledgerhq/test-quarantine/jest-retries"],
+  transform: {
+    "^.+\\.(ts|tsx)?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+        },
+      },
+    ],
+  },
+  collectCoverageFrom: ["src/**/*.ts", "!src/**/*.d.ts", "!tests/**/*.test.ts"],
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../" }], "text"],
+  reporters: [
+    "default",
+    ...(process.env.CI ? ["github-actions"] : []),
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
+  ],
+};

--- a/libs/live-signer-xrp/package.json
+++ b/libs/live-signer-xrp/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@ledgerhq/live-signer-xrp",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Ledger Hardware Wallet XRP Application API",
+  "keywords": [
+    "Ledger",
+    "LedgerWallet",
+    "xrp",
+    "ripple",
+    "NanoS",
+    "Blue",
+    "Hardware Wallet"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LedgerHQ/ledger-live.git"
+  },
+  "bugs": {
+    "url": "https://github.com/LedgerHQ/ledger-live/issues"
+  },
+  "homepage": "https://github.com/LedgerHQ/ledger-live/tree/develop/libs/live-signer-xrp",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "lib/index.js",
+  "module": "lib-es/index.js",
+  "types": "lib-es/index.d.ts",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@ledgerhq/device-management-kit": "catalog:",
+    "@ledgerhq/device-signer-kit-xrp": "catalog:",
+    "@ledgerhq/hw-app-xrp": "workspace:^",
+    "@ledgerhq/hw-transport": "workspace:*",
+    "rxjs": "catalog:"
+  },
+  "scripts": {
+    "clean": "rimraf lib lib-es",
+    "build": "tsc --project tsconfig.build.json && tsc --project tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es",
+    "prewatch": "pnpm build",
+    "watch": "tsc --watch --project tsconfig.build.json",
+    "watch:es": "tsc --watch --project tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es",
+    "lint": "oxlint -c ../oxc-live-libs/.oxlintrc.json ./src",
+    "lint:fix": "pnpm lint --fix",
+    "test": "jest",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../.. -W libs/live-signer-xrp"
+  },
+  "devDependencies": {
+    "@ledgerhq/disable-network-setup": "workspace:^",
+    "@ledgerhq/test-quarantine": "workspace:*",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "jest": "catalog:",
+    "rimraf": "^4.4.1",
+    "ts-node": "^10.4.0"
+  },
+  "exports": {
+    ".": {
+      "@ledgerhq/source": "./src/index.ts",
+      "import": "./lib-es/index.js",
+      "require": "./lib/index.js",
+      "default": "./lib/index.js"
+    },
+    "./lib-es/*": "./lib-es/*.js",
+    "./lib/*": "./lib/*.js",
+    "./package.json": "./package.json"
+  }
+}

--- a/libs/live-signer-xrp/src/DmkSignerXrp.ts
+++ b/libs/live-signer-xrp/src/DmkSignerXrp.ts
@@ -1,0 +1,107 @@
+import { lastValueFrom } from "rxjs";
+import {
+  DeviceActionState,
+  DeviceActionStatus,
+  type DeviceManagementKit,
+} from "@ledgerhq/device-management-kit";
+import {
+  SignerXrpBuilder,
+  type GetAddressDAError,
+  type SignTransactionDAError,
+  type SignerXrp,
+} from "@ledgerhq/device-signer-kit-xrp";
+import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/hw-transport/errors";
+import type { XrpAddress, XrpSignature, XrpSigner } from "./types";
+
+type DAError = GetAddressDAError | SignTransactionDAError;
+
+export class DmkSignerXrp implements XrpSigner {
+  private readonly signer: SignerXrp;
+
+  constructor(dmk: DeviceManagementKit, sessionId: string) {
+    this.signer = new SignerXrpBuilder({ dmk, sessionId }).build();
+  }
+
+  private _mapError<E extends DAError>(error: E): Error {
+    if (!("errorCode" in error)) {
+      return new Error(error._tag);
+    }
+
+    switch (error.errorCode) {
+      case "5515":
+        return new LockedDeviceError();
+      case "6985":
+      case "6982":
+        return new UserRefusedOnDevice();
+      default:
+        return new Error(error._tag);
+    }
+  }
+
+  private _mapResult<T, E extends DAError>(actionState: DeviceActionState<T, E, unknown>): T {
+    switch (actionState.status) {
+      case DeviceActionStatus.Completed: {
+        return actionState.output;
+      }
+      case DeviceActionStatus.Error: {
+        throw this._mapError<E>(actionState.error);
+      }
+      case DeviceActionStatus.NotStarted:
+      case DeviceActionStatus.Pending:
+      case DeviceActionStatus.Stopped:
+      default: {
+        throw new Error("Unknown device action status");
+      }
+    }
+  }
+
+  /**
+   * The signer kit drives the XRP app on secp256k1 only — its APDUs pin `p2` to the secp256k1
+   * curve mask. Refuse rather than sign on a curve the caller did not ask for: the app answers
+   * happily either way, so a silent fallback would return a signature for the wrong key.
+   */
+  private _rejectEd25519(ed25519?: boolean): void {
+    if (ed25519) {
+      throw new Error("DmkSignerXrp: the XRP signer kit does not support the ed25519 curve yet");
+    }
+  }
+
+  async getAddress(
+    path: string,
+    display?: boolean,
+    chainCode?: boolean,
+    ed25519?: boolean,
+  ): Promise<XrpAddress> {
+    this._rejectEd25519(ed25519);
+
+    const { observable } = this.signer.getAddress(path, {
+      checkOnDevice: !!display,
+      returnChainCode: !!chainCode,
+      // Ledger Live opens the app itself before it reaches the signer.
+      skipOpenApp: true,
+    });
+
+    const address = this._mapResult(await lastValueFrom(observable));
+
+    return {
+      publicKey: address.publicKey,
+      address: address.address,
+      chainCode: address.chainCode,
+    };
+  }
+
+  async signTransaction(path: string, rawTxHex: string, ed25519?: boolean): Promise<XrpSignature> {
+    this._rejectEd25519(ed25519);
+
+    // Passed through unchanged: the XRP app prepends the `53545800` signing prefix itself.
+    const transaction = Buffer.from(rawTxHex, "hex");
+
+    const { observable } = this.signer.signTransaction(path, transaction, {
+      skipOpenApp: true,
+    });
+
+    const signature = this._mapResult(await lastValueFrom(observable));
+
+    return Buffer.from(signature).toString("hex");
+  }
+}

--- a/libs/live-signer-xrp/src/LegacySignerXrp.ts
+++ b/libs/live-signer-xrp/src/LegacySignerXrp.ts
@@ -1,0 +1,24 @@
+import Xrp from "@ledgerhq/hw-app-xrp";
+import Transport from "@ledgerhq/hw-transport";
+import type { XrpAddress, XrpSignature, XrpSigner } from "./types";
+
+export class LegacySignerXrp implements XrpSigner {
+  private readonly signer: Xrp;
+
+  constructor(transport: Transport) {
+    this.signer = new Xrp(transport);
+  }
+
+  async getAddress(
+    path: string,
+    display?: boolean,
+    chainCode?: boolean,
+    ed25519?: boolean,
+  ): Promise<XrpAddress> {
+    return this.signer.getAddress(path, display, chainCode, ed25519);
+  }
+
+  async signTransaction(path: string, rawTxHex: string, ed25519?: boolean): Promise<XrpSignature> {
+    return this.signer.signTransaction(path, rawTxHex, ed25519);
+  }
+}

--- a/libs/live-signer-xrp/src/index.ts
+++ b/libs/live-signer-xrp/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./DmkSignerXrp";
+export * from "./LegacySignerXrp";
+export * from "./types";

--- a/libs/live-signer-xrp/src/types.ts
+++ b/libs/live-signer-xrp/src/types.ts
@@ -1,0 +1,23 @@
+export type XrpAddress = {
+  publicKey: string;
+  address: string;
+  chainCode?: string;
+};
+
+/** DER-encoded signature, hex string, as `hw-app-xrp` has always returned it. */
+export type XrpSignature = string;
+
+/**
+ * Mirrors `XrpSigner` in `@ledgerhq/live-common/families/xrp/types`. It is duplicated rather
+ * than imported because live-common depends on this package, not the other way round; the two
+ * are structurally identical so either signer satisfies the live-common contract.
+ */
+export interface XrpSigner {
+  getAddress(
+    path: string,
+    display?: boolean,
+    chainCode?: boolean,
+    ed25519?: boolean,
+  ): Promise<XrpAddress>;
+  signTransaction(path: string, rawTxHex: string, ed25519?: boolean): Promise<XrpSignature>;
+}

--- a/libs/live-signer-xrp/tests/DmkSignerXrp.test.ts
+++ b/libs/live-signer-xrp/tests/DmkSignerXrp.test.ts
@@ -1,0 +1,235 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+import { DeviceActionStatus } from "@ledgerhq/device-management-kit";
+import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/hw-transport/errors";
+import { of, throwError } from "rxjs";
+import { DmkSignerXrp } from "../src/DmkSignerXrp";
+
+jest.mock("@ledgerhq/device-signer-kit-xrp", () => ({
+  SignerXrpBuilder: jest.fn().mockImplementation(() => ({
+    build: () => ({}),
+  })),
+}));
+
+const PATH = "44'/144'/0'/0/0";
+
+/** Replaces the kit-built signer with one whose device action emits `states`. */
+const stubDeviceAction = (
+  signer: DmkSignerXrp,
+  method: "getAddress" | "signTransaction",
+  observable: unknown,
+): jest.Mock => {
+  const mock = jest.fn().mockReturnValue({ observable });
+  (signer as any).signer = { [method]: mock };
+  return mock;
+};
+
+const errorState = (error: unknown) => of({ status: DeviceActionStatus.Error, error });
+
+describe("DmkSignerXrp", () => {
+  let signer: DmkSignerXrp;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    signer = new DmkSignerXrp({} as any, "sessionId");
+  });
+
+  describe("getAddress", () => {
+    const completed = (output: unknown) =>
+      of(
+        { status: DeviceActionStatus.Pending, intermediateValue: {} },
+        { status: DeviceActionStatus.Completed, output },
+      );
+
+    it("returns the public key, address and chain code the app answered with", async () => {
+      const getAddress = stubDeviceAction(
+        signer,
+        "getAddress",
+        completed({
+          publicKey: "0324e5f600b52bb3d9246d49c4ab1722ba7f32b7a3e4f9f2b8a1a28b9118cc36c4",
+          address: "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+          chainCode: "aa".repeat(32),
+        }),
+      );
+
+      const result = await signer.getAddress(PATH, true, true);
+
+      expect(getAddress).toHaveBeenCalledWith(PATH, {
+        checkOnDevice: true,
+        returnChainCode: true,
+        skipOpenApp: true,
+      });
+      expect(result).toEqual({
+        publicKey: "0324e5f600b52bb3d9246d49c4ab1722ba7f32b7a3e4f9f2b8a1a28b9118cc36c4",
+        address: "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        chainCode: "aa".repeat(32),
+      });
+    });
+
+    it("defaults display and chain code to off, and always opens the app itself", async () => {
+      const getAddress = stubDeviceAction(
+        signer,
+        "getAddress",
+        completed({ publicKey: "0324", address: "rHb9" }),
+      );
+
+      const result = await signer.getAddress(PATH);
+
+      expect(getAddress).toHaveBeenCalledWith(PATH, {
+        checkOnDevice: false,
+        returnChainCode: false,
+        skipOpenApp: true,
+      });
+      expect(result).toEqual({ publicKey: "0324", address: "rHb9", chainCode: undefined });
+    });
+
+    it("surfaces a locked device as LockedDeviceError", async () => {
+      stubDeviceAction(
+        signer,
+        "getAddress",
+        errorState({ _tag: "XrpAppCommandError", errorCode: "5515" }),
+      );
+
+      await expect(signer.getAddress(PATH)).rejects.toBeInstanceOf(LockedDeviceError);
+    });
+
+    it("surfaces an on-device rejection as UserRefusedOnDevice", async () => {
+      stubDeviceAction(
+        signer,
+        "getAddress",
+        errorState({ _tag: "XrpAppCommandError", errorCode: "6985" }),
+      );
+
+      await expect(signer.getAddress(PATH)).rejects.toBeInstanceOf(UserRefusedOnDevice);
+    });
+
+    it("refuses ed25519 rather than signing on the kit's secp256k1 curve", async () => {
+      const getAddress = stubDeviceAction(signer, "getAddress", of());
+
+      await expect(signer.getAddress(PATH, false, false, true)).rejects.toThrow(/ed25519/);
+      expect(getAddress).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("signTransaction", () => {
+    const signature = Uint8Array.from([0x30, 0x45, 0xde, 0xad, 0xbe, 0xef]);
+    const completed = of({ status: DeviceActionStatus.Completed, output: signature });
+
+    it("passes the blob through unchanged and hex-encodes the signature", async () => {
+      const signTransaction = stubDeviceAction(signer, "signTransaction", completed);
+
+      const result = await signer.signTransaction(PATH, "1200002280000000");
+
+      expect(signTransaction).toHaveBeenCalledWith(
+        PATH,
+        Uint8Array.from([0x12, 0x00, 0x00, 0x22, 0x80, 0x00, 0x00, 0x00]),
+        { skipOpenApp: true },
+      );
+      expect(result).toBe("3045deadbeef");
+    });
+
+    it("does not prepend the 53545800 signing prefix — the app adds it", async () => {
+      const signTransaction = stubDeviceAction(signer, "signTransaction", completed);
+
+      await signer.signTransaction(PATH, "1200");
+
+      const [, blob] = signTransaction.mock.calls[0];
+      expect(Array.from(blob as Uint8Array)).toEqual([0x12, 0x00]);
+    });
+
+    it("hands a blob larger than one APDU to the kit whole, for it to chunk", async () => {
+      const signTransaction = stubDeviceAction(signer, "signTransaction", completed);
+      const rawTxHex = "ab".repeat(600);
+
+      await signer.signTransaction(PATH, rawTxHex);
+
+      const [, blob] = signTransaction.mock.calls[0];
+      expect((blob as Uint8Array).length).toBe(600);
+    });
+
+    it("surfaces a locked device as LockedDeviceError", async () => {
+      stubDeviceAction(
+        signer,
+        "signTransaction",
+        errorState({ _tag: "XrpAppCommandError", errorCode: "5515" }),
+      );
+
+      await expect(signer.signTransaction(PATH, "1200")).rejects.toBeInstanceOf(LockedDeviceError);
+    });
+
+    it.each(["6985", "6982"])("surfaces status word %s as UserRefusedOnDevice", async errorCode => {
+      stubDeviceAction(
+        signer,
+        "signTransaction",
+        errorState({ _tag: "XrpAppCommandError", errorCode }),
+      );
+
+      await expect(signer.signTransaction(PATH, "1200")).rejects.toBeInstanceOf(
+        UserRefusedOnDevice,
+      );
+    });
+
+    it("falls back to the error tag for an unmapped status word", async () => {
+      stubDeviceAction(
+        signer,
+        "signTransaction",
+        errorState({ _tag: "XrpAppCommandError", errorCode: "6a80" }),
+      );
+
+      await expect(signer.signTransaction(PATH, "1200")).rejects.toThrow("XrpAppCommandError");
+    });
+
+    it("falls back to the error tag for an error with no status word", async () => {
+      stubDeviceAction(signer, "signTransaction", errorState({ _tag: "DeviceLockedError" }));
+
+      await expect(signer.signTransaction(PATH, "1200")).rejects.toThrow("DeviceLockedError");
+    });
+
+    it("propagates a failure of the device action observable itself", async () => {
+      stubDeviceAction(
+        signer,
+        "signTransaction",
+        throwError(() => new Error("transport gone")),
+      );
+
+      await expect(signer.signTransaction(PATH, "1200")).rejects.toThrow("transport gone");
+    });
+
+    it("refuses ed25519 rather than signing on the kit's secp256k1 curve", async () => {
+      const signTransaction = stubDeviceAction(signer, "signTransaction", of());
+
+      await expect(signer.signTransaction(PATH, "1200", true)).rejects.toThrow(/ed25519/);
+      expect(signTransaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("device action ending without completing", () => {
+    const nonTerminalStatuses = [
+      DeviceActionStatus.NotStarted,
+      DeviceActionStatus.Pending,
+      DeviceActionStatus.Stopped,
+    ];
+
+    it.each(nonTerminalStatuses)("rejects when getAddress ends on %s", async status => {
+      stubDeviceAction(signer, "getAddress", of({ status }));
+
+      await expect(signer.getAddress(PATH)).rejects.toThrow("Unknown device action status");
+    });
+
+    it.each(nonTerminalStatuses)("rejects when signTransaction ends on %s", async status => {
+      stubDeviceAction(signer, "signTransaction", of({ status }));
+
+      await expect(signer.signTransaction(PATH, "1200")).rejects.toThrow(
+        "Unknown device action status",
+      );
+    });
+
+    it("rejects on a status the kit does not define", async () => {
+      stubDeviceAction(signer, "signTransaction", of({ status: "somethingElse" }));
+
+      await expect(signer.signTransaction(PATH, "1200")).rejects.toThrow(
+        "Unknown device action status",
+      );
+    });
+  });
+});

--- a/libs/live-signer-xrp/tests/LegacySignerXrp.test.ts
+++ b/libs/live-signer-xrp/tests/LegacySignerXrp.test.ts
@@ -1,0 +1,51 @@
+import Xrp from "@ledgerhq/hw-app-xrp";
+import Transport from "@ledgerhq/hw-transport";
+import { LegacySignerXrp } from "../src/LegacySignerXrp";
+
+jest.mock("@ledgerhq/hw-app-xrp");
+
+const MockedXrp = Xrp as jest.MockedClass<typeof Xrp>;
+
+describe("LegacySignerXrp", () => {
+  const transport = {} as Transport;
+  let getAddress: jest.Mock;
+  let signTransaction: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getAddress = jest.fn().mockResolvedValue({
+      publicKey: "0324e5f6",
+      address: "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+    });
+    signTransaction = jest.fn().mockResolvedValue("3045deadbeef");
+    MockedXrp.mockImplementation(() => ({ getAddress, signTransaction }) as unknown as Xrp);
+  });
+
+  it("delegates getAddress to hw-app-xrp and returns its answer unchanged", async () => {
+    const signer = new LegacySignerXrp(transport);
+
+    const result = await signer.getAddress("44'/144'/0'/0/0", true, true, false);
+
+    expect(getAddress).toHaveBeenCalledWith("44'/144'/0'/0/0", true, true, false);
+    expect(result).toEqual({
+      publicKey: "0324e5f6",
+      address: "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+    });
+  });
+
+  it("delegates signTransaction to hw-app-xrp and returns its hex signature", async () => {
+    const signer = new LegacySignerXrp(transport);
+
+    const result = await signer.signTransaction("44'/144'/0'/0/0", "1200002280000000", true);
+
+    expect(signTransaction).toHaveBeenCalledWith("44'/144'/0'/0/0", "1200002280000000", true);
+    expect(result).toBe("3045deadbeef");
+  });
+
+  it("builds one hw-app-xrp client per signer, on the transport it is given", () => {
+    new LegacySignerXrp(transport);
+
+    expect(MockedXrp).toHaveBeenCalledTimes(1);
+    expect(MockedXrp).toHaveBeenCalledWith(transport);
+  });
+});

--- a/libs/live-signer-xrp/tests/tsconfig.json
+++ b/libs/live-signer-xrp/tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": null,
+    "types": ["node", "jest"]
+  },
+  "include": ["."]
+}

--- a/libs/live-signer-xrp/tsconfig.build.json
+++ b/libs/live-signer-xrp/tsconfig.build.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "customConditions": [],
+    "types": ["node"]
+  },
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/__tests__/**/*",
+    "**/tests/**/*",
+    "**/*.test.js",
+    "**/*.test.jsx",
+    "**/*.spec.js",
+    "**/*.spec.jsx"
+  ]
+}

--- a/libs/live-signer-xrp/tsconfig.json
+++ b/libs/live-signer-xrp/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "lib": ["es2020", "dom"],
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/libs/types-live/src/feature.ts
+++ b/libs/types-live/src/feature.ts
@@ -265,6 +265,7 @@ export type Features = CurrencyFeatures & {
   ldmkSolanaSigner: DefaultFeature;
   ldmkSolanaSignerIsTxcActive: DefaultFeature;
   ldmkCosmosSigner: DefaultFeature;
+  ldmkXrpSigner: DefaultFeature;
   ldmkConnectApp: DefaultFeature;
   lldNetworkBasedAddAccount: DefaultFeature;
   llmDatadog: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ catalogs:
     '@ledgerhq/device-signer-kit-solana':
       specifier: 1.13.0
       version: 1.13.0
+    '@ledgerhq/device-signer-kit-xrp':
+      specifier: 0.2.0
+      version: 0.2.0
     '@ledgerhq/device-transport-kit-react-native-ble':
       specifier: 1.3.2
       version: 1.3.2
@@ -12791,6 +12794,9 @@ importers:
       '@ledgerhq/live-signer-solana':
         specifier: workspace:^
         version: link:../live-signer-solana
+      '@ledgerhq/live-signer-xrp':
+        specifier: workspace:^
+        version: link:../live-signer-xrp
       '@ledgerhq/live-signer-zcash':
         specifier: workspace:^
         version: link:../live-signer-zcash
@@ -15928,6 +15934,52 @@ importers:
       '@types/semver':
         specifier: 'catalog:'
         version: 7.7.1
+      jest:
+        specifier: 'catalog:'
+        version: 30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(@typescript/typescript6@6.0.2))
+      rimraf:
+        specifier: ^4.4.1
+        version: 4.4.1
+      ts-node:
+        specifier: ^10.4.0
+        version: 10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+
+  libs/live-signer-xrp:
+    dependencies:
+      '@ledgerhq/device-management-kit':
+        specifier: 'catalog:'
+        version: 1.9.0(rxjs@7.8.2)
+      '@ledgerhq/device-signer-kit-xrp':
+        specifier: 'catalog:'
+        version: 0.2.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
+      '@ledgerhq/hw-app-xrp':
+        specifier: workspace:^
+        version: link:../ledgerjs/packages/hw-app-xrp
+      '@ledgerhq/hw-transport':
+        specifier: workspace:*
+        version: link:../ledgerjs/packages/hw-transport
+      rxjs:
+        specifier: 'catalog:'
+        version: 7.8.2
+    devDependencies:
+      '@ledgerhq/disable-network-setup':
+        specifier: workspace:^
+        version: link:../disable-network-setup
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../support/test-quarantine
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
       jest:
         specifier: 'catalog:'
         version: 30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(@typescript/typescript6@6.0.2))
@@ -22193,6 +22245,11 @@ packages:
     peerDependencies:
       '@ledgerhq/device-management-kit': ^1.8.0
 
+  '@ledgerhq/device-signer-kit-xrp@0.2.0':
+    resolution: {integrity: sha512-7tRV20TvSVWjy1iRALzWf+1RGrDlwVlAsW+SUzeMc0vTed26967gdW0fXjN489kEmxxfTU2EIkIsIf7SuI8qcA==}
+    peerDependencies:
+      '@ledgerhq/device-management-kit': ^1.9.0
+
   '@ledgerhq/device-signer-kit-zcash@0.6.0':
     resolution: {integrity: sha512-RASZEFtPKW+PY8N8Q5NMUT3OF3PkVX0UGLS05GKpbkS5w1eGwtsbXXcgv67oR1DwtJpfPW+98ifdWi42RHalHw==}
     peerDependencies:
@@ -28302,7 +28359,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: '*'
+      rxjs: ^5.5.10
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -48786,6 +48843,15 @@ snapshots:
       - typescript
       - utf-8-validate
 
+  '@ledgerhq/device-signer-kit-xrp@0.2.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))':
+    dependencies:
+      '@ledgerhq/device-management-kit': 1.9.0(rxjs@7.8.2)
+      '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
+      inversify: 7.5.1(reflect-metadata@0.2.2)
+      purify-ts: 2.1.0
+      reflect-metadata: 0.2.2
+      xstate: 5.19.2
+
   '@ledgerhq/device-signer-kit-zcash@0.6.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))':
     dependencies:
       '@ledgerhq/device-management-kit': 1.9.0(rxjs@7.8.2)
@@ -66236,7 +66302,9 @@ snapshots:
     optionalDependencies:
       metro-transform-worker: 0.81.5
     transitivePeerDependencies:
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   metro-config@0.83.3(metro-transform-worker@0.83.3):
     dependencies:
@@ -66283,7 +66351,9 @@ snapshots:
     optionalDependencies:
       metro-transform-worker: 0.83.7
     transitivePeerDependencies:
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   metro-core@0.81.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,6 +34,7 @@ catalog:
   "@ledgerhq/device-signer-kit-solana": 1.13.0
   "@ledgerhq/device-signer-kit-cosmos": 1.0.1
   "@ledgerhq/device-signer-kit-icp": 0.2.0
+  "@ledgerhq/device-signer-kit-xrp": 0.2.0
   "@ledgerhq/device-transport-kit-react-native-ble": 1.3.2
   "@ledgerhq/device-transport-kit-react-native-hid": 1.0.4
   "@ledgerhq/device-transport-kit-speculos": 1.2.1

--- a/shared/feature-flags/src/flags/team-live-devices/index.ts
+++ b/shared/feature-flags/src/flags/team-live-devices/index.ts
@@ -5,6 +5,7 @@ export * from "./ldmkCosmosSigner";
 export * from "./ldmkSolanaSigner";
 export * from "./ldmkSolanaSignerIsTxcActive";
 export * from "./ldmkTransport";
+export * from "./ldmkXrpSigner";
 export * from "./llmNanoSDeprecation";
 export * from "./myLedgerDisplayAppDeveloperName";
 export * from "./onboardingIgnoredOsUpdates";

--- a/shared/feature-flags/src/flags/team-live-devices/ldmkXrpSigner.ts
+++ b/shared/feature-flags/src/flags/team-live-devices/ldmkXrpSigner.ts
@@ -1,0 +1,2 @@
+import { flag } from "../../define";
+export const ldmkXrpSigner = flag();


### PR DESCRIPTION
### 📝 Description

Adds `@ledgerhq/live-signer-xrp` so Ledger Live can drive the XRP app through
`@ledgerhq/device-signer-kit-xrp` instead of `@ledgerhq/hw-app-xrp`, behind the new
`ldmkXrpSigner` feature flag, with the legacy path kept as the fallback. Same shape as
`live-signer-cosmos` / `live-signer-solana`.

**New package `libs/live-signer-xrp/`**

- `LegacySignerXrp` — wraps `new Xrp(transport)`, straight delegation.
- `DmkSignerXrp` — builds via `new SignerXrpBuilder({ dmk, sessionId }).build()`, awaits the
  device-action observable with `lastValueFrom`, and maps `DeviceActionStatus.Error` through
  `_mapError` (`5515` → `LockedDeviceError`, `6985` / `6982` → `UserRefusedOnDevice`, otherwise
  the `_tag`). This is the `DmkSignerEth` / `DmkSignerAleo` shape rather than the cosmos one,
  because the XRP kit's DA errors carry `errorCode` at the top level, not under `originalError`.
  `skipOpenApp: true` on every call — Live opens the app itself.
- `src/types.ts` restates the `XrpSigner` contract. It is duplicated rather than imported
  because live-common depends on this package, not the other way round.

The signing blob is passed through unchanged: the XRP app prepends the `53545800` signing
prefix itself, so — unlike the software signer in `coin-tester-xrp` — the adapter must not add it.

**Wiring**

- `families/xrp/setup.ts` owns `setXrpLdmkEnabled` and the
  `isDmkTransport(transport) && _xrpLdmkFFEnabled` factory (the cosmos convention, so the apps'
  import path matches the existing ones); `families/xrp/signer.ts` consumes that factory and
  keeps its option-shape adapter for the generic coin framework.
- `ldmkXrpSigner` is declared in `libs/types-live/src/feature.ts` **and** registered in
  `shared/feature-flags/src/flags/team-live-devices/` — the latter is what `useFeature` /
  `getFeature` type against, and live-common's build fails without it.
- `useFeature("ldmkXrpSigner")` → `setXrpLdmkEnabled` in LLD `Default.tsx` and LLM `index.tsx`,
  next to the Solana and Cosmos calls.

### 🔗 Context

- **JIRA / GitHub issue**: [DSDK-1453](https://ledgerhq.atlassian.net/browse/DSDK-1453)
- Parent epic: [DSDK-1248](https://ledgerhq.atlassian.net/browse/DSDK-1248) — [TS][Signer] XRP Signer

### ⚠️ Two things to agree on before merge

**1. The catalog pins a nightly.** `@ledgerhq/device-signer-kit-xrp` has no tagged release yet,
so the catalog pins `0.0.0-develop-20260828024102` (same precedent as
`@ledgerhq/device-signer-kit-hyperliquid`). That build also declares a strict peer on
`@ledgerhq/device-management-kit@0.0.0-develop-20260828024102` while the repo resolves DMK to
`1.8.0`. Either we ship on the nightly, or this waits for a tagged `signer-xrp` release.

**2. `ed25519` is not supported yet.** `GetAddressCommand` / `SignTransactionCommand` in that
build pin `p2` to `P2_SECP256K1`; `AddressOptions` / `TransactionOptions` carry no curve option
(`Curve` was described in DSDK-1437 / DSDK-1438 but has not shipped). `DmkSignerXrp` therefore
**throws** on `ed25519 = true` rather than silently signing on the wrong curve. This is not a
regression in practice: the generic coin framework calls `signTransaction` with an options
object, never a boolean, so Live always resolves `ed25519` to `undefined`. It becomes a real
option once the kit ships `Curve`.

### ✅ Checks run

- `nx build @ledgerhq/live-signer-xrp` and `nx build ledger-live-common` pass; `oxlint` / `oxfmt` clean.
- 25 package tests (`DmkSignerXrp`, `LegacySignerXrp`) pass, at 100% line and branch coverage.
- 22 live-common `families/xrp` tests pass. The new `setup.test.ts` covers all four
  flag × transport combinations, including **DMK transport with the flag off → legacy signer**.

### 🧪 Not covered here

- Receive and send verified on LLD / LLM against a device or Speculos with the flag on.
- A `coin-tester-xrp` run.


[DSDK-1453]: https://ledgerhq.atlassian.net/browse/DSDK-1453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ