### PR TITLE
fix(e2e): accept the device transaction check prompt

### DIFF
--- a/libs/live-e2e-shared/src/speculos.ts
+++ b/libs/live-e2e-shared/src/speculos.ts
@@ -566,8 +566,16 @@ export function drainSpeculosScreenshots(port: number): Buffer[] {
   return screenshots;
 }
 
+function isTransactionCheckPrompt(screenTexts: string): boolean {
+  const texts = screenTexts.toLowerCase();
+  return (
+    texts.includes(DeviceLabels.ENABLE_TRANSACTION_CHECK.toLowerCase()) &&
+    texts.includes(DeviceLabels.YES_ENABLE.toLowerCase())
+  );
+}
+
 async function acceptTransactionCheckPrompt(screenTexts: string): Promise<boolean> {
-  if (!isTouchDevice() || !screenTexts.includes(DeviceLabels.YES_ENABLE)) return false;
+  if (!isTouchDevice() || !isTransactionCheckPrompt(screenTexts)) return false;
 
   try {
     await pressAndRelease(DeviceLabels.YES_ENABLE);

--- a/libs/live-e2e-shared/src/speculos.ts
+++ b/libs/live-e2e-shared/src/speculos.ts
@@ -566,6 +566,18 @@ export function drainSpeculosScreenshots(port: number): Buffer[] {
   return screenshots;
 }
 
+async function acceptTransactionCheckPrompt(screenTexts: string): Promise<boolean> {
+  if (!isTouchDevice() || !screenTexts.includes(DeviceLabels.YES_ENABLE)) return false;
+
+  try {
+    await pressAndRelease(DeviceLabels.YES_ENABLE);
+    return true;
+  } catch (err) {
+    console.warn(`[waitFor] failed to accept the Transaction Check prompt: ${sanitizeError(err)}`);
+    return false;
+  }
+}
+
 export async function waitFor(
   text: string,
   maxAttempts = 60,
@@ -573,11 +585,16 @@ export async function waitFor(
 ): Promise<string> {
   const port = getEnv("SPECULOS_API_PORT");
   let texts = "";
+  let transactionCheckAccepted = false;
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     texts = await fetchCurrentScreenTexts(port);
 
     if (texts.toLowerCase().includes(text.toLowerCase())) {
       return texts;
+    }
+
+    if (!transactionCheckAccepted) {
+      transactionCheckAccepted = await acceptTransactionCheckPrompt(texts);
     }
 
     await sleep(SCREEN_POLL_INTERVAL_MS);
@@ -615,35 +632,14 @@ export async function waitForReviewTransaction(
   maxAttempts = 60,
   { matchFullEvents = false }: { matchFullEvents?: boolean } = {},
 ): Promise<void> {
-  if (!isTouchDevice()) {
-    try {
-      await waitFor(DeviceLabels.REVIEW_TRANSACTION, maxAttempts, { matchFullEvents });
-    } catch (error) {
-      if (error instanceof Error && isExchangeAppReadyStall(error.message)) {
-        error.message += SWAP_INIT_STALL_HINT;
-      }
-      throw error;
+  try {
+    await waitFor(DeviceLabels.REVIEW_TRANSACTION, maxAttempts, { matchFullEvents });
+  } catch (error) {
+    if (error instanceof Error && isExchangeAppReadyStall(error.message)) {
+      error.message += SWAP_INIT_STALL_HINT;
     }
-    return;
+    throw error;
   }
-
-  const port = getEnv("SPECULOS_API_PORT");
-  let texts = "";
-  let enabled = false;
-  for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    texts = await fetchCurrentScreenTexts(port);
-    if (texts.includes(DeviceLabels.REVIEW_TRANSACTION)) {
-      return;
-    }
-    if (!enabled && texts.includes(DeviceLabels.YES_ENABLE)) {
-      await pressAndRelease(DeviceLabels.YES_ENABLE);
-      enabled = true; // press once, then keep polling for review within the same budget
-    }
-    await sleep(SCREEN_POLL_INTERVAL_MS);
-  }
-
-  const base = `Text "${DeviceLabels.REVIEW_TRANSACTION}" not found on device screen after ${maxAttempts} attempts. Last screen text: "${texts}"`;
-  throw new Error(isExchangeAppReadyStall(texts) ? base + SWAP_INIT_STALL_HINT : base);
 }
 
 export async function fetchCurrentScreenTexts(speculosApiPort: number): Promise<string> {


### PR DESCRIPTION
### 📝 Description

`[SOL] - Delegate` and the other Solana signing specs started failing on the Flex/Stax E2E runs with:

```
Error: Text "Review" not found on device screen after 60 attempts.
Last screen text: "Enable Transaction Check? Get real-time warnings about risky Solana
transactions. ... Maybe later  Yes, enable"
```

**Root cause** — not the seed rotation, despite the timing. The Speculos app version is not pinned: `startSpeculos` resolves the latest firmware from the Manager API and then the latest app from that catalog, and `setup-speculos_image` checks out `LedgerHQ/coin-apps` at `ref: master`. The catalog now serves **Solana 1.9.2** on touch devices (`flex/1.3.0`, `stax/1.7.0+`), and 1.9.x introduced a one-off "Enable Transaction Check?" opt-in screen that sits in front of the review screen.

Three different code paths wait for that review screen, and only one of them knew about the prompt:

| Path | Used by | Handled the prompt? |
|---|---|---|
| `waitForReviewTransaction()` | swap | ✅ tapped `YES_ENABLE` |
| `acceptEnableTransactionCheck()` | borrow, SEI delegate | ✅ explicit call |
| `waitFor()` via `getDelegateEvents()` / `waitForSendReviewTransaction()` | **SOL delegate + send** | ❌ plain poll |

**Fix** — move the handling down into the shared `waitFor()` so every touch-device review wait is resilient to it, and collapse `waitForReviewTransaction`'s duplicated touch branch onto it. The target-text check still runs *before* the tap, so `waitFor` never touches the device when the expected screen is already up; the tap happens once, within the same attempt budget; and a failed tap is non-fatal (the screen can move on between the poll and the tap) so a recoverable state can't become a hard failure.

This fixes 4 tests in one place rather than just the reported one: `[SOL] - Delegate`, `[SOL] - Send`, `[SOL] - Send (new send flow) with memo` and `[GIGA (Solana)] - Send`.

**Verification** — Desktop E2E dispatched on Speculos **flex**, the device that reproduces it:

| Run | Scope | Result |
|---|---|---|
| [33738717325](https://github.com/LedgerHQ/ledger-live/actions/runs/33738717325) | `@solana` | 24 passed / 4 failed |
| [33738736128](https://github.com/LedgerHQ/ledger-live/actions/runs/33738736128) | full suite | 301 passed / 20 failed |

Across both runs: **0** occurrences of `Enable Transaction Check`, **0** of `Text "Review" not found`, **0** of `Text "Review transaction" not found`.

Full-suite comparison against the pre-fix Allure artifact from the same flex configuration:

| | Before | After |
|---|---|---|
| Passed | 283 | **301** |
| Unique failures | 40 | **20** |
| tx-check failures | 4 | **0** |

The 20 remaining failures are all pre-existing and unrelated (`send-skip-memo-link` click timeouts, OSMO "Keplr" vs "Ledger by Figment", `[CCD] - Send`, `[ETH] - Send to ENS address`, the GIGA token assertions, `[USDT (Algorand)] - Add sub-account`). No device-screen wait failures of any kind remain.

No regression from collapsing `waitForReviewTransaction`: six swap pairs routed through it passed — `[SOL-ETH]`, `[ETH-SOL]`, `[BTC-SOL]`, `[SOL-BTC]`, `[USDC (Sui)-SOL]`, `[USDT (Ethereum)-SOL]`.

> [!NOTE]
> No changeset: `@ledgerhq/live-e2e-shared` is `private: true` and this is test-tooling only, matching the precedent of #21463, which changed the same file.

> [!IMPORTANT]
> This class of breakage will recur. Neither `SPECULOS_FIRMWARE_VERSION` (only the nanoSP smoke job pins it) nor `coin-apps` (`ref: master`) is pinned for the on-demand E2E workflow, so any embedded-app release can turn the suite red with no repo change. Worth a follow-up.

### 🔗 Context

- **JIRA / GitHub issue**: _TBD — please add the ticket_
- **ADR** (if any): n/a

