### PR TITLE
[LWM] feat(perps): close the mobile deposit with a transaction signed screen

### DIFF
--- a/.changeset/perps-transaction-signed-mobile.md
+++ b/.changeset/perps-transaction-signed-mobile.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Close the Perps deposit flow on mobile with a transaction signed screen, from which the user can follow the deposit on the status of the swap that funds it. It replaces the deposit form once the transaction is broadcast, so going back leaves the flow rather than returning to a form that has nothing left to do.

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -69,6 +69,7 @@ import { BaseNavigatorStackParamList } from "./types/BaseNavigator";
 import DeviceConnect, { deviceConnectHeaderOptions } from "~/screens/DeviceConnect";
 import PerpsSign from "LLM/features/Perps/screens/PerpsSign/PerpsSignScreen";
 import PerpsDeposit from "LLM/features/Perps/screens/PerpsDeposit/PerpsDepositScreen";
+import PerpsTransactionSigned from "LLM/features/Perps/screens/PerpsTransactionSigned/PerpsTransactionSignedScreen";
 import NoFundsFlowNavigator from "./NoFundsFlowNavigator";
 import StakeFlowNavigator from "./StakeFlowNavigator";
 import { RecoverPlayer } from "~/screens/Protect/Player";
@@ -585,6 +586,14 @@ export default function BaseNavigator() {
           options={{
             title: t("perpsDeposit.title"),
             headerStyle: { backgroundColor: lumenBaseColor },
+            contentStyle: { backgroundColor: lumenBaseColor },
+          }}
+        />
+        <Stack.Screen
+          name={ScreenName.PerpsTransactionSigned}
+          component={PerpsTransactionSigned}
+          options={{
+            headerShown: false,
             contentStyle: { backgroundColor: lumenBaseColor },
           }}
         />

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
@@ -17,7 +17,7 @@ import type {
 } from "@ledgerhq/live-common/wallet-api/Perps/server";
 import type { SendFlowInitParams } from "@ledgerhq/live-common/flows/send/types";
 import type { DecodedURISchemePayment } from "@ledgerhq/live-common/flows/send/utils/uriScheme";
-import type { PerpsTransactionSignedParams } from "LLM/features/Perps/screens/PerpsTransactionSigned/usePerpsTransactionSignedViewModel";
+import type { PerpsTransactionSignedParams } from "LLM/features/Perps/types";
 import type { AssetDetailNavigatorParamsList } from "LLM/features/AssetDetail/types";
 import type { AssetsNavigatorParamsList } from "LLM/features/Assets/types";
 import type { DeviceSelectionNavigatorParamsList } from "LLM/features/DeviceSelection/types";

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
@@ -17,6 +17,7 @@ import type {
 } from "@ledgerhq/live-common/wallet-api/Perps/server";
 import type { SendFlowInitParams } from "@ledgerhq/live-common/flows/send/types";
 import type { DecodedURISchemePayment } from "@ledgerhq/live-common/flows/send/utils/uriScheme";
+import type { PerpsTransactionSignedParams } from "LLM/features/Perps/screens/PerpsTransactionSigned/usePerpsTransactionSignedViewModel";
 import type { AssetDetailNavigatorParamsList } from "LLM/features/AssetDetail/types";
 import type { AssetsNavigatorParamsList } from "LLM/features/Assets/types";
 import type { DeviceSelectionNavigatorParamsList } from "LLM/features/DeviceSelection/types";
@@ -366,6 +367,7 @@ export type BaseNavigatorStackParamList = {
     onCancel: () => void;
   };
   [ScreenName.PerpsDeposit]: PerpsDepositUiParams;
+  [ScreenName.PerpsTransactionSigned]: PerpsTransactionSignedParams;
   [ScreenName.DeeplinkInstallAppDeviceSelection]: {
     appKey: string;
   };

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -114,6 +114,7 @@ export enum ScreenName {
   DeviceConnect = "DeviceConnect",
   PerpsSign = "PerpsSign",
   PerpsDeposit = "PerpsDeposit",
+  PerpsTransactionSigned = "PerpsTransactionSigned",
   EditAccountName = "EditAccountName",
   EditDeviceName = "EditDeviceName",
   Card = "Card",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -9875,6 +9875,11 @@
   "perpsDepositSign": {
     "terms": "By signing this transaction, I accept <termsLink>SwapKit by NEAR Intents T&C</termsLink>"
   },
+  "perpsTransactionSigned": {
+    "title": "Transaction signed",
+    "description": "You'll receive your {{currency}} once confirmed on the blockchain",
+    "viewTransaction": "View transaction"
+  },
   "perpsDeposit": {
     "title": "Deposit",
     "inputDepositAmount": "Deposit ~{{value}}",

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/hooks/__tests__/usePerpsDepositExecution.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/hooks/__tests__/usePerpsDepositExecution.test.ts
@@ -204,7 +204,8 @@ describe("usePerpsDepositExecution", () => {
 
     expect(mockBroadcast).toHaveBeenCalledWith({ operation });
     expect(onSwapSuccess).toHaveBeenCalledWith({ operationHash: "0xhash", swapId: "swap-1" });
-    expect(onDone).toHaveBeenCalled();
+    // Handed on so the receipt can offer to track the swap that funds the deposit.
+    expect(onDone).toHaveBeenCalledWith({ swapId: "swap-1" });
   });
 
   it("records the swap at the quoted price, not the one the payload implies", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/hooks/usePerpsDepositExecution.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/hooks/usePerpsDepositExecution.ts
@@ -60,8 +60,14 @@ export type PerpsDepositExecution = Readonly<{
   retry: () => void;
 }>;
 
+/** What a signed deposit leaves behind for the screen that reports it. */
+export type PerpsDepositOutcome = Readonly<{
+  /** Only set when the provider issued one, so the deposit can be tracked. */
+  swapId?: string;
+}>;
+
 export type PerpsDepositExecutionCallbacks = Readonly<{
-  onDone: () => void;
+  onDone: (outcome: PerpsDepositOutcome) => void;
   onRefused: () => void;
 }>;
 
@@ -269,7 +275,7 @@ export function usePerpsDepositExecution(
 
       if (!signed) return;
 
-      onDone();
+      onDone({ swapId: signed.swapId });
     } catch (e) {
       if (isUserRefusal(e)) {
         onRefused();

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__integrations__/perpsDepositSign.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__integrations__/perpsDepositSign.integration.test.tsx
@@ -5,6 +5,7 @@ import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import type { Account } from "@ledgerhq/types-live";
 import { act, render, screen } from "@tests/test-renderer";
 import type { PerpsDepositExecutionCallbacks } from "LLM/features/Perps/hooks/usePerpsDepositExecution";
+import { ScreenName } from "~/const";
 import PerpsDepositScreen from "../PerpsDepositScreen";
 
 const mockOpenDrawer = jest.fn();
@@ -67,7 +68,12 @@ function createAccount(id: string, spendableBalance: number): Account {
 const receiverAccount = createAccount("receiver-1", 0);
 const fundingAccount = createAccount("funding-1", 10000);
 
-const mockNavigation = { navigate: jest.fn(), goBack: jest.fn(), setOptions: jest.fn() };
+const mockNavigation = {
+  navigate: jest.fn(),
+  replace: jest.fn(),
+  goBack: jest.fn(),
+  setOptions: jest.fn(),
+};
 const mockRoute = { params: { receiverAccount } };
 
 function renderDeposit() {
@@ -167,8 +173,22 @@ describe("PerpsDepositSign integration", () => {
     await user.press(await fillFormAndReview(user));
     await user.press(await screen.findByTestId("select-device"));
 
-    act(() => capturedCallbacks?.onDone());
+    act(() => capturedCallbacks?.onDone({ swapId: "swap-1" }));
 
     expect(screen.queryByTestId("perps-deposit-sign-step")).not.toBeOnTheScreen();
+  });
+
+  it("hands the signed deposit to the receipt", async () => {
+    const { user } = renderDeposit();
+
+    await user.press(await fillFormAndReview(user));
+    await user.press(await screen.findByTestId("select-device"));
+
+    act(() => capturedCallbacks?.onDone({ swapId: "swap-1" }));
+
+    expect(mockNavigation.replace).toHaveBeenCalledWith(
+      ScreenName.PerpsTransactionSigned,
+      expect.objectContaining({ receiveCurrencyTicker: "ETH", swapId: "swap-1" }),
+    );
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/__tests__/usePerpsDepositViewModel.test.ts
@@ -3,7 +3,9 @@ import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import type { Account } from "@ledgerhq/types-live";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { PERPS_DEPOSIT_QUOTE_PROVIDER } from "@ledgerhq/live-common/wallet-api/Perps/depositQuote";
 import { act, renderHook } from "@tests/test-renderer";
+import { ScreenName } from "~/const";
 import { usePerpsDepositViewModel } from "../usePerpsDepositViewModel";
 
 const mockOpenDrawer = jest.fn();
@@ -44,10 +46,11 @@ const fundingAccount = createAccount("funding-1", "ethereum", 10000);
 /** Holds more than the form can ask for, so the balance cap never kicks in. */
 const fundedAccount = createAccount("funding-2", "ethereum", 1e18);
 
-function createProps(navigate = jest.fn()) {
+function createProps(navigate = jest.fn(), replace = jest.fn()) {
   return {
-    props: { navigation: { navigate }, route: { params: { receiverAccount } } } as never,
+    props: { navigation: { navigate, replace }, route: { params: { receiverAccount } } } as never,
     navigate,
+    replace,
   };
 }
 
@@ -382,7 +385,7 @@ describe("usePerpsDepositViewModel", () => {
 
     function renderReviewedDeposit() {
       mockCalculate.mockReturnValue(2.5e16);
-      const { props } = createProps();
+      const { props, replace } = createProps();
       const { result } = renderViewModel(props);
 
       act(() => result.current.pickDepositAccount());
@@ -390,11 +393,11 @@ describe("usePerpsDepositViewModel", () => {
       typeAmount(result.current.pressAmountKey, "20");
       act(() => result.current.handleReview());
 
-      return result;
+      return { result, replace };
     }
 
     it("swaps the summary for the device step once the deposit is handed over", () => {
-      const result = renderReviewedDeposit();
+      const { result } = renderReviewedDeposit();
 
       act(() => result.current.handOverToDevice());
 
@@ -403,7 +406,7 @@ describe("usePerpsDepositViewModel", () => {
     });
 
     it("brings the summary back, amounts intact, when signing is declined", () => {
-      const result = renderReviewedDeposit();
+      const { result } = renderReviewedDeposit();
       const reviewed = result.current.reviewParams;
 
       act(() => result.current.handOverToDevice());
@@ -415,7 +418,7 @@ describe("usePerpsDepositViewModel", () => {
     });
 
     it("keeps the device after a decline, so handing over again skips the device list", () => {
-      const result = renderReviewedDeposit();
+      const { result } = renderReviewedDeposit();
 
       act(() => result.current.handOverToDevice());
       act(() => result.current.selectSigningDevice(device));
@@ -425,15 +428,40 @@ describe("usePerpsDepositViewModel", () => {
     });
 
     it("forgets the device once the deposit lands, so the next one starts at selection", () => {
-      const result = renderReviewedDeposit();
+      const { result } = renderReviewedDeposit();
 
       act(() => result.current.handOverToDevice());
       act(() => result.current.selectSigningDevice(device));
-      act(() => result.current.endSigning());
+      act(() => result.current.endSigning({ swapId: "swap-1" }));
 
       expect(result.current.isSignOpen).toBe(false);
       expect(result.current.isReviewOpen).toBe(false);
       expect(result.current.signingDevice).toBeUndefined();
+    });
+
+    it("replaces the form with the receipt, so back leaves the flow", () => {
+      const { result, replace } = renderReviewedDeposit();
+
+      act(() => result.current.handOverToDevice());
+      act(() => result.current.endSigning({ swapId: "swap-1" }));
+
+      expect(replace).toHaveBeenCalledWith(ScreenName.PerpsTransactionSigned, {
+        receiveCurrencyTicker: "ETH",
+        swapId: "swap-1",
+        provider: PERPS_DEPOSIT_QUOTE_PROVIDER,
+      });
+    });
+
+    it("still shows the receipt when the provider issued no swap id", () => {
+      const { result, replace } = renderReviewedDeposit();
+
+      act(() => result.current.handOverToDevice());
+      act(() => result.current.endSigning({}));
+
+      expect(replace).toHaveBeenCalledWith(
+        ScreenName.PerpsTransactionSigned,
+        expect.objectContaining({ swapId: undefined }),
+      );
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsDepositSign/__tests__/usePerpsDepositSignViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsDepositSign/__tests__/usePerpsDepositSignViewModel.test.ts
@@ -126,9 +126,9 @@ describe("usePerpsDepositSignViewModel", () => {
   it("reports success without reopening the summary", () => {
     const { onDone, onRefused } = renderSignViewModel(device);
 
-    act(() => capturedCallbacks?.onDone());
+    act(() => capturedCallbacks?.onDone({ swapId: "swap-1" }));
 
-    expect(onDone).toHaveBeenCalled();
+    expect(onDone).toHaveBeenCalledWith({ swapId: "swap-1" });
     expect(onRefused).not.toHaveBeenCalled();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsDepositSign/usePerpsDepositSignViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/components/PerpsDepositSign/usePerpsDepositSignViewModel.ts
@@ -5,6 +5,7 @@ import type { SetHeaderOptionsRequest } from "~/components/SelectDevice2";
 import {
   usePerpsDepositExecution,
   type PerpsDepositDeviceStep,
+  type PerpsDepositOutcome,
 } from "LLM/features/Perps/hooks/usePerpsDepositExecution";
 import { isUserRefusal } from "LLM/features/Perps/utils/isUserRefusal";
 
@@ -14,7 +15,7 @@ export type PerpsDepositSignProps = Readonly<PerpsDepositReviewParams> &
   Readonly<{
     selectedDevice: Device | null | undefined;
     onSelectDevice: (device: Device | null | undefined) => void;
-    onDone: () => void;
+    onDone: (outcome: PerpsDepositOutcome) => void;
     onRefused: () => void;
   }>;
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/index.tsx
@@ -48,7 +48,11 @@ function AmountMessage({
 
   if (statusError) {
     return (
-      <Text typography="body3" lx={{ color: "error" }} testID="perps-deposit-form-error">
+      <Text
+        typography="body3"
+        lx={{ color: "error", textAlign: "center" }}
+        testID="perps-deposit-form-error"
+      >
         {t(statusError.labelKey, { provider })}
       </Text>
     );

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
@@ -3,6 +3,7 @@ import BigNumber from "bignumber.js";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit, valueFromUnit } from "@ledgerhq/live-common/currencies/index";
 import { PERPS_UI_USE_CASE } from "@ledgerhq/live-common/wallet-api/ModularDrawer/uiUseCase";
+import { PERPS_DEPOSIT_QUOTE_PROVIDER } from "@ledgerhq/live-common/wallet-api/Perps/depositQuote";
 import {
   useCalculateCountervalueCallback,
   useCountervaluesState,
@@ -26,6 +27,7 @@ import {
   PERPS_DEPOSIT_DEFAULT_FUNDING_CURRENCY_ID,
   PERPS_DEPOSIT_DEFAULT_FUNDING_TICKER,
 } from "../../constants/depositFunding";
+import type { PerpsDepositOutcome } from "../../hooks/usePerpsDepositExecution";
 import type { PerpsReviewParams } from "./components/PerpsReview";
 import { usePerpsDepositQuote } from "./usePerpsDepositQuote";
 import { applyAmountKey, toAmountText } from "./utils/amountKeys";
@@ -71,11 +73,14 @@ export type PerpsDepositViewModel = Readonly<{
   handOverToDevice: () => void;
   /** The device declined, which is not a failure: the summary takes over again. */
   returnToReview: () => void;
-  /** Signed and broadcast, so nothing is left to sign. */
-  endSigning: () => void;
+  /** Signed and broadcast, so the form gives way to the receipt. */
+  endSigning: (outcome: PerpsDepositOutcome) => void;
 }>;
 
-export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepositViewModel {
+export function usePerpsDepositViewModel({
+  navigation,
+  route,
+}: NavigationProps): PerpsDepositViewModel {
   const { receiverAccount } = route.params;
 
   const walletState = useSelector(walletSelector);
@@ -92,7 +97,6 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
   const [signingDevice, setSigningDevice] = useState<Device | null | undefined>();
   const [reviewParams, setReviewParams] = useState<PerpsReviewParams | null>(null);
 
-  /** Read from the store so balances stay live while the form is open. */
   const depositAccount = useMemo(
     () => accounts.find(account => account.id === depositAccountId),
     [accounts, depositAccountId],
@@ -277,16 +281,23 @@ export function usePerpsDepositViewModel({ route }: NavigationProps): PerpsDepos
     setIsSignOpen(true);
   }, []);
 
-  /** The device is kept, so handing over again skips the device list. */
   const returnToReview = useCallback(() => {
     setIsSignOpen(false);
     setIsReviewOpen(true);
   }, []);
 
-  const endSigning = useCallback(() => {
-    setIsSignOpen(false);
-    setSigningDevice(undefined);
-  }, []);
+  const endSigning = useCallback(
+    ({ swapId }: PerpsDepositOutcome) => {
+      setIsSignOpen(false);
+      setSigningDevice(undefined);
+      navigation.replace(ScreenName.PerpsTransactionSigned, {
+        receiveCurrencyTicker: receiverCurrency.ticker,
+        swapId,
+        provider: PERPS_DEPOSIT_QUOTE_PROVIDER,
+      });
+    },
+    [navigation, receiverCurrency.ticker],
+  );
 
   return {
     headerDescription: `${receiverAccountName} · ${receiverAccountCounterValue}`,

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsTransactionSigned/PerpsTransactionSignedScreen.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsTransactionSigned/PerpsTransactionSignedScreen.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import type { RootComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { ScreenName } from "~/const";
+import { PerpsTransactionSignedView } from ".";
+import { usePerpsTransactionSignedViewModel } from "./usePerpsTransactionSignedViewModel";
+
+type NavigationProps = RootComposite<
+  StackNavigatorProps<BaseNavigatorStackParamList, ScreenName.PerpsTransactionSigned>
+>;
+
+export default function PerpsTransactionSignedScreen(props: NavigationProps) {
+  const viewModel = usePerpsTransactionSignedViewModel(props);
+  return <PerpsTransactionSignedView {...viewModel} />;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsTransactionSigned/__integrations__/perpsTransactionSigned.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsTransactionSigned/__integrations__/perpsTransactionSigned.integration.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import PerpsTransactionSignedScreen from "../PerpsTransactionSignedScreen";
+import type { PerpsTransactionSignedParams } from "../usePerpsTransactionSignedViewModel";
+
+const mockNavigation = { goBack: jest.fn() };
+
+const SIGNED_PARAMS: PerpsTransactionSignedParams = {
+  receiveCurrencyTicker: "USDC",
+  swapId: "swap-1",
+  provider: "swapkit",
+};
+
+function renderScreen(params: PerpsTransactionSignedParams = SIGNED_PARAMS) {
+  return render(
+    <PerpsTransactionSignedScreen
+      navigation={mockNavigation as never}
+      route={{ params } as never}
+    />,
+  );
+}
+
+describe("PerpsTransactionSigned integration", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should tell the holder the deposit is on its way", async () => {
+    renderScreen();
+
+    expect(await screen.findByTestId("perps-transaction-signed")).toBeOnTheScreen();
+    expect(screen.getByText("Transaction signed")).toBeOnTheScreen();
+    expect(
+      screen.getByText("You'll receive your USDC once confirmed on the blockchain"),
+    ).toBeOnTheScreen();
+  });
+
+  it("should offer to track the swap it was given", async () => {
+    const { user } = renderScreen();
+
+    await user.press(await screen.findByTestId("perps-transaction-signed-cta"));
+
+    expect(mockNavigation.goBack).toHaveBeenCalled();
+  });
+
+  it("should offer nothing to track without a swap id", async () => {
+    renderScreen({ receiveCurrencyTicker: "USDC" });
+
+    expect(await screen.findByTestId("perps-transaction-signed")).toBeOnTheScreen();
+    expect(screen.queryByTestId("perps-transaction-signed-cta")).not.toBeOnTheScreen();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsTransactionSigned/__integrations__/perpsTransactionSigned.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsTransactionSigned/__integrations__/perpsTransactionSigned.integration.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen } from "@tests/test-renderer";
 import PerpsTransactionSignedScreen from "../PerpsTransactionSignedScreen";
-import type { PerpsTransactionSignedParams } from "../usePerpsTransactionSignedViewModel";
+import type { PerpsTransactionSignedParams } from "../../../types";
 
 const mockNavigation = { goBack: jest.fn() };
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsTransactionSigned/__tests__/usePerpsTransactionSignedViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsTransactionSigned/__tests__/usePerpsTransactionSignedViewModel.test.ts
@@ -1,0 +1,63 @@
+import { act, renderHook } from "@tests/test-renderer";
+import { openSwapTransactionStatusDrawer } from "~/reducers/swapTransactionStatusDrawer";
+import {
+  usePerpsTransactionSignedViewModel,
+  type PerpsTransactionSignedParams,
+} from "../usePerpsTransactionSignedViewModel";
+
+const mockDispatch = jest.fn();
+jest.mock("~/context/hooks", () => ({
+  ...jest.requireActual("~/context/hooks"),
+  useDispatch: () => mockDispatch,
+}));
+
+const SIGNED_PARAMS: PerpsTransactionSignedParams = {
+  receiveCurrencyTicker: "USDC",
+  swapId: "swap-1",
+  provider: "swapkit",
+};
+
+function renderViewModel(params: PerpsTransactionSignedParams = SIGNED_PARAMS) {
+  const goBack = jest.fn();
+  const props = { navigation: { goBack }, route: { params } } as never;
+  const { result } = renderHook(() => usePerpsTransactionSignedViewModel(props));
+
+  return { result, goBack };
+}
+
+describe("usePerpsTransactionSignedViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("names the currency the deposit credits", () => {
+    const { result } = renderViewModel();
+
+    expect(result.current.receiveCurrencyTicker).toBe("USDC");
+  });
+
+  it("hands the swap to the status drawer, which tracks it from there", () => {
+    const { result, goBack } = renderViewModel();
+
+    act(() => result.current.handleViewTransaction?.());
+
+    expect(goBack).toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalledWith(
+      openSwapTransactionStatusDrawer({ swapId: "swap-1", provider: "swapkit" }),
+    );
+  });
+
+  it("offers nothing to track when the provider issued no swap id", () => {
+    const { result } = renderViewModel({ receiveCurrencyTicker: "USDC" });
+
+    expect(result.current.handleViewTransaction).toBeUndefined();
+  });
+
+  it("closes back to whatever opened the deposit", () => {
+    const { result, goBack } = renderViewModel();
+
+    act(() => result.current.handleClose());
+
+    expect(goBack).toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsTransactionSigned/__tests__/usePerpsTransactionSignedViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsTransactionSigned/__tests__/usePerpsTransactionSignedViewModel.test.ts
@@ -1,9 +1,7 @@
 import { act, renderHook } from "@tests/test-renderer";
 import { openSwapTransactionStatusDrawer } from "~/reducers/swapTransactionStatusDrawer";
-import {
-  usePerpsTransactionSignedViewModel,
-  type PerpsTransactionSignedParams,
-} from "../usePerpsTransactionSignedViewModel";
+import type { PerpsTransactionSignedParams } from "../../../types";
+import { usePerpsTransactionSignedViewModel } from "../usePerpsTransactionSignedViewModel";
 
 const mockDispatch = jest.fn();
 jest.mock("~/context/hooks", () => ({

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsTransactionSigned/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsTransactionSigned/index.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
+import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
+import { InfoState } from "LLM/components/InfoState";
+import { StatusGradient } from "LLM/components/StatusGradient";
+import { NavigationHeaderCloseButton } from "~/components/NavigationHeaderCloseButton";
+import { useTranslation } from "~/context/Locale";
+import type { PerpsTransactionSignedViewModel } from "./usePerpsTransactionSignedViewModel";
+
+export function PerpsTransactionSignedView({
+  receiveCurrencyTicker,
+  handleViewTransaction,
+  handleClose,
+}: Readonly<PerpsTransactionSignedViewModel>) {
+  const { t } = useTranslation();
+  const styles = useStyleSheet(
+    theme => ({
+      root: {
+        flex: 1,
+        backgroundColor: theme.colors.bg.base,
+      },
+      gradient: {
+        position: "absolute",
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+      },
+      safeArea: {
+        flex: 1,
+      },
+    }),
+    [],
+  );
+
+  return (
+    <View style={styles.root}>
+      <View pointerEvents="none" style={styles.gradient}>
+        <StatusGradient tone="success" testID="perps-transaction-signed-gradient" />
+      </View>
+
+      <SafeAreaView edges={["top", "bottom"]} style={styles.safeArea}>
+        <Box lx={{ paddingHorizontal: "s8", paddingTop: "s8", alignItems: "flex-start" }}>
+          <NavigationHeaderCloseButton
+            onPress={handleClose}
+            testIDSuffix="PerpsTransactionSigned"
+          />
+        </Box>
+        <Box lx={{ flex: 1, paddingHorizontal: "s16", paddingBottom: "s16" }}>
+          <InfoState
+            preset="success"
+            title={t("perpsTransactionSigned.title")}
+            description={t("perpsTransactionSigned.description", {
+              currency: receiveCurrencyTicker,
+            })}
+            primaryCta={
+              handleViewTransaction
+                ? {
+                    label: t("perpsTransactionSigned.viewTransaction"),
+                    onPress: handleViewTransaction,
+                    testID: "perps-transaction-signed-cta",
+                  }
+                : undefined
+            }
+            testID="perps-transaction-signed"
+          />
+        </Box>
+      </SafeAreaView>
+    </View>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsTransactionSigned/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsTransactionSigned/index.tsx
@@ -3,7 +3,7 @@ import { View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
-import { InfoState } from "LLM/components/InfoState";
+import { InfoState } from "@shared/ui-info-state";
 import { StatusGradient } from "LLM/components/StatusGradient";
 import { NavigationHeaderCloseButton } from "~/components/NavigationHeaderCloseButton";
 import { useTranslation } from "~/context/Locale";

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsTransactionSigned/usePerpsTransactionSignedViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsTransactionSigned/usePerpsTransactionSignedViewModel.ts
@@ -5,15 +5,6 @@ import type { RootComposite, StackNavigatorProps } from "~/components/RootNaviga
 import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { ScreenName } from "~/const";
 
-export type PerpsTransactionSignedParams = Readonly<{
-  /** Ticker of the currency credited to the perps balance, e.g. "USDC". */
-  receiveCurrencyTicker: string;
-  /** Only set when the provider issued one, so the deposit can be tracked. */
-  swapId?: string;
-  /** Provider that quoted the deposit, which titles the status drawer. */
-  provider?: string;
-}>;
-
 type NavigationProps = RootComposite<
   StackNavigatorProps<BaseNavigatorStackParamList, ScreenName.PerpsTransactionSigned>
 >;

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsTransactionSigned/usePerpsTransactionSignedViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsTransactionSigned/usePerpsTransactionSignedViewModel.ts
@@ -1,0 +1,49 @@
+import { useCallback } from "react";
+import { useDispatch } from "~/context/hooks";
+import { openSwapTransactionStatusDrawer } from "~/reducers/swapTransactionStatusDrawer";
+import type { RootComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { ScreenName } from "~/const";
+
+export type PerpsTransactionSignedParams = Readonly<{
+  /** Ticker of the currency credited to the perps balance, e.g. "USDC". */
+  receiveCurrencyTicker: string;
+  /** Only set when the provider issued one, so the deposit can be tracked. */
+  swapId?: string;
+  /** Provider that quoted the deposit, which titles the status drawer. */
+  provider?: string;
+}>;
+
+type NavigationProps = RootComposite<
+  StackNavigatorProps<BaseNavigatorStackParamList, ScreenName.PerpsTransactionSigned>
+>;
+
+export type PerpsTransactionSignedViewModel = Readonly<{
+  receiveCurrencyTicker: string;
+  handleViewTransaction: (() => void) | undefined;
+  handleClose: () => void;
+}>;
+
+export function usePerpsTransactionSignedViewModel({
+  navigation,
+  route,
+}: NavigationProps): PerpsTransactionSignedViewModel {
+  const { receiveCurrencyTicker, swapId, provider } = route.params;
+  const dispatch = useDispatch();
+
+  const handleClose = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
+
+  const handleViewTransaction = useCallback(() => {
+    if (!swapId) return;
+    navigation.goBack();
+    dispatch(openSwapTransactionStatusDrawer({ swapId, provider }));
+  }, [dispatch, navigation, provider, swapId]);
+
+  return {
+    receiveCurrencyTicker,
+    handleViewTransaction: swapId ? handleViewTransaction : undefined,
+    handleClose,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/types.ts
@@ -1,0 +1,5 @@
+export type PerpsTransactionSignedParams = Readonly<{
+  receiveCurrencyTicker: string;
+  swapId?: string;
+  provider?: string;
+}>;


### PR DESCRIPTION
Stacked on #21457. Mobile port of #21260.

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/ade51be5-d0f5-4c01-a41f-15febb1ca5c8" />

Adds the transaction signed screen that closes the deposit flow, with a **View transaction** CTA into the swap status drawer. `onDone` now carries the `swapId`.

Also includes one unrelated one-liner: centres the wrapped "no quote" error.