### PR TITLE
[LWD] fix(theme): prevent theme reverting to dark on navigation

### DIFF
--- a/.changeset/tidy-mirrors-repaint.md
+++ b/.changeset/tidy-mirrors-repaint.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix theme reverting to dark when navigating from My Ledger to Contacts

--- a/apps/ledger-live-desktop/src/renderer/styles/StyleProvider.tsx
+++ b/apps/ledger-live-desktop/src/renderer/styles/StyleProvider.tsx
@@ -31,8 +31,9 @@ const StyleProvider = ({ children, selectedPalette }: Props) => {
     }),
     [v3SelectedPalette, selectedPalette],
   );
+  // No `colorScheme`: Lumen writes its scheme as a global `<html>` class, owned solely by `App.tsx`.
   return (
-    <PlatformStyleProvider theme={theme} colorScheme={selectedPalette}>
+    <PlatformStyleProvider theme={theme}>
       <GlobalStyle />
       {children}
     </PlatformStyleProvider>

--- a/apps/ledger-live-desktop/src/renderer/styles/__tests__/StyleProvider.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/styles/__tests__/StyleProvider.test.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@ledgerhq/lumen-ui-react";
+import { useTheme } from "styled-components";
+import StyleProvider from "../StyleProvider";
+
+function PaletteProbe() {
+  const theme = useTheme();
+  return <span data-testid="palette">{theme.theme}</span>;
+}
+
+describe("StyleProvider", () => {
+  afterEach(() => {
+    document.documentElement.classList.remove("light", "dark");
+  });
+
+  it("gives its subtree the requested styled-components palette", () => {
+    render(
+      <StyleProvider selectedPalette="dark">
+        <PaletteProbe />
+      </StyleProvider>,
+    );
+
+    expect(screen.getByTestId("palette")).toHaveTextContent("dark");
+  });
+
+  it("leaves the document color scheme to the app-level Lumen provider", () => {
+    render(
+      <ThemeProvider colorScheme="light">
+        <StyleProvider selectedPalette="dark">
+          <span>dark banner</span>
+        </StyleProvider>
+      </ThemeProvider>,
+    );
+
+    expect(document.documentElement).toHaveClass("light");
+    expect(document.documentElement).not.toHaveClass("dark");
+  });
+
+  it("keeps the document color scheme when a scoped palette mounts on an already themed tree", () => {
+    const { rerender } = render(
+      <ThemeProvider colorScheme="light">
+        <span>app</span>
+      </ThemeProvider>,
+    );
+
+    rerender(
+      <ThemeProvider colorScheme="light">
+        <StyleProvider selectedPalette="dark">
+          <span>dark banner</span>
+        </StyleProvider>
+      </ThemeProvider>,
+    );
+
+    expect(document.documentElement).toHaveClass("light");
+    expect(document.documentElement).not.toHaveClass("dark");
+  });
+});

--- a/apps/ledger-live-desktop/tests/testSetup.tsx
+++ b/apps/ledger-live-desktop/tests/testSetup.tsx
@@ -7,6 +7,7 @@ import {
   PartialFeatures,
 } from "@shared/feature-flags";
 import { CountervaluesProvider } from "@ledgerhq/live-countervalues-react";
+import { ThemeProvider } from "@ledgerhq/lumen-ui-react";
 import { CounterValuesStateRaw } from "@ledgerhq/live-countervalues/types";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
@@ -196,11 +197,13 @@ function Providers({
 function EnhancedProviders({ children }: { children: React.ReactNode }): React.JSX.Element {
   return (
     <DrawerProvider>
-      <StyleProvider selectedPalette="dark">
-        <LiveStyleSheetManager>
-          <ContextMenuWrapper>{children}</ContextMenuWrapper>
-        </LiveStyleSheetManager>
-      </StyleProvider>
+      <ThemeProvider colorScheme="dark">
+        <StyleProvider selectedPalette="dark">
+          <LiveStyleSheetManager>
+            <ContextMenuWrapper>{children}</ContextMenuWrapper>
+          </LiveStyleSheetManager>
+        </StyleProvider>
+      </ThemeProvider>
     </DrawerProvider>
   );
 }


### PR DESCRIPTION
### 📝 Description

Navigating My Ledger → Contacts flipped the UI to Dark even when Light was selected. Settings still showed Light, so the preference was not overwritten.

Cause: nested `StyleProvider selectedPalette="dark"` (OS-update banner) also mounted a Lumen `ThemeProvider`. Lumen writes the scheme on `<html>` and never restores it, so leaving My Ledger remounted the banner and left the whole app Dark.

Fix: desktop `StyleProvider` no longer forwards `colorScheme`. Only `App.tsx` owns the document scheme. Nested providers still set the styled-components palette for their own subtree.

Covered by `src/renderer/styles/__tests__/StyleProvider.test.tsx`.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36780](https://ledgerhq.atlassian.net/browse/LIVE-36780)
- **ADR** (if any): n/a

[LIVE-36780]: https://ledgerhq.atlassian.net/browse/LIVE-36780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ