### PR TITLE
[LWM] fix(contacts): render delete contact trash icon red (LIVE-36696)

### DIFF
--- a/.changeset/LIVE-36696-contacts-delete-trash-icon.md
+++ b/.changeset/LIVE-36696-contacts-delete-trash-icon.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-contacts": patch
+"live-mobile": patch
+---
+
+Fix the trash icon of the contact "Delete contact" action rendering white instead of red.

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactDetailEditDeleteSheets/ContactDetailActionsMenu.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactDetailEditDeleteSheets/ContactDetailActionsMenu.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import type { ReactTestInstance } from "react-test-renderer";
+import { ledgerLiveThemes } from "@ledgerhq/lumen-design-core";
+import { ContactDetailActionsMenu } from "@features/flow-contacts";
+import { QueuedBottomSheet } from "@shared/ui-queued-bottom-sheet";
+import { render, screen } from "@tests/test-renderer";
+
+// The flow package stubs Lumen in its own Jest setup, so the icon colors the design system
+// resolves at render time can only be asserted from the app.
+const theme = ledgerLiveThemes.dark;
+
+function iconColor(testID: string): unknown {
+  const [group] = screen
+    .getByTestId(testID)
+    .findAll((node: ReactTestInstance) => String(node.type) === "RNSVGGroup");
+  return group?.props.color;
+}
+
+describe("ContactDetailActionsMenu", () => {
+  beforeEach(() => {
+    render(
+      <QueuedBottomSheet isRequestingToBeOpened onClose={jest.fn()} enableDynamicSizing>
+        <ContactDetailActionsMenu
+          isOpen
+          canDelete
+          labels={{ editContact: "Edit name", deleteContact: "Delete contact" }}
+          onEdit={jest.fn()}
+          onDelete={jest.fn()}
+        />
+      </QueuedBottomSheet>,
+    );
+  });
+
+  it("should render the delete action with a destructive trash icon", () => {
+    expect(iconColor("contacts-detail-delete-action")).toBe(theme.colors.text.error);
+  });
+
+  it("should keep the edit action icon neutral", () => {
+    expect(iconColor("contacts-detail-edit-action")).toBe(theme.colors.text.base);
+  });
+});

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailActionsMenu/ContactDetailActionsMenu.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailActionsMenu/ContactDetailActionsMenu.native.tsx
@@ -1,14 +1,26 @@
 import React from "react";
+import { StyleSheet } from "react-native";
 import {
   BottomSheetHeader,
   BottomSheetView,
   Box,
+  type IconProps,
   ListItem,
   Spot,
   Text,
+  useTheme,
 } from "@ledgerhq/lumen-ui-rnative";
 import { PenEdit, Trash } from "@ledgerhq/lumen-ui-rnative/symbols";
 import type { ContactDetailActionsLabels } from "../../types";
+
+// Spot paints custom icons with the neutral color of its "icon" appearance and injects it
+// through `style`, so the destructive color has to override that style on the symbol itself.
+function TrashDestructive({ style, ...props }: IconProps) {
+  const { theme } = useTheme();
+  return (
+    <Trash {...props} style={StyleSheet.flatten([style, { color: theme.colors.text.error }])} />
+  );
+}
 
 export type ContactDetailActionsMenuProps = Readonly<{
   isOpen: boolean;
@@ -44,7 +56,7 @@ export function ContactDetailActionsMenu({
             {canDelete ? (
               <ListItem onPress={onDelete} testID="contacts-detail-delete-action">
                 <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s12" }}>
-                  <Spot appearance="icon" icon={Trash} size={40} />
+                  <Spot appearance="icon" icon={TrashDestructive} size={40} />
                   <Text typography="body1SemiBold" lx={{ color: "error" }}>
                     {labels.deleteContact}
                   </Text>


### PR DESCRIPTION
### 📝 Description

The trash icon next to "Delete contact" in the contact options bottom sheet on Ledger Wallet Mobile rendered white instead of red, while the label next to it was already red.

**Previous behaviour** — Lumen's `Spot` deliberately paints custom icons with a fixed neutral color: `appearance="icon"` resolves to `colors.text.base` and is handed to the symbol through the `style` prop. react-native-svg applies that style to the inner `<G>`, the direct parent of the trash path, so it overrides everything else — including a `color="error"` prop on the symbol. There is no supported `Spot` variant for a red custom icon, since the self-contained `appearance="error"` renders a `DeleteCircleFill` rather than a trash.

**Fix** — `ContactDetailActionsMenu.native.tsx` now wraps the symbol in a local `TrashDestructive` component that flattens the injected style with the error color, so the icon resolves to `colors.text.error` while the muted circle stays untouched. No other row changes appearance.

**Regression check** — `ContactDetailActionsMenu.test.tsx` asserts the delete icon renders in the error color and the edit icon stays neutral. It lives in the mobile app rather than in `features/flow/contacts` because that package stubs out all of Lumen in its Jest setup, so the resolved color is only observable where the real design system renders. Reverting the fix makes it fail with `Expected: "#f87274" / Received: "#ffffff"`.

**Follow-up for the design system** — this is a Lumen gap. A destructive menu row is a common pattern and `Spot` cannot express "custom icon, error color", so every consumer will hit the same workaround. Once `Spot` supports it, `TrashDestructive` can be deleted.

<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-09-04 at 15 20 12" src="https://github.com/user-attachments/assets/d8aabd9c-da72-4be7-b285-535bdbb4b936" />


### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36696](https://ledgerhq.atlassian.net/browse/LIVE-36696)
- **ADR** (if any): n/a

[LIVE-36696]: https://ledgerhq.atlassian.net/browse/LIVE-36696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ