### PR TITLE
feat(pay-card): add a Card interaction screen to the devtool

### DIFF
--- a/.changeset/pay-card-devtools-card-interaction.md
+++ b/.changeset/pay-card-devtools-card-interaction.md
@@ -1,0 +1,12 @@
+---
+"@devtools/pay-card": minor
+"@devtools/bindings": minor
+"@domain/api-card-management": minor
+---
+
+Add a "Card interaction" screen to the Card / Pay devtool.
+
+- Calls a signed-in cardholder's endpoints on demand and prints what they answer, so the data can be checked before any screen renders it.
+- First probe: card status. Probes are a list, so further endpoints are one entry each.
+- Exports `useLazyGetCardStatusQuery`, which a button-triggered fetch needs.
+- Native only for now.

--- a/devtools/bindings/package.json
+++ b/devtools/bindings/package.json
@@ -20,8 +20,9 @@
     "lint": "oxlint src"
   },
   "dependencies": {
-    "@devtools/registry": "workspace:*",
     "@devtools/env": "workspace:*",
+    "@devtools/registry": "workspace:*",
+    "@domain/api-card-management": "workspace:*",
     "@features/flow-pay-feature-tour": "workspace:*",
     "@features/flow-pay-request": "workspace:*",
     "@features/platform-feature-flags": "workspace:*",
@@ -35,6 +36,7 @@
   "devDependencies": {
     "@ledgerhq/test-quarantine": "workspace:*",
     "@reduxjs/toolkit": "catalog:",
+    "@shared/api-services": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@testing-library/dom": "catalog:",
@@ -44,10 +46,10 @@
     "@types/react": "catalog:",
     "jest": "catalog:",
     "jest-environment-jsdom": "catalog:",
+    "jest-sonar": "0.2.16",
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-redux": "catalog:",
-    "typescript": "catalog:",
-    "jest-sonar": "0.2.16"
+    "typescript": "catalog:"
   }
 }

--- a/devtools/bindings/src/usePayCardToolProps.test.tsx
+++ b/devtools/bindings/src/usePayCardToolProps.test.tsx
@@ -11,6 +11,7 @@ import {
   payRequestVerifyHintSlice,
   markReceiveVerifyHintSeen,
 } from "@features/flow-pay-request/state";
+import { cardApi } from "@shared/api-services";
 import { usePayCardToolProps } from "./usePayCardToolProps";
 
 /**
@@ -50,8 +51,13 @@ function buildStore() {
       featureFlags: featureFlagsReducer,
       payCardFeatureTour: payCardFeatureTourSlice.reducer,
       payRequestVerifyHint: payRequestVerifyHintSlice.reducer,
+      // The tool reads the Card endpoints, so its api has to be part of the store under test.
+      [cardApi.reducerPath]: cardApi.reducer,
     },
-    middleware: gdm => gdm().concat(createFeatureFlagsMiddleware({ resolutionConfig: {} })),
+    middleware: gdm =>
+      gdm()
+        .concat(createFeatureFlagsMiddleware({ resolutionConfig: {} }))
+        .concat(cardApi.middleware),
   });
 }
 

--- a/devtools/bindings/src/usePayCardToolProps.ts
+++ b/devtools/bindings/src/usePayCardToolProps.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useLazyGetCardStatusQuery } from "@domain/api-card-management";
 import { useDispatch, useSelector } from "react-redux";
 import { setOverride } from "@shared/feature-flags";
 import { changes, getEnv, setEnvUnsafe, type EnvName } from "@shared/env";
@@ -16,6 +17,8 @@ import type { DevToolsConfig } from "@devtools/registry";
 type PayCardToolProps = Extract<DevToolsConfig[number], { id: "pay-card" }>["config"];
 type OnboardingStep = PayCardToolProps["onboarding"]["steps"][number];
 type PayCardEnvVar = PayCardToolProps["env"]["vars"][number];
+
+type PayCardProbe = PayCardToolProps["interaction"]["probes"][number];
 
 export type UsePayCardToolPropsOptions = {
   /** Pass `"native"` on mobile to include the `walletPay` onboarding step. */
@@ -60,6 +63,12 @@ function initialSteps(platform: "web" | "native"): readonly OnboardingStep[] {
   return platform === "native"
     ? [...LEADING_ONBOARDING_STEPS, NATIVE_ONLY_STEP, PURCHASE_STEP]
     : [...LEADING_ONBOARDING_STEPS, PURCHASE_STEP];
+}
+
+/** Reads what an endpoint answered, whatever shape the failure arrives in. */
+function describeError(error: unknown): string {
+  if (error === undefined || error === null) return "";
+  return typeof error === "string" ? error : JSON.stringify(error, null, 2);
 }
 
 /**
@@ -154,10 +163,29 @@ export function usePayCardToolProps(options: UsePayCardToolPropsOptions = {}): P
 
   const env = useMemo(() => ({ vars: envVars, setVar: setEnvVar }), [envVars, setEnvVar]);
 
+  const [runCardStatus, cardStatus] = useLazyGetCardStatusQuery();
+
+  const cardStatusProbe = useMemo<PayCardProbe>(
+    () => ({
+      id: "card-status",
+      label: "Card Status",
+      isFetching: cardStatus.isFetching,
+      result: cardStatus.data === undefined ? undefined : JSON.stringify(cardStatus.data, null, 2),
+      error: cardStatus.error === undefined ? undefined : describeError(cardStatus.error),
+      run: () => {
+        runCardStatus();
+      },
+    }),
+    [cardStatus.isFetching, cardStatus.data, cardStatus.error, runCardStatus],
+  );
+
+  const interaction = useMemo(() => ({ probes: [cardStatusProbe] }), [cardStatusProbe]);
+
   return useMemo(
     () => ({
       flags,
       onboarding,
+      interaction,
       hasSeenFeatureTour,
       resetPayCardFeatureTourSeen: resetFeatureTour,
       hasSeenReceiveVerifyHint,
@@ -167,6 +195,7 @@ export function usePayCardToolProps(options: UsePayCardToolPropsOptions = {}): P
     [
       flags,
       onboarding,
+      interaction,
       hasSeenFeatureTour,
       resetFeatureTour,
       hasSeenReceiveVerifyHint,

--- a/devtools/pay-card/src/components/Interaction/Interaction.native.tsx
+++ b/devtools/pay-card/src/components/Interaction/Interaction.native.tsx
@@ -1,0 +1,45 @@
+import { ScrollView } from "react-native";
+import { Box, Button, Text } from "@ledgerhq/lumen-ui-rnative";
+import type { PayCardInteractionProps } from "../../types";
+
+export interface InteractionProps extends PayCardInteractionProps {
+  readonly onBack: () => void;
+}
+
+const CONTAINER_LX = { gap: "s12", padding: "s16" } as const;
+const PROBE_LX = { gap: "s8" } as const;
+const BUTTON_ROW_LX = { flexDirection: "row", flexWrap: "wrap", gap: "s8" } as const;
+
+export function Interaction({ probes, onBack }: InteractionProps) {
+  return (
+    <ScrollView>
+      <Box lx={CONTAINER_LX}>
+        <Box lx={BUTTON_ROW_LX}>
+          <Button appearance="gray" size="sm" onPress={onBack}>
+            Back
+          </Button>
+        </Box>
+
+        {probes.map(probe => (
+          <Box key={probe.id} lx={PROBE_LX}>
+            <Box lx={BUTTON_ROW_LX}>
+              <Button appearance="accent" size="sm" loading={probe.isFetching} onPress={probe.run}>
+                {probe.label}
+              </Button>
+            </Box>
+            {probe.error === undefined ? null : (
+              <Text typography="body3" lx={{ color: "error" }}>
+                {probe.error}
+              </Text>
+            )}
+            {probe.result === undefined ? null : (
+              <Text typography="body3" lx={{ color: "muted" }}>
+                {probe.result}
+              </Text>
+            )}
+          </Box>
+        ))}
+      </Box>
+    </ScrollView>
+  );
+}

--- a/devtools/pay-card/src/components/Interaction/Interaction.web.test.tsx
+++ b/devtools/pay-card/src/components/Interaction/Interaction.web.test.tsx
@@ -1,0 +1,12 @@
+import { render } from "@testing-library/react";
+import { Interaction } from "./Interaction";
+
+describe("Interaction (web)", () => {
+  it("renders nothing: the probes ship with the mobile tool first", () => {
+    const onBack = jest.fn();
+    const { container } = render(<Interaction probes={[]} onBack={onBack} />);
+
+    expect(container).toBeEmptyDOMElement();
+    expect(onBack).not.toHaveBeenCalled();
+  });
+});

--- a/devtools/pay-card/src/components/Interaction/Interaction.web.tsx
+++ b/devtools/pay-card/src/components/Interaction/Interaction.web.tsx
@@ -1,0 +1,10 @@
+import type { PayCardInteractionProps } from "../../types";
+
+export interface InteractionProps extends PayCardInteractionProps {
+  readonly onBack: () => void;
+}
+
+/** Native-only for now: the Card interaction probes ship with the mobile tool first. */
+export function Interaction(_props: InteractionProps) {
+  return null;
+}

--- a/devtools/pay-card/src/pay-card/PayCard.native.test.tsx
+++ b/devtools/pay-card/src/pay-card/PayCard.native.test.tsx
@@ -22,6 +22,7 @@ function buildProps(): PayCardToolProps {
       ],
       setStepDone: jest.fn(),
     },
+    interaction: { probes: [] },
     hasSeenFeatureTour: false,
     resetPayCardFeatureTourSeen: jest.fn(),
     hasSeenReceiveVerifyHint: false,
@@ -43,6 +44,9 @@ function buildProps(): PayCardToolProps {
 describe("PayCard (native)", () => {
   it("renders every section", () => {
     render(<PayCard {...buildProps()} />);
+    expect(screen.getByText("Card Debug")).toBeTruthy();
+    expect(screen.getByText("Card interaction")).toBeTruthy();
+    expect(screen.getByText("Balance")).toBeTruthy();
     expect(screen.getByText("Feature flags")).toBeTruthy();
     expect(screen.getByText("Onboarding")).toBeTruthy();
     expect(screen.getByText("Feature tour")).toBeTruthy();
@@ -127,6 +131,65 @@ describe("PayCard (native)", () => {
       "CARD_API_URL",
       "https://card.api.live.ledger.com",
     );
+  });
+
+  it("opens the interaction screen and runs a probe", async () => {
+    const user = userEvent.setup();
+    const run = jest.fn();
+    const props = buildProps();
+    render(
+      <PayCard
+        {...props}
+        interaction={{
+          probes: [
+            {
+              id: "card-status",
+              label: "Card Status",
+              isFetching: false,
+              result: undefined,
+              error: undefined,
+              run,
+            },
+          ],
+        }}
+      />,
+    );
+
+    await user.press(screen.getByText("Card interaction"));
+    // The tool swaps its whole body for the probes, so the flag rows are gone.
+    expect(screen.queryByText("Feature flags")).toBeNull();
+
+    // The probe names itself; there is no generic "Fetch".
+    await user.press(screen.getByText("Card Status"));
+    expect(run).toHaveBeenCalledTimes(1);
+
+    await user.press(screen.getByText("Back"));
+    expect(screen.getByText("Feature flags")).toBeTruthy();
+  });
+
+  it("shows what a probe came back with", async () => {
+    const user = userEvent.setup();
+    render(
+      <PayCard
+        {...buildProps()}
+        interaction={{
+          probes: [
+            {
+              id: "card-status",
+              label: "Card Status",
+              isFetching: false,
+              result: '{ "status": "ACTIVE" }',
+              error: undefined,
+              run: jest.fn(),
+            },
+          ],
+        }}
+      />,
+    );
+
+    await user.press(screen.getByText("Card interaction"));
+
+    expect(screen.getByText('{ "status": "ACTIVE" }')).toBeTruthy();
   });
 
   it("wires onboarding actions", async () => {

--- a/devtools/pay-card/src/pay-card/PayCard.native.tsx
+++ b/devtools/pay-card/src/pay-card/PayCard.native.tsx
@@ -1,9 +1,24 @@
+import { useState } from "react";
 import { ScrollView } from "react-native";
-import { Box, Button, Divider, Tag, Text } from "@ledgerhq/lumen-ui-rnative";
+import {
+  Box,
+  Button,
+  Divider,
+  ListItem,
+  ListItemContent,
+  ListItemLeading,
+  ListItemTitle,
+  ListItemTrailing,
+  Spot,
+  Tag,
+  Text,
+} from "@ledgerhq/lumen-ui-rnative";
+import { ChevronRight, CoinsCrypto, CreditCard } from "@ledgerhq/lumen-ui-rnative/symbols";
 import type { PayCardToolProps } from "../types";
 import { Section } from "../components/Section/Section";
 import { ToggleRow } from "../components/ToggleRow/ToggleRow";
 import { EnvVarRow } from "../components/EnvVarRow/EnvVarRow";
+import { Interaction } from "../components/Interaction/Interaction";
 
 const BUTTON_ROW_STYLE = { flexDirection: "row", flexWrap: "wrap", gap: 8 } as const;
 
@@ -11,6 +26,7 @@ export function PayCard(props: Readonly<PayCardToolProps>) {
   const {
     flags,
     onboarding,
+    interaction,
     hasSeenFeatureTour,
     resetPayCardFeatureTourSeen,
     hasSeenReceiveVerifyHint,
@@ -19,9 +35,42 @@ export function PayCard(props: Readonly<PayCardToolProps>) {
     onNavigateToPayTab,
     env,
   } = props;
+  const [showInteraction, setShowInteraction] = useState(false);
+
+  if (showInteraction) {
+    return <Interaction {...interaction} onBack={() => setShowInteraction(false)} />;
+  }
 
   return (
     <ScrollView>
+      <Section title="Card Debug">
+        <ListItem onPress={() => setShowInteraction(true)}>
+          <ListItemLeading>
+            <Spot appearance="icon" icon={CreditCard} />
+            <ListItemContent>
+              <ListItemTitle>Card interaction</ListItemTitle>
+            </ListItemContent>
+          </ListItemLeading>
+          <ListItemTrailing>
+            <ChevronRight />
+          </ListItemTrailing>
+        </ListItem>
+
+        <ListItem>
+          <ListItemLeading>
+            <Spot appearance="icon" icon={CoinsCrypto} />
+            <ListItemContent>
+              <ListItemTitle>Balance</ListItemTitle>
+            </ListItemContent>
+          </ListItemLeading>
+          <ListItemTrailing>
+            <ChevronRight />
+          </ListItemTrailing>
+        </ListItem>
+      </Section>
+
+      <Divider />
+
       <Section title="Feature flags">
         <ToggleRow
           label="Pay tab"

--- a/devtools/pay-card/src/pay-card/PayCard.web.test.tsx
+++ b/devtools/pay-card/src/pay-card/PayCard.web.test.tsx
@@ -22,6 +22,7 @@ function buildProps(): PayCardToolProps {
       ],
       setStepDone: jest.fn(),
     },
+    interaction: { probes: [] },
     hasSeenFeatureTour: false,
     resetPayCardFeatureTourSeen: jest.fn(),
     hasSeenReceiveVerifyHint: false,

--- a/devtools/pay-card/src/types.ts
+++ b/devtools/pay-card/src/types.ts
@@ -32,6 +32,25 @@ export interface PayCardOnboardingProps {
   readonly setStepDone: (id: string, done: boolean) => void;
 }
 
+/** One Card endpoint the tool can call on demand, with the last thing it returned. */
+export interface PayCardProbe {
+  readonly id: string;
+  readonly label: string;
+  readonly isFetching: boolean;
+  /** The last response, pretty-printed. `undefined` until the probe has been run. */
+  readonly result: string | undefined;
+  readonly error: string | undefined;
+  readonly run: () => void;
+}
+
+/**
+ * Card interaction controls: call the signed-in cardholder's endpoints and read back what they
+ * answer, so the data can be checked without a screen to render it.
+ */
+export interface PayCardInteractionProps {
+  readonly probes: readonly PayCardProbe[];
+}
+
 /**
  * One env var the tool shows, with the value a tester most often wants next.
  *
@@ -61,6 +80,7 @@ export interface PayCardEnvProps {
 export interface PayCardToolProps {
   readonly flags: PayCardFlagsProps;
   readonly onboarding: PayCardOnboardingProps;
+  readonly interaction: PayCardInteractionProps;
   /** Whether the user has already seen the Pay feature tour. */
   readonly hasSeenFeatureTour: boolean;
   /** Resets the feature tour so it plays again on the next Pay visit. */

--- a/devtools/pay-card/src/usePayCardViewModel.native.test.ts
+++ b/devtools/pay-card/src/usePayCardViewModel.native.test.ts
@@ -28,6 +28,7 @@ function buildProps(overrides: Partial<PayCardToolProps> = {}): PayCardToolProps
       setStepDone: jest.fn(),
       ...overrides.onboarding,
     },
+    interaction: { probes: [], ...overrides.interaction },
     hasSeenFeatureTour: overrides.hasSeenFeatureTour ?? false,
     resetPayCardFeatureTourSeen: overrides.resetPayCardFeatureTourSeen ?? jest.fn(),
     hasSeenReceiveVerifyHint: overrides.hasSeenReceiveVerifyHint ?? false,

--- a/devtools/pay-card/src/usePayCardViewModel.test.ts
+++ b/devtools/pay-card/src/usePayCardViewModel.test.ts
@@ -27,6 +27,7 @@ function buildProps(overrides: Partial<PayCardToolProps> = {}): PayCardToolProps
       setStepDone: jest.fn(),
       ...overrides.onboarding,
     },
+    interaction: { probes: [], ...overrides.interaction },
     hasSeenFeatureTour: overrides.hasSeenFeatureTour ?? false,
     resetPayCardFeatureTourSeen: overrides.resetPayCardFeatureTourSeen ?? jest.fn(),
     hasSeenReceiveVerifyHint: overrides.hasSeenReceiveVerifyHint ?? false,

--- a/domain/api/card-management/src/api.test.ts
+++ b/domain/api/card-management/src/api.test.ts
@@ -4,6 +4,7 @@ import {
   cardManagementApi,
   useGetCardLinkedWalletsQuery,
   useGetCardStatusQuery,
+  useLazyGetCardStatusQuery,
   useGetInternalWalletsQuery,
   useOrderCardMutation,
 } from "./api";
@@ -150,6 +151,8 @@ describe("cardManagementApi configuration", () => {
   it("exposes the getCardStatus endpoint and its hook", () => {
     expect(cardManagementApi.endpoints.getCardStatus).toBeDefined();
     expect(useGetCardStatusQuery).toBeDefined();
+    // The devtool fetches on press, not on mount, so the lazy hook is part of the surface too.
+    expect(useLazyGetCardStatusQuery).toBeDefined();
   });
 
   it("exposes the wallet endpoints and their hooks", () => {

--- a/domain/api/card-management/src/api.ts
+++ b/domain/api/card-management/src/api.ts
@@ -125,6 +125,7 @@ export const {
   useGetUserQuery,
   useOrderCardMutation,
   useGetCardStatusQuery,
+  useLazyGetCardStatusQuery,
   useGetInternalWalletsQuery,
   useGetCardLinkedWalletsQuery,
 } = cardManagementApi;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3157,6 +3157,9 @@ importers:
       '@devtools/registry':
         specifier: workspace:*
         version: link:../registry
+      '@domain/api-card-management':
+        specifier: workspace:*
+        version: link:../../domain/api/card-management
       '@features/flow-pay-feature-tour':
         specifier: workspace:*
         version: link:../../features/flow/pay-feature-tour
@@ -3179,6 +3182,9 @@ importers:
       '@reduxjs/toolkit':
         specifier: 'catalog:'
         version: 2.11.2(react-redux@9.2.0(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@shared/api-services':
+        specifier: workspace:*
+        version: link:../../shared/api-services
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11


### PR DESCRIPTION
<!-- stac-man:stack-start -->
**Stack** _(managed by [stac-man](https://github.com/bluegardenproject/stac-man))_

- **#21444 feat/pay-card-devtools-card-interaction ← this PR**
- #21163 feat/LIVE-34784-card-freeze-unfreeze
- #21399 feat/LIVE-35428-native-card-visual
- #21425 feat/LIVE-34772-card-balance-from-linked-wallets
- #21445 fix/pay-card-schema-failure-detail
- #21448 feat/pay-card-devtools-balance
- #21467 feat/LIVE-34778-card-details-token
- #21468 feat/pay-card-devtools-card-details
- #21495 feat/LIVE-34792-link-unlink-card-wallet
<!-- stac-man:stack-end -->

The Card endpoints have no UI yet, so nothing shows whether they return what
we expect. The devtool can call them once the cardholder is signed in and print
the response.

- "Card interaction" opens over the tool's own body and lists one entry per
  endpoint, with the last response or error underneath. Sub-views live in the
  tool: the shell's navigator only knows categories, tools and tool.
- The first entry is the card status. Adding an endpoint is one probe in the
  binding, which keeps the tool component free of app state as before.
- Export `useLazyGetCardStatusQuery`: a probe fetches on press, not on mount.
- 
<img width="350" alt="Screenshot_20260904_095102_LL  DEV" src="https://github.com/user-attachments/assets/05c63f30-7657-41da-acda-b3b5ae908191" />
