### PR TITLE
fix(contacts): offer only registerable networks in add address flow

### DIFF
--- a/.changeset/LIVE-36688-contacts-signable-networks.md
+++ b/.changeset/LIVE-36688-contacts-signable-networks.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@features/platform-contacts": patch
+---
+
+Fix the Contacts add address flow stalling on Continue by only offering networks the device can register an address on: EVM networks running their own coin app, such as Ethereum Classic, Sonic and Sei, are no longer selectable

--- a/features/flow/flow-contacts-add-address/src/state/useAddAddressCurrencySelectionViewModel.web.test.tsx
+++ b/features/flow/flow-contacts-add-address/src/state/useAddAddressCurrencySelectionViewModel.web.test.tsx
@@ -21,6 +21,17 @@ const ETHEREUM_SELECTION = {
   assetDisplayName: "Ethereum",
 } as const;
 
+const CONTACTS_DEVICE_APP_NAMES = new Set(["Ethereum", "Tron"]);
+
+function eligibleNetworkIdsOf(families: readonly string[]) {
+  return listCryptoCurrencies()
+    .filter(
+      network =>
+        families.includes(network.family) && CONTACTS_DEVICE_APP_NAMES.has(network.managerAppName),
+    )
+    .map(network => network.id);
+}
+
 function makeWrapper(contactsFeature?: Features["lwdContacts"]) {
   const resolved: Features = {
     ...FEATURE_FLAGS_DEFAULTS,
@@ -60,9 +71,7 @@ describe("useAddAddressCurrencySelectionViewModel", () => {
   it("passes production EVM network ids when feature params are missing", async () => {
     const selectCurrency = jest.fn().mockResolvedValue(null);
     const { result } = renderViewModel({ selectCurrency }, { enabled: true });
-    const expectedNetworkIds = listCryptoCurrencies()
-      .filter(network => network.family === "evm")
-      .map(network => network.id);
+    const expectedNetworkIds = eligibleNetworkIdsOf(["evm"]);
 
     let selectionResult: AddAddressCurrencySelectionResult | undefined;
     await act(async () => {
@@ -85,13 +94,11 @@ describe("useAddAddressCurrencySelectionViewModel", () => {
         enabled: true,
         params: {
           newBadge: false,
-          eligibleAddressFamilies: ["evm", "bitcoin"],
+          eligibleAddressFamilies: ["evm", "tron"],
         },
       },
     );
-    const expectedNetworkIds = listCryptoCurrencies()
-      .filter(network => network.family === "evm" || network.family === "bitcoin")
-      .map(network => network.id);
+    const expectedNetworkIds = eligibleNetworkIdsOf(["evm", "tron"]);
 
     let selectionResult: AddAddressCurrencySelectionResult | undefined;
     await act(async () => {

--- a/features/platform/contacts/README.md
+++ b/features/platform/contacts/README.md
@@ -25,7 +25,7 @@ ports, address-entry primitives, and shared analytics building blocks used by fl
 - `useContactsFeature()` and related resolvers: expose the Contacts feature configuration for both
   applications and Contacts leaf flows.
 - `resolveEligibleAddressCurrencyIds()`: resolves configured Contacts families to production
-  network identifiers.
+  network identifiers, keeping only the networks the device can register an address on.
 - `ContactEditPort` and `createContactEditPort()`: define and implement the shared Contact rename
   operation, including device credentials for external contacts.
 - `ContactAddressEditPort` and `createContactAddressEditPort()`: define and implement the shared

--- a/features/platform/contacts/src/device/resolveContactDeviceContext.test.ts
+++ b/features/platform/contacts/src/device/resolveContactDeviceContext.test.ts
@@ -1,5 +1,6 @@
 import { ContactCurrencyIdSchema } from "@domain/entity-contact";
 import {
+  isContactDeviceCurrencySupported,
   resolveContactDeviceContext,
   UnsupportedContactDeviceCurrencyError,
 } from "./resolveContactDeviceContext";
@@ -67,5 +68,31 @@ describe("resolveContactDeviceContext", () => {
 
     // THEN
     expect(resolve).toThrow(UnsupportedContactDeviceCurrencyError);
+  });
+
+  it("GIVEN an EVM network running its own app WHEN resolving its context THEN it rejects the currency", () => {
+    // GIVEN
+    const currencyId = ContactCurrencyIdSchema.parse("ethereum_classic");
+
+    // WHEN
+    const resolve = () => resolveContactDeviceContext(currencyId);
+
+    // THEN
+    expect(resolve).toThrow(UnsupportedContactDeviceCurrencyError);
+  });
+});
+
+describe("isContactDeviceCurrencySupported", () => {
+  it.each([
+    ["ethereum", true],
+    ["polygon", true],
+    ["base/erc20/usd_coin", true],
+    ["tron", true],
+    ["ethereum_classic", false],
+    ["bitcoin", false],
+  ])("GIVEN %s THEN it reports %s", (currencyId, isSupported) => {
+    expect(isContactDeviceCurrencySupported(ContactCurrencyIdSchema.parse(currencyId))).toBe(
+      isSupported,
+    );
   });
 });

--- a/features/platform/contacts/src/device/resolveContactDeviceContext.ts
+++ b/features/platform/contacts/src/device/resolveContactDeviceContext.ts
@@ -1,5 +1,5 @@
 import type { ContactAddress } from "@domain/entity-contact";
-import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { findCryptoCurrencyById, type CryptoCurrency } from "@domain/entity-currency-crypto";
 import type { ContactsDeviceInitializationInput } from "./types";
 
 const SUPPORTED_MANAGER_APP_NAMES = new Set(["Ethereum", "Tron"]);
@@ -24,13 +24,30 @@ export const CONTACTS_DASHBOARD_INITIALIZATION_INPUT: ContactsDeviceInitializati
   requireLatestFirmware: false,
 };
 
-export function resolveContactDeviceContext(
+function findContactDeviceCurrency(
   currencyId: ContactAddress["currencyId"],
-): ContactDeviceContext {
+): CryptoCurrency | undefined {
   const currency =
     findCryptoCurrencyById(currencyId) ?? findCryptoCurrencyById(currencyId.split("/")[0]);
 
-  if (currency === undefined || !SUPPORTED_MANAGER_APP_NAMES.has(currency.managerAppName)) {
+  return currency !== undefined && SUPPORTED_MANAGER_APP_NAMES.has(currency.managerAppName)
+    ? currency
+    : undefined;
+}
+
+/** The Contacts kit keys its family table by coin app, and several EVM networks ship their own. */
+export function isContactDeviceCurrencySupported(
+  currencyId: ContactAddress["currencyId"],
+): boolean {
+  return findContactDeviceCurrency(currencyId) !== undefined;
+}
+
+export function resolveContactDeviceContext(
+  currencyId: ContactAddress["currencyId"],
+): ContactDeviceContext {
+  const currency = findContactDeviceCurrency(currencyId);
+
+  if (currency === undefined) {
     throw new UnsupportedContactDeviceCurrencyError(currencyId);
   }
 

--- a/features/platform/contacts/src/utils/resolveEligibleAddressCurrencyIds.ts
+++ b/features/platform/contacts/src/utils/resolveEligibleAddressCurrencyIds.ts
@@ -1,7 +1,9 @@
 import { listCryptoCurrencies, type CryptoCurrency } from "@domain/entity-currency-crypto";
+import { isContactDeviceCurrencySupported } from "../device/resolveContactDeviceContext";
 
 export type EligibleAddressNetwork = Readonly<Pick<CryptoCurrency, "id" | "family">>;
 
+/** Every contact address is signed on the device, so an eligible family alone is not enough. */
 export function resolveEligibleAddressCurrencyIds(
   eligibleFamilies: readonly string[],
   networks: readonly EligibleAddressNetwork[] = listCryptoCurrencies(),
@@ -10,7 +12,7 @@ export function resolveEligibleAddressCurrencyIds(
   const networkIds = new Set<CryptoCurrency["id"]>();
 
   for (const network of networks) {
-    if (families.has(network.family)) {
+    if (families.has(network.family) && isContactDeviceCurrencySupported(network.id)) {
       networkIds.add(network.id);
     }
   }

--- a/features/platform/contacts/src/utils/resolveEligibleAddressCurrencyIds.web.test.ts
+++ b/features/platform/contacts/src/utils/resolveEligibleAddressCurrencyIds.web.test.ts
@@ -1,4 +1,5 @@
 import { getCryptoCurrencyById, listCryptoCurrencies } from "@domain/entity-currency-crypto";
+import { resolveContactDeviceContext } from "../device/resolveContactDeviceContext";
 import {
   resolveEligibleAddressCurrencyIds,
   type EligibleAddressNetwork,
@@ -8,13 +9,14 @@ const NETWORKS: readonly EligibleAddressNetwork[] = [
   { id: getCryptoCurrencyById("ethereum").id, family: "evm" },
   { id: getCryptoCurrencyById("bitcoin").id, family: "bitcoin" },
   { id: getCryptoCurrencyById("base").id, family: "evm" },
+  { id: getCryptoCurrencyById("tron").id, family: "tron" },
   { id: getCryptoCurrencyById("solana").id, family: "solana" },
 ];
 
 describe("resolveEligibleAddressCurrencyIds", () => {
   it("resolves the default EVM family from production networks", () => {
     const expectedNetworkIds = listCryptoCurrencies()
-      .filter(network => network.family === "evm")
+      .filter(network => network.family === "evm" && network.managerAppName === "Ethereum")
       .map(network => network.id);
     const excludedNetworkIds = listCryptoCurrencies(true)
       .filter(
@@ -29,11 +31,20 @@ describe("resolveEligibleAddressCurrencyIds", () => {
     expect(networkIds).toEqual(expect.not.arrayContaining(excludedNetworkIds));
   });
 
+  it("drops networks the device cannot register, so every offered network reaches a signature", () => {
+    const networkIds = resolveEligibleAddressCurrencyIds(["evm"]);
+
+    expect(networkIds).not.toContain("ethereum_classic");
+    for (const networkId of networkIds) {
+      expect(() => resolveContactDeviceContext(networkId)).not.toThrow();
+    }
+  });
+
   it("resolves future multi-family values in network order", () => {
-    expect(resolveEligibleAddressCurrencyIds(["evm", "bitcoin"], NETWORKS)).toEqual([
+    expect(resolveEligibleAddressCurrencyIds(["evm", "tron"], NETWORKS)).toEqual([
       "ethereum",
-      "bitcoin",
       "base",
+      "tron",
     ]);
   });
 


### PR DESCRIPTION
### 📝 Description

Adding an address to a contact could dead-end: entering a name and tapping **Continue** did nothing — no device prompt, no error, no way forward.

**Previous behaviour**

The network picker and the device hand-off disagreed about which networks are supported:

- `resolveEligibleAddressCurrencyIds` offered every network in an eligible *family* (`evm` by default).
- `resolveContactDeviceContext` only accepts networks whose Ledger coin app the Contacts kit knows (`Ethereum` and `Tron`).

23 EVM networks fall in that gap — mostly dead legacy chains, but also Ethereum Classic, Sonic and Sei. Picking one threw `UnsupportedContactDeviceCurrencyError` while building the operation, i.e. *before* the intent existed, so `setActiveIntent` never fired, the Device Intent Executor never mounted, and the throw was swallowed by the `console.warn` catch in `useContactDetailScreenViewModel`.

**Fix**

`resolveEligibleAddressCurrencyIds` now also gates on device support, so a network can only be offered if the flow can actually reach a signature on it. The supported-app check in `resolveContactDeviceContext` is extracted into an exported `isContactDeviceCurrencySupported` predicate rather than duplicated.

`selectableNetworkIds` disables rather than hides, so the affected networks stay visible and greyed out and tapping one shows the existing Contacts explanation ("… isn't supported yet") instead of a button that silently does nothing. Desktop shares the resolver, so it gets the same fix through its built-in tooltip.

**Regression check**

`resolveEligibleAddressCurrencyIds.web.test.ts` asserts the invariant directly — every network the picker offers must resolve a device context — so a newly added EVM network with its own coin app fails the suite instead of reaching users.

Note: a second cause of the same symptom, the add-address drawer holding the queued-bottom-sheet slot so the executor could never open, was fixed separately in 1c9242dda3a.



https://github.com/user-attachments/assets/2bc25014-2a8a-4cad-b9e0-b230833fe92c




### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36688](https://ledgerhq.atlassian.net/browse/LIVE-36688)
- **ADR** (if any): n/a

[LIVE-36688]: https://ledgerhq.atlassian.net/browse/LIVE-36688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ