### PR TITLE
test(e2e-desktop): cosmo displays uosmo

### DIFF
--- a/e2e/desktop/docs/add-or-update-e2e.md
+++ b/e2e/desktop/docs/add-or-update-e2e.md
@@ -15,8 +15,8 @@ This agent guides you through adding or updating E2E tests for ledger-live-deskt
 
 - `e2e/desktop/tests/specs/` — test scenarios (`.spec.ts`)
 - `e2e/desktop/tests/page/` — Page Objects with reusable actions
-- `e2e/desktop/tests/utils/` — CLI utilities, Speculos helpers
-- `libs/ledger-live-common/src/e2e/` — shared e2e enums and families
+- `e2e/desktop/tests/utils/` — desktop test helpers (tags, feature flags, Allure)
+- `libs/live-e2e-shared/src/` — shared e2e enums, families, and Speculos helpers
 
 ---
 
@@ -41,7 +41,7 @@ When the user wants to add e2e tests for a new coin, follow these steps and **as
 
 ### Step 1: Add Network enum
 
-[File](/libs/ledger-live-common/src/e2e/enum/Network.ts)
+[File](/libs/live-e2e-shared/src/enum/Network.ts)
 
 ```typescript
 NEWCOIN = "NewCoin",
@@ -49,7 +49,7 @@ NEWCOIN = "NewCoin",
 
 ### Step 2: Add AppInfos
 
-[File](/libs/ledger-live-common/src/e2e/enum/AppInfos.ts)
+[File](/libs/live-e2e-shared/src/enum/AppInfos.ts)
 
 ```typescript
 static readonly NEWCOIN = new AppInfos("NewCoin");
@@ -57,7 +57,7 @@ static readonly NEWCOIN = new AppInfos("NewCoin");
 
 ### Step 3: Add Currency
 
-[File](/libs/ledger-live-common/src/e2e/enum/Currency.ts)
+[File](/libs/live-e2e-shared/src/enum/Currency.ts)
 
 **Ask user for:** name, ticker, currency_id
 
@@ -67,7 +67,7 @@ static readonly NEWCOIN = new Currency("NewCoin", "TICKER", "currency_id", AppIn
 
 ### Step 4: Add Accounts
 
-[File](/libs/ledger-live-common/src/e2e/enum/Account.ts)
+[File](/libs/live-e2e-shared/src/enum/Account.ts)
 
 **Ask user for:** account derivation path (BIP44)
 
@@ -78,7 +78,7 @@ static readonly NEWCOIN_2 = new Account(Currency.NEWCOIN, "NewCoin 2", 1, "44'/x
 
 ### Step 5: Add family file (if new family)
 
-[File](/libs/ledger-live-common/src/e2e/families/newcoin.ts)
+[File](/libs/live-e2e-shared/src/families/newcoin.ts)
 
 **Ask user:** "Does this coin belong to an existing family (evm, bitcoin, cosmos...)?"
 
@@ -87,13 +87,13 @@ static readonly NEWCOIN_2 = new Account(Currency.NEWCOIN, "NewCoin 2", 1, "44'/x
 
 ```typescript
 import { Transaction } from "../models/Transaction";
-import { getSendEvents, containsSubstringInEvent } from "../speculos";
+import { getSendEvents, expectSpeculosEventsContain } from "../speculos";
 // implement sendNewCoin function
 ```
 
 ### Step 6: Add to speculos.ts
 
-[File](libs/ledger-live-common/src/e2e/speculos.ts)
+[File](/libs/live-e2e-shared/src/speculos.ts)
 
 **6a. Add to `specs` object:**
 

--- a/libs/live-e2e-shared/src/families/algorand.ts
+++ b/libs/live-e2e-shared/src/families/algorand.ts
@@ -1,6 +1,5 @@
-import expect from "expect";
 import { Transaction } from "../models/Transaction";
-import { containsSubstringInEvent, getSendEvents } from "../speculos";
+import { expectSpeculosEventsContain, getSendEvents } from "../speculos";
 import { isTouchDevice } from "../speculosAppVersion";
 import { DeviceLabels } from "../enum/DeviceLabels";
 import { longPressAndRelease } from "../deviceInteraction/TouchDeviceSimulator";
@@ -12,14 +11,12 @@ export const sendAlgorand = withDeviceController(
       const buttons = getButtonsController();
 
       const events = await getSendEvents(tx);
-      const isAmountCorrect = containsSubstringInEvent(tx.amount, events);
-      expect(isAmountCorrect).toBeTruthy();
+      expectSpeculosEventsContain(tx.amount, events);
 
       if (!tx.accountToCredit.address) {
         throw new Error("Recipient address is not set");
       }
-      const isAddressCorrect = containsSubstringInEvent(tx.accountToCredit.address, events);
-      expect(isAddressCorrect).toBeTruthy();
+      expectSpeculosEventsContain(tx.accountToCredit.address, events);
 
       if (isTouchDevice()) {
         await longPressAndRelease(DeviceLabels.HOLD_TO_SIGN, 3);

--- a/libs/live-e2e-shared/src/families/aptos.ts
+++ b/libs/live-e2e-shared/src/families/aptos.ts
@@ -1,6 +1,10 @@
-import expect from "expect";
 import { Transaction } from "../models/Transaction";
-import { waitFor, pressUntilTextFound, containsSubstringInEvent, getSendEvents } from "../speculos";
+import {
+  waitFor,
+  pressUntilTextFound,
+  expectSpeculosEventsContain,
+  getSendEvents,
+} from "../speculos";
 import { isTouchDevice } from "../speculosAppVersion";
 import { DeviceLabels } from "../enum/DeviceLabels";
 import { Delegate } from "../models/Delegate";
@@ -29,8 +33,7 @@ export const delegateAptos = withDeviceController(
 
       await waitFor(DeviceLabels.REVIEW_OPERATION);
       const events = await pressUntilTextFound(DeviceLabels.APPROVE);
-      const isAmountCorrect = containsSubstringInEvent(delegatingAccount.amount, events);
-      expect(isAmountCorrect).toBeTruthy();
+      expectSpeculosEventsContain(delegatingAccount.amount, events);
 
       await buttons.both();
     },

--- a/libs/live-e2e-shared/src/families/bitcoin.ts
+++ b/libs/live-e2e-shared/src/families/bitcoin.ts
@@ -1,8 +1,7 @@
-import expect from "expect";
 import { Transaction } from "../models/Transaction";
 import {
   waitFor,
-  containsSubstringInEvent,
+  expectSpeculosEventsContain,
   pressUntilTextFound,
   getSendEvents,
   waitForSendReviewTransaction,
@@ -37,19 +36,15 @@ export const sendBTCBasedCoin = withDeviceController(
 
       if (isTouchDevice()) {
         const events = await pressUntilTextFound(DeviceLabels.HOLD_TO_SIGN);
-        const isAmountCorrect = containsSubstringInEvent(tx.amount, events);
-        expect(isAmountCorrect).toBeTruthy();
-        const isAddressCorrect = containsSubstringInEvent(tx.accountToCredit.address, events);
-        expect(isAddressCorrect).toBeTruthy();
+        expectSpeculosEventsContain(tx.amount, events);
+        expectSpeculosEventsContain(tx.accountToCredit.address, events);
         await longPressAndRelease(DeviceLabels.HOLD_TO_SIGN, 3);
       } else {
         const amountStep = await pressUntilTextFound(DeviceLabels.AMOUNT);
-        const isAmountCorrect = containsSubstringInEvent(tx.amount, amountStep);
-        expect(isAmountCorrect).toBeTruthy();
+        expectSpeculosEventsContain(tx.amount, amountStep);
 
         const addressStep = await pressUntilTextFound(DeviceLabels.ADDRESS);
-        const isAddressCorrect = containsSubstringInEvent(tx.accountToCredit.address, addressStep);
-        expect(isAddressCorrect).toBeTruthy();
+        expectSpeculosEventsContain(tx.accountToCredit.address, addressStep);
 
         await pressUntilTextFound(getSignTransactionLabel(currencyId));
         if (currencyId !== Currency.ZEC.id) {
@@ -70,14 +65,12 @@ export const sendBTC = withDeviceController(
 
       try {
         const events = await getSendEvents(tx);
-        const isAmountCorrect = containsSubstringInEvent(tx.amount, events);
-        expect(isAmountCorrect).toBeTruthy();
+        expectSpeculosEventsContain(tx.amount, events);
 
         if (!tx.accountToCredit.address) {
           throw new Error("Recipient address is not set");
         }
-        const isAddressCorrect = containsSubstringInEvent(tx.accountToCredit.address, events);
-        expect(isAddressCorrect).toBeTruthy();
+        expectSpeculosEventsContain(tx.accountToCredit.address, events);
 
         if (isTouchDevice()) {
           await longPressAndRelease(DeviceLabels.HOLD_TO_SIGN, 3);

--- a/libs/live-e2e-shared/src/families/cardano.ts
+++ b/libs/live-e2e-shared/src/families/cardano.ts
@@ -1,6 +1,5 @@
-import expect from "expect";
 import { Transaction } from "../models/Transaction";
-import { pressUntilTextFound, containsSubstringInEvent, waitFor } from "../speculos";
+import { pressUntilTextFound, expectSpeculosEventsContain, waitFor } from "../speculos";
 import { getSpeculosModel, isTouchDevice } from "../speculosAppVersion";
 import {
   pressAndRelease,
@@ -17,10 +16,8 @@ function validateTransactionData(tx: Transaction, events: string[]) {
   if (!tx.accountToCredit.address) {
     throw new Error("Recipient address is not set");
   }
-  const isAddressCorrect = containsSubstringInEvent(tx.accountToCredit.address, events);
-  expect(isAddressCorrect).toBeTruthy();
-  const isAmountCorrect = containsSubstringInEvent(tx.amount, events);
-  expect(isAmountCorrect).toBeTruthy();
+  expectSpeculosEventsContain(tx.accountToCredit.address, events);
+  expectSpeculosEventsContain(tx.amount, events);
 }
 
 async function sendCardanoTouchDevices(tx: Transaction) {

--- a/libs/live-e2e-shared/src/families/celo.ts
+++ b/libs/live-e2e-shared/src/families/celo.ts
@@ -1,7 +1,6 @@
-import { containsSubstringInEvent, getDelegateEvents, pressUntilTextFound } from "../speculos";
+import { expectSpeculosEventsContain, getDelegateEvents, pressUntilTextFound } from "../speculos";
 import { isTouchDevice } from "../speculosAppVersion";
 import { Delegate } from "../models/Delegate";
-import expect from "expect";
 import { longPressAndRelease } from "../deviceInteraction/TouchDeviceSimulator";
 import { DeviceLabels } from "../enum/DeviceLabels";
 import { withDeviceController } from "../deviceInteraction/DeviceController";
@@ -12,8 +11,7 @@ export const delegateCelo = withDeviceController(
       const buttons = getButtonsController();
 
       const events = await getDelegateEvents(delegatingAccount);
-      const isAmountCorrect = containsSubstringInEvent(delegatingAccount.amount, events);
-      expect(isAmountCorrect).toBeTruthy();
+      expectSpeculosEventsContain(delegatingAccount.amount, events);
 
       if (isTouchDevice()) {
         await pressUntilTextFound(DeviceLabels.HOLD_TO_SIGN);

--- a/libs/live-e2e-shared/src/families/cosmos.ts
+++ b/libs/live-e2e-shared/src/families/cosmos.ts
@@ -1,8 +1,7 @@
-import expect from "expect";
 import { Delegate } from "../models/Delegate";
 import { Transaction } from "../models/Transaction";
 import {
-  containsSubstringInEvent,
+  expectSpeculosEventsContain,
   expectMemoTagInEvents,
   getDelegateEvents,
   getSendEvents,
@@ -18,8 +17,7 @@ export const delegateCosmos = withDeviceController(
       const buttons = getButtonsController();
 
       const events = await getDelegateEvents(delegatingAccount);
-      const isAmountCorrect = containsSubstringInEvent(delegatingAccount.amount, events);
-      expect(isAmountCorrect).toBeTruthy();
+      expectSpeculosEventsContain(delegatingAccount.amount, events);
 
       if (isTouchDevice()) {
         await longPressAndRelease(DeviceLabels.HOLD_TO_SIGN, 3);
@@ -35,14 +33,12 @@ export const sendCosmos = withDeviceController(
       const buttons = getButtonsController();
 
       const events = await getSendEvents(tx);
-      const isAmountCorrect = containsSubstringInEvent(tx.amount, events);
-      expect(isAmountCorrect).toBeTruthy();
+      expectSpeculosEventsContain(tx.amount, events);
 
       if (!tx.accountToCredit.address) {
         throw new Error("Recipient address is not set");
       }
-      const isAddressCorrect = containsSubstringInEvent(tx.accountToCredit.address, events);
-      expect(isAddressCorrect).toBeTruthy();
+      expectSpeculosEventsContain(tx.accountToCredit.address, events);
       expectMemoTagInEvents(tx, events);
 
       if (isTouchDevice()) {

--- a/libs/live-e2e-shared/src/families/evm.ts
+++ b/libs/live-e2e-shared/src/families/evm.ts
@@ -1,6 +1,6 @@
 import { Transaction } from "../models/Transaction";
 import {
-  containsSubstringInEvent,
+  expectSpeculosEventsContain,
   fetchCurrentScreenTexts,
   waitForReviewTransaction,
   pressUntilTextFound,
@@ -21,14 +21,6 @@ import { withDeviceController } from "../deviceInteraction/DeviceController";
 import { getEnv } from "@shared/env";
 import { getDeviceCoordinates } from "../deviceCoordinates";
 
-function formatEventsForError(events: string[], maxLength = 1000): string {
-  const formatted = events.map((e, i) => `  [${i}] ${e}`).join("\n");
-  if (formatted.length <= maxLength) {
-    return formatted;
-  }
-  return `${formatted.slice(0, maxLength)}...\n  (truncated, ${events.length} total events)`;
-}
-
 // TODO: remove once LIVE-28070 is fixed
 function shouldSkipRecipientDisplayValidation(tx: Transaction): boolean {
   return (
@@ -38,35 +30,31 @@ function shouldSkipRecipientDisplayValidation(tx: Transaction): boolean {
 }
 
 function validateTransactionData(tx: Transaction, events: string[]) {
-  const formattedEvents = formatEventsForError(events);
-  const isAmountCorrect = containsSubstringInEvent(tx.amount, events);
-  if (!isAmountCorrect) {
-    throw new Error(
-      `Expected amount "${tx.amount}" to be displayed on Speculos device, but it was not found.\nEvents:\n${formattedEvents}`,
-    );
-  }
+  expectSpeculosEventsContain(
+    tx.amount,
+    events,
+    "Expected amount to be displayed on Speculos device",
+  );
 
   if (shouldSkipRecipientDisplayValidation(tx)) {
     return;
   }
 
   if (tx.accountToCredit.ensName && process.env.SPECULOS_DEVICE !== Device.LNS.name) {
-    const isENSNameCorrect = containsSubstringInEvent(tx.accountToCredit.ensName, events);
-    if (!isENSNameCorrect) {
-      throw new Error(
-        `Expected ENS name "${tx.accountToCredit.ensName}" to be displayed on Speculos device, but it was not found.\nEvents:\n${formattedEvents}`,
-      );
-    }
+    expectSpeculosEventsContain(
+      tx.accountToCredit.ensName,
+      events,
+      "Expected ENS name to be displayed on Speculos device",
+    );
   } else {
     if (!tx.accountToCredit.address) {
       throw new Error("Recipient address is not set");
     }
-    const isAddressCorrect = containsSubstringInEvent(tx.accountToCredit.address, events);
-    if (!isAddressCorrect) {
-      throw new Error(
-        `Expected recipient address "${tx.accountToCredit.address}" to be displayed on Speculos device, but it was not found.\nEvents:\n${formattedEvents}`,
-      );
-    }
+    expectSpeculosEventsContain(
+      tx.accountToCredit.address,
+      events,
+      "Expected recipient address to be displayed on Speculos device",
+    );
   }
 }
 

--- a/libs/live-e2e-shared/src/families/internet_computer.ts
+++ b/libs/live-e2e-shared/src/families/internet_computer.ts
@@ -1,6 +1,5 @@
-import expect from "expect";
 import { Transaction } from "../models/Transaction";
-import { containsSubstringInEvent, getSendEvents } from "../speculos";
+import { expectSpeculosEventsContain, getSendEvents } from "../speculos";
 import { isTouchDevice } from "../speculosAppVersion";
 import { DeviceLabels } from "../enum/DeviceLabels";
 import { longPressAndRelease } from "../deviceInteraction/TouchDeviceSimulator";
@@ -12,14 +11,12 @@ export const sendInternetComputer = withDeviceController(
       const buttons = getButtonsController();
 
       const events = await getSendEvents(tx);
-      const isAmountCorrect = containsSubstringInEvent(tx.amount, events);
-      expect(isAmountCorrect).toBeTruthy();
+      expectSpeculosEventsContain(tx.amount, events);
 
       if (!tx.accountToCredit.address) {
         throw new Error("Recipient address is not set");
       }
-      const isAddressCorrect = containsSubstringInEvent(tx.accountToCredit.address, events);
-      expect(isAddressCorrect).toBeTruthy();
+      expectSpeculosEventsContain(tx.accountToCredit.address, events);
 
       if (isTouchDevice()) {
         await longPressAndRelease(DeviceLabels.HOLD_TO_SIGN, 3);

--- a/libs/live-e2e-shared/src/families/mina.ts
+++ b/libs/live-e2e-shared/src/families/mina.ts
@@ -1,6 +1,5 @@
-import expect from "expect";
 import { Delegate } from "../models/Delegate";
-import { containsSubstringInEvent, getDelegateEvents } from "../speculos";
+import { expectSpeculosEventsContain, getDelegateEvents } from "../speculos";
 import { DeviceLabels } from "../enum/DeviceLabels";
 import { isTouchDevice } from "../speculosAppVersion";
 import { longPressAndRelease } from "../deviceInteraction/TouchDeviceSimulator";
@@ -12,8 +11,7 @@ export const delegateMina = withDeviceController(
       const buttons = getButtonsController();
 
       const events = await getDelegateEvents(delegatingAccount);
-      const isProviderCorrect = containsSubstringInEvent(delegatingAccount.provider, events);
-      expect(isProviderCorrect).toBeTruthy();
+      expectSpeculosEventsContain(delegatingAccount.provider, events);
 
       if (isTouchDevice()) {
         await longPressAndRelease(DeviceLabels.HOLD_TO_SIGN, 3);

--- a/libs/live-e2e-shared/src/families/near.ts
+++ b/libs/live-e2e-shared/src/families/near.ts
@@ -1,8 +1,7 @@
-import expect from "expect";
 import { Delegate } from "../models/Delegate";
 import {
   waitFor,
-  containsSubstringInEvent,
+  expectSpeculosEventsContain,
   getDelegateEvents,
   pressUntilTextFound,
 } from "../speculos";
@@ -17,8 +16,7 @@ export const delegateNear = withDeviceController(
       const buttons = getButtonsController();
 
       const events = await getDelegateEvents(delegatingAccount);
-      const isProviderCorrect = containsSubstringInEvent(delegatingAccount.provider, events);
-      expect(isProviderCorrect).toBeTruthy();
+      expectSpeculosEventsContain(delegatingAccount.provider, events);
 
       if (isTouchDevice()) {
         await pressAndRelease(DeviceLabels.CONFIRM_HEADER);

--- a/libs/live-e2e-shared/src/families/osmosis.ts
+++ b/libs/live-e2e-shared/src/families/osmosis.ts
@@ -1,10 +1,26 @@
 import { Delegate } from "../models/Delegate";
-import { pressUntilTextFound, containsSubstringInEvent, getDelegateEvents } from "../speculos";
+import { Transaction } from "../models/Transaction";
+import {
+  pressUntilTextFound,
+  expectSpeculosEventsContain,
+  expectMemoTagInEvents,
+  getDelegateEvents,
+  getSendEvents,
+} from "../speculos";
 import { isTouchDevice } from "../speculosAppVersion";
-import expect from "expect";
 import { DeviceLabels } from "../enum/DeviceLabels";
 import { longPressAndRelease } from "../deviceInteraction/TouchDeviceSimulator";
 import { withDeviceController } from "../deviceInteraction/DeviceController";
+
+const UOSMO_MAGNITUDE = 6;
+
+/** The Cosmos app has no display unit for osmo, so it shows raw uosmo (e.g. "10" for 0.00001 OSMO). */
+function toUosmo(amount: string): string {
+  const [whole, fraction = ""] = amount.split(".");
+  const padded = fraction.padEnd(UOSMO_MAGNITUDE, "0").slice(0, UOSMO_MAGNITUDE);
+  const digits = `${whole}${padded}`.replace(/^0+/, "");
+  return digits === "" ? "0" : digits;
+}
 
 export const delegateOsmosis = withDeviceController(
   ({ getButtonsController }) =>
@@ -12,12 +28,32 @@ export const delegateOsmosis = withDeviceController(
       const buttons = getButtonsController();
 
       const events = await getDelegateEvents(delegatingAccount);
-      const amountInUosmo = (Number(delegatingAccount.amount) * 1_000_000).toString();
-      const isAmountCorrect = containsSubstringInEvent(amountInUosmo, events);
-      expect(isAmountCorrect).toBeTruthy();
+      expectSpeculosEventsContain(toUosmo(delegatingAccount.amount), events);
 
       if (isTouchDevice()) {
         await pressUntilTextFound(DeviceLabels.HOLD_TO_SIGN);
+        await longPressAndRelease(DeviceLabels.HOLD_TO_SIGN, 3);
+      } else {
+        await buttons.both();
+      }
+    },
+);
+
+export const sendOsmosis = withDeviceController(
+  ({ getButtonsController }) =>
+    async (tx: Transaction) => {
+      const buttons = getButtonsController();
+
+      const events = await getSendEvents(tx);
+      expectSpeculosEventsContain(toUosmo(tx.amount), events);
+
+      if (!tx.accountToCredit.address) {
+        throw new Error("Recipient address is not set");
+      }
+      expectSpeculosEventsContain(tx.accountToCredit.address, events);
+      expectMemoTagInEvents(tx, events);
+
+      if (isTouchDevice()) {
         await longPressAndRelease(DeviceLabels.HOLD_TO_SIGN, 3);
       } else {
         await buttons.both();

--- a/libs/live-e2e-shared/src/families/polkadot.ts
+++ b/libs/live-e2e-shared/src/families/polkadot.ts
@@ -1,6 +1,5 @@
-import expect from "expect";
 import { Transaction } from "../models/Transaction";
-import { containsSubstringInEvent, getSendEvents } from "../speculos";
+import { expectSpeculosEventsContain, getSendEvents } from "../speculos";
 import { isTouchDevice } from "../speculosAppVersion";
 import { DeviceLabels } from "../enum/DeviceLabels";
 import { longPressAndRelease } from "../deviceInteraction/TouchDeviceSimulator";
@@ -12,14 +11,12 @@ export const sendPolkadot = withDeviceController(
       const buttons = getButtonsController();
 
       const events = await getSendEvents(tx);
-      const isAmountCorrect = containsSubstringInEvent(tx.amount, events);
-      expect(isAmountCorrect).toBeTruthy();
+      expectSpeculosEventsContain(tx.amount, events);
 
       if (!tx.accountToCredit.address) {
         throw new Error("Recipient address is not set");
       }
-      const isAddressCorrect = containsSubstringInEvent(tx.accountToCredit.address, events);
-      expect(isAddressCorrect).toBeTruthy();
+      expectSpeculosEventsContain(tx.accountToCredit.address, events);
 
       if (isTouchDevice()) {
         await longPressAndRelease(DeviceLabels.HOLD_TO_SIGN, 3);

--- a/libs/live-e2e-shared/src/families/solana.ts
+++ b/libs/live-e2e-shared/src/families/solana.ts
@@ -1,5 +1,4 @@
-import expect from "expect";
-import { containsSubstringInEvent, getDelegateEvents, getSendEvents } from "../speculos";
+import { getDelegateEvents, getSendEvents, expectSpeculosEventsContain } from "../speculos";
 import { isTouchDevice } from "../speculosAppVersion";
 import { longPressAndRelease } from "../deviceInteraction/TouchDeviceSimulator";
 import { DeviceLabels } from "../enum/DeviceLabels";
@@ -29,16 +28,14 @@ export const sendSolana = withDeviceController(
       const buttons = getButtonsController();
 
       const events = await getSendEvents(tx);
-      const isAmountCorrect = containsSubstringInEvent(tx.amount, events);
-      expect(isAmountCorrect).toBeTruthy();
+      expectSpeculosEventsContain(tx.amount, events);
 
       const isSplToken = !!tx.accountToCredit.currency.contractAddress;
       if (!isSplToken && process.env.SPECULOS_DEVICE !== Device.LNS.name) {
         if (!tx.accountToCredit.address) {
           throw new Error("Recipient address is not set");
         }
-        const isAddressCorrect = containsSubstringInEvent(tx.accountToCredit.address, events);
-        expect(isAddressCorrect).toBeTruthy();
+        expectSpeculosEventsContain(tx.accountToCredit.address, events);
       }
 
       if (isTouchDevice()) {

--- a/libs/live-e2e-shared/src/families/stellar.ts
+++ b/libs/live-e2e-shared/src/families/stellar.ts
@@ -1,6 +1,5 @@
-import expect from "expect";
 import { Transaction } from "../models/Transaction";
-import { containsSubstringInEvent, expectMemoTagInEvents, getSendEvents } from "../speculos";
+import { expectSpeculosEventsContain, expectMemoTagInEvents, getSendEvents } from "../speculos";
 import { isTouchDevice } from "../speculosAppVersion";
 import { DeviceLabels } from "../enum/DeviceLabels";
 import { longPressAndRelease } from "../deviceInteraction/TouchDeviceSimulator";
@@ -12,14 +11,12 @@ export const sendStellar = withDeviceController(
       const buttons = getButtonsController();
 
       const events = await getSendEvents(tx);
-      const isAmountCorrect = containsSubstringInEvent(tx.amount, events);
-      expect(isAmountCorrect).toBeTruthy();
+      expectSpeculosEventsContain(tx.amount, events);
 
       if (!tx.accountToCredit.address) {
         throw new Error("Recipient address is not set");
       }
-      const isAddressCorrect = containsSubstringInEvent(tx.accountToCredit.address, events);
-      expect(isAddressCorrect).toBeTruthy();
+      expectSpeculosEventsContain(tx.accountToCredit.address, events);
       expectMemoTagInEvents(tx, events);
 
       if (isTouchDevice()) {

--- a/libs/live-e2e-shared/src/families/tezos.ts
+++ b/libs/live-e2e-shared/src/families/tezos.ts
@@ -1,6 +1,5 @@
-import expect from "expect";
 import {
-  containsSubstringInEvent,
+  expectSpeculosEventsContain,
   getDelegateEvents,
   getDeviceLabels,
   pressUntilTextFound,
@@ -25,8 +24,7 @@ export const delegateTezos = withDeviceController(
       // Stake/unstake reviews show the amount on-device; a pure delegation (amount "N/A") shows the
       // baker address + fee but no amount, so only assert when an amount is expected.
       if (delegatingAccount.amount !== "N/A") {
-        const isAmountCorrect = containsSubstringInEvent(delegatingAccount.amount, events);
-        expect(isAmountCorrect).toBeTruthy();
+        expectSpeculosEventsContain(delegatingAccount.amount, events);
       }
       await pressUntilTextFound(delegateConfirmLabel);
 

--- a/libs/live-e2e-shared/src/families/tron.ts
+++ b/libs/live-e2e-shared/src/families/tron.ts
@@ -1,6 +1,5 @@
-import expect from "expect";
 import { Transaction } from "../models/Transaction";
-import { containsSubstringInEvent, getSendEvents } from "../speculos";
+import { expectSpeculosEventsContain, getSendEvents } from "../speculos";
 import { isTouchDevice } from "../speculosAppVersion";
 import { DeviceLabels } from "../enum/DeviceLabels";
 import { longPressAndRelease } from "../deviceInteraction/TouchDeviceSimulator";
@@ -12,14 +11,12 @@ export const sendTron = withDeviceController(
       const buttons = getButtonsController();
 
       const events = await getSendEvents(tx);
-      const isAmountCorrect = containsSubstringInEvent(tx.amount, events);
-      expect(isAmountCorrect).toBeTruthy();
+      expectSpeculosEventsContain(tx.amount, events);
 
       if (!tx.accountToCredit.address) {
         throw new Error("Recipient address is not set");
       }
-      const isAddressCorrect = containsSubstringInEvent(tx.accountToCredit.address, events);
-      expect(isAddressCorrect).toBeTruthy();
+      expectSpeculosEventsContain(tx.accountToCredit.address, events);
 
       if (isTouchDevice()) {
         await longPressAndRelease(DeviceLabels.HOLD_TO_SIGN, 3);

--- a/libs/live-e2e-shared/src/families/vechain.ts
+++ b/libs/live-e2e-shared/src/families/vechain.ts
@@ -1,6 +1,5 @@
-import expect from "expect";
 import { Transaction } from "../models/Transaction";
-import { containsSubstringInEvent, getSendEvents } from "../speculos";
+import { expectSpeculosEventsContain, getSendEvents } from "../speculos";
 import { isTouchDevice } from "../speculosAppVersion";
 import { DeviceLabels } from "../enum/DeviceLabels";
 import { longPressAndRelease } from "../deviceInteraction/TouchDeviceSimulator";
@@ -12,14 +11,12 @@ export const sendVechain = withDeviceController(
       const buttons = getButtonsController();
 
       const events = await getSendEvents(tx);
-      const isAmountCorrect = containsSubstringInEvent(tx.amount, events);
-      expect(isAmountCorrect).toBeTruthy();
+      expectSpeculosEventsContain(tx.amount, events);
 
       if (!tx.accountToCredit.address) {
         throw new Error("Recipient address is not set");
       }
-      const isAddressCorrect = containsSubstringInEvent(tx.accountToCredit.address, events);
-      expect(isAddressCorrect).toBeTruthy();
+      expectSpeculosEventsContain(tx.accountToCredit.address, events);
 
       if (isTouchDevice()) {
         await longPressAndRelease(DeviceLabels.HOLD_TO_SIGN, 3);

--- a/libs/live-e2e-shared/src/families/xrp.ts
+++ b/libs/live-e2e-shared/src/families/xrp.ts
@@ -1,6 +1,5 @@
-import expect from "expect";
 import { Transaction } from "../models/Transaction";
-import { containsSubstringInEvent, expectMemoTagInEvents, getSendEvents } from "../speculos";
+import { expectSpeculosEventsContain, expectMemoTagInEvents, getSendEvents } from "../speculos";
 import { isTouchDevice } from "../speculosAppVersion";
 import { DeviceLabels } from "../enum/DeviceLabels";
 import { longPressAndRelease } from "../deviceInteraction/TouchDeviceSimulator";
@@ -12,13 +11,11 @@ export const sendXRP = withDeviceController(
       const buttons = getButtonsController();
 
       const events = await getSendEvents(tx);
-      const isAmountCorrect = containsSubstringInEvent(tx.amount, events);
-      expect(isAmountCorrect).toBeTruthy();
+      expectSpeculosEventsContain(tx.amount, events);
       if (!tx.accountToCredit.address) {
         throw new Error("Recipient address is not set");
       }
-      const isAddressCorrect = containsSubstringInEvent(tx.accountToCredit.address, events);
-      expect(isAddressCorrect).toBeTruthy();
+      expectSpeculosEventsContain(tx.accountToCredit.address, events);
       expectMemoTagInEvents(tx, events);
 
       if (isTouchDevice()) {

--- a/libs/live-e2e-shared/src/speculos.ts
+++ b/libs/live-e2e-shared/src/speculos.ts
@@ -17,7 +17,6 @@ import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { DeviceLabels } from "./enum/DeviceLabels";
 import { Account } from "./enum/Account";
 import { Currency } from "./enum/Currency";
-import expect from "expect";
 import { sendBTC, sendBTCBasedCoin } from "./families/bitcoin";
 import { sendEVM, approveToken, signTypedMessage } from "./families/evm";
 import { sendPolkadot } from "./families/polkadot";
@@ -38,7 +37,7 @@ import { delegateMultiversX } from "./families/multiversX";
 import { Transaction } from "./models/Transaction";
 import { Delegate } from "./models/Delegate";
 import { Swap } from "./models/Swap";
-import { delegateOsmosis } from "./families/osmosis";
+import { delegateOsmosis, sendOsmosis } from "./families/osmosis";
 import { AppInfos } from "./enum/AppInfos";
 import { DEVICE_LABELS_CONFIG } from "./data/deviceLabelsData";
 import { sendSui, delegateSui } from "./families/sui";
@@ -744,12 +743,29 @@ export function containsSubstringInEvent(targetString: string, events: string[])
   return result;
 }
 
+export function expectSpeculosEventsContain(
+  substring: string,
+  events: string[],
+  message = "Speculos events validation failed",
+) {
+  if (containsSubstringInEvent(substring, events) !== true) {
+    let formattedEvents = events.join("\n  ");
+    const maxLength = 1000;
+    if (formattedEvents.length > maxLength) {
+      formattedEvents = `${formattedEvents.slice(0, maxLength)}...\n  (truncated, ${events.length} total events)`;
+    }
+    throw new Error(
+      `${message}. Expected events to contain "${substring}". Events:\n\n  ${formattedEvents}`,
+    );
+  }
+}
+
 /** Asserts memo/tag appears on Speculos screens when the tx includes one. */
 export function expectMemoTagInEvents(tx: Transaction, events: string[]) {
   if (!tx.memoTag || tx.memoTag === "noTag") {
     return;
   }
-  expect(containsSubstringInEvent(tx.memoTag, events)).toBeTruthy();
+  expectSpeculosEventsContain(tx.memoTag, events);
 }
 
 export async function takeScreenshot(port?: number): Promise<Buffer | undefined> {
@@ -928,13 +944,11 @@ export const expectValidAddressDevice = withDeviceController(
 
       if (isTouchDevice()) {
         const events = await pressUntilTextFound(receiveConfirmLabel);
-        const isAddressCorrect = containsSubstringInEvent(addressDisplayed, events);
-        expect(isAddressCorrect).toBeTruthy();
+        expectSpeculosEventsContain(addressDisplayed, events);
         await pressAndRelease(DeviceLabels.CONFIRM);
       } else {
         const events = await pressUntilTextFound(receiveConfirmLabel);
-        const isAddressCorrect = containsSubstringInEvent(addressDisplayed, events);
-        expect(isAddressCorrect).toBeTruthy();
+        expectSpeculosEventsContain(addressDisplayed, events);
         await buttons.both();
       }
     },
@@ -977,8 +991,10 @@ export async function signSendTransaction(tx: Transaction) {
       await sendStellar(tx);
       break;
     case Currency.ATOM.id:
-    case Currency.OSMO.id:
       await sendCosmos(tx);
+      break;
+    case Currency.OSMO.id:
+      await sendOsmosis(tx);
       break;
     case Currency.ADA.id:
       await sendCardano(tx);
@@ -1156,25 +1172,16 @@ function verifySwapData(swap: Swap, events: string[], amount: string) {
 
   if (getSpeculosModel() !== DeviceModelId.nanoS) {
     if (swap.provider && swap.provider.app && swap.provider.app !== AppInfos.EXCHANGE) {
-      expectDeviceScreenContains(
+      expectSpeculosEventsContain(
         swap.provider.uiName,
         events,
         "Provider not found on the device screen",
       );
     } else {
-      expectDeviceScreenContains(swapPair, events, "Swap pair not found on the device screen");
+      expectSpeculosEventsContain(swapPair, events, "Swap pair not found on the device screen");
     }
   }
-  expectDeviceScreenContains(amount, events, `Amount ${amount} not found on the device screen`);
-}
-
-function expectDeviceScreenContains(substring: string, events: string[], message: string) {
-  const found = containsSubstringInEvent(substring, events);
-  if (!found) {
-    throw new Error(
-      `${message}. Expected events to contain "${substring}". Got: ${JSON.stringify(events)}`,
-    );
-  }
+  expectSpeculosEventsContain(amount, events, `Amount ${amount} not found on the device screen`);
 }
 
 export const exportUfvk = withDeviceController(


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Desktop E2E [OSMO] - Send (new send flow) fails at Speculos signing with expect(received).toBeTruthy() Received: false. The device is showing a valid Osmosis send; the test is asserting the wrong amount string.

OSMO send reused sendCosmos, which asserts the human amount. The Cosmos app has no OSMO display unit, so it prints proto denom uosmo (6 decimals).

Convert to the appropriate format for validation and centralise function for validation and readable and helpful error message on failure.

Send specs regression:
- desktop: https://github.com/LedgerHQ/ledger-live/actions/runs/33889158500
- mobile: https://github.com/LedgerHQ/ledger-live/actions/runs/33886608538

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
