### PR TITLE
feat(pay): show New contacts even when they have no address (LIVE-36371)

### DIFF
--- a/.changeset/quiet-empty-contacts.md
+++ b/.changeset/quiet-empty-contacts.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Open Pay New on the contacts list even when nobody has an address yet.


### PR DESCRIPTION
## Summary
- Pay New always opens the contacts-first Send list
- Contacts with no address stay visible; empty book shows the empty state instead of MAD

## Test plan
- [ ] New with only Me → empty contacts state, not MAD
- [ ] New with contacts that have no address → they appear on the list
- [ ] New with a mix → both listed; pick one with an address still opens MAD