### PR TITLE
[LWDM] refactor(pay-contact): migrate contact copy to @shared/i18n (LIVE-36810)

### DIFF
--- a/.changeset/pay-contact-i18n.md
+++ b/.changeset/pay-contact-i18n.md
@@ -1,0 +1,7 @@
+---
+"@features/flow-pay-contact": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Move Pay contact copy resolution into @features/flow-pay-contact via @shared/i18n so hosts no longer pass translated labels.

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabContacts.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabContacts.ts
@@ -122,27 +122,12 @@ export function usePayTabContacts(): UsePayTabContactsResult {
   return useMemo(
     () => ({
       contacts: {
-        title: t("payTab.contacts.title"),
-        emptyState: {
-          info: t("payTab.contacts.empty.info"),
-          addContactLabel: t("payTab.contacts.empty.addContact"),
-        },
         addContact: {
           labels,
           contactCreation,
           onRequestAddContact,
           onSaveSuccess,
           callbacks,
-        },
-        labels: {
-          name: t("payTab.contacts.table.name"),
-          addresses: t("payTab.contacts.table.addresses"),
-          transactions: t("payTab.contacts.table.transactions"),
-          formatTransactionCount: count => t("payTab.contacts.table.transactionCount", { count }),
-          payAction: t("payTab.contacts.actions.pay"),
-          moreAction: t("payTab.contacts.actions.more"),
-          viewContact: t("payTab.contacts.actions.viewContact"),
-          viewTransactions: t("payTab.contacts.actions.viewTransactions"),
         },
         renderAddresses: renderPayContactAddresses,
         onContactPress,

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/__tests__/usePayTabContacts.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/__tests__/usePayTabContacts.test.tsx
@@ -19,11 +19,8 @@ describe("usePayTabContacts", () => {
     jest.clearAllMocks();
   });
 
-  it("builds i18n labels and wires the Pay tile to the Send flow", () => {
+  it("wires the Pay tile to the Send flow", () => {
     const { result } = renderHook(() => usePayTabContacts());
-
-    expect(result.current.title).toBeTruthy();
-    expect(result.current.payLabel).toBeTruthy();
 
     act(() => result.current.onPay());
     expect(mockOpen).toHaveBeenCalledTimes(1);

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabContacts.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabContacts.ts
@@ -25,13 +25,11 @@ export function usePayTabContacts(): ContactsNativeProps {
 
   return useMemo(
     () => ({
-      title: t("payTab.contacts.title"),
-      payLabel: t("payTab.contacts.pay"),
       onPay: open,
       onContactPress,
       onSeeAll,
       outgoingOperations,
     }),
-    [t, open, onContactPress, onSeeAll, outgoingOperations],
+    [open, onContactPress, onSeeAll, outgoingOperations],
   );
 }

--- a/features/flow/pay-contact/README.md
+++ b/features/flow/pay-contact/README.md
@@ -9,16 +9,30 @@ Pay tile. Both exclude the `me` contact.
 Mount `Contacts` under a Redux `Provider` with `contactsSlice`. Desktop adapter:
 `usePayTabContacts`.
 
+Copy lives with the feature: the container view models resolve their own strings through
+[`@shared/i18n`](../../../shared/i18n), so the host only injects behavior (callbacks, add-contact
+wiring, `renderAddresses`). Keys read from the host app's **default** namespace (`app` on Desktop,
+`common` on Mobile):
+
+| Key | Rendered as |
+| --- | --- |
+| `payTab.contacts.title` | Section title |
+| `payTab.contacts.pay` | Native leading Pay tile |
+| `payTab.contacts.empty.{info,addContact}` | Web empty state |
+| `payTab.contacts.table.{name,addresses,transactions,transactionCount}` | Web table headers + count |
+| `payTab.contacts.actions.{pay,more,viewTransactions}` | Web row actions |
+
+Both apps must carry these keys at the same path until translation keys are colocated per feature
+(a follow-up of [LIVE-36540](https://ledgerhq.atlassian.net/browse/LIVE-36540)). The add-contact
+dialog copy stays owned by `@features/flow-contacts-add-contact` and is passed via `addContact.labels`.
+
 ## Web
 
 ```tsx
 import { Contacts } from "@features/flow-pay-contact";
 
 <Contacts
-  title={title}
-  emptyState={{ info, addContactLabel }}
   addContact={{ labels, contactCreation, onRequestAddContact, onSaveSuccess, callbacks }}
-  labels={{ name, addresses, transactions, formatTransactionCount, payAction, moreAction, viewContact, viewTransactions }}
   renderAddresses={addresses => <PayContactAddresses addresses={addresses} />}
   onContactPress={openNewPayment}
   onViewContact={openContactDetail}
@@ -62,8 +76,10 @@ optional.
 ```tsx
 import { Contacts } from "@features/flow-pay-contact";
 
-<Contacts title={title} payLabel={payLabel} onPay={openSend} onSeeAll={openContactsList} />;
+<Contacts onPay={openSend} onSeeAll={openContactsList} />;
 ```
 
-Caps at 8 contacts. `onSeeAll` opens the full list when there are more. `onContactPress(contact)`
-fires when a contact tile is pressed.
+Caps at 8 contacts. `onSeeAll` opens the full list when there are more. `onContactPress` is optional
+and unused for now.
+
+Tests wrap the component in `I18nTestProvider` from `@shared/i18n/testing`.

--- a/features/flow/pay-contact/package.json
+++ b/features/flow/pay-contact/package.json
@@ -30,7 +30,8 @@
   "dependencies": {
     "@domain/entity-contact": "workspace:*",
     "@features/flow-contacts-add-contact": "workspace:^",
-    "@features/platform-contacts": "workspace:^"
+    "@features/platform-contacts": "workspace:^",
+    "@shared/i18n": "workspace:*"
   },
   "devDependencies": {
     "@features/platform-style": "workspace:*",

--- a/features/flow/pay-contact/src/components/Contacts/__tests__/Contacts.native.test.tsx
+++ b/features/flow/pay-contact/src/components/Contacts/__tests__/Contacts.native.test.tsx
@@ -101,4 +101,12 @@ describe("Contacts (Native)", () => {
     expect(screen.getByTestId("pay-contacts-tile-0").props.accessibilityLabel).toBe("Alice");
     expect(screen.getByTestId("pay-contacts-tile-1").props.accessibilityLabel).toBe("Bob");
   });
+
+  it("should resolve its copy from the mounted i18n provider, not from props", () => {
+    renderWithContacts([mockMeContact()], <Contacts {...makeContactsProps()} />, undefined, {
+      en: { translation: { payTab: { contacts: { pay: "Envoyer" } } } },
+    });
+
+    expect(screen.getByTestId("pay-contacts-pay-tile").props.accessibilityLabel).toBe("Envoyer");
+  });
 });

--- a/features/flow/pay-contact/src/components/Contacts/__tests__/Contacts.web.test.tsx
+++ b/features/flow/pay-contact/src/components/Contacts/__tests__/Contacts.web.test.tsx
@@ -5,12 +5,10 @@ import { mockContact, mockMeContact } from "@domain/entity-contact/schema.mock";
 import { createContactCreationPort } from "@features/flow-contacts-add-contact";
 import { Contacts } from "../Contacts.web";
 import {
-  emptyStateLabels,
   makeAddContactProps,
   makeContactsStore,
   renderAddresses,
   renderWithContacts,
-  tableLabels,
 } from "./shared";
 
 function renderContacts(
@@ -20,13 +18,7 @@ function renderContacts(
 ) {
   return renderWithContacts(
     contacts,
-    <Contacts
-      title="Pay contact"
-      emptyState={emptyStateLabels}
-      addContact={addContact}
-      labels={tableLabels}
-      renderAddresses={renderAddresses}
-    />,
+    <Contacts addContact={addContact} renderAddresses={renderAddresses} />,
     store,
   );
 }
@@ -91,5 +83,16 @@ describe("Contacts (Web)", () => {
 
     expect(screen.queryByTestId("pay-contacts-empty-state")).not.toBeInTheDocument();
     expect(screen.getByTestId("pay-contacts-tile-contact-ada")).toBeVisible();
+  });
+
+  it("should resolve its copy from the mounted i18n provider, not from props", () => {
+    renderWithContacts(
+      [mockMeContact()],
+      <Contacts addContact={makeAddContactProps()} renderAddresses={renderAddresses} />,
+      undefined,
+      { en: { translation: { payTab: { contacts: { empty: { info: "Aucun contact" } } } } } },
+    );
+
+    expect(screen.getByText("Aucun contact")).toBeVisible();
   });
 });

--- a/features/flow/pay-contact/src/components/Contacts/__tests__/i18n.ts
+++ b/features/flow/pay-contact/src/components/Contacts/__tests__/i18n.ts
@@ -1,0 +1,34 @@
+import type { ComponentProps } from "react";
+import type { I18nTestProvider } from "@shared/i18n/testing";
+
+export type I18nResources = ComponentProps<typeof I18nTestProvider>["resources"];
+
+export const CONTACTS_RESOURCES: I18nResources = {
+  en: {
+    translation: {
+      payTab: {
+        contacts: {
+          title: "Pay contact",
+          pay: "Pay",
+          empty: {
+            info: "You don’t have contact yet",
+            addContact: "Add contact",
+          },
+          table: {
+            name: "Name",
+            addresses: "Addresses",
+            transactions: "Transactions",
+            transactionCount_zero: "No transaction",
+            transactionCount_one: "{{count}} transaction",
+            transactionCount_other: "{{count}} transactions",
+          },
+          actions: {
+            pay: "Send to contact",
+            more: "More options",
+            viewTransactions: "View transactions",
+          },
+        },
+      },
+    },
+  },
+};

--- a/features/flow/pay-contact/src/components/Contacts/__tests__/i18n.ts
+++ b/features/flow/pay-contact/src/components/Contacts/__tests__/i18n.ts
@@ -1,7 +1,6 @@
-import type { ComponentProps } from "react";
-import type { I18nTestProvider } from "@shared/i18n/testing";
+import type { I18nTestProviderProps } from "@shared/i18n/testing";
 
-export type I18nResources = ComponentProps<typeof I18nTestProvider>["resources"];
+export type I18nResources = I18nTestProviderProps["resources"];
 
 export const CONTACTS_RESOURCES: I18nResources = {
   en: {

--- a/features/flow/pay-contact/src/components/Contacts/__tests__/i18n.ts
+++ b/features/flow/pay-contact/src/components/Contacts/__tests__/i18n.ts
@@ -25,6 +25,7 @@ export const CONTACTS_RESOURCES: I18nResources = {
           actions: {
             pay: "Send to contact",
             more: "More options",
+            viewContact: "View contact",
             viewTransactions: "View transactions",
           },
         },

--- a/features/flow/pay-contact/src/components/Contacts/__tests__/shared.native.tsx
+++ b/features/flow/pay-contact/src/components/Contacts/__tests__/shared.native.tsx
@@ -3,7 +3,11 @@ import { configureStore } from "@reduxjs/toolkit";
 import { render } from "@testing-library/react-native";
 import { Provider } from "react-redux";
 import { contactsSlice, type Contact } from "@domain/entity-contact";
+import { I18nTestProvider } from "@shared/i18n/testing";
 import type { ContactsNativeProps } from "../../../types";
+import { CONTACTS_RESOURCES, type I18nResources } from "./i18n";
+
+export { CONTACTS_RESOURCES };
 
 export function makeContactsStore(contacts: Contact[]) {
   return configureStore({
@@ -16,10 +20,15 @@ export function renderWithContacts(
   contacts: Contact[],
   ui: ReactElement,
   store = makeContactsStore(contacts),
+  resources: I18nResources = CONTACTS_RESOURCES,
 ) {
   return {
     store,
-    ...render(<Provider store={store}>{ui}</Provider>),
+    ...render(
+      <Provider store={store}>
+        <I18nTestProvider resources={resources}>{ui}</I18nTestProvider>
+      </Provider>,
+    ),
   };
 }
 
@@ -27,8 +36,6 @@ export function makeContactsProps(
   overrides: Partial<ContactsNativeProps> = {},
 ): ContactsNativeProps {
   return {
-    title: "Pay contact",
-    payLabel: "Pay",
     onPay: jest.fn(),
     onSeeAll: jest.fn(),
     ...overrides,

--- a/features/flow/pay-contact/src/components/Contacts/__tests__/shared.web.tsx
+++ b/features/flow/pay-contact/src/components/Contacts/__tests__/shared.web.tsx
@@ -12,12 +12,17 @@ import {
 } from "@domain/entity-contact";
 import type { AddContactDialogViewModel } from "@features/flow-contacts-add-contact";
 import { StyleProvider } from "@features/platform-style";
+import { I18nTestProvider } from "@shared/i18n/testing";
 import type {
   ContactsProps,
   ContactsTableLabels,
   ContactsViewProps,
+  EmptyStateLabels,
   PayAddContactProps,
 } from "../../../types";
+import { CONTACTS_RESOURCES, type I18nResources } from "./i18n";
+
+export { CONTACTS_RESOURCES };
 
 export function makeContactsStore(contacts: Contact[]) {
   return configureStore({
@@ -26,28 +31,38 @@ export function makeContactsStore(contacts: Contact[]) {
   });
 }
 
-export function makeContactsWrapper(contacts: Contact[]): FC<{ children: ReactNode }> {
+export function makeContactsWrapper(
+  contacts: Contact[],
+  resources: I18nResources = CONTACTS_RESOURCES,
+): FC<{ children: ReactNode }> {
   const store = makeContactsStore(contacts);
 
-  return ({ children }) => <Provider store={store}>{children}</Provider>;
+  return ({ children }) => (
+    <Provider store={store}>
+      <I18nTestProvider resources={resources}>{children}</I18nTestProvider>
+    </Provider>
+  );
 }
 
 export function renderWithContacts(
   contacts: Contact[],
   ui: ReactElement,
   store = makeContactsStore(contacts),
+  resources: I18nResources = CONTACTS_RESOURCES,
 ) {
   return {
     store,
     ...render(
       <Provider store={store}>
-        <StyleProvider colorScheme="dark">{ui}</StyleProvider>
+        <I18nTestProvider resources={resources}>
+          <StyleProvider colorScheme="dark">{ui}</StyleProvider>
+        </I18nTestProvider>
       </Provider>,
     ),
   };
 }
 
-export const emptyStateLabels: ContactsProps["emptyState"] = {
+export const emptyStateLabels: EmptyStateLabels = {
   info: "You don’t have contact yet",
   addContactLabel: "Add contact",
 };
@@ -92,10 +107,7 @@ export function makeAddContactProps(
 
 export function makeContactsProps(overrides: Partial<ContactsProps> = {}): ContactsProps {
   return {
-    title: "Pay contact",
-    emptyState: emptyStateLabels,
     addContact: makeAddContactProps(),
-    labels: tableLabels,
     renderAddresses,
     ...overrides,
   };

--- a/features/flow/pay-contact/src/components/Contacts/useContactsViewModel.native.ts
+++ b/features/flow/pay-contact/src/components/Contacts/useContactsViewModel.native.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useTranslation } from "@shared/i18n";
 import {
   sortContactsByLastSentThenLastAdded,
   summarizeOutgoingOperationsByContact,
@@ -14,6 +15,7 @@ export function useContactsViewModel({
   outgoingOperations = EMPTY_OPERATIONS,
   ...props
 }: ContactsNativeProps): ContactsViewNativeProps {
+  const { t } = useTranslation();
   const contacts = useContacts();
   const sortedContacts = useMemo(() => {
     const savedContacts = contacts.filter(contact => !contact.isMe);
@@ -28,5 +30,11 @@ export function useContactsViewModel({
     [sortedContacts],
   );
 
-  return { ...props, contacts: displayedContacts, hasMore };
+  return {
+    ...props,
+    title: t("payTab.contacts.title"),
+    payLabel: t("payTab.contacts.pay"),
+    contacts: displayedContacts,
+    hasMore,
+  };
 }

--- a/features/flow/pay-contact/src/components/Contacts/useContactsViewModel.web.ts
+++ b/features/flow/pay-contact/src/components/Contacts/useContactsViewModel.web.ts
@@ -1,21 +1,27 @@
 import { useCallback, useMemo } from "react";
+import { useTranslation } from "@shared/i18n";
 import { useAddContactDialogViewModel } from "@features/flow-contacts-add-contact";
 import {
   sortContactsByLastSentThenLastAdded,
   summarizeContactOperationsByContact,
   useContacts,
 } from "@features/platform-contacts";
-import type { ContactRowViewModel, ContactsProps, ContactsViewProps } from "../../types";
+import type {
+  ContactRowViewModel,
+  ContactsProps,
+  ContactsTableLabels,
+  ContactsViewProps,
+} from "../../types";
 
 const noop = () => undefined;
 const EMPTY_OPERATIONS = [] as const;
 
 export function useContactsViewModel({
-  emptyState,
   addContact,
   operations = EMPTY_OPERATIONS,
   ...props
 }: ContactsProps): ContactsViewProps {
+  const { t } = useTranslation();
   const contacts = useContacts();
   const rows = useMemo<readonly ContactRowViewModel[]>(() => {
     const savedContacts = contacts.filter(contact => !contact.isMe);
@@ -26,10 +32,16 @@ export function useContactsViewModel({
       transactionCount: summaries[contact.id]?.txCount ?? 0,
     }));
   }, [contacts, operations]);
-  const { labels, contactCreation, onRequestAddContact, onSaveSuccess, callbacks } = addContact;
+  const {
+    labels: addContactLabels,
+    contactCreation,
+    onRequestAddContact,
+    onSaveSuccess,
+    callbacks,
+  } = addContact;
   const addContactDialog = useAddContactDialogViewModel({
     contactCreation,
-    labels,
+    labels: addContactLabels,
     onSaveSuccess: onSaveSuccess ?? noop,
     callbacks,
   });
@@ -38,11 +50,30 @@ export function useContactsViewModel({
     [addContactDialog.onOpen, onRequestAddContact],
   );
 
+  const labels = useMemo<ContactsTableLabels>(
+    () => ({
+      name: t("payTab.contacts.table.name"),
+      addresses: t("payTab.contacts.table.addresses"),
+      transactions: t("payTab.contacts.table.transactions"),
+      formatTransactionCount: count => t("payTab.contacts.table.transactionCount", { count }),
+      payAction: t("payTab.contacts.actions.pay"),
+      moreAction: t("payTab.contacts.actions.more"),
+      viewTransactions: t("payTab.contacts.actions.viewTransactions"),
+    }),
+    [t],
+  );
+
   return {
     ...props,
+    title: t("payTab.contacts.title"),
+    labels,
     isEmpty: rows.length === 0,
     rows,
-    emptyState: { ...emptyState, onAddContact },
+    emptyState: {
+      info: t("payTab.contacts.empty.info"),
+      addContactLabel: t("payTab.contacts.empty.addContact"),
+      onAddContact,
+    },
     addContactDialog,
   };
 }

--- a/features/flow/pay-contact/src/components/Contacts/useContactsViewModel.web.ts
+++ b/features/flow/pay-contact/src/components/Contacts/useContactsViewModel.web.ts
@@ -58,6 +58,7 @@ export function useContactsViewModel({
       formatTransactionCount: count => t("payTab.contacts.table.transactionCount", { count }),
       payAction: t("payTab.contacts.actions.pay"),
       moreAction: t("payTab.contacts.actions.more"),
+      viewContact: t("payTab.contacts.actions.viewContact"),
       viewTransactions: t("payTab.contacts.actions.viewTransactions"),
     }),
     [t],

--- a/features/flow/pay-contact/src/types.ts
+++ b/features/flow/pay-contact/src/types.ts
@@ -35,10 +35,7 @@ export type ContactsTableLabels = Readonly<{
 }>;
 
 export type ContactsProps = Readonly<{
-  title: string;
-  emptyState: EmptyStateLabels;
   addContact: PayAddContactProps;
-  labels: ContactsTableLabels;
   renderAddresses: (addresses: Contact["addresses"]) => ReactNode;
   onContactPress?: (contact: Contact) => void;
   onViewContact?: (contact: Contact) => void;
@@ -53,9 +50,11 @@ export type ContactRowViewModel = Readonly<{
 
 export type ContactsViewProps = Pick<
   ContactsProps,
-  "title" | "labels" | "renderAddresses" | "onContactPress" | "onViewContact" | "onViewTransactions"
+  "renderAddresses" | "onContactPress" | "onViewTransactions" | "onViewContact"
 > &
   Readonly<{
+    title: string;
+    labels: ContactsTableLabels;
     isEmpty: boolean;
     rows: readonly ContactRowViewModel[];
     emptyState: EmptyStateProps;
@@ -63,8 +62,6 @@ export type ContactsViewProps = Pick<
   }>;
 
 export type ContactsNativeProps = Readonly<{
-  title: string;
-  payLabel: string;
   onPay: () => void;
   onContactPress?: (contact: Contact) => void;
   onSeeAll: () => void;
@@ -73,6 +70,8 @@ export type ContactsNativeProps = Readonly<{
 
 export type ContactsViewNativeProps = ContactsNativeProps &
   Readonly<{
+    title: string;
+    payLabel: string;
     contacts: readonly Contact[];
     hasMore: boolean;
   }>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6927,6 +6927,9 @@ importers:
       '@features/platform-contacts':
         specifier: workspace:^
         version: link:../../platform/contacts
+      '@shared/i18n':
+        specifier: workspace:*
+        version: link:../../../shared/i18n
     devDependencies:
       '@features/platform-style':
         specifier: workspace:*


### PR DESCRIPTION
### 📝 Description

Move Pay tab contact copy resolution into `@features/flow-pay-contact` via `@shared/i18n`, following the `@features/flow-pay-feature-tour` / `@features/flow-pay-balance` pilots.

The container view models now resolve their own `payTab.contacts.*` keys (section title, empty state, table headers, row actions on web; title and Pay tile on native) through `useTranslation()`. Host props carry behavior only — both apps (LWD, LWM) stop building contact labels and passing translated strings.

Out of scope (still resolved by the host): the add-contact dialog copy (owned by `@features/flow-contacts-add-contact`), the desktop Ledger Sync introduction, and the mobile `payTab.contacts.seeAllTitle` navigation title.

Commits are split by area: package (+ changeset), desktop host, mobile host.

Tests: package unit tests wrap the container in `I18nTestProvider` from `@shared/i18n/testing` (resources centralized in a single shared fixture), with a per-platform "resolves copy from the provider, not from props" case. Typecheck passes for both web and native projects.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36810](https://ledgerhq.atlassian.net/browse/LIVE-36810)

[LIVE-36810]: https://ledgerhq.atlassian.net/browse/LIVE-36810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ