### PR TITLE
feat(devtools): add card onboarding controls

### DIFF
--- a/.changeset/card-onboarding-devtools.md
+++ b/.changeset/card-onboarding-devtools.md
@@ -1,0 +1,6 @@
+---
+"@devtools/bindings": patch
+"@devtools/pay-card": patch
+---
+
+Add controls for card onboarding progress and dismiss state to the Pay Card DevTool.

--- a/devtools/bindings/package.json
+++ b/devtools/bindings/package.json
@@ -23,6 +23,7 @@
     "@devtools/env": "workspace:*",
     "@devtools/registry": "workspace:*",
     "@domain/api-card-management": "workspace:*",
+    "@features/flow-pay-card-widget": "workspace:*",
     "@features/flow-pay-feature-tour": "workspace:*",
     "@features/flow-pay-request": "workspace:*",
     "@features/platform-feature-flags": "workspace:*",

--- a/devtools/bindings/src/usePayCardToolProps.test.tsx
+++ b/devtools/bindings/src/usePayCardToolProps.test.tsx
@@ -12,6 +12,7 @@ import {
   markReceiveVerifyHintSeen,
 } from "@features/flow-pay-request/state";
 import { cardApi } from "@shared/api-services";
+import { payCardOnboardingWidgetSlice } from "@features/flow-pay-card-widget/state";
 import { usePayCardToolProps } from "./usePayCardToolProps";
 
 /**
@@ -51,6 +52,7 @@ function buildStore() {
       featureFlags: featureFlagsReducer,
       payCardFeatureTour: payCardFeatureTourSlice.reducer,
       payRequestVerifyHint: payRequestVerifyHintSlice.reducer,
+      payCardOnboardingWidget: payCardOnboardingWidgetSlice.reducer,
       // The tool reads the Card endpoints, so its api has to be part of the store under test.
       [cardApi.reducerPath]: cardApi.reducer,
     },
@@ -78,26 +80,26 @@ describe("usePayCardToolProps", () => {
     const { result } = renderHook(() => usePayCardToolProps(), { wrapper: withStore(store) });
 
     expect(result.current.onboarding.steps.map(step => step.id)).toEqual([
-      "kyc",
-      "claim",
-      "topup",
-      "purchase",
+      "create-account",
+      "choose-card-type",
+      "top-up-card",
+      "first-purchase",
     ]);
     expect(result.current.flags.payTabEnabled).toBe(false);
     expect(result.current.flags.ptxCardEnabled).toBe(false);
   });
 
-  it("includes walletPay when platform is native", () => {
+  it("includes apple-google-pay step when platform is native", () => {
     const { result } = renderHook(() => usePayCardToolProps({ platform: "native" }), {
       wrapper: withStore(store),
     });
 
     expect(result.current.onboarding.steps.map(step => step.id)).toEqual([
-      "kyc",
-      "claim",
-      "topup",
-      "walletPay",
-      "purchase",
+      "create-account",
+      "choose-card-type",
+      "top-up-card",
+      "apple-google-pay",
+      "first-purchase",
     ]);
   });
 
@@ -174,9 +176,11 @@ describe("usePayCardToolProps", () => {
     const { result } = renderHook(() => usePayCardToolProps(), { wrapper: withStore(store) });
 
     act(() => {
-      result.current.onboarding.setStepDone("kyc", true);
+      result.current.onboarding.setStepDone("choose-card-type", true);
     });
-    expect(result.current.onboarding.steps.find(step => step.id === "kyc")?.done).toBe(true);
+    expect(result.current.onboarding.steps.find(step => step.id === "choose-card-type")?.done).toBe(
+      true,
+    );
 
     act(() => {
       result.current.onboarding.setStepDone("all", false);

--- a/devtools/bindings/src/usePayCardToolProps.ts
+++ b/devtools/bindings/src/usePayCardToolProps.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useLazyGetCardStatusQuery } from "@domain/api-card-management";
+import { cardManagementApi, useLazyGetCardStatusQuery } from "@domain/api-card-management";
 import { useDispatch, useSelector } from "react-redux";
 import { setOverride } from "@shared/feature-flags";
 import { changes, getEnv, setEnvUnsafe, type EnvName } from "@shared/env";
@@ -12,6 +12,11 @@ import {
   resetReceiveVerifyHintSeen,
   selectHasSeenReceiveVerifyHint,
 } from "@features/flow-pay-request/state";
+import {
+  resetCardOnboardingCompleted,
+  selectHasCompletedCardOnboarding,
+} from "@features/flow-pay-card-widget/state";
+import { setMockOnboardingStepDone } from "@domain/api-card-management/mock";
 import type { DevToolsConfig } from "@devtools/registry";
 
 type PayCardToolProps = Extract<DevToolsConfig[number], { id: "pay-card" }>["config"];
@@ -26,19 +31,23 @@ export type UsePayCardToolPropsOptions = {
 };
 
 const LEADING_ONBOARDING_STEPS: readonly OnboardingStep[] = [
-  { id: "kyc", label: "Kyc", done: false },
-  { id: "claim", label: "Claim card", done: false },
-  { id: "topup", label: "Top up", done: false },
+  { id: "create-account", label: "Create account", done: true },
+  { id: "choose-card-type", label: "Choose card type", done: false },
+  { id: "top-up-card", label: "Top up card", done: false },
 ];
 
 // Mobile-only, injected just before the final purchase step.
 const NATIVE_ONLY_STEP: OnboardingStep = {
-  id: "walletPay",
+  id: "apple-google-pay",
   label: "Apple/Google Pay",
   done: false,
 };
 
-const PURCHASE_STEP: OnboardingStep = { id: "purchase", label: "First Purchase", done: false };
+const PURCHASE_STEP: OnboardingStep = {
+  id: "first-purchase",
+  label: "First purchase",
+  done: false,
+};
 
 /**
  * The two Card env vars the tool shows, each with the value of the Baanx development tenant.
@@ -114,6 +123,7 @@ export function usePayCardToolProps(options: UsePayCardToolPropsOptions = {}): P
 
   const hasSeenFeatureTour = useSelector(selectPayCardHasSeenFeatureTour);
   const hasSeenReceiveVerifyHint = useSelector(selectHasSeenReceiveVerifyHint);
+  const hasCompletedCardOnboarding = useSelector(selectHasCompletedCardOnboarding);
 
   const resetFeatureTour = useCallback(() => {
     dispatch(resetPayCardFeatureTourSeen());
@@ -123,14 +133,25 @@ export function usePayCardToolProps(options: UsePayCardToolPropsOptions = {}): P
     dispatch(resetReceiveVerifyHintSeen());
   }, [dispatch]);
 
-  const setStepDone = useCallback((id: string, done: boolean) => {
-    setSteps(current => {
-      if (id === "all") {
-        return current.map(step => (step.done === done ? step : { ...step, done }));
-      }
-      return current.map(step => (step.id === id && step.done !== done ? { ...step, done } : step));
-    });
-  }, []);
+  const resetCardOnboarding = useCallback(() => {
+    dispatch(resetCardOnboardingCompleted());
+  }, [dispatch]);
+
+  const setStepDone = useCallback(
+    (id: string, done: boolean) => {
+      setSteps(current => {
+        if (id === "all") {
+          return current.map(step => (step.done === done ? step : { ...step, done }));
+        }
+        return current.map(step =>
+          step.id === id && step.done !== done ? { ...step, done } : step,
+        );
+      });
+      setMockOnboardingStepDone(id, done);
+      dispatch(cardManagementApi.util.invalidateTags(["CardOnboardingStatus"]));
+    },
+    [dispatch],
+  );
 
   const flags = useMemo(
     () => ({
@@ -190,6 +211,8 @@ export function usePayCardToolProps(options: UsePayCardToolPropsOptions = {}): P
       resetPayCardFeatureTourSeen: resetFeatureTour,
       hasSeenReceiveVerifyHint,
       resetReceiveVerifyHintSeen: resetVerifyHint,
+      hasCompletedCardOnboarding,
+      resetCardOnboarding,
       env,
     }),
     [
@@ -200,6 +223,8 @@ export function usePayCardToolProps(options: UsePayCardToolPropsOptions = {}): P
       resetFeatureTour,
       hasSeenReceiveVerifyHint,
       resetVerifyHint,
+      hasCompletedCardOnboarding,
+      resetCardOnboarding,
       env,
     ],
   );

--- a/devtools/pay-card/src/pay-card/PayCard.native.test.tsx
+++ b/devtools/pay-card/src/pay-card/PayCard.native.test.tsx
@@ -27,6 +27,8 @@ function buildProps(): PayCardToolProps {
     resetPayCardFeatureTourSeen: jest.fn(),
     hasSeenReceiveVerifyHint: false,
     resetReceiveVerifyHintSeen: jest.fn(),
+    hasCompletedCardOnboarding: false,
+    resetCardOnboarding: jest.fn(),
     env: {
       vars: [
         {

--- a/devtools/pay-card/src/pay-card/PayCard.native.tsx
+++ b/devtools/pay-card/src/pay-card/PayCard.native.tsx
@@ -31,6 +31,8 @@ export function PayCard(props: Readonly<PayCardToolProps>) {
     resetPayCardFeatureTourSeen,
     hasSeenReceiveVerifyHint,
     resetReceiveVerifyHintSeen,
+    hasCompletedCardOnboarding,
+    resetCardOnboarding,
     onNavigateToPortfolio,
     onNavigateToPayTab,
     env,
@@ -111,8 +113,11 @@ export function PayCard(props: Readonly<PayCardToolProps>) {
 
       <Section title="Reset onboarding">
         <Box style={BUTTON_ROW_STYLE}>
+          <Button appearance="gray" size="sm" onPress={() => onboarding.setStepDone("all", true)}>
+            Set all done
+          </Button>
           <Button appearance="gray" size="sm" onPress={() => onboarding.setStepDone("all", false)}>
-            Reset onboarding widget
+            Reset all
           </Button>
         </Box>
       </Section>
@@ -133,6 +138,15 @@ export function PayCard(props: Readonly<PayCardToolProps>) {
         seen={hasSeenReceiveVerifyHint}
         resetLabel="Reset verify hint"
         onReset={resetReceiveVerifyHintSeen}
+      />
+
+      <Divider />
+
+      <SeenReset
+        title="Onboarding completed"
+        seen={hasCompletedCardOnboarding}
+        resetLabel="Reset onboarding completion"
+        onReset={resetCardOnboarding}
       />
 
       {onNavigateToPortfolio || onNavigateToPayTab ? (

--- a/devtools/pay-card/src/pay-card/PayCard.web.test.tsx
+++ b/devtools/pay-card/src/pay-card/PayCard.web.test.tsx
@@ -27,6 +27,8 @@ function buildProps(): PayCardToolProps {
     resetPayCardFeatureTourSeen: jest.fn(),
     hasSeenReceiveVerifyHint: false,
     resetReceiveVerifyHintSeen: jest.fn(),
+    hasCompletedCardOnboarding: false,
+    resetCardOnboarding: jest.fn(),
     env: {
       vars: [
         {

--- a/devtools/pay-card/src/pay-card/PayCard.web.tsx
+++ b/devtools/pay-card/src/pay-card/PayCard.web.tsx
@@ -12,6 +12,8 @@ export function PayCard(props: Readonly<PayCardToolProps>) {
     resetPayCardFeatureTourSeen,
     hasSeenReceiveVerifyHint,
     resetReceiveVerifyHintSeen,
+    hasCompletedCardOnboarding,
+    resetCardOnboarding,
     onNavigateToPortfolio,
     onNavigateToPayTab,
     env,
@@ -59,8 +61,11 @@ export function PayCard(props: Readonly<PayCardToolProps>) {
 
       <Section title="Reset onboarding">
         <div className="flex flex-wrap gap-8">
+          <Button appearance="gray" size="sm" onClick={() => onboarding.setStepDone("all", true)}>
+            Set all done
+          </Button>
           <Button appearance="gray" size="sm" onClick={() => onboarding.setStepDone("all", false)}>
-            Reset onboarding widget
+            Reset all
           </Button>
         </div>
       </Section>
@@ -81,6 +86,15 @@ export function PayCard(props: Readonly<PayCardToolProps>) {
         seen={hasSeenReceiveVerifyHint}
         resetLabel="Reset verify hint"
         onReset={resetReceiveVerifyHintSeen}
+      />
+
+      <Divider />
+
+      <SeenReset
+        title="Onboarding completed"
+        seen={hasCompletedCardOnboarding}
+        resetLabel="Reset onboarding completion"
+        onReset={resetCardOnboarding}
       />
 
       {onNavigateToPortfolio || onNavigateToPayTab ? (

--- a/devtools/pay-card/src/types.ts
+++ b/devtools/pay-card/src/types.ts
@@ -89,6 +89,10 @@ export interface PayCardToolProps {
   readonly hasSeenReceiveVerifyHint: boolean;
   /** Resets the Request Verify hint so it shows again on the next Request. */
   readonly resetReceiveVerifyHintSeen: () => void;
+  /** Whether the card onboarding widget has been permanently dismissed (all steps done + Got it). */
+  readonly hasCompletedCardOnboarding: boolean;
+  /** Resets the onboarding completion flag so the widget reappears. */
+  readonly resetCardOnboarding: () => void;
   /** Host-only: jump to Portfolio. Omitted when the host cannot navigate. */
   readonly onNavigateToPortfolio?: () => void;
   /** Host-only: jump to the Pay tab. Omitted when the host cannot navigate. */

--- a/devtools/pay-card/src/usePayCardViewModel.native.test.ts
+++ b/devtools/pay-card/src/usePayCardViewModel.native.test.ts
@@ -2,14 +2,13 @@ import { renderHook } from "@support/jest-devtools/native";
 import { usePayCardViewModel } from "./usePayCardViewModel";
 import type { OnboardingStep, PayCardToolProps } from "./types";
 
-// Mobile step set: same as desktop plus the mobile-only `walletPay`
-// (Apple/Google Pay) step, injected here by the native binding.
+// Mobile step set: same as desktop plus the mobile-only Apple/Google Pay step.
 const DEFAULT_STEPS: OnboardingStep[] = [
-  { id: "kyc", label: "Kyc", done: false },
-  { id: "claim", label: "Claim card", done: false },
-  { id: "topup", label: "Top up", done: false },
-  { id: "walletPay", label: "Apple/Google Pay", done: false },
-  { id: "purchase", label: "First Purchase", done: false },
+  { id: "create-account", label: "Create account", done: false },
+  { id: "choose-card-type", label: "Choose card type", done: false },
+  { id: "top-up-card", label: "Top up card", done: false },
+  { id: "apple-google-pay", label: "Apple/Google Pay", done: false },
+  { id: "first-purchase", label: "First purchase", done: false },
 ];
 
 function buildProps(overrides: Partial<PayCardToolProps> = {}): PayCardToolProps {
@@ -33,6 +32,8 @@ function buildProps(overrides: Partial<PayCardToolProps> = {}): PayCardToolProps
     resetPayCardFeatureTourSeen: overrides.resetPayCardFeatureTourSeen ?? jest.fn(),
     hasSeenReceiveVerifyHint: overrides.hasSeenReceiveVerifyHint ?? false,
     resetReceiveVerifyHintSeen: overrides.resetReceiveVerifyHintSeen ?? jest.fn(),
+    hasCompletedCardOnboarding: overrides.hasCompletedCardOnboarding ?? false,
+    resetCardOnboarding: overrides.resetCardOnboarding ?? jest.fn(),
     env: overrides.env ?? { vars: [], setVar: jest.fn() },
   };
 }
@@ -41,7 +42,7 @@ describe("usePayCardViewModel (native)", () => {
   it("exposes the mobile step set including the wallet-pay step", () => {
     const { result } = renderHook(() => usePayCardViewModel(buildProps()));
     expect(result.current.totalCount).toBe(5);
-    expect(result.current.steps.map(step => step.id)).toContain("walletPay");
+    expect(result.current.steps.map(step => step.id)).toContain("apple-google-pay");
     expect(result.current.allDone).toBe(false);
   });
 
@@ -56,8 +57,8 @@ describe("usePayCardViewModel (native)", () => {
   it("toggleStep flips the mobile-only step", () => {
     const props = buildProps();
     const { result } = renderHook(() => usePayCardViewModel(props));
-    result.current.toggleStep("walletPay");
-    expect(props.onboarding.setStepDone).toHaveBeenCalledWith("walletPay", true);
+    result.current.toggleStep("apple-google-pay");
+    expect(props.onboarding.setStepDone).toHaveBeenCalledWith("apple-google-pay", true);
   });
 
   it("setAllSteps updates every not-done step", () => {

--- a/devtools/pay-card/src/usePayCardViewModel.test.ts
+++ b/devtools/pay-card/src/usePayCardViewModel.test.ts
@@ -2,13 +2,12 @@ import { renderHook } from "@testing-library/react";
 import { formatId, usePayCardViewModel } from "./usePayCardViewModel";
 import type { OnboardingStep, PayCardToolProps } from "./types";
 
-// Desktop step set. The `walletPay` (Apple/Google Pay) step is mobile-only and
-// is injected by the native binding, so it never appears here.
+// Desktop step set. The Apple/Google Pay step is mobile-only.
 const DEFAULT_STEPS: OnboardingStep[] = [
-  { id: "kyc", label: "Kyc", done: false },
-  { id: "claim", label: "Claim card", done: false },
-  { id: "topup", label: "Top up", done: false },
-  { id: "purchase", label: "First Purchase", done: false },
+  { id: "create-account", label: "Create account", done: false },
+  { id: "choose-card-type", label: "Choose card type", done: false },
+  { id: "top-up-card", label: "Top up card", done: false },
+  { id: "first-purchase", label: "First purchase", done: false },
 ];
 
 function buildProps(overrides: Partial<PayCardToolProps> = {}): PayCardToolProps {
@@ -32,6 +31,8 @@ function buildProps(overrides: Partial<PayCardToolProps> = {}): PayCardToolProps
     resetPayCardFeatureTourSeen: overrides.resetPayCardFeatureTourSeen ?? jest.fn(),
     hasSeenReceiveVerifyHint: overrides.hasSeenReceiveVerifyHint ?? false,
     resetReceiveVerifyHintSeen: overrides.resetReceiveVerifyHintSeen ?? jest.fn(),
+    hasCompletedCardOnboarding: overrides.hasCompletedCardOnboarding ?? false,
+    resetCardOnboarding: overrides.resetCardOnboarding ?? jest.fn(),
     env: overrides.env ?? { vars: [], setVar: jest.fn() },
   };
 }
@@ -74,16 +75,18 @@ describe("usePayCardViewModel", () => {
   it("toggleStep flips a not-done step to done", () => {
     const props = buildProps();
     const { result } = renderHook(() => usePayCardViewModel(props));
-    result.current.toggleStep("kyc");
-    expect(props.onboarding.setStepDone).toHaveBeenCalledWith("kyc", true);
+    result.current.toggleStep("create-account");
+    expect(props.onboarding.setStepDone).toHaveBeenCalledWith("create-account", true);
   });
 
   it("toggleStep flips a done step back to not-done", () => {
-    const steps = DEFAULT_STEPS.map(step => (step.id === "kyc" ? { ...step, done: true } : step));
+    const steps = DEFAULT_STEPS.map(step =>
+      step.id === "create-account" ? { ...step, done: true } : step,
+    );
     const props = buildProps({ onboarding: { steps, setStepDone: jest.fn() } });
     const { result } = renderHook(() => usePayCardViewModel(props));
-    result.current.toggleStep("kyc");
-    expect(props.onboarding.setStepDone).toHaveBeenCalledWith("kyc", false);
+    result.current.toggleStep("create-account");
+    expect(props.onboarding.setStepDone).toHaveBeenCalledWith("create-account", false);
   });
 
   it("toggleStep ignores unknown step ids", () => {
@@ -94,13 +97,15 @@ describe("usePayCardViewModel", () => {
   });
 
   it("setAllSteps only updates steps whose state changes", () => {
-    const steps = DEFAULT_STEPS.map(step => (step.id === "kyc" ? { ...step, done: true } : step));
+    const steps = DEFAULT_STEPS.map(step =>
+      step.id === "create-account" ? { ...step, done: true } : step,
+    );
     const props = buildProps({ onboarding: { steps, setStepDone: jest.fn() } });
     const { result } = renderHook(() => usePayCardViewModel(props));
 
     result.current.setAllSteps(true);
     expect(props.onboarding.setStepDone).toHaveBeenCalledTimes(3);
-    expect(props.onboarding.setStepDone).not.toHaveBeenCalledWith("kyc", true);
+    expect(props.onboarding.setStepDone).not.toHaveBeenCalledWith("create-account", true);
   });
 
   it("setAllSteps(false) clears the steps that were done", () => {
@@ -110,6 +115,6 @@ describe("usePayCardViewModel", () => {
 
     result.current.setAllSteps(false);
     expect(props.onboarding.setStepDone).toHaveBeenCalledTimes(4);
-    expect(props.onboarding.setStepDone).toHaveBeenCalledWith("kyc", false);
+    expect(props.onboarding.setStepDone).toHaveBeenCalledWith("create-account", false);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3163,6 +3163,9 @@ importers:
       '@domain/api-card-management':
         specifier: workspace:*
         version: link:../../domain/api/card-management
+      '@features/flow-pay-card-widget':
+        specifier: workspace:*
+        version: link:../../features/flow/pay-card-widget
       '@features/flow-pay-feature-tour':
         specifier: workspace:*
         version: link:../../features/flow/pay-feature-tour


### PR DESCRIPTION
### 📝 Description

Adds Card onboarding controls to the existing Pay Card DevTool so QA/dev can drive widget progress without the real backend.

- Onboarding section: list steps, toggle completion via `@domain/api-card-management/mock`, invalidate `getCardOnboardingStatus`
- Reset dismissed onboarding (`resetCardOnboardingCompleted`)
- Native-only Apple/Google Pay step on the mobile tool
- Test fixtures aligned with production step IDs

Depends on the shared widget view-model PR.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36928](https://ledgerhq.atlassian.net/browse/LIVE-36928)
- **ADR** (if any): n/a


[LIVE-36928]: https://ledgerhq.atlassian.net/browse/LIVE-36928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ