### PR TITLE
[LWM] chore(currency-crypto): drop disableCountervalue (LIVE-36664)

### DIFF
--- a/.changeset/drop-crypto-disable-countervalue.md
+++ b/.changeset/drop-crypto-disable-countervalue.md
@@ -1,0 +1,9 @@
+---
+"@domain/entity-currency-crypto": minor
+"@ledgerhq/types-live": minor
+"@ledgerhq/ledger-wallet-framework": minor
+"@domain/api-aggregated-assets": minor
+"live-mobile": minor
+---
+
+Drop `disableCountervalue` from `CryptoCurrency`. Nothing read it on a crypto currency; it stays on `TokenCurrency`, where the assets API drives it, and on `FiatCurrency`.

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/__integrations__/mockedAccounts.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/__integrations__/mockedAccounts.ts
@@ -599,7 +599,6 @@ export const MockedAccounts: AccountsState = {
           { name: "Kwei", code: "Kwei", magnitude: 3 },
           { name: "wei", code: "wei", magnitude: 0 },
         ],
-        disableCountervalue: false,
         ethereumLikeInfo: { chainId: 59144 },
         explorerViews: [
           {

--- a/apps/ledger-live-mobile/src/screens/Portfolio/__integrations__/mockedAccount.ts
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/__integrations__/mockedAccount.ts
@@ -549,7 +549,6 @@ export const MockedAccounts: AccountsState = {
           { name: "Kwei", code: "Kwei", magnitude: 3 },
           { name: "wei", code: "wei", magnitude: 0 },
         ],
-        disableCountervalue: false,
         ethereumLikeInfo: { chainId: 59144 },
         explorerViews: [
           {

--- a/domain/api/aggregated-assets/src/transforms.test.ts
+++ b/domain/api/aggregated-assets/src/transforms.test.ts
@@ -180,7 +180,6 @@ describe("convertApiAssets, via getAssetData", () => {
         family: "unknownfamily",
         explorerViews: [],
         symbol: "U",
-        disableCountervalue: true,
         supportsSegwit: true,
       });
     });

--- a/domain/api/aggregated-assets/src/transforms.ts
+++ b/domain/api/aggregated-assets/src/transforms.ts
@@ -44,7 +44,6 @@ export function convertApiAssets(
           family: asset.family ?? asset.id,
           explorerViews: [],
           symbol: asset.symbol,
-          disableCountervalue: asset.disableCountervalue,
           supportsSegwit: asset.hasSegwit,
           ...(asset.chainId ? { ethereumLikeInfo: { chainId: parseInt(asset.chainId, 10) } } : {}),
         });

--- a/domain/entity/currency-crypto/src/currencies/arbitrum_sepolia.ts
+++ b/domain/entity/currency-crypto/src/currencies/arbitrum_sepolia.ts
@@ -39,7 +39,6 @@ export const arbitrum_sepolia = currency({
     },
   ],
   isTestnetFor: "arbitrum",
-  disableCountervalue: true,
   ethereumLikeInfo: {
     chainId: 421614,
   },

--- a/domain/entity/currency-crypto/src/currencies/arc_testnet.ts
+++ b/domain/entity/currency-crypto/src/currencies/arc_testnet.ts
@@ -38,7 +38,6 @@ export const arc_testnet = currency({
       magnitude: 0,
     },
   ],
-  disableCountervalue: true,
   ethereumLikeInfo: {
     chainId: 5042002,
   },

--- a/domain/entity/currency-crypto/src/currencies/base_sepolia.ts
+++ b/domain/entity/currency-crypto/src/currencies/base_sepolia.ts
@@ -38,7 +38,6 @@ export const base_sepolia = currency({
       magnitude: 0,
     },
   ],
-  disableCountervalue: true,
   isTestnetFor: "base",
   ethereumLikeInfo: {
     chainId: 84532,

--- a/domain/entity/currency-crypto/src/currencies/bitcoin_regtest.ts
+++ b/domain/entity/currency-crypto/src/currencies/bitcoin_regtest.ts
@@ -36,7 +36,6 @@ export const bitcoin_regtest = currency({
   supportsSegwit: true,
   supportsNativeSegwit: true,
   isTestnetFor: "bitcoin",
-  disableCountervalue: true,
   family: "bitcoin",
   blockAvgTime: 900,
   bitcoinLikeInfo: {

--- a/domain/entity/currency-crypto/src/currencies/bitcoin_testnet.ts
+++ b/domain/entity/currency-crypto/src/currencies/bitcoin_testnet.ts
@@ -36,7 +36,6 @@ export const bitcoin_testnet = currency({
   supportsSegwit: true,
   supportsNativeSegwit: true,
   isTestnetFor: "bitcoin",
-  disableCountervalue: true,
   family: "bitcoin",
   blockAvgTime: 900,
   bitcoinLikeInfo: {

--- a/domain/entity/currency-crypto/src/currencies/blast.ts
+++ b/domain/entity/currency-crypto/src/currencies/blast.ts
@@ -37,7 +37,6 @@ export const blast = currency({
       magnitude: 0,
     },
   ],
-  disableCountervalue: false,
   ethereumLikeInfo: {
     chainId: 81457,
   },

--- a/domain/entity/currency-crypto/src/currencies/blast_sepolia.ts
+++ b/domain/entity/currency-crypto/src/currencies/blast_sepolia.ts
@@ -37,7 +37,6 @@ export const blast_sepolia = currency({
       magnitude: 0,
     },
   ],
-  disableCountervalue: false,
   isTestnetFor: "blast",
   ethereumLikeInfo: {
     chainId: 168587773,

--- a/domain/entity/currency-crypto/src/currencies/cardano_testnet.ts
+++ b/domain/entity/currency-crypto/src/currencies/cardano_testnet.ts
@@ -9,7 +9,6 @@ export const cardano_testnet = currency({
   ticker: "tADA",
   scheme: "cardano_testnet",
   isTestnetFor: "cardano",
-  disableCountervalue: true,
   color: "#0A1D2C",
   family: "cardano",
   blockAvgTime: 20,

--- a/domain/entity/currency-crypto/src/currencies/cosmos_testnet.ts
+++ b/domain/entity/currency-crypto/src/currencies/cosmos_testnet.ts
@@ -9,7 +9,6 @@ export const cosmos_testnet = currency({
   ticker: "MUON",
   scheme: "cosmos_testnet",
   isTestnetFor: "cosmos",
-  disableCountervalue: true,
   color: "#16192f",
   family: "cosmos",
   units: [

--- a/domain/entity/currency-crypto/src/currencies/crypto_org_croeseid.ts
+++ b/domain/entity/currency-crypto/src/currencies/crypto_org_croeseid.ts
@@ -23,7 +23,6 @@ export const crypto_org_croeseid = currency({
     },
   ],
   isTestnetFor: "crypto_org",
-  disableCountervalue: true,
   explorerViews: [
     {
       tx: "https://cronos-pos.org/explorer/croeseid/tx/$hash",

--- a/domain/entity/currency-crypto/src/currencies/ethereum_hoodi.ts
+++ b/domain/entity/currency-crypto/src/currencies/ethereum_hoodi.ts
@@ -38,7 +38,6 @@ export const ethereum_hoodi = currency({
     },
   ],
   isTestnetFor: "ethereum",
-  disableCountervalue: true,
   family: "evm",
   blockAvgTime: 15,
   ethereumLikeInfo: {

--- a/domain/entity/currency-crypto/src/currencies/ethereum_sepolia.ts
+++ b/domain/entity/currency-crypto/src/currencies/ethereum_sepolia.ts
@@ -38,7 +38,6 @@ export const ethereum_sepolia = currency({
     },
   ],
   isTestnetFor: "ethereum",
-  disableCountervalue: true,
   family: "evm",
   blockAvgTime: 15,
   ethereumLikeInfo: {

--- a/domain/entity/currency-crypto/src/currencies/linea.ts
+++ b/domain/entity/currency-crypto/src/currencies/linea.ts
@@ -37,7 +37,6 @@ export const linea = currency({
       magnitude: 0,
     },
   ],
-  disableCountervalue: false,
   ethereumLikeInfo: {
     chainId: 59144,
   },

--- a/domain/entity/currency-crypto/src/currencies/linea_sepolia.ts
+++ b/domain/entity/currency-crypto/src/currencies/linea_sepolia.ts
@@ -37,7 +37,6 @@ export const linea_sepolia = currency({
       magnitude: 0,
     },
   ],
-  disableCountervalue: false,
   isTestnetFor: "linea",
   ethereumLikeInfo: {
     chainId: 59141,

--- a/domain/entity/currency-crypto/src/currencies/lukso.ts
+++ b/domain/entity/currency-crypto/src/currencies/lukso.ts
@@ -37,7 +37,6 @@ export const lukso = currency({
       magnitude: 0,
     },
   ],
-  disableCountervalue: false,
   ethereumLikeInfo: {
     chainId: 42,
   },

--- a/domain/entity/currency-crypto/src/currencies/mantle_sepolia.ts
+++ b/domain/entity/currency-crypto/src/currencies/mantle_sepolia.ts
@@ -38,7 +38,6 @@ export const mantle_sepolia = currency({
     },
   ],
   isTestnetFor: "mantle",
-  disableCountervalue: true,
   ethereumLikeInfo: {
     chainId: 5003,
   },

--- a/domain/entity/currency-crypto/src/currencies/polygon_amoy.ts
+++ b/domain/entity/currency-crypto/src/currencies/polygon_amoy.ts
@@ -12,7 +12,6 @@ export const polygon_amoy = currency({
   color: "#6d29de",
   family: "evm",
   isTestnetFor: "polygon",
-  disableCountervalue: true,
   ethereumLikeInfo: {
     chainId: 80002,
   },

--- a/domain/entity/currency-crypto/src/currencies/polygon_zk_evm_testnet.ts
+++ b/domain/entity/currency-crypto/src/currencies/polygon_zk_evm_testnet.ts
@@ -38,7 +38,6 @@ export const polygon_zk_evm_testnet = currency({
       magnitude: 0,
     },
   ],
-  disableCountervalue: true,
   isTestnetFor: "polygon_zk_evm",
   ethereumLikeInfo: {
     chainId: 1442,

--- a/domain/entity/currency-crypto/src/currencies/robinhood_testnet.ts
+++ b/domain/entity/currency-crypto/src/currencies/robinhood_testnet.ts
@@ -38,7 +38,6 @@ export const robinhood_testnet = currency({
       magnitude: 0,
     },
   ],
-  disableCountervalue: true,
   isTestnetFor: "robinhood",
   ethereumLikeInfo: {
     chainId: 46630,

--- a/domain/entity/currency-crypto/src/currencies/scroll.ts
+++ b/domain/entity/currency-crypto/src/currencies/scroll.ts
@@ -37,7 +37,6 @@ export const scroll = currency({
       magnitude: 0,
     },
   ],
-  disableCountervalue: false,
   ethereumLikeInfo: {
     chainId: 534352,
   },

--- a/domain/entity/currency-crypto/src/currencies/solana_devnet.ts
+++ b/domain/entity/currency-crypto/src/currencies/solana_devnet.ts
@@ -11,7 +11,6 @@ export const solana_devnet = currency({
   color: "#000",
   family: "solana",
   isTestnetFor: "solana",
-  disableCountervalue: true,
   units: [
     {
       name: "SOL",

--- a/domain/entity/currency-crypto/src/currencies/solana_testnet.ts
+++ b/domain/entity/currency-crypto/src/currencies/solana_testnet.ts
@@ -11,7 +11,6 @@ export const solana_testnet = currency({
   color: "#000",
   family: "solana",
   isTestnetFor: "solana",
-  disableCountervalue: true,
   units: [
     {
       name: "SOL",

--- a/domain/entity/currency-crypto/src/currencies/sui_testnet.ts
+++ b/domain/entity/currency-crypto/src/currencies/sui_testnet.ts
@@ -11,7 +11,6 @@ export const sui_testnet = currency({
   color: "#000",
   family: "sui",
   isTestnetFor: "sui",
-  disableCountervalue: true,
   units: [
     {
       name: "Sui",

--- a/domain/entity/currency-crypto/src/currencies/unichain_sepolia.ts
+++ b/domain/entity/currency-crypto/src/currencies/unichain_sepolia.ts
@@ -39,7 +39,6 @@ export const unichain_sepolia = currency({
     },
   ],
   isTestnetFor: "unichain",
-  disableCountervalue: true,
   ethereumLikeInfo: {
     chainId: 1301,
   },

--- a/domain/entity/currency-crypto/src/schema.ts
+++ b/domain/entity/currency-crypto/src/schema.ts
@@ -63,8 +63,6 @@ export const CryptoCurrencySchema = z.object({
   units: z.array(UnitSchema).min(1),
   /** Optional currency symbol (e.g. `"Ƀ"`). Not all currencies have one. */
   symbol: z.string().optional(),
-  /** When `true`, countervalue display is disabled (e.g. colliding tickers). */
-  disableCountervalue: z.boolean().optional(),
   /** Search keywords (e.g. `["btc", "bitcoin"]`). */
   keywords: z.array(z.string()).optional(),
   /** Id of the currency this was forked from (e.g. `"bitcoin"` for Bitcoin Cash). */

--- a/libs/ledger-wallet-framework/src/types.ts
+++ b/libs/ledger-wallet-framework/src/types.ts
@@ -51,7 +51,6 @@ export interface CryptoCurrency {
     XPUBVersion?: number;
   };
   symbol?: string;
-  disableCountervalue?: boolean;
   keywords?: string[];
   explorerId?: string;
   tokenTypes?: string[];

--- a/libs/types-live/src/currency.ts
+++ b/libs/types-live/src/currency.ts
@@ -41,11 +41,6 @@ type CurrencyCommon = {
   units: Unit[];
   // a shorter version of code using the symbol of the currency. like Ƀ . not all cryptocurrencies have a symbol
   symbol?: string;
-  /**
-   * tells if countervalue need to be disabled (typically because colliding with other coins)
-   * @deprecated this field will soon be dropped. this is the API that drives this dynamically.
-   */
-  disableCountervalue?: boolean;
   // keywords to be able to find currency from "obvious" terms
   keywords?: string[];
 };
@@ -65,6 +60,11 @@ export type TokenCurrency = CurrencyCommon & {
   tokenType: string;
   // tells if the token was delisted by the assets API and should be hidden from new flows
   delisted?: boolean;
+  /**
+   * tells if countervalue need to be disabled (typically because colliding with other coins)
+   * @deprecated this field will soon be dropped. this is the API that drives this dynamically.
+   */
+  disableCountervalue?: boolean;
 };
 
 /**


### PR DESCRIPTION
### 📝 Description

`disableCountervalue` has no reader on `CryptoCurrency`. It was already marked `@deprecated`, set by 24 registry entries (mostly testnets, plus `blast`, `linea`, `linea_sepolia`, `lukso` and `scroll` which set it to `false`), and read by nothing: verified absent from `live-countervalues`, `live-countervalues-react`, `libs/ledger-live-common/src/portfolio` and `.../market`.

This PR removes the `CryptoCurrency` declaration only:

- deleted from `domain/entity/currency-crypto/src/schema.ts` and from the `CryptoCurrency` interface in `libs/ledger-wallet-framework/src/types.ts`;
- in `libs/types-live/src/currency.ts` it sat on the shared `CurrencyCommon`, so it moved down onto `TokenCurrency` rather than being deleted from the base;
- deleted from the 24 registry entries;
- `domain/api/aggregated-assets/src/transforms.ts` stopped writing it into the synthesised DADA fallback, since the schema would now strip it. `ApiCryptoCurrency` keeps the field: that is the wire contract.

It stays on `TokenCurrency`, where it is server-driven and derived in `domain/api/currency-token/src/converter.ts` as `!!parentCurrency.isTestnetFor || !!apiToken.disableCountervalue`, and on `FiatCurrency`, which keeps its own field. No behaviour change.

Verified beyond direct property reads: no runtime narrowing, no bracket or dynamic access, and absent from the wallet-api and platform converters.

> [!NOTE]
> The registry files under `domain/entity/currency-crypto/src/currencies/` are owned by `@ledgerhq/coin-integration`, so their review is expected even though the work is generic.
>
> This is one of three sibling PRs splitting [LIVE-36644](https://ledgerhq.atlassian.net/browse/LIVE-36644). They touch the same declaration blocks, so whichever lands second will need a trivial rebase.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36664](https://ledgerhq.atlassian.net/browse/LIVE-36664), part of [LIVE-36644](https://ledgerhq.atlassian.net/browse/LIVE-36644)
- **ADR** (if any): n/a


[LIVE-36644]: https://ledgerhq.atlassian.net/browse/LIVE-36644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ