### PR TITLE
fix(pay): use theme text color in the mobile Pay Card DevTool

### DIFF
--- a/.changeset/quick-pay-devtool.md
+++ b/.changeset/quick-pay-devtool.md
@@ -1,0 +1,5 @@
+---
+"@devtools/pay-card": patch
+---
+
+Use theme `base` text color in the mobile Pay Card DevTool so labels stay readable in dark mode.

--- a/devtools/pay-card/src/components/Section/Section.native.tsx
+++ b/devtools/pay-card/src/components/Section/Section.native.tsx
@@ -12,7 +12,9 @@ const CONTENT_LX = { gap: "s8" } as const;
 export function Section({ title, children }: SectionProps) {
   return (
     <Box lx={CONTAINER_LX}>
-      <Text typography="body2">{title}</Text>
+      <Text typography="body2" lx={{ color: "base" }}>
+        {title}
+      </Text>
       <Box lx={CONTENT_LX}>{children}</Box>
     </Box>
   );

--- a/devtools/pay-card/src/components/ToggleRow/ToggleRow.native.tsx
+++ b/devtools/pay-card/src/components/ToggleRow/ToggleRow.native.tsx
@@ -18,7 +18,9 @@ export function ToggleRow({ label, description, checked, onChange }: ToggleRowPr
   return (
     <Box style={ROW_LX}>
       <Box style={{ flexShrink: 1 }}>
-        <Text typography="body3">{label}</Text>
+        <Text typography="body3" lx={{ color: "base" }}>
+          {label}
+        </Text>
         {description ? (
           <Text typography="body4" lx={{ color: "muted" }}>
             {description}


### PR DESCRIPTION
## Summary
- Set Lumen `color: "base"` on Pay Card DevTool section titles and toggle labels so they follow the theme in dark mode (native only).
- Independent of the feature-tour stack.

## Test plan
- [ ] Open DevTools → Pay Card on mobile in dark mode
- [ ] Confirm section titles and toggle labels are not black