### PR TITLE
feat(card): mint the secure card details token (LIVE-34778)

### DIFF
--- a/.changeset/pay-card-details-token.md
+++ b/.changeset/pay-card-details-token.md
@@ -1,0 +1,9 @@
+---
+"@domain/api-card-management": minor
+---
+
+Add `createCardDetailsToken` for `POST /v1/card/details/token`.
+
+- Answers with a single-use token and an image URL that renders PAN, CVV and expiry, so the app never handles the card data itself.
+- A mutation, not a query: the provider spends the token on first use, so the answer must never be served from a cache.
+- Takes the documented `customCss` colours, and validates them as hex before the provider answers 422.

--- a/.changeset/pay-card-details-token.md
+++ b/.changeset/pay-card-details-token.md
@@ -7,3 +7,5 @@ Add `createCardDetailsToken` for `POST /v1/card/details/token`.
 - Answers with a single-use token and an image URL that renders PAN, CVV and expiry, so the app never handles the card data itself.
 - A mutation, not a query: the provider spends the token on first use, so the answer must never be served from a cache.
 - Takes the documented `customCss` colours, and validates them as hex before the provider answers 422.
+- `imageUrl` must be an `https` URL: it is loaded straight into an image.
+- RTK Query retains a tracked mutation result, so callers dispatch with `track: false` or reset once the URL is used. The answer is a credential.

--- a/domain/api/card-management/README.md
+++ b/domain/api/card-management/README.md
@@ -24,6 +24,9 @@ shape and the reasons.
 | `getUser` | GET | `/v1/user` | Read the account id and verification state |
 | `orderCard` | POST | `/v1/card/order` | Order a virtual card |
 | `getCardStatus` | GET | `/v1/card/status` | Read the ordered card's state and preview fields |
+| `createCardDetailsToken` | POST | `/v1/card/details/token` | Mint a single-use token and image URL showing PAN, CVV and expiry |
+| `freezeCard` | POST | `/v1/card/freeze` | Move an active card to `FROZEN` |
+| `unfreezeCard` | POST | `/v1/card/unfreeze` | Move a frozen card back to `ACTIVE` |
 | `getInternalWallets` | GET | `/v1/wallet/internal` | Read every custodial wallet, with balances |
 | `getCardLinkedWallets` | GET | `/v1/wallet/internal/card_linked` | Read the wallets funding the card, in charging order |
 

--- a/domain/api/card-management/src/api.test.ts
+++ b/domain/api/card-management/src/api.test.ts
@@ -715,15 +715,70 @@ describe("cardManagementApi requests", () => {
       });
     });
 
-    it("keeps no cache entry: the provider spends the token on first use", async () => {
-      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(detailsToken));
+    it("rejects a colour that is not a hex value before the request goes out", async () => {
+      fetchSpy = jest
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(async () => jsonResponse(detailsToken));
+
+      const store = makeStore("session-token");
+      const result = await store.dispatch(
+        cardManagementApi.endpoints.createCardDetailsToken.initiate({
+          cardBackgroundColor: "rebeccapurple",
+        }),
+      );
+
+      expect(result.error).toBeDefined();
+      // The point of validating the argument: the provider never sees it.
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("rejects an image url that is not https, which is loaded straight into an image", async () => {
+      fetchSpy = jest
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(async () =>
+          jsonResponse({ ...detailsToken, imageUrl: "javascript:alert(1)" }),
+        );
+
+      const store = makeStore("session-token");
+      const result = await store.dispatch(
+        cardManagementApi.endpoints.createCardDetailsToken.initiate(),
+      );
+
+      expect(result.data).toBeUndefined();
+      expect(result.error).toBeDefined();
+    });
+
+    it("reaches no part of the store when the caller does not track it", async () => {
+      fetchSpy = jest
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(async () => jsonResponse(detailsToken));
+
+      const store = makeStore("session-token");
+      await store
+        .dispatch(
+          cardManagementApi.endpoints.createCardDetailsToken.initiate(undefined, {
+            track: false,
+          }),
+        )
+        .unwrap();
+
+      // Both halves: a query result lands under `queries`, a mutation result under `mutations`.
+      const state = JSON.stringify(store.getState().cardApi);
+      expect(state).not.toContain(detailsToken.token);
+      expect(state).not.toContain("details-image");
+    });
+
+    it("is held in the store when the caller does track it, which is why callers must not", async () => {
+      fetchSpy = jest
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(async () => jsonResponse(detailsToken));
 
       const store = makeStore("session-token");
       await store.dispatch(cardManagementApi.endpoints.createCardDetailsToken.initiate()).unwrap();
 
-      const cached = JSON.stringify(store.getState().cardApi.queries);
-      expect(cached).not.toContain(detailsToken.token);
-      expect(cached).not.toContain("details-image");
+      // Pinned deliberately: RTK Query retains a tracked mutation result, so a caller that drops
+      // `track: false` leaves the PAN image URL in Redux. This failing would mean that changed.
+      expect(JSON.stringify(store.getState().cardApi.mutations)).toContain(detailsToken.token);
     });
   });
 

--- a/domain/api/card-management/src/api.test.ts
+++ b/domain/api/card-management/src/api.test.ts
@@ -11,6 +11,7 @@ import {
   useFreezeCardMutation,
   useGetCardLinkedWalletsQuery,
   useGetCardOnboardingStatusQuery,
+  useCreateCardDetailsTokenMutation,
   useGetCardStatusQuery,
   useLazyGetCardStatusQuery,
   useGetInternalWalletsQuery,
@@ -129,6 +130,7 @@ describe("cardManagementApi configuration", () => {
 
   it("injects exactly its own endpoints", () => {
     expect(Object.keys(cardManagementApi.endpoints).sort()).toEqual([
+      "createCardDetailsToken",
       "exchangeAuthorizationCode",
       "freezeCard",
       "getCardLinkedWallets",
@@ -168,6 +170,11 @@ describe("cardManagementApi configuration", () => {
     expect(useGetCardStatusQuery).toBeDefined();
     // The devtool fetches on press, not on mount, so the lazy hook is part of the surface too.
     expect(useLazyGetCardStatusQuery).toBeDefined();
+  });
+
+  it("exposes the card details token endpoint and its hook", () => {
+    expect(cardManagementApi.endpoints.createCardDetailsToken).toBeDefined();
+    expect(useCreateCardDetailsTokenMutation).toBeDefined();
   });
 
   it("exposes the freeze endpoints and their hooks", () => {
@@ -666,6 +673,57 @@ describe("cardManagementApi requests", () => {
 
       expect(result.data).toBeUndefined();
       expect(result.error).toBeDefined();
+    });
+  });
+
+  describe("createCardDetailsToken", () => {
+    // The provider's example, with an all-zero token: a real-looking one trips secret scanning.
+    const detailsToken = {
+      token: "00000000-0000-4000-8000-000000000000",
+      imageUrl: "https://card.test/details-image?token=00000000-0000-4000-8000-000000000000",
+    };
+
+    it("asks for a token with the bearer token and the client key, and sends no body by default", async () => {
+      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(detailsToken));
+
+      const store = makeStore("session-token");
+      const result = await store.dispatch(
+        cardManagementApi.endpoints.createCardDetailsToken.initiate(),
+      );
+
+      expect(request(fetchSpy).url).toBe("https://card.test/v1/card/details/token");
+      expect(request(fetchSpy).method).toBe("POST");
+      expect(request(fetchSpy).headers.get("authorization")).toBe("Bearer session-token");
+      expect(request(fetchSpy).headers.get("x-client-key")).toBe("client-key");
+      // No colours asked for: the provider paints its own defaults.
+      expect(await request(fetchSpy).clone().text()).toBe("");
+      expect(result.data).toEqual(detailsToken);
+    });
+
+    it("sends the colours the host asked for", async () => {
+      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(detailsToken));
+
+      const store = makeStore("session-token");
+      await store
+        .dispatch(
+          cardManagementApi.endpoints.createCardDetailsToken.initiate({ panTextColor: "#000000" }),
+        )
+        .unwrap();
+
+      expect(JSON.parse(await request(fetchSpy).clone().text())).toEqual({
+        customCss: { panTextColor: "#000000" },
+      });
+    });
+
+    it("keeps no cache entry: the provider spends the token on first use", async () => {
+      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(detailsToken));
+
+      const store = makeStore("session-token");
+      await store.dispatch(cardManagementApi.endpoints.createCardDetailsToken.initiate()).unwrap();
+
+      const cached = JSON.stringify(store.getState().cardApi.queries);
+      expect(cached).not.toContain(detailsToken.token);
+      expect(cached).not.toContain("details-image");
     });
   });
 

--- a/domain/api/card-management/src/api.ts
+++ b/domain/api/card-management/src/api.ts
@@ -9,6 +9,7 @@ import {
   PayCardOrderResponseSchema,
   PayCardSessionResponseSchema,
   PayCardSessionSchema,
+  PayCardDetailsCssSchema,
   PayCardDetailsTokenResponseSchema,
   PayCardStatusResponseSchema,
   PayCardUserResponseSchema,
@@ -107,7 +108,11 @@ export const cardManagementApi = cardApi
 
       /**
        * A mutation, though it reads: the provider spends the token on first use, so the answer must
-       * never be served from a cache. Mutations are not cached and are not retained.
+       * never be served from a cache, and a mutation is never cached.
+       *
+       * It is still **retained**: RTK Query holds a tracked mutation result in
+       * `state.cardApi.mutations`. Dispatch this one with `{ track: false }`, or reset it as soon
+       * as the URL has been used — the answer is a credential, not data.
        */
       createCardDetailsToken: build.mutation<PayCardDetailsToken, PayCardDetailsCss | void>({
         query: customCss => ({
@@ -115,6 +120,7 @@ export const cardManagementApi = cardApi
           method: "POST",
           ...(customCss ? { body: { customCss } } : {}),
         }),
+        argSchema: PayCardDetailsCssSchema.optional(),
         responseSchema: PayCardDetailsTokenResponseSchema,
       }),
 

--- a/domain/api/card-management/src/api.ts
+++ b/domain/api/card-management/src/api.ts
@@ -9,6 +9,7 @@ import {
   PayCardOrderResponseSchema,
   PayCardSessionResponseSchema,
   PayCardSessionSchema,
+  PayCardDetailsTokenResponseSchema,
   PayCardStatusResponseSchema,
   PayCardUserResponseSchema,
 } from "./schema";
@@ -23,6 +24,8 @@ import type {
   PayCardOrderResult,
   PayCardRefreshSessionRequest,
   PayCardSession,
+  PayCardDetailsCss,
+  PayCardDetailsToken,
   PayCardStatus,
   PayCardUser,
 } from "./types";
@@ -102,6 +105,19 @@ export const cardManagementApi = cardApi
         providesTags: ["CardStatus"],
       }),
 
+      /**
+       * A mutation, though it reads: the provider spends the token on first use, so the answer must
+       * never be served from a cache. Mutations are not cached and are not retained.
+       */
+      createCardDetailsToken: build.mutation<PayCardDetailsToken, PayCardDetailsCss | void>({
+        query: customCss => ({
+          url: "/v1/card/details/token",
+          method: "POST",
+          ...(customCss ? { body: { customCss } } : {}),
+        }),
+        responseSchema: PayCardDetailsTokenResponseSchema,
+      }),
+
       freezeCard: build.mutation<PayCardFreezeStateResult, void>({
         query: () => ({
           url: "/v1/card/freeze",
@@ -154,6 +170,7 @@ export const {
   useGetUserQuery,
   useOrderCardMutation,
   useGetCardStatusQuery,
+  useCreateCardDetailsTokenMutation,
   useLazyGetCardStatusQuery,
   useFreezeCardMutation,
   useUnfreezeCardMutation,

--- a/domain/api/card-management/src/schema.test.ts
+++ b/domain/api/card-management/src/schema.test.ts
@@ -7,6 +7,8 @@ import {
   PayCardOnboardingStatusResponseSchema,
   PayCardOrderResponseSchema,
   PayCardSessionResponseSchema,
+  PayCardDetailsCssSchema,
+  PayCardDetailsTokenResponseSchema,
   PayCardStatusResponseSchema,
   PayCardUserResponseSchema,
 } from "./schema";
@@ -128,6 +130,44 @@ describe("PayCardStatusResponseSchema", () => {
     expect(() =>
       PayCardStatusResponseSchema.parse({ ...cardStatus, type: "SOMETHING_ELSE" }),
     ).toThrow();
+  });
+});
+
+describe("PayCardDetailsTokenResponseSchema", () => {
+  // The provider's example, with an all-zero token: a real-looking one trips secret scanning.
+  const detailsToken = {
+    token: "00000000-0000-4000-8000-000000000000",
+    imageUrl:
+      "https://card.api.live.ledger.com/details-image?token=00000000-0000-4000-8000-000000000000",
+  };
+
+  it("reads the documented token response", () => {
+    expect(PayCardDetailsTokenResponseSchema.parse(detailsToken)).toEqual(detailsToken);
+  });
+
+  it("rejects an empty image url, which would render nothing at all", () => {
+    expect(() =>
+      PayCardDetailsTokenResponseSchema.parse({ ...detailsToken, imageUrl: "" }),
+    ).toThrow();
+  });
+});
+
+describe("PayCardDetailsCssSchema", () => {
+  it("takes the documented colours, and takes none at all", () => {
+    const css = {
+      cardBackgroundColor: "#000000",
+      cardTextColor: "#FFFFFF",
+      panBackgroundColor: "#EFEFEF",
+      panTextColor: "#000000",
+    };
+
+    expect(PayCardDetailsCssSchema.parse(css)).toEqual(css);
+    expect(PayCardDetailsCssSchema.parse({})).toEqual({});
+  });
+
+  it("rejects a colour the provider would answer 422 for", () => {
+    expect(() => PayCardDetailsCssSchema.parse({ cardTextColor: "white" })).toThrow();
+    expect(() => PayCardDetailsCssSchema.parse({ cardTextColor: "#GGGGGG" })).toThrow();
   });
 });
 

--- a/domain/api/card-management/src/schema.ts
+++ b/domain/api/card-management/src/schema.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+const HEX_COLOR = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
 /**
  * Both grants — `authorization_code` and `refresh_token` — answer with this shape. Baanx's contract
  * carries no lifetime for the refresh token itself, only for the access token.
@@ -56,6 +58,19 @@ export const PayCardStatusResponseSchema = z.object({
   status: z.enum(["ACTIVE", "FROZEN", "BLOCKED"]),
   type: z.enum(["VIRTUAL", "PHYSICAL", "METAL"]),
   orderedAt: z.string().min(1),
+});
+
+/** Hex colours the provider paints the details image with. Its own defaults apply when omitted. */
+export const PayCardDetailsCssSchema = z.object({
+  cardBackgroundColor: z.string().regex(HEX_COLOR).optional(),
+  cardTextColor: z.string().regex(HEX_COLOR).optional(),
+  panBackgroundColor: z.string().regex(HEX_COLOR).optional(),
+  panTextColor: z.string().regex(HEX_COLOR).optional(),
+});
+
+export const PayCardDetailsTokenResponseSchema = z.object({
+  token: z.string().min(1),
+  imageUrl: z.string().min(1),
 });
 
 export const PayCardInternalWalletSchema = z.object({

--- a/domain/api/card-management/src/schema.ts
+++ b/domain/api/card-management/src/schema.ts
@@ -70,7 +70,11 @@ export const PayCardDetailsCssSchema = z.object({
 
 export const PayCardDetailsTokenResponseSchema = z.object({
   token: z.string().min(1),
-  imageUrl: z.string().min(1),
+  /** Loaded straight into an image, so reject anything that is not an `https:` URL. */
+  imageUrl: z
+    .string()
+    .url()
+    .refine(value => value.startsWith("https://"), { message: "must be an https URL" }),
 });
 
 export const PayCardInternalWalletSchema = z.object({

--- a/domain/api/card-management/src/types.ts
+++ b/domain/api/card-management/src/types.ts
@@ -10,6 +10,8 @@ import {
   PayCardOrderResponseSchema,
   PayCardSessionResponseSchema,
   PayCardSessionSchema,
+  PayCardDetailsCssSchema,
+  PayCardDetailsTokenResponseSchema,
   PayCardStatusResponseSchema,
   PayCardUserResponseSchema,
 } from "./schema";
@@ -30,6 +32,14 @@ export type PayCardFreezeStateResult = z.infer<typeof PayCardFreezeStateResponse
 export type PayCardErrorResponse = z.infer<typeof PayCardErrorResponseSchema>;
 
 export type PayCardStatus = z.infer<typeof PayCardStatusResponseSchema>;
+
+export type PayCardDetailsCss = z.infer<typeof PayCardDetailsCssSchema>;
+
+/**
+ * Single use, and short-lived: the provider invalidates the token once the image has been read.
+ * Neither field may be logged, stored, or put in a cache that outlives the render.
+ */
+export type PayCardDetailsToken = z.infer<typeof PayCardDetailsTokenResponseSchema>;
 
 export type PayCardAuthorizationCodeRequest = {
   readonly code: string;

--- a/domain/api/card-management/src/types.ts
+++ b/domain/api/card-management/src/types.ts
@@ -37,7 +37,10 @@ export type PayCardDetailsCss = z.infer<typeof PayCardDetailsCssSchema>;
 
 /**
  * Single use, and short-lived: the provider invalidates the token once the image has been read.
- * Neither field may be logged, stored, or put in a cache that outlives the render.
+ *
+ * Neither field may be logged or stored. RTK Query does not enforce that: it holds a tracked
+ * mutation result in `state.cardApi.mutations`, so the caller has to dispatch with
+ * `{ track: false }` or reset as soon as the URL has been used.
  */
 export type PayCardDetailsToken = z.infer<typeof PayCardDetailsTokenResponseSchema>;
 


### PR DESCRIPTION
<!-- stac-man:stack-start -->
**Stack** _(managed by [stac-man](https://github.com/bluegardenproject/stac-man))_

- **#21467 feat/LIVE-34778-card-details-token ← this PR**
- #21468 feat/pay-card-devtools-card-details
- #21495 feat/LIVE-34792-link-unlink-card-wallet
- #21533 feat/pay-card-devtools-freeze-unfreeze
- #21569 feat/pay-card-asset-mapping
- #21571 feat/pay-card-wallet-counter-value
<!-- stac-man:stack-end -->

`POST /v1/card/details/token` answers with a token and an image URL. The image
renders PAN, CVV and expiry, so the card data never passes through the app.

- A mutation, though it reads. The provider spends the token the first time the
  image is fetched, so a cached answer would be a spent one, and RTK Query
  retains query results while a subscriber lives. Mutations are neither cached
  nor retained, and a test asserts the token never reaches the cache.
- `customCss` is optional and validated as hex here, so a bad colour fails
  before the request rather than as a 422.
- `token` is a plain non-empty string. The reference calls it a UUID, but the
  card id in the same API is a digit string despite looking like one, and the
  sandbox has already diverged from the reference three times this week.