### PR TITLE
[LWDM] chore(env): deprecate live-env and ship its migration guide (LIVE-36897)

### DIFF
--- a/.changeset/hw-app-exchange-prebuild-format.md
+++ b/.changeset/hw-app-exchange-prebuild-format.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/hw-app-exchange": patch
+---
+
+Format the generated protobuf files in `prebuild`. `pbjs`/`pbts` emit their own style while the committed `generate-protocol.js`/`.d.ts` are oxfmt-formatted, so regenerating them always dirtied the tree and failed the CLI job's `git diff` check. Only visible on an nx cache miss, which is why it went unnoticed.

--- a/.changeset/live-env-deprecation-notice.md
+++ b/.changeset/live-env-deprecation-notice.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-env": minor
+"@shared/env": patch
+"@features/platform-env": patch
+---
+
+Mark the whole public API deprecated and ship the migration guide. `getEnv`, `setEnv`, `setEnvUnsafe`, `getEnvDefault`, `getAllEnvs`, `injectDefinitions`, `changes`, the registry introspection helpers, the exported types and the `useEnv` hook now carry `@deprecated`. `libs/env/MIGRATION.md` documents the four exits every variable takes; `shared/env/MIGRATION.md` covers what that means inside ledger-live. No behaviour change.

--- a/features/platform/env/README.md
+++ b/features/platform/env/README.md
@@ -1,7 +1,9 @@
 # @features/platform-env
 
-> [!NOTE]
-> **Status: STABLE** — Production-ready; API is considered stable.
+> [!WARNING]
+> **Status: DEPRECATED** — sunset together with `@ledgerhq/live-env`
+> ([LIVE-36894](https://ledgerhq.atlassian.net/browse/LIVE-36894)). Do not add a call site. See
+> **[../../../shared/env/MIGRATION.md](../../../shared/env/MIGRATION.md)** for how to migrate.
 
 React hook for subscribing to typed env var changes in Ledger Live apps.
 

--- a/features/platform/env/src/useEnv.ts
+++ b/features/platform/env/src/useEnv.ts
@@ -1,6 +1,11 @@
 import { useEffect, useState } from "react";
 import { changes, getEnv, type EnvName, type EnvValue } from "@shared/env";
 
+/**
+ * @deprecated `@shared/env` is being sunset with `@ledgerhq/live-env`. A value a component has to
+ * re-render on belongs in a feature flag or in the app's own state — see
+ * https://github.com/LedgerHQ/ledger-live/blob/develop/shared/env/MIGRATION.md
+ */
 export function useEnv<K extends EnvName>(name: K): EnvValue<K> {
   const [env, setEnv] = useState<EnvValue<K>>(() => getEnv(name));
   useEffect(() => {

--- a/libs/env/MIGRATION.md
+++ b/libs/env/MIGRATION.md
@@ -1,0 +1,148 @@
+# Migrating off `@ledgerhq/live-env`
+
+> [!WARNING]
+> **`@ledgerhq/live-env` is deprecated.** Do not add definitions, do not add call sites.
+> This guide is how you take an existing one out.
+
+## Why
+
+The framework is fine; the injection is the problem. `injectDefinitions()` registers a global
+mutable singleton, and everything downstream inherits it:
+
+- every consumer of a shared library must inject, or `getEnv` throws
+- a value read through a global is invisible in the dependency graph — nothing tells you a library
+  needs it until it fails at runtime
+- it duplicates three mechanisms that already exist: feature flags, build-time constants, and
+  `process.env`
+
+## The four exits
+
+Every variable leaves by exactly one of these. Pick by asking what the value actually does, not by
+what is easiest to type.
+
+| The value…                 | Replacement                       | Why                              |
+| -------------------------- | --------------------------------- | -------------------------------- |
+| is togglable remotely      | **feature flag**                  | already remote, typed, audited   |
+| never varies at runtime    | **inline constant**               | the dependency leaves the graph  |
+| varies in CI / tests / dev | **`process.env` at the use site** | no registry, no injection        |
+| varies per app             | **passed in as a parameter**      | the app owns state, not the lib  |
+
+If two look plausible, prefer the one further down the table: it removes more machinery.
+If none fit, that is a signal worth raising, not a blocker.
+
+---
+
+### 1. Togglable remotely → feature flag
+
+A value someone wants to flip without a release is a feature flag. Often the flag already exists
+and the env var is just the fallback nobody deleted — check before writing a new one.
+
+```diff
+- import { getEnv } from "@ledgerhq/live-env";
+-
+- if (!feature?.enabled) return getEnv("ENABLE_THING").split(",");
+- return feature?.params?.things ?? null;
++ return feature?.params?.things ?? null;
+```
+
+Outside React, the flag reaches you through the config your composition root already builds — not
+through a second global.
+
+### 2. Never varies at runtime → inline constant
+
+If nothing calls `setEnv` on it and no bootstrap overrides it, it is a constant that has been
+paying registry rent for years.
+
+```diff
+- import { getEnv } from "@ledgerhq/live-env";
+- const version = () => getEnv("API_VERSION");
++ const API_VERSION = 2;
+```
+
+This is the exit that shrinks the dependency graph: the module stops importing the library at all.
+
+Two things make *every* variable look overridable, and neither should stop you: a bootstrap that
+loops `process.env` into `setEnvUnsafe`, and any debug UI that can set a variable by name. Those
+are generic escape hatches, not evidence that a value varies. Ask whether a *product* path sets it.
+
+### 3. Varies in CI / tests / dev → `process.env` at the point of use
+
+Read it where you need it and parse it there. No registry entry, no injection, no import ordering.
+
+```diff
+- import { getEnv } from "@ledgerhq/live-env";
+- setDecimalPlaces(getEnv("DECIMAL_PLACES"));
++ const decimalPlaces = Number.parseInt(process.env.DECIMAL_PLACES ?? "", 10);
++ setDecimalPlaces(Number.isNaN(decimalPlaces) ? 40 : decimalPlaces);
+```
+
+Keep the default at the use site, as above.
+
+> [!CAUTION]
+> **Do not fall back with `||`.** `Number(process.env.X) || 40` looks equivalent and is not: it
+> swallows a legitimate `0`, and `false` for booleans. `intParser` returns `0` for `X=0` today, so
+> `||` silently changes behaviour for anyone who set it. Test against `Number.isNaN`, or `??` over
+> an already-parsed value. This is the most likely way to introduce a bug while migrating.
+
+Where `process.env` is not populated the way it is under Node — a React Native app, a bundler
+target — use that platform's existing accessor. The point of the exit is unchanged: the value stops
+travelling through a singleton.
+
+### 4. Varies per app → passed in as a parameter
+
+The app knows things a library cannot. Take the value as an argument. Do not store it.
+
+Replacing `getEnv` with a module-level `let` and a `configure()` is the same anti-pattern one size
+down — still global, still mutable, still absent from the signature, still order-dependent at
+import time. Runtime state is the end app's responsibility; a library receives what it needs.
+
+```diff
+  // library
+- import { getEnv } from "@ledgerhq/live-env";
+-
+- export function fetchThing(id: string) {
+-   return request(`${getEnv("API_URL")}/things/${id}`);
+- }
++ export function fetchThing(ctx: { apiUrl: string }, id: string) {
++   return request(`${ctx.apiUrl}/things/${id}`);
++ }
+```
+
+Where several values travel together, group them into one context object threaded as the first
+argument rather than growing the parameter list.
+
+The signature is the whole point. A caller cannot forget the value, a test supplies a different one
+without touching global state, and two callers can use two different values at the same time —
+none of which a singleton allows.
+
+If the library already has a `setX()`/`configure()`, moving a variable into it is a shorter step
+than staying, but it is not the destination. Prefer the parameter.
+
+Two things to get right:
+
+- **A value the user can change is app state.** The library does not subscribe to it; the app
+  re-reads its own store and passes the current value on the next call.
+- **Migrate the whole bridge, not one key.** Where a setup function copies several variables into a
+  library, taking one of them out and leaving the call silently drops the rest.
+
+**Backend URLs deserve extra care.** Do not inline an endpoint where the `getEnv` used to be — that
+scatters one backend's address across every file that talks to it, which is the same mistake in a
+new shape. Resolve it once, in the app, and pass it down with the rest of the context.
+`_STAGING`/`_PROD` pairs are not two endpoints: they are one endpoint and an app-level choice of
+which URL to pass.
+
+---
+
+## While the burn-down runs
+
+- **Do not add a new definition.** A new value should be born in one of the four exits.
+- **Do not add a new call site**, including in tests. In a test, set the value the way the
+  production code will read it after the migration, not through `setEnv`.
+- Migrating a variable means removing its definition in the same PR. A definition with zero call
+  sites left is dead weight nobody will come back for.
+- **Check for dead ones first.** A definition with no call sites anywhere is a deletion, not a
+  migration.
+
+## Done
+
+`@ledgerhq/live-env` unpublished and deleted.

--- a/libs/env/README.md
+++ b/libs/env/README.md
@@ -1,7 +1,12 @@
 # live-env
 
-> [!NOTE]
-> **Status: STABLE** — Production-ready; API is considered stable.
+> [!WARNING]
+> **Status: DEPRECATED** — `@ledgerhq/live-env` is being sunset. Do not add env var definitions and
+> do not add call sites. To take an existing one out, read **[MIGRATION.md](./MIGRATION.md)**:
+> every variable exits as a feature flag, an inline constant, `process.env` at the point of use,
+> or a parameter the caller passes in.
+>
+> The package still works exactly as documented below until the last call site is gone.
 
 `@ledgerhq/live-env` is the **framework** for typed runtime environment variables, enabling interoperability across `@ledgerhq/*` libraries. It exposes a reactive API (`getEnv`, `setEnv`, `changes`) but ships **no env-var definitions** — those live in the workspace-private `@shared/env` layer inside the monorepo.
 

--- a/libs/env/src/env.ts
+++ b/libs/env/src/env.ts
@@ -4,26 +4,46 @@ export type { EnvDef, EnvDefs, EnvChange } from "./state";
 import { configured, notifyChange } from "./state";
 import type { EnvDef as EnvDefRecord } from "./state";
 
+/**
+ * @deprecated `@ledgerhq/live-env` is being sunset, and these parsers go with it. Parse and
+ * default explicitly at the point of use instead — see MIGRATION.md.
+ */
 export const intParser = (v: any): number | undefined => {
   const n = Number.parseInt(v, 10);
   if (!Number.isNaN(n)) return n;
 };
 
+/**
+ * @deprecated `@ledgerhq/live-env` is being sunset, and these parsers go with it. Parse and
+ * default explicitly at the point of use instead — see MIGRATION.md.
+ */
 export const floatParser = (v: any): number | undefined => {
   const n = Number.parseFloat(v);
   if (!Number.isNaN(n)) return n;
 };
 
+/**
+ * @deprecated `@ledgerhq/live-env` is being sunset, and these parsers go with it. Parse and
+ * default explicitly at the point of use instead — see MIGRATION.md.
+ */
 export const boolParser = (v: unknown): boolean | undefined => {
   if (typeof v === "boolean") return v;
   return !(v === "0" || v === "false");
 };
 
+/**
+ * @deprecated `@ledgerhq/live-env` is being sunset, and these parsers go with it. Parse and
+ * default explicitly at the point of use instead — see MIGRATION.md.
+ */
 export const stringParser = (v: unknown): string | undefined =>
   typeof v === "string" ? v : undefined;
 
 type JSONValue = string | number | boolean | { [x: string]: JSONValue } | Array<JSONValue>;
 
+/**
+ * @deprecated `@ledgerhq/live-env` is being sunset, and these parsers go with it. Parse and
+ * default explicitly at the point of use instead — see MIGRATION.md.
+ */
 export const jsonParser = (v: unknown): JSONValue | undefined => {
   try {
     if (typeof v !== "string") throw new Error();
@@ -33,34 +53,71 @@ export const jsonParser = (v: unknown): JSONValue | undefined => {
   }
 };
 
+/**
+ * @deprecated `@ledgerhq/live-env` is being sunset, and these parsers go with it. Parse and
+ * default explicitly at the point of use instead — see MIGRATION.md.
+ */
 export const stringArrayParser = (v: unknown): string[] | undefined => {
   const v_array = typeof v === "string" ? v.split(",") : null;
   if (Array.isArray(v_array) && v_array.length > 0) return v_array;
 };
 
+/**
+ * @deprecated `@ledgerhq/live-env` is being sunset, and the registry it introspects goes with
+ * it — see MIGRATION.md.
+ */
 export const getDefinition = (name: string): EnvDefRecord<unknown> | undefined =>
   configured().definitions[name] as EnvDefRecord<unknown> | undefined;
 
+/**
+ * @deprecated `@ledgerhq/live-env` is being sunset, and the registry it introspects goes with
+ * it — see MIGRATION.md.
+ */
 export const getAllEnvNames = (): string[] => Object.keys(configured().definitions);
+
+/**
+ * @deprecated `@ledgerhq/live-env` is being sunset. See MIGRATION.md.
+ */
 export const getAllEnvs = (): Record<string, unknown> => ({ ...configured().env });
 
 // `any`, not `unknown`: the framework knows no value type, and callers expect a usable value.
+/**
+ * @deprecated `@ledgerhq/live-env` is being sunset. Replace this read with a feature flag,
+ * an inline constant, `process.env` at the point of use, or a value the caller passes in —
+ * see MIGRATION.md.
+ */
 export function getEnv(name: string): any {
   return configured(name).env[name];
 }
 
+/**
+ * @deprecated `@ledgerhq/live-env` is being sunset. See MIGRATION.md.
+ */
 export function getEnvDefault(name: string): any {
   return configured(name).defaults[name];
 }
 
+/**
+ * @deprecated `@ledgerhq/live-env` is being sunset, and the registry it introspects goes with
+ * it — see MIGRATION.md.
+ */
 export const isEnvDefault = (name: string): boolean => {
   const { env: e, defaults: d } = configured();
   return e[name] === d[name];
 };
 
+/**
+ * @deprecated `@ledgerhq/live-env` is being sunset, and the registry it introspects goes with
+ * it — see MIGRATION.md.
+ */
 export const getEnvDesc = (name: string): string =>
   (configured().definitions as Record<string, { desc: string }>)[name]?.desc ?? "";
 
+/**
+ * @deprecated `@ledgerhq/live-env` is being sunset. A value that has to change at runtime
+ * belongs in a feature flag or in the app's own state, not in a global mutable singleton —
+ * see MIGRATION.md.
+ */
 export function setEnv(name: string, value: unknown): void {
   const state = configured();
   const oldValue = state.env[name];
@@ -70,6 +127,10 @@ export function setEnv(name: string, value: unknown): void {
   }
 }
 
+/**
+ * @deprecated `@ledgerhq/live-env` is being sunset. Read and parse the raw value where you
+ * use it instead — see MIGRATION.md.
+ */
 export const setEnvUnsafe = (name: string, unsafeValue: unknown): boolean => {
   const definition = getDefinition(name);
   if (!definition) return false;

--- a/libs/env/src/state.ts
+++ b/libs/env/src/state.ts
@@ -1,4 +1,10 @@
+/**
+ * @deprecated `@ledgerhq/live-env` is being sunset — see MIGRATION.md.
+ */
 export type EnvDef<T> = { def: T; parser: (v: unknown) => T | undefined; desc: string };
+/**
+ * @deprecated `@ledgerhq/live-env` is being sunset — see MIGRATION.md.
+ */
 export type EnvDefs = Record<string, EnvDef<unknown>>;
 
 type State = {
@@ -7,6 +13,9 @@ type State = {
   defaults: Record<string, unknown>;
 };
 
+/**
+ * @deprecated `@ledgerhq/live-env` is being sunset — see MIGRATION.md.
+ */
 export type EnvChange = { name: string; value: unknown; oldValue: unknown };
 type Listener = (change: EnvChange) => void;
 
@@ -21,6 +30,10 @@ function getListeners(): Set<Listener> {
   return g.__ledgerLiveEnvListeners;
 }
 
+/**
+ * @deprecated `@ledgerhq/live-env` is being sunset. Subscribe to the app's own state or to a
+ * feature flag instead — see MIGRATION.md.
+ */
 export const changes = {
   subscribe(fn: Listener): { unsubscribe(): void } {
     getListeners().add(fn);
@@ -42,6 +55,10 @@ export function notifyChange(change: EnvChange): void {
   });
 }
 
+/**
+ * @deprecated `@ledgerhq/live-env` is being sunset. Do not register new definitions —
+ * see MIGRATION.md.
+ */
 export function injectDefinitions(defs: EnvDefs): void {
   // Idempotent: Jest reloads modules per test file but globalThis persists, so skip if already set.
   if (g.__ledgerLiveEnvState !== undefined) return;

--- a/libs/ledgerjs/packages/hw-app-exchange/package.json
+++ b/libs/ledgerjs/packages/hw-app-exchange/package.json
@@ -48,7 +48,7 @@
   },
   "scripts": {
     "clean": "rimraf lib lib-es",
-    "prebuild": "pnpm pbjs -t static-module -w es6 -r ledger_trade -o src/generate-protocol.js ./protocol.proto && pnpm pbts -o src/generate-protocol.d.ts src/generate-protocol.js",
+    "prebuild": "pnpm pbjs -t static-module -w es6 -r ledger_trade -o src/generate-protocol.js ./protocol.proto && pnpm pbts -o src/generate-protocol.d.ts src/generate-protocol.js && pnpm exec oxfmt -c ../../../../.oxfmtrc.json src/generate-protocol.js src/generate-protocol.d.ts",
     "build": "tsc --project tsconfig.build.json && tsc --project tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es",
     "postbuild": "cp src/generate-protocol.d.ts lib/generate-protocol.d.ts && cp src/generate-protocol.d.ts lib-es/generate-protocol.d.ts && rm -f lib/generate-protocol.d.ts.map lib-es/generate-protocol.d.ts.map",
     "coverage": "jest --coverage --passWithNoTests",

--- a/shared/env/MIGRATION.md
+++ b/shared/env/MIGRATION.md
@@ -1,0 +1,129 @@
+# Migrating off `@shared/env` in ledger-live
+
+The four exits and the general rules live in
+[`libs/env/MIGRATION.md`](../../libs/env/MIGRATION.md) — read that first. This page is the
+ledger-live-specific half: which exit each kind of variable takes *here*, and who owns the work.
+
+> Tracking: [LIVE-36894](https://ledgerhq.atlassian.net/browse/LIVE-36894).
+
+## API endpoints → `shared/api-services`
+
+Backend URLs are the biggest group in the registry — `CAL_SERVICE_URL`, `LEDGER_COUNTERVALUES_API`,
+`MANAGER_API_BASE`, `SWAP_API_BASE`, `STATUS_API_URL`, `PUSH_DEVICES_SERVICE_URL`, plus the long
+tail of per-coin `*_API_ENDPOINT` / `API_*_NODE`.
+
+An endpoint belongs in exactly one place: **one service per backend under
+`shared/api-services/src/services/<service>/`**, following the split the repo already uses —
+`shared/api-services` owns *reaching* a backend (base URL, headers, retry, reducer path),
+`domain/api/*` owns *what you ask it for* (endpoints, schemas, cache tags, hooks).
+
+The seam is already built. Each service declares its config as a zod contract read from the thunk
+`extraArgument`, so the package holds no env dependency —
+`shared/api-services/src/services/cal/schema.ts`:
+
+```ts
+export const CalApiExtraSchema = z.object({
+  calServiceUrl: z.string().min(1),
+  ledgerClientVersion: z.string().min(1),
+  logger: z.custom<(...args: unknown[]) => void>().optional(),
+});
+```
+
+All five apps already supply it at store configuration, so the migration is only **where the value
+comes from** — the shape does not change, and `parse` fails fast at app init instead of handing you
+an empty string three layers down:
+
+```diff
+  // apps/ledger-live-desktop/src/state-manager/configureStore.ts (and llm, cli, wallet-cli, web-tools)
+- calServiceUrl: getEnv("CAL_SERVICE_URL"),
++ calServiceUrl: config.calServiceUrl,
+```
+
+For a backend with no service yet, add the service first — a single-use-case backend still belongs
+there, so the second one is a one-line addition rather than a migration.
+
+**Coin modules do not go through RTK Query.** A per-coin node URL reaches the module through the
+`Context` threaded as the first argument (ADR-019), resolved from config the app supplies — not
+through a `getCoinConfig` read on the data path. Same principle, different transport; do not reach
+for `shared/api-services` there.
+
+## Feature flags
+
+Declare in `shared/feature-flags/src/flags/team-<yours>/` with `flag()` (no params) or `flagWith()`
+(typed params), export from that folder's `index.ts`, read with `useFeature("<name>")` from
+`@features/platform-feature-flags`.
+
+> [!NOTE]
+> Do **not** add it to `libs/types-live/src/feature.ts` — that file is itself deprecated in favour
+> of `@shared/feature-flags`.
+
+Often the flag already exists. `ADDRESS_POISONING_FAMILIES` duplicates
+`addressPoisoningOperationsFilter`, which already carries the same list under `params.families`;
+the env var is only read when the flag is off, so the exit is deleting the fallback branch:
+
+```diff
+  // libs/ledger-live-common/src/hooks/useAddressPoisoningOperationsFamilies.ts
+- import { getEnv } from "@shared/env";
+  import { useFeature } from "@features/platform-feature-flags";
+
+  const addressPoisoningOperationsFilterFeature = useFeature("addressPoisoningOperationsFilter");
+- const isFeatureEnabled = addressPoisoningOperationsFilterFeature?.enabled;
+-
+- if (!isFeatureEnabled)
+-   return getEnv("ADDRESS_POISONING_FAMILIES")
+-     .split(",")
+-     .map((s: string) => s.trim());
+-
+  return addressPoisoningOperationsFilterFeature?.params?.families ?? null;
+```
+
+Only four variables are genuinely flag-shaped: `ADDRESS_POISONING_FAMILIES`,
+`APTOS_ENABLE_STAKING`, `ENABLE_CELO_TOKENS` and `EXPERIMENTAL_ROI_CALCULATION`. For anything else,
+check the other exits first.
+
+## Pass the context, do not restore a singleton
+
+The target shape is ADR-019: exported functions take the context as their first argument and
+resolve config from it — no singleton reads on the data path. `getCoinConfig`/`setCoinConfig`
+survive only as the compatibility surface for the classic account bridge, and that is the model for
+everything else: a `setX()` is a compatibility shim, not the destination.
+
+That applies to the network bridge too. `bridgeEnvToNetworkState()` in
+`libs/ledger-live-common/src/network/setup.ts` copies **five** variables into `live-network` —
+`ENABLE_NETWORK_LOGS`, `DEBUG_HTTP_RESPONSE`, `LEDGER_CLIENT_VERSION`, `GET_CALLS_TIMEOUT`,
+`GET_CALLS_RETRY` — and subscribes to `changes` so the Developer-settings toggles apply without a
+restart. Moving those five onto `setNetworkState` trades one global for a smaller one; it is
+progress, not the end state.
+
+Two things not to get wrong on the way:
+
+- drop `bridgeEnvToNetworkState()` before all five have an owner and you silently lose network
+  logging, HTTP-response debug and the timeout/retry config
+- the two toggles are app state — the settings store owns them and pushes the current value, the
+  library does not subscribe
+
+## Escape hatches that make everything look variable
+
+`apps/cli/src/live-common-setup-base.ts` does `for (const k in process.env) setEnvUnsafe(k, …)`,
+and the dev settings can set any variable by name — LLD's `EnvVariableOverride`, LLM's `DebugEnv`
+and `FeatureRow`. Neither is evidence that a value varies in a product path.
+
+## Who owns what
+
+Definitions are split under `shared/env/src/definitions/team-*/` and `CODEOWNERS` maps each folder
+to its team. **Ownership for the migration follows the call site, not the definition** — `MOCK` is
+a Platform definition read from coin-integration, wallet-xp, live-devices, qaa and ptx code. The
+team holding the call site is the one that has to make the product decision.
+
+`libs/coin-modules/*` is **already co-owned per module** in `CODEOWNERS`. Only
+`coin-module-boilerplate`, `coin-bitcoin`, `coin-cosmos`, `coin-polkadot`, `coin-solana` and
+`coin-tron` are coin-integration alone; every other module is shared with blockchain-support,
+hoodies, blockydevs or third-party-leads.
+
+Per-team epics hang off [LIVE-36894](https://ledgerhq.atlassian.net/browse/LIVE-36894).
+
+## Outside this monorepo
+
+Three repos call `injectDefinitions()` themselves and are covered by no team epic here —
+`coin-modules` (`apps/coin-service`), `revault` (`packages/mobile`) and `qaa-slack-notifier`
+(`fund-monitor`). They break when the package is unpublished, not before.

--- a/shared/env/README.md
+++ b/shared/env/README.md
@@ -1,7 +1,10 @@
 # @shared/env
 
-> [!NOTE]
-> **Status: STABLE** — Production-ready; API is considered stable.
+> [!WARNING]
+> **Status: DEPRECATED** — sunset together with `@ledgerhq/live-env`
+> ([LIVE-36894](https://ledgerhq.atlassian.net/browse/LIVE-36894)). Do not add a definition and do
+> not add a call site. See **[MIGRATION.md](./MIGRATION.md)** for how each kind of variable exits
+> here, and [`libs/env/MIGRATION.md`](../../libs/env/MIGRATION.md) for the four exits themselves.
 
 Workspace-private DDD layer for Ledger Live environment variables.
 

--- a/shared/env/project.json
+++ b/shared/env/project.json
@@ -2,8 +2,7 @@
   "name": "@shared/env",
   "targets": {
     "build": {
-      "executor": "nx:noop",
-      "dependsOn": []
+      "executor": "nx:noop"
     },
     "coverage": {
       "dependsOn": ["build"]

--- a/shared/env/src/index.ts
+++ b/shared/env/src/index.ts
@@ -10,25 +10,53 @@ import { allDefinitions } from "./definitions";
 
 injectDefinitions(allDefinitions);
 
+/**
+ * @deprecated `@shared/env` is being sunset with `@ledgerhq/live-env` — see
+ * https://github.com/LedgerHQ/ledger-live/blob/develop/shared/env/MIGRATION.md
+ */
 export type EnvName = keyof typeof allDefinitions;
 type InferDef<K extends EnvName> = NonNullable<ReturnType<(typeof allDefinitions)[K]["parser"]>>;
 
+/**
+ * @deprecated `@shared/env` is being sunset with `@ledgerhq/live-env`. Replace this read with
+ * a feature flag, an inline constant, `process.env` at the point of use, or a value the caller
+ * passes in — see https://github.com/LedgerHQ/ledger-live/blob/develop/shared/env/MIGRATION.md
+ */
 export function getEnv<K extends EnvName>(name: K): InferDef<K> {
   return _getEnv(name) as InferDef<K>;
 }
 
+/**
+ * @deprecated `@shared/env` is being sunset with `@ledgerhq/live-env`. A value that has to
+ * change at runtime belongs in a feature flag or in the app's own state, not in a global
+ * mutable singleton — see
+ * https://github.com/LedgerHQ/ledger-live/blob/develop/shared/env/MIGRATION.md
+ */
 export function setEnv<K extends EnvName>(name: K, value: InferDef<K>): void {
   _setEnv(name, value);
 }
 
+/**
+ * @deprecated `@shared/env` is being sunset with `@ledgerhq/live-env`. Read and parse the raw
+ * value where you use it instead — see
+ * https://github.com/LedgerHQ/ledger-live/blob/develop/shared/env/MIGRATION.md
+ */
 export function setEnvUnsafe(name: string, raw: unknown): boolean {
   return _setEnvUnsafe(name, raw);
 }
 
+/**
+ * @deprecated `@shared/env` is being sunset with `@ledgerhq/live-env` — see
+ * https://github.com/LedgerHQ/ledger-live/blob/develop/shared/env/MIGRATION.md
+ */
 export type EnvValue<K extends EnvName> = InferDef<K>;
 
 export { changes } from "@ledgerhq/live-env";
 
+/**
+ * @deprecated `@shared/env` is being sunset with `@ledgerhq/live-env` — see
+ * https://github.com/LedgerHQ/ledger-live/blob/develop/shared/env/MIGRATION.md
+ */
 export function getEnvDefault<K extends EnvName>(name: K): InferDef<K> {
   return _getEnvDefault(name) as InferDef<K>;
 }
@@ -47,6 +75,10 @@ export {
   getAllEnvNames,
 } from "@ledgerhq/live-env";
 
+/**
+ * @deprecated `@shared/env` is being sunset with `@ledgerhq/live-env` — see
+ * https://github.com/LedgerHQ/ledger-live/blob/develop/shared/env/MIGRATION.md
+ */
 export function getAllEnvs(): { [K in EnvName]: InferDef<K> } {
   return _getAllEnvs() as unknown as { [K in EnvName]: InferDef<K> };
 }


### PR DESCRIPTION
### 📝 Description

Marks the whole `@ledgerhq/live-env` / `@shared/env` public API `@deprecated` — functions, types and the `useEnv` hook — so it shows at the call site in the IDE.

Two guides, split along the sunset: `libs/env/MIGRATION.md` is standalone and describes the four exits every variable takes (feature flag, inline constant, `process.env` at the point of use, the app's own config), so it survives the move to ts-libs; `shared/env/MIGRATION.md` covers what that means here — `shared/api-services` for endpoints, the feature-flag registry, and ownership by call site.

No behaviour change: the packages work exactly as before until the last call site is gone.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36897](https://ledgerhq.atlassian.net/browse/LIVE-36897), under [LIVE-36894](https://ledgerhq.atlassian.net/browse/LIVE-36894)


[LIVE-36897]: https://ledgerhq.atlassian.net/browse/LIVE-36897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-36894]: https://ledgerhq.atlassian.net/browse/LIVE-36894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ