### PR TITLE
[LWM] fix(e2e): update osmosis validator and skip-memo steps (LIVE-36834)

### DIFF
--- a/.changeset/eighty-lions-listen.md
+++ b/.changeset/eighty-lions-listen.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add a `provider-row-<name>` testID to the Cosmos family validator row so automation can select a validator explicitly, which Osmosis now requires since it has no pre-selected Ledger validator

--- a/apps/ledger-live-mobile/src/families/cosmos/shared/ValidatorRow.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/shared/ValidatorRow.tsx
@@ -33,6 +33,7 @@ const ValidatorRow = ({
         validatorName: validator.name || validator.validatorAddress,
       }}
       onPress={onPressT}
+      touchableTestID={`provider-row-${validator.name || validator.validatorAddress}`}
     >
       <View style={styles.validator}>
         <ValidatorImage

--- a/e2e/desktop/tests/page/modal/delegate.modal.ts
+++ b/e2e/desktop/tests/page/modal/delegate.modal.ts
@@ -96,6 +96,11 @@ export class DelegateModal extends Modal {
     await this.inputSearchField.fill(providerTicker);
   }
 
+  @step("Clear provider search field")
+  async clearProviderSearch() {
+    await this.inputSearchField.clear();
+  }
+
   @step("Get selected provider name ")
   async getSelectedProviderName() {
     const selectedProviderElement = this.rowProvider.filter({

--- a/e2e/desktop/tests/page/modal/new.send.modal.ts
+++ b/e2e/desktop/tests/page/modal/new.send.modal.ts
@@ -15,8 +15,7 @@ export class NewSendModal extends Modal {
     .locator('[data-testid="send-matched-address-button"]')
     .filter({ visible: true });
   readonly memoInput = this.dialog.getByTestId("send-memo-input");
-  readonly skipMemoLink = this.dialog.getByTestId("send-skip-memo-link");
-  readonly skipMemoConfirmButton = this.dialog.getByTestId("send-skip-memo-confirm-button");
+  readonly skipMemoConfirmButton = this.dialog.getByTestId("send-skip-memo-confirm");
   readonly amountInput = this.dialog.getByTestId("send-amount-input");
   readonly feesMenuTrigger = this.dialog.getByTestId("send-network-fees-menu-trigger");
   readonly reviewButton = this.dialog.getByTestId("send-review-button");
@@ -80,12 +79,9 @@ export class NewSendModal extends Modal {
     await expect(this.memoInput).toHaveValue(memo);
   }
 
-  @step("Skip memo")
-  async skipMemo({ confirm = true }: { confirm?: boolean } = {}) {
-    await this.skipMemoLink.click();
-    if (confirm) {
-      await this.skipMemoConfirmButton.click();
-    }
+  @step("Confirm sending without memo")
+  async confirmSkipMemo() {
+    await this.skipMemoConfirmButton.click();
   }
 
   @step("Click View details")

--- a/e2e/desktop/tests/specs/delegate.spec.ts
+++ b/e2e/desktop/tests/specs/delegate.spec.ts
@@ -27,6 +27,7 @@ const e2eDelegationAccounts: Array<{
   requiresExpertMode?: boolean;
   supportsLNS?: boolean;
   bugTicket?: string;
+  requiresValidatorSelection?: boolean;
 }> = [
   {
     delegate: new Delegate(Account.ATOM_1, "0.001", "Ledger"),
@@ -48,6 +49,7 @@ const e2eDelegationAccounts: Array<{
     delegate: new Delegate(Account.OSMO_1, "0.0001", "Ledger by Figment"),
     xrayTicket: "B2CQA-3022",
     transactionType: "Delegated",
+    requiresValidatorSelection: true,
   },
   {
     delegate: new Delegate(Account.SUI_1, "1", "Ledger by P2P.ORG"),
@@ -131,7 +133,12 @@ for (const account of e2eDelegationAccounts) {
         }
 
         await app.account.startStakingFlowFromMainStakeButton();
-        await app.delegate.verifyFirstProviderName(account.delegate.provider);
+        if (account.requiresValidatorSelection) {
+          await app.delegate.inputProvider(account.delegate.provider);
+          await app.delegate.selectProviderByName(account.delegate.provider);
+        } else {
+          await app.delegate.verifyFirstProviderName(account.delegate.provider);
+        }
         await app.delegate.continue();
         await app.delegate.fillAmount(account.delegate.amount);
         await app.delegate.continue();
@@ -391,6 +398,8 @@ for (const validator of validators) {
         await app.account.startStakingFlowFromMainStakeButton();
         await app.delegate.continue();
 
+        const isOsmosis = validator.delegate.account.currency.id === Currency.OSMO.id;
+
         if (validator.delegate.account.currency.name == Currency.MULTIVERS_X.name) {
           await app.delegate.verifyContinueDisabled();
           await app.delegate.checkValidatorListIsVisible();
@@ -407,12 +416,23 @@ for (const validator of validators) {
           // Explicitly (re)select the provider to force a clean, settled transaction update.
           await app.delegate.verifyFirstProviderName(validator.delegate.provider);
           await app.delegate.selectProviderByName(validator.delegate.provider);
+        } else if (isOsmosis) {
+          // Osmosis has no Ledger validator pre-selection: the full list is already expanded
+          // and Continue stays disabled until a validator is explicitly picked.
+          await app.delegate.verifyContinueDisabled();
+          await app.delegate.checkValidatorListIsVisible();
+          await app.delegate.inputProvider(validator.delegate.provider);
+          await app.delegate.selectProviderByName(validator.delegate.provider);
         } else {
           await app.delegate.verifyFirstProviderName(validator.delegate.provider);
           await app.delegate.verifyContinueEnabled();
         }
         await app.delegate.verifyProvider(1);
-        await app.delegate.openSearchProviderModal();
+        if (isOsmosis) {
+          await app.delegate.clearProviderSearch();
+        } else {
+          await app.delegate.openSearchProviderModal();
+        }
         await app.delegate.checkValidatorListIsVisible();
         await app.delegate.selectProviderOnRow(2);
         await app.delegate.closeProviderList(2);

--- a/e2e/desktop/tests/utils/newSendFlowUtils.ts
+++ b/e2e/desktop/tests/utils/newSendFlowUtils.ts
@@ -131,15 +131,12 @@ export function registerNewSendFlowTests(entries: NewSendFlowEntry[]) {
           }
           await app.newSendFlow.typeAddress(recipientAddress);
 
-          if (requiresMemoStep) {
-            if (validMemoTag) {
-              await app.newSendFlow.typeMemo(validMemoTag);
-              await app.newSendFlow.clickOnSendToButton(tx.accountToCredit);
-            } else {
-              await app.newSendFlow.skipMemo();
-            }
-          } else {
-            await app.newSendFlow.clickOnSendToButton(tx.accountToCredit);
+          if (requiresMemoStep && validMemoTag) {
+            await app.newSendFlow.typeMemo(validMemoTag);
+          }
+          await app.newSendFlow.clickOnSendToButton(tx.accountToCredit);
+          if (requiresMemoStep && !validMemoTag) {
+            await app.newSendFlow.confirmSkipMemo();
           }
 
           await app.newSendFlow.fillCryptoAmount(tx.amount);

--- a/e2e/mobile/specs/delegate/delegate.ts
+++ b/e2e/mobile/specs/delegate/delegate.ts
@@ -39,7 +39,11 @@ export function runDelegateTest(delegation: DelegateType, tmsLinks: string[], ta
       await app.account.tapEarn();
 
       await app.stake.dismissDelegationStart(currencyId);
-      if (delegation.account.currency.name === Currency.MULTIVERS_X.name) {
+      // Osmosis, like MultiversX, has no pre-selected validator: pick it after the amount.
+      if (
+        delegation.account.currency.name === Currency.MULTIVERS_X.name ||
+        delegation.account.currency.name === Currency.OSMO.name
+      ) {
         await app.stake.setAmount(currencyId, delegation.amount);
         await app.stake.validateAmount(currencyId);
         await app.stake.selectValidator(currencyId, delegation.provider);


### PR DESCRIPTION
### 📝 Description

**Problem**: A batch of Coin Integration E2E tests went red over the last two days. Two recent product changes were not reflected in the specs, so the tests were still asserting behaviour that no longer exists.

**Solution**: Both fixes are test-side, the product is correct in each case.

- **Osmosis no longer pre-selects the Ledger validator.** `ledgerValidator` was dropped from `config_currency_osmo`, so the validator list is now sorted by voting power (Keplr first) instead of putting Ledger by Figment on top. Osmosis also joined `shouldDisplayAllValidators`, so the list is expanded from the start and Continue stays disabled until a validator is picked. Desktop and mobile specs now search and select the provider explicitly. The Cosmos validator row had no testID, so mobile automation could not tap it: added `provider-row-<name>`, matching the name the row actually displays.

- **Skip memo became a dedicated confirmation step.** `SkipMemoSection` was removed along with the `send-skip-memo-link` testID, replaced by a screen exposing `send-skip-memo-confirm` / `send-skip-memo-cancel`. That change updated the page object under `apps/ledger-live-desktop/tests/`, but the executed specs live in `e2e/desktop/tests/`, so the copy in use kept clicking a testID that no longer exists and timed out for every memo-capable currency (OSMO, ATOM, SOL, XLM, GIGA, USDC). Ported here to the copy that actually runs. Worth flagging: while both test directories coexist, this will happen again.

**Also investigated under this ticket, not fixed here:**

- `B2CQA-3058` (SOL invalid amount) and `B2CQA-3083` (Solana ATA holding another token) fail on stale test data, not on product bugs. The parent Solana account now holds enough SOL for fees, so `NotEnoughGas` can no longer be raised; and the WIF ATA no longer exists on-chain (`getAccountInfo` returns `null`), so reporting an off-curve PDA is correct. Both need the test accounts refreshed.
- `USDC (Stellar)` targets an unactivated Stellar account, which the app correctly rejects. Needs a funded recipient.
- `B2CQA-2202` (send to ENS address) looks like a genuine product regression: no `provideDomainName` APDU is sent any more, so the device shows the raw hex recipient instead of the ENS name. Network logs show no call to the only endpoint that can produce that APDU. Worth a separate ticket for the EVM signing path.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36834](https://ledgerhq.atlassian.net/browse/LIVE-36834)


[LIVE-36834]: https://ledgerhq.atlassian.net/browse/LIVE-36834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ