### PR TITLE
[LWDM] feat(hedera): validateIntent method

### DIFF
--- a/.changeset/tidy-hedera-validate-intent.md
+++ b/.changeset/tidy-hedera-validate-intent.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-hedera": minor
+"@ledgerhq/live-common": minor
+---
+
+feat: implement `validateIntent` in coin-hedera's logic layer, replacing the "not supported" throw

--- a/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
@@ -10,6 +10,7 @@ import {
   ContractFunctionParameters,
 } from "@hashgraph/sdk";
 import type { FeeEstimation } from "@ledgerhq/coin-module-framework/api/types";
+import { NotEnoughBalance, RecipientRequired } from "@ledgerhq/ledger-wallet-framework/errors";
 import { getEnv } from "@ledgerhq/live-env";
 import invariant from "invariant";
 import { createApi } from "../api";
@@ -19,7 +20,15 @@ import {
   STAKING_REWARD_HASH_SUFFIX,
   TINYBAR_SCALE,
 } from "../constants";
+import {
+  HederaInsufficientFundsForAssociation,
+  HederaInvalidStakingNodeIdError,
+  HederaMemoExceededSizeError,
+  HederaNoStakingRewardsError,
+  HederaRedundantStakingNodeIdError,
+} from "../errors";
 import { getSyntheticBlock } from "../logic/utils";
+import { HEDERA_MAX_MEMO_SIZE } from "../logic/validateMemo";
 import { rpcClient } from "../network/rpc";
 import { MAINNET_TEST_ACCOUNTS } from "../test/fixtures/account.fixture";
 import { getMockedConfig, getMockedContext } from "../test/fixtures/config.fixture";
@@ -1207,6 +1216,301 @@ describe("createApi", () => {
       const rewards = await api.getRewards(context, MAINNET_TEST_ACCOUNTS.activeStaking.accountId);
 
       expect(rewards.items.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("validateIntent", () => {
+    describe("native send", () => {
+      it("completes with no errors for a well-formed send", async () => {
+        const balances = await api.getBalance(
+          context,
+          MAINNET_TEST_ACCOUNTS.withoutTokens.accountId,
+        );
+
+        const result = await api.validateIntent(
+          context,
+          {
+            intentType: "transaction",
+            type: HEDERA_TRANSACTION_MODES.Send,
+            asset: { type: "native" },
+            sender: MAINNET_TEST_ACCOUNTS.withoutTokens.accountId,
+            recipient: MAINNET_TEST_ACCOUNTS.withTokens.accountId,
+            amount: 100n,
+            memo: { kind: "text", type: "string", value: "" },
+          },
+          balances,
+        );
+
+        expect(result.errors).toEqual({});
+        expect(result.amount).toBe(100n);
+        expect(result.estimatedFees).toBeGreaterThan(0n);
+        expect(result.totalSpent).toBe(100n + result.estimatedFees);
+      });
+
+      it("adds errors.recipient for an empty recipient", async () => {
+        const balances = await api.getBalance(
+          context,
+          MAINNET_TEST_ACCOUNTS.withoutTokens.accountId,
+        );
+
+        const result = await api.validateIntent(
+          context,
+          {
+            intentType: "transaction",
+            type: HEDERA_TRANSACTION_MODES.Send,
+            asset: { type: "native" },
+            sender: MAINNET_TEST_ACCOUNTS.withoutTokens.accountId,
+            recipient: "",
+            amount: 100n,
+            memo: { kind: "text", type: "string", value: "" },
+          },
+          balances,
+        );
+
+        expect(result.errors.recipient).toBeInstanceOf(RecipientRequired);
+      });
+
+      it("adds errors.amount = NotEnoughBalance for a pristine (zero-balance) account", async () => {
+        const balances = await api.getBalance(context, MAINNET_TEST_ACCOUNTS.pristine.accountId);
+
+        const result = await api.validateIntent(
+          context,
+          {
+            intentType: "transaction",
+            type: HEDERA_TRANSACTION_MODES.Send,
+            asset: { type: "native" },
+            sender: MAINNET_TEST_ACCOUNTS.pristine.accountId,
+            recipient: MAINNET_TEST_ACCOUNTS.withTokens.accountId,
+            amount: 10n,
+            memo: { kind: "text", type: "string", value: "" },
+          },
+          balances,
+        );
+
+        expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+      });
+    });
+
+    describe("hts token send", () => {
+      it("completes with no errors for a well-formed token send", async () => {
+        const balances = await api.getBalance(context, MAINNET_TEST_ACCOUNTS.withTokens.accountId);
+
+        const result = await api.validateIntent(
+          context,
+          {
+            intentType: "transaction",
+            type: HEDERA_TRANSACTION_MODES.Send,
+            asset: {
+              type: "hts",
+              assetReference: MAINNET_TEST_ACCOUNTS.withTokens.associatedTokenWithBalance,
+            },
+            sender: MAINNET_TEST_ACCOUNTS.withTokens.accountId,
+            recipient: MAINNET_TEST_ACCOUNTS.withoutTokens.accountId,
+            amount: 1n,
+            memo: { kind: "text", type: "string", value: "" },
+          },
+          balances,
+        );
+
+        expect(result.errors).toEqual({});
+      });
+    });
+
+    describe("erc20 token send", () => {
+      it("prices fees through the ContractCall path and completes with no errors", async () => {
+        const balances = await api.getBalance(context, MAINNET_TEST_ACCOUNTS.withTokens.accountId);
+
+        const result = await api.validateIntent(
+          context,
+          {
+            intentType: "transaction",
+            type: HEDERA_TRANSACTION_MODES.Send,
+            asset: { type: "erc20", assetReference: MAINNET_TEST_ACCOUNTS.withTokens.erc20Token },
+            sender: MAINNET_TEST_ACCOUNTS.withTokens.accountId,
+            recipient: MAINNET_TEST_ACCOUNTS.withoutTokens.accountId,
+            amount: 1n,
+            memo: { kind: "text", type: "string", value: "" },
+          },
+          balances,
+        );
+
+        expect(result.errors).toEqual({});
+        expect(result.estimatedFees).toBeGreaterThan(0n);
+      });
+    });
+
+    describe("token-associate", () => {
+      it("has no errors and amount 0 for an account above the USD minimum", async () => {
+        const balances = await api.getBalance(context, MAINNET_TEST_ACCOUNTS.withTokens.accountId);
+
+        const result = await api.validateIntent(
+          context,
+          {
+            intentType: "transaction",
+            type: HEDERA_TRANSACTION_MODES.TokenAssociate,
+            asset: {
+              type: "hts",
+              assetReference: MAINNET_TEST_ACCOUNTS.withTokens.notAssociatedToken,
+            },
+            sender: MAINNET_TEST_ACCOUNTS.withTokens.accountId,
+            recipient: "",
+            amount: 0n,
+            memo: { kind: "text", type: "string", value: "" },
+          },
+          balances,
+        );
+
+        expect(result.errors).toEqual({});
+        expect(result.amount).toBe(0n);
+      });
+
+      it("adds errors.insufficientAssociateBalance for a pristine (zero-balance) account", async () => {
+        const balances = await api.getBalance(context, MAINNET_TEST_ACCOUNTS.pristine.accountId);
+
+        const result = await api.validateIntent(
+          context,
+          {
+            intentType: "transaction",
+            type: HEDERA_TRANSACTION_MODES.TokenAssociate,
+            asset: {
+              type: "hts",
+              assetReference: MAINNET_TEST_ACCOUNTS.withTokens.notAssociatedToken,
+            },
+            sender: MAINNET_TEST_ACCOUNTS.pristine.accountId,
+            recipient: "",
+            amount: 0n,
+            memo: { kind: "text", type: "string", value: "" },
+          },
+          balances,
+        );
+
+        expect(result.errors.insufficientAssociateBalance).toBeInstanceOf(
+          HederaInsufficientFundsForAssociation,
+        );
+      });
+    });
+
+    describe("memo", () => {
+      it("adds errors.transaction when the memo exceeds the maximum size", async () => {
+        const balances = await api.getBalance(
+          context,
+          MAINNET_TEST_ACCOUNTS.withoutTokens.accountId,
+        );
+
+        const result = await api.validateIntent(
+          context,
+          {
+            intentType: "transaction",
+            type: HEDERA_TRANSACTION_MODES.Send,
+            asset: { type: "native" },
+            sender: MAINNET_TEST_ACCOUNTS.withoutTokens.accountId,
+            recipient: MAINNET_TEST_ACCOUNTS.withTokens.accountId,
+            amount: 100n,
+            memo: { kind: "text", type: "string", value: "a".repeat(HEDERA_MAX_MEMO_SIZE + 1) },
+          },
+          balances,
+        );
+
+        expect(result.errors.transaction).toBeInstanceOf(HederaMemoExceededSizeError);
+      });
+    });
+
+    describe("staking", () => {
+      it("flags delegating to the already-delegated node", async () => {
+        const [stakes, balances] = await Promise.all([
+          api.getStakes(context, MAINNET_TEST_ACCOUNTS.activeStaking.accountId),
+          api.getBalance(context, MAINNET_TEST_ACCOUNTS.activeStaking.accountId),
+        ]);
+        const stakedNodeId = stakes.items[0]?.details?.stakedNodeId;
+        invariant(typeof stakedNodeId === "number", "expected an active stake with a node id");
+
+        const result = await api.validateIntent(
+          context,
+          {
+            intentType: "transaction",
+            type: HEDERA_TRANSACTION_MODES.Delegate,
+            asset: { type: "native" },
+            sender: MAINNET_TEST_ACCOUNTS.activeStaking.accountId,
+            recipient: "",
+            amount: 0n,
+            memo: { kind: "text", type: "string", value: "" },
+            data: { type: "staking", stakingNodeId: stakedNodeId },
+          },
+          balances,
+        );
+
+        expect(result.errors.stakingNodeId).toBeInstanceOf(HederaRedundantStakingNodeIdError);
+      });
+
+      it("flags a node id absent from the live validator list", async () => {
+        const balances = await api.getBalance(
+          context,
+          MAINNET_TEST_ACCOUNTS.withoutTokens.accountId,
+        );
+
+        const result = await api.validateIntent(
+          context,
+          {
+            intentType: "transaction",
+            type: HEDERA_TRANSACTION_MODES.Delegate,
+            asset: { type: "native" },
+            sender: MAINNET_TEST_ACCOUNTS.withoutTokens.accountId,
+            recipient: "",
+            amount: 0n,
+            memo: { kind: "text", type: "string", value: "" },
+            data: { type: "staking", stakingNodeId: 999999 },
+          },
+          balances,
+        );
+
+        expect(result.errors.stakingNodeId).toBeInstanceOf(HederaInvalidStakingNodeIdError);
+      });
+
+      it("flags claiming rewards on an account with none pending", async () => {
+        const balances = await api.getBalance(
+          context,
+          MAINNET_TEST_ACCOUNTS.inactiveStaking.accountId,
+        );
+
+        const result = await api.validateIntent(
+          context,
+          {
+            intentType: "transaction",
+            type: HEDERA_TRANSACTION_MODES.ClaimRewards,
+            asset: { type: "native" },
+            sender: MAINNET_TEST_ACCOUNTS.inactiveStaking.accountId,
+            recipient: "",
+            amount: 0n,
+            memo: { kind: "text", type: "string", value: "" },
+          },
+          balances,
+        );
+
+        expect(result.errors.noRewardsToClaim).toBeInstanceOf(HederaNoStakingRewardsError);
+      });
+    });
+
+    describe("customFees", () => {
+      it("uses customFees.value directly, skipping estimation", async () => {
+        const customFees: FeeEstimation = { value: 123456n };
+
+        const result = await api.validateIntent(
+          context,
+          {
+            intentType: "transaction",
+            type: HEDERA_TRANSACTION_MODES.Send,
+            asset: { type: "native" },
+            sender: MAINNET_TEST_ACCOUNTS.withoutTokens.accountId,
+            recipient: MAINNET_TEST_ACCOUNTS.withTokens.accountId,
+            amount: 100n,
+            memo: { kind: "text", type: "string", value: "" },
+          },
+          [],
+          { customFees },
+        );
+
+        expect(result.estimatedFees).toBe(customFees.value);
+      });
     });
   });
 });

--- a/libs/coin-modules/coin-hedera/src/api/index.test.ts
+++ b/libs/coin-modules/coin-hedera/src/api/index.test.ts
@@ -37,6 +37,7 @@ const mockGetValidators = jest.mocked(logic.getValidators);
 const mockGetStakes = jest.mocked(logic.getStakes);
 const mockGetRewards = jest.mocked(logic.getRewards);
 const mockListOperationsV2 = jest.mocked(logic.listOperationsV2);
+const mockValidateIntent = jest.mocked(logic.validateIntent);
 
 // The consumer resolver hands the module to callers through `withDefaults`, so exercise the API the
 // way a consumer sees it: the capabilities Hedera omits are backfilled by the framework.
@@ -52,14 +53,10 @@ describe("createApi", () => {
     api = buildApi(mockCurrency.id);
   });
 
-  // Absent, raising "<name> is not supported" through the resolver — exhaustive by `toEqual`.
-  //
-  // Kept out rather than stubbed: intent validation still lives in the account bridge's
-  // getTransactionStatus, and the module exposes no sequence, no externally-built transaction,
-  // no contract-call escape hatch and no enrollment step.
+  // `toEqual` on purpose: the list of unsupported capabilities is exhaustive.
   it("omits the capabilities the chain has none of", async () => {
     await expect(capabilityReport(createApi(mockCurrency.id), mockContext)).resolves.toEqual({
-      unsupported: ["call", "craftRawTransaction", "getNextSequence", "register", "validateIntent"],
+      unsupported: ["call", "craftRawTransaction", "getNextSequence", "register"],
       inconsistent: [],
     });
   });
@@ -516,6 +513,42 @@ describe("createApi", () => {
       await expect(api.listOperations(mockContext, mockAddress, mockOptions)).rejects.toThrow(
         "hedera: evm address is missing",
       );
+    });
+  });
+
+  describe("validateIntent", () => {
+    it("should resolve the config and delegate to logic's validateIntent", async () => {
+      const mockedValidation = {
+        errors: {},
+        warnings: {},
+        estimatedFees: 100n,
+        amount: 0n,
+        totalSpent: 100n,
+      };
+
+      // @ts-expect-error - partial intent
+      const txIntent: TransactionIntent<HederaMemo> = {
+        type: "send",
+        sender: "0.0.1234",
+        recipient: "0.0.5678",
+        amount: 100n,
+      };
+      const balances = [{ value: 100n, asset: { type: "native" } }];
+      const customFees = { value: 10n };
+
+      mockValidateIntent.mockResolvedValue(mockedValidation);
+
+      const result = await api.validateIntent(mockContext, txIntent, balances, { customFees });
+
+      expect(result).toEqual(mockedValidation);
+      expect(mockValidateIntent).toHaveBeenCalledTimes(1);
+      expect(mockValidateIntent).toHaveBeenCalledWith({
+        config: await mockContext.config(),
+        currencyId: mockCurrency.id,
+        intent: txIntent,
+        balances,
+        customFees,
+      });
     });
   });
 });

--- a/libs/coin-modules/coin-hedera/src/api/index.ts
+++ b/libs/coin-modules/coin-hedera/src/api/index.ts
@@ -27,6 +27,7 @@ import {
   broadcast as logicBroadcast,
   estimateFees as logicEstimateFees,
   listOperationsV2 as logicListOperationsV2,
+  validateIntent as logicValidateIntent,
 } from "../logic";
 import {
   extractInitiator,
@@ -54,8 +55,6 @@ import type {
 // proxy-stakes to a node, so `getStakes`, `getRewards` and `getValidators` are all real.
 //
 // Omitted rather than stubbed, and why:
-//   - `validateIntent`      — intent validation still lives in the account bridge's
-//                             `getTransactionStatus`; the api path has none of its own yet.
 //   - `getNextSequence`     — no per-account nonce: a Hedera transaction is identified by its
 //                             payer plus a valid-start timestamp (`createTransactionId`).
 //   - `craftRawTransaction` — the module accepts no externally-built transaction.
@@ -242,6 +241,16 @@ export function createApi(currencyId: string) {
     getRewards: async (context: HederaContext, address, options?) => {
       const coinConfig = await context.config();
       return getRewards({ configOrCurrencyId: coinConfig, address, cursor: options?.cursor });
+    },
+    validateIntent: async (context: HederaContext, transactionIntent, balances, options?) => {
+      const coinConfig = await context.config();
+      return logicValidateIntent({
+        config: coinConfig,
+        currencyId,
+        intent: transactionIntent,
+        balances,
+        customFees: options?.customFees,
+      });
     },
     validateAddress: (_context, address, parameters) => validateAddress(address, parameters),
     craftTransactionData: (_context, intent) => craftTransactionData(intent),

--- a/libs/coin-modules/coin-hedera/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/getTransactionStatus.ts
@@ -141,10 +141,11 @@ async function handleHTSTokenTransaction(
 
   if (!errors.recipient) {
     try {
-      const hasRecipientTokenAssociated = await checkAccountTokenAssociationStatus(
-        transaction.recipient,
-        subAccount.token,
-      );
+      const hasRecipientTokenAssociated = await checkAccountTokenAssociationStatus({
+        configOrCurrencyId: account.currency.id,
+        address: transaction.recipient,
+        tokenId: subAccount.token.contractAddress,
+      });
 
       if (!hasRecipientTokenAssociated) {
         warnings.missingAssociation = new HederaRecipientTokenAssociationRequired();
@@ -291,7 +292,7 @@ async function handleStakingTransaction(account: HederaAccount, transaction: Tra
 
   const [validators, estimatedFees] = await Promise.all([
     needsValidators
-      ? getHederaValidators(account.currency.id).catch(error =>
+      ? getHederaValidators({ currencyId: account.currency.id }).catch(error =>
           error instanceof Error ? error : new Error(String(error)),
         )
       : undefined,

--- a/libs/coin-modules/coin-hedera/src/logic/index.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/index.ts
@@ -12,3 +12,4 @@ export { getTokenFromAsset } from "./getTokenFromAsset";
 export { getValidators } from "./getValidators";
 export { getRewards } from "./getRewards";
 export { getStakes } from "./getStakes";
+export { validateIntent } from "./validateIntent";

--- a/libs/coin-modules/coin-hedera/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/validateIntent.test.ts
@@ -1,0 +1,730 @@
+import type {
+  AssetInfo,
+  Balance,
+  FeeEstimation,
+  TransactionIntent,
+} from "@ledgerhq/coin-module-framework/api/types";
+import {
+  AmountRequired,
+  InvalidAddress,
+  InvalidAddressBecauseDestinationIsAlsoSource,
+  NotEnoughBalance,
+  RecipientRequired,
+} from "@ledgerhq/ledger-wallet-framework/errors";
+import BigNumber from "bignumber.js";
+import { HEDERA_OPERATION_TYPES, HEDERA_TRANSACTION_MODES } from "../constants";
+import {
+  ClaimRewardsFeesWarning,
+  HederaInsufficientFundsForAssociation,
+  HederaInvalidStakingNodeIdError,
+  HederaMemoExceededSizeError,
+  HederaNoStakingRewardsError,
+  HederaRecipientEvmAddressVerificationRequired,
+  HederaRecipientTokenAssociationRequired,
+  HederaRecipientTokenAssociationUnverified,
+  HederaRedundantStakingNodeIdError,
+} from "../errors";
+import { apiClient } from "../network/api";
+import { rpcClient } from "../network/rpc";
+import {
+  checkAccountTokenAssociationStatus,
+  getCurrencyToUSDRate,
+  getHederaAccountForValidation,
+  getHederaValidators,
+} from "../network/utils";
+import { getMockedConfig } from "../test/fixtures/config.fixture";
+import { getMockedCurrency } from "../test/fixtures/currency.fixture";
+import { getMockedMirrorAccount } from "../test/fixtures/mirror.fixture";
+import { getMockedValidator } from "../test/fixtures/validator.fixture";
+import type { HederaMemo, HederaTxData } from "../types";
+import { estimateFees } from "./estimateFees";
+import { validateIntent } from "./validateIntent";
+import { HEDERA_MAX_MEMO_SIZE } from "./validateMemo";
+
+jest.mock("../network/api");
+jest.mock("./estimateFees", () => ({
+  ...jest.requireActual("./estimateFees"),
+  estimateFees: jest.fn(),
+}));
+jest.mock("../network/utils", () => ({
+  ...jest.requireActual("../network/utils"),
+  getHederaValidators: jest.fn(),
+  getCurrencyToUSDRate: jest.fn(),
+  checkAccountTokenAssociationStatus: jest.fn(),
+}));
+jest.mock("../network/rpc", () => ({
+  rpcClient: require("../test/fixtures/rpc.fixture").getMockedRpcClient(),
+}));
+
+const mockGetAccount = apiClient.getAccount as jest.Mock;
+const mockEstimateFees = estimateFees as jest.Mock;
+const mockGetHederaValidators = getHederaValidators as unknown as jest.Mock;
+const mockGetCurrencyToUSDRate = getCurrencyToUSDRate as unknown as jest.Mock;
+const mockCheckAssociation = checkAccountTokenAssociationStatus as unknown as jest.Mock;
+
+type HederaIntent = TransactionIntent<HederaMemo, HederaTxData>;
+
+const config = getMockedConfig();
+const currencyId = getMockedCurrency().id;
+
+const SENDER = "0.0.1000";
+const RECIPIENT = "0.0.2000";
+
+const NATIVE_ASSET: AssetInfo = { type: "native" };
+const HTS_ASSET: AssetInfo = { type: "hts", assetReference: "0.0.456858" };
+const ERC20_ASSET: AssetInfo = {
+  type: "erc20",
+  assetReference: "0x39ceba2b467fa987546000eb5d1373acf1f3a2e1",
+};
+
+function balance(asset: AssetInfo, value: bigint, locked = 0n): Balance {
+  return { asset, value, locked };
+}
+
+function makeIntent(overrides: {
+  type?: string;
+  sender?: string;
+  recipient?: string;
+  amount?: bigint;
+  asset?: AssetInfo;
+  useAllAmount?: boolean;
+  data?: HederaTxData;
+  memo?: HederaMemo;
+}): HederaIntent {
+  return {
+    intentType: "transaction",
+    type: HEDERA_TRANSACTION_MODES.Send,
+    sender: SENDER,
+    recipient: "",
+    amount: 0n,
+    asset: NATIVE_ASSET,
+    data: { type: "none" },
+    ...overrides,
+  } as HederaIntent;
+}
+
+function callValidateIntent(intent: HederaIntent, balances: Balance[], customFees?: FeeEstimation) {
+  return validateIntent({ config, currencyId, intent, balances, customFees });
+}
+
+describe("validateIntent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getHederaAccountForValidation.reset();
+    mockGetAccount.mockResolvedValue(getMockedMirrorAccount());
+    mockGetHederaValidators.mockResolvedValue([]);
+    mockGetCurrencyToUSDRate.mockResolvedValue(new BigNumber(0.2));
+    mockCheckAssociation.mockResolvedValue(true);
+    mockEstimateFees.mockResolvedValue({ tinybars: new BigNumber(0) });
+  });
+
+  afterAll(async () => {
+    await rpcClient._resetInstance();
+  });
+
+  describe("staking", () => {
+    describe.each([HEDERA_TRANSACTION_MODES.Delegate, HEDERA_TRANSACTION_MODES.Redelegate])(
+      "%s node id validation",
+      mode => {
+        beforeEach(() => {
+          mockGetHederaValidators.mockResolvedValue([getMockedValidator({ id: "1" })]);
+          mockEstimateFees.mockResolvedValue({ tinybars: new BigNumber(50) });
+        });
+
+        it("flags a missing node id without fetching the mirror account", async () => {
+          mockGetAccount.mockResolvedValue(getMockedMirrorAccount({ staked_node_id: null }));
+          const intent = makeIntent({ type: mode, data: { type: "none" } });
+
+          const result = await callValidateIntent(intent, [balance(NATIVE_ASSET, 100000n)]);
+
+          expect(result.errors.missingStakingNodeId).toBeInstanceOf(
+            HederaInvalidStakingNodeIdError,
+          );
+          expect(result.errors.missingStakingNodeId?.message).toBe("Validator must be set");
+          expect(result.errors.stakingNodeId).toBeUndefined();
+          expect(mockGetAccount).not.toHaveBeenCalled();
+        });
+
+        it("flags a node id absent from the validator list", async () => {
+          mockGetAccount.mockResolvedValue(getMockedMirrorAccount({ staked_node_id: null }));
+          const intent = makeIntent({ type: mode, data: { type: "staking", stakingNodeId: 999 } });
+
+          const result = await callValidateIntent(intent, [balance(NATIVE_ASSET, 100000n)]);
+
+          expect(result.errors.stakingNodeId).toBeInstanceOf(HederaInvalidStakingNodeIdError);
+        });
+
+        it("flags delegating to the already-delegated node", async () => {
+          mockGetAccount.mockResolvedValue(getMockedMirrorAccount({ staked_node_id: 1 }));
+          const intent = makeIntent({ type: mode, data: { type: "staking", stakingNodeId: 1 } });
+
+          const result = await callValidateIntent(intent, [balance(NATIVE_ASSET, 100000n)]);
+
+          expect(result.errors.stakingNodeId).toBeInstanceOf(HederaRedundantStakingNodeIdError);
+        });
+      },
+    );
+
+    it("delegate with a valid, not-yet-delegated node completes with no errors", async () => {
+      mockGetHederaValidators.mockResolvedValue([getMockedValidator({ id: "1" })]);
+      mockGetAccount.mockResolvedValue(getMockedMirrorAccount({ staked_node_id: null }));
+      mockEstimateFees.mockResolvedValue({ tinybars: new BigNumber(50) });
+      const intent = makeIntent({
+        type: HEDERA_TRANSACTION_MODES.Delegate,
+        data: { type: "staking", stakingNodeId: 1 },
+      });
+
+      const result = await callValidateIntent(intent, [balance(NATIVE_ASSET, 100000n)]);
+
+      expect(result.errors).toEqual({});
+      expect(result.amount).toBe(0n);
+      expect(result.totalSpent).toBe(50n);
+    });
+
+    it("resolves with errors.validators instead of throwing when the validator fetch fails", async () => {
+      mockGetHederaValidators.mockRejectedValue(new Error("network down"));
+      mockEstimateFees.mockResolvedValue({ tinybars: new BigNumber(50) });
+      const intent = makeIntent({
+        type: HEDERA_TRANSACTION_MODES.Delegate,
+        data: { type: "staking", stakingNodeId: 1 },
+      });
+
+      const result = await callValidateIntent(intent, [balance(NATIVE_ASSET, 100000n)]);
+
+      expect(result.errors.validators).toBeInstanceOf(Error);
+      expect(result.errors.stakingNodeId).toBeUndefined();
+      expect(mockGetAccount).not.toHaveBeenCalled();
+    });
+
+    it("undelegate never validates a node id, even though it clears one, and never fetches the account", async () => {
+      const intent = makeIntent({
+        type: HEDERA_TRANSACTION_MODES.Undelegate,
+        data: { type: "staking", stakingNodeId: null },
+      });
+
+      const result = await callValidateIntent(intent, [balance(NATIVE_ASSET, 100000n)]);
+
+      expect(result.errors.missingStakingNodeId).toBeUndefined();
+      expect(result.errors.stakingNodeId).toBeUndefined();
+      expect(mockGetAccount).not.toHaveBeenCalled();
+    });
+
+    it.each([HEDERA_TRANSACTION_MODES.Undelegate, HEDERA_TRANSACTION_MODES.ClaimRewards])(
+      "%s neither fetches the validators nor is blocked when that fetch would fail",
+      async type => {
+        mockGetHederaValidators.mockRejectedValue(new Error("network down"));
+        const intent = makeIntent({ type, data: { type: "staking", stakingNodeId: null } });
+
+        const result = await callValidateIntent(intent, [balance(NATIVE_ASSET, 100000n)]);
+
+        expect(result.errors.validators).toBeUndefined();
+        expect(mockGetHederaValidators).not.toHaveBeenCalled();
+      },
+    );
+
+    it("claim-rewards with no pending reward adds errors.noRewardsToClaim", async () => {
+      mockGetAccount.mockResolvedValue(getMockedMirrorAccount({ pending_reward: 0 }));
+      mockEstimateFees.mockResolvedValue({ tinybars: new BigNumber(10) });
+      const intent = makeIntent({ type: HEDERA_TRANSACTION_MODES.ClaimRewards });
+
+      const result = await callValidateIntent(intent, [balance(NATIVE_ASSET, 100000n)]);
+
+      expect(result.errors.noRewardsToClaim).toBeInstanceOf(HederaNoStakingRewardsError);
+    });
+
+    it("claim-rewards warns, but does not error, when the fee exceeds the pending reward", async () => {
+      mockGetAccount.mockResolvedValue(getMockedMirrorAccount({ pending_reward: 10 }));
+      mockEstimateFees.mockResolvedValue({ tinybars: new BigNumber(100) });
+      const intent = makeIntent({ type: HEDERA_TRANSACTION_MODES.ClaimRewards });
+
+      const result = await callValidateIntent(intent, [balance(NATIVE_ASSET, 100000n)]);
+
+      expect(result.warnings.claimRewardsFee).toBeInstanceOf(ClaimRewardsFeesWarning);
+      expect(result.errors.noRewardsToClaim).toBeUndefined();
+    });
+
+    it("prices claim-rewards as a CryptoTransfer, not the legacy CryptoUpdate", async () => {
+      mockGetAccount.mockResolvedValue(getMockedMirrorAccount({ pending_reward: 1000 }));
+      mockEstimateFees.mockResolvedValue({ tinybars: new BigNumber(10) });
+      const intent = makeIntent({ type: HEDERA_TRANSACTION_MODES.ClaimRewards });
+
+      await callValidateIntent(intent, [balance(NATIVE_ASSET, 100000n)]);
+
+      expect(mockEstimateFees).toHaveBeenCalledTimes(1);
+      expect(mockEstimateFees).toHaveBeenCalledWith(
+        expect.objectContaining({ operationType: HEDERA_OPERATION_TYPES.CryptoTransfer }),
+      );
+    });
+
+    // The fee check is the same tail branch for every staking mode, so one mode covers it.
+    it("adds errors.fee when native balance cannot cover the fee", async () => {
+      mockGetAccount.mockResolvedValue(getMockedMirrorAccount({ pending_reward: 1000 }));
+      mockEstimateFees.mockResolvedValue({ tinybars: new BigNumber(100) });
+      const intent = makeIntent({ type: HEDERA_TRANSACTION_MODES.ClaimRewards });
+
+      const result = await callValidateIntent(intent, [balance(NATIVE_ASSET, 10n)]);
+
+      expect(result.errors.fee).toBeInstanceOf(NotEnoughBalance);
+    });
+  });
+
+  describe("native send", () => {
+    beforeEach(() => {
+      mockEstimateFees.mockResolvedValue({ tinybars: new BigNumber(100) });
+    });
+
+    it("adds errors.amount = AmountRequired when amount is zero and useAllAmount is false", async () => {
+      const intent = makeIntent({ recipient: RECIPIENT, amount: 0n, useAllAmount: false });
+
+      const result = await callValidateIntent(intent, [balance(NATIVE_ASSET, 100000n)]);
+
+      expect(result.errors.amount).toBeInstanceOf(AmountRequired);
+    });
+
+    it("resolves useAllAmount to balance minus fees when balance covers the fee, with no error", async () => {
+      const intent = makeIntent({ recipient: RECIPIENT, amount: 0n, useAllAmount: true });
+
+      const result = await callValidateIntent(intent, [balance(NATIVE_ASSET, 1000n)]);
+
+      expect(result.errors.amount).toBeUndefined();
+      expect(result.amount).toBe(900n);
+      expect(result.totalSpent).toBe(1000n);
+    });
+
+    it("resolves useAllAmount to 0 and reports NotEnoughBalance (not AmountRequired) when balance cannot cover the fee", async () => {
+      const intent = makeIntent({ recipient: RECIPIENT, amount: 0n, useAllAmount: true });
+
+      const result = await callValidateIntent(intent, [balance(NATIVE_ASSET, 100n)]);
+
+      expect(result.amount).toBe(0n);
+      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+    });
+
+    it("adds errors.amount = NotEnoughBalance when amount + fees exceed balance", async () => {
+      const intent = makeIntent({ recipient: RECIPIENT, amount: 950n, useAllAmount: false });
+
+      const result = await callValidateIntent(intent, [balance(NATIVE_ASSET, 1000n)]);
+
+      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+    });
+
+    it("adds errors.recipient = RecipientRequired when recipient is empty", async () => {
+      const intent = makeIntent({ recipient: "", amount: 10n });
+
+      const result = await callValidateIntent(intent, [balance(NATIVE_ASSET, 100000n)]);
+
+      expect(result.errors.recipient).toBeInstanceOf(RecipientRequired);
+    });
+
+    it("adds errors.recipient from the parser when the address is malformed", async () => {
+      const intent = makeIntent({ recipient: "not-an-account", amount: 10n });
+
+      const result = await callValidateIntent(intent, [balance(NATIVE_ASSET, 100000n)]);
+
+      expect(result.errors.recipient).toBeInstanceOf(InvalidAddress);
+    });
+
+    it("adds errors.recipient = InvalidAddressBecauseDestinationIsAlsoSource for a self-send", async () => {
+      const intent = makeIntent({ recipient: SENDER, amount: 10n });
+
+      const result = await callValidateIntent(intent, [balance(NATIVE_ASSET, 100000n)]);
+
+      expect(result.errors.recipient).toBeInstanceOf(InvalidAddressBecauseDestinationIsAlsoSource);
+    });
+
+    it("runs no association check and raises no warnings", async () => {
+      const intent = makeIntent({ recipient: RECIPIENT, amount: 100n });
+
+      const result = await callValidateIntent(intent, [balance(NATIVE_ASSET, 100000n)]);
+
+      expect(mockCheckAssociation).not.toHaveBeenCalled();
+      expect(result.warnings).toEqual({});
+    });
+
+    it("completes with no errors for a well-formed send", async () => {
+      const intent = makeIntent({ recipient: RECIPIENT, amount: 500n });
+
+      const result = await callValidateIntent(intent, [balance(NATIVE_ASSET, 1000n)]);
+
+      expect(result.errors).toEqual({});
+      expect(result.amount).toBe(500n);
+      expect(result.totalSpent).toBe(600n);
+      expect(result.estimatedFees).toBe(100n);
+    });
+  });
+
+  describe("hts token send", () => {
+    beforeEach(() => {
+      mockEstimateFees.mockResolvedValue({ tinybars: new BigNumber(200) });
+    });
+
+    it("adds errors.amount = AmountRequired for a zero amount even with useAllAmount (legacy asymmetry)", async () => {
+      const intent = makeIntent({
+        asset: HTS_ASSET,
+        recipient: RECIPIENT,
+        amount: 0n,
+        useAllAmount: true,
+      });
+
+      const result = await callValidateIntent(intent, [
+        balance(NATIVE_ASSET, 100000n),
+        balance(HTS_ASSET, 0n),
+      ]);
+
+      expect(result.errors.amount).toBeInstanceOf(AmountRequired);
+    });
+
+    it("keeps AmountRequired for a zero amount even when the native balance cannot cover the fee", async () => {
+      const intent = makeIntent({
+        asset: HTS_ASSET,
+        recipient: RECIPIENT,
+        amount: 0n,
+        useAllAmount: true,
+      });
+
+      const result = await callValidateIntent(intent, [
+        balance(NATIVE_ASSET, 0n),
+        balance(HTS_ASSET, 0n),
+      ]);
+
+      expect(result.errors.amount).toBeInstanceOf(AmountRequired);
+    });
+
+    it("warns when the recipient has not associated the token", async () => {
+      mockCheckAssociation.mockResolvedValueOnce(false);
+      const intent = makeIntent({ asset: HTS_ASSET, recipient: RECIPIENT, amount: 100n });
+
+      const result = await callValidateIntent(intent, [
+        balance(NATIVE_ASSET, 100000n),
+        balance(HTS_ASSET, 1000n),
+      ]);
+
+      expect(mockCheckAssociation).toHaveBeenCalledTimes(1);
+      expect(mockCheckAssociation).toHaveBeenCalledWith({
+        configOrCurrencyId: config,
+        address: RECIPIENT,
+        tokenId: "0.0.456858",
+      });
+      expect(result.warnings.missingAssociation).toBeInstanceOf(
+        HederaRecipientTokenAssociationRequired,
+      );
+      expect(result.errors).toEqual({});
+    });
+
+    it("warns when the association status cannot be verified", async () => {
+      mockCheckAssociation.mockRejectedValueOnce(new Error("mirror node unavailable"));
+      const intent = makeIntent({ asset: HTS_ASSET, recipient: RECIPIENT, amount: 100n });
+
+      const result = await callValidateIntent(intent, [
+        balance(NATIVE_ASSET, 100000n),
+        balance(HTS_ASSET, 1000n),
+      ]);
+
+      expect(result.warnings.unverifiedAssociation).toBeInstanceOf(
+        HederaRecipientTokenAssociationUnverified,
+      );
+      expect(result.errors).toEqual({});
+    });
+
+    it("skips the association check when the recipient is already invalid", async () => {
+      const intent = makeIntent({ asset: HTS_ASSET, recipient: "", amount: 100n });
+
+      const result = await callValidateIntent(intent, [
+        balance(NATIVE_ASSET, 100000n),
+        balance(HTS_ASSET, 1000n),
+      ]);
+
+      expect(mockCheckAssociation).not.toHaveBeenCalled();
+      expect(result.errors.recipient).toBeInstanceOf(RecipientRequired);
+      expect(result.warnings).toEqual({});
+    });
+
+    it("adds errors.amount = NotEnoughBalance (default message) when the token balance is too low", async () => {
+      const intent = makeIntent({ asset: HTS_ASSET, recipient: RECIPIENT, amount: 500n });
+
+      const result = await callValidateIntent(intent, [
+        balance(NATIVE_ASSET, 100000n),
+        balance(HTS_ASSET, 10n),
+      ]);
+
+      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+      expect(result.errors.amount?.message).not.toBe("");
+    });
+
+    it("adds errors.amount (not errors.fee) when the native balance cannot cover the fee", async () => {
+      const intent = makeIntent({ asset: HTS_ASSET, recipient: RECIPIENT, amount: 5n });
+
+      const result = await callValidateIntent(intent, [
+        balance(NATIVE_ASSET, 0n),
+        balance(HTS_ASSET, 1000n),
+      ]);
+
+      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+      expect(result.errors.fee).toBeUndefined();
+    });
+
+    it("completes with no errors for a well-formed token send", async () => {
+      const intent = makeIntent({ asset: HTS_ASSET, recipient: RECIPIENT, amount: 100n });
+
+      const result = await callValidateIntent(intent, [
+        balance(NATIVE_ASSET, 100000n),
+        balance(HTS_ASSET, 1000n),
+      ]);
+
+      expect(result.errors).toEqual({});
+      expect(result.amount).toBe(100n);
+      expect(result.totalSpent).toBe(100n);
+      expect(result.estimatedFees).toBe(200n);
+    });
+  });
+
+  describe("erc20 token send", () => {
+    beforeEach(() => {
+      mockEstimateFees.mockResolvedValue({ tinybars: new BigNumber(300) });
+    });
+
+    it("prices fees through the ContractCall path with the intent as-is", async () => {
+      const intent = makeIntent({ asset: ERC20_ASSET, recipient: RECIPIENT, amount: 10n });
+
+      await callValidateIntent(intent, [
+        balance(NATIVE_ASSET, 100000n),
+        balance(ERC20_ASSET, 1000n),
+      ]);
+
+      expect(mockEstimateFees).toHaveBeenCalledTimes(1);
+      expect(mockEstimateFees).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operationType: HEDERA_OPERATION_TYPES.ContractCall,
+          txIntent: intent,
+        }),
+      );
+    });
+
+    it("warns that the recipient evm address is unverified, without an association check", async () => {
+      const intent = makeIntent({ asset: ERC20_ASSET, recipient: RECIPIENT, amount: 10n });
+
+      const result = await callValidateIntent(intent, [
+        balance(NATIVE_ASSET, 100000n),
+        balance(ERC20_ASSET, 1000n),
+      ]);
+
+      // An ERC20 contract address would never match a mirror `token_id`, so the check would
+      // always report "not associated" and warn on every ERC20 send.
+      expect(mockCheckAssociation).not.toHaveBeenCalled();
+      expect(result.warnings.unverifiedEvmAddress).toBeInstanceOf(
+        HederaRecipientEvmAddressVerificationRequired,
+      );
+      expect(result.errors).toEqual({});
+    });
+
+    it("adds errors.amount when the token balance is too low", async () => {
+      const intent = makeIntent({ asset: ERC20_ASSET, recipient: RECIPIENT, amount: 500n });
+
+      const result = await callValidateIntent(intent, [
+        balance(NATIVE_ASSET, 100000n),
+        balance(ERC20_ASSET, 10n),
+      ]);
+
+      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+    });
+
+    it("adds errors.amount (not errors.fee) when the native balance cannot cover the fee", async () => {
+      const intent = makeIntent({ asset: ERC20_ASSET, recipient: RECIPIENT, amount: 5n });
+
+      const result = await callValidateIntent(intent, [
+        balance(NATIVE_ASSET, 0n),
+        balance(ERC20_ASSET, 1000n),
+      ]);
+
+      expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+      expect(result.errors.fee).toBeUndefined();
+    });
+  });
+
+  describe("token-associate", () => {
+    // 0.25 HBAR: the 0.05 USD minimum at the mocked 0.2 USD/HBAR rate.
+    const ENOUGH_FOR_ASSOCIATION = 25_000_000n;
+
+    beforeEach(() => {
+      mockEstimateFees.mockResolvedValue({ tinybars: new BigNumber(500000) });
+      mockCheckAssociation.mockResolvedValue(false);
+    });
+
+    it("has no errors, amount 0, and totalSpent equal to the fee", async () => {
+      const intent = makeIntent({
+        type: HEDERA_TRANSACTION_MODES.TokenAssociate,
+        asset: HTS_ASSET,
+      });
+
+      const result = await callValidateIntent(intent, [
+        balance(NATIVE_ASSET, ENOUGH_FOR_ASSOCIATION),
+      ]);
+
+      expect(result.errors).toEqual({});
+      expect(result.amount).toBe(0n);
+      expect(result.totalSpent).toBe(500000n);
+      expect(result.estimatedFees).toBe(500000n);
+    });
+
+    it("adds errors.insufficientAssociateBalance when the account is worth less than the minimum", async () => {
+      const intent = makeIntent({
+        type: HEDERA_TRANSACTION_MODES.TokenAssociate,
+        asset: HTS_ASSET,
+      });
+
+      const result = await callValidateIntent(intent, [
+        balance(NATIVE_ASSET, ENOUGH_FOR_ASSOCIATION - 1n),
+      ]);
+
+      expect(result.errors.insufficientAssociateBalance).toBeInstanceOf(
+        HederaInsufficientFundsForAssociation,
+      );
+      expect(result.errors.insufficientAssociateBalance).toMatchObject({
+        requiredWorthInUSD: config.tokenAssociationMinUsd,
+      });
+    });
+
+    it("treats a missing USD rate as zero worth", async () => {
+      mockGetCurrencyToUSDRate.mockResolvedValue(null);
+      const intent = makeIntent({
+        type: HEDERA_TRANSACTION_MODES.TokenAssociate,
+        asset: HTS_ASSET,
+      });
+
+      const result = await callValidateIntent(intent, [balance(NATIVE_ASSET, 100_000_000_000n)]);
+
+      expect(result.errors.insufficientAssociateBalance).toBeInstanceOf(
+        HederaInsufficientFundsForAssociation,
+      );
+    });
+
+    it("skips the balance check when the sender already has the token associated", async () => {
+      mockCheckAssociation.mockResolvedValue(true);
+      const intent = makeIntent({
+        type: HEDERA_TRANSACTION_MODES.TokenAssociate,
+        asset: HTS_ASSET,
+      });
+
+      const result = await callValidateIntent(intent, [balance(NATIVE_ASSET, 0n)]);
+
+      expect(mockCheckAssociation).toHaveBeenCalledWith({
+        configOrCurrencyId: config,
+        address: SENDER,
+        tokenId: "0.0.456858",
+      });
+      expect(result.errors).toEqual({});
+    });
+
+    it("runs the balance check when the association status can't be determined", async () => {
+      mockCheckAssociation.mockRejectedValue(new Error("mirror node unavailable"));
+      const intent = makeIntent({
+        type: HEDERA_TRANSACTION_MODES.TokenAssociate,
+        asset: HTS_ASSET,
+      });
+
+      const result = await callValidateIntent(intent, [
+        balance(NATIVE_ASSET, ENOUGH_FOR_ASSOCIATION - 1n),
+      ]);
+
+      expect(result.errors.insufficientAssociateBalance).toBeInstanceOf(
+        HederaInsufficientFundsForAssociation,
+      );
+    });
+  });
+
+  describe("memo", () => {
+    const OVERSIZED_MEMO = "a".repeat(HEDERA_MAX_MEMO_SIZE + 1);
+
+    beforeEach(() => {
+      mockEstimateFees.mockResolvedValue({ tinybars: new BigNumber(100) });
+    });
+
+    it("adds errors.transaction when the memo exceeds the maximum size", async () => {
+      const intent = makeIntent({
+        recipient: RECIPIENT,
+        amount: 10n,
+        memo: { type: "string", kind: "text", value: OVERSIZED_MEMO },
+      });
+
+      const result = await callValidateIntent(intent, [balance(NATIVE_ASSET, 100000n)]);
+
+      expect(result.errors.transaction).toBeInstanceOf(HederaMemoExceededSizeError);
+    });
+
+    it("keeps the mode-specific errors alongside the memo error", async () => {
+      const intent = makeIntent({
+        recipient: "",
+        amount: 10n,
+        memo: { type: "string", kind: "text", value: OVERSIZED_MEMO },
+      });
+
+      const result = await callValidateIntent(intent, [balance(NATIVE_ASSET, 100000n)]);
+
+      expect(result.errors.transaction).toBeInstanceOf(HederaMemoExceededSizeError);
+      expect(result.errors.recipient).toBeInstanceOf(RecipientRequired);
+    });
+
+    it("accepts a memo at the maximum size", async () => {
+      const intent = makeIntent({
+        recipient: RECIPIENT,
+        amount: 10n,
+        memo: { type: "string", kind: "text", value: "a".repeat(HEDERA_MAX_MEMO_SIZE) },
+      });
+
+      const result = await callValidateIntent(intent, [balance(NATIVE_ASSET, 100000n)]);
+
+      expect(result.errors.transaction).toBeUndefined();
+    });
+
+    it("flags an oversized memo on a token-associate intent too", async () => {
+      const intent = makeIntent({
+        type: HEDERA_TRANSACTION_MODES.TokenAssociate,
+        asset: HTS_ASSET,
+        memo: { type: "string", kind: "text", value: OVERSIZED_MEMO },
+      });
+
+      const result = await callValidateIntent(intent, [balance(NATIVE_ASSET, 25_000_000n)]);
+
+      expect(result.errors.transaction).toBeInstanceOf(HederaMemoExceededSizeError);
+    });
+  });
+
+  describe("fee resolution (customFees)", () => {
+    it("skips estimation and uses customFees.value when it is non-zero", async () => {
+      const intent = makeIntent({ recipient: RECIPIENT, amount: 10n });
+
+      const result = await callValidateIntent(intent, [balance(NATIVE_ASSET, 100000n)], {
+        value: 777n,
+      });
+
+      expect(mockEstimateFees).not.toHaveBeenCalled();
+      expect(result.estimatedFees).toBe(777n);
+    });
+
+    it("still estimates when customFees.value is 0n", async () => {
+      mockEstimateFees.mockResolvedValue({ tinybars: new BigNumber(123) });
+      const intent = makeIntent({ recipient: RECIPIENT, amount: 10n });
+
+      const result = await callValidateIntent(intent, [balance(NATIVE_ASSET, 100000n)], {
+        value: 0n,
+      });
+
+      expect(mockEstimateFees).toHaveBeenCalledTimes(1);
+      expect(result.estimatedFees).toBe(123n);
+    });
+  });
+
+  describe("account caching", () => {
+    it("fetches the mirror account once for two consecutive validations of the same sender", async () => {
+      mockGetAccount.mockResolvedValue(getMockedMirrorAccount({ pending_reward: 1000 }));
+      mockEstimateFees.mockResolvedValue({ tinybars: new BigNumber(10) });
+      const intent = makeIntent({ type: HEDERA_TRANSACTION_MODES.ClaimRewards });
+      const balances = [balance(NATIVE_ASSET, 100000n)];
+
+      await callValidateIntent(intent, balances);
+      await callValidateIntent(intent, balances);
+
+      expect(mockGetAccount).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/libs/coin-modules/coin-hedera/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/validateIntent.ts
@@ -1,0 +1,391 @@
+import type {
+  AssetInfo,
+  Balance,
+  FeeEstimation,
+  TransactionIntent,
+  TransactionValidation,
+} from "@ledgerhq/coin-module-framework/api/types";
+import { findCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
+import {
+  AmountRequired,
+  InvalidAddressBecauseDestinationIsAlsoSource,
+  NotEnoughBalance,
+  RecipientRequired,
+} from "@ledgerhq/ledger-wallet-framework/errors";
+import BigNumber from "bignumber.js";
+import invariant from "invariant";
+import { HEDERA_OPERATION_TYPES, HEDERA_TRANSACTION_MODES, TINYBAR_SCALE } from "../constants";
+import {
+  ClaimRewardsFeesWarning,
+  HederaInsufficientFundsForAssociation,
+  HederaInvalidStakingNodeIdError,
+  HederaMemoExceededSizeError,
+  HederaNoStakingRewardsError,
+  HederaRecipientEvmAddressVerificationRequired,
+  HederaRecipientTokenAssociationRequired,
+  HederaRecipientTokenAssociationUnverified,
+  HederaRedundantStakingNodeIdError,
+} from "../errors";
+import type { EstimateFeesParams, HederaCoinConfig, HederaMemo, HederaTxData } from "../types";
+import { estimateFees } from "./estimateFees";
+import { hasSpecificIntentData, mapIntentToSDKOperation } from "./utils";
+import { validateMemo } from "./validateMemo";
+import {
+  checkAccountTokenAssociationStatus,
+  getCurrencyToUSDRate,
+  getHederaAccountForValidation,
+  getHederaValidators,
+  safeParseAccountId,
+} from "../network/utils";
+
+type Errors = Record<string, Error>;
+type Warnings = Record<string, Error>;
+type HederaIntent = TransactionIntent<HederaMemo, HederaTxData>;
+
+interface ValidateContext {
+  config: HederaCoinConfig;
+  currencyId: string;
+  intent: HederaIntent;
+  balances: Balance[];
+  customFees: FeeEstimation | undefined;
+}
+
+// `erc20` references arrive from the EVM side in mixed case, hence the case-insensitive compare.
+function findAssetBalance(asset: AssetInfo, balances: Balance[]): Balance | undefined {
+  if (asset.type === "native") {
+    return balances.find(b => b.asset.type === "native");
+  }
+
+  const reference = "assetReference" in asset ? asset.assetReference : undefined;
+  if (!reference) return undefined;
+
+  return balances.find(b => {
+    if (b.asset.type !== asset.type || !("assetReference" in b.asset)) return false;
+    return asset.type === "erc20"
+      ? b.asset.assetReference?.toLowerCase() === reference.toLowerCase()
+      : b.asset.assetReference === reference;
+  });
+}
+
+// Deliberately stricter than the legacy bridge, which validated against the raw balance (LIVE-36147).
+function available(balance: Balance | undefined): bigint {
+  const value = (balance?.value ?? 0n) - (balance?.locked ?? 0n);
+  return value > 0n ? value : 0n;
+}
+
+async function validateRecipient({
+  config,
+  sender,
+  recipient,
+}: {
+  config: HederaCoinConfig;
+  sender: string;
+  recipient: string;
+}): Promise<Error | null> {
+  if (!recipient) {
+    return new RecipientRequired();
+  }
+
+  const [parsingError, parsingResult] = await safeParseAccountId({
+    configOrCurrencyId: config,
+    address: recipient,
+  });
+
+  if (parsingError) {
+    return parsingError;
+  }
+
+  if (parsingResult.accountId === sender) {
+    return new InvalidAddressBecauseDestinationIsAlsoSource();
+  }
+
+  return null;
+}
+
+async function resolveEstimatedFees({
+  config,
+  currencyId,
+  intent,
+  customFees,
+}: Pick<ValidateContext, "config" | "currencyId" | "intent" | "customFees">): Promise<bigint> {
+  if (customFees?.value !== undefined && customFees.value !== 0n) {
+    return customFees.value;
+  }
+
+  const operationType = mapIntentToSDKOperation(intent);
+  const params: EstimateFeesParams =
+    operationType === HEDERA_OPERATION_TYPES.ContractCall
+      ? { configOrCurrencyId: config, operationType, txIntent: intent }
+      : { currencyId, operationType };
+
+  const result = await estimateFees(params);
+  return BigInt(result.tinybars.toFixed(0));
+}
+
+// Without a USD rate the account counts as worthless and the flow stays blocked, as in the legacy bridge.
+async function validateTokenAssociate({
+  config,
+  currencyId,
+  intent,
+  balances,
+  customFees,
+}: ValidateContext): Promise<TransactionValidation> {
+  invariant(intent.asset.type === "hts", "hedera: association requires hts token type");
+  const errors: Errors = {};
+  const tokenId = "assetReference" in intent.asset ? intent.asset.assetReference : undefined;
+  const currency = findCryptoCurrencyById(currencyId);
+  invariant(currency, `hedera: currency with id ${currencyId} not found`);
+  const [usdRate, estimatedFees, isAlreadyAssociated] = await Promise.all([
+    getCurrencyToUSDRate(currency),
+    resolveEstimatedFees({ config, currencyId, intent, customFees }),
+    tokenId
+      ? checkAccountTokenAssociationStatus({
+          configOrCurrencyId: config,
+          address: intent.sender,
+          tokenId,
+        }).catch(() => false)
+      : false,
+  ]);
+
+  if (!isAlreadyAssociated) {
+    const nativeAvailable = available(findAssetBalance({ type: "native" }, balances));
+    const hbarAvailable = new BigNumber(nativeAvailable.toString()).shiftedBy(-TINYBAR_SCALE);
+    const worthInUSD = usdRate ? hbarAvailable.multipliedBy(usdRate) : new BigNumber(0);
+    const requiredWorthInUSD = config.tokenAssociationMinUsd;
+
+    if (worthInUSD.isLessThan(requiredWorthInUSD)) {
+      errors.insufficientAssociateBalance = new HederaInsufficientFundsForAssociation("", {
+        requiredWorthInUSD,
+      });
+    }
+  }
+
+  return {
+    errors,
+    warnings: {},
+    estimatedFees,
+    amount: 0n,
+    totalSpent: estimatedFees,
+  };
+}
+
+async function validateStaking({
+  config,
+  currencyId,
+  intent,
+  balances,
+  customFees,
+}: ValidateContext): Promise<TransactionValidation> {
+  const errors: Errors = {};
+  const warnings: Warnings = {};
+
+  // Undelegate and claim-rewards must not be blocked by a failed validator fetch.
+  const isDelegateOrRedelegate =
+    intent.type === HEDERA_TRANSACTION_MODES.Delegate ||
+    intent.type === HEDERA_TRANSACTION_MODES.Redelegate;
+
+  const [validators, estimatedFees] = await Promise.all([
+    isDelegateOrRedelegate
+      ? getHederaValidators({ currencyId, config }).catch(error =>
+          error instanceof Error ? error : new Error(String(error)),
+        )
+      : null,
+    resolveEstimatedFees({ config, currencyId, intent, customFees }),
+  ]);
+  const totalSpent = estimatedFees;
+
+  if (validators instanceof Error) {
+    errors.validators = validators;
+  } else if (validators) {
+    const stakingNodeId = hasSpecificIntentData(intent, "staking")
+      ? intent.data.stakingNodeId
+      : undefined;
+
+    if (typeof stakingNodeId === "number") {
+      const isValid = validators.some(validator => validator.id === String(stakingNodeId));
+
+      if (!isValid) {
+        errors.stakingNodeId = new HederaInvalidStakingNodeIdError();
+      }
+
+      const account = await getHederaAccountForValidation({
+        currencyId,
+        config,
+        address: intent.sender,
+      });
+
+      // Do not normalise `-1` (the mirror node's "no longer delegated" value) — compare the raw number.
+      if (account.staked_node_id === stakingNodeId) {
+        errors.stakingNodeId = new HederaRedundantStakingNodeIdError();
+      }
+    } else {
+      errors.missingStakingNodeId = new HederaInvalidStakingNodeIdError("Validator must be set");
+    }
+  }
+
+  if (intent.type === HEDERA_TRANSACTION_MODES.ClaimRewards) {
+    const account = await getHederaAccountForValidation({
+      currencyId,
+      config,
+      address: intent.sender,
+    });
+    const pendingReward = BigInt(account.pending_reward);
+
+    if (pendingReward <= 0n) {
+      errors.noRewardsToClaim = new HederaNoStakingRewardsError();
+    }
+
+    if (estimatedFees > pendingReward) {
+      warnings.claimRewardsFee = new ClaimRewardsFeesWarning();
+    }
+  }
+
+  const nativeAvailable = available(findAssetBalance({ type: "native" }, balances));
+
+  if (nativeAvailable < totalSpent) {
+    errors.fee = new NotEnoughBalance("");
+  }
+
+  return {
+    errors,
+    warnings,
+    estimatedFees,
+    amount: 0n,
+    totalSpent,
+  };
+}
+
+async function validateNativeSend({
+  config,
+  currencyId,
+  intent,
+  balances,
+  customFees,
+}: ValidateContext): Promise<TransactionValidation> {
+  const errors: Errors = {};
+  const warnings: Warnings = {};
+
+  const [recipientError, estimatedFees] = await Promise.all([
+    validateRecipient({ config, sender: intent.sender, recipient: intent.recipient }),
+    resolveEstimatedFees({ config, currencyId, intent, customFees }),
+  ]);
+
+  if (recipientError) {
+    errors.recipient = recipientError;
+  }
+
+  const nativeAvailable = available(findAssetBalance({ type: "native" }, balances));
+  const maxSpendable = nativeAvailable > estimatedFees ? nativeAvailable - estimatedFees : 0n;
+  const amount = intent.useAllAmount ? maxSpendable : intent.amount;
+  const totalSpent = amount + estimatedFees;
+
+  if (amount === 0n) {
+    errors.amount = intent.useAllAmount ? new NotEnoughBalance("") : new AmountRequired();
+  } else if (nativeAvailable < totalSpent) {
+    errors.amount = new NotEnoughBalance("");
+  }
+
+  return { errors, warnings, estimatedFees, amount, totalSpent };
+}
+
+async function validateTokenSend({
+  config,
+  currencyId,
+  intent,
+  balances,
+  customFees,
+}: ValidateContext): Promise<TransactionValidation> {
+  const errors: Errors = {};
+  const warnings: Warnings = {};
+
+  const [recipientError, estimatedFees] = await Promise.all([
+    validateRecipient({ config, sender: intent.sender, recipient: intent.recipient }),
+    resolveEstimatedFees({ config, currencyId, intent, customFees }),
+  ]);
+
+  if (recipientError) {
+    errors.recipient = recipientError;
+  }
+
+  const tokenId = "assetReference" in intent.asset ? intent.asset.assetReference : undefined;
+
+  if (intent.asset.type === "erc20") {
+    warnings.unverifiedEvmAddress = new HederaRecipientEvmAddressVerificationRequired();
+  } else if (intent.asset.type === "hts" && tokenId && !errors.recipient) {
+    try {
+      const hasRecipientTokenAssociated = await checkAccountTokenAssociationStatus({
+        configOrCurrencyId: config,
+        address: intent.recipient,
+        tokenId,
+      });
+
+      if (!hasRecipientTokenAssociated) {
+        warnings.missingAssociation = new HederaRecipientTokenAssociationRequired();
+      }
+    } catch {
+      warnings.unverifiedAssociation = new HederaRecipientTokenAssociationUnverified();
+    }
+  }
+
+  const tokenAvailable = available(findAssetBalance(intent.asset, balances));
+  const nativeAvailable = available(findAssetBalance({ type: "native" }, balances));
+  const amount = intent.useAllAmount ? tokenAvailable : intent.amount;
+  const totalSpent = amount;
+
+  // Deliberate legacy asymmetry: unlike native send, `useAllAmount` gets no zero-amount exemption.
+  if (amount === 0n) {
+    errors.amount = new AmountRequired();
+  } else if (tokenAvailable < totalSpent) {
+    errors.amount = new NotEnoughBalance();
+  } else if (nativeAvailable < estimatedFees) {
+    errors.amount = new NotEnoughBalance();
+  }
+
+  return { errors, warnings, estimatedFees, amount, totalSpent };
+}
+
+async function validateByMode(context: ValidateContext): Promise<TransactionValidation> {
+  const { intent } = context;
+  const isTokenAsset = intent.asset.type === "hts" || intent.asset.type === "erc20";
+
+  if (intent.type === HEDERA_TRANSACTION_MODES.TokenAssociate) {
+    return validateTokenAssociate(context);
+  }
+
+  if (intent.type === HEDERA_TRANSACTION_MODES.Send && isTokenAsset) {
+    return validateTokenSend(context);
+  }
+
+  if (
+    intent.type === HEDERA_TRANSACTION_MODES.Delegate ||
+    intent.type === HEDERA_TRANSACTION_MODES.Undelegate ||
+    intent.type === HEDERA_TRANSACTION_MODES.Redelegate ||
+    intent.type === HEDERA_TRANSACTION_MODES.ClaimRewards
+  ) {
+    return validateStaking(context);
+  }
+
+  return validateNativeSend(context);
+}
+
+export async function validateIntent({
+  config,
+  currencyId,
+  intent,
+  balances,
+  customFees,
+}: ValidateContext): Promise<TransactionValidation> {
+  const result = await validateByMode({ config, currencyId, intent, balances, customFees });
+
+  if (validateMemo(intent.memo?.value)) {
+    return result;
+  }
+
+  return {
+    ...result,
+    errors: {
+      ...result.errors,
+      transaction: new HederaMemoExceededSizeError(),
+    },
+  };
+}

--- a/libs/coin-modules/coin-hedera/src/network/utils.integ.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.integ.test.ts
@@ -111,18 +111,20 @@ describe("checkAccountTokenAssociationStatus", () => {
   const usdcToken = getTokenCurrencyFromCAL(0); // HTS USDC "0.0.456858"
 
   it("returns true when account has the HTS token associated", async () => {
-    const result = await checkAccountTokenAssociationStatus(
-      MAINNET_TEST_ACCOUNTS.withTokens.accountId,
-      usdcToken,
-    );
+    const result = await checkAccountTokenAssociationStatus({
+      configOrCurrencyId: coinConfig,
+      address: MAINNET_TEST_ACCOUNTS.withTokens.accountId,
+      tokenId: usdcToken.contractAddress,
+    });
     expect(result).toBe(true);
   });
 
   it("returns false when account does not have the HTS token associated", async () => {
-    const result = await checkAccountTokenAssociationStatus(
-      MAINNET_TEST_ACCOUNTS.withoutTokens.accountId,
-      usdcToken,
-    );
+    const result = await checkAccountTokenAssociationStatus({
+      configOrCurrencyId: coinConfig,
+      address: MAINNET_TEST_ACCOUNTS.withoutTokens.accountId,
+      tokenId: usdcToken.contractAddress,
+    });
     expect(result).toBe(false);
   });
 });
@@ -172,7 +174,7 @@ describe("getHederaValidators", () => {
   let validators: HederaValidator[];
 
   beforeAll(async () => {
-    validators = await getHederaValidators("hedera");
+    validators = await getHederaValidators({ currencyId: "hedera" });
   });
 
   it("fetches every page and returns a non-empty list", () => {

--- a/libs/coin-modules/coin-hedera/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.test.ts
@@ -3,7 +3,7 @@ import BigNumber from "bignumber.js";
 import { STAKING_REWARD_ACCOUNT_ID } from "../constants";
 import { HederaRecipientInvalidChecksum } from "../errors";
 import { getMockedAccount } from "../test/fixtures/account.fixture";
-import { getMockedCurrency, getMockedHTSTokenCurrency } from "../test/fixtures/currency.fixture";
+import { getMockedCurrency } from "../test/fixtures/currency.fixture";
 import {
   getMockedERC20TokenBalance,
   getMockedERC20TokenTransfer,
@@ -468,9 +468,11 @@ describe("network utils", () => {
 
   describe("getHederaValidators", () => {
     const mockGetNodes = jest.mocked(apiClient.getNodes);
+    const config = getMockedConfig({ ledgerNodeId: 0 });
+    const params = { currencyId: mockCurrency.id, config };
 
     beforeAll(() => {
-      hederaCoinConfig.setCoinConfig(() => getMockedConfig({ ledgerNodeId: 0 }));
+      hederaCoinConfig.setCoinConfig(() => config);
     });
 
     beforeEach(() => {
@@ -480,10 +482,11 @@ describe("network utils", () => {
     });
 
     it("calls getNodes with fetchAllPages=true and maps the result", async () => {
-      const validators = await getHederaValidators(mockCurrency.id);
+      const validators = await getHederaValidators(params);
 
+      expect(mockGetNodes).toHaveBeenCalledTimes(1);
       expect(mockGetNodes).toHaveBeenCalledWith({
-        configOrCurrencyId: mockCurrency.id,
+        configOrCurrencyId: config,
         fetchAllPages: true,
       });
       expect(validators).toHaveLength(1);
@@ -491,13 +494,13 @@ describe("network utils", () => {
     });
 
     it("hits the network once for two consecutive calls, and again after clear()", async () => {
-      await getHederaValidators(mockCurrency.id);
-      await getHederaValidators(mockCurrency.id);
+      await getHederaValidators(params);
+      await getHederaValidators(params);
 
       expect(mockGetNodes).toHaveBeenCalledTimes(1);
 
       getHederaValidators.clear(mockCurrency.id);
-      await getHederaValidators(mockCurrency.id);
+      await getHederaValidators(params);
 
       expect(mockGetNodes).toHaveBeenCalledTimes(2);
     });
@@ -505,24 +508,20 @@ describe("network utils", () => {
     it("does not cache a failed fetch, so the next call retries", async () => {
       mockGetNodes.mockRejectedValueOnce(new Error("network unavailable"));
 
-      await expect(getHederaValidators(mockCurrency.id)).rejects.toThrow("network unavailable");
-      await expect(getHederaValidators(mockCurrency.id)).resolves.toHaveLength(1);
+      await expect(getHederaValidators(params)).rejects.toThrow("network unavailable");
+      await expect(getHederaValidators(params)).resolves.toHaveLength(1);
       expect(mockGetNodes).toHaveBeenCalledTimes(2);
     });
   });
 
   describe("checkAccountTokenAssociationStatus", () => {
     const accountId = "0.0.1234";
-    const htsToken = getMockedHTSTokenCurrency({ contractAddress: "0.0.1234", tokenType: "hts" });
-    const erc20Token = getMockedHTSTokenCurrency({
-      contractAddress: "0.0.4321",
-      tokenType: "erc20",
-    });
+    const tokenId = "0.0.1234";
 
     beforeEach(() => {
       jest.clearAllMocks();
       // reset LRU cache to make sure all tests receive correct mocks from mockedGetAccount
-      checkAccountTokenAssociationStatus.clear(`${accountId}-${htsToken.contractAddress}`);
+      checkAccountTokenAssociationStatus.reset();
     });
 
     it("returns true if max_automatic_token_associations === -1", async () => {
@@ -536,7 +535,11 @@ describe("network utils", () => {
         },
       });
 
-      const result = await checkAccountTokenAssociationStatus(accountId, htsToken);
+      const result = await checkAccountTokenAssociationStatus({
+        configOrCurrencyId: defaultConfig,
+        address: accountId,
+        tokenId,
+      });
       expect(result).toBe(true);
     });
 
@@ -547,11 +550,15 @@ describe("network utils", () => {
         balance: {
           balance: 1,
           timestamp: "",
-          tokens: [{ token_id: htsToken.contractAddress, balance: 1 }],
+          tokens: [{ token_id: tokenId, balance: 1 }],
         },
       });
 
-      const result = await checkAccountTokenAssociationStatus(accountId, htsToken);
+      const result = await checkAccountTokenAssociationStatus({
+        configOrCurrencyId: defaultConfig,
+        address: accountId,
+        tokenId,
+      });
       expect(result).toBe(true);
     });
 
@@ -566,14 +573,12 @@ describe("network utils", () => {
         },
       });
 
-      const result = await checkAccountTokenAssociationStatus(accountId, htsToken);
+      const result = await checkAccountTokenAssociationStatus({
+        configOrCurrencyId: defaultConfig,
+        address: accountId,
+        tokenId,
+      });
       expect(result).toBe(false);
-    });
-
-    it("returns true for erc20 tokens", async () => {
-      const result = await checkAccountTokenAssociationStatus(accountId, erc20Token);
-      expect(apiClient.getAccount as jest.Mock).not.toHaveBeenCalled();
-      expect(result).toBe(true);
     });
 
     it("supports addresses with checksum", async () => {
@@ -585,16 +590,86 @@ describe("network utils", () => {
         balance: {
           balance: 1,
           timestamp: "",
-          tokens: [{ token_id: htsToken.contractAddress, balance: 1 }],
+          tokens: [{ token_id: tokenId, balance: 1 }],
         },
       });
 
-      await checkAccountTokenAssociationStatus(addressWithChecksum, htsToken);
+      await checkAccountTokenAssociationStatus({
+        configOrCurrencyId: defaultConfig,
+        address: addressWithChecksum,
+        tokenId,
+      });
       expect(apiClient.getAccount).toHaveBeenCalledTimes(1);
       expect(apiClient.getAccount).toHaveBeenCalledWith({
-        configOrCurrencyId: htsToken.parentCurrencyId,
+        configOrCurrencyId: defaultConfig,
         address: "0.0.9124531",
       });
+    });
+
+    it("caches per network, so the same account and token on another network refetches", async () => {
+      const testnetConfig = getMockedConfig({ networkType: "testnet" });
+      (apiClient.getAccount as jest.Mock)
+        .mockResolvedValueOnce({
+          account: accountId,
+          max_automatic_token_associations: 0,
+          balance: { balance: 1, timestamp: "", tokens: [{ token_id: tokenId, balance: 1 }] },
+        })
+        .mockResolvedValueOnce({
+          account: accountId,
+          max_automatic_token_associations: 0,
+          balance: { balance: 1, timestamp: "", tokens: [] },
+        });
+
+      const params = { address: accountId, tokenId };
+
+      await expect(
+        checkAccountTokenAssociationStatus({ ...params, configOrCurrencyId: defaultConfig }),
+      ).resolves.toBe(true);
+      await expect(
+        checkAccountTokenAssociationStatus({ ...params, configOrCurrencyId: testnetConfig }),
+      ).resolves.toBe(false);
+
+      expect(apiClient.getAccount).toHaveBeenCalledTimes(2);
+    });
+
+    it("caches per currency id when given one instead of a config", async () => {
+      (apiClient.getAccount as jest.Mock)
+        .mockResolvedValueOnce({
+          account: accountId,
+          max_automatic_token_associations: 0,
+          balance: { balance: 1, timestamp: "", tokens: [{ token_id: tokenId, balance: 1 }] },
+        })
+        .mockResolvedValueOnce({
+          account: accountId,
+          max_automatic_token_associations: 0,
+          balance: { balance: 1, timestamp: "", tokens: [] },
+        });
+
+      const params = { address: accountId, tokenId };
+
+      await expect(
+        checkAccountTokenAssociationStatus({ ...params, configOrCurrencyId: "hedera" }),
+      ).resolves.toBe(true);
+      await expect(
+        checkAccountTokenAssociationStatus({ ...params, configOrCurrencyId: "hedera_testnet" }),
+      ).resolves.toBe(false);
+
+      expect(apiClient.getAccount).toHaveBeenCalledTimes(2);
+    });
+
+    it("reuses the cached result for a repeated call on the same network", async () => {
+      (apiClient.getAccount as jest.Mock).mockResolvedValueOnce({
+        account: accountId,
+        max_automatic_token_associations: 0,
+        balance: { balance: 1, timestamp: "", tokens: [{ token_id: tokenId, balance: 1 }] },
+      });
+
+      const params = { configOrCurrencyId: defaultConfig, address: accountId, tokenId };
+
+      await expect(checkAccountTokenAssociationStatus(params)).resolves.toBe(true);
+      await expect(checkAccountTokenAssociationStatus(params)).resolves.toBe(true);
+
+      expect(apiClient.getAccount).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/libs/coin-modules/coin-hedera/src/network/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.ts
@@ -4,11 +4,7 @@ import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currenc
 import { InvalidAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 import cvsApi from "@ledgerhq/live-countervalues/api/index";
 import { makeLRUCache, minutes, seconds } from "@ledgerhq/live-network/cache";
-import type {
-  FiatCurrency,
-  TokenCurrency,
-  Currency,
-} from "@ledgerhq/ledger-wallet-framework/types";
+import type { FiatCurrency, Currency } from "@ledgerhq/ledger-wallet-framework/types";
 import type { Operation, OperationType } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { HEDERA_VALIDATORS_CACHE_MINUTES, STAKING_REWARD_ACCOUNT_ID } from "../constants";
@@ -232,27 +228,37 @@ export const getCurrencyToUSDRate = makeLRUCache(
 );
 
 export const getHederaValidators = makeLRUCache(
-  async (currencyId: string): Promise<HederaValidator[]> => {
-    const ledgerNodeId = String(resolveConfig(currencyId).ledgerNodeId);
+  async ({
+    currencyId,
+    config,
+  }: {
+    currencyId: string;
+    config?: HederaCoinConfig;
+  }): Promise<HederaValidator[]> => {
+    const resolvedConfig = config ?? resolveConfig(currencyId);
     const result = await apiClient.getNodes({
-      configOrCurrencyId: currencyId,
+      configOrCurrencyId: resolvedConfig,
       fetchAllPages: true,
     });
 
-    return mapMirrorNodesToValidators(result.nodes, ledgerNodeId);
+    return mapMirrorNodesToValidators(result.nodes, String(resolvedConfig.ledgerNodeId));
   },
-  (currencyId: string) => currencyId,
+  ({ currencyId }) => currencyId,
   minutes(HEDERA_VALIDATORS_CACHE_MINUTES),
 );
 
 export const checkAccountTokenAssociationStatus = makeLRUCache(
-  async (address: string, token: TokenCurrency) => {
-    if (token.tokenType !== "hts") {
-      return true;
-    }
-
+  async ({
+    configOrCurrencyId,
+    address,
+    tokenId,
+  }: {
+    configOrCurrencyId: HederaCoinConfig | string;
+    address: string;
+    tokenId: string;
+  }) => {
     const [parsingError, parsingResult] = await safeParseAccountId({
-      configOrCurrencyId: token.parentCurrencyId,
+      configOrCurrencyId,
       address,
     });
 
@@ -262,7 +268,7 @@ export const checkAccountTokenAssociationStatus = makeLRUCache(
 
     const addressWithoutChecksum = parsingResult.accountId;
     const mirrorAccount = await apiClient.getAccount({
-      configOrCurrencyId: token.parentCurrencyId,
+      configOrCurrencyId,
       address: addressWithoutChecksum,
     });
 
@@ -272,12 +278,33 @@ export const checkAccountTokenAssociationStatus = makeLRUCache(
     }
 
     const isTokenAssociated = mirrorAccount.balance.tokens.some(t => {
-      return t.token_id === token.contractAddress;
+      return t.token_id === tokenId;
     });
 
     return isTokenAssociated;
   },
-  (accountId, token) => `${accountId}-${token.contractAddress}`,
+  ({ configOrCurrencyId, address, tokenId }) => {
+    if (typeof configOrCurrencyId === "string") {
+      return `${configOrCurrencyId}-${address}-${tokenId}`;
+    }
+
+    return `${configOrCurrencyId.networkType}-${address}-${tokenId}`;
+  },
+  seconds(30),
+);
+
+export const getHederaAccountForValidation = makeLRUCache(
+  async ({
+    config,
+    address,
+  }: {
+    currencyId: string;
+    config: HederaCoinConfig;
+    address: string;
+  }) => {
+    return apiClient.getAccount({ configOrCurrencyId: config, address });
+  },
+  ({ currencyId, address }) => `${currencyId}:${address}`,
   seconds(30),
 );
 

--- a/libs/coin-modules/coin-hedera/src/signer/frameworkSigner.test.ts
+++ b/libs/coin-modules/coin-hedera/src/signer/frameworkSigner.test.ts
@@ -9,6 +9,7 @@ import {
   serializeSignature,
   serializeTransaction,
 } from "../logic/utils";
+import { rpcClient } from "../network/rpc";
 import { getMockedConfig } from "../test/fixtures/config.fixture";
 import type { HederaMemo, HederaSigner } from "../types";
 import { createFrameworkSigner } from "./frameworkSigner";
@@ -33,6 +34,10 @@ const makeSigner = (overrides: Partial<HederaSigner> = {}): HederaSigner => ({
   getPublicKey: jest.fn().mockResolvedValue("aabbcc"),
   signTransaction: jest.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
   ...overrides,
+});
+
+afterAll(async () => {
+  await rpcClient._resetInstance();
 });
 
 describe("createFrameworkSigner.getAddress", () => {

--- a/libs/ledger-live-common/src/families/hedera/react.test.ts
+++ b/libs/ledger-live-common/src/families/hedera/react.test.ts
@@ -112,7 +112,7 @@ describe("hedera/react", () => {
     let validators: HederaValidator[];
 
     beforeEach(async () => {
-      validators = await getHederaValidators(currency.id);
+      validators = await getHederaValidators({ currencyId: currency.id });
     });
 
     it("should report loading:true before validators resolve, then loading:false once they do", async () => {

--- a/libs/ledger-live-common/src/families/hedera/state-manager/api.ts
+++ b/libs/ledger-live-common/src/families/hedera/state-manager/api.ts
@@ -12,7 +12,7 @@ export const hederaApi = createApi({
     getValidators: build.query<HederaValidator[], string>({
       queryFn: async currencyId => {
         try {
-          return { data: await getHederaValidators(currencyId) };
+          return { data: await getHederaValidators({ currencyId }) };
         } catch (error) {
           return { error: error instanceof Error ? error : new Error(String(error)) };
         }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR adds a `validateIntent` implementation to the Hedera coin module, so the generic coin framework path can validate transactions on its own instead of throwing "not supported". Validation covers native sends, token sends, token association and all four staking modes, and it mirrors the checks the legacy account bridge does in `getTransactionStatus`. It is deliberately stricter than the legacy bridge in one place: balance checks now subtract locked funds instead of using the raw balance.

To make the shared network helpers usable from the api path, several of them now take a resolved coin config object rather than a currency id or a token currency. That keeps the api layer explicit about which config it threads down, per the context pattern the rest of the module already follows.

- Validator lookup, token association status and a new account lookup helper all accept an options object with an explicit config.
- The token association check now takes a plain token id, so callers filter out non-Hedera-native tokens before calling it.
- The legacy account bridge and the validators query in live-common are updated to the new signatures, with no behaviour change.
- Association is still blocked outright when the HBAR to USD rate cannot be fetched, matching the legacy bridge.

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

Old bridge is not affected by getTransactionStatus changes:
| <img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/26a9f30a-c35f-4217-970c-ca7a2a39c9b2" /> | <img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/f483697d-9681-49b6-b28a-52c21df29924" /> |
|---|--|

### 🔗 Context

- https://ledgerhq.atlassian.net/browse/LIVE-36147