### PR TITLE
fix(card): accept a card status with no holder name or expiry date

### DIFF
--- a/.changeset/pay-card-status-optional-fields.md
+++ b/.changeset/pay-card-status-optional-fields.md
@@ -1,0 +1,8 @@
+---
+"@domain/api-card-management": patch
+---
+
+Accept a card status with no holder name or expiry date.
+
+- A live card answers `/v1/card/status` without `holderName` or `expiryDate`, and the response was rejected, so the endpoint returned nothing at all.
+- Both are optional now; every other field stays required.

--- a/domain/api/card-management/src/schema.test.ts
+++ b/domain/api/card-management/src/schema.test.ts
@@ -93,6 +93,18 @@ describe("PayCardStatusResponseSchema", () => {
     expect(PayCardStatusResponseSchema.parse(cardStatus).id).toBe("000000000050277836");
   });
 
+  it("reads a card that answered without a holder name or expiry date", () => {
+    const { holderName: _holderName, expiryDate: _expiryDate, ...withoutPreview } = cardStatus;
+
+    expect(PayCardStatusResponseSchema.parse(withoutPreview)).toEqual(withoutPreview);
+  });
+
+  it("still requires the fields a card always answers with", () => {
+    const { panLast4: _panLast4, ...withoutPanLast4 } = cardStatus;
+
+    expect(() => PayCardStatusResponseSchema.parse(withoutPanLast4)).toThrow();
+  });
+
   it("rejects a status the wire contract does not name", () => {
     expect(() =>
       PayCardStatusResponseSchema.parse({ ...cardStatus, status: "SOMETHING_ELSE" }),

--- a/domain/api/card-management/src/schema.ts
+++ b/domain/api/card-management/src/schema.ts
@@ -44,9 +44,10 @@ export const PayCardOrderResponseSchema = z.object({
 
 export const PayCardStatusResponseSchema = z.object({
   id: z.string().min(1),
-  holderName: z.string().min(1),
+  // Optional because a live card answered with neither.
+  holderName: z.string().min(1).optional(),
   /** `YYYY/MM`, as the provider formats it. */
-  expiryDate: z.string().min(1),
+  expiryDate: z.string().min(1).optional(),
   panLast4: z.string().min(1),
   status: z.enum(["ACTIVE", "FROZEN", "BLOCKED"]),
   type: z.enum(["VIRTUAL", "PHYSICAL", "METAL"]),


### PR DESCRIPTION
### 📝 Description

A signed-in cardholder's `/v1/card/status` answers without `holderName` and `expiryDate`. `PayCardStatusResponseSchema` required both, so the whole response was rejected and the endpoint returned nothing at all — there is no partial result, the card status is simply unavailable.

Both fields are optional now. Every other field stays required: only these two have been seen absent, so the schema is not loosened on speculation.

Two tests cover it: one parses a status with neither field, one asserts a still-required field is still rejected when missing.

This is lifted out of the Pay-card stack (it was a commit in #21445) so it can merge on its own and unblock the UI team, rather than waiting on the three PRs below it.

**Scope**: the fields are read nowhere in the codebase yet — the only reference is a test fixture — so widening them to `string | undefined` breaks no consumer.

### 🔗 Context

- **JIRA / GitHub issue**: —
- **ADR** (if any): —
