### PR TITLE
[LWDM] fix(coin-solana): prevent withdraw while delegation is activating

### DIFF
--- a/.changeset/pretty-ravens-battle.md
+++ b/.changeset/pretty-ravens-battle.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-solana": patch
+---
+
+fix(coin-solana): prevent withdraw while activating

--- a/libs/coin-modules/coin-solana/src/logic.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic.test.ts
@@ -10,6 +10,7 @@ describe("withdrawableFromStake", () => {
       const activation: SolanaStake["activation"] = {
         state: "active",
         active: 7000000,
+        activating: 0,
         inactive: 717120, // MEV rewards
       };
 
@@ -29,6 +30,7 @@ describe("withdrawableFromStake", () => {
       const activation: SolanaStake["activation"] = {
         state: "active",
         active: 7717120,
+        activating: 0,
         inactive: 0,
       };
 
@@ -44,12 +46,16 @@ describe("withdrawableFromStake", () => {
   });
 
   describe("activating stake", () => {
-    test("should allow withdrawal of inactive balance during activation", () => {
-      const stakeAccBalance = 10000000;
+    test("returns 0 when principal is fully activating (nothing withdrawable)", () => {
+      // Bug case: stake just delegated, no epoch boundary crossed yet.
+      // effective=0, activating=full delegation — the old formula (balance - rent - effective)
+      // incorrectly returned the full principal as withdrawable, causing an on-chain error.
+      const stakeAccBalance = 10000000; // rentExemptReserve + delegation
       const activation: SolanaStake["activation"] = {
         state: "activating",
-        active: 5000000,
-        inactive: 2717120,
+        active: 0,
+        activating: 7717120, // full delegation still warming up
+        inactive: 0,
       };
 
       const withdrawable = withdrawableFromStake({
@@ -58,8 +64,49 @@ describe("withdrawableFromStake", () => {
         rentExemptReserve,
       });
 
-      // Should be able to withdraw inactive portion
-      expect(withdrawable).toBe(2717120);
+      expect(withdrawable).toBe(0);
+    });
+
+    test("returns 0 using amount-minus-activeAmount as activating (prepareTransaction call shape)", () => {
+      // prepareTransaction.ts derives activating as Math.max(0, amount - activeAmount).
+      // For a newly delegated stake: amount=delegation, activeAmount=0 → activating=delegation.
+      const delegation = 7717120;
+      const stakeAccBalance = rentExemptReserve + delegation; // no MEV rewards yet
+      const activation: SolanaStake["activation"] = {
+        state: "activating",
+        active: 0,
+        activating: Math.max(0, delegation - 0), // amount - activeAmount
+        inactive: 0,
+      };
+
+      const withdrawable = withdrawableFromStake({
+        stakeAccBalance,
+        activation,
+        rentExemptReserve,
+      });
+
+      expect(withdrawable).toBe(0);
+    });
+
+    test("returns MEV rewards above delegation when partially activated", () => {
+      // delegation = 7_000_000; 5_000_000 effective so far, 2_000_000 still activating.
+      // stakeAccBalance includes 717_120 of MEV rewards above the full delegation.
+      const stakeAccBalance = 10000000; // 2_282_880 rent + 7_000_000 delegation + 717_120 MEV
+      const activation: SolanaStake["activation"] = {
+        state: "activating",
+        active: 5000000,
+        activating: 2000000,
+        inactive: 717120,
+      };
+
+      const withdrawable = withdrawableFromStake({
+        stakeAccBalance,
+        activation,
+        rentExemptReserve,
+      });
+
+      // Only the excess above the full delegation (effective + activating) is withdrawable.
+      expect(withdrawable).toBe(717120);
     });
   });
 
@@ -69,6 +116,7 @@ describe("withdrawableFromStake", () => {
       const activation: SolanaStake["activation"] = {
         state: "deactivating",
         active: 3000000,
+        activating: 0,
         inactive: 4717120,
       };
 
@@ -89,6 +137,7 @@ describe("withdrawableFromStake", () => {
       const activation: SolanaStake["activation"] = {
         state: "inactive",
         active: 0,
+        activating: 0,
         inactive: 7717120,
       };
 
@@ -109,6 +158,7 @@ describe("withdrawableFromStake", () => {
       const activation: SolanaStake["activation"] = {
         state: "active",
         active: 7000000,
+        activating: 0,
         inactive: 0,
       };
 
@@ -127,6 +177,7 @@ describe("withdrawableFromStake", () => {
       const activation: SolanaStake["activation"] = {
         state: "active",
         active: 7000000,
+        activating: 0,
         inactive: 1000, // Small reward
       };
 

--- a/libs/coin-modules/coin-solana/src/logic.ts
+++ b/libs/coin-modules/coin-solana/src/logic.ts
@@ -61,14 +61,21 @@ export function withdrawableFromStake({
 }: {
   stakeAccBalance: number;
   // Structural, not `SolanaStake["activation"]`, so a generic staking position fits too.
-  activation: { state: SolanaStake["activation"]["state"]; active: number };
+  activation: { state: SolanaStake["activation"]["state"]; active: number; activating: number };
   rentExemptReserve: number;
 }) {
   switch (activation.state) {
     case "active":
-    case "activating":
-      // Allow withdrawal of inactive stake (e.g., Jito MEV rewards) without deactivating
+      // Allow withdrawal of excess lamports above active stake (e.g. Jito MEV rewards).
       return stakeAccBalance - rentExemptReserve - activation.active;
+    case "activating":
+      // Per Solana docs: only lamports in excess of (effective + activating) may be withdrawn.
+      // Without subtracting activating, effective=0 early in warmup makes the full principal
+      // appear withdrawable — the on-chain tx would fail.
+      return Math.max(
+        0,
+        stakeAccBalance - rentExemptReserve - activation.active - activation.activating,
+      );
     case "deactivating":
       return stakeAccBalance - rentExemptReserve - activation.active;
     case "inactive":

--- a/libs/coin-modules/coin-solana/src/logic/tests/stakingResources.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/stakingResources.unit.test.ts
@@ -20,7 +20,7 @@ const activeStake: SolanaStake = {
   stakeAccBalance: 500,
   rentExemptReserve: 10,
   withdrawable: 90,
-  activation: { state: "active", active: 400, inactive: 90 },
+  activation: { state: "active", active: 400, activating: 0, inactive: 90 },
 };
 
 const inactiveStake: SolanaStake = {
@@ -31,7 +31,7 @@ const inactiveStake: SolanaStake = {
   stakeAccBalance: 200,
   rentExemptReserve: 10,
   withdrawable: 200,
-  activation: { state: "inactive", active: 0, inactive: 190 },
+  activation: { state: "inactive", active: 0, activating: 0, inactive: 190 },
 };
 
 const deactivatingStake: SolanaStake = {
@@ -42,7 +42,7 @@ const deactivatingStake: SolanaStake = {
   stakeAccBalance: 320,
   rentExemptReserve: 10,
   withdrawable: 0,
-  activation: { state: "deactivating", active: 300, inactive: 0 },
+  activation: { state: "deactivating", active: 300, activating: 0, inactive: 0 },
 };
 
 const activatingStake: SolanaStake = {
@@ -53,7 +53,7 @@ const activatingStake: SolanaStake = {
   stakeAccBalance: 110,
   rentExemptReserve: 10,
   withdrawable: 0,
-  activation: { state: "activating", active: 0, inactive: 100 },
+  activation: { state: "activating", active: 0, activating: 100, inactive: 100 },
   reward: { amount: 12 },
 };
 

--- a/libs/coin-modules/coin-solana/src/network/chain/stake-activation/rpc.ts
+++ b/libs/coin-modules/coin-solana/src/network/chain/stake-activation/rpc.ts
@@ -29,6 +29,7 @@ export interface StakeActivationData {
   state: StakeActivationState;
   active: number;
   inactive: number;
+  activating: number;
 }
 
 export interface StakeAccount {
@@ -75,6 +76,7 @@ function toStakeAccount(
       state: getStakeActivationState({ effective, activating, deactivating }),
       active: effective.toNumber(),
       inactive: inactive.toNumber(),
+      activating: activating.toNumber(),
     } as StakeActivationData,
     reward: null,
   };

--- a/libs/coin-modules/coin-solana/src/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-solana/src/prepareTransaction.test.ts
@@ -732,7 +732,7 @@ describe("testing prepareTransaction", () => {
           stakeAccBalance: STALE_WITHDRAWABLE + RENT_EXEMPT_RESERVE,
           rentExemptReserve: RENT_EXEMPT_RESERVE,
           withdrawable: STALE_WITHDRAWABLE,
-          activation: { state: "inactive", active: 0, inactive: STALE_WITHDRAWABLE },
+          activation: { state: "inactive", active: 0, activating: 0, inactive: STALE_WITHDRAWABLE },
           ...stakeOverrides,
         };
         return {

--- a/libs/coin-modules/coin-solana/src/prepareTransaction.ts
+++ b/libs/coin-modules/coin-solana/src/prepareTransaction.ts
@@ -832,6 +832,10 @@ async function deriveStakeWithdrawCommandDescriptor(
           activation: {
             state: solanaActivationState(stake),
             active: stake.activeAmount?.toNumber() ?? 0,
+            activating: Math.max(
+              0,
+              (stake.amount?.toNumber() ?? 0) - (stake.activeAmount?.toNumber() ?? 0),
+            ),
           },
           rentExemptReserve: stake.lockedReserve?.toNumber() ?? 0,
         }),

--- a/libs/coin-modules/coin-solana/src/tests/stakes-bridge.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/tests/stakes-bridge.unit.test.ts
@@ -169,6 +169,7 @@ async function runStakeTest(stakeTestSpec: StakeTestSpec) {
           activation: {
             state: stakeTestSpec.activationState,
             active: stakeTestSpec.activationState === "active" ? 1 : 0,
+            activating: 0,
             inactive: stakeTestSpec.activationState === "active" ? 0 : 1,
           },
         },

--- a/libs/coin-modules/coin-solana/src/types.ts
+++ b/libs/coin-modules/coin-solana/src/types.ts
@@ -270,6 +270,7 @@ export type SolanaStake = {
     state: "active" | "inactive" | "activating" | "deactivating";
     active: number;
     inactive: number;
+    activating: number;
   };
   reward?:
     | {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Users have the possibility to withdraw Solana delegations while they are activating. This is blocked by the protocol, resulting in a fail.
We take the activating amount into account so it becomes impossible to withdraw.

| Before | After |
| - | - |
| <img width="1624" height="1061" alt="image" src="https://github.com/user-attachments/assets/e0f99ff5-ddea-4ab7-9e4a-fbf7999f7ffe" /> | <img width="1624" height="1061" alt="image" src="https://github.com/user-attachments/assets/76af242b-b94e-4957-a87e-d8d15854db43" /> |
| <img width="1116" height="2484" alt="image" src="https://github.com/user-attachments/assets/6183614d-2712-45bf-9115-14f8b8ec8e40" /> | <img width="1116" height="2484" alt="image" src="https://github.com/user-attachments/assets/0bf819e2-65ee-4ce7-b390-329e2e1a6405" /> |

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-36790
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
