### PR TITLE
[LWM] feat(pay): title MAD account step for a known recipient

### DIFF
--- a/.changeset/loud-pay-account.md
+++ b/.changeset/loud-pay-account.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Title the pay-contact MAD account step “Select account to pay from”.

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -9785,6 +9785,7 @@
     "selectAsset": "Select asset",
     "selectNetwork": "Select network",
     "selectAccount": "Select account",
+    "selectAccountToPayFrom": "Select account to pay from",
     "selectAccountPerpsTitle": "Select Hyperliquid account",
     "selectAccountPerpsDescription": "Select an account you want to deposit funds into to place your trades",
     "selectAccountPerpsEmptyDescription": "To fund your perps, you need a Hyperliquid account. Add one to continue.",

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AccountSelection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AccountSelection/index.tsx
@@ -21,6 +21,7 @@ import {
   getPerpsUiUseCase,
   PERPS_UI_USE_CASE,
 } from "@ledgerhq/live-common/wallet-api/ModularDrawer/uiUseCase";
+import { PAY_ACCOUNT_UI_USE_CASE } from "../../types";
 
 type DescribeHeaderParams = {
   isPerpsReceive: boolean;
@@ -93,7 +94,9 @@ const AccountSelectionContent = ({
 
   const headerTitle = isPerpsReceive
     ? t("modularDrawer.selectAccountPerpsTitle")
-    : t("modularDrawer.selectAccount");
+    : uiUseCase === PAY_ACCOUNT_UI_USE_CASE
+      ? t("modularDrawer.selectAccountToPayFrom")
+      : t("modularDrawer.selectAccount");
 
   const headerDescription = describeHeader(t, {
     isPerpsReceive,

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/types.ts
@@ -21,6 +21,7 @@ export type DisabledItemsExplanation = Readonly<{
 }>;
 
 export const MODULAR_DRAWER_KEY = "modularDrawer";
+export const PAY_ACCOUNT_UI_USE_CASE = "pay";
 
 export type ModularDrawerCompletionMode = "currency";
 export type ModularDrawerPresentation = "drawer" | "embedded";

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
@@ -520,6 +520,7 @@ describe("PayTab integration", () => {
         isOpen: true,
         flow: "send",
         source: "Pay",
+        uiUseCase: "pay",
         preselectedCurrencies: [address.currencyId],
       });
       expect(
@@ -547,6 +548,7 @@ describe("PayTab integration", () => {
       expect(store.getState().modularDrawer).toMatchObject({
         isOpen: true,
         flow: "send",
+        uiUseCase: "pay",
         preselectedCurrencies: [address.currencyId],
       });
     });
@@ -581,6 +583,7 @@ describe("PayTab integration", () => {
       await user.press(await screen.findByTestId("pay-contacts-pay-tile"));
 
       expect(store.getState().modularDrawer.isOpen).toBe(true);
+      expect(store.getState().modularDrawer.uiUseCase).not.toBe("pay");
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useOpenSendFlow.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useOpenSendFlow.test.ts
@@ -129,6 +129,14 @@ describe("useOpenSendFlow", () => {
     );
 
     act(() => result.current.handleOpenSendFlow({ recipient, skipRecipientStep: true }));
+
+    expect(mockOpenDrawer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flow: "send",
+        uiUseCase: "pay",
+      }),
+    );
+
     const onAccountSelected = mockOpenDrawer.mock.calls[0][0].onAccountSelected;
     act(() => onAccountSelected(account));
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useOpenSendFlow.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useOpenSendFlow.ts
@@ -14,6 +14,7 @@ import { NavigatorName, ScreenName } from "~/const";
 import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import type { SendFundsNavigatorStackParamList } from "~/components/RootNavigator/types/SendFundsNavigator";
 import { useModularDrawerController } from "LLM/features/ModularDrawer";
+import { PAY_ACCOUNT_UI_USE_CASE } from "LLM/features/ModularDrawer/types";
 import { getCustomSendFlow } from "~/screens/SendFunds/utils/customSendFlow";
 import { useNewSendFlowFeature } from "./useNewSendFlowFeature";
 
@@ -187,6 +188,9 @@ export function useOpenSendFlow({
         currencies = [currency.id];
       }
 
+      const payFromKnownRecipient =
+        Boolean(resolvedRecipient?.trim()) && resolvedSkipRecipientStep === true;
+
       openDrawer({
         currencies,
         categories: resolvedCategories,
@@ -194,6 +198,7 @@ export function useOpenSendFlow({
         source: sourceScreenName,
         areCurrenciesFiltered: hasCurrencyIds || Boolean(currency),
         enableAccountSelection: true,
+        ...(payFromKnownRecipient ? { uiUseCase: PAY_ACCOUNT_UI_USE_CASE } : {}),
         onAccountSelected: (account, parentAccount) =>
           navigateAfterAccountSelection(
             account,


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

After Pay → address sheet, MAD opened with the generic “Select account” title.

**Problem:** The pay-contact account drawer used the same copy as every other send MAD.

**Solution:**
- When MAD opens for a known recipient (`skipRecipientStep` + recipient), set `uiUseCase: pay`
- Account step title is “Select account to pay from”
- Asset and Network steps stay “Select asset” / “Select network”
- New / send MAD stays “Select account”

Account rows already match the Figma list. Close lives on the sheet chrome.

<img width="353" height="560" alt="image" src="https://github.com/user-attachments/assets/4dd5a220-3814-42af-bf1b-1860d635a7de" />


send flow normal:
<img width="381" height="702" alt="image" src="https://github.com/user-attachments/assets/a7297599-02e7-4f33-98f2-23175b2163fe" />



### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36372](https://ledgerhq.atlassian.net/browse/LIVE-36372)
- **ADR** (if any): none
- **Depends on**: [#21526](https://github.com/LedgerHQ/ledger-live/pull/21526)
- **Figma**: [account drawer](https://www.figma.com/design/WYQQwem0QyG2fTuaAKAe3Y/Pay-%E2%80%A2-Production?node-id=6784-65560&m=dev)

### QA

Flag `lwmContacts` on.

1. Pay → contact → address → MAD title is “Select account to pay from”
2. New with no one to pay → MAD still says “Select account”

[LIVE-36372]: https://ledgerhq.atlassian.net/browse/LIVE-36372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ