### PR TITLE
[LWDM] refactor(hedera): migrate to rtk query

### DIFF
--- a/.changeset/hedera-validators-rtk-query.md
+++ b/.changeset/hedera-validators-rtk-query.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+refactor: serve the Hedera validators list from an RTK Query api instead of React Query

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/ClaimRewardsFlowModal/__integrations__/claimRewardsFlowModal.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/ClaimRewardsFlowModal/__integrations__/claimRewardsFlowModal.integ.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { act, render, screen, waitFor } from "tests/testSetup";
 import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+import type { HederaValidatorsQuery } from "@ledgerhq/live-common/families/hedera/react";
 import ClaimRewardsModal from "../index";
 import { HEDERA_ACCOUNT_1 } from "../../__mocks__/account.mock";
 import { mockSignedOperation } from "../../__mocks__/signedOperation.mock";
@@ -12,13 +13,10 @@ import {
   clickContinueWhenEnabled,
 } from "../../__mocks__/flowHelpers";
 
+const mockValidatorsQuery: HederaValidatorsQuery = { validators: [], loading: false, error: null };
+
 jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
-  hederaQueries: {
-    validatorsList: () => ({
-      queryKey: ["mock-hedera-validators"],
-      queryFn: () => Promise.resolve([]),
-    }),
-  },
+  useHederaValidators: () => mockValidatorsQuery,
   useHederaEnrichedDelegation: jest.fn(
     () => require("../../__mocks__/delegation.mock").mockEnrichedDelegation,
   ),

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/Body.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect, useMemo } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import { compose } from "redux";
 import { connect } from "react-redux";
 import { useDispatch } from "LLD/hooks/redux";
@@ -6,9 +6,8 @@ import { Trans, withTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import type { Account, Operation } from "@ledgerhq/types-live";
-import { useQuery } from "@tanstack/react-query";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
-import { hederaQueries } from "@ledgerhq/live-common/families/hedera/react";
+import { useHederaValidators } from "@ledgerhq/live-common/families/hedera/react";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
 import type { HederaAccount, Transaction } from "@ledgerhq/live-common/families/hedera/types";
 import { getDefaultValidator } from "@ledgerhq/live-common/families/hedera/utils";
@@ -93,8 +92,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   const [transactionError, setTransactionError] = useState<Error | null>(null);
   const [signed, setSigned] = useState(false);
   const dispatch = useDispatch();
-  const queryValidators = useQuery(hederaQueries.validatorsList(account.currency.id));
-  const validators = useMemo(() => queryValidators.data ?? [], [queryValidators.data]);
+  const { validators } = useHederaValidators(account.currency.id);
   const bridge = useAccountBridge<Transaction>(account);
   const { transaction, setTransaction, updateTransaction, status, bridgeError, bridgePending } =
     useBridgeTransaction(bridge, () => {

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/__integrations__/delegationFlowModal.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/__integrations__/delegationFlowModal.integ.test.tsx
@@ -4,6 +4,7 @@ import { act, render, screen, waitFor } from "tests/testSetup";
 import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
 import DelegationModal from "../index";
 import { HEDERA_ACCOUNT_1 } from "../../__mocks__/account.mock";
+import type { HederaValidatorsQuery } from "@ledgerhq/live-common/families/hedera/react";
 import { mockSignedOperation } from "../../__mocks__/signedOperation.mock";
 import { subjectRefs } from "../../__mocks__/bridge.mock";
 import {
@@ -29,16 +30,10 @@ const mockValidators = [
   },
 ];
 
-let queryFn: () => Promise<unknown> = () => Promise.resolve(mockValidators);
+let mockValidatorsQuery: HederaValidatorsQuery;
 
 jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
-  hederaQueries: {
-    validatorsList: () => ({
-      queryKey: ["mock-hedera-validators"],
-      queryFn: () => queryFn(),
-      retry: false,
-    }),
-  },
+  useHederaValidators: () => mockValidatorsQuery,
   useHederaEnrichedDelegation: jest.fn(() => null),
 }));
 
@@ -60,7 +55,7 @@ jest.mock("@ledgerhq/live-common/bridge/impl", () => ({
 }));
 
 beforeEach(async () => {
-  queryFn = () => Promise.resolve(mockValidators);
+  mockValidatorsQuery = { validators: mockValidators, loading: false, error: null };
   await setupHederaModalTest();
 });
 
@@ -115,7 +110,7 @@ describe("Hedera DelegationFlowModal (integration)", () => {
   });
 
   it("keeps Continue disabled and shows the fetch error when the validators fetch fails", async () => {
-    queryFn = () => Promise.reject(new Error("network down"));
+    mockValidatorsQuery = { validators: [], loading: false, error: new Error("network down") };
     await setupHederaModalTest({
       ...DEFAULT_TX_STATUS,
       errors: { validators: new Error("network down") },

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/__integrations__/redelegationFlowModal.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/__integrations__/redelegationFlowModal.integ.test.tsx
@@ -13,39 +13,44 @@ import {
   cleanupHederaModalTest,
   clickContinueWhenEnabled,
 } from "../../__mocks__/flowHelpers";
-import { useHederaEnrichedDelegation } from "@ledgerhq/live-common/families/hedera/react";
+import {
+  useHederaEnrichedDelegation,
+  type HederaValidatorsQuery,
+} from "@ledgerhq/live-common/families/hedera/react";
+
+const mockValidatorsQuery: HederaValidatorsQuery = {
+  validators: [
+    {
+      id: "0",
+      name: "Hedera Node 0",
+      address: "0.0.3",
+      addressChecksum: null,
+      minStake: new BigNumber(0),
+      maxStake: new BigNumber(250_000_000_000_000_000),
+      activeStake: new BigNumber(0),
+      activeStakePercentage: new BigNumber(0),
+      overstaked: false,
+      isLedgerNode: false,
+    },
+    {
+      id: "5",
+      name: "Hedera Node 5",
+      address: "0.0.5",
+      addressChecksum: null,
+      minStake: new BigNumber(0),
+      maxStake: new BigNumber(250_000_000_000_000_000),
+      activeStake: new BigNumber(0),
+      activeStakePercentage: new BigNumber(0),
+      overstaked: false,
+      isLedgerNode: false,
+    },
+  ],
+  loading: false,
+  error: null,
+};
 
 jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
-  hederaQueries: {
-    validatorsList: () => ({
-      queryKey: ["mock-hedera-validators"],
-      queryFn: () =>
-        Promise.resolve([
-          {
-            id: "0",
-            name: "Hedera Node 0",
-            address: "0.0.3",
-            addressChecksum: null,
-            minStake: new BigNumber(0),
-            maxStake: new BigNumber(250_000_000_000_000_000),
-            activeStake: new BigNumber(0),
-            activeStakePercentage: new BigNumber(0),
-            overstaked: false,
-          },
-          {
-            id: "5",
-            name: "Hedera Node 5",
-            address: "0.0.5",
-            addressChecksum: null,
-            minStake: new BigNumber(0),
-            maxStake: new BigNumber(250_000_000_000_000_000),
-            activeStake: new BigNumber(0),
-            activeStakePercentage: new BigNumber(0),
-            overstaked: false,
-          },
-        ]),
-    }),
-  },
+  useHederaValidators: () => mockValidatorsQuery,
   useHederaEnrichedDelegation: jest.fn(() => ({
     nodeId: 0,
     delegated: new BigNumber(5_000_000_000),

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/__tests__/StepValidators.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/__tests__/StepValidators.test.tsx
@@ -4,21 +4,16 @@ import { render, screen, waitFor } from "tests/testSetup";
 import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
 import type { HederaAccount } from "@ledgerhq/live-common/families/hedera/types";
+import type { HederaValidatorsQuery } from "@ledgerhq/live-common/families/hedera/react";
 import { makeHederaAccount } from "../../__mocks__/account.mock";
 import { makeHederaTransaction } from "../../__mocks__/transaction.mock";
 import StepValidators from "../steps/StepValidators";
 import type { StepProps } from "../types";
 
-let queryFn: () => Promise<unknown>;
+let mockValidatorsQuery: HederaValidatorsQuery;
 
 jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
-  hederaQueries: {
-    validatorsList: () => ({
-      queryKey: ["mock-hedera-validators"],
-      queryFn: () => queryFn(),
-      retry: false,
-    }),
-  },
+  useHederaValidators: () => mockValidatorsQuery,
   useHederaEnrichedDelegation: () => ({
     loading: false,
     error: null,
@@ -51,8 +46,8 @@ const makeProps = (): StepProps =>
   }) as unknown as StepProps;
 
 describe("RedelegationFlowModal/StepValidators", () => {
-  it("shows the fetch error only once when both selects hit a failing fetch", async () => {
-    queryFn = () => Promise.reject(new Error("network down"));
+  it("renders the fetch error once even though two selects read it", async () => {
+    mockValidatorsQuery = { validators: [], loading: false, error: new Error("network down") };
 
     render(<StepValidators {...makeProps()} />, { initialState: defaultState });
 

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/__integrations__/undelegationFlowModal.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/__integrations__/undelegationFlowModal.integ.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import BigNumber from "bignumber.js";
 import { act, render, screen, waitFor } from "tests/testSetup";
 import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+import type { HederaValidatorsQuery } from "@ledgerhq/live-common/families/hedera/react";
 import UndelegationModal from "../index";
 import { HEDERA_ACCOUNT_1 } from "../../__mocks__/account.mock";
 import { mockSignedOperation } from "../../__mocks__/signedOperation.mock";
@@ -13,26 +14,27 @@ import {
   clickContinueWhenEnabled,
 } from "../../__mocks__/flowHelpers";
 
+const mockValidatorsQuery: HederaValidatorsQuery = {
+  validators: [
+    {
+      id: "0",
+      name: "Hedera Node 0",
+      address: "0.0.3",
+      addressChecksum: null,
+      minStake: new BigNumber(0),
+      maxStake: new BigNumber(250_000_000_000_000_000),
+      activeStake: new BigNumber(0),
+      activeStakePercentage: new BigNumber(0),
+      overstaked: false,
+      isLedgerNode: false,
+    },
+  ],
+  loading: false,
+  error: null,
+};
+
 jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
-  hederaQueries: {
-    validatorsList: () => ({
-      queryKey: ["mock-hedera-validators"],
-      queryFn: () =>
-        Promise.resolve([
-          {
-            id: "0",
-            name: "Hedera Node 0",
-            address: "0.0.3",
-            addressChecksum: null,
-            minStake: new BigNumber(0),
-            maxStake: new BigNumber(250_000_000_000_000_000),
-            activeStake: new BigNumber(0),
-            activeStakePercentage: new BigNumber(0),
-            overstaked: false,
-          },
-        ]),
-    }),
-  },
+  useHederaValidators: () => mockValidatorsQuery,
   useHederaEnrichedDelegation: jest.fn(
     () => require("../../__mocks__/delegation.mock").mockEnrichedDelegation,
   ),

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/__tests__/StepSummary.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/__tests__/StepSummary.test.tsx
@@ -3,19 +3,14 @@ import BigNumber from "bignumber.js";
 import { render, screen, waitFor } from "tests/testSetup";
 import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
 import type { HederaAccount } from "@ledgerhq/live-common/families/hedera/types";
+import type { HederaValidatorsQuery } from "@ledgerhq/live-common/families/hedera/react";
 import { makeHederaAccount } from "../../__mocks__/account.mock";
 import type { StepProps } from "../types";
 
-let queryFn: () => Promise<unknown>;
+let mockValidatorsQuery: HederaValidatorsQuery;
 
 jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
-  hederaQueries: {
-    validatorsList: () => ({
-      queryKey: ["mock-hedera-validators"],
-      queryFn: () => queryFn(),
-      retry: false,
-    }),
-  },
+  useHederaValidators: () => mockValidatorsQuery,
 }));
 
 import StepSummary from "../steps/StepSummary";
@@ -52,7 +47,7 @@ const makeProps = (): StepProps =>
 
 describe("UndelegationFlowModal/StepSummary", () => {
   it("does not show the removed-validator placeholder while the validator list fetch is still failing", async () => {
-    queryFn = () => Promise.reject(new Error("network down"));
+    mockValidatorsQuery = { validators: [], loading: false, error: new Error("network down") };
 
     render(<StepSummary {...makeProps()} />, { initialState: defaultState });
 
@@ -63,7 +58,7 @@ describe("UndelegationFlowModal/StepSummary", () => {
   });
 
   it("shows the removed-validator placeholder once the fetch succeeds and the validator is gone", async () => {
-    queryFn = () => Promise.resolve([]);
+    mockValidatorsQuery = { validators: [], loading: false, error: null };
 
     render(<StepSummary {...makeProps()} />, { initialState: defaultState });
 
@@ -75,7 +70,7 @@ describe("UndelegationFlowModal/StepSummary", () => {
   });
 
   it("shows the validator name once the fetch succeeds and the validator is still present", async () => {
-    queryFn = () => Promise.resolve([validator]);
+    mockValidatorsQuery = { validators: [validator], loading: false, error: null };
 
     render(<StepSummary {...makeProps()} />, { initialState: defaultState });
 

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/steps/StepSummary.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { Trans } from "react-i18next";
 import invariant from "invariant";
-import { useQuery } from "@tanstack/react-query";
-import { hederaQueries } from "@ledgerhq/live-common/families/hedera/react";
+import { useHederaValidators } from "@ledgerhq/live-common/families/hedera/react";
 import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account/helpers";
 import { urls } from "~/config/urls";
 import Alert from "~/renderer/components/Alert";
@@ -28,11 +27,11 @@ function StepSummary({
   invariant(account && transaction, "hedera: account and transaction required");
   const mainAccount = account ? getMainAccount(account, parentAccount) : null;
   const currentValidatorNodeId = account.hederaResources?.delegation?.nodeId;
-  const queryValidators = useQuery(hederaQueries.validatorsList(account.currency.id));
-  const validator = queryValidators.data?.find(v => v.id === String(currentValidatorNodeId));
+  const queryValidators = useHederaValidators(account.currency.id);
+  const validator = queryValidators.validators.find(v => v.id === String(currentValidatorNodeId));
   const validatorRemoved = isValidatorRemoved({
-    loading: queryValidators.isLoading,
-    error: queryValidators.isLoadingError,
+    loading: queryValidators.loading,
+    error: !!queryValidators.error,
     hasValidator: !!validator,
     nodeId: currentValidatorNodeId,
   });

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/shared/staking/ValidatorsListField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/shared/staking/ValidatorsListField.tsx
@@ -1,14 +1,10 @@
 import React, { useState, useCallback } from "react";
 import { Trans } from "react-i18next";
-import { useQuery } from "@tanstack/react-query";
 import styled from "styled-components";
 import type { Account } from "@ledgerhq/types-live";
-import { hederaQueries } from "@ledgerhq/live-common/families/hedera/react";
+import { useHederaValidators } from "@ledgerhq/live-common/families/hedera/react";
 import type { HederaValidator } from "@ledgerhq/live-common/families/hedera/types";
-import {
-  getDefaultValidator,
-  filterValidatorBySearchTerm,
-} from "@ledgerhq/live-common/families/hedera/utils";
+import { getDefaultValidator } from "@ledgerhq/live-common/families/hedera/utils";
 import Box from "~/renderer/components/Box";
 import Text from "~/renderer/components/Text";
 import TranslatedError from "~/renderer/components/TranslatedError";
@@ -31,11 +27,8 @@ const ValidatorsListField = ({ account, selectedValidatorId, onChangeValidator }
   const [search, setSearch] = useState("");
   const [showAll, setShowAll] = useState(true);
   const unit = useAccountUnit(account);
-  const queryValidators = useQuery({
-    ...hederaQueries.validatorsList(account.currency.id),
-    select: data => (search ? data.filter(v => filterValidatorBySearchTerm(v, search)) : data),
-  });
-  const validators = queryValidators.data ?? [];
+  const queryValidators = useHederaValidators(account.currency.id, search);
+  const validators = queryValidators.validators;
 
   const defaultValidator = getDefaultValidator(validators);
   const selectedValidator = validators.find(v => v.id === selectedValidatorId);
@@ -67,19 +60,19 @@ const ValidatorsListField = ({ account, selectedValidatorId, onChangeValidator }
 
   return (
     <>
-      {queryValidators.isLoadingError && (
+      {!!queryValidators.error && (
         <Box mb={2}>
           <Text color="pearl">
             <TranslatedError error={queryValidators.error} />
           </Text>
         </Box>
       )}
-      {showAll && !queryValidators.isLoadingError && (
+      {showAll && !queryValidators.error && (
         <ValidatorSearchInput noMargin={true} search={search} onSearch={onSearch} />
       )}
       <ValidatorsFieldContainer>
         <Box p={1} data-testid="validator-list">
-          {queryValidators.isLoading ? (
+          {queryValidators.loading ? (
             <Box p={4} alignItems="center" justifyContent="center">
               <Spinner size={24} />
             </Box>
@@ -93,7 +86,7 @@ const ValidatorsListField = ({ account, selectedValidatorId, onChangeValidator }
               }}
               renderItem={renderItem}
               noResultPlaceholder={
-                !queryValidators.isLoadingError &&
+                !queryValidators.error &&
                 validators.length <= 0 &&
                 search.length > 0 && <NoResultPlaceholder search={search} />
               }

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/shared/staking/ValidatorsSelect.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/shared/staking/ValidatorsSelect.tsx
@@ -3,11 +3,10 @@ import { useTranslation } from "react-i18next";
 // FilterOptionOption type for react-select v5 filter callback
 type FilterOptionOption<T> = { label: string; value: string; data: T };
 import styled from "styled-components";
-import { useQuery } from "@tanstack/react-query";
 import { Box } from "@ledgerhq/react-ui";
 import type { HederaAccount, HederaValidator } from "@ledgerhq/live-common/families/hedera/types";
 import { filterValidatorBySearchTerm } from "@ledgerhq/live-common/families/hedera/utils";
-import { hederaQueries } from "@ledgerhq/live-common/families/hedera/react";
+import { useHederaValidators } from "@ledgerhq/live-common/families/hedera/react";
 import Select from "~/renderer/components/Select";
 import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import ValidatorOption from "~/renderer/families/hedera/shared/staking/ValidatorOption";
@@ -35,8 +34,8 @@ export default function ValidatorsSelect({
   const [query, setQuery] = useState<string>();
   const { t } = useTranslation();
   const unit = useAccountUnit(account);
-  const queryValidators = useQuery(hederaQueries.validatorsList(account.currency.id));
-  const options = useMemo(() => queryValidators.data ?? [], [queryValidators.data]);
+  const queryValidators = useHederaValidators(account.currency.id);
+  const options = queryValidators.validators;
 
   const renderItem = useCallback(
     (item: { data: HederaValidator; isDisabled: boolean }) => {
@@ -57,16 +56,14 @@ export default function ValidatorsSelect({
     return options.find(v => v.id === selectedValidatorId) ?? null;
   }, [selectedValidatorId, options]);
 
-  const hasNoDataError = queryValidators.data === undefined && !!queryValidators.error;
-  const fetchError = hasNoDataError && !disabled ? queryValidators.error : undefined;
-  const displayError = error ?? fetchError;
+  const displayError = error ?? (disabled ? null : queryValidators.error);
 
   const getPlaceholder = () => {
-    if (hasNoDataError) {
+    if (queryValidators.error) {
       return t("hedera.redelegation.flow.steps.validators.unableToLoadSelectPlaceholder");
     }
 
-    if (queryValidators.isLoading) {
+    if (queryValidators.loading) {
       return t("hedera.redelegation.flow.steps.validators.loadingValidatorPlaceholder");
     }
 
@@ -110,7 +107,7 @@ export default function ValidatorsSelect({
         onInputChange={setQuery}
         filterOption={filterOptions}
         inputValue={query}
-        isLoading={queryValidators.isLoading}
+        isLoading={queryValidators.loading}
         isDisabled={disabled || options.length <= 1}
         placeholder={getPlaceholder()}
         noOptionsMessage={({ inputValue }) =>
@@ -122,13 +119,13 @@ export default function ValidatorsSelect({
           onChangeValidator?.(validator ?? null);
         }}
       />
-      <ErrorContainer hasError={displayError || warning}>{renderErrorMessage()}</ErrorContainer>
+      <ErrorContainer hasError={!!displayError || !!warning}>{renderErrorMessage()}</ErrorContainer>
     </>
   );
 }
 
 const ErrorContainer = styled(Box)<{
-  hasError: Error | undefined;
+  hasError: boolean;
 }>`
   margin-top: 0px;
   font-size: 12px;

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/shared/staking/__tests__/ValidatorsListField.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/shared/staking/__tests__/ValidatorsListField.test.tsx
@@ -3,17 +3,12 @@ import { render, screen, userEvent, waitFor } from "tests/testSetup";
 import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
 import ValidatorsListField from "../ValidatorsListField";
 import { makeHederaAccount } from "../../../__mocks__/account.mock";
+import type { HederaValidatorsQuery } from "@ledgerhq/live-common/families/hedera/react";
 
-let queryFn: () => Promise<unknown>;
+let mockValidatorsQuery: HederaValidatorsQuery;
 
 jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
-  hederaQueries: {
-    validatorsList: () => ({
-      queryKey: ["mock-hedera-validators"],
-      queryFn: () => queryFn(),
-      retry: false,
-    }),
-  },
+  useHederaValidators: () => mockValidatorsQuery,
 }));
 
 const defaultState = { settings: AFTER_ONBOARDING_STATE };
@@ -22,7 +17,7 @@ const onChangeValidator = jest.fn();
 
 describe("ValidatorsListField", () => {
   it("shows the fetch error text and keeps the list mounted", async () => {
-    queryFn = () => Promise.reject(new Error("network down"));
+    mockValidatorsQuery = { validators: [], loading: false, error: new Error("network down") };
 
     render(
       <ValidatorsListField
@@ -38,7 +33,7 @@ describe("ValidatorsListField", () => {
   });
 
   it("hides the search input while the fetch has never succeeded", async () => {
-    queryFn = () => Promise.reject(new Error("network down"));
+    mockValidatorsQuery = { validators: [], loading: false, error: new Error("network down") };
 
     render(
       <ValidatorsListField
@@ -54,7 +49,7 @@ describe("ValidatorsListField", () => {
   });
 
   it("does not show an error when the fetch succeeds", async () => {
-    queryFn = () => Promise.resolve([]);
+    mockValidatorsQuery = { validators: [], loading: false, error: null };
 
     render(
       <ValidatorsListField
@@ -70,7 +65,7 @@ describe("ValidatorsListField", () => {
   });
 
   it("shows a spinner and no list while the fetch is pending", async () => {
-    queryFn = () => new Promise(() => {});
+    mockValidatorsQuery = { validators: [], loading: true, error: null };
 
     render(
       <ValidatorsListField
@@ -85,7 +80,7 @@ describe("ValidatorsListField", () => {
   });
 
   it("does not crash clicking 'Show less' with an empty list from a failed fetch", async () => {
-    queryFn = () => Promise.reject(new Error("network down"));
+    mockValidatorsQuery = { validators: [], loading: false, error: new Error("network down") };
 
     render(
       <ValidatorsListField

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/shared/staking/__tests__/ValidatorsSelect.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/shared/staking/__tests__/ValidatorsSelect.test.tsx
@@ -3,17 +3,12 @@ import { render, screen, waitFor } from "tests/testSetup";
 import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
 import ValidatorsSelect from "../ValidatorsSelect";
 import { makeHederaAccount } from "../../../__mocks__/account.mock";
+import type { HederaValidatorsQuery } from "@ledgerhq/live-common/families/hedera/react";
 
-let queryFn: () => Promise<unknown>;
+let mockValidatorsQuery: HederaValidatorsQuery;
 
 jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
-  hederaQueries: {
-    validatorsList: () => ({
-      queryKey: ["mock-hedera-validators"],
-      queryFn: () => queryFn(),
-      retry: false,
-    }),
-  },
+  useHederaValidators: () => mockValidatorsQuery,
 }));
 
 const defaultState = { settings: AFTER_ONBOARDING_STATE };
@@ -21,7 +16,7 @@ const account = makeHederaAccount();
 
 describe("ValidatorsSelect", () => {
   it("shows the fetch error text and keeps the select mounted", async () => {
-    queryFn = () => Promise.reject(new Error("network down"));
+    mockValidatorsQuery = { validators: [], loading: false, error: new Error("network down") };
 
     render(<ValidatorsSelect account={account} selectedValidatorId={null} />, {
       initialState: defaultState,
@@ -32,7 +27,7 @@ describe("ValidatorsSelect", () => {
   });
 
   it("does not show the generic 'select validator' placeholder when the fetch fails", async () => {
-    queryFn = () => Promise.reject(new Error("network down"));
+    mockValidatorsQuery = { validators: [], loading: false, error: new Error("network down") };
 
     render(<ValidatorsSelect account={account} selectedValidatorId={null} />, {
       initialState: defaultState,
@@ -43,7 +38,7 @@ describe("ValidatorsSelect", () => {
   });
 
   it("does not show the removed-validator placeholder when the fetch fails", async () => {
-    queryFn = () => Promise.reject(new Error("network down"));
+    mockValidatorsQuery = { validators: [], loading: false, error: new Error("network down") };
 
     render(
       <ValidatorsSelect account={account} selectedValidatorId={null} showRemovedPlaceholder />,
@@ -57,7 +52,7 @@ describe("ValidatorsSelect", () => {
   });
 
   it("does not show an error when the fetch succeeds", async () => {
-    queryFn = () => Promise.resolve([]);
+    mockValidatorsQuery = { validators: [], loading: false, error: null };
 
     render(<ValidatorsSelect account={account} selectedValidatorId={null} />, {
       initialState: defaultState,
@@ -67,7 +62,7 @@ describe("ValidatorsSelect", () => {
   });
 
   it("shows the loading placeholder and disables the select while the fetch is pending", async () => {
-    queryFn = () => new Promise(() => {});
+    mockValidatorsQuery = { validators: [], loading: true, error: null };
 
     render(<ValidatorsSelect account={account} selectedValidatorId={null} />, {
       initialState: defaultState,

--- a/apps/ledger-live-desktop/src/renderer/reducers/rtkQueryApi.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/rtkQueryApi.test.ts
@@ -16,6 +16,7 @@ const EXPECTED_REDUCER_PATHS = [
   "coinMarketCapApi",
   "counterValuesApi",
   "countervaluesApi",
+  "hederaApi",
   "marketApi",
   "ofacGeoBlockApi",
   "pushDevicesApi",

--- a/apps/ledger-live-desktop/src/renderer/reducers/rtkQueryApi.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/rtkQueryApi.ts
@@ -2,6 +2,7 @@ import type { Middleware, Reducer, Tuple } from "@reduxjs/toolkit";
 import { ofacGeoBlockApi } from "@ledgerhq/live-common/api/ofacGeoBlockApi";
 import { marketApi } from "@ledgerhq/live-common/market/state-manager/api";
 import { cgApi } from "@ledgerhq/live-common/cg-client/state-manager/api";
+import { hederaApi } from "@ledgerhq/live-common/families/hedera/state-manager/api";
 import {
   calApi,
   cardApi,
@@ -25,6 +26,7 @@ const APIs = {
   [counterValuesApi.reducerPath]: counterValuesApi,
   [marketApi.reducerPath]: marketApi,
   [cgApi.reducerPath]: cgApi,
+  [hederaApi.reducerPath]: hederaApi,
   [ofacGeoBlockApi.reducerPath]: ofacGeoBlockApi,
   [pushDevicesApi.reducerPath]: pushDevicesApi,
   [swapApi.reducerPath]: swapApi,

--- a/apps/ledger-live-mobile/src/context/rtkQueryApi.test.ts
+++ b/apps/ledger-live-mobile/src/context/rtkQueryApi.test.ts
@@ -16,6 +16,7 @@ const EXPECTED_REDUCER_PATHS = [
   "coinMarketCapApi",
   "counterValuesApi",
   "countervaluesApi",
+  "hederaApi",
   "marketApi",
   "ofacGeoBlockApi",
   "pushDevicesApi",

--- a/apps/ledger-live-mobile/src/context/rtkQueryApi.ts
+++ b/apps/ledger-live-mobile/src/context/rtkQueryApi.ts
@@ -2,6 +2,7 @@ import type { Middleware, Reducer, Tuple } from "@reduxjs/toolkit";
 import { ofacGeoBlockApi } from "@ledgerhq/live-common/api/ofacGeoBlockApi";
 import { marketApi } from "@ledgerhq/live-common/market/state-manager/api";
 import { cgApi } from "@ledgerhq/live-common/cg-client/state-manager/api";
+import { hederaApi } from "@ledgerhq/live-common/families/hedera/state-manager/api";
 import {
   calApi,
   cardApi,
@@ -23,6 +24,7 @@ const APIs = {
   [countervaluesApi.reducerPath]: countervaluesApi,
   [counterValuesApi.reducerPath]: counterValuesApi,
   [cgApi.reducerPath]: cgApi,
+  [hederaApi.reducerPath]: hederaApi,
   [marketApi.reducerPath]: marketApi,
   [ofacGeoBlockApi.reducerPath]: ofacGeoBlockApi,
   [pushDevicesApi.reducerPath]: pushDevicesApi,

--- a/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/SelectValidator.test.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/SelectValidator.test.tsx
@@ -1,22 +1,17 @@
 import React from "react";
 import BigNumber from "bignumber.js";
 import { Spinner } from "@ledgerhq/lumen-ui-rnative";
-import { renderWithReactQuery as render, screen, waitFor } from "@tests/test-renderer";
+import { render, screen, waitFor } from "@tests/test-renderer";
 import { ScreenName } from "~/const";
 import type { State } from "~/reducers/types";
+import type { HederaValidatorsQuery } from "@ledgerhq/live-common/families/hedera/react";
 import SelectValidator from "./SelectValidator";
 import { HEDERA_ACCOUNT_1 } from "../__mocks__/account.mock";
 
-let validatorsQueryFn: () => Promise<unknown>;
+let mockValidatorsQuery: HederaValidatorsQuery;
 
 jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
-  hederaQueries: {
-    validatorsList: () => ({
-      queryKey: ["mock-hedera-validators"],
-      queryFn: () => validatorsQueryFn(),
-      retry: false,
-    }),
-  },
+  useHederaValidators: () => mockValidatorsQuery,
 }));
 
 const mockNavigate = jest.fn();
@@ -37,6 +32,7 @@ const validator = {
   activeStake: new BigNumber(0),
   activeStakePercentage: new BigNumber(0),
   overstaked: false,
+  isLedgerNode: false,
 };
 
 const overrideInitialState = (state: State): State => ({
@@ -50,7 +46,7 @@ describe("DelegationFlow SelectValidator", () => {
   });
 
   it("shows a spinner and no validator row while the validators query is loading", () => {
-    validatorsQueryFn = () => new Promise(() => {});
+    mockValidatorsQuery = { validators: [], loading: true, error: null };
 
     render(<SelectValidator navigation={mockNavigation} route={mockRoute} />, {
       overrideInitialState,
@@ -61,7 +57,7 @@ describe("DelegationFlow SelectValidator", () => {
   });
 
   it("shows the fetch error text and keeps the list mounted", async () => {
-    validatorsQueryFn = () => Promise.reject(new Error("network down"));
+    mockValidatorsQuery = { validators: [], loading: false, error: new Error("network down") };
 
     render(<SelectValidator navigation={mockNavigation} route={mockRoute} />, {
       overrideInitialState,
@@ -71,7 +67,7 @@ describe("DelegationFlow SelectValidator", () => {
   });
 
   it("does not show an error and navigates to Summary when a validator is selected", async () => {
-    validatorsQueryFn = () => Promise.resolve([validator]);
+    mockValidatorsQuery = { validators: [validator], loading: false, error: null };
 
     const { user } = render(<SelectValidator navigation={mockNavigation} route={mockRoute} />, {
       overrideInitialState,

--- a/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/Summary.tsx
@@ -1,5 +1,4 @@
 import React, { ReactNode, useCallback, useEffect } from "react";
-import { useQuery } from "@tanstack/react-query";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { formatCurrencyUnit, getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
@@ -8,7 +7,7 @@ import {
   getDefaultValidator,
   isStakingTransaction,
 } from "@ledgerhq/live-common/families/hedera/utils";
-import { hederaQueries } from "@ledgerhq/live-common/families/hedera/react";
+import { useHederaValidators } from "@ledgerhq/live-common/families/hedera/react";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
 import type { HederaValidator, Transaction } from "@ledgerhq/live-common/families/hedera/types";
 import type { AccountBridge, AccountLike } from "@ledgerhq/types-live";
@@ -48,8 +47,8 @@ export default function DelegationSummary({ navigation, route }: Readonly<Props>
   invariant(account.type === "Account", "account type must be Account");
 
   const bridge: AccountBridge<Transaction> = useAccountBridge(account);
-  const queryValidators = useQuery(hederaQueries.validatorsList(account.currency.id));
-  const validators = queryValidators.data ?? [];
+  const queryValidators = useHederaValidators(account.currency.id);
+  const validators = queryValidators.validators;
   const defaultValidator = getDefaultValidator(validators);
 
   const { transaction, updateTransaction, status, bridgePending, bridgeError } =
@@ -136,7 +135,7 @@ export default function DelegationSummary({ navigation, route }: Readonly<Props>
           right={
             <Touchable event="DelegationFlowSummaryChangeCircleBtn" onPress={onChangeDelegator}>
               <Circle size={70} style={[styles.validatorCircle, { borderColor: colors.primary }]}>
-                <Skeleton loading={queryValidators.isLoading} style={styles.validatorIconSkeleton}>
+                <Skeleton loading={queryValidators.loading} style={styles.validatorIconSkeleton}>
                   <Animated.View
                     style={{
                       transform: [{ rotate }],
@@ -155,10 +154,10 @@ export default function DelegationSummary({ navigation, route }: Readonly<Props>
             onChangeValidator={onChangeDelegator}
             validator={selectedValidator}
             account={account}
-            isLoadingValidator={queryValidators.isLoading}
+            isLoadingValidator={queryValidators.loading}
           />
         </View>
-        {queryValidators.isLoadingError && (
+        {!!queryValidators.error && (
           <View style={styles.fetchError}>
             <Text color="error.c50" textAlign="center">
               <TranslatedError error={queryValidators.error} />

--- a/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/__integrations__/delegationFlow.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/__integrations__/delegationFlow.integration.test.tsx
@@ -9,34 +9,31 @@ import { NavigatorName, ScreenName } from "~/const";
 import { component } from "../index";
 import { HEDERA_ACCOUNT_1, overrideWithHederaAccount1 } from "../../__mocks__/account.mock";
 import { makeMockAccountBridge } from "../../__mocks__/bridge.mock";
+import type { HederaValidatorsQuery } from "@ledgerhq/live-common/families/hedera/react";
 
 jest.mock("LLM/features/NotificationsPrompt", () => ({
   useNotificationsPrompt: () => ({ notifyFlowCompleted: jest.fn() }),
 }));
 
-let validatorsQueryFn = () =>
-  Promise.resolve([
-    {
-      id: "0",
-      name: "Hedera Node 0",
-      address: "0.0.3",
-      addressChecksum: null,
-      minStake: new BigNumber(0),
-      maxStake: new BigNumber(250_000_000_000_000_000),
-      activeStake: new BigNumber(0),
-      activeStakePercentage: new BigNumber(0),
-      overstaked: false,
-    },
-  ]);
+const MOCK_VALIDATORS = [
+  {
+    id: "0",
+    name: "Hedera Node 0",
+    address: "0.0.3",
+    addressChecksum: null,
+    minStake: new BigNumber(0),
+    maxStake: new BigNumber(250_000_000_000_000_000),
+    activeStake: new BigNumber(0),
+    activeStakePercentage: new BigNumber(0),
+    overstaked: false,
+    isLedgerNode: false,
+  },
+];
+
+let mockValidatorsQuery: HederaValidatorsQuery;
 
 jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
-  hederaQueries: {
-    validatorsList: () => ({
-      queryKey: ["mock-hedera-validators"],
-      queryFn: () => validatorsQueryFn(),
-      retry: false,
-    }),
-  },
+  useHederaValidators: () => mockValidatorsQuery,
   useHederaEnrichedDelegation: jest.fn(() => null),
 }));
 
@@ -118,20 +115,7 @@ describe("Hedera DelegationFlow (integration)", () => {
     mockAccountBridge = makeMockAccountBridge(HEDERA_TRANSACTION_MODES.Delegate, {
       stakingNodeId: 0,
     });
-    validatorsQueryFn = () =>
-      Promise.resolve([
-        {
-          id: "0",
-          name: "Hedera Node 0",
-          address: "0.0.3",
-          addressChecksum: null,
-          minStake: new BigNumber(0),
-          maxStake: new BigNumber(250_000_000_000_000_000),
-          activeStake: new BigNumber(0),
-          activeStakePercentage: new BigNumber(0),
-          overstaked: false,
-        },
-      ]);
+    mockValidatorsQuery = { validators: MOCK_VALIDATORS, loading: false, error: null };
   });
 
   it("completes the happy path: Summary → SelectDevice → ConnectDevice → ValidationSuccess", async () => {
@@ -176,7 +160,7 @@ describe("Hedera DelegationFlow (integration)", () => {
   });
 
   it("blocks Continue and shows the error when the validator list fails to load", async () => {
-    validatorsQueryFn = () => Promise.reject(new Error("network down"));
+    mockValidatorsQuery = { validators: [], loading: false, error: new Error("network down") };
     mockAccountBridge = makeMockAccountBridge(
       HEDERA_TRANSACTION_MODES.Delegate,
       { stakingNodeId: 0 },

--- a/apps/ledger-live-mobile/src/families/hedera/RedelegationFlow/SelectValidator.test.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/RedelegationFlow/SelectValidator.test.tsx
@@ -1,22 +1,17 @@
 import React from "react";
 import BigNumber from "bignumber.js";
 import { Spinner } from "@ledgerhq/lumen-ui-rnative";
-import { renderWithReactQuery as render, screen, waitFor } from "@tests/test-renderer";
+import { render, screen, waitFor } from "@tests/test-renderer";
 import { ScreenName } from "~/const";
 import type { State } from "~/reducers/types";
+import type { HederaValidatorsQuery } from "@ledgerhq/live-common/families/hedera/react";
 import RedelegationSelectValidator from "./SelectValidator";
 import { HEDERA_ACCOUNT_1 } from "../__mocks__/account.mock";
 
-let validatorsQueryFn: () => Promise<unknown>;
+let mockValidatorsQuery: HederaValidatorsQuery;
 
 jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
-  hederaQueries: {
-    validatorsList: () => ({
-      queryKey: ["mock-hedera-validators"],
-      queryFn: () => validatorsQueryFn(),
-      retry: false,
-    }),
-  },
+  useHederaValidators: () => mockValidatorsQuery,
 }));
 
 const mockNavigate = jest.fn();
@@ -37,6 +32,7 @@ const validator = {
   activeStake: new BigNumber(0),
   activeStakePercentage: new BigNumber(0),
   overstaked: false,
+  isLedgerNode: false,
 };
 
 const overrideInitialState = (state: State): State => ({
@@ -50,7 +46,7 @@ describe("RedelegationFlow SelectValidator", () => {
   });
 
   it("shows a spinner and no validator row while the validators query is loading", () => {
-    validatorsQueryFn = () => new Promise(() => {});
+    mockValidatorsQuery = { validators: [], loading: true, error: null };
 
     render(<RedelegationSelectValidator navigation={mockNavigation} route={mockRoute} />, {
       overrideInitialState,
@@ -61,7 +57,7 @@ describe("RedelegationFlow SelectValidator", () => {
   });
 
   it("shows the fetch error text and keeps the list mounted", async () => {
-    validatorsQueryFn = () => Promise.reject(new Error("network down"));
+    mockValidatorsQuery = { validators: [], loading: false, error: new Error("network down") };
 
     render(<RedelegationSelectValidator navigation={mockNavigation} route={mockRoute} />, {
       overrideInitialState,
@@ -71,7 +67,7 @@ describe("RedelegationFlow SelectValidator", () => {
   });
 
   it("does not show an error and navigates to Amount when a validator is selected", async () => {
-    validatorsQueryFn = () => Promise.resolve([validator]);
+    mockValidatorsQuery = { validators: [validator], loading: false, error: null };
 
     const { user } = render(
       <RedelegationSelectValidator navigation={mockNavigation} route={mockRoute} />,

--- a/apps/ledger-live-mobile/src/families/hedera/shared/ValidatorsList.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/shared/ValidatorsList.tsx
@@ -1,9 +1,7 @@
 import React, { useCallback } from "react";
 import { FlatList, StyleSheet, View } from "react-native";
-import { useQuery } from "@tanstack/react-query";
 import { Spinner } from "@ledgerhq/lumen-ui-rnative";
-import { hederaQueries } from "@ledgerhq/live-common/families/hedera/react";
-import { filterValidatorBySearchTerm } from "@ledgerhq/live-common/families/hedera/utils";
+import { useHederaValidators } from "@ledgerhq/live-common/families/hedera/react";
 import type { HederaValidator } from "@ledgerhq/live-common/families/hedera/types";
 import type { Account } from "@ledgerhq/types-live";
 import ValidatorRow from "./ValidatorRow";
@@ -24,12 +22,8 @@ export default function ValidatorsList({
   onItemPress,
   header,
 }: Readonly<Props>) {
-  const queryValidators = useQuery({
-    ...hederaQueries.validatorsList(account.currency.id),
-    select: data =>
-      searchQuery ? data.filter(v => filterValidatorBySearchTerm(v, searchQuery)) : data,
-  });
-  const validators = queryValidators.data ?? [];
+  const queryValidators = useHederaValidators(account.currency.id, searchQuery);
+  const validators = queryValidators.validators;
 
   const renderItem = useCallback(
     (data: { item: HederaValidator }) => (
@@ -38,7 +32,7 @@ export default function ValidatorsList({
     [onItemPress, account],
   );
 
-  if (queryValidators.isLoading) {
+  if (queryValidators.loading) {
     return (
       <View style={styles.center}>
         <Spinner size={32} />
@@ -49,7 +43,7 @@ export default function ValidatorsList({
   return (
     <>
       {header}
-      {queryValidators.isLoadingError && <ValidatorsFetchError error={queryValidators.error} />}
+      {!!queryValidators.error && <ValidatorsFetchError error={queryValidators.error} />}
       <FlatList
         contentContainerStyle={styles.list}
         data={validators}

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -130,6 +130,7 @@
     "src/families/filecoin/types.ts",
     "src/families/hedera/types.ts",
     "src/families/hedera/signer.ts",
+    "src/families/hedera/state-manager/api.ts",
     "src/families/internet_computer/react.ts",
     "src/families/internet_computer/types.ts",
     "src/families/mina/types.ts",

--- a/libs/ledger-live-common/src/families/hedera/react.test.ts
+++ b/libs/ledger-live-common/src/families/hedera/react.test.ts
@@ -2,31 +2,24 @@
  * @jest-environment jsdom
  */
 import "../../__tests__/test-helpers/dom-polyfill";
-import React from "react";
 import BigNumber from "bignumber.js";
 import invariant from "invariant";
 import hederaCoinConfig from "@ledgerhq/coin-hedera/config";
 import { getHederaValidators } from "@ledgerhq/coin-hedera/network/utils";
 import { apiClient } from "@ledgerhq/coin-hedera/network/api";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
-import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import { liveConfig } from "../../config/sharedConfig";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { createTestStore, createWrapper } from "@tests/test-helpers/testUtils";
+import { hederaApi } from "./state-manager/api";
 import * as hooks from "./react";
 import type { HederaAccount, HederaDelegation, HederaValidator } from "./types";
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: queryClient }, children);
-}
-
 describe("hedera/react", () => {
   const currency = getCryptoCurrencyById("hedera");
+  let store: ReturnType<typeof createTestStore>;
+  let wrapper: ReturnType<typeof createWrapper>;
 
   beforeAll(() => {
     LiveConfig.setConfig(liveConfig);
@@ -81,35 +74,26 @@ describe("hedera/react", () => {
       ],
       nextCursor: null,
     });
+    store = createTestStore([hederaApi], { disableSerializableCheck: true });
+    wrapper = createWrapper(store);
   });
 
-  describe("hederaQueries.validatorsList", () => {
+  describe("useHederaValidators", () => {
     it("should return all validators", async () => {
-      const { result } = renderHook(
-        () => useQuery(hooks.hederaQueries.validatorsList(currency.id)),
-        {
-          wrapper: createWrapper(),
-        },
-      );
+      const { result } = renderHook(() => hooks.useHederaValidators(currency.id), { wrapper });
 
-      await waitFor(() => expect(result.current.data).toHaveLength(3));
+      await waitFor(() => expect(result.current.validators).toHaveLength(3));
       // sortValidators puts the Ledger node first, then orders by active stake descending
-      expect(result.current.data?.map(validator => validator.id)).toEqual(["1", "0", "3"]);
+      expect(result.current.validators.map(validator => validator.id)).toEqual(["1", "0", "3"]);
     });
 
     it("should surface an error when the validators fetch fails", async () => {
       jest.spyOn(apiClient, "getNodes").mockRejectedValueOnce(new Error("network down"));
 
-      const { result } = renderHook(
-        () => useQuery(hooks.hederaQueries.validatorsList(currency.id)),
-        {
-          wrapper: createWrapper(),
-        },
-      );
+      const { result } = renderHook(() => hooks.useHederaValidators(currency.id), { wrapper });
 
-      await waitFor(() => expect(result.current.isError).toBe(true));
-      expect(result.current.error).toBeInstanceOf(Error);
-      expect(result.current.data).toBeUndefined();
+      await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
+      expect(result.current.validators).toEqual([]);
     });
   });
 
@@ -140,9 +124,7 @@ describe("hedera/react", () => {
 
       const { result } = renderHook(
         () => hooks.useHederaEnrichedDelegation(mockAccount, delegation),
-        {
-          wrapper: createWrapper(),
-        },
+        { wrapper },
       );
 
       expect(result.current.loading).toBe(true);
@@ -161,9 +143,7 @@ describe("hedera/react", () => {
 
       const { result } = renderHook(
         () => hooks.useHederaEnrichedDelegation(mockAccount, delegation),
-        {
-          wrapper: createWrapper(),
-        },
+        { wrapper },
       );
 
       await waitFor(() =>
@@ -199,9 +179,7 @@ describe("hedera/react", () => {
 
       const { result } = renderHook(
         () => hooks.useHederaEnrichedDelegation(mockAccount, delegation),
-        {
-          wrapper: createWrapper(),
-        },
+        { wrapper },
       );
 
       await waitFor(() =>
@@ -240,9 +218,7 @@ describe("hedera/react", () => {
 
       const { result } = renderHook(
         () => hooks.useHederaEnrichedDelegation(mockAccount, delegation),
-        {
-          wrapper: createWrapper(),
-        },
+        { wrapper },
       );
 
       await waitFor(() => expect(result.current.validator.id).toEqual(validator.id));
@@ -262,9 +238,7 @@ describe("hedera/react", () => {
 
       const { result } = renderHook(
         () => hooks.useHederaEnrichedDelegation(mockAccount, delegation),
-        {
-          wrapper: createWrapper(),
-        },
+        { wrapper },
       );
 
       await waitFor(() => expect(result.current.error).toBeInstanceOf(Error));
@@ -282,10 +256,6 @@ describe("hedera/react", () => {
         pendingReward: new BigNumber(500),
       };
 
-      const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-      const wrapper = ({ children }: { children: React.ReactNode }) =>
-        React.createElement(QueryClientProvider, { client: queryClient }, children);
-
       const { result } = renderHook(
         () => hooks.useHederaEnrichedDelegation(mockAccount, delegation),
         { wrapper },
@@ -296,11 +266,11 @@ describe("hedera/react", () => {
       expect(result.current.error).toBeNull();
 
       jest.spyOn(apiClient, "getNodes").mockRejectedValueOnce(new Error("network down"));
-      // without this the queryFn just replays the cached promise and the refetch never fails
+      // without this the query just replays the cached list and the refetch never fails
       getHederaValidators.clear(currency.id);
-      await queryClient.refetchQueries({
-        queryKey: [...hooks.hederaQueries.all(), "validators", currency.id],
-      });
+      await store.dispatch(
+        hederaApi.endpoints.getValidators.initiate(currency.id, { forceRefetch: true }),
+      );
 
       await waitFor(() => expect(result.current.error).toBeNull());
       expect(result.current.validator.id).toEqual(validator.id);
@@ -318,9 +288,7 @@ describe("hedera/react", () => {
 
       const { result } = renderHook(
         () => hooks.useHederaEnrichedDelegation(mockAccount, delegation),
-        {
-          wrapper: createWrapper(),
-        },
+        { wrapper },
       );
 
       await waitFor(() => expect(result.current.pendingReward).toEqual(new BigNumber(1500)));

--- a/libs/ledger-live-common/src/families/hedera/react.ts
+++ b/libs/ledger-live-common/src/families/hedera/react.ts
@@ -1,8 +1,7 @@
 import BigNumber from "bignumber.js";
-import { queryOptions, useQuery } from "@tanstack/react-query";
-import { getHederaValidators } from "@ledgerhq/coin-hedera/network/utils";
-import { HEDERA_VALIDATORS_CACHE_MINUTES } from "@ledgerhq/coin-hedera/constants";
-import { getDelegationStatus } from "./utils";
+import { useMemo } from "react";
+import { useGetValidatorsQuery } from "./state-manager/api";
+import { filterValidatorBySearchTerm, getDelegationStatus } from "./utils";
 import type {
   HederaAccount,
   HederaValidator,
@@ -10,36 +9,40 @@ import type {
   HederaEnrichedDelegation,
 } from "./types";
 
-const HEDERA_VALIDATORS_CACHE_TTL_MS = HEDERA_VALIDATORS_CACHE_MINUTES * 60 * 1000;
-
-export const hederaQueries = {
-  all: () => ["hedera"] as const,
-  validatorsList: (currencyId: string) =>
-    queryOptions({
-      queryKey: [...hederaQueries.all(), "validators", currencyId],
-      // getHederaValidators owns the TTL and is the same data that getTransactionStatus validates against.
-      // staleTime stays 0 to keep both reading one entry.
-      // side effect: refetch and invalidateQueries are no-ops, call .clear() to force a refresh.
-      queryFn: (): Promise<HederaValidator[]> => getHederaValidators(currencyId),
-      retry: false,
-      staleTime: 0,
-      gcTime: HEDERA_VALIDATORS_CACHE_TTL_MS,
-    }),
+export type HederaValidatorsQuery = {
+  validators: HederaValidator[];
+  loading: boolean;
+  error: Error | null;
 };
+
+export function useHederaValidators(currencyId: string, search?: string): HederaValidatorsQuery {
+  const { data, isLoading, error } = useGetValidatorsQuery(currencyId);
+
+  const validators = useMemo(() => {
+    const all = data ?? [];
+    return search ? all.filter(v => filterValidatorBySearchTerm(v, search)) : all;
+  }, [data, search]);
+
+  return {
+    validators,
+    loading: isLoading,
+    // an error while validators are already cached is not worth showing, the list still renders
+    error: data === undefined && error instanceof Error ? error : null,
+  };
+}
 
 export function useHederaEnrichedDelegation(
   account: HederaAccount,
   delegation: HederaDelegation,
 ): HederaEnrichedDelegation {
-  const queryValidators = useQuery(hederaQueries.validatorsList(account.currency.id));
-  const validators = queryValidators.data ?? [];
+  const { validators, loading, error } = useHederaValidators(account.currency.id);
   const validatorById = new Map(validators.map(v => [v.id, v]));
   const validator = validatorById.get(String(delegation.nodeId)) ?? null;
 
   return {
     ...delegation,
-    loading: queryValidators.isLoading,
-    error: queryValidators.data === undefined ? queryValidators.error : null,
+    loading,
+    error,
     status: getDelegationStatus(validator),
     validator: {
       name: validator?.name ?? "",

--- a/libs/ledger-live-common/src/families/hedera/state-manager/api.ts
+++ b/libs/ledger-live-common/src/families/hedera/state-manager/api.ts
@@ -1,0 +1,25 @@
+import { createApi, fakeBaseQuery } from "@reduxjs/toolkit/query/react";
+import { getHederaValidators } from "@ledgerhq/coin-hedera/network/utils";
+import { HEDERA_VALIDATORS_CACHE_MINUTES } from "@ledgerhq/coin-hedera/constants";
+import type { HederaValidator } from "../types";
+
+export const hederaApi = createApi({
+  reducerPath: "hederaApi",
+  baseQuery: fakeBaseQuery<Error>(),
+  // getHederaValidators is LRU-cached, so refetching on mount re-reads that cache, not the network.
+  refetchOnMountOrArgChange: true,
+  endpoints: build => ({
+    getValidators: build.query<HederaValidator[], string>({
+      queryFn: async currencyId => {
+        try {
+          return { data: await getHederaValidators(currencyId) };
+        } catch (error) {
+          return { error: error instanceof Error ? error : new Error(String(error)) };
+        }
+      },
+      keepUnusedDataFor: HEDERA_VALIDATORS_CACHE_MINUTES * 60,
+    }),
+  }),
+});
+
+export const { useGetValidatorsQuery } = hederaApi;


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR moves the Hedera validators list from the React Query cache onto RTK Query, keeping it consistent with how the rest of the app fetches remote data. It adds a small RTK Query api that wraps the existing LRU-cached validators fetch and wires it into both apps' shared query reducers, and updates `useHederaValidators` (and everything that consumes it: the delegation, redelegation and undelegation flows on desktop and mobile) to read loading and error state from the query hook instead of the old preload observable. No behavior changes beyond that swap, mostly test and call-site updates to match the new hook shape.

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- https://ledgerhq.atlassian.net/browse/LIVE-36153