### PR TITLE
[LWM] feat(pay): show contact success after a Pay send (LIVE-36879)

### DIFF
--- a/.changeset/calm-pay-success.md
+++ b/.changeset/calm-pay-success.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Show the Pay contact success screen after a Pay send.

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -168,6 +168,7 @@ export enum ScreenName {
   SendFlowRecipient = "SendFlowRecipient",
   SendFlowAmount = "SendFlowAmount",
   SendFlowConfirmation = "SendFlowConfirmation",
+  SendFlowPaySuccess = "SendFlowPaySuccess",
   SendFlowCustomFees = "SendFlowCustomFees",
   SendFlowCoinControl = "SendFlowCoinControl",
   SendFlowSignature = "SendFlowSignature",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10344,6 +10344,14 @@
       "addressPicker": {
         "title": "Select {{name}}'s address",
         "addAddress": "Add address"
+      },
+      "paySuccess": {
+        "title": "You paid ({{recipient}})",
+        "amount": "Amount",
+        "estimatedTime": "Est. time",
+        "from": "From",
+        "viewTransaction": "View transaction",
+        "close": "Close"
       }
     },
     "cardOnboarding": {

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/shared.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/shared.tsx
@@ -84,6 +84,7 @@ type TestStackParamList = {
           account?: { id: string };
           recipient?: string;
           skipRecipientStep?: boolean;
+          source?: string;
         };
       }
     | undefined;

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabNewPayment.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayTabNewPayment.ts
@@ -3,6 +3,7 @@ import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { Contact, ContactAddress } from "@domain/entity-contact";
 import type { ContactAddressPickerProps } from "@features/flow-pay-contact";
+import { SEND_FLOW_SOURCE } from "@ledgerhq/live-common/flows/send/types";
 import { useContactAddressPicker } from "LLM/features/Contacts/hooks/useContactAddressPicker";
 import { useOpenSendFlow } from "LLM/features/Send/hooks/useOpenSendFlow";
 import { ScreenName } from "~/const";
@@ -16,7 +17,7 @@ export type UsePayTabNewPayment = Readonly<{
 export function usePayTabNewPayment(): UsePayTabNewPayment {
   const navigation = useNavigation<NativeStackNavigationProp<PayTabNavigatorParamList>>();
   const { handleOpenSendFlow } = useOpenSendFlow({
-    sourceScreenName: "Pay",
+    sourceScreenName: SEND_FLOW_SOURCE.PAY,
   });
 
   const payFromAddress = useCallback(

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
@@ -26,6 +26,7 @@ import { CustomFeesScreen } from "../screens/CustomFees";
 import { CoinControlScreen } from "../screens/CoinControl";
 import { SignatureScreen } from "../screens/Signature";
 import { ConfirmationScreen } from "../screens/Confirmation";
+import { PaySuccessScreen } from "../screens/PaySuccess";
 import {
   SEND_FLOW_STEP,
   type SendFlowStep,
@@ -56,6 +57,7 @@ const stepRegistry: StepRegistry<SendFlowStep> = {
   [SEND_FLOW_STEP.COIN_CONTROL]: CoinControlScreen,
   [SEND_FLOW_STEP.SIGNATURE]: SignatureScreen,
   [SEND_FLOW_STEP.CONFIRMATION]: ConfirmationScreen,
+  [SEND_FLOW_STEP.PAY_SUCCESS]: PaySuccessScreen,
 };
 
 const HostStack = createNativeStackNavigator();

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/__integrations__/SendPaySuccess.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/__integrations__/SendPaySuccess.integration.test.tsx
@@ -1,0 +1,153 @@
+import * as React from "react";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { setEnv } from "@shared/env";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { mockContactWithAddress, mockMeContact } from "@domain/entity-contact/schema.mock";
+import {
+  SEND_FLOW_SOURCE,
+  SEND_FLOW_STEP,
+  type SendFlowInitParams,
+  type SendFlowStep,
+} from "@ledgerhq/live-common/flows/send/types";
+import type { StepRegistry } from "@ledgerhq/live-common/flows/wizard/types";
+import { act, renderWithReactQuery, screen, withFlagOverrides } from "@tests/test-renderer";
+import type { Account } from "@ledgerhq/types-live";
+import type { State } from "~/reducers/types";
+import { SendFlowOrchestrator } from "../SendFlowOrchestrator";
+import { SEND_FLOW_CONFIG } from "../constants";
+import { RecipientScreen } from "../screens/Recipient";
+import { AmountScreen } from "../screens/Amount";
+import { CustomFeesScreen } from "../screens/CustomFees";
+import { CoinControlScreen } from "../screens/CoinControl";
+import { ConfirmationScreen } from "../screens/Confirmation";
+import { PaySuccessScreen } from "../screens/PaySuccess";
+
+jest.mock("../screens/Signature", () => {
+  const ReactModule = jest.requireActual<typeof import("react")>("react");
+  const { useSendSignature } = jest.requireActual("../context/SendSignatureContext");
+
+  return {
+    SignatureScreen: function SignatureScreenAutoComplete() {
+      const { finishSigning } = useSendSignature();
+      ReactModule.useEffect(() => {
+        finishSigning();
+      }, [finishSigning]);
+      return null;
+    },
+  };
+});
+
+jest.mock("LLM/features/Contacts/hooks/useContactsAddressValidationAdapter", () => ({
+  useContactsAddressValidationAdapter: () => ({
+    validateAddress: async ({ address }: { address: string }) => ({
+      status: "valid",
+      resolvedAddress: address,
+      isDomain: false,
+    }),
+  }),
+}));
+
+const ethereum = getCryptoCurrencyById("ethereum");
+const account = genAccount("pay-success-send", { currency: ethereum });
+const ada = mockContactWithAddress({ id: "contact-ada", name: "Ada" });
+const adaAddress = ada.addresses[0]!.address;
+
+const stepRegistry: StepRegistry<SendFlowStep> = {
+  [SEND_FLOW_STEP.RECIPIENT]: RecipientScreen,
+  [SEND_FLOW_STEP.RECENT_HISTORY]: () => null,
+  [SEND_FLOW_STEP.AMOUNT]: AmountScreen,
+  [SEND_FLOW_STEP.CUSTOM_FEES]: CustomFeesScreen,
+  [SEND_FLOW_STEP.COIN_CONTROL]: CoinControlScreen,
+  [SEND_FLOW_STEP.SIGNATURE]: () => null,
+  [SEND_FLOW_STEP.CONFIRMATION]: ConfirmationScreen,
+  [SEND_FLOW_STEP.PAY_SUCCESS]: PaySuccessScreen,
+};
+
+const HostStack = createNativeStackNavigator();
+
+function SendPage({ initParams }: { initParams: SendFlowInitParams }) {
+  return (
+    <HostStack.Navigator screenOptions={{ headerShown: false }}>
+      <HostStack.Screen name="SendHost">
+        {() => (
+          <SendFlowOrchestrator
+            initParams={initParams}
+            onClose={() => {}}
+            stepRegistry={stepRegistry}
+            flowConfig={SEND_FLOW_CONFIG}
+          />
+        )}
+      </HostStack.Screen>
+    </HostStack.Navigator>
+  );
+}
+
+function renderSend(initParams: Omit<SendFlowInitParams, "account">, accountOverride: Account) {
+  return renderWithReactQuery(
+    <SendPage initParams={{ account: accountOverride, ...initParams }} />,
+    {
+      overrideInitialState: withFlagOverrides(
+        {
+          lwmContacts: { enabled: true, params: { newBadge: false } },
+          newSendFlow: { enabled: true, params: { families: ["evm"], excludedCurrencyIds: [] } },
+        },
+        (state: State) => ({
+          ...state,
+          accounts: { ...state.accounts, active: [accountOverride] },
+          contacts: { contacts: [mockMeContact(), ada] },
+        }),
+      ),
+    },
+  );
+}
+
+async function reviewSend(user: ReturnType<typeof renderSend>["user"]) {
+  await user.press(await screen.findByText("50%"));
+  await user.press(await screen.findByText("Review"));
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe("Send Pay success", () => {
+  beforeAll(() => {
+    setEnv("MOCK", "1");
+  });
+
+  afterAll(() => {
+    setEnv("MOCK", "");
+  });
+
+  it("should show the contact success screen when the send source is Pay", async () => {
+    const { user } = renderSend(
+      {
+        recipient: adaAddress,
+        skipRecipientStep: true,
+        source: SEND_FLOW_SOURCE.PAY,
+      },
+      account,
+    );
+
+    await reviewSend(user);
+
+    expect(await screen.findByText(/You paid \(Ada\)/)).toBeVisible();
+    expect(screen.queryByTestId("send-confirmation-success")).not.toBeOnTheScreen();
+  });
+
+  it("should show send confirmation when the send source is not Pay", async () => {
+    const { user } = renderSend(
+      {
+        recipient: adaAddress,
+        skipRecipientStep: true,
+        source: "Asset Detail",
+      },
+      account,
+    );
+
+    await reviewSend(user);
+
+    expect(await screen.findByTestId("send-confirmation-success")).toBeVisible();
+    expect(screen.queryByText(/You paid \(Ada\)/)).not.toBeOnTheScreen();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/__tests__/SendFlowOrchestrator.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/__tests__/SendFlowOrchestrator.test.tsx
@@ -61,6 +61,7 @@ function createStepRegistry(): StepRegistry<SendFlowStep> {
     [SEND_FLOW_STEP.COIN_CONTROL]: () => null,
     [SEND_FLOW_STEP.SIGNATURE]: () => null,
     [SEND_FLOW_STEP.CONFIRMATION]: () => null,
+    [SEND_FLOW_STEP.PAY_SUCCESS]: () => null,
   };
 }
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/constants.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/constants.ts
@@ -12,6 +12,7 @@ export const SEND_FLOW_STEP_ORDER: readonly SendFlowStep[] = [
   SEND_FLOW_STEP.CUSTOM_FEES,
   SEND_FLOW_STEP.COIN_CONTROL,
   SEND_FLOW_STEP.CONFIRMATION,
+  SEND_FLOW_STEP.PAY_SUCCESS,
 ];
 
 export const SEND_STEP_CONFIGS: Record<SendFlowStep, SendStepConfig> = {
@@ -123,6 +124,11 @@ export const SEND_STEP_CONFIGS: Record<SendFlowStep, SendStepConfig> = {
     canGoBack: false,
     showHeaderRight: false,
     showTitle: false,
+    screenName: ScreenName.SendFlowPaySuccess,
+    screenOptions: {
+      ...TransparentHeaderNavigationOptions,
+      title: "",
+    },
   },
 };
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/context/SendFlowContext.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/context/SendFlowContext.tsx
@@ -18,6 +18,7 @@ type DataContextValue = Readonly<{
     setValue: (value: string) => void;
     clear: () => void;
   }>;
+  source?: string;
 }>;
 
 const SendFlowDataContext = createContext<DataContextValue | null>(null);
@@ -46,8 +47,9 @@ export function SendFlowProvider({ value, onClose, children }: SendFlowProviderP
       state: value.state,
       uiConfig: value.uiConfig,
       recipientSearch: value.recipientSearch,
+      source: value.source,
     }),
-    [value.state, value.uiConfig, value.recipientSearch],
+    [value.state, value.uiConfig, value.recipientSearch, value.source],
   );
 
   const actionsValue = useMemo<ActionsContextValue>(

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useOpenSendFlow.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useOpenSendFlow.test.ts
@@ -69,6 +69,7 @@ describe("useOpenSendFlow", () => {
         account,
         parentAccount: undefined,
         fromMAD: true,
+        source: "Asset Detail",
       },
     });
   });
@@ -104,6 +105,7 @@ describe("useOpenSendFlow", () => {
         parentAccount: undefined,
         fromMAD: true,
         recipient,
+        source: "Contact Detail",
       },
     });
   });
@@ -147,6 +149,7 @@ describe("useOpenSendFlow", () => {
         fromMAD: true,
         recipient,
         skipRecipientStep: true,
+        source: "Contact Detail",
       },
     });
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useOpenSendFlow.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useOpenSendFlow.ts
@@ -140,6 +140,7 @@ export function useOpenSendFlow({
             fromMAD: true,
             recipient: prefilledRecipient,
             skipRecipientStep,
+            source: sourceScreenName,
           },
         });
         return;
@@ -170,6 +171,7 @@ export function useOpenSendFlow({
       isEnabledForFamily,
       navigateToLegacyRecipient,
       navigation,
+      sourceScreenName,
     ],
   );
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/index.tsx
@@ -15,6 +15,7 @@ import { SEND_FLOW_CONFIG } from "./constants";
 import { RecipientScreen } from "./screens/Recipient";
 import { AmountScreen } from "./screens/Amount";
 import { ConfirmationScreen } from "./screens/Confirmation";
+import { PaySuccessScreen } from "./screens/PaySuccess";
 import { SignatureScreen } from "./screens/Signature";
 import { CoinControlScreen } from "./screens/CoinControl";
 import { CustomFeesScreen } from "./screens/CustomFees";
@@ -27,6 +28,7 @@ const stepRegistry: StepRegistry<SendFlowStep> = {
   [SEND_FLOW_STEP.COIN_CONTROL]: CoinControlScreen,
   [SEND_FLOW_STEP.SIGNATURE]: SignatureScreen,
   [SEND_FLOW_STEP.CONFIRMATION]: ConfirmationScreen,
+  [SEND_FLOW_STEP.PAY_SUCCESS]: PaySuccessScreen,
 };
 
 type SendWorkflowParams = Readonly<{
@@ -37,6 +39,7 @@ type SendWorkflowParams = Readonly<{
   amount?: string;
   memo?: string;
   fromMAD?: boolean;
+  source?: string;
 }>;
 
 type SendWorkflowRouteParams = {
@@ -50,6 +53,7 @@ type SendWorkflowRouteParams = {
   amount?: string;
   memo?: string;
   fromMAD?: boolean;
+  source?: string;
 };
 
 export default function SendWorkflow() {
@@ -78,6 +82,7 @@ export default function SendWorkflow() {
       amount: params?.amount ?? routeParams?.amount,
       memo: params?.memo ?? routeParams?.memo,
       fromMAD: params?.fromMAD ?? routeParams?.fromMAD ?? false,
+      source: params?.source ?? routeParams?.source,
     }),
     [params, routeParams],
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/hooks/useAmountScreen.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/hooks/useAmountScreen.ts
@@ -8,6 +8,7 @@ import type {
   SendFlowUiConfig,
 } from "@ledgerhq/live-common/flows/send/types";
 import { ScreenName } from "~/const";
+import { getSendSuccessScreenName } from "../../../utils/getSendSuccessScreenName";
 import type { SendFlowNavigationProp } from "../../../types";
 import { useSendSignature } from "../../../context/SendSignatureContext";
 import { getSendFlowTrackingProperties } from "@ledgerhq/ledger-wallet-framework/tracking/send";
@@ -37,7 +38,7 @@ export type AmountScreenViewModel =
       }>);
 
 export function useAmountScreen(): AmountScreenViewModel {
-  const { state, uiConfig } = useSendFlowData();
+  const { state, uiConfig, source } = useSendFlowData();
   const { transaction: transactionActions, close } = useSendFlowActions();
   const navigation = useNavigation<SendFlowNavigationProp>();
   const { startSigning } = useSendSignature();
@@ -61,8 +62,8 @@ export function useAmountScreen(): AmountScreenViewModel {
       page: "step amount",
       input_mode: inputMode,
     });
-    startSigning(() => navigation.navigate(ScreenName.SendFlowConfirmation));
-  }, [startSigning, navigation, trackingProperties, inputMode]);
+    startSigning(() => navigation.navigate(getSendSuccessScreenName(source)));
+  }, [startSigning, navigation, trackingProperties, inputMode, source]);
 
   const onSelectCoinControl = useCallback(() => {
     navigation.navigate(ScreenName.SendFlowCoinControl);

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/hooks/useCoinControlScreen.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CoinControl/hooks/useCoinControlScreen.ts
@@ -7,6 +7,7 @@ import type { Account, AccountLike } from "@ledgerhq/types-live";
 import { useCallback } from "react";
 import { useNavigation } from "@react-navigation/native";
 import { ScreenName } from "~/const";
+import { getSendSuccessScreenName } from "../../../utils/getSendSuccessScreenName";
 import { useSendFlowActions, useSendFlowData } from "../../../context/SendFlowContext";
 import { useSendSignature } from "../../../context/SendSignatureContext";
 import type { SendFlowNavigationProp } from "../../../types";
@@ -28,7 +29,7 @@ export type CoinControlScreenViewModel =
     };
 
 export function useCoinControlScreen(): CoinControlScreenViewModel {
-  const { state, uiConfig } = useSendFlowData();
+  const { state, uiConfig, source } = useSendFlowData();
   const { transaction: transactionActions, close } = useSendFlowActions();
   const { startSigning } = useSendSignature();
   const navigation = useNavigation<SendFlowNavigationProp>();
@@ -37,8 +38,8 @@ export function useCoinControlScreen(): CoinControlScreenViewModel {
   const { bridgePending, status, transaction } = state.transaction;
 
   const onReview = useCallback(() => {
-    startSigning(() => navigation.navigate(ScreenName.SendFlowConfirmation));
-  }, [startSigning, navigation]);
+    startSigning(() => navigation.navigate(getSendSuccessScreenName(source)));
+  }, [startSigning, navigation, source]);
 
   const onGetFunds = useCallback(() => {
     close();

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/PaySuccess/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/PaySuccess/index.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { PaySuccess } from "@features/flow-pay-contact";
+import SafeAreaView from "~/components/SafeAreaView";
+import { usePaySuccessViewModel } from "./usePaySuccessViewModel";
+
+export function PaySuccessScreen() {
+  const viewModel = usePaySuccessViewModel();
+
+  return (
+    <SafeAreaView edges={["bottom"]}>
+      <PaySuccess {...viewModel} />
+    </SafeAreaView>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/PaySuccess/usePaySuccessViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/PaySuccess/usePaySuccessViewModel.test.ts
@@ -1,0 +1,164 @@
+import { BigNumber } from "bignumber.js";
+import { parseAnyAccountId } from "@domain/entity-account";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { mockContactWithAddress } from "@domain/entity-contact/schema.mock";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import type { SendFlowState } from "@ledgerhq/live-common/flows/send/types";
+import { FLOW_STATUS } from "@ledgerhq/live-common/flows/wizard/types";
+import type { Operation } from "@ledgerhq/types-live";
+import { renderHook, withFlagOverrides } from "@tests/test-renderer";
+import { ScreenName } from "~/const";
+import { usePaySuccessViewModel } from "./usePaySuccessViewModel";
+
+const mockClose = jest.fn();
+const mockNavigate = jest.fn();
+let mockFlowState: SendFlowState;
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock("../../context/SendFlowContext", () => ({
+  useSendFlowData: () => ({ state: mockFlowState }),
+  useSendFlowActions: () => ({ close: mockClose }),
+}));
+
+const ADA_ADDRESS = "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034";
+const UNKNOWN_ADDRESS = "0xfeedfacefeedfacefeedfacefeedfacefeedface";
+const ACCOUNT_NAME = "Ada's payments";
+
+const ada = mockContactWithAddress({ id: "contact-ada", name: "Ada" });
+const account = genAccount("pay-success-eth", {
+  currency: getCryptoCurrencyById("ethereum"),
+  operationsSize: 0,
+});
+
+function buildFlowState(
+  overrides: {
+    address?: string;
+    signedRecipient?: string;
+    optimisticOperation?: Operation | null;
+  } = {},
+): SendFlowState {
+  return {
+    account: { account, parentAccount: null, currency: account.currency },
+    transaction: {
+      transaction: {
+        amount: new BigNumber("1500000000000000000"),
+        recipient: overrides.signedRecipient ?? overrides.address ?? ADA_ADDRESS,
+      } as SendFlowState["transaction"]["transaction"],
+      status: {} as SendFlowState["transaction"]["status"],
+      bridgeError: null,
+      bridgePending: false,
+    },
+    recipient: { address: overrides.address ?? ADA_ADDRESS },
+    operation: {
+      optimisticOperation: overrides.optimisticOperation ?? null,
+      transactionError: null,
+      signed: true,
+    },
+    isLoading: false,
+    flowStatus: FLOW_STATUS.SUCCESS,
+  };
+}
+
+function renderPaySuccess(state = buildFlowState(), { isContactsEnabled = true } = {}) {
+  mockFlowState = state;
+
+  return renderHook(() => usePaySuccessViewModel(), {
+    overrideInitialState: withFlagOverrides(
+      { lwmContacts: { enabled: isContactsEnabled, params: { newBadge: false } } },
+      state => ({
+        ...state,
+        accounts: { ...state.accounts, active: [account] },
+        wallet: {
+          ...state.wallet,
+          accountNames: new Map([[parseAnyAccountId(account.id), ACCOUNT_NAME]]),
+        },
+        contacts: { contacts: [ada] },
+      }),
+    ),
+  });
+}
+
+describe("usePaySuccessViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should expose the contact as recipient when the address belongs to one", () => {
+    const { result } = renderPaySuccess();
+
+    expect(result.current.recipient).toEqual({ id: "contact-ada", name: "Ada", isMe: false });
+    expect(result.current.recipientLabel).toBe("Ada");
+  });
+
+  it("should fall back to the input recipient when the signed transaction has no address", () => {
+    const { result } = renderPaySuccess(buildFlowState({ signedRecipient: "" }));
+
+    expect(result.current.recipient).toEqual({ id: "contact-ada", name: "Ada", isMe: false });
+    expect(result.current.recipientLabel).toBe("Ada");
+  });
+
+  it("should match the contact from the signed transaction address when input was a domain", () => {
+    const { result } = renderPaySuccess(
+      buildFlowState({ address: "ada.eth", signedRecipient: ADA_ADDRESS }),
+    );
+
+    expect(result.current.recipient).toEqual({ id: "contact-ada", name: "Ada", isMe: false });
+    expect(result.current.recipientLabel).toBe("Ada");
+  });
+
+  it("should fall back to the truncated address when no contact matches", () => {
+    const { result } = renderPaySuccess(buildFlowState({ address: UNKNOWN_ADDRESS }));
+
+    expect(result.current.recipient).toBeUndefined();
+    expect(result.current.recipientLabel).toBe("0xfeedfa...feedface");
+  });
+
+  it("should ignore matching contacts when the contacts feature is disabled", () => {
+    const { result } = renderPaySuccess(buildFlowState(), { isContactsEnabled: false });
+
+    expect(result.current.recipient).toBeUndefined();
+    expect(result.current.recipientLabel).toBe("0x1ad23b...46c53034");
+  });
+
+  it("should summarize the transaction from the account and its network", () => {
+    const { result } = renderPaySuccess();
+
+    expect(result.current.amountFormatted).toMatch(/1\.5/);
+    expect(result.current.fromAccountName).toBe(ACCOUNT_NAME);
+    expect(result.current.networkIcon).toEqual({ ledgerId: "ethereum", ticker: "ETH" });
+    expect(result.current.estimatedTime).toBe("~15s");
+  });
+
+  it("should open operation details when viewing the transaction", () => {
+    const operation = { id: "op-child", accountId: account.id } as Operation;
+    const { result } = renderPaySuccess(
+      buildFlowState({
+        optimisticOperation: {
+          id: "op-root",
+          accountId: account.id,
+          subOperations: [operation],
+        } as Operation,
+      }),
+    );
+
+    result.current.onViewTransaction();
+
+    expect(mockNavigate).toHaveBeenCalledWith(ScreenName.OperationDetails, {
+      accountId: account.id,
+      parentId: undefined,
+      operation,
+    });
+  });
+
+  it("should not navigate when there is no operation to view", () => {
+    const { result } = renderPaySuccess();
+
+    result.current.onViewTransaction();
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/PaySuccess/usePaySuccessViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/PaySuccess/usePaySuccessViewModel.ts
@@ -1,0 +1,123 @@
+import { useCallback, useMemo } from "react";
+import { useNavigation } from "@react-navigation/native";
+import { BigNumber } from "bignumber.js";
+import type { PaySuccessProps } from "@features/flow-pay-contact";
+import { getRecipientHeaderPresentation } from "@ledgerhq/live-common/flows/send/recipient/utils/getRecipientHeaderPresentation";
+import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import {
+  getAccountCurrency,
+  getMainAccount,
+} from "@ledgerhq/ledger-wallet-framework/account/helpers";
+import { useContactsFeature } from "@features/platform-contacts";
+import { selectContacts, ContactIdSchema } from "@domain/entity-contact";
+import { ScreenName } from "~/const";
+import type { BaseNavigationComposite } from "~/components/RootNavigator/types/helpers";
+import { useSelector } from "~/context/hooks";
+import { localeSelector } from "~/reducers/settings";
+import { useMaybeAccountName } from "~/reducers/wallet";
+import { useMaybeAccountUnit } from "LLM/hooks/useAccountUnit";
+import { useSendFlowActions, useSendFlowData } from "../../context/SendFlowContext";
+import type { SendFlowNavigationProp } from "../../types";
+
+function formatApproximateBlockTime(seconds: number | undefined): string | undefined {
+  if (!seconds || seconds <= 0) return undefined;
+  if (seconds < 60) return `~${Math.round(seconds)}s`;
+  return `~${Math.round(seconds / 60)} min`;
+}
+
+export function usePaySuccessViewModel(): PaySuccessProps {
+  const navigation = useNavigation<BaseNavigationComposite<SendFlowNavigationProp>>();
+  const { state } = useSendFlowData();
+  const { close } = useSendFlowActions();
+  const locale = useSelector(localeSelector);
+  const contacts = useSelector(selectContacts);
+  const { isEnabled: isContactsFeatureEnabled } = useContactsFeature("mobile");
+
+  const account = state.account.account;
+  const parentAccount = state.account.parentAccount;
+  const currency = state.account.currency;
+
+  const mainAccount = useMemo(
+    () => (account ? getMainAccount(account, parentAccount ?? undefined) : null),
+    [account, parentAccount],
+  );
+  const networkCurrency = useMemo(
+    () => (mainAccount ? getAccountCurrency(mainAccount) : null),
+    [mainAccount],
+  );
+
+  const recipient = useMemo(() => {
+    const signedAddress = state.transaction.transaction?.recipient;
+    if (typeof signedAddress === "string" && signedAddress.length > 0) {
+      return { address: signedAddress };
+    }
+    return state.recipient;
+  }, [state.recipient, state.transaction.transaction?.recipient]);
+
+  const recipientHeader = useMemo(
+    () =>
+      getRecipientHeaderPresentation({
+        recipient,
+        contacts,
+        currencyId: currency?.id,
+        isContactsFeatureEnabled,
+      }),
+    [contacts, currency?.id, isContactsFeatureEnabled, recipient],
+  );
+
+  const amountUnit = useMaybeAccountUnit(account ?? undefined) ?? currency?.units[0];
+  const amountFormatted = useMemo(() => {
+    if (!amountUnit) return "";
+    const amount = state.transaction.transaction?.amount ?? new BigNumber(0);
+    return formatCurrencyUnit(amountUnit, amount, {
+      showCode: true,
+      disableRounding: true,
+      locale,
+    });
+  }, [amountUnit, locale, state.transaction.transaction]);
+
+  const fromAccountName = useMaybeAccountName(account ?? undefined) ?? "";
+
+  const optimisticOperation = state.operation.optimisticOperation;
+  const concernedOperation =
+    optimisticOperation?.subOperations?.find(op => op.accountId === account?.id) ??
+    optimisticOperation ??
+    null;
+
+  const onViewTransaction = useCallback(() => {
+    if (!account || !concernedOperation) return;
+    navigation.navigate(ScreenName.OperationDetails, {
+      accountId: account.id,
+      parentId: parentAccount?.id ?? undefined,
+      operation: concernedOperation,
+    });
+  }, [account, concernedOperation, parentAccount, navigation]);
+
+  const matchedRecipient = recipientHeader.contact
+    ? {
+        id: ContactIdSchema.parse(recipientHeader.contact.id),
+        name: recipientHeader.contact.name,
+        isMe: false,
+      }
+    : undefined;
+
+  const networkIcon = networkCurrency
+    ? { ledgerId: networkCurrency.id, ticker: networkCurrency.ticker }
+    : undefined;
+
+  const estimatedTime =
+    networkCurrency?.type === "CryptoCurrency"
+      ? formatApproximateBlockTime(networkCurrency.blockAvgTime)
+      : undefined;
+
+  return {
+    recipient: matchedRecipient,
+    recipientLabel: recipientHeader.label,
+    amountFormatted,
+    fromAccountName,
+    networkIcon,
+    estimatedTime,
+    onViewTransaction,
+    onClose: close,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/types.ts
@@ -28,6 +28,7 @@ export type SendFlowStackParamList = {
   [ScreenName.SendFlowCoinControl]: undefined;
   [ScreenName.SendFlowSignature]: undefined;
   [ScreenName.SendFlowConfirmation]: undefined;
+  [ScreenName.SendFlowPaySuccess]: undefined;
 };
 
 export type SendFlowNavigationProp = NativeStackNavigationProp<SendFlowStackParamList>;

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/utils/__tests__/getSendSuccessScreenName.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/utils/__tests__/getSendSuccessScreenName.test.ts
@@ -1,0 +1,14 @@
+import { SEND_FLOW_SOURCE } from "@ledgerhq/live-common/flows/send/types";
+import { ScreenName } from "~/const";
+import { getSendSuccessScreenName } from "../getSendSuccessScreenName";
+
+describe("getSendSuccessScreenName", () => {
+  it("should open pay success when the send source is Pay", () => {
+    expect(getSendSuccessScreenName(SEND_FLOW_SOURCE.PAY)).toBe(ScreenName.SendFlowPaySuccess);
+  });
+
+  it("should open confirmation when the send source is not Pay", () => {
+    expect(getSendSuccessScreenName("Asset Detail")).toBe(ScreenName.SendFlowConfirmation);
+    expect(getSendSuccessScreenName()).toBe(ScreenName.SendFlowConfirmation);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/utils/getSendSuccessScreenName.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/utils/getSendSuccessScreenName.ts
@@ -1,0 +1,8 @@
+import { SEND_FLOW_SOURCE } from "@ledgerhq/live-common/flows/send/types";
+import { ScreenName } from "~/const";
+
+export function getSendSuccessScreenName(source?: string) {
+  return source === SEND_FLOW_SOURCE.PAY
+    ? ScreenName.SendFlowPaySuccess
+    : ScreenName.SendFlowConfirmation;
+}

--- a/features/flow/pay-contact/src/components/PaySuccess/PaySuccess.native.tsx
+++ b/features/flow/pay-contact/src/components/PaySuccess/PaySuccess.native.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { Button, Box } from "@ledgerhq/lumen-ui-rnative";
+import { useTranslation } from "@shared/i18n";
+import { PaySuccessHero, type PaySuccessRecipient } from "./PaySuccessHero.native";
+import {
+  PaySuccessSummary,
+  type PaySuccessSummaryIcon,
+  type PaySuccessSummaryRow,
+} from "./PaySuccessSummary.native";
+
+export type PaySuccessProps = Readonly<{
+  recipient?: PaySuccessRecipient;
+  recipientLabel: string;
+  amountFormatted: string;
+  fromAccountName: string;
+  networkIcon?: PaySuccessSummaryIcon;
+  estimatedTime?: string;
+  onViewTransaction: () => void;
+  onClose: () => void;
+}>;
+
+export function PaySuccess({
+  recipient,
+  recipientLabel,
+  amountFormatted,
+  fromAccountName,
+  networkIcon,
+  estimatedTime,
+  onViewTransaction,
+  onClose,
+}: PaySuccessProps) {
+  const { t } = useTranslation();
+
+  const rows: ReadonlyArray<PaySuccessSummaryRow> = [
+    { id: "amount", label: t("payTab.contacts.paySuccess.amount"), value: amountFormatted },
+    ...(estimatedTime
+      ? [
+          {
+            id: "estimatedTime",
+            label: t("payTab.contacts.paySuccess.estimatedTime"),
+            value: estimatedTime,
+          },
+        ]
+      : []),
+    {
+      id: "from",
+      label: t("payTab.contacts.paySuccess.from"),
+      value: fromAccountName,
+      trailingIcon: networkIcon,
+    },
+  ];
+
+  return (
+    <Box
+      lx={{ flex: 1, paddingHorizontal: "s16", paddingVertical: "s24" }}
+      testID="pay-success-step"
+    >
+      <Box lx={{ flex: 1, alignItems: "center", justifyContent: "center", gap: "s32" }}>
+        <PaySuccessHero
+          recipient={recipient}
+          recipientLabel={recipientLabel}
+          amountFormatted={amountFormatted}
+        />
+        <PaySuccessSummary rows={rows} />
+      </Box>
+      <Box lx={{ gap: "s16" }}>
+        <Button
+          appearance="gray"
+          size="lg"
+          lx={{ width: "full" }}
+          onPress={onViewTransaction}
+          testID="pay-success-view-transaction"
+        >
+          {t("payTab.contacts.paySuccess.viewTransaction")}
+        </Button>
+        <Button
+          appearance="base"
+          size="lg"
+          lx={{ width: "full" }}
+          onPress={onClose}
+          testID="pay-success-close"
+        >
+          {t("payTab.contacts.paySuccess.close")}
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/features/flow/pay-contact/src/components/PaySuccess/PaySuccessHero.native.tsx
+++ b/features/flow/pay-contact/src/components/PaySuccess/PaySuccessHero.native.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { Avatar, Box, Text } from "@ledgerhq/lumen-ui-rnative";
+import { ContactAvatar } from "@features/platform-contacts";
+import type { ContactId } from "@domain/entity-contact";
+import { useTranslation } from "@shared/i18n";
+
+const AVATAR_SIZE = "xl";
+
+export type PaySuccessRecipient = Readonly<{
+  id: ContactId;
+  name: string;
+  isMe?: boolean;
+}>;
+
+export type PaySuccessHeroProps = Readonly<{
+  recipient?: PaySuccessRecipient;
+  recipientLabel: string;
+  amountFormatted: string;
+}>;
+
+export function PaySuccessHero({
+  recipient,
+  recipientLabel,
+  amountFormatted,
+}: PaySuccessHeroProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Box lx={{ alignItems: "center", gap: "s24" }}>
+      {recipient ? (
+        <ContactAvatar
+          contactId={recipient.id}
+          name={recipient.name}
+          isMe={recipient.isMe}
+          size={AVATAR_SIZE}
+        />
+      ) : (
+        <Avatar size={AVATAR_SIZE} />
+      )}
+      <Box lx={{ alignItems: "center", gap: "s8" }}>
+        <Text typography="heading2SemiBold" lx={{ color: "base", textAlign: "center" }}>
+          {t("payTab.contacts.paySuccess.title", { recipient: recipientLabel })}
+        </Text>
+        <Text typography="heading2SemiBold" lx={{ color: "base", textAlign: "center" }}>
+          {amountFormatted}
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/features/flow/pay-contact/src/components/PaySuccess/PaySuccessSummary.native.tsx
+++ b/features/flow/pay-contact/src/components/PaySuccess/PaySuccessSummary.native.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import {
+  Box,
+  DescriptionItem,
+  DescriptionItemLabel,
+  DescriptionItemLeading,
+  DescriptionItemTrailing,
+  DescriptionItemValue,
+} from "@ledgerhq/lumen-ui-rnative";
+import CryptoIcon from "@ledgerhq/crypto-icons/native";
+
+const ICON_SIZE = 16;
+
+export type PaySuccessSummaryIcon = Readonly<{
+  ledgerId: string;
+  ticker: string;
+}>;
+
+export type PaySuccessSummaryRow = Readonly<{
+  id: string;
+  label: string;
+  value: string;
+  trailingIcon?: PaySuccessSummaryIcon;
+}>;
+
+export type PaySuccessSummaryProps = Readonly<{
+  rows: ReadonlyArray<PaySuccessSummaryRow>;
+}>;
+
+export function PaySuccessSummary({ rows }: PaySuccessSummaryProps) {
+  return (
+    <Box lx={{ gap: "s12", width: "full" }}>
+      {rows.map(({ id, label, value, trailingIcon }) => (
+        <DescriptionItem key={id} size="md">
+          <DescriptionItemLeading>
+            <DescriptionItemLabel>{label}</DescriptionItemLabel>
+          </DescriptionItemLeading>
+          <DescriptionItemTrailing>
+            <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s8" }}>
+              <DescriptionItemValue>{value}</DescriptionItemValue>
+              {trailingIcon ? (
+                <Box testID="pay-success-summary-icon">
+                  <CryptoIcon
+                    ledgerId={trailingIcon.ledgerId}
+                    ticker={trailingIcon.ticker}
+                    size={ICON_SIZE}
+                    shape="square"
+                  />
+                </Box>
+              ) : null}
+            </Box>
+          </DescriptionItemTrailing>
+        </DescriptionItem>
+      ))}
+    </Box>
+  );
+}

--- a/features/flow/pay-contact/src/components/PaySuccess/__tests__/PaySuccess.native.test.tsx
+++ b/features/flow/pay-contact/src/components/PaySuccess/__tests__/PaySuccess.native.test.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { fireEvent, screen } from "@testing-library/react-native";
+import { ContactIdSchema } from "@domain/entity-contact";
+import { PaySuccess, type PaySuccessProps } from "../PaySuccess.native";
+import { renderPaySuccess } from "./shared.native";
+
+const baseProps: PaySuccessProps = {
+  recipient: { id: ContactIdSchema.parse("contact-ada"), name: "Ada", isMe: false },
+  recipientLabel: "Ada",
+  amountFormatted: "100 USDC",
+  fromAccountName: "Ethereum 1",
+  networkIcon: { ledgerId: "ethereum", ticker: "ETH" },
+  onViewTransaction: jest.fn(),
+  onClose: jest.fn(),
+};
+
+function renderStep(overrides: Partial<PaySuccessProps> = {}) {
+  return renderPaySuccess(<PaySuccess {...baseProps} {...overrides} />);
+}
+
+describe("PaySuccess (Native)", () => {
+  it("should render the recipient headline, amount and from account", () => {
+    renderStep();
+
+    expect(screen.getByTestId("pay-success-step")).toBeVisible();
+    expect(screen.getByText("You paid (Ada)")).toBeVisible();
+    expect(screen.getAllByText("100 USDC").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText("Ethereum 1")).toBeVisible();
+  });
+
+  it("should show the network icon on the From row", () => {
+    renderStep();
+
+    expect(screen.getByTestId("pay-success-summary-icon")).toBeVisible();
+  });
+
+  it("should hide the estimated time row when it is not provided", () => {
+    renderStep();
+
+    expect(screen.queryByText("Est. time")).not.toBeOnTheScreen();
+  });
+
+  it("should show the estimated time row when it is provided", () => {
+    renderStep({ estimatedTime: "~15s" });
+
+    expect(screen.getByText("Est. time")).toBeVisible();
+    expect(screen.getByText("~15s")).toBeVisible();
+  });
+
+  it("should fall back to a generic avatar when no contact is matched", () => {
+    renderStep({ recipient: undefined, recipientLabel: "0x1ad2...c53034" });
+
+    expect(screen.getByTestId("pay-success-step")).toBeVisible();
+    expect(screen.getByText("You paid (0x1ad2...c53034)")).toBeVisible();
+    expect(screen.getAllByText("100 USDC").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("should call onViewTransaction when the view transaction button is pressed", () => {
+    const onViewTransaction = jest.fn();
+    renderStep({ onViewTransaction });
+
+    fireEvent.press(screen.getByTestId("pay-success-view-transaction"));
+
+    expect(onViewTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call onClose when the close button is pressed", () => {
+    const onClose = jest.fn();
+    renderStep({ onClose });
+
+    fireEvent.press(screen.getByTestId("pay-success-close"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/flow/pay-contact/src/components/PaySuccess/__tests__/shared.native.tsx
+++ b/features/flow/pay-contact/src/components/PaySuccess/__tests__/shared.native.tsx
@@ -1,0 +1,26 @@
+import React, { type ReactElement } from "react";
+import { render } from "@testing-library/react-native";
+import { I18nTestProvider, type I18nTestProviderProps } from "@shared/i18n/testing";
+
+export const PAY_SUCCESS_RESOURCES: I18nTestProviderProps["resources"] = {
+  en: {
+    translation: {
+      payTab: {
+        contacts: {
+          paySuccess: {
+            title: "You paid ({{recipient}})",
+            amount: "Amount",
+            estimatedTime: "Est. time",
+            from: "From",
+            viewTransaction: "View transaction",
+            close: "Close",
+          },
+        },
+      },
+    },
+  },
+};
+
+export function renderPaySuccess(ui: ReactElement) {
+  return render(<I18nTestProvider resources={PAY_SUCCESS_RESOURCES}>{ui}</I18nTestProvider>);
+}

--- a/features/flow/pay-contact/src/index.native.ts
+++ b/features/flow/pay-contact/src/index.native.ts
@@ -2,3 +2,4 @@ export * from "./exports";
 export * from "./components/Contacts/Contacts.native";
 export * from "./components/ContactAddressPicker/ContactAddressPicker.native";
 export * from "./components/ContactAddressPicker/useContactAddressPickerViewModel";
+export * from "./components/PaySuccess/PaySuccess.native";


### PR DESCRIPTION
## Problem
Pay send currently lands on the generic Send confirmation. After paying a contact, users should see the contact success screen.

## Solution
- Route to `SendFlowPaySuccess` when send `source` is `Pay`
- Resolve the recipient from the signed transaction address
- Native `PaySuccess` in `@features/flow-pay-contact` (LIVE-36879 is LWM)

Desktop Pay send / success stays on LIVE-36375.

<img width="398" height="772" alt="image" src="https://github.com/user-attachments/assets/3ec81510-1f2c-471f-9613-b9965f88156c" />


Jira: LIVE-36879
Figma: https://www.figma.com/design/WYQQwem0QyG2fTuaAKAe3Y/Pay-%E2%80%A2-Production?node-id=7870-52322

## Test plan
- [ ] Pay a saved contact from Pay tab → success shows avatar + “You paid (Name)” + amount
- [ ] Unknown address still shows truncated address + generic avatar
- [ ] View transaction opens operation details
- [ ] Close exits the send flow
- [ ] A non-Pay send still opens the generic confirmation