### PR TITLE
[LWDM] fix(market): open correct asset detail for Arbitrum (LIVE-36771)

### DIFF
--- a/.changeset/light-numbers-kick.md
+++ b/.changeset/light-numbers-kick.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@ledgerhq/asset-aggregation": minor
+---
+
+Fix MarketBanner/Market list navigation so clicking Arbitrum opens the ARB asset detail instead of the Ethereum one, by passing the market ledger ids in the navigation state and preventing a bare market id from colliding with a same-named chain id

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/__tests__/useAssetDetailViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/__tests__/useAssetDetailViewModel.test.ts
@@ -132,6 +132,18 @@ describe("useAssetDetailViewModel", () => {
 
       expect((await waitForReady()).distributionItem).toBe(item);
     });
+
+    it("does not resolve a market id to a chain that shares the same id", async () => {
+      mockMarket.empty();
+      mockDada.empty();
+      route("arbitrum");
+      locationState({ id: "arbitrum", ledgerIds: ["ethereum/erc20/arbitrum"] });
+
+      const vm = await waitForReady();
+
+      expect(vm.ledgerCurrency?.id).not.toBe("arbitrum");
+      expect(vm.displayTicker).not.toBe("ETH");
+    });
   });
 
   describe("distribution options", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/useAssetDetailViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/useAssetDetailViewModel.ts
@@ -40,11 +40,12 @@ export function useAssetDetailViewModel(): AssetDetailViewModel {
     [routeAssetId, decodedAssetId, marketState, distribution],
   );
 
-  // The market API expects a CoinGecko id, which only coincidentally matches the
-  // ledger id for some coins (e.g. "hedera" vs "hedera-hashgraph").
+  // Prefer the market ledger id over the route param: a bare market id can collide
+  // with a same-named chain (e.g. "arbitrum" resolves to the Arbitrum One chain, ETH).
+  const fallbackLedgerId = marketState?.ledgerIds?.[0] ?? decodedAssetId;
   const fallbackCurrency = useMemo(
-    () => (decodedAssetId ? findCryptoCurrencyById(decodedAssetId) : undefined),
-    [decodedAssetId],
+    () => (fallbackLedgerId ? findCryptoCurrencyById(fallbackLedgerId) : undefined),
+    [fallbackLedgerId],
   );
 
   const { marketApiId, knownLedgerIds } = useMemo(

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__integrations__/MarketBanner.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__integrations__/MarketBanner.integration.test.tsx
@@ -96,6 +96,8 @@ describe("MarketBanner integration", () => {
 
     await user.click(screen.getByTestId("market-banner-asset-bitcoin"));
 
-    expect(mockNavigate).toHaveBeenCalledWith("/market/bitcoin");
+    expect(mockNavigate).toHaveBeenCalledWith("/market/bitcoin", {
+      state: { id: "bitcoin", ledgerIds: ["bitcoin"] },
+    });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/TrendingAssetTile.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/TrendingAssetTile.test.tsx
@@ -21,7 +21,7 @@ describe("TrendingAssetTile", () => {
     expect(screen.getByText("+5.50%")).toBeVisible();
 
     await user.click(screen.getByTestId("market-banner-asset-bitcoin"));
-    expect(onNavigate).toHaveBeenCalledWith("bitcoin");
+    expect(onNavigate).toHaveBeenCalledWith(item);
     expect(clickHandler).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/TrendingAssetsList.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/__tests__/TrendingAssetsList.test.tsx
@@ -63,7 +63,9 @@ describe("TrendingAssetsList", () => {
 
     await user.click(screen.getByTestId("market-banner-asset-bitcoin"));
     expect(mockSetTrackingSource).toHaveBeenCalledWith(MARKET_BANNER_TRACKING_SOURCE);
-    expect(mockNavigate).toHaveBeenCalledWith("/market/bitcoin");
+    expect(mockNavigate).toHaveBeenCalledWith("/market/bitcoin", {
+      state: { id: "bitcoin", ledgerIds: ["bitcoin"] },
+    });
   });
 
   it("should show left arrow and handle scroll left when not at start", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/TrendingAssetTile.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/TrendingAssetTile.tsx
@@ -6,7 +6,7 @@ import { AssetIcon } from "./AssetIcon";
 
 type TrendingAssetTileProps = {
   readonly item: MarketItemPerformer;
-  readonly onNavigate: (id: string) => () => void;
+  readonly onNavigate: (item: MarketItemPerformer) => () => void;
 };
 
 const TrendingAssetTileComponent = ({ item, onNavigate }: TrendingAssetTileProps) => {
@@ -31,7 +31,7 @@ const TrendingAssetTileComponent = ({ item, onNavigate }: TrendingAssetTileProps
     <Tile
       className="w-[98px]"
       appearance="card"
-      onClick={onNavigate(item.id)}
+      onClick={onNavigate(item)}
       data-testid={`market-banner-asset-${item.id}`}
     >
       <Spot size={40} appearance="icon" icon={renderIcon} />

--- a/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/TrendingAssetsList.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/TrendingAssetsList.tsx
@@ -25,14 +25,16 @@ export const TrendingAssetsList = ({ items, isLoading, isError }: TrendingAssets
   const { shouldDisplayAggregatedAssets } = useWalletFeaturesConfig("desktop");
 
   const onAssetClick = useCallback(
-    (id: string) => () => {
+    (item: MarketItemPerformer) => () => {
       track("button_clicked", {
         button: "Market Tile",
-        currency: id,
+        currency: item.id,
         page: PORTFOLIO_TRACKING_PAGE_NAME,
       });
       setTrackingSource(MARKET_BANNER_TRACKING_SOURCE);
-      navigate(getMarketOrAssetDetailPath(id, shouldDisplayAggregatedAssets));
+      navigate(getMarketOrAssetDetailPath(item.id, shouldDisplayAggregatedAssets), {
+        state: { id: item.id, ledgerIds: item.ledgerIds },
+      });
     },
     [navigate, shouldDisplayAggregatedAssets],
   );

--- a/libs/asset-aggregation/src/assetDistribution/__tests__/resolveDistributionItem.test.ts
+++ b/libs/asset-aggregation/src/assetDistribution/__tests__/resolveDistributionItem.test.ts
@@ -127,6 +127,32 @@ describe("resolveDistributionItem", () => {
     expect(result).toBe(usdt);
   });
 
+  it("does not match a network by a bare market id that collides with a chain id", () => {
+    const eth = item(cryptoCurrency("ethereum"), ["arbitrum", "optimism"]);
+    const result = resolveDistributionItem(
+      base({
+        routeAssetId: "arbitrum",
+        decodedAssetId: "arbitrum",
+        distribution: { bySlug: {}, list: [eth] },
+        marketState: { ledgerIds: ["ethereum/erc20/arbitrum"] },
+      }),
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("matches a token by its ledger id hint when its market id collides with a chain id", () => {
+    const token = item(tokenCurrency("ethereum/erc20/arbitrum"));
+    const result = resolveDistributionItem(
+      base({
+        routeAssetId: "arbitrum",
+        decodedAssetId: "arbitrum",
+        distribution: { bySlug: {}, list: [token] },
+        marketState: { ledgerIds: ["ethereum/erc20/arbitrum"] },
+      }),
+    );
+    expect(result).toBe(token);
+  });
+
   it("matches by market ledger id in the distribution list", () => {
     const btc = item(cryptoCurrency("bitcoin"));
     const result = resolveDistributionItem(

--- a/libs/asset-aggregation/src/assetDistribution/resolveDistributionItem.ts
+++ b/libs/asset-aggregation/src/assetDistribution/resolveDistributionItem.ts
@@ -8,6 +8,14 @@ export type DistributionLookup = {
 
 export type MarketStateSlice = { ledgerIds?: string[] } | undefined;
 
+/** Case-insensitive matcher for a group of ids. */
+type IdMatcher = { readonly size: number; matches: (id: string) => boolean };
+
+function createIdMatcher(...ids: Array<string | undefined>): IdMatcher {
+  const set = new Set(ids.filter((id): id is string => id != null).map(id => id.toLowerCase()));
+  return { size: set.size, matches: id => set.has(id.toLowerCase()) };
+}
+
 export type ResolveDistributionItemParams = {
   /** The id (or slug) coming from the route / caller. */
   routeAssetId: string | undefined;
@@ -42,15 +50,21 @@ export function resolveDistributionItem({
   if (!routeAssetId) return undefined;
   const decoded = decodedAssetId ?? routeAssetId;
   const marketLedgerId = marketState?.ledgerIds?.[0];
-  const targetIds = new Set(
-    [decoded, marketLedgerId].filter((id): id is string => id != null).map(id => id.toLowerCase()),
-  );
-  const matchesId = (id: string): boolean => targetIds.has(id.toLowerCase());
+  const primaryMatcher = createIdMatcher(decoded, marketLedgerId);
+
+  // Network matching only uses ledger ids, never a bare market id that can collide
+  // with a chain id (e.g. "arbitrum" is a market id and the Arbitrum One chain id).
+  const decodedLedgerId = decoded.includes("/") ? decoded : undefined;
+  const networkMatcher = createIdMatcher(decodedLedgerId, marketLedgerId);
 
   return (
     distribution.bySlug?.[decoded] ??
     (marketLedgerId ? distribution.bySlug?.[toSlug(marketLedgerId)] : undefined) ??
-    distribution.list.find(item => matchesId(item.currency.id)) ??
-    distribution.list.find(item => item.networks?.some(n => matchesId(n.currency.id)))
+    distribution.list.find(item => primaryMatcher.matches(item.currency.id)) ??
+    (networkMatcher.size > 0
+      ? distribution.list.find(item =>
+          item.networks?.some(n => networkMatcher.matches(n.currency.id)),
+        )
+      : undefined)
   );
 }


### PR DESCRIPTION
### 📝 Description

On Ledger Wallet Desktop, clicking Arbitrum from the MarketBanner or Market list opened the Ethereum asset detail page instead of the ARB token page. Mobile already behaved correctly.

The root cause is an id collision: the CoinGecko/market id `arbitrum` (the ARB token) is identical to the Ledger chain id for Arbitrum One (whose native currency is ETH). Desktop resolved the asset from the bare market id, so it fell back to the Arbitrum One chain (ETH).

Fix:
- MarketBanner navigation now passes the full market item, including `ledgerIds`, in the React Router `location.state` (aligning Desktop with Mobile). See [TrendingAssetsList.tsx](apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/TrendingAssetsList.tsx) and [TrendingAssetTile.tsx](apps/ledger-live-desktop/src/mvvm/features/MarketBanner/components/TrendingAssetTile.tsx).
- [useAssetDetailViewModel.ts](apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/useAssetDetailViewModel.ts) now prefers `marketState.ledgerIds[0]` over the bare route param when resolving the fallback currency, so a market id can no longer resolve to a same-named chain.
- [resolveDistributionItem.ts](libs/asset-aggregation/src/assetDistribution/resolveDistributionItem.ts) network matching only uses ledger ids (never a bare market id), and the duplicated id-matching logic was extracted into a small `createIdMatcher` helper.

Regression coverage: new unit tests in [resolveDistributionItem.test.ts](libs/asset-aggregation/src/assetDistribution/__tests__/resolveDistributionItem.test.ts) and [useAssetDetailViewModel.test.ts](apps/ledger-live-desktop/src/mvvm/features/AssetDetail/hooks/__tests__/useAssetDetailViewModel.test.ts) cover the market-id/chain-id collision; MarketBanner tests assert `ledgerIds` is passed in navigation state.



https://github.com/user-attachments/assets/5aa529f1-a3af-4d58-bd8d-c99af534691b




### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36771](https://ledgerhq.atlassian.net/browse/LIVE-36771)
- **ADR** (if any): N/A

[LIVE-36771]: https://ledgerhq.atlassian.net/browse/LIVE-36771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ