### PR TITLE
[LWDM] refactor(pay-balance): resolve copy via @shared/i18n (LIVE-36732)

### DIFF
--- a/.changeset/friendly-numbers-complain.md
+++ b/.changeset/friendly-numbers-complain.md
@@ -1,0 +1,7 @@
+---
+"@features/flow-pay-balance": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+ddd

--- a/.changeset/friendly-numbers-complain.md
+++ b/.changeset/friendly-numbers-complain.md
@@ -4,4 +4,4 @@
 "live-mobile": minor
 ---
 
-ddd
+Move Pay balance/action-tile copy resolution into @features/flow-pay-balance via @shared/i18n so hosts no longer pass translated labels.

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayCardBalance.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayCardBalance.ts
@@ -1,6 +1,5 @@
 import { useCallback } from "react";
 import BigNumber from "bignumber.js";
-import { useTranslation } from "react-i18next";
 import {
   formatCurrencyUnit,
   formatCurrencyUnitFragment,
@@ -13,7 +12,6 @@ import {
   type FormattedValue,
   type BalanceData,
   type BalanceFilter,
-  type BalanceLabels,
 } from "@features/flow-pay-balance";
 import type { Unit } from "@domain/entity-currency-unit";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
@@ -21,9 +19,8 @@ import { counterValueCurrencySelector, localeSelector } from "~/renderer/reducer
 import { track } from "~/renderer/analytics/segment";
 import { usePayStablecoins } from "./usePayStablecoins";
 
-export function usePayCardBalance(): BalanceData & { labels: BalanceLabels } {
+export function usePayCardBalance(): BalanceData {
   const dispatch = useDispatch();
-  const { t } = useTranslation();
   const locale = useSelector(localeSelector);
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   const filter = useSelector(selectPayCardBalanceFilter);
@@ -65,23 +62,12 @@ export function usePayCardBalance(): BalanceData & { labels: BalanceLabels } {
     track(event, params);
   }, []);
 
-  const labels: BalanceLabels = {
-    emptyTitle: t("payTab.balance.emptyTitle"),
-    emptyDescription: t("payTab.balance.emptyDescription"),
-    allStablecoins: t("payTab.balance.filter.allStablecoins"),
-    filterDialogTitle: t("payTab.balance.filter.dialogTitle"),
-    filterDialogDescription: t("payTab.balance.filter.dialogDescription"),
-    filterDialogBanner: t("payTab.balance.filter.dialogBanner"),
-    confirm: t("payTab.balance.filter.confirm"),
-  };
-
-  const data = useBalanceData({
+  return useBalanceData({
     stablecoins,
     defaultStablecoins,
     filter,
     isLoading,
     isError,
-    allLabel: labels.allStablecoins,
     formatFiat,
     formatCrypto,
     formatCountervalue,
@@ -89,6 +75,4 @@ export function usePayCardBalance(): BalanceData & { labels: BalanceLabels } {
     onResetFilter,
     onTrackEvent,
   });
-
-  return { ...data, labels };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabActionTiles.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabActionTiles.ts
@@ -1,5 +1,4 @@
 import { useMemo } from "react";
-import { useTranslation } from "react-i18next";
 import type { ActionTilesProps } from "@features/flow-pay-balance";
 
 export function usePayTabActionTiles(
@@ -8,28 +7,16 @@ export function usePayTabActionTiles(
   onRequest: () => void,
   onPay: () => void,
 ): ActionTilesProps {
-  const { t } = useTranslation();
-
   return useMemo(
     () => ({
       tiles: [
-        {
-          id: "deposit",
-          label: t("payTab.actions.deposit"),
-          onPress: onDeposit,
-          appearance: "base",
-        },
-        {
-          id: "request",
-          label: t("payTab.actions.request"),
-          onPress: onRequest,
-          appearance: "transparent",
-        },
-        { id: "pay", label: t("payTab.actions.pay"), onPress: onPay, appearance: "transparent" },
+        { id: "deposit", onPress: onDeposit, appearance: "base" },
+        { id: "request", onPress: onRequest, appearance: "transparent" },
+        { id: "pay", onPress: onPay, appearance: "transparent" },
       ],
       page: "Pay",
       onTrackEvent,
     }),
-    [t, onTrackEvent, onDeposit, onRequest, onPay],
+    [onTrackEvent, onDeposit, onRequest, onPay],
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayCardBalance.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayCardBalance.ts
@@ -15,14 +15,12 @@ import {
 } from "@features/flow-pay-balance";
 import type { Unit } from "@domain/entity-currency-unit";
 import { useDispatch, useSelector } from "~/context/hooks";
-import { useTranslation } from "~/context/Locale";
 import { counterValueCurrencySelector, localeSelector } from "~/reducers/settings";
 import { track } from "~/analytics";
 import { usePayStablecoins } from "./usePayStablecoins";
 
 export function usePayCardBalance(): BalanceData {
   const dispatch = useDispatch();
-  const { t } = useTranslation();
   const locale = useSelector(localeSelector);
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   const filter = useSelector(selectPayCardBalanceFilter);
@@ -70,7 +68,6 @@ export function usePayCardBalance(): BalanceData {
     filter,
     isLoading,
     isError,
-    allLabel: t("payTab.balance.filter.allStablecoins"),
     formatFiat,
     formatCrypto,
     formatCountervalue,

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabActionTiles.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabActionTiles.ts
@@ -1,5 +1,4 @@
 import { useMemo } from "react";
-import { useTranslation } from "~/context/Locale";
 import type { ActionTilesProps } from "@features/flow-pay-balance";
 
 export function usePayTabActionTiles(
@@ -7,17 +6,15 @@ export function usePayTabActionTiles(
   onDeposit: () => void,
   onRequest: () => void,
 ): ActionTilesProps {
-  const { t } = useTranslation();
-
   return useMemo(
     () => ({
       tiles: [
-        { id: "deposit", label: t("payTab.actions.deposit"), onPress: onDeposit },
-        { id: "request", label: t("payTab.actions.request"), onPress: onRequest },
+        { id: "deposit", onPress: onDeposit },
+        { id: "request", onPress: onRequest },
       ],
       page: "Pay",
       onTrackEvent,
     }),
-    [t, onTrackEvent, onDeposit, onRequest],
+    [onTrackEvent, onDeposit, onRequest],
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/PayTabView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/PayTabView.tsx
@@ -1,12 +1,7 @@
 import React from "react";
 import { Card, type CardProps } from "@features/flow-pay-card";
 import { FeatureTour, type FeatureTourProps } from "@features/flow-pay-feature-tour";
-import {
-  Balance,
-  type ActionTilesProps,
-  type BalanceData,
-  type BalanceLabels,
-} from "@features/flow-pay-balance";
+import { Balance, type ActionTilesProps, type BalanceData } from "@features/flow-pay-balance";
 import { DepositOptions, type DepositOptionsProps } from "@features/flow-pay-deposit";
 import { Contacts, type ContactsNativeProps } from "@features/flow-pay-contact";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
@@ -20,7 +15,6 @@ type PayTabViewProps = {
   readonly callback: CardProps["callback"];
   readonly featureTour: FeatureTourProps;
   readonly balance: BalanceData;
-  readonly balanceLabels: BalanceLabels;
   readonly actionTiles: ActionTilesProps;
   readonly contacts: ContactsNativeProps;
   readonly depositOptions: DepositOptionsProps;
@@ -33,7 +27,6 @@ export function PayTabView({
   callback,
   featureTour,
   balance,
-  balanceLabels,
   actionTiles,
   contacts,
   depositOptions,
@@ -43,7 +36,7 @@ export function PayTabView({
       <Wallet40Background type="pay" />
       <Box lx={{ flex: 1, gap: "s24", paddingHorizontal: "s16" }} style={{ paddingTop: top }}>
         <TrackScreen category="Pay" balance_filter={balance.filter} />
-        <Balance {...balance} labels={balanceLabels} actionTiles={actionTiles} />
+        <Balance {...balance} actionTiles={actionTiles} />
         <Contacts {...contacts} />
         <Card title={cardTitle} oauthConfig={oauthConfig} callback={callback} />
         <FeatureTour {...featureTour} />

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
@@ -6,7 +6,6 @@ import type { ScreenName } from "~/const";
 import type { CardProps } from "@features/flow-pay-card";
 import type { PayTabNavigatorParamList } from "LLM/features/PayTab/types";
 import type { FeatureTourProps } from "@features/flow-pay-feature-tour";
-import type { BalanceLabels } from "@features/flow-pay-balance";
 import { useNavigationBarHeights } from "LLM/hooks/useNavigationBarHeights";
 import { usePayCardBalance } from "LLM/features/PayTab/hooks/usePayCardBalance";
 import { usePayTabActionTiles } from "LLM/features/PayTab/hooks/usePayTabActionTiles";
@@ -26,19 +25,6 @@ export function usePayTabViewModel() {
   const request = usePayTabRequestReceive();
   const actionTiles = usePayTabActionTiles(balance.onTrackEvent, deposit.open, request.open);
   const contacts = usePayTabContacts();
-
-  const balanceLabels: BalanceLabels = useMemo(
-    () => ({
-      emptyTitle: t("payTab.balance.emptyTitle"),
-      emptyDescription: t("payTab.balance.emptyDescription"),
-      allStablecoins: t("payTab.balance.filter.allStablecoins"),
-      filterDialogTitle: t("payTab.balance.filter.dialogTitle"),
-      filterDialogDescription: t("payTab.balance.filter.dialogDescription"),
-      filterDialogBanner: t("payTab.balance.filter.dialogBanner"),
-      confirm: t("payTab.balance.filter.confirm"),
-    }),
-    [t],
-  );
 
   // Baanx uses the same value for the client key header and the OAuth `client_id`.
   const oauthConfig: CardProps["oauthConfig"] = useMemo(
@@ -73,7 +59,6 @@ export function usePayTabViewModel() {
     callback,
     featureTour,
     balance,
-    balanceLabels,
     actionTiles,
     contacts,
     depositOptions: deposit.depositOptions,

--- a/features/flow/pay-balance/README.md
+++ b/features/flow/pay-balance/README.md
@@ -23,13 +23,12 @@ import { Balance } from "@features/flow-pay-balance";
   stableBalance={stableBalance}
   filter={filter}
   formatCountervalue={formatCountervalue}
-  labels={labels}
 />;
 ```
 
 The host passes the balance data (aggregated stable balance, `status`, `filter` and a countervalue
-formatter) and the display `labels` directly, so the views stay props-only and platform navigation
-and data access remain at the app composition root.
+formatter) directly, so platform navigation and data access remain at the app composition root.
+Copy is resolved inside the feature through `@shared/i18n`.
 
 Store, persistence and test setup should import the slice from
 `@features/flow-pay-balance/state` so they do not load the hero UI.
@@ -50,7 +49,6 @@ return useBalanceData({
   filter,
   isLoading,
   isError,
-  allLabel,
   formatFiat,
   formatCrypto,
   formatCountervalue,

--- a/features/flow/pay-balance/package.json
+++ b/features/flow/pay-balance/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@domain/entity-currency-unit": "workspace:^",
+    "@shared/i18n": "workspace:*",
     "@shared/ui-queued-bottom-sheet": "workspace:*",
     "@ledgerhq/lumen-utils-shared": "catalog:",
     "@ledgerhq/crypto-icons": "catalog:",

--- a/features/flow/pay-balance/src/__tests__/BalanceView.native.test.tsx
+++ b/features/flow/pay-balance/src/__tests__/BalanceView.native.test.tsx
@@ -3,6 +3,7 @@ import { View } from "react-native";
 import { render, screen } from "@testing-library/react-native";
 import type { BalanceViewProps } from "../types";
 import { BalanceView } from "../components/Hero/BalanceView.native";
+import { i18nWrapper } from "./i18nWrapper";
 import {
   depositActionTiles,
   emptyLabels,
@@ -44,7 +45,7 @@ function fundedProps(): BalanceViewProps {
 }
 
 function renderView(props: BalanceViewProps) {
-  return render(<BalanceView {...props} />);
+  return render(<BalanceView {...props} />, { wrapper: i18nWrapper() });
 }
 
 describe("BalanceView (Native)", () => {

--- a/features/flow/pay-balance/src/__tests__/fixtures.tsx
+++ b/features/flow/pay-balance/src/__tests__/fixtures.tsx
@@ -43,7 +43,32 @@ export const fundedStateProps = {
 
 export const depositActionTiles: ActionTilesProps = {
   page: "Pay",
-  tiles: [{ id: "deposit", label: "Deposit", onPress: () => undefined, appearance: "base" }],
+  tiles: [{ id: "deposit", onPress: () => undefined, appearance: "base" }],
+};
+
+export const BALANCE_RESOURCES = {
+  en: {
+    translation: {
+      payTab: {
+        balance: {
+          emptyTitle: "Pay and get paid",
+          emptyDescription: "Start by depositing stablecoin to your wallet",
+          filter: {
+            allStablecoins: "All stablecoins",
+            dialogTitle: "Filter balance",
+            dialogDescription: "Select a stablecoin to filter your balance",
+            dialogBanner: "USDC and USDT are always shown",
+            confirm: "Confirm",
+          },
+        },
+        actions: {
+          deposit: "Add stablecoin",
+          request: "Request",
+          pay: "New payment",
+        },
+      },
+    },
+  },
 };
 
 export const USDC_ID = "ethereum/erc20/usd__coin";

--- a/features/flow/pay-balance/src/__tests__/i18nWrapper.tsx
+++ b/features/flow/pay-balance/src/__tests__/i18nWrapper.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { I18nTestProvider } from "@shared/i18n/testing";
+
+type Resources = React.ComponentProps<typeof I18nTestProvider>["resources"];
+
+/**
+ * A `renderHook` / `render` wrapper that mounts the shared i18n test provider. With no `resources`
+ * every key resolves to itself; pass `resources` to assert copy comes from the provider.
+ */
+export function i18nWrapper(resources?: Resources) {
+  return function I18nWrapper({ children }: { children: React.ReactNode }) {
+    return <I18nTestProvider resources={resources}>{children}</I18nTestProvider>;
+  };
+}

--- a/features/flow/pay-balance/src/__tests__/renderWithStyle.web.tsx
+++ b/features/flow/pay-balance/src/__tests__/renderWithStyle.web.tsx
@@ -1,7 +1,12 @@
 import React from "react";
 import { render } from "@testing-library/react";
 import { StyleProvider } from "@features/platform-style";
+import { I18nTestProvider } from "@shared/i18n/testing";
 
 export function renderWithStyle(ui: React.ReactElement) {
-  return render(<StyleProvider colorScheme="dark">{ui}</StyleProvider>);
+  return render(
+    <I18nTestProvider>
+      <StyleProvider colorScheme="dark">{ui}</StyleProvider>
+    </I18nTestProvider>,
+  );
 }

--- a/features/flow/pay-balance/src/__tests__/useBalanceViewModel.web.test.ts
+++ b/features/flow/pay-balance/src/__tests__/useBalanceViewModel.web.test.ts
@@ -1,7 +1,8 @@
 import { act, renderHook } from "@testing-library/react";
 import { useBalanceViewModel } from "../components/Hero/useBalanceViewModel";
 import type { BalanceProps } from "../types";
-import { USDC_ID, formatCountervalue, labels, options } from "./fixtures";
+import { USDC_ID, formatCountervalue, options } from "./fixtures";
+import { i18nWrapper } from "./i18nWrapper";
 
 function buildProps(overrides: Partial<BalanceProps> = {}): BalanceProps {
   return {
@@ -12,17 +13,18 @@ function buildProps(overrides: Partial<BalanceProps> = {}): BalanceProps {
     filterOptions: options,
     formatCountervalue,
     onConfirmFilter: jest.fn(),
-    labels,
     ...overrides,
   };
+}
+
+function renderBalanceViewModel(props: BalanceProps) {
+  return renderHook(() => useBalanceViewModel(props), { wrapper: i18nWrapper() });
 }
 
 describe("useBalanceViewModel", () => {
   it("should be empty when the user has no balance", () => {
     const actionTiles = { page: "Pay", tiles: [] };
-    const { result } = renderHook(() =>
-      useBalanceViewModel(buildProps({ hasBalance: false, actionTiles })),
-    );
+    const { result } = renderBalanceViewModel(buildProps({ hasBalance: false, actionTiles }));
 
     expect(result.current).toMatchObject({
       displayMode: "empty",
@@ -31,8 +33,8 @@ describe("useBalanceViewModel", () => {
   });
 
   it("should be funded when the user has balance and is ready", () => {
-    const { result } = renderHook(() =>
-      useBalanceViewModel(buildProps({ hasBalance: true, stableBalance: 1250.5 })),
+    const { result } = renderBalanceViewModel(
+      buildProps({ hasBalance: true, stableBalance: 1250.5 }),
     );
 
     expect(result.current).toMatchObject({
@@ -44,10 +46,8 @@ describe("useBalanceViewModel", () => {
   });
 
   it("should keep funded chrome and skeleton the amount while funded data loads", () => {
-    const { result } = renderHook(() =>
-      useBalanceViewModel(
-        buildProps({ status: "loading", hasBalance: true, stableBalance: 1250.5 }),
-      ),
+    const { result } = renderBalanceViewModel(
+      buildProps({ status: "loading", hasBalance: true, stableBalance: 1250.5 }),
     );
 
     expect(result.current).toMatchObject({
@@ -58,16 +58,14 @@ describe("useBalanceViewModel", () => {
   });
 
   it("should stay empty while data loads if the user has no balance", () => {
-    const { result } = renderHook(() =>
-      useBalanceViewModel(buildProps({ status: "loading", hasBalance: false })),
-    );
+    const { result } = renderBalanceViewModel(buildProps({ status: "loading", hasBalance: false }));
 
     expect(result.current.displayMode).toBe("empty");
   });
 
   it("should stay funded on error if the user has a balance", () => {
-    const { result } = renderHook(() =>
-      useBalanceViewModel(buildProps({ status: "error", hasBalance: true, stableBalance: 1250.5 })),
+    const { result } = renderBalanceViewModel(
+      buildProps({ status: "error", hasBalance: true, stableBalance: 1250.5 }),
     );
 
     expect(result.current).toMatchObject({
@@ -78,17 +76,13 @@ describe("useBalanceViewModel", () => {
   });
 
   it("should stay empty on error if the user has no balance", () => {
-    const { result } = renderHook(() =>
-      useBalanceViewModel(buildProps({ status: "error", hasBalance: false })),
-    );
+    const { result } = renderBalanceViewModel(buildProps({ status: "error", hasBalance: false }));
 
     expect(result.current.displayMode).toBe("empty");
   });
 
   it("should expose the selected option for a valid filter", () => {
-    const { result } = renderHook(() =>
-      useBalanceViewModel(buildProps({ hasBalance: true, filter: USDC_ID })),
-    );
+    const { result } = renderBalanceViewModel(buildProps({ hasBalance: true, filter: USDC_ID }));
 
     expect(result.current).toMatchObject({
       displayMode: "funded",
@@ -99,9 +93,7 @@ describe("useBalanceViewModel", () => {
 
   it("should open the filter and track the open event", () => {
     const onTrackEvent = jest.fn();
-    const { result } = renderHook(() =>
-      useBalanceViewModel(buildProps({ hasBalance: true, onTrackEvent })),
-    );
+    const { result } = renderBalanceViewModel(buildProps({ hasBalance: true, onTrackEvent }));
 
     if (result.current.displayMode !== "funded") throw new Error("expected funded");
     expect(result.current.isFilterOpen).toBe(false);
@@ -114,12 +106,23 @@ describe("useBalanceViewModel", () => {
   });
 
   it("should close the filter", () => {
-    const { result } = renderHook(() => useBalanceViewModel(buildProps({ hasBalance: true })));
+    const { result } = renderBalanceViewModel(buildProps({ hasBalance: true }));
 
     act(() => result.current.displayMode === "funded" && result.current.onOpenFilter());
     act(() => result.current.displayMode === "funded" && result.current.onCloseFilter());
 
     if (result.current.displayMode !== "funded") throw new Error("expected funded");
     expect(result.current.isFilterOpen).toBe(false);
+  });
+
+  it("should resolve its copy from the mounted i18n provider, not from props", () => {
+    const { result } = renderHook(() => useBalanceViewModel(buildProps({ hasBalance: false })), {
+      wrapper: i18nWrapper({
+        en: { translation: { payTab: { balance: { emptyTitle: "Payez" } } } },
+      }),
+    });
+
+    if (result.current.displayMode !== "empty") throw new Error("expected empty");
+    expect(result.current.labels.emptyTitle).toBe("Payez");
   });
 });

--- a/features/flow/pay-balance/src/components/ActionTiles/__tests__/ActionTiles.web.test.tsx
+++ b/features/flow/pay-balance/src/components/ActionTiles/__tests__/ActionTiles.web.test.tsx
@@ -1,18 +1,14 @@
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
-import { StyleProvider } from "@features/platform-style";
+import { fireEvent, screen } from "@testing-library/react";
 import { ActionTiles } from "../ActionTiles";
 import type { ActionTilesProps } from "../types";
-
-function renderWithStyle(ui: React.ReactElement) {
-  return render(<StyleProvider colorScheme="dark">{ui}</StyleProvider>);
-}
+import { renderWithStyle } from "../../../__tests__/renderWithStyle.web";
 
 function buildProps(overrides: Partial<ActionTilesProps> = {}): ActionTilesProps {
   return {
     tiles: [
-      { id: "deposit", label: "Deposit", onPress: jest.fn(), appearance: "base" },
-      { id: "request", label: "Request", onPress: jest.fn(), appearance: "transparent" },
+      { id: "deposit", onPress: jest.fn(), appearance: "base" },
+      { id: "request", onPress: jest.fn(), appearance: "transparent" },
     ],
     page: "Pay",
     ...overrides,
@@ -33,7 +29,7 @@ describe("ActionTiles (Web)", () => {
     renderWithStyle(
       <ActionTiles
         {...buildProps({
-          tiles: [{ id: "deposit", label: "Deposit", onPress, appearance: "base" }],
+          tiles: [{ id: "deposit", onPress, appearance: "base" }],
           onTrackEvent,
         })}
       />,

--- a/features/flow/pay-balance/src/components/ActionTiles/__tests__/useActionTilesViewModel.web.test.ts
+++ b/features/flow/pay-balance/src/components/ActionTiles/__tests__/useActionTilesViewModel.web.test.ts
@@ -1,22 +1,28 @@
 import { renderHook } from "@testing-library/react";
 import { useActionTilesViewModel } from "../useActionTilesViewModel";
-import type { ActionTile, ActionTilesProps } from "../types";
+import type { ActionTileInput, ActionTilesProps } from "../types";
+import { i18nWrapper } from "../../../__tests__/i18nWrapper";
 
-const deposit: ActionTile = {
+const deposit: ActionTileInput = {
   id: "deposit",
-  label: "Deposit",
   onPress: jest.fn(),
   appearance: "base",
 };
-const request: ActionTile = {
+const request: ActionTileInput = {
   id: "request",
-  label: "Request",
   onPress: jest.fn(),
   appearance: "transparent",
 };
 
 function buildProps(overrides: Partial<ActionTilesProps> = {}): ActionTilesProps {
   return { tiles: [deposit, request], page: "Pay", ...overrides };
+}
+
+function renderActionTilesViewModel(
+  props: ActionTilesProps,
+  resources?: Parameters<typeof i18nWrapper>[0],
+) {
+  return renderHook(() => useActionTilesViewModel(props), { wrapper: i18nWrapper(resources) });
 }
 
 describe("useActionTilesViewModel", () => {
@@ -26,7 +32,7 @@ describe("useActionTilesViewModel", () => {
 
   it("should fire tracking then call the original handler on press", () => {
     const onTrackEvent = jest.fn();
-    const { result } = renderHook(() => useActionTilesViewModel(buildProps({ onTrackEvent })));
+    const { result } = renderActionTilesViewModel(buildProps({ onTrackEvent }));
 
     result.current.tiles[0].onPress();
 
@@ -41,7 +47,7 @@ describe("useActionTilesViewModel", () => {
 
   it("should fire tracking with the correct button id per tile", () => {
     const onTrackEvent = jest.fn();
-    const { result } = renderHook(() => useActionTilesViewModel(buildProps({ onTrackEvent })));
+    const { result } = renderActionTilesViewModel(buildProps({ onTrackEvent }));
 
     result.current.tiles[1].onPress();
 
@@ -53,24 +59,31 @@ describe("useActionTilesViewModel", () => {
   });
 
   it("should not throw when onTrackEvent is absent", () => {
-    const { result } = renderHook(() => useActionTilesViewModel(buildProps()));
+    const { result } = renderActionTilesViewModel(buildProps());
 
     expect(() => result.current.tiles[0].onPress()).not.toThrow();
     expect(deposit.onPress).toHaveBeenCalledTimes(1);
   });
 
   it("should expose all input tiles in the output", () => {
-    const pay: ActionTile = {
+    const pay: ActionTileInput = {
       id: "pay",
-      label: "New payment",
       onPress: jest.fn(),
       appearance: "transparent",
     };
-    const { result } = renderHook(() =>
-      useActionTilesViewModel(buildProps({ tiles: [deposit, request, pay] })),
-    );
+    const { result } = renderActionTilesViewModel(buildProps({ tiles: [deposit, request, pay] }));
 
     expect(result.current.tiles).toHaveLength(3);
     expect(result.current.tiles.map(t => t.id)).toEqual(["deposit", "request", "pay"]);
+  });
+
+  it("should resolve each tile label from the mounted i18n provider", () => {
+    const { result } = renderActionTilesViewModel(buildProps(), {
+      en: {
+        translation: { payTab: { actions: { deposit: "Add stablecoin", request: "Request" } } },
+      },
+    });
+
+    expect(result.current.tiles.map(t => t.label)).toEqual(["Add stablecoin", "Request"]);
   });
 });

--- a/features/flow/pay-balance/src/components/ActionTiles/types.ts
+++ b/features/flow/pay-balance/src/components/ActionTiles/types.ts
@@ -1,14 +1,17 @@
 export type ActionTileId = "deposit" | "request" | "pay";
 
-export type ActionTile = Readonly<{
+/** Host-provided tile: copy is resolved inside the feature from the tile `id`. */
+export type ActionTileInput = Readonly<{
   id: ActionTileId;
-  label: string;
   onPress: () => void;
   appearance?: "base" | "transparent";
 }>;
 
+/** A tile with its resolved copy, consumed by the views. */
+export type ActionTile = ActionTileInput & Readonly<{ label: string }>;
+
 export type ActionTilesProps = Readonly<{
-  tiles: readonly ActionTile[];
+  tiles: readonly ActionTileInput[];
   page: string;
   onTrackEvent?: (event: string, params: Record<string, unknown>) => void;
 }>;

--- a/features/flow/pay-balance/src/components/ActionTiles/useActionTilesViewModel.ts
+++ b/features/flow/pay-balance/src/components/ActionTiles/useActionTilesViewModel.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useTranslation } from "@shared/i18n";
 import type { ActionTilesProps, ActionTilesViewProps } from "./types";
 
 export function useActionTilesViewModel({
@@ -6,10 +7,13 @@ export function useActionTilesViewModel({
   page,
   onTrackEvent,
 }: ActionTilesProps): ActionTilesViewProps {
+  const { t } = useTranslation();
+
   const trackedTiles = useMemo(
     () =>
       tiles.map(tile => ({
         ...tile,
+        label: t(`payTab.actions.${tile.id}`),
         onPress: () => {
           onTrackEvent?.("button_clicked", {
             button: tile.id,
@@ -19,7 +23,7 @@ export function useActionTilesViewModel({
           tile.onPress();
         },
       })),
-    [tiles, page, onTrackEvent],
+    [t, tiles, page, onTrackEvent],
   );
 
   return { tiles: trackedTiles };

--- a/features/flow/pay-balance/src/components/Hero/useBalanceViewModel.ts
+++ b/features/flow/pay-balance/src/components/Hero/useBalanceViewModel.ts
@@ -1,7 +1,8 @@
 import { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "@shared/i18n";
 import { PAY_CARD_BALANCE_FILTER_ALL } from "../../state";
 import { resolveSelection } from "../../logic/resolveSelection";
-import type { BalanceProps, BalanceViewProps } from "../../types";
+import type { BalanceLabels, BalanceProps, BalanceViewProps } from "../../types";
 
 export function useBalanceViewModel({
   status,
@@ -13,8 +14,22 @@ export function useBalanceViewModel({
   onConfirmFilter,
   onTrackEvent,
   actionTiles,
-  labels,
 }: BalanceProps): BalanceViewProps {
+  const { t } = useTranslation();
+
+  const labels: BalanceLabels = useMemo(
+    () => ({
+      emptyTitle: t("payTab.balance.emptyTitle"),
+      emptyDescription: t("payTab.balance.emptyDescription"),
+      allStablecoins: t("payTab.balance.filter.allStablecoins"),
+      filterDialogTitle: t("payTab.balance.filter.dialogTitle"),
+      filterDialogDescription: t("payTab.balance.filter.dialogDescription"),
+      filterDialogBanner: t("payTab.balance.filter.dialogBanner"),
+      confirm: t("payTab.balance.filter.confirm"),
+    }),
+    [t],
+  );
+
   const optionIds = useMemo(() => filterOptions.map(option => option.id), [filterOptions]);
   const effectiveFilter = resolveSelection(filter, optionIds);
 

--- a/features/flow/pay-balance/src/hooks/useBalanceData.ts
+++ b/features/flow/pay-balance/src/hooks/useBalanceData.ts
@@ -1,4 +1,5 @@
 import { useEffect, useMemo } from "react";
+import { useTranslation } from "@shared/i18n";
 import type { Unit } from "@domain/entity-currency-unit";
 import type { BalanceFilter } from "../state";
 import type { DefaultStablecoin, StablecoinItem } from "../logic/buildBalanceFilterOptions";
@@ -11,7 +12,6 @@ export type UseBalanceDataParams = Readonly<{
   filter: BalanceFilter;
   isLoading: boolean;
   isError: boolean;
-  allLabel: string;
   formatFiat: (value: number) => string;
   formatCrypto: (unit: Unit, balance: number) => string;
   formatCountervalue: (value: number) => FormattedValue;
@@ -28,7 +28,6 @@ export function useBalanceData({
   filter,
   isLoading,
   isError,
-  allLabel,
   formatFiat,
   formatCrypto,
   formatCountervalue,
@@ -36,6 +35,9 @@ export function useBalanceData({
   onResetFilter,
   onTrackEvent,
 }: UseBalanceDataParams): BalanceData {
+  const { t } = useTranslation();
+  const allLabel = t("payTab.balance.filter.allStablecoins");
+
   const { data, shouldResetFilter } = useMemo(
     () =>
       buildBalanceData({

--- a/features/flow/pay-balance/src/types.ts
+++ b/features/flow/pay-balance/src/types.ts
@@ -77,7 +77,6 @@ export type BalanceData = BalanceAggregate &
 
 export type BalanceProps = BalanceData &
   Readonly<{
-    labels: BalanceLabels;
     actionTiles?: ActionTilesProps;
   }>;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6391,6 +6391,9 @@ importers:
       '@reduxjs/toolkit':
         specifier: 'catalog:'
         version: 2.11.2(react@19.1.4)
+      '@shared/i18n':
+        specifier: workspace:*
+        version: link:../../../shared/i18n
       '@shared/ui-queued-bottom-sheet':
         specifier: workspace:*
         version: link:../../../shared/ui-queued-bottom-sheet
@@ -28705,7 +28708,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: ^5.5.10
+      rxjs: '*'
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -67314,9 +67317,7 @@ snapshots:
     optionalDependencies:
       metro-transform-worker: 0.81.5
     transitivePeerDependencies:
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   metro-config@0.83.3(metro-transform-worker@0.83.3):
     dependencies:
@@ -67624,7 +67625,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.7(metro-transform-worker@0.83.7)
+      metro: 0.83.7
       metro-babel-transformer: 0.83.7
       metro-cache: 0.83.7
       metro-cache-key: 0.83.7
@@ -67774,53 +67775,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro@0.83.7(metro-transform-worker@0.83.7):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 2.0.0
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.35.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.7
-      metro-cache: 0.83.7
-      metro-cache-key: 0.83.7
-      metro-config: 0.83.7(metro-transform-worker@0.83.7)
-      metro-core: 0.83.7
-      metro-file-map: 0.83.7
-      metro-resolver: 0.83.7
-      metro-runtime: 0.83.7
-      metro-source-map: 0.83.7
-      metro-symbolicate: 0.83.7
-      metro-transform-plugins: 0.83.7
-      metro-transform-worker: 0.83.7
-      mime-types: 3.0.1
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
### 📝 Description

Pay balance copy was props-drilled from both apps: each host built `BalanceLabels`, passed `allLabel` into `useBalanceData`, and translated the action-tile labels before handing them to the feature.

This PR moves copy resolution into `@features/flow-pay-balance`, following the `@features/flow-pay-feature-tour` pilot. The hero, filter and action tiles now call `useTranslation()` from `@shared/i18n` and resolve their own `payTab.balance.*` / `payTab.actions.*` keys. Hosts inject data and analytics only:

- `useBalanceViewModel` builds `BalanceLabels` from `t(...)` (removed from `BalanceProps`).
- `useBalanceData` resolves the "all stablecoins" label itself (`allLabel` dropped from its params).
- `useActionTilesViewModel` resolves each tile label from its `id`; host tiles are now `ActionTileInput` (`{ id, onPress, appearance? }`).
- Desktop and mobile `usePayCardBalance` / `usePayTabActionTiles` / `PayTabView` stop building and passing copy.

No locale JSON changes: the keys already exist at the same path in both apps (`app` on Desktop, `common` on Mobile). Tests wrap components/hooks in `I18nTestProvider` from `@shared/i18n/testing`.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36732](https://ledgerhq.atlassian.net/browse/LIVE-36732) 

[LIVE-36732]: https://ledgerhq.atlassian.net/browse/LIVE-36732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ