### PR TITLE
test(e2e): stabilize ADA select validator delegation test

### DIFF
--- a/e2e/desktop/tests/specs/delegate.spec.ts
+++ b/e2e/desktop/tests/specs/delegate.spec.ts
@@ -399,6 +399,13 @@ for (const validator of validators) {
           await app.delegate.verifyContinueDisabled();
           await app.delegate.selectProviderByName(validator.delegate.provider);
           await app.delegate.verifyProviderTC(validator.delegate.provider);
+        } else if (validator.delegate.account.currency.name == Currency.ADA.name) {
+          // Cardano auto-selects the first validator asynchronously and only enables Continue
+          // once the bridge finishes recomputing the transaction status. The provider row renders
+          // before that recompute settles, so asserting Continue right after the name is flaky.
+          // Explicitly (re)select the provider to force a clean, settled transaction update.
+          await app.delegate.verifyFirstProviderName(validator.delegate.provider);
+          await app.delegate.selectProviderByName(validator.delegate.provider);
         } else {
           await app.delegate.verifyFirstProviderName(validator.delegate.provider);
           await app.delegate.verifyContinueEnabled();

--- a/e2e/tooling/filter/README.md
+++ b/e2e/tooling/filter/README.md
@@ -11,8 +11,22 @@ the test runtime (specs, page objects, fixtures) — they run inside GitHub Acti
 | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `escaping.mjs`       | Single source of truth for the filter grammar: splits patterns on separators (`\|` / `,`) that are not backslash-escaped and is odd-backslash aware, defines the Playwright leaf anchor `(?! [^@])`, and unescapes regex-literal characters (`unescapeLiteral`) for display.                                                                               |
 | `resolve.mjs`        | Resolves the workflow `test_filter` input into a Playwright/Detox grep string (expands `@generic-coin-framework`, applies `@smoke`, warns on zero matches). The zero-match check mirrors the target runner (`--runner detox\|playwright`): detox reuses `selectSpecs.filterTestFiles` (path + `@`-tag), playwright matches a regex over spec path/content. |
+| `generatedTags.mjs`  | Vocabulary of tags the specs attach at **runtime** (`buildTags`): currency ids + families (from `domain/entity/currency-crypto/src/currencies/*.ts`) and the device tags (from `e2e/desktop/tests/utils/tagsUtils.ts`). Lets the playwright zero-match check downgrade "matched 0 specs" to a notice for a valid-but-unobservable tag, while a real typo still warns. |
 | `selectSpecs.mjs`    | Selects which Detox spec files a mobile E2E run executes for a filter — matches a spec by its path or a declared `@` tag (never raw file text). Consumed by `e2e/mobile/scripts/shard-tests.mjs`.                                                                                                                                                          |
 | `format-summary.mjs` | Renders a resolved filter as a readable Markdown bullet list for the "Workflow Context" job summary.                                                                                                                                                                                                                                                       |
+
+## Zero-match check
+
+`resolve.mjs` warns when a filter selects nothing, but the two runners are not equally
+knowable ahead of the run:
+
+- **detox** — the check *is* the runner's own selection logic (`selectSpecs.filterTestFiles`),
+  so a 0-match is a real empty run and always warns.
+- **playwright** — the check only approximates `--grep` with a regex over spec path/content, so
+  it cannot see tags that `buildTags({ currencyId })` derives at collection time (`@cardano`,
+  `@family-cardano`, the device tags). For those, `resolve.mjs` emits a `::notice` ("not
+  statically verifiable") instead of a misleading `::warning`. A tag that is *not* in the
+  vocabulary (a typo such as `@cardanoo`) still warns.
 
 ## Usage
 

--- a/e2e/tooling/filter/generatedTags.mjs
+++ b/e2e/tooling/filter/generatedTags.mjs
@@ -1,0 +1,100 @@
+// Vocabulary of e2e tags that specs attach at *runtime* rather than spelling out literally.
+//
+// `buildTags({ currencyId })` (e2e/desktop/tests/utils/tagsUtils.ts) derives `@<currencyId>`,
+// `@family-<family>` and the device tags at collection time, so those strings never appear in
+// the spec source. A purely textual "does this filter match a spec?" check therefore cannot
+// observe them and would report a false "matched 0 specs" for a perfectly valid filter.
+//
+// This module lets the zero-match check tell those two cases apart:
+//   - a known runtime-generated tag -> unverifiable statically, not an error
+//   - anything else                 -> most likely a typo, still worth warning about
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { stripLeafAnchor, unescapeLiteral } from "./escaping.mjs";
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(currentDir, "../../..");
+
+// One file per crypto currency, each declaring `id:` and `family:` — the same values
+// `getFamilyByCurrencyId` resolves at runtime, so this is the authoritative tag vocabulary.
+const CRYPTO_CURRENCIES_DIR = path.join(repoRoot, "domain/entity/currency-crypto/src/currencies");
+const DEVICE_TAGS_FILE = path.join(repoRoot, "e2e/desktop/tests/utils/tagsUtils.ts");
+
+const FAMILY_TAG_PREFIX = "family-";
+const ID_PATTERN = /^\s*id:\s*"([^"]+)"/m;
+const FAMILY_PATTERN = /^\s*family:\s*"([^"]+)"/m;
+const DEVICE_TAGS_PATTERN = /DEVICE_TAGS\s*=\s*\[([^\]]*)\]/;
+
+function readCurrencyVocabulary() {
+  const currencyIds = new Set();
+  const families = new Set();
+
+  let entries;
+  try {
+    entries = fs.readdirSync(CRYPTO_CURRENCIES_DIR);
+  } catch {
+    return { currencyIds, families };
+  }
+
+  for (const entry of entries) {
+    if (!entry.endsWith(".ts") || entry.endsWith(".test.ts")) continue;
+
+    let content;
+    try {
+      content = fs.readFileSync(path.join(CRYPTO_CURRENCIES_DIR, entry), "utf8");
+    } catch {
+      continue;
+    }
+
+    const id = content.match(ID_PATTERN)?.[1];
+    const family = content.match(FAMILY_PATTERN)?.[1];
+    if (id) currencyIds.add(id.toLowerCase());
+    if (family) families.add(family.toLowerCase());
+  }
+
+  return { currencyIds, families };
+}
+
+function readDeviceTags() {
+  const deviceTags = new Set();
+  try {
+    const content = fs.readFileSync(DEVICE_TAGS_FILE, "utf8");
+    const block = content.match(DEVICE_TAGS_PATTERN)?.[1] ?? "";
+    for (const literal of block.match(/["'`]@[\w-]+["'`]/g) ?? []) {
+      deviceTags.add(literal.slice(1, -1).toLowerCase());
+    }
+  } catch {
+    // A missing/renamed tagsUtils only shrinks the vocabulary; the caller still warns.
+  }
+  return deviceTags;
+}
+
+let cachedVocabulary;
+
+export function readTagVocabulary() {
+  if (!cachedVocabulary) {
+    const { currencyIds, families } = readCurrencyVocabulary();
+    cachedVocabulary = { currencyIds, families, deviceTags: readDeviceTags() };
+  }
+  return cachedVocabulary;
+}
+
+// True when `part` is a tag the specs can only produce at runtime, so its absence from the
+// spec text proves nothing about whether the run will select tests.
+export function isRuntimeGeneratedTag(part, vocabulary = readTagVocabulary()) {
+  const token = unescapeLiteral(stripLeafAnchor(String(part)))
+    .trim()
+    .toLowerCase();
+  if (!token.startsWith("@")) return false;
+
+  const { currencyIds, families, deviceTags } = vocabulary;
+  if (deviceTags.has(token)) return true;
+
+  const name = token.slice(1);
+  if (name.startsWith(FAMILY_TAG_PREFIX)) {
+    return families.has(name.slice(FAMILY_TAG_PREFIX.length));
+  }
+  return currencyIds.has(name);
+}

--- a/e2e/tooling/filter/resolve.mjs
+++ b/e2e/tooling/filter/resolve.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { joinFilter, splitFilter } from "./escaping.mjs";
+import { isRuntimeGeneratedTag } from "./generatedTags.mjs";
 import { findTestFiles as findSpecFiles, filterTestFiles } from "./selectSpecs.mjs";
 
 const currentFile = fileURLToPath(import.meta.url);
@@ -98,10 +99,23 @@ function warnZeroMatches(checkDir, baseFilter, expandedTags, runner) {
     ? pattern => filterTestFiles(files, pattern).length > 0
     : pattern => hasMatch(files, pattern);
 
+  // Only the playwright check is an approximation (a regex over spec path/content), so it alone
+  // can miss tags that buildTags() attaches at collection time. The detox check *is* how the
+  // mobile runner selects specs, so a 0-match there is a real empty run and must stay a warning.
+  const isUnverifiableTag = tag => !isDetox && isRuntimeGeneratedTag(tag);
+
   for (const tag of expandedTags) {
-    if (!selectsSomething(tag)) {
-      console.warn(`::warning title=Missing E2E tag::${tag} has no matching specs in ${checkDir}`);
+    if (selectsSomething(tag)) continue;
+    // Family tags are attached by buildTags() at collection time, so a spec that carries one
+    // never spells it out. Only flag a tag that isn't a real family either.
+    if (isUnverifiableTag(tag)) {
+      // stderr, like every other message here: stdout carries the resolved filter to the workflow.
+      console.warn(
+        `::notice title=E2E tag not statically verifiable::${tag} is generated at runtime (buildTags); its specs can't be detected before the run`,
+      );
+      continue;
     }
+    console.warn(`::warning title=Missing E2E tag::${tag} has no matching specs in ${checkDir}`);
   }
 
   // filterTestFiles already splits on whitespace/","/"|"; the playwright regex needs "|" alternation.
@@ -109,6 +123,15 @@ function warnZeroMatches(checkDir, baseFilter, expandedTags, runner) {
     ? baseFilter
     : baseFilter.split(/\s+/).filter(Boolean).join("|");
   if (baseFilter && !selectsSomething(baseFilterPattern)) {
+    // The filter is an OR: one runtime-generated tag is enough for the run to select specs,
+    // so "0 matches" here would be an artefact of the static check, not a real empty run.
+    const runtimeTags = splitFilter(baseFilter).filter(isUnverifiableTag);
+    if (runtimeTags.length > 0) {
+      console.warn(
+        `::notice title=E2E filter not statically verifiable::${runtimeTags.join(", ")} ${runtimeTags.length === 1 ? "is" : "are"} generated at runtime (buildTags); matching specs can't be detected before the run`,
+      );
+      return;
+    }
     console.warn(
       `::warning title=E2E filter has no matches::${baseFilter} matched 0 specs in ${checkDir}`,
     );


### PR DESCRIPTION
### 📝 Description

**Previous behaviour** — `[ADA] - Select validator` failed intermittently on CI with:

```
expect(locator).toBeEnabled() failed
Locator: locator('#delegate-continue-button')
Received: disabled
Timeout: 41000ms
```

All network calls returned 200, there were no JS exceptions, and account funds were fine — this is a race, not a product regression.

**Root cause** — `StepDelegation.tsx` gates the Continue button on
`canNext = !bridgePending && Object.keys(errors).length === 0 && transaction`.
`ValidatorField.tsx` auto-selects the first Cardano pool asynchronously (`fetchPoolDetails(...).then(...)`) and renders the provider row as soon as `userAndLedgerPools` is set — i.e. _before_ the bridge finishes recomputing the transaction status. The test asserted Continue was enabled immediately after seeing the provider name, so it could win the race against the recompute. `bridgePending` is not exposed in the DOM (no `aria-busy`, testid or spinner), so the button itself is the only observable signal.

**Fix** — for Cardano only, explicitly (re)select the provider after verifying its name. That forces a clean `prepareTransaction` and leaves the bridge in a settled state before Continue is asserted. Other families keep the existing assertion path.

**Bonus fix** — while validating on CI, the run was annotated with a misleading
`@cardano matched 0 specs in e2e/desktop/tests`.
The zero-match pre-check in `e2e/tooling/filter/resolve.mjs` greps spec source, but `buildTags({ currencyId })` generates `@cardano` / `@family-<family>` at Playwright collection time, so the literal never appears in the file. Added `e2e/tooling/filter/generatedTags.mjs`, which reads the real currency / family / device tag vocabulary, and downgraded these cases to a `::notice`.

Scoped deliberately to Playwright: for detox the check _is_ `selectSpecs.filterTestFiles` — the runner's real selection logic — so a 0-match there is a genuinely empty run and still warns. Notices go to **stderr**, since the workflow captures this script's stdout into `RESOLVED_FILTER`.

**Validation** — `[Desktop] - E2E Only` with `test_filter=@cardano`:

| Run | Result | `[ADA] - Select validator` |
| --- | --- | --- |
| Before | ❌ | timeout at 41s |
| [33192502404](https://github.com/LedgerHQ/ledger-live/actions/runs/33192502404) | ✅ 6 passed | ✓ 22.9s |
| [33379424248](https://github.com/LedgerHQ/ledger-live/actions/runs/33379424248) | ✅ 6 passed | ✓ 14.2s (annotation now a notice) |

**Follow-up (not in this PR)** — product-side hardening worth considering: expose `bridgePending` via `aria-busy` on the Continue button in `StepDelegation.tsx`, and fix the `ValidatorField.tsx` auto-select race so the row does not render ahead of a settled status.

### 🔗 Context

- **JIRA / GitHub issue**: n/a — CI flakiness triage
- **ADR** (if any): n/a

