### PR TITLE
feat(account-alias): anonymize account ids in LLD routes (LIVE-35367)

### DIFF
--- a/.changeset/anonymize-account-ids-in-desktop-routes.md
+++ b/.changeset/anonymize-account-ids-in-desktop-routes.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@domain/entity-account-alias": minor
+---
+
+Anonymize account ids in Desktop routes: `/account/...` paths now carry a non-reversible alias instead of the account id, which embeds an xpub or an address

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -74,6 +74,7 @@
     "@domain/api-currency-token": "workspace:^",
     "@domain/api-market-sentiment": "workspace:^",
     "@domain/api-push-devices": "workspace:*",
+    "@domain/entity-account-alias": "workspace:^",
     "@domain/entity-account-name": "workspace:^",
     "@domain/entity-analytics-consent": "workspace:*",
     "@domain/entity-client-identity": "workspace:*",

--- a/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/AccountsAdded/components/AccountList.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/AccountsAdded/components/AccountList.tsx
@@ -6,6 +6,7 @@ import { FormattedAccountItem } from "../../../components/FormattedAccountItem";
 import { Account } from "@ledgerhq/types-live";
 import { setDrawer } from "~/renderer/drawers/Provider";
 import { AccountListProps } from "../types";
+import { getAccountUrl } from "~/renderer/utils";
 
 export const AccountList = ({
   accounts,
@@ -21,7 +22,7 @@ export const AccountList = ({
       if (isAccountSelectionFlow) {
         navigateToEditAccountName(account);
       } else {
-        navigate(`/account/${account.id}`);
+        navigate(getAccountUrl(account.id));
         setDrawer();
       }
     },

--- a/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/AccountsWarning/useWarningConfig.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AddAccountDrawer/screens/AccountsWarning/useWarningConfig.tsx
@@ -12,6 +12,7 @@ import { useLocalizedUrl } from "~/renderer/hooks/useLocalizedUrls";
 import { openURL } from "~/renderer/linking";
 import { useMaybeAccountName } from "~/renderer/reducers/wallet";
 import { useAccountFormatter } from "../AccountsAdded/hooks";
+import { getAccountUrl } from "~/renderer/utils";
 
 export const useWarningConfig = (
   currency: CryptoCurrency,
@@ -34,7 +35,7 @@ export const useWarningConfig = (
 
   const handleAccountClick = useCallback(
     (accountId: string) => {
-      navigate(`/account/${accountId}`);
+      navigate(getAccountUrl(accountId));
       setDrawer();
     },
     [navigate],

--- a/apps/ledger-live-desktop/src/mvvm/features/NftEntryPoint/__tests__/NftEntryPoint.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/NftEntryPoint/__tests__/NftEntryPoint.test.tsx
@@ -5,6 +5,7 @@ import NftEntryPoint from "..";
 import { Entry } from "../types";
 import { track } from "~/renderer/analytics/segment";
 import { Account } from "@ledgerhq/types-live";
+import { getAccountUrl } from "~/renderer/utils";
 
 const mockNavigate = jest.fn();
 
@@ -116,7 +117,7 @@ describe("NftEntryPoint", () => {
       state: {
         accountId: mockAccount.id,
         chainId: mockAccount.currency.id,
-        returnTo: `/account/${mockAccount.id}`,
+        returnTo: getAccountUrl(mockAccount.id),
         website: "https://magiceden.io",
       },
     });

--- a/apps/ledger-live-desktop/src/mvvm/features/NftEntryPoint/useNftsEntryPointViewModel.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/NftEntryPoint/useNftsEntryPointViewModel.tsx
@@ -6,6 +6,7 @@ import React from "react";
 
 import { useNavigate } from "react-router";
 import { entryPointConfig } from "./config";
+import { getAccountUrl } from "~/renderer/utils";
 
 type Props = {
   accountId: string;
@@ -27,7 +28,7 @@ export default function useNftsEntryPointViewModel({ accountId, currencyId }: Pr
         website: link,
         accountId,
         chainId: currencyId,
-        returnTo: `/account/${accountId}`,
+        returnTo: getAccountUrl(accountId),
       },
     });
   };

--- a/apps/ledger-live-desktop/src/mvvm/hooks/useStake.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/useStake.test.ts
@@ -9,6 +9,7 @@ import { AccountRaw, TokenAccount } from "@ledgerhq/types-live";
 
 import { fromAccountRaw } from "@ledgerhq/ledger-wallet-framework/serialization/account";
 import { setCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
+import { getAccountUrl } from "~/renderer/utils";
 
 const raw: AccountRaw = {
   id: "js:2:ethereum:0x01:",
@@ -241,7 +242,7 @@ describe("useStake()", () => {
           customDappUrl: `https://mockdapp.com/?embed=true&chainId=1&accountId=${URIEncodedParentAccountId}`,
           name: "Mock Dapp v3",
           walletAccountId: "1a536838-dd18-5e39-b13f-0ba422fb395c",
-          returnTo: "/account/js:2:ethereum:0x01:/js:2:ethereum:0x01:usdt:",
+          returnTo: getAccountUrl("js:2:ethereum:0x01:usdt:", "js:2:ethereum:0x01:"),
           chainId: 1,
         },
       }),
@@ -265,7 +266,7 @@ describe("useStake()", () => {
           name: "Mock dapp browser v1 app",
           appId: "mock-dapp-v1",
           walletAccountId: "6760dd02-ab43-5c5a-9c7e-c75731580a08",
-          returnTo: "/account/js:2:ethereum:0x01:/js:2:ethereum:0x01:usdc:",
+          returnTo: getAccountUrl("js:2:ethereum:0x01:usdc:", "js:2:ethereum:0x01:"),
           chainId: 1,
         },
       }),
@@ -289,7 +290,7 @@ describe("useStake()", () => {
         name: "Mock Live App",
         appId: "mock-live-app",
         walletAccountId: "0eda416c-9669-57a2-84f6-741df8c11267",
-        returnTo: "/account/js:2:tron:T:",
+        returnTo: getAccountUrl("js:2:tron:T:"),
         yieldId: "tron-native-staking",
       },
     });

--- a/apps/ledger-live-desktop/src/mvvm/hooks/useStake.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/useStake.ts
@@ -14,6 +14,7 @@ import {
 import { accountToWalletAPIAccount } from "@ledgerhq/live-common/wallet-api/converters";
 import { type WalletState } from "~/renderer/reducers/wallet";
 import { useVersionedStakePrograms } from "./useVersionedStakePrograms";
+import { getAccountUrl } from "~/renderer/utils";
 
 const getRemoteLiveAppManifestById = (
   appId: string,
@@ -122,8 +123,8 @@ export function useStake() {
       );
 
       const returnToAccount = isTokenAccount(account)
-        ? `/account/${earningsAccountId}/${account.id}`
-        : `/account/${earningsAccountId}`;
+        ? getAccountUrl(account.id, earningsAccountId)
+        : getAccountUrl(earningsAccountId);
 
       const customPartnerParams = appDetails?.queryParams ?? {};
 

--- a/apps/ledger-live-desktop/src/renderer/components/Breadcrumb/AccountCrumb.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Breadcrumb/AccountCrumb.tsx
@@ -28,6 +28,7 @@ import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import { walletSelector, accountNameWithDefaultSelector } from "~/renderer/reducers/wallet";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import { getAccountsSidebarPath } from "LLD/components/SideBar/utils";
+import { useAccountIdFromRoute } from "~/renderer/hooks/useAccountIdFromRoute";
 
 type ItemShape = {
   key: string;
@@ -40,22 +41,25 @@ const AccountCrumb = () => {
   const { t } = useTranslation();
   const { "*": splat } = useParams<{ "*": string }>();
 
-  const { parentId, id } = useMemo(() => {
+  const { parentSegment, idSegment } = useMemo(() => {
     if (!splat) {
-      return { parentId: undefined, id: undefined };
+      return { parentSegment: undefined, idSegment: undefined };
     }
     const segments = splat.split("/").filter(Boolean);
     if (segments.length === 0) {
-      return { parentId: undefined, id: undefined };
+      return { parentSegment: undefined, idSegment: undefined };
     }
     if (segments.length === 1) {
-      return { parentId: undefined, id: segments[0] };
+      return { parentSegment: undefined, idSegment: segments[0] };
     }
     return {
-      parentId: segments[0],
-      id: segments.slice(1).join("/"),
+      parentSegment: segments[0],
+      idSegment: segments.slice(1).join("/"),
     };
   }, [splat]);
+
+  const parentId = useAccountIdFromRoute(parentSegment);
+  const id = useAccountIdFromRoute(idSegment);
 
   const { shouldDisplayAssetSection } = useWalletFeaturesConfig("desktop");
 

--- a/apps/ledger-live-desktop/src/renderer/drawers/OperationDetails/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/OperationDetails/index.tsx
@@ -226,7 +226,7 @@ const OperationD = (props: Props) => {
     });
   }, [operation, props, account]);
   const goToMainAccount = useCallback(() => {
-    const url = `/account/${mainAccount.id}`;
+    const url = getAccountUrl(mainAccount.id);
     if (location.pathname !== url) {
       setTrackingSource("operation details");
       navigate(url);

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/AccountHeaderManageActions.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/AccountHeaderManageActions.ts
@@ -10,6 +10,7 @@ import { useGetStakeLabelLocaleBased } from "~/renderer/hooks/useGetStakeLabelLo
 import { useStake } from "LLD/hooks/useStake";
 import { useSelector } from "LLD/hooks/redux";
 import { walletSelector } from "~/renderer/reducers/wallet";
+import { getAccountUrl } from "~/renderer/utils";
 
 type Props = {
   account: BitcoinAccount | TokenAccount;
@@ -55,7 +56,7 @@ const AccountHeaderActions = ({ account, parentAccount }: Props) => {
 
     navigate(routeToPlatformApp?.pathname ?? "/", {
       state: {
-        returnTo: `/account/${account.id}`,
+        returnTo: getAccountUrl(account.id),
         ...routeToPlatformApp?.state,
       },
     });

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/AccountHeaderManageActions.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/AccountHeaderManageActions.ts
@@ -9,6 +9,7 @@ import { useNavigate } from "react-router";
 import { openModal } from "~/renderer/actions/modals";
 import { useGetStakeLabelLocaleBased } from "~/renderer/hooks/useGetStakeLabelLocaleBased";
 import IconCoins from "~/renderer/icons/Coins";
+import { getAccountUrl } from "~/renderer/utils";
 
 type Props = {
   account: CosmosAccount | TokenAccount;
@@ -41,7 +42,7 @@ const AccountHeaderActions = ({ account, parentAccount, source }: Props) => {
         state: {
           yieldId: "cronos-cro-native-staking",
           accountId: account.id,
-          returnTo: `/account/${account.id}`,
+          returnTo: getAccountUrl(account.id),
         },
       });
     }

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/Delegation/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/Delegation/index.tsx
@@ -30,6 +30,7 @@ import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import cosmosBase from "@ledgerhq/coin-cosmos/chain/cosmosBase";
 import { useNavigate } from "react-router";
 import { getCurrencyConfiguration } from "@ledgerhq/live-common/config/index";
+import { getAccountUrl } from "~/renderer/utils";
 
 type DelegationActionsModalName =
   | "MODAL_COSMOS_CLAIM_REWARDS"
@@ -68,7 +69,7 @@ const Delegation = ({ account }: { account: CosmosAccount }) => {
       state: {
         yieldId: "cronos-cro-native-staking",
         accountId: account.id,
-        returnTo: `/account/${account.id}`,
+        returnTo: getAccountUrl(account.id),
       },
     });
   }, [account.id, navigate]);

--- a/apps/ledger-live-desktop/src/renderer/families/evm/AccountHeaderManageActions.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/AccountHeaderManageActions.ts
@@ -11,6 +11,7 @@ import { useDispatch, useSelector } from "LLD/hooks/redux";
 import IconCoins from "~/renderer/icons/Coins";
 
 import { walletSelector } from "~/renderer/reducers/wallet";
+import { getAccountUrl } from "~/renderer/utils";
 
 type Props = {
   account: AccountLike;
@@ -47,7 +48,7 @@ const AccountHeaderActions = ({ account, parentAccount }: Props) => {
         state: {
           yieldId,
           accountId: account.id,
-          returnTo: `/account/${account.id}`,
+          returnTo: getAccountUrl(account.id),
         },
       });
     },

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/AccountHeaderManageActions.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/AccountHeaderManageActions.ts
@@ -13,6 +13,7 @@ import { useGetStakeLabelLocaleBased } from "~/renderer/hooks/useGetStakeLabelLo
 import { useNavigate } from "react-router";
 import { openModal } from "~/renderer/actions/modals";
 import { useDispatch } from "LLD/hooks/redux";
+import { getAccountUrl } from "~/renderer/utils";
 
 type Props = {
   account: PolkadotAccount | TokenAccount;
@@ -40,8 +41,8 @@ const AccountHeaderManageActions = ({ account, parentAccount, source = "Account 
           accountId: account.id,
           returnTo:
             account.type === "TokenAccount"
-              ? `/account/${account.parentId}/${account.id}`
-              : `/account/${account.id}`,
+              ? getAccountUrl(account.id, account.parentId)
+              : getAccountUrl(account.id),
         },
       });
     } else if (bridge.isAccountEmpty(mainAccount)) {

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/Nomination/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/Nomination/index.tsx
@@ -45,6 +45,7 @@ import {
 import { TokenAccount } from "@ledgerhq/types-live";
 import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import { useNavigate } from "react-router";
+import { getAccountUrl } from "~/renderer/utils";
 
 type Props = {
   account: PolkadotAccount | TokenAccount;
@@ -123,7 +124,7 @@ const Nomination = ({ account }: { account: PolkadotAccount }) => {
         state: {
           yieldId: "polkadot-dot-validator-staking",
           accountId: account.id,
-          returnTo: `/account/${account.id}`,
+          returnTo: getAccountUrl(account.id),
         },
       });
     } else {

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/StepConfirmation.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/StepConfirmation.test.tsx
@@ -55,6 +55,7 @@ jest.mock("~/renderer/components/RetryButton", () => ({
 }));
 
 import StepConfirmation, { StepConfirmationFooter } from "../steps/StepConfirmation";
+import { getAccountUrl } from "~/renderer/utils";
 
 const currency = getCryptoCurrencyById("tezos");
 
@@ -188,7 +189,7 @@ describe("StakeFlowModal/StepConfirmation", () => {
       fireEvent.click(cta!);
     });
     expect(props.onClose).toHaveBeenCalledTimes(1);
-    expect(mockNavigate).toHaveBeenCalledWith(`/account/${props.account?.id}`);
+    expect(mockNavigate).toHaveBeenCalledWith(getAccountUrl(props.account?.id ?? ""));
   });
 
   it("footer success CTA falls back to the operation's account id when account is missing", () => {
@@ -203,6 +204,6 @@ describe("StakeFlowModal/StepConfirmation", () => {
       fireEvent.click(cta!);
     });
     expect(props.onClose).toHaveBeenCalledTimes(1);
-    expect(mockNavigate).toHaveBeenCalledWith(`/account/${operation.accountId}`);
+    expect(mockNavigate).toHaveBeenCalledWith(getAccountUrl(operation.accountId));
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/steps/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/steps/StepConfirmation.tsx
@@ -7,6 +7,7 @@ import { SyncOneAccountOnMount } from "@ledgerhq/live-common/bridge/react/index"
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/coin-module-framework/currencies/index";
 import TrackPage, { setTrackingSource } from "~/renderer/analytics/TrackPage";
+import { getAccountUrl } from "~/renderer/utils";
 import { track } from "~/renderer/analytics/segment";
 import Box from "~/renderer/components/Box";
 import BroadcastErrorDisclaimer from "~/renderer/components/BroadcastErrorDisclaimer";
@@ -126,7 +127,7 @@ export const StepConfirmationFooter = ({
       ? getMainAccount(account, parentAccount).id
       : optimisticOperation?.accountId;
     if (accountId) {
-      navigate(`/account/${accountId}`);
+      navigate(getAccountUrl(accountId));
     }
   }, [account, parentAccount, optimisticOperation, navigate, onClose]);
 

--- a/apps/ledger-live-desktop/src/renderer/families/tron/AccountHeaderManageActions.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/tron/AccountHeaderManageActions.ts
@@ -7,6 +7,7 @@ import { useNavigate } from "react-router";
 import { track } from "~/renderer/analytics/segment";
 import { stakeDefaultTrack } from "~/renderer/screens/stake/constants";
 import { useGetStakeLabelLocaleBased } from "~/renderer/hooks/useGetStakeLabelLocaleBased";
+import { getAccountUrl } from "~/renderer/utils";
 
 type Props = {
   account: TronAccount | TokenAccount;
@@ -38,7 +39,7 @@ const AccountHeaderManageActions = ({
       state: {
         yieldId: "tron-trx-native-staking",
         accountId: account.id,
-        returnTo: `/account/${account.id}`,
+        returnTo: getAccountUrl(account.id),
       },
     });
   };

--- a/apps/ledger-live-desktop/src/renderer/families/tron/Votes/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tron/Votes/index.tsx
@@ -35,6 +35,7 @@ import { useNavigate } from "react-router";
 import { stakeDefaultTrack } from "~/renderer/screens/stake/constants";
 import { track } from "~/renderer/analytics/segment";
 import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
+import { getAccountUrl } from "~/renderer/utils";
 
 const Wrapper = styled(Box).attrs(() => ({
   p: 3,
@@ -95,7 +96,7 @@ const Delegation = ({ account }: { account: TronAccount }) => {
         pendingaction: "REVOTE",
         yieldId: "tron-trx-native-staking",
         accountId: account.id,
-        returnTo: `/account/${account.id}`,
+        returnTo: getAccountUrl(account.id),
       },
     });
   };
@@ -115,7 +116,7 @@ const Delegation = ({ account }: { account: TronAccount }) => {
         pendingaction: "CLAIM_REWARDS",
         yieldId: "tron-trx-native-staking",
         accountId: account.id,
-        returnTo: `/account/${account.id}`,
+        returnTo: getAccountUrl(account.id),
       },
     });
   };

--- a/apps/ledger-live-desktop/src/renderer/hooks/useAccountIdFromRoute.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useAccountIdFromRoute.ts
@@ -1,0 +1,12 @@
+import { resolveAccountIdSelector } from "@domain/entity-account-alias";
+import { useSelector } from "LLD/hooks/redux";
+
+/**
+ * Turns an `/account/:parentId/:id` route segment back into the account id it aliases.
+ * Counterpart of `getAccountUrl`.
+ */
+export function useAccountIdFromRoute(segment: string | undefined): string | undefined {
+  return useSelector(({ accountAliases }) =>
+    segment === undefined ? undefined : resolveAccountIdSelector(accountAliases, segment),
+  );
+}

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/accounts.handler.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/__tests__/accounts.handler.test.ts
@@ -13,6 +13,7 @@ jest.mock("../../utils", () => ({
 }));
 
 import { getAccountsOrSubAccountsByCurrency } from "../../utils";
+import { getAccountUrl } from "~/renderer/utils";
 
 const mockFindCryptoCurrencyByKeyword = jest.mocked(findCryptoCurrencyByKeyword);
 const mockGetAccountsOrSubAccountsByCurrency = jest.mocked(getAccountsOrSubAccountsByCurrency);
@@ -49,7 +50,7 @@ describe("accounts.handler", () => {
 
       accountsHandler({ type: "accounts", address: "bc1qtest123" }, context);
 
-      expect(context.navigate).toHaveBeenCalledWith(`/account/${mockAccount.id}`);
+      expect(context.navigate).toHaveBeenCalledWith(getAccountUrl(mockAccount.id));
     });
 
     it("navigates to accounts list when address not found", () => {
@@ -127,7 +128,7 @@ describe("accounts.handler", () => {
 
       accountHandler({ type: "account", currency: "bitcoin", address: "bc1qtest123" }, context);
 
-      expect(context.navigate).toHaveBeenCalledWith(`/account/${mockAccount.id}`);
+      expect(context.navigate).toHaveBeenCalledWith(getAccountUrl(mockAccount.id));
     });
 
     it("navigates to first matching account when no address provided", () => {
@@ -139,7 +140,7 @@ describe("accounts.handler", () => {
 
       accountHandler({ type: "account", currency: "ethereum" }, context);
 
-      expect(context.navigate).toHaveBeenCalledWith(`/account/${mockAccount.id}`);
+      expect(context.navigate).toHaveBeenCalledWith(getAccountUrl(mockAccount.id));
     });
 
     it("navigates to token account with parent path", () => {
@@ -156,7 +157,9 @@ describe("accounts.handler", () => {
 
       accountHandler({ type: "account", currency: "ethereum" }, context);
 
-      expect(context.navigate).toHaveBeenCalledWith("/account/parent-account-1/token-account-1");
+      expect(context.navigate).toHaveBeenCalledWith(
+        getAccountUrl("token-account-1", "parent-account-1"),
+      );
     });
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/accounts.handler.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/accounts.handler.ts
@@ -1,6 +1,7 @@
 import { findCryptoCurrencyByKeyword } from "@domain/entity-currency-crypto";
 import { Currency } from "@domain/entity-currency";
 import { DeeplinkHandler } from "../types";
+import { getAccountUrl } from "~/renderer/utils";
 import { getAccountsOrSubAccountsByCurrency } from "../utils";
 
 export const accountsHandler: DeeplinkHandler<"accounts"> = (
@@ -12,7 +13,7 @@ export const accountsHandler: DeeplinkHandler<"accounts"> = (
   if (address && typeof address === "string") {
     const account = accounts.find(acc => acc.freshAddress === address);
     if (account) {
-      navigate(`/account/${account.id}`);
+      navigate(getAccountUrl(account.id));
       return;
     }
   }
@@ -38,16 +39,17 @@ export const accountHandler: DeeplinkHandler<"account"> = (route, { accounts, na
     );
 
     if (account) {
-      navigate(`/account/${account.id}`);
+      navigate(getAccountUrl(account.id));
     }
     return;
   }
 
   const [chosenAccount] = foundAccounts;
+  if (!chosenAccount) return;
 
-  if (chosenAccount?.type === "Account") {
-    navigate(`/account/${chosenAccount.id}`);
+  if (chosenAccount.type === "Account") {
+    navigate(getAccountUrl(chosenAccount.id));
   } else {
-    navigate(`/account/${chosenAccount?.parentId}/${chosenAccount?.id}`);
+    navigate(getAccountUrl(chosenAccount.id, chosenAccount.parentId));
   }
 };

--- a/apps/ledger-live-desktop/src/renderer/middlewares/__tests__/accountAlias.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/__tests__/accountAlias.test.ts
@@ -1,0 +1,100 @@
+import type { Dispatch, MiddlewareAPI, UnknownAction } from "@reduxjs/toolkit";
+import { computeAccountAlias, registerAccountAliases } from "@domain/entity-account-alias";
+import type { State } from "../../reducers";
+import { createAccountAliasMiddleware, withAccountAliases } from "../accountAlias";
+
+const account = (id: string, subAccounts: { id: string }[] = []) => ({
+  type: "Account",
+  id,
+  subAccounts,
+});
+
+const BTC_ID = "js:2:bitcoin:xpub:segwit";
+const ETH_ID = "js:2:ethereum:0xdead:";
+
+/** Fake store whose account list moves to the next step every time `next` is called. */
+function setup(accountsByStep: unknown[][]) {
+  let step = 0;
+  const dispatch = jest.fn();
+  const getState = jest.fn(() => ({ accounts: accountsByStep[step] }) as unknown as State);
+  const api = { dispatch, getState } as unknown as MiddlewareAPI<Dispatch, State>;
+  const next = jest.fn(() => {
+    step = Math.min(step + 1, accountsByStep.length - 1);
+  });
+  const middleware = createAccountAliasMiddleware();
+  return { dispatch, next, invoke: (action: UnknownAction) => middleware(api)(next)(action) };
+}
+
+describe("createAccountAliasMiddleware", () => {
+  it("registers aliases when the account list changes", () => {
+    const { dispatch, invoke } = setup([[], [account(BTC_ID)]]);
+
+    invoke({ type: "INIT_ACCOUNTS" });
+
+    expect(dispatch).toHaveBeenCalledWith(registerAccountAliases([BTC_ID]));
+  });
+
+  it("registers token accounts too", () => {
+    const accounts = [account(ETH_ID, [{ id: `${ETH_ID}+usdc` }])];
+    const { dispatch, invoke } = setup([[], accounts]);
+
+    invoke({ type: "UPDATE_ACCOUNT" });
+
+    expect(dispatch).toHaveBeenCalledWith(registerAccountAliases([ETH_ID, `${ETH_ID}+usdc`]));
+  });
+
+  it("does not re-register when a sync rewrites the accounts without changing their ids", () => {
+    const { dispatch, invoke } = setup([[], [account(BTC_ID)], [account(BTC_ID)]]);
+
+    invoke({ type: "INIT_ACCOUNTS" });
+    dispatch.mockClear();
+    invoke({ type: "UPDATE_ACCOUNT" });
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the account list is untouched", () => {
+    const accounts = [account(BTC_ID)];
+    const { dispatch, invoke } = setup([accounts]);
+
+    invoke({ type: "FIRST" });
+    dispatch.mockClear();
+    invoke({ type: "SOME_UNRELATED_ACTION" });
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("passes the action down the chain", () => {
+    const { next, invoke } = setup([[]]);
+    const action = { type: "ANY" };
+
+    invoke(action);
+
+    expect(next).toHaveBeenCalledWith(action);
+  });
+});
+
+describe("withAccountAliases", () => {
+  it("seeds the reverse map from preloaded accounts", () => {
+    const state = { accounts: [account(BTC_ID, [{ id: `${BTC_ID}+token` }])] } as unknown as State;
+
+    expect(withAccountAliases(state)?.accountAliases.accountIdByAlias).toEqual({
+      [computeAccountAlias(BTC_ID)]: BTC_ID,
+      [computeAccountAlias(`${BTC_ID}+token`)]: `${BTC_ID}+token`,
+    });
+  });
+
+  it("copes with a partial state that carries no accounts", () => {
+    expect(withAccountAliases({} as State)?.accountAliases.accountIdByAlias).toEqual({});
+  });
+
+  it("copes with a hand-built state whose accounts are not an array", () => {
+    const state = { accounts: { active: [account(BTC_ID)] } } as unknown as State;
+
+    expect(withAccountAliases(state)?.accountAliases.accountIdByAlias).toEqual({});
+  });
+
+  it("passes undefined through", () => {
+    expect(withAccountAliases(undefined)).toBeUndefined();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/middlewares/accountAlias.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/accountAlias.ts
@@ -1,0 +1,49 @@
+import { Middleware } from "@reduxjs/toolkit";
+import { accountAliasSlice, registerAccountAliases } from "@domain/entity-account-alias";
+import { State } from "../reducers";
+
+// tolerates a partial preloaded state, which tests build by hand
+const allAccountIds = (accounts: State["accounts"] | undefined) =>
+  Array.isArray(accounts)
+    ? accounts.flatMap(account => [account.id, ...(account.subAccounts ?? []).map(({ id }) => id)])
+    : [];
+
+const sameIds = (a: string[], b: string[]) =>
+  a.length === b.length && a.every((id, i) => id === b[i]);
+
+/**
+ * Keeps the alias reverse map in sync with the account list. Runs in the dispatch chain rather
+ * than in an effect so a route rendered right after accounts land already resolves its alias.
+ */
+export const createAccountAliasMiddleware = (): Middleware<object, State> => {
+  let knownAccounts: State["accounts"] | undefined;
+  let knownIds: string[] = [];
+  return store => next => action => {
+    const result = next(action);
+    const { accounts } = store.getState();
+    // a sync rewrites the accounts without touching their ids, hence the second comparison
+    if (accounts !== knownAccounts) {
+      knownAccounts = accounts;
+      const ids = allAccountIds(accounts);
+      if (!sameIds(ids, knownIds)) {
+        knownIds = ids;
+        store.dispatch(registerAccountAliases(ids));
+      }
+    }
+    return result;
+  };
+};
+
+/**
+ * Seeds the reverse map from preloaded accounts, which no action ever announces. The real app
+ * boots with an empty store and gets its accounts through the middleware above; this covers tests
+ * that hand a populated state to `createStore`.
+ */
+export const withAccountAliases = (state?: State): State | undefined =>
+  state && {
+    ...state,
+    accountAliases: accountAliasSlice.reducer(
+      state.accountAliases,
+      registerAccountAliases(allAccountIds(state.accounts)),
+    ),
+  };

--- a/apps/ledger-live-desktop/src/renderer/reducers/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/index.ts
@@ -24,6 +24,7 @@ import modularDialog, { ModularDialogState } from "./modularDialog";
 import sendFlow, { SendFlowState } from "./sendFlow";
 import onboarding, { OnboardingState } from "./onboarding";
 import { lldRTKApiReducers, LLDRTKApiState } from "./rtkQueryApi";
+import { accountAliasSlice, type AccountAliasState } from "@domain/entity-account-alias";
 import { identitiesSlice, type IdentitiesState } from "@domain/entity-client-identity";
 import { supportedFiatsSlice, type SupportedFiatsState } from "@domain/entity-currency-fiat";
 import { contactsSlice, type ContactsState } from "@domain/entity-contact";
@@ -58,6 +59,7 @@ import coinConfigOverrides, { CoinConfigOverridesState } from "./coinConfigOverr
 import knownDevices, { KnownDevicesState } from "./knownDevices";
 
 export type State = LLDRTKApiState & {
+  accountAliases: AccountAliasState;
   accounts: AccountsState;
   application: ApplicationState;
   countervalues: CountervaluesState;
@@ -100,6 +102,7 @@ export type State = LLDRTKApiState & {
 };
 
 const appReducer = combineReducers({
+  accountAliases: accountAliasSlice.reducer,
   accounts,
   application,
   countervalues,

--- a/apps/ledger-live-desktop/src/renderer/screens/account/index.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/index.test.tsx
@@ -3,6 +3,8 @@ import { render, screen, withFlagOverrides } from "tests/testSetup";
 import { genAccount } from "@ledgerhq/live-common/mock/account";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { useLLDCoinFamily } from "~/renderer/families";
+import { computeAccountAlias } from "@domain/entity-account-alias";
+import { getAccountUrl } from "~/renderer/utils";
 import AccountPageWrapper from "./index";
 
 jest.mock("~/renderer/families");
@@ -80,5 +82,43 @@ describe("AccountPage — useLLDCoinFamily slots", () => {
 
     expect(screen.queryByTestId("body-header")).not.toBeInTheDocument();
     expect(screen.queryByTestId("sub-header")).not.toBeInTheDocument();
+  });
+});
+
+describe("AccountPage — aliased route params", () => {
+  beforeEach(() => {
+    mockFamily.mockReturnValue({} as never);
+  });
+
+  it("renders the account the route alias points to", () => {
+    useParams.mockReturnValue({
+      id: computeAccountAlias(account.id),
+      parentId: undefined,
+      "*": undefined,
+    });
+
+    render(<AccountPageWrapper />, {
+      initialState: { ...accountPageFlags, accounts: [account] },
+    });
+
+    expect(screen.getByTestId("balance-summary")).toBeInTheDocument();
+  });
+
+  it("keeps the account id out of the url getAccountUrl builds for it", () => {
+    expect(getAccountUrl(account.id)).not.toContain(account.id);
+  });
+
+  it("falls back to the accounts list when the alias is unknown", () => {
+    useParams.mockReturnValue({
+      id: computeAccountAlias("js:2:bitcoin:not-an-account:segwit"),
+      parentId: undefined,
+      "*": undefined,
+    });
+
+    render(<AccountPageWrapper />, {
+      initialState: { ...accountPageFlags, accounts: [account] },
+    });
+
+    expect(screen.queryByTestId("balance-summary")).not.toBeInTheDocument();
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/screens/account/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/index.tsx
@@ -35,6 +35,7 @@ import { useAddressPoisoningOperationsFamilies } from "@ledgerhq/live-common/hoo
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import { getAccountsSidebarPath } from "LLD/components/SideBar/utils";
 import { useAccountBackNavigation } from "./hooks/useAccountBackNavigation";
+import { useAccountIdFromRoute } from "~/renderer/hooks/useAccountIdFromRoute";
 
 type Params = {
   id?: string;
@@ -202,12 +203,15 @@ const ConnectedAccountPage = compose<React.ComponentType<OwnProps>>(
   withTranslation(),
 )(AccountPage);
 
-// Wrapper component that extracts route params and passes them to the connected component
+// Wrapper component that resolves the aliased route params and passes them to the connected component
 const AccountPageWrapper = () => {
   const { id, parentId, "*": splat } = useParams<Params & { "*"?: string }>();
+  // legacy links carry a raw account id, whose slashes react-router hands over in the splat
   const fullId =
     id && parentId && splat && splat.indexOf("account/") === -1 ? `${id}/${splat}` : id;
-  return <ConnectedAccountPage id={fullId} parentId={parentId} />;
+  const accountId = useAccountIdFromRoute(fullId);
+  const parentAccountId = useAccountIdFromRoute(parentId);
+  return <ConnectedAccountPage id={accountId} parentId={parentAccountId} />;
 };
 
 export default AccountPageWrapper;

--- a/apps/ledger-live-desktop/src/renderer/screens/accounts/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/accounts/index.tsx
@@ -14,6 +14,7 @@ import AccountList from "./AccountList";
 import AccountsHeader from "./AccountsHeader";
 import LedgerSyncEntryPoint from "LLD/features/LedgerSyncEntryPoints";
 import { EntryPoint } from "LLD/features/LedgerSyncEntryPoints/types";
+import { getAccountUrl } from "~/renderer/utils";
 
 export default function AccountsPage() {
   const mode = useSelector(accountsViewModeSelector);
@@ -33,9 +34,7 @@ export default function AccountsPage() {
   const onAccountClick = useCallback(
     (account: AccountLike, parentAccount?: Account | null) => {
       setTrackingSource("accounts page");
-      navigate(
-        parentAccount ? `/account/${parentAccount.id}/${account.id}` : `/account/${account.id}`,
-      );
+      navigate(getAccountUrl(account.id, parentAccount?.id));
     },
     [navigate],
   );

--- a/apps/ledger-live-desktop/src/renderer/screens/asset/AccountDistribution/Row.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/asset/AccountDistribution/Row.tsx
@@ -22,6 +22,7 @@ import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import { IconsLegacy } from "@ledgerhq/react-ui";
 import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import { useAccountName, useMaybeAccountName } from "~/renderer/reducers/wallet";
+import { getAccountUrl } from "~/renderer/utils";
 
 export type AccountDistributionItem = {
   account: AccountLike;
@@ -47,8 +48,8 @@ export default function Row({
       setTrackingSource("account allocation");
       navigate(
         account.type !== "Account"
-          ? `/account/${account.parentId}/${account.id}`
-          : `/account/${account.id}`,
+          ? getAccountUrl(account.id, account.parentId)
+          : getAccountUrl(account.id),
       );
     },
     [navigate],

--- a/apps/ledger-live-desktop/src/renderer/screens/stake/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/stake/index.tsx
@@ -13,6 +13,7 @@ import { HOOKS_TRACKING_LOCATIONS } from "~/renderer/analytics/hooks/variables";
 import { setOriginFlow } from "~/renderer/analytics/originFlow";
 import { useFeature } from "@features/platform-feature-flags";
 import { useOpenAssetAndAccount } from "LLD/features/ModularDialog/Web3AppWebview/AssetAndAccountDrawer";
+import { getAccountUrl } from "~/renderer/utils";
 
 const DRAWER_FLOW = "stake";
 
@@ -76,7 +77,7 @@ const useStakeFlow = () => {
       }
 
       if (shouldRedirect && outcome.outcome === "native_stake") {
-        navigate(returnTo ?? `/account/${account.id}`);
+        navigate(returnTo ?? getAccountUrl(account.id));
       }
     },
     [navigate, location, navigateToStakeForAccount],

--- a/apps/ledger-live-desktop/src/renderer/utils/accountUrl.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/utils/accountUrl.test.ts
@@ -1,29 +1,30 @@
+import { computeAccountAlias } from "@domain/entity-account-alias";
 import { getAccountUrl } from "./accountUrl";
+
+const ETH_ACCOUNT_ID = "js:2:ethereum:0x66c4371aE8FFeD2ec1c2EBbbcCfb7E494181E1E3:";
+const TRON_ACCOUNT_ID = "js:2:tron:TDyq9kiahZXthXHrpQNLyyRSj75kEZuYZQ:";
 
 describe("getAccountUrl", () => {
   it("should construct URL for main account without parent", () => {
-    const accountId = "js:2:ethereum:0x66c4371aE8FFeD2ec1c2EBbbcCfb7E494181E1E3:";
-    const url = getAccountUrl(accountId);
-    expect(url).toBe("/account/js:2:ethereum:0x66c4371aE8FFeD2ec1c2EBbbcCfb7E494181E1E3:");
+    expect(getAccountUrl(ETH_ACCOUNT_ID)).toBe(`/account/${computeAccountAlias(ETH_ACCOUNT_ID)}`);
   });
 
   it("should construct URL for token account with parent", () => {
-    const accountId =
-      "js:2:ethereum:0x66c4371aE8FFeD2ec1c2EBbbcCfb7E494181E1E3:+ethereum%2Ferc20%2Fusd__coin";
-    const parentId = "js:2:ethereum:0x66c4371aE8FFeD2ec1c2EBbbcCfb7E494181E1E3:";
-    const url = getAccountUrl(accountId, parentId);
-    expect(url).toBe(
-      "/account/js:2:ethereum:0x66c4371aE8FFeD2ec1c2EBbbcCfb7E494181E1E3:/js:2:ethereum:0x66c4371aE8FFeD2ec1c2EBbbcCfb7E494181E1E3:+ethereum%2Ferc20%2Fusd__coin",
+    const tokenAccountId = `${ETH_ACCOUNT_ID}+ethereum%2Ferc20%2Fusd__coin`;
+    expect(getAccountUrl(tokenAccountId, ETH_ACCOUNT_ID)).toBe(
+      `/account/${computeAccountAlias(ETH_ACCOUNT_ID)}/${computeAccountAlias(tokenAccountId)}`,
     );
   });
 
-  it("should handle account IDs with slashes (React Router wildcard captures them)", () => {
-    const accountId =
-      "js:2:tron:TDyq9kiahZXthXHrpQNLyyRSj75kEZuYZQ:+tron/trc20/tr7nhqjekqxgtci8q8zy4pl8otszgjlj6t";
-    const parentId = "js:2:tron:TDyq9kiahZXthXHrpQNLyyRSj75kEZuYZQ:";
-    const url = getAccountUrl(accountId, parentId);
-    expect(url).toBe(
-      "/account/js:2:tron:TDyq9kiahZXthXHrpQNLyyRSj75kEZuYZQ:/js:2:tron:TDyq9kiahZXthXHrpQNLyyRSj75kEZuYZQ:+tron/trc20/tr7nhqjekqxgtci8q8zy4pl8otszgjlj6t",
-    );
+  it("should leak neither address nor token id", () => {
+    const tokenAccountId = `${TRON_ACCOUNT_ID}+tron/trc20/tr7nhqjekqxgtci8q8zy4pl8otszgjlj6t`;
+    const url = getAccountUrl(tokenAccountId, TRON_ACCOUNT_ID);
+    expect(url).not.toContain("TDyq9kiahZXthXHrpQNLyyRSj75kEZuYZQ");
+    expect(url).not.toContain("trc20");
+    expect(url.split("/")).toHaveLength(4);
+  });
+
+  it("should be stable across calls", () => {
+    expect(getAccountUrl(ETH_ACCOUNT_ID)).toBe(getAccountUrl(ETH_ACCOUNT_ID));
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/utils/accountUrl.ts
+++ b/apps/ledger-live-desktop/src/renderer/utils/accountUrl.ts
@@ -1,3 +1,5 @@
+import { computeAccountAlias } from "@domain/entity-account-alias";
+
 /**
  * React Router decodes URL parameters, but account IDs in the Redux store are encoded.
  * This function returns an array of IDs to try when searching for an account:
@@ -96,15 +98,18 @@ export function findSubAccountByIdWithFallback<
 /**
  * Constructs a URL path for navigating to an account.
  * Handles both main accounts and token accounts (sub-accounts).
- * React Router v7 with wildcard routes (*) captures the full path including slashes.
+ *
+ * Account IDs embed an xpub or an address, so the path carries their alias instead — see
+ * `@domain/entity-account-alias`. Resolve it back with `useAccountIdFromRoute`.
  *
  * @param accountId - The account ID (required)
  * @param parentId - The parent account ID (optional, for token accounts)
- * @returns The URL path (e.g., "/account/{parentId}/{accountId}" or "/account/{accountId}")
+ * @returns The URL path (e.g., "/account/{parentAlias}/{alias}" or "/account/{alias}")
  */
 export function getAccountUrl(accountId: string, parentId?: string): string {
+  const alias = computeAccountAlias(accountId);
   if (parentId) {
-    return `/account/${parentId}/${accountId}`;
+    return `/account/${computeAccountAlias(parentId)}/${alias}`;
   }
-  return `/account/${accountId}`;
+  return `/account/${alias}`;
 }

--- a/apps/ledger-live-desktop/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-desktop/src/state-manager/configureStore.ts
@@ -14,6 +14,10 @@ import {
   swapApiExtra,
 } from "@shared/api-services";
 import { getCardSessionToken, refreshCardSession } from "@features/platform-card";
+import {
+  createAccountAliasMiddleware,
+  withAccountAliases,
+} from "~/renderer/middlewares/accountAlias";
 import logger from "~/renderer/middlewares/logger";
 import reducers, { State } from "~/renderer/reducers";
 import { applyLldRTKApiMiddlewares } from "~/renderer/reducers/rtkQueryApi";
@@ -45,7 +49,7 @@ const customCreateStore = ({
 }: Props) => {
   const store = configureStore({
     reducer: reducers,
-    preloadedState: state,
+    preloadedState: withAccountAliases(state),
     middleware: getDefaultMiddleware =>
       applyLldRTKApiMiddlewares(
         getDefaultMiddleware({
@@ -102,6 +106,7 @@ const customCreateStore = ({
         }),
       )
         .concat(logger)
+        .concat(createAccountAliasMiddleware())
         .concat(analyticsMiddleware ? [analyticsMiddleware] : [])
         .concat(dbMiddleware ? [dbMiddleware] : [])
         .concat(

--- a/domain/entity/account-alias/README.md
+++ b/domain/entity/account-alias/README.md
@@ -1,0 +1,52 @@
+# @domain/entity-account-alias
+
+> [!CAUTION]
+> **Status: UNSTABLE** — New package, API still being designed.
+
+## Why
+
+`account.id` embeds derivation data in plain text:
+
+```
+js:2:bitcoin:xpub6DEHKg8fgKcb5iYGPLtpBYD9gm7nvym3wwhHVnH3TtogvJGTcApj71K8iTpL7CzdZWAxwyjkZEFUrnLK24zKqgj3EVH7Vg1CD1ujibwiHuy:segwit
+```
+
+Every surface that carries an account id therefore leaks an xpub or an address: route paths, the
+`page` property of analytics events, breadcrumbs, logs. This package provides the aliasing layer
+that keeps those surfaces free of PII, without changing the account id itself.
+
+## How
+
+`computeAccountAlias(accountId)` returns `uuidv5(accountId, <private namespace>)`. It is:
+
+- **deterministic** — same id, same alias, across sessions and devices, so an alias can be stored
+  in a URL or in navigation state;
+- **one-way** — an alias carries no address or xpub (see the limit below);
+- **memoized** — hashing happens once per account id.
+
+**What this does and does not buy.** It stops account ids from reaching analytics, logs and route
+paths in plaintext. It is not unlinkability: the namespace ships in the binary, so an alias can be
+confirmed against a candidate address, and one wallet produces the same alias on every install. A
+per-installation namespace would close that at the cost of persisting it; routes only need
+stability within an install, so it remains an option.
+
+The reverse direction needs state: `accountAliasSlice` holds `accountIdByAlias`, filled by
+`registerAccountAliases(accountIds)` and read back with `accountIdFromAliasSelector` /
+`resolveAccountIdSelector`. Apps must register the ids (main **and** token accounts) whenever the
+account list changes, before any alias can be resolved.
+
+## Main exports
+
+| Export | Direction |
+| --- | --- |
+| `computeAccountAlias(accountId)` | id → alias, pure |
+| `registerAccountAliases(accountIds)` | feeds the reverse map |
+| `accountIdFromAliasSelector(state, alias)` | alias → id, `undefined` when unknown |
+| `resolveAccountIdSelector(state, segment)` | alias → id, falls back to the segment itself |
+
+`resolveAccountIdSelector` is the one to use at a route boundary: a link created before this
+package existed still carries a raw account id, and must keep working.
+
+## Related
+
+- `libs/ledger-live-common/src/wallet-api/converters.ts` — same `uuidv5` scheme, other namespace

--- a/domain/entity/account-alias/jest.config.js
+++ b/domain/entity/account-alias/jest.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  testEnvironment: "node",
+  passWithNoTests: true,
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.(t|j)sx?$": ["@swc/jest", { jsc: { target: "esnext" } }],
+  },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+    "@ledgerhq/test-quarantine/jest",
+  ],
+  setupFilesAfterEnv: ["@ledgerhq/test-quarantine/jest-retries"],
+};

--- a/domain/entity/account-alias/package.json
+++ b/domain/entity/account-alias/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@domain/entity-account-alias",
+  "version": "0.0.1",
+  "private": true,
+  "description": "AccountAlias entity: non-reversible aliases for account ids, reverse-lookup state and selectors",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../../.. -W domain/entity/account-alias"
+  },
+  "dependencies": {
+    "@reduxjs/toolkit": "catalog:",
+    "uuid": "^9.0.0",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@ledgerhq/test-quarantine": "workspace:*",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/uuid": "^9.0.0",
+    "jest": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/domain/entity/account-alias/project.json
+++ b/domain/entity/account-alias/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@domain/entity-account-alias",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/domain/entity/account-alias/src/index.ts
+++ b/domain/entity/account-alias/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./schema";
+export * from "./selectors";
+export * from "./slice";

--- a/domain/entity/account-alias/src/schema.test.ts
+++ b/domain/entity/account-alias/src/schema.test.ts
@@ -1,0 +1,51 @@
+import {
+  AccountAliasSchema,
+  computeAccountAlias,
+  initialAccountAliasState,
+  AccountAliasStateSchema,
+} from "./schema";
+
+const BTC_ACCOUNT_ID = "js:2:bitcoin:xpub6DEHKg8fgKcb5iYGPLtpBYD9gm7nvym3wwhH:segwit";
+const ETH_ACCOUNT_ID = "js:2:ethereum:0x66c4371aE8FFeD2ec1c2EBbbcCfb7E494181E1E3:";
+
+describe("computeAccountAlias", () => {
+  it("returns a uuid", () => {
+    expect(AccountAliasSchema.safeParse(computeAccountAlias(BTC_ACCOUNT_ID)).success).toBe(true);
+  });
+
+  it("is deterministic", () => {
+    expect(computeAccountAlias(BTC_ACCOUNT_ID)).toBe(computeAccountAlias(BTC_ACCOUNT_ID));
+  });
+
+  it("gives different aliases to different accounts", () => {
+    expect(computeAccountAlias(BTC_ACCOUNT_ID)).not.toBe(computeAccountAlias(ETH_ACCOUNT_ID));
+  });
+
+  it("leaks no part of the account id", () => {
+    const alias: string = computeAccountAlias(BTC_ACCOUNT_ID);
+    expect(alias).not.toContain("xpub");
+    expect(alias).not.toContain("bitcoin");
+    expect(alias).not.toMatch(/[/+:]/);
+  });
+
+  it("aliases token account ids, slashes and all", () => {
+    const tokenAccountId = `${ETH_ACCOUNT_ID}+ethereum/erc20/usd__coin`;
+    expect(AccountAliasSchema.safeParse(computeAccountAlias(tokenAccountId)).success).toBe(true);
+  });
+});
+
+describe("AccountAliasStateSchema", () => {
+  it("accepts the initial state", () => {
+    expect(AccountAliasStateSchema.safeParse(initialAccountAliasState).success).toBe(true);
+  });
+
+  it("accepts a populated reverse map", () => {
+    const state = { accountIdByAlias: { [computeAccountAlias(BTC_ACCOUNT_ID)]: BTC_ACCOUNT_ID } };
+    expect(AccountAliasStateSchema.safeParse(state).success).toBe(true);
+  });
+
+  it("rejects a non-string entry", () => {
+    const state = { accountIdByAlias: { [computeAccountAlias(BTC_ACCOUNT_ID)]: 42 } };
+    expect(AccountAliasStateSchema.safeParse(state).success).toBe(false);
+  });
+});

--- a/domain/entity/account-alias/src/schema.ts
+++ b/domain/entity/account-alias/src/schema.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+import { v5 as uuidv5 } from "uuid";
+
+/**
+ * Namespace for account id aliasing. Randomly generated uuid v4, distinct from the wallet-api one
+ * so the same account cannot be correlated across the two surfaces. It is a build-time constant,
+ * not a secret — see the reversibility note on `computeAccountAlias`.
+ */
+const ACCOUNT_ALIAS_NAMESPACE = "6f2f9d3a-0f5d-4d51-9b5b-2f0f2a2f1c73";
+
+/** Opaque, deterministic stand-in for an account id. */
+export const AccountAliasSchema = z.uuid().brand<"AccountAlias">();
+
+export type AccountAlias = z.infer<typeof AccountAliasSchema>;
+
+const aliasByAccountId = new Map<string, AccountAlias>();
+
+/**
+ * Derives the alias of an account id. Deterministic across sessions and devices, so an alias can
+ * safely be put in a route, and one-way, so it carries neither xpub nor address.
+ *
+ * It is not a secret. The namespace ships in the binary, so anyone already holding a candidate
+ * address or xpub can confirm a match by recomputing the alias, and the same wallet yields the
+ * same alias on every install. This stops the plaintext leak; it is not an unlinkability
+ * guarantee. Same trade-off as the wallet-api aliasing this generalizes.
+ */
+export function computeAccountAlias(accountId: string): AccountAlias {
+  const cached = aliasByAccountId.get(accountId);
+  if (cached) return cached;
+  const alias = AccountAliasSchema.parse(uuidv5(accountId, ACCOUNT_ALIAS_NAMESPACE));
+  aliasByAccountId.set(accountId, alias);
+  return alias;
+}
+
+export const AccountAliasStateSchema = z.object({
+  /** Reverse map keyed by alias, only known for accounts registered during this session. */
+  accountIdByAlias: z.record(z.string(), z.string()),
+});
+
+export type AccountAliasState = z.infer<typeof AccountAliasStateSchema>;
+
+export const initialAccountAliasState: AccountAliasState = { accountIdByAlias: {} };

--- a/domain/entity/account-alias/src/selectors.test.ts
+++ b/domain/entity/account-alias/src/selectors.test.ts
@@ -1,0 +1,26 @@
+import { computeAccountAlias, initialAccountAliasState } from "./schema";
+import { accountIdFromAliasSelector, resolveAccountIdSelector } from "./selectors";
+
+const ACCOUNT_ID = "js:2:bitcoin:xpub6DEHKg8fgKcb5iYGPLtpBYD9gm7nvym3wwhH:segwit";
+const alias = computeAccountAlias(ACCOUNT_ID);
+const state = { accountIdByAlias: { [alias]: ACCOUNT_ID } };
+
+describe("accountIdFromAliasSelector", () => {
+  it("resolves a registered alias", () => {
+    expect(accountIdFromAliasSelector(state, alias)).toBe(ACCOUNT_ID);
+  });
+
+  it("returns undefined for an unknown alias", () => {
+    expect(accountIdFromAliasSelector(initialAccountAliasState, alias)).toBeUndefined();
+  });
+});
+
+describe("resolveAccountIdSelector", () => {
+  it("resolves a registered alias", () => {
+    expect(resolveAccountIdSelector(state, alias)).toBe(ACCOUNT_ID);
+  });
+
+  it("passes a raw account id through", () => {
+    expect(resolveAccountIdSelector(state, ACCOUNT_ID)).toBe(ACCOUNT_ID);
+  });
+});

--- a/domain/entity/account-alias/src/selectors.ts
+++ b/domain/entity/account-alias/src/selectors.ts
@@ -1,0 +1,14 @@
+import type { AccountAliasState } from "./schema";
+
+/** Account id behind an alias, `undefined` when the alias was never registered. */
+export const accountIdFromAliasSelector = (
+  state: AccountAliasState,
+  alias: string,
+): string | undefined => state.accountIdByAlias[alias];
+
+/**
+ * Account id behind a route segment. Falls back to the segment itself so links holding a raw
+ * account id — legacy deeplinks, persisted navigation state — keep working.
+ */
+export const resolveAccountIdSelector = (state: AccountAliasState, segment: string): string =>
+  state.accountIdByAlias[segment] ?? segment;

--- a/domain/entity/account-alias/src/slice.test.ts
+++ b/domain/entity/account-alias/src/slice.test.ts
@@ -1,0 +1,32 @@
+import { computeAccountAlias, initialAccountAliasState } from "./schema";
+import { accountAliasSlice, registerAccountAliases } from "./slice";
+
+const { reducer } = accountAliasSlice;
+
+const ACCOUNT_ID = "js:2:bitcoin:xpub6DEHKg8fgKcb5iYGPLtpBYD9gm7nvym3wwhH:segwit";
+const TOKEN_ACCOUNT_ID = "js:2:ethereum:0xdead:+ethereum/erc20/usd__coin";
+
+describe("accountAliasSlice", () => {
+  it("starts empty", () => {
+    expect(reducer(undefined, { type: "@@INIT" })).toEqual(initialAccountAliasState);
+  });
+
+  it("registers aliases for main and token accounts", () => {
+    const state = reducer(undefined, registerAccountAliases([ACCOUNT_ID, TOKEN_ACCOUNT_ID]));
+    expect(state.accountIdByAlias).toEqual({
+      [computeAccountAlias(ACCOUNT_ID)]: ACCOUNT_ID,
+      [computeAccountAlias(TOKEN_ACCOUNT_ID)]: TOKEN_ACCOUNT_ID,
+    });
+  });
+
+  it("merges successive registrations", () => {
+    const first = reducer(undefined, registerAccountAliases([ACCOUNT_ID]));
+    const second = reducer(first, registerAccountAliases([TOKEN_ACCOUNT_ID]));
+    expect(Object.keys(second.accountIdByAlias)).toHaveLength(2);
+  });
+
+  it("keeps the same state reference when nothing is new", () => {
+    const state = reducer(undefined, registerAccountAliases([ACCOUNT_ID]));
+    expect(reducer(state, registerAccountAliases([ACCOUNT_ID]))).toBe(state);
+  });
+});

--- a/domain/entity/account-alias/src/slice.ts
+++ b/domain/entity/account-alias/src/slice.ts
@@ -1,0 +1,20 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import { computeAccountAlias, initialAccountAliasState } from "./schema";
+
+export const accountAliasSlice = createSlice({
+  name: "accountAlias",
+  initialState: initialAccountAliasState,
+  reducers: {
+    /** Makes the given account ids resolvable from their alias. Idempotent. */
+    registerAccountAliases: (state, { payload }: PayloadAction<string[]>) => {
+      for (const accountId of payload) {
+        const alias = computeAccountAlias(accountId);
+        if (state.accountIdByAlias[alias] !== accountId) {
+          state.accountIdByAlias[alias] = accountId;
+        }
+      }
+    },
+  },
+});
+
+export const { registerAccountAliases } = accountAliasSlice.actions;

--- a/domain/entity/account-alias/tsconfig.json
+++ b/domain/entity/account-alias/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["jest"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -854,6 +854,9 @@ importers:
       '@domain/api-push-devices':
         specifier: workspace:*
         version: link:../../domain/api/push-devices
+      '@domain/entity-account-alias':
+        specifier: workspace:^
+        version: link:../../domain/entity/account-alias
       '@domain/entity-account-name':
         specifier: workspace:^
         version: link:../../domain/entity/account-name
@@ -4589,6 +4592,40 @@ importers:
       msw:
         specifier: 'catalog:'
         version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
+  domain/entity/account-alias:
+    dependencies:
+      '@reduxjs/toolkit':
+        specifier: 'catalog:'
+        version: 2.11.2
+      uuid:
+        specifier: ^9.0.0
+        version: 9.0.1
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+    devDependencies:
+      '@ledgerhq/test-quarantine':
+        specifier: workspace:*
+        version: link:../../../support/test-quarantine
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/uuid':
+        specifier: ^9.0.0
+        version: 9.0.8
+      jest:
+        specifier: 'catalog:'
+        version: 30.4.1
       typescript:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
@@ -67366,7 +67403,9 @@ snapshots:
     optionalDependencies:
       metro-transform-worker: 0.83.7
     transitivePeerDependencies:
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   metro-core@0.81.5:
     dependencies:
@@ -67627,7 +67666,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.7(metro-transform-worker@0.83.7)
+      metro: 0.83.7
       metro-babel-transformer: 0.83.7
       metro-cache: 0.83.7
       metro-cache-key: 0.83.7
@@ -67777,53 +67816,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro@0.83.7(metro-transform-worker@0.83.7):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 2.0.0
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.35.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.7
-      metro-cache: 0.83.7
-      metro-cache-key: 0.83.7
-      metro-config: 0.83.7(metro-transform-worker@0.83.7)
-      metro-core: 0.83.7
-      metro-file-map: 0.83.7
-      metro-resolver: 0.83.7
-      metro-runtime: 0.83.7
-      metro-source-map: 0.83.7
-      metro-symbolicate: 0.83.7
-      metro-transform-plugins: 0.83.7
-      metro-transform-worker: 0.83.7
-      mime-types: 3.0.1
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
### 📝 Description

Account ids embed an xpub or an address, so every `/account/...` path leaks PII to analytics (`page: location.pathname`), logs and breadcrumbs. Routes now carry a deterministic, one-way `uuidv5` alias instead, resolved back at the route boundary — the same scheme as the existing wallet-api aliasing, extracted into `@domain/entity-account-alias`.

Consumer side — `getAccountUrl` is unchanged at the call site, only its output changed:

```ts
getAccountUrl(account.id, parentAccount?.id); // → /account/{parentAlias}/{alias}
const accountId = useAccountIdFromRoute(useParams().id); // alias → account id
```

Unknown segments fall through untouched, so links minted before aliasing keep working.

> [!NOTE]
> The alias is not a secret: the namespace ships in the binary, so it stops the plaintext leak but is not an unlinkability guarantee. A per-installation namespace would close that and is noted as an option in the package README — worth deciding on the epic.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35367](https://ledgerhq.atlassian.net/browse/LIVE-35367) — epic [LIVE-34982](https://ledgerhq.atlassian.net/browse/LIVE-34982) (Option B)
- **ADR** (if any): n/a

[LIVE-35367]: https://ledgerhq.atlassian.net/browse/LIVE-35367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ