### PR TITLE
feat(pay-card): drive freeze and unfreeze from the devtool

### DIFF
--- a/.changeset/pay-card-devtools-freeze-unfreeze.md
+++ b/.changeset/pay-card-devtools-freeze-unfreeze.md
@@ -1,0 +1,8 @@
+---
+"@devtools/bindings": minor
+---
+
+Add Freeze Card and Unfreeze Card to the Card interaction screen.
+
+- Both sit next to Card Status as probes, so one screen drives the card's whole state.
+- Freezing and unfreezing invalidate `CardStatus`, so a status already read refreshes itself without a second press.

--- a/.changeset/pay-card-link-unlink-wallet.md
+++ b/.changeset/pay-card-link-unlink-wallet.md
@@ -1,0 +1,9 @@
+---
+"@domain/api-card-management": minor
+---
+
+Add `linkCardWallet` and `unlinkCardWallet` for `POST` and `DELETE /v1/wallet/internal/card_linked`.
+
+- Both identify the wallet by `addressId`, which is now kept from `/v1/wallet/internal` rather than dropped: without it neither endpoint can be called.
+- Both invalidate a new `CardLinkedWallets` tag that `getCardLinkedWallets` provides, so the charging order reloads itself.
+- Neither touches the internal wallets: unlinking leaves the wallet and its funds alone.

--- a/devtools/bindings/src/usePayCardToolProps.test.tsx
+++ b/devtools/bindings/src/usePayCardToolProps.test.tsx
@@ -221,6 +221,27 @@ describe("usePayCardToolProps", () => {
     expect(result.current.balance.isFetching).toBe(true);
   });
 
+  it("offers a probe per Card endpoint the tool can call, in the order they are read", () => {
+    const store = buildStore();
+    const { result } = renderHook(() => usePayCardToolProps(), { wrapper: withStore(store) });
+
+    expect(result.current.interaction.probes.map(({ id, label }) => [id, label])).toEqual([
+      ["card-status", "Card Status"],
+      ["freeze-card", "Freeze Card"],
+      ["unfreeze-card", "Unfreeze Card"],
+    ]);
+  });
+
+  it("starts every probe idle, with nothing answered and nothing failed", () => {
+    const store = buildStore();
+    const { result } = renderHook(() => usePayCardToolProps(), { wrapper: withStore(store) });
+
+    for (const probe of result.current.interaction.probes) {
+      expect(probe).toMatchObject({ isFetching: false, result: undefined, error: undefined });
+      expect(typeof probe.run).toBe("function");
+    }
+  });
+
   it("exposes hasSeenFeatureTour from the payCard slice", () => {
     store.dispatch(markPayCardFeatureTourSeen());
 

--- a/devtools/bindings/src/usePayCardToolProps.ts
+++ b/devtools/bindings/src/usePayCardToolProps.ts
@@ -5,6 +5,8 @@ import {
   useGetInternalWalletsQuery,
   useLazyGetCardStatusQuery,
   useCreateCardDetailsTokenMutation,
+  useFreezeCardMutation,
+  useUnfreezeCardMutation,
 } from "@domain/api-card-management";
 import {
   useCardLinkedWallets,
@@ -90,6 +92,25 @@ function initialSteps(platform: "web" | "native"): readonly OnboardingStep[] {
  * balance and answers `null`, which the screen reports as unpriced.
  */
 const NO_COUNTER_VALUE: ResolveWalletCounterValue = () => null;
+
+type ProbeState = Readonly<{
+  isFetching?: boolean;
+  isLoading?: boolean;
+  data?: unknown;
+  error?: unknown;
+}>;
+
+/** Maps one endpoint's hook state onto the probe the tool renders. */
+function toProbe(id: string, label: string, state: ProbeState, run: () => void): PayCardProbe {
+  return {
+    id,
+    label,
+    isFetching: state.isFetching ?? state.isLoading ?? false,
+    result: state.data === undefined ? undefined : JSON.stringify(state.data, null, 2),
+    error: state.error === undefined ? undefined : describeError(state.error),
+    run,
+  };
+}
 
 /** Reads what an endpoint answered, whatever shape the failure arrives in. */
 function describeError(error: unknown): string {
@@ -203,18 +224,39 @@ export function usePayCardToolProps(options: UsePayCardToolPropsOptions = {}): P
 
   const [runCardStatus, cardStatus] = useLazyGetCardStatusQuery();
 
-  const cardStatusProbe = useMemo<PayCardProbe>(
-    () => ({
-      id: "card-status",
-      label: "Card Status",
-      isFetching: cardStatus.isFetching,
-      result: cardStatus.data === undefined ? undefined : JSON.stringify(cardStatus.data, null, 2),
-      error: cardStatus.error === undefined ? undefined : describeError(cardStatus.error),
-      run: () => {
+  const [freezeCard, freeze] = useFreezeCardMutation();
+  const [unfreezeCard, unfreeze] = useUnfreezeCardMutation();
+
+  /**
+   * Freezing and unfreezing invalidate `CardStatus`, so once the status probe has been run its
+   * result refreshes itself here: the tool shows the state change without a second press.
+   */
+  const probes = useMemo<PayCardProbe[]>(
+    () => [
+      toProbe("card-status", "Card Status", cardStatus, () => {
         runCardStatus();
-      },
-    }),
-    [cardStatus.isFetching, cardStatus.data, cardStatus.error, runCardStatus],
+      }),
+      toProbe("freeze-card", "Freeze Card", freeze, () => {
+        freezeCard();
+      }),
+      toProbe("unfreeze-card", "Unfreeze Card", unfreeze, () => {
+        unfreezeCard();
+      }),
+    ],
+    [
+      cardStatus.isFetching,
+      cardStatus.data,
+      cardStatus.error,
+      freeze.isLoading,
+      freeze.data,
+      freeze.error,
+      unfreeze.isLoading,
+      unfreeze.data,
+      unfreeze.error,
+      runCardStatus,
+      freezeCard,
+      unfreezeCard,
+    ],
   );
 
   const [requestCardDetails, cardDetails] = useCreateCardDetailsTokenMutation();
@@ -242,10 +284,7 @@ export function usePayCardToolProps(options: UsePayCardToolPropsOptions = {}): P
     ],
   );
 
-  const interaction = useMemo(
-    () => ({ probes: [cardStatusProbe], details }),
-    [cardStatusProbe, details],
-  );
+  const interaction = useMemo(() => ({ probes, details }), [probes, details]);
 
   // The wallets are read when the balance screen opens, not when the tool mounts.
   const [walletsRequested, setWalletsRequested] = useState(false);

--- a/domain/api/card-management/README.md
+++ b/domain/api/card-management/README.md
@@ -29,6 +29,8 @@ shape and the reasons.
 | `unfreezeCard` | POST | `/v1/card/unfreeze` | Move a frozen card back to `ACTIVE` |
 | `getInternalWallets` | GET | `/v1/wallet/internal` | Read every custodial wallet, with balances |
 | `getCardLinkedWallets` | GET | `/v1/wallet/internal/card_linked` | Read the wallets funding the card, in charging order |
+| `linkCardWallet` | POST | `/v1/wallet/internal/card_linked` | Link a custodial wallet as a funding source, by `addressId` |
+| `unlinkCardWallet` | DELETE | `/v1/wallet/internal/card_linked` | Drop a wallet as a funding source, leaving it and its funds alone |
 
 ## OAuth2 grants
 

--- a/domain/api/card-management/src/api.test.ts
+++ b/domain/api/card-management/src/api.test.ts
@@ -11,6 +11,8 @@ import {
   useFreezeCardMutation,
   useGetCardLinkedWalletsQuery,
   useGetCardOnboardingStatusQuery,
+  useLinkCardWalletMutation,
+  useUnlinkCardWalletMutation,
   useCreateCardDetailsTokenMutation,
   useGetCardStatusQuery,
   useLazyGetCardStatusQuery,
@@ -18,6 +20,7 @@ import {
   useOrderCardMutation,
   useUnfreezeCardMutation,
 } from "./api";
+import { CARD_MANAGEMENT_TAGS } from "./constants";
 import { PayCardErrorResponseSchema } from "./schema";
 
 function jsonResponse(body: unknown): Response {
@@ -80,9 +83,7 @@ const internalWalletsOnTheWire = [
   },
 ];
 
-const internalWallets = internalWalletsOnTheWire.map(
-  ({ addressId: _addressId, type: _type, ...wallet }) => wallet,
-);
+const internalWallets = internalWalletsOnTheWire.map(({ type: _type, ...wallet }) => wallet);
 
 const linkedWallets = [
   {
@@ -138,10 +139,12 @@ describe("cardManagementApi configuration", () => {
       "getCardStatus",
       "getInternalWallets",
       "getUser",
+      "linkCardWallet",
       "logout",
       "orderCard",
       "refreshSession",
       "unfreezeCard",
+      "unlinkCardWallet",
     ]);
   });
 
@@ -182,6 +185,13 @@ describe("cardManagementApi configuration", () => {
     expect(useFreezeCardMutation).toBeDefined();
     expect(cardManagementApi.endpoints.unfreezeCard).toBeDefined();
     expect(useUnfreezeCardMutation).toBeDefined();
+  });
+
+  it("exposes the link endpoints and their hooks", () => {
+    expect(cardManagementApi.endpoints.linkCardWallet).toBeDefined();
+    expect(useLinkCardWalletMutation).toBeDefined();
+    expect(cardManagementApi.endpoints.unlinkCardWallet).toBeDefined();
+    expect(useUnlinkCardWalletMutation).toBeDefined();
   });
 
   it("exposes the wallet endpoints and their hooks", () => {
@@ -622,7 +632,7 @@ describe("cardManagementApi requests", () => {
       expect(result.data?.[0].balance).toBe("9007199254740993.000001");
     });
 
-    it("drops the keys the wire contract does not declare", async () => {
+    it("drops the constant type, and keeps the address id links are made with", async () => {
       fetchSpy = jest
         .spyOn(globalThis, "fetch")
         .mockResolvedValue(jsonResponse([internalWalletsOnTheWire[0]]));
@@ -673,6 +683,62 @@ describe("cardManagementApi requests", () => {
 
       expect(result.data).toBeUndefined();
       expect(result.error).toBeDefined();
+    });
+  });
+
+  describe("linkCardWallet and unlinkCardWallet", () => {
+    // The provider's own example: the address id of the second documented internal wallet.
+    const addressId = "7c1839ee-918e-4787-b74f-deeb48ead58b";
+
+    it("links a wallet by its address id, with the bearer token and the client key", async () => {
+      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ success: true }));
+
+      const store = makeStore("session-token");
+      const result = await store.dispatch(
+        cardManagementApi.endpoints.linkCardWallet.initiate({ addressId }),
+      );
+
+      expect(request(fetchSpy).url).toBe("https://card.test/v1/wallet/internal/card_linked");
+      expect(request(fetchSpy).method).toBe("POST");
+      expect(request(fetchSpy).headers.get("authorization")).toBe("Bearer session-token");
+      expect(request(fetchSpy).headers.get("x-client-key")).toBe("client-key");
+      expect(JSON.parse(await request(fetchSpy).clone().text())).toEqual({ addressId });
+      expect(result.data).toEqual({ success: true });
+    });
+
+    it("unlinks with the same body, on DELETE", async () => {
+      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ success: true }));
+
+      const store = makeStore("session-token");
+      await store
+        .dispatch(cardManagementApi.endpoints.unlinkCardWallet.initiate({ addressId }))
+        .unwrap();
+
+      expect(request(fetchSpy).url).toBe("https://card.test/v1/wallet/internal/card_linked");
+      expect(request(fetchSpy).method).toBe("DELETE");
+      expect(JSON.parse(await request(fetchSpy).clone().text())).toEqual({ addressId });
+    });
+
+    it("reports the provider refusing a sixth wallet", async () => {
+      fetchSpy = jest
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(errorResponse(422, "Maximum 5 wallets can be linked"));
+
+      const store = makeStore("session-token");
+      const result = await store.dispatch(
+        cardManagementApi.endpoints.linkCardWallet.initiate({ addressId }),
+      );
+
+      expect(result.data).toBeUndefined();
+      expect(result.error).toMatchObject({ status: 422 });
+    });
+
+    it("both invalidate the linked wallets, so the charging order reloads", () => {
+      for (const endpoint of ["linkCardWallet", "unlinkCardWallet"] as const) {
+        expect(cardManagementApi.endpoints[endpoint]).toBeDefined();
+      }
+      // Provider and invalidator are a pair: a tag only one side names is dead config.
+      expect(CARD_MANAGEMENT_TAGS).toContain("CardLinkedWallets");
     });
   });
 

--- a/domain/api/card-management/src/api.ts
+++ b/domain/api/card-management/src/api.ts
@@ -11,6 +11,7 @@ import {
   PayCardSessionSchema,
   PayCardDetailsCssSchema,
   PayCardDetailsTokenResponseSchema,
+  PayCardLinkedWalletMutationResponseSchema,
   PayCardStatusResponseSchema,
   PayCardUserResponseSchema,
 } from "./schema";
@@ -26,6 +27,8 @@ import type {
   PayCardRefreshSessionRequest,
   PayCardSession,
   PayCardDetailsCss,
+  PayCardLinkedWalletMutationResult,
+  PayCardLinkedWalletRequest,
   PayCardDetailsToken,
   PayCardStatus,
   PayCardUser,
@@ -142,6 +145,36 @@ export const cardManagementApi = cardApi
         invalidatesTags: ["CardStatus"],
       }),
 
+      /**
+       * Both take the wallet's `addressId`, not its `id`, and both invalidate the linked list so the
+       * charging order reloads itself. Neither touches `getInternalWallets`: unlinking a wallet
+       * leaves it and its funds alone.
+       */
+      linkCardWallet: build.mutation<PayCardLinkedWalletMutationResult, PayCardLinkedWalletRequest>(
+        {
+          query: ({ addressId }) => ({
+            url: "/v1/wallet/internal/card_linked",
+            method: "POST",
+            body: { addressId },
+          }),
+          responseSchema: PayCardLinkedWalletMutationResponseSchema,
+          invalidatesTags: ["CardLinkedWallets"],
+        },
+      ),
+
+      unlinkCardWallet: build.mutation<
+        PayCardLinkedWalletMutationResult,
+        PayCardLinkedWalletRequest
+      >({
+        query: ({ addressId }) => ({
+          url: "/v1/wallet/internal/card_linked",
+          method: "DELETE",
+          body: { addressId },
+        }),
+        responseSchema: PayCardLinkedWalletMutationResponseSchema,
+        invalidatesTags: ["CardLinkedWallets"],
+      }),
+
       getInternalWallets: build.query<PayCardInternalWallet[], void>({
         query: () => ({
           url: "/v1/wallet/internal",
@@ -155,6 +188,7 @@ export const cardManagementApi = cardApi
           url: "/v1/wallet/internal/card_linked",
           method: "GET",
         }),
+        providesTags: ["CardLinkedWallets"],
         responseSchema: PayCardLinkedWalletsResponseSchema,
       }),
 
@@ -183,4 +217,6 @@ export const {
   useGetInternalWalletsQuery,
   useGetCardLinkedWalletsQuery,
   useGetCardOnboardingStatusQuery,
+  useLinkCardWalletMutation,
+  useUnlinkCardWalletMutation,
 } = cardManagementApi;

--- a/domain/api/card-management/src/constants.ts
+++ b/domain/api/card-management/src/constants.ts
@@ -2,6 +2,10 @@
  * RTK Query cache tags owned by the Card Management use case. Registered on the shared `cardApi` via
  * `enhanceEndpoints({ addTagTypes })`, so the shared service never has to know they exist.
  */
-export const CARD_MANAGEMENT_TAGS = ["CardStatus", "CardOnboardingStatus"] as const;
+export const CARD_MANAGEMENT_TAGS = [
+  "CardStatus",
+  "CardOnboardingStatus",
+  "CardLinkedWallets",
+] as const;
 
 export const OAUTH2_TOKEN_PATH = "/v1/auth/oauth2/token";

--- a/domain/api/card-management/src/schema.test.ts
+++ b/domain/api/card-management/src/schema.test.ts
@@ -229,11 +229,20 @@ describe("PayCardInternalWalletSchema", () => {
     expect(PayCardInternalWalletSchema.parse(wallet).balance).toBe("125.50");
   });
 
-  it("drops the internal address id and the constant type the contract does not declare", () => {
-    const parsed = PayCardInternalWalletSchema.parse(wallet);
+  it("keeps the address id, which is what links and unlinks the wallet", () => {
+    expect(PayCardInternalWalletSchema.parse(wallet).addressId).toBe(
+      "0x0a4b21fa733e9aeaddbf070302a85c559de13c4c",
+    );
+  });
 
-    expect(parsed).not.toHaveProperty("addressId");
-    expect(parsed).not.toHaveProperty("type");
+  it("drops the constant type the contract does not declare", () => {
+    expect(PayCardInternalWalletSchema.parse(wallet)).not.toHaveProperty("type");
+  });
+
+  it("rejects a wallet with no address id: it could then never be linked", () => {
+    const { addressId: _addressId, ...withoutAddressId } = wallet;
+
+    expect(() => PayCardInternalWalletSchema.parse(withoutAddressId)).toThrow();
   });
 
   it("keeps the address memo the chain needs", () => {

--- a/domain/api/card-management/src/schema.ts
+++ b/domain/api/card-management/src/schema.ts
@@ -84,6 +84,13 @@ export const PayCardInternalWalletSchema = z.object({
   address: z.string().min(1),
   // Nullish because a wallet with no memo answers with the key absent, others with `null`.
   addressMemo: z.string().min(1).nullish(),
+  /** What the link and unlink endpoints identify a wallet by. Not the same as `id`. */
+  addressId: z.string().min(1),
+});
+
+/** Both linking and unlinking answer with this and nothing else. */
+export const PayCardLinkedWalletMutationResponseSchema = z.object({
+  success: z.boolean(),
 });
 
 export const PayCardInternalWalletsResponseSchema = z.array(PayCardInternalWalletSchema);

--- a/domain/api/card-management/src/types.ts
+++ b/domain/api/card-management/src/types.ts
@@ -11,6 +11,7 @@ import {
   PayCardSessionResponseSchema,
   PayCardSessionSchema,
   PayCardDetailsCssSchema,
+  PayCardLinkedWalletMutationResponseSchema,
   PayCardDetailsTokenResponseSchema,
   PayCardStatusResponseSchema,
   PayCardUserResponseSchema,
@@ -54,6 +55,15 @@ export type PayCardRefreshSessionRequest = {
 };
 
 export type PayCardInternalWallet = z.infer<typeof PayCardInternalWalletSchema>;
+
+export type PayCardLinkedWalletMutationResult = z.infer<
+  typeof PayCardLinkedWalletMutationResponseSchema
+>;
+
+/** Both endpoints identify the wallet by its `addressId`, which `getInternalWallets` returns. */
+export type PayCardLinkedWalletRequest = {
+  readonly addressId: string;
+};
 
 export type PayCardLinkedWallet = z.infer<typeof PayCardLinkedWalletSchema>;
 

--- a/features/flow/pay-card-wallets/src/__tests__/combineCardLinkedWallets.web.test.ts
+++ b/features/flow/pay-card-wallets/src/__tests__/combineCardLinkedWallets.web.test.ts
@@ -3,15 +3,37 @@ import { combineCardLinkedWallets } from "../logic/combineCardLinkedWallets";
 import type { ResolveWalletCounterValue } from "../types";
 
 const internal: PayCardInternalWallet[] = [
-  { id: "w-usdc", balance: "125.40", currency: "usdc", address: "0xusdc", addressMemo: null },
-  { id: "w-usdt", balance: "10.00", currency: "usdt", address: "0xusdt", addressMemo: null },
-  { id: "w-sol", balance: "2.5", currency: "sol", address: "sol-addr", addressMemo: null },
+  {
+    id: "w-usdc",
+    balance: "125.40",
+    currency: "usdc",
+    address: "0xusdc",
+    addressMemo: null,
+    addressId: "addr-w-usdc",
+  },
+  {
+    id: "w-usdt",
+    balance: "10.00",
+    currency: "usdt",
+    address: "0xusdt",
+    addressMemo: null,
+    addressId: "addr-w-usdt",
+  },
+  {
+    id: "w-sol",
+    balance: "2.5",
+    currency: "sol",
+    address: "sol-addr",
+    addressMemo: null,
+    addressId: "addr-w-sol",
+  },
   {
     id: "w-unlinked",
     balance: "999.99",
     currency: "usdc",
     address: "0xunlinked",
     addressMemo: null,
+    addressId: "addr-w-unlinked",
   },
 ];
 
@@ -154,7 +176,14 @@ describe("combineCardLinkedWallets", () => {
     const { wallets, isPartialTotal } = combineCardLinkedWallets({
       linked: [linked[1]],
       internal: [
-        { id: "w-usdc", balance: "0.00", currency: "usdc", address: "0xusdc", addressMemo: null },
+        {
+          id: "w-usdc",
+          balance: "0.00",
+          currency: "usdc",
+          address: "0xusdc",
+          addressMemo: null,
+          addressId: "addr-w-usdc",
+        },
       ],
       resolveCounterValue,
     });


### PR DESCRIPTION
<!-- stac-man:stack-start -->
**Stack** _(managed by [stac-man](https://github.com/bluegardenproject/stac-man))_

- #21467 feat/LIVE-34778-card-details-token
- #21468 feat/pay-card-devtools-card-details
- #21495 feat/LIVE-34792-link-unlink-card-wallet
- **#21533 feat/pay-card-devtools-freeze-unfreeze ← this PR**
- #21569 feat/pay-card-asset-mapping
- #21571 feat/pay-card-wallet-counter-value
<!-- stac-man:stack-end -->

The freeze endpoints had no way to be exercised outside a unit test. They join
Card Status on the interaction screen.

- The three probes share one mapping now. Queries report `isFetching` and
  mutations `isLoading`, which is the only difference between them.
- Both invalidate `CardStatus`, so a status that has already been read updates
  itself after a freeze: the tool shows the transition without a second press.