### PR TITLE
[LWDM] fix(contacts): decode 0x-prefixed proof material for the address book

### DIFF
--- a/.changeset/quiet-otters-gather.md
+++ b/.changeset/quiet-otters-gather.md
@@ -1,0 +1,5 @@
+---
+"@features/platform-contacts": minor
+---
+
+Fix registered contacts never reaching the Ethereum signer's address book

--- a/features/platform/contacts/src/device/addressBook/toEvmAddressBook.test.ts
+++ b/features/platform/contacts/src/device/addressBook/toEvmAddressBook.test.ts
@@ -5,11 +5,14 @@ import {
   type ContactAddressInput,
   type ContactInput,
 } from "@domain/entity-contact";
+import { mapBytesToGroupHandle, mapBytesToProof } from "../contactsKitMappers";
 import { toEvmAddressBook } from "./toEvmAddressBook";
 
-const GROUP_HANDLE_HEX = "ab".repeat(64);
-const HMAC_PROOF_HEX = "cd".repeat(32);
-const HMAC_REST_HEX = "ef".repeat(32);
+// Proof material reaches this mapper the way it was persisted: 0x-prefixed, as
+// the Contacts kit mappers emit it through the kit's `bufferToHexaString`.
+const GROUP_HANDLE_HEX = `0x${"ab".repeat(64)}`;
+const HMAC_PROOF_HEX = `0x${"cd".repeat(32)}`;
+const HMAC_REST_HEX = `0x${"ef".repeat(32)}`;
 
 const ADDRESS = "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034";
 
@@ -118,6 +121,34 @@ describe("toEvmAddressBook", () => {
     ]);
 
     expect(book?.contactGroups[0]?.contactName).toBe("Me");
+  });
+
+  it("accepts proof material the kit mappers produced", () => {
+    const groupHandle = new Uint8Array(64).fill(0xab);
+    const hmacProof = new Uint8Array(32).fill(0xcd);
+    const hmacRest = new Uint8Array(32).fill(0xef);
+
+    const book = toEvmAddressBook([
+      evmContact({
+        deviceCredentials: {
+          groupHandle: mapBytesToGroupHandle(groupHandle),
+          hmacProof: mapBytesToProof(hmacProof),
+        },
+        addresses: [
+          evmAddress({
+            device: {
+              blockchainFamily: "evm",
+              chainId: 1,
+              hmacRest: mapBytesToProof(hmacRest),
+            },
+          }),
+        ],
+      }),
+    ]);
+
+    expect(book?.contactGroups[0]?.groupHandle).toEqual(groupHandle);
+    expect(book?.contactGroups[0]?.hmacProof).toEqual(hmacProof);
+    expect(book?.contactGroups[0]?.externalAddresses[0]?.hmacRest).toEqual(hmacRest);
   });
 
   it("accepts uppercase hex proof material", () => {

--- a/features/platform/contacts/src/device/addressBook/toEvmAddressBook.ts
+++ b/features/platform/contacts/src/device/addressBook/toEvmAddressBook.ts
@@ -4,6 +4,7 @@ import type {
   EvmContactGroup,
   EvmExternalAddress,
 } from "@ledgerhq/device-signer-kit-ethereum";
+import { tryDecodeHex } from "../contactsKitMappers";
 
 /**
  * Contacts persist `currency.family` in their device context. Only this family
@@ -12,7 +13,6 @@ import type {
  */
 const EVM_BLOCKCHAIN_FAMILY = "evm";
 
-const HEX_PATTERN = /^[0-9a-f]+$/;
 const EVM_ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/;
 
 /**
@@ -34,8 +34,8 @@ function toEvmContactGroup(contact: Contact): EvmContactGroup[] {
   const credentials = contact.deviceCredentials;
   if (credentials === undefined) return [];
 
-  const groupHandle = hexToBytes(credentials.groupHandle);
-  const hmacProof = hexToBytes(credentials.hmacProof);
+  const groupHandle = tryDecodeHex(credentials.groupHandle);
+  const hmacProof = tryDecodeHex(credentials.hmacProof);
   if (groupHandle === null || hmacProof === null) return [];
 
   const externalAddresses = contact.addresses.flatMap(toEvmExternalAddress);
@@ -48,7 +48,7 @@ function toEvmExternalAddress(address: ContactAddress): EvmExternalAddress[] {
   const { blockchainFamily, chainId, hmacRest } = address.device;
   if (blockchainFamily !== EVM_BLOCKCHAIN_FAMILY) return [];
 
-  const proof = hexToBytes(hmacRest);
+  const proof = tryDecodeHex(hmacRest);
   const parsedChainId = toChainId(chainId);
   if (proof === null || parsedChainId === null || !isEvmAddress(address.address)) return [];
 
@@ -74,18 +74,4 @@ function toChainId(value: string | number): bigint | null {
   } catch {
     return null;
   }
-}
-
-function hexToBytes(value: string): Uint8Array | null {
-  const normalized = value.toLowerCase();
-  if (normalized.length === 0 || normalized.length % 2 !== 0 || !HEX_PATTERN.test(normalized)) {
-    return null;
-  }
-
-  const bytes = new Uint8Array(normalized.length / 2);
-  for (let index = 0; index < bytes.length; index++) {
-    bytes[index] = Number.parseInt(normalized.slice(index * 2, index * 2 + 2), 16);
-  }
-
-  return bytes;
 }

--- a/features/platform/contacts/src/device/contactsKitMappers.test.ts
+++ b/features/platform/contacts/src/device/contactsKitMappers.test.ts
@@ -6,7 +6,42 @@ import {
   mapGroupHandleToBytes,
   mapIdentifierToBytes,
   mapProofToBytes,
+  tryDecodeHex,
 } from "./contactsKitMappers";
+
+describe("tryDecodeHex", () => {
+  it.each([
+    ["a 0x-prefixed string, as mapBytesTo* emits it", "0xabc0"],
+    ["an unprefixed string", "abc0"],
+    ["an uppercase string", "0xABC0"],
+    ["an uppercase prefix", "0XABC0"],
+  ])("GIVEN %s WHEN decoding THEN it returns the bytes", (_label, value) => {
+    expect(tryDecodeHex(value)).toEqual(new Uint8Array([0xab, 0xc0]));
+  });
+
+  it.each([
+    ["a non-hex string", "not-hex"],
+    ["an even-length non-hex string", "zzzz"],
+    ["an odd-length string", "abc"],
+    ["an odd-length string behind a prefix", "0xabc"],
+    ["an empty string", ""],
+    ["a bare prefix", "0x"],
+  ])("GIVEN %s WHEN decoding THEN it returns null", (_label, value) => {
+    expect(tryDecodeHex(value)).toBeNull();
+  });
+
+  it("GIVEN an odd-length string WHEN decoding THEN it rejects rather than left-padding", () => {
+    // The kit's own hexaStringToBuffer would widen "0xabc" to 0x0abc, sending a
+    // different handle to the device than the one that was stored.
+    expect(tryDecodeHex("0xabc")).toBeNull();
+  });
+
+  it("GIVEN bytes WHEN round-tripping through mapBytesToProof THEN it returns the same bytes", () => {
+    const bytes = new Uint8Array(32).fill(0xef);
+
+    expect(tryDecodeHex(mapBytesToProof(bytes))).toEqual(bytes);
+  });
+});
 
 describe("mapIdentifierToBytes", () => {
   it("GIVEN a valid hex identifier WHEN mapping THEN it returns the decoded bytes", () => {
@@ -64,6 +99,11 @@ describe("mapGroupHandleToBytes / mapBytesToGroupHandle", () => {
     // WHEN / THEN
     expect(() => mapGroupHandleToBytes("not-hex")).toThrow(ContactDeviceIntentInputError);
   });
+
+  it("GIVEN an odd-length group handle WHEN mapping THEN it throws instead of left-padding", () => {
+    // WHEN / THEN
+    expect(() => mapGroupHandleToBytes("0xabc")).toThrow(ContactDeviceIntentInputError);
+  });
 });
 
 describe("mapProofToBytes / mapBytesToProof", () => {
@@ -83,5 +123,10 @@ describe("mapProofToBytes / mapBytesToProof", () => {
   it("GIVEN a non-hex proof WHEN mapping THEN it throws ContactDeviceIntentInputError", () => {
     // WHEN / THEN
     expect(() => mapProofToBytes("not-hex")).toThrow(ContactDeviceIntentInputError);
+  });
+
+  it("GIVEN an odd-length proof WHEN mapping THEN it throws instead of left-padding", () => {
+    // WHEN / THEN
+    expect(() => mapProofToBytes("0xabc")).toThrow(ContactDeviceIntentInputError);
   });
 });

--- a/features/platform/contacts/src/device/contactsKitMappers.ts
+++ b/features/platform/contacts/src/device/contactsKitMappers.ts
@@ -2,12 +2,41 @@ import { bufferToHexaString, hexaStringToBuffer } from "@ledgerhq/device-managem
 import { ContactDeviceIntentInputError } from "./errors";
 
 /**
- * Shared conversions between Ledger Wallet's string/number Contacts intent
- * contracts and `@ledgerhq/device-contacts-kit`'s byte/bigint wire types.
- * Every Contacts intent job needs some subset of these; keep intent-specific
- * shapes (e.g. an intent's own `existingContactGroup` composite) local to
- * that intent's job instead.
+ * Shared conversions between Ledger Wallet's string/number Contacts contracts
+ * and `@ledgerhq/device-contacts-kit`'s byte/bigint wire types. Contacts intent
+ * jobs and the EVM address-book snapshot both cross this boundary; keep
+ * caller-specific shapes (e.g. an intent's own `existingContactGroup`
+ * composite) local to that caller instead.
+ *
+ * Proof material and identifiers are persisted as whatever `mapBytesTo*`
+ * produced, which is `0x`-prefixed because the kit's `bufferToHexaString`
+ * always prefixes. Decoding therefore has to accept that prefix, and every
+ * decoder here shares `tryDecodeHex` so the two directions cannot drift apart.
  */
+
+/**
+ * Decodes hex to bytes, or `null` when the string is not a faithful encoding.
+ *
+ * Stricter than the kit's own `hexaStringToBuffer`, which left-pads an
+ * odd-length string and maps an empty one to zero bytes: either would turn a
+ * truncated handle into a valid-looking but different value on its way to the
+ * device, where the caller wants to reject it instead.
+ */
+export function tryDecodeHex(value: string): Uint8Array | null {
+  const digits = value.replace(/^0x/i, "");
+  if (digits.length === 0 || digits.length % 2 !== 0) return null;
+
+  return hexaStringToBuffer(digits);
+}
+
+function decodeHexOrThrow(value: string, subject: string): Uint8Array {
+  const bytes = tryDecodeHex(value);
+  if (bytes === null) {
+    throw new ContactDeviceIntentInputError(`${subject} ${JSON.stringify(value)} is not valid hex`);
+  }
+
+  return bytes;
+}
 
 /**
  * Contact addresses are family-agnostic in the domain layer (Solana base58,
@@ -20,13 +49,7 @@ import { ContactDeviceIntentInputError } from "./errors";
  * action.
  */
 export function mapIdentifierToBytes(identifier: string): Uint8Array {
-  const bytes = hexaStringToBuffer(identifier);
-  if (bytes === null) {
-    throw new ContactDeviceIntentInputError(
-      `identifier ${JSON.stringify(identifier)} is not valid hex`,
-    );
-  }
-  return bytes;
+  return decodeHexOrThrow(identifier, "identifier");
 }
 
 export function mapChainIdToBigInt(chainId: string | number): bigint {
@@ -38,13 +61,7 @@ export function mapChainIdToBigInt(chainId: string | number): bigint {
 }
 
 export function mapGroupHandleToBytes(groupHandle: string): Uint8Array {
-  const bytes = hexaStringToBuffer(groupHandle);
-  if (bytes === null) {
-    throw new ContactDeviceIntentInputError(
-      `groupHandle ${JSON.stringify(groupHandle)} is not valid hex`,
-    );
-  }
-  return bytes;
+  return decodeHexOrThrow(groupHandle, "groupHandle");
 }
 
 export function mapBytesToGroupHandle(bytes: Uint8Array): string {
@@ -52,11 +69,7 @@ export function mapBytesToGroupHandle(bytes: Uint8Array): string {
 }
 
 export function mapProofToBytes(proof: string): Uint8Array {
-  const bytes = hexaStringToBuffer(proof);
-  if (bytes === null) {
-    throw new ContactDeviceIntentInputError(`proof ${JSON.stringify(proof)} is not valid hex`);
-  }
-  return bytes;
+  return decodeHexOrThrow(proof, "proof");
 }
 
 export function mapBytesToProof(bytes: Uint8Array): string {


### PR DESCRIPTION
### 📝 Description

The Ethereum signer clear-signed no contact at all: `getAddressBook()` always returned `undefined`, so `DmkSignerEth` skipped `withAddressBook`.

Proof material is written through the kit's `bufferToHexaString`, which always emits a `0x` prefix — but `toEvmAddressBook` hand-rolled a decoder that rejected it (`/^[0-9a-f]+$/`). Every contact was dropped. Tests missed it because their fixtures were unprefixed.

**Fix:** move the decode into `contactsKitMappers`, which already owns this boundary, as one `tryDecodeHex` shared by the intent mappers and the address book — one definition of valid hex, two failure policies (throw vs. drop).

It stays stricter than the kit's `hexaStringToBuffer`, which left-pads odd-length input (`"0xabc"` → `0x0abc`) and would send the device a different handle than the one stored. That also closes the same leniency in `mapGroupHandleToBytes` / `mapProofToBytes`.

Tests now cover the hex rules in one place, plus a round-trip from real writer output so the two ends can't drift again.

### 🔗 Context

- **JIRA / GitHub issue**: none — found testing Contacts on Flex
- **ADR** (if any): n/a
