### PR TITLE
[LWDM] fix(coin-zcash): bound selection to PCZT ceilings (LIVE-36831)

### DIFF
--- a/.changeset/coin-zcash-bound-input-selection.md
+++ b/.changeset/coin-zcash-bound-input-selection.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-zcash": patch
+---
+
+Bound transparent-input and Ironwood-note selection to the device's per-PCZT ceilings on both pools, so a send from an account holding more UTXOs or notes than the device can sign in one PCZT no longer produces an unsignable transaction. A send whose full balance covers the requested amount but whose device-safe selection does not now reports a distinct, actionable error instead of a plain insufficient-balance one.

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7399,6 +7399,9 @@
     "ZcashMemoTooLong": {
       "title": "Memo must not exceed {{maxBytes}} bytes"
     },
+    "ZcashSendTooLarge": {
+      "title": "This amount is too large to send in one transaction: try sending it in smaller amounts"
+    },
     "InvalidNonce": {
       "title": "Nonce is required"
     },

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -132,6 +132,9 @@
     "ZcashMemoTooLong": {
       "title": "Memo must not exceed {{maxBytes}} bytes"
     },
+    "ZcashSendTooLarge": {
+      "title": "This amount is too large to send in one transaction: try sending it in smaller amounts"
+    },
     "ReplacementTransactionUnderpriced": {
       "title": "Replacement transaction underpriced",
       "description": "The network fee might be too low. Please increase"

--- a/libs/coin-modules/coin-zcash/src/bridge/estimateMaxSpendable.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/estimateMaxSpendable.test.ts
@@ -1,14 +1,37 @@
 import { BigNumber } from "bignumber.js";
 import { estimateMaxSpendable } from "./estimateMaxSpendable";
-import { computeShieldedSpendFee } from "../logic/coin-selection";
-import type { Transaction, ZcashAccount } from "../types/bridge";
-import { ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS } from "../constants";
+import { computeShieldedSpendFee, estimateMaxSpendableTransparent } from "../logic/coin-selection";
+import type { BitcoinOutput, Transaction, ZcashAccount } from "../types/bridge";
+import {
+  ZCASH_MAX_TRANSPARENT_INPUTS,
+  ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS,
+} from "../constants";
 
 const U_ADDRESS =
   "u1u2h4ce7e2cn3z4nzur95muq2dl4da9x8h8kdp2l80gm9nl9raj8zzpx79ycjnfvar4v5exea5pqr5y9qsnlp0cdunwf9yjjx5c4q7ar9";
+const T_ADDRESS = "t1b1Rbw2shhJkP6MCnCyxCPuyFedHrwKty8";
 const REFERENCE_HEIGHT = 3_450_000;
 const MATURE_BLOCK = REFERENCE_HEIGHT - ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS;
 const IMMATURE_BLOCK = REFERENCE_HEIGHT - 3;
+
+const utxo = (value: number, outputIndex: number): BitcoinOutput => ({
+  hash: "aa".repeat(32),
+  outputIndex,
+  blockHeight: 3_425_800,
+  address: T_ADDRESS,
+  value: new BigNumber(value),
+  rbf: false,
+  isChange: false,
+});
+
+function accountWithUtxos(values: number[]): ZcashAccount {
+  return {
+    type: "Account",
+    id: "js:2:zcash:xpub6D:",
+    currency: { id: "zcash", name: "Zcash" },
+    bitcoinResources: { utxos: values.map((v, i) => utxo(v, i)) },
+  } as unknown as ZcashAccount;
+}
 
 const nullifierAt = (index: number) => index.toString(16).padStart(2, "0").repeat(32);
 
@@ -108,5 +131,87 @@ describe("estimateMaxSpendable, note maturity", () => {
 
     const fee = computeShieldedSpendFee(2, false, "shielded");
     expect(await max(acc)).toEqual(BigNumber.max(new BigNumber(50_000).minus(fee), 0));
+  });
+});
+
+describe("estimateMaxSpendable, transparent-input bound", () => {
+  // A "Max" this returns must always be an amount a real transparent send
+  // (bounded to ZCASH_MAX_TRANSPARENT_INPUTS) can actually carry -- whether or
+  // not a transaction is passed to resolve the bound through.
+
+  it("bounds the transparent pool when called WITHOUT a transaction (no-tx fallback)", async () => {
+    const extra = 5;
+    const values = Array.from(
+      { length: ZCASH_MAX_TRANSPARENT_INPUTS + extra },
+      (_, i) => (i + 1) * 1_000,
+    );
+    const acc = accountWithUtxos(values);
+
+    const result = await estimateMaxSpendable({ account: acc } as never);
+
+    // The defect this guards: before the fix, this path summed every UTXO
+    // account.bitcoinResources holds instead of resolving through the bounded
+    // funnel, so it could disagree with the bounded (with-transaction) figure
+    // below -- either over- or under-stating it, since ZIP-317 fees scale
+    // with input count and a dropped dust UTXO can raise the net figure.
+    const boundedValues = [...values].sort((a, b) => b - a).slice(0, ZCASH_MAX_TRANSPARENT_INPUTS);
+    const expected = estimateMaxSpendableTransparent(
+      boundedValues.map(v => new BigNumber(v)),
+      "transparent",
+    );
+    expect(result).toEqual(expected);
+  });
+
+  it("bounds the transparent pool when called WITH a transparent transaction", async () => {
+    const extra = 5;
+    const values = Array.from(
+      { length: ZCASH_MAX_TRANSPARENT_INPUTS + extra },
+      (_, i) => (i + 1) * 1_000,
+    );
+    const acc = accountWithUtxos(values);
+    const transparentTransaction = {
+      family: "zcash",
+      transferType: "transparent",
+      amount: new BigNumber(0),
+      recipient: T_ADDRESS,
+      useAllAmount: true,
+    } as Transaction;
+
+    const result = await estimateMaxSpendable({
+      account: acc,
+      transaction: transparentTransaction,
+    } as never);
+
+    const boundedValues = [...values].sort((a, b) => b - a).slice(0, ZCASH_MAX_TRANSPARENT_INPUTS);
+    const expected = estimateMaxSpendableTransparent(
+      boundedValues.map(v => new BigNumber(v)),
+      "transparent",
+    );
+    expect(result).toEqual(expected);
+  });
+
+  it("returns the naive full-sum figure when the account holds at most the bound (no-tx and with-tx agree)", async () => {
+    const values = Array.from({ length: ZCASH_MAX_TRANSPARENT_INPUTS }, (_, i) => (i + 1) * 1_000);
+    const acc = accountWithUtxos(values);
+    const transparentTransaction = {
+      family: "zcash",
+      transferType: "transparent",
+      amount: new BigNumber(0),
+      recipient: T_ADDRESS,
+      useAllAmount: true,
+    } as Transaction;
+
+    const withoutTx = await estimateMaxSpendable({ account: acc } as never);
+    const withTx = await estimateMaxSpendable({
+      account: acc,
+      transaction: transparentTransaction,
+    } as never);
+
+    const expected = estimateMaxSpendableTransparent(
+      values.map(v => new BigNumber(v)),
+      "transparent",
+    );
+    expect(withoutTx).toEqual(expected);
+    expect(withTx).toEqual(expected);
   });
 });

--- a/libs/coin-modules/coin-zcash/src/bridge/estimateMaxSpendable.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/estimateMaxSpendable.ts
@@ -5,7 +5,11 @@ import {
   estimateMaxSpendableAmount,
   estimateMaxSpendableTransparent,
 } from "../logic/coin-selection";
-import { isTransparentInputTransfer, resolveTransparentUtxos } from "./statusHelpers";
+import {
+  boundTransparentUtxos,
+  isTransparentInputTransfer,
+  resolveTransparentUtxos,
+} from "./statusHelpers";
 import { getReservedNullifiers } from "./note-reservation";
 import { collectSelectableIronwoodNotes } from "../logic/account/spendability";
 
@@ -24,7 +28,12 @@ export const estimateMaxSpendable: AccountBridge<
   const transferType = tx?.transferType ?? "transparent";
   // Max spendable from the Ironwood note pool for shielded-input flows.
   if (transferType !== "shielded" && transferType !== "shielded-to-transparent") {
-    const utxoValues = (mainAccount.bitcoinResources?.utxos ?? []).map(utxo => utxo.value);
+    // No transaction to resolve a caller override through -- bound the
+    // account-synced set directly so this path can never disagree with
+    // resolveTransparentUtxos's bound above.
+    const utxoValues = boundTransparentUtxos(mainAccount.bitcoinResources?.utxos ?? []).map(
+      utxo => utxo.value,
+    );
     return estimateMaxSpendableTransparent(utxoValues, "transparent");
   }
 

--- a/libs/coin-modules/coin-zcash/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/getTransactionStatus.test.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from "bignumber.js";
+import { NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import { getTransactionStatus } from "./getTransactionStatus";
 import { prepareTransaction } from "./prepareTransaction";
 import {
@@ -9,10 +10,14 @@ import {
   resolveTransparentUtxos,
 } from "./statusHelpers";
 import { TRANSPARENT_OUTPUT_DUST_THRESHOLD, ZIP317_MINIMUM_FEE } from "../logic/coin-selection";
-import { ZcashAmountBelowDustThreshold } from "../types/errors";
+import { ZcashAmountBelowDustThreshold, ZcashSendTooLarge } from "../types/errors";
 import type { BitcoinOutput, Transaction, ZcashAccount, ZcashTransferType } from "../types/bridge";
 import type { SpendableNote } from "../network/types";
-import { ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS } from "../constants";
+import {
+  ZCASH_MAX_IRONWOOD_ACTIONS,
+  ZCASH_MAX_TRANSPARENT_INPUTS,
+  ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS,
+} from "../constants";
 
 const T_ADDRESS = "t1b1Rbw2shhJkP6MCnCyxCPuyFedHrwKty8";
 const U_ADDRESS =
@@ -486,6 +491,122 @@ describe("getTransactionStatus, transparent-input flows", () => {
     );
 
     expect(status.errors).toEqual({});
+  });
+});
+
+describe("getTransactionStatus, bounded-selection shortfall (ZcashSendTooLarge)", () => {
+  const FEE = 10_000;
+
+  it.each(["transparent", "transparent-to-shielded"] as ZcashTransferType[])(
+    "resolves without an amount error for a %s send within the bounded max, from an account above the bound",
+    async transferType => {
+      const utxoCount = ZCASH_MAX_TRANSPARENT_INPUTS + 5;
+      const acc = account({ utxos: Array(utxoCount).fill(100_000) });
+      const boundedBalance = ZCASH_MAX_TRANSPARENT_INPUTS * 100_000;
+      const recipient = transferType === "transparent" ? T_ADDRESS : U_ADDRESS;
+      const tx = transaction({
+        transferType,
+        recipient,
+        amount: new BigNumber(boundedBalance - FEE),
+        zcashFee: new BigNumber(FEE),
+      });
+
+      const status = await getTransactionStatus(acc, tx);
+
+      expect(status.errors.amount).toBeUndefined();
+    },
+  );
+
+  it.each(["transparent", "transparent-to-shielded"] as ZcashTransferType[])(
+    "rejects a %s send between the bounded max and the full balance with ZcashSendTooLarge",
+    async transferType => {
+      const utxoCount = ZCASH_MAX_TRANSPARENT_INPUTS + 5;
+      const acc = account({ utxos: Array(utxoCount).fill(100_000) });
+      const boundedBalance = ZCASH_MAX_TRANSPARENT_INPUTS * 100_000;
+      const fullBalance = utxoCount * 100_000;
+      const recipient = transferType === "transparent" ? T_ADDRESS : U_ADDRESS;
+      // amount + FEE sits strictly between boundedBalance and fullBalance.
+      const tx = transaction({
+        transferType,
+        recipient,
+        amount: new BigNumber(boundedBalance),
+        zcashFee: new BigNumber(FEE),
+      });
+
+      const status = await getTransactionStatus(acc, tx);
+
+      expect(status.errors.amount).toBeInstanceOf(ZcashSendTooLarge);
+      expect(status.errors.amount).not.toBeInstanceOf(NotEnoughBalance);
+      expect(boundedBalance + FEE).toBeLessThanOrEqual(fullBalance);
+    },
+  );
+
+  it("keeps reporting NotEnoughBalance for a genuine shortfall, on an account below the bound", async () => {
+    const acc = account({ utxos: [10_000, 10_000, 10_000] }); // full balance 30_000, well below the bound
+    const tx = transaction({
+      amount: new BigNumber(100_000),
+      zcashFee: new BigNumber(FEE),
+    });
+
+    const status = await getTransactionStatus(acc, tx);
+
+    expect(status.errors.amount).toEqual(new NotEnoughBalance());
+    expect(status.errors.amount).not.toBeInstanceOf(ZcashSendTooLarge);
+  });
+
+  it("resolves without an amount error for a shielded send within the bounded max, from a pool above the bound", async () => {
+    const noteCount = ZCASH_MAX_IRONWOOD_ACTIONS + 5;
+    const acc = account({ ironwoodNotes: Array(noteCount).fill(100_000) });
+    const boundedTotal = ZCASH_MAX_IRONWOOD_ACTIONS * 100_000;
+    const selectedNotes = Array.from({ length: ZCASH_MAX_IRONWOOD_ACTIONS }, (_, i) =>
+      note(100_000, i),
+    );
+    const tx = transaction({
+      transferType: "shielded",
+      recipient: U_ADDRESS,
+      amount: new BigNumber(boundedTotal - FEE),
+      selectedNotes,
+      zcashFee: new BigNumber(FEE),
+    });
+
+    const status = await getTransactionStatus(acc, tx);
+
+    expect(status.errors.amount).toBeUndefined();
+  });
+
+  it("rejects a shielded send between the bounded and full pool with ZcashSendTooLarge, not the generic insufficiency error", async () => {
+    const noteCount = ZCASH_MAX_IRONWOOD_ACTIONS + 5;
+    const acc = account({ ironwoodNotes: Array(noteCount).fill(100_000) });
+    const boundedTotal = ZCASH_MAX_IRONWOOD_ACTIONS * 100_000;
+    const fullTotal = noteCount * 100_000;
+    const tx = transaction({
+      transferType: "shielded",
+      recipient: U_ADDRESS,
+      amount: new BigNumber(boundedTotal),
+      zcashFee: new BigNumber(FEE),
+    });
+
+    const status = await getTransactionStatus(acc, tx);
+
+    expect(status.errors.amount).toBeInstanceOf(ZcashSendTooLarge);
+    expect(status.errors.amount).not.toEqual(new Error("Insufficient shielded balance"));
+    expect(boundedTotal + FEE).toBeLessThanOrEqual(fullTotal);
+  });
+
+  it("keeps reporting the generic insufficiency error for a genuine shielded shortfall, on a pool below the bound", async () => {
+    const acc = account({ ironwoodNotes: [10_000, 10_000] }); // pool 20_000, well below the bound
+    const tx = transaction({
+      transferType: "shielded",
+      recipient: U_ADDRESS,
+      amount: new BigNumber(100_000),
+      selectedNotes: [note(20_000)],
+      zcashFee: new BigNumber(FEE),
+    });
+
+    const status = await getTransactionStatus(acc, tx);
+
+    expect(status.errors.amount).toEqual(new Error("Insufficient shielded balance"));
+    expect(status.errors.amount).not.toBeInstanceOf(ZcashSendTooLarge);
   });
 });
 

--- a/libs/coin-modules/coin-zcash/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/getTransactionStatus.test.ts
@@ -593,6 +593,28 @@ describe("getTransactionStatus, bounded-selection shortfall (ZcashSendTooLarge)"
     expect(boundedTotal + FEE).toBeLessThanOrEqual(fullTotal);
   });
 
+  it("rejects a shielded-to-transparent send between the bounded and full pool with ZcashSendTooLarge", async () => {
+    // shielded-to-transparent (z->t) also spends the Ironwood pool and routes
+    // through the same shielded branch of getTransactionStatus as "shielded"
+    // -- this is the transfer type the sibling test above doesn't cover.
+    const noteCount = ZCASH_MAX_IRONWOOD_ACTIONS + 5;
+    const acc = account({ ironwoodNotes: Array(noteCount).fill(100_000) });
+    const boundedTotal = ZCASH_MAX_IRONWOOD_ACTIONS * 100_000;
+    const fullTotal = noteCount * 100_000;
+    const tx = transaction({
+      transferType: "shielded-to-transparent",
+      recipient: T_ADDRESS,
+      amount: new BigNumber(boundedTotal),
+      zcashFee: new BigNumber(FEE),
+    });
+
+    const status = await getTransactionStatus(acc, tx);
+
+    expect(status.errors.amount).toBeInstanceOf(ZcashSendTooLarge);
+    expect(status.errors.amount).not.toEqual(new Error("Insufficient shielded balance"));
+    expect(boundedTotal + FEE).toBeLessThanOrEqual(fullTotal);
+  });
+
   it("keeps reporting the generic insufficiency error for a genuine shielded shortfall, on a pool below the bound", async () => {
     const acc = account({ ironwoodNotes: [10_000, 10_000] }); // pool 20_000, well below the bound
     const tx = transaction({

--- a/libs/coin-modules/coin-zcash/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/getTransactionStatus.ts
@@ -106,9 +106,13 @@ export const getTransactionStatus: AccountBridge<
     };
   }
 
-  // Shielded sends spend the Ironwood pool, so validate the amount against the
-  // mature, unreserved figure -- the same one selection draws from, so the
-  // status can never accept an amount selection cannot cover.
+  // Shielded sends spend the Ironwood pool. `poolBalance` is the account's
+  // full mature, unreserved total -- deliberately unbounded (see
+  // `getSpendableIronwoodBalance`), so a genuine shortfall below is checked
+  // against everything owned, not against the smaller, per-PCZT-bounded
+  // selection pool. `hasBoundedIronwoodShortfall` (below) is what catches the
+  // case selection can't cover even though this balance can, before this
+  // check ever runs.
   const reserved = getReservedNullifiers(account);
   const poolBalance = getSpendableIronwoodBalance(account, reserved);
   const fee = transaction.zcashFee ?? new BigNumber(ZIP317_MINIMUM_FEE);

--- a/libs/coin-modules/coin-zcash/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/getTransactionStatus.ts
@@ -3,18 +3,26 @@ import { NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import type { AccountBridge } from "@ledgerhq/types-live";
 import type { Transaction, TransactionStatus, ZcashAccount } from "../types/bridge";
 import { ZIP317_MINIMUM_FEE } from "../logic/coin-selection";
-import { ZcashAmountBelowDustThreshold, ZcashMemoTooLong } from "../types/errors";
+import {
+  ZcashAmountBelowDustThreshold,
+  ZcashMemoTooLong,
+  ZcashSendTooLarge,
+} from "../types/errors";
 import { ZCASH_MEMO_MAX_BYTES } from "../constants";
 import {
   computeAmountError,
   computeRecipientError,
+  hasBoundedTransparentShortfall,
   hasShieldedKey,
   isTransparentInputTransfer,
   isTransparentOutputDust,
   resolveTransparentUtxos,
 } from "./statusHelpers";
 import { getReservedNullifiers } from "./note-reservation";
-import { getSpendableIronwoodBalance } from "../logic/account/spendability";
+import {
+  getSpendableIronwoodBalance,
+  hasBoundedIronwoodShortfall,
+} from "../logic/account/spendability";
 
 const encoder = new TextEncoder();
 
@@ -54,7 +62,9 @@ function getTransparentInputStatus(
   if (tx.amount.lte(0) && !tx.useAllAmount) {
     errors.amount = new Error("Amount must be positive");
   } else if (totalSpent.gt(transparentBalance)) {
-    errors.amount = new NotEnoughBalance();
+    errors.amount = hasBoundedTransparentShortfall(account, tx, totalSpent)
+      ? new ZcashSendTooLarge()
+      : new NotEnoughBalance();
   } else if (tx.transferType === "transparent" && isTransparentOutputDust(tx.amount)) {
     errors.amount = new ZcashAmountBelowDustThreshold();
   }
@@ -99,7 +109,8 @@ export const getTransactionStatus: AccountBridge<
   // Shielded sends spend the Ironwood pool, so validate the amount against the
   // mature, unreserved figure -- the same one selection draws from, so the
   // status can never accept an amount selection cannot cover.
-  const poolBalance = getSpendableIronwoodBalance(account, getReservedNullifiers(account));
+  const reserved = getReservedNullifiers(account);
+  const poolBalance = getSpendableIronwoodBalance(account, reserved);
   const fee = transaction.zcashFee ?? new BigNumber(ZIP317_MINIMUM_FEE);
   const totalSpent = transaction.amount.plus(fee);
 
@@ -110,16 +121,20 @@ export const getTransactionStatus: AccountBridge<
   );
   if (recipientError) errors.recipient = recipientError;
 
-  const amountError = computeAmountError(transaction, totalSpent, poolBalance);
-  if (amountError) {
-    errors.amount = amountError;
-  } else if (
-    transaction.transferType === "shielded-to-transparent" &&
-    isTransparentOutputDust(transaction.amount)
-  ) {
-    // A shielded-to-transparent (z->t) recipient is also a transparent
-    // output, so it needs the same dust check as a t->t send.
-    errors.amount = new ZcashAmountBelowDustThreshold();
+  if (hasBoundedIronwoodShortfall(account, reserved, totalSpent)) {
+    errors.amount = new ZcashSendTooLarge();
+  } else {
+    const amountError = computeAmountError(transaction, totalSpent, poolBalance);
+    if (amountError) {
+      errors.amount = amountError;
+    } else if (
+      transaction.transferType === "shielded-to-transparent" &&
+      isTransparentOutputDust(transaction.amount)
+    ) {
+      // A shielded-to-transparent (z->t) recipient is also a transparent
+      // output, so it needs the same dust check as a t->t send.
+      errors.amount = new ZcashAmountBelowDustThreshold();
+    }
   }
 
   return {

--- a/libs/coin-modules/coin-zcash/src/bridge/mapping.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/mapping.ts
@@ -75,6 +75,14 @@ export async function mapTransparentInputs(
   );
 }
 
+/**
+ * Always exactly one requested output. The native builder adds at most one
+ * change output on top (craft.rs) -- coin-zcash itself never requests more
+ * than one, so the transparent/shielded output count this module can produce
+ * is capped at 2 regardless of account size, comfortably under either pool's
+ * device output ceiling. This is why input/spend selection is bounded but
+ * outputs are not: there is nothing to bound on the output side.
+ */
 export function mapOutputs(tx: Transaction): OutputRequestJs[] {
   return [
     {

--- a/libs/coin-modules/coin-zcash/src/bridge/statusHelpers.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/statusHelpers.test.ts
@@ -68,22 +68,24 @@ describe("resolveTransparentUtxos, bounding", () => {
     expect(resolved.map(u => u.value.toNumber())).toEqual(expectedLargest);
   });
 
-  it("applies the same bound to a caller-supplied selectedUtxos override", () => {
+  it("passes a caller-supplied selectedUtxos override through unbounded and in caller order", () => {
+    // A future coin-control caller picks its own UTXOs deliberately; silently
+    // reordering or truncating that explicit selection would spend a
+    // different set than the caller asked for. The device ceiling is only
+    // enforced on the account-synced default set above, which the wallet is
+    // free to choose from.
     const extra = 3;
     const values = Array.from(
       { length: ZCASH_MAX_TRANSPARENT_INPUTS + extra },
       (_, i) => (i + 1) * 1_000,
     );
-    const selectedUtxos = utxosOfValues(values);
+    const selectedUtxos = utxosOfValues(values); // increasing order, on purpose
     const acc = account([]);
 
     const resolved = resolveTransparentUtxos(acc, transaction({ selectedUtxos }));
 
-    expect(resolved).toHaveLength(ZCASH_MAX_TRANSPARENT_INPUTS);
-    const expectedLargest = [...values]
-      .sort((a, b) => b - a)
-      .slice(0, ZCASH_MAX_TRANSPARENT_INPUTS);
-    expect(resolved.map(u => u.value.toNumber())).toEqual(expectedLargest);
+    expect(resolved).toBe(selectedUtxos);
+    expect(resolved.map(u => u.value.toNumber())).toEqual(values);
   });
 
   it.each(["shielded", "shielded-to-transparent"] as ZcashTransferType[])(
@@ -158,5 +160,24 @@ describe("hasBoundedTransparentShortfall", () => {
     expect(hasBoundedTransparentShortfall(acc, transaction(), new BigNumber(fullBalance + 1))).toBe(
       false,
     );
+  });
+
+  it("is false for a selectedUtxos override past the bound -- the ceiling isn't enforced there", () => {
+    const extra = 3;
+    const values = Array.from(
+      { length: ZCASH_MAX_TRANSPARENT_INPUTS + extra },
+      (_, i) => (i + 1) * 1_000,
+    );
+    const selectedUtxos = utxosOfValues(values);
+    const acc = account([]);
+    const fullBalance = values.reduce((sum, v) => sum + v, 0);
+
+    expect(
+      hasBoundedTransparentShortfall(
+        acc,
+        transaction({ selectedUtxos }),
+        new BigNumber(fullBalance),
+      ),
+    ).toBe(false);
   });
 });

--- a/libs/coin-modules/coin-zcash/src/bridge/statusHelpers.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/statusHelpers.test.ts
@@ -1,0 +1,162 @@
+import { BigNumber } from "bignumber.js";
+import { hasBoundedTransparentShortfall, resolveTransparentUtxos } from "./statusHelpers";
+import { ZCASH_MAX_TRANSPARENT_INPUTS } from "../constants";
+import type { BitcoinOutput, Transaction, ZcashAccount, ZcashTransferType } from "../types/bridge";
+
+const T_ADDRESS = "t1b1Rbw2shhJkP6MCnCyxCPuyFedHrwKty8";
+
+const utxo = (value: number, outputIndex = 0): BitcoinOutput => ({
+  hash: "aa".repeat(32),
+  outputIndex,
+  blockHeight: 3_425_800,
+  address: T_ADDRESS,
+  value: new BigNumber(value),
+  rbf: false,
+  isChange: false,
+});
+
+function account(utxos: BitcoinOutput[]): ZcashAccount {
+  return {
+    type: "Account",
+    id: "js:2:zcash:xpub6D:",
+    currency: { id: "zcash", name: "Zcash" },
+    bitcoinResources: { utxos },
+  } as unknown as ZcashAccount;
+}
+
+function transaction(overrides: Partial<Transaction> = {}): Transaction {
+  return {
+    family: "zcash",
+    transferType: "transparent",
+    amount: new BigNumber(10_000),
+    recipient: T_ADDRESS,
+    useAllAmount: false,
+    ...overrides,
+  } as Transaction;
+}
+
+// One UTXO per value, decreasing in the array so an "already sorted" fixture
+// can never accidentally pass a largest-first assertion by coincidence.
+const utxosOfValues = (values: number[]): BitcoinOutput[] =>
+  values.map((value, i) => utxo(value, i));
+
+describe("resolveTransparentUtxos, bounding", () => {
+  it("returns all UTXOs, largest-first, when the account holds at most the bound", () => {
+    const values = Array.from({ length: ZCASH_MAX_TRANSPARENT_INPUTS }, (_, i) => (i + 1) * 1_000);
+    const acc = account(utxosOfValues(values));
+
+    const resolved = resolveTransparentUtxos(acc, transaction());
+
+    expect(resolved).toHaveLength(ZCASH_MAX_TRANSPARENT_INPUTS);
+    expect(resolved.map(u => u.value.toNumber())).toEqual([...values].sort((a, b) => b - a));
+  });
+
+  it("bounds to the largest ZCASH_MAX_TRANSPARENT_INPUTS UTXOs when the account holds more", () => {
+    const extra = 5;
+    const values = Array.from(
+      { length: ZCASH_MAX_TRANSPARENT_INPUTS + extra },
+      (_, i) => (i + 1) * 1_000,
+    );
+    const acc = account(utxosOfValues(values));
+
+    const resolved = resolveTransparentUtxos(acc, transaction());
+
+    expect(resolved).toHaveLength(ZCASH_MAX_TRANSPARENT_INPUTS);
+    const expectedLargest = [...values]
+      .sort((a, b) => b - a)
+      .slice(0, ZCASH_MAX_TRANSPARENT_INPUTS);
+    expect(resolved.map(u => u.value.toNumber())).toEqual(expectedLargest);
+  });
+
+  it("applies the same bound to a caller-supplied selectedUtxos override", () => {
+    const extra = 3;
+    const values = Array.from(
+      { length: ZCASH_MAX_TRANSPARENT_INPUTS + extra },
+      (_, i) => (i + 1) * 1_000,
+    );
+    const selectedUtxos = utxosOfValues(values);
+    const acc = account([]);
+
+    const resolved = resolveTransparentUtxos(acc, transaction({ selectedUtxos }));
+
+    expect(resolved).toHaveLength(ZCASH_MAX_TRANSPARENT_INPUTS);
+    const expectedLargest = [...values]
+      .sort((a, b) => b - a)
+      .slice(0, ZCASH_MAX_TRANSPARENT_INPUTS);
+    expect(resolved.map(u => u.value.toNumber())).toEqual(expectedLargest);
+  });
+
+  it.each(["shielded", "shielded-to-transparent"] as ZcashTransferType[])(
+    "still returns [] for %s, unchanged",
+    transferType => {
+      const values = Array.from(
+        { length: ZCASH_MAX_TRANSPARENT_INPUTS + 5 },
+        (_, i) => (i + 1) * 1_000,
+      );
+      const acc = account(utxosOfValues(values));
+
+      expect(resolveTransparentUtxos(acc, transaction({ transferType }))).toEqual([]);
+    },
+  );
+});
+
+describe("hasBoundedTransparentShortfall", () => {
+  it.each(["shielded", "shielded-to-transparent"] as ZcashTransferType[])(
+    "is false for %s -- a flow that never spends transparent inputs",
+    transferType => {
+      const values = Array.from(
+        { length: ZCASH_MAX_TRANSPARENT_INPUTS + 5 },
+        (_, i) => (i + 1) * 1_000,
+      );
+      const acc = account(utxosOfValues(values));
+
+      expect(
+        hasBoundedTransparentShortfall(acc, transaction({ transferType }), new BigNumber(1e9)),
+      ).toBe(false);
+    },
+  );
+
+  it("is false when the account holds at most the bound, regardless of totalSpent", () => {
+    const values = Array.from({ length: ZCASH_MAX_TRANSPARENT_INPUTS }, (_, i) => (i + 1) * 1_000);
+    const acc = account(utxosOfValues(values));
+    const total = values.reduce((sum, v) => sum + v, 0);
+
+    expect(hasBoundedTransparentShortfall(acc, transaction(), new BigNumber(total * 10))).toBe(
+      false,
+    );
+  });
+
+  it("is true when totalSpent exceeds the bounded balance but not the full balance", () => {
+    const extra = 5;
+    const values = Array.from(
+      { length: ZCASH_MAX_TRANSPARENT_INPUTS + extra },
+      (_, i) => (i + 1) * 1_000,
+    );
+    const acc = account(utxosOfValues(values));
+    const fullBalance = values.reduce((sum, v) => sum + v, 0);
+    const boundedBalance = [...values]
+      .sort((a, b) => b - a)
+      .slice(0, ZCASH_MAX_TRANSPARENT_INPUTS)
+      .reduce((sum, v) => sum + v, 0);
+    // Strictly between the bounded and full balances.
+    const totalSpent = new BigNumber(boundedBalance + 1).lt(fullBalance)
+      ? new BigNumber(boundedBalance + 1)
+      : new BigNumber(fullBalance);
+
+    expect(hasBoundedTransparentShortfall(acc, transaction(), totalSpent)).toBe(true);
+  });
+
+  it("is false when totalSpent exceeds even the full (unbounded) balance -- genuine insufficiency", () => {
+    const extra = 5;
+    const values = Array.from(
+      { length: ZCASH_MAX_TRANSPARENT_INPUTS + extra },
+      (_, i) => (i + 1) * 1_000,
+    );
+    const acc = account(utxosOfValues(values));
+    const fullBalance = values.reduce((sum, v) => sum + v, 0);
+
+    expect(hasBoundedTransparentShortfall(acc, transaction(), new BigNumber(fullBalance + 1))).toBe(
+      false,
+    );
+  });
+});

--- a/libs/coin-modules/coin-zcash/src/bridge/statusHelpers.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/statusHelpers.ts
@@ -4,6 +4,7 @@ import type { BitcoinOutput, ZcashAccount, Transaction } from "../types/bridge";
 import { ZcashSaplingRecipientNotSupported, ZcashShieldedKeyMissing } from "../types/errors";
 import { classifyZcashRecipient } from "../logic/address";
 import { TRANSPARENT_OUTPUT_DUST_THRESHOLD } from "../logic/coin-selection";
+import { ZCASH_MAX_TRANSPARENT_INPUTS } from "../constants";
 
 // Transfer types that actually spend transparent UTXOs as inputs. A pure
 // shielded send ("shielded" / "shielded-to-transparent") spends Ironwood notes
@@ -27,7 +28,38 @@ export const isTransparentInputTransfer = (transferType: Transaction["transferTy
  */
 export function resolveTransparentUtxos(account: ZcashAccount, tx: Transaction): BitcoinOutput[] {
   if (!TRANSPARENT_INPUT_TRANSFER_TYPES.has(tx.transferType)) return [];
-  return tx.selectedUtxos ?? account.bitcoinResources?.utxos ?? [];
+  const utxos = tx.selectedUtxos ?? account.bitcoinResources?.utxos ?? [];
+  // Largest-first, then bounded to the device's per-PCZT input ceiling: picking
+  // the largest N maximizes the amount a single send can carry (ZIP-317 prices
+  // per input, so more of the account's value per spent input is strictly
+  // better) and mirrors the "largest-first stays" selection strategy already
+  // used on the shielded side (logic/coin-selection.ts's selectNotes).
+  return [...utxos]
+    .sort((a, b) => b.value.comparedTo(a.value))
+    .slice(0, ZCASH_MAX_TRANSPARENT_INPUTS);
+}
+
+/**
+ * True when the transparent-input bound is the reason `totalSpent` cannot be
+ * covered -- the account's full transparent balance covers it, only the
+ * bounded PCZT (device-safe) selection does not. Lets the caller raise a
+ * "too large for one send" error instead of NotEnoughBalance in exactly that
+ * case, and never in a genuine-shortfall case.
+ */
+export function hasBoundedTransparentShortfall(
+  account: ZcashAccount,
+  tx: Transaction,
+  totalSpent: BigNumber,
+): boolean {
+  if (!TRANSPARENT_INPUT_TRANSFER_TYPES.has(tx.transferType)) return false;
+  const allUtxos = tx.selectedUtxos ?? account.bitcoinResources?.utxos ?? [];
+  if (allUtxos.length <= ZCASH_MAX_TRANSPARENT_INPUTS) return false; // nothing was bounded
+  const fullBalance = allUtxos.reduce((sum, u) => sum.plus(u.value), new BigNumber(0));
+  const boundedBalance = resolveTransparentUtxos(account, tx).reduce(
+    (sum, u) => sum.plus(u.value),
+    new BigNumber(0),
+  );
+  return totalSpent.gt(boundedBalance) && totalSpent.lte(fullBalance);
 }
 
 /**

--- a/libs/coin-modules/coin-zcash/src/bridge/statusHelpers.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/statusHelpers.ts
@@ -22,6 +22,25 @@ export const isTransparentInputTransfer = (transferType: Transaction["transferTy
   TRANSPARENT_INPUT_TRANSFER_TYPES.has(transferType);
 
 /**
+ * Sorts the account's synced transparent UTXOs largest-first and bounds them
+ * to the device's per-PCZT input ceiling: picking the largest N maximizes the
+ * amount a single send can carry (ZIP-317 prices per input, so more of the
+ * account's value per spent input is strictly better) and mirrors the
+ * "largest-first stays" selection strategy already used on the shielded side
+ * (logic/coin-selection.ts's selectNotes).
+ *
+ * Shared by `resolveTransparentUtxos` (below) and `estimateMaxSpendable`'s
+ * no-transaction fallback, so "Max" can never disagree with what a real send
+ * would bound its input set to -- a caller-supplied `selectedUtxos` override
+ * is deliberately never passed through here (see `resolveTransparentUtxos`).
+ */
+export function boundTransparentUtxos(utxos: BitcoinOutput[]): BitcoinOutput[] {
+  return [...utxos]
+    .sort((a, b) => b.value.comparedTo(a.value))
+    .slice(0, ZCASH_MAX_TRANSPARENT_INPUTS);
+}
+
+/**
  * Resolves the transparent UTXOs spent by a Public→* flow. Returns an empty
  * set for transfer types that do not spend transparent inputs. Caller-supplied
  * `selectedUtxos` takes precedence over the account's synced UTXO set.
@@ -32,16 +51,9 @@ export function resolveTransparentUtxos(account: ZcashAccount, tx: Transaction):
   // not a pool the wallet is free to pick from -- reordering or truncating it
   // would silently spend a different set than the caller asked for, so it
   // passes through exactly as it did before this ceiling existed. Only the
-  // account-synced default set is sorted largest-first and bounded to the
-  // device's per-PCZT input ceiling: picking the largest N maximizes the
-  // amount a single send can carry (ZIP-317 prices per input, so more of the
-  // account's value per spent input is strictly better) and mirrors the
-  // "largest-first stays" selection strategy already used on the shielded
-  // side (logic/coin-selection.ts's selectNotes).
+  // account-synced default set is bounded.
   if (tx.selectedUtxos) return tx.selectedUtxos;
-  return [...(account.bitcoinResources?.utxos ?? [])]
-    .sort((a, b) => b.value.comparedTo(a.value))
-    .slice(0, ZCASH_MAX_TRANSPARENT_INPUTS);
+  return boundTransparentUtxos(account.bitcoinResources?.utxos ?? []);
 }
 
 /**

--- a/libs/coin-modules/coin-zcash/src/bridge/statusHelpers.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/statusHelpers.ts
@@ -62,6 +62,11 @@ export function resolveTransparentUtxos(account: ZcashAccount, tx: Transaction):
  * bounded PCZT (device-safe) selection does not. Lets the caller raise a
  * "too large for one send" error instead of NotEnoughBalance in exactly that
  * case, and never in a genuine-shortfall case.
+ *
+ * Inherits `resolveTransparentUtxos`'s exclusion of `tx.selectedUtxos`: a
+ * caller-supplied override is never bounded (see that function's comment), so
+ * this always answers `false` when one is set, however many UTXOs it holds --
+ * there is no bounded-only shortfall to report for an unbounded set.
  */
 export function hasBoundedTransparentShortfall(
   account: ZcashAccount,

--- a/libs/coin-modules/coin-zcash/src/bridge/statusHelpers.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/statusHelpers.ts
@@ -28,13 +28,18 @@ export const isTransparentInputTransfer = (transferType: Transaction["transferTy
  */
 export function resolveTransparentUtxos(account: ZcashAccount, tx: Transaction): BitcoinOutput[] {
   if (!TRANSPARENT_INPUT_TRANSFER_TYPES.has(tx.transferType)) return [];
-  const utxos = tx.selectedUtxos ?? account.bitcoinResources?.utxos ?? [];
-  // Largest-first, then bounded to the device's per-PCZT input ceiling: picking
-  // the largest N maximizes the amount a single send can carry (ZIP-317 prices
-  // per input, so more of the account's value per spent input is strictly
-  // better) and mirrors the "largest-first stays" selection strategy already
-  // used on the shielded side (logic/coin-selection.ts's selectNotes).
-  return [...utxos]
+  // A caller-supplied override is an explicit UTXO selection (coin control),
+  // not a pool the wallet is free to pick from -- reordering or truncating it
+  // would silently spend a different set than the caller asked for, so it
+  // passes through exactly as it did before this ceiling existed. Only the
+  // account-synced default set is sorted largest-first and bounded to the
+  // device's per-PCZT input ceiling: picking the largest N maximizes the
+  // amount a single send can carry (ZIP-317 prices per input, so more of the
+  // account's value per spent input is strictly better) and mirrors the
+  // "largest-first stays" selection strategy already used on the shielded
+  // side (logic/coin-selection.ts's selectNotes).
+  if (tx.selectedUtxos) return tx.selectedUtxos;
+  return [...(account.bitcoinResources?.utxos ?? [])]
     .sort((a, b) => b.value.comparedTo(a.value))
     .slice(0, ZCASH_MAX_TRANSPARENT_INPUTS);
 }

--- a/libs/coin-modules/coin-zcash/src/constants.ts
+++ b/libs/coin-modules/coin-zcash/src/constants.ts
@@ -102,3 +102,25 @@ export const DEFAULT_ZCASH_PRIVATE_INFO: ZcashPrivateInfo = {
 
 /** Estimation recipient used by estimateMaxSpendable/fee-estimation flows. */
 export const ZCASH_ESTIMATION_RECIPIENT = "t1XVXWCvpMgBvUaed4XDqWtgQgJSu1Ghz7F";
+
+// ── Per-PCZT device ceilings ────────────────────────────────────────────────
+//
+// Values read from `app-zcash`'s `src/consts.rs` on `develop` (merge commit
+// `22dc385`, the non-`capacity_probe` build, which is what ships): both
+// bounds moved from 10 to 32 there. Re-check that file if these ever need
+// revisiting -- the device's own bound is the source of truth, this is only
+// a mirror of it.
+
+/**
+ * Transparent inputs one PCZT may spend, mirroring the device's
+ * `MAX_PCZT_TRANSPARENT_INPUTS_NUMBER` (app-zcash, src/consts.rs).
+ */
+export const ZCASH_MAX_TRANSPARENT_INPUTS = 32;
+
+/**
+ * Ironwood spends one PCZT may carry, mirroring the device's
+ * `MAX_PCZT_IRONWOOD_ACTIONS_NUMBER` (app-zcash, src/consts.rs). The shielded
+ * send flow spends the Ironwood pool exclusively (types/bridge.ts), so this is
+ * the only shielded-pool ceiling coin-zcash's own selection needs to mirror.
+ */
+export const ZCASH_MAX_IRONWOOD_ACTIONS = 32;

--- a/libs/coin-modules/coin-zcash/src/logic/account/spendability.test.ts
+++ b/libs/coin-modules/coin-zcash/src/logic/account/spendability.test.ts
@@ -2,11 +2,15 @@ import { BigNumber } from "bignumber.js";
 import {
   collectSelectableIronwoodNotes,
   getSpendableIronwoodBalance,
+  hasBoundedIronwoodShortfall,
   hasMaturingIronwoodNotes,
   isMatureAtHeight,
   resolveReferenceHeight,
 } from "./spendability";
-import { ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS } from "../../constants";
+import {
+  ZCASH_MAX_IRONWOOD_ACTIONS,
+  ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS,
+} from "../../constants";
 import type { ZcashAccount } from "../../types/bridge";
 
 const REFERENCE_HEIGHT = 3_450_000;
@@ -196,6 +200,91 @@ describe("collectSelectableIronwoodNotes", () => {
     const selectable = collectSelectableIronwoodNotes(acc, reserved);
 
     expect(selectable.map(n => n.amount.toNumber())).toEqual([30_000]);
+  });
+});
+
+describe("collectSelectableIronwoodNotes, bounding", () => {
+  const matureBlockHeight = REFERENCE_HEIGHT - ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS;
+
+  it("returns every mature, unreserved note, unbounded and unsorted-input-order-independent, when at most the bound", () => {
+    const amounts = Array.from({ length: ZCASH_MAX_IRONWOOD_ACTIONS }, (_, i) => (i + 1) * 1_000);
+    const acc = account({
+      notes: amounts.map(amount => ({ amount, blockHeight: matureBlockHeight })),
+    });
+
+    const selectable = collectSelectableIronwoodNotes(acc, noReservations);
+
+    expect(selectable.map(n => n.amount.toNumber()).sort((a, b) => a - b)).toEqual(
+      [...amounts].sort((a, b) => a - b),
+    );
+  });
+
+  it("returns the largest ZCASH_MAX_IRONWOOD_ACTIONS mature, unreserved notes when more are available", () => {
+    const extra = 5;
+    const amounts = Array.from(
+      { length: ZCASH_MAX_IRONWOOD_ACTIONS + extra },
+      (_, i) => (i + 1) * 1_000,
+    );
+    const acc = account({
+      notes: amounts.map(amount => ({ amount, blockHeight: matureBlockHeight })),
+    });
+
+    const selectable = collectSelectableIronwoodNotes(acc, noReservations);
+
+    expect(selectable).toHaveLength(ZCASH_MAX_IRONWOOD_ACTIONS);
+    const expectedLargest = [...amounts].sort((a, b) => b - a).slice(0, ZCASH_MAX_IRONWOOD_ACTIONS);
+    expect(selectable.map(n => n.amount.toNumber())).toEqual(expectedLargest);
+  });
+});
+
+describe("hasBoundedIronwoodShortfall", () => {
+  const matureBlockHeight = REFERENCE_HEIGHT - ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS;
+
+  it("is false when the pool holds at most the bound, regardless of totalSpent", () => {
+    const amounts = Array.from({ length: ZCASH_MAX_IRONWOOD_ACTIONS }, (_, i) => (i + 1) * 1_000);
+    const acc = account({
+      notes: amounts.map(amount => ({ amount, blockHeight: matureBlockHeight })),
+    });
+    const total = amounts.reduce((sum, v) => sum + v, 0);
+
+    expect(hasBoundedIronwoodShortfall(acc, noReservations, new BigNumber(total * 10))).toBe(false);
+  });
+
+  it("is true when totalSpent exceeds the bounded pool but not the full pool", () => {
+    const extra = 5;
+    const amounts = Array.from(
+      { length: ZCASH_MAX_IRONWOOD_ACTIONS + extra },
+      (_, i) => (i + 1) * 1_000,
+    );
+    const acc = account({
+      notes: amounts.map(amount => ({ amount, blockHeight: matureBlockHeight })),
+    });
+    const fullTotal = amounts.reduce((sum, v) => sum + v, 0);
+    const boundedTotal = [...amounts]
+      .sort((a, b) => b - a)
+      .slice(0, ZCASH_MAX_IRONWOOD_ACTIONS)
+      .reduce((sum, v) => sum + v, 0);
+
+    expect(hasBoundedIronwoodShortfall(acc, noReservations, new BigNumber(boundedTotal + 1))).toBe(
+      true,
+    );
+    expect(fullTotal).toBeGreaterThan(boundedTotal + 1);
+  });
+
+  it("is false when totalSpent exceeds even the full pool -- genuine insufficiency", () => {
+    const extra = 5;
+    const amounts = Array.from(
+      { length: ZCASH_MAX_IRONWOOD_ACTIONS + extra },
+      (_, i) => (i + 1) * 1_000,
+    );
+    const acc = account({
+      notes: amounts.map(amount => ({ amount, blockHeight: matureBlockHeight })),
+    });
+    const fullTotal = amounts.reduce((sum, v) => sum + v, 0);
+
+    expect(hasBoundedIronwoodShortfall(acc, noReservations, new BigNumber(fullTotal + 1))).toBe(
+      false,
+    );
   });
 });
 

--- a/libs/coin-modules/coin-zcash/src/logic/account/spendability.test.ts
+++ b/libs/coin-modules/coin-zcash/src/logic/account/spendability.test.ts
@@ -314,6 +314,31 @@ describe("getSpendableIronwoodBalance", () => {
 
     expect(getSpendableIronwoodBalance(acc, noReservations)).toEqual(new BigNumber(0));
   });
+
+  it("counts every mature note even past the per-PCZT bound -- it's the real balance, not a max-per-send figure", () => {
+    // A note past ZCASH_MAX_IRONWOOD_ACTIONS is real, owned, mature, unreserved
+    // value: not spendable in one transaction, but still part of what the
+    // account holds. Regression guard: getSpendableIronwoodBalance must not
+    // silently drop it just because collectSelectableIronwoodNotes bounds the
+    // per-transaction selection pool.
+    const extra = 5;
+    const notes = Array.from({ length: ZCASH_MAX_IRONWOOD_ACTIONS + extra }, (_, i) => ({
+      amount: (i + 1) * 1_000,
+      blockHeight: REFERENCE_HEIGHT - ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS,
+    }));
+    const acc = account({ notes });
+
+    const fullTotal = notes.reduce((sum, n) => sum + n.amount, 0);
+    const boundedTotal = collectSelectableIronwoodNotes(acc, noReservations).reduce(
+      (sum, n) => sum.plus(n.amount),
+      new BigNumber(0),
+    );
+
+    expect(getSpendableIronwoodBalance(acc, noReservations)).toEqual(new BigNumber(fullTotal));
+    // The bound is real (selection is smaller) -- otherwise this test would
+    // not actually exercise the regression it guards against.
+    expect(boundedTotal.lt(fullTotal)).toBe(true);
+  });
 });
 
 describe("hasMaturingIronwoodNotes", () => {

--- a/libs/coin-modules/coin-zcash/src/logic/account/spendability.ts
+++ b/libs/coin-modules/coin-zcash/src/logic/account/spendability.ts
@@ -1,7 +1,10 @@
 import { BigNumber } from "bignumber.js";
 import type { ZcashAccount } from "../../types/bridge";
 import type { SpendableNote, ZcashPrivateInfo } from "../../network/types";
-import { ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS } from "../../constants";
+import {
+  ZCASH_MAX_IRONWOOD_ACTIONS,
+  ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS,
+} from "../../constants";
 import { collectIronwoodSpendableNotes } from "../../bridge/operations";
 
 /**
@@ -68,19 +71,55 @@ function collectIronwoodNotesWithMaturity(account: SpendabilityAccount): Ironwoo
   });
 }
 
-/**
- * The spendable pool: mature, unreserved Ironwood notes. Note selection
- * (`prepareTransaction`) and max-spendable (`estimateMaxSpendable`) both go
- * through this so a selection and the figure offered as "Max" can never
- * disagree.
- */
-export function collectSelectableIronwoodNotes(
+/** Mature, unreserved notes, largest-first, unbounded. Private: callers use
+ * either the bounded export below or the shortfall check, never this directly. */
+function collectAllSelectableIronwoodNotes(
   account: SpendabilityAccount,
   reserved: ReadonlySet<string>,
 ): SpendableNote[] {
   return collectIronwoodNotesWithMaturity(account)
     .filter(({ note, mature }) => mature && !reserved.has(note.nullifier))
-    .map(({ note }) => note);
+    .map(({ note }) => note)
+    .sort((a, b) => b.amount.comparedTo(a.amount));
+}
+
+/**
+ * The spendable pool: mature, unreserved Ironwood notes. Note selection
+ * (`prepareTransaction`) and max-spendable (`estimateMaxSpendable`) both go
+ * through this so a selection and the figure offered as "Max" can never
+ * disagree.
+ *
+ * Bounded to the device's per-PCZT Ironwood action ceiling: N spent notes
+ * produce exactly N actions once N >= 2 (the native builder pads to
+ * max(2, max(n_spends, n_outputs)), and a send's output count never exceeds
+ * 2), so bounding the note count bounds the action count exactly -- no
+ * off-by-one.
+ */
+export function collectSelectableIronwoodNotes(
+  account: SpendabilityAccount,
+  reserved: ReadonlySet<string>,
+): SpendableNote[] {
+  return collectAllSelectableIronwoodNotes(account, reserved).slice(0, ZCASH_MAX_IRONWOOD_ACTIONS);
+}
+
+/**
+ * True when the Ironwood action bound is the reason `totalSpent` cannot be
+ * covered -- the account's full spendable pool covers it, only the bounded
+ * (device-safe) pool does not. Mirrors `hasBoundedTransparentShortfall`
+ * (bridge/statusHelpers.ts) for the shielded pool.
+ */
+export function hasBoundedIronwoodShortfall(
+  account: SpendabilityAccount,
+  reserved: ReadonlySet<string>,
+  totalSpent: BigNumber,
+): boolean {
+  const all = collectAllSelectableIronwoodNotes(account, reserved);
+  if (all.length <= ZCASH_MAX_IRONWOOD_ACTIONS) return false;
+  const boundedTotal = all
+    .slice(0, ZCASH_MAX_IRONWOOD_ACTIONS)
+    .reduce((sum, n) => sum.plus(n.amount), new BigNumber(0));
+  const fullTotal = all.reduce((sum, n) => sum.plus(n.amount), new BigNumber(0));
+  return totalSpent.gt(boundedTotal) && totalSpent.lte(fullTotal);
 }
 
 /** Sum of the spendable pool -- the figure presented as spendable. */

--- a/libs/coin-modules/coin-zcash/src/logic/account/spendability.ts
+++ b/libs/coin-modules/coin-zcash/src/logic/account/spendability.ts
@@ -94,6 +94,9 @@ function collectAllSelectableIronwoodNotes(
  * max(2, max(n_spends, n_outputs)), and a send's output count never exceeds
  * 2), so bounding the note count bounds the action count exactly -- no
  * off-by-one.
+ *
+ * Returned largest-first (see `collectAllSelectableIronwoodNotes`) -- this is
+ * now a contract callers may rely on, not an artifact of iteration order.
  */
 export function collectSelectableIronwoodNotes(
   account: SpendabilityAccount,

--- a/libs/coin-modules/coin-zcash/src/logic/account/spendability.ts
+++ b/libs/coin-modules/coin-zcash/src/logic/account/spendability.ts
@@ -122,12 +122,26 @@ export function hasBoundedIronwoodShortfall(
   return totalSpent.gt(boundedTotal) && totalSpent.lte(fullTotal);
 }
 
-/** Sum of the spendable pool -- the figure presented as spendable. */
+/**
+ * Sum of the spendable pool -- the figure presented as the account's Private
+ * balance (`ZcashTransferFromSelector`, `AccountBalanceSummaryFooter`).
+ *
+ * Deliberately **unbounded** by the per-PCZT action ceiling: a note past that
+ * ceiling is real, owned, mature, unreserved value -- it just cannot be spent
+ * in a *single* transaction, which is a fact about one send, not about the
+ * account's balance. Reporting less than the true mature total here would
+ * make funds silently vanish from the figure a user reads as "what I have",
+ * the same failure mode `getMaturingIronwoodBalance` exists to avoid for
+ * immature notes. `collectSelectableIronwoodNotes` (bounded) stays the right
+ * pool for selection and max-spendable; a send that needs more than the bound
+ * covers is caught at that point by `hasBoundedIronwoodShortfall`, not by
+ * understating the balance here.
+ */
 export function getSpendableIronwoodBalance(
   account: SpendabilityAccount,
   reserved: ReadonlySet<string>,
 ): BigNumber {
-  return collectSelectableIronwoodNotes(account, reserved).reduce(
+  return collectAllSelectableIronwoodNotes(account, reserved).reduce(
     (sum, note) => sum.plus(note.amount),
     new BigNumber(0),
   );

--- a/libs/coin-modules/coin-zcash/src/logic/account/spendability.ts
+++ b/libs/coin-modules/coin-zcash/src/logic/account/spendability.ts
@@ -141,10 +141,13 @@ export function getSpendableIronwoodBalance(
   account: SpendabilityAccount,
   reserved: ReadonlySet<string>,
 ): BigNumber {
-  return collectAllSelectableIronwoodNotes(account, reserved).reduce(
-    (sum, note) => sum.plus(note.amount),
-    new BigNumber(0),
-  );
+  // A sum doesn't care about order, so this filters the maturity pass
+  // directly instead of going through collectAllSelectableIronwoodNotes,
+  // which sorts largest-first for callers that need a ranked pool -- this
+  // renderer-facing path never does.
+  return collectIronwoodNotesWithMaturity(account)
+    .filter(({ note, mature }) => mature && !reserved.has(note.nullifier))
+    .reduce((sum, { note }) => sum.plus(note.amount), new BigNumber(0));
 }
 
 /**

--- a/libs/coin-modules/coin-zcash/src/types/errors.test.ts
+++ b/libs/coin-modules/coin-zcash/src/types/errors.test.ts
@@ -2,6 +2,7 @@ import {
   ZcashAmountBelowDustThreshold,
   ZcashNotesNotYetSpendable,
   ZcashSaplingRecipientNotSupported,
+  ZcashSendTooLarge,
   ZcashShieldedKeyMissing,
   ZcashSignerNotSupported,
   ZcashSigningCancelled,
@@ -24,6 +25,10 @@ describe("zcash errors", () => {
     [
       ZcashAmountBelowDustThreshold,
       `Amount is too small to be broadcast (minimum ${TRANSPARENT_OUTPUT_DUST_THRESHOLD} zatoshis)`,
+    ],
+    [
+      ZcashSendTooLarge,
+      "This amount is too large to send in one transaction: try sending it in smaller amounts",
     ],
   ])("names %p and gives it a readable default message", (Err, message) => {
     const error = new Err();

--- a/libs/coin-modules/coin-zcash/src/types/errors.ts
+++ b/libs/coin-modules/coin-zcash/src/types/errors.ts
@@ -86,6 +86,25 @@ export class ZcashMemoTooLong extends Error {
 }
 
 /**
+ * Raised when a bounded selection cannot cover the requested amount + fee
+ * while the account's full (unbounded) balance could -- the device refuses a
+ * PCZT past its per-pool action/input ceiling, so the wallet must stop short
+ * of it rather than offer a total it cannot sign in one transaction. Distinct
+ * from a genuine `NotEnoughBalance`/"Insufficient shielded balance": the funds
+ * exist, they are just not reachable in a single send (see
+ * bridge/statusHelpers.ts's `hasBoundedTransparentShortfall` and
+ * logic/account/spendability.ts's `hasBoundedIronwoodShortfall`).
+ */
+export class ZcashSendTooLarge extends Error {
+  constructor(
+    message = "This amount is too large to send in one transaction: try sending it in smaller amounts",
+  ) {
+    super(message);
+    this.name = "ZcashSendTooLarge";
+  }
+}
+
+/**
  * Raised when the builder rejects a selected note because its leaf position is
  * at or past the number of leaves the Ironwood tree held at its anchor -- the
  * note exists on-chain but is not yet inside the tree the transaction is built

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,8 +142,8 @@ catalogs:
       specifier: 2.3.3
       version: 2.3.3
     '@ledgerhq/zcash-utils':
-      specifier: 2.4.0
-      version: 2.4.0
+      specifier: 2.5.0
+      version: 2.5.0
     '@nx/devkit':
       specifier: 22.7.8
       version: 22.7.8
@@ -1157,7 +1157,7 @@ importers:
         version: link:../../libs/wallet-pnl
       '@ledgerhq/zcash-utils':
         specifier: 'catalog:'
-        version: 2.4.0
+        version: 2.5.0
       '@lottiefiles/dotlottie-react':
         specifier: 0.17.13
         version: 0.17.13(react@19.1.4)
@@ -10719,7 +10719,7 @@ importers:
         version: link:../../wallet-btc
       '@ledgerhq/zcash-utils':
         specifier: 'catalog:'
-        version: 2.4.0
+        version: 2.5.0
       '@noble/hashes':
         specifier: 1.8.0
         version: 1.8.0
@@ -12057,7 +12057,7 @@ importers:
         version: link:../../wallet-btc
       '@ledgerhq/zcash-utils':
         specifier: 'catalog:'
-        version: 2.4.0
+        version: 2.5.0
       '@noble/curves':
         specifier: 1.9.7
         version: 1.9.7
@@ -22493,8 +22493,8 @@ packages:
   '@ledgerhq/wallet-api-simulator@2.3.3':
     resolution: {integrity: sha512-gtSepkiGXvwIyvMC0DhNNYfZKt2BXFZ7IeFIY7h3Edz9ya5LxaRWWe3Zczo5Ex2CHgH2ALfXew+tZOod9Hd6Rg==}
 
-  '@ledgerhq/zcash-utils@2.4.0':
-    resolution: {integrity: sha512-lsAydrDeudztkKIfgbVPV+3n0oYyWj+cjq5HlVDea6nuhGs1RvE5RYwe0grixfpZ3BUOSD2ebpLgfV76L35qEg==}
+  '@ledgerhq/zcash-utils@2.5.0':
+    resolution: {integrity: sha512-E1nj2UoUsTw9DHp6lGMwVzdo1huT0bSCvDxS8TiYv2fMU+4TX7gXl8D2JQnfA+XQV21Ogfb8gWYoOjYJ+GO7qQ==}
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
@@ -22947,7 +22947,6 @@ packages:
     resolution: {integrity: sha512-KRbkSthClEwkbpt/LLJmBJhIOvOsyrp9OICisF9p3mOODjaxAuYmyOgrVreg09BT2F4hXN3JXpvt9eIZpTCRsw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.7.8':
     resolution: {integrity: sha512-pdPMWko1yZI5ZNI6/t2Y5rQPGgV/ah5DW+mlHo2aFKav4lnxvgisEh9e4HtOsYBfK/9PyYZ5u3M9hLSaMiJ75w==}
@@ -28420,7 +28419,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: ^5.5.10
+      rxjs: '*'
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -44806,7 +44805,7 @@ snapshots:
       make-fetch-happen: 10.2.1
       nopt: 6.0.0
       proc-log: 2.0.1
-      semver: 7.7.3
+      semver: 7.8.1
       tar: 6.2.1
       which: 2.0.2
     transitivePeerDependencies:
@@ -48544,7 +48543,7 @@ snapshots:
       - encoding
       - utf-8-validate
 
-  '@ledgerhq/zcash-utils@2.4.0': {}
+  '@ledgerhq/zcash-utils@2.5.0': {}
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 
@@ -49013,7 +49012,7 @@ snapshots:
   '@npmcli/fs@2.1.2':
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.7.3
+      semver: 7.8.1
 
   '@npmcli/move-file@1.1.2':
     dependencies:
@@ -63818,7 +63817,7 @@ snapshots:
   jscodeshift@17.3.0(@babel/preset-env@7.28.5(@babel/core@7.28.5)):
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.8
       '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.28.5)
@@ -65265,9 +65264,7 @@ snapshots:
     optionalDependencies:
       metro-transform-worker: 0.83.7
     transitivePeerDependencies:
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   metro-core@0.81.5:
     dependencies:
@@ -65374,7 +65371,7 @@ snapshots:
   metro-source-map@0.81.5:
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.27.0'
+      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.29.8'
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -60,7 +60,7 @@ catalog:
   "@ledgerhq/wallet-api-core": 2.0.0
   "@ledgerhq/wallet-api-server": 3.4.3
   "@ledgerhq/wallet-api-simulator": 2.3.3
-  "@ledgerhq/zcash-utils": 2.4.0
+  "@ledgerhq/zcash-utils": 2.5.0
   # React Native
   react-native: 0.81.6
   "@react-native/assets-registry": 0.81.6


### PR DESCRIPTION
### 📝 Description

`coin-zcash` selected transparent UTXOs and shielded (Ironwood) notes with no ceiling on either pool, while the device refuses a PCZT whose bundle exceeds its per-pool ceiling. An account holding more inputs/notes than the device accepts could not send at all: the wallet offered a maximum it would refuse to sign, and reported `NotEnoughBalance` even when the shortfall was only caused by the device ceiling, not by an actual lack of funds.

This PR bounds the account-synced transparent-input and Ironwood-note selection to the device's per-PCZT ceilings (`ZCASH_MAX_TRANSPARENT_INPUTS` / `ZCASH_MAX_IRONWOOD_ACTIONS`, mirroring `app-zcash`'s `MAX_PCZT_TRANSPARENT_INPUTS_NUMBER` / `MAX_PCZT_IRONWOOD_ACTIONS_NUMBER`), applied at the shared funnel every reader goes through for that default set (`resolveTransparentUtxos`, `collectSelectableIronwoodNotes`) so fee pricing, PCZT construction, balance status and max-spendable always agree for it. A caller-supplied `tx.selectedUtxos` override (currently unused — no coin-control feature exists in coin-zcash yet) deliberately passes through unbounded, exactly as before this PR; bounding an explicit selection is a decision for whichever future feature introduces one, not for this fix. A bounded-only shortfall on the default set (the account's full balance covers the amount, only the device-safe selection doesn't) now raises a new `ZcashSendTooLarge` error instead of `NotEnoughBalance`, so the user is told to split the send instead of being told they lack funds.

Regression check: `logic/coin-selection.ts`'s selection/fee functions are untouched — the bounding lives entirely upstream of them (`bridge/statusHelpers.ts`, `logic/account/spendability.ts`), so existing behaviour for accounts at or below both bounds is unchanged and covered by the pre-existing test suite.

**Measured coverage** (modified files, `pnpm nx run @ledgerhq/coin-zcash:coverage`): `getTransactionStatus.ts` 100%, `mapping.ts` 100%, `errors.ts` 100%, `statusHelpers.ts` 98.33% stmts/100% lines, `constants.ts` 89.13% stmts/100% lines, `spendability.ts` 90.47% stmts/89.18% lines (the one gap, lines 173-176, is `getMaturingIronwoodBalance` — pre-existing code this PR does not touch).

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36831](https://ledgerhq.atlassian.net/browse/LIVE-36831)
- **ADR** (if any): N/A


[LIVE-36831]: https://ledgerhq.atlassian.net/browse/LIVE-36831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ