### PR TITLE
[LWM] fix(send): fix redirection to amount for contact in new send flow lwm

### DIFF
--- a/.changeset/dirty-avocados-call.md
+++ b/.changeset/dirty-avocados-call.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix(send): picking a contact on the recipient step now goes straight to the amount step, matching desktop

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenView.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenView.test.ts
@@ -67,34 +67,6 @@ const idleResult: AddressSearchResult = {
   matchedContact: undefined,
 };
 
-function mockContactAddressValidation() {
-  let searchValue = "";
-  let validationResult: AddressSearchResult = idleResult;
-  const setValue = jest.fn((value: string) => {
-    searchValue = value;
-  });
-  mockedUseSendFlowData.mockImplementation(() => ({
-    recipientSearch: { ...mockRecipientSearch, value: searchValue, setValue },
-    state: {} as never,
-    uiConfig: {} as never,
-  }));
-  mockedUseAddressValidation.mockImplementation(() => ({
-    result: validationResult,
-    isLoading: false,
-    validateAddress: jest.fn(),
-  }));
-  return {
-    setValue,
-    markAddressValid() {
-      validationResult = {
-        ...idleResult,
-        status: "valid",
-        hasBridgeValidationResult: true,
-      };
-    },
-  };
-}
-
 describe("useRecipientScreenView", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -318,9 +290,8 @@ describe("useRecipientScreenView", () => {
     });
   });
 
-  it("validates the address matching the current currency among network addresses", () => {
+  it("advances with the address matching the current currency among network addresses", () => {
     const onAddressSelected = jest.fn();
-    const { setValue, markAddressValid } = mockContactAddressValidation();
     const contact = mockContact({
       addresses: [
         mockContactAddress({
@@ -336,7 +307,7 @@ describe("useRecipientScreenView", () => {
       ],
     });
 
-    const { result, rerender } = renderHook(() =>
+    const { result } = renderHook(() =>
       useRecipientScreenView({
         account: mockAccount,
         currency: createMockTokenCurrency(),
@@ -347,19 +318,12 @@ describe("useRecipientScreenView", () => {
 
     act(() => result.current.handleContactSelect(contact));
 
-    expect(setValue).toHaveBeenCalledWith("0xusdt");
-    expect(onAddressSelected).not.toHaveBeenCalled();
-
-    markAddressValid();
-    rerender(undefined);
-
     expect(onAddressSelected).toHaveBeenCalledWith("0xusdt", undefined);
   });
 
-  it("validates the only compatible contact address before continuing", () => {
+  it("advances straight to the next step for a contact with one address", () => {
     const onAddressSelected = jest.fn();
     const selectContact = jest.fn();
-    const { setValue, markAddressValid } = mockContactAddressValidation();
     mockedUseRecipientContactSelection.mockReturnValue({
       selectedContact: undefined,
       selectContact,
@@ -374,57 +338,6 @@ describe("useRecipientScreenView", () => {
       ],
     });
 
-    const { result, rerender } = renderHook(() =>
-      useRecipientScreenView({
-        account: mockAccount,
-        currency: createMockCurrency({ id: "ethereum" }),
-        onAddressSelected,
-        recipientSupportsDomain: true,
-      }),
-    );
-
-    act(() => result.current.handleContactSelect(contact));
-
-    expect(setValue).toHaveBeenCalledWith("0x1234567890123456789012345678901234567890");
-    expect(onAddressSelected).not.toHaveBeenCalled();
-    expect(selectContact).not.toHaveBeenCalled();
-
-    markAddressValid();
-    rerender(undefined);
-
-    expect(onAddressSelected).toHaveBeenCalledWith(
-      "0x1234567890123456789012345678901234567890",
-      undefined,
-    );
-  });
-
-  it.each([
-    ["invalid", "incorrect_format"],
-    ["sanctioned", "sanctioned"],
-  ] as const)("does not continue with a %s contact address", (status, error) => {
-    const onAddressSelected = jest.fn();
-    let searchValue = "";
-    const setValue = jest.fn((value: string) => {
-      searchValue = value;
-    });
-    mockedUseSendFlowData.mockImplementation(() => ({
-      recipientSearch: { ...mockRecipientSearch, value: searchValue, setValue },
-      state: {} as never,
-      uiConfig: {} as never,
-    }));
-    mockedUseAddressValidation.mockReturnValue({
-      result: { ...idleResult, status, error },
-      isLoading: false,
-      validateAddress: jest.fn(),
-    });
-    const contact = mockContact({
-      addresses: [
-        mockContactAddress({
-          currencyId: "ethereum",
-          address: "0x1234567890123456789012345678901234567890",
-        }),
-      ],
-    });
     const { result } = renderHook(() =>
       useRecipientScreenView({
         account: mockAccount,
@@ -436,8 +349,11 @@ describe("useRecipientScreenView", () => {
 
     act(() => result.current.handleContactSelect(contact));
 
-    expect(setValue).toHaveBeenCalledWith("0x1234567890123456789012345678901234567890");
-    expect(onAddressSelected).not.toHaveBeenCalled();
+    expect(onAddressSelected).toHaveBeenCalledWith(
+      "0x1234567890123456789012345678901234567890",
+      undefined,
+    );
+    expect(selectContact).not.toHaveBeenCalled();
   });
 
   it("opens address selection when a contact has several compatible addresses", () => {
@@ -508,17 +424,16 @@ describe("useRecipientScreenView", () => {
     expect(onAddressSelected).not.toHaveBeenCalled();
   });
 
-  it("validates the chosen address after contact address selection", () => {
+  it("advances with the chosen address after contact address selection", () => {
     const onAddressSelected = jest.fn();
     const clearSelectedContact = jest.fn();
-    const { setValue, markAddressValid } = mockContactAddressValidation();
     mockedUseRecipientContactSelection.mockReturnValue({
       selectedContact: undefined,
       selectContact: jest.fn(),
       clearSelectedContact,
     });
 
-    const { result, rerender } = renderHook(() =>
+    const { result } = renderHook(() =>
       useRecipientScreenView({
         account: mockAccount,
         currency: createMockCurrency({ id: "ethereum" }),
@@ -530,12 +445,6 @@ describe("useRecipientScreenView", () => {
     act(() => result.current.handleContactAddressSelect("0x456"));
 
     expect(clearSelectedContact).toHaveBeenCalledTimes(1);
-    expect(setValue).toHaveBeenCalledWith("0x456");
-    expect(onAddressSelected).not.toHaveBeenCalled();
-
-    markAddressValid();
-    rerender(undefined);
-
     expect(onAddressSelected).toHaveBeenCalledWith("0x456", undefined);
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenView.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenView.ts
@@ -9,7 +9,7 @@ import type { CryptoCurrency } from "@domain/entity-currency-crypto";
 import type { TokenCurrency } from "@domain/entity-currency-token";
 import type { Contact } from "@domain/entity-contact";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { useSendFlowData } from "../../../context/SendFlowContext";
 import { useRecipientContactSelection } from "../../../context/RecipientContactSelectionContext";
 import { useContactsFeatureIntroductionViewModel } from "./useContactsFeatureIntroductionViewModel";
@@ -38,7 +38,6 @@ export function useRecipientScreenView({
   const { isEnabled: isContactsFeatureEnabled, eligibleAddressFamilies } =
     useContactsFeature("mobile");
   const { selectedContact, selectContact, clearSelectedContact } = useRecipientContactSelection();
-  const [pendingContactAddress, setPendingContactAddress] = useState<string>();
 
   const mainAccount = getMainAccount(account, parentAccount);
   const hasAddressBook = isEligibleAddressCurrency(eligibleAddressFamilies, currency);
@@ -105,39 +104,30 @@ export function useRecipientScreenView({
 
   const handleAddressSelect = useCallback(
     (address: string, ensName?: string) => {
-      setPendingContactAddress(undefined);
       onAddressSelected(address, ensName);
     },
     [onAddressSelected],
-  );
-
-  const validateContactAddress = useCallback(
-    (address: string) => {
-      setPendingContactAddress(address);
-      recipientSearch.setValue(address);
-    },
-    [recipientSearch],
   );
 
   const handleContactSelect = useCallback(
     (contact: Contact) => {
       const address = pickContactAddressForCurrency(contact.addresses, currency.id);
       if (address) {
-        validateContactAddress(address.address);
+        handleAddressSelect(address.address);
         return;
       }
 
       selectContact(contact);
     },
-    [currency.id, selectContact, validateContactAddress],
+    [currency.id, handleAddressSelect, selectContact],
   );
 
   const handleContactAddressSelect = useCallback(
     (address: string) => {
       clearSelectedContact();
-      validateContactAddress(address);
+      handleAddressSelect(address);
     },
-    [clearSelectedContact, validateContactAddress],
+    [clearSelectedContact, handleAddressSelect],
   );
 
   const featureIntroduction = useContactsFeatureIntroductionViewModel({
@@ -150,25 +140,6 @@ export function useRecipientScreenView({
     isLoading,
     recipientSupportsDomain,
   });
-
-  useEffect(() => {
-    const selectedAddressIsValidated =
-      Boolean(pendingContactAddress) &&
-      pendingContactAddress === recipientSearch.value &&
-      searchState.isAddressValid &&
-      !searchState.showBridgeSenderError &&
-      !searchState.showBridgeRecipientWarning;
-    if (selectedAddressIsValidated && pendingContactAddress) {
-      handleAddressSelect(pendingContactAddress);
-    }
-  }, [
-    handleAddressSelect,
-    pendingContactAddress,
-    recipientSearch.value,
-    searchState.isAddressValid,
-    searchState.showBridgeRecipientWarning,
-    searchState.showBridgeSenderError,
-  ]);
 
   const shouldHideRegularSearchState = showContactSearchResult || selectedContact !== undefined;
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

On lwm, selecting a contact in the new Send flow no longer waits for recipient validation or briefly shows the “address matched” step before navigating to Amount. The recipient step now matches desktop: a single compatible address goes straight to Amount, and contacts with multiple addresses still show inline address selection first. Regression coverage was added in `useRecipientScreenView` tests for both single- and multi-address contact selection


https://github.com/user-attachments/assets/2db69425-9791-4ae0-a4f1-fe12316cbda7



### 🔗 Context

- **[JIRA / GitHub issue](https://ledgerhq.atlassian.net/browse/LIVE-36849)** <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
