### PR TITLE
fix(ci): regenerate nx cache config after pnpm clean

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint:boundaries": "nx run enforce-boundaries:lint:boundaries",
     "lint:structure": "nx run-many -t lint:structure",
     "bump": "changeset version",
-    "clean": "git clean -fdX",
+    "clean": "git clean -fdX && node tools/nx/write-nx-cache-config.mjs --force",
     "changelog": "changeset add",
     "prerelease": "pnpm run build:libs",
     "release": "changeset publish",

--- a/tools/actions/composites/configure-nx-remote-cache-profile/README.md
+++ b/tools/actions/composites/configure-nx-remote-cache-profile/README.md
@@ -2,6 +2,8 @@
 
 Resolves **one** IAM role ARN and the Nx S3 **`cacheKeyPrefix`** from `github.ref`, then runs [`tools/nx/write-nx-cache-config.mjs`](../../../../tools/nx/write-nx-cache-config.mjs) so **gitignored** `nx.cache-config.json` is generated with the right prefix. Tracked root [`nx.json`](../../../../nx.json) only `extends` that file and is never patched in CI.
 
+The resolved prefix is also exported as **`NX_CACHE_KEY_PREFIX`** to `$GITHUB_ENV`, so any later step that regenerates the config lands on the same prefix. `pnpm clean` (`git clean -fdX`) deletes `nx.cache-config.json` along with every other gitignored file, and the mobile install-retry paths call it, so `clean` regenerates the config itself — without this env export it would silently fall back to prefix `local` on CI.
+
 ## Edge cases
 
 - **Pull requests:** `github.ref` is `refs/pull/<n>/merge`, so jobs use the **branch** profile (`cacheKeyPrefix: branch` and the branch OIDC role when both profile ARNs are set).

--- a/tools/actions/composites/configure-nx-remote-cache-profile/action.yml
+++ b/tools/actions/composites/configure-nx-remote-cache-profile/action.yml
@@ -79,6 +79,12 @@ runs:
           fs.appendFileSync(out, `nx-cache-key-prefix=${nxCacheKeyPrefix}\n`);
           fs.appendFileSync(out, `cache-profile=${cacheProfile}\n`);
 
+    - name: Export NX_CACHE_KEY_PREFIX
+      shell: bash
+      env:
+        NX_CACHE_KEY_PREFIX: ${{ steps.resolve.outputs.nx-cache-key-prefix }}
+      run: echo "NX_CACHE_KEY_PREFIX=${NX_CACHE_KEY_PREFIX}" >> "$GITHUB_ENV" # zizmor: ignore[github-env]
+
     - name: Write Nx cache config (gitignored nx.cache-config.json)
       shell: bash
       run: node "${{ github.workspace }}/tools/nx/write-nx-cache-config.mjs" --cache-key-prefix "${{ steps.resolve.outputs.nx-cache-key-prefix }}"


### PR DESCRIPTION
### 📝 Description

**Previous behaviour.** The mobile install steps retry via `nick-fields/retry`, and the retry command runs `pnpm clean` (`git clean -fdX`) before reinstalling. That wipes every gitignored file — including `nx.cache-config.json`, which the tracked root `nx.json` does nothing but `extends`. The reinstall runs with `--ignore-scripts` so the root `postinstall` never regenerates it, and `setup-caches` (which originally wrote it) has already completed earlier in the job. The next `nx` invocation then dies:

```
Cannot find module './nx.cache-config.json'
Require stack:
- node_modules/.pnpm/nx@22.5.1/node_modules/nx/src/config/nx-json.js
- node_modules/.pnpm/nx@22.5.1/node_modules/nx/src/command-line/yargs-utils/shared-options.js
...
```

Seen in [run 33401844077](https://github.com/LedgerHQ/ledger-live/actions/runs/33401844077/job/99521445371) (iOS UI E2E Smoke Tests on `develop`), where a JFrog Artifactory `ETIMEDOUT`/`ECONNRESET` blew through the 15-minute install timeout, the retry fired, and the log shows `Removing nx.cache-config.json` verbatim. Every step after `Build e2e dependencies` was skipped.

The same `pnpm clean` retry exists in 5 places across 4 workflows (`test-mobile-e2e-reusable.yml`, `test-mobile-mock-reusable.yml`, `test-mobile-build-ios-reusable.yml` ×2, `test-mobile-build-android-reusable.yml`), so any install retry in any of them fails the same way.

**The fix.** The full `git clean -fdX` is doing real work on retry — recovering from partial installs, half-written generated files, stale pods — so narrowing it to `node_modules` would trade a loud failure for a subtle one. Instead the clean keeps its nuclear semantics and restores the one invariant the workspace can't function without:

- `package.json` — `"clean": "git clean -fdX && node tools/nx/write-nx-cache-config.mjs --force"`. The script imports only `node:` builtins, so it runs fine with `node_modules` gone.
- `tools/actions/composites/configure-nx-remote-cache-profile/action.yml` — the resolved prefix currently only reaches `GITHUB_OUTPUT`, visible to a single step. It's now also exported as `NX_CACHE_KEY_PREFIX` to `$GITHUB_ENV`, so the regenerated file keeps the correct S3 prefix. **These two changes are load-bearing together**: without the env export, a `pnpm clean` on CI would regenerate at prefix `local` and silently miss the cache against the wrong S3 namespace — a worse failure than the loud one being fixed.

This covers all 5 retry sites and every local `pnpm clean` with no per-workflow plumbing. `pnpm clean` has no other callers in the repo.

No changeset: nothing published changes (root `package.json` is private, the rest is CI tooling).

### 🔗 Context

Ticket: https://ledgerhq.atlassian.net/browse/LIVE-36776
