### PR TITLE
fix(contacts): correct dark mode QR contrast (LIVE-36639)

### DIFF
--- a/.changeset/standard-qr-contrast.md
+++ b/.changeset/standard-qr-contrast.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": patch
+---
+
+Use a white QR card with black modules in Contact details for reliable dark mode scanning.

--- a/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/ContactAddressDetailQrCode.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/ContactAddressDetailQrCode.native.tsx
@@ -25,7 +25,7 @@ export function ContactAddressDetailQrCode({
         justifyContent: "center",
         padding: t.spacings.s24,
         borderRadius: t.sizes.s36,
-        backgroundColor: t.colors.bg.base,
+        backgroundColor: t.colors.bg.white,
         boxShadow: t.shadows.lg,
       },
     }),
@@ -37,7 +37,7 @@ export function ContactAddressDetailQrCode({
       <QrCode
         value={address}
         size={QR_CODE_SIZE}
-        foregroundColor={theme.colors.bg.interactive}
+        foregroundColor={theme.colors.bg.black}
         centerContent={
           <CryptoIcon
             ledgerId={iconProps.ledgerId}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** No dedicated component test is included at the request of the author; existing shared QR renderer tests remain available.
- [x] **Impact of the changes:**
      Scan an address QR in the Contacts detail sheet with dark mode enabled on iOS and Android, and confirm it decodes to the displayed address.

### 📝 Description

Contacts rendered an inverted white QR on a dark card in dark mode, which some scanners do not reliably detect.

The Contacts QR card now matches Figma node `754:171613`: a white 248 pt card containing a black 200 pt QR matrix. The shared renderer and other QR consumers remain unchanged.

### Screenshots

<img width="350" height="750" alt="Simulator Screenshot - build2 - 2026-08-31 at 15 27 31" src="https://github.com/user-attachments/assets/50cefe4e-0638-44b0-87c0-671e4a78a222" />


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-36639

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)