### PR TITLE
[LWM] feat(pay-card): persist onboarding widget on mobile

### DIFF
--- a/.changeset/card-onboarding-widget-mobile.md
+++ b/.changeset/card-onboarding-widget-mobile.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Register and persist the card onboarding widget state in Ledger Wallet Mobile.

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -113,6 +113,7 @@
     "@features/flow-app-lock": "workspace:*",
     "@features/flow-pay-card": "workspace:^",
     "@features/flow-pay-card-auth": "workspace:^",
+    "@features/flow-pay-card-widget": "workspace:^",
     "@features/flow-pay-balance": "workspace:^",
     "@features/flow-pay-bank-transfer": "workspace:^",
     "@features/flow-pay-deposit": "workspace:^",

--- a/apps/ledger-live-mobile/src/components/DBSave.test.ts
+++ b/apps/ledger-live-mobile/src/components/DBSave.test.ts
@@ -20,11 +20,12 @@ describe("featureFlagsLense", () => {
 });
 
 describe("payCardPersistedSelector (mobile persistence lens)", () => {
-  it("composes { hasSeenFeatureTour, hasSeenReceiveVerifyHint, balanceFilter } from the pay card flow slices", () => {
+  it("composes the pay card flow slices into one persisted blob", () => {
     const state = {
       payCardFeatureTour: { hasSeenFeatureTour: true },
       payRequestVerifyHint: { hasSeenReceiveVerifyHint: true },
       payCardBalance: { balanceFilter: "ethereum/erc20/usd__coin" },
+      payCardOnboardingWidget: { hasCompletedOnboarding: true },
     } as unknown as State;
 
     const projected = payCardPersistedSelector(state);
@@ -33,6 +34,7 @@ describe("payCardPersistedSelector (mobile persistence lens)", () => {
       hasSeenFeatureTour: true,
       hasSeenReceiveVerifyHint: true,
       balanceFilter: "ethereum/erc20/usd__coin",
+      hasCompletedOnboarding: true,
     });
   });
 });

--- a/apps/ledger-live-mobile/src/components/DBSave.ts
+++ b/apps/ledger-live-mobile/src/components/DBSave.ts
@@ -38,6 +38,7 @@ import { marketBannerStoreSelector } from "~/reducers/marketBanner";
 import { payCardBalancePersistedSelector } from "@features/flow-pay-balance/state";
 import { payCardFeatureTourPersistedSelector } from "@features/flow-pay-feature-tour/state";
 import { payRequestVerifyHintPersistedSelector } from "@features/flow-pay-request/state";
+import { payCardOnboardingWidgetPersistedSelector } from "@features/flow-pay-card-widget/state";
 import { settingsStoreSelector } from "~/reducers/settings";
 import type { State } from "~/reducers/types";
 import { Maybe } from "../types/helpers";
@@ -190,16 +191,19 @@ export const payCardPersistedSelector = (state: State) => ({
   ...payCardFeatureTourPersistedSelector(state),
   ...payRequestVerifyHintPersistedSelector(state),
   ...payCardBalancePersistedSelector(state),
+  ...payCardOnboardingWidgetPersistedSelector(state),
 });
 
 const payCardDbSaveSliceSelector = createSelector(
   (state: State) => state.payCardBalance,
   (state: State) => state.payCardFeatureTour,
   (state: State) => state.payRequestVerifyHint,
-  (payCardBalance, payCardFeatureTour, payRequestVerifyHint) => ({
+  (state: State) => state.payCardOnboardingWidget,
+  (payCardBalance, payCardFeatureTour, payRequestVerifyHint, payCardOnboardingWidget) => ({
     payCardBalance,
     payCardFeatureTour,
     payRequestVerifyHint,
+    payCardOnboardingWidget,
   }),
 );
 const payCardPersistedNotEquals = (a: State, b: State) =>

--- a/apps/ledger-live-mobile/src/context/LedgerStore.tsx
+++ b/apps/ledger-live-mobile/src/context/LedgerStore.tsx
@@ -6,6 +6,7 @@ import { restoreLargeScreenUpsellModalState } from "@ledgerhq/live-engagement/la
 import { restorePayCardBalanceFilter } from "@features/flow-pay-balance/state";
 import { restorePayCardFeatureTour } from "@features/flow-pay-feature-tour/state";
 import { restoreReceiveVerifyHint } from "@features/flow-pay-request/state";
+import { restorePayCardOnboardingWidget } from "@features/flow-pay-card-widget/state";
 import { backfillOnboardingDate } from "~/logic/postOnboarding/backfillOnboardingDate";
 import { CounterValuesStateRaw } from "@ledgerhq/live-countervalues/types";
 import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
@@ -206,6 +207,7 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
         store.dispatch(restorePayCardFeatureTour(payCardState));
         store.dispatch(restoreReceiveVerifyHint(payCardState));
         store.dispatch(restorePayCardBalanceFilter(payCardState));
+        store.dispatch(restorePayCardOnboardingWidget(payCardState));
       }
 
       store.dispatch(importTrustchainStoreState(trustchainStore));

--- a/apps/ledger-live-mobile/src/db.ts
+++ b/apps/ledger-live-mobile/src/db.ts
@@ -34,11 +34,12 @@ import type { PersistedIdentities } from "@domain/entity-client-identity";
 import type { PayCardBalanceState } from "@features/flow-pay-balance/state";
 import type { PayCardFeatureTourState } from "@features/flow-pay-feature-tour/state";
 import type { PayRequestVerifyHintState } from "@features/flow-pay-request/state";
+import type { PayCardOnboardingWidgetState } from "@features/flow-pay-card-widget/state";
 
-/** Persisted pay card blob: tour, request verify hint, and balance filter, stored under one key. */
 type PayCardPersistedState = PayCardFeatureTourState &
   PayRequestVerifyHintState &
-  PayCardBalanceState;
+  PayCardBalanceState &
+  PayCardOnboardingWidgetState;
 
 const ACCOUNTS_KEY = "accounts";
 const ACCOUNTS_KEY_SORT = "accounts.sort";

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10297,6 +10297,17 @@
         "title": "Select {{name}}'s address",
         "addAddress": "Add address"
       }
+    },
+    "cardOnboarding": {
+      "widget": {
+        "title": "Set up your card to start spending",
+        "allDone": "You're all set"
+      },
+      "dialog": {
+        "title": "Set up your card",
+        "stepComplete": "Complete",
+        "gotIt": "Got it"
+      }
     }
   },
   "syncIndicator": {

--- a/apps/ledger-live-mobile/src/reducers/index.ts
+++ b/apps/ledger-live-mobile/src/reducers/index.ts
@@ -48,6 +48,7 @@ import { supportedFiatsSlice } from "@domain/entity-currency-fiat";
 import { payCardBalanceSlice } from "@features/flow-pay-balance/state";
 import { payCardFeatureTourSlice } from "@features/flow-pay-feature-tour/state";
 import { payRequestVerifyHintSlice } from "@features/flow-pay-request/state";
+import { payCardOnboardingWidgetSlice } from "@features/flow-pay-card-widget/state";
 import { payCardAuthSlice } from "@features/flow-pay-card-auth/state";
 import { contactsSlice } from "@domain/entity-contact";
 import type { UnknownAction } from "@reduxjs/toolkit";
@@ -93,6 +94,7 @@ const appReducer = combineReducers({
   payCardBalance: payCardBalanceSlice.reducer,
   payCardFeatureTour: payCardFeatureTourSlice.reducer,
   payRequestVerifyHint: payRequestVerifyHintSlice.reducer,
+  payCardOnboardingWidget: payCardOnboardingWidgetSlice.reducer,
   payCardAuth: payCardAuthSlice.reducer,
   toasts,
   trustchain,

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -43,6 +43,7 @@ import type { PayCardBalanceState } from "@features/flow-pay-balance/state";
 import type { PayCardFeatureTourState } from "@features/flow-pay-feature-tour/state";
 import type { PayRequestVerifyHintState } from "@features/flow-pay-request/state";
 import type { PayCardAuthState } from "@features/flow-pay-card-auth/state";
+import type { PayCardOnboardingWidgetState } from "@features/flow-pay-card-widget/state";
 import type { IdentitiesState } from "@domain/entity-client-identity";
 import type { FirebaseMessagingTypes } from "@react-native-firebase/messaging";
 import { RebornBuyDeviceDrawerState } from "./rebornBuyDeviceDrawer";
@@ -482,6 +483,7 @@ export type State = LLMRTKApiState & {
   payCardBalance: PayCardBalanceState;
   payCardFeatureTour: PayCardFeatureTourState;
   payRequestVerifyHint: PayRequestVerifyHintState;
+  payCardOnboardingWidget: PayCardOnboardingWidgetState;
   payCardAuth: PayCardAuthState;
   settings: SettingsState;
   toasts: ToastState;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1790,6 +1790,9 @@ importers:
       '@features/flow-pay-card-auth':
         specifier: workspace:^
         version: link:../../features/flow/pay-card-auth
+      '@features/flow-pay-card-widget':
+        specifier: workspace:^
+        version: link:../../features/flow/pay-card-widget
       '@features/flow-pay-contact':
         specifier: workspace:^
         version: link:../../features/flow/pay-contact


### PR DESCRIPTION
### 📝 Description

Wires the card onboarding widget into Ledger Wallet Mobile: persist dismiss and i18n. Native UI views stay stubbed in this PR.

- Register the `payCardOnboardingWidget` reducer and persist it (`DBSave` / `LedgerStore`)
- Mobile i18n strings for the widget
- Package wiring so the Pay tab can consume `@features/flow-pay-card-widget`

Depends on the shared widget view-model PR.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35425](https://ledgerhq.atlassian.net/browse/LIVE-35425)
- **ADR** (if any): n/a


[LIVE-35425]: https://ledgerhq.atlassian.net/browse/LIVE-35425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ