### PR TITLE
[LWDM] feat(coin-concordium): PLT transaction and account types (LIVE-36751)

### DIFF
--- a/.changeset/brisk-thistle-wanders.md
+++ b/.changeset/brisk-thistle-wanders.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-concordium": minor
+---
+
+Extend the transaction and account types with the PLT token id, the persisted fee-estimation energy, and per-token state

--- a/libs/coin-modules/coin-concordium/src/bridge/onboard.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/onboard.ts
@@ -2,6 +2,7 @@ import type { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { LockedDeviceError } from "../errors";
 import { ConcordiumPairingExpiredError, ConcordiumSessionExpiredError } from "../types/errors";
+import type { ConcordiumAccount } from "../types";
 import { log } from "@ledgerhq/logs";
 import type { Account } from "@ledgerhq/types-live";
 import { Observable } from "rxjs";
@@ -133,7 +134,10 @@ export const buildOnboardAccount =
               freshAddress: accountAddress,
               xpub: publicKey,
               seedIdentifier: publicKey,
+              // Spread first so a field this function does not know about is
+              // carried rather than dropped.
               concordiumResources: {
+                ...(account as Partial<ConcordiumAccount>).concordiumResources,
                 credId: credentialDeploymentTransaction.credId,
                 credNumber,
                 identityIndex,

--- a/libs/coin-modules/coin-concordium/src/bridge/onboard.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/onboard.ts
@@ -2,7 +2,6 @@ import type { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { LockedDeviceError } from "../errors";
 import { ConcordiumPairingExpiredError, ConcordiumSessionExpiredError } from "../types/errors";
-import type { ConcordiumAccount } from "../types";
 import { log } from "@ledgerhq/logs";
 import type { Account } from "@ledgerhq/types-live";
 import { Observable } from "rxjs";
@@ -15,6 +14,7 @@ import {
 import { getWalletConnect } from "../network/walletConnect";
 import { getPublicKey, signCredentialDeployment } from "../signer";
 import {
+  type ConcordiumAccount,
   type ConcordiumSigner,
   type ConcordiumOnboardProgress,
   type ConcordiumOnboardResult,

--- a/libs/coin-modules/coin-concordium/src/bridge/serialization.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/serialization.test.ts
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js";
-import type { ConcordiumResources, RawOperation } from "../types";
+import type { ConcordiumAccountRaw, ConcordiumResources, RawOperation } from "../types";
 import {
   createTestAccount,
   createTestConcordiumAccount,
@@ -120,7 +120,7 @@ describe("assignToAccountRaw", () => {
     expect("concordiumResources" in accountRaw).toBe(false);
   });
 
-  it("should handle undefined values in resources", () => {
+  it("should materialize missing fields as undefined rather than aliasing the source", () => {
     const resources = {
       isOnboarded: false,
     } as ConcordiumResources;
@@ -129,11 +129,16 @@ describe("assignToAccountRaw", () => {
 
     assignToAccountRaw(account, accountRaw);
 
-    expect("concordiumResources" in accountRaw).toBe(true);
-    if ("concordiumResources" in accountRaw) {
-      expect(accountRaw.concordiumResources).not.toBeUndefined();
-      expect((accountRaw.concordiumResources as any)?.isOnboarded).toBe(false);
-    }
+    // toStrictEqual, not toEqual: toEqual ignores undefined-valued keys and so
+    // passes against the old Object.assign too.
+    expect((accountRaw as ConcordiumAccountRaw).concordiumResources).toStrictEqual({
+      isOnboarded: false,
+      credId: undefined,
+      publicKey: undefined,
+      identityIndex: undefined,
+      credNumber: undefined,
+      ipIdentity: undefined,
+    });
   });
 });
 
@@ -197,6 +202,74 @@ describe("roundtrip serialization", () => {
     if ("concordiumResources" in restoredAccount) {
       expect(restoredAccount.concordiumResources).toEqual(originalResources);
     }
+  });
+
+  it("should preserve the per-token map, including through JSON storage", () => {
+    const originalResources: ConcordiumResources = {
+      isOnboarded: true,
+      credId: "roundtrip-cred",
+      publicKey: "roundtrip-key",
+      identityIndex: 10,
+      credNumber: 20,
+      ipIdentity: 30,
+      tokens: {
+        PLT: { transferStatus: "allowed", paused: false },
+        "EUR.e": { transferStatus: "blocked", paused: true },
+        UNKNOWN: { transferStatus: "unknown" },
+      },
+    };
+    const account = createTestConcordiumAccount({ concordiumResources: originalResources });
+
+    const accountRaw = createTestAccountRaw();
+    assignToAccountRaw(account, accountRaw);
+
+    const stored = JSON.parse(JSON.stringify(accountRaw));
+    const restoredAccount = createTestAccount();
+    assignFromAccountRaw(stored, restoredAccount);
+
+    expect("concordiumResources" in restoredAccount).toBe(true);
+    if ("concordiumResources" in restoredAccount) {
+      expect(restoredAccount.concordiumResources).toEqual(originalResources);
+    }
+  });
+
+  it("should omit tokens entirely for an account that has none", () => {
+    const account = createTestConcordiumAccount({
+      concordiumResources: {
+        isOnboarded: true,
+        credId: "no-tokens",
+        publicKey: "no-tokens-key",
+        identityIndex: 1,
+        credNumber: 2,
+        ipIdentity: 3,
+      },
+    });
+
+    const accountRaw = createTestAccountRaw();
+    assignToAccountRaw(account, accountRaw);
+
+    expect("tokens" in (accountRaw as ConcordiumAccountRaw).concordiumResources).toBe(false);
+  });
+
+  it("should rebuild the resources object rather than aliasing it", () => {
+    const account = createTestConcordiumAccount({
+      concordiumResources: {
+        isOnboarded: true,
+        credId: "alias-check",
+        publicKey: "alias-key",
+        identityIndex: 1,
+        credNumber: 2,
+        ipIdentity: 3,
+        tokens: { PLT: { transferStatus: "allowed", paused: false } },
+      },
+    });
+
+    const accountRaw = createTestAccountRaw();
+    assignToAccountRaw(account, accountRaw);
+
+    expect((accountRaw as ConcordiumAccountRaw).concordiumResources).not.toBe(
+      account.concordiumResources,
+    );
   });
 });
 

--- a/libs/coin-modules/coin-concordium/src/bridge/serialization.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/serialization.test.ts
@@ -1,5 +1,10 @@
 import BigNumber from "bignumber.js";
-import type { ConcordiumAccountRaw, ConcordiumResources, RawOperation } from "../types";
+import type {
+  ConcordiumAccount,
+  ConcordiumAccountRaw,
+  ConcordiumResources,
+  RawOperation,
+} from "../types";
 import {
   createTestAccount,
   createTestConcordiumAccount,
@@ -249,6 +254,34 @@ describe("roundtrip serialization", () => {
     assignToAccountRaw(account, accountRaw);
 
     expect("tokens" in (accountRaw as ConcordiumAccountRaw).concordiumResources).toBe(false);
+  });
+
+  it("should drop keys it does not know about in both directions", () => {
+    // Storage can hold a key written by a newer app version. Carrying it back
+    // out would make it self-propagating, so the converter is an allowlist.
+    const withStrayKey = {
+      isOnboarded: true,
+      credId: "c",
+      publicKey: "p",
+      identityIndex: 1,
+      credNumber: 2,
+      ipIdentity: 3,
+      stray: "should not survive",
+    } as unknown as ConcordiumResources;
+
+    const accountRaw = createTestAccountRaw();
+    assignToAccountRaw(
+      createTestConcordiumAccount({ concordiumResources: withStrayKey }),
+      accountRaw,
+    );
+    expect((accountRaw as ConcordiumAccountRaw).concordiumResources).not.toHaveProperty("stray");
+
+    const account = createTestAccount();
+    assignFromAccountRaw(
+      createTestConcordiumAccountRaw({ concordiumResources: withStrayKey }),
+      account,
+    );
+    expect((account as ConcordiumAccount).concordiumResources).not.toHaveProperty("stray");
   });
 
   it("should rebuild the resources object rather than aliasing it", () => {

--- a/libs/coin-modules/coin-concordium/src/bridge/serialization.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/serialization.ts
@@ -1,7 +1,13 @@
 import BigNumber from "bignumber.js";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import type { Account, AccountRaw, Operation, OperationType } from "@ledgerhq/types-live";
-import type { ConcordiumAccount, ConcordiumAccountRaw, RawOperation } from "../types";
+import type {
+  ConcordiumAccount,
+  ConcordiumAccountRaw,
+  ConcordiumResources,
+  ConcordiumResourcesRaw,
+  RawOperation,
+} from "../types";
 
 export function isConcordiumAccount(account: Account): account is ConcordiumAccount {
   return account.currency?.family === "concordium" && "concordiumResources" in account;
@@ -11,36 +17,62 @@ function isConcordiumAccountRaw(accountRaw: AccountRaw): accountRaw is Concordiu
   return "concordiumResources" in accountRaw;
 }
 
+/** Fails to compile when a resources field is declared but not mapped below. */
+function assertNoUnmappedFields(_rest: Record<string, never>): void {}
+
 /**
- * Copies concordiumResources from Account to AccountRaw.
- *
- * Note: ConcordiumResources contains only primitives (boolean, string, number),
- * so no transformation is needed - the object can be directly assigned.
+ * Naming the fields keeps what reaches disk an allowlist. `tokens` is copied by
+ * reference, as Canton does with its own keyed map: nothing mutates an entry in
+ * place, so a deep copy would protect nothing.
  */
+function toResourcesRaw(r: ConcordiumResources): ConcordiumResourcesRaw {
+  const { isOnboarded, credId, publicKey, identityIndex, credNumber, ipIdentity, tokens, ...rest } =
+    r;
+  assertNoUnmappedFields(rest);
+  return {
+    isOnboarded,
+    credId,
+    publicKey,
+    identityIndex,
+    credNumber,
+    ipIdentity,
+    ...(tokens === undefined ? {} : { tokens }),
+  };
+}
+
+function fromResourcesRaw(r: ConcordiumResourcesRaw): ConcordiumResources {
+  const { isOnboarded, credId, publicKey, identityIndex, credNumber, ipIdentity, tokens, ...rest } =
+    r;
+  assertNoUnmappedFields(rest);
+  return {
+    isOnboarded,
+    credId,
+    publicKey,
+    identityIndex,
+    credNumber,
+    ipIdentity,
+    ...(tokens === undefined ? {} : { tokens }),
+  };
+}
+
 export function assignToAccountRaw(account: Account, accountRaw: AccountRaw): void {
   if (!isConcordiumAccount(account) || !account.concordiumResources) {
     return;
   }
 
-  Object.assign(accountRaw, {
-    concordiumResources: account.concordiumResources,
-  });
+  (accountRaw as ConcordiumAccountRaw).concordiumResources = toResourcesRaw(
+    account.concordiumResources,
+  );
 }
 
-/**
- * Copies concordiumResources from AccountRaw to Account.
- *
- * Note: ConcordiumResources contains only primitives (boolean, string, number),
- * so no transformation is needed - the object can be directly assigned.
- */
 export function assignFromAccountRaw(accountRaw: AccountRaw, account: Account): void {
   if (!isConcordiumAccountRaw(accountRaw) || !accountRaw.concordiumResources) {
     return;
   }
 
-  Object.assign(account, {
-    concordiumResources: accountRaw.concordiumResources,
-  });
+  (account as ConcordiumAccount).concordiumResources = fromResourcesRaw(
+    accountRaw.concordiumResources,
+  );
 }
 
 export function mapRawOperationToBridgeOperation(op: RawOperation, accountId: string): Operation {

--- a/libs/coin-modules/coin-concordium/src/bridge/serialization.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/serialization.ts
@@ -5,7 +5,6 @@ import type {
   ConcordiumAccount,
   ConcordiumAccountRaw,
   ConcordiumResources,
-  ConcordiumResourcesRaw,
   RawOperation,
 } from "../types";
 
@@ -17,33 +16,23 @@ function isConcordiumAccountRaw(accountRaw: AccountRaw): accountRaw is Concordiu
   return "concordiumResources" in accountRaw;
 }
 
-/** Fails to compile when a resources field is declared but not mapped below. */
-function assertNoUnmappedFields(_rest: Record<string, never>): void {}
-
 /**
- * Naming the fields keeps what reaches disk an allowlist. `tokens` is copied by
- * reference, as Canton does with its own keyed map: nothing mutates an entry in
- * place, so a deep copy would protect nothing.
+ * Serves both directions: the runtime and raw shapes are identical, so a
+ * separate converter per direction would be the same function twice. Split it
+ * the day a field needs converting.
+ *
+ * Naming the fields makes this an allowlist: a key on the input that is not
+ * listed here is dropped rather than carried to disk. The `satisfies` line is
+ * compile-time only — it turns a field added to the type but forgotten here
+ * into an error instead of data silently lost on save.
+ *
+ * `tokens` is copied by reference, as Canton does with its own keyed map:
+ * nothing mutates an entry in place, so a deep copy would protect nothing.
  */
-function toResourcesRaw(r: ConcordiumResources): ConcordiumResourcesRaw {
+function copyResources(r: ConcordiumResources): ConcordiumResources {
   const { isOnboarded, credId, publicKey, identityIndex, credNumber, ipIdentity, tokens, ...rest } =
     r;
-  assertNoUnmappedFields(rest);
-  return {
-    isOnboarded,
-    credId,
-    publicKey,
-    identityIndex,
-    credNumber,
-    ipIdentity,
-    ...(tokens === undefined ? {} : { tokens }),
-  };
-}
-
-function fromResourcesRaw(r: ConcordiumResourcesRaw): ConcordiumResources {
-  const { isOnboarded, credId, publicKey, identityIndex, credNumber, ipIdentity, tokens, ...rest } =
-    r;
-  assertNoUnmappedFields(rest);
+  void (rest satisfies Record<string, never>);
   return {
     isOnboarded,
     credId,
@@ -60,7 +49,7 @@ export function assignToAccountRaw(account: Account, accountRaw: AccountRaw): vo
     return;
   }
 
-  (accountRaw as ConcordiumAccountRaw).concordiumResources = toResourcesRaw(
+  (accountRaw as ConcordiumAccountRaw).concordiumResources = copyResources(
     account.concordiumResources,
   );
 }
@@ -70,7 +59,7 @@ export function assignFromAccountRaw(accountRaw: AccountRaw, account: Account): 
     return;
   }
 
-  (account as ConcordiumAccount).concordiumResources = fromResourcesRaw(
+  (account as ConcordiumAccount).concordiumResources = copyResources(
     accountRaw.concordiumResources,
   );
 }

--- a/libs/coin-modules/coin-concordium/src/bridge/transaction.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/transaction.test.ts
@@ -1,0 +1,68 @@
+import BigNumber from "bignumber.js";
+import { fromTransactionRaw, toTransactionRaw } from "./transaction";
+import type { TransactionRaw } from "../types";
+
+const ccdRaw: TransactionRaw = {
+  family: "concordium",
+  amount: "10000000",
+  recipient: "3a9gh23nNY3kH4k3ajaCqAbM8rcbWMor2VhEzQ6qkn2r17UU7w",
+  fee: "501",
+  memo: undefined,
+  useAllAmount: false,
+};
+
+describe("transaction serialization", () => {
+  it("round-trips a CCD transaction without adding PLT fields", () => {
+    const raw = toTransactionRaw(fromTransactionRaw(ccdRaw));
+
+    expect(raw).toMatchObject({ family: "concordium", fee: "501" });
+    // Absent must stay absent, not become `undefined` keys: a CCD transaction
+    // has to serialize to the shape it had before PLT existed.
+    expect("tokenId" in raw).toBe(false);
+    expect("energy" in raw).toBe(false);
+  });
+
+  it("round-trips tokenId and energy when both are set", () => {
+    const raw = toTransactionRaw(fromTransactionRaw({ ...ccdRaw, tokenId: "PLT", energy: 759 }));
+
+    expect(raw.tokenId).toBe("PLT");
+    expect(raw.energy).toBe(759);
+  });
+
+  it("carries tokenId and energy onto the runtime transaction", () => {
+    const tx = fromTransactionRaw({ ...ccdRaw, tokenId: "PLT", energy: 759 });
+
+    expect(tx.tokenId).toBe("PLT");
+    expect(tx.energy).toBe(759);
+    expect(tx.fee).toEqual(new BigNumber("501"));
+  });
+
+  it("keeps energy a JSON-safe number through a stringify cycle", () => {
+    const raw = toTransactionRaw(fromTransactionRaw({ ...ccdRaw, tokenId: "PLT", energy: 759 }));
+
+    // A bigint here would throw; the number survives storage untouched.
+    expect(JSON.parse(JSON.stringify(raw)).energy).toBe(759);
+  });
+
+  it("round-trips each PLT field independently of the other", () => {
+    expect(toTransactionRaw(fromTransactionRaw({ ...ccdRaw, tokenId: "PLT" }))).toMatchObject({
+      tokenId: "PLT",
+    });
+    expect("energy" in toTransactionRaw(fromTransactionRaw({ ...ccdRaw, tokenId: "PLT" }))).toBe(
+      false,
+    );
+
+    expect(toTransactionRaw(fromTransactionRaw({ ...ccdRaw, energy: 501 }))).toMatchObject({
+      energy: 501,
+    });
+    expect("tokenId" in toTransactionRaw(fromTransactionRaw({ ...ccdRaw, energy: 501 }))).toBe(
+      false,
+    );
+  });
+
+  it("preserves a zero energy rather than dropping it as falsy", () => {
+    const raw = toTransactionRaw(fromTransactionRaw({ ...ccdRaw, energy: 0 }));
+
+    expect(raw.energy).toBe(0);
+  });
+});

--- a/libs/coin-modules/coin-concordium/src/bridge/transaction.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/transaction.ts
@@ -40,6 +40,8 @@ export const fromTransactionRaw = (tr: TransactionRaw): Transaction => {
     family: tr.family,
     fee: tr.fee ? new BigNumber(tr.fee) : null,
     memo: tr.memo,
+    ...(tr.tokenId === undefined ? {} : { tokenId: tr.tokenId }),
+    ...(tr.energy === undefined ? {} : { energy: tr.energy }),
   };
 };
 
@@ -50,6 +52,8 @@ export const toTransactionRaw = (t: Transaction): TransactionRaw => {
     family: t.family,
     fee: t.fee ? t.fee.toString() : null,
     memo: t.memo,
+    ...(t.tokenId === undefined ? {} : { tokenId: t.tokenId }),
+    ...(t.energy === undefined ? {} : { energy: t.energy }),
   };
 };
 

--- a/libs/coin-modules/coin-concordium/src/logic/transaction/craftTransaction.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/transaction/craftTransaction.ts
@@ -36,6 +36,8 @@ export async function craftTransaction(
       sender: AccountAddress.fromBase58(account.address),
       nonce: BigInt(account.nextSequenceNumber || 0),
       expiry: BigInt(expiryEpochSeconds),
+      // Drop this fallback when signing reads the persisted energy (LIVE-28337):
+      // 0 NRG is rejected at broadcast, after the device ceremony has completed.
       energyAmount: transaction.energy ?? BigInt(0),
     },
     payload: {

--- a/libs/coin-modules/coin-concordium/src/network/plt.ts
+++ b/libs/coin-modules/coin-concordium/src/network/plt.ts
@@ -2,6 +2,7 @@ import type {
   PltAccountModuleState,
   PltAccountToken,
   PltEncodedState,
+  PltListStatus,
   PltModuleState,
   PltRejectReason,
   PltTokenModuleRejectReason,
@@ -21,16 +22,6 @@ export function isDecodedPltState<T extends PltModuleState | PltAccountModuleSta
 ): state is T {
   return typeof state === "object" && state !== null && !Array.isArray(state);
 }
-
-/**
- * Result of checking a token's allow/deny lists against one account.
- *
- * `unknown` is not a soft `allowed`: it means the module state or the account's
- * membership could not be read, so nothing can be concluded. A caller gating a
- * send must treat it as a blocker and say the restrictions could not be
- * verified, rather than letting the transfer reach the chain to be rejected.
- */
-export type PltListStatus = "allowed" | "blocked" | "unknown";
 
 /**
  * Checks whether the token's own lists block this account from transacting.

--- a/libs/coin-modules/coin-concordium/src/types/bridge.ts
+++ b/libs/coin-modules/coin-concordium/src/types/bridge.ts
@@ -9,6 +9,7 @@ import type {
 } from "@ledgerhq/types-live";
 import type { BigNumber } from "bignumber.js";
 import type { Observable } from "rxjs";
+import type { PltTransferStatus } from "./network";
 import type {
   ConcordiumOnboardProgress,
   ConcordiumOnboardResult,
@@ -27,28 +28,47 @@ export interface ConcordiumCurrencyBridge extends CurrencyBridge {
   ) => Observable<ConcordiumOnboardProgress | ConcordiumOnboardResult>;
 }
 
+/**
+ * `energy` is the estimate signing will read instead of re-estimating, so the
+ * fee shown and the device's "Max fees" come from one estimate. Not yet in
+ * force: `signOperation` still calls `estimateFees` (LIVE-28337).
+ *
+ * It is a `number` on both sides, unlike `fee`, because `number` is what
+ * `getTransactionCost` returns — MultiversX's `gasLimit`, not EVM's.
+ */
 export type Transaction = TransactionCommon & {
   family: "concordium";
   fee: BigNumber | null | undefined;
   memo: string | undefined;
+  tokenId?: string;
+  energy?: number;
 };
 
 export type TransactionRaw = TransactionCommonRaw & {
   family: "concordium";
   fee: string | null | undefined;
   memo: string | undefined;
+  tokenId?: string;
+  energy?: number;
 };
 
 export type TransactionStatus = TransactionStatusCommon;
 export type TransactionStatusRaw = TransactionStatusCommonRaw;
 
 /**
- * Concordium-specific account resources.
- * Contains onboarding status and identity information.
- *
- * Note: All fields are primitives, so this type is used for both
- * runtime (ConcordiumAccount) and serialized (ConcordiumAccountRaw) formats.
- * No separate "Raw" type needed since primitives serialize transparently.
+ * Per-token state the send path needs, cached on the parent account. It lives
+ * here rather than on the token sub-account because `TokenAccount` is a closed
+ * type with no `extra` field and no family slot.
+ */
+export type ConcordiumTokenResources = {
+  transferStatus: PltTransferStatus;
+  /** Display fact only. Absent means the module never declared it, not `false`. */
+  paused?: boolean;
+};
+
+/**
+ * Every value is JSON-safe, so the runtime and raw shapes coincide; they are
+ * still declared and converted separately to match every other coin module.
  */
 export type ConcordiumResources = {
   isOnboarded: boolean;
@@ -57,6 +77,17 @@ export type ConcordiumResources = {
   identityIndex: number;
   credNumber: number;
   ipIdentity: number;
+  tokens?: Record<string, ConcordiumTokenResources>;
+};
+
+export type ConcordiumResourcesRaw = {
+  isOnboarded: boolean;
+  credId: string;
+  publicKey: string;
+  identityIndex: number;
+  credNumber: number;
+  ipIdentity: number;
+  tokens?: Record<string, ConcordiumTokenResources>;
 };
 
 export type ConcordiumAccount = Account & {
@@ -64,5 +95,5 @@ export type ConcordiumAccount = Account & {
 };
 
 export type ConcordiumAccountRaw = AccountRaw & {
-  concordiumResources: ConcordiumResources;
+  concordiumResources: ConcordiumResourcesRaw;
 };

--- a/libs/coin-modules/coin-concordium/src/types/network.ts
+++ b/libs/coin-modules/coin-concordium/src/types/network.ts
@@ -335,6 +335,25 @@ export interface PltAccountToken {
 }
 
 /**
+ * Result of checking a token's allow/deny lists against one account.
+ *
+ * `unknown` is not a soft `allowed`: it means the module state or the account's
+ * membership could not be read, so nothing can be concluded. A caller gating a
+ * send must treat it as a blocker and say the restrictions could not be
+ * verified, rather than letting the transfer reach the chain to be rejected.
+ */
+export type PltListStatus = "allowed" | "blocked" | "unknown";
+
+/**
+ * Whether this account may transfer a token: pause state and both list rules
+ * folded into one verdict, resolved once by the producer.
+ *
+ * Gate on `!== "allowed"`, not `=== "blocked"` — a value from a corrupted store
+ * or a newer app version is off-union, and only the first form fails closed.
+ */
+export type PltTransferStatus = "allowed" | "blocked" | "unknown";
+
+/**
  * Details of a token-module rejection, carried by a `TokenUpdateTransactionFailed`
  * reject reason. `type` is a module-defined string, not a closed set.
  */


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Type groundwork for PLT send: `tokenId` and the persisted fee-estimation `energy` on the transaction types, plus a per-token map on `ConcordiumResources`. Nothing populates or reads it yet — five follow-up tickets need the same shape, so it lands once.

Two decisions a reviewer will want the reasoning for:

- Per-token state carries **one** `transferStatus` verdict rather than `paused` plus a list status. An absent `paused` means "not declared by the module", not `false`, so two fields would leave every call site ANDing a tri-state with an optional boolean — and the permissive collapse is the wrong default for a send gate.
- `energy` is a `number` on both sides rather than following `fee`'s BigNumber/string split, because `number` is what the wallet-proxy returns; the `bigint` in `estimateFees` is the derived form.

Also replaces the resources `Object.assign` with explicit converters (matching every other coin module), where a `never`-typed rest parameter makes a forgotten field a compile error instead of silent data loss on every save.

Round-trip tests cover both new transaction fields set, absent, and independently, plus the token map through a real JSON cycle.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36751](https://ledgerhq.atlassian.net/browse/LIVE-36751?atlOrigin=eyJpIjoiYzJkOWQ5YTE3ODM2NGJhMmI3MTY5M2Q4ODU5MDJiMjEiLCJwIjoiaiJ9)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-36751]: https://ledgerhq.atlassian.net/browse/LIVE-36751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ