### PR TITLE
[LWD] fix(contacts): select newly created contact (LIVE-36687)

### DIFF
--- a/.changeset/brisk-new-contact-selection.md
+++ b/.changeset/brisk-new-contact-selection.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Select newly created contacts in the Contacts detail pane.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -315,8 +315,9 @@ describe("Contacts integration", () => {
 
     await waitFor(() => {
       expect(screen.queryByTestId("contacts-add-contact-dialog")).not.toBeInTheDocument();
-      expect(screen.getByText("Coinbase 1")).toBeVisible();
     });
+
+    expect(screen.getByTestId("contacts-detail-name")).toHaveTextContent("Coinbase 1");
   });
 
   it("should open Ledger Sync activation instead of adding a contact while sync is inactive", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/index.tsx
@@ -7,7 +7,10 @@ import { useContactsViewModel } from "./useContactsViewModel";
 
 function ContactsScreen() {
   const pageViewModel = useContactsViewModel();
-  const addContactDialog = useAddContactDialogAdapter(pageViewModel.onClearSearch);
+  const addContactDialog = useAddContactDialogAdapter(contact => {
+    pageViewModel.onClearSearch();
+    pageViewModel.onSelectContact(contact.id);
+  });
   const viewModel = {
     ...pageViewModel,
     onAddContact: () => pageViewModel.onRequestAddContact(addContactDialog.onOpen),

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailPaneAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailPaneAdapter.ts
@@ -36,6 +36,7 @@ export function useContactDetailPaneAdapter(
   addressDetailActionsDialogs: ReturnType<typeof useContactAddressDetailActionsAdapter>;
   onOpenMe: ContactsViewProps["onOpenMe"];
   onOpenContact: ContactsViewProps["onOpenContact"];
+  onSelectContact: (contactId: ContactId) => void;
 }> {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -107,13 +108,19 @@ export function useContactDetailPaneAdapter(
       buildNavigationBackState(CRYPTO_ADDRESSES_BACK_PATH_STATE_KEY, "/contacts"),
     );
   }, [navigate]);
-  const openContact = useCallback(
+  const selectContact = useCallback(
     (contactId: ContactId) => {
-      trackContactsListContactOpen(analytics, contactId, meContact.id);
       setDetailContactId(contactId);
       clearSelection();
     },
-    [analytics, clearSelection, meContact.id],
+    [clearSelection],
+  );
+  const openContact = useCallback(
+    (contactId: ContactId) => {
+      trackContactsListContactOpen(analytics, contactId, meContact.id);
+      selectContact(contactId);
+    },
+    [analytics, meContact.id, selectContact],
   );
   const handleAddAddress = useCallback(
     (contact: AddAddressContact) => {
@@ -230,5 +237,6 @@ export function useContactDetailPaneAdapter(
     addressDetailActionsDialogs,
     onOpenMe: openContact,
     onOpenContact: openContact,
+    onSelectContact: selectContact,
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -72,6 +72,7 @@ export type ContactsPageViewModel = Omit<ContactsViewProps, "onAddContact" | "ad
     addressDetailActionsDialogs: ContactAddressDetailActionsDialogProps;
     onClearSearch: () => void;
     onRequestAddContact: (onAllowed: () => void) => void;
+    onSelectContact: (contactId: ContactId) => void;
   }>;
 
 export function useContactsViewModel(): ContactsPageViewModel {
@@ -343,6 +344,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
     addressDetailActionsDialogs,
     onOpenMe,
     onOpenContact,
+    onSelectContact,
   } = useContactDetailPaneAdapter(onAddAddress, deviceIntents);
   const preference = useContactsFeatureIntroductionPreference();
   const featureIntroductionState = useContactsFeatureIntroductionState({
@@ -450,6 +452,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
     onRequestAddContact,
     onOpenMe,
     onOpenContact,
+    onSelectContact,
     detail,
     ledgerSyncStatus,
     dieProps,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** The Contacts integration test covers saving and selecting the created contact.
- [x] **Impact of the changes:**
      Newly created Desktop Contacts now open directly in the detail pane without misattributing an analytics event.

### 📝 Description

This fixes the Desktop Contacts creation flow, where a successfully created contact remained unselected.

After saving, the app clears any active list search and selects the new contact in the detail pane. The programmatic selection is kept distinct from list-click tracking.

https://github.com/user-attachments/assets/2c35c241-6f0d-4801-b6a9-76f0540b80ea


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-36687

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
