### PR TITLE
[LWDM] Feat(LIVE-32286)/staking bond cleanup

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/Body.tsx
@@ -58,7 +58,8 @@ export default createStakingFlowBody<StepId>({
     return networkType ? DEFAULT_ALEO_VALIDATOR[networkType] : "";
   },
   // The withdrawal address is fixed to the user's own account and never exposed as a step.
-  // This seeds it at transaction-creation time so getTransactionStatus — which validates the
-  // field — never sees it empty; prepareTransaction re-pins it on every update as a backstop.
+  // prepareTransaction now pins it unconditionally in the coin module, so this seed is
+  // redundant rather than load-bearing; it is kept only until the flag is removed from the
+  // shared factory.
   withdrawalFromFresh: true,
 });

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/Body.tsx
@@ -58,8 +58,7 @@ export default createStakingFlowBody<StepId>({
     return networkType ? DEFAULT_ALEO_VALIDATOR[networkType] : "";
   },
   // The withdrawal address is fixed to the user's own account and never exposed as a step.
-  // prepareTransaction now pins it unconditionally in the coin module, so this seed is
-  // redundant rather than load-bearing; it is kept only until the flag is removed from the
-  // shared factory.
+  // This seeds it at transaction-creation time so getTransactionStatus — which validates the
+  // field — never sees it empty; prepareTransaction re-pins it on every update as a backstop.
   withdrawalFromFresh: true,
 });

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/ValidatorRow.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/BondPublicFlowModal/ValidatorRow.tsx
@@ -25,9 +25,7 @@ import { openURL } from "~/renderer/linking";
  * explorer, but sunk below anything better and not selectable.
  */
 export const isDisabled = (validator: AleoValidator) =>
-  !validator.isOpen ||
-  validator.nonEarningReason === "belowCommitteeMinimum" ||
-  validator.nonEarningReason === "overConcentrated";
+  !validator.isOpen || validator.nonEarningReason === "overConcentrated";
 
 type Props = {
   validator: AleoValidator;

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9336,7 +9336,6 @@
             "rowSubtitleClosed": "Validator is closed to new stake",
             "rowSubtitleEarnsNothing": "Validator earns no rewards",
             "nonEarning": {
-              "belowCommitteeMinimum": "This validator holds less than the 10,000,000 ALEO committee minimum, so it earns no rewards and neither would you.",
               "fullCommission": "This validator takes 100% commission, so delegators keep nothing.",
               "overConcentrated": "This validator holds more than 25% of all staked ALEO. The protocol pays it nothing above that cap, so delegators earn nothing."
             },

--- a/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.ts
@@ -322,15 +322,6 @@ async function handleTransferTransaction({
   }
 
   if (transaction.mode === TRANSACTION_TYPE.BOND_PUBLIC) {
-    const withdrawalError = await validateRecipient({
-      account,
-      recipient: transaction.withdrawal,
-      allowSelfTransfer: true,
-    });
-    if (withdrawalError) {
-      errors.withdrawal = withdrawalError;
-    }
-
     if (!recipientError) {
       // One validator per address: a bond to any other one is rejected on-chain, so
       // that takes precedence over whether the target happens to be open.

--- a/libs/coin-modules/coin-aleo/src/bridge/prepareTransaction.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/prepareTransaction.ts
@@ -190,9 +190,6 @@ export const prepareTransaction: AccountBridge<
     return updateTransaction(transaction, {
       amount: calculatedAmount.amount,
       fees: estimatedFees,
-      // `unbond_public` asserts the caller is `withdraw[staker]`, so a foreign withdrawal
-      // address permanently removes this account's ability to unbond; the value cannot be
-      // corrected by a later bond. The bridge decides it, never the caller.
       withdrawal: account.freshAddress,
     });
   }

--- a/libs/coin-modules/coin-aleo/src/bridge/prepareTransaction.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/prepareTransaction.ts
@@ -190,7 +190,10 @@ export const prepareTransaction: AccountBridge<
     return updateTransaction(transaction, {
       amount: calculatedAmount.amount,
       fees: estimatedFees,
-      withdrawal: transaction.withdrawal || account.freshAddress,
+      // `unbond_public` asserts the caller is `withdraw[staker]`, so a foreign withdrawal
+      // address permanently removes this account's ability to unbond; the value cannot be
+      // corrected by a later bond. The bridge decides it, never the caller.
+      withdrawal: account.freshAddress,
     });
   }
 

--- a/libs/coin-modules/coin-aleo/src/constants.ts
+++ b/libs/coin-modules/coin-aleo/src/constants.ts
@@ -115,8 +115,6 @@ export const MICROCREDITS_PER_CREDIT = 1_000_000;
 // Below this bonded total the protocol pays a delegator nothing at all.
 export const MIN_DELEGATOR_STAKE_MICROCREDITS = 10_000 * MICROCREDITS_PER_CREDIT;
 
-// A validator holding less than this is below the committee minimum and earns nothing,
-// so neither do the delegators bonded to it.
 export const MIN_VALIDATOR_STAKE_MICROCREDITS = 10_000_000 * MICROCREDITS_PER_CREDIT;
 
 // snarkVM `block_reward_v2` adds a coinbase share and transaction fees on top, so

--- a/libs/coin-modules/coin-aleo/src/logic/getValidators.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getValidators.test.ts
@@ -13,9 +13,6 @@ const CLOSED_HIGH_STAKE = "aleo1closed_high";
 
 const microcredits = (credits: number) => credits * MICROCREDITS_PER_CREDIT;
 
-// Keep these magnitudes above MIN_VALIDATOR_STAKE_MICROCREDITS: a validator under that
-// committee floor earns nothing whatever the ratios say, so shrinking them would make the
-// test stop testing the ratios it asserts on.
 const TOTAL_STAKE_CREDITS = 200_000_000;
 const TOTAL_SUPPLY_CREDITS = TOTAL_STAKE_CREDITS;
 const GROSS_RATE = 0.05;
@@ -77,22 +74,6 @@ describe("getValidators", () => {
     expect(validators.find(v => v.address === CLOSED_HIGH_STAKE)?.estimatedYearlyRewardsRate).toBe(
       0,
     );
-  });
-
-  it("reports a zero rate below the committee minimum, even at zero commission", async () => {
-    const BELOW_MINIMUM = "aleo1below_minimum";
-    jest.mocked(apiClient.getCommittee).mockResolvedValue({
-      ...committee,
-      members: {
-        ...committee.members,
-        // Just under the floor, so this is the threshold and not the ratios talking.
-        [BELOW_MINIMUM]: [microcredits(9_999_999), true, 0],
-      },
-    });
-
-    const validators = await getValidators(CURRENCY_ID);
-
-    expect(validators.find(v => v.address === BELOW_MINIMUM)?.estimatedYearlyRewardsRate).toBe(0);
   });
 
   it("fetches committee, names and supply concurrently", async () => {

--- a/libs/coin-modules/coin-aleo/src/logic/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.ts
@@ -34,7 +34,6 @@ import {
   MAX_VALIDATOR_STAKE_SHARE,
   MICROCREDITS_PER_CREDIT,
   MIN_DELEGATOR_STAKE_MICROCREDITS,
-  MIN_VALIDATOR_STAKE_MICROCREDITS,
   PRIVATE_TRANSFER_FUNCTIONS,
   PROGRAM_ID,
   SINGLE_CALL_SIGNING_TIME,
@@ -1569,9 +1568,6 @@ export function getValidatorNonEarningReason({
   validatorStakeMicrocredits: BigNumber;
   commissionPercent: BigNumber;
 }): AleoValidatorNonEarningReason | null {
-  if (validatorStakeMicrocredits.isLessThan(MIN_VALIDATOR_STAKE_MICROCREDITS)) {
-    return "belowCommitteeMinimum";
-  }
   if (
     validatorStakeMicrocredits
       .dividedBy(totalStakeMicrocredits)

--- a/libs/coin-modules/coin-aleo/src/types/logic.ts
+++ b/libs/coin-modules/coin-aleo/src/types/logic.ts
@@ -49,10 +49,7 @@ export type AleoAccountInfo = {
   scannedHeight: number;
 };
 
-export type AleoValidatorNonEarningReason =
-  | "belowCommitteeMinimum"
-  | "overConcentrated"
-  | "fullCommission";
+export type AleoValidatorNonEarningReason = "overConcentrated" | "fullCommission";
 
 export type AleoValidator = {
   address: string;

--- a/shared/env/src/definitions/team-ledger-partner-blockydevs/index.ts
+++ b/shared/env/src/definitions/team-ledger-partner-blockydevs/index.ts
@@ -27,12 +27,12 @@ const teamLedgerPartnerBlockydevs = {
     desc: "Aleo mainnet node URL",
   },
   ALEO_MAINNET_SDK_ENDPOINT: {
-    def: "https://api.ledger-aleo.blockydevs.dev/network/mainnet",
+    def: "https://aleo-backend.api.live.ledger.com/network/mainnet",
     parser: stringParser,
     desc: "Aleo mainnet SDK URL",
   },
   ALEO_TESTNET_SDK_ENDPOINT: {
-    def: "https://api.ledger-aleo.blockydevs.dev/network/testnet",
+    def: "https://aleo-backend.api.live.ledger.com/network/testnet",
     parser: stringParser,
     desc: "Aleo testnet SDK URL",
   },


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Cleanup pass on the Aleo staking prototype, targeting `wip/aleo-staking-prototype-rebased`.

- **Restore the production Aleo SDK endpoints.** The mainnet and testnet SDK defaults pointed at a partner development host; they now point at `aleo-backend.api.live.ledger.com`.
- **Pin the bond withdrawal address in the bridge.** The account's own address is always used, whatever the UI passes in — a foreign withdrawal address would permanently block unbonding. Its now-unreachable validation is removed.
- **Drop the below-committee-minimum validator state.** The 10M credit floor is a committee admission rule, not a reward rule, so the wallet could never see a validator in that state. The classification, its copy and its test are removed; the constant stays, with a comment describing what it actually guards.

No behaviour change for released code — the staking flow has not landed on `develop`.

### 🔗 Context

- **JIRA / GitHub issue**:  [LIVE-32286](https://ledgerhq.atlassian.net/browse/LIVE-32286)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->

[LIVE-32286]: https://ledgerhq.atlassian.net/browse/LIVE-32286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
