### PR TITLE
[LWM] fix(lwm): drop shrinkResources to unbreak AAB builds (LIVE-28531)

### DIFF
--- a/.changeset/eighty-pugs-shave.md
+++ b/.changeset/eighty-pugs-shave.md
@@ -2,4 +2,4 @@
 "live-mobile": patch
 ---
 
-Enable R8 code shrinking, optimization and resource shrinking on Android release builds (LIVE-28531)
+Enable R8 code shrinking, optimization and obfuscation on Android release builds (LIVE-28531)

--- a/apps/ledger-live-mobile/android/app/build.gradle
+++ b/apps/ledger-live-mobile/android/app/build.gradle
@@ -177,8 +177,8 @@ android {
             applicationIdSuffix ".debug"
         }
         release {
+            // no shrinkResources: one shrunk-resources per splits.abi ABI breaks bundleRelease https://issuetracker.google.com/402800800
             minifyEnabled enableProguardInReleaseBuilds
-            shrinkResources enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
             matchingFallbacks = ['debug']
         }


### PR DESCRIPTION
> [!IMPORTANT]
> This unblocks every AAB pipeline (nightly, prerelease, Play Store release), all of which have been failing since #21296 merged.

### 📝 Description

**Previous behaviour.** #21296 enabled R8 and, alongside it, `shrinkResources`. Resource shrinking is incompatible with the `splits.abi` config this app has always used: the shrinker emits one `shrunk-resources-proto-format-<abi>-release.ap_` per ABI, while `buildReleasePreBundle` accepts exactly one. AGP names the conflict itself ([issuetracker 402800800](https://issuetracker.google.com/402800800)):

```
Execution failed for task ':app:buildReleasePreBundle'.
> Multiple shrunk-resources files found in directory '.../shrunk_resources_proto_format/release/minifyReleaseWithR8':
  [...-armeabi-v7a-release.ap_, ...-x86_64-release.ap_, ...-x86-release.ap_, ...-arm64-v8a-release.ap_]
  Please disable building multiple APKs when building an Android app bundle.
```

`ci_nightly`, `ci_playstore` and its prerelease dry run all build `["assemble", "bundle"]` in a single gradle invocation, so they broke simultaneously. `ci_build` is APK-only and is the PR check, which is why review stayed green.

**The fix.** Drop `shrinkResources`. `minifyEnabled` is unaffected — dex is not split per ABI — so R8 still shrinks, optimizes and obfuscates, and the Play Store requirement behind LIVE-28531 holds.

```diff
  release {
+     // no shrinkResources: one shrunk-resources per splits.abi ABI breaks bundleRelease
      minifyEnabled enableProguardInReleaseBuilds
-     shrinkResources enableProguardInReleaseBuilds
      proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
  }
```

**What it costs**, measured on one tree, `arm64-v8a assembleRelease`:

| | bytes |
| --- | --- |
| `shrinkResources` on | 139,772,632 |
| `shrinkResources` off | 140,102,046 |
| **delta** | **+329,414 (+0.24%)** |

Identical delta on `armeabi-v7a` — resources are ABI-independent. Dex is unchanged at 13.5 MB across 2 files, so the whole 47.7 MB → 13.5 MB win from #21296 is retained. Resource shrinking was worth a third of a megabyte out of 140 MB, and it carries the same silent-breakage risk that already bit `react-native-config` in #21296: anything resolved by name (`Resources.getIdentifier`, common in RN libraries) looks unreferenced to static analysis and is deleted with no build error.

**Verification.** Locally on `arm64-v8a` + `armeabi-v7a` (two ABIs are enough to trigger the condition):

- `bundleRelease` on `develop` reproduces the CI failure exactly, same task, same message
- `assembleRelease` + `bundleRelease` in one invocation on this branch: `BUILD SUCCESSFUL`, producing `app-release.aab` plus both per-ABI APKs, with `app-arm64-v8a-release.apk` naming preserved so the artifact paths in ledger-live-build still resolve
- `minifyReleaseWithR8` runs in both

The changeset from #21296 is still unreleased, so its text is amended in place rather than adding a second, contradictory release note.

> [!NOTE]
> Two follow-ups, deliberately not in this PR:
> 1. No PR-level check builds an AAB, which is the gap that let this through. A `bundleRelease` job on mobile CI, or in the on-demand build workflow, would catch this class of regression at review time.
> 2. Recovering the 0.33 MB is possible by splitting the gradle invocation so the bundle builds with `splits.abi` disabled, at the price of a second full R8 pass per release build. Not worth it at 0.24%.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-28531](https://ledgerhq.atlassian.net/browse/LIVE-28531), regression from #21296
- **ADR** (if any): n/a


[LIVE-28531]: https://ledgerhq.atlassian.net/browse/LIVE-28531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ