### PR TITLE
fix(e2e): update OSMO delegate test after Ledger validator removal (LIVE-36816)

### DIFF
--- a/e2e/mobile/specs/delegate/delegate.ts
+++ b/e2e/mobile/specs/delegate/delegate.ts
@@ -39,7 +39,11 @@ export function runDelegateTest(delegation: DelegateType, tmsLinks: string[], ta
       await app.account.tapEarn();
 
       await app.stake.dismissDelegationStart(currencyId);
-      if (delegation.account.currency.name === Currency.MULTIVERS_X.name) {
+      if (
+        delegation.account.currency.name === Currency.MULTIVERS_X.name ||
+        delegation.account.currency.name === Currency.OSMO.name
+      ) {
+        // OSMO: Ledger validator removed as default (LIVE-36720); must select explicitly
         await app.stake.setAmount(currencyId, delegation.amount);
         await app.stake.validateAmount(currencyId);
         await app.stake.selectValidator(currencyId, delegation.provider);


### PR DESCRIPTION
## Summary

- LIVE-36720 removed Ledger by Figment as the default pre-selected validator for OSMO in the delegation summary
- After that change, `chosenValidator` returns `undefined` for OSMO (same behavior as persistence/quicksilver), rendering `"-"` in the UI
- The E2E test `delegateOSMO.spec.ts` still expected `"Ledger by Figment"` to be pre-selected, causing a nightly failure

## Fix

Added OSMO to the explicit `selectValidator` path in `delegate.ts`, matching the existing MultiversX pattern. The test now selects the validator explicitly before asserting the provider.

## Test plan

- [ ] Run `[Mobile] - E2E Only` nightly on develop — OSMO delegate test (B2CQA-3022) should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)