### PR TITLE
[LWM] feat(pay): pay a contact from the strip

### DIFF
--- a/.changeset/calm-strip-picker.md
+++ b/.changeset/calm-strip-picker.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Open the contact address sheet from the Pay strip and continue to MAD with the chosen recipient.

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
@@ -10,6 +10,12 @@ import { ScreenName } from "~/const";
 import { track } from "~/analytics";
 import { screen as trackScreen } from "~/analytics/segment";
 import {
+  mockContact,
+  mockContactWithAddress,
+  mockContactWithMultipleAddresses,
+  mockMeContact,
+} from "@domain/entity-contact/schema.mock";
+import {
   EMPTY_DESCRIPTION,
   EMPTY_TITLE,
   FEATURE_TOUR_CTA,
@@ -52,8 +58,10 @@ jest.mock("@shared/ui-queued-bottom-sheet", () => {
   }: QueuedBottomSheetProps) {
     const shouldOpen = !!(isRequestingToBeOpened || isForcingToBeOpened);
     React.useEffect(() => {
-      if (shouldOpen) onOpened?.();
-    }, [shouldOpen, onOpened]);
+      if (shouldOpen) {
+        onOpened?.();
+      }
+    }, [onOpened, shouldOpen]);
     return (
       <QueuedBottomSheet
         isRequestingToBeOpened={isRequestingToBeOpened}
@@ -489,6 +497,90 @@ describe("PayTab integration", () => {
       expect(await screen.findByTestId("my-wallet-contacts-screen")).toHaveTextContent(
         `${ScreenName.MyWalletContacts}:Pay contact`,
       );
+    });
+
+    it("should pick a contact address before opening MAD", async () => {
+      const contact = mockContactWithMultipleAddresses({
+        id: "contact-stephanie",
+        name: "Stephanie",
+      });
+      const address = contact.addresses[0];
+      const { user, store } = renderPayTab({
+        contacts: [mockMeContact(), contact],
+        contactsEnabled: true,
+      });
+
+      await user.press(await screen.findByRole("button", { name: "Stephanie" }));
+
+      expect(await screen.findByText("Select Stephanie's address")).toBeVisible();
+
+      await user.press(screen.getByLabelText(`${address.label}, ${address.address}`));
+
+      expect(store.getState().modularDrawer).toMatchObject({
+        isOpen: true,
+        flow: "send",
+        source: "Pay",
+        preselectedCurrencies: [address.currencyId],
+      });
+      expect(
+        screen.queryByText(`${ScreenName.SendCoin}:${address.currencyId}`),
+      ).not.toBeOnTheScreen();
+    });
+
+    it("should still open the address sheet when the contact has one address", async () => {
+      const contact = mockContactWithAddress({
+        id: "contact-yana",
+        name: "Yana",
+      });
+      const address = contact.addresses[0];
+      const { user, store } = renderPayTab({
+        contacts: [mockMeContact(), contact],
+        contactsEnabled: true,
+      });
+
+      await user.press(await screen.findByRole("button", { name: "Yana" }));
+
+      expect(await screen.findByText("Select Yana's address")).toBeVisible();
+
+      await user.press(screen.getByLabelText(`${address.label}, ${address.address}`));
+
+      expect(store.getState().modularDrawer).toMatchObject({
+        isOpen: true,
+        flow: "send",
+        preselectedCurrencies: [address.currencyId],
+      });
+    });
+
+    it("should open the contact to add an address when the picker has none", async () => {
+      const contact = mockContact({
+        id: "contact-rosa",
+        name: "Rosa",
+      });
+      const { user } = renderPayTab({
+        contacts: [mockMeContact(), contact],
+        contactsEnabled: true,
+      });
+
+      await user.press(await screen.findByRole("button", { name: "Rosa" }));
+
+      expect(await screen.findByText("Select Rosa's address")).toBeVisible();
+
+      await user.press(screen.getByText("Add address"));
+
+      expect(
+        await screen.findByText(`${ScreenName.MyWalletContactDetail}:${contact.id}`),
+      ).toBeVisible();
+    });
+
+    it("should open the modular send drawer from New", async () => {
+      const { user, store } = renderPayTab({
+        contacts: seedContacts(2),
+        contactsEnabled: true,
+      });
+
+      await user.press(await screen.findByTestId("pay-contacts-pay-tile"));
+
+      expect(store.getState().modularDrawer.isOpen).toBe(true);
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/shared.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/shared.tsx
@@ -63,8 +63,18 @@ type TestStackParamList = {
   };
   [NavigatorName.MyWallet]:
     | {
-        screen: ScreenName.MyWalletContacts;
+        screen: typeof ScreenName.MyWalletContacts;
         params?: { title?: string };
+      }
+    | {
+        screen: typeof ScreenName.MyWalletContactDetail;
+        params: { contactId: string };
+      }
+    | undefined;
+  [NavigatorName.SendFunds]:
+    | {
+        screen: ScreenName.SendCoin;
+        params?: { currencyIds?: string[] };
       }
     | undefined;
 };
@@ -85,9 +95,30 @@ function ReceiveFundsScreen({
 function MyWalletContactsScreen({
   route,
 }: NativeStackScreenProps<TestStackParamList, NavigatorName.MyWallet>) {
+  const screenName = route.params?.screen;
+  const params = route.params?.params;
+  const detail = params && "contactId" in params ? params.contactId : undefined;
+  const title = params && "title" in params ? params.title : undefined;
+
   return (
-    <Text testID="my-wallet-contacts-screen">
-      {route.params?.screen}:{route.params?.params?.title}
+    <Text
+      testID={
+        screenName === ScreenName.MyWalletContactDetail
+          ? "my-wallet-contact-detail-screen"
+          : "my-wallet-contacts-screen"
+      }
+    >
+      {screenName}:{title ?? detail ?? ""}
+    </Text>
+  );
+}
+
+function SendFundsScreen({
+  route,
+}: NativeStackScreenProps<TestStackParamList, NavigatorName.SendFunds>) {
+  return (
+    <Text testID="send-funds-screen">
+      {route.params?.screen}:{route.params?.params?.currencyIds?.join(",") ?? ""}
     </Text>
   );
 }
@@ -209,6 +240,7 @@ export function renderPayTab({
         <Stack.Screen name="PayTabTest" component={PayTabNavigator} />
         <Stack.Screen name={NavigatorName.ReceiveFunds} component={ReceiveFundsScreen} />
         <Stack.Screen name={NavigatorName.MyWallet} component={MyWalletContactsScreen} />
+        <Stack.Screen name={NavigatorName.SendFunds} component={SendFundsScreen} />
       </Stack.Navigator>
       <ModularDrawerWrapper />
     </>,

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/__tests__/usePayTabContacts.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/__tests__/usePayTabContacts.test.tsx
@@ -10,24 +10,23 @@ jest.mock("@react-navigation/native", () => ({
   useNavigation: () => ({ navigate: mockNavigate }),
 }));
 
-jest.mock("../usePayTabNewPayment", () => ({
-  usePayTabNewPayment: () => ({ open: mockOpen }),
-}));
-
 describe("usePayTabContacts", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it("wires the Pay tile to the Send flow", () => {
-    const { result } = renderHook(() => usePayTabContacts());
+  it("wires the New tile to open send", () => {
+    const { result } = renderHook(() => usePayTabContacts(mockOpen));
 
     act(() => result.current.onPay());
+
     expect(mockOpen).toHaveBeenCalledTimes(1);
+    expect(mockOpen).toHaveBeenCalledWith();
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it("opens the full contacts list from the My Wallet stack with a Pay title on see-all", () => {
-    const { result } = renderHook(() => usePayTabContacts());
+    const { result } = renderHook(() => usePayTabContacts(mockOpen));
 
     act(() => result.current.onSeeAll?.());
 

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/__tests__/usePayTabNewPayment.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/__tests__/usePayTabNewPayment.test.ts
@@ -1,10 +1,6 @@
 import { act, renderHook } from "@tests/test-renderer";
 import { AssetCategory } from "@domain/api-aggregated-assets";
-import {
-  mockContact,
-  mockContactWithAddress,
-  mockContactWithMultipleAddresses,
-} from "@domain/entity-contact/schema.mock";
+import { mockContact, mockContactAddress } from "@domain/entity-contact/schema.mock";
 import { useOpenSendFlow } from "LLM/features/Send/hooks/useOpenSendFlow";
 import { usePayTabNewPayment } from "../usePayTabNewPayment";
 
@@ -21,41 +17,49 @@ describe("usePayTabNewPayment", () => {
     });
   });
 
-  it("should configure and open the send flow from the Pay page filtered to stablecoins", () => {
-    const { result } = renderHook(() => usePayTabNewPayment());
+  it("should configure send from Pay", () => {
+    renderHook(() => usePayTabNewPayment());
 
     expect(mockUseOpenSendFlow).toHaveBeenCalledWith({
       sourceScreenName: "Pay",
-      categories: [AssetCategory.Stablecoins],
     });
+  });
+
+  it("should open that send flow when New is pressed without a contact", () => {
+    const { result } = renderHook(() => usePayTabNewPayment());
 
     act(() => result.current.open());
 
-    expect(mockHandleOpenSendFlow).toHaveBeenCalledWith();
-  });
-
-  it("should prefill the recipient and network for a contact with one address", () => {
-    const contact = mockContactWithAddress();
-    const address = contact.addresses[0];
-    const { result } = renderHook(() => usePayTabNewPayment());
-
-    act(() => result.current.open(contact));
-
     expect(mockHandleOpenSendFlow).toHaveBeenCalledWith({
-      currencyIds: [address.currencyId],
-      recipient: address.address,
-      skipRecipientStep: true,
+      categories: [AssetCategory.Stablecoins],
     });
   });
 
-  it.each([
-    ["no address", mockContact()],
-    ["multiple addresses", mockContactWithMultipleAddresses()],
-  ])("should keep the account picker for a contact with %s", (_case, contact) => {
+  it("should open the address sheet instead of send when a contact is selected", () => {
+    const contact = mockContact();
     const { result } = renderHook(() => usePayTabNewPayment());
 
     act(() => result.current.open(contact));
 
-    expect(mockHandleOpenSendFlow).toHaveBeenCalledWith();
+    expect(result.current.contactAddressPicker.contact).toBe(contact);
+    expect(mockHandleOpenSendFlow).not.toHaveBeenCalled();
+  });
+
+  it("should open MAD for the selected address currency", () => {
+    const address = mockContactAddress({
+      currencyId: "ethereum",
+      address: "0xeth",
+    });
+    const contact = mockContact({ addresses: [address] });
+    const { result } = renderHook(() => usePayTabNewPayment());
+
+    act(() => result.current.open(contact));
+    act(() => result.current.contactAddressPicker.onSelectAddress(address));
+
+    expect(mockHandleOpenSendFlow).toHaveBeenCalledWith({
+      currencyIds: ["ethereum"],
+      recipient: "0xeth",
+      skipRecipientStep: true,
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabContacts.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabContacts.ts
@@ -6,30 +6,29 @@ import type { ContactsNativeProps } from "@features/flow-pay-contact";
 import { useTranslation } from "@shared/i18n";
 import { NavigatorName, ScreenName } from "~/const";
 import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
-import { usePayTabNewPayment } from "./usePayTabNewPayment";
 import { usePayTabOutgoingOperations } from "./usePayTabOutgoingOperations";
 
-export function usePayTabContacts(): ContactsNativeProps {
+export function usePayTabContacts(open: (contact?: Contact) => void): ContactsNativeProps {
   const { t } = useTranslation();
-  const { open } = usePayTabNewPayment();
   const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
   const outgoingOperations = usePayTabOutgoingOperations();
 
-  const onSeeAll = useCallback(() => {
+  const openPayContactList = useCallback(() => {
     navigation.navigate(NavigatorName.MyWallet, {
       screen: ScreenName.MyWalletContacts,
       params: { title: t("payTab.contacts.seeAllTitle") },
     });
   }, [navigation, t]);
+  const onPay = useCallback(() => open(), [open]);
   const onContactPress = useCallback((contact: Contact) => open(contact), [open]);
 
   return useMemo(
     () => ({
-      onPay: open,
+      onPay,
       onContactPress,
-      onSeeAll,
+      onSeeAll: openPayContactList,
       outgoingOperations,
     }),
-    [open, onContactPress, onSeeAll, outgoingOperations],
+    [onContactPress, onPay, openPayContactList, outgoingOperations],
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabNewPayment.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabNewPayment.ts
@@ -1,42 +1,45 @@
 import { useCallback } from "react";
 import { AssetCategory } from "@domain/api-aggregated-assets";
-import type { Contact } from "@domain/entity-contact";
+import type { Contact, ContactAddress } from "@domain/entity-contact";
+import type { ContactAddressPickerProps } from "@features/flow-pay-contact";
+import { useContactAddressPicker } from "LLM/features/Contacts/hooks/useContactAddressPicker";
 import { useOpenSendFlow } from "LLM/features/Send/hooks/useOpenSendFlow";
-
-const PAY_PAGE = "Pay";
-const PAY_CATEGORIES: AssetCategory[] = [AssetCategory.Stablecoins];
 
 export type UsePayTabNewPayment = Readonly<{
   open: (contact?: Contact) => void;
+  contactAddressPicker: ContactAddressPickerProps;
 }>;
 
 export function usePayTabNewPayment(): UsePayTabNewPayment {
   const { handleOpenSendFlow } = useOpenSendFlow({
-    sourceScreenName: PAY_PAGE,
-    categories: PAY_CATEGORIES,
+    sourceScreenName: "Pay",
   });
 
-  const open = useCallback(
-    (contact?: Contact) => {
-      // Prefill the recipient only when the contact has a single saved address; with zero or
-      // several addresses we keep the account/network picker so the user resolves the ambiguity.
-      const contactAddress = contact?.addresses.length === 1 ? contact.addresses[0] : undefined;
-      if (contactAddress) {
-        // Scope account selection to the contact address' currency so the picked account is on the
-        // same network, then skip to the amount step where the header resolves the prefilled
-        // address back to the contact and shows the "To <contact>" header.
-        handleOpenSendFlow({
-          currencyIds: [contactAddress.currencyId],
-          recipient: contactAddress.address,
-          skipRecipientStep: true,
-        });
-        return;
-      }
-
-      handleOpenSendFlow();
+  const payFromAddress = useCallback(
+    (address: ContactAddress) => {
+      handleOpenSendFlow({
+        currencyIds: [address.currencyId],
+        recipient: address.address,
+        skipRecipientStep: true,
+      });
     },
     [handleOpenSendFlow],
   );
+  const { open: openPicker, contactAddressPicker } = useContactAddressPicker({
+    onSelectAddress: payFromAddress,
+  });
 
-  return { open };
+  const open = useCallback(
+    (nextContact?: Contact) => {
+      if (!nextContact) {
+        handleOpenSendFlow({ categories: [AssetCategory.Stablecoins] });
+        return;
+      }
+
+      openPicker(nextContact);
+    },
+    [handleOpenSendFlow, openPicker],
+  );
+
+  return { open, contactAddressPicker };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/PayTabView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/PayTabView.tsx
@@ -4,7 +4,12 @@ import { FeatureTour, type FeatureTourProps } from "@features/flow-pay-feature-t
 import { Balance, type ActionTilesProps, type BalanceData } from "@features/flow-pay-balance";
 import { BankTransferIntro, type BankTransferIntroProps } from "@features/flow-pay-bank-transfer";
 import { DepositOptions, type DepositOptionsProps } from "@features/flow-pay-deposit";
-import { Contacts, type ContactsNativeProps } from "@features/flow-pay-contact";
+import {
+  ContactAddressPicker,
+  Contacts,
+  type ContactAddressPickerProps,
+  type ContactsNativeProps,
+} from "@features/flow-pay-contact";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { Wallet40Background } from "LLM/components/Wallet40Background";
 import { TrackScreen } from "~/analytics";
@@ -18,6 +23,7 @@ type PayTabViewProps = {
   readonly balance: BalanceData;
   readonly actionTiles: ActionTilesProps;
   readonly contacts: ContactsNativeProps;
+  readonly contactAddressPicker: ContactAddressPickerProps;
   readonly isContactsEnabled: boolean;
   readonly depositOptions: DepositOptionsProps;
   readonly bankTransferIntro: BankTransferIntroProps;
@@ -32,6 +38,7 @@ export function PayTabView({
   balance,
   actionTiles,
   contacts,
+  contactAddressPicker,
   isContactsEnabled,
   depositOptions,
   bankTransferIntro,
@@ -43,6 +50,7 @@ export function PayTabView({
         <TrackScreen category="Pay" balance_filter={balance.filter} />
         <Balance {...balance} actionTiles={actionTiles} />
         {isContactsEnabled && <Contacts {...contacts} />}
+        <ContactAddressPicker {...contactAddressPicker} />
         <Card title={cardTitle} oauthConfig={oauthConfig} callback={callback} />
         <FeatureTour {...featureTour} />
         <DepositOptions {...depositOptions} />

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
@@ -12,6 +12,7 @@ import { usePayCardBalance } from "LLM/features/PayTab/hooks/usePayCardBalance";
 import { usePayTabActionTiles } from "LLM/features/PayTab/hooks/usePayTabActionTiles";
 import { usePayTabContacts } from "LLM/features/PayTab/hooks/usePayTabContacts";
 import { usePayTabDepositOptions } from "LLM/features/PayTab/hooks/usePayTabDepositOptions";
+import { usePayTabNewPayment } from "LLM/features/PayTab/hooks/usePayTabNewPayment";
 import { usePayTabRequestReceive } from "LLM/features/PayTab/hooks/usePayTabRequestReceive";
 import { track } from "~/analytics";
 import { PAY_TAB_DEEP_LINK } from "~/navigation/deeplinks/payTabDeepLink";
@@ -25,7 +26,8 @@ export function usePayTabViewModel() {
   const deposit = usePayTabDepositOptions(balance.onTrackEvent);
   const request = usePayTabRequestReceive();
   const actionTiles = usePayTabActionTiles(balance.onTrackEvent, deposit.open, request.open);
-  const contacts = usePayTabContacts();
+  const payment = usePayTabNewPayment();
+  const contacts = usePayTabContacts(payment.open);
   const { isEnabled: isContactsEnabled } = useContactsFeature("mobile");
 
   // Read with `useEnv`, and not with `getEnv`: a tester sets these in the debug settings, and the
@@ -69,6 +71,7 @@ export function usePayTabViewModel() {
     balance,
     actionTiles,
     contacts,
+    contactAddressPicker: payment.contactAddressPicker,
     isContactsEnabled,
     depositOptions: deposit.depositOptions,
     bankTransferIntro: deposit.bankTransferIntro,


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

A tap on a Pay strip contact needs to pick an address, then open MAD so the user picks the account to debit. This PR mounts the picker from #21522 and wires the handoff.

**Problem:** The Pay strip showed contacts but could not start a payment to a saved address.

**Solution:**
- Tap a contact on the strip → `Select {{name}}'s address`
- Zero, one, or many addresses: same sheet
- Address press → MAD for that currency, recipient prefilled
- Add address opens the contact detail screen
- New without a contact still opens MAD (stablecoins). See-all is #21527

Jira still mentions skip-on-single-address and MAD. Implemented flow is always-open sheet, then MAD.






### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36372](https://ledgerhq.atlassian.net/browse/LIVE-36372)
- **ADR** (if any): none
- **Depends on**: [#21522](https://github.com/LedgerHQ/ledger-live/pull/21522)
- **Figma**: [address sheet](https://www.figma.com/design/WYQQwem0QyG2fTuaAKAe3Y/Pay-%E2%80%A2-Production?node-id=6784-65588&m=dev)

### QA

Flag `lwmContacts` on. Open Pay.

1. Contact with two or more addresses: tap → sheet → pick a row → MAD
2. Contact with one address: same sheet, then MAD
3. Contact with no address: sheet → Add address → contact detail
4. New still opens MAD when there is no one to pay

[LIVE-36372]: https://ledgerhq.atlassian.net/browse/LIVE-36372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
