### PR TITLE
ci(desktop): make Windows nx cache read-only (LIVE-36624)

### DIFF
--- a/.github/workflows/build-desktop-reusable.yml
+++ b/.github/workflows/build-desktop-reusable.yml
@@ -73,6 +73,7 @@ jobs:
 
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
+      NX_POWERPACK_CACHE_MODE: ${{ matrix.config.name == 'Windows' && 'read-only' || '' }}
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:


### PR DESCRIPTION
### 📝 Description

The Windows desktop build job fails with an EOF error when the Nx S3 remote cache uploads a fresh cache entry, driven by the size of the `ledger-live-common` outputs. This sets `NX_POWERPACK_CACHE_MODE: read-only` on the Windows matrix entry of `build-desktop-reusable.yml` so the job never writes to the remote cache.

Reads are unaffected. `@nx/s3-cache` treats `read-only` as reads enabled / writes disabled, so the Windows job still restores entries from the same bucket and `cacheKeyPrefix` as its peers — including hits produced by the Linux and macOS jobs in the same run and by earlier runs on the branch. Only the upload path is removed.

Linux and macOS are untouched: the expression resolves to an empty string for them, which the plugin treats as unset, so they keep the workspace default `ciMode: "read-write"` from `nx.s3.defaults.json`.

Trade-off: task outputs that only ever run on Windows are no longer populated in the cache by this job, so those tasks recompute on every Windows run. Everything shared with Linux/macOS is still cached by those jobs, so the practical hit rate for Windows stays close to unchanged. This only affects the Nx remote cache — the pnpm store and CocoaPods caches in `setup-caches` are already skipped for this workflow.

This is firefighting, not a fix for the underlying artefact size.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36624](https://ledgerhq.atlassian.net/browse/LIVE-36624)
- Test run: https://github.com/LedgerHQ/ledger-live/actions/runs/33501740993/job/99836711500?pr=21327


[LIVE-36624]: https://ledgerhq.atlassian.net/browse/LIVE-36624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ