### PR TITLE
[LWDM] fix(contacts): count feature intro dismissal as seen (LIVE-36870)

### DIFF
--- a/.changeset/LIVE-36870-contacts-feature-intro-dismissal.md
+++ b/.changeset/LIVE-36870-contacts-feature-intro-dismissal.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": patch
+"ledger-live-desktop": patch
+---
+
+Fix the Contacts feature introduction so closing it counts as seen and keeps you on the Contacts list, instead of navigating back and reopening the introduction on the next visit.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -416,6 +416,21 @@ describe("Contacts integration", () => {
     expect(screen.getByTestId("contacts-list")).toBeVisible();
   });
 
+  it("should count closing the feature introduction as seen and keep the Contacts page open", async () => {
+    const { user, store } = renderContactsScreen({
+      settings: { hasDismissedContactsFeatureIntroduction: false },
+    });
+
+    await user.click(screen.getByLabelText("Close"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("contacts-feature-introduction-dialog")).not.toBeInTheDocument();
+    });
+    expect(store.getState().settings.hasDismissedContactsFeatureIntroduction).toBe(true);
+    expect(screen.getByTestId("contacts-list")).toBeVisible();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
   it("should render populated Me detail on load when populated contacts are persisted", () => {
     renderContactsScreen(populatedContactsPageState);
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
 import { getCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router";
 import { urls } from "~/config/urls";
 import { useLocalizedUrl } from "~/renderer/hooks/useLocalizedUrls";
 import { openURL } from "~/renderer/linking";
@@ -77,7 +76,6 @@ export type ContactsPageViewModel = Omit<ContactsViewProps, "onAddContact" | "ad
 export function useContactsViewModel(): ContactsPageViewModel {
   const dispatch = useDispatch();
   const { t } = useTranslation();
-  const navigate = useNavigate();
   const analytics = useContactsAnalytics();
   const { openDrawer } = useActivationDrawer();
   const helpCenterUrl = useLocalizedUrl(urls.helpModal.helpCenter);
@@ -388,10 +386,11 @@ export function useContactsViewModel(): ContactsPageViewModel {
     onSelectContact,
   } = useContactDetailPaneAdapter(onAddAddress, deviceIntents);
   const preference = useContactsFeatureIntroductionPreference();
-  const featureIntroductionState = useContactsFeatureIntroductionState({
-    isContactsEntryAvailable: true,
-    preference,
-  });
+  const { isRequested: isFeatureIntroductionRequested, dismiss: dismissFeatureIntroduction } =
+    useContactsFeatureIntroductionState({
+      isContactsEntryAvailable: true,
+      preference,
+    });
   const labels = useMemo<ContactsListViewLabels>(
     () => ({
       title: t("contacts.title"),
@@ -459,16 +458,10 @@ export function useContactsViewModel(): ContactsPageViewModel {
   }, [dismissPendingIntent, ledgerSyncStatus]);
 
   const isLedgerSyncIntroductionOpen = resolveContactsLedgerSyncIntroductionOpen({
-    isFeatureIntroductionRequested: featureIntroductionState.isRequested,
+    isFeatureIntroductionRequested,
     ledgerSyncStatus,
     isLedgerSyncIntroductionRequested,
   });
-  const onCompleteFeatureIntroduction = useCallback(() => {
-    featureIntroductionState.dismiss();
-  }, [featureIntroductionState]);
-  const onCloseFeatureIntroduction = useCallback(() => {
-    navigate(-1);
-  }, [navigate]);
   const searchHasResults = !("status" in viewModel && viewModel.status === "no-results");
 
   useContactsListPageAnalytics({
@@ -498,12 +491,12 @@ export function useContactsViewModel(): ContactsPageViewModel {
     ledgerSyncStatus,
     dieProps,
     featureIntroduction: {
-      isOpen: featureIntroductionState.isRequested,
+      isOpen: isFeatureIntroductionRequested,
       title: t("contacts.featureIntroduction.title"),
       highlights: featureIntroductionHighlights,
       primaryActionLabel: t("contacts.featureIntroduction.primaryAction"),
-      onComplete: onCompleteFeatureIntroduction,
-      onClose: onCloseFeatureIntroduction,
+      onComplete: dismissFeatureIntroduction,
+      onClose: dismissFeatureIntroduction,
     },
     ledgerSyncIntroduction: {
       isOpen: isLedgerSyncIntroductionOpen,

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/ContactsFeatureIntroduction.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/ContactsFeatureIntroduction.integration.test.tsx
@@ -88,6 +88,28 @@ describe("Contacts feature introduction integration", () => {
     });
   });
 
+  it("should persist dismissal from the sheet header and keep the Contacts page open", async () => {
+    const { user, store } = render(<ContactsFeatureIntroductionTestApp />, {
+      navigationInitialState: contactsNavigationState,
+      overrideInitialState: withFlagOverrides(
+        { lwmContacts: { enabled: true, params: { newBadge: false } } },
+        state => ({
+          ...state,
+          settings: { ...state.settings, hasDismissedContactsFeatureIntroduction: false },
+        }),
+      ),
+    });
+
+    await user.press(screen.getByTestId("bottom-sheet-header-close-button"));
+
+    await waitFor(() => {
+      expect(store.getState().settings.hasDismissedContactsFeatureIntroduction).toBe(true);
+      expect(screen.queryByTestId("contacts-feature-introduction-primary")).toBeNull();
+      expect(screen.getByTestId("contacts-screen")).toBeVisible();
+    });
+    expect(screen.queryByTestId("my-wallet-home")).toBeNull();
+  });
+
   it("should navigate to the introduction from My Wallet when the feature flag is enabled", async () => {
     const { user } = render(<MyWalletNavigator />, {
       overrideInitialState: withFlagOverrides(

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageViewModel.test.ts
@@ -90,14 +90,27 @@ describe("useContactsPageViewModel", () => {
     });
   });
 
-  it("should close the feature introduction by going back", () => {
-    const { result } = renderViewModel();
+  it("should count closing the feature introduction as seen and stay on Contacts", () => {
+    const { result, store } = renderViewModel();
 
     act(() => {
       result.current.featureIntroduction.onClose();
     });
 
-    expect(mockGoBack).toHaveBeenCalledTimes(1);
+    expect(store.getState().settings.hasDismissedContactsFeatureIntroduction).toBe(true);
+    expect(result.current.featureIntroduction.isOpen).toBe(false);
+    expect(mockGoBack).not.toHaveBeenCalled();
+  });
+
+  it("should count completing the feature introduction as seen", () => {
+    const { result, store } = renderViewModel();
+
+    act(() => {
+      result.current.featureIntroduction.onComplete();
+    });
+
+    expect(store.getState().settings.hasDismissedContactsFeatureIntroduction).toBe(true);
+    expect(result.current.featureIntroduction.isOpen).toBe(false);
   });
 
   it("should keep the Ledger Sync introduction closed while no contact is being added", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageViewModel.ts
@@ -58,10 +58,11 @@ export function useContactsPageViewModel(
     [t],
   );
   const preference = useContactsFeatureIntroductionPreference();
-  const featureIntroductionState = useContactsFeatureIntroductionState({
-    isContactsEntryAvailable: true,
-    preference,
-  });
+  const { isRequested: isFeatureIntroductionRequested, dismiss: dismissFeatureIntroduction } =
+    useContactsFeatureIntroductionState({
+      isContactsEntryAvailable: true,
+      preference,
+    });
   const featureIntroductionHighlights = useMemo(
     () =>
       CONTACTS_FEATURE_INTRODUCTION_HIGHLIGHTS.map(({ icon, translationKey }) => ({
@@ -115,12 +116,6 @@ export function useContactsPageViewModel(
     },
     [ledgerSyncStatus, requestMutation],
   );
-  const onCompleteFeatureIntroduction = useCallback(() => {
-    featureIntroductionState.dismiss();
-  }, [featureIntroductionState]);
-  const onCloseFeatureIntroduction = useCallback(() => {
-    navigation.goBack();
-  }, [navigation]);
 
   useEffect(() => {
     if (!isContactsLedgerSyncActivationRequired(ledgerSyncStatus)) {
@@ -129,10 +124,10 @@ export function useContactsPageViewModel(
     }
   }, [dismissPendingIntent, ledgerSyncStatus]);
 
-  const showFeatureIntroduction = !onSelectContact && featureIntroductionState.isRequested;
-  // Pay never shows Introducing Contacts. Until you have seen that sheet on Contacts
-  // (Explore now, or close after LIVE-36870), Add contact here would open nothing if
-  // Ledger Sync is off. Pass the intro you actually see so you still get Sync your wallet.
+  const showFeatureIntroduction = !onSelectContact && isFeatureIntroductionRequested;
+  // Pay never shows Introducing Contacts. Until you have seen that sheet on Contacts,
+  // Add contact here would open nothing if Ledger Sync is off. Pass the intro you
+  // actually see so you still get Sync your wallet.
   const isLedgerSyncIntroductionOpen = resolveContactsLedgerSyncIntroductionOpen({
     isFeatureIntroductionRequested: showFeatureIntroduction,
     ledgerSyncStatus,
@@ -160,8 +155,8 @@ export function useContactsPageViewModel(
       title: t("contacts.featureIntroduction.title"),
       highlights: featureIntroductionHighlights,
       primaryActionLabel: t("contacts.featureIntroduction.primaryAction"),
-      onComplete: onCompleteFeatureIntroduction,
-      onClose: onCloseFeatureIntroduction,
+      onComplete: dismissFeatureIntroduction,
+      onClose: dismissFeatureIntroduction,
     },
     ledgerSyncIntroduction: {
       isOpen: isLedgerSyncIntroductionOpen,


### PR DESCRIPTION
### 📝 Description

Closing the Contacts feature introduction (header X / backdrop) navigated back and did not persist dismissal, so the intro reappeared on the next visit. “Explore now” already persisted it.

Both exits now call `dismiss()`, which sets `hasDismissedContactsFeatureIntroduction` and keeps the user on the Contacts list. Same behaviour as Send recipient.

**Checks**
- Mobile: close via sheet header → preference persisted, Contacts stays open
- Desktop: close via dialog header → preference persisted, list stays open, no `navigate(-1)`

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-36870](https://ledgerhq.atlassian.net/browse/LIVE-36870)
- **ADR** (if any): n/a

[LIVE-36870]: https://ledgerhq.atlassian.net/browse/LIVE-36870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ