### PR TITLE
[LWDM] fix(coin-tron): restore the TRC20 fee_limit default (LIVE-36865)

### DIFF
--- a/.changeset/seven-rats-add.md
+++ b/.changeset/seven-rats-add.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/coin-tester-tron": minor
+"@ledgerhq/coin-tron": minor
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+---
+
+fix(coin-tron): restore the TRC20 fee_limit default

--- a/libs/coin-modules/coin-tron/src/logic/craftTransaction.integ.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/craftTransaction.integ.test.ts
@@ -142,7 +142,7 @@ describe("Testing craftTransaction function", () => {
         amount,
         data: { type: "tron" },
       },
-      { value: 0n },
+      { value: 0n, parameters: { fees: 0n } },
     );
 
     const decodeResult = await decodeTransaction(result);
@@ -170,6 +170,41 @@ describe("Testing craftTransaction function", () => {
     expect(decodeResult.raw_data.fee_limit).toBeUndefined();
   });
 
+  it("should default the fee limit for an auto-resolved fee with no override marker for a TRC20 transaction", async () => {
+    // LIVE-36865: the generic framework passes the net display fee as customFees.value on every send,
+    // with no override marker; that value is 0 for an energy-covered account. Without the marker it must
+    // NOT pin the fee_limit to 0 — the default ceiling applies, otherwise the tx reverts OUT_OF_ENERGY.
+    const amount = BigInt(20);
+    const sender = "TRqkRnAj6ceJFYAn2p1eE7aWrgBBwtdhS9";
+    const recipient = "TPswDDCAWhJAZGdHPidFg5nEf8TkNToDX1";
+
+    const { transaction: result } = await craftTransaction(
+      mockConfig,
+      {
+        intentType: "transaction",
+        type: "send",
+        asset: {
+          type: "trc20",
+          assetReference: "TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7",
+        },
+        sender,
+        recipient,
+        amount,
+        data: { type: "tron" },
+      },
+      { value: 0n },
+    );
+
+    const decodeResult = await decodeTransaction(result);
+    expect(decodeResult).toEqual(
+      expect.objectContaining({
+        raw_data: expect.objectContaining({
+          fee_limit: DEFAULT_TRC20_FEES_LIMIT,
+        }),
+      }),
+    );
+  });
+
   it("should pass a custom fee below the default straight through for a TRC20 transaction", async () => {
     const amount = BigInt(20);
     const sender = "TRqkRnAj6ceJFYAn2p1eE7aWrgBBwtdhS9";
@@ -190,7 +225,7 @@ describe("Testing craftTransaction function", () => {
         amount,
         data: { type: "tron" },
       },
-      { value: customFees },
+      { value: customFees, parameters: { fees: customFees } },
     );
 
     const decodeResult = await decodeTransaction(result);

--- a/libs/coin-modules/coin-tron/src/logic/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/craftTransaction.test.ts
@@ -159,7 +159,10 @@ describe("craftTransaction", () => {
       raw_data_hex: "extendedRawDataHex",
     });
 
-    await craftTransaction(mockConfig, transactionIntent, { value: customFees });
+    await craftTransaction(mockConfig, transactionIntent, {
+      value: customFees,
+      parameters: { fees: customFees },
+    });
     expect(craftTrc20Transaction).toHaveBeenCalledWith(
       mockConfig,
       "contractAddress",
@@ -189,7 +192,10 @@ describe("craftTransaction", () => {
       raw_data_hex: "extendedRawDataHex",
     });
 
-    await craftTransaction(mockConfig, transactionIntent, { value: customFees });
+    await craftTransaction(mockConfig, transactionIntent, {
+      value: customFees,
+      parameters: { fees: customFees },
+    });
     expect(craftTrc20Transaction).toHaveBeenCalledWith(
       mockConfig,
       "contractAddress",
@@ -219,7 +225,10 @@ describe("craftTransaction", () => {
       raw_data_hex: "extendedRawDataHex",
     });
 
-    await craftTransaction(mockConfig, transactionIntent, { value: customFees });
+    await craftTransaction(mockConfig, transactionIntent, {
+      value: customFees,
+      parameters: { fees: customFees },
+    });
     expect(craftTrc20Transaction).toHaveBeenCalledWith(
       mockConfig,
       "contractAddress",
@@ -262,6 +271,38 @@ describe("craftTransaction", () => {
     );
   });
 
+  it("should ignore an auto-resolved fee with no override marker and default the fee limit for a TRC20 transaction", async () => {
+    // LIVE-36865: the generic framework forwards the net display fee as customFees.value on every send,
+    // with no override marker. That value collapses to 0 for an energy-covered account, so it must NOT
+    // pin the fee_limit to 0 (OUT_OF_ENERGY) — the default ceiling applies instead.
+    const amount = 1000;
+    const transactionIntent = {
+      intentType: "transaction",
+      type: "send",
+      asset: {
+        type: "trc20",
+        assetReference: "contractAddress",
+      },
+      amount: BigInt(amount),
+    } as TronIntent;
+
+    (decode58Check as jest.Mock).mockImplementation(_address => undefined);
+    (craftTrc20Transaction as jest.Mock).mockResolvedValue({
+      raw_data_hex: "extendedRawDataHex",
+    });
+
+    await craftTransaction(mockConfig, transactionIntent, { value: 0n });
+    expect(craftTrc20Transaction).toHaveBeenCalledWith(
+      mockConfig,
+      "contractAddress",
+      undefined,
+      undefined,
+      BigNumber(amount),
+      undefined,
+      undefined,
+    );
+  });
+
   it.each([-1n, BigInt(2 * Number.MAX_SAFE_INTEGER)])(
     "should throw an error when user provides fees which exceeds Typescript Number type value limit for crafting a TRC20 transaction",
     async (customFees: bigint) => {
@@ -276,7 +317,7 @@ describe("craftTransaction", () => {
               assetReference: "contractAddress",
             },
           } as TronIntent,
-          { value: customFees },
+          { value: customFees, parameters: { fees: customFees } },
         ),
       ).rejects.toThrow(
         `fees must be between 0 and ${Number.MAX_SAFE_INTEGER} (Typescript Number type value limit)`,

--- a/libs/coin-modules/coin-tron/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-tron/src/logic/craftTransaction.ts
@@ -101,7 +101,14 @@ async function craftSend(
   const { amount, asset, recipient, sender, expiration } = transactionIntent;
 
   if (asset.type === "trc20" && asset.assetReference) {
-    const fees = customFees?.value;
+    // `fee_limit` caps what the TVM may burn for energy, not a charge — unused energy is never taken —
+    // so it must cover the worst-case burn. Only a deliberate override sets it, and the framework marks
+    // one with `customFees.parameters.fees` (see the generic `signOperation`); it is honoured verbatim,
+    // including a below-default or `0` cap (VSD-5287/LIVE-36391). `customFees.value` alone is the
+    // auto-resolved display fee — net of the account's own energy and `0` when energy is covered — so
+    // pinning `fee_limit` to it reverts OUT_OF_ENERGY (LIVE-36865). Absent an override,
+    // `craftTrc20Transaction` applies its `DEFAULT_TRC20_FEES_LIMIT` ceiling.
+    const fees = customFees?.parameters?.fees !== undefined ? customFees?.value : undefined;
     if (fees !== undefined && (fees < 0n || fees > BigInt(Number.MAX_SAFE_INTEGER))) {
       throw new Error(
         `fees must be between 0 and ${Number.MAX_SAFE_INTEGER} (Typescript Number type value limit)`,
@@ -112,12 +119,6 @@ async function craftSend(
       throw new Error("Memo cannot be used with smart contract transactions");
     }
 
-    // `fee_limit` caps what the TVM may burn, not a charge — unused energy is never taken. When the
-    // caller passes a custom fee we honour it verbatim, including a value below
-    // `DEFAULT_TRC20_FEES_LIMIT` or `0`: a low cap can OUT_OF_ENERGY-revert with the fee still burned,
-    // but that trade-off is the caller's to make and the coin module must not silently override it
-    // (LIVE-36391). Only when no custom fee is given does the default apply, and `craftTrc20Transaction`
-    // owns that fallback (`customFees ?? DEFAULT_TRC20_FEES_LIMIT`).
     const feeLimit = feesToNumber(fees);
 
     return toCrafted(

--- a/libs/coin-tester-modules/coin-tester-tron/src/indexer.ts
+++ b/libs/coin-tester-modules/coin-tester-tron/src/indexer.ts
@@ -1,6 +1,6 @@
 import { createHash } from "crypto";
 import bs58 from "bs58";
-import { http, HttpResponse } from "msw";
+import { http, HttpResponse, bypass, passthrough } from "msw";
 import { setupServer } from "msw/node";
 import { TRON_LOCAL_RPC } from "./fixtures";
 
@@ -63,6 +63,15 @@ const trc20ByAddress = new Map<string, Trc20Transfer[]>();
 const trc20Contracts = new Map<string, Trc20Contract>();
 let lastIndexedBlock = 0;
 
+// When set, the getaccountresource handler reports this much available ENERGY (with none used),
+// overriding the devnet's real value. The devnet never credits a real `EnergyLimit`, so this is the
+// only way to put the account in the energy-covered state a mainnet USDT holder reaches — where a
+// TRC-20 estimate nets to 0. `null` reports the devnet's real resources unchanged.
+let energyLimitOverride: number | null = null;
+export function setEnergyLimitOverride(energyLimit: number | null): void {
+  energyLimitOverride = energyLimit;
+}
+
 export function registerTrc20Contract(c: Trc20Contract): void {
   trc20Contracts.set(c.contractAddress, c);
 }
@@ -72,6 +81,7 @@ export function resetIndexer(): void {
   trc20ByAddress.clear();
   trc20Contracts.clear();
   lastIndexedBlock = 0;
+  energyLimitOverride = null;
 }
 
 function hexToTronAddress(hex: string): string | null {
@@ -291,6 +301,17 @@ async function fetchTrc20Balance(contract: string, owner: string): Promise<strin
 
 export function initMswHandlers(): () => void {
   const server = setupServer(
+    http.get(`${TRON_LOCAL_RPC}/wallet/getaccountresource`, async ({ request }) => {
+      // Untouched unless a scenario opts in: report the devnet's real resources verbatim.
+      if (energyLimitOverride === null) return passthrough();
+      // Proxy the real node (bypass so this handler doesn't intercept its own proxy call); bandwidth is
+      // left as the devnet reports it, so only the energy pool is forced to "covered".
+      const real = (await fetch(bypass(request))
+        .then(res => (res.ok ? res.json() : {}))
+        .catch(() => ({}))) as Record<string, unknown>;
+      return HttpResponse.json({ ...real, EnergyLimit: energyLimitOverride, EnergyUsed: 0 });
+    }),
+
     http.get(`${TRON_LOCAL_RPC}/v1/accounts/:address`, async ({ params }) => {
       const address = params.address as string;
       const account = await nodeFetch<Record<string, unknown>>("/wallet/getaccount", {

--- a/libs/coin-tester-modules/coin-tester-tron/src/scenarii/tron.ts
+++ b/libs/coin-tester-modules/coin-tester-tron/src/scenarii/tron.ts
@@ -4,6 +4,7 @@ import type { Account } from "@ledgerhq/types-live";
 import type { TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
 import tronCoinConfig from "@ledgerhq/coin-tron/config";
+import { DEFAULT_TRC20_FEES_LIMIT } from "@ledgerhq/coin-tron/network";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { encodeTokenAccountId } from "@ledgerhq/ledger-wallet-framework/account";
 import {
@@ -28,6 +29,7 @@ import {
   initMswHandlers,
   registerTrc20Contract,
   resetIndexer,
+  setEnergyLimitOverride,
   waitForOperationInclusion,
 } from "../indexer";
 import { deployTrc20, issueTrc10 } from "../tokenFixtures";
@@ -63,6 +65,12 @@ const CUSTOM_FEE_LIMIT_SUN = 100_000_000; // 100 TRX
 const BELOW_DEFAULT_FEE_LIMIT_SUN = 30_000_000; // 30 TRX
 /** tx hash → on-chain `fee_limit`, recorded by `mockIndexer` for the guard row to assert against. */
 const onChainFeeLimitByHash = new Map<string, number | undefined>();
+/**
+ * Energy the indexer mock reports for the energy-covered row — large enough to dwarf a TRC-20
+ * transfer's cost, so `estimateFees` nets the fee to 0. Reproduces the mainnet USDT-holder state the
+ * devnet can't credit on-chain (see `setEnergyLimitOverride`).
+ */
+const COVERED_ENERGY = 1_000_000_000; // 1e9 energy
 
 /**
  * The transaction the wallet hands the bridge for Tron: the generic shape with `mode` widened to
@@ -171,6 +179,9 @@ function makeTransactions(): Tx[] {
       expect(latestOp.recipients).toContain(recipient.address);
       // No frozen energy → TVM call burns TRX for energy.
       expect(latestOp.fee.gt(0)).toBe(true);
+      // LIVE-36865: with no fee override the crafted `fee_limit` is the DEFAULT ceiling, never the
+      // display estimate — which the migration wrongly piped into it.
+      expect(onChainFeeLimitByHash.get(latestOp.hash)).toBe(DEFAULT_TRC20_FEES_LIMIT);
     },
   };
 
@@ -220,6 +231,55 @@ function makeTransactions(): Tx[] {
       expect(latestOp.type).toBe("OUT");
       expect(latestOp.recipients).toContain(recipient.address);
       expect(onChainFeeLimitByHash.get(latestOp.hash)).toBe(BELOW_DEFAULT_FEE_LIMIT_SUN);
+    },
+  };
+
+  const freezeEnergy: Tx = {
+    name: "Freeze 50 TRX for ENERGY",
+    mode: "freeze",
+    amount: new BigNumber(FROZEN_SUN),
+    recipient: funder.address,
+    familySpecificData: { resource: "ENERGY" } satisfies TronFamilySpecificData,
+    expect: (prev, curr) => {
+      // From here on the account holds staked energy. The devnet meters energy differently from mainnet,
+      // so make the wallet see it as fully covered for the next row — reproducing the mainnet USDT-holder
+      // state on-chain devnet data alone can't provide. Set first so it survives an expect retry.
+      setEnergyLimitOverride(COVERED_ENERGY);
+
+      const prevFrozen =
+        (prev as TronAccount).tronResources?.frozen.energy?.amount ?? new BigNumber(0);
+      const currFrozen =
+        (curr as TronAccount).tronResources?.frozen.energy?.amount ?? new BigNumber(0);
+      expect(currFrozen.minus(prevFrozen)).toStrictEqual(new BigNumber(FROZEN_SUN));
+
+      const [latestOp] = curr.operations;
+      expect(latestOp.type).toBe("FREEZE");
+      expect(latestOp.value).toStrictEqual(latestOp.fee);
+    },
+  };
+
+  const sendTrc20FromEnergyCovered: Tx = {
+    name: `Send 1 ${trc20.symbol} (TRC20) from an energy-covered account`,
+    amount: new BigNumber(1_000_000),
+    recipient: recipient.address,
+    subAccountId: trc20SubAccountId,
+    // LIVE-36865 regression guard. With energy mocked as covered, `estimateFees` nets the display fee to
+    // 0 — the exact state the generic-adapter migration crafted `fee_limit: 0` from, reverting
+    // OUT_OF_ENERGY on-chain. With no fee override the crafted `fee_limit` must instead be the DEFAULT
+    // ceiling (the on-chain readback proves it), and the transfer must still land.
+    expect: (prev, curr) => {
+      // Restore real energy reporting for the remaining rows. Set first so it survives an expect retry.
+      setEnergyLimitOverride(null);
+
+      const sub = curr.subAccounts?.find(s => s.id === trc20SubAccountId);
+      const prevSub = prev.subAccounts?.find(s => s.id === trc20SubAccountId);
+      expect(sub).toBeDefined();
+      expect(sub!.balance).toStrictEqual((prevSub?.balance ?? new BigNumber(0)).minus(1_000_000));
+
+      const [latestOp] = sub!.operations;
+      expect(latestOp.type).toBe("OUT");
+      expect(latestOp.recipients).toContain(recipient.address);
+      expect(onChainFeeLimitByHash.get(latestOp.hash)).toBe(DEFAULT_TRC20_FEES_LIMIT);
     },
   };
 
@@ -324,6 +384,9 @@ function makeTransactions(): Tx[] {
 
   // Ordering is load-bearing:
   //  - `vote` needs tron power, so it must follow `freeze`.
+  //  - `freezeEnergy` flips the indexer's energy-covered mock on, so `sendTrc20FromEnergyCovered` must
+  //    directly follow it; that row flips the mock back off. Both must precede `sendMaxTrc20`, which
+  //    empties the TRC20 balance they spend from.
   //  - TRC20 sends burn energy (= TRX), so `sendMaxTrx` must stay last; otherwise the funder no
   //    longer has enough TRX to cover TRC20 fees. `freeze` also locks TRX, which `sendMaxTrx`'s
   //    spendable-balance assertion tolerates.
@@ -335,6 +398,8 @@ function makeTransactions(): Tx[] {
     sendTrc20,
     sendTrc20WithCustomFees,
     sendTrc20WithBelowDefaultFee,
+    freezeEnergy,
+    sendTrc20FromEnergyCovered,
     sendMaxTrc20,
     freeze,
     vote,

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/signOperation.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/signOperation.ts
@@ -40,6 +40,11 @@ export const genericSignOperation =
         const customFees = bigNumberToBigIntDeep({
           value: transaction.fees ?? new BigNumber(0),
           parameters: {
+            // A deliberate fee override — prepareTransaction sets this only when the user picks a custom
+            // fee. `value` above is the auto-resolved display fee, which a coin module must NOT treat as an
+            // override: TRON crafts its TRC20 `fee_limit` from an override, and pinning it to the net,
+            // energy-covered display fee (0 when the account has energy) reverts OUT_OF_ENERGY (LIVE-36865).
+            fees: transaction.customFees?.parameters?.fees,
             feesStrategy: transaction.feesStrategy ?? undefined,
             sponsored: transaction.sponsored,
             gasLimit: transaction.customGasLimit ?? transaction.gasLimit,

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/signOperation.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/signOperation.test.ts
@@ -206,4 +206,43 @@ describe("genericSignOperation", () => {
 
     await expect(lastValueFrom(observable)).rejects.toThrow(FeeNotLoaded);
   });
+
+  it("forwards an explicit fee-override marker to craftTransaction, and undefined on the auto path", async () => {
+    // LIVE-36865: `transaction.fees` is the auto-resolved display fee, forwarded as customFees.value on
+    // every send. Only a deliberate user override carries customFees.parameters.fees, and the framework
+    // must relay it so a coin module (TRON's TRC20 fee_limit) can tell an override from the auto value.
+    const signOperation = genericSignOperation("mainnet", "xrp")(mockSignerContext);
+
+    // Auto path: no override on the transaction → the module sees no fee marker.
+    await lastValueFrom(signOperation({ account, transaction, deviceId: "" }).pipe(toArray()));
+    const autoArgs = craftTransaction.mock.calls.at(-1);
+    expect(autoArgs[2].customFees.parameters.fees).toBeUndefined();
+
+    // Override path: the marker is forwarded verbatim (deeply converted to bigint).
+    await lastValueFrom(
+      signOperation({
+        account,
+        transaction: {
+          ...transaction,
+          customFees: { parameters: { fees: new BigNumber(30_000_000) } },
+        },
+        deviceId: "",
+      }).pipe(toArray()),
+    );
+    const overrideArgs = craftTransaction.mock.calls.at(-1);
+    expect(overrideArgs[2].customFees.parameters.fees).toBe(30_000_000n);
+
+    // A deliberate 0 override survives the bigint conversion (bigNumberToBigIntDeep drops only undefined,
+    // not 0), so it reaches the module as a real override and a 0 fee cap still reaches the chain
+    // (VSD-5287/LIVE-36391) rather than falling back to the default ceiling.
+    await lastValueFrom(
+      signOperation({
+        account,
+        transaction: { ...transaction, customFees: { parameters: { fees: new BigNumber(0) } } },
+        deviceId: "",
+      }).pipe(toArray()),
+    );
+    const zeroOverrideArgs = craftTransaction.mock.calls.at(-1);
+    expect(zeroOverrideArgs[2].customFees.parameters.fees).toBe(0n);
+  });
 });


### PR DESCRIPTION
### 📝 Description

**Previous behaviour** — Since the generic-coin-framework Tron migration (LIVE-29826), coin-tron crafted a TRC20 transfer's on-chain `fee_limit` from `transaction.fees`, the net displayed fee. That estimate nets out the account's own energy, so it is `0` whenever the account holds enough energy to cover the transfer. The transfer then broadcast with `fee_limit: 0`, which forbids the TVM from burning any energy, and reverted on-chain with `OUT_OF_ENERGY` — the USDT-send failures reported on LWM 4.18.

**The fix** — The generic `signOperation` now forwards a deliberate-override marker, `customFees.parameters.fees` (set by `prepareTransaction` only for a genuine user fee override), alongside the existing `customFees` — additive, so every generic family keeps exactly what it received before plus one field it ignores. coin-tron derives the TRC20 `fee_limit` only from that marker; on the normal auto path there is no marker, so `craftTrc20Transaction` applies its `DEFAULT_TRC20_FEES_LIMIT` ceiling. A deliberate below-default or `0` override is still honoured verbatim, preserving VSD-5287 / LIVE-36391.

**Regression checks** — coin-tron unit + integ tests assert a no-override TRC20 send crafts the DEFAULT ceiling (not `0`); a generic-framework `signOperation` test asserts the marker is forwarded verbatim (including `0n`) and is `undefined` on the auto path; and the Tron coin-tester gained an energy-covered `sendTrc20` row — driven by an opt-in `getaccountresource` energy mock plus a real freeze-for-ENERGY row — that reproduces the estimate-nets-to-0 state end to end and asserts the on-chain `fee_limit` is the DEFAULT ceiling.

### 🔗 Context

- **JIRA / GitHub issue**: LIVE-36865 (regression from LIVE-29826; preserves VSD-5287 / LIVE-36391)
- **ADR** (if any): n/a