### PR TITLE
docs(e2e): trim the portfolio page object comments

### DIFF
--- a/.changeset/trim-portfolio-page-comments.md
+++ b/.changeset/trim-portfolio-page-comments.md
@@ -1,0 +1,13 @@
+---
+"ledger-live-mobile-e2e-tests": patch
+---
+
+Trim the portfolio page object comments to one line each
+
+The two settle helpers carried four comment blocks, 15 lines, restating the root
+cause already recorded in the QAA-1522 and QAA-1524 pull requests. Long comments
+go stale and the analysis is easier to correct where people look for it.
+
+The two container id fields lose their comments entirely — the field names already
+say they are containers. Each settle helper keeps one line, holding only the fact a
+future reader needs to not remove the wait, plus its ticket reference.

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -36,9 +36,6 @@ export default class PortfolioPage {
   fearAndGreedTitle = "fear-and-greed-title";
   bottomSheetCloseButton = "bottom-sheet-header-close-button";
   marketBannerTitle = "market-banner-title";
-  // The row's own container, from QUICK_ACTIONS_TEST_IDS.ctas.container. Waiting on this at 100%
-  // visibility is what proves the row has mounted and settled; the buttons inside it are laid out
-  // by then, so a tap cannot land on a view that is still arriving.
   quickActionsCtasContainerId = "quick-actions-ctas";
   quickActionTransferButtonV4 = "quick-action-transfer";
   quickActionSwapButtonV4 = "quick-action-swap";
@@ -49,9 +46,6 @@ export default class PortfolioPage {
   portfolioBalanceAnalyticsPill = "portfolio-balance-analytics-pill";
   portfolioBalanceDelta = "portfolio-balance-delta";
   borrowEntryPointId = "portfolio-borrow-entry-point";
-  // The sheet's own container, from QUICK_ACTIONS_TEST_IDS.transferDrawer.container. This is the
-  // anchor to wait on rather than a control inside it: the controls mount before the sheet is
-  // presented, so they are matchable while it is still sliding into place.
   transferDrawerContainerId = "transfer-drawer";
   transferBottomSheetReceiveButton = "transfer-action-receive";
   transferBottomSheetSendButton = "transfer-action-send";
@@ -362,10 +356,7 @@ export default class PortfolioPage {
     await waitForElementById(this.quickActionBuyButtonV4);
   }
 
-  // tapById does not wait, so these taps used to be issued the moment the portfolio rendered.
-  // The quick actions mount after the portfolio's own data resolves, which is why the tap could
-  // fail with "No views in hierarchy found matching ... quick-action-buy" (QAA-1524) — the row was
-  // not there yet, rather than being under-visible.
+  // The row mounts only after portfolio data resolves (QAA-1524).
   private async waitForQuickActionsSettled() {
     await waitForFullyVisibleById(this.quickActionsCtasContainerId);
   }
@@ -422,11 +413,7 @@ export default class PortfolioPage {
     await detoxExpect(getElementById(this.transferBottomSheetBankTransferButton)).toBeVisible();
   }
 
-  // tapById does not wait, so these taps used to be issued the instant the sheet was asked to open.
-  // toBeVisible() is satisfied at 75%, which a bottom sheet meets while still sliding, so the tap
-  // could land on a moving view and Espresso refused the action ("target view does not match one or
-  // more of the following constraints"), or the button was not mounted yet at all ("No views in
-  // hierarchy found matching ... transfer-action-receive"). Both are QAA-1522.
+  // Anchor on the container: the controls are matchable while the sheet still slides (QAA-1522).
   private async waitForTransferDrawerSettled() {
     await waitForFullyVisibleById(this.transferDrawerContainerId);
   }


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _This change alters no executable code — only comments — so no test applies. The two settle helpers it documents are exercised by the existing portfolio and transfer specs in the nightly._
- [x] **Impact of the changes:**
      - No runtime impact. `portfolio.page.ts` comments only; no test id, helper or assertion changed.

### Description

Review feedback on #21312: long comments in code go stale and bloat the repo.

The file carried four blocks, 15 lines, across the two settle helpers added by QAA-1522 and QAA-1524. All four restated the root cause, which is already written in both pull requests and reachable from `git blame`.

The two container id fields lose their comments entirely — `quickActionsCtasContainerId` and `transferDrawerContainerId` already say they are containers.

Each settle helper keeps one line, holding only the fact a future reader needs in order not to remove the wait, plus its ticket:

```ts
// The row mounts only after portfolio data resolves (QAA-1524).
// Anchor on the container: the controls are matchable while the sheet still slides (QAA-1522).
```

Net 15 lines removed, 2 added. `oxfmt` and `oxlint` clean.

### Context

- Review comment on #21312
- Follows `.agents/skills/comments/SKILL.md`

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
