### PR TITLE
chore(deps): bump signer-solana and contacts device kits

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 2.0.4
       version: 2.0.4
     '@ledgerhq/device-contacts-kit':
-      specifier: 0.2.0
-      version: 0.2.0
+      specifier: 0.3.0
+      version: 0.3.0
     '@ledgerhq/device-management-kit':
       specifier: 1.8.0
       version: 1.8.0
@@ -61,8 +61,8 @@ catalogs:
       specifier: 0.2.0
       version: 0.2.0
     '@ledgerhq/device-signer-kit-solana':
-      specifier: 1.12.1
-      version: 1.12.1
+      specifier: 1.13.0
+      version: 1.13.0
     '@ledgerhq/device-transport-kit-react-native-ble':
       specifier: 1.3.2
       version: 1.3.2
@@ -7507,7 +7507,7 @@ importers:
         version: link:../feature-flags
       '@ledgerhq/device-contacts-kit':
         specifier: 'catalog:'
-        version: 0.2.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+        version: 0.3.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
       '@ledgerhq/device-signer-kit-ethereum':
         specifier: 'catalog:'
         version: 1.17.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
@@ -15900,7 +15900,7 @@ importers:
         version: 1.8.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-solana':
         specifier: 'catalog:'
-        version: 1.12.1(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))(@typescript/typescript6@6.0.2)
+        version: 1.13.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))(@typescript/typescript6@6.0.2)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../ledgerjs/packages/devices
@@ -22170,8 +22170,8 @@ packages:
       react-native:
         optional: true
 
-  '@ledgerhq/device-contacts-kit@0.2.0':
-    resolution: {integrity: sha512-k8DPz+aMGGfYoB9lLe2GDmrHidHHeN8uuMjRqEBDJUecwZ4j3wxSAxsHHR66cXWqAU5QJH7bz3XzXvUSqkMzBg==}
+  '@ledgerhq/device-contacts-kit@0.3.0':
+    resolution: {integrity: sha512-RDSOiOhfIzTC0d/YCjCte90zqt1Kwr4YKIh1j+Tw8EaHUIq2kQtgqE1zwTFJO1YHVwFn0dHG1brxtnwGnMkPnA==}
     peerDependencies:
       '@ledgerhq/device-management-kit': ^1.8.0
 
@@ -22213,8 +22213,8 @@ packages:
     peerDependencies:
       '@ledgerhq/device-management-kit': ^1.7.1
 
-  '@ledgerhq/device-signer-kit-solana@1.12.1':
-    resolution: {integrity: sha512-hCqTkLLH9DycViDBgYU6KkSE01yOp8AsnqjIzq5Gsy9803CVzrw+veld82YzY1UMMvQHqZDaFHNXkHoiMcGxJA==}
+  '@ledgerhq/device-signer-kit-solana@1.13.0':
+    resolution: {integrity: sha512-rP1entTQsavEbhsOuKhsB5hS4JTs0BM5U1jdD+6iVbgghxy4NYESjS0Szq+iq7JI48EdyX65JE4rhz6WAoRHOQ==}
     peerDependencies:
       '@ledgerhq/device-management-kit': ^1.8.0
 
@@ -28711,7 +28711,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: '*'
+      rxjs: ^5.5.10
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -49176,7 +49176,7 @@ snapshots:
       '@ledgerhq/lumen-ui-rnative': 0.1.58(50360a3b8905e3a0b0efc588bd9418f4)
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
 
-  '@ledgerhq/device-contacts-kit@0.2.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))':
+  '@ledgerhq/device-contacts-kit@0.3.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))':
     dependencies:
       '@ledgerhq/device-management-kit': 1.8.0(rxjs@7.8.2)
       '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
@@ -49316,7 +49316,7 @@ snapshots:
       reflect-metadata: 0.2.2
       xstate: 5.19.2
 
-  '@ledgerhq/device-signer-kit-solana@1.12.1(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))(@typescript/typescript6@6.0.2)':
+  '@ledgerhq/device-signer-kit-solana@1.13.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))(@typescript/typescript6@6.0.2)':
     dependencies:
       '@ledgerhq/context-module': 2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
       '@ledgerhq/device-management-kit': 1.8.0(rxjs@7.8.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,14 +24,14 @@ catalog:
   "@jest/globals": 30.4.1
   "@ledgerhq/context-module": 2.5.0
   "@ledgerhq/crypto-icons": "2.0.4"
-  "@ledgerhq/device-contacts-kit": 0.2.0
+  "@ledgerhq/device-contacts-kit": 0.3.0
   "@ledgerhq/device-management-kit": 1.8.0
   "@ledgerhq/dmk-ledger-wallet": 0.5.0
   "@ledgerhq/device-signer-kit-aleo": 0.4.0
   "@ledgerhq/device-signer-kit-concordium": 0.4.0
   "@ledgerhq/device-signer-kit-ethereum": 1.17.0
   "@ledgerhq/device-signer-kit-hyperliquid": 0.0.0-hyperliquid-unified-20260728150448
-  "@ledgerhq/device-signer-kit-solana": 1.12.1
+  "@ledgerhq/device-signer-kit-solana": 1.13.0
   "@ledgerhq/device-signer-kit-cosmos": 1.0.1
   "@ledgerhq/device-signer-kit-icp": 0.2.0
   "@ledgerhq/device-transport-kit-react-native-ble": 1.3.2


### PR DESCRIPTION
### 📝 Description

Move the pnpm catalog onto the two device kits published by the [device-sdk-ts release run 33408503608](https://github.com/LedgerHQ/device-sdk-ts/actions/runs/33408503608), which completed successfully.

| Package | Before | After |
| --- | --- | --- |
| `@ledgerhq/device-signer-kit-solana` | 1.12.1 | 1.13.0 |
| `@ledgerhq/device-contacts-kit` | 0.2.0 | 0.3.0 |

Both still peer-depend on `@ledgerhq/device-management-kit` `^1.8.0`, so the catalog's DMK 1.8.0 keeps satisfying them and no other pin moves. The lockfile diff touches only these two entries.

**`device-signer-kit-solana` 1.13.0**

- Blind-sign event reporting for the Solana transaction signing flow ([device-sdk-ts#1796](https://github.com/LedgerHQ/device-sdk-ts/pull/1796) — blind-sign events)
- Request `ALT_RESOLUTION` for every ALT-backed account the device dereferences at finalize ([device-sdk-ts#1821](https://github.com/LedgerHQ/device-sdk-ts/pull/1821) — ALT resolution coverage)
- Context-providers return `CommandResult` instead of throwing ([device-sdk-ts#1764](https://github.com/LedgerHQ/device-sdk-ts/pull/1764) — command result refactor)
- Error-logging cleanups ([device-sdk-ts#1765](https://github.com/LedgerHQ/device-sdk-ts/pull/1765) — clear-sign log refactor, [device-sdk-ts#1771](https://github.com/LedgerHQ/device-sdk-ts/pull/1771) — no raw errors in log data)

**`device-contacts-kit` 0.3.0**

- `ContactsManager.editExternalAddressIdentifier` ([device-sdk-ts#1803](https://github.com/LedgerHQ/device-sdk-ts/pull/1803) — edit identifier op)
- `ContactsManager.editExternalAddressScope` ([device-sdk-ts#1825](https://github.com/LedgerHQ/device-sdk-ts/pull/1825) — edit scope op)
- The external-address operations no longer send the `DERIVATION_PATH` TLV (tag `0x69`) ([device-sdk-ts#1830](https://github.com/LedgerHQ/device-sdk-ts/pull/1830) — drop derivation path TLV)

### ❓ Context

- **JIRA or GitHub link**: [NO-ISSUE]
- **Feature**: dependency maintenance — unblocks the Contacts edit-identifier / edit-scope flows, which currently sit on a pinned snapshot of the kit.

### ✅ Checklist

- [x] **Covered by automatic tests** — no product code changes; existing suites cover the consumers (`libs/live-signer-solana`, `features/platform/contacts`).
- [x] **Changeset is provided** — not needed. Catalog-only bumps of external dependencies publish nothing; this matches the precedent set by `chore(deps): bump device kits to their latest releases`.
- [x] **Documentation is up-to-date** — nothing to document.
- [ ] **Impact of the changes:**
  - `@ledgerhq/device-signer-kit-solana` 1.12.1 → 1.13.0, consumed by `libs/live-signer-solana`. QA should exercise Solana send / clear-sign, including blind-sign and ALT-heavy transactions.
  - `@ledgerhq/device-contacts-kit` 0.2.0 → 0.3.0, consumed by `features/platform/contacts`. QA should exercise register / edit external address.
  - ⚠️ **Requires an Ethereum app build that has dropped the `DERIVATION_PATH` requirement.** Older Ethereum apps that still mandate the tag reject the external-address operations with `0x6a80`. This is the kit's own note on the change, and it is the one item worth watching in this bump.
