### PR TITLE
[LWDM] feat(feature-flags): add the Gonka currency feature flag (LIVE-36045)

### DIFF
--- a/.changeset/gonka-currency-feature-flag.md
+++ b/.changeset/gonka-currency-feature-flag.md
@@ -1,0 +1,7 @@
+---
+"@shared/feature-flags": minor
+"@ledgerhq/live-common": minor
+"@features/platform-currencies": minor
+---
+
+Add the Gonka (GNK) currency feature flag, disabled by default

--- a/features/platform/currencies/src/hooks/useFeatureFlaggedCurrencies.test.tsx
+++ b/features/platform/currencies/src/hooks/useFeatureFlaggedCurrencies.test.tsx
@@ -24,4 +24,19 @@ describe("useFeatureFlaggedCurrencies", () => {
     const { result } = renderHook(() => useFeatureFlaggedCurrencies(true), { wrapper: Wrapper });
     expect(result.current.deactivatedCurrencyIds.size).toBe(0);
   });
+
+  it("deactivates gonka by default", () => {
+    const { Wrapper } = makeStoreWrapper();
+    const { result } = renderHook(() => useFeatureFlaggedCurrencies(), { wrapper: Wrapper });
+    expect(result.current.featureFlaggedCurrencies.gonka).toBeDefined();
+    expect(result.current.deactivatedCurrencyIds.has("gonka")).toBe(true);
+  });
+
+  it("stops deactivating gonka once its gating flag is enabled", () => {
+    const { Wrapper } = makeStoreWrapper({
+      resolved: { ...FEATURE_FLAGS_DEFAULTS, currencyGonka: { enabled: true } },
+    });
+    const { result } = renderHook(() => useFeatureFlaggedCurrencies(), { wrapper: Wrapper });
+    expect(result.current.deactivatedCurrencyIds.has("gonka")).toBe(false);
+  });
 });

--- a/features/platform/currencies/src/hooks/useFeatureFlaggedCurrencies.ts
+++ b/features/platform/currencies/src/hooks/useFeatureFlaggedCurrencies.ts
@@ -119,6 +119,7 @@ export function useFeatureFlaggedCurrencies(mock = false): FeatureFlaggedCurrenc
   const arcTestnet = useFeature("currencyArcTestnet");
   const robinhood = useFeature("currencyRobinhood");
   const robinhoodTestnet = useFeature("currencyRobinhoodTestnet");
+  const gonka = useFeature("currencyGonka");
 
   const featureFlaggedCurrencies = useMemo(
     (): FeatureFlaggedCurrencies => ({
@@ -214,6 +215,7 @@ export function useFeatureFlaggedCurrencies(mock = false): FeatureFlaggedCurrenc
       arc_testnet: arcTestnet,
       robinhood,
       robinhood_testnet: robinhoodTestnet,
+      gonka,
     }),
     [
       adi,
@@ -308,6 +310,7 @@ export function useFeatureFlaggedCurrencies(mock = false): FeatureFlaggedCurrenc
       arcTestnet,
       robinhood,
       robinhoodTestnet,
+      gonka,
     ],
   );
 

--- a/libs/ledger-live-common/src/modularDrawer/hooks/__test__/useCurrenciesUnderFeatureFlag.test.ts
+++ b/libs/ledger-live-common/src/modularDrawer/hooks/__test__/useCurrenciesUnderFeatureFlag.test.ts
@@ -55,5 +55,6 @@ describe("useCurrenciesUnderFeatureFlag", () => {
     expect(currencies).toHaveProperty("aptos");
     expect(currencies).toHaveProperty("stacks");
     expect(currencies).toHaveProperty("optimism");
+    expect(currencies).toHaveProperty("gonka");
   });
 });

--- a/libs/ledger-live-common/src/modularDrawer/hooks/useCurrenciesUnderFeatureFlag.ts
+++ b/libs/ledger-live-common/src/modularDrawer/hooks/useCurrenciesUnderFeatureFlag.ts
@@ -98,6 +98,7 @@ export function useCurrenciesUnderFeatureFlag() {
   const arcTestnet = useFeature("currencyArcTestnet");
   const robinhood = useFeature("currencyRobinhood");
   const robinhoodTestnet = useFeature("currencyRobinhoodTestnet");
+  const gonka = useFeature("currencyGonka");
 
   const featureFlaggedCurrencies = useMemo(
     (): Partial<Record<string, Feature<unknown> | null>> => ({
@@ -194,6 +195,7 @@ export function useCurrenciesUnderFeatureFlag() {
       arc_testnet: arcTestnet,
       robinhood,
       robinhood_testnet: robinhoodTestnet,
+      gonka,
     }),
     [
       adi,
@@ -288,6 +290,7 @@ export function useCurrenciesUnderFeatureFlag() {
       arcTestnet,
       robinhood,
       robinhoodTestnet,
+      gonka,
     ],
   );
 

--- a/shared/feature-flags/src/flags/team-coin-integration/currencyGonka.ts
+++ b/shared/feature-flags/src/flags/team-coin-integration/currencyGonka.ts
@@ -1,0 +1,2 @@
+import { flag } from "../../define";
+export const currencyGonka = flag();

--- a/shared/feature-flags/src/flags/team-coin-integration/index.ts
+++ b/shared/feature-flags/src/flags/team-coin-integration/index.ts
@@ -37,6 +37,7 @@ export * from "./currencyDydx";
 export * from "./currencyEnergyWeb";
 export * from "./currencyEthereumHoodi";
 export * from "./currencyEtherlink";
+export * from "./currencyGonka";
 export * from "./currencyHypercore";
 export * from "./currencyHyperevm";
 export * from "./currencyIcon";


### PR DESCRIPTION
### 📝 Description

Registers the `currencyGonka` feature flag so Gonka (GNK) stays hidden in Ledger Wallet until the
integration is complete and validated.

Registering a flag in `@shared/feature-flags` is not by itself a visibility gate — a currency is hidden
because a hook maps its id to a flag and emits `deactivatedCurrencyIds`. So this adds:

- `shared/feature-flags/src/flags/team-coin-integration/currencyGonka.ts` — the flag, declared with the
  bare `flag()` helper, so it defaults to `{ enabled: false }`
- the barrel export in that team's `index.ts` (alphabetical)
- `gonka` wired into **both** live currency-gating hooks —
  `libs/ledger-live-common/src/modularDrawer/hooks/useCurrenciesUnderFeatureFlag.ts` (modular drawer,
  wallet-api, asset-detail) and
  `features/platform/currencies/src/hooks/useFeatureFlaggedCurrencies.ts` (desktop/mobile search and
  asset surfaces) — in all three places each: the `useFeature` const, the memo object and the memo
  dependency array

The flag is **disabled by default in code**, and the Firebase Remote Config parameters
(`feature_currency_gonka`) are being created at `{"enabled": false}` in all four environments. Nothing
becomes visible to users as a result of this PR.

**Why the flag matters more than usual here.** Gonka derives on coin type 1200, which the Cosmos device
app rejects until the change tracked in LIVE-36205 reaches a release *published to the app store*. A user
reaching the flow on an older app gets APDU `0x698B`, which has no mapping anywhere in this monorepo and
so surfaces as a raw transport error rather than "update your Cosmos app". The per-app minimum-version
mechanism (`config_nanoapp_cosmos` in `libs/ledger-live-common/src/apps/config.ts`) cannot substitute: it
is keyed per device app, not per currency, so raising it would block every Cosmos-family currency. The
feature flag is the only per-currency gate available.

**Production enablement condition:** enable `feature_currency_gonka` in production only once the Cosmos
device app accepting coin type 1200 is **published to the app store** — merged is not sufficient, and the
interim fork build serves developers and CI, not users.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36045](https://ledgerhq.atlassian.net/browse/LIVE-36045)
- **ADR** (if any): n/a

### ✅ Tests

- `features/platform/currencies/src/hooks/useFeatureFlaggedCurrencies.test.tsx` — two new cases: Gonka is
  in `deactivatedCurrencyIds` by default, and leaves it once `currencyGonka` is enabled. The second is what
  catches a missing memo dependency-array entry, which no typecheck would.
- `libs/ledger-live-common/src/modularDrawer/hooks/__test__/useCurrenciesUnderFeatureFlag.test.ts` —
  `toHaveProperty("gonka")` added to the existing currency-mapping case.

Executed locally: typecheck on `@shared/feature-flags`, `@features/platform-currencies` and
`ledger-live-common` — all pass. Tests: 104/104, 50/50, and 6851/6851 respectively. `lint:fix` and
`format:check` on `ledger-live-common` — pass. Coverage measured at 100% of statements on every modified
logic file.

### ⚠️ Notes for reviewers

- **Two acceptance criteria on the ticket are deliberately not closed here.** "Gonka appears / is absent in
  account creation" cannot be exercised end-to-end yet: `gonka` is not in the cosmos `supportedCoins` list
  in `libs/ledger-live-common/src/coin-modules/loaders.ts`, which is LIVE-36038. The hook-level halves are
  covered by the unit tests above; the end-to-end assertions belong to LIVE-36046 / LIVE-36047. Nothing is
  added to `loaders.ts` in this PR.
- **The Firebase parameters are a manual step outside this PR** and are not created by merging it.
- **Nothing added to the legacy `CurrencyFeatures` type** in `libs/types-live/src/feature.ts`. Its entries
  had been in exact parity with the flag registry, and every previous currency change mirrored it (most
  recently the Scroll Sepolia removal in `6a531c54cc`), so adding `currencyGonka` there was the initial
  approach. Dropped deliberately: `DefaultFeature` is `@deprecated`, the file is "retained as published
  surface only; slated for removal", CODEOWNERS disowns it, and each new use trips SonarQube's S1874. The
  type has no runtime role — flag resolution comes from the registry and the two hooks — so the parity is
  cosmetic and not worth adding to a surface that is on its way out. Say the word if Platform would rather
  keep the mirror complete.
- The `unimported` (knip) target fails on this branch, and fails identically on the clean base branch —
  pre-existing, not introduced here.


[LIVE-36045]: https://ledgerhq.atlassian.net/browse/LIVE-36045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ