### PR TITLE
[LWM] feat(notifications): make prompt QA screen readable (LIVE-35955)

### DIFF
--- a/.changeset/notifications-prompt-qa-screen.md
+++ b/.changeset/notifications-prompt-qa-screen.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Make the notifications prompt debug screen QA-readable with named scenarios, plain-English verdicts and an in-place drawer preview (LIVE-35955)

--- a/apps/ledger-live-mobile/src/mvvm/components/QaInspectorRow/index.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/QaInspectorRow/index.test.tsx
@@ -1,21 +1,9 @@
 import React from "react";
-import { configureStore } from "@reduxjs/toolkit";
-import { Provider } from "react-redux";
-import { render, screen } from "@testing-library/react-native";
-import StyleProvider from "~/StyleProvider";
-import settings from "~/reducers/settings";
+import { render, screen } from "@tests/test-renderer";
 import { QaInspectorRow, type QaInspectorField } from ".";
 
 function renderRow(field: QaInspectorField) {
-  const store = configureStore({ reducer: { settings } });
-
-  return render(
-    <Provider store={store}>
-      <StyleProvider selectedPalette="dark">
-        <QaInspectorRow field={field} />
-      </StyleProvider>
-    </Provider>,
-  );
+  return render(<QaInspectorRow field={field} />);
 }
 
 describe("QaInspectorRow", () => {

--- a/apps/ledger-live-mobile/src/mvvm/components/QaInspectorRow/index.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/QaInspectorRow/index.test.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { configureStore } from "@reduxjs/toolkit";
+import { Provider } from "react-redux";
+import { render, screen } from "@testing-library/react-native";
+import StyleProvider from "~/StyleProvider";
+import settings from "~/reducers/settings";
+import { QaInspectorRow, type QaInspectorField } from ".";
+
+function renderRow(field: QaInspectorField) {
+  const store = configureStore({ reducer: { settings } });
+
+  return render(
+    <Provider store={store}>
+      <StyleProvider selectedPalette="dark">
+        <QaInspectorRow field={field} />
+      </StyleProvider>
+    </Provider>,
+  );
+}
+
+describe("QaInspectorRow", () => {
+  it("should show the label, value, status and raw line", () => {
+    renderRow({
+      label: "OS notification permission",
+      value: "Not determined",
+      raw: "permissionStatus: -1",
+      status: { label: "Off", tone: "gray" },
+    });
+
+    expect(screen.getByText("OS notification permission")).toBeVisible();
+    expect(screen.getByText("Not determined")).toBeVisible();
+    expect(screen.getByText("permissionStatus: -1")).toBeVisible();
+    expect(screen.getByText("Off")).toBeVisible();
+  });
+
+  it("should omit the raw line when the field has no raw value", () => {
+    renderRow({
+      label: "Drawer target",
+      value: "globalPushNotifications",
+      status: { label: "Resolved", tone: "success" },
+    });
+
+    expect(screen.getByText("globalPushNotifications")).toBeVisible();
+    expect(screen.queryByText(/permissionStatus/)).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/components/QaInspectorRow/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/QaInspectorRow/index.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { Box, Tag, Text } from "@ledgerhq/lumen-ui-rnative";
+
+export type QaInspectorFieldTone = "success" | "error" | "warning" | "gray";
+
+export type QaInspectorField = {
+  label: string;
+  /** Large primary value the tester should read first. */
+  value: string;
+  /** Small secondary line, typically the raw stored form. */
+  raw?: string;
+  /** Tag shown next to the label: Valid, Invalid, Missing, On, Off… */
+  status: { label: string; tone: QaInspectorFieldTone };
+};
+
+export function QaInspectorRow({ field }: Readonly<{ field: QaInspectorField }>) {
+  return (
+    <Box
+      lx={{
+        paddingHorizontal: "s8",
+        paddingVertical: "s12",
+        borderRadius: "sm",
+        marginBottom: "s8",
+        gap: "s8",
+        borderWidth: "s1",
+        borderColor: "muted",
+      }}
+    >
+      <Box
+        lx={{
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: "s8",
+        }}
+      >
+        <Text typography="body2SemiBold" lx={{ color: "base", flex: 1 }}>
+          {field.label}
+        </Text>
+        <Tag label={field.status.label} size="sm" appearance={field.status.tone} />
+      </Box>
+      <Text typography="body2SemiBold" lx={{ color: "base" }} selectable>
+        {field.value}
+      </Text>
+      {field.raw ? (
+        <Text typography="body3" lx={{ color: "muted" }} selectable>
+          {field.raw}
+        </Text>
+      ) : null}
+    </Box>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/NotificationsPromptProvider.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/NotificationsPromptProvider.tsx
@@ -1,7 +1,13 @@
 import React, { createContext, useContext, useEffect, useMemo } from "react";
 import { AppState } from "react-native";
-import type { InitPushNotificationsDataResult } from "LLM/features/NotificationsPrompt/types";
-import type { NotificationsPromptAfterActionSource } from "LLM/features/NotificationsPrompt/utils/notificationsPromptEngine";
+import type {
+  InitPushNotificationsDataResult,
+  NotificationPromptTarget,
+} from "LLM/features/NotificationsPrompt/types";
+import type {
+  NotificationsPromptAfterActionSource,
+  NotificationsPromptSource,
+} from "LLM/features/NotificationsPrompt/utils/notificationsPromptEngine";
 import { useNotificationsPromptTriggers } from "LLM/features/NotificationsPrompt/new/hooks/useNotificationsPromptTriggers";
 
 type NotificationsPromptProviderProps = {
@@ -12,6 +18,13 @@ export type NotificationsPromptContextValue = {
   notifyFlowCompleted: (source: NotificationsPromptAfterActionSource) => void;
   tryTriggerPushNotificationDrawerAfterInactivity: (data: InitPushNotificationsDataResult) => void;
   initPushNotificationsData: () => Promise<InitPushNotificationsDataResult>;
+  openDrawer: (
+    source: NotificationsPromptSource,
+    timer?: number,
+    drawerPromptTarget?: NotificationPromptTarget,
+  ) => void;
+  isDrawerPending: () => boolean;
+  cancelPendingDrawer: () => void;
 };
 
 export const NotificationsPromptContext = createContext<NotificationsPromptContextValue | null>(
@@ -33,6 +46,9 @@ export function NotificationsPromptProvider({ children }: NotificationsPromptPro
     notifyFlowCompleted,
     tryTriggerPushNotificationDrawerAfterInactivity,
     initPushNotificationsData,
+    openDrawer,
+    isDrawerPending,
+    cancelPendingDrawer,
   } = useNotificationsPromptTriggers();
 
   useEffect(() => {
@@ -56,9 +72,15 @@ export function NotificationsPromptProvider({ children }: NotificationsPromptPro
       notifyFlowCompleted,
       tryTriggerPushNotificationDrawerAfterInactivity,
       initPushNotificationsData,
+      openDrawer,
+      isDrawerPending,
+      cancelPendingDrawer,
     }),
     [
       notifyFlowCompleted,
+      openDrawer,
+      isDrawerPending,
+      cancelPendingDrawer,
       tryTriggerPushNotificationDrawerAfterInactivity,
       initPushNotificationsData,
     ],

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/hooks/useNotificationsPromptDrawerScheduler.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/hooks/useNotificationsPromptDrawerScheduler.ts
@@ -16,16 +16,20 @@ export function useNotificationsPromptDrawerScheduler() {
   const isPushNotificationsModalOpen = useSelector(notificationsModalOpenSelector);
   const eventTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
+  const cancelPendingDrawer = useCallback(() => {
+    if (eventTimeoutRef.current) {
+      clearTimeout(eventTimeoutRef.current);
+      eventTimeoutRef.current = null;
+    }
+  }, []);
+
   const openDrawer = useCallback(
     (
       source: NotificationsPromptSource,
       timer = 0,
       drawerPromptTarget?: NotificationPromptTarget,
     ) => {
-      if (eventTimeoutRef.current) {
-        clearTimeout(eventTimeoutRef.current);
-        eventTimeoutRef.current = null;
-      }
+      cancelPendingDrawer();
 
       eventTimeoutRef.current = setTimeout(() => {
         eventTimeoutRef.current = null;
@@ -37,7 +41,7 @@ export function useNotificationsPromptDrawerScheduler() {
         dispatch(setNotificationsModalOpen(true));
       }, timer);
     },
-    [dispatch],
+    [cancelPendingDrawer, dispatch],
   );
 
   const isDrawerPending = useCallback(
@@ -46,16 +50,12 @@ export function useNotificationsPromptDrawerScheduler() {
   );
 
   useEffect(() => {
-    return () => {
-      if (eventTimeoutRef.current) {
-        clearTimeout(eventTimeoutRef.current);
-        eventTimeoutRef.current = null;
-      }
-    };
-  }, []);
+    return cancelPendingDrawer;
+  }, [cancelPendingDrawer]);
 
   return {
     openDrawer,
     isDrawerPending,
+    cancelPendingDrawer,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/hooks/useNotificationsPromptTriggers.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/new/hooks/useNotificationsPromptTriggers.ts
@@ -31,7 +31,8 @@ export function useNotificationsPromptTriggers() {
     syncOptOutState,
     updatePushNotificationsDataOfUserInStateAndStore,
   } = useNotificationsData();
-  const { openDrawer, isDrawerPending } = useNotificationsPromptDrawerScheduler();
+  const { openDrawer, isDrawerPending, cancelPendingDrawer } =
+    useNotificationsPromptDrawerScheduler();
 
   const initPushNotificationsData =
     useCallback(async (): Promise<InitPushNotificationsDataResult> => {
@@ -180,5 +181,8 @@ export function useNotificationsPromptTriggers() {
     notifyFlowCompleted,
     tryTriggerPushNotificationDrawerAfterInactivity,
     initPushNotificationsData,
+    openDrawer,
+    isDrawerPending,
+    cancelPendingDrawer,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/NotificationsPromptDrawer.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/NotificationsPromptDrawer.tsx
@@ -1,6 +1,4 @@
 import React, { useCallback, useRef } from "react";
-import { useTranslation } from "~/context/Locale";
-import { Flex, Link as TextLink, Button } from "@ledgerhq/native-ui";
 import {
   useNotificationsData,
   useNotificationsDrawer,
@@ -8,13 +6,11 @@ import {
 } from "LLM/features/NotificationsPrompt";
 import { useNotificationsPermission } from "LLM/hooks/useNotificationsPermission";
 import QueuedDrawer from "LLM/components/QueuedDrawer";
-import { NotificationsDrawerIllustration } from "LLM/features/NotificationsPrompt/components/NotificationsDrawerIllustration";
-import { NotificationsPromptContent } from "LLM/features/NotificationsPrompt/components/NotificationsPromptContent";
 import { resolveDrawerPromptTargetForAnalytics } from "LLM/features/NotificationsPrompt/new/notificationsPromptAnalytics";
-import { getNotificationsPromptCopy } from "LLM/features/NotificationsPrompt/utils/getNotificationsPromptCopy";
 import type { NotificationPromptTarget } from "LLM/features/NotificationsPrompt/types";
 import { TrackScreen } from "~/analytics";
 import type { NotificationsState } from "~/reducers/types";
+import { NotificationsPromptDrawerView } from "./NotificationsPromptDrawerView";
 
 type DrawerDisplayState = {
   drawerSource: NotificationsState["drawerSource"];
@@ -22,7 +18,6 @@ type DrawerDisplayState = {
 };
 
 export const NotificationsPromptDrawer = () => {
-  const { t } = useTranslation();
   const { permissionStatus, requestPushNotificationsPermission } = useNotificationsPermission();
   const {
     notifications,
@@ -78,8 +73,6 @@ export const NotificationsPromptDrawer = () => {
     };
   }, []);
 
-  const { allowKey, laterKey } = getNotificationsPromptCopy(displayedDrawerPromptTarget);
-
   return (
     <QueuedDrawer
       isRequestingToBeOpened={isPushNotificationsModalOpen}
@@ -95,28 +88,11 @@ export const NotificationsPromptDrawer = () => {
         dismissedCount={pushNotificationsDataOfUser?.dismissedOptInDrawerAtList?.length ?? 0}
       />
 
-      <Flex mb={4}>
-        <Flex alignItems={"center"}>
-          <NotificationsDrawerIllustration promptTarget={displayedDrawerPromptTarget} />
-          <NotificationsPromptContent promptTarget={displayedDrawerPromptTarget} />
-        </Flex>
-        <Button
-          type={"main"}
-          mt={8}
-          mb={7}
-          onPress={handleAllowNotificationsPress}
-          testID="notifications-prompt-allow"
-        >
-          {t(allowKey)}
-        </Button>
-        <TextLink
-          type={"shade"}
-          onPress={handleDelayLaterPress}
-          testID="notifications-prompt-later"
-        >
-          {t(laterKey)}
-        </TextLink>
-      </Flex>
+      <NotificationsPromptDrawerView
+        promptTarget={displayedDrawerPromptTarget}
+        onAllow={handleAllowNotificationsPress}
+        onLater={handleDelayLaterPress}
+      />
     </QueuedDrawer>
   );
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/NotificationsPromptDrawerView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/NotificationsPromptDrawerView.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Flex, Link as TextLink, Button } from "@ledgerhq/native-ui";
+import { Box, Button, Link } from "@ledgerhq/lumen-ui-rnative";
 import { useTranslation } from "~/context/Locale";
 import { NotificationsDrawerIllustration } from "LLM/features/NotificationsPrompt/components/NotificationsDrawerIllustration";
 import { NotificationsPromptContent } from "LLM/features/NotificationsPrompt/components/NotificationsPromptContent";
@@ -17,17 +17,29 @@ export function NotificationsPromptDrawerView({ promptTarget, onAllow, onLater }
   const { allowKey, laterKey } = getNotificationsPromptCopy(promptTarget);
 
   return (
-    <Flex mb={4}>
-      <Flex alignItems="center">
+    <Box lx={{ marginBottom: "s12" }}>
+      <Box lx={{ alignItems: "center" }}>
         <NotificationsDrawerIllustration promptTarget={promptTarget} />
         <NotificationsPromptContent promptTarget={promptTarget} />
-      </Flex>
-      <Button type="main" mt={8} mb={7} onPress={onAllow} testID="notifications-prompt-allow">
+      </Box>
+      <Button
+        appearance="base"
+        size="lg"
+        isFull
+        lx={{ marginTop: "s32", marginBottom: "s24" }}
+        onPress={onAllow}
+        testID="notifications-prompt-allow"
+      >
         {t(allowKey)}
       </Button>
-      <TextLink type="shade" onPress={onLater} testID="notifications-prompt-later">
+      <Link
+        appearance="base"
+        underline={false}
+        onPress={onLater}
+        testID="notifications-prompt-later"
+      >
         {t(laterKey)}
-      </TextLink>
-    </Flex>
+      </Link>
+    </Box>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/NotificationsPromptDrawerView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/NotificationsPromptDrawerView.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Flex, Link as TextLink, Button } from "@ledgerhq/native-ui";
+import { useTranslation } from "~/context/Locale";
+import { NotificationsDrawerIllustration } from "LLM/features/NotificationsPrompt/components/NotificationsDrawerIllustration";
+import { NotificationsPromptContent } from "LLM/features/NotificationsPrompt/components/NotificationsPromptContent";
+import { getNotificationsPromptCopy } from "LLM/features/NotificationsPrompt/utils/getNotificationsPromptCopy";
+import type { NotificationPromptTarget } from "LLM/features/NotificationsPrompt/types";
+
+type Props = {
+  promptTarget: NotificationPromptTarget | undefined;
+  onAllow: () => void;
+  onLater: () => void;
+};
+
+export function NotificationsPromptDrawerView({ promptTarget, onAllow, onLater }: Props) {
+  const { t } = useTranslation();
+  const { allowKey, laterKey } = getNotificationsPromptCopy(promptTarget);
+
+  return (
+    <Flex mb={4}>
+      <Flex alignItems="center">
+        <NotificationsDrawerIllustration promptTarget={promptTarget} />
+        <NotificationsPromptContent promptTarget={promptTarget} />
+      </Flex>
+      <Button type="main" mt={8} mb={7} onPress={onAllow} testID="notifications-prompt-allow">
+        {t(allowKey)}
+      </Button>
+      <TextLink type="shade" onPress={onLater} testID="notifications-prompt-later">
+        {t(laterKey)}
+      </TextLink>
+    </Flex>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/NotificationsPromptDrawerView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/NotificationsPromptDrawerView.tsx
@@ -12,7 +12,7 @@ type Props = {
   onLater: () => void;
 };
 
-export function NotificationsPromptDrawerView({ promptTarget, onAllow, onLater }: Props) {
+export function NotificationsPromptDrawerView({ promptTarget, onAllow, onLater }: Readonly<Props>) {
   const { t } = useTranslation();
   const { allowKey, laterKey } = getNotificationsPromptCopy(promptTarget);
 

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/__tests__/NotificationsPromptDrawerView.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/__tests__/NotificationsPromptDrawerView.test.tsx
@@ -1,15 +1,7 @@
 import React from "react";
-import { configureStore } from "@reduxjs/toolkit";
-import { Provider } from "react-redux";
-import { fireEvent, render, screen } from "@testing-library/react-native";
-import StyleProvider from "~/StyleProvider";
-import settings from "~/reducers/settings";
+import { fireEvent, render, screen } from "@tests/test-renderer";
 import { NotificationsPromptDrawerView } from "../NotificationsPromptDrawerView";
 
-jest.mock("~/images/illustration/Illustration", () => "Illustration");
-jest.mock("~/context/Locale", () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
-}));
 jest.mock("LLM/features/NotificationsPrompt/components/NotificationsDrawerIllustration", () => ({
   NotificationsDrawerIllustration: () => null,
 }));
@@ -20,18 +12,13 @@ describe("NotificationsPromptDrawerView", () => {
   it("should call onAllow and onLater from the prompt actions", () => {
     const onAllow = jest.fn();
     const onLater = jest.fn();
-    const store = configureStore({ reducer: { settings } });
 
     render(
-      <Provider store={store}>
-        <StyleProvider selectedPalette="dark">
-          <NotificationsPromptDrawerView
-            promptTarget="globalPushNotifications"
-            onAllow={onAllow}
-            onLater={onLater}
-          />
-        </StyleProvider>
-      </Provider>,
+      <NotificationsPromptDrawerView
+        promptTarget="globalPushNotifications"
+        onAllow={onAllow}
+        onLater={onLater}
+      />,
     );
 
     fireEvent.press(screen.getByTestId("notifications-prompt-allow"));

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/__tests__/NotificationsPromptDrawerView.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/__tests__/NotificationsPromptDrawerView.test.tsx
@@ -1,5 +1,9 @@
 import React from "react";
+import { configureStore } from "@reduxjs/toolkit";
+import { Provider } from "react-redux";
 import { fireEvent, render, screen } from "@testing-library/react-native";
+import StyleProvider from "~/StyleProvider";
+import settings from "~/reducers/settings";
 import { NotificationsPromptDrawerView } from "../NotificationsPromptDrawerView";
 
 jest.mock("~/images/illustration/Illustration", () => "Illustration");
@@ -12,50 +16,22 @@ jest.mock("LLM/features/NotificationsPrompt/components/NotificationsDrawerIllust
 jest.mock("LLM/features/NotificationsPrompt/components/NotificationsPromptContent", () => ({
   NotificationsPromptContent: () => null,
 }));
-jest.mock("@ledgerhq/native-ui", () => {
-  const { View, Text, Pressable } = require("react-native");
-  return {
-    Flex: ({ children }: { children?: React.ReactNode }) => <View>{children}</View>,
-    Button: ({
-      children,
-      onPress,
-      testID,
-    }: {
-      children?: React.ReactNode;
-      onPress?: () => void;
-      testID?: string;
-    }) => (
-      <Pressable testID={testID} onPress={onPress}>
-        <Text>{children}</Text>
-      </Pressable>
-    ),
-    Link: ({
-      children,
-      onPress,
-      testID,
-    }: {
-      children?: React.ReactNode;
-      onPress?: () => void;
-      testID?: string;
-    }) => (
-      <Pressable testID={testID} onPress={onPress}>
-        <Text>{children}</Text>
-      </Pressable>
-    ),
-  };
-});
-
 describe("NotificationsPromptDrawerView", () => {
   it("should call onAllow and onLater from the prompt actions", () => {
     const onAllow = jest.fn();
     const onLater = jest.fn();
+    const store = configureStore({ reducer: { settings } });
 
     render(
-      <NotificationsPromptDrawerView
-        promptTarget="globalPushNotifications"
-        onAllow={onAllow}
-        onLater={onLater}
-      />,
+      <Provider store={store}>
+        <StyleProvider selectedPalette="dark">
+          <NotificationsPromptDrawerView
+            promptTarget="globalPushNotifications"
+            onAllow={onAllow}
+            onLater={onLater}
+          />
+        </StyleProvider>
+      </Provider>,
     );
 
     fireEvent.press(screen.getByTestId("notifications-prompt-allow"));

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/__tests__/NotificationsPromptDrawerView.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/screens/__tests__/NotificationsPromptDrawerView.test.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+import { NotificationsPromptDrawerView } from "../NotificationsPromptDrawerView";
+
+jest.mock("~/images/illustration/Illustration", () => "Illustration");
+jest.mock("~/context/Locale", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+jest.mock("LLM/features/NotificationsPrompt/components/NotificationsDrawerIllustration", () => ({
+  NotificationsDrawerIllustration: () => null,
+}));
+jest.mock("LLM/features/NotificationsPrompt/components/NotificationsPromptContent", () => ({
+  NotificationsPromptContent: () => null,
+}));
+jest.mock("@ledgerhq/native-ui", () => {
+  const { View, Text, Pressable } = require("react-native");
+  return {
+    Flex: ({ children }: { children?: React.ReactNode }) => <View>{children}</View>,
+    Button: ({
+      children,
+      onPress,
+      testID,
+    }: {
+      children?: React.ReactNode;
+      onPress?: () => void;
+      testID?: string;
+    }) => (
+      <Pressable testID={testID} onPress={onPress}>
+        <Text>{children}</Text>
+      </Pressable>
+    ),
+    Link: ({
+      children,
+      onPress,
+      testID,
+    }: {
+      children?: React.ReactNode;
+      onPress?: () => void;
+      testID?: string;
+    }) => (
+      <Pressable testID={testID} onPress={onPress}>
+        <Text>{children}</Text>
+      </Pressable>
+    ),
+  };
+});
+
+describe("NotificationsPromptDrawerView", () => {
+  it("should call onAllow and onLater from the prompt actions", () => {
+    const onAllow = jest.fn();
+    const onLater = jest.fn();
+
+    render(
+      <NotificationsPromptDrawerView
+        promptTarget="globalPushNotifications"
+        onAllow={onAllow}
+        onLater={onLater}
+      />,
+    );
+
+    fireEvent.press(screen.getByTestId("notifications-prompt-allow"));
+    fireEvent.press(screen.getByTestId("notifications-prompt-later"));
+
+    expect(onAllow).toHaveBeenCalledTimes(1);
+    expect(onLater).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/AnalyticsConsentQA/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/AnalyticsConsentQA/index.tsx
@@ -53,6 +53,7 @@ import {
   setPersonalizedRecommendations,
 } from "~/actions/settings";
 import { AnalyticsConsentDrawer } from "LLM/features/AnalyticsConsentDrawer";
+import { QaInspectorRow, type QaInspectorField } from "LLM/components/QaInspectorRow";
 import NavigationScrollView from "~/components/NavigationScrollView";
 import { TrackScreen } from "~/analytics";
 
@@ -60,17 +61,7 @@ const FLAG_KEY = "analyticsOptIn";
 
 type TabId = "scenarios" | "inspect";
 
-type FieldTone = "success" | "error" | "warning" | "gray";
-
-type InspectorField = {
-  label: string;
-  /** Large primary value the tester should read first. */
-  value: string;
-  /** Small secondary line, typically the raw stored form. */
-  raw?: string;
-  /** Tag shown next to the label: Valid, Invalid, Missing, On, Off… */
-  status: { label: string; tone: FieldTone };
-};
+type InspectorField = QaInspectorField;
 
 type ToggleField = {
   label: string;
@@ -191,44 +182,6 @@ function buildInspectorFields(
         : { label: "Invalid", tone: "error" },
     },
   };
-}
-
-function InspectorRow({ field }: Readonly<{ field: InspectorField }>) {
-  return (
-    <Box
-      lx={{
-        paddingHorizontal: "s8",
-        paddingVertical: "s12",
-        borderRadius: "sm",
-        marginBottom: "s8",
-        gap: "s8",
-        borderWidth: "s1",
-        borderColor: "muted",
-      }}
-    >
-      <Box
-        lx={{
-          flexDirection: "row",
-          alignItems: "center",
-          justifyContent: "space-between",
-          gap: "s8",
-        }}
-      >
-        <Text typography="body2SemiBold" lx={{ color: "base", flex: 1 }}>
-          {field.label}
-        </Text>
-        <Tag label={field.status.label} size="sm" appearance={field.status.tone} />
-      </Box>
-      <Text typography="body2SemiBold" lx={{ color: "base" }} selectable>
-        {field.value}
-      </Text>
-      {field.raw ? (
-        <Text typography="body3" lx={{ color: "muted" }} selectable>
-          {field.raw}
-        </Text>
-      ) : null}
-    </Box>
-  );
 }
 
 function ToggleRow({ field }: Readonly<{ field: ToggleField }>) {
@@ -402,7 +355,7 @@ function QaTabSection({
             Stored on this device
           </Text>
           {storedFields.map(field => (
-            <InspectorRow key={field.label} field={field} />
+            <QaInspectorRow key={field.label} field={field} />
           ))}
           <Text
             typography="body3SemiBold"
@@ -417,7 +370,7 @@ function QaTabSection({
               onChange: onFlagEnabledChange,
             }}
           />
-          <InspectorRow field={policyVersionField} />
+          <QaInspectorRow field={policyVersionField} />
           <Text
             typography="body3SemiBold"
             lx={{ color: "muted", marginTop: "s16", marginBottom: "s4" }}

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/__tests__/NotificationsPromptQA.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/__tests__/NotificationsPromptQA.test.tsx
@@ -1,10 +1,6 @@
 import React from "react";
 import { Alert } from "react-native";
-import { configureStore } from "@reduxjs/toolkit";
-import { Provider } from "react-redux";
-import { fireEvent, render, screen } from "@testing-library/react-native";
-import StyleProvider from "~/StyleProvider";
-import settings from "~/reducers/settings";
+import { fireEvent, render, screen } from "@tests/test-renderer";
 import DebugNotificationsPromptQA from "../index";
 import { useNotificationsPromptQaViewModel } from "../useNotificationsPromptQaViewModel";
 import { NOTIFICATIONS_QA_VERDICT_META } from "../utils";
@@ -56,15 +52,7 @@ jest.mock("LLM/features/NotificationsPrompt/screens/NotificationsPromptDrawerVie
 const mockedViewModel = useNotificationsPromptQaViewModel as jest.Mock;
 
 function renderScreen() {
-  const store = configureStore({ reducer: { settings } });
-
-  return render(
-    <Provider store={store}>
-      <StyleProvider selectedPalette="dark">
-        <DebugNotificationsPromptQA />
-      </StyleProvider>
-    </Provider>,
-  );
+  return render(<DebugNotificationsPromptQA />);
 }
 
 function buildViewModel(overrides: Record<string, unknown> = {}) {

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/__tests__/NotificationsPromptQA.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/__tests__/NotificationsPromptQA.test.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import { Alert } from "react-native";
+import { configureStore } from "@reduxjs/toolkit";
+import { Provider } from "react-redux";
 import { fireEvent, render, screen } from "@testing-library/react-native";
+import StyleProvider from "~/StyleProvider";
+import settings from "~/reducers/settings";
 import DebugNotificationsPromptQA from "../index";
 import { useNotificationsPromptQaViewModel } from "../useNotificationsPromptQaViewModel";
 import { NOTIFICATIONS_QA_VERDICT_META } from "../utils";
@@ -16,50 +20,6 @@ jest.mock("~/analytics", () => ({
 jest.mock("../../../SettingsNavigationScrollView", () => {
   const { View } = require("react-native");
   return ({ children }: { children: React.ReactNode }) => <View>{children}</View>;
-});
-
-jest.mock("@ledgerhq/lumen-ui-rnative", () => {
-  const { View, Text, Pressable } = require("react-native");
-  const Box = ({ children }: { children?: React.ReactNode }) => <View>{children}</View>;
-  const Button = ({
-    children,
-    onPress,
-    disabled,
-  }: {
-    children?: React.ReactNode;
-    onPress?: () => void;
-    disabled?: boolean;
-  }) => (
-    <Pressable accessibilityRole="button" disabled={disabled} onPress={onPress}>
-      <Text>{children}</Text>
-    </Pressable>
-  );
-  const Tag = ({ label }: { label: string }) => <Text>{label}</Text>;
-  const Divider = () => <View />;
-  const SegmentedControl = ({
-    children,
-    onSelectedChange,
-  }: {
-    children?: React.ReactNode;
-    onSelectedChange?: (value: string) => void;
-  }) => (
-    <View>
-      {React.Children.map(children, child => {
-        if (!React.isValidElement<{ value: string; children?: React.ReactNode }>(child)) {
-          return child;
-        }
-        return (
-          <Pressable onPress={() => onSelectedChange?.(child.props.value)}>
-            <Text>{child.props.children}</Text>
-          </Pressable>
-        );
-      })}
-    </View>
-  );
-  const SegmentedControlButton = ({ children }: { children?: React.ReactNode; value: string }) => (
-    <Text>{children}</Text>
-  );
-  return { Box, Button, Divider, SegmentedControl, SegmentedControlButton, Tag, Text };
 });
 
 jest.mock("~/components/QueuedDrawer", () => {
@@ -94,6 +54,18 @@ jest.mock("LLM/features/NotificationsPrompt/screens/NotificationsPromptDrawerVie
 }));
 
 const mockedViewModel = useNotificationsPromptQaViewModel as jest.Mock;
+
+function renderScreen() {
+  const store = configureStore({ reducer: { settings } });
+
+  return render(
+    <Provider store={store}>
+      <StyleProvider selectedPalette="dark">
+        <DebugNotificationsPromptQA />
+      </StyleProvider>
+    </Provider>,
+  );
+}
 
 function buildViewModel(overrides: Record<string, unknown> = {}) {
   return {
@@ -159,7 +131,7 @@ describe("DebugNotificationsPromptQA", () => {
     const onForceOpenDrawer = jest.fn();
     mockedViewModel.mockReturnValue(buildViewModel({ onForceOpenDrawer }));
 
-    render(<DebugNotificationsPromptQA />);
+    renderScreen();
 
     expect(screen.getByText("NOTIFICATIONS PROMPT — QA")).toBeVisible();
     expect(screen.getAllByText("Show drawer").length).toBeGreaterThan(0);
@@ -180,14 +152,14 @@ describe("DebugNotificationsPromptQA", () => {
       apply?.onPress?.();
     });
 
-    render(<DebugNotificationsPromptQA />);
+    renderScreen();
 
     fireEvent.press(screen.getByLabelText("Apply First prompt scenario"));
     expect(applyScenario).toHaveBeenCalledWith(expect.objectContaining({ id: "first-prompt" }));
   });
 
   it("should show inspector fields on the Inspect tab", () => {
-    render(<DebugNotificationsPromptQA />);
+    renderScreen();
 
     fireEvent.press(screen.getByText("Inspect"));
 
@@ -202,7 +174,7 @@ describe("DebugNotificationsPromptQA", () => {
     const onForceOpenDrawer = jest.fn();
     mockedViewModel.mockReturnValue(buildViewModel({ onForceOpenDrawer }));
 
-    render(<DebugNotificationsPromptQA />);
+    renderScreen();
 
     fireEvent.press(screen.getByText("Preview drawer"));
     expect(screen.getByTestId("qa-preview-allow")).toBeVisible();
@@ -220,7 +192,7 @@ describe("DebugNotificationsPromptQA", () => {
       reset?.onPress?.();
     });
 
-    render(<DebugNotificationsPromptQA />);
+    renderScreen();
 
     fireEvent.press(screen.getByText("Reset all"));
     expect(onResetAll).toHaveBeenCalled();

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/__tests__/NotificationsPromptQA.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/__tests__/NotificationsPromptQA.test.tsx
@@ -1,0 +1,228 @@
+import React from "react";
+import { Alert } from "react-native";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+import DebugNotificationsPromptQA from "../index";
+import { useNotificationsPromptQaViewModel } from "../useNotificationsPromptQaViewModel";
+import { NOTIFICATIONS_QA_VERDICT_META } from "../utils";
+
+jest.mock("../useNotificationsPromptQaViewModel", () => ({
+  useNotificationsPromptQaViewModel: jest.fn(),
+}));
+
+jest.mock("~/analytics", () => ({
+  TrackScreen: () => null,
+}));
+
+jest.mock("../../../SettingsNavigationScrollView", () => {
+  const { View } = require("react-native");
+  return ({ children }: { children: React.ReactNode }) => <View>{children}</View>;
+});
+
+jest.mock("@ledgerhq/lumen-ui-rnative", () => {
+  const { View, Text, Pressable } = require("react-native");
+  const Box = ({ children }: { children?: React.ReactNode }) => <View>{children}</View>;
+  const Button = ({
+    children,
+    onPress,
+    disabled,
+  }: {
+    children?: React.ReactNode;
+    onPress?: () => void;
+    disabled?: boolean;
+  }) => (
+    <Pressable accessibilityRole="button" disabled={disabled} onPress={onPress}>
+      <Text>{children}</Text>
+    </Pressable>
+  );
+  const Tag = ({ label }: { label: string }) => <Text>{label}</Text>;
+  const Divider = () => <View />;
+  const SegmentedControl = ({
+    children,
+    onSelectedChange,
+  }: {
+    children?: React.ReactNode;
+    onSelectedChange?: (value: string) => void;
+  }) => (
+    <View>
+      {React.Children.map(children, child => {
+        if (!React.isValidElement<{ value: string; children?: React.ReactNode }>(child)) {
+          return child;
+        }
+        return (
+          <Pressable onPress={() => onSelectedChange?.(child.props.value)}>
+            <Text>{child.props.children}</Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+  const SegmentedControlButton = ({ children }: { children?: React.ReactNode; value: string }) => (
+    <Text>{children}</Text>
+  );
+  return { Box, Button, Divider, SegmentedControl, SegmentedControlButton, Tag, Text };
+});
+
+jest.mock("~/components/QueuedDrawer", () => {
+  const { View, Pressable } = require("react-native");
+  return {
+    __esModule: true,
+    default: (props: {
+      isRequestingToBeOpened?: boolean;
+      onBackdropPress?: () => void;
+      children?: React.ReactNode;
+    }) => {
+      if (!props.isRequestingToBeOpened) return <View />;
+      return (
+        <View>
+          <Pressable testID="drawer-backdrop" onPress={props.onBackdropPress} />
+          {props.children}
+        </View>
+      );
+    },
+  };
+});
+
+jest.mock("LLM/features/NotificationsPrompt/screens/NotificationsPromptDrawerView", () => ({
+  NotificationsPromptDrawerView: ({ onAllow }: { onAllow: () => void }) => {
+    const { Pressable, Text } = require("react-native");
+    return (
+      <Pressable testID="qa-preview-allow" onPress={onAllow}>
+        <Text>Preview allow</Text>
+      </Pressable>
+    );
+  },
+}));
+
+const mockedViewModel = useNotificationsPromptQaViewModel as jest.Mock;
+
+function buildViewModel(overrides: Record<string, unknown> = {}) {
+  return {
+    selectedSource: "onboarding",
+    setSelectedSource: jest.fn(),
+    isBaselineCaptured: true,
+    verdict: "Show drawer",
+    verdictMeta: NOTIFICATIONS_QA_VERDICT_META["Show drawer"],
+    reason: "Eligible now",
+    rawReason: "kind: show",
+    resolvedPromptTarget: "globalPushNotifications",
+    forceOpenDrawerLabel: "Force open globalPushNotifications drawer — bypass rules",
+    decision: {
+      kind: "show",
+      source: "onboarding",
+      delayMs: 0,
+      drawerPromptTarget: "globalPushNotifications",
+      dismissedCount: 0,
+    },
+    sourceLabel: "Onboarding",
+    applyScenario: jest.fn(),
+    onResetAll: jest.fn(),
+    onTriggerProductionDrawer: jest.fn(),
+    onForceOpenDrawer: jest.fn(),
+    onMarkInactive: jest.fn(),
+    onMarkRepromptable: jest.fn(),
+    onKeepTwoDismissals: jest.fn(),
+    userStateFields: [
+      {
+        label: "OS notification permission",
+        value: "Not determined",
+        raw: "permissionStatus: -1",
+        status: { label: "Off", tone: "gray" },
+      },
+    ],
+    decisionFields: [
+      {
+        label: "Drawer target",
+        value: "globalPushNotifications",
+        raw: "drawerPromptTarget: globalPushNotifications · dismissedCount: 0",
+        status: { label: "Resolved", tone: "success" },
+      },
+    ],
+    featureFields: [
+      {
+        label: "Braze notifications prompt",
+        value: "Enabled",
+        raw: "feature: brazePushNotifications",
+        status: { label: "On", tone: "success" },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("DebugNotificationsPromptQA", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedViewModel.mockReturnValue(buildViewModel());
+  });
+
+  it("should show the headline verdict and force-open the resolved target", () => {
+    const onForceOpenDrawer = jest.fn();
+    mockedViewModel.mockReturnValue(buildViewModel({ onForceOpenDrawer }));
+
+    render(<DebugNotificationsPromptQA />);
+
+    expect(screen.getByText("NOTIFICATIONS PROMPT — QA")).toBeVisible();
+    expect(screen.getAllByText("Show drawer").length).toBeGreaterThan(0);
+    expect(screen.getByText("Eligible now")).toBeVisible();
+    expect(
+      screen.getByText("Force open globalPushNotifications drawer — bypass rules"),
+    ).toBeVisible();
+
+    fireEvent.press(screen.getByText("Force open globalPushNotifications drawer — bypass rules"));
+    expect(onForceOpenDrawer).toHaveBeenCalled();
+  });
+
+  it("should apply a named scenario after confirm", () => {
+    const applyScenario = jest.fn();
+    mockedViewModel.mockReturnValue(buildViewModel({ applyScenario }));
+    jest.spyOn(Alert, "alert").mockImplementation((_title, _message, buttons) => {
+      const apply = buttons?.find(button => button.text === "Apply");
+      apply?.onPress?.();
+    });
+
+    render(<DebugNotificationsPromptQA />);
+
+    fireEvent.press(screen.getByLabelText("Apply First prompt scenario"));
+    expect(applyScenario).toHaveBeenCalledWith(expect.objectContaining({ id: "first-prompt" }));
+  });
+
+  it("should show inspector fields on the Inspect tab", () => {
+    render(<DebugNotificationsPromptQA />);
+
+    fireEvent.press(screen.getByText("Inspect"));
+
+    expect(screen.getByText("Current user and device state")).toBeVisible();
+    expect(
+      screen.getByText("drawerPromptTarget: globalPushNotifications · dismissedCount: 0"),
+    ).toBeVisible();
+    expect(screen.getByText("feature: brazePushNotifications")).toBeVisible();
+  });
+
+  it("should preview the drawer without calling production handlers", () => {
+    const onForceOpenDrawer = jest.fn();
+    mockedViewModel.mockReturnValue(buildViewModel({ onForceOpenDrawer }));
+
+    render(<DebugNotificationsPromptQA />);
+
+    fireEvent.press(screen.getByText("Preview drawer"));
+    expect(screen.getByTestId("qa-preview-allow")).toBeVisible();
+
+    fireEvent.press(screen.getByTestId("qa-preview-allow"));
+    expect(screen.queryByTestId("qa-preview-allow")).toBeNull();
+    expect(onForceOpenDrawer).not.toHaveBeenCalled();
+  });
+
+  it("should reset after confirm when a baseline was captured", () => {
+    const onResetAll = jest.fn();
+    mockedViewModel.mockReturnValue(buildViewModel({ onResetAll, isBaselineCaptured: true }));
+    jest.spyOn(Alert, "alert").mockImplementation((_title, _message, buttons) => {
+      const reset = buttons?.find(button => button.text === "Reset");
+      reset?.onPress?.();
+    });
+
+    render(<DebugNotificationsPromptQA />);
+
+    fireEvent.press(screen.getByText("Reset all"));
+    expect(onResetAll).toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/__tests__/useNotificationsPromptQaViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/__tests__/useNotificationsPromptQaViewModel.test.ts
@@ -13,9 +13,12 @@ const mockIsDrawerPending = jest.fn(() => false);
 const mockCancelPendingDrawer = jest.fn();
 
 /** State the ViewModel reads through native-backed hooks rather than Redux. */
-const nativeState = {
-  permissionStatus: AuthorizationStatus.NOT_DETERMINED as PermissionStatus,
-  pushNotificationsDataOfUser: undefined as DataOfUser | undefined,
+const nativeState: {
+  permissionStatus: PermissionStatus | undefined;
+  pushNotificationsDataOfUser: DataOfUser | undefined;
+} = {
+  permissionStatus: AuthorizationStatus.NOT_DETERMINED,
+  pushNotificationsDataOfUser: undefined,
 };
 
 const mockSetPermissionStatus = jest.fn((status: PermissionStatus) => {
@@ -87,6 +90,21 @@ describe("useNotificationsPromptQaViewModel", () => {
     expect(result.current.reason).toBe("Eligible now");
     expect(result.current.forceOpenDrawerLabel).toContain(result.current.resolvedPromptTarget);
     expect(mockCancelPendingDrawer).toHaveBeenCalled();
+  });
+
+  it("should not apply a scenario before the baseline is captured", () => {
+    nativeState.permissionStatus = undefined;
+    const { result, store } = renderViewModel();
+
+    act(() => {
+      result.current.applyScenario(getScenario("already-opted-in"));
+    });
+
+    expect(result.current.isBaselineCaptured).toBe(false);
+    expect(store.getState().settings.notifications.areNotificationsAllowed).toBe(true);
+    expect(mockSetPermissionStatus).not.toHaveBeenCalled();
+    expect(mockUpdateUserData).not.toHaveBeenCalled();
+    expect(mockCancelPendingDrawer).not.toHaveBeenCalled();
   });
 
   it("should report Skip when the already opted in scenario is applied", () => {

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/__tests__/useNotificationsPromptQaViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/__tests__/useNotificationsPromptQaViewModel.test.ts
@@ -1,19 +1,7 @@
-import React, { type ReactNode } from "react";
 import { AuthorizationStatus } from "@react-native-firebase/messaging";
-import { configureStore } from "@reduxjs/toolkit";
-import { Provider } from "react-redux";
-import { act, renderHook } from "@testing-library/react-native";
-import {
-  FEATURE_FLAGS_DEFAULTS,
-  FEATURE_FLAGS_INITIAL_STATE,
-  featureFlagsReducer,
-  type Features,
-} from "@shared/feature-flags";
+import { act, renderHook, withFlagOverrides } from "@tests/test-renderer";
 import { createNotificationsPromptFeatureFlags } from "LLM/features/NotificationsPrompt/testUtils";
 import type { DataOfUser } from "LLM/features/NotificationsPrompt";
-import notifications from "~/reducers/notifications";
-import ratings from "~/reducers/ratings";
-import settings from "~/reducers/settings";
 import { NOTIFICATIONS_QA_SCENARIOS } from "../utils";
 import { useNotificationsPromptQaViewModel } from "../useNotificationsPromptQaViewModel";
 
@@ -60,36 +48,18 @@ jest.mock("LLM/features/NotificationsPrompt/hooks/useNotificationsData", () => (
   }),
 }));
 
-const { brazePushNotifications } = createNotificationsPromptFeatureFlags({
+const notificationsPromptFlags = createNotificationsPromptFeatureFlags({
   inactivityEnabled: true,
 });
 
 /**
- * Real store seeded with the slices the ViewModel reads, so feature flags resolve
+ * Real store seeded with the notifications prompt flags, so feature flags resolve
  * through `useFeature` and `setOverride` instead of being mocked.
  */
-function createTestStore() {
-  return configureStore({
-    reducer: { featureFlags: featureFlagsReducer, notifications, ratings, settings },
-    preloadedState: {
-      featureFlags: {
-        ...FEATURE_FLAGS_INITIAL_STATE,
-        overrides: { brazePushNotifications },
-        resolved: { ...FEATURE_FLAGS_DEFAULTS, brazePushNotifications } as Features,
-      },
-    },
-  });
-}
-
 function renderViewModel() {
-  const store = createTestStore();
-  const Wrapper = ({ children }: Readonly<{ children?: ReactNode }>) =>
-    React.createElement(Provider, { store }, children);
-
-  return {
-    store,
-    ...renderHook(() => useNotificationsPromptQaViewModel(), { wrapper: Wrapper }),
-  };
+  return renderHook(() => useNotificationsPromptQaViewModel(), {
+    overrideInitialState: withFlagOverrides(notificationsPromptFlags),
+  });
 }
 
 function getScenario(id: string) {

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/__tests__/useNotificationsPromptQaViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/__tests__/useNotificationsPromptQaViewModel.test.ts
@@ -1,76 +1,45 @@
+import React, { type ReactNode } from "react";
 import { AuthorizationStatus } from "@react-native-firebase/messaging";
+import { configureStore } from "@reduxjs/toolkit";
+import { Provider } from "react-redux";
 import { act, renderHook } from "@testing-library/react-native";
+import {
+  FEATURE_FLAGS_DEFAULTS,
+  FEATURE_FLAGS_INITIAL_STATE,
+  featureFlagsReducer,
+  type Features,
+} from "@shared/feature-flags";
 import { createNotificationsPromptFeatureFlags } from "LLM/features/NotificationsPrompt/testUtils";
 import type { DataOfUser } from "LLM/features/NotificationsPrompt";
+import notifications from "~/reducers/notifications";
+import ratings from "~/reducers/ratings";
+import settings from "~/reducers/settings";
 import { NOTIFICATIONS_QA_SCENARIOS } from "../utils";
 import { useNotificationsPromptQaViewModel } from "../useNotificationsPromptQaViewModel";
+
+type PermissionStatus = (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus];
 
 const mockOpenDrawer = jest.fn();
 const mockNotifyFlowCompleted = jest.fn();
 const mockIsDrawerPending = jest.fn(() => false);
 const mockCancelPendingDrawer = jest.fn();
 
-const qaState = {
-  permissionStatus: AuthorizationStatus.NOT_DETERMINED as
-    | (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus]
-    | null
-    | undefined,
-  areNotificationsAllowed: false,
-  transactionsAlertsCategory: false,
-  hasCompletedOnboarding: true,
-  isRatingsModalOpen: false,
+/** State the ViewModel reads through native-backed hooks rather than Redux. */
+const nativeState = {
+  permissionStatus: AuthorizationStatus.NOT_DETERMINED as PermissionStatus,
   pushNotificationsDataOfUser: undefined as DataOfUser | undefined,
-  brazePushNotifications: createNotificationsPromptFeatureFlags({ inactivityEnabled: true })
-    .brazePushNotifications,
 };
 
-const mockSetPermissionStatus = jest.fn(
-  (status: (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus]) => {
-    qaState.permissionStatus = status;
-  },
-);
-const mockUpdateUserData = jest.fn((data: DataOfUser) => {
-  qaState.pushNotificationsDataOfUser = data;
+const mockSetPermissionStatus = jest.fn((status: PermissionStatus) => {
+  nativeState.permissionStatus = status;
 });
-
-jest.mock("~/context/hooks", () => ({
-  useDispatch: () => (action: { type?: string; payload?: unknown }) => {
-    if (action.type === "SET_NOTIFICATIONS") {
-      const payload = action.payload as {
-        areNotificationsAllowed?: boolean;
-        transactionsAlertsCategory?: boolean;
-      };
-      if (typeof payload?.areNotificationsAllowed === "boolean") {
-        qaState.areNotificationsAllowed = payload.areNotificationsAllowed;
-      }
-      if (typeof payload?.transactionsAlertsCategory === "boolean") {
-        qaState.transactionsAlertsCategory = payload.transactionsAlertsCategory;
-      }
-    }
-    if (action.type === "SETTINGS_COMPLETE_ONBOARDING" && typeof action.payload === "boolean") {
-      qaState.hasCompletedOnboarding = action.payload;
-    }
-  },
-  useSelector: (selector: (state: never) => unknown) =>
-    selector({
-      settings: {
-        notifications: {
-          areNotificationsAllowed: qaState.areNotificationsAllowed,
-          transactionsAlertsCategory: qaState.transactionsAlertsCategory,
-        },
-        hasCompletedOnboarding: qaState.hasCompletedOnboarding,
-      },
-      ratings: { isRatingsModalOpen: qaState.isRatingsModalOpen },
-    } as never),
-}));
-
-jest.mock("@features/platform-feature-flags", () => ({
-  useFeature: () => qaState.brazePushNotifications,
-}));
+const mockUpdateUserData = jest.fn((data: DataOfUser) => {
+  nativeState.pushNotificationsDataOfUser = data;
+});
 
 jest.mock("LLM/hooks/useNotificationsPermission", () => ({
   useNotificationsPermission: () => ({
-    permissionStatus: qaState.permissionStatus,
+    permissionStatus: nativeState.permissionStatus,
     setPermissionStatus: mockSetPermissionStatus,
   }),
 }));
@@ -81,36 +50,67 @@ jest.mock("LLM/features/NotificationsPrompt/new/NotificationsPromptProvider", ()
     openDrawer: mockOpenDrawer,
     isDrawerPending: mockIsDrawerPending,
     cancelPendingDrawer: mockCancelPendingDrawer,
-    tryTriggerPushNotificationDrawerAfterInactivity: jest.fn(),
-    initPushNotificationsData: jest.fn(async () => ({})),
   }),
 }));
 
 jest.mock("LLM/features/NotificationsPrompt/hooks/useNotificationsData", () => ({
   useNotificationsData: () => ({
-    pushNotificationsDataOfUser: qaState.pushNotificationsDataOfUser,
+    pushNotificationsDataOfUser: nativeState.pushNotificationsDataOfUser,
     updatePushNotificationsDataOfUserInStateAndStore: mockUpdateUserData,
   }),
 }));
+
+const { brazePushNotifications } = createNotificationsPromptFeatureFlags({
+  inactivityEnabled: true,
+});
+
+/**
+ * Real store seeded with the slices the ViewModel reads, so feature flags resolve
+ * through `useFeature` and `setOverride` instead of being mocked.
+ */
+function createTestStore() {
+  return configureStore({
+    reducer: { featureFlags: featureFlagsReducer, notifications, ratings, settings },
+    preloadedState: {
+      featureFlags: {
+        ...FEATURE_FLAGS_INITIAL_STATE,
+        overrides: { brazePushNotifications },
+        resolved: { ...FEATURE_FLAGS_DEFAULTS, brazePushNotifications } as Features,
+      },
+    },
+  });
+}
+
+function renderViewModel() {
+  const store = createTestStore();
+  const Wrapper = ({ children }: Readonly<{ children?: ReactNode }>) =>
+    React.createElement(Provider, { store }, children);
+
+  return {
+    store,
+    ...renderHook(() => useNotificationsPromptQaViewModel(), { wrapper: Wrapper }),
+  };
+}
+
+function getScenario(id: string) {
+  const scenario = NOTIFICATIONS_QA_SCENARIOS.find(candidate => candidate.id === id);
+  if (!scenario) throw new Error(`Unknown QA scenario: ${id}`);
+  return scenario;
+}
 
 describe("useNotificationsPromptQaViewModel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsDrawerPending.mockReturnValue(false);
-    qaState.permissionStatus = AuthorizationStatus.NOT_DETERMINED;
-    qaState.areNotificationsAllowed = false;
-    qaState.transactionsAlertsCategory = false;
-    qaState.hasCompletedOnboarding = true;
-    qaState.isRatingsModalOpen = false;
-    qaState.pushNotificationsDataOfUser = undefined;
+    nativeState.permissionStatus = AuthorizationStatus.NOT_DETERMINED;
+    nativeState.pushNotificationsDataOfUser = undefined;
   });
 
   it("should report Show drawer for the first prompt scenario", () => {
-    const { result } = renderHook(() => useNotificationsPromptQaViewModel());
-    const firstPrompt = NOTIFICATIONS_QA_SCENARIOS.find(scenario => scenario.id === "first-prompt");
+    const { result } = renderViewModel();
 
     act(() => {
-      result.current.applyScenario(firstPrompt!);
+      result.current.applyScenario(getScenario("first-prompt"));
     });
 
     expect(result.current.verdict).toBe("Show drawer");
@@ -120,38 +120,49 @@ describe("useNotificationsPromptQaViewModel", () => {
   });
 
   it("should report Skip when the already opted in scenario is applied", () => {
-    const { result } = renderHook(() => useNotificationsPromptQaViewModel());
-    const optedIn = NOTIFICATIONS_QA_SCENARIOS.find(scenario => scenario.id === "already-opted-in");
+    const { result, store } = renderViewModel();
 
     act(() => {
-      result.current.applyScenario(optedIn!);
+      result.current.applyScenario(getScenario("already-opted-in"));
     });
 
+    expect(store.getState().settings.notifications.areNotificationsAllowed).toBe(true);
     expect(result.current.verdict).toBe("Skip");
     expect(result.current.reason).toBe("Already opted in");
     expect(result.current.rawReason).toBe("reason: fully_opted_in");
   });
 
-  it("should restore captured baseline on reset", () => {
-    const { result } = renderHook(() => useNotificationsPromptQaViewModel());
-    const optedIn = NOTIFICATIONS_QA_SCENARIOS.find(scenario => scenario.id === "already-opted-in");
+  it("should keep the feature flag enabled through the store when a scenario runs", () => {
+    const { result, store } = renderViewModel();
 
     act(() => {
-      result.current.applyScenario(optedIn!);
+      result.current.applyScenario(getScenario("first-prompt"));
     });
-    expect(qaState.areNotificationsAllowed).toBe(true);
+
+    expect(store.getState().featureFlags.overrides.brazePushNotifications?.enabled).toBe(true);
+  });
+
+  it("should restore captured baseline on reset", () => {
+    const { result, store } = renderViewModel();
+
+    act(() => {
+      result.current.applyScenario(getScenario("too-soon"));
+    });
+    expect(store.getState().settings.notifications.areNotificationsAllowed).toBe(false);
 
     act(() => {
       result.current.onResetAll();
     });
 
+    expect(store.getState().settings.notifications.areNotificationsAllowed).toBe(true);
+    expect(store.getState().featureFlags.overrides.brazePushNotifications).toBeUndefined();
     expect(mockSetPermissionStatus).toHaveBeenCalledWith(AuthorizationStatus.NOT_DETERMINED);
     expect(result.current.selectedSource).toBe("onboarding");
     expect(mockCancelPendingDrawer).toHaveBeenCalled();
   });
 
   it("should force-open the resolved prompt target", () => {
-    const { result } = renderHook(() => useNotificationsPromptQaViewModel());
+    const { result } = renderViewModel();
 
     act(() => {
       result.current.onForceOpenDrawer();
@@ -166,7 +177,7 @@ describe("useNotificationsPromptQaViewModel", () => {
   });
 
   it("should call notifyFlowCompleted for after-action production triggers", () => {
-    const { result } = renderHook(() => useNotificationsPromptQaViewModel());
+    const { result } = renderViewModel();
 
     act(() => {
       result.current.setSelectedSource("send");
@@ -180,11 +191,10 @@ describe("useNotificationsPromptQaViewModel", () => {
   });
 
   it("should open the inactivity drawer when production rules allow it", () => {
-    const { result } = renderHook(() => useNotificationsPromptQaViewModel());
-    const inactive = NOTIFICATIONS_QA_SCENARIOS.find(scenario => scenario.id === "inactive-user");
+    const { result } = renderViewModel();
 
     act(() => {
-      result.current.applyScenario(inactive!);
+      result.current.applyScenario(getScenario("inactive-user"));
     });
     act(() => {
       result.current.onTriggerProductionDrawer();
@@ -199,7 +209,7 @@ describe("useNotificationsPromptQaViewModel", () => {
   });
 
   it("should switch to inactivity after making the user inactive", () => {
-    const { result } = renderHook(() => useNotificationsPromptQaViewModel());
+    const { result } = renderViewModel();
 
     act(() => {
       result.current.onMarkInactive();
@@ -209,12 +219,12 @@ describe("useNotificationsPromptQaViewModel", () => {
   });
 
   it("should mark after-action as eligible and keep two dismissals", () => {
-    qaState.pushNotificationsDataOfUser = {
+    nativeState.pushNotificationsDataOfUser = {
       dismissedOptInDrawerAtList: [1, 2, 3],
       dismissedPromptAtListByTarget: { globalPushNotifications: [1, 2, 3] },
       lastActionAt: Date.now(),
     };
-    const { result } = renderHook(() => useNotificationsPromptQaViewModel());
+    const { result } = renderViewModel();
 
     act(() => {
       result.current.onMarkRepromptable();
@@ -223,6 +233,9 @@ describe("useNotificationsPromptQaViewModel", () => {
       result.current.onKeepTwoDismissals();
     });
 
-    expect(mockUpdateUserData).toHaveBeenCalled();
+    expect(mockUpdateUserData).toHaveBeenCalledTimes(2);
+    expect(
+      mockUpdateUserData.mock.calls[1][0].dismissedPromptAtListByTarget?.globalPushNotifications,
+    ).toHaveLength(2);
   });
 });

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/__tests__/useNotificationsPromptQaViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/__tests__/useNotificationsPromptQaViewModel.test.ts
@@ -1,0 +1,228 @@
+import { AuthorizationStatus } from "@react-native-firebase/messaging";
+import { act, renderHook } from "@testing-library/react-native";
+import { createNotificationsPromptFeatureFlags } from "LLM/features/NotificationsPrompt/testUtils";
+import type { DataOfUser } from "LLM/features/NotificationsPrompt";
+import { NOTIFICATIONS_QA_SCENARIOS } from "../utils";
+import { useNotificationsPromptQaViewModel } from "../useNotificationsPromptQaViewModel";
+
+const mockOpenDrawer = jest.fn();
+const mockNotifyFlowCompleted = jest.fn();
+const mockIsDrawerPending = jest.fn(() => false);
+const mockCancelPendingDrawer = jest.fn();
+
+const qaState = {
+  permissionStatus: AuthorizationStatus.NOT_DETERMINED as
+    | (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus]
+    | null
+    | undefined,
+  areNotificationsAllowed: false,
+  transactionsAlertsCategory: false,
+  hasCompletedOnboarding: true,
+  isRatingsModalOpen: false,
+  pushNotificationsDataOfUser: undefined as DataOfUser | undefined,
+  brazePushNotifications: createNotificationsPromptFeatureFlags({ inactivityEnabled: true })
+    .brazePushNotifications,
+};
+
+const mockSetPermissionStatus = jest.fn(
+  (status: (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus]) => {
+    qaState.permissionStatus = status;
+  },
+);
+const mockUpdateUserData = jest.fn((data: DataOfUser) => {
+  qaState.pushNotificationsDataOfUser = data;
+});
+
+jest.mock("~/context/hooks", () => ({
+  useDispatch: () => (action: { type?: string; payload?: unknown }) => {
+    if (action.type === "SET_NOTIFICATIONS") {
+      const payload = action.payload as {
+        areNotificationsAllowed?: boolean;
+        transactionsAlertsCategory?: boolean;
+      };
+      if (typeof payload?.areNotificationsAllowed === "boolean") {
+        qaState.areNotificationsAllowed = payload.areNotificationsAllowed;
+      }
+      if (typeof payload?.transactionsAlertsCategory === "boolean") {
+        qaState.transactionsAlertsCategory = payload.transactionsAlertsCategory;
+      }
+    }
+    if (action.type === "SETTINGS_COMPLETE_ONBOARDING" && typeof action.payload === "boolean") {
+      qaState.hasCompletedOnboarding = action.payload;
+    }
+  },
+  useSelector: (selector: (state: never) => unknown) =>
+    selector({
+      settings: {
+        notifications: {
+          areNotificationsAllowed: qaState.areNotificationsAllowed,
+          transactionsAlertsCategory: qaState.transactionsAlertsCategory,
+        },
+        hasCompletedOnboarding: qaState.hasCompletedOnboarding,
+      },
+      ratings: { isRatingsModalOpen: qaState.isRatingsModalOpen },
+    } as never),
+}));
+
+jest.mock("@features/platform-feature-flags", () => ({
+  useFeature: () => qaState.brazePushNotifications,
+}));
+
+jest.mock("LLM/hooks/useNotificationsPermission", () => ({
+  useNotificationsPermission: () => ({
+    permissionStatus: qaState.permissionStatus,
+    setPermissionStatus: mockSetPermissionStatus,
+  }),
+}));
+
+jest.mock("LLM/features/NotificationsPrompt/new/NotificationsPromptProvider", () => ({
+  useNotificationsPrompt: () => ({
+    notifyFlowCompleted: mockNotifyFlowCompleted,
+    openDrawer: mockOpenDrawer,
+    isDrawerPending: mockIsDrawerPending,
+    cancelPendingDrawer: mockCancelPendingDrawer,
+    tryTriggerPushNotificationDrawerAfterInactivity: jest.fn(),
+    initPushNotificationsData: jest.fn(async () => ({})),
+  }),
+}));
+
+jest.mock("LLM/features/NotificationsPrompt/hooks/useNotificationsData", () => ({
+  useNotificationsData: () => ({
+    pushNotificationsDataOfUser: qaState.pushNotificationsDataOfUser,
+    updatePushNotificationsDataOfUserInStateAndStore: mockUpdateUserData,
+  }),
+}));
+
+describe("useNotificationsPromptQaViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsDrawerPending.mockReturnValue(false);
+    qaState.permissionStatus = AuthorizationStatus.NOT_DETERMINED;
+    qaState.areNotificationsAllowed = false;
+    qaState.transactionsAlertsCategory = false;
+    qaState.hasCompletedOnboarding = true;
+    qaState.isRatingsModalOpen = false;
+    qaState.pushNotificationsDataOfUser = undefined;
+  });
+
+  it("should report Show drawer for the first prompt scenario", () => {
+    const { result } = renderHook(() => useNotificationsPromptQaViewModel());
+    const firstPrompt = NOTIFICATIONS_QA_SCENARIOS.find(scenario => scenario.id === "first-prompt");
+
+    act(() => {
+      result.current.applyScenario(firstPrompt!);
+    });
+
+    expect(result.current.verdict).toBe("Show drawer");
+    expect(result.current.reason).toBe("Eligible now");
+    expect(result.current.forceOpenDrawerLabel).toContain(result.current.resolvedPromptTarget);
+    expect(mockCancelPendingDrawer).toHaveBeenCalled();
+  });
+
+  it("should report Skip when the already opted in scenario is applied", () => {
+    const { result } = renderHook(() => useNotificationsPromptQaViewModel());
+    const optedIn = NOTIFICATIONS_QA_SCENARIOS.find(scenario => scenario.id === "already-opted-in");
+
+    act(() => {
+      result.current.applyScenario(optedIn!);
+    });
+
+    expect(result.current.verdict).toBe("Skip");
+    expect(result.current.reason).toBe("Already opted in");
+    expect(result.current.rawReason).toBe("reason: fully_opted_in");
+  });
+
+  it("should restore captured baseline on reset", () => {
+    const { result } = renderHook(() => useNotificationsPromptQaViewModel());
+    const optedIn = NOTIFICATIONS_QA_SCENARIOS.find(scenario => scenario.id === "already-opted-in");
+
+    act(() => {
+      result.current.applyScenario(optedIn!);
+    });
+    expect(qaState.areNotificationsAllowed).toBe(true);
+
+    act(() => {
+      result.current.onResetAll();
+    });
+
+    expect(mockSetPermissionStatus).toHaveBeenCalledWith(AuthorizationStatus.NOT_DETERMINED);
+    expect(result.current.selectedSource).toBe("onboarding");
+    expect(mockCancelPendingDrawer).toHaveBeenCalled();
+  });
+
+  it("should force-open the resolved prompt target", () => {
+    const { result } = renderHook(() => useNotificationsPromptQaViewModel());
+
+    act(() => {
+      result.current.onForceOpenDrawer();
+    });
+
+    expect(mockCancelPendingDrawer).toHaveBeenCalled();
+    expect(mockOpenDrawer).toHaveBeenCalledWith(
+      "onboarding",
+      0,
+      result.current.resolvedPromptTarget,
+    );
+  });
+
+  it("should call notifyFlowCompleted for after-action production triggers", () => {
+    const { result } = renderHook(() => useNotificationsPromptQaViewModel());
+
+    act(() => {
+      result.current.setSelectedSource("send");
+    });
+    act(() => {
+      result.current.onTriggerProductionDrawer();
+    });
+
+    expect(mockNotifyFlowCompleted).toHaveBeenCalledWith("send");
+    expect(mockOpenDrawer).not.toHaveBeenCalled();
+  });
+
+  it("should open the inactivity drawer when production rules allow it", () => {
+    const { result } = renderHook(() => useNotificationsPromptQaViewModel());
+    const inactive = NOTIFICATIONS_QA_SCENARIOS.find(scenario => scenario.id === "inactive-user");
+
+    act(() => {
+      result.current.applyScenario(inactive!);
+    });
+    act(() => {
+      result.current.onTriggerProductionDrawer();
+    });
+
+    expect(result.current.verdict).toBe("Show drawer");
+    expect(mockOpenDrawer).toHaveBeenCalledWith(
+      "inactivity",
+      expect.any(Number),
+      result.current.resolvedPromptTarget,
+    );
+  });
+
+  it("should switch to inactivity after making the user inactive", () => {
+    const { result } = renderHook(() => useNotificationsPromptQaViewModel());
+
+    act(() => {
+      result.current.onMarkInactive();
+    });
+
+    expect(result.current.selectedSource).toBe("inactivity");
+  });
+
+  it("should mark after-action as eligible and keep two dismissals", () => {
+    qaState.pushNotificationsDataOfUser = {
+      dismissedOptInDrawerAtList: [1, 2, 3],
+      dismissedPromptAtListByTarget: { globalPushNotifications: [1, 2, 3] },
+      lastActionAt: Date.now(),
+    };
+    const { result } = renderHook(() => useNotificationsPromptQaViewModel());
+
+    act(() => {
+      result.current.onMarkRepromptable();
+    });
+    act(() => {
+      result.current.onKeepTwoDismissals();
+    });
+
+    expect(mockUpdateUserData).toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/__tests__/utils.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/__tests__/utils.test.ts
@@ -13,11 +13,16 @@ import {
   formatDismissalTimestamp,
   formatPermissionStatus,
   getAfterActionRepromptLabel,
+  getForceOpenDrawerLabel,
   getGlobalPushNotificationsDismissals,
   getInactivityRepromptLabel,
+  getNotificationsQaHeadline,
   mapNotificationsDecisionToQaExpectation,
   NOTIFICATIONS_PROMPT_REASON_LABEL,
   NOTIFICATIONS_QA_SCENARIOS,
+  formatDelay,
+  buildDecisionInspectorFields,
+  buildFeatureInspectorFields,
 } from "../utils";
 
 describe("NotificationsPromptQA utils", () => {
@@ -478,6 +483,83 @@ describe("NotificationsPromptQA utils", () => {
       expect(formatPermissionStatus(AuthorizationStatus.DENIED)).toBe("Denied");
       expect(formatPermissionStatus(AuthorizationStatus.NOT_DETERMINED)).toBe("Not determined");
       expect(formatPermissionStatus(undefined)).toBe("Unknown");
+    });
+
+    it("should format delay maps for QA", () => {
+      expect(formatDelay(undefined)).toBe("Not configured");
+      expect(formatDelay({ days: 0, hours: 0, minutes: 0, months: 0, seconds: 0 })).toBe(
+        "Immediately",
+      );
+      expect(formatDelay({ days: 7, hours: 0, minutes: 0, months: 0, seconds: 0 })).toBe("7 days");
+    });
+
+    it("should label force-open with the resolved prompt target", () => {
+      expect(getForceOpenDrawerLabel("globalPushNotifications")).toBe(
+        "Force open globalPushNotifications drawer — bypass rules",
+      );
+      expect(getForceOpenDrawerLabel("transactionsAlertsCategory")).toBe(
+        "Force open transactionsAlertsCategory drawer — bypass rules",
+      );
+    });
+
+    it("should map a show decision to Eligible now", () => {
+      expect(
+        getNotificationsQaHeadline({
+          kind: "show",
+          source: "send",
+          delayMs: 200,
+          drawerPromptTarget: "globalPushNotifications",
+          dismissedCount: 1,
+          nextRepromptDelay: null,
+        }),
+      ).toEqual({
+        verdict: "Show drawer",
+        reason: "Eligible now",
+        rawReason: "kind: show",
+      });
+    });
+
+    it("should put the resolved target in the drawer-target inspector raw line", () => {
+      const [triggerField, targetField] = buildDecisionInspectorFields({
+        selectedSource: "send",
+        decision: {
+          kind: "skip",
+          source: "send",
+          reason: "reprompt_delay_not_reached",
+          dismissedCount: 2,
+          nextRepromptDelay: null,
+        },
+        resolvedPromptTarget: "transactionsAlertsCategory",
+        verdictTone: "warning",
+      });
+
+      expect(triggerField).toMatchObject({
+        label: "Selected trigger",
+        value: "Send",
+        raw: "source: send",
+      });
+      expect(targetField).toMatchObject({
+        label: "Drawer target",
+        value: "transactionsAlertsCategory",
+        raw: "drawerPromptTarget: transactionsAlertsCategory · dismissedCount: 2",
+      });
+    });
+
+    it("should inspect the inactivity config when the source is inactivity", () => {
+      const fields = buildFeatureInspectorFields({
+        selectedSource: "inactivity",
+        brazePushNotifications,
+        afterActionRepromptLabel: "now (eligible)",
+        inactivityRepromptLabel: "in 6 days",
+      });
+
+      expect(fields.map(field => field.label)).toEqual([
+        "Braze notifications prompt",
+        "Inactivity prompt",
+        "After-action reprompt",
+        "Inactivity reprompt",
+      ]);
+      expect(fields[1]?.raw).toContain("inactivity_reprompt:");
     });
   });
 });

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/__tests__/utils.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/__tests__/utils.test.ts
@@ -1,12 +1,23 @@
 import { add, sub } from "date-fns";
+import { AuthorizationStatus } from "@react-native-firebase/messaging";
+import type { Features } from "@shared/feature-flags";
+import {
+  evaluateAfterActionTrigger,
+  evaluateInactivityTrigger,
+} from "LLM/features/NotificationsPrompt";
 import {
   buildInactiveUserData,
+  buildNotificationsQaScenarioUserData,
   buildRepromptableUserData,
   buildTruncatedDismissalsUserData,
   formatDismissalTimestamp,
+  formatPermissionStatus,
   getAfterActionRepromptLabel,
   getGlobalPushNotificationsDismissals,
   getInactivityRepromptLabel,
+  mapNotificationsDecisionToQaExpectation,
+  NOTIFICATIONS_PROMPT_REASON_LABEL,
+  NOTIFICATIONS_QA_SCENARIOS,
 } from "../utils";
 
 describe("NotificationsPromptQA utils", () => {
@@ -17,7 +28,13 @@ describe("NotificationsPromptQA utils", () => {
     expect(
       getInactivityRepromptLabel({
         lastActionAt: now,
-        inactivityReprompt: { months: 0, days: 3, hours: 0, minutes: 0, seconds: 0 },
+        inactivityReprompt: {
+          months: 0,
+          days: 3,
+          hours: 0,
+          minutes: 0,
+          seconds: 0,
+        },
         inactivityEnabled: true,
         now,
       }),
@@ -25,7 +42,13 @@ describe("NotificationsPromptQA utils", () => {
     expect(
       getInactivityRepromptLabel({
         lastActionAt: now,
-        inactivityReprompt: { months: 0, days: 1, hours: 0, minutes: 0, seconds: 0 },
+        inactivityReprompt: {
+          months: 0,
+          days: 1,
+          hours: 0,
+          minutes: 0,
+          seconds: 0,
+        },
         inactivityEnabled: true,
         now,
       }),
@@ -33,7 +56,13 @@ describe("NotificationsPromptQA utils", () => {
     expect(
       getInactivityRepromptLabel({
         lastActionAt: now - 1,
-        inactivityReprompt: { months: 0, days: 0, hours: 0, minutes: 0, seconds: 0 },
+        inactivityReprompt: {
+          months: 0,
+          days: 0,
+          hours: 0,
+          minutes: 0,
+          seconds: 0,
+        },
         inactivityEnabled: true,
         now,
       }),
@@ -54,7 +83,13 @@ describe("NotificationsPromptQA utils", () => {
     expect(
       getInactivityRepromptLabel({
         lastActionAt: evening,
-        inactivityReprompt: { months: 0, days: 0, hours: 0, minutes: 30, seconds: 0 },
+        inactivityReprompt: {
+          months: 0,
+          days: 0,
+          hours: 0,
+          minutes: 30,
+          seconds: 0,
+        },
         inactivityEnabled: true,
         now: evening,
       }),
@@ -107,7 +142,13 @@ describe("NotificationsPromptQA utils", () => {
     expect(
       getInactivityRepromptLabel({
         lastActionAt: add(now, { days: -1 }).getTime(),
-        inactivityReprompt: { months: 0, days: 2, hours: 0, minutes: 0, seconds: 0 },
+        inactivityReprompt: {
+          months: 0,
+          days: 2,
+          hours: 0,
+          minutes: 0,
+          seconds: 0,
+        },
         inactivityEnabled: true,
         now,
       }),
@@ -119,7 +160,9 @@ describe("NotificationsPromptQA utils", () => {
     const legacyDismissals = [add(now, { days: -30 }).getTime()];
     const userData = {
       dismissedOptInDrawerAtList: legacyDismissals,
-      dismissedPromptAtListByTarget: { globalPushNotifications: migratedDismissals },
+      dismissedPromptAtListByTarget: {
+        globalPushNotifications: migratedDismissals,
+      },
     };
 
     expect(getGlobalPushNotificationsDismissals(userData)).toEqual(migratedDismissals);
@@ -266,7 +309,9 @@ describe("NotificationsPromptQA utils", () => {
       const result = buildTruncatedDismissalsUserData(
         {
           dismissedOptInDrawerAtList: legacyDismissals,
-          dismissedPromptAtListByTarget: { globalPushNotifications: migratedDismissals },
+          dismissedPromptAtListByTarget: {
+            globalPushNotifications: migratedDismissals,
+          },
         },
         2,
       );
@@ -308,7 +353,13 @@ describe("NotificationsPromptQA utils", () => {
   });
 
   it("should build inactive user data that satisfies checkIsInactive", () => {
-    const inactivityReprompt = { months: 0, days: 2, hours: 0, minutes: 0, seconds: 0 };
+    const inactivityReprompt = {
+      months: 0,
+      days: 2,
+      hours: 0,
+      minutes: 0,
+      seconds: 0,
+    };
     const result = buildInactiveUserData(undefined, inactivityReprompt, now);
 
     expect(result.lastActionAt).toBe(sub(now, inactivityReprompt).getTime());
@@ -323,5 +374,110 @@ describe("NotificationsPromptQA utils", () => {
         now,
       }),
     ).toBe("now (eligible)");
+  });
+
+  describe("QA scenarios", () => {
+    type BrazePushNotifications = Features["brazePushNotifications"];
+
+    const brazePushNotifications = {
+      enabled: true,
+      params: {
+        reprompt_schedule: repromptSchedule,
+        action_events: {
+          complete_onboarding: { enabled: true, timer: 100 },
+          send: { enabled: true, timer: 200 },
+          dapp_complete: { enabled: true, timer: 200 },
+          receive: { enabled: true, timer: 300 },
+          buy: { enabled: true, timer: 400 },
+          swap: { enabled: true, timer: 500 },
+          stake: { enabled: true, timer: 600 },
+          add_favorite_coin: { enabled: true, timer: 700 },
+        },
+        inactivity_enabled: true,
+        inactivity_reprompt: {
+          months: 6,
+          days: 0,
+          hours: 0,
+          minutes: 0,
+          seconds: 0,
+        },
+        notificationsCategories: [],
+      },
+    } as BrazePushNotifications;
+
+    it.each(NOTIFICATIONS_QA_SCENARIOS)("should resolve $name to $expected", scenario => {
+      const pushNotificationsDataOfUser = buildNotificationsQaScenarioUserData(scenario, {
+        repromptSchedule,
+        inactivityReprompt: brazePushNotifications.params?.inactivity_reprompt,
+        now,
+      });
+      const context = {
+        brazePushNotifications,
+        isRatingsModalOpen: false,
+        isDrawerPending: false,
+        now,
+      };
+      const decision =
+        scenario.source === "inactivity"
+          ? evaluateInactivityTrigger(
+              {
+                permissionStatus: scenario.permissionStatus,
+                areNotificationsAllowed: scenario.areNotificationsAllowed,
+                pushNotificationsDataOfUser,
+                hasCompletedOnboarding: scenario.hasCompletedOnboarding,
+              },
+              context,
+            )
+          : evaluateAfterActionTrigger(
+              {
+                source: scenario.source,
+                permissionStatus: scenario.permissionStatus,
+                areNotificationsAllowed: scenario.areNotificationsAllowed,
+                transactionsAlertsCategory: scenario.transactionsAlertsCategory,
+                pushNotificationsDataOfUser,
+              },
+              context,
+            );
+
+      expect(mapNotificationsDecisionToQaExpectation(decision)).toBe(scenario.expected);
+    });
+
+    it("should map runtime and configuration gates to Blocked", () => {
+      const decision = evaluateAfterActionTrigger(
+        {
+          source: "send",
+          permissionStatus: AuthorizationStatus.DENIED,
+          areNotificationsAllowed: false,
+          transactionsAlertsCategory: false,
+          pushNotificationsDataOfUser: {},
+        },
+        {
+          brazePushNotifications: { ...brazePushNotifications, enabled: false },
+          isRatingsModalOpen: false,
+          isDrawerPending: false,
+          now,
+        },
+      );
+
+      expect(mapNotificationsDecisionToQaExpectation(decision)).toBe("Blocked");
+      expect(decision).toMatchObject({
+        kind: "skip",
+        reason: "feature_disabled",
+      });
+    });
+
+    it("should expose a readable label for every skip reason", () => {
+      expect(Object.values(NOTIFICATIONS_PROMPT_REASON_LABEL)).toHaveLength(11);
+      Object.values(NOTIFICATIONS_PROMPT_REASON_LABEL).forEach(label => {
+        expect(label).not.toMatch(/^[a-z]+(?:_[a-z]+)+$/);
+      });
+    });
+
+    it("should format OS permission statuses with human labels", () => {
+      expect(formatPermissionStatus(AuthorizationStatus.AUTHORIZED)).toBe("Authorized");
+      expect(formatPermissionStatus(AuthorizationStatus.DENIED)).toBe("Denied");
+      expect(formatPermissionStatus(AuthorizationStatus.NOT_DETERMINED)).toBe("Not determined");
+      expect(formatPermissionStatus(undefined)).toBe("Unknown");
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/index.tsx
@@ -11,6 +11,7 @@ import {
 } from "@ledgerhq/lumen-ui-rnative";
 import type { NotificationPromptTarget } from "LLM/features/NotificationsPrompt";
 import { NotificationsPromptDrawerView } from "LLM/features/NotificationsPrompt/screens/NotificationsPromptDrawerView";
+import { QaInspectorRow } from "LLM/components/QaInspectorRow";
 import QueuedDrawer from "~/components/QueuedDrawer";
 import { TrackScreen } from "~/analytics";
 import SettingsNavigationScrollView from "../../SettingsNavigationScrollView";
@@ -32,44 +33,6 @@ function confirm(title: string, message: string, confirmLabel: string, onConfirm
     { text: "Cancel", style: "cancel" },
     { text: confirmLabel, onPress: onConfirm },
   ]);
-}
-
-function InspectorRow({ field }: Readonly<{ field: NotificationsQaInspectorField }>) {
-  return (
-    <Box
-      lx={{
-        paddingHorizontal: "s8",
-        paddingVertical: "s12",
-        borderRadius: "sm",
-        marginBottom: "s8",
-        gap: "s8",
-        borderWidth: "s1",
-        borderColor: "muted",
-      }}
-    >
-      <Box
-        lx={{
-          flexDirection: "row",
-          alignItems: "center",
-          justifyContent: "space-between",
-          gap: "s8",
-        }}
-      >
-        <Text typography="body2SemiBold" lx={{ color: "base", flex: 1 }}>
-          {field.label}
-        </Text>
-        <Tag label={field.status.label} size="sm" appearance={field.status.tone} />
-      </Box>
-      <Text typography="body2SemiBold" lx={{ color: "base" }} selectable>
-        {field.value}
-      </Text>
-      {field.raw ? (
-        <Text typography="body3" lx={{ color: "muted" }} selectable>
-          {field.raw}
-        </Text>
-      ) : null}
-    </Box>
-  );
 }
 
 function ScenariosTab({
@@ -228,7 +191,7 @@ function InspectTab({
         Current user and device state
       </Text>
       {userStateFields.map(field => (
-        <InspectorRow key={field.label} field={field} />
+        <QaInspectorRow key={field.label} field={field} />
       ))}
 
       <Text
@@ -238,7 +201,7 @@ function InspectTab({
         Production decision
       </Text>
       {decisionFields.map(field => (
-        <InspectorRow key={field.label} field={field} />
+        <QaInspectorRow key={field.label} field={field} />
       ))}
 
       <Text
@@ -248,7 +211,7 @@ function InspectTab({
         Feature configuration
       </Text>
       {featureFields.map(field => (
-        <InspectorRow key={field.label} field={field} />
+        <QaInspectorRow key={field.label} field={field} />
       ))}
     </Box>
   );

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/index.tsx
@@ -1,6 +1,5 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useState } from "react";
 import { Alert, TouchableOpacity } from "react-native";
-import { AuthorizationStatus } from "@react-native-firebase/messaging";
 import {
   Box,
   Button,
@@ -10,81 +9,23 @@ import {
   Tag,
   Text,
 } from "@ledgerhq/lumen-ui-rnative";
-import { useFeature } from "@features/platform-feature-flags";
-import { setOverride } from "@shared/feature-flags";
-import {
-  evaluateAfterActionTrigger,
-  evaluateInactivityTrigger,
-  getNotificationPromptTarget,
-  type AfterActionTriggerDecision,
-  type InactivityTriggerDecision,
-  type NotificationPromptTarget,
-  useNotificationsPrompt,
-  useNotificationsData,
-} from "LLM/features/NotificationsPrompt";
+import type { NotificationPromptTarget } from "LLM/features/NotificationsPrompt";
 import { NotificationsPromptDrawerView } from "LLM/features/NotificationsPrompt/screens/NotificationsPromptDrawerView";
-import { useNotificationsPermission } from "LLM/hooks/useNotificationsPermission";
 import QueuedDrawer from "~/components/QueuedDrawer";
 import { TrackScreen } from "~/analytics";
-import { useDispatch, useSelector } from "~/context/hooks";
-import {
-  setNotificationsDrawerPromptTarget,
-  setNotificationsDrawerSource,
-  setNotificationsModalOpen,
-} from "~/actions/notifications";
-import { completeOnboarding, setNotifications } from "~/actions/settings";
-import { ratingsModalOpenSelector } from "~/reducers/ratings";
-import { hasCompletedOnboardingSelector, notificationsSelector } from "~/reducers/settings";
 import SettingsNavigationScrollView from "../../SettingsNavigationScrollView";
+import { useNotificationsPromptQaViewModel } from "./useNotificationsPromptQaViewModel";
 import {
-  buildInactiveUserData,
-  buildNotificationsQaScenarioUserData,
-  buildRepromptableUserData,
-  buildTruncatedDismissalsUserData,
-  formatDismissalTimestamp,
-  formatPermissionStatus,
-  getAfterActionRepromptLabel,
-  getGlobalPushNotificationsDismissals,
-  getInactivityRepromptLabel,
-  mapNotificationsDecisionToQaExpectation,
-  NOTIFICATIONS_PROMPT_REASON_LABEL,
   NOTIFICATIONS_QA_GROUPS,
   NOTIFICATIONS_QA_SCENARIOS,
   NOTIFICATIONS_QA_VERDICT_META,
+  SOURCE_LABEL,
+  TRIGGER_SOURCES,
+  type NotificationsQaInspectorField,
   type NotificationsQaScenario,
-  type NotificationsQaTriggerSource,
 } from "./utils";
 
-const TRIGGER_SOURCES: NotificationsQaTriggerSource[] = [
-  "onboarding",
-  "send",
-  "receive",
-  "swap",
-  "stake",
-  "add_favorite_coin",
-  "inactivity",
-];
-
-const SOURCE_LABEL: Record<NotificationsQaTriggerSource, string> = {
-  onboarding: "Onboarding",
-  send: "Send",
-  receive: "Receive",
-  swap: "Swap",
-  stake: "Stake",
-  add_favorite_coin: "Add favourite coin",
-  dapp_complete: "DApp complete",
-  inactivity: "Inactivity",
-};
-
 type TabId = "scenarios" | "inspect";
-type FieldTone = "success" | "error" | "warning" | "gray";
-
-type InspectorField = {
-  label: string;
-  value: string;
-  raw?: string;
-  status: { label: string; tone: FieldTone };
-};
 
 function confirm(title: string, message: string, confirmLabel: string, onConfirm: () => void) {
   Alert.alert(title, message, [
@@ -93,16 +34,7 @@ function confirm(title: string, message: string, confirmLabel: string, onConfirm
   ]);
 }
 
-function formatDelay(delay: Record<string, number> | null | undefined): string {
-  if (!delay) return "Not configured";
-
-  const parts = Object.entries(delay)
-    .filter(([, value]) => value > 0)
-    .map(([unit, value]) => `${value} ${unit}`);
-  return parts.length > 0 ? parts.join(", ") : "Immediately";
-}
-
-function InspectorRow({ field }: Readonly<{ field: InspectorField }>) {
+function InspectorRow({ field }: Readonly<{ field: NotificationsQaInspectorField }>) {
   return (
     <Box
       lx={{
@@ -140,359 +72,216 @@ function InspectorRow({ field }: Readonly<{ field: InspectorField }>) {
   );
 }
 
+function ScenariosTab({
+  selectedSource,
+  forceOpenDrawerLabel,
+  onSelectSource,
+  onApplyScenario,
+  onTriggerProductionDrawer,
+  onForceOpenDrawer,
+  onMarkInactive,
+  onMarkRepromptable,
+  onKeepTwoDismissals,
+}: Readonly<{
+  selectedSource: ReturnType<typeof useNotificationsPromptQaViewModel>["selectedSource"];
+  forceOpenDrawerLabel: string;
+  onSelectSource: ReturnType<typeof useNotificationsPromptQaViewModel>["setSelectedSource"];
+  onApplyScenario: (scenario: NotificationsQaScenario) => void;
+  onTriggerProductionDrawer: () => void;
+  onForceOpenDrawer: () => void;
+  onMarkInactive: () => void;
+  onMarkRepromptable: () => void;
+  onKeepTwoDismissals: () => void;
+}>) {
+  return (
+    <Box>
+      {NOTIFICATIONS_QA_GROUPS.map((expectation, index) => {
+        const meta = NOTIFICATIONS_QA_VERDICT_META[expectation];
+        const scenarios = NOTIFICATIONS_QA_SCENARIOS.filter(
+          scenario => scenario.expected === expectation,
+        );
+        if (scenarios.length === 0) return null;
+
+        return (
+          <Box key={expectation}>
+            <Box
+              lx={{
+                flexDirection: "row",
+                alignItems: "center",
+                gap: "s8",
+                marginTop: index === 0 ? undefined : "s16",
+                marginBottom: "s8",
+              }}
+            >
+              <Tag label={expectation} size="sm" appearance={meta.tone} />
+              <Text typography="body3" lx={{ color: "muted", flex: 1 }}>
+                {meta.hint}
+              </Text>
+            </Box>
+            <Box lx={{ flexDirection: "row", flexWrap: "wrap", gap: "s8" }}>
+              {scenarios.map(scenario => (
+                <TouchableOpacity
+                  key={scenario.id}
+                  activeOpacity={0.7}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Apply ${scenario.name} scenario`}
+                  style={{ flexBasis: "47%", flexGrow: 1 }}
+                  onPress={() =>
+                    confirm(
+                      scenario.name,
+                      `${scenario.summary}\n\nExpected: ${scenario.expected}.`,
+                      "Apply",
+                      () => onApplyScenario(scenario),
+                    )
+                  }
+                >
+                  <Box
+                    lx={{
+                      gap: "s8",
+                      padding: "s12",
+                      borderRadius: "sm",
+                      borderWidth: "s1",
+                      borderColor: "muted",
+                      backgroundColor: "baseTransparent",
+                    }}
+                  >
+                    <Tag label={scenario.expected} size="sm" appearance={meta.tone} />
+                    <Text typography="body2SemiBold" lx={{ color: "base" }}>
+                      {scenario.name}
+                    </Text>
+                    <Text typography="body3" lx={{ color: "muted" }}>
+                      {scenario.summary}
+                    </Text>
+                  </Box>
+                </TouchableOpacity>
+              ))}
+            </Box>
+          </Box>
+        );
+      })}
+
+      <Text
+        typography="body3SemiBold"
+        lx={{ color: "muted", marginTop: "s16", marginBottom: "s8" }}
+      >
+        Trigger source
+      </Text>
+      <Box lx={{ flexDirection: "row", flexWrap: "wrap", gap: "s8" }}>
+        {TRIGGER_SOURCES.map(source => (
+          <Button
+            key={source}
+            size="sm"
+            appearance={selectedSource === source ? "accent" : "base"}
+            onPress={() => onSelectSource(source)}
+          >
+            {SOURCE_LABEL[source]}
+          </Button>
+        ))}
+      </Box>
+
+      <Box lx={{ gap: "s8", marginTop: "s16" }}>
+        <Button appearance="accent" onPress={onTriggerProductionDrawer}>
+          Trigger drawer with production rules
+        </Button>
+        <Button appearance="base" onPress={onForceOpenDrawer}>
+          {forceOpenDrawerLabel}
+        </Button>
+        <Text typography="body3" lx={{ color: "muted" }}>
+          The production trigger uses the real engine and configured delay. Force open bypasses
+          eligibility and runs the real drawer handlers.
+        </Text>
+      </Box>
+
+      <Text
+        typography="body3SemiBold"
+        lx={{ color: "muted", marginTop: "s16", marginBottom: "s8" }}
+      >
+        Advanced state actions
+      </Text>
+      <Box lx={{ gap: "s8" }}>
+        <Button appearance="base" size="sm" onPress={onMarkInactive}>
+          Make inactivity eligible
+        </Button>
+        <Button appearance="base" size="sm" onPress={onMarkRepromptable}>
+          Make after-action eligible
+        </Button>
+        <Button appearance="base" size="sm" onPress={onKeepTwoDismissals}>
+          Keep only first two dismissals
+        </Button>
+      </Box>
+    </Box>
+  );
+}
+
+function InspectTab({
+  userStateFields,
+  decisionFields,
+  featureFields,
+}: Readonly<{
+  userStateFields: NotificationsQaInspectorField[];
+  decisionFields: NotificationsQaInspectorField[];
+  featureFields: NotificationsQaInspectorField[];
+}>) {
+  return (
+    <Box>
+      <Text typography="body3SemiBold" lx={{ color: "muted", marginBottom: "s4" }}>
+        Current user and device state
+      </Text>
+      {userStateFields.map(field => (
+        <InspectorRow key={field.label} field={field} />
+      ))}
+
+      <Text
+        typography="body3SemiBold"
+        lx={{ color: "muted", marginTop: "s16", marginBottom: "s4" }}
+      >
+        Production decision
+      </Text>
+      {decisionFields.map(field => (
+        <InspectorRow key={field.label} field={field} />
+      ))}
+
+      <Text
+        typography="body3SemiBold"
+        lx={{ color: "muted", marginTop: "s16", marginBottom: "s4" }}
+      >
+        Feature configuration
+      </Text>
+      {featureFields.map(field => (
+        <InspectorRow key={field.label} field={field} />
+      ))}
+    </Box>
+  );
+}
+
 export default function DebugNotificationsPromptQA() {
-  const dispatch = useDispatch();
+  const {
+    selectedSource,
+    setSelectedSource,
+    isBaselineCaptured,
+    verdict,
+    verdictMeta,
+    reason,
+    rawReason,
+    resolvedPromptTarget,
+    forceOpenDrawerLabel,
+    decision,
+    sourceLabel,
+    applyScenario,
+    onResetAll,
+    onTriggerProductionDrawer,
+    onForceOpenDrawer,
+    onMarkInactive,
+    onMarkRepromptable,
+    onKeepTwoDismissals,
+    userStateFields,
+    decisionFields,
+    featureFields,
+  } = useNotificationsPromptQaViewModel();
   const [tab, setTab] = useState<TabId>("scenarios");
-  const [selectedSource, setSelectedSource] = useState<NotificationsQaTriggerSource>("onboarding");
   const [isPreviewOpen, setPreviewOpen] = useState(false);
   const [previewTarget, setPreviewTarget] =
     useState<NotificationPromptTarget>("globalPushNotifications");
-  const [hasSimulatedPermission, setHasSimulatedPermission] = useState(false);
-  const [evaluationNow, setEvaluationNow] = useState(() => Date.now());
-  const [isBaselineCaptured, setBaselineCaptured] = useState(false);
-
-  const brazePushNotifications = useFeature("brazePushNotifications");
-  const notifications = useSelector(notificationsSelector);
-  const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
-  const isRatingsModalOpen = useSelector(ratingsModalOpenSelector);
-  const { permissionStatus, setPermissionStatus } = useNotificationsPermission();
-  const { pushNotificationsDataOfUser, updatePushNotificationsDataOfUserInStateAndStore } =
-    useNotificationsData();
-  const { notifyFlowCompleted, openDrawer, isDrawerPending, cancelPendingDrawer } =
-    useNotificationsPrompt();
-
-  const initialStateRef = useRef<{
-    permissionStatus: NonNullable<typeof permissionStatus>;
-    notifications: typeof notifications;
-    hasCompletedOnboarding: boolean;
-    pushNotificationsDataOfUser: typeof pushNotificationsDataOfUser;
-  } | null>(null);
-
-  useEffect(() => {
-    if (
-      initialStateRef.current === null &&
-      permissionStatus !== null &&
-      permissionStatus !== undefined
-    ) {
-      initialStateRef.current = {
-        permissionStatus,
-        notifications,
-        hasCompletedOnboarding,
-        pushNotificationsDataOfUser,
-      };
-      setBaselineCaptured(true);
-    }
-  }, [hasCompletedOnboarding, notifications, permissionStatus, pushNotificationsDataOfUser]);
-
-  const globalDismissals = useMemo(
-    () => getGlobalPushNotificationsDismissals(pushNotificationsDataOfUser),
-    [pushNotificationsDataOfUser],
-  );
-
-  const decision = useMemo<AfterActionTriggerDecision | InactivityTriggerDecision>(() => {
-    const context = {
-      brazePushNotifications,
-      isRatingsModalOpen,
-      isDrawerPending: isDrawerPending(),
-      now: evaluationNow,
-    };
-
-    if (selectedSource === "inactivity") {
-      return evaluateInactivityTrigger(
-        {
-          permissionStatus,
-          areNotificationsAllowed: notifications.areNotificationsAllowed,
-          pushNotificationsDataOfUser,
-          hasCompletedOnboarding,
-        },
-        context,
-      );
-    }
-
-    return evaluateAfterActionTrigger(
-      {
-        source: selectedSource,
-        permissionStatus,
-        areNotificationsAllowed: notifications.areNotificationsAllowed,
-        transactionsAlertsCategory: notifications.transactionsAlertsCategory,
-        pushNotificationsDataOfUser,
-      },
-      context,
-    );
-  }, [
-    brazePushNotifications,
-    evaluationNow,
-    hasCompletedOnboarding,
-    isDrawerPending,
-    isRatingsModalOpen,
-    notifications.areNotificationsAllowed,
-    notifications.transactionsAlertsCategory,
-    permissionStatus,
-    pushNotificationsDataOfUser,
-    selectedSource,
-  ]);
-
-  const verdict = mapNotificationsDecisionToQaExpectation(decision);
-  const verdictMeta = NOTIFICATIONS_QA_VERDICT_META[verdict];
-  const reason =
-    decision.kind === "show" ? "Eligible now" : NOTIFICATIONS_PROMPT_REASON_LABEL[decision.reason];
-  const rawReason = decision.kind === "show" ? "kind: show" : `reason: ${decision.reason}`;
-  const resolvedPromptTarget =
-    decision.kind === "show"
-      ? decision.drawerPromptTarget
-      : (getNotificationPromptTarget({
-          permissionStatus,
-          areNotificationsAllowed: notifications.areNotificationsAllowed,
-          transactionsAlertsCategory: notifications.transactionsAlertsCategory,
-        }) ?? "globalPushNotifications");
-
-  const selectedActionEvent = (() => {
-    if (selectedSource === "inactivity") return undefined;
-    const actionEventKey = selectedSource === "onboarding" ? "complete_onboarding" : selectedSource;
-    return brazePushNotifications?.params?.action_events?.[actionEventKey];
-  })();
-  const afterActionRepromptLabel = getAfterActionRepromptLabel({
-    dismissedOptInDrawerAtList: globalDismissals,
-    repromptSchedule: brazePushNotifications?.params?.reprompt_schedule,
-    now: evaluationNow,
-  });
-  const inactivityRepromptLabel = getInactivityRepromptLabel({
-    lastActionAt: pushNotificationsDataOfUser?.lastActionAt,
-    inactivityReprompt: brazePushNotifications?.params?.inactivity_reprompt,
-    inactivityEnabled: brazePushNotifications?.params?.inactivity_enabled,
-    now: evaluationNow,
-  });
-
-  const applyScenario = useCallback(
-    (scenario: NotificationsQaScenario) => {
-      const now = Date.now();
-      const userData = buildNotificationsQaScenarioUserData(scenario, {
-        repromptSchedule: brazePushNotifications?.params?.reprompt_schedule,
-        inactivityReprompt: brazePushNotifications?.params?.inactivity_reprompt,
-        now,
-      });
-
-      dispatch(
-        setOverride({
-          key: "brazePushNotifications",
-          value: {
-            ...brazePushNotifications,
-            enabled: true,
-            params: brazePushNotifications?.params ?? {},
-          },
-        }),
-      );
-      cancelPendingDrawer();
-      dispatch(setNotificationsModalOpen(false));
-      dispatch(setNotificationsDrawerSource(undefined));
-      dispatch(setNotificationsDrawerPromptTarget(undefined));
-      setPermissionStatus(scenario.permissionStatus);
-      setHasSimulatedPermission(true);
-      dispatch(
-        setNotifications({
-          ...notifications,
-          areNotificationsAllowed: scenario.areNotificationsAllowed,
-          transactionsAlertsCategory: scenario.transactionsAlertsCategory,
-        }),
-      );
-      dispatch(completeOnboarding(scenario.hasCompletedOnboarding));
-      updatePushNotificationsDataOfUserInStateAndStore(userData);
-      setSelectedSource(scenario.source);
-      setPreviewOpen(false);
-      setEvaluationNow(now);
-    },
-    [
-      brazePushNotifications,
-      cancelPendingDrawer,
-      dispatch,
-      notifications,
-      setPermissionStatus,
-      updatePushNotificationsDataOfUserInStateAndStore,
-    ],
-  );
-
-  const onResetAll = useCallback(() => {
-    const initialState = initialStateRef.current;
-    cancelPendingDrawer();
-    dispatch(setOverride({ key: "brazePushNotifications", value: undefined }));
-    if (initialState) {
-      updatePushNotificationsDataOfUserInStateAndStore(
-        initialState.pushNotificationsDataOfUser ?? {},
-      );
-      dispatch(setNotifications(initialState.notifications));
-      dispatch(completeOnboarding(initialState.hasCompletedOnboarding));
-      setPermissionStatus(initialState.permissionStatus);
-    }
-    dispatch(setNotificationsModalOpen(false));
-    dispatch(setNotificationsDrawerSource(undefined));
-    dispatch(setNotificationsDrawerPromptTarget(undefined));
-    setSelectedSource("onboarding");
-    setPreviewOpen(false);
-    setHasSimulatedPermission(false);
-    setEvaluationNow(Date.now());
-  }, [
-    cancelPendingDrawer,
-    dispatch,
-    setPermissionStatus,
-    updatePushNotificationsDataOfUserInStateAndStore,
-  ]);
-
-  const onPreviewDrawer = useCallback(() => {
-    setPreviewTarget(resolvedPromptTarget);
-    setPreviewOpen(true);
-  }, [resolvedPromptTarget]);
-
-  const onTriggerProductionDrawer = useCallback(() => {
-    setPreviewOpen(false);
-    cancelPendingDrawer();
-    const now = Date.now();
-    setEvaluationNow(now);
-
-    if (selectedSource === "inactivity") {
-      const inactivityDecision = evaluateInactivityTrigger(
-        {
-          permissionStatus,
-          areNotificationsAllowed: notifications.areNotificationsAllowed,
-          pushNotificationsDataOfUser,
-          hasCompletedOnboarding,
-        },
-        {
-          brazePushNotifications,
-          isRatingsModalOpen,
-          isDrawerPending: isDrawerPending(),
-          now,
-        },
-      );
-      if (inactivityDecision.kind === "show") {
-        openDrawer(
-          inactivityDecision.source,
-          inactivityDecision.delayMs,
-          inactivityDecision.drawerPromptTarget,
-        );
-      }
-      return;
-    }
-    notifyFlowCompleted(selectedSource);
-  }, [
-    brazePushNotifications,
-    cancelPendingDrawer,
-    hasCompletedOnboarding,
-    isDrawerPending,
-    isRatingsModalOpen,
-    notifyFlowCompleted,
-    notifications.areNotificationsAllowed,
-    openDrawer,
-    permissionStatus,
-    pushNotificationsDataOfUser,
-    selectedSource,
-  ]);
-
-  const onForceOpenDrawer = useCallback(() => {
-    setPreviewOpen(false);
-    cancelPendingDrawer();
-    const source = selectedSource === "inactivity" ? "inactivity" : selectedSource;
-    openDrawer(source, 0, resolvedPromptTarget);
-  }, [cancelPendingDrawer, openDrawer, resolvedPromptTarget, selectedSource]);
-
-  const onMarkInactive = useCallback(() => {
-    const now = Date.now();
-    updatePushNotificationsDataOfUserInStateAndStore(
-      buildInactiveUserData(
-        pushNotificationsDataOfUser,
-        brazePushNotifications?.params?.inactivity_reprompt,
-        now,
-      ),
-    );
-    setSelectedSource("inactivity");
-    setEvaluationNow(now);
-  }, [
-    brazePushNotifications?.params?.inactivity_reprompt,
-    pushNotificationsDataOfUser,
-    updatePushNotificationsDataOfUserInStateAndStore,
-  ]);
-
-  const onMarkRepromptable = useCallback(() => {
-    const now = Date.now();
-    updatePushNotificationsDataOfUserInStateAndStore(
-      buildRepromptableUserData(
-        pushNotificationsDataOfUser,
-        brazePushNotifications?.params?.reprompt_schedule,
-        now,
-      ),
-    );
-    setEvaluationNow(now);
-  }, [
-    brazePushNotifications?.params?.reprompt_schedule,
-    pushNotificationsDataOfUser,
-    updatePushNotificationsDataOfUserInStateAndStore,
-  ]);
-
-  const onKeepTwoDismissals = useCallback(() => {
-    updatePushNotificationsDataOfUserInStateAndStore(
-      buildTruncatedDismissalsUserData(pushNotificationsDataOfUser, 2),
-    );
-  }, [pushNotificationsDataOfUser, updatePushNotificationsDataOfUserInStateAndStore]);
-
-  const inspectorFields: InspectorField[] = [
-    {
-      label: "OS notification permission",
-      value: formatPermissionStatus(permissionStatus),
-      raw: `permissionStatus: ${String(permissionStatus)}${
-        hasSimulatedPermission ? " · simulated until app foreground sync" : ""
-      }`,
-      status: {
-        label: permissionStatus === AuthorizationStatus.AUTHORIZED ? "On" : "Off",
-        tone: permissionStatus === AuthorizationStatus.AUTHORIZED ? "success" : "gray",
-      },
-    },
-    {
-      label: "App notifications",
-      value: notifications.areNotificationsAllowed ? "Enabled" : "Disabled",
-      raw: `areNotificationsAllowed: ${String(notifications.areNotificationsAllowed)}`,
-      status: {
-        label: notifications.areNotificationsAllowed ? "On" : "Off",
-        tone: notifications.areNotificationsAllowed ? "success" : "gray",
-      },
-    },
-    {
-      label: "Transaction alerts",
-      value: notifications.transactionsAlertsCategory ? "Enabled" : "Disabled",
-      raw: `transactionsAlertsCategory: ${String(notifications.transactionsAlertsCategory)}`,
-      status: {
-        label: notifications.transactionsAlertsCategory ? "On" : "Off",
-        tone: notifications.transactionsAlertsCategory ? "success" : "gray",
-      },
-    },
-    {
-      label: "Onboarding",
-      value: hasCompletedOnboarding ? "Complete" : "Incomplete",
-      raw: `hasCompletedOnboarding: ${String(hasCompletedOnboarding)}`,
-      status: {
-        label: hasCompletedOnboarding ? "Ready" : "Blocked",
-        tone: hasCompletedOnboarding ? "success" : "error",
-      },
-    },
-    {
-      label: "Stored dismissals",
-      value: `${globalDismissals?.length ?? 0} dismissal(s)`,
-      raw: `globalPushNotifications: ${JSON.stringify(globalDismissals ?? [])}`,
-      status: {
-        label: globalDismissals?.length ? "Saved" : "Empty",
-        tone: "gray",
-      },
-    },
-    {
-      label: "Last activity",
-      value: pushNotificationsDataOfUser?.lastActionAt
-        ? formatDismissalTimestamp(pushNotificationsDataOfUser.lastActionAt).local
-        : "Missing",
-      raw: `lastActionAt: ${String(pushNotificationsDataOfUser?.lastActionAt)}`,
-      status: {
-        label: pushNotificationsDataOfUser?.lastActionAt ? "Saved" : "Missing",
-        tone: "gray",
-      },
-    },
-  ];
 
   return (
     <Box lx={{ flex: 1 }}>
@@ -557,7 +346,7 @@ export default function DebugNotificationsPromptQA() {
                   Evaluation
                 </Text>
                 <Text typography="body2SemiBold" lx={{ color: "base" }}>
-                  {SOURCE_LABEL[selectedSource]} · {resolvedPromptTarget}
+                  {sourceLabel} · {resolvedPromptTarget}
                 </Text>
                 <Text typography="body3" lx={{ color: "muted" }}>
                   {decision.kind === "show"
@@ -570,7 +359,14 @@ export default function DebugNotificationsPromptQA() {
             <Divider />
 
             <Box lx={{ gap: "s8" }}>
-              <Button appearance="accent" size="sm" onPress={onPreviewDrawer}>
+              <Button
+                appearance="accent"
+                size="sm"
+                onPress={() => {
+                  setPreviewTarget(resolvedPromptTarget);
+                  setPreviewOpen(true);
+                }}
+              >
                 Preview drawer
               </Button>
               <Text typography="body3" lx={{ color: "muted" }}>
@@ -609,232 +405,29 @@ export default function DebugNotificationsPromptQA() {
           </Box>
 
           {tab === "scenarios" ? (
-            <Box>
-              {NOTIFICATIONS_QA_GROUPS.map((expectation, index) => {
-                const meta = NOTIFICATIONS_QA_VERDICT_META[expectation];
-                const scenarios = NOTIFICATIONS_QA_SCENARIOS.filter(
-                  scenario => scenario.expected === expectation,
-                );
-                if (scenarios.length === 0) return null;
-
-                return (
-                  <Box key={expectation}>
-                    <Box
-                      lx={{
-                        flexDirection: "row",
-                        alignItems: "center",
-                        gap: "s8",
-                        marginTop: index === 0 ? undefined : "s16",
-                        marginBottom: "s8",
-                      }}
-                    >
-                      <Tag label={expectation} size="sm" appearance={meta.tone} />
-                      <Text typography="body3" lx={{ color: "muted", flex: 1 }}>
-                        {meta.hint}
-                      </Text>
-                    </Box>
-                    <Box lx={{ flexDirection: "row", flexWrap: "wrap", gap: "s8" }}>
-                      {scenarios.map(scenario => (
-                        <TouchableOpacity
-                          key={scenario.id}
-                          activeOpacity={0.7}
-                          accessibilityRole="button"
-                          accessibilityLabel={`Apply ${scenario.name} scenario`}
-                          style={{ flexBasis: "47%", flexGrow: 1 }}
-                          onPress={() =>
-                            confirm(
-                              scenario.name,
-                              `${scenario.summary}\n\nExpected: ${scenario.expected}.`,
-                              "Apply",
-                              () => applyScenario(scenario),
-                            )
-                          }
-                        >
-                          <Box
-                            lx={{
-                              gap: "s8",
-                              padding: "s12",
-                              borderRadius: "sm",
-                              borderWidth: "s1",
-                              borderColor: "muted",
-                              backgroundColor: "baseTransparent",
-                            }}
-                          >
-                            <Tag label={scenario.expected} size="sm" appearance={meta.tone} />
-                            <Text typography="body2SemiBold" lx={{ color: "base" }}>
-                              {scenario.name}
-                            </Text>
-                            <Text typography="body3" lx={{ color: "muted" }}>
-                              {scenario.summary}
-                            </Text>
-                          </Box>
-                        </TouchableOpacity>
-                      ))}
-                    </Box>
-                  </Box>
-                );
-              })}
-
-              <Text
-                typography="body3SemiBold"
-                lx={{ color: "muted", marginTop: "s16", marginBottom: "s8" }}
-              >
-                Trigger source
-              </Text>
-              <Box lx={{ flexDirection: "row", flexWrap: "wrap", gap: "s8" }}>
-                {TRIGGER_SOURCES.map(source => (
-                  <Button
-                    key={source}
-                    size="sm"
-                    appearance={selectedSource === source ? "accent" : "base"}
-                    onPress={() => setSelectedSource(source)}
-                  >
-                    {SOURCE_LABEL[source]}
-                  </Button>
-                ))}
-              </Box>
-
-              <Box lx={{ gap: "s8", marginTop: "s16" }}>
-                <Button appearance="accent" onPress={onTriggerProductionDrawer}>
-                  Trigger drawer with production rules
-                </Button>
-                <Button appearance="base" onPress={onForceOpenDrawer}>
-                  Force open global drawer — bypass rules
-                </Button>
-                <Text typography="body3" lx={{ color: "muted" }}>
-                  The production trigger uses the real engine and configured delay. Force open
-                  bypasses eligibility and runs the real drawer handlers.
-                </Text>
-              </Box>
-
-              <Text
-                typography="body3SemiBold"
-                lx={{ color: "muted", marginTop: "s16", marginBottom: "s8" }}
-              >
-                Advanced state actions
-              </Text>
-              <Box lx={{ gap: "s8" }}>
-                <Button appearance="base" size="sm" onPress={onMarkInactive}>
-                  Make inactivity eligible
-                </Button>
-                <Button appearance="base" size="sm" onPress={onMarkRepromptable}>
-                  Make after-action eligible
-                </Button>
-                <Button appearance="base" size="sm" onPress={onKeepTwoDismissals}>
-                  Keep only first two dismissals
-                </Button>
-              </Box>
-            </Box>
+            <ScenariosTab
+              selectedSource={selectedSource}
+              forceOpenDrawerLabel={forceOpenDrawerLabel}
+              onSelectSource={setSelectedSource}
+              onApplyScenario={applyScenario}
+              onTriggerProductionDrawer={() => {
+                setPreviewOpen(false);
+                onTriggerProductionDrawer();
+              }}
+              onForceOpenDrawer={() => {
+                setPreviewOpen(false);
+                onForceOpenDrawer();
+              }}
+              onMarkInactive={onMarkInactive}
+              onMarkRepromptable={onMarkRepromptable}
+              onKeepTwoDismissals={onKeepTwoDismissals}
+            />
           ) : (
-            <Box>
-              <Text typography="body3SemiBold" lx={{ color: "muted", marginBottom: "s4" }}>
-                Current user and device state
-              </Text>
-              {inspectorFields.map(field => (
-                <InspectorRow key={field.label} field={field} />
-              ))}
-
-              <Text
-                typography="body3SemiBold"
-                lx={{ color: "muted", marginTop: "s16", marginBottom: "s4" }}
-              >
-                Production decision
-              </Text>
-              <InspectorRow
-                field={{
-                  label: "Selected trigger",
-                  value: SOURCE_LABEL[selectedSource],
-                  raw: `source: ${selectedSource}`,
-                  status: {
-                    label: decision.kind === "show" ? "Show" : "Skip",
-                    tone: verdictMeta.tone,
-                  },
-                }}
-              />
-              <InspectorRow
-                field={{
-                  label: "Drawer target",
-                  value: resolvedPromptTarget,
-                  raw: `dismissedCount: ${decision.dismissedCount}`,
-                  status: { label: "Resolved", tone: "success" },
-                }}
-              />
-
-              <Text
-                typography="body3SemiBold"
-                lx={{ color: "muted", marginTop: "s16", marginBottom: "s4" }}
-              >
-                Feature configuration
-              </Text>
-              <InspectorRow
-                field={{
-                  label: "Braze notifications prompt",
-                  value: brazePushNotifications?.enabled ? "Enabled" : "Disabled",
-                  raw: "feature: brazePushNotifications",
-                  status: {
-                    label: brazePushNotifications?.enabled ? "On" : "Off",
-                    tone: brazePushNotifications?.enabled ? "success" : "error",
-                  },
-                }}
-              />
-              {selectedSource === "inactivity" ? (
-                <InspectorRow
-                  field={{
-                    label: "Inactivity prompt",
-                    value: brazePushNotifications?.params?.inactivity_enabled
-                      ? "Enabled"
-                      : "Disabled",
-                    raw: `inactivity_reprompt: ${formatDelay(
-                      brazePushNotifications?.params?.inactivity_reprompt,
-                    )}`,
-                    status: {
-                      label: brazePushNotifications?.params?.inactivity_enabled ? "On" : "Off",
-                      tone: brazePushNotifications?.params?.inactivity_enabled
-                        ? "success"
-                        : "error",
-                    },
-                  }}
-                />
-              ) : (
-                <InspectorRow
-                  field={{
-                    label: `${SOURCE_LABEL[selectedSource]} action`,
-                    value: selectedActionEvent?.enabled ? "Enabled" : "Disabled",
-                    raw: `timer: ${selectedActionEvent?.timer ?? "missing"} ms`,
-                    status: {
-                      label: selectedActionEvent?.enabled ? "On" : "Off",
-                      tone: selectedActionEvent?.enabled ? "success" : "error",
-                    },
-                  }}
-                />
-              )}
-              <InspectorRow
-                field={{
-                  label: "After-action reprompt",
-                  value: afterActionRepromptLabel,
-                  raw: `reprompt_schedule: ${
-                    brazePushNotifications?.params?.reprompt_schedule?.length ?? 0
-                  } step(s)`,
-                  status: {
-                    label: afterActionRepromptLabel.includes("eligible") ? "Ready" : "Waiting",
-                    tone: afterActionRepromptLabel.includes("eligible") ? "success" : "warning",
-                  },
-                }}
-              />
-              <InspectorRow
-                field={{
-                  label: "Inactivity reprompt",
-                  value: inactivityRepromptLabel,
-                  raw: `inactivity_reprompt: ${formatDelay(
-                    brazePushNotifications?.params?.inactivity_reprompt,
-                  )}`,
-                  status: {
-                    label: inactivityRepromptLabel.includes("eligible") ? "Ready" : "Waiting",
-                    tone: inactivityRepromptLabel.includes("eligible") ? "success" : "warning",
-                  },
-                }}
-              />
-            </Box>
+            <InspectTab
+              userStateFields={userStateFields}
+              decisionFields={decisionFields}
+              featureFields={featureFields}
+            />
           )}
         </Box>
       </SettingsNavigationScrollView>

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/index.tsx
@@ -1,86 +1,410 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Alert, TouchableOpacity } from "react-native";
 import { AuthorizationStatus } from "@react-native-firebase/messaging";
-import { Box, Button, Text } from "@ledgerhq/lumen-ui-rnative";
-import { useFeature } from "@features/platform-feature-flags";
 import {
-  type NotificationsPromptAfterActionSource,
+  Box,
+  Button,
+  Divider,
+  SegmentedControl,
+  SegmentedControlButton,
+  Tag,
+  Text,
+} from "@ledgerhq/lumen-ui-rnative";
+import { useFeature } from "@features/platform-feature-flags";
+import { setOverride } from "@shared/feature-flags";
+import {
+  evaluateAfterActionTrigger,
+  evaluateInactivityTrigger,
+  getNotificationPromptTarget,
+  type AfterActionTriggerDecision,
+  type InactivityTriggerDecision,
+  type NotificationPromptTarget,
   useNotificationsPrompt,
   useNotificationsData,
 } from "LLM/features/NotificationsPrompt";
-import { useNotificationsPromptDrawerScheduler } from "LLM/features/NotificationsPrompt/new/hooks/useNotificationsPromptDrawerScheduler";
+import { NotificationsPromptDrawerView } from "LLM/features/NotificationsPrompt/screens/NotificationsPromptDrawerView";
 import { useNotificationsPermission } from "LLM/hooks/useNotificationsPermission";
+import QueuedDrawer from "~/components/QueuedDrawer";
 import { TrackScreen } from "~/analytics";
-import { useSelector } from "~/context/hooks";
+import { useDispatch, useSelector } from "~/context/hooks";
+import {
+  setNotificationsDrawerPromptTarget,
+  setNotificationsDrawerSource,
+  setNotificationsModalOpen,
+} from "~/actions/notifications";
+import { completeOnboarding, setNotifications } from "~/actions/settings";
+import { ratingsModalOpenSelector } from "~/reducers/ratings";
 import { hasCompletedOnboardingSelector, notificationsSelector } from "~/reducers/settings";
 import SettingsNavigationScrollView from "../../SettingsNavigationScrollView";
 import {
   buildInactiveUserData,
+  buildNotificationsQaScenarioUserData,
   buildRepromptableUserData,
   buildTruncatedDismissalsUserData,
   formatDismissalTimestamp,
+  formatPermissionStatus,
   getAfterActionRepromptLabel,
   getGlobalPushNotificationsDismissals,
   getInactivityRepromptLabel,
+  mapNotificationsDecisionToQaExpectation,
+  NOTIFICATIONS_PROMPT_REASON_LABEL,
+  NOTIFICATIONS_QA_GROUPS,
+  NOTIFICATIONS_QA_SCENARIOS,
+  NOTIFICATIONS_QA_VERDICT_META,
+  type NotificationsQaScenario,
+  type NotificationsQaTriggerSource,
 } from "./utils";
 
-const TRIGGER_SOURCES: NotificationsPromptAfterActionSource[] = [
+const TRIGGER_SOURCES: NotificationsQaTriggerSource[] = [
   "onboarding",
-  "add_favorite_coin",
   "send",
   "receive",
   "swap",
   "stake",
+  "add_favorite_coin",
+  "inactivity",
 ];
 
-function valueLxColor(ok: boolean): "success" | "error" {
-  return ok ? "success" : "error";
+const SOURCE_LABEL: Record<NotificationsQaTriggerSource, string> = {
+  onboarding: "Onboarding",
+  send: "Send",
+  receive: "Receive",
+  swap: "Swap",
+  stake: "Stake",
+  add_favorite_coin: "Add favourite coin",
+  dapp_complete: "DApp complete",
+  inactivity: "Inactivity",
+};
+
+type TabId = "scenarios" | "inspect";
+type FieldTone = "success" | "error" | "warning" | "gray";
+
+type InspectorField = {
+  label: string;
+  value: string;
+  raw?: string;
+  status: { label: string; tone: FieldTone };
+};
+
+function confirm(title: string, message: string, confirmLabel: string, onConfirm: () => void) {
+  Alert.alert(title, message, [
+    { text: "Cancel", style: "cancel" },
+    { text: confirmLabel, onPress: onConfirm },
+  ]);
+}
+
+function formatDelay(delay: Record<string, number> | null | undefined): string {
+  if (!delay) return "Not configured";
+
+  const parts = Object.entries(delay)
+    .filter(([, value]) => value > 0)
+    .map(([unit, value]) => `${value} ${unit}`);
+  return parts.length > 0 ? parts.join(", ") : "Immediately";
+}
+
+function InspectorRow({ field }: Readonly<{ field: InspectorField }>) {
+  return (
+    <Box
+      lx={{
+        paddingHorizontal: "s8",
+        paddingVertical: "s12",
+        borderRadius: "sm",
+        marginBottom: "s8",
+        gap: "s8",
+        borderWidth: "s1",
+        borderColor: "muted",
+      }}
+    >
+      <Box
+        lx={{
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: "s8",
+        }}
+      >
+        <Text typography="body2SemiBold" lx={{ color: "base", flex: 1 }}>
+          {field.label}
+        </Text>
+        <Tag label={field.status.label} size="sm" appearance={field.status.tone} />
+      </Box>
+      <Text typography="body2SemiBold" lx={{ color: "base" }} selectable>
+        {field.value}
+      </Text>
+      {field.raw ? (
+        <Text typography="body3" lx={{ color: "muted" }} selectable>
+          {field.raw}
+        </Text>
+      ) : null}
+    </Box>
+  );
 }
 
 export default function DebugNotificationsPromptQA() {
-  const [selectedSource, setSelectedSource] =
-    useState<NotificationsPromptAfterActionSource>("onboarding");
-  const [featureFlagsExpanded, setFeatureFlagsExpanded] = useState(false);
+  const dispatch = useDispatch();
+  const [tab, setTab] = useState<TabId>("scenarios");
+  const [selectedSource, setSelectedSource] = useState<NotificationsQaTriggerSource>("onboarding");
+  const [isPreviewOpen, setPreviewOpen] = useState(false);
+  const [previewTarget, setPreviewTarget] =
+    useState<NotificationPromptTarget>("globalPushNotifications");
+  const [hasSimulatedPermission, setHasSimulatedPermission] = useState(false);
+  const [evaluationNow, setEvaluationNow] = useState(() => Date.now());
+  const [isBaselineCaptured, setBaselineCaptured] = useState(false);
 
   const brazePushNotifications = useFeature("brazePushNotifications");
   const notifications = useSelector(notificationsSelector);
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
-  const { permissionStatus } = useNotificationsPermission();
+  const isRatingsModalOpen = useSelector(ratingsModalOpenSelector);
+  const { permissionStatus, setPermissionStatus } = useNotificationsPermission();
   const { pushNotificationsDataOfUser, updatePushNotificationsDataOfUserInStateAndStore } =
     useNotificationsData();
-  const { notifyFlowCompleted } = useNotificationsPrompt();
-  const { openDrawer } = useNotificationsPromptDrawerScheduler();
+  const { notifyFlowCompleted, openDrawer, isDrawerPending, cancelPendingDrawer } =
+    useNotificationsPrompt();
 
-  const globalPushNotificationsDismissals = useMemo(
+  const initialStateRef = useRef<{
+    permissionStatus: NonNullable<typeof permissionStatus>;
+    notifications: typeof notifications;
+    hasCompletedOnboarding: boolean;
+    pushNotificationsDataOfUser: typeof pushNotificationsDataOfUser;
+  } | null>(null);
+
+  useEffect(() => {
+    if (
+      initialStateRef.current === null &&
+      permissionStatus !== null &&
+      permissionStatus !== undefined
+    ) {
+      initialStateRef.current = {
+        permissionStatus,
+        notifications,
+        hasCompletedOnboarding,
+        pushNotificationsDataOfUser,
+      };
+      setBaselineCaptured(true);
+    }
+  }, [hasCompletedOnboarding, notifications, permissionStatus, pushNotificationsDataOfUser]);
+
+  const globalDismissals = useMemo(
     () => getGlobalPushNotificationsDismissals(pushNotificationsDataOfUser),
     [pushNotificationsDataOfUser],
   );
-  const dismissedCount = globalPushNotificationsDismissals?.length ?? 0;
-  const isOsNotificationsEnabled = permissionStatus === AuthorizationStatus.AUTHORIZED;
-  const isAppNotificationsEnabled = notifications.areNotificationsAllowed === true;
-  const isOptIn = isOsNotificationsEnabled && isAppNotificationsEnabled;
-  const optState = isOptIn ? "isOptIn" : "isOptOut";
 
-  const now = Date.now();
+  const decision = useMemo<AfterActionTriggerDecision | InactivityTriggerDecision>(() => {
+    const context = {
+      brazePushNotifications,
+      isRatingsModalOpen,
+      isDrawerPending: isDrawerPending(),
+      now: evaluationNow,
+    };
+
+    if (selectedSource === "inactivity") {
+      return evaluateInactivityTrigger(
+        {
+          permissionStatus,
+          areNotificationsAllowed: notifications.areNotificationsAllowed,
+          pushNotificationsDataOfUser,
+          hasCompletedOnboarding,
+        },
+        context,
+      );
+    }
+
+    return evaluateAfterActionTrigger(
+      {
+        source: selectedSource,
+        permissionStatus,
+        areNotificationsAllowed: notifications.areNotificationsAllowed,
+        transactionsAlertsCategory: notifications.transactionsAlertsCategory,
+        pushNotificationsDataOfUser,
+      },
+      context,
+    );
+  }, [
+    brazePushNotifications,
+    evaluationNow,
+    hasCompletedOnboarding,
+    isDrawerPending,
+    isRatingsModalOpen,
+    notifications.areNotificationsAllowed,
+    notifications.transactionsAlertsCategory,
+    permissionStatus,
+    pushNotificationsDataOfUser,
+    selectedSource,
+  ]);
+
+  const verdict = mapNotificationsDecisionToQaExpectation(decision);
+  const verdictMeta = NOTIFICATIONS_QA_VERDICT_META[verdict];
+  const reason =
+    decision.kind === "show" ? "Eligible now" : NOTIFICATIONS_PROMPT_REASON_LABEL[decision.reason];
+  const rawReason = decision.kind === "show" ? "kind: show" : `reason: ${decision.reason}`;
+  const resolvedPromptTarget =
+    decision.kind === "show"
+      ? decision.drawerPromptTarget
+      : (getNotificationPromptTarget({
+          permissionStatus,
+          areNotificationsAllowed: notifications.areNotificationsAllowed,
+          transactionsAlertsCategory: notifications.transactionsAlertsCategory,
+        }) ?? "globalPushNotifications");
+
+  const selectedActionEvent = (() => {
+    if (selectedSource === "inactivity") return undefined;
+    const actionEventKey = selectedSource === "onboarding" ? "complete_onboarding" : selectedSource;
+    return brazePushNotifications?.params?.action_events?.[actionEventKey];
+  })();
   const afterActionRepromptLabel = getAfterActionRepromptLabel({
-    dismissedOptInDrawerAtList: globalPushNotificationsDismissals,
+    dismissedOptInDrawerAtList: globalDismissals,
     repromptSchedule: brazePushNotifications?.params?.reprompt_schedule,
-    now,
+    now: evaluationNow,
   });
   const inactivityRepromptLabel = getInactivityRepromptLabel({
     lastActionAt: pushNotificationsDataOfUser?.lastActionAt,
     inactivityReprompt: brazePushNotifications?.params?.inactivity_reprompt,
     inactivityEnabled: brazePushNotifications?.params?.inactivity_enabled,
-    now,
+    now: evaluationNow,
   });
 
+  const applyScenario = useCallback(
+    (scenario: NotificationsQaScenario) => {
+      const now = Date.now();
+      const userData = buildNotificationsQaScenarioUserData(scenario, {
+        repromptSchedule: brazePushNotifications?.params?.reprompt_schedule,
+        inactivityReprompt: brazePushNotifications?.params?.inactivity_reprompt,
+        now,
+      });
+
+      dispatch(
+        setOverride({
+          key: "brazePushNotifications",
+          value: {
+            ...brazePushNotifications,
+            enabled: true,
+            params: brazePushNotifications?.params ?? {},
+          },
+        }),
+      );
+      cancelPendingDrawer();
+      dispatch(setNotificationsModalOpen(false));
+      dispatch(setNotificationsDrawerSource(undefined));
+      dispatch(setNotificationsDrawerPromptTarget(undefined));
+      setPermissionStatus(scenario.permissionStatus);
+      setHasSimulatedPermission(true);
+      dispatch(
+        setNotifications({
+          ...notifications,
+          areNotificationsAllowed: scenario.areNotificationsAllowed,
+          transactionsAlertsCategory: scenario.transactionsAlertsCategory,
+        }),
+      );
+      dispatch(completeOnboarding(scenario.hasCompletedOnboarding));
+      updatePushNotificationsDataOfUserInStateAndStore(userData);
+      setSelectedSource(scenario.source);
+      setPreviewOpen(false);
+      setEvaluationNow(now);
+    },
+    [
+      brazePushNotifications,
+      cancelPendingDrawer,
+      dispatch,
+      notifications,
+      setPermissionStatus,
+      updatePushNotificationsDataOfUserInStateAndStore,
+    ],
+  );
+
+  const onResetAll = useCallback(() => {
+    const initialState = initialStateRef.current;
+    cancelPendingDrawer();
+    dispatch(setOverride({ key: "brazePushNotifications", value: undefined }));
+    if (initialState) {
+      updatePushNotificationsDataOfUserInStateAndStore(
+        initialState.pushNotificationsDataOfUser ?? {},
+      );
+      dispatch(setNotifications(initialState.notifications));
+      dispatch(completeOnboarding(initialState.hasCompletedOnboarding));
+      setPermissionStatus(initialState.permissionStatus);
+    }
+    dispatch(setNotificationsModalOpen(false));
+    dispatch(setNotificationsDrawerSource(undefined));
+    dispatch(setNotificationsDrawerPromptTarget(undefined));
+    setSelectedSource("onboarding");
+    setPreviewOpen(false);
+    setHasSimulatedPermission(false);
+    setEvaluationNow(Date.now());
+  }, [
+    cancelPendingDrawer,
+    dispatch,
+    setPermissionStatus,
+    updatePushNotificationsDataOfUserInStateAndStore,
+  ]);
+
+  const onPreviewDrawer = useCallback(() => {
+    setPreviewTarget(resolvedPromptTarget);
+    setPreviewOpen(true);
+  }, [resolvedPromptTarget]);
+
+  const onTriggerProductionDrawer = useCallback(() => {
+    setPreviewOpen(false);
+    cancelPendingDrawer();
+    const now = Date.now();
+    setEvaluationNow(now);
+
+    if (selectedSource === "inactivity") {
+      const inactivityDecision = evaluateInactivityTrigger(
+        {
+          permissionStatus,
+          areNotificationsAllowed: notifications.areNotificationsAllowed,
+          pushNotificationsDataOfUser,
+          hasCompletedOnboarding,
+        },
+        {
+          brazePushNotifications,
+          isRatingsModalOpen,
+          isDrawerPending: isDrawerPending(),
+          now,
+        },
+      );
+      if (inactivityDecision.kind === "show") {
+        openDrawer(
+          inactivityDecision.source,
+          inactivityDecision.delayMs,
+          inactivityDecision.drawerPromptTarget,
+        );
+      }
+      return;
+    }
+    notifyFlowCompleted(selectedSource);
+  }, [
+    brazePushNotifications,
+    cancelPendingDrawer,
+    hasCompletedOnboarding,
+    isDrawerPending,
+    isRatingsModalOpen,
+    notifyFlowCompleted,
+    notifications.areNotificationsAllowed,
+    openDrawer,
+    permissionStatus,
+    pushNotificationsDataOfUser,
+    selectedSource,
+  ]);
+
+  const onForceOpenDrawer = useCallback(() => {
+    setPreviewOpen(false);
+    cancelPendingDrawer();
+    const source = selectedSource === "inactivity" ? "inactivity" : selectedSource;
+    openDrawer(source, 0, resolvedPromptTarget);
+  }, [cancelPendingDrawer, openDrawer, resolvedPromptTarget, selectedSource]);
+
   const onMarkInactive = useCallback(() => {
+    const now = Date.now();
     updatePushNotificationsDataOfUserInStateAndStore(
       buildInactiveUserData(
         pushNotificationsDataOfUser,
         brazePushNotifications?.params?.inactivity_reprompt,
-        Date.now(),
+        now,
       ),
     );
+    setSelectedSource("inactivity");
+    setEvaluationNow(now);
   }, [
     brazePushNotifications?.params?.inactivity_reprompt,
     pushNotificationsDataOfUser,
@@ -88,200 +412,432 @@ export default function DebugNotificationsPromptQA() {
   ]);
 
   const onMarkRepromptable = useCallback(() => {
+    const now = Date.now();
     updatePushNotificationsDataOfUserInStateAndStore(
       buildRepromptableUserData(
         pushNotificationsDataOfUser,
         brazePushNotifications?.params?.reprompt_schedule,
-        Date.now(),
+        now,
       ),
     );
+    setEvaluationNow(now);
   }, [
     brazePushNotifications?.params?.reprompt_schedule,
     pushNotificationsDataOfUser,
     updatePushNotificationsDataOfUserInStateAndStore,
   ]);
 
-  const onGoBackToSecondDismissal = useCallback(() => {
+  const onKeepTwoDismissals = useCallback(() => {
     updatePushNotificationsDataOfUserInStateAndStore(
       buildTruncatedDismissalsUserData(pushNotificationsDataOfUser, 2),
     );
   }, [pushNotificationsDataOfUser, updatePushNotificationsDataOfUserInStateAndStore]);
 
-  const onTriggerDrawer = useCallback(() => {
-    notifyFlowCompleted(selectedSource);
-  }, [notifyFlowCompleted, selectedSource]);
-
-  const onForceOpenDrawer = useCallback(() => {
-    openDrawer(selectedSource, 0, "globalPushNotifications");
-  }, [openDrawer, selectedSource]);
+  const inspectorFields: InspectorField[] = [
+    {
+      label: "OS notification permission",
+      value: formatPermissionStatus(permissionStatus),
+      raw: `permissionStatus: ${String(permissionStatus)}${
+        hasSimulatedPermission ? " · simulated until app foreground sync" : ""
+      }`,
+      status: {
+        label: permissionStatus === AuthorizationStatus.AUTHORIZED ? "On" : "Off",
+        tone: permissionStatus === AuthorizationStatus.AUTHORIZED ? "success" : "gray",
+      },
+    },
+    {
+      label: "App notifications",
+      value: notifications.areNotificationsAllowed ? "Enabled" : "Disabled",
+      raw: `areNotificationsAllowed: ${String(notifications.areNotificationsAllowed)}`,
+      status: {
+        label: notifications.areNotificationsAllowed ? "On" : "Off",
+        tone: notifications.areNotificationsAllowed ? "success" : "gray",
+      },
+    },
+    {
+      label: "Transaction alerts",
+      value: notifications.transactionsAlertsCategory ? "Enabled" : "Disabled",
+      raw: `transactionsAlertsCategory: ${String(notifications.transactionsAlertsCategory)}`,
+      status: {
+        label: notifications.transactionsAlertsCategory ? "On" : "Off",
+        tone: notifications.transactionsAlertsCategory ? "success" : "gray",
+      },
+    },
+    {
+      label: "Onboarding",
+      value: hasCompletedOnboarding ? "Complete" : "Incomplete",
+      raw: `hasCompletedOnboarding: ${String(hasCompletedOnboarding)}`,
+      status: {
+        label: hasCompletedOnboarding ? "Ready" : "Blocked",
+        tone: hasCompletedOnboarding ? "success" : "error",
+      },
+    },
+    {
+      label: "Stored dismissals",
+      value: `${globalDismissals?.length ?? 0} dismissal(s)`,
+      raw: `globalPushNotifications: ${JSON.stringify(globalDismissals ?? [])}`,
+      status: {
+        label: globalDismissals?.length ? "Saved" : "Empty",
+        tone: "gray",
+      },
+    },
+    {
+      label: "Last activity",
+      value: pushNotificationsDataOfUser?.lastActionAt
+        ? formatDismissalTimestamp(pushNotificationsDataOfUser.lastActionAt).local
+        : "Missing",
+      raw: `lastActionAt: ${String(pushNotificationsDataOfUser?.lastActionAt)}`,
+      status: {
+        label: pushNotificationsDataOfUser?.lastActionAt ? "Saved" : "Missing",
+        tone: "gray",
+      },
+    },
+  ];
 
   return (
-    <SettingsNavigationScrollView>
+    <Box lx={{ flex: 1 }}>
       <TrackScreen category="Settings" name="DebugNotificationsPromptQA" />
-      <Box lx={{ paddingHorizontal: "s24", paddingBottom: "s24" }}>
-        <Text typography="body2SemiBold" lx={{ color: "muted", marginBottom: "s12" }}>
-          NOTIFICATIONS PROMPT — QA
-        </Text>
-
-        <SectionTitle>1. Opt state</SectionTitle>
-        <InfoRow label="State" value={optState} valueColor={isOptIn ? "success" : "error"} />
-
-        <SectionTitle>2. Notification enablement status</SectionTitle>
-        <InfoRow
-          label="App notifications enabled"
-          value={String(isAppNotificationsEnabled)}
-          valueColor={valueLxColor(isAppNotificationsEnabled)}
+      <QueuedDrawer
+        isRequestingToBeOpened={isPreviewOpen}
+        noCloseButton
+        onClose={() => setPreviewOpen(false)}
+        onBackdropPress={() => setPreviewOpen(false)}
+      >
+        <NotificationsPromptDrawerView
+          promptTarget={previewTarget}
+          onAllow={() => setPreviewOpen(false)}
+          onLater={() => setPreviewOpen(false)}
         />
-        <InfoRow
-          label="OS notifications enabled"
-          value={String(isOsNotificationsEnabled)}
-          valueColor={valueLxColor(isOsNotificationsEnabled)}
-        />
-        <InfoRow label="OS permission status" value={String(permissionStatus ?? "undefined")} />
-        <InfoRow
-          label="Onboarding complete"
-          value={String(hasCompletedOnboarding)}
-          valueColor={valueLxColor(hasCompletedOnboarding)}
-        />
+      </QueuedDrawer>
 
-        <SectionTitle>3. Reprompt timing</SectionTitle>
-        <InfoRow label="After action" value={afterActionRepromptLabel} />
-        <InfoRow label="After inactivity" value={inactivityRepromptLabel} />
-
-        <SectionTitle>4. Dismissal data</SectionTitle>
-        <InfoRow label="dismissedCount" value={String(dismissedCount)} />
-        {!globalPushNotificationsDismissals?.length ? (
-          <Text typography="body3" lx={{ color: "muted", marginBottom: "s12" }}>
-            globalPushNotifications dismissals are empty
+      <SettingsNavigationScrollView>
+        <Box
+          lx={{
+            paddingHorizontal: "s24",
+            paddingBottom: "s24",
+            paddingTop: "s16",
+            gap: "s16",
+          }}
+        >
+          <Text typography="body2SemiBold" lx={{ color: "muted" }}>
+            NOTIFICATIONS PROMPT — QA
           </Text>
-        ) : (
-          globalPushNotificationsDismissals.map((timestamp, index) => {
-            const formatted = formatDismissalTimestamp(timestamp);
-            return (
-              <Box key={`${timestamp}-${index}`} lx={{ marginBottom: "s12" }}>
-                <Text typography="body3SemiBold" lx={{ color: "base", marginBottom: "s4" }}>
-                  #{index + 1}
+
+          <Box
+            lx={{
+              backgroundColor: "muted",
+              borderRadius: "md",
+              padding: "s16",
+              gap: "s12",
+            }}
+          >
+            <Box lx={{ gap: "s4" }}>
+              <Text typography="heading3SemiBold" lx={{ color: verdictMeta.tone }}>
+                {verdict}
+              </Text>
+              <Text typography="body3" lx={{ color: "muted" }}>
+                {verdictMeta.hint}
+              </Text>
+            </Box>
+
+            <Box lx={{ gap: "s8" }}>
+              <Box lx={{ gap: "s2" }}>
+                <Text typography="body3" lx={{ color: "muted" }}>
+                  Reason
                 </Text>
-                <Text typography="body3" lx={{ color: "muted" }} selectable>
-                  epoch ms: {formatted.epochMs}
+                <Text typography="body2SemiBold" lx={{ color: "base" }}>
+                  {reason}
                 </Text>
-                <Text typography="body3" lx={{ color: "muted" }} selectable>
-                  ISO: {formatted.iso}
-                </Text>
-                <Text typography="body3" lx={{ color: "muted" }} selectable>
-                  local: {formatted.local}
+                <Text typography="body3" lx={{ color: "muted" }}>
+                  {rawReason}
                 </Text>
               </Box>
-            );
-          })
-        )}
+              <Box lx={{ gap: "s2" }}>
+                <Text typography="body3" lx={{ color: "muted" }}>
+                  Evaluation
+                </Text>
+                <Text typography="body2SemiBold" lx={{ color: "base" }}>
+                  {SOURCE_LABEL[selectedSource]} · {resolvedPromptTarget}
+                </Text>
+                <Text typography="body3" lx={{ color: "muted" }}>
+                  {decision.kind === "show"
+                    ? `Delay: ${decision.delayMs} ms`
+                    : `Dismissals: ${decision.dismissedCount}`}
+                </Text>
+              </Box>
+            </Box>
 
-        <SectionTitle>5. Feature flags</SectionTitle>
-        <Button
-          size="sm"
-          appearance="base"
-          onPress={() => setFeatureFlagsExpanded(expanded => !expanded)}
-          lx={{ marginBottom: "s12", alignSelf: "flex-start" }}
-        >
-          {featureFlagsExpanded ? "Hide feature flag details" : "Show feature flag details"}
-        </Button>
-        {featureFlagsExpanded ? (
-          <Box lx={{ marginBottom: "s16" }}>
-            <Text typography="body3" lx={{ color: "muted", marginBottom: "s8" }} selectable>
-              brazePushNotifications.enabled: {String(brazePushNotifications?.enabled ?? false)}
-            </Text>
-            <Text typography="body3" lx={{ color: "muted", marginBottom: "s8" }} selectable>
-              reprompt_schedule:{" "}
-              {JSON.stringify(brazePushNotifications?.params?.reprompt_schedule ?? null)}
-            </Text>
-            <Text typography="body3" lx={{ color: "muted", marginBottom: "s8" }} selectable>
-              action_events: {JSON.stringify(brazePushNotifications?.params?.action_events ?? null)}
-            </Text>
-            <Text typography="body3" lx={{ color: "muted", marginBottom: "s8" }} selectable>
-              inactivity_enabled:{" "}
-              {String(brazePushNotifications?.params?.inactivity_enabled ?? false)}
-            </Text>
-            <Text typography="body3" lx={{ color: "muted" }} selectable>
-              inactivity_reprompt:{" "}
-              {JSON.stringify(brazePushNotifications?.params?.inactivity_reprompt ?? null)}
-            </Text>
+            <Divider />
+
+            <Box lx={{ gap: "s8" }}>
+              <Button appearance="accent" size="sm" onPress={onPreviewDrawer}>
+                Preview drawer
+              </Button>
+              <Text typography="body3" lx={{ color: "muted" }}>
+                Visual preview only. Buttons close it without changing notification state.
+              </Text>
+            </Box>
           </Box>
-        ) : null}
 
-        <SectionTitle>Actions</SectionTitle>
-        <Box lx={{ gap: "s8", marginBottom: "s16" }}>
-          <Button appearance="accent" size="sm" onPress={onMarkInactive}>
-            Mark as inactive
-          </Button>
-          <Button appearance="accent" size="sm" onPress={onMarkRepromptable}>
-            Mark user as can be reprompted
-          </Button>
-          <Button appearance="accent" size="sm" onPress={onGoBackToSecondDismissal}>
-            Go back in time (keep 2 dismissals)
-          </Button>
-        </Box>
-
-        <Text typography="body3SemiBold" lx={{ color: "base", marginBottom: "s8" }}>
-          Trigger drawer source
-        </Text>
-        <Box lx={{ flexDirection: "row", flexWrap: "wrap", gap: "s8", marginBottom: "s12" }}>
-          {TRIGGER_SOURCES.map(source => (
+          <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s8" }}>
+            <Box lx={{ flex: 1 }}>
+              <SegmentedControl
+                selectedValue={tab}
+                onSelectedChange={setTab}
+                tabLayout="fit"
+                accessibilityLabel="Notifications prompt QA sections"
+              >
+                <SegmentedControlButton value="scenarios">Scenarios</SegmentedControlButton>
+                <SegmentedControlButton value="inspect">Inspect</SegmentedControlButton>
+              </SegmentedControl>
+            </Box>
             <Button
-              key={source}
+              appearance="no-background"
               size="sm"
-              appearance={selectedSource === source ? "accent" : "base"}
-              onPress={() => setSelectedSource(source)}
+              disabled={!isBaselineCaptured}
+              onPress={() =>
+                confirm(
+                  "Reset all",
+                  "Restores the prompt state from when this screen opened and clears QA overrides. The app cannot change the real OS permission.",
+                  "Reset",
+                  onResetAll,
+                )
+              }
             >
-              {source}
+              Reset all
             </Button>
-          ))}
+          </Box>
+
+          {tab === "scenarios" ? (
+            <Box>
+              {NOTIFICATIONS_QA_GROUPS.map((expectation, index) => {
+                const meta = NOTIFICATIONS_QA_VERDICT_META[expectation];
+                const scenarios = NOTIFICATIONS_QA_SCENARIOS.filter(
+                  scenario => scenario.expected === expectation,
+                );
+                if (scenarios.length === 0) return null;
+
+                return (
+                  <Box key={expectation}>
+                    <Box
+                      lx={{
+                        flexDirection: "row",
+                        alignItems: "center",
+                        gap: "s8",
+                        marginTop: index === 0 ? undefined : "s16",
+                        marginBottom: "s8",
+                      }}
+                    >
+                      <Tag label={expectation} size="sm" appearance={meta.tone} />
+                      <Text typography="body3" lx={{ color: "muted", flex: 1 }}>
+                        {meta.hint}
+                      </Text>
+                    </Box>
+                    <Box lx={{ flexDirection: "row", flexWrap: "wrap", gap: "s8" }}>
+                      {scenarios.map(scenario => (
+                        <TouchableOpacity
+                          key={scenario.id}
+                          activeOpacity={0.7}
+                          accessibilityRole="button"
+                          accessibilityLabel={`Apply ${scenario.name} scenario`}
+                          style={{ flexBasis: "47%", flexGrow: 1 }}
+                          onPress={() =>
+                            confirm(
+                              scenario.name,
+                              `${scenario.summary}\n\nExpected: ${scenario.expected}.`,
+                              "Apply",
+                              () => applyScenario(scenario),
+                            )
+                          }
+                        >
+                          <Box
+                            lx={{
+                              gap: "s8",
+                              padding: "s12",
+                              borderRadius: "sm",
+                              borderWidth: "s1",
+                              borderColor: "muted",
+                              backgroundColor: "baseTransparent",
+                            }}
+                          >
+                            <Tag label={scenario.expected} size="sm" appearance={meta.tone} />
+                            <Text typography="body2SemiBold" lx={{ color: "base" }}>
+                              {scenario.name}
+                            </Text>
+                            <Text typography="body3" lx={{ color: "muted" }}>
+                              {scenario.summary}
+                            </Text>
+                          </Box>
+                        </TouchableOpacity>
+                      ))}
+                    </Box>
+                  </Box>
+                );
+              })}
+
+              <Text
+                typography="body3SemiBold"
+                lx={{ color: "muted", marginTop: "s16", marginBottom: "s8" }}
+              >
+                Trigger source
+              </Text>
+              <Box lx={{ flexDirection: "row", flexWrap: "wrap", gap: "s8" }}>
+                {TRIGGER_SOURCES.map(source => (
+                  <Button
+                    key={source}
+                    size="sm"
+                    appearance={selectedSource === source ? "accent" : "base"}
+                    onPress={() => setSelectedSource(source)}
+                  >
+                    {SOURCE_LABEL[source]}
+                  </Button>
+                ))}
+              </Box>
+
+              <Box lx={{ gap: "s8", marginTop: "s16" }}>
+                <Button appearance="accent" onPress={onTriggerProductionDrawer}>
+                  Trigger drawer with production rules
+                </Button>
+                <Button appearance="base" onPress={onForceOpenDrawer}>
+                  Force open global drawer — bypass rules
+                </Button>
+                <Text typography="body3" lx={{ color: "muted" }}>
+                  The production trigger uses the real engine and configured delay. Force open
+                  bypasses eligibility and runs the real drawer handlers.
+                </Text>
+              </Box>
+
+              <Text
+                typography="body3SemiBold"
+                lx={{ color: "muted", marginTop: "s16", marginBottom: "s8" }}
+              >
+                Advanced state actions
+              </Text>
+              <Box lx={{ gap: "s8" }}>
+                <Button appearance="base" size="sm" onPress={onMarkInactive}>
+                  Make inactivity eligible
+                </Button>
+                <Button appearance="base" size="sm" onPress={onMarkRepromptable}>
+                  Make after-action eligible
+                </Button>
+                <Button appearance="base" size="sm" onPress={onKeepTwoDismissals}>
+                  Keep only first two dismissals
+                </Button>
+              </Box>
+            </Box>
+          ) : (
+            <Box>
+              <Text typography="body3SemiBold" lx={{ color: "muted", marginBottom: "s4" }}>
+                Current user and device state
+              </Text>
+              {inspectorFields.map(field => (
+                <InspectorRow key={field.label} field={field} />
+              ))}
+
+              <Text
+                typography="body3SemiBold"
+                lx={{ color: "muted", marginTop: "s16", marginBottom: "s4" }}
+              >
+                Production decision
+              </Text>
+              <InspectorRow
+                field={{
+                  label: "Selected trigger",
+                  value: SOURCE_LABEL[selectedSource],
+                  raw: `source: ${selectedSource}`,
+                  status: {
+                    label: decision.kind === "show" ? "Show" : "Skip",
+                    tone: verdictMeta.tone,
+                  },
+                }}
+              />
+              <InspectorRow
+                field={{
+                  label: "Drawer target",
+                  value: resolvedPromptTarget,
+                  raw: `dismissedCount: ${decision.dismissedCount}`,
+                  status: { label: "Resolved", tone: "success" },
+                }}
+              />
+
+              <Text
+                typography="body3SemiBold"
+                lx={{ color: "muted", marginTop: "s16", marginBottom: "s4" }}
+              >
+                Feature configuration
+              </Text>
+              <InspectorRow
+                field={{
+                  label: "Braze notifications prompt",
+                  value: brazePushNotifications?.enabled ? "Enabled" : "Disabled",
+                  raw: "feature: brazePushNotifications",
+                  status: {
+                    label: brazePushNotifications?.enabled ? "On" : "Off",
+                    tone: brazePushNotifications?.enabled ? "success" : "error",
+                  },
+                }}
+              />
+              {selectedSource === "inactivity" ? (
+                <InspectorRow
+                  field={{
+                    label: "Inactivity prompt",
+                    value: brazePushNotifications?.params?.inactivity_enabled
+                      ? "Enabled"
+                      : "Disabled",
+                    raw: `inactivity_reprompt: ${formatDelay(
+                      brazePushNotifications?.params?.inactivity_reprompt,
+                    )}`,
+                    status: {
+                      label: brazePushNotifications?.params?.inactivity_enabled ? "On" : "Off",
+                      tone: brazePushNotifications?.params?.inactivity_enabled
+                        ? "success"
+                        : "error",
+                    },
+                  }}
+                />
+              ) : (
+                <InspectorRow
+                  field={{
+                    label: `${SOURCE_LABEL[selectedSource]} action`,
+                    value: selectedActionEvent?.enabled ? "Enabled" : "Disabled",
+                    raw: `timer: ${selectedActionEvent?.timer ?? "missing"} ms`,
+                    status: {
+                      label: selectedActionEvent?.enabled ? "On" : "Off",
+                      tone: selectedActionEvent?.enabled ? "success" : "error",
+                    },
+                  }}
+                />
+              )}
+              <InspectorRow
+                field={{
+                  label: "After-action reprompt",
+                  value: afterActionRepromptLabel,
+                  raw: `reprompt_schedule: ${
+                    brazePushNotifications?.params?.reprompt_schedule?.length ?? 0
+                  } step(s)`,
+                  status: {
+                    label: afterActionRepromptLabel.includes("eligible") ? "Ready" : "Waiting",
+                    tone: afterActionRepromptLabel.includes("eligible") ? "success" : "warning",
+                  },
+                }}
+              />
+              <InspectorRow
+                field={{
+                  label: "Inactivity reprompt",
+                  value: inactivityRepromptLabel,
+                  raw: `inactivity_reprompt: ${formatDelay(
+                    brazePushNotifications?.params?.inactivity_reprompt,
+                  )}`,
+                  status: {
+                    label: inactivityRepromptLabel.includes("eligible") ? "Ready" : "Waiting",
+                    tone: inactivityRepromptLabel.includes("eligible") ? "success" : "warning",
+                  },
+                }}
+              />
+            </Box>
+          )}
         </Box>
-        <Box lx={{ gap: "s8", marginBottom: "s16" }}>
-          <Button appearance="accent" onPress={onTriggerDrawer}>
-            Trigger drawer (production rules)
-          </Button>
-          <Button appearance="base" onPress={onForceOpenDrawer}>
-            Force open drawer
-          </Button>
-        </Box>
-
-        <Text typography="body3" lx={{ color: "muted" }}>
-          Leave this screen to see the drawer. Production rules may skip the drawer if eligibility
-          checks fail — use force open to bypass them.
-        </Text>
-      </Box>
-    </SettingsNavigationScrollView>
-  );
-}
-
-function SectionTitle({ children }: Readonly<{ children: string }>) {
-  return (
-    <Text
-      typography="heading5SemiBold"
-      lx={{ color: "base", marginTop: "s16", marginBottom: "s8" }}
-    >
-      {children}
-    </Text>
-  );
-}
-
-function InfoRow({
-  label,
-  value,
-  valueColor = "base",
-}: Readonly<{
-  label: string;
-  value: string;
-  valueColor?: "base" | "success" | "error" | "muted";
-}>) {
-  return (
-    <Box lx={{ marginBottom: "s8" }}>
-      <Text typography="body3" lx={{ color: "muted" }}>
-        {label}
-      </Text>
-      <Text typography="body2SemiBold" lx={{ color: valueColor }} selectable>
-        {value}
-      </Text>
+      </SettingsNavigationScrollView>
     </Box>
   );
 }

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/useNotificationsPromptQaViewModel.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/useNotificationsPromptQaViewModel.ts
@@ -152,6 +152,8 @@ export function useNotificationsPromptQaViewModel() {
 
   const applyScenario = useCallback(
     (scenario: NotificationsQaScenario) => {
+      if (initialStateRef.current === null) return;
+
       const now = Date.now();
       const userData = buildNotificationsQaScenarioUserData(scenario, {
         repromptSchedule: brazePushNotifications?.params?.reprompt_schedule,
@@ -273,6 +275,8 @@ export function useNotificationsPromptQaViewModel() {
   }, [cancelPendingDrawer, openDrawer, resolvedPromptTarget, selectedSource]);
 
   const onMarkInactive = useCallback(() => {
+    if (initialStateRef.current === null) return;
+
     const now = Date.now();
     updatePushNotificationsDataOfUserInStateAndStore(
       buildInactiveUserData(
@@ -290,6 +294,8 @@ export function useNotificationsPromptQaViewModel() {
   ]);
 
   const onMarkRepromptable = useCallback(() => {
+    if (initialStateRef.current === null) return;
+
     const now = Date.now();
     updatePushNotificationsDataOfUserInStateAndStore(
       buildRepromptableUserData(
@@ -306,6 +312,8 @@ export function useNotificationsPromptQaViewModel() {
   ]);
 
   const onKeepTwoDismissals = useCallback(() => {
+    if (initialStateRef.current === null) return;
+
     updatePushNotificationsDataOfUserInStateAndStore(
       buildTruncatedDismissalsUserData(pushNotificationsDataOfUser, 2),
     );

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/useNotificationsPromptQaViewModel.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/useNotificationsPromptQaViewModel.ts
@@ -1,0 +1,359 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useFeature } from "@features/platform-feature-flags";
+import { setOverride } from "@shared/feature-flags";
+import {
+  evaluateAfterActionTrigger,
+  evaluateInactivityTrigger,
+  getNotificationPromptTarget,
+  type AfterActionTriggerDecision,
+  type InactivityTriggerDecision,
+} from "LLM/features/NotificationsPrompt/utils/notificationsPromptEngine";
+import { useNotificationsPrompt } from "LLM/features/NotificationsPrompt/new/NotificationsPromptProvider";
+import { useNotificationsData } from "LLM/features/NotificationsPrompt/hooks/useNotificationsData";
+import { useNotificationsPermission } from "LLM/hooks/useNotificationsPermission";
+import { useDispatch, useSelector } from "~/context/hooks";
+import {
+  setNotificationsDrawerPromptTarget,
+  setNotificationsDrawerSource,
+  setNotificationsModalOpen,
+} from "~/actions/notifications";
+import { completeOnboarding, setNotifications } from "~/actions/settings";
+import { ratingsModalOpenSelector } from "~/reducers/ratings";
+import { hasCompletedOnboardingSelector, notificationsSelector } from "~/reducers/settings";
+import {
+  buildDecisionInspectorFields,
+  buildFeatureInspectorFields,
+  buildInactiveUserData,
+  buildNotificationsQaScenarioUserData,
+  buildRepromptableUserData,
+  buildTruncatedDismissalsUserData,
+  buildUserStateInspectorFields,
+  getAfterActionRepromptLabel,
+  getForceOpenDrawerLabel,
+  getGlobalPushNotificationsDismissals,
+  getInactivityRepromptLabel,
+  getNotificationsQaHeadline,
+  NOTIFICATIONS_QA_VERDICT_META,
+  SOURCE_LABEL,
+  type NotificationsQaScenario,
+  type NotificationsQaTriggerSource,
+} from "./utils";
+
+export function useNotificationsPromptQaViewModel() {
+  const dispatch = useDispatch();
+  const [selectedSource, setSelectedSource] = useState<NotificationsQaTriggerSource>("onboarding");
+  const [hasSimulatedPermission, setHasSimulatedPermission] = useState(false);
+  const [evaluationNow, setEvaluationNow] = useState(() => Date.now());
+  const [isBaselineCaptured, setBaselineCaptured] = useState(false);
+
+  const brazePushNotifications = useFeature("brazePushNotifications");
+  const notifications = useSelector(notificationsSelector);
+  const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
+  const isRatingsModalOpen = useSelector(ratingsModalOpenSelector);
+  const { permissionStatus, setPermissionStatus } = useNotificationsPermission();
+  const { pushNotificationsDataOfUser, updatePushNotificationsDataOfUserInStateAndStore } =
+    useNotificationsData();
+  const { notifyFlowCompleted, openDrawer, isDrawerPending, cancelPendingDrawer } =
+    useNotificationsPrompt();
+
+  const initialStateRef = useRef<{
+    permissionStatus: NonNullable<typeof permissionStatus>;
+    notifications: typeof notifications;
+    hasCompletedOnboarding: boolean;
+    pushNotificationsDataOfUser: typeof pushNotificationsDataOfUser;
+  } | null>(null);
+
+  useEffect(() => {
+    if (
+      initialStateRef.current === null &&
+      permissionStatus !== null &&
+      permissionStatus !== undefined
+    ) {
+      initialStateRef.current = {
+        permissionStatus,
+        notifications,
+        hasCompletedOnboarding,
+        pushNotificationsDataOfUser,
+      };
+      setBaselineCaptured(true);
+    }
+  }, [hasCompletedOnboarding, notifications, permissionStatus, pushNotificationsDataOfUser]);
+
+  const globalDismissals = useMemo(
+    () => getGlobalPushNotificationsDismissals(pushNotificationsDataOfUser),
+    [pushNotificationsDataOfUser],
+  );
+
+  const decision = useMemo<AfterActionTriggerDecision | InactivityTriggerDecision>(() => {
+    const context = {
+      brazePushNotifications,
+      isRatingsModalOpen,
+      isDrawerPending: isDrawerPending(),
+      now: evaluationNow,
+    };
+
+    if (selectedSource === "inactivity") {
+      return evaluateInactivityTrigger(
+        {
+          permissionStatus,
+          areNotificationsAllowed: notifications.areNotificationsAllowed,
+          pushNotificationsDataOfUser,
+          hasCompletedOnboarding,
+        },
+        context,
+      );
+    }
+
+    return evaluateAfterActionTrigger(
+      {
+        source: selectedSource,
+        permissionStatus,
+        areNotificationsAllowed: notifications.areNotificationsAllowed,
+        transactionsAlertsCategory: notifications.transactionsAlertsCategory,
+        pushNotificationsDataOfUser,
+      },
+      context,
+    );
+  }, [
+    brazePushNotifications,
+    evaluationNow,
+    hasCompletedOnboarding,
+    isDrawerPending,
+    isRatingsModalOpen,
+    notifications.areNotificationsAllowed,
+    notifications.transactionsAlertsCategory,
+    permissionStatus,
+    pushNotificationsDataOfUser,
+    selectedSource,
+  ]);
+
+  const { verdict, reason, rawReason } = getNotificationsQaHeadline(decision);
+  const verdictMeta = NOTIFICATIONS_QA_VERDICT_META[verdict];
+  const resolvedPromptTarget =
+    decision.kind === "show"
+      ? decision.drawerPromptTarget
+      : (getNotificationPromptTarget({
+          permissionStatus,
+          areNotificationsAllowed: notifications.areNotificationsAllowed,
+          transactionsAlertsCategory: notifications.transactionsAlertsCategory,
+        }) ?? "globalPushNotifications");
+
+  const afterActionRepromptLabel = getAfterActionRepromptLabel({
+    dismissedOptInDrawerAtList: globalDismissals,
+    repromptSchedule: brazePushNotifications?.params?.reprompt_schedule,
+    now: evaluationNow,
+  });
+  const inactivityRepromptLabel = getInactivityRepromptLabel({
+    lastActionAt: pushNotificationsDataOfUser?.lastActionAt,
+    inactivityReprompt: brazePushNotifications?.params?.inactivity_reprompt,
+    inactivityEnabled: brazePushNotifications?.params?.inactivity_enabled,
+    now: evaluationNow,
+  });
+
+  const applyScenario = useCallback(
+    (scenario: NotificationsQaScenario) => {
+      const now = Date.now();
+      const userData = buildNotificationsQaScenarioUserData(scenario, {
+        repromptSchedule: brazePushNotifications?.params?.reprompt_schedule,
+        inactivityReprompt: brazePushNotifications?.params?.inactivity_reprompt,
+        now,
+      });
+
+      dispatch(
+        setOverride({
+          key: "brazePushNotifications",
+          value: {
+            ...brazePushNotifications,
+            enabled: true,
+            params: brazePushNotifications?.params ?? {},
+          },
+        }),
+      );
+      cancelPendingDrawer();
+      dispatch(setNotificationsModalOpen(false));
+      dispatch(setNotificationsDrawerSource(undefined));
+      dispatch(setNotificationsDrawerPromptTarget(undefined));
+      setPermissionStatus(scenario.permissionStatus);
+      setHasSimulatedPermission(true);
+      dispatch(
+        setNotifications({
+          ...notifications,
+          areNotificationsAllowed: scenario.areNotificationsAllowed,
+          transactionsAlertsCategory: scenario.transactionsAlertsCategory,
+        }),
+      );
+      dispatch(completeOnboarding(scenario.hasCompletedOnboarding));
+      updatePushNotificationsDataOfUserInStateAndStore(userData);
+      setSelectedSource(scenario.source);
+      setEvaluationNow(now);
+    },
+    [
+      brazePushNotifications,
+      cancelPendingDrawer,
+      dispatch,
+      notifications,
+      setPermissionStatus,
+      updatePushNotificationsDataOfUserInStateAndStore,
+    ],
+  );
+
+  const onResetAll = useCallback(() => {
+    const initialState = initialStateRef.current;
+    cancelPendingDrawer();
+    dispatch(setOverride({ key: "brazePushNotifications", value: undefined }));
+    if (initialState) {
+      updatePushNotificationsDataOfUserInStateAndStore(
+        initialState.pushNotificationsDataOfUser ?? {},
+      );
+      dispatch(setNotifications(initialState.notifications));
+      dispatch(completeOnboarding(initialState.hasCompletedOnboarding));
+      setPermissionStatus(initialState.permissionStatus);
+    }
+    dispatch(setNotificationsModalOpen(false));
+    dispatch(setNotificationsDrawerSource(undefined));
+    dispatch(setNotificationsDrawerPromptTarget(undefined));
+    setSelectedSource("onboarding");
+    setHasSimulatedPermission(false);
+    setEvaluationNow(Date.now());
+  }, [
+    cancelPendingDrawer,
+    dispatch,
+    setPermissionStatus,
+    updatePushNotificationsDataOfUserInStateAndStore,
+  ]);
+
+  const onTriggerProductionDrawer = useCallback(() => {
+    cancelPendingDrawer();
+    const now = Date.now();
+    setEvaluationNow(now);
+
+    if (selectedSource === "inactivity") {
+      const inactivityDecision = evaluateInactivityTrigger(
+        {
+          permissionStatus,
+          areNotificationsAllowed: notifications.areNotificationsAllowed,
+          pushNotificationsDataOfUser,
+          hasCompletedOnboarding,
+        },
+        {
+          brazePushNotifications,
+          isRatingsModalOpen,
+          isDrawerPending: isDrawerPending(),
+          now,
+        },
+      );
+      if (inactivityDecision.kind === "show") {
+        openDrawer(
+          inactivityDecision.source,
+          inactivityDecision.delayMs,
+          inactivityDecision.drawerPromptTarget,
+        );
+      }
+      return;
+    }
+    notifyFlowCompleted(selectedSource);
+  }, [
+    brazePushNotifications,
+    cancelPendingDrawer,
+    hasCompletedOnboarding,
+    isDrawerPending,
+    isRatingsModalOpen,
+    notifyFlowCompleted,
+    notifications.areNotificationsAllowed,
+    openDrawer,
+    permissionStatus,
+    pushNotificationsDataOfUser,
+    selectedSource,
+  ]);
+
+  const onForceOpenDrawer = useCallback(() => {
+    cancelPendingDrawer();
+    const source = selectedSource === "inactivity" ? "inactivity" : selectedSource;
+    openDrawer(source, 0, resolvedPromptTarget);
+  }, [cancelPendingDrawer, openDrawer, resolvedPromptTarget, selectedSource]);
+
+  const onMarkInactive = useCallback(() => {
+    const now = Date.now();
+    updatePushNotificationsDataOfUserInStateAndStore(
+      buildInactiveUserData(
+        pushNotificationsDataOfUser,
+        brazePushNotifications?.params?.inactivity_reprompt,
+        now,
+      ),
+    );
+    setSelectedSource("inactivity");
+    setEvaluationNow(now);
+  }, [
+    brazePushNotifications?.params?.inactivity_reprompt,
+    pushNotificationsDataOfUser,
+    updatePushNotificationsDataOfUserInStateAndStore,
+  ]);
+
+  const onMarkRepromptable = useCallback(() => {
+    const now = Date.now();
+    updatePushNotificationsDataOfUserInStateAndStore(
+      buildRepromptableUserData(
+        pushNotificationsDataOfUser,
+        brazePushNotifications?.params?.reprompt_schedule,
+        now,
+      ),
+    );
+    setEvaluationNow(now);
+  }, [
+    brazePushNotifications?.params?.reprompt_schedule,
+    pushNotificationsDataOfUser,
+    updatePushNotificationsDataOfUserInStateAndStore,
+  ]);
+
+  const onKeepTwoDismissals = useCallback(() => {
+    updatePushNotificationsDataOfUserInStateAndStore(
+      buildTruncatedDismissalsUserData(pushNotificationsDataOfUser, 2),
+    );
+  }, [pushNotificationsDataOfUser, updatePushNotificationsDataOfUserInStateAndStore]);
+
+  const userStateFields = buildUserStateInspectorFields({
+    permissionStatus,
+    hasSimulatedPermission,
+    areNotificationsAllowed: notifications.areNotificationsAllowed,
+    transactionsAlertsCategory: notifications.transactionsAlertsCategory,
+    hasCompletedOnboarding,
+    globalDismissals,
+    lastActionAt: pushNotificationsDataOfUser?.lastActionAt,
+  });
+  const decisionFields = buildDecisionInspectorFields({
+    selectedSource,
+    decision,
+    resolvedPromptTarget,
+    verdictTone: verdictMeta.tone,
+  });
+  const featureFields = buildFeatureInspectorFields({
+    selectedSource,
+    brazePushNotifications,
+    afterActionRepromptLabel,
+    inactivityRepromptLabel,
+  });
+
+  return {
+    selectedSource,
+    setSelectedSource,
+    isBaselineCaptured,
+    verdict,
+    verdictMeta,
+    reason,
+    rawReason,
+    resolvedPromptTarget,
+    forceOpenDrawerLabel: getForceOpenDrawerLabel(resolvedPromptTarget),
+    decision,
+    sourceLabel: SOURCE_LABEL[selectedSource],
+    applyScenario,
+    onResetAll,
+    onTriggerProductionDrawer,
+    onForceOpenDrawer,
+    onMarkInactive,
+    onMarkRepromptable,
+    onKeepTwoDismissals,
+    userStateFields,
+    decisionFields,
+    featureFields,
+  };
+}

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/utils.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/utils.ts
@@ -10,6 +10,7 @@ import type {
   NotificationsPromptRepromptDelay,
   NotificationsPromptSkipReason,
 } from "LLM/features/NotificationsPrompt";
+import type { QaInspectorField, QaInspectorFieldTone } from "LLM/components/QaInspectorRow";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
@@ -234,20 +235,27 @@ export type NotificationsQaScenario = {
   userData: "firstPrompt" | "alreadyOptedIn" | "tooSoon" | "eligibleAfterAction" | "inactive";
 };
 
+/** Opted-out user who already went through onboarding: the common QA starting point. */
+const SCENARIO_DEFAULTS = {
+  permissionStatus: AuthorizationStatus.DENIED,
+  areNotificationsAllowed: false,
+  transactionsAlertsCategory: false,
+  hasCompletedOnboarding: true,
+} satisfies Partial<NotificationsQaScenario>;
+
 export const NOTIFICATIONS_QA_SCENARIOS: NotificationsQaScenario[] = [
   {
+    ...SCENARIO_DEFAULTS,
     id: "first-prompt",
     name: "First prompt",
     summary: "No previous dismissal → drawer can show after onboarding",
     expected: "Show drawer",
     source: "onboarding",
     permissionStatus: AuthorizationStatus.NOT_DETERMINED,
-    areNotificationsAllowed: false,
-    transactionsAlertsCategory: false,
-    hasCompletedOnboarding: true,
     userData: "firstPrompt",
   },
   {
+    ...SCENARIO_DEFAULTS,
     id: "already-opted-in",
     name: "Already opted in",
     summary: "OS, app and transaction alerts are on → skip",
@@ -256,43 +264,33 @@ export const NOTIFICATIONS_QA_SCENARIOS: NotificationsQaScenario[] = [
     permissionStatus: AuthorizationStatus.AUTHORIZED,
     areNotificationsAllowed: true,
     transactionsAlertsCategory: true,
-    hasCompletedOnboarding: true,
     userData: "alreadyOptedIn",
   },
   {
+    ...SCENARIO_DEFAULTS,
     id: "too-soon",
     name: "Too soon to ask again",
     summary: "A recent dismissal keeps the drawer inside its cooldown",
     expected: "Skip",
     source: "send",
-    permissionStatus: AuthorizationStatus.DENIED,
-    areNotificationsAllowed: false,
-    transactionsAlertsCategory: false,
-    hasCompletedOnboarding: true,
     userData: "tooSoon",
   },
   {
+    ...SCENARIO_DEFAULTS,
     id: "eligible-after-action",
     name: "Eligible after action",
     summary: "The dismissal cooldown has elapsed → drawer can show",
     expected: "Show drawer",
     source: "send",
-    permissionStatus: AuthorizationStatus.DENIED,
-    areNotificationsAllowed: false,
-    transactionsAlertsCategory: false,
-    hasCompletedOnboarding: true,
     userData: "eligibleAfterAction",
   },
   {
+    ...SCENARIO_DEFAULTS,
     id: "inactive-user",
     name: "Inactive user",
     summary: "The inactivity threshold has elapsed → drawer can show",
     expected: "Show drawer",
     source: "inactivity",
-    permissionStatus: AuthorizationStatus.DENIED,
-    areNotificationsAllowed: false,
-    transactionsAlertsCategory: false,
-    hasCompletedOnboarding: true,
     userData: "inactive",
   },
 ];
@@ -423,14 +421,8 @@ export const SOURCE_LABEL: Record<NotificationsQaTriggerSource, string> = {
   inactivity: "Inactivity",
 };
 
-export type NotificationsQaInspectorFieldTone = "success" | "error" | "warning" | "gray";
-
-export type NotificationsQaInspectorField = {
-  label: string;
-  value: string;
-  raw?: string;
-  status: { label: string; tone: NotificationsQaInspectorFieldTone };
-};
+export type NotificationsQaInspectorFieldTone = QaInspectorFieldTone;
+export type NotificationsQaInspectorField = QaInspectorField;
 
 type BrazePushNotificationsFeature = Features["brazePushNotifications"] | null | undefined;
 

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/utils.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/utils.ts
@@ -1,7 +1,12 @@
 import { add, sub } from "date-fns";
+import { AuthorizationStatus } from "@react-native-firebase/messaging";
 import type {
+  AfterActionTriggerDecision,
   DataOfUser,
+  InactivityTriggerDecision,
+  NotificationsPromptAfterActionSource,
   NotificationsPromptRepromptDelay,
+  NotificationsPromptSkipReason,
 } from "LLM/features/NotificationsPrompt";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -209,4 +214,188 @@ export const buildTruncatedDismissalsUserData = (
       globalPushNotifications: dismissedOptInDrawerAtList,
     },
   };
+};
+
+export type NotificationsQaExpectation = "Show drawer" | "Skip" | "Blocked";
+export type NotificationsQaTriggerSource = NotificationsPromptAfterActionSource | "inactivity";
+
+export type NotificationsQaScenario = {
+  id: string;
+  name: string;
+  summary: string;
+  expected: NotificationsQaExpectation;
+  source: NotificationsQaTriggerSource;
+  permissionStatus: (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus];
+  areNotificationsAllowed: boolean;
+  transactionsAlertsCategory: boolean;
+  hasCompletedOnboarding: boolean;
+  userData: "firstPrompt" | "alreadyOptedIn" | "tooSoon" | "eligibleAfterAction" | "inactive";
+};
+
+export const NOTIFICATIONS_QA_SCENARIOS: NotificationsQaScenario[] = [
+  {
+    id: "first-prompt",
+    name: "First prompt",
+    summary: "No previous dismissal → drawer can show after onboarding",
+    expected: "Show drawer",
+    source: "onboarding",
+    permissionStatus: AuthorizationStatus.NOT_DETERMINED,
+    areNotificationsAllowed: false,
+    transactionsAlertsCategory: false,
+    hasCompletedOnboarding: true,
+    userData: "firstPrompt",
+  },
+  {
+    id: "already-opted-in",
+    name: "Already opted in",
+    summary: "OS, app and transaction alerts are on → skip",
+    expected: "Skip",
+    source: "send",
+    permissionStatus: AuthorizationStatus.AUTHORIZED,
+    areNotificationsAllowed: true,
+    transactionsAlertsCategory: true,
+    hasCompletedOnboarding: true,
+    userData: "alreadyOptedIn",
+  },
+  {
+    id: "too-soon",
+    name: "Too soon to ask again",
+    summary: "A recent dismissal keeps the drawer inside its cooldown",
+    expected: "Skip",
+    source: "send",
+    permissionStatus: AuthorizationStatus.DENIED,
+    areNotificationsAllowed: false,
+    transactionsAlertsCategory: false,
+    hasCompletedOnboarding: true,
+    userData: "tooSoon",
+  },
+  {
+    id: "eligible-after-action",
+    name: "Eligible after action",
+    summary: "The dismissal cooldown has elapsed → drawer can show",
+    expected: "Show drawer",
+    source: "send",
+    permissionStatus: AuthorizationStatus.DENIED,
+    areNotificationsAllowed: false,
+    transactionsAlertsCategory: false,
+    hasCompletedOnboarding: true,
+    userData: "eligibleAfterAction",
+  },
+  {
+    id: "inactive-user",
+    name: "Inactive user",
+    summary: "The inactivity threshold has elapsed → drawer can show",
+    expected: "Show drawer",
+    source: "inactivity",
+    permissionStatus: AuthorizationStatus.DENIED,
+    areNotificationsAllowed: false,
+    transactionsAlertsCategory: false,
+    hasCompletedOnboarding: true,
+    userData: "inactive",
+  },
+];
+
+export const NOTIFICATIONS_QA_GROUPS: NotificationsQaExpectation[] = ["Skip", "Show drawer"];
+
+export const NOTIFICATIONS_QA_VERDICT_META: Record<
+  NotificationsQaExpectation,
+  { hint: string; tone: "success" | "warning" | "error" }
+> = {
+  "Show drawer": {
+    hint: "Production eligibility says this drawer can be shown.",
+    tone: "success",
+  },
+  Skip: {
+    hint: "The current user state does not need a drawer.",
+    tone: "warning",
+  },
+  Blocked: {
+    hint: "A configuration or runtime gate prevents the drawer.",
+    tone: "error",
+  },
+};
+
+export const NOTIFICATIONS_PROMPT_REASON_LABEL: Record<NotificationsPromptSkipReason, string> = {
+  feature_disabled: "Feature flag disabled",
+  configuration_missing: "Configuration missing",
+  ratings_modal_open: "Ratings modal is open",
+  drawer_already_pending: "Drawer already pending",
+  fully_opted_in: "Already opted in",
+  reprompt_delay_not_reached: "Too soon to ask again",
+  action_event_disabled: "This action does not trigger the prompt",
+  transactions_alerts_not_eligible: "Transaction alerts not eligible for this action",
+  onboarding_incomplete: "Onboarding incomplete",
+  user_not_inactive: "User is still active",
+  globally_opted_in_no_inactivity_drawer: "Already opted in — no inactivity prompt",
+};
+
+const BLOCKED_REASONS = new Set<NotificationsPromptSkipReason>([
+  "feature_disabled",
+  "configuration_missing",
+  "ratings_modal_open",
+  "drawer_already_pending",
+  "onboarding_incomplete",
+]);
+
+export const mapNotificationsDecisionToQaExpectation = (
+  decision: AfterActionTriggerDecision | InactivityTriggerDecision,
+): NotificationsQaExpectation => {
+  if (decision.kind === "show") {
+    return "Show drawer";
+  }
+
+  return BLOCKED_REASONS.has(decision.reason) ? "Blocked" : "Skip";
+};
+
+export const buildNotificationsQaScenarioUserData = (
+  scenario: NotificationsQaScenario,
+  {
+    repromptSchedule,
+    inactivityReprompt,
+    now,
+  }: {
+    repromptSchedule: NotificationsPromptRepromptDelay[] | null | undefined;
+    inactivityReprompt: NotificationsPromptRepromptDelay | null | undefined;
+    now: number;
+  },
+): DataOfUser => {
+  switch (scenario.userData) {
+    case "firstPrompt":
+      return {
+        dismissedOptInDrawerAtList: [],
+        dismissedPromptAtListByTarget: { globalPushNotifications: [] },
+        lastActionAt: now,
+      };
+    case "alreadyOptedIn":
+      return { lastActionAt: now };
+    case "tooSoon":
+      return {
+        dismissedOptInDrawerAtList: [now],
+        dismissedPromptAtListByTarget: { globalPushNotifications: [now] },
+        lastActionAt: now,
+      };
+    case "eligibleAfterAction":
+      return buildRepromptableUserData(undefined, repromptSchedule, now);
+    case "inactive":
+      return buildInactiveUserData(undefined, inactivityReprompt, now);
+  }
+};
+
+export const formatPermissionStatus = (
+  status: (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus] | null | undefined,
+): string => {
+  switch (status) {
+    case AuthorizationStatus.AUTHORIZED:
+      return "Authorized";
+    case AuthorizationStatus.DENIED:
+      return "Denied";
+    case AuthorizationStatus.NOT_DETERMINED:
+      return "Not determined";
+    case AuthorizationStatus.PROVISIONAL:
+      return "Provisional";
+    case AuthorizationStatus.EPHEMERAL:
+      return "Ephemeral";
+    default:
+      return "Unknown";
+  }
 };

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/utils.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/NotificationsPromptQA/utils.ts
@@ -1,9 +1,11 @@
 import { add, sub } from "date-fns";
 import { AuthorizationStatus } from "@react-native-firebase/messaging";
+import type { Features } from "@shared/feature-flags";
 import type {
   AfterActionTriggerDecision,
   DataOfUser,
   InactivityTriggerDecision,
+  NotificationPromptTarget,
   NotificationsPromptAfterActionSource,
   NotificationsPromptRepromptDelay,
   NotificationsPromptSkipReason,
@@ -399,3 +401,246 @@ export const formatPermissionStatus = (
       return "Unknown";
   }
 };
+
+export const TRIGGER_SOURCES: NotificationsQaTriggerSource[] = [
+  "onboarding",
+  "send",
+  "receive",
+  "swap",
+  "stake",
+  "add_favorite_coin",
+  "inactivity",
+];
+
+export const SOURCE_LABEL: Record<NotificationsQaTriggerSource, string> = {
+  onboarding: "Onboarding",
+  send: "Send",
+  receive: "Receive",
+  swap: "Swap",
+  stake: "Stake",
+  add_favorite_coin: "Add favourite coin",
+  dapp_complete: "DApp complete",
+  inactivity: "Inactivity",
+};
+
+export type NotificationsQaInspectorFieldTone = "success" | "error" | "warning" | "gray";
+
+export type NotificationsQaInspectorField = {
+  label: string;
+  value: string;
+  raw?: string;
+  status: { label: string; tone: NotificationsQaInspectorFieldTone };
+};
+
+type BrazePushNotificationsFeature = Features["brazePushNotifications"] | null | undefined;
+
+export function formatDelay(delay: Record<string, number> | null | undefined): string {
+  if (!delay) return "Not configured";
+
+  const parts = Object.entries(delay)
+    .filter(([, value]) => value > 0)
+    .map(([unit, value]) => `${value} ${unit}`);
+  return parts.length > 0 ? parts.join(", ") : "Immediately";
+}
+
+export function getForceOpenDrawerLabel(target: NotificationPromptTarget): string {
+  return `Force open ${target} drawer — bypass rules`;
+}
+
+export function getSelectedActionEvent(
+  selectedSource: NotificationsQaTriggerSource,
+  brazePushNotifications: BrazePushNotificationsFeature,
+) {
+  if (selectedSource === "inactivity") return undefined;
+  const actionEventKey = selectedSource === "onboarding" ? "complete_onboarding" : selectedSource;
+  return brazePushNotifications?.params?.action_events?.[actionEventKey];
+}
+
+export function getNotificationsQaHeadline(
+  decision: AfterActionTriggerDecision | InactivityTriggerDecision,
+): { verdict: NotificationsQaExpectation; reason: string; rawReason: string } {
+  const verdict = mapNotificationsDecisionToQaExpectation(decision);
+  return {
+    verdict,
+    reason:
+      decision.kind === "show"
+        ? "Eligible now"
+        : NOTIFICATIONS_PROMPT_REASON_LABEL[decision.reason],
+    rawReason: decision.kind === "show" ? "kind: show" : `reason: ${decision.reason}`,
+  };
+}
+
+export function buildUserStateInspectorFields({
+  permissionStatus,
+  hasSimulatedPermission,
+  areNotificationsAllowed,
+  transactionsAlertsCategory,
+  hasCompletedOnboarding,
+  globalDismissals,
+  lastActionAt,
+}: {
+  permissionStatus:
+    | (typeof AuthorizationStatus)[keyof typeof AuthorizationStatus]
+    | null
+    | undefined;
+  hasSimulatedPermission: boolean;
+  areNotificationsAllowed: boolean;
+  transactionsAlertsCategory: boolean;
+  hasCompletedOnboarding: boolean;
+  globalDismissals: number[] | undefined;
+  lastActionAt: number | undefined;
+}): NotificationsQaInspectorField[] {
+  return [
+    {
+      label: "OS notification permission",
+      value: formatPermissionStatus(permissionStatus),
+      raw: `permissionStatus: ${String(permissionStatus)}${
+        hasSimulatedPermission ? " · simulated until app foreground sync" : ""
+      }`,
+      status: {
+        label: permissionStatus === AuthorizationStatus.AUTHORIZED ? "On" : "Off",
+        tone: permissionStatus === AuthorizationStatus.AUTHORIZED ? "success" : "gray",
+      },
+    },
+    {
+      label: "App notifications",
+      value: areNotificationsAllowed ? "Enabled" : "Disabled",
+      raw: `areNotificationsAllowed: ${String(areNotificationsAllowed)}`,
+      status: {
+        label: areNotificationsAllowed ? "On" : "Off",
+        tone: areNotificationsAllowed ? "success" : "gray",
+      },
+    },
+    {
+      label: "Transaction alerts",
+      value: transactionsAlertsCategory ? "Enabled" : "Disabled",
+      raw: `transactionsAlertsCategory: ${String(transactionsAlertsCategory)}`,
+      status: {
+        label: transactionsAlertsCategory ? "On" : "Off",
+        tone: transactionsAlertsCategory ? "success" : "gray",
+      },
+    },
+    {
+      label: "Onboarding",
+      value: hasCompletedOnboarding ? "Complete" : "Incomplete",
+      raw: `hasCompletedOnboarding: ${String(hasCompletedOnboarding)}`,
+      status: {
+        label: hasCompletedOnboarding ? "Ready" : "Blocked",
+        tone: hasCompletedOnboarding ? "success" : "error",
+      },
+    },
+    {
+      label: "Stored dismissals",
+      value: `${globalDismissals?.length ?? 0} dismissal(s)`,
+      raw: `globalPushNotifications: ${JSON.stringify(globalDismissals ?? [])}`,
+      status: {
+        label: globalDismissals?.length ? "Saved" : "Empty",
+        tone: "gray",
+      },
+    },
+    {
+      label: "Last activity",
+      value: lastActionAt ? formatDismissalTimestamp(lastActionAt).local : "Missing",
+      raw: `lastActionAt: ${String(lastActionAt)}`,
+      status: {
+        label: lastActionAt ? "Saved" : "Missing",
+        tone: "gray",
+      },
+    },
+  ];
+}
+
+export function buildDecisionInspectorFields({
+  selectedSource,
+  decision,
+  resolvedPromptTarget,
+  verdictTone,
+}: {
+  selectedSource: NotificationsQaTriggerSource;
+  decision: AfterActionTriggerDecision | InactivityTriggerDecision;
+  resolvedPromptTarget: NotificationPromptTarget;
+  verdictTone: NotificationsQaInspectorFieldTone;
+}): NotificationsQaInspectorField[] {
+  return [
+    {
+      label: "Selected trigger",
+      value: SOURCE_LABEL[selectedSource],
+      raw: `source: ${selectedSource}`,
+      status: {
+        label: decision.kind === "show" ? "Show" : "Skip",
+        tone: verdictTone,
+      },
+    },
+    {
+      label: "Drawer target",
+      value: resolvedPromptTarget,
+      raw: `drawerPromptTarget: ${resolvedPromptTarget} · dismissedCount: ${decision.dismissedCount}`,
+      status: { label: "Resolved", tone: "success" },
+    },
+  ];
+}
+
+export function buildFeatureInspectorFields({
+  selectedSource,
+  brazePushNotifications,
+  afterActionRepromptLabel,
+  inactivityRepromptLabel,
+}: {
+  selectedSource: NotificationsQaTriggerSource;
+  brazePushNotifications: BrazePushNotificationsFeature;
+  afterActionRepromptLabel: string;
+  inactivityRepromptLabel: string;
+}): NotificationsQaInspectorField[] {
+  const selectedActionEvent = getSelectedActionEvent(selectedSource, brazePushNotifications);
+  const inactivityField: NotificationsQaInspectorField = {
+    label: "Inactivity prompt",
+    value: brazePushNotifications?.params?.inactivity_enabled ? "Enabled" : "Disabled",
+    raw: `inactivity_reprompt: ${formatDelay(brazePushNotifications?.params?.inactivity_reprompt)}`,
+    status: {
+      label: brazePushNotifications?.params?.inactivity_enabled ? "On" : "Off",
+      tone: brazePushNotifications?.params?.inactivity_enabled ? "success" : "error",
+    },
+  };
+  const actionField: NotificationsQaInspectorField = {
+    label: `${SOURCE_LABEL[selectedSource]} action`,
+    value: selectedActionEvent?.enabled ? "Enabled" : "Disabled",
+    raw: `timer: ${selectedActionEvent?.timer ?? "missing"} ms`,
+    status: {
+      label: selectedActionEvent?.enabled ? "On" : "Off",
+      tone: selectedActionEvent?.enabled ? "success" : "error",
+    },
+  };
+
+  return [
+    {
+      label: "Braze notifications prompt",
+      value: brazePushNotifications?.enabled ? "Enabled" : "Disabled",
+      raw: "feature: brazePushNotifications",
+      status: {
+        label: brazePushNotifications?.enabled ? "On" : "Off",
+        tone: brazePushNotifications?.enabled ? "success" : "error",
+      },
+    },
+    selectedSource === "inactivity" ? inactivityField : actionField,
+    {
+      label: "After-action reprompt",
+      value: afterActionRepromptLabel,
+      raw: `reprompt_schedule: ${
+        brazePushNotifications?.params?.reprompt_schedule?.length ?? 0
+      } step(s)`,
+      status: {
+        label: afterActionRepromptLabel.includes("eligible") ? "Ready" : "Waiting",
+        tone: afterActionRepromptLabel.includes("eligible") ? "success" : "warning",
+      },
+    },
+    {
+      label: "Inactivity reprompt",
+      value: inactivityRepromptLabel,
+      raw: `inactivity_reprompt: ${formatDelay(brazePushNotifications?.params?.inactivity_reprompt)}`,
+      status: {
+        label: inactivityRepromptLabel.includes("eligible") ? "Ready" : "Waiting",
+        tone: inactivityRepromptLabel.includes("eligible") ? "success" : "warning",
+      },
+    },
+  ];
+}


### PR DESCRIPTION
### 📝 Description

**Problem**: the LWM notifications prompt debug screen (Settings → Debug → Notifications prompt QA) could not be used by QA without an engineer. Field labels exposed implementation names (`isOptIn`, `dismissedCount`, the raw OS permission enum), feature flag params rendered as JSON, actions used engineer verbs, and the screen never stated whether the drawer would show or why.

**Solution**: the screen is reshaped after the Analytics consent QA screen, and every verdict is computed from `notificationsPromptEngine` rather than duplicating eligibility rules.

- Headline card with a plain-English verdict (`Show drawer`, `Skip`, `Blocked`) and the reason behind it.
- **Scenarios** tab with named presets grouped by expected outcome: first prompt, already opted in, too soon to ask again, eligible after action, inactive user. Applying a preset sets OS permission, notification settings, onboarding state and stored prompt history deterministically.
- **Inspect** tab with human labels and status tags, raw values on a secondary line, including the resolved `brazePushNotifications` configuration.
- In-place drawer preview: the drawer content was extracted into `NotificationsPromptDrawerView`, which the QA screen mounts in its own local drawer so previewing never touches production prompt state.
- `Reset all` restores the state captured when the screen was opened and clears the feature flag override.
- Force open is kept as a secondary action and labelled as a bypass of production rules.

Production behaviour is unchanged. The drawer scheduler is now shared through `NotificationsPromptProvider` (which also exposes `cancelPendingDrawer`) so the QA screen reuses the single scheduler instead of instantiating a second one, and skip reasons map to labels the same way analytics consent maps `REASON_LABEL`.

| Scenarios | Bottom sheet | Inspect |
| --- | --- | --- |
| <img width="240" alt="Notifications prompt QA — Scenarios tab" src="https://github.com/user-attachments/assets/1f18efb9-0973-49c9-9dee-0cc53218fa78" /> | <img width="240" alt="Notifications prompt QA — drawer preview" src="https://github.com/user-attachments/assets/6ce949d0-dc50-4dc4-aac1-235ee0d518dc" /> | <img width="240" alt="Notifications prompt QA — Inspect tab" src="https://github.com/user-attachments/assets/d3a5c699-a189-4bac-92cd-8e7b1eb6032a" /> |

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35955](https://ledgerhq.atlassian.net/browse/LIVE-35955)
- Relates to [LIVE-27106](https://ledgerhq.atlassian.net/browse/LIVE-27106) (original debug screen)
- **ADR** (if any): n/a

### ✅ Checks

- `pnpm --filter live-mobile exec jest src/screens/Settings/Debug/NotificationsPromptQA` → 26 passed, including one case per QA scenario asserting the engine decision matches the advertised outcome.
- `pnpm --filter live-mobile exec oxlint` on the changed paths → warnings only, all pre-existing.
- Suites under `src/mvvm/features/NotificationsPrompt` that fail on `@shared/i18n` / `@ledgerhq/live-common/families/hedera/...` resolution fail the same way on `develop` (unbuilt workspace packages), unrelated to this change.

### 🧪 QA focus

- Apply each scenario and confirm the headline verdict and reason match the scenario name.
- Preview the drawer from the QA screen and confirm no production drawer is queued afterwards.
- Trigger by source (onboarding, send, receive, swap, stake, add favourite coin) and inactivity, then confirm the production drawer still appears as before.
- `Reset all`, then confirm the inspector returns to the values seen when the screen was opened.
- Run through both iOS and Android debug builds.

[LIVE-35955]: https://ledgerhq.atlassian.net/browse/LIVE-35955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
