### PR TITLE
fix(e2e): wait for review screen before signing btc-based send

### DIFF
--- a/libs/live-e2e-shared/src/families/bitcoin.ts
+++ b/libs/live-e2e-shared/src/families/bitcoin.ts
@@ -1,6 +1,12 @@
 import expect from "expect";
 import { Transaction } from "../models/Transaction";
-import { waitFor, containsSubstringInEvent, pressUntilTextFound, getSendEvents } from "../speculos";
+import {
+  waitFor,
+  containsSubstringInEvent,
+  pressUntilTextFound,
+  getSendEvents,
+  waitForSendReviewTransaction,
+} from "../speculos";
 import { getSpeculosModel, isTouchDevice } from "../speculosAppVersion";
 import { DeviceLabels } from "../enum/DeviceLabels";
 import invariant from "invariant";
@@ -26,6 +32,8 @@ export const sendBTCBasedCoin = withDeviceController(
       }
 
       const buttons = getButtonsController();
+
+      await waitForSendReviewTransaction(tx);
 
       if (isTouchDevice()) {
         const events = await pressUntilTextFound(DeviceLabels.HOLD_TO_SIGN);

--- a/libs/live-e2e-shared/src/speculos.ts
+++ b/libs/live-e2e-shared/src/speculos.ts
@@ -1012,14 +1012,20 @@ export async function signSendTransaction(tx: Transaction) {
   }
 }
 
+export async function waitForSendReviewTransaction(
+  tx: Transaction,
+  maxAttempts: number = SEND_REVIEW_TRANSACTION_MAX_ATTEMPTS,
+): Promise<string> {
+  const { sendVerifyLabel } = getDeviceLabels(tx.accountToDebit.currency.speculosApp);
+  return await waitFor(sendVerifyLabel, maxAttempts);
+}
+
 export async function getSendEvents(
   tx: Transaction,
   verifyMaxAttempts: number = SEND_REVIEW_TRANSACTION_MAX_ATTEMPTS,
 ): Promise<string[]> {
-  const { sendVerifyLabel, sendConfirmLabel } = getDeviceLabels(
-    tx.accountToDebit.currency.speculosApp,
-  );
-  await waitFor(sendVerifyLabel, verifyMaxAttempts);
+  const { sendConfirmLabel } = getDeviceLabels(tx.accountToDebit.currency.speculosApp);
+  await waitForSendReviewTransaction(tx, verifyMaxAttempts);
   return await pressUntilTextFound(sendConfirmLabel);
 }
 


### PR DESCRIPTION
### 📝 Description

The `[BCH] - Send (new send flow)` Playwright test failed at the signing step:

```
Error: ElementNotFoundException: Element with text "Amount" not found on speculos screen.
Screens observed during navigation (3 unique):
  [1] "Application is ready" → [2] "Version 2.4.12" → [3] "Quit"
```

**Previous behaviour**

`sendBTCBasedCoin` (used by **BCH**, **DOGE** and **ZEC**) started navigating the Speculos screens immediately, without first waiting for the device to receive the transaction payload:

```ts
const amountStep = await pressUntilTextFound(DeviceLabels.AMOUNT); // no prior wait
```

`pressUntilTextFound` only has an **18 × 200 ms ≈ 3.6 s** budget and *presses right on every attempt*. Because Ledger Live had not delivered the payload yet, the device was still sitting on the app dashboard — exactly what the observed screens show. The helper burned its entire budget cycling the app menu (`Application is ready` → `Version` → `Quit`) instead of waiting for the review screen, and could even land on `Quit`.

Every other family (`sendBTC`, `sendEVM`, `sendSolana`, `sendAptos`, …) goes through `getSendEvents`, which does `waitFor(sendVerifyLabel, …)` first with a **120 s** budget. `sendBTCBasedCoin` was the only outlier.

**Fix**

- Extracted a reusable `waitForSendReviewTransaction(tx, maxAttempts = SEND_REVIEW_TRANSACTION_MAX_ATTEMPTS)` helper in `speculos.ts`. It polls for the app's `sendVerifyLabel` (`"Review"` for the Bitcoin Cash app) for up to 120 s.
- `getSendEvents` now delegates to it, so there is a single source of truth for _"wait for the review screen"_.
- `sendBTCBasedCoin` awaits it before touching the device, on both the touch and button paths. Navigation only begins once the review screen is actually rendered.

```ts
const buttons = getButtonsController();

// The device sits on the app dashboard until Ledger Live delivers the payload.
// Navigating before the review screen shows up would only cycle the app menu.
await waitForSendReviewTransaction(tx);
```

**Regression prevention**

The signing helper itself is the automated check: the wait is now part of the shared `sendBTCBasedCoin` path, so the BCH, DOGE and ZEC send specs all exercise it on every E2E run. Any future family added to that switch inherits the same guarantee.

### 🔗 Context

- **JIRA / GitHub issue**: _to be added — flaky E2E found locally on `newSendFlow.tx.spec.ts`_
- **ADR** (if any): n/a

### 🧪 QA focus

- Desktop E2E `newSendFlow.tx.spec.ts` for **BCH**, **DOGE** and **ZEC** (the three currencies sharing `sendBTCBasedCoin`), on both button devices (Nano S/SP/X) and touch devices (Stax/Flex).
- No changeset: `@ledgerhq/live-e2e-shared` is `"private": true`.

