### PR TITLE
fix(e2e): stop allure repeating the speculos block (QAA-1547)

### DIFF
--- a/.changeset/allure-dedupe-speculos-description.md
+++ b/.changeset/allure-dedupe-speculos-description.md
@@ -1,0 +1,18 @@
+---
+"ledger-live-mobile-e2e-tests": patch
+---
+
+Stop the Allure test description from repeating the `SPECULOS App: <name> (<version>)` block once
+per Speculos (re)launch. `jest-allure2-reporter`'s `allure.description()` appends rather than
+replaces — each call pushes a paragraph that the reporter joins with a blank line — and
+`launchSpeculos()` emits one on every invocation, so a test whose setup retried three times printed
+the same block four times. The mobile reporter config now drops verbatim-duplicate paragraphs before
+joining, keeping the first of each; blocks for genuinely different apps (a swap lists one per
+currency plus Exchange and its dependencies) all differ, so they are untouched. `descriptionHtml` is
+deduplicated the same way, since it appends identically.
+
+Also stops `executeCliCommands` from tearing down and relaunching Speculos after its *final* failed
+attempt. Its two siblings, `executeCliCommandsOnApp` and `setupMainSpeculosApp`, already guard that
+re-setup with `attempt < maxRetries`; without the guard the loop pays for one more
+acquire/release cycle it will never use, and a failure inside that re-setup escapes the retry loop
+and replaces the real `lastError` in the reported message.

--- a/e2e/mobile/jest.config.js
+++ b/e2e/mobile/jest.config.js
@@ -40,10 +40,23 @@ const retryTestNames = process.env.E2E_RETRY_TEST_NAMES
   ? new Set(JSON.parse(process.env.E2E_RETRY_TEST_NAMES))
   : undefined;
 
+// `allure.description()` appends rather than replaces: every call pushes one paragraph and the
+// reporter joins them with a blank line. Speculos is legitimately launched more than once per test
+// — the initUtil retry loops re-create the instance, and the swap helpers bring up a second one for
+// a token approval — so the same `SPECULOS App: <name> (<version>)` block can land in a description
+// several times. Keep the first of each and drop verbatim repeats: blocks for genuinely different
+// apps (a swap shows one per currency plus Exchange and its dependencies) all differ, so they stay.
+const dedupeParagraphs = paragraphs => [...new Set(paragraphs ?? [])];
+
 const jestAllure2ReporterOptions = {
   extends: "detox-allure2-adapter/preset-detox",
   resultsDir: "artifacts",
   testCase: {
+    description: ({ testCaseMetadata }) =>
+      dedupeParagraphs(testCaseMetadata.description).join("\n\n"),
+    // Same appending behaviour, and the same separator the reporter's own default uses.
+    descriptionHtml: ({ testCaseMetadata }) =>
+      dedupeParagraphs(testCaseMetadata.descriptionHtml).join("\n"),
     links: {
       issue: "https://ledgerhq.atlassian.net/browse/{{name}}",
       tms: "https://ledgerhq.atlassian.net/browse/{{name}}",

--- a/e2e/mobile/jest.config.js
+++ b/e2e/mobile/jest.config.js
@@ -40,12 +40,7 @@ const retryTestNames = process.env.E2E_RETRY_TEST_NAMES
   ? new Set(JSON.parse(process.env.E2E_RETRY_TEST_NAMES))
   : undefined;
 
-// `allure.description()` appends rather than replaces: every call pushes one paragraph and the
-// reporter joins them with a blank line. Speculos is legitimately launched more than once per test
-// — the initUtil retry loops re-create the instance, and the swap helpers bring up a second one for
-// a token approval — so the same `SPECULOS App: <name> (<version>)` block can land in a description
-// several times. Keep the first of each and drop verbatim repeats: blocks for genuinely different
-// apps (a swap shows one per currency plus Exchange and its dependencies) all differ, so they stay.
+// jest-allure2-reporter appends descriptions rather than replacing — QAA-1547
 const dedupeParagraphs = paragraphs => [...new Set(paragraphs ?? [])];
 
 const jestAllure2ReporterOptions = {
@@ -54,7 +49,6 @@ const jestAllure2ReporterOptions = {
   testCase: {
     description: ({ testCaseMetadata }) =>
       dedupeParagraphs(testCaseMetadata.description).join("\n\n"),
-    // Same appending behaviour, and the same separator the reporter's own default uses.
     descriptionHtml: ({ testCaseMetadata }) =>
       dedupeParagraphs(testCaseMetadata.descriptionHtml).join("\n"),
     links: {

--- a/e2e/mobile/utils/initUtil.ts
+++ b/e2e/mobile/utils/initUtil.ts
@@ -109,7 +109,7 @@ async function launchSpeculosDevices(toStart: SpeculosAppType[]): Promise<Record
     );
     throw new Error(
       `Failed to launch ${failures.length}/${toStart.length} Speculos device(s): ${failures
-        .map(sanitizeError)
+        .map(err => sanitizeError(err))
         .join("; ")}`,
     );
   }

--- a/e2e/mobile/utils/initUtil.ts
+++ b/e2e/mobile/utils/initUtil.ts
@@ -275,22 +275,25 @@ async function executeCliCommands(
     } catch (err) {
       lastError = err;
 
-      if (speculosApp && entryMap) {
-        checkTestFailed();
-
-        const main = entryMap[speculosApp.name];
-
-        await removeSpeculosAndDeregisterKnownSpeculos(main.deviceId);
-        const device = await launchSpeculos(speculosApp.name);
-        entryMap[speculosApp.name] = {
-          name: speculosApp.name,
-          speculosPort: device.port,
-          deviceId: device.id,
-        };
-        await setupMainSpeculosApp(speculosApp, entryMap);
-      }
-
+      // Guarded like executeCliCommandsOnApp and setupMainSpeculosApp above: after the final
+      // attempt the loop exits and throws, so re-setting up Speculos there only burns an
+      // acquire/release cycle, and would replace lastError with its own failure if it threw.
       if (attempt < maxRetries) {
+        if (speculosApp && entryMap) {
+          checkTestFailed();
+
+          const main = entryMap[speculosApp.name];
+
+          await removeSpeculosAndDeregisterKnownSpeculos(main.deviceId);
+          const device = await launchSpeculos(speculosApp.name);
+          entryMap[speculosApp.name] = {
+            name: speculosApp.name,
+            speculosPort: device.port,
+            deviceId: device.id,
+          };
+          await setupMainSpeculosApp(speculosApp, entryMap);
+        }
+
         log.info(`[Global CLI] Retrying full command run (attempt ${attempt + 1}/${maxRetries})`);
       }
     }

--- a/e2e/mobile/utils/initUtil.ts
+++ b/e2e/mobile/utils/initUtil.ts
@@ -275,9 +275,6 @@ async function executeCliCommands(
     } catch (err) {
       lastError = err;
 
-      // Guarded like executeCliCommandsOnApp and setupMainSpeculosApp above: after the final
-      // attempt the loop exits and throws, so re-setting up Speculos there only burns an
-      // acquire/release cycle, and would replace lastError with its own failure if it threw.
       if (attempt < maxRetries) {
         if (speculosApp && entryMap) {
           checkTestFailed();


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No automated test ships in this diff: `e2e/mobile` has no unit-test runner (its jest config is the Detox suite), so the evidence is a manual reporter harness plus three replayed nightlies, described below._
- [x] **Impact of the changes:**
      - **Allure description rendering for every mobile test.** The extractor runs on every test case, not just the ones that relaunch Speculos. Replaying all 1938 test-case records from three nightlies through the shipped extractor changed 5 of them and left 1933 byte-identical, so the legitimate multi-app swap blocks (one per currency plus Exchange and its dependencies) are untouched.
      - **`descriptionHtml` too**, which nothing currently emits — this is forward cover for QAA-1535, whose switch to `allure.descriptionHtml()` would otherwise reintroduce the bug because it appends identically.
      - **The `executeCliCommands` retry path in `initUtil.ts`, including which error is reported.** The likeliest thing to miss: the catch block has no inner `try`, so before this change a failure inside the final-attempt Speculos re-setup escaped the retry loop entirely and surfaced instead of the real `lastError` — a CLI setup failure could be reported as "Speculos failed to start". Guarding the re-setup means the wrapped `lastError` message is now always the actual cause. Only reachable when Speculos setup fails all three attempts.
      - **No product code**, and nothing reads the Allure `description` field programmatically (checked `e2e/mobile/scripts` and `libs/live-e2e-shared/src`), so no downstream parser depends on the duplicates.

### 📝 Description

**Previous behaviour.** A test whose setup relaunched Speculos got the same `SPECULOS App: <name> (<version>)` paragraph in its Allure description once per launch. On the 2026-09-01 nightly, `[CCD] - Send` (iOS) printed `SPECULOS App: Concordium (5.6.3)` **four** times.

**Root cause.** `jest-allure2-reporter`'s `allure.description()` *appends*; it does not replace. `CoreModule.description()` does `metadata.push('description', [value])`, and the reporter's default extractor renders `testCaseMetadata.description?.join('\n\n')` (`dist/options/default/testCase.js:13`). `launchSpeculos()` calls it on every invocation (`e2e/mobile/utils/speculosUtils.ts:157`), and `initUtil.ts` calls `launchSpeculos()` from four places, three of them inside `maxRetries = 3` retry loops. Four blocks is exactly `1` initial launch + `3` re-launches from `executeCliCommands`' catch block.

**Change.**

1. `e2e/mobile/jest.config.js` — a `testCase.description` extractor drops verbatim-duplicate paragraphs before joining, keeping the first of each. `descriptionHtml` gets the same treatment because it appends identically (`join('\n')`, same file, line 14) — so QAA-1535 can switch the call sites over without reintroducing this.
2. `e2e/mobile/utils/initUtil.ts` — `executeCliCommands` no longer tears down and relaunches Speculos after its **final** failed attempt. Its two siblings, `executeCliCommandsOnApp` (`:167`) and `setupMainSpeculosApp` (`:228`), already guard that re-setup with `attempt < maxRetries`. Without the guard the loop pays for an acquire/release cycle it will never use, emits a fourth SPECULOS block, and — because the catch block has no inner `try` — a failure inside that re-setup escapes the retry loop and replaces the real `lastError` in the reported message.

The fix is at the reporter rather than at the four call sites, deliberately. Descriptions are scoped per test case along the ancestor chain (`MetadataSelector.testVertical`), and a `beforeAll`'s metadata attaches to the *first test invocation* of its describe block (`DescribeBlockMetadata.js:85`, `#firstTestInvocation`). A cache in `launchSpeculos()` keyed on `appName@appVersion` would therefore have to be scoped to that same boundary or it silently drops a block a later test legitimately needs — see the harness result below, where `group B` keeps its own block. Deduplicating at render is scoped correctly by construction, needs no cross-test state, and covers every emitter, including `swapUtils.ts`' `ensureTokenApproval`/`revokeTokenApproval`.

Blocks for genuinely different apps all differ textually, so they are untouched: a swap description keeps one block per currency plus `Exchange` and its dependencies.

```mermaid
flowchart TD
    subgraph before["before — one paragraph per launch, joined verbatim"]
        B1["launchSpeculosDevices() → launchSpeculos(CCD)"] --> BD1["description += SPECULOS CCD 5.6.3"]
        B2["executeCliCommands attempt 1 fails → relaunch"] --> BD2["description += SPECULOS CCD 5.6.3"]
        B3["attempt 2 fails → relaunch"] --> BD3["description += SPECULOS CCD 5.6.3"]
        B4["attempt 3 fails (final) → relaunch anyway"] --> BD4["description += SPECULOS CCD 5.6.3"]
        BD1 --> BR["report: 4 identical blocks"]
        BD2 --> BR
        BD3 --> BR
        BD4 --> BR
    end

    subgraph after["after"]
        A1["launchSpeculosDevices() → launchSpeculos(CCD)"] --> AD1["description += SPECULOS CCD 5.6.3"]
        A2["attempt 1 fails → relaunch"] --> AD2["description += SPECULOS CCD 5.6.3"]
        A3["attempt 2 fails → relaunch"] --> AD3["description += SPECULOS CCD 5.6.3"]
        A4["attempt 3 fails (final)"] --> AG["no relaunch — attempt &lt; maxRetries guard"]
        AD1 --> AR["dedupeParagraphs → 1 block"]
        AD2 --> AR
        AD3 --> AR
    end
```

**Blast radius, audited on three nightlies.** Test-case records from the `*-ai-analysis` artifacts, replayed through the shipped extractor. Tests with more than one SPECULOS block are common and almost all legitimate (multi-app swaps); only a *verbatim repeat* is the bug:

| nightly | run | records | >1 SPECULOS block | verbatim repeat | changed by this PR |
| --- | --- | --- | --- | --- | --- |
| 2026-09-01 | [33454191987](https://github.com/LedgerHQ/ledger-live/actions/runs/33454191987) | 655 | 69 | 3 | 3 |
| 2026-08-31 | [33344108182](https://github.com/LedgerHQ/ledger-live/actions/runs/33344108182) | 651 | 68 | 0 | 0 |
| 2026-08-28 | [33137517669](https://github.com/LedgerHQ/ledger-live/actions/runs/33137517669) | 632 | 65 | 2 | 2 |

- 2026-09-01 — three `[CCD] - Send` attempts (iOS, `failed`): 4 SPECULOS blocks → 1, description 5 paragraphs → 2, 173 → 68 chars. The 503s behind those retries are QAA-1549 and are not addressed here.
- 2026-08-28 — `[USDC (Ethereum)-ETH] - Swap token approval flow` and `[USDT (Ethereum)-ETH] - Swap token reapproval flow`, both **`passed`** (android): the `swapUtils.ts` path, which brings up a second Speculos for the same app the main setup already launched. 2 → 1 and 3 → 1 blocks. No retry involved, and no change to `swapUtils.ts` was needed.
- The other 1933 records are byte-identical before and after.

### 🔗 Context

- **JIRA / GitHub issue**: [QAA-1547](https://ledgerhq.atlassian.net/browse/QAA-1547) (task under [QAA-1371](https://ledgerhq.atlassian.net/browse/QAA-1371))
- Coordination: [QAA-1535](https://ledgerhq.atlassian.net/browse/QAA-1535) (`descriptionHtml()`) has no open PR and no remote branch, so nothing collided. Its concern is covered — `descriptionHtml` appends the same way and is deduplicated here too.

### 🧪 How this was verified

No E2E run: this is reporting-layer code and Speculos was not needed to prove it.

- **A jest + `jest-allure2-reporter` harness** wired like `e2e/mobile/jest.config.js` (`jest-metadata/environment-node`, both environment listeners), importing the extractors from this branch's config rather than a copy of them, with a spec that reproduces the three real shapes: a root `beforeAll` header, a describe `beforeAll` calling `description()` three times with the same string, and a sibling describe launching the same app.

  | test | before | after |
  | --- | --- | --- |
  | `group A / first test` | `HEADER` + `SPECULOS` ×3 | `HEADER` + `SPECULOS` ×1 |
  | `group B / first test` | `SPECULOS` ×1 | `SPECULOS` ×1 (kept) |

- **The three nightlies above**, replayed through the shipped extractor: 3 + 0 + 2 descriptions changed, 1933 unchanged.
- `pnpm typecheck` ✅ · `pnpm lint` ✅ (0 errors; warnings are pre-existing and none in the touched files) · `pnpm format:check` ✅ · `pnpm lint:test-names` ✅ · `pnpm commitlint --from origin/develop` ✅

### ⚠️ What is not proven

- **No Detox run exercised this.** The evidence is the reporter harness plus replayed nightly data, not a live mobile E2E job. The `initUtil.ts` guard in particular is on a path that only executes when Speculos setup fails three times, and nothing here reproduced that end to end.
- **`allure.description()` called from inside a test body looks unreliable, independently of this PR.** In the harness, descriptions emitted from a test function landed on a *different* test's result, or vanished; only `beforeAll`-emitted and the first-in-file cases were stable. `swapUtils.ts` emits from inside the test body, so its `Token approval result` paragraphs may already be misattributed in the nightly reports. Not investigated further and not touched — flagging it as a separate ticket's worth of work.
- **The header itself is emitted once per file, not once per test.** `setAllureDescription()` runs in a root `beforeAll`, whose metadata attaches only to the first test invocation of the file, so `📄 Test file: …` is missing from every other test's description. Confirmed in the 2026-09-01 nightly: of the 40 spec files that ran more than one distinct test, 36 carry the header on only some of them — `deeplinks.spec.ts` 1/16, `swapDeeplinks.spec.ts` 1/13, `languageChange.spec.ts` 1/4. Out of scope here; likely relevant to QAA-1530.

> **Known red check:** SonarCloud `C Reliability Rating on New Code`, from `typescript:S7727` at `initUtil.ts:112` (`.map(sanitizeError)`). That line is byte-identical on `origin/develop` and the only hunk in that file is at line 275 — Sonar attributes it because the *file* changed, not the line. Not fixed here to stay within one CI iteration.

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-1547]: https://ledgerhq.atlassian.net/browse/QAA-1547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

