### PR TITLE
[LWD] feat(contacts): run the prefilled add address flows on the device (LIVE-36795)

### DIFF
--- a/.changeset/contacts-prefill-add-address-device-intent-desktop.md
+++ b/.changeset/contacts-prefill-add-address-device-intent-desktop.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Run the prefilled add address flows on the device: the Contacts deep link and the Send add-contact steps now execute the register external address intent through the Device Intent Executor instead of the mocked device intents port

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/prefillAddAddress/PrefillAddAddressFlowRoot.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/prefillAddAddress/PrefillAddAddressFlowRoot.tsx
@@ -12,15 +12,21 @@ import {
   type ContactsAddAddressNameLabels,
   type ContactsAddAddressReviewLabels,
 } from "@features/flow-contacts-add-address";
-import { createMockContactDeviceIntentsPort } from "@features/platform-contacts";
+import { useContactsIntentsOrchestrator } from "@features/platform-contacts/device";
+import { getMinVersion } from "@ledgerhq/live-common/apps/support";
+import { DeviceIntentExecutorLWD } from "LLD/components/DeviceIntentExecutor";
 import { ContactsAddAddressFlowDialog } from "../../screens/Contacts/components/ContactsAddAddressFlowDialog";
 import type { ContactsAddAddressFlowDialogProps } from "../../screens/Contacts/components/ContactsAddAddressFlowDialog/types";
+import { contactsIntentLWDDefinitions } from "../../deviceIntents/contactsIntentPlatformDefinitions";
 import { useContactsAddressValidationAdapter } from "../useContactsAddressValidationAdapter";
 
 export function PrefillAddAddressFlowRoot(): React.JSX.Element | null {
   const { t } = useTranslation();
   const addressValidation = useContactsAddressValidationAdapter();
-  const deviceIntents = useMemo(() => createMockContactDeviceIntentsPort(), []);
+  const { deviceIntents, dieProps } = useContactsIntentsOrchestrator({
+    intents: contactsIntentLWDDefinitions,
+    getLiveConfigMinVersion: getMinVersion,
+  });
   const { state, updateAddressLabel, continueFromName, onBack, onClose, saveFromReview } =
     usePrefillAddAddressFlow({ addressValidation, deviceIntents });
 
@@ -61,6 +67,10 @@ export function PrefillAddAddressFlowRoot(): React.JSX.Element | null {
     }),
     [t],
   );
+
+  if (dieProps?.enabled === true) {
+    return <DeviceIntentExecutorLWD sourceFlow="contacts" {...dieProps} />;
+  }
 
   if (!isPrefillAddAddressFlowOpen(state)) {
     return null;

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendPrefillAddAddressFlow.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendPrefillAddAddressFlow.ts
@@ -11,7 +11,11 @@ import {
 } from "@domain/entity-contact";
 import { SEND_FLOW_STEP, type SendFlowStep } from "@ledgerhq/live-common/flows/send/types";
 import { resolvePrefillAddAddressParams } from "@ledgerhq/live-common/flows/send/recipient/utils/resolvePrefillAddAddressParams";
-import { createMockContactDeviceIntentsPort } from "@features/platform-contacts";
+import {
+  useContactsIntentsOrchestrator,
+  type ContactsDeviceIntentExecutorProps,
+} from "@features/platform-contacts/device";
+import { getMinVersion } from "@ledgerhq/live-common/apps/support";
 import {
   isPrefillAddAddressFlowOpen,
   useAddAddressFlowViewModel,
@@ -21,6 +25,7 @@ import {
   type ContactsAddAddressReviewLabels,
   type PrefillAddAddressFlowVisibleState,
 } from "@features/flow-contacts-add-address";
+import { contactsIntentLWDDefinitions } from "LLD/features/Contacts/deviceIntents/contactsIntentPlatformDefinitions";
 import { useContactsAddressValidationAdapter } from "LLD/features/Contacts/hooks/useContactsAddressValidationAdapter";
 import { useDispatch } from "LLD/hooks/redux";
 import { useFlowWizard } from "../../FlowWizard/FlowWizardContext";
@@ -37,6 +42,7 @@ export type SendPrefillAddAddressPhase = Readonly<{
   nameLabels: ContactsAddAddressNameLabels;
   reviewLabels: ContactsAddAddressReviewLabels;
   completionLabels: AddAddressCompletionLabels;
+  dieProps: ContactsDeviceIntentExecutorProps | undefined;
   onAddressLabelChange: (value: string) => void;
   onContinueFromName: () => void;
   onContinueFromReview: () => void;
@@ -70,7 +76,10 @@ export function useSendPrefillAddAddressFlow({
   const saveRequestId = useRef(0);
   const isSaving = useRef(false);
   const addressValidation = useContactsAddressValidationAdapter();
-  const deviceIntents = useMemo(() => createMockContactDeviceIntentsPort(), []);
+  const { deviceIntents, dieProps } = useContactsIntentsOrchestrator({
+    intents: contactsIntentLWDDefinitions,
+    getLiveConfigMinVersion: getMinVersion,
+  });
   const {
     state: addressFlowState,
     startWithPrefilled,
@@ -260,6 +269,7 @@ export function useSendPrefillAddAddressFlow({
         nameLabels,
         reviewLabels,
         completionLabels,
+        dieProps,
         onAddressLabelChange: updateAddressLabel,
         onContinueFromName: continueFromName,
         onContinueFromReview: () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/AddNewContact/AddNewContactAddressView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/AddNewContact/AddNewContactAddressView.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { ContactsAddAddressFlowContent } from "@features/flow-contacts-add-address";
+import { DeviceIntentExecutorLWD } from "LLD/components/DeviceIntentExecutor";
 import type { AddNewContactAddressPhase } from "./hooks/useAddNewContactViewModel";
 
 type AddNewContactAddressViewProps = Readonly<{
@@ -26,6 +27,9 @@ export function AddNewContactAddressView({ addressPhase }: AddNewContactAddressV
         onCompleteMockConfirmation={() => undefined}
         onClose={() => undefined}
       />
+      {addressPhase.dieProps?.enabled === true ? (
+        <DeviceIntentExecutorLWD sourceFlow="contacts" {...addressPhase.dieProps} />
+      ) : null}
     </div>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/AddNewContact/hooks/__tests__/useAddNewContactViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/AddNewContact/hooks/__tests__/useAddNewContactViewModel.test.tsx
@@ -37,9 +37,11 @@ jest.mock("LLD/hooks/redux", () => ({
   useDispatch: () => dispatch,
 }));
 
-jest.mock("@features/platform-contacts", () => ({
-  ...jest.requireActual("@features/platform-contacts"),
-  createMockContactDeviceIntentsPort: () => ({ registerExternalAddress }),
+jest.mock("@features/platform-contacts/device", () => ({
+  useContactsIntentsOrchestrator: () => ({
+    deviceIntents: { registerExternalAddress },
+    dieProps: undefined,
+  }),
 }));
 
 jest.mock("../../../../context/SendFlowContext", () => ({

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/AddToExistingContact/hooks/__tests__/useAddToExistingContactViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/AddToExistingContact/hooks/__tests__/useAddToExistingContactViewModel.test.tsx
@@ -31,9 +31,15 @@ jest.mock("LLD/hooks/redux", () => ({
 
 jest.mock("@features/platform-contacts", () => ({
   ...jest.requireActual("@features/platform-contacts"),
-  createMockContactDeviceIntentsPort: () => ({ registerExternalAddress }),
   useContacts: () => [me, ada],
   useContactsMeContact: () => me,
+}));
+
+jest.mock("@features/platform-contacts/device", () => ({
+  useContactsIntentsOrchestrator: () => ({
+    deviceIntents: { registerExternalAddress },
+    dieProps: undefined,
+  }),
 }));
 
 jest.mock("../../../../context/SendFlowContext", () => ({


### PR DESCRIPTION
> [!WARNING]
> **Draft: not landable as-is.** This branch carries only the port swap. On desktop the Device Intent Executor renders its own dialog *inside* the Send flow dialog, so the two visibly stack. See **Remaining work** below.

### 📝 Description

**Problem**

Three desktop add-address entry points still registered addresses through `createMockContactDeviceIntentsPort()`, so they never talked to a device:

- the globally mounted `PrefillAddAddressFlowRoot` (`GlobalDialogs`) — wired but dormant today: nothing calls `useOpenPrefillAddAddressFlow` yet,
- the Send *add contact* and *add to existing contact* steps — the two you can exercise by hand.

**Solution (this branch)**

Each builds its port from `useContactsIntentsOrchestrator` and renders the Device Intent Executor, like the Contacts page flow already did. The three Send view-model specs mocked `createMockContactDeviceIntentsPort`, which the orchestrator's app-level mock calls while its module initializes — that ordering made the spy throw, so they now mock `useContactsIntentsOrchestrator` itself.

This is the desktop half of a change that was originally one PR. The mobile half shipped separately in #21351 (LIVE-36782), because mobile needed different fixes — a drawer queue conflict — and was landable on its own.

### 🚧 Remaining work

`DeviceIntentExecutorLWD` renders its own `<Dialog>` that portals to `body`, and it is rendered from inside `SendFlowLayout`'s `<Dialog>`. Both are open at once, so they stack.

Hiding the Send dialog is not a shortcut: Lumen's `Dialog` is plain Radix with no `forceMount`, so closing it unmounts `DialogContent` and everything below — which currently includes the executor itself, the add-address state (`useAddAddressFlowViewModel`) and the orchestrator. Closing the dialog would tear down the device flow it just started.

The fix is to lift the orchestrator and the add-address flow above the dialog:

- new provider under `SendFlowOrchestrator` but outside `SendFlowLayout`, owning `useContactsIntentsOrchestrator` and the ~140 logic lines of `useSendPrefillAddAddressFlow` (its four label `useMemo` blocks stay in the step)
- `SendFlowLayout` gates its dialog: `open={isOpen && !dieOpen}`
- the executor renders as a sibling of `SendFlowLayout`
- `AddNewContactAddressView` stops rendering the executor
- the two Send view-model specs mock the context instead of the orchestrator

The save must move up too, not only the orchestrator: once the dialog closes the step is unmounted, so the continuation after `await registerExternalAddress` would still dispatch (the store is external) but `close()` and `onSaved()` would be no-ops, and the navigation back to the recipient step would never fire.

No step restoration is needed — success navigates back to the recipient step, and a device reject or cancel is a user decision, so the flow just closes.

Estimated ~250 lines across 8 files, mostly a move. Two traps worth naming:

- `saveRequestId` / `isSaving` become provider-scoped instead of step-scoped. More correct, but it changes the double-submit guard, so the "register only once" test has to still hold at the new scope.
- closing the dialog currently routes through `handleDialogOpenChange` → `onClose()` → `closeSendFlowDialog()`, which tears down the *whole* Send flow. The `open` gate must not go through that handler, or starting a device intent would close the send flow. This is the desktop analogue of the mobile bug fixed in #21351, where the queued drawer reported a programmatic close as a user cancel and discarded the signed address after a successful approval.

### ✅ Tests

Not re-run since the split — the desktop suites were green on the combined branch before it was separated, and this branch's content is byte-identical to that snapshot. To be re-verified once the lift is in.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36795](https://ledgerhq.atlassian.net/browse/LIVE-36795)
- **Mobile counterpart**: #21351 ([LIVE-36782](https://ledgerhq.atlassian.net/browse/LIVE-36782)) — merged path for the same port swap on mobile
- **Related**: #21352 skips the in-app "Review address" / "Address saved" placeholders. Separate change, deliberately not part of this PR.
- **ADR** (if any): n/a


[LIVE-36795]: https://ledgerhq.atlassian.net/browse/LIVE-36795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ