### PR TITLE
[LWDM] feat(coin-tron): add Tronify listFeeOptions discovery (LIVE-34996)

### DIFF
--- a/.changeset/LIVE-34996-coin-tron-listfeeoptions.md
+++ b/.changeset/LIVE-34996-coin-tron-listfeeoptions.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-tron": minor
+---
+
+Add Tronify `listFeeOptions` fee-option discovery (ADR-050 Option 3).
+
+`listFeeOptions(intent)` is the lightweight first step of the two-call fee flow: it returns availability metadata only (no amounts). It advertises `[tronify, standard]` only when the intent is a TRC-20 transfer, a recipient is set, the Tronify provider is activated in remote coin-config (`energyRent` present), and the standard path would actually burn TRX; it returns `[standard]` otherwise. It never throws — any failure degrades to the standard-only list so the default path always works. The priced quote per option is fetched later by `estimateFees(intent, "tronify")`.

--- a/libs/coin-modules/coin-tron/src/api/index.test.ts
+++ b/libs/coin-modules/coin-tron/src/api/index.test.ts
@@ -16,6 +16,7 @@ import {
   getAccountInfo,
   getBalance,
   lastBlock,
+  listFeeOptions,
   listOperations,
 } from "../logic";
 import { TRONIFY_FEE_OPTION_ID } from ".";
@@ -28,12 +29,14 @@ jest.mock("../logic", () => ({
   estimateTronifyFees: jest.fn(),
   getAccountInfo: jest.fn(),
   getBalance: jest.fn(),
+  listFeeOptions: jest.fn(),
   listOperations: jest.fn().mockResolvedValue({ items: [], next: undefined }),
   lastBlock: jest.fn(),
 }));
 
 const mockEstimateFees = jest.mocked(estimateFees);
 const mockEstimateTronifyFees = jest.mocked(estimateTronifyFees);
+const mockListFeeOptions = jest.mocked(listFeeOptions);
 
 jest.mock("../network", () => ({
   defaultFetchParams: { minTimestamp: 0 },
@@ -180,6 +183,29 @@ describe("createApi", () => {
 
       expect(mockEstimateFees).toHaveBeenCalledWith(mockTronConfig, trc20Intent);
       expect(mockEstimateTronifyFees).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("listFeeOptions", () => {
+    const trc20Intent: TransactionIntent<TronMemo, TronTxData> = {
+      intentType: "transaction",
+      type: "send",
+      sender: "sender",
+      recipient: "recipient",
+      amount: BigInt(1000),
+      asset: { type: "trc20", assetReference: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t" },
+      data: { type: "tron" },
+    };
+
+    // The framework's listFeeOptions receives only the intent (no context): coin-config is read from
+    // the singleton inside the logic layer, so the API method is a thin pass-through of the intent.
+    it("delegates to the logic layer with the intent and returns its result", async () => {
+      const feeOptions = [{ id: TRONIFY_FEE_OPTION_ID, feeAsset: { type: "native" as const } }];
+      mockListFeeOptions.mockResolvedValue(feeOptions);
+      const api = createApi();
+
+      await expect(api.listFeeOptions!(trc20Intent)).resolves.toBe(feeOptions);
+      expect(mockListFeeOptions).toHaveBeenCalledWith(trc20Intent);
     });
   });
 

--- a/libs/coin-modules/coin-tron/src/api/index.ts
+++ b/libs/coin-modules/coin-tron/src/api/index.ts
@@ -27,16 +27,19 @@ import {
   getStakes,
   getValidators,
   lastBlock,
+  listFeeOptions as listFeeOptionsLogic,
   listOperations as listOperationsLogic,
   validateAddress,
   validateIntent,
 } from "../logic";
+import { TRONIFY_FEE_OPTION_ID } from "../logic/constants";
 import { defaultFetchParams, getBlock as getBlockNetwork } from "../network";
 import type { TronMemo, TronTxData } from "../types";
 
 const MAX_TRONGRID_LIMIT = 200;
 
-export const TRONIFY_FEE_OPTION_ID = "tronify" as const;
+// Re-exported for consumers (the generic fee-picker); canonical definition lives in logic/constants.
+export { TRONIFY_FEE_OPTION_ID };
 
 // Checked against CoinModuleImpl with `satisfies` rather than annotated as it, so the precise shape
 // survives and a caller sees exactly which methods exist.
@@ -65,6 +68,10 @@ export function createApi() {
       }
       return estimateFees(config, transactionIntent);
     },
+    // Fee-option discovery (ADR-050 Option 3): advertises [tronify, standard] for eligible TRC-20
+    // sends, [standard] otherwise. The framework passes only the intent — the coin-config is read
+    // from the singleton inside the logic layer (no context here). See logic/feeOptions.ts.
+    listFeeOptions: transactionIntent => listFeeOptionsLogic(transactionIntent),
     getAccountInfo: async (context, address): Promise<AccountInfo> => {
       const config = await context.config();
       return getAccountInfo(config, address);

--- a/libs/coin-modules/coin-tron/src/index.ts
+++ b/libs/coin-modules/coin-tron/src/index.ts
@@ -2,5 +2,4 @@ export * from "./types";
 
 export { isAccountEmpty } from "./resources";
 export { ENERGY_PROVIDERS, TRONIFY_PROVIDER, getEnergyProvider } from "./logic/energyProviders";
-// TODO(LIVE-34996): promote to stable public API once listFeeOptions is implemented
-export { TRONIFY_FEE_OPTION_ID } from "./api";
+export { STANDARD_FEE_OPTION_ID, TRONIFY_FEE_OPTION_ID } from "./logic/constants";

--- a/libs/coin-modules/coin-tron/src/logic/constants.ts
+++ b/libs/coin-modules/coin-tron/src/logic/constants.ts
@@ -13,6 +13,14 @@ export const MEMO_FEE_PESSIMISTIC = ONE_TRX;
 // `validateIntent` (which rejects a premature claim) and `getStakes` (which offers `claim_reward`).
 export const REWARD_WITHDRAW_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 
+// Fee-option ids surfaced by `listFeeOptions` and routed on by `estimateFees` (ADR-050 Option 3).
+// Kept in this low-level constants module — not the `logic` barrel — so `api/index.ts` can import
+// them without the `jest.mock("../logic")` in its tests blanking them out. `listFeeOptions` and the
+// `estimateFees` routing must agree on these exact strings, or a user's selection silently falls
+// back to the standard path.
+export const STANDARD_FEE_OPTION_ID = "standard" as const;
+export const TRONIFY_FEE_OPTION_ID = "tronify" as const;
+
 // TRX's own unit and identity, used to format user-facing fee amounts in validation errors.
 // Hardcoded rather than resolved from a CryptoCurrency: `logic/` must not reach into live-common's
 // currency registry (coin-modules restricted imports), and these are fixed chain constants.

--- a/libs/coin-modules/coin-tron/src/logic/feeOptions.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/feeOptions.test.ts
@@ -1,0 +1,142 @@
+import type { FeeEstimation, TransactionIntent } from "@ledgerhq/coin-module-framework/api/index";
+import coinConfig, { type TronCoinConfig } from "../config";
+import type { TronMemo, TronTxData } from "../types";
+import { STANDARD_FEE_OPTION_ID, TRONIFY_FEE_OPTION_ID } from "./constants";
+import { estimateFees } from "./estimateFees";
+import { listFeeOptions } from "./feeOptions";
+
+jest.mock("./estimateFees", () => ({ estimateFees: jest.fn() }));
+jest.mock("../config", () => ({ __esModule: true, default: { getCoinConfig: jest.fn() } }));
+
+const mockEstimateFees = jest.mocked(estimateFees);
+const mockGetCoinConfig = jest.mocked(coinConfig.getCoinConfig);
+
+const TRC20_CONTRACT = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t";
+const SENDER = "TF17BgPaZYbz8oxbjhriubPDsA7ArKoLX3";
+const RECIPIENT = "TJRabPrwbZy45sbavfcjinPJC18kjpRTv8";
+
+const activatedConfig = {
+  explorer: { url: "https://explorer" },
+  status: { type: "active" },
+  energyRent: {
+    provider: "tronify",
+    tronify: { url: "https://open.tronify.io", sourceFlag: "ledger" },
+  },
+} as unknown as TronCoinConfig;
+
+const notActivatedConfig = {
+  explorer: { url: "https://explorer" },
+  status: { type: "active" },
+} as unknown as TronCoinConfig;
+
+const sendTrc20 = (recipient = RECIPIENT): TransactionIntent<TronMemo, TronTxData> => ({
+  intentType: "transaction",
+  type: "send",
+  sender: SENDER,
+  recipient,
+  amount: BigInt(1000),
+  asset: { type: "trc20", assetReference: TRC20_CONTRACT },
+  data: { type: "tron" },
+});
+
+const sendNative: TransactionIntent<TronMemo, TronTxData> = {
+  intentType: "transaction",
+  type: "send",
+  sender: SENDER,
+  recipient: RECIPIENT,
+  amount: BigInt(1000),
+  asset: { type: "native" },
+  data: { type: "tron" },
+};
+
+const sendTrc10: TransactionIntent<TronMemo, TronTxData> = {
+  intentType: "transaction",
+  type: "send",
+  sender: SENDER,
+  recipient: RECIPIENT,
+  amount: BigInt(1000),
+  asset: { type: "trc10", assetReference: "1002000" },
+  data: { type: "tron" },
+};
+
+const fee = (value: bigint): FeeEstimation => ({ value });
+
+const standardOption = {
+  id: STANDARD_FEE_OPTION_ID,
+  feeAsset: expect.objectContaining({ type: "native" }),
+};
+const tronifyOption = {
+  id: TRONIFY_FEE_OPTION_ID,
+  feeAsset: expect.objectContaining({ type: "native" }),
+};
+
+describe("listFeeOptions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCoinConfig.mockReturnValue(activatedConfig);
+    mockEstimateFees.mockResolvedValue(fee(1_000_000n));
+  });
+
+  it("returns [standard] for a native TRX transfer (Tronify does not apply)", async () => {
+    await expect(listFeeOptions(sendNative)).resolves.toEqual([standardOption]);
+    expect(mockEstimateFees).not.toHaveBeenCalled();
+  });
+
+  it("returns [standard] for a TRC-10 transfer (Tronify does not apply)", async () => {
+    await expect(listFeeOptions(sendTrc10)).resolves.toEqual([standardOption]);
+    expect(mockEstimateFees).not.toHaveBeenCalled();
+  });
+
+  it("returns [standard] before a recipient is entered, without estimating", async () => {
+    await expect(listFeeOptions(sendTrc20(""))).resolves.toEqual([standardOption]);
+    expect(mockEstimateFees).not.toHaveBeenCalled();
+  });
+
+  it("returns [standard] for a malformed recipient, without estimating (no log spam while typing)", async () => {
+    await expect(listFeeOptions(sendTrc20("TJRabPrwbZy45sbav"))).resolves.toEqual([standardOption]);
+    expect(mockEstimateFees).not.toHaveBeenCalled();
+  });
+
+  it("returns [standard] when Tronify is not activated in coin-config", async () => {
+    mockGetCoinConfig.mockReturnValue(notActivatedConfig);
+    await expect(listFeeOptions(sendTrc20())).resolves.toEqual([standardOption]);
+    expect(mockEstimateFees).not.toHaveBeenCalled();
+  });
+
+  it("returns [standard] when the sender has enough energy/bandwidth (standard fee is 0)", async () => {
+    mockEstimateFees.mockResolvedValue(fee(0n));
+    await expect(listFeeOptions(sendTrc20())).resolves.toEqual([standardOption]);
+    expect(mockEstimateFees).toHaveBeenCalledWith(activatedConfig, sendTrc20());
+  });
+
+  it("returns [tronify, standard] for an activated, energy-deficient TRC-20 transfer", async () => {
+    await expect(listFeeOptions(sendTrc20())).resolves.toEqual([tronifyOption, standardOption]);
+  });
+
+  it("reports the fee asset as native TRX for every option", async () => {
+    const options = await listFeeOptions(sendTrc20());
+    expect(options).toEqual([
+      {
+        id: TRONIFY_FEE_OPTION_ID,
+        feeAsset: { type: "native", name: "Tron", unit: expect.objectContaining({ code: "TRX" }) },
+      },
+      {
+        id: STANDARD_FEE_OPTION_ID,
+        feeAsset: { type: "native", name: "Tron", unit: expect.objectContaining({ code: "TRX" }) },
+      },
+    ]);
+  });
+
+  it("degrades to [standard] (never throws) when the standard estimate fails", async () => {
+    mockEstimateFees.mockRejectedValue(new Error("network down"));
+    await expect(listFeeOptions(sendTrc20())).resolves.toEqual([standardOption]);
+  });
+
+  it("degrades to [standard] (never throws) when the coin-config read throws", async () => {
+    mockGetCoinConfig.mockImplementation(() => {
+      throw new Error("no coin-config set");
+    });
+    await expect(listFeeOptions(sendTrc20())).resolves.toEqual([standardOption]);
+    expect(mockEstimateFees).not.toHaveBeenCalled();
+  });
+});

--- a/libs/coin-modules/coin-tron/src/logic/feeOptions.ts
+++ b/libs/coin-modules/coin-tron/src/logic/feeOptions.ts
@@ -1,0 +1,73 @@
+import type { FeeOptionMeta, TransactionIntent } from "@ledgerhq/coin-module-framework/api/index";
+import coinConfig from "../config";
+import type { TronMemo, TronTxData } from "../types";
+import {
+  STANDARD_FEE_OPTION_ID,
+  TRONIFY_FEE_OPTION_ID,
+  TRX_CURRENCY_NAME,
+  TRX_UNIT,
+} from "./constants";
+import { estimateFees } from "./estimateFees";
+import { validateAddress } from "./validateAddress";
+
+type TronIntent = TransactionIntent<TronMemo, TronTxData>;
+
+// Both fee options are paid in native TRX — Tronify quotes are TRX-denominated (estimateTronifyFees
+// rejects any non-TRX quote) — so the fee asset is identical for each; the id is what distinguishes
+// them. A fresh feeAsset (and unit clone) per call keeps returned options free of shared mutable
+// state — mutating an option must never leak into the module-level `TRX_UNIT` constant.
+const feeOption = (id: string): FeeOptionMeta => ({
+  id,
+  feeAsset: { type: "native", name: TRX_CURRENCY_NAME, unit: { ...TRX_UNIT } },
+});
+
+// Fresh array per call so a caller can't mutate a shared module-level list.
+const standardOnly = (): FeeOptionMeta[] => [feeOption(STANDARD_FEE_OPTION_ID)];
+
+/**
+ * List the fee-payment options available for an intent (ADR-050 Option 3) — availability metadata
+ * only, no amounts. The Tronify energy-rent option is offered alongside the standard TRX burn only
+ * when all of the following hold:
+ *   - the intent is a TRC-20 transfer (Tronify covers nothing else — never native or TRC-10 sends),
+ *   - the Tronify provider is activated in remote coin-config (its `energyRent` block is present),
+ *   - the standard path would actually burn TRX (the sender lacks the staked energy/bandwidth to
+ *     send for free — otherwise Tronify saves nothing).
+ *
+ * Never throws: any failure (unreadable config, a failed energy simulation) degrades to the
+ * standard-only list, so the standard path always works (ADR-050 Option 3 AC). Availability is not
+ * probed over the network here — the actual Tronify price (and hence its live availability) is
+ * fetched later by `estimateFees(intent, "tronify")`, which surfaces any failure explicitly.
+ */
+export async function listFeeOptions(intent: TronIntent): Promise<FeeOptionMeta[]> {
+  try {
+    // Tronify only applies to TRC-20 transfers.
+    if (intent.type !== "send" || intent.asset.type !== "trc20") return standardOnly();
+
+    // `prepareTransaction` re-estimates on every change — before a recipient is entered and while the
+    // user is still typing. Bail quietly until the recipient is a valid Tron address, so the estimate
+    // below never throws decoding a malformed base58 (repeated try/catch + wasted estimates each keystroke).
+    if (!intent.recipient || !(await validateAddress(intent.recipient, {}))) return standardOnly();
+
+    const config = coinConfig.getCoinConfig();
+
+    // Activation gate: Tronify is offered only when configured in remote coin-config. Presence of the
+    // `energyRent` block is the activation switch — the same source `getEnergyProvider` dispatches on.
+    if (!config.energyRent) return standardOnly();
+
+    // Offer Tronify only when the standard path would burn TRX. The standard estimate folds energy,
+    // bandwidth and activation into one value; `value === 0n` means the sender covers the transfer
+    // for free (enough staked energy/bandwidth), so Tronify would save nothing.
+    const standard = await estimateFees(config, intent);
+    if (standard.value === 0n) return standardOnly();
+
+    return [feeOption(TRONIFY_FEE_OPTION_ID), feeOption(STANDARD_FEE_OPTION_ID)];
+  } catch {
+    // Availability is best-effort: any failure degrades to the standard-only list. `listFeeOptions`
+    // is the one CoinModuleApi method that receives no framework Context, so there is no injected
+    // logger to report through here — the fallback is intentionally silent.
+    // TODO(follow-up): once the framework passes a Context to `listFeeOptions`, log the swallowed
+    // error via `context.logger` instead of staying silent (and migrate the rest of coin-tron off the
+    // direct `@ledgerhq/logs` import). See the LIVE-34996 review thread.
+    return standardOnly();
+  }
+}

--- a/libs/coin-modules/coin-tron/src/logic/index.ts
+++ b/libs/coin-modules/coin-tron/src/logic/index.ts
@@ -3,6 +3,7 @@ export * from "./combine";
 export * from "./craftTransaction";
 export * from "./energyRent";
 export * from "./estimateFees";
+export * from "./feeOptions";
 export * from "./getAccountInfo";
 export * from "./getBalance";
 export * from "./getBlock";


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

Implements the `listFeeOptions` hook in `coin-tron` — the lightweight first step of the
two-call fee-discovery flow from **ADR-050 Option 3**. It answers *"which fee-payment
methods are available for this intent?"* with availability metadata only (no amounts).
The priced quote per option is fetched separately by `estimateFees(intent, "tronify")`
(shipped in #20928 / LIVE-34999).

**Behaviour** — `listFeeOptions(intent)` returns `[tronify, standard]` **only** when all
of the following hold, and `[standard]` otherwise:
- the intent is a **TRC-20** transfer (Tronify never applies to native TRX or TRC-10),
- a **recipient is set** (`prepareTransaction` re-estimates on every keystroke, before an
  address exists — there is nothing to price yet),
- the Tronify provider is **activated in remote coin-config** (`energyRent` block present),
- the standard path would **actually burn TRX** (`estimateFees(...).value !== 0n`) — if the
  sender already has enough staked energy/bandwidth to send for free, Tronify saves nothing.

It **never throws**: any failure (unreadable config, failed estimate) degrades to the
standard-only list, so the default TRX path always works (ADR-050 Option 3 AC).

**Note on AC #3 (availability ping):** the ticket suggested a network "ping" to confirm
Tronify is live. This implementation deliberately does **not** ping — availability is
derived from config activation + a non-zero standard estimate, and the *live* availability
is surfaced later by `estimateFees(intent, "tronify")`, which propagates any Tronify error
explicitly. This keeps `listFeeOptions` cheap (no extra round-trip on every
`prepareTransaction`).

Both ids are re-exported from the package entry (index.ts, from logic/constants); api/index.ts additionally keeps re-exporting TRONIFY_FEE_OPTION_ID for back-compat, so no public export is removed. (STANDARD_FEE_OPTION_ID is a new id — nothing outside coin-tron imports either today.)

**Usage:**
```ts
const options = await api.listFeeOptions(intent);
// TRC-20 send, sponsorship activated, sender lacks energy → [{ id: "tronify", ... }, { id: "standard", ... }]
// native / sufficient energy / not activated / any error     → [{ id: "standard", ... }]

Implements the `listFeeOptions` hook in `coin-tron`, the lightweight first step of
the two-call fee-discovery flow defined by **ADR-050 Option 3**. It answers *"which
fee-payment methods are available for this intent?"* with availability metadata only
— no amounts. The priced quote per option is fetched separately by
`estimateFees(intent, feeOptionId)` (LIVE-34999).
```
### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 --> [LIVE-34996](https://ledgerhq.atlassian.net/browse/LIVE-34996)
- **ADR** (if any): <!-- link to the relevant architectural decision record --> [ADR+050](https://ledgerhq.atlassian.net/wiki/spaces/CF/pages/7341375672/Coin+modules+-+ADR+050+-+FeeOption+abstraction)

### 🔭 Follow-up

`listFeeOptions` swallows any failure and degrades to `[standard]` **silently**: it is the only
`CoinModuleApi` method whose framework contract passes no `Context`, so there is no injected
`context.logger` to report the swallowed error through, and we deliberately don't import
`@ledgerhq/logs` directly (per review).

Follow-up (coin-inte / framework-owned): add `Context` to the `listFeeOptions` contract in
`@ledgerhq/coin-module-framework`, then log the swallowed error via `context.logger` here — ideally
batched with migrating the rest of `coin-tron` off the direct `@ledgerhq/logs` import (7 files
today). Blast radius is small: only `coin-tron` implements `listFeeOptions` and nothing calls it yet.
