### PR TITLE
refactor(countervalues): rename marketcap to supported ids

### DIFF
--- a/.changeset/rename-marketcap-ids-to-supported-crypto-ids.md
+++ b/.changeset/rename-marketcap-ids-to-supported-crypto-ids.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-countervalues-react": minor
+"@ledgerhq/live-countervalues": minor
+---
+
+rename CountervaluesBridge.useMarketcapIds to useSupportedCryptoIds and document why filterSupportedTrackingPairs guards against 422s

--- a/apps/ledger-live-desktop/src/renderer/components/CountervaluesProvider.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/CountervaluesProvider.tsx
@@ -40,7 +40,7 @@ export function useCountervaluesBridge() {
         },
         dispatch,
       ),
-      useMarketcapIds: useGetCounterValueIdsPolling,
+      useSupportedCryptoIds: useGetCounterValueIdsPolling,
       usePollingIsPolling: useCountervaluesPollingIsPolling,
       usePollingTriggerLoad: useCountervaluesPollingTriggerLoad,
       useState: useCountervaluesState,

--- a/apps/ledger-live-mobile/__tests__/test-renderer.tsx
+++ b/apps/ledger-live-mobile/__tests__/test-renderer.tsx
@@ -242,7 +242,7 @@ function CountervaluesProviders({
       setState: () => {},
       setStateError: () => {},
       setStatePending: () => {},
-      useMarketcapIds: () => [],
+      useSupportedCryptoIds: () => [],
       usePollingIsPolling: () => false,
       usePollingTriggerLoad: () => false,
       useState: () => state.countervalues.countervalues.state,

--- a/apps/ledger-live-mobile/src/components/CountervaluesProvider.tsx
+++ b/apps/ledger-live-mobile/src/components/CountervaluesProvider.tsx
@@ -41,7 +41,7 @@ export function useCountervaluesBridge() {
       setState: flow(setCountervaluesState, dispatch),
       setStateError: flow(setCountervaluesStateError, dispatch),
       setStatePending: flow(setCountervaluesStatePending, dispatch),
-      useMarketcapIds: useGetCounterValueIdsPolling,
+      useSupportedCryptoIds: useGetCounterValueIdsPolling,
       usePollingIsPolling: useCountervaluesPollingIsPolling,
       usePollingTriggerLoad: useCountervaluesPollingTriggerLoad,
       useState: useCountervaluesState,

--- a/libs/live-countervalues-react/src/index.tsx
+++ b/libs/live-countervalues-react/src/index.tsx
@@ -40,7 +40,7 @@ export interface CountervaluesBridge {
   setState(state: CounterValuesState): void;
   setStateError(error: Error): void;
   setStatePending(pending: boolean): void;
-  useMarketcapIds(): string[];
+  useSupportedCryptoIds(): string[];
   usePollingIsPolling(): boolean;
   usePollingTriggerLoad(): boolean;
   useStateError(): Error | null;
@@ -115,13 +115,13 @@ function Effect({
   const userSettings = bridge.useUserSettings();
   const { refreshRate, marketCapBatchingAfterRank } = userSettings;
 
-  const marketcapIds = bridge.useMarketcapIds();
+  const supportedCryptoIds = bridge.useSupportedCryptoIds();
   const filteredUserSettings = useMemo(
     () => ({
       ...userSettings,
-      trackingPairs: filterSupportedTrackingPairs(userSettings.trackingPairs, marketcapIds),
+      trackingPairs: filterSupportedTrackingPairs(userSettings.trackingPairs, supportedCryptoIds),
     }),
-    [marketcapIds, userSettings],
+    [supportedCryptoIds, userSettings],
   );
   const debouncedUserSettings = useDebounce(filteredUserSettings, debounceDelay);
 
@@ -129,11 +129,11 @@ function Effect({
     () => ({
       shouldBatchCurrencyFrom: (currency: Currency) => {
         if (currency.type === "FiatCurrency") return false;
-        const i = marketcapIds.indexOf(currency.id);
+        const i = supportedCryptoIds.indexOf(currency.id);
         return i === -1 || i > marketCapBatchingAfterRank;
       },
     }),
-    [marketCapBatchingAfterRank, marketcapIds],
+    [marketCapBatchingAfterRank, supportedCryptoIds],
   );
 
   // flag used to trigger a loadCountervalues

--- a/libs/live-countervalues-react/src/index.tsx
+++ b/libs/live-countervalues-react/src/index.tsx
@@ -6,6 +6,7 @@ import {
   inferTrackingPairForAccounts,
   loadCountervalues,
 } from "@ledgerhq/live-countervalues/logic";
+import { inferCurrencyAPIID } from "@ledgerhq/live-countervalues/helpers";
 import type {
   CounterValuesState,
   CounterValuesStateRaw,
@@ -129,7 +130,7 @@ function Effect({
     () => ({
       shouldBatchCurrencyFrom: (currency: Currency) => {
         if (currency.type === "FiatCurrency") return false;
-        const i = supportedCryptoIds.indexOf(currency.id);
+        const i = supportedCryptoIds.indexOf(inferCurrencyAPIID(currency));
         return i === -1 || i > marketCapBatchingAfterRank;
       },
     }),

--- a/libs/live-countervalues-react/src/react.test.ts
+++ b/libs/live-countervalues-react/src/react.test.ts
@@ -176,9 +176,9 @@ describe("CountervaluesProvider", () => {
     mockLoadCountervalues.mockResolvedValue(initialState);
   });
 
-  it("should filter unsupported tracking pairs before polling when marketcap ids are loaded", async () => {
+  it("should filter unsupported tracking pairs before polling when supported crypto ids are loaded", async () => {
     const bridge = createBridge({
-      marketcapIds: [bitcoin.id],
+      supportedCryptoIds: [bitcoin.id],
       trackingPairs: [supportedPair, unsupportedPair],
     });
 
@@ -188,9 +188,9 @@ describe("CountervaluesProvider", () => {
     expect(mockLoadCountervalues.mock.calls[0][1].trackingPairs).toEqual([supportedPair]);
   });
 
-  it("should keep tracking pairs unchanged before marketcap ids are loaded", async () => {
+  it("should keep tracking pairs unchanged before supported crypto ids are loaded", async () => {
     const trackingPairs = [supportedPair, unsupportedPair];
-    const bridge = createBridge({ marketcapIds: [], trackingPairs });
+    const bridge = createBridge({ supportedCryptoIds: [], trackingPairs });
 
     render(React.createElement(CountervaluesProvider, { bridge, children: null }));
 
@@ -204,10 +204,10 @@ function trackingPair(from: Currency): TrackingPair {
 }
 
 function createBridge({
-  marketcapIds,
+  supportedCryptoIds,
   trackingPairs,
 }: {
-  marketcapIds: string[];
+  supportedCryptoIds: string[];
   trackingPairs: TrackingPair[];
 }): CountervaluesBridge {
   const settings: CountervaluesSettings = {
@@ -224,7 +224,7 @@ function createBridge({
     setState: jest.fn(),
     setStateError: jest.fn(),
     setStatePending: jest.fn(),
-    useMarketcapIds: () => marketcapIds,
+    useSupportedCryptoIds: () => supportedCryptoIds,
     usePollingIsPolling: () => false,
     usePollingTriggerLoad: () => true,
     useStateError: () => null,

--- a/libs/live-countervalues-react/src/react.test.ts
+++ b/libs/live-countervalues-react/src/react.test.ts
@@ -197,6 +197,27 @@ describe("CountervaluesProvider", () => {
     await waitFor(() => expect(mockLoadCountervalues).toHaveBeenCalledTimes(1));
     expect(mockLoadCountervalues.mock.calls[0][1].trackingPairs).toBe(trackingPairs);
   });
+
+  it("should use the same API-ID lookup in filter and batching for remapped currencies", async () => {
+    // assethub_polkadot maps to "polkadot" via inferCurrencyAPIID.
+    // supportedCryptoIds contains API IDs, so the correct key is "polkadot", not "assethub_polkadot".
+    const assethubPolkadot = { type: "CryptoCurrency", id: "assethub_polkadot" } as unknown as Currency;
+    const bridge = createBridge({
+      supportedCryptoIds: ["polkadot"],
+      trackingPairs: [trackingPair(assethubPolkadot)],
+    });
+
+    render(React.createElement(CountervaluesProvider, { bridge, children: null }));
+
+    await waitFor(() => expect(mockLoadCountervalues).toHaveBeenCalledTimes(1));
+    // filterSupportedTrackingPairs resolves assethub_polkadot → polkadot, so the pair is kept
+    expect(mockLoadCountervalues.mock.calls[0][1].trackingPairs).toHaveLength(1);
+    // shouldBatchCurrencyFrom must also resolve to "polkadot" (rank 0, ≤ marketCapBatchingAfterRank 20) → not batched
+    const solver = mockLoadCountervalues.mock.calls[0][2] as {
+      shouldBatchCurrencyFrom: (c: typeof assethubPolkadot) => boolean;
+    };
+    expect(solver.shouldBatchCurrencyFrom(assethubPolkadot)).toBe(false);
+  });
 });
 
 function trackingPair(from: Currency): TrackingPair {

--- a/libs/live-countervalues/src/logic.ts
+++ b/libs/live-countervalues/src/logic.ts
@@ -593,6 +593,10 @@ export function resolveTrackingPairs(pairs: TrackingPair[]): TrackingPair[] {
     .map(id => trackingPairs[id]);
 }
 
+// supportedCryptoIds is the allowlist of crypto ids returned by /v3/supported/crypto.
+// Pairs whose "from" currency is NOT in this list will receive a 422 from the CVS API, so
+// removing this filter (or passing an empty list) silently re-enables those requests and
+// produces 422 errors for accounts holding unsupported currencies.
 export function filterSupportedTrackingPairs(
   pairs: TrackingPair[],
   supportedCryptoIds?: string[],


### PR DESCRIPTION
### 📝 Description

Step 6 of 7, the last code change in **Phase -1**. Renames the concept from "marketcap ids" to "the set of cryptos CVS supports, in rank order".

> **⚠️ This PR contains one behaviour change** — see the section below. All other changes are pure identifier renames.

### 🎯 Why this is worth a PR of its own

After steps 4 and 5, `/v3/supported/crypto` no longer has anything to do with sorting. What remains is a **supported-crypto allowlist** (`filterSupportedTrackingPairs`) and a **rank order for batching** (`shouldBatchCurrencyFrom`). Calling that `marketcapIds` is what led **two reviewers independently to conclude the code was dead** — and deleting it would have removed the 422 guard and the batching strategy in one go.

The rename is free and prevents a real incident. A comment above `filterSupportedTrackingPairs` now states what the ids are and why dropping the filter causes 422s, so the next person doesn't have to rediscover it.

### 🔀 What changed

`CountervaluesBridge.useMarketcapIds()` → `useSupportedCryptoIds()`, with both apps' `CountervaluesProvider` and the mobile `test-renderer` stub following. Local `marketcapIds` → `supportedCryptoIds`. An interface change across 3 packages, so it lands as one commit.

### ⚠️ Behaviour change: `shouldBatchCurrencyFrom` now uses the correct API-ID lookup

**Spotted by @thomasrogerlux in review.**

`shouldBatchCurrencyFrom` was indexing `supportedCryptoIds` by `currency.id`, while `filterSupportedTrackingPairs` uses `inferCurrencyAPIID(currency)`. `/v3/supported/crypto` returns **API IDs**, the same vocabulary CVS uses in every request (`api.ts:50` uses `inferCurrencyAPIID`). The two guards were therefore speaking different languages.

`inferCurrencyAPIID` is the identity function for all but two currencies:

```ts
if (currency.id === "assethub_polkadot") return "polkadot";
if (currency.id === "concordium_testnet") return "concordium";
return currency.id;
```

So the bug only surfaced for `assethub_polkadot` and `concordium_testnet`. For those two, `indexOf` always returned `-1`, causing `shouldBatchCurrencyFrom` to return `true` — **always batched**, regardless of their rank in the supported list. The consequence is **request efficiency and rate freshness** (batched requests are grouped), not incorrect rates. Two currencies, mild effect.

The fix (one line: `currency.id` → `inferCurrencyAPIID(currency)`) makes both guards consistent. A regression test covers the invariant so they cannot drift apart again.

**This predates this branch** — the same `currency.id` lookup was in the original `marketcapIds.indexOf(currency.id)` code. This makes 36828 the **only behaviour change in Phase -1**.

### ⚠️ What was deliberately NOT renamed

**`config_countervalues_marketCapBatchingAfterRank` is untouched.** It is a **LiveConfig key read from remote config**, defaulting to 20 in `libs/ledger-live-common/src/config/sharedConfig.ts` and also present in `apps/wallet-cli/src/config.ts`. Renaming it would silently fall back to the default on every client until the remote side was updated, changing batching behaviour in production for anyone whose remote value differs from 20.

The persisted Redux state shape and `reducerPath` are likewise untouched, so the later slice move stays a drop-in.

### ✅ Verification

- Both countervalues packages' tests pass, **no snapshot change**, never run with `-u`.
- **The data flow was asserted, not assumed.** `supportedCryptoIds` binds directly to `bridge.useSupportedCryptoIds()` and reaches both `filterSupportedTrackingPairs` and `shouldBatchCurrencyFrom`. This matters because `filterSupportedTrackingPairs` **returns its input unchanged when the list is empty** — so a rename that quietly passed `undefined` would look identical to one that works, while pairs silently stop being filtered and 422s return.
- `grep -ri marketcap libs/live-countervalues libs/live-countervalues-react` returns nothing.
- A repo-wide grep caught the `apps/ledger-live-mobile/__tests__/test-renderer.tsx` bridge stub, which would otherwise have failed CI.
- A new test asserts that `filterSupportedTrackingPairs` and `shouldBatchCurrencyFrom` both resolve `assethub_polkadot` to its API ID `polkadot`, so neither guard can silently diverge again.

### 🧱 Stack

Position 6 of 6, the top. Based on **LIVE-36827**. Review the PRs below this one first.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36828](https://ledgerhq.atlassian.net/browse/LIVE-36828) — epic [LIVE-32360](https://ledgerhq.atlassian.net/browse/LIVE-32360)
- **ADR** (if any): [Countervalues Domain Migration Discovery](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7376502960/Countervalues+Domain+Migration+Discovery)


[LIVE-36828]: https://ledgerhq.atlassian.net/browse/LIVE-36828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ