### PR TITLE
[LWDM] chore(cosmos): remove Ledger validator as the default one for Osmosis

### DIFF
--- a/.changeset/polite-spiders-unite.md
+++ b/.changeset/polite-spiders-unite.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/coin-cosmos": minor
+---
+
+chore(cosmos): remove Ledger validator as the default one for Osmosis

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/fields/ValidatorField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/fields/ValidatorField.tsx
@@ -36,10 +36,9 @@ const ValidatorField = ({ account, onChangeValidator, chosenVoteAccAddr }: Props
     (evt: React.ChangeEvent<HTMLInputElement>) => setSearch(evt.target.value),
     [setSearch],
   );
-  //Check if the account is a Persistence or Quicksilver account
   const shouldDisplayAllValidators =
     account.type === "Account" &&
-    ["quicksilver", "persistence", "mantra", "axelar"].includes(account.currency.id);
+    ["quicksilver", "persistence", "mantra", "axelar", "osmo"].includes(account.currency.id);
 
   useEffect(() => {
     if (shouldDisplayAllValidators) {

--- a/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/02-Summary.tsx
@@ -58,7 +58,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
     if (validator !== undefined) {
       return validator;
     }
-    if (mainAccount.currency.id === "persistence" || mainAccount.currency.id === "quicksilver") {
+    if (["persistence", "quicksilver", "osmo"].includes(mainAccount.currency.id)) {
       return undefined;
     }
     return validators[0];

--- a/libs/coin-modules/coin-cosmos/src/config.ts
+++ b/libs/coin-modules/coin-cosmos/src/config.ts
@@ -71,7 +71,6 @@ export const cosmosConfig: CosmosConfig = {
     default: {
       lcd: "https://osmo.coin.ledger.com",
       minGasPrice: 0.04,
-      ledgerValidator: "osmovaloper17cp6fxccqxrpj4zc00w2c7u6y0umc2jajsyc5t",
       status: {
         type: "active",
       },


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

The list of validators on Osmosis prefix Ledger node as the default. This removes Ledger validator as the default one for Osmosis.

| Before | After |
| - | - |
| <img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/7df82dc4-1266-43b6-8da8-32059d2e2eba" /> | <img width="2672" height="1522" alt="image" src="https://github.com/user-attachments/assets/a42fa34b-435f-4386-b8b5-87e24be6483b" /> |
| <img width="1116" height="2484" alt="image" src="https://github.com/user-attachments/assets/bbedaa0c-fa92-4ea2-8706-144df0eb932a" /> | <img width="1116" height="2484" alt="image" src="https://github.com/user-attachments/assets/ed077411-8096-4e34-b192-ab3d7ba370fb" /> |

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-36720
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
