### PR TITLE
fix(contacts): adjust address input padding on mobile (LIVE-36691)

### DIFF
--- a/.changeset/LIVE-36691-contacts-address-input-padding.md
+++ b/.changeset/LIVE-36691-contacts-address-input-padding.md
@@ -1,0 +1,7 @@
+---
+"@features/flow-contacts-add-address": minor
+"@features/flow-contacts-edit-address": minor
+"live-mobile": minor
+---
+
+Fix the extra left padding on the address field of the Mobile add address and edit address drawers. Both screens render the address without the "To:" prefix, but Lumen's AddressInput mounts its prefix even when empty, so the prefix still took a slot in the field's inner gap and pushed the address 8px to the right. Add address now drops that gap and keeps the spacing only between the address and the trailing QR code icon, and edit address, which has no trailing icon, uses a plain TextInput instead.

--- a/features/flow/flow-contacts-add-address/src/screens/AddressEntry/components/ContactsAddAddressEntryView/ContactsAddAddressEntryView.native.tsx
+++ b/features/flow/flow-contacts-add-address/src/screens/AddressEntry/components/ContactsAddAddressEntryView/ContactsAddAddressEntryView.native.tsx
@@ -7,6 +7,7 @@ import {
   Box,
   Button,
 } from "@ledgerhq/lumen-ui-rnative";
+import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
 import { CONTACTS_NATIVE_ADDRESS_INPUT_PROPS } from "@features/platform-contacts";
 import type { ContactsAddAddressEntryViewProps } from "../ContactsAddAddressEntry/ContactsAddAddressEntry.types";
 import { SanctionedAddressBanner } from "../../../../components/SanctionedAddressBanner/SanctionedAddressBanner";
@@ -25,6 +26,17 @@ export function ContactsAddAddressEntryView({
   onConfirm,
   onQrCodeClick,
 }: ContactsAddAddressEntryViewProps): React.JSX.Element {
+  // `AddressInput` always mounts its prefix, so the empty prefix this screen needs still claims a
+  // slot in the container gap and insets the address. Drop that gap and keep the spacing only
+  // where it is needed, between the address and the trailing QR code / clear icon.
+  const styles = useStyleSheet(
+    t => ({
+      inputContainer: { gap: 0 },
+      input: { marginRight: t.spacings.s8 },
+    }),
+    [],
+  );
+
   return (
     <BottomSheetView
       testID="contacts-add-address-entry-screen"
@@ -36,6 +48,8 @@ export function ContactsAddAddressEntryView({
           <AddressInput
             testID="contacts-add-address-input"
             prefix=""
+            containerStyle={styles.inputContainer}
+            inputStyle={styles.input}
             value={value}
             placeholder={labels.addressPlaceholder}
             onChangeText={onAddressChange}

--- a/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDrawer.native.tsx
+++ b/features/flow/flow-contacts-edit-address/src/ContactsRenameAddressDrawer.native.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import {
-  AddressInput,
   Banner,
   BottomSheetHeader,
   BottomSheetView,
@@ -43,9 +42,8 @@ export function ContactsRenameAddressDialog({
         <Box lx={{ gap: "s24" }}>
           <BottomSheetHeader density="expanded" title={labels.title} />
           <Box lx={{ gap: "s24", paddingHorizontal: "s16" }}>
-            <AddressInput
+            <TextInput
               testID="contacts-edit-address-input"
-              prefix=""
               value={addressInput.value}
               placeholder={labels.addressValidation.addressPlaceholder}
               onChangeText={addressInput.onChangeText}


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

On Mobile Contacts **Add address → Enter address**, the address field had extra left padding. Both add and edit address pass `prefix=""` to Lumen `AddressInput` so there is no “To:” label, but `AddressInput` still mounts an empty prefix node. `BaseInput` lays prefix / input / suffix out with `gap: s8`, so that empty node still took a slot and pushed the address 8px to the right.

Add address keeps `AddressInput` (QR / clear affordance) and removes the container gap, restoring `s8` only between the address and the trailing icon. Edit address has no trailing icon, so it uses `TextInput` instead of `AddressInput` with an empty prefix.

Desktop is unchanged. There is no automated visual check for this inset; native unit tests for both drawers still pass.

before:
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-09-02 at 10 24 46" src="https://github.com/user-attachments/assets/9d9860fc-82de-49d1-80f6-4e3285b91500" />
after:
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-09-02 at 10 25 13" src="https://github.com/user-attachments/assets/cba3bca1-1f03-4d1e-9b78-01d13d4bb6cc" />


### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36691](https://ledgerhq.atlassian.net/browse/LIVE-36691)
- **ADR** (if any):

[LIVE-36691]: https://ledgerhq.atlassian.net/browse/LIVE-36691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ