### PR TITLE
fix(e2e): wait for the portfolio balance to resolve (QAA-1523)

### DIFF
--- a/.changeset/qaa-1523-await-balance-resolved.md
+++ b/.changeset/qaa-1523-await-balance-resolved.md
@@ -1,0 +1,18 @@
+---
+"ledger-live-mobile-e2e-tests": patch
+---
+
+Wait for the portfolio balance to resolve before reading it (QAA-1523)
+
+`expectTotalBalanceCounterValue` read `portfolio-balance-amount` with no prior
+wait. The balance section renders a skeleton in place of that element until the
+counter values resolve, so straight after a counter-value change the element does
+not exist. `getLabelOfElement` wraps its read in `retryUntilTimeout`, which
+retries on throw — so it polled a missing element for 60s and failed with
+`❌ [retryUntilTimeout] Timed out after 60000ms`, naming neither the element nor
+the reason. 3/5 nightlies on Android.
+
+The assertion now waits for `portfolio-balance-normal`, which the section carries
+only once the balance is available, before reading the amount. That puts the
+budget on the step that is actually slow and separates "the balance never
+resolved" from "it resolved in the wrong currency".

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -132,14 +132,6 @@ export default class PortfolioPage {
 
   @Step("Expect total balance value {{{0}}}")
   async expectTotalBalanceCounterValue(counterValue: string) {
-    // The balance section renders a skeleton in place of the amount until the counter values
-    // resolve, and carries portfolio-balance-loading rather than portfolio-balance-normal while
-    // it does. So after a counter-value change portfolio-balance-amount does not exist yet.
-    // Reading it straight away left getLabelOfElement polling a missing element through
-    // retryUntilTimeout, which failed after 60s with a message naming neither the element nor
-    // the reason (QAA-1523). Waiting on the section's resolved state gives the budget to the
-    // thing that is actually slow, and tells the two failures apart: balance never resolved
-    // versus resolved in the wrong currency.
     await waitForElementById(this.portfolioBalanceNormal);
     const label = await getLabelOfElement(this.portfolioBalanceAmount);
     jestExpect(label).toContain(counterValue);

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -132,6 +132,15 @@ export default class PortfolioPage {
 
   @Step("Expect total balance value {{{0}}}")
   async expectTotalBalanceCounterValue(counterValue: string) {
+    // The balance section renders a skeleton in place of the amount until the counter values
+    // resolve, and carries portfolio-balance-loading rather than portfolio-balance-normal while
+    // it does. So after a counter-value change portfolio-balance-amount does not exist yet.
+    // Reading it straight away left getLabelOfElement polling a missing element through
+    // retryUntilTimeout, which failed after 60s with a message naming neither the element nor
+    // the reason (QAA-1523). Waiting on the section's resolved state gives the budget to the
+    // thing that is actually slow, and tells the two failures apart: balance never resolved
+    // versus resolved in the wrong currency.
+    await waitForElementById(this.portfolioBalanceNormal);
     const label = await getLabelOfElement(this.portfolioBalanceAmount);
     jestExpect(label).toContain(counterValue);
   }


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _This change is itself E2E test code, and there is no unit test for a Detox page object. It is verified by a filtered Mobile E2E run on this branch ([run 33394793726](https://github.com/LedgerHQ/ledger-live/actions/runs/33394793726), iOS & Android), and the standing regression detector is the nightly flake report (`e2e/mobile/scripts/flake-report.mjs`), which measured this signature at 3/5 nightlies._
- [x] **Impact of the changes:**
      - `userCanSelectCounterValueToDisplayAmountInLedgerLive.spec.ts` — the **only** caller of the changed method, so this is the complete blast radius
      - The portfolio total-balance assertion after a counter-value change
      - No other caller exists, so no other spec can regress
      - No product code is touched — only `e2e/mobile/page/wallet/portfolio.page.ts`

### Description

**Problem.** `expectTotalBalanceCounterValue` read the amount with no prior wait:

```ts
const label = await getLabelOfElement(this.portfolioBalanceAmount);
jestExpect(label).toContain(counterValue);
```

`PortfolioBalanceSectionView` renders a Skeleton **in place of** that element while the balance is unavailable, and carries `portfolio-balance-loading` rather than `portfolio-balance-normal` while it does:

```tsx
{isBalanceAvailable ? (
  <AmountDisplay testID="portfolio-balance-amount" .../>
) : (
  <Skeleton testID="portfolio-placeholder-balance" .../>
)}
```

The spec changes the counter value and then reads the balance immediately, so the EUR counter values are still resolving and `portfolio-balance-amount` **does not exist yet**:

```ts
await app.settingsGeneral.changeCounterValue("Euro - EUR");
await app.mainNavigation.openPortfolioViaDeeplink();
await app.portfolio.expectTotalBalanceCounterValue("€");   // reads immediately
```

`getLabelOfElement` wraps its `getAttributes()` call in `retryUntilTimeout`, which **retries on throw**. So the assertion polled a missing element every 500ms for 60s and then failed with `❌ [retryUntilTimeout] Timed out after 60000ms` — naming neither the element nor the reason. That opacity is why the ticket's original hypothesis (the string being compared before the re-render settled) was wrong: the element was absent, not stale.

**Solution.** Wait for the section's resolved state before reading it.

```ts
await waitForElementById(this.portfolioBalanceNormal);
const label = await getLabelOfElement(this.portfolioBalanceAmount);
jestExpect(label).toContain(counterValue);
```

`portfolio-balance-normal` is applied only when `isBalanceAvailable` is true, which is exactly the condition under which `portfolio-balance-amount` renders — so it is a precise anchor, not a proxy. This puts the wait budget on the step that is actually slow, and it separates two failures the old message conflated: *the balance never resolved* versus *it resolved in the wrong currency*. `e2e/mobile/docs/add-or-update-e2e.md` rules 11 and 12.

No product-code change was needed — `portfolio-balance-normal` already exists and the page object already held the constant.

**Trade-off worth naming.** The `noSigner` and `noAccounts` states carry different ids (`portfolio-balance-noSigner`, `portfolio-balance-noAccounts`), so this anchor is only correct for the `normal` state. That is safe here because the single caller runs with a funded account via `liveDataCommand`. A future caller asserting a balance in a read-only or empty-portfolio state would need a different anchor.

**Evidence.** 3/5 nightlies, most recently 2026-08-28, Android only, 20% of runs of the spec. Neither occurrence in the current window is from the infra-suspect 2026-08-25 night. `oxfmt`, `oxlint` and `pnpm typecheck` all clean.

### Context

- **JIRA or GitHub link**: [QAA-1523](https://ledgerhq.atlassian.net/browse/QAA-1523) (sub-task of [QAA-1445](https://ledgerhq.atlassian.net/browse/QAA-1445))

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[QAA-1523]: https://ledgerhq.atlassian.net/browse/QAA-1523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ