### PR TITLE
refactor(countervalues): drop duplicate CVS client

### DIFF
--- a/.changeset/drop-duplicate-cvs-supported-crypto.md
+++ b/.changeset/drop-duplicate-cvs-supported-crypto.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-countervalues": minor
+---
+
+Remove `fetchIdsSortedByMarketcap` from the legacy countervalues API client. The RTK Query client in `ledger-live-common` already covers the same endpoint and is the single source of truth going forward.

--- a/libs/live-countervalues/src/api/api.mock.ts
+++ b/libs/live-countervalues/src/api/api.mock.ts
@@ -1,6 +1,6 @@
 import type { CounterValuesAPI, RateGranularity } from "../types";
 import { getEnv } from "@ledgerhq/live-env";
-import { getBTCValues, BTCtoUSD, referenceSnapshotDate, TICKER_TO_ID_AND_VALUE } from "../mock";
+import { getBTCValues, BTCtoUSD, referenceSnapshotDate } from "../mock";
 import { formatPerGranularity } from "../helpers";
 import Prando from "prando";
 
@@ -73,10 +73,6 @@ const increment = {
   hourly: 60 * 60 * 1000,
 };
 
-async function getIds(): Promise<string[]> {
-  return Object.values(TICKER_TO_ID_AND_VALUE).map(([id]) => id);
-}
-
 function getDates(granularity: RateGranularity, start: Date): Date[] {
   const array: Date[] = [];
   const f = formatPerGranularity[granularity];
@@ -104,6 +100,5 @@ const api: CounterValuesAPI = {
     return Promise.resolve(r);
   },
   fetchLatest: pairs => Promise.resolve(pairs.map(({ from, to }) => rate(from.ticker, to.ticker))),
-  fetchIdsSortedByMarketcap: () => getIds(),
 };
 export default api;

--- a/libs/live-countervalues/src/api/api.ts
+++ b/libs/live-countervalues/src/api/api.ts
@@ -118,14 +118,6 @@ const api: CounterValuesAPI = {
 
     return data;
   },
-
-  fetchIdsSortedByMarketcap: async () => {
-    const { data } = await network<string[]>({
-      method: "GET",
-      url: `${baseURL()}/v3/supported/crypto`,
-    });
-    return data;
-  },
 };
 
 export default api;

--- a/libs/live-countervalues/src/api/index.ts
+++ b/libs/live-countervalues/src/api/index.ts
@@ -12,10 +12,6 @@ const api: CounterValuesAPI = {
     getEnv("MOCK_COUNTERVALUES")
       ? mockAPI.fetchLatest(pairs, batchStrategySolver)
       : prodAPI.fetchLatest(pairs, batchStrategySolver),
-  fetchIdsSortedByMarketcap: () =>
-    getEnv("MOCK_COUNTERVALUES")
-      ? mockAPI.fetchIdsSortedByMarketcap()
-      : prodAPI.fetchIdsSortedByMarketcap(),
 };
 
 export default api;

--- a/libs/live-countervalues/src/mock.test.ts
+++ b/libs/live-countervalues/src/mock.test.ts
@@ -1,6 +1,5 @@
 import "@ledgerhq/ledger-wallet-framework/test-helpers/staticTime";
 import { initialState, loadCountervalues, calculate } from "./logic";
-import CountervaluesAPI from "./api";
 import { setEnv } from "@ledgerhq/live-env";
 import { getFiatCurrencyByTicker, getCryptoCurrencyById } from "./tests/currencies";
 import { formatCounterValueDay, formatCounterValueHour, parseFormattedDate } from "./helpers";
@@ -56,9 +55,6 @@ test("mock load with nothing to track", async () => {
       to: getFiatCurrencyByTicker("USD"),
     }),
   ).toBeUndefined();
-});
-test("mock fetchIdsSortedByMarketcap", async () => {
-  expect(await CountervaluesAPI.fetchIdsSortedByMarketcap()).toBeDefined();
 });
 test("mock load with btc-usd to track", async () => {
   const state = await loadCountervalues(initialState, {
@@ -263,9 +259,4 @@ test("missing rate in mock is filled by autofillGaps", async () => {
       date: new Date("2018-01-06T19:00"),
     }),
   );
-});
-
-test("fetchIdsSortedByMarketcap", async () => {
-  const ids = await CountervaluesAPI.fetchIdsSortedByMarketcap();
-  expect(ids).toContain("bitcoin");
 });

--- a/libs/live-countervalues/src/types.ts
+++ b/libs/live-countervalues/src/types.ts
@@ -59,7 +59,6 @@ export type CounterValuesAPI = {
     pairs: TrackingPair[],
     batchStrategySolver?: BatchStrategySolver,
   ) => Promise<Array<number | null | undefined>>;
-  fetchIdsSortedByMarketcap: () => Promise<string[]>;
 };
 export type CounterValuesStatus = Record<
   string,


### PR DESCRIPTION
### 📝 Description

Step 5 of 6 in **Phase -1** of the countervalues domain migration. Deletes the **legacy** duplicate client for `/v3/supported/crypto` inside `libs/live-countervalues`, so `@domain/api-market-countervalues` has one legacy client fewer to absorb. **No behaviour change.**

Two clients hit that endpoint today. The one in `libs/ledger-live-common/src/counterValues/` is already new-architecture shaped — `createApi`, `fetchBaseQuery`, `@shared/env`, Zod schemas — and is the one the plan keeps. The legacy duplicate in `libs/live-countervalues` is deleted here.

**Deleted:** `fetchIdsSortedByMarketcap` from `src/api/api.ts`, its dispatcher entry in `src/api/index.ts`, its `CounterValuesAPI` type member in `src/types.ts`, and its mock in `src/api/api.mock.ts` — plus the now-orphaned `getIds()` helper and an unused import that only it needed.

**Kept deliberately:** `fetchHistorical` and `fetchLatest`. No duplicate exists for them and they are the core rate-fetch path.

### ✅ Verification

- `fetchIdsSortedByMarketcap` at **zero references** repo-wide.
- `libs/live-countervalues` tests: 28/28.
- `libs/coin-modules/coin-hedera`: **605/605, unchanged** — see below.
- `libs/ledger-live-common/src/counterValues/` and `currencies/hooks.ts` untouched.

### 👀 Notes for reviewers

- **This was safe to delete only because [LIVE-36826](https://ledgerhq.atlassian.net/browse/LIVE-36826) removed the last external caller.** Before that PR, `libs/ledger-live-common/src/currencies/sortByMarketcap.ts` still reached it via `currenciesByMarketcap`. Both tests exercising it in `mock.test.ts` were **removed rather than skipped**.
- **`coin-hedera` is published and calls `cvsApi.fetchLatest`** once at `src/network/utils.ts:207`. This PR does not touch `fetchLatest`, so hedera is unaffected. Decoupling hedera is Phase 0 work and needs #team-coin-integration — deliberately out of scope.
- **The `/v3/spot/simple` overlap is not duplication and was left alone.** `fetchLatest` takes many `from` currencies against one `to` and batches in chunks of 50; `getUsdToFiatRate` is a single usd-to-fiat lookup with its own cache lifetime. Unifying them belongs with the consolidated api package design.

### 👀 Reviewer note: TWO callers of `/v3/supported/crypto` remain after this, by design

The live-common RTK Query client, and `fetchMarketcapIds` in `currencies/sortByMarketcap.ts` (repointed in [#21510](https://github.com/LedgerHQ/ledger-live/pull/21510)).

This PR's job is narrower than "one client repo-wide": it deletes the duplicate **inside `libs/live-countervalues`**. Collapsing all CVS access to a single client is a **Phase 1** outcome, when `@domain/api-market-countervalues` absorbs the client and `sortByMarketcap.ts` calls it instead of holding its own fetch.

The exit-gate ticket originally demanded one caller at the end of Phase -1; that was mis-scoped and has been amended. See [LIVE-36829](https://ledgerhq.atlassian.net/browse/LIVE-36829).

### 🧱 Stack

Position 5 of 6. Based on **LIVE-36826**. Review the PRs below this one first.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36827](https://ledgerhq.atlassian.net/browse/LIVE-36827) — epic [LIVE-32360](https://ledgerhq.atlassian.net/browse/LIVE-32360)
- **ADR** (if any): [Countervalues Domain Migration Discovery](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7376502960/Countervalues+Domain+Migration+Discovery)


[LIVE-36826]: https://ledgerhq.atlassian.net/browse/LIVE-36826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ