### PR TITLE
[LWDM] chore(currency-crypto): drop deviceTicker (LIVE-36663)

### DIFF
--- a/.changeset/drop-crypto-device-ticker.md
+++ b/.changeset/drop-crypto-device-ticker.md
@@ -1,0 +1,8 @@
+---
+"@domain/entity-currency-crypto": minor
+"@ledgerhq/types-live": minor
+"@ledgerhq/ledger-wallet-framework": minor
+"@ledgerhq/live-common": minor
+---
+
+Drop `deviceTicker` from `CryptoCurrency`. The field was declared in three places and set by 17 testnet/L2 registry entries, but nothing ever read it.

--- a/domain/entity/currency-crypto/src/currencies/arbitrum_sepolia.ts
+++ b/domain/entity/currency-crypto/src/currencies/arbitrum_sepolia.ts
@@ -7,7 +7,6 @@ export const arbitrum_sepolia = currency({
   name: "Arbitrum Sepolia",
   managerAppName: "Ethereum",
   ticker: "ETH",
-  deviceTicker: "ETH",
   scheme: "arbitrum_sepolia",
   color: "#ff0000",
   family: "evm",

--- a/domain/entity/currency-crypto/src/currencies/arc.ts
+++ b/domain/entity/currency-crypto/src/currencies/arc.ts
@@ -7,7 +7,6 @@ export const arc = currency({
   name: "Arc",
   managerAppName: "Ethereum",
   ticker: "USDC",
-  deviceTicker: "USDC",
   scheme: "arc",
   color: "#1A2B5F",
   family: "evm",

--- a/domain/entity/currency-crypto/src/currencies/arc_testnet.ts
+++ b/domain/entity/currency-crypto/src/currencies/arc_testnet.ts
@@ -7,7 +7,6 @@ export const arc_testnet = currency({
   name: "Arc Testnet",
   managerAppName: "Ethereum",
   ticker: "USDC",
-  deviceTicker: "USDC",
   scheme: "arc_testnet",
   color: "#6B7280",
   family: "evm",

--- a/domain/entity/currency-crypto/src/currencies/assethub_polkadot.ts
+++ b/domain/entity/currency-crypto/src/currencies/assethub_polkadot.ts
@@ -7,7 +7,6 @@ export const assethub_polkadot = currency({
   name: "Polkadot",
   managerAppName: "Polkadot",
   ticker: "DOT",
-  deviceTicker: "DOT",
   scheme: "assethub_polkadot",
   color: "#E6007A",
   family: "polkadot",

--- a/domain/entity/currency-crypto/src/currencies/assethub_westend.ts
+++ b/domain/entity/currency-crypto/src/currencies/assethub_westend.ts
@@ -7,7 +7,6 @@ export const assethub_westend = currency({
   name: "Assethub Westend",
   managerAppName: "Polkadot",
   ticker: "WND",
-  deviceTicker: "DOT",
   scheme: "assethub_westend",
   color: "#00ff00",
   units: [

--- a/domain/entity/currency-crypto/src/currencies/base_sepolia.ts
+++ b/domain/entity/currency-crypto/src/currencies/base_sepolia.ts
@@ -7,7 +7,6 @@ export const base_sepolia = currency({
   name: "Base Sepolia",
   managerAppName: "Ethereum",
   ticker: "ETH",
-  deviceTicker: "ETH",
   scheme: "base_sepolia",
   color: "#FF0000",
   family: "evm",

--- a/domain/entity/currency-crypto/src/currencies/bitcoin_regtest.ts
+++ b/domain/entity/currency-crypto/src/currencies/bitcoin_regtest.ts
@@ -32,7 +32,6 @@ export const bitcoin_regtest = currency({
       magnitude: 0,
     },
   ],
-  deviceTicker: "TEST",
   supportsSegwit: true,
   supportsNativeSegwit: true,
   isTestnetFor: "bitcoin",

--- a/domain/entity/currency-crypto/src/currencies/bitcoin_testnet.ts
+++ b/domain/entity/currency-crypto/src/currencies/bitcoin_testnet.ts
@@ -32,7 +32,6 @@ export const bitcoin_testnet = currency({
       magnitude: 0,
     },
   ],
-  deviceTicker: "TEST",
   supportsSegwit: true,
   supportsNativeSegwit: true,
   isTestnetFor: "bitcoin",

--- a/domain/entity/currency-crypto/src/currencies/elrond.ts
+++ b/domain/entity/currency-crypto/src/currencies/elrond.ts
@@ -11,7 +11,6 @@ export const elrond = currency({
   color: "#23F7DD",
   family: "multiversx",
   blockAvgTime: 6,
-  deviceTicker: "EGLD",
   units: [
     {
       name: "EGLD",

--- a/domain/entity/currency-crypto/src/currencies/ethereum_hoodi.ts
+++ b/domain/entity/currency-crypto/src/currencies/ethereum_hoodi.ts
@@ -7,7 +7,6 @@ export const ethereum_hoodi = currency({
   name: "Ethereum Hoodi",
   managerAppName: "Ethereum",
   ticker: "ETH",
-  deviceTicker: "ETH",
   scheme: "eth_hoodi",
   color: "#0ebdcd",
   units: [

--- a/domain/entity/currency-crypto/src/currencies/ethereum_sepolia.ts
+++ b/domain/entity/currency-crypto/src/currencies/ethereum_sepolia.ts
@@ -7,7 +7,6 @@ export const ethereum_sepolia = currency({
   name: "Ethereum Sepolia",
   managerAppName: "Ethereum",
   ticker: "ETH",
-  deviceTicker: "ETH",
   scheme: "eth_sepolia",
   color: "#ff0000",
   units: [

--- a/domain/entity/currency-crypto/src/currencies/polygon_amoy.ts
+++ b/domain/entity/currency-crypto/src/currencies/polygon_amoy.ts
@@ -7,7 +7,6 @@ export const polygon_amoy = currency({
   name: "Polygon Amoy",
   managerAppName: "Ethereum",
   ticker: "POL",
-  deviceTicker: "POL",
   scheme: "polygon_amoy",
   color: "#6d29de",
   family: "evm",

--- a/domain/entity/currency-crypto/src/currencies/polygon_zk_evm_testnet.ts
+++ b/domain/entity/currency-crypto/src/currencies/polygon_zk_evm_testnet.ts
@@ -7,7 +7,6 @@ export const polygon_zk_evm_testnet = currency({
   name: "Polygon zkEVM Testnet",
   managerAppName: "Ethereum",
   ticker: "ETH",
-  deviceTicker: "ETH",
   scheme: "polygon_zk_evm_testnet",
   color: "#E58247",
   family: "evm",

--- a/domain/entity/currency-crypto/src/currencies/robinhood.ts
+++ b/domain/entity/currency-crypto/src/currencies/robinhood.ts
@@ -7,7 +7,6 @@ export const robinhood = currency({
   name: "Robinhood Chain",
   managerAppName: "Ethereum",
   ticker: "ETH",
-  deviceTicker: "ETH",
   scheme: "robinhood",
   color: "#00C805",
   family: "evm",

--- a/domain/entity/currency-crypto/src/currencies/robinhood_testnet.ts
+++ b/domain/entity/currency-crypto/src/currencies/robinhood_testnet.ts
@@ -7,7 +7,6 @@ export const robinhood_testnet = currency({
   name: "Robinhood Chain Testnet",
   managerAppName: "Ethereum",
   ticker: "ETH",
-  deviceTicker: "ETH",
   scheme: "robinhood_testnet",
   color: "#00C805",
   family: "evm",

--- a/domain/entity/currency-crypto/src/currencies/unichain_sepolia.ts
+++ b/domain/entity/currency-crypto/src/currencies/unichain_sepolia.ts
@@ -7,7 +7,6 @@ export const unichain_sepolia = currency({
   name: "Unichain Sepolia",
   managerAppName: "Ethereum",
   ticker: "ETH",
-  deviceTicker: "ETH",
   scheme: "unichain_sepolia",
   color: "#f50fb4",
   family: "evm",

--- a/domain/entity/currency-crypto/src/currencies/westend.ts
+++ b/domain/entity/currency-crypto/src/currencies/westend.ts
@@ -7,7 +7,6 @@ export const westend = currency({
   name: "Westend",
   managerAppName: "Polkadot",
   ticker: "WND",
-  deviceTicker: "DOT",
   scheme: "westend",
   color: "#00ff00",
   units: [

--- a/domain/entity/currency-crypto/src/schema.ts
+++ b/domain/entity/currency-crypto/src/schema.ts
@@ -98,8 +98,6 @@ export const CryptoCurrencySchema = z.object({
   ethereumLikeInfo: EthereumLikeInfoSchema.optional(),
   /** One or more blockchain explorer URL templates. */
   explorerViews: z.array(ExplorerViewSchema),
-  /** Ticker displayed on the device (when different from `ticker`). */
-  deviceTicker: z.string().optional(),
   /**
    * Id used to connect to the Ledger explorer endpoint (when different from the currency id and ticker).
    * @deprecated Kept only for backward compatibility; the explorer-id concept is being phased out.

--- a/libs/ledger-live-common/src/currencies/mock.ts
+++ b/libs/ledger-live-common/src/currencies/mock.ts
@@ -344,7 +344,6 @@ export const CURRENCIES_LIST: CryptoCurrency[] = [
     color: "#23F7DD",
     family: "multiversx",
     blockAvgTime: 6,
-    deviceTicker: "EGLD",
     units: [
       {
         name: "EGLD",

--- a/libs/ledger-wallet-framework/src/types.ts
+++ b/libs/ledger-wallet-framework/src/types.ts
@@ -31,7 +31,6 @@ export interface CryptoCurrency {
   id: CryptoCurrencyId;
   name: string;
   ticker: string;
-  deviceTicker?: string;
   color: string;
   coinType: number;
   family: string;

--- a/libs/types-live/src/currency.ts
+++ b/libs/types-live/src/currency.ts
@@ -116,7 +116,6 @@ export type CryptoCurrency = CurrencyCommon & {
   bitcoinLikeInfo?: BitcoinLikeInfo;
   ethereumLikeInfo?: EthereumLikeInfo;
   explorerViews: ExplorerView[];
-  deviceTicker?: string;
   /**
    * Used to connect to the right endpoint url since it is different from currencyId and ticker.
    * @deprecated Kept only for backward compatibility; the explorer-id concept is being phased out.


### PR DESCRIPTION
### 📝 Description

`CryptoCurrency#deviceTicker` has no reader anywhere in the repo. It was declared in three places — `domain/entity/currency-crypto/src/schema.ts`, `libs/types-live/src/currency.ts` and `libs/ledger-wallet-framework/src/types.ts` — set by 17 testnet/L2 registry entries plus one mock value, and read by nothing.

This PR deletes the three declarations, the mock value and the 17 registry entries. No behaviour change.

Verified beyond direct property reads: no runtime narrowing (`"deviceTicker" in x`), no bracket or dynamic access, absent from the wallet-api and platform converters (both whitelist fields explicitly, so nothing leaked to live-apps) and absent from the DADA wire format.

> [!NOTE]
> The registry files under `domain/entity/currency-crypto/src/currencies/` are owned by `@ledgerhq/coin-integration`, so their review is expected even though the work is generic.
>
> This is one of three sibling PRs splitting [LIVE-36644](https://ledgerhq.atlassian.net/browse/LIVE-36644). They touch the same declaration blocks, so whichever lands second will need a trivial rebase.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36663](https://ledgerhq.atlassian.net/browse/LIVE-36663), part of [LIVE-36644](https://ledgerhq.atlassian.net/browse/LIVE-36644)
- **ADR** (if any): n/a


[LIVE-36644]: https://ledgerhq.atlassian.net/browse/LIVE-36644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-36663]: https://ledgerhq.atlassian.net/browse/LIVE-36663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ