### PR TITLE
[LWDM] fix(live-dmk): accept prerelease app builds that meet the version floor

### DIFF
--- a/.changeset/lucky-lions-wander.md
+++ b/.changeset/lucky-lions-wander.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Fix prerelease coin-app builds being rejected as unsupported when they satisfy the required version

--- a/libs/ledger-live-common/src/device/buildApplicationDependency.test.ts
+++ b/libs/ledger-live-common/src/device/buildApplicationDependency.test.ts
@@ -1,0 +1,80 @@
+import { DeviceModelId } from "@ledgerhq/device-management-kit";
+import semver from "semver";
+import { buildApplicationDependency, type GetMinVersion } from "./buildApplicationDependency";
+
+function minVersionFor(appName: string, getMinVersion: GetMinVersion): string | undefined {
+  const { constraints } = buildApplicationDependency(appName, getMinVersion);
+  return constraints?.[0]?.minVersion;
+}
+
+const always =
+  (minVersion: string | undefined): GetMinVersion =>
+  () =>
+    minVersion;
+
+const onlyFor =
+  (model: DeviceModelId, minVersion: string): GetMinVersion =>
+  (_appName, candidate) =>
+    candidate === model ? minVersion : undefined;
+
+describe("buildApplicationDependency", () => {
+  it("names the application it was asked for", () => {
+    expect(buildApplicationDependency("Ethereum", always("1.23.0")).name).toBe("Ethereum");
+  });
+
+  it("emits one constraint per device model that has a floor", () => {
+    const { constraints } = buildApplicationDependency(
+      "Ethereum",
+      onlyFor(DeviceModelId.NANO_X, "1.23.0"),
+    );
+
+    expect(constraints).toEqual([
+      { minVersion: "1.23.0-0", applicableModels: [DeviceModelId.NANO_X] },
+    ]);
+  });
+
+  it("emits no constraint when no model has a floor", () => {
+    expect(buildApplicationDependency("Ethereum", always(undefined)).constraints).toEqual([]);
+  });
+
+  it("skips a floor that is not a usable version constraint", () => {
+    expect(buildApplicationDependency("Ethereum", always("not-a-version")).constraints).toEqual([]);
+  });
+
+  describe("prerelease tolerance", () => {
+    it("widens a release floor so it ranks below any prerelease of the same version", () => {
+      expect(minVersionFor("Ethereum", always("1.23.0"))).toBe("1.23.0-0");
+    });
+
+    it("leaves a floor that already names a prerelease untouched", () => {
+      expect(minVersionFor("Ethereum", always("1.23.0-rc2"))).toBe("1.23.0-rc2");
+    });
+
+    it("leaves the latest constraint untouched, since the kit resolves it by catalog", () => {
+      expect(minVersionFor("Ethereum", always("latest"))).toBe("latest");
+    });
+
+    it("drops build metadata rather than appending after it", () => {
+      expect(minVersionFor("Ethereum", always("1.23.0+build7"))).toBe("1.23.0-0");
+    });
+
+    it.each([
+      ["a prerelease build of the required version", "1.23.0-dev", true],
+      ["the plain release of the required version", "1.23.0", true],
+      ["a later release", "1.24.0", true],
+      ["a prerelease build of an older version", "1.22.9-dev", false],
+      ["an older release", "1.22.0", false],
+    ])("accepts %s: %s -> %s", (_label, deviceVersion, expected) => {
+      const floor = minVersionFor("Ethereum", always("1.23.0"))!;
+
+      expect(semver.gte(deviceVersion, floor)).toBe(expected);
+    });
+
+    it("keeps a prerelease floor discriminating between its own prereleases", () => {
+      const floor = minVersionFor("Ethereum", always("1.23.0-rc2"))!;
+
+      expect(semver.gte("1.23.0-rc1", floor)).toBe(false);
+      expect(semver.gte("1.23.0-rc2", floor)).toBe(true);
+    });
+  });
+});

--- a/libs/ledger-live-common/src/device/buildApplicationDependency.ts
+++ b/libs/ledger-live-common/src/device/buildApplicationDependency.ts
@@ -1,0 +1,73 @@
+import {
+  type ApplicationConstraint,
+  type ApplicationDependency,
+  type ApplicationVersionConstraint,
+  DeviceModelId,
+} from "@ledgerhq/device-management-kit";
+import semver from "semver";
+
+export type GetMinVersion = (appName: string, model?: DeviceModelId) => string | undefined;
+
+function isApplicationVersionConstraint(version: string): version is ApplicationVersionConstraint {
+  return (
+    version === "latest" || /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(version)
+  );
+}
+
+/**
+ * Widens a release floor so prerelease builds of that same version satisfy it:
+ * `1.23.0` becomes `1.23.0-0`.
+ *
+ * Constraints are checked against the version the device reports with a raw
+ * `semver.gte`, which ranks `1.23.0-dev` below `1.23.0`, so a `-dev` or `-rc`
+ * build of the required version would be rejected outright. Lowering the floor
+ * to just under the release keeps the version ordering itself intact, so
+ * `1.22.9-dev` is still rejected — unlike coercing the device version, which
+ * would also let `1.23.0-rc1` satisfy a `1.23.0-rc2` floor.
+ *
+ * A floor that already names a prerelease is its own answer and is left alone,
+ * as is `latest`, which the kit resolves against the catalog rather than by
+ * comparison.
+ */
+function toPrereleaseTolerantMinVersion(
+  minVersion: ApplicationVersionConstraint,
+): ApplicationVersionConstraint {
+  if (minVersion === "latest") return minVersion;
+
+  const parsed = semver.parse(minVersion);
+  if (parsed === null || parsed.prerelease.length > 0) return minVersion;
+
+  return `${parsed.major}.${parsed.minor}.${parsed.patch}-0`;
+}
+
+/**
+ * Builds the per-device-model version constraints for one application, from
+ * the app-global version floors the host supplies.
+ */
+export function buildApplicationDependency(
+  appName: string,
+  getMinVersion: GetMinVersion,
+): ApplicationDependency {
+  const constraints = Object.values(DeviceModelId).reduce<ApplicationConstraint[]>(
+    (result, model) => {
+      const minVersion = getMinVersion(appName, model);
+
+      if (!minVersion || !isApplicationVersionConstraint(minVersion)) {
+        return result;
+      }
+
+      result.push({
+        minVersion: toPrereleaseTolerantMinVersion(minVersion),
+        applicableModels: [model],
+      });
+
+      return result;
+    },
+    [],
+  );
+
+  return {
+    name: appName,
+    constraints,
+  };
+}

--- a/libs/ledger-live-common/src/device/use-cases/ensureAppReady/helpers/buildConnectAppDAInput.test.ts
+++ b/libs/ledger-live-common/src/device/use-cases/ensureAppReady/helpers/buildConnectAppDAInput.test.ts
@@ -82,7 +82,7 @@ describe("buildConnectAppDeviceActionInput", () => {
         name: "Ethereum",
         constraints: [
           {
-            minVersion: "1.2.3",
+            minVersion: "1.2.3-0",
             applicableModels: [DeviceModelId.NANO_X],
           },
         ],
@@ -92,7 +92,7 @@ describe("buildConnectAppDeviceActionInput", () => {
           name: "1inch",
           constraints: [
             {
-              minVersion: "4.5.6",
+              minVersion: "4.5.6-0",
               applicableModels: [DeviceModelId.NANO_S],
             },
           ],

--- a/libs/ledger-live-common/src/device/use-cases/ensureAppReady/helpers/buildConnectAppDAInput.ts
+++ b/libs/ledger-live-common/src/device/use-cases/ensureAppReady/helpers/buildConnectAppDAInput.ts
@@ -1,52 +1,19 @@
-import type {
-  ApplicationConstraint,
-  ApplicationDependency,
-  ApplicationVersionConstraint,
-  DeviceManagementKit,
-} from "@ledgerhq/device-management-kit";
-import { DeviceModelId } from "@ledgerhq/device-management-kit";
+import type { DeviceManagementKit } from "@ledgerhq/device-management-kit";
 import { DmkCompatTransport } from "@ledgerhq/live-dmk-shared";
 import type { ConnectAppDAInput } from "@ledgerhq/live-dmk-shared";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import {
+  buildApplicationDependency,
+  type GetMinVersion,
+} from "../../../buildApplicationDependency";
 import getAddress from "../../../../hw/getAddress";
 import type { EnsureAppReadyInput } from "../types";
 
-export type GetMinVersion = (appName: string, model?: DeviceModelId) => string | undefined;
+export type { GetMinVersion };
 export type GetDeprecationConfig = (
   appName: string,
   dependencies?: string[],
 ) => ConnectAppDAInput["deprecationConfig"];
-
-function isApplicationVersionConstraint(version: string): version is ApplicationVersionConstraint {
-  return (
-    version === "latest" || /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(version)
-  );
-}
-
-function appNameToDependency(appName: string, getMinVersion: GetMinVersion): ApplicationDependency {
-  const constraints = Object.values(DeviceModelId).reduce<ApplicationConstraint[]>(
-    (result, model) => {
-      const minVersion = getMinVersion(appName, model);
-
-      if (!minVersion || !isApplicationVersionConstraint(minVersion)) {
-        return result;
-      }
-
-      result.push({
-        minVersion,
-        applicableModels: [model],
-      });
-
-      return result;
-    },
-    [],
-  );
-
-  return {
-    name: appName,
-    constraints,
-  };
-}
 
 function createRequiredDerivation(params: {
   dmk: DeviceManagementKit;
@@ -97,9 +64,9 @@ export function buildConnectAppDeviceActionInput(params: {
   } = params;
 
   return {
-    application: appNameToDependency(ensureAppReadyInput.appName, getMinVersion),
+    application: buildApplicationDependency(ensureAppReadyInput.appName, getMinVersion),
     dependencies: ensureAppReadyInput.dependencies.map(appName =>
-      appNameToDependency(appName, getMinVersion),
+      buildApplicationDependency(appName, getMinVersion),
     ),
     requireLatestFirmware: ensureAppReadyInput.requireLatestFirmware,
     allowMissingApplication: false,

--- a/libs/ledger-live-common/src/device/use-cases/ensureAppReady/helpers/runEnsureAppReadyAttempt.test.ts
+++ b/libs/ledger-live-common/src/device/use-cases/ensureAppReady/helpers/runEnsureAppReadyAttempt.test.ts
@@ -190,7 +190,7 @@ describe("runEnsureAppReadyAttempt", () => {
       name: "Ethereum",
       constraints: [
         {
-          minVersion: "1.2.3",
+          minVersion: "1.2.3-0",
           applicableModels: [DeviceModelId.NANO_X],
         },
       ],
@@ -200,7 +200,7 @@ describe("runEnsureAppReadyAttempt", () => {
         name: "1inch",
         constraints: [
           {
-            minVersion: "1.2.3",
+            minVersion: "1.2.3-0",
             applicableModels: [DeviceModelId.NANO_X],
           },
         ],

--- a/libs/ledger-live-common/src/hw/connectApp.ts
+++ b/libs/ledger-live-common/src/hw/connectApp.ts
@@ -22,6 +22,7 @@ import getAddress from "./getAddress";
 import openApp from "./openApp";
 import quitApp from "./quitApp";
 import { mustUpgrade, getMinVersion, getDeprecationConfig } from "../apps";
+import { buildApplicationDependency } from "../device/buildApplicationDependency";
 import isUpdateAvailable from "./isUpdateAvailable";
 import { LockedDeviceEvent } from "./actions/types";
 import { getLatestFirmwareForDeviceUseCase } from "../device/use-cases/getLatestFirmwareForDeviceUseCase";
@@ -530,25 +531,8 @@ const cmd = (transport: Transport, { request }: Input): Observable<ConnectAppEve
   });
 };
 
-const appNameToDependency = (appName: string): ApplicationDependency => {
-  const constraints = Object.values(DeviceModelId).reduce<ApplicationConstraint[]>(
-    (result, model) => {
-      const minVersion = getMinVersion(appName, model);
-      if (minVersion) {
-        result.push({
-          minVersion: minVersion as ApplicationVersionConstraint,
-          applicableModels: [model],
-        });
-      }
-      return result;
-    },
-    [],
-  );
-  return {
-    name: appName,
-    constraints,
-  };
-};
+const appNameToDependency = (appName: string): ApplicationDependency =>
+  buildApplicationDependency(appName, getMinVersion);
 
 export default function connectAppFactory(
   {

--- a/libs/live-dmk-shared/src/device-action/ConnectApp/ConnectAppDeviceAction.test.ts
+++ b/libs/live-dmk-shared/src/device-action/ConnectApp/ConnectAppDeviceAction.test.ts
@@ -964,6 +964,50 @@ describe("OpenAppWithDependenciesDeviceAction", () => {
       expect(result).toBe(true);
     });
 
+    // Callers widen a release floor to x.y.z-0 when building the constraint, so
+    // a prerelease build of the required version clears it here.
+    it("should return true when the current app is a prerelease build meeting a widened floor", () => {
+      const application = {
+        name: "TestApp",
+        constraints: [
+          {
+            minVersion: "2.3.4-0",
+            applicableModels: [DeviceModelId.NANO_X],
+          },
+        ],
+      } as ApplicationDependency;
+      const deviceStatus = {
+        currentApp: "TestApp",
+        currentAppVersion: "2.3.4-dev",
+      };
+      const deviceModel = DeviceModelId.NANO_X;
+
+      const result = ConnectAppDeviceAction.isAppOpened(application, deviceStatus, deviceModel);
+
+      expect(result).toBe(true);
+    });
+
+    it("should return false when the current app is a prerelease build of an older version", () => {
+      const application = {
+        name: "TestApp",
+        constraints: [
+          {
+            minVersion: "2.3.4-0",
+            applicableModels: [DeviceModelId.NANO_X],
+          },
+        ],
+      } as ApplicationDependency;
+      const deviceStatus = {
+        currentApp: "TestApp",
+        currentAppVersion: "2.3.3-dev",
+      };
+      const deviceModel = DeviceModelId.NANO_X;
+
+      const result = ConnectAppDeviceAction.isAppOpened(application, deviceStatus, deviceModel);
+
+      expect(result).toBe(false);
+    });
+
     it("should return false when the app does not match", () => {
       const application = {
         name: "TestApp",
@@ -1015,7 +1059,11 @@ describe("OpenAppWithDependenciesDeviceAction", () => {
       deviceModelId: "nanoS" as LLDeviceModelId,
       warningScreen: { date: FUTURE, deprecatedFlow: [] },
       errorScreen: { date: FUTURE, deprecatedFlow: [] },
-      warningClearSigningScreen: { date: FUTURE, deprecatedFlow: [], exception: [] },
+      warningClearSigningScreen: {
+        date: FUTURE,
+        deprecatedFlow: [],
+        exception: [],
+      },
       ...over,
     });
 
@@ -1024,7 +1072,11 @@ describe("OpenAppWithDependenciesDeviceAction", () => {
         deviceModelId: "nanoS" as LLDeviceModelId,
         warningScreen: { date: PAST, deprecatedFlow: ["receive"] },
         errorScreen: { date: FUTURE, deprecatedFlow: [] },
-        warningClearSigningScreen: { date: FUTURE, deprecatedFlow: [], exception: [] },
+        warningClearSigningScreen: {
+          date: FUTURE,
+          deprecatedFlow: [],
+          exception: [],
+        },
       },
     ];
 
@@ -1033,7 +1085,11 @@ describe("OpenAppWithDependenciesDeviceAction", () => {
         deviceModelId: "nanoS" as LLDeviceModelId,
         warningScreen: { date: FUTURE, deprecatedFlow: [] },
         errorScreen: { date: PAST, deprecatedFlow: ["receive"] },
-        warningClearSigningScreen: { date: FUTURE, deprecatedFlow: [], exception: [] },
+        warningClearSigningScreen: {
+          date: FUTURE,
+          deprecatedFlow: [],
+          exception: [],
+        },
       },
     ];
 
@@ -1051,11 +1107,16 @@ describe("OpenAppWithDependenciesDeviceAction", () => {
 
     it("sets warning visible when infoScreen date is past", () => {
       const cfg: DeviceDeprecationConfigs = [
-        baseEntry({ warningScreen: { date: PAST, deprecatedFlow: ["receive"] } }),
+        baseEntry({
+          warningScreen: { date: PAST, deprecatedFlow: ["receive"] },
+        }),
       ];
       const res = extractDeviceDeprecationRules(cfg, MODEL);
       expect(res.warningScreenVisible).toBe(true);
-      expect(res.warningScreenRules).toEqual({ exception: [], deprecatedFlow: ["receive"] });
+      expect(res.warningScreenRules).toEqual({
+        exception: [],
+        deprecatedFlow: ["receive"],
+      });
       expect(res.errorScreenVisible).toBe(false);
       expect(res.clearSigningScreenVisible).toBe(false);
     });
@@ -1076,11 +1137,20 @@ describe("OpenAppWithDependenciesDeviceAction", () => {
 
     it("sets error visible and date = errorDate when errorScreen is past", () => {
       const cfg: DeviceDeprecationConfigs = [
-        baseEntry({ errorScreen: { date: PAST, deprecatedFlow: ["receive"], exception: ["X"] } }),
+        baseEntry({
+          errorScreen: {
+            date: PAST,
+            deprecatedFlow: ["receive"],
+            exception: ["X"],
+          },
+        }),
       ];
       const res = extractDeviceDeprecationRules(cfg, MODEL);
       expect(res.errorScreenVisible).toBe(true);
-      expect(res.errorScreenRules).toEqual({ exception: ["X"], deprecatedFlow: ["receive"] });
+      expect(res.errorScreenRules).toEqual({
+        exception: ["X"],
+        deprecatedFlow: ["receive"],
+      });
       expect(res.date.toISOString().startsWith("2000-01-01")).toBe(true);
     });
 
@@ -1115,7 +1185,11 @@ describe("OpenAppWithDependenciesDeviceAction", () => {
         baseEntry({
           errorScreen: { date: FUTURE, deprecatedFlow: [] },
           warningScreen: { date: PAST, deprecatedFlow: [] },
-          warningClearSigningScreen: { date: FUTURE, deprecatedFlow: [], exception: [] },
+          warningClearSigningScreen: {
+            date: FUTURE,
+            deprecatedFlow: [],
+            exception: [],
+          },
         }),
       ];
       const res = extractDeviceDeprecationRules(cfg, MODEL);


### PR DESCRIPTION
### 📝 Description

A coin app with a prerelease version (`1.23.0-dev`) was rejected as `UnsupportedApplicationDAError` — a blocking `unsupported-feature` state — even when it met the required floor, because semver ranks a prerelease below its release:

```
gte("1.23.0-dev", "1.23.0")   // false
```

The legacy `connectApp` path never hit this: `mustUpgrade` coerced the device version before comparing. The DMK-based path dropped that.

**Fix:** widen release floors to `x.y.z-0` where constraints are built, so a prerelease of the required version passes and older ones still fail.

```
gte("1.23.0-dev", "1.23.0-0")   // true
gte("1.22.9-dev", "1.23.0-0")   // false
```

Lowering the floor rather than coercing the device version keeps the ordering intact, so a prerelease floor still discriminates between its own prereleases — `1.23.0-rc1` does not satisfy a `1.23.0-rc2` floor. `latest` is passed through untouched, since the kit resolves it against the catalog.

Also extracts the two near-identical `appNameToDependency` implementations into a single `buildApplicationDependency`, so the widening lives in one place and the `connectApp` path gains the constraint validation it was missing.

### 🔗 Context

- **JIRA / GitHub issue**: none — found testing Contacts against an Ethereum `1.23.0-dev` build on Flex
- **ADR** (if any): n/a
