### PR TITLE
[LWDM] feat(contacts): recover from a wrong device (LIVE-36562)

### DIFF
--- a/.changeset/contacts-wrong-device-connect-another.md
+++ b/.changeset/contacts-wrong-device-connect-another.md
@@ -1,0 +1,7 @@
+---
+"@features/platform-contacts": patch
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Offer "Connect a different device" when a contact operation hits the wrong Ledger device, keeping the entered address details.

--- a/.changeset/device-intent-restart-on-another-device.md
+++ b/.changeset/device-intent-restart-on-another-device.md
@@ -1,0 +1,10 @@
+---
+"@features/platform-device-intent": patch
+"@ledgerhq/live-dmk-shared": patch
+"@ledgerhq/live-dmk-desktop": patch
+"@ledgerhq/live-dmk-mobile": patch
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Let a Device Intent Executor job restart on another device, and stop settling intent results on job teardown.

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/useDeviceConnectionComponentLWDViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/useDeviceConnectionComponentLWDViewModel.test.tsx
@@ -1,5 +1,5 @@
 import type {
-  DeviceConnectionParams,
+  DeviceConnectionComponentParams,
   DeviceConnectionResult,
 } from "@features/platform-device-intent";
 import {
@@ -61,8 +61,9 @@ const mockDmk = { id: "dmk" } as unknown as NonNullable<ReturnType<typeof useDev
 let connectDeviceObserver: ConnectDeviceObserver | undefined;
 let mockUnsubscribe: jest.Mock;
 
-const defaultDeviceConnectionParams: DeviceConnectionParams = {
+const defaultDeviceConnectionParams: DeviceConnectionComponentParams = {
   acceptedDeviceModelIds: [],
+  disableAutoConnect: false,
 };
 
 const layerABaseProperties = {
@@ -87,7 +88,7 @@ function renderViewModel({
   onConnected = jest.fn(),
 }: {
   knownDevices?: KnownDevice[];
-  deviceConnectionParams?: DeviceConnectionParams;
+  deviceConnectionParams?: DeviceConnectionComponentParams;
   onConnected?: (connectionResult: DeviceConnectionResult) => void;
 } = {}) {
   const store = createStore({
@@ -178,6 +179,7 @@ describe("useDeviceConnectionComponentLWDViewModel", () => {
     expect(mockedConnectDevice).toHaveBeenCalledWith({
       knownDevices,
       acceptedDeviceModelIds: [],
+      disableAutoConnect: false,
       dmk: mockDmk,
       onConnected: expect.any(Function),
     });
@@ -189,7 +191,7 @@ describe("useDeviceConnectionComponentLWDViewModel", () => {
 
     // WHEN
     renderViewModel({
-      deviceConnectionParams: { acceptedDeviceModelIds },
+      deviceConnectionParams: { acceptedDeviceModelIds, disableAutoConnect: false },
     });
 
     // THEN
@@ -197,6 +199,18 @@ describe("useDeviceConnectionComponentLWDViewModel", () => {
       expect.objectContaining({
         acceptedDeviceModelIds: [DeviceModelId.stax],
       }),
+    );
+  });
+
+  it("GIVEN the executor suppressed auto-connect WHEN rendering the view model THEN it passes that to connect device", () => {
+    // WHEN
+    renderViewModel({
+      deviceConnectionParams: { acceptedDeviceModelIds: [], disableAutoConnect: true },
+    });
+
+    // THEN
+    expect(mockedConnectDevice).toHaveBeenCalledWith(
+      expect.objectContaining({ disableAutoConnect: true }),
     );
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/useDeviceConnectionComponentLWDViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/useDeviceConnectionComponentLWDViewModel.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type {
-  DeviceConnectionParams,
+  DeviceConnectionComponentParams,
   DeviceConnectionResult,
 } from "@features/platform-device-intent";
 import { dmkToLedgerDeviceIdMap, useDeviceIntentTracking } from "@ledgerhq/live-dmk-shared";
@@ -24,7 +24,7 @@ import {
 const missingDeviceManagementKitError = new Error("Device Management Kit is not available");
 
 type UseDeviceConnectionComponentLWDViewModelParams = {
-  deviceConnectionParams: DeviceConnectionParams;
+  deviceConnectionParams: DeviceConnectionComponentParams;
   onConnected: (connectionResult: DeviceConnectionResult) => void;
 };
 
@@ -107,6 +107,7 @@ export function useDeviceConnectionComponentLWDViewModel({
       acceptedDeviceModelIds: deviceConnectionParams.acceptedDeviceModelIds.map(
         deviceModelId => dmkToLedgerDeviceIdMap[deviceModelId],
       ),
+      disableAutoConnect: deviceConnectionParams.disableAutoConnect,
       dmk,
       onConnected: wrappedOnConnected,
     }).subscribe({
@@ -118,7 +119,12 @@ export function useDeviceConnectionComponentLWDViewModel({
     return () => {
       subscription.unsubscribe();
     };
-  }, [deviceConnectionParams.acceptedDeviceModelIds, dmk, wrappedOnConnected]);
+  }, [
+    deviceConnectionParams.acceptedDeviceModelIds,
+    deviceConnectionParams.disableAutoConnect,
+    dmk,
+    wrappedOnConnected,
+  ]);
 
   return {
     state,

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWDViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWDViewModel.test.tsx
@@ -309,7 +309,7 @@ describe("useDeviceIntentExecutorLWDViewModel", () => {
 
   describe("GIVEN a non-completing executor state", () => {
     const nonCompleting: ExecutorState[] = [
-      { type: "connectingDevice" },
+      { type: "connectingDevice", disableAutoConnect: false },
       { type: "deviceDisconnected", device: makeConnectionResult().connectedDevice },
       { type: "initializingDeviceContext", connectionResult: makeConnectionResult() },
       { type: "idle" },

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/deviceIntents/editExternalAddressIntent/componentLWD.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/deviceIntents/editExternalAddressIntent/componentLWD.test.tsx
@@ -16,6 +16,7 @@ const COPY = {
 
 const CLOSE_CTA = "contacts-edit-external-address-close";
 const RETRY_CTA = "contacts-edit-external-address-retry";
+const RECONNECT_CTA = "contacts-edit-external-address-wrong-device-reconnect";
 
 const failure = (type: string): EditExternalAddressJobState =>
   ({ type, error: new Error("boom") }) as EditExternalAddressJobState;
@@ -113,5 +114,25 @@ describe("EditExternalAddressComponentLWD", () => {
     });
 
     expect(screen.getByText(COPY.continueOnDevice)).toBeVisible();
+  });
+
+  it("should let the user connect a different device when the wrong device carries a reconnect", async () => {
+    const reconnect = jest.fn();
+    const { user } = renderComponent({
+      type: "existing-group-verification-failed",
+      error: new Error("SWO_SECURITY_CONDITION_NOT_SATISFIED"),
+      reconnect,
+    });
+
+    await user.click(screen.getByTestId(RECONNECT_CTA));
+
+    expect(reconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("should offer cancel alone when the wrong device carries no reconnect", () => {
+    renderComponent(failure("existing-group-verification-failed"));
+
+    expect(screen.queryByTestId(RECONNECT_CTA)).not.toBeInTheDocument();
+    expect(screen.getByText("Cancel")).toBeVisible();
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/deviceIntents/editExternalAddressIntent/componentLWD.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/deviceIntents/editExternalAddressIntent/componentLWD.tsx
@@ -77,21 +77,33 @@ export function EditExternalAddressComponentLWD({
       );
     }
 
-    case "existing-group-verification-failed":
+    case "existing-group-verification-failed": {
+      const reconnect = jobState.reconnect;
+      const cancelCta = {
+        label: t("common.cancel"),
+        onPress: onClose,
+        testID: "contacts-edit-external-address-wrong-device-cancel",
+      };
       return (
         <InfoState
           preset="info"
           size="hug"
           title={t("contacts.deviceIntents.errors.wrongDevice.title")}
           description={t("contacts.deviceIntents.errors.wrongDevice.description")}
-          primaryCta={{
-            label: t("common.cancel"),
-            onPress: onClose,
-            testID: "contacts-edit-external-address-wrong-device-cancel",
-          }}
+          primaryCta={
+            reconnect
+              ? {
+                  label: t("contacts.deviceIntents.errors.wrongDevice.connectDifferentDevice"),
+                  onPress: reconnect,
+                  testID: "contacts-edit-external-address-wrong-device-reconnect",
+                }
+              : cancelCta
+          }
+          secondaryCta={reconnect ? cancelCta : undefined}
           testID="contacts-edit-external-address-wrong-device"
         />
       );
+    }
 
     case "invalid-input":
     case "unsupported-operation":

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/deviceIntents/registerExternalAddressIntent/componentLWD.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/deviceIntents/registerExternalAddressIntent/componentLWD.test.tsx
@@ -16,6 +16,7 @@ const COPY = {
 
 const CLOSE_CTA = "contacts-register-external-address-close";
 const RETRY_CTA = "contacts-register-external-address-retry";
+const RECONNECT_CTA = "contacts-register-external-address-wrong-device-reconnect";
 
 const failure = (type: string): RegisterExternalAddressJobState =>
   ({ type, error: new Error("boom") }) as RegisterExternalAddressJobState;
@@ -94,5 +95,25 @@ describe("RegisterExternalAddressComponentLWD", () => {
     await user.click(screen.getByTestId(CLOSE_CTA));
 
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("should let the user connect a different device when the wrong device carries a reconnect", async () => {
+    const reconnect = jest.fn();
+    const { user } = renderComponent({
+      type: "existing-group-verification-failed",
+      error: new Error("SWO_SECURITY_CONDITION_NOT_SATISFIED"),
+      reconnect,
+    });
+
+    await user.click(screen.getByTestId(RECONNECT_CTA));
+
+    expect(reconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("should offer cancel alone when the wrong device carries no reconnect", () => {
+    renderComponent(failure("existing-group-verification-failed"));
+
+    expect(screen.queryByTestId(RECONNECT_CTA)).not.toBeInTheDocument();
+    expect(screen.getByText("Cancel")).toBeVisible();
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/deviceIntents/registerExternalAddressIntent/componentLWD.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/deviceIntents/registerExternalAddressIntent/componentLWD.tsx
@@ -81,21 +81,33 @@ export function RegisterExternalAddressComponentLWD({
       );
     }
 
-    case "existing-group-verification-failed":
+    case "existing-group-verification-failed": {
+      const reconnect = jobState.reconnect;
+      const cancelCta = {
+        label: t("common.cancel"),
+        onPress: onClose,
+        testID: "contacts-register-external-address-wrong-device-cancel",
+      };
       return (
         <InfoState
           preset="info"
           size="hug"
           title={t("contacts.deviceIntents.errors.wrongDevice.title")}
           description={t("contacts.deviceIntents.errors.wrongDevice.description")}
-          primaryCta={{
-            label: t("common.cancel"),
-            onPress: onClose,
-            testID: "contacts-register-external-address-wrong-device-cancel",
-          }}
+          primaryCta={
+            reconnect
+              ? {
+                  label: t("contacts.deviceIntents.errors.wrongDevice.connectDifferentDevice"),
+                  onPress: reconnect,
+                  testID: "contacts-register-external-address-wrong-device-reconnect",
+                }
+              : cancelCta
+          }
+          secondaryCta={reconnect ? cancelCta : undefined}
           testID="contacts-register-external-address-wrong-device"
         />
       );
+    }
 
     case "invalid-input":
     case "unsupported-operation":

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/deviceIntents/renameContactIntent/componentLWD.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/deviceIntents/renameContactIntent/componentLWD.test.tsx
@@ -16,6 +16,7 @@ const COPY = {
 
 const CLOSE_CTA = "contacts-rename-contact-close";
 const RETRY_CTA = "contacts-rename-contact-retry";
+const RECONNECT_CTA = "contacts-rename-contact-wrong-device-reconnect";
 
 const failure = (type: string): RenameContactJobState =>
   ({ type, error: new Error("boom") }) as RenameContactJobState;
@@ -94,5 +95,25 @@ describe("RenameContactComponentLWD", () => {
     await user.click(screen.getByTestId(CLOSE_CTA));
 
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("should let the user connect a different device when the wrong device carries a reconnect", async () => {
+    const reconnect = jest.fn();
+    const { user } = renderComponent({
+      type: "existing-group-verification-failed",
+      error: new Error("SWO_SECURITY_CONDITION_NOT_SATISFIED"),
+      reconnect,
+    });
+
+    await user.click(screen.getByTestId(RECONNECT_CTA));
+
+    expect(reconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("should offer cancel alone when the wrong device carries no reconnect", () => {
+    renderComponent(failure("existing-group-verification-failed"));
+
+    expect(screen.queryByTestId(RECONNECT_CTA)).not.toBeInTheDocument();
+    expect(screen.getByText("Cancel")).toBeVisible();
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/deviceIntents/renameContactIntent/componentLWD.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/deviceIntents/renameContactIntent/componentLWD.tsx
@@ -78,21 +78,33 @@ export function RenameContactComponentLWD({ jobState, onClose }: RenameContactCo
       );
     }
 
-    case "existing-group-verification-failed":
+    case "existing-group-verification-failed": {
+      const reconnect = jobState.reconnect;
+      const cancelCta = {
+        label: t("common.cancel"),
+        onPress: onClose,
+        testID: "contacts-rename-contact-wrong-device-cancel",
+      };
       return (
         <InfoState
           preset="info"
           size="hug"
           title={t("contacts.deviceIntents.errors.wrongDevice.title")}
           description={t("contacts.deviceIntents.errors.wrongDevice.description")}
-          primaryCta={{
-            label: t("common.cancel"),
-            onPress: onClose,
-            testID: "contacts-rename-contact-wrong-device-cancel",
-          }}
+          primaryCta={
+            reconnect
+              ? {
+                  label: t("contacts.deviceIntents.errors.wrongDevice.connectDifferentDevice"),
+                  onPress: reconnect,
+                  testID: "contacts-rename-contact-wrong-device-reconnect",
+                }
+              : cancelCta
+          }
+          secondaryCta={reconnect ? cancelCta : undefined}
           testID="contacts-rename-contact-wrong-device"
         />
       );
+    }
 
     case "invalid-input":
     case "unsupported-operation":

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9598,7 +9598,8 @@
       "errors": {
         "wrongDevice": {
           "title": "Use the same Ledger device you used to add this contact",
-          "description": "The connected device isn't a match."
+          "description": "The connected device isn't a match.",
+          "connectDifferentDevice": "Connect a different device"
         },
         "invalidData": {
           "title": "This address can't be saved",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10473,7 +10473,8 @@
       "errors": {
         "wrongDevice": {
           "title": "Use the same Ledger device you used to add this contact",
-          "description": "The connected device isn't a match."
+          "description": "The connected device isn't a match.",
+          "connectDifferentDevice": "Connect a different device"
         },
         "invalidData": {
           "title": "This address can't be saved",

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/useDeviceConnectionComponentLWMViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/useDeviceConnectionComponentLWMViewModel.test.tsx
@@ -4,7 +4,7 @@ import { Linking } from "react-native";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { DeviceModelId as DMKDeviceModelId } from "@ledgerhq/device-management-kit";
 import type {
-  DeviceConnectionParams,
+  DeviceConnectionComponentParams,
   DeviceConnectionResult,
 } from "@features/platform-device-intent";
 import {
@@ -112,8 +112,9 @@ function withViewModelState({
 }
 
 const sourceFlow: SourceFlow = "my_ledger";
-const defaultDeviceConnectionParams: DeviceConnectionParams = {
+const defaultDeviceConnectionParams: DeviceConnectionComponentParams = {
   acceptedDeviceModelIds: [],
+  disableAutoConnect: false,
 };
 
 const layerABaseProperties = {
@@ -197,6 +198,7 @@ describe("useDeviceConnectionComponentLWMViewModel", () => {
     expect(mockedConnectDevice).toHaveBeenCalledWith({
       knownDevices,
       acceptedDeviceModelIds: [],
+      disableAutoConnect: false,
       dmk: mockDmk,
       onConnected: expect.any(Function),
     });
@@ -208,7 +210,7 @@ describe("useDeviceConnectionComponentLWMViewModel", () => {
 
     // WHEN
     renderViewModel({
-      deviceConnectionParams: { acceptedDeviceModelIds },
+      deviceConnectionParams: { acceptedDeviceModelIds, disableAutoConnect: false },
     });
 
     // THEN
@@ -216,6 +218,18 @@ describe("useDeviceConnectionComponentLWMViewModel", () => {
       expect.objectContaining({
         acceptedDeviceModelIds: [DeviceModelId.stax],
       }),
+    );
+  });
+
+  it("should pass the executor's auto-connect suppression to the connect device flow", () => {
+    // WHEN
+    renderViewModel({
+      deviceConnectionParams: { acceptedDeviceModelIds: [], disableAutoConnect: true },
+    });
+
+    // THEN
+    expect(mockedConnectDevice).toHaveBeenCalledWith(
+      expect.objectContaining({ disableAutoConnect: true }),
     );
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/useDeviceConnectionComponentLWMViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWM/useDeviceConnectionComponentLWMViewModel.ts
@@ -3,7 +3,7 @@ import { Linking, Platform } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type {
-  DeviceConnectionParams,
+  DeviceConnectionComponentParams,
   DeviceConnectionResult,
 } from "@features/platform-device-intent";
 import { log } from "@ledgerhq/logs";
@@ -35,7 +35,7 @@ import { useDeviceIntentTracking } from "../utils/DeviceIntentTrackingContext";
 const LOG_TYPE = "DeviceConnectionComponentLWM";
 
 type UseDeviceConnectionComponentLWMViewModelParams = {
-  deviceConnectionParams: DeviceConnectionParams;
+  deviceConnectionParams: DeviceConnectionComponentParams;
   onConnected: (connectionResult: DeviceConnectionResult) => void;
 };
 
@@ -181,12 +181,19 @@ export function useDeviceConnectionComponentLWMViewModel({
       acceptedDeviceModelIds: deviceConnectionParams.acceptedDeviceModelIds.map(
         deviceModelId => dmkToLedgerDeviceIdMap[deviceModelId],
       ),
+      disableAutoConnect: deviceConnectionParams.disableAutoConnect,
       dmk,
       onConnected: wrappedOnConnected,
     }).subscribe({ next: setState });
 
     return () => subscription.unsubscribe();
-  }, [deviceConnectionParams.acceptedDeviceModelIds, dmk, knownDevices, wrappedOnConnected]);
+  }, [
+    deviceConnectionParams.acceptedDeviceModelIds,
+    deviceConnectionParams.disableAutoConnect,
+    dmk,
+    knownDevices,
+    wrappedOnConnected,
+  ]);
 
   return {
     state,

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWMViewModel.test.tsx
@@ -296,7 +296,7 @@ describe("useDeviceIntentExecutorLWMViewModel", () => {
 
   describe("GIVEN a non-completing executor state", () => {
     const nonCompleting: ExecutorState[] = [
-      { type: "connectingDevice" },
+      { type: "connectingDevice", disableAutoConnect: false },
       { type: "deviceDisconnected", device: makeConnectionResult().connectedDevice },
       { type: "initializingDeviceContext", connectionResult: makeConnectionResult() },
       { type: "idle" },

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/deviceIntents/editExternalAddressIntent/componentLWM.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/deviceIntents/editExternalAddressIntent/componentLWM.test.tsx
@@ -111,4 +111,24 @@ describe("EditExternalAddressComponentLWM", () => {
 
     expect(screen.getByText(COPY.continueOnDevice)).toBeVisible();
   });
+
+  it("should let the user connect a different device when the wrong device carries a reconnect", async () => {
+    const reconnect = jest.fn();
+    const { user } = renderComponent({
+      type: "existing-group-verification-failed",
+      error: new Error("SWO_SECURITY_CONDITION_NOT_SATISFIED"),
+      reconnect,
+    });
+
+    await user.press(screen.getByText("Connect a different device"));
+
+    expect(reconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("should offer cancel alone when the wrong device carries no reconnect", () => {
+    renderComponent(failure("existing-group-verification-failed"));
+
+    expect(screen.queryByText("Connect a different device")).toBeNull();
+    expect(screen.getByText("Cancel")).toBeVisible();
+  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/deviceIntents/editExternalAddressIntent/componentLWM.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/deviceIntents/editExternalAddressIntent/componentLWM.tsx
@@ -77,21 +77,35 @@ export function EditExternalAddressComponentLWM({
       );
     }
 
-    case "existing-group-verification-failed":
+    case "existing-group-verification-failed": {
+      const reconnect = jobState.reconnect;
+      const cancelCta = {
+        label: <Trans i18nKey="common.cancel" />,
+        onPress: onClose,
+        testID: "contacts-edit-external-address-wrong-device-cancel",
+      };
       return (
         <InfoState
           preset="info"
           size="hug"
           title={<Trans i18nKey="contacts.deviceIntents.errors.wrongDevice.title" />}
           description={<Trans i18nKey="contacts.deviceIntents.errors.wrongDevice.description" />}
-          primaryCta={{
-            label: <Trans i18nKey="common.cancel" />,
-            onPress: onClose,
-            testID: "contacts-edit-external-address-wrong-device-cancel",
-          }}
+          primaryCta={
+            reconnect
+              ? {
+                  label: (
+                    <Trans i18nKey="contacts.deviceIntents.errors.wrongDevice.connectDifferentDevice" />
+                  ),
+                  onPress: reconnect,
+                  testID: "contacts-edit-external-address-wrong-device-reconnect",
+                }
+              : cancelCta
+          }
+          secondaryCta={reconnect ? cancelCta : undefined}
           testID="contacts-edit-external-address-wrong-device"
         />
       );
+    }
 
     case "invalid-input":
     case "unsupported-operation":

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/deviceIntents/registerExternalAddressIntent/componentLWM.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/deviceIntents/registerExternalAddressIntent/componentLWM.test.tsx
@@ -92,4 +92,24 @@ describe("RegisterExternalAddressComponentLWM", () => {
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  it("should let the user connect a different device when the wrong device carries a reconnect", async () => {
+    const reconnect = jest.fn();
+    const { user } = renderComponent({
+      type: "existing-group-verification-failed",
+      error: new Error("SWO_SECURITY_CONDITION_NOT_SATISFIED"),
+      reconnect,
+    });
+
+    await user.press(screen.getByText("Connect a different device"));
+
+    expect(reconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("should offer cancel alone when the wrong device carries no reconnect", () => {
+    renderComponent(failure("existing-group-verification-failed"));
+
+    expect(screen.queryByText("Connect a different device")).toBeNull();
+    expect(screen.getByText("Cancel")).toBeVisible();
+  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/deviceIntents/registerExternalAddressIntent/componentLWM.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/deviceIntents/registerExternalAddressIntent/componentLWM.tsx
@@ -76,21 +76,35 @@ export function RegisterExternalAddressComponentLWM({
       );
     }
 
-    case "existing-group-verification-failed":
+    case "existing-group-verification-failed": {
+      const reconnect = jobState.reconnect;
+      const cancelCta = {
+        label: <Trans i18nKey="common.cancel" />,
+        onPress: onClose,
+        testID: "contacts-register-external-address-wrong-device-cancel",
+      };
       return (
         <InfoState
           preset="info"
           size="hug"
           title={<Trans i18nKey="contacts.deviceIntents.errors.wrongDevice.title" />}
           description={<Trans i18nKey="contacts.deviceIntents.errors.wrongDevice.description" />}
-          primaryCta={{
-            label: <Trans i18nKey="common.cancel" />,
-            onPress: onClose,
-            testID: "contacts-register-external-address-wrong-device-cancel",
-          }}
+          primaryCta={
+            reconnect
+              ? {
+                  label: (
+                    <Trans i18nKey="contacts.deviceIntents.errors.wrongDevice.connectDifferentDevice" />
+                  ),
+                  onPress: reconnect,
+                  testID: "contacts-register-external-address-wrong-device-reconnect",
+                }
+              : cancelCta
+          }
+          secondaryCta={reconnect ? cancelCta : undefined}
           testID="contacts-register-external-address-wrong-device"
         />
       );
+    }
 
     case "invalid-input":
     case "unsupported-operation":

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/deviceIntents/renameContactIntent/componentLWM.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/deviceIntents/renameContactIntent/componentLWM.test.tsx
@@ -92,4 +92,24 @@ describe("RenameContactComponentLWM", () => {
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  it("should let the user connect a different device when the wrong device carries a reconnect", async () => {
+    const reconnect = jest.fn();
+    const { user } = renderComponent({
+      type: "existing-group-verification-failed",
+      error: new Error("SWO_SECURITY_CONDITION_NOT_SATISFIED"),
+      reconnect,
+    });
+
+    await user.press(screen.getByText("Connect a different device"));
+
+    expect(reconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("should offer cancel alone when the wrong device carries no reconnect", () => {
+    renderComponent(failure("existing-group-verification-failed"));
+
+    expect(screen.queryByText("Connect a different device")).toBeNull();
+    expect(screen.getByText("Cancel")).toBeVisible();
+  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/deviceIntents/renameContactIntent/componentLWM.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/deviceIntents/renameContactIntent/componentLWM.tsx
@@ -73,21 +73,35 @@ export function RenameContactComponentLWM({ jobState, onClose }: RenameContactCo
       );
     }
 
-    case "existing-group-verification-failed":
+    case "existing-group-verification-failed": {
+      const reconnect = jobState.reconnect;
+      const cancelCta = {
+        label: <Trans i18nKey="common.cancel" />,
+        onPress: onClose,
+        testID: "contacts-rename-contact-wrong-device-cancel",
+      };
       return (
         <InfoState
           preset="info"
           size="hug"
           title={<Trans i18nKey="contacts.deviceIntents.errors.wrongDevice.title" />}
           description={<Trans i18nKey="contacts.deviceIntents.errors.wrongDevice.description" />}
-          primaryCta={{
-            label: <Trans i18nKey="common.cancel" />,
-            onPress: onClose,
-            testID: "contacts-rename-contact-wrong-device-cancel",
-          }}
+          primaryCta={
+            reconnect
+              ? {
+                  label: (
+                    <Trans i18nKey="contacts.deviceIntents.errors.wrongDevice.connectDifferentDevice" />
+                  ),
+                  onPress: reconnect,
+                  testID: "contacts-rename-contact-wrong-device-reconnect",
+                }
+              : cancelCta
+          }
+          secondaryCta={reconnect ? cancelCta : undefined}
           testID="contacts-rename-contact-wrong-device"
         />
       );
+    }
 
     case "invalid-input":
     case "unsupported-operation":

--- a/features/platform/contacts/src/device/contactsDeviceActionFailure.ts
+++ b/features/platform/contacts/src/device/contactsDeviceActionFailure.ts
@@ -10,8 +10,19 @@ export type ContactDeviceIntentFailureJobState =
   | { readonly type: "invalid-input"; readonly error: Error }
   /** 0x5501 (`ActionRefusedError`) from the dashboard, or 0x6A80 (SWO_INCORRECT_DATA) from the Contacts app, which buckets a refusal with malformed TLV and an invalid group handle. */
   | { readonly type: "device-rejected"; readonly error: Error; readonly retry?: () => void }
-  /** 0x6982 (SWO_SECURITY_CONDITION_NOT_SATISFIED): HMAC_PROOF/HMAC_REST verification failed — only reachable when replaying an existing group. */
-  | { readonly type: "existing-group-verification-failed"; readonly error: Error }
+  /**
+   * 0x6982 (SWO_SECURITY_CONDITION_NOT_SATISFIED): HMAC_PROOF/HMAC_REST
+   * verification failed — only reachable when replaying an existing group.
+   * Devices are stateless and keep honouring the proofs they minted, so this
+   * means the connected device is not the one that minted them. `reconnect`
+   * sends the executor back to device selection to replay on another device; it
+   * is absent when the host has no connection phase to return to.
+   */
+  | {
+      readonly type: "existing-group-verification-failed";
+      readonly error: Error;
+      readonly reconnect?: () => void;
+    }
   /** 0x6984 (SWO_CONDITIONS_NOT_SATISFIED): unknown sub-command or unsupported configuration. */
   | { readonly type: "unsupported-operation"; readonly error: Error }
   /**

--- a/features/platform/contacts/src/device/intents/editExternalAddressIntent/job.test.ts
+++ b/features/platform/contacts/src/device/intents/editExternalAddressIntent/job.test.ts
@@ -5,7 +5,6 @@ import {
   UserInteractionRequired,
 } from "@ledgerhq/device-management-kit";
 import { Subject } from "rxjs";
-import { ContactDeviceIntentCancelledError } from "../../errors";
 import { editExternalAddressIntentJob } from "./job";
 import type { EditExternalAddressIntentInput, EditExternalAddressJobState } from "./types";
 
@@ -377,7 +376,7 @@ describe("editExternalAddressIntentJob", () => {
       expect(steps).toEqual(["identifier", "scope"]);
     });
 
-    it("GIVEN the user gives up between the two steps THEN it cancels without reporting a partial result", () => {
+    it("GIVEN a teardown between the two steps THEN it reports nothing, not a partial result", () => {
       // GIVEN
       const job = startJob(COMBINED);
       job.emitIdentifier(identifierCompletion([0x07, 0x08]));
@@ -388,11 +387,7 @@ describe("editExternalAddressIntentJob", () => {
       // THEN
       // The device records nothing, so dropping the intermediate proof leaves
       // the stored record untouched and still valid.
-      expect(job.onResult).toHaveBeenCalledWith({
-        type: "failure",
-        error: expect.any(ContactDeviceIntentCancelledError),
-      });
-      expect(job.onResult).toHaveBeenCalledTimes(1);
+      expect(job.onResult).not.toHaveBeenCalled();
     });
 
     it("GIVEN the scope step is running WHEN the caller unsubscribes THEN it tears that step down", () => {
@@ -688,7 +683,7 @@ describe("editExternalAddressIntentJob", () => {
       expect(job.isCompleted()).toBe(true);
     });
 
-    it("GIVEN a rejection WHEN the user gives up instead THEN it settles as a cancellation", () => {
+    it("GIVEN a rejection WHEN the job is torn down instead of retried THEN it reports nothing", () => {
       // GIVEN
       const job = startJob();
       job.emitIdentifier(REJECTION);
@@ -697,10 +692,9 @@ describe("editExternalAddressIntentJob", () => {
       job.subscription.unsubscribe();
 
       // THEN
-      expect(job.onResult).toHaveBeenCalledWith({
-        type: "failure",
-        error: expect.any(ContactDeviceIntentCancelledError),
-      });
+      // Giving up is the orchestrator's `onUserCancel`, not a teardown: the
+      // executor also tears jobs down on paths that keep the operation alive.
+      expect(job.onResult).not.toHaveBeenCalled();
     });
 
     it("GIVEN status word 0x6982 WHEN the device action errors THEN it reports existing-group-verification-failed", () => {
@@ -802,7 +796,7 @@ describe("editExternalAddressIntentJob", () => {
       },
     );
 
-    it("GIVEN an active edit WHEN the caller unsubscribes before completion THEN it cancels the device action and reports cancellation", () => {
+    it("GIVEN an active edit WHEN the caller unsubscribes before completion THEN it cancels the device action without reporting", () => {
       // GIVEN
       const job = startJob();
 
@@ -811,10 +805,9 @@ describe("editExternalAddressIntentJob", () => {
 
       // THEN
       expect(job.identifierCancel(0)).toHaveBeenCalled();
-      expect(job.onResult).toHaveBeenCalledWith({
-        type: "failure",
-        error: expect.any(ContactDeviceIntentCancelledError),
-      });
+      // The executor tears the job down whenever it leaves intent execution, so a
+      // report here would settle the flow that a later run is meant to finish.
+      expect(job.onResult).not.toHaveBeenCalled();
     });
 
     it("GIVEN the device action is stopped WHEN reported THEN it reports failure", () => {

--- a/features/platform/contacts/src/device/intents/editExternalAddressIntent/job.test.ts
+++ b/features/platform/contacts/src/device/intents/editExternalAddressIntent/job.test.ts
@@ -46,7 +46,10 @@ const COMBINED: EditExternalAddressIntentInput = { ...INPUT, newScope: "Testnet"
  * subject per call, so a chained or replayed edit can be stepped independently:
  * `identifierRun(0)` is the first identifier attempt, `(1)` the retry, and so on.
  */
-function startJob(input: EditExternalAddressIntentInput = INPUT) {
+function startJob(
+  input: EditExternalAddressIntentInput = INPUT,
+  { canReconnect = true }: { canReconnect?: boolean } = {},
+) {
   const runs = { identifier: [] as Subject<unknown>[], scope: [] as Subject<unknown>[] };
   const cancels = { identifier: [] as jest.Mock[], scope: [] as jest.Mock[] };
 
@@ -66,6 +69,7 @@ function startJob(input: EditExternalAddressIntentInput = INPUT) {
 
   const states: EditExternalAddressJobState[] = [];
   const onResult = jest.fn();
+  const restartExecutor = jest.fn();
   let error: unknown;
   let completed = false;
 
@@ -86,6 +90,7 @@ function startJob(input: EditExternalAddressIntentInput = INPUT) {
     },
     input,
     onResult,
+    ...(canReconnect ? { restartExecutor } : {}),
   }).subscribe({
     next: state => states.push(state),
     error: e => {
@@ -105,6 +110,7 @@ function startJob(input: EditExternalAddressIntentInput = INPUT) {
   return {
     states,
     onResult,
+    restartExecutor,
     subscription,
     editExternalAddressIdentifier,
     editExternalAddressScope,
@@ -438,7 +444,7 @@ describe("editExternalAddressIntentJob", () => {
       expect(job.states).toContainEqual({ type: "failed", error: expect.any(Error) });
     });
 
-    it("GIVEN status word 0x6982 on the scope step THEN it reports existing-group-verification-failed", () => {
+    it("GIVEN status word 0x6982 on the scope step THEN it reports existing-group-verification-failed carrying a reconnect handle", () => {
       // GIVEN
       const job = startJob(COMBINED);
       job.emitIdentifier(identifierCompletion([0x07, 0x08]));
@@ -457,7 +463,11 @@ describe("editExternalAddressIntentJob", () => {
       expect(job.states).toContainEqual({
         type: "existing-group-verification-failed",
         error: expect.objectContaining({ message: "SWO_SECURITY_CONDITION_NOT_SATISFIED" }),
+        reconnect: expect.any(Function),
       });
+      // A retry replays from the stored proof, so the chain survives the swap.
+      expect(job.isCompleted()).toBe(false);
+      expect(job.onResult).not.toHaveBeenCalled();
     });
 
     it("GIVEN the scope step is rejected WHEN the user retries THEN it restarts from the identifier step", () => {
@@ -697,7 +707,7 @@ describe("editExternalAddressIntentJob", () => {
       expect(job.onResult).not.toHaveBeenCalled();
     });
 
-    it("GIVEN status word 0x6982 WHEN the device action errors THEN it reports existing-group-verification-failed", () => {
+    it("GIVEN status word 0x6982 WHEN the device action errors THEN it reports existing-group-verification-failed carrying a reconnect handle", () => {
       // GIVEN
       const job = startJob();
       // An edit always replays the entry's existing proofs, so this is how proofs
@@ -715,7 +725,53 @@ describe("editExternalAddressIntentJob", () => {
       expect(job.states).toContainEqual({
         type: "existing-group-verification-failed",
         error: expect.objectContaining({ message: "SWO_SECURITY_CONDITION_NOT_SATISFIED" }),
+        reconnect: expect.any(Function),
       });
+      expect(job.isCompleted()).toBe(false);
+      expect(job.onResult).not.toHaveBeenCalled();
+    });
+
+    it("GIVEN a wrong device WHEN the reconnect handle is called THEN it restarts the executor", () => {
+      // GIVEN
+      const job = startJob();
+      job.emitIdentifier({
+        status: DeviceActionStatus.Error,
+        error: { _tag: "ContactsCommandError", errorCode: "6982", message: "wrong device" },
+      });
+      const state = job.states.find(s => s.type === "existing-group-verification-failed");
+
+      // WHEN
+      if (state?.type !== "existing-group-verification-failed") {
+        throw new Error("Expected the job to have reported a wrong device");
+      }
+      state.reconnect?.();
+
+      // THEN
+      expect(job.restartExecutor).toHaveBeenCalled();
+    });
+
+    it("GIVEN no restart affordance WHEN a wrong device is reported THEN it settles as a terminal failure", () => {
+      // GIVEN
+      const job = startJob(INPUT, { canReconnect: false });
+
+      // WHEN
+      job.emitIdentifier({
+        status: DeviceActionStatus.Error,
+        error: { _tag: "ContactsCommandError", errorCode: "6982", message: "wrong device" },
+      });
+
+      // THEN
+      // Nothing can send this host back to device selection, so leaving the job
+      // open would hang the caller on a recovery it cannot offer.
+      expect(job.states).toContainEqual({
+        type: "existing-group-verification-failed",
+        error: expect.objectContaining({ message: "wrong device" }),
+      });
+      expect(job.onResult).toHaveBeenCalledWith({
+        type: "failure",
+        error: expect.objectContaining({ message: "wrong device" }),
+      });
+      expect(job.isCompleted()).toBe(true);
     });
 
     it("GIVEN status word 0x6984 WHEN the device action errors THEN it reports unsupported-operation", () => {

--- a/features/platform/contacts/src/device/intents/editExternalAddressIntent/job.ts
+++ b/features/platform/contacts/src/device/intents/editExternalAddressIntent/job.ts
@@ -64,6 +64,17 @@ const OPEN_JOB_STATE_TYPES = new Set<EditExternalAddressJobState["type"]>([
   "device-rejected",
 ]);
 
+/**
+ * A wrong device only keeps the job open where the executor can be sent back to
+ * pick another one. Without that, the state is terminal and the job settles, so
+ * the caller is not left waiting on a recovery the host cannot offer.
+ */
+function openJobStateTypes(canReconnect: boolean): Set<EditExternalAddressJobState["type"]> {
+  return canReconnect
+    ? new Set([...OPEN_JOB_STATE_TYPES, "existing-group-verification-failed" as const])
+    : OPEN_JOB_STATE_TYPES;
+}
+
 /** Pairs the kit's `cancel` with unsubscription, so teardown is one concern. */
 function createDeviceActionObservable<State>(
   call: () => { observable: Observable<State>; cancel: () => void },
@@ -81,6 +92,7 @@ function createDeviceActionObservable<State>(
 
 function createStepOutcomeMapper(
   awaitingConfirmation: EditExternalAddressJobState,
+  canReconnect: boolean,
 ): (state: DeviceActionState) => StepOutcome {
   return state => {
     switch (state.status) {
@@ -115,7 +127,12 @@ function createStepOutcomeMapper(
 
       case DeviceActionStatus.Error: {
         const jobState = mapDeviceActionErrorToFailureJobState(state.error);
-        const isReplayableByTheUser = jobState.type === "device-rejected";
+        // A rejection replays on this device, a wrong device on whichever one the
+        // user connects next. Both stay open and are handed their callback by the
+        // tail `map`, rather than settling the port promise.
+        const isReplayableByTheUser =
+          jobState.type === "device-rejected" ||
+          (jobState.type === "existing-group-verification-failed" && canReconnect);
 
         return isReplayableByTheUser
           ? { kind: "state", jobState, terminal: false }
@@ -140,11 +157,12 @@ export const editExternalAddressIntentJob: Job<
   EditExternalAddressJobState,
   EditExternalAddressIntentInput,
   ContactIntentResult<EditExternalAddressResult>
-> = ({ deviceConnectionResult, deviceExtractedContext, input, onResult }) => {
+> = ({ deviceConnectionResult, deviceExtractedContext, input, onResult, restartExecutor }) => {
   const reporter = createContactIntentResultReporter(onResult);
   const retries = new Subject<void>();
   const deviceModelId = deviceConnectionResult.connectedDevice.modelId;
   const deviceName = deviceConnectionResult.compatDeviceName;
+  const openStateTypes = openJobStateTypes(restartExecutor !== undefined);
 
   const scopeChanges = input.newScope !== input.previousScope;
   const identifierChanges = input.newAddress !== input.previousAddress;
@@ -200,7 +218,10 @@ export const editExternalAddressIntentJob: Job<
       awaitingConfirmation: EditExternalAddressJobState,
       next: (hmacRest: Uint8Array) => Observable<EditExternalAddressJobState>,
     ): Observable<EditExternalAddressJobState> {
-      const toOutcome = createStepOutcomeMapper(awaitingConfirmation);
+      const toOutcome = createStepOutcomeMapper(
+        awaitingConfirmation,
+        restartExecutor !== undefined,
+      );
 
       return deviceAction.pipe(
         map(toOutcome),
@@ -292,12 +313,18 @@ export const editExternalAddressIntentJob: Job<
       // still accepts: it never recorded the intermediate step.
       switchMap(runEdit),
       // `retries` never completes, so the job's end has to come from its states.
-      takeWhile(jobState => OPEN_JOB_STATE_TYPES.has(jobState.type), true),
+      takeWhile(jobState => openStateTypes.has(jobState.type), true),
     );
   }).pipe(
-    map(jobState =>
-      jobState.type === "device-rejected" ? { ...jobState, retry: () => retries.next() } : jobState,
-    ),
+    map(jobState => {
+      if (jobState.type === "device-rejected") {
+        return { ...jobState, retry: () => retries.next() };
+      }
+      if (jobState.type === "existing-group-verification-failed" && restartExecutor) {
+        return { ...jobState, reconnect: restartExecutor };
+      }
+      return jobState;
+    }),
     // Jobs report failures as a terminal JobState rather than erroring the
     // observable, which would drop the executor into its generic fallback
     // instead of this intent's own InfoState.

--- a/features/platform/contacts/src/device/intents/editExternalAddressIntent/job.ts
+++ b/features/platform/contacts/src/device/intents/editExternalAddressIntent/job.ts
@@ -306,6 +306,5 @@ export const editExternalAddressIntentJob: Job<
       reporter.report({ type: "failure", error: mapped });
       return of<EditExternalAddressJobState>({ type: "failed", error: mapped });
     }),
-    reporter.cancelOnUnsubscribe(),
   );
 };

--- a/features/platform/contacts/src/device/intents/registerExternalAddressIntent/job.test.ts
+++ b/features/platform/contacts/src/device/intents/registerExternalAddressIntent/job.test.ts
@@ -22,7 +22,14 @@ const INPUT: RegisterExternalAddressIntentInput = {
   chainId: 1,
 };
 
-function startJob(input: RegisterExternalAddressIntentInput = INPUT) {
+/**
+ * `canReconnect: false` stands in for a host with no connection phase to return
+ * to, which the executor signals by withholding `restartExecutor`.
+ */
+function startJob(
+  input: RegisterExternalAddressIntentInput = INPUT,
+  { canReconnect = true }: { canReconnect?: boolean } = {},
+) {
   const subject = new Subject<unknown>();
   const cancel = jest.fn();
   const registerExternalAddress = jest.fn(() => ({ observable: subject.asObservable(), cancel }));
@@ -31,6 +38,7 @@ function startJob(input: RegisterExternalAddressIntentInput = INPUT) {
 
   const states: RegisterExternalAddressJobState[] = [];
   const onResult = jest.fn();
+  const restartExecutor = jest.fn();
   let error: unknown;
   let completed = false;
 
@@ -51,6 +59,7 @@ function startJob(input: RegisterExternalAddressIntentInput = INPUT) {
     },
     input,
     onResult,
+    ...(canReconnect ? { restartExecutor } : {}),
   }).subscribe({
     next: state => states.push(state),
     error: e => {
@@ -64,6 +73,7 @@ function startJob(input: RegisterExternalAddressIntentInput = INPUT) {
   return {
     states,
     onResult,
+    restartExecutor,
     cancel,
     registerExternalAddress,
     subscription,
@@ -304,7 +314,7 @@ describe("registerExternalAddressIntentJob", () => {
     expect(job.onResult).not.toHaveBeenCalled();
   });
 
-  it("GIVEN status word 0x6982 WHEN the device action errors THEN it reports existing-group-verification-failed", () => {
+  it("GIVEN status word 0x6982 WHEN the device action errors THEN it reports existing-group-verification-failed carrying a reconnect handle", () => {
     // GIVEN
     const job = startJob();
     const error = {
@@ -320,7 +330,67 @@ describe("registerExternalAddressIntentJob", () => {
     expect(job.states).toContainEqual({
       type: "existing-group-verification-failed",
       error: expect.objectContaining({ message: "SWO_SECURITY_CONDITION_NOT_SATISFIED" }),
+      reconnect: expect.any(Function),
     });
+  });
+
+  it("GIVEN a wrong device WHEN it is reported THEN the job stays open so the operation survives the device swap", () => {
+    // GIVEN
+    const job = startJob();
+
+    // WHEN
+    job.emit({
+      status: DeviceActionStatus.Error,
+      error: { _tag: "ContactsCommandError", errorCode: "6982", message: "wrong device" },
+    });
+
+    // THEN
+    expect(job.isCompleted()).toBe(false);
+    // Reporting here would reject the port promise the retried run has to settle.
+    expect(job.onResult).not.toHaveBeenCalled();
+  });
+
+  it("GIVEN a wrong device WHEN the reconnect handle is called THEN it restarts the executor", () => {
+    // GIVEN
+    const job = startJob();
+    job.emit({
+      status: DeviceActionStatus.Error,
+      error: { _tag: "ContactsCommandError", errorCode: "6982", message: "wrong device" },
+    });
+    const state = job.states.find(s => s.type === "existing-group-verification-failed");
+
+    // WHEN
+    if (state?.type !== "existing-group-verification-failed") {
+      throw new Error("Expected the job to have reported a wrong device");
+    }
+    state.reconnect?.();
+
+    // THEN
+    expect(job.restartExecutor).toHaveBeenCalled();
+  });
+
+  it("GIVEN no restart affordance WHEN a wrong device is reported THEN it settles as a terminal failure", () => {
+    // GIVEN
+    const job = startJob(INPUT, { canReconnect: false });
+
+    // WHEN
+    job.emit({
+      status: DeviceActionStatus.Error,
+      error: { _tag: "ContactsCommandError", errorCode: "6982", message: "wrong device" },
+    });
+
+    // THEN
+    // Nothing can send this host back to device selection, so leaving the job
+    // open would hang the caller on a recovery it cannot offer.
+    expect(job.states).toContainEqual({
+      type: "existing-group-verification-failed",
+      error: expect.objectContaining({ message: "wrong device" }),
+    });
+    expect(job.onResult).toHaveBeenCalledWith({
+      type: "failure",
+      error: expect.objectContaining({ message: "wrong device" }),
+    });
+    expect(job.isCompleted()).toBe(true);
   });
 
   it("GIVEN status word 0x6984 WHEN the device action errors THEN it reports unsupported-operation", () => {

--- a/features/platform/contacts/src/device/intents/registerExternalAddressIntent/job.test.ts
+++ b/features/platform/contacts/src/device/intents/registerExternalAddressIntent/job.test.ts
@@ -5,7 +5,6 @@ import {
   UserInteractionRequired,
 } from "@ledgerhq/device-management-kit";
 import { Subject } from "rxjs";
-import { ContactDeviceIntentCancelledError } from "../../errors";
 import { registerExternalAddressIntentJob } from "./job";
 import type { RegisterExternalAddressIntentInput, RegisterExternalAddressJobState } from "./types";
 
@@ -291,7 +290,7 @@ describe("registerExternalAddressIntentJob", () => {
     expect(job.isCompleted()).toBe(true);
   });
 
-  it("GIVEN a rejection WHEN the user gives up instead THEN it settles as a cancellation", () => {
+  it("GIVEN a rejection WHEN the job is torn down instead of retried THEN it reports nothing", () => {
     // GIVEN
     const job = startJob();
     job.emit(REJECTION);
@@ -300,10 +299,9 @@ describe("registerExternalAddressIntentJob", () => {
     job.subscription.unsubscribe();
 
     // THEN
-    expect(job.onResult).toHaveBeenCalledWith({
-      type: "failure",
-      error: expect.any(ContactDeviceIntentCancelledError),
-    });
+    // Giving up is the orchestrator's `onUserCancel`, not a teardown: the
+    // executor also tears jobs down on paths that keep the operation alive.
+    expect(job.onResult).not.toHaveBeenCalled();
   });
 
   it("GIVEN status word 0x6982 WHEN the device action errors THEN it reports existing-group-verification-failed", () => {
@@ -392,7 +390,7 @@ describe("registerExternalAddressIntentJob", () => {
     expect(job.isCompleted()).toBe(true);
   });
 
-  it("GIVEN an active registration WHEN the caller unsubscribes before completion THEN it cancels the device action and reports cancellation", () => {
+  it("GIVEN an active registration WHEN the caller unsubscribes before completion THEN it cancels the device action without reporting", () => {
     // GIVEN
     const job = startJob();
 
@@ -401,10 +399,9 @@ describe("registerExternalAddressIntentJob", () => {
 
     // THEN
     expect(job.cancel).toHaveBeenCalled();
-    expect(job.onResult).toHaveBeenCalledWith({
-      type: "failure",
-      error: expect.any(ContactDeviceIntentCancelledError),
-    });
+    // The executor tears the job down whenever it leaves intent execution, so a
+    // report here would settle the flow that a later run is meant to finish.
+    expect(job.onResult).not.toHaveBeenCalled();
   });
 
   it("GIVEN a non-numeric chainId WHEN starting THEN it fails immediately without calling the kit", () => {

--- a/features/platform/contacts/src/device/intents/registerExternalAddressIntent/job.ts
+++ b/features/platform/contacts/src/device/intents/registerExternalAddressIntent/job.ts
@@ -215,5 +215,5 @@ export const registerExternalAddressIntentJob: Job<
         return of<RegisterExternalAddressJobState>({ type: "failed", error: mapped });
       }),
     );
-  }).pipe(reporter.cancelOnUnsubscribe());
+  });
 };

--- a/features/platform/contacts/src/device/intents/registerExternalAddressIntent/job.ts
+++ b/features/platform/contacts/src/device/intents/registerExternalAddressIntent/job.ts
@@ -87,6 +87,7 @@ function createOutcomeMapper(
     input: RegisterExternalAddressIntentInput;
     awaitingConfirmation: RegisterExternalAddressJobState;
     retry: () => void;
+    reconnect?: () => void;
   }>,
 ): (state: RegisterExternalAddressDAState) => Outcome {
   return state => {
@@ -125,11 +126,16 @@ function createOutcomeMapper(
       case DeviceActionStatus.Error: {
         const jobState = mapDeviceActionErrorToFailureJobState(state.error);
 
-        // A rejection is the one failure the user can undo, so it stays open and
-        // carries the replay handle instead of settling the port promise.
-        return jobState.type === "device-rejected"
-          ? { jobState: { ...jobState, retry: params.retry }, terminal: false }
-          : { jobState, terminal: true, report: { type: "failure", error: jobState.error } };
+        // Two failures the user can undo, so both stay open and carry their handle
+        // instead of settling the port promise: a rejection replays on this device,
+        // a wrong device replays on whichever one they connect next.
+        if (jobState.type === "device-rejected") {
+          return { jobState: { ...jobState, retry: params.retry }, terminal: false };
+        }
+        if (jobState.type === "existing-group-verification-failed" && params.reconnect) {
+          return { jobState: { ...jobState, reconnect: params.reconnect }, terminal: false };
+        }
+        return { jobState, terminal: true, report: { type: "failure", error: jobState.error } };
       }
     }
   };
@@ -143,7 +149,7 @@ export const registerExternalAddressIntentJob: Job<
   RegisterExternalAddressJobState,
   RegisterExternalAddressIntentInput,
   ContactIntentResult<RegisterExternalAddressResult>
-> = ({ deviceConnectionResult, deviceExtractedContext, input, onResult }) => {
+> = ({ deviceConnectionResult, deviceExtractedContext, input, onResult, restartExecutor }) => {
   const reporter = createContactIntentResultReporter(onResult);
   const retries = new Subject<void>();
   const retry = () => retries.next();
@@ -154,7 +160,12 @@ export const registerExternalAddressIntentJob: Job<
     deviceName: deviceConnectionResult.compatDeviceName,
   };
 
-  const toOutcome = createOutcomeMapper({ input, awaitingConfirmation, retry });
+  const toOutcome = createOutcomeMapper({
+    input,
+    awaitingConfirmation,
+    retry,
+    ...(restartExecutor ? { reconnect: restartExecutor } : {}),
+  });
 
   return defer(() => {
     let deviceActionInput: RegisterExternalAddressKitInput;

--- a/features/platform/contacts/src/device/intents/renameContactIntent/job.test.ts
+++ b/features/platform/contacts/src/device/intents/renameContactIntent/job.test.ts
@@ -21,7 +21,14 @@ const INPUT: RenameContactIntentInput = {
   hmacProof: "0x0304",
 };
 
-function startJob(input: RenameContactIntentInput = INPUT) {
+/**
+ * `canReconnect: false` stands in for a host with no connection phase to return
+ * to, which the executor signals by withholding `restartExecutor`.
+ */
+function startJob(
+  input: RenameContactIntentInput = INPUT,
+  { canReconnect = true }: { canReconnect?: boolean } = {},
+) {
   const subject = new Subject<unknown>();
   const cancel = jest.fn();
   const renameContact = jest.fn(() => ({ observable: subject.asObservable(), cancel }));
@@ -31,6 +38,7 @@ function startJob(input: RenameContactIntentInput = INPUT) {
 
   const states: RenameContactJobState[] = [];
   const onResult = jest.fn();
+  const restartExecutor = jest.fn();
   let error: unknown;
   let completed = false;
 
@@ -52,6 +60,7 @@ function startJob(input: RenameContactIntentInput = INPUT) {
     },
     input,
     onResult,
+    ...(canReconnect ? { restartExecutor } : {}),
   }).subscribe({
     next: state => states.push(state),
     error: e => {
@@ -65,6 +74,7 @@ function startJob(input: RenameContactIntentInput = INPUT) {
   return {
     states,
     onResult,
+    restartExecutor,
     cancel,
     renameContact,
     registerExternalAddress,
@@ -307,7 +317,7 @@ describe("renameContactIntentJob", () => {
     expect(job.onResult).not.toHaveBeenCalled();
   });
 
-  it("GIVEN status word 0x6982 WHEN the device action errors THEN it reports existing-group-verification-failed", () => {
+  it("GIVEN status word 0x6982 WHEN the device action errors THEN it reports existing-group-verification-failed carrying a reconnect handle", () => {
     // GIVEN
     const job = startJob();
     // Rename always replays the group's existing name proof, so this is how a
@@ -325,6 +335,65 @@ describe("renameContactIntentJob", () => {
     expect(job.states).toContainEqual({
       type: "existing-group-verification-failed",
       error: expect.objectContaining({ message: "SWO_SECURITY_CONDITION_NOT_SATISFIED" }),
+      reconnect: expect.any(Function),
+    });
+  });
+
+  it("GIVEN a wrong device WHEN it is reported THEN the job stays open so the operation survives the device swap", () => {
+    // GIVEN
+    const job = startJob();
+
+    // WHEN
+    job.emit({
+      status: DeviceActionStatus.Error,
+      error: { _tag: "ContactsCommandError", errorCode: "6982", message: "wrong device" },
+    });
+
+    // THEN
+    expect(job.isCompleted()).toBe(false);
+    // Reporting here would reject the port promise the retried run has to settle.
+    expect(job.onResult).not.toHaveBeenCalled();
+  });
+
+  it("GIVEN a wrong device WHEN the reconnect handle is called THEN it restarts the executor", () => {
+    // GIVEN
+    const job = startJob();
+    job.emit({
+      status: DeviceActionStatus.Error,
+      error: { _tag: "ContactsCommandError", errorCode: "6982", message: "wrong device" },
+    });
+    const state = job.states.find(s => s.type === "existing-group-verification-failed");
+
+    // WHEN
+    if (state?.type !== "existing-group-verification-failed") {
+      throw new Error("Expected the job to have reported a wrong device");
+    }
+    state.reconnect?.();
+
+    // THEN
+    expect(job.restartExecutor).toHaveBeenCalled();
+  });
+
+  it("GIVEN no restart affordance WHEN a wrong device is reported THEN it settles as a terminal failure", () => {
+    // GIVEN
+    const job = startJob(INPUT, { canReconnect: false });
+
+    // WHEN
+    job.emit({
+      status: DeviceActionStatus.Error,
+      error: { _tag: "ContactsCommandError", errorCode: "6982", message: "wrong device" },
+    });
+
+    // THEN
+    // Nothing can send this host back to device selection, so leaving the job
+    // open would hang the caller on a recovery it cannot offer.
+    expect(job.states).toContainEqual({
+      type: "existing-group-verification-failed",
+      error: expect.objectContaining({ message: "wrong device" }),
+    });
+    expect(job.onResult).toHaveBeenCalledWith({
+      type: "failure",
+      error: expect.objectContaining({ message: "wrong device" }),
     });
   });
 

--- a/features/platform/contacts/src/device/intents/renameContactIntent/job.test.ts
+++ b/features/platform/contacts/src/device/intents/renameContactIntent/job.test.ts
@@ -5,7 +5,6 @@ import {
   UserInteractionRequired,
 } from "@ledgerhq/device-management-kit";
 import { Subject } from "rxjs";
-import { ContactDeviceIntentCancelledError } from "../../errors";
 import { renameContactIntentJob } from "./job";
 import type { RenameContactIntentInput, RenameContactJobState } from "./types";
 
@@ -294,7 +293,7 @@ describe("renameContactIntentJob", () => {
     expect(job.isCompleted()).toBe(true);
   });
 
-  it("GIVEN a rejection WHEN the user gives up instead THEN it settles as a cancellation", () => {
+  it("GIVEN a rejection WHEN the job is torn down instead of retried THEN it reports nothing", () => {
     // GIVEN
     const job = startJob();
     job.emit(REJECTION);
@@ -303,10 +302,9 @@ describe("renameContactIntentJob", () => {
     job.subscription.unsubscribe();
 
     // THEN
-    expect(job.onResult).toHaveBeenCalledWith({
-      type: "failure",
-      error: expect.any(ContactDeviceIntentCancelledError),
-    });
+    // Giving up is the orchestrator's `onUserCancel`, not a teardown: the
+    // executor also tears jobs down on paths that keep the operation alive.
+    expect(job.onResult).not.toHaveBeenCalled();
   });
 
   it("GIVEN status word 0x6982 WHEN the device action errors THEN it reports existing-group-verification-failed", () => {
@@ -410,7 +408,7 @@ describe("renameContactIntentJob", () => {
     expect(job.states).toContainEqual({ type: "invalid-input", error: expect.any(Error) });
   });
 
-  it("GIVEN an active rename WHEN the caller unsubscribes before completion THEN it cancels the device action and reports cancellation", () => {
+  it("GIVEN an active rename WHEN the caller unsubscribes before completion THEN it cancels the device action without reporting", () => {
     // GIVEN
     const job = startJob();
 
@@ -419,10 +417,9 @@ describe("renameContactIntentJob", () => {
 
     // THEN
     expect(job.cancel).toHaveBeenCalled();
-    expect(job.onResult).toHaveBeenCalledWith({
-      type: "failure",
-      error: expect.any(ContactDeviceIntentCancelledError),
-    });
+    // The executor tears the job down whenever it leaves intent execution, so a
+    // report here would settle the flow that a later run is meant to finish.
+    expect(job.onResult).not.toHaveBeenCalled();
   });
 
   it("GIVEN the device action is stopped WHEN reported THEN it reports failure", () => {

--- a/features/platform/contacts/src/device/intents/renameContactIntent/job.ts
+++ b/features/platform/contacts/src/device/intents/renameContactIntent/job.ts
@@ -193,5 +193,5 @@ export const renameContactIntentJob: Job<
         return of<RenameContactJobState>({ type: "failed", error: mapped });
       }),
     );
-  }).pipe(reporter.cancelOnUnsubscribe());
+  });
 };

--- a/features/platform/contacts/src/device/intents/renameContactIntent/job.ts
+++ b/features/platform/contacts/src/device/intents/renameContactIntent/job.ts
@@ -61,6 +61,7 @@ function createOutcomeMapper(
   params: Readonly<{
     awaitingConfirmation: RenameContactJobState;
     retry: () => void;
+    reconnect?: () => void;
   }>,
 ): (state: RenameContactDAState) => Outcome {
   return state => {
@@ -103,11 +104,16 @@ function createOutcomeMapper(
       case DeviceActionStatus.Error: {
         const jobState = mapDeviceActionErrorToFailureJobState(state.error);
 
-        // A rejection is the one failure the user can undo, so it stays open and
-        // carries the replay handle instead of settling the port promise.
-        return jobState.type === "device-rejected"
-          ? { jobState: { ...jobState, retry: params.retry }, terminal: false }
-          : { jobState, terminal: true, report: { type: "failure", error: jobState.error } };
+        // Two failures the user can undo, so both stay open and carry their handle
+        // instead of settling the port promise: a rejection replays on this device,
+        // a wrong device replays on whichever one they connect next.
+        if (jobState.type === "device-rejected") {
+          return { jobState: { ...jobState, retry: params.retry }, terminal: false };
+        }
+        if (jobState.type === "existing-group-verification-failed" && params.reconnect) {
+          return { jobState: { ...jobState, reconnect: params.reconnect }, terminal: false };
+        }
+        return { jobState, terminal: true, report: { type: "failure", error: jobState.error } };
       }
     }
   };
@@ -125,7 +131,7 @@ export const renameContactIntentJob: Job<
   RenameContactJobState,
   RenameContactIntentInput,
   ContactIntentResult<RenameContactResult>
-> = ({ deviceConnectionResult, deviceExtractedContext, input, onResult }) => {
+> = ({ deviceConnectionResult, deviceExtractedContext, input, onResult, restartExecutor }) => {
   const reporter = createContactIntentResultReporter(onResult);
   const retries = new Subject<void>();
   const retry = () => retries.next();
@@ -136,7 +142,11 @@ export const renameContactIntentJob: Job<
     deviceName: deviceConnectionResult.compatDeviceName,
   };
 
-  const toOutcome = createOutcomeMapper({ awaitingConfirmation, retry });
+  const toOutcome = createOutcomeMapper({
+    awaitingConfirmation,
+    retry,
+    ...(restartExecutor ? { reconnect: restartExecutor } : {}),
+  });
 
   return defer(() => {
     let deviceActionInput: RenameContactKitInput;

--- a/features/platform/contacts/src/device/intents/resultReporter.test.ts
+++ b/features/platform/contacts/src/device/intents/resultReporter.test.ts
@@ -1,63 +1,30 @@
-import { NEVER, of, throwError } from "rxjs";
-import { ContactDeviceIntentCancelledError } from "../../contactDeviceIntentsPort";
 import { createContactIntentResultReporter, type ContactIntentResult } from "./resultReporter";
 
 describe("createContactIntentResultReporter", () => {
-  it("GIVEN a reported success WHEN the observable finalizes THEN it keeps the success as the only result", () => {
+  it("GIVEN nothing reported yet WHEN a result is reported THEN it forwards that result", () => {
     // GIVEN
     const onResult = jest.fn<void, [ContactIntentResult<string>]>();
     const reporter = createContactIntentResultReporter(onResult);
-    reporter.report({ type: "success", result: "proof" });
 
     // WHEN
-    of(undefined).pipe(reporter.cancelOnUnsubscribe()).subscribe();
+    reporter.report({ type: "success", result: "proof" });
 
     // THEN
     expect(onResult).toHaveBeenCalledTimes(1);
     expect(onResult).toHaveBeenCalledWith({ type: "success", result: "proof" });
   });
 
-  it("GIVEN no reported result WHEN the observable is unsubscribed THEN it reports cancellation", () => {
+  it("GIVEN a reported success WHEN a later result is reported THEN it keeps the first as the only result", () => {
     // GIVEN
     const onResult = jest.fn<void, [ContactIntentResult<string>]>();
     const reporter = createContactIntentResultReporter(onResult);
-    const subscription = NEVER.pipe(reporter.cancelOnUnsubscribe()).subscribe();
+    reporter.report({ type: "success", result: "proof" });
 
     // WHEN
-    subscription.unsubscribe();
+    reporter.report({ type: "failure", error: new Error("late failure") });
 
     // THEN
     expect(onResult).toHaveBeenCalledTimes(1);
-    expect(onResult.mock.calls[0]?.[0]).toEqual({
-      type: "failure",
-      error: expect.any(ContactDeviceIntentCancelledError),
-    });
-  });
-
-  it("GIVEN no reported result WHEN the observable completes THEN it leaves missing-result handling to the orchestrator", () => {
-    // GIVEN
-    const onResult = jest.fn<void, [ContactIntentResult<string>]>();
-    const reporter = createContactIntentResultReporter(onResult);
-
-    // WHEN
-    of(undefined).pipe(reporter.cancelOnUnsubscribe()).subscribe();
-
-    // THEN
-    expect(onResult).not.toHaveBeenCalled();
-  });
-
-  it("GIVEN no reported result WHEN the observable errors THEN it leaves fallback handling to the executor", () => {
-    // GIVEN
-    const onResult = jest.fn<void, [ContactIntentResult<string>]>();
-    const reporter = createContactIntentResultReporter(onResult);
-    const error = new Error("unexpected error");
-
-    // WHEN
-    throwError(() => error)
-      .pipe(reporter.cancelOnUnsubscribe())
-      .subscribe({ error: () => undefined });
-
-    // THEN
-    expect(onResult).not.toHaveBeenCalled();
+    expect(onResult).toHaveBeenCalledWith({ type: "success", result: "proof" });
   });
 });

--- a/features/platform/contacts/src/device/intents/resultReporter.ts
+++ b/features/platform/contacts/src/device/intents/resultReporter.ts
@@ -1,55 +1,28 @@
-import { finalize, tap, type MonoTypeOperatorFunction } from "rxjs";
-import { ContactDeviceIntentCancelledError } from "../errors";
-
 export type ContactIntentResult<Value> =
   | { readonly type: "success"; readonly result: Value }
   | { readonly type: "failure"; readonly error: Error };
 
 /**
- * Reports one terminal intent result so consumers awaiting `onResult` always settle.
- * An unsubscribe before normal completion is reported as a cancellation failure.
+ * Reports at most one terminal intent result per job run.
+ *
+ * A teardown before the job reports settles nothing: the executor tears jobs down
+ * whenever it leaves intent execution and keeps the operation alive, so a later run
+ * can still report. Dismissal is what settles the flow's promise.
  */
 export function createContactIntentResultReporter<Value>(
   onResult: (result: ContactIntentResult<Value>) => void,
 ): Readonly<{
   report: (result: ContactIntentResult<Value>) => void;
-  cancelOnUnsubscribe: <JobState>() => MonoTypeOperatorFunction<JobState>;
 }> {
   let hasReported = false;
 
-  const report = (result: ContactIntentResult<Value>) => {
-    if (hasReported) {
-      return;
-    }
-    hasReported = true;
-    onResult(result);
-  };
-
-  const cancelIfPending = () => {
-    report({ type: "failure", error: new ContactDeviceIntentCancelledError() });
-  };
-
   return {
-    report,
-    cancelOnUnsubscribe:
-      <JobState>() =>
-      source => {
-        let hasTerminated = false;
-        return source.pipe(
-          tap({
-            complete: () => {
-              hasTerminated = true;
-            },
-            error: () => {
-              hasTerminated = true;
-            },
-          }),
-          finalize(() => {
-            if (!hasTerminated) {
-              cancelIfPending();
-            }
-          }),
-        );
-      },
+    report: (result: ContactIntentResult<Value>) => {
+      if (hasReported) {
+        return;
+      }
+      hasReported = true;
+      onResult(result);
+    },
   };
 }

--- a/features/platform/contacts/src/device/useContactsIntentsOrchestrator.ts
+++ b/features/platform/contacts/src/device/useContactsIntentsOrchestrator.ts
@@ -137,9 +137,9 @@ export function useContactsIntentsOrchestrator({
         setActiveIntent({
           intent: intent as unknown as ContactDeviceIntent,
           initializationInput: operation.initializationInput,
-          // Dismissed (or unmounted) before the job settled: nothing else will
-          // settle the promise. Clearing `activeIntent` is the dismissal's own
-          // job, not this callback's.
+          // Dismissed, unmounted, or the executor stopped before the job
+          // settled: nothing else will settle the promise. Clearing
+          // `activeIntent` is the dismissal's own job, not this callback's.
           cancel: () => fail(new ContactDeviceIntentCancelledError()),
         });
       }),
@@ -190,6 +190,9 @@ export function useContactsIntentsOrchestrator({
       intentComponentExtraProps: undefined,
       onExecutorStateChanged: () => undefined,
       onUserCancel: cancel,
+      // Jobs no longer settle on their own teardown, so this is what keeps the
+      // promise from hanging once no later run can report.
+      onExecutorStopped: activeIntent.cancel,
       cancelIntentRequestId: undefined,
       initializerConfig: { dependencies: { getMinVersion } },
     };

--- a/features/platform/contacts/src/device/useContactsIntentsOrchestrator.web.test.ts
+++ b/features/platform/contacts/src/device/useContactsIntentsOrchestrator.web.test.ts
@@ -315,6 +315,45 @@ describe("useContactsIntentsOrchestrator", () => {
     expect(result.current.dieProps).toBeUndefined();
   });
 
+  it("GIVEN an active operation WHEN the executor reports it stopped THEN it rejects the active request", async () => {
+    // GIVEN
+    const { result } = renderHook(() => useContactsIntentsOrchestrator({ intents }));
+    let request!: ReturnType<typeof startRegisterExternalAddress>;
+    act(() => {
+      request = startRegisterExternalAddress(result.current);
+    });
+    const dieProps = getActiveDieProps(result.current);
+
+    // WHEN
+    act(() => {
+      dieProps.onExecutorStopped?.();
+    });
+
+    // THEN
+    await expect(request.promise).rejects.toBeInstanceOf(ContactDeviceIntentCancelledError);
+  });
+
+  it("GIVEN a stopped executor WHEN a later run reports success THEN it keeps the rejection", async () => {
+    // GIVEN
+    const { result } = renderHook(() => useContactsIntentsOrchestrator({ intents }));
+    let request!: ReturnType<typeof startRegisterExternalAddress>;
+    act(() => {
+      request = startRegisterExternalAddress(result.current);
+    });
+    const dieProps = getActiveDieProps(result.current);
+    act(() => {
+      dieProps.onExecutorStopped?.();
+    });
+
+    // WHEN
+    act(() => {
+      dieProps.intent.onResult?.(registerExternalAddressSuccessResult(request));
+    });
+
+    // THEN
+    await expect(request.promise).rejects.toBeInstanceOf(ContactDeviceIntentCancelledError);
+  });
+
   it("GIVEN a job has not started WHEN the Contacts surface unmounts THEN it rejects the active request", async () => {
     // GIVEN
     const { result, unmount } = renderHook(() => useContactsIntentsOrchestrator({ intents }));

--- a/features/platform/device-intent/README.md
+++ b/features/platform/device-intent/README.md
@@ -1222,10 +1222,32 @@ The executor reports progress and lifecycle changes through callback props:
 | `onIntentJobStateChanged(jobState)` | Optional. The running job's observable emits a new `JobState` value (UI / observability only).                                                            |
 | `onIntentJobComplete()`             | Optional. The job observable completes (no more emissions). The executor transitions to `idle`.                                                           |
 | `onIntentJobError(error)`           | Optional. The job observable errors. The executor transitions to `executingIntentError`.                                                                  |
+| `onExecutorStopped()`               | Optional. The executor is destroyed: the component unmounts, or `enabled` flips to `false`. See below.                                                    |
 
 All callbacks use refs internally, so the executor always calls the **latest**
 version of each callback without needing to be recreated when the callback
 identity changes.
+
+##### `onExecutorStopped` and job teardown
+
+The executor terminates the running job on several paths, and only some of them
+end the operation. It tears a job down and **stays alive** when it leaves intent
+execution — handling a device disconnection, or restarting into device
+connection — and in each of those the current intent is kept, so a later run of
+the same job can still report an outcome.
+
+`onExecutorStopped` fires only on the paths where the executor itself goes away
+and no later run is possible. A caller awaiting an intent outcome (e.g. holding
+a promise it resolves from `onResult`) must settle it here, and must **not**
+settle on job teardown alone: doing so rejects the caller before a retry has
+had its chance, and the retry's eventual result is then discarded as a late
+duplicate.
+
+> [!WARNING]
+> The callback is unmount-scoped, so an effect that mounts, cleans up and
+> remounts — React `StrictMode`'s double-invoke — reports a stop for a job that
+> is about to run again. Neither wallet app enables `StrictMode` today; enabling
+> it would need this revisited.
 
 #### Intent-level callbacks (on `Intent`)
 

--- a/features/platform/device-intent/README.md
+++ b/features/platform/device-intent/README.md
@@ -52,6 +52,7 @@ See the [ADR: Device Intent Executor component](https://ledgerhq.atlassian.net/w
   - [Job completion contract](#job-completion-contract)
   - [Changing `deviceInitializationInput` and `intent` together](#changing-deviceinitializationinput-and-intent-together)
   - [Observability: callbacks](#observability-callbacks)
+  - [Restarting on a different device](#restarting-on-a-different-device)
   - [Cancelling an intent](#cancelling-an-intent)
   - [Enabling / disabling](#enabling--disabling)
   - [Idle state and `lastIntentSnapshot`](#idle-state-and-lastintentsnapshot)
@@ -1287,6 +1288,48 @@ derived address) run before a cross-cutting executor callback reads it.
 Intent-level callbacks are useful for orchestrating multi-intent flows where
 each phase needs its own reaction logic, while executor-level callbacks handle
 cross-cutting concerns (updating global state, logging, debug UI).
+
+### Restarting on a different device
+
+A job whose failure is "this is the wrong device" can send the executor back to
+the connection phase, keeping the current intent. Call the `restartExecutor`
+param the job receives — surface it in a `JobState` so the component can offer
+it as a CTA, the way `device-rejected` states carry a `retry`:
+
+```typescript
+const job: Job<MyState, MyInput> = ({ input, restartExecutor }) =>
+  runDeviceAction(input).pipe(
+    map(state =>
+      state.type === "wrong-device" && restartExecutor
+        ? { ...state, reconnect: restartExecutor }
+        : state,
+    ),
+  );
+```
+
+The executor then:
+
+- disconnects the DMK session of the device it is leaving,
+- tears the job down (see [`onExecutorStopped`](#onexecutorstopped-and-job-teardown):
+  this is a teardown that keeps the operation alive, so awaiting callers must not
+  settle),
+- re-enters device connection with **auto-connect suppressed** — no reusing a live
+  session, no preselecting the only known device, no connecting to a lone
+  discovery — because every one of those would land back on the refused device.
+  Suppression stays on for the rest of the executor's life. Tapping a device still
+  connects: that choice is explicit.
+- runs the same job again once the new device is connected and initialised.
+
+Only accepted while a job is running or from idle. `restartExecutor` is optional
+precisely because a host may have no connection phase to return to (the CLI
+drives jobs directly); guard on it and offer no CTA when it is absent.
+
+> [!NOTE]
+> Desktop identifies known devices by model, not by unit
+> (`knownDevices.ts`: WebHID exposes no stable per-device id worth persisting), so
+> two devices of the same model are one entry in the picker. The restart cannot
+> exclude the refused unit there — it can only stop connecting to it on the
+> executor's own initiative, leaving the choice to the user.
 
 ### Cancelling an intent
 

--- a/features/platform/device-intent/src/DeviceIntentExecutor.test.tsx
+++ b/features/platform/device-intent/src/DeviceIntentExecutor.test.tsx
@@ -342,7 +342,7 @@ describe("DeviceIntentExecutor (unit)", () => {
       const mockConfig = makeMockPlatformConfig();
       const onConnected = jest.fn();
       const onClose = jest.fn();
-      const deviceConnectionParams = { acceptedDeviceModelIds: [] };
+      const deviceConnectionParams = { acceptedDeviceModelIds: [], disableAutoConnect: false };
       const props = makeUnitProps(
         {
           phase: "deviceConnection",

--- a/features/platform/device-intent/src/DeviceIntentExecutorStateMachine.test.ts
+++ b/features/platform/device-intent/src/DeviceIntentExecutorStateMachine.test.ts
@@ -98,8 +98,14 @@ describe("DeviceIntentExecutorStateMachine", () => {
       sm.start();
 
       // THEN
-      expect(listeners.onExecutorStateChanged).toHaveBeenCalledWith({ type: "connectingDevice" });
-      expect(lastExecutorState(listeners)).toEqual({ type: "connectingDevice" });
+      expect(listeners.onExecutorStateChanged).toHaveBeenCalledWith({
+        type: "connectingDevice",
+        disableAutoConnect: false,
+      });
+      expect(lastExecutorState(listeners)).toEqual({
+        type: "connectingDevice",
+        disableAutoConnect: false,
+      });
       sm.stop();
     });
 
@@ -195,7 +201,10 @@ describe("DeviceIntentExecutorStateMachine", () => {
       });
 
       sm.retry();
-      expect(lastExecutorState(listeners)).toEqual({ type: "connectingDevice" });
+      expect(lastExecutorState(listeners)).toEqual({
+        type: "connectingDevice",
+        disableAutoConnect: false,
+      });
       sm.stop();
     });
   });
@@ -260,6 +269,7 @@ describe("DeviceIntentExecutorStateMachine", () => {
         deviceExtractedContext: extractedContext,
         input: jobInput,
         onResult: expect.any(Function),
+        restartExecutor: expect.any(Function),
       });
       sm.stop();
     });
@@ -536,13 +546,115 @@ describe("DeviceIntentExecutorStateMachine", () => {
     });
   });
 
+  describe("GIVEN a job restarts the executor", () => {
+    /**
+     * `restartExecutor` reaches a job through its params only, so the tests grab
+     * the handle from the running job and fire it the way its CTA would.
+     */
+    function createRestartableSM(job?: Job<unknown, unknown>) {
+      let restart: (() => void) | undefined;
+      const connectionResult = makeConnectionResult();
+      const { sm, listeners } = createSM({
+        job: params => {
+          restart = params.restartExecutor;
+          return job ? job(params) : NEVER;
+        },
+      });
+      driveToExecution(sm, connectionResult);
+      if (restart === undefined) {
+        throw new Error("Expected the running job to receive restartExecutor");
+      }
+      return { sm, listeners, connectionResult, restart };
+    }
+
+    it("WHEN RESTART is received during intent execution THEN it returns to connectingDevice with auto-connect disabled", () => {
+      const { sm, listeners, restart } = createRestartableSM();
+      expect(lastExecutorState(listeners)).toMatchObject({ type: "executingIntent" });
+
+      restart();
+      expect(lastExecutorState(listeners)).toEqual({
+        type: "connectingDevice",
+        disableAutoConnect: true,
+      });
+      sm.stop();
+    });
+
+    it("WHEN RESTART is received THEN it disconnects the device it is leaving", () => {
+      const { sm, connectionResult, restart } = createRestartableSM();
+
+      restart();
+      expect(connectionResult.dmk.disconnect).toHaveBeenCalledWith({
+        sessionId: connectionResult.sessionId,
+      });
+      sm.stop();
+    });
+
+    it("WHEN RESTART is received THEN the job observable is auto-cancelled", async () => {
+      let unsubscribed = false;
+      const { sm, restart } = createRestartableSM(
+        () =>
+          new Observable<TestJobState>(() => () => {
+            unsubscribed = true;
+          }),
+      );
+      await flushMicrotasks();
+      expect(unsubscribed).toBe(false);
+
+      restart();
+      await flushMicrotasks();
+      expect(unsubscribed).toBe(true);
+      sm.stop();
+    });
+
+    it("WHEN RESTART is received again from connectingDevice THEN it is a no-op", () => {
+      const { sm, listeners, restart } = createRestartableSM();
+      restart();
+      const statesAfterRestart = listeners.executorStates.length;
+
+      restart();
+      // Re-entering would reset the connection component the user is working in.
+      expect(listeners.executorStates).toHaveLength(statesAfterRestart);
+      sm.stop();
+    });
+
+    it("WHEN RESTART is received from idle THEN it returns to connectingDevice with auto-connect disabled", () => {
+      const { sm, listeners, restart } = createRestartableSM(() => of({ step: "done" as const }));
+      expect(lastExecutorState(listeners)).toEqual({ type: "idle" });
+
+      restart();
+      expect(lastExecutorState(listeners)).toEqual({
+        type: "connectingDevice",
+        disableAutoConnect: true,
+      });
+      sm.stop();
+    });
+
+    it("GIVEN a restart WHEN a device connects and the job runs again THEN auto-connect stays disabled", () => {
+      const { sm, listeners, restart } = createRestartableSM();
+      restart();
+
+      driveToExecution(sm);
+      expect(lastExecutorState(listeners)).toMatchObject({ type: "executingIntent" });
+
+      restart();
+      expect(lastExecutorState(listeners)).toEqual({
+        type: "connectingDevice",
+        disableAutoConnect: true,
+      });
+      sm.stop();
+    });
+  });
+
   describe("end-to-end: happy path", () => {
     it("GIVEN a fresh machine WHEN connect, init, execute, complete THEN it goes through all phases to idle", async () => {
       const subject = new Subject<TestJobState>();
       const intent = makeIntent(() => subject.asObservable());
       const { sm, listeners } = createSM({ intent });
 
-      expect(lastExecutorState(listeners)).toEqual({ type: "connectingDevice" });
+      expect(lastExecutorState(listeners)).toEqual({
+        type: "connectingDevice",
+        disableAutoConnect: false,
+      });
 
       sm.deviceConnected(makeConnectionResult());
       expect(lastExecutorState(listeners)).toMatchObject({ type: "initializingDeviceContext" });
@@ -651,7 +763,10 @@ describe("DeviceIntentExecutorStateMachine", () => {
       });
 
       sm.retry();
-      expect(lastExecutorState(listeners)).toEqual({ type: "connectingDevice" });
+      expect(lastExecutorState(listeners)).toEqual({
+        type: "connectingDevice",
+        disableAutoConnect: false,
+      });
 
       sm.deviceConnected(makeConnectionResult("session-2"));
       expect(lastExecutorState(listeners)).toMatchObject({ type: "initializingDeviceContext" });

--- a/features/platform/device-intent/src/DeviceIntentExecutorStateMachine.ts
+++ b/features/platform/device-intent/src/DeviceIntentExecutorStateMachine.ts
@@ -43,6 +43,12 @@ type MachineContext<JobState, Input, ExtraProps, Result> = {
   currentIntent: Intent<JobState, Input, ExtraProps, Result>;
   deviceConnectionResult: DeviceConnectionResult | null;
   deviceExtractedContext: DeviceExtractedContext | null;
+  /**
+   * Set once a `RESTART` has sent the machine back to device connection, and
+   * never cleared: after the user has asked to change device, picking the next
+   * one stays their explicit choice for the rest of this executor's life.
+   */
+  disableAutoConnect: boolean;
   error: unknown;
 };
 
@@ -53,7 +59,8 @@ type MachineEvent<JobState, Input, ExtraProps, Result> =
   | { type: "RETRY" }
   | { type: "SET_INTENT"; intent: Intent<JobState, Input, ExtraProps, Result> }
   | { type: "REINITIALIZE" }
-  | { type: "STOP_INTENT" };
+  | { type: "STOP_INTENT" }
+  | { type: "RESTART" };
 
 type MachineInput<JobState, Input, ExtraProps, Result> = {
   deviceConnectionParams: DeviceConnectionParams;
@@ -67,11 +74,13 @@ type JobInvokeInput<JobState, Input, Result> = {
     deviceExtractedContext: DeviceExtractedContext;
     input: Input;
     onResult: (result: Result) => void;
+    restartExecutor?: () => void;
   }) => Observable<JobState>;
   deviceConnectionResult: DeviceConnectionResult;
   deviceExtractedContext: DeviceExtractedContext;
   intentInput: Input;
   onResult: (result: Result) => void;
+  restartExecutor: () => void;
 };
 
 // ---- Machine factory ----
@@ -91,6 +100,7 @@ function createExecutorMachine<JobState, Input, ExtraProps, Result>() {
           deviceExtractedContext: input.deviceExtractedContext,
           input: input.intentInput,
           onResult: input.onResult,
+          restartExecutor: input.restartExecutor,
         }),
       ),
     },
@@ -106,6 +116,17 @@ function createExecutorMachine<JobState, Input, ExtraProps, Result>() {
         deviceExtractedContext: () => null,
         error: () => null,
       }),
+      // Ordered before `resetConnection`, which clears what this reads. Leaving the
+      // session live would let the connection phase reuse the very device the job
+      // just refused; the machine is already leaving `intentExecution`, so the
+      // resulting NOT_CONNECTED lands on `deviceConnection`, which ignores it.
+      disconnectCurrentDevice: ({ context }) => {
+        const connection = context.deviceConnectionResult;
+        if (!connection) return;
+        connection.dmk.disconnect({ sessionId: connection.sessionId }).catch((error: unknown) => {
+          log(LOG_TYPE, "failed to disconnect the refused device", { error });
+        });
+      },
     },
   }).createMachine({
     id: "DeviceIntentExecutor",
@@ -116,13 +137,17 @@ function createExecutorMachine<JobState, Input, ExtraProps, Result>() {
       currentIntent: input.intent,
       deviceConnectionResult: null,
       deviceExtractedContext: null,
+      disableAutoConnect: false,
       error: null,
     }),
     states: {
       deviceConnection: {
         entry: ({ context }) => {
           log(LOG_TYPE, "state: deviceConnection");
-          context.listeners.onExecutorStateChanged({ type: "connectingDevice" });
+          context.listeners.onExecutorStateChanged({
+            type: "connectingDevice",
+            disableAutoConnect: context.disableAutoConnect,
+          });
         },
         on: {
           DEVICE_CONNECTED: {
@@ -131,6 +156,10 @@ function createExecutorMachine<JobState, Input, ExtraProps, Result>() {
               deviceConnectionResult: ({ event }) => event.result,
             }),
           },
+          // Already where a restart leads. Handled explicitly so a second request
+          // is a stated no-op rather than an event the machine silently drops,
+          // and so it cannot re-enter and reset the connection component.
+          RESTART: {},
         },
       },
       deviceDisconnected: {
@@ -189,12 +218,13 @@ function createExecutorMachine<JobState, Input, ExtraProps, Result>() {
         },
         invoke: {
           src: "executeJob",
-          input: ({ context }) => ({
+          input: ({ context, self }) => ({
             job: context.currentIntent.job,
             deviceConnectionResult: context.deviceConnectionResult!,
             deviceExtractedContext: context.deviceExtractedContext!,
             intentInput: context.currentIntent.input,
             onResult: context.currentIntent.onResult ?? (() => undefined),
+            restartExecutor: () => self.send({ type: "RESTART" }),
           }),
           onSnapshot: {
             actions: ({ event, context }) => {
@@ -240,6 +270,14 @@ function createExecutorMachine<JobState, Input, ExtraProps, Result>() {
             actions: assign({
               error: () => new Error("REINITIALIZE received during intent execution"),
             }),
+          },
+          RESTART: {
+            target: "deviceConnection",
+            actions: [
+              "disconnectCurrentDevice",
+              "resetConnection",
+              assign({ disableAutoConnect: () => true }),
+            ],
           },
         },
       },
@@ -303,6 +341,14 @@ function createExecutorMachine<JobState, Input, ExtraProps, Result>() {
             actions: assign({
               deviceExtractedContext: () => null,
             }),
+          },
+          RESTART: {
+            target: "deviceConnection",
+            actions: [
+              "disconnectCurrentDevice",
+              "resetConnection",
+              assign({ disableAutoConnect: () => true }),
+            ],
           },
         },
       },

--- a/features/platform/device-intent/src/__tests__/test-utils.tsx
+++ b/features/platform/device-intent/src/__tests__/test-utils.tsx
@@ -39,7 +39,9 @@ export const makeIntent = (
 });
 
 export const makeConnectionResult = (sessionId = "session-1"): DeviceConnectionResult => ({
-  dmk: {} as DeviceConnectionResult["dmk"],
+  // `disconnect` is stubbed because restarting the executor calls it on the
+  // device it is leaving behind.
+  dmk: { disconnect: jest.fn(() => Promise.resolve()) } as unknown as DeviceConnectionResult["dmk"],
   sessionId,
   connectedDevice: {} as DeviceConnectionResult["connectedDevice"],
   compatDeviceId: "compat-1",

--- a/features/platform/device-intent/src/core.ts
+++ b/features/platform/device-intent/src/core.ts
@@ -16,6 +16,15 @@ export type DeviceConnectionParams = {
 };
 
 /**
+ * What the connection component receives: the caller's params plus the executor's
+ * own flags. `disableAutoConnect` is owned by the executor — it sets it when a job
+ * sent it back here to pick a different device — so callers cannot configure it.
+ */
+export type DeviceConnectionComponentParams = DeviceConnectionParams & {
+  disableAutoConnect: boolean;
+};
+
+/**
  * Result of a successful device connection, providing everything needed to
  * interact with the device during intent execution.
  */
@@ -65,6 +74,17 @@ export type Job<JobState, Input = undefined, Result = undefined> = (params: {
   deviceExtractedContext: DeviceExtractedContext;
   input: Input;
   onResult: (result: Result) => void;
+  /**
+   * Sends the executor back to device connection, keeping this intent. The job is
+   * torn down and re-run once another device is connected and initialised, so the
+   * same operation continues there. The current session is disconnected and that
+   * pass requires an explicit device choice.
+   *
+   * Optional because a host may drive a job with no connection phase to return to
+   * (the CLI). Surface it in a `JobState` only when present, so such a host renders
+   * no reconnect affordance rather than a dead one.
+   */
+  restartExecutor?: () => void;
 }) => Observable<JobState>;
 
 /**

--- a/features/platform/device-intent/src/deriveHookState.test.ts
+++ b/features/platform/device-intent/src/deriveHookState.test.ts
@@ -44,15 +44,27 @@ describe("deriveHookState", () => {
       onConnected,
       onUserCancel,
     });
-    const state: ExecutorState = { type: "connectingDevice" };
+    const state: ExecutorState = { type: "connectingDevice", disableAutoConnect: false };
 
     const result = deriveHookState(state, params);
 
     expect(result).toEqual({
       phase: "deviceConnection",
-      deviceConnectionParams,
+      deviceConnectionParams: { ...deviceConnectionParams, disableAutoConnect: false },
       onConnected,
       onClose: onUserCancel,
+    });
+  });
+
+  it("maps a restarted connectingDevice to deviceConnection phase with auto-connect disabled", () => {
+    const params = makeParams({ deviceConnectionParams: { acceptedDeviceModelIds: [] } });
+    const state: ExecutorState = { type: "connectingDevice", disableAutoConnect: true };
+
+    const result = deriveHookState(state, params);
+
+    expect(result).toMatchObject({
+      phase: "deviceConnection",
+      deviceConnectionParams: { acceptedDeviceModelIds: [], disableAutoConnect: true },
     });
   });
 
@@ -216,7 +228,7 @@ describe("deriveHookState", () => {
     const params = makeParams({ onUserCancel });
 
     const phases: ExecutorState[] = [
-      { type: "connectingDevice" },
+      { type: "connectingDevice", disableAutoConnect: false },
       { type: "deviceDisconnected", device: defaultDevice },
       {
         type: "initializingDeviceContext",

--- a/features/platform/device-intent/src/deriveHookState.ts
+++ b/features/platform/device-intent/src/deriveHookState.ts
@@ -1,6 +1,7 @@
 import type React from "react";
 import type { ConnectedDevice } from "@ledgerhq/device-management-kit";
 import type {
+  DeviceConnectionComponentParams,
   DeviceConnectionParams,
   DeviceConnectionResult,
   DeviceExtractedContext,
@@ -22,7 +23,7 @@ export type IntentExecutionSnapshot<JobState, ExtraProps> = {
 export type DeviceIntentExecutorHookState<JobState, _Input, ExtraProps, InitInput> =
   | {
       phase: "deviceConnection";
-      deviceConnectionParams: DeviceConnectionParams;
+      deviceConnectionParams: DeviceConnectionComponentParams;
       onConnected: (result: DeviceConnectionResult) => void;
       onClose: () => void;
     }
@@ -94,7 +95,12 @@ export function deriveHookState<JobState, Input, ExtraProps, InitInput>(
     case "connectingDevice":
       return {
         phase: "deviceConnection",
-        deviceConnectionParams: params.deviceConnectionParams,
+        // Built here rather than taken from the caller's prop, so the executor
+        // stays the only owner of `disableAutoConnect`.
+        deviceConnectionParams: {
+          ...params.deviceConnectionParams,
+          disableAutoConnect: executorState.disableAutoConnect,
+        },
         onConnected: params.onConnected,
         onClose: params.onUserCancel,
       };

--- a/features/platform/device-intent/src/executor.ts
+++ b/features/platform/device-intent/src/executor.ts
@@ -167,6 +167,13 @@ export interface DeviceIntentExecutorProps<
    * (e.g. user closes the bottom sheet containing the executor, or clicks a "Close" CTA in a given error state, etc.).
    */
   onUserCancel: () => void;
+  /**
+   * Optional. Called when the executor is destroyed — the component unmounts, or
+   * `enabled` flips to `false` — leaving no later run to report an outcome, so a
+   * caller awaiting an intent result has to settle here. It does **not** fire when
+   * the executor tears a job down but stays alive (restart, disconnection).
+   */
+  onExecutorStopped?: () => void;
   /** Set to a new value to request cancellation of the ongoing job. */
   cancelIntentRequestId: string | undefined;
   /** Optional. Called whenever the running job emits a new state. */

--- a/features/platform/device-intent/src/executor.ts
+++ b/features/platform/device-intent/src/executor.ts
@@ -1,6 +1,7 @@
 import type React from "react";
 import type { ConnectedDevice } from "@ledgerhq/device-management-kit";
 import type {
+  DeviceConnectionComponentParams,
   DeviceConnectionParams,
   DeviceConnectionResult,
   DeviceExtractedContext,
@@ -19,7 +20,7 @@ import type {
  * errors, transport setup issues): they never surface to the executor.
  */
 export type DeviceConnectionComponent = React.ComponentType<{
-  deviceConnectionParams: DeviceConnectionParams;
+  deviceConnectionParams: DeviceConnectionComponentParams;
   onConnected: (connectionResult: DeviceConnectionResult) => void;
   /** Call to request the executor to close (forwards to `DeviceIntentExecutorProps.onUserCancel`). */
   onClose: () => void;
@@ -110,7 +111,7 @@ export interface ExecutorPlatformConfiguration<InitInput = void, InitializerConf
  * - `deviceDisconnected` → the disconnected device from the last successful connection.
  */
 export type ExecutorState =
-  | { type: "connectingDevice" }
+  | { type: "connectingDevice"; disableAutoConnect: boolean }
   | { type: "deviceDisconnected"; device: ConnectedDevice }
   | {
       type: "initializingDeviceContext";

--- a/features/platform/device-intent/src/useDeviceIntentExecutor.test.tsx
+++ b/features/platform/device-intent/src/useDeviceIntentExecutor.test.tsx
@@ -312,6 +312,22 @@ describe("useDeviceIntentExecutor — integration smoke tests (real SM)", () => 
 
       inPhase(result.current, "deviceDisconnected");
     });
+
+    it("WHEN the device disconnects THEN onExecutorStopped is not called", () => {
+      const onExecutorStopped = jest.fn();
+      const { connectionResult } = driveToExecution({
+        intent: makeIntent(() => NEVER),
+        onExecutorStopped,
+      });
+
+      act(() => {
+        connectionResult._sessionStateSubject.next({ deviceStatus: "not-connected" });
+      });
+
+      // The job is torn down but the executor stays alive, so a later run can
+      // still report and the caller must not settle.
+      expect(onExecutorStopped).not.toHaveBeenCalled();
+    });
   });
 
   describe("GIVEN the hook is in intentError phase", () => {
@@ -753,6 +769,48 @@ describe("useDeviceIntentExecutor — unit (mocked SM)", () => {
 
       unmount();
       expect(instance.stop).toHaveBeenCalled();
+    });
+  });
+
+  describe("onExecutorStopped", () => {
+    it("WHEN the hook unmounts THEN onExecutorStopped is called once", () => {
+      const onExecutorStopped = jest.fn();
+      const { unmount } = renderWithMockSM({ onExecutorStopped });
+
+      expect(onExecutorStopped).not.toHaveBeenCalled();
+
+      unmount();
+      expect(onExecutorStopped).toHaveBeenCalledTimes(1);
+    });
+
+    it("WHEN enabled transitions from true to false THEN onExecutorStopped is called once", () => {
+      const onExecutorStopped = jest.fn();
+      const { rerender, props } = renderWithMockSM({ onExecutorStopped });
+
+      // The cleanup and the disabled branch both run on this render, and only
+      // one of them may report the stop.
+      rerender({ p: { ...props, enabled: false } });
+      expect(onExecutorStopped).toHaveBeenCalledTimes(1);
+    });
+
+    it("WHEN enabled is false from the start THEN onExecutorStopped is never called", () => {
+      const onExecutorStopped = jest.fn();
+      const { unmount } = renderWithMockSM({ enabled: false, onExecutorStopped });
+
+      unmount();
+      expect(onExecutorStopped).not.toHaveBeenCalled();
+    });
+
+    it("WHEN the SM is stopped and restarted THEN each stop is reported once", () => {
+      const onExecutorStopped = jest.fn();
+      const { rerender, props } = renderWithMockSM({ onExecutorStopped });
+
+      rerender({ p: { ...props, enabled: false } });
+      rerender({ p: { ...props, enabled: true } });
+      expect(onExecutorStopped).toHaveBeenCalledTimes(1);
+
+      rerender({ p: { ...props, enabled: false } });
+      expect(onExecutorStopped).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/features/platform/device-intent/src/useDeviceIntentExecutor.test.tsx
+++ b/features/platform/device-intent/src/useDeviceIntentExecutor.test.tsx
@@ -154,7 +154,10 @@ describe("useDeviceIntentExecutor — integration smoke tests (real SM)", () => 
 
     it("THEN onExecutorStateChanged is called with connectingDevice", () => {
       const { props } = renderIntegration();
-      expect(props.onExecutorStateChanged).toHaveBeenCalledWith({ type: "connectingDevice" });
+      expect(props.onExecutorStateChanged).toHaveBeenCalledWith({
+        type: "connectingDevice",
+        disableAutoConnect: false,
+      });
     });
   });
 
@@ -620,7 +623,10 @@ describe("useDeviceIntentExecutor — integration smoke tests (real SM)", () => 
       });
 
       // First callback should have been called on mount
-      expect(firstCallback).toHaveBeenCalledWith({ type: "connectingDevice" });
+      expect(firstCallback).toHaveBeenCalledWith({
+        type: "connectingDevice",
+        disableAutoConnect: false,
+      });
 
       // Update the callback prop
       rerender({ p: { ...props, onExecutorStateChanged: secondCallback } });
@@ -921,7 +927,7 @@ describe("useDeviceIntentExecutor — unit (mocked SM)", () => {
       });
 
       act(() => {
-        listeners.onExecutorStateChanged({ type: "connectingDevice" });
+        listeners.onExecutorStateChanged({ type: "connectingDevice", disableAutoConnect: false });
       });
 
       inPhase(result.current, "deviceConnection");
@@ -983,10 +989,13 @@ describe("useDeviceIntentExecutor — unit (mocked SM)", () => {
       const { listeners, props } = renderWithMockSM();
 
       act(() => {
-        listeners.onExecutorStateChanged({ type: "connectingDevice" });
+        listeners.onExecutorStateChanged({ type: "connectingDevice", disableAutoConnect: false });
       });
 
-      expect(props.onExecutorStateChanged).toHaveBeenCalledWith({ type: "connectingDevice" });
+      expect(props.onExecutorStateChanged).toHaveBeenCalledWith({
+        type: "connectingDevice",
+        disableAutoConnect: false,
+      });
     });
 
     it("WHEN SM emits onIntentJobStateChanged THEN the prop callback is forwarded", () => {
@@ -1306,7 +1315,7 @@ describe("useDeviceIntentExecutor — unit (mocked SM)", () => {
       });
 
       act(() => {
-        listeners.onExecutorStateChanged({ type: "connectingDevice" });
+        listeners.onExecutorStateChanged({ type: "connectingDevice", disableAutoConnect: false });
       });
 
       const connectionResult2 = makeConnectionResult("session-2");

--- a/features/platform/device-intent/src/useDeviceIntentExecutor.ts
+++ b/features/platform/device-intent/src/useDeviceIntentExecutor.ts
@@ -44,6 +44,8 @@ export function useDeviceIntentExecutor<JobState, Input, ExtraProps, InitInput, 
   onIntentJobCompleteRef.current = props.onIntentJobComplete;
   const onIntentJobErrorRef = useRef(props.onIntentJobError);
   onIntentJobErrorRef.current = props.onIntentJobError;
+  const onExecutorStoppedRef = useRef(props.onExecutorStopped);
+  onExecutorStoppedRef.current = props.onExecutorStopped;
 
   // -- Creation-time prop refs --
   // The SM is created once when `enabled` becomes true, using these refs to
@@ -144,6 +146,16 @@ export function useDeviceIntentExecutor<JobState, Input, ExtraProps, InitInput, 
     smRef.current = createStateMachine();
   }
 
+  // False for a SM that never ran — one built by a render React threw away, or
+  // none at all because `enabled` started out false — so neither reports a stop.
+  const hasStartedSmRef = useRef(false);
+
+  const reportExecutorStopped = useCallback(() => {
+    if (!hasStartedSmRef.current) return;
+    hasStartedSmRef.current = false;
+    onExecutorStoppedRef.current?.();
+  }, []);
+
   useLayoutEffect(() => {
     if (!props.enabled) {
       smRef.current?.stop();
@@ -152,19 +164,24 @@ export function useDeviceIntentExecutor<JobState, Input, ExtraProps, InitInput, 
       setConnectionResult(null);
       setLatestJobState(undefined);
       lastIntentSnapshotRef.current = null;
+      reportExecutorStopped();
       return;
     }
 
     const sm = smRef.current ?? createStateMachine();
     smRef.current = sm;
     sm.start();
+    hasStartedSmRef.current = true;
+    // On an `enabled` flip React runs this before the branch above, whose own call
+    // is then a no-op, so the stop is reported exactly once.
     return () => {
       sm.stop();
       if (smRef.current === sm) {
         smRef.current = null;
       }
+      reportExecutorStopped();
     };
-  }, [createStateMachine, props.enabled]);
+  }, [createStateMachine, props.enabled, reportExecutorStopped]);
 
   // ---- 5. Device disconnection monitoring effect ----
 

--- a/features/platform/device-intent/src/useDeviceIntentExecutor.ts
+++ b/features/platform/device-intent/src/useDeviceIntentExecutor.ts
@@ -72,6 +72,7 @@ export function useDeviceIntentExecutor<JobState, Input, ExtraProps, InitInput, 
   > | null>(null);
   const [executorState, setExecutorState] = useState<ExecutorState>({
     type: "connectingDevice",
+    disableAutoConnect: false,
   });
   const [latestJobState, setLatestJobState] = useState<JobState | undefined>(undefined);
   const [connectionResult, setConnectionResult] = useState<DeviceConnectionResult | null>(null);
@@ -160,7 +161,7 @@ export function useDeviceIntentExecutor<JobState, Input, ExtraProps, InitInput, 
     if (!props.enabled) {
       smRef.current?.stop();
       smRef.current = null;
-      setExecutorState({ type: "connectingDevice" });
+      setExecutorState({ type: "connectingDevice", disableAutoConnect: false });
       setConnectionResult(null);
       setLatestJobState(undefined);
       lastIntentSnapshotRef.current = null;

--- a/libs/live-dmk-desktop/src/connectDevice/connectDevice.ts
+++ b/libs/live-dmk-desktop/src/connectDevice/connectDevice.ts
@@ -16,6 +16,8 @@ import { createConnectionError, filterMatchedDevices } from "./utils";
 export type ConnectDeviceInput = {
   knownDevices: Array<KnownDevice>;
   acceptedDeviceModelIds?: Array<DeviceModelId>;
+  /** See {@link ConnectDeviceStateMachineInput.disableAutoConnect}. */
+  disableAutoConnect?: boolean;
   dmk: DeviceManagementKit;
   onConnected: (result: DeviceConnectionResult) => void;
 };

--- a/libs/live-dmk-mobile/src/connectDevice/connectDevice.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/connectDevice.ts
@@ -17,6 +17,8 @@ import { buildMobileCompatDeviceId, createConnectionError, filterMatchedDevices 
 export type ConnectDeviceInput = {
   knownDevices: Array<KnownDevice>;
   acceptedDeviceModelIds?: Array<DeviceModelId>;
+  /** See {@link ConnectDeviceStateMachineInput.disableAutoConnect}. */
+  disableAutoConnect?: boolean;
   dmk: DeviceManagementKit;
   onConnected: (result: DeviceConnectionResult) => void;
 };

--- a/libs/live-dmk-shared/src/connectDevice/ConnectDeviceStateMachine.spec.md
+++ b/libs/live-dmk-shared/src/connectDevice/ConnectDeviceStateMachine.spec.md
@@ -13,13 +13,15 @@ stateDiagram-v2
   [*] --> Startup
 
   Startup --> NoKnownDevice: no known devices
-  Startup --> Connected: existing session
-  Startup --> WaitingForSelectedDevice: exactly one known device and no session
+  Startup --> Connected: existing session and auto-connect allowed
+  Startup --> WaitingForSelectedDevice: exactly one known device, no session, auto-connect allowed
   Startup --> Discovering: multiple known devices and no session
+  Startup --> Discovering: auto-connect disabled
 
   NoKnownDevice --> [*]
 
   Discovering --> Discovering: DiscoveredNoDevice / DiscoveredManyDevices
+  Discovering --> Discovering: DiscoveredOneDevice and auto-connect disabled
   Discovering --> Connecting: DiscoveredOneDevice matching a known device
   Discovering --> Connecting: UserTapsAvailableDevice
   Discovering --> WaitingForSelectedDevice: UserTapsUnavailableDevice
@@ -55,6 +57,12 @@ stateDiagram-v2
 - If startup receives exactly one known device and no existing session, the
   machine selects that device immediately and waits for it to be discovered
   instead of first rendering the discovery list.
+- `disableAutoConnect` withholds every connection the machine would make on its
+  own initiative: startup ignores an existing `sessionId` and skips preselecting
+  the only known device, and a lone discovery is rendered rather than connected.
+  Startup therefore reaches `NoKnownDevice` or `Discovering`, and only a user tap
+  leaves it. Tapping a device still connects once it is discovered — that choice
+  was explicit.
 - `Discovering` starts the discovery service and renders all known devices as
   available or unavailable depending on the latest matched discoveries.
 - DMK discovery emissions are filtered before reaching the state machine:

--- a/libs/live-dmk-shared/src/connectDevice/ConnectDeviceStateMachine.test.ts
+++ b/libs/live-dmk-shared/src/connectDevice/ConnectDeviceStateMachine.test.ts
@@ -124,6 +124,7 @@ type SetupTestOptions = {
   readonly matchDiscoveredDevices?: ConnectDeviceMatchDiscoveredDevices;
   readonly onConnected?: jest.Mock;
   readonly buildCompatDeviceId?: (device: ConnectedDevice) => string;
+  readonly disableAutoConnect?: boolean;
 };
 
 const defaultMatchDiscoveredDevices: ConnectDeviceMatchDiscoveredDevices = (
@@ -159,6 +160,7 @@ const setupTest = (options: SetupTestOptions = {}) => {
     matchDiscoveredDevices = defaultMatchDiscoveredDevices,
     onConnected = jest.fn(),
     buildCompatDeviceId,
+    disableAutoConnect,
   } = options;
   const discoveredDevices = new Subject<Array<DiscoveredDevice>>();
   const errors = new Subject<UnknownDiscoveryError>();
@@ -192,6 +194,7 @@ const setupTest = (options: SetupTestOptions = {}) => {
     mapConnectionError,
     matchDiscoveredDevices,
     onConnected,
+    ...(disableAutoConnect === undefined ? {} : { disableAutoConnect }),
     ...(buildCompatDeviceId ? { buildCompatDeviceId } : {}),
   });
 
@@ -284,6 +287,89 @@ describe("ConnectDeviceStateMachine", () => {
         expect.objectContaining({ type: "not-available", knownDevice: knownDeviceA }),
         expect.objectContaining({ type: "not-available", knownDevice: knownDeviceB }),
       ]);
+    });
+  });
+
+  describe("Startup with auto-connect disabled", () => {
+    it("emits Discovering instead of preselecting the only known device", () => {
+      // Arrange
+      const { machine, states } = setupTest({
+        knownDevices: [knownDeviceA],
+        disableAutoConnect: true,
+      });
+
+      // Act
+      machine.start();
+
+      // Assert
+      expect(states[states.length - 1].type).toBe(ConnectDeviceUIStateTypes.Discovering);
+    });
+
+    it("emits Discovering instead of reusing an existing session", () => {
+      // Arrange
+      const { machine, onConnected, states } = setupTest({
+        knownDevices: [knownDeviceA, knownDeviceB],
+        sessionId: "existing-session-id",
+        disableAutoConnect: true,
+      });
+
+      // Act
+      machine.start();
+
+      // Assert
+      expect(states[states.length - 1].type).toBe(ConnectDeviceUIStateTypes.Discovering);
+      expect(onConnected).not.toHaveBeenCalled();
+    });
+
+    it("keeps a lone discovered device available instead of connecting to it", () => {
+      // Arrange
+      const { connect, discoverDevices, machine, states } = setupTest({
+        knownDevices: [knownDeviceA, knownDeviceB],
+        disableAutoConnect: true,
+      });
+      machine.start();
+
+      // Act
+      discoverDevices([makeDiscoveredDeviceFromKnownDevice(knownDeviceA)]);
+
+      // Assert
+      expect(connect).not.toHaveBeenCalled();
+      const discoveringState = states[states.length - 1];
+      expect(discoveringState.type).toBe(ConnectDeviceUIStateTypes.Discovering);
+      expect(
+        (
+          discoveringState as {
+            type: ConnectDeviceUIStateTypes.Discovering;
+            devices: Array<DisplayedDevice>;
+          }
+        ).devices,
+      ).toEqual([
+        expect.objectContaining({ type: "available", knownDevice: knownDeviceA }),
+        expect.objectContaining({ type: "not-available", knownDevice: knownDeviceB }),
+      ]);
+    });
+
+    it("still connects to a device the user taps", () => {
+      // Arrange
+      const { connect, discoverDevices, machine, states } = setupTest({
+        knownDevices: [knownDeviceA, knownDeviceB],
+        disableAutoConnect: true,
+      });
+      machine.start();
+      discoverDevices([makeDiscoveredDeviceFromKnownDevice(knownDeviceA)]);
+      const devices = (
+        states[states.length - 1] as {
+          type: ConnectDeviceUIStateTypes.Discovering;
+          devices: Array<DisplayedDevice>;
+        }
+      ).devices;
+
+      // Act
+      devices[0].onSelect();
+
+      // Assert
+      // The choice was explicit, so nothing here should stand in its way.
+      expect(connect).toHaveBeenCalled();
     });
   });
 

--- a/libs/live-dmk-shared/src/connectDevice/ConnectDeviceStateMachine.ts
+++ b/libs/live-dmk-shared/src/connectDevice/ConnectDeviceStateMachine.ts
@@ -1,5 +1,5 @@
 import { Subscription } from "rxjs";
-import { assign, createActor, fromPromise, setup } from "xstate";
+import { and, assign, createActor, fromPromise, not, setup } from "xstate";
 import type { DeviceManagementKit } from "@ledgerhq/device-management-kit";
 import {
   BaseDiscoveryErrorTypes,
@@ -77,6 +77,7 @@ const createConnectDeviceStateMachine = <
       hasOnlyOneKnownDevice: ({ context }) => context.knownDevices.length === 1,
       hasMoreThanOneKnownDevice: ({ context }) => context.knownDevices.length > 1,
       hasSession: ({ context }) => context.sessionId !== null,
+      canAutoConnect: ({ context }) => context.disableAutoConnect !== true,
       hasSelectedKnownDeviceMatch: ({ context, event }) =>
         getSelectedMatchedDeviceFromDiscoveryEvent(event, context.selectedKnownDevice) !== null,
       retryOutputIsTrue: (_, params: { output: true | BaseDiscoveryError }) =>
@@ -254,11 +255,11 @@ const createConnectDeviceStateMachine = <
             target: "NoKnownDevice",
           },
           {
-            guard: "hasSession",
+            guard: and(["hasSession", "canAutoConnect"]),
             target: "Connected",
           },
           {
-            guard: "hasOnlyOneKnownDevice",
+            guard: and(["hasOnlyOneKnownDevice", "canAutoConnect"]),
             actions: ["assignDefaultSelectedKnownDevice"],
             target: "WaitingForSelectedDevice",
           },
@@ -285,10 +286,18 @@ const createConnectDeviceStateMachine = <
           [ConnectDeviceStateMachineEventTypes.DiscoveredManyDevices]: {
             actions: ["assignMatchedDevices", "emitDiscovering"],
           },
-          [ConnectDeviceStateMachineEventTypes.DiscoveredOneDevice]: {
-            target: "Connecting",
-            actions: ["assignMatchedDevices", "assignSelectedMatchedDeviceFromDiscoveryEvent"],
-          },
+          [ConnectDeviceStateMachineEventTypes.DiscoveredOneDevice]: [
+            // Without auto-connect the lone discovery is rendered like any other,
+            // so the user picks it (or another device) themselves.
+            {
+              guard: not("canAutoConnect"),
+              actions: ["assignMatchedDevices", "emitDiscovering"],
+            },
+            {
+              target: "Connecting",
+              actions: ["assignMatchedDevices", "assignSelectedMatchedDeviceFromDiscoveryEvent"],
+            },
+          ],
           [ConnectDeviceStateMachineEventTypes.DiscoveryError]: {
             target: "DiscoveryError",
             actions: "assignDiscoveryError",

--- a/libs/live-dmk-shared/src/connectDevice/ConnectDeviceUseCase.test.ts
+++ b/libs/live-dmk-shared/src/connectDevice/ConnectDeviceUseCase.test.ts
@@ -19,6 +19,14 @@ const knownDevice: KnownDevice = {
   name: "Ledger Nano X",
 };
 
+/** Pairs with `knownDevice` so startup reaches Discovering rather than preselecting. */
+const secondKnownDevice: KnownDevice = {
+  transport: "RN_BLE",
+  deviceModelId: DeviceModelId.nanoSP,
+  id: "known-device-b",
+  name: "Ledger Nano S Plus",
+};
+
 type SetupTestOptions = {
   readonly knownDevices?: Array<KnownDevice>;
   readonly acceptedDeviceModelIds?: Array<DeviceModelId>;
@@ -37,6 +45,7 @@ const setupTest = ({
 
   const dmk = {
     listConnectedDevices: jest.fn(() => []),
+    getConnectedDevice: jest.fn(() => ({ id: "connected-device-a", name: "Ledger Nano X" })),
   } as unknown as DeviceManagementKit;
 
   const input = {} as ConnectDeviceUseCaseInput;
@@ -126,9 +135,7 @@ describe("connectDeviceUseCase", () => {
     });
 
     //Assert
-    expect(states).toEqual([
-      { type: ConnectDeviceUIStateTypes.UnknownError, error: thrown },
-    ]);
+    expect(states).toEqual([{ type: ConnectDeviceUIStateTypes.UnknownError, error: thrown }]);
     expect(errorHandler).not.toHaveBeenCalled();
     expect(completeHandler).toHaveBeenCalledTimes(1);
 
@@ -157,6 +164,44 @@ describe("connectDeviceUseCase", () => {
       type: ConnectDeviceUIStateTypes.WaitingForSelectedDevice,
       device: knownDevice,
     });
+
+    subscription.unsubscribe();
+  });
+
+  it("should ignore a lone live session when auto-connect is disabled", () => {
+    // Arrange
+    const { input } = setupTest({ knownDevices: [knownDevice, secondKnownDevice] });
+    (input.dmk.listConnectedDevices as jest.Mock).mockReturnValue([
+      { sessionId: "existing-session-id" },
+    ]);
+    input.disableAutoConnect = true;
+    const states: Array<ConnectDeviceUIState> = [];
+
+    // Act
+    const subscription = connectDeviceUseCase(input).subscribe(state => states.push(state));
+
+    // Assert
+    // Otherwise the machine goes straight to Connected on the very device the
+    // caller is trying to get away from.
+    expect(states[0]?.type).toBe(ConnectDeviceUIStateTypes.Discovering);
+    expect(input.onConnected).not.toHaveBeenCalled();
+
+    subscription.unsubscribe();
+  });
+
+  it("should reuse a lone live session when auto-connect is allowed", () => {
+    // Arrange
+    const { input } = setupTest({ knownDevices: [knownDevice, secondKnownDevice] });
+    (input.dmk.listConnectedDevices as jest.Mock).mockReturnValue([
+      { sessionId: "existing-session-id" },
+    ]);
+    const states: Array<ConnectDeviceUIState> = [];
+
+    // Act
+    const subscription = connectDeviceUseCase(input).subscribe(state => states.push(state));
+
+    // Assert
+    expect(states[0]).toEqual({ type: ConnectDeviceUIStateTypes.Connected });
 
     subscription.unsubscribe();
   });

--- a/libs/live-dmk-shared/src/connectDevice/connectDeviceUseCase.ts
+++ b/libs/live-dmk-shared/src/connectDevice/connectDeviceUseCase.ts
@@ -27,6 +27,8 @@ export type ConnectDeviceUseCaseInput<
 > = {
   knownDevices: Array<KnownDevice>;
   acceptedDeviceModelIds?: Array<DeviceModelId>;
+  /** See {@link ConnectDeviceStateMachineInput.disableAutoConnect}. */
+  disableAutoConnect?: boolean;
   dmk: DeviceManagementKit;
   deviceDiscoveryService: DeviceDiscoveryService<TDiscoveryError>;
   matchDiscoveredDevices: ConnectDeviceMatchDiscoveredDevices;

--- a/libs/live-dmk-shared/src/connectDevice/types.ts
+++ b/libs/live-dmk-shared/src/connectDevice/types.ts
@@ -127,6 +127,13 @@ export type ConnectDeviceStateMachineInput<
 > = {
   knownDevices: Array<KnownDevice>;
   sessionId: string | null;
+  /**
+   * Require an explicit device choice instead of connecting on the machine's own
+   * initiative: no reuse of an existing session, no preselecting the only known
+   * device, no connecting to a lone discovery. Use it when the caller knows the
+   * device that would be picked is the wrong one — after refusing it, say.
+   */
+  disableAutoConnect?: boolean;
   dmk: DeviceManagementKit;
   deviceDiscoveryService: DeviceDiscoveryService<TDiscoveryError>;
   observer: Observer<ConnectDeviceUIState<TDiscoveryError, TConnectionError>>;


### PR DESCRIPTION
### 📝 Description

The wrong-device screen shipped with **Cancel** alone. The approved design has a primary **Connect a different device** CTA, which was blocked because the executor could only be closed, and closing abandoned the flow — dropping the currency, address and label the user had entered.

Three commits, in dependency order:

**1. `fix(contacts)`: settle intent promises on executor stop, not teardown**

The result reporter rejected the flow's promise whenever a job observable was unsubscribed without reporting. The executor unsubscribes on paths that keep the operation alive, so that safety net fired too early.

Unplugging the device on the rejection screen shows it, **on `develop` today**: the executor moves `intentExecution → deviceDisconnected`, stopping the job actor, so the promise rejects and the host runs `closeAddAddress()`. Tapping Retry then reconnects, re-runs the job and signs on the device for nothing — the reporter's success lands on an already-settled promise and is dropped as a late duplicate. The user sees a success screen with no address saved.

Dismissal was already the settling authority (the orchestrator rejects on `onUserCancel` and on unmount, independently of the reporter). The only gap was the executor being destroyed while the orchestrator stayed mounted, so the executor now reports that through an optional `onExecutorStopped` — fired on unmount and on `enabled` flipping to false, and deliberately **not** when it tears a job down but stays alive.

**2. `feat(device-intent)`: let a job send the executor to another device**

Jobs get a `restartExecutor` param that returns the executor to the connection phase while keeping the current intent, so the same job runs again on whichever device the user connects next.

Restarting disconnects the session of the device being left behind, then suppresses auto-connect for the rest of the executor's life. Every shortcut the connect machine takes on its own initiative would otherwise land straight back on the refused device: reusing a lone live session, preselecting the only known device, connecting to a lone discovery. `disableAutoConnect` withholds all three. Tapping a device still connects — that choice is explicit.

The flag is **owned by the executor** and merged into `deviceConnectionParams` by `deriveHookState`, so callers cannot set it and the executor's six other consumers are untouched.

**3. `feat(contacts)`: offer "Connect a different device" on a wrong device**

Status word `0x6982` now keeps its job open and carries a `reconnect` handle, alongside the rejection that already worked this way. Devices are stateless and keep honouring the proofs they minted, so `0x6982` means the connected device is not the one that minted them — a different device is the only fix, and it is always worth offering.

Leaving the state open is what preserves the entered data: reporting it settled the port promise, so the host ran `closeAddAddress()` and the data was gone before the screen even painted.

All three intents and their six renderers, since the failure and the screen are shared.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36562](https://ledgerhq.atlassian.net/browse/LIVE-36562)
- **ADR** (if any): [Device Intent Executor component](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/6852083917)

---

### Design decisions worth a reviewer's attention

**`restartExecutor` is optional.** 14 call sites construct job params, including `apps/wallet-cli/src/commands/swap/cli-swap-die-pipeline.ts` — a real non-test direct caller. Requiring it would force a no-op stub there that lies to any job calling it. Optional mirrors `device-rejected`'s existing `retry?`: jobs surface `reconnect` only when present, so a host with no connection phase falls back to the shipped Cancel-only screen instead of a dead CTA. Each of the three jobs covers that path.

**Suppression lives entirely in the connect state machine.** The `hasSession` half was first implemented in `connectDeviceUseCase` (withholding the session id), with only the other two guarded in the machine. A test written as belt-and-braces failed and showed the machine still honouring a session id handed to it directly, which made the behaviour depend on a collaborator withholding it. All three short-circuits are now guarded in one place.

**Desktop has no per-unit device identity**, so the restart cannot exclude the refused unit — only stop connecting to it on the executor's own initiative. `knownDevices.ts`: WebHID exposes no stable per-device id worth persisting, so `KnownDevice.id` is `""` and identity is the model; the picker renders one row per model, and two same-model devices are one entry. Documented in the DIE README. **Open question for design:** the copy says *"Use the same Ledger device you used to add this contact"* but never tells the user to unplug, and on desktop with two same-model devices they must physically swap before that row means the other unit.

### ✅ Checks

Not run on CI yet — opened as a draft to have it online. Locally green: `@features/platform-device-intent` 152, `@features/platform-contacts` 302, `@ledgerhq/live-dmk-shared` 315, `-desktop` 39, `-mobile` 331, plus both app suites (LWD 6291, LWM 5910). Typecheck and format clean across all five packages and both apps.


[LIVE-36562]: https://ledgerhq.atlassian.net/browse/LIVE-36562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ