### PR TITLE
fix(e2e): fail fast on the error modal in success wait (QAA-1540)

### DIFF
--- a/.changeset/success-view-details-fail-fast.md
+++ b/.changeset/success-view-details-fail-fast.md
@@ -1,0 +1,17 @@
+---
+"ledger-live-mobile-e2e-tests": patch
+---
+
+Make `CommonPage.successViewDetails()` fail on the app's error modal instead of waiting out its full
+60s budget on a success screen that can no longer appear. The step is shared by every mobile
+send/delegate/stake spec, and it waited on `validate-success-screen` with a bare `toBeVisible`. When
+the signing job fails, the flow renders `GenericErrorView` in place of the success screen, so the
+wait could only ever time out — and reported "success screen never appears", which hid the real
+error and mis-attributed QAA-1540 for four nightlies.
+
+The wait now passes `errorElementId: generic-error-modal`, the fail-fast option `waitForElement`
+already offers and that `swap.page.ts` already uses, so the failure is raised within ~1s of the
+error modal appearing and names it.
+
+This does not make the underlying NEAR/Stax delegate failure less frequent — see QAA-1540 for the
+30s `GeneralDmkError` it exposes.

--- a/e2e/mobile/page/common.page.ts
+++ b/e2e/mobile/page/common.page.ts
@@ -3,6 +3,7 @@ import { removeSpeculosAndDeregisterKnownSpeculos } from "@e2e/utils/speculosUti
 import { Account, getParentAccountName } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { isIos, openDeeplink } from "@e2e/helpers/commonHelpers";
 import { device } from "detox";
+import { DEFAULT_TIMEOUT } from "@e2e/helpers/elementHelpers";
 import ErrorPage from "@e2e/page/error.page";
 import { isAggregatedAssetsEnabled } from "@e2e/utils/featureFlagUtils";
 
@@ -69,7 +70,9 @@ export default class CommonPage {
 
   @Step("Tap on view details")
   async successViewDetails() {
-    await waitForElementById(this.validateSuccessScreenId);
+    await waitForElementById(this.validateSuccessScreenId, DEFAULT_TIMEOUT, {
+      errorElementId: this.errorPage.genericErrorModalId,
+    });
     await waitForElementById(this.successViewDetailsButtonId);
     await tapById(this.successViewDetailsButtonId);
   }


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _The change only alters behaviour on the failure path, so it was not verified end to end locally — reproducing it means manufacturing a `GeneralDmkError`, which needs a Stax Speculos instance. It was exercised on CI instead; see Verification._
- [x] **Impact of the changes:**
      - Every existing caller of `CommonPage.successViewDetails()` — all mobile delegate, stake and send flows go through it, not just NEAR.
      - Happy-path timing: the wait becomes a 500 ms-slice poll loop instead of one 60 s `toBeVisible`, so a success screen that took 5.69 s is now reported at ~6-7 s.
      - Failure messages change shape: a signing failure now reports `Error element 'generic-error-modal' detected while waiting for element` instead of a `validate-success-screen` timeout. Anything parsing those messages (nightly collector, Allure triage) will see the new text.
      - No product code touched, no timeout raised, no retry added.

### 📝 Description

**This PR does not make the NEAR delegate flake less frequent.** It fixes the *reporting* defect that
hid the real cause for four nightlies, and the diagnosis below is the substance of the ticket.

**Problem.** `CommonPage.successViewDetails()` waited on `validate-success-screen` with a bare
`toBeVisible` and a 60s budget. The success screen only mounts once the device signature has come
back; when the signing job fails instead, the flow renders `GenericErrorView` in its place, so that
wait can never succeed. It burned the full minute and reported

```
Timed out while waiting for expectation:
TOBEVISIBLE WITH MATCHER(id == "validate-success-screen") TIMEOUT(1m)
```

which says nothing about the actual failure. That message is what the nightly collector recorded, and
it is why QAA-1540 was filed against the wrong step.

**Solution.** Pass `errorElementId: generic-error-modal` to the wait — the fail-fast option
`waitForElement` already offers and `swap.page.ts` already uses. The step now raises within ~1s of
the error modal appearing and names it, instead of ~30s later with a misleading message.

```mermaid
sequenceDiagram
    participant S as delegateNEAR.spec
    participant D as Speculos (Stax)
    participant A as Ledger Wallet Mobile
    Note over S,A: before — the wait cannot observe the failure
    S->>D: delegateNear() walks the review, holds to sign (~11s)
    A->>D: POST /apdu (sign) — aborted at 15s, re-sent, aborted at 15s
    A->>A: GeneralDmkError → renders generic-error-modal
    S->>A: waitFor(validate-success-screen) — 60s, then "success screen never appears"
    Note over S,A: after — the terminal error state ends the wait
    S->>A: waitFor(validate-success-screen) errorElementId=generic-error-modal
    A-->>S: generic-error-modal visible
    S->>S: fails in ~1s, naming the error modal
```

### 🔎 Root cause of the flake itself

Established from run
[33454191987](https://github.com/LedgerHQ/ledger-live/actions/runs/33454191987) (iOS shard 7,
`ios-test-artifacts-7`), whose failure message is byte-identical across all four flaky nights
(08-26, 08-27, 08-31, 09-01).

**"iOS only" is not the same claim as "OS-specific".** On scheduled runs
`.github/workflows/test-mobile-e2e-reusable.yml` maps iOS → **Stax** and Android → **nanoX**, so the
nightly's Android leg never exercises the `isTouchDevice()` branch of `delegateNear` at all. Worth
knowing when reading the ledger — though the CI run below then ran Android on Stax, and it passed, so
the device branch alone does not explain the failure.

The 09-01 run took three attempts — fail (99.3s), fail (98.7s), pass (49.3s). In **all three** the
`Sign Delegation Transaction on Speculos` step passed in ~11s (10.95 / 11.00 / 10.47s). What differs
is what happened to the app's signing request:

| Evidence | Failing attempts | Passing attempt |
| --- | --- | --- |
| App network log, `POST /apdu` (sign) | fails after **15 041 ms**, re-sent, fails again after **15 033 ms** — `Network request failed` | n/a |
| `[hw] Job error` | `GeneralDmkError` / `DmkNetworkClientError`, `isTimeout: false`, at **30.349s** and **30.353s** after the sign job opened | n/a |
| Native view hierarchy at failure | `generic-error-modal` visible — `GeneralDmkError`, "Something went wrong…", Save logs / Retry / Close | n/a |
| Speculos screenshot at failure | **"View header — 1 of 3"** — the review restarted by the re-sent APDU, never signed | n/a |
| `validate-success-screen` | never appears | appears in **5.69s** |

So the app aborts the in-flight sign APDU after ~15s, retries once, aborts again, and surfaces
`GeneralDmkError` at 30.35s — twice, to the millisecond. The device is left mid-review. The e2e
device walk consumes ~11s of that 15s budget, and `longPressAndRelease` returns as soon as Speculos
ACKs the `/finger` POST without verifying that a signature was produced, so the step reports success
either way.

**Alternatives ruled out.** A renamed locator and a changed feature flag produce the same timeout,
so both were checked against the source rather than assumed:

- `validate-success-screen` still exists, at
  `apps/ledger-live-mobile/src/components/ValidateSuccess.tsx:40`. `git log -S` over the last six
  weeks shows only hedera and aleo test additions touching that string — no rename, no deletion.
- No `useFeature` call gates `ValidateSuccess` or the validation screens. The send flow uses
  `domainInputResolution`, but earlier in the flow and not on this path. Flag state at run time
  resolves from Firebase Remote Config and was not confirmed from the repository.
- `generic-error-modal` is rendered by `GenericErrorView.tsx:65`, which matches the native view
  hierarchy captured at the failure.

### ⚠️ What this PR does not do, and what is still open

Nothing here changes the failure rate. The two candidate causes, ranked **after** the CI run below:

1. **The app's sign `POST /apdu` is cut at ~15s, and that appears to be iOS-specific.** A
   hardware-in-the-loop signature legitimately outlives that budget — the e2e device walk alone is
   ~11s. RN `fetch` is `NSURLSession` on iOS and OkHttp on Android, and the abort surfaces as
   `Network request failed` in the app's own network log. Lives in the DMK Speculos transport / RN
   networking, **outside E2E scope**.
2. **The Stax hold-to-sign does not reliably complete the signature.** The walk finished 2.1-2.4s
   before the abort with no response, and `longPressAndRelease` returns on the `/finger` HTTP ACK
   without checking that the device advanced past the signing screen — so the step reports `passed`
   either way. This ranked first until CI ran `delegateNEAR` on **Android + Stax**
   and it passed first time, which this hypothesis now has to explain. Would be fixable in
   `live-e2e-shared`.

**The one observation that would settle it:** Speculos APDU-level logs (or a local Stax run with
`apdu` logging) showing whether the device emitted a signature response after the long press. The
Speculos log attached to the nightly contains only boot lines, so it cannot answer this.

### 🔗 Context

- **JIRA / GitHub issue**: [QAA-1540](https://ledgerhq.atlassian.net/browse/QAA-1540) — sub-task of
  [QAA-1445](https://ledgerhq.atlassian.net/browse/QAA-1445)
- **Evidence**: [nightly run 33454191987](https://github.com/LedgerHQ/ledger-live/actions/runs/33454191987),
  also 33344108182, 33029699276, 32914765581


---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)



[QAA-1540]: https://ledgerhq.atlassian.net/browse/QAA-1540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
