### PR TITLE
[LWM] feat(perps): title the transaction detail drawer (LIVE-35330)

### DIFF
--- a/.changeset/perps-transaction-detail-mobile.md
+++ b/.changeset/perps-transaction-detail-mobile.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Name the transaction detail drawer after the Perps deposit it is funding, keeping the swapped pair on its own line, and offer a way back to Perps from it. Swap opens the same drawer unchanged.

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -105,7 +105,7 @@ import AssetsListNavigator from "LLM/features/Assets/Navigator";
 import AnalyticsNavigator from "LLM/features/Analytics/Navigator";
 import OperationsHistoryNavigator from "LLM/features/OperationsHistory/Navigator";
 import FeesNavigator from "./FeesNavigator";
-import { getEarnScreenOptions, getEarnScreenOptionsFromRouteParams } from "./getEarnScreenOptions";
+import { getEarnScreenOptionsFromRouteParams } from "./getEarnScreenOptions";
 import SignRawTransactionNavigator from "./SignRawTransactionNavigator";
 import LiveAppModalScreen from "LLM/features/LiveAppModal";
 

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -9880,6 +9880,11 @@
     "description": "You'll receive your {{currency}} once confirmed on the blockchain",
     "viewTransaction": "View transaction"
   },
+  "perpsTransactionStatus": {
+    "title": "Fund Perpetuals",
+    "currencies": "{{sendTicker}} → {{receiveTicker}}",
+    "returnToPerps": "Return to Perps"
+  },
   "perpsDeposit": {
     "title": "Deposit",
     "inputDepositAmount": "Deposit ~{{value}}",

--- a/apps/ledger-live-mobile/src/mvvm/components/RatioPicker/__tests__/RatioPicker.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/RatioPicker/__tests__/RatioPicker.test.tsx
@@ -4,19 +4,17 @@ import { RatioPicker } from "../index";
 
 const renderPicker = (props: Partial<React.ComponentProps<typeof RatioPicker>> = {}) => {
   const onChange = jest.fn();
-  const onMax = jest.fn();
   const { user } = render(
     <RatioPicker
       value={0}
       maxValue={100}
       decimalPlaces={2}
       onChange={onChange}
-      onMax={onMax}
       testIDPrefix="ratio"
       {...props}
     />,
   );
-  return { onChange, onMax, user };
+  return { onChange, user };
 };
 
 describe("RatioPicker", () => {
@@ -36,13 +34,12 @@ describe("RatioPicker", () => {
     expect(onChange).toHaveBeenCalledWith(5);
   });
 
-  it("delegates the max pill to its own handler", async () => {
-    const { onMax, onChange, user } = renderPicker();
+  it("fills the field with the whole balance from the max pill", async () => {
+    const { onChange, user } = renderPicker({ maxValue: 10.005, decimalPlaces: 2 });
 
     await user.press(screen.getByTestId("ratio-MAX"));
 
-    expect(onMax).toHaveBeenCalled();
-    expect(onChange).not.toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledWith(10);
   });
 
   it("disables the pill whose value the field already holds", async () => {
@@ -54,20 +51,19 @@ describe("RatioPicker", () => {
   });
 
   it("disables the max pill once the field holds the whole balance", async () => {
-    const { onMax, user } = renderPicker({ value: 100 });
+    const { onChange, user } = renderPicker({ value: 100 });
 
     await user.press(screen.getByTestId("ratio-MAX"));
 
-    expect(onMax).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   it("disables every pill when there is nothing to spend", async () => {
-    const { onChange, onMax, user } = renderPicker({ maxValue: 0 });
+    const { onChange, user } = renderPicker({ maxValue: 0 });
 
     await user.press(screen.getByTestId("ratio-25%"));
     await user.press(screen.getByTestId("ratio-MAX"));
 
     expect(onChange).not.toHaveBeenCalled();
-    expect(onMax).not.toHaveBeenCalled();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/components/RatioPicker/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/RatioPicker/index.tsx
@@ -9,7 +9,6 @@ type RatioPickerProps = Readonly<{
   maxValue: number;
   decimalPlaces: number;
   onChange: (value: number) => void;
-  onMax: () => void;
   testIDPrefix: string;
   disabled?: boolean;
 }>;
@@ -31,7 +30,6 @@ export function RatioPicker({
   maxValue,
   decimalPlaces,
   onChange,
-  onMax,
   testIDPrefix,
   disabled,
 }: RatioPickerProps) {
@@ -60,7 +58,7 @@ export function RatioPicker({
         size="sm"
         lx={{ flex: 1 }}
         disabled={disabled || maxValue === 0 || value === maxOption}
-        onPress={onMax}
+        onPress={() => onChange(maxOption)}
         testID={`${testIDPrefix}-${MAX_LABEL}`}
       >
         {MAX_LABEL}

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/index.tsx
@@ -84,7 +84,6 @@ function DepositForm({
   depositAccountName,
   depositAccountCounterValue,
   maxAmount,
-  selectMax,
   statusError,
   canReview,
   exceedsBalance,
@@ -134,7 +133,6 @@ function DepositForm({
           value={depositAmount}
           decimalPlaces={maxDecimalLength}
           onChange={selectAmountRatio}
-          onMax={selectMax}
           testIDPrefix="perps-deposit-ratio"
         />
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsDeposit/usePerpsDepositViewModel.ts
@@ -57,7 +57,6 @@ export type PerpsDepositViewModel = Readonly<{
   depositAccountName: string | null;
   depositAccountCounterValue: string | null;
   maxAmount: number;
-  selectMax: () => void;
   statusError: DepositFormError | null;
   canReview: boolean;
   exceedsBalance: boolean;
@@ -192,11 +191,6 @@ export function usePerpsDepositViewModel({
     [counterValueUnit.magnitude, depositAccountBalanceCounterValue],
   );
 
-  const selectMax = useCallback(() => {
-    if (maxAmount === null) return;
-    selectAmountRatio(maxAmount);
-  }, [maxAmount, selectAmountRatio]);
-
   const submitError = useMemo(
     () =>
       validateDepositFlow({
@@ -316,7 +310,6 @@ export function usePerpsDepositViewModel({
       : null,
     depositAccountCounterValue,
     maxAmount: maxAmount ?? 0,
-    selectMax,
     statusError,
     canReview,
     exceedsBalance,

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsTransactionSigned/__tests__/usePerpsTransactionSignedViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsTransactionSigned/__tests__/usePerpsTransactionSignedViewModel.test.ts
@@ -41,7 +41,11 @@ describe("usePerpsTransactionSignedViewModel", () => {
 
     expect(goBack).toHaveBeenCalled();
     expect(mockDispatch).toHaveBeenCalledWith(
-      openSwapTransactionStatusDrawer({ swapId: "swap-1", provider: "swapkit" }),
+      openSwapTransactionStatusDrawer({
+        swapId: "swap-1",
+        provider: "swapkit",
+        origin: "perps",
+      }),
     );
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsTransactionSigned/usePerpsTransactionSignedViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Perps/screens/PerpsTransactionSigned/usePerpsTransactionSignedViewModel.ts
@@ -29,7 +29,7 @@ export function usePerpsTransactionSignedViewModel({
   const handleViewTransaction = useCallback(() => {
     if (!swapId) return;
     navigation.goBack();
-    dispatch(openSwapTransactionStatusDrawer({ swapId, provider }));
+    dispatch(openSwapTransactionStatusDrawer({ swapId, provider, origin: "perps" }));
   }, [dispatch, navigation, provider, swapId]);
 
   return {

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__integrations__/SwapTransactionStatusDrawer.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__integrations__/SwapTransactionStatusDrawer.integration.test.tsx
@@ -26,6 +26,20 @@ function withSwapTransactionStatusDrawerOpen(state: State): State {
   };
 }
 
+function withPerpsSwapTransactionStatusDrawerOpen(state: State): State {
+  return {
+    ...state,
+    swapTransactionStatusDrawer: {
+      isOpen: true,
+      params: {
+        provider: "lifi",
+        swapId: "swap-1",
+        origin: "perps",
+      },
+    },
+  };
+}
+
 describe("SwapTransactionStatusDrawer", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -79,5 +93,39 @@ describe("SwapTransactionStatusDrawer", () => {
       });
     });
     expect(screen.queryByText("Swap BTC → ETH")).toBeNull();
+  });
+
+  it("should name the deposit it is funding when perps opens it", async () => {
+    render(<SwapTransactionStatusDrawerWrapper />, {
+      overrideInitialState: withPerpsSwapTransactionStatusDrawerOpen,
+    });
+
+    expect(await screen.findByText("Fund Perpetuals")).toBeOnTheScreen();
+    expect(screen.getByText("BTC → ETH")).toBeOnTheScreen();
+    expect(screen.queryByText("Swap BTC → ETH")).toBeNull();
+  });
+
+  it("should return to perps by closing the drawer over it", async () => {
+    const { store, user } = render(<SwapTransactionStatusDrawerWrapper />, {
+      overrideInitialState: withPerpsSwapTransactionStatusDrawerOpen,
+    });
+
+    await user.press(await screen.findByText("Return to Perps"));
+
+    await waitFor(() => {
+      expect(store.getState().swapTransactionStatusDrawer).toEqual({
+        isOpen: false,
+        params: null,
+      });
+    });
+  });
+
+  it("should offer no way back to perps when swap opens it", async () => {
+    render(<SwapTransactionStatusDrawerWrapper />, {
+      overrideInitialState: withSwapTransactionStatusDrawerOpen,
+    });
+
+    expect(await screen.findByText("Swap BTC → ETH")).toBeOnTheScreen();
+    expect(screen.queryByText("Return to Perps")).toBeNull();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__tests__/FooterSection.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__tests__/FooterSection.test.tsx
@@ -54,4 +54,25 @@ describe("FooterSection", () => {
 
     expect(screen.queryByText("View in explorer")).toBeNull();
   });
+
+  it("should offer a way back to perps once it has funded a deposit", async () => {
+    const onReturn = jest.fn();
+    const { user } = render(<FooterSection isLoading={false} origin="perps" onReturn={onReturn} />);
+
+    await user.press(screen.getByText("Return to Perps"));
+
+    expect(onReturn).toHaveBeenCalled();
+  });
+
+  it("should keep the way back to perps while the explorer link is still loading", () => {
+    render(<FooterSection isLoading origin="perps" onReturn={jest.fn()} />);
+
+    expect(screen.getByText("Return to Perps")).toBeVisible();
+  });
+
+  it("should offer no way back to perps for a plain swap", () => {
+    render(<FooterSection explorerUrl="https://explorer.test/tx/1" isLoading={false} />);
+
+    expect(screen.queryByText("Return to Perps")).toBeNull();
+  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__tests__/TransactionHeader.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__tests__/TransactionHeader.test.tsx
@@ -43,6 +43,36 @@ describe("TransactionHeader", () => {
     ).toBeVisible();
   });
 
+  it("should name the perps deposit and keep the swapped pair on its own line", () => {
+    render(
+      <TransactionHeader
+        sendCurrency={bitcoin}
+        receiveCurrency={ethereum}
+        createdAt={new Date(2024, 0, 2, 15, 4).getTime()}
+        locale="en-US"
+        origin="perps"
+      />,
+    );
+
+    expect(screen.getByText("Fund Perpetuals")).toBeVisible();
+    expect(screen.getByText("BTC → ETH")).toBeVisible();
+    expect(screen.queryByText("Swap BTC → ETH")).toBeNull();
+  });
+
+  it("should keep the swap title when no origin is given", () => {
+    render(
+      <TransactionHeader
+        sendCurrency={bitcoin}
+        receiveCurrency={ethereum}
+        createdAt={new Date(2024, 0, 2, 15, 4).getTime()}
+        locale="en-US"
+      />,
+    );
+
+    expect(screen.getByText("Swap BTC → ETH")).toBeVisible();
+    expect(screen.queryByTestId("swap-transaction-currencies")).toBeNull();
+  });
+
   it("should render token icons without a parent network badge", () => {
     render(
       <TransactionHeader

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__tests__/TransactionHeader.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/__tests__/TransactionHeader.test.tsx
@@ -91,4 +91,10 @@ describe("TransactionHeader", () => {
 
     expect(screen.queryByText("Swap BTC → ETH")).toBeNull();
   });
+
+  it("should name the perps deposit before the currencies resolve", () => {
+    render(<TransactionHeader locale="en-US" origin="perps" />);
+
+    expect(screen.getByText("Fund Perpetuals")).toBeVisible();
+  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Footer/FooterSection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/Footer/FooterSection.tsx
@@ -3,16 +3,23 @@ import { log } from "@ledgerhq/logs";
 import { Linking } from "react-native";
 import { Box, Button, Skeleton } from "@ledgerhq/lumen-ui-rnative";
 import { ExternalLink } from "@ledgerhq/lumen-ui-rnative/symbols";
+import type { SwapTransactionStatusOrigin } from "@ledgerhq/live-common/exchange/swapTransactionStatus/index";
 import { useFooterSectionViewModel } from "../../hooks/useFooterSectionViewModel";
 
 type FooterSectionProps = Readonly<{
   explorerUrl?: string;
   isLoading: boolean;
+  origin?: SwapTransactionStatusOrigin;
+  onReturn?: () => void;
 }>;
 
-export function FooterSection({ explorerUrl, isLoading }: FooterSectionProps) {
-  const { viewInExplorerLabel } = useFooterSectionViewModel();
+type ExplorerButtonProps = Readonly<{
+  explorerUrl?: string;
+  isLoading: boolean;
+  label: string;
+}>;
 
+function ExplorerButton({ explorerUrl, isLoading, label }: ExplorerButtonProps) {
   if (isLoading) {
     return <Skeleton lx={{ height: "s40", width: "full" }} />;
   }
@@ -37,7 +44,29 @@ export function FooterSection({ explorerUrl, isLoading }: FooterSectionProps) {
         })
       }
     >
-      {viewInExplorerLabel}
+      {label}
     </Button>
+  );
+}
+
+export function FooterSection({ explorerUrl, isLoading, origin, onReturn }: FooterSectionProps) {
+  const { viewInExplorerLabel, returnToPerpsLabel } = useFooterSectionViewModel();
+
+  return (
+    <Box lx={{ gap: "s8" }}>
+      {origin === "perps" && onReturn ? (
+        <Button
+          testID="swap-transaction-return-btn"
+          appearance="base"
+          size="md"
+          lx={{ width: "full" }}
+          onPress={onReturn}
+        >
+          {returnToPerpsLabel}
+        </Button>
+      ) : null}
+
+      <ExplorerButton explorerUrl={explorerUrl} isLoading={isLoading} label={viewInExplorerLabel} />
+    </Box>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/SwapTransactionStatusDrawerBody.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/SwapTransactionStatusDrawerBody.tsx
@@ -14,5 +14,5 @@ export function SwapTransactionStatusDrawerBody({
 }: SwapTransactionStatusDrawerBodyProps) {
   const viewModel = useSwapTransactionStatusViewModel({ params, onClose });
 
-  return <SwapTransactionStatusView {...viewModel} />;
+  return <SwapTransactionStatusView {...viewModel} origin={params.origin} onClose={onClose} />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/SwapTransactionStatusView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/SwapTransactionStatusView.tsx
@@ -1,11 +1,19 @@
 import React from "react";
 import { BottomSheetScrollView, Box } from "@ledgerhq/lumen-ui-rnative";
+import type { SwapTransactionStatusOrigin } from "@ledgerhq/live-common/exchange/swapTransactionStatus/index";
 import type { SwapTransactionStatusViewModel } from "../hooks/useSwapTransactionStatusViewModel";
 import { DetailsSection } from "./Details/DetailsSection";
 import { EarnBanner } from "./EarnBanner/EarnBanner";
 import { FooterSection } from "./Footer/FooterSection";
 import { StatusSection } from "./Status/StatusSection";
 import { TransactionHeader } from "./TransactionHeader";
+
+type SwapTransactionStatusViewProps = Readonly<
+  SwapTransactionStatusViewModel & {
+    origin?: SwapTransactionStatusOrigin;
+    onClose: () => void;
+  }
+>;
 
 export function SwapTransactionStatusView({
   sendCurrency,
@@ -26,7 +34,9 @@ export function SwapTransactionStatusView({
   explorerUrl,
   isStatusSectionLoading,
   isFooterLoading,
-}: Readonly<SwapTransactionStatusViewModel>) {
+  origin,
+  onClose,
+}: SwapTransactionStatusViewProps) {
   return (
     <BottomSheetScrollView
       testID="swap-transaction-status-scroll-view"
@@ -38,6 +48,7 @@ export function SwapTransactionStatusView({
           receiveCurrency={receiveCurrency}
           createdAt={createdAt}
           locale={locale}
+          origin={origin}
         />
 
         <StatusSection
@@ -66,7 +77,12 @@ export function SwapTransactionStatusView({
           swapId={swapId}
         />
 
-        <FooterSection explorerUrl={explorerUrl} isLoading={isFooterLoading} />
+        <FooterSection
+          explorerUrl={explorerUrl}
+          isLoading={isFooterLoading}
+          origin={origin}
+          onReturn={onClose}
+        />
       </Box>
     </BottomSheetScrollView>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/TransactionHeader.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/components/TransactionHeader.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
+import type { SwapTransactionStatusOrigin } from "@ledgerhq/live-common/exchange/swapTransactionStatus/index";
 import { Box, Skeleton, Text } from "@ledgerhq/lumen-ui-rnative";
 import CurrencyIcon from "~/components/CurrencyIcon";
 import { useTransactionHeaderViewModel } from "../hooks/useTransactionHeaderViewModel";
@@ -9,6 +10,7 @@ type TransactionHeaderProps = Readonly<{
   receiveCurrency?: CryptoOrTokenCurrency;
   createdAt?: number;
   locale: string;
+  origin?: SwapTransactionStatusOrigin;
 }>;
 
 export function TransactionHeader({
@@ -16,12 +18,14 @@ export function TransactionHeader({
   receiveCurrency,
   createdAt,
   locale,
+  origin,
 }: TransactionHeaderProps) {
-  const { title, formattedDate } = useTransactionHeaderViewModel({
+  const { title, currencies, formattedDate } = useTransactionHeaderViewModel({
     sendCurrency,
     receiveCurrency,
     createdAt,
     locale,
+    origin,
   });
 
   return (
@@ -52,6 +56,15 @@ export function TransactionHeader({
       ) : (
         <Skeleton lx={{ height: "s24", width: "s176" }} />
       )}
+      {currencies ? (
+        <Text
+          testID="swap-transaction-currencies"
+          typography="heading5SemiBold"
+          lx={{ color: "base", textAlign: "center" }}
+        >
+          {currencies}
+        </Text>
+      ) : null}
       {formattedDate ? (
         <Text
           testID="swap-transaction-date"

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/useFooterSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/useFooterSectionViewModel.ts
@@ -4,5 +4,6 @@ export function useFooterSectionViewModel() {
   const { t } = useTranslation();
   return {
     viewInExplorerLabel: t("transfer.swap2.modals.transactionStatus.actions.viewInExplorer"),
+    returnToPerpsLabel: t("perpsTransactionStatus.returnToPerps"),
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/useTransactionHeaderViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/useTransactionHeaderViewModel.ts
@@ -24,13 +24,12 @@ export function useTransactionHeaderViewModel({
     ? { sendTicker: sendCurrency.ticker, receiveTicker: receiveCurrency.ticker }
     : undefined;
 
-  // Perps leads with the deposit it is funding, and keeps the swapped pair on its own line.
   const isPerps = origin === "perps";
-  const title = tickers
-    ? isPerps
-      ? t("perpsTransactionStatus.title")
-      : t("transfer.swap2.modals.transactionStatus.title", tickers)
-    : undefined;
+  const title = isPerps
+    ? t("perpsTransactionStatus.title")
+    : tickers
+      ? t("transfer.swap2.modals.transactionStatus.title", tickers)
+      : undefined;
   const currencies =
     tickers && isPerps ? t("perpsTransactionStatus.currencies", tickers) : undefined;
 

--- a/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/useTransactionHeaderViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/SwapTransactionStatus/hooks/useTransactionHeaderViewModel.ts
@@ -1,4 +1,5 @@
 import { formatSwapTransactionStatusCreatedAt } from "@ledgerhq/live-common/exchange/swapTransactionStatus/index";
+import type { SwapTransactionStatusOrigin } from "@ledgerhq/live-common/exchange/swapTransactionStatus/index";
 import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import { useTranslation } from "~/context/Locale";
 
@@ -7,6 +8,7 @@ type UseTransactionHeaderViewModelProps = Readonly<{
   receiveCurrency?: CryptoOrTokenCurrency;
   createdAt?: number;
   locale: string;
+  origin?: SwapTransactionStatusOrigin;
 }>;
 
 export function useTransactionHeaderViewModel({
@@ -14,18 +16,27 @@ export function useTransactionHeaderViewModel({
   receiveCurrency,
   createdAt,
   locale,
+  origin,
 }: UseTransactionHeaderViewModelProps) {
   const { t } = useTranslation();
-  const title =
-    sendCurrency && receiveCurrency
-      ? t("transfer.swap2.modals.transactionStatus.title", {
-          sendTicker: sendCurrency.ticker,
-          receiveTicker: receiveCurrency.ticker,
-        })
-      : undefined;
+  const hasCurrencies = sendCurrency !== undefined && receiveCurrency !== undefined;
+  const tickers = hasCurrencies
+    ? { sendTicker: sendCurrency.ticker, receiveTicker: receiveCurrency.ticker }
+    : undefined;
+
+  // Perps leads with the deposit it is funding, and keeps the swapped pair on its own line.
+  const isPerps = origin === "perps";
+  const title = tickers
+    ? isPerps
+      ? t("perpsTransactionStatus.title")
+      : t("transfer.swap2.modals.transactionStatus.title", tickers)
+    : undefined;
+  const currencies =
+    tickers && isPerps ? t("perpsTransactionStatus.currencies", tickers) : undefined;
+
   const formattedDate = createdAt
     ? formatSwapTransactionStatusCreatedAt(createdAt, locale)
     : undefined;
 
-  return { title, formattedDate };
+  return { title, currencies, formattedDate };
 }


### PR DESCRIPTION
Mobile counterpart of #21261.

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/ce8ead61-94dd-4cb6-afc1-a2c58ca6de38" />

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/5b3ead34-6982-46a4-855f-39a91f2018e8" />


The status drawer now knows which flow opened it. For a Perps deposit it reads "Fund Perpetuals" with the pair on its own line, and gains a "Return to Perps" CTA that closes it. Swap is unchanged.

Per design, and unlike desktop: no header title, plus the return CTA.