### PR TITLE
chore(dmk): bump DMK packages to latest

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,11 +40,11 @@ catalogs:
       specifier: 2.0.4
       version: 2.0.4
     '@ledgerhq/device-contacts-kit':
-      specifier: 0.3.1
-      version: 0.3.1
+      specifier: 0.4.0
+      version: 0.4.0
     '@ledgerhq/device-management-kit':
-      specifier: 1.8.0
-      version: 1.8.0
+      specifier: 1.9.0
+      version: 1.9.0
     '@ledgerhq/device-signer-kit-aleo':
       specifier: 0.4.0
       version: 0.4.0
@@ -55,8 +55,8 @@ catalogs:
       specifier: 1.0.1
       version: 1.0.1
     '@ledgerhq/device-signer-kit-ethereum':
-      specifier: 1.17.0
-      version: 1.17.0
+      specifier: 1.18.0
+      version: 1.18.0
     '@ledgerhq/device-signer-kit-hyperliquid':
       specifier: 0.0.0-hyperliquid-unified-20260728150448
       version: 0.0.0-hyperliquid-unified-20260728150448
@@ -1019,16 +1019,16 @@ importers:
         version: link:../../libs/coin-modules/coin-zcash
       '@ledgerhq/context-module':
         specifier: 2.5.0
-        version: 2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+        version: 2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
         version: 2.0.4(@ledgerhq/lumen-design-core@0.1.27)(@ledgerhq/lumen-ui-react@0.1.56(@ledgerhq/lumen-design-core@0.1.27)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.8.0(rxjs@7.8.2)
+        version: 1.9.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-ethereum':
         specifier: 'catalog:'
-        version: 1.17.0(@ledgerhq/context-module@2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+        version: 1.18.0(@ledgerhq/context-module@2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../libs/ledgerjs/packages/devices
@@ -1846,7 +1846,7 @@ importers:
         version: link:../../libs/coin-modules/coin-stacks
       '@ledgerhq/context-module':
         specifier: 2.5.0
-        version: 2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+        version: 2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
         version: 2.0.4(@ledgerhq/lumen-design-core@0.1.27)(@ledgerhq/lumen-ui-rnative@0.1.59(95a5529a40b265321b5bf1b94e2a2591))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
@@ -1855,13 +1855,13 @@ importers:
         version: link:../../libs/device-core
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.8.0(rxjs@7.8.2)
+        version: 1.9.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-ethereum':
         specifier: 'catalog:'
-        version: 1.17.0(@ledgerhq/context-module@2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+        version: 1.18.0(@ledgerhq/context-module@2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@ledgerhq/device-transport-kit-react-native-hid':
         specifier: 'catalog:'
-        version: 1.0.4(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(rxjs@7.8.2)
+        version: 1.0.4(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(rxjs@7.8.2)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../libs/ledgerjs/packages/devices
@@ -2636,13 +2636,13 @@ importers:
         version: link:../../libs/coin-modules/coin-solana
       '@ledgerhq/context-module':
         specifier: 2.5.0
-        version: 2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+        version: 2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.8.0(rxjs@7.8.2)
+        version: 1.9.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-ethereum':
         specifier: 'catalog:'
-        version: 1.17.0(@ledgerhq/context-module@2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+        version: 1.18.0(@ledgerhq/context-module@2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@ledgerhq/hw-app-exchange':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/hw-app-exchange
@@ -2846,10 +2846,10 @@ importers:
         version: 2.0.4(@ledgerhq/lumen-design-core@0.1.27)(@ledgerhq/lumen-ui-react@0.1.56(@ledgerhq/lumen-design-core@0.1.27)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.8.0(bufferutil@4.1.0)(rxjs@7.8.2)(utf-8-validate@6.0.6)
+        version: 1.9.0(bufferutil@4.1.0)(rxjs@7.8.2)(utf-8-validate@6.0.6)
       '@ledgerhq/device-transport-kit-web-hid':
         specifier: 'catalog:'
-        version: 1.2.4(@ledgerhq/device-management-kit@1.8.0(bufferutil@4.1.0)(rxjs@7.8.2)(utf-8-validate@6.0.6))(rxjs@7.8.2)
+        version: 1.2.4(@ledgerhq/device-management-kit@1.9.0(bufferutil@4.1.0)(rxjs@7.8.2)(utf-8-validate@6.0.6))(rxjs@7.8.2)
       '@ledgerhq/domain-service':
         specifier: workspace:^
         version: link:../../libs/domain-service
@@ -7516,10 +7516,10 @@ importers:
         version: link:../feature-flags
       '@ledgerhq/device-contacts-kit':
         specifier: 'catalog:'
-        version: 0.3.1(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+        version: 0.4.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@ledgerhq/device-signer-kit-ethereum':
         specifier: 'catalog:'
-        version: 1.17.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+        version: 1.18.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@shared/feature-flags':
         specifier: workspace:^
         version: link:../../../shared/feature-flags
@@ -7532,7 +7532,7 @@ importers:
     devDependencies:
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.8.0(rxjs@7.8.2)
+        version: 1.9.0(rxjs@7.8.2)
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
         version: 0.1.56(@ledgerhq/lumen-design-core@0.1.27)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
@@ -7760,7 +7760,7 @@ importers:
     devDependencies:
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.8.0(rxjs@7.8.2)
+        version: 1.9.0(rxjs@7.8.2)
       '@ledgerhq/test-quarantine':
         specifier: workspace:*
         version: link:../../../support/test-quarantine
@@ -7953,7 +7953,7 @@ importers:
     devDependencies:
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.8.0(rxjs@7.8.2)
+        version: 1.9.0(rxjs@7.8.2)
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -12637,16 +12637,16 @@ importers:
         version: link:../coin-modules/coin-zcash
       '@ledgerhq/context-module':
         specifier: 2.5.0
-        version: 2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+        version: 2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@ledgerhq/device-core':
         specifier: workspace:^
         version: link:../device-core
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.8.0(rxjs@7.8.2)
+        version: 1.9.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-ethereum':
         specifier: 'catalog:'
-        version: 1.17.0(@ledgerhq/context-module@2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+        version: 1.18.0(@ledgerhq/context-module@2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../ledgerjs/packages/devices
@@ -13818,7 +13818,7 @@ importers:
     dependencies:
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.8.0
+        version: 1.9.0
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../hw-transport
@@ -14926,10 +14926,10 @@ importers:
     dependencies:
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.8.0(rxjs@7.8.2)
+        version: 1.9.0(rxjs@7.8.2)
       '@ledgerhq/device-transport-kit-web-hid':
         specifier: 'catalog:'
-        version: 1.2.4(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))(rxjs@7.8.2)
+        version: 1.2.4(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))(rxjs@7.8.2)
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../ledgerjs/packages/hw-transport
@@ -14996,10 +14996,10 @@ importers:
     dependencies:
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.8.0(rxjs@7.8.2)
+        version: 1.9.0(rxjs@7.8.2)
       '@ledgerhq/device-transport-kit-react-native-ble':
         specifier: 'catalog:'
-        version: 1.3.2(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))(react-native-ble-plx@3.5.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(react@19.1.4))(rxjs@7.8.2)
+        version: 1.3.2(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))(react-native-ble-plx@3.5.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(react@19.1.4))(rxjs@7.8.2)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../ledgerjs/packages/devices
@@ -15024,7 +15024,7 @@ importers:
     devDependencies:
       '@ledgerhq/device-transport-kit-react-native-hid':
         specifier: 'catalog:'
-        version: 1.0.4(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(react@19.1.4))(rxjs@7.8.2)
+        version: 1.0.4(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(react@19.1.4))(rxjs@7.8.2)
       '@ledgerhq/test-quarantine':
         specifier: workspace:*
         version: link:../../support/test-quarantine
@@ -15078,10 +15078,10 @@ importers:
     dependencies:
       '@ledgerhq/context-module':
         specifier: 2.5.0
-        version: 2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+        version: 2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@ledgerhq/dmk-ledger-wallet':
         specifier: 'catalog:'
-        version: 0.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+        version: 0.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../ledgerjs/packages/hw-transport
@@ -15109,7 +15109,7 @@ importers:
     devDependencies:
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.8.0(rxjs@7.8.2)
+        version: 1.9.0(rxjs@7.8.2)
       '@ledgerhq/test-quarantine':
         specifier: workspace:*
         version: link:../../support/test-quarantine
@@ -15157,10 +15157,10 @@ importers:
     dependencies:
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.8.0(rxjs@7.8.2)
+        version: 1.9.0(rxjs@7.8.2)
       '@ledgerhq/device-transport-kit-speculos':
         specifier: 'catalog:'
-        version: 1.2.1(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))(rxjs@7.8.2)
+        version: 1.2.1(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))(rxjs@7.8.2)
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../ledgerjs/packages/hw-transport
@@ -15169,7 +15169,7 @@ importers:
         version: 6.19.0
       '@ledgerhq/speculos-device-controller':
         specifier: 'catalog:'
-        version: 0.3.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+        version: 0.3.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@shared/env':
         specifier: workspace:*
         version: link:../../shared/env
@@ -15230,7 +15230,7 @@ importers:
         version: link:../device-core
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.8.0(rxjs@7.8.2)
+        version: 1.9.0(rxjs@7.8.2)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../ledgerjs/packages/devices
@@ -15260,7 +15260,7 @@ importers:
         version: 6.19.0
       '@ledgerhq/speculos-device-controller':
         specifier: 'catalog:'
-        version: 0.3.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+        version: 0.3.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@ledgerhq/speculos-transport':
         specifier: workspace:^
         version: link:../speculos-transport
@@ -15435,13 +15435,13 @@ importers:
         version: link:../coin-modules/coin-aleo
       '@ledgerhq/context-module':
         specifier: 2.5.0
-        version: 2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+        version: 2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.8.0(rxjs@7.8.2)
+        version: 1.9.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-aleo':
         specifier: 'catalog:'
-        version: 0.4.0(@ledgerhq/context-module@2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+        version: 0.4.0(@ledgerhq/context-module@2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../ledgerjs/packages/hw-transport
@@ -15585,13 +15585,13 @@ importers:
         version: link:../concordium-core
       '@ledgerhq/context-module':
         specifier: 2.5.0
-        version: 2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+        version: 2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.8.0(rxjs@7.8.2)
+        version: 1.9.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-concordium':
         specifier: 'catalog:'
-        version: 0.4.0(@ledgerhq/context-module@2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+        version: 0.4.0(@ledgerhq/context-module@2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../ledgerjs/packages/hw-transport
@@ -15631,10 +15631,10 @@ importers:
         version: link:../coin-modules/coin-cosmos
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.8.0(rxjs@7.8.2)
+        version: 1.9.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-cosmos':
         specifier: 'catalog:'
-        version: 1.0.1(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+        version: 1.0.1(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@ledgerhq/hw-app-cosmos':
         specifier: workspace:^
         version: link:../ledgerjs/packages/hw-app-cosmos
@@ -15686,13 +15686,13 @@ importers:
     dependencies:
       '@ledgerhq/context-module':
         specifier: 2.5.0
-        version: 2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+        version: 2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.8.0(rxjs@7.8.2)
+        version: 1.9.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-ethereum':
         specifier: 'catalog:'
-        version: 1.17.0(@ledgerhq/context-module@2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+        version: 1.18.0(@ledgerhq/context-module@2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@ledgerhq/hw-app-eth':
         specifier: workspace:^
         version: link:../ledgerjs/packages/hw-app-eth
@@ -15747,10 +15747,10 @@ importers:
     dependencies:
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.8.0(rxjs@7.8.2)
+        version: 1.9.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-hyperliquid':
         specifier: 'catalog:'
-        version: 0.0.0-hyperliquid-unified-20260728150448(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+        version: 0.0.0-hyperliquid-unified-20260728150448(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../ledgerjs/packages/devices
@@ -15796,10 +15796,10 @@ importers:
         version: link:../coin-modules/coin-internet_computer
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.8.0(rxjs@7.8.2)
+        version: 1.9.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-icp':
         specifier: 'catalog:'
-        version: 0.2.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+        version: 0.2.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../ledger-wallet-framework
@@ -15845,13 +15845,13 @@ importers:
         version: link:../coin-modules/coin-solana
       '@ledgerhq/context-module':
         specifier: 2.5.0
-        version: 2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+        version: 2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.8.0(rxjs@7.8.2)
+        version: 1.9.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-solana':
         specifier: 'catalog:'
-        version: 1.13.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))(@typescript/typescript6@6.0.2)
+        version: 1.13.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))(@typescript/typescript6@6.0.2)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../ledgerjs/packages/devices
@@ -15930,10 +15930,10 @@ importers:
     dependencies:
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
-        version: 1.8.0(rxjs@7.8.2)
+        version: 1.9.0(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-zcash':
         specifier: 0.6.0
-        version: 0.6.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+        version: 0.6.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2
@@ -22128,13 +22128,13 @@ packages:
       react-native:
         optional: true
 
-  '@ledgerhq/device-contacts-kit@0.3.1':
-    resolution: {integrity: sha512-qKGhVNJe7iNNITd0+5mmWDzL09xj0XFU/DO8zA0cdoBdQXv96pbgRC6JHG8bB8hiob1ixTRDEbsMp+UKm4xTSQ==}
+  '@ledgerhq/device-contacts-kit@0.4.0':
+    resolution: {integrity: sha512-Mq6HaXlPi5d08s2RRmCABkIfLT7uoxc/JdoIo3e9IWayimoMfQb7UhgiTL5Dwck//oXrV+66ID6nkjiSu4Auzg==}
     peerDependencies:
-      '@ledgerhq/device-management-kit': ^1.8.0
+      '@ledgerhq/device-management-kit': ^1.9.0
 
-  '@ledgerhq/device-management-kit@1.8.0':
-    resolution: {integrity: sha512-yRYt4a0/tuYjoYDePBMlhCm3Bej0F/TiVu09Hl5fjO4f64Q6jbI2/YthzRWrgP7CEs93EgN7hxJ0WSErtzvEwA==}
+  '@ledgerhq/device-management-kit@1.9.0':
+    resolution: {integrity: sha512-M9M8Uy8c6diJ0pdK/85oP1u2+S6iO8WQcQ8V5FCWu/LyjXKrmTakQ9GRwWYNOp79nbcO+oXcLxJpvZtvpgquIg==}
     peerDependencies:
       rxjs: 7.8.2
 
@@ -22155,11 +22155,11 @@ packages:
     peerDependencies:
       '@ledgerhq/device-management-kit': ^1.5.1
 
-  '@ledgerhq/device-signer-kit-ethereum@1.17.0':
-    resolution: {integrity: sha512-L7mgJateCia2+Z+Y+qe/e9ul3uXVzDgBFuDG9IaV2U5/MwL82BIFd0s7KHEvu3lmUkdQt54Px6Vi9DA5PVIuTw==}
+  '@ledgerhq/device-signer-kit-ethereum@1.18.0':
+    resolution: {integrity: sha512-qMfQF9+idZ8bjWF2GmKZh9TkmT5viAZnL91/837qZq5QAdGn/4DmROvxUnM6mzuwcB5pg5C/QBGj4dF+EGj+bQ==}
     peerDependencies:
       '@ledgerhq/context-module': 2.5.0
-      '@ledgerhq/device-management-kit': ^1.8.0
+      '@ledgerhq/device-management-kit': ^1.9.0
 
   '@ledgerhq/device-signer-kit-hyperliquid@0.0.0-hyperliquid-unified-20260728150448':
     resolution: {integrity: sha512-QJJG47HeKEw3rH1PINtRTjxFmpA2/NJl7Ae3dzEXT4yvHDHCHaoCX494GGueS9/I4dKeifCA75pNK5WJ7e5A5A==}
@@ -28469,7 +28469,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: '*'
+      rxjs: ^5.5.10
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -48683,9 +48683,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/context-module@2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))':
+  '@ledgerhq/context-module@2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.8.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.9.0(rxjs@7.8.2)
       bs58: 6.0.0
       crypto-js: 4.2.0
       ethers: 6.15.0
@@ -48742,17 +48742,17 @@ snapshots:
       react-dom: 19.1.4(react@19.1.4)
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4)
 
-  '@ledgerhq/device-contacts-kit@0.3.1(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))':
+  '@ledgerhq/device-contacts-kit@0.4.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.8.0(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+      '@ledgerhq/device-management-kit': 1.9.0(rxjs@7.8.2)
+      '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       inversify: 7.5.1(reflect-metadata@0.2.2)
       purify-ts: 2.1.0
       reflect-metadata: 0.2.2
       semver: 7.7.2
       xstate: 5.19.2
 
-  '@ledgerhq/device-management-kit@1.8.0':
+  '@ledgerhq/device-management-kit@1.9.0':
     dependencies:
       '@noble/hashes': 1.8.0
       '@sentry/minimal': 6.19.7
@@ -48768,7 +48768,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/device-management-kit@1.8.0(bufferutil@4.1.0)(rxjs@7.8.2)(utf-8-validate@6.0.6)':
+  '@ledgerhq/device-management-kit@1.9.0(bufferutil@4.1.0)(rxjs@7.8.2)(utf-8-validate@6.0.6)':
     dependencies:
       '@noble/hashes': 1.8.0
       '@sentry/minimal': 6.19.7
@@ -48785,7 +48785,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2)':
+  '@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2)':
     dependencies:
       '@noble/hashes': 1.8.0
       '@sentry/minimal': 6.19.7
@@ -48802,40 +48802,41 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/device-signer-kit-aleo@0.4.0(@ledgerhq/context-module@2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-aleo@0.4.0(@ledgerhq/context-module@2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/context-module': 2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
-      '@ledgerhq/device-management-kit': 1.8.0(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 1.1.3(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+      '@ledgerhq/context-module': 2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
+      '@ledgerhq/device-management-kit': 1.9.0(rxjs@7.8.2)
+      '@ledgerhq/signer-utils': 1.1.3(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       inversify: 7.5.1(reflect-metadata@0.2.2)
       purify-ts: 2.1.0
       reflect-metadata: 0.2.2
       xstate: 5.19.2
 
-  '@ledgerhq/device-signer-kit-concordium@0.4.0(@ledgerhq/context-module@2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-concordium@0.4.0(@ledgerhq/context-module@2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/context-module': 2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
-      '@ledgerhq/device-management-kit': 1.8.0(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+      '@ledgerhq/context-module': 2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
+      '@ledgerhq/device-management-kit': 1.9.0(rxjs@7.8.2)
+      '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       inversify: 7.5.1(reflect-metadata@0.2.2)
       purify-ts: 2.1.0
       reflect-metadata: 0.2.2
       xstate: 5.19.2
 
-  '@ledgerhq/device-signer-kit-cosmos@1.0.1(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-cosmos@1.0.1(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.8.0(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+      '@ledgerhq/device-management-kit': 1.9.0(rxjs@7.8.2)
+      '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       inversify: 7.5.1(reflect-metadata@0.2.2)
       purify-ts: 2.1.0
       reflect-metadata: 0.2.2
       xstate: 5.19.2
 
-  '@ledgerhq/device-signer-kit-ethereum@1.17.0(@ledgerhq/context-module@2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-ethereum@1.18.0(@ledgerhq/context-module@2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/context-module': 2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
-      '@ledgerhq/device-management-kit': 1.8.0(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+      '@ledgerhq/context-module': 2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
+      '@ledgerhq/device-contacts-kit': 0.4.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
+      '@ledgerhq/device-management-kit': 1.9.0(rxjs@7.8.2)
+      '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       ethers: 6.15.0
       inversify: 7.5.1(reflect-metadata@0.2.2)
       purify-ts: 2.1.0
@@ -48846,10 +48847,11 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/device-signer-kit-ethereum@1.17.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-ethereum@1.18.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.8.0(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+      '@ledgerhq/device-contacts-kit': 0.4.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
+      '@ledgerhq/device-management-kit': 1.9.0(rxjs@7.8.2)
+      '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       ethers: 6.15.0
       inversify: 7.5.1(reflect-metadata@0.2.2)
       purify-ts: 2.1.0
@@ -48860,11 +48862,11 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/device-signer-kit-hyperliquid@0.0.0-hyperliquid-unified-20260728150448(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-hyperliquid@0.0.0-hyperliquid-unified-20260728150448(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/context-module': 2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
-      '@ledgerhq/device-management-kit': 1.8.0(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 0.0.0-hyperliquid-unified-20260728150448(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+      '@ledgerhq/context-module': 2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
+      '@ledgerhq/device-management-kit': 1.9.0(rxjs@7.8.2)
+      '@ledgerhq/signer-utils': 0.0.0-hyperliquid-unified-20260728150448(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       inversify: 7.5.1(reflect-metadata@0.2.2)
       purify-ts: 2.1.0
       reflect-metadata: 0.2.2
@@ -48873,20 +48875,20 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/device-signer-kit-icp@0.2.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-icp@0.2.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.8.0(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+      '@ledgerhq/device-management-kit': 1.9.0(rxjs@7.8.2)
+      '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       inversify: 7.5.1(reflect-metadata@0.2.2)
       purify-ts: 2.1.0
       reflect-metadata: 0.2.2
       xstate: 5.19.2
 
-  '@ledgerhq/device-signer-kit-solana@1.13.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))(@typescript/typescript6@6.0.2)':
+  '@ledgerhq/device-signer-kit-solana@1.13.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@ledgerhq/context-module': 2.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
-      '@ledgerhq/device-management-kit': 1.8.0(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+      '@ledgerhq/context-module': 2.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
+      '@ledgerhq/device-management-kit': 1.9.0(rxjs@7.8.2)
+      '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@solana/web3.js': 1.98.4(@typescript/typescript6@6.0.2)
       bs58: 6.0.0
       buffer: 6.0.3(patch_hash=42321bf7b7c77317e644bb216138271640fb39808e74312037dac216f4b9bc5d)
@@ -48901,19 +48903,19 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@ledgerhq/device-signer-kit-zcash@0.6.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-zcash@0.6.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.8.0(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+      '@ledgerhq/device-management-kit': 1.9.0(rxjs@7.8.2)
+      '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       '@noble/hashes': 1.8.0
       inversify: 7.5.1(reflect-metadata@0.2.2)
       purify-ts: 2.1.0
       reflect-metadata: 0.2.2
       xstate: 5.19.2
 
-  '@ledgerhq/device-transport-kit-react-native-ble@1.3.2(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))(react-native-ble-plx@3.5.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(react@19.1.4))(rxjs@7.8.2)':
+  '@ledgerhq/device-transport-kit-react-native-ble@1.3.2(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))(react-native-ble-plx@3.5.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(react@19.1.4))(rxjs@7.8.2)':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.8.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.9.0(rxjs@7.8.2)
       '@sentry/minimal': 6.19.7
       js-base64: 3.7.8
       purify-ts: 2.1.0
@@ -48922,51 +48924,51 @@ snapshots:
       rxjs: 7.8.2
       uuid: 11.0.3
 
-  '@ledgerhq/device-transport-kit-react-native-hid@1.0.4(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(rxjs@7.8.2)':
+  '@ledgerhq/device-transport-kit-react-native-hid@1.0.4(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(rxjs@7.8.2)':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.8.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.9.0(rxjs@7.8.2)
       '@sentry/minimal': 6.19.7
       purify-ts: 2.1.0
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
       rxjs: 7.8.2
       uuid: 11.0.3
 
-  '@ledgerhq/device-transport-kit-react-native-hid@1.0.4(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(react@19.1.4))(rxjs@7.8.2)':
+  '@ledgerhq/device-transport-kit-react-native-hid@1.0.4(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(react@19.1.4))(rxjs@7.8.2)':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.8.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.9.0(rxjs@7.8.2)
       '@sentry/minimal': 6.19.7
       purify-ts: 2.1.0
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(react@19.1.4)
       rxjs: 7.8.2
       uuid: 11.0.3
 
-  '@ledgerhq/device-transport-kit-speculos@1.2.1(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))(rxjs@7.8.2)':
+  '@ledgerhq/device-transport-kit-speculos@1.2.1(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))(rxjs@7.8.2)':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.8.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.9.0(rxjs@7.8.2)
       '@sentry/minimal': 6.19.7
       purify-ts: 2.1.0
       rxjs: 7.8.2
 
-  '@ledgerhq/device-transport-kit-web-hid@1.2.4(@ledgerhq/device-management-kit@1.8.0(bufferutil@4.1.0)(rxjs@7.8.2)(utf-8-validate@6.0.6))(rxjs@7.8.2)':
+  '@ledgerhq/device-transport-kit-web-hid@1.2.4(@ledgerhq/device-management-kit@1.9.0(bufferutil@4.1.0)(rxjs@7.8.2)(utf-8-validate@6.0.6))(rxjs@7.8.2)':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.8.0(bufferutil@4.1.0)(rxjs@7.8.2)(utf-8-validate@6.0.6)
-      '@sentry/minimal': 6.19.7
-      purify-ts: 2.1.0
-      rxjs: 7.8.2
-      uuid: 11.0.3
-
-  '@ledgerhq/device-transport-kit-web-hid@1.2.4(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))(rxjs@7.8.2)':
-    dependencies:
-      '@ledgerhq/device-management-kit': 1.8.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.9.0(bufferutil@4.1.0)(rxjs@7.8.2)(utf-8-validate@6.0.6)
       '@sentry/minimal': 6.19.7
       purify-ts: 2.1.0
       rxjs: 7.8.2
       uuid: 11.0.3
 
-  '@ledgerhq/dmk-ledger-wallet@0.5.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))':
+  '@ledgerhq/device-transport-kit-web-hid@1.2.4(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))(rxjs@7.8.2)':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.8.0(rxjs@7.8.2)
-      '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))
+      '@ledgerhq/device-management-kit': 1.9.0(rxjs@7.8.2)
+      '@sentry/minimal': 6.19.7
+      purify-ts: 2.1.0
+      rxjs: 7.8.2
+      uuid: 11.0.3
+
+  '@ledgerhq/dmk-ledger-wallet@0.5.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))':
+    dependencies:
+      '@ledgerhq/device-management-kit': 1.9.0(rxjs@7.8.2)
+      '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))
       pako: 2.1.0
       purify-ts: 2.1.0
       rxjs: 7.8.2
@@ -49401,24 +49403,24 @@ snapshots:
       react: 19.1.4
       tailwind-merge: 2.6.0
 
-  '@ledgerhq/signer-utils@0.0.0-hyperliquid-unified-20260728150448(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))':
+  '@ledgerhq/signer-utils@0.0.0-hyperliquid-unified-20260728150448(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.8.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.9.0(rxjs@7.8.2)
       semver: 7.7.2
 
-  '@ledgerhq/signer-utils@1.1.3(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))':
+  '@ledgerhq/signer-utils@1.1.3(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.8.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.9.0(rxjs@7.8.2)
       semver: 7.7.2
 
-  '@ledgerhq/signer-utils@1.3.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))':
+  '@ledgerhq/signer-utils@1.3.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.8.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.9.0(rxjs@7.8.2)
       semver: 7.7.2
 
-  '@ledgerhq/speculos-device-controller@0.3.0(@ledgerhq/device-management-kit@1.8.0(rxjs@7.8.2))':
+  '@ledgerhq/speculos-device-controller@0.3.0(@ledgerhq/device-management-kit@1.9.0(rxjs@7.8.2))':
     dependencies:
-      '@ledgerhq/device-management-kit': 1.8.0(rxjs@7.8.2)
+      '@ledgerhq/device-management-kit': 1.9.0(rxjs@7.8.2)
       '@sentry/minimal': 6.19.7
 
   '@ledgerhq/wallet-api-client-react@1.4.34(@ton/crypto@3.3.0)(react@19.1.4)':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28469,7 +28469,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: ^5.5.10
+      rxjs: '*'
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,12 +24,12 @@ catalog:
   "@jest/globals": 30.5.0
   "@ledgerhq/context-module": 2.5.0
   "@ledgerhq/crypto-icons": "2.0.4"
-  "@ledgerhq/device-contacts-kit": 0.3.1
-  "@ledgerhq/device-management-kit": 1.8.0
+  "@ledgerhq/device-contacts-kit": 0.4.0
+  "@ledgerhq/device-management-kit": 1.9.0
   "@ledgerhq/dmk-ledger-wallet": 0.5.0
   "@ledgerhq/device-signer-kit-aleo": 0.4.0
   "@ledgerhq/device-signer-kit-concordium": 0.4.0
-  "@ledgerhq/device-signer-kit-ethereum": 1.17.0
+  "@ledgerhq/device-signer-kit-ethereum": 1.18.0
   "@ledgerhq/device-signer-kit-hyperliquid": 0.0.0-hyperliquid-unified-20260728150448
   "@ledgerhq/device-signer-kit-solana": 1.13.0
   "@ledgerhq/device-signer-kit-cosmos": 1.0.1


### PR DESCRIPTION
### 📝 Description

Bump the device-sdk-ts catalog entries to the versions published by the 2026-09-02 release.

| Catalog entry | Before | After |
| --- | --- | --- |
| `@ledgerhq/device-management-kit` | 1.8.0 | **1.9.0** |
| `@ledgerhq/device-contacts-kit` | 0.3.1 | **0.4.0** |
| `@ledgerhq/device-signer-kit-ethereum` | 1.17.0 | **1.18.0** |

These three ship together on purpose: Signer ETH 1.18.0 provides matching external contacts before signing, which calls `sendProvideContactPayload` / `buildProvideContactPayload` from Contacts Kit 0.4.0, and both rely on `ApplicationChecker.withMinVersionInclusiveAcceptingPrerelease` from DMK 1.9.0. Bumping Signer ETH alone against the older kits would not resolve.

Only the catalog and the lockfile change — every consuming package already declares `"catalog:"`. Following the precedent set by `chore(deps): bump device kits to their latest releases` and `chore(contacts): bump @ledgerhq/device-contacts-kit to 0.3.1`, this carries no changeset.

**Deliberately not bumped:**

- `@ledgerhq/device-signer-kit-concordium` — 0.5.0 is published; left at 0.4.0 by request. Verified it still resolves to 0.4.0.
- `@ledgerhq/device-signer-kit-hyperliquid` — stays on its unrelated snapshot pin `0.0.0-hyperliquid-unified-20260728150448`, as in the earlier device-kit bumps. Moving to 1.1.0 stable is a separate decision.
- `@ledgerhq/signer-utils` — 1.3.0 is published, but no package references that catalog entry (the only constraint is an aleo-scoped override at 1.1.3), so bumping it would be a no-op.
- Signer TRON 0.2.0 and Signer XRP 0.2.0 were part of the same upstream release but have no catalog entry or consumer in this repo yet.

Every other DMK-family catalog entry is already at its latest published version.

### ✅ Verification

Ran locally against the new versions:

| Check | Result |
| --- | --- |
| `features/platform/contacts` typecheck (web + native) | clean |
| `features/platform/contacts` tests | 294 passed, 38 suites |
| `libs/live-dmk-shared` typecheck | clean |
| `libs/live-dmk-shared` tests | 309 passed, 30 suites |
| `libs/live-signer-evm` tests | 50 passed, 3 suites |

The lockfile re-pegged every dependent onto `device-management-kit@1.9.0` as its peer, leaving no duplicate DMK copies.

One caveat for reviewers: `libs/live-signer-evm` has no `typecheck` script, and a bare `tsc --noEmit` there reports only unbuilt workspace siblings (`types-live`, `live-env`, `hw-app-eth`), not the bumped packages. Instead of building that cascade, compatibility was confirmed by its passing tests plus checking that all 12 symbols it imports from Signer ETH still exist in 1.18.0's declarations. CI covers the full build.

### 🔗 Context

- **JIRA / GitHub issue**: none — follow-up to the device-sdk-ts release ([LedgerHQ/device-sdk-ts#1843](https://github.com/LedgerHQ/device-sdk-ts/pull/1843))
- **ADR** (if any): n/a
