### PR TITLE
[LWM] fix(e2e): fix OSMO delegation test after validator removal

### DIFF
--- a/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/02-Summary.tsx
@@ -218,6 +218,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
             validator={chosenValidator}
             account={account}
             amount={transaction.amount}
+            currencyId={mainAccount.currency.family}
           />
         </View>
       </View>
@@ -333,12 +334,14 @@ function SummaryWords({
   validator,
   account,
   amount,
+  currencyId,
   onChangeValidator,
   onChangeAmount,
 }: {
   validator?: CosmosValidatorItem;
   account: AccountLike;
   amount: BigNumber;
+  currencyId: string;
   onChangeValidator: () => void;
   onChangeAmount: () => void;
 }) {
@@ -354,18 +357,27 @@ function SummaryWords({
         <Words>
           <Trans i18nKey={`cosmos.delegation.iDelegate`} />
         </Words>
-        <Touchable onPress={onChangeAmount}>
-          <Selectable name={formattedAmount} testID="cosmos-delegation-summary-amount" />
+        <Touchable
+          onPress={onChangeAmount}
+          touchableTestID={`${currencyId}-delegation-summary-amount`}
+        >
+          <Selectable
+            name={formattedAmount}
+            testID={`${currencyId}-delegation-summary-amount-text`}
+          />
         </Touchable>
       </Line>
       <Line>
         <Words>
           <Trans i18nKey="delegation.to" />
         </Words>
-        <Touchable onPress={onChangeValidator}>
+        <Touchable
+          onPress={onChangeValidator}
+          touchableTestID={`${currencyId}-delegation-summary-validator-touchable`}
+        >
           <Selectable
             name={validator?.name ?? validator?.validatorAddress ?? "-"}
-            testID="cosmos-delegation-summary-validator"
+            testID={`${currencyId}-delegation-summary-validator`}
           />
         </Touchable>
       </Line>

--- a/apps/ledger-live-mobile/src/families/cosmos/shared/ValidatorRow.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/shared/ValidatorRow.tsx
@@ -32,6 +32,7 @@ const ValidatorRow = ({
       eventProperties={{
         validatorName: validator.name || validator.validatorAddress,
       }}
+      touchableTestID={`provider-row-${validator.name || validator.validatorAddress}`}
       onPress={onPressT}
     >
       <View style={styles.validator}>

--- a/e2e/mobile/page/trade/stake.page.ts
+++ b/e2e/mobile/page/trade/stake.page.ts
@@ -12,6 +12,8 @@ export default class StakePage {
 
   delegationSummaryValidatorId = (currencyId: string) =>
     `${currencyId}-delegation-summary-validator`;
+  delegationSummaryValidatorTouchableId = (currencyId: string) =>
+    `${currencyId}-delegation-summary-validator-touchable`;
   delegationSummaryValidator = (currencyId: string) =>
     getTextOfElement(this.delegationSummaryValidatorId(currencyId));
   delegationSummaryAmountId = (currencyId: string) => `${currencyId}-delegation-summary-amount`;
@@ -71,10 +73,17 @@ export default class StakePage {
   @Step("Select new provider {{{1}}}")
   async selectValidator(currencyId: string, provider: string) {
     const ticker = provider.split(" - ")[0];
-    await tapById(this.delegationSummaryValidatorId(currencyId));
+    const touchableId = this.delegationSummaryValidatorTouchableId(currencyId);
+    const baseId = this.delegationSummaryValidatorId(currencyId);
+    if (await IsIdVisible(touchableId)) {
+      await tapById(touchableId);
+    } else {
+      await tapById(baseId);
+    }
     await typeTextById(this.searchPoolInput, ticker);
     await waitForElementById(this.searchPoolInput);
     await tapById(this.providerRow(ticker));
+    await waitForElementById(baseId);
   }
 
   @Step("Verify fees visible in summary {{{0}}}")

--- a/e2e/mobile/specs/delegate/delegate.ts
+++ b/e2e/mobile/specs/delegate/delegate.ts
@@ -39,11 +39,17 @@ export function runDelegateTest(delegation: DelegateType, tmsLinks: string[], ta
       await app.account.tapEarn();
 
       await app.stake.dismissDelegationStart(currencyId);
-      if (delegation.account.currency.name === Currency.MULTIVERS_X.name) {
+      if (delegation.account.currency.id === Currency.MULTIVERS_X.id) {
         await app.stake.setAmount(currencyId, delegation.amount);
         await app.stake.validateAmount(currencyId);
         await app.stake.selectValidator(currencyId, delegation.provider);
-      } else if (delegation.account.currency.name !== Currency.ADA.name) {
+      } else if (delegation.account.currency.id === Currency.OSMO.id) {
+        // OSMO: no validator pre-selected by default (LIVE-36720)
+        await app.stake.expectProvider(currencyId, "-");
+        await app.stake.setAmount(currencyId, delegation.amount);
+        await app.stake.validateAmount(currencyId);
+        await app.stake.selectValidator(currencyId, delegation.provider);
+      } else if (delegation.account.currency.id !== Currency.ADA.id) {
         await app.stake.setAmount(currencyId, delegation.amount);
         await app.stake.validateAmount(currencyId);
       } else {


### PR DESCRIPTION
## Summary

LIVE-36720 removed Ledger by Figment as the default pre-selected validator for OSMO in the delegation summary. This caused a cascade of E2E test failures (B2CQA-3022) which required multiple fixes to resolve:

**1. Missing `touchableTestID` on ValidatorRow** (`cosmos/shared/ValidatorRow.tsx`)
`tapById("provider-row-Ledger by Figment")` had no element to tap — the Touchable lacked a testID.

**2. Race condition after validator selection** (`e2e/mobile/page/trade/stake.page.ts`)
`expectProvider` ran before navigation back to Summary completed. Added `waitForElementById` at the end of `selectValidator`.

**3. iOS: tap on Text child does not propagate to Pressable** (`cosmos/DelegationFlow/02-Summary.tsx`)
On iOS (XCUITest), tapping a `Text` leaf element inside a `Pressable` does not fire `onPress`. Fixed by adding `touchableTestID` directly on the `Touchable` wrapper in `SummaryWords`.

**4. testID prefix mismatch: `currency.id` vs `currency.family`** (`cosmos/DelegationFlow/02-Summary.tsx`)
The app used `mainAccount.currency.id` (= `"osmo"`) as the testID prefix, but the test uses `getCurrencyManagerApp("osmo")` = `"cosmos"` (the Ledger app name). Fixed by using `mainAccount.currency.family` (= `"cosmos"` for all cosmos-family coins).

**5. Currency object identity comparison fails across Jest module boundaries** (`e2e/mobile/specs/delegate/delegate.ts`)
`delegation.account.currency === Currency.OSMO` uses reference equality (`===`). Jest can load the same module as separate instances across the environment and test files, making the comparison always return `false` — the OSMO branch never executed. Fixed by comparing `.id` strings instead: `delegation.account.currency.id === Currency.OSMO.id`.

## Test plan

- [x] OSMO delegate test (B2CQA-3022) passes on iOS and Android
- [x] ATOM, SEI, INJ delegate tests unaffected (cosmos-family regression check)
