### PR TITLE
[LWM] feat(pay): add native contact address picker

### DIFF
--- a/.changeset/quick-flow-picker.md
+++ b/.changeset/quick-flow-picker.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-pay-contact": minor
+---
+
+Add a native ContactAddressPicker sheet next to the existing web dialog.

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10279,7 +10279,11 @@
     "contacts": {
       "title": "Pay",
       "pay": "New",
-      "seeAllTitle": "Pay contact"
+      "seeAllTitle": "Pay contact",
+      "addressPicker": {
+        "title": "Select {{name}}'s address",
+        "addAddress": "Add address"
+      }
     }
   },
   "syncIndicator": {

--- a/features/flow/pay-contact/README.md
+++ b/features/flow/pay-contact/README.md
@@ -21,7 +21,7 @@ wiring, `renderAddresses`). Keys read from the host app's **default** namespace 
 | `payTab.contacts.empty.{info,addContact}` | Web empty state |
 | `payTab.contacts.table.{name,addresses,transactions,transactionCount}` | Web table headers + count |
 | `payTab.contacts.actions.{pay,more,viewTransactions}` | Web row actions |
-| `payTab.contacts.addressPicker.{title,addAddress}` | Web address picker dialog |
+| `payTab.contacts.addressPicker.{title,addAddress}` | Address picker (web dialog, native sheet) |
 
 Both apps must carry these keys at the same path until translation keys are colocated per feature
 (a follow-up of [LIVE-36540](https://ledgerhq.atlassian.net/browse/LIVE-36540)). The add-contact
@@ -48,21 +48,19 @@ its Telegram button) calls `onContactPress(contact)`. The row overflow (`...`) m
 **View contact** → `onViewContact(contact)` and **View transactions** → `onViewTransactions(contact)`;
 each item is shown only when its handler is provided.
 
-## Contact address picker (web)
+## Contact address picker
 
-> [!NOTE]
-> Native picker lands in a later ticket.
-
-`ContactAddressPicker` is a Lumen dialog that opens after a contact is pressed so the user can pick
-which address to pay. `useContactAddressPickerViewModel` builds the presentation groups (addresses
-segmented by network with asset-aware icons and truncated display), owns visibility and the selected
-contact, and resolves its own copy through `@shared/i18n`. The host injects behavior only — no labels.
-Grouping, icon resolution and truncation are shared from [`@features/flow-contacts`](../contacts).
+`ContactAddressPicker` is a Lumen dialog on web and a `QueuedBottomSheet` on native. It opens after
+a contact is pressed so the user can pick which address to pay. `useContactAddressPickerViewModel`
+builds the presentation groups (addresses segmented by network with asset-aware icons and truncated
+display), owns visibility and the selected contact, and resolves its own copy through
+`@shared/i18n`. The host injects behavior only — no labels. Grouping, icon resolution and
+truncation are shared from [`@features/flow-contacts`](../contacts).
 
 ```tsx
 import { ContactAddressPicker, useContactAddressPickerViewModel } from "@features/flow-pay-contact";
 
-const { open, contactAddressPicker } = useContactAddressPickerViewModel({
+const { open, close, contactAddressPicker } = useContactAddressPickerViewModel({
   onSelectAddress: address => startPayment(address),
   onAddNewAddress,
 });
@@ -72,17 +70,19 @@ const { open, contactAddressPicker } = useContactAddressPickerViewModel({
 ```
 
 `onSelectAddress` receives the full `ContactAddress` (currency + recipient). `onAddNewAddress` is
-optional and receives the open `contact`; wire it to the contact's add-address flow.
+optional and receives the open `contact`; wire it to the contact's add-address flow. Call `close`
+from the host when a selection should dismiss the picker (the view model does not auto-close).
 
 ## Native
 
 ```tsx
 import { Contacts } from "@features/flow-pay-contact";
 
-<Contacts onPay={openSend} onSeeAll={openContactsList} />;
+<Contacts onPay={openSend} onSeeAll={openContactsList} onContactPress={open} />;
+<ContactAddressPicker {...contactAddressPicker} />;
 ```
 
-Caps at 8 contacts. `onSeeAll` opens the full list when there are more. `onContactPress` is optional
-and unused for now.
+Caps at 8 contacts. `onSeeAll` opens the full list when there are more. `onContactPress` opens the
+address picker.
 
 Tests wrap the component in `I18nTestProvider` from `@shared/i18n/testing`.

--- a/features/flow/pay-contact/knip.native.config.mjs
+++ b/features/flow/pay-contact/knip.native.config.mjs
@@ -5,5 +5,4 @@ export default createDualPlatformKnipConfig({
   platform: "native",
   entry: ["src/index.native.ts"],
   additionalProjectExcludes: ["src/index.ts"],
-  additionalIgnoreDependencies: ["@ledgerhq/crypto-icons"], // update when mobile uses crypto icons
 });

--- a/features/flow/pay-contact/knip.web.config.mjs
+++ b/features/flow/pay-contact/knip.web.config.mjs
@@ -4,4 +4,5 @@ export default createDualPlatformKnipConfig({
   packagePath: "features/flow/pay-contact",
   platform: "web",
   entry: ["src/index.ts"],
+  additionalIgnoreDependencies: ["@shared/ui-queued-bottom-sheet"],
 });

--- a/features/flow/pay-contact/package.json
+++ b/features/flow/pay-contact/package.json
@@ -33,6 +33,7 @@
     "@features/flow-contacts-add-contact": "workspace:^",
     "@features/platform-contacts": "workspace:^",
     "@shared/i18n": "workspace:*",
+    "@shared/ui-queued-bottom-sheet": "workspace:*",
     "@ledgerhq/crypto-icons": "catalog:"
   },
   "devDependencies": {
@@ -62,6 +63,7 @@
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-native": "catalog:",
+    "react-native-safe-area-context": "catalog:",
     "react-redux": "catalog:",
     "react-test-renderer": "catalog:",
     "tailwindcss": "catalog:",
@@ -79,10 +81,14 @@
     "@ledgerhq/lumen-ui-rnative": "catalog:",
     "react": "catalog:",
     "react-native": "catalog:",
+    "react-native-safe-area-context": ">=4.0.0",
     "react-redux": ">=9.0.0"
   },
   "peerDependenciesMeta": {
     "react-native": {
+      "optional": true
+    },
+    "react-native-safe-area-context": {
       "optional": true
     },
     "@ledgerhq/lumen-ui-react": {

--- a/features/flow/pay-contact/src/components/ContactAddressPicker/ContactAddressPicker.native.tsx
+++ b/features/flow/pay-contact/src/components/ContactAddressPicker/ContactAddressPicker.native.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { ScrollView } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Box, BottomSheetHeader, BottomSheetView } from "@ledgerhq/lumen-ui-rnative";
+import { QueuedBottomSheet } from "@shared/ui-queued-bottom-sheet";
+import type { ContactAddressPickerProps } from "../../types";
+import { ContactAddressPickerAddAddress } from "./components/ContactAddressPickerAddAddress/ContactAddressPickerAddAddress.native";
+import { ContactAddressPickerNetworkSection } from "./components/ContactAddressPickerNetworkSection/ContactAddressPickerNetworkSection.native";
+
+export function ContactAddressPicker({
+  isOpen,
+  contact,
+  title,
+  addAddressLabel,
+  groups,
+  onClose,
+  onSelectAddress,
+  onAddNewAddress,
+}: ContactAddressPickerProps) {
+  const { bottom } = useSafeAreaInsets();
+
+  return (
+    <QueuedBottomSheet isRequestingToBeOpened={isOpen} enableDynamicSizing onClose={onClose}>
+      {isOpen && contact ? (
+        <BottomSheetView style={{ paddingBottom: bottom + 24 }}>
+          <BottomSheetHeader spacing title={title} density="expanded" />
+          <ScrollView
+            testID="pay-contact-address-picker"
+            alwaysBounceVertical={false}
+            showsVerticalScrollIndicator={false}
+          >
+            <Box
+              lx={{ gap: "s24", paddingHorizontal: "s16", paddingTop: "s8", paddingBottom: "s8" }}
+            >
+              {groups.map(group => (
+                <ContactAddressPickerNetworkSection
+                  key={group.networkId}
+                  group={group}
+                  onSelectAddress={onSelectAddress}
+                />
+              ))}
+              {onAddNewAddress ? (
+                <ContactAddressPickerAddAddress
+                  label={addAddressLabel}
+                  onAddNewAddress={onAddNewAddress}
+                />
+              ) : null}
+            </Box>
+          </ScrollView>
+        </BottomSheetView>
+      ) : null}
+    </QueuedBottomSheet>
+  );
+}

--- a/features/flow/pay-contact/src/components/ContactAddressPicker/__tests__/ContactAddressPicker.native.test.tsx
+++ b/features/flow/pay-contact/src/components/ContactAddressPicker/__tests__/ContactAddressPicker.native.test.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { View } from "react-native";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react-native";
+import { mockContact, mockContactAddress } from "@domain/entity-contact/schema.mock";
+import { ContactAddressPicker } from "../ContactAddressPicker.native";
+import type { ContactAddressPickerProps } from "../../../types";
+
+jest.mock("@shared/ui-queued-bottom-sheet", () => ({
+  QueuedBottomSheet: ({
+    children,
+    isRequestingToBeOpened,
+  }: {
+    children: React.ReactNode;
+    isRequestingToBeOpened?: boolean;
+  }) => (
+    <View accessibilityState={{ expanded: !!isRequestingToBeOpened }} testID="queued-sheet">
+      {children}
+    </View>
+  ),
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ bottom: 0, top: 0, left: 0, right: 0 }),
+}));
+
+const contactAddress = mockContactAddress({
+  id: "address-eth",
+  currencyId: "ethereum",
+  label: "Ethereum",
+});
+
+const defaultProps: ContactAddressPickerProps = {
+  isOpen: true,
+  contact: mockContact({ id: "contact-ada", name: "Ada", addresses: [contactAddress] }),
+  title: "Select Ada's address",
+  addAddressLabel: "Add address",
+  groups: [
+    {
+      networkId: "ethereum",
+      networkName: "Ethereum",
+      networkTicker: "ETH",
+      rows: [
+        {
+          addressId: contactAddress.id,
+          label: contactAddress.label,
+          address: "0x1ad23b...46c53034",
+          icon: { ledgerId: "ethereum", ticker: "ETH" },
+          contactAddress,
+        },
+      ],
+    },
+  ],
+  onClose: jest.fn(),
+  onSelectAddress: jest.fn(),
+};
+
+describe("ContactAddressPicker (Native)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the title and address groups", () => {
+    render(<ContactAddressPicker {...defaultProps} />);
+
+    expect(screen.getByTestId("pay-contact-address-picker")).toBeVisible();
+    expect(screen.getByTestId("pay-contact-address-group-ethereum")).toBeVisible();
+    expect(screen.getByTestId("pay-contact-address-row-address-eth")).toBeVisible();
+    expect(screen.getByText("0x1ad23b...46c53034")).toBeVisible();
+  });
+
+  it("selecting a row calls onSelectAddress", () => {
+    const onSelectAddress = jest.fn();
+    render(<ContactAddressPicker {...defaultProps} onSelectAddress={onSelectAddress} />);
+
+    fireEvent.press(screen.getByTestId("pay-contact-address-row-address-eth"));
+
+    expect(onSelectAddress).toHaveBeenCalledWith(contactAddress);
+  });
+
+  it("shows the add-address action when onAddNewAddress is provided", () => {
+    const onAddNewAddress = jest.fn();
+    render(<ContactAddressPicker {...defaultProps} onAddNewAddress={onAddNewAddress} />);
+
+    fireEvent.press(screen.getByTestId("pay-contact-address-add"));
+
+    expect(onAddNewAddress).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the sheet mounted but hides content when closed", () => {
+    render(<ContactAddressPicker {...defaultProps} isOpen={false} />);
+
+    expect(screen.getByTestId("queued-sheet").props.accessibilityState.expanded).toBe(false);
+    expect(screen.queryByTestId("pay-contact-address-picker")).toBeNull();
+  });
+});

--- a/features/flow/pay-contact/src/components/ContactAddressPicker/__tests__/useContactAddressPickerViewModel.web.test.tsx
+++ b/features/flow/pay-contact/src/components/ContactAddressPicker/__tests__/useContactAddressPickerViewModel.web.test.tsx
@@ -5,7 +5,7 @@ import { I18nTestProvider, type I18nTestProviderProps } from "@shared/i18n/testi
 import {
   useContactAddressPickerViewModel,
   type UseContactAddressPickerViewModelParams,
-} from "../useContactAddressPickerViewModel.web";
+} from "../useContactAddressPickerViewModel";
 
 const resources: I18nTestProviderProps["resources"] = {
   en: {
@@ -66,7 +66,7 @@ describe("useContactAddressPickerViewModel", () => {
     const { result } = renderViewModel();
 
     act(() => result.current.open(contact));
-    act(() => result.current.contactAddressPicker.onClose());
+    act(() => result.current.close());
 
     expect(result.current.contactAddressPicker.isOpen).toBe(false);
     expect(result.current.contactAddressPicker.contact).toBeNull();

--- a/features/flow/pay-contact/src/components/ContactAddressPicker/components/ContactAddressPickerAddAddress/ContactAddressPickerAddAddress.native.tsx
+++ b/features/flow/pay-contact/src/components/ContactAddressPicker/components/ContactAddressPickerAddAddress/ContactAddressPickerAddAddress.native.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import {
+  ListItem,
+  ListItemContent,
+  ListItemLeading,
+  ListItemTitle,
+  Spot,
+} from "@ledgerhq/lumen-ui-rnative";
+import { Plus } from "@ledgerhq/lumen-ui-rnative/symbols";
+
+type ContactAddressPickerAddAddressProps = Readonly<{
+  label: string;
+  onAddNewAddress: () => void;
+}>;
+
+export function ContactAddressPickerAddAddress({
+  label,
+  onAddNewAddress,
+}: ContactAddressPickerAddAddressProps) {
+  return (
+    <ListItem
+      onPress={onAddNewAddress}
+      testID="pay-contact-address-add"
+      accessibilityLabel={label}
+      lx={{ backgroundColor: "surface", borderRadius: "md" }}
+    >
+      <ListItemLeading>
+        <Spot appearance="icon" icon={Plus} size={48} />
+        <ListItemContent>
+          <ListItemTitle>{label}</ListItemTitle>
+        </ListItemContent>
+      </ListItemLeading>
+    </ListItem>
+  );
+}

--- a/features/flow/pay-contact/src/components/ContactAddressPicker/components/ContactAddressPickerNetworkSection/ContactAddressPickerNetworkSection.native.tsx
+++ b/features/flow/pay-contact/src/components/ContactAddressPicker/components/ContactAddressPickerNetworkSection/ContactAddressPickerNetworkSection.native.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import CryptoIcon from "@ledgerhq/crypto-icons/native";
+import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
+import type {
+  ContactAddressPickerNetworkGroup,
+  ContactAddressPickerProps,
+} from "../../../../types";
+import { ContactAddressPickerRow } from "../ContactAddressPickerRow/ContactAddressPickerRow.native";
+
+const NETWORK_ICON_SIZE = 16;
+
+type ContactAddressPickerNetworkSectionProps = Readonly<{
+  group: ContactAddressPickerNetworkGroup;
+  onSelectAddress: ContactAddressPickerProps["onSelectAddress"];
+}>;
+
+export function ContactAddressPickerNetworkSection({
+  group,
+  onSelectAddress,
+}: ContactAddressPickerNetworkSectionProps) {
+  return (
+    <Box testID={`pay-contact-address-group-${group.networkId}`} lx={{ gap: "s8" }}>
+      <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s8", paddingHorizontal: "s8" }}>
+        <CryptoIcon
+          ledgerId={group.networkId}
+          ticker={group.networkTicker}
+          size={NETWORK_ICON_SIZE}
+          shape="square"
+        />
+        <Text typography="body2" lx={{ color: "muted" }}>
+          {group.networkName}
+        </Text>
+      </Box>
+      <Box lx={{ gap: "s8" }}>
+        {group.rows.map(row => (
+          <ContactAddressPickerRow
+            key={row.addressId}
+            row={row}
+            onSelectAddress={onSelectAddress}
+          />
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/features/flow/pay-contact/src/components/ContactAddressPicker/components/ContactAddressPickerRow/ContactAddressPickerRow.native.tsx
+++ b/features/flow/pay-contact/src/components/ContactAddressPicker/components/ContactAddressPickerRow/ContactAddressPickerRow.native.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import CryptoIcon from "@ledgerhq/crypto-icons/native";
+import {
+  ListItem,
+  ListItemContent,
+  ListItemDescription,
+  ListItemLeading,
+  ListItemTitle,
+} from "@ledgerhq/lumen-ui-rnative";
+import type { ContactAddressPickerProps, ContactAddressPickerRow } from "../../../../types";
+
+const ASSET_ICON_SIZE = 48;
+
+type ContactAddressPickerRowProps = Readonly<{
+  row: ContactAddressPickerRow;
+  onSelectAddress: ContactAddressPickerProps["onSelectAddress"];
+}>;
+
+export function ContactAddressPickerRow({ row, onSelectAddress }: ContactAddressPickerRowProps) {
+  return (
+    <ListItem
+      onPress={() => onSelectAddress(row.contactAddress)}
+      testID={`pay-contact-address-row-${row.addressId}`}
+      accessibilityLabel={`${row.label}, ${row.contactAddress.address}`}
+      lx={{ backgroundColor: "surface", borderRadius: "md" }}
+    >
+      <ListItemLeading>
+        <CryptoIcon
+          ledgerId={row.icon.ledgerId}
+          ticker={row.icon.ticker}
+          network={row.icon.network}
+          size={ASSET_ICON_SIZE}
+          shape="circle"
+        />
+        <ListItemContent>
+          <ListItemTitle>{row.label}</ListItemTitle>
+          <ListItemDescription>{row.address}</ListItemDescription>
+        </ListItemContent>
+      </ListItemLeading>
+    </ListItem>
+  );
+}

--- a/features/flow/pay-contact/src/components/ContactAddressPicker/useContactAddressPickerViewModel.ts
+++ b/features/flow/pay-contact/src/components/ContactAddressPicker/useContactAddressPickerViewModel.ts
@@ -11,6 +11,7 @@ export type UseContactAddressPickerViewModelParams = Readonly<{
 
 export type UseContactAddressPickerViewModel = Readonly<{
   open: (contact: Contact) => void;
+  close: () => void;
   contactAddressPicker: ContactAddressPickerProps;
 }>;
 
@@ -22,7 +23,7 @@ export function useContactAddressPickerViewModel({
   const [contact, setContact] = useState<Contact | null>(null);
 
   const open = useCallback((nextContact: Contact) => setContact(nextContact), []);
-  const onClose = useCallback(() => setContact(null), []);
+  const close = useCallback(() => setContact(null), []);
 
   const groups = useMemo(
     () => (contact === null ? [] : buildContactAddressPickerGroups(contact)),
@@ -50,15 +51,16 @@ export function useContactAddressPickerViewModel({
       title,
       addAddressLabel: t("payTab.contacts.addressPicker.addAddress"),
       groups,
-      onClose,
+      onClose: close,
       onSelectAddress,
       onAddNewAddress: handleAddNewAddress,
     }),
-    [contact, title, groups, t, onClose, onSelectAddress, handleAddNewAddress],
+    [contact, title, groups, t, close, onSelectAddress, handleAddNewAddress],
   );
 
   return {
     open,
+    close,
     contactAddressPicker,
   };
 }

--- a/features/flow/pay-contact/src/index.native.ts
+++ b/features/flow/pay-contact/src/index.native.ts
@@ -1,2 +1,4 @@
 export * from "./exports";
 export * from "./components/Contacts/Contacts.native";
+export * from "./components/ContactAddressPicker/ContactAddressPicker.native";
+export * from "./components/ContactAddressPicker/useContactAddressPickerViewModel";

--- a/features/flow/pay-contact/src/index.ts
+++ b/features/flow/pay-contact/src/index.ts
@@ -1,5 +1,5 @@
 export * from "./exports";
 export * from "./components/Contacts/Contacts.web";
 export * from "./components/ContactAddressPicker/ContactAddressPicker.web";
-export * from "./components/ContactAddressPicker/useContactAddressPickerViewModel.web";
+export * from "./components/ContactAddressPicker/useContactAddressPickerViewModel";
 export * from "./components/PaySuccess/PaySuccess.web";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7094,10 +7094,13 @@ importers:
         version: link:../../platform/contacts
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.4(@ledgerhq/lumen-design-core@0.1.27)(@ledgerhq/lumen-ui-react@0.1.56(@ledgerhq/lumen-design-core@0.1.27)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(@ledgerhq/lumen-ui-rnative@0.1.59(@ledgerhq/lumen-design-core@0.1.27)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+        version: 2.0.4(@ledgerhq/lumen-design-core@0.1.27)(@ledgerhq/lumen-ui-react@0.1.56(@ledgerhq/lumen-design-core@0.1.27)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(@ledgerhq/lumen-ui-rnative@0.1.59(@ledgerhq/lumen-design-core@0.1.27)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native-safe-area-context@5.6.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@shared/i18n':
         specifier: workspace:*
         version: link:../../../shared/i18n
+      '@shared/ui-queued-bottom-sheet':
+        specifier: workspace:*
+        version: link:../../../shared/ui-queued-bottom-sheet
     devDependencies:
       '@features/platform-style':
         specifier: workspace:*
@@ -7110,7 +7113,7 @@ importers:
         version: 0.1.56(@ledgerhq/lumen-design-core@0.1.27)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.59(@ledgerhq/lumen-design-core@0.1.27)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+        version: 0.1.59(@ledgerhq/lumen-design-core@0.1.27)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native-safe-area-context@5.6.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@reduxjs/toolkit':
         specifier: 'catalog:'
         version: 2.11.2(react-redux@9.2.0(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
@@ -7177,6 +7180,9 @@ importers:
       react-native:
         specifier: 'catalog:'
         version: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4)
+      react-native-safe-area-context:
+        specifier: 'catalog:'
+        version: 5.6.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       react-redux:
         specifier: 'catalog:'
         version: 9.2.0(@types/react@19.0.14)(react@19.1.4)
@@ -22810,6 +22816,7 @@ packages:
     resolution: {integrity: sha512-KRbkSthClEwkbpt/LLJmBJhIOvOsyrp9OICisF9p3mOODjaxAuYmyOgrVreg09BT2F4hXN3JXpvt9eIZpTCRsw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.7.8':
     resolution: {integrity: sha512-pdPMWko1yZI5ZNI6/t2Y5rQPGgV/ah5DW+mlHo2aFKav4lnxvgisEh9e4HtOsYBfK/9PyYZ5u3M9hLSaMiJ75w==}
@@ -28289,7 +28296,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: '*'
+      rxjs: ^5.5.10
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -47545,6 +47552,16 @@ snapshots:
       '@ledgerhq/lumen-design-core': 0.1.27
       '@ledgerhq/lumen-ui-react': 0.1.56(@ledgerhq/lumen-design-core@0.1.27)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@ledgerhq/lumen-ui-rnative': 0.1.59(@ledgerhq/lumen-design-core@0.1.27)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native-reanimated@4.3.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      react-dom: 19.1.4(react@19.1.4)
+      react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4)
+
+  '@ledgerhq/crypto-icons@2.0.4(@ledgerhq/lumen-design-core@0.1.27)(@ledgerhq/lumen-ui-react@0.1.56(@ledgerhq/lumen-design-core@0.1.27)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(@ledgerhq/lumen-ui-rnative@0.1.59(@ledgerhq/lumen-design-core@0.1.27)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native-safe-area-context@5.6.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)':
+    dependencies:
+      react: 19.1.4
+    optionalDependencies:
+      '@ledgerhq/lumen-design-core': 0.1.27
+      '@ledgerhq/lumen-ui-react': 0.1.56(@ledgerhq/lumen-design-core@0.1.27)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@ledgerhq/lumen-ui-rnative': 0.1.59(@ledgerhq/lumen-design-core@0.1.27)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native-safe-area-context@5.6.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       react-dom: 19.1.4(react@19.1.4)
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@types/react@19.0.14)(react@19.1.4)
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Pay and Send need the same contact address sheet. Desktop already has it in `@features/flow-pay-contact`. This PR adds the native sheet next to that web dialog so mobile can reuse the same view-model and grouping.

**Problem:** Mobile had no shared picker in the flow package. Wiring Send/Pay in the app would have duplicated desktop grouping, i18n, and open/close state.

**Solution:**
- Native `ContactAddressPicker` (`QueuedBottomSheet`) matching the web `Dialog` API
- Shared `useContactAddressPickerViewModel` (no longer `.web`-only) and `buildContactAddressPickerGroups`
- i18n keys `payTab.contacts.addressPicker.{title,addAddress}`

```tsx
import { ContactAddressPicker, useContactAddressPickerViewModel } from "@features/flow-pay-contact";

const { open, close, contactAddressPicker } = useContactAddressPickerViewModel({
  onSelectAddress: address => startPayment(address),
  onAddNewAddress,
});

<ContactAddressPicker {...contactAddressPicker} />;
```

Not wired in the app yet. Send mounts it in #21522.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36371](https://ledgerhq.atlassian.net/browse/LIVE-36371)
- **ADR** (if any): none
- **Follow-up**: [#21522](https://github.com/LedgerHQ/ledger-live/pull/21522)

### QA

Package tests only (`pnpm nx run @features/flow-pay-contact:test`). No user-facing change in this PR. Demo the sheet on #21522.

[LIVE-36371]: https://ledgerhq.atlassian.net/browse/LIVE-36371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ