### PR TITLE
fix(bottom-sheet): stop keyboard disappearing after sheet dismissal

### DIFF
--- a/.changeset/LIVE-36689-edit-contact-keyboard.md
+++ b/.changeset/LIVE-36689-edit-contact-keyboard.md
@@ -1,0 +1,6 @@
+---
+"@shared/ui-queued-bottom-sheet": patch
+"live-mobile": patch
+---
+
+Fix the keyboard disappearing instantly when editing a contact name on Mobile. A bottom sheet retracts the keyboard when its close begins, but it also did so again when its dismissal finally landed — by then the sheet that replaced it (here, the rename drawer) had already raised the keyboard for its own field, so the late retraction stole it. A dismissal now only retracts the keyboard when it bypassed the close animation entirely.

--- a/shared/ui-queued-bottom-sheet/src/internals/useQueuedBottomSheet.native.test.ts
+++ b/shared/ui-queued-bottom-sheet/src/internals/useQueuedBottomSheet.native.test.ts
@@ -695,6 +695,45 @@ describe("useQueuedBottomSheet", () => {
     expect(dismissKeyboard).toHaveBeenCalled();
   });
 
+  it("retracts the keyboard when a dismissal bypasses the close animation", () => {
+    const dismissKeyboard = jest.spyOn(Keyboard, "dismiss");
+    jest.spyOn(Keyboard, "isVisible").mockReturnValue(true);
+    const { signalOpen } = setupBottomSheetStateCapture();
+
+    const { result } = renderHook(() => useQueuedBottomSheet({ isRequestingToBeOpened: true }));
+
+    signalOpen();
+
+    act(() => {
+      result.current.handleDismiss();
+    });
+
+    expect(dismissKeyboard).toHaveBeenCalled();
+  });
+
+  it("leaves the keyboard alone when the dismissal lands after the close already handled it", () => {
+    const dismissKeyboard = jest.spyOn(Keyboard, "dismiss");
+    const isKeyboardVisible = jest.spyOn(Keyboard, "isVisible").mockReturnValue(false);
+    const { signalOpen, signalClose } = setupBottomSheetStateCapture();
+
+    const { result } = renderHook(() => useQueuedBottomSheet({ isRequestingToBeOpened: true }));
+
+    signalOpen();
+    signalClose();
+
+    expect(dismissKeyboard).not.toHaveBeenCalled();
+
+    // The sheet that took over focuses its own input, so the keyboard is up again by the time this
+    // sheet's onDismiss finally arrives.
+    isKeyboardVisible.mockReturnValue(true);
+
+    act(() => {
+      result.current.handleDismiss();
+    });
+
+    expect(dismissKeyboard).not.toHaveBeenCalled();
+  });
+
   it("does not reopen after dismiss when it is no longer requested (normal close)", () => {
     const { signalOpen, signalClose } = setupBottomSheetStateCapture();
     let isRequestingToBeOpened = true;

--- a/shared/ui-queued-bottom-sheet/src/internals/useQueuedBottomSheet.native.ts
+++ b/shared/ui-queued-bottom-sheet/src/internals/useQueuedBottomSheet.native.ts
@@ -229,10 +229,12 @@ export function useQueuedBottomSheet({
   const handleDismiss = useCallback(() => {
     logBottomSheet("BottomSheet dismissed (onDismiss)");
 
-    dismissKeyboard();
-
-    // Fallback for dismissals that bypass the close animation (and thus handleAnimate).
+    // Fallback for dismissals that bypass the close animation (and thus handleAnimate). An
+    // orderly close already retracted the keyboard when it began, and onDismiss can land long
+    // after that — by then the sheet that took over may have raised the keyboard for its own
+    // input, and retracting it again would steal it.
     if (stateRef.current === "open") {
+      dismissKeyboard();
       onCloseRef.current?.();
     }
 


### PR DESCRIPTION
### 📝 Description

**Previous behaviour:** on Mobile, tapping `Edit contact > Edit Name` opened the rename drawer with the keyboard, and the keyboard then vanished instantly. The sheet stayed open and correctly sized; tapping the name field brought the keyboard back and it stayed.

**Cause:** a `QueuedBottomSheet` retracted the keyboard twice on its way out — once when the close animation starts (`handleClose` / `handleAnimate`) and again unconditionally when gorhom's `onDismiss` landed. `Keyboard.dismiss()` is global, not scoped to the calling sheet.

Tapping "Edit name" closes the actions-menu sheet and opens the rename drawer in the same React commit. The actions menu retracted the keyboard at close-start (a no-op — nothing was focused yet), the rename drawer then opened and focused its field so the keyboard rose, and only afterwards did the actions menu's `onDismiss` arrive and pull that keyboard down. That callback can land hundreds of milliseconds late, which is why the hook already carries a 600 ms `DISMISS_FALLBACK_DELAY_MS` for the case where it never arrives at all.

**Fix:** `handleDismiss` now retracts the keyboard only when the dismissal bypassed the close animation, the one case where nothing has retracted it yet. A dismissal that follows an orderly close leaves the keyboard alone, so it can no longer steal focus from the sheet that replaced it.

This is the same class of bug the legacy drawer fixed with its `preventKeyboardDismissOnClose` opt-out; the shared queued-sheet package had no equivalent guard. Fixing it in the shared hook covers every sheet-to-sheet hand-off rather than just this flow, and needs no opt-in from callers.

**Regression cover:** two tests in `useQueuedBottomSheet.native.test.ts` pin both branches — a dismissal that bypasses the close still retracts the keyboard, and one landing after an orderly close leaves it alone.

Checked against the earlier LIVE-35853 fix, where retracting the keyboard as an edit-address sheet closes is needed so the sheet underneath lays out correctly: that retraction happens at close-start and is untouched.

I deliberately did not add a focus retry to `ContactNameInput` — that would paper over the race rather than remove it.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36689](https://ledgerhq.atlassian.net/browse/LIVE-36689)
- **ADR** (if any): n/a

[LIVE-36689]: https://ledgerhq.atlassian.net/browse/LIVE-36689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ