### PR TITLE
chore(contacts): bump @ledgerhq/device-contacts-kit to 0.3.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 2.0.4
       version: 2.0.4
     '@ledgerhq/device-contacts-kit':
-      specifier: 0.3.0
-      version: 0.3.0
+      specifier: 0.3.1
+      version: 0.3.1
     '@ledgerhq/device-management-kit':
       specifier: 1.8.0
       version: 1.8.0
@@ -7554,7 +7554,7 @@ importers:
         version: link:../feature-flags
       '@ledgerhq/device-contacts-kit':
         specifier: 'catalog:'
-        version: 0.3.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+        version: 0.3.1(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
       '@ledgerhq/device-signer-kit-ethereum':
         specifier: 'catalog:'
         version: 1.17.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
@@ -22224,8 +22224,8 @@ packages:
       react-native:
         optional: true
 
-  '@ledgerhq/device-contacts-kit@0.3.0':
-    resolution: {integrity: sha512-RDSOiOhfIzTC0d/YCjCte90zqt1Kwr4YKIh1j+Tw8EaHUIq2kQtgqE1zwTFJO1YHVwFn0dHG1brxtnwGnMkPnA==}
+  '@ledgerhq/device-contacts-kit@0.3.1':
+    resolution: {integrity: sha512-qKGhVNJe7iNNITd0+5mmWDzL09xj0XFU/DO8zA0cdoBdQXv96pbgRC6JHG8bB8hiob1ixTRDEbsMp+UKm4xTSQ==}
     peerDependencies:
       '@ledgerhq/device-management-kit': ^1.8.0
 
@@ -28864,7 +28864,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: ^5.5.10
+      rxjs: '*'
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -49336,7 +49336,7 @@ snapshots:
       '@ledgerhq/lumen-ui-rnative': 0.1.58(50360a3b8905e3a0b0efc588bd9418f4)
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
 
-  '@ledgerhq/device-contacts-kit@0.3.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))':
+  '@ledgerhq/device-contacts-kit@0.3.1(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))':
     dependencies:
       '@ledgerhq/device-management-kit': 1.8.0(rxjs@7.8.2)
       '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
@@ -67554,7 +67554,9 @@ snapshots:
     optionalDependencies:
       metro-transform-worker: 0.81.5
     transitivePeerDependencies:
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   metro-config@0.83.3(metro-transform-worker@0.83.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,7 +24,7 @@ catalog:
   "@jest/globals": 30.5.0
   "@ledgerhq/context-module": 2.5.0
   "@ledgerhq/crypto-icons": "2.0.4"
-  "@ledgerhq/device-contacts-kit": 0.3.0
+  "@ledgerhq/device-contacts-kit": 0.3.1
   "@ledgerhq/device-management-kit": 1.8.0
   "@ledgerhq/dmk-ledger-wallet": 0.5.0
   "@ledgerhq/device-signer-kit-aleo": 0.4.0


### PR DESCRIPTION
### 📝 Description

Bumps the `@ledgerhq/device-contacts-kit` catalog version from `0.3.0` to `0.3.1`, following the new release published from [device-sdk-ts#881](https://github.com/LedgerHQ/device-sdk-ts/actions/runs/33492616663). `pnpm-lock.yaml` updated accordingly.

### 🔗 Context

- **JIRA / GitHub issue**: n/a
- **ADR** (if any): n/a