### PR TITLE
[LWDM] fix(contacts): repair Ledger Sync entry point (LIVE-36667)

### DIFF
--- a/.changeset/LIVE-36667-contacts-ledger-sync-entry.md
+++ b/.changeset/LIVE-36667-contacts-ledger-sync-entry.md
@@ -1,0 +1,8 @@
+---
+"@features/flow-contacts-introduction": minor
+"@features/flow-contacts": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Fix the Ledger Sync entry point from Contacts: align the introduction copy and artwork with the production design, only show it when the user actually tries to add a contact or an address, start the flow on "Choose your sync method", and return to Contacts instead of the Portfolio once the flow is done on Mobile.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -320,6 +320,16 @@ describe("Contacts integration", () => {
     expect(screen.getByTestId("contacts-detail-name")).toHaveTextContent("Coinbase 1");
   });
 
+  it("should not open Ledger Sync activation when landing on Contacts while sync is inactive", () => {
+    mockedContactsLedgerSyncStatus.mockReturnValue("inactive");
+    renderContactsScreen();
+
+    expect(screen.getByTestId("contacts-page")).toBeVisible();
+    expect(
+      screen.queryByTestId("contacts-ledger-sync-introduction-dialog"),
+    ).not.toBeInTheDocument();
+  });
+
   it("should open Ledger Sync activation instead of adding a contact while sync is inactive", async () => {
     mockedContactsLedgerSyncStatus.mockReturnValue("inactive");
     const { user } = renderContactsScreen();
@@ -327,12 +337,28 @@ describe("Contacts integration", () => {
     await user.click(screen.getByTestId("contacts-add-contact"));
 
     expect(screen.queryByTestId("contacts-add-contact-dialog")).not.toBeInTheDocument();
-    expect(screen.getByRole("dialog")).toBeVisible();
+    expect(screen.getByTestId("contacts-ledger-sync-introduction-dialog")).toBeVisible();
+    expect(screen.getByText("Sync your wallet to add a contact")).toBeVisible();
 
-    await user.click(screen.getByRole("button", { name: "Turn on Ledger Sync" }));
+    await user.click(screen.getByRole("button", { name: "Sync my wallet" }));
 
-    expect(mockOpenActivationDrawer).toHaveBeenCalledTimes(1);
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(mockOpenActivationDrawer).toHaveBeenCalledWith({ startOnSyncMethod: true });
+    expect(
+      screen.queryByTestId("contacts-ledger-sync-introduction-dialog"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should close the Ledger Sync introduction from the secondary action", async () => {
+    mockedContactsLedgerSyncStatus.mockReturnValue("inactive");
+    const { user } = renderContactsScreen();
+
+    await user.click(screen.getByTestId("contacts-add-contact"));
+    await user.click(screen.getByRole("button", { name: "Not now" }));
+
+    expect(mockOpenActivationDrawer).not.toHaveBeenCalled();
+    expect(
+      screen.queryByTestId("contacts-ledger-sync-introduction-dialog"),
+    ).not.toBeInTheDocument();
   });
 
   it("should block a duplicate contact name and allow a unique replacement", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -203,7 +203,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
   );
   const ledgerSyncStatus = useContactsLedgerSyncStatus();
   const { requestMutation, dismissPendingIntent } = useContactsLedgerSyncMutationGuard();
-  const [isLedgerSyncIntroductionDismissed, setIsLedgerSyncIntroductionDismissed] = useState(false);
+  const [isLedgerSyncIntroductionRequested, setIsLedgerSyncIntroductionRequested] = useState(false);
   const onAddAddress = useCallback(
     (contact: AddAddressContact) => {
       const result = requestMutation(
@@ -212,7 +212,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
       );
       if (result.status !== "allowed") {
         if (result.status === "blocked") {
-          setIsLedgerSyncIntroductionDismissed(false);
+          setIsLedgerSyncIntroductionRequested(true);
         }
         return;
       }
@@ -390,13 +390,13 @@ export function useContactsViewModel(): ContactsPageViewModel {
   const onDismissLedgerSyncIntroduction = useCallback(() => {
     trackContactsLedgerSyncDismiss(analytics);
     dismissPendingIntent();
-    setIsLedgerSyncIntroductionDismissed(true);
+    setIsLedgerSyncIntroductionRequested(false);
   }, [analytics, dismissPendingIntent]);
   const onActivateLedgerSyncIntroduction = useCallback(() => {
     trackContactsLedgerSyncActivate(analytics);
     dismissPendingIntent();
-    setIsLedgerSyncIntroductionDismissed(true);
-    openDrawer();
+    setIsLedgerSyncIntroductionRequested(false);
+    openDrawer({ startOnSyncMethod: true });
   }, [analytics, dismissPendingIntent, openDrawer]);
   const onRequestAddContact = useCallback(
     (onAllowed: () => void) => {
@@ -404,7 +404,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
       if (result.status === "allowed") {
         onAllowed();
       } else if (result.status === "blocked") {
-        setIsLedgerSyncIntroductionDismissed(false);
+        setIsLedgerSyncIntroductionRequested(true);
       }
     },
     [ledgerSyncStatus, requestMutation],
@@ -413,14 +413,14 @@ export function useContactsViewModel(): ContactsPageViewModel {
   useEffect(() => {
     if (!isContactsLedgerSyncActivationRequired(ledgerSyncStatus)) {
       dismissPendingIntent();
-      setIsLedgerSyncIntroductionDismissed(false);
+      setIsLedgerSyncIntroductionRequested(false);
     }
   }, [dismissPendingIntent, ledgerSyncStatus]);
 
   const isLedgerSyncIntroductionOpen = resolveContactsLedgerSyncIntroductionOpen({
     isFeatureIntroductionRequested: featureIntroductionState.isRequested,
     ledgerSyncStatus,
-    isLedgerSyncIntroductionDismissed,
+    isLedgerSyncIntroductionRequested,
   });
   const onCompleteFeatureIntroduction = useCallback(() => {
     featureIntroductionState.dismiss();
@@ -466,6 +466,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
     },
     ledgerSyncIntroduction: {
       isOpen: isLedgerSyncIntroductionOpen,
+      title: t("contacts.ledgerSyncIntroduction.title"),
       description: t("contacts.ledgerSyncIntroduction.description"),
       activateLabel: t("contacts.ledgerSyncIntroduction.activate"),
       dismissLabel: t("contacts.ledgerSyncIntroduction.dismiss"),

--- a/apps/ledger-live-desktop/src/mvvm/features/LedgerSyncEntryPoints/hooks/useActivationDrawer.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LedgerSyncEntryPoints/hooks/useActivationDrawer.ts
@@ -9,17 +9,25 @@ import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { walletSyncFakedSelector, walletSyncStepSelector } from "~/renderer/reducers/walletSync";
 import { useFlows } from "../../WalletSync/hooks/useFlows";
 
+export type OpenActivationDrawerOptions = Readonly<{
+  startOnSyncMethod?: boolean;
+}>;
+
 export function useActivationDrawer(onboardingNewDevice?: boolean) {
   const dispatch = useDispatch();
-  const { goToWelcomeScreenWalletSync } = useFlows();
+  const { goToWelcomeScreenWalletSync, goToSyncMethodScreenWalletSync } = useFlows();
   const hasBeenFaked = useSelector(walletSyncFakedSelector);
   const currentStep = useSelector(walletSyncStepSelector);
   const hasFlowEvent = useMemo(() => !StepsOutsideFlow.includes(currentStep), [currentStep]);
   const { onActionTrack } = useLedgerSyncAnalytics();
 
-  const openDrawer = () => {
+  const openDrawer = (options?: OpenActivationDrawerOptions) => {
     if (!hasBeenFaked) {
-      goToWelcomeScreenWalletSync(onboardingNewDevice);
+      if (options?.startOnSyncMethod) {
+        goToSyncMethodScreenWalletSync();
+      } else {
+        goToWelcomeScreenWalletSync(onboardingNewDevice);
+      }
     }
     dispatch(setDrawerVisibility(true));
   };

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabContacts.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabContacts.ts
@@ -87,7 +87,7 @@ export function usePayTabContacts(): UsePayTabContactsResult {
     trackContactsLedgerSyncActivate(analytics);
     dismissPendingIntent();
     setIsLedgerSyncIntroductionRequested(false);
-    openDrawer();
+    openDrawer({ startOnSyncMethod: true });
   }, [analytics, dismissPendingIntent, openDrawer]);
   const onDismissLedgerSyncIntroduction = useCallback(() => {
     trackContactsLedgerSyncDismiss(analytics);
@@ -129,6 +129,7 @@ export function usePayTabContacts(): UsePayTabContactsResult {
       },
       ledgerSyncIntroduction: {
         open: isLedgerSyncIntroductionOpen,
+        title: t("contacts.ledgerSyncIntroduction.title"),
         description: t("contacts.ledgerSyncIntroduction.description"),
         activateLabel: t("contacts.ledgerSyncIntroduction.activate"),
         dismissLabel: t("contacts.ledgerSyncIntroduction.dismiss"),

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/useFlows.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/__tests__/useFlows.test.ts
@@ -72,6 +72,28 @@ describe("useFlows", () => {
     expect(store.getState().walletSync.flow).toBe(Flow.Activation);
   });
 
+  it("should go to the sync method step when no trustchain", () => {
+    const { result, store } = renderHook(() => useFlows(), { initialState: INITIAL_STATE });
+
+    act(() => {
+      result.current.goToSyncMethodScreenWalletSync();
+    });
+    expect(store.getState().walletSync.step).toBe(Step.SynchronizeMode);
+    expect(store.getState().walletSync.flow).toBe(Flow.Synchronize);
+  });
+
+  it("should go to LedgerSyncActivated from the sync method step when trustchain exists", () => {
+    const { result, store } = renderHook(() => useFlows(), {
+      initialState: INITIAL_STATE_WITH_TRUSTCHAIN,
+    });
+
+    act(() => {
+      result.current.goToSyncMethodScreenWalletSync();
+    });
+    expect(store.getState().walletSync.step).toBe(Step.LedgerSyncActivated);
+    expect(store.getState().walletSync.flow).toBe(Flow.LedgerSyncActivated);
+  });
+
   it("should expose FlowOptions and STEPS_WITH_BACK", () => {
     const { result } = renderHook(() => useFlows(), { initialState: INITIAL_STATE });
     expect(result.current.FlowOptions).toBeDefined();

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useFlows.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useFlows.ts
@@ -107,6 +107,14 @@ export const useFlows = () => {
     }
   };
 
+  const goToSyncMethodScreenWalletSync = () => {
+    if (trustchain?.rootId) {
+      dispatch(setFlow({ flow: Flow.LedgerSyncActivated, step: Step.LedgerSyncActivated }));
+    } else {
+      dispatch(setFlow({ flow: Flow.Synchronize, step: Step.SynchronizeMode }));
+    }
+  };
+
   return {
     currentFlow,
     currentStep,
@@ -114,5 +122,6 @@ export const useFlows = () => {
     goToPreviousScene,
     FlowOptions,
     goToWelcomeScreenWalletSync,
+    goToSyncMethodScreenWalletSync,
   };
 };

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9719,9 +9719,10 @@
       "cancel": "Cancel"
     },
     "ledgerSyncIntroduction": {
-      "description": "Your contacts are end-to-end encrypted with your Ledger and synced across your devices, only you can unlock them.",
-      "activate": "Turn on Ledger Sync",
-      "dismiss": "Got it"
+      "title": "Sync your wallet to add a contact",
+      "description": "Contacts are end-to-end encrypted and synced across Ledger Wallet on all your phones and computers.",
+      "activate": "Sync my wallet",
+      "dismiss": "Not now"
     },
     "featureIntroduction": {
       "title": "Introducing Contacts",

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -582,15 +582,18 @@ export enum WalletSyncActionTypes {
   WALLET_SYNC_SET_MANAGE_KEY_DRAWER = "WALLET_SYNC_SET_MANAGE_KEY_DRAWER",
   LEDGER_SYNC_SET_ACTIVATE_DRAWER = "LEDGER_SYNC_SET_ACTIVATE_DRAWER",
   LEDGER_SYNC_SET_ACTIVATE_STEP = "LEDGER_SYNC_SET_ACTIVATE_STEP",
+  LEDGER_SYNC_SET_RETURNS_TO_ENTRY_SCREEN = "LEDGER_SYNC_SET_RETURNS_TO_ENTRY_SCREEN",
 }
 
 export type WalletSyncSetManageKeyDrawerPayload = boolean;
 export type WalletSyncSetActivateDrawer = boolean;
 export type WalletSyncSetActivateStep = Steps;
+export type WalletSyncSetReturnsToEntryScreen = boolean;
 export type WalletSyncPayload =
   | WalletSyncSetManageKeyDrawerPayload
   | WalletSyncSetActivateDrawer
-  | WalletSyncSetActivateStep;
+  | WalletSyncSetActivateStep
+  | WalletSyncSetReturnsToEntryScreen;
 
 // === AUTH ACTIONS ===
 export enum AuthActionTypes {

--- a/apps/ledger-live-mobile/src/actions/walletSync.ts
+++ b/apps/ledger-live-mobile/src/actions/walletSync.ts
@@ -4,6 +4,7 @@ import type {
   WalletSyncSetActivateDrawer,
   WalletSyncSetActivateStep,
   WalletSyncSetManageKeyDrawerPayload,
+  WalletSyncSetReturnsToEntryScreen,
 } from "./types";
 
 export const setWallectSyncManageKeyDrawer = createAction<WalletSyncSetManageKeyDrawerPayload>(
@@ -16,4 +17,8 @@ export const setLedgerSyncActivateDrawer = createAction<WalletSyncSetActivateDra
 
 export const setLedgerSyncActivateStep = createAction<WalletSyncSetActivateStep>(
   WalletSyncActionTypes.LEDGER_SYNC_SET_ACTIVATE_STEP,
+);
+
+export const setLedgerSyncReturnsToEntryScreen = createAction<WalletSyncSetReturnsToEntryScreen>(
+  WalletSyncActionTypes.LEDGER_SYNC_SET_RETURNS_TO_ENTRY_SCREEN,
 );

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10581,10 +10581,10 @@
       "cancel": "Cancel"
     },
     "ledgerSyncIntroduction": {
-      "title": "Turn on Ledger Sync to save contacts",
-      "description": "Your contacts are end-to-end encrypted with your Ledger and synced across your devices, only you can unlock them.",
-      "activate": "Turn on Ledger Sync",
-      "dismiss": "Got it",
+      "title": "Sync your wallet to add a contact",
+      "description": "Contacts are end-to-end encrypted and synced across Ledger Wallet on all your phones and computers.",
+      "activate": "Sync my wallet",
+      "dismiss": "Not now",
       "checkingAccessibilityLabel": "Checking Ledger Sync status"
     },
     "featureIntroduction": {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -32,6 +32,11 @@ jest.mock("LLM/features/Send/hooks/useOpenSendFlow", () => ({
 
 jest.mock("LLM/features/MyWallet/views/Header/useMyWalletHeaderViewModel");
 jest.mock("LLM/features/Contacts/hooks/useContactsLedgerSyncStatus");
+jest.mock("LLM/features/WalletSync/screens/Activation/ActivationDrawer", () => ({
+  __esModule: true,
+  default: ({ isOpen, startingStep }: { isOpen: boolean; startingStep: string }) =>
+    isOpen ? <Text testID={`wallet-sync-drawer-${startingStep}`}>{startingStep}</Text> : null,
+}));
 // Device intents resolve without a device so these tests cover the calling flows only.
 // The executor wiring is covered by Contacts.deviceIntents.integration.test.tsx.
 jest.mock("@features/platform-contacts/device");
@@ -606,14 +611,15 @@ describe("Contacts integration", () => {
 
     await user.press(await screen.findByTestId("contacts-detail-add-address"));
 
-    expect(screen.getByText("Turn on Ledger Sync to save contacts")).toBeVisible();
+    expect(screen.getByText("Sync your wallet to add a contact")).toBeVisible();
     expect(screen.queryByTestId("contacts-add-address-flow-drawer")).toBeNull();
 
-    await user.press(screen.getByRole("button", { name: "Turn on Ledger Sync" }));
+    await user.press(screen.getByRole("button", { name: "Sync my wallet" }));
 
     await waitFor(() => {
-      expect(screen.getByTestId("wallet-sync-activation")).toBeVisible();
+      expect(screen.getByTestId("wallet-sync-drawer-ChooseSyncMethod")).toBeVisible();
     });
+    expect(screen.queryByTestId("wallet-sync-activation")).toBeNull();
   });
 
   it("should open Wallet Sync activation instead of Add Contact when sync is unavailable", async () => {
@@ -625,20 +631,21 @@ describe("Contacts integration", () => {
       }),
     });
 
-    expect(screen.getByText("Turn on Ledger Sync to save contacts")).toBeVisible();
-    await user.press(screen.getByRole("button", { name: "Got it" }));
+    expect(screen.queryByText("Sync your wallet to add a contact")).toBeNull();
+
     await user.press(await screen.findByTestId("contacts-add-contact-row"));
 
     await waitFor(() => {
-      expect(screen.getByText("Turn on Ledger Sync to save contacts")).toBeVisible();
+      expect(screen.getByText("Sync your wallet to add a contact")).toBeVisible();
     });
     expect(screen.queryByTestId("contacts-add-contact-drawer")).toBeNull();
 
-    await user.press(screen.getByRole("button", { name: "Turn on Ledger Sync" }));
+    await user.press(screen.getByRole("button", { name: "Sync my wallet" }));
 
     await waitFor(() => {
-      expect(screen.getByTestId("wallet-sync-activation")).toBeVisible();
+      expect(screen.getByTestId("wallet-sync-drawer-ChooseSyncMethod")).toBeVisible();
     });
+    expect(screen.queryByTestId("wallet-sync-activation")).toBeNull();
   });
 
   it("should open Wallet Sync activation instead of Add Address when sync is unavailable", async () => {
@@ -653,15 +660,47 @@ describe("Contacts integration", () => {
     await user.press(await screen.findByTestId("contacts-detail-add-address"));
 
     await waitFor(() => {
-      expect(screen.getByText("Turn on Ledger Sync to save contacts")).toBeVisible();
+      expect(screen.getByText("Sync your wallet to add a contact")).toBeVisible();
     });
     expect(screen.queryByTestId("contacts-add-address-flow-drawer")).toBeNull();
 
-    await user.press(screen.getByRole("button", { name: "Turn on Ledger Sync" }));
+    await user.press(screen.getByRole("button", { name: "Sync my wallet" }));
 
     await waitFor(() => {
-      expect(screen.getByTestId("wallet-sync-activation")).toBeVisible();
+      expect(screen.getByTestId("wallet-sync-drawer-ChooseSyncMethod")).toBeVisible();
     });
+    expect(screen.queryByTestId("wallet-sync-activation")).toBeNull();
+  });
+
+  it("should not open the Ledger Sync introduction when landing on Contacts", async () => {
+    mockedContactsLedgerSyncStatus.mockReturnValue("inactive");
+    render(<ContactsGatingTestApp />, {
+      navigationInitialState: contactsNavigationState,
+      overrideInitialState: withContactsPageReadyState({
+        lwmContacts: { enabled: true, params: { newBadge: false } },
+      }),
+    });
+
+    expect(await screen.findByTestId("contacts-screen")).toBeVisible();
+    expect(screen.queryByText("Sync your wallet to add a contact")).toBeNull();
+  });
+
+  it("should dismiss the Ledger Sync introduction from the secondary action", async () => {
+    mockedContactsLedgerSyncStatus.mockReturnValue("inactive");
+    const { user } = render(<ContactsGatingTestApp />, {
+      navigationInitialState: contactsNavigationState,
+      overrideInitialState: withContactsPageReadyState({
+        lwmContacts: { enabled: true, params: { newBadge: false } },
+      }),
+    });
+
+    await user.press(await screen.findByTestId("contacts-add-contact-row"));
+    await user.press(await screen.findByRole("button", { name: "Not now" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Sync your wallet to add a contact")).toBeNull();
+    });
+    expect(screen.queryByTestId("wallet-sync-drawer-ChooseSyncMethod")).toBeNull();
   });
 
   it.each(["checking"] as const)(
@@ -678,7 +717,7 @@ describe("Contacts integration", () => {
       await user.press(await screen.findByTestId("contacts-detail-add-address"));
 
       expect(screen.queryByTestId("contacts-add-address-flow-drawer")).toBeNull();
-      expect(screen.queryByText("Turn on Ledger Sync to save contacts")).toBeNull();
+      expect(screen.queryByText("Sync your wallet to add a contact")).toBeNull();
     },
   );
   it("should expose the Add Address session started for Me", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/ContactsFeatureIntroduction.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/ContactsFeatureIntroduction.integration.test.tsx
@@ -64,7 +64,7 @@ describe("Contacts feature introduction integration", () => {
       expect(screen.getByText("Introducing Contacts")).toBeVisible();
       expect(screen.getByTestId("contacts-feature-introduction-primary")).toBeVisible();
     });
-    expect(screen.queryByText("Turn on Ledger Sync to save contacts")).toBeNull();
+    expect(screen.queryByText("Sync your wallet to add a contact")).toBeNull();
   });
 
   it("should persist dismissal from Explore now and keep the Contacts page available", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/ContactsPage.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/ContactsPage.integration.test.tsx
@@ -36,8 +36,11 @@ function renderContactsPage(
       featureIntroduction={createClosedContactsFeatureIntroduction()}
       ledgerSyncIntroduction={{
         isOpen: false,
+        title: "Sync your wallet to add a contact",
         description: "Contacts are encrypted.",
+        activateLabel: "Sync my wallet",
         dismissLabel: "Not now",
+        onActivate: jest.fn(),
         onDismiss: jest.fn(),
       }}
     />,

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/components/ContactsLedgerSyncActivationDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/components/ContactsLedgerSyncActivationDrawer/index.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from "react";
+import ActivationDrawer from "LLM/features/WalletSync/screens/Activation/ActivationDrawer";
+import { Steps } from "LLM/features/WalletSync/types/Activation";
+
+export type ContactsLedgerSyncActivationDrawerProps = Readonly<{
+  isOpen: boolean;
+  onClose: () => void;
+}>;
+
+export function ContactsLedgerSyncActivationDrawer({
+  isOpen,
+  onClose,
+}: ContactsLedgerSyncActivationDrawerProps): React.JSX.Element | null {
+  // Mounted on first open only, then kept mounted so that closing stays animated.
+  const [isMounted, setIsMounted] = useState(isOpen);
+  if (isOpen && !isMounted) {
+    setIsMounted(true);
+  }
+
+  if (!isMounted) {
+    return null;
+  }
+
+  return (
+    <ActivationDrawer startingStep={Steps.ChooseSyncMethod} isOpen={isOpen} handleClose={onClose} />
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/components/ContactsLedgerSyncIntroductionSheet/ContactsLedgerSyncIntroductionSheet.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/components/ContactsLedgerSyncIntroductionSheet/ContactsLedgerSyncIntroductionSheet.test.tsx
@@ -9,17 +9,17 @@ describe("ContactsLedgerSyncIntroductionSheet", () => {
     const { user } = render(
       <ContactsLedgerSyncIntroductionSheet
         isOpen
-        title="Turn on Ledger Sync to save contacts"
+        title="Sync your wallet to add a contact"
         description="Your contacts are encrypted."
-        activateLabel="Turn on Ledger Sync"
-        dismissLabel="Got it"
+        activateLabel="Sync my wallet"
+        dismissLabel="Not now"
         onActivate={onActivate}
         onDismiss={onDismiss}
       />,
     );
 
-    await user.press(screen.getByRole("button", { name: "Turn on Ledger Sync" }));
-    await user.press(screen.getByRole("button", { name: "Got it" }));
+    await user.press(screen.getByRole("button", { name: "Sync my wallet" }));
+    await user.press(screen.getByRole("button", { name: "Not now" }));
 
     expect(onActivate).toHaveBeenCalledTimes(1);
     expect(onDismiss).toHaveBeenCalledTimes(1);

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsLedgerSyncActivationDrawer.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsLedgerSyncActivationDrawer.ts
@@ -1,0 +1,24 @@
+import { useCallback, useState } from "react";
+import { setLedgerSyncReturnsToEntryScreen } from "~/actions/walletSync";
+import { useDispatch } from "~/context/hooks";
+import type { ContactsLedgerSyncActivationDrawerProps } from "../components/ContactsLedgerSyncActivationDrawer";
+
+export function useContactsLedgerSyncActivationDrawer(): Readonly<{
+  ledgerSyncActivationDrawer: ContactsLedgerSyncActivationDrawerProps;
+  openLedgerSyncActivationDrawer: () => void;
+}> {
+  const dispatch = useDispatch();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const openLedgerSyncActivationDrawer = useCallback(() => {
+    dispatch(setLedgerSyncReturnsToEntryScreen(true));
+    setIsOpen(true);
+  }, [dispatch]);
+
+  const onClose = useCallback(() => setIsOpen(false), []);
+
+  return {
+    ledgerSyncActivationDrawer: { isOpen, onClose },
+    openLedgerSyncActivationDrawer,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/index.tsx
@@ -4,6 +4,7 @@ import { ContactsAddAddressFlowDrawer } from "./components/ContactsAddAddressFlo
 import { ContactAddressDetailActionsSheets } from "./components/ContactAddressDetailActionsSheets";
 import { ContactAddressDetailDialogSheet } from "./components/ContactAddressDetailDialogSheet";
 import { ContactDetailEditDeleteSheets } from "./components/ContactDetailEditDeleteSheets";
+import { ContactsLedgerSyncActivationDrawer } from "LLM/features/Contacts/components/ContactsLedgerSyncActivationDrawer";
 import { ContactsLedgerSyncIntroductionSheet } from "LLM/features/Contacts/components/ContactsLedgerSyncIntroductionSheet";
 import { DeviceIntentExecutorLWM } from "LLM/components/DeviceIntentExecutor";
 import { useContactDetailNavigationViewModel } from "./hooks/useContactDetailNavigationViewModel";
@@ -37,10 +38,8 @@ export function ContactDetailScreen(): React.JSX.Element | null {
         signerMismatchSheet={viewModel.addressDetailActions.signerMismatchSheet}
       />
       <ContactDetailEditDeleteSheets {...viewModel.editDeleteFlow} />
-      <ContactsLedgerSyncIntroductionSheet
-        {...viewModel.ledgerSyncIntroduction}
-        {...viewModel.ledgerSyncIntroductionContent}
-      />
+      <ContactsLedgerSyncIntroductionSheet {...viewModel.ledgerSyncIntroduction} />
+      <ContactsLedgerSyncActivationDrawer {...viewModel.ledgerSyncActivationDrawer} />
       {viewModel.dieProps === undefined ? null : (
         <DeviceIntentExecutorLWM sourceFlow="contacts" {...viewModel.dieProps} />
       )}

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
@@ -22,10 +22,9 @@ import {
   CONTACTS_TRACKING_BUTTON,
   trackContactsAddAddressClick,
 } from "@features/flow-contacts";
-import { isContactsLedgerSyncActivationRequired } from "@features/flow-contacts-introduction";
-import type {
-  ContactsLedgerSyncIntroduction,
-  ContactsLedgerSyncIntroductionContentProps,
+import {
+  isContactsLedgerSyncActivationRequired,
+  type ContactsLedgerSyncIntroduction,
 } from "@features/flow-contacts-introduction";
 import {
   useAddAddressFlowViewModel,
@@ -56,6 +55,8 @@ import { USER_AVATAR_URL } from "LLM/components/UserAvatar/constants";
 import type { MyWalletNavigatorStackParamList } from "LLM/features/MyWallet/types";
 import { useContactsAddressValidationAdapter } from "../../hooks/useContactsAddressValidationAdapter";
 import { useContactsLedgerSyncStatus } from "../../hooks/useContactsLedgerSyncStatus";
+import { useContactsLedgerSyncActivationDrawer } from "../../hooks/useContactsLedgerSyncActivationDrawer";
+import type { ContactsLedgerSyncActivationDrawerProps } from "../../components/ContactsLedgerSyncActivationDrawer";
 import type { ContactsAddAddressFlowDrawerProps } from "./components/ContactsAddAddressFlowDrawer/types";
 import type { ContactDetailEditDeleteFlowProps } from "./hooks/useContactDetailEditDeleteAdapter";
 import { useContactDetailEditDeleteAdapter } from "./hooks/useContactDetailEditDeleteAdapter";
@@ -75,10 +76,7 @@ type ContactDetailScreenViewModel =
       addressDetailActions: ReturnType<typeof useContactAddressDetailActionsAdapter>;
       editDeleteFlow: ContactDetailEditDeleteFlowProps;
       ledgerSyncIntroduction: ContactsLedgerSyncIntroduction;
-      ledgerSyncIntroductionContent: Pick<
-        ContactsLedgerSyncIntroductionContentProps,
-        "title" | "activateLabel" | "onActivate"
-      >;
+      ledgerSyncActivationDrawer: ContactsLedgerSyncActivationDrawerProps;
       dieProps: ContactsDeviceIntentExecutorProps | undefined;
     }>;
 
@@ -99,6 +97,8 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
   const { isEnabled, eligibleAddressFamilies } = useContactsFeature("mobile");
   const ledgerSyncStatus = useContactsLedgerSyncStatus();
   const { requestMutation, dismissPendingIntent } = useContactsLedgerSyncMutationGuard();
+  const { ledgerSyncActivationDrawer, openLedgerSyncActivationDrawer } =
+    useContactsLedgerSyncActivationDrawer();
   const [isLedgerSyncIntroductionOpen, setIsLedgerSyncIntroductionOpen] = useState(false);
   const { t } = useTranslation();
   const { deviceIntents, dieProps } = useContactsIntentsOrchestrator({
@@ -250,10 +250,9 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
   }, [navigation]);
   const onActivateLedgerSync = useCallback(() => {
     dismissPendingIntent();
-    navigation.navigate(NavigatorName.WalletSync, {
-      screen: ScreenName.WalletSyncActivationInit,
-    });
-  }, [dismissPendingIntent, navigation]);
+    setIsLedgerSyncIntroductionOpen(false);
+    openLedgerSyncActivationDrawer();
+  }, [dismissPendingIntent, openLedgerSyncActivationDrawer]);
   const onDismissLedgerSyncIntroduction = useCallback(() => {
     dismissPendingIntent();
     setIsLedgerSyncIntroductionOpen(false);
@@ -476,15 +475,14 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
     ledgerSyncIntroduction: {
       isOpen:
         isContactsLedgerSyncActivationRequired(ledgerSyncStatus) && isLedgerSyncIntroductionOpen,
+      title: t("contacts.ledgerSyncIntroduction.title"),
       description: t("contacts.ledgerSyncIntroduction.description"),
+      activateLabel: t("contacts.ledgerSyncIntroduction.activate"),
       dismissLabel: t("contacts.ledgerSyncIntroduction.dismiss"),
+      onActivate: onActivateLedgerSync,
       onDismiss: onDismissLedgerSyncIntroduction,
     },
-    ledgerSyncIntroductionContent: {
-      title: t("contacts.ledgerSyncIntroduction.title"),
-      activateLabel: t("contacts.ledgerSyncIntroduction.activate"),
-      onActivate: onActivateLedgerSync,
-    },
+    ledgerSyncActivationDrawer,
     dieProps,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsPageContent/ContactsPageContent.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsPageContent/ContactsPageContent.test.tsx
@@ -54,15 +54,13 @@ function createViewModel({
       : createClosedContactsFeatureIntroduction(),
     ledgerSyncIntroduction: {
       isOpen: isFeatureIntroductionOpen ? false : isIntroductionOpen,
+      title: "Sync your wallet to add a contact",
       description:
-        "Your contacts are end-to-end encrypted with your Ledger and synced across your devices, only you can unlock them.",
-      dismissLabel: "Got it",
-      onDismiss,
-    },
-    ledgerSyncIntroductionContent: {
-      title: "Turn on Ledger Sync to save contacts",
-      activateLabel: "Turn on Ledger Sync",
+        "Contacts are end-to-end encrypted and synced across Ledger Wallet on all your phones and computers.",
+      activateLabel: "Sync my wallet",
+      dismissLabel: "Not now",
       onActivate,
+      onDismiss,
     },
     addContactDrawer: {
       isOpen: false,
@@ -87,22 +85,26 @@ function createViewModel({
       onConfirm: jest.fn(),
       reset: jest.fn(),
     },
+    ledgerSyncActivationDrawer: {
+      isOpen: false,
+      onClose: jest.fn(),
+    },
   };
 }
 
 describe("ContactsPageContent", () => {
-  it("should render the inactive introduction with the Figma labels", () => {
+  it("should render the introduction with the Contacts production labels", () => {
     render(<ContactsPageContent {...createViewModel()} />);
 
     expect(screen.getByTestId("contacts-screen")).toBeVisible();
-    expect(screen.getByText("Turn on Ledger Sync to save contacts")).toBeVisible();
+    expect(screen.getByText("Sync your wallet to add a contact")).toBeVisible();
     expect(
       screen.getByText(
-        "Your contacts are end-to-end encrypted with your Ledger and synced across your devices, only you can unlock them.",
+        "Contacts are end-to-end encrypted and synced across Ledger Wallet on all your phones and computers.",
       ),
     ).toBeVisible();
-    expect(screen.getByRole("button", { name: "Turn on Ledger Sync" })).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Got it" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Sync my wallet" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Not now" })).toBeEnabled();
   });
 
   it("should keep the introduction open when activating Ledger Sync", async () => {
@@ -112,18 +114,18 @@ describe("ContactsPageContent", () => {
       <ContactsPageContent {...createViewModel({ onActivate, onDismiss })} />,
     );
 
-    await user.press(screen.getByRole("button", { name: "Turn on Ledger Sync" }));
+    await user.press(screen.getByRole("button", { name: "Sync my wallet" }));
 
     expect(onActivate).toHaveBeenCalledTimes(1);
     expect(onDismiss).not.toHaveBeenCalled();
-    expect(screen.getByText("Turn on Ledger Sync to save contacts")).toBeVisible();
+    expect(screen.getByText("Sync your wallet to add a contact")).toBeVisible();
   });
 
   it("should dismiss the introduction from the secondary action", async () => {
     const onDismiss = jest.fn();
     const { user } = render(<ContactsPageContent {...createViewModel({ onDismiss })} />);
 
-    await user.press(screen.getByRole("button", { name: "Got it" }));
+    await user.press(screen.getByRole("button", { name: "Not now" }));
 
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
@@ -135,7 +137,7 @@ describe("ContactsPageContent", () => {
       />,
     );
 
-    expect(screen.queryByText("Turn on Ledger Sync to save contacts")).toBeNull();
+    expect(screen.queryByText("Sync your wallet to add a contact")).toBeNull();
 
     rerender(
       <ContactsPageContent
@@ -144,7 +146,7 @@ describe("ContactsPageContent", () => {
     );
     rerender(<ContactsPageContent {...createViewModel({ ledgerSyncStatus: "inactive" })} />);
 
-    expect(screen.getByText("Turn on Ledger Sync to save contacts")).toBeVisible();
+    expect(screen.getByText("Sync your wallet to add a contact")).toBeVisible();
   });
 
   it("should defer the Ledger Sync introduction while the feature introduction is open", () => {
@@ -160,7 +162,7 @@ describe("ContactsPageContent", () => {
       />,
     );
 
-    expect(screen.queryByText("Turn on Ledger Sync to save contacts")).toBeNull();
+    expect(screen.queryByText("Sync your wallet to add a contact")).toBeNull();
     expect(screen.getByTestId("contacts-feature-introduction-primary")).toBeVisible();
 
     rerender(
@@ -174,6 +176,6 @@ describe("ContactsPageContent", () => {
       />,
     );
 
-    expect(screen.getByText("Turn on Ledger Sync to save contacts")).toBeVisible();
+    expect(screen.getByText("Sync your wallet to add a contact")).toBeVisible();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsPageContent/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsPageContent/index.tsx
@@ -1,23 +1,22 @@
 import React from "react";
 import { ContactsView } from "@features/flow-contacts";
+import { ContactsLedgerSyncActivationDrawer } from "LLM/features/Contacts/components/ContactsLedgerSyncActivationDrawer";
 import { ContactsLedgerSyncIntroductionSheet } from "LLM/features/Contacts/components/ContactsLedgerSyncIntroductionSheet";
 import { ContactsAddContactDrawerSheet } from "../ContactsAddContactDrawerSheet";
 import { ContactsFeatureIntroductionSheet } from "../ContactsFeatureIntroductionSheet";
 import type { ContactsPageContentProps } from "../../types";
 
 export function ContactsPageContent({
-  ledgerSyncIntroductionContent,
   addContactDrawer,
+  ledgerSyncActivationDrawer,
   ...pageProps
 }: ContactsPageContentProps): React.JSX.Element {
   return (
     <>
       <ContactsView {...pageProps} />
       <ContactsFeatureIntroductionSheet {...pageProps.featureIntroduction} />
-      <ContactsLedgerSyncIntroductionSheet
-        {...pageProps.ledgerSyncIntroduction}
-        {...ledgerSyncIntroductionContent}
-      />
+      <ContactsLedgerSyncIntroductionSheet {...pageProps.ledgerSyncIntroduction} />
+      <ContactsLedgerSyncActivationDrawer {...ledgerSyncActivationDrawer} />
       <ContactsAddContactDrawerSheet {...addContactDrawer} />
     </>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageViewModel.test.ts
@@ -22,6 +22,13 @@ function renderViewModel(patchState?: Parameters<typeof withFlagOverrides>[1]) {
   });
 }
 
+function renderViewModelWithFeatureIntroductionDismissed() {
+  return renderViewModel(state => ({
+    ...state,
+    settings: { ...state.settings, hasDismissedContactsFeatureIntroduction: true },
+  }));
+}
+
 describe("useContactsPageViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -52,5 +59,72 @@ describe("useContactsPageViewModel", () => {
     });
 
     expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("should keep the Ledger Sync introduction closed while no contact is being added", () => {
+    mockedContactsLedgerSyncStatus.mockReturnValue("inactive");
+    const { result } = renderViewModelWithFeatureIntroductionDismissed();
+
+    expect(result.current.ledgerSyncIntroduction.isOpen).toBe(false);
+  });
+
+  it("should open the Ledger Sync introduction only when adding a contact is blocked", () => {
+    mockedContactsLedgerSyncStatus.mockReturnValue("inactive");
+    const onAllowed = jest.fn();
+    const { result } = renderViewModelWithFeatureIntroductionDismissed();
+
+    act(() => {
+      result.current.onRequestAddContact(onAllowed);
+    });
+
+    expect(onAllowed).not.toHaveBeenCalled();
+    expect(result.current.ledgerSyncIntroduction.isOpen).toBe(true);
+  });
+
+  it("should open the activation drawer without leaving Contacts when activating from the introduction", () => {
+    mockedContactsLedgerSyncStatus.mockReturnValue("inactive");
+    const { result, store } = renderViewModelWithFeatureIntroductionDismissed();
+
+    act(() => {
+      result.current.onRequestAddContact(jest.fn());
+    });
+    act(() => {
+      result.current.ledgerSyncIntroduction.onActivate();
+    });
+
+    expect(result.current.ledgerSyncActivationDrawer.isOpen).toBe(true);
+    expect(result.current.ledgerSyncIntroduction.isOpen).toBe(false);
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(store.getState().walletSync.returnsToEntryScreen).toBe(true);
+  });
+
+  it("should close the activation drawer when it is dismissed", () => {
+    mockedContactsLedgerSyncStatus.mockReturnValue("inactive");
+    const { result } = renderViewModelWithFeatureIntroductionDismissed();
+
+    act(() => {
+      result.current.ledgerSyncIntroduction.onActivate();
+    });
+    act(() => {
+      result.current.ledgerSyncActivationDrawer.onClose();
+    });
+
+    expect(result.current.ledgerSyncActivationDrawer.isOpen).toBe(false);
+  });
+
+  it("should close the Ledger Sync introduction when it is dismissed", () => {
+    mockedContactsLedgerSyncStatus.mockReturnValue("inactive");
+    const { result } = renderViewModelWithFeatureIntroductionDismissed();
+
+    act(() => {
+      result.current.onRequestAddContact(jest.fn());
+    });
+    act(() => {
+      result.current.ledgerSyncIntroduction.onDismiss();
+    });
+
+    expect(result.current.ledgerSyncIntroduction.isOpen).toBe(false);
+    expect(result.current.ledgerSyncActivationDrawer.isOpen).toBe(false);
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageViewModel.ts
@@ -21,11 +21,12 @@ import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { BaseNavigationComposite } from "~/components/RootNavigator/types/helpers";
 import { USER_AVATAR_URL } from "LLM/components/UserAvatar/constants";
 import type { MyWalletNavigatorStackParamList } from "LLM/features/MyWallet/types";
-import { NavigatorName, ScreenName } from "~/const";
+import { ScreenName } from "~/const";
 import { useTranslation } from "~/context/Locale";
 import { useContactsAnalytics } from "../../../analytics/useContactsAnalytics";
 import { useContactsFeatureIntroductionPreference } from "../../../hooks/useContactsFeatureIntroductionPreference";
 import { useContactsLedgerSyncStatus } from "../../../hooks/useContactsLedgerSyncStatus";
+import { useContactsLedgerSyncActivationDrawer } from "../../../hooks/useContactsLedgerSyncActivationDrawer";
 import type { ContactsPageViewModel } from "../types";
 
 type NavigationProp = BaseNavigationComposite<
@@ -67,7 +68,9 @@ export function useContactsPageViewModel(): ContactsPageViewModel {
   );
   const ledgerSyncStatus = useContactsLedgerSyncStatus();
   const { requestMutation, dismissPendingIntent } = useContactsLedgerSyncMutationGuard();
-  const [isLedgerSyncIntroductionDismissed, setIsLedgerSyncIntroductionDismissed] = useState(false);
+  const { ledgerSyncActivationDrawer, openLedgerSyncActivationDrawer } =
+    useContactsLedgerSyncActivationDrawer();
+  const [isLedgerSyncIntroductionRequested, setIsLedgerSyncIntroductionRequested] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const viewModel = useContactsSearchViewModel(searchQuery, labels.formatMeDisplayName);
   const onSearchQueryChange = useCallback((query: string) => setSearchQuery(query), []);
@@ -81,22 +84,21 @@ export function useContactsPageViewModel(): ContactsPageViewModel {
   const onDismissLedgerSyncIntroduction = useCallback(() => {
     trackContactsLedgerSyncDismiss(analytics);
     dismissPendingIntent();
-    setIsLedgerSyncIntroductionDismissed(true);
+    setIsLedgerSyncIntroductionRequested(false);
   }, [analytics, dismissPendingIntent]);
   const onActivateIntroduction = useCallback(() => {
     trackContactsLedgerSyncActivate(analytics);
     dismissPendingIntent();
-    navigation.navigate(NavigatorName.WalletSync, {
-      screen: ScreenName.WalletSyncActivationInit,
-    });
-  }, [analytics, dismissPendingIntent, navigation]);
+    setIsLedgerSyncIntroductionRequested(false);
+    openLedgerSyncActivationDrawer();
+  }, [analytics, dismissPendingIntent, openLedgerSyncActivationDrawer]);
   const onRequestAddContact = useCallback(
     (onAllowed: () => void) => {
       const result = requestMutation({ kind: "addContact" }, ledgerSyncStatus);
       if (result.status === "allowed") {
         onAllowed();
       } else if (result.status === "blocked") {
-        setIsLedgerSyncIntroductionDismissed(false);
+        setIsLedgerSyncIntroductionRequested(true);
       }
     },
     [ledgerSyncStatus, requestMutation],
@@ -111,14 +113,14 @@ export function useContactsPageViewModel(): ContactsPageViewModel {
   useEffect(() => {
     if (!isContactsLedgerSyncActivationRequired(ledgerSyncStatus)) {
       dismissPendingIntent();
-      setIsLedgerSyncIntroductionDismissed(false);
+      setIsLedgerSyncIntroductionRequested(false);
     }
   }, [dismissPendingIntent, ledgerSyncStatus]);
 
   const isLedgerSyncIntroductionOpen = resolveContactsLedgerSyncIntroductionOpen({
     isFeatureIntroductionRequested: featureIntroductionState.isRequested,
     ledgerSyncStatus,
-    isLedgerSyncIntroductionDismissed,
+    isLedgerSyncIntroductionRequested,
   });
   const searchHasResults = !("status" in viewModel && viewModel.status === "no-results");
 
@@ -147,15 +149,14 @@ export function useContactsPageViewModel(): ContactsPageViewModel {
     },
     ledgerSyncIntroduction: {
       isOpen: isLedgerSyncIntroductionOpen,
+      title: t("contacts.ledgerSyncIntroduction.title"),
       description: t("contacts.ledgerSyncIntroduction.description"),
+      activateLabel: t("contacts.ledgerSyncIntroduction.activate"),
       dismissLabel: t("contacts.ledgerSyncIntroduction.dismiss"),
+      onActivate: onActivateIntroduction,
       onDismiss: onDismissLedgerSyncIntroduction,
     },
-    ledgerSyncIntroductionContent: {
-      title: t("contacts.ledgerSyncIntroduction.title"),
-      activateLabel: t("contacts.ledgerSyncIntroduction.activate"),
-      onActivate: onActivateIntroduction,
-    },
+    ledgerSyncActivationDrawer,
     onRequestAddContact,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/types.ts
@@ -1,14 +1,9 @@
 import type { AddContactAppAdapterResult, ContactsViewNativeProps } from "@features/flow-contacts";
-import type { ContactsLedgerSyncIntroductionContentProps } from "@features/flow-contacts-introduction";
-
-type ContactsLedgerSyncIntroductionPresentationProps = Pick<
-  ContactsLedgerSyncIntroductionContentProps,
-  "title" | "activateLabel" | "onActivate"
->;
+import type { ContactsLedgerSyncActivationDrawerProps } from "../../components/ContactsLedgerSyncActivationDrawer";
 
 export type ContactsPageViewModel = Omit<ContactsViewNativeProps, "onAddContact"> &
   Readonly<{
-    ledgerSyncIntroductionContent: ContactsLedgerSyncIntroductionPresentationProps;
+    ledgerSyncActivationDrawer: ContactsLedgerSyncActivationDrawerProps;
     onRequestAddContact: (onAllowed: () => void) => void;
   }>;
 

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/__tests__/useClose.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/__tests__/useClose.test.ts
@@ -1,0 +1,58 @@
+import { act, renderHook } from "@tests/test-renderer";
+import { NavigatorName } from "~/const";
+import { INITIAL_STATE as WALLET_SYNC_INITIAL_STATE } from "~/reducers/walletSync";
+import { useClose } from "../useClose";
+
+const mockPopToTop = jest.fn();
+const mockGoBack = jest.fn();
+const mockReplace = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual<typeof import("@react-navigation/native")>("@react-navigation/native"),
+  useNavigation: () => ({
+    popToTop: mockPopToTop,
+    goBack: mockGoBack,
+    replace: mockReplace,
+  }),
+}));
+
+function renderClose(returnsToEntryScreen: boolean) {
+  return renderHook(() => useClose(), {
+    overrideInitialState: state => ({
+      ...state,
+      walletSync: { ...WALLET_SYNC_INITIAL_STATE, returnsToEntryScreen },
+    }),
+  });
+}
+
+describe("useClose", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should go back to the entry screen when the flow was started from it", () => {
+    const { result, store } = renderClose(true);
+
+    act(() => {
+      result.current();
+    });
+
+    expect(mockPopToTop).toHaveBeenCalledTimes(1);
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+    expect(mockReplace).not.toHaveBeenCalled();
+    expect(store.getState().walletSync.returnsToEntryScreen).toBe(false);
+  });
+
+  it("should replace with the main navigator otherwise", () => {
+    const { result } = renderClose(false);
+
+    act(() => {
+      result.current();
+    });
+
+    expect(mockReplace).toHaveBeenCalledWith(NavigatorName.Base, {
+      screen: NavigatorName.Main,
+    });
+    expect(mockPopToTop).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useClose.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useClose.ts
@@ -13,6 +13,8 @@ import {
   isPostOnboardingFlowSelector,
   onboardingTypeSelector,
 } from "~/reducers/settings";
+import { returnsToEntryScreenSelector } from "~/reducers/walletSync";
+import { setLedgerSyncReturnsToEntryScreen } from "~/actions/walletSync";
 import { OnboardingType } from "~/reducers/types";
 
 export function useClose() {
@@ -21,6 +23,7 @@ export function useClose() {
   const isFromLedgerSyncOnboarding = useSelector(isFromLedgerSyncOnboardingSelector);
   const onboardingType = useSelector(onboardingTypeSelector);
   const isPostOnboardingFlow = useSelector(isPostOnboardingFlowSelector);
+  const returnsToEntryScreen = useSelector(returnsToEntryScreenSelector);
   const navigateToPostOnboardingHub = useNavigateToPostOnboardingHubCallback();
   const dispatch = useDispatch();
 
@@ -33,6 +36,13 @@ export function useClose() {
         navigationOnbarding.goBack();
         return;
       }
+    }
+
+    if (returnsToEntryScreen) {
+      dispatch(setLedgerSyncReturnsToEntryScreen(false));
+      navigationOnbarding.popToTop();
+      navigationOnbarding.goBack();
+      return;
     }
 
     if (isPostOnboardingFlow) {

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -424,6 +424,7 @@ export type WalletSyncState = {
   isManageKeyDrawerOpen: boolean;
   isActivateDrawerOpen: boolean;
   activateDrawerStep: Steps;
+  returnsToEntryScreen: boolean;
 };
 
 // === LARGEMOVER STATE ===

--- a/apps/ledger-live-mobile/src/reducers/walletSync.ts
+++ b/apps/ledger-live-mobile/src/reducers/walletSync.ts
@@ -7,6 +7,7 @@ import {
   WalletSyncSetActivateDrawer,
   WalletSyncSetActivateStep,
   WalletSyncSetManageKeyDrawerPayload,
+  WalletSyncSetReturnsToEntryScreen,
 } from "../actions/types";
 import { Steps } from "LLM/features/WalletSync/types/Activation";
 
@@ -14,6 +15,7 @@ export const INITIAL_STATE: WalletSyncState = {
   isManageKeyDrawerOpen: false,
   isActivateDrawerOpen: false,
   activateDrawerStep: Steps.Activation,
+  returnsToEntryScreen: false,
 };
 
 const handlers: ReducerMap<WalletSyncState, WalletSyncPayload> = {
@@ -29,6 +31,10 @@ const handlers: ReducerMap<WalletSyncState, WalletSyncPayload> = {
     ...state,
     activateDrawerStep: (action as Action<WalletSyncSetActivateStep>).payload,
   }),
+  [WalletSyncActionTypes.LEDGER_SYNC_SET_RETURNS_TO_ENTRY_SCREEN]: (state, action) => ({
+    ...state,
+    returnsToEntryScreen: (action as Action<WalletSyncSetReturnsToEntryScreen>).payload,
+  }),
 };
 
 export const manageKeyDrawerSelector = (state: State): boolean =>
@@ -37,5 +43,7 @@ export const activateDrawerSelector = (state: State): boolean =>
   state.walletSync.isActivateDrawerOpen;
 export const activateDrawerStepSelector = (state: State): Steps =>
   state.walletSync.activateDrawerStep;
+export const returnsToEntryScreenSelector = (state: State): boolean =>
+  state.walletSync.returnsToEntryScreen;
 
 export default handleActions<WalletSyncState, WalletSyncPayload>(handlers, INITIAL_STATE);

--- a/features/flow/contacts/src/ContactsView.web.test.tsx
+++ b/features/flow/contacts/src/ContactsView.web.test.tsx
@@ -39,8 +39,11 @@ describe("ContactsView", () => {
         }}
         ledgerSyncIntroduction={{
           isOpen: false,
+          title: "Sync your wallet to add a contact",
           description: "Keep contacts in sync.",
-          dismissLabel: "Got it",
+          activateLabel: "Sync my wallet",
+          dismissLabel: "Not now",
+          onActivate: jest.fn(),
           onDismiss: jest.fn(),
         }}
       />,
@@ -76,8 +79,11 @@ describe("ContactsView", () => {
         }}
         ledgerSyncIntroduction={{
           isOpen: true,
+          title: "Sync your wallet to add a contact",
           description: "Keep contacts in sync.",
-          dismissLabel: "Got it",
+          activateLabel: "Sync my wallet",
+          dismissLabel: "Not now",
+          onActivate: jest.fn(),
           onDismiss: jest.fn(),
         }}
       />,

--- a/features/flow/contacts/src/ContactsView.web.tsx
+++ b/features/flow/contacts/src/ContactsView.web.tsx
@@ -27,6 +27,7 @@ export function ContactsView({
             isContactsLedgerSyncActivationRequired(ledgerSyncStatus) &&
             ledgerSyncIntroduction.isOpen
           }
+          title={ledgerSyncIntroduction.title}
           description={ledgerSyncIntroduction.description}
           activateLabel={ledgerSyncIntroduction.activateLabel}
           dismissLabel={ledgerSyncIntroduction.dismissLabel}

--- a/features/flow/flow-contacts-introduction/src/screens/LedgerSyncIntroduction/ContactsLedgerSyncIntroduction.native.tsx
+++ b/features/flow/flow-contacts-introduction/src/screens/LedgerSyncIntroduction/ContactsLedgerSyncIntroduction.native.tsx
@@ -1,5 +1,13 @@
 import React from "react";
-import { BottomSheetHeader, BottomSheetView, Box, Button, Text } from "@ledgerhq/lumen-ui-rnative";
+import {
+  BottomSheetHeader,
+  BottomSheetView,
+  Box,
+  Button,
+  Spot,
+  Text,
+} from "@ledgerhq/lumen-ui-rnative";
+import { Refresh } from "@ledgerhq/lumen-ui-rnative/symbols";
 import type { ContactsLedgerSyncIntroductionContentProps } from "./types";
 
 export function ContactsLedgerSyncIntroductionContent({
@@ -15,15 +23,18 @@ export function ContactsLedgerSyncIntroductionContent({
   return (
     <BottomSheetView style={{ paddingBottom: bottomInset + 24 }}>
       {isOpen ? (
-        <Box lx={{ gap: "s24", paddingHorizontal: "s16" }}>
+        <Box lx={{ gap: "s32", paddingHorizontal: "s16" }}>
           <BottomSheetHeader />
-          <Box lx={{ gap: "s12" }}>
-            <Text typography="heading3SemiBold" lx={{ color: "base" }}>
-              {title}
-            </Text>
-            <Text typography="body2" lx={{ color: "muted" }}>
-              {description}
-            </Text>
+          <Box lx={{ alignItems: "center", gap: "s24" }}>
+            <Spot appearance="icon" size={72} icon={Refresh} />
+            <Box lx={{ gap: "s8" }}>
+              <Text typography="heading4SemiBold" lx={{ color: "base", textAlign: "center" }}>
+                {title}
+              </Text>
+              <Text typography="body2" lx={{ color: "muted", textAlign: "center" }}>
+                {description}
+              </Text>
+            </Box>
           </Box>
           <Box lx={{ gap: "s16" }}>
             <Button appearance="base" size="lg" isFull onPress={onActivate}>

--- a/features/flow/flow-contacts-introduction/src/screens/LedgerSyncIntroduction/ContactsLedgerSyncIntroductionDialog.web.test.tsx
+++ b/features/flow/flow-contacts-introduction/src/screens/LedgerSyncIntroduction/ContactsLedgerSyncIntroductionDialog.web.test.tsx
@@ -3,44 +3,46 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ContactsLedgerSyncIntroductionDialog } from "./ContactsLedgerSyncIntroductionDialog";
 
+function renderDialog(overrides: { onActivate?: jest.Mock; onDismiss?: jest.Mock } = {}) {
+  const onActivate = overrides.onActivate ?? jest.fn();
+  const onDismiss = overrides.onDismiss ?? jest.fn();
+
+  render(
+    <ContactsLedgerSyncIntroductionDialog
+      open
+      title="Sync your wallet to add a contact"
+      description="Contacts are end-to-end encrypted and synced across Ledger Wallet."
+      activateLabel="Sync my wallet"
+      dismissLabel="Not now"
+      onActivate={onActivate}
+      onDismiss={onDismiss}
+    />,
+  );
+
+  return { onActivate, onDismiss };
+}
+
 describe("ContactsLedgerSyncIntroductionDialog", () => {
   it("should render the Ledger Sync explanation and dismiss it once", async () => {
-    const onDismiss = jest.fn();
     const user = userEvent.setup();
+    const { onDismiss } = renderDialog();
 
-    render(
-      <ContactsLedgerSyncIntroductionDialog
-        open
-        description="Ledger Sync keeps contacts up to date."
-        dismissLabel="Got it"
-        onDismiss={onDismiss}
-      />,
-    );
+    expect(screen.getByText("Sync your wallet to add a contact")).toBeVisible();
+    expect(
+      screen.getByText("Contacts are end-to-end encrypted and synced across Ledger Wallet."),
+    ).toBeVisible();
 
-    expect(screen.getByText("Ledger Sync keeps contacts up to date.")).toBeVisible();
-
-    await user.click(screen.getByRole("button", { name: "Got it" }));
-    await user.click(screen.getByRole("button", { name: "Got it" }));
+    await user.click(screen.getByRole("button", { name: "Not now" }));
+    await user.click(screen.getByRole("button", { name: "Not now" }));
 
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
-  it("should call the activation action when it is provided", async () => {
-    const onActivate = jest.fn();
+  it("should call the activation action", async () => {
     const user = userEvent.setup();
+    const { onActivate } = renderDialog();
 
-    render(
-      <ContactsLedgerSyncIntroductionDialog
-        open
-        description="Ledger Sync keeps contacts up to date."
-        activateLabel="Turn on Ledger Sync"
-        dismissLabel="Not now"
-        onActivate={onActivate}
-        onDismiss={jest.fn()}
-      />,
-    );
-
-    await user.click(screen.getByRole("button", { name: "Turn on Ledger Sync" }));
+    await user.click(screen.getByRole("button", { name: "Sync my wallet" }));
 
     expect(onActivate).toHaveBeenCalledTimes(1);
   });

--- a/features/flow/flow-contacts-introduction/src/screens/LedgerSyncIntroduction/ContactsLedgerSyncIntroductionDialog.web.tsx
+++ b/features/flow/flow-contacts-introduction/src/screens/LedgerSyncIntroduction/ContactsLedgerSyncIntroductionDialog.web.tsx
@@ -1,10 +1,19 @@
 import React from "react";
-import { Button, Dialog, DialogBody, DialogContent, DialogHeader } from "@ledgerhq/lumen-ui-react";
+import {
+  Button,
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogHeader,
+  Spot,
+} from "@ledgerhq/lumen-ui-react";
+import { Refresh } from "@ledgerhq/lumen-ui-react/symbols";
 import { useSingleFireDismiss } from "../../internals/useSingleFireDismiss";
 import type { ContactsLedgerSyncIntroductionDialogProps } from "./types";
 
 export function ContactsLedgerSyncIntroductionDialog({
   open,
+  title,
   description,
   activateLabel,
   dismissLabel,
@@ -21,23 +30,44 @@ export function ContactsLedgerSyncIntroductionDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange} height="fit">
-      <DialogContent aria-describedby={undefined} className="w-[400px] bg-base p-0">
+      <DialogContent
+        aria-describedby={undefined}
+        className="w-[400px] bg-canvas-sheet p-0"
+        data-testid="contacts-ledger-sync-introduction-dialog"
+      >
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 top-0 h-full bg-gradient-muted"
+        />
         <DialogHeader density="compact" onClose={dismiss} />
-        <DialogBody className="flex flex-col gap-24 px-24 pb-24">
-          <p className="body-1 text-base">{description}</p>
-          {activateLabel && onActivate ? (
-            <Button appearance="base" size="md" onClick={onActivate} className="w-full">
+        <DialogBody className="flex flex-col gap-32 px-24 pb-24">
+          <div className="flex flex-col items-center gap-24">
+            <Spot appearance="icon" size={72} icon={Refresh} />
+            <div className="flex flex-col items-center gap-8 text-center">
+              <h2 className="heading-4-semi-bold text-base">{title}</h2>
+              <p className="body-2 text-muted">{description}</p>
+            </div>
+          </div>
+          <div className="flex flex-col gap-16">
+            <Button
+              appearance="base"
+              size="lg"
+              isFull
+              onClick={onActivate}
+              data-testid="contacts-ledger-sync-introduction-activate"
+            >
               {activateLabel}
             </Button>
-          ) : null}
-          <Button
-            appearance={activateLabel && onActivate ? "gray" : "base"}
-            size="md"
-            onClick={dismiss}
-            className="w-full"
-          >
-            {dismissLabel}
-          </Button>
+            <Button
+              appearance="gray"
+              size="lg"
+              isFull
+              onClick={dismiss}
+              data-testid="contacts-ledger-sync-introduction-dismiss"
+            >
+              {dismissLabel}
+            </Button>
+          </div>
         </DialogBody>
       </DialogContent>
     </Dialog>

--- a/features/flow/flow-contacts-introduction/src/screens/LedgerSyncIntroduction/types.ts
+++ b/features/flow/flow-contacts-introduction/src/screens/LedgerSyncIntroduction/types.ts
@@ -11,9 +11,10 @@ export type ContactsLedgerSyncIntroductionContentProps = Readonly<{
 
 export type ContactsLedgerSyncIntroductionDialogProps = Readonly<{
   open: boolean;
+  title: string;
   description: string;
-  activateLabel?: string;
+  activateLabel: string;
   dismissLabel: string;
-  onActivate?: () => void;
+  onActivate: () => void;
   onDismiss: () => void;
 }>;

--- a/features/flow/flow-contacts-introduction/src/state/resolver.ts
+++ b/features/flow/flow-contacts-introduction/src/state/resolver.ts
@@ -8,7 +8,7 @@ export type ContactsFeatureIntroductionRequestInput = Readonly<{
 export type ContactsLedgerSyncIntroductionOpenInput = Readonly<{
   isFeatureIntroductionRequested: boolean;
   ledgerSyncStatus: ContactsLedgerSyncStatus;
-  isLedgerSyncIntroductionDismissed: boolean;
+  isLedgerSyncIntroductionRequested: boolean;
 }>;
 
 export function resolveContactsFeatureIntroductionRequested(
@@ -29,7 +29,7 @@ export function resolveContactsLedgerSyncIntroductionOpen(
   }
 
   return (
-    isContactsLedgerSyncActivationRequired(input.ledgerSyncStatus) &&
-    !input.isLedgerSyncIntroductionDismissed
+    input.isLedgerSyncIntroductionRequested &&
+    isContactsLedgerSyncActivationRequired(input.ledgerSyncStatus)
   );
 }

--- a/features/flow/flow-contacts-introduction/src/state/resolver.web.test.ts
+++ b/features/flow/flow-contacts-introduction/src/state/resolver.web.test.ts
@@ -33,12 +33,22 @@ describe("resolveContactsFeatureIntroductionRequested", () => {
 });
 
 describe("resolveContactsLedgerSyncIntroductionOpen", () => {
+  it("stays closed until the user requests a mutation that needs Ledger Sync", () => {
+    expect(
+      resolveContactsLedgerSyncIntroductionOpen({
+        isFeatureIntroductionRequested: false,
+        ledgerSyncStatus: "inactive",
+        isLedgerSyncIntroductionRequested: false,
+      }),
+    ).toBe(false);
+  });
+
   it("defers the Ledger Sync introduction while the feature introduction is requested", () => {
     expect(
       resolveContactsLedgerSyncIntroductionOpen({
         isFeatureIntroductionRequested: true,
         ledgerSyncStatus: "inactive",
-        isLedgerSyncIntroductionDismissed: false,
+        isLedgerSyncIntroductionRequested: true,
       }),
     ).toBe(false);
   });
@@ -48,7 +58,7 @@ describe("resolveContactsLedgerSyncIntroductionOpen", () => {
       resolveContactsLedgerSyncIntroductionOpen({
         isFeatureIntroductionRequested: false,
         ledgerSyncStatus: "inactive",
-        isLedgerSyncIntroductionDismissed: false,
+        isLedgerSyncIntroductionRequested: true,
       }),
     ).toBe(true);
   });
@@ -58,7 +68,7 @@ describe("resolveContactsLedgerSyncIntroductionOpen", () => {
       resolveContactsLedgerSyncIntroductionOpen({
         isFeatureIntroductionRequested: false,
         ledgerSyncStatus: "checking",
-        isLedgerSyncIntroductionDismissed: false,
+        isLedgerSyncIntroductionRequested: true,
       }),
     ).toBe(false);
   });
@@ -68,18 +78,8 @@ describe("resolveContactsLedgerSyncIntroductionOpen", () => {
       resolveContactsLedgerSyncIntroductionOpen({
         isFeatureIntroductionRequested: false,
         ledgerSyncStatus: "unavailable",
-        isLedgerSyncIntroductionDismissed: false,
+        isLedgerSyncIntroductionRequested: true,
       }),
     ).toBe(true);
-  });
-
-  it("does not reopen the Ledger Sync introduction after session dismissal", () => {
-    expect(
-      resolveContactsLedgerSyncIntroductionOpen({
-        isFeatureIntroductionRequested: false,
-        ledgerSyncStatus: "inactive",
-        isLedgerSyncIntroductionDismissed: true,
-      }),
-    ).toBe(false);
   });
 });

--- a/features/flow/flow-contacts-introduction/src/state/types.ts
+++ b/features/flow/flow-contacts-introduction/src/state/types.ts
@@ -2,10 +2,11 @@ export type ContactsLedgerSyncStatus = "ready" | "checking" | "inactive" | "unav
 
 export type ContactsLedgerSyncIntroduction = Readonly<{
   isOpen: boolean;
+  title: string;
   description: string;
-  activateLabel?: string;
+  activateLabel: string;
   dismissLabel: string;
-  onActivate?: () => void;
+  onActivate: () => void;
   onDismiss: () => void;
 }>;
 


### PR DESCRIPTION
### 📝 Description

Ledger Sync, when reached from Contacts, showed the wrong copy and artwork, appeared at the wrong moment, started on the wrong step, and dropped the user on the Portfolio afterwards. This fixes all four on both apps.

**Modal trigger.** 
`resolveContactsLedgerSyncIntroductionOpen` used to open the introduction whenever sync was off and the user had not dismissed it, which is why it appeared as soon as Contacts loaded. It now takes an explicit `isLedgerSyncIntroductionRequested` flag, set only when `requestMutation` blocks an add-contact or add-address attempt. 
Mobile had the same bug (the sheet auto-opened on mount) and is fixed too — the new copy only makes sense as a reaction to an add attempt.

**Entry step.** 
Desktop's `openDrawer` accepts `{ startOnSyncMethod: true }`, which dispatches the `Synchronize` flow at `SynchronizeMode` ("Choose your sync method") instead of the activation welcome step. 
Mobile navigates to `WalletSyncActivationInit` with a new `openSyncMethod` param that opens the activation drawer directly on `Steps.ChooseSyncMethod`.

**Post-flow redirect.** 
Desktop already stayed on Contacts (the drawer just closes), so this is Mobile-only: a new `returnsToEntryScreen` flag in the `walletSync` reducer is set when the flow starts from Contacts, and `useClose` pops back to Contacts instead of replacing the root navigator with Main.


Regression coverage added for each behaviour: the introduction stays closed on landing, opens only on a blocked action, activation lands on the sync-method step, and closing the Mobile flow returns to the entry screen (`useContactsPageViewModel.test.ts`, `useClose.test.ts`, `useFlows.test.ts`, and the Desktop/Mobile Contacts integration suites).


https://github.com/user-attachments/assets/8ad32775-b95d-42d8-a7c4-ee6b9da53f9d

https://github.com/user-attachments/assets/725626a1-b0e6-4b30-8f8f-f177c67f2b10





### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36667](https://ledgerhq.atlassian.net/browse/LIVE-36667)
- **Design**: [Contacts • Production](https://www.figma.com/design/9kuJiSsYpP9nImhPWXzWPF/Contacts-%E2%80%A2-Production?node-id=1633-38015)
- **ADR** (if any): n/a

[LIVE-36667]: https://ledgerhq.atlassian.net/browse/LIVE-36667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ