### PR TITLE
test(queued-bottom-sheet): native jest double (LIVE-36959)

### DIFF
--- a/.changeset/queued-sheet-double.md
+++ b/.changeset/queued-sheet-double.md
@@ -1,0 +1,7 @@
+---
+"@shared/ui-queued-bottom-sheet": minor
+"@support/jest-features-flow": minor
+"@support/jest-shared": patch
+---
+
+Ship a QueuedBottomSheet test double from `@shared/ui-queued-bottom-sheet/testing` and map it by default in the features/flow native jest project, so sheet-hosting views no longer hand-roll a mock per test.

--- a/features/flow/pay-balance/src/__tests__/BalanceFilterPickerView.native.test.tsx
+++ b/features/flow/pay-balance/src/__tests__/BalanceFilterPickerView.native.test.tsx
@@ -1,25 +1,8 @@
 import React from "react";
-import { View } from "react-native";
 import { fireEvent, render, screen } from "@testing-library/react-native";
 import type { BalanceFilterPickerViewProps } from "../types";
 import { BalanceFilterPickerView } from "../components/Filter/BalanceFilterPickerView.native";
 import { filterLabels, options, usdcOption } from "./fixtures";
-
-jest.mock("@shared/ui-queued-bottom-sheet", () => ({
-  QueuedBottomSheet: ({
-    children,
-    isRequestingToBeOpened,
-    testID,
-  }: {
-    children: React.ReactNode;
-    isRequestingToBeOpened?: boolean;
-    testID?: string;
-  }) => (
-    <View testID={testID} accessibilityState={{ expanded: !!isRequestingToBeOpened }}>
-      {children}
-    </View>
-  ),
-}));
 
 jest.mock("@ledgerhq/crypto-icons/native", () => () => null);
 

--- a/features/flow/pay-balance/src/__tests__/BalanceView.native.test.tsx
+++ b/features/flow/pay-balance/src/__tests__/BalanceView.native.test.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { View } from "react-native";
 import { render, screen } from "@testing-library/react-native";
 import type { BalanceViewProps } from "../types";
 import { BalanceView } from "../components/Hero/BalanceView.native";
@@ -11,22 +10,6 @@ import {
   formatCountervalue,
   options,
 } from "./fixtures";
-
-jest.mock("@shared/ui-queued-bottom-sheet", () => ({
-  QueuedBottomSheet: ({
-    children,
-    isRequestingToBeOpened,
-    testID,
-  }: {
-    children: React.ReactNode;
-    isRequestingToBeOpened?: boolean;
-    testID?: string;
-  }) => (
-    <View testID={testID} accessibilityState={{ expanded: !!isRequestingToBeOpened }}>
-      {children}
-    </View>
-  ),
-}));
 
 function fundedProps(): BalanceViewProps {
   return {

--- a/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/BankTransferIntro.native.test.tsx
+++ b/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/BankTransferIntro.native.test.tsx
@@ -3,10 +3,6 @@ import { cleanup, render, screen, userEvent } from "@testing-library/react-nativ
 import { BankTransferIntro } from "../BankTransferIntro";
 import type { BankTransferIntroProps } from "../../../types";
 
-jest.mock("@shared/ui-queued-bottom-sheet", () => ({
-  QueuedBottomSheet: ({ children }: { children: React.ReactNode }) => children,
-}));
-
 const LABELS: BankTransferIntroProps["labels"] = {
   title: "Convert cash to stablecoins",
   description: "Transfer USD or EUR from your bank.",

--- a/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/BankTransferIntroView.native.test.tsx
+++ b/features/flow/pay-bank-transfer/src/components/BankTransferIntro/__tests__/BankTransferIntroView.native.test.tsx
@@ -1,31 +1,7 @@
 import React from "react";
-import { Pressable, View } from "react-native";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react-native";
 import { BankTransferIntroView } from "../BankTransferIntroView.native";
 import type { BankTransferIntroViewProps } from "../../../types";
-
-jest.mock("@shared/ui-queued-bottom-sheet", () => ({
-  QueuedBottomSheet: ({
-    children,
-    isForcingToBeOpened,
-    onHeaderClosePressed,
-    testID,
-  }: {
-    children: React.ReactNode;
-    isForcingToBeOpened?: boolean;
-    onHeaderClosePressed?: () => void;
-    testID?: string;
-  }) => (
-    <View testID={testID} accessibilityState={{ expanded: !!isForcingToBeOpened }}>
-      <Pressable
-        onPress={onHeaderClosePressed}
-        testID="pay-bank-transfer-intro-header-close"
-        accessibilityRole="button"
-      />
-      {children}
-    </View>
-  ),
-}));
 
 const defaultProps: BankTransferIntroViewProps = {
   isOpen: true,
@@ -115,7 +91,7 @@ describe("BankTransferIntroView (Native)", () => {
     const onClosePress = jest.fn();
     render(<BankTransferIntroView {...defaultProps} onClosePress={onClosePress} />);
 
-    fireEvent.press(screen.getByTestId("pay-bank-transfer-intro-header-close"));
+    fireEvent.press(screen.getByTestId("pay-bank-transfer-intro-sheet-header-close"));
     expect(onClosePress).toHaveBeenCalledTimes(1);
   });
 });

--- a/features/flow/pay-card-auth/src/components/CardMore/__tests__/CardMoreSheet.native.test.tsx
+++ b/features/flow/pay-card-auth/src/components/CardMore/__tests__/CardMoreSheet.native.test.tsx
@@ -1,26 +1,6 @@
 import React from "react";
-import { Pressable, View } from "react-native";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react-native";
 import { CardMoreSheet } from "../CardMoreSheet.native";
-
-jest.mock("@shared/ui-queued-bottom-sheet", () => ({
-  QueuedBottomSheet: ({
-    children,
-    isRequestingToBeOpened,
-    onClose,
-    testID,
-  }: {
-    children: React.ReactNode;
-    isRequestingToBeOpened?: boolean;
-    onClose?: () => void;
-    testID?: string;
-  }) => (
-    <View testID={testID} accessibilityState={{ expanded: !!isRequestingToBeOpened }}>
-      <Pressable testID={`${testID}-dismiss`} onPress={onClose} />
-      {children}
-    </View>
-  ),
-}));
 
 const onPress = {
   managePin: jest.fn(),

--- a/features/flow/pay-card-auth/src/components/CardMore/__tests__/CardMoreView.native.test.tsx
+++ b/features/flow/pay-card-auth/src/components/CardMore/__tests__/CardMoreView.native.test.tsx
@@ -1,23 +1,6 @@
 import React from "react";
-import { View } from "react-native";
 import { fireEvent, render, screen } from "@testing-library/react-native";
 import { CardMoreView } from "../CardMoreView.native";
-
-jest.mock("@shared/ui-queued-bottom-sheet", () => ({
-  QueuedBottomSheet: ({
-    children,
-    isRequestingToBeOpened,
-    testID,
-  }: {
-    children: React.ReactNode;
-    isRequestingToBeOpened?: boolean;
-    testID?: string;
-  }) => (
-    <View testID={testID} accessibilityState={{ expanded: !!isRequestingToBeOpened }}>
-      {children}
-    </View>
-  ),
-}));
 
 const defaultProps: React.ComponentProps<typeof CardMoreView> = {
   moreLabel: "More",

--- a/features/flow/pay-contact/src/components/ContactAddressPicker/__tests__/ContactAddressPicker.native.test.tsx
+++ b/features/flow/pay-contact/src/components/ContactAddressPicker/__tests__/ContactAddressPicker.native.test.tsx
@@ -1,23 +1,9 @@
 import React from "react";
-import { View } from "react-native";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react-native";
 import { mockContact, mockContactAddress } from "@domain/entity-contact/schema.mock";
+import { QUEUED_BOTTOM_SHEET_MOCK_TEST_ID } from "@shared/ui-queued-bottom-sheet/testing";
 import { ContactAddressPicker } from "../ContactAddressPicker.native";
 import type { ContactAddressPickerProps } from "../../../types";
-
-jest.mock("@shared/ui-queued-bottom-sheet", () => ({
-  QueuedBottomSheet: ({
-    children,
-    isRequestingToBeOpened,
-  }: {
-    children: React.ReactNode;
-    isRequestingToBeOpened?: boolean;
-  }) => (
-    <View accessibilityState={{ expanded: !!isRequestingToBeOpened }} testID="queued-sheet">
-      {children}
-    </View>
-  ),
-}));
 
 jest.mock("react-native-safe-area-context", () => ({
   useSafeAreaInsets: () => ({ bottom: 0, top: 0, left: 0, right: 0 }),
@@ -89,7 +75,9 @@ describe("ContactAddressPicker (Native)", () => {
   it("keeps the sheet mounted but hides content when closed", () => {
     render(<ContactAddressPicker {...defaultProps} isOpen={false} />);
 
-    expect(screen.getByTestId("queued-sheet").props.accessibilityState.expanded).toBe(false);
+    expect(
+      screen.getByTestId(QUEUED_BOTTOM_SHEET_MOCK_TEST_ID).props.accessibilityState.expanded,
+    ).toBe(false);
     expect(screen.queryByTestId("pay-contact-address-picker")).toBeNull();
   });
 });

--- a/features/flow/pay-deposit/src/components/DepositOptions/__tests__/DepositOptionsView.native.test.tsx
+++ b/features/flow/pay-deposit/src/components/DepositOptions/__tests__/DepositOptionsView.native.test.tsx
@@ -1,23 +1,6 @@
 import React from "react";
-import { View } from "react-native";
 import { cleanup, render, screen, userEvent } from "@testing-library/react-native";
 import { DepositOptionsView } from "../DepositOptionsView.native";
-
-jest.mock("@shared/ui-queued-bottom-sheet", () => ({
-  QueuedBottomSheet: ({
-    children,
-    isRequestingToBeOpened,
-    testID,
-  }: {
-    children: React.ReactNode;
-    isRequestingToBeOpened?: boolean;
-    testID?: string;
-  }) => (
-    <View testID={testID} accessibilityState={{ expanded: !!isRequestingToBeOpened }}>
-      {children}
-    </View>
-  ),
-}));
 
 const defaultProps: React.ComponentProps<typeof DepositOptionsView> = {
   isOpen: true,

--- a/features/flow/pay-feature-tour/src/components/FeatureTour/__tests__/FeatureTour.native.test.tsx
+++ b/features/flow/pay-feature-tour/src/components/FeatureTour/__tests__/FeatureTour.native.test.tsx
@@ -8,10 +8,6 @@ import { I18nTestProvider } from "@shared/i18n/testing";
 import type { FeatureTourProps } from "../types";
 import { FEATURE_TOUR_RESOURCES } from "./fixtures";
 
-jest.mock("@shared/ui-queued-bottom-sheet", () => ({
-  QueuedBottomSheet: ({ children }: { children: React.ReactNode }) => children,
-}));
-
 function makeStore() {
   return configureStore({ reducer: { payCardFeatureTour: payCardFeatureTourSlice.reducer } });
 }

--- a/features/flow/pay-feature-tour/src/components/FeatureTour/__tests__/FeatureTourView.native.test.tsx
+++ b/features/flow/pay-feature-tour/src/components/FeatureTour/__tests__/FeatureTourView.native.test.tsx
@@ -1,23 +1,6 @@
 import React from "react";
-import { View } from "react-native";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react-native";
 import { FeatureTourView } from "../FeatureTourView.native";
-
-jest.mock("@shared/ui-queued-bottom-sheet", () => ({
-  QueuedBottomSheet: ({
-    children,
-    isRequestingToBeOpened,
-    testID,
-  }: {
-    children: React.ReactNode;
-    isRequestingToBeOpened?: boolean;
-    testID?: string;
-  }) => (
-    <View testID={testID} accessibilityState={{ expanded: !!isRequestingToBeOpened }}>
-      {children}
-    </View>
-  ),
-}));
 
 const defaultProps: React.ComponentProps<typeof FeatureTourView> = {
   isVisible: true,

--- a/features/flow/pay-request/src/components/VerifyAddress/__tests__/VerifyAddressIntroView.native.test.tsx
+++ b/features/flow/pay-request/src/components/VerifyAddress/__tests__/VerifyAddressIntroView.native.test.tsx
@@ -1,23 +1,6 @@
 import React from "react";
-import { View } from "react-native";
 import { cleanup, render, screen, userEvent } from "@testing-library/react-native";
 import { VerifyAddressIntroView } from "../VerifyAddressIntroView.native";
-
-jest.mock("@shared/ui-queued-bottom-sheet", () => ({
-  QueuedBottomSheet: ({
-    children,
-    isRequestingToBeOpened,
-    testID,
-  }: {
-    children: React.ReactNode;
-    isRequestingToBeOpened?: boolean;
-    testID?: string;
-  }) => (
-    <View testID={testID} accessibilityState={{ expanded: !!isRequestingToBeOpened }}>
-      {children}
-    </View>
-  ),
-}));
 
 const defaultProps: React.ComponentProps<typeof VerifyAddressIntroView> = {
   isOpen: true,

--- a/features/flow/pay-request/src/components/VerifyAddress/__tests__/VerifyAddressSuccessView.native.test.tsx
+++ b/features/flow/pay-request/src/components/VerifyAddress/__tests__/VerifyAddressSuccessView.native.test.tsx
@@ -1,23 +1,6 @@
 import React from "react";
-import { View } from "react-native";
 import { cleanup, render, screen, userEvent } from "@testing-library/react-native";
 import { VerifyAddressSuccessView } from "../VerifyAddressSuccessView.native";
-
-jest.mock("@shared/ui-queued-bottom-sheet", () => ({
-  QueuedBottomSheet: ({
-    children,
-    isRequestingToBeOpened,
-    testID,
-  }: {
-    children: React.ReactNode;
-    isRequestingToBeOpened?: boolean;
-    testID?: string;
-  }) => (
-    <View testID={testID} accessibilityState={{ expanded: !!isRequestingToBeOpened }}>
-      {children}
-    </View>
-  ),
-}));
 
 const defaultProps: React.ComponentProps<typeof VerifyAddressSuccessView> = {
   isOpen: true,

--- a/shared/ui-queued-bottom-sheet/README.md
+++ b/shared/ui-queued-bottom-sheet/README.md
@@ -15,11 +15,13 @@ src/
   contexts/                   ← public React contexts
   hooks/                      ← public hooks
   internals/                  ← package-private (not re-exported)
+  testing/                    ← test double, exposed as `./testing` (see Testing)
   index.ts                    ← default stub (QueuedBottomSheet throws outside RN)
   index.native.ts             ← RN entry (unsuffixed imports; resolved via moduleSuffixes)
 ```
 
-- `package.json` `exports` expose only `"."` (`react-native` → `index.native.ts`).
+- `package.json` `exports` expose `"."` (`react-native` → `index.native.ts`), `"./testing"` and
+  `"./testing/module-mock"`.
 - RN-only package: `tsconfig.json` is platform-agnostic and `tsconfig.native.json` adds
   `moduleSuffixes: [".native", ""]`. There are no `.web` files or a web tsconfig.
 - Barrels import unsuffixed paths (`./QueuedBottomSheet/QueuedBottomSheet`); `moduleSuffixes`
@@ -69,3 +71,34 @@ import { QueuedBottomSheet } from "@shared/ui-queued-bottom-sheet";
 ```
 
 This package is React Native only. The default (non-`react-native`) export stub throws if `QueuedBottomSheet` is imported outside RN.
+
+## Testing
+
+The real sheet needs the queue and the adapters the app injects at its composition root, so a view
+test can't render it. This package ships the double instead of each consumer hand-rolling one:
+
+| Export                                      | Use                                                                     |
+| ------------------------------------------- | ----------------------------------------------------------------------- |
+| `./testing`                                 | `QueuedBottomSheetMock`, `QUEUED_BOTTOM_SHEET_MOCK_TEST_ID`             |
+| `./testing/module-mock`                     | Drop-in module replacement for a jest `moduleNameMapper`                 |
+
+`features/flow/*` packages get it for free: `@support/jest-features-flow` maps the package to
+`./testing/module-mock` in its native project, so their tests just render the view.
+
+The double renders its children unconditionally — whether content shows while closed is the
+consumer's decision, and the test should be able to assert it. It exposes open state through
+`accessibilityState.expanded` (either `isRequestingToBeOpened` or `isForcingToBeOpened`), fires
+`onOpened` when the sheet becomes open, and wires each close/back callback to a pressable derived
+from the sheet `testID`: `-dismiss` → `onClose`, `-header-close` → `onHeaderClosePressed`,
+`-backdrop` → `onBackdropPress`, `-back` → `onBack`. Sheets that pass no `testID` fall back to
+`QUEUED_BOTTOM_SHEET_MOCK_TEST_ID`.
+
+```tsx
+render(<CardMoreSheet isSheetOpen onClose={onClose} />);
+
+expect(screen.getByTestId("card-more-sheet").props.accessibilityState.expanded).toBe(true);
+fireEvent.press(screen.getByTestId("card-more-sheet-dismiss"));
+```
+
+Only the sheet is replaced. A test that needs `QueuedBottomSheetsProvider`, the adapters or the
+queue hooks — an app-level concern — should `jest.mock` the module itself.

--- a/shared/ui-queued-bottom-sheet/package.json
+++ b/shared/ui-queued-bottom-sheet/package.json
@@ -11,6 +11,8 @@
       "react-native": "./src/index.native.ts",
       "default": "./src/index.ts"
     },
+    "./testing": "./src/testing/index.ts",
+    "./testing/module-mock": "./src/testing/moduleMock.ts",
     "./package.json": "./package.json"
   },
   "sideEffects": false,

--- a/shared/ui-queued-bottom-sheet/src/testing/QueuedBottomSheetMock.native.test.tsx
+++ b/shared/ui-queued-bottom-sheet/src/testing/QueuedBottomSheetMock.native.test.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { Text } from "react-native";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react-native";
+import { QUEUED_BOTTOM_SHEET_MOCK_TEST_ID, QueuedBottomSheetMock } from "./QueuedBottomSheetMock";
+
+afterEach(cleanup);
+
+describe("QueuedBottomSheetMock", () => {
+  it("exposes the open state requested by the consumer", () => {
+    render(
+      <QueuedBottomSheetMock testID="sheet" isRequestingToBeOpened>
+        <Text>content</Text>
+      </QueuedBottomSheetMock>,
+    );
+
+    expect(screen.getByTestId("sheet").props.accessibilityState.expanded).toBe(true);
+  });
+
+  it("reports a force-opened sheet as open too", () => {
+    render(
+      <QueuedBottomSheetMock testID="sheet" isForcingToBeOpened>
+        <Text>content</Text>
+      </QueuedBottomSheetMock>,
+    );
+
+    expect(screen.getByTestId("sheet").props.accessibilityState.expanded).toBe(true);
+  });
+
+  it("keeps the children mounted while closed, so consumers own content visibility", () => {
+    render(
+      <QueuedBottomSheetMock testID="sheet">
+        <Text>content</Text>
+      </QueuedBottomSheetMock>,
+    );
+
+    expect(screen.getByTestId("sheet").props.accessibilityState.expanded).toBe(false);
+    expect(screen.getByText("content")).toBeTruthy();
+  });
+
+  it("falls back to a stable testID when the sheet passes none", () => {
+    render(
+      <QueuedBottomSheetMock>
+        <Text>content</Text>
+      </QueuedBottomSheetMock>,
+    );
+
+    expect(screen.getByTestId(QUEUED_BOTTOM_SHEET_MOCK_TEST_ID)).toBeTruthy();
+  });
+
+  it.each([
+    ["dismiss", "onClose"],
+    ["header-close", "onHeaderClosePressed"],
+    ["backdrop", "onBackdropPress"],
+    ["back", "onBack"],
+  ] as const)("presses %s to call %s", (control, handlerName) => {
+    const handler = jest.fn();
+    render(
+      <QueuedBottomSheetMock testID="sheet" {...{ [handlerName]: handler }}>
+        <Text>content</Text>
+      </QueuedBottomSheetMock>,
+    );
+
+    fireEvent.press(screen.getByTestId(`sheet-${control}`));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders no control for a callback the sheet does not pass", () => {
+    render(
+      <QueuedBottomSheetMock testID="sheet">
+        <Text>content</Text>
+      </QueuedBottomSheetMock>,
+    );
+
+    expect(screen.queryByTestId("sheet-dismiss")).toBeNull();
+  });
+
+  it("calls onOpened once the sheet becomes open", () => {
+    const onOpened = jest.fn();
+    const { rerender } = render(
+      <QueuedBottomSheetMock testID="sheet" onOpened={onOpened}>
+        <Text>content</Text>
+      </QueuedBottomSheetMock>,
+    );
+
+    expect(onOpened).not.toHaveBeenCalled();
+
+    rerender(
+      <QueuedBottomSheetMock testID="sheet" onOpened={onOpened} isRequestingToBeOpened>
+        <Text>content</Text>
+      </QueuedBottomSheetMock>,
+    );
+
+    expect(onOpened).toHaveBeenCalledTimes(1);
+  });
+});

--- a/shared/ui-queued-bottom-sheet/src/testing/QueuedBottomSheetMock.native.tsx
+++ b/shared/ui-queued-bottom-sheet/src/testing/QueuedBottomSheetMock.native.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { Pressable, View } from "react-native";
+import type { QueuedBottomSheetProps } from "../components/QueuedBottomSheet/types";
+
+export const QUEUED_BOTTOM_SHEET_MOCK_TEST_ID = "queued-bottom-sheet";
+
+/**
+ * Test double for `QueuedBottomSheet`, for tests that render a sheet-hosting view without the
+ * queue and adapter providers the real component needs.
+ *
+ * It renders its children unconditionally: whether the content shows while closed is the
+ * consumer's decision, and the test should be able to assert it. Open state is exposed through
+ * `accessibilityState.expanded`, and each close/back/open callback through a pressable derived
+ * from the sheet `testID`:
+ *
+ * - `<testID>-dismiss` → `onClose`
+ * - `<testID>-header-close` → `onHeaderClosePressed`
+ * - `<testID>-backdrop` → `onBackdropPress`
+ * - `<testID>-back` → `onBack`
+ *
+ * `onOpened` fires when the sheet becomes open. Sheets that pass no `testID` fall back to
+ * {@link QUEUED_BOTTOM_SHEET_MOCK_TEST_ID}.
+ */
+export function QueuedBottomSheetMock({
+  children,
+  isRequestingToBeOpened = false,
+  isForcingToBeOpened = false,
+  onClose,
+  onHeaderClosePressed,
+  onBackdropPress,
+  onBack,
+  onOpened,
+  testID = QUEUED_BOTTOM_SHEET_MOCK_TEST_ID,
+}: QueuedBottomSheetProps) {
+  const isOpen = isRequestingToBeOpened || isForcingToBeOpened;
+
+  const onOpenedRef = React.useRef(onOpened);
+  onOpenedRef.current = onOpened;
+
+  React.useEffect(() => {
+    if (isOpen) onOpenedRef.current?.();
+  }, [isOpen]);
+
+  return (
+    <View testID={testID} accessibilityState={{ expanded: isOpen }}>
+      {onClose ? <Pressable testID={`${testID}-dismiss`} onPress={onClose} /> : null}
+      {onHeaderClosePressed ? (
+        <Pressable testID={`${testID}-header-close`} onPress={onHeaderClosePressed} />
+      ) : null}
+      {onBackdropPress ? (
+        <Pressable testID={`${testID}-backdrop`} onPress={onBackdropPress} />
+      ) : null}
+      {onBack ? <Pressable testID={`${testID}-back`} onPress={onBack} /> : null}
+      {children}
+    </View>
+  );
+}

--- a/shared/ui-queued-bottom-sheet/src/testing/index.ts
+++ b/shared/ui-queued-bottom-sheet/src/testing/index.ts
@@ -1,0 +1,1 @@
+export * from "./QueuedBottomSheetMock";

--- a/shared/ui-queued-bottom-sheet/src/testing/moduleMock.ts
+++ b/shared/ui-queued-bottom-sheet/src/testing/moduleMock.ts
@@ -1,0 +1,9 @@
+/**
+ * Drop-in replacement for this package in native tests, for jest configs to point
+ * `@shared/ui-queued-bottom-sheet` at through `moduleNameMapper`. The rename is the point: the
+ * consumer keeps importing `QueuedBottomSheet` and gets the double.
+ *
+ * Only the sheet is replaced. A test that needs `QueuedBottomSheetsProvider`, the adapters or the
+ * queue hooks — an app-level concern — should mock the module itself instead.
+ */
+export { QueuedBottomSheetMock as QueuedBottomSheet } from "./QueuedBottomSheetMock";

--- a/support/jest-features-flow/README.md
+++ b/support/jest-features-flow/README.md
@@ -38,6 +38,15 @@ As a result:
 
 Tests therefore assert on your own layout/view-model wiring, not on real Lumen internals.
 
+## Queued bottom sheet
+
+The Native project maps `@shared/ui-queued-bottom-sheet` to the double that package ships
+(`@shared/ui-queued-bottom-sheet/testing/module-mock`), resolved from the consuming package's own
+dependency on it. Sheet-hosting views therefore render in tests without the queue and adapter
+providers the app supplies, and with no per-test mock. See
+[the package README](../../shared/ui-queued-bottom-sheet/README.md#testing) for the double's
+contract, and `jest.mock` the module in a test that needs the provider or the queue hooks.
+
 ## Web environment polyfills
 
 `setup/web.js` polyfills the Encoding API (`TextEncoder` / `TextDecoder`) on the jsdom global.

--- a/support/jest-features-flow/index.js
+++ b/support/jest-features-flow/index.js
@@ -24,6 +24,7 @@ const nativeMocks = {
   "^@ledgerhq/lumen-ui-rnative(/.*)?$": path.join(__dirname, "mocks/passthrough-native.js"),
   "^@ledgerhq/crypto-icons$": path.join(__dirname, "mocks/passthrough-native.js"),
   "\\.(webp|png|jpg|jpeg|gif|svg)$": path.join(__dirname, "mocks/file-stub.js"),
+  "^@shared/ui-queued-bottom-sheet$": "@shared/ui-queued-bottom-sheet/testing/module-mock",
 };
 
 /**

--- a/support/jest-shared/mocks/react-native.js
+++ b/support/jest-shared/mocks/react-native.js
@@ -8,6 +8,7 @@ module.exports = {
     flatten: style => (Array.isArray(style) ? Object.assign({}, ...style) : style || {}),
   },
   View: "View",
+  Pressable: "Pressable",
   Text: "Text",
   Image: "Image",
   ScrollView: "ScrollView",


### PR DESCRIPTION
### 📝 Description

The real `QueuedBottomSheet` needs the queue and adapters the app injects at composition root, so flow native view tests cannot render it. Each sheet-hosting test was hand-rolling `jest.mock("@shared/ui-queued-bottom-sheet")`.

This ships a package-owned native double (`@shared/ui-queued-bottom-sheet/testing`) and maps `@shared/ui-queued-bottom-sheet` to it in the features/flow native Jest project. Existing sheet tests drop their local mocks. A test that still needs the real provider or queue hooks can `jest.mock` the module to opt out.

Mock contract: children always render; open state is `accessibilityState.expanded`; close/back/open are pressables derived from the sheet `testID` (`-dismiss`, `-header-close`, `-backdrop`, `-back`); `onOpened` fires when the sheet is open.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36959](https://ledgerhq.atlassian.net/browse/LIVE-36959)
- **ADR** (if any): N/A

[LIVE-36959]: https://ledgerhq.atlassian.net/browse/LIVE-36959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ