### PR TITLE
[LWDM] feat(zcash): resolve send descriptor via bridge family resolution

### DIFF
--- a/.changeset/brave-memos-validate.md
+++ b/.changeset/brave-memos-validate.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-zcash": minor
+---
+
+Reject a Zcash memo exceeding the ZIP-302 512-byte limit in getTransactionStatus

--- a/.changeset/tame-otters-resolve.md
+++ b/.changeset/tame-otters-resolve.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Add a Zcash send descriptor declaring the ZIP-317 fee model and a shielded memo input

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7346,6 +7346,9 @@
     "ZcashAmountBelowDustThreshold": {
       "title": "Amount is too small to be broadcast (minimum {{minimumZatoshis}} zatoshis)"
     },
+    "ZcashMemoTooLong": {
+      "title": "Memo must not exceed {{maxBytes}} bytes"
+    },
     "InvalidNonce": {
       "title": "Nonce is required"
     },

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -129,6 +129,9 @@
     "ldmkEnabled": "LDMK transport enabled"
   },
   "errors": {
+    "ZcashMemoTooLong": {
+      "title": "Memo must not exceed {{maxBytes}} bytes"
+    },
     "ReplacementTransactionUnderpriced": {
       "title": "Replacement transaction underpriced",
       "description": "The network fee might be too low. Please increase"

--- a/libs/coin-modules/coin-zcash/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/getTransactionStatus.test.ts
@@ -662,6 +662,33 @@ describe("getTransactionStatus, note-spending flows", () => {
   });
 });
 
+describe("getTransactionStatus, memo byte limit", () => {
+  it.each([
+    [
+      "transparent-input",
+      transaction({ transferType: "transparent-to-shielded", recipient: U_ADDRESS }),
+    ],
+    ["note-spending", transaction({ transferType: "shielded", recipient: U_ADDRESS })],
+  ])("rejects an oversized UTF-8 memo for %s flows", async (_label, tx) => {
+    const status = await getTransactionStatus(account(), { ...tx, memo: "😀".repeat(129) });
+
+    expect(status.errors.transaction?.name).toBe("ZcashMemoTooLong");
+  });
+
+  it("accepts a memo at exactly 512 UTF-8 bytes", async () => {
+    const status = await getTransactionStatus(
+      account(),
+      transaction({
+        transferType: "transparent-to-shielded",
+        recipient: U_ADDRESS,
+        memo: "😀".repeat(128),
+      }),
+    );
+
+    expect(status.errors.transaction).toBeUndefined();
+  });
+});
+
 describe("getTransactionStatus, recipientIsReadOnly", () => {
   it.each([
     ["transparent-input", transaction({ selfTransfer: true }), account()],

--- a/libs/coin-modules/coin-zcash/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/getTransactionStatus.ts
@@ -3,7 +3,8 @@ import { NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import type { AccountBridge } from "@ledgerhq/types-live";
 import type { Transaction, TransactionStatus, ZcashAccount } from "../types/bridge";
 import { ZIP317_MINIMUM_FEE } from "../logic/coin-selection";
-import { ZcashAmountBelowDustThreshold } from "../types/errors";
+import { ZcashAmountBelowDustThreshold, ZcashMemoTooLong } from "../types/errors";
+import { ZCASH_MEMO_MAX_BYTES } from "../constants";
 import {
   computeAmountError,
   computeRecipientError,
@@ -14,6 +15,14 @@ import {
 } from "./statusHelpers";
 import { getReservedNullifiers } from "./note-reservation";
 import { getSpendableIronwoodBalance } from "../logic/account/spendability";
+
+const encoder = new TextEncoder();
+
+function computeMemoError(memo: string | undefined): Error | null {
+  return memo !== undefined && encoder.encode(memo).length > ZCASH_MEMO_MAX_BYTES
+    ? new ZcashMemoTooLong(ZCASH_MEMO_MAX_BYTES)
+    : null;
+}
 
 /**
  * Transaction status for a transparent-input (Public→*) send: the recipient
@@ -28,6 +37,8 @@ function getTransparentInputStatus(
 ): TransactionStatus {
   const errors: Record<string, Error> = {};
   const warnings: Record<string, Error> = {};
+  const memoError = computeMemoError(tx.memo);
+  if (memoError) errors.transaction = memoError;
 
   const transparentBalance = resolveTransparentUtxos(account, tx).reduce(
     (sum, utxo) => sum.plus(utxo.value),
@@ -69,6 +80,8 @@ export const getTransactionStatus: AccountBridge<
 
   const errors: Record<string, Error> = {};
   const warnings: Record<string, Error> = {};
+  const memoError = computeMemoError(transaction.memo);
+  if (memoError) errors.transaction = memoError;
 
   const privateInfo = account.privateInfo;
   if (!privateInfo) {

--- a/libs/coin-modules/coin-zcash/src/constants.ts
+++ b/libs/coin-modules/coin-zcash/src/constants.ts
@@ -65,6 +65,7 @@ export const ZCASH_ACTIVATION_DATE_STRING = "2026-07-28";
 // the note's transaction has this many blocks mined on top of it, the spendable
 // balance can trail the total.
 export const ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS = 12;
+export const ZCASH_MEMO_MAX_BYTES = 512;
 /** @deprecated kept for backward compatibility */
 export const ZCASH_OUTDATED_SYNC_INTERVAL_MINUTES = 2;
 /** @deprecated kept for backward compatibility */

--- a/libs/coin-modules/coin-zcash/src/types/errors.ts
+++ b/libs/coin-modules/coin-zcash/src/types/errors.ts
@@ -75,6 +75,16 @@ export class ZcashAmountBelowDustThreshold extends Error {
   }
 }
 
+export class ZcashMemoTooLong extends Error {
+  maxBytes: number;
+
+  constructor(maxBytes: number, message = `Memo exceeds the ${maxBytes}-byte limit`) {
+    super(message);
+    this.name = "ZcashMemoTooLong";
+    this.maxBytes = maxBytes;
+  }
+}
+
 /**
  * Raised when the builder rejects a selected note because its leaf position is
  * at or past the number of leaves the Ironwood tree held at its anchor -- the

--- a/libs/ledger-live-common/src/bridge/descriptor.test.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor.test.ts
@@ -718,6 +718,7 @@ describe("zcash descriptor resolution", () => {
   });
 
   afterEach(() => {
+    jest.restoreAllMocks();
     // `setZcashShieldedEnabled` is module-level global state shared across
     // every suite in this jest worker: restore it so later suites are not
     // silently corrupted.

--- a/libs/ledger-live-common/src/bridge/descriptor.test.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor.test.ts
@@ -6,6 +6,7 @@ import { resolveFeeUnitLabel, sendFeatures } from "./descriptor/send/features";
 import { applyMemoToTransaction } from "./descriptor/send/memo";
 import * as configModule from "../config/index";
 import { genAccount } from "../mock/account";
+import { isZcashShieldedEnabled, setZcashShieldedEnabled } from "./zcashRouting";
 
 jest.mock("../config/index");
 
@@ -702,4 +703,117 @@ describe("sendFeatures", () => {
       sendFeatures.isUserRefusedTransactionError(undefined, { name: "TransactionRefusedOnDevice" }),
     ).toBe(false);
   });
+});
+
+describe("zcash descriptor resolution", () => {
+  const previousShieldedEnabled = isZcashShieldedEnabled();
+
+  beforeEach(() => {
+    jest.spyOn(configModule, "getCurrencyConfiguration").mockReturnValue({
+      status: {
+        type: "active",
+        features: [{ id: "blockchain_txs", status: "active" }],
+      },
+    });
+  });
+
+  afterEach(() => {
+    // `setZcashShieldedEnabled` is module-level global state shared across
+    // every suite in this jest worker: restore it so later suites are not
+    // silently corrupted.
+    setZcashShieldedEnabled(previousShieldedEnabled);
+  });
+
+  it("returns the Zcash descriptor when zcashShielded is on", () => {
+    setZcashShieldedEnabled(true);
+    const zcash = getCryptoCurrencyById("zcash");
+
+    const descriptor = getDescriptor(zcash);
+
+    expect(descriptor).toMatchObject({
+      send: {
+        inputs: { memo: { type: "text", maxLength: 512 } },
+        fees: {
+          hasPresets: false,
+          hasCustom: false,
+          hasCoinControl: false,
+        },
+        selfTransfer: "free",
+      },
+    });
+  });
+
+  it("is not the Bitcoin descriptor when zcashShielded is on", () => {
+    setZcashShieldedEnabled(true);
+    const zcash = getCryptoCurrencyById("zcash");
+
+    const descriptor = getDescriptor(zcash);
+
+    expect(descriptor?.send.fees.presets).toBeUndefined();
+    expect(descriptor?.send.fees.coinControl).toBeUndefined();
+  });
+
+  it("returns the Bitcoin descriptor when zcashShielded is off", () => {
+    // Deliberate: with the flag off, the account is served by coin-bitcoin's
+    // Zcash chain-adapter, so the Bitcoin descriptor is the consistent answer.
+    setZcashShieldedEnabled(false);
+    const zcash = getCryptoCurrencyById("zcash");
+
+    const descriptor = getDescriptor(zcash);
+
+    expect(descriptor?.send.fees.hasCoinControl).toBe(true);
+  });
+
+  it("resolves memo and fee-preset features for Zcash when the flag is on", () => {
+    setZcashShieldedEnabled(true);
+    const zcash = getCryptoCurrencyById("zcash");
+
+    expect(sendFeatures.hasMemo(zcash)).toBe(true);
+    expect(sendFeatures.getMemoMaxLength(zcash)).toBe(512);
+    expect(sendFeatures.hasDefaultStrategy(zcash)).toBe(false);
+    expect(sendFeatures.getFeePresetOptions(zcash, {})).toEqual([]);
+  });
+
+  it.each([true, false])(
+    "leaves the Bitcoin descriptor unchanged regardless of the Zcash flag (flag=%s)",
+    flag => {
+      setZcashShieldedEnabled(flag);
+      const bitcoin = getCryptoCurrencyById("bitcoin");
+
+      const descriptor = getDescriptor(bitcoin);
+
+      expect(descriptor?.send.fees).toMatchObject({
+        hasCoinControl: true,
+        hasPresets: true,
+        hasCustom: true,
+      });
+    },
+  );
+
+  it.each([true, false])(
+    "leaves an unrelated family (evm) unchanged regardless of the Zcash flag (flag=%s)",
+    flag => {
+      setZcashShieldedEnabled(flag);
+      const ethereum = getCryptoCurrencyById("ethereum");
+
+      const descriptor = getDescriptor(ethereum);
+
+      expect(descriptor?.send.fees).toMatchObject({
+        hasPresets: true,
+        hasCustom: true,
+      });
+    },
+  );
+
+  it.each([true, false])(
+    "resolves the identity family for a non-Zcash bitcoin-family currency (litecoin, flag=%s)",
+    flag => {
+      setZcashShieldedEnabled(flag);
+      const litecoin = getCryptoCurrencyById("litecoin");
+
+      const descriptor = getDescriptor(litecoin);
+
+      expect(descriptor?.send.fees.hasCoinControl).toBe(true);
+    },
+  );
 });

--- a/libs/ledger-live-common/src/bridge/descriptor/registry.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor/registry.ts
@@ -1,6 +1,7 @@
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import { getCurrencyBridge } from "../impl";
+import { resolveFamily } from "../zcashRouting";
 import { descriptor as algorandDescriptor } from "../../families/algorand/descriptor";
 import { descriptor as aptosDescriptor } from "../../families/aptos/descriptor";
 import { descriptor as bitcoinDescriptor } from "../../families/bitcoin/descriptor";
@@ -28,6 +29,7 @@ import { descriptor as tonDescriptor } from "../../families/ton/descriptor";
 import { descriptor as tronDescriptor } from "../../families/tron/descriptor";
 import { descriptor as vechainDescriptor } from "../../families/vechain/descriptor";
 import { descriptor as xrpDescriptor } from "../../families/xrp/descriptor";
+import { descriptor as zcashDescriptor } from "../../families/zcash/descriptor";
 import type { CoinDescriptor, SendDescriptor, StakeDescriptor } from "./types";
 
 const descriptorRegistry: Record<string, CoinDescriptor> = {
@@ -58,6 +60,7 @@ const descriptorRegistry: Record<string, CoinDescriptor> = {
   tron: tronDescriptor,
   vechain: vechainDescriptor,
   xrp: xrpDescriptor,
+  zcash: zcashDescriptor,
 };
 
 /**
@@ -78,7 +81,9 @@ export function getDescriptor(currency: CryptoOrTokenCurrency | undefined): Coin
   }
 
   // Fallback: use the descriptor registry
-  const fullDescriptor = descriptorRegistry[cryptoCurrency.family];
+  // Same family resolution as the bridge layer, so a Zcash account served by
+  // @ledgerhq/coin-zcash resolves to the Zcash descriptor rather than Bitcoin's.
+  const fullDescriptor = descriptorRegistry[resolveFamily(cryptoCurrency)];
   if (fullDescriptor) {
     return fullDescriptor;
   }

--- a/libs/ledger-live-common/src/bridge/impl.ts
+++ b/libs/ledger-live-common/src/bridge/impl.ts
@@ -26,7 +26,7 @@ import {
   loadBridgeExtensionsForFamily,
 } from "../coin-modules/registry";
 import { defaultBridgeExtensions } from "./defaultBridgeExtensions";
-import { isZcashShieldedEnabled } from "./zcashRouting";
+import { resolveFamily } from "./zcashRouting";
 import { liveBlindSigningReporter } from "@ledgerhq/live-dmk-shared";
 import { throwError } from "rxjs";
 import { catchError, tap } from "rxjs/operators";
@@ -41,15 +41,7 @@ import {
   TransactionStage,
 } from "@ledgerhq/transaction-observability";
 
-// The family owning a currency's bridge is `currency.family`, except zcash:
-// `zcashShielded` routes it to the standalone "zcash" family
-// (@ledgerhq/coin-zcash) instead of coin-bitcoin's chain-adapter. The flag is
-// read from the mirror the host app feeds (`setZcashShieldedEnabled`), so a
-// developer-drawer override moves the routing with it; the two families keep
-// separate cache entries, so a flip mid-session resolves the other bridge.
-function resolveFamily(currency: CryptoCurrency): string {
-  return currency.id === "zcash" && isZcashShieldedEnabled() ? "zcash" : currency.family;
-}
+export { resolveFamily };
 
 // Rejections stay cached: evicting would hand React.use() a fresh Promise per render and re-suspend forever.
 // Callers that want to retry a transient failure must invalidate via clearBridgeCache(family).

--- a/libs/ledger-live-common/src/bridge/zcashRouting.ts
+++ b/libs/ledger-live-common/src/bridge/zcashRouting.ts
@@ -1,3 +1,5 @@
+import type { CryptoCurrency } from "@domain/entity-currency-crypto";
+
 // Which module serves a Zcash account: the standalone @ledgerhq/coin-zcash, or
 // coin-bitcoin's Zcash chain-adapter.
 //
@@ -20,3 +22,8 @@ export const setZcashShieldedEnabled = (enabled: boolean): void => {
 
 /** Whether Zcash accounts are served by @ledgerhq/coin-zcash. */
 export const isZcashShieldedEnabled = (): boolean => shieldedEnabled;
+
+/** Bridge family for `currency`: `zcash` when shielded, otherwise `currency.family`. */
+export function resolveFamily(currency: CryptoCurrency): string {
+  return currency.id === "zcash" && isZcashShieldedEnabled() ? "zcash" : currency.family;
+}

--- a/libs/ledger-live-common/src/families/zcash/descriptor/index.test.ts
+++ b/libs/ledger-live-common/src/families/zcash/descriptor/index.test.ts
@@ -1,0 +1,27 @@
+import { descriptor } from "./index";
+
+describe("zcash send descriptor", () => {
+  it("declares nothing that replaces estimatedFees", () => {
+    // ZIP-317 is the one conventional fee, computed by the bridge and surfaced
+    // as `status.estimatedFees`; the descriptor must not intercept it with a
+    // preset list, a custom-fee input, a default-strategy patch, or a
+    // `getNetworkFeesInfo` override.
+    expect(descriptor.send.fees.hasPresets).toBe(false);
+    expect(descriptor.send.fees.hasCustom).toBe(false);
+    expect(descriptor.send.fees.hasCoinControl).toBe(false);
+    expect(descriptor.send.fees.presets).toBeUndefined();
+    expect(descriptor.send.fees.custom).toBeUndefined();
+    expect(descriptor.send.fees.coinControl).toBeUndefined();
+    expect(descriptor.send.fees.defaultStrategy).toBeUndefined();
+    expect(descriptor.send.fees.getNetworkFeesInfo).toBeUndefined();
+    expect(descriptor.send.errors).toBeUndefined();
+  });
+
+  it("declares a shielded memo input capped at 512 characters", () => {
+    expect(descriptor.send.inputs.memo).toEqual({ type: "text", maxLength: 512 });
+  });
+
+  it("allows self-transfer", () => {
+    expect(descriptor.send.selfTransfer).toBe("free");
+  });
+});

--- a/libs/ledger-live-common/src/families/zcash/descriptor/index.ts
+++ b/libs/ledger-live-common/src/families/zcash/descriptor/index.ts
@@ -1,0 +1,17 @@
+import type { CoinDescriptor } from "../../../bridge/descriptor/types";
+import { memo } from "./memo";
+
+// ZIP-317 defines one conventional fee computed from the transaction's action
+// layout: no presets, no custom fee, and no coin control. The fee shown is the
+// bridge's `status.estimatedFees`, which the descriptor deliberately leaves alone.
+export const descriptor: CoinDescriptor = {
+  send: {
+    inputs: { memo },
+    fees: {
+      hasPresets: false,
+      hasCustom: false,
+      hasCoinControl: false,
+    },
+    selfTransfer: "free",
+  },
+};

--- a/libs/ledger-live-common/src/families/zcash/descriptor/memo.ts
+++ b/libs/ledger-live-common/src/families/zcash/descriptor/memo.ts
@@ -1,8 +1,8 @@
 import type { InputDescriptor } from "../../../bridge/descriptor/types";
 
-// ZIP-302 caps a shielded-output memo at 512 bytes. `maxLength` caps characters,
-// so multi-byte input can still exceed the byte budget; the legacy field
-// truncates on bytes (see apps/ledger-live-desktop/.../ZcashMemoField.tsx).
+// ZIP-302 caps a shielded-output memo at 512 bytes, while `maxLength` caps characters.
+// The byte budget is enforced by coin-zcash's getTransactionStatus, which rejects a
+// multi-byte memo that fits in 512 characters but not in 512 bytes.
 export const memo: InputDescriptor = {
   type: "text",
   maxLength: 512,

--- a/libs/ledger-live-common/src/families/zcash/descriptor/memo.ts
+++ b/libs/ledger-live-common/src/families/zcash/descriptor/memo.ts
@@ -1,0 +1,9 @@
+import type { InputDescriptor } from "../../../bridge/descriptor/types";
+
+// ZIP-302 caps a shielded-output memo at 512 bytes. `maxLength` caps characters,
+// so multi-byte input can still exceed the byte budget; the legacy field
+// truncates on bytes (see apps/ledger-live-desktop/.../ZcashMemoField.tsx).
+export const memo: InputDescriptor = {
+  type: "text",
+  maxLength: 512,
+};

--- a/libs/ledger-live-common/src/flows/send/__tests__/uiConfig.zcash.test.ts
+++ b/libs/ledger-live-common/src/flows/send/__tests__/uiConfig.zcash.test.ts
@@ -1,0 +1,78 @@
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { getSendUiConfig } from "../uiConfig";
+import { isZcashShieldedEnabled, setZcashShieldedEnabled } from "../../../bridge/zcashRouting";
+
+// Unlike `flows/__tests__/uiConfig.test.ts`, this suite does not mock the
+// registry or `sendFeatures`: it exercises the real family-resolution ->
+// descriptor -> uiConfig chain end to end.
+
+describe("getSendUiConfig (zcash, real resolution)", () => {
+  const previousShieldedEnabled = isZcashShieldedEnabled();
+
+  afterEach(() => {
+    // `setZcashShieldedEnabled` is module-level global state shared across
+    // every suite in this jest worker: restore it so later suites are not
+    // silently corrupted.
+    setZcashShieldedEnabled(previousShieldedEnabled);
+  });
+
+  it("resolves the ZIP-317 fee config with the flag on", () => {
+    setZcashShieldedEnabled(true);
+    const zcash = getCryptoCurrencyById("zcash");
+
+    const uiConfig = getSendUiConfig(zcash);
+
+    expect(uiConfig.hasFeePresets).toBe(false);
+    expect(uiConfig.hasCustomFees).toBe(false);
+    expect(uiConfig.hasCoinControl).toBe(false);
+    expect(uiConfig.hasDefaultStrategy).toBe(false);
+    expect(uiConfig.hasMemo).toBe(true);
+    expect(uiConfig.memoType).toBe("text");
+    expect(uiConfig.memoMaxLength).toBe(512);
+  });
+
+  it("areFeesEditable is false", () => {
+    setZcashShieldedEnabled(true);
+    const zcash = getCryptoCurrencyById("zcash");
+
+    const uiConfig = getSendUiConfig(zcash);
+
+    // Reproduces `flows/send/hooks/useNetworkFeesCore.ts:172` verbatim:
+    //   areFeesEditable = feeStrategyOptions.length > 0 || uiConfig.hasCustomFees || uiConfig.hasCoinControl
+    // `feeStrategyOptions` (useNetworkFeesCore.ts:135-146) is empty here because
+    // it is only populated from fee presets, and falls back to a single
+    // "default" entry only when `hasDefaultStrategy` is true -- both false for
+    // Zcash. A future edit to either hook is caught by this citation drifting.
+    const feeStrategyOptions = uiConfig.hasFeePresets
+      ? ["preset"]
+      : uiConfig.hasDefaultStrategy
+        ? ["default"]
+        : [];
+    const areFeesEditable =
+      feeStrategyOptions.length > 0 || uiConfig.hasCustomFees || uiConfig.hasCoinControl;
+
+    expect(areFeesEditable).toBe(false);
+  });
+
+  it("regression: Bitcoin keeps coin control", () => {
+    setZcashShieldedEnabled(true);
+    const bitcoin = getCryptoCurrencyById("bitcoin");
+
+    const uiConfig = getSendUiConfig(bitcoin);
+
+    expect(uiConfig.hasCoinControl).toBe(true);
+    expect(uiConfig.hasFeePresets).toBe(true);
+    expect(uiConfig.hasCustomFees).toBe(true);
+  });
+
+  it("regression: an unrelated family (evm) is unchanged", () => {
+    setZcashShieldedEnabled(true);
+    const ethereum = getCryptoCurrencyById("ethereum");
+
+    const uiConfig = getSendUiConfig(ethereum);
+
+    expect(uiConfig.hasFeePresets).toBe(true);
+    expect(uiConfig.hasCustomFees).toBe(true);
+    expect(uiConfig.recipientSupportsDomain).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Resolve the send descriptor through the same family resolution as the bridge, and add a Zcash send descriptor declaring the ZIP-317 fee model (no presets, no custom fees, no coin control) and a shielded memo input
### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36470](https://ledgerhq.atlassian.net/browse/LIVE-36470)


[LIVE-36470]: https://ledgerhq.atlassian.net/browse/LIVE-36470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ