### PR TITLE
[LWDM] feat(send): add Pay success screen (LIVE-36376)

### DIFF
--- a/.changeset/funny-cars-obey.md
+++ b/.changeset/funny-cars-obey.md
@@ -1,0 +1,8 @@
+---
+"@features/flow-pay-contact": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Add a Pay success screen to the Send flow. When the flow is launched from the Pay tab and the transaction succeeds, it now routes to a dedicated `PAY_SUCCESS` step that shows the recipient, amount, source account (with network icon) and a link to the transaction details, instead of the standard confirmation step. Exposes a presentational `PaySuccess` component from `@features/flow-pay-contact` and wires it in ledger-live-desktop via an MVVM `PaySuccessScreen` + `usePaySuccessViewModel`.

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabNewPayment.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayTabNewPayment.ts
@@ -1,9 +1,8 @@
 import { useCallback } from "react";
 import { AssetCategory } from "@domain/api-aggregated-assets";
 import type { Contact } from "@domain/entity-contact";
+import { SEND_FLOW_SOURCE } from "@ledgerhq/live-common/flows/send/types";
 import { useOpenSendFlow } from "LLD/features/Send/hooks/useOpenSendFlow";
-
-const PAY_PAGE = "Pay";
 
 // Card payments only spend stablecoins; filter the account picker by category so the
 // user still picks any supported network without listing every currency id.
@@ -26,7 +25,7 @@ export function usePayTabNewPayment(): UsePayTabNewPayment {
         // same network, then skip to the amount step where the header resolves the prefilled
         // address back to the contact and shows the "To <contact>" header.
         openSendFlow({
-          source: PAY_PAGE,
+          source: SEND_FLOW_SOURCE.PAY,
           currencyIds: [contactAddress.currencyId],
           recipient: contactAddress.address,
           skipRecipientStep: true,
@@ -34,7 +33,7 @@ export function usePayTabNewPayment(): UsePayTabNewPayment {
         return;
       }
 
-      openSendFlow({ source: PAY_PAGE, categories: PAY_CATEGORIES });
+      openSendFlow({ source: SEND_FLOW_SOURCE.PAY, categories: PAY_CATEGORIES });
     },
     [openSendFlow],
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/constants.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/constants.ts
@@ -13,6 +13,7 @@ export const SEND_FLOW_STEP_ORDER: readonly SendFlowStep[] = [
   SEND_FLOW_STEP.SIGNATURE,
   SEND_FLOW_STEP.CONFIRMATION,
   SEND_FLOW_STEP.SKIP_MEMO_CONFIRMATION,
+  SEND_FLOW_STEP.PAY_SUCCESS,
 ];
 
 export const SEND_STEP_CONFIGS: Record<SendFlowStep, SendStepConfig> = {
@@ -90,6 +91,12 @@ export const SEND_STEP_CONFIGS: Record<SendFlowStep, SendStepConfig> = {
   },
   [SEND_FLOW_STEP.CONFIRMATION]: {
     id: SEND_FLOW_STEP.CONFIRMATION,
+    canGoBack: false,
+    showTitle: false,
+    height: "fit",
+  },
+  [SEND_FLOW_STEP.PAY_SUCCESS]: {
+    id: SEND_FLOW_STEP.PAY_SUCCESS,
     canGoBack: false,
     showTitle: false,
     height: "fit",

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/context/SendFlowContext.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/context/SendFlowContext.tsx
@@ -34,6 +34,7 @@ type DataContextValue = Readonly<{
     clear: () => void;
   }>;
   isRecipientAddressComplete: boolean;
+  source?: string;
 }>;
 
 const SendFlowDataContext = createContext<DataContextValue | null>(null);
@@ -65,8 +66,15 @@ export function SendFlowProvider({ value, children }: SendFlowProviderProps) {
       uiConfig: value.uiConfig,
       recipientSearch: value.recipientSearch,
       isRecipientAddressComplete: value.isRecipientAddressComplete,
+      source: value.source,
     }),
-    [value.state, value.uiConfig, value.recipientSearch, value.isRecipientAddressComplete],
+    [
+      value.state,
+      value.uiConfig,
+      value.recipientSearch,
+      value.isRecipientAddressComplete,
+      value.source,
+    ],
   );
 
   const actionsValue = useMemo(

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useOpenSendFlow.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useOpenSendFlow.test.ts
@@ -80,6 +80,37 @@ describe("useOpenSendFlow", () => {
 
     expect(store.getState().sendFlow.isOpen).toBe(true);
     expect(store.getState().sendFlow.data?.params).not.toHaveProperty("categories");
+    expect(store.getState().sendFlow.data?.params).toEqual(
+      expect.objectContaining({ source: "Pay" }),
+    );
+  });
+
+  it("forwards the source into the send params when an account is preselected", () => {
+    const account = genAccount("send-preselected-source", {
+      currency: getCryptoCurrencyById("bitcoin"),
+    });
+
+    const { result, store } = renderHook(() => useOpenSendFlow(), {
+      initialState: {
+        ...withFlagOverrides({
+          newSendFlow: {
+            enabled: true,
+            params: { families: ["bitcoin"], excludedCurrencyIds: [] },
+          },
+        }),
+        accounts: [account],
+      },
+    });
+
+    result.current({
+      account,
+      source: "Pay",
+    });
+
+    expect(store.getState().sendFlow.isOpen).toBe(true);
+    expect(store.getState().sendFlow.data?.params).toEqual(
+      expect.objectContaining({ account, source: "Pay" }),
+    );
   });
 
   it("preserves the direct-recipient intent after account selection", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useOpenSendFlow.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useOpenSendFlow.ts
@@ -18,7 +18,6 @@ import { HOOKS_TRACKING_LOCATIONS } from "~/renderer/analytics/hooks/variables";
 import { setOriginFlow } from "~/renderer/analytics/originFlow";
 import { track } from "~/renderer/analytics/segment";
 import { getSendFlowTrackingProperties } from "../utils/tracking";
-
 const SEND_ACCOUNT_SELECTION_DRAWER_CONFIGURATION: EnhancedModularDrawerConfiguration = {
   assets: { rightElement: "balance" },
   networks: {},

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/index.tsx
@@ -18,6 +18,7 @@ import { AddToExistingContactScreen } from "./screens/AddToExistingContact/AddTo
 import { CustomFeesScreen } from "./screens/CustomFees/CustomFeesScreen";
 import { CoinControlScreen } from "./screens/CoinControl/CoinControlScreen";
 import { SkipMemoConfirmationScreen } from "./screens/SkipMemoConfirmation/SkipMemoConfirmationScreen";
+import { PaySuccessScreen } from "./screens/PaySuccess/PaySuccessScreen";
 import type { StepRegistry } from "@ledgerhq/live-common/flows/wizard/types";
 
 const stepRegistry: StepRegistry<SendFlowStep> = {
@@ -32,6 +33,7 @@ const stepRegistry: StepRegistry<SendFlowStep> = {
   [SEND_FLOW_STEP.COIN_CONTROL]: CoinControlScreen,
   [SEND_FLOW_STEP.SIGNATURE]: SignatureScreen,
   [SEND_FLOW_STEP.CONFIRMATION]: ConfirmationScreen,
+  [SEND_FLOW_STEP.PAY_SUCCESS]: PaySuccessScreen,
 };
 
 type SendWorkflowParams = Readonly<{
@@ -43,6 +45,7 @@ type SendWorkflowParams = Readonly<{
   memo?: string;
   fromMAD?: boolean;
   startWithWarning?: boolean;
+  source?: string;
 }>;
 
 type SendWorkflowProps = Readonly<{
@@ -65,6 +68,7 @@ export function SendWorkflow({ onClose, params, isOpen }: SendWorkflowProps) {
       amount: params?.amount,
       memo: params?.memo,
       fromMAD: params?.fromMAD ?? false,
+      source: params?.source,
     }),
     [params],
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/PaySuccess/PaySuccessScreen.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/PaySuccess/PaySuccessScreen.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { PaySuccess } from "@features/flow-pay-contact";
+import { usePaySuccessViewModel } from "./hooks/usePaySuccessViewModel";
+
+export function PaySuccessScreen() {
+  const viewModel = usePaySuccessViewModel();
+
+  return <PaySuccess {...viewModel} />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/PaySuccess/hooks/__tests__/usePaySuccessViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/PaySuccess/hooks/__tests__/usePaySuccessViewModel.test.tsx
@@ -1,0 +1,132 @@
+import { BigNumber } from "bignumber.js";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { mockContactWithAddress } from "@domain/entity-contact/schema.mock";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import type { SendFlowState } from "@ledgerhq/live-common/flows/send/types";
+import { FLOW_STATUS } from "@ledgerhq/live-common/flows/wizard/types";
+import type { Operation } from "@ledgerhq/types-live";
+import { renderHook, withFlagOverrides } from "tests/testSetup";
+import { setDrawer } from "~/renderer/drawers/Provider";
+import { OperationDetails } from "~/renderer/drawers/OperationDetails";
+import { usePaySuccessViewModel } from "../usePaySuccessViewModel";
+
+const mockClose = jest.fn();
+let mockFlowState: SendFlowState;
+
+jest.mock("~/renderer/drawers/Provider", () => ({
+  ...jest.requireActual("~/renderer/drawers/Provider"),
+  setDrawer: jest.fn(),
+}));
+
+jest.mock("../../../../context/SendFlowContext", () => ({
+  useSendFlowData: () => ({ state: mockFlowState }),
+  useSendFlowActions: () => ({ close: mockClose }),
+}));
+
+const ADA_ADDRESS = "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034";
+const UNKNOWN_ADDRESS = "0xfeedfacefeedfacefeedfacefeedfacefeedface";
+const ACCOUNT_NAME = "Ada's payments";
+
+const ada = mockContactWithAddress({ id: "contact-ada", name: "Ada" });
+const account = genAccount("pay-success-eth", {
+  currency: getCryptoCurrencyById("ethereum"),
+  operationsSize: 0,
+});
+
+function buildFlowState(
+  overrides: { address?: string; optimisticOperation?: Operation | null } = {},
+): SendFlowState {
+  return {
+    account: { account, parentAccount: null, currency: account.currency },
+    transaction: {
+      transaction: {
+        amount: new BigNumber("1500000000000000000"),
+      } as SendFlowState["transaction"]["transaction"],
+      status: {} as SendFlowState["transaction"]["status"],
+      bridgeError: null,
+      bridgePending: false,
+    },
+    recipient: { address: overrides.address ?? ADA_ADDRESS },
+    operation: {
+      optimisticOperation: overrides.optimisticOperation ?? null,
+      transactionError: null,
+      signed: true,
+    },
+    isLoading: false,
+    flowStatus: FLOW_STATUS.SUCCESS,
+  };
+}
+
+function renderPaySuccess(state = buildFlowState(), { isContactsEnabled = true } = {}) {
+  mockFlowState = state;
+
+  return renderHook(() => usePaySuccessViewModel(), {
+    initialState: {
+      accounts: [account],
+      wallet: { accountNames: new Map([[account.id, ACCOUNT_NAME]]) },
+      contacts: { contacts: [ada] },
+      ...withFlagOverrides({ lwdContacts: { enabled: isContactsEnabled } }),
+    },
+  });
+}
+
+describe("usePaySuccessViewModel", () => {
+  it("should expose the contact as recipient when the address belongs to one", () => {
+    const { result } = renderPaySuccess();
+
+    expect(result.current.recipient).toEqual({ id: "contact-ada", name: "Ada", isMe: false });
+    expect(result.current.recipientLabel).toBe("Ada");
+  });
+
+  it("should fall back to the truncated address when no contact matches", () => {
+    const { result } = renderPaySuccess(buildFlowState({ address: UNKNOWN_ADDRESS }));
+
+    expect(result.current.recipient).toBeUndefined();
+    expect(result.current.recipientLabel).toBe("0xfeedfa...feedface");
+  });
+
+  it("should ignore matching contacts when the contacts feature is disabled", () => {
+    const { result } = renderPaySuccess(buildFlowState(), { isContactsEnabled: false });
+
+    expect(result.current.recipient).toBeUndefined();
+    expect(result.current.recipientLabel).toBe("0x1ad23b...46c53034");
+  });
+
+  it("should summarize the transaction from the account and its network", () => {
+    const { result } = renderPaySuccess();
+
+    expect(result.current.amountFormatted).toBe("1.5\u00A0ETH");
+    expect(result.current.fromAccountName).toBe(ACCOUNT_NAME);
+    expect(result.current.networkIcon).toEqual({ ledgerId: "ethereum", ticker: "ETH" });
+    expect(result.current.estimatedTime).toBe("~15s");
+  });
+
+  it("should open the operation details drawer on the sub operation when viewing the transaction", () => {
+    const { result } = renderPaySuccess(
+      buildFlowState({
+        optimisticOperation: {
+          id: "op-root",
+          subOperations: [{ id: "op-child" }],
+        } as Operation,
+      }),
+    );
+
+    result.current.onViewTransaction();
+
+    expect(mockClose).toHaveBeenCalled();
+    expect(setDrawer).toHaveBeenCalledWith(
+      OperationDetails,
+      { operationId: "op-child", accountId: account.id, parentId: undefined },
+      expect.objectContaining({ onRequestClose: expect.any(Function) }),
+    );
+  });
+
+  it("should only close the flow when there is no operation to view", () => {
+    const { result } = renderPaySuccess();
+
+    result.current.onViewTransaction();
+
+    expect(mockClose).toHaveBeenCalled();
+    expect(setDrawer).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/PaySuccess/hooks/usePaySuccessViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/PaySuccess/hooks/usePaySuccessViewModel.ts
@@ -1,0 +1,118 @@
+import { useCallback, useMemo } from "react";
+import { BigNumber } from "bignumber.js";
+import type { PaySuccessProps } from "@features/flow-pay-contact";
+import { getRecipientHeaderPresentation } from "@ledgerhq/live-common/flows/send/recipient/utils/getRecipientHeaderPresentation";
+import { formatCurrencyUnit } from "@ledgerhq/live-currency-format";
+import {
+  getAccountCurrency,
+  getMainAccount,
+} from "@ledgerhq/ledger-wallet-framework/account/helpers";
+import { useContactsFeature } from "@features/platform-contacts";
+import { selectContacts, ContactIdSchema } from "@domain/entity-contact";
+import { useSelector } from "LLD/hooks/redux";
+import { useMaybeAccountUnit } from "~/renderer/hooks/useAccountUnit";
+import { useMaybeAccountName } from "~/renderer/reducers/wallet";
+import { localeSelector } from "~/renderer/reducers/settings";
+import { setDrawer } from "~/renderer/drawers/Provider";
+import { OperationDetails } from "~/renderer/drawers/OperationDetails";
+import { useSendFlowActions, useSendFlowData } from "../../../context/SendFlowContext";
+
+function formatApproximateBlockTime(seconds: number | undefined): string | undefined {
+  if (!seconds || seconds <= 0) return undefined;
+  if (seconds < 60) return `~${Math.round(seconds)}s`;
+  return `~${Math.round(seconds / 60)} min`;
+}
+
+export function usePaySuccessViewModel(): PaySuccessProps {
+  const { state } = useSendFlowData();
+  const { close } = useSendFlowActions();
+  const locale = useSelector(localeSelector);
+  const contacts = useSelector(selectContacts);
+  const { isEnabled: isContactsFeatureEnabled } = useContactsFeature("desktop");
+
+  const account = state.account.account;
+  const parentAccount = state.account.parentAccount;
+  const currency = state.account.currency;
+
+  const mainAccount = useMemo(
+    () => (account ? getMainAccount(account, parentAccount ?? undefined) : null),
+    [account, parentAccount],
+  );
+  const networkCurrency = useMemo(
+    () => (mainAccount ? getAccountCurrency(mainAccount) : null),
+    [mainAccount],
+  );
+
+  const recipientHeader = useMemo(
+    () =>
+      getRecipientHeaderPresentation({
+        recipient: state.recipient,
+        contacts,
+        currencyId: currency?.id,
+        isContactsFeatureEnabled,
+      }),
+    [contacts, currency?.id, isContactsFeatureEnabled, state.recipient],
+  );
+
+  const amountUnit = useMaybeAccountUnit(account ?? undefined) ?? currency?.units[0];
+  const amountFormatted = useMemo(() => {
+    if (!amountUnit) return "";
+    const amount = state.transaction.transaction?.amount ?? new BigNumber(0);
+    return formatCurrencyUnit(amountUnit, amount, {
+      showCode: true,
+      disableRounding: true,
+      locale,
+    });
+  }, [amountUnit, locale, state.transaction.transaction]);
+
+  const fromAccountName = useMaybeAccountName(account ?? undefined) ?? "";
+
+  const optimisticOperation = state.operation.optimisticOperation;
+  const concernedOperation = useMemo(
+    () => optimisticOperation?.subOperations?.[0] ?? optimisticOperation ?? null,
+    [optimisticOperation],
+  );
+
+  const onViewTransaction = useCallback(() => {
+    close();
+    if (account && concernedOperation) {
+      setDrawer(
+        OperationDetails,
+        {
+          operationId: concernedOperation.id,
+          accountId: account.id,
+          parentId: parentAccount?.id,
+        },
+        { onRequestClose: () => setDrawer() },
+      );
+    }
+  }, [account, concernedOperation, parentAccount, close]);
+
+  const recipient = recipientHeader.contact
+    ? {
+        id: ContactIdSchema.parse(recipientHeader.contact.id),
+        name: recipientHeader.contact.name,
+        isMe: false,
+      }
+    : undefined;
+
+  const networkIcon = networkCurrency
+    ? { ledgerId: networkCurrency.id, ticker: networkCurrency.ticker }
+    : undefined;
+
+  const estimatedTime =
+    networkCurrency?.type === "CryptoCurrency"
+      ? formatApproximateBlockTime(networkCurrency.blockAvgTime)
+      : undefined;
+
+  return {
+    recipient,
+    recipientLabel: recipientHeader.label,
+    amountFormatted,
+    fromAccountName,
+    networkIcon,
+    estimatedTime,
+    onViewTransaction,
+    onClose: close,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Signature/hooks/__tests__/useSignatureViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Signature/hooks/__tests__/useSignatureViewModel.test.tsx
@@ -1,5 +1,6 @@
 import React, { forwardRef, useImperativeHandle } from "react";
 import { render, cleanup, waitFor } from "tests/testSetup";
+import { SEND_FLOW_SOURCE, SEND_FLOW_STEP } from "@ledgerhq/live-common/flows/send/types";
 import { useSignatureViewModel } from "../useSignatureViewModel";
 
 declare global {
@@ -16,7 +17,8 @@ jest.mock("LLD/hooks/redux", () => {
     useDispatch: () => reduxDispatchMock,
   };
 });
-const mockNavigation = { goToNextStep: jest.fn() };
+const mockNavigation = { goToNextStep: jest.fn(), goToStep: jest.fn() };
+let mockSource: string | undefined;
 const mockOperation = {
   onTransactionError: jest.fn(),
   onOperationBroadcasted: jest.fn(),
@@ -68,7 +70,7 @@ jest.mock("../../../../context/SendFlowContext", () => ({
     status: mockStatus,
     close: mockClose,
   })),
-  useSendFlowData: jest.fn(() => ({ state: mockState })),
+  useSendFlowData: jest.fn(() => ({ state: mockState, source: mockSource })),
 }));
 
 // eslint-disable-next-line
@@ -106,6 +108,7 @@ describe("useSignatureViewModel", () => {
     jest.clearAllMocks();
     reduxDispatchMock.mockReset();
     mockClose.mockReset();
+    mockSource = undefined;
     mockState = {
       account: {
         account: { id: "acc", type: "Account" },
@@ -301,5 +304,53 @@ describe("useSignatureViewModel", () => {
     ref.current?.finishWithError(new Error("second"));
     expect(mockOperation.onTransactionError).toHaveBeenCalledTimes(2);
     expect(mockNavigation.goToNextStep).toHaveBeenCalledTimes(2);
+  });
+
+  test("routes to the Pay success step on success when launched from Pay", async () => {
+    mockSource = SEND_FLOW_SOURCE.PAY;
+    const op = { id: "op-pay" };
+    broadcastFn.mockResolvedValue(op);
+
+    const ref = React.createRef<HookApi>();
+    render(<Harness ref={ref} />);
+
+    // @ts-expect-error - providing minimal stub for SignedOperation in tests
+    ref.current?.onDeviceActionResult({ signedOperation: { raw: "sig" }, device: {} });
+
+    await waitFor(() => {
+      expect(mockStatus.setSuccess).toHaveBeenCalledTimes(1);
+      expect(mockNavigation.goToStep).toHaveBeenCalledWith(SEND_FLOW_STEP.PAY_SUCCESS);
+    });
+    expect(mockNavigation.goToNextStep).not.toHaveBeenCalled();
+  });
+
+  test("routes to confirmation on success for a regular (non-Pay) send", async () => {
+    const op = { id: "op-regular" };
+    broadcastFn.mockResolvedValue(op);
+
+    const ref = React.createRef<HookApi>();
+    render(<Harness ref={ref} />);
+
+    // @ts-expect-error - providing minimal stub for SignedOperation in tests
+    ref.current?.onDeviceActionResult({ signedOperation: { raw: "sig" }, device: {} });
+
+    await waitFor(() => {
+      expect(mockStatus.setSuccess).toHaveBeenCalledTimes(1);
+      expect(mockNavigation.goToNextStep).toHaveBeenCalledTimes(1);
+    });
+    expect(mockNavigation.goToStep).not.toHaveBeenCalled();
+  });
+
+  test("routes to confirmation on failure even when launched from Pay", () => {
+    mockSource = SEND_FLOW_SOURCE.PAY;
+    mockState.account.currency = null;
+
+    const ref = React.createRef<HookApi>();
+    render(<Harness ref={ref} />);
+
+    ref.current?.finishWithError(new Error("boom"));
+
+    expect(mockNavigation.goToNextStep).toHaveBeenCalledTimes(1);
+    expect(mockNavigation.goToStep).not.toHaveBeenCalled();
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Signature/hooks/useSignatureViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Signature/hooks/useSignatureViewModel.ts
@@ -5,6 +5,12 @@ import type { Account, Operation } from "@ledgerhq/types-live";
 import { useBroadcast } from "@ledgerhq/live-common/hooks/useBroadcast";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { useSendFlowSignatureCore } from "@ledgerhq/live-common/flows/send/hooks/useSendFlowSignatureCore";
+import {
+  SEND_FLOW_COMPLETION,
+  SEND_FLOW_SOURCE,
+  SEND_FLOW_STEP,
+  type SendFlowCompletion,
+} from "@ledgerhq/live-common/flows/send/types";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
 import { useTransactionAction } from "~/renderer/hooks/useConnectAppAction";
@@ -17,7 +23,7 @@ import { broadcastLogger } from "~/datadog/logs";
 export function useSignatureViewModel() {
   const { navigation } = useFlowWizard();
   const { operation, status, close } = useSendFlowActions();
-  const { state } = useSendFlowData();
+  const { state, source } = useSendFlowData();
   const reduxDispatch = useDispatch();
 
   const wasBuyDeviceOpenRef = useRef(false);
@@ -72,6 +78,17 @@ export function useSignatureViewModel() {
     [reduxDispatch],
   );
 
+  const onFinish = useCallback(
+    (completion: SendFlowCompletion) => {
+      if (completion === SEND_FLOW_COMPLETION.SUCCESS && source === SEND_FLOW_SOURCE.PAY) {
+        navigation.goToStep(SEND_FLOW_STEP.PAY_SUCCESS);
+        return;
+      }
+      navigation.goToNextStep();
+    },
+    [navigation, source],
+  );
+
   const { request, finishWithError, onDeviceActionResult } = useSendFlowSignatureCore({
     account,
     parentAccount,
@@ -81,7 +98,7 @@ export function useSignatureViewModel() {
     broadcast,
     operation,
     statusActions: status,
-    onFinish: navigation.goToNextStep,
+    onFinish,
     registerPendingOperation,
     recipientEnsName: state.recipient?.ensName,
   });

--- a/apps/ledger-live-desktop/src/renderer/reducers/sendFlow.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/sendFlow.ts
@@ -11,6 +11,7 @@ export type SendFlowParams = {
   memo?: string;
   fromMAD?: boolean;
   startWithWarning?: boolean;
+  source?: string;
 };
 
 export type SendFlowDialogPayload = {

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -934,6 +934,14 @@
       "addressPicker": {
         "title": "Select {{name}}'s address",
         "addAddress": "Add address"
+      },
+      "paySuccess": {
+        "title": "You paid ({{recipient}}) {{amount}}",
+        "amount": "Amount",
+        "estimatedTime": "Est. time",
+        "from": "From",
+        "viewTransaction": "View transaction",
+        "close": "Close"
       }
     },
     "actions": {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/__tests__/SendFlowOrchestrator.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/__tests__/SendFlowOrchestrator.test.tsx
@@ -101,6 +101,7 @@ function createFlowConfig(overrides?: Partial<SendFlowConfig>): SendFlowConfig {
         screenOptions: { title: "Sign" },
       },
       [SEND_FLOW_STEP.CONFIRMATION]: { id: SEND_FLOW_STEP.CONFIRMATION, canGoBack: true },
+      [SEND_FLOW_STEP.PAY_SUCCESS]: { id: SEND_FLOW_STEP.PAY_SUCCESS, canGoBack: false },
     },
     ...overrides,
   };

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/constants.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/constants.ts
@@ -118,6 +118,12 @@ export const SEND_STEP_CONFIGS: Record<SendFlowStep, SendStepConfig> = {
       title: "",
     },
   },
+  [SEND_FLOW_STEP.PAY_SUCCESS]: {
+    id: SEND_FLOW_STEP.PAY_SUCCESS,
+    canGoBack: false,
+    showHeaderRight: false,
+    showTitle: false,
+  },
 };
 
 export const SEND_FLOW_CONFIG: SendFlowConfig = {

--- a/features/flow/pay-contact/src/components/PaySuccess/PaySuccess.web.tsx
+++ b/features/flow/pay-contact/src/components/PaySuccess/PaySuccess.web.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { Button, DialogBody, DialogFooter } from "@ledgerhq/lumen-ui-react";
+import { useTranslation } from "@shared/i18n";
+import { PaySuccessHero, type PaySuccessRecipient } from "./PaySuccessHero.web";
+import {
+  PaySuccessSummary,
+  type PaySuccessSummaryIcon,
+  type PaySuccessSummaryRow,
+} from "./PaySuccessSummary.web";
+
+export type PaySuccessProps = Readonly<{
+  recipient?: PaySuccessRecipient;
+  recipientLabel: string;
+  amountFormatted: string;
+  fromAccountName: string;
+  networkIcon?: PaySuccessSummaryIcon;
+  estimatedTime?: string;
+  onViewTransaction: () => void;
+  onClose: () => void;
+}>;
+
+export function PaySuccess({
+  recipient,
+  recipientLabel,
+  amountFormatted,
+  fromAccountName,
+  networkIcon,
+  estimatedTime,
+  onViewTransaction,
+  onClose,
+}: PaySuccessProps) {
+  const { t } = useTranslation();
+
+  const rows: ReadonlyArray<PaySuccessSummaryRow> = [
+    { id: "amount", label: t("payTab.contacts.paySuccess.amount"), value: amountFormatted },
+    ...(estimatedTime
+      ? [
+          {
+            id: "estimatedTime",
+            label: t("payTab.contacts.paySuccess.estimatedTime"),
+            value: estimatedTime,
+          },
+        ]
+      : []),
+    {
+      id: "from",
+      label: t("payTab.contacts.paySuccess.from"),
+      value: fromAccountName,
+      trailingIcon: networkIcon,
+    },
+  ];
+
+  return (
+    <>
+      <DialogBody className="flex flex-col py-24" data-testid="pay-success-step">
+        <PaySuccessHero
+          recipient={recipient}
+          recipientLabel={recipientLabel}
+          amountFormatted={amountFormatted}
+        />
+
+        <div className="mt-32 mb-16">
+          <PaySuccessSummary rows={rows} />
+        </div>
+      </DialogBody>
+      <DialogFooter className="flex flex-col gap-16">
+        <Button
+          appearance="gray"
+          size="lg"
+          isFull
+          data-testid="pay-success-view-transaction"
+          onClick={onViewTransaction}
+        >
+          {t("payTab.contacts.paySuccess.viewTransaction")}
+        </Button>
+        <Button
+          appearance="base"
+          size="lg"
+          isFull
+          data-testid="pay-success-close"
+          onClick={onClose}
+        >
+          {t("payTab.contacts.paySuccess.close")}
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}

--- a/features/flow/pay-contact/src/components/PaySuccess/PaySuccessHero.web.tsx
+++ b/features/flow/pay-contact/src/components/PaySuccess/PaySuccessHero.web.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { Avatar } from "@ledgerhq/lumen-ui-react";
+import { ContactAvatar } from "@features/platform-contacts";
+import type { ContactId } from "@domain/entity-contact";
+import { useTranslation } from "@shared/i18n";
+
+const AVATAR_SIZE = "xl";
+
+export type PaySuccessRecipient = Readonly<{
+  id: ContactId;
+  name: string;
+  isMe?: boolean;
+}>;
+
+export type PaySuccessHeroProps = Readonly<{
+  recipient?: PaySuccessRecipient;
+  recipientLabel: string;
+  amountFormatted: string;
+}>;
+
+export function PaySuccessHero({
+  recipient,
+  recipientLabel,
+  amountFormatted,
+}: PaySuccessHeroProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex flex-col items-center gap-24">
+      {recipient ? (
+        <ContactAvatar
+          contactId={recipient.id}
+          name={recipient.name}
+          isMe={recipient.isMe}
+          size={AVATAR_SIZE}
+          ariaHidden
+        />
+      ) : (
+        <Avatar size={AVATAR_SIZE} aria-hidden />
+      )}
+      <p className="heading-3-semi-bold text-center">
+        {t("payTab.contacts.paySuccess.title", {
+          recipient: recipientLabel,
+          amount: amountFormatted,
+        })}
+      </p>
+    </div>
+  );
+}

--- a/features/flow/pay-contact/src/components/PaySuccess/PaySuccessSummary.web.tsx
+++ b/features/flow/pay-contact/src/components/PaySuccess/PaySuccessSummary.web.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import {
+  DescriptionItem,
+  DescriptionItemLeading,
+  DescriptionItemLabel,
+  DescriptionItemTrailing,
+  DescriptionItemValue,
+} from "@ledgerhq/lumen-ui-react";
+import { CryptoIcon } from "@ledgerhq/crypto-icons";
+
+const ICON_SIZE = 16;
+
+export type PaySuccessSummaryIcon = Readonly<{
+  ledgerId: string;
+  ticker: string;
+}>;
+
+export type PaySuccessSummaryRow = Readonly<{
+  id: string;
+  label: string;
+  value: string;
+  trailingIcon?: PaySuccessSummaryIcon;
+}>;
+
+export type PaySuccessSummaryProps = Readonly<{
+  rows: ReadonlyArray<PaySuccessSummaryRow>;
+}>;
+
+export function PaySuccessSummary({ rows }: PaySuccessSummaryProps) {
+  return (
+    <div className="flex flex-col gap-12">
+      {rows.map(({ id, label, value, trailingIcon }) => (
+        <DescriptionItem key={id}>
+          <DescriptionItemLeading>
+            <DescriptionItemLabel>{label}</DescriptionItemLabel>
+          </DescriptionItemLeading>
+          <DescriptionItemTrailing>
+            <span className="flex items-center gap-8">
+              <DescriptionItemValue>{value}</DescriptionItemValue>
+              {trailingIcon ? (
+                <span data-testid="pay-success-summary-icon">
+                  <CryptoIcon
+                    ledgerId={trailingIcon.ledgerId}
+                    ticker={trailingIcon.ticker}
+                    size={ICON_SIZE}
+                    shape="square"
+                  />
+                </span>
+              ) : null}
+            </span>
+          </DescriptionItemTrailing>
+        </DescriptionItem>
+      ))}
+    </div>
+  );
+}

--- a/features/flow/pay-contact/src/components/PaySuccess/__tests__/PaySuccess.web.test.tsx
+++ b/features/flow/pay-contact/src/components/PaySuccess/__tests__/PaySuccess.web.test.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { fireEvent, screen } from "@testing-library/react";
+import { ContactIdSchema } from "@domain/entity-contact";
+import { PaySuccess, type PaySuccessProps } from "../PaySuccess.web";
+import { renderPaySuccess } from "./shared.web";
+
+const baseProps: PaySuccessProps = {
+  recipient: { id: ContactIdSchema.parse("contact-ada"), name: "Ada", isMe: false },
+  recipientLabel: "Ada",
+  amountFormatted: "100 USDC",
+  fromAccountName: "Ethereum 1",
+  networkIcon: { ledgerId: "ethereum", ticker: "ETH" },
+  onViewTransaction: jest.fn(),
+  onClose: jest.fn(),
+};
+
+function renderStep(overrides: Partial<PaySuccessProps> = {}) {
+  return renderPaySuccess(<PaySuccess {...baseProps} {...overrides} />);
+}
+
+describe("PaySuccess (Web)", () => {
+  it("renders the recipient headline, amount and from account", () => {
+    renderStep();
+
+    expect(screen.getByTestId("pay-success-step")).toBeVisible();
+    expect(screen.getByText(/You paid/)).toHaveTextContent("You paid (Ada) 100 USDC");
+    expect(screen.getByText("Ethereum 1")).toBeVisible();
+  });
+
+  it("shows the network icon on the From row", () => {
+    renderStep();
+
+    expect(screen.getByTestId("pay-success-summary-icon")).toBeVisible();
+  });
+
+  it("hides the estimated time row when it is not provided", () => {
+    renderStep();
+
+    expect(screen.queryByText("Est. time")).not.toBeInTheDocument();
+  });
+
+  it("shows the estimated time row when it is provided", () => {
+    renderStep({ estimatedTime: "~15s" });
+
+    expect(screen.getByText("Est. time")).toBeVisible();
+    expect(screen.getByText("~15s")).toBeVisible();
+  });
+
+  it("falls back to a generic avatar when no contact is matched", () => {
+    renderStep({ recipient: undefined, recipientLabel: "0x1ad2...c53034" });
+
+    expect(screen.getByTestId("pay-success-step")).toBeVisible();
+    expect(screen.getByText(/You paid/)).toHaveTextContent("You paid (0x1ad2...c53034) 100 USDC");
+  });
+
+  it("calls onViewTransaction when the primary CTA is clicked", () => {
+    const onViewTransaction = jest.fn();
+    renderStep({ onViewTransaction });
+
+    fireEvent.click(screen.getByTestId("pay-success-view-transaction"));
+
+    expect(onViewTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when the close CTA is clicked", () => {
+    const onClose = jest.fn();
+    renderStep({ onClose });
+
+    fireEvent.click(screen.getByTestId("pay-success-close"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/flow/pay-contact/src/components/PaySuccess/__tests__/shared.web.tsx
+++ b/features/flow/pay-contact/src/components/PaySuccess/__tests__/shared.web.tsx
@@ -1,0 +1,31 @@
+import React, { type ReactElement } from "react";
+import { render } from "@testing-library/react";
+import { StyleProvider } from "@features/platform-style";
+import { I18nTestProvider, type I18nTestProviderProps } from "@shared/i18n/testing";
+
+export const PAY_SUCCESS_RESOURCES: I18nTestProviderProps["resources"] = {
+  en: {
+    translation: {
+      payTab: {
+        contacts: {
+          paySuccess: {
+            title: "You paid ({{recipient}}) {{amount}}",
+            amount: "Amount",
+            estimatedTime: "Est. time",
+            from: "From",
+            viewTransaction: "View transaction",
+            close: "Close",
+          },
+        },
+      },
+    },
+  },
+};
+
+export function renderPaySuccess(ui: ReactElement) {
+  return render(
+    <I18nTestProvider resources={PAY_SUCCESS_RESOURCES}>
+      <StyleProvider colorScheme="dark">{ui}</StyleProvider>
+    </I18nTestProvider>,
+  );
+}

--- a/features/flow/pay-contact/src/index.ts
+++ b/features/flow/pay-contact/src/index.ts
@@ -2,3 +2,4 @@ export * from "./exports";
 export * from "./components/Contacts/Contacts.web";
 export * from "./components/ContactAddressPicker/ContactAddressPicker.web";
 export * from "./components/ContactAddressPicker/useContactAddressPickerViewModel.web";
+export * from "./components/PaySuccess/PaySuccess.web";

--- a/libs/ledger-live-common/src/flows/send/hooks/__tests__/useSendFlowSignatureCore.test.ts
+++ b/libs/ledger-live-common/src/flows/send/hooks/__tests__/useSendFlowSignatureCore.test.ts
@@ -14,6 +14,7 @@ import {
   useSendFlowSignatureCore,
   type UseSendFlowSignatureCoreParams,
 } from "../useSendFlowSignatureCore";
+import { SEND_FLOW_COMPLETION } from "../../types";
 
 jest.mock("../../../../account/index", () => ({
   getMainAccount: jest.fn(),
@@ -186,6 +187,7 @@ describe("useSendFlowSignatureCore", () => {
     expect(params.operation.onOperationBroadcasted).toHaveBeenCalledWith(operation);
     expect(params.statusActions.setSuccess).toHaveBeenCalledTimes(1);
     expect(params.onFinish).toHaveBeenCalledTimes(1);
+    expect(params.onFinish).toHaveBeenCalledWith(SEND_FLOW_COMPLETION.SUCCESS);
   });
 
   it("should pass the flow ENS name when saving the recent recipient", () => {
@@ -225,6 +227,7 @@ describe("useSendFlowSignatureCore", () => {
     expect(params.statusActions.resetStatus).toHaveBeenCalledTimes(1);
     expect(params.statusActions.setError).not.toHaveBeenCalled();
     expect(params.onFinish).toHaveBeenCalledTimes(1);
+    expect(params.onFinish).toHaveBeenCalledWith(SEND_FLOW_COMPLETION.FAILURE);
   });
 
   it("should set error when finishing with a non-user-refused error", () => {
@@ -240,6 +243,7 @@ describe("useSendFlowSignatureCore", () => {
     expect(params.statusActions.setError).toHaveBeenCalledTimes(1);
     expect(params.statusActions.resetStatus).not.toHaveBeenCalled();
     expect(params.onFinish).toHaveBeenCalledTimes(1);
+    expect(params.onFinish).toHaveBeenCalledWith(SEND_FLOW_COMPLETION.FAILURE);
   });
 
   it("should broadcast the signed operation from a device action result", async () => {

--- a/libs/ledger-live-common/src/flows/send/hooks/useSendFlowBusinessLogic.ts
+++ b/libs/ledger-live-common/src/flows/send/hooks/useSendFlowBusinessLogic.ts
@@ -56,6 +56,7 @@ type UseSendFlowBusinessLogicResult = Readonly<{
   isRecipientAddressComplete: boolean;
   setIsRecipientAddressComplete: (value: boolean) => void;
   setAccountAndNavigate: (account: AccountLike, parentAccount?: Account) => void;
+  source?: string;
 }>;
 
 /**
@@ -187,6 +188,7 @@ export function useSendFlowBusinessLogic({
       isRecipientAddressComplete,
       setIsRecipientAddressComplete,
       setAccountAndNavigate,
+      source: initParams?.source,
     }),
     [
       state,
@@ -198,6 +200,7 @@ export function useSendFlowBusinessLogic({
       recipient,
       isRecipientAddressComplete,
       setAccountAndNavigate,
+      initParams?.source,
     ],
   );
 }

--- a/libs/ledger-live-common/src/flows/send/hooks/useSendFlowSignatureCore.ts
+++ b/libs/ledger-live-common/src/flows/send/hooks/useSendFlowSignatureCore.ts
@@ -6,6 +6,7 @@ import { getMainAccount } from "../../../account/index";
 import { sendFeatures } from "../../../bridge/descriptor/send/features";
 import type { Transaction, TransactionStatus } from "../../../coin-modules/transaction-types";
 import { saveRecentSendRecipient } from "../utils";
+import { SEND_FLOW_COMPLETION, type SendFlowCompletion } from "../types";
 
 export type SignatureDeviceActionResult =
   | { signedOperation: SignedOperation | undefined | null; device: unknown }
@@ -37,8 +38,8 @@ export type UseSendFlowSignatureCoreParams = Readonly<{
     setError: () => void;
     setSuccess: () => void;
   }>;
-  /** Advances the flow to the next step (e.g. confirmation). */
-  onFinish: () => void;
+  /** Advances the flow once signature resolves; the outcome lets platforms branch success vs failure. */
+  onFinish: (completion: SendFlowCompletion) => void;
   /** Persists the optimistic operation as pending on the (main) account, app-side. */
   registerPendingOperation: (mainAccount: Account, operation: Operation) => void;
   /** Optional ENS name from the flow recipient state (fallback: transaction.recipientDomain). */
@@ -56,7 +57,7 @@ export type UseSendFlowSignatureCoreResult = Readonly<{
  * Platform-agnostic Send flow signature logic shared by desktop and mobile.
  *
  * It builds the device-action request, handles the signature result (broadcast,
- * success/error resolution) and guarantees the flow only finishes once per set
+ * success/failure resolution) and guarantees the flow only finishes once per set
  * of inputs. The platform layer injects the side-effects that differ across apps
  * (broadcast, redux pending-operation persistence, navigation, status actions).
  */
@@ -122,7 +123,7 @@ export function useSendFlowSignatureCore({
         statusActions.setError();
       }
 
-      onFinish();
+      onFinish(SEND_FLOW_COMPLETION.FAILURE);
     },
     [currency, operation, statusActions, onFinish],
   );
@@ -143,7 +144,7 @@ export function useSendFlowSignatureCore({
 
       operation.onOperationBroadcasted(op);
       statusActions.setSuccess();
-      onFinish();
+      onFinish(SEND_FLOW_COMPLETION.SUCCESS);
     },
     [
       account,

--- a/libs/ledger-live-common/src/flows/send/types.ts
+++ b/libs/ledger-live-common/src/flows/send/types.ts
@@ -15,9 +15,21 @@ export const SEND_FLOW_STEP = {
   COIN_CONTROL: "COIN_CONTROL",
   SIGNATURE: "SIGNATURE",
   CONFIRMATION: "CONFIRMATION",
+  PAY_SUCCESS: "PAY_SUCCESS",
 } as const;
 
 export type SendFlowStep = (typeof SEND_FLOW_STEP)[keyof typeof SEND_FLOW_STEP];
+
+export const SEND_FLOW_COMPLETION = {
+  SUCCESS: "SUCCESS",
+  FAILURE: "FAILURE",
+} as const;
+
+export type SendFlowCompletion = (typeof SEND_FLOW_COMPLETION)[keyof typeof SEND_FLOW_COMPLETION];
+
+export const SEND_FLOW_SOURCE = {
+  PAY: "Pay",
+} as const;
 
 export type BaseSendStepConfig = FlowStepConfig<SendFlowStep> &
   Readonly<{
@@ -101,6 +113,7 @@ export type SendFlowInitParams = Readonly<{
   amount?: string;
   memo?: string;
   fromMAD?: boolean;
+  source?: string;
 }>;
 
 export function hasDirectRecipient(
@@ -125,6 +138,7 @@ export type SendFlowBusinessContext = Readonly<{
   operation: SendFlowOperationActions;
   status: FlowStatusActions;
   uiConfig: SendFlowUiConfig;
+  source?: string;
   recipientSearch: Readonly<{
     value: string;
     setValue: (value: string) => void;


### PR DESCRIPTION
### 📝 Description

When the Send flow is launched from the **Pay** tab and the transaction succeeds, it now routes to a dedicated `PAY_SUCCESS` step instead of the generic Send confirmation. The screen reads **"You paid (\<contact\>) \<amount\>"** and shows the amount, the source account (with its network icon) and a link to the transaction details.

**Problem:** the new Send confirmation used generic success copy regardless of where the flow was started from. A Pay-sourced send needs the "You paid …" wording.

**Solution:**
- Track the launch `source` through the shared Send flow (`@ledgerhq/live-common`), the Redux params and the desktop context.
- Add a presentational `PaySuccess` component (`Hero` + `Summary`) exported from `@features/flow-pay-contact`, with copy resolved via `@shared/i18n`.
- On desktop, wire it through an MVVM `PaySuccessScreen` + `usePaySuccessViewModel` (resolves the recipient contact from the address, formats the amount, derives the network icon, opens the operation details drawer).
- The signature step routes to `PAY_SUCCESS` only when `source === Pay` **and** the broadcast succeeds; every other source keeps the generic confirmation.

The Pay flow only passes a recipient address, so `getRecipientHeaderPresentation` maps it to a contact name/avatar (falling back to the truncated address when unmatched).

> Note: mobile wiring is a desktop-only stub for now (out of scope of this PR); the shared plumbing is in place.




https://github.com/user-attachments/assets/3e089c55-17f1-4076-8d4a-ec9abefd4b21



### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36376](https://ledgerhq.atlassian.net/browse/LIVE-36376)
- **ADR** (if any): N/A


[LIVE-36376]: https://ledgerhq.atlassian.net/browse/LIVE-36376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ