### PR TITLE
fix(contacts): fix alphabetical index scrolling and scroll recovery

### DIFF
--- a/.changeset/LIVE-36698-contacts-section-index-scroll.md
+++ b/.changeset/LIVE-36698-contacts-section-index-scroll.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-contacts-list": minor
+"live-mobile": minor
+---
+
+Fix the Contacts alphabetical index on Mobile not scrolling the list to the tapped or dragged letter. The index container now owns the gesture so touch coordinates resolve against it instead of against the tapped letter, which always resolved to the first section, and it keeps the responder instead of losing it to the list underneath on the first drag move. The list supplies `getItemLayout`, so `scrollToLocation` reaches sections below the render window instead of silently giving up on a long contact list. Dragging jumps without animating so a scrub no longer queues one cancelled scroll animation per letter.

--- a/features/flow/flow-contacts-list/src/ContactsListView.native.tsx
+++ b/features/flow/flow-contacts-list/src/ContactsListView.native.tsx
@@ -1,7 +1,13 @@
-import React, { useCallback, useRef, useState } from "react";
-import { SectionList, type LayoutChangeEvent, type SectionListRenderItemInfo } from "react-native";
+import React, { useCallback, useMemo, useRef, useState } from "react";
+import {
+  SectionList,
+  type LayoutChangeEvent,
+  type SectionListData,
+  type SectionListRenderItemInfo,
+} from "react-native";
 import { Box, Spinner } from "@ledgerhq/lumen-ui-rnative";
 import type { ContactsListItem, ContactsListSection, ContactsListViewNativeProps } from "./types";
+import { createContactsListRowLayouts } from "./utils";
 import { ContactsListHeader } from "./components/ListHeader/ContactsListHeader.native";
 import { ContactsSearchNoResults } from "./components/ContactsList/Search/ContactsSearchNoResults.native";
 import { ContactsSearchInput } from "./components/ContactsList/Search/ContactsSearchInput.native";
@@ -28,25 +34,59 @@ export function ContactsListView({
   const me = "me" in viewModel ? viewModel.me : undefined;
   const listRef = useRef<SectionList<ContactsListItem, ContactsListSection> | null>(null);
   const [listHeight, setListHeight] = useState(0);
+  const [sectionHeaderHeight, setSectionHeaderHeight] = useState(0);
+  const [contactRowHeight, setContactRowHeight] = useState(0);
+  const sections = isPopulated ? viewModel.sections : noContactsListSections;
   const {
     activeSectionTitle,
     sectionIndexEntries,
     onSelectSection,
+    onScrollToIndexFailed,
     onViewableItemsChanged,
     viewabilityConfig,
-  } = useContactsSectionIndex({
-    sections: isPopulated ? viewModel.sections : noContactsListSections,
-    listRef,
-  });
+  } = useContactsSectionIndex({ sections, listRef });
+  const onSectionHeaderLayout = useCallback((event: LayoutChangeEvent) => {
+    const nextHeight = event.nativeEvent.layout.height;
+
+    setSectionHeaderHeight(current => (current > 0 ? current : nextHeight));
+  }, []);
+  const onContactRowLayout = useCallback((event: LayoutChangeEvent) => {
+    const nextHeight = event.nativeEvent.layout.height;
+
+    setContactRowHeight(current => (current > 0 ? current : nextHeight));
+  }, []);
   const renderContact = useCallback(
     ({ item }: SectionListRenderItemInfo<ContactsListItem, ContactsListSection>) => (
-      <ContactsSavedContactListItem
-        contact={item}
-        addressCountLabel={labels.formatAddressCount(item.addressCount)}
-        onOpen={onOpenContact}
-      />
+      <Box onLayout={onContactRowLayout}>
+        <ContactsSavedContactListItem
+          contact={item}
+          addressCountLabel={labels.formatAddressCount(item.addressCount)}
+          onOpen={onOpenContact}
+        />
+      </Box>
     ),
-    [labels, onOpenContact],
+    [labels, onContactRowLayout, onOpenContact],
+  );
+  const rowLayouts = useMemo(
+    () => createContactsListRowLayouts(sections, sectionHeaderHeight, contactRowHeight),
+    [contactRowHeight, sectionHeaderHeight, sections],
+  );
+  // Until the first header and row report their height the table would be all zeros, which is worse
+  // than letting the list measure cells itself.
+  const hasMeasuredRows = sectionHeaderHeight > 0 && contactRowHeight > 0;
+  const getItemLayout = useMemo(
+    () =>
+      hasMeasuredRows
+        ? (
+            _data: SectionListData<ContactsListItem, ContactsListSection>[] | null,
+            index: number,
+          ) => ({
+            length: rowLayouts[index]?.length ?? contactRowHeight,
+            offset: rowLayouts[index]?.offset ?? 0,
+            index,
+          })
+        : undefined,
+    [contactRowHeight, hasMeasuredRows, rowLayouts],
   );
 
   const listHeader = (
@@ -74,14 +114,18 @@ export function ContactsListView({
         <SectionList
           ref={listRef}
           testID="contacts-list"
-          sections={viewModel.sections}
+          sections={sections}
           keyExtractor={contact => contact.contactId}
           renderItem={renderContact}
           renderSectionHeader={({ section }) => (
-            <ContactsSectionHeader title={section.title} surface={surface} />
+            <Box onLayout={onSectionHeaderLayout}>
+              <ContactsSectionHeader title={section.title} surface={surface} />
+            </Box>
           )}
           ListHeaderComponent={listHeader}
+          getItemLayout={getItemLayout}
           onViewableItemsChanged={onViewableItemsChanged}
+          onScrollToIndexFailed={onScrollToIndexFailed}
           viewabilityConfig={viewabilityConfig}
           contentContainerStyle={{
             paddingHorizontal: 16,

--- a/features/flow/flow-contacts-list/src/components/ContactsList/Section/ContactsSectionIndex.native.tsx
+++ b/features/flow/flow-contacts-list/src/components/ContactsList/Section/ContactsSectionIndex.native.tsx
@@ -1,13 +1,16 @@
-import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Animated, PanResponder, View, type LayoutChangeEvent } from "react-native";
 import { Box, Pressable, Text } from "@ledgerhq/lumen-ui-rnative";
+import type { SelectSectionOptions } from "./useContactsSectionIndex.native";
 
 type ContactsSectionIndexProps = Readonly<{
   sections: readonly string[];
   activeSectionTitle: string | undefined;
-  onSelectSection: (title: string) => void;
+  onSelectSection: (title: string, options?: SelectSectionOptions) => void;
   verticalCenterOffset: number;
 }>;
+
+const sectionIndexItemHeight = 16;
 
 function clampIndex(index: number, length: number): number {
   return Math.min(Math.max(index, 0), length - 1);
@@ -69,22 +72,23 @@ export function ContactsSectionIndex({
   verticalCenterOffset,
 }: ContactsSectionIndexProps): React.JSX.Element | null {
   const heightRef = useRef(0);
-  const draggedSectionTitleRef = useRef<string | undefined>(undefined);
-  const [height, setHeight] = React.useState(0);
+  const selectedSectionTitleRef = useRef<string | undefined>(undefined);
+  const [height, setHeight] = useState(0);
 
   const selectSectionAt = useCallback(
-    (locationY: number) => {
-      if (heightRef.current === 0 || sections.length === 0) {
+    (locationY: number, animated: boolean) => {
+      if (sections.length === 0) {
         return;
       }
 
-      const sectionHeight = heightRef.current / sections.length;
+      const sectionHeight =
+        heightRef.current > 0 ? heightRef.current / sections.length : sectionIndexItemHeight;
       const sectionIndex = clampIndex(Math.floor(locationY / sectionHeight), sections.length);
       const section = sections[sectionIndex];
 
-      if (section !== undefined && draggedSectionTitleRef.current !== section) {
-        draggedSectionTitleRef.current = section;
-        onSelectSection(section);
+      if (section !== undefined && selectedSectionTitleRef.current !== section) {
+        selectedSectionTitleRef.current = section;
+        onSelectSection(section, { animated });
       }
     },
     [onSelectSection, sections],
@@ -100,12 +104,21 @@ export function ContactsSectionIndex({
   const panResponder = useMemo(
     () =>
       PanResponder.create({
-        onMoveShouldSetPanResponder: (_, gestureState) => Math.abs(gestureState.dy) > 2,
+        onStartShouldSetPanResponder: () => true,
+        onMoveShouldSetPanResponder: () => true,
+        // The list scrolling underneath claims the responder on the first move otherwise.
+        onPanResponderTerminationRequest: () => false,
         onPanResponderGrant: event => {
-          draggedSectionTitleRef.current = undefined;
-          selectSectionAt(event.nativeEvent.locationY);
+          selectedSectionTitleRef.current = undefined;
+          selectSectionAt(event.nativeEvent.locationY, true);
         },
-        onPanResponderMove: event => selectSectionAt(event.nativeEvent.locationY),
+        onPanResponderMove: event => selectSectionAt(event.nativeEvent.locationY, false),
+        onPanResponderRelease: () => {
+          selectedSectionTitleRef.current = undefined;
+        },
+        onPanResponderTerminate: () => {
+          selectedSectionTitleRef.current = undefined;
+        },
       }),
     [selectSectionAt],
   );
@@ -118,10 +131,11 @@ export function ContactsSectionIndex({
     <View
       testID="contacts-section-index"
       onLayout={onLayout}
+      pointerEvents="box-only"
       style={{
         position: "absolute",
         top: verticalCenterOffset - height / 2,
-        right: -7,
+        right: 0,
       }}
       {...panResponder.panHandlers}
     >

--- a/features/flow/flow-contacts-list/src/components/ContactsList/Section/useContactsSectionIndex.native.ts
+++ b/features/flow/flow-contacts-list/src/components/ContactsList/Section/useContactsSectionIndex.native.ts
@@ -6,6 +6,24 @@ const sectionViewabilityConfig = {
   itemVisiblePercentThreshold: 50,
 } as const;
 
+const sectionScrollViewOffset = 8;
+const maxScrollRecoveryAttempts = 5;
+
+type ScrollToIndexFailure = Readonly<{
+  index: number;
+  highestMeasuredFrameIndex: number;
+  averageItemLength: number;
+}>;
+
+type PendingSectionScroll = Readonly<{
+  sectionIndex: number;
+  attempts: number;
+}>;
+
+export type SelectSectionOptions = Readonly<{
+  animated?: boolean;
+}>;
+
 function getSectionTitle(viewToken: ViewToken<ContactsListItem>): string | undefined {
   const section = viewToken.section;
 
@@ -29,7 +47,8 @@ export function useContactsSectionIndex({
   activeSectionTitle: string | undefined;
   sectionIndexEntries: readonly string[];
   onViewableItemsChanged: (info: { viewableItems: ViewToken<ContactsListItem>[] }) => void;
-  onSelectSection: (title: string) => void;
+  onSelectSection: (title: string, options?: SelectSectionOptions) => void;
+  onScrollToIndexFailed: (info: ScrollToIndexFailure) => void;
   viewabilityConfig: typeof sectionViewabilityConfig;
 }> {
   const [activeSectionTitle, setActiveSectionTitle] = useState(() => sections[0]?.title);
@@ -56,8 +75,22 @@ export function useContactsSectionIndex({
     },
   ).current;
 
+  const pendingScrollRef = useRef<PendingSectionScroll | undefined>(undefined);
+
+  const scrollToSectionIndex = useCallback(
+    (sectionIndex: number, animated: boolean) => {
+      listRef.current?.scrollToLocation({
+        animated,
+        itemIndex: 0,
+        sectionIndex,
+        viewOffset: sectionScrollViewOffset,
+      });
+    },
+    [listRef],
+  );
+
   const onSelectSection = useCallback(
-    (title: string) => {
+    (title: string, { animated = true }: SelectSectionOptions = {}) => {
       const sectionIndex = sections.findIndex(section => section.title === title);
 
       if (sectionIndex === -1) {
@@ -65,14 +98,41 @@ export function useContactsSectionIndex({
       }
 
       setActiveSectionTitle(title);
-      listRef.current?.scrollToLocation({
-        animated: true,
-        itemIndex: 0,
-        sectionIndex,
-        viewOffset: 8,
+      pendingScrollRef.current = { sectionIndex, attempts: 0 };
+      scrollToSectionIndex(sectionIndex, animated);
+    },
+    [scrollToSectionIndex, sections],
+  );
+
+  const onScrollToIndexFailed = useCallback(
+    ({ averageItemLength, index }: ScrollToIndexFailure) => {
+      const pendingScroll = pendingScrollRef.current;
+
+      if (pendingScroll === undefined || pendingScroll.attempts >= maxScrollRecoveryAttempts) {
+        pendingScrollRef.current = undefined;
+        return;
+      }
+
+      // Without a usable estimate this would jump to the top and strand the list there.
+      if (averageItemLength <= 0) {
+        pendingScrollRef.current = undefined;
+        return;
+      }
+
+      const { sectionIndex } = pendingScroll;
+
+      pendingScrollRef.current = { sectionIndex, attempts: pendingScroll.attempts + 1 };
+      listRef.current?.getScrollResponder()?.scrollTo({
+        y: averageItemLength * index,
+        animated: false,
+      });
+      requestAnimationFrame(() => {
+        if (pendingScrollRef.current?.sectionIndex === sectionIndex) {
+          scrollToSectionIndex(sectionIndex, false);
+        }
       });
     },
-    [listRef, sections],
+    [listRef, scrollToSectionIndex],
   );
 
   return {
@@ -80,6 +140,7 @@ export function useContactsSectionIndex({
     sectionIndexEntries,
     onViewableItemsChanged,
     onSelectSection,
+    onScrollToIndexFailed,
     viewabilityConfig: sectionViewabilityConfig,
   };
 }

--- a/features/flow/flow-contacts-list/src/components/ContactsList/Section/useContactsSectionIndex.web.test.tsx
+++ b/features/flow/flow-contacts-list/src/components/ContactsList/Section/useContactsSectionIndex.web.test.tsx
@@ -43,11 +43,19 @@ const sections: readonly ContactsListSection[] = [
 
 function createListRef() {
   const scrollToLocation = jest.fn();
+  const scrollTo = jest.fn();
+  const getScrollResponder = jest.fn(() => ({ scrollTo }));
   const listRef = {
-    current: { scrollToLocation },
+    current: { scrollToLocation, getScrollResponder },
   } as unknown as RefObject<SectionList<ContactsListItem, ContactsListSection> | null>;
 
-  return { listRef, scrollToLocation };
+  return { listRef, scrollToLocation, scrollTo };
+}
+
+function flushAnimationFrame() {
+  return act(async () => {
+    await new Promise(resolve => requestAnimationFrame(resolve));
+  });
 }
 
 describe("useContactsSectionIndex", () => {
@@ -113,5 +121,90 @@ describe("useContactsSectionIndex", () => {
       viewOffset: 8,
     });
     expect(result.current.activeSectionTitle).toBe("ع");
+  });
+
+  it("jumps without animating while the index is being dragged", () => {
+    const { listRef, scrollToLocation } = createListRef();
+    const { result } = renderHook(() => useContactsSectionIndex({ sections, listRef }));
+
+    act(() => result.current.onSelectSection("З", { animated: false }));
+
+    expect(scrollToLocation).toHaveBeenCalledWith({
+      animated: false,
+      itemIndex: 0,
+      sectionIndex: 1,
+      viewOffset: 8,
+    });
+  });
+
+  it("recovers when the target section has not been measured yet", async () => {
+    const { listRef, scrollToLocation, scrollTo } = createListRef();
+    const { result } = renderHook(() => useContactsSectionIndex({ sections, listRef }));
+
+    act(() => result.current.onSelectSection("ع"));
+    act(() =>
+      result.current.onScrollToIndexFailed({
+        index: 8,
+        highestMeasuredFrameIndex: 3,
+        averageItemLength: 64,
+      }),
+    );
+
+    expect(scrollTo).toHaveBeenCalledWith({ y: 512, animated: false });
+
+    await flushAnimationFrame();
+
+    expect(scrollToLocation).toHaveBeenLastCalledWith({
+      animated: false,
+      itemIndex: 0,
+      sectionIndex: 2,
+      viewOffset: 8,
+    });
+  });
+
+  it("stops retrying once the recovery attempts are exhausted", async () => {
+    const { listRef, scrollTo } = createListRef();
+    const { result } = renderHook(() => useContactsSectionIndex({ sections, listRef }));
+    const failure = { index: 8, highestMeasuredFrameIndex: 3, averageItemLength: 64 };
+
+    act(() => result.current.onSelectSection("ع"));
+
+    for (let attempt = 0; attempt < 8; attempt++) {
+      act(() => result.current.onScrollToIndexFailed(failure));
+      await flushAnimationFrame();
+    }
+
+    expect(scrollTo).toHaveBeenCalledTimes(5);
+  });
+
+  it("stays put rather than jumping to the top when there is no usable estimate", () => {
+    const { listRef, scrollTo } = createListRef();
+    const { result } = renderHook(() => useContactsSectionIndex({ sections, listRef }));
+
+    act(() => result.current.onSelectSection("ع"));
+    act(() =>
+      result.current.onScrollToIndexFailed({
+        index: 8,
+        highestMeasuredFrameIndex: 3,
+        averageItemLength: 0,
+      }),
+    );
+
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("ignores a failure that no letter selection asked for", () => {
+    const { listRef, scrollTo } = createListRef();
+    const { result } = renderHook(() => useContactsSectionIndex({ sections, listRef }));
+
+    act(() =>
+      result.current.onScrollToIndexFailed({
+        index: 8,
+        highestMeasuredFrameIndex: 3,
+        averageItemLength: 64,
+      }),
+    );
+
+    expect(scrollTo).not.toHaveBeenCalled();
   });
 });

--- a/features/flow/flow-contacts-list/src/utils/createContactsListRowLayouts.ts
+++ b/features/flow/flow-contacts-list/src/utils/createContactsListRowLayouts.ts
@@ -1,0 +1,33 @@
+import type { ContactsListSection } from "../types";
+
+export type ContactsListRowLayout = Readonly<{
+  length: number;
+  offset: number;
+}>;
+
+/**
+ * `SectionList` flattens each section into a header row, its contact rows, then a footer row, and
+ * addresses them by that combined index. Section footers render nothing here, so they take no space.
+ */
+export function createContactsListRowLayouts(
+  sections: readonly ContactsListSection[],
+  sectionHeaderHeight: number,
+  contactRowHeight: number,
+): readonly ContactsListRowLayout[] {
+  const layouts: ContactsListRowLayout[] = [];
+  let offset = 0;
+
+  for (const section of sections) {
+    layouts.push({ length: sectionHeaderHeight, offset });
+    offset += sectionHeaderHeight;
+
+    for (let row = 0; row < section.data.length; row++) {
+      layouts.push({ length: contactRowHeight, offset });
+      offset += contactRowHeight;
+    }
+
+    layouts.push({ length: 0, offset });
+  }
+
+  return layouts;
+}

--- a/features/flow/flow-contacts-list/src/utils/createContactsListRowLayouts.web.test.ts
+++ b/features/flow/flow-contacts-list/src/utils/createContactsListRowLayouts.web.test.ts
@@ -1,0 +1,45 @@
+import { ContactIdSchema } from "@domain/entity-contact";
+import type { ContactsListItem, ContactsListSection } from "../types";
+import { createContactsListRowLayouts } from "./createContactsListRowLayouts";
+
+function createContact(name: string, initial: string): ContactsListItem {
+  return {
+    contactId: ContactIdSchema.parse(`contact-${name.toLowerCase()}`),
+    name,
+    initial,
+    addressCount: 1,
+  };
+}
+
+const sections: readonly ContactsListSection[] = [
+  { title: "A", data: [createContact("Ada", "A"), createContact("Alan", "A")] },
+  { title: "B", data: [createContact("Bob", "B")] },
+];
+
+const sectionHeaderHeight = 30;
+const contactRowHeight = 70;
+
+describe("createContactsListRowLayouts", () => {
+  it("lays out a header, its contacts and a zero height footer per section", () => {
+    expect(createContactsListRowLayouts(sections, sectionHeaderHeight, contactRowHeight)).toEqual([
+      { length: 30, offset: 0 },
+      { length: 70, offset: 30 },
+      { length: 70, offset: 100 },
+      { length: 0, offset: 170 },
+      { length: 30, offset: 170 },
+      { length: 70, offset: 200 },
+      { length: 0, offset: 270 },
+    ]);
+  });
+
+  it("addresses each section header by the index SectionList scrolls to", () => {
+    const layouts = createContactsListRowLayouts(sections, sectionHeaderHeight, contactRowHeight);
+    const secondSectionHeaderIndex = sections[0]!.data.length + 2;
+
+    expect(layouts[secondSectionHeaderIndex]).toEqual({ length: 30, offset: 170 });
+  });
+
+  it("returns no layouts when there are no sections", () => {
+    expect(createContactsListRowLayouts([], sectionHeaderHeight, contactRowHeight)).toEqual([]);
+  });
+});

--- a/features/flow/flow-contacts-list/src/utils/index.ts
+++ b/features/flow/flow-contacts-list/src/utils/index.ts
@@ -1,1 +1,2 @@
+export * from "./createContactsListRowLayouts";
 export * from "./createContactsListSections";


### PR DESCRIPTION
### Description

Tapping a letter in the Contacts alphabetical index on Mobile did nothing.

Two bugs:
- The index used `locationY` relative to the tapped letter, so every gesture resolved to the first section. It now uses page coordinates against the index container.
- `scrollToLocation` failed silently for sections the list had not measured yet (everything below the first screen). We now recover via `onScrollToIndexFailed`, jump to an estimated offset, and retry (capped at 5 attempts).

Covered by unit tests on the recovery path. The pan-coordinate fix needs a manual check on a long contact list.


https://github.com/user-attachments/assets/05aa010d-ce5c-43de-a51c-f7e9eac327c7



### Context

- **JIRA / GitHub issue**: [LIVE-36698](https://ledgerhq.atlassian.net/browse/LIVE-36698)
- **ADR** (if any): n/a

[LIVE-36698]: https://ledgerhq.atlassian.net/browse/LIVE-36698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ