### PR TITLE
[LWM] feat(contacts): device intents in send flow add address (LIVE-36782)

### DIFF
--- a/.changeset/contacts-wire-device-intents-remaining-flows.md
+++ b/.changeset/contacts-wire-device-intents-remaining-flows.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Wire the contacts device intents in the remaining add address flows: adding an external address from the new send flow now goes through the Device Intent Executor instead of the mocked device intents port

--- a/.changeset/contacts-wire-device-intents-remaining-flows.md
+++ b/.changeset/contacts-wire-device-intents-remaining-flows.md
@@ -2,4 +2,4 @@
 "live-mobile": minor
 ---
 
-Wire the contacts device intents in the remaining add address flows: adding an external address from the new send flow now goes through the Device Intent Executor instead of the mocked device intents port
+Wire the contacts device intents in the remaining add address flows: adding an external address from the new send flow now goes through the Device Intent Executor instead of the mocked device intents port. The calling drawer closes so the executor can take the queue, and the add address flow closes as it hands the review over to the device

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
@@ -127,7 +127,6 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
     updateAddressLabel,
     confirmAddress,
     continueFromName,
-    completeMockConfirmation,
     goBack: goBackAddAddress,
     close: closeAddAddress,
   } = useAddAddressFlowViewModel({
@@ -149,6 +148,12 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
     }
 
     hasCompletedMockConfirmation.current = true;
+
+    /**
+     * The Device Intent Executor owns the review from here, so this flow has nothing left
+     * to show. `addAddressFlowState` below is this render's snapshot, unaffected by closing.
+     */
+    closeAddAddress();
 
     try {
       const signedAddress = await deviceIntents.registerExternalAddress({
@@ -172,8 +177,6 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
           deviceCredentials: signedAddress.deviceCredentials,
         }),
       );
-      completeMockConfirmation();
-      closeAddAddress();
 
       try {
         const { network, asset } = await resolveContactsCurrencyAnalytics(
@@ -196,17 +199,8 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
     } catch (error) {
       hasCompletedMockConfirmation.current = false;
       console.warn("Failed to complete add-address confirmation", error);
-      closeAddAddress();
     }
-  }, [
-    addAddressFlowState,
-    analytics,
-    closeAddAddress,
-    completeMockConfirmation,
-    contact,
-    deviceIntents,
-    dispatch,
-  ]);
+  }, [addAddressFlowState, analytics, closeAddAddress, contact, deviceIntents, dispatch]);
   useEffect(() => {
     void completeMockAddressConfirmation();
   }, [completeMockAddressConfirmation]);

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
@@ -88,7 +88,7 @@ type NavigationProp = BaseNavigationComposite<
 
 export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel {
   const dispatch = useDispatch();
-  const hasCompletedMockConfirmation = useRef(false);
+  const hasCompletedConfirmation = useRef(false);
   const trackedContactDetailId = useRef<string | undefined>(undefined);
   const trackedAddressDetailId = useRef<string | undefined>(undefined);
   const analytics = useContactsAnalytics();
@@ -133,13 +133,13 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
     addressValidation,
     manualValidationDebounceMs: MANUAL_ADDRESS_VALIDATION_DEBOUNCE_MS,
   });
-  const completeMockAddressConfirmation = useCallback(async () => {
+  const completeAddressConfirmation = useCallback(async () => {
     if (addAddressFlowState.status !== "confirmationRequired") {
-      hasCompletedMockConfirmation.current = false;
+      hasCompletedConfirmation.current = false;
       return;
     }
 
-    if (hasCompletedMockConfirmation.current) {
+    if (hasCompletedConfirmation.current) {
       return;
     }
 
@@ -147,7 +147,7 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
       return;
     }
 
-    hasCompletedMockConfirmation.current = true;
+    hasCompletedConfirmation.current = true;
 
     /**
      * The Device Intent Executor owns the review from here, so this flow has nothing left
@@ -197,13 +197,13 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
         // Analytics enrichment is best-effort and must not affect the user flow.
       }
     } catch (error) {
-      hasCompletedMockConfirmation.current = false;
+      hasCompletedConfirmation.current = false;
       console.warn("Failed to complete add-address confirmation", error);
     }
   }, [addAddressFlowState, analytics, closeAddAddress, contact, deviceIntents, dispatch]);
   useEffect(() => {
-    void completeMockAddressConfirmation();
-  }, [completeMockAddressConfirmation]);
+    void completeAddressConfirmation();
+  }, [completeAddressConfirmation]);
   const startAddAddressForContact = useCallback(() => {
     if (!contact || eligibleNetworkIds.length === 0) return;
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendPrefillAddAddressFlow.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendPrefillAddAddressFlow.ts
@@ -1,13 +1,18 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { v4 as uuid } from "uuid";
 import { addAddress, contactAddress, type Contact } from "@domain/entity-contact";
 import { resolvePrefillAddAddressParams } from "@ledgerhq/live-common/flows/send/recipient/utils/resolvePrefillAddAddressParams";
-import { createMockContactDeviceIntentsPort } from "@features/platform-contacts";
+import {
+  useContactsIntentsOrchestrator,
+  type ContactsDeviceIntentExecutorProps,
+} from "@features/platform-contacts/device";
+import { getMinVersion } from "@ledgerhq/live-common/apps/support";
 import {
   isPrefillAddAddressFlowOpen,
   useAddAddressFlowViewModel,
   type PrefillAddAddressFlowVisibleState,
 } from "@features/flow-contacts-add-address";
+import { contactsIntentLWMDefinitions } from "LLM/features/Contacts/deviceIntents/contactsIntentPlatformDefinitions";
 import { useContactsAddressValidationAdapter } from "LLM/features/Contacts/hooks/useContactsAddressValidationAdapter";
 import { useSendFlowData } from "LLM/features/Send/context/SendFlowContext";
 import { useDispatch } from "~/context/hooks";
@@ -21,6 +26,7 @@ export type SendPrefillAddAddressPhase = Readonly<{
 
 export type SendPrefillAddAddressFlow = Readonly<{
   addressPhase: SendPrefillAddAddressPhase | null;
+  dieProps: ContactsDeviceIntentExecutorProps | undefined;
   isOpeningAddressFlow: boolean;
   startForContact: (contact: Contact) => Promise<void>;
   goBackFromAddressPhase: () => void;
@@ -41,7 +47,10 @@ export function useSendPrefillAddAddressFlow({
   const saveRequestId = useRef(0);
   const isSaving = useRef(false);
   const addressValidation = useContactsAddressValidationAdapter();
-  const deviceIntents = useMemo(() => createMockContactDeviceIntentsPort(), []);
+  const { deviceIntents, dieProps } = useContactsIntentsOrchestrator({
+    intents: contactsIntentLWMDefinitions,
+    getLiveConfigMinVersion: getMinVersion,
+  });
   const {
     state: addressFlowState,
     startWithPrefilled,
@@ -166,6 +175,7 @@ export function useSendPrefillAddAddressFlow({
 
   return {
     addressPhase,
+    dieProps,
     isOpeningAddressFlow,
     startForContact,
     goBackFromAddressPhase,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendPrefillAddAddressFlow.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendPrefillAddAddressFlow.ts
@@ -66,11 +66,15 @@ export function useSendPrefillAddAddressFlow({
     isSaving.current = false;
   }, []);
 
+  /**
+   * Closing does not cancel a registration already handed to the device: the drawer also
+   * closes to free the queue for the executor, and the signed address must still be saved.
+   * Cancelling on the device rejects the intent, which the save path already handles.
+   */
   const closeAddressFlow = useCallback(() => {
-    cancelPendingSave();
     setIsOpeningAddressFlow(false);
     close();
-  }, [cancelPendingSave, close]);
+  }, [close]);
 
   const goBackFromAddressPhase = useCallback(() => {
     cancelPendingSave();

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/AddNewContact/AddNewContactView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/AddNewContact/AddNewContactView.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { BottomSheetHeader, BottomSheetView, Box } from "@ledgerhq/lumen-ui-rnative";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { DeviceIntentExecutorLWM } from "LLM/components/DeviceIntentExecutor";
 import {
   QueuedDrawerFlow,
   type QueuedDrawerFlowOptions,
@@ -80,6 +81,7 @@ function AddContactChooserStep({
 
 export function AddNewContactView({
   addressPhase,
+  dieProps,
   isOpeningAddressFlow,
   keyboardBottomOffset,
   drawerStep,
@@ -193,6 +195,9 @@ export function AddNewContactView({
         isOpen={isActivationDrawerVisible}
         handleClose={closeActivationDrawer}
       />
+      {dieProps === undefined ? null : (
+        <DeviceIntentExecutorLWM sourceFlow="contacts" {...dieProps} />
+      )}
     </>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/AddNewContact/hooks/__tests__/useAddNewContactViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/AddNewContact/hooks/__tests__/useAddNewContactViewModel.test.ts
@@ -32,9 +32,11 @@ jest.mock("~/context/hooks", () => ({
   useDispatch: () => dispatch,
 }));
 
-jest.mock("@features/platform-contacts", () => ({
-  ...jest.requireActual("@features/platform-contacts"),
-  createMockContactDeviceIntentsPort: () => ({ registerExternalAddress }),
+jest.mock("@features/platform-contacts/device", () => ({
+  useContactsIntentsOrchestrator: () => ({
+    deviceIntents: { registerExternalAddress },
+    dieProps: undefined,
+  }),
 }));
 
 jest.mock(

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/AddNewContact/hooks/__tests__/useAddNewContactViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/AddNewContact/hooks/__tests__/useAddNewContactViewModel.test.ts
@@ -32,10 +32,12 @@ jest.mock("~/context/hooks", () => ({
   useDispatch: () => dispatch,
 }));
 
+let mockDieProps: { enabled: boolean } | undefined;
+
 jest.mock("@features/platform-contacts/device", () => ({
   useContactsIntentsOrchestrator: () => ({
     deviceIntents: { registerExternalAddress },
-    dieProps: undefined,
+    dieProps: mockDieProps,
   }),
 }));
 
@@ -104,6 +106,7 @@ describe("useAddNewContactViewModel", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockDieProps = undefined;
     registerExternalAddress.mockResolvedValue(signedAddress);
     mockedUseContactsAddContactDrawerAdapter.mockReturnValue(adapterResult as never);
     mockedUseContactsAddressValidationAdapter.mockReturnValue({
@@ -127,6 +130,14 @@ describe("useAddNewContactViewModel", () => {
     expect(result.current.isDrawerOpen).toBe(true);
     expect(result.current.addressPhase).toBeNull();
     expect(mockedUseContactsAddContactDrawerAdapter).toHaveBeenCalled();
+  });
+
+  it("should close the drawer while the device intent executor is running", () => {
+    mockDieProps = { enabled: true };
+
+    const { result } = renderDrawer();
+
+    expect(result.current.isDrawerOpen).toBe(false);
   });
 
   it("should start the add-address flow after creating a contact", async () => {
@@ -260,6 +271,29 @@ describe("useAddNewContactViewModel", () => {
     expect(registerExternalAddress).toHaveBeenCalledTimes(1);
     expect(countAddAddressDispatches()).toBe(1);
     expect(result.current.addressPhase).toBeNull();
+  });
+
+  it("should still save the address when the drawer closes to free the queue", async () => {
+    const deferredRegistration = createDeferred<typeof signedAddress>();
+    registerExternalAddress.mockReturnValue(deferredRegistration.promise);
+
+    const { result, rerender } = await renderAtReviewStep();
+
+    act(() => result.current.addressPhase?.onContinueFromReview());
+
+    // The executor is up, so the drawer yields the queue and QueuedBottomSheet reports the
+    // programmatic close through onClose. That must not cancel the pending save.
+    mockDieProps = { enabled: true };
+    rerender({});
+    expect(result.current.isDrawerOpen).toBe(false);
+    act(() => result.current.onDrawerClose());
+
+    await act(async () => {
+      deferredRegistration.resolve(signedAddress);
+      await deferredRegistration.promise;
+    });
+
+    expect(countAddAddressDispatches()).toBe(1);
   });
 
   it("should discard a pending registration when the user goes back", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/AddNewContact/hooks/useAddNewContactViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/AddNewContact/hooks/useAddNewContactViewModel.ts
@@ -2,6 +2,7 @@ import { useCallback, useState } from "react";
 import { Platform } from "react-native";
 import type { Contact } from "@domain/entity-contact";
 import type { AddAddressFlowState } from "@features/flow-contacts-add-address";
+import type { ContactsDeviceIntentExecutorProps } from "@features/platform-contacts/device";
 import { useContactsAddContactDrawerAdapter } from "LLM/features/Contacts/screens/ContactsPage/hooks/useContactsAddContactDrawerAdapter";
 import {
   useSendPrefillAddAddressFlow,
@@ -20,6 +21,7 @@ type AddContactDrawerOrigin = "chooser" | "contact" | "select";
 export type AddNewContactViewModel = ReturnType<typeof useContactsAddContactDrawerAdapter> &
   Readonly<{
     addressPhase: AddNewContactAddressPhase | null;
+    dieProps: ContactsDeviceIntentExecutorProps | undefined;
     isOpeningAddressFlow: boolean;
     keyboardBottomOffset: number;
     drawerStep: AddContactDrawerStep;
@@ -88,6 +90,7 @@ export function useAddNewContactViewModel(): AddNewContactViewModel {
   }, []);
   const {
     addressPhase,
+    dieProps,
     isOpeningAddressFlow,
     startForContact,
     goBackFromAddressPhase,
@@ -145,6 +148,7 @@ export function useAddNewContactViewModel(): AddNewContactViewModel {
     onOpen,
     onClose: closeDrawer,
     addressPhase,
+    dieProps,
     isOpeningAddressFlow,
     keyboardBottomOffset,
     drawerStep,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/AddNewContact/hooks/useAddNewContactViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/AddNewContact/hooks/useAddNewContactViewModel.ts
@@ -135,7 +135,13 @@ export function useAddNewContactViewModel(): AddNewContactViewModel {
   }, [closeAddressFlow, closeContactStep, resetSearch]);
 
   const drawerStep = resolveDrawerStep(drawerOrigin, addressPhase?.state.status ?? "closed");
-  const isDrawerOpen = drawerOrigin !== null || isOpeningAddressFlow || addressPhase !== null;
+  /**
+   * The Device Intent Executor is a queued drawer too: this one has to give up its slot
+   * while the intent runs, or the executor waits in the queue behind it and never shows.
+   */
+  const isDrawerOpen =
+    dieProps?.enabled !== true &&
+    (drawerOrigin !== null || isOpeningAddressFlow || addressPhase !== null);
   const onDrawerBack = resolveOnDrawerBack(drawerStep, drawerOrigin, {
     goBackFromAddressPhase,
     closeDrawer,


### PR DESCRIPTION
### 📝 Description

**Problem**

The contacts device intents are wired in the contact detail screen, but the add address steps of the new send flow still went through `createMockContactDeviceIntentsPort()`, so they never talked to a device: *add contact* and *add to existing contact*.

`PrefillAddAddressFlowRoot` is deliberately left untouched. It looked like a third entry point, but it's dead code that will be dropped later.

Swapping the port was not enough to make them work, and the two follow-up bugs are the substance of this PR:

- The Device Intent Executor is itself a `QueuedBottomSheet`. The drawer calling it kept the queue, so the executor waited behind it and never opened — pressing **Confirm on device** appeared to do nothing.
- `QueuedBottomSheet` reports every close through `onClose`, programmatic ones included. Once the drawer closed to free the queue, that was read as the user cancelling, which discarded the signed address after a successful device approval.

**Solution**

Both steps now build their port from `useContactsIntentsOrchestrator` and render the Device Intent Executor, the way the contact detail screen already did.

The send flow add contact drawer gives up its queue slot while an intent runs, and closing no longer cancels a registration already handed to the device — going back *before* the hand-off still cancels. On the contacts screen the add address flow now closes as it hands the review over, instead of lingering behind the executor until the intent resolves.

**Desktop is deliberately out of scope.** https://github.com/LedgerHQ/ledger-live/pull/21403

### ✅ Tests

Three send flow view-model specs mocked `createMockContactDeviceIntentsPort`, which the orchestrator's app-level mock calls while its module initializes — that ordering made the spy throw, so they now mock `useContactsIntentsOrchestrator` itself.

Two regression tests were added for the bugs above, both verified to fail without their fix:

- `should close the drawer while the device intent executor is running`
- `should still save the address when the drawer closes to free the queue`

The existing integration specs did not catch either bug: they assert on what the queue ended up rendering, and the mocked intent resolves instantly, so the pending window never exists in a test. The new tests assert the view model's intent directly instead.

Locally green: mobile Send (327), mobile Contacts (155) — 63 suites, 484 tests. Mobile typecheck passes (4516 files). oxfmt clean; oxlint exits 0 — the warnings it reports in the touched files are pre-existing on `develop` and fall outside this diff's hunks.

### 🔍 QA

**Feature flags**:
- `newSendFlow` needs its params, not just the toggle: `{"enabled": true, "params": {"families": ["evm"]}}`. An empty `families` array silently falls back to the old send flow.
- `lwmContacts` enabled, on an Ethereum account.

**Launch it** — launch a send flow with Ethereum and an address that isn't already in your Contacts.

From there: **Add to contacts** (or **add to an existing contact**) → name it → the review step is the one this PR sends to the device.

**Then check**

- Adding an address to a contact in the new send flow asks for a real device approval, and the executor actually appears — the calling drawer gets out of its way.
- Approving saves the address and returns to the recipient step with the contact now matching it.
- Rejecting or cancelling on the device saves nothing and leaves the executor's own error screen up, with the calling flow closed behind it.
- Same on the contacts screen: contact detail → **Add address** → the executor opens on its own, not behind the drawer.


https://github.com/user-attachments/assets/9e0282e2-14d5-41b5-8374-35ed63543ada



### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36782](https://ledgerhq.atlassian.net/browse/LIVE-36782)
- **Related**: #21352 skips the in-app "Review address" / "Address saved" placeholders. That is a separate change and is deliberately **not** part of this PR — this one only swaps the mocked port for the real orchestrator and leaves those screens as they are on `develop`.
- **Follow-up**: `feat/contacts-device-owned-address-review-desktop` carries the desktop half; it needs the send flow dialog lift before it can land.
- **ADR** (if any): n/a



[LIVE-36782]: https://ledgerhq.atlassian.net/browse/LIVE-36782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

