### PR TITLE
fix(domain): add resilience to CAL `null` and `undefined` responses

### DIFF
--- a/.changeset/lazy-cows-punch.md
+++ b/.changeset/lazy-cows-punch.md
@@ -1,0 +1,6 @@
+---
+"@features/platform-currencies": patch
+"@domain/api-currency-token": patch
+---
+
+fix(domain): add resilience to `null` and `undefined` responses from CAL

--- a/domain/api/currency-token/src/internals/utils.test.ts
+++ b/domain/api/currency-token/src/internals/utils.test.ts
@@ -91,6 +91,14 @@ describe("validateAndTransformSingleTokenResponse", () => {
     );
   });
 
+  it("should return undefined when the response is null", () => {
+    expect(validateAndTransformSingleTokenResponse(null)).toBeUndefined();
+  });
+
+  it("should return undefined when the response is undefined", () => {
+    expect(validateAndTransformSingleTokenResponse(undefined)).toBeUndefined();
+  });
+
   it("should return undefined when the array is empty", () => {
     expect(validateAndTransformSingleTokenResponse([])).toBeUndefined();
   });

--- a/domain/api/currency-token/src/internals/utils.ts
+++ b/domain/api/currency-token/src/internals/utils.ts
@@ -42,6 +42,9 @@ export function transformApiTokenToTokenCurrency(
 export function validateAndTransformSingleTokenResponse(
   response: unknown,
 ): TokenCurrency | undefined {
+  if (response === undefined || response === null) {
+    return undefined;
+  }
   const validatedResponse = ApiResponseSchema.parse(response);
   const apiToken = validatedResponse[0];
   if (!apiToken) {

--- a/features/platform/currencies/src/legacy/store/buildCryptoAssetsStore.test.ts
+++ b/features/platform/currencies/src/legacy/store/buildCryptoAssetsStore.test.ts
@@ -109,6 +109,25 @@ describe("buildCryptoAssetsStore", () => {
     });
   });
 
+  it("PARSING_ERROR with a raw Zod-issue-array payload -> readable fallback message", async () => {
+    const { store, dispatch } = setup();
+    dispatch.mockResolvedValue({
+      error: {
+        status: "PARSING_ERROR",
+        error: [
+          {
+            code: "invalid_type",
+            expected: "array",
+            received: "null",
+            path: [],
+            message: "Invalid input: expected array, received null",
+          },
+        ],
+      },
+    });
+    await expect(store.findTokenById("id")).rejects.toThrow("Unknown parsing_error error");
+  });
+
   it("defaults to the shared cryptoAssetsApi when no api is injected", () => {
     expect(() =>
       buildCryptoAssetsStore({ dispatch: jest.fn() as unknown as CryptoAssetsStoreDispatch }),

--- a/features/platform/currencies/src/legacy/store/buildCryptoAssetsStore.ts
+++ b/features/platform/currencies/src/legacy/store/buildCryptoAssetsStore.ts
@@ -102,7 +102,11 @@ export function remapRtkQueryError(error: FetchBaseQueryError | SerializedError)
     }
     if (status === "FETCH_ERROR") return new NetworkDown();
     // PARSING_ERROR / TIMEOUT_ERROR / CUSTOM_ERROR — surface the message.
-    return new Error("error" in error ? error.error : String(status));
+    return new Error("error" in error ? toErrorMessage(error.error, status) : String(status));
   }
   return new Error(error.message ?? "Unknown crypto-assets store error");
+}
+
+function toErrorMessage(rawError: unknown, status: string): string {
+  return typeof rawError === "string" ? rawError : `Unknown ${status.toLowerCase()} error`;
 }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

CAL does respond with `null` under certain circumstances. This breaks Zod trying to [parse an array](https://app.datadoghq.eu/error-tracking/issue/9f8bd764-a131-11f1-b6be-da7ad0900005?refresh_mode=sliding&from_ts=1787695200000&to_ts=1788181117388&live=true).
Add resilience to `null` and `undefined`.

Improve error message to avoid `[object Object]` passing by.

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-36598
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
