### PR TITLE
chore(codeowners): assign pay-card-wallets to wallet-xp (LIVE-35974)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -137,6 +137,7 @@ features/flow/pay-bank-transfer/                         @ledgerhq/wallet-xp
 features/flow/pay-feature-tour/                          @ledgerhq/wallet-xp
 features/flow/pay-request/                               @ledgerhq/wallet-xp
 features/flow/pay-card-details/                          @ledgerhq/wallet-xp
+features/flow/pay-card-wallets/                          @ledgerhq/wallet-xp
 features/flow/pay-contact/                               @ledgerhq/wallet-xp
 
 # Wallet — Intents


### PR DESCRIPTION
GitHub reads CODEOWNERS from a PR's base branch, so the PR that adds a package
cannot also claim ownership of it: the rule is not on develop yet when reviewers
are picked. Landing the rule on its own means the package's own PR routes to
Wallet XP instead of asking the CODEOWNERS owners to approve the whole thing.

The directory arrives with LIVE-34772.

### Reference

- [LIVE-35974](https://ledgerhq.atlassian.net/browse/LIVE-35974) — the epic the `pay-card-wallets` package belongs to.



[LIVE-35974]: https://ledgerhq.atlassian.net/browse/LIVE-35974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ