### PR TITLE
[LWD] refactor(pay): extract desktop pay card db persistence

### DIFF
--- a/.changeset/strong-cooks-repair.md
+++ b/.changeset/strong-cooks-repair.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Extract Pay card persistence from the desktop db middleware into a dedicated helper

--- a/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
@@ -32,10 +32,8 @@ import {
 } from "@features/flow-large-screen-upsell";
 import { knownDevicesStoreSelector } from "../reducers/knownDevices";
 import { exportIdentitiesForPersistence } from "@domain/entity-client-identity";
-import { payCardBalancePersistedSelector } from "@features/flow-pay-balance/state";
-import { payCardFeatureTourPersistedSelector } from "@features/flow-pay-feature-tour/state";
-import { payRequestVerifyHintPersistedSelector } from "@features/flow-pay-request/state";
 import { accountsPersistedStateChanged } from "@ledgerhq/live-common/account/index";
+import { isPayAction, persistPayCard } from "./payPersistence";
 
 let DB_MIDDLEWARE_ENABLED = true;
 
@@ -135,19 +133,9 @@ const DBMiddleware: Middleware<object, State> = store => next => action => {
     return res;
   }
 
-  if (
-    action.type.startsWith("payCardBalance/") ||
-    action.type.startsWith("payCardFeatureTour/") ||
-    action.type.startsWith("payRequestVerifyHint/")
-  ) {
+  if (isPayAction(action.type)) {
     const res = next(action);
-    const state = store.getState();
-    // Pay card flow slices persist into a single blob under one storage key.
-    setKey("app", "payCard", {
-      ...payCardFeatureTourPersistedSelector(state),
-      ...payRequestVerifyHintPersistedSelector(state),
-      ...payCardBalancePersistedSelector(state),
-    });
+    persistPayCard(store.getState());
     return res;
   }
 

--- a/apps/ledger-live-desktop/src/renderer/middlewares/payPersistence.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/payPersistence.ts
@@ -1,0 +1,17 @@
+import { payCardBalancePersistedSelector } from "@features/flow-pay-balance/state";
+import { payCardFeatureTourPersistedSelector } from "@features/flow-pay-feature-tour/state";
+import { payRequestVerifyHintPersistedSelector } from "@features/flow-pay-request/state";
+import { setKey } from "~/renderer/storage";
+import type { State } from "../reducers";
+
+const PAY_ACTION_PREFIXES = ["payCardFeatureTour/", "payRequestVerifyHint/", "payCardBalance/"];
+
+export const isPayAction = (actionType: string) =>
+  PAY_ACTION_PREFIXES.some(prefix => actionType.startsWith(prefix));
+
+export const persistPayCard = (state: State) =>
+  setKey("app", "payCard", {
+    ...payCardFeatureTourPersistedSelector(state),
+    ...payRequestVerifyHintPersistedSelector(state),
+    ...payCardBalancePersistedSelector(state),
+  });


### PR DESCRIPTION
### 📝 Description

Desktop Pay card persistence (feature tour, request verify hint, balance filter) was inlined in the db middleware as a three-prefix `if` plus a merged `setKey("app", "payCard", …)` write. That made the middleware own Pay-specific selectors and hid the feature name behind a generic blob.

This PR extracts `isPayAction` and `persistPayCard` into `payPersistence.ts` and leaves a named `if (isPayAction)` branch in `db.ts`. Behavior is unchanged: the three slices still persist as one `payCard` key. Existing middleware tests still cover the composed blob.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36857](https://ledgerhq.atlassian.net/browse/LIVE-36857)
- **ADR** (if any): n/a

[LIVE-36857]: https://ledgerhq.atlassian.net/browse/LIVE-36857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ