### PR TITLE
chore(pay-card): add pay-card-wallets tooling config (LIVE-34772)

### DIFF
--- a/features/flow/pay-card-wallets/.oxfmtrc.json
+++ b/features/flow/pay-card-wallets/.oxfmtrc.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "printWidth": 100,
+  "trailingComma": "all",
+  "arrowParens": "avoid",
+  "sortPackageJson": false,
+  "ignorePatterns": [
+    "**/*.md",
+    "**/*.json"
+  ]
+}

--- a/features/flow/pay-card-wallets/.oxlintrc.json
+++ b/features/flow/pay-card-wallets/.oxlintrc.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "env": {
+    "browser": true,
+    "es6": true,
+    "node": true
+  },
+  "plugins": [
+    "eslint",
+    "import",
+    "oxc",
+    "unicorn",
+    "typescript",
+    "react",
+    "jest",
+    "jsx-a11y"
+  ],
+  "ignorePatterns": ["*.js", "*.cjs", "*.mjs", "node_modules"],
+  "categories": {
+    "correctness": "error",
+    "suspicious": "warn",
+    "pedantic": "off"
+  },
+  "rules": {
+    "eslint/no-unused-vars": "warn",
+    "eslint/no-empty-pattern": "warn",
+    "eslint/no-constant-binary-expression": "warn",
+    "eslint/no-shadow": "off",
+    "react/globals": "warn",
+    "react/immutability": "warn",
+    "react/preserve-manual-memoization": "warn",
+    "react/purity": "warn",
+    "react/refs": "warn",
+    "react/set-state-in-effect": "warn",
+    "react/set-state-in-render": "warn",
+    "react/static-components": "warn",
+    "react/use-memo": "warn",
+    "import/namespace": "warn",
+    "eslint/no-unused-expressions": "warn",
+    "eslint/no-unsafe-optional-chaining": "off",
+    "eslint/no-useless-rename": "warn",
+    "eslint/no-console": ["error", { "allow": ["warn", "error"] }],
+    "eslint/no-restricted-imports": [
+      "error",
+      {
+        "paths": ["lodash"],
+        "patterns": [
+          {
+            "group": [
+              "@ledgerhq/live-common/lib/**",
+              "@ledgerhq/live-common/lib-es/**"
+            ],
+            "message": "Please remove the /lib import from live-common import."
+          }
+        ]
+      }
+    ],
+    "import/no-duplicates": "error",
+    "import/no-named-as-default": "off",
+    "typescript/no-explicit-any": "error",
+    "typescript/no-non-null-assertion": "off",
+    "typescript/no-deprecated": "error",
+    "react/no-did-mount-set-state": "warn",
+    "react/jsx-key": "warn",
+    "react/display-name": "off",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": [
+      "error",
+      {
+        "additionalHooks": "(useInViewContext|useAnimatedStyle|useDerivedValue|useAnimatedProps)"
+      }
+    ],
+    "unicorn/no-useless-fallback-in-spread": "off",
+    "unicorn/no-useless-spread": "off",
+    "unicorn/no-new-array": "off",
+    "unicorn/no-array-sort": "off",
+    "jest/no-conditional-expect": "warn",
+    "jest/expect-expect": "warn",
+    "jest/require-to-throw-message": "warn",
+    "jest/valid-title": "warn",
+    "jest/no-disabled-tests": "warn",
+    "oxc/const-comparisons": "warn",
+    "jsx-a11y/no-autofocus": "off",
+    "jsx-a11y/anchor-is-valid": "off"
+  },
+  "overrides": [
+    {
+      "files": ["**/*.test.{ts,tsx}", "**/__tests__/**"],
+      "env": { "jest": true },
+      "plugins": ["jest"],
+      "rules": {
+        "typescript/no-explicit-any": "warn"
+      }
+    }
+  ]
+}

--- a/features/flow/pay-card-wallets/jest.config.js
+++ b/features/flow/pay-card-wallets/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require("@support/jest-features-flow").createFlowJestConfig();

--- a/features/flow/pay-card-wallets/tsconfig.json
+++ b/features/flow/pay-card-wallets/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "types": ["jest", "node", "@testing-library/jest-dom"]
+  },
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.web.json" },
+    { "path": "./tsconfig.native.json" }
+  ]
+}

--- a/features/flow/pay-card-wallets/tsconfig.native.json
+++ b/features/flow/pay-card-wallets/tsconfig.native.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleSuffixes": [".native", ""]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "src/**/*.web.*"]
+}

--- a/features/flow/pay-card-wallets/tsconfig.test.json
+++ b/features/flow/pay-card-wallets/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.web.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "src/**/*.native.*"]
+}

--- a/features/flow/pay-card-wallets/tsconfig.web.json
+++ b/features/flow/pay-card-wallets/tsconfig.web.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleSuffixes": [".web", ""]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "src/**/*.native.*"]
+}


### PR DESCRIPTION
<!-- stac-man:stack-start -->
**Stack** _(managed by [stac-man](https://github.com/bluegardenproject/stac-man))_

- **#21459 chore/LIVE-34772-pay-card-wallets-config ← this PR**
- #21000 feat/LIVE-34772-card-linked-wallet-balances
- #21444 feat/pay-card-devtools-card-interaction
- #21163 feat/LIVE-34784-card-freeze-unfreeze
- #21399 feat/LIVE-35428-native-card-visual
- #21425 feat/LIVE-34772-card-balance-from-linked-wallets
- #21445 fix/pay-card-schema-failure-detail
- #21448 feat/pay-card-devtools-balance
<!-- stac-man:stack-end -->

CODEOWNERS is last-match-wins, and the `**/tsconfig*`, `**/jest.config*`,
`**/.oxlintrc.*` and `**/.oxfmtrc.*` rules sit far below the per-package ones.
Every new package therefore needs the tooling owners to approve it, whoever
owns the code. Splitting the config files out leaves the package's own PR to
its team.

Nothing reads these yet: without a package.json the directory is not a
workspace member, so no target resolves against it.