### PR TITLE
feat(pay): gate Pay tab contacts section behind flag (LIVE-36767)

### DIFF
--- a/.changeset/gate-pay-contacts-section.md
+++ b/.changeset/gate-pay-contacts-section.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Gate the Pay tab contacts section behind the contacts feature flag (lwdContacts on desktop, lwmContacts on mobile)

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/PayTabView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/PayTabView.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { Balance } from "@features/flow-pay-balance";
+import { Contacts } from "@features/flow-pay-contact";
+import { ContactsLedgerSyncIntroductionDialog } from "@features/flow-contacts-introduction";
+import { DepositOptions } from "@features/flow-pay-deposit";
+import { RequestReceive, VerifyAddress } from "@features/flow-pay-request";
+import { FeatureTour } from "@features/flow-pay-feature-tour";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import PayTabHeader from "./components/PayTabHeader";
+import { VerifyAddressExecutorLWD } from "./verifyAddressIntent/VerifyAddressExecutorLWD";
+import type { PayTabViewModel } from "./usePayTabViewModel";
+
+export function PayTabView({
+  balance,
+  featureTour,
+  actionTiles,
+  depositOptions,
+  requestReceive,
+  verifyPhase,
+  verifyAddress,
+  deviceIntent,
+  contacts,
+  ledgerSyncIntroduction,
+  isContactsEnabled,
+}: Readonly<PayTabViewModel>) {
+  return (
+    <div className="flex flex-col gap-24">
+      <TrackPage category="Pay" balance_filter={balance.filter} />
+      {verifyPhase === "intro" && <TrackPage category="Request Address Verification" />}
+      <PayTabHeader />
+      <Balance {...balance} actionTiles={actionTiles} />
+
+      {isContactsEnabled && (
+        <>
+          <Contacts {...contacts} />
+          <ContactsLedgerSyncIntroductionDialog {...ledgerSyncIntroduction} />
+        </>
+      )}
+
+      <DepositOptions {...depositOptions} />
+      <RequestReceive {...requestReceive} />
+
+      <VerifyAddress {...verifyAddress} />
+      {deviceIntent.active && deviceIntent.selection && (
+        <VerifyAddressExecutorLWD
+          selection={deviceIntent.selection}
+          onReady={deviceIntent.onReady}
+          onExit={deviceIntent.onExit}
+        />
+      )}
+      <FeatureTour {...featureTour} />
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
@@ -7,6 +7,7 @@ import {
   waitFor,
   render,
   within,
+  withFlagOverrides,
 } from "tests/testSetup";
 import { useNavigate } from "react-router";
 import type { TokenAccount } from "@ledgerhq/types-live";
@@ -305,6 +306,22 @@ describe("PayTab integration", () => {
     expect(screen.queryByTestId("device-intent-executor")).not.toBeInTheDocument();
   });
 
+  it("should not render the contacts section when lwdContacts is disabled", async () => {
+    const account = createEthAccountWithContactTransfers();
+    render(<PayTab />, {
+      initialRoute: "/paytab",
+      initialState: {
+        ...onboardedState,
+        ...tourSeenState,
+        accounts: [account],
+        contacts: { contacts: [aliceContact()] },
+      },
+    });
+
+    expect(await screen.findByText(EMPTY_TITLE)).toBeVisible();
+    expect(screen.queryByTestId("pay-contacts")).not.toBeInTheDocument();
+  });
+
   it("should count send and receive transfers with a contact and open History from View transactions", async () => {
     const account = createEthAccountWithContactTransfers();
     const { user } = render(<PayTab />, {
@@ -314,6 +331,7 @@ describe("PayTab integration", () => {
         ...tourSeenState,
         accounts: [account],
         contacts: { contacts: [aliceContact()] },
+        ...withFlagOverrides({ lwdContacts: { enabled: true, params: { newBadge: false } } }),
       },
     });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/index.tsx
@@ -1,61 +1,7 @@
 import React from "react";
-import { Balance } from "@features/flow-pay-balance";
-import { Contacts } from "@features/flow-pay-contact";
-import { ContactsLedgerSyncIntroductionDialog } from "@features/flow-contacts-introduction";
-import { DepositOptions } from "@features/flow-pay-deposit";
-import { RequestReceive, VerifyAddress } from "@features/flow-pay-request";
-import TrackPage from "~/renderer/analytics/TrackPage";
-import PayTabHeader from "./components/PayTabHeader";
-import { usePayCardBalance } from "./hooks/usePayCardBalance";
-import { FeatureTour } from "@features/flow-pay-feature-tour";
-import { usePayTabFeatureTour } from "./hooks/usePayTabFeatureTour";
-import { usePayTabActionTiles } from "./hooks/usePayTabActionTiles";
-import { usePayTabContacts } from "./hooks/usePayTabContacts";
-import { usePayTabDepositOptions } from "./hooks/usePayTabDepositOptions";
-import { usePayTabRequestReceive } from "./hooks/usePayTabRequestReceive";
-import { usePayTabNewPayment } from "./hooks/usePayTabNewPayment";
-import { usePayTabVerifyAddress } from "./hooks/usePayTabVerifyAddress";
-import { VerifyAddressExecutorLWD } from "./verifyAddressIntent/VerifyAddressExecutorLWD";
+import { PayTabView } from "./PayTabView";
+import { usePayTabViewModel } from "./usePayTabViewModel";
 
-const PayTab = () => {
-  const balance = usePayCardBalance();
-  const featureTour = usePayTabFeatureTour();
-  const deposit = usePayTabDepositOptions(balance.onTrackEvent);
-  const verify = usePayTabVerifyAddress(balance.onTrackEvent);
-  const request = usePayTabRequestReceive(balance.onTrackEvent, verify.openIntro);
-  const newPayment = usePayTabNewPayment();
-  const actionTiles = usePayTabActionTiles(
-    balance.onTrackEvent,
-    deposit.open,
-    request.open,
-    newPayment.open,
-  );
-  const { contacts, ledgerSyncIntroduction } = usePayTabContacts();
-
-  return (
-    <div className="flex flex-col gap-24">
-      <TrackPage category="Pay" balance_filter={balance.filter} />
-      {verify.phase === "intro" && <TrackPage category="Request Address Verification" />}
-      <PayTabHeader />
-      <Balance {...balance} actionTiles={actionTiles} />
-
-      <Contacts {...contacts} />
-      <ContactsLedgerSyncIntroductionDialog {...ledgerSyncIntroduction} />
-
-      <DepositOptions {...deposit.depositOptions} />
-      <RequestReceive {...request.requestReceive} />
-
-      <VerifyAddress {...verify.verifyAddress} />
-      {verify.deviceIntent.active && verify.deviceIntent.selection && (
-        <VerifyAddressExecutorLWD
-          selection={verify.deviceIntent.selection}
-          onReady={verify.deviceIntent.onReady}
-          onExit={verify.deviceIntent.onExit}
-        />
-      )}
-      <FeatureTour {...featureTour} />
-    </div>
-  );
-};
+const PayTab = () => <PayTabView {...usePayTabViewModel()} />;
 
 export default PayTab;

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/usePayTabViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/usePayTabViewModel.ts
@@ -1,0 +1,42 @@
+import { useContactsFeature } from "@features/platform-contacts";
+import { usePayCardBalance } from "./hooks/usePayCardBalance";
+import { usePayTabFeatureTour } from "./hooks/usePayTabFeatureTour";
+import { usePayTabActionTiles } from "./hooks/usePayTabActionTiles";
+import { usePayTabContacts } from "./hooks/usePayTabContacts";
+import { usePayTabDepositOptions } from "./hooks/usePayTabDepositOptions";
+import { usePayTabRequestReceive } from "./hooks/usePayTabRequestReceive";
+import { usePayTabNewPayment } from "./hooks/usePayTabNewPayment";
+import { usePayTabVerifyAddress } from "./hooks/usePayTabVerifyAddress";
+
+export function usePayTabViewModel() {
+  const balance = usePayCardBalance();
+  const featureTour = usePayTabFeatureTour();
+  const deposit = usePayTabDepositOptions(balance.onTrackEvent);
+  const verify = usePayTabVerifyAddress(balance.onTrackEvent);
+  const request = usePayTabRequestReceive(balance.onTrackEvent, verify.openIntro);
+  const newPayment = usePayTabNewPayment();
+  const actionTiles = usePayTabActionTiles(
+    balance.onTrackEvent,
+    deposit.open,
+    request.open,
+    newPayment.open,
+  );
+  const { contacts, ledgerSyncIntroduction } = usePayTabContacts();
+  const { isEnabled: isContactsEnabled } = useContactsFeature("desktop");
+
+  return {
+    balance,
+    featureTour,
+    actionTiles,
+    depositOptions: deposit.depositOptions,
+    requestReceive: request.requestReceive,
+    verifyPhase: verify.phase,
+    verifyAddress: verify.verifyAddress,
+    deviceIntent: verify.deviceIntent,
+    contacts,
+    ledgerSyncIntroduction,
+    isContactsEnabled,
+  };
+}
+
+export type PayTabViewModel = ReturnType<typeof usePayTabViewModel>;

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
@@ -369,8 +369,15 @@ describe("PayTab integration", () => {
   });
 
   describe("contacts strip", () => {
-    it("should render the Pay tile without see-all when 8 or fewer contacts are saved", async () => {
+    it("should not render the contacts section when lwmContacts is disabled", async () => {
       renderPayTab({ contacts: seedContacts(8) });
+
+      expect(await screen.findByTestId("paytab-screen")).toBeVisible();
+      expect(screen.queryByTestId("pay-contacts")).toBeNull();
+    });
+
+    it("should render the Pay tile without see-all when 8 or fewer contacts are saved", async () => {
+      renderPayTab({ contacts: seedContacts(8), contactsEnabled: true });
 
       expect(await screen.findByTestId("pay-contacts-pay-tile")).toBeVisible();
       expect(screen.getByTestId("pay-contacts-tile-7")).toBeVisible();
@@ -379,7 +386,7 @@ describe("PayTab integration", () => {
     });
 
     it("should cap the strip at 8 and open the contacts list with a Pay title via see-all", async () => {
-      const { user } = renderPayTab({ contacts: seedContacts(9) });
+      const { user } = renderPayTab({ contacts: seedContacts(9), contactsEnabled: true });
 
       expect(await screen.findByTestId("pay-contacts-tile-7")).toBeVisible();
       expect(screen.queryByTestId("pay-contacts-tile-8")).toBeNull();

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/shared.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/shared.tsx
@@ -104,6 +104,7 @@ type RenderPayTabOptions = Readonly<{
   holdsUni?: boolean;
   cryptoOnly?: boolean;
   contacts?: Contact[];
+  contactsEnabled?: boolean;
 }>;
 
 function withUsdcHoldings(state: State): State {
@@ -200,6 +201,7 @@ export function renderPayTab({
   holdsUni = false,
   cryptoOnly = false,
   contacts,
+  contactsEnabled = false,
 }: RenderPayTabOptions = {}) {
   return render(
     <>
@@ -217,6 +219,9 @@ export function renderPayTab({
             enabled: true,
             params: { enableModularization: true, searchDebounceTime: 0 },
           },
+          ...(contactsEnabled
+            ? { lwmContacts: { enabled: true, params: { newBadge: false } } }
+            : {}),
         },
         state => {
           const next: State = {

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/PayTabView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/PayTabView.tsx
@@ -17,6 +17,7 @@ type PayTabViewProps = {
   readonly balance: BalanceData;
   readonly actionTiles: ActionTilesProps;
   readonly contacts: ContactsNativeProps;
+  readonly isContactsEnabled: boolean;
   readonly depositOptions: DepositOptionsProps;
 };
 
@@ -29,6 +30,7 @@ export function PayTabView({
   balance,
   actionTiles,
   contacts,
+  isContactsEnabled,
   depositOptions,
 }: PayTabViewProps) {
   return (
@@ -37,7 +39,7 @@ export function PayTabView({
       <Box lx={{ flex: 1, gap: "s24", paddingHorizontal: "s16" }} style={{ paddingTop: top }}>
         <TrackScreen category="Pay" balance_filter={balance.filter} />
         <Balance {...balance} actionTiles={actionTiles} />
-        <Contacts {...contacts} />
+        {isContactsEnabled && <Contacts {...contacts} />}
         <Card title={cardTitle} oauthConfig={oauthConfig} callback={callback} />
         <FeatureTour {...featureTour} />
         <DepositOptions {...depositOptions} />

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useRoute, type RouteProp } from "@react-navigation/native";
 import useEnv from "@features/platform-env";
+import { useContactsFeature } from "@features/platform-contacts";
 import { useTranslation } from "~/context/Locale";
 import type { ScreenName } from "~/const";
 import type { CardProps } from "@features/flow-pay-card";
@@ -25,6 +26,7 @@ export function usePayTabViewModel() {
   const request = usePayTabRequestReceive();
   const actionTiles = usePayTabActionTiles(balance.onTrackEvent, deposit.open, request.open);
   const contacts = usePayTabContacts();
+  const { isEnabled: isContactsEnabled } = useContactsFeature("mobile");
 
   // Read with `useEnv`, and not with `getEnv`: a tester sets these in the debug settings, and the
   // login must take the new values without a restart of the app.
@@ -67,6 +69,7 @@ export function usePayTabViewModel() {
     balance,
     actionTiles,
     contacts,
+    isContactsEnabled,
     depositOptions: deposit.depositOptions,
   };
 }


### PR DESCRIPTION
### 📝 Description

The Pay tab renders a contacts section (`<Contacts />`) on both Ledger Wallet Desktop and Mobile. This PR gates that section behind the contacts feature flag so it only renders when contacts is enabled:

- **Desktop**: `PayTab` reads `useContactsFeature("desktop")` and renders `<Contacts />` (and the Ledger Sync introduction dialog) only when `lwdContacts` is enabled. While doing so, `PayTab` was refactored to the MVVM Container -> ViewModel -> View pattern (`usePayTabViewModel` + `PayTabView`).
- **Mobile**: `usePayTabViewModel` exposes `isContactsEnabled` via `useContactsFeature("mobile")`, and `PayTabView` renders `<Contacts />` only when `lwmContacts` is enabled.

Automated checks preventing regression (PayTab integration tests, both apps):
- Flag off/absent: the `pay-contacts` section is not rendered.
- Flag on: the contacts strip/table renders as before.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36767](https://ledgerhq.atlassian.net/browse/LIVE-36767)
- **ADR** (if any): N/A

[LIVE-36767]: https://ledgerhq.atlassian.net/browse/LIVE-36767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ