### PR TITLE
[LWM] feat(send): open the mad in the new send flow on lwm

### DIFF
--- a/.changeset/good-rats-push.md
+++ b/.changeset/good-rats-push.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"ledger-live-mobile-e2e-tests": minor
+---
+
+feat(send): open the MAD for the new send flow on LWM

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/components/QuickActionsCtas/__tests__/useQuickActionsCtasViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/components/QuickActionsCtas/__tests__/useQuickActionsCtasViewModel.test.ts
@@ -1,10 +1,15 @@
-import { renderHook } from "@tests/test-renderer";
+import { act, renderHook, withFlagOverrides } from "@tests/test-renderer";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { Account } from "@ledgerhq/types-live";
 import type { State } from "~/reducers/types";
+import { NavigatorName, ScreenName } from "~/const";
+import { track } from "~/analytics";
 import { useQuickActionsCtasViewModel } from "../useQuickActionsCtasViewModel";
 import { QUICK_ACTIONS_TEST_IDS } from "../../../testIds";
+
+const mockNavigate = jest.fn();
+const mockHandleOpenSendFlow = jest.fn();
 
 jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => {
   const { defaultIsAccountEmpty } = jest.requireActual(
@@ -21,7 +26,7 @@ jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => {
 
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
-  useNavigation: () => ({ navigate: jest.fn() }),
+  useNavigation: () => ({ navigate: mockNavigate }),
   useRoute: () => ({ name: "Portfolio", key: "portfolio-key", params: {} }),
 }));
 
@@ -45,6 +50,10 @@ jest.mock("LLM/features/Swap", () => ({
 
 jest.mock("LLM/features/Receive", () => ({
   useOpenReceiveDrawer: () => ({ handleOpenReceiveDrawer: jest.fn() }),
+}));
+
+jest.mock("LLM/features/Send/hooks/useOpenSendFlow", () => ({
+  useOpenSendFlow: () => ({ handleOpenSendFlow: mockHandleOpenSendFlow }),
 }));
 
 const bitcoin = getCryptoCurrencyById("bitcoin");
@@ -75,6 +84,10 @@ const withEmptyAccount = (state: State): State => ({
 });
 
 describe("useQuickActionsCtasViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("returns the no_signer CTAs (connect + buy_ledger) when readOnlyModeEnabled", () => {
     const { result } = renderHook(() => useQuickActionsCtasViewModel(), {
       overrideInitialState: withReadOnly,
@@ -125,5 +138,77 @@ describe("useQuickActionsCtasViewModel", () => {
     );
 
     expect(result.current.quickActions.length).toBeGreaterThan(0);
+  });
+
+  it("keeps legacy account selection when the new send flow is disabled", () => {
+    const { result } = renderHook(() => useQuickActionsCtasViewModel(), {
+      overrideInitialState: withFlagOverrides(
+        { lwmQuickActionsCtasVariant: { enabled: true } },
+        withFundedAccount,
+      ),
+    });
+
+    const sendAction = result.current.quickActions.find(action => action.id === "send");
+    expect(sendAction).toBeDefined();
+    act(() => sendAction!.onPress());
+
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SendFunds, {
+      screen: ScreenName.SendCoin,
+    });
+    expect(mockHandleOpenSendFlow).not.toHaveBeenCalled();
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({ button: "send", newSendFlow: false }),
+    );
+  });
+
+  it("opens the modular account selection when the new send flow is enabled", () => {
+    const { result } = renderHook(() => useQuickActionsCtasViewModel(), {
+      overrideInitialState: withFlagOverrides(
+        {
+          lwmQuickActionsCtasVariant: { enabled: true },
+          newSendFlow: {
+            enabled: true,
+            params: { families: ["evm"], excludedCurrencyIds: [] },
+          },
+        },
+        withFundedAccount,
+      ),
+    });
+
+    const sendAction = result.current.quickActions.find(action => action.id === "send");
+    expect(sendAction).toBeDefined();
+    act(() => sendAction!.onPress());
+
+    expect(mockHandleOpenSendFlow).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({ button: "send", newSendFlow: true }),
+    );
+  });
+
+  it("keeps legacy account selection when the new send flow config has no families", () => {
+    const { result } = renderHook(() => useQuickActionsCtasViewModel(), {
+      overrideInitialState: withFlagOverrides(
+        {
+          lwmQuickActionsCtasVariant: { enabled: true },
+          newSendFlow: {
+            enabled: true,
+            params: { families: [], excludedCurrencyIds: [] },
+          },
+        },
+        withFundedAccount,
+      ),
+    });
+
+    const sendAction = result.current.quickActions.find(action => action.id === "send");
+    expect(sendAction).toBeDefined();
+    act(() => sendAction!.onPress());
+
+    expect(mockHandleOpenSendFlow).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SendFunds, {
+      screen: ScreenName.SendCoin,
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/components/QuickActionsCtas/useQuickActionsCtasViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/components/QuickActionsCtas/useQuickActionsCtasViewModel.ts
@@ -28,6 +28,9 @@ import { useTranslation } from "~/context/Locale";
 import useBuyDeviceAction from "LLM/features/Reborn/hooks/useBuyDeviceAction";
 import { useOpenSwap } from "LLM/features/Swap";
 import { useOpenReceiveDrawer } from "LLM/features/Receive";
+import { useNewSendFlowFeature } from "LLM/features/Send/hooks/useNewSendFlowFeature";
+import { useOpenSendFlow } from "LLM/features/Send/hooks/useOpenSendFlow";
+import { getSendFlowTrackingProperties } from "@ledgerhq/ledger-wallet-framework/tracking/send";
 
 const BUTTON_LOCATION = "quick_action";
 
@@ -70,6 +73,11 @@ export const useQuickActionsCtasViewModel = ({
     sourceScreenName: pageName,
     fromMenu: false,
   });
+  const { isEnabledForFamily } = useNewSendFlowFeature();
+  const shouldOpenNewSendFlow = isEnabledForFamily();
+  const { handleOpenSendFlow } = useOpenSendFlow({
+    sourceScreenName: pageName,
+  });
 
   const userState: UserQuickActionsState = useMemo(() => {
     if (readOnlyModeEnabled) return "no_signer";
@@ -79,7 +87,11 @@ export const useQuickActionsCtasViewModel = ({
 
   const trackPress = useCallback(
     (button: string) => {
-      track("button_clicked", { button, buttonLocation: BUTTON_LOCATION, page: pageName });
+      track("button_clicked", {
+        button,
+        buttonLocation: BUTTON_LOCATION,
+        page: pageName,
+      });
     },
     [pageName],
   );
@@ -96,7 +108,9 @@ export const useQuickActionsCtasViewModel = ({
 
   const handleBuyPress = useCallback(() => {
     trackPress("buy");
-    navigation.navigate(NavigatorName.Exchange, { screen: ScreenName.ExchangeBuy });
+    navigation.navigate(NavigatorName.Exchange, {
+      screen: ScreenName.ExchangeBuy,
+    });
   }, [trackPress, navigation]);
 
   const handleConnectPress = useCallback(() => {
@@ -120,10 +134,26 @@ export const useQuickActionsCtasViewModel = ({
     handleOpenReceiveDrawer();
   }, [trackPress, handleOpenReceiveDrawer]);
 
+  const sendTrackingProperties = useMemo(
+    () => getSendFlowTrackingProperties(null, null, shouldOpenNewSendFlow),
+    [shouldOpenNewSendFlow],
+  );
+
   const handleSendPress = useCallback(() => {
-    trackPress("send");
-    navigation.navigate(NavigatorName.SendFunds, { screen: ScreenName.SendCoin });
-  }, [trackPress, navigation]);
+    track("button_clicked", {
+      ...sendTrackingProperties,
+      button: "send",
+      buttonLocation: BUTTON_LOCATION,
+      page: pageName,
+    });
+    if (shouldOpenNewSendFlow) {
+      handleOpenSendFlow();
+      return;
+    }
+    navigation.navigate(NavigatorName.SendFunds, {
+      screen: ScreenName.SendCoin,
+    });
+  }, [handleOpenSendFlow, navigation, pageName, sendTrackingProperties, shouldOpenNewSendFlow]);
 
   // no signer: Connect + Buy Ledger
   const noSignerActions: readonly QuickActionCta[] = useMemo(

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/__integrations__/TransferDrawer.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/__integrations__/TransferDrawer.integration.test.tsx
@@ -163,7 +163,10 @@ describe("TransferDrawer Navigation", () => {
         {
           newSendFlow: {
             enabled: true,
-            params: { families: ["evm", "bitcoin", "tron"], excludedCurrencyIds: [] },
+            params: {
+              families: ["evm", "bitcoin", "tron"],
+              excludedCurrencyIds: [],
+            },
           },
         },
         overrideWithOpenDrawer,
@@ -176,6 +179,11 @@ describe("TransferDrawer Navigation", () => {
       "button_clicked",
       expect.objectContaining({ button: "send", newSendFlow: false }),
     );
+    expect(mockHandleOpenSendFlow).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SendFunds, {
+      screen: ScreenName.SendCoin,
+      params: { selectedCurrency: currency, currencyIds: undefined },
+    });
   });
 
   it("tracks newSendFlow as false when the asset currency is excluded by the flag", () => {
@@ -198,9 +206,14 @@ describe("TransferDrawer Navigation", () => {
       "button_clicked",
       expect.objectContaining({ button: "send", newSendFlow: false }),
     );
+    expect(mockHandleOpenSendFlow).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SendFunds, {
+      screen: ScreenName.SendCoin,
+      params: { selectedCurrency: currency, currencyIds: undefined },
+    });
   });
 
-  it("tracks newSendFlow as false when the drawer has no currency to open the new send flow", () => {
+  it("opens unfiltered account selection when the new send flow is enabled without a currency", () => {
     const { result } = renderHook(() => useTransferDrawerViewModel(), {
       overrideInitialState: withFlagOverrides(
         {
@@ -215,11 +228,33 @@ describe("TransferDrawer Navigation", () => {
 
     findAction(result, "send").onPress();
 
-    expect(mockHandleOpenSendFlow).not.toHaveBeenCalled();
+    expect(mockHandleOpenSendFlow).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalled();
     expect(track).toHaveBeenCalledWith(
       "button_clicked",
-      expect.objectContaining({ button: "send", newSendFlow: false }),
+      expect.objectContaining({ button: "send", newSendFlow: true }),
     );
+  });
+
+  it("keeps legacy account selection when the new send flow config has no families", () => {
+    const { result } = renderHook(() => useTransferDrawerViewModel(), {
+      overrideInitialState: withFlagOverrides(
+        {
+          newSendFlow: {
+            enabled: true,
+            params: { families: [], excludedCurrencyIds: [] },
+          },
+        },
+        overrideWithOpenDrawer,
+      ),
+    });
+
+    findAction(result, "send").onPress();
+
+    expect(mockHandleOpenSendFlow).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SendFunds, {
+      screen: ScreenName.SendCoin,
+    });
   });
 
   it("bank_transfer navigates to ReceiveFunds/ReceiveProvider with noah manifest and tracks", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/useTransferDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/screens/TransferDrawer/useTransferDrawerViewModel.ts
@@ -89,7 +89,7 @@ export const useTransferDrawerViewModel = ({
     handleOpenReceiveDrawer();
   }, [closeDrawer, handleOpenReceiveDrawer, sourceScreenName]);
 
-  const { isEnabled: isNewSendFlowEnabled, isEnabledForFamily } = useNewSendFlowFeature();
+  const { isEnabledForFamily } = useNewSendFlowFeature();
   const { handleOpenSendFlow } = useOpenSendFlow({
     currency,
     currencyIds: ledgerIds,
@@ -104,13 +104,11 @@ export const useTransferDrawerViewModel = ({
     () => (assetCurrencyId ? getFamilyByCurrencyId(assetCurrencyId) : undefined),
     [assetCurrencyId],
   );
-  const canOpenNewSendFlowFromEntry = Boolean(currency || ledgerIds?.length);
-  const isNewSendFlowEnabledForAsset =
-    canOpenNewSendFlowFromEntry && isEnabledForFamily(assetFamily, assetCurrencyId);
+  const shouldOpenNewSendFlow = isEnabledForFamily(assetFamily, assetCurrencyId);
 
   const trackingProperties = useMemo(() => {
-    return getSendFlowTrackingProperties(null, null, isNewSendFlowEnabledForAsset);
-  }, [isNewSendFlowEnabledForAsset]);
+    return getSendFlowTrackingProperties(null, null, shouldOpenNewSendFlow);
+  }, [shouldOpenNewSendFlow]);
 
   const handleSendPress = useCallback(() => {
     track("button_clicked", {
@@ -120,7 +118,7 @@ export const useTransferDrawerViewModel = ({
       page: sourceScreenName,
     });
     closeDrawer();
-    if (isNewSendFlowEnabled && canOpenNewSendFlowFromEntry) {
+    if (shouldOpenNewSendFlow) {
       handleOpenSendFlow();
       return;
     }
@@ -139,13 +137,12 @@ export const useTransferDrawerViewModel = ({
       });
     }
   }, [
-    canOpenNewSendFlowFromEntry,
     closeDrawer,
     currency,
     handleOpenSendFlow,
-    isNewSendFlowEnabled,
     ledgerIds,
     navigation,
+    shouldOpenNewSendFlow,
     sourceScreenName,
     trackingProperties,
   ]);

--- a/e2e/mobile/specs/wallet40Q2/portfolioWithAccount.spec.ts
+++ b/e2e/mobile/specs/wallet40Q2/portfolioWithAccount.spec.ts
@@ -1,6 +1,6 @@
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { setTeamOwner } from "@e2e/helpers/allure/allure-helper";
-import { FF_LWM_WALLET_40_Q2 } from "@e2e/utils/featureFlagUtils";
+import { FF_LWM_WALLET_40_Q2, FF_NEW_SEND_FLOW_ENABLED } from "@e2e/utils/featureFlagUtils";
 
 const testConfig = {
   tmsLinks: ["B2CQA-4345", "B2CQA-4339", "B2CQA-4346", "B2CQA-4341", "B2CQA-4340", "B2CQA-4351"],
@@ -17,7 +17,7 @@ describe("Portfolio with account", () => {
     await app.init({
       userdata: "skip-onboarding",
       speculosApp: CURRENCY.speculosApp,
-      featureFlags: FF_LWM_WALLET_40_Q2,
+      featureFlags: { ...FF_LWM_WALLET_40_Q2, ...FF_NEW_SEND_FLOW_ENABLED },
     });
     await app.mainNavigation.waitForWallet40Ready();
     await app.portfolio.addAccount();
@@ -72,6 +72,6 @@ describe("Portfolio with account", () => {
 
     await app.portfolio.pressQuickActionTransferButton();
     await app.portfolio.pressTransferBottomSheetSendButton();
-    await app.send.expectFirstStep();
+    await app.modularDrawer.checkSelectAssetPage();
   });
 });


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Generic Send entries on mobile still opened the legacy account picker (`SendCoin`) even when the new send flow was enabled, so toggling `send_flow` / `newSendFlow` had no visible effect. This PR routes those entries (transfer drawer without an asset, and the quick-action Send CTA) through `useOpenSendFlow`, which opens the MAD to pick an account, then continues into the new send flow, matching LWD


https://github.com/user-attachments/assets/553eb59d-a0ae-4174-ba11-ed73e0177483



### 🔗 Context

- **[JIRA / GitHub issue](https://ledgerhq.atlassian.net/browse/LIVE-36733)**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
