### PR TITLE
[LWD] feat(pay-contact): add ContactAddressPicker dialog skeleton (LIVE-36373)

### DIFF
--- a/.changeset/LIVE-36373-contact-address-picker.md
+++ b/.changeset/LIVE-36373-contact-address-picker.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-pay-contact": minor
+"ledger-live-desktop": minor
+---
+
+Add a web `ContactAddressPicker` dialog skeleton to the Pay contact flow and open it from the desktop Pay tab when a contact is pressed. The address list UI and the account/send handoff on address selection land in follow-ups.

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/PayTabView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/PayTabView.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Balance } from "@features/flow-pay-balance";
-import { Contacts } from "@features/flow-pay-contact";
+import { Contacts, ContactAddressPicker } from "@features/flow-pay-contact";
 import { ContactsLedgerSyncIntroductionDialog } from "@features/flow-contacts-introduction";
 import { DepositOptions } from "@features/flow-pay-deposit";
 import { BankTransferIntro } from "@features/flow-pay-bank-transfer";
@@ -23,6 +23,7 @@ export function PayTabView({
   deviceIntent,
   contacts,
   ledgerSyncIntroduction,
+  contactAddressPicker,
   isContactsEnabled,
 }: Readonly<PayTabViewModel>) {
   return (
@@ -35,6 +36,7 @@ export function PayTabView({
       {isContactsEnabled && (
         <>
           <Contacts {...contacts} />
+          <ContactAddressPicker {...contactAddressPicker} />
           <ContactsLedgerSyncIntroductionDialog {...ledgerSyncIntroduction} />
         </>
       )}

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayTabContacts.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayTabContacts.test.ts
@@ -1,9 +1,8 @@
 import { act, renderHook } from "tests/testSetup";
-import { mockContact } from "@domain/entity-contact/schema.mock";
+import { mockContact, mockContactAddress } from "@domain/entity-contact/schema.mock";
 import { usePayTabContacts } from "../usePayTabContacts";
 
 const mockNavigate = jest.fn();
-const mockOpenNewPayment = jest.fn();
 
 jest.mock("react-router", () => ({
   ...jest.requireActual("react-router"),
@@ -11,22 +10,43 @@ jest.mock("react-router", () => ({
   useLocation: () => ({ pathname: "/pay" }),
 }));
 
-jest.mock("../usePayTabNewPayment", () => ({
-  usePayTabNewPayment: () => ({ open: mockOpenNewPayment }),
-}));
-
 describe("usePayTabContacts", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it("should open send with the contact when the tile is pressed", () => {
+  it("should open the address picker with the contact when the tile is pressed", () => {
+    const contact = mockContact({ id: "contact-ada", name: "Ada" });
+    const { result } = renderHook(() => usePayTabContacts());
+
+    expect(result.current.contactAddressPicker.isOpen).toBe(false);
+
+    act(() => result.current.contacts.onContactPress?.(contact));
+
+    expect(result.current.contactAddressPicker.isOpen).toBe(true);
+    expect(result.current.contactAddressPicker.contact).toBe(contact);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("should close the address picker when it is dismissed", () => {
     const contact = mockContact({ id: "contact-ada", name: "Ada" });
     const { result } = renderHook(() => usePayTabContacts());
 
     act(() => result.current.contacts.onContactPress?.(contact));
+    act(() => result.current.contactAddressPicker.onClose());
 
-    expect(mockOpenNewPayment).toHaveBeenCalledWith(contact);
+    expect(result.current.contactAddressPicker.isOpen).toBe(false);
+    expect(result.current.contactAddressPicker.contact).toBeNull();
+  });
+
+  it("should keep the address picker open when an address is selected", () => {
+    const contact = mockContact({ id: "contact-ada", name: "Ada" });
+    const { result } = renderHook(() => usePayTabContacts());
+
+    act(() => result.current.contacts.onContactPress?.(contact));
+    act(() => result.current.contactAddressPicker.onSelectAddress(mockContactAddress()));
+
+    expect(result.current.contactAddressPicker.isOpen).toBe(true);
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabContacts.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabContacts.ts
@@ -18,19 +18,25 @@ import {
   isContactsLedgerSyncActivationRequired,
   type ContactsLedgerSyncIntroductionDialogProps,
 } from "@features/flow-contacts-introduction";
-import type { ContactsProps } from "@features/flow-pay-contact";
+import {
+  useContactAddressPickerViewModel,
+  type ContactAddressPickerProps,
+  type ContactsProps,
+} from "@features/flow-pay-contact";
 import { useDispatch } from "LLD/hooks/redux";
 import { useActivationDrawer } from "LLD/features/LedgerSyncEntryPoints/hooks/useActivationDrawer";
 import { useContactsAnalytics } from "LLD/features/Contacts/analytics";
 import { useContactsLedgerSyncStatus } from "LLD/features/Contacts/hooks/useContactsLedgerSyncStatus";
 import { buildNavigationBackState } from "LLD/utils/navigationBackPath";
 import { usePayTabContactOperations } from "./usePayTabContactOperations";
-import { usePayTabNewPayment } from "./usePayTabNewPayment";
 import { renderPayContactAddresses } from "../components/PayContactAddresses";
+
+const noopSelectAddress = () => undefined;
 
 export type UsePayTabContactsResult = Readonly<{
   contacts: ContactsProps;
   ledgerSyncIntroduction: ContactsLedgerSyncIntroductionDialogProps;
+  contactAddressPicker: ContactAddressPickerProps;
 }>;
 
 export function usePayTabContacts(): UsePayTabContactsResult {
@@ -43,7 +49,12 @@ export function usePayTabContacts(): UsePayTabContactsResult {
   const ledgerSyncStatus = useContactsLedgerSyncStatus();
   const { requestMutation, dismissPendingIntent } = useContactsLedgerSyncMutationGuard();
   const operations = usePayTabContactOperations();
-  const { open: openNewPayment } = usePayTabNewPayment();
+
+  const { open: openContactAddressPicker, contactAddressPicker } = useContactAddressPickerViewModel(
+    {
+      onSelectAddress: noopSelectAddress,
+    },
+  );
   const onViewTransactions = useCallback(
     (contact: Contact) => {
       navigate(
@@ -54,8 +65,8 @@ export function usePayTabContacts(): UsePayTabContactsResult {
     [navigate, payTabPath],
   );
   const onContactPress = useCallback(
-    (contact: Contact) => openNewPayment(contact),
-    [openNewPayment],
+    (contact: Contact) => openContactAddressPicker(contact),
+    [openContactAddressPicker],
   );
   const onViewContact = useCallback(
     (contact: Contact) => {
@@ -148,6 +159,7 @@ export function usePayTabContacts(): UsePayTabContactsResult {
         onActivate: onActivateLedgerSyncIntroduction,
         onDismiss: onDismissLedgerSyncIntroduction,
       },
+      contactAddressPicker,
     }),
     [
       t,
@@ -163,6 +175,7 @@ export function usePayTabContacts(): UsePayTabContactsResult {
       isLedgerSyncIntroductionOpen,
       onActivateLedgerSyncIntroduction,
       onDismissLedgerSyncIntroduction,
+      contactAddressPicker,
     ],
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/usePayTabViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/usePayTabViewModel.ts
@@ -21,7 +21,7 @@ export function usePayTabViewModel() {
     request.open,
     newPayment.open,
   );
-  const { contacts, ledgerSyncIntroduction } = usePayTabContacts();
+  const { contacts, ledgerSyncIntroduction, contactAddressPicker } = usePayTabContacts();
   const { isEnabled: isContactsEnabled } = useContactsFeature("desktop");
 
   return {
@@ -36,6 +36,7 @@ export function usePayTabViewModel() {
     deviceIntent: verify.deviceIntent,
     contacts,
     ledgerSyncIntroduction,
+    contactAddressPicker,
     isContactsEnabled,
   };
 }

--- a/features/flow/pay-contact/README.md
+++ b/features/flow/pay-contact/README.md
@@ -33,6 +33,30 @@ its Telegram button) calls `onContactPress(contact)`. The row overflow (`...`) m
 **View contact** → `onViewContact(contact)` and **View transactions** → `onViewTransactions(contact)`;
 each item is shown only when its handler is provided.
 
+## Contact address picker (web)
+
+> [!NOTE]
+> Skeleton dialog — no address list UI yet (see LIVE-36373). Native picker lands in a later ticket.
+
+`ContactAddressPicker` is a Lumen dialog that opens after a contact is pressed so the user can pick
+which address to pay. The host owns visibility and the selected contact via
+`useContactAddressPickerViewModel`.
+
+```tsx
+import { ContactAddressPicker, useContactAddressPickerViewModel } from "@features/flow-pay-contact";
+
+const { open, contactAddressPicker } = useContactAddressPickerViewModel({
+  onSelectAddress: address => startPayment(address),
+  onAddNewContact,
+});
+
+<Contacts {...contacts} onContactPress={open} />;
+<ContactAddressPicker {...contactAddressPicker} />;
+```
+
+`onSelectAddress` receives the full `ContactAddress` (currency + recipient). `onAddNewContact` is
+optional.
+
 ## Native
 
 ```tsx

--- a/features/flow/pay-contact/src/__tests__/renderWithStyle.web.tsx
+++ b/features/flow/pay-contact/src/__tests__/renderWithStyle.web.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { StyleProvider } from "@features/platform-style";
+
+export function renderWithStyle(ui: React.ReactElement) {
+  return render(<StyleProvider colorScheme="dark">{ui}</StyleProvider>);
+}

--- a/features/flow/pay-contact/src/components/ContactAddressPicker/ContactAddressPicker.web.tsx
+++ b/features/flow/pay-contact/src/components/ContactAddressPicker/ContactAddressPicker.web.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+import { ContactAddressPickerView } from "./ContactAddressPickerView.web";
+import type { ContactAddressPickerProps } from "../../types";
+
+export function ContactAddressPicker(props: ContactAddressPickerProps) {
+  return <ContactAddressPickerView {...props} />;
+}

--- a/features/flow/pay-contact/src/components/ContactAddressPicker/ContactAddressPickerView.web.tsx
+++ b/features/flow/pay-contact/src/components/ContactAddressPicker/ContactAddressPickerView.web.tsx
@@ -1,0 +1,27 @@
+import React, { useCallback } from "react";
+import { Dialog, DialogBody, DialogContent, DialogHeader } from "@ledgerhq/lumen-ui-react";
+import type { ContactAddressPickerProps } from "../../types";
+
+export function ContactAddressPickerView({ isOpen, contact, onClose }: ContactAddressPickerProps) {
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  if (!isOpen || !contact) {
+    return null;
+  }
+
+  return (
+    <Dialog open onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader density="expanded" title={contact.name} onClose={onClose} />
+        <DialogBody className="flex flex-col gap-8" data-testid="pay-contact-address-picker" />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/flow/pay-contact/src/components/ContactAddressPicker/__tests__/ContactAddressPicker.web.test.tsx
+++ b/features/flow/pay-contact/src/components/ContactAddressPicker/__tests__/ContactAddressPicker.web.test.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { mockContact } from "@domain/entity-contact/schema.mock";
+import { renderWithStyle } from "../../../__tests__/renderWithStyle.web";
+import { ContactAddressPicker } from "../ContactAddressPicker.web";
+import type { ContactAddressPickerProps } from "../../../types";
+
+const contact = mockContact({ id: "contact-ada", name: "Ada" });
+
+const defaultProps: ContactAddressPickerProps = {
+  isOpen: true,
+  contact,
+  onClose: jest.fn(),
+  onSelectAddress: jest.fn(),
+};
+
+describe("ContactAddressPicker (Web)", () => {
+  it("should render the address picker view", () => {
+    renderWithStyle(<ContactAddressPicker {...defaultProps} />);
+
+    expect(screen.getByTestId("pay-contact-address-picker")).toBeVisible();
+    expect(screen.getByText("Ada")).toBeVisible();
+  });
+});

--- a/features/flow/pay-contact/src/components/ContactAddressPicker/__tests__/ContactAddressPickerView.web.test.tsx
+++ b/features/flow/pay-contact/src/components/ContactAddressPicker/__tests__/ContactAddressPickerView.web.test.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { fireEvent, screen } from "@testing-library/react";
+import { mockContact } from "@domain/entity-contact/schema.mock";
+import { renderWithStyle } from "../../../__tests__/renderWithStyle.web";
+import { ContactAddressPickerView } from "../ContactAddressPickerView.web";
+import type { ContactAddressPickerProps } from "../../../types";
+
+const contact = mockContact({ id: "contact-ada", name: "Ada" });
+
+const defaultProps: ContactAddressPickerProps = {
+  isOpen: true,
+  contact,
+  onClose: jest.fn(),
+  onSelectAddress: jest.fn(),
+};
+
+describe("ContactAddressPickerView (Web)", () => {
+  it("should render the dialog with the contact name when open", () => {
+    renderWithStyle(<ContactAddressPickerView {...defaultProps} />);
+
+    expect(screen.getByTestId("pay-contact-address-picker")).toBeVisible();
+    expect(screen.getByText("Ada")).toBeVisible();
+  });
+
+  it("should not render anything when it is closed", () => {
+    renderWithStyle(<ContactAddressPickerView {...defaultProps} isOpen={false} />);
+
+    expect(screen.queryByTestId("pay-contact-address-picker")).not.toBeInTheDocument();
+  });
+
+  it("should not render anything when there is no contact", () => {
+    renderWithStyle(<ContactAddressPickerView {...defaultProps} contact={null} />);
+
+    expect(screen.queryByTestId("pay-contact-address-picker")).not.toBeInTheDocument();
+  });
+
+  it("should call onClose when the dialog close button is pressed", () => {
+    const onClose = jest.fn();
+    renderWithStyle(<ContactAddressPickerView {...defaultProps} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /close/i }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/flow/pay-contact/src/components/ContactAddressPicker/__tests__/useContactAddressPickerViewModel.web.test.ts
+++ b/features/flow/pay-contact/src/components/ContactAddressPicker/__tests__/useContactAddressPickerViewModel.web.test.ts
@@ -1,0 +1,41 @@
+import { act, renderHook } from "@testing-library/react";
+import { mockContact } from "@domain/entity-contact/schema.mock";
+import { useContactAddressPickerViewModel } from "../useContactAddressPickerViewModel.web";
+
+describe("useContactAddressPickerViewModel", () => {
+  it("starts closed with no contact", () => {
+    const { result } = renderHook(() =>
+      useContactAddressPickerViewModel({ onSelectAddress: jest.fn() }),
+    );
+
+    expect(result.current.contactAddressPicker.isOpen).toBe(false);
+    expect(result.current.contactAddressPicker.contact).toBeNull();
+  });
+
+  it("opens with the pressed contact and closes clearing it", () => {
+    const contact = mockContact({ id: "contact-ada", name: "Ada" });
+    const { result } = renderHook(() =>
+      useContactAddressPickerViewModel({ onSelectAddress: jest.fn() }),
+    );
+
+    act(() => result.current.open(contact));
+    expect(result.current.contactAddressPicker.isOpen).toBe(true);
+    expect(result.current.contactAddressPicker.contact).toBe(contact);
+
+    act(() => result.current.contactAddressPicker.onClose());
+    expect(result.current.contactAddressPicker.isOpen).toBe(false);
+    expect(result.current.contactAddressPicker.contact).toBeNull();
+  });
+
+  it("passes onSelectAddress and onAddNewContact through", () => {
+    const onSelectAddress = jest.fn();
+    const onAddNewContact = jest.fn();
+
+    const { result } = renderHook(() =>
+      useContactAddressPickerViewModel({ onSelectAddress, onAddNewContact }),
+    );
+
+    expect(result.current.contactAddressPicker.onSelectAddress).toBe(onSelectAddress);
+    expect(result.current.contactAddressPicker.onAddNewContact).toBe(onAddNewContact);
+  });
+});

--- a/features/flow/pay-contact/src/components/ContactAddressPicker/useContactAddressPickerViewModel.web.ts
+++ b/features/flow/pay-contact/src/components/ContactAddressPicker/useContactAddressPickerViewModel.web.ts
@@ -1,0 +1,38 @@
+import { useCallback, useMemo, useState } from "react";
+import type { Contact, ContactAddress } from "@domain/entity-contact";
+import type { ContactAddressPickerProps } from "../../types";
+
+export type UseContactAddressPickerViewModelParams = Readonly<{
+  onSelectAddress: (address: ContactAddress) => void;
+  onAddNewContact?: () => void;
+}>;
+
+export type UseContactAddressPickerViewModel = Readonly<{
+  open: (contact: Contact) => void;
+  contactAddressPicker: ContactAddressPickerProps;
+}>;
+
+export function useContactAddressPickerViewModel({
+  onSelectAddress,
+  onAddNewContact,
+}: UseContactAddressPickerViewModelParams): UseContactAddressPickerViewModel {
+  const [contact, setContact] = useState<Contact | null>(null);
+
+  const open = useCallback((nextContact: Contact) => setContact(nextContact), []);
+  const onClose = useCallback(() => setContact(null), []);
+  const contactAddressPicker = useMemo(
+    (): ContactAddressPickerProps => ({
+      isOpen: contact !== null,
+      contact,
+      onClose,
+      onSelectAddress,
+      onAddNewContact,
+    }),
+    [contact, onClose, onSelectAddress, onAddNewContact],
+  );
+
+  return {
+    open,
+    contactAddressPicker,
+  };
+}

--- a/features/flow/pay-contact/src/components/Contacts/__tests__/shared.web.tsx
+++ b/features/flow/pay-contact/src/components/Contacts/__tests__/shared.web.tsx
@@ -32,10 +32,6 @@ export function makeContactsWrapper(contacts: Contact[]): FC<{ children: ReactNo
   return ({ children }) => <Provider store={store}>{children}</Provider>;
 }
 
-export function renderWithStyle(ui: ReactElement) {
-  return render(<StyleProvider colorScheme="dark">{ui}</StyleProvider>);
-}
-
 export function renderWithContacts(
   contacts: Contact[],
   ui: ReactElement,

--- a/features/flow/pay-contact/src/components/EmptyState/__tests__/EmptyState.web.test.tsx
+++ b/features/flow/pay-contact/src/components/EmptyState/__tests__/EmptyState.web.test.tsx
@@ -1,12 +1,8 @@
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
-import { StyleProvider } from "@features/platform-style";
+import { fireEvent, screen } from "@testing-library/react";
+import { renderWithStyle } from "../../../__tests__/renderWithStyle.web";
 import { EmptyState } from "../EmptyState.web";
 import type { EmptyStateProps } from "../../../types";
-
-function renderWithStyle(ui: React.ReactElement) {
-  return render(<StyleProvider colorScheme="dark">{ui}</StyleProvider>);
-}
 
 const defaultProps: EmptyStateProps = {
   info: "No contacts yet",

--- a/features/flow/pay-contact/src/index.ts
+++ b/features/flow/pay-contact/src/index.ts
@@ -1,2 +1,4 @@
 export * from "./exports";
 export * from "./components/Contacts/Contacts.web";
+export * from "./components/ContactAddressPicker/ContactAddressPicker.web";
+export * from "./components/ContactAddressPicker/useContactAddressPickerViewModel.web";

--- a/features/flow/pay-contact/src/types.ts
+++ b/features/flow/pay-contact/src/types.ts
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import type { Contact } from "@domain/entity-contact";
+import type { Contact, ContactAddress } from "@domain/entity-contact";
 import type {
   AddContactDialogLifecycleCallbacks,
   AddContactDialogViewModel,
@@ -76,3 +76,11 @@ export type ContactsViewNativeProps = ContactsNativeProps &
     contacts: readonly Contact[];
     hasMore: boolean;
   }>;
+
+export type ContactAddressPickerProps = Readonly<{
+  isOpen: boolean;
+  contact: Contact | null;
+  onClose: () => void;
+  onSelectAddress: (address: ContactAddress) => void;
+  onAddNewContact?: () => void;
+}>;


### PR DESCRIPTION
### 📝 Description

Adds the skeleton for the Pay tab **contact address picker** and wires it into the desktop Pay tab.

**Problem**: When a saved contact is pressed on the Pay tab, we go straight to the send flow. To let the user choose which of a contact's addresses to pay, we need a dedicated address picker dialog.

**Solution**: Introduce a web-only `ContactAddressPicker` in `@features/flow-pay-contact` and open it from the Pay tab on contact press. This is the architecture & plug slice only — the empty dialog plus its wiring; the address list UI and the account/send handoff on selection come next.

Included:
- `@features/flow-pay-contact`: `ContactAddressPicker.web.tsx` (container), `ContactAddressPickerView.web.tsx` (empty Lumen `Dialog`, title = contact name), `useContactAddressPickerViewModel.web.ts` (open/close + selected contact), and `ContactAddressPickerProps` in `types.ts`; exported from the barrel; README snippet; shared `renderWithStyle` test helper; unit tests.
- `ledger-live-desktop`: `usePayTabContacts` opens the picker on `onContactPress` (was: open send); picker mounted in `PayTabView` and threaded through `usePayTabViewModel`; updated test.

Usage:

```tsx
import { ContactAddressPicker, useContactAddressPickerViewModel } from "@features/flow-pay-contact";

const { open, contactAddressPicker } = useContactAddressPickerViewModel({
  onSelectAddress: address => startPayment(address),
});

<Contacts {...contacts} onContactPress={open} />;
<ContactAddressPicker {...contactAddressPicker} />;
```

The dialog is an intentional skeleton (no address rows yet)


https://github.com/user-attachments/assets/c4b05e79-1192-45f1-9a7f-0ca53c023604






### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36373](https://ledgerhq.atlassian.net/browse/LIVE-36373)
- **ADR** (if any): n/a

[LIVE-36373]: https://ledgerhq.atlassian.net/browse/LIVE-36373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ