### PR TITLE
ci(nx-affected): always log nx output when affected fails

### DIFF
--- a/.github/workflows/nx-affected-reusable.yml
+++ b/.github/workflows/nx-affected-reusable.yml
@@ -11,11 +11,6 @@ on:
         description: "Head branch"
         type: string
         required: true
-      affected_debug:
-        description: "Enable verbose debug output for nx affected merge-base diagnostics"
-        type: boolean
-        required: false
-        default: false
       skip_nx_cache:
         description: "Skip Nx task cache when computing affected projects (e.g. external fork workflows)"
         type: boolean

--- a/tools/actions/composites/nx-affected-packages/get-affected-packages-and-paths.js
+++ b/tools/actions/composites/nx-affected-packages/get-affected-packages-and-paths.js
@@ -67,10 +67,13 @@ async function getAffectedPackagesAndPaths(options = {}) {
   let packageNames = [];
   const { stdout: affectedStdout, stderr: affectedStderr, exitCode } = await runPnpm(args, exec);
 
+  // Continuation lines are indented so none can start with `::` and be parsed as a
+  // workflow command.
   const clip = value => {
     const text = (value || "").trim();
     if (!text) return "<none>";
-    return text.length > 4000 ? `${text.slice(0, 4000)}… (truncated)` : text;
+    const clipped = text.length > 4000 ? `${text.slice(0, 4000)}… (truncated)` : text;
+    return clipped.replace(/\r?\n/g, "\n  ");
   };
 
   const diagnostics = () =>

--- a/tools/actions/composites/nx-affected-packages/get-affected-packages-and-paths.js
+++ b/tools/actions/composites/nx-affected-packages/get-affected-packages-and-paths.js
@@ -67,53 +67,44 @@ async function getAffectedPackagesAndPaths(options = {}) {
   let packageNames = [];
   const { stdout: affectedStdout, stderr: affectedStderr, exitCode } = await runPnpm(args, exec);
 
+  const clip = value => {
+    const text = (value || "").trim();
+    if (!text) return "<none>";
+    return text.length > 4000 ? `${text.slice(0, 4000)}… (truncated)` : text;
+  };
+
+  const diagnostics = () =>
+    [
+      `base: ${base || "<nx default>"}`,
+      `head: ${head || "<nx default>"}`,
+      `exitCode: ${exitCode}`,
+      `stderr: ${clip(affectedStderr)}`,
+      `stdout: ${clip(affectedStdout)}`,
+    ].join("\n");
+
+  // github-script surfaces only `error.message` in the ##[error] annotation, and truncates it,
+  // so the same diagnostics also go to the step log.
+  const fail = summary => {
+    const message = `${summary}\n${diagnostics()}`;
+    console.error(`[nx-affected] ${message}`);
+    throw new Error(message);
+  };
+
   // If Nx cannot compute affected projects, fail instead of silently
   // returning an empty list, which could cause CI to skip tests/jobs.
   if (exitCode !== 0) {
-    const debugEnabled = process.env.RUNNER_DEBUG === "1" || process.env.DEBUG_NX_AFFECTED;
-    if (debugEnabled) {
-      console.error(
-        "[nx-affected] `pnpm nx show projects --affected --json` failed.",
-        "exitCode:",
-        exitCode,
-        "stderr:",
-        affectedStderr || "<none>",
-        "stdout:",
-        affectedStdout || "<none>",
-      );
-    }
-    throw new Error(`pnpm nx show projects --affected --json failed with exit code ${exitCode}`);
+    fail(`pnpm nx show projects --affected --json failed with exit code ${exitCode}.`);
   }
 
   if (!affectedStdout || !affectedStdout.trim()) {
-    const debugEnabled = process.env.RUNNER_DEBUG === "1" || process.env.DEBUG_NX_AFFECTED;
-    if (debugEnabled) {
-      console.error(
-        "[nx-affected] `pnpm nx show projects --affected --json` produced no output.",
-        "stderr:",
-        affectedStderr || "<none>",
-      );
-    }
-    throw new Error("pnpm nx show projects --affected --json returned empty output");
+    fail("pnpm nx show projects --affected --json returned empty output.");
   }
 
   try {
     const parsed = JSON.parse(affectedStdout.trim());
     if (Array.isArray(parsed)) packageNames = parsed.filter(Boolean);
   } catch (e) {
-    const debugEnabled = process.env.RUNNER_DEBUG === "1" || process.env.DEBUG_NX_AFFECTED;
-    if (debugEnabled) {
-      console.error(
-        "[nx-affected] Failed to parse affected projects JSON.",
-        "error:",
-        e,
-        "stderr:",
-        affectedStderr || "<none>",
-        "stdout:",
-        affectedStdout || "<none>",
-      );
-    }
-    throw new Error("Failed to parse output from pnpm nx show projects");
+    fail(`Failed to parse output from pnpm nx show projects: ${e}`);
   }
 
   const paths = [];


### PR DESCRIPTION
## Why

`Determine Affected (Nx)` has failed in the merge queue three times (2026-08-24 ×2, 2026-08-26) reporting nothing but `pnpm nx show projects --affected --json failed with exit code 1`. The cause is still unknown after three occurrences, because the diagnostics were gated behind `RUNNER_DEBUG` / `DEBUG_NX_AFFECTED` and `runPnpm` passes `silent: true`, so nothing reaches the log on its own.

The `affected_debug` input on `nx-affected-reusable.yml` looks like the escape hatch for exactly this, but it is declared and never used — it does not set `DEBUG_NX_AFFECTED`, so turning it on would have changed nothing.

## What

Always log `base`, `head`, `exitCode` and both streams on all three failure paths, and carry the nx output in the thrown error so it reaches the `##[error]` annotation rather than sitting only in the step log.

Nx reports its failures on **stdout**, not stderr (verified locally), so the error includes both streams rather than stderr alone. Each stream is clipped at 4000 characters.

## Verification

Forced failure locally with a bogus base:

```
[nx-affected] `pnpm nx show projects --affected --json` failed.
base: definitely-not-a-real-ref
head: HEAD
exitCode: 1
stderr: <none>
stdout: NX   Command failed: git diff --name-only --no-renames --relative "definitely-not-a-real-ref" "HEAD"

fatal: ambiguous argument 'definitely-not-a-real-ref': unknown revision or path not in the working tree.
```

Success path unchanged: `BASE=origin/develop~3 HEAD=HEAD` still returns the expected `{"packages":[...],"paths":[...]}`.

## Notes

Diagnostics only — no behaviour change on the success path, and no change to the workflow contract.

Deliberately shipped ahead of the `base_sha` fetch and the cached-affected-index work, so the next occurrence is readable instead of being masked by a rewrite of the same code path.
