### PR TITLE
[LWD] feat(pay): update desktop feature tour to match mockups

### DIFF
--- a/.changeset/calm-pay-tour.md
+++ b/.changeset/calm-pay-tour.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Update the desktop Pay feature tour layout and copy to match mockups (LIVE-36499).

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
@@ -24,6 +24,7 @@ import { AssetCategory } from "@domain/api-aggregated-assets";
 import {
   EMPTY_DESCRIPTION,
   EMPTY_TITLE,
+  FEATURE_TOUR_CTA,
   FEATURE_TOUR_ROW,
   INIT_INPUT,
   USDC_TOKEN,
@@ -128,10 +129,10 @@ describe("PayTab integration", () => {
     });
 
     expect(screen.getByText(FEATURE_TOUR_ROW)).toBeVisible();
-    expect(screen.getByRole("button", { name: "Got it" })).toBeVisible();
+    expect(screen.getByRole("button", { name: FEATURE_TOUR_CTA })).toBeVisible();
   });
 
-  it("should persist dismissal and hide the tour after clicking Got it", async () => {
+  it("should persist dismissal and hide the tour after clicking Explore Pay", async () => {
     const { user, store } = render(<PayTab />, {
       initialState: {
         payCardFeatureTour: { ...payCardFeatureTourInitialState, hasSeenFeatureTour: false },
@@ -140,7 +141,7 @@ describe("PayTab integration", () => {
 
     expect(screen.getByText(FEATURE_TOUR_ROW)).toBeVisible();
 
-    await user.click(screen.getByRole("button", { name: "Got it" }));
+    await user.click(screen.getByRole("button", { name: FEATURE_TOUR_CTA }));
 
     await waitFor(() => {
       expect(store.getState().payCardFeatureTour.hasSeenFeatureTour).toBe(true);
@@ -154,7 +155,7 @@ describe("PayTab integration", () => {
     });
 
     expect(screen.queryByText(FEATURE_TOUR_ROW)).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Got it" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: FEATURE_TOUR_CTA })).not.toBeInTheDocument();
   });
 
   it("should render the empty hero when the user holds no stablecoins", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/fixtures.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/fixtures.ts
@@ -14,7 +14,8 @@ import { USDC, USDT } from "../hooks/__tests__/fixtures";
 
 export const EMPTY_TITLE = "Pay and get paid";
 export const EMPTY_DESCRIPTION = "Start by depositing stablecoin to your wallet";
-export const FEATURE_TOUR_ROW = "Minimal volatility";
+export const FEATURE_TOUR_ROW = "Request payments";
+export const FEATURE_TOUR_CTA = "Explore Pay";
 
 export const onboardedState = { settings: { ...AFTER_ONBOARDING_STATE, counterValue: "USD" } };
 

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -873,21 +873,21 @@
   },
   "payTab": {
     "featureTour": {
-      "title": "Pay and get paid",
-      "description": "Stablecoin closes the gap between crypto and real life spending",
-      "cta": "Got it",
+      "title": "All your payments, in one place",
+      "description": "Meet your new Pay tab, making your crypto ready for everyday money moments.",
+      "cta": "Explore Pay",
       "rows": {
         "global": {
-          "title": "Pay and get paid globally",
-          "description": "Benefits from low networks fees"
+          "title": "Pay your contacts",
+          "description": "Send crypto to saved addresses."
         },
         "volatility": {
-          "title": "Minimal volatility",
-          "description": "Stablecoin are based on fiat"
+          "title": "Request payments",
+          "description": "Ask Contacts to send funds straight to you."
         },
         "card": {
-          "title": "Spend with a card and get 1% cashback",
-          "description": "Pay in USDC, USDT, BTC, ETH and more"
+          "title": "Shop worldwide with crypto card",
+          "description": "And earn uncapped 1% cashback."
         }
       }
     },

--- a/features/flow/pay-feature-tour/src/components/FeatureTour/FeatureTourView.web.tsx
+++ b/features/flow/pay-feature-tour/src/components/FeatureTour/FeatureTourView.web.tsx
@@ -60,7 +60,7 @@ export function FeatureTourView({
   return (
     <Dialog open onOpenChange={handleOpenChange}>
       <DialogContent className="min-h-[696px]">
-        <DialogHeader density="expanded" onClose={handleDismiss} />
+        <DialogHeader density="compact" onClose={handleDismiss} />
         <DialogBody className="flex flex-1 flex-col">
           <div className="flex min-h-[608px] w-full flex-1 flex-col justify-between gap-16">
             <div className="flex flex-col gap-16">

--- a/features/flow/pay-feature-tour/src/components/FeatureTour/__tests__/FeatureTour.native.test.tsx
+++ b/features/flow/pay-feature-tour/src/components/FeatureTour/__tests__/FeatureTour.native.test.tsx
@@ -37,8 +37,8 @@ describe("FeatureTour (Native)", () => {
   it("renders the intro title and feature rows when not seen", () => {
     renderTour();
 
-    expect(screen.getByText("All your payments, in one place")).toBeTruthy();
-    expect(screen.getByText("Shop worldwide with crypto card")).toBeTruthy();
+    expect(screen.getByText("All your payments, in one place")).toBeVisible();
+    expect(screen.getByText("Shop worldwide with crypto card")).toBeVisible();
   });
 
   it("tracks the screen view once shown", () => {
@@ -81,6 +81,6 @@ describe("FeatureTour (Native)", () => {
       </Provider>,
     );
 
-    expect(screen.getByLabelText("Compris")).toBeTruthy();
+    expect(screen.getByLabelText("Compris")).toBeVisible();
   });
 });

--- a/features/flow/pay-feature-tour/src/components/FeatureTour/__tests__/FeatureTour.web.test.tsx
+++ b/features/flow/pay-feature-tour/src/components/FeatureTour/__tests__/FeatureTour.web.test.tsx
@@ -33,8 +33,8 @@ describe("FeatureTour (Web)", () => {
   it("renders the feature rows and CTA when not seen", () => {
     renderTour();
 
-    expect(screen.getByText("Shop worldwide with crypto card")).toBeInTheDocument();
-    expect(screen.getByText("Explore Pay")).toBeInTheDocument();
+    expect(screen.getByText("Shop worldwide with crypto card")).toBeVisible();
+    expect(screen.getByText("Explore Pay")).toBeVisible();
   });
 
   it("tracks the screen view once shown", () => {
@@ -76,6 +76,6 @@ describe("FeatureTour (Web)", () => {
       </Provider>,
     );
 
-    expect(screen.getByText("Compris")).toBeInTheDocument();
+    expect(screen.getByText("Compris")).toBeVisible();
   });
 });

--- a/features/flow/pay-feature-tour/src/components/FeatureTour/__tests__/FeatureTourView.native.test.tsx
+++ b/features/flow/pay-feature-tour/src/components/FeatureTour/__tests__/FeatureTourView.native.test.tsx
@@ -60,7 +60,7 @@ describe("FeatureTourView (Native)", () => {
     render(<FeatureTourView {...defaultProps} isVisible={false} />);
 
     const sheet = screen.getByTestId("pay-feature-tour-sheet");
-    expect(sheet).toBeTruthy();
+    expect(sheet).toBeVisible();
     expect(sheet.props.accessibilityState.expanded).toBe(false);
     expect(screen.queryByText("Pay and get paid")).toBeNull();
   });
@@ -70,8 +70,8 @@ describe("FeatureTourView (Native)", () => {
 
     const sheet = screen.getByTestId("pay-feature-tour-sheet");
     expect(sheet.props.accessibilityState.expanded).toBe(true);
-    expect(screen.getByText("Pay and get paid")).toBeTruthy();
-    expect(screen.getByLabelText("Explore Pay")).toBeTruthy();
+    expect(screen.getByText("Pay and get paid")).toBeVisible();
+    expect(screen.getByLabelText("Explore Pay")).toBeVisible();
   });
 
   it("dismisses once even if the CTA is pressed repeatedly", () => {


### PR DESCRIPTION
## Summary
- Align the desktop Pay tab feature tour with the [desktop mockup](https://www.figma.com/design/WYQQwem0QyG2fTuaAKAe3Y/Pay-%E2%80%A2-Production?node-id=7592-57942&m=dev): compact dialog header and matching English copy.
- Depends on #21373 for shared icons, hero, and view-model rows.

Top of stack. Base: `feat/pay-LIVE-36497-feature-tour-mobile`.

<img width="988" height="948" alt="image" src="https://github.com/user-attachments/assets/1da3eeba-bed9-4d70-b545-ff5b09fe3001" />

## Context
- **JIRA**: [LIVE-36499](https://ledgerhq.atlassian.net/browse/LIVE-36499)

## Test plan
- [ ] First Pay tab visit shows the new title, three rows, lifestyle hero, and **Explore Pay**
- [ ] Explore Pay / close / backdrop dismiss the tour once and do not show it again
- [ ] Dialog header is close-only (compact)

[LIVE-36499]: https://ledgerhq.atlassian.net/browse/LIVE-36499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ