### PR TITLE
[LWD] fix(zcash): sync now action not working

### DIFF
--- a/.changeset/lucky-pandas-listen.md
+++ b/.changeset/lucky-pandas-listen.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix Zcash private balance sync staying at 0% when started from the UFVK export modal

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/AccountBalanceSummaryFooter.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React from "react";
 import styled from "styled-components";
 import { Trans, useTranslation } from "react-i18next";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
@@ -221,13 +221,6 @@ const EstimatedTimeRemaining = ({
   );
 };
 
-function usePrevious<T>(val: T): T {
-  const ref = useRef<T>(val);
-  const prevVal = ref.current;
-  ref.current = val;
-  return prevVal;
-}
-
 type Props = {
   account: ZcashAccount | TokenAccount;
 };
@@ -238,7 +231,6 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
 
   const privateInfo = "privateInfo" in account ? account.privateInfo : null;
   const syncState = privateInfo?.syncState ?? "disabled";
-  const previousSyncState = usePrevious(syncState);
   const lastSync = privateInfo?.lastSyncTimestamp ? new Date(privateInfo.lastSyncTimestamp) : null;
   const progress = privateInfo?.progress ?? 0;
   const estimatedTimeRemaining = privateInfo?.estimatedTimeRemaining ?? { hours: 0, minutes: 0 };
@@ -282,13 +274,6 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
         break;
     }
   };
-
-  // Check if private balance has been activated
-  useEffect(() => {
-    if (previousSyncState === "disabled" && syncState === "running") {
-      startShieldedSync();
-    }
-  }, [previousSyncState, syncState, startShieldedSync]);
 
   if (
     account.type !== "Account" ||

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/Body.tsx
@@ -17,7 +17,6 @@ import { BitcoinAccount } from "@ledgerhq/live-common/families/bitcoin/types";
 import { ContinueFooter } from "./shared/ContinueFooter";
 import StepUfvk from "./steps/StepUfvk";
 import StepDevice, { StepDeviceFooter } from "./steps/StepDevice";
-import { ZcashSyncState } from "@ledgerhq/coin-zcash/network/types";
 
 export type Data = {
   account: BitcoinAccount;
@@ -37,7 +36,7 @@ type OwnProps = {
   syncFromZero: boolean;
   handleBirthdayChange: (value: string) => void;
   handleSyncFromZero: () => void;
-  handleEnableShieldedBalance: (nextSyncState: ZcashSyncState) => void;
+  handleEnableShieldedBalance: (options: { startSyncNow: boolean }) => void;
 };
 
 type StateProps = {

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/__tests__/ZCashExportKeyFlowModal.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/__tests__/ZCashExportKeyFlowModal.integ.test.tsx
@@ -59,7 +59,7 @@ jest.mock("../Body", () => {
     onUfvkChanged: (ufvk: string) => void;
     handleBirthdayChange: (birthday: string) => void;
     handleSyncFromZero: () => void;
-    handleEnableShieldedBalance: (nextSyncState: "ready" | "running") => void;
+    handleEnableShieldedBalance: (options: { startSyncNow: boolean }) => void;
     invalidBirthday: boolean;
   }) {
     return (
@@ -78,10 +78,10 @@ jest.mock("../Body", () => {
           sync from zero
         </button>
         <span data-testid="invalid-birthday">{String(invalidBirthday)}</span>
-        <button type="button" onClick={() => handleEnableShieldedBalance("ready")}>
+        <button type="button" onClick={() => handleEnableShieldedBalance({ startSyncNow: false })}>
           Close
         </button>
-        <button type="button" onClick={() => handleEnableShieldedBalance("running")}>
+        <button type="button" onClick={() => handleEnableShieldedBalance({ startSyncNow: true })}>
           Start sync
         </button>
       </div>
@@ -490,7 +490,11 @@ describe("ZCash Export UFVK Flow - Persistence integration", () => {
     expect(mockDispatch).toHaveBeenCalledWith({ type: "TEST_SYNC_STATE_ACTION" });
   });
 
-  it("persists ufvk and birthday when clicking Start sync", async () => {
+  // "Start sync" persists the key as "ready" exactly like Close, and leaves the
+  // "running" transition to startShieldedSync, which is the only place that also
+  // registers the subscription driving the sync. Persisting "running" here instead
+  // stranded the account on a 0% spinner nothing ever advanced.
+  it("persists ufvk and birthday as ready when clicking Start sync", async () => {
     mockSyncStateUpdater.mockReturnValue({ type: "TEST_SYNC_STATE_ACTION" });
     render(<ExportKeyModal account={account} />);
 
@@ -502,12 +506,16 @@ describe("ZCash Export UFVK Flow - Persistence integration", () => {
       expect(mockSyncStateUpdater).toHaveBeenCalledWith(
         account,
         expect.objectContaining({
-          syncState: "running",
+          syncState: "ready",
           ufvk: "test-ufvk",
           birthday: "2026-08-01",
         }),
       );
     });
+    expect(mockSyncStateUpdater).not.toHaveBeenCalledWith(
+      account,
+      expect.objectContaining({ syncState: "running" }),
+    );
     expect(mockDispatch).toHaveBeenCalledWith({ type: "TEST_SYNC_STATE_ACTION" });
   });
 

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/__tests__/ZCashExportKeyStartSync.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/__tests__/ZCashExportKeyStartSync.test.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+import { Observable } from "rxjs";
+import { render, screen, userEvent, waitFor } from "tests/testSetup";
+import { createFixtureAccount } from "@ledgerhq/coin-bitcoin/fixtures/common.fixtures";
+import { DEFAULT_ZCASH_PRIVATE_INFO } from "@ledgerhq/coin-zcash/constants";
+import { CryptoCurrency } from "@domain/entity-currency-crypto";
+import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { SYNC_TYPE_SHIELDED } from "@ledgerhq/types-live";
+import type { Account } from "@ledgerhq/types-live";
+import type { ZcashAccount } from "@ledgerhq/live-common/families/bitcoin/types";
+import ExportKeyModal from "../index";
+
+jest.mock("@ledgerhq/live-common/bridge/index", () => {
+  const actual = jest.requireActual<Record<PropertyKey, unknown>>(
+    "@ledgerhq/live-common/bridge/index",
+  );
+  const overrides: Record<PropertyKey, unknown> = { __esModule: true, getAccountBridge: jest.fn() };
+  return new Proxy(overrides, { get: (o, k) => (k in o ? o[k] : actual[k]) });
+});
+const mockedGetAccountBridge = jest.mocked(getAccountBridge);
+
+jest.mock("~/renderer/components/Modal", () => {
+  const actual = jest.requireActual("~/renderer/components/Modal");
+  const MockModal = ({
+    render: renderContent,
+  }: {
+    render?: (args: { onClose: () => void; data: unknown }) => React.ReactNode;
+  }) => <>{renderContent?.({ onClose: jest.fn(), data: {} })}</>;
+
+  return { ...actual, __esModule: true, default: MockModal };
+});
+
+// Stands in for the stepper so the two confirmation-step CTAs can be driven
+// directly; StepConfirmation's own mapping of those buttons to the
+// startSyncNow flag is covered in ZCashExportKeyFlowModal.test.tsx.
+jest.mock("../Body", () => {
+  return function MockBody({
+    onUfvkChanged,
+    handleEnableShieldedBalance,
+  }: {
+    onUfvkChanged: (ufvk: string, shieldedAddress?: string | null) => void;
+    handleEnableShieldedBalance: (options: { startSyncNow: boolean }) => void;
+  }) {
+    return (
+      <div>
+        <button type="button" onClick={() => onUfvkChanged("test-ufvk", "test-shielded-address")}>
+          set ufvk
+        </button>
+        <button type="button" onClick={() => handleEnableShieldedBalance({ startSyncNow: true })}>
+          Start sync
+        </button>
+        <button type="button" onClick={() => handleEnableShieldedBalance({ startSyncNow: false })}>
+          Close
+        </button>
+      </div>
+    );
+  };
+});
+
+const zcashAccount = {
+  ...createFixtureAccount(),
+  currency: { id: "zcash" } as CryptoCurrency,
+  privateInfo: { ...DEFAULT_ZCASH_PRIVATE_INFO, syncState: "disabled", ufvk: null },
+} as unknown as ZcashAccount;
+
+const renderModal = () =>
+  render(<ExportKeyModal account={zcashAccount} />, {
+    initialState: { accounts: [zcashAccount], shieldedSyncSubscriptions: [] },
+  });
+
+const accountFromStore = (state: { accounts: Account[] }): ZcashAccount =>
+  state.accounts.find(a => a.id === zcashAccount.id) as ZcashAccount;
+
+describe("ZCash Export UFVK Flow - starting the sync from the modal", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetAccountBridge.mockReturnValue({
+      sync: jest.fn(() => new Observable(subscriber => subscriber.next((a: unknown) => a))),
+    } as unknown as ReturnType<typeof getAccountBridge>);
+  });
+
+  // The regression: "Start sync" used to only write syncState "running" to redux.
+  // Nothing registered the rxjs subscription that actually advances the scan, and
+  // startShieldedSync — the only thing that could — refuses to run once it sees
+  // "running", so the account sat on a 0% spinner until the user stopped and
+  // restarted the sync by hand.
+  it("registers a shielded sync subscription when starting the sync", async () => {
+    const { store } = renderModal();
+
+    await userEvent.click(screen.getByRole("button", { name: /set ufvk/i }));
+    await userEvent.click(screen.getByRole("button", { name: /start sync/i }));
+
+    await waitFor(() => {
+      expect(store.getState().shieldedSyncSubscriptions).toEqual([
+        {
+          accountId: zcashAccount.id,
+          subscription: expect.objectContaining({ unsubscribe: expect.any(Function) }),
+        },
+      ]);
+    });
+
+    const bridge = mockedGetAccountBridge.mock.results[0].value;
+    expect(bridge.sync).toHaveBeenCalledWith(
+      expect.objectContaining({ id: zcashAccount.id }),
+      expect.objectContaining({ syncType: SYNC_TYPE_SHIELDED }),
+    );
+
+    const account = accountFromStore(store.getState());
+    expect(account.privateInfo?.ufvk).toBe("test-ufvk");
+    expect(account.privateInfo?.syncState).toBe("running");
+  });
+
+  // Closing only enables private balance. Leaving syncState "ready" is what keeps
+  // the account-page CTA a working "Start sync" rather than a "Stop sync" for a
+  // sync that was never running.
+  it("enables private balance without starting a sync when closing", async () => {
+    const { store } = renderModal();
+
+    await userEvent.click(screen.getByRole("button", { name: /set ufvk/i }));
+    await userEvent.click(screen.getByRole("button", { name: /close/i }));
+
+    await waitFor(() => {
+      const account = accountFromStore(store.getState());
+      expect(account.privateInfo?.ufvk).toBe("test-ufvk");
+      expect(account.privateInfo?.syncState).toBe("ready");
+    });
+
+    expect(store.getState().shieldedSyncSubscriptions).toEqual([]);
+    expect(mockedGetAccountBridge).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/index.tsx
@@ -5,13 +5,14 @@ import {
   ZCASH_ACTIVATION_DATE,
   ZCASH_ACTIVATION_DATE_STRING,
 } from "@ledgerhq/coin-zcash/constants";
-import type { ZcashSyncState, ZcashPrivateInfo } from "@ledgerhq/coin-zcash/network/types";
+import type { ZcashPrivateInfo } from "@ledgerhq/coin-zcash/network/types";
 import type { ZcashAccount } from "@ledgerhq/live-common/families/bitcoin/types";
 import Modal from "~/renderer/components/Modal";
 import logger from "~/renderer/logger";
 import Body from "./Body";
 import { StepId } from "./types";
 import { syncStateUpdater } from "./sync";
+import { useZcashShieldedSync } from "../useZcashShieldedSync";
 
 const ExportKeyModal = ({ account }: { account: ZcashAccount }) => {
   const [stepId, setStepId] = useState<StepId>("birthday");
@@ -29,6 +30,7 @@ const ExportKeyModal = ({ account }: { account: ZcashAccount }) => {
   const [syncFromZero, setSyncFromZero] = useState(false);
 
   const dispatch = useDispatch();
+  const { startShieldedSync } = useZcashShieldedSync(account);
 
   const saveSyncState = (info: Partial<ZcashPrivateInfo>) => {
     dispatch(
@@ -84,13 +86,21 @@ const ExportKeyModal = ({ account }: { account: ZcashAccount }) => {
     setShieldedAddress(shieldedAddr ?? null);
   };
 
-  const handleEnableShieldedBalance = (nextSyncState: ZcashSyncState) => {
+  // Persisting the viewing key is what enables private balance, and "ready" is the
+  // only honest state to persist it with: nothing is syncing yet. Starting is
+  // delegated to startShieldedSync, the one place that both registers the rxjs
+  // subscription and flips syncState to "running". Writing "running" here instead
+  // would leave the UI on a 0% spinner no subscription ever advances, and would
+  // then be refused by startShieldedSync's own "already running" guard.
+  const handleEnableShieldedBalance = ({ startSyncNow }: { startSyncNow: boolean }) => {
     saveSyncState({
-      syncState: nextSyncState,
+      syncState: "ready",
       ufvk,
       birthday,
       shieldedAddress,
     });
+
+    if (startSyncNow) startShieldedSync();
   };
 
   const isModalLocked = ["device", "confirmation"].includes(stepId);

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/steps/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/steps/StepConfirmation.tsx
@@ -72,12 +72,12 @@ export function StepConfirmationFooter({
   handleEnableShieldedBalance,
 }: Readonly<StepProps>) {
   const handleCloseModal = () => {
-    handleEnableShieldedBalance("ready");
+    handleEnableShieldedBalance({ startSyncNow: false });
     closeModal();
   };
 
   const handleStartSync = () => {
-    handleEnableShieldedBalance("running");
+    handleEnableShieldedBalance({ startSyncNow: true });
     closeModal();
   };
 

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/types.ts
@@ -3,7 +3,6 @@ import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { Step } from "~/renderer/components/Stepper";
 import { AccountLike } from "@ledgerhq/types-live";
 import { OpenModal } from "~/renderer/actions/modals";
-import { ZcashSyncState } from "@ledgerhq/coin-zcash/network/types";
 
 export type StepId = "birthday" | "ufvk" | "device" | "confirmation";
 
@@ -27,7 +26,7 @@ export type StepProps = {
   syncFromZero: boolean;
   handleBirthdayChange: (value: string) => void;
   handleSyncFromZero: () => void;
-  handleEnableShieldedBalance: (nextSyncState: ZcashSyncState) => void;
+  handleEnableShieldedBalance: (options: { startSyncNow: boolean }) => void;
 };
 
 export type StepperProps = Step<StepId, StepProps>;


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

When activating Zcash private balance, and export the Unified Full Viewing Key, there's the option to start syncing the private balance at the end of the process. That option wasn't working. This PR fixes that.

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-36798
