### PR TITLE
test(e2e): only retry detox unitary failing tests

### DIFF
--- a/.github/workflows/test-mobile-e2e-lint-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-lint-reusable.yml
@@ -53,4 +53,4 @@ jobs:
         run: pnpm exec nx run ledger-live-mobile-e2e-tests:format:check
 
       - name: Run lint and typecheck
-        run: pnpm exec nx run-many -t lint,typecheck --projects=ledger-live-mobile-e2e-tests
+        run: pnpm exec nx run-many -t lint,typecheck,lint:test-names --projects=ledger-live-mobile-e2e-tests

--- a/e2e/mobile/jest.config.js
+++ b/e2e/mobile/jest.config.js
@@ -35,6 +35,11 @@ function pathsToModuleNameMapper(paths, { prefix = "<rootDir>/" } = {}) {
 
 const platform = process.env.DETOX_CONFIGURATION?.startsWith("ios") ? "ios" : "android";
 
+// Same set jest.environment.ts narrows the run to on a Detox retry. Present only on a retry pass.
+const retryTestNames = process.env.E2E_RETRY_TEST_NAMES
+  ? new Set(JSON.parse(process.env.E2E_RETRY_TEST_NAMES))
+  : undefined;
+
 const jestAllure2ReporterOptions = {
   extends: "detox-allure2-adapter/preset-detox",
   resultsDir: "artifacts",
@@ -54,6 +59,14 @@ const jestAllure2ReporterOptions = {
     },
     status: ({ value }) => (value === "broken" ? "failed" : value),
     historyId: ({ value }) => `${value}:${platform}`,
+    // On a Detox retry, jest.environment.ts marks the tests we are not retrying as skipped rather
+    // than deleting them, because deleting desynchronises jest's result list from jest-metadata's
+    // registry and the reporter pairs those positionally (losing a result entirely). They are
+    // still reported, though, so drop them here: they share a historyId with their previous
+    // attempt, and a later-timestamped "skipped" would override that verdict in the report.
+    // Inert outside a retry pass, when retryTestNames is undefined.
+    ignored: ({ value, testCase }) =>
+      value || (!!retryTestNames && !retryTestNames.has(testCase.fullName)),
   },
   overwrite: false,
   environment: async ({ $ }) => ({

--- a/e2e/mobile/jest.environment.ts
+++ b/e2e/mobile/jest.environment.ts
@@ -44,6 +44,35 @@ import { withTimeout } from "@e2e/utils/withTimeout";
 const FAST_DIAGNOSTIC_TIMEOUT_MS = 5_000;
 const SLOW_DIAGNOSTIC_TIMEOUT_MS = 15_000;
 
+// Set by the patched Detox retry (patches/detox@20.51.3.patch) to the exact full names of the
+// tests that failed in the previous attempt.
+const retryTestNames = process.env.E2E_RETRY_TEST_NAMES
+  ? new Set<string>(JSON.parse(process.env.E2E_RETRY_TEST_NAMES))
+  : undefined;
+
+/**
+ * Mark every test that is not in `names` (so passed in the previous attempt) as skipped.
+ * Skipped tests write no Allure result, so the previous attempt's verdict remains.
+ */
+const skipToRetrySet = (
+  block: Circus.DescribeBlock,
+  names: Set<string>,
+  path: string[] = [],
+): number => {
+  let kept = 0;
+  for (const child of block.children) {
+    if (child.type === "describeBlock") {
+      kept += skipToRetrySet(child, names, [...path, child.name]);
+      // Mirrors jest-circus getTestID: the names path minus the root block, space-joined.
+    } else if (names.has([...path, child.name].join(" "))) {
+      kept++;
+    } else {
+      child.mode = "skip";
+    }
+  }
+  return kept;
+};
+
 async function captureFailureDiagnostics(): Promise<void> {
   await withTimeout(takeSpeculosScreenshot(), FAST_DIAGNOSTIC_TIMEOUT_MS, "takeSpeculosScreenshot");
   await withTimeout(
@@ -308,6 +337,18 @@ export default class TestEnvironment extends DetoxEnvironment {
     }
 
     if (event.name === "run_start") {
+      if (retryTestNames) {
+        const kept = skipToRetrySet(state.rootDescribeBlock, retryTestNames);
+        // Detox only retries spec files that failed, and narrowing is all-or-nothing, so every
+        // retried file contributed at least one name. Matching none means the names and the tree
+        // disagree — fail loudly rather than skip the whole file and report a green pass.
+        if (kept === 0) {
+          throw new Error(
+            `E2E_RETRY_TEST_NAMES matched no test in this file, so the retry would run nothing. ` +
+              `Expected one of: ${[...retryTestNames].join(" | ")}`,
+          );
+        }
+      }
       resetStderrCaptureForCurrentTest();
       installConsoleCapture();
       await logMemoryUsage();

--- a/e2e/mobile/package.json
+++ b/e2e/mobile/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "lint": "oxlint .",
+    "lint:test-names": "node ./scripts/check-test-names.mjs",
     "lint:fix": "oxfmt . && oxlint . --fix",
     "format": "oxfmt .",
     "format:check": "oxfmt . --check",

--- a/e2e/mobile/scripts/check-test-names.mjs
+++ b/e2e/mobile/scripts/check-test-names.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+/**
+ * Fails if any test or describe title could differ between two runs of the same commit.
+ *
+ * A Detox retry re-runs only the tests that failed, and selects them by exact full name
+ * (see jest.environment.ts). A title that changes between attempts cannot be matched, so the
+ * test is silently left un-retried on its failed verdict — or, if it was the only failure in
+ * its file, the retry aborts because nothing matched. Neither is visible in a green log, which
+ * is why this is enforced rather than reviewed.
+ *
+ * Three things are rejected:
+ *   1. a known non-deterministic call written straight into the title, e.g. `${Date.now()}`
+ *   2. any other call made inside the interpolation itself, e.g. `${getRandomLiveApp()}`
+ *   3. a title interpolating an in-file binding whose initializer calls a function, e.g.
+ *        const liveApp = app.discover.getRandomLiveApp();
+ *        it(`opens ${liveApp}`, ...)
+ *
+ * 2 and 3 are the same hazard reached two ways: a call runs at collection time, and every retry
+ * attempt is a fresh process that runs it again, so nothing guarantees the same value twice.
+ * Property access on fixtures and enums (`account.currency.testLabel`) is fine and is by far the
+ * common case — of the 45 interpolations in the suite today, none is a call.
+ *
+ * Keep the value out of the name and log it from the test body instead. If a call really is
+ * deterministic, put `// deterministic-title-ok` on the line above the declaration.
+ */
+import ts from "typescript";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const OPT_OUT = "deterministic-title-ok";
+const TITLE_CALLEES = new Set(["it", "test", "describe", "fit", "xit"]);
+// Written into a title directly; the in-file binding rule below covers the indirect cases.
+const NON_DETERMINISTIC = /\b(Math\.random|randomInt|Date\.now|new Date|uuid|nanoid|randomUUID)\b/;
+
+const files = [];
+(function walk(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name !== "node_modules" && entry.name !== "artifacts") walk(full);
+    } else if (/\.tsx?$/.test(entry.name)) {
+      files.push(full);
+    }
+  }
+})(ROOT);
+
+/** Unwraps `(isSmokeTestRun ? it.skip : it)(...)` and `it.skip(...)` down to the base name. */
+const calleeName = expr => {
+  let node = expr;
+  while (ts.isParenthesizedExpression(node)) node = node.expression;
+  if (ts.isConditionalExpression(node)) {
+    return calleeName(node.whenTrue) ?? calleeName(node.whenFalse);
+  }
+  if (ts.isPropertyAccessExpression(node)) return calleeName(node.expression);
+  return ts.isIdentifier(node) ? node.text : null;
+};
+
+/** A call or `new` anywhere in the expression: evaluated per process, so not stable by construction. */
+const containsCall = node => {
+  let found = false;
+  (function scan(n) {
+    if (found) return;
+    if (ts.isCallExpression(n) || ts.isNewExpression(n)) found = true;
+    else ts.forEachChild(n, scan);
+  })(node);
+  return found;
+};
+
+const violations = [];
+
+for (const file of files) {
+  const text = fs.readFileSync(file, "utf8");
+  const src = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true);
+  const rel = path.relative(ROOT, file);
+  const lineOf = node => src.getLineAndCharacterOfPosition(node.getStart(src)).line + 1;
+  const optedOut = node =>
+    (text.slice(0, node.getStart(src)).split("\n").at(-2) ?? "").includes(OPT_OUT);
+
+  // Bindings declared in this file whose initializer calls something, so their value is
+  // produced at collection time rather than read from a fixture.
+  const callBackedBindings = new Map();
+  (function collect(node) {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      let hasCall = false;
+      (function scan(n) {
+        if (ts.isCallExpression(n)) hasCall = true;
+        ts.forEachChild(n, scan);
+      })(node.initializer);
+      if (hasCall && !optedOut(node)) {
+        callBackedBindings.set(node.name.text, {
+          line: lineOf(node),
+          init: node.initializer.getText(src).replace(/\s+/g, " ").slice(0, 60),
+        });
+      }
+    }
+    ts.forEachChild(node, collect);
+  })(src);
+
+  (function visit(node) {
+    if (ts.isCallExpression(node) && node.arguments.length) {
+      const name = calleeName(node.expression);
+      const title = node.arguments[0];
+      if (TITLE_CALLEES.has(name) && ts.isTemplateExpression(title) && !optedOut(title)) {
+        for (const span of title.templateSpans) {
+          const expr = span.expression.getText(src);
+          if (NON_DETERMINISTIC.test(expr)) {
+            violations.push({
+              rel,
+              line: lineOf(title),
+              expr,
+              why: "non-deterministic call in the title",
+            });
+            continue;
+          }
+          if (containsCall(span.expression)) {
+            violations.push({
+              rel,
+              line: lineOf(title),
+              expr,
+              why: `interpolation calls a function ("${expr}"), which re-runs in every attempt's process`,
+            });
+            continue;
+          }
+          // Only a bare identifier can be traced back to a declaration here; a property chain
+          // such as `account.currency.testLabel` reads a fixture and is stable by construction.
+          const binding = ts.isIdentifier(span.expression) && callBackedBindings.get(expr);
+          if (binding) {
+            violations.push({
+              rel,
+              line: lineOf(title),
+              expr,
+              why: `interpolates "${expr}", assigned from a call at line ${binding.line}: ${binding.init}`,
+            });
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  })(src);
+}
+
+if (violations.length === 0) {
+  console.log(`✅ ${files.length} files: every test title is stable across retries.`);
+  process.exit(0);
+}
+
+console.error(`❌ ${violations.length} test title(s) may change between attempts:\n`);
+for (const v of violations) {
+  console.error(`  ${v.rel}:${v.line}`);
+  console.error(`    ${v.why}`);
+}
+console.error(
+  `\nA Detox retry matches tests by exact name, so these cannot be retried reliably.\n` +
+    `Keep the value out of the title and log it from the test body, or mark a genuinely\n` +
+    `deterministic declaration with "// ${OPT_OUT}" on the line above.`,
+);
+process.exit(1);

--- a/e2e/mobile/specs/deeplinks.spec.ts
+++ b/e2e/mobile/specs/deeplinks.spec.ts
@@ -2,6 +2,7 @@ import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { swapSetup } from "@e2e/bridge/server";
 import { setTeamOwner } from "@e2e/helpers/allure/allure-helper";
+import { allure } from "jest-allure2-reporter/api";
 
 const isSmokeTestRun = process.env.INPUTS_TEST_FILTER?.includes("@smoke");
 
@@ -30,11 +31,6 @@ describe("Deeplinks", () => {
       },
     });
     await app.mainNavigation.waitForWallet40Ready();
-  });
-
-  beforeEach(async () => {
-    // workaround: modular drawer blocks deeplink
-    await app.modularDrawer.tapDrawerCloseButton({ onlyIfVisible: true });
   });
 
   beforeEach(async () => {
@@ -75,8 +71,9 @@ describe("Deeplinks", () => {
   });
 
   (isSmokeTestRun ? it.skip : it)(
-    `should open the Discover page and search for ${randomLiveApp}`,
+    "should open the Discover page and search for a live app",
     async () => {
+      allure.description(`Live app: ${randomLiveApp}`);
       await app.discover.openViaDeeplink();
       await app.discover.typeInCatalogSearchBar(randomLiveApp);
       await app.discover.expectCatalogAppCard(randomLiveApp);
@@ -85,13 +82,11 @@ describe("Deeplinks", () => {
     },
   );
 
-  (isSmokeTestRun ? it.skip : it)(
-    `should open discovery to ${randomLiveApp} live App`,
-    async () => {
-      await app.discover.openViaDeeplink(randomLiveApp);
-      await app.discover.expectApp(randomLiveApp);
-    },
-  );
+  (isSmokeTestRun ? it.skip : it)("should open discovery to a live App", async () => {
+    allure.description(`Live app: ${randomLiveApp}`);
+    await app.discover.openViaDeeplink(randomLiveApp);
+    await app.discover.expectApp(randomLiveApp);
+  });
 
   (isSmokeTestRun ? it.skip : it)("should open discovery to Kiln Widget live App", async () => {
     await app.discover.openViaDeeplink("Kiln-Widget");

--- a/e2e/mobile/specs/languageChange.spec.ts
+++ b/e2e/mobile/specs/languageChange.spec.ts
@@ -53,9 +53,6 @@ describe("Settings", () => {
       speculosForSetupOnly: true,
     });
     await app.mainNavigation.waitForWallet40Ready();
-  });
-
-  it("Open general settings", async () => {
     await app.mainNavigation.navigateToSettings();
     await app.settings.navigateToGeneralSettings();
   });

--- a/e2e/mobile/specs/wallet40Q2/portfolioWithAccount.spec.ts
+++ b/e2e/mobile/specs/wallet40Q2/portfolioWithAccount.spec.ts
@@ -3,16 +3,7 @@ import { setTeamOwner } from "@e2e/helpers/allure/allure-helper";
 import { FF_LWM_WALLET_40_Q2 } from "@e2e/utils/featureFlagUtils";
 
 const testConfig = {
-  tmsLinks: [
-    "B2CQA-4345",
-    "B2CQA-4339",
-    "B2CQA-4346",
-    "B2CQA-4343",
-    "B2CQA-4341",
-    "B2CQA-4340",
-    "B2CQA-4351",
-    "B2CQA-4350",
-  ],
+  tmsLinks: ["B2CQA-4345", "B2CQA-4339", "B2CQA-4346", "B2CQA-4341", "B2CQA-4340", "B2CQA-4351"],
   tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],
 };
 
@@ -21,7 +12,7 @@ const CURRENCY = ACCOUNT.currency;
 const TICKER = CURRENCY.ticker;
 
 setTeamOwner(Team.WALLET_XP);
-describe("Portfolio", () => {
+describe("Portfolio with account", () => {
   beforeAll(async () => {
     await app.init({
       userdata: "skip-onboarding",
@@ -29,19 +20,6 @@ describe("Portfolio", () => {
       featureFlags: FF_LWM_WALLET_40_Q2,
     });
     await app.mainNavigation.waitForWallet40Ready();
-  });
-
-  testConfig.tmsLinks.forEach(link => $TmsLink(link));
-  testConfig.tags.forEach(tag => $Tag(tag));
-
-  it("Portfolio zero balance state shows quick actions", async () => {
-    await app.portfolio.checkQuickActionTransferButtonVisibility();
-    await app.portfolio.checkQuickActionSwapButtonVisibility();
-    await app.portfolio.checkQuickActionBuyButtonVisibility();
-    await app.portfolio.checkNoBalanceTitleVisibility();
-  });
-
-  it(`[${ACCOUNT.currency.testLabel}] - Portfolio with a zero-balance account shows balance and analytics`, async () => {
     await app.portfolio.addAccount();
     await app.addAccount.importWithYourLedger();
     await app.modularDrawer.performSearchByTicker(TICKER);
@@ -51,6 +29,9 @@ describe("Portfolio", () => {
     await app.common.tapCloseWithConfirmationButton();
     await app.mainNavigation.tapWallet40Tab("home");
   });
+
+  testConfig.tmsLinks.forEach(link => $TmsLink(link));
+  testConfig.tags.forEach(tag => $Tag(tag));
 
   it("Portfolio with funds shows balance and quick actions", async () => {
     await app.portfolio.checkQuickActionTransferButtonVisibility();

--- a/e2e/mobile/specs/wallet40Q2/portfolioWithoutAccount.spec.ts
+++ b/e2e/mobile/specs/wallet40Q2/portfolioWithoutAccount.spec.ts
@@ -1,0 +1,29 @@
+import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
+import { setTeamOwner } from "@e2e/helpers/allure/allure-helper";
+import { FF_LWM_WALLET_40_Q2 } from "@e2e/utils/featureFlagUtils";
+
+const testConfig = {
+  tmsLinks: ["B2CQA-4350", "B2CQA-4343"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"],
+};
+
+setTeamOwner(Team.WALLET_XP);
+describe("Portfolio without account", () => {
+  beforeAll(async () => {
+    await app.init({
+      userdata: "skip-onboarding",
+      featureFlags: FF_LWM_WALLET_40_Q2,
+    });
+    await app.mainNavigation.waitForWallet40Ready();
+  });
+
+  testConfig.tmsLinks.forEach(link => $TmsLink(link));
+  testConfig.tags.forEach(tag => $Tag(tag));
+
+  it("Portfolio zero balance state shows quick actions", async () => {
+    await app.portfolio.checkQuickActionTransferButtonVisibility();
+    await app.portfolio.checkQuickActionSwapButtonVisibility();
+    await app.portfolio.checkQuickActionBuyButtonVisibility();
+    await app.portfolio.checkNoBalanceTitleVisibility();
+  });
+});

--- a/patches/detox@20.51.3.patch
+++ b/patches/detox@20.51.3.patch
@@ -1,5 +1,5 @@
 diff --git a/local-cli/testCommand/TestRunnerCommand.js b/local-cli/testCommand/TestRunnerCommand.js
-index 65e6cd70a6257138afd8270671f0ef1c555a9bbc..f321f60e621d5a487a5571e0bb807932fb7d8f78 100644
+index 65e6cd7..1fbdd2b 100644
 --- a/local-cli/testCommand/TestRunnerCommand.js
 +++ b/local-cli/testCommand/TestRunnerCommand.js
 @@ -36,6 +36,7 @@ class TestRunnerCommand {
@@ -10,7 +10,7 @@ index 65e6cd70a6257138afd8270671f0ef1c555a9bbc..f321f60e621d5a487a5571e0bb807932
  
      if (runnerConfig.forwardEnv) {
        this._envFwd = this._buildEnvOverride(cliConfig, deviceConfig);
-@@ -85,6 +86,7 @@ class TestRunnerCommand {
+@@ -85,10 +86,12 @@ class TestRunnerCommand {
          }
  
          if (--runsLeft > 0) {
@@ -18,7 +18,51 @@ index 65e6cd70a6257138afd8270671f0ef1c555a9bbc..f321f60e621d5a487a5571e0bb807932
            // @ts-ignore
            detox.session.testSessionIndex++; // it is always the primary context, so we can update it
            this._noRetryArgs.forEach(arg => delete this._argv[arg]);
-@@ -210,11 +212,16 @@ class TestRunnerCommand {
+           this._argv._ = testFilesToRetry.map(useForwardSlashes);
++          this._setRetryTestNames(failedTestFiles, testFilesToRetry);
+           this._logRelaunchError(testFilesToRetry);
+         }
+       }
+@@ -109,6 +112,38 @@ class TestRunnerCommand {
+       .value();
+   }
+ 
++  /**
++   * Narrow the upcoming retry to the individual tests that failed, on top of the spec-file
++   * narrowing above. Consumed by e2e/mobile/jest.environment.ts, which prunes everything else
++   * out of the circus tree, so the tests that already passed are neither re-run nor re-reported.
++   *
++   * Passed by environment rather than as --testNamePattern on purpose: _buildSpawnArguments
++   * escapes only spaces before cp.spawn({ shell: true }), so a regex would reach /bin/sh with
++   * its metacharacters live. Exact names in a JSON array have no such hazard, and cannot
++   * mis-select the way an imperfectly escaped pattern can.
++   *
++   * A file that failed without producing assertion results (a module-load or transform error)
++   * yields no names. Narrowing is therefore all-or-nothing: if any retried file cannot supply
++   * names, every file is retried whole, which is the pre-existing behaviour.
++   *
++   * @param {{ testFilePath: string, isPermanentFailure?: boolean, failedTestNames?: string[] }[]} failedTestFiles
++   * @param {string[]} testFilesToRetry
++   */
++  _setRetryTestNames(failedTestFiles, testFilesToRetry) {
++    const namesByFile = new Map(failedTestFiles.map(r => [r.testFilePath, r.failedTestNames || []]));
++    const canNarrow = testFilesToRetry.every(f => (namesByFile.get(f) || []).length > 0);
++    const names = testFilesToRetry.flatMap(f => namesByFile.get(f) || []);
++
++    if (canNarrow) {
++      this._envFwd.E2E_RETRY_TEST_NAMES = JSON.stringify(names);
++      log.warn(`Retrying ${names.length} failed test(s) rather than the whole spec file(s).`);
++    } else {
++      // Leave no stale value from an earlier retry, or the next attempt prunes to the wrong set.
++      delete this._envFwd.E2E_RETRY_TEST_NAMES;
++      log.warn('Some failed spec files reported no test names; retrying them in full.');
++    }
++  }
++
+   _prepareStartCommands(commands, cliConfig) {
+     if (`${cliConfig.start}` === 'false') {
+       return [];
+@@ -210,11 +245,16 @@ class TestRunnerCommand {
      /* istanbul ignore next */
      const { _: specs = [], '--': passthrough = [], $0, ...argv } = this._argv;
      const { _: $0_, ...$0argv } = parser($0);
@@ -37,39 +81,27 @@ index 65e6cd70a6257138afd8270671f0ef1c555a9bbc..f321f60e621d5a487a5571e0bb807932
        ...unparse({ _: [...passthrough, ...specs] }),
      ].map(String);
    }
-diff --git a/src/utils/ExclusiveLockfile.js b/src/utils/ExclusiveLockfile.js
-index 1234567890abcdef1234567890abcdef12345678..abcdef1234567890abcdef1234567890abcdef12 100644
---- a/src/utils/ExclusiveLockfile.js
-+++ b/src/utils/ExclusiveLockfile.js
-@@ -6,6 +6,14 @@ const DetoxRuntimeError = require('../errors/DetoxRuntimeError');
+diff --git a/runners/jest/reporters/DetoxIPCReporter.js b/runners/jest/reporters/DetoxIPCReporter.js
+index 9e4c6ea..623bd4b 100644
+--- a/runners/jest/reporters/DetoxIPCReporter.js
++++ b/runners/jest/reporters/DetoxIPCReporter.js
+@@ -16,6 +16,10 @@ class DetoxIPCReporter {
+       testFilePath: r.testFilePath,
+       testExecError: r.testExecError,
+       isPermanentFailure: lostTests > 0 || this._isPermanentFailure(r),
++      // Exact full names of the tests that failed, so a retry can re-run just those rather than
++      // the whole spec file. Empty when the suite died before running any test (testExecError),
++      // which the retry reads as "cannot narrow" and falls back to re-running the file.
++      failedTestNames: r.testResults.filter(t => t.status === 'failed').map(t => t.fullName),
+     })));
+   }
  
- const retry = require('./retry');
- 
-+// Increase stale threshold for CI environments where disk I/O can be slow
-+// Default is 10000ms which causes ECOMPROMISED errors under heavy load
-+const LOCKFILE_STALE_MS = parseInt(process.env.DETOX_LOCKFILE_STALE_MS, 10) || 60000;
-+const LOCKFILE_OPTIONS = {
-+  stale: LOCKFILE_STALE_MS,
-+  update: Math.floor(LOCKFILE_STALE_MS / 2),
-+};
-+
- const DEFAULT_OPTIONS = {
-   retry: { retries: 10000, interval: 5 },
-   read: { encoding: 'utf8' },
-@@ -100,7 +108,7 @@ class ExclusiveLockfile {
-     this._ensureFileExists();
- 
-     await retry(this._options.retry, () => {
--      const operationResult = plockfile.lockSync(this._lockFilePath);
-+      const operationResult = plockfile.lockSync(this._lockFilePath, LOCKFILE_OPTIONS);
- 
-       this._isLocked = true;
-       this._invalidate();
 diff --git a/src/devices/common/drivers/android/exec/ADB.js b/src/devices/common/drivers/android/exec/ADB.js
-index ab269f5ba3cb6ec033594a5e05284b95f01a39a6..f38390723a0bb70af36ef4017353c3f9257afe53 100644
+index bde116c..06ab2f0 100644
 --- a/src/devices/common/drivers/android/exec/ADB.js
 +++ b/src/devices/common/drivers/android/exec/ADB.js
-@@ -9,12 +9,14 @@ const DeviceHandle = require('../tools/DeviceHandle');
+@@ -9,13 +9,15 @@ const { escape } = require('../../../../../utils/pipeCommands');
+ const DeviceHandle = require('../tools/DeviceHandle');
  const EmulatorHandle = require('../tools/EmulatorHandle');
  
 +const { DETOX_INSTALL_TIMEOUT = "60000" } = process.env;
@@ -85,13 +117,7 @@ index ab269f5ba3cb6ec033594a5e05284b95f01a39a6..f38390723a0bb70af36ef4017353c3f9
    retries: 3,
  };
  
-@@ -376,15 +376,25 @@ class ADB {
-   async emu(deviceId, cmd, options) {
-     return (await this.adbCmd(deviceId, `emu "${escape.inQuotedString(cmd)}"`, options)).stdout.trim();
-   }
- 
-   async reverse(deviceId, port) {
-     return this.adbCmd(deviceId, `reverse tcp:${port} tcp:${port}`);
+@@ -380,7 +382,17 @@ class ADB {
    }
  
    async reverseRemove(deviceId, port) {
@@ -110,5 +136,31 @@ index ab269f5ba3cb6ec033594a5e05284b95f01a39a6..f38390723a0bb70af36ef4017353c3f9
    }
  
    async emuKill(deviceId) {
-     return this.adbCmd(deviceId, `emu kill`);
-   }
+diff --git a/src/utils/ExclusiveLockfile.js b/src/utils/ExclusiveLockfile.js
+index da29ae9..cb210d6 100644
+--- a/src/utils/ExclusiveLockfile.js
++++ b/src/utils/ExclusiveLockfile.js
+@@ -6,6 +6,14 @@ const DetoxRuntimeError = require('../errors/DetoxRuntimeError');
+ 
+ const retry = require('./retry');
+ 
++// Raise the lockfile stale threshold in EVERY environment, not just CI: Detox's 10_000ms default
++// causes ECOMPROMISED under heavy I/O. Override with DETOX_LOCKFILE_STALE_MS; default 60_000ms.
++const LOCKFILE_STALE_MS = parseInt(process.env.DETOX_LOCKFILE_STALE_MS, 10) || 60000;
++const LOCKFILE_OPTIONS = {
++  stale: LOCKFILE_STALE_MS,
++  update: Math.floor(LOCKFILE_STALE_MS / 2),
++};
++
+ const DEFAULT_OPTIONS = {
+   retry: { retries: 10000, interval: 5 },
+   read: { encoding: 'utf8' },
+@@ -107,7 +115,7 @@ class ExclusiveLockfile {
+     this._ensureFileExists();
+ 
+     await retry(this._options.retry, () => {
+-      const operationResult = plockfile.lockSync(this._lockFilePath);
++      const operationResult = plockfile.lockSync(this._lockFilePath, LOCKFILE_OPTIONS);
+ 
+       this._isLocked = true;
+       this._invalidate();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -584,7 +584,7 @@ patchedDependencies:
     hash: c0c5e6419e53a25ed902cac4ce3608f467d0332b34c90b669fed2089e2bf97ba
     path: patches/detox-allure2-adapter@1.0.0-alpha.42.patch
   detox@20.51.3:
-    hash: 6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61
+    hash: 1d9c14005235485782e6bfe70e7bcfb3cd2995c141f10bdc8a18701ebf1de0a9
     path: patches/detox@20.51.3.patch
   react-native-bundle-visualizer@3.1.3:
     hash: 860509fa484fba50bc575fd4729f51687bfb5342e9fca66d2b7c12b0cf81e11d
@@ -2555,7 +2555,7 @@ importers:
         version: 0.4.4
       detox:
         specifier: 'catalog:'
-        version: 20.51.3(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(@typescript/typescript6@6.0.2)))
+        version: 20.51.3(patch_hash=1d9c14005235485782e6bfe70e7bcfb3cd2995c141f10bdc8a18701ebf1de0a9)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(@typescript/typescript6@6.0.2)))
       eslint:
         specifier: 8.57.0
         version: 8.57.0
@@ -5350,10 +5350,10 @@ importers:
         version: 2.8.5
       detox:
         specifier: 'catalog:'
-        version: 20.51.3(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(@jest/types@30.5.0)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(@typescript/typescript6@6.0.2)))
+        version: 20.51.3(patch_hash=1d9c14005235485782e6bfe70e7bcfb3cd2995c141f10bdc8a18701ebf1de0a9)(@jest/types@30.5.0)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(@typescript/typescript6@6.0.2)))
       detox-allure2-adapter:
         specifier: 1.0.0-alpha.42
-        version: 1.0.0-alpha.42(patch_hash=c0c5e6419e53a25ed902cac4ce3608f467d0332b34c90b669fed2089e2bf97ba)(detox@20.51.3(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(@jest/types@30.5.0)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(@typescript/typescript6@6.0.2))))(jest-allure2-reporter@2.2.8(@jest/reporters@30.5.0)(@jest/types@30.5.0)(jest-docblock@30.5.0)(jest-environment-node@30.5.0)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(@typescript/typescript6@6.0.2))))
+        version: 1.0.0-alpha.42(patch_hash=c0c5e6419e53a25ed902cac4ce3608f467d0332b34c90b669fed2089e2bf97ba)(detox@20.51.3(patch_hash=1d9c14005235485782e6bfe70e7bcfb3cd2995c141f10bdc8a18701ebf1de0a9)(@jest/types@30.5.0)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(@typescript/typescript6@6.0.2))))(jest-allure2-reporter@2.2.8(@jest/reporters@30.5.0)(@jest/types@30.5.0)(jest-docblock@30.5.0)(jest-environment-node@30.5.0)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(@typescript/typescript6@6.0.2))))
       expect:
         specifier: 30.5.0
         version: 30.5.0
@@ -58393,16 +58393,16 @@ snapshots:
     optionalDependencies:
       expect: 30.5.0
 
-  '@wix-pilot/detox@1.0.13(@wix-pilot/core@3.4.2(expect@30.5.0))(detox@20.51.3(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(@jest/types@30.5.0)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(@typescript/typescript6@6.0.2))))(expect@30.5.0)':
+  '@wix-pilot/detox@1.0.13(@wix-pilot/core@3.4.2(expect@30.5.0))(detox@20.51.3(patch_hash=1d9c14005235485782e6bfe70e7bcfb3cd2995c141f10bdc8a18701ebf1de0a9)(@jest/types@30.5.0)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(@typescript/typescript6@6.0.2))))(expect@30.5.0)':
     dependencies:
       '@wix-pilot/core': 3.4.2(expect@30.5.0)
-      detox: 20.51.3(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(@jest/types@30.5.0)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(@typescript/typescript6@6.0.2)))
+      detox: 20.51.3(patch_hash=1d9c14005235485782e6bfe70e7bcfb3cd2995c141f10bdc8a18701ebf1de0a9)(@jest/types@30.5.0)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(@typescript/typescript6@6.0.2)))
       expect: 30.5.0
 
-  '@wix-pilot/detox@1.0.13(@wix-pilot/core@3.4.2(expect@30.5.0))(detox@20.51.3(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(@typescript/typescript6@6.0.2))))(expect@30.5.0)':
+  '@wix-pilot/detox@1.0.13(@wix-pilot/core@3.4.2(expect@30.5.0))(detox@20.51.3(patch_hash=1d9c14005235485782e6bfe70e7bcfb3cd2995c141f10bdc8a18701ebf1de0a9)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(@typescript/typescript6@6.0.2))))(expect@30.5.0)':
     dependencies:
       '@wix-pilot/core': 3.4.2(expect@30.5.0)
-      detox: 20.51.3(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(@typescript/typescript6@6.0.2)))
+      detox: 20.51.3(patch_hash=1d9c14005235485782e6bfe70e7bcfb3cd2995c141f10bdc8a18701ebf1de0a9)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(@typescript/typescript6@6.0.2)))
       expect: 30.5.0
 
   '@wry/caches@1.0.1':
@@ -61677,21 +61677,21 @@ snapshots:
 
   detect-node@2.1.0: {}
 
-  detox-allure2-adapter@1.0.0-alpha.42(patch_hash=c0c5e6419e53a25ed902cac4ce3608f467d0332b34c90b669fed2089e2bf97ba)(detox@20.51.3(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(@jest/types@30.5.0)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(@typescript/typescript6@6.0.2))))(jest-allure2-reporter@2.2.8(@jest/reporters@30.5.0)(@jest/types@30.5.0)(jest-docblock@30.5.0)(jest-environment-node@30.5.0)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(@typescript/typescript6@6.0.2)))):
+  detox-allure2-adapter@1.0.0-alpha.42(patch_hash=c0c5e6419e53a25ed902cac4ce3608f467d0332b34c90b669fed2089e2bf97ba)(detox@20.51.3(patch_hash=1d9c14005235485782e6bfe70e7bcfb3cd2995c141f10bdc8a18701ebf1de0a9)(@jest/types@30.5.0)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(@typescript/typescript6@6.0.2))))(jest-allure2-reporter@2.2.8(@jest/reporters@30.5.0)(@jest/types@30.5.0)(jest-docblock@30.5.0)(jest-environment-node@30.5.0)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(@typescript/typescript6@6.0.2)))):
     dependencies:
       archiver: 6.0.2
-      detox: 20.51.3(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(@jest/types@30.5.0)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(@typescript/typescript6@6.0.2)))
+      detox: 20.51.3(patch_hash=1d9c14005235485782e6bfe70e7bcfb3cd2995c141f10bdc8a18701ebf1de0a9)(@jest/types@30.5.0)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(@typescript/typescript6@6.0.2)))
       jest-allure2-reporter: 2.2.8(@jest/reporters@30.5.0)(@jest/types@30.5.0)(jest-docblock@30.5.0)(jest-environment-node@30.5.0)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(@typescript/typescript6@6.0.2)))
       logkitten: 1.3.3
       screenkitten: 1.0.0
       tslib: 2.6.2
       videokitten: 1.0.1
 
-  detox@20.51.3(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(@jest/types@30.5.0)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(@typescript/typescript6@6.0.2))):
+  detox@20.51.3(patch_hash=1d9c14005235485782e6bfe70e7bcfb3cd2995c141f10bdc8a18701ebf1de0a9)(@jest/types@30.5.0)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(@typescript/typescript6@6.0.2))):
     dependencies:
       '@jest/reporters': 30.5.0
       '@wix-pilot/core': 3.4.2(expect@30.5.0)
-      '@wix-pilot/detox': 1.0.13(@wix-pilot/core@3.4.2(expect@30.5.0))(detox@20.51.3(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(@jest/types@30.5.0)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(@typescript/typescript6@6.0.2))))(expect@30.5.0)
+      '@wix-pilot/detox': 1.0.13(@wix-pilot/core@3.4.2(expect@30.5.0))(detox@20.51.3(patch_hash=1d9c14005235485782e6bfe70e7bcfb3cd2995c141f10bdc8a18701ebf1de0a9)(@jest/types@30.5.0)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@24.12.0)(@typescript/typescript6@6.0.2))))(expect@30.5.0)
       ajv: 8.17.1
       bunyan: 1.8.15
       bunyan-debug-stream: 3.1.0(bunyan@1.8.15)
@@ -61743,11 +61743,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  detox@20.51.3(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(@typescript/typescript6@6.0.2))):
+  detox@20.51.3(patch_hash=1d9c14005235485782e6bfe70e7bcfb3cd2995c141f10bdc8a18701ebf1de0a9)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(@typescript/typescript6@6.0.2))):
     dependencies:
       '@jest/reporters': 30.5.0
       '@wix-pilot/core': 3.4.2(expect@30.5.0)
-      '@wix-pilot/detox': 1.0.13(@wix-pilot/core@3.4.2(expect@30.5.0))(detox@20.51.3(patch_hash=6b1689c8f2f12516e3e1130fd1eef40799da1f07d3c7d30c754548d8a34d4c61)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(@typescript/typescript6@6.0.2))))(expect@30.5.0)
+      '@wix-pilot/detox': 1.0.13(@wix-pilot/core@3.4.2(expect@30.5.0))(detox@20.51.3(patch_hash=1d9c14005235485782e6bfe70e7bcfb3cd2995c141f10bdc8a18701ebf1de0a9)(jest@30.5.0(@types/node@24.12.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(@types/node@24.12.0)(@typescript/typescript6@6.0.2))))(expect@30.5.0)
       ajv: 8.17.1
       bunyan: 1.8.15
       bunyan-debug-stream: 3.1.0(bunyan@1.8.15)


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR improves mobile Detox retry behavior by narrowing retries to only the individual failed Jest tests (instead of re-running whole spec files), and adds a lint gate to ensure test titles remain deterministic so name-based retries are reliable.

Changes:

- Patch Detox to collect failed test full names and forward them to retries via E2E_RETRY_TEST_NAMES.
- Update the mobile Jest environment + Allure reporter config to skip non-retried tests and avoid retry runs overwriting prior Allure verdicts.
- Add a deterministic test-title linter (lint:test-names) and update affected specs to remove non-deterministic titles.

### 🔗 Context

- Mobile execution with [retry](https://github.com/LedgerHQ/ledger-live/actions/runs/33428522858/job/99609924815)
Around 7 minutes execution time retrying passed tests avoided

<img width="1122" height="124" alt="Screenshot 2026-09-01 at 08 01 42" src="https://github.com/user-attachments/assets/2bd5022c-49f6-44d2-b538-6fcbe1dbbb4e" />
<img width="686" height="401" alt="Screenshot 2026-09-01 at 08 00 32" src="https://github.com/user-attachments/assets/681e4029-f3e8-4d16-8493-ef5e99643595" />

<img width="686" height="272" alt="Screenshot 2026-09-01 at 07 56 16" src="https://github.com/user-attachments/assets/c4c4d78e-b579-4340-89d2-5efef123e0eb" />
<img width="686" height="523" alt="Screenshot 2026-09-01 at 07 56 51" src="https://github.com/user-attachments/assets/58b537d7-d75a-4364-9777-2f39091c4829" />





