### PR TITLE
[LWDM] feat(coin-concordium): add PLT errors and mapping (LIVE-36748)

### DIFF
--- a/.changeset/quiet-lantern-drifts.md
+++ b/.changeset/quiet-lantern-drifts.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-concordium": minor
+---
+
+Add PLT error classes and map chain reject reasons onto them

--- a/libs/coin-modules/coin-concordium/src/logic/index.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/index.ts
@@ -10,4 +10,6 @@ export { getBlockInfo } from "./history/getBlockInfo";
 export { listOperations } from "./history/listOperations";
 export { getNextValidSequence } from "./account/getNextSequence";
 
+export { mapPltRejectReason } from "./transaction/pltRejectReason";
+
 export { parseAPIValue } from "./common";

--- a/libs/coin-modules/coin-concordium/src/logic/transaction/pltRejectReason.test.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/transaction/pltRejectReason.test.ts
@@ -1,0 +1,96 @@
+import { mapPltRejectReason } from "./pltRejectReason";
+
+describe("mapPltRejectReason", () => {
+  it("maps NonExistentTokenId to its own error, carrying the token id", () => {
+    const error = mapPltRejectReason({ tag: "NonExistentTokenId", contents: "PLT" });
+
+    expect(error?.name).toBe("ConcordiumNonExistentTokenId");
+    expect(error).toHaveProperty("tokenId", "PLT");
+  });
+
+  it("maps addressNotFound to the recipient error", () => {
+    const error = mapPltRejectReason({
+      tag: "TokenUpdateTransactionFailed",
+      contents: { tokenId: "PLT", type: "addressNotFound" },
+    });
+
+    expect(error?.name).toBe("ConcordiumRecipientNotFound");
+  });
+
+  it("maps tokenBalanceInsufficient to the existing insufficient-funds error", () => {
+    const error = mapPltRejectReason({
+      tag: "TokenUpdateTransactionFailed",
+      contents: { tokenId: "PLT", type: "tokenBalanceInsufficient" },
+    });
+
+    expect(error?.name).toBe("ConcordiumInsufficientFunds");
+  });
+
+  it("degrades an unrecognised module reject type to the generic error", () => {
+    const error = mapPltRejectReason({
+      tag: "TokenUpdateTransactionFailed",
+      contents: { tokenId: "PLT", type: "somethingTheModuleInvented" },
+    });
+
+    expect(error?.name).toBe("ConcordiumPltTransferRejected");
+    expect(error).toHaveProperty("type", "somethingTheModuleInvented");
+    expect(error).toHaveProperty("tokenId", "PLT");
+  });
+
+  // paused, allow-list and deny-list all arrive as this one type; the `reason`
+  // that would separate them sits in `details` as CBOR this repo cannot decode.
+  it("degrades operationNotPermitted to the generic error", () => {
+    const error = mapPltRejectReason({
+      tag: "TokenUpdateTransactionFailed",
+      contents: { tokenId: "PLT", type: "operationNotPermitted", details: "a1656361757365" },
+    });
+
+    expect(error?.name).toBe("ConcordiumPltTransferRejected");
+  });
+
+  it.each(["deserializationFailure", "unsupportedOperation", "mintWouldOverflow"])(
+    "degrades %s to the generic error",
+    type => {
+      const error = mapPltRejectReason({
+        tag: "TokenUpdateTransactionFailed",
+        contents: { tokenId: "PLT", type },
+      });
+
+      expect(error?.name).toBe("ConcordiumPltTransferRejected");
+    },
+  );
+
+  it("does not resolve a module reject type off Object.prototype", () => {
+    const error = mapPltRejectReason({
+      tag: "TokenUpdateTransactionFailed",
+      contents: { tokenId: "PLT", type: "constructor" },
+    });
+
+    expect(error?.name).toBe("ConcordiumPltTransferRejected");
+  });
+
+  it("returns undefined for a non-PLT reject reason", () => {
+    expect(mapPltRejectReason({ tag: "InvalidAccountReference" })).toBeUndefined();
+  });
+
+  it("returns undefined when there is no reject reason", () => {
+    expect(mapPltRejectReason(undefined)).toBeUndefined();
+  });
+
+  it.each([
+    ["NonExistentTokenId with a non-string payload", { tokenId: "PLT" }],
+    ["NonExistentTokenId with no payload", undefined],
+  ])("returns undefined for %s", (_label, contents) => {
+    expect(mapPltRejectReason({ tag: "NonExistentTokenId", contents })).toBeUndefined();
+  });
+
+  it.each([
+    ["a missing payload", undefined],
+    ["a string payload", "PLT"],
+    ["a null payload", null],
+    ["a payload without type", { tokenId: "PLT" }],
+    ["a payload without tokenId", { type: "operationNotPermitted" }],
+  ])("returns undefined for TokenUpdateTransactionFailed with %s", (_label, contents) => {
+    expect(mapPltRejectReason({ tag: "TokenUpdateTransactionFailed", contents })).toBeUndefined();
+  });
+});

--- a/libs/coin-modules/coin-concordium/src/logic/transaction/pltRejectReason.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/transaction/pltRejectReason.ts
@@ -1,0 +1,62 @@
+import { isPltRejectReason } from "../../network/plt";
+import {
+  ConcordiumInsufficientFunds,
+  ConcordiumNonExistentTokenId,
+  ConcordiumPltTransferRejected,
+  ConcordiumRecipientNotFound,
+} from "../../types/errors";
+import type { WalletProxyRawRejectReason } from "../../types";
+
+/**
+ * Module reject `type` values this layer narrows to a typed error.
+ *
+ * CIS-7 defines six (`addressNotFound`, `tokenBalanceInsufficient`,
+ * `deserializationFailure`, `unsupportedOperation`, `operationNotPermitted`,
+ * `mintWouldOverflow`), but only these two say something a sender can act on:
+ *
+ * - `mintWouldOverflow` never arises from a transfer.
+ * - `deserializationFailure` and `unsupportedOperation` mean the wallet built a
+ *   payload the module would not take — a bug here, not a user-facing state.
+ * - `operationNotPermitted` covers paused, allow-list and deny-list alike. The
+ *   only discriminator is a `reason` string inside `details`, which arrives as
+ *   hex-encoded CBOR that this repo has no decoder for, so it cannot be
+ *   narrowed and falls through to the generic error.
+ *
+ * The set is open regardless: a module may define its own types, and the node
+ * truncates the value to 255 bytes without re-validating UTF-8, so an
+ * unrecognised or mangled string is expected input rather than a defect.
+ *
+ * A `Map` rather than an object literal because the key comes off the wire: an
+ * object would resolve `constructor` and `toString` off its prototype.
+ */
+const MODULE_REJECT_ERRORS = new Map<string, () => Error>([
+  ["addressNotFound", () => new ConcordiumRecipientNotFound()],
+  ["tokenBalanceInsufficient", () => new ConcordiumInsufficientFunds()],
+]);
+
+/**
+ * Maps a chain reject reason onto a typed PLT error.
+ *
+ * Returns `undefined` when the reason is absent, belongs to another
+ * transaction kind, or carries a payload that does not match its tag — the
+ * caller keeps whatever generic failure it already had rather than claiming a
+ * PLT cause it cannot support.
+ *
+ * This is a backstop. A reject reason only exists once the user has signed and
+ * paid the fee, so the pre-send checks own every failure worth preventing.
+ */
+export function mapPltRejectReason(
+  reason: WalletProxyRawRejectReason | undefined,
+): Error | undefined {
+  if (!isPltRejectReason(reason)) return undefined;
+
+  if (reason.tag === "NonExistentTokenId") {
+    return new ConcordiumNonExistentTokenId(undefined, { tokenId: reason.contents });
+  }
+
+  const { tokenId, type } = reason.contents;
+  return (
+    MODULE_REJECT_ERRORS.get(type)?.() ??
+    new ConcordiumPltTransferRejected(undefined, { tokenId, type })
+  );
+}

--- a/libs/coin-modules/coin-concordium/src/types/errors.test.ts
+++ b/libs/coin-modules/coin-concordium/src/types/errors.test.ts
@@ -1,7 +1,15 @@
 import {
+  ConcordiumAccountDenied,
+  ConcordiumAccountNotAllowed,
   ConcordiumAppOutdatedError,
+  ConcordiumInsufficientCcdForFee,
   ConcordiumInvalidPltPayloadError,
+  ConcordiumNonExistentTokenId,
+  ConcordiumPltTransferRejected,
+  ConcordiumRecipientNotAllowed,
+  ConcordiumRecipientNotFound,
   ConcordiumSignerProtocolError,
+  ConcordiumTokenPaused,
 } from "./errors";
 
 // The PLT signer errors are constructed in live-signer-concordium, a separate
@@ -29,5 +37,48 @@ describe("types/errors — PLT signer errors", () => {
     const error = new ErrorClass("device said no", { errorCode: "6b0d" });
 
     expect(error).toHaveProperty("errorCode", "6b0d");
+  });
+});
+
+// The token-state errors are raised by the pre-send checks and the broadcast
+// ones by the reject-reason mapping, so nothing constructs them here either.
+describe("types/errors — PLT transfer errors", () => {
+  const pltErrors = [
+    ConcordiumTokenPaused,
+    ConcordiumAccountNotAllowed,
+    ConcordiumAccountDenied,
+    ConcordiumRecipientNotAllowed,
+    ConcordiumInsufficientCcdForFee,
+    ConcordiumNonExistentTokenId,
+    ConcordiumRecipientNotFound,
+    ConcordiumPltTransferRejected,
+  ];
+  const cases = pltErrors.map(ErrorClass => [ErrorClass.name, ErrorClass] as const);
+
+  it.each(cases)("%s is an Error whose name survives serialization", (expectedName, ErrorClass) => {
+    const error = new ErrorClass();
+
+    expect(error).toBeInstanceOf(Error);
+    // `name` is the contract across IPC and worker boundaries, where the
+    // prototype is lost and `instanceof` stops working.
+    expect(error.name).toBe(expectedName);
+    expect(JSON.parse(JSON.stringify({ name: error.name })).name).toBe(expectedName);
+  });
+
+  it.each(cases)("%s defaults its message to its name", (expectedName, ErrorClass) => {
+    expect(new ErrorClass().message).toBe(expectedName);
+  });
+
+  it.each(cases)("%s keeps an explicit message and assigns extra fields", (_name, ErrorClass) => {
+    const error = new ErrorClass("boom", { tokenId: "PLT" });
+
+    expect(error.message).toBe("boom");
+    expect(error).toHaveProperty("tokenId", "PLT");
+  });
+
+  it("gives every PLT transfer error a distinct name", () => {
+    const names = pltErrors.map(ErrorClass => new ErrorClass().name);
+
+    expect(new Set(names).size).toBe(pltErrors.length);
   });
 });

--- a/libs/coin-modules/coin-concordium/src/types/errors.ts
+++ b/libs/coin-modules/coin-concordium/src/types/errors.ts
@@ -62,6 +62,112 @@ export class SimulationError extends Error {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Protocol-Level Token (PLT) errors
+// ---------------------------------------------------------------------------
+
+/**
+ * The token's module state has `paused: true`, so every balance-changing
+ * operation is suspended (CIS-7 `pause`). List updates are unaffected.
+ */
+export class ConcordiumTokenPaused extends Error {
+  override name = "ConcordiumTokenPaused";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message ?? "ConcordiumTokenPaused");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+/**
+ * The token enforces an allow list and the sender is not on it.
+ */
+export class ConcordiumAccountNotAllowed extends Error {
+  override name = "ConcordiumAccountNotAllowed";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message ?? "ConcordiumAccountNotAllowed");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+/**
+ * The token enforces a deny list and the sender is on it.
+ */
+export class ConcordiumAccountDenied extends Error {
+  override name = "ConcordiumAccountDenied";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message ?? "ConcordiumAccountDenied");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+/**
+ * The recipient fails the token's own list rules — absent from an allow list,
+ * or present on a deny list. Distinct from the sender-side errors because the
+ * user's remedy is to change the recipient, not to get themselves approved.
+ */
+export class ConcordiumRecipientNotAllowed extends Error {
+  override name = "ConcordiumRecipientNotAllowed";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message ?? "ConcordiumRecipientNotAllowed");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+/**
+ * The token balance covers the amount but the CCD balance does not cover the
+ * fee.
+ *
+ * Deliberately distinct from {@link ConcordiumInsufficientFunds}: the failing
+ * balance is the parent account's, not the token sub-account's, so the remedy
+ * is to top up CCD rather than to send less of the token.
+ */
+export class ConcordiumInsufficientCcdForFee extends Error {
+  override name = "ConcordiumInsufficientCcdForFee";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message ?? "ConcordiumInsufficientCcdForFee");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+/**
+ * The signed `token_id` does not exist on chain. Chain-level, so it is reported
+ * against the whole transaction rather than one operation.
+ */
+export class ConcordiumNonExistentTokenId extends Error {
+  override name = "ConcordiumNonExistentTokenId";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message ?? "ConcordiumNonExistentTokenId");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+/**
+ * The recipient account could not be resolved on chain (`addressNotFound`).
+ */
+export class ConcordiumRecipientNotFound extends Error {
+  override name = "ConcordiumRecipientNotFound";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message ?? "ConcordiumRecipientNotFound");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+/**
+ * The token module rejected the transfer for a reason that cannot be narrowed
+ * further.
+ *
+ * The catch-all for the broadcast mapping. It covers unrecognised module reject
+ * types and, unavoidably, `operationNotPermitted` — see
+ * {@link mapPltRejectReason} for why that one cannot be discriminated.
+ */
+export class ConcordiumPltTransferRejected extends Error {
+  override name = "ConcordiumPltTransferRejected";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message ?? "ConcordiumPltTransferRejected");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
 /**
  * The device refused the PLT payload the wallet built, or the signer refused it
  * before sending. The user did nothing wrong, so this is reported as a defect


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Groundwork for PLT send: adds the 8 error classes a PLT transfer needs and maps chain reject reasons onto them. Nothing calls it yet — the pre-send checks (LIVE-28334) and the signer (LIVE-28337) are the consumers.

```ts
import { mapPltRejectReason } from "@ledgerhq/coin-concordium/logic";

const error = mapPltRejectReason(tx.details.rawRejectReason);
// undefined when the reason is absent, non-PLT, or its payload does not match its tag
```

- Only addressNotFound and tokenBalanceInsufficient are narrowed. operationNotPermitted covers paused, allow-list and deny-list alike, and the reason that would separate them sits in details as hex CBOR that concordium-core has no decoder for — so those three conditions are reachable only from the pre-send checks, never from this mapping. Confirmed against CIS-7 and concordium-grpc-api.
- ConcordiumInsufficientCcdForFee is a new class rather than the existing generic NotEnoughBalanceInParentAccount — deliberate, so the copy can name CCD.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36748](https://ledgerhq.atlassian.net/browse/LIVE-36748?atlOrigin=eyJpIjoiMjkzZjUwYmZmMWMzNDVjZmE4NmYzZjM4MDJhNWI0NDIiLCJwIjoiaiJ9)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-36748]: https://ledgerhq.atlassian.net/browse/LIVE-36748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ