### PR TITLE
[LWD] feat(history): filter operations by contact query param (LIVE-36678)

### DIFF
--- a/.changeset/calm-history-scope.md
+++ b/.changeset/calm-history-scope.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Filter desktop History by contact addresses via `?contactId=`.

--- a/apps/ledger-live-desktop/src/mvvm/components/PageHeader/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/PageHeader/index.tsx
@@ -1,19 +1,32 @@
 import React from "react";
-import { NavBar, NavBarBackButton, NavBarTitle, NavBarTrailing } from "@ledgerhq/lumen-ui-react";
+import {
+  NavBar,
+  NavBarBackButton,
+  NavBarTitle,
+  NavBarTrailing,
+  NavBarDescription,
+  NavBarLeading,
+} from "@ledgerhq/lumen-ui-react";
 
 type Props = Readonly<{
   title: string;
+  /** Optional element rendered next to the title, e.g. a scope badge. */
+  extra?: React.ReactNode;
   onBack?: () => void;
   trailing?: React.ReactNode;
 }>;
 
-export default function PageHeader({ title, onBack, trailing }: Props) {
+export default function PageHeader({ title, extra, onBack, trailing }: Props) {
   return (
     <NavBar data-testid="page-header">
       {onBack ? <NavBarBackButton onClick={onBack} /> : null}
-      <NavBarTitle>
-        <span data-testid="page-header-title">{title}</span>
-      </NavBarTitle>
+      <NavBarLeading>
+        <NavBarTitle>
+          <span data-testid="page-header-title">{title}</span>
+        </NavBarTitle>
+        {extra ? <NavBarDescription>{extra}</NavBarDescription> : null}
+      </NavBarLeading>
+
       {trailing ? <NavBarTrailing>{trailing}</NavBarTrailing> : null}
     </NavBar>
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/History/HistoryView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/HistoryView.tsx
@@ -19,6 +19,7 @@ export function HistoryView({
   hideSmallValueTokenOperations,
   dustFilterThreshold,
   onToggleHideSmallValueTokenOperations,
+  contact,
 }: Readonly<HistoryViewModel>) {
   const operationsCountRef = useRef(operationsCount);
   const hasPendingOperationsRef = useRef(hasPendingOperations);
@@ -37,6 +38,7 @@ export function HistoryView({
         hideSmallValueTokenOperations={hideSmallValueTokenOperations}
         dustFilterThreshold={dustFilterThreshold}
         onToggleHideSmallValueTokenOperations={onToggleHideSmallValueTokenOperations}
+        contact={contact}
       />
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         <HistoryList

--- a/apps/ledger-live-desktop/src/mvvm/features/History/__integrations__/History.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/__integrations__/History.integration.test.tsx
@@ -10,6 +10,15 @@ import { bitcoinCurrency, ethereumCurrency } from "../../__mocks__/useSelectAsse
 import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
 import type { Account } from "@ledgerhq/types-live";
 import History from "../index";
+import {
+  aliceContact,
+  CONTACT_HISTORY_ID,
+  CONTACT_HISTORY_NAME,
+  createEthAccountWithContactTransfers,
+  IN_FROM_CONTACT_OP_ID,
+  OUT_TO_CONTACT_OP_ID,
+  OUT_TO_OTHER_OP_ID,
+} from "./contactHistory.fixtures";
 
 const mockNavigate = jest.fn();
 let mockExportShouldSucceed = true;
@@ -232,6 +241,61 @@ describe("History integration", () => {
     await user.click(await screen.findByTestId("history-actions-menu-button"));
 
     expect(screen.queryByTestId("history-toggle-dust-filter-button")).not.toBeInTheDocument();
+  });
+
+  it("should show the contact in the header and only that contact's send and receive rows", async () => {
+    const account = createEthAccountWithContactTransfers();
+
+    render(<History />, {
+      initialRoute: `/history?contactId=${CONTACT_HISTORY_ID}`,
+      initialState: {
+        accounts: [account],
+        settings: AFTER_ONBOARDING_STATE,
+        contacts: { contacts: [aliceContact()] },
+      },
+    });
+
+    expect(await screen.findByTestId("history-contact-scope")).toHaveTextContent(
+      CONTACT_HISTORY_NAME,
+    );
+    expect(screen.getByTestId(`history-operation-row-${OUT_TO_CONTACT_OP_ID}`)).toBeVisible();
+    expect(screen.getByTestId(`history-operation-row-${IN_FROM_CONTACT_OP_ID}`)).toBeVisible();
+    expect(
+      screen.queryByTestId(`history-operation-row-${OUT_TO_OTHER_OP_ID}`),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should leave History unscoped when the contactId is unknown", async () => {
+    const account = createEthAccountWithContactTransfers();
+
+    render(<History />, {
+      initialRoute: "/history?contactId=contact-missing",
+      initialState: {
+        accounts: [account],
+        settings: AFTER_ONBOARDING_STATE,
+        contacts: { contacts: [aliceContact()] },
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId(`history-operation-row-${OUT_TO_OTHER_OP_ID}`)).toBeVisible();
+    });
+    expect(screen.queryByTestId("history-contact-scope")).not.toBeInTheDocument();
+  });
+
+  it("should show the empty state when the contact has no matching transactions", async () => {
+    render(<History />, {
+      initialRoute: `/history?contactId=${CONTACT_HISTORY_ID}`,
+      initialState: {
+        accounts: [EMPTY_BTC_ACCOUNT],
+        settings: AFTER_ONBOARDING_STATE,
+        contacts: { contacts: [aliceContact()] },
+      },
+    });
+
+    expect(await screen.findByText("No transactions yet")).toBeVisible();
+    expect(screen.getByTestId("history-contact-scope")).toHaveTextContent(CONTACT_HISTORY_NAME);
+    expect(screen.queryByTestId("history-table")).not.toBeInTheDocument();
   });
 });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/History/__integrations__/contactHistory.fixtures.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/__integrations__/contactHistory.fixtures.ts
@@ -1,0 +1,89 @@
+import BigNumber from "bignumber.js";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import {
+  mockContact,
+  mockContactAddress,
+  mockDeviceContactGroupCredentials,
+} from "@domain/entity-contact/schema.mock";
+import type { Account, Operation } from "@ledgerhq/types-live";
+import { ethereumCurrency } from "../../__mocks__/useSelectAssetFlow.mock";
+
+export const CONTACT_HISTORY_ID = "contact-alice";
+export const CONTACT_HISTORY_NAME = "Alice";
+export const CONTACT_HISTORY_ADDRESS = "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034";
+export const OTHER_HISTORY_ADDRESS = "0xdeadbeef00000000000000000000000000000000";
+export const OUT_TO_CONTACT_OP_ID = "out-to-alice";
+export const IN_FROM_CONTACT_OP_ID = "in-from-alice";
+export const OUT_TO_OTHER_OP_ID = "out-to-other";
+
+function createTransfer(
+  accountId: string,
+  id: string,
+  type: "IN" | "OUT",
+  parties: { senders: string[]; recipients: string[] },
+  date: Date,
+): Operation {
+  return {
+    id,
+    hash: id,
+    type,
+    value: new BigNumber(10),
+    fee: new BigNumber(0),
+    senders: parties.senders,
+    recipients: parties.recipients,
+    blockHash: "0xblock",
+    blockHeight: 1,
+    accountId,
+    date,
+    extra: {},
+  };
+}
+
+export function createEthAccountWithContactTransfers(): Account {
+  const account = genAccount("eth-contact-history", {
+    currency: ethereumCurrency,
+    subAccountsCount: 0,
+    operationsSize: 0,
+  });
+  const operations = [
+    createTransfer(
+      account.id,
+      OUT_TO_CONTACT_OP_ID,
+      "OUT",
+      { senders: [OTHER_HISTORY_ADDRESS], recipients: [CONTACT_HISTORY_ADDRESS] },
+      new Date("2026-08-31T12:00:00Z"),
+    ),
+    createTransfer(
+      account.id,
+      IN_FROM_CONTACT_OP_ID,
+      "IN",
+      { senders: [CONTACT_HISTORY_ADDRESS], recipients: [OTHER_HISTORY_ADDRESS] },
+      new Date("2026-08-31T11:00:00Z"),
+    ),
+    createTransfer(
+      account.id,
+      OUT_TO_OTHER_OP_ID,
+      "OUT",
+      { senders: [OTHER_HISTORY_ADDRESS], recipients: [OTHER_HISTORY_ADDRESS] },
+      new Date("2026-08-31T10:00:00Z"),
+    ),
+  ];
+
+  return { ...account, operations, operationsCount: operations.length };
+}
+
+export function aliceContact() {
+  return mockContact({
+    id: CONTACT_HISTORY_ID,
+    name: CONTACT_HISTORY_NAME,
+    addresses: [
+      mockContactAddress({
+        id: "addr-alice-eth",
+        currencyId: "ethereum",
+        label: "Ethereum",
+        address: CONTACT_HISTORY_ADDRESS,
+      }),
+    ],
+    deviceCredentials: mockDeviceContactGroupCredentials(),
+  });
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryContactScope/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryContactScope/index.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { ContactAvatar } from "@features/platform-contacts";
+import type { Contact } from "@domain/entity-contact";
+
+type Props = Readonly<{ contact: Contact }>;
+
+export function HistoryContactScope({ contact }: Props) {
+  return (
+    <span className="inline-flex items-center gap-8 body-1" data-testid="history-contact-scope">
+      {contact.name}
+      <ContactAvatar contactId={contact.id} name={contact.name} isMe={contact.isMe} size="sm" />
+    </span>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryPageHeader.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/HistoryPageHeader.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from "react";
 import PageHeader from "LLD/components/PageHeader";
 import { useTranslation } from "react-i18next";
+import type { Contact } from "@domain/entity-contact";
 import { HistoryExportDialog } from "./HistoryExportDialog";
+import { HistoryContactScope } from "./HistoryContactScope";
 import { ActionsMenu } from "./HistoryPageHeader/ActionsMenu";
 
 type Props = Readonly<{
@@ -11,6 +13,7 @@ type Props = Readonly<{
   hideSmallValueTokenOperations: boolean;
   dustFilterThreshold: string;
   onToggleHideSmallValueTokenOperations: () => void;
+  contact?: Contact;
 }>;
 
 export default function HistoryPageHeader({
@@ -20,6 +23,7 @@ export default function HistoryPageHeader({
   hideSmallValueTokenOperations,
   dustFilterThreshold,
   onToggleHideSmallValueTokenOperations,
+  contact,
 }: Props) {
   const { t } = useTranslation();
   const [isExportDialogOpen, setExportDialogOpen] = useState(false);
@@ -29,6 +33,7 @@ export default function HistoryPageHeader({
       <HistoryExportDialog open={isExportDialogOpen} onOpenChange={setExportDialogOpen} />
       <PageHeader
         title={t("history.title")}
+        extra={contact ? <HistoryContactScope contact={contact} /> : undefined}
         onBack={onBack}
         trailing={
           <ActionsMenu

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/__tests__/useHistoryOperations.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/__tests__/useHistoryOperations.test.ts
@@ -5,6 +5,7 @@ import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { calculate } from "@ledgerhq/live-countervalues/logic";
 import { maticEth, usdcToken } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
 import type { Account, Operation, TokenAccount } from "@ledgerhq/types-live";
+import type { Contact } from "@domain/entity-contact";
 import { INITIAL_STATE } from "~/renderer/reducers/settings";
 import { useHistoryOperations } from "../useHistoryOperations";
 import { BTC_ACCOUNT, ETH_ACCOUNT } from "LLD/features/__mocks__/accounts.mock";
@@ -137,6 +138,74 @@ function createAccountWithNativeOutgoingOperations(): Account {
   };
 }
 
+const CONTACT_ADDRESS = "0xC0FFEE0000000000000000000000000000C0FFEE";
+const OTHER_ADDRESS = "0xDEAD0000000000000000000000000000DEADDEAD";
+const OUT_TO_CONTACT_OP_ID = "out-to-contact-op-id";
+const OUT_TO_OTHER_OP_ID = "out-to-other-op-id";
+const IN_FROM_CONTACT_OP_ID = "in-from-contact-op-id";
+const IN_FROM_OTHER_OP_ID = "in-from-other-op-id";
+
+function createNativeTransfer(
+  accountId: string,
+  id: string,
+  type: "IN" | "OUT",
+  parties: { senders: string[]; recipients: string[] },
+): Operation {
+  return {
+    id,
+    hash: id,
+    type,
+    value: new BigNumber(10),
+    fee: new BigNumber(0),
+    senders: parties.senders,
+    recipients: parties.recipients,
+    blockHash: "0xblock",
+    blockHeight: 1,
+    accountId,
+    date: new Date(),
+    extra: {},
+  };
+}
+
+function createEthAccountWithContactTransfers(): Account {
+  const account = genAccount("eth-contact-scope", {
+    currency: ETH_ACCOUNT.currency,
+    subAccountsCount: 0,
+    operationsSize: 0,
+  });
+  const operations = [
+    createNativeTransfer(account.id, OUT_TO_CONTACT_OP_ID, "OUT", {
+      senders: [OTHER_ADDRESS],
+      recipients: [CONTACT_ADDRESS],
+    }),
+    createNativeTransfer(account.id, OUT_TO_OTHER_OP_ID, "OUT", {
+      senders: [OTHER_ADDRESS],
+      recipients: [OTHER_ADDRESS],
+    }),
+    createNativeTransfer(account.id, IN_FROM_CONTACT_OP_ID, "IN", {
+      senders: [CONTACT_ADDRESS],
+      recipients: [OTHER_ADDRESS],
+    }),
+    createNativeTransfer(account.id, IN_FROM_OTHER_OP_ID, "IN", {
+      senders: [OTHER_ADDRESS],
+      recipients: [OTHER_ADDRESS],
+    }),
+  ];
+
+  return { ...account, operations, operationsCount: operations.length };
+}
+
+function contactWithEthereumAddress(): Contact {
+  return {
+    id: "contact-scope",
+    isMe: false,
+    name: "Alice",
+    addresses: [
+      { id: "addr-1", currencyId: "ethereum", label: "Ethereum", address: CONTACT_ADDRESS },
+    ],
+  } as unknown as Contact;
+}
+
 describe("useHistoryOperations", () => {
   beforeEach(() => {
     mockCalculate.mockReset();
@@ -208,6 +277,18 @@ describe("useHistoryOperations", () => {
     const items = result.current;
     expect(items.length).toBeGreaterThan(0);
     expect(items.every(item => item.account.id === usdc.id)).toBe(true);
+  });
+
+  it("scopes to a contact's addresses, keeping IN (senders) and OUT (recipients) that touch them", () => {
+    const account = createEthAccountWithContactTransfers();
+
+    const { result } = renderHook(() => useHistoryOperations(contactWithEthereumAddress()), {
+      initialState: { accounts: [account], settings: INITIAL_STATE },
+    });
+
+    expect(result.current.map(item => item.operation.id).sort()).toEqual(
+      [OUT_TO_CONTACT_OP_ID, IN_FROM_CONTACT_OP_ID].sort(),
+    );
   });
 
   it("keeps zero-value token operations when dust filtering is disabled", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryOperations.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryOperations.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { useSearchParams } from "react-router";
+import type { Contact } from "@domain/entity-contact";
 import { useSelector } from "LLD/hooks/redux";
 import { accountsSelector } from "~/renderer/reducers/accounts";
 import type { OperationTableItem } from "../types";
@@ -9,9 +10,10 @@ import {
   filterTopLevelAccountsByAllowedAccountIds,
   parseAccountIdsSearchParam,
 } from "../utils/accountScopeForHistory";
+import { filterOperationTableItemsByContact } from "../utils/contactScopeForHistory";
 import { useHistoryOperationItemsForRootAccounts } from "./useHistoryOperationItemsForRootAccounts";
 
-export function useHistoryOperations(): OperationTableItem[] {
+export function useHistoryOperations(contact?: Contact): OperationTableItem[] {
   const [searchParams] = useSearchParams();
   const accountIdsQuery = searchParams.get("accountIds");
   const allAccounts = useSelector(accountsSelector);
@@ -30,8 +32,16 @@ export function useHistoryOperations(): OperationTableItem[] {
     return expandRequestedAccountIdsForHistoryScope(allAccounts, new Set(ids));
   }, [accountIdsQuery, allAccounts]);
 
-  return useMemo(() => {
+  const accountScopedItems = useMemo(() => {
     if (!operationAccountIds) return baseOperationItems;
     return filterOperationTableItemsByAllowedAccountIds(baseOperationItems, operationAccountIds);
   }, [baseOperationItems, operationAccountIds]);
+
+  return useMemo(
+    () =>
+      contact
+        ? filterOperationTableItemsByContact(accountScopedItems, contact)
+        : accountScopedItems,
+    [accountScopedItems, contact],
+  );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryViewModel.ts
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useMemo } from "react";
+import { useSearchParams } from "react-router";
 import {
   formatSmallValueOperationsThreshold,
   SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY,
 } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
+import { ContactIdSchema, selectContactById, type Contact } from "@domain/entity-contact";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { useHideSmallValueTokenOperations } from "~/renderer/actions/settings";
 import { addExtraTrackingPairs } from "~/renderer/reducers/countervaluesExtraTracking";
@@ -40,6 +42,7 @@ export type HistoryViewModel = {
   hideSmallValueTokenOperations: boolean;
   dustFilterThreshold: string;
   onToggleHideSmallValueTokenOperations: () => void;
+  contact?: Contact;
 };
 
 export function useHistoryViewModel(): HistoryViewModel {
@@ -53,7 +56,14 @@ export function useHistoryViewModel(): HistoryViewModel {
 
   const { showBackButton, navigateBack } = usePopNavigationBack(parseHistoryBackPath);
 
-  const operations = useHistoryOperations();
+  const [searchParams] = useSearchParams();
+  const contactIdResult = ContactIdSchema.safeParse(searchParams.get("contactId"));
+  const contactId = contactIdResult.success ? contactIdResult.data : undefined;
+  const contact = useSelector(state =>
+    contactId ? selectContactById(state, contactId) : undefined,
+  );
+
+  const operations = useHistoryOperations(contact);
   const table = useHistoryTable(operations);
   const { parentRef, rowVirtualizer, flatItems } = useHistoryVirtualization(table);
 
@@ -132,5 +142,6 @@ export function useHistoryViewModel(): HistoryViewModel {
     hideSmallValueTokenOperations,
     dustFilterThreshold,
     onToggleHideSmallValueTokenOperations,
+    contact,
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/History/utils/contactScopeForHistory.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/utils/contactScopeForHistory.ts
@@ -1,0 +1,37 @@
+import type { Contact } from "@domain/entity-contact";
+import { findContactOperationsToAddresses, toContactOperation } from "@features/platform-contacts";
+import type { OperationTableItem } from "../types";
+
+/**
+ * Currency a contact address is matched on: token rows fold onto their parent chain, mirroring
+ * {@link OperationCounterpartyCell}. Account rows are never fiat, so `null` is effectively unused.
+ */
+function contactMatchCurrencyId(currency: OperationTableItem["currency"]): string | null {
+  if (currency.type === "TokenCurrency") return currency.parentCurrencyId;
+  if (currency.type === "CryptoCurrency") return currency.id;
+  return null;
+}
+
+/** Keeps only the send/receive rows whose counterparty is one of the contact's addresses. */
+export function filterOperationTableItemsByContact(
+  items: readonly OperationTableItem[],
+  contact: Contact,
+): OperationTableItem[] {
+  return items.filter(item => {
+    const currencyId = contactMatchCurrencyId(item.currency);
+    if (currencyId === null) return false;
+
+    const operation = toContactOperation({
+      id: item.id,
+      type: item.type,
+      currencyId,
+      date: item.date,
+      senders: item.operation.senders,
+      recipients: item.operation.recipients,
+    });
+    return (
+      operation !== null &&
+      findContactOperationsToAddresses(contact.addresses, [operation]).length > 0
+    );
+  });
+}


### PR DESCRIPTION
### 📝 Description

Desktop History always listed every wallet operation. Pay needs a contact-scoped list without a second tx screen.

This PR reuses History: `?contactId=` filters send/receive rows to that contact’s addresses (IN and OUT), and the header shows the contact next to the title.

**Approach**

- `useHistoryViewModel` parses `contactId` with `ContactIdSchema.safeParse`.
- `filterOperationTableItemsByContact` maps each History row through `toContactOperation` + `findContactOperationsToAddresses`. Token transfers match a chain-level contact address.
- Unknown or missing `contactId` leaves the list unscoped.
- `PageHeader` gains an `extra` slot; `HistoryContactScope` renders the contact name there.
- Empty copy when the scoped list is empty: “No transactions yet”.

**Tests**

- Unit: `useHistoryOperations` with a contact scope.
- Integration: known contact (header + IN/OUT rows), unknown `contactId` (unscoped), empty contact list.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36678](https://ledgerhq.atlassian.net/browse/LIVE-36678)
- **ADR** (if any):

[LIVE-36678]: https://ledgerhq.atlassian.net/browse/LIVE-36678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ