### PR TITLE
feat(pay-card): show the card details image in the devtool

### DIFF
--- a/.changeset/pay-card-devtools-card-details.md
+++ b/.changeset/pay-card-devtools-card-details.md
@@ -1,0 +1,12 @@
+---
+"@devtools/pay-card": minor
+"@devtools/bindings": minor
+---
+
+Show the secure card details image in the Card interaction screen.
+
+- A placeholder stands in for the card until it is pressed, then the provider's image replaces it.
+- The image loads straight from the returned URL: its token is the whole credential, so no headers are needed.
+- Leaving the screen drops the URL, because the provider spends it on first use and a stale one renders nothing.
+- The URL is never rendered as text.
+- Asks for the card and PAN colours per colour scheme, so the card number reads as its own surface against the card body.

--- a/.changeset/pay-card-devtools-card-details.md
+++ b/.changeset/pay-card-devtools-card-details.md
@@ -9,4 +9,5 @@ Show the secure card details image in the Card interaction screen.
 - The image loads straight from the returned URL: its token is the whole credential, so no headers are needed.
 - Leaving the screen drops the URL, because the provider spends it on first use and a stale one renders nothing.
 - The URL is never rendered as text.
+- The image loads with `cache: "reload"`: the token is spent on first use, so a cache hit is the only way it could be seen twice.
 - Asks for the card and PAN colours per colour scheme, so the card number reads as its own surface against the card body.

--- a/devtools/bindings/src/usePayCardToolProps.ts
+++ b/devtools/bindings/src/usePayCardToolProps.ts
@@ -222,7 +222,9 @@ export function usePayCardToolProps(options: UsePayCardToolPropsOptions = {}): P
   const { reset: resetCardDetails } = cardDetails;
   const details = useMemo(
     () => ({
-      // The URL itself never leaves this object: it is a live, single-use credential.
+      // A live, single-use credential. RTK holds it in mutation state while this hook is mounted,
+      // so what the tool guarantees is narrower: it is never handed over as text, and `clear`
+      // resets it on the way out.
       imageUrl: cardDetails.data?.imageUrl,
       isFetching: cardDetails.isLoading,
       error: cardDetails.error === undefined ? undefined : describeError(cardDetails.error),

--- a/devtools/bindings/src/usePayCardToolProps.ts
+++ b/devtools/bindings/src/usePayCardToolProps.ts
@@ -4,6 +4,7 @@ import {
   useGetCardLinkedWalletsQuery,
   useGetInternalWalletsQuery,
   useLazyGetCardStatusQuery,
+  useCreateCardDetailsTokenMutation,
 } from "@domain/api-card-management";
 import {
   useCardLinkedWallets,
@@ -21,6 +22,7 @@ import {
   resetReceiveVerifyHintSeen,
   selectHasSeenReceiveVerifyHint,
 } from "@features/flow-pay-request/state";
+import type { PayCardDetailsCss } from "@domain/api-card-management";
 import {
   resetCardOnboardingCompleted,
   selectHasCompletedCardOnboarding,
@@ -215,7 +217,33 @@ export function usePayCardToolProps(options: UsePayCardToolPropsOptions = {}): P
     [cardStatus.isFetching, cardStatus.data, cardStatus.error, runCardStatus],
   );
 
-  const interaction = useMemo(() => ({ probes: [cardStatusProbe] }), [cardStatusProbe]);
+  const [requestCardDetails, cardDetails] = useCreateCardDetailsTokenMutation();
+
+  const { reset: resetCardDetails } = cardDetails;
+  const details = useMemo(
+    () => ({
+      // The URL itself never leaves this object: it is a live, single-use credential.
+      imageUrl: cardDetails.data?.imageUrl,
+      isFetching: cardDetails.isLoading,
+      error: cardDetails.error === undefined ? undefined : describeError(cardDetails.error),
+      request: (customCss?: PayCardDetailsCss) => {
+        requestCardDetails(customCss);
+      },
+      clear: resetCardDetails,
+    }),
+    [
+      cardDetails.data,
+      cardDetails.isLoading,
+      cardDetails.error,
+      requestCardDetails,
+      resetCardDetails,
+    ],
+  );
+
+  const interaction = useMemo(
+    () => ({ probes: [cardStatusProbe], details }),
+    [cardStatusProbe, details],
+  );
 
   // The wallets are read when the balance screen opens, not when the tool mounts.
   const [walletsRequested, setWalletsRequested] = useState(false);

--- a/devtools/pay-card/src/components/Interaction/Interaction.native.tsx
+++ b/devtools/pay-card/src/components/Interaction/Interaction.native.tsx
@@ -1,6 +1,11 @@
-import { ScrollView } from "react-native";
-import { Box, Button, Text } from "@ledgerhq/lumen-ui-rnative";
-import type { PayCardInteractionProps } from "../../types";
+import { Image, Pressable, ScrollView } from "react-native";
+import { Box, Button, Spinner, Text } from "@ledgerhq/lumen-ui-rnative";
+import { useTheme } from "@ledgerhq/lumen-ui-rnative/styles";
+import type {
+  PayCardDetailsCssProps,
+  PayCardDetailsImageProps,
+  PayCardInteractionProps,
+} from "../../types";
 
 export interface InteractionProps extends PayCardInteractionProps {
   readonly onBack: () => void;
@@ -10,15 +15,84 @@ const CONTAINER_LX = { gap: "s12", padding: "s16" } as const;
 const PROBE_LX = { gap: "s8" } as const;
 const BUTTON_ROW_LX = { flexDirection: "row", flexWrap: "wrap", gap: "s8" } as const;
 
-export function Interaction({ probes, onBack }: InteractionProps) {
+/**
+ * The provider bakes these into the image, so they are chosen per colour scheme and a fresh token is
+ * needed to change them. The PAN strip sits a shade off the card body — pure black or white against
+ * the card's own near-black or near-white — so the card number reads as its own surface.
+ */
+const detailsCss = (isDark: boolean): PayCardDetailsCssProps => ({
+  cardBackgroundColor: isDark ? "#1f1f1f" : "#f1f1f1",
+  cardTextColor: isDark ? "#ffffff" : "#000000",
+  panBackgroundColor: isDark ? "#000000" : "#ffffff",
+  panTextColor: isDark ? "#ffffff" : "#000000",
+});
+
+// The provider renders the details at its own size; contain rather than crop what it sends back.
+const CARD_IMAGE_STYLE = { width: "100%", aspectRatio: 16 / 9 } as const;
+
+/**
+ * Stands in for the card details until a developer asks for them, then shows the image the provider
+ * rendered. The URL is the credential, so it loads with no headers and is never shown as text.
+ */
+function CardDetails({ imageUrl, isFetching, error, request }: PayCardDetailsImageProps) {
+  const { colorScheme } = useTheme();
+  if (imageUrl !== undefined) {
+    return (
+      <Image
+        source={{ uri: imageUrl }}
+        style={CARD_IMAGE_STYLE}
+        resizeMode="contain"
+        accessibilityLabel="Card details"
+      />
+    );
+  }
+
+  return (
+    <Pressable onPress={() => request(detailsCss(colorScheme === "dark"))} disabled={isFetching}>
+      <Box
+        lx={{
+          borderWidth: "s1",
+          borderColor: "mutedSubtle",
+          borderRadius: "lg",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: "s8",
+        }}
+        style={CARD_IMAGE_STYLE}
+      >
+        {isFetching ? <Spinner /> : null}
+        <Text typography="body2" lx={{ color: "muted" }}>
+          {isFetching ? "Requesting…" : "Request Card Details"}
+        </Text>
+        {error === undefined ? null : (
+          <Text typography="body3" lx={{ color: "error" }}>
+            {error}
+          </Text>
+        )}
+      </Box>
+    </Pressable>
+  );
+}
+
+export function Interaction({ probes, details, onBack }: InteractionProps) {
   return (
     <ScrollView>
       <Box lx={CONTAINER_LX}>
         <Box lx={BUTTON_ROW_LX}>
-          <Button appearance="gray" size="sm" onPress={onBack}>
+          <Button
+            appearance="gray"
+            size="sm"
+            onPress={() => {
+              // Drop the minted URL: it is single-use, so coming back must mint a fresh one.
+              details.clear();
+              onBack();
+            }}
+          >
             Back
           </Button>
         </Box>
+
+        <CardDetails {...details} />
 
         {probes.map(probe => (
           <Box key={probe.id} lx={PROBE_LX}>

--- a/devtools/pay-card/src/components/Interaction/Interaction.native.tsx
+++ b/devtools/pay-card/src/components/Interaction/Interaction.native.tsx
@@ -33,13 +33,18 @@ const CARD_IMAGE_STYLE = { width: "100%", aspectRatio: 16 / 9 } as const;
 /**
  * Stands in for the card details until a developer asks for them, then shows the image the provider
  * rendered. The URL is the credential, so it loads with no headers and is never shown as text.
+ *
+ * `cache: "reload"` keeps the load off any existing cache entry. The provider spends the token on
+ * first use, so a cache hit is the only way this image could be seen a second time. It is not a
+ * promise that nothing is written: the option is iOS-only, and neither platform offers a
+ * no-store image load.
  */
 function CardDetails({ imageUrl, isFetching, error, request }: PayCardDetailsImageProps) {
   const { colorScheme } = useTheme();
   if (imageUrl !== undefined) {
     return (
       <Image
-        source={{ uri: imageUrl }}
+        source={{ uri: imageUrl, cache: "reload" }}
         style={CARD_IMAGE_STYLE}
         resizeMode="contain"
         accessibilityLabel="Card details"
@@ -48,7 +53,12 @@ function CardDetails({ imageUrl, isFetching, error, request }: PayCardDetailsIma
   }
 
   return (
-    <Pressable onPress={() => request(detailsCss(colorScheme === "dark"))} disabled={isFetching}>
+    <Pressable
+      onPress={() => request(detailsCss(colorScheme === "dark"))}
+      disabled={isFetching}
+      accessibilityRole="button"
+      accessibilityLabel="Request Card Details"
+    >
       <Box
         lx={{
           borderWidth: "s1",

--- a/devtools/pay-card/src/components/Interaction/Interaction.web.test.tsx
+++ b/devtools/pay-card/src/components/Interaction/Interaction.web.test.tsx
@@ -1,12 +1,21 @@
 import { render } from "@testing-library/react";
 import { Interaction } from "./Interaction";
 
+const details = {
+  imageUrl: undefined,
+  isFetching: false,
+  error: undefined,
+  request: jest.fn(),
+  clear: jest.fn(),
+};
+
 describe("Interaction (web)", () => {
   it("renders nothing: the probes ship with the mobile tool first", () => {
     const onBack = jest.fn();
-    const { container } = render(<Interaction probes={[]} onBack={onBack} />);
+    const { container } = render(<Interaction probes={[]} details={details} onBack={onBack} />);
 
     expect(container).toBeEmptyDOMElement();
     expect(onBack).not.toHaveBeenCalled();
+    expect(details.request).not.toHaveBeenCalled();
   });
 });

--- a/devtools/pay-card/src/pay-card/PayCard.native.test.tsx
+++ b/devtools/pay-card/src/pay-card/PayCard.native.test.tsx
@@ -22,7 +22,16 @@ function buildProps(): PayCardToolProps {
       ],
       setStepDone: jest.fn(),
     },
-    interaction: { probes: [] },
+    interaction: {
+      probes: [],
+      details: {
+        imageUrl: undefined,
+        isFetching: false,
+        error: undefined,
+        request: jest.fn(),
+        clear: jest.fn(),
+      },
+    },
     balance: {
       baanxWallets: [],
       linkedWallets: [],
@@ -152,6 +161,7 @@ describe("PayCard (native)", () => {
       <PayCard
         {...props}
         interaction={{
+          ...props.interaction,
           probes: [
             {
               id: "card-status",
@@ -180,10 +190,12 @@ describe("PayCard (native)", () => {
 
   it("shows what a probe came back with", async () => {
     const user = userEvent.setup();
+    const props = buildProps();
     render(
       <PayCard
-        {...buildProps()}
+        {...props}
         interaction={{
+          ...props.interaction,
           probes: [
             {
               id: "card-status",
@@ -372,6 +384,65 @@ describe("PayCard (native)", () => {
     await user.press(screen.getByLabelText("Refresh"));
 
     expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("stands in for the card details until asked, then shows the image", async () => {
+    const user = userEvent.setup();
+    const request = jest.fn();
+    const props = buildProps();
+    const { rerender } = render(
+      <PayCard
+        {...props}
+        interaction={{ ...props.interaction, details: { ...props.interaction.details, request } }}
+      />,
+    );
+
+    await user.press(screen.getByText("Card interaction"));
+    await user.press(screen.getByText("Request Card Details"));
+    // The colours are baked into the image, so they go out with the request. The stubbed theme
+    // reports no scheme, which is the light branch.
+    expect(request).toHaveBeenCalledWith({
+      cardBackgroundColor: "#f1f1f1",
+      cardTextColor: "#000000",
+      panBackgroundColor: "#ffffff",
+      panTextColor: "#000000",
+    });
+
+    rerender(
+      <PayCard
+        {...props}
+        interaction={{
+          ...props.interaction,
+          details: {
+            ...props.interaction.details,
+            imageUrl: "https://card.test/details-image?token=x",
+          },
+        }}
+      />,
+    );
+
+    // The placeholder gives way to the image, and the url is never shown as text.
+    expect(screen.queryByText("Request Card Details")).toBeNull();
+    expect(screen.getByLabelText("Card details")).toBeTruthy();
+    expect(screen.queryByText("https://card.test/details-image?token=x")).toBeNull();
+  });
+
+  it("drops the minted url on the way back, so returning asks for a fresh one", async () => {
+    const user = userEvent.setup();
+    const clear = jest.fn();
+    const props = buildProps();
+    render(
+      <PayCard
+        {...props}
+        interaction={{ ...props.interaction, details: { ...props.interaction.details, clear } }}
+      />,
+    );
+
+    await user.press(screen.getByText("Card interaction"));
+    await user.press(screen.getByText("Back"));
+
+    expect(clear).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Feature flags")).toBeTruthy();
   });
 
   it("wires onboarding actions", async () => {

--- a/devtools/pay-card/src/pay-card/PayCard.native.test.tsx
+++ b/devtools/pay-card/src/pay-card/PayCard.native.test.tsx
@@ -398,7 +398,7 @@ describe("PayCard (native)", () => {
     );
 
     await user.press(screen.getByText("Card interaction"));
-    await user.press(screen.getByText("Request Card Details"));
+    await user.press(screen.getByLabelText("Request Card Details"));
     // The colours are baked into the image, so they go out with the request. The stubbed theme
     // reports no scheme, which is the light branch.
     expect(request).toHaveBeenCalledWith({

--- a/devtools/pay-card/src/pay-card/PayCard.web.test.tsx
+++ b/devtools/pay-card/src/pay-card/PayCard.web.test.tsx
@@ -22,7 +22,16 @@ function buildProps(): PayCardToolProps {
       ],
       setStepDone: jest.fn(),
     },
-    interaction: { probes: [] },
+    interaction: {
+      probes: [],
+      details: {
+        imageUrl: undefined,
+        isFetching: false,
+        error: undefined,
+        request: jest.fn(),
+        clear: jest.fn(),
+      },
+    },
     balance: {
       baanxWallets: [],
       linkedWallets: [],

--- a/devtools/pay-card/src/types.ts
+++ b/devtools/pay-card/src/types.ts
@@ -43,12 +43,38 @@ export interface PayCardProbe {
   readonly run: () => void;
 }
 
+/** The four colours the provider paints the details image with. Hex, `#RGB` or `#RRGGBB`. */
+export interface PayCardDetailsCssProps {
+  readonly cardBackgroundColor?: string;
+  readonly cardTextColor?: string;
+  /** PAN is the card number: the provider draws it on its own strip. */
+  readonly panBackgroundColor?: string;
+  readonly panTextColor?: string;
+}
+
+/**
+ * The secure card details image.
+ *
+ * The provider renders PAN, CVV and expiry itself and hands back a URL whose token is the whole
+ * credential, so the image loads with no headers. The URL is single-use and short-lived: it is
+ * never rendered as text, never logged, and dropped when the screen is left.
+ */
+export interface PayCardDetailsImageProps {
+  readonly imageUrl: string | undefined;
+  readonly isFetching: boolean;
+  readonly error: string | undefined;
+  readonly request: (customCss?: PayCardDetailsCssProps) => void;
+  /** Drops the minted URL, so coming back to the screen mints a fresh one. */
+  readonly clear: () => void;
+}
+
 /**
  * Card interaction controls: call the signed-in cardholder's endpoints and read back what they
  * answer, so the data can be checked without a screen to render it.
  */
 export interface PayCardInteractionProps {
   readonly probes: readonly PayCardProbe[];
+  readonly details: PayCardDetailsImageProps;
 }
 
 /** One wallet exactly as `GET /v1/wallet/internal` answered. */

--- a/devtools/pay-card/src/usePayCardViewModel.native.test.ts
+++ b/devtools/pay-card/src/usePayCardViewModel.native.test.ts
@@ -27,7 +27,17 @@ function buildProps(overrides: Partial<PayCardToolProps> = {}): PayCardToolProps
       setStepDone: jest.fn(),
       ...overrides.onboarding,
     },
-    interaction: { probes: [], ...overrides.interaction },
+    interaction: {
+      probes: [],
+      details: {
+        imageUrl: undefined,
+        isFetching: false,
+        error: undefined,
+        request: jest.fn(),
+        clear: jest.fn(),
+      },
+      ...overrides.interaction,
+    },
     balance: {
       baanxWallets: [],
       linkedWallets: [],

--- a/devtools/pay-card/src/usePayCardViewModel.test.ts
+++ b/devtools/pay-card/src/usePayCardViewModel.test.ts
@@ -26,7 +26,17 @@ function buildProps(overrides: Partial<PayCardToolProps> = {}): PayCardToolProps
       setStepDone: jest.fn(),
       ...overrides.onboarding,
     },
-    interaction: { probes: [], ...overrides.interaction },
+    interaction: {
+      probes: [],
+      details: {
+        imageUrl: undefined,
+        isFetching: false,
+        error: undefined,
+        request: jest.fn(),
+        clear: jest.fn(),
+      },
+      ...overrides.interaction,
+    },
     balance: {
       baanxWallets: [],
       linkedWallets: [],


### PR DESCRIPTION
<!-- stac-man:stack-start -->
**Stack** _(managed by [stac-man](https://github.com/bluegardenproject/stac-man))_

- #21467 feat/LIVE-34778-card-details-token
- **#21468 feat/pay-card-devtools-card-details ← this PR**
- #21495 feat/LIVE-34792-link-unlink-card-wallet
- #21533 feat/pay-card-devtools-freeze-unfreeze
- #21569 feat/pay-card-asset-mapping
- #21571 feat/pay-card-wallet-counter-value
<!-- stac-man:stack-end -->

Nothing renders the secure details yet, so the endpoint's answer could not be
seen. The Card interaction screen now stands a placeholder where the card goes
and swaps in the provider's image once a developer asks for it.

- The image loads from the returned URL with no headers: the token in the query
  string is the whole credential, which is what makes an <Image> enough.
- Going back clears the minted URL. The provider spends it the first time the
  image is read, so a retained one renders nothing on the way back in.
- The URL is never rendered as text, and a test asserts it.