### PR TITLE
[LWM] feat(pay-card): show the linked-wallet total as the card balance

### DIFF
--- a/.changeset/pay-card-balance-from-linked-wallets.md
+++ b/.changeset/pay-card-balance-from-linked-wallets.md
@@ -1,0 +1,10 @@
+---
+"@features/flow-pay-card": minor
+"live-mobile": minor
+---
+
+Show the real card balance: the total of the wallets linked to the card.
+
+- `useCardViewModel` reads `useCardLinkedWallets().total` instead of a placeholder, and passes `isLoading` to the visual.
+- `CardProps` takes `resolveCounterValue`; the wallet queries are skipped without it, so hosts that omit it are unaffected.
+- Mobile resolves a Baanx ticker to a Ledger currency via the stablecoin catalog, then prices it with the app's countervalue state. An asset outside that catalog resolves to `null`, which the total reports as partial rather than as zero.

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -113,6 +113,7 @@
     "@features/flow-app-lock": "workspace:*",
     "@features/flow-pay-card": "workspace:^",
     "@features/flow-pay-card-auth": "workspace:^",
+    "@features/flow-pay-card-wallets": "workspace:^",
     "@features/flow-pay-card-widget": "workspace:^",
     "@features/flow-pay-balance": "workspace:^",
     "@features/flow-pay-bank-transfer": "workspace:^",

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/__tests__/usePayCardWalletCounterValue.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/__tests__/usePayCardWalletCounterValue.test.ts
@@ -1,0 +1,63 @@
+import BigNumber from "bignumber.js";
+import { renderHook } from "@tests/test-renderer";
+import { usePayCardWalletCounterValue } from "../usePayCardWalletCounterValue";
+
+const USDC = {
+  id: "ethereum/erc20/usd__coin",
+  type: "TokenCurrency",
+  ticker: "USDC",
+  name: "USD Coin",
+  units: [{ name: "USDC", code: "USDC", magnitude: 6 }],
+};
+
+const mockCalculateCountervalue = jest.fn();
+
+jest.mock("~/actions/general", () => ({
+  ...jest.requireActual("~/actions/general"),
+  useCalculateCountervalueCallback: () => mockCalculateCountervalue,
+}));
+
+jest.mock("@domain/api-aggregated-assets", () => ({
+  ...jest.requireActual("@domain/api-aggregated-assets"),
+  useGetAssetsDataInfiniteQuery: () => ({ data: { pages: [{}] } }),
+  mergeAssetsDataPages: () => ({
+    currenciesOrder: { metaCurrencyIds: ["usd__coin"] },
+    cryptoAssets: { usd__coin: { ticker: "USDC" } },
+  }),
+}));
+
+jest.mock("@features/platform-aggregated-assets", () => ({
+  ...jest.requireActual("@features/platform-aggregated-assets"),
+  selectCurrencyForMetaId: () => USDC,
+}));
+
+describe("usePayCardWalletCounterValue", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("prices a wallet in the counter-value currency's smallest unit", () => {
+    // 125.40 USDC at 1.00 -> 12540 cents, the scale AmountDisplay's formatter expects.
+    mockCalculateCountervalue.mockReturnValue(new BigNumber(12540));
+
+    const { result } = renderHook(() => usePayCardWalletCounterValue());
+    const counterValue = result.current({ currency: "usdc", network: "ethereum" }, "125.40");
+
+    // The raw string is parsed into the token's own smallest unit before being priced.
+    expect(mockCalculateCountervalue).toHaveBeenCalledWith(USDC, new BigNumber("125400000"));
+    expect(counterValue).toBe(12540);
+  });
+
+  it("returns null for an asset the catalog cannot resolve", () => {
+    const { result } = renderHook(() => usePayCardWalletCounterValue());
+
+    expect(result.current({ currency: "sol", network: "solana" }, "2.5")).toBeNull();
+    expect(mockCalculateCountervalue).not.toHaveBeenCalled();
+  });
+
+  it("returns null when no rate is available", () => {
+    mockCalculateCountervalue.mockReturnValue(null);
+
+    const { result } = renderHook(() => usePayCardWalletCounterValue());
+
+    expect(result.current({ currency: "usdc", network: "ethereum" }, "125.40")).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayCardWalletCounterValue.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayCardWalletCounterValue.ts
@@ -1,0 +1,61 @@
+import { useCallback, useMemo } from "react";
+import VersionNumber from "react-native-version-number";
+import { parseCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
+import {
+  AssetCategory,
+  mergeAssetsDataPages,
+  useGetAssetsDataInfiniteQuery,
+} from "@domain/api-aggregated-assets";
+import { selectCurrencyForMetaId } from "@features/platform-aggregated-assets";
+import type { ResolveWalletCounterValue } from "@features/flow-pay-card-wallets";
+import { useCalculateCountervalueCallback } from "~/actions/general";
+
+const STABLECOIN_CATEGORIES = [AssetCategory.Stablecoins];
+
+/**
+ * Values a card-linked custodial wallet in the user's counter-value currency.
+ *
+ * Baanx names the asset by ticker (`usdc`), so the ticker has to be resolved to a Ledger currency
+ * before the countervalue state can price it. The stablecoin catalog is the only resolvable set the
+ * Pay tab already loads; a wallet holding anything else resolves to `null`, which the caller reports
+ * as a partial total rather than as zero.
+ */
+export function usePayCardWalletCounterValue(): ResolveWalletCounterValue {
+  const version = VersionNumber.appVersion ?? "";
+  const calculateCountervalue = useCalculateCountervalueCallback();
+
+  const { data } = useGetAssetsDataInfiniteQuery({
+    categories: STABLECOIN_CATEGORIES,
+    product: "llm",
+    version,
+  });
+
+  const currencyByTicker = useMemo(() => {
+    const merged = mergeAssetsDataPages(data?.pages);
+    const byTicker = new Map<string, CryptoOrTokenCurrency>();
+    if (!merged) return byTicker;
+
+    for (const metaId of merged.currenciesOrder.metaCurrencyIds) {
+      const ticker = merged.cryptoAssets[metaId]?.ticker?.toUpperCase();
+      if (!ticker || byTicker.has(ticker)) continue;
+
+      const currency = selectCurrencyForMetaId(metaId, merged);
+      if (currency) byTicker.set(ticker, currency);
+    }
+
+    return byTicker;
+  }, [data]);
+
+  return useCallback(
+    ({ currency }, balance) => {
+      const from = currencyByTicker.get(currency.toUpperCase());
+      const unit = from?.units[0];
+      if (!from || !unit) return null;
+
+      const counterValue = calculateCountervalue(from, parseCurrencyUnit(unit, balance));
+      return counterValue ? counterValue.toNumber() : null;
+    },
+    [currencyByTicker, calculateCountervalue],
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/PayTabView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/PayTabView.tsx
@@ -21,6 +21,7 @@ type PayTabViewProps = {
   readonly cardTitle: string;
   readonly cardBalanceLabel: string;
   readonly formatCountervalue: CardProps["formatCountervalue"];
+  readonly resolveCardWalletCounterValue: CardProps["resolveCounterValue"];
   readonly oauthConfig: CardProps["oauthConfig"];
   readonly callback: CardProps["callback"];
   readonly featureTour: FeatureTourProps;
@@ -39,6 +40,7 @@ export function PayTabView({
   cardTitle,
   cardBalanceLabel,
   formatCountervalue,
+  resolveCardWalletCounterValue,
   oauthConfig,
   callback,
   featureTour,
@@ -68,6 +70,7 @@ export function PayTabView({
             callback={callback}
             formatCountervalue={formatCountervalue}
             balanceLabel={cardBalanceLabel}
+            resolveCounterValue={resolveCardWalletCounterValue}
           />
           <FeatureTour {...featureTour} />
           <DepositOptions {...depositOptions} />

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
@@ -11,6 +11,7 @@ import type { PayTabNavigatorParamList } from "LLM/features/PayTab/types";
 import type { FeatureTourProps } from "@features/flow-pay-feature-tour";
 import { useNavigationBarHeights } from "LLM/hooks/useNavigationBarHeights";
 import { usePayCardBalance } from "LLM/features/PayTab/hooks/usePayCardBalance";
+import { usePayCardWalletCounterValue } from "LLM/features/PayTab/hooks/usePayCardWalletCounterValue";
 import { usePayTabActionTiles } from "LLM/features/PayTab/hooks/usePayTabActionTiles";
 import { usePayTabContacts } from "LLM/features/PayTab/hooks/usePayTabContacts";
 import { usePayTabDepositOptions } from "LLM/features/PayTab/hooks/usePayTabDepositOptions";
@@ -30,6 +31,7 @@ export function usePayTabViewModel() {
   const unit = counterValueCurrency.units[0];
 
   const balance = usePayCardBalance();
+  const resolveCardWalletCounterValue = usePayCardWalletCounterValue();
   const deposit = usePayTabDepositOptions(balance.onTrackEvent);
   const request = usePayTabRequestReceive();
   const actionTiles = usePayTabActionTiles(balance.onTrackEvent, deposit.open, request.open);
@@ -81,6 +83,7 @@ export function usePayTabViewModel() {
     cardTitle: t("payTab.card.title"),
     cardBalanceLabel: t("payTab.card.balanceLabel"),
     formatCountervalue,
+    resolveCardWalletCounterValue,
     oauthConfig,
     callback,
     featureTour,

--- a/features/flow/pay-card/package.json
+++ b/features/flow/pay-card/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@features/flow-pay-card-auth": "workspace:^",
     "@features/flow-pay-card-details": "workspace:^",
+    "@features/flow-pay-card-wallets": "workspace:^",
     "@features/flow-pay-card-widget": "workspace:^"
   },
   "devDependencies": {

--- a/features/flow/pay-card/src/Card.native.test.tsx
+++ b/features/flow/pay-card/src/Card.native.test.tsx
@@ -3,6 +3,13 @@ import { render, screen } from "@testing-library/react-native";
 import { View } from "react-native";
 import type { CardProps } from "./Card.types";
 
+const mockUseCardLinkedWallets = jest.fn();
+const mockCardVisual = jest.fn();
+
+jest.mock("@features/flow-pay-card-wallets", () => ({
+  useCardLinkedWallets: (params: unknown) => mockUseCardLinkedWallets(params),
+}));
+
 jest.mock("@features/flow-pay-card-auth", () => ({
   CardLogin: () => <View testID="card-login" />,
   CardMore: () => <View testID="card-more" />,
@@ -10,7 +17,10 @@ jest.mock("@features/flow-pay-card-auth", () => ({
 
 jest.mock("@features/flow-pay-card-details", () => ({
   CardArtwork: () => <View testID="card-artwork" />,
-  CardVisual: () => <View testID="card-visual" />,
+  CardVisual: (props: { balance: number }) => {
+    mockCardVisual(props);
+    return <View testID="card-visual" />;
+  },
 }));
 
 import { Card } from "./Card";
@@ -29,6 +39,21 @@ const formatCountervalue: CardProps["formatCountervalue"] = (value: number) => (
   currencyText: "$",
   decimalSeparator: ".",
   currencyPosition: "start",
+});
+
+const resolveCounterValue: NonNullable<CardProps["resolveCounterValue"]> = () => null;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseCardLinkedWallets.mockReturnValue({
+    wallets: [],
+    total: 0,
+    isPartialTotal: false,
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    refetch: jest.fn(),
+  });
 });
 
 describe("Card (native)", () => {
@@ -55,5 +80,47 @@ describe("Card (native)", () => {
     expect(screen.queryByTestId("card-artwork")).toBeNull();
     expect(screen.getByTestId("card-login")).toBeVisible();
     expect(screen.getByTestId("card-more")).toBeVisible();
+  });
+
+  it("shows the linked-wallet total as the card balance", () => {
+    mockUseCardLinkedWallets.mockReturnValue({
+      wallets: [],
+      total: 125_40,
+      isPartialTotal: false,
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      refetch: jest.fn(),
+    });
+
+    render(
+      <Card
+        title={title}
+        oauthConfig={oauthConfig}
+        formatCountervalue={formatCountervalue}
+        balanceLabel="Balance"
+        resolveCounterValue={resolveCounterValue}
+      />,
+    );
+
+    expect(mockCardVisual).toHaveBeenCalledWith(
+      expect.objectContaining({ balance: 125_40, isLoading: false }),
+    );
+    expect(mockUseCardLinkedWallets).toHaveBeenCalledWith(
+      expect.objectContaining({ resolveCounterValue, skip: false }),
+    );
+  });
+
+  it("skips the wallet queries when the host provides no resolver", () => {
+    render(
+      <Card
+        title={title}
+        oauthConfig={oauthConfig}
+        formatCountervalue={formatCountervalue}
+        balanceLabel="Balance"
+      />,
+    );
+
+    expect(mockUseCardLinkedWallets).toHaveBeenCalledWith(expect.objectContaining({ skip: true }));
   });
 });

--- a/features/flow/pay-card/src/Card.types.ts
+++ b/features/flow/pay-card/src/Card.types.ts
@@ -1,5 +1,6 @@
 import type { CardLoginOauthConfig, PayCardAuthCallback } from "@features/flow-pay-card-auth";
 import type { CardVisualProps, FormattedValue } from "@features/flow-pay-card-details";
+import type { ResolveWalletCounterValue } from "@features/flow-pay-card-wallets";
 
 /** Host input for the Pay Card flow. */
 export type CardProps = {
@@ -18,6 +19,11 @@ export type CardProps = {
   readonly formatCountervalue?: (value: number) => FormattedValue;
   /** Localized caption shown above the balance. i18n stays with the host, so the app passes the string. */
   readonly balanceLabel?: string;
+  /**
+   * Prices one card-linked wallet in the user's counter-value currency. Needs the app's rates and
+   * currency settings, so the host owns it. Omit it and the card shows no balance.
+   */
+  readonly resolveCounterValue?: ResolveWalletCounterValue;
 };
 
 /** Props the presentational view renders, resolved by {@link useCardViewModel}. */

--- a/features/flow/pay-card/src/Card.web.test.tsx
+++ b/features/flow/pay-card/src/Card.web.test.tsx
@@ -2,6 +2,13 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import type { CardProps } from "./Card.types";
 
+const mockUseCardLinkedWallets = jest.fn();
+const mockCardVisual = jest.fn();
+
+jest.mock("@features/flow-pay-card-wallets", () => ({
+  useCardLinkedWallets: (params: unknown) => mockUseCardLinkedWallets(params),
+}));
+
 jest.mock("@features/flow-pay-card-auth", () => ({
   CardLogin: () => <div data-testid="card-login" />,
   CardMore: () => <div data-testid="card-more" />,
@@ -9,7 +16,10 @@ jest.mock("@features/flow-pay-card-auth", () => ({
 
 jest.mock("@features/flow-pay-card-details", () => ({
   CardArtwork: () => <div data-testid="card-artwork" />,
-  CardVisual: () => <div data-testid="card-visual" />,
+  CardVisual: (props: { balance: number }) => {
+    mockCardVisual(props);
+    return <div data-testid="card-visual" />;
+  },
 }));
 
 jest.mock("@features/flow-pay-card-widget", () => ({
@@ -32,6 +42,21 @@ const formatCountervalue: CardProps["formatCountervalue"] = (value: number) => (
   currencyText: "$",
   decimalSeparator: ".",
   currencyPosition: "start",
+});
+
+const resolveCounterValue: NonNullable<CardProps["resolveCounterValue"]> = () => null;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseCardLinkedWallets.mockReturnValue({
+    wallets: [],
+    total: 0,
+    isPartialTotal: false,
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    refetch: jest.fn(),
+  });
 });
 
 describe("Card (web)", () => {
@@ -69,5 +94,47 @@ describe("Card (web)", () => {
     expect(screen.queryByTestId("card-artwork")).not.toBeInTheDocument();
     expect(screen.getByTestId("card-login")).toBeVisible();
     expect(screen.getByTestId("card-more")).toBeVisible();
+  });
+
+  it("shows the linked-wallet total as the card balance", () => {
+    mockUseCardLinkedWallets.mockReturnValue({
+      wallets: [],
+      total: 125_40,
+      isPartialTotal: false,
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      refetch: jest.fn(),
+    });
+
+    render(
+      <Card
+        title={title}
+        oauthConfig={oauthConfig}
+        formatCountervalue={formatCountervalue}
+        balanceLabel="Balance"
+        resolveCounterValue={resolveCounterValue}
+      />,
+    );
+
+    expect(mockCardVisual).toHaveBeenCalledWith(
+      expect.objectContaining({ balance: 125_40, isLoading: false }),
+    );
+    expect(mockUseCardLinkedWallets).toHaveBeenCalledWith(
+      expect.objectContaining({ resolveCounterValue, skip: false }),
+    );
+  });
+
+  it("skips the wallet queries when the host provides no resolver", () => {
+    render(
+      <Card
+        title={title}
+        oauthConfig={oauthConfig}
+        formatCountervalue={formatCountervalue}
+        balanceLabel="Balance"
+      />,
+    );
+
+    expect(mockUseCardLinkedWallets).toHaveBeenCalledWith(expect.objectContaining({ skip: true }));
   });
 });

--- a/features/flow/pay-card/src/useCardViewModel.ts
+++ b/features/flow/pay-card/src/useCardViewModel.ts
@@ -1,14 +1,16 @@
 import { useMemo } from "react";
+import { useCardLinkedWallets } from "@features/flow-pay-card-wallets";
+import type { ResolveWalletCounterValue } from "@features/flow-pay-card-wallets";
 import type { CardProps, CardViewProps } from "./Card.types";
 
-/** The balance API is not wired yet, and the card renders the same at zero as at any amount. */
-const PLACEHOLDER_CARD_BALANCE = 0;
+/** Never called: the wallet queries are skipped whenever the host omits its own resolver. */
+const NO_COUNTER_VALUE: ResolveWalletCounterValue = () => null;
 
 /**
- * View model for the Pay Card flow. The flow owns the (currently mocked) balance, so hosts no longer
- * assemble the card visual themselves; they only hand over the two things the flow cannot know — the
- * countervalue formatter (locale + counter-value currency) and the localized label. Without both, the
- * card falls back to the bare artwork.
+ * View model for the Pay Card flow. The card balance is the total of the wallets currently linked to
+ * the card, so the flow owns it; hosts only hand over the three things the flow cannot know — the
+ * countervalue formatter and resolver (locale, counter-value currency, rates) and the localized
+ * label. Without the formatter and the label, the card falls back to the bare artwork.
  */
 export function useCardViewModel({
   title,
@@ -16,11 +18,17 @@ export function useCardViewModel({
   callback,
   formatCountervalue,
   balanceLabel,
+  resolveCounterValue,
 }: CardProps): CardViewProps {
+  const { total, isLoading } = useCardLinkedWallets({
+    resolveCounterValue: resolveCounterValue ?? NO_COUNTER_VALUE,
+    skip: !resolveCounterValue,
+  });
+
   const cardVisual = useMemo<CardViewProps["cardVisual"]>(() => {
     if (!formatCountervalue || balanceLabel === undefined) return undefined;
-    return { balance: PLACEHOLDER_CARD_BALANCE, formatCountervalue, balanceLabel };
-  }, [formatCountervalue, balanceLabel]);
+    return { balance: total, formatCountervalue, balanceLabel, isLoading };
+  }, [formatCountervalue, balanceLabel, total, isLoading]);
 
   return { title, oauthConfig, callback, cardVisual };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1793,6 +1793,9 @@ importers:
       '@features/flow-pay-card-auth':
         specifier: workspace:^
         version: link:../../features/flow/pay-card-auth
+      '@features/flow-pay-card-wallets':
+        specifier: workspace:^
+        version: link:../../features/flow/pay-card-wallets
       '@features/flow-pay-card-widget':
         specifier: workspace:^
         version: link:../../features/flow/pay-card-widget
@@ -6655,6 +6658,9 @@ importers:
       '@features/flow-pay-card-details':
         specifier: workspace:^
         version: link:../pay-card-details
+      '@features/flow-pay-card-wallets':
+        specifier: workspace:^
+        version: link:../pay-card-wallets
       '@features/flow-pay-card-widget':
         specifier: workspace:^
         version: link:../pay-card-widget


### PR DESCRIPTION
<!-- stac-man:stack-start -->
**Stack** _(managed by [stac-man](https://github.com/bluegardenproject/stac-man))_

- #21399 feat/LIVE-35428-native-card-visual
- **#21425 feat/LIVE-34772-card-balance-from-linked-wallets ← this PR**
<!-- stac-man:stack-end -->

The card face rendered a placeholder. It now shows the total of the wallets
currently linked to the card, which is what `useCardLinkedWallets` computes.

- `CardProps` gains `resolveCounterValue`. Pricing a wallet needs the app's
  rates and currency settings, so the host owns it; the flow keeps owning the
  balance itself. The wallet queries are skipped when it is absent, so a host
  that does not pass one keeps working.
- On mobile, resolve the Baanx ticker to a Ledger currency through the
  stablecoin catalog the Pay tab already loads, then price it with the app's
  countervalue state. This keeps the amount in the counter-value currency's
  smallest unit, which is the scale the card's formatter expects.
- An asset outside that catalog resolves to `null`. The total already reports
  that as partial rather than counting the wallet as zero.