### PR TITLE
[LWDM] refactor(pay): resolve bank-transfer copy via @shared/i18n

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayTabDepositOptions.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayTabDepositOptions.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook } from "tests/testSetup";
 import { useNavigate } from "react-router";
 import { AssetCategory } from "@domain/api-aggregated-assets";
 import { useOpenAssetFlow } from "../../../ModularDialog/hooks/useOpenAssetFlow";

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabDepositOptions.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabDepositOptions.ts
@@ -1,12 +1,10 @@
 import { useCallback } from "react";
-import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
 import { ModularDrawerLocation } from "@ledgerhq/live-common/modularDrawer/enums";
 import { AssetCategory } from "@domain/api-aggregated-assets";
 import {
   useBankTransferIntroAdapter,
   type BankTransferHandoff,
-  type BankTransferIntroLabels,
   type BankTransferIntroProps,
 } from "@features/flow-pay-bank-transfer";
 import {
@@ -28,7 +26,6 @@ export type UsePayTabDepositOptions = UseDepositOptionsAdapter & {
 export function usePayTabDepositOptions(
   onTrackEvent: PayCardTrackEvent | undefined,
 ): UsePayTabDepositOptions {
-  const { t } = useTranslation();
   const navigate = useNavigate();
 
   const { openAssetFlow } = useOpenAssetFlow(
@@ -48,33 +45,7 @@ export function usePayTabDepositOptions(
     [navigate],
   );
 
-  const introLabels: BankTransferIntroLabels = {
-    title: t("payTab.bankTransferIntro.title"),
-    description: t("payTab.bankTransferIntro.description"),
-    createAccountLabel: t("payTab.bankTransferIntro.createAccount"),
-    logInLabel: t("payTab.bankTransferIntro.logIn"),
-    providedBy: t("payTab.bankTransferIntro.providedBy"),
-    rows: [
-      {
-        icon: "Bank",
-        title: t("payTab.bankTransferIntro.rows.bank.title"),
-        description: t("payTab.bankTransferIntro.rows.bank.description"),
-      },
-      {
-        icon: "Coins",
-        title: t("payTab.bankTransferIntro.rows.fees.title"),
-        description: t("payTab.bankTransferIntro.rows.fees.description"),
-      },
-      {
-        icon: "Chart5",
-        title: t("payTab.bankTransferIntro.rows.earn.title"),
-        description: t("payTab.bankTransferIntro.rows.earn.description"),
-      },
-    ],
-  };
-
   const { open: openBankTransferIntro, bankTransferIntro } = useBankTransferIntroAdapter({
-    labels: introLabels,
     onBankTransfer,
     onTrackEvent,
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabDepositOptions.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabDepositOptions.ts
@@ -7,7 +7,6 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import {
   useBankTransferIntroAdapter,
   type BankTransferHandoff,
-  type BankTransferIntroLabels,
   type BankTransferIntroProps,
 } from "@features/flow-pay-bank-transfer";
 import {
@@ -18,7 +17,6 @@ import {
 } from "@features/flow-pay-deposit";
 import { NavigatorName, ScreenName } from "~/const";
 import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
-import { useTranslation } from "~/context/Locale";
 import { useOpenReceiveDrawer } from "LLM/features/Receive";
 import { useOpenSwap } from "LLM/features/Swap";
 import { useOpenBuySell } from "LLM/features/Buy";
@@ -38,7 +36,6 @@ export type UsePayTabDepositOptions = UseDepositOptionsAdapter & {
 export function usePayTabDepositOptions(
   onTrackEvent: PayCardTrackEvent | undefined,
 ): UsePayTabDepositOptions {
-  const { t } = useTranslation();
   const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
   const { bottom } = useSafeAreaInsets();
   const bottomInset = Platform.OS === "ios" ? bottom : 0;
@@ -65,33 +62,7 @@ export function usePayTabDepositOptions(
     [navigation],
   );
 
-  const introLabels: BankTransferIntroLabels = {
-    title: t("payTab.bankTransferIntro.title"),
-    description: t("payTab.bankTransferIntro.description"),
-    createAccountLabel: t("payTab.bankTransferIntro.createAccount"),
-    logInLabel: t("payTab.bankTransferIntro.logIn"),
-    providedBy: t("payTab.bankTransferIntro.providedBy"),
-    rows: [
-      {
-        icon: "Bank",
-        title: t("payTab.bankTransferIntro.rows.bank.title"),
-        description: t("payTab.bankTransferIntro.rows.bank.description"),
-      },
-      {
-        icon: "Coins",
-        title: t("payTab.bankTransferIntro.rows.fees.title"),
-        description: t("payTab.bankTransferIntro.rows.fees.description"),
-      },
-      {
-        icon: "Chart5",
-        title: t("payTab.bankTransferIntro.rows.earn.title"),
-        description: t("payTab.bankTransferIntro.rows.earn.description"),
-      },
-    ],
-  };
-
   const { open: openBankTransferIntro, bankTransferIntro } = useBankTransferIntroAdapter({
-    labels: introLabels,
     heroImage: BANK_TRANSFER_INTRO_HERO_IMAGE,
     bottomInset,
     onBankTransfer,

--- a/features/flow/pay-bank-transfer/README.md
+++ b/features/flow/pay-bank-transfer/README.md
@@ -3,9 +3,10 @@
 > [!CAUTION]
 > **Status: UNSTABLE** — In active development; API may change.
 
-Shared cash-to-stable intro for the Pay deposit **Bank transfer** row. The view-model owns
-intro content, continue / close intents, and tracking. Views are props-only. Host apps own
-sheet / dialog presentation and the partner (Noah) handoff.
+Shared cash-to-stable **feature intro** for the Pay deposit **Bank transfer** row. The view-model
+owns intro content, create-account / log-in / close intents, and tracking. Views are props-only.
+Native uses the Lumen bottom sheet. Web uses the Lumen Dialog. Host apps own the partner (Noah)
+handoff.
 
 This is a dedicated `@features/flow-*` package because Trading owns the partner WebView, not
 the Pay card package.
@@ -13,53 +14,35 @@ the Pay card package.
 ## Usage
 
 ```tsx
-import {
-  BankTransferIntroView,
-  useBankTransferIntroAdapter,
-} from "@features/flow-pay-bank-transfer";
+import { BankTransferIntro, useBankTransferIntroAdapter } from "@features/flow-pay-bank-transfer";
 
 const intro = useBankTransferIntroAdapter({
-  labels: {
-    title: t("payTab.bankTransferIntro.title"),
-    description: t("payTab.bankTransferIntro.description"),
-    continueLabel: t("payTab.bankTransferIntro.continue"),
-    rows: [
-      {
-        icon: "Bank",
-        title: t("payTab.bankTransferIntro.rows.bank.title"),
-        description: t("payTab.bankTransferIntro.rows.bank.description"),
-      },
-    ],
-  },
-  onBankTransfer: () => navigateToPartner(),
+  heroImage: require("./bank-transfer-intro-hero.webp"),
+  onBankTransfer: handoff => navigateToPartner(handoff),
   onTrackEvent: track,
 });
 
 // Deposit options `onSelect("bankTransfer")` → intro.open()
-<QueuedBottomSheet
-  isRequestingToBeOpened={intro.isOpen}
-  onClose={intro.onClosePress}
->
-  <BankTransferIntroView {...intro} />
-</QueuedBottomSheet>
+<BankTransferIntro {...intro.bankTransferIntro} />
 ```
 
-i18n stays in the app. This package is copy-agnostic.
+Copy is resolved inside this package via `@shared/i18n` (`payTab.bankTransferIntro.*` in each
+app's default namespace). Hosts inject data, analytics, and partner handoff only.
 
 ## Host intents
 
 | Intent | When | Host does |
 | --- | --- | --- |
 | `open()` | Deposit row **Bank transfer** | Open the intro overlay |
-| `onBankTransfer` | Intro **Continue** | Partner handoff (below) |
-| `onClosePress` | Overlay dismiss / close | Close the overlay; no partner |
+| `onBankTransfer("createAccount")` | Intro **Create an account** | Partner signup handoff (below) |
+| `onBankTransfer("logIn")` | Intro **Log in to Noah** | Partner login handoff (below) |
 
 Partner UI is **not** in this package. Known in-app routes (deep link TBD):
 
 | App | Route | Partner |
 | --- | --- | --- |
-| Desktop | `/bank` | Noah `WebPlatformPlayer` (`manifestId: "noah"`) |
-| Mobile | `ReceiveFunds` / `ReceiveProvider` `{ manifestId: "noah" }` | Noah `WebReceivePlayer` |
+| Desktop | `/bank?noahAuth=createAccount` or `/bank?noahAuth=logIn` | Noah `WebPlatformPlayer` (`manifestId: "noah"`) |
+| Mobile | `ReceiveFunds` / `ReceiveProvider` `{ manifestId: "noah", noahAuth }` | Noah `WebReceivePlayer` |
 
 Child screens under Figma `6784:63692` are TBD.
 
@@ -72,7 +55,8 @@ Injected `onTrackEvent` only (Pay Tracking Plan). Deposit-row
 | Event | Payload |
 | --- | --- |
 | Open intro | `Page cash to stable` `{ flow: "C2S" }` |
-| Continue | `button_clicked` `{ button: "continue", flow: "C2S", page: "cash to stable" }` |
+| Create an account | `button_clicked` `{ button: "create an account", flow: "C2S", page: "cash to stable" }` |
+| Log in to Noah | `button_clicked` `{ button: "log in to noah", flow: "C2S", page: "cash to stable" }` |
 | Close | `button_clicked` `{ button: "close", flow: "C2S", page: "cash to stable" }` |
 
 ## Platform resolution
@@ -94,6 +78,7 @@ pay-bank-transfer/
     │   ├── useBankTransferIntroAdapter.ts
     │   ├── BankTransferIntroView.web.tsx
     │   ├── BankTransferIntroView.native.tsx
+    │   ├── assets.ts
     │   └── __tests__/
     ├── types.ts
     ├── exports.ts

--- a/features/flow/pay-bank-transfer/package.json
+++ b/features/flow/pay-bank-transfer/package.json
@@ -28,6 +28,7 @@
     "unimported": "pnpm knip --directory ../../.. -W features/flow/pay-bank-transfer"
   },
   "dependencies": {
+    "@shared/i18n": "workspace:*",
     "@shared/ui-queued-bottom-sheet": "workspace:*"
   },
   "devDependencies": {

--- a/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/BankTransferIntro.native.test.tsx
+++ b/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/BankTransferIntro.native.test.tsx
@@ -2,26 +2,28 @@ import React from "react";
 import { cleanup, render, screen, userEvent } from "@testing-library/react-native";
 import { BankTransferIntro } from "../BankTransferIntro";
 import type { BankTransferIntroProps } from "../../../types";
+import { I18nWrapper } from "./i18nWrapper";
 
-const LABELS: BankTransferIntroProps["labels"] = {
-  title: "Convert cash to stablecoins",
-  description: "Transfer USD or EUR from your bank.",
-  createAccountLabel: "Create an account",
-  logInLabel: "Log in",
-  providedBy: "Provided by Noah",
-  rows: [{ icon: "Bank", title: "Bank transfer", description: "Send USD or EUR." }],
-};
+jest.mock("@shared/ui-queued-bottom-sheet", () => ({
+  QueuedBottomSheet: ({ children }: { children: React.ReactNode }) => children,
+}));
 
 function renderIntro(overrides: Partial<BankTransferIntroProps> = {}) {
   const props: BankTransferIntroProps = {
     isOpen: true,
-    labels: LABELS,
     onBankTransfer: jest.fn(),
     onClose: jest.fn(),
     onTrackEvent: jest.fn(),
     ...overrides,
   };
-  return { props, ...render(<BankTransferIntro {...props} />) };
+  return {
+    props,
+    ...render(
+      <I18nWrapper>
+        <BankTransferIntro {...props} />
+      </I18nWrapper>,
+    ),
+  };
 }
 
 describe("BankTransferIntro (Native)", () => {

--- a/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/BankTransferIntro.web.test.tsx
+++ b/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/BankTransferIntro.web.test.tsx
@@ -1,28 +1,29 @@
 import React from "react";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { I18nTestProvider } from "@shared/i18n/testing";
 import { BankTransferIntro } from "../BankTransferIntro";
+import { useBankTransferIntroAdapter } from "../useBankTransferIntroAdapter";
 import type { BankTransferIntroProps } from "../../../types";
+import { I18nWrapper } from "./i18nWrapper";
 
-const LABELS: BankTransferIntroProps["labels"] = {
-  title: "Convert cash to stablecoins",
-  description: "Transfer USD or EUR from your bank.",
-  createAccountLabel: "Create an account",
-  logInLabel: "Log in",
-  providedBy: "Provided by Noah",
-  rows: [{ icon: "Bank", title: "Bank transfer", description: "Send USD or EUR." }],
-};
-
-function renderIntro(overrides: Partial<BankTransferIntroProps> = {}) {
-  const props: BankTransferIntroProps = {
-    isOpen: true,
-    labels: LABELS,
+function OpenIntro({
+  onTrackEvent = jest.fn(),
+}: {
+  onTrackEvent?: BankTransferIntroProps["onTrackEvent"];
+}) {
+  const { open, bankTransferIntro } = useBankTransferIntroAdapter({
     onBankTransfer: jest.fn(),
-    onClose: jest.fn(),
-    onTrackEvent: jest.fn(),
-    ...overrides,
-  };
-  return { props, ...render(<BankTransferIntro {...props} />) };
+    onTrackEvent,
+  });
+  React.useEffect(() => {
+    open();
+  }, [open]);
+  return <BankTransferIntro {...bankTransferIntro} />;
+}
+
+function renderIntro(ui: React.ReactElement) {
+  return render(<I18nWrapper>{ui}</I18nWrapper>);
 }
 
 describe("BankTransferIntro (Web)", () => {
@@ -30,45 +31,91 @@ describe("BankTransferIntro (Web)", () => {
     cleanup();
   });
 
-  it("tracks the page when opened", () => {
-    const { props } = renderIntro();
+  it("should render the intro copy", () => {
+    const onTrackEvent = jest.fn();
+    renderIntro(<OpenIntro onTrackEvent={onTrackEvent} />);
 
-    expect(props.onTrackEvent).toHaveBeenCalledWith("Page cash to stable", { flow: "C2S" });
+    expect(screen.getByRole("heading", { name: "Send cash, receive stablecoin" })).toBeVisible();
+    expect(
+      screen.getByText("Transfer cash and receive stablecoins straight to your Ledger Wallet™."),
+    ).toBeVisible();
+    expect(screen.getByText("Get salary, payments, deposits via SEPA or ACH.")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Create an account" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Log in to Noah" })).toBeVisible();
+    expect(screen.getByText("Provided by Noah")).toBeVisible();
+    expect(onTrackEvent).toHaveBeenCalledWith("Page cash to stable", { flow: "C2S" });
   });
 
-  it("tracks create account, hands off and closes", async () => {
+  it("should close after create account and track that CTA", async () => {
     const user = userEvent.setup();
-    const { props } = renderIntro();
+    const onTrackEvent = jest.fn();
+    renderIntro(<OpenIntro onTrackEvent={onTrackEvent} />);
 
-    await user.click(screen.getByTestId("pay-bank-transfer-intro-create-account"));
+    await user.click(screen.getByRole("button", { name: "Create an account" }));
 
-    expect(props.onTrackEvent).toHaveBeenCalledWith("button_clicked", {
+    expect(
+      screen.queryByRole("heading", { name: "Send cash, receive stablecoin" }),
+    ).not.toBeInTheDocument();
+    expect(onTrackEvent).toHaveBeenCalledWith("button_clicked", {
       button: "create an account",
       flow: "C2S",
       page: "cash to stable",
     });
-    expect(props.onBankTransfer).toHaveBeenCalledWith("createAccount");
-    expect(props.onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("tracks log in, hands off and closes", async () => {
+  it("should close after log in and track that CTA", async () => {
     const user = userEvent.setup();
-    const { props } = renderIntro();
+    const onTrackEvent = jest.fn();
+    renderIntro(<OpenIntro onTrackEvent={onTrackEvent} />);
 
-    await user.click(screen.getByTestId("pay-bank-transfer-intro-log-in"));
+    await user.click(screen.getByRole("button", { name: "Log in to Noah" }));
 
-    expect(props.onTrackEvent).toHaveBeenCalledWith("button_clicked", {
+    expect(
+      screen.queryByRole("heading", { name: "Send cash, receive stablecoin" }),
+    ).not.toBeInTheDocument();
+    expect(onTrackEvent).toHaveBeenCalledWith("button_clicked", {
       button: "log in to noah",
       flow: "C2S",
       page: "cash to stable",
     });
-    expect(props.onBankTransfer).toHaveBeenCalledWith("logIn");
-    expect(props.onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("renders nothing when closed", () => {
-    renderIntro({ isOpen: false });
+  it("should close after header close and track close", async () => {
+    const user = userEvent.setup();
+    const onTrackEvent = jest.fn();
+    renderIntro(<OpenIntro onTrackEvent={onTrackEvent} />);
 
-    expect(screen.queryByTestId("pay-bank-transfer-intro-content")).toBeNull();
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(
+      screen.queryByRole("heading", { name: "Send cash, receive stablecoin" }),
+    ).not.toBeInTheDocument();
+    expect(onTrackEvent).toHaveBeenCalledWith("button_clicked", {
+      button: "close",
+      flow: "C2S",
+      page: "cash to stable",
+    });
+  });
+
+  it("should render nothing when closed", () => {
+    renderIntro(
+      <BankTransferIntro isOpen={false} onBankTransfer={jest.fn()} onClose={jest.fn()} />,
+    );
+
+    expect(
+      screen.queryByRole("heading", { name: "Send cash, receive stablecoin" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("resolves its copy from the mounted i18n provider, not from props", () => {
+    render(
+      <I18nTestProvider
+        resources={{ en: { translation: { payTab: { bankTransferIntro: { title: "Envoyer" } } } } }}
+      >
+        <OpenIntro />
+      </I18nTestProvider>,
+    );
+
+    expect(screen.getByRole("heading", { name: "Envoyer" })).toBeVisible();
   });
 });

--- a/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/fixtures.ts
+++ b/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/fixtures.ts
@@ -1,0 +1,30 @@
+/** The `payTab.bankTransferIntro.*` copy each app ships, mirrored here for the container tests. */
+export const BANK_TRANSFER_INTRO_RESOURCES = {
+  en: {
+    translation: {
+      payTab: {
+        bankTransferIntro: {
+          title: "Send cash, receive stablecoin",
+          description: "Transfer cash and receive stablecoins straight to your Ledger Wallet™.",
+          createAccount: "Create an account",
+          logIn: "Log in to Noah",
+          providedBy: "Provided by Noah",
+          rows: {
+            bank: {
+              title: "Receive transfers from any bank",
+              description: "Get salary, payments, deposits via SEPA or ACH.",
+            },
+            fees: {
+              title: "No hidden fees",
+              description: "Direct from bank to blockchain for 0.25% fees.",
+            },
+            earn: {
+              title: "Put your money to work right away",
+              description: "You can swap or earn with your stablecoin.",
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/i18nWrapper.tsx
+++ b/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/i18nWrapper.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+import { I18nTestProvider } from "@shared/i18n/testing";
+import { BANK_TRANSFER_INTRO_RESOURCES } from "./fixtures";
+
+export function I18nWrapper({ children }: { children: React.ReactNode }) {
+  return <I18nTestProvider resources={BANK_TRANSFER_INTRO_RESOURCES}>{children}</I18nTestProvider>;
+}

--- a/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/useBankTransferIntroAdapter.web.test.ts
+++ b/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/useBankTransferIntroAdapter.web.test.ts
@@ -4,9 +4,12 @@ import { I18nWrapper } from "./i18nWrapper";
 
 describe("useBankTransferIntroAdapter", () => {
   it("starts closed and toggles isOpen via open and onClosePress", () => {
-    const { result } = renderHook(() => useBankTransferIntroAdapter({ onBankTransfer: jest.fn() }), {
-      wrapper: I18nWrapper,
-    });
+    const { result } = renderHook(
+      () => useBankTransferIntroAdapter({ onBankTransfer: jest.fn() }),
+      {
+        wrapper: I18nWrapper,
+      },
+    );
 
     expect(result.current.isOpen).toBe(false);
     expect(result.current.bankTransferIntro.isOpen).toBe(false);

--- a/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/useBankTransferIntroAdapter.web.test.ts
+++ b/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/useBankTransferIntroAdapter.web.test.ts
@@ -1,21 +1,12 @@
 import { act, renderHook } from "@testing-library/react";
-import type { BankTransferIntroLabels } from "../../../types";
 import { useBankTransferIntroAdapter } from "../useBankTransferIntroAdapter";
-
-const labels: BankTransferIntroLabels = {
-  title: "Convert cash to stablecoins",
-  description: "Transfer USD or EUR from your bank.",
-  createAccountLabel: "Create an account",
-  logInLabel: "Log in",
-  providedBy: "Provided by Noah",
-  rows: [{ icon: "Bank", title: "Bank transfer", description: "Send USD or EUR." }],
-};
+import { I18nWrapper } from "./i18nWrapper";
 
 describe("useBankTransferIntroAdapter", () => {
   it("starts closed and toggles isOpen via open and onClosePress", () => {
-    const { result } = renderHook(() =>
-      useBankTransferIntroAdapter({ labels, onBankTransfer: jest.fn() }),
-    );
+    const { result } = renderHook(() => useBankTransferIntroAdapter({ onBankTransfer: jest.fn() }), {
+      wrapper: I18nWrapper,
+    });
 
     expect(result.current.isOpen).toBe(false);
     expect(result.current.bankTransferIntro.isOpen).toBe(false);
@@ -27,22 +18,22 @@ describe("useBankTransferIntroAdapter", () => {
     expect(result.current.isOpen).toBe(false);
   });
 
-  it("passes labels, onBankTransfer and onTrackEvent through into bankTransferIntro", () => {
+  it("passes onBankTransfer and onTrackEvent through into bankTransferIntro", () => {
     const onBankTransfer = jest.fn();
     const onTrackEvent = jest.fn();
 
-    const { result } = renderHook(() =>
-      useBankTransferIntroAdapter({
-        labels,
-        heroImage: 7,
-        bottomInset: 34,
-        onBankTransfer,
-        onTrackEvent,
-      }),
+    const { result } = renderHook(
+      () =>
+        useBankTransferIntroAdapter({
+          heroImage: 7,
+          bottomInset: 34,
+          onBankTransfer,
+          onTrackEvent,
+        }),
+      { wrapper: I18nWrapper },
     );
 
     const { bankTransferIntro } = result.current;
-    expect(bankTransferIntro.labels).toBe(labels);
     expect(bankTransferIntro.heroImage).toBe(7);
     expect(bankTransferIntro.bottomInset).toBe(34);
     expect(bankTransferIntro.onBankTransfer).toBe(onBankTransfer);
@@ -51,7 +42,9 @@ describe("useBankTransferIntroAdapter", () => {
 
   it("emits onBankTransfer and closes on create account", () => {
     const onBankTransfer = jest.fn();
-    const { result } = renderHook(() => useBankTransferIntroAdapter({ labels, onBankTransfer }));
+    const { result } = renderHook(() => useBankTransferIntroAdapter({ onBankTransfer }), {
+      wrapper: I18nWrapper,
+    });
 
     act(() => result.current.open());
     act(() => result.current.onCreateAccountPress());

--- a/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/useBankTransferIntroViewModel.web.test.ts
+++ b/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/useBankTransferIntroViewModel.web.test.ts
@@ -1,42 +1,50 @@
 import { renderHook } from "@testing-library/react";
 import { useBankTransferIntroViewModel } from "../useBankTransferIntroViewModel";
 import type { BankTransferIntroProps } from "../../../types";
-
-const LABELS: BankTransferIntroProps["labels"] = {
-  title: "Convert cash to stablecoins",
-  description: "Transfer USD or EUR from your bank.",
-  createAccountLabel: "Create an account",
-  logInLabel: "Log in",
-  providedBy: "Provided by Noah",
-  rows: [
-    { icon: "Bank", title: "Bank transfer", description: "Send USD or EUR." },
-    { icon: "Coins", title: "No hidden fees", description: "Direct from bank to blockchain." },
-    { icon: "Chart5", title: "Put your money to work", description: "Swap or earn stablecoin." },
-  ],
-};
+import { I18nWrapper } from "./i18nWrapper";
 
 function setup(overrides: Partial<BankTransferIntroProps> = {}) {
   const props: BankTransferIntroProps = {
     isOpen: true,
-    labels: LABELS,
     onBankTransfer: jest.fn(),
     onClose: jest.fn(),
     onTrackEvent: jest.fn(),
     ...overrides,
   };
-  const { result } = renderHook(() => useBankTransferIntroViewModel(props));
+  const { result } = renderHook(() => useBankTransferIntroViewModel(props), {
+    wrapper: I18nWrapper,
+  });
   return { props, result };
 }
 
 describe("useBankTransferIntroViewModel", () => {
-  it("exposes the injected labels", () => {
+  it("resolves copy from the mounted i18n provider", () => {
     const { result } = setup();
 
-    expect(result.current.title).toBe(LABELS.title);
-    expect(result.current.description).toBe(LABELS.description);
-    expect(result.current.createAccountLabel).toBe(LABELS.createAccountLabel);
-    expect(result.current.logInLabel).toBe(LABELS.logInLabel);
-    expect(result.current.rows).toEqual(LABELS.rows);
+    expect(result.current.title).toBe("Send cash, receive stablecoin");
+    expect(result.current.description).toBe(
+      "Transfer cash and receive stablecoins straight to your Ledger Wallet™.",
+    );
+    expect(result.current.createAccountLabel).toBe("Create an account");
+    expect(result.current.logInLabel).toBe("Log in to Noah");
+    expect(result.current.providedBy).toBe("Provided by Noah");
+    expect(result.current.rows).toEqual([
+      {
+        icon: "Bank",
+        title: "Receive transfers from any bank",
+        description: "Get salary, payments, deposits via SEPA or ACH.",
+      },
+      {
+        icon: "Coins",
+        title: "No hidden fees",
+        description: "Direct from bank to blockchain for 0.25% fees.",
+      },
+      {
+        icon: "Chart5",
+        title: "Put your money to work right away",
+        description: "You can swap or earn with your stablecoin.",
+      },
+    ]);
   });
 
   it("tracks the cash-to-stable page when shown", () => {
@@ -58,6 +66,20 @@ describe("useBankTransferIntroViewModel", () => {
       page: "cash to stable",
     });
     expect(props.onBankTransfer).toHaveBeenCalledWith("createAccount");
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("tracks log in, emits onBankTransfer, then closes", () => {
+    const { props, result } = setup();
+
+    result.current.onLogInPress();
+
+    expect(props.onTrackEvent).toHaveBeenCalledWith("button_clicked", {
+      button: "log in to noah",
+      flow: "C2S",
+      page: "cash to stable",
+    });
+    expect(props.onBankTransfer).toHaveBeenCalledWith("logIn");
     expect(props.onClose).toHaveBeenCalledTimes(1);
   });
 
@@ -87,6 +109,6 @@ describe("useBankTransferIntroViewModel", () => {
 
     expect(() => result.current.onShown()).not.toThrow();
     expect(() => result.current.onCreateAccountPress()).not.toThrow();
-    expect(props.onBankTransfer).toHaveBeenCalledTimes(1);
+    expect(props.onBankTransfer).toHaveBeenCalledWith("createAccount");
   });
 });

--- a/features/flow/pay-bank-transfer/src/components/BankTransferIntro/useBankTransferIntroAdapter.ts
+++ b/features/flow/pay-bank-transfer/src/components/BankTransferIntro/useBankTransferIntroAdapter.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 import type {
-  BankTransferIntroLabels,
+  BankTransferHandoff,
   BankTransferIntroProps,
   BankTransferIntroViewModel,
   PayCardTrackEvent,
@@ -8,10 +8,9 @@ import type {
 import { useBankTransferIntroViewModel } from "./useBankTransferIntroViewModel";
 
 export type UseBankTransferIntroAdapterParams = Readonly<{
-  labels: BankTransferIntroLabels;
   heroImage?: BankTransferIntroProps["heroImage"];
   bottomInset?: number;
-  onBankTransfer: BankTransferIntroProps["onBankTransfer"];
+  onBankTransfer: (handoff: BankTransferHandoff) => void;
   onTrackEvent?: PayCardTrackEvent;
 }>;
 
@@ -22,7 +21,6 @@ export type UseBankTransferIntroAdapter = Readonly<{
   BankTransferIntroViewModel;
 
 export function useBankTransferIntroAdapter({
-  labels,
   heroImage,
   bottomInset,
   onBankTransfer,
@@ -35,7 +33,6 @@ export function useBankTransferIntroAdapter({
 
   const bankTransferIntro: BankTransferIntroProps = {
     isOpen,
-    labels,
     heroImage,
     bottomInset,
     onBankTransfer,

--- a/features/flow/pay-bank-transfer/src/components/BankTransferIntro/useBankTransferIntroViewModel.ts
+++ b/features/flow/pay-bank-transfer/src/components/BankTransferIntro/useBankTransferIntroViewModel.ts
@@ -1,13 +1,23 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
+import { useTranslation } from "@shared/i18n";
 import type {
   BankTransferHandoff,
   BankTransferIntroProps,
+  BankTransferIntroRowIcon,
   BankTransferIntroViewModel,
 } from "../../types";
 
 export const BANK_TRANSFER_INTRO_PAGE_EVENT = "Page cash to stable";
 export const BANK_TRANSFER_INTRO_PAGE = "cash to stable";
 export const BANK_TRANSFER_INTRO_FLOW = "C2S";
+
+const KEY_PREFIX = "payTab.bankTransferIntro";
+
+const ROWS: readonly { icon: BankTransferIntroRowIcon; key: string }[] = [
+  { icon: "Bank", key: "bank" },
+  { icon: "Coins", key: "fees" },
+  { icon: "Chart5", key: "earn" },
+];
 
 const TRACK_BUTTON = {
   createAccount: "create an account",
@@ -17,13 +27,14 @@ const TRACK_BUTTON = {
 
 export function useBankTransferIntroViewModel({
   isOpen,
-  labels,
   heroImage,
   bottomInset = 0,
   onBankTransfer,
   onClose,
   onTrackEvent,
 }: BankTransferIntroProps): BankTransferIntroViewModel {
+  const { t } = useTranslation();
+
   const onShown = useCallback(() => {
     onTrackEvent?.(BANK_TRANSFER_INTRO_PAGE_EVENT, { flow: BANK_TRANSFER_INTRO_FLOW });
   }, [onTrackEvent]);
@@ -65,15 +76,25 @@ export function useBankTransferIntroViewModel({
     onClose();
   }, [onClose]);
 
+  const rows = useMemo(
+    () =>
+      ROWS.map(({ icon, key }) => ({
+        icon,
+        title: t(`${KEY_PREFIX}.rows.${key}.title`),
+        description: t(`${KEY_PREFIX}.rows.${key}.description`),
+      })),
+    [t],
+  );
+
   return {
     isOpen,
-    title: labels.title,
-    description: labels.description,
-    createAccountLabel: labels.createAccountLabel,
-    logInLabel: labels.logInLabel,
-    providedBy: labels.providedBy,
+    title: t(`${KEY_PREFIX}.title`),
+    description: t(`${KEY_PREFIX}.description`),
+    createAccountLabel: t(`${KEY_PREFIX}.createAccount`),
+    logInLabel: t(`${KEY_PREFIX}.logIn`),
+    providedBy: t(`${KEY_PREFIX}.providedBy`),
     heroImage,
-    rows: labels.rows,
+    rows,
     bottomInset,
     onShown,
     onCreateAccountPress,

--- a/features/flow/pay-bank-transfer/src/types.ts
+++ b/features/flow/pay-bank-transfer/src/types.ts
@@ -12,18 +12,13 @@ export type BankTransferHandoff = "createAccount" | "logIn";
 
 export type BankTransferIntroHeroImage = number | { readonly uri: string };
 
-export type BankTransferIntroLabels = Readonly<{
-  title: string;
-  description: string;
-  createAccountLabel: string;
-  logInLabel: string;
-  providedBy: string;
-  rows: readonly BankTransferIntroRow[];
-}>;
-
+/**
+ * Copy is resolved inside this package through `@shared/i18n`; the host only injects
+ * analytics, open state, and partner handoff. Keys live under `payTab.bankTransferIntro.*`
+ * in each app's default namespace.
+ */
 export type BankTransferIntroProps = Readonly<{
   isOpen: boolean;
-  labels: BankTransferIntroLabels;
   /** Host-bundled image source. Re.pack only resolves assets required from the app. */
   heroImage?: BankTransferIntroHeroImage;
   bottomInset?: number;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6609,6 +6609,9 @@ importers:
 
   features/flow/pay-bank-transfer:
     dependencies:
+      '@shared/i18n':
+        specifier: workspace:*
+        version: link:../../../shared/i18n
       '@shared/ui-queued-bottom-sheet':
         specifier: workspace:*
         version: link:../../../shared/ui-queued-bottom-sheet


### PR DESCRIPTION
### 📝 Description

Bank-transfer intro copy was props-drilled from both apps: each host built `BankTransferIntroLabels` and passed it through `useBankTransferIntroAdapter`.

This PR moves copy resolution into `@features/flow-pay-bank-transfer`, following the `@features/flow-pay-feature-tour` pilot. The view-model calls `useTranslation()` from `@shared/i18n` and resolves `payTab.bankTransferIntro.*`. Hosts inject handoff, analytics, and the mobile hero only.

- `useBankTransferIntroViewModel` builds title, description, rows, and CTAs from `t(...)`
- `BankTransferIntroLabels` is removed from the public contract
- Desktop and mobile `usePayTabDepositOptions` stop building and passing intro copy

```tsx
const { open: openBankTransferIntro, bankTransferIntro } = useBankTransferIntroAdapter({
  onBankTransfer,
  onTrackEvent: track,
});
```

No locale JSON changes: the keys already exist at the same path in both apps (`app` on Desktop, `common` on Mobile). Tests wrap in `I18nTestProvider` from `@shared/i18n/testing`.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35383](https://ledgerhq.atlassian.net/browse/LIVE-35383)
- **Stacked on**: #21298

### 🧪 How to test

- [ ] Open Bank transfer from Pay deposit on desktop — copy matches `payTab.bankTransferIntro.*`
- [ ] Same on mobile
- [ ] Create an account / Log in to Noah still hand off

[LIVE-35383]: https://ledgerhq.atlassian.net/browse/LIVE-35383