### PR TITLE
[LWDM] fix(pay-card): read the Card env vars on every use

### DIFF
--- a/.changeset/card-env-vars-read-live.md
+++ b/.changeset/card-env-vars-read-live.md
@@ -1,0 +1,8 @@
+---
+"@shared/api-services": minor
+"@features/flow-pay-card": minor
+"live-mobile": minor
+"ledger-live-desktop": minor
+---
+
+Read CARD_API_URL and CARD_BAANX_CLIENT_KEY on every use, and not one time at boot. The debug settings can now change the Card tenant without a restart. The mobile app also applies its `.env` values before the store reads them.

--- a/apps/ledger-live-desktop/src/mvvm/components/RightPanel/Card/useCardViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/RightPanel/Card/useCardViewModel.ts
@@ -3,7 +3,7 @@ import BigNumber from "bignumber.js";
 import { useTranslation } from "react-i18next";
 import { formatCurrencyUnitFragment } from "@ledgerhq/live-common/currencies/index";
 import type { FormattedValue } from "@features/flow-pay-card-details";
-import { getEnv } from "@shared/env";
+import useEnv from "@features/platform-env";
 import { useSelector } from "LLD/hooks/redux";
 import { counterValueCurrencySelector, localeSelector } from "~/renderer/reducers/settings";
 import type { CardViewModel } from "./types";
@@ -20,15 +20,21 @@ export function useCardViewModel(): CardViewModel {
     [unit, locale],
   );
 
+  // Read with `useEnv`, and not with `getEnv`: a tester sets these in the debug settings, and the
+  // login must take the new values without a restart of the app.
+  const apiUrl = useEnv("CARD_API_URL");
+  const clientId = useEnv("CARD_BAANX_CLIENT_KEY");
+  const redirectUri = useEnv("CARD_OAUTH_REDIRECT_URI");
+
   // Baanx uses the same value for the client key header and the OAuth `client_id`.
   const oauthConfig: CardViewModel["oauthConfig"] = useMemo(
     () => ({
-      apiUrl: getEnv("CARD_API_URL"),
-      clientId: getEnv("CARD_BAANX_CLIENT_KEY"),
+      apiUrl,
+      clientId,
       // No `deepLink`: the user's own browser opens the page, and it reports nothing back (LIVE-34740).
-      redirectUri: getEnv("CARD_OAUTH_REDIRECT_URI"),
+      redirectUri,
     }),
-    [],
+    [apiUrl, clientId, redirectUri],
   );
 
   return {

--- a/apps/ledger-live-desktop/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-desktop/src/state-manager/configureStore.ts
@@ -64,8 +64,9 @@ const customCreateStore = ({
                 coinMarketCapApiUrl: getEnv("CMC_API_URL"),
               }),
               ...cardApiExtra({
-                cardApiBaseUrl: getEnv("CARD_API_URL"),
-                cardBaanxClientKey: getEnv("CARD_BAANX_CLIENT_KEY"),
+                // Read on every request, so the debug settings can change them without a restart.
+                getCardApiBaseUrl: () => getEnv("CARD_API_URL"),
+                getCardBaanxClientKey: () => getEnv("CARD_BAANX_CLIENT_KEY"),
                 getCardSessionToken,
                 refreshCardSession,
               }),

--- a/apps/ledger-live-mobile/src/experimental.ts
+++ b/apps/ledger-live-mobile/src/experimental.ts
@@ -152,28 +152,15 @@ export const isReadOnly = (key: string) => Object.keys(Config).includes(key);
 export const enabledExperimentalFeatures = (): string[] =>
   [...experimentalFeatures, ...developerFeatures].map(e => e.name).filter(k => !isEnvDefault(k));
 
-/**
- * The build's own values, which `react-native-config` reads from the `.env` file.
- *
- * They are applied here, while this module evaluates, and not in the asynchronous block below. Some
- * modules read an env once, as they evaluate, and keep that value: the redux store takes the Card
- * API base URL and the Baanx client key that way. A copy that waits for the disk lands after those
- * reads, and the store keeps the definition default instead of the `.env` value.
- */
-for (const k in Config) {
-  // The native module answers null for a key the build left out, and the parsers refuse it.
-  if (Config[k] == null) continue;
-  setEnvUnsafe(k as EnvName, Config[k]);
-}
-
 (async () => {
   const envs = await getStorageEnv();
 
   for (const k in envs) {
-    // The build value wins over a saved one, which is the rule `isReadOnly` states. The loop above
-    // already applied it, so a saved value must not overwrite it here.
-    if (isReadOnly(k)) continue;
     setEnvUnsafe(k as EnvName, envs[k]);
+  }
+
+  for (const k in Config) {
+    setEnvUnsafe(k as EnvName, Config[k]);
   }
 
   const saveEnvs = async (name: string, value: unknown) => {

--- a/apps/ledger-live-mobile/src/experimental.ts
+++ b/apps/ledger-live-mobile/src/experimental.ts
@@ -152,15 +152,28 @@ export const isReadOnly = (key: string) => Object.keys(Config).includes(key);
 export const enabledExperimentalFeatures = (): string[] =>
   [...experimentalFeatures, ...developerFeatures].map(e => e.name).filter(k => !isEnvDefault(k));
 
+/**
+ * The build's own values, which `react-native-config` reads from the `.env` file.
+ *
+ * They are applied here, while this module evaluates, and not in the asynchronous block below. Some
+ * modules read an env once, as they evaluate, and keep that value: the redux store takes the Card
+ * API base URL and the Baanx client key that way. A copy that waits for the disk lands after those
+ * reads, and the store keeps the definition default instead of the `.env` value.
+ */
+for (const k in Config) {
+  // The native module answers null for a key the build left out, and the parsers refuse it.
+  if (Config[k] == null) continue;
+  setEnvUnsafe(k as EnvName, Config[k]);
+}
+
 (async () => {
   const envs = await getStorageEnv();
 
   for (const k in envs) {
+    // The build value wins over a saved one, which is the rule `isReadOnly` states. The loop above
+    // already applied it, so a saved value must not overwrite it here.
+    if (isReadOnly(k)) continue;
     setEnvUnsafe(k as EnvName, envs[k]);
-  }
-
-  for (const k in Config) {
-    setEnvUnsafe(k as EnvName, Config[k]);
   }
 
   const saveEnvs = async (name: string, value: unknown) => {

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.test.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { Text } from "react-native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import { render, screen } from "@tests/test-renderer";
-import { getEnv } from "@shared/env";
+import { act, render, screen } from "@tests/test-renderer";
+import { getEnv, getEnvDefault, setEnv } from "@shared/env";
 import { ScreenName } from "~/const";
 import { PAY_TAB_DEEP_LINK } from "~/navigation/deeplinks/payTabDeepLink";
 import type { PayTabNavigatorParamList } from "../../types";
@@ -37,6 +37,11 @@ function renderViewModel(params?: PayTabNavigatorParamList[typeof ScreenName.Pay
 }
 
 describe("usePayTabViewModel", () => {
+  afterEach(() => {
+    setEnv("CARD_API_URL", getEnvDefault("CARD_API_URL"));
+    setEnv("CARD_BAANX_CLIENT_KEY", getEnvDefault("CARD_BAANX_CLIENT_KEY"));
+  });
+
   it("should expose the OAuth client configuration", () => {
     renderViewModel();
 
@@ -48,6 +53,19 @@ describe("usePayTabViewModel", () => {
       getEnv("CARD_OAUTH_REDIRECT_URI"),
     );
     expect(screen.getByTestId("oauth-deeplink")).toHaveTextContent(PAY_TAB_DEEP_LINK);
+  });
+
+  it("should follow a change of the Card env vars", () => {
+    // What the debug settings do. The login has to take the new tenant without a restart.
+    renderViewModel();
+
+    act(() => {
+      setEnv("CARD_API_URL", "https://card.staging.test");
+      setEnv("CARD_BAANX_CLIENT_KEY", "staging-client-key");
+    });
+
+    expect(screen.getByTestId("oauth-api-url")).toHaveTextContent("https://card.staging.test");
+    expect(screen.getByTestId("oauth-client-id")).toHaveTextContent("staging-client-key");
   });
 
   it("should hand the login flow the redirect the deep link carried", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { useRoute, type RouteProp } from "@react-navigation/native";
-import { getEnv } from "@shared/env";
+import useEnv from "@features/platform-env";
 import { useTranslation } from "~/context/Locale";
 import type { ScreenName } from "~/const";
 import type { CardProps } from "@features/flow-pay-card";
@@ -26,15 +26,21 @@ export function usePayTabViewModel() {
   const actionTiles = usePayTabActionTiles(balance.onTrackEvent, deposit.open, request.open);
   const contacts = usePayTabContacts();
 
+  // Read with `useEnv`, and not with `getEnv`: a tester sets these in the debug settings, and the
+  // login must take the new values without a restart of the app.
+  const apiUrl = useEnv("CARD_API_URL");
+  const clientId = useEnv("CARD_BAANX_CLIENT_KEY");
+  const redirectUri = useEnv("CARD_OAUTH_REDIRECT_URI");
+
   // Baanx uses the same value for the client key header and the OAuth `client_id`.
   const oauthConfig: CardProps["oauthConfig"] = useMemo(
     () => ({
-      apiUrl: getEnv("CARD_API_URL"),
-      clientId: getEnv("CARD_BAANX_CLIENT_KEY"),
-      redirectUri: getEnv("CARD_OAUTH_REDIRECT_URI"),
+      apiUrl,
+      clientId,
+      redirectUri,
       deepLink: PAY_TAB_DEEP_LINK,
     }),
-    [],
+    [apiUrl, clientId, redirectUri],
   );
 
   // The OAuth redirect, when the deep link brought one. The code is the whole of it: PKCE ties it to

--- a/apps/ledger-live-mobile/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-mobile/src/state-manager/configureStore.ts
@@ -59,8 +59,9 @@ export const store = configureStore({
               coinMarketCapApiUrl: getEnv("CMC_API_URL"),
             }),
             ...cardApiExtra({
-              cardApiBaseUrl: getEnv("CARD_API_URL"),
-              cardBaanxClientKey: getEnv("CARD_BAANX_CLIENT_KEY"),
+              // Read on every request, so the debug settings can change them without a restart.
+              getCardApiBaseUrl: () => getEnv("CARD_API_URL"),
+              getCardBaanxClientKey: () => getEnv("CARD_BAANX_CLIENT_KEY"),
               getCardSessionToken,
               refreshCardSession,
             }),

--- a/domain/api/card-management/src/api.test.ts
+++ b/domain/api/card-management/src/api.test.ts
@@ -114,8 +114,8 @@ const makeStore = (
       gdm({
         thunk: {
           extraArgument: cardApiExtra({
-            cardApiBaseUrl: "https://card.test",
-            cardBaanxClientKey: "client-key",
+            getCardApiBaseUrl: () => "https://card.test",
+            getCardBaanxClientKey: () => "client-key",
             getCardSessionToken,
             refreshCardSession: () => Promise.resolve(null),
           }),

--- a/features/flow/pay-card/src/CardView.native.tsx
+++ b/features/flow/pay-card/src/CardView.native.tsx
@@ -16,14 +16,7 @@ export function CardView({ title, oauthConfig, callback, cardVisual }: CardViewP
           face shows once the holder is signed in and has a card, while the login shows only while
           nobody is signed in. Right now each child decides on its own, so they can overlap. */}
       {cardVisual ? <CardVisual {...cardVisual} /> : <CardArtwork />}
-      {/* `key`: the login machine reads its config one time, when it starts. A tester who changes
-          CARD_API_URL or CARD_BAANX_CLIENT_KEY in the debug settings gets a new config here, and the
-          machine has to start again to build the authorize URL from it. */}
-      <CardLogin
-        key={`${oauthConfig.apiUrl}|${oauthConfig.clientId}`}
-        oauthConfig={oauthConfig}
-        callback={callback}
-      />
+      <CardLogin key={`${oauthConfig.apiUrl}`} oauthConfig={oauthConfig} callback={callback} />
       <CardLogout />
     </Box>
   );

--- a/features/flow/pay-card/src/CardView.native.tsx
+++ b/features/flow/pay-card/src/CardView.native.tsx
@@ -16,7 +16,14 @@ export function CardView({ title, oauthConfig, callback, cardVisual }: CardViewP
           face shows once the holder is signed in and has a card, while the login shows only while
           nobody is signed in. Right now each child decides on its own, so they can overlap. */}
       {cardVisual ? <CardVisual {...cardVisual} /> : <CardArtwork />}
-      <CardLogin oauthConfig={oauthConfig} callback={callback} />
+      {/* `key`: the login machine reads its config one time, when it starts. A tester who changes
+          CARD_API_URL or CARD_BAANX_CLIENT_KEY in the debug settings gets a new config here, and the
+          machine has to start again to build the authorize URL from it. */}
+      <CardLogin
+        key={`${oauthConfig.apiUrl}|${oauthConfig.clientId}`}
+        oauthConfig={oauthConfig}
+        callback={callback}
+      />
       <CardLogout />
     </Box>
   );

--- a/features/flow/pay-card/src/CardView.web.tsx
+++ b/features/flow/pay-card/src/CardView.web.tsx
@@ -13,14 +13,7 @@ export function CardView({ title, oauthConfig, callback, cardVisual }: CardViewP
           nobody is signed in. Right now each child decides on its own, so they can overlap. */}
       {cardVisual ? <CardVisual {...cardVisual} /> : <CardArtwork />}
       <Divider />
-      {/* `key`: the login machine reads its config one time, when it starts. A tester who changes
-          CARD_API_URL or CARD_BAANX_CLIENT_KEY in the debug settings gets a new config here, and the
-          machine has to start again to build the authorize URL from it. */}
-      <CardLogin
-        key={`${oauthConfig.apiUrl}|${oauthConfig.clientId}`}
-        oauthConfig={oauthConfig}
-        callback={callback}
-      />
+      <CardLogin key={`${oauthConfig.apiUrl}`} oauthConfig={oauthConfig} callback={callback} />
       <CardLogout />
     </div>
   );

--- a/features/flow/pay-card/src/CardView.web.tsx
+++ b/features/flow/pay-card/src/CardView.web.tsx
@@ -13,7 +13,14 @@ export function CardView({ title, oauthConfig, callback, cardVisual }: CardViewP
           nobody is signed in. Right now each child decides on its own, so they can overlap. */}
       {cardVisual ? <CardVisual {...cardVisual} /> : <CardArtwork />}
       <Divider />
-      <CardLogin oauthConfig={oauthConfig} callback={callback} />
+      {/* `key`: the login machine reads its config one time, when it starts. A tester who changes
+          CARD_API_URL or CARD_BAANX_CLIENT_KEY in the debug settings gets a new config here, and the
+          machine has to start again to build the authorize URL from it. */}
+      <CardLogin
+        key={`${oauthConfig.apiUrl}|${oauthConfig.clientId}`}
+        oauthConfig={oauthConfig}
+        callback={callback}
+      />
       <CardLogout />
     </div>
   );

--- a/shared/api-services/src/services/card/api.test.ts
+++ b/shared/api-services/src/services/card/api.test.ts
@@ -4,8 +4,8 @@ import type { CardApiExtra } from "./types";
 
 function buildExtra(overrides: Partial<CardApiExtra> = {}): CardApiExtra {
   return {
-    cardApiBaseUrl: "https://card.test",
-    cardBaanxClientKey: "test-client-key",
+    getCardApiBaseUrl: () => "https://card.test",
+    getCardBaanxClientKey: () => "test-client-key",
     getCardSessionToken: async () => "session-token",
     refreshCardSession: async () => "refreshed-token",
     ...overrides,
@@ -31,9 +31,9 @@ describe("cardApiExtra", () => {
     expect(cardApiExtra(extra)).toEqual(extra);
   });
 
-  it("throws when the base url is missing or empty", () => {
-    expect(() => cardApiExtra(buildExtra({ cardApiBaseUrl: undefined }))).toThrow();
-    expect(() => cardApiExtra(buildExtra({ cardApiBaseUrl: "" }))).toThrow();
+  it("throws when the config accessors are not functions", () => {
+    expect(() => cardApiExtra(buildExtra({ getCardApiBaseUrl: undefined }))).toThrow();
+    expect(() => cardApiExtra(buildExtra({ getCardBaanxClientKey: undefined }))).toThrow();
   });
 
   it("throws when the session accessors are not functions", () => {
@@ -42,7 +42,9 @@ describe("cardApiExtra", () => {
   });
 
   it("accepts an empty Baanx client key (provisioned later via CARD_BAANX_CLIENT_KEY)", () => {
-    expect(cardApiExtra(buildExtra({ cardBaanxClientKey: "" })).cardBaanxClientKey).toBe("");
+    expect(
+      cardApiExtra(buildExtra({ getCardBaanxClientKey: () => "" })).getCardBaanxClientKey(),
+    ).toBe("");
   });
 });
 
@@ -84,6 +86,30 @@ describe("cardBaseQuery", () => {
     expect(sent.url).toBe("https://card.test/probe");
     expect(sent.headers.get("authorization")).toBe("Bearer session-token");
     expect(sent.headers.get("x-client-key")).toBe("test-client-key");
+  });
+
+  it("reads the base url and the client key again on every request", async () => {
+    // The debug settings change the two envs while the app runs. The store holds the accessors, so
+    // the next request must carry the new values without a restart.
+    fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({}));
+    let baseUrl = "https://card.first";
+    let clientKey = "first-key";
+
+    const { api, store } = probeStore(
+      cardApiExtra(
+        buildExtra({ getCardApiBaseUrl: () => baseUrl, getCardBaanxClientKey: () => clientKey }),
+      ),
+    );
+    await store.dispatch(api.endpoints.probe.initiate());
+
+    baseUrl = "https://card.second";
+    clientKey = "second-key";
+    await store.dispatch(api.endpoints.probe.initiate(undefined, { forceRefetch: true }));
+
+    expect(request(fetchSpy, 0).url).toBe("https://card.first/probe");
+    expect(request(fetchSpy, 0).headers.get("x-client-key")).toBe("first-key");
+    expect(request(fetchSpy, 1).url).toBe("https://card.second/probe");
+    expect(request(fetchSpy, 1).headers.get("x-client-key")).toBe("second-key");
   });
 
   it("sends x-client-key and omits Authorization when no session token is available", async () => {

--- a/shared/api-services/src/services/card/api.ts
+++ b/shared/api-services/src/services/card/api.ts
@@ -44,10 +44,10 @@ const cardBaseQuery: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryErro
 
   const runWithToken = (token: string | null | undefined) =>
     fetchBaseQuery({
-      baseUrl: extra.cardApiBaseUrl,
+      baseUrl: extra.getCardApiBaseUrl(),
       prepareHeaders: headers => {
         headers.set("Content-Type", "application/json");
-        headers.set(HEADER_X_CLIENT_KEY, extra.cardBaanxClientKey);
+        headers.set(HEADER_X_CLIENT_KEY, extra.getCardBaanxClientKey());
         if (token) {
           headers.set("authorization", `Bearer ${token}`);
         }

--- a/shared/api-services/src/services/card/schema.ts
+++ b/shared/api-services/src/services/card/schema.ts
@@ -1,15 +1,24 @@
 import { z } from "zod";
 
+const isFunction = (value: unknown) => typeof value === "function";
+
 export const CardApiExtraSchema = z.object({
-  cardApiBaseUrl: z.string().min(1),
-  cardBaanxClientKey: z.string(),
+  /**
+   * The two Card values are read on every request, and not once at store creation: a tester sets
+   * `CARD_API_URL` and `CARD_BAANX_CLIENT_KEY` in the debug settings, and the next request carries
+   * the new value without a restart of the app.
+   */
+  getCardApiBaseUrl: z.custom<() => string>(isFunction, {
+    message: "getCardApiBaseUrl must be a function",
+  }),
+  getCardBaanxClientKey: z.custom<() => string>(isFunction, {
+    message: "getCardBaanxClientKey must be a function",
+  }),
   /** Async: the owner reads the session from OS secure storage on every call. */
-  getCardSessionToken: z.custom<() => Promise<string | null | undefined>>(
-    value => typeof value === "function",
-    { message: "getCardSessionToken must be a function" },
-  ),
-  refreshCardSession: z.custom<() => Promise<string | null | undefined>>(
-    value => typeof value === "function",
-    { message: "refreshCardSession must be a function" },
-  ),
+  getCardSessionToken: z.custom<() => Promise<string | null | undefined>>(isFunction, {
+    message: "getCardSessionToken must be a function",
+  }),
+  refreshCardSession: z.custom<() => Promise<string | null | undefined>>(isFunction, {
+    message: "refreshCardSession must be a function",
+  }),
 });


### PR DESCRIPTION
### 📝 Description

**Previous behaviour.** `CARD_API_URL` and `CARD_BAANX_CLIENT_KEY` entered the app one time only:

- `configureStore.ts` read both while its own module evaluated and put the two strings in the thunk `extraArgument`. Every Card request read that snapshot.
- The Pay tab and desktop card panel read them in a `useMemo` with an empty dependency list, while the login machine keeps its input for the life of the actor.

A tester who changed the two variables in Settings > Developer > Env therefore did not update Card requests or the login flow without restarting the app.

**The fix.**

1. `CardApiExtraSchema` takes `getCardApiBaseUrl` and `getCardBaanxClientKey`, next to the two session accessors it already had. The shared base query calls them on every request, so the base URL and `x-client-key` header always carry the current value.
2. Both stores pass `() => getEnv(...)`.
3. `usePayTabViewModel` (mobile) and `useCardViewModel` (desktop) read the three Card envs with `useEnv`, so a change re-renders the view model.
4. `CardLogin` is keyed by the Card API URL. The login machine reads its config once when it starts, so changing the tenant starts a new machine and updates the authorize URL.

**Automated checks.** The new test in `shared/api-services/src/services/card/api.test.ts` sends two requests through the base query and changes both values between them; it asserts each request carried its own URL and client key. The new test in `usePayTabViewModel.test.tsx` changes the two envs after render and reads the new config back.

**Behaviour for a tester.** Values changed in Settings > Developer > Env apply to the next request and the next login, with no app restart.

### 🔗 Context

- **JIRA / GitHub issue**: none yet — found while testing the Pay tab against the Baanx dev tenant on an iOS staging build.
- **ADR** (if any): n/a