### PR TITLE
[LWM] ci(optimisation): skip bundler for non macOS jobs

### DIFF
--- a/apps/ledger-live-mobile/scripts/post.mjs
+++ b/apps/ledger-live-mobile/scripts/post.mjs
@@ -118,17 +118,19 @@ BRAZE_CUSTOM_ENDPOINT="sdk.fra-02.braze.eu"`;
     await $`rndebugger-open`;
   }
 
-  try {
-    await which("bundle");
+  if (os.platform() === "darwin") {
     try {
-      await $`bundle install`;
+      await which("bundle");
+      try {
+        await $`bundle install`;
+      } catch (error) {
+        echo(chalk.red(error));
+      }
     } catch (error) {
-      echo(chalk.red(error));
+      echo(
+        chalk.red("Error: `bundle` command is missing. Please install Bundler. https://bundler.io"),
+      );
     }
-  } catch (error) {
-    echo(
-      chalk.red("Error: `bundle` command is missing. Please install Bundler. https://bundler.io"),
-    );
   }
 
   let hashesAreEquals = false;


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Bundler is currently run on the postcommit and is not required for linux, causing a 30-40s performance hit. This PR skips bundler unless the post install is run on macOS

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-36840
- Test run: https://github.com/LedgerHQ/ledger-live/actions/runs/33670098194
