### PR TITLE
[LWDM] fix(countervalues): don't poll while refreshRate is zero

### DIFF
--- a/.changeset/wild-donkeys-invite.md
+++ b/.changeset/wild-donkeys-invite.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-countervalues-react": patch
+---
+
+Don't arm the countervalues polling loop while refreshRate is 0
+
+Both apps initialise `refreshRate` to 0 and overwrite it from LiveConfig once it resolves. Until then the loop re-armed itself with `setTimeout(pollingLoop, 0)`, so it spun at zero delay, dispatching `setPollingTriggerLoad(true)` into Redux on every tick. Polling now waits for a positive refresh rate; the effect already re-runs when one arrives.

--- a/libs/live-countervalues-react/src/index.tsx
+++ b/libs/live-countervalues-react/src/index.tsx
@@ -181,7 +181,10 @@ function Effect({
   // manage the auto polling loop
   const isPolling = bridge.usePollingIsPolling();
   useEffect(() => {
-    if (!isPolling) return;
+    // Both apps initialise refreshRate to 0 and overwrite it from LiveConfig once it resolves.
+    // Re-arming at 0 is a zero-delay self-rescheduling loop, so wait for a real rate; the effect
+    // re-runs when one arrives.
+    if (!isPolling || refreshRate <= 0) return;
     let pollingTimeout: ReturnType<typeof setTimeout>;
     function pollingLoop() {
       bridge.setPollingTriggerLoad(true);


### PR DESCRIPTION
The countervalues store starts with `isPolling: true` and `refreshRate: 0`, and the apps overwrite the rate from LiveConfig once it resolves. Until then the polling effect re-armed itself with `setTimeout(pollingLoop, 0)`, so it spun at zero delay and dispatched `setPollingTriggerLoad(true)` on every tick.

Wait for a positive rate. The effect already re-runs when one arrives, and LiveConfig defaults it to 60s, so app behaviour is unchanged.