### PR TITLE
refactor(pay-deposit): resolve copy via @shared/i18n (LIVE-36747)

### DIFF
--- a/.changeset/tidy-deposits-translate.md
+++ b/.changeset/tidy-deposits-translate.md
@@ -1,0 +1,7 @@
+---
+"@features/flow-pay-deposit": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Resolve Pay deposit-options copy inside `@features/flow-pay-deposit` through `@shared/i18n` instead of receiving translated strings as props. The deposit options view-model now calls `useTranslation()` for its `payTab.deposit.*` keys, so both apps stop building `DepositOptionsLabels` and passing them to `useDepositOptionsAdapter`.

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayTabDepositOptions.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayTabDepositOptions.test.tsx
@@ -36,16 +36,10 @@ describe("usePayTabDepositOptions", () => {
     });
   });
 
-  it("builds i18n labels for the title and the four options", () => {
+  it("exposes the deposit page to the feature", () => {
     const { result } = render();
 
-    const { labels, page } = result.current.depositOptions;
-    expect(page).toBe("Pay");
-    expect(labels.title).toBeTruthy();
-    (["bankTransfer", "swap", "receive", "buy"] as const).forEach(id => {
-      expect(labels.options[id].title).toBeTruthy();
-      expect(labels.options[id].description).toBeTruthy();
-    });
+    expect(result.current.depositOptions.page).toBe("Pay");
   });
 
   it("passes the host tracking callback through", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabDepositOptions.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabDepositOptions.ts
@@ -1,12 +1,10 @@
 import { useCallback } from "react";
-import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
 import { ModularDrawerLocation } from "@ledgerhq/live-common/modularDrawer/enums";
 import { AssetCategory } from "@domain/api-aggregated-assets";
 import {
   useDepositOptionsAdapter,
   type DepositOptionId,
-  type DepositOptionsLabels,
   type PayCardTrackEvent,
   type UseDepositOptionsAdapter,
 } from "@features/flow-pay-deposit";
@@ -21,7 +19,6 @@ export type UsePayTabDepositOptions = UseDepositOptionsAdapter;
 export function usePayTabDepositOptions(
   onTrackEvent: PayCardTrackEvent | undefined,
 ): UsePayTabDepositOptions {
-  const { t } = useTranslation();
   const navigate = useNavigate();
 
   const { openAssetFlow } = useOpenAssetFlow(
@@ -51,27 +48,5 @@ export function usePayTabDepositOptions(
     [navigate, openAssetFlow],
   );
 
-  const labels: DepositOptionsLabels = {
-    title: t("payTab.deposit.title"),
-    options: {
-      bankTransfer: {
-        title: t("payTab.deposit.options.bankTransfer.title"),
-        description: t("payTab.deposit.options.bankTransfer.description"),
-      },
-      swap: {
-        title: t("payTab.deposit.options.swap.title"),
-        description: t("payTab.deposit.options.swap.description"),
-      },
-      receive: {
-        title: t("payTab.deposit.options.receive.title"),
-        description: t("payTab.deposit.options.receive.description"),
-      },
-      buy: {
-        title: t("payTab.deposit.options.buy.title"),
-        description: t("payTab.deposit.options.buy.description"),
-      },
-    },
-  };
-
-  return useDepositOptionsAdapter({ labels, page: DEPOSIT_PAGE, onSelect, onTrackEvent });
+  return useDepositOptionsAdapter({ page: DEPOSIT_PAGE, onSelect, onTrackEvent });
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/__tests__/usePayTabDepositOptions.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/__tests__/usePayTabDepositOptions.test.tsx
@@ -37,16 +37,10 @@ describe("usePayTabDepositOptions", () => {
     jest.clearAllMocks();
   });
 
-  it("builds i18n labels for the title and the four options", () => {
+  it("exposes the deposit page to the feature", () => {
     const { result } = render();
 
-    const { labels, page } = result.current.depositOptions;
-    expect(page).toBe("Pay");
-    expect(labels.title).toBeTruthy();
-    (["bankTransfer", "swap", "receive", "buy"] as const).forEach(id => {
-      expect(labels.options[id].title).toBeTruthy();
-      expect(labels.options[id].description).toBeTruthy();
-    });
+    expect(result.current.depositOptions.page).toBe("Pay");
   });
 
   it("passes the host tracking callback through", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabDepositOptions.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabDepositOptions.ts
@@ -5,11 +5,9 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import {
   useDepositOptionsAdapter,
   type DepositOptionId,
-  type DepositOptionsLabels,
   type PayCardTrackEvent,
   type UseDepositOptionsAdapter,
 } from "@features/flow-pay-deposit";
-import { useTranslation } from "~/context/Locale";
 import { NavigatorName, ScreenName } from "~/const";
 import { useOpenReceiveDrawer } from "LLM/features/Receive";
 import { useOpenSwap } from "LLM/features/Swap";
@@ -25,7 +23,6 @@ export type UsePayTabDepositOptions = UseDepositOptionsAdapter;
 export function usePayTabDepositOptions(
   onTrackEvent: PayCardTrackEvent | undefined,
 ): UsePayTabDepositOptions {
-  const { t } = useTranslation();
   const navigation = useNavigation();
   const { bottom: bottomInset } = useSafeAreaInsets();
 
@@ -60,30 +57,7 @@ export function usePayTabDepositOptions(
     [navigation, handleOpenSwap, handleOpenBuySell, handleOpenReceiveDrawer],
   );
 
-  const labels: DepositOptionsLabels = {
-    title: t("payTab.deposit.title"),
-    options: {
-      bankTransfer: {
-        title: t("payTab.deposit.options.bankTransfer.title"),
-        description: t("payTab.deposit.options.bankTransfer.description"),
-      },
-      swap: {
-        title: t("payTab.deposit.options.swap.title"),
-        description: t("payTab.deposit.options.swap.description"),
-      },
-      receive: {
-        title: t("payTab.deposit.options.receive.title"),
-        description: t("payTab.deposit.options.receive.description"),
-      },
-      buy: {
-        title: t("payTab.deposit.options.buy.title"),
-        description: t("payTab.deposit.options.buy.description"),
-      },
-    },
-  };
-
   const { open, depositOptions } = useDepositOptionsAdapter({
-    labels,
     page: DEPOSIT_PAGE,
     onSelect,
     onTrackEvent,

--- a/features/flow/pay-deposit/README.md
+++ b/features/flow/pay-deposit/README.md
@@ -15,15 +15,6 @@ import { DepositOptions } from "@features/flow-pay-deposit";
 <DepositOptions
   isOpen={isDepositOpen}
   page="Pay"
-  labels={{
-    title: t("payTab.deposit.title"),
-    options: {
-      bankTransfer: { title: t("..."), description: t("...") },
-      swap: { title: t("..."), description: t("...") },
-      receive: { title: t("..."), description: t("...") },
-      buy: { title: t("..."), description: t("...") },
-    },
-  }}
   onClose={closeDeposit}
   onSelect={handleDepositOption}
   onTrackEvent={track}
@@ -32,8 +23,9 @@ import { DepositOptions } from "@features/flow-pay-deposit";
 
 The overlay is opened by the host (the Pay tab Deposit / "add stablecoins" action tile) via a local
 `isOpen` boolean. The view stays props-only: it emits `onSelect(id)` and the host owns navigation
-(Swap tab, Receive filtered to stablecoins, Buy live app, Bank transfer flow). i18n and analytics
-resolution stay in the app; this package stays i18n-agnostic.
+(Swap tab, Receive filtered to stablecoins, Buy live app, Bank transfer flow). Copy is resolved
+inside the feature through `@shared/i18n` (`payTab.deposit.*`); the host injects navigation and
+analytics only.
 
 ### Tracking
 

--- a/features/flow/pay-deposit/package.json
+++ b/features/flow/pay-deposit/package.json
@@ -28,6 +28,7 @@
     "unimported": "pnpm knip --directory ../../.. -W features/flow/pay-deposit"
   },
   "dependencies": {
+    "@shared/i18n": "workspace:*",
     "@shared/ui-queued-bottom-sheet": "workspace:*"
   },
   "devDependencies": {

--- a/features/flow/pay-deposit/src/components/DepositOptions/DepositOptions.tsx
+++ b/features/flow/pay-deposit/src/components/DepositOptions/DepositOptions.tsx
@@ -4,12 +4,12 @@ import type { DepositOptionsProps } from "../../types";
 import { useDepositOptionsViewModel } from "./useDepositOptionsViewModel";
 
 export function DepositOptions(props: DepositOptionsProps) {
-  const { options, onSelectOption } = useDepositOptionsViewModel(props);
+  const { title, options, onSelectOption } = useDepositOptionsViewModel(props);
 
   return (
     <DepositOptionsView
       isOpen={props.isOpen}
-      title={props.labels.title}
+      title={title}
       options={options}
       bottomInset={props.bottomInset}
       onClose={props.onClose}

--- a/features/flow/pay-deposit/src/components/DepositOptions/__tests__/DepositOptions.web.test.tsx
+++ b/features/flow/pay-deposit/src/components/DepositOptions/__tests__/DepositOptions.web.test.tsx
@@ -3,28 +3,21 @@ import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { DepositOptions } from "../DepositOptions";
 import type { DepositOptionsProps } from "../../../types";
-
-const LABELS: DepositOptionsProps["labels"] = {
-  title: "Deposit stablecoin",
-  options: {
-    bankTransfer: { title: "Bank transfer", description: "From your bank account" },
-    swap: { title: "Swap", description: "From your crypto" },
-    receive: { title: "Receive", description: "From another wallet" },
-    buy: { title: "Buy", description: "With card or bank" },
-  },
-};
+import { DEPOSIT_RESOURCES, i18nWrapper } from "./i18nWrapper";
 
 function renderDeposit(overrides: Partial<DepositOptionsProps> = {}) {
   const props: DepositOptionsProps = {
     isOpen: true,
-    labels: LABELS,
     page: "Pay",
     onClose: jest.fn(),
     onSelect: jest.fn(),
     onTrackEvent: jest.fn(),
     ...overrides,
   };
-  return { props, ...render(<DepositOptions {...props} />) };
+  return {
+    props,
+    ...render(<DepositOptions {...props} />, { wrapper: i18nWrapper(DEPOSIT_RESOURCES) }),
+  };
 }
 
 describe("DepositOptions (Web)", () => {

--- a/features/flow/pay-deposit/src/components/DepositOptions/__tests__/i18nWrapper.tsx
+++ b/features/flow/pay-deposit/src/components/DepositOptions/__tests__/i18nWrapper.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { I18nTestProvider } from "@shared/i18n/testing";
+
+type Resources = React.ComponentProps<typeof I18nTestProvider>["resources"];
+
+/**
+ * A `renderHook` / `render` wrapper that mounts the shared i18n test provider. With no `resources`
+ * every key resolves to itself; pass `resources` to assert copy comes from the provider.
+ */
+export function i18nWrapper(resources?: Resources) {
+  return function I18nWrapper({ children }: { children: React.ReactNode }) {
+    return <I18nTestProvider resources={resources}>{children}</I18nTestProvider>;
+  };
+}
+
+/** The `payTab.deposit.*` copy each app ships, mirrored for the deposit-options tests. */
+export const DEPOSIT_RESOURCES = {
+  en: {
+    translation: {
+      payTab: {
+        deposit: {
+          title: "Deposit stablecoin",
+          options: {
+            bankTransfer: { title: "Bank transfer", description: "From your bank account" },
+            swap: { title: "Swap", description: "From your crypto" },
+            receive: { title: "Receive", description: "From another wallet" },
+            buy: { title: "Buy", description: "With card or bank" },
+          },
+        },
+      },
+    },
+  },
+};

--- a/features/flow/pay-deposit/src/components/DepositOptions/__tests__/useDepositOptionsAdapter.web.test.ts
+++ b/features/flow/pay-deposit/src/components/DepositOptions/__tests__/useDepositOptionsAdapter.web.test.ts
@@ -1,21 +1,10 @@
 import { act, renderHook } from "@testing-library/react";
-import type { DepositOptionsLabels } from "../../../types";
 import { useDepositOptionsAdapter } from "../useDepositOptionsAdapter";
-
-const labels: DepositOptionsLabels = {
-  title: "Add stablecoins",
-  options: {
-    bankTransfer: { title: "Bank transfer", description: "Transfer USD or EUR." },
-    swap: { title: "Swap from crypto", description: "Swap your crypto." },
-    receive: { title: "Crypto address", description: "Receive from another wallet." },
-    buy: { title: "Buy", description: "Buy with credit card." },
-  },
-};
 
 describe("useDepositOptionsAdapter", () => {
   it("starts closed and toggles isOpen via open and onClose", () => {
     const { result } = renderHook(() =>
-      useDepositOptionsAdapter({ labels, page: "Pay", onSelect: jest.fn() }),
+      useDepositOptionsAdapter({ page: "Pay", onSelect: jest.fn() }),
     );
 
     expect(result.current.depositOptions.isOpen).toBe(false);
@@ -27,17 +16,16 @@ describe("useDepositOptionsAdapter", () => {
     expect(result.current.depositOptions.isOpen).toBe(false);
   });
 
-  it("passes page, labels, onSelect and onTrackEvent through into depositOptions", () => {
+  it("passes page, onSelect and onTrackEvent through into depositOptions", () => {
     const onSelect = jest.fn();
     const onTrackEvent = jest.fn();
 
     const { result } = renderHook(() =>
-      useDepositOptionsAdapter({ labels, page: "Pay", onSelect, onTrackEvent }),
+      useDepositOptionsAdapter({ page: "Pay", onSelect, onTrackEvent }),
     );
 
     const { depositOptions } = result.current;
     expect(depositOptions.page).toBe("Pay");
-    expect(depositOptions.labels).toBe(labels);
     expect(depositOptions.onSelect).toBe(onSelect);
     expect(depositOptions.onTrackEvent).toBe(onTrackEvent);
   });

--- a/features/flow/pay-deposit/src/components/DepositOptions/__tests__/useDepositOptionsViewModel.web.test.ts
+++ b/features/flow/pay-deposit/src/components/DepositOptions/__tests__/useDepositOptionsViewModel.web.test.ts
@@ -1,28 +1,20 @@
 import { renderHook } from "@testing-library/react";
 import { useDepositOptionsViewModel } from "../useDepositOptionsViewModel";
 import type { DepositOptionsProps } from "../../../types";
-
-const LABELS: DepositOptionsProps["labels"] = {
-  title: "Deposit stablecoin",
-  options: {
-    bankTransfer: { title: "Bank transfer", description: "From your bank account" },
-    swap: { title: "Swap", description: "From your crypto" },
-    receive: { title: "Receive", description: "From another wallet" },
-    buy: { title: "Buy", description: "With card or bank" },
-  },
-};
+import { DEPOSIT_RESOURCES, i18nWrapper } from "./i18nWrapper";
 
 function setup(overrides: Partial<DepositOptionsProps> = {}) {
   const props: DepositOptionsProps = {
     isOpen: true,
-    labels: LABELS,
     page: "Pay",
     onClose: jest.fn(),
     onSelect: jest.fn(),
     onTrackEvent: jest.fn(),
     ...overrides,
   };
-  const { result } = renderHook(() => useDepositOptionsViewModel(props));
+  const { result } = renderHook(() => useDepositOptionsViewModel(props), {
+    wrapper: i18nWrapper(DEPOSIT_RESOURCES),
+  });
   return { props, result };
 }
 
@@ -30,6 +22,7 @@ describe("useDepositOptionsViewModel", () => {
   it("builds the four options in a fixed order", () => {
     const { result } = setup();
 
+    expect(result.current.title).toBe("Deposit stablecoin");
     expect(result.current.options.map(option => option.id)).toEqual([
       "bankTransfer",
       "swap",
@@ -62,5 +55,24 @@ describe("useDepositOptionsViewModel", () => {
 
     expect(() => result.current.onSelectOption("swap")).not.toThrow();
     expect(props.onSelect).toHaveBeenCalledWith("swap");
+  });
+
+  it("resolves its copy from the mounted i18n provider, not from props", () => {
+    const { result } = renderHook(
+      () =>
+        useDepositOptionsViewModel({
+          isOpen: true,
+          page: "Pay",
+          onClose: jest.fn(),
+          onSelect: jest.fn(),
+        }),
+      {
+        wrapper: i18nWrapper({
+          en: { translation: { payTab: { deposit: { title: "Déposer" } } } },
+        }),
+      },
+    );
+
+    expect(result.current.title).toBe("Déposer");
   });
 });

--- a/features/flow/pay-deposit/src/components/DepositOptions/useDepositOptionsAdapter.ts
+++ b/features/flow/pay-deposit/src/components/DepositOptions/useDepositOptionsAdapter.ts
@@ -1,13 +1,7 @@
 import { useCallback, useState } from "react";
-import type {
-  DepositOptionId,
-  DepositOptionsLabels,
-  DepositOptionsProps,
-  PayCardTrackEvent,
-} from "../../types";
+import type { DepositOptionId, DepositOptionsProps, PayCardTrackEvent } from "../../types";
 
 export type UseDepositOptionsAdapterParams = Readonly<{
-  labels: DepositOptionsLabels;
   page: string;
   onSelect: (id: DepositOptionId) => void;
   onTrackEvent?: PayCardTrackEvent;
@@ -19,7 +13,6 @@ export type UseDepositOptionsAdapter = Readonly<{
 }>;
 
 export function useDepositOptionsAdapter({
-  labels,
   page,
   onSelect,
   onTrackEvent,
@@ -34,7 +27,6 @@ export function useDepositOptionsAdapter({
     depositOptions: {
       isOpen,
       page,
-      labels,
       onClose,
       onSelect,
       onTrackEvent,

--- a/features/flow/pay-deposit/src/components/DepositOptions/useDepositOptionsViewModel.ts
+++ b/features/flow/pay-deposit/src/components/DepositOptions/useDepositOptionsViewModel.ts
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from "react";
+import { useTranslation } from "@shared/i18n";
 import type { DepositOptionId, DepositOptionsProps, DepositOptionsViewModel } from "../../types";
 
 const OPTION_ORDER: readonly DepositOptionId[] = ["bankTransfer", "swap", "receive", "buy"];
@@ -11,13 +12,24 @@ const TRACK_BUTTON: Readonly<Record<DepositOptionId, string>> = {
 };
 
 export function useDepositOptionsViewModel({
-  labels,
   page,
   onSelect,
   onClose,
   onTrackEvent,
 }: DepositOptionsProps): DepositOptionsViewModel {
-  const options = useMemo(() => OPTION_ORDER.map(id => ({ id, ...labels.options[id] })), [labels]);
+  const { t } = useTranslation();
+
+  const title = t("payTab.deposit.title");
+
+  const options = useMemo(
+    () =>
+      OPTION_ORDER.map(id => ({
+        id,
+        title: t(`payTab.deposit.options.${id}.title`),
+        description: t(`payTab.deposit.options.${id}.description`),
+      })),
+    [t],
+  );
 
   const onSelectOption = useCallback(
     (id: DepositOptionId) => {
@@ -32,5 +44,5 @@ export function useDepositOptionsViewModel({
     [onSelect, onClose, onTrackEvent, page],
   );
 
-  return { options, onSelectOption };
+  return { title, options, onSelectOption };
 }

--- a/features/flow/pay-deposit/src/types.ts
+++ b/features/flow/pay-deposit/src/types.ts
@@ -7,18 +7,8 @@ export type DepositOptionContent = Readonly<{
   description: string;
 }>;
 
-/**
- * User-facing copy injected by the host app. This package stays i18n-agnostic: the app
- * resolves translations and passes the strings in.
- */
-export type DepositOptionsLabels = Readonly<{
-  title: string;
-  options: Readonly<Record<DepositOptionId, DepositOptionContent>>;
-}>;
-
 export type DepositOptionsProps = Readonly<{
   isOpen: boolean;
-  labels: DepositOptionsLabels;
   page: string;
   bottomInset?: number;
   onClose: () => void;
@@ -30,6 +20,7 @@ export type DepositOptionsProps = Readonly<{
 export type DepositOption = DepositOptionContent & Readonly<{ id: DepositOptionId }>;
 
 export type DepositOptionsViewModel = Readonly<{
+  title: string;
   options: readonly DepositOption[];
   onSelectOption: (id: DepositOptionId) => void;
 }>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7138,6 +7138,9 @@ importers:
 
   features/flow/pay-deposit:
     dependencies:
+      '@shared/i18n':
+        specifier: workspace:*
+        version: link:../../../shared/i18n
       '@shared/ui-queued-bottom-sheet':
         specifier: workspace:*
         version: link:../../../shared/ui-queued-bottom-sheet


### PR DESCRIPTION
### 📝 Description

Migrates i18n ownership for the `pay-deposit` feature into the feature package itself, mirroring the `pay-feature-tour` / `pay-balance` pattern. Deposit-options copy is now resolved inside the feature via `@shared/i18n` instead of being prop-drilled from the host apps.

- **Package (`@features/flow-pay-deposit`)**: adds the `@shared/i18n` dependency, resolves `title` and each option's `title`/`description` from `payTab.deposit.*` keys inside `useDepositOptionsViewModel`, and drops the `labels` plumbing from types/adapter/container.
- **Desktop & Mobile hosts**: removed the `useTranslation()` + `labels` wiring from `usePayTabDepositOptions` since the feature now owns the copy.
- **Tests & docs**: shared `i18nWrapper` + `DEPOSIT_RESOURCES` fixture, tests updated to render with i18n context, README refreshed, changeset added.

Usage after this change (host no longer passes `labels`):

\`\`\`tsx
const vm = useDepositOptionsAdapter({ /* host inputs, no labels */ });
<DepositOptions {...vm} />
\`\`\`

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36747](https://ledgerhq.atlassian.net/browse/LIVE-36747) (Epic [LIVE-33492](https://ledgerhq.atlassian.net/browse/LIVE-33492))
- **ADR** (if any): N/A

[LIVE-36747]: https://ledgerhq.atlassian.net/browse/LIVE-36747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ