### PR TITLE
[LWD] feat(pay): add desktop request verify hint

### DIFF
--- a/.changeset/LIVE-36582-pay-request-verify-hint.md
+++ b/.changeset/LIVE-36582-pay-request-verify-hint.md
@@ -1,0 +1,7 @@
+---
+"@features/flow-pay-request": minor
+"ledger-live-desktop": minor
+"@support/jest-features-flow": patch
+---
+
+Add a first-time Popover on desktop Pay Request Verify.

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
@@ -10,7 +10,6 @@ import {
   withFlagOverrides,
 } from "tests/testSetup";
 import { useNavigate } from "react-router";
-import type { TokenAccount } from "@ledgerhq/types-live";
 import type { VerifyAddressIntentJobState } from "@features/platform-verify-address-intent";
 import { buildDeviceInitializationInput } from "LLD/components/DeviceIntentExecutor";
 import { useOpenAssetAndAccount } from "LLD/features/ModularDialog/Web3AppWebview/AssetAndAccountDrawer";
@@ -107,13 +106,22 @@ const mockedUseOpenAssetAndAccount = jest.mocked(useOpenAssetAndAccount);
 
 let openAssetAndAccount: jest.Mock;
 
+const VERIFY_HINT_COPY = "Verify your address on your Ledger device before sharing";
+
+async function openRequestReceive(user: { click: (element: HTMLElement) => Promise<void> }) {
+  await user.click(await screen.findByRole("button", { name: "Request" }));
+  expect(await screen.findByTestId("pay-request-receive")).toBeVisible();
+}
+
 describe("PayTab integration", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     capturedExecutor = undefined;
     mockPayStablecoins();
     mockedUseNavigate.mockReturnValue(mockNavigate);
-    openAssetAndAccount = jest.fn();
+    openAssetAndAccount = jest.fn(({ onSuccess }) => {
+      onSuccess(USDC_TOKEN, ETH_ACCOUNT_WITH_USDC);
+    });
     mockedUseOpenAssetAndAccount.mockReturnValue({
       openAssetAndAccount,
       openAssetAndAccountPromise: jest.fn(),
@@ -356,12 +364,7 @@ describe("PayTab integration", () => {
       initialState: dieEnabledState,
     });
 
-    await user.click(await screen.findByRole("button", { name: "Request" }));
-    const { onSuccess } = openAssetAndAccount.mock.calls[0][0] as {
-      onSuccess: (account: TokenAccount, parentAccount: typeof ETH_ACCOUNT_WITH_USDC) => void;
-    };
-    act(() => onSuccess(USDC_TOKEN, ETH_ACCOUNT_WITH_USDC));
-
+    await openRequestReceive(user);
     await user.click(await screen.findByTestId("pay-request-receive-verify"));
     await user.click(await screen.findByTestId("pay-card-verify-address-verify-cta"));
 
@@ -378,6 +381,93 @@ describe("PayTab integration", () => {
 
     expect(await screen.findByTestId("pay-request-receive")).toBeVisible();
     expect(screen.queryByTestId("device-intent-executor")).not.toBeInTheDocument();
+    expect(screen.queryByText(VERIFY_HINT_COPY)).not.toBeInTheDocument();
+  });
+
+  describe("receive verify hint", () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    async function openRequestReceiveNow(user: { click: (element: HTMLElement) => Promise<void> }) {
+      await user.click(screen.getByRole("button", { name: "Request" }));
+      expect(screen.getByTestId("pay-request-receive")).toBeVisible();
+    }
+
+    function flushHintTimers() {
+      act(() => {
+        jest.runOnlyPendingTimers();
+      });
+    }
+
+    function renderHintPayTab() {
+      return renderWithMockedCounterValuesProvider(<PayTab />, {
+        initialState: fundedState,
+        userEventOptions: { advanceTimers: jest.advanceTimersByTime },
+      });
+    }
+
+    it("should show the receive verify hint on first visit and hide it after Got it", async () => {
+      mockFundedPayStablecoins();
+      const { user } = renderHintPayTab();
+
+      expect(await screen.findByRole("button", { name: "Request" })).toBeVisible();
+      jest.useFakeTimers({ doNotFake: ["queueMicrotask"] });
+      await openRequestReceiveNow(user);
+      expect(mockedTrack).not.toHaveBeenCalledWith("hint_impression", expect.anything());
+      flushHintTimers();
+
+      expect(screen.getByText(VERIFY_HINT_COPY)).toBeInTheDocument();
+      expect(mockedTrack).toHaveBeenCalledWith("hint_impression", {
+        hint: "verify",
+        buttonLocation: "request",
+        page: "Pay",
+      });
+
+      await user.click(screen.getByRole("button", { name: "Got it" }));
+
+      expect(screen.queryByText(VERIFY_HINT_COPY)).not.toBeInTheDocument();
+      expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+        button: "got it",
+        hint: "verify",
+        buttonLocation: "request",
+        page: "Pay",
+      });
+
+      await user.click(screen.getByRole("button", { name: /close/i }));
+      await openRequestReceiveNow(user);
+      flushHintTimers();
+
+      expect(screen.queryByText(VERIFY_HINT_COPY)).not.toBeInTheDocument();
+    });
+
+    it("should keep the receive dialog open until Got it or Verify", async () => {
+      mockFundedPayStablecoins();
+      const { user } = renderHintPayTab();
+
+      expect(await screen.findByRole("button", { name: "Request" })).toBeVisible();
+      jest.useFakeTimers({ doNotFake: ["queueMicrotask"] });
+      await openRequestReceiveNow(user);
+      flushHintTimers();
+      expect(screen.getByText(VERIFY_HINT_COPY)).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: /close/i }));
+      expect(screen.getByTestId("pay-request-receive")).toBeVisible();
+      expect(screen.getByText(VERIFY_HINT_COPY)).toBeInTheDocument();
+    });
+
+    it("should not track hint_impression if Verify is pressed before the hint shows", async () => {
+      mockFundedPayStablecoins();
+      const { user } = renderHintPayTab();
+
+      expect(await screen.findByRole("button", { name: "Request" })).toBeVisible();
+      jest.useFakeTimers({ doNotFake: ["queueMicrotask"] });
+      await openRequestReceiveNow(user);
+      await user.click(screen.getByTestId("pay-request-receive-verify"));
+      flushHintTimers();
+
+      expect(mockedTrack).not.toHaveBeenCalledWith("hint_impression", expect.anything());
+    });
   });
 
   it("should not render the contacts section when lwdContacts is disabled", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabRequestReceive.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabRequestReceive.ts
@@ -3,6 +3,12 @@ import { useTranslation } from "react-i18next";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import { AssetCategory } from "@domain/api-aggregated-assets";
 import type { PayRequestTrackEvent, RequestReceiveProps } from "@features/flow-pay-request";
+import {
+  markReceiveVerifyHintSeen,
+  selectHasSeenReceiveVerifyHint,
+} from "@features/flow-pay-request/state";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
+import { track } from "~/renderer/analytics/segment";
 import { useCopyToClipboard } from "../../../hooks/useCopyToClipboard";
 import { useOpenAssetAndAccount } from "../../ModularDialog/Web3AppWebview/AssetAndAccountDrawer";
 import { deriveRequestReceiveData } from "./deriveRequestReceiveData";
@@ -10,6 +16,7 @@ import { useSaveRequestReceive } from "./useSaveRequestReceive";
 import type { PayVerifySelection } from "./usePayTabVerifyAddress";
 
 const REQUEST_PAGE = "Pay";
+const VERIFY_HINT = "verify";
 
 // Card top-ups only support stablecoins; filter MAD server-side by category so the
 // user can still pick any supported network without exploding the request URL.
@@ -27,6 +34,8 @@ export function usePayTabRequestReceive(
   onVerify: (selection: PayVerifySelection, onDone: () => void) => void,
 ): UsePayTabRequestReceive {
   const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const hasSeenReceiveVerifyHint = useSelector(selectHasSeenReceiveVerifyHint);
   const [isOpen, setIsOpen] = useState(false);
   const [selection, setSelection] = useState<Selection | null>(null);
   const copyToClipboard = useCopyToClipboard();
@@ -48,11 +57,34 @@ export function usePayTabRequestReceive(
 
   const onCopy = useCallback((address: string) => copyToClipboard(address), [copyToClipboard]);
 
+  const markHintSeen = useCallback(() => {
+    dispatch(markReceiveVerifyHintSeen());
+  }, [dispatch]);
+
+  const onHintShown = useCallback(() => {
+    track("hint_impression", {
+      hint: VERIFY_HINT,
+      buttonLocation: "request",
+      page: REQUEST_PAGE,
+    });
+  }, []);
+
+  const onGotIt = useCallback(() => {
+    track("button_clicked", {
+      button: "got it",
+      hint: VERIFY_HINT,
+      buttonLocation: "request",
+      page: REQUEST_PAGE,
+    });
+    markHintSeen();
+  }, [markHintSeen]);
+
   const handleVerify = useCallback(() => {
     if (!selection) return;
+    markHintSeen();
     onClose();
     onVerify(selection, reopen);
-  }, [onVerify, onClose, reopen, selection]);
+  }, [markHintSeen, onClose, onVerify, reopen, selection]);
 
   const data = useMemo(
     () => (selection ? deriveRequestReceiveData(selection.account, selection.parentAccount) : null),
@@ -92,8 +124,30 @@ export function usePayTabRequestReceive(
       onVerify: handleVerify,
       onClose,
       onTrackEvent,
+      verifyHint: hasSeenReceiveVerifyHint
+        ? undefined
+        : {
+            open: true,
+            message: t("payTab.request.verifyHint.message"),
+            gotItLabel: t("payTab.request.verifyHint.gotIt"),
+            onGotIt,
+            onShown: onHintShown,
+          },
     }),
-    [isOpen, data, labels, onCopy, saveCard, handleVerify, onClose, onTrackEvent],
+    [
+      isOpen,
+      data,
+      labels,
+      onCopy,
+      saveCard,
+      handleVerify,
+      onClose,
+      onTrackEvent,
+      hasSeenReceiveVerifyHint,
+      t,
+      onGotIt,
+      onHintShown,
+    ],
   );
 
   return { open, requestReceive };

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -990,6 +990,10 @@
         "save": "Save",
         "verify": "Verify"
       },
+      "verifyHint": {
+        "message": "Verify your address on\nyour Ledger device\nbefore sharing",
+        "gotIt": "Got it"
+      },
       "verifyAddress": {
         "introTitle": "Verify your address",
         "introDescription": "To protect against address replacement attacks, verify your address on your Ledger device's Secure Screen.",

--- a/features/flow/pay-request/src/components/RequestReceive/RequestReceiveActions.web.tsx
+++ b/features/flow/pay-request/src/components/RequestReceive/RequestReceiveActions.web.tsx
@@ -1,7 +1,12 @@
 import React from "react";
 import { TileButton } from "@ledgerhq/lumen-ui-react";
 import { useRequestReceiveActions } from "./useRequestReceiveActions.web";
-import type { RequestReceiveActionId, RequestReceiveActionLabels } from "../../types";
+import { RequestReceiveVerifyHint } from "./RequestReceiveVerifyHint.web";
+import type {
+  RequestReceiveActionId,
+  RequestReceiveActionLabels,
+  RequestReceiveVerifyHint as RequestReceiveVerifyHintProps,
+} from "../../types";
 
 type RequestReceiveActionsProps = Readonly<{
   labels: RequestReceiveActionLabels;
@@ -11,20 +16,36 @@ type RequestReceiveActionsProps = Readonly<{
   onCopy: () => void;
   onSave: () => void;
   onVerify: () => void;
+  verifyHint?: RequestReceiveVerifyHintProps;
 }>;
 
 export function RequestReceiveActions(props: RequestReceiveActionsProps) {
+  const { verifyHint } = props;
   const tiles = useRequestReceiveActions(props);
 
   return (
     <div className="flex w-full flex-row gap-8">
-      {tiles.map(tile => (
-        <div key={tile.id} className="flex-1">
+      {tiles.map(tile => {
+        const button = (
           <TileButton icon={tile.icon} isFull onClick={tile.onClick} data-testid={tile.testId}>
             {tile.label}
           </TileButton>
-        </div>
-      ))}
+        );
+
+        if (tile.id === "verify" && verifyHint) {
+          return (
+            <RequestReceiveVerifyHint key={tile.id} {...verifyHint}>
+              {button}
+            </RequestReceiveVerifyHint>
+          );
+        }
+
+        return (
+          <div key={tile.id} className="flex-1">
+            {button}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/features/flow/pay-request/src/components/RequestReceive/RequestReceiveVerifyHint.web.tsx
+++ b/features/flow/pay-request/src/components/RequestReceive/RequestReceiveVerifyHint.web.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, type ReactNode } from "react";
+import { Button, Popover, PopoverContent, PopoverTrigger } from "@ledgerhq/lumen-ui-react";
+import type { RequestReceiveVerifyHint as RequestReceiveVerifyHintProps } from "../../types";
+
+type Props = RequestReceiveVerifyHintProps &
+  Readonly<{
+    children: ReactNode;
+  }>;
+
+export function RequestReceiveVerifyHint({
+  open,
+  message,
+  gotItLabel,
+  onGotIt,
+  onShown,
+  children,
+}: Props) {
+  useEffect(() => {
+    if (open) onShown?.();
+  }, [open, onShown]);
+  return (
+    <Popover open={open} onOpenChange={() => undefined}>
+      <PopoverTrigger render={<div className="relative z-menu flex-1">{children}</div>} />
+      {/* The dialog sets pointer-events: none on body. Restore them here so the portaled popover stays clickable. */}
+      <PopoverContent side="top" align="end" className="pointer-events-auto max-w-256">
+        <div className="flex flex-col gap-12" data-testid="pay-request-receive-verify-hint">
+          <p className="body-2 whitespace-pre-line text-base">{message}</p>
+          <Button size="sm" className="self-end" onClick={onGotIt}>
+            {gotItLabel}
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/features/flow/pay-request/src/components/RequestReceive/RequestReceiveView.web.tsx
+++ b/features/flow/pay-request/src/components/RequestReceive/RequestReceiveView.web.tsx
@@ -18,12 +18,15 @@ export function RequestReceiveView({
   onCopy,
   onSave,
   onVerify,
+  verifyHint,
 }: RequestReceiveViewProps) {
-  const { hasCopied, handleOpenChange, handleCopy } = useRequestReceiveView({
-    isOpen,
-    onClose,
-    onCopy,
-  });
+  const { hasCopied, hint, handleOpenChange, handleCopy, handleInteractOutside } =
+    useRequestReceiveView({
+      isOpen,
+      onClose,
+      onCopy,
+      verifyHint,
+    });
 
   if (!isOpen) {
     return null;
@@ -31,9 +34,23 @@ export function RequestReceiveView({
 
   return (
     <Dialog open onOpenChange={handleOpenChange} height="fit">
-      <DialogContent className="max-h-[90vh]">
-        <DialogHeader onClose={onClose} />
-        <DialogBody className="flex flex-col gap-12" data-testid="pay-request-receive">
+      <DialogContent
+        className="max-h-[90vh]"
+        onPointerDownOutside={handleInteractOutside}
+        onInteractOutside={handleInteractOutside}
+      >
+        {hint?.open ? (
+          <div
+            aria-hidden
+            data-testid="pay-request-receive-verify-hint-overlay"
+            className="absolute inset-0 z-table-header bg-canvas-overlay"
+          />
+        ) : null}
+        <DialogHeader onClose={() => handleOpenChange(false)} />
+        <DialogBody
+          className="relative flex flex-col gap-12 overflow-visible"
+          data-testid="pay-request-receive"
+        >
           <RequestReceiveSummary
             title={labels.title}
             networkLabel={labels.networkLabel}
@@ -50,6 +67,7 @@ export function RequestReceiveView({
             onCopy={handleCopy}
             onSave={onSave}
             onVerify={onVerify}
+            verifyHint={hint}
           />
         </DialogBody>
       </DialogContent>

--- a/features/flow/pay-request/src/components/RequestReceive/__tests__/useRequestReceiveView.web.test.ts
+++ b/features/flow/pay-request/src/components/RequestReceive/__tests__/useRequestReceiveView.web.test.ts
@@ -1,0 +1,81 @@
+import { act, renderHook } from "@testing-library/react";
+import type { RequestReceiveVerifyHint } from "../../../types";
+import { useRequestReceiveView } from "../useRequestReceiveView.web";
+
+function setup(overrides: { isOpen?: boolean; verifyHint?: RequestReceiveVerifyHint } = {}) {
+  const onClose = jest.fn();
+  const onCopy = jest.fn();
+  const onGotIt = jest.fn();
+  const { result } = renderHook(() =>
+    useRequestReceiveView({
+      isOpen: overrides.isOpen ?? true,
+      onClose,
+      onCopy,
+      verifyHint: overrides.verifyHint ?? {
+        open: true,
+        message: "Verify your address",
+        gotItLabel: "Got it",
+        onGotIt,
+      },
+    }),
+  );
+  return { result, onClose, onCopy, onGotIt };
+}
+
+describe("useRequestReceiveView", () => {
+  beforeEach(() => {
+    // React 19 act() schedules work with queueMicrotask. Jest fake timers
+    // mock that API by default, so act() never returns.
+    jest.useFakeTimers({ doNotFake: ["queueMicrotask"] });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("keeps the hint closed until the show delay elapses", () => {
+    const { result } = setup();
+
+    expect(result.current.hint?.open).toBe(false);
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(result.current.hint?.open).toBe(true);
+  });
+
+  it("does not close the dialog while the hint is open", () => {
+    const { result, onClose } = setup();
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    const event = { preventDefault: jest.fn() } as unknown as CustomEvent;
+    act(() => {
+      result.current.handleOpenChange(false);
+      result.current.handleInteractOutside(event);
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it("closes the dialog after the hint is dismissed", () => {
+    const onGotIt = jest.fn();
+    const { result, onClose } = setup({
+      verifyHint: {
+        open: false,
+        message: "Verify your address",
+        gotItLabel: "Got it",
+        onGotIt,
+      },
+    });
+
+    act(() => {
+      result.current.handleOpenChange(false);
+    });
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/features/flow/pay-request/src/components/RequestReceive/useRequestReceiveView.web.ts
+++ b/features/flow/pay-request/src/components/RequestReceive/useRequestReceiveView.web.ts
@@ -1,31 +1,51 @@
 import { useCallback, useEffect, useState } from "react";
+import type { RequestReceiveVerifyHint } from "../../types";
 
 const COPY_FEEDBACK_MS = 3000;
+const HINT_SHOW_DELAY_MS = 500;
 
 type UseRequestReceiveViewParams = Readonly<{
   isOpen: boolean;
   onClose: () => void;
   onCopy: () => void;
+  verifyHint?: RequestReceiveVerifyHint;
 }>;
 
 type UseRequestReceiveView = Readonly<{
   hasCopied: boolean;
+  hint?: RequestReceiveVerifyHint;
   handleOpenChange: (open: boolean) => void;
   handleCopy: () => void;
+  handleInteractOutside: (event: CustomEvent) => void;
 }>;
 
 export function useRequestReceiveView({
   isOpen,
   onClose,
   onCopy,
+  verifyHint,
 }: UseRequestReceiveViewParams): UseRequestReceiveView {
   const [hasCopied, setHasCopied] = useState(false);
+  const [isHintReady, setIsHintReady] = useState(false);
 
   useEffect(() => {
     if (!isOpen) {
       setHasCopied(false);
     }
   }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen || !verifyHint?.open) {
+      setIsHintReady(false);
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setIsHintReady(true);
+    }, HINT_SHOW_DELAY_MS);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [isOpen, verifyHint?.open]);
 
   useEffect(() => {
     if (!hasCopied) {
@@ -39,11 +59,11 @@ export function useRequestReceiveView({
 
   const handleOpenChange = useCallback(
     (open: boolean) => {
-      if (!open) {
+      if (!open && !verifyHint?.open) {
         onClose();
       }
     },
-    [onClose],
+    [onClose, verifyHint?.open],
   );
 
   const handleCopy = useCallback(() => {
@@ -51,5 +71,27 @@ export function useRequestReceiveView({
     setHasCopied(true);
   }, [onCopy]);
 
-  return { hasCopied, handleOpenChange, handleCopy };
+  const handleInteractOutside = useCallback(
+    (event: CustomEvent) => {
+      if (verifyHint?.open) {
+        event.preventDefault();
+      }
+    },
+    [verifyHint?.open],
+  );
+
+  const hint = verifyHint
+    ? {
+        ...verifyHint,
+        open: verifyHint.open && isHintReady,
+      }
+    : undefined;
+
+  return {
+    hasCopied,
+    hint,
+    handleOpenChange,
+    handleCopy,
+    handleInteractOutside,
+  };
 }

--- a/features/flow/pay-request/src/types.ts
+++ b/features/flow/pay-request/src/types.ts
@@ -130,6 +130,14 @@ export type RequestReceiveLabels = Readonly<{
   actions: RequestReceiveActionLabels;
 }>;
 
+export type RequestReceiveVerifyHint = Readonly<{
+  open: boolean;
+  message: string;
+  gotItLabel: string;
+  onGotIt: () => void;
+  onShown?: () => void;
+}>;
+
 /** Props for the branded `CryptoIcon` shown for the asset and (optionally) the network row. */
 export type RequestReceiveIconProps = Readonly<{
   ledgerId: string;
@@ -151,6 +159,7 @@ type RequestReceiveShell = Readonly<{
    */
   cardRef?: RefObject<unknown>;
   onClose: () => void;
+  verifyHint?: RequestReceiveVerifyHint;
 }>;
 
 export type RequestReceiveProps = RequestReceiveViewModelParams & RequestReceiveShell;

--- a/support/jest-features-flow/mocks/passthrough-web.js
+++ b/support/jest-features-flow/mocks/passthrough-web.js
@@ -1,6 +1,7 @@
 const React = require("react");
 const TooltipOpenContext = React.createContext();
 const DialogOpenContext = React.createContext();
+const PopoverOpenContext = React.createContext();
 
 function resolveAvatarColor(identifier) {
   return `avatar-color:${identifier}`;
@@ -98,6 +99,26 @@ function TooltipTrigger({ children }) {
   return React.createElement(React.Fragment, undefined, children);
 }
 
+function Popover({ children, open }) {
+  return React.createElement(PopoverOpenContext.Provider, { value: open }, children);
+}
+
+function PopoverTrigger({ render, children }) {
+  if (typeof render === "function") {
+    return render({});
+  }
+  if (React.isValidElement(render)) {
+    return render;
+  }
+  return React.createElement(React.Fragment, undefined, children);
+}
+
+function PopoverContent({ children, ...props }) {
+  if (React.useContext(PopoverOpenContext) === false) return null;
+
+  return React.createElement("div", props, children);
+}
+
 function TooltipContent({ children, ...props }) {
   if (React.useContext(TooltipOpenContext) === false) return null;
 
@@ -150,6 +171,9 @@ module.exports = new Proxy(
     Tooltip,
     TooltipContent,
     TooltipTrigger,
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
   },
   {
     get(target, prop) {


### PR DESCRIPTION
### 📝 Description

Users have no first-time nudge to verify a receive address on device before they share it.

This PR adds a desktop FTU Popover on Pay Request, anchored on Verify: copy “Verify your address on your Ledger device before sharing”, a Got it action, overlay, and dismiss via Got it or Verify only (not outside click, Escape, or the sheet X). Persist/restore lives in #21434.

**Stack:** 2/4. State is #21434. Mobile UI is #21421. DevTools reset is #21422.

https://github.com/user-attachments/assets/0fcf721f-088b-428a-8366-5bb3052bdf28

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36582](https://ledgerhq.atlassian.net/browse/LIVE-36582)

[LIVE-36582]: https://ledgerhq.atlassian.net/browse/LIVE-36582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ