### PR TITLE
[LWM] fix(send): fix addressinput focus in lwm

### DIFF
--- a/.changeset/metal-melons-vanish.md
+++ b/.changeset/metal-melons-vanish.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix(send): the send recipient AddressInput taking then losing the keyboard,it now only focuses once the step shows nothing at all, not when contacts are in the list

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/SendFlowOrchestrator.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/SendFlowOrchestrator.tsx
@@ -10,6 +10,7 @@ import {
 import { FlowStackNavigator } from "../FlowWizard/FlowStackNavigator";
 import { SendFlowProvider } from "./context/SendFlowContext";
 import { RecipientContactSelectionProvider } from "./context/RecipientContactSelectionContext";
+import { RecipientInputFocusProvider } from "./context/RecipientInputFocusContext";
 import { SendSignatureProvider, useSendSignature } from "./context/SendSignatureContext";
 import { SignatureOverlayHost } from "./components/SignatureOverlayHost";
 import { useSendFlowBusinessLogic } from "./hooks/useSendFlowState";
@@ -78,15 +79,17 @@ export function SendFlowOrchestrator({
   return (
     <SendFlowProvider value={businessContext} onClose={onClose}>
       <RecipientContactSelectionProvider>
-        <SendSignatureProvider>
-          <SendFlowNavigator
-            stepRegistry={stepRegistry}
-            flowConfig={configuredFlowConfig}
-            onClose={onClose}
-          />
-          <SignatureOverlayHost />
-          {children}
-        </SendSignatureProvider>
+        <RecipientInputFocusProvider>
+          <SendSignatureProvider>
+            <SendFlowNavigator
+              stepRegistry={stepRegistry}
+              flowConfig={configuredFlowConfig}
+              onClose={onClose}
+            />
+            <SignatureOverlayHost />
+            {children}
+          </SendSignatureProvider>
+        </RecipientInputFocusProvider>
       </RecipientContactSelectionProvider>
     </SendFlowProvider>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/SendHeader.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/SendHeader.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from "~/context/Locale";
 
 import { AddressDisclaimer } from "./AddressDisclaimer";
 import { RecipientContactRow } from "./RecipientContactRow";
+import { useRecipientInputAutoFocus } from "../hooks/useRecipientInputAutoFocus";
 import { useSendHeaderViewModel } from "../hooks/useSendHeaderViewModel";
 import { useSendFlowData } from "../context/SendFlowContext";
 import { track, usePageNameFromRoute } from "~/analytics";
@@ -32,6 +33,7 @@ const DISCLAIMER_HIT_AREA = 56;
 export function SendHeader({ headerRight }: SendHeaderProps) {
   const { t } = useTranslation();
   const viewModel = useSendHeaderViewModel();
+  const recipientInputRef = useRecipientInputAutoFocus(viewModel.isRecipientStep);
   const styles = useStyleSheet(
     theme => ({
       addressInputContainer: {
@@ -111,6 +113,7 @@ export function SendHeader({ headerRight }: SendHeaderProps) {
         <View style={styles.addressInputContainer}>
           {viewModel.isRecipientStep ? (
             <AddressInput
+              ref={recipientInputRef}
               testID="recipient-input"
               prefix={t("send.newSendFlow.to")}
               value={viewModel.recipientSearch.value}
@@ -118,7 +121,6 @@ export function SendHeader({ headerRight }: SendHeaderProps) {
               onClear={viewModel.clearRecipientSearch}
               onQrCodeClick={viewModel.handleQrCodeClick}
               placeholder={viewModel.recipientPlaceholder}
-              autoFocus
             />
           ) : (
             <>

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/__tests__/SendHeader.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/__tests__/SendHeader.test.tsx
@@ -8,6 +8,7 @@ import { useSendHeaderViewModel } from "../../hooks/useSendHeaderViewModel";
 import { useSendFlowData } from "../../context/SendFlowContext";
 
 jest.mock("../../hooks/useSendHeaderViewModel");
+jest.mock("../../hooks/useRecipientInputAutoFocus");
 jest.mock("../../context/SendFlowContext");
 jest.mock("~/context/Locale", () => ({
   useTranslation: () => ({ t: (key: string) => key }),

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/context/RecipientInputFocusContext.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/context/RecipientInputFocusContext.tsx
@@ -1,0 +1,59 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+
+type RecipientInputFocusDecision = "pending" | "focus" | "skip";
+
+type RecipientInputFocusContextValue = Readonly<{
+  /** Whether the address input should take the keyboard. Turns true at most once, never back. */
+  shouldFocusRecipientInput: boolean;
+  /** Whether the recipient step already made its call. */
+  isRecipientInputFocusSettled: boolean;
+  /** Records the decision of the recipient step. Only the first call is taken into account. */
+  settleRecipientInputFocus: (shouldFocus: boolean) => void;
+}>;
+
+const RecipientInputFocusContext = createContext<RecipientInputFocusContextValue | null>(null);
+
+type RecipientInputFocusProviderProps = Readonly<{
+  children: ReactNode;
+}>;
+
+/**
+ * Bridges the recipient step, which knows when its content settled, and the send header, which
+ * owns the address input.
+ */
+export function RecipientInputFocusProvider({ children }: RecipientInputFocusProviderProps) {
+  const [decision, setDecision] = useState<RecipientInputFocusDecision>("pending");
+
+  const settleRecipientInputFocus = useCallback((shouldFocus: boolean) => {
+    setDecision(current => {
+      if (current !== "pending") {
+        return current;
+      }
+      return shouldFocus ? "focus" : "skip";
+    });
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      shouldFocusRecipientInput: decision === "focus",
+      isRecipientInputFocusSettled: decision !== "pending",
+      settleRecipientInputFocus,
+    }),
+    [decision, settleRecipientInputFocus],
+  );
+
+  return (
+    <RecipientInputFocusContext.Provider value={value}>
+      {children}
+    </RecipientInputFocusContext.Provider>
+  );
+}
+
+export function useRecipientInputFocus(): RecipientInputFocusContextValue {
+  const context = useContext(RecipientInputFocusContext);
+  if (!context) {
+    throw new Error("useRecipientInputFocus must be used within a RecipientInputFocusProvider");
+  }
+  return context;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useRecipientInputAutoFocus.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useRecipientInputAutoFocus.test.ts
@@ -1,0 +1,62 @@
+import { renderHook } from "@testing-library/react-native";
+import { InteractionManager, type TextInput } from "react-native";
+import { useRecipientInputFocus } from "../../context/RecipientInputFocusContext";
+import { useRecipientInputAutoFocus } from "../useRecipientInputAutoFocus";
+
+jest.mock("../../context/RecipientInputFocusContext");
+
+const mockedUseRecipientInputFocus = jest.mocked(useRecipientInputFocus);
+
+function mockDecision(shouldFocusRecipientInput: boolean) {
+  mockedUseRecipientInputFocus.mockReturnValue({
+    shouldFocusRecipientInput,
+    isRecipientInputFocusSettled: true,
+    settleRecipientInputFocus: jest.fn(),
+  });
+}
+
+function runInteractionsImmediately() {
+  jest.spyOn(InteractionManager, "runAfterInteractions").mockImplementation(task => {
+    if (typeof task === "function") task();
+    return { done: jest.fn(), cancel: jest.fn() } as never;
+  });
+}
+
+describe("useRecipientInputAutoFocus", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  it("leaves the keyboard alone until the recipient step settled on focusing", () => {
+    const runAfterInteractions = jest.spyOn(InteractionManager, "runAfterInteractions");
+    mockDecision(false);
+
+    renderHook(() => useRecipientInputAutoFocus(true));
+
+    expect(runAfterInteractions).not.toHaveBeenCalled();
+  });
+
+  it("focuses the address input once the recipient step settled on focusing", () => {
+    const focus = jest.fn();
+    runInteractionsImmediately();
+    mockDecision(false);
+
+    const { result, rerender } = renderHook(() => useRecipientInputAutoFocus(true));
+    result.current.current = { focus } as unknown as TextInput;
+
+    mockDecision(true);
+    rerender({});
+
+    expect(focus).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not focus while another step owns the header", () => {
+    const runAfterInteractions = jest.spyOn(InteractionManager, "runAfterInteractions");
+    mockDecision(true);
+
+    renderHook(() => useRecipientInputAutoFocus(false));
+
+    expect(runAfterInteractions).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useRecipientInputAutoFocus.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useRecipientInputAutoFocus.ts
@@ -1,0 +1,27 @@
+import { useEffect, useRef, type RefObject } from "react";
+import { InteractionManager, type TextInput } from "react-native";
+import { useRecipientInputFocus } from "../context/RecipientInputFocusContext";
+
+/**
+ * Hands the keyboard to the address input once the recipient step decided it is safe to.
+ *
+ * `autoFocus` grabs it on mount instead, while the enter transition still runs and while the
+ * drawer the flow was opened from still retracts the keyboard as it dismisses. The focus is then
+ * lost a few hundred milliseconds later and, since `autoFocus` only applies on mount, never
+ * restored.
+ */
+export function useRecipientInputAutoFocus(isRecipientStep: boolean): RefObject<TextInput | null> {
+  const inputRef = useRef<TextInput>(null);
+  const { shouldFocusRecipientInput } = useRecipientInputFocus();
+
+  useEffect(() => {
+    if (!shouldFocusRecipientInput || !isRecipientStep) {
+      return;
+    }
+
+    const task = InteractionManager.runAfterInteractions(() => inputRef.current?.focus());
+    return () => task.cancel();
+  }, [isRecipientStep, shouldFocusRecipientInput]);
+
+  return inputRef;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenContentViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenContentViewModel.test.ts
@@ -5,12 +5,14 @@ import { useAddressMatchedSectionViewModel } from "../useAddressMatchedSectionVi
 import { useRecipientScreenView } from "../useRecipientScreenView";
 import { createMockAccount } from "./accounts";
 import { useRecipientScreenContentViewModel } from "../useRecipientScreenContentViewModel";
+import { useSettleRecipientInputFocus } from "../useSettleRecipientInputFocus";
 import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 
 jest.mock("~/analytics");
 jest.mock("../../../../components/Memo/hooks/useMemoViewModel");
 jest.mock("../useRecipientScreenView");
 jest.mock("../useAddressMatchedSectionViewModel");
+jest.mock("../useSettleRecipientInputFocus");
 jest.mock("@ledgerhq/ledger-wallet-framework/tracking/send", () => ({
   getSendFlowTrackingProperties: jest.fn(() => ({ currency: "bitcoin" })),
 }));
@@ -28,6 +30,7 @@ const mockedUseMemoViewModel = jest.mocked(useMemoViewModel);
 const mockedUseRecipientScreenView = jest.mocked(useRecipientScreenView);
 const mockedUseAddressMatchedSectionViewModel = jest.mocked(useAddressMatchedSectionViewModel);
 const mockedSendFeatures = jest.mocked(sendFeatures);
+const mockedUseSettleRecipientInputFocus = jest.mocked(useSettleRecipientInputFocus);
 
 const account = createMockAccount({ id: "account_1" });
 const handleAddressSelect = jest.fn();
@@ -36,6 +39,9 @@ const onMemoProceed = jest.fn();
 const recipientViewModel = {
   isLoading: false,
   showInitialState: false,
+  showContactsList: false,
+  showEmptyContactsState: false,
+  featureIntroduction: { isOpen: false },
   showMatchedAddress: true,
   result: {
     status: "valid",
@@ -169,6 +175,36 @@ describe("useRecipientScreenContentViewModel", () => {
       expect.objectContaining({ button: "my accounts", page: "step recipient" }),
     );
     expect(handleAddressSelect).toHaveBeenCalledWith("destination", "name.eth");
+  });
+
+  it.each([
+    ["a contacts list", { showInitialState: true, showContactsList: true }],
+    ["a clipboard suggestion", { showInitialState: true, clipboardAddress: "clipboard-address" }],
+    [
+      "the contacts introduction",
+      { showInitialState: true, featureIntroduction: { isOpen: true } },
+    ],
+    ["search results", { showInitialState: false }],
+  ])("reports %s as content the user has to deal with first", (_, overrides) => {
+    mockedUseRecipientScreenView.mockReturnValue({
+      ...(recipientViewModel as object),
+      ...overrides,
+    } as never);
+
+    renderViewModel();
+
+    expect(mockedUseSettleRecipientInputFocus).toHaveBeenLastCalledWith(true);
+  });
+
+  it("reports an empty initial step as free for the address input to focus", () => {
+    mockedUseRecipientScreenView.mockReturnValue({
+      ...(recipientViewModel as object),
+      showInitialState: true,
+    } as never);
+
+    renderViewModel();
+
+    expect(mockedUseSettleRecipientInputFocus).toHaveBeenLastCalledWith(false);
   });
 
   it("tracks memo skipping before proceeding", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useSettleRecipientInputFocus.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useSettleRecipientInputFocus.test.tsx
@@ -1,0 +1,87 @@
+import { act, renderHook } from "@testing-library/react-native";
+import React, { type ReactNode } from "react";
+import {
+  RecipientInputFocusProvider,
+  useRecipientInputFocus,
+} from "../../../../context/RecipientInputFocusContext";
+import { useSettleRecipientInputFocus } from "../useSettleRecipientInputFocus";
+
+const SETTLE_DELAY_MS = 400;
+
+function renderSettle(hasContent: boolean) {
+  return renderHook(
+    (props: { hasContent: boolean }) => {
+      useSettleRecipientInputFocus(props.hasContent);
+      return useRecipientInputFocus();
+    },
+    {
+      initialProps: { hasContent },
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <RecipientInputFocusProvider>{children}</RecipientInputFocusProvider>
+      ),
+    },
+  );
+}
+
+describe("useSettleRecipientInputFocus", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("hands the keyboard over once an empty step stopped changing", () => {
+    const { result } = renderSettle(false);
+
+    act(() => {
+      jest.advanceTimersByTime(SETTLE_DELAY_MS);
+    });
+
+    expect(result.current.isRecipientInputFocusSettled).toBe(true);
+    expect(result.current.shouldFocusRecipientInput).toBe(true);
+  });
+
+  it("holds the decision back while the step is still filling in", () => {
+    const { result, rerender } = renderSettle(false);
+
+    act(() => {
+      jest.advanceTimersByTime(SETTLE_DELAY_MS - 1);
+    });
+    expect(result.current.isRecipientInputFocusSettled).toBe(false);
+
+    rerender({ hasContent: true });
+    act(() => {
+      jest.advanceTimersByTime(SETTLE_DELAY_MS);
+    });
+
+    expect(result.current.isRecipientInputFocusSettled).toBe(true);
+    expect(result.current.shouldFocusRecipientInput).toBe(false);
+  });
+
+  it("keeps the keyboard away when the step already has content", () => {
+    const { result } = renderSettle(true);
+
+    act(() => {
+      jest.advanceTimersByTime(SETTLE_DELAY_MS);
+    });
+
+    expect(result.current.shouldFocusRecipientInput).toBe(false);
+  });
+
+  it("never revisits its decision once settled", () => {
+    const { result, rerender } = renderSettle(false);
+
+    act(() => {
+      jest.advanceTimersByTime(SETTLE_DELAY_MS);
+    });
+
+    rerender({ hasContent: true });
+    act(() => {
+      jest.advanceTimersByTime(SETTLE_DELAY_MS * 10);
+    });
+
+    expect(result.current.shouldFocusRecipientInput).toBe(true);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenContentViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenContentViewModel.ts
@@ -12,6 +12,7 @@ import { shouldUseKeyboardAvoidance } from "~/logic/keyboardVisible";
 import { useMemoViewModel } from "../../../components/Memo/hooks/useMemoViewModel";
 import { useAddressMatchedSectionViewModel } from "./useAddressMatchedSectionViewModel";
 import { useRecipientScreenView } from "./useRecipientScreenView";
+import { useSettleRecipientInputFocus } from "./useSettleRecipientInputFocus";
 
 export type UseRecipientScreenContentViewModelProps = Readonly<{
   account: AccountLike;
@@ -119,6 +120,16 @@ export function useRecipientScreenContentViewModel({
       recipient.showSanctionedBanner ||
       recipient.showBridgeRecipientError ||
       recipient.showBridgeRecipientWarning);
+
+  const hasContent =
+    !recipient.showInitialState ||
+    recipient.isLoading ||
+    recipient.showContactsList ||
+    recipient.showEmptyContactsState ||
+    recipient.featureIntroduction.isOpen ||
+    Boolean(recipient.clipboardAddress);
+
+  useSettleRecipientInputFocus(hasContent);
 
   const keyboardBehavior: KeyboardAvoidingViewProps["behavior"] = shouldUseKeyboardAvoidance(
     Platform.OS,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useSettleRecipientInputFocus.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useSettleRecipientInputFocus.ts
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+import { useRecipientInputFocus } from "../../../context/RecipientInputFocusContext";
+
+/**
+ * The step fills in from several async sources — the contacts feature flag, the contacts sync and
+ * the clipboard read — so the decision is delayed until it stopped changing for a moment. That
+ * quiet period also outlives the enter transition and the dismissal of the drawer the flow was
+ * opened from, both of which retract the keyboard.
+ */
+const SETTLE_DELAY_MS = 400;
+
+/**
+ * Tells the send header whether the address input may take the keyboard. It only may when the
+ * step settled on showing nothing at all: any content is something to read or tap first.
+ */
+export function useSettleRecipientInputFocus(hasContent: boolean): void {
+  const { isRecipientInputFocusSettled, settleRecipientInputFocus } = useRecipientInputFocus();
+
+  useEffect(() => {
+    if (isRecipientInputFocusSettled) {
+      return;
+    }
+
+    const timeout = setTimeout(() => settleRecipientInputFocus(!hasContent), SETTLE_DELAY_MS);
+    return () => clearTimeout(timeout);
+  }, [hasContent, isRecipientInputFocusSettled, settleRecipientInputFocus]);
+}


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

The recipient step’s address input used `autoFocus`, so the keyboard opened during navigation and then closed when contacts or other content appeared, or when a parent drawer dismissed and called `Keyboard.dismiss()`. This change removes immediate autofocus and coordinates focus between the header and recipient screen: after the step has settled for 400ms, the keyboard opens only when there is no content to show (no contacts list, clipboard suggestion, introduction sheet, or search results)


https://github.com/user-attachments/assets/e4a1712b-f63b-457c-aaeb-db92b215b441


### 🔗 Context

- **[JIRA / GitHub issue](https://ledgerhq.atlassian.net/browse/LIVE-36848)** <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
