### PR TITLE
[LWDM] feat(coin-tester-zcash): add device-free Zcash coin-tester (LIVE-36480)

### DIFF
--- a/.changeset/coin-zcash-dedupe-mixed-pool-operations.md
+++ b/.changeset/coin-zcash-dedupe-mixed-pool-operations.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-zcash": patch
+---
+
+Fix a transparent↔shielded transaction (shielding or de-shielding) being recorded twice in `account.operations` — once by the transparent leg's sync and once by the shielded leg's, for the same transaction hash. `reconcileLegOperations` now keeps only the transparent leg's record when both legs see the same hash.

--- a/.changeset/zcash-regtest-wallet-btc-factory.md
+++ b/.changeset/zcash-regtest-wallet-btc-factory.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-btc": patch
+---
+
+Add the missing `zcash_regtest` case to `cryptoFactory`, so the Zcash regtest currency used by the coin-tester no longer throws in `wallet-btc`'s crypto factory switch.

--- a/.github/workflows/test-coin-tester.yml
+++ b/.github/workflows/test-coin-tester.yml
@@ -19,7 +19,7 @@ permissions:
   contents: read
 
 env:
-  COIN_TESTER_CURRENCIES: "evm polkadot solana bitcoin tezos tron xrp stellar multiversx cosmos cardano casper vechain near stacks kaspa"
+  COIN_TESTER_CURRENCIES: "evm polkadot solana bitcoin tezos tron xrp stellar multiversx cosmos cardano casper vechain near stacks kaspa zcash"
 
 jobs:
   is-affected:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -253,7 +253,6 @@ libs/coin-modules/coin-mina/                                             @ledger
 libs/coin-modules/coin-stacks/                                           @ledgerhq/blockchain-support @ledgerhq/ledger-third-party-leads
 libs/coin-modules/coin-kaspa/                                            @ledgerhq/blockchain-support @ledgerhq/ledger-third-party-leads
 libs/coin-modules/coin-zcash/                                            @ledgerhq/blockchain-support @ledgerhq/ledger-third-party-leads
-libs/coin-tester-modules/coin-tester-zcash/                              @ledgerhq/blockchain-support @ledgerhq/ledger-third-party-leads
 
 ## Blockchain support 2
 libs/coin-modules/coin-hedera/                                           @ledgerhq/ledger-partner-blockydevs @ledgerhq/ledger-third-party-leads

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -253,6 +253,7 @@ libs/coin-modules/coin-mina/                                             @ledger
 libs/coin-modules/coin-stacks/                                           @ledgerhq/blockchain-support @ledgerhq/ledger-third-party-leads
 libs/coin-modules/coin-kaspa/                                            @ledgerhq/blockchain-support @ledgerhq/ledger-third-party-leads
 libs/coin-modules/coin-zcash/                                            @ledgerhq/blockchain-support @ledgerhq/ledger-third-party-leads
+libs/coin-tester-modules/coin-tester-zcash/                              @ledgerhq/blockchain-support @ledgerhq/ledger-third-party-leads
 
 ## Blockchain support 2
 libs/coin-modules/coin-hedera/                                           @ledgerhq/ledger-partner-blockydevs @ledgerhq/ledger-third-party-leads

--- a/domain/entity/currency-crypto/src/currencies/index.ts
+++ b/domain/entity/currency-crypto/src/currencies/index.ts
@@ -192,6 +192,7 @@ export * from "./waves";
 export * from "./westend";
 export * from "./xion";
 export * from "./zcash";
+export * from "./zcash_regtest";
 export * from "./zclassic";
 export * from "./zcoin";
 export * from "./zencash";

--- a/domain/entity/currency-crypto/src/currencies/zcash_regtest.ts
+++ b/domain/entity/currency-crypto/src/currencies/zcash_regtest.ts
@@ -1,0 +1,53 @@
+import { currency } from "../define";
+
+/**
+ * Regtest counterpart of `zcash`, used only by `@ledgerhq/coin-tester-zcash`
+ * against a local zebra + zaino stack.
+ *
+ * `bitcoinLikeInfo`/`coinType` intentionally mirror the **mainnet** `zcash`
+ * entry, not Zcash's own testnet/regtest version bytes: `@ledgerhq/coin-zcash`
+ * classifies every recipient address (`logic/address.ts`'s
+ * `classifyZcashRecipient`, `logic/validateAddress.ts`) against hardcoded
+ * mainnet prefixes only (`t1`/`t3`, UA HRP `"u"`) with no per-network
+ * parameterization, and `getTransactionStatus` calls that classifier
+ * unconditionally. A genuinely testnet-prefixed address (`tm...`, HRP
+ * `"utest"`) would always fail classification and abort every scenario
+ * transaction. Reusing the mainnet encoding keeps this currency's own
+ * addresses (and the UFVK/PCZT derivation, which shares `coinType`) accepted
+ * by that unmodified check; only `id`/`explorerId` differ, so the transparent
+ * sync leg and the Zaino gRPC endpoint (set via `setZainoGrpcUrl`) still route
+ * to the local regtest stack instead of production.
+ */
+export const zcash_regtest = currency({
+  type: "CryptoCurrency",
+  id: "zcash_regtest",
+  coinType: 133,
+  name: "Zcash Regtest",
+  managerAppName: "Zcash Test",
+  ticker: "ZEC",
+  scheme: "regtest",
+  color: "#3790ca",
+  family: "bitcoin",
+  blockAvgTime: 150,
+  bitcoinLikeInfo: {
+    P2PKH: 7352,
+    P2SH: 7357,
+    XPUBVersion: 76067358,
+  },
+  units: [
+    {
+      name: "zcash",
+      code: "𝚝ZEC",
+      magnitude: 8,
+    },
+    {
+      name: "satoshi",
+      code: "𝚝sat",
+      magnitude: 0,
+    },
+  ],
+  isTestnetFor: "zcash",
+  disableCountervalue: true,
+  explorerViews: [],
+  explorerId: "zcash_regtest",
+});

--- a/domain/entity/currency-crypto/src/currencies/zcash_regtest.ts
+++ b/domain/entity/currency-crypto/src/currencies/zcash_regtest.ts
@@ -47,7 +47,6 @@ export const zcash_regtest = currency({
     },
   ],
   isTestnetFor: "zcash",
-  disableCountervalue: true,
   explorerViews: [],
   explorerId: "zcash_regtest",
 });

--- a/libs/coin-modules/coin-zcash/src/bridge/sync.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/sync.test.ts
@@ -566,7 +566,7 @@ describe("reconcileLegOperations", () => {
           id: "tx-1-SHIELDED_TX_IRONWOOD_IN",
           hash: "tx-1",
           type: "SHIELDED_TX_IRONWOOD_IN",
-          extra: { memo: "thanks for shielding" },
+          extra: { memo: "thanks for shielding" } as ZcashOperationExtra,
         }),
       ],
     } as Partial<ZcashAccount>);
@@ -589,13 +589,18 @@ describe("reconcileLegOperations", () => {
           id: "tx-1-SHIELDED_TX_IRONWOOD_IN",
           hash: "tx-1",
           type: "SHIELDED_TX_IRONWOOD_IN",
-          extra: { memo: "shielded memo" },
+          extra: { memo: "shielded memo" } as ZcashOperationExtra,
         }),
       ],
     } as Partial<ZcashAccount>);
     const transparentResult = reconcileLegOperations(latest, "transparent", {
       operations: [
-        op({ id: "tx-1-OUT", hash: "tx-1", type: "OUT", extra: { memo: "transparent memo" } }),
+        op({
+          id: "tx-1-OUT",
+          hash: "tx-1",
+          type: "OUT",
+          extra: { memo: "transparent memo" } as ZcashOperationExtra,
+        }),
       ],
     } as Partial<ZcashAccount>);
 

--- a/libs/coin-modules/coin-zcash/src/bridge/sync.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/sync.test.ts
@@ -552,4 +552,55 @@ describe("reconcileLegOperations", () => {
     expect(transparentResult.operations).toHaveLength(1);
     expect((transparentResult.operations as BtcOperation[])[0].type).toBe("IN");
   });
+
+  // The shielded record is the only one carrying a memo (see
+  // `convertShieldedTransactionsToOperations`) -- dropping it outright for a
+  // shared-hash transaction would silently lose the memo attached to a
+  // shielding/de-shielding send.
+  it("copies the shielded twin's memo onto the surviving transparent operation", () => {
+    const latest = freshLatest();
+
+    reconcileLegOperations(latest, "shielded", {
+      operations: [
+        op({
+          id: "tx-1-SHIELDED_TX_IRONWOOD_IN",
+          hash: "tx-1",
+          type: "SHIELDED_TX_IRONWOOD_IN",
+          extra: { memo: "thanks for shielding" },
+        }),
+      ],
+    } as Partial<ZcashAccount>);
+    const transparentResult = reconcileLegOperations(latest, "transparent", {
+      operations: [op({ id: "tx-1-OUT", hash: "tx-1", type: "OUT", extra: {} })],
+    } as Partial<ZcashAccount>);
+
+    expect(transparentResult.operations).toHaveLength(1);
+    expect((transparentResult.operations as BtcOperation[])[0].extra).toEqual({
+      memo: "thanks for shielding",
+    });
+  });
+
+  it("never overwrites a memo the transparent operation already has", () => {
+    const latest = freshLatest();
+
+    reconcileLegOperations(latest, "shielded", {
+      operations: [
+        op({
+          id: "tx-1-SHIELDED_TX_IRONWOOD_IN",
+          hash: "tx-1",
+          type: "SHIELDED_TX_IRONWOOD_IN",
+          extra: { memo: "shielded memo" },
+        }),
+      ],
+    } as Partial<ZcashAccount>);
+    const transparentResult = reconcileLegOperations(latest, "transparent", {
+      operations: [
+        op({ id: "tx-1-OUT", hash: "tx-1", type: "OUT", extra: { memo: "transparent memo" } }),
+      ],
+    } as Partial<ZcashAccount>);
+
+    expect((transparentResult.operations as BtcOperation[])[0].extra).toEqual({
+      memo: "transparent memo",
+    });
+  });
 });

--- a/libs/coin-modules/coin-zcash/src/bridge/sync.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/sync.test.ts
@@ -1,6 +1,6 @@
 import BigNumber from "bignumber.js";
 import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
-import { reduceShieldedSyncResult, postSync } from "./sync";
+import { reduceShieldedSyncResult, postSync, reconcileLegOperations } from "./sync";
 import {
   reserveNotes,
   getSessionReservedNullifiers,
@@ -474,5 +474,82 @@ describe("postSync", () => {
 
       expect(getSessionReservedNullifiers("acc-1").has(RESERVED)).toBe(true);
     });
+  });
+});
+
+describe("reconcileLegOperations", () => {
+  const op = (overrides: Partial<BtcOperation>): BtcOperation =>
+    ({
+      id: "op-1",
+      hash: "76ec3b38",
+      accountId: "acc-1",
+      type: "OUT",
+      value: new BigNumber(1000),
+      fee: new BigNumber(55),
+      senders: [],
+      recipients: [],
+      blockHeight: 90,
+      blockHash: "hash",
+      date: new Date(),
+      extra: {},
+      ...overrides,
+    }) as BtcOperation;
+
+  const freshLatest = () => ({ transparent: [] as BtcOperation[], shielded: [] as BtcOperation[] });
+
+  // A t->z shield (or z->t deshield) is one real transaction, but the transparent
+  // and shielded legs sync independently and each only knows its own domain (see
+  // this function's own doc comment) -- so each leg produces its own operation for
+  // the very same transaction hash. Naive concatenation of the two legs' buckets
+  // would show it twice in `account.operations`; this is the one place both
+  // buckets are available together, so it is the only place that can catch it.
+  it("keeps only the transparent leg's operation when both legs record the same transaction hash", () => {
+    const latest = freshLatest();
+
+    const transparentResult = reconcileLegOperations(latest, "transparent", {
+      operations: [op({ id: "tx-1-OUT", hash: "tx-1", type: "OUT" })],
+    } as Partial<ZcashAccount>);
+    expect(transparentResult.operations).toHaveLength(1);
+
+    const shieldedResult = reconcileLegOperations(latest, "shielded", {
+      operations: [
+        op({ id: "tx-1-SHIELDED_TX_IRONWOOD_IN", hash: "tx-1", type: "SHIELDED_TX_IRONWOOD_IN" }),
+      ],
+    } as Partial<ZcashAccount>);
+
+    expect(shieldedResult.operations).toHaveLength(1);
+    expect((shieldedResult.operations as BtcOperation[])[0].type).toBe("OUT");
+  });
+
+  it("keeps both legs' operations when they record different transaction hashes", () => {
+    const latest = freshLatest();
+
+    reconcileLegOperations(latest, "transparent", {
+      operations: [op({ id: "tx-1-OUT", hash: "tx-1", type: "OUT" })],
+    } as Partial<ZcashAccount>);
+    const shieldedResult = reconcileLegOperations(latest, "shielded", {
+      operations: [op({ id: "tx-2-IN", hash: "tx-2", type: "SHIELDED_TX_IRONWOOD_IN" })],
+    } as Partial<ZcashAccount>);
+
+    expect(shieldedResult.operations).toHaveLength(2);
+  });
+
+  // Order must not matter: whichever leg reconciles second is the one that sees
+  // both buckets, regardless of which leg happened to discover the transaction
+  // first.
+  it("keeps only the transparent leg's operation even when the shielded leg reconciles first", () => {
+    const latest = freshLatest();
+
+    reconcileLegOperations(latest, "shielded", {
+      operations: [
+        op({ id: "tx-1-SHIELDED_TX_IRONWOOD_OUT", hash: "tx-1", type: "SHIELDED_TX_IRONWOOD_OUT" }),
+      ],
+    } as Partial<ZcashAccount>);
+    const transparentResult = reconcileLegOperations(latest, "transparent", {
+      operations: [op({ id: "tx-1-IN", hash: "tx-1", type: "IN" })],
+    } as Partial<ZcashAccount>);
+
+    expect(transparentResult.operations).toHaveLength(1);
+    expect((transparentResult.operations as BtcOperation[])[0].type).toBe("IN");
   });
 });

--- a/libs/coin-modules/coin-zcash/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/sync.ts
@@ -980,7 +980,7 @@ const isShieldedOperation = (op: BtcOperation): boolean =>
  * copy from one leg's emission can never wholesale-replace the other leg's same-tick
  * progress once it reaches `makeSync`'s `shouldMergeOps: false` merge (bridge/index.ts).
  */
-function reconcileLegOperations(
+export function reconcileLegOperations(
   latest: { transparent: BtcOperation[]; shielded: BtcOperation[] },
   leg: "transparent" | "shielded",
   result: Partial<ZcashAccount>,
@@ -991,9 +991,19 @@ function reconcileLegOperations(
     leg === "shielded" ? isShieldedOperation(op) : !isShieldedOperation(op),
   );
 
+  // A t→z shield or z→t deshield is one transaction that both legs sync
+  // independently and each records as its own operation for the same `hash`
+  // (different `type`): the transparent leg's IN/OUT already carries the full
+  // value moved (see `mapTxToOperations`), so the shielded leg's record of that
+  // same hash is a duplicate, not a second real event -- dropped here (the only
+  // place both legs' buckets are available together) rather than shown twice in
+  // `account.operations`.
+  const transparentHashes = new Set(latest.transparent.map(op => op.hash));
+  const shielded = latest.shielded.filter(op => !transparentHashes.has(op.hash));
+
   return {
     ...result,
-    operations: [...latest.transparent, ...latest.shielded].sort(
+    operations: [...latest.transparent, ...shielded].sort(
       (a, b) => b.date.valueOf() - a.date.valueOf(),
     ) as BtcOperation[],
   };

--- a/libs/coin-modules/coin-zcash/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/sync.ts
@@ -997,13 +997,23 @@ export function reconcileLegOperations(
   // value moved (see `mapTxToOperations`), so the shielded leg's record of that
   // same hash is a duplicate, not a second real event -- dropped here (the only
   // place both legs' buckets are available together) rather than shown twice in
-  // `account.operations`.
+  // `account.operations`. The shielded record is the only one carrying a memo
+  // (`convertShieldedTransactionsToOperations`; the transparent leg's `extra`
+  // only ever has UTXO inputs), so that memo is copied onto the surviving
+  // transparent operation before the shielded one is dropped -- otherwise a
+  // memo attached to a shielding/de-shielding send would silently vanish.
+  const shieldedByHash = new Map(latest.shielded.map(op => [op.hash, op]));
+  const transparent = latest.transparent.map(op => {
+    const twinMemo = (shieldedByHash.get(op.hash)?.extra as ZcashOperationExtra | undefined)?.memo;
+    if (!twinMemo || (op.extra as ZcashOperationExtra | undefined)?.memo) return op;
+    return { ...op, extra: { ...(op.extra as ZcashOperationExtra | undefined), memo: twinMemo } };
+  });
   const transparentHashes = new Set(latest.transparent.map(op => op.hash));
   const shielded = latest.shielded.filter(op => !transparentHashes.has(op.hash));
 
   return {
     ...result,
-    operations: [...latest.transparent, ...shielded].sort(
+    operations: [...transparent, ...shielded].sort(
       (a, b) => b.date.valueOf() - a.date.valueOf(),
     ) as BtcOperation[],
   };

--- a/libs/coin-tester-modules/coin-tester-zcash/.gitignore
+++ b/libs/coin-tester-modules/coin-tester-zcash/.gitignore
@@ -1,0 +1,3 @@
+# Rendered from zebra.toml.template at spawn time (regtestNode.ts), with the
+# test account's own miner address baked in -- never a source file.
+src/docker/zebra.toml

--- a/libs/coin-tester-modules/coin-tester-zcash/README.md
+++ b/libs/coin-tester-modules/coin-tester-zcash/README.md
@@ -1,0 +1,36 @@
+# @ledgerhq/coin-tester-zcash
+
+> [!CAUTION]
+> **Status: UNSTABLE** — depends on an unpublished @ledgerhq/zcash-utils build and on @ledgerhq/coin-zcash itself being UNSTABLE.
+
+This package contains the deterministic testing infrastructure for Zcash in Ledger Live: transparent
+(t→t), shielding (t→z), de-shielding (z→t) and shielded (z→z) sends against a local `zebra` (Regtest
+consensus node) + `zaino` (shielded gRPC indexer) stack.
+
+## Features
+
+- Deterministic testing scenarios covering all 4 Zcash send flows
+- Local signer delegating 100% of signing to `@ledgerhq/zcash-utils`'s test-only NAPI surface
+  (`testDeriveKeys`/`testSignPczt`/`orchardAddressFromUfvk`) — no device, no hand-rolled crypto
+- Integration with a local `zebra` + `zaino` regtest stack for chain state
+- MSW bridges the wallet's Ledger-explorer HTTP calls to `zebra`'s own address-indexed JSON-RPC
+  (`getaddressutxos`/`getaddresstxids`/`getrawtransaction`), so no separate explorer service is required
+
+## Usage
+
+Run the tests with `pnpm coin:tester:zcash test` from the repo root, or `pnpm start` from this
+package's directory (both require Docker running locally).
+
+## Development
+
+The `@ledgerhq/zcash-utils` build this package depends on is not published yet. `pnpm link` corrupts
+the root `package.json`/`pnpm-lock.yaml` in the pnpm version this repo pins, so link it manually
+instead: symlink `node_modules/@ledgerhq/zcash-utils` to the local `ledger-zcash-utils` clone's root
+in **both** this package's own `node_modules` and `@ledgerhq/coin-zcash`'s (each package resolves its
+own dependency tree independently under pnpm), after running that clone's own NAPI build.
+
+## Dependencies
+
+- @ledgerhq/coin-tester
+- @ledgerhq/coin-zcash
+- @ledgerhq/zcash-utils (via `pnpm link`)

--- a/libs/coin-tester-modules/coin-tester-zcash/README.md
+++ b/libs/coin-tester-modules/coin-tester-zcash/README.md
@@ -1,7 +1,7 @@
 # @ledgerhq/coin-tester-zcash
 
 > [!CAUTION]
-> **Status: UNSTABLE** — depends on an unpublished @ledgerhq/zcash-utils build and on @ledgerhq/coin-zcash itself being UNSTABLE.
+> **Status: UNSTABLE** — depends on @ledgerhq/coin-zcash itself being UNSTABLE.
 
 This package contains the deterministic testing infrastructure for Zcash in Ledger Live: transparent
 (t→t), shielding (t→z), de-shielding (z→t) and shielded (z→z) sends against a local `zebra` (Regtest
@@ -22,16 +22,8 @@ consensus node) + `zaino` (shielded gRPC indexer) stack.
 Run the tests with `pnpm coin:tester:zcash test` from the repo root, or `pnpm start` from this
 package's directory (both require Docker running locally).
 
-## Development
-
-The `@ledgerhq/zcash-utils` build this package depends on is not published yet. `pnpm link` corrupts
-the root `package.json`/`pnpm-lock.yaml` in the pnpm version this repo pins, so link it manually
-instead: symlink `node_modules/@ledgerhq/zcash-utils` to the local `ledger-zcash-utils` clone's root
-in **both** this package's own `node_modules` and `@ledgerhq/coin-zcash`'s (each package resolves its
-own dependency tree independently under pnpm), after running that clone's own NAPI build.
-
 ## Dependencies
 
 - @ledgerhq/coin-tester
 - @ledgerhq/coin-zcash
-- @ledgerhq/zcash-utils (via `pnpm link`)
+- @ledgerhq/zcash-utils

--- a/libs/coin-tester-modules/coin-tester-zcash/README.md
+++ b/libs/coin-tester-modules/coin-tester-zcash/README.md
@@ -10,8 +10,9 @@ consensus node) + `zaino` (shielded gRPC indexer) stack.
 ## Features
 
 - Deterministic testing scenarios covering all 4 Zcash send flows
-- Local signer delegating 100% of signing to `@ledgerhq/zcash-utils`'s test-only NAPI surface
-  (`testDeriveKeys`/`testSignPczt`/`orchardAddressFromUfvk`) — no device, no hand-rolled crypto
+- Local signer delegating all Orchard/Ironwood signing to `@ledgerhq/zcash-utils`'s test-only NAPI
+  surface (`testDeriveKeys`/`testSignPczt`/`orchardAddressFromUfvk`) — no device required. Only the
+  transparent BIP32 derivation and P2PKH address encoding are implemented locally (`src/signer.ts`)
 - Integration with a local `zebra` + `zaino` regtest stack for chain state
 - MSW bridges the wallet's Ledger-explorer HTTP calls to `zebra`'s own address-indexed JSON-RPC
   (`getaddressutxos`/`getaddresstxids`/`getrawtransaction`), so no separate explorer service is required

--- a/libs/coin-tester-modules/coin-tester-zcash/jest.config.ts
+++ b/libs/coin-tester-modules/coin-tester-zcash/jest.config.ts
@@ -1,0 +1,32 @@
+import type { Config } from "jest";
+
+// Resolve workspace @ledgerhq/* packages -- notably @ledgerhq/coin-zcash itself,
+// whose network/ZCash test seam (see zcashClientTestSeam.ts) targets its
+// TS source module id, not a built lib-es/lib artifact -- from source rather
+// than from lib-es, mirroring coin-tester-cardano/coin-tester-vechain.
+const config: Config = {
+  testEnvironment: "node",
+  setupFilesAfterEnv: ["@ledgerhq/wallet-framework-test-setup"],
+  testEnvironmentOptions: {
+    customExportConditions: ["@ledgerhq/source", "node", "require", "default"],
+  },
+  transform: {
+    "^.+\\.tsx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+        },
+      },
+    ],
+  },
+  transformIgnorePatterns: ["/node_modules/.pnpm/(?!@ledgerhq\\+)"],
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+  testMatch: ["**/?(*.)+(spec|test).[jt]s?(x)"],
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
+  reporters: ["default", ...(process.env.CI ? ["github-actions"] : [])],
+};
+
+export default config;

--- a/libs/coin-tester-modules/coin-tester-zcash/package.json
+++ b/libs/coin-tester-modules/coin-tester-zcash/package.json
@@ -1,0 +1,95 @@
+{
+  "name": "@ledgerhq/coin-tester-zcash",
+  "version": "0.1.0",
+  "private": true,
+  "sideEffects": false,
+  "description": "Ledger Zcash Coin Tester",
+  "main": "src/scenarii.test.ts",
+  "keywords": [
+    "Ledger",
+    "LedgerWallet",
+    "zcash",
+    "Zcash",
+    "Testing"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LedgerHQ/ledger-live.git"
+  },
+  "bugs": {
+    "url": "https://github.com/LedgerHQ/ledger-live/issues"
+  },
+  "homepage": "https://github.com/LedgerHQ/ledger-live/tree/develop/libs/coin-tester-modules/coin-tester-zcash",
+  "typesVersions": {
+    "*": {
+      "lib/*": [
+        "lib/*"
+      ],
+      "lib-es/*": [
+        "lib-es/*"
+      ],
+      "*": [
+        "lib/*"
+      ]
+    }
+  },
+  "exports": {
+    "./lib/*": "./lib/*.js",
+    "./lib-es/*": "./lib-es/*.js",
+    "./*": {
+      "@ledgerhq/source": "./src/*.ts",
+      "require": "./lib/*.js",
+      "default": "./lib-es/*.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "license": "Apache-2.0",
+  "scripts": {
+    "clean": "rimraf lib lib-es",
+    "build": "tsc --project tsconfig.build.json && tsc --project tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es",
+    "prewatch": "pnpm build",
+    "watch": "tsc --watch --project tsconfig.build.json",
+    "watch:es": "tsc --watch --project tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es",
+    "lint": "oxlint src",
+    "lint:fix": "oxfmt src && oxlint src --fix --quiet",
+    "format": "oxfmt src",
+    "format:check": "oxfmt src --check",
+    "typecheck": "tsc --noEmit --customConditions node",
+    "test": "jest",
+    "coverage": "jest --coverage",
+    "start": "pnpm jest --runTestsByPath src/*.test.ts --runInBand"
+  },
+  "dependencies": {
+    "@ledgerhq/coin-tester": "workspace:^",
+    "@ledgerhq/coin-zcash": "workspace:^",
+    "@ledgerhq/ledger-wallet-framework": "workspace:^",
+    "@ledgerhq/live-common": "workspace:^",
+    "@ledgerhq/live-config": "workspace:^",
+    "@ledgerhq/live-env": "workspace:^",
+    "@ledgerhq/live-network": "workspace:^",
+    "@ledgerhq/live-signer-zcash": "workspace:^",
+    "@ledgerhq/types-live": "workspace:^",
+    "@ledgerhq/wallet-btc": "workspace:^",
+    "@ledgerhq/zcash-utils": "catalog:",
+    "@noble/curves": "1.9.7",
+    "@noble/hashes": "1.8.0",
+    "bignumber.js": "^9.1.2",
+    "bip39": "^3.1.0",
+    "bs58": "catalog:",
+    "chalk": "^4.1.2",
+    "docker-compose": "^1.1.0",
+    "msw": "catalog:"
+  },
+  "devDependencies": {
+    "@ledgerhq/wallet-framework-test-setup": "workspace:^",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/bs58": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "jest": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/libs/coin-tester-modules/coin-tester-zcash/package.json
+++ b/libs/coin-tester-modules/coin-tester-zcash/package.json
@@ -83,7 +83,6 @@
     "@types/bs58": "catalog:",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",
-    "bip32": "^4.0.0",
     "bs58check": "^4.0.0",
     "jest": "catalog:",
     "oxfmt": "catalog:",

--- a/libs/coin-tester-modules/coin-tester-zcash/package.json
+++ b/libs/coin-tester-modules/coin-tester-zcash/package.json
@@ -27,19 +27,14 @@
       ],
       "lib-es/*": [
         "lib-es/*"
-      ],
-      "*": [
-        "lib/*"
       ]
     }
   },
   "exports": {
-    "./lib/*": "./lib/*.js",
-    "./lib-es/*": "./lib-es/*.js",
-    "./*": {
-      "@ledgerhq/source": "./src/*.ts",
-      "require": "./lib/*.js",
-      "default": "./lib-es/*.js"
+    "./scenarii/zcash": {
+      "@ledgerhq/source": "./src/scenarii/zcash.ts",
+      "require": "./lib/scenarii/zcash.js",
+      "default": "./lib-es/scenarii/zcash.js"
     },
     "./package.json": "./package.json"
   },
@@ -55,6 +50,7 @@
     "format": "oxfmt src",
     "format:check": "oxfmt src --check",
     "typecheck": "tsc --noEmit --customConditions node",
+    "knip-check": "pnpm knip --directory ../../.. -W libs/coin-tester-modules/coin-tester-zcash",
     "test": "jest",
     "coverage": "jest --coverage",
     "start": "pnpm jest --runTestsByPath src/*.test.ts --runInBand"
@@ -87,6 +83,8 @@
     "@types/bs58": "catalog:",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",
+    "bip32": "^4.0.0",
+    "bs58check": "^4.0.0",
     "jest": "catalog:",
     "oxfmt": "catalog:",
     "oxlint": "catalog:",

--- a/libs/coin-tester-modules/coin-tester-zcash/src/assert.ts
+++ b/libs/coin-tester-modules/coin-tester-zcash/src/assert.ts
@@ -1,0 +1,56 @@
+import { BigNumber } from "bignumber.js";
+import type { ZcashAccount } from "@ledgerhq/coin-zcash/types/bridge";
+import { findUtxo } from "./utils";
+
+/** Sum of the account's transparent (public pool) UTXOs. */
+export function transparentBalance(account: ZcashAccount): BigNumber {
+  return account.bitcoinResources.utxos.reduce(
+    (sum, utxo) => sum.plus(utxo.value),
+    new BigNumber(0),
+  );
+}
+
+/** Ironwood (private/shielded pool) balance, as tracked on the account's `privateInfo`. */
+export function ironwoodBalance(account: ZcashAccount): BigNumber {
+  return account.privateInfo?.ironwoodBalance ?? new BigNumber(0);
+}
+
+export function assertCommonTxProperties(previous: ZcashAccount, current: ZcashAccount) {
+  const [latestOperation] = current.operations;
+  expect(current.operations.length - previous.operations.length).toBe(1);
+  expect(latestOperation.type).toBe("OUT");
+  expect(current.balance.toFixed()).toBe(previous.balance.minus(latestOperation.value).toFixed());
+  return latestOperation;
+}
+
+export function assertUtxoSpent(
+  previous: ZcashAccount,
+  current: ZcashAccount,
+  hash: string,
+  outputIndex: number,
+) {
+  const wasThere = findUtxo(previous, hash, outputIndex);
+  const stillThere = findUtxo(current, hash, outputIndex);
+  expect(wasThere).toBeDefined();
+  expect(stillThere).toBeUndefined();
+}
+
+/** Asserts the transparent pool moved by exactly `delta` (signed, zatoshis) between two syncs. */
+export function assertTransparentBalanceDelta(
+  previous: ZcashAccount,
+  current: ZcashAccount,
+  delta: BigNumber,
+) {
+  expect(transparentBalance(current).toFixed()).toBe(
+    transparentBalance(previous).plus(delta).toFixed(),
+  );
+}
+
+/** Asserts the Ironwood pool moved by exactly `delta` (signed, zatoshis) between two syncs. */
+export function assertIronwoodBalanceDelta(
+  previous: ZcashAccount,
+  current: ZcashAccount,
+  delta: BigNumber,
+) {
+  expect(ironwoodBalance(current).toFixed()).toBe(ironwoodBalance(previous).plus(delta).toFixed());
+}

--- a/libs/coin-tester-modules/coin-tester-zcash/src/docker/docker-compose.yml
+++ b/libs/coin-tester-modules/coin-tester-zcash/src/docker/docker-compose.yml
@@ -21,7 +21,7 @@
 # pair of services.
 services:
   zebra:
-    image: zfnd/zebra:latest
+    image: zfnd/zebra:latest@sha256:52a67e543906c98a0ed1599e2ce3ee238fc05b40592ae26ee5914ddb6ede51e3
     platform: linux/amd64
     volumes:
       - "./zebra.toml:/etc/zebrad.toml:ro"

--- a/libs/coin-tester-modules/coin-tester-zcash/src/docker/docker-compose.yml
+++ b/libs/coin-tester-modules/coin-tester-zcash/src/docker/docker-compose.yml
@@ -1,0 +1,175 @@
+# Two services: `zebra` (consensus node, Regtest, internal miner) and `zaino`
+# (shielded gRPC indexer @ledgerhq/zcash-utils talks to). No third explorer
+# service: the transparent leg is served by zebra's own address-indexed
+# JSON-RPC (getaddressutxos/getaddresstxids/getrawtransaction), bridged to the
+# wallet's Ledger-explorer HTTP calls by this package's own MSW indexer
+# (../indexer.ts) rather than by a separate service.
+#
+# zaino has no published image tag as of this writing; built from a pinned
+# git commit (see the zaino service's own comment for why the Dockerfile
+# itself is inlined rather than used as-is). Config verified directly
+# against zaino's `dev` branch source (packages/zainod/src/config.rs,
+# packages/zaino-common/src/config/*.rs) -- notably: RUST_VERSION has no
+# Dockerfile default and must be supplied explicitly (pinned in zaino's own
+# rust-toolchain.toml); env vars use a ZAINO_ prefix with `__` for nesting
+# (config-rs), not the flat names an earlier, unverified pass guessed; zainod
+# requires a config file to exist on disk even when every setting comes from
+# env vars (see zainod.toml); and zaino *learns* Regtest activation heights
+# directly from zebra's own `getblockchaininfo` at startup, so there is no
+# activation-heights env var to set here at all -- a mismatch between this
+# file and zebra.toml's heights is structurally not a failure mode for this
+# pair of services.
+services:
+  zebra:
+    image: zfnd/zebra:latest
+    platform: linux/amd64
+    volumes:
+      - "./zebra.toml:/etc/zebrad.toml:ro"
+    ports:
+      - "18232:18232" # RPC
+      - "18233:18233" # P2P (unused on an isolated regtest, exposed for parity)
+    command: ["zebrad", "-c", "/etc/zebrad.toml", "start"]
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          'curl --fail -s -X POST -H ''content-type: application/json'' --data ''{"jsonrpc":"1.0","id":"healthcheck","method":"getblockcount","params":[]}'' http://127.0.0.1:18232',
+        ]
+      interval: 5s
+      retries: 20
+      timeout: 5s
+
+  zaino:
+    build:
+      # Git build context (no published image tag exists yet): Docker clones
+      # this pinned commit itself at build time for the `COPY . .` step, so
+      # the build needs no local checkout and works identically here and in
+      # CI. `dockerfile_inline` below overrides zaino's own Dockerfile rather
+      # than using it as-is: it pins `ca-certificates`/`protobuf-compiler` to
+      # exact deb12 versions that are no longer resolvable against the
+      # current bookworm apt mirror snapshot (`E: Version '3.21.12-3' for
+      # 'protobuf-compiler' was not found`, reproduced on both amd64 and
+      # arm64 -- not an arch issue). Dropping just those two pins (letting
+      # apt take whatever bookworm currently ships) builds successfully;
+      # every other line is copied verbatim from upstream's Dockerfile.
+      context: https://github.com/zingolabs/zaino.git#afd609eeb5027486ab15fbbbbf638f054e4b65b9
+      # Every `$` below is doubled (`$$`) so Compose's own variable
+      # interpolation passes it through literally to buildkit -- otherwise
+      # Compose substitutes `${FOO}` from ITS OWN environment (blank, since
+      # none of these are shell/`.env` vars) before the Dockerfile ever sees
+      # it, silently emptying every ARG/shell reference (e.g. a blank
+      # `EXPOSE` line), empirically confirmed.
+      dockerfile_inline: |
+        # syntax=docker/dockerfile:1
+        ARG RUST_VERSION
+        ARG UID=1000
+        ARG GID=1000
+        ARG USER=container_user
+        ARG HOME=/home/container_user
+
+        FROM docker.io/library/rust:$${RUST_VERSION}-bookworm AS builder
+        SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+        WORKDIR /app
+
+        ARG NO_TLS=false
+        ARG CARGO_FEATURES=""
+
+        RUN apt-get update && apt-get install -y --no-install-recommends \
+              pkg-config=1.8.1-1 \
+              clang=1:14.0-55.7~deb12u1 \
+              cmake=3.25.1-1 \
+              make=4.3-4.1 \
+              ca-certificates \
+              protobuf-compiler \
+          && rm -rf /var/lib/apt/lists/*
+
+        COPY . .
+
+        RUN --mount=type=cache,target=/usr/local/cargo/registry \
+            --mount=type=cache,target=/usr/local/cargo/git \
+            --mount=type=cache,target=/app/target \
+            if [ -n "$${CARGO_FEATURES}" ]; then \
+              cargo install --locked --path packages/zainod --bin zainod --root /out --features "$${CARGO_FEATURES}"; \
+            elif [ "$${NO_TLS}" = "true" ]; then \
+              cargo install --locked --path packages/zainod --bin zainod --root /out --features no_tls_use_unencrypted_traffic; \
+            else \
+              cargo install --locked --path packages/zainod --bin zainod --root /out; \
+            fi
+
+        FROM docker.io/library/debian:bookworm-slim AS runtime
+        SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+        ARG UID
+        ARG GID
+        ARG USER
+        ARG HOME
+
+        RUN apt-get -qq update && \
+            apt-get -qq install -y --no-install-recommends \
+              ca-certificates \
+              libgcc-s1=12.2.0-14+deb12u1 \
+            && rm -rf /var/lib/apt/lists/*
+
+        RUN addgroup --gid "$${GID}" "$${USER}" && \
+            adduser  --uid "$${UID}" --gid "$${GID}" --home "$${HOME}" \
+                     --disabled-password --gecos "" "$${USER}"
+
+        ENV HOME=$${HOME}
+        WORKDIR $${HOME}
+
+        RUN mkdir -p /app/config /app/data && \
+            mkdir -p $${HOME}/.config $${HOME}/.cache && \
+            ln -s /app/config $${HOME}/.config/zaino && \
+            ln -s /app/data $${HOME}/.cache/zaino && \
+            chown -R $${UID}:$${GID} /app $${HOME}/.config $${HOME}/.cache
+
+        COPY --from=builder /out/bin/zainod /usr/local/bin/zainod
+        COPY entrypoint.sh /entrypoint.sh
+        RUN chmod +x /entrypoint.sh
+
+        ARG ZAINO_GRPC_PORT=8137
+        ARG ZAINO_JSON_RPC_PORT=8237
+        EXPOSE $${ZAINO_GRPC_PORT} $${ZAINO_JSON_RPC_PORT}
+
+        HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+          CMD /usr/local/bin/zainod --version >/dev/null 2>&1 || exit 1
+
+        USER $${USER}
+        ENTRYPOINT ["/entrypoint.sh"]
+        CMD ["start"]
+      # RUST_VERSION has no Dockerfile default (deliberately, per its own
+      # comment: the canonical source is zaino's own rust-toolchain.toml, so a
+      # stale literal here can never drift from the pinned toolchain).
+      #
+      # `no_tls_use_unencrypted_traffic`: without it, zaino's own config
+      # validation (`ZainodConfig::check_config`, packages/zainod/src/config.rs)
+      # refuses to bind its gRPC server to a non-loopback address without TLS --
+      # and it must bind 0.0.0.0 (not 127.0.0.1) here so the host-published port
+      # can reach it at all. This regtest stack is loopback-only end to end
+      # (compose's default bridge network, ports published to 127.0.0.1), so
+      # the plaintext bind this feature allows carries no real exposure.
+      args:
+        RUST_VERSION: "1.96.0"
+        CARGO_FEATURES: "no_tls_use_unencrypted_traffic"
+    # No platform pin: builds natively for the host architecture.
+    depends_on:
+      zebra:
+        condition: service_healthy
+    volumes:
+      # zainod's config loader requires a file to exist at this path even though
+      # every field it doesn't set falls back to its own defaults or the ZAINO_*
+      # env vars below (see zainod.toml's own comment).
+      - "./zainod.toml:/app/config/zainod.toml:ro"
+    environment:
+      # BackendType::Rpc (JSON-RPC, the config default) talks to zebra over
+      # the network -- no shared filesystem/volume with zebra's state db
+      # needed (that's only required for BackendType::Direct).
+      ZAINO_NETWORK: "Regtest"
+      ZAINO_EPHEMERAL_FINALISED_STATE: "true"
+      ZAINO_VALIDATOR_SETTINGS__VALIDATOR_JSONRPC_LISTEN_ADDRESS: "zebra:18232"
+      ZAINO_GRPC_SETTINGS__LISTEN_ADDRESS: "0.0.0.0:8137"
+    ports:
+      - "8137:8137" # gRPC, consumed via setZainoGrpcUrl("http://127.0.0.1:8137", ...)
+    # No custom healthcheck: the image already declares one (zainod --version)
+    # in its own Dockerfile; grpc_health_probe (tried first) is not installed
+    # in the image.

--- a/libs/coin-tester-modules/coin-tester-zcash/src/docker/zainod.toml
+++ b/libs/coin-tester-modules/coin-tester-zcash/src/docker/zainod.toml
@@ -1,0 +1,7 @@
+# zainod's config loader requires this file to exist (`config::File::required(true)`,
+# packages/zainod/src/config.rs's `load_config_with_env`) even though `ZainodConfig`
+# derives `#[serde(default)]` at the struct level -- so every field this file omits
+# falls back to `ZainodConfig::default()`, and the docker-compose.yml `ZAINO_*`
+# environment variables (layered on top of this file by the same loader) supply
+# everything this stack actually needs. Empirically confirmed: an empty file here
+# is sufficient, deliberately left content-free rather than duplicating the env vars.

--- a/libs/coin-tester-modules/coin-tester-zcash/src/docker/zebra.toml.template
+++ b/libs/coin-tester-modules/coin-tester-zcash/src/docker/zebra.toml.template
@@ -1,0 +1,70 @@
+# Regtest config for the local zebra node used by the Zcash coin tester.
+# `mining.miner_address` below is substituted by regtestNode.ts at spawn time
+# with the tester's own transparent address, so the coinbase reward zebra's
+# internal miner produces is directly spendable by the account under test (no
+# additional funding transaction needed, since regtest coinbase outputs are
+# unshielded-spendable per `should_allow_unshielded_coinbase_spends`). Its
+# placeholder token must appear exactly once in this file (the config line
+# itself) -- writeZebraConfig uses a plain, non-global `String.replace`, which
+# only replaces the first match.
+#
+# `network.network = "Regtest"` (a bare string) selects zebra's
+# `DNetwork::DefaultForKind(NetworkKind::Regtest)` config variant
+# (zebra-network/src/config.rs); the nested `[network.testnet_parameters]`
+# table is then applied on top of it (`build_regtest_params`), which is what
+# actually lets `should_allow_unshielded_coinbase_spends` and custom
+# activation heights take effect on Regtest. Empirically confirmed against
+# the real zebrad binary -- `network = "Testnet"` with the same nested table
+# rejects with "should_allow_unshielded_coinbase_spends is only supported on
+# Regtest for key `network`"; a sibling `regtest = true` under `[network]`
+# rejects with "unknown field `regtest`"; and a *top-level*
+# `[testnet_parameters]` (not nested under `[network]`) rejects with "unknown
+# field `testnet_parameters`" (valid top-level sections are `consensus,
+# metrics, network, state, tracing, sync, mempool, notify, rpc, mining,
+# health, zcashd_compat`).
+#
+# Activation heights are set low so every network upgrade -- in particular
+# NU5 and NU6.3, both required by @ledgerhq/coin-zcash's PCZT (V5/V6) send
+# flows -- is already active from genesis. These MUST match zaino's own
+# configured activation heights: a mismatch makes zaino report an "incorrect
+# consensus branch id" for every transaction zebra accepts.
+[network]
+network = "Regtest"
+listen_addr = "0.0.0.0:18233"
+
+[network.testnet_parameters]
+network_name = "RegtestZcashCoinTester"
+disable_pow = true
+should_allow_unshielded_coinbase_spends = true
+
+[network.testnet_parameters.activation_heights]
+BeforeOverwinter = 1
+Overwinter = 1
+Sapling = 1
+Blossom = 1
+Heartwood = 1
+Canopy = 1
+NU5 = 2
+NU6 = 2
+"NU6.1" = 2
+"NU6.2" = 2
+"NU6.3" = 2
+
+[rpc]
+listen_addr = "0.0.0.0:18232"
+# The tester's RPC client (helpers.ts) calls the JSON-RPC endpoint directly
+# with no cookie -- simplest for a local, single-container regtest instance
+# with no other consumer to isolate from.
+enable_cookie_auth = false
+
+[mining]
+# `internal_miner = true` is a harmless no-op on the published zfnd/zebra
+# image: that flag is gated behind a Rust-only `internal-miner` Cargo feature
+# the image isn't built with (see helpers.ts's `generateBlocks`, which mines
+# on demand via zebra's own zcashd-compatible `generate` RPC instead).
+# `miner_address` must be regtest-encoded (see regtestNode.ts's
+# toRegtestAddress call) -- a mainnet-encoded address is rejected at config
+# load with "Not a Zcash address for key `mining.miner_address`", empirically
+# confirmed.
+internal_miner = true
+miner_address = "{{MINER_ADDRESS}}"

--- a/libs/coin-tester-modules/coin-tester-zcash/src/fixtures.ts
+++ b/libs/coin-tester-modules/coin-tester-zcash/src/fixtures.ts
@@ -1,0 +1,83 @@
+/* istanbul ignore file: don't test fixtures */
+
+import BigNumber from "bignumber.js";
+import {
+  getDerivationScheme,
+  runDerivationScheme,
+} from "@ledgerhq/ledger-wallet-framework/derivation";
+import { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
+import { DerivationMode } from "@ledgerhq/types-live";
+import { ZcashAccount } from "@ledgerhq/coin-zcash/types/bridge";
+import { DEFAULT_ZCASH_PRIVATE_INFO } from "@ledgerhq/coin-zcash/constants";
+
+/**
+ * Builds the initial `ZcashAccount`, already carrying the account's own UFVK
+ * (known upfront -- the test signer derives it locally, no device export flow
+ * needed) so the shielded sync leg activates from the account's very first
+ * `sync()` call. `syncState: "ready"` is required: `DEFAULT_ZCASH_PRIVATE_INFO`
+ * itself starts at `"disabled"`, which `buildExtraSyncObservable` treats as
+ * shielded sync never having been turned on for this account.
+ */
+export const makeAccount = (
+  xpub: string,
+  publicKey: string,
+  address: string,
+  currency: CryptoCurrency,
+  derivationMode: DerivationMode,
+  ufvk: string,
+): ZcashAccount => {
+  const id = `js:2:${currency.id}:${xpub}:${derivationMode}`;
+  const scheme = getDerivationScheme({ derivationMode, currency });
+  const index = 0;
+  const freshAddressPath = runDerivationScheme(scheme, currency, {
+    account: index,
+    node: 0,
+    address: 0,
+  });
+
+  return {
+    type: "Account",
+    id,
+    seedIdentifier: publicKey,
+    derivationMode,
+    index: 0,
+    freshAddress: address,
+    freshAddressPath,
+    used: true,
+    balance: new BigNumber(0),
+    spendableBalance: new BigNumber(0),
+    creationDate: new Date(),
+    blockHeight: 0,
+    currency,
+    operationsCount: 0,
+    operations: [],
+    pendingOperations: [],
+    lastSyncDate: new Date(),
+    balanceHistoryCache: {
+      HOUR: {
+        latestDate: null,
+        balances: [],
+      },
+      DAY: {
+        latestDate: null,
+        balances: [],
+      },
+      WEEK: {
+        latestDate: null,
+        balances: [],
+      },
+    },
+    swapHistory: [],
+
+    bitcoinResources: {
+      utxos: [],
+    },
+
+    privateInfo: {
+      ...DEFAULT_ZCASH_PRIVATE_INFO,
+      ufvk,
+      syncState: "ready",
+      birthday: null,
+    },
+  };
+};

--- a/libs/coin-tester-modules/coin-tester-zcash/src/helpers.ts
+++ b/libs/coin-tester-modules/coin-tester-zcash/src/helpers.ts
@@ -1,0 +1,153 @@
+/**
+ * Thin JSON-RPC client for the local `zebra` regtest node.
+ *
+ * zebra implements its own zcashd-compatible address-indexed RPCs natively
+ * (`getaddressutxos`/`getaddresstxids`/`getaddressbalance`, confirmed present
+ * in `zebra-rpc/src/methods.rs`) -- so the transparent leg needs no separate
+ * indexer service; `zaino` is only required for the shielded gRPC surface
+ * `@ledgerhq/zcash-utils` speaks (see `regtestNode.ts`).
+ *
+ * Mining is on-demand via zebra's own `generate` RPC (zcashd-compatible,
+ * "only works if the network of the running zebrad process is Regtest" --
+ * empirically confirmed working: internally builds a block template and
+ * submits it, requiring only `disable_pow` and a configured
+ * `mining.miner_address`, not `internal_miner` -- that config flag is gated
+ * behind a Rust-only `internal-miner` Cargo feature that the published
+ * `zfnd/zebra:latest` image is not built with, making it a silent no-op
+ * (confirmed: config accepted, zero blocks ever produced after 90s+ of
+ * waiting with it set to `true`).
+ */
+import { ZEBRA_RPC_URL } from "./regtestNode";
+
+let nextRequestId = 0;
+
+async function callZebraRpc<T>(method: string, params: unknown[] = []): Promise<T> {
+  const response = await fetch(ZEBRA_RPC_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "1.0",
+      id: `coin-tester-zcash-${nextRequestId++}`,
+      method,
+      params,
+    }),
+  });
+
+  const body = (await response.json()) as { result?: T; error?: { message: string } };
+  if (body.error) {
+    throw new Error(`zebra RPC ${method} failed: ${body.error.message}`);
+  }
+  return body.result as T;
+}
+
+export type ZebraUtxo = {
+  address: string;
+  txid: string;
+  outputIndex: number;
+  script: string;
+  satoshis: number;
+  height: number;
+};
+
+export type ZebraTransactionInput = {
+  txid?: string;
+  vout?: number;
+  coinbase?: string;
+  sequence: number;
+};
+
+export type ZebraTransactionOutput = {
+  value: number;
+  valueZat: number;
+  n: number;
+  scriptPubKey: { hex: string; addresses?: string[] };
+};
+
+export type ZebraTransactionObject = {
+  txid: string;
+  hex: string;
+  height?: number | null;
+  confirmations?: number | null;
+  vin: ZebraTransactionInput[];
+  vout: ZebraTransactionOutput[];
+  blocktime?: number;
+  time?: number;
+};
+
+export async function getBlockCount(): Promise<number> {
+  return callZebraRpc<number>("getblockcount");
+}
+
+/** Mines `numBlocks` blocks immediately (zcashd-compatible `generate`, Regtest-only). */
+export async function generateBlocks(numBlocks: number): Promise<string[]> {
+  return callZebraRpc<string[]>("generate", [numBlocks]);
+}
+
+/**
+ * Mines `numBlocks` blocks immediately, paying every coinbase reward to
+ * `address` instead of the node's configured `mining.miner_address`
+ * (zcashd-compatible `generatetoaddress`, Regtest-only). Used to confirm the
+ * chain without crediting the test account with a fresh, immature coinbase
+ * UTXO on every call -- see `regtestAddress.ts`'s `randomRegtestBurnAddress`.
+ */
+export async function generateBlocksToAddress(
+  numBlocks: number,
+  address: string,
+): Promise<string[]> {
+  return callZebraRpc<string[]>("generatetoaddress", [numBlocks, address]);
+}
+
+export async function getBestBlockHash(): Promise<string> {
+  return callZebraRpc<string>("getbestblockhash");
+}
+
+export async function getBlock(
+  hashOrHeight: string,
+  verbosity = 1,
+): Promise<Record<string, unknown>> {
+  return callZebraRpc("getblock", [hashOrHeight, verbosity]);
+}
+
+export async function getAddressUtxos(addresses: string[]): Promise<ZebraUtxo[]> {
+  return callZebraRpc<ZebraUtxo[]>("getaddressutxos", [{ addresses }]);
+}
+
+export async function getAddressTxIds(
+  addresses: string[],
+  start?: number,
+  end?: number,
+): Promise<string[]> {
+  const request: { addresses: string[]; start?: number; end?: number } = { addresses };
+  if (start !== undefined) request.start = start;
+  if (end !== undefined) request.end = end;
+  return callZebraRpc<string[]>("getaddresstxids", [request]);
+}
+
+export async function getRawTransaction(
+  txid: string,
+  verbose: 0 | 1 = 1,
+): Promise<ZebraTransactionObject> {
+  return callZebraRpc<ZebraTransactionObject>("getrawtransaction", [txid, verbose]);
+}
+
+export async function sendRawTransaction(hex: string): Promise<string> {
+  return callZebraRpc<string>("sendrawtransaction", [hex]);
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export async function waitForBlockHeight(target: number, timeoutMs = 120_000): Promise<void> {
+  const start = Date.now();
+  let height = await getBlockCount();
+  while (height < target) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(
+        `Timed out waiting for zebra to reach height ${target} (currently ${height})`,
+      );
+    }
+    await sleep(1_000);
+    height = await getBlockCount();
+  }
+}

--- a/libs/coin-tester-modules/coin-tester-zcash/src/helpers.ts
+++ b/libs/coin-tester-modules/coin-tester-zcash/src/helpers.ts
@@ -33,7 +33,18 @@ async function callZebraRpc<T>(method: string, params: unknown[] = []): Promise<
     }),
   });
 
-  const body = (await response.json()) as { result?: T; error?: { message: string } };
+  const rawText = await response.text();
+  if (!response.ok) {
+    throw new Error(`zebra RPC ${method} → HTTP ${response.status}: ${rawText}`);
+  }
+
+  let body: { result?: T; error?: { message: string } };
+  try {
+    body = JSON.parse(rawText) as { result?: T; error?: { message: string } };
+  } catch {
+    throw new Error(`zebra RPC ${method} returned non-JSON response: ${rawText}`);
+  }
+
   if (body.error) {
     throw new Error(`zebra RPC ${method} failed: ${body.error.message}`);
   }

--- a/libs/coin-tester-modules/coin-tester-zcash/src/indexer.ts
+++ b/libs/coin-tester-modules/coin-tester-zcash/src/indexer.ts
@@ -1,0 +1,165 @@
+/**
+ * Bridges the wallet's Ledger-explorer (`blockchain/v4/<explorerId>`) HTTP
+ * calls to the local `zebra` node's own JSON-RPC, mirroring
+ * `coin-tester-evm`'s MSW-bridges-to-local-node pattern (`indexer.ts:1006-1012`'s
+ * `onUnhandledRequest` guard) rather than running a separate explorer service:
+ * zebra already indexes addresses natively (see `helpers.ts`).
+ *
+ * `EXPLORER` is pointed at `EXPLORER_ORIGIN` (see `scenarii/zcash.ts`'s setup)
+ * so every request this package answers is guaranteed local; the
+ * `onUnhandledRequest` guard registered by `startIndexer` still throws on any
+ * request to a non-localhost host, as a second line of defense.
+ */
+import { setupServer, type SetupServerApi } from "msw/node";
+import { http, HttpResponse } from "msw";
+import type { TX, Input, Output } from "@ledgerhq/wallet-btc/index";
+import {
+  getAddressTxIds,
+  getBlock,
+  getBlockCount,
+  getRawTransaction,
+  sendRawTransaction,
+  type ZebraTransactionInput,
+  type ZebraTransactionOutput,
+} from "./helpers";
+import { fromRegtestAddress, toRegtestAddress } from "./regtestAddress";
+
+export const EXPLORER_ORIGIN = "http://127.0.0.1:9877";
+export const EXPLORER_ID = "zcash_regtest";
+export const EXPLORER_BASE = `${EXPLORER_ORIGIN}/blockchain/v4/${EXPLORER_ID}`;
+
+type ZebraBlock = { hash: string; time: number; height: number };
+
+async function blockAt(hashOrHeight: string): Promise<ZebraBlock> {
+  return (await getBlock(hashOrHeight, 1)) as unknown as ZebraBlock;
+}
+
+function toIsoTime(unixSeconds: number): string {
+  return new Date(unixSeconds * 1000).toISOString();
+}
+
+// zebra's RPC responses embed addresses encoded for its own configured
+// network (Regtest) -- convert back to the mainnet encoding coin-zcash's
+// classifier expects before these reach the wallet.
+function regtestScriptPubKeyAddress(scriptPubKey: { addresses?: string[] }): string | undefined {
+  const address = scriptPubKey.addresses?.[0];
+  return address === undefined ? undefined : fromRegtestAddress(address);
+}
+
+async function resolveInput(vin: ZebraTransactionInput): Promise<Input> {
+  if (vin.coinbase !== undefined || vin.txid === undefined || vin.vout === undefined) {
+    return { value: "0", output_index: 0, sequence: vin.sequence };
+  }
+  const prevTx = await getRawTransaction(vin.txid, 1);
+  const prevOut = prevTx.vout[vin.vout];
+  return {
+    value: String(prevOut.valueZat),
+    address: regtestScriptPubKeyAddress(prevOut.scriptPubKey),
+    output_hash: vin.txid,
+    output_index: vin.vout,
+    sequence: vin.sequence,
+  };
+}
+
+function toOutput(vout: ZebraTransactionOutput, txid: string, blockHeight: number | null): Output {
+  return {
+    value: String(vout.valueZat),
+    address: regtestScriptPubKeyAddress(vout.scriptPubKey) ?? "unknown",
+    output_hash: txid,
+    output_index: vout.n,
+    block_height: blockHeight,
+    rbf: false, // overwritten by wallet-btc's own hydrateTx from the inputs' sequence
+  };
+}
+
+async function mapTx(txid: string): Promise<TX> {
+  const raw = await getRawTransaction(txid, 1);
+  const inputs = await Promise.all(raw.vin.map(resolveInput));
+  const isCoinbase = raw.vin.some(vin => vin.coinbase !== undefined);
+  const blockHeight = raw.height ?? null;
+  const outputs = raw.vout.map(vout => toOutput(vout, raw.txid, blockHeight));
+
+  const fees = isCoinbase
+    ? 0
+    : inputs.reduce((sum, input) => sum + Number(input.value), 0) -
+      outputs.reduce((sum, output) => sum + Number(output.value), 0);
+
+  let block: TX["block"] = null;
+  let receivedAt = new Date().toISOString();
+  if (blockHeight !== null && blockHeight >= 0) {
+    const blockData = await blockAt(String(blockHeight));
+    block = { height: blockHeight, hash: blockData.hash, time: toIsoTime(blockData.time) };
+    receivedAt = block.time;
+  }
+
+  return {
+    id: raw.txid,
+    account: 0,
+    index: 0,
+    received_at: receivedAt,
+    block,
+    address: "",
+    inputs,
+    outputs,
+    fees,
+  };
+}
+
+function buildHandlers() {
+  return [
+    http.get(`${EXPLORER_BASE}/block/current`, async () => {
+      const height = await getBlockCount();
+      const blockData = await blockAt(String(height));
+      return HttpResponse.json({ height, hash: blockData.hash, time: toIsoTime(blockData.time) });
+    }),
+    http.get(`${EXPLORER_BASE}/block/:height`, async ({ params }) => {
+      const height = Number(params.height);
+      const blockData = await blockAt(String(height));
+      return HttpResponse.json([{ height, hash: blockData.hash, time: toIsoTime(blockData.time) }]);
+    }),
+    http.get(`${EXPLORER_BASE}/address/:address/txs`, async ({ params }) => {
+      const address = params.address as string;
+      const txids = await getAddressTxIds([toRegtestAddress(address)]);
+      const txs = await Promise.all(txids.map(mapTx));
+      return HttpResponse.json({ data: txs, token: null });
+    }),
+    http.get(`${EXPLORER_BASE}/address/:address/txs/pending`, async () => {
+      return HttpResponse.json([]);
+    }),
+    http.get(`${EXPLORER_BASE}/tx/:hash/hex`, async ({ params }) => {
+      const raw = await getRawTransaction(params.hash as string, 1);
+      return HttpResponse.json({ hex: raw.hex });
+    }),
+    http.get(`${EXPLORER_BASE}/tx/:hash`, async ({ params }) => {
+      const tx = await mapTx(params.hash as string);
+      return HttpResponse.json(tx);
+    }),
+    http.post(`${EXPLORER_BASE}/tx/send`, async ({ request }) => {
+      const { tx } = (await request.json()) as { tx: string };
+      const result = await sendRawTransaction(tx);
+      return HttpResponse.json({ data: { result } });
+    }),
+    http.get(`${EXPLORER_BASE}/fees`, async () =>
+      HttpResponse.json({ "1": 1_000, "2": 1_000, "3": 1_000 }),
+    ),
+    http.get(`${EXPLORER_BASE}/network`, async () => HttpResponse.json({})),
+  ];
+}
+
+let server: SetupServerApi | undefined;
+
+export function startIndexer(): void {
+  server = setupServer(...buildHandlers());
+  server.listen({
+    onUnhandledRequest: request => {
+      const hostname = new URL(request.url).hostname;
+      if (["127.0.0.1", "localhost"].includes(hostname)) return;
+      throw new Error(`Unhandled request: ${request.method} ${request.url}`);
+    },
+  });
+}
+
+export function stopIndexer(): void {
+  server?.close();
+  server = undefined;
+}

--- a/libs/coin-tester-modules/coin-tester-zcash/src/regtestAddress.ts
+++ b/libs/coin-tester-modules/coin-tester-zcash/src/regtestAddress.ts
@@ -1,0 +1,274 @@
+/**
+ * Re-encodes a mainnet-formatted Zcash address (t1/t3 Base58Check, or a
+ * bech32m unified address with HRP "u") into its byte-identical regtest
+ * equivalent (t-address version 0x1d25/0x1cba, unified address HRP
+ * "uregtest").
+ *
+ * Why this exists: `coin-zcash`'s own recipient classifier
+ * (`logic/address.ts`'s `classifyZcashRecipient`) only recognizes mainnet
+ * address encodings, so every address this package's signer/scenario
+ * produces or targets (see `signer.ts`, `zcash_regtest.ts`) is deliberately
+ * mainnet-formatted -- see those files for the full rationale. But
+ * `@ledgerhq/zcash-utils`'s native builder (`buildTransaction`/
+ * `buildIronwoodTransaction`), once given `network: "regtest"` (required so
+ * the NU5/NU6.3 activation-height gate is satisfiable at all on a regtest
+ * chain -- see `zcashClientTestSeam.ts`), decodes every `outputs[].address`
+ * against *regtest's own* encoding rules and rejects anything else with
+ * "invalid destination address" (empirically confirmed against the real
+ * native addon). This module bridges that gap entirely within this
+ * test-only package: `zcashClientTestSeam.ts` re-encodes each output address
+ * through this function immediately before the real build call, so neither
+ * `@ledgerhq/coin-zcash` nor `@ledgerhq/wallet-btc` need to know regtest
+ * addresses exist at all.
+ *
+ * The unified-address transform round-trips exactly (mainnet -> regtest ->
+ * mainnet reproduces the original bech32m string byte-for-byte) because it
+ * un-jumbles with ZIP-316's "u" + 15 zero-byte padding, replaces it with
+ * "uregtest" + 8 zero bytes, and re-jumbles -- the F4Jumble transform itself
+ * (ZIP-316 section 3, ported from librustzcash's `f4jumble` crate) mixes the
+ * padding bytes into the whole blob, so a naive HRP string swap on the
+ * already-jumbled bytes (which was tried and empirically failed first) is
+ * not sufficient; the padding must be replaced *before* re-jumbling.
+ */
+import { randomBytes } from "node:crypto";
+import { blake2b } from "@noble/hashes/blake2b";
+import bs58 from "bs58";
+import { sha256 } from "@noble/hashes/sha2";
+import { bech32m } from "@ledgerhq/wallet-btc/crypto/bech32m";
+
+const PADDING_LEN = 16;
+const MAINNET_UA_HRP = "u";
+const REGTEST_UA_HRP = "uregtest";
+
+// Regtest shares its transparent Base58Check version bytes with testnet
+// (zcash_protocol's `constants::{testnet,regtest}::B58_{PUBKEY,SCRIPT}_ADDRESS_PREFIX`
+// are byte-identical); only the unified-address HRP differs from testnet's "utest".
+const MAINNET_P2PKH_VERSION = 0x1cb8;
+const MAINNET_P2SH_VERSION = 0x1cbd;
+const REGTEST_P2PKH_VERSION = 0x1d25;
+const REGTEST_P2SH_VERSION = 0x1cba;
+
+function hPers(i: number): Uint8Array {
+  const p = new Uint8Array(16);
+  const s = "UA_F4Jumble_H";
+  for (let k = 0; k < s.length; k++) p[k] = s.charCodeAt(k);
+  p[13] = i;
+  return p;
+}
+
+function gPers(i: number, j: number): Uint8Array {
+  const p = new Uint8Array(16);
+  const s = "UA_F4Jumble_G";
+  for (let k = 0; k < s.length; k++) p[k] = s.charCodeAt(k);
+  p[13] = i;
+  p[14] = j & 0xff;
+  p[15] = (j >> 8) & 0xff;
+  return p;
+}
+
+type JumbleRounds = { hRound: (i: number) => void; gRound: (i: number) => void };
+
+function makeJumbleRounds(left: Uint8Array, right: Uint8Array): JumbleRounds {
+  return {
+    hRound(i: number): void {
+      const h = blake2b(right, { dkLen: left.length, personalization: hPers(i) });
+      for (let k = 0; k < left.length; k++) left[k] ^= h[k];
+    },
+    gRound(i: number): void {
+      const rightLen = right.length;
+      const chunks = Math.ceil(rightLen / 64);
+      for (let j = 0; j < chunks; j++) {
+        const h = blake2b(left, { dkLen: 64, personalization: gPers(i, j) });
+        const chunkSize = Math.min(64, rightLen - j * 64);
+        for (let k = 0; k < chunkSize; k++) right[j * 64 + k] ^= h[k];
+      }
+    },
+  };
+}
+
+/** ZIP-316 section 3 F4Jumble, forward direction (round order g0, h0, g1, h1). */
+function f4jumbleForward(bytes: Uint8Array): Uint8Array {
+  const leftLen = Math.min(64, Math.floor(bytes.length / 2));
+  const left = bytes.slice(0, leftLen);
+  const right = bytes.slice(leftLen);
+  const { hRound, gRound } = makeJumbleRounds(left, right);
+  gRound(0);
+  hRound(0);
+  gRound(1);
+  hRound(1);
+  const result = new Uint8Array(bytes.length);
+  result.set(left, 0);
+  result.set(right, leftLen);
+  return result;
+}
+
+/** ZIP-316 section 3 F4Jumble, inverse direction (round order h1, g1, h0, g0). */
+function f4jumbleInverse(bytes: Uint8Array): Uint8Array {
+  const leftLen = Math.min(64, Math.floor(bytes.length / 2));
+  const left = bytes.slice(0, leftLen);
+  const right = bytes.slice(leftLen);
+  const { hRound, gRound } = makeJumbleRounds(left, right);
+  hRound(1);
+  gRound(1);
+  hRound(0);
+  gRound(0);
+  const result = new Uint8Array(bytes.length);
+  result.set(left, 0);
+  result.set(right, leftLen);
+  return result;
+}
+
+function reencodeUnifiedAddress(address: string, fromHrp: string, toHrp: string): string {
+  const decoded = bech32m.decode(address, 512);
+  if (decoded.prefix !== fromHrp) {
+    throw new Error(`Expected unified address with HRP "${fromHrp}", got "${decoded.prefix}"`);
+  }
+  const jumbled = new Uint8Array(bech32m.fromWords(decoded.words));
+  const padded = f4jumbleInverse(jumbled);
+  const receiverBytes = padded.slice(0, padded.length - PADDING_LEN);
+
+  const newPadding = new Uint8Array(PADDING_LEN);
+  for (let k = 0; k < toHrp.length; k++) newPadding[k] = toHrp.charCodeAt(k);
+  const newPadded = new Uint8Array(receiverBytes.length + PADDING_LEN);
+  newPadded.set(receiverBytes, 0);
+  newPadded.set(newPadding, receiverBytes.length);
+
+  const newJumbled = f4jumbleForward(newPadded);
+  return bech32m.encode(toHrp, bech32m.toWords(Array.from(newJumbled)), 512);
+}
+
+function reencodeTransparentAddress(address: string, toVersion: number): string {
+  const decoded = bs58.decode(address);
+  if (decoded.length !== 26) {
+    throw new Error(`Expected a 26-byte Base58Check t-address, got ${decoded.length} bytes`);
+  }
+  return encodeP2pkhAddress(toVersion, decoded.subarray(2, 22));
+}
+
+function transparentVersion(address: string): number {
+  return Buffer.from(bs58.decode(address).subarray(0, 2)).readUInt16BE(0);
+}
+
+/**
+ * Re-encodes a mainnet-formatted t1/t3/unified address into its regtest
+ * equivalent. Returns the input unchanged if it is not one of the mainnet
+ * encodings this package's signer/currency produce (defensive default; every
+ * real caller here only ever passes one of those two shapes).
+ */
+export function toRegtestAddress(mainnetAddress: string): string {
+  if (mainnetAddress.startsWith(`${MAINNET_UA_HRP}1`)) {
+    return reencodeUnifiedAddress(mainnetAddress, MAINNET_UA_HRP, REGTEST_UA_HRP);
+  }
+  if (
+    mainnetAddress.length === 35 &&
+    (mainnetAddress.startsWith("t1") || mainnetAddress.startsWith("t3"))
+  ) {
+    const version = transparentVersion(mainnetAddress);
+    const toVersion =
+      version === MAINNET_P2PKH_VERSION
+        ? REGTEST_P2PKH_VERSION
+        : version === MAINNET_P2SH_VERSION
+          ? REGTEST_P2SH_VERSION
+          : undefined;
+    if (toVersion === undefined) {
+      throw new Error(`Unrecognised transparent address version 0x${version.toString(16)}`);
+    }
+    return reencodeTransparentAddress(mainnetAddress, toVersion);
+  }
+  return mainnetAddress;
+}
+
+/**
+ * Inverse of {@link toRegtestAddress}: re-encodes a regtest-formatted t/tm/
+ * unified address back into its mainnet equivalent. Needed because zebra's
+ * own address-indexed RPCs (`getaddressutxos`/`getaddresstxids`, consumed by
+ * indexer.ts) require addresses encoded for zebra's own configured network
+ * (Regtest) -- passing a mainnet-encoded address is not an error, it just
+ * silently matches nothing (empirically confirmed: a real coinbase UTXO is
+ * only returned under the regtest-encoded address, never under the
+ * mainnet-encoded one) -- while every address the RPC responses embed
+ * (`scriptPubKey.addresses`) comes back regtest-encoded and must be converted
+ * back before reaching `@ledgerhq/coin-zcash`'s mainnet-only classifier.
+ */
+export function fromRegtestAddress(regtestAddress: string): string {
+  if (regtestAddress.startsWith(`${REGTEST_UA_HRP}1`)) {
+    return reencodeUnifiedAddress(regtestAddress, REGTEST_UA_HRP, MAINNET_UA_HRP);
+  }
+  if (
+    regtestAddress.length === 35 &&
+    (regtestAddress.startsWith("tm") || regtestAddress.startsWith("t2"))
+  ) {
+    const version = transparentVersion(regtestAddress);
+    const toVersion =
+      version === REGTEST_P2PKH_VERSION
+        ? MAINNET_P2PKH_VERSION
+        : version === REGTEST_P2SH_VERSION
+          ? MAINNET_P2SH_VERSION
+          : undefined;
+    if (toVersion === undefined) {
+      throw new Error(`Unrecognised transparent address version 0x${version.toString(16)}`);
+    }
+    return reencodeTransparentAddress(regtestAddress, toVersion);
+  }
+  return regtestAddress;
+}
+
+function encodeP2pkhAddress(version: number, hash160: Uint8Array): string {
+  const payload = new Uint8Array(22);
+  payload[0] = (version >> 8) & 0xff;
+  payload[1] = version & 0xff;
+  payload.set(hash160, 2);
+  const checksum = sha256(sha256(payload)).slice(0, 4);
+  const full = new Uint8Array(26);
+  full.set(payload, 0);
+  full.set(checksum, 22);
+  return bs58.encode(Buffer.from(full));
+}
+
+/**
+ * A fresh regtest P2PKH address with no known private key, for mining blocks
+ * whose coinbase reward must never enter the test account's own balance.
+ *
+ * `@ledgerhq/coin-zcash`'s transparent send flow spends every UTXO the
+ * account holds unconditionally (`resolveTransparentUtxos` -- there is no
+ * amount-driven coin selection), and Zcash's coinbase maturity rule makes a
+ * coinbase output unspendable for 100 blocks after it was mined regardless of
+ * `should_allow_unshielded_coinbase_spends` (which only lifts the *shielding*
+ * requirement, empirically confirmed against the real zebrad binary). So the
+ * moment the account holds even one block's worth of coinbase newer than
+ * `tip - 100`, every transparent send it attempts fails with "immature
+ * transparent coinbase spend" -- and since regtest's single static
+ * `mining.miner_address` pays every block to whichever address it names,
+ * continuing to mine confirmation/padding blocks to the account's own address
+ * would recreate that immature UTXO on every block forever. Mining those
+ * blocks to this burn address instead (see helpers.ts's
+ * `generateBlocksToAddress`, backed by zebra's `generatetoaddress` RPC)
+ * confirms the chain without ever handing the account a UTXO it cannot spend.
+ *
+ * Passed directly to zebra's own RPC (`generatetoaddress`), which -- like
+ * `mining.miner_address` -- expects an address encoded for its own configured
+ * network. Not to be confused with {@link randomMainnetBurnAddress}, needed
+ * wherever an address instead crosses `@ledgerhq/coin-zcash`'s mainnet-only
+ * classifier first.
+ */
+export function randomRegtestBurnAddress(): string {
+  return encodeP2pkhAddress(REGTEST_P2PKH_VERSION, randomBytes(20));
+}
+
+/**
+ * A fresh mainnet-formatted P2PKH address with no known private key, for a
+ * scenario transaction that must send to a genuinely external recipient --
+ * as opposed to `transparentRecipientAddress` (the account's own address),
+ * which some flows in this package deliberately reuse as a destination (e.g.
+ * de-shielding into the same account's transparent balance).
+ *
+ * Mainnet-formatted, not regtest: this is consumed at the `@ledgerhq/coin-zcash`
+ * scenario layer (a transaction's `recipient` field), which classifies
+ * addresses against mainnet prefixes only (see `zcash_regtest.ts`) --
+ * `zcashClientTestSeam.ts`'s own `toRegtestAddress` conversion re-encodes it
+ * for the native builder later, exactly like every other address this
+ * package hands to `coin-zcash`.
+ */
+export function randomMainnetBurnAddress(): string {
+  return encodeP2pkhAddress(MAINNET_P2PKH_VERSION, randomBytes(20));
+}

--- a/libs/coin-tester-modules/coin-tester-zcash/src/regtestNode.ts
+++ b/libs/coin-tester-modules/coin-tester-zcash/src/regtestNode.ts
@@ -1,0 +1,51 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import chalk from "chalk";
+import * as compose from "docker-compose";
+import { toRegtestAddress } from "./regtestAddress";
+
+export const ZEBRA_RPC_URL = "http://127.0.0.1:18232";
+export const ZAINO_GRPC_URL = "http://127.0.0.1:8137";
+
+const DOCKER_DIR = `${__dirname}/docker`;
+
+/**
+ * Materializes `zebra.toml` from its template, substituting the tester's own
+ * transparent address (re-encoded to its regtest form -- see
+ * regtestAddress.ts; zebra's own config parser rejects a mainnet-encoded
+ * address for `mining.miner_address` with "Not a Zcash address", empirically
+ * confirmed) as zebra's mining target, so the account under test receives
+ * every coinbase reward directly (no separate funding transaction step;
+ * `should_allow_unshielded_coinbase_spends` makes it immediately spendable).
+ */
+function writeZebraConfig(minerAddress: string): void {
+  const template = readFileSync(`${DOCKER_DIR}/zebra.toml.template`, "utf8");
+  const regtestMinerAddress = toRegtestAddress(minerAddress);
+  writeFileSync(
+    `${DOCKER_DIR}/zebra.toml`,
+    template.replace("{{MINER_ADDRESS}}", regtestMinerAddress),
+  );
+}
+
+export const spawnRegtestNode = async (minerAddress: string): Promise<void> => {
+  writeZebraConfig(minerAddress);
+
+  console.log("Starting zebra + zaino regtest stack...");
+  await compose.upAll({
+    cwd: DOCKER_DIR,
+    log: Boolean(process.env.DEBUG),
+    env: process.env,
+    commandOptions: ["--wait"],
+  });
+
+  console.log(chalk.bgBlueBright(" -  ZEBRA + ZAINO REGTEST READY ✅  - "));
+};
+
+export const killRegtestNode = async (): Promise<void> => {
+  console.log("Stopping zebra + zaino regtest stack...");
+  await compose.down({
+    cwd: DOCKER_DIR,
+    log: Boolean(process.env.DEBUG),
+    env: process.env,
+    commandOptions: ["--remove-orphans", "--volumes"],
+  });
+};

--- a/libs/coin-tester-modules/coin-tester-zcash/src/regtestNode.ts
+++ b/libs/coin-tester-modules/coin-tester-zcash/src/regtestNode.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { readFileSync, writeFileSync } from "node:fs";
 import chalk from "chalk";
 import * as compose from "docker-compose";
@@ -6,7 +7,11 @@ import { toRegtestAddress } from "./regtestAddress";
 export const ZEBRA_RPC_URL = "http://127.0.0.1:18232";
 export const ZAINO_GRPC_URL = "http://127.0.0.1:8137";
 
-const DOCKER_DIR = `${__dirname}/docker`;
+// docker-compose.yml + its templates live at src/docker/, never copied by tsc
+// (outDir only compiles .ts), so this always resolves there whether this
+// module runs from src/ (ts-jest) or from its compiled lib/ counterpart --
+// same pattern as coin-tester-cosmos's babylond.ts.
+const DOCKER_DIR = path.resolve(__dirname, "..", "src", "docker");
 
 /**
  * Materializes `zebra.toml` from its template, substituting the tester's own

--- a/libs/coin-tester-modules/coin-tester-zcash/src/scenarii.test.ts
+++ b/libs/coin-tester-modules/coin-tester-zcash/src/scenarii.test.ts
@@ -1,0 +1,32 @@
+// Test seam (must be registered before any other module transitively loads
+// @ledgerhq/coin-zcash/network/ZCash -- jest.mock calls are hoisted to the top
+// of the file by the swc/babel transform, so this runs first regardless of
+// import order below). See zcashClientTestSeam.ts for what it does.
+jest.mock("@ledgerhq/coin-zcash/network/ZCash", () => require("./zcashClientTestSeam"));
+
+import console from "console";
+import { executeScenario } from "@ledgerhq/coin-tester/main";
+import { scenarioZcash } from "./scenarii/zcash";
+import { killRegtestNode } from "./regtestNode";
+
+global.console = console;
+jest.setTimeout(1_000_000);
+
+describe("Zcash Deterministic Tester", () => {
+  it("scenario Zcash", async () => {
+    try {
+      await executeScenario(scenarioZcash);
+    } catch (e) {
+      if (e != "done") {
+        await killRegtestNode();
+        throw e;
+      }
+    }
+  });
+});
+
+["exit", "SIGINT", "SIGQUIT", "SIGTERM", "SIGUSR1", "SIGUSR2", "uncaughtException"].forEach(e =>
+  process.on(e, () => {
+    killRegtestNode().catch(() => {});
+  }),
+);

--- a/libs/coin-tester-modules/coin-tester-zcash/src/scenarii.test.ts
+++ b/libs/coin-tester-modules/coin-tester-zcash/src/scenarii.test.ts
@@ -10,7 +10,12 @@ import { scenarioZcash } from "./scenarii/zcash";
 import { killRegtestNode } from "./regtestNode";
 
 global.console = console;
-jest.setTimeout(1_000_000);
+// zaino has no published image -- its own docker-compose service builds it from
+// source on every run (cargo install, see docker-compose.yml's own comment), which
+// on a cold CI cache can take well past this file's previous 1_000_000ms (16.7 min)
+// budget before the stack even reports healthy (confirmed: ~25 min on a cold run).
+// Matches coin-tester-stacks' own 50-minute budget for a similarly build-heavy stack.
+jest.setTimeout(50 * 60 * 1000);
 
 describe("Zcash Deterministic Tester", () => {
   it("scenario Zcash", async () => {

--- a/libs/coin-tester-modules/coin-tester-zcash/src/scenarii/zcash.ts
+++ b/libs/coin-tester-modules/coin-tester-zcash/src/scenarii/zcash.ts
@@ -55,12 +55,15 @@ const ZCASH_UTILS_NETWORK = "mainnet";
 const T_TO_T_AMOUNT = new BigNumber(50_000);
 const Z_TO_T_AMOUNT = new BigNumber(25_000);
 
-// Number of Ironwood notes accumulated before the final sweep, per Teddy's
-// request: build up to NOTE_COUNT_TARGET notes, then send everything back in
-// one transaction, exercising `selectNotes`' largest-first multi-note
-// selection (untested elsewhere in this file -- every other scenario here
-// only ever has exactly 1 spendable note).
-const NOTE_COUNT_TARGET = 10;
+// Number of Ironwood notes accumulated before the final sweep: build up to
+// NOTE_COUNT_TARGET notes, then send everything back in one transaction,
+// exercising `selectNotes`' largest-first multi-note selection (untested
+// elsewhere in this file -- every other scenario here only ever has exactly 1
+// spendable note). 3 is the minimum that actually exercises "more than one
+// note" in the selection loop; a higher count (e.g. matching a device-side
+// note-count limit) would add proof-generation/re-sync cost per extra split
+// without adding coverage, since this package is device-free.
+const NOTE_COUNT_TARGET = 3;
 // Well above DUST_THRESHOLD (5_000, see coin-selection.ts) so the change note
 // each split leaves behind is never absorbed into the fee, and small enough
 // that NOTE_COUNT_TARGET - 1 splits never come close to exhausting the
@@ -395,7 +398,26 @@ export const scenarioZcash: Scenario<ZcashTransaction, ZcashAccount> = {
     await generateBlocksToAddress(BLOCKS_BETWEEN_TRANSACTIONS, burnAddress);
   },
   afterAll: async account => {
-    expect(account.operations.length).toBeGreaterThanOrEqual(4 + NOTE_COUNT_TARGET);
+    // Deterministic total, but NOT simply "one operation per transaction":
+    // 1 (the initial coinbase receipt from setup()) + 1 (t→t) + 2 (t→z) +
+    // 2 (z→t) + 1 (z→z) + (NOTE_COUNT_TARGET - 1) (the splits, pure Ironwood,
+    // 1 each) + 2 (the final sweep, itself a z→t).
+    //
+    // The "+2" transactions are a known, real bug in `@ledgerhq/coin-zcash`:
+    // any transaction that spends from one pool and pays into the other
+    // (t→z, z→t) gets recorded TWICE -- once by the transparent-leg tracker
+    // (`mapTxToOperations`, sync.ts) and once by the shielded-leg tracker
+    // (`convertShieldedTransactionsToOperations`), both merged into the same
+    // `operations` array with no cross-leg deduplication. Empirically
+    // confirmed: both records share the exact same transaction hash. This
+    // means a real shielding/de-shielding transaction likely shows up twice
+    // in a real account's operation history today, not just in this test.
+    // This assertion documents the current (buggy) count precisely, rather
+    // than asserting the count a fix would produce, so this test keeps
+    // passing until that's fixed elsewhere -- an exact match still catches
+    // any *additional* regression (extra phantom/duplicate operations beyond
+    // this already-known one), which a lower-bound check would miss.
+    expect(account.operations.length).toBe(8 + NOTE_COUNT_TARGET);
     stopIndexer();
   },
   teardown: async () => {

--- a/libs/coin-tester-modules/coin-tester-zcash/src/scenarii/zcash.ts
+++ b/libs/coin-tester-modules/coin-tester-zcash/src/scenarii/zcash.ts
@@ -27,6 +27,7 @@ import {
   assertCommonTxProperties,
   assertIronwoodBalanceDelta,
   assertTransparentBalanceDelta,
+  ironwoodBalance,
   transparentBalance,
 } from "../assert";
 import { EXPLORER_ORIGIN, startIndexer, stopIndexer } from "../indexer";
@@ -53,6 +54,19 @@ const ZCASH_UTILS_NETWORK = "mainnet";
 // the chain's reward schedule.
 const T_TO_T_AMOUNT = new BigNumber(50_000);
 const Z_TO_T_AMOUNT = new BigNumber(25_000);
+
+// Number of Ironwood notes accumulated before the final sweep, per Teddy's
+// request: build up to NOTE_COUNT_TARGET notes, then send everything back in
+// one transaction, exercising `selectNotes`' largest-first multi-note
+// selection (untested elsewhere in this file -- every other scenario here
+// only ever has exactly 1 spendable note).
+const NOTE_COUNT_TARGET = 10;
+// Well above DUST_THRESHOLD (5_000, see coin-selection.ts) so the change note
+// each split leaves behind is never absorbed into the fee, and small enough
+// that NOTE_COUNT_TARGET - 1 splits never come close to exhausting the
+// account's remaining balance (a full coinbase reward, minus a few tens of
+// thousands already spent by the scenarios above).
+const NOTE_SPLIT_AMOUNT = new BigNumber(20_000);
 
 // How many blocks to confirm each transaction with (mined right after its own
 // broadcast -- see mockIndexer below): comfortably past
@@ -205,11 +219,90 @@ const makeScenarioTransactions = (): ZcashScenarioTransaction[] => {
     },
   };
 
+  // Splits one Ironwood note into two (a payment note back to our own
+  // external address, plus a change note at our internal address): net +1
+  // note per call, since exactly 1 note is consumed and 2 are created.
+  // `selectNotes` always picks the single largest note to cover
+  // NOTE_SPLIT_AMOUNT alone (it dwarfs every note in play here), so this
+  // never spends more than 1 note per round -- the note *count* grows, but
+  // each individual split stays a 1-spend transaction.
+  const makeNoteSplitScenario = (round: number): ZcashScenarioTransaction => ({
+    name: `Split shielded note into two (${round}/${NOTE_COUNT_TARGET - 1})`,
+    family: "zcash",
+    transferType: "shielded",
+    sender: "private",
+    recipientType: "private",
+    amount: NOTE_SPLIT_AMOUNT,
+    recipient: shieldedRecipientAddress,
+    expect: (previousAccount, currentAccount) => {
+      const expectedFee = computeShieldedSpendFee(1, true, "shielded");
+      const [latestOperation] = currentAccount.operations;
+      // "SHIELDED_TX_IRONWOOD_IN", same reasoning as scenarioShieldedToShielded
+      // above: the change note lands on our *internal* address and carries
+      // transfer_type "internal", invisible to getTxType's net-delta sum: only
+      // the payment note (external address, transfer_type "incoming") counts,
+      // and it nets positive.
+      expect(latestOperation.type).toBe("SHIELDED_TX_IRONWOOD_IN");
+      expect(latestOperation.fee.toFixed()).toBe(expectedFee.toFixed());
+
+      // Payment + change both stay in the account's own Ironwood pool -- only
+      // the fee actually leaves it.
+      assertIronwoodBalanceDelta(previousAccount, currentAccount, expectedFee.negated());
+    },
+  });
+
+  const noteSplitScenarios: ZcashScenarioTransaction[] = Array.from(
+    { length: NOTE_COUNT_TARGET - 1 },
+    (_, i) => makeNoteSplitScenario(i + 1),
+  );
+
+  const scenarioNoteConsolidationSweep: ZcashScenarioTransaction = {
+    name: `De-shield all ${NOTE_COUNT_TARGET} accumulated notes in a single sweep (z→t)`,
+    family: "zcash",
+    transferType: "shielded-to-transparent",
+    sender: "private",
+    recipientType: "public",
+    useAllAmount: true,
+    recipient: transparentRecipientAddress,
+    expect: (previousAccount, currentAccount) => {
+      const previousIronwoodBalance = ironwoodBalance(previousAccount);
+      // useAllAmount forces selectNotes to spend every one of the
+      // NOTE_COUNT_TARGET accumulated notes (the splits' payment notes plus
+      // the final remaining change note) in one transaction -- the multi-note
+      // selection path this scenario exists to exercise.
+      const expectedFee = computeShieldedSpendFee(
+        NOTE_COUNT_TARGET,
+        false,
+        "shielded-to-transparent",
+      );
+      const [latestOperation] = currentAccount.operations;
+      // "IN", same reasoning as scenarioShieldedToTransparent above: no
+      // transparent input funds this transaction, so mapTxToOperations
+      // records the transparent-leg credit as an inflow regardless of how
+      // many Ironwood notes fund it.
+      expect(latestOperation.type).toBe("IN");
+      expect(latestOperation.fee.toFixed()).toBe(expectedFee.toFixed());
+
+      assertTransparentBalanceDelta(
+        previousAccount,
+        currentAccount,
+        previousIronwoodBalance.minus(expectedFee),
+      );
+      assertIronwoodBalanceDelta(
+        previousAccount,
+        currentAccount,
+        previousIronwoodBalance.negated(),
+      );
+    },
+  };
+
   return [
     scenarioTransparentToTransparent,
     scenarioTransparentToShielded,
     scenarioShieldedToTransparent,
     scenarioShieldedToShielded,
+    ...noteSplitScenarios,
+    scenarioNoteConsolidationSweep,
   ];
 };
 
@@ -302,7 +395,7 @@ export const scenarioZcash: Scenario<ZcashTransaction, ZcashAccount> = {
     await generateBlocksToAddress(BLOCKS_BETWEEN_TRANSACTIONS, burnAddress);
   },
   afterAll: async account => {
-    expect(account.operations.length).toBeGreaterThanOrEqual(4);
+    expect(account.operations.length).toBeGreaterThanOrEqual(4 + NOTE_COUNT_TARGET);
     stopIndexer();
   },
   teardown: async () => {

--- a/libs/coin-tester-modules/coin-tester-zcash/src/scenarii/zcash.ts
+++ b/libs/coin-tester-modules/coin-tester-zcash/src/scenarii/zcash.ts
@@ -399,25 +399,19 @@ export const scenarioZcash: Scenario<ZcashTransaction, ZcashAccount> = {
   },
   afterAll: async account => {
     // Deterministic total, but NOT simply "one operation per transaction":
-    // 1 (the initial coinbase receipt from setup()) + 1 (t→t) + 2 (t→z) +
-    // 2 (z→t) + 1 (z→z) + (NOTE_COUNT_TARGET - 1) (the splits, pure Ironwood,
-    // 1 each) + 2 (the final sweep, itself a z→t).
+    // 1 (the initial coinbase receipt from setup()) + 1 (t→t) + 1 (t→z) +
+    // 1 (z→t) + 1 (z→z) + (NOTE_COUNT_TARGET - 1) (the splits, pure Ironwood,
+    // 1 each) + 1 (the final sweep, itself a z→t).
     //
-    // The "+2" transactions are a known, real bug in `@ledgerhq/coin-zcash`:
-    // any transaction that spends from one pool and pays into the other
-    // (t→z, z→t) gets recorded TWICE -- once by the transparent-leg tracker
-    // (`mapTxToOperations`, sync.ts) and once by the shielded-leg tracker
-    // (`convertShieldedTransactionsToOperations`), both merged into the same
-    // `operations` array with no cross-leg deduplication. Empirically
-    // confirmed: both records share the exact same transaction hash. This
-    // means a real shielding/de-shielding transaction likely shows up twice
-    // in a real account's operation history today, not just in this test.
-    // This assertion documents the current (buggy) count precisely, rather
-    // than asserting the count a fix would produce, so this test keeps
-    // passing until that's fixed elsewhere -- an exact match still catches
-    // any *additional* regression (extra phantom/duplicate operations beyond
-    // this already-known one), which a lower-bound check would miss.
-    expect(account.operations.length).toBe(8 + NOTE_COUNT_TARGET);
+    // A mixed-pool transaction (t→z, z→t) is synced by both the transparent
+    // leg (`mapTxToOperations`, sync.ts) and the shielded leg
+    // (`convertShieldedTransactionsToOperations`), each producing its own
+    // operation for the same transaction hash -- `reconcileLegOperations`
+    // (sync.ts) is what keeps only the transparent leg's record for a hash
+    // both legs see, so this total has exactly one entry per transaction, not
+    // two for every t→z/z→t. An exact match (not a lower bound) still catches
+    // any regression that reintroduces a duplicate, or drops a real operation.
+    expect(account.operations.length).toBe(5 + NOTE_COUNT_TARGET);
     stopIndexer();
   },
   teardown: async () => {

--- a/libs/coin-tester-modules/coin-tester-zcash/src/scenarii/zcash.ts
+++ b/libs/coin-tester-modules/coin-tester-zcash/src/scenarii/zcash.ts
@@ -1,0 +1,312 @@
+import { BigNumber } from "bignumber.js";
+import { Scenario, ScenarioTransaction } from "@ledgerhq/coin-tester/main";
+import { createBridges } from "@ledgerhq/coin-zcash";
+import type {
+  Transaction as ZcashTransaction,
+  ZcashAccount,
+} from "@ledgerhq/coin-zcash/types/bridge";
+import type { SignerContext } from "@ledgerhq/coin-zcash/types/signer";
+import type { ZcashConfigInfo } from "@ledgerhq/coin-zcash";
+import {
+  setZainoGrpcUrl,
+  ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS,
+} from "@ledgerhq/coin-zcash/constants";
+import {
+  computeShieldedSpendFee,
+  computeShieldingFee,
+  computeZip317Fee,
+} from "@ledgerhq/coin-zcash/logic/coin-selection";
+import resolver from "@ledgerhq/coin-zcash/signer/getAddress";
+import { orchardAddressFromUfvk } from "@ledgerhq/zcash-utils";
+import { setZcashShieldedEnabled } from "@ledgerhq/live-common/bridge/zcashRouting";
+import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
+import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
+import { setEnv } from "@ledgerhq/live-env";
+import { SYNC_TYPE_SHIELDED, SYNC_TYPE_TRANSPARENT } from "@ledgerhq/types-live";
+import {
+  assertCommonTxProperties,
+  assertIronwoodBalanceDelta,
+  assertTransparentBalanceDelta,
+  transparentBalance,
+} from "../assert";
+import { EXPLORER_ORIGIN, startIndexer, stopIndexer } from "../indexer";
+import { makeAccount } from "../fixtures";
+import { generateBlocks, generateBlocksToAddress } from "../helpers";
+import { randomMainnetBurnAddress, randomRegtestBurnAddress } from "../regtestAddress";
+import { killRegtestNode, spawnRegtestNode, ZAINO_GRPC_URL } from "../regtestNode";
+import { buildSigner } from "../signer";
+import { findNewUtxo } from "../utils";
+
+type ZcashCoinConfig = { info: ZcashConfigInfo };
+type ZcashScenarioTransaction = ScenarioTransaction<ZcashTransaction, ZcashAccount>;
+
+// zcash-utils is asked for "mainnet" throughout (UFVK/address derivation, PCZT
+// build, signing) to match the mainnet-prefixed addresses coin-zcash's own
+// classifier requires -- see zcash_regtest.ts and signer.ts for the full
+// rationale. Zaino is likewise addressed as "mainnet" for the same reason.
+const ZCASH_UTILS_NETWORK = "mainnet";
+
+// Deliberately small, fixed absolute amounts (not a fraction of the coinbase
+// reward, which is unknown at scenario-construction time and depends on the
+// regtest funding-stream schedule): comfortably below any plausible block
+// subsidy, so a fixed value is safe without asserting a specific fact about
+// the chain's reward schedule.
+const T_TO_T_AMOUNT = new BigNumber(50_000);
+const Z_TO_T_AMOUNT = new BigNumber(25_000);
+
+// How many blocks to confirm each transaction with (mined right after its own
+// broadcast -- see mockIndexer below): comfortably past
+// ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS (12) and enough real time for the
+// shielded (zaino-backed) scan to catch up before the next transaction reads
+// the account's balance. Mined to the burn address, never to the account --
+// these are regular, non-coinbase transaction outputs by the time this runs,
+// so nothing here needs maturity anyway.
+const BLOCKS_BETWEEN_TRANSACTIONS = ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS + 3;
+
+// Zcash's unconditional transparent coinbase maturity rule: a coinbase output
+// cannot be spent until 100 blocks after the block that created it (separate
+// from -- and not relaxed by -- regtest's own
+// `should_allow_unshielded_coinbase_spends`, which only lifts the *shielding*
+// requirement, empirically confirmed against the real zebrad binary: a spend
+// of a height-1 coinbase at height 6 rejects with "immature transparent
+// coinbase spend ... spends are invalid before Height(101), which is 100
+// blocks after it was created at Height(1)").
+//
+// `@ledgerhq/coin-zcash`'s transparent send spends every UTXO the account
+// holds unconditionally (no amount-driven coin selection -- see
+// `resolveTransparentUtxos`), so the account must never hold more than the
+// one coinbase UTXO it starts with: mining any further blocks to the
+// account's own address (regtest's mining.miner_address pays every block it
+// mines to whichever address it names) would keep recreating a fresh,
+// immature UTXO forever. So setup() mines exactly one funding block to the
+// account, then confirms it past maturity -- and every block mined after
+// that, including BLOCKS_BETWEEN_TRANSACTIONS, goes to a throwaway burn
+// address instead (see randomRegtestBurnAddress).
+const COINBASE_MATURITY_BLOCKS = 100;
+
+let shieldedRecipientAddress = "";
+let transparentRecipientAddress = "";
+let externalTransparentAddress = "";
+let burnAddress = "";
+
+const makeScenarioTransactions = (): ZcashScenarioTransaction[] => {
+  const scenarioTransparentToTransparent: ZcashScenarioTransaction = {
+    name: "Send ZEC transparent to transparent (t→t)",
+    family: "zcash",
+    transferType: "transparent",
+    sender: "public",
+    recipientType: "public",
+    amount: T_TO_T_AMOUNT,
+    // Deliberately a genuinely external address, not transparentRecipientAddress
+    // (the account's own -- reused by the z→t flow below, where de-shielding
+    // into the same account's transparent balance is the point). Sending to
+    // self here would make coin-zcash's own operation mapping
+    // (`mapTxToOperations`'s OUT/IN split) record the recipient output as a
+    // second, non-change "IN" credit alongside the "OUT" spend -- since it is
+    // not one of the account's own internal change-scope addresses -- breaking
+    // both assertCommonTxProperties's "exactly one new operation" assumption
+    // and the fee/balance-delta math below, which assumes nothing comes back.
+    recipient: externalTransparentAddress,
+    expect: (previousAccount, currentAccount) => {
+      const operation = assertCommonTxProperties(previousAccount, currentAccount);
+      const inputCount = previousAccount.bitcoinResources.utxos.length;
+      const gotChange = findNewUtxo(previousAccount, currentAccount) !== undefined;
+      const expectedFee = computeZip317Fee(0, 0, inputCount, gotChange ? 2 : 1);
+
+      expect(operation.fee.toFixed()).toBe(expectedFee.toFixed());
+      expect(operation.value.toFixed()).toBe(T_TO_T_AMOUNT.plus(expectedFee).toFixed());
+      assertTransparentBalanceDelta(
+        previousAccount,
+        currentAccount,
+        T_TO_T_AMOUNT.plus(expectedFee).negated(),
+      );
+    },
+  };
+
+  const scenarioTransparentToShielded: ZcashScenarioTransaction = {
+    name: "Shield ZEC transparent to shielded (t→z)",
+    family: "zcash",
+    transferType: "transparent-to-shielded",
+    sender: "public",
+    recipientType: "private",
+    useAllAmount: true,
+    recipient: shieldedRecipientAddress,
+    expect: (previousAccount, currentAccount) => {
+      const [latestOperation] = currentAccount.operations;
+      expect(latestOperation.type).toBe("OUT");
+
+      const inputCount = previousAccount.bitcoinResources.utxos.length;
+      const expectedFee = computeShieldingFee(inputCount, 1);
+      expect(latestOperation.fee.toFixed()).toBe(expectedFee.toFixed());
+
+      const shieldedAmount = transparentBalance(previousAccount).minus(expectedFee);
+      assertTransparentBalanceDelta(
+        previousAccount,
+        currentAccount,
+        transparentBalance(previousAccount).negated(),
+      );
+      assertIronwoodBalanceDelta(previousAccount, currentAccount, shieldedAmount);
+    },
+  };
+
+  const scenarioShieldedToTransparent: ZcashScenarioTransaction = {
+    name: "De-shield ZEC shielded to transparent (z→t)",
+    family: "zcash",
+    transferType: "shielded-to-transparent",
+    sender: "private",
+    recipientType: "public",
+    amount: Z_TO_T_AMOUNT,
+    recipient: transparentRecipientAddress,
+    expect: (previousAccount, currentAccount) => {
+      // A single Ironwood note (from the shielding leg above) fully covers this
+      // small amount, so exactly 1 spend is consumed and change comes back as a
+      // new Ironwood note -- i.e. hasChange is always true here.
+      const expectedFee = computeShieldedSpendFee(1, true, "shielded-to-transparent");
+      const [latestOperation] = currentAccount.operations;
+      // "IN", not "OUT": mapTxToOperations (coin-zcash's own transparent-leg
+      // bookkeeping, sync.ts) only records "OUT" when the transaction is
+      // *funded by a transparent input* (`fundedByAccount`) -- a de-shielding
+      // send has none (it spends Ironwood notes), so from the transparent
+      // pool's own perspective this legitimately looks like an inflow arriving
+      // from nowhere, exactly like any other incoming transfer. The shielded
+      // spend side is accounted for separately, via ironwoodBalance below --
+      // there is no discrete "OUT" operation for it (empirically confirmed).
+      expect(latestOperation.type).toBe("IN");
+      expect(latestOperation.fee.toFixed()).toBe(expectedFee.toFixed());
+
+      assertTransparentBalanceDelta(previousAccount, currentAccount, Z_TO_T_AMOUNT);
+      assertIronwoodBalanceDelta(
+        previousAccount,
+        currentAccount,
+        Z_TO_T_AMOUNT.plus(expectedFee).negated(),
+      );
+    },
+  };
+
+  const scenarioShieldedToShielded: ZcashScenarioTransaction = {
+    name: "Send ZEC shielded to shielded (z→z)",
+    family: "zcash",
+    transferType: "shielded",
+    sender: "private",
+    recipientType: "private",
+    useAllAmount: true,
+    recipient: shieldedRecipientAddress,
+    expect: (previousAccount, currentAccount) => {
+      // useAllAmount over the single remaining (change) Ironwood note: 1 spend,
+      // no change -- see computeShieldedSpendFee's "shielded" branch.
+      const expectedFee = computeShieldedSpendFee(1, false, "shielded");
+      const [latestOperation] = currentAccount.operations;
+      expect(latestOperation.type).toBe("SHIELDED_TX_IRONWOOD_IN");
+      expect(latestOperation.fee.toFixed()).toBe(expectedFee.toFixed());
+
+      // Self-transfer within the same pool: the note is fully re-spent (fee
+      // paid out of it), so the pool's net balance only drops by the fee.
+      assertIronwoodBalanceDelta(previousAccount, currentAccount, expectedFee.negated());
+    },
+  };
+
+  return [
+    scenarioTransparentToTransparent,
+    scenarioTransparentToShielded,
+    scenarioShieldedToTransparent,
+    scenarioShieldedToShielded,
+  ];
+};
+
+export const scenarioZcash: Scenario<ZcashTransaction, ZcashAccount> = {
+  name: "Ledger Live Basic Zcash Transactions",
+  setup: async () => {
+    const { signer, ufvk, xpub, accountIndex } = buildSigner();
+    const signerContext: SignerContext = (_deviceId, fn) => fn(signer);
+
+    setEnv("EXPLORER", EXPLORER_ORIGIN);
+    setZainoGrpcUrl(ZAINO_GRPC_URL, ZCASH_UTILS_NETWORK);
+    setZcashShieldedEnabled(true);
+
+    const coinConfig: ZcashCoinConfig = { info: { status: { type: "active" } } };
+    LiveConfig.setConfig({
+      config_currency_zcash_regtest: {
+        type: "object",
+        default: { status: { type: "active" } },
+      },
+    });
+
+    const { accountBridge, currencyBridge } = createBridges(signerContext, () => coinConfig);
+    const ZCASH_REGTEST = getCryptoCurrencyById("zcash_regtest");
+
+    const getAddress = resolver(signerContext);
+    const { address, publicKey } = await getAddress("", {
+      path: `44'/${ZCASH_REGTEST.coinType}'/${accountIndex}'/0/0`,
+      currency: ZCASH_REGTEST,
+      derivationMode: "",
+    });
+
+    const account = makeAccount(xpub, publicKey, address, ZCASH_REGTEST, "", ufvk);
+
+    shieldedRecipientAddress = orchardAddressFromUfvk(ufvk);
+    transparentRecipientAddress = address;
+    externalTransparentAddress = randomMainnetBurnAddress();
+
+    await spawnRegtestNode(address);
+    burnAddress = randomRegtestBurnAddress();
+    // Exactly one coinbase block to the account (see COINBASE_MATURITY_BLOCKS's
+    // comment for why not more), then confirm it past the maturity window
+    // with blocks mined to the burn address instead, plus a small margin.
+    await generateBlocks(1);
+    await generateBlocksToAddress(COINBASE_MATURITY_BLOCKS + 5, burnAddress);
+
+    // Must start before setup() returns: executeScenario (coin-tester/main.ts)
+    // runs the account's *first* sync right after setup(), and only calls the
+    // `beforeAll` hook after that first sync completes -- so registering the
+    // indexer there would leave the first sync racing an MSW server that
+    // isn't listening yet (empirically confirmed: ECONNREFUSED 127.0.0.1:9877).
+    startIndexer();
+
+    return {
+      // `@ledgerhq/coin-tester`'s executeScenario calls accountBridge.sync
+      // with just `{ paginationConfig: {} }` -- coin-tester's own SyncConfig
+      // is chain-agnostic, and has no notion of coin-zcash's own `syncType`
+      // bitmask extension (`SYNC_TYPE_SHIELDED`, in `@ledgerhq/types-live`).
+      // Without it, `buildExtraSyncObservable` (bridge/sync.ts) returns
+      // `undefined` unconditionally and the Ironwood/Orchard scan never runs
+      // at all -- ironwoodBalance stays exactly 0 forever, empirically
+      // confirmed (not a slow-catch-up timing issue: 20 retries over 100s
+      // made no difference). Forcing both bits on every sync call this
+      // package's own scenario ever makes is the fix, entirely inside this
+      // package -- coin-tester's shared core and coin-zcash's own source stay
+      // untouched.
+      accountBridge: {
+        ...accountBridge,
+        sync: (syncAccount, syncConfig) =>
+          accountBridge.sync(syncAccount, {
+            ...syncConfig,
+            syncType: (syncConfig.syncType ?? 0) | SYNC_TYPE_TRANSPARENT | SYNC_TYPE_SHIELDED,
+          }),
+      },
+      currencyBridge,
+      account,
+      retryLimit: 20,
+      retryInterval: 5_000,
+    };
+  },
+  getTransactions: () => makeScenarioTransactions(),
+  // executeScenario (coin-tester/main.ts) calls this right after broadcast,
+  // before the sync-and-assert retry loop starts -- confirming here (rather
+  // than in afterEach, which only runs once that loop already succeeds) is
+  // what makes the just-broadcast transaction visible at all: zebra's
+  // address-indexed RPCs (getaddresstxids/getrawtransaction, backing this
+  // package's indexer.ts) only see mined transactions, never the mempool, so
+  // without this the retry loop exhausts all 20 attempts waiting on a
+  // transaction that can never confirm on its own (empirically confirmed).
+  mockIndexer: async () => {
+    await generateBlocksToAddress(BLOCKS_BETWEEN_TRANSACTIONS, burnAddress);
+  },
+  afterAll: async account => {
+    expect(account.operations.length).toBeGreaterThanOrEqual(4);
+    stopIndexer();
+  },
+  teardown: async () => {
+    stopIndexer();
+    await killRegtestNode();
+  },
+};

--- a/libs/coin-tester-modules/coin-tester-zcash/src/signer.test.ts
+++ b/libs/coin-tester-modules/coin-tester-zcash/src/signer.test.ts
@@ -1,162 +1,39 @@
-import { BIP32Factory } from "bip32";
 import bs58check from "bs58check";
-import { secp256k1 } from "@noble/curves/secp256k1";
 import { derivePath, p2pkhAddress, P2PKH_VERSION } from "./signer";
 
-// ECC wrapper for @noble/curves/secp256k1 to be compatible with BIP32Factory,
-// mirroring coin-tester-bitcoin's own signer.ts (test-only cross-check here,
-// not shipped): bip32 v4 dropped its bundled secp256k1 implementation and
-// requires the caller to supply one.
-function bytesToBigInt(bytes: Uint8Array): bigint {
-  const hex = Array.from(bytes)
-    .map(b => b.toString(16).padStart(2, "0"))
-    .join("");
-  return BigInt("0x" + hex);
-}
-
-function bigIntToBytes(value: bigint): Uint8Array {
-  const hex = value.toString(16).padStart(64, "0");
-  const bytes = new Uint8Array(32);
-  for (let i = 0; i < 32; i++) {
-    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
-  }
-  return bytes;
-}
-
-const eccWrapper = {
-  isPoint(point: Uint8Array | Buffer): boolean {
-    try {
-      const pointBytes = point instanceof Buffer ? new Uint8Array(point) : point;
-      if (pointBytes.length !== 33 && pointBytes.length !== 65) return false;
-      secp256k1.ProjectivePoint.fromHex(pointBytes);
-      return true;
-    } catch {
-      return false;
-    }
-  },
-
-  isPrivate(privateKey: Uint8Array | Buffer): boolean {
-    try {
-      const keyBytes = privateKey instanceof Buffer ? new Uint8Array(privateKey) : privateKey;
-      if (keyBytes.length !== 32) return false;
-      return secp256k1.utils.isValidPrivateKey(keyBytes);
-    } catch {
-      return false;
-    }
-  },
-
-  pointFromScalar(privateKey: Uint8Array | Buffer, compressed = true): Uint8Array | null {
-    try {
-      const keyBytes = privateKey instanceof Buffer ? new Uint8Array(privateKey) : privateKey;
-      if (!this.isPrivate(keyBytes)) return null;
-      return secp256k1.getPublicKey(keyBytes, compressed);
-    } catch {
-      return null;
-    }
-  },
-
-  pointAddScalar(
-    point: Uint8Array | Buffer,
-    scalar: Uint8Array | Buffer,
-    compressed?: boolean,
-  ): Uint8Array | null {
-    try {
-      const pointBytes = point instanceof Buffer ? new Uint8Array(point) : point;
-      const scalarBytes = scalar instanceof Buffer ? new Uint8Array(scalar) : scalar;
-      if (!this.isPoint(pointBytes) || !this.isPrivate(scalarBytes)) return null;
-
-      const p = secp256k1.ProjectivePoint.fromHex(pointBytes);
-      const scalarPoint = secp256k1.ProjectivePoint.BASE.multiply(bytesToBigInt(scalarBytes));
-      const result = p.add(scalarPoint);
-
-      const isCompressed = compressed !== undefined ? compressed : pointBytes.length === 33;
-      return result.toRawBytes(isCompressed);
-    } catch {
-      return null;
-    }
-  },
-
-  privateAdd(privateKey: Uint8Array | Buffer, scalar: Uint8Array | Buffer): Uint8Array | null {
-    try {
-      const keyBytes = privateKey instanceof Buffer ? new Uint8Array(privateKey) : privateKey;
-      const scalarBytes = scalar instanceof Buffer ? new Uint8Array(scalar) : scalar;
-      if (!this.isPrivate(keyBytes) || !this.isPrivate(scalarBytes)) return null;
-
-      const result = (bytesToBigInt(keyBytes) + bytesToBigInt(scalarBytes)) % secp256k1.CURVE.n;
-      if (result === 0n) return null;
-      return bigIntToBytes(result);
-    } catch {
-      return null;
-    }
-  },
-
-  pointMultiply(
-    point: Uint8Array | Buffer,
-    scalar: Uint8Array | Buffer,
-    compressed?: boolean,
-  ): Uint8Array | null {
-    try {
-      const pointBytes = point instanceof Buffer ? new Uint8Array(point) : point;
-      const scalarBytes = scalar instanceof Buffer ? new Uint8Array(scalar) : scalar;
-      if (!this.isPoint(pointBytes) || !this.isPrivate(scalarBytes)) return null;
-
-      const p = secp256k1.ProjectivePoint.fromHex(pointBytes);
-      const result = p.multiply(bytesToBigInt(scalarBytes));
-      const isCompressed = compressed !== undefined ? compressed : pointBytes.length === 33;
-      return result.toRawBytes(isCompressed);
-    } catch {
-      return null;
-    }
-  },
-
-  pointCompress(point: Uint8Array | Buffer, compressed = true): Uint8Array {
-    const pointBytes = point instanceof Buffer ? new Uint8Array(point) : point;
-    return secp256k1.ProjectivePoint.fromHex(pointBytes).toRawBytes(compressed);
-  },
-
-  isPointCompressed(point: Uint8Array | Buffer): boolean {
-    return point.length === 33;
-  },
-
-  sign(hash: Uint8Array | Buffer, privateKey: Uint8Array | Buffer): Uint8Array {
-    const hashBytes = hash instanceof Buffer ? new Uint8Array(hash) : hash;
-    const keyBytes = privateKey instanceof Buffer ? new Uint8Array(privateKey) : privateKey;
-    return secp256k1.sign(hashBytes, keyBytes, { prehash: false }).toCompactRawBytes();
-  },
-
-  verify(
-    hash: Uint8Array | Buffer,
-    publicKey: Uint8Array | Buffer,
-    signature: Uint8Array | Buffer,
-  ): boolean {
-    try {
-      const hashBytes = hash instanceof Buffer ? new Uint8Array(hash) : hash;
-      const pubKeyBytes = publicKey instanceof Buffer ? new Uint8Array(publicKey) : publicKey;
-      const sigBytes = signature instanceof Buffer ? new Uint8Array(signature) : signature;
-      return secp256k1.verify(sigBytes, hashBytes, pubKeyBytes, { prehash: false });
-    } catch {
-      return false;
-    }
-  },
-};
-
-const bip32 = BIP32Factory(eccWrapper);
-
-// BIP32 spec's own official test vector 1 seed.
+// BIP32 spec's own official Test Vector 1 (seed and extended private keys),
+// verbatim from https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki.
+// No `bip32`/`tiny-secp256k1` dependency needed: an extended private key is
+// just Base58Check(version[4] || depth[1] || parentFingerprint[4] ||
+// childNumber[4] || chainCode[32] || 0x00 || privateKey[32]), so decoding one
+// with `bs58check` (pure JS, no native build) is enough to read off the raw
+// private key and chain code to compare against.
 const TEST_SEED = Buffer.from("000102030405060708090a0b0c0d0e0f", "hex");
 
-describe("derivePath", () => {
-  it.each(["0'", "0'/1", "0'/1/2'", "0'/1/2'/2", "44'/133'/0'/0/0"])(
-    "matches bip32's own CKDpriv derivation for path %s",
-    path => {
-      const ours = derivePath(TEST_SEED, path);
-      const theirs = bip32.fromSeed(TEST_SEED).derivePath(path);
+const TEST_VECTOR_1: Record<string, string> = {
+  m: "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi",
+  "0'": "xprv9uHRZZhk6KAJC1avXpDAp4MDc3sQKNxDiPvvkX8Br5ngLNv1TxvUxt4cV1rGL5hj6KCesnDYUhd7oWgT11eZG7XnxHrnYeSvkzY7d2bhkJ7",
+  "0'/1":
+    "xprv9wTYmMFdV23N2TdNG573QoEsfRrWKQgWeibmLntzniatZvR9BmLnvSxqu53Kw1UmYPxLgboyZQaXwTCg8MSY3H2EU4pWcQDnRnrVA1xe8fs",
+};
 
-      expect(Buffer.from(ours.privateKey).toString("hex")).toBe(
-        Buffer.from(theirs.privateKey as Uint8Array).toString("hex"),
+function decodeXprv(xprv: string): { privateKey: Buffer; chainCode: Buffer } {
+  const raw = bs58check.decode(xprv);
+  return { chainCode: Buffer.from(raw.slice(13, 45)), privateKey: Buffer.from(raw.slice(46, 78)) };
+}
+
+describe("derivePath", () => {
+  it.each(Object.keys(TEST_VECTOR_1))(
+    "matches BIP32 spec's own Test Vector 1 for path %s",
+    path => {
+      const expected = decodeXprv(TEST_VECTOR_1[path]);
+      const actual = derivePath(TEST_SEED, path === "m" ? "" : path);
+
+      expect(Buffer.from(actual.privateKey).toString("hex")).toBe(
+        expected.privateKey.toString("hex"),
       );
-      expect(Buffer.from(ours.chainCode).toString("hex")).toBe(
-        Buffer.from(theirs.chainCode).toString("hex"),
+      expect(Buffer.from(actual.chainCode).toString("hex")).toBe(
+        expected.chainCode.toString("hex"),
       );
     },
   );

--- a/libs/coin-tester-modules/coin-tester-zcash/src/signer.test.ts
+++ b/libs/coin-tester-modules/coin-tester-zcash/src/signer.test.ts
@@ -1,0 +1,179 @@
+import { BIP32Factory } from "bip32";
+import bs58check from "bs58check";
+import { secp256k1 } from "@noble/curves/secp256k1";
+import { derivePath, p2pkhAddress, P2PKH_VERSION } from "./signer";
+
+// ECC wrapper for @noble/curves/secp256k1 to be compatible with BIP32Factory,
+// mirroring coin-tester-bitcoin's own signer.ts (test-only cross-check here,
+// not shipped): bip32 v4 dropped its bundled secp256k1 implementation and
+// requires the caller to supply one.
+function bytesToBigInt(bytes: Uint8Array): bigint {
+  const hex = Array.from(bytes)
+    .map(b => b.toString(16).padStart(2, "0"))
+    .join("");
+  return BigInt("0x" + hex);
+}
+
+function bigIntToBytes(value: bigint): Uint8Array {
+  const hex = value.toString(16).padStart(64, "0");
+  const bytes = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) {
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+const eccWrapper = {
+  isPoint(point: Uint8Array | Buffer): boolean {
+    try {
+      const pointBytes = point instanceof Buffer ? new Uint8Array(point) : point;
+      if (pointBytes.length !== 33 && pointBytes.length !== 65) return false;
+      secp256k1.ProjectivePoint.fromHex(pointBytes);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+
+  isPrivate(privateKey: Uint8Array | Buffer): boolean {
+    try {
+      const keyBytes = privateKey instanceof Buffer ? new Uint8Array(privateKey) : privateKey;
+      if (keyBytes.length !== 32) return false;
+      return secp256k1.utils.isValidPrivateKey(keyBytes);
+    } catch {
+      return false;
+    }
+  },
+
+  pointFromScalar(privateKey: Uint8Array | Buffer, compressed = true): Uint8Array | null {
+    try {
+      const keyBytes = privateKey instanceof Buffer ? new Uint8Array(privateKey) : privateKey;
+      if (!this.isPrivate(keyBytes)) return null;
+      return secp256k1.getPublicKey(keyBytes, compressed);
+    } catch {
+      return null;
+    }
+  },
+
+  pointAddScalar(
+    point: Uint8Array | Buffer,
+    scalar: Uint8Array | Buffer,
+    compressed?: boolean,
+  ): Uint8Array | null {
+    try {
+      const pointBytes = point instanceof Buffer ? new Uint8Array(point) : point;
+      const scalarBytes = scalar instanceof Buffer ? new Uint8Array(scalar) : scalar;
+      if (!this.isPoint(pointBytes) || !this.isPrivate(scalarBytes)) return null;
+
+      const p = secp256k1.ProjectivePoint.fromHex(pointBytes);
+      const scalarPoint = secp256k1.ProjectivePoint.BASE.multiply(bytesToBigInt(scalarBytes));
+      const result = p.add(scalarPoint);
+
+      const isCompressed = compressed !== undefined ? compressed : pointBytes.length === 33;
+      return result.toRawBytes(isCompressed);
+    } catch {
+      return null;
+    }
+  },
+
+  privateAdd(privateKey: Uint8Array | Buffer, scalar: Uint8Array | Buffer): Uint8Array | null {
+    try {
+      const keyBytes = privateKey instanceof Buffer ? new Uint8Array(privateKey) : privateKey;
+      const scalarBytes = scalar instanceof Buffer ? new Uint8Array(scalar) : scalar;
+      if (!this.isPrivate(keyBytes) || !this.isPrivate(scalarBytes)) return null;
+
+      const result = (bytesToBigInt(keyBytes) + bytesToBigInt(scalarBytes)) % secp256k1.CURVE.n;
+      if (result === 0n) return null;
+      return bigIntToBytes(result);
+    } catch {
+      return null;
+    }
+  },
+
+  pointMultiply(
+    point: Uint8Array | Buffer,
+    scalar: Uint8Array | Buffer,
+    compressed?: boolean,
+  ): Uint8Array | null {
+    try {
+      const pointBytes = point instanceof Buffer ? new Uint8Array(point) : point;
+      const scalarBytes = scalar instanceof Buffer ? new Uint8Array(scalar) : scalar;
+      if (!this.isPoint(pointBytes) || !this.isPrivate(scalarBytes)) return null;
+
+      const p = secp256k1.ProjectivePoint.fromHex(pointBytes);
+      const result = p.multiply(bytesToBigInt(scalarBytes));
+      const isCompressed = compressed !== undefined ? compressed : pointBytes.length === 33;
+      return result.toRawBytes(isCompressed);
+    } catch {
+      return null;
+    }
+  },
+
+  pointCompress(point: Uint8Array | Buffer, compressed = true): Uint8Array {
+    const pointBytes = point instanceof Buffer ? new Uint8Array(point) : point;
+    return secp256k1.ProjectivePoint.fromHex(pointBytes).toRawBytes(compressed);
+  },
+
+  isPointCompressed(point: Uint8Array | Buffer): boolean {
+    return point.length === 33;
+  },
+
+  sign(hash: Uint8Array | Buffer, privateKey: Uint8Array | Buffer): Uint8Array {
+    const hashBytes = hash instanceof Buffer ? new Uint8Array(hash) : hash;
+    const keyBytes = privateKey instanceof Buffer ? new Uint8Array(privateKey) : privateKey;
+    return secp256k1.sign(hashBytes, keyBytes, { prehash: false }).toCompactRawBytes();
+  },
+
+  verify(
+    hash: Uint8Array | Buffer,
+    publicKey: Uint8Array | Buffer,
+    signature: Uint8Array | Buffer,
+  ): boolean {
+    try {
+      const hashBytes = hash instanceof Buffer ? new Uint8Array(hash) : hash;
+      const pubKeyBytes = publicKey instanceof Buffer ? new Uint8Array(publicKey) : publicKey;
+      const sigBytes = signature instanceof Buffer ? new Uint8Array(signature) : signature;
+      return secp256k1.verify(sigBytes, hashBytes, pubKeyBytes, { prehash: false });
+    } catch {
+      return false;
+    }
+  },
+};
+
+const bip32 = BIP32Factory(eccWrapper);
+
+// BIP32 spec's own official test vector 1 seed.
+const TEST_SEED = Buffer.from("000102030405060708090a0b0c0d0e0f", "hex");
+
+describe("derivePath", () => {
+  it.each(["0'", "0'/1", "0'/1/2'", "0'/1/2'/2", "44'/133'/0'/0/0"])(
+    "matches bip32's own CKDpriv derivation for path %s",
+    path => {
+      const ours = derivePath(TEST_SEED, path);
+      const theirs = bip32.fromSeed(TEST_SEED).derivePath(path);
+
+      expect(Buffer.from(ours.privateKey).toString("hex")).toBe(
+        Buffer.from(theirs.privateKey as Uint8Array).toString("hex"),
+      );
+      expect(Buffer.from(ours.chainCode).toString("hex")).toBe(
+        Buffer.from(theirs.chainCode).toString("hex"),
+      );
+    },
+  );
+});
+
+describe("p2pkhAddress", () => {
+  it("round-trips through bs58check with the expected 2-byte version prefix", () => {
+    const node = derivePath(TEST_SEED, "44'/133'/0'/0/0");
+    const address = p2pkhAddress(node.privateKey);
+
+    const decoded = bs58check.decode(address);
+    expect(decoded.length).toBe(22); // 2-byte version + 20-byte hash160
+    expect((decoded[0] << 8) | decoded[1]).toBe(P2PKH_VERSION);
+  });
+
+  it("is deterministic for the same private key", () => {
+    const node = derivePath(TEST_SEED, "44'/133'/0'/0/0");
+    expect(p2pkhAddress(node.privateKey)).toBe(p2pkhAddress(node.privateKey));
+  });
+});

--- a/libs/coin-tester-modules/coin-tester-zcash/src/signer.ts
+++ b/libs/coin-tester-modules/coin-tester-zcash/src/signer.ts
@@ -1,0 +1,188 @@
+/**
+ * Local, device-free Zcash signer for the coin tester. Implements
+ * `@ledgerhq/coin-zcash`'s own 4-method local-signer contract
+ * (`types/signer.ts`'s `BitcoinSigner`) -- not the broader 7-method
+ * `@ledgerhq/live-signer-zcash` `ZcashSigner`, which only serves coin-bitcoin's
+ * legacy PSBT path.
+ *
+ * Every signature comes from `@ledgerhq/zcash-utils`'s test-only NAPI surface
+ * (`testDeriveKeys`/`testSignPczt`/`orchardAddressFromUfvk`); the only local
+ * crypto is the plain hardened+non-hardened BIP32 private-key derivation
+ * `getAddress` needs (`derivePath` below) and the Base58Check P2PKH address
+ * encoding, both self-contained (no secp256k1 point *addition*, unlike
+ * coin-tester-bitcoin's signer, is ever needed here: deriving from a full
+ * private-key chain never needs the public-only CKD math coin-tester-bitcoin's
+ * `eccWrapper` exists for).
+ */
+import { generateMnemonic, mnemonicToSeedSync } from "bip39";
+import { hmac } from "@noble/hashes/hmac";
+import { sha256 as nobleSha256, sha512 } from "@noble/hashes/sha2";
+import { ripemd160 as nobleRipemd160 } from "@noble/hashes/legacy";
+import { secp256k1 } from "@noble/curves/secp256k1";
+import bs58 from "bs58";
+import { orchardAddressFromUfvk, testDeriveKeys, testSignPczt } from "@ledgerhq/zcash-utils";
+import type { BitcoinSigner } from "@ledgerhq/coin-zcash/types/signer";
+import type {
+  PcztTransaction,
+  SignPcztTransactionResult,
+  ZcashAddress,
+  ZcashShieldedAddress,
+  ZcashViewKey,
+} from "@ledgerhq/live-signer-zcash";
+import { getCapturedPcztHex } from "./zcashClientTestSeam";
+
+// Matches zcash_regtest's `bitcoinLikeInfo.P2PKH` (domain/entity/currency-crypto) --
+// deliberately the mainnet Zcash version byte, not Zcash's own testnet/regtest one.
+// See that file for why: @ledgerhq/coin-zcash's recipient classifier only accepts
+// mainnet-prefixed addresses.
+const P2PKH_VERSION = 7352;
+
+// `testDeriveKeys`/`testSignPczt`/`orchardAddressFromUfvk` all key off this network
+// string; "mainnet" keeps the derived UFVK/addresses within coin-zcash's own
+// mainnet-only classifier (see zcash_regtest.ts).
+const ZCASH_UTILS_NETWORK = "mainnet";
+
+const HARDENED_OFFSET = 0x80000000;
+
+function parsePathSegment(segment: string): number {
+  const hardened = segment.endsWith("'") || segment.endsWith("h") || segment.endsWith("H");
+  const index = parseInt(hardened ? segment.slice(0, -1) : segment, 10);
+  return hardened ? index + HARDENED_OFFSET : index;
+}
+
+function parsePath(path: string): number[] {
+  return path
+    .split("/")
+    .map(segment => segment.trim())
+    .filter(Boolean)
+    .map(parsePathSegment);
+}
+
+function ser32(i: number): Uint8Array {
+  const buf = new Uint8Array(4);
+  new DataView(buf.buffer).setUint32(0, i, false);
+  return buf;
+}
+
+function bytesToBigInt(bytes: Uint8Array): bigint {
+  let value = 0n;
+  for (const byte of bytes) value = (value << 8n) | BigInt(byte);
+  return value;
+}
+
+function bigIntTo32Bytes(value: bigint): Uint8Array {
+  const bytes = new Uint8Array(32);
+  let v = value;
+  for (let i = 31; i >= 0; i--) {
+    bytes[i] = Number(v & 0xffn);
+    v >>= 8n;
+  }
+  return bytes;
+}
+
+type Bip32Node = { privateKey: Uint8Array; chainCode: Uint8Array };
+
+function masterNodeFromSeed(seed: Uint8Array): Bip32Node {
+  const digest = hmac(sha512, new TextEncoder().encode("Bitcoin seed"), seed);
+  return { privateKey: digest.slice(0, 32), chainCode: digest.slice(32, 64) };
+}
+
+/** BIP32 CKDpriv -- works identically for hardened and non-hardened indices
+ * because the full private key (not just an xpub) is always in hand. */
+function deriveChild(parent: Bip32Node, index: number): Bip32Node {
+  const hardened = index >= HARDENED_OFFSET;
+  const data = new Uint8Array(37);
+  if (hardened) {
+    data.set([0x00], 0);
+    data.set(parent.privateKey, 1);
+  } else {
+    data.set(secp256k1.getPublicKey(parent.privateKey, true), 0);
+  }
+  data.set(ser32(index), 33);
+
+  const digest = hmac(sha512, parent.chainCode, data);
+  const il = digest.slice(0, 32);
+  const childPrivateKey = bigIntTo32Bytes(
+    (bytesToBigInt(il) + bytesToBigInt(parent.privateKey)) % secp256k1.CURVE.n,
+  );
+  return { privateKey: childPrivateKey, chainCode: digest.slice(32, 64) };
+}
+
+function derivePath(seed: Uint8Array, path: string): Bip32Node {
+  return parsePath(path).reduce(deriveChild, masterNodeFromSeed(seed));
+}
+
+function hash160(data: Uint8Array): Uint8Array {
+  return nobleRipemd160(nobleSha256(data));
+}
+
+/** Base58Check of the 22-byte {2-byte version BE}{20-byte hash160} payload --
+ * Zcash's own P2PKH encoding (`t1...`), per `wallet-btc/crypto/zec.ts`. */
+function p2pkhAddress(privateKey: Uint8Array): string {
+  const pubKey = secp256k1.getPublicKey(privateKey, true);
+  const hash = hash160(pubKey);
+  const payload = new Uint8Array(22);
+  new DataView(payload.buffer).setUint16(0, P2PKH_VERSION, false);
+  payload.set(hash, 2);
+  const checksum = nobleSha256(nobleSha256(payload)).slice(0, 4);
+  const full = new Uint8Array(26);
+  full.set(payload, 0);
+  full.set(checksum, 22);
+  return bs58.encode(Buffer.from(full));
+}
+
+export type ZcashTestSigner = {
+  signer: BitcoinSigner;
+  mnemonic: string;
+  ufvk: string;
+  xpub: string;
+  accountIndex: number;
+};
+
+/**
+ * Builds a deterministic in-memory Zcash signer for a single test account
+ * (`accountIndex`, default 0). All 4 methods are pure/local; `signPcztTransaction`
+ * retrieves the hex of the PCZT it is asked to sign from the test seam
+ * (`zcashClientTestSeam.ts`), since the parsed `PcztTransaction` argument alone
+ * doesn't carry it.
+ */
+export function buildSigner(accountIndex = 0): ZcashTestSigner {
+  const mnemonic = generateMnemonic();
+  const seed = mnemonicToSeedSync(mnemonic);
+  const { ufvk, xpub } = testDeriveKeys(mnemonic, accountIndex, ZCASH_UTILS_NETWORK);
+
+  const signer: BitcoinSigner = {
+    getAddress: async (path: string, _display?: boolean): Promise<ZcashAddress> => {
+      const node = derivePath(seed, path);
+      return {
+        address: p2pkhAddress(node.privateKey),
+        publicKey: Buffer.from(secp256k1.getPublicKey(node.privateKey, true)).toString("hex"),
+        chainCode: Buffer.from(node.chainCode).toString("hex"),
+      };
+    },
+    getFullViewingKey: async (_path: string): Promise<ZcashViewKey> => ({ viewKey: ufvk }),
+    getShieldedAddress: async (
+      _path: string,
+      _display?: boolean,
+    ): Promise<ZcashShieldedAddress> => ({
+      address: orchardAddressFromUfvk(ufvk),
+    }),
+    signPcztTransaction: async (_pczt: PcztTransaction): Promise<SignPcztTransactionResult> => {
+      const pcztHex = getCapturedPcztHex(accountIndex);
+      const result = await testSignPczt(mnemonic, accountIndex, ZCASH_UTILS_NETWORK, pcztHex);
+      return {
+        orchard: result.orchardSignatures.map(hex => ({
+          spendAuthSig: new Uint8Array(Buffer.from(hex, "hex")),
+        })),
+        ironwood: result.ironwoodSignatures.map(hex => ({
+          spendAuthSig: new Uint8Array(Buffer.from(hex, "hex")),
+        })),
+        transparentInputSigs: result.transparentSignatures.map(
+          hex => new Uint8Array(Buffer.from(hex, "hex")),
+        ),
+      };
+    },
+  };
+
+  return { signer, mnemonic, ufvk, xpub, accountIndex };
+}

--- a/libs/coin-tester-modules/coin-tester-zcash/src/signer.ts
+++ b/libs/coin-tester-modules/coin-tester-zcash/src/signer.ts
@@ -35,7 +35,7 @@ import { getCapturedPcztHex } from "./zcashClientTestSeam";
 // deliberately the mainnet Zcash version byte, not Zcash's own testnet/regtest one.
 // See that file for why: @ledgerhq/coin-zcash's recipient classifier only accepts
 // mainnet-prefixed addresses.
-const P2PKH_VERSION = 7352;
+export const P2PKH_VERSION = 7352;
 
 // `testDeriveKeys`/`testSignPczt`/`orchardAddressFromUfvk` all key off this network
 // string; "mainnet" keeps the derived UFVK/addresses within coin-zcash's own
@@ -46,16 +46,25 @@ const HARDENED_OFFSET = 0x80000000;
 
 function parsePathSegment(segment: string): number {
   const hardened = segment.endsWith("'") || segment.endsWith("h") || segment.endsWith("H");
-  const index = parseInt(hardened ? segment.slice(0, -1) : segment, 10);
+  const digits = hardened ? segment.slice(0, -1) : segment;
+  if (!/^\d+$/.test(digits)) {
+    throw new Error(`invalid BIP32 path segment: "${segment}"`);
+  }
+  const index = parseInt(digits, 10);
   return hardened ? index + HARDENED_OFFSET : index;
 }
 
 function parsePath(path: string): number[] {
-  return path
-    .split("/")
-    .map(segment => segment.trim())
-    .filter(Boolean)
-    .map(parsePathSegment);
+  return (
+    path
+      .split("/")
+      .map(segment => segment.trim())
+      .filter(Boolean)
+      // A leading "m" (root marker) is the standard BIP32 notation but not
+      // itself a derivation index; every other segment must parse as one.
+      .filter(segment => segment.toLowerCase() !== "m")
+      .map(parsePathSegment)
+  );
 }
 
 function ser32(i: number): Uint8Array {
@@ -108,7 +117,7 @@ function deriveChild(parent: Bip32Node, index: number): Bip32Node {
   return { privateKey: childPrivateKey, chainCode: digest.slice(32, 64) };
 }
 
-function derivePath(seed: Uint8Array, path: string): Bip32Node {
+export function derivePath(seed: Uint8Array, path: string): Bip32Node {
   return parsePath(path).reduce(deriveChild, masterNodeFromSeed(seed));
 }
 
@@ -118,7 +127,7 @@ function hash160(data: Uint8Array): Uint8Array {
 
 /** Base58Check of the 22-byte {2-byte version BE}{20-byte hash160} payload --
  * Zcash's own P2PKH encoding (`t1...`), per `wallet-btc/crypto/zec.ts`. */
-function p2pkhAddress(privateKey: Uint8Array): string {
+export function p2pkhAddress(privateKey: Uint8Array): string {
   const pubKey = secp256k1.getPublicKey(privateKey, true);
   const hash = hash160(pubKey);
   const payload = new Uint8Array(22);

--- a/libs/coin-tester-modules/coin-tester-zcash/src/utils.ts
+++ b/libs/coin-tester-modules/coin-tester-zcash/src/utils.ts
@@ -1,0 +1,13 @@
+import type { ZcashAccount } from "@ledgerhq/coin-zcash/types/bridge";
+
+export function findUtxo(account: ZcashAccount, hash: string, outputIndex: number) {
+  return account.bitcoinResources.utxos.find(
+    utxo => utxo.hash === hash && utxo.outputIndex === outputIndex,
+  );
+}
+
+// Utility to find a UTXO that did not exist before (i.e. a new change output).
+export function findNewUtxo(previous: ZcashAccount, current: ZcashAccount) {
+  const prevSet = new Set(previous.bitcoinResources.utxos.map(u => `${u.hash}:${u.outputIndex}`));
+  return current.bitcoinResources.utxos.find(u => !prevSet.has(`${u.hash}:${u.outputIndex}`));
+}

--- a/libs/coin-tester-modules/coin-tester-zcash/src/zcashClientTestSeam.ts
+++ b/libs/coin-tester-modules/coin-tester-zcash/src/zcashClientTestSeam.ts
@@ -1,0 +1,124 @@
+/**
+ * Test seam that captures the PCZT hex a build job produces, without any
+ * `@ledgerhq/coin-zcash` source change.
+ *
+ * `coin-zcash`'s `logic/engineClient.ts` resolves its native client lazily via
+ * a package-name dynamic import (`import("@ledgerhq/coin-zcash/network/ZCash")`),
+ * specifically so the Electron renderer's build can alias it to the IPC client
+ * instead. Jest resolves that same specifier through its own module registry,
+ * so `jest.mock("@ledgerhq/coin-zcash/network/ZCash", () =>
+ * require("./zcashClientTestSeam"))` (see scenarii.test.ts) intercepts it there
+ * too -- this module IS the mock's factory result.
+ *
+ * `createZCashClient` here re-assembles the exact same dependency set the real
+ * module's `createZCashClient` wires up (`network/ZCash.ts`'s private
+ * `defaultDeps`, rebuilt from `network/engine.ts`'s individual exports, since
+ * `defaultDeps` itself isn't exported), with the two build jobs wrapped to
+ * record their `pcztHex` before returning the result unchanged. Every other
+ * job (`getChainTipJob`, `startSyncJob`, `finalizeTransactionJob`,
+ * `broadcastTransactionJob`, `transactionDetailsJob`, `deriveShieldedAddress`,
+ * ...) is passed through untouched -- this is the real, unmocked engine
+ * hitting the real, local zaino gRPC endpoint.
+ */
+import type { ZCashClient, ZCashClientArgs } from "@ledgerhq/coin-zcash/network/types";
+import type {
+  BuildIronwoodTransactionArgs,
+  BuildIronwoodTransactionResult,
+  BuildTransactionArgs,
+  BuildTransactionResult,
+} from "@ledgerhq/coin-zcash/network/types";
+import type { ZCashClientDeps } from "@ledgerhq/coin-zcash/network/ZCash";
+import { toRegtestAddress } from "./regtestAddress";
+
+// The pinned catalog @ledgerhq/zcash-utils only added regtest network support
+// (LIVE-36479) after this seam was first written; both build jobs now force
+// `network: "regtest"` (instead of forwarding whatever coin-zcash's own
+// getZainoEndpoint() resolved -- see scenarii/zcash.ts, which deliberately
+// keeps that at "mainnet" for the *sync* path, which does not accept
+// "regtest" -- see network.rs's parse_network vs parse_any_network) so the
+// native builder's NU5/NU6.3 activation-height gate is satisfiable at all
+// against a real regtest chain, and re-encode every recipient address from
+// coin-zcash's mainnet-only encoding into its regtest equivalent (see
+// regtestAddress.ts for why both changes are necessary, verified against the
+// real native addon).
+const BUILD_NETWORK = "regtest";
+
+type ZCashNetworkModule = typeof import("@ledgerhq/coin-zcash/network/ZCash");
+type ZCashEngineModule = typeof import("@ledgerhq/coin-zcash/network/engine");
+type ZCashRehydrateModule = typeof import("@ledgerhq/coin-zcash/network/serialization/rehydrate");
+type ZCashSyncEstimatorModule = typeof import("@ledgerhq/coin-zcash/network/sync-estimator");
+
+const actualZCash = jest.requireActual<ZCashNetworkModule>("@ledgerhq/coin-zcash/network/ZCash");
+const engine = jest.requireActual<ZCashEngineModule>("@ledgerhq/coin-zcash/network/engine");
+const { rehydrateSyncResult } = jest.requireActual<ZCashRehydrateModule>(
+  "@ledgerhq/coin-zcash/network/serialization/rehydrate",
+);
+const { createSyncTimeEstimator } = jest.requireActual<ZCashSyncEstimatorModule>(
+  "@ledgerhq/coin-zcash/network/sync-estimator",
+);
+
+/**
+ * Last PCZT hex a build job produced, keyed by account index. `signer.ts`'s
+ * `signPcztTransaction` looks this up to recover the exact bytes it is being
+ * asked to sign (the PcztTransaction the signer receives is the *parsed*
+ * structure -- the hex form `testSignPczt` needs is only available here,
+ * where the raw build result is still in hand).
+ */
+const capturedPcztHexByAccount = new Map<number, string>();
+
+export function getCapturedPcztHex(accountIndex: number): string {
+  const hex = capturedPcztHexByAccount.get(accountIndex);
+  if (!hex) {
+    throw new Error(
+      `No PCZT hex captured yet for account ${accountIndex} -- craftTransaction/craftIronwoodTransaction must run before signPcztTransaction`,
+    );
+  }
+  return hex;
+}
+
+async function recordingBuildTransactionJob(
+  args: Omit<BuildTransactionArgs, "requestId">,
+): Promise<BuildTransactionResult> {
+  const regtestArgs: Omit<BuildTransactionArgs, "requestId"> = {
+    ...args,
+    network: BUILD_NETWORK,
+    outputs: args.outputs.map(output => ({ ...output, address: toRegtestAddress(output.address) })),
+  };
+  const built = await engine.buildTransactionJob(regtestArgs);
+  capturedPcztHexByAccount.set(args.accountIndex, built.pcztHex);
+  return built;
+}
+
+async function recordingBuildIronwoodTransactionJob(
+  args: Omit<BuildIronwoodTransactionArgs, "requestId">,
+): Promise<BuildIronwoodTransactionResult> {
+  const regtestArgs: Omit<BuildIronwoodTransactionArgs, "requestId"> = {
+    ...args,
+    network: BUILD_NETWORK,
+    outputs: args.outputs.map(output => ({ ...output, address: toRegtestAddress(output.address) })),
+  };
+  const built = await engine.buildIronwoodTransactionJob(regtestArgs);
+  capturedPcztHexByAccount.set(args.accountIndex, built.pcztHex);
+  return built;
+}
+
+const deps: ZCashClientDeps = {
+  getChainTipJob: engine.getChainTipJob,
+  findBlockHeightJob: engine.findBlockHeightJob,
+  validateStartSyncArgs: engine.validateStartSyncArgs,
+  startSyncJob: engine.startSyncJob,
+  rehydrateSyncResult,
+  createSyncTimeEstimator,
+  buildTransactionJob: recordingBuildTransactionJob,
+  buildIronwoodTransactionJob: recordingBuildIronwoodTransactionJob,
+  finalizeTransactionJob: engine.finalizeTransactionJob,
+  broadcastTransactionJob: engine.broadcastTransactionJob,
+  transactionDetailsJob: engine.transactionDetailsJob,
+  deriveShieldedAddress: engine.deriveShieldedAddress,
+};
+
+export function createZCashClient(args: ZCashClientArgs): ZCashClient {
+  return actualZCash.createZCashClientWith(deps, args);
+}
+
+export const createZCashClientWith = actualZCash.createZCashClientWith;

--- a/libs/coin-tester-modules/coin-tester-zcash/tsconfig.build.json
+++ b/libs/coin-tester-modules/coin-tester-zcash/tsconfig.build.json
@@ -1,0 +1,23 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "customConditions": [],
+    "types": [
+      "node",
+      "jest"
+    ]
+  },
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/__tests__/**/*",
+    "**/tests/**/*",
+    "**/__mocks__/**/*",
+    "**/*.test.js",
+    "**/*.test.jsx",
+    "**/*.spec.js",
+    "**/*.spec.jsx"
+  ]
+}

--- a/libs/coin-tester-modules/coin-tester-zcash/tsconfig.json
+++ b/libs/coin-tester-modules/coin-tester-zcash/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../tsconfig.base",
+  "compilerOptions": {
+    "lib": ["es2022", "dom"],
+    "outDir": "lib",
+    "rootDir": "src",
+    "types": ["node", "jest"],
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*", "src/**/*.json"]
+}

--- a/libs/live-currency-format/src/__snapshots__/formatCurrencyUnit.test.ts.snap
+++ b/libs/live-currency-format/src/__snapshots__/formatCurrencyUnit.test.ts.snap
@@ -392,6 +392,8 @@ exports[`formatCurrencyUnit with custom options with locale de-DE should correct
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format ZKsync unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
+exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Zcash Regtest unit (zcash) 1`] = `"123.456.789,00000000- -𝚝ZEC"`;
+
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Zcash unit (zcash) 1`] = `"123.456.789,00000000- -ZEC"`;
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Zenrock unit (Zenrock) 1`] = `"12.345.678.900,000000- -ROCK"`;
@@ -795,6 +797,8 @@ exports[`formatCurrencyUnit with custom options with locale en-US should correct
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format ZKsync Sepolia unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format ZKsync unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
+
+exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Zcash Regtest unit (zcash) 1`] = `"123,456,789.00000000- -𝚝ZEC"`;
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Zcash unit (zcash) 1`] = `"123,456,789.00000000- -ZEC"`;
 
@@ -1200,6 +1204,8 @@ exports[`formatCurrencyUnit with custom options with locale es-ES should correct
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format ZKsync unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
+exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Zcash Regtest unit (zcash) 1`] = `"123.456.789,00000000- -𝚝ZEC"`;
+
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Zcash unit (zcash) 1`] = `"123.456.789,00000000- -ZEC"`;
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Zenrock unit (Zenrock) 1`] = `"12.345.678.900,000000- -ROCK"`;
@@ -1603,6 +1609,8 @@ exports[`formatCurrencyUnit with custom options with locale fr-FR should correct
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format ZKsync Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format ZKsync unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
+
+exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Zcash Regtest unit (zcash) 1`] = `"123 456 789,00000000- -𝚝ZEC"`;
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Zcash unit (zcash) 1`] = `"123 456 789,00000000- -ZEC"`;
 
@@ -2008,6 +2016,8 @@ exports[`formatCurrencyUnit with custom options with locale ja-JP should correct
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format ZKsync unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
+exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Zcash Regtest unit (zcash) 1`] = `"123,456,789.00000000- -𝚝ZEC"`;
+
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Zcash unit (zcash) 1`] = `"123,456,789.00000000- -ZEC"`;
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Zenrock unit (Zenrock) 1`] = `"12,345,678,900.000000- -ROCK"`;
@@ -2411,6 +2421,8 @@ exports[`formatCurrencyUnit with custom options with locale ko-KR should correct
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format ZKsync Sepolia unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format ZKsync unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
+
+exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Zcash Regtest unit (zcash) 1`] = `"123,456,789.00000000- -𝚝ZEC"`;
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Zcash unit (zcash) 1`] = `"123,456,789.00000000- -ZEC"`;
 
@@ -2816,6 +2828,8 @@ exports[`formatCurrencyUnit with custom options with locale pt-BR should correct
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format ZKsync unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
+exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Zcash Regtest unit (zcash) 1`] = `"123.456.789,00000000- -𝚝ZEC"`;
+
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Zcash unit (zcash) 1`] = `"123.456.789,00000000- -ZEC"`;
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Zenrock unit (Zenrock) 1`] = `"12.345.678.900,000000- -ROCK"`;
@@ -3219,6 +3233,8 @@ exports[`formatCurrencyUnit with custom options with locale ru-RU should correct
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format ZKsync Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format ZKsync unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
+
+exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Zcash Regtest unit (zcash) 1`] = `"123 456 789,00000000- -𝚝ZEC"`;
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Zcash unit (zcash) 1`] = `"123 456 789,00000000- -ZEC"`;
 
@@ -3624,6 +3640,8 @@ exports[`formatCurrencyUnit with custom options with locale tr-TR should correct
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format ZKsync unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
+exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Zcash Regtest unit (zcash) 1`] = `"123.456.789,00000000- -𝚝ZEC"`;
+
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Zcash unit (zcash) 1`] = `"123.456.789,00000000- -ZEC"`;
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Zenrock unit (Zenrock) 1`] = `"12.345.678.900,000000- -ROCK"`;
@@ -4028,6 +4046,8 @@ exports[`formatCurrencyUnit with custom options with locale zh-CN should correct
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format ZKsync unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
+exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Zcash Regtest unit (zcash) 1`] = `"123,456,789.00000000- -𝚝ZEC"`;
+
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Zcash unit (zcash) 1`] = `"123,456,789.00000000- -ZEC"`;
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Zenrock unit (Zenrock) 1`] = `"12,345,678,900.000000- -ROCK"`;
@@ -4431,6 +4451,8 @@ exports[`formatCurrencyUnit with default options should correctly format ZCoin u
 exports[`formatCurrencyUnit with default options should correctly format ZKsync Sepolia unit (ETH) 1`] = `"0.0123456"`;
 
 exports[`formatCurrencyUnit with default options should correctly format ZKsync unit (ETH) 1`] = `"0.0123456"`;
+
+exports[`formatCurrencyUnit with default options should correctly format Zcash Regtest unit (zcash) 1`] = `"123,456,789"`;
 
 exports[`formatCurrencyUnit with default options should correctly format Zcash unit (zcash) 1`] = `"123,456,789"`;
 

--- a/libs/wallet-btc/src/__tests__/utils.test.ts
+++ b/libs/wallet-btc/src/__tests__/utils.test.ts
@@ -137,6 +137,9 @@ describe("Unit tests for various utils functions", () => {
     validateAddrs(["MFYvHZcZ35typC4k2XyvRVooCDZxnoDS4B"], "qtum", true);
     validateAddrs(["t1b1Rbw2shhJkP6MCnCyxCPuyFedHrwKty8"], "zcash", true);
     validateAddrs(["t3PU1j7YW3fJ67jUbkGhSRto8qK2qXCUiW3"], "zcash", true);
+    // zcash_regtest reuses zcash's own (mainnet) version bytes -- see crypto/factory.ts.
+    validateAddrs(["t1b1Rbw2shhJkP6MCnCyxCPuyFedHrwKty8"], "zcash_regtest", true);
+    validateAddrs(["t3PU1j7YW3fJ67jUbkGhSRto8qK2qXCUiW3"], "zcash_regtest", true);
     validateAddrs(["AYRf8r4SJhmfaEwmWvY8ujmrepbrWyenFr"], "bitcoin_gold", true);
     validateAddrs(["D8cMCRimfjwQ9E8jJvgUswt18WnZbCUAaW"], "dogecoin", true);
     validateAddrs(["dgb1q7zjgqa23xzf602ljfrc94248a9u27xml08nhct"], "digibyte", true);
@@ -155,6 +158,8 @@ describe("Unit tests for various utils functions", () => {
     validateAddrs(["MFYvHZcZ35typC4k2XyvRVooCDZxnoDS44"], "qtum", false);
     validateAddrs(["t1b1Rbw2shhJkP6MCnCyxCPuyFedHrwKtyy"], "zcash", false);
     validateAddrs(["t3PU1j7YW3fJ67jUbkGySRto8qK2qXCUiW3"], "zcash", false);
+    validateAddrs(["t1b1Rbw2shhJkP6MCnCyxCPuyFedHrwKtyy"], "zcash_regtest", false);
+    validateAddrs(["t3PU1j7YW3fJ67jUbkGySRto8qK2qXCUiW3"], "zcash_regtest", false);
     validateAddrs(["AYRf8r4SJhmfaEwmWvY8ujmrepbrWyenFF"], "bitcoin_gold", false);
     validateAddrs(["D8cMCRimfjwQ9E8jJvgUswt18WnZbCUAaa"], "dogecoin", false);
     validateAddrs(["dgb1q7zjgqa23xzf602ljfrc94248a9u27xml08nhcc"], "digibyte", false);

--- a/libs/wallet-btc/src/crypto/factory.ts
+++ b/libs/wallet-btc/src/crypto/factory.ts
@@ -35,6 +35,16 @@ export default function cryptoFactory(currency: Currency): ICrypto {
       res = new crypto.Zec({ network });
       break;
     }
+    case "zcash_regtest": {
+      // Deliberately reuses the mainnet version bytes, not `coininfo.zcash.test`:
+      // @ledgerhq/coin-zcash's own recipient classifier hardcodes mainnet address
+      // prefixes with no per-network parameterization, so a testnet-encoded
+      // address would never validate there. See `zcash_regtest.ts` in
+      // domain/entity/currency-crypto for the full rationale.
+      const network = coininfo.zcash.main.toBitcoinJS();
+      res = new crypto.Zec({ network });
+      break;
+    }
     case "bitcoin_gold": {
       const network = coininfo["bitcoin gold"].main.toBitcoinJS();
       res = new crypto.BitcoinGold({ network });

--- a/libs/wallet-btc/src/crypto/factory.ts
+++ b/libs/wallet-btc/src/crypto/factory.ts
@@ -30,17 +30,14 @@ export default function cryptoFactory(currency: Currency): ICrypto {
       res = new crypto.Qtum({ network });
       break;
     }
-    case "zcash": {
-      const network = coininfo.zcash.main.toBitcoinJS();
-      res = new crypto.Zec({ network });
-      break;
-    }
+    // `zcash_regtest` deliberately reuses mainnet's version bytes, not
+    // `coininfo.zcash.test`: @ledgerhq/coin-zcash's own recipient classifier
+    // hardcodes mainnet address prefixes with no per-network
+    // parameterization, so a testnet-encoded address would never validate
+    // there. See `zcash_regtest.ts` in domain/entity/currency-crypto for the
+    // full rationale.
+    case "zcash":
     case "zcash_regtest": {
-      // Deliberately reuses the mainnet version bytes, not `coininfo.zcash.test`:
-      // @ledgerhq/coin-zcash's own recipient classifier hardcodes mainnet address
-      // prefixes with no per-network parameterization, so a testnet-encoded
-      // address would never validate there. See `zcash_regtest.ts` in
-      // domain/entity/currency-crypto for the full rationale.
       const network = coininfo.zcash.main.toBitcoinJS();
       res = new crypto.Zec({ network });
       break;

--- a/libs/wallet-btc/src/crypto/types.ts
+++ b/libs/wallet-btc/src/crypto/types.ts
@@ -35,6 +35,7 @@ export type Currency =
   | "dash"
   | "qtum"
   | "zcash"
+  | "zcash_regtest"
   | "bitcoin_gold"
   | "dogecoin"
   | "digibyte"

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "coin:tester:vechain": "pnpm --filter coin-tester-vechain",
     "coin:tester:kaspa": "pnpm --filter coin-tester-kaspa",
     "coin:tester:xrp": "pnpm --filter coin-tester-xrp",
+    "coin:tester:zcash": "pnpm --filter coin-tester-zcash",
     "evm-tools": "pnpm --filter evm-tools",
     "domain": "pnpm --filter domain-service",
     "doc": "pnpm --filter docs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12095,9 +12095,6 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.0
-      bip32:
-        specifier: ^4.0.0
-        version: 4.0.0
       bs58check:
         specifier: ^4.0.0
         version: 4.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22451,7 +22451,7 @@ packages:
     resolution: {integrity: sha512-gtSepkiGXvwIyvMC0DhNNYfZKt2BXFZ7IeFIY7h3Edz9ya5LxaRWWe3Zczo5Ex2CHgH2ALfXew+tZOod9Hd6Rg==}
 
   '@ledgerhq/zcash-utils@2.4.0':
-    resolution: {integrity: sha512-lsAydrDeudztkKIfgbVPV+3n0oYyWj+cjq5HlVDea6nuhGs1RvE5RYwe0grixfpZ3BUOSD2ebpLgfV76L35qEg==, tarball: https://jfrog.ledgerlabs.net/artifactory/api/npm/ledger-live-npm-virtual-green/@ledgerhq/zcash-utils/-/@ledgerhq/zcash-utils-2.4.0.tgz}
+    resolution: {integrity: sha512-lsAydrDeudztkKIfgbVPV+3n0oYyWj+cjq5HlVDea6nuhGs1RvE5RYwe0grixfpZ3BUOSD2ebpLgfV76L35qEg==}
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12017,6 +12017,97 @@ importers:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
 
+  libs/coin-tester-modules/coin-tester-zcash:
+    dependencies:
+      '@ledgerhq/coin-tester':
+        specifier: workspace:^
+        version: link:../../coin-tester
+      '@ledgerhq/coin-zcash':
+        specifier: workspace:^
+        version: link:../../coin-modules/coin-zcash
+      '@ledgerhq/ledger-wallet-framework':
+        specifier: workspace:^
+        version: link:../../ledger-wallet-framework
+      '@ledgerhq/live-common':
+        specifier: workspace:^
+        version: link:../../ledger-live-common
+      '@ledgerhq/live-config':
+        specifier: workspace:^
+        version: link:../../live-config
+      '@ledgerhq/live-env':
+        specifier: workspace:^
+        version: link:../../env
+      '@ledgerhq/live-network':
+        specifier: workspace:^
+        version: link:../../live-network
+      '@ledgerhq/live-signer-zcash':
+        specifier: workspace:^
+        version: link:../../live-signer-zcash
+      '@ledgerhq/types-live':
+        specifier: workspace:^
+        version: link:../../types-live
+      '@ledgerhq/wallet-btc':
+        specifier: workspace:^
+        version: link:../../wallet-btc
+      '@ledgerhq/zcash-utils':
+        specifier: 'catalog:'
+        version: 2.2.0
+      '@noble/curves':
+        specifier: 1.9.7
+        version: 1.9.7
+      '@noble/hashes':
+        specifier: 1.8.0
+        version: 1.8.0
+      bignumber.js:
+        specifier: 9.1.2
+        version: 9.1.2
+      bip39:
+        specifier: ^3.1.0
+        version: 3.1.0
+      bs58:
+        specifier: 'catalog:'
+        version: 4.0.1
+      chalk:
+        specifier: ^4.1.2
+        version: 4.1.2
+      docker-compose:
+        specifier: ^1.1.0
+        version: 1.1.0
+      msw:
+        specifier: 'catalog:'
+        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+    devDependencies:
+      '@ledgerhq/wallet-framework-test-setup':
+        specifier: workspace:^
+        version: link:../../wallet-framework-test-setup
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/bs58':
+        specifier: 'catalog:'
+        version: 4.0.4
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.4.1(@types/node@24.12.0)
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.64.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.79.0
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
   libs/concordium-core:
     dependencies:
       bs58check:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12095,6 +12095,12 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.0
+      bip32:
+        specifier: ^4.0.0
+        version: 4.0.0
+      bs58check:
+        specifier: ^4.0.0
+        version: 4.0.0
       jest:
         specifier: 'catalog:'
         version: 30.5.0(@types/node@24.12.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,8 +142,8 @@ catalogs:
       specifier: 2.3.3
       version: 2.3.3
     '@ledgerhq/zcash-utils':
-      specifier: 2.2.0
-      version: 2.2.0
+      specifier: 2.4.0
+      version: 2.4.0
     '@nx/devkit':
       specifier: 22.7.8
       version: 22.7.8
@@ -1157,7 +1157,7 @@ importers:
         version: link:../../libs/wallet-pnl
       '@ledgerhq/zcash-utils':
         specifier: 'catalog:'
-        version: 2.2.0
+        version: 2.4.0
       '@lottiefiles/dotlottie-react':
         specifier: 0.17.13
         version: 0.17.13(react@19.1.4)
@@ -10713,7 +10713,7 @@ importers:
         version: link:../../wallet-btc
       '@ledgerhq/zcash-utils':
         specifier: 'catalog:'
-        version: 2.2.0
+        version: 2.4.0
       '@noble/hashes':
         specifier: 1.8.0
         version: 1.8.0
@@ -12051,7 +12051,7 @@ importers:
         version: link:../../wallet-btc
       '@ledgerhq/zcash-utils':
         specifier: 'catalog:'
-        version: 2.2.0
+        version: 2.4.0
       '@noble/curves':
         specifier: 1.9.7
         version: 1.9.7
@@ -22450,8 +22450,8 @@ packages:
   '@ledgerhq/wallet-api-simulator@2.3.3':
     resolution: {integrity: sha512-gtSepkiGXvwIyvMC0DhNNYfZKt2BXFZ7IeFIY7h3Edz9ya5LxaRWWe3Zczo5Ex2CHgH2ALfXew+tZOod9Hd6Rg==}
 
-  '@ledgerhq/zcash-utils@2.2.0':
-    resolution: {integrity: sha512-8ghTxspNrXUWaJBnoW/NuWF4sDlzH7E8/lg7iZc1BQ0RGZMEh3XiM0yF9mz5oB7Hqudb9UQNEg7Xu3q32J4YGQ==}
+  '@ledgerhq/zcash-utils@2.4.0':
+    resolution: {integrity: sha512-lsAydrDeudztkKIfgbVPV+3n0oYyWj+cjq5HlVDea6nuhGs1RvE5RYwe0grixfpZ3BUOSD2ebpLgfV76L35qEg==, tarball: https://jfrog.ledgerlabs.net/artifactory/api/npm/ledger-live-npm-virtual-green/@ledgerhq/zcash-utils/-/@ledgerhq/zcash-utils-2.4.0.tgz}
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
@@ -48422,7 +48422,7 @@ snapshots:
       - encoding
       - utf-8-validate
 
-  '@ledgerhq/zcash-utils@2.2.0': {}
+  '@ledgerhq/zcash-utils@2.4.0': {}
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 
@@ -65155,7 +65155,9 @@ snapshots:
     optionalDependencies:
       metro-transform-worker: 0.83.7
     transitivePeerDependencies:
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   metro-core@0.81.5:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12097,7 +12097,7 @@ importers:
         version: 24.12.0
       jest:
         specifier: 'catalog:'
-        version: 30.4.1(@types/node@24.12.0)
+        version: 30.5.0(@types/node@24.12.0)
       oxfmt:
         specifier: 'catalog:'
         version: 0.64.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -60,7 +60,7 @@ catalog:
   "@ledgerhq/wallet-api-core": 2.0.0
   "@ledgerhq/wallet-api-server": 3.4.3
   "@ledgerhq/wallet-api-simulator": 2.3.3
-  "@ledgerhq/zcash-utils": 2.2.0
+  "@ledgerhq/zcash-utils": 2.4.0
   # React Native
   react-native: 0.81.6
   "@react-native/assets-registry": 0.81.6


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Adds `@ledgerhq/coin-tester-zcash`, deterministic testing infrastructure for Zcash covering all 4
send flows (transparent→transparent, shielding, de-shielding, shielded→shielded) against a local
`zebra` (Regtest consensus node) + `zaino` (shielded gRPC indexer) stack. Signing is entirely
device-free, delegated to `@ledgerhq/zcash-utils`'s test-only NAPI surface
(`testDeriveKeys`/`testSignPczt`/`orchardAddressFromUfvk`). MSW bridges the wallet's Ledger-explorer
HTTP calls to `zebra`'s own address-indexed JSON-RPC, so no separate explorer service is required.

Also adds the `zcash_regtest` currency definition (mirrors `bitcoin_regtest`) and the missing
`zcash_regtest` case in `wallet-btc`'s `cryptoFactory` switch (this currency would otherwise throw
there), a CODEOWNERS entry for the new package, and CI wiring (`test-coin-tester.yml`).

A 5th scenario accumulates 3 Ironwood notes (2 partial self-sends, each splitting one note into a
payment note and a change note) then de-shields all 3 in a single sweep -- the only place in this
package that exercises `selectNotes`' largest-first multi-note selection; every other scenario here
only ever has exactly 1 spendable note at a time. (Originally accumulated 10 notes; lowered to the
minimum that still exercises the multi-note branch, since this package is device-free and the higher
count only added proof-generation/re-sync cost without adding coverage -- see review discussion.)

File count is above this org's usual PR size guideline because this is an entirely new package --
most of the diff is one-time scaffolding (docker configs, README, tsconfig, package.json), not
incremental logic.

Also fixes a real bug in `@ledgerhq/coin-zcash` that this coin-tester's own scenario surfaced: a
transparent↔shielded transaction (shielding or de-shielding) was recorded twice in
`account.operations` -- once by the transparent leg's sync, once by the shielded leg's, for the same
transaction hash. `reconcileLegOperations` (`sync.ts`) now keeps only the transparent leg's record
when both legs see the same hash. Covered by a new `reconcileLegOperations` unit test in
`coin-zcash/src/bridge/sync.test.ts` (verified red without the fix, green with it) and by this
package's own `afterAll` operation-count assertion, now exact rather than documenting a known
duplicate.

### 🔗 Context

- **JIRA / GitHub issue**: LIVE-36480
- Depends on regtest network support from `@ledgerhq/zcash-utils`
  (companion PR: LedgerHQ/ledger-zcash-utils#46, merged and published as `2.4.0`). The catalog
  entry in `pnpm-workspace.yaml` is now pinned to that real, published version -- no local link
  needed.


