### PR TITLE
[LWM] feat(send): open the contact address sheet

### DIFF
--- a/.changeset/quiet-picker-groups.md
+++ b/.changeset/quiet-picker-groups.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Open the contact address sheet from Send recipient.

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/__tests__/useContactAddressPicker.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/__tests__/useContactAddressPicker.test.ts
@@ -1,0 +1,57 @@
+import { act, renderHook } from "@tests/test-renderer";
+import { mockContact, mockContactAddress } from "@domain/entity-contact/schema.mock";
+import { NavigatorName, ScreenName } from "~/const";
+import { useContactAddressPicker } from "../useContactAddressPicker";
+
+const navigate = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate }),
+}));
+
+describe("useContactAddressPicker", () => {
+  const contact = mockContact({
+    id: "contact-ada",
+    name: "Ada",
+    addresses: [mockContactAddress({ id: "address-eth", currencyId: "ethereum" })],
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("opens the flow picker for a contact", () => {
+    const { result } = renderHook(() => useContactAddressPicker({ onSelectAddress: jest.fn() }));
+
+    act(() => result.current.open(contact));
+
+    expect(result.current.contactAddressPicker.contact).toBe(contact);
+    expect(result.current.contactAddressPicker.isOpen).toBe(true);
+    expect(result.current.contactAddressPicker.title).toBe("Select Ada's address");
+  });
+
+  it("closes the picker then reports the selected address", () => {
+    const onSelectAddress = jest.fn();
+    const { result } = renderHook(() => useContactAddressPicker({ onSelectAddress }));
+
+    act(() => result.current.open(contact));
+    act(() => result.current.contactAddressPicker.onSelectAddress(contact.addresses[0]));
+
+    expect(onSelectAddress).toHaveBeenCalledWith(contact.addresses[0]);
+    expect(result.current.contactAddressPicker.contact).toBeNull();
+  });
+
+  it("navigates to contact detail when adding an address", () => {
+    const { result } = renderHook(() => useContactAddressPicker({ onSelectAddress: jest.fn() }));
+
+    act(() => result.current.open(contact));
+    act(() => result.current.contactAddressPicker.onAddNewAddress?.());
+
+    expect(navigate).toHaveBeenCalledWith(NavigatorName.MyWallet, {
+      screen: ScreenName.MyWalletContactDetail,
+      params: { contactId: contact.id },
+    });
+    expect(result.current.contactAddressPicker.contact).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressPicker.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressPicker.ts
@@ -1,0 +1,46 @@
+import { useCallback, useRef } from "react";
+import { useNavigation } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import type { Contact, ContactAddress } from "@domain/entity-contact";
+import {
+  useContactAddressPickerViewModel,
+  type ContactAddressPickerProps,
+} from "@features/flow-pay-contact";
+import { NavigatorName, ScreenName } from "~/const";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+
+export type UseContactAddressPicker = Readonly<{
+  open: (contact: Contact) => void;
+  contactAddressPicker: ContactAddressPickerProps;
+}>;
+
+export function useContactAddressPicker({
+  onSelectAddress,
+}: Readonly<{
+  onSelectAddress: (address: ContactAddress) => void;
+}>): UseContactAddressPicker {
+  const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
+  const closeRef = useRef(() => {});
+
+  const onAddNewAddress = useCallback(
+    (contact: Contact) => {
+      closeRef.current();
+      navigation.navigate(NavigatorName.MyWallet, {
+        screen: ScreenName.MyWalletContactDetail,
+        params: { contactId: contact.id },
+      });
+    },
+    [navigation],
+  );
+
+  const { open, close, contactAddressPicker } = useContactAddressPickerViewModel({
+    onSelectAddress: (address: ContactAddress) => {
+      closeRef.current();
+      onSelectAddress(address);
+    },
+    onAddNewAddress,
+  });
+  closeRef.current = close;
+
+  return { open, contactAddressPicker };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
@@ -78,6 +78,39 @@ jest.mock("LLM/features/Contacts/hooks/useContactsAddressValidationAdapter", () 
   }),
 }));
 
+jest.mock("@shared/ui-queued-bottom-sheet", () => {
+  const actual = jest.requireActual("@shared/ui-queued-bottom-sheet");
+  const React = jest.requireActual<typeof import("react")>("react");
+  const { QueuedBottomSheet } = actual;
+
+  function MockQueuedBottomSheet({
+    isRequestingToBeOpened,
+    isForcingToBeOpened,
+    onOpened,
+    ...props
+  }: import("@shared/ui-queued-bottom-sheet").QueuedBottomSheetProps) {
+    const shouldOpen = !!(isRequestingToBeOpened || isForcingToBeOpened);
+    React.useEffect(() => {
+      if (shouldOpen) {
+        onOpened?.();
+      }
+    }, [onOpened, shouldOpen]);
+    return (
+      <QueuedBottomSheet
+        isRequestingToBeOpened={isRequestingToBeOpened}
+        isForcingToBeOpened={isForcingToBeOpened}
+        onOpened={onOpened}
+        {...props}
+      />
+    );
+  }
+
+  return {
+    ...actual,
+    QueuedBottomSheet: MockQueuedBottomSheet,
+  };
+});
+
 jest.mock("LLM/components/DeviceIntentExecutor", () => {
   const actual = jest.requireActual("LLM/components/DeviceIntentExecutor");
   const ReactModule = jest.requireActual("react");
@@ -282,7 +315,7 @@ describe("Send flow integration tests", () => {
     expect(screen.queryByTestId("send-add-to-existing-contact-step")).toBeNull();
   });
 
-  it("should show network contacts and advance when selecting a contact with one address", async () => {
+  it("should show network contacts and open the address sheet for a contact with one address", async () => {
     const contacts = [
       mockContact({
         id: "contact-vincent",
@@ -316,10 +349,13 @@ describe("Send flow integration tests", () => {
 
     await user.press(screen.getByTestId("contacts-compact-row-contact-vincent"));
 
+    expect(await screen.findByText("Select Vincent's address")).toBeVisible();
+    await user.press(screen.getByLabelText("Ethereum Main, " + VALID_ETHEREUM_RECIPIENT));
+
     expect(await screen.findByText("Review")).toBeVisible();
   });
 
-  it("should ask which address to use when a contact has several network addresses", async () => {
+  it("should open the address sheet when a contact has several network addresses", async () => {
     const contacts = [
       mockContact({
         id: "contact-benoit",
@@ -344,11 +380,11 @@ describe("Send flow integration tests", () => {
 
     await user.press(await screen.findByTestId("contacts-compact-row-contact-benoit"));
 
-    expect(await screen.findByText("Select address")).toBeVisible();
-    expect(screen.getByText("Benoit")).toBeVisible();
-    expect(screen.queryByTestId("recipient-input")).toBeNull();
+    expect(await screen.findByText("Select Benoit's address")).toBeVisible();
 
-    await user.press(screen.getByTestId("send-recipient-contact-address-address-benoit-coinbase"));
+    await user.press(
+      screen.getByLabelText("Ethereum Coinbase, 0x1234567890123456789012345678901234567890"),
+    );
 
     expect(await screen.findByText("Review")).toBeVisible();
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientScreenView.tsx
@@ -9,7 +9,7 @@ import { AddressMatchedSection } from "./AddressMatchedSection";
 import { AddressValidationError } from "./AddressValidationError";
 import { LoadingState } from "./LoadingState";
 import { PasteFromClipboard } from "./PasteFromClipboard";
-import { RecipientContactAddressSelection } from "./RecipientContactAddressSelection";
+import { ContactAddressPicker } from "@features/flow-pay-contact";
 import { RecipientContactsList } from "./RecipientContactsList";
 import { RecipientEmptyContactsState } from "./RecipientEmptyContactsState";
 import { ValidationBanner } from "./ValidationBanner";
@@ -36,9 +36,8 @@ export const RecipientScreenView = ({ viewModel }: RecipientScreenViewProps) => 
     showEmptyContactsState,
     contactsOnNetwork,
     contactSearchResult,
-    selectedContact,
     handleContactSelect,
-    handleContactAddressSelect,
+    contactAddressPicker,
     showBridgeSenderError,
     bridgeSenderError,
     showSanctionedBanner,
@@ -87,14 +86,6 @@ export const RecipientScreenView = ({ viewModel }: RecipientScreenViewProps) => 
             />
           )}
 
-          {selectedContact && (
-            <RecipientContactAddressSelection
-              contact={selectedContact}
-              network={recipient.mainAccount.currency}
-              onAddressSelect={handleContactAddressSelect}
-            />
-          )}
-
           {showMemo && <MemoControls vm={memo} />}
 
           {showMatched && <AddressMatchedSection viewModel={addressMatchedSectionViewModel} />}
@@ -128,6 +119,7 @@ export const RecipientScreenView = ({ viewModel }: RecipientScreenViewProps) => 
           )}
         </ScrollView>
       </KeyboardAvoidingView>
+      <ContactAddressPicker {...contactAddressPicker} />
     </SendFlowLayout>
   );
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenView.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenView.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react-native";
+import { act, renderHook } from "@tests/test-renderer";
 import { useRecipientScreenView } from "../useRecipientScreenView";
 import { useAddressValidation } from "../useAddressValidation";
 import { useClipboardRecipient } from "../useClipboardRecipient";
@@ -290,45 +290,8 @@ describe("useRecipientScreenView", () => {
     });
   });
 
-  it("advances with the address matching the current currency among network addresses", () => {
+  it("opens the address sheet when a contact is selected", () => {
     const onAddressSelected = jest.fn();
-    const contact = mockContact({
-      addresses: [
-        mockContactAddress({
-          id: "address-eth",
-          currencyId: "ethereum",
-          address: "0xeth",
-        }),
-        mockContactAddress({
-          id: "address-usdt",
-          currencyId: "ethereum/erc20/usdt",
-          address: "0xusdt",
-        }),
-      ],
-    });
-
-    const { result } = renderHook(() =>
-      useRecipientScreenView({
-        account: mockAccount,
-        currency: createMockTokenCurrency(),
-        onAddressSelected,
-        recipientSupportsDomain: true,
-      }),
-    );
-
-    act(() => result.current.handleContactSelect(contact));
-
-    expect(onAddressSelected).toHaveBeenCalledWith("0xusdt", undefined);
-  });
-
-  it("advances straight to the next step for a contact with one address", () => {
-    const onAddressSelected = jest.fn();
-    const selectContact = jest.fn();
-    mockedUseRecipientContactSelection.mockReturnValue({
-      selectedContact: undefined,
-      selectContact,
-      clearSelectedContact: jest.fn(),
-    });
     const contact = mockContact({
       addresses: [
         mockContactAddress({
@@ -349,51 +312,12 @@ describe("useRecipientScreenView", () => {
 
     act(() => result.current.handleContactSelect(contact));
 
-    expect(onAddressSelected).toHaveBeenCalledWith(
-      "0x1234567890123456789012345678901234567890",
-      undefined,
-    );
-    expect(selectContact).not.toHaveBeenCalled();
-  });
-
-  it("opens address selection when a contact has several compatible addresses", () => {
-    const onAddressSelected = jest.fn();
-    const selectContact = jest.fn();
-    mockedUseRecipientContactSelection.mockReturnValue({
-      selectedContact: undefined,
-      selectContact,
-      clearSelectedContact: jest.fn(),
-    });
-    const contact = mockContact({
-      addresses: [
-        mockContactAddress({ id: "address-one", currencyId: "ethereum" }),
-        mockContactAddress({ id: "address-two", currencyId: "ethereum" }),
-      ],
-    });
-
-    const { result } = renderHook(() =>
-      useRecipientScreenView({
-        account: mockAccount,
-        currency: createMockCurrency({ id: "ethereum" }),
-        onAddressSelected,
-        recipientSupportsDomain: true,
-      }),
-    );
-
-    act(() => result.current.handleContactSelect(contact));
-
-    expect(selectContact).toHaveBeenCalledWith(contact);
+    expect(result.current.contactAddressPicker.contact).toBe(contact);
     expect(onAddressSelected).not.toHaveBeenCalled();
   });
 
-  it("opens address selection when several network addresses remain without a currency match", () => {
+  it("fills the recipient after an address is chosen in the sheet", () => {
     const onAddressSelected = jest.fn();
-    const selectContact = jest.fn();
-    mockedUseRecipientContactSelection.mockReturnValue({
-      selectedContact: undefined,
-      selectContact,
-      clearSelectedContact: jest.fn(),
-    });
     const contact = mockContact({
       addresses: [
         mockContactAddress({
@@ -401,36 +325,7 @@ describe("useRecipientScreenView", () => {
           currencyId: "ethereum",
           address: "0xeth",
         }),
-        mockContactAddress({
-          id: "address-usdc",
-          currencyId: "ethereum/erc20/usd_coin",
-          address: "0xusdc",
-        }),
       ],
-    });
-
-    const { result } = renderHook(() =>
-      useRecipientScreenView({
-        account: mockAccount,
-        currency: createMockTokenCurrency(),
-        onAddressSelected,
-        recipientSupportsDomain: true,
-      }),
-    );
-
-    act(() => result.current.handleContactSelect(contact));
-
-    expect(selectContact).toHaveBeenCalledWith(contact);
-    expect(onAddressSelected).not.toHaveBeenCalled();
-  });
-
-  it("advances with the chosen address after contact address selection", () => {
-    const onAddressSelected = jest.fn();
-    const clearSelectedContact = jest.fn();
-    mockedUseRecipientContactSelection.mockReturnValue({
-      selectedContact: undefined,
-      selectContact: jest.fn(),
-      clearSelectedContact,
     });
 
     const { result } = renderHook(() =>
@@ -442,10 +337,11 @@ describe("useRecipientScreenView", () => {
       }),
     );
 
-    act(() => result.current.handleContactAddressSelect("0x456"));
+    act(() => result.current.handleContactSelect(contact));
+    act(() => result.current.contactAddressPicker.onSelectAddress(contact.addresses[0]));
 
-    expect(clearSelectedContact).toHaveBeenCalledTimes(1);
-    expect(onAddressSelected).toHaveBeenCalledWith("0x456", undefined);
+    expect(onAddressSelected).toHaveBeenCalledWith("0xeth", undefined);
+    expect(result.current.contactAddressPicker.contact).toBeNull();
   });
 
   it("shows an exact contact search result when its network address is ambiguous", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenView.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenView.ts
@@ -3,13 +3,13 @@ import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { isEligibleAddressCurrency } from "@ledgerhq/live-common/flows/send/recipient/utils/isEligibleAddressCurrency";
 import { useRecipientSearchState } from "@ledgerhq/live-common/flows/send/recipient/hooks/useRecipientSearchState";
 import { filterContactsByNetwork } from "@ledgerhq/live-common/flows/send/recipient/utils/filterContactsByNetwork";
-import { pickContactAddressForCurrency } from "@ledgerhq/live-common/flows/send/recipient/utils/pickContactAddressForCurrency";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import type { CryptoCurrency } from "@domain/entity-currency-crypto";
 import type { TokenCurrency } from "@domain/entity-currency-token";
-import type { Contact } from "@domain/entity-contact";
+import type { Contact, ContactAddress } from "@domain/entity-contact";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import { useCallback, useMemo } from "react";
+import { useContactAddressPicker } from "LLM/features/Contacts/hooks/useContactAddressPicker";
 import { useSendFlowData } from "../../../context/SendFlowContext";
 import { useRecipientContactSelection } from "../../../context/RecipientContactSelectionContext";
 import { useContactsFeatureIntroductionViewModel } from "./useContactsFeatureIntroductionViewModel";
@@ -37,7 +37,7 @@ export function useRecipientScreenView({
   const contacts = useContacts();
   const { isEnabled: isContactsFeatureEnabled, eligibleAddressFamilies } =
     useContactsFeature("mobile");
-  const { selectedContact, selectContact, clearSelectedContact } = useRecipientContactSelection();
+  const { selectedContact } = useRecipientContactSelection();
 
   const mainAccount = getMainAccount(account, parentAccount);
   const hasAddressBook = isEligibleAddressCurrency(eligibleAddressFamilies, currency);
@@ -109,25 +109,21 @@ export function useRecipientScreenView({
     [onAddressSelected],
   );
 
+  const handleContactAddressSelect = useCallback(
+    (address: ContactAddress) => {
+      handleAddressSelect(address.address);
+    },
+    [handleAddressSelect],
+  );
+  const { open: openPicker, contactAddressPicker } = useContactAddressPicker({
+    onSelectAddress: handleContactAddressSelect,
+  });
+
   const handleContactSelect = useCallback(
     (contact: Contact) => {
-      const address = pickContactAddressForCurrency(contact.addresses, currency.id);
-      if (address) {
-        handleAddressSelect(address.address);
-        return;
-      }
-
-      selectContact(contact);
+      openPicker(contact);
     },
-    [currency.id, handleAddressSelect, selectContact],
-  );
-
-  const handleContactAddressSelect = useCallback(
-    (address: string) => {
-      clearSelectedContact();
-      handleAddressSelect(address);
-    },
-    [clearSelectedContact, handleAddressSelect],
+    [openPicker],
   );
 
   const featureIntroduction = useContactsFeatureIntroductionViewModel({
@@ -161,7 +157,7 @@ export function useRecipientScreenView({
     handlePasteFromClipboard,
     handleAddressSelect,
     handleContactSelect,
-    handleContactAddressSelect,
+    contactAddressPicker,
     isContactsFeatureEnabled,
     featureIntroduction,
     ...searchState,


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Send recipient must use the shared Pay contact address sheet. This PR mounts the picker from #21537 on the existing Send flow.

**Problem:** Tapping a contact on Send recipient did not open `Select {{name}}'s address`.

**Solution:**
- `useContactAddressPicker` wraps the flow VM: close the sheet, then navigate to `MyWallet` / contact detail for Add address
- Send recipient: tap a contact (0 / 1 / 2+ addresses) → same sheet. Pick an address → fill the current send. Stay on Send.

Depends on #21537. Pay strip is still unwired (#21526).

https://github.com/user-attachments/assets/07bf1b63-abfd-4126-83a6-a53ff5dd428e




### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36371](https://ledgerhq.atlassian.net/browse/LIVE-36371)
- **ADR** (if any): none
- **Figma**: [address sheet](https://www.figma.com/design/WYQQwem0QyG2fTuaAKAe3Y/Pay-%E2%80%A2-Production?node-id=6784-65588&m=dev)

### QA

Flag `lwmContacts` on. Start a Send with an account already selected.

1. Tap a contact with 0, 1, or several addresses
2. Sheet `Select {{name}}'s address` opens in every case
3. Pick an address: recipient fills, you stay on Send (no Account to debit)
4. Add address opens contact detail

[LIVE-36371]: https://ledgerhq.atlassian.net/browse/LIVE-36371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
