### PR TITLE
[LWD] feat(card): add onboarding status query

### DIFF
--- a/.changeset/card-onboarding-status-query.md
+++ b/.changeset/card-onboarding-status-query.md
@@ -1,0 +1,6 @@
+---
+"@domain/api-card-management": minor
+"ledger-live-desktop": patch
+---
+
+Add a getCardOnboardingStatus RTK Query endpoint and a schema-validated mock fixture.

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -69,6 +69,7 @@
     "@devtools/wire": "workspace:*",
     "@domain/api-aggregated-assets": "workspace:*",
     "@domain/api-altcoins-sentiment": "workspace:^",
+    "@domain/api-card-management": "workspace:^",
     "@domain/api-currency-fiat": "workspace:^",
     "@domain/api-currency-token": "workspace:^",
     "@domain/api-market-sentiment": "workspace:^",

--- a/apps/ledger-live-desktop/src/mocks/browser.ts
+++ b/apps/ledger-live-desktop/src/mocks/browser.ts
@@ -5,6 +5,7 @@ import { mockStablecoinsResponse } from "@domain/api-aggregated-assets/mock/stab
 import { mockStocksResponse } from "@domain/api-aggregated-assets/mock/stocks";
 import { mockLedgerStatus } from "@ledgerhq/live-common/notifications/ServiceStatusProvider/mocks/ledgerStatus";
 import { mockFearAndGreedLatest } from "@domain/api-market-sentiment/mock";
+import { getMockCardOnboardingStatus } from "@domain/api-card-management/mock";
 import countervaluesHandlers from "../../tests/handlers/countervalues";
 import marketHandlers from "../../tests/handlers/market";
 
@@ -26,6 +27,7 @@ const handlers = [
   }),
   ...marketHandlers,
   ...countervaluesHandlers,
+  http.get("*/v1/card/onboarding-status", () => HttpResponse.json(getMockCardOnboardingStatus())),
 ];
 
 const mswWorker = setupWorker(...handlers);

--- a/domain/api/card-management/package.json
+++ b/domain/api/card-management/package.json
@@ -7,6 +7,7 @@
   "types": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./mock": "./src/onboardingStatus.mock.ts",
     "./package.json": "./package.json"
   },
   "sideEffects": false,

--- a/domain/api/card-management/src/api.test.ts
+++ b/domain/api/card-management/src/api.test.ts
@@ -4,6 +4,7 @@ import {
   cardManagementApi,
   useFreezeCardMutation,
   useGetCardLinkedWalletsQuery,
+  useGetCardOnboardingStatusQuery,
   useGetCardStatusQuery,
   useLazyGetCardStatusQuery,
   useGetInternalWalletsQuery,
@@ -137,6 +138,7 @@ describe("cardManagementApi configuration", () => {
       "exchangeAuthorizationCode",
       "freezeCard",
       "getCardLinkedWallets",
+      "getCardOnboardingStatus",
       "getCardStatus",
       "getInternalWallets",
       "getUser",
@@ -171,6 +173,11 @@ describe("cardManagementApi configuration", () => {
     expect(useGetInternalWalletsQuery).toBeDefined();
     expect(cardManagementApi.endpoints.getCardLinkedWallets).toBeDefined();
     expect(useGetCardLinkedWalletsQuery).toBeDefined();
+  });
+
+  it("exposes the onboarding status endpoint and its hook", () => {
+    expect(cardManagementApi.endpoints.getCardOnboardingStatus).toBeDefined();
+    expect(useGetCardOnboardingStatusQuery).toBeDefined();
   });
 
   it("shares the Card service reducer and middleware once registered in a store", () => {
@@ -653,6 +660,56 @@ describe("cardManagementApi requests", () => {
       const store = makeStore(async () => "session-token");
       const result = await store.dispatch(
         cardManagementApi.endpoints.getCardLinkedWallets.initiate(),
+      );
+
+      expect(result.data).toBeUndefined();
+      expect(result.error).toBeDefined();
+    });
+  });
+
+  describe("getCardOnboardingStatus", () => {
+    const onboardingStatus = {
+      steps: [
+        {
+          id: "kyc",
+          title: "Verify your identity",
+          description: "Complete KYC verification to activate your card.",
+          isDone: true,
+        },
+        {
+          id: "address",
+          title: "Add shipping address",
+          description: "Tell us where to send your physical card.",
+          isDone: false,
+        },
+      ],
+    };
+
+    it("reads the onboarding steps with the bearer token and the client key", async () => {
+      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(onboardingStatus));
+
+      const store = makeStore(async () => "session-token");
+      const result = await store.dispatch(
+        cardManagementApi.endpoints.getCardOnboardingStatus.initiate(),
+      );
+
+      expect(request(fetchSpy).url).toBe("https://card.test/v1/card/onboarding-status");
+      expect(request(fetchSpy).method).toBe("GET");
+      expect(request(fetchSpy).headers.get("authorization")).toBe("Bearer session-token");
+      expect(request(fetchSpy).headers.get("x-client-key")).toBe("client-key");
+      expect(result.data).toEqual(onboardingStatus);
+    });
+
+    it("rejects a step whose done flag is not a boolean", async () => {
+      fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue(
+        jsonResponse({
+          steps: [{ ...onboardingStatus.steps[0], isDone: "yes" }],
+        }),
+      );
+
+      const store = makeStore(async () => "session-token");
+      const result = await store.dispatch(
+        cardManagementApi.endpoints.getCardOnboardingStatus.initiate(),
       );
 
       expect(result.data).toBeUndefined();

--- a/domain/api/card-management/src/api.ts
+++ b/domain/api/card-management/src/api.ts
@@ -5,6 +5,7 @@ import {
   PayCardInternalWalletsResponseSchema,
   PayCardLinkedWalletsResponseSchema,
   PayCardLogoutResponseSchema,
+  PayCardOnboardingStatusResponseSchema,
   PayCardOrderResponseSchema,
   PayCardSessionResponseSchema,
   PayCardSessionSchema,
@@ -18,6 +19,7 @@ import type {
   PayCardInternalWallet,
   PayCardLinkedWallet,
   PayCardLogoutResult,
+  PayCardOnboardingStatus,
   PayCardOrderResult,
   PayCardRefreshSessionRequest,
   PayCardSession,
@@ -133,6 +135,15 @@ export const cardManagementApi = cardApi
         }),
         responseSchema: PayCardLinkedWalletsResponseSchema,
       }),
+
+      getCardOnboardingStatus: build.query<PayCardOnboardingStatus, void>({
+        query: () => ({
+          url: "/v1/card/onboarding-status",
+          method: "GET",
+        }),
+        responseSchema: PayCardOnboardingStatusResponseSchema,
+        providesTags: ["CardOnboardingStatus"],
+      }),
     }),
   });
 
@@ -150,4 +161,5 @@ export const {
   useUnfreezeCardMutation,
   useGetInternalWalletsQuery,
   useGetCardLinkedWalletsQuery,
+  useGetCardOnboardingStatusQuery,
 } = cardManagementApi;

--- a/domain/api/card-management/src/constants.ts
+++ b/domain/api/card-management/src/constants.ts
@@ -2,4 +2,4 @@
  * RTK Query cache tags owned by the Card Management use case. Registered on the shared `cardApi` via
  * `enhanceEndpoints({ addTagTypes })`, so the shared service never has to know they exist.
  */
-export const CARD_MANAGEMENT_TAGS = ["CardStatus"] as const;
+export const CARD_MANAGEMENT_TAGS = ["CardStatus", "CardOnboardingStatus"] as const;

--- a/domain/api/card-management/src/onboardingStatus.mock.ts
+++ b/domain/api/card-management/src/onboardingStatus.mock.ts
@@ -1,0 +1,44 @@
+import { PayCardOnboardingStatusResponseSchema } from "./schema";
+import type { PayCardOnboardingStatus } from "./types";
+
+type Step = PayCardOnboardingStatus["steps"][number];
+
+const INITIAL_STEPS: readonly Step[] = PayCardOnboardingStatusResponseSchema.parse({
+  steps: [
+    {
+      id: "create-account",
+      title: "Create an account",
+      description: "Sign up to start using your Ledger Card.",
+      isDone: true,
+    },
+    {
+      id: "choose-card-type",
+      title: "Choose card type",
+      description: "Choose between virtual and physical",
+      isDone: false,
+    },
+    {
+      id: "top-up-card",
+      title: "Top up your card",
+      description: "Choose USDC, USDT, BTC or more",
+      isDone: false,
+    },
+    {
+      id: "first-purchase",
+      title: "Make your first purchase",
+      description: "Pay online or in store",
+      isDone: false,
+    },
+  ],
+}).steps;
+
+let steps: Step[] = INITIAL_STEPS.map(step => ({ ...step }));
+
+export function getMockCardOnboardingStatus(): PayCardOnboardingStatus {
+  return PayCardOnboardingStatusResponseSchema.parse({ steps });
+}
+
+/** Mark a single step done/undone, or pass `"all"` to update every step. */
+export function setMockOnboardingStepDone(id: string, isDone: boolean): void {
+  steps = steps.map(step => (id === "all" || step.id === id ? { ...step, isDone } : step));
+}

--- a/domain/api/card-management/src/schema.test.ts
+++ b/domain/api/card-management/src/schema.test.ts
@@ -4,6 +4,7 @@ import {
   PayCardInternalWalletSchema,
   PayCardLinkedWalletSchema,
   PayCardLogoutResponseSchema,
+  PayCardOnboardingStatusResponseSchema,
   PayCardOrderResponseSchema,
   PayCardSessionResponseSchema,
   PayCardStatusResponseSchema,
@@ -249,5 +250,56 @@ describe("PayCardLinkedWalletSchema", () => {
 
   it("rejects a linked wallet with no network, which would not identify the asset", () => {
     expect(() => PayCardLinkedWalletSchema.parse({ ...linked, network: "" })).toThrow();
+  });
+});
+
+describe("PayCardOnboardingStatusResponseSchema", () => {
+  const response = {
+    steps: [
+      {
+        id: "kyc",
+        title: "Verify your identity",
+        description: "Complete KYC verification to activate your card.",
+        isDone: true,
+      },
+      {
+        id: "address",
+        title: "Add shipping address",
+        description: "Tell us where to send your physical card.",
+        isDone: false,
+      },
+    ],
+  };
+
+  it("reads a status made of onboarding steps", () => {
+    expect(PayCardOnboardingStatusResponseSchema.parse(response)).toEqual(response);
+  });
+
+  it("accepts a status with no remaining steps as an empty list", () => {
+    expect(PayCardOnboardingStatusResponseSchema.parse({ steps: [] })).toEqual({ steps: [] });
+  });
+
+  it("drops the keys the wire contract does not declare on a step", () => {
+    const parsed = PayCardOnboardingStatusResponseSchema.parse({
+      steps: [{ ...response.steps[0], cta: "https://ledger.com" }],
+    });
+
+    expect(parsed.steps[0]).not.toHaveProperty("cta");
+  });
+
+  it("rejects a step whose done flag is not a boolean", () => {
+    expect(() =>
+      PayCardOnboardingStatusResponseSchema.parse({
+        steps: [{ ...response.steps[0], isDone: "yes" }],
+      }),
+    ).toThrow();
+  });
+
+  it("rejects a step with an empty title", () => {
+    expect(() =>
+      PayCardOnboardingStatusResponseSchema.parse({
+        steps: [{ ...response.steps[0], title: "" }],
+      }),
+    ).toThrow();
   });
 });

--- a/domain/api/card-management/src/schema.ts
+++ b/domain/api/card-management/src/schema.ts
@@ -77,3 +77,15 @@ export const PayCardLinkedWalletSchema = z.object({
 });
 
 export const PayCardLinkedWalletsResponseSchema = z.array(PayCardLinkedWalletSchema);
+
+/** One onboarding step the card holder still has to complete, as the backend describes it. */
+export const PayCardOnboardingStepSchema = z.object({
+  id: z.string().min(1),
+  title: z.string().min(1),
+  description: z.string().min(1),
+  isDone: z.boolean(),
+});
+
+export const PayCardOnboardingStatusResponseSchema = z.object({
+  steps: z.array(PayCardOnboardingStepSchema),
+});

--- a/domain/api/card-management/src/types.ts
+++ b/domain/api/card-management/src/types.ts
@@ -5,6 +5,8 @@ import {
   PayCardInternalWalletSchema,
   PayCardLinkedWalletSchema,
   PayCardLogoutResponseSchema,
+  PayCardOnboardingStatusResponseSchema,
+  PayCardOnboardingStepSchema,
   PayCardOrderResponseSchema,
   PayCardSessionResponseSchema,
   PayCardSessionSchema,
@@ -41,3 +43,7 @@ export type PayCardRefreshSessionRequest = {
 export type PayCardInternalWallet = z.infer<typeof PayCardInternalWalletSchema>;
 
 export type PayCardLinkedWallet = z.infer<typeof PayCardLinkedWalletSchema>;
+
+export type PayCardOnboardingStep = z.infer<typeof PayCardOnboardingStepSchema>;
+
+export type PayCardOnboardingStatus = z.infer<typeof PayCardOnboardingStatusResponseSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -858,6 +858,9 @@ importers:
       '@domain/api-altcoins-sentiment':
         specifier: workspace:^
         version: link:../../domain/api/altcoins-sentiment
+      '@domain/api-card-management':
+        specifier: workspace:^
+        version: link:../../domain/api/card-management
       '@domain/api-currency-fiat':
         specifier: workspace:^
         version: link:../../domain/api/currency-fiat
@@ -22847,6 +22850,7 @@ packages:
     resolution: {integrity: sha512-KRbkSthClEwkbpt/LLJmBJhIOvOsyrp9OICisF9p3mOODjaxAuYmyOgrVreg09BT2F4hXN3JXpvt9eIZpTCRsw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.7.8':
     resolution: {integrity: sha512-pdPMWko1yZI5ZNI6/t2Y5rQPGgV/ah5DW+mlHo2aFKav4lnxvgisEh9e4HtOsYBfK/9PyYZ5u3M9hLSaMiJ75w==}
@@ -28319,7 +28323,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: '*'
+      rxjs: ^5.5.10
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -44705,7 +44709,7 @@ snapshots:
       make-fetch-happen: 10.2.1
       nopt: 6.0.0
       proc-log: 2.0.1
-      semver: 7.7.3
+      semver: 7.8.1
       tar: 6.2.1
       which: 2.0.2
     transitivePeerDependencies:
@@ -48896,13 +48900,13 @@ snapshots:
   '@npmcli/fs@1.1.1':
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.7.3
+      semver: 7.8.1
     optional: true
 
   '@npmcli/fs@2.1.2':
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.7.3
+      semver: 7.8.1
 
   '@npmcli/move-file@1.1.2':
     dependencies:
@@ -50960,7 +50964,7 @@ snapshots:
 
   '@react-native/codegen@0.77.3(@babel/preset-env@7.28.5(@babel/core@7.28.5))':
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.8
       '@babel/preset-env': 7.28.5(@babel/core@7.28.5)
       glob: 7.2.3
       hermes-parser: 0.25.1
@@ -50974,7 +50978,7 @@ snapshots:
   '@react-native/codegen@0.81.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.8
       glob: 7.2.3
       hermes-parser: 0.29.1
       invariant: 2.2.4
@@ -63707,7 +63711,7 @@ snapshots:
   jscodeshift@17.3.0(@babel/preset-env@7.28.5(@babel/core@7.28.5)):
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.8
       '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.28.5)
@@ -65154,9 +65158,7 @@ snapshots:
     optionalDependencies:
       metro-transform-worker: 0.83.7
     transitivePeerDependencies:
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   metro-core@0.81.5:
     dependencies:
@@ -65263,7 +65265,7 @@ snapshots:
   metro-source-map@0.81.5:
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.27.0'
+      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.29.8'
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4


### PR DESCRIPTION
### 📝 Description

Adds the Card onboarding status endpoint that the Pay onboarding widget needs.

- `getCardOnboardingStatus` RTK Query endpoint on the Card service (`GET /v1/card/onboarding-status`)
- Zod schema and inferred types for the aggregated steps payload
- A schema-validated fixture exported from `@domain/api-card-management/mock`, with a helper to flip a step done/undone so DevTools can drive it
- Desktop registers the development MSW handler for the endpoint

No UI in this PR: it only lands the contract so the widget work can build on top.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36927](https://ledgerhq.atlassian.net/browse/LIVE-36927)
- **ADR** (if any): n/a


[LIVE-36927]: https://ledgerhq.atlassian.net/browse/LIVE-36927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ