### PR TITLE
[LWDM] fix(coin-evm): drop decommissioned fantom explorer (LIVE-36439)

### DIFF
--- a/.changeset/fantom-explorer-decommissioned.md
+++ b/.changeset/fantom-explorer-decommissioned.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/live-common": patch
+"@domain/entity-currency-crypto": patch
+---
+
+Stop calling the decommissioned Fantom explorer. Fantom Opera migrated to Sonic and its explorer infrastructure is gone: ftmscout.com returns HTTP 522 and ftmscan.com no longer resolves, which made adding a Fantom account fail with "Invalid Response from Fantom explorer".
+
+Fantom now uses `explorer: { type: "none" }`, so accounts sync balances through the still-live RPC node instead of erroring, with an empty operation history. The user-facing explorer links point to the OKX explorer.

--- a/domain/entity/currency-crypto/src/currencies/fantom.ts
+++ b/domain/entity/currency-crypto/src/currencies/fantom.ts
@@ -42,9 +42,9 @@ export const fantom = currency({
   },
   explorerViews: [
     {
-      tx: "https://ftmscan.com/tx/$hash",
-      address: "https://ftmscan.com/address/$address",
-      token: "https://ftmscan.com/token/$contractAddress?a=$address",
+      tx: "https://web3.okx.com/explorer/fantom/tx/$hash",
+      address: "https://web3.okx.com/explorer/fantom/address/$address",
+      token: "https://web3.okx.com/explorer/fantom/token/$contractAddress",
     },
   ],
 });

--- a/libs/ledger-live-common/src/families/evm/config.ts
+++ b/libs/ledger-live-common/src/families/evm/config.ts
@@ -511,8 +511,7 @@ const evmCurrencies: CurrencyLiveConfigDefinition = {
         uri: "https://fantom.coin.ledger.com",
       },
       explorer: {
-        type: "blockscout",
-        uri: "https://ftmscout.com/api",
+        type: "none",
       },
     },
   },


### PR DESCRIPTION
### 📝 Description

Adding a Fantom account failed with `InvalidExplorerResponse: Fantom - LedgerAPI5xx - API HTTP 522 https://ftmscout.com/api?module=account&action=txlist&...`.

**Previous behaviour:** Fantom Opera migrated to Sonic and its explorer infrastructure was decommissioned, so every account discovery call hit a dead host, retried 8 times, then threw. The account could not be added at all.

There is no compatible replacement indexer for chain 250. Verified by hand:

| Endpoint | Result |
| --- | --- |
| `ftmscout.com/api` (previous config) | HTTP 522 |
| `api.ftmscan.com` | connection failure (DNS) |
| `proxyetherscan.api.live.ledger.com/v2/api/250` | `Missing or unsupported chainid` — Etherscan V2 dropped Fantom, its chainlist now only has Sonic |
| `api.routescan.io/v2/network/mainnet/evm/250/etherscan` | `chain not supported` |
| `explorers.api.live.ledger.com/blockchain/v4/ftm` | 404 (Ledger explorer does not index Fantom; `eth` sanity check returns 200) |
| `oklink.com/api/v5/explorer/ftm/api?module=account&action=txlist` | 401 `OK-ACCESS-KEY can not be blank` |
| `web3.okx.com/api/v5/explorer/...` | `50404 URL not found` |

**The fix:** Fantom now uses `explorer: { type: "none" }`, a first-class branch of `EvmConfig["explorer"]` dispatched to the no-explorer adapter, which returns empty operation lists instead of throwing. Accounts are created and balances sync through the RPC node, which is still healthy (`https://fantom.coin.ledger.com` → `eth_chainId` = `0xfa`). Transaction history is empty. This matches the existing `type: "none"` entries for `core`, `arc`, `bitlayer` and `robinhood`, which likewise keep `blockchain_txs` active.

The user-facing `explorerViews` links also pointed at the dead `ftmscan.com` and now target the OKX explorer, whose `tx` / `address` / `token` routes were each verified to return 200. Note that OKX is only usable for the links: `web3.okx.com` serves the web UI and exposes no v5 API, while the API gateway lives on `www.oklink.com` and requires an `OK-ACCESS-KEY` — and `EvmConfig["explorer"]` carries only `{ type, uri, noCache?, maxLimit? }`, with no way to pass an auth header from config.

Two follow-ups worth noting for reviewers:

- **This is hotfixable without a release.** The values in `families/evm/config.ts` are only defaults; `LiveConfig.getValueByKey` deep-merges the remote payload over them via Firebase Remote Config. Pushing a `config_currency_fantom` object with `explorer: { type: "none" }` fixes production users immediately, and this PR just aligns the shipped default.
- **Restoring history is a backend ask.** Once chain 250 is served by a Ledger proxy — added to `proxyetherscan.api.live.ledger.com`, or a new proxy carrying an OKLink key (`proxyblockscout.api.live.ledger.com` already exists for `arc_testnet`, so the pattern is established) — history comes back through a config change alone, with no code change.

**Automated checks:** no test asserted Fantom's explorer config, and none is added here, since this is a data-only config change whose correctness is enforced by the discriminated `explorer` union at compile time (a malformed `none` block fails typecheck via `uri?: never`). Existing suites pass: `evm/config.test.ts` and `a4/config.test.ts` (30 tests), `currency-crypto` (73 tests), plus typecheck on both touched packages.

**QA focus:** adding a Fantom account (the acceptance criterion — the account should be created with a correct balance and an empty operations list, with no `InvalidExplorerResponse` in the logs), and the "view in explorer" links from a Fantom account address and token.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36439](https://ledgerhq.atlassian.net/browse/LIVE-36439)
- **ADR** (if any): n/a

[LIVE-36439]: https://ledgerhq.atlassian.net/browse/LIVE-36439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ