### PR TITLE
test(desktop): add post-onboarding hub e2e full mock flow

### DIFF
--- a/.changeset/LIVE-31322-post-onboarding-hub-e2e.md
+++ b/.changeset/LIVE-31322-post-onboarding-hub-e2e.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop-e2e-tests": patch
+---
+
+Add desktop E2E for the post-onboarding hub mock flow (LIVE-31322).

--- a/e2e/desktop/tests/page/index.ts
+++ b/e2e/desktop/tests/page/index.ts
@@ -22,6 +22,7 @@ import { OperationDrawer } from "tests/page/drawer/operation.drawer";
 import { PageHolder } from "tests/page/abstractClasses";
 import { PasswordlockModal } from "tests/page/modal/passwordlock.modal";
 import { PortfolioPage } from "tests/page/portfolio.page";
+import { PostOnboardingPage } from "tests/page/postOnboarding.page";
 import { ReceiveModal } from "tests/page/modal/receive.modal";
 import { Redux } from "tests/utils/redux";
 import { SendDrawer } from "tests/page/drawer/send.drawer";
@@ -77,6 +78,7 @@ export class Application extends PageHolder {
   public operationDrawer = new OperationDrawer(this.page);
   public password = new PasswordlockModal(this.page);
   public portfolio = new PortfolioPage(this.page);
+  public postOnboarding = new PostOnboardingPage(this.page);
   public receive = new ReceiveModal(this.page);
   public privateBalance = new PrivateBalanceModal(this.page);
   public redux = new Redux(this.page);

--- a/e2e/desktop/tests/page/postOnboarding.page.ts
+++ b/e2e/desktop/tests/page/postOnboarding.page.ts
@@ -44,8 +44,8 @@ export class PostOnboardingPage extends AppPage {
     await expect(row).toContainText(completedLabel);
   }
 
-  @step("Tap post-onboarding action $0")
-  async tapAction(actionId: string) {
+  @step("Click post-onboarding action $0")
+  async clickAction(actionId: string) {
     await this.actionRow(actionId).click();
     await expect(this.finishOnboardingDialog).toBeHidden();
     await expect(this.completeMockActionButton).toBeVisible();

--- a/e2e/desktop/tests/page/postOnboarding.page.ts
+++ b/e2e/desktop/tests/page/postOnboarding.page.ts
@@ -1,0 +1,59 @@
+import { expect } from "@playwright/test";
+import { step } from "tests/misc/reporters/step";
+import { AppPage } from "tests/page/abstractClasses";
+
+export class PostOnboardingPage extends AppPage {
+  private readonly finishOnboardingWidget = this.page.getByTestId("finish-onboarding-widget");
+  private readonly finishOnboardingDialog = this.page
+    .getByRole("dialog")
+    .filter({ has: this.page.locator("[data-post-onboarding-action-id]") });
+  private readonly sideDrawer = this.page.getByTestId("side-drawer-container");
+  private readonly completeMockActionButton = this.page.getByTestId(
+    "postonboarding-complete-action-button",
+  );
+
+  private actionRow(actionId: string) {
+    return this.finishOnboardingDialog.locator(`[data-post-onboarding-action-id="${actionId}"]`);
+  }
+
+  @step("Expect finish-onboarding widget to be visible")
+  async expectWidgetVisible() {
+    await expect(this.finishOnboardingWidget).toBeVisible();
+  }
+
+  @step("Expect finish-onboarding widget to be hidden")
+  async expectWidgetHidden() {
+    await expect(this.finishOnboardingWidget).toBeHidden();
+  }
+
+  @step("Open finish-onboarding dialog from widget")
+  async openDialogFromWidget() {
+    await this.finishOnboardingWidget.click();
+    await expect(this.finishOnboardingDialog).toBeVisible();
+  }
+
+  @step("Expect post-onboarding action $0 to be pending")
+  async expectActionPending(actionId: string) {
+    await expect(this.actionRow(actionId)).toBeVisible();
+  }
+
+  @step("Expect post-onboarding action $0 to be completed")
+  async expectActionCompleted(actionId: string, completedLabel: string) {
+    const row = this.actionRow(actionId);
+    await expect(row).toBeVisible();
+    await expect(row).toContainText(completedLabel);
+  }
+
+  @step("Tap post-onboarding action $0")
+  async tapAction(actionId: string) {
+    await this.actionRow(actionId).click();
+    await expect(this.finishOnboardingDialog).toBeHidden();
+    await expect(this.completeMockActionButton).toBeVisible();
+  }
+
+  @step("Complete mock post-onboarding action")
+  async completeMockAction() {
+    await this.completeMockActionButton.click();
+    await expect(this.sideDrawer).toBeHidden();
+  }
+}

--- a/e2e/desktop/tests/page/postOnboarding.page.ts
+++ b/e2e/desktop/tests/page/postOnboarding.page.ts
@@ -33,8 +33,10 @@ export class PostOnboardingPage extends AppPage {
   }
 
   @step("Expect post-onboarding action $0 to be pending")
-  async expectActionPending(actionId: string) {
-    await expect(this.actionRow(actionId)).toBeVisible();
+  async expectActionPending(actionId: string, completedLabel: string) {
+    const row = this.actionRow(actionId);
+    await expect(row).toBeVisible();
+    await expect(row).not.toContainText(completedLabel);
   }
 
   @step("Expect post-onboarding action $0 to be completed")

--- a/e2e/desktop/tests/specs/postOnboarding/postOnboardingHub.ts
+++ b/e2e/desktop/tests/specs/postOnboarding/postOnboardingHub.ts
@@ -1,0 +1,17 @@
+import { FF_LWD_WALLET_40_Q2_NO_ANALYTICS_CONSENT } from "tests/utils/featureFlagUtils";
+
+/** Must stay in sync with `postOnboarding.actionsToComplete` in userdata/post-onboarding-hub-flow.json. */
+export const MOCK_ACTIONS = ["claimMock", "personalizeMock", "migrateAssetsMock"] as const;
+
+export const POST_ONBOARDING_FLAGS = {
+  ...FF_LWD_WALLET_40_Q2_NO_ANALYTICS_CONSENT,
+  onboardingWidget: { enabled: true },
+  protectServicesDesktop: { enabled: false },
+  lwdProductTour: { enabled: false },
+  lldLedgerSyncEntryPoints: { enabled: false },
+};
+
+export const POST_ONBOARDING_USERDATA = "post-onboarding-hub-flow";
+
+// i18n `postOnboarding.dialog.actionCompletedLabel`
+export const ACTION_COMPLETED_LABEL = "Complete";

--- a/e2e/desktop/tests/specs/postOnboarding/postOnboardingHub.ts
+++ b/e2e/desktop/tests/specs/postOnboarding/postOnboardingHub.ts
@@ -1,15 +1,5 @@
-import { FF_LWD_WALLET_40_Q2_NO_ANALYTICS_CONSENT } from "tests/utils/featureFlagUtils";
-
 /** Must stay in sync with `postOnboarding.actionsToComplete` in userdata/post-onboarding-hub-flow.json. */
 export const MOCK_ACTIONS = ["claimMock", "personalizeMock", "migrateAssetsMock"] as const;
-
-export const POST_ONBOARDING_FLAGS = {
-  ...FF_LWD_WALLET_40_Q2_NO_ANALYTICS_CONSENT,
-  onboardingWidget: { enabled: true },
-  protectServicesDesktop: { enabled: false },
-  lwdProductTour: { enabled: false },
-  lldLedgerSyncEntryPoints: { enabled: false },
-};
 
 export const POST_ONBOARDING_USERDATA = "post-onboarding-hub-flow";
 

--- a/e2e/desktop/tests/specs/postOnboarding/postOnboardingHubFlow.spec.ts
+++ b/e2e/desktop/tests/specs/postOnboarding/postOnboardingHubFlow.spec.ts
@@ -1,0 +1,55 @@
+import test from "tests/fixtures/common";
+import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
+import { addTmsLink } from "tests/utils/allureUtils";
+import { DEVICE_TAGS } from "tests/utils/tagsUtils";
+import {
+  ACTION_COMPLETED_LABEL,
+  MOCK_ACTIONS,
+  POST_ONBOARDING_FLAGS,
+  POST_ONBOARDING_USERDATA,
+} from "./postOnboardingHub";
+
+/**
+ * B2CQA-6545. Mock post-onboarding widget flow — no Speculos; each step completes via
+ * PostOnboardingMockAction side drawer.
+ */
+test.describe("Post-onboarding hub", () => {
+  test.use({
+    teamOwner: Team.ENGAGEMENT,
+    userdata: POST_ONBOARDING_USERDATA,
+    featureFlags: POST_ONBOARDING_FLAGS,
+  });
+
+  test(
+    "Full post-onboarding widget flow — all mock steps",
+    {
+      tag: [...DEVICE_TAGS, "@postOnboarding"],
+      annotation: { type: "TMS", description: "B2CQA-6545" },
+    },
+    async ({ app }) => {
+      await addTmsLink(["B2CQA-6545"]);
+
+      await app.mainNavigation.openTargetFromMainNavigation("home");
+      await app.postOnboarding.expectWidgetVisible();
+      await app.postOnboarding.openDialogFromWidget();
+
+      const lastActionId = MOCK_ACTIONS.at(-1);
+
+      for (const actionId of MOCK_ACTIONS) {
+        const isLast = actionId === lastActionId;
+
+        await app.postOnboarding.expectActionPending(actionId);
+        await app.postOnboarding.tapAction(actionId);
+        await app.postOnboarding.completeMockAction();
+
+        if (isLast) break;
+
+        await app.postOnboarding.expectWidgetVisible();
+        await app.postOnboarding.openDialogFromWidget();
+        await app.postOnboarding.expectActionCompleted(actionId, ACTION_COMPLETED_LABEL);
+      }
+
+      await app.postOnboarding.expectWidgetHidden();
+    },
+  );
+});

--- a/e2e/desktop/tests/specs/postOnboarding/postOnboardingHubFlow.spec.ts
+++ b/e2e/desktop/tests/specs/postOnboarding/postOnboardingHubFlow.spec.ts
@@ -39,7 +39,7 @@ test.describe("Post-onboarding hub", () => {
         const isLast = actionId === lastActionId;
 
         await app.postOnboarding.expectActionPending(actionId);
-        await app.postOnboarding.tapAction(actionId);
+        await app.postOnboarding.clickAction(actionId);
         await app.postOnboarding.completeMockAction();
 
         if (isLast) break;

--- a/e2e/desktop/tests/specs/postOnboarding/postOnboardingHubFlow.spec.ts
+++ b/e2e/desktop/tests/specs/postOnboarding/postOnboardingHubFlow.spec.ts
@@ -1,13 +1,14 @@
 import test from "tests/fixtures/common";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { addTmsLink } from "tests/utils/allureUtils";
-import { DEVICE_TAGS } from "tests/utils/tagsUtils";
+import { getDescription } from "tests/utils/customJsonReporter";
+import { FF_POST_ONBOARDING_DESKTOP } from "tests/utils/featureFlagUtils";
+import { deviceTagsWithoutLNS } from "tests/utils/tagsUtils";
 import {
   ACTION_COMPLETED_LABEL,
   MOCK_ACTIONS,
-  POST_ONBOARDING_FLAGS,
   POST_ONBOARDING_USERDATA,
-} from "./postOnboardingHub";
+} from "tests/specs/postOnboarding/postOnboardingHub";
 
 /**
  * B2CQA-6545. Mock post-onboarding widget flow — no Speculos; each step completes via
@@ -17,17 +18,17 @@ test.describe("Post-onboarding hub", () => {
   test.use({
     teamOwner: Team.ENGAGEMENT,
     userdata: POST_ONBOARDING_USERDATA,
-    featureFlags: POST_ONBOARDING_FLAGS,
+    featureFlags: FF_POST_ONBOARDING_DESKTOP,
   });
 
   test(
     "Full post-onboarding widget flow — all mock steps",
     {
-      tag: [...DEVICE_TAGS, "@postOnboarding"],
+      tag: [...deviceTagsWithoutLNS(), "@postOnboarding"],
       annotation: { type: "TMS", description: "B2CQA-6545" },
     },
     async ({ app }) => {
-      await addTmsLink(["B2CQA-6545"]);
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
       await app.mainNavigation.openTargetFromMainNavigation("home");
       await app.postOnboarding.expectWidgetVisible();
@@ -38,7 +39,7 @@ test.describe("Post-onboarding hub", () => {
       for (const actionId of MOCK_ACTIONS) {
         const isLast = actionId === lastActionId;
 
-        await app.postOnboarding.expectActionPending(actionId);
+        await app.postOnboarding.expectActionPending(actionId, ACTION_COMPLETED_LABEL);
         await app.postOnboarding.clickAction(actionId);
         await app.postOnboarding.completeMockAction();
 

--- a/e2e/desktop/tests/userdata/post-onboarding-hub-flow.json
+++ b/e2e/desktop/tests/userdata/post-onboarding-hub-flow.json
@@ -1,0 +1,74 @@
+{
+  "data": {
+    "PLAYWRIGHT_RUN": {
+      "localStorage": {
+        "acceptedTermsVersion": "2042-01-01"
+      }
+    },
+    "settings": {
+      "hasCompletedOnboarding": true,
+      "hasSeenWalletV4Tour": true,
+      "hasBeenUpsoldRecover": true,
+      "hasBeenRedirectedToPostOnboarding": true,
+      "counterValue": "USD",
+      "language": "en",
+      "theme": null,
+      "region": null,
+      "locale": "en-US",
+      "orderAccounts": "balance|desc",
+      "countervalueFirst": false,
+      "autoLockTimeout": 10,
+      "selectedTimeRange": "month",
+      "marketIndicator": "western",
+      "currenciesSettings": {},
+      "pairExchanges": {},
+      "developerMode": false,
+      "loaded": true,
+      "shareAnalytics": false,
+      "sharePersonalizedRecommandations": false,
+      "analyticsConsentInfo": {
+        "consentDate": "2099-01-01T00:00:00.000Z",
+        "privacyPolicyVersion": 1
+      },
+      "hasSeenAnalyticsOptInPrompt": true,
+      "sentryLogs": true,
+      "lastUsedVersion": "99.99.99",
+      "dismissedBanners": [],
+      "accountsViewMode": "list",
+      "showAccountsHelperBanner": true,
+      "hideEmptyTokenAccounts": false,
+      "sidebarCollapsed": false,
+      "discreetMode": false,
+      "preferredDeviceModel": "stax",
+      "hasInstalledApps": true,
+      "blacklistedTokenIds": [],
+      "swapAcceptedProviderIds": [],
+      "deepLinkUrl": null,
+      "firstTimeLend": false,
+      "swapProviders": [],
+      "showClearCacheBanner": false,
+      "starredAccountIds": [],
+      "hasPassword": false
+    },
+    "user": {
+      "id": "08cf3393-c5eb-4ea7-92de-0deea22e3971"
+    },
+    "accounts": [],
+    "countervalues": {},
+    "postOnboarding": {
+      "deviceModelId": "stax",
+      "walletEntryPointDismissed": false,
+      "entryPointFirstDisplayedDate": null,
+      "walletEntryPointEligibleForPortfolio": true,
+      "actionsToComplete": ["claimMock", "personalizeMock", "migrateAssetsMock"],
+      "actionsCompleted": {
+        "claimMock": false,
+        "personalizeMock": false,
+        "migrateAssetsMock": false
+      },
+      "lastActionCompleted": null,
+      "postOnboardingInProgress": true,
+      "onboardingDate": null
+    }
+  }
+}

--- a/e2e/desktop/tests/utils/featureFlagUtils.ts
+++ b/e2e/desktop/tests/utils/featureFlagUtils.ts
@@ -79,6 +79,15 @@ export const FF_LWD_WALLET_40_Q2_NO_ANALYTICS_CONSENT = {
   analyticsOptIn: { enabled: false },
 } satisfies PartialFeatures;
 
+// Wallet 4.0 without analytics consent; pins flags that would block the finish-onboarding widget.
+export const FF_POST_ONBOARDING_DESKTOP = {
+  ...FF_LWD_WALLET_40_Q2_NO_ANALYTICS_CONSENT,
+  onboardingWidget: { enabled: true },
+  protectServicesDesktop: { enabled: false },
+  lwdProductTour: { enabled: false },
+  lldLedgerSyncEntryPoints: { enabled: false },
+} satisfies OptionalFeatureMap;
+
 export const FF_BORROW_DESKTOP = {
   ptxBorrowLiveApp: {
     enabled: true,

--- a/e2e/desktop/tests/utils/featureFlagUtils.ts
+++ b/e2e/desktop/tests/utils/featureFlagUtils.ts
@@ -86,7 +86,7 @@ export const FF_POST_ONBOARDING_DESKTOP = {
   protectServicesDesktop: { enabled: false },
   lwdProductTour: { enabled: false },
   lldLedgerSyncEntryPoints: { enabled: false },
-} satisfies OptionalFeatureMap;
+} satisfies PartialFeatures;
 
 export const FF_BORROW_DESKTOP = {
   ptxBorrowLiveApp: {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Add desktop Playwright E2E for the post-onboarding widget mock flow (LIVE-31322 / B2CQA-6545), aligned with the merged mobile implementation (#21206).

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-31322]<!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-31322]: https://ledgerhq.atlassian.net/browse/LIVE-31322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ