### PR TITLE
feat(pay-card): set the Card env vars from the Card / Pay DevTool

### DIFF
--- a/.changeset/pay-card-devtool-env-shortcuts.md
+++ b/.changeset/pay-card-devtool-env-shortcuts.md
@@ -1,0 +1,6 @@
+---
+"@devtools/pay-card": minor
+"@devtools/bindings": minor
+---
+
+Add an "Env vars" section to the Card / Pay DevTool. It shows the value the app reads for CARD_API_URL and CARD_BAANX_CLIENT_KEY, and it sets either one from an input. Each input starts on the Baanx development tenant, so a tester switches with one press.

--- a/devtools/bindings/src/usePayCardToolProps.test.tsx
+++ b/devtools/bindings/src/usePayCardToolProps.test.tsx
@@ -7,6 +7,7 @@ import {
   payCardFeatureTourSlice,
   markPayCardFeatureTourSeen,
 } from "@features/flow-pay-feature-tour/state";
+import { getEnv, getEnvDefault, setEnv } from "@shared/env";
 import { usePayCardToolProps } from "./usePayCardToolProps";
 
 function buildStore() {
@@ -28,6 +29,11 @@ describe("usePayCardToolProps", () => {
 
   beforeEach(() => {
     store = buildStore();
+  });
+
+  afterEach(() => {
+    setEnv("CARD_API_URL", getEnvDefault("CARD_API_URL"));
+    setEnv("CARD_BAANX_CLIENT_KEY", getEnvDefault("CARD_BAANX_CLIENT_KEY"));
   });
 
   it("exposes desktop onboarding steps and default flag values", () => {
@@ -146,6 +152,44 @@ describe("usePayCardToolProps", () => {
     const { result } = renderHook(() => usePayCardToolProps(), { wrapper: withStore(store) });
 
     expect(result.current.hasSeenFeatureTour).toBe(true);
+  });
+
+  it("exposes the two Card env vars, with the development tenant as the suggestion", () => {
+    const { result } = renderHook(() => usePayCardToolProps(), { wrapper: withStore(store) });
+
+    expect(result.current.env.vars).toEqual([
+      {
+        key: "CARD_API_URL",
+        value: getEnv("CARD_API_URL"),
+        suggestedValue: "https://dev.api.baanx.com",
+      },
+      {
+        key: "CARD_BAANX_CLIENT_KEY",
+        value: getEnv("CARD_BAANX_CLIENT_KEY"),
+        suggestedValue: "dc16bbda-eb1b-487c-be60-1a90ca7c9dd6",
+      },
+    ]);
+  });
+
+  it("setVar changes the env, and the value it reports follows", () => {
+    const { result } = renderHook(() => usePayCardToolProps(), { wrapper: withStore(store) });
+
+    act(() => {
+      result.current.env.setVar("CARD_API_URL", "https://card.staging.test");
+    });
+
+    expect(getEnv("CARD_API_URL")).toBe("https://card.staging.test");
+    expect(result.current.env.vars[0]?.value).toBe("https://card.staging.test");
+  });
+
+  it("follows a change made outside the tool", () => {
+    const { result } = renderHook(() => usePayCardToolProps(), { wrapper: withStore(store) });
+
+    act(() => {
+      setEnv("CARD_BAANX_CLIENT_KEY", "another-tenant-key");
+    });
+
+    expect(result.current.env.vars[1]?.value).toBe("another-tenant-key");
   });
 
   it("resetPayCardFeatureTourSeen clears the seen flag", () => {

--- a/devtools/bindings/src/usePayCardToolProps.test.tsx
+++ b/devtools/bindings/src/usePayCardToolProps.test.tsx
@@ -7,8 +7,38 @@ import {
   payCardFeatureTourSlice,
   markPayCardFeatureTourSeen,
 } from "@features/flow-pay-feature-tour/state";
-import { getEnv, getEnvDefault, setEnv } from "@shared/env";
 import { usePayCardToolProps } from "./usePayCardToolProps";
+
+/**
+ * `@shared/env` is mocked, as in `useEnvDevToolProps.test.ts`. The real module reads its definitions
+ * from `@ledgerhq/live-env`, which this package does not depend on, so CI cannot resolve it.
+ */
+const DEFAULT_ENV_VALUES: Record<string, string> = {
+  CARD_API_URL: "https://card.api.live.ledger.com",
+  CARD_BAANX_CLIENT_KEY: "",
+};
+let envValues: Record<string, string> = { ...DEFAULT_ENV_VALUES };
+let envListener: ((change: { name: string }) => void) | undefined;
+
+const mockSetEnvUnsafe = jest.fn((key: string, value: string) => {
+  envValues[key] = value;
+  envListener?.({ name: key });
+});
+
+jest.mock("@shared/env", () => ({
+  getEnv: (key: string) => envValues[key],
+  setEnvUnsafe: (key: string, value: string) => mockSetEnvUnsafe(key, value),
+  changes: {
+    subscribe: (listener: (change: { name: string }) => void) => {
+      envListener = listener;
+      return {
+        unsubscribe: () => {
+          envListener = undefined;
+        },
+      };
+    },
+  },
+}));
 
 function buildStore() {
   return configureStore({
@@ -29,11 +59,8 @@ describe("usePayCardToolProps", () => {
 
   beforeEach(() => {
     store = buildStore();
-  });
-
-  afterEach(() => {
-    setEnv("CARD_API_URL", getEnvDefault("CARD_API_URL"));
-    setEnv("CARD_BAANX_CLIENT_KEY", getEnvDefault("CARD_BAANX_CLIENT_KEY"));
+    envValues = { ...DEFAULT_ENV_VALUES };
+    mockSetEnvUnsafe.mockClear();
   });
 
   it("exposes desktop onboarding steps and default flag values", () => {
@@ -160,12 +187,12 @@ describe("usePayCardToolProps", () => {
     expect(result.current.env.vars).toEqual([
       {
         key: "CARD_API_URL",
-        value: getEnv("CARD_API_URL"),
+        value: "https://card.api.live.ledger.com",
         suggestedValue: "https://dev.api.baanx.com",
       },
       {
         key: "CARD_BAANX_CLIENT_KEY",
-        value: getEnv("CARD_BAANX_CLIENT_KEY"),
+        value: "",
         suggestedValue: "dc16bbda-eb1b-487c-be60-1a90ca7c9dd6",
       },
     ]);
@@ -178,17 +205,22 @@ describe("usePayCardToolProps", () => {
       result.current.env.setVar("CARD_API_URL", "https://card.staging.test");
     });
 
-    expect(getEnv("CARD_API_URL")).toBe("https://card.staging.test");
+    expect(mockSetEnvUnsafe).toHaveBeenCalledWith("CARD_API_URL", "https://card.staging.test");
     expect(result.current.env.vars[0]?.value).toBe("https://card.staging.test");
   });
 
-  it("follows a change made outside the tool", () => {
+  it("follows a change made outside the tool, and ignores every other env", () => {
     const { result } = renderHook(() => usePayCardToolProps(), { wrapper: withStore(store) });
 
     act(() => {
-      setEnv("CARD_BAANX_CLIENT_KEY", "another-tenant-key");
+      envValues.CARD_BAANX_CLIENT_KEY = "another-tenant-key";
+      envListener?.({ name: "SOME_OTHER_ENV" });
     });
+    expect(result.current.env.vars[1]?.value).toBe("");
 
+    act(() => {
+      envListener?.({ name: "CARD_BAANX_CLIENT_KEY" });
+    });
     expect(result.current.env.vars[1]?.value).toBe("another-tenant-key");
   });
 

--- a/devtools/bindings/src/usePayCardToolProps.ts
+++ b/devtools/bindings/src/usePayCardToolProps.ts
@@ -1,6 +1,7 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { setOverride } from "@shared/feature-flags";
+import { changes, getEnv, setEnvUnsafe, type EnvName } from "@shared/env";
 import { useFeature } from "@features/platform-feature-flags";
 import {
   resetPayCardFeatureTourSeen,
@@ -10,6 +11,7 @@ import type { DevToolsConfig } from "@devtools/registry";
 
 type PayCardToolProps = Extract<DevToolsConfig[number], { id: "pay-card" }>["config"];
 type OnboardingStep = PayCardToolProps["onboarding"]["steps"][number];
+type PayCardEnvVar = PayCardToolProps["env"]["vars"][number];
 
 export type UsePayCardToolPropsOptions = {
   /** Pass `"native"` on mobile to include the `walletPay` onboarding step. */
@@ -30,6 +32,25 @@ const NATIVE_ONLY_STEP: OnboardingStep = {
 };
 
 const PURCHASE_STEP: OnboardingStep = { id: "purchase", label: "First Purchase", done: false };
+
+/**
+ * The two Card env vars the tool shows, each with the value of the Baanx development tenant.
+ *
+ * A release build carries neither, so it starts on the definition defaults: the production URL and
+ * an empty client key. The suggestions put the development tenant one press away.
+ */
+const CARD_ENV_VARS: readonly { key: EnvName; suggestedValue: string }[] = [
+  { key: "CARD_API_URL", suggestedValue: "https://dev.api.baanx.com" },
+  { key: "CARD_BAANX_CLIENT_KEY", suggestedValue: "dc16bbda-eb1b-487c-be60-1a90ca7c9dd6" },
+];
+
+function readCardEnvVars(): readonly PayCardEnvVar[] {
+  return CARD_ENV_VARS.map(({ key, suggestedValue }) => ({
+    key,
+    value: String(getEnv(key)),
+    suggestedValue,
+  }));
+}
 
 function initialSteps(platform: "web" | "native"): readonly OnboardingStep[] {
   return platform === "native"
@@ -107,13 +128,31 @@ export function usePayCardToolProps(options: UsePayCardToolPropsOptions = {}): P
 
   const onboarding = useMemo(() => ({ steps, setStepDone }), [steps, setStepDone]);
 
+  const [envVars, setEnvVars] = useState<readonly PayCardEnvVar[]>(readCardEnvVars);
+
+  useEffect(() => {
+    // Read again on mount, because a change can land between the first render and this subscription.
+    setEnvVars(readCardEnvVars());
+    const sub = changes.subscribe(({ name }) => {
+      if (CARD_ENV_VARS.some(candidate => candidate.key === name)) setEnvVars(readCardEnvVars());
+    });
+    return () => sub.unsubscribe();
+  }, []);
+
+  const setEnvVar = useCallback((key: string, value: string) => {
+    setEnvUnsafe(key, value);
+  }, []);
+
+  const env = useMemo(() => ({ vars: envVars, setVar: setEnvVar }), [envVars, setEnvVar]);
+
   return useMemo(
     () => ({
       flags,
       onboarding,
       hasSeenFeatureTour,
       resetPayCardFeatureTourSeen: resetFeatureTour,
+      env,
     }),
-    [flags, onboarding, hasSeenFeatureTour, resetFeatureTour],
+    [flags, onboarding, hasSeenFeatureTour, resetFeatureTour, env],
   );
 }

--- a/devtools/pay-card/README.md
+++ b/devtools/pay-card/README.md
@@ -1,8 +1,9 @@
 # @devtools/pay-card
 
-The Card / Pay DevTool. It puts the Card / Pay feature into a given state from one place, in four
-sections: **Feature flags**, **Onboarding** (toggle each step done or not-done), **Reset onboarding**
-and **Feature tour** (seen state plus a reset).
+The Card / Pay DevTool. It puts the Card / Pay feature into a given state from one place, in five
+sections: **Feature flags**, **Onboarding** (toggle each step done or not-done), **Reset onboarding**,
+**Feature tour** (seen state plus a reset) and **Env vars** (the Card backend values, with the
+development tenant ready in each input).
 
 ## Import boundary
 
@@ -16,7 +17,8 @@ import PayCard, { type PayCardToolProps } from "@devtools/pay-card";
 
 - `PayCard` (default export) — the React component rendered by the shell.
 - `PayCardToolProps` — the props contract the host (via bindings) must satisfy, with its parts
-  `PayCardFlagsProps`, `PayCardOnboardingProps` and `OnboardingStep`.
+  `PayCardFlagsProps`, `PayCardOnboardingProps`, `OnboardingStep`, `PayCardEnvProps` and
+  `PayCardEnvVar`.
 - `usePayCardViewModel` / `PayCardViewModel` — onboarding progress derived from those props, plus
   `toggleStep` and `setAllSteps`.
 - `formatId` — turns a step id into a label: `"kyc-check"` → `"Kyc check"`.
@@ -44,6 +46,18 @@ interface PayCardToolProps {
   };
   hasSeenFeatureTour: boolean;
   resetPayCardFeatureTourSeen: () => void;
+  env: {
+    // The app reads these values on every request, so `setVar` applies without a restart. Nothing
+    // saves them: after a restart the app reads the build's values again.
+    vars: readonly {
+      key: string;
+      // The value the app reads right now.
+      value: string;
+      // What the input starts with, so one press is enough to change the tenant.
+      suggestedValue: string;
+    }[];
+    setVar: (key: string, value: string) => void;
+  };
 }
 ```
 

--- a/devtools/pay-card/src/components/EnvVarRow/EnvVarRow.native.tsx
+++ b/devtools/pay-card/src/components/EnvVarRow/EnvVarRow.native.tsx
@@ -1,0 +1,48 @@
+import { useState } from "react";
+import { TextInput } from "react-native";
+import { Box, Button, Text, useTheme } from "@ledgerhq/lumen-ui-rnative";
+import type { PayCardEnvVar } from "../../types";
+
+export interface EnvVarRowProps {
+  readonly envVar: PayCardEnvVar;
+  readonly onSet: (key: string, value: string) => void;
+}
+
+const ROW_LX = { gap: "s2" } as const;
+const INPUT_ROW_LX = { flexDirection: "row", alignItems: "center", gap: "s8" } as const;
+
+export function EnvVarRow({ envVar, onSet }: EnvVarRowProps) {
+  const { theme } = useTheme();
+  // Starts on the value the tester switches to, so the other tenant is one press away.
+  const [draft, setDraft] = useState(envVar.suggestedValue);
+
+  return (
+    <Box lx={ROW_LX}>
+      <Text typography="body4" lx={{ color: "base" }} selectable>
+        {`${envVar.key}=${envVar.value === "" ? "(empty)" : envVar.value}`}
+      </Text>
+      <Box lx={INPUT_ROW_LX}>
+        <TextInput
+          value={draft}
+          onChangeText={setDraft}
+          autoCapitalize="none"
+          autoCorrect={false}
+          testID={`pay-card-env-input-${envVar.key}`}
+          style={{
+            flex: 1,
+            borderWidth: 1,
+            borderColor: theme.colors.border.mutedSubtle,
+            borderRadius: 4,
+            paddingHorizontal: 8,
+            paddingVertical: 4,
+            fontSize: 13,
+            color: theme.colors.text.base,
+          }}
+        />
+        <Button appearance="gray" size="sm" onPress={() => onSet(envVar.key, draft)}>
+          Set
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/devtools/pay-card/src/components/EnvVarRow/EnvVarRow.web.tsx
+++ b/devtools/pay-card/src/components/EnvVarRow/EnvVarRow.web.tsx
@@ -1,0 +1,33 @@
+import { useState } from "react";
+import { Button } from "@ledgerhq/lumen-ui-react";
+import type { PayCardEnvVar } from "../../types";
+
+export interface EnvVarRowProps {
+  readonly envVar: PayCardEnvVar;
+  readonly onSet: (key: string, value: string) => void;
+}
+
+export function EnvVarRow({ envVar, onSet }: EnvVarRowProps) {
+  // Starts on the value the tester switches to, so the other tenant is one click away.
+  const [draft, setDraft] = useState(envVar.suggestedValue);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="body-4 text-base break-all">
+        {`${envVar.key}=${envVar.value === "" ? "(empty)" : envVar.value}`}
+      </p>
+      <div className="flex items-center gap-8">
+        <input
+          type="text"
+          value={draft}
+          onChange={event => setDraft(event.target.value)}
+          aria-label={envVar.key}
+          className="flex-1 bg-base border border-base rounded px-8 py-4 body-3 text-base"
+        />
+        <Button appearance="gray" size="sm" onClick={() => onSet(envVar.key, draft)}>
+          Set
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/devtools/pay-card/src/components/Section/Section.native.tsx
+++ b/devtools/pay-card/src/components/Section/Section.native.tsx
@@ -12,7 +12,9 @@ const CONTENT_LX = { gap: "s8" } as const;
 export function Section({ title, children }: SectionProps) {
   return (
     <Box lx={CONTAINER_LX}>
-      <Text typography="body2">{title}</Text>
+      <Text typography="body2" lx={{ color: "base" }}>
+        {title}
+      </Text>
       <Box lx={CONTENT_LX}>{children}</Box>
     </Box>
   );

--- a/devtools/pay-card/src/components/ToggleRow/ToggleRow.native.tsx
+++ b/devtools/pay-card/src/components/ToggleRow/ToggleRow.native.tsx
@@ -18,7 +18,9 @@ export function ToggleRow({ label, description, checked, onChange }: ToggleRowPr
   return (
     <Box style={ROW_LX}>
       <Box style={{ flexShrink: 1 }}>
-        <Text typography="body3">{label}</Text>
+        <Text typography="body3" lx={{ color: "base" }}>
+          {label}
+        </Text>
         {description ? (
           <Text typography="body4" lx={{ color: "muted" }}>
             {description}

--- a/devtools/pay-card/src/index.native.ts
+++ b/devtools/pay-card/src/index.native.ts
@@ -4,6 +4,8 @@ export type {
   PayCardToolProps,
   PayCardFlagsProps,
   PayCardOnboardingProps,
+  PayCardEnvProps,
+  PayCardEnvVar,
   OnboardingStep,
 } from "./types";
 export { usePayCardViewModel, formatId } from "./usePayCardViewModel";

--- a/devtools/pay-card/src/index.ts
+++ b/devtools/pay-card/src/index.ts
@@ -4,6 +4,8 @@ export type {
   PayCardToolProps,
   PayCardFlagsProps,
   PayCardOnboardingProps,
+  PayCardEnvProps,
+  PayCardEnvVar,
   OnboardingStep,
 } from "./types";
 export { usePayCardViewModel, formatId } from "./usePayCardViewModel";

--- a/devtools/pay-card/src/pay-card/PayCard.native.test.tsx
+++ b/devtools/pay-card/src/pay-card/PayCard.native.test.tsx
@@ -24,6 +24,17 @@ function buildProps(): PayCardToolProps {
     },
     hasSeenFeatureTour: false,
     resetPayCardFeatureTourSeen: jest.fn(),
+    env: {
+      vars: [
+        {
+          key: "CARD_API_URL",
+          value: "https://card.api.live.ledger.com",
+          suggestedValue: "https://dev.api.baanx.com",
+        },
+        { key: "CARD_BAANX_CLIENT_KEY", value: "", suggestedValue: "dev-client-key" },
+      ],
+      setVar: jest.fn(),
+    },
   };
 }
 
@@ -42,6 +53,44 @@ describe("PayCard (native)", () => {
 
     await user.press(screen.getByText("Reset feature tour"));
     expect(props.resetPayCardFeatureTourSeen).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows both Card env vars, and the value the app reads now", () => {
+    render(<PayCard {...buildProps()} />);
+
+    expect(screen.getByText("Env vars")).toBeTruthy();
+    expect(screen.getByText("CARD_API_URL=https://card.api.live.ledger.com")).toBeTruthy();
+    // An empty client key must read as empty, and not as a missing row.
+    expect(screen.getByText("CARD_BAANX_CLIENT_KEY=(empty)")).toBeTruthy();
+  });
+
+  it("fills each input with the suggested value, so one press changes the tenant", async () => {
+    const user = userEvent.setup();
+    const props = buildProps();
+    render(<PayCard {...props} />);
+
+    expect(screen.getByTestId("pay-card-env-input-CARD_API_URL").props.value).toBe(
+      "https://dev.api.baanx.com",
+    );
+
+    await user.press(screen.getAllByText("Set")[0]!);
+    expect(props.env.setVar).toHaveBeenCalledWith("CARD_API_URL", "https://dev.api.baanx.com");
+  });
+
+  it("sets what the tester typed", async () => {
+    const user = userEvent.setup();
+    const props = buildProps();
+    render(<PayCard {...props} />);
+
+    const input = screen.getByTestId("pay-card-env-input-CARD_API_URL");
+    await user.clear(input);
+    await user.type(input, "https://card.api.live.ledger.com");
+    await user.press(screen.getAllByText("Set")[0]!);
+
+    expect(props.env.setVar).toHaveBeenCalledWith(
+      "CARD_API_URL",
+      "https://card.api.live.ledger.com",
+    );
   });
 
   it("wires onboarding actions", async () => {

--- a/devtools/pay-card/src/pay-card/PayCard.native.tsx
+++ b/devtools/pay-card/src/pay-card/PayCard.native.tsx
@@ -1,13 +1,14 @@
 import { ScrollView } from "react-native";
-import { Box, Button, Divider, Tag } from "@ledgerhq/lumen-ui-rnative";
+import { Box, Button, Divider, Tag, Text } from "@ledgerhq/lumen-ui-rnative";
 import type { PayCardToolProps } from "../types";
 import { Section } from "../components/Section/Section";
 import { ToggleRow } from "../components/ToggleRow/ToggleRow";
+import { EnvVarRow } from "../components/EnvVarRow/EnvVarRow";
 
 const BUTTON_ROW_STYLE = { flexDirection: "row", flexWrap: "wrap", gap: 8 } as const;
 
 export function PayCard(props: Readonly<PayCardToolProps>) {
-  const { flags, onboarding, hasSeenFeatureTour, resetPayCardFeatureTourSeen } = props;
+  const { flags, onboarding, hasSeenFeatureTour, resetPayCardFeatureTourSeen, env } = props;
 
   return (
     <ScrollView>
@@ -72,6 +73,17 @@ export function PayCard(props: Readonly<PayCardToolProps>) {
             Reset feature tour
           </Button>
         </Box>
+      </Section>
+
+      <Divider />
+
+      <Section title="Env vars">
+        <Text typography="body4" lx={{ color: "muted" }}>
+          Applied at once, and not saved: a restart brings the build's values back.
+        </Text>
+        {env.vars.map(envVar => (
+          <EnvVarRow key={envVar.key} envVar={envVar} onSet={env.setVar} />
+        ))}
       </Section>
     </ScrollView>
   );

--- a/devtools/pay-card/src/pay-card/PayCard.web.test.tsx
+++ b/devtools/pay-card/src/pay-card/PayCard.web.test.tsx
@@ -24,6 +24,17 @@ function buildProps(): PayCardToolProps {
     },
     hasSeenFeatureTour: false,
     resetPayCardFeatureTourSeen: jest.fn(),
+    env: {
+      vars: [
+        {
+          key: "CARD_API_URL",
+          value: "https://card.api.live.ledger.com",
+          suggestedValue: "https://dev.api.baanx.com",
+        },
+        { key: "CARD_BAANX_CLIENT_KEY", value: "", suggestedValue: "dev-client-key" },
+      ],
+      setVar: jest.fn(),
+    },
   };
 }
 
@@ -41,6 +52,41 @@ describe("PayCard (web)", () => {
 
     fireEvent.click(screen.getByText("Reset feature tour"));
     expect(props.resetPayCardFeatureTourSeen).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows both Card env vars, and the value the app reads now", () => {
+    render(<PayCard {...buildProps()} />);
+
+    expect(screen.getByText("Env vars")).toBeDefined();
+    expect(screen.getByText("CARD_API_URL=https://card.api.live.ledger.com")).toBeDefined();
+    // An empty client key must read as empty, and not as a missing row.
+    expect(screen.getByText("CARD_BAANX_CLIENT_KEY=(empty)")).toBeDefined();
+  });
+
+  it("fills each input with the suggested value, so one click changes the tenant", () => {
+    const props = buildProps();
+    render(<PayCard {...props} />);
+
+    const input = screen.getByLabelText("CARD_API_URL") as HTMLInputElement;
+    expect(input.value).toBe("https://dev.api.baanx.com");
+
+    fireEvent.click(screen.getAllByText("Set")[0]!);
+    expect(props.env.setVar).toHaveBeenCalledWith("CARD_API_URL", "https://dev.api.baanx.com");
+  });
+
+  it("sets what the tester typed", () => {
+    const props = buildProps();
+    render(<PayCard {...props} />);
+
+    fireEvent.change(screen.getByLabelText("CARD_API_URL"), {
+      target: { value: "https://card.api.live.ledger.com" },
+    });
+    fireEvent.click(screen.getAllByText("Set")[0]!);
+
+    expect(props.env.setVar).toHaveBeenCalledWith(
+      "CARD_API_URL",
+      "https://card.api.live.ledger.com",
+    );
   });
 
   it("wires onboarding actions", () => {

--- a/devtools/pay-card/src/pay-card/PayCard.web.tsx
+++ b/devtools/pay-card/src/pay-card/PayCard.web.tsx
@@ -2,9 +2,10 @@ import { Button, Divider, Tag } from "@ledgerhq/lumen-ui-react";
 import type { PayCardToolProps } from "../types";
 import { Section } from "../components/Section/Section";
 import { ToggleRow } from "../components/ToggleRow/ToggleRow";
+import { EnvVarRow } from "../components/EnvVarRow/EnvVarRow";
 
 export function PayCard(props: Readonly<PayCardToolProps>) {
-  const { flags, onboarding, hasSeenFeatureTour, resetPayCardFeatureTourSeen } = props;
+  const { flags, onboarding, hasSeenFeatureTour, resetPayCardFeatureTourSeen, env } = props;
 
   return (
     <div className="flex flex-col overflow-y-auto">
@@ -69,6 +70,17 @@ export function PayCard(props: Readonly<PayCardToolProps>) {
             Reset feature tour
           </Button>
         </div>
+      </Section>
+
+      <Divider />
+
+      <Section title="Env vars">
+        <p className="body-4 text-muted">
+          Applied at once, and not saved: a restart brings the build's values back.
+        </p>
+        {env.vars.map(envVar => (
+          <EnvVarRow key={envVar.key} envVar={envVar} onSet={env.setVar} />
+        ))}
       </Section>
     </div>
   );

--- a/devtools/pay-card/src/types.ts
+++ b/devtools/pay-card/src/types.ts
@@ -33,6 +33,26 @@ export interface PayCardOnboardingProps {
 }
 
 /**
+ * One env var the tool shows, with the value a tester most often wants next.
+ *
+ * The app reads the two Card env vars on every request, so a value set here applies without a
+ * restart. Nothing saves it: after a restart the app reads the build's value again.
+ */
+export interface PayCardEnvVar {
+  readonly key: string;
+  /** The value the app reads right now. */
+  readonly value: string;
+  /** What the input starts with, so one press is enough to change the tenant. */
+  readonly suggestedValue: string;
+}
+
+/** The Card env vars the tool reads, and the one way it changes them. */
+export interface PayCardEnvProps {
+  readonly vars: readonly PayCardEnvVar[];
+  readonly setVar: (key: string, value: string) => void;
+}
+
+/**
  * Props contract for the Card / Pay DevTool.
  *
  * Built by `@devtools/bindings` (`usePayCardToolProps`) from the host's Redux
@@ -45,4 +65,6 @@ export interface PayCardToolProps {
   readonly hasSeenFeatureTour: boolean;
   /** Resets the feature tour so it plays again on the next Pay visit. */
   readonly resetPayCardFeatureTourSeen: () => void;
+  /** The Card backend env vars, read live and set from the tool. */
+  readonly env: PayCardEnvProps;
 }

--- a/devtools/pay-card/src/usePayCardViewModel.native.test.ts
+++ b/devtools/pay-card/src/usePayCardViewModel.native.test.ts
@@ -30,6 +30,7 @@ function buildProps(overrides: Partial<PayCardToolProps> = {}): PayCardToolProps
     },
     hasSeenFeatureTour: overrides.hasSeenFeatureTour ?? false,
     resetPayCardFeatureTourSeen: overrides.resetPayCardFeatureTourSeen ?? jest.fn(),
+    env: overrides.env ?? { vars: [], setVar: jest.fn() },
   };
 }
 

--- a/devtools/pay-card/src/usePayCardViewModel.test.ts
+++ b/devtools/pay-card/src/usePayCardViewModel.test.ts
@@ -29,6 +29,7 @@ function buildProps(overrides: Partial<PayCardToolProps> = {}): PayCardToolProps
     },
     hasSeenFeatureTour: overrides.hasSeenFeatureTour ?? false,
     resetPayCardFeatureTourSeen: overrides.resetPayCardFeatureTourSeen ?? jest.fn(),
+    env: overrides.env ?? { vars: [], setVar: jest.fn() },
   };
 }
 


### PR DESCRIPTION
### 📝 Description

<img width="331" height="193" alt="image" src="https://github.com/user-attachments/assets/3e96f656-a265-4851-8dac-a19e0f46691f" />


**The problem.** A tester who moves the app onto another Baanx tenant has to open Settings > Developer > Env, find `CARD_API_URL` and `CARD_BAANX_CLIENT_KEY` among every other variable, and type both values by hand, twice, on a phone keyboard.

**The change.** The Card / Pay DevTool now ends with an **Env vars** section:

```
Env vars
Applied at once, and not saved: a restart brings the build's values back.

CARD_API_URL=https://card.api.live.ledger.com
[ https://dev.api.baanx.com            ] [Set]

CARD_BAANX_CLIENT_KEY=(empty)
[ dc16bbda-eb1b-487c-be60-1a90ca7c9dd6 ] [Set]
```

- Each line reads `KEY=value`, so the value names its own variable.
- Each input starts on the Baanx development tenant, so one press per variable is enough. The input stays editable for any other value.
- The value line follows the env: it is rebuilt from `changes` in `@shared/env`, so it answers a change made anywhere, including from the general Env tool.
- Both apps take the new value without a restart. The Card base query reads the two accessors on every request, and the Pay tab reads the envs with `useEnv` (#21363).

The tool reads no app state of its own. The values and the setter arrive as props through `PayCardToolProps`, built in `@devtools/bindings`, which the import-boundary rule names as the only bridge to Ledger Live internals. Neither host changed: both already pass the whole `usePayCardToolProps` result.

**One fix beyond the feature.** Every native `Text` in the tool now takes an explicit colour token. Lumen's `Text` sets no colour of its own — its typography tokens carry no `color`, and `lx` maps only what you pass — so a `Text` without one falls back to black. The section titles and the toggle labels were therefore unreadable in the dark theme.

**Tests.** `@devtools/pay-card` 26 (16 web, 10 native), with three new ones per platform: both rows render with the live value and an empty value reads `(empty)`; the input starts on the suggestion and Set sends it; Set sends what the tester typed. `@devtools/bindings` 39, with three new ones: the two variables and their suggestions, `setVar` changing the env, and a change made outside the tool. Both app typechecks pass.

### 🔗 Context

- **JIRA / GitHub issue**: none yet — a test aid asked for while testing the Pay tab against the Baanx development tenant.
- **ADR** (if any): n/a
