### PR TITLE
feat(pay): request verify hint persist redux state

### DIFF
--- a/.changeset/LIVE-36582-pay-request-verify-hint-state.md
+++ b/.changeset/LIVE-36582-pay-request-verify-hint-state.md
@@ -1,0 +1,7 @@
+---
+"@features/flow-pay-request": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Add persisted Pay Request verify-hint state in `@features/flow-pay-request`.

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -13,6 +13,7 @@ import {
 } from "@features/flow-large-screen-upsell";
 import { restorePayCardBalanceFilter } from "@features/flow-pay-balance/state";
 import { restorePayCardFeatureTour } from "@features/flow-pay-feature-tour/state";
+import { restoreReceiveVerifyHint } from "@features/flow-pay-request/state";
 import i18n from "~/renderer/i18n/init";
 import { webFrame, ipcRenderer } from "electron";
 import each from "lodash/each";
@@ -343,6 +344,7 @@ async function init() {
   const payCardState = await getKey("app", "payCard");
   if (payCardState !== undefined) {
     store.dispatch(restorePayCardFeatureTour(payCardState));
+    store.dispatch(restoreReceiveVerifyHint(payCardState));
     store.dispatch(restorePayCardBalanceFilter(payCardState));
   }
 

--- a/apps/ledger-live-desktop/src/renderer/middlewares/__tests__/db.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/__tests__/db.test.ts
@@ -80,6 +80,9 @@ type FakeState = {
   payCardFeatureTour: {
     hasSeenFeatureTour: boolean;
   };
+  payRequestVerifyHint: {
+    hasSeenReceiveVerifyHint: boolean;
+  };
   trustchain?: unknown;
 };
 
@@ -96,6 +99,7 @@ const baseState = (): FakeState => ({
   largeScreenUpsellModal: { retriesModal: 0, lastSeenAt: null },
   payCardBalance: { balanceFilter: "all" },
   payCardFeatureTour: { hasSeenFeatureTour: false },
+  payRequestVerifyHint: { hasSeenReceiveVerifyHint: false },
 });
 
 function runMiddleware(states: FakeState[], action: { type: string; payload?: unknown }) {
@@ -239,10 +243,11 @@ describe("DBMiddleware - payCard branch", () => {
     mockedSetKey.mockReset();
   });
 
-  it("persists the composed { hasSeenFeatureTour, balanceFilter } blob on payCardFeatureTour/* actions", () => {
+  it("persists the composed { hasSeenFeatureTour, hasSeenReceiveVerifyHint, balanceFilter } blob on payCardFeatureTour/* actions", () => {
     const state: FakeState = {
       ...baseState(),
       payCardFeatureTour: { hasSeenFeatureTour: true },
+      payRequestVerifyHint: { hasSeenReceiveVerifyHint: true },
       payCardBalance: { balanceFilter: "ethereum/erc20/usd__coin" },
     };
 
@@ -251,6 +256,25 @@ describe("DBMiddleware - payCard branch", () => {
     expect(mockedSetKey).toHaveBeenCalledTimes(1);
     expect(mockedSetKey).toHaveBeenCalledWith("app", "payCard", {
       hasSeenFeatureTour: true,
+      hasSeenReceiveVerifyHint: true,
+      balanceFilter: "ethereum/erc20/usd__coin",
+    });
+  });
+
+  it("persists the composed blob on payRequestVerifyHint/* actions", () => {
+    const state: FakeState = {
+      ...baseState(),
+      payCardFeatureTour: { hasSeenFeatureTour: true },
+      payRequestVerifyHint: { hasSeenReceiveVerifyHint: true },
+      payCardBalance: { balanceFilter: "ethereum/erc20/usd__coin" },
+    };
+
+    runMiddleware([state, state], { type: "payRequestVerifyHint/markReceiveVerifyHintSeen" });
+
+    expect(mockedSetKey).toHaveBeenCalledTimes(1);
+    expect(mockedSetKey).toHaveBeenCalledWith("app", "payCard", {
+      hasSeenFeatureTour: true,
+      hasSeenReceiveVerifyHint: true,
       balanceFilter: "ethereum/erc20/usd__coin",
     });
   });
@@ -259,6 +283,7 @@ describe("DBMiddleware - payCard branch", () => {
     const state: FakeState = {
       ...baseState(),
       payCardFeatureTour: { hasSeenFeatureTour: true },
+      payRequestVerifyHint: { hasSeenReceiveVerifyHint: true },
       payCardBalance: { balanceFilter: "ethereum/erc20/usd__coin" },
     };
 
@@ -267,6 +292,7 @@ describe("DBMiddleware - payCard branch", () => {
     expect(mockedSetKey).toHaveBeenCalledTimes(1);
     expect(mockedSetKey).toHaveBeenCalledWith("app", "payCard", {
       hasSeenFeatureTour: true,
+      hasSeenReceiveVerifyHint: true,
       balanceFilter: "ethereum/erc20/usd__coin",
     });
   });

--- a/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
@@ -34,6 +34,7 @@ import { knownDevicesStoreSelector } from "../reducers/knownDevices";
 import { exportIdentitiesForPersistence } from "@domain/entity-client-identity";
 import { payCardBalancePersistedSelector } from "@features/flow-pay-balance/state";
 import { payCardFeatureTourPersistedSelector } from "@features/flow-pay-feature-tour/state";
+import { payRequestVerifyHintPersistedSelector } from "@features/flow-pay-request/state";
 import { accountsPersistedStateChanged } from "@ledgerhq/live-common/account/index";
 
 let DB_MIDDLEWARE_ENABLED = true;
@@ -134,12 +135,17 @@ const DBMiddleware: Middleware<object, State> = store => next => action => {
     return res;
   }
 
-  if (action.type.startsWith("payCardBalance/") || action.type.startsWith("payCardFeatureTour/")) {
+  if (
+    action.type.startsWith("payCardBalance/") ||
+    action.type.startsWith("payCardFeatureTour/") ||
+    action.type.startsWith("payRequestVerifyHint/")
+  ) {
     const res = next(action);
     const state = store.getState();
-    // Both pay card flow slices persist into a single blob under one storage key.
+    // Pay card flow slices persist into a single blob under one storage key.
     setKey("app", "payCard", {
       ...payCardFeatureTourPersistedSelector(state),
+      ...payRequestVerifyHintPersistedSelector(state),
       ...payCardBalancePersistedSelector(state),
     });
     return res;

--- a/apps/ledger-live-desktop/src/renderer/reducers/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/index.ts
@@ -37,6 +37,10 @@ import {
   payCardFeatureTourSlice,
   type PayCardFeatureTourState,
 } from "@features/flow-pay-feature-tour/state";
+import {
+  payRequestVerifyHintSlice,
+  type PayRequestVerifyHintState,
+} from "@features/flow-pay-request/state";
 import { payCardAuthSlice, type PayCardAuthState } from "@features/flow-pay-card-auth/state";
 import type { PayloadAction, UnknownAction } from "@reduxjs/toolkit";
 import dialogs, { DialogsState } from "./dialogs";
@@ -98,6 +102,7 @@ export type State = LLDRTKApiState & {
   largeScreenUpsellModal: LargeScreenUpsellModalState;
   payCardBalance: PayCardBalanceState;
   payCardFeatureTour: PayCardFeatureTourState;
+  payRequestVerifyHint: PayRequestVerifyHintState;
   payCardAuth: PayCardAuthState;
 };
 
@@ -141,6 +146,7 @@ const appReducer = combineReducers({
   largeScreenUpsellModal: largeScreenUpsellModalSlice.reducer,
   payCardBalance: payCardBalanceSlice.reducer,
   payCardFeatureTour: payCardFeatureTourSlice.reducer,
+  payRequestVerifyHint: payRequestVerifyHintSlice.reducer,
   payCardAuth: payCardAuthSlice.reducer,
   ...lldRTKApiReducers,
   ...(getEnv("PLAYWRIGHT_RUN") && {

--- a/apps/ledger-live-desktop/src/renderer/storage.ts
+++ b/apps/ledger-live-desktop/src/renderer/storage.ts
@@ -24,9 +24,12 @@ import type { FeatureFlagsState } from "@shared/feature-flags";
 import type { RestorableLargeScreenUpsellModalState } from "@features/flow-large-screen-upsell";
 import type { PayCardBalanceState } from "@features/flow-pay-balance/state";
 import type { PayCardFeatureTourState } from "@features/flow-pay-feature-tour/state";
+import type { PayRequestVerifyHintState } from "@features/flow-pay-request/state";
 
-/** Persisted pay card blob: the tour flag and the balance filter, stored under one key. */
-type PayCardPersistedState = PayCardFeatureTourState & PayCardBalanceState;
+/** Persisted pay card blob: tour, request verify hint, and balance filter, stored under one key. */
+type PayCardPersistedState = PayCardFeatureTourState &
+  PayRequestVerifyHintState &
+  PayCardBalanceState;
 
 /*
   This file serve as an interface for the RPC binding to the main thread that now manage the config file.

--- a/apps/ledger-live-mobile/__tests__/test-renderer.tsx
+++ b/apps/ledger-live-mobile/__tests__/test-renderer.tsx
@@ -2,6 +2,7 @@ import { BottomSheetModalProvider } from "@ledgerhq/lumen-ui-rnative";
 import { contactsInitialState } from "@domain/entity-contact";
 import { payCardBalanceInitialState } from "@features/flow-pay-balance/state";
 import { payCardFeatureTourInitialState } from "@features/flow-pay-feature-tour/state";
+import { payRequestVerifyHintInitialState } from "@features/flow-pay-request/state";
 import { initialIdentitiesState } from "@domain/entity-client-identity";
 import { INITIAL_STATE as TRUSTCHAIN_INITIAL_STATE } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { initialState as POST_ONBOARDING_INITIAL_STATE } from "@ledgerhq/live-common/postOnboarding/reducer";
@@ -88,6 +89,7 @@ const INITIAL_STATE: State = {
   ratings: RATINGS_INITIAL_STATE,
   payCardBalance: payCardBalanceInitialState,
   payCardFeatureTour: payCardFeatureTourInitialState,
+  payRequestVerifyHint: payRequestVerifyHintInitialState,
   settings: SETTINGS_INITIAL_STATE,
   toasts: TOASTS_INITIAL_STATE,
   trustchain: TRUSTCHAIN_INITIAL_STATE,

--- a/apps/ledger-live-mobile/src/components/DBSave.test.ts
+++ b/apps/ledger-live-mobile/src/components/DBSave.test.ts
@@ -20,9 +20,10 @@ describe("featureFlagsLense", () => {
 });
 
 describe("payCardPersistedSelector (mobile persistence lens)", () => {
-  it("composes { hasSeenFeatureTour, balanceFilter } from both pay card flow slices", () => {
+  it("composes { hasSeenFeatureTour, hasSeenReceiveVerifyHint, balanceFilter } from the pay card flow slices", () => {
     const state = {
       payCardFeatureTour: { hasSeenFeatureTour: true },
+      payRequestVerifyHint: { hasSeenReceiveVerifyHint: true },
       payCardBalance: { balanceFilter: "ethereum/erc20/usd__coin" },
     } as unknown as State;
 
@@ -30,6 +31,7 @@ describe("payCardPersistedSelector (mobile persistence lens)", () => {
 
     expect(projected).toEqual({
       hasSeenFeatureTour: true,
+      hasSeenReceiveVerifyHint: true,
       balanceFilter: "ethereum/erc20/usd__coin",
     });
   });

--- a/apps/ledger-live-mobile/src/components/DBSave.ts
+++ b/apps/ledger-live-mobile/src/components/DBSave.ts
@@ -37,6 +37,7 @@ import { exportMarketSelector, exportMarketListConfigSelector } from "~/reducers
 import { marketBannerStoreSelector } from "~/reducers/marketBanner";
 import { payCardBalancePersistedSelector } from "@features/flow-pay-balance/state";
 import { payCardFeatureTourPersistedSelector } from "@features/flow-pay-feature-tour/state";
+import { payRequestVerifyHintPersistedSelector } from "@features/flow-pay-request/state";
 import { settingsStoreSelector } from "~/reducers/settings";
 import type { State } from "~/reducers/types";
 import { Maybe } from "../types/helpers";
@@ -187,13 +188,19 @@ const marketBannerNotEquals = (a: State, b: State) => a.marketBanner !== b.marke
 
 export const payCardPersistedSelector = (state: State) => ({
   ...payCardFeatureTourPersistedSelector(state),
+  ...payRequestVerifyHintPersistedSelector(state),
   ...payCardBalancePersistedSelector(state),
 });
 
 const payCardDbSaveSliceSelector = createSelector(
   (state: State) => state.payCardBalance,
   (state: State) => state.payCardFeatureTour,
-  (payCardBalance, payCardFeatureTour) => ({ payCardBalance, payCardFeatureTour }),
+  (state: State) => state.payRequestVerifyHint,
+  (payCardBalance, payCardFeatureTour, payRequestVerifyHint) => ({
+    payCardBalance,
+    payCardFeatureTour,
+    payRequestVerifyHint,
+  }),
 );
 const payCardPersistedNotEquals = (a: State, b: State) =>
   !isEqual(payCardPersistedSelector(a), payCardPersistedSelector(b));

--- a/apps/ledger-live-mobile/src/context/LedgerStore.tsx
+++ b/apps/ledger-live-mobile/src/context/LedgerStore.tsx
@@ -5,6 +5,7 @@ import { importPostOnboardingState } from "@ledgerhq/live-common/postOnboarding/
 import { restoreLargeScreenUpsellModalState } from "@ledgerhq/live-engagement/largeScreenUpsellModal";
 import { restorePayCardBalanceFilter } from "@features/flow-pay-balance/state";
 import { restorePayCardFeatureTour } from "@features/flow-pay-feature-tour/state";
+import { restoreReceiveVerifyHint } from "@features/flow-pay-request/state";
 import { backfillOnboardingDate } from "~/logic/postOnboarding/backfillOnboardingDate";
 import { CounterValuesStateRaw } from "@ledgerhq/live-countervalues/types";
 import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
@@ -203,6 +204,7 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
 
       if (payCardState) {
         store.dispatch(restorePayCardFeatureTour(payCardState));
+        store.dispatch(restoreReceiveVerifyHint(payCardState));
         store.dispatch(restorePayCardBalanceFilter(payCardState));
       }
 

--- a/apps/ledger-live-mobile/src/db.ts
+++ b/apps/ledger-live-mobile/src/db.ts
@@ -33,9 +33,12 @@ import { type PersistedCAL } from "@domain/api-currency-token";
 import type { PersistedIdentities } from "@domain/entity-client-identity";
 import type { PayCardBalanceState } from "@features/flow-pay-balance/state";
 import type { PayCardFeatureTourState } from "@features/flow-pay-feature-tour/state";
+import type { PayRequestVerifyHintState } from "@features/flow-pay-request/state";
 
-/** Persisted pay card blob: the tour flag and the balance filter, stored under one key. */
-type PayCardPersistedState = PayCardFeatureTourState & PayCardBalanceState;
+/** Persisted pay card blob: tour, request verify hint, and balance filter, stored under one key. */
+type PayCardPersistedState = PayCardFeatureTourState &
+  PayRequestVerifyHintState &
+  PayCardBalanceState;
 
 const ACCOUNTS_KEY = "accounts";
 const ACCOUNTS_KEY_SORT = "accounts.sort";

--- a/apps/ledger-live-mobile/src/reducers/index.ts
+++ b/apps/ledger-live-mobile/src/reducers/index.ts
@@ -47,6 +47,7 @@ import { identitiesSlice } from "@domain/entity-client-identity";
 import { supportedFiatsSlice } from "@domain/entity-currency-fiat";
 import { payCardBalanceSlice } from "@features/flow-pay-balance/state";
 import { payCardFeatureTourSlice } from "@features/flow-pay-feature-tour/state";
+import { payRequestVerifyHintSlice } from "@features/flow-pay-request/state";
 import { payCardAuthSlice } from "@features/flow-pay-card-auth/state";
 import { contactsSlice } from "@domain/entity-contact";
 import type { UnknownAction } from "@reduxjs/toolkit";
@@ -91,6 +92,7 @@ const appReducer = combineReducers({
   sendFlow,
   payCardBalance: payCardBalanceSlice.reducer,
   payCardFeatureTour: payCardFeatureTourSlice.reducer,
+  payRequestVerifyHint: payRequestVerifyHintSlice.reducer,
   payCardAuth: payCardAuthSlice.reducer,
   toasts,
   trustchain,

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -41,6 +41,7 @@ import type { PostOnboardingHubDrawerState } from "./postOnboardingHubDrawer";
 import type { SendFlowState } from "./sendFlow";
 import type { PayCardBalanceState } from "@features/flow-pay-balance/state";
 import type { PayCardFeatureTourState } from "@features/flow-pay-feature-tour/state";
+import type { PayRequestVerifyHintState } from "@features/flow-pay-request/state";
 import type { PayCardAuthState } from "@features/flow-pay-card-auth/state";
 import type { IdentitiesState } from "@domain/entity-client-identity";
 import type { FirebaseMessagingTypes } from "@react-native-firebase/messaging";
@@ -480,6 +481,7 @@ export type State = LLMRTKApiState & {
   sendFlow: SendFlowState;
   payCardBalance: PayCardBalanceState;
   payCardFeatureTour: PayCardFeatureTourState;
+  payRequestVerifyHint: PayRequestVerifyHintState;
   payCardAuth: PayCardAuthState;
   settings: SettingsState;
   toasts: ToastState;

--- a/features/flow/pay-request/package.json
+++ b/features/flow/pay-request/package.json
@@ -11,6 +11,7 @@
       "react-native": "./src/index.native.ts",
       "default": "./src/index.ts"
     },
+    "./state": "./src/state/index.ts",
     "./package.json": "./package.json"
   },
   "sideEffects": false,
@@ -29,6 +30,7 @@
   },
   "dependencies": {
     "@ledgerhq/crypto-icons": "catalog:",
+    "@reduxjs/toolkit": "catalog:",
     "@shared/ui-qr-code": "workspace:*",
     "@shared/ui-queued-bottom-sheet": "workspace:*"
   },

--- a/features/flow/pay-request/src/state/__tests__/slice.test.ts
+++ b/features/flow/pay-request/src/state/__tests__/slice.test.ts
@@ -1,0 +1,66 @@
+import {
+  payRequestVerifyHintSlice,
+  payRequestVerifyHintInitialState,
+  markReceiveVerifyHintSeen,
+  resetReceiveVerifyHintSeen,
+  restoreReceiveVerifyHint,
+  selectHasSeenReceiveVerifyHint,
+  payRequestVerifyHintPersistedSelector,
+} from "../slice";
+
+const reducer = payRequestVerifyHintSlice.reducer;
+const root = (state = payRequestVerifyHintInitialState) => ({ payRequestVerifyHint: state });
+
+describe("payRequestVerifyHint slice", () => {
+  it("initializes with the hint unseen", () => {
+    expect(reducer(undefined, { type: "unknown" })).toEqual(payRequestVerifyHintInitialState);
+  });
+
+  it("marks the receive verify hint as seen", () => {
+    const state = reducer(undefined, markReceiveVerifyHintSeen());
+    expect(state.hasSeenReceiveVerifyHint).toBe(true);
+  });
+
+  it("resets the receive verify hint to unseen", () => {
+    const seen = reducer(undefined, markReceiveVerifyHintSeen());
+    const state = reducer(seen, resetReceiveVerifyHintSeen());
+    expect(state.hasSeenReceiveVerifyHint).toBe(false);
+  });
+});
+
+describe("restoreReceiveVerifyHint", () => {
+  it("restores hasSeenReceiveVerifyHint from a valid payload", () => {
+    const state = reducer(undefined, restoreReceiveVerifyHint({ hasSeenReceiveVerifyHint: true }));
+    expect(state.hasSeenReceiveVerifyHint).toBe(true);
+  });
+
+  it("is a no-op when dispatched with an undefined payload", () => {
+    const state = reducer(undefined, restoreReceiveVerifyHint(undefined));
+    expect(state).toEqual(payRequestVerifyHintInitialState);
+  });
+
+  it("ignores non-boolean values", () => {
+    const state = reducer(
+      undefined,
+      // @ts-expect-error - guarding against malformed persisted data
+      restoreReceiveVerifyHint({ hasSeenReceiveVerifyHint: "yes" }),
+    );
+    expect(state.hasSeenReceiveVerifyHint).toBe(false);
+  });
+});
+
+describe("payRequestVerifyHint selectors", () => {
+  it("selectHasSeenReceiveVerifyHint reflects mark/reset", () => {
+    expect(selectHasSeenReceiveVerifyHint(root())).toBe(false);
+    expect(
+      selectHasSeenReceiveVerifyHint(root(reducer(undefined, markReceiveVerifyHintSeen()))),
+    ).toBe(true);
+  });
+
+  it("payRequestVerifyHintPersistedSelector returns the slice", () => {
+    const state = reducer(undefined, markReceiveVerifyHintSeen());
+    expect(payRequestVerifyHintPersistedSelector(root(state))).toEqual({
+      hasSeenReceiveVerifyHint: true,
+    });
+  });
+});

--- a/features/flow/pay-request/src/state/index.ts
+++ b/features/flow/pay-request/src/state/index.ts
@@ -1,0 +1,1 @@
+export * from "./slice";

--- a/features/flow/pay-request/src/state/slice.ts
+++ b/features/flow/pay-request/src/state/slice.ts
@@ -1,0 +1,45 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+
+export type PayRequestVerifyHintState = Readonly<{
+  hasSeenReceiveVerifyHint: boolean;
+}>;
+
+type PayRequestVerifyHintStateRoot = {
+  payRequestVerifyHint: PayRequestVerifyHintState;
+};
+
+export const payRequestVerifyHintInitialState: PayRequestVerifyHintState = {
+  hasSeenReceiveVerifyHint: false,
+};
+
+export const payRequestVerifyHintSlice = createSlice({
+  name: "payRequestVerifyHint",
+  initialState: payRequestVerifyHintInitialState,
+  reducers: {
+    markReceiveVerifyHintSeen: state => {
+      state.hasSeenReceiveVerifyHint = true;
+    },
+    resetReceiveVerifyHintSeen: state => {
+      state.hasSeenReceiveVerifyHint = false;
+    },
+    restoreReceiveVerifyHint: (
+      state,
+      action: PayloadAction<Partial<PayRequestVerifyHintState> | undefined>,
+    ) => {
+      const { hasSeenReceiveVerifyHint } = action.payload ?? {};
+      if (typeof hasSeenReceiveVerifyHint === "boolean") {
+        state.hasSeenReceiveVerifyHint = hasSeenReceiveVerifyHint;
+      }
+    },
+  },
+});
+
+export const { markReceiveVerifyHintSeen, resetReceiveVerifyHintSeen, restoreReceiveVerifyHint } =
+  payRequestVerifyHintSlice.actions;
+
+export const selectHasSeenReceiveVerifyHint = (state: PayRequestVerifyHintStateRoot): boolean =>
+  state.payRequestVerifyHint.hasSeenReceiveVerifyHint;
+
+export const payRequestVerifyHintPersistedSelector = (
+  state: PayRequestVerifyHintStateRoot,
+): PayRequestVerifyHintState => state.payRequestVerifyHint;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7254,6 +7254,9 @@ importers:
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
         version: 2.0.4(@ledgerhq/lumen-design-core@0.1.27)(@ledgerhq/lumen-ui-react@0.1.56(@ledgerhq/lumen-design-core@0.1.27)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(@ledgerhq/lumen-ui-rnative@0.1.59(@ledgerhq/lumen-design-core@0.1.27)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@reduxjs/toolkit':
+        specifier: 'catalog:'
+        version: 2.11.2(react@19.1.4)
       '@shared/ui-qr-code':
         specifier: workspace:*
         version: link:../../../shared/ui-qr-code


### PR DESCRIPTION
## Summary
- Adds `payRequestVerifyHint` in `@features/flow-pay-request` (`hasSeenReceiveVerifyHint`).
- Wires the reducer and persist/restore on desktop and mobile (`payCard` blob). No Request UI.

**Stack:** 1/4. Desktop UI is #21408. Mobile UI is #21421. DevTools reset is #21422.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36582](https://ledgerhq.atlassian.net/browse/LIVE-36582)

[LIVE-36582]: https://ledgerhq.atlassian.net/browse/LIVE-36582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ