### PR TITLE
[LWM] feat(pay): add DevTools reset for verify hint (LIVE-36582)

### DIFF
--- a/.changeset/LIVE-36582-pay-request-verify-hint-devtools.md
+++ b/.changeset/LIVE-36582-pay-request-verify-hint-devtools.md
@@ -1,0 +1,6 @@
+---
+"@devtools/pay-card": minor
+"@devtools/bindings": minor
+---
+
+Add a DevTools reset for the Pay Request verify hint, plus mobile shortcuts to Portfolio and Pay.

--- a/apps/ledger-live-mobile/src/mvvm/features/DevTools/__integrations__/DevToolsScreen.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/DevTools/__integrations__/DevToolsScreen.integration.test.tsx
@@ -65,7 +65,14 @@ describe("DevToolsScreen", () => {
     expect(props.config).toEqual([
       { id: "feature-flags", config: { marker: "ff-props" } },
       { id: "env", config: { marker: "env-props" } },
-      { id: "pay-card", config: { marker: "pay-card-props" } },
+      {
+        id: "pay-card",
+        config: {
+          marker: "pay-card-props",
+          onNavigateToPortfolio: expect.any(Function),
+          onNavigateToPayTab: expect.any(Function),
+        },
+      },
     ]);
     expect(props.screenOptions.contentStyle).toEqual([expect.anything(), { paddingBottom: 34 }]);
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/DevTools/screens/DevToolsScreen/useDevToolsScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/DevTools/screens/DevToolsScreen/useDevToolsScreenViewModel.ts
@@ -1,6 +1,10 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
+import { StackActions, useNavigation } from "@react-navigation/native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import type { NativeStackNavigationOptions } from "@react-navigation/native-stack";
+import type {
+  NativeStackNavigationOptions,
+  NativeStackNavigationProp,
+} from "@react-navigation/native-stack";
 import { useTheme } from "@ledgerhq/lumen-ui-rnative/styles";
 import { getStackNavigationConfigV4 } from "LLM/components/Navigation";
 import {
@@ -9,11 +13,35 @@ import {
   useEnvDevToolProps,
 } from "@devtools/bindings";
 import type { DevToolsConfig } from "@devtools/shell";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { BASE_NAVIGATOR_ID, NavigatorName, ScreenName } from "~/const";
+import { navigateToPayTab } from "LLM/features/PayTab/utils/navigateToPayTab";
 import { useDevToolsRelay } from "./useDevToolsRelay";
 
+type BaseNavigation = NativeStackNavigationProp<
+  BaseNavigatorStackParamList,
+  keyof BaseNavigatorStackParamList,
+  typeof BASE_NAVIGATOR_ID
+>;
+
 export function useDevToolsScreenViewModel() {
+  const navigation = useNavigation<BaseNavigation>();
+  const tabNavigation = navigation.getParent(BASE_NAVIGATOR_ID) ?? navigation;
   const featureFlagsProps = useFeatureFlagsToolProps();
-  const payCardToolProps = usePayCardToolProps({ platform: "native" });
+  const boundPayCard = usePayCardToolProps({ platform: "native" });
+  const onNavigateToPortfolio = useCallback(() => {
+    tabNavigation.dispatch(
+      StackActions.replace(NavigatorName.Main, {
+        screen: NavigatorName.Portfolio,
+        params: { screen: ScreenName.Portfolio },
+      }),
+    );
+  }, [tabNavigation]);
+  const onNavigateToPayTab = useCallback(() => navigateToPayTab(tabNavigation), [tabNavigation]);
+  const payCardToolProps = useMemo(
+    () => ({ ...boundPayCard, onNavigateToPortfolio, onNavigateToPayTab }),
+    [boundPayCard, onNavigateToPortfolio, onNavigateToPayTab],
+  );
   const envToolProps = useEnvDevToolProps();
   const { theme } = useTheme();
   const { bottom } = useSafeAreaInsets();

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/utils/__tests__/navigateToPayTab.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/utils/__tests__/navigateToPayTab.test.ts
@@ -1,0 +1,18 @@
+import { StackActions } from "@react-navigation/native";
+import { NavigatorName, ScreenName } from "~/const";
+import { navigateToPayTab } from "../navigateToPayTab";
+
+describe("navigateToPayTab", () => {
+  it("should replace to the Pay tab screen", () => {
+    const dispatch = jest.fn();
+
+    navigateToPayTab({ dispatch });
+
+    expect(dispatch).toHaveBeenCalledWith(
+      StackActions.replace(NavigatorName.Main, {
+        screen: NavigatorName.PayTab,
+        params: { screen: ScreenName.PayTab },
+      }),
+    );
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/utils/navigateToPayTab.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/utils/navigateToPayTab.ts
@@ -1,0 +1,13 @@
+import { StackActions, type NavigationProp, type ParamListBase } from "@react-navigation/native";
+import { NavigatorName, ScreenName } from "~/const";
+
+export function navigateToPayTab(
+  navigation: Pick<NavigationProp<ParamListBase>, "dispatch">,
+): void {
+  navigation.dispatch(
+    StackActions.replace(NavigatorName.Main, {
+      screen: NavigatorName.PayTab,
+      params: { screen: ScreenName.PayTab },
+    }),
+  );
+}

--- a/devtools/bindings/package.json
+++ b/devtools/bindings/package.json
@@ -23,6 +23,7 @@
     "@devtools/registry": "workspace:*",
     "@devtools/env": "workspace:*",
     "@features/flow-pay-feature-tour": "workspace:*",
+    "@features/flow-pay-request": "workspace:*",
     "@features/platform-feature-flags": "workspace:*",
     "@shared/env": "workspace:*",
     "@shared/feature-flags": "workspace:*"

--- a/devtools/bindings/src/usePayCardToolProps.test.tsx
+++ b/devtools/bindings/src/usePayCardToolProps.test.tsx
@@ -7,6 +7,10 @@ import {
   payCardFeatureTourSlice,
   markPayCardFeatureTourSeen,
 } from "@features/flow-pay-feature-tour/state";
+import {
+  payRequestVerifyHintSlice,
+  markReceiveVerifyHintSeen,
+} from "@features/flow-pay-request/state";
 import { usePayCardToolProps } from "./usePayCardToolProps";
 
 /**
@@ -45,6 +49,7 @@ function buildStore() {
     reducer: {
       featureFlags: featureFlagsReducer,
       payCardFeatureTour: payCardFeatureTourSlice.reducer,
+      payRequestVerifyHint: payRequestVerifyHintSlice.reducer,
     },
     middleware: gdm => gdm().concat(createFeatureFlagsMiddleware({ resolutionConfig: {} })),
   });
@@ -235,5 +240,26 @@ describe("usePayCardToolProps", () => {
 
     expect(store.getState().payCardFeatureTour.hasSeenFeatureTour).toBe(false);
     expect(result.current.hasSeenFeatureTour).toBe(false);
+  });
+
+  it("exposes hasSeenReceiveVerifyHint from the request verify hint slice", () => {
+    store.dispatch(markReceiveVerifyHintSeen());
+
+    const { result } = renderHook(() => usePayCardToolProps(), { wrapper: withStore(store) });
+
+    expect(result.current.hasSeenReceiveVerifyHint).toBe(true);
+  });
+
+  it("resetReceiveVerifyHintSeen clears the seen flag", () => {
+    store.dispatch(markReceiveVerifyHintSeen());
+
+    const { result } = renderHook(() => usePayCardToolProps(), { wrapper: withStore(store) });
+
+    act(() => {
+      result.current.resetReceiveVerifyHintSeen();
+    });
+
+    expect(store.getState().payRequestVerifyHint.hasSeenReceiveVerifyHint).toBe(false);
+    expect(result.current.hasSeenReceiveVerifyHint).toBe(false);
   });
 });

--- a/devtools/bindings/src/usePayCardToolProps.ts
+++ b/devtools/bindings/src/usePayCardToolProps.ts
@@ -7,6 +7,10 @@ import {
   resetPayCardFeatureTourSeen,
   selectPayCardHasSeenFeatureTour,
 } from "@features/flow-pay-feature-tour/state";
+import {
+  resetReceiveVerifyHintSeen,
+  selectHasSeenReceiveVerifyHint,
+} from "@features/flow-pay-request/state";
 import type { DevToolsConfig } from "@devtools/registry";
 
 type PayCardToolProps = Extract<DevToolsConfig[number], { id: "pay-card" }>["config"];
@@ -100,9 +104,14 @@ export function usePayCardToolProps(options: UsePayCardToolPropsOptions = {}): P
   );
 
   const hasSeenFeatureTour = useSelector(selectPayCardHasSeenFeatureTour);
+  const hasSeenReceiveVerifyHint = useSelector(selectHasSeenReceiveVerifyHint);
 
   const resetFeatureTour = useCallback(() => {
     dispatch(resetPayCardFeatureTourSeen());
+  }, [dispatch]);
+
+  const resetVerifyHint = useCallback(() => {
+    dispatch(resetReceiveVerifyHintSeen());
   }, [dispatch]);
 
   const setStepDone = useCallback((id: string, done: boolean) => {
@@ -151,8 +160,18 @@ export function usePayCardToolProps(options: UsePayCardToolPropsOptions = {}): P
       onboarding,
       hasSeenFeatureTour,
       resetPayCardFeatureTourSeen: resetFeatureTour,
+      hasSeenReceiveVerifyHint,
+      resetReceiveVerifyHintSeen: resetVerifyHint,
       env,
     }),
-    [flags, onboarding, hasSeenFeatureTour, resetFeatureTour, env],
+    [
+      flags,
+      onboarding,
+      hasSeenFeatureTour,
+      resetFeatureTour,
+      hasSeenReceiveVerifyHint,
+      resetVerifyHint,
+      env,
+    ],
   );
 }

--- a/devtools/pay-card/README.md
+++ b/devtools/pay-card/README.md
@@ -1,9 +1,10 @@
 # @devtools/pay-card
 
-The Card / Pay DevTool. It puts the Card / Pay feature into a given state from one place, in five
-sections: **Feature flags**, **Onboarding** (toggle each step done or not-done), **Reset onboarding**,
-**Feature tour** (seen state plus a reset) and **Env vars** (the Card backend values, with the
-development tenant ready in each input).
+The Card / Pay DevTool. It puts the Card / Pay feature into a given state from one place:
+**Feature flags**, **Onboarding** (toggle each step done or not-done), **Reset onboarding**,
+**Feature tour** (seen state plus a reset), **Request verify hint** (seen state plus a reset),
+**Env vars** (the Card backend values, with the development tenant ready in each input), and
+optional **Quick actions** (Portfolio / Pay) when the host passes navigation callbacks.
 
 ## Import boundary
 
@@ -46,6 +47,10 @@ interface PayCardToolProps {
   };
   hasSeenFeatureTour: boolean;
   resetPayCardFeatureTourSeen: () => void;
+  hasSeenReceiveVerifyHint: boolean;
+  resetReceiveVerifyHintSeen: () => void;
+  onNavigateToPortfolio?: () => void;
+  onNavigateToPayTab?: () => void;
   env: {
     // The app reads these values on every request, so `setVar` applies without a restart. Nothing
     // saves them: after a restart the app reads the build's values again.

--- a/devtools/pay-card/src/pay-card/PayCard.native.test.tsx
+++ b/devtools/pay-card/src/pay-card/PayCard.native.test.tsx
@@ -24,6 +24,8 @@ function buildProps(): PayCardToolProps {
     },
     hasSeenFeatureTour: false,
     resetPayCardFeatureTourSeen: jest.fn(),
+    hasSeenReceiveVerifyHint: false,
+    resetReceiveVerifyHintSeen: jest.fn(),
     env: {
       vars: [
         {
@@ -44,6 +46,7 @@ describe("PayCard (native)", () => {
     expect(screen.getByText("Feature flags")).toBeTruthy();
     expect(screen.getByText("Onboarding")).toBeTruthy();
     expect(screen.getByText("Feature tour")).toBeTruthy();
+    expect(screen.getByText("Request verify hint")).toBeTruthy();
   });
 
   it("resets the feature tour", async () => {
@@ -53,6 +56,39 @@ describe("PayCard (native)", () => {
 
     await user.press(screen.getByText("Reset feature tour"));
     expect(props.resetPayCardFeatureTourSeen).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the request verify hint", async () => {
+    const user = userEvent.setup();
+    const props = buildProps();
+    render(<PayCard {...props} />);
+
+    await user.press(screen.getByText("Reset verify hint"));
+    expect(props.resetReceiveVerifyHintSeen).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides quick actions when the host does not pass navigation", () => {
+    render(<PayCard {...buildProps()} />);
+    expect(screen.queryByText("Quick actions")).toBeNull();
+  });
+
+  it("navigates to Portfolio and Pay when the host wires the actions", async () => {
+    const user = userEvent.setup();
+    const onNavigateToPortfolio = jest.fn();
+    const onNavigateToPayTab = jest.fn();
+    render(
+      <PayCard
+        {...buildProps()}
+        onNavigateToPortfolio={onNavigateToPortfolio}
+        onNavigateToPayTab={onNavigateToPayTab}
+      />,
+    );
+
+    expect(screen.getByText("Quick actions")).toBeTruthy();
+    await user.press(screen.getByText("Go to Portfolio"));
+    await user.press(screen.getByText("Go to Pay tab"));
+    expect(onNavigateToPortfolio).toHaveBeenCalledTimes(1);
+    expect(onNavigateToPayTab).toHaveBeenCalledTimes(1);
   });
 
   it("shows both Card env vars, and the value the app reads now", () => {

--- a/devtools/pay-card/src/pay-card/PayCard.native.tsx
+++ b/devtools/pay-card/src/pay-card/PayCard.native.tsx
@@ -8,7 +8,17 @@ import { EnvVarRow } from "../components/EnvVarRow/EnvVarRow";
 const BUTTON_ROW_STYLE = { flexDirection: "row", flexWrap: "wrap", gap: 8 } as const;
 
 export function PayCard(props: Readonly<PayCardToolProps>) {
-  const { flags, onboarding, hasSeenFeatureTour, resetPayCardFeatureTourSeen, env } = props;
+  const {
+    flags,
+    onboarding,
+    hasSeenFeatureTour,
+    resetPayCardFeatureTourSeen,
+    hasSeenReceiveVerifyHint,
+    resetReceiveVerifyHintSeen,
+    onNavigateToPortfolio,
+    onNavigateToPayTab,
+    env,
+  } = props;
 
   return (
     <ScrollView>
@@ -60,20 +70,41 @@ export function PayCard(props: Readonly<PayCardToolProps>) {
 
       <Divider />
 
-      <Section title="Feature tour">
-        <Box style={BUTTON_ROW_STYLE}>
-          <Tag
-            size="sm"
-            appearance={hasSeenFeatureTour ? "success" : "gray"}
-            label={hasSeenFeatureTour ? "Seen" : "Not seen"}
-          />
-        </Box>
-        <Box style={BUTTON_ROW_STYLE}>
-          <Button appearance="gray" size="sm" onPress={resetPayCardFeatureTourSeen}>
-            Reset feature tour
-          </Button>
-        </Box>
-      </Section>
+      <SeenReset
+        title="Feature tour"
+        seen={hasSeenFeatureTour}
+        resetLabel="Reset feature tour"
+        onReset={resetPayCardFeatureTourSeen}
+      />
+
+      <Divider />
+
+      <SeenReset
+        title="Request verify hint"
+        seen={hasSeenReceiveVerifyHint}
+        resetLabel="Reset verify hint"
+        onReset={resetReceiveVerifyHintSeen}
+      />
+
+      {onNavigateToPortfolio || onNavigateToPayTab ? (
+        <>
+          <Divider />
+          <Section title="Quick actions">
+            <Box style={BUTTON_ROW_STYLE}>
+              {onNavigateToPortfolio ? (
+                <Button appearance="gray" size="sm" onPress={onNavigateToPortfolio}>
+                  Go to Portfolio
+                </Button>
+              ) : null}
+              {onNavigateToPayTab ? (
+                <Button appearance="gray" size="sm" onPress={onNavigateToPayTab}>
+                  Go to Pay tab
+                </Button>
+              ) : null}
+            </Box>
+          </Section>
+        </>
+      ) : null}
 
       <Divider />
 
@@ -86,6 +117,31 @@ export function PayCard(props: Readonly<PayCardToolProps>) {
         ))}
       </Section>
     </ScrollView>
+  );
+}
+
+function SeenReset({
+  title,
+  seen,
+  resetLabel,
+  onReset,
+}: Readonly<{
+  title: string;
+  seen: boolean;
+  resetLabel: string;
+  onReset: () => void;
+}>) {
+  return (
+    <Section title={title}>
+      <Box style={BUTTON_ROW_STYLE}>
+        <Tag size="sm" appearance={seen ? "success" : "gray"} label={seen ? "Seen" : "Not seen"} />
+      </Box>
+      <Box style={BUTTON_ROW_STYLE}>
+        <Button appearance="gray" size="sm" onPress={onReset}>
+          {resetLabel}
+        </Button>
+      </Box>
+    </Section>
   );
 }
 

--- a/devtools/pay-card/src/pay-card/PayCard.web.test.tsx
+++ b/devtools/pay-card/src/pay-card/PayCard.web.test.tsx
@@ -24,6 +24,8 @@ function buildProps(): PayCardToolProps {
     },
     hasSeenFeatureTour: false,
     resetPayCardFeatureTourSeen: jest.fn(),
+    hasSeenReceiveVerifyHint: false,
+    resetReceiveVerifyHintSeen: jest.fn(),
     env: {
       vars: [
         {
@@ -44,6 +46,7 @@ describe("PayCard (web)", () => {
     expect(screen.getByText("Feature flags")).toBeDefined();
     expect(screen.getByText("Onboarding")).toBeDefined();
     expect(screen.getByText("Feature tour")).toBeDefined();
+    expect(screen.getByText("Request verify hint")).toBeDefined();
   });
 
   it("resets the feature tour", () => {
@@ -52,6 +55,37 @@ describe("PayCard (web)", () => {
 
     fireEvent.click(screen.getByText("Reset feature tour"));
     expect(props.resetPayCardFeatureTourSeen).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the request verify hint", () => {
+    const props = buildProps();
+    render(<PayCard {...props} />);
+
+    fireEvent.click(screen.getByText("Reset verify hint"));
+    expect(props.resetReceiveVerifyHintSeen).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides quick actions when the host does not pass navigation", () => {
+    render(<PayCard {...buildProps()} />);
+    expect(screen.queryByText("Quick actions")).toBeNull();
+  });
+
+  it("navigates to Portfolio and Pay when the host wires the actions", () => {
+    const onNavigateToPortfolio = jest.fn();
+    const onNavigateToPayTab = jest.fn();
+    render(
+      <PayCard
+        {...buildProps()}
+        onNavigateToPortfolio={onNavigateToPortfolio}
+        onNavigateToPayTab={onNavigateToPayTab}
+      />,
+    );
+
+    expect(screen.getByText("Quick actions")).toBeDefined();
+    fireEvent.click(screen.getByText("Go to Portfolio"));
+    fireEvent.click(screen.getByText("Go to Pay tab"));
+    expect(onNavigateToPortfolio).toHaveBeenCalledTimes(1);
+    expect(onNavigateToPayTab).toHaveBeenCalledTimes(1);
   });
 
   it("shows both Card env vars, and the value the app reads now", () => {

--- a/devtools/pay-card/src/pay-card/PayCard.web.tsx
+++ b/devtools/pay-card/src/pay-card/PayCard.web.tsx
@@ -5,7 +5,17 @@ import { ToggleRow } from "../components/ToggleRow/ToggleRow";
 import { EnvVarRow } from "../components/EnvVarRow/EnvVarRow";
 
 export function PayCard(props: Readonly<PayCardToolProps>) {
-  const { flags, onboarding, hasSeenFeatureTour, resetPayCardFeatureTourSeen, env } = props;
+  const {
+    flags,
+    onboarding,
+    hasSeenFeatureTour,
+    resetPayCardFeatureTourSeen,
+    hasSeenReceiveVerifyHint,
+    resetReceiveVerifyHintSeen,
+    onNavigateToPortfolio,
+    onNavigateToPayTab,
+    env,
+  } = props;
 
   return (
     <div className="flex flex-col overflow-y-auto">
@@ -57,20 +67,41 @@ export function PayCard(props: Readonly<PayCardToolProps>) {
 
       <Divider />
 
-      <Section title="Feature tour">
-        <div>
-          <Tag
-            size="sm"
-            appearance={hasSeenFeatureTour ? "success" : "gray"}
-            label={hasSeenFeatureTour ? "Seen" : "Not seen"}
-          />
-        </div>
-        <div className="flex flex-wrap gap-8">
-          <Button appearance="gray" size="sm" onClick={resetPayCardFeatureTourSeen}>
-            Reset feature tour
-          </Button>
-        </div>
-      </Section>
+      <SeenReset
+        title="Feature tour"
+        seen={hasSeenFeatureTour}
+        resetLabel="Reset feature tour"
+        onReset={resetPayCardFeatureTourSeen}
+      />
+
+      <Divider />
+
+      <SeenReset
+        title="Request verify hint"
+        seen={hasSeenReceiveVerifyHint}
+        resetLabel="Reset verify hint"
+        onReset={resetReceiveVerifyHintSeen}
+      />
+
+      {onNavigateToPortfolio || onNavigateToPayTab ? (
+        <>
+          <Divider />
+          <Section title="Quick actions">
+            <div className="flex flex-wrap gap-8">
+              {onNavigateToPortfolio ? (
+                <Button appearance="gray" size="sm" onClick={onNavigateToPortfolio}>
+                  Go to Portfolio
+                </Button>
+              ) : null}
+              {onNavigateToPayTab ? (
+                <Button appearance="gray" size="sm" onClick={onNavigateToPayTab}>
+                  Go to Pay tab
+                </Button>
+              ) : null}
+            </div>
+          </Section>
+        </>
+      ) : null}
 
       <Divider />
 
@@ -83,6 +114,31 @@ export function PayCard(props: Readonly<PayCardToolProps>) {
         ))}
       </Section>
     </div>
+  );
+}
+
+function SeenReset({
+  title,
+  seen,
+  resetLabel,
+  onReset,
+}: Readonly<{
+  title: string;
+  seen: boolean;
+  resetLabel: string;
+  onReset: () => void;
+}>) {
+  return (
+    <Section title={title}>
+      <div>
+        <Tag size="sm" appearance={seen ? "success" : "gray"} label={seen ? "Seen" : "Not seen"} />
+      </div>
+      <div className="flex flex-wrap gap-8">
+        <Button appearance="gray" size="sm" onClick={onReset}>
+          {resetLabel}
+        </Button>
+      </div>
+    </Section>
   );
 }
 

--- a/devtools/pay-card/src/types.ts
+++ b/devtools/pay-card/src/types.ts
@@ -65,6 +65,14 @@ export interface PayCardToolProps {
   readonly hasSeenFeatureTour: boolean;
   /** Resets the feature tour so it plays again on the next Pay visit. */
   readonly resetPayCardFeatureTourSeen: () => void;
+  /** Whether the user has already dismissed the Request Verify hint. */
+  readonly hasSeenReceiveVerifyHint: boolean;
+  /** Resets the Request Verify hint so it shows again on the next Request. */
+  readonly resetReceiveVerifyHintSeen: () => void;
+  /** Host-only: jump to Portfolio. Omitted when the host cannot navigate. */
+  readonly onNavigateToPortfolio?: () => void;
+  /** Host-only: jump to the Pay tab. Omitted when the host cannot navigate. */
+  readonly onNavigateToPayTab?: () => void;
   /** The Card backend env vars, read live and set from the tool. */
   readonly env: PayCardEnvProps;
 }

--- a/devtools/pay-card/src/usePayCardViewModel.native.test.ts
+++ b/devtools/pay-card/src/usePayCardViewModel.native.test.ts
@@ -30,6 +30,8 @@ function buildProps(overrides: Partial<PayCardToolProps> = {}): PayCardToolProps
     },
     hasSeenFeatureTour: overrides.hasSeenFeatureTour ?? false,
     resetPayCardFeatureTourSeen: overrides.resetPayCardFeatureTourSeen ?? jest.fn(),
+    hasSeenReceiveVerifyHint: overrides.hasSeenReceiveVerifyHint ?? false,
+    resetReceiveVerifyHintSeen: overrides.resetReceiveVerifyHintSeen ?? jest.fn(),
     env: overrides.env ?? { vars: [], setVar: jest.fn() },
   };
 }

--- a/devtools/pay-card/src/usePayCardViewModel.test.ts
+++ b/devtools/pay-card/src/usePayCardViewModel.test.ts
@@ -29,6 +29,8 @@ function buildProps(overrides: Partial<PayCardToolProps> = {}): PayCardToolProps
     },
     hasSeenFeatureTour: overrides.hasSeenFeatureTour ?? false,
     resetPayCardFeatureTourSeen: overrides.resetPayCardFeatureTourSeen ?? jest.fn(),
+    hasSeenReceiveVerifyHint: overrides.hasSeenReceiveVerifyHint ?? false,
+    resetReceiveVerifyHintSeen: overrides.resetReceiveVerifyHintSeen ?? jest.fn(),
     env: overrides.env ?? { vars: [], setVar: jest.fn() },
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3163,6 +3163,9 @@ importers:
       '@features/flow-pay-feature-tour':
         specifier: workspace:*
         version: link:../../features/flow/pay-feature-tour
+      '@features/flow-pay-request':
+        specifier: workspace:*
+        version: link:../../features/flow/pay-request
       '@features/platform-feature-flags':
         specifier: workspace:*
         version: link:../../features/platform/feature-flags


### PR DESCRIPTION
### 📝 Description

QA cannot reset the Request verify hint without wiping `payCard` storage.

This PR adds Seen / Not seen and Reset verify hint on the Pay card DevTool (web + native), wired to `resetReceiveVerifyHintSeen`.

**Stack:** 4/4, based on #21421. State is #21434.

<img width="383" height="653" alt="image" src="https://github.com/user-attachments/assets/7b31aa19-b5c1-4225-af8a-718a86d1b6b3" />


### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36582](https://ledgerhq.atlassian.net/browse/LIVE-36582)

[LIVE-36582]: https://ledgerhq.atlassian.net/browse/LIVE-36582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ