### PR TITLE
[LWM] fix(LIVE-36760): fix inline account creation drawer flow

### DIFF
--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/__tests__/ScanDeviceAccountsCallbacks.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/__tests__/ScanDeviceAccountsCallbacks.test.ts
@@ -154,7 +154,7 @@ describe("useScanDeviceAccountsViewModel callbacks", () => {
     expect(track).toHaveBeenCalledWith("accounts_added", expect.anything());
   });
 
-  it("resolves inline import with onSuccess before popping and does not cancel", async () => {
+  it("resolves inline import by popping before onSuccess and does not cancel", async () => {
     const callOrder: string[] = [];
     const onSuccess = jest.fn(() => callOrder.push("success"));
     const onCloseNavigation = jest.fn(() => callOrder.push("cancel"));
@@ -173,7 +173,7 @@ describe("useScanDeviceAccountsViewModel callbacks", () => {
       expect.objectContaining({ selected: expect.any(Array) }),
     );
     expect(pop).toHaveBeenCalled();
-    expect(callOrder).toEqual(["success", "pop"]);
+    expect(callOrder).toEqual(["pop", "success"]);
     expect(replace).not.toHaveBeenCalledWith(ScreenName.AddAccountsSuccess, expect.anything());
     pop.mockReset();
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
@@ -264,13 +264,13 @@ export default function useScanDeviceAccountsViewModel({
     const { onSuccess } = route.params;
 
     if (inline) {
+      popInlineScreens();
       if (onSuccess) {
         onSuccess({
           scannedAccounts,
           selected: accountsToAdd,
         });
       }
-      popInlineScreens();
     } else
       navigation.replace(ScreenName.AddAccountsSuccess, {
         ...route.params,
@@ -414,6 +414,7 @@ export default function useScanDeviceAccountsViewModel({
       } else if (!hasScannedAccounts && CustomNoAssociatedAccounts) {
         navigation.replace(ScreenName.NoAssociatedAccounts, {
           CustomNoAssociatedAccounts,
+          onCloseNavigation,
         });
       }
     }


### PR DESCRIPTION
### 📝 Description

**Bug:** After creating a new account inline from the receive drawer (Receive → select currency → Add new account → device flow → account created), the app failed to navigate to the receive confirmation screen.

**Root cause:** In the inline success path of `useScanDeviceAccountsViewModel`, `onSuccess()` was called before `popInlineScreens()`. Since `onSuccess` dispatches a `navigate(ReceiveConfirmation)` and `pop(2)` runs immediately after in the same JS turn, React Navigation's action queue processes the `pop` and cancels the pending navigation.

**Fix:** Swap the order — pop the inline screens first, then call `onSuccess()`. The `silentHideRef` mechanism in `ModularDrawerWrapper` already prevents the cancel callback from firing during the close animation, so this order is safe.

**Also fixed:** `NoAssociatedAccounts` redirect was not forwarding `onCloseNavigation` in its route params, causing the cancel callback to never fire when a user closed that screen mid-inline-flow. Added the missing prop — the screen already had full wiring to use it.

**Regression test:** `ScanDeviceAccountsCallbacks.test.ts` updated to assert `["pop", "success"]` call order and that `onCloseNavigation` is never called in the success path.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36760]


[LIVE-36760]: https://ledgerhq.atlassian.net/browse/LIVE-36760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ