### PR TITLE
chore(codeowners): assign pay-card devtools to wallet-xp

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -151,6 +151,9 @@ features/flow/app-lock/                                  @ledgerhq/wallet-xp
 /shared/ui-info-state/                                   @ledgerhq/wallet-xp
 /shared/ui-queued-bottom-sheet/                          @ledgerhq/wallet-xp
 
+# Wallet — devtools
+devtools/pay-card/                                       @ledgerhq/wallet-xp
+
 # Platform — desktop mvvm overrides (override WXP mvvm catch-all)
 apps/ledger-live-desktop/src/mvvm/features/AppBlockers/  @ledgerhq/platform
 apps/ledger-live-desktop/src/mvvm/features/WalletSync/   @ledgerhq/platform


### PR DESCRIPTION
### 📝 Description

`devtools/pay-card/` was not listed in `CODEOWNERS`, so review requests for changes under that devtool did not route to the owning team and fell through to a broader owner.

This adds an explicit rule under a new "Wallet — devtools" section assigning `devtools/pay-card/` to `@ledgerhq/wallet-xp`, consistent with the existing Wallet Pay Card entries (`features/flow/pay-*`) and alongside the existing Platform devtools entries.

```
# Wallet — devtools
devtools/pay-card/                                       @ledgerhq/wallet-xp
```

### 🔗 Context

- **JIRA / GitHub issue**: N/A
- **ADR** (if any): N/A