### PR TITLE
[LWM] feat(perps): sign mobile deposits through the exchange swap flow

### DIFF
--- a/.changeset/perps-deposit-signing-mobile.md
+++ b/.changeset/perps-deposit-signing-mobile.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Add the Perps deposit signing step on mobile, as a bottom sheet on the deposit screen that the review hands over to. It runs on the same swap orchestration as the `custom.exchange.swap` handler — now extracted into a shared `executeSwap` — behind the perps screens, and executes against the quote the review priced against. Declining a device prompt returns to the review with the entered amount intact, rather than raising an error screen.

--- a/.changeset/perps-deposit-signing-mobile.md
+++ b/.changeset/perps-deposit-signing-mobile.md
@@ -1,6 +1,5 @@
 ---
 "live-mobile": minor
-"@ledgerhq/live-common": minor
 ---
 
-Add the Perps deposit signing step on mobile, as a bottom sheet on the deposit screen that the review hands over to. It runs on the same swap orchestration as the `custom.exchange.swap` handler — now extracted into a shared `executeSwap` — behind the perps screens, and executes against the quote the review priced against. Declining a device prompt returns to the review with the entered amount intact, rather than raising an error screen.
+Add the Perps deposit signing step on mobile, as a bottom sheet on the deposit screen that the review hands over to. It runs on the shared `executeSwap` orchestration behind the perps screens, and executes against the quote the review priced against. Declining a device prompt returns to the review with the entered amount intact, rather than raising an error screen.

--- a/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
@@ -70,7 +70,7 @@ import { DeviceModelId, getDeviceModel } from "@ledgerhq/devices";
 import { FlowName, getCurrencyName, getFlowName } from "./utils";
 import { useFeature } from "@features/platform-feature-flags";
 
-type Status = PartialNullable<{
+export type Status = PartialNullable<{
   appAndVersion: AppAndVersion;
   device: Device;
   unresponsive: boolean;
@@ -135,11 +135,7 @@ type Props<H extends Status, P> = {
   analyticsPropertyFlow?: string;
   location?: HOOKS_TRACKING_LOCATIONS;
   onClose?: () => void;
-  /*
-   * Defines in what type of component this action will be rendered in.
-   *
-   * Used to adapt the UI to either a drawer or a view.
-   */
+  renderExchangeConfirmation?: () => React.JSX.Element;
 };
 
 export default function DeviceAction<R, H extends Status, P>({
@@ -180,6 +176,7 @@ export function DeviceActionDefaultRendering<R, H extends Status, P>({
   payload,
   location,
   onClose,
+  renderExchangeConfirmation,
 }: Props<H, P> & {
   request?: R;
 }): React.JSX.Element | null {
@@ -577,6 +574,8 @@ export function DeviceActionDefaultRendering<R, H extends Status, P>({
   }
 
   if (completeExchangeStarted && !completeExchangeResult && !completeExchangeError) {
+    if (renderExchangeConfirmation) return renderExchangeConfirmation();
+
     const swapRequest = {
       ...request,
       colors,

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -9872,6 +9872,9 @@
     "depositReceiveLabel": "Receiver account",
     "depositCTA": "Deposit"
   },
+  "perpsDepositSign": {
+    "terms": "By signing this transaction, I accept <termsLink>SwapKit by NEAR Intents T&C</termsLink>"
+  },
   "perpsDeposit": {
     "title": "Deposit",
     "inputDepositAmount": "Deposit ~{{value}}",

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/hooks/__tests__/usePerpsDepositExecution.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/hooks/__tests__/usePerpsDepositExecution.test.ts
@@ -1,6 +1,7 @@
 import BigNumber from "bignumber.js";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
-import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { usdcToken } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
 import { act, renderHook } from "@tests/test-renderer";
 import { usePerpsDepositExecution, type PerpsDepositDeviceStep } from "../usePerpsDepositExecution";
 
@@ -117,6 +118,37 @@ describe("usePerpsDepositExecution", () => {
         quoteId: "quote-1",
         feeStrategy: "medium",
       }),
+    );
+  });
+
+  it("hands over the token accounts, which fund most deposits", async () => {
+    const parent = genAccount("funding-parent", { currency: ethereum, operationsSize: 0 });
+    const tokenAccount = genTokenAccount(0, parent, usdcToken);
+    mockExecuteSwap.mockResolvedValue({ operationHash: operation.hash, swapId: "swap-1" });
+
+    const { result } = renderHook(
+      () =>
+        usePerpsDepositExecution(
+          { ...params, depositAccount: tokenAccount },
+          { onDone: jest.fn(), onRefused: jest.fn() },
+        ),
+      {
+        overrideInitialState: state => ({
+          ...state,
+          accounts: { ...state.accounts, active: [{ ...parent, subAccounts: [tokenAccount] }] },
+        }),
+      },
+    );
+
+    await act(async () => {
+      await result.current.executeDeposit();
+    });
+
+    expect(mockExecuteSwap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accounts: expect.arrayContaining([expect.objectContaining({ id: tokenAccount.id })]),
+      }),
+      expect.anything(),
     );
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/hooks/__tests__/usePerpsDepositExecution.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/hooks/__tests__/usePerpsDepositExecution.test.ts
@@ -1,0 +1,226 @@
+import BigNumber from "bignumber.js";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { act, renderHook } from "@tests/test-renderer";
+import { usePerpsDepositExecution, type PerpsDepositDeviceStep } from "../usePerpsDepositExecution";
+
+const mockExecuteSwap = jest.fn();
+jest.mock("@ledgerhq/live-common/wallet-api/Exchange/executeSwap", () => ({
+  executeSwap: (deps: unknown, params: unknown) => mockExecuteSwap(deps, params),
+}));
+
+const mockBroadcast = jest.fn();
+jest.mock("@ledgerhq/live-common/hooks/useBroadcast", () => ({
+  useBroadcast: () => mockBroadcast,
+}));
+
+jest.mock("~/hooks/deviceActions", () => ({
+  useStartExchangeDeviceAction: () => "start-action",
+  useTransactionDeviceAction: () => "sign-action",
+  useCompleteExchangeDeviceAction: () => "complete-action",
+}));
+
+// The account updater needs a full swap exchange to build its updaters; the
+// deposit only cares about what it is told the swap is worth.
+const mockGetUpdateAccountWithUpdaterParams = jest.fn((_params: unknown) => []);
+jest.mock("@ledgerhq/live-common/exchange/swap/getUpdateAccountWithUpdaterParams", () => ({
+  getUpdateAccountWithUpdaterParams: (params: unknown) =>
+    mockGetUpdateAccountWithUpdaterParams(params as never),
+}));
+
+const ethereum = getCryptoCurrencyById("ethereum");
+const depositAccount = genAccount("funding-1", { currency: ethereum, operationsSize: 0 });
+const receiverAccount = genAccount("receiver-1", { currency: ethereum, operationsSize: 0 });
+
+const params = {
+  depositAccount,
+  receiverAccount,
+  amountSent: "0.02",
+  amountTo: "0.019",
+  quoteId: "quote-1",
+};
+
+const swapUiRequest = {
+  provider: "swapkit_hyperliquid",
+  transaction: { family: "ethereum" },
+  binaryPayload: "payload",
+  signature: "signature",
+  exchange: { fromAccount: depositAccount, toAccount: receiverAccount },
+  swapId: "swap-1",
+  magnitudeAwareRate: new BigNumber(1),
+};
+
+const operation = { id: "operation-1", hash: "0xhash" };
+
+/** Answers the device action the hook is currently waiting on. */
+function answerDeviceStep(deviceStep: PerpsDepositDeviceStep, result: unknown) {
+  if (deviceStep.kind !== "device")
+    throw new Error(`expected a device step, got ${deviceStep.kind}`);
+  return act(async () => {
+    deviceStep.withDeviceAction(binding => binding.onResult(result as never));
+  });
+}
+
+function renderExecution() {
+  const onDone = jest.fn();
+  const onRefused = jest.fn();
+  const { result } = renderHook(() => usePerpsDepositExecution(params, { onDone, onRefused }));
+  return { result, onDone, onRefused };
+}
+
+/** Runs the deposit up to the coin-app signature and answers it with `signResult`. */
+async function signWith(signResult: unknown) {
+  mockExecuteSwap.mockImplementation(async deps => {
+    await new Promise<void>((resolve, reject) => {
+      deps.uiHooks["custom.exchange.swap"]({
+        exchangeParams: swapUiRequest,
+        onSuccess: () => resolve(),
+        onCancel: reject,
+      });
+    });
+  });
+
+  const execution = renderExecution();
+  act(() => {
+    void execution.result.current.executeDeposit();
+  });
+
+  await answerDeviceStep(execution.result.current.deviceStep, {
+    completeExchangeResult: { family: "ethereum", amount: new BigNumber("20000000000000000") },
+  });
+  await answerDeviceStep(execution.result.current.deviceStep, signResult);
+
+  return execution;
+}
+
+describe("usePerpsDepositExecution", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockBroadcast.mockResolvedValue(operation);
+  });
+
+  it("quotes the deposit as a swap against the perps provider, at the price the review showed", async () => {
+    mockExecuteSwap.mockResolvedValue({ operationHash: operation.hash, swapId: "swap-1" });
+    const { result } = renderExecution();
+
+    await act(async () => {
+      await result.current.executeDeposit();
+    });
+
+    expect(mockExecuteSwap).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        exchangeType: "SWAP",
+        provider: "swapkit_hyperliquid",
+        fromAmount: "0.02",
+        fromAmountAtomic: new BigNumber("20000000000000000"),
+        quoteId: "quote-1",
+        feeStrategy: "medium",
+      }),
+    );
+  });
+
+  it("drives every device step and reports the deposit as done", async () => {
+    const onStartSuccess = jest.fn();
+    const onSwapSuccess = jest.fn();
+    mockExecuteSwap.mockImplementation(async deps => {
+      const nonce = await new Promise<string>((resolve, reject) =>
+        deps.uiHooks["custom.exchange.start"]({
+          exchangeParams: { exchangeType: "SWAP", provider: "swapkit_hyperliquid", exchange: {} },
+          onSuccess: (...args: unknown[]) => {
+            onStartSuccess(...args);
+            resolve(args[0] as string);
+          },
+          onCancel: reject,
+        }),
+      );
+      expect(nonce).toBe("nonce-1");
+
+      await new Promise<void>((resolve, reject) =>
+        deps.uiHooks["custom.exchange.swap"]({
+          exchangeParams: swapUiRequest,
+          onSuccess: (...args: unknown[]) => {
+            onSwapSuccess(...args);
+            resolve();
+          },
+          onCancel: reject,
+        }),
+      );
+    });
+
+    const { result, onDone } = renderExecution();
+    act(() => {
+      void result.current.executeDeposit();
+    });
+
+    // Nonce: the Exchange app opens and returns a device transaction id.
+    expect(result.current.deviceStep).toMatchObject({ stepId: "start" });
+    await answerDeviceStep(result.current.deviceStep, {
+      startExchangeResult: { nonce: "nonce-1", device: { modelId: "stax" } },
+    });
+    expect(onStartSuccess).toHaveBeenCalledWith("nonce-1", { modelId: "stax" });
+
+    // Confirm, sign, broadcast: the perps confirmation screen only shows on the
+    // Exchange app's payload check.
+    expect(result.current.deviceStep).toMatchObject({ stepId: "confirm" });
+    await answerDeviceStep(result.current.deviceStep, {
+      completeExchangeResult: { family: "ethereum", amount: new BigNumber("20000000000000000") },
+    });
+
+    expect(result.current.deviceStep).toMatchObject({ stepId: "sign" });
+    await answerDeviceStep(result.current.deviceStep, { signedOperation: { operation } });
+
+    expect(mockBroadcast).toHaveBeenCalledWith({ operation });
+    expect(onSwapSuccess).toHaveBeenCalledWith({ operationHash: "0xhash", swapId: "swap-1" });
+    expect(onDone).toHaveBeenCalled();
+  });
+
+  it("records the swap at the quoted price, not the one the payload implies", async () => {
+    await signWith({ signedOperation: { operation } });
+
+    // The payload states its payout in the provider's own precision, so pricing
+    // the history from it would misreport the deposit once it is displayed.
+    expect(mockGetUpdateAccountWithUpdaterParams).toHaveBeenCalledWith(
+      expect.objectContaining({ magnitudeAwareRate: new BigNumber("0.95") }),
+    );
+  });
+
+  it("surfaces a failed signature instead of spinning", async () => {
+    const { result, onDone, onRefused } = await signWith({
+      transactionSignError: new Error("signature failed"),
+    });
+
+    expect(result.current.deviceStep).toEqual({
+      kind: "error",
+      error: new Error("signature failed"),
+    });
+    expect(onDone).not.toHaveBeenCalled();
+    expect(onRefused).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      "the coin app prompt",
+      Object.assign(new Error("refused"), { name: "TransactionRefusedOnDevice" }),
+    ],
+    [
+      "a signer naming it itself",
+      Object.assign(new Error("refused"), { name: "UserRefusedOnDevice" }),
+    ],
+    [
+      "the Exchange app's own error",
+      Object.assign(new Error("User refused"), {
+        name: "CompleteExchangeError",
+        title: "userRefused",
+      }),
+    ],
+  ])("reports a decline reported by %s rather than an error", async (_case, error) => {
+    const { result, onDone, onRefused } = await signWith({ transactionSignError: error });
+
+    // Declining is a decision: the caller sends the holder back to the summary,
+    // so no error screen is raised here.
+    expect(onRefused).toHaveBeenCalled();
+    expect(result.current.deviceStep).toEqual({ kind: "processing" });
+    expect(onDone).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/hooks/usePerpsDepositExecution.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/hooks/usePerpsDepositExecution.ts
@@ -22,7 +22,7 @@ import { useFeatureFlags } from "@features/platform-feature-flags";
 import type { Feature, FeatureId } from "@shared/feature-flags";
 import { useDispatch, useSelector } from "~/context/hooks";
 import { updateAccountWithUpdater } from "~/actions/accounts";
-import { shallowAccountsSelector } from "~/reducers/accounts";
+import { flattenAccountsSelector } from "~/reducers/accounts";
 import { mevProtectionSelector } from "~/reducers/settings";
 import {
   useCompleteExchangeDeviceAction,
@@ -88,7 +88,8 @@ export function usePerpsDepositExecution(
   const [deviceStep, setDeviceStep] = useState<PerpsDepositDeviceStep>(PROCESSING_STEP);
 
   const dispatch = useDispatch();
-  const accounts = useSelector(shallowAccountsSelector);
+
+  const accounts = useSelector(flattenAccountsSelector);
   const mevProtected = useSelector(mevProtectionSelector);
 
   const featureFlagsMap = useFeatureFlags();

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/hooks/usePerpsDepositExecution.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/hooks/usePerpsDepositExecution.ts
@@ -8,10 +8,7 @@ import type { ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
 import { executeSwap } from "@ledgerhq/live-common/wallet-api/Exchange/executeSwap";
 import trackingWrapper from "@ledgerhq/live-common/wallet-api/Exchange/tracking";
 import { ExchangeType, type SwapUiRequest } from "@ledgerhq/live-common/wallet-api/Exchange/server";
-import {
-  getWalletApiIdFromAccountId,
-  setWalletApiIdForAccountId,
-} from "@ledgerhq/live-common/wallet-api/converters";
+import { getWalletApiIdFromAccountId } from "@ledgerhq/live-common/wallet-api/converters";
 import { PERPS_DEPOSIT_QUOTE_PROVIDER } from "@ledgerhq/live-common/wallet-api/Perps/depositQuote";
 import type { PerpsDepositReviewParams } from "@ledgerhq/live-common/wallet-api/Perps/server";
 import type { Action } from "@ledgerhq/live-common/hw/actions/types";
@@ -218,10 +215,6 @@ export function usePerpsDepositExecution(
     try {
       // Reset to the loading state on every run (including retry after an error).
       setDeviceStep(PROCESSING_STEP);
-
-      // `executeSwap` resolves both accounts by their wallet-api id.
-      setWalletApiIdForAccountId(depositAccount.id);
-      setWalletApiIdForAccountId(receiverAccount.id);
 
       const depositCurrency = getAccountCurrency(depositAccount);
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/hooks/usePerpsDepositExecution.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/hooks/usePerpsDepositExecution.ts
@@ -1,0 +1,309 @@
+import { useCallback, useMemo, useState } from "react";
+import BigNumber from "bignumber.js";
+import type { SignedOperation } from "@ledgerhq/types-live";
+import { getAccountCurrency, getParentAccount } from "@ledgerhq/live-common/account/index";
+import { parseCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import { getUpdateAccountWithUpdaterParams } from "@ledgerhq/live-common/exchange/swap/getUpdateAccountWithUpdaterParams";
+import type { ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
+import { executeSwap } from "@ledgerhq/live-common/wallet-api/Exchange/executeSwap";
+import trackingWrapper from "@ledgerhq/live-common/wallet-api/Exchange/tracking";
+import { ExchangeType, type SwapUiRequest } from "@ledgerhq/live-common/wallet-api/Exchange/server";
+import {
+  getWalletApiIdFromAccountId,
+  setWalletApiIdForAccountId,
+} from "@ledgerhq/live-common/wallet-api/converters";
+import { PERPS_DEPOSIT_QUOTE_PROVIDER } from "@ledgerhq/live-common/wallet-api/Perps/depositQuote";
+import type { PerpsDepositReviewParams } from "@ledgerhq/live-common/wallet-api/Perps/server";
+import type { Action } from "@ledgerhq/live-common/hw/actions/types";
+import type { Result as StartExchangeResult } from "@ledgerhq/live-common/hw/actions/startExchange";
+import type { Result as CompleteExchangeResult } from "@ledgerhq/live-common/hw/actions/completeExchange";
+import { useBroadcast } from "@ledgerhq/live-common/hooks/useBroadcast";
+import { useFeatureFlags } from "@features/platform-feature-flags";
+import type { Feature, FeatureId } from "@shared/feature-flags";
+import { useDispatch, useSelector } from "~/context/hooks";
+import { updateAccountWithUpdater } from "~/actions/accounts";
+import { shallowAccountsSelector } from "~/reducers/accounts";
+import { mevProtectionSelector } from "~/reducers/settings";
+import {
+  useCompleteExchangeDeviceAction,
+  useStartExchangeDeviceAction,
+  useTransactionDeviceAction,
+} from "~/hooks/deviceActions";
+import type { Status } from "~/components/DeviceAction";
+import { broadcastLogger } from "~/datadog";
+import { track } from "~/analytics";
+import { isUserRefusal } from "../utils/isUserRefusal";
+
+type StartResult = StartExchangeResult;
+type CompleteResult = CompleteExchangeResult;
+type SignResult = { signedOperation: SignedOperation } | { transactionSignError: Error };
+
+export type PerpsDepositDeviceStep =
+  | { kind: "processing" }
+  | { kind: "error"; error: Error }
+  | {
+      kind: "device";
+      stepId: "start" | "confirm" | "sign";
+      withDeviceAction: <T>(
+        render: <R, H extends Status, P>(binding: {
+          action: Action<R, H, P>;
+          request: R;
+          onResult: (result: P) => void;
+        }) => T,
+      ) => T;
+    };
+
+type PerpsDepositDevicePhase = Extract<PerpsDepositDeviceStep, { kind: "device" }>;
+
+const PROCESSING_STEP: PerpsDepositDeviceStep = { kind: "processing" };
+
+export type PerpsDepositExecution = Readonly<{
+  deviceStep: PerpsDepositDeviceStep;
+  executeDeposit: () => Promise<void>;
+  retry: () => void;
+}>;
+
+export type PerpsDepositExecutionCallbacks = Readonly<{
+  onDone: () => void;
+  onRefused: () => void;
+}>;
+
+const EXCHANGE_APP_NAME = "Exchange";
+const FEE_STRATEGY = "medium";
+
+/** The swap orchestration's analytics sink, pointed at the perps flow. */
+const tracking = trackingWrapper((eventName, properties, mandatory) =>
+  track(eventName, { ...properties, flowInitiatedFrom: "Perps" }, mandatory),
+);
+
+/**
+ * Runs a perps deposit through `executeSwap`, which owns the sequence, and
+ * renders its device steps in the perps signing screen rather than the live-app
+ * exchange stack.
+ */
+export function usePerpsDepositExecution(
+  params: PerpsDepositReviewParams,
+  { onDone, onRefused }: PerpsDepositExecutionCallbacks,
+): PerpsDepositExecution {
+  const [deviceStep, setDeviceStep] = useState<PerpsDepositDeviceStep>(PROCESSING_STEP);
+
+  const dispatch = useDispatch();
+  const accounts = useSelector(shallowAccountsSelector);
+  const mevProtected = useSelector(mevProtectionSelector);
+
+  const featureFlagsMap = useFeatureFlags();
+  const getFeature = useCallback(
+    (id: FeatureId): Feature | null => featureFlagsMap[id] ?? null,
+    [featureFlagsMap],
+  );
+
+  const startAction = useStartExchangeDeviceAction();
+  const signAction = useTransactionDeviceAction();
+  const completeAction = useCompleteExchangeDeviceAction();
+
+  const { depositAccount, receiverAccount, amountSent, amountTo, quoteId } = params;
+  const fromParentAccount = useMemo(
+    () => getParentAccount(depositAccount, accounts),
+    [depositAccount, accounts],
+  );
+
+  const quotedReceiveAmount = useMemo(
+    () => parseCurrencyUnit(getAccountCurrency(receiverAccount).units[0], amountTo),
+    [amountTo, receiverAccount],
+  );
+
+  const broadcastConfig = useMemo(
+    () => ({ mevProtected, source: { type: "swap" as const, name: "perps-deposit" } }),
+    [mevProtected],
+  );
+  const broadcast = useBroadcast({
+    account: depositAccount,
+    parentAccount: fromParentAccount,
+    broadcastConfig,
+    logger: broadcastLogger,
+  });
+
+  const runDeviceStep = useCallback(
+    <R>(build: (onResult: (result: R) => void) => PerpsDepositDevicePhase): Promise<R> =>
+      new Promise<R>(resolve => setDeviceStep(build(resolve))).finally(() =>
+        setDeviceStep(PROCESSING_STEP),
+      ),
+    [],
+  );
+
+  /**
+   * Confirms the provider payload on the Exchange app, signs the funding
+   * transaction with the coin app, then broadcasts it.
+   */
+  const confirmSignAndBroadcast = useCallback(
+    async (exchangeParams: SwapUiRequest) => {
+      const completeResult = await runDeviceStep<CompleteResult>(onResult => ({
+        kind: "device",
+        stepId: "confirm",
+        withDeviceAction: render =>
+          render({
+            action: completeAction,
+            request: {
+              provider: exchangeParams.provider ?? PERPS_DEPOSIT_QUOTE_PROVIDER,
+              transaction: exchangeParams.transaction,
+              binaryPayload: exchangeParams.binaryPayload,
+              signature: exchangeParams.signature,
+              exchange: exchangeParams.exchange,
+              exchangeType: ExchangeType.SWAP,
+            },
+            onResult,
+          }),
+      }));
+      if ("completeExchangeError" in completeResult) {
+        throw completeResult.completeExchangeError;
+      }
+      const finalTransaction = completeResult.completeExchangeResult;
+
+      const tokenCurrency =
+        depositAccount.type === "TokenAccount" ? depositAccount.token : undefined;
+      const signResult = await runDeviceStep<SignResult>(onResult => ({
+        kind: "device",
+        stepId: "sign",
+        withDeviceAction: render =>
+          render({
+            action: signAction,
+            request: {
+              tokenCurrency,
+              parentAccount: fromParentAccount,
+              account: depositAccount,
+              transaction: finalTransaction,
+              appName: EXCHANGE_APP_NAME,
+            },
+            onResult,
+          }),
+      }));
+      if ("transactionSignError" in signResult) {
+        throw signResult.transactionSignError;
+      }
+
+      const operation = await broadcast(signResult.signedOperation);
+
+      const swapId = exchangeParams.swapId;
+      if (swapId) {
+        const [accountId, updater] = getUpdateAccountWithUpdaterParams({
+          result: { operation, swapId },
+          exchange: exchangeParams.exchange as ExchangeSwap,
+          transaction: finalTransaction,
+          magnitudeAwareRate: finalTransaction.amount.isZero()
+            ? new BigNumber(0)
+            : quotedReceiveAmount.div(finalTransaction.amount),
+          provider: PERPS_DEPOSIT_QUOTE_PROVIDER,
+        });
+        if (accountId && updater) {
+          dispatch(updateAccountWithUpdater({ accountId, updater }));
+        }
+      }
+
+      return { operation, swapId };
+    },
+    [
+      broadcast,
+      completeAction,
+      depositAccount,
+      dispatch,
+      fromParentAccount,
+      quotedReceiveAmount,
+      runDeviceStep,
+      signAction,
+    ],
+  );
+
+  const executeDeposit = useCallback(async () => {
+    try {
+      // Reset to the loading state on every run (including retry after an error).
+      setDeviceStep(PROCESSING_STEP);
+
+      // `executeSwap` resolves both accounts by their wallet-api id.
+      setWalletApiIdForAccountId(depositAccount.id);
+      setWalletApiIdForAccountId(receiverAccount.id);
+
+      const depositCurrency = getAccountCurrency(depositAccount);
+
+      let signed: Awaited<ReturnType<typeof confirmSignAndBroadcast>> | undefined;
+
+      await executeSwap(
+        {
+          accounts,
+          tracking,
+          getFeature,
+          uiHooks: {
+            "custom.exchange.start": ({ exchangeParams, onSuccess, onCancel }) => {
+              void runDeviceStep<StartResult>(onResult => ({
+                kind: "device",
+                stepId: "start",
+                withDeviceAction: render =>
+                  render({
+                    action: startAction,
+                    request: {
+                      ...exchangeParams,
+                      exchangeType: ExchangeType[exchangeParams.exchangeType],
+                    },
+                    onResult,
+                  }),
+              })).then(result =>
+                "startExchangeError" in result
+                  ? onCancel(result.startExchangeError.error)
+                  : onSuccess(result.startExchangeResult.nonce, result.startExchangeResult.device),
+              );
+            },
+            "custom.exchange.swap": ({ exchangeParams, onSuccess, onCancel }) => {
+              void confirmSignAndBroadcast(exchangeParams).then(result => {
+                signed = result;
+                onSuccess({ operationHash: result.operation.hash, swapId: result.swapId ?? "" });
+              }, onCancel);
+            },
+
+            "custom.exchange.error": ({ onCancel }) => onCancel(),
+          },
+        },
+        {
+          exchangeType: "SWAP",
+          provider: PERPS_DEPOSIT_QUOTE_PROVIDER,
+          fromAccountId: getWalletApiIdFromAccountId(depositAccount.id),
+          toAccountId: getWalletApiIdFromAccountId(receiverAccount.id),
+          fromAmount: amountSent,
+          fromAmountAtomic: parseCurrencyUnit(depositCurrency.units[0], amountSent),
+          quoteId,
+          feeStrategy: FEE_STRATEGY,
+        },
+      );
+
+      if (!signed) return;
+
+      onDone();
+    } catch (e) {
+      if (isUserRefusal(e)) {
+        onRefused();
+        return;
+      }
+      setDeviceStep({ kind: "error", error: e instanceof Error ? e : new Error(String(e)) });
+    }
+  }, [
+    accounts,
+    amountSent,
+    confirmSignAndBroadcast,
+    depositAccount,
+    getFeature,
+    onDone,
+    onRefused,
+    quoteId,
+    receiverAccount,
+    runDeviceStep,
+    startAction,
+  ]);
+
+  const retry = useCallback(() => {
+    void executeDeposit();
+  }, [executeDeposit]);
+
+  return {
+    deviceStep,
+    executeDeposit,
+    retry,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__integrations__/perpsDepositSign.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__integrations__/perpsDepositSign.integration.test.tsx
@@ -1,0 +1,174 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import type { Account } from "@ledgerhq/types-live";
+import { act, render, screen } from "@tests/test-renderer";
+import type { PerpsDepositExecutionCallbacks } from "LLM/features/Perps/hooks/usePerpsDepositExecution";
+import PerpsDepositScreen from "../PerpsDepositScreen";
+
+const mockOpenDrawer = jest.fn();
+jest.mock("LLM/features/ModularDrawer", () => ({
+  useModularDrawerController: () => ({ openDrawer: mockOpenDrawer }),
+}));
+
+jest.mock("@ledgerhq/live-countervalues-react", () => ({
+  ...jest.requireActual("@ledgerhq/live-countervalues-react"),
+  useCalculateCountervalueCallback: () => (_currency: unknown, value: BigNumber) => value,
+  useCountervaluesState: () => ({}),
+}));
+
+jest.mock("@ledgerhq/live-countervalues/logic", () => ({
+  ...jest.requireActual("@ledgerhq/live-countervalues/logic"),
+  calculate: () => 20000000000000000,
+}));
+
+const mockUsePerpsDepositQuote = jest.fn();
+jest.mock("../usePerpsDepositQuote", () => ({
+  usePerpsDepositQuote: () => mockUsePerpsDepositQuote(),
+}));
+
+let capturedCallbacks: PerpsDepositExecutionCallbacks | undefined;
+const mockExecuteDeposit = jest.fn();
+jest.mock("LLM/features/Perps/hooks/usePerpsDepositExecution", () => ({
+  usePerpsDepositExecution: (_params: unknown, callbacks: PerpsDepositExecutionCallbacks) => {
+    capturedCallbacks = callbacks;
+    return {
+      deviceStep: { kind: "processing" },
+      executeDeposit: mockExecuteDeposit,
+      retry: jest.fn(),
+    };
+  },
+}));
+
+jest.mock("~/components/SelectDevice2", () => {
+  const { Text, TouchableOpacity } = require("react-native");
+  return {
+    __esModule: true,
+    default: ({ onSelect }: { onSelect: (device: unknown) => void }) => (
+      <TouchableOpacity
+        testID="select-device"
+        onPress={() => onSelect({ deviceId: "device-1", modelId: "stax", wired: false })}
+      >
+        <Text>SelectDevice</Text>
+      </TouchableOpacity>
+    ),
+  };
+});
+
+function createAccount(id: string, spendableBalance: number): Account {
+  return {
+    ...genAccount(id, { currency: getCryptoCurrencyById("ethereum"), operationsSize: 0 }),
+    spendableBalance: new BigNumber(spendableBalance),
+    balance: new BigNumber(spendableBalance),
+  };
+}
+
+const receiverAccount = createAccount("receiver-1", 0);
+const fundingAccount = createAccount("funding-1", 10000);
+
+const mockNavigation = { navigate: jest.fn(), goBack: jest.fn(), setOptions: jest.fn() };
+const mockRoute = { params: { receiverAccount } };
+
+function renderDeposit() {
+  return render(
+    <PerpsDepositScreen navigation={mockNavigation as never} route={mockRoute as never} />,
+    {
+      overrideInitialState: state => ({
+        ...state,
+        accounts: { ...state.accounts, active: [fundingAccount] },
+      }),
+    },
+  );
+}
+
+/** Walks the form up to the point where the summary is on screen. */
+async function fillFormAndReview(user: ReturnType<typeof renderDeposit>["user"]) {
+  await user.press(screen.getByTestId("perps-deposit-select-currency"));
+  const { onAccountSelected } = mockOpenDrawer.mock.calls[0][0];
+  act(() => onAccountSelected(fundingAccount));
+
+  await user.press(screen.getByTestId("perps-deposit-key-2"));
+  await user.press(screen.getByTestId("perps-deposit-key-0"));
+  await user.press(screen.getByTestId("perps-deposit-review-cta"));
+
+  return screen.findByTestId("perps-deposit-cta");
+}
+
+describe("PerpsDepositSign integration", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedCallbacks = undefined;
+    mockUsePerpsDepositQuote.mockReturnValue({
+      quote: { amountTo: new BigNumber(42) },
+      isLoading: false,
+      isUnavailable: false,
+    });
+  });
+
+  it("asks for a device once the summary is confirmed, without leaving the deposit screen", async () => {
+    const { user } = renderDeposit();
+
+    await user.press(await fillFormAndReview(user));
+
+    // The device list covers the form, as in every signing flow.
+    expect(await screen.findByTestId("select-device")).toBeOnTheScreen();
+    // Picking a device is what starts the deposit, so nothing has run yet.
+    expect(mockExecuteDeposit).not.toHaveBeenCalled();
+    // It takes over in place, so no new screen is pushed.
+    expect(mockNavigation.navigate).not.toHaveBeenCalled();
+  });
+
+  it("runs the deposit once a device is picked", async () => {
+    const { user } = renderDeposit();
+
+    await user.press(await fillFormAndReview(user));
+    await user.press(await screen.findByTestId("select-device"));
+
+    expect(screen.getByTestId("perps-deposit-sign-step")).toBeOnTheScreen();
+    expect(mockExecuteDeposit).toHaveBeenCalledTimes(1);
+    // The list has served its purpose, so the deposit is what sits behind the drawer.
+    expect(screen.queryByTestId("select-device")).not.toBeOnTheScreen();
+    expect(screen.getByTestId("perps-deposit-amount-input")).toBeOnTheScreen();
+  });
+
+  it("drops the device step when the deposit is declined, so the summary is back in front", async () => {
+    const { user } = renderDeposit();
+
+    await user.press(await fillFormAndReview(user));
+    await user.press(await screen.findByTestId("select-device"));
+
+    act(() => capturedCallbacks?.onRefused());
+
+    expect(screen.queryByTestId("perps-deposit-sign-step")).not.toBeOnTheScreen();
+    // The form comes back with the typed amount, so the holder can sign again as-is.
+    expect(screen.getByTestId("perps-deposit-amount-input").props.value).toBe("20");
+    expect(screen.getByTestId("perps-deposit-amount-sent")).toBeOnTheScreen();
+  });
+
+  it("goes straight back to the same device after a decline, without asking again", async () => {
+    const { user } = renderDeposit();
+
+    await user.press(await fillFormAndReview(user));
+    await user.press(await screen.findByTestId("select-device"));
+    act(() => capturedCallbacks?.onRefused());
+
+    await user.press(screen.getByTestId("perps-deposit-cta"));
+
+    // The device list would otherwise flash up before auto-selection re-picked it.
+    expect(await screen.findByTestId("perps-deposit-sign-step")).toBeOnTheScreen();
+    expect(screen.queryByTestId("select-device")).not.toBeOnTheScreen();
+    expect(mockExecuteDeposit).toHaveBeenCalledTimes(2);
+  });
+
+  it("drops the device step once the deposit lands", async () => {
+    const { user } = renderDeposit();
+
+    await user.press(await fillFormAndReview(user));
+    await user.press(await screen.findByTestId("select-device"));
+
+    act(() => capturedCallbacks?.onDone());
+
+    expect(screen.queryByTestId("perps-deposit-sign-step")).not.toBeOnTheScreen();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
@@ -2,6 +2,7 @@ import BigNumber from "bignumber.js";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import type { Account } from "@ledgerhq/types-live";
+import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { act, renderHook } from "@tests/test-renderer";
 import { usePerpsDepositViewModel } from "../usePerpsDepositViewModel";
 
@@ -369,5 +370,70 @@ describe("usePerpsDepositViewModel", () => {
 
     expect(result.current.isReviewOpen).toBe(false);
     expect(result.current.reviewParams).toBeNull();
+  });
+
+  describe("handing the reviewed deposit over to the device", () => {
+    const device = {
+      deviceId: "device-1",
+      deviceName: "Ledger Stax",
+      modelId: "stax",
+      wired: false,
+    } as unknown as Device;
+
+    function renderReviewedDeposit() {
+      mockCalculate.mockReturnValue(2.5e16);
+      const { props } = createProps();
+      const { result } = renderViewModel(props);
+
+      act(() => result.current.pickDepositAccount());
+      selectFundingAccount(fundedAccount);
+      typeAmount(result.current.pressAmountKey, "20");
+      act(() => result.current.handleReview());
+
+      return result;
+    }
+
+    it("swaps the summary for the device step once the deposit is handed over", () => {
+      const result = renderReviewedDeposit();
+
+      act(() => result.current.handOverToDevice());
+
+      expect(result.current.isReviewOpen).toBe(false);
+      expect(result.current.isSignOpen).toBe(true);
+    });
+
+    it("brings the summary back, amounts intact, when signing is declined", () => {
+      const result = renderReviewedDeposit();
+      const reviewed = result.current.reviewParams;
+
+      act(() => result.current.handOverToDevice());
+      act(() => result.current.returnToReview());
+
+      expect(result.current.isSignOpen).toBe(false);
+      expect(result.current.isReviewOpen).toBe(true);
+      expect(result.current.reviewParams).toEqual(reviewed);
+    });
+
+    it("keeps the device after a decline, so handing over again skips the device list", () => {
+      const result = renderReviewedDeposit();
+
+      act(() => result.current.handOverToDevice());
+      act(() => result.current.selectSigningDevice(device));
+      act(() => result.current.returnToReview());
+
+      expect(result.current.signingDevice).toEqual(device);
+    });
+
+    it("forgets the device once the deposit lands, so the next one starts at selection", () => {
+      const result = renderReviewedDeposit();
+
+      act(() => result.current.handOverToDevice());
+      act(() => result.current.selectSigningDevice(device));
+      act(() => result.current.endSigning());
+
+      expect(result.current.isSignOpen).toBe(false);
+      expect(result.current.isReviewOpen).toBe(false);
+      expect(result.current.signingDevice).toBeUndefined();
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsDepositSign/PerpsDepositSignView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsDepositSign/PerpsDepositSignView.tsx
@@ -1,0 +1,120 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useNavigation, useTheme } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { BottomSheetView, Box } from "@ledgerhq/lumen-ui-rnative";
+import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
+import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
+import type { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { QueuedBottomSheet } from "@shared/ui-queued-bottom-sheet";
+import { useTranslation } from "~/context/Locale";
+import DeviceAction from "~/components/DeviceAction";
+import { renderError, renderLoading } from "~/components/DeviceAction/rendering";
+import SelectDevice2 from "~/components/SelectDevice2";
+import type { RootStackParamList } from "~/components/RootNavigator/types/RootNavigator";
+import type { PerpsDepositDeviceStep } from "LLM/features/Perps/hooks/usePerpsDepositExecution";
+import { PerpsDepositConfirmation } from "./components/PerpsDepositConfirmation";
+import type { PerpsDepositSignViewModel } from "./usePerpsDepositSignViewModel";
+
+type DepositStepProps = Readonly<{
+  deviceStep: PerpsDepositDeviceStep;
+  device: Device;
+  retry: () => void;
+  onDeviceError: (error: Error) => void;
+}>;
+
+function DepositStep({ deviceStep, device, retry, onDeviceError }: DepositStepProps) {
+  const { t } = useTranslation();
+  const { colors, dark } = useTheme();
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const theme: "dark" | "light" = dark ? "dark" : "light";
+
+  if (deviceStep.kind === "error")
+    return renderError({
+      t,
+      navigation,
+      error: deviceStep.error,
+      onRetry: retry,
+      colors,
+      theme,
+      device,
+    });
+
+  if (deviceStep.kind !== "device") return renderLoading({ t, colors, theme });
+
+  return deviceStep.withDeviceAction(({ action, request, onResult }) => (
+    <DeviceAction
+      key={deviceStep.stepId}
+      action={action}
+      request={request}
+      device={device}
+      onResult={onResult}
+      onError={onDeviceError}
+      analyticsPropertyFlow="perps deposit"
+      renderExchangeConfirmation={
+        deviceStep.stepId === "confirm"
+          ? () => <PerpsDepositConfirmation device={device} />
+          : undefined
+      }
+    />
+  ));
+}
+
+export function PerpsDepositSignView({
+  selectedDevice,
+  deviceStep,
+  setSelectedDevice,
+  retry,
+  onDeviceError,
+  handleDrawerClose,
+  ignoreHeaderOptions,
+}: Readonly<PerpsDepositSignViewModel>) {
+  const { bottom: bottomInset } = useSafeAreaInsets();
+  const styles = useStyleSheet(
+    theme => ({
+      deviceSelection: {
+        ...StyleSheet.absoluteFillObject,
+        backgroundColor: theme.colors.bg.base,
+        paddingHorizontal: 16,
+        paddingTop: 8,
+      },
+    }),
+    [],
+  );
+
+  return (
+    <>
+      {selectedDevice ? null : (
+        <View style={styles.deviceSelection}>
+          <SelectDevice2
+            onSelect={setSelectedDevice}
+            requestToSetHeaderOptions={ignoreHeaderOptions}
+            autoSelectLastConnectedDevice
+          />
+        </View>
+      )}
+      <QueuedBottomSheet
+        isRequestingToBeOpened={!!selectedDevice}
+        onClose={handleDrawerClose}
+        preventBackdropClick={deviceStep.kind !== "error"}
+        hideHandle
+        enableDynamicSizing
+      >
+        <BottomSheetView style={{ paddingBottom: bottomInset + 16 }}>
+          <Box lx={{ alignItems: "center" }} testID="perps-deposit-sign-step">
+            {selectedDevice ? (
+              <DepositStep
+                deviceStep={deviceStep}
+                device={selectedDevice}
+                retry={retry}
+                onDeviceError={onDeviceError}
+              />
+            ) : null}
+          </Box>
+          {selectedDevice ? <SyncSkipUnderPriority priority={100} /> : null}
+        </BottomSheetView>
+      </QueuedBottomSheet>
+    </>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsDepositSign/__tests__/usePerpsDepositSignViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsDepositSign/__tests__/usePerpsDepositSignViewModel.test.ts
@@ -1,0 +1,134 @@
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import type { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { act, renderHook } from "@tests/test-renderer";
+import type { PerpsDepositExecutionCallbacks } from "LLM/features/Perps/hooks/usePerpsDepositExecution";
+import {
+  usePerpsDepositSignViewModel,
+  type PerpsDepositSignProps,
+} from "../usePerpsDepositSignViewModel";
+
+let capturedCallbacks: PerpsDepositExecutionCallbacks | undefined;
+const mockExecuteDeposit = jest.fn();
+jest.mock("LLM/features/Perps/hooks/usePerpsDepositExecution", () => ({
+  usePerpsDepositExecution: (_params: unknown, callbacks: PerpsDepositExecutionCallbacks) => {
+    capturedCallbacks = callbacks;
+    return {
+      deviceStep: { kind: "processing" },
+      executeDeposit: mockExecuteDeposit,
+      retry: jest.fn(),
+    };
+  },
+}));
+
+const ethereum = getCryptoCurrencyById("ethereum");
+const depositAccount = genAccount("funding-1", { currency: ethereum, operationsSize: 0 });
+const receiverAccount = genAccount("receiver-1", { currency: ethereum, operationsSize: 0 });
+
+const device = {
+  deviceId: "device-1",
+  deviceName: "Ledger Stax",
+  modelId: "stax",
+  wired: false,
+} as unknown as Device;
+
+/** The device is owned by the deposit screen, so the harness holds it the same way. */
+function renderSignViewModel(initialDevice?: Device) {
+  const onDone = jest.fn();
+  const onRefused = jest.fn();
+  let selectedDevice = initialDevice;
+
+  const buildProps = () =>
+    ({
+      depositAccount,
+      receiverAccount,
+      amountSent: "0.02",
+      amountTo: "0.019",
+      quoteId: "quote-1",
+      selectedDevice,
+      onSelectDevice: (next: Device | null | undefined) => {
+        selectedDevice = next ?? undefined;
+      },
+      onDone,
+      onRefused,
+    }) as unknown as PerpsDepositSignProps;
+
+  const { result, rerender } = renderHook(() => usePerpsDepositSignViewModel(buildProps()));
+
+  const pickDevice = (picked: Device) => {
+    act(() => {
+      result.current.setSelectedDevice(picked);
+      rerender(undefined);
+    });
+  };
+
+  return { result, pickDevice, onDone, onRefused };
+}
+
+describe("usePerpsDepositSignViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedCallbacks = undefined;
+  });
+
+  it("waits for a device before running the deposit", () => {
+    renderSignViewModel();
+
+    expect(mockExecuteDeposit).not.toHaveBeenCalled();
+  });
+
+  it("starts the deposit once a device is picked, and only once", () => {
+    const { pickDevice } = renderSignViewModel();
+
+    pickDevice(device);
+    pickDevice(device);
+
+    expect(mockExecuteDeposit).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts straight away when the screen already knows the device", () => {
+    // Signing again after a decline: the device is remembered, so no list is shown.
+    renderSignViewModel(device);
+
+    expect(mockExecuteDeposit).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a decline on the device so the summary can come back", () => {
+    const { onDone, onRefused } = renderSignViewModel(device);
+
+    act(() => capturedCallbacks?.onRefused());
+
+    expect(onRefused).toHaveBeenCalled();
+    expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it("reports a decline of the manager prompt, which fails the connection instead", () => {
+    const { result, onRefused } = renderSignViewModel(device);
+
+    act(() =>
+      result.current.onDeviceError(
+        Object.assign(new Error("refused"), { name: "UserRefusedAllowManager" }),
+      ),
+    );
+
+    expect(onRefused).toHaveBeenCalled();
+  });
+
+  it("leaves a connection failure to the device action, which retries in place", () => {
+    const { result, onDone, onRefused } = renderSignViewModel(device);
+
+    act(() => result.current.onDeviceError(new Error("device is locked")));
+
+    expect(onRefused).not.toHaveBeenCalled();
+    expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it("reports success without reopening the summary", () => {
+    const { onDone, onRefused } = renderSignViewModel(device);
+
+    act(() => capturedCallbacks?.onDone());
+
+    expect(onDone).toHaveBeenCalled();
+    expect(onRefused).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsDepositSign/components/PerpsDepositConfirmation.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsDepositSign/components/PerpsDepositConfirmation.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
-import { getProductName } from "LLM/utils/getProductName";
+import { getProductName } from "@ledgerhq/devices";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { ContinueOnDevice } from "LLM/components/DeviceIntentExecutor/components/DeviceGenericStates/ContinueOnDevice";
 import { PerpsDepositSignTerms } from "./PerpsDepositSignTerms";

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsDepositSign/components/PerpsDepositConfirmation.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsDepositSign/components/PerpsDepositConfirmation.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
+import { getProductName } from "LLM/utils/getProductName";
+import type { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { ContinueOnDevice } from "LLM/components/DeviceIntentExecutor/components/DeviceGenericStates/ContinueOnDevice";
+import { PerpsDepositSignTerms } from "./PerpsDepositSignTerms";
+
+export function PerpsDepositConfirmation({ device }: Readonly<{ device: Device }>) {
+  return (
+    <Box lx={{ alignItems: "center", padding: "s24", gap: "s24" }}>
+      <ContinueOnDevice
+        deviceModelId={device.modelId}
+        deviceName={device.deviceName || getProductName(device.modelId)}
+      />
+      <PerpsDepositSignTerms />
+    </Box>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsDepositSign/components/PerpsDepositSignTerms.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsDepositSign/components/PerpsDepositSignTerms.tsx
@@ -1,14 +1,15 @@
 import React, { useCallback } from "react";
 import { Linking, StyleSheet } from "react-native";
 import { Text } from "@ledgerhq/lumen-ui-rnative";
+import { getProviderTermsOfUseUrl } from "@ledgerhq/live-common/exchange/swap/utils/index";
 import { Trans } from "~/context/Locale";
-
-const SWAPKIT_TERMS_URL = "https://swapkit.dev/terms-of-service/";
+import { PERPS_DEPOSIT_PROVIDER_ID } from "LLM/features/Perps/constants/depositFunding";
 
 export function PerpsDepositSignTerms() {
+  const termsUrl = getProviderTermsOfUseUrl(PERPS_DEPOSIT_PROVIDER_ID);
   const openTerms = useCallback(() => {
-    Linking.openURL(SWAPKIT_TERMS_URL);
-  }, []);
+    if (termsUrl) Linking.openURL(termsUrl);
+  }, [termsUrl]);
 
   return (
     <Text typography="body4" lx={{ color: "muted", textAlign: "center" }}>
@@ -19,9 +20,9 @@ export function PerpsDepositSignTerms() {
             <Text
               typography="body4"
               lx={{ color: "muted" }}
-              style={styles.link}
-              onPress={openTerms}
-              accessibilityRole="link"
+              style={termsUrl ? styles.link : undefined}
+              onPress={termsUrl ? openTerms : undefined}
+              accessibilityRole={termsUrl ? "link" : undefined}
             />
           ),
         }}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsDepositSign/components/PerpsDepositSignTerms.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsDepositSign/components/PerpsDepositSignTerms.tsx
@@ -1,0 +1,37 @@
+import React, { useCallback } from "react";
+import { Linking, StyleSheet } from "react-native";
+import { Text } from "@ledgerhq/lumen-ui-rnative";
+import { Trans } from "~/context/Locale";
+
+const SWAPKIT_TERMS_URL = "https://swapkit.dev/terms-of-service/";
+
+export function PerpsDepositSignTerms() {
+  const openTerms = useCallback(() => {
+    Linking.openURL(SWAPKIT_TERMS_URL);
+  }, []);
+
+  return (
+    <Text typography="body4" lx={{ color: "muted", textAlign: "center" }}>
+      <Trans
+        i18nKey="perpsDepositSign.terms"
+        components={{
+          termsLink: (
+            <Text
+              typography="body4"
+              lx={{ color: "muted" }}
+              style={styles.link}
+              onPress={openTerms}
+              accessibilityRole="link"
+            />
+          ),
+        }}
+      />
+    </Text>
+  );
+}
+
+const styles = StyleSheet.create({
+  link: {
+    textDecorationLine: "underline",
+  },
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsDepositSign/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsDepositSign/index.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { PerpsDepositSignView } from "./PerpsDepositSignView";
+import {
+  usePerpsDepositSignViewModel,
+  type PerpsDepositSignProps,
+} from "./usePerpsDepositSignViewModel";
+
+export type { PerpsDepositSignProps } from "./usePerpsDepositSignViewModel";
+
+export function PerpsDepositSign(props: PerpsDepositSignProps) {
+  const viewModel = usePerpsDepositSignViewModel(props);
+  return <PerpsDepositSignView {...viewModel} />;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsDepositSign/usePerpsDepositSignViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsDepositSign/usePerpsDepositSignViewModel.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useRef } from "react";
+import type { Device } from "@ledgerhq/live-common/hw/actions/types";
+import type { PerpsDepositReviewParams } from "@ledgerhq/live-common/wallet-api/Perps/server";
+import type { SetHeaderOptionsRequest } from "~/components/SelectDevice2";
+import {
+  usePerpsDepositExecution,
+  type PerpsDepositDeviceStep,
+} from "LLM/features/Perps/hooks/usePerpsDepositExecution";
+import { isUserRefusal } from "LLM/features/Perps/utils/isUserRefusal";
+
+/** The sheet owns no navigation header, so pairing's header requests are dropped. */
+const ignoreHeaderOptions = (_request: SetHeaderOptionsRequest) => undefined;
+
+/** Mounted only while signing, so opening and closing is the caller's business. */
+export type PerpsDepositSignProps = Readonly<PerpsDepositReviewParams> &
+  Readonly<{
+    /**
+     * The device to sign on, held by the deposit screen so that it outlives a
+     * single attempt. Signing again after a decline then skips the device list.
+     */
+    selectedDevice: Device | null | undefined;
+    onSelectDevice: (device: Device | null | undefined) => void;
+    /** The deposit landed. */
+    onDone: () => void;
+    /** The holder backed out, so the summary they came from comes back. */
+    onRefused: () => void;
+  }>;
+
+export type PerpsDepositSignViewModel = Readonly<{
+  selectedDevice: Device | null | undefined;
+  deviceStep: PerpsDepositDeviceStep;
+  setSelectedDevice: (device: Device | null | undefined) => void;
+  retry: () => void;
+  /** Errors raised while connecting to the device, which never reach the execution. */
+  onDeviceError: (error: Error) => void;
+  handleDrawerClose: () => void;
+  ignoreHeaderOptions: (request: SetHeaderOptionsRequest) => void;
+}>;
+
+export function usePerpsDepositSignViewModel({
+  selectedDevice,
+  onSelectDevice,
+  onDone,
+  onRefused,
+  ...depositParams
+}: PerpsDepositSignProps): PerpsDepositSignViewModel {
+  const { deviceStep, executeDeposit, retry } = usePerpsDepositExecution(depositParams, {
+    onDone,
+    onRefused,
+  });
+
+  const onDeviceError = useCallback(
+    (error: Error) => {
+      if (isUserRefusal(error)) onRefused();
+    },
+    [onRefused],
+  );
+
+  const startedRef = useRef(false);
+  useEffect(() => {
+    if (!selectedDevice || startedRef.current) return;
+    startedRef.current = true;
+    void executeDeposit();
+  }, [executeDeposit, selectedDevice]);
+
+  return {
+    selectedDevice,
+    deviceStep,
+    setSelectedDevice: onSelectDevice,
+    retry,
+    onDeviceError,
+    handleDrawerClose: onRefused,
+    ignoreHeaderOptions,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsDepositSign/usePerpsDepositSignViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsDepositSign/usePerpsDepositSignViewModel.ts
@@ -10,7 +10,7 @@ import { isUserRefusal } from "LLM/features/Perps/utils/isUserRefusal";
 
 const ignoreHeaderOptions = (_request: SetHeaderOptionsRequest) => undefined;
 
-ßexport type PerpsDepositSignProps = Readonly<PerpsDepositReviewParams> &
+export type PerpsDepositSignProps = Readonly<PerpsDepositReviewParams> &
   Readonly<{
     selectedDevice: Device | null | undefined;
     onSelectDevice: (device: Device | null | undefined) => void;

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsDepositSign/usePerpsDepositSignViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsDepositSign/usePerpsDepositSignViewModel.ts
@@ -8,21 +8,13 @@ import {
 } from "LLM/features/Perps/hooks/usePerpsDepositExecution";
 import { isUserRefusal } from "LLM/features/Perps/utils/isUserRefusal";
 
-/** The sheet owns no navigation header, so pairing's header requests are dropped. */
 const ignoreHeaderOptions = (_request: SetHeaderOptionsRequest) => undefined;
 
-/** Mounted only while signing, so opening and closing is the caller's business. */
-export type PerpsDepositSignProps = Readonly<PerpsDepositReviewParams> &
+ßexport type PerpsDepositSignProps = Readonly<PerpsDepositReviewParams> &
   Readonly<{
-    /**
-     * The device to sign on, held by the deposit screen so that it outlives a
-     * single attempt. Signing again after a decline then skips the device list.
-     */
     selectedDevice: Device | null | undefined;
     onSelectDevice: (device: Device | null | undefined) => void;
-    /** The deposit landed. */
     onDone: () => void;
-    /** The holder backed out, so the summary they came from comes back. */
     onRefused: () => void;
   }>;
 
@@ -31,7 +23,6 @@ export type PerpsDepositSignViewModel = Readonly<{
   deviceStep: PerpsDepositDeviceStep;
   setSelectedDevice: (device: Device | null | undefined) => void;
   retry: () => void;
-  /** Errors raised while connecting to the device, which never reach the execution. */
   onDeviceError: (error: Error) => void;
   handleDrawerClose: () => void;
   ignoreHeaderOptions: (request: SetHeaderOptionsRequest) => void;

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/__tests__/usePerpsReviewViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/__tests__/usePerpsReviewViewModel.test.ts
@@ -15,6 +15,7 @@ function createProps(overrides?: Partial<PerpsReviewProps>): PerpsReviewProps {
     amountTo: "0.019",
     isOpen: true,
     onClose: jest.fn(),
+    onConfirm: jest.fn(),
     ...overrides,
   };
 }
@@ -66,12 +67,17 @@ describe("usePerpsReviewViewModel", () => {
     expect(result.current.drawerOpen).toBe(false);
   });
 
-  it("closes the drawer when confirming the deposit", () => {
+  it("hands over to the deposit screen when confirming, which opens the device step", () => {
     const onClose = jest.fn();
-    const { result } = renderHook(() => usePerpsReviewViewModel(createProps({ onClose })));
+    const onConfirm = jest.fn();
+    const { result } = renderHook(() =>
+      usePerpsReviewViewModel(createProps({ onClose, onConfirm })),
+    );
 
     result.current.handleDeposit();
 
-    expect(onClose).toHaveBeenCalled();
+    expect(onConfirm).toHaveBeenCalled();
+    // Closing is the deposit screen's call, so the summary can come back on a decline.
+    expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/usePerpsReviewViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsReview/usePerpsReviewViewModel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useMemo } from "react";
 import type { PerpsDepositReviewParams } from "@ledgerhq/live-common/wallet-api/Perps/server";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit, parseCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
@@ -19,6 +19,7 @@ export type PerpsReviewProps = PerpsReviewParams &
   Readonly<{
     isOpen: boolean;
     onClose: () => void;
+    onConfirm: () => void;
   }>;
 
 export type PerpsReviewViewModel = Readonly<{
@@ -32,6 +33,7 @@ export type PerpsReviewViewModel = Readonly<{
 export function usePerpsReviewViewModel({
   isOpen,
   onClose,
+  onConfirm,
   amountSent,
   amountTo,
   depositAccount,
@@ -104,17 +106,11 @@ export function usePerpsReviewViewModel({
     [approximateAmountReceived, receiverAccountLabel],
   );
 
-  const handleDeposit = useCallback(() => {
-    // Confirming closes the drawer; executing the deposit (sign + broadcast) is
-    // owned by the wallet's deposit flow and reports no result to the live app.
-    onClose();
-  }, [onClose]);
-
   return {
     drawerOpen: isOpen,
     swapDetails,
     depositDetails,
     handleDrawerClose: onClose,
-    handleDeposit,
+    handleDeposit: onConfirm,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/index.tsx
@@ -8,6 +8,7 @@ import { PERPS_DEPOSIT_PROVIDER_ID } from "../../constants/depositFunding";
 import { AmountKeypad } from "LLM/components/AmountKeypad";
 import { RatioPicker } from "LLM/components/RatioPicker";
 import { DepositAccountSelector } from "./components/DepositAccountSelector";
+import { PerpsDepositSign } from "./components/PerpsDepositSign";
 import { PerpsReview } from "./components/PerpsReview";
 import type { PerpsDepositViewModel } from "./usePerpsDepositViewModel";
 
@@ -64,7 +65,7 @@ function AmountMessage({
   return null;
 }
 
-export function PerpsDepositView({
+function DepositForm({
   headerDescription,
   amountText,
   depositAmount,
@@ -86,23 +87,11 @@ export function PerpsDepositView({
   missingAccount,
   pickDepositAccount,
   handleReview,
-  isReviewOpen,
-  reviewParams,
-  closeReview,
 }: Readonly<PerpsDepositViewModel>) {
   const { t } = useTranslation();
-  const styles = useStyleSheet(
-    theme => ({
-      root: {
-        flex: 1,
-        backgroundColor: theme.colors.bg.base,
-      },
-    }),
-    [],
-  );
 
   return (
-    <SafeAreaView edges={["bottom"]} style={styles.root}>
+    <>
       <Box lx={{ flex: 1, paddingHorizontal: "s16", gap: "s16" }}>
         <Text typography="body2" lx={{ color: "muted", textAlign: "center" }}>
           {headerDescription}
@@ -164,9 +153,44 @@ export function PerpsDepositView({
           {t("perpsDeposit.review")}
         </Button>
       </Box>
+    </>
+  );
+}
+
+export function PerpsDepositView(viewModel: Readonly<PerpsDepositViewModel>) {
+  const { isReviewOpen, reviewParams, closeReview, isSignOpen, handOverToDevice } = viewModel;
+  const { signingDevice, selectSigningDevice, returnToReview, endSigning } = viewModel;
+  const styles = useStyleSheet(
+    theme => ({
+      root: {
+        flex: 1,
+        backgroundColor: theme.colors.bg.base,
+      },
+    }),
+    [],
+  );
+
+  return (
+    <SafeAreaView edges={["bottom"]} style={styles.root}>
+      <DepositForm {...viewModel} />
+
+      {isSignOpen && reviewParams ? (
+        <PerpsDepositSign
+          {...reviewParams}
+          selectedDevice={signingDevice}
+          onSelectDevice={selectSigningDevice}
+          onDone={endSigning}
+          onRefused={returnToReview}
+        />
+      ) : null}
 
       {reviewParams ? (
-        <PerpsReview {...reviewParams} isOpen={isReviewOpen} onClose={closeReview} />
+        <PerpsReview
+          {...reviewParams}
+          isOpen={isReviewOpen}
+          onClose={closeReview}
+          onConfirm={handOverToDevice}
+        />
       ) : null}
     </SafeAreaView>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
@@ -9,6 +9,7 @@ import {
 } from "@ledgerhq/live-countervalues-react";
 import { calculate } from "@ledgerhq/live-countervalues/logic";
 import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
+import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { useSelector } from "~/context/hooks";
 import { flattenAccountsSelector } from "~/reducers/accounts";
 import {
@@ -64,6 +65,14 @@ export type PerpsDepositViewModel = Readonly<{
   isReviewOpen: boolean;
   reviewParams: PerpsReviewParams | null;
   closeReview: () => void;
+  isSignOpen: boolean;
+  signingDevice: Device | null | undefined;
+  selectSigningDevice: (device: Device | null | undefined) => void;
+  handOverToDevice: () => void;
+  /** The device declined, which is not a failure: the summary takes over again. */
+  returnToReview: () => void;
+  /** Signed and broadcast, so nothing is left to sign. */
+  endSigning: () => void;
 }>;
 
 export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepositViewModel {
@@ -79,6 +88,8 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
   const [depositAccountId, setDepositAccountId] = useState<string | undefined>(undefined);
   const [amountText, setAmountText] = useState("");
   const [isReviewOpen, setIsReviewOpen] = useState(false);
+  const [isSignOpen, setIsSignOpen] = useState(false);
+  const [signingDevice, setSigningDevice] = useState<Device | null | undefined>();
   const [reviewParams, setReviewParams] = useState<PerpsReviewParams | null>(null);
 
   /** Read from the store so balances stay live while the form is open. */
@@ -261,6 +272,22 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
 
   const closeReview = useCallback(() => setIsReviewOpen(false), []);
 
+  const handOverToDevice = useCallback(() => {
+    setIsReviewOpen(false);
+    setIsSignOpen(true);
+  }, []);
+
+  /** The device is kept, so handing over again skips the device list. */
+  const returnToReview = useCallback(() => {
+    setIsSignOpen(false);
+    setIsReviewOpen(true);
+  }, []);
+
+  const endSigning = useCallback(() => {
+    setIsSignOpen(false);
+    setSigningDevice(undefined);
+  }, []);
+
   return {
     headerDescription: `${receiverAccountName} · ${receiverAccountCounterValue}`,
     amountText,
@@ -288,5 +315,11 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
     isReviewOpen,
     reviewParams,
     closeReview,
+    isSignOpen,
+    signingDevice,
+    selectSigningDevice: setSigningDevice,
+    handOverToDevice,
+    returnToReview,
+    endSigning,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/utils/__tests__/isUserRefusal.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/utils/__tests__/isUserRefusal.test.ts
@@ -1,0 +1,32 @@
+import { isUserRefusal } from "../isUserRefusal";
+
+describe("isUserRefusal", () => {
+  it.each([
+    ["the coin app prompt, normalized by the transaction action", "TransactionRefusedOnDevice"],
+    ["a signer that names the refusal itself", "UserRefusedOnDevice"],
+    ["the manager allowance prompt, raised while resolving apps", "UserRefusedAllowManager"],
+  ])("recognises a decline reported by %s", (_case, name) => {
+    expect(isUserRefusal(Object.assign(new Error("refused"), { name }))).toBe(true);
+  });
+
+  it("recognises a decline on the Exchange app prompt, which survives only as a title", () => {
+    const error = Object.assign(new Error("refused"), {
+      name: "CompleteExchangeError",
+      title: "userRefused",
+    });
+
+    expect(isUserRefusal(error)).toBe(true);
+  });
+
+  it.each([
+    ["a plain failure", new Error("boom")],
+    [
+      "an Exchange failure that is not a decline",
+      Object.assign(new Error("boom"), { name: "CompleteExchangeError", title: "internalError" }),
+    ],
+    ["nothing at all", undefined],
+    ["a string", "userRefused"],
+  ])("does not mistake %s for a decline", (_case, error) => {
+    expect(isUserRefusal(error)).toBe(false);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/utils/isUserRefusal.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/utils/isUserRefusal.ts
@@ -1,0 +1,20 @@
+/** Every name or title a decline arrives under, one per prompt a deposit raises. */
+const REFUSAL_MARKERS = new Set([
+  "TransactionRefusedOnDevice",
+  "UserRefusedOnDevice",
+  "UserRefusedAllowManager",
+  "userRefused",
+]);
+
+const marksARefusal = (value: unknown): boolean =>
+  typeof value === "string" && REFUSAL_MARKERS.has(value);
+
+/** Tells a decline apart from a failure. Duck-typed, as `instanceof` is unreliable here. */
+export function isUserRefusal(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+
+  return (
+    ("name" in error && marksARefusal(error.name)) ||
+    ("title" in error && marksARefusal(error.title))
+  );
+}


### PR DESCRIPTION
[LIVE-35328](https://ledgerhq.atlassian.net/browse/LIVE-35328)

Mobile counterpart of #21246. Stacked on `feat/LIVE-35327-mobile`.

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/ceee421d-f4e6-4467-a9c9-ed32d2022069" />

## What

A perps deposit is a swap, but the swap sequence lived inside the wallet-api RPC
handler and could only run from a live app. `executeSwap` is lifted out of
`server.ts` so perps can call it directly, and `usePerpsDepositExecution` renders
its steps — nonce, payload confirmation, signature, broadcast — in perps' own UI.

Signing happens on the deposit screen: device selection takes over the screen, then
a bottom sheet holds the device step. Declining on the device returns to the review
with the draft and the chosen device intact, rather than raising an error.

[LIVE-35328]: https://ledgerhq.atlassian.net/browse/LIVE-35328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ