### PR TITLE
refactor(wallet-analytics): inline meaningfulPercentage

### DIFF
--- a/.changeset/inline-meaningful-percentage.md
+++ b/.changeset/inline-meaningful-percentage.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/wallet-analytics": minor
+"@ledgerhq/live-countervalues": minor
+---
+
+wallet-analytics: inline `meaningfulPercentage` as a private utility, removing the `/portfolio` import edge. `live-countervalues`: un-export `meaningfulPercentage` (private implementation detail).

--- a/libs/live-countervalues/src/portfolio.ts
+++ b/libs/live-countervalues/src/portfolio.ts
@@ -137,7 +137,7 @@ function getBalanceHistoryWithChanges(
   };
 }
 
-export function meaningfulPercentage(
+function meaningfulPercentage(
   deltaChange: number | null | undefined,
   balanceDivider: number | null | undefined,
   percentageHighThreshold = 100000,

--- a/libs/wallet-analytics/src/__tests__/meaningfulPercentage.test.ts
+++ b/libs/wallet-analytics/src/__tests__/meaningfulPercentage.test.ts
@@ -21,7 +21,7 @@ describe("meaningfulPercentage", () => {
     expect(meaningfulPercentage(100001, 1)).toBeUndefined();
   });
 
-  it("returns the percentage when it exactly equals the threshold minus epsilon", () => {
+  it("returns the percentage when it is one below the threshold", () => {
     expect(meaningfulPercentage(99999, 1)).toBe(99999);
   });
 

--- a/libs/wallet-analytics/src/__tests__/meaningfulPercentage.test.ts
+++ b/libs/wallet-analytics/src/__tests__/meaningfulPercentage.test.ts
@@ -1,0 +1,32 @@
+import { meaningfulPercentage } from "../meaningfulPercentage";
+
+describe("meaningfulPercentage", () => {
+  it("returns the percentage when inputs are valid", () => {
+    expect(meaningfulPercentage(10, 100)).toBe(0.1);
+  });
+
+  it("returns undefined (not null, not 0) when deltaChange is falsy", () => {
+    expect(meaningfulPercentage(0, 100)).toBeUndefined();
+    expect(meaningfulPercentage(null, 100)).toBeUndefined();
+    expect(meaningfulPercentage(undefined, 100)).toBeUndefined();
+  });
+
+  it("returns undefined when balanceDivider is falsy or zero", () => {
+    expect(meaningfulPercentage(10, 0)).toBeUndefined();
+    expect(meaningfulPercentage(10, null)).toBeUndefined();
+    expect(meaningfulPercentage(10, undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when the percentage exceeds the threshold", () => {
+    expect(meaningfulPercentage(100001, 1)).toBeUndefined();
+  });
+
+  it("returns the percentage when it exactly equals the threshold minus epsilon", () => {
+    expect(meaningfulPercentage(99999, 1)).toBe(99999);
+  });
+
+  it("respects a custom percentageHighThreshold", () => {
+    expect(meaningfulPercentage(200, 1, 100)).toBeUndefined();
+    expect(meaningfulPercentage(50, 1, 100)).toBe(50);
+  });
+});

--- a/libs/wallet-analytics/src/computeAllTimeValueChangeFromFirstReceive.ts
+++ b/libs/wallet-analytics/src/computeAllTimeValueChangeFromFirstReceive.ts
@@ -4,8 +4,8 @@ import {
 } from "@ledgerhq/ledger-wallet-framework/account/helpers";
 import { getOperationAmountNumber } from "@ledgerhq/ledger-wallet-framework/operation";
 import { calculate } from "@ledgerhq/live-countervalues/logic";
-import { meaningfulPercentage } from "@ledgerhq/live-countervalues/portfolio";
 import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
+import { meaningfulPercentage } from "./meaningfulPercentage";
 import type { Currency } from "@domain/entity-currency";
 import type { AccountLike, ValueChange } from "@ledgerhq/types-live";
 

--- a/libs/wallet-analytics/src/meaningfulPercentage.ts
+++ b/libs/wallet-analytics/src/meaningfulPercentage.ts
@@ -1,0 +1,13 @@
+export function meaningfulPercentage(
+  deltaChange: number | null | undefined,
+  balanceDivider: number | null | undefined,
+  percentageHighThreshold = 100000,
+): number | null | undefined {
+  if (deltaChange && balanceDivider && balanceDivider !== 0) {
+    const percent = deltaChange / balanceDivider;
+
+    if (percent < percentageHighThreshold) {
+      return percent;
+    }
+  }
+}


### PR DESCRIPTION
### 📝 Description

Step 2 of 7 in **Phase -1** of the countervalues domain migration. Gives `libs/wallet-analytics` its own copy of `meaningfulPercentage` and un-exports the original, removing the **last** `@ledgerhq/live-countervalues/portfolio` import in `wallet-analytics`. **No behaviour change.**

`meaningfulPercentage` is pure arithmetic: no countervalues, no account coupling. It must not travel to `live-common` in step 3/7 and must not enter the domain package later, so it leaves now.

### ⚠️ This is a duplication plus a de-export, not a move

`portfolio.ts` calls `meaningfulPercentage` at **4** internal sites (lines 211, 323, 360, 419 — in `getBalanceHistoryWithChanges`, `getPortfolio`, `getCurrencyPortfolio` and `getCurrentBalanceCountervalueChange`), so the function has to keep existing there. End state:

- `wallet-analytics` owns a private copy and imports nothing from `/portfolio`
- `portfolio.ts` keeps a **private, un-exported** copy for its own 4 call sites

Two copies of a 6-line pure function is the intended outcome. The alternative is keeping a package-to-package dependency alive purely to share it. Please don't "fix" this later by re-sharing it.

Deleting it from `portfolio.ts` rather than un-exporting it would have silently broken the `percentage` field in `getPortfolio` and `getCurrencyPortfolio`, with no type error to catch it. The unchanged snapshots below are what prove that didn't happen.

The copied body is verbatim, including the **implicit `undefined`** on the falsy path (not `0`, not `null`) and the `percentageHighThreshold = 100000` default.

### 🔍 Dependency check

`@ledgerhq/live-countervalues` **stays** in `libs/wallet-analytics/package.json`. It still imports `/logic` for `calculate` and `/types` for `CounterValuesState`, so the dependency could not be dropped. Checked rather than assumed.

### ✅ Verification

- `pnpm nx run-many -t typecheck` clean.
- `wallet-analytics`: 16/16 pass, including `computeAllTimeValueChangeFromFirstReceive`. New direct tests cover the threshold and the falsy-path `undefined`.
- `live-countervalues`: 85/85 pass, **9 snapshots unchanged** and never regenerated. This is what proves the 4 internal call sites still behave identically.
- Zero remaining imports of `meaningfulPercentage` from `/portfolio`.

### 🧱 Stack

Second of a 6-branch stack. **Based on [#21499](https://github.com/LedgerHQ/ledger-live/pull/21499) (LIVE-36823), review that one first.** This PR's diff is a single new file, a new test, one import swap, and one removed `export` keyword.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36824](https://ledgerhq.atlassian.net/browse/LIVE-36824) — epic [LIVE-32360](https://ledgerhq.atlassian.net/browse/LIVE-32360)
- **ADR** (if any): [Countervalues Domain Migration Discovery](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7376502960/Countervalues+Domain+Migration+Discovery)


[LIVE-36824]: https://ledgerhq.atlassian.net/browse/LIVE-36824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ