### PR TITLE
feat(pay): send noah webview to signup or signin

### DIFF
--- a/.changeset/noah-auth-redirect.md
+++ b/.changeset/noah-auth-redirect.md
@@ -1,0 +1,7 @@
+---
+"@features/flow-pay-bank-transfer": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Route the Noah webview to signup or signin when noahAuth is set (LIVE-35383).

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -105,6 +105,7 @@
     "@features/flow-pay-card-auth": "workspace:^",
     "@features/flow-pay-balance": "workspace:^",
     "@features/flow-pay-contact": "workspace:^",
+    "@features/flow-pay-bank-transfer": "workspace:^",
     "@features/flow-pay-deposit": "workspace:^",
     "@features/flow-pay-card-details": "workspace:^",
     "@features/flow-pay-feature-tour": "workspace:^",

--- a/apps/ledger-live-desktop/src/renderer/screens/bank/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/bank/index.tsx
@@ -6,6 +6,7 @@ import { useProviderInterstitalEnabled } from "@ledgerhq/live-common/hooks/useSh
 import { useManifestWithSessionId } from "@ledgerhq/live-common/hooks/useManifestWithSessionId";
 import { useRemoteLiveAppManifest } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
 import { useLocalLiveAppManifest } from "@ledgerhq/live-common/wallet-api/LocalLiveAppProvider/index";
+import { getNoahGoToURL, type NoahAuthPath } from "@features/flow-pay-bank-transfer";
 import { openModal } from "~/renderer/actions/modals";
 import { RECEIVE_SOURCE_PAGE } from "LLD/features/Receive/types";
 import Card from "~/renderer/components/Box/Card";
@@ -31,7 +32,18 @@ const Bank = () => {
   });
   const navigate = useNavigate();
   const themeType = useTheme().theme;
-  const params = location.state || {};
+  const noahAuth = new URLSearchParams(location.search).get("noahAuth");
+  let authPath: NoahAuthPath | undefined;
+  if (noahAuth === "createAccount") {
+    authPath = "/auth/signup";
+  }
+  if (noahAuth === "logIn") {
+    authPath = "/auth/signin";
+  }
+  const goToURL = getNoahGoToURL(manifestWithSessionId?.url.toString(), authPath, {
+    theme: themeType,
+    lang: locale,
+  });
   const providerInterstitialEnabled = useProviderInterstitalEnabled({
     manifest,
   });
@@ -45,6 +57,7 @@ const Bank = () => {
     <Card grow style={{ overflow: "hidden" }} data-testid="reveive-app-container">
       {manifestWithSessionId ? (
         <WebPlatformPlayer
+          key={goToURL ?? "catalog"}
           config={{
             topBarConfig: {
               shouldDisplayName: false,
@@ -57,7 +70,7 @@ const Bank = () => {
           inputs={{
             theme: themeType,
             lang: locale,
-            ...params,
+            ...(goToURL ? { goToURL } : {}),
           }}
           onClose={handleClose}
           Loader={providerInterstitialEnabled ? CustomProviderInterstitial : undefined}

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -114,6 +114,7 @@
     "@features/flow-pay-card": "workspace:^",
     "@features/flow-pay-card-auth": "workspace:^",
     "@features/flow-pay-balance": "workspace:^",
+    "@features/flow-pay-bank-transfer": "workspace:^",
     "@features/flow-pay-deposit": "workspace:^",
     "@features/flow-pay-feature-tour": "workspace:^",
     "@features/flow-pay-card-request": "workspace:^",

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/ReceiveFundsNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/ReceiveFundsNavigator.ts
@@ -9,6 +9,7 @@ export type ReceiveFundsStackParamList = {
   [ScreenName.ReceiveProvider]: {
     manifestId: string;
     fromMenu?: boolean;
+    noahAuth?: "createAccount" | "logIn";
   };
   [ScreenName.ReceiveConnectDevice]: {
     account?: AccountLike;

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/01b-ReceiveProvider..tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/01b-ReceiveProvider..tsx
@@ -10,28 +10,42 @@ import {
   useRemoteLiveAppContext,
   useRemoteLiveAppManifest,
 } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
+import { getNoahGoToURL, type NoahAuthPath } from "@features/flow-pay-bank-transfer";
 import WebRecievePlayer from "~/components/WebReceivePlayer";
 import GenericErrorView from "~/components/GenericErrorView";
 import { Flex, InfiniteLoader } from "@ledgerhq/native-ui";
 import { useSelector } from "~/context/hooks";
-import { analyticsEnabledSelector } from "~/reducers/settings";
+import { analyticsEnabledSelector, languageSelector } from "~/reducers/settings";
 
 export default function ReceiveProvider(
   props: StackNavigatorProps<ReceiveFundsStackParamList, ScreenName.ReceiveProvider>,
 ) {
-  const { manifestId } = props?.route?.params ?? {};
+  const { manifestId, noahAuth } = props?.route?.params ?? {};
+  let authPath: NoahAuthPath | undefined;
+  if (noahAuth === "createAccount") {
+    authPath = "/auth/signup";
+  }
+  if (noahAuth === "logIn") {
+    authPath = "/auth/signin";
+  }
   const localManifest = useLocalLiveAppManifest(manifestId);
   const remoteManifest = useRemoteLiveAppManifest(manifestId);
   const manifest = localManifest || remoteManifest;
   const shareAnalytics = useSelector(analyticsEnabledSelector);
+  const lang = useSelector(languageSelector);
   const { manifest: manifestWithSessionId, loading: sessionIdLoading } = useManifestWithSessionId({
     manifest,
     shareAnalytics,
   });
   const { state: remoteLiveAppState } = useRemoteLiveAppContext();
+  const goToURL = getNoahGoToURL(manifestWithSessionId?.url.toString(), authPath, { lang });
 
   return manifestWithSessionId ? (
-    <WebRecievePlayer manifest={manifestWithSessionId} />
+    <WebRecievePlayer
+      key={goToURL ?? "catalog"}
+      manifest={manifestWithSessionId}
+      inputs={goToURL ? { goToURL } : undefined}
+    />
   ) : (
     <Flex flex={1} p={10} justifyContent="center" alignItems="center">
       {remoteLiveAppState.isLoading || sessionIdLoading ? (

--- a/features/flow/pay-bank-transfer/src/exports.ts
+++ b/features/flow/pay-bank-transfer/src/exports.ts
@@ -1,2 +1,3 @@
 export * from "./components/BankTransferIntro";
+export * from "./getNoahGoToURL";
 export * from "./types";

--- a/features/flow/pay-bank-transfer/src/getNoahGoToURL.test.ts
+++ b/features/flow/pay-bank-transfer/src/getNoahGoToURL.test.ts
@@ -1,0 +1,35 @@
+import { getNoahGoToURL } from "./getNoahGoToURL";
+
+const MANIFEST_URL = "https://noah.example/app?session=abc";
+
+describe("getNoahGoToURL", () => {
+  it("should rewrite the pathname to signup", () => {
+    expect(getNoahGoToURL(MANIFEST_URL, "/auth/signup")).toBe(
+      "https://noah.example/auth/signup?session=abc",
+    );
+  });
+
+  it("should rewrite the pathname to signin", () => {
+    expect(getNoahGoToURL(MANIFEST_URL, "/auth/signin")).toBe(
+      "https://noah.example/auth/signin?session=abc",
+    );
+  });
+
+  it("should set theme and lang query params when provided", () => {
+    expect(getNoahGoToURL(MANIFEST_URL, "/auth/signup", { theme: "dark", lang: "fr" })).toBe(
+      "https://noah.example/auth/signup?session=abc&theme=dark&lang=fr",
+    );
+  });
+
+  it("should return undefined when the manifest url is missing", () => {
+    expect(getNoahGoToURL(undefined, "/auth/signup")).toBeUndefined();
+  });
+
+  it("should return undefined when the auth path is missing", () => {
+    expect(getNoahGoToURL(MANIFEST_URL, undefined)).toBeUndefined();
+  });
+
+  it("should return undefined when the manifest url is invalid", () => {
+    expect(getNoahGoToURL("not-a-url", "/auth/signup")).toBeUndefined();
+  });
+});

--- a/features/flow/pay-bank-transfer/src/getNoahGoToURL.ts
+++ b/features/flow/pay-bank-transfer/src/getNoahGoToURL.ts
@@ -1,0 +1,23 @@
+export type NoahAuthPath = "/auth/signup" | "/auth/signin";
+
+export type NoahGoToURLParams = Readonly<{
+  lang?: string;
+  theme?: string;
+}>;
+
+export function getNoahGoToURL(
+  manifestUrl: string | undefined,
+  authPath: NoahAuthPath | undefined,
+  params?: NoahGoToURLParams,
+): string | undefined {
+  if (!manifestUrl || !authPath) return undefined;
+  try {
+    const url = new URL(manifestUrl);
+    url.pathname = authPath;
+    if (params?.theme) url.searchParams.set("theme", params.theme);
+    if (params?.lang) url.searchParams.set("lang", params.lang);
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}

--- a/features/flow/pay-bank-transfer/src/types.ts
+++ b/features/flow/pay-bank-transfer/src/types.ts
@@ -8,6 +8,8 @@ export type BankTransferIntroRow = Readonly<{
   description: string;
 }>;
 
+export type BankTransferHandoff = "createAccount" | "logIn";
+
 export type BankTransferIntroLabels = Readonly<{
   title: string;
   description: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -938,6 +938,9 @@ importers:
       '@features/flow-pay-balance':
         specifier: workspace:^
         version: link:../../features/flow/pay-balance
+      '@features/flow-pay-bank-transfer':
+        specifier: workspace:^
+        version: link:../../features/flow/pay-bank-transfer
       '@features/flow-pay-card':
         specifier: workspace:^
         version: link:../../features/flow/pay-card
@@ -1789,6 +1792,9 @@ importers:
       '@features/flow-pay-balance':
         specifier: workspace:^
         version: link:../../features/flow/pay-balance
+      '@features/flow-pay-bank-transfer':
+        specifier: workspace:^
+        version: link:../../features/flow/pay-bank-transfer
       '@features/flow-pay-card':
         specifier: workspace:^
         version: link:../../features/flow/pay-card


### PR DESCRIPTION
### 📝 Description

Pay deposit Bank transfer will hand users to Noah signup or signin. The webview still always opened the Noah catalog.

This PR adds `getNoahGoToURL(manifestUrl, authPath, params?)` and wires it on both hosts. `authPath` is `"/auth/signup" | "/auth/signin"`. Call sites map `noahAuth=createAccount|logIn` with two `if`s. No `noahAuth` keeps the catalog.

```ts
const goToURL = getNoahGoToURL(manifestUrl, authPath, { theme, lang });
// WebPlatformPlayer / WebReceivePlayer inputs.goToURL
```

Intros in the stacked PRs start passing `noahAuth`. This PR only prepares the rewrite.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35383](https://ledgerhq.atlassian.net/browse/LIVE-35383)
- **Stacked**: #21299 (desktop intro) → #21298 (mobile intro) → #21350 (i18n)

### 🧪 How to test

- [ ] Desktop: `/bank?noahAuth=createAccount` lands on Noah signup
- [ ] Desktop: `/bank?noahAuth=logIn` lands on Noah signin
- [ ] Mobile: ReceiveProvider `{ manifestId: "noah", noahAuth: "logIn" }` lands on signin
- [ ] Pay deposit Bank transfer without `noahAuth` still opens the catalog

[LIVE-35383]: https://ledgerhq.atlassian.net/browse/LIVE-35383