### PR TITLE
[LWDM] feat(concordium): build PLT token sub-accounts on sync (LIVE-28332)

### DIFF
--- a/.changeset/concordium-plt-token-sub-accounts.md
+++ b/.changeset/concordium-plt-token-sub-accounts.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-concordium": minor
+"@ledgerhq/live-common": minor
+---
+
+Build PLT token sub-accounts during Concordium account sync, behind the new `enableTokens` coin config flag (off by default). Tokens are resolved from the CAL by on-chain address, per-token pause and allow/deny state is cached on the account, and PLT balances are reported on the `api/` surface.

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.integ.test.tsx
@@ -162,6 +162,7 @@ describe("OnboardModal Integration", () => {
       grpcPort: 443,
       proxyUrl: "https://ccd-wallet-proxy-mainnet.coin.ledger.com",
       minReserve: 0,
+      enableTokens: false,
     }));
   });
 

--- a/libs/coin-modules/coin-concordium/src/api/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-concordium/src/api/craftTransaction.test.ts
@@ -101,4 +101,24 @@ describe("api/craftTransaction", () => {
     expect(result).toHaveProperty("transaction");
     expect(typeof result.transaction).toBe("string");
   });
+
+  it("should reject a non-native asset instead of crafting a CCD transfer", async () => {
+    const api = createApi("concordium_testnet");
+    const transactionIntent = {
+      intentType: "transaction" as const,
+      type: "send",
+      sender: VALID_ADDRESS,
+      recipient: VALID_ADDRESS_2,
+      amount: BigInt(1000000),
+      asset: { type: "plt", assetReference: "t-USDT" },
+    } as any;
+
+    await expect(api.craftTransaction(context, transactionIntent)).rejects.toThrow(
+      /asset type plt is not supported/,
+    );
+    // Crafting ignores `asset`, so without the guard this would sign a CCD
+    // transfer of the same integer amount. PLT crafting is LIVE-28337.
+    expect(getNextValidSequenceMock).not.toHaveBeenCalled();
+    expect(craftTransactionMock).not.toHaveBeenCalled();
+  });
 });

--- a/libs/coin-modules/coin-concordium/src/api/estimateFees.test.ts
+++ b/libs/coin-modules/coin-concordium/src/api/estimateFees.test.ts
@@ -84,4 +84,21 @@ describe("api/estimateFees", () => {
 
     expect(result).toEqual({ value: BigInt(1000) });
   });
+
+  it("should reject a non-native asset rather than return a plausible native fee", async () => {
+    const api = createApi("concordium_testnet");
+    const transactionIntent = {
+      intentType: "transaction" as const,
+      type: "send",
+      sender: VALID_ADDRESS,
+      recipient: VALID_ADDRESS_2,
+      amount: BigInt(1000000),
+      asset: { type: "plt", assetReference: "t-USDT" },
+    } as any;
+
+    await expect(api.estimateFees(context, transactionIntent)).rejects.toThrow(
+      /asset type plt is not supported/,
+    );
+    expect(estimateFeesMock).not.toHaveBeenCalled();
+  });
 });

--- a/libs/coin-modules/coin-concordium/src/api/index.ts
+++ b/libs/coin-modules/coin-concordium/src/api/index.ts
@@ -20,6 +20,7 @@ import {
   TransactionType,
 } from "@ledgerhq/concordium-core";
 import BigNumber from "bignumber.js";
+import invariant from "invariant";
 import { validateAddress } from "../bridge/validateAddress";
 import { rejectBalanceOptions } from "@ledgerhq/coin-module-framework/api/getBalance/rejectBalanceOptions";
 import {
@@ -105,11 +106,27 @@ export function createApi(currencyId: string) {
   } satisfies CoinModuleImpl<ConcordiumCoinConfig, ConcordiumMemo>;
 }
 
+/**
+ * Crafting ignores `asset` and always emits a native transfer, so without this
+ * a PLT intent would be signed as a CCD transfer of the same integer amount.
+ * `getBalance` reports PLT balances, which makes such an intent constructible;
+ * PLT crafting itself lands in LIVE-28337.
+ */
+function assertNativeAsset(transactionIntent: TransactionIntent<ConcordiumMemo>): void {
+  invariant(
+    transactionIntent.asset.type === "native",
+    "concordium: asset type %s is not supported",
+    transactionIntent.asset.type,
+  );
+}
+
 async function craftTransaction(
   config: ConcordiumCoinConfig,
   transactionIntent: TransactionIntent<ConcordiumMemo>,
   currencyId: string,
 ): Promise<CraftedTransaction> {
+  assertNativeAsset(transactionIntent);
+
   const nextSequenceNumber = await getNextValidSequence(
     config,
     transactionIntent.sender,
@@ -139,6 +156,10 @@ async function estimateFees(
   transactionIntent: TransactionIntent<ConcordiumMemo>,
   currencyId: string,
 ): Promise<FeeEstimation> {
+  // Rejected here too, or a caller gets a plausible native fee for a send that
+  // cannot be crafted.
+  assertNativeAsset(transactionIntent);
+
   const memo =
     "memo" in transactionIntent && transactionIntent.memo?.type === "string"
       ? transactionIntent.memo.value

--- a/libs/coin-modules/coin-concordium/src/bridge/index.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/index.test.ts
@@ -1,4 +1,31 @@
+import type { ConcordiumAccount } from "../types";
 import { createBridges } from ".";
+
+jest.mock("@ledgerhq/ledger-wallet-framework/bridge/jsHelpers", () => ({
+  getSerializedAddressParameters: jest.fn(),
+  makeSync: jest.fn(() => jest.fn()),
+  makeScanAccounts: jest.fn(() => jest.fn()),
+  mergeOps: jest.fn(),
+}));
+
+jest.mock("../config", () => ({
+  __esModule: true,
+  default: { setCoinConfig: jest.fn(), getCoinConfig: jest.fn() },
+}));
+
+const { makeSync, makeScanAccounts } = jest.requireMock(
+  "@ledgerhq/ledger-wallet-framework/bridge/jsHelpers",
+);
+const coinConfig = jest.requireMock("../config").default;
+
+type PostSync = (initial: ConcordiumAccount, synced: ConcordiumAccount) => ConcordiumAccount;
+
+const account = (subAccounts?: unknown[]): ConcordiumAccount =>
+  ({
+    id: "acc",
+    currency: { id: "concordium_testnet" },
+    ...(subAccounts === undefined ? {} : { subAccounts }),
+  }) as unknown as ConcordiumAccount;
 
 describe("createBridges", () => {
   it("has a currency bridge and an account bridge with required methods", () => {
@@ -26,5 +53,54 @@ describe("createBridges", () => {
         scanAccounts: expect.any(Function),
       },
     });
+  });
+});
+
+/**
+ * Token visibility is cleared in `postSync` rather than in the account shape, so
+ * omitting it from either builder silently reintroduces the empty token section.
+ */
+describe("createBridges token visibility wiring", () => {
+  const build = (enableTokens: boolean): { sync: PostSync; scan: PostSync } => {
+    jest.clearAllMocks();
+    coinConfig.getCoinConfig.mockReturnValue({ enableTokens });
+    createBridges(undefined as never, {} as never);
+
+    return {
+      sync: makeSync.mock.calls[0][0].postSync,
+      scan: makeScanAccounts.mock.calls[0][0].postSync,
+    };
+  };
+
+  it("passes a postSync to both makeSync and makeScanAccounts", () => {
+    const { sync, scan } = build(false);
+
+    expect(sync).toEqual(expect.any(Function));
+    expect(scan).toEqual(expect.any(Function));
+  });
+
+  it.each([
+    ["sync", (b: { sync: PostSync; scan: PostSync }) => b.sync],
+    ["scan", (b: { sync: PostSync; scan: PostSync }) => b.scan],
+  ])("removes subAccounts on the %s path when tokens are off", (_name, pick) => {
+    const result = pick(build(false))(account(), account([{ id: "sub" }]));
+
+    expect("subAccounts" in result).toBe(false);
+  });
+
+  it.each([
+    ["sync", (b: { sync: PostSync; scan: PostSync }) => b.sync],
+    ["scan", (b: { sync: PostSync; scan: PostSync }) => b.scan],
+  ])("keeps subAccounts on the %s path when tokens are on", (_name, pick) => {
+    const built = build(true);
+    const synced = account([{ id: "sub" }]);
+
+    expect(pick(built)(account(), synced)).toBe(synced);
+  });
+
+  it("reads the flag per currency, so one network can differ from the other", () => {
+    build(false).sync(account(), account([]));
+
+    expect(coinConfig.getCoinConfig).toHaveBeenCalledWith("concordium_testnet");
   });
 });

--- a/libs/coin-modules/coin-concordium/src/bridge/index.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/index.ts
@@ -26,8 +26,19 @@ import { buildReceive } from "./receive";
 import { assignFromAccountRaw, assignToAccountRaw } from "./serialization";
 import { buildSignOperation } from "./signOperation";
 import { getAccountShape } from "./sync";
+import { stripSubAccounts } from "./tokens";
 import { updateTransaction } from "./updateTransaction";
 import { validateAddress } from "./validateAddress";
+
+/**
+ * See `stripSubAccounts` for why the shape cannot clear tokens itself. Wired
+ * into scanning as well as syncing: a freshly discovered account never reaches
+ * `makeSync`, and would keep an empty array until its first sync.
+ */
+const postSync = (_initial: ConcordiumAccount, synced: ConcordiumAccount): ConcordiumAccount =>
+  concordiumCoinConfig.getCoinConfig(synced.currency.id).enableTokens
+    ? synced
+    : stripSubAccounts(synced);
 
 export function createBridges(
   signerContext: SignerContext<ConcordiumSigner>,
@@ -37,7 +48,7 @@ export function createBridges(
 
   const getAddress = resolver(signerContext);
   const receive = buildReceive(signerContext);
-  const scanAccounts = makeScanAccounts({ getAccountShape, getAddressFn: getAddress });
+  const scanAccounts = makeScanAccounts({ getAccountShape, getAddressFn: getAddress, postSync });
   const onboardAccount = buildOnboardAccount(signerContext);
   const pairWalletConnect = buildPairWalletConnect();
 
@@ -48,7 +59,7 @@ export function createBridges(
   };
 
   const signOperation = buildSignOperation(signerContext);
-  const sync = makeSync({ getAccountShape });
+  const sync = makeSync({ getAccountShape, postSync });
 
   const accountBridge: AccountBridge<Transaction, ConcordiumAccount> = {
     broadcast,

--- a/libs/coin-modules/coin-concordium/src/bridge/serialization.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/serialization.test.ts
@@ -1,4 +1,5 @@
 import BigNumber from "bignumber.js";
+import type { Account, AccountRaw } from "@ledgerhq/types-live";
 import type {
   ConcordiumAccount,
   ConcordiumAccountRaw,
@@ -17,6 +18,19 @@ import {
   assignToAccountRaw,
   assignFromAccountRaw,
 } from "./serialization";
+
+jest.mock("../config", () => ({
+  __esModule: true,
+  default: { getCoinConfig: jest.fn() },
+}));
+
+const coinConfig = jest.requireMock("../config").default;
+
+// Token state only survives deserialization while the feature is on. The suites
+// below assume it is; "assignFromAccountRaw and the token flag" varies it.
+beforeEach(() => {
+  coinConfig.getCoinConfig.mockReturnValue({ enableTokens: true });
+});
 
 const ACCOUNT_ID = "js:2:concordium_testnet:someaddr:";
 
@@ -351,5 +365,76 @@ describe("mapRawOperationToBridgeOperation", () => {
     const result = mapRawOperationToBridgeOperation(raw, ACCOUNT_ID);
 
     expect(result.blockHash).toBeNull();
+  });
+});
+
+/**
+ * Deserialization is the one account-producing path no `postSync` covers, so
+ * the flag has to be enforced here too.
+ */
+describe("assignFromAccountRaw and the token flag", () => {
+  const storedTokens = { "t-USDT": { transferStatus: "allowed" } };
+
+  const raw = () =>
+    ({
+      concordiumResources: {
+        isOnboarded: true,
+        credId: "",
+        publicKey: "",
+        identityIndex: 0,
+        credNumber: 0,
+        ipIdentity: 0,
+        tokens: { ...storedTokens },
+      },
+    }) as unknown as AccountRaw;
+
+  const account = () =>
+    ({
+      currency: { id: "concordium_testnet", family: "concordium" },
+      subAccounts: [{ id: "sub", type: "TokenAccount" }],
+    }) as unknown as Account;
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it("drops sub-accounts and stored token state when the flag is off", () => {
+    coinConfig.getCoinConfig.mockReturnValue({ enableTokens: false });
+    const target = account();
+
+    assignFromAccountRaw(raw(), target);
+
+    expect(target.subAccounts).toBeUndefined();
+    expect(
+      "tokens" in (target as never as { concordiumResources: object }).concordiumResources,
+    ).toBe(false);
+  });
+
+  it("keeps both when the flag is on", () => {
+    coinConfig.getCoinConfig.mockReturnValue({ enableTokens: true });
+    const target = account();
+
+    assignFromAccountRaw(raw(), target);
+
+    expect(target.subAccounts).toHaveLength(1);
+    expect(
+      (target as never as { concordiumResources: { tokens?: object } }).concordiumResources.tokens,
+    ).toEqual(storedTokens);
+  });
+
+  it.each([
+    [
+      "the config cannot be resolved",
+      () => {
+        throw new Error("MissingCoinConfig");
+      },
+    ],
+    ["the flag is absent from the config", () => ({})],
+  ])("fails closed and strips tokens when %s", (_case, impl) => {
+    // An unreadable flag must not expose token UI for a feature that is off by
+    // default. Sub-accounts are rebuilt from chain on the next sync.
+    coinConfig.getCoinConfig.mockImplementation(impl);
+    const target = account();
+
+    expect(() => assignFromAccountRaw(raw(), target)).not.toThrow();
+    expect(target.subAccounts).toBeUndefined();
   });
 });

--- a/libs/coin-modules/coin-concordium/src/bridge/serialization.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/serialization.ts
@@ -7,6 +7,8 @@ import type {
   ConcordiumResources,
   RawOperation,
 } from "../types";
+import coinConfig from "../config";
+import { applyTokensToResources } from "./tokens";
 
 export function isConcordiumAccount(account: Account): account is ConcordiumAccount {
   return account.currency?.family === "concordium" && "concordiumResources" in account;
@@ -54,14 +56,43 @@ export function assignToAccountRaw(account: Account, accountRaw: AccountRaw): vo
   );
 }
 
+/**
+ * Reads the token flag, treating an unreadable config as off.
+ *
+ * `getCoinConfig` throws when unset, but that does not mean "too early":
+ * `fromAccountRaw` awaits `getAccountBridgeByFamily`, which loads the family
+ * setup, and concordium's setup seeds the config at module initialization. A
+ * throw therefore signals abnormal config resolution, where failing closed is
+ * right — exposing token UI for a feature that is off by default is worse than
+ * rebuilding sub-accounts from chain on the next sync.
+ */
+function tokensEnabled(currencyId: string): boolean {
+  try {
+    return coinConfig.getCoinConfig(currencyId).enableTokens === true;
+  } catch {
+    return false;
+  }
+}
+
 export function assignFromAccountRaw(accountRaw: AccountRaw, account: Account): void {
   if (!isConcordiumAccountRaw(accountRaw) || !accountRaw.concordiumResources) {
     return;
   }
 
-  (account as ConcordiumAccount).concordiumResources = copyResources(
-    accountRaw.concordiumResources,
-  );
+  const resources = copyResources(accountRaw.concordiumResources);
+
+  // The only account-producing path no `postSync` covers: the framework assigns
+  // the raw token sub-accounts just before calling this hook, so without a strip
+  // here disabling the flag would hold only until the next app start.
+  if (!tokensEnabled(account.currency.id)) {
+    (account as ConcordiumAccount).concordiumResources = applyTokensToResources(resources, {
+      kind: "cleared",
+    });
+    delete account.subAccounts;
+    return;
+  }
+
+  (account as ConcordiumAccount).concordiumResources = resources;
 }
 
 export function mapRawOperationToBridgeOperation(op: RawOperation, accountId: string): Operation {

--- a/libs/coin-modules/coin-concordium/src/bridge/sync.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/sync.test.ts
@@ -20,6 +20,12 @@ jest.mock("../logic/history/listOperations", () => ({
   listOperations: jest.fn(),
 }));
 
+jest.mock("@ledgerhq/ledger-wallet-framework/cryptoAssetsStore", () => ({
+  getCryptoAssetsStore: () => {
+    throw new Error("the CAL must not be consulted while tokens are off");
+  },
+}));
+
 jest.mock("../config", () => ({
   __esModule: true,
   default: {
@@ -54,6 +60,56 @@ function createRawOpFixture(overrides?: Record<string, unknown>) {
     ...overrides,
   };
 }
+
+describe("getBalance token list authority", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("reports the token list alongside the balance, from one request", async () => {
+    const accountTokens = [{ token: { tokenId: "t-USDT" } }];
+    getAccountBalance.mockResolvedValue({
+      finalizedBalance: { accountAmount: "1", accountAtDisposal: "1", accountTokens },
+    });
+
+    const result = await getBalance(CURRENCY_ID, VALID_ADDRESS);
+
+    expect(result.accountTokens).toBe(accountTokens);
+    expect(getAccountBalance).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports no token list when the request fails, so the caller can tell that apart from empty", async () => {
+    getAccountBalance.mockRejectedValue(new Error("network error"));
+
+    const result = await getBalance(CURRENCY_ID, VALID_ADDRESS);
+
+    // A zeroed balance is synthetic here; treating an absent list as authoritative
+    // would delete the account's token sub-accounts on one bad response.
+    expect(result.balance).toEqual(new BigNumber(0));
+    expect(result.accountTokens).toBeUndefined();
+  });
+
+  it("reports no token list when the field is present but not an array", async () => {
+    getAccountBalance.mockResolvedValue({
+      finalizedBalance: { accountAmount: "1", accountAtDisposal: "1", accountTokens: null },
+    });
+
+    const result = await getBalance(CURRENCY_ID, VALID_ADDRESS);
+
+    // Normalised at this boundary so the declared type holds for every caller.
+    expect(result.accountTokens).toBeUndefined();
+  });
+
+  it("reports no token list when the response omits the field", async () => {
+    getAccountBalance.mockResolvedValue({
+      finalizedBalance: { accountAmount: "1", accountAtDisposal: "1" },
+    });
+
+    const result = await getBalance(CURRENCY_ID, VALID_ADDRESS);
+
+    expect(result.accountTokens).toBeUndefined();
+  });
+});
 
 describe("getBalances", () => {
   beforeEach(() => {
@@ -365,5 +421,67 @@ describe("getAccountShape", () => {
     expect(getAccountBalance).toHaveBeenCalled();
     expect(listOperations).toHaveBeenCalled();
     expect(getConsensusInfo).toHaveBeenCalledWith(config, currency.id);
+  });
+});
+
+/**
+ * `enableTokens` is the shipping default of `false`, and this file's coin config
+ * mock omits the flag, so no extra setup is needed to exercise it.
+ *
+ * The chain response carries a PLT throughout, so the flag rather than an empty
+ * chain is what has to keep tokens out.
+ */
+describe("getAccountShape with tokens disabled", () => {
+  const PLT_ENTRY = {
+    token: { tokenId: "t-USDT", tokenState: { decimals: 6, moduleState: {} } },
+    tokenAccountState: { balance: { value: "500000", decimals: 6 } },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getAccountsByPublicKey.mockResolvedValue([{ address: VALID_ADDRESS }]);
+    getAccountBalance.mockResolvedValue({
+      finalizedBalance: {
+        accountAmount: "10000000",
+        accountAtDisposal: "9900000",
+        accountTokens: [PLT_ENTRY],
+      },
+    });
+    listOperations.mockResolvedValue({ items: [], next: undefined });
+    getConsensusInfo.mockResolvedValue({ lastFinalizedBlockHeight: 5000 });
+  });
+
+  const shape = () =>
+    getAccountShape({
+      currency: createFixtureCurrency(),
+      derivationMode: "",
+      derivationPath: "44'/1'/0'/0'/0'/0'",
+      index: 0,
+      rest: { publicKey: PUBLIC_KEY },
+    });
+
+  it("reports the native balance unchanged", async () => {
+    const result = await shape();
+
+    expect(result.balance).toEqual(new BigNumber(10000000));
+    expect(result.spendableBalance).toEqual(new BigNumber(9900000));
+  });
+
+  it("never consults the CAL, so a CAL outage cannot affect a tokens-off sync", async () => {
+    // The store mock throws on access; reaching it would fail this test.
+    await expect(shape()).resolves.toBeDefined();
+  });
+
+  it("stores no per-token state", async () => {
+    const result = await shape();
+
+    expect(result.concordiumResources).not.toHaveProperty("tokens");
+  });
+
+  it("empties subAccounts so a previous tokens-on sync leaves nothing behind", async () => {
+    const result = await shape();
+
+    // `postSync` then removes the key entirely; see bridge/index.test.ts.
+    expect(result.subAccounts).toEqual([]);
   });
 });

--- a/libs/coin-modules/coin-concordium/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/sync.ts
@@ -10,8 +10,9 @@ import {
   getConsensusInfo,
 } from "../network/proxyClient";
 import { listOperations } from "../logic/history/listOperations";
-import type { ConcordiumAccount, ConcordiumResources } from "../types";
+import type { ConcordiumAccount, ConcordiumResources, PltAccountToken } from "../types";
 import { mapRawOperationToBridgeOperation } from "./serialization";
+import { applyTokensToResources, resolveTokenSubAccounts, subAccountsPatch } from "./tokens";
 
 const fillConcordiumResources = (
   existing: Partial<ConcordiumResources> = {},
@@ -32,21 +33,32 @@ const valueToBigNumber = (value?: string | number): BigNumber => {
   return result.isNaN() ? new BigNumber(0) : result;
 };
 
+/**
+ * Reads the account balance once and reports the PLT list alongside it.
+ *
+ * `accountTokens` is `undefined` when the fetch failed, the response omitted
+ * the field, or it arrived as something other than an array — all three
+ * reachable because the response is not schema-checked. Callers must not read
+ * that as "holds no tokens": the zeroed balance below is synthetic, and
+ * treating the absent list as authoritative would drop the account's token
+ * sub-accounts on a single bad response.
+ */
 export async function getBalance(
   currencyId: string,
   address: string,
-): Promise<{ balance: BigNumber; spendableBalance: BigNumber }> {
+): Promise<{
+  balance: BigNumber;
+  spendableBalance: BigNumber;
+  accountTokens: PltAccountToken[] | undefined;
+}> {
   const config = coinConfig.getCoinConfig(currencyId);
-  const { finalizedBalance: { accountAmount, accountAtDisposal } = {} } = await getAccountBalance(
-    config,
-    currencyId,
-    address,
-  ).catch((error): { finalizedBalance: { accountAmount: string; accountAtDisposal: string } } => {
-    log("concordium-sync", `Error fetching balance for account with address ${address}`, {
-      error,
+  const { finalizedBalance: { accountAmount, accountAtDisposal, accountTokens } = {} } =
+    await getAccountBalance(config, currencyId, address).catch(error => {
+      log("concordium-sync", `Error fetching balance for account with address ${address}`, {
+        error,
+      });
+      return { finalizedBalance: undefined };
     });
-    return { finalizedBalance: { accountAmount: "0", accountAtDisposal: "0" } };
-  });
 
   const balance = valueToBigNumber(accountAmount);
   const minReserve = config.minReserve;
@@ -56,7 +68,12 @@ export async function getBalance(
     : balance.minus(minReserve);
   spendableBalance = spendableBalance.isNegative() ? new BigNumber(0) : spendableBalance;
 
-  return { balance, spendableBalance };
+  // Normalised rather than passed through, so the declared type holds.
+  return {
+    balance,
+    spendableBalance,
+    accountTokens: Array.isArray(accountTokens) ? accountTokens : undefined,
+  };
 }
 
 export async function syncOperations(
@@ -85,7 +102,7 @@ export async function syncOperations(
   return mergeOps(oldOperations, newOperations);
 }
 
-export const getAccountShape: GetAccountShape<ConcordiumAccount> = async info => {
+export const getAccountShape: GetAccountShape<ConcordiumAccount> = async (info, syncConfig) => {
   const { currency, derivationMode, derivationPath, index, initialAccount, rest = {} } = info;
 
   const publicKey = rest.publicKey || initialAccount?.concordiumResources?.publicKey;
@@ -104,13 +121,19 @@ export const getAccountShape: GetAccountShape<ConcordiumAccount> = async info =>
     const accountsResponse = await getAccountsByPublicKey(config, currency.id, publicKey);
 
     if (!accountsResponse?.length) {
+      // An account that does not exist on chain holds no tokens, so this is
+      // authoritative: clear rather than preserve.
       return {
         balance: new BigNumber(0),
         blockHeight: 0,
-        concordiumResources: fillConcordiumResources(initialAccount?.concordiumResources, {
-          publicKey,
-          isOnboarded: false,
-        }),
+        subAccounts: [],
+        concordiumResources: applyTokensToResources(
+          fillConcordiumResources(initialAccount?.concordiumResources, {
+            publicKey,
+            isOnboarded: false,
+          }),
+          { kind: "cleared" },
+        ),
         derivationMode,
         derivationPath,
         id: accountId,
@@ -125,21 +148,37 @@ export const getAccountShape: GetAccountShape<ConcordiumAccount> = async info =>
 
     const account = accountsResponse[0];
 
-    const [{ balance, spendableBalance }, operations, blockHeight] = await Promise.all([
-      getBalance(currency.id, account.address),
-      syncOperations(currency.id, account.address, accountId, initialAccount?.operations ?? []),
-      getConsensusInfo(config, currency.id)
-        .then(info => info.lastFinalizedBlockHeight)
-        .catch(() => 0),
-    ]);
+    const [{ balance, spendableBalance, accountTokens }, operations, blockHeight] =
+      await Promise.all([
+        getBalance(currency.id, account.address),
+        syncOperations(currency.id, account.address, accountId, initialAccount?.operations ?? []),
+        getConsensusInfo(config, currency.id)
+          .then(info => info.lastFinalizedBlockHeight)
+          .catch(() => 0),
+      ]);
+
+    const resolvedTokens = await resolveTokenSubAccounts({
+      enableTokens: config.enableTokens,
+      currencyId: currency.id,
+      accountId,
+      accountTokens,
+      initialAccount,
+      ...(syncConfig?.blacklistedTokenIds
+        ? { blacklistedTokenIds: syncConfig.blacklistedTokenIds }
+        : {}),
+    });
 
     return {
       balance,
       blockHeight,
-      concordiumResources: fillConcordiumResources(initialAccount?.concordiumResources, {
-        isOnboarded: true,
-        publicKey,
-      }),
+      ...subAccountsPatch(resolvedTokens),
+      concordiumResources: applyTokensToResources(
+        fillConcordiumResources(initialAccount?.concordiumResources, {
+          isOnboarded: true,
+          publicKey,
+        }),
+        resolvedTokens,
+      ),
       freshAddress: account.address,
       seedIdentifier: publicKey,
       derivationMode,

--- a/libs/coin-modules/coin-concordium/src/bridge/tokens.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/tokens.test.ts
@@ -1,0 +1,506 @@
+import BigNumber from "bignumber.js";
+import { encodeTokenAccountId } from "@ledgerhq/ledger-wallet-framework/account";
+import { setCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
+import {
+  CryptoCurrencyIdSchema,
+  TokenCurrencyIdSchema,
+  type TokenCurrency,
+} from "@ledgerhq/ledger-wallet-framework/types";
+import type { Operation, TokenAccount } from "@ledgerhq/types-live";
+import {
+  applyTokensToResources,
+  mergeSubAccounts,
+  resolveTokenSubAccounts,
+  stripSubAccounts,
+  subAccountsPatch,
+} from "./tokens";
+import type {
+  ConcordiumAccount,
+  ConcordiumResources,
+  PltAccountToken,
+  PltModuleState,
+} from "../types";
+
+const CURRENCY_ID = "concordium";
+const ACCOUNT_ID = "js:2:concordium:pubkey:";
+const TOKEN_ID = "t-USDT";
+
+const makeToken = (contractAddress: string, magnitude = 6): TokenCurrency => ({
+  type: "TokenCurrency",
+  id: TokenCurrencyIdSchema.parse(`concordium/plt/${contractAddress.toLowerCase()}`),
+  contractAddress,
+  parentCurrencyId: CryptoCurrencyIdSchema.parse(CURRENCY_ID),
+  tokenType: "plt",
+  name: contractAddress,
+  ticker: contractAddress,
+  delisted: false,
+  disableCountervalue: false,
+  units: [{ name: contractAddress, code: contractAddress, magnitude }],
+});
+
+const makeEntry = ({
+  tokenId = TOKEN_ID,
+  balance = "1000000",
+  decimals = 6,
+  moduleState = {} as PltModuleState | string,
+  accountState,
+}: {
+  tokenId?: string;
+  balance?: string;
+  decimals?: number;
+  moduleState?: PltModuleState | string;
+  accountState?: PltAccountToken["tokenAccountState"]["state"];
+} = {}): PltAccountToken =>
+  ({
+    token: {
+      tokenId,
+      tokenState: {
+        tokenModuleRef: "ref",
+        decimals,
+        totalSupply: { value: "1", decimals },
+        moduleState,
+      },
+    },
+    tokenAccountState: {
+      balance: { value: balance, decimals },
+      ...(accountState === undefined ? {} : { state: accountState }),
+    },
+  }) as PltAccountToken;
+
+const useStore = (tokens: Record<string, TokenCurrency | undefined>) =>
+  setCryptoAssetsStore({
+    findTokenById: async () => undefined,
+    getTokensSyncHash: async () => "hash",
+    findTokenByAddressInCurrency: jest.fn(async (address: string) => tokens[address]),
+  });
+
+const resolve = (over: Partial<Parameters<typeof resolveTokenSubAccounts>[0]> = {}) =>
+  resolveTokenSubAccounts({
+    enableTokens: true,
+    currencyId: CURRENCY_ID,
+    accountId: ACCOUNT_ID,
+    accountTokens: [makeEntry()],
+    initialAccount: undefined,
+    ...over,
+  });
+
+describe("resolveTokenSubAccounts", () => {
+  beforeEach(() => {
+    useStore({ [TOKEN_ID]: makeToken(TOKEN_ID) });
+  });
+
+  it("clears when the feature is off, whatever the chain reports", async () => {
+    await expect(resolve({ enableTokens: false })).resolves.toEqual({ kind: "cleared" });
+  });
+
+  it("builds a sub-account for any curated token, with no token special-cased", async () => {
+    useStore({ AAA: makeToken("AAA"), BBB: makeToken("BBB") });
+
+    const result = await resolve({
+      accountTokens: [
+        makeEntry({ tokenId: "AAA", balance: "1" }),
+        makeEntry({ tokenId: "BBB", balance: "2" }),
+      ],
+    });
+
+    expect(result.kind).toBe("resolved");
+    if (result.kind !== "resolved") return;
+    expect(result.subAccounts.map(s => s.token.contractAddress)).toEqual(["AAA", "BBB"]);
+    expect(result.subAccounts.map(s => s.balance.toString())).toEqual(["1", "2"]);
+  });
+
+  it("sets balance and spendableBalance from the chain value", async () => {
+    const result = await resolve({ accountTokens: [makeEntry({ balance: "42" })] });
+
+    if (result.kind !== "resolved") throw new Error("expected resolved");
+    const [sub] = result.subAccounts;
+    expect(sub.balance).toEqual(new BigNumber("42"));
+    expect(sub.spendableBalance).toEqual(new BigNumber("42"));
+    expect(sub.id).toBe(encodeTokenAccountId(ACCOUNT_ID, makeToken(TOKEN_ID)));
+    expect(sub.parentId).toBe(ACCOUNT_ID);
+  });
+
+  it("skips a token that is not in the CAL, without failing the sync", async () => {
+    useStore({});
+
+    const result = await resolve();
+
+    expect(result).toEqual({ kind: "resolved", subAccounts: [], tokens: {} });
+  });
+
+  it("publishes no balance for a token whose CAL magnitude disagrees with the chain", async () => {
+    useStore({ [TOKEN_ID]: makeToken(TOKEN_ID, 8) });
+
+    const result = await resolve({ accountTokens: [makeEntry({ decimals: 6 })] });
+
+    expect(result).toEqual({ kind: "resolved", subAccounts: [], tokens: {} });
+  });
+
+  it("keeps an existing sub-account when the decimals disagree, rather than deleting it", async () => {
+    const token = makeToken(TOKEN_ID, 8);
+    const subId = encodeTokenAccountId(ACCOUNT_ID, token);
+    useStore({ [TOKEN_ID]: token });
+
+    const initialAccount = {
+      subAccounts: [
+        {
+          type: "TokenAccount",
+          id: subId,
+          parentId: ACCOUNT_ID,
+          token,
+          balance: new BigNumber(5),
+          spendableBalance: new BigNumber(5),
+          creationDate: new Date(0),
+          operations: [],
+          operationsCount: 0,
+          pendingOperations: [],
+          balanceHistoryCache: {},
+          swapHistory: [],
+        },
+      ],
+    } as unknown as ConcordiumAccount;
+
+    const result = await resolve({ initialAccount, accountTokens: [makeEntry({ decimals: 6 })] });
+
+    if (result.kind !== "resolved") throw new Error("expected resolved");
+    expect(result.subAccounts.map(s => s.id)).toEqual([subId]);
+    expect(result.subAccounts[0].balance).toEqual(new BigNumber(5));
+    // A data fault must not be reported as the account no longer holding it.
+    expect(result.tokens).toEqual({});
+  });
+
+  describe("authority of the token list", () => {
+    it("treats a missing accountTokens as no information and keeps what exists", async () => {
+      await expect(resolve({ accountTokens: undefined })).resolves.toEqual({ kind: "unchanged" });
+    });
+
+    it("treats a non-array accountTokens as no information", async () => {
+      await expect(
+        resolve({ accountTokens: null as unknown as PltAccountToken[] }),
+      ).resolves.toEqual({ kind: "unchanged" });
+    });
+
+    it("treats an empty array as authoritative, not as missing", async () => {
+      const result = await resolve({ accountTokens: [] });
+
+      expect(result).toEqual({ kind: "resolved", subAccounts: [], tokens: {} });
+    });
+  });
+
+  it("keeps an existing sub-account when the balance is unusable, rather than showing NaN", async () => {
+    const token = makeToken(TOKEN_ID);
+    const subId = encodeTokenAccountId(ACCOUNT_ID, token);
+    useStore({ [TOKEN_ID]: token });
+
+    const broken = makeEntry();
+    // The response is not schema-checked, so a missing value is reachable.
+    (broken.tokenAccountState as { balance?: unknown }).balance = undefined;
+
+    const initialAccount = {
+      subAccounts: [{ id: subId, token, balance: new BigNumber(5), operations: [] }],
+    } as unknown as ConcordiumAccount;
+
+    const result = await resolve({ initialAccount, accountTokens: [broken] });
+
+    if (result.kind !== "resolved") throw new Error("expected resolved");
+    expect(result.subAccounts.map(s => s.id)).toEqual([subId]);
+    expect(result.subAccounts[0].balance).toEqual(new BigNumber(5));
+  });
+
+  it("publishes no sub-account for an unusable balance when none existed before", async () => {
+    const broken = makeEntry({ balance: "not-a-number" });
+
+    const result = await resolve({ accountTokens: [broken] });
+
+    expect(result).toEqual({ kind: "resolved", subAccounts: [], tokens: {} });
+  });
+
+  it("ignores a repeated token id rather than building two sub-accounts for it", async () => {
+    const result = await resolve({
+      accountTokens: [makeEntry({ balance: "1" }), makeEntry({ balance: "2" })],
+    });
+
+    if (result.kind !== "resolved") throw new Error("expected resolved");
+    expect(result.subAccounts).toHaveLength(1);
+    expect(result.subAccounts[0].balance).toEqual(new BigNumber("1"));
+  });
+
+  it("skips a malformed entry and still resolves the rest, rather than aborting the sync", async () => {
+    useStore({ AAA: makeToken("AAA") });
+
+    const result = await resolve({
+      accountTokens: [
+        { token: null } as unknown as PltAccountToken,
+        {} as unknown as PltAccountToken,
+        makeEntry({ tokenId: "AAA", balance: "3" }),
+      ],
+    });
+
+    if (result.kind !== "resolved") throw new Error("expected resolved");
+    expect(result.subAccounts.map(s => s.token.contractAddress)).toEqual(["AAA"]);
+  });
+
+  it("skips a token the user has blacklisted", async () => {
+    const token = makeToken(TOKEN_ID);
+    useStore({ [TOKEN_ID]: token });
+
+    const result = await resolve({ blacklistedTokenIds: [token.id] });
+
+    expect(result).toEqual({ kind: "resolved", subAccounts: [], tokens: {} });
+  });
+
+  it("does not blacklist a different token that happens to share a prefix", async () => {
+    useStore({ [TOKEN_ID]: makeToken(TOKEN_ID) });
+
+    const result = await resolve({ blacklistedTokenIds: ["concordium/plt/t-usd"] });
+
+    if (result.kind !== "resolved") throw new Error("expected resolved");
+    expect(result.subAccounts).toHaveLength(1);
+  });
+
+  it("skips a CAL entry with no units, which cannot be denominated", async () => {
+    const unitless = { ...makeToken(TOKEN_ID), units: [] } as unknown as ReturnType<
+      typeof makeToken
+    >;
+    useStore({ [TOKEN_ID]: unitless });
+
+    const result = await resolve();
+
+    expect(result).toEqual({ kind: "resolved", subAccounts: [], tokens: {} });
+  });
+
+  it("keeps known tokens when the CAL lookup itself fails, rather than failing the sync", async () => {
+    // The injected store throws on a query error instead of returning undefined
+    // (buildCryptoAssetsStore.ts), so a CAL outage rejects here.
+    setCryptoAssetsStore({
+      findTokenById: async () => undefined,
+      getTokensSyncHash: async () => "hash",
+      findTokenByAddressInCurrency: jest.fn(async () => {
+        throw new Error("CAL is down");
+      }),
+    });
+
+    await expect(resolve()).resolves.toEqual({ kind: "unchanged" });
+  });
+
+  it("carries the prior token state over for a token it could not trust", async () => {
+    const token = makeToken(TOKEN_ID, 8);
+    useStore({ [TOKEN_ID]: token });
+
+    const initialAccount = {
+      subAccounts: [
+        { id: encodeTokenAccountId(ACCOUNT_ID, token), token, balance: new BigNumber(5) },
+      ],
+      concordiumResources: { tokens: { [TOKEN_ID]: { transferStatus: "blocked", paused: true } } },
+    } as unknown as ConcordiumAccount;
+
+    const result = await resolve({ initialAccount, accountTokens: [makeEntry({ decimals: 6 })] });
+
+    if (result.kind !== "resolved") throw new Error("expected resolved");
+    // A preserved sub-account with no transferStatus would leave the send path
+    // unable to tell whether the token is restricted.
+    expect(result.tokens[TOKEN_ID]).toEqual({ transferStatus: "blocked", paused: true });
+  });
+
+  describe("transferStatus", () => {
+    it("is blocked for a paused token even when the lists allow the account", async () => {
+      const result = await resolve({
+        accountTokens: [makeEntry({ moduleState: { paused: true } })],
+      });
+
+      if (result.kind !== "resolved") throw new Error("expected resolved");
+      expect(result.tokens[TOKEN_ID]).toEqual({ transferStatus: "blocked", paused: true });
+    });
+
+    it("is allowed for a token that declares neither list nor pause", async () => {
+      const result = await resolve();
+
+      if (result.kind !== "resolved") throw new Error("expected resolved");
+      expect(result.tokens[TOKEN_ID].transferStatus).toBe("allowed");
+    });
+
+    it("is blocked for an allow-list token the account is not on", async () => {
+      const result = await resolve({
+        accountTokens: [makeEntry({ moduleState: { allowList: true } })],
+      });
+
+      if (result.kind !== "resolved") throw new Error("expected resolved");
+      expect(result.tokens[TOKEN_ID].transferStatus).toBe("blocked");
+    });
+
+    it("is unknown, and omits paused, when the module state did not decode", async () => {
+      const result = await resolve({ accountTokens: [makeEntry({ moduleState: "a1b2c3" })] });
+
+      if (result.kind !== "resolved") throw new Error("expected resolved");
+      expect(result.tokens[TOKEN_ID]).toEqual({ transferStatus: "unknown" });
+      expect(result.tokens[TOKEN_ID]).not.toHaveProperty("paused");
+    });
+  });
+});
+
+describe("mergeSubAccounts", () => {
+  const token = makeToken(TOKEN_ID);
+  const subId = encodeTokenAccountId(ACCOUNT_ID, token);
+
+  // `date` is required: mergeOps sorts on it and compares `newOps[0].date >= o.date`,
+  // so an undated operation is silently discarded.
+  const operation = (id: string, date: Date): Operation =>
+    ({ id, hash: id, accountId: subId, type: "IN", value: new BigNumber(1), date }) as Operation;
+
+  const OLD_DATE = new Date("2026-01-01T00:00:00Z");
+  const NEW_DATE = new Date("2026-02-01T00:00:00Z");
+
+  const existing = (over: Partial<TokenAccount> = {}): TokenAccount =>
+    ({
+      type: "TokenAccount",
+      id: subId,
+      parentId: ACCOUNT_ID,
+      token,
+      balance: new BigNumber(1),
+      spendableBalance: new BigNumber(1),
+      creationDate: new Date(0),
+      operations: [operation("old", OLD_DATE)],
+      operationsCount: 1,
+      pendingOperations: [],
+      balanceHistoryCache: { HOUR: { latestDate: 1, balances: [1] } },
+      swapHistory: [],
+      ...over,
+    }) as TokenAccount;
+
+  const incoming = (over: Partial<TokenAccount> = {}): TokenAccount =>
+    ({ ...existing(), balance: new BigNumber(9), operations: [], ...over }) as TokenAccount;
+
+  it("returns the new list when there is nothing to merge against", () => {
+    const next = [incoming()];
+    expect(mergeSubAccounts(undefined, next)).toBe(next);
+  });
+
+  it("keeps previous operations and takes the new balance", () => {
+    const [merged] = mergeSubAccounts(
+      [existing()],
+      [incoming({ operations: [operation("new", NEW_DATE)] })],
+    );
+
+    expect(merged.balance).toEqual(new BigNumber(9));
+    expect(merged.operations.map(op => op.id).sort()).toEqual(["new", "old"]);
+    expect(merged.operationsCount).toBe(2);
+  });
+
+  it("preserves balanceHistoryCache, which the balance-history recalculation keys on", () => {
+    const previous = existing();
+    const [merged] = mergeSubAccounts([previous], [incoming()]);
+
+    expect(merged.balanceHistoryCache).toBe(previous.balanceHistoryCache);
+    expect(merged.creationDate).toBe(previous.creationDate);
+  });
+
+  it("takes the token metadata from CAL rather than the stored copy", () => {
+    const renamed = { ...token, name: "Renamed", ticker: "NEW" } as typeof token;
+    const [merged] = mergeSubAccounts([existing()], [incoming({ token: renamed })]);
+
+    expect(merged.token).toBe(renamed);
+  });
+
+  it("keeps a sub-account whose id is listed in keepIds even when absent", () => {
+    const other = makeToken("KEPT");
+    const keptId = encodeTokenAccountId(ACCOUNT_ID, other);
+    const kept = existing({ id: keptId, token: other });
+
+    const merged = mergeSubAccounts([kept, existing()], [incoming()], new Set([keptId]));
+
+    expect(merged.map(s => s.id).sort()).toEqual([keptId, subId].sort());
+  });
+
+  it("drops a previous sub-account the chain no longer reports", () => {
+    const other = makeToken("GONE");
+    const stale = existing({ id: encodeTokenAccountId(ACCOUNT_ID, other), token: other });
+
+    const merged = mergeSubAccounts([stale, existing()], [incoming()]);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].id).toBe(subId);
+  });
+});
+
+describe("applying a result to the account shape", () => {
+  const resources: ConcordiumResources = {
+    isOnboarded: true,
+    credId: "",
+    publicKey: "",
+    identityIndex: 0,
+    credNumber: 0,
+    ipIdentity: 0,
+    tokens: { [TOKEN_ID]: { transferStatus: "allowed" } },
+  };
+
+  it("omits subAccounts when unchanged, so the shallow sync spread keeps the previous array", () => {
+    expect(subAccountsPatch({ kind: "unchanged" })).toEqual({});
+    expect("subAccounts" in subAccountsPatch({ kind: "unchanged" })).toBe(false);
+  });
+
+  it("empties subAccounts when cleared", () => {
+    expect(subAccountsPatch({ kind: "cleared" })).toEqual({ subAccounts: [] });
+  });
+
+  it("strips the subAccounts key entirely, since an empty array still renders a token section", () => {
+    const stripped = stripSubAccounts({ id: "a", subAccounts: [] });
+
+    expect("subAccounts" in stripped).toBe(false);
+    expect(stripped).toEqual({ id: "a" });
+  });
+
+  it("leaves an account without subAccounts untouched", () => {
+    const account: { id: string; subAccounts?: TokenAccount[] } = { id: "a" };
+    expect(stripSubAccounts(account)).toBe(account);
+  });
+
+  it("removes the tokens key entirely when cleared, rather than setting it undefined", () => {
+    const cleared = applyTokensToResources(resources, { kind: "cleared" });
+
+    expect("tokens" in cleared).toBe(false);
+  });
+
+  it("leaves resources untouched when unchanged", () => {
+    expect(applyTokensToResources(resources, { kind: "unchanged" })).toBe(resources);
+  });
+});
+
+describe("initialAccount continuity", () => {
+  it("merges against the previous sub-accounts on a re-sync", async () => {
+    const token = makeToken(TOKEN_ID);
+    const subId = encodeTokenAccountId(ACCOUNT_ID, token);
+    useStore({ [TOKEN_ID]: token });
+
+    const previousOp = {
+      id: "kept",
+      hash: "kept",
+      accountId: subId,
+      type: "IN",
+      date: new Date("2026-01-01T00:00:00Z"),
+    } as Operation;
+    const initialAccount = {
+      subAccounts: [
+        {
+          type: "TokenAccount",
+          id: subId,
+          parentId: ACCOUNT_ID,
+          token,
+          balance: new BigNumber(1),
+          spendableBalance: new BigNumber(1),
+          creationDate: new Date(0),
+          operations: [previousOp],
+          operationsCount: 1,
+          pendingOperations: [],
+          balanceHistoryCache: { HOUR: { latestDate: 1, balances: [1] } },
+          swapHistory: [],
+        },
+      ],
+    } as unknown as ConcordiumAccount;
+
+    const result = await resolve({ initialAccount, accountTokens: [makeEntry({ balance: "77" })] });
+
+    if (result.kind !== "resolved") throw new Error("expected resolved");
+    expect(result.subAccounts[0].balance).toEqual(new BigNumber("77"));
+    expect(result.subAccounts[0].operations.map(op => op.id)).toEqual(["kept"]);
+  });
+});

--- a/libs/coin-modules/coin-concordium/src/bridge/tokens.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/tokens.ts
@@ -1,0 +1,384 @@
+import BigNumber from "bignumber.js";
+import { emptyHistoryCache, encodeTokenAccountId } from "@ledgerhq/ledger-wallet-framework/account";
+import { mergeOps } from "@ledgerhq/ledger-wallet-framework/bridge/jsHelpers";
+import { getCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
+import { promiseAllBatched } from "@ledgerhq/coin-module-framework/promises";
+import { log } from "@ledgerhq/logs";
+import type { TokenAccount } from "@ledgerhq/types-live";
+import type { TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";
+import { getAccountListStatus, isDecodedPltState } from "../network/plt";
+import type {
+  ConcordiumAccount,
+  ConcordiumResources,
+  ConcordiumTokenResources,
+  PltAccountToken,
+  PltTransferStatus,
+} from "../types";
+
+const CAL_LOOKUP_CONCURRENCY = 4;
+
+/**
+ * Result of one sync's token resolution.
+ *
+ * Discriminated rather than nullable so that a caller cannot conflate "the
+ * chain says this account holds nothing" with "we learned nothing this round" —
+ * the difference between clearing an account's tokens and preserving them.
+ */
+export type ResolvedTokens =
+  | { kind: "cleared" }
+  | { kind: "unchanged" }
+  | {
+      kind: "resolved";
+      subAccounts: TokenAccount[];
+      tokens: Record<string, ConcordiumTokenResources>;
+    };
+
+/**
+ * Removes `subAccounts` entirely once the account shape has been applied.
+ *
+ * The shape cannot do this itself: `exactOptionalPropertyTypes` forbids an
+ * explicit `undefined`, and omitting the key makes the shallow spread in
+ * `makeSync` keep the previous array — the opposite of clearing. Running after
+ * that spread is what lets the key be dropped rather than emptied.
+ *
+ * It matters because `[]` is not inert. Desktop `TokensList` bails on a falsy
+ * `subAccounts`, but an empty array passes that guard and, once the currency
+ * declares `tokenTypes`, renders the token section and its receive affordance —
+ * for a feature that is switched off.
+ */
+export function stripSubAccounts<A extends { subAccounts?: TokenAccount[] }>(account: A): A {
+  if (!("subAccounts" in account)) return account;
+  const { subAccounts: _dropped, ...rest } = account;
+  return rest as A;
+}
+
+/**
+ * Turns a {@link ResolvedTokens} into the `subAccounts` slice of an account
+ * shape.
+ *
+ * Omitting the key is not the same as emptying it: `makeSync` spreads the shape
+ * over the previous account, so only `unchanged` may omit. `cleared` empties,
+ * and {@link stripSubAccounts} drops the key afterwards.
+ */
+export function subAccountsPatch(resolved: ResolvedTokens): { subAccounts?: TokenAccount[] } {
+  switch (resolved.kind) {
+    case "resolved":
+      return { subAccounts: resolved.subAccounts };
+    case "cleared":
+      return { subAccounts: [] };
+    case "unchanged":
+      return {};
+  }
+}
+
+/**
+ * Applies a {@link ResolvedTokens} to the account's resources.
+ *
+ * Clearing removes the key rather than setting it to `undefined`, matching
+ * `copyResources`, which omits an undefined `tokens` on save.
+ */
+export function applyTokensToResources(
+  resources: ConcordiumResources,
+  resolved: ResolvedTokens,
+): ConcordiumResources {
+  switch (resolved.kind) {
+    case "resolved":
+      return { ...resources, tokens: resolved.tokens };
+    case "cleared": {
+      const { tokens: _cleared, ...withoutTokens } = resources;
+      return withoutTokens;
+    }
+    case "unchanged":
+      return resources;
+  }
+}
+
+function buildTokenAccount(
+  id: string,
+  parentId: string,
+  token: TokenCurrency,
+  balance: BigNumber,
+): TokenAccount {
+  return {
+    type: "TokenAccount",
+    id,
+    parentId,
+    token,
+    balance,
+    spendableBalance: balance,
+    creationDate: new Date(),
+    operations: [],
+    operationsCount: 0,
+    pendingOperations: [],
+    balanceHistoryCache: emptyHistoryCache,
+    swapHistory: [],
+  };
+}
+
+/**
+ * Folds pause state and both list rules into the single verdict the send path
+ * reads.
+ *
+ * Not interchangeable with `getAccountListStatus`, which answers only the list
+ * half. The two share a shape, so assigning one to the other compiles and would
+ * let a paused token through.
+ */
+function resolveTransferStatus(entry: PltAccountToken): PltTransferStatus {
+  const moduleState = entry.token.tokenState.moduleState;
+  if (!isDecodedPltState(moduleState)) return "unknown";
+  if (moduleState.paused === true) return "blocked";
+  return getAccountListStatus(entry);
+}
+
+/**
+ * Checks the fields this module dereferences before it reads them.
+ *
+ * `Array.isArray` establishes the container, not the entries, and the response
+ * is not schema-checked. Validating here costs one token; throwing on a nested
+ * access costs the whole account sync.
+ */
+function isUsableEntry(entry: PltAccountToken): boolean {
+  return (
+    typeof entry?.token?.tokenId === "string" &&
+    entry.token.tokenId.length > 0 &&
+    typeof entry.token.tokenState?.decimals === "number"
+  );
+}
+
+function readPaused(entry: PltAccountToken): boolean | undefined {
+  const moduleState = entry.token.tokenState.moduleState;
+  return isDecodedPltState(moduleState) ? moduleState.paused : undefined;
+}
+
+/**
+ * Merges freshly built sub-accounts onto the previous ones, keyed by
+ * sub-account id.
+ *
+ * Only the listed properties are taken from the new object, so anything the
+ * previous sync established and this one does not know about survives. Notably
+ * `balanceHistoryCache` is preserved: `recalculateAccountBalanceHistories`
+ * regenerates a sub-account's cache only when it is reference-identical to the
+ * previous one, so replacing it every sync would defeat that check.
+ *
+ * Unlike the coin-hedera helper this is modelled on, a previous sub-account
+ * absent from `newSubAccounts` is dropped rather than carried forward. Callers
+ * must therefore only reach this with an authoritative token list — see
+ * {@link resolveTokenSubAccounts}.
+ *
+ * `keepIds` is the exception: ids listed there survive even when absent. It
+ * carries tokens the chain still reports but this sync could not trust, so that
+ * a data fault is never expressed as the account no longer holding the asset.
+ */
+export function mergeSubAccounts(
+  previous: TokenAccount[] | undefined,
+  newSubAccounts: TokenAccount[],
+  keepIds: ReadonlySet<string> = new Set(),
+): TokenAccount[] {
+  if (!previous?.length) return newSubAccounts;
+
+  const previousById = new Map(previous.map(sub => [sub.id, sub]));
+
+  const merged = newSubAccounts.map(newSubAccount => {
+    const old = previousById.get(newSubAccount.id);
+    if (!old) return newSubAccount;
+
+    const operations = mergeOps(old.operations, newSubAccount.operations);
+
+    return {
+      ...old,
+      // Taken from the new object: CAL is the source of token metadata, and a
+      // renamed or re-denominated token must not keep the stored copy.
+      token: newSubAccount.token,
+      balance: newSubAccount.balance,
+      spendableBalance: newSubAccount.spendableBalance,
+      operations,
+      operationsCount: operations.length,
+    };
+  });
+
+  const mergedIds = new Set(merged.map(sub => sub.id));
+  const kept = previous.filter(sub => keepIds.has(sub.id) && !mergedIds.has(sub.id));
+
+  return [...merged, ...kept];
+}
+
+type ResolvedEntry =
+  | { entry: PltAccountToken; token: TokenCurrency; tokenId: string; balance: BigNumber }
+  | { untrusted: string; tokenId: string }
+  | undefined;
+
+/**
+ * Resolves to `undefined` when the lookup itself failed, which is distinct from
+ * an entry resolving to `undefined` because the token is not curated.
+ */
+function resolveEntries({
+  accountTokens,
+  currencyId,
+  accountId,
+  blacklistedTokenIds,
+}: {
+  accountTokens: PltAccountToken[];
+  currencyId: string;
+  accountId: string;
+  blacklistedTokenIds: string[];
+}): Promise<ResolvedEntry[] | undefined> {
+  return promiseAllBatched(
+    CAL_LOOKUP_CONCURRENCY,
+    accountTokens,
+    async (entry: PltAccountToken): Promise<ResolvedEntry> => {
+      if (!isUsableEntry(entry)) {
+        log("concordium-sync", "PLT entry is malformed, skipping it and continuing the sync");
+        return undefined;
+      }
+
+      const tokenId = entry.token.tokenId;
+      const token = await getCryptoAssetsStore().findTokenByAddressInCurrency(tokenId, currencyId);
+
+      if (!token) {
+        log("concordium-sync", `PLT ${tokenId} is not in the CAL, skipping`);
+        return undefined;
+      }
+
+      // A user-hidden token is a deliberate absence, so it drops like an
+      // uncurated one rather than being preserved.
+      if (blacklistedTokenIds.includes(token.id)) {
+        return undefined;
+      }
+
+      // Balances arrive in the smallest unit, so both cases below leave the
+      // amount undenominable. Both preserve the existing sub-account rather
+      // than dropping it — a data fault must not read as a vanished asset — and
+      // are logged separately because the remedies differ.
+      const chainDecimals = entry.token.tokenState.decimals;
+      const calMagnitude = token.units[0]?.magnitude;
+
+      if (calMagnitude === undefined) {
+        log(
+          "concordium-sync",
+          `PLT ${tokenId} has no CAL unit to denominate it, keeping the previous sub-account`,
+        );
+        return { untrusted: encodeTokenAccountId(accountId, token), tokenId };
+      }
+
+      if (calMagnitude !== chainDecimals) {
+        log(
+          "concordium-sync",
+          `PLT ${tokenId} decimals mismatch: CAL ${calMagnitude}, chain ${chainDecimals}, keeping the previous sub-account`,
+        );
+        return { untrusted: encodeTokenAccountId(accountId, token), tokenId };
+      }
+
+      // An absent or non-numeric balance would otherwise reach BigNumber and
+      // produce a NaN sub-account, which renders as a broken amount rather than
+      // as an error.
+      const balance = new BigNumber(entry.tokenAccountState?.balance?.value);
+      if (!balance.isFinite()) {
+        log(
+          "concordium-sync",
+          `PLT ${tokenId} has an unusable balance, keeping the previous sub-account`,
+        );
+        return { untrusted: encodeTokenAccountId(accountId, token), tokenId };
+      }
+
+      return { entry, token, tokenId, balance };
+    },
+  ).catch((error: unknown) => {
+    log("concordium-sync", "PLT metadata lookup failed, keeping known tokens", { error });
+    return undefined;
+  });
+}
+
+/**
+ * Builds the token sub-accounts and the per-token state for one sync.
+ *
+ * Only an actual array is authoritative enough to drop a token the account no
+ * longer holds. Anything else preserves, because the absent list is reachable
+ * on an HTTP 200: `getAccountBalance` performs no runtime validation, so a
+ * response omitting `accountTokens` satisfies the declared type while carrying
+ * nothing, and reading that as empty would delete every sub-account and its
+ * operations.
+ */
+export async function resolveTokenSubAccounts({
+  enableTokens,
+  currencyId,
+  accountId,
+  accountTokens,
+  initialAccount,
+  blacklistedTokenIds = [],
+}: {
+  enableTokens: boolean;
+  currencyId: string;
+  accountId: string;
+  accountTokens: PltAccountToken[] | undefined;
+  initialAccount: ConcordiumAccount | undefined;
+  blacklistedTokenIds?: string[];
+}): Promise<ResolvedTokens> {
+  if (!enableTokens) {
+    return { kind: "cleared" };
+  }
+
+  if (!Array.isArray(accountTokens)) {
+    log("concordium-sync", "PLT token list absent from the balance response, keeping known tokens");
+    return { kind: "unchanged" };
+  }
+
+  const resolved = await resolveEntries({
+    accountTokens,
+    currencyId,
+    accountId,
+    blacklistedTokenIds,
+  });
+
+  // A CAL query error rejects rather than returning undefined, and one rejection
+  // fails the whole batch. `getAccountShape` only logs and rethrows, so letting
+  // it escape would discard an already-fetched CCD sync because a secondary
+  // metadata service was down.
+  if (resolved === undefined) {
+    return { kind: "unchanged" };
+  }
+
+  const newSubAccounts: TokenAccount[] = [];
+  const tokens: Record<string, ConcordiumTokenResources> = {};
+  const untrustedIds = new Set<string>();
+  const seenIds = new Set<string>();
+
+  for (const item of resolved) {
+    if (!item) continue;
+
+    if ("untrusted" in item) {
+      untrustedIds.add(item.untrusted);
+
+      // The sub-account survives through `keepIds`, but the resources map is
+      // rebuilt wholesale, so its prior entry has to be carried over with it.
+      // Otherwise the send path sees a visible token with no transferStatus.
+      const priorState = initialAccount?.concordiumResources?.tokens?.[item.tokenId];
+      if (priorState) tokens[item.tokenId] = priorState;
+      continue;
+    }
+
+    const { entry, token, tokenId, balance } = item;
+    const subAccountId = encodeTokenAccountId(accountId, token);
+
+    // A duplicate id would otherwise produce two sub-accounts for one token,
+    // which the merge cannot reconcile. Only a malformed snapshot can cause it.
+    if (seenIds.has(subAccountId)) {
+      log("concordium-sync", `PLT ${tokenId} appears more than once, ignoring the repeat`);
+      continue;
+    }
+    seenIds.add(subAccountId);
+
+    newSubAccounts.push(buildTokenAccount(subAccountId, accountId, token, balance));
+
+    const paused = readPaused(entry);
+    tokens[tokenId] = {
+      transferStatus: resolveTransferStatus(entry),
+      ...(paused === undefined ? {} : { paused }),
+    };
+  }
+
+  return {
+    kind: "resolved",
+    subAccounts: mergeSubAccounts(initialAccount?.subAccounts, newSubAccounts, untrustedIds),
+    tokens,
+  };
+}

--- a/libs/coin-modules/coin-concordium/src/logic/account/getBalance.test.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/account/getBalance.test.ts
@@ -1,0 +1,89 @@
+import { getBalance } from "./getBalance";
+import type { ConcordiumCoinConfig } from "../../types";
+
+jest.mock("../../network/proxyClient", () => ({ getAccountBalance: jest.fn() }));
+
+const { getAccountBalance } = jest.requireMock("../../network/proxyClient");
+
+const CONFIG = {} as ConcordiumCoinConfig;
+const ADDRESS = "3a9gh23nNY3kH4k3ajaCqAbM8rcbWMor2VhEzQ6qkn2r17UU7w";
+
+const entry = (tokenId: string, value: string) => ({
+  token: { tokenId },
+  tokenAccountState: { balance: { value, decimals: 6 } },
+});
+
+describe("api getBalance", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("reports the native balance", async () => {
+    getAccountBalance.mockResolvedValue({ finalizedBalance: { accountAmount: "10000000" } });
+
+    await expect(getBalance(CONFIG, ADDRESS, "concordium")).resolves.toEqual([
+      { asset: { type: "native" }, value: 10000000n },
+    ]);
+  });
+
+  it("reports one entry per PLT, keyed by the on-chain token id and the holder", async () => {
+    getAccountBalance.mockResolvedValue({
+      finalizedBalance: {
+        accountAmount: "1",
+        accountTokens: [entry("t-USDT", "500000"), entry("USDR", "7")],
+      },
+    });
+
+    const result = await getBalance(CONFIG, ADDRESS, "concordium");
+
+    expect(result).toEqual([
+      { asset: { type: "native" }, value: 1n },
+      { asset: { type: "plt", assetReference: "t-USDT", assetOwner: ADDRESS }, value: 500000n },
+      { asset: { type: "plt", assetReference: "USDR", assetOwner: ADDRESS }, value: 7n },
+    ]);
+  });
+
+  it("keeps the exact case of the on-chain token id", async () => {
+    getAccountBalance.mockResolvedValue({
+      finalizedBalance: { accountAmount: "0", accountTokens: [entry("t-USDT", "1")] },
+    });
+
+    const [, plt] = await getBalance(CONFIG, ADDRESS, "concordium");
+
+    expect(plt.asset).toMatchObject({ assetReference: "t-USDT" });
+  });
+
+  it("omits a malformed token entry and still reports the native balance", async () => {
+    getAccountBalance.mockResolvedValue({
+      finalizedBalance: {
+        accountAmount: "1",
+        accountTokens: [
+          { token: null },
+          {},
+          { token: { tokenId: "t-USDT" }, tokenAccountState: { balance: { value: "oops" } } },
+          entry("USDR", "9"),
+        ],
+      },
+    });
+
+    // One bad entry must not discard the native balance with it.
+    await expect(getBalance(CONFIG, ADDRESS, "concordium")).resolves.toEqual([
+      { asset: { type: "native" }, value: 1n },
+      { asset: { type: "plt", assetReference: "USDR", assetOwner: ADDRESS }, value: 9n },
+    ]);
+  });
+
+  it("reports no token balances, rather than throwing, when the response omits the list", async () => {
+    getAccountBalance.mockResolvedValue({ finalizedBalance: { accountAmount: "1" } });
+
+    await expect(getBalance(CONFIG, ADDRESS, "concordium")).resolves.toHaveLength(1);
+  });
+
+  it("does not report a PLT this account holds no entry for", async () => {
+    getAccountBalance.mockResolvedValue({
+      finalizedBalance: { accountAmount: "1", accountTokens: [] },
+    });
+
+    await expect(getBalance(CONFIG, ADDRESS, "concordium")).resolves.toEqual([
+      { asset: { type: "native" }, value: 1n },
+    ]);
+  });
+});

--- a/libs/coin-modules/coin-concordium/src/logic/account/getBalance.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/account/getBalance.ts
@@ -1,6 +1,32 @@
 import type { Balance } from "@ledgerhq/coin-module-framework/api/types";
+import { log } from "@ledgerhq/logs";
 import { getAccountBalance } from "../../network/proxyClient";
-import type { ConcordiumCoinConfig } from "../../types";
+import type { ConcordiumCoinConfig, PltAccountToken } from "../../types";
+
+/**
+ * The bridge guards the same fields through `isUsableEntry`. This surface reads
+ * the same unvalidated response and needs its own guard, or one malformed entry
+ * would throw and discard the native CCD balance with it.
+ */
+function toPltBalance(entry: PltAccountToken, address: string): Balance | undefined {
+  const tokenId = entry?.token?.tokenId;
+  const rawValue = entry?.tokenAccountState?.balance?.value;
+
+  if (typeof tokenId !== "string" || tokenId.length === 0) return undefined;
+
+  let value: bigint;
+  try {
+    value = BigInt(rawValue);
+  } catch {
+    log("concordium-api", `PLT ${tokenId} has an unusable balance, omitting it`);
+    return undefined;
+  }
+
+  return {
+    asset: { type: "plt", assetReference: tokenId, assetOwner: address },
+    value,
+  };
+}
 
 export async function getBalance(
   config: ConcordiumCoinConfig,
@@ -8,7 +34,18 @@ export async function getBalance(
   currencyId: string,
 ): Promise<Balance[]> {
   const balanceResponse = await getAccountBalance(config, currencyId, address);
-  return [
-    { asset: { type: "native" }, value: BigInt(balanceResponse.finalizedBalance.accountAmount) },
-  ];
+  const { accountAmount, accountTokens } = balanceResponse.finalizedBalance;
+
+  const native: Balance = { asset: { type: "native" }, value: BigInt(accountAmount) };
+
+  // Unlike the bridge, this surface reports what the chain says and holds no
+  // prior state, so an absent list is simply no token balances. The response is
+  // not runtime-validated, hence the array check rather than a bare access.
+  if (!Array.isArray(accountTokens)) return [native];
+
+  const plt = accountTokens
+    .map(entry => toPltBalance(entry, address))
+    .filter((balance): balance is Balance => balance !== undefined);
+
+  return [native, ...plt];
 }

--- a/libs/coin-modules/coin-concordium/src/test/fixtures.ts
+++ b/libs/coin-modules/coin-concordium/src/test/fixtures.ts
@@ -30,6 +30,8 @@ export const TESTNET_COIN_CONFIG: ConcordiumConfig = {
   networkType: "testnet",
   proxyUrl: "https://ccd-wallet-proxy-testnet.coin.ledger-test.com",
   minReserve: 100000,
+  // Matches the shipped default. Token tests opt in through `setupTestnetCoinConfig`.
+  enableTokens: false,
 };
 
 export function setupTestnetCoinConfig(overrides?: Partial<ConcordiumCoinConfig>): void {

--- a/libs/coin-modules/coin-concordium/src/types/config.ts
+++ b/libs/coin-modules/coin-concordium/src/types/config.ts
@@ -6,6 +6,12 @@ export type ConcordiumConfig = {
   networkType: ConcordiumNetwork;
   proxyUrl: string;
   minReserve: number;
+  /**
+   * Gates PLT token sub-accounts. Off means the wallet syncs exactly as it did
+   * before tokens existed, so history and send validation can land behind it
+   * without a user ever seeing a balance they cannot spend.
+   */
+  enableTokens: boolean;
 };
 
 export type ConcordiumCoinConfig = CurrencyConfig & ConcordiumConfig;

--- a/libs/ledger-live-common/src/families/concordium/config.ts
+++ b/libs/ledger-live-common/src/families/concordium/config.ts
@@ -9,6 +9,7 @@ export const concordiumConfig: Record<string, ConfigInfo> = {
       networkType: "mainnet",
       proxyUrl: "https://ccd-wallet-proxy-mainnet.coin.ledger.com",
       minReserve: 0,
+      enableTokens: false,
     } satisfies ConcordiumCoinConfig,
   },
   config_currency_concordium_testnet: {
@@ -18,6 +19,7 @@ export const concordiumConfig: Record<string, ConfigInfo> = {
       networkType: "testnet",
       proxyUrl: "https://ccd-wallet-proxy-testnet.coin.ledger-test.com",
       minReserve: 0,
+      enableTokens: false,
     } satisfies ConcordiumCoinConfig,
   },
 };


### PR DESCRIPTION
### 📝 Description

PLT (CIS-7) token sub-accounts during Concordium account sync, behind a new `enableTokens` coin config flag, defaulted **off**.

Flag off means no behaviour change — pinned by the `getAccountShape with tokens disabled` suite in `bridge/sync.test.ts`, which uses a chain response that does carry a PLT.

#### Notes

- Mirrors **coin-hedera**, not coin-aleo as the ticket says.
- CAL lookup is by `contract_address`: the `tokens.csv` id, the CAL service id and the chain id all differ.
- A sub-account absent from an **authoritative** token list is dropped. A data fault (decimals mismatch, unusable balance, CAL failure) preserves it instead.
- The flag is enforced in `postSync` for both `makeSync` and `makeScanAccounts`, and in `assignFromAccountRaw` — deserialization assigns raw sub-accounts and no `postSync` covers it.
- `api/getBalance` reports PLT ungated (chain view); `craftTransaction` and `estimateFees` reject non-native assets. Those rejects have no caller today — **keep until LIVE-28337**.
- `syncConfig.blacklistedTokenIds` honoured.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-28332](https://ledgerhq.atlassian.net/browse/LIVE-28332)
- **ADR** (if any): n/a


[LIVE-28332]: https://ledgerhq.atlassian.net/browse/LIVE-28332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ