### PR TITLE
fix(pay-card): name the fields a Card response was rejected on

### DIFF
--- a/.changeset/pay-card-schema-failure-detail.md
+++ b/.changeset/pay-card-schema-failure-detail.md
@@ -1,5 +1,6 @@
 ---
 "@shared/api-services": patch
+"@domain/api-card-management": patch
 ---
 
 Name the fields a Card response was rejected on.
@@ -7,3 +8,4 @@ Name the fields a Card response was rejected on.
 - A schema failure reported only `expected string, received undefined`, naming no field, because RTK Query keeps just the thrown error's message unless the api converts it.
 - `catchSchemaFailure` now lists every failing path, so one run reports them all.
 - The rejected value is never carried into the error: a Card response holds the cardholder's name and PAN digits.
+- An internal wallet with no address memo answers with the key absent, not `null`, so `addressMemo` is nullish.

--- a/.changeset/pay-card-schema-failure-detail.md
+++ b/.changeset/pay-card-schema-failure-detail.md
@@ -1,0 +1,9 @@
+---
+"@shared/api-services": patch
+---
+
+Name the fields a Card response was rejected on.
+
+- A schema failure reported only `expected string, received undefined`, naming no field, because RTK Query keeps just the thrown error's message unless the api converts it.
+- `catchSchemaFailure` now lists every failing path, so one run reports them all.
+- The rejected value is never carried into the error: a Card response holds the cardholder's name and PAN digits.

--- a/domain/api/card-management/src/schema.test.ts
+++ b/domain/api/card-management/src/schema.test.ts
@@ -203,6 +203,12 @@ describe("PayCardInternalWalletSchema", () => {
     expect(() => PayCardInternalWalletSchema.parse({ ...wallet, addressMemo: "" })).toThrow();
   });
 
+  it("reads a wallet that answered with no address memo at all", () => {
+    const { addressMemo: _addressMemo, ...withoutMemo } = documentedWallets[0]!;
+
+    expect(PayCardInternalWalletSchema.parse(withoutMemo).addressMemo).toBeUndefined();
+  });
+
   it("rejects a balance sent as a number, which would already have lost precision", () => {
     expect(() => PayCardInternalWalletSchema.parse({ ...wallet, balance: 125.4 })).toThrow();
   });

--- a/domain/api/card-management/src/schema.ts
+++ b/domain/api/card-management/src/schema.ts
@@ -63,7 +63,8 @@ export const PayCardInternalWalletSchema = z.object({
   balance: z.string().min(1),
   currency: z.string().min(1),
   address: z.string().min(1),
-  addressMemo: z.string().min(1).nullable(),
+  // Nullish because a wallet with no memo answers with the key absent, others with `null`.
+  addressMemo: z.string().min(1).nullish(),
 });
 
 export const PayCardInternalWalletsResponseSchema = z.array(PayCardInternalWalletSchema);

--- a/shared/api-services/src/services/card/api.test.ts
+++ b/shared/api-services/src/services/card/api.test.ts
@@ -1,4 +1,5 @@
 import { configureStore } from "@reduxjs/toolkit";
+import { NamedSchemaError } from "@reduxjs/toolkit/query";
 import { describeSchemaFailure, getCardExtra, cardApi, cardApiExtra } from "./api";
 import type { CardApiExtra } from "./types";
 
@@ -26,17 +27,19 @@ describe("cardApi", () => {
 });
 
 describe("cardApi schema failures", () => {
-  // A real rejection from the Card status response: one required string absent.
-  const holderNameMissing = {
-    issues: [
-      { path: ["holderName"], message: "Invalid input: expected string, received undefined" },
-    ],
-    schemaName: "responseSchema",
-    value: { id: "card-1" },
-  };
+  type Issues = ConstructorParameters<typeof NamedSchemaError>[0];
+
+  /** The error RTK Query hands the converter when a response fails its schema. */
+  const rejection = (issues: Issues, value: unknown = { id: "card-1" }) =>
+    new NamedSchemaError(issues, value, "responseSchema", undefined);
 
   it("names the field the response was rejected on", () => {
-    const error = describeSchemaFailure(holderNameMissing as never);
+    // A real rejection from the Card status response: one required string absent.
+    const error = describeSchemaFailure(
+      rejection([
+        { path: ["holderName"], message: "Invalid input: expected string, received undefined" },
+      ]),
+    );
 
     expect(error).toEqual({
       status: "CUSTOM_ERROR",
@@ -46,24 +49,36 @@ describe("cardApi schema failures", () => {
   });
 
   it("joins every failing field, so one run reports them all", () => {
-    const error = describeSchemaFailure({
-      ...holderNameMissing,
-      issues: [
+    const error = describeSchemaFailure(
+      rejection([
         { path: ["holderName"], message: "expected string" },
         { path: ["panLast4"], message: "expected string" },
-      ],
-    } as never);
+      ]),
+    );
 
     expect(error).toMatchObject({
       error: expect.stringContaining("holderName: expected string; panLast4: expected string"),
     });
   });
 
+  it("reports a root-level rejection by its message, with no empty field label", () => {
+    const error = describeSchemaFailure(
+      rejection([{ path: [], message: "Invalid input: expected object, received array" }]),
+    );
+
+    expect(error).toMatchObject({
+      error:
+        "responseSchema rejected the response — Invalid input: expected object, received array",
+    });
+  });
+
   it("keeps the rejected value out of the error: it carries the holder's name and PAN", () => {
-    const error = describeSchemaFailure({
-      ...holderNameMissing,
-      value: { holderName: "Ada Lovelace", panLast4: "4242" },
-    } as never);
+    const error = describeSchemaFailure(
+      rejection([{ path: ["holderName"], message: "expected string" }], {
+        holderName: "Ada Lovelace",
+        panLast4: "4242",
+      }),
+    );
 
     expect(JSON.stringify(error)).not.toContain("Ada Lovelace");
     expect(JSON.stringify(error)).not.toContain("4242");

--- a/shared/api-services/src/services/card/api.test.ts
+++ b/shared/api-services/src/services/card/api.test.ts
@@ -1,5 +1,6 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { NamedSchemaError } from "@reduxjs/toolkit/query";
+import { z } from "zod";
 import { describeSchemaFailure, getCardExtra, cardApi, cardApiExtra } from "./api";
 import type { CardApiExtra } from "./types";
 
@@ -82,6 +83,47 @@ describe("cardApi schema failures", () => {
 
     expect(JSON.stringify(error)).not.toContain("Ada Lovelace");
     expect(JSON.stringify(error)).not.toContain("4242");
+  });
+});
+
+describe("cardApi schema failure wiring", () => {
+  let fetchSpy: jest.SpyInstance;
+
+  afterEach(() => {
+    fetchSpy?.mockRestore();
+  });
+
+  /**
+   * `catchSchemaFailure` is the only RTK Query hook that can change what a caller receives:
+   * `onSchemaFailure` runs beside it for its side effect and its return value is discarded. Drive a
+   * real response through a real endpoint, so the wiring is proven rather than assumed — if the
+   * option is ever renamed or dropped, this fails instead of quietly reporting the old message.
+   */
+  it("hands a rejected response to the converter, and returns what it built", async () => {
+    fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ ok: 42 }));
+
+    const api = cardApi.injectEndpoints({
+      endpoints: build => ({
+        schemaProbe: build.query<{ ok: string }, void>({
+          query: () => "/probe",
+          responseSchema: z.object({ ok: z.string() }),
+        }),
+      }),
+      overrideExisting: true,
+    });
+    const store = configureStore({
+      reducer: { [cardApi.reducerPath]: cardApi.reducer },
+      middleware: gdm =>
+        gdm({ thunk: { extraArgument: cardApiExtra(buildExtra()) } }).concat(cardApi.middleware),
+    });
+
+    const result = await store.dispatch(api.endpoints.schemaProbe.initiate());
+
+    expect(result.data).toBeUndefined();
+    expect(result.error).toMatchObject({
+      status: "CUSTOM_ERROR",
+      error: expect.stringContaining("responseSchema rejected the response — ok:"),
+    });
   });
 });
 

--- a/shared/api-services/src/services/card/api.test.ts
+++ b/shared/api-services/src/services/card/api.test.ts
@@ -1,5 +1,5 @@
 import { configureStore } from "@reduxjs/toolkit";
-import { getCardExtra, cardApi, cardApiExtra } from "./api";
+import { describeSchemaFailure, getCardExtra, cardApi, cardApiExtra } from "./api";
 import type { CardApiExtra } from "./types";
 
 function buildExtra(overrides: Partial<CardApiExtra> = {}): CardApiExtra {
@@ -22,6 +22,51 @@ describe("cardApi", () => {
 
   it("declares no endpoints of its own", () => {
     expect(OWN_ENDPOINT_NAMES).toHaveLength(0);
+  });
+});
+
+describe("cardApi schema failures", () => {
+  // A real rejection from the Card status response: one required string absent.
+  const holderNameMissing = {
+    issues: [
+      { path: ["holderName"], message: "Invalid input: expected string, received undefined" },
+    ],
+    schemaName: "responseSchema",
+    value: { id: "card-1" },
+  };
+
+  it("names the field the response was rejected on", () => {
+    const error = describeSchemaFailure(holderNameMissing as never);
+
+    expect(error).toEqual({
+      status: "CUSTOM_ERROR",
+      error:
+        "responseSchema rejected the response — holderName: Invalid input: expected string, received undefined",
+    });
+  });
+
+  it("joins every failing field, so one run reports them all", () => {
+    const error = describeSchemaFailure({
+      ...holderNameMissing,
+      issues: [
+        { path: ["holderName"], message: "expected string" },
+        { path: ["panLast4"], message: "expected string" },
+      ],
+    } as never);
+
+    expect(error).toMatchObject({
+      error: expect.stringContaining("holderName: expected string; panLast4: expected string"),
+    });
+  });
+
+  it("keeps the rejected value out of the error: it carries the holder's name and PAN", () => {
+    const error = describeSchemaFailure({
+      ...holderNameMissing,
+      value: { holderName: "Ada Lovelace", panLast4: "4242" },
+    } as never);
+
+    expect(JSON.stringify(error)).not.toContain("Ada Lovelace");
+    expect(JSON.stringify(error)).not.toContain("4242");
   });
 });
 

--- a/shared/api-services/src/services/card/api.ts
+++ b/shared/api-services/src/services/card/api.ts
@@ -5,6 +5,7 @@ import {
   type FetchArgs,
   type FetchBaseQueryError,
 } from "@reduxjs/toolkit/query/react";
+import type { NamedSchemaError } from "@reduxjs/toolkit/query";
 import { CARD_REDUCER_PATH, HEADER_X_CLIENT_KEY } from "./constants";
 import { CardApiExtraSchema } from "./schema";
 import type { CardApiExtra } from "./types";
@@ -90,12 +91,35 @@ const cardBaseQuery: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryErro
   return runWithToken(refreshedToken);
 };
 
+/**
+ * Names the fields a response was rejected on. The thrown error's own `message` is only the first
+ * issue's text — "expected string, received undefined" names nothing — and without a converter RTK
+ * keeps just that message, so a drift between the provider and our schemas is unactionable.
+ *
+ * Only the paths and messages are carried over, never the value that failed: a Card response holds
+ * the cardholder's name and PAN digits, and an error lands in the store and in reports.
+ */
+export function describeSchemaFailure(error: NamedSchemaError): FetchBaseQueryError {
+  const issues = error.issues
+    .map(issue => {
+      const path = issue.path?.map((segment: unknown) => String(segment)).join(".");
+      return path ? `${path}: ${issue.message}` : issue.message;
+    })
+    .join("; ");
+
+  return {
+    status: "CUSTOM_ERROR",
+    error: `${error.schemaName} rejected the response — ${issues}`,
+  };
+}
+
 /** Endpoint-less Card api — use cases inject here. See shared/api-services README. */
 export const cardApi = createApi({
   reducerPath: CARD_REDUCER_PATH,
   baseQuery: cardBaseQuery,
   tagTypes: [],
   endpoints: () => ({}),
+  catchSchemaFailure: describeSchemaFailure,
 });
 
 export type CardApi = typeof cardApi;

--- a/shared/api-services/src/services/card/api.ts
+++ b/shared/api-services/src/services/card/api.ts
@@ -102,7 +102,7 @@ const cardBaseQuery: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryErro
 export function describeSchemaFailure(error: NamedSchemaError): FetchBaseQueryError {
   const issues = error.issues
     .map(issue => {
-      const path = issue.path?.map((segment: unknown) => String(segment)).join(".");
+      const path = issue.path?.map(String).join(".");
       return path ? `${path}: ${issue.message}` : issue.message;
     })
     .join("; ");


### PR DESCRIPTION
<!-- stac-man:stack-start -->
**Stack** _(managed by [stac-man](https://github.com/bluegardenproject/stac-man))_

- **#21445 fix/pay-card-schema-failure-detail ← this PR**
- #21448 feat/pay-card-devtools-balance
- #21467 feat/LIVE-34778-card-details-token
- #21468 feat/pay-card-devtools-card-details
- #21495 feat/LIVE-34792-link-unlink-card-wallet
- #21533 feat/pay-card-devtools-freeze-unfreeze
- #21569 feat/pay-card-asset-mapping
- #21571 feat/pay-card-wallet-counter-value
<!-- stac-man:stack-end -->

A schema failure surfaced as `SchemaError: Invalid input: expected string,
received undefined` and named no field, so a drift between the provider and our
schemas could not be acted on.

- The thrown `NamedSchemaError` carries an issue per failing path, but its own
  `message` is only the first issue's text, and RTK Query keeps nothing else
  unless the api converts the failure. Convert it, listing every path.
- Carry over only the paths and messages, never the value that failed: a Card
  response holds the cardholder's name and PAN digits, and an error lands in the
  store and in reports.