### PR TITLE
[LWD] fix(swap): handle webview load failures gracefully (LIVE-36600)

### DIFF
--- a/.changeset/swap-webview-err-aborted-fix.md
+++ b/.changeset/swap-webview-err-aborted-fix.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix swap webview silently reporting ERR_ABORTED as an error and showing a blank screen on ERR_FAILED

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/PlatformAPIWebview.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/PlatformAPIWebview.test.tsx
@@ -1,0 +1,212 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { PlatformAPIWebview } from "./PlatformAPIWebview";
+import { useWebviewState } from "./helpers";
+import type { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
+
+jest.mock("./helpers", () => ({
+  useWebviewState: jest.fn(),
+  getAttachedWebview: jest.fn(),
+}));
+
+jest.mock("./NetworkError", () => ({
+  NetworkErrorScreen: ({ refresh }: { refresh: () => void }) => (
+    <div data-testid="network-error-screen" onClick={refresh} />
+  ),
+}));
+
+jest.mock("./styled", () => ({
+  Loader: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="loader">{children}</div>
+  ),
+}));
+
+jest.mock("../BigSpinner", () => ({
+  __esModule: true,
+  default: () => <div data-testid="spinner" />,
+}));
+
+jest.mock("LLD/hooks/redux", () => ({
+  useDispatch: () => jest.fn(),
+  useSelector: jest.fn(selector => selector({})),
+}));
+
+jest.mock("@ledgerhq/live-common/notifications/ToastProvider/index", () => ({
+  useToasts: () => ({ pushToast: jest.fn() }),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock("@ledgerhq/live-common/platform/react", () => ({
+  useListPlatformAccounts: () => jest.fn(),
+  useListPlatformCurrencies: () => jest.fn(),
+}));
+
+jest.mock("@ledgerhq/live-common/platform/JSONRPCServer", () => ({
+  useJSONRPCServer: () => [jest.fn()],
+}));
+
+jest.mock("@ledgerhq/live-common/platform/logic", () => ({
+  receiveOnAccountLogic: jest.fn(),
+  signTransactionLogic: jest.fn(),
+  completeExchangeLogic: jest.fn(),
+  signMessageLogic: jest.fn(),
+}));
+
+jest.mock("@ledgerhq/live-common/platform/serializers", () => ({
+  serializePlatformSignedTransaction: jest.fn(),
+}));
+
+jest.mock("@ledgerhq/live-common/platform/tracking", () => ({
+  __esModule: true,
+  default: () => ({
+    platformLoad: jest.fn(),
+    platformLoadSuccess: jest.fn(),
+    platformSignMessageUserRefused: jest.fn(),
+    platformReceiveSuccess: jest.fn(),
+    platformReceiveFail: jest.fn(),
+    platformStartExchangeRequested: jest.fn(),
+    platformStartExchangeSuccess: jest.fn(),
+    platformStartExchangeFail: jest.fn(),
+    platformCompleteExchangeSuccess: jest.fn(),
+    platformCompleteExchangeFail: jest.fn(),
+    platformSignTransactionSuccess: jest.fn(),
+    platformSignTransactionFail: jest.fn(),
+    platformSignMessageSuccess: jest.fn(),
+    platformSignMessageFail: jest.fn(),
+  }),
+}));
+
+jest.mock("@features/platform-currencies", () => ({
+  useFeatureFlaggedCurrencies: () => ({ deactivatedCurrencyIds: [] }),
+}));
+
+jest.mock("@features/platform-env", () => ({ __esModule: true, default: () => false }));
+
+jest.mock("@features/platform-feature-flags", () => ({
+  useFeature: () => null,
+}));
+
+jest.mock("LLD/features/ModularDialog/Web3AppWebview/AssetAndAccountDrawer", () => ({
+  useOpenAssetAndAccount: () => ({ openAssetAndAccountPromise: jest.fn() }),
+}));
+
+jest.mock("~/renderer/reducers/accounts", () => ({
+  flattenAccountsSelector: jest.fn(() => []),
+}));
+
+jest.mock("~/renderer/reducers/settings", () => ({
+  mevProtectionSelector: jest.fn(() => false),
+}));
+
+jest.mock("~/renderer/reducers/wallet", () => ({
+  walletSelector: jest.fn(() => ({ accountNames: {} })),
+}));
+
+jest.mock("~/renderer/reducers/modularDialog", () => ({
+  setFlowValue: jest.fn(),
+  setSourceValue: jest.fn(),
+}));
+
+jest.mock("~/renderer/analytics/originFlow", () => ({
+  setOriginFlow: jest.fn(),
+}));
+
+jest.mock("~/renderer/analytics/segment", () => ({ track: jest.fn() }));
+
+jest.mock("~/renderer/analytics/screenRefs", () => ({
+  currentRouteNameRef: { current: null },
+}));
+
+jest.mock("~/renderer/analytics/hooks/variables", () => ({
+  HOOKS_TRACKING_LOCATIONS: {},
+}));
+
+jest.mock("../../actions/modals", () => ({ openModal: jest.fn() }));
+
+jest.mock("./LiveAppSDKLogic", () => ({
+  requestAccountLogic: jest.fn(),
+  broadcastTransactionLogic: jest.fn(),
+}));
+
+const mockManifest: LiveAppManifest = {
+  id: "test-app",
+  name: "Test App",
+  private: false,
+  url: "https://example.com",
+  homepageUrl: "https://example.com",
+  icon: "",
+  platforms: ["desktop"],
+  providerTestBaseUrl: "",
+  providerTestId: "",
+  apiVersion: "^1.0.0",
+  manifestVersion: "2",
+  branch: "stable",
+  categories: [],
+  currencies: "*",
+  content: { shortDescription: { en: "Test" }, description: { en: "Test" } },
+  permissions: [],
+  domains: ["https://example.com"],
+  visibility: "complete",
+};
+
+const mockWebviewState = (overrides = {}) => ({
+  loading: false,
+  isAppUnavailable: false,
+  url: new URL("https://example.com"),
+  canGoBack: false,
+  canGoForward: false,
+  title: "",
+  ...overrides,
+});
+
+const defaultHookResult = {
+  webviewState: mockWebviewState(),
+  webviewRef: { current: null },
+  setWebviewRef: jest.fn(),
+  webviewProps: { src: "https://example.com" },
+  webviewPartition: {},
+  handleRefresh: jest.fn(),
+};
+
+const mockUseWebviewState = jest.mocked(useWebviewState);
+
+describe("PlatformAPIWebview", () => {
+  beforeAll(() => {
+    Object.defineProperty(global, "api", {
+      value: { appDirname: "/fake/path", openWindow: jest.fn() },
+      writable: true,
+    });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseWebviewState.mockReturnValue(defaultHookResult as never);
+  });
+
+  it("shows NetworkErrorScreen and hides Loader when isAppUnavailable", () => {
+    mockUseWebviewState.mockReturnValue({
+      ...defaultHookResult,
+      webviewState: mockWebviewState({ isAppUnavailable: true }),
+    } as never);
+
+    const { queryByTestId } = render(<PlatformAPIWebview manifest={mockManifest} />);
+
+    expect(queryByTestId("network-error-screen")).toBeInTheDocument();
+    expect(queryByTestId("loader")).not.toBeInTheDocument();
+  });
+
+  it("hides NetworkErrorScreen when app is available", () => {
+    const { queryByTestId } = render(<PlatformAPIWebview manifest={mockManifest} />);
+
+    expect(queryByTestId("network-error-screen")).not.toBeInTheDocument();
+  });
+
+  it("shows Loader while widget is loading and no error", () => {
+    const { queryByTestId } = render(<PlatformAPIWebview manifest={mockManifest} />);
+
+    expect(queryByTestId("loader")).toBeInTheDocument();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/PlatformAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/PlatformAPIWebview.tsx
@@ -51,15 +51,21 @@ import { setOriginFlow } from "~/renderer/analytics/originFlow";
 export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
   ({ manifest, inputs = {}, onStateChange }, ref) => {
     const manifestDomainCheckEnabled = useFeature("lldWebviewManifestDomainCheck")?.enabled;
-    const { webviewState, webviewRef, setWebviewRef, webviewProps, webviewPartition, handleRefresh } =
-      useWebviewState(
-        {
-          manifest,
-          inputs,
-          manifestDomainCheckEnabled,
-        },
-        ref,
-      );
+    const {
+      webviewState,
+      webviewRef,
+      setWebviewRef,
+      webviewProps,
+      webviewPartition,
+      handleRefresh,
+    } = useWebviewState(
+      {
+        manifest,
+        inputs,
+        manifestDomainCheckEnabled,
+      },
+      ref,
+    );
 
     const tracking = useMemo(
       () =>

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/PlatformAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/PlatformAPIWebview.tsx
@@ -38,6 +38,7 @@ import {
 import { Loader } from "./styled";
 import { WebviewAPI, WebviewProps } from "./types";
 import { useWebviewState } from "./helpers";
+import { NetworkErrorScreen } from "./NetworkError";
 import { currentRouteNameRef } from "~/renderer/analytics/screenRefs";
 import { mevProtectionSelector } from "~/renderer/reducers/settings";
 import { walletSelector } from "~/renderer/reducers/wallet";
@@ -50,7 +51,7 @@ import { setOriginFlow } from "~/renderer/analytics/originFlow";
 export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
   ({ manifest, inputs = {}, onStateChange }, ref) => {
     const manifestDomainCheckEnabled = useFeature("lldWebviewManifestDomainCheck")?.enabled;
-    const { webviewState, webviewRef, setWebviewRef, webviewProps, webviewPartition } =
+    const { webviewState, webviewRef, setWebviewRef, webviewProps, webviewPartition, handleRefresh } =
       useWebviewState(
         {
           manifest,
@@ -443,6 +444,8 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
       // oxlint-disable-next-line react-hooks/exhaustive-deps
     }, [handleLoad, handleDomReady]);
 
+    const isNetworkErrorVisible = !webviewState.loading && webviewState.isAppUnavailable;
+
     const webviewStyle = useMemo(() => {
       return {
         opacity: widgetLoaded ? 1 : 0,
@@ -450,11 +453,13 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
         width: "100%",
         flex: 1,
         transition: "opacity 200ms ease-out",
+        ...(isNetworkErrorVisible ? { display: "none" } : {}),
       };
-    }, [widgetLoaded]);
+    }, [widgetLoaded, isNetworkErrorVisible]);
 
     return (
       <>
+        {isNetworkErrorVisible && <NetworkErrorScreen refresh={handleRefresh} />}
         <webview
           ref={setWebviewRef}
           /**
@@ -478,7 +483,7 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
           {...webviewProps}
           {...webviewPartition}
         />
-        {!widgetLoaded ? (
+        {!widgetLoaded && !isNetworkErrorVisible ? (
           <Loader>
             <BigSpinner size={50} />
           </Loader>

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook } from "tests/testSetup";
 import { getAttachedWebview, useWebviewState } from "./helpers";
 import { getInitialURL } from "@ledgerhq/live-common/wallet-api/helpers";
+import { track } from "~/renderer/analytics/segment";
 import type { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import type { WebviewAPI, WebviewTag } from "./types";
 import type { RefObject } from "react";
@@ -15,6 +16,10 @@ jest.mock("@ledgerhq/live-common/wallet-api/manifestDomainUtils", () => ({
 
 jest.mock("@ledgerhq/live-common/wallet-api/react", () => ({
   useDAppManifestCurrencyIds: jest.fn(() => []),
+}));
+
+jest.mock("~/renderer/analytics/segment", () => ({
+  track: jest.fn(),
 }));
 
 const mockManifest: LiveAppManifest = {
@@ -42,6 +47,7 @@ const mockManifest: LiveAppManifest = {
 };
 
 const mockGetInitialURL = jest.mocked(getInitialURL);
+const mockTrack = jest.mocked(track);
 
 const createWebview = (getWebContentsId: () => number) =>
   ({
@@ -81,6 +87,7 @@ describe("getAttachedWebview", () => {
 describe("useWebviewState", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockTrack.mockClear();
   });
 
   describe("webviewProps.src", () => {
@@ -297,6 +304,66 @@ describe("useWebviewState", () => {
       addEventListener.mock.calls.forEach(([eventName, handler]) => {
         expect(removeEventListener).toHaveBeenCalledWith(eventName, handler);
       });
+    });
+  });
+
+  describe("handleFailLoad", () => {
+    const setupWithWebview = () => {
+      mockGetInitialURL.mockReturnValue("https://example.com/");
+      const addEventListener = jest.fn();
+      const mockWebview = {
+        addEventListener,
+        removeEventListener: jest.fn(),
+        getWebContentsId: () => 42,
+        reload: jest.fn(),
+        goBack: jest.fn(),
+        goForward: jest.fn(),
+        openDevTools: jest.fn(),
+        clearHistory: jest.fn(),
+        loadURL: jest.fn(() => Promise.resolve()),
+      } as unknown as WebviewTag;
+
+      const { result } = renderHook(() => useWebviewState({ manifest: mockManifest }, null));
+      act(() => { result.current.setWebviewRef(mockWebview); });
+
+      const handler = addEventListener.mock.calls.find(
+        ([event]: [string]) => event === "did-fail-load",
+      )?.[1];
+
+      return { result, handler };
+    };
+
+    it("ignores ERR_ABORTED (-3) without updating state or tracking", () => {
+      const { result, handler } = setupWithWebview();
+
+      act(() => {
+        handler({ errorCode: -3, errorDescription: "ERR_ABORTED", validatedURL: "https://example.com/", isMainFrame: true });
+      });
+
+      expect(result.current.webviewState.isAppUnavailable).toBe(false);
+      expect(mockTrack).not.toHaveBeenCalled();
+    });
+
+    it("sets isAppUnavailable and tracks when ERR_FAILED (-2) hits the main frame", () => {
+      const { result, handler } = setupWithWebview();
+
+      act(() => {
+        handler({ errorCode: -2, errorDescription: "ERR_FAILED", validatedURL: "https://example.com/", isMainFrame: true });
+      });
+
+      expect(result.current.webviewState.isAppUnavailable).toBe(true);
+      expect(mockTrack).toHaveBeenCalledWith("useWebviewState", { errorCode: -2, url: "example.com" });
+    });
+
+    it("does not set isAppUnavailable when ERR_FAILED (-2) is on a sub-frame", () => {
+      const { result, handler } = setupWithWebview();
+
+      act(() => {
+        handler({ errorCode: -2, errorDescription: "ERR_FAILED", validatedURL: "https://example.com/", isMainFrame: false });
+      });
+
+      expect(result.current.webviewState.isAppUnavailable).toBe(false);
+      expect(mockTrack).toHaveBeenCalled();
     });
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.test.ts
@@ -324,7 +324,9 @@ describe("useWebviewState", () => {
       } as unknown as WebviewTag;
 
       const { result } = renderHook(() => useWebviewState({ manifest: mockManifest }, null));
-      act(() => { result.current.setWebviewRef(mockWebview); });
+      act(() => {
+        result.current.setWebviewRef(mockWebview);
+      });
 
       const handler = addEventListener.mock.calls.find(
         ([event]: [string]) => event === "did-fail-load",
@@ -337,7 +339,12 @@ describe("useWebviewState", () => {
       const { result, handler } = setupWithWebview();
 
       act(() => {
-        handler({ errorCode: -3, errorDescription: "ERR_ABORTED", validatedURL: "https://example.com/", isMainFrame: true });
+        handler({
+          errorCode: -3,
+          errorDescription: "ERR_ABORTED",
+          validatedURL: "https://example.com/",
+          isMainFrame: true,
+        });
       });
 
       expect(result.current.webviewState.isAppUnavailable).toBe(false);
@@ -348,18 +355,31 @@ describe("useWebviewState", () => {
       const { result, handler } = setupWithWebview();
 
       act(() => {
-        handler({ errorCode: -2, errorDescription: "ERR_FAILED", validatedURL: "https://example.com/", isMainFrame: true });
+        handler({
+          errorCode: -2,
+          errorDescription: "ERR_FAILED",
+          validatedURL: "https://example.com/",
+          isMainFrame: true,
+        });
       });
 
       expect(result.current.webviewState.isAppUnavailable).toBe(true);
-      expect(mockTrack).toHaveBeenCalledWith("useWebviewState", { errorCode: -2, url: "example.com" });
+      expect(mockTrack).toHaveBeenCalledWith("useWebviewState", {
+        errorCode: -2,
+        url: "example.com",
+      });
     });
 
     it("does not set isAppUnavailable when ERR_FAILED (-2) is on a sub-frame", () => {
       const { result, handler } = setupWithWebview();
 
       act(() => {
-        handler({ errorCode: -2, errorDescription: "ERR_FAILED", validatedURL: "https://example.com/", isMainFrame: false });
+        handler({
+          errorCode: -2,
+          errorDescription: "ERR_FAILED",
+          validatedURL: "https://example.com/",
+          isMainFrame: false,
+        });
       });
 
       expect(result.current.webviewState.isAppUnavailable).toBe(false);

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "tests/testSetup";
+import { act, renderHook } from "@testing-library/react";
 import { getAttachedWebview, useWebviewState } from "./helpers";
 import { getInitialURL } from "@ledgerhq/live-common/wallet-api/helpers";
 import { track } from "~/renderer/analytics/segment";

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.ts
@@ -242,6 +242,11 @@ export function useWebviewState(
 
   const handleFailLoad = useCallback((errorEvent: Electron.DidFailLoadEvent) => {
     const { errorCode, validatedURL, isMainFrame } = errorEvent;
+
+    // ERR_ABORTED (-3) means the navigation was cancelled (e.g. user closed the drawer
+    // before the webview finished loading). This is intentional — not an error.
+    if (errorCode === -3) return;
+
     const fullURL = new URL(validatedURL);
     const errorInfo = {
       errorCode,


### PR DESCRIPTION
### 📝 Description

Two Chromium error codes were being reported identically to Datadog as unexpected errors on the swap webview (`swap-live-app.ledger.com`), affecting 646 users over 7 days.

**ERR_ABORTED (-3)** fires when the user closes the drawer before the webview finishes loading — this is intentional cancellation, not an error. Fixed by returning early in `handleFailLoad` before any state change or tracking.

**ERR_FAILED (-2)** fires on a genuine load failure. `WalletAPIWebview` already showed a `NetworkErrorScreen` with a retry button in this case, but `PlatformAPIWebview` had no such handling — leaving users on a blank screen. Fixed by mirroring the same `isNetworkErrorVisible` pattern from `WalletAPIWebview`.

Regression covered by 3 new unit tests in `helpers.test.ts`.

### 🔗 Context

- **JIRA / GitHub issue**: LIVE-36600
