### PR TITLE
[LWDM] feat(pay-contact): send from tile and view contact (LIVE-35378)

### DIFF
--- a/.changeset/pay-contact-tile-press.md
+++ b/.changeset/pay-contact-tile-press.md
@@ -1,0 +1,8 @@
+---
+"@features/flow-pay-contact": minor
+"@support/jest-features-flow": patch
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Wire Pay contact tile press to send (prefill a single-address contact), add a desktop View contact overflow action, and render Lumen `MenuTrigger` `render` props in the shared web passthrough stub.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailPaneAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailPaneAdapter.ts
@@ -1,8 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router";
-import type { ContactId } from "@domain/entity-contact";
-import { useContactsMeContact, type ContactDeviceIntentsPort } from "@features/platform-contacts";
+import { useNavigate, useSearchParams } from "react-router";
+import { ContactIdSchema, type ContactId } from "@domain/entity-contact";
+import {
+  useContacts,
+  useContactsMeContact,
+  type ContactDeviceIntentsPort,
+} from "@features/platform-contacts";
 import {
   useContactDetailSharedState,
   useEmptyContactDetail,
@@ -42,9 +46,22 @@ export function useContactDetailPaneAdapter(
   const navigate = useNavigate();
   const analytics = useContactsAnalytics();
   const meContact = useContactsMeContact();
+  const contacts = useContacts();
   const trackedContactDetailId = useRef<ContactId | undefined>(undefined);
   const trackedAddressDetailId = useRef<string | undefined>(undefined);
-  const [detailContactId, setDetailContactId] = useState<ContactId | undefined>(meContact.id);
+  const [searchParams] = useSearchParams();
+
+  const initialDetailContactId = useMemo<ContactId>(() => {
+    const parsed = ContactIdSchema.safeParse(searchParams.get("contactId"));
+    if (parsed.success && contacts.some(contact => contact.id === parsed.data)) {
+      return parsed.data;
+    }
+    return meContact.id;
+  }, [contacts, meContact.id, searchParams]);
+
+  const [detailContactId, setDetailContactId] = useState<ContactId | undefined>(
+    initialDetailContactId,
+  );
   const onDeleteSuccess = useCallback(() => {
     setDetailContactId(meContact.id);
   }, [meContact.id]);

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayTabContacts.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayTabContacts.test.ts
@@ -1,0 +1,41 @@
+import { act, renderHook } from "tests/testSetup";
+import { mockContact } from "@domain/entity-contact/schema.mock";
+import { usePayTabContacts } from "../usePayTabContacts";
+
+const mockNavigate = jest.fn();
+const mockOpenNewPayment = jest.fn();
+
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
+  useNavigate: () => mockNavigate,
+  useLocation: () => ({ pathname: "/pay" }),
+}));
+
+jest.mock("../usePayTabNewPayment", () => ({
+  usePayTabNewPayment: () => ({ open: mockOpenNewPayment }),
+}));
+
+describe("usePayTabContacts", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should open send with the contact when the tile is pressed", () => {
+    const contact = mockContact({ id: "contact-ada", name: "Ada" });
+    const { result } = renderHook(() => usePayTabContacts());
+
+    act(() => result.current.contacts.onContactPress?.(contact));
+
+    expect(mockOpenNewPayment).toHaveBeenCalledWith(contact);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("should navigate to the contact detail when View contact is chosen", () => {
+    const contact = mockContact({ id: "contact-ada", name: "Ada" });
+    const { result } = renderHook(() => usePayTabContacts());
+
+    act(() => result.current.contacts.onViewContact?.(contact));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/contacts?contactId=contact-ada");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayTabNewPayment.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayTabNewPayment.test.ts
@@ -1,5 +1,10 @@
 import { renderHook, act } from "tests/testSetup";
 import { AssetCategory } from "@domain/api-aggregated-assets";
+import {
+  mockContact,
+  mockContactWithAddress,
+  mockContactWithMultipleAddresses,
+} from "@domain/entity-contact/schema.mock";
 import { useOpenSendFlow } from "LLD/features/Send/hooks/useOpenSendFlow";
 import { usePayTabNewPayment } from "../usePayTabNewPayment";
 
@@ -14,10 +19,39 @@ describe("usePayTabNewPayment", () => {
     mockUseOpenSendFlow.mockReturnValue(mockOpenSendFlow);
   });
 
-  it("opens the send flow from the Pay page filtered to stablecoins", () => {
+  it("should open the send flow from the Pay page filtered to stablecoins", () => {
     const { result } = renderHook(() => usePayTabNewPayment());
 
     act(() => result.current.open());
+
+    expect(mockOpenSendFlow).toHaveBeenCalledWith({
+      source: "Pay",
+      categories: [AssetCategory.Stablecoins],
+    });
+  });
+
+  it("should prefill the recipient and network for a contact with one address", () => {
+    const contact = mockContactWithAddress();
+    const address = contact.addresses[0];
+    const { result } = renderHook(() => usePayTabNewPayment());
+
+    act(() => result.current.open(contact));
+
+    expect(mockOpenSendFlow).toHaveBeenCalledWith({
+      source: "Pay",
+      currencyIds: [address.currencyId],
+      recipient: address.address,
+      skipRecipientStep: true,
+    });
+  });
+
+  it.each([
+    ["no address", mockContact()],
+    ["multiple addresses", mockContactWithMultipleAddresses()],
+  ])("should keep the account picker for a contact with %s", (_case, contact) => {
+    const { result } = renderHook(() => usePayTabNewPayment());
+
+    act(() => result.current.open(contact));
 
     expect(mockOpenSendFlow).toHaveBeenCalledWith({
       source: "Pay",

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabContacts.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabContacts.ts
@@ -53,6 +53,16 @@ export function usePayTabContacts(): UsePayTabContactsResult {
     },
     [navigate, payTabPath],
   );
+  const onContactPress = useCallback(
+    (contact: Contact) => openNewPayment(contact),
+    [openNewPayment],
+  );
+  const onViewContact = useCallback(
+    (contact: Contact) => {
+      navigate(`/contacts?contactId=${encodeURIComponent(contact.id)}`);
+    },
+    [navigate],
+  );
   const [isLedgerSyncIntroductionRequested, setIsLedgerSyncIntroductionRequested] = useState(false);
   const contactCreation = useMemo(
     () => createContactCreationPort({ dispatch, generateId: uuid }),
@@ -120,10 +130,12 @@ export function usePayTabContacts(): UsePayTabContactsResult {
           formatTransactionCount: count => t("payTab.contacts.table.transactionCount", { count }),
           payAction: t("payTab.contacts.actions.pay"),
           moreAction: t("payTab.contacts.actions.more"),
+          viewContact: t("payTab.contacts.actions.viewContact"),
           viewTransactions: t("payTab.contacts.actions.viewTransactions"),
         },
         renderAddresses: renderPayContactAddresses,
-        onPayContact: () => openNewPayment(),
+        onContactPress,
+        onViewContact,
         onViewTransactions,
         operations,
       },
@@ -144,8 +156,9 @@ export function usePayTabContacts(): UsePayTabContactsResult {
       onSaveSuccess,
       callbacks,
       operations,
+      onContactPress,
+      onViewContact,
       onViewTransactions,
-      openNewPayment,
       isLedgerSyncIntroductionOpen,
       onActivateLedgerSyncIntroduction,
       onDismissLedgerSyncIntroduction,

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabNewPayment.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabNewPayment.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { AssetCategory } from "@domain/api-aggregated-assets";
+import type { Contact } from "@domain/entity-contact";
 import { useOpenSendFlow } from "LLD/features/Send/hooks/useOpenSendFlow";
 
 const PAY_PAGE = "Pay";
@@ -9,15 +10,34 @@ const PAY_PAGE = "Pay";
 const PAY_CATEGORIES = [AssetCategory.Stablecoins] as const;
 
 export type UsePayTabNewPayment = Readonly<{
-  open: () => void;
+  open: (contact?: Contact) => void;
 }>;
 
 export function usePayTabNewPayment(): UsePayTabNewPayment {
   const openSendFlow = useOpenSendFlow();
 
-  const open = useCallback(() => {
-    openSendFlow({ source: PAY_PAGE, categories: PAY_CATEGORIES });
-  }, [openSendFlow]);
+  const open = useCallback(
+    (contact?: Contact) => {
+      // Prefill the recipient only when the contact has a single saved address; with zero or
+      // several addresses we keep the account/network picker so the user resolves the ambiguity.
+      const contactAddress = contact?.addresses.length === 1 ? contact.addresses[0] : undefined;
+      if (contactAddress) {
+        // Scope account selection to the contact address' currency so the picked account is on the
+        // same network, then skip to the amount step where the header resolves the prefilled
+        // address back to the contact and shows the "To <contact>" header.
+        openSendFlow({
+          source: PAY_PAGE,
+          currencyIds: [contactAddress.currencyId],
+          recipient: contactAddress.address,
+          skipRecipientStep: true,
+        });
+        return;
+      }
+
+      openSendFlow({ source: PAY_PAGE, categories: PAY_CATEGORIES });
+    },
+    [openSendFlow],
+  );
 
   return { open };
 }

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/createContactsFromSendHistory.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/createContactsFromSendHistory.ts
@@ -8,12 +8,15 @@ import {
 
 const MAX_SEND_HISTORY_CONTACTS = 15;
 
+/** Cycled so the generated list mixes single-address contacts with multi-address ones. */
+const SEND_HISTORY_ADDRESS_COUNTS = [1, 2, 1, 3] as const;
+
 type SendHistoryEntry = { address: string; currencyId: string; label: string; date: number };
 
 /**
- * Builds one contact per distinct address the accounts have sent to, most recent first, so the Pay
- * contacts list can be exercised against real `last sent-to` ordering instead of synthetic addresses
- * that no operation targets.
+ * Builds contacts from the distinct addresses the accounts have sent to, most recent first, so the
+ * Pay contacts list can be exercised against real `last sent-to` ordering instead of synthetic
+ * addresses that no operation targets.
  */
 export function createContactsFromSendHistory(accounts: readonly AccountLike[]): Contact[] {
   const latestByAddress = new Map<string, SendHistoryEntry>();
@@ -43,26 +46,36 @@ export function createContactsFromSendHistory(accounts: readonly AccountLike[]):
     }
   }
 
-  return [...latestByAddress.values()]
-    .sort((left, right) => right.date - left.date)
-    .slice(0, MAX_SEND_HISTORY_CONTACTS)
-    .map((entry, index) => {
-      const id = `contact-send-history-${index + 1}`;
+  const entries = [...latestByAddress.values()].sort((left, right) => right.date - left.date);
+  const contacts: Contact[] = [];
+  let cursor = 0;
 
-      return contact({
+  while (cursor < entries.length && contacts.length < MAX_SEND_HISTORY_CONTACTS) {
+    const index = contacts.length;
+    const id = `contact-send-history-${index + 1}`;
+    const addressCount = SEND_HISTORY_ADDRESS_COUNTS[index % SEND_HISTORY_ADDRESS_COUNTS.length];
+    const group = entries.slice(cursor, cursor + addressCount);
+
+    cursor += group.length;
+
+    contacts.push(
+      contact({
         id,
         isMe: false,
         name: `Payee ${index + 1}`,
-        addresses: [
+        addresses: group.map((entry, addressIndex) =>
           contactAddress({
-            id: `${id}-address-1`,
+            id: `${id}-address-${addressIndex + 1}`,
             currencyId: entry.currencyId,
-            label: entry.label,
+            label: group.length > 1 ? `${entry.label} ${addressIndex + 1}` : entry.label,
             address: entry.address,
             device: mockExternalAddressDeviceContext(),
           }),
-        ],
+        ),
         deviceCredentials: mockDeviceContactGroupCredentials(),
-      });
-    });
+      }),
+    );
+  }
+
+  return contacts;
 }

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -923,6 +923,7 @@
       "actions": {
         "pay": "Send to contact",
         "more": "More options",
+        "viewContact": "View contact",
         "viewTransactions": "View transactions"
       }
     },

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/__tests__/usePayTabNewPayment.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/__tests__/usePayTabNewPayment.test.ts
@@ -1,0 +1,61 @@
+import { act, renderHook } from "@tests/test-renderer";
+import { AssetCategory } from "@domain/api-aggregated-assets";
+import {
+  mockContact,
+  mockContactWithAddress,
+  mockContactWithMultipleAddresses,
+} from "@domain/entity-contact/schema.mock";
+import { useOpenSendFlow } from "LLM/features/Send/hooks/useOpenSendFlow";
+import { usePayTabNewPayment } from "../usePayTabNewPayment";
+
+jest.mock("LLM/features/Send/hooks/useOpenSendFlow");
+
+const mockHandleOpenSendFlow = jest.fn();
+const mockUseOpenSendFlow = jest.mocked(useOpenSendFlow);
+
+describe("usePayTabNewPayment", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseOpenSendFlow.mockReturnValue({
+      handleOpenSendFlow: mockHandleOpenSendFlow,
+    });
+  });
+
+  it("should configure and open the send flow from the Pay page filtered to stablecoins", () => {
+    const { result } = renderHook(() => usePayTabNewPayment());
+
+    expect(mockUseOpenSendFlow).toHaveBeenCalledWith({
+      sourceScreenName: "Pay",
+      categories: [AssetCategory.Stablecoins],
+    });
+
+    act(() => result.current.open());
+
+    expect(mockHandleOpenSendFlow).toHaveBeenCalledWith();
+  });
+
+  it("should prefill the recipient and network for a contact with one address", () => {
+    const contact = mockContactWithAddress();
+    const address = contact.addresses[0];
+    const { result } = renderHook(() => usePayTabNewPayment());
+
+    act(() => result.current.open(contact));
+
+    expect(mockHandleOpenSendFlow).toHaveBeenCalledWith({
+      currencyIds: [address.currencyId],
+      recipient: address.address,
+      skipRecipientStep: true,
+    });
+  });
+
+  it.each([
+    ["no address", mockContact()],
+    ["multiple addresses", mockContactWithMultipleAddresses()],
+  ])("should keep the account picker for a contact with %s", (_case, contact) => {
+    const { result } = renderHook(() => usePayTabNewPayment());
+
+    act(() => result.current.open(contact));
+
+    expect(mockHandleOpenSendFlow).toHaveBeenCalledWith();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabContacts.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabContacts.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from "react";
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import type { Contact } from "@domain/entity-contact";
 import type { ContactsNativeProps } from "@features/flow-pay-contact";
 import { useTranslation } from "@shared/i18n";
 import { NavigatorName, ScreenName } from "~/const";
@@ -20,15 +21,17 @@ export function usePayTabContacts(): ContactsNativeProps {
       params: { title: t("payTab.contacts.seeAllTitle") },
     });
   }, [navigation, t]);
+  const onContactPress = useCallback((contact: Contact) => open(contact), [open]);
 
   return useMemo(
     () => ({
       title: t("payTab.contacts.title"),
       payLabel: t("payTab.contacts.pay"),
       onPay: open,
+      onContactPress,
       onSeeAll,
       outgoingOperations,
     }),
-    [t, open, onSeeAll, outgoingOperations],
+    [t, open, onContactPress, onSeeAll, outgoingOperations],
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabNewPayment.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabNewPayment.ts
@@ -1,12 +1,13 @@
 import { useCallback } from "react";
 import { AssetCategory } from "@domain/api-aggregated-assets";
+import type { Contact } from "@domain/entity-contact";
 import { useOpenSendFlow } from "LLM/features/Send/hooks/useOpenSendFlow";
 
 const PAY_PAGE = "Pay";
 const PAY_CATEGORIES: AssetCategory[] = [AssetCategory.Stablecoins];
 
 export type UsePayTabNewPayment = Readonly<{
-  open: () => void;
+  open: (contact?: Contact) => void;
 }>;
 
 export function usePayTabNewPayment(): UsePayTabNewPayment {
@@ -15,7 +16,27 @@ export function usePayTabNewPayment(): UsePayTabNewPayment {
     categories: PAY_CATEGORIES,
   });
 
-  const open = useCallback(() => handleOpenSendFlow(), [handleOpenSendFlow]);
+  const open = useCallback(
+    (contact?: Contact) => {
+      // Prefill the recipient only when the contact has a single saved address; with zero or
+      // several addresses we keep the account/network picker so the user resolves the ambiguity.
+      const contactAddress = contact?.addresses.length === 1 ? contact.addresses[0] : undefined;
+      if (contactAddress) {
+        // Scope account selection to the contact address' currency so the picked account is on the
+        // same network, then skip to the amount step where the header resolves the prefilled
+        // address back to the contact and shows the "To <contact>" header.
+        handleOpenSendFlow({
+          currencyIds: [contactAddress.currencyId],
+          recipient: contactAddress.address,
+          skipRecipientStep: true,
+        });
+        return;
+      }
+
+      handleOpenSendFlow();
+    },
+    [handleOpenSendFlow],
+  );
 
   return { open };
 }

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/__tests__/mockContacts.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/__tests__/mockContacts.test.ts
@@ -50,6 +50,28 @@ describe("createContactsFromSendHistory", () => {
     expect(createContactsFromSendHistory([account])).toEqual([]);
   });
 
+  it("groups recipients so some contacts hold two or three addresses", () => {
+    const account = ethereumAccount(
+      Array.from({ length: 7 }, (_, index) =>
+        outOperation(
+          `op-${index}`,
+          `0x${String(index + 1)
+            .repeat(40)
+            .slice(0, 40)}`,
+          `2026-01-0${index + 1}`,
+        ),
+      ),
+    );
+
+    const contacts = createContactsFromSendHistory([account]);
+
+    expect(contacts.map(contact => contact.addresses.length)).toEqual([1, 2, 1, 3]);
+    expect(contacts[1].addresses.map(address => address.label)).toEqual(["ETH 1", "ETH 2"]);
+    expect(contacts.flatMap(contact => contact.addresses.map(address => address.id))).toHaveLength(
+      7,
+    );
+  });
+
   it("creates one contact per distinct recipient ordered by last sent-to", () => {
     const older = "0x1111111111111111111111111111111111111111";
     const newer = "0x2222222222222222222222222222222222222222";

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/mockContacts.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/mockContacts.ts
@@ -64,12 +64,15 @@ export function createContactsDebugSamples(): Contact[] {
 
 const MAX_SEND_HISTORY_CONTACTS = 15;
 
+/** Cycled so the generated list mixes single-address contacts with multi-address ones. */
+const SEND_HISTORY_ADDRESS_COUNTS = [1, 2, 1, 3] as const;
+
 type SendHistoryEntry = { address: string; currencyId: string; label: string; date: number };
 
 /**
- * Builds one contact per distinct address the accounts have sent to, most recent first, so the Pay
- * strip can be exercised against real `last sent-to` ordering instead of synthetic addresses that no
- * operation targets.
+ * Builds contacts from the distinct addresses the accounts have sent to, most recent first, so the
+ * Pay strip can be exercised against real `last sent-to` ordering instead of synthetic addresses
+ * that no operation targets.
  */
 export function createContactsFromSendHistory(accounts: readonly AccountLike[]): Contact[] {
   const latestByAddress = new Map<string, SendHistoryEntry>();
@@ -99,26 +102,36 @@ export function createContactsFromSendHistory(accounts: readonly AccountLike[]):
     }
   }
 
-  return [...latestByAddress.values()]
-    .sort((left, right) => right.date - left.date)
-    .slice(0, MAX_SEND_HISTORY_CONTACTS)
-    .map((entry, index) => {
-      const id = `contact-send-history-${index + 1}`;
+  const entries = [...latestByAddress.values()].sort((left, right) => right.date - left.date);
+  const contacts: Contact[] = [];
+  let cursor = 0;
 
-      return contact({
+  while (cursor < entries.length && contacts.length < MAX_SEND_HISTORY_CONTACTS) {
+    const index = contacts.length;
+    const id = `contact-send-history-${index + 1}`;
+    const addressCount = SEND_HISTORY_ADDRESS_COUNTS[index % SEND_HISTORY_ADDRESS_COUNTS.length];
+    const group = entries.slice(cursor, cursor + addressCount);
+
+    cursor += group.length;
+
+    contacts.push(
+      contact({
         id,
         isMe: false,
         name: `Payee ${index + 1}`,
-        addresses: [
+        addresses: group.map((entry, addressIndex) =>
           contactAddress({
-            id: `${id}-address-1`,
+            id: `${id}-address-${addressIndex + 1}`,
             currencyId: entry.currencyId,
-            label: entry.label,
+            label: group.length > 1 ? `${entry.label} ${addressIndex + 1}` : entry.label,
             address: entry.address,
             device: mockExternalAddressDeviceContext(),
           }),
-        ],
+        ),
         deviceCredentials: mockDeviceContactGroupCredentials(),
-      });
-    });
+      }),
+    );
+  }
+
+  return contacts;
 }

--- a/features/flow/pay-contact/README.md
+++ b/features/flow/pay-contact/README.md
@@ -18,17 +18,20 @@ import { Contacts } from "@features/flow-pay-contact";
   title={title}
   emptyState={{ info, addContactLabel }}
   addContact={{ labels, contactCreation, onRequestAddContact, onSaveSuccess, callbacks }}
-  labels={{ name, addresses, transactions, formatTransactionCount, payAction, moreAction, viewTransactions }}
+  labels={{ name, addresses, transactions, formatTransactionCount, payAction, moreAction, viewContact, viewTransactions }}
   renderAddresses={addresses => <PayContactAddresses addresses={addresses} />}
-  onPayContact={openNewPayment}
+  onContactPress={openNewPayment}
+  onViewContact={openContactDetail}
   onViewTransactions={openContactHistory}
   operations={operations}
 />;
 ```
 
 `renderAddresses` is app-owned (e.g. `IconStack`). Optional `operations` (incoming + outgoing
-`ContactOperation`s) fill the transaction count and order rows by last sent-to. The row overflow
-(`...`) menu exposes **View transactions** → `onViewTransactions(contact)`.
+`ContactOperation`s) fill the transaction count and order rows by last sent-to. Clicking a row (or
+its Telegram button) calls `onContactPress(contact)`. The row overflow (`...`) menu exposes
+**View contact** → `onViewContact(contact)` and **View transactions** → `onViewTransactions(contact)`;
+each item is shown only when its handler is provided.
 
 ## Native
 
@@ -38,5 +41,5 @@ import { Contacts } from "@features/flow-pay-contact";
 <Contacts title={title} payLabel={payLabel} onPay={openSend} onSeeAll={openContactsList} />;
 ```
 
-Caps at 8 contacts. `onSeeAll` opens the full list when there are more. `onContactPress` is optional
-and unused for now.
+Caps at 8 contacts. `onSeeAll` opens the full list when there are more. `onContactPress(contact)`
+fires when a contact tile is pressed.

--- a/features/flow/pay-contact/src/components/ContactMoreMenu/ContactMoreMenu.web.tsx
+++ b/features/flow/pay-contact/src/components/ContactMoreMenu/ContactMoreMenu.web.tsx
@@ -1,16 +1,22 @@
 import React from "react";
 import { IconButton, Menu, MenuContent, MenuItem, MenuTrigger } from "@ledgerhq/lumen-ui-react";
-import { Clock, MoreHorizontal } from "@ledgerhq/lumen-ui-react/symbols";
+import { Clock, Contact as ContactIcon, MoreHorizontal } from "@ledgerhq/lumen-ui-react/symbols";
 import type { Contact } from "@domain/entity-contact";
 import type { ContactsTableLabels } from "../../types";
 
 type ContactMoreMenuProps = Readonly<{
   contact: Contact;
-  labels: Pick<ContactsTableLabels, "moreAction" | "viewTransactions">;
+  labels: Pick<ContactsTableLabels, "moreAction" | "viewContact" | "viewTransactions">;
+  onViewContact?: (contact: Contact) => void;
   onViewTransactions?: (contact: Contact) => void;
 }>;
 
-export function ContactMoreMenu({ contact, labels, onViewTransactions }: ContactMoreMenuProps) {
+export function ContactMoreMenu({
+  contact,
+  labels,
+  onViewContact,
+  onViewTransactions,
+}: ContactMoreMenuProps) {
   return (
     <Menu>
       <MenuTrigger
@@ -20,20 +26,32 @@ export function ContactMoreMenu({ contact, labels, onViewTransactions }: Contact
             size="sm"
             icon={MoreHorizontal}
             aria-label={labels.moreAction}
-            disabled={!onViewTransactions}
+            disabled={!onViewContact && !onViewTransactions}
             data-testid={`pay-contacts-more-action-${contact.id}`}
           />
         }
       />
       <MenuContent side="bottom" align="end">
-        <MenuItem
-          className="cursor-pointer"
-          onClick={() => onViewTransactions?.(contact)}
-          data-testid={`pay-contacts-view-transactions-${contact.id}`}
-        >
-          <Clock size={20} />
-          {labels.viewTransactions}
-        </MenuItem>
+        {onViewContact && (
+          <MenuItem
+            className="cursor-pointer"
+            onClick={() => onViewContact(contact)}
+            data-testid={`pay-contacts-view-contact-${contact.id}`}
+          >
+            <ContactIcon size={20} />
+            {labels.viewContact}
+          </MenuItem>
+        )}
+        {onViewTransactions && (
+          <MenuItem
+            className="cursor-pointer"
+            onClick={() => onViewTransactions(contact)}
+            data-testid={`pay-contacts-view-transactions-${contact.id}`}
+          >
+            <Clock size={20} />
+            {labels.viewTransactions}
+          </MenuItem>
+        )}
       </MenuContent>
     </Menu>
   );

--- a/features/flow/pay-contact/src/components/ContactTile/ContactTile.web.tsx
+++ b/features/flow/pay-contact/src/components/ContactTile/ContactTile.web.tsx
@@ -18,7 +18,8 @@ type ContactTileProps = Readonly<{
   transactionCount: number;
   labels: ContactsTableLabels;
   renderAddresses: (addresses: Contact["addresses"]) => React.ReactNode;
-  onPay?: (contact: Contact) => void;
+  onContactPress?: (contact: Contact) => void;
+  onViewContact?: (contact: Contact) => void;
   onViewTransactions?: (contact: Contact) => void;
 }>;
 
@@ -27,11 +28,16 @@ export function ContactTile({
   transactionCount,
   labels,
   renderAddresses,
-  onPay,
+  onContactPress,
+  onViewContact,
   onViewTransactions,
 }: ContactTileProps) {
   return (
-    <TableRow data-testid={`pay-contacts-tile-${contact.id}`}>
+    <TableRow
+      clickable={Boolean(onContactPress)}
+      onClick={onContactPress ? () => onContactPress(contact) : undefined}
+      data-testid={`pay-contacts-tile-${contact.id}`}
+    >
       <TableCell>
         <TableCellItem>
           <ContactAvatar contactId={contact.id} name={contact.name} size="sm" ariaHidden />
@@ -43,19 +49,24 @@ export function ContactTile({
       <TableCell align="end">{renderAddresses(contact.addresses)}</TableCell>
       <TableCell align="end">{labels.formatTransactionCount(transactionCount)}</TableCell>
       <TableCell align="end">
-        <div className="flex items-center justify-end gap-8">
+        <div
+          className="flex items-center justify-end gap-8"
+          onClick={e => e.stopPropagation()}
+          role="presentation"
+        >
           <IconButton
             appearance="gray"
             size="sm"
             icon={Telegram}
             aria-label={labels.payAction}
-            disabled={!onPay}
-            onClick={() => onPay?.(contact)}
+            disabled={!onContactPress}
+            onClick={() => onContactPress?.(contact)}
             data-testid={`pay-contacts-pay-action-${contact.id}`}
           />
           <ContactMoreMenu
             contact={contact}
             labels={labels}
+            onViewContact={onViewContact}
             onViewTransactions={onViewTransactions}
           />
         </div>

--- a/features/flow/pay-contact/src/components/Contacts/__tests__/ContactsView.web.test.tsx
+++ b/features/flow/pay-contact/src/components/Contacts/__tests__/ContactsView.web.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { mockContact } from "@domain/entity-contact/schema.mock";
 import { ContactsView } from "../ContactsView.web";
 import { makeContactsViewProps, renderWithContacts } from "./shared";
@@ -49,5 +50,42 @@ describe("ContactsView (Web)", () => {
     renderView();
 
     expect(screen.queryByTestId("contacts-add-contact-dialog")).not.toBeInTheDocument();
+  });
+
+  it("should call onContactPress with the contact when the row is clicked", async () => {
+    const user = userEvent.setup();
+    const onContactPress = jest.fn();
+    const contact = mockContact({ id: "contact-ada", name: "Ada" });
+    renderView({ isEmpty: false, rows: [{ contact, transactionCount: 0 }], onContactPress });
+
+    await user.click(screen.getByTestId("pay-contacts-tile-contact-ada"));
+
+    expect(onContactPress).toHaveBeenCalledTimes(1);
+    expect(onContactPress).toHaveBeenCalledWith(contact);
+  });
+
+  it("should call onContactPress once from the Telegram action without firing the row twice", async () => {
+    const user = userEvent.setup();
+    const onContactPress = jest.fn();
+    const contact = mockContact({ id: "contact-ada", name: "Ada" });
+    renderView({ isEmpty: false, rows: [{ contact, transactionCount: 0 }], onContactPress });
+
+    await user.click(screen.getByTestId("pay-contacts-pay-action-contact-ada"));
+
+    expect(onContactPress).toHaveBeenCalledTimes(1);
+    expect(onContactPress).toHaveBeenCalledWith(contact);
+  });
+
+  it("should expose View contact in the overflow menu and call onViewContact", async () => {
+    const user = userEvent.setup();
+    const onViewContact = jest.fn();
+    const contact = mockContact({ id: "contact-ada", name: "Ada" });
+    renderView({ isEmpty: false, rows: [{ contact, transactionCount: 0 }], onViewContact });
+
+    await user.click(screen.getByTestId("pay-contacts-more-action-contact-ada"));
+    await user.click(screen.getByTestId("pay-contacts-view-contact-contact-ada"));
+
+    expect(onViewContact).toHaveBeenCalledTimes(1);
+    expect(onViewContact).toHaveBeenCalledWith(contact);
   });
 });

--- a/features/flow/pay-contact/src/components/Contacts/__tests__/shared.web.tsx
+++ b/features/flow/pay-contact/src/components/Contacts/__tests__/shared.web.tsx
@@ -63,6 +63,7 @@ export const tableLabels: ContactsTableLabels = {
   formatTransactionCount: count => `${count} transaction`,
   payAction: "Pay",
   moreAction: "More",
+  viewContact: "View contact",
   viewTransactions: "View transactions",
 };
 

--- a/features/flow/pay-contact/src/components/ContactsTable/ContactsTable.web.tsx
+++ b/features/flow/pay-contact/src/components/ContactsTable/ContactsTable.web.tsx
@@ -12,14 +12,15 @@ import type { ContactsViewProps } from "../../types";
 
 type ContactsTableProps = Pick<
   ContactsViewProps,
-  "rows" | "labels" | "renderAddresses" | "onPayContact" | "onViewTransactions"
+  "rows" | "labels" | "renderAddresses" | "onContactPress" | "onViewContact" | "onViewTransactions"
 >;
 
 export function ContactsTable({
   rows,
   labels,
   renderAddresses,
-  onPayContact,
+  onContactPress,
+  onViewContact,
   onViewTransactions,
 }: ContactsTableProps) {
   return (
@@ -41,7 +42,8 @@ export function ContactsTable({
               transactionCount={transactionCount}
               labels={labels}
               renderAddresses={renderAddresses}
-              onPay={onPayContact}
+              onContactPress={onContactPress}
+              onViewContact={onViewContact}
               onViewTransactions={onViewTransactions}
             />
           ))}

--- a/features/flow/pay-contact/src/types.ts
+++ b/features/flow/pay-contact/src/types.ts
@@ -30,6 +30,7 @@ export type ContactsTableLabels = Readonly<{
   formatTransactionCount: (count: number) => string;
   payAction: string;
   moreAction: string;
+  viewContact: string;
   viewTransactions: string;
 }>;
 
@@ -39,7 +40,8 @@ export type ContactsProps = Readonly<{
   addContact: PayAddContactProps;
   labels: ContactsTableLabels;
   renderAddresses: (addresses: Contact["addresses"]) => ReactNode;
-  onPayContact?: (contact: Contact) => void;
+  onContactPress?: (contact: Contact) => void;
+  onViewContact?: (contact: Contact) => void;
   onViewTransactions?: (contact: Contact) => void;
   operations?: readonly ContactOperation[];
 }>;
@@ -51,7 +53,7 @@ export type ContactRowViewModel = Readonly<{
 
 export type ContactsViewProps = Pick<
   ContactsProps,
-  "title" | "labels" | "renderAddresses" | "onPayContact" | "onViewTransactions"
+  "title" | "labels" | "renderAddresses" | "onContactPress" | "onViewContact" | "onViewTransactions"
 > &
   Readonly<{
     isEmpty: boolean;

--- a/support/jest-features-flow/mocks/passthrough-web.js
+++ b/support/jest-features-flow/mocks/passthrough-web.js
@@ -68,6 +68,14 @@ function Tag({ label, children, ...props }) {
   return React.createElement("span", { ...props, label }, label, children);
 }
 
+// `MenuTrigger` takes its trigger element through `render`, not through children, so the generic
+// stub would drop it and the consumer's button would never reach the DOM.
+function MenuTrigger({ render, children, ...props }) {
+  if (React.isValidElement(render)) return React.cloneElement(render, props);
+
+  return React.createElement("button", { type: "button", ...props }, children);
+}
+
 function Tooltip({ children, onOpenChange, open }) {
   return React.createElement(
     TooltipOpenContext.Provider,
@@ -136,6 +144,7 @@ module.exports = new Proxy(
     DialogContent,
     DialogHeader,
     InteractiveIcon,
+    MenuTrigger,
     Tag,
     resolveAvatarColor,
     Tooltip,


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Pay contact tiles did not start a payment from the strip/table, and desktop had no overflow action to open a contact's detail.

This implements the remaining [LIVE-35378](https://ledgerhq.atlassian.net/browse/LIVE-35378) press and row-action model:

- Tile press (and the desktop Telegram button) calls `onContactPress`, which opens Send. The recipient is prefilled only when the contact has a single saved address; otherwise the account/network picker stays.
- Desktop overflow adds **View contact** (`onViewContact`) and navigates to `/contacts?contactId=…`.
- The contacts debug send-history generator groups some payees with 2 or 3 addresses so the multi-address send path can be exercised.

Package usage (web):

```tsx
<Contacts
  labels={{ ..., viewContact, viewTransactions }}
  onContactPress={openNewPayment}
  onViewContact={openContactDetail}
  onViewTransactions={openContactHistory}
/>
```

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35378](https://ledgerhq.atlassian.net/browse/LIVE-35378)
- **ADR** (if any): —

[LIVE-35378]: https://ledgerhq.atlassian.net/browse/LIVE-35378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-35378]: https://ledgerhq.atlassian.net/browse/LIVE-35378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ