### PR TITLE
chore(currency-crypto): drop delisted (LIVE-36665)

### DIFF
--- a/.changeset/drop-crypto-delisted.md
+++ b/.changeset/drop-crypto-delisted.md
@@ -1,0 +1,8 @@
+---
+"@domain/entity-currency-crypto": minor
+"@ledgerhq/types-live": minor
+"@ledgerhq/ledger-wallet-framework": minor
+"@features/platform-contacts": minor
+---
+
+Drop `delisted` from `CryptoCurrency`. No registry entry ever set it, so the `listCryptoCurrencies()` production filter was testing a dead branch. It stays on `TokenCurrency`, where CAL drives it.

--- a/domain/entity/currency-crypto/src/legacy/accessors.ts
+++ b/domain/entity/currency-crypto/src/legacy/accessors.ts
@@ -31,17 +31,16 @@ export function hasCryptoCurrencyId(id: string): boolean {
 /**
  * Return all known crypto currencies.
  *
- * By default (`withDevCrypto = false`) returns production currencies only: entries where both
- * `isTestnetFor` and `delisted` are falsy. Pass `true` to get the full unfiltered list, which
- * includes testnet and delisted entries.
+ * By default (`withDevCrypto = false`) returns production currencies only: entries where
+ * `isTestnetFor` is falsy. Pass `true` to get the full unfiltered list, which includes testnets.
  */
 export function listCryptoCurrencies(withDevCrypto = false): CryptoCurrency[] {
   return withDevCrypto ? allCurrencies : prodCurrencies;
 }
 
 /**
- * Return the first crypto currency (including testnets and delisted entries) that satisfies the
- * predicate, or `undefined` when none matches.
+ * Return the first crypto currency (including testnets) that satisfies the predicate, or
+ * `undefined` when none matches.
  */
 export function findCryptoCurrency(f: (c: CryptoCurrency) => boolean): CryptoCurrency | undefined {
   return allCurrencies.find(f);
@@ -107,7 +106,7 @@ function findByManagerApp(managerAppName: string): CryptoCurrency | undefined {
 
 const allCurrencies: CryptoCurrency[] = Object.values(CRYPTO_CURRENCIES_REGISTRY);
 
-const prodCurrencies: CryptoCurrency[] = allCurrencies.filter(c => !c.isTestnetFor && !c.delisted);
+const prodCurrencies: CryptoCurrency[] = allCurrencies.filter(c => !c.isTestnetFor);
 
 const byScheme: Record<string, CryptoCurrency> = Object.fromEntries(
   allCurrencies.map(c => [c.scheme, c]),

--- a/domain/entity/currency-crypto/src/schema.ts
+++ b/domain/entity/currency-crypto/src/schema.ts
@@ -65,8 +65,6 @@ export const CryptoCurrencySchema = z.object({
   symbol: z.string().optional(),
   /** When `true`, countervalue display is disabled (e.g. colliding tickers). */
   disableCountervalue: z.boolean().optional(),
-  /** When `true`, the currency has been delisted and should not appear in new flows. */
-  delisted: z.boolean().optional(),
   /** Search keywords (e.g. `["btc", "bitcoin"]`). */
   keywords: z.array(z.string()).optional(),
   /** Id of the currency this was forked from (e.g. `"bitcoin"` for Bitcoin Cash). */

--- a/features/platform/contacts/src/utils/resolveEligibleAddressCurrencyIds.web.test.ts
+++ b/features/platform/contacts/src/utils/resolveEligibleAddressCurrencyIds.web.test.ts
@@ -19,9 +19,7 @@ describe("resolveEligibleAddressCurrencyIds", () => {
       .filter(network => network.family === "evm" && network.managerAppName === "Ethereum")
       .map(network => network.id);
     const excludedNetworkIds = listCryptoCurrencies(true)
-      .filter(
-        network => network.family === "evm" && Boolean(network.isTestnetFor || network.delisted),
-      )
+      .filter(network => network.family === "evm" && Boolean(network.isTestnetFor))
       .map(network => network.id);
     const networkIds = resolveEligibleAddressCurrencyIds(["evm"]);
 

--- a/libs/ledger-wallet-framework/src/types.ts
+++ b/libs/ledger-wallet-framework/src/types.ts
@@ -52,7 +52,6 @@ export interface CryptoCurrency {
   };
   symbol?: string;
   disableCountervalue?: boolean;
-  delisted?: boolean;
   keywords?: string[];
   explorerId?: string;
   tokenTypes?: string[];

--- a/libs/types-live/src/currency.ts
+++ b/libs/types-live/src/currency.ts
@@ -46,8 +46,6 @@ type CurrencyCommon = {
    * @deprecated this field will soon be dropped. this is the API that drives this dynamically.
    */
   disableCountervalue?: boolean;
-  // tells if countervalue need to be disabled (typically because colliding with other coins)
-  delisted?: boolean;
   // keywords to be able to find currency from "obvious" terms
   keywords?: string[];
 };
@@ -65,6 +63,8 @@ export type TokenCurrency = CurrencyCommon & {
   parentCurrencyId: any;
   // the type of token in the blockchain it belongs. e.g. 'erc20'
   tokenType: string;
+  // tells if the token was delisted by the assets API and should be hidden from new flows
+  delisted?: boolean;
 };
 
 /**


### PR DESCRIPTION
### 📝 Description

Not a single one of the 202 crypto currency registry entries declares `delisted`. Its only reader was the production-list filter in `domain/entity/currency-crypto/src/legacy/accessors.ts`:

```ts
const prodCurrencies = allCurrencies.filter(c => !c.isTestnetFor && !c.delisted);
```

Since nothing set it, `!c.delisted` was always `true` — a dead branch. This PR simplifies the filter to `c => !c.isTestnetFor`, updates the doc comments on `listCryptoCurrencies` / `findCryptoCurrency` that described the removed behaviour, and removes the field from `domain/entity/currency-crypto/src/schema.ts` and from the `CryptoCurrency` interface in `libs/ledger-wallet-framework/src/types.ts`. In `libs/types-live/src/currency.ts` it sat on the shared `CurrencyCommon`, so it moved down onto `TokenCurrency` rather than being deleted from the base. No registry file to touch, and `listCryptoCurrencies()` returns exactly the same list as before.

`TokenCurrency#delisted` stays: it is server-driven (CAL `delisted`, mapped in `domain/api/currency-token/src/internals/utils.ts`) and real.

Verified beyond direct property reads: no runtime narrowing, no bracket or dynamic access, and absent from the wallet-api and platform converters.

> [!IMPORTANT]
> Worth a deliberate ack rather than a rubber stamp: dynamic currencies may eventually want to delist a whole chain. Removing the field now is safe — nothing sets it and nothing meaningfully reads it — and it can be reintroduced with a real source behind it. Flagging so this is a decision, not an accident.

> [!NOTE]
> This is one of three sibling PRs splitting [LIVE-36644](https://ledgerhq.atlassian.net/browse/LIVE-36644). They touch the same declaration blocks, so whichever lands second will need a trivial rebase.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36665](https://ledgerhq.atlassian.net/browse/LIVE-36665), part of [LIVE-36644](https://ledgerhq.atlassian.net/browse/LIVE-36644)
- **ADR** (if any): n/a


[LIVE-36644]: https://ledgerhq.atlassian.net/browse/LIVE-36644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ