### PR TITLE
[LWD] fix(zcash): make Learn more a link in confirmation banner (LIVE-36777)

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/__tests__/ZCashExportKeyFlowModal.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/__tests__/ZCashExportKeyFlowModal.test.tsx
@@ -232,6 +232,37 @@ describe("ZCash Export UFVK Flow", () => {
     });
   });
 
+  it("opens the support article when Learn more is clicked on confirmation step", async () => {
+    const stepId: StepId = "confirmation";
+
+    render(
+      <Body
+        stepId={stepId}
+        ufvk={ufvk}
+        ufvkExportError={ufvkExportError}
+        onStepIdChanged={jest.fn()}
+        onUfvkChanged={jest.fn()}
+        onRetry={jest.fn()}
+        onClose={jest.fn()}
+        birthday={birthday}
+        invalidBirthday={invalidBirthday}
+        syncFromZero={syncFromZero}
+        handleBirthdayChange={jest.fn()}
+        handleSyncFromZero={jest.fn()}
+        handleEnableShieldedBalance={jest.fn()}
+        params={{ account }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText(/ufvk successfully imported/i)).toBeVisible();
+    });
+
+    await userEvent.click(screen.getByText(/learn more/i));
+
+    expect(openURL).toHaveBeenCalledWith("https://support.ledger.com/article/115005177269-zd");
+  });
+
   it("should show confirmation step", async () => {
     const stepId: StepId = "confirmation";
 

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/steps/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/steps/StepConfirmation.tsx
@@ -6,8 +6,13 @@ import { multiline } from "~/renderer/styles/helpers";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
 import SuccessDisplay from "~/renderer/components/SuccessDisplay";
+import LinkWithExternalIcon from "~/renderer/components/LinkWithExternalIcon";
+import { openURL } from "~/renderer/linking";
 import { Container } from "../shared/Container";
 import type { StepProps } from "../types";
+
+// Placeholder support article; content owners plan to swap this for a dedicated one later.
+const UFVK_LEARN_MORE_URL = "https://support.ledger.com/article/115005177269-zd";
 
 function StepConfirmation({ t }: Readonly<StepProps>) {
   return (
@@ -33,11 +38,13 @@ function StepConfirmation({ t }: Readonly<StepProps>) {
               color="neutral.c100"
               fontSize={13}
             >
-              <Trans i18nKey="zcash.shielded.flows.export.steps.confirmation.success.info.text" />
-              <b>
-                {" "}
-                <Trans i18nKey="zcash.shielded.flows.export.steps.confirmation.success.info.cta" />
-              </b>
+              <Trans i18nKey="zcash.shielded.flows.export.steps.confirmation.success.info.text" />{" "}
+              <LinkWithExternalIcon
+                label={
+                  <Trans i18nKey="zcash.shielded.flows.export.steps.confirmation.success.info.cta" />
+                }
+                onClick={() => openURL(UFVK_LEARN_MORE_URL)}
+              />
             </Text>
           )}
         />


### PR DESCRIPTION
### 📝 Description

The **Learn more** text in the purple info banner on the UFVK import confirmation screen was static bold text with no navigation. This PR replaces it with a `LinkWithExternalIcon` that opens the support article, matching the existing pattern from the birthday step.

**Before:** static `<b>Learn more</b>` — no pointer, no navigation.
**After:** clickable link opening `https://support.ledger.com/article/115005177269-zd`.

A test was added to verify the click calls `openURL` with the correct URL.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36777](https://ledgerhq.atlassian.net/browse/LIVE-36777)

[LIVE-36777]: https://ledgerhq.atlassian.net/browse/LIVE-36777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ