### PR TITLE
test(e2e): give the Buy/Sell webview time to boot before reloading

### DIFF
--- a/e2e/desktop/tests/page/buyAndSell.page.ts
+++ b/e2e/desktop/tests/page/buyAndSell.page.ts
@@ -110,18 +110,14 @@ export class BuyAndSellPage extends WebViewAppPage {
    * Workaround: PTX Buy/Sell web app can remain stuck loading; reload the webview and retry.
    * Mirrors the recovery used in borrow.page.ts. Used to guard every entry point that lands
    * on the Buy/Sell webview, not just the crypto selector step.
-   *
-   * The web app gates its whole tree (including `navigation-tabs`) behind two spinners, and
-   * every HTTP call it makes is serialized behind a Firebase Remote Config fetch plus a
-   * wallet-api round trip in its axios request interceptor — none of which have a timeout.
-   * On a loaded CI runner that boot has been observed to take >50s, so a short deadline here
-   * fails while the app is still making progress, and reloading throws that progress away and
-   * restarts the same slow boot. Wait generously first, and only reload as a genuine last
-   * resort.
    */
   @step("Wait for the Buy/Sell web app to finish loading")
   private async waitForWebviewReady(testId: string) {
     const attemptTimeouts = [90_000, 60_000];
+    // Kept short and independent of the attempt budget: the reload is best-effort (its failure
+    // is ignored), so letting it inherit a 90s deadline would only make the worst case
+    // unpredictable without improving recovery.
+    const reloadTimeout = 15_000;
 
     for (const [attempt, readyTimeout] of attemptTimeouts.entries()) {
       // Re-fetch the webview on every attempt: it can be torn down and recreated
@@ -147,7 +143,7 @@ export class BuyAndSellPage extends WebViewAppPage {
         // aborting the whole retry loop.
         try {
           const freshWebview = await this.getWebView();
-          await freshWebview.reload({ timeout: readyTimeout, waitUntil: "domcontentloaded" });
+          await freshWebview.reload({ timeout: reloadTimeout, waitUntil: "domcontentloaded" });
         } catch {
           // Ignore: target likely closed mid-wait; next attempt re-resolves the webview.
         }

--- a/e2e/desktop/tests/page/buyAndSell.page.ts
+++ b/e2e/desktop/tests/page/buyAndSell.page.ts
@@ -110,13 +110,20 @@ export class BuyAndSellPage extends WebViewAppPage {
    * Workaround: PTX Buy/Sell web app can remain stuck loading; reload the webview and retry.
    * Mirrors the recovery used in borrow.page.ts. Used to guard every entry point that lands
    * on the Buy/Sell webview, not just the crypto selector step.
+   *
+   * The web app gates its whole tree (including `navigation-tabs`) behind two spinners, and
+   * every HTTP call it makes is serialized behind a Firebase Remote Config fetch plus a
+   * wallet-api round trip in its axios request interceptor — none of which have a timeout.
+   * On a loaded CI runner that boot has been observed to take >50s, so a short deadline here
+   * fails while the app is still making progress, and reloading throws that progress away and
+   * restarts the same slow boot. Wait generously first, and only reload as a genuine last
+   * resort.
    */
   @step("Wait for the Buy/Sell web app to finish loading")
   private async waitForWebviewReady(testId: string) {
-    const readyTimeout = 30_000;
-    const maxReloads = 2;
+    const attemptTimeouts = [90_000, 60_000];
 
-    for (let attempt = 0; ; attempt++) {
+    for (const [attempt, readyTimeout] of attemptTimeouts.entries()) {
       // Re-fetch the webview on every attempt: it can be torn down and recreated
       // while we wait, and reloading a stale handle throws
       // "Target page, context or browser has been closed".
@@ -126,10 +133,10 @@ export class BuyAndSellPage extends WebViewAppPage {
         await expect(selector).toBeVisible({ timeout: readyTimeout });
         return;
       } catch (error) {
-        if (attempt >= maxReloads) {
+        if (attempt === attemptTimeouts.length - 1) {
           throw new Error(
-            `Buy/Sell web app did not render "${testId}" after ${maxReloads + 1} attempts — ` +
-              `webview stuck loading.`,
+            `Buy/Sell web app did not render "${testId}" after ${attemptTimeouts.length} attempts ` +
+              `(${attemptTimeouts.map(t => `${t / 1000}s`).join(" + ")}) — webview stuck loading.`,
             { cause: error },
           );
         }

--- a/e2e/desktop/tests/page/buyAndSell.page.ts
+++ b/e2e/desktop/tests/page/buyAndSell.page.ts
@@ -20,6 +20,8 @@ interface ProviderConfig {
   parseAddress?: (value: string) => string;
 }
 
+const toSeconds = (ms: number) => `${ms / 1000}s`;
+
 export class BuyAndSellPage extends WebViewAppPage {
   protected readonly webviewIdentifier = "buy";
 
@@ -130,10 +132,13 @@ export class BuyAndSellPage extends WebViewAppPage {
         return;
       } catch (error) {
         if (attempt === attemptTimeouts.length - 1) {
-          const budget = attemptTimeouts.map(t => `${t / 1000}s`).join(" + ");
+          const waits = attemptTimeouts.map(toSeconds).join(" + ");
+          const reloadBudget = reloadTimeout * (attemptTimeouts.length - 1);
+          const worstCase = attemptTimeouts.reduce((total, t) => total + t, reloadBudget);
           throw new Error(
             `Buy/Sell web app did not render "${testId}" after ${attemptTimeouts.length} attempts ` +
-              `(${budget}) — webview stuck loading.`,
+              `(${waits} waiting + up to ${toSeconds(reloadBudget)} reloading, ` +
+              `${toSeconds(worstCase)} worst case) — webview stuck loading.`,
             { cause: error },
           );
         }

--- a/e2e/desktop/tests/page/buyAndSell.page.ts
+++ b/e2e/desktop/tests/page/buyAndSell.page.ts
@@ -134,9 +134,10 @@ export class BuyAndSellPage extends WebViewAppPage {
         return;
       } catch (error) {
         if (attempt === attemptTimeouts.length - 1) {
+          const budget = attemptTimeouts.map(t => `${t / 1000}s`).join(" + ");
           throw new Error(
             `Buy/Sell web app did not render "${testId}" after ${attemptTimeouts.length} attempts ` +
-              `(${attemptTimeouts.map(t => `${t / 1000}s`).join(" + ")}) — webview stuck loading.`,
+              `(${budget}) — webview stuck loading.`,
             { cause: error },
           );
         }


### PR DESCRIPTION
### 📝 Description

**Previous behaviour** — `[ETH] - Buy entry point from asset page` failed on CI with:

```
Buy/Sell web app did not render "navigation-tabs" after 3 attempts — webview stuck loading.
[cause]: expect(locator).toBeVisible() failed
Locator: getByTestId('navigation-tabs')
Timeout: 30000ms
Error: element(s) not found
```

The `BTC` and `USDT (Ethereum)` variants of the same test passed in the same run, so this is not currency-specific — it is a boot-time race.

**Root cause** — the webview network log shows the app was ~0.8s away from being ready when the first attempt was killed:

| Time (UTC) | Event |
| --- | --- |
| 14:52:48.7 | webview loads → `bigspinner.png` (spinner on screen) |
| 14:52:51.5–51.7 | `buy/v1/provider/currencies?currency=crypto` + `=fiat` + `/session` → 200 |
| **14:53:20.8** | `sell/v1/provider/currencies?currency=fiat` → 200 — **29s after the buy calls** |
| 14:53:21.6 | `toBeVisible` times out — **0.8s too early** |
| 14:53:32.9 | test reloads the webview → boot restarts from zero |
| 14:54:20.0 | reload #2 → boot restarts again |
| 14:55:10.4 | `sell/…currencies` lands — **50s** into that attempt |

Two things in the Buy/Sell web app make that boot slow:

1. `navigation-tabs` is blocked on the **sell** fiat list even in a buy flow — `FirstTimeUserWrapper` renders a spinner while `isBuyCurrencyLoading || isSellCurrencyLoading`, so the testid is never in the DOM (hence `element(s) not found`, not "hidden").
2. Every HTTP request is serialized behind two untimed awaits in its axios request interceptor — a Firebase Remote Config `fetchAndActivate()` and a wallet-api round trip. The webview console is full of `[Remote-Config] ⚠️ Effective feature flags are null`, which is exactly what stalls the second `provider/currencies` call by 29–50s.

The run itself was broadly slow (307 passed / 15 failed, with `[ETH] - Add account`, `[SOL] - Add account` and `[ETH] - Send` all hitting 120s timeouts); ETH simply landed in the congested window.

**Fix** — the old recovery was actively counterproductive: a 30s deadline fired while the app was still making progress, and the reload threw that progress away and restarted the same slow boot. Now:

- first attempt waits **90s** (comfortably above the worst observed 50s boot),
- reload is a genuine last resort — **one** retry with a 60s window.

The reload also gets its own short fixed deadline (15s) instead of inheriting the attempt's, so it can't silently double the retry window — worst case is a predictable 90 + 15 + 60 = 165s here, plus ~127s of surrounding steps ≈ 292s, still under the 400s CI test timeout (the failing run took 255s total).

**Follow-up for the Buy & Sell team (not in this PR)** — the test change only absorbs the latency. Worth fixing at the source in `buy-sell-ui`:

- don't gate the buy flow on the `OFF_RAMP` fiat query in `FirstTimeUserWrapper`;
- memoize/dedupe `getFeatureFlags()` in `axiosInterceptor.ts` (currently re-invoked per request) and give it and `getWalletInfo()` a timeout with a safe fallback, so a slow Firebase fetch can't stall every API call.

### 🔗 Context

- **JIRA / GitHub issue**: n/a — CI flakiness triage
- **ADR** (if any): n/a

