### PR TITLE
[LWD] feat(history): gate contactId scoping behind lwdPayTab flag (LIVE-36762)

### DIFF
--- a/.changeset/fuzzy-carrots-report.md
+++ b/.changeset/fuzzy-carrots-report.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Gate History contactId scoping behind the lwdPayTab feature flag

--- a/.changeset/fuzzy-carrots-report.md
+++ b/.changeset/fuzzy-carrots-report.md
@@ -2,4 +2,4 @@
 "ledger-live-desktop": patch
 ---
 
-Gate History contactId scoping behind the lwdPayTab feature flag
+Gate History contact features (contactId scoping and From/To contact name resolution) behind the lwdPayTab feature flag

--- a/apps/ledger-live-desktop/src/mvvm/features/History/__integrations__/History.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/__integrations__/History.integration.test.tsx
@@ -252,6 +252,7 @@ describe("History integration", () => {
         accounts: [account],
         settings: AFTER_ONBOARDING_STATE,
         contacts: { contacts: [aliceContact()] },
+        ...withFlagOverrides({ lwdPayTab: { enabled: true } }),
       },
     });
 
@@ -274,12 +275,33 @@ describe("History integration", () => {
         accounts: [account],
         settings: AFTER_ONBOARDING_STATE,
         contacts: { contacts: [aliceContact()] },
+        ...withFlagOverrides({ lwdPayTab: { enabled: true } }),
       },
     });
 
     await waitFor(() => {
       expect(screen.getByTestId(`history-operation-row-${OUT_TO_OTHER_OP_ID}`)).toBeVisible();
     });
+    expect(screen.queryByTestId("history-contact-scope")).not.toBeInTheDocument();
+  });
+
+  it("should ignore the contactId scope when the lwdPayTab flag is disabled", async () => {
+    const account = createEthAccountWithContactTransfers();
+
+    render(<History />, {
+      initialRoute: `/history?contactId=${CONTACT_HISTORY_ID}`,
+      initialState: {
+        accounts: [account],
+        settings: AFTER_ONBOARDING_STATE,
+        contacts: { contacts: [aliceContact()] },
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId(`history-operation-row-${OUT_TO_OTHER_OP_ID}`)).toBeVisible();
+    });
+    expect(screen.getByTestId(`history-operation-row-${OUT_TO_CONTACT_OP_ID}`)).toBeVisible();
+    expect(screen.getByTestId(`history-operation-row-${IN_FROM_CONTACT_OP_ID}`)).toBeVisible();
     expect(screen.queryByTestId("history-contact-scope")).not.toBeInTheDocument();
   });
 
@@ -290,6 +312,7 @@ describe("History integration", () => {
         accounts: [EMPTY_BTC_ACCOUNT],
         settings: AFTER_ONBOARDING_STATE,
         contacts: { contacts: [aliceContact()] },
+        ...withFlagOverrides({ lwdPayTab: { enabled: true } }),
       },
     });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/OperationCounterpartyCell/__tests__/useOperationCounterpartyCellViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/OperationCounterpartyCell/__tests__/useOperationCounterpartyCellViewModel.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "tests/testSetup";
+import { renderHook, withFlagOverrides } from "tests/testSetup";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import {
@@ -36,9 +36,13 @@ const makeItem = (address: string): OperationTableItem =>
     type: "OUT",
   }) as unknown as OperationTableItem;
 
-const renderViewModel = (address: string) =>
+const renderViewModel = (address: string, payTabEnabled = true) =>
   renderHook(() => useOperationCounterpartyCellViewModel(makeItem(address)), {
-    initialState: { accounts: [account], contacts: { contacts: [ben] } },
+    initialState: {
+      accounts: [account],
+      contacts: { contacts: [ben] },
+      ...withFlagOverrides({ lwdPayTab: { enabled: payTabEnabled } }),
+    },
   });
 
 describe("useOperationCounterpartyCellViewModel", () => {
@@ -58,6 +62,13 @@ describe("useOperationCounterpartyCellViewModel", () => {
     const { result } = renderViewModel("0xdeadbeef00000000000000000000000000000000");
 
     expect(result.current.displayName).toBe("0xdead...0000");
+    expect(result.current.contactAddressLabel).toBeUndefined();
+  });
+
+  it("should ignore contact resolution when the lwdPayTab flag is disabled", () => {
+    const { result } = renderViewModel(contactAddress, false);
+
+    expect(result.current.displayName).toBe("0x1ad2...3034");
     expect(result.current.contactAddressLabel).toBeUndefined();
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/OperationCounterpartyCell/useOperationCounterpartyCellViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/OperationCounterpartyCell/useOperationCounterpartyCellViewModel.ts
@@ -1,5 +1,6 @@
 import { getCurrencyForAccount } from "@ledgerhq/types-live";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { useFeature } from "@features/platform-feature-flags";
 import { useAddressDisplay } from "LLD/hooks/useAddressDisplay";
 import type { OperationTableItem } from "../../types";
 
@@ -10,9 +11,12 @@ export function useOperationCounterpartyCellViewModel(item: OperationTableItem) 
   const currencyId =
     cryptoOrToken.type === "TokenCurrency" ? cryptoOrToken.parentCurrencyId : cryptoOrToken.id;
 
+  const isPayTabEnabled = !!useFeature("lwdPayTab")?.enabled;
+
   const { displayName, contactAddressLabel } = useAddressDisplay(
     address || mainAccount.freshAddress,
     currencyId,
+    { includeContacts: isPayTabEnabled },
   );
 
   return { displayName, contactAddressLabel };

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryViewModel.ts
@@ -5,6 +5,7 @@ import {
   SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY,
 } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
 import { ContactIdSchema, selectContactById, type Contact } from "@domain/entity-contact";
+import { useFeature } from "@features/platform-feature-flags";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { useHideSmallValueTokenOperations } from "~/renderer/actions/settings";
 import { addExtraTrackingPairs } from "~/renderer/reducers/countervaluesExtraTracking";
@@ -57,8 +58,9 @@ export function useHistoryViewModel(): HistoryViewModel {
   const { showBackButton, navigateBack } = usePopNavigationBack(parseHistoryBackPath);
 
   const [searchParams] = useSearchParams();
+  const isPayTabEnabled = !!useFeature("lwdPayTab")?.enabled;
   const contactIdResult = ContactIdSchema.safeParse(searchParams.get("contactId"));
-  const contactId = contactIdResult.success ? contactIdResult.data : undefined;
+  const contactId = isPayTabEnabled && contactIdResult.success ? contactIdResult.data : undefined;
   const contact = useSelector(state =>
     contactId ? selectContactById(state, contactId) : undefined,
   );

--- a/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/useAddressDisplay.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/useAddressDisplay.test.ts
@@ -94,6 +94,17 @@ describe("useAddressDisplay", () => {
     expect(result.current.contactAddressLabel).toBe("USDT Coinbase");
   });
 
+  it("should ignore contacts when includeContacts is false", () => {
+    const { result } = renderHook(
+      () => useAddressDisplay(contactAddress, "ethereum", { includeContacts: false }),
+      { initialState: stateWithContact },
+    );
+
+    expect(result.current.contactName).toBeUndefined();
+    expect(result.current.contactAddressLabel).toBeUndefined();
+    expect(result.current.displayName).toBe("0x1ad2...3034");
+  });
+
   it("should not match a contact address on another network", () => {
     const { result } = renderHook(() => useAddressDisplay(contactAddress, "polygon"), {
       initialState: stateWithContact,

--- a/apps/ledger-live-desktop/src/mvvm/hooks/useAddressDisplay.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/useAddressDisplay.ts
@@ -45,14 +45,25 @@ function useMatchingContact(address: string, currencyId: string) {
   );
 }
 
+export type UseAddressDisplayOptions = {
+  /** When false, contact matches are ignored (no contact name nor address label). Defaults to true. */
+  includeContacts?: boolean;
+};
+
 /**
  * Resolves the best display label for a blockchain address.
  * Priority: Ledger account name > contact name > truncated address.
  *
  * @param address - raw blockchain address
  * @param currencyId - main currency id (use parentCurrency.id for tokens)
+ * @param options - set of options to configure the display
  */
-export function useAddressDisplay(address: string, currencyId: string): AddressDisplayResult {
+export function useAddressDisplay(
+  address: string,
+  currencyId: string,
+  options?: UseAddressDisplayOptions,
+): AddressDisplayResult {
+  const includeContacts = options?.includeContacts ?? true;
   const matchingAccount = useMatchingAccount(address, currencyId);
   const accountName = useMaybeAccountName(matchingAccount);
   const matchingContact = useMatchingContact(address, currencyId);
@@ -60,7 +71,8 @@ export function useAddressDisplay(address: string, currencyId: string): AddressD
   return useMemo(() => {
     if (!address) return EMPTY_RESULT;
 
-    const contactName = matchingContact?.contactName;
+    const contact = includeContacts ? matchingContact : undefined;
+    const contactName = contact?.contactName;
     const displayName = accountName ?? contactName ?? truncateAddress(address);
 
     return {
@@ -68,7 +80,7 @@ export function useAddressDisplay(address: string, currencyId: string): AddressD
       matchingAccount,
       accountName,
       contactName,
-      contactAddressLabel: matchingContact?.addressLabel,
+      contactAddressLabel: contact?.addressLabel,
     };
-  }, [address, matchingAccount, accountName, matchingContact]);
+  }, [address, matchingAccount, accountName, matchingContact, includeContacts]);
 }


### PR DESCRIPTION
### 📝 Description

On Ledger Wallet Desktop, the History page reads `?contactId=` from the URL to scope operations to a single contact (contact chip in the header + send/receive filtering). This entry point originates from the Pay Tab, which is gated behind the `lwdPayTab` feature flag.

This PR gates the History `contactId` scoping behind the same `lwdPayTab` flag:

- `useHistoryViewModel` now reads `useFeature("lwdPayTab")` and only parses/selects the contact when the flag is enabled. With the flag off (default), `/history?contactId=...` behaves like unscoped History (no contact chip, no filtering).
- Pay Tab's "View transactions" navigation is unchanged (Pay Tab is already flag-gated).

Automated checks preventing regression (`History.integration.test.tsx`):
- Flag on: contact chip is shown and only the contact's send/receive rows are visible.
- Flag off/absent: `contactId` in the URL is ignored, all rows are shown and no contact chip is rendered.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36762](https://ledgerhq.atlassian.net/browse/LIVE-36762)
- **ADR** (if any): N/A

[LIVE-36762]: https://ledgerhq.atlassian.net/browse/LIVE-36762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ