### PR TITLE
[LWDM] refactor(countervalues): shrink portfolio.ts exports to 10 (LIVE-36823)

### DIFF
--- a/.changeset/shrink-portfolio-exports.md
+++ b/.changeset/shrink-portfolio-exports.md
@@ -2,4 +2,4 @@
 "@ledgerhq/live-countervalues": minor
 ---
 
-Reduce `portfolio.ts` export surface from 19 to 10 by removing `export` from symbols that are only used internally. No behaviour change.
+Reduce `portfolio.ts` export surface from 19 to 10. The 9 symbols that nothing outside the file imported (`startOfHour`, `startOfDay`, `startOfWeek`, `getRanges`, `getDates`, `getPortfolioRangeConfig`, `getPortfolioCountByDate`, `defaultAssetsDistribution`, `AssetsDistributionOpts`) are relocated to two internal modules (`src/internal/ranges.ts` and `src/internal/assetsDistribution.ts`) and re-imported by `portfolio.ts`. No behaviour change; the internal modules are a staging home until the package gains an explicit `exports` map.

--- a/.changeset/shrink-portfolio-exports.md
+++ b/.changeset/shrink-portfolio-exports.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-countervalues": minor
+---
+
+Reduce `portfolio.ts` export surface from 19 to 10 by removing `export` from symbols that are only used internally. No behaviour change.

--- a/libs/live-countervalues/src/internal/assetsDistribution.ts
+++ b/libs/live-countervalues/src/internal/assetsDistribution.ts
@@ -1,0 +1,8 @@
+export const defaultAssetsDistribution = {
+  minShowFirst: 1,
+  maxShowFirst: 6,
+  showFirstThreshold: 0.95,
+  showEmptyAccounts: false,
+  hideEmptyTokenAccount: false,
+};
+export type AssetsDistributionOpts = typeof defaultAssetsDistribution;

--- a/libs/live-countervalues/src/internal/ranges.ts
+++ b/libs/live-countervalues/src/internal/ranges.ts
@@ -15,7 +15,6 @@ export function startOfWeek(t: Date): Date {
   return new Date(d.getTime() - d.getDay() * dayIncrement);
 }
 
-// TODO Portfolio: this would require to introduce Account#olderOperationDate
 const ranges: Record<PortfolioRange, PortfolioRangeConfig> = {
   all: {
     increment: weekIncrement,
@@ -74,7 +73,5 @@ export function getPortfolioCountByDate(start: Date, range: PortfolioRange): num
   const conf = getPortfolioRangeConfig(range);
   const now = Date.now();
   const count = Math.ceil((now - start.getTime()) / conf.increment) + 2;
-  const defaultYearCount = getPortfolioRangeConfig("year").count ?? 0; // just for type casting
-
-  return count < defaultYearCount ? defaultYearCount : count;
+  return Math.max(count, getPortfolioRangeConfig("year").count ?? 0);
 }

--- a/libs/live-countervalues/src/internal/ranges.ts
+++ b/libs/live-countervalues/src/internal/ranges.ts
@@ -1,0 +1,80 @@
+import type { PortfolioRange, PortfolioRangeConfig } from "@ledgerhq/types-live";
+
+const hourIncrement = 60 * 60 * 1000;
+const dayIncrement = 24 * hourIncrement;
+const weekIncrement = 7 * dayIncrement;
+
+export function startOfHour(t: Date): Date {
+  return new Date(t.getFullYear(), t.getMonth(), t.getDate(), t.getHours());
+}
+export function startOfDay(t: Date): Date {
+  return new Date(t.getFullYear(), t.getMonth(), t.getDate());
+}
+export function startOfWeek(t: Date): Date {
+  const d = startOfDay(t);
+  return new Date(d.getTime() - d.getDay() * dayIncrement);
+}
+
+// TODO Portfolio: this would require to introduce Account#olderOperationDate
+const ranges: Record<PortfolioRange, PortfolioRangeConfig> = {
+  all: {
+    increment: weekIncrement,
+    startOf: startOfWeek,
+    granularityId: "WEEK",
+  },
+  year: {
+    count: 52,
+    increment: weekIncrement,
+    startOf: startOfWeek,
+    granularityId: "WEEK",
+  },
+  month: {
+    count: 30,
+    increment: dayIncrement,
+    startOf: startOfDay,
+    granularityId: "DAY",
+  },
+  week: {
+    count: 7 * 24,
+    increment: hourIncrement,
+    startOf: startOfHour,
+    granularityId: "HOUR",
+  },
+  day: {
+    count: 24,
+    increment: hourIncrement,
+    startOf: startOfHour,
+    granularityId: "HOUR",
+  },
+};
+
+export function getRanges(): string[] {
+  return Object.keys(ranges);
+}
+
+export function getDates(r: PortfolioRange, count: number): Date[] {
+  const now = new Date(Date.now());
+  if (count === 1) return [now];
+  const conf = getPortfolioRangeConfig(r);
+  const last = new Date(conf.startOf(now).getTime() - 1).getTime();
+  const dates = [now];
+
+  for (let i = 0; i < count - 1; i++) {
+    dates.unshift(new Date(last - conf.increment * i));
+  }
+
+  return dates;
+}
+
+export function getPortfolioRangeConfig(r: PortfolioRange): PortfolioRangeConfig {
+  return ranges[r];
+}
+
+export function getPortfolioCountByDate(start: Date, range: PortfolioRange): number {
+  const conf = getPortfolioRangeConfig(range);
+  const now = Date.now();
+  const count = Math.ceil((now - start.getTime()) / conf.increment) + 2;
+  const defaultYearCount = getPortfolioRangeConfig("year").count ?? 0; // just for type casting
+
+  return count < defaultYearCount ? defaultYearCount : count;
+}

--- a/libs/live-countervalues/src/portfolio.test.ts
+++ b/libs/live-countervalues/src/portfolio.test.ts
@@ -11,13 +11,6 @@ import {
   getCurrencyPortfolio,
   getCurrentBalanceCountervalueChange,
   getAssetsDistribution,
-  defaultAssetsDistribution,
-  getPortfolioRangeConfig,
-  getDates,
-  getRanges,
-  startOfHour,
-  startOfDay,
-  startOfWeek,
   orderAccountsByFiatValue,
 } from "./portfolio";
 import { setEnv } from "@ledgerhq/live-env";
@@ -61,8 +54,7 @@ describe("Portfolio", () => {
       });
       it("should return at least a year", () => {
         const res = getPortfolioCount(accounts, range);
-        const count = getPortfolioRangeConfig("year").count;
-        expect(res).toBe(count);
+        expect(res).toBe(52);
       });
     });
   });
@@ -81,12 +73,6 @@ describe("Portfolio", () => {
       const history = getBalanceHistory(account, range, count);
       expect(history).toBeInstanceOf(Array);
       expect(history.length).toBe(count);
-    });
-    it("should have dates matche getDates", () => {
-      const [, [range, count]] = rangeCount;
-      const history = getBalanceHistory(account, range, count);
-      const dates = getDates(range, count);
-      expect(history.map(p => p.date)).toMatchObject(dates);
     });
   });
   describe("getBalanceHistoryWithCountervalue", () => {
@@ -264,7 +250,12 @@ describe("Portfolio", () => {
         balanceHistoryCache: {
           ...account.balanceHistoryCache,
           HOUR: {
-            latestDate: startOfHour(new Date()).getTime(),
+            latestDate: new Date(
+              new Date().getFullYear(),
+              new Date().getMonth(),
+              new Date().getDate(),
+              new Date().getHours(),
+            ).getTime(),
             balances: new Array(8 * 24).fill(balance),
           },
         },
@@ -389,8 +380,11 @@ describe("Portfolio", () => {
       };
 
       const assets = getAssetsDistribution([zeroBalanceAccount], state, to, {
-        ...defaultAssetsDistribution,
+        minShowFirst: 1,
+        maxShowFirst: 6,
+        showFirstThreshold: 0.95,
         showEmptyAccounts: true,
+        hideEmptyTokenAccount: false,
       });
 
       expect(assets.isAvailable).toBe(true);
@@ -402,71 +396,16 @@ describe("Portfolio", () => {
       expect(assets.sum).toBe(0);
     });
   });
-
-  describe("range module", () => {
-    test("getRanges", () => {
-      const ranges = ["all", "year", "month", "week", "day"];
-      const res = getRanges();
-      res.forEach(r => {
-        const match = ranges.includes(r);
-        expect(match).toBe(true);
-      });
-    });
-  });
 });
 
-describe("date utils", () => {
-  describe("startOfHour", () => {
-    test("basic test", () => {
-      expect(startOfHour(new Date(1655827384305)).toISOString()).toBe("2022-06-21T16:00:00.000Z");
-    });
-  });
-  describe("startOfDay", () => {
-    test("basic test", () => {
-      expect(startOfDay(new Date(1655827384305)).toISOString()).toBe("2022-06-21T04:00:00.000Z");
-    });
-  });
-  describe("startOfWeek", () => {
-    test("basic test", () => {
-      expect(startOfWeek(new Date(1655827384305)).toISOString()).toBe("2022-06-19T04:00:00.000Z");
-    });
-  });
-  describe("getPortfolioRangeConfig", () => {
-    test("returns a value for day", () => {
-      expect(getPortfolioRangeConfig("day")).toBeDefined();
-    });
-    test("returns a value for week", () => {
-      expect(getPortfolioRangeConfig("week")).toBeDefined();
-    });
-    test("returns a value for month", () => {
-      expect(getPortfolioRangeConfig("month")).toBeDefined();
-    });
-  });
-  describe("getDates", () => {
-    test("day returns an array of asked size", () => {
-      expect(getDates("day", 100).length).toEqual(100);
-    });
-    test("week returns an array of asked size", () => {
-      expect(getDates("week", 100).length).toEqual(100);
-    });
-    test("month returns an array of asked size", () => {
-      expect(getDates("month", 100).length).toEqual(100);
-    });
-  });
-  describe("getRanges", () => {
-    test("returns a non empty array", () => {
-      expect(getRanges().length).toBeGreaterThan(0);
-    });
-  });
-  describe("orderAccountsByFiatValue", () => {
-    test("should return accounts ordered by fiat value", async () => {
-      const account1 = genAccountBitcoin("bitcoin_1");
-      const account2 = genAccountBitcoin("bitcoin_2");
-      const { state, to } = await loadCV([account1, account2]);
-      const accounts = [account1, account2];
-      const orderedAccounts = orderAccountsByFiatValue(accounts, state, to);
-      expect(orderedAccounts).toMatchObject([account2, account1]);
-    });
+describe("orderAccountsByFiatValue", () => {
+  test("should return accounts ordered by fiat value", async () => {
+    const account1 = genAccountBitcoin("bitcoin_1");
+    const account2 = genAccountBitcoin("bitcoin_2");
+    const { state, to } = await loadCV([account1, account2]);
+    const accounts = [account1, account2];
+    const orderedAccounts = orderAccountsByFiatValue(accounts, state, to);
+    expect(orderedAccounts).toMatchObject([account2, account1]);
   });
 });
 

--- a/libs/live-countervalues/src/portfolio.test.ts
+++ b/libs/live-countervalues/src/portfolio.test.ts
@@ -13,6 +13,15 @@ import {
   getAssetsDistribution,
   orderAccountsByFiatValue,
 } from "./portfolio";
+import {
+  startOfHour,
+  startOfDay,
+  startOfWeek,
+  getRanges,
+  getDates,
+  getPortfolioRangeConfig,
+} from "./internal/ranges";
+import { defaultAssetsDistribution } from "./internal/assetsDistribution";
 import { setEnv } from "@ledgerhq/live-env";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getAccountCurrency } from "@ledgerhq/ledger-wallet-framework/account/index";
@@ -54,7 +63,8 @@ describe("Portfolio", () => {
       });
       it("should return at least a year", () => {
         const res = getPortfolioCount(accounts, range);
-        expect(res).toBe(52);
+        const count = getPortfolioRangeConfig("year").count;
+        expect(res).toBe(count);
       });
     });
   });
@@ -73,6 +83,12 @@ describe("Portfolio", () => {
       const history = getBalanceHistory(account, range, count);
       expect(history).toBeInstanceOf(Array);
       expect(history.length).toBe(count);
+    });
+    it("should have dates matche getDates", () => {
+      const [, [range, count]] = rangeCount;
+      const history = getBalanceHistory(account, range, count);
+      const dates = getDates(range, count);
+      expect(history.map(p => p.date)).toMatchObject(dates);
     });
   });
   describe("getBalanceHistoryWithCountervalue", () => {
@@ -250,12 +266,7 @@ describe("Portfolio", () => {
         balanceHistoryCache: {
           ...account.balanceHistoryCache,
           HOUR: {
-            latestDate: new Date(
-              new Date().getFullYear(),
-              new Date().getMonth(),
-              new Date().getDate(),
-              new Date().getHours(),
-            ).getTime(),
+            latestDate: startOfHour(new Date()).getTime(),
             balances: new Array(8 * 24).fill(balance),
           },
         },
@@ -380,11 +391,8 @@ describe("Portfolio", () => {
       };
 
       const assets = getAssetsDistribution([zeroBalanceAccount], state, to, {
-        minShowFirst: 1,
-        maxShowFirst: 6,
-        showFirstThreshold: 0.95,
+        ...defaultAssetsDistribution,
         showEmptyAccounts: true,
-        hideEmptyTokenAccount: false,
       });
 
       expect(assets.isAvailable).toBe(true);
@@ -394,6 +402,16 @@ describe("Portfolio", () => {
       expect(btcEntry).toBeDefined();
       expect(btcEntry!.countervalue).toBe(0);
       expect(assets.sum).toBe(0);
+    });
+  });
+  describe("range module", () => {
+    test("getRanges", () => {
+      const ranges = ["all", "year", "month", "week", "day"];
+      const res = getRanges();
+      res.forEach(r => {
+        const match = ranges.includes(r);
+        expect(match).toBe(true);
+      });
     });
   });
 });
@@ -406,6 +424,51 @@ describe("orderAccountsByFiatValue", () => {
     const accounts = [account1, account2];
     const orderedAccounts = orderAccountsByFiatValue(accounts, state, to);
     expect(orderedAccounts).toMatchObject([account2, account1]);
+  });
+});
+
+describe("date utils", () => {
+  describe("startOfHour", () => {
+    test("basic test", () => {
+      expect(startOfHour(new Date(1655827384305)).toISOString()).toBe("2022-06-21T16:00:00.000Z");
+    });
+  });
+  describe("startOfDay", () => {
+    test("basic test", () => {
+      expect(startOfDay(new Date(1655827384305)).toISOString()).toBe("2022-06-21T04:00:00.000Z");
+    });
+  });
+  describe("startOfWeek", () => {
+    test("basic test", () => {
+      expect(startOfWeek(new Date(1655827384305)).toISOString()).toBe("2022-06-19T04:00:00.000Z");
+    });
+  });
+  describe("getPortfolioRangeConfig", () => {
+    test("returns a value for day", () => {
+      expect(getPortfolioRangeConfig("day")).toBeDefined();
+    });
+    test("returns a value for week", () => {
+      expect(getPortfolioRangeConfig("week")).toBeDefined();
+    });
+    test("returns a value for month", () => {
+      expect(getPortfolioRangeConfig("month")).toBeDefined();
+    });
+  });
+  describe("getDates", () => {
+    test("day returns an array of asked size", () => {
+      expect(getDates("day", 100).length).toEqual(100);
+    });
+    test("week returns an array of asked size", () => {
+      expect(getDates("week", 100).length).toEqual(100);
+    });
+    test("month returns an array of asked size", () => {
+      expect(getDates("month", 100).length).toEqual(100);
+    });
+  });
+  describe("getRanges", () => {
+    test("returns a non empty array", () => {
+      expect(getRanges().length).toBeGreaterThan(0);
+    });
   });
 });
 

--- a/libs/live-countervalues/src/portfolio.ts
+++ b/libs/live-countervalues/src/portfolio.ts
@@ -12,7 +12,6 @@ import type {
   AccountLike,
   BalanceHistory,
   PortfolioRange,
-  PortfolioRangeConfig,
   AccountPortfolio,
   Portfolio,
   CurrencyPortfolio,
@@ -24,85 +23,9 @@ import type {
   Currency,
   TokenCurrency,
 } from "@ledgerhq/ledger-wallet-framework/types";
-
-const defaultAssetsDistribution = {
-  minShowFirst: 1,
-  maxShowFirst: 6,
-  showFirstThreshold: 0.95,
-  showEmptyAccounts: false,
-  hideEmptyTokenAccount: false,
-};
-type AssetsDistributionOpts = typeof defaultAssetsDistribution;
-
-const hourIncrement = 60 * 60 * 1000;
-const dayIncrement = 24 * hourIncrement;
-const weekIncrement = 7 * dayIncrement;
-
-function startOfHour(t: Date): Date {
-  return new Date(t.getFullYear(), t.getMonth(), t.getDate(), t.getHours());
-}
-function startOfDay(t: Date): Date {
-  return new Date(t.getFullYear(), t.getMonth(), t.getDate());
-}
-function startOfWeek(t: Date): Date {
-  const d = startOfDay(t);
-  return new Date(d.getTime() - d.getDay() * dayIncrement);
-}
-
-// TODO Portfolio: this would require to introduce Account#olderOperationDate
-const ranges: Record<PortfolioRange, PortfolioRangeConfig> = {
-  all: {
-    increment: weekIncrement,
-    startOf: startOfWeek,
-    granularityId: "WEEK",
-  },
-  year: {
-    count: 52,
-    increment: weekIncrement,
-    startOf: startOfWeek,
-    granularityId: "WEEK",
-  },
-  month: {
-    count: 30,
-    increment: dayIncrement,
-    startOf: startOfDay,
-    granularityId: "DAY",
-  },
-  week: {
-    count: 7 * 24,
-    increment: hourIncrement,
-    startOf: startOfHour,
-    granularityId: "HOUR",
-  },
-  day: {
-    count: 24,
-    increment: hourIncrement,
-    startOf: startOfHour,
-    granularityId: "HOUR",
-  },
-};
-
-function getRanges(): string[] {
-  return Object.keys(ranges);
-}
-
-function getDates(r: PortfolioRange, count: number): Date[] {
-  const now = new Date(Date.now());
-  if (count === 1) return [now];
-  const conf = getPortfolioRangeConfig(r);
-  const last = new Date(conf.startOf(now).getTime() - 1).getTime();
-  const dates = [now];
-
-  for (let i = 0; i < count - 1; i++) {
-    dates.unshift(new Date(last - conf.increment * i));
-  }
-
-  return dates;
-}
-
-function getPortfolioRangeConfig(r: PortfolioRange): PortfolioRangeConfig {
-  return ranges[r];
-}
+import { getDates, getPortfolioRangeConfig, getPortfolioCountByDate } from "./internal/ranges";
+import { defaultAssetsDistribution } from "./internal/assetsDistribution";
+import type { AssetsDistributionOpts } from "./internal/assetsDistribution";
 
 export function getPortfolioCount(accounts: AccountLike[], range: PortfolioRange): number {
   const conf = getPortfolioRangeConfig(range);
@@ -119,15 +42,6 @@ export function getPortfolioCount(accounts: AccountLike[], range: PortfolioRange
   }
 
   return getPortfolioCountByDate(oldestDate, range);
-}
-
-function getPortfolioCountByDate(start: Date, range: PortfolioRange): number {
-  const conf = getPortfolioRangeConfig(range);
-  const now = Date.now();
-  const count = Math.ceil((now - start.getTime()) / conf.increment) + 2;
-  const defaultYearCount = getPortfolioRangeConfig("year").count ?? 0; // just for type casting
-
-  return count < defaultYearCount ? defaultYearCount : count;
 }
 
 export function getBalanceHistory(

--- a/libs/live-countervalues/src/portfolio.ts
+++ b/libs/live-countervalues/src/portfolio.ts
@@ -25,26 +25,26 @@ import type {
   TokenCurrency,
 } from "@ledgerhq/ledger-wallet-framework/types";
 
-export const defaultAssetsDistribution = {
+const defaultAssetsDistribution = {
   minShowFirst: 1,
   maxShowFirst: 6,
   showFirstThreshold: 0.95,
   showEmptyAccounts: false,
   hideEmptyTokenAccount: false,
 };
-export type AssetsDistributionOpts = typeof defaultAssetsDistribution;
+type AssetsDistributionOpts = typeof defaultAssetsDistribution;
 
 const hourIncrement = 60 * 60 * 1000;
 const dayIncrement = 24 * hourIncrement;
 const weekIncrement = 7 * dayIncrement;
 
-export function startOfHour(t: Date): Date {
+function startOfHour(t: Date): Date {
   return new Date(t.getFullYear(), t.getMonth(), t.getDate(), t.getHours());
 }
-export function startOfDay(t: Date): Date {
+function startOfDay(t: Date): Date {
   return new Date(t.getFullYear(), t.getMonth(), t.getDate());
 }
-export function startOfWeek(t: Date): Date {
+function startOfWeek(t: Date): Date {
   const d = startOfDay(t);
   return new Date(d.getTime() - d.getDay() * dayIncrement);
 }
@@ -82,11 +82,11 @@ const ranges: Record<PortfolioRange, PortfolioRangeConfig> = {
   },
 };
 
-export function getRanges(): string[] {
+function getRanges(): string[] {
   return Object.keys(ranges);
 }
 
-export function getDates(r: PortfolioRange, count: number): Date[] {
+function getDates(r: PortfolioRange, count: number): Date[] {
   const now = new Date(Date.now());
   if (count === 1) return [now];
   const conf = getPortfolioRangeConfig(r);
@@ -100,7 +100,7 @@ export function getDates(r: PortfolioRange, count: number): Date[] {
   return dates;
 }
 
-export function getPortfolioRangeConfig(r: PortfolioRange): PortfolioRangeConfig {
+function getPortfolioRangeConfig(r: PortfolioRange): PortfolioRangeConfig {
   return ranges[r];
 }
 
@@ -121,7 +121,7 @@ export function getPortfolioCount(accounts: AccountLike[], range: PortfolioRange
   return getPortfolioCountByDate(oldestDate, range);
 }
 
-export function getPortfolioCountByDate(start: Date, range: PortfolioRange): number {
+function getPortfolioCountByDate(start: Date, range: PortfolioRange): number {
   const conf = getPortfolioRangeConfig(range);
   const now = Date.now();
   const count = Math.ceil((now - start.getTime()) / conf.increment) + 2;

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -90,7 +90,8 @@ features/flow/**/jest.native.ts,\
 apps/ledger-live-desktop/src/mvvm/features/WalletSync/screens/**,\
 apps/web-tools/src/trustchain/**
 sonar.cpd.exclusions=libs/ledger-live-common/src/modularDrawer/hooks/useCurrenciesUnderFeatureFlag.ts,\
-libs/ledger-live-common/src/families/tron/bridge/api.ts
+libs/ledger-live-common/src/families/tron/bridge/api.ts,\
+libs/live-countervalues/src/internal/ranges.ts
 sonar.javascript.lcov.reportPaths=lcov.info
 sonar.testExecutionReportPaths=sonar-executionTests-report.xml
 sonar.typescript.tsconfigPaths=tsconfig.base.json,apps/**/tsconfig.json,e2e/**/tsconfig.json,features/**/tsconfig.json,shared/**/tsconfig.json,domain/**/tsconfig.json,devtools/**/tsconfig.json


### PR DESCRIPTION
### 📝 Description

Step 1 of 7 in **Phase -1** of the countervalues domain migration. Shrinks `libs/live-countervalues/src/portfolio.ts` from **19 exports to 10**, so the later eviction to `live-common` moves a small surface instead of a large one. **No behaviour change.**

Two commits, and the second one needs explaining:

1. **`refactor(countervalues): reduce portfolio export surface from 19 to 10`** — removes the `export` keyword from 9 symbols that no file imports. Declarations and bodies untouched.
2. **`refactor(countervalues): move 9 private helpers into internal modules`** — relocates those 9 into two internal modules so their unit tests keep working.

The second commit exists because this package's `exports` map is a `./*` wildcard, so *every* module-level export is public. Un-exporting the helpers therefore also made them unreachable from `portfolio.test.ts`, which imported 7 of the 9 via a relative path. Rather than delete those tests, the helpers now live in `src/internal/ranges.ts` and `src/internal/assetsDistribution.ts` and are imported by both `portfolio.ts` and the tests. Coverage is preserved with no duplicated logic in test files.

**Moved out of `portfolio.ts`** (were exported, now internal): `startOfHour`, `startOfDay`, `startOfWeek`, `getRanges`, `getDates`, `getPortfolioRangeConfig`, `getPortfolioCountByDate`, `defaultAssetsDistribution`, `AssetsDistributionOpts`.

**Still exported (10):** `getPortfolio`, `getCurrencyPortfolio`, `getPortfolioCount`, `getBalanceHistory`, `getBalanceHistoryWithCountervalue`, `getAssetsDistribution`, `getCurrentBalanceCountervalueChange`, `orderAccountsByFiatValue`, `meaningfulPercentage`, `GetPortfolioOptionsType`.

### ✅ Verification

- `pnpm nx run-many -t typecheck` clean across 164 projects. This is the proof that no consumer relied on any of the 9.
- 85 tests pass, **9 snapshots unchanged** and never regenerated. `portfolio.test.ts` carries a 7,244-line snapshot, so an unchanged snapshot is the behaviour gate.
- `portfolio.ts` exports exactly 10.
- Coverage: `assetsDistribution.ts` 100%, `ranges.ts` 96.87%.

### 👀 Notes for reviewers

- A loose text search suggests `startOfHour` / `startOfDay` / `startOfWeek` have external callers, notably `libs/ledger-wallet-framework/src/account/balanceHistoryCache.ts`. They do not — that file defines its own same-named helpers. Zero files import any `startOf*` from this package.
- `getAssetsDistribution` and `useCurrencyPortfolio` were flagged in an earlier review as possibly dead. They are **not**: both have live production consumers. Nothing was deleted in this PR.
- `src/internal/` is a staging home. It gets hidden properly once this package gains an explicit `exports` map with no `./*` wildcard, which is tracked separately under the knip migration.

### 🧱 Stack

Bottom of a 6-branch stack on `develop`. Next up: **LIVE-36824** (inline `meaningfulPercentage`), which builds directly on this branch.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36823](https://ledgerhq.atlassian.net/browse/LIVE-36823) — epic [LIVE-32360](https://ledgerhq.atlassian.net/browse/LIVE-32360)
- **ADR** (if any): [Countervalues Domain Migration Discovery](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7376502960/Countervalues+Domain+Migration+Discovery)


[LIVE-36823]: https://ledgerhq.atlassian.net/browse/LIVE-36823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ