### PR TITLE
[LWDM] feat(concordium): estimate PLT fees via tokenUpdate (LIVE-28335)

### DIFF
--- a/.changeset/concordium-plt-fee-estimation.md
+++ b/.changeset/concordium-plt-fee-estimation.md
@@ -1,0 +1,12 @@
+---
+"@ledgerhq/coin-concordium": minor
+---
+
+Estimate PLT transfer fees through the wallet-proxy `tokenUpdate` cost endpoint
+
+`getTransactionCost` is parameterized on transaction type instead of hardcoding
+`simpleTransfer`. PLT preparation encodes the CBOR operations blob first, since
+its byte length is a required cost parameter, then applies a 20% energy buffer
+and persists the result. Signing reads that persisted pair rather than
+re-estimating, so the fee shown in the wallet and the energy in the signed
+header cannot disagree. Native CCD estimation is unchanged.

--- a/libs/coin-modules/coin-concordium/src/bridge/estimateMaxSpendable.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/estimateMaxSpendable.test.ts
@@ -177,4 +177,32 @@ describe("estimateMaxSpendable", () => {
     // THEN
     expect(result).toEqual(new BigNumber(0));
   });
+
+  describe("a failed preparation", () => {
+    // A rejection reaches the consumers as an unhandled one, so resolving is the
+    // contract, not a convenience.
+    it("resolves to zero rather than rejecting", async () => {
+      const { prepareTransaction } = jest.requireMock("./prepareTransaction");
+      prepareTransaction.mockRejectedValueOnce(new Error("proxy down"));
+
+      const result = await estimateMaxSpendable({
+        account: createFixtureAccount(),
+        transaction: null,
+      });
+
+      expect(result).toEqual(new BigNumber(0));
+    });
+
+    it("resolves to zero when the status lookup fails", async () => {
+      const { getTransactionStatus } = jest.requireMock("./getTransactionStatus");
+      getTransactionStatus.mockRejectedValueOnce(new Error("proxy down"));
+
+      const result = await estimateMaxSpendable({
+        account: createFixtureAccount(),
+        transaction: null,
+      });
+
+      expect(result).toEqual(new BigNumber(0));
+    });
+  });
 });

--- a/libs/coin-modules/coin-concordium/src/bridge/estimateMaxSpendable.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/estimateMaxSpendable.ts
@@ -1,4 +1,5 @@
 import BigNumber from "bignumber.js";
+import { log } from "@ledgerhq/logs";
 import type { AccountBridge } from "@ledgerhq/types-live";
 import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account/index";
 import type { Transaction } from "../types";
@@ -13,13 +14,25 @@ export const estimateMaxSpendable: AccountBridge<Transaction>["estimateMaxSpenda
   transaction,
 }) => {
   const mainAccount = getMainAccount(account, parentAccount);
-  const newTransaction = await prepareTransaction(mainAccount, {
-    ...createTransaction(account),
-    ...transaction,
-    // fee estimation might require a recipient to work, in that case, we use a dummy one
-    recipient: transaction?.recipient || CONCORDIUM_DUMMY_ADDRESS,
-    amount: new BigNumber(0),
-  });
-  const status = await getTransactionStatus(mainAccount, newTransaction);
-  return BigNumber.max(0, account.spendableBalance.minus(status.estimatedFees));
+
+  try {
+    const newTransaction = await prepareTransaction(mainAccount, {
+      ...createTransaction(account),
+      ...transaction,
+      // Estimation runs before a recipient is chosen, so substitute a dummy one
+      recipient: transaction?.recipient || CONCORDIUM_DUMMY_ADDRESS,
+      amount: new BigNumber(0),
+    });
+    const status = await getTransactionStatus(mainAccount, newTransaction);
+    return BigNumber.max(0, account.spendableBalance.minus(status.estimatedFees));
+  } catch (error) {
+    // Both callers consume this promise with no rejection handler
+    // (`SpendableAmount.tsx`, `03a-AmountCoin.tsx`), so a throw here surfaces as
+    // an unhandled rejection. The PLT path is the first preparation that can
+    // reject at all, the native estimate having swallowed its own failures.
+    // Zero rather than a partial figure, so a failed estimate can never read as
+    // more spendable than it is.
+    log("concordium", "estimateMaxSpendable failed", { error });
+    return new BigNumber(0);
+  }
 };

--- a/libs/coin-modules/coin-concordium/src/bridge/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/prepareTransaction.test.ts
@@ -1,19 +1,43 @@
 import BigNumber from "bignumber.js";
+import { AccountAddress, encodePltTransferOperations } from "@ledgerhq/concordium-core";
 import {
   createFixtureAccount,
   createFixtureConfig,
+  createFixtureTokenAccount,
+  createFixtureTokenCurrency,
   createFixtureTransaction,
+  PLT_TOKEN_ID,
   setupTestnetCoinConfig,
   VALID_ADDRESS,
+  VALID_ADDRESS_2,
 } from "../test/fixtures";
+import { CONCORDIUM_DUMMY_ADDRESS } from "../constants";
 import { prepareTransaction } from "./prepareTransaction";
 
 jest.mock("../logic", () => ({
   estimateFees: jest.fn(),
+  estimateTokenFees: jest.fn(),
 }));
 
-const { estimateFees } = jest.requireMock("../logic");
+const { estimateFees, estimateTokenFees } = jest.requireMock("../logic");
 const config = createFixtureConfig();
+
+/** The real encoder, so the expected size is derived rather than asserted as a magic number. */
+const blobSize = (recipient: string, amount: number, decimals = 6) =>
+  encodePltTransferOperations({
+    recipient: AccountAddress.fromBase58(recipient),
+    amount: BigInt(amount),
+    decimals,
+  }).length;
+
+const tokenAccountFor = (account: ReturnType<typeof createFixtureAccount>) =>
+  createFixtureTokenAccount({ parentId: account.id });
+
+const withTokenSubAccount = () => {
+  const parent = createFixtureAccount();
+  const subAccount = tokenAccountFor(parent);
+  return { account: { ...parent, subAccounts: [subAccount] }, subAccount };
+};
 
 describe("prepareTransaction", () => {
   beforeEach(() => {
@@ -123,6 +147,146 @@ describe("prepareTransaction", () => {
       expect(result.amount).toEqual(new BigNumber(12345));
       expect(result.recipient).toBe(VALID_ADDRESS);
       expect(result.memo).toBe("preserve me");
+    });
+  });
+
+  describe("PLT transfers", () => {
+    beforeEach(() => {
+      estimateTokenFees.mockResolvedValue({ cost: BigInt(3600), energy: BigInt(1080) });
+    });
+
+    it("prices the token, not the native transfer", async () => {
+      const { account, subAccount } = withTokenSubAccount();
+      const tx = createFixtureTransaction({
+        subAccountId: subAccount.id,
+        recipient: VALID_ADDRESS_2,
+        amount: new BigNumber(1500000),
+      });
+
+      await prepareTransaction(account, tx);
+
+      expect(estimateFees).not.toHaveBeenCalled();
+      expect(estimateTokenFees).toHaveBeenCalledWith(config, account.currency.id, {
+        tokenId: PLT_TOKEN_ID,
+        listOperationsSize: blobSize(VALID_ADDRESS_2, 1500000),
+      });
+    });
+
+    // The proxy prices the id by its byte length, so it must be the on-chain id
+    // and not the CAL token id, which is longer and differently shaped.
+    it("sends the on-chain token id", async () => {
+      const { account, subAccount } = withTokenSubAccount();
+      const tx = createFixtureTransaction({ subAccountId: subAccount.id });
+
+      await prepareTransaction(account, tx);
+
+      const [, , params] = estimateTokenFees.mock.calls[0];
+      expect(params.tokenId).toBe(PLT_TOKEN_ID);
+      expect(params.tokenId).not.toBe(subAccount.token.id);
+    });
+
+    it("persists both halves of the estimate", async () => {
+      const { account, subAccount } = withTokenSubAccount();
+      const tx = createFixtureTransaction({ subAccountId: subAccount.id, fee: new BigNumber(0) });
+
+      const result = await prepareTransaction(account, tx);
+
+      expect(result.fee).toEqual(new BigNumber(3600));
+      expect(result.energy).toBe(1080);
+    });
+
+    it("returns the same transaction when neither half moved", async () => {
+      const { account, subAccount } = withTokenSubAccount();
+      const tx = createFixtureTransaction({
+        subAccountId: subAccount.id,
+        fee: new BigNumber(3600),
+        energy: 1080,
+      });
+
+      expect(await prepareTransaction(account, tx)).toBe(tx);
+    });
+
+    // A fee that rounds to the same microCCD while the energy moves would be
+    // discarded as unchanged if only the fee were compared, leaving the signed
+    // header behind the estimate.
+    it("re-persists when only the energy moved", async () => {
+      const { account, subAccount } = withTokenSubAccount();
+      const tx = createFixtureTransaction({
+        subAccountId: subAccount.id,
+        fee: new BigNumber(3600),
+        energy: 999,
+      });
+
+      const result = await prepareTransaction(account, tx);
+
+      expect(result).not.toBe(tx);
+      expect(result.energy).toBe(1080);
+    });
+
+    it("estimates against the dummy address while the recipient is unparseable", async () => {
+      const { account, subAccount } = withTokenSubAccount();
+      const tx = createFixtureTransaction({
+        subAccountId: subAccount.id,
+        recipient: "3kBx2h5Y",
+        amount: new BigNumber(1500000),
+      });
+
+      await expect(prepareTransaction(account, tx)).resolves.toBeDefined();
+      expect(estimateTokenFees).toHaveBeenCalledWith(config, account.currency.id, {
+        tokenId: PLT_TOKEN_ID,
+        listOperationsSize: blobSize(CONCORDIUM_DUMMY_ADDRESS, 1500000),
+      });
+    });
+
+    // Every Concordium address is 32 bytes, so substituting one changes nothing
+    // the fee depends on.
+    it("prices the dummy and the real recipient identically", async () => {
+      expect(blobSize(CONCORDIUM_DUMMY_ADDRESS, 1500000)).toBe(blobSize(VALID_ADDRESS_2, 1500000));
+    });
+
+    it("leaves the transaction alone when the token has no magnitude", async () => {
+      const parent = createFixtureAccount();
+      const subAccount = createFixtureTokenAccount({
+        parentId: parent.id,
+        token: createFixtureTokenCurrency({ units: [] }),
+      });
+      const account = { ...parent, subAccounts: [subAccount] };
+      const tx = createFixtureTransaction({ subAccountId: subAccount.id });
+
+      expect(await prepareTransaction(account, tx)).toBe(tx);
+      expect(estimateTokenFees).not.toHaveBeenCalled();
+    });
+
+    // Switching from the token back to CCD reaches this branch with the token's
+    // energy still attached.
+    it("drops a stale energy when the native path re-prices", async () => {
+      const account = createFixtureAccount();
+      const tx = createFixtureTransaction({ fee: null, energy: 1080 });
+
+      const result = await prepareTransaction(account, tx);
+
+      expect(result).not.toHaveProperty("energy");
+      expect(result.fee).toEqual(new BigNumber(500));
+    });
+
+    it("drops a stale energy even when the native fee is unchanged", async () => {
+      const account = createFixtureAccount();
+      const tx = createFixtureTransaction({ fee: new BigNumber(500), energy: 1080 });
+
+      const result = await prepareTransaction(account, tx);
+
+      expect(result).not.toBe(tx);
+      expect(result).not.toHaveProperty("energy");
+    });
+
+    it("stays on the native path when no sub-account is selected", async () => {
+      const { account } = withTokenSubAccount();
+      const tx = createFixtureTransaction();
+
+      await prepareTransaction(account, tx);
+
+      expect(estimateTokenFees).not.toHaveBeenCalled();
+      expect(estimateFees).toHaveBeenCalled();
     });
   });
 });

--- a/libs/coin-modules/coin-concordium/src/bridge/prepareTransaction.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/prepareTransaction.ts
@@ -1,19 +1,95 @@
-import type { AccountBridge } from "@ledgerhq/types-live";
+import type { AccountBridge, TokenAccount } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
-import type { Transaction } from "../types";
-import { estimateFees } from "../logic";
+import { findSubAccountById } from "@ledgerhq/ledger-wallet-framework/account/helpers";
+import { AccountAddress, encodePltTransferOperations } from "@ledgerhq/concordium-core";
+import type { ConcordiumCoinConfig, Transaction } from "../types";
+import { estimateFees, estimateTokenFees } from "../logic";
+import type { FeeEstimation } from "../logic/transaction/estimateFees";
+import { CONCORDIUM_DUMMY_ADDRESS } from "../constants";
 import coinConfig from "../config";
+
+/**
+ * Parses the recipient, falling back to the dummy address.
+ *
+ * A parse failure is the common case, not an error: the recipient is still
+ * being typed. Substituting is exact rather than approximate, because every
+ * Concordium address encodes to the same 32 bytes and the blob's length is all
+ * the fee depends on.
+ */
+function recipientForEstimation(recipient: string): AccountAddress {
+  try {
+    return AccountAddress.fromBase58(recipient);
+  } catch {
+    return AccountAddress.fromBase58(CONCORDIUM_DUMMY_ADDRESS);
+  }
+}
+
+/**
+ * Estimates a PLT transfer fee, encoding the operations blob first.
+ *
+ * The order is the reverse of the CCD path's because `listOperationsSize` is the
+ * blob's byte length, so the payload has to exist before it can be priced.
+ *
+ * Resolves to `undefined` when the token's magnitude is missing. Sync only
+ * builds a sub-account whose CAL magnitude matches the chain's decimals, so
+ * this should not occur; leaving the fee unset is still preferable to pricing a
+ * blob encoded with a guessed exponent, which the chain would reject outright.
+ */
+async function estimatePltFees(
+  config: ConcordiumCoinConfig,
+  currencyId: string,
+  subAccount: TokenAccount,
+  transaction: Transaction,
+): Promise<FeeEstimation | undefined> {
+  const decimals = subAccount.token.units[0]?.magnitude;
+  if (decimals === undefined) return undefined;
+
+  const operations = encodePltTransferOperations({
+    recipient: recipientForEstimation(transaction.recipient),
+    amount: BigInt(transaction.amount.toFixed(0)),
+    decimals,
+  });
+
+  return estimateTokenFees(config, currencyId, {
+    tokenId: subAccount.token.contractAddress,
+    listOperationsSize: operations.length,
+  });
+}
 
 export const prepareTransaction: AccountBridge<Transaction>["prepareTransaction"] = async (
   account,
   transaction,
 ) => {
   const config = coinConfig.getCoinConfig(account.currency.id);
-  const estimation = await estimateFees(config, account.currency.id, transaction.memo);
+  const subAccount = findSubAccountById(account, transaction.subAccountId ?? "");
 
-  if (!transaction.fee?.isEqualTo(new BigNumber(estimation.cost.toString()))) {
-    return { ...transaction, fee: new BigNumber(estimation.cost.toString()) };
+  if (subAccount?.type === "TokenAccount") {
+    const estimation = await estimatePltFees(config, account.currency.id, subAccount, transaction);
+    if (!estimation) return transaction;
+
+    const fee = new BigNumber(estimation.cost.toString());
+    const energy = Number(estimation.energy);
+
+    // Both are compared, so that a re-estimate which moves only the energy is
+    // still persisted rather than discarded as unchanged.
+    if (transaction.fee?.isEqualTo(fee) && transaction.energy === energy) {
+      return transaction;
+    }
+
+    return { ...transaction, fee, energy };
   }
 
-  return transaction;
+  const estimation = await estimateFees(config, account.currency.id, transaction.memo);
+  const fee = new BigNumber(estimation.cost.toString());
+
+  // Only the PLT path persists `energy`, so one arriving here belonged to a
+  // token transfer the account has since moved away from. `updateTransaction`
+  // resets `fee` on every patch but carries `energy` across, so it is dropped
+  // here rather than left for signing to pair with a native fee.
+  if (transaction.fee?.isEqualTo(fee) && transaction.energy === undefined) {
+    return transaction;
+  }
+
+  const { energy: _stale, ...withoutEnergy } = transaction;
+  return { ...withoutEnergy, fee };
 };

--- a/libs/coin-modules/coin-concordium/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/signOperation.test.ts
@@ -488,32 +488,18 @@ describe("signOperation", () => {
     it("does not re-estimate when preparation persisted the energy", async () => {
       const { account, transaction } = tokenTransaction();
 
-      await sign(transaction, account);
+      await expect(sign(transaction, account)).rejects.toThrow();
 
       expect(estimateFees).not.toHaveBeenCalled();
     });
 
-    it("crafts with the persisted pair, not a fresh estimate", async () => {
+    // Reaching the device at all is the defect here: a completed signature would
+    // be a CCD transfer. Flipped back by LIVE-28337.
+    it("refuses to sign a token transfer, rather than signing a native one", async () => {
       const { account, transaction } = tokenTransaction();
 
-      await sign(transaction, account);
-
-      expect(craftTransaction).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({ fee: new BigNumber(3600), energy: BigInt(1080) }),
-      );
-    });
-
-    it("signs against the persisted cost", async () => {
-      const { account, transaction } = tokenTransaction();
-
-      const { mockSigner } = await sign(transaction, account);
-
-      expect(mockSigner.signTransaction).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.any(String),
-        BigInt(3600),
-      );
+      await expect(sign(transaction, account)).rejects.toThrow(/not supported yet/);
+      expect(craftTransaction).not.toHaveBeenCalled();
     });
 
     it("keeps estimating for a native transfer", async () => {

--- a/libs/coin-modules/coin-concordium/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/signOperation.test.ts
@@ -4,6 +4,7 @@ import { firstValueFrom, toArray } from "rxjs";
 import { AccountAddress } from "@ledgerhq/concordium-core";
 import {
   createFixtureAccount,
+  createFixtureTokenAccount,
   createFixtureTransaction,
   createFixtureOperation,
   setupTestnetCoinConfig,
@@ -42,6 +43,25 @@ jest.mock("./getTransactionStatus", () => ({
     totalSpent: new BigNumber(5001000),
   }),
 }));
+
+const sign = async (
+  transaction: ReturnType<typeof createFixtureTransaction>,
+  account: ReturnType<typeof createFixtureAccount> = createFixtureAccount(),
+) => {
+  const mockSigner = createFixtureSigner();
+  const signOperation = buildSignOperation(createFixtureSignerContext(mockSigner));
+  const events = await firstValueFrom(
+    signOperation({ account, deviceId: "device-1", transaction }).pipe(toArray()),
+  );
+  return { mockSigner, events };
+};
+
+/** A parent carrying its PLT sub-account, which is what marks a transfer as a token send. */
+const withTokenSubAccount = () => {
+  const parent = createFixtureAccount();
+  const subAccount = createFixtureTokenAccount({ parentId: parent.id });
+  return { account: { ...parent, subAccounts: [subAccount] }, subAccount };
+};
 
 describe("signOperation", () => {
   beforeEach(() => {
@@ -446,6 +466,100 @@ describe("signOperation", () => {
       // THEN
       expect(signedEvent.signedOperation.operation.id).toContain("concordium:test-account");
       expect(signedEvent.signedOperation.operation.id).toContain("OUT");
+    });
+  });
+
+  describe("the persisted estimate", () => {
+    const { craftTransaction, estimateFees } = jest.requireMock("../logic");
+
+    const tokenTransaction = (over = {}) => {
+      const { account, subAccount } = withTokenSubAccount();
+      const transaction = createFixtureTransaction({
+        subAccountId: subAccount.id,
+        fee: new BigNumber(3600),
+        energy: 1080,
+        ...over,
+      });
+      return { account, transaction };
+    };
+
+    // A second estimate would put a different number on the device's "Max fees"
+    // step from the one the wallet showed.
+    it("does not re-estimate when preparation persisted the energy", async () => {
+      const { account, transaction } = tokenTransaction();
+
+      await sign(transaction, account);
+
+      expect(estimateFees).not.toHaveBeenCalled();
+    });
+
+    it("crafts with the persisted pair, not a fresh estimate", async () => {
+      const { account, transaction } = tokenTransaction();
+
+      await sign(transaction, account);
+
+      expect(craftTransaction).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ fee: new BigNumber(3600), energy: BigInt(1080) }),
+      );
+    });
+
+    it("signs against the persisted cost", async () => {
+      const { account, transaction } = tokenTransaction();
+
+      const { mockSigner } = await sign(transaction, account);
+
+      expect(mockSigner.signTransaction).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(String),
+        BigInt(3600),
+      );
+    });
+
+    it("keeps estimating for a native transfer", async () => {
+      await sign(createFixtureTransaction({ fee: new BigNumber(1000) }));
+
+      expect(estimateFees).toHaveBeenCalled();
+      expect(craftTransaction).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ energy: BigInt(501) }),
+      );
+    });
+
+    // A draft that was a token transfer can arrive native with the token's
+    // energy still attached, via a raw round-trip or an account change.
+    it("ignores a stale energy on a native transfer", async () => {
+      await sign(createFixtureTransaction({ fee: new BigNumber(1000), energy: 1080 }));
+
+      expect(estimateFees).toHaveBeenCalled();
+      expect(craftTransaction).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ energy: BigInt(501) }),
+      );
+    });
+
+    it("ignores a stale energy when the sub-account is not a token account", async () => {
+      await sign(
+        createFixtureTransaction({
+          subAccountId: "js:2:concordium_testnet:nope:",
+          fee: new BigNumber(1000),
+          energy: 1080,
+        }),
+      );
+
+      expect(estimateFees).toHaveBeenCalled();
+    });
+
+    // The energy half of the pair is missing, so the fee on screen has no
+    // matching limit to sign; preparation could not have produced this.
+    it("refuses a token transfer with no persisted energy", async () => {
+      const { account, subAccount } = withTokenSubAccount();
+      const transaction = createFixtureTransaction({
+        subAccountId: subAccount.id,
+        fee: new BigNumber(3600),
+      });
+
+      await expect(sign(transaction, account)).rejects.toThrow(FeeNotLoaded);
     });
   });
 });

--- a/libs/coin-modules/coin-concordium/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/signOperation.ts
@@ -1,4 +1,5 @@
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
+import { findSubAccountById } from "@ledgerhq/ledger-wallet-framework/account/helpers";
 import type { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import type { AccountBridge, Operation } from "@ledgerhq/types-live";
@@ -31,7 +32,21 @@ export const buildSignOperation =
           account.currency.id,
         );
 
-        const estimation = await estimateFees(config, account.currency.id, transaction.memo);
+        // The fee shown in the wallet and the energy in the signed header must
+        // be two halves of one estimate, or the device's "Max fees" step
+        // contradicts the figure the user already approved. The discriminator is
+        // the selected sub-account, not a present `energy`: that field outlives
+        // any token selection, so reading it alone would declare a token energy
+        // limit on a native transfer.
+        const isTokenTransfer =
+          findSubAccountById(account, transaction.subAccountId ?? "")?.type === "TokenAccount";
+
+        if (isTokenTransfer && transaction.energy === undefined) throw new FeeNotLoaded();
+
+        const estimation =
+          isTokenTransfer && transaction.energy !== undefined
+            ? { cost: BigInt(fee.toString()), energy: BigInt(transaction.energy) }
+            : await estimateFees(config, account.currency.id, transaction.memo);
 
         const signature = await signerContext(deviceId, async signer => {
           const { freshAddressPath: derivationPath } = account;

--- a/libs/coin-modules/coin-concordium/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/signOperation.ts
@@ -4,6 +4,7 @@ import type { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import type { AccountBridge, Operation } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
+import invariant from "invariant";
 import { Observable } from "rxjs";
 import type { ConcordiumSigner, Transaction } from "../types";
 import { combine, craftTransaction, estimateFees, getNextValidSequence } from "../logic";
@@ -47,6 +48,14 @@ export const buildSignOperation =
           isTokenTransfer && transaction.energy !== undefined
             ? { cost: BigInt(fee.toString()), energy: BigInt(transaction.energy) }
             : await estimateFees(config, account.currency.id, transaction.memo);
+
+        // `craftTransaction` emits a native transfer whatever it is handed, so a
+        // token send would move CCD at the token's integer amount — the wrong
+        // asset, at a magnitude the token's decimals chose. The api layer refuses
+        // a PLT intent for this reason (`assertNativeAsset`); the bridge had no
+        // equivalent. Removed by LIVE-28337, which crafts the `TokenUpdate`
+        // payload.
+        invariant(!isTokenTransfer, "concordium: signing a PLT transfer is not supported yet");
 
         const signature = await signerContext(deviceId, async signer => {
           const { freshAddressPath: derivationPath } = account;

--- a/libs/coin-modules/coin-concordium/src/constants.ts
+++ b/libs/coin-modules/coin-concordium/src/constants.ts
@@ -31,3 +31,15 @@ export const CONCORDIUM_ENERGY = {
   /** Default fallback cost in microCCD when estimation fails */
   DEFAULT_COST: BigInt(1000000),
 } as const;
+
+/**
+ * Buffer added to a PLT fee estimate, as a percentage of the proxy's figure.
+ *
+ * Energy is a ceiling, not a charge: the chain bills actual execution, so the
+ * buffer costs the user nothing while absorbing any drift between preparing the
+ * transaction and submitting it.
+ *
+ * A percentage rather than a float multiplier because energy and cost are both
+ * bigints, and a float would need rounding rules of its own.
+ */
+export const PLT_ENERGY_BUFFER_PERCENT = BigInt(20);

--- a/libs/coin-modules/coin-concordium/src/logic/index.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/index.ts
@@ -2,7 +2,7 @@ export { broadcast } from "./transaction/broadcast";
 export { combine } from "./transaction/combine";
 export { craftTransaction } from "./transaction/craftTransaction";
 export { craftRawTransaction } from "./transaction/craftRawTransaction";
-export { estimateFees } from "./transaction/estimateFees";
+export { estimateFees, estimateTokenFees } from "./transaction/estimateFees";
 export { getBalance } from "./account/getBalance";
 export { lastBlock } from "./history/lastBlock";
 export { getBlock } from "./history/getBlock";

--- a/libs/coin-modules/coin-concordium/src/logic/transaction/estimateFees.test.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/transaction/estimateFees.test.ts
@@ -1,0 +1,136 @@
+import { createFixtureConfig } from "../../test/fixtures";
+import { CONCORDIUM_ENERGY } from "../../constants";
+import { applyEnergyBuffer, estimateFees, estimateTokenFees } from "./estimateFees";
+
+jest.mock("../../network/proxyClient", () => ({
+  getTransactionCost: jest.fn(),
+}));
+
+const { getTransactionCost } = jest.requireMock("../../network/proxyClient");
+
+const config = createFixtureConfig();
+const CURRENCY_ID = "concordium_testnet";
+
+describe("applyEnergyBuffer", () => {
+  it("adds 20 percent", () => {
+    expect(applyEnergyBuffer(BigInt(100))).toBe(BigInt(120));
+    expect(applyEnergyBuffer(BigInt(1000))).toBe(BigInt(1200));
+  });
+
+  // Truncating would hand back the input unchanged for a small enough estimate,
+  // which is a buffer in name only.
+  it("rounds up rather than truncating", () => {
+    expect(applyEnergyBuffer(BigInt(1))).toBe(BigInt(2));
+    expect(applyEnergyBuffer(BigInt(501))).toBe(BigInt(602));
+  });
+
+  it("leaves zero at zero", () => {
+    expect(applyEnergyBuffer(BigInt(0))).toBe(BigInt(0));
+  });
+});
+
+describe("estimateFees", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("prices a simpleTransfer and does not buffer it", async () => {
+    getTransactionCost.mockResolvedValue({ cost: "1000", energy: 501 });
+
+    const result = await estimateFees(config, CURRENCY_ID);
+
+    expect(getTransactionCost).toHaveBeenCalledWith(config, CURRENCY_ID, {
+      type: "simpleTransfer",
+      numSignatures: 1,
+    });
+    expect(result).toEqual({ cost: BigInt(1000), energy: BigInt(501) });
+  });
+
+  // The size is the CBOR-encoded length, not the string length: the proxy
+  // charges for the bytes that reach the chain.
+  it("passes the encoded memo size", async () => {
+    getTransactionCost.mockResolvedValue({ cost: "1200", energy: 520 });
+
+    await estimateFees(config, CURRENCY_ID, "test");
+
+    expect(getTransactionCost).toHaveBeenCalledWith(config, CURRENCY_ID, {
+      type: "simpleTransfer",
+      numSignatures: 1,
+      memoSize: 5,
+    });
+  });
+
+  it("pins a simple transfer to the documented fixed energy", async () => {
+    getTransactionCost.mockResolvedValue({ cost: "1000000", energy: "501" });
+
+    const result = await estimateFees(config, CURRENCY_ID);
+
+    expect(result.energy).toBe(CONCORDIUM_ENERGY.SIMPLE_TRANSFER);
+  });
+
+  it("falls back to the fixed energy when the proxy fails", async () => {
+    getTransactionCost.mockRejectedValue(new Error("proxy down"));
+
+    await expect(estimateFees(config, CURRENCY_ID)).resolves.toEqual({
+      cost: CONCORDIUM_ENERGY.DEFAULT_COST,
+      energy: CONCORDIUM_ENERGY.DEFAULT,
+    });
+  });
+
+  it("falls back to the memo ceiling when the proxy fails on a memo transfer", async () => {
+    getTransactionCost.mockRejectedValue(new Error("proxy down"));
+
+    await expect(estimateFees(config, CURRENCY_ID, "hello")).resolves.toEqual({
+      cost: CONCORDIUM_ENERGY.DEFAULT_COST,
+      energy: CONCORDIUM_ENERGY.TRANSFER_WITH_MEMO_MAX,
+    });
+  });
+});
+
+describe("estimateTokenFees", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("prices a tokenUpdate for a single transfer", async () => {
+    getTransactionCost.mockResolvedValue({ cost: "3000", energy: 900 });
+
+    await estimateTokenFees(config, CURRENCY_ID, { tokenId: "t-USDT", listOperationsSize: 42 });
+
+    expect(getTransactionCost).toHaveBeenCalledWith(config, CURRENCY_ID, {
+      type: "tokenUpdate",
+      numSignatures: 1,
+      tokenId: "t-USDT",
+      listOperationsSize: 42,
+      tokenOperationTypeCount: { transfer: 1 },
+    });
+  });
+
+  // Both halves carry the buffer, or the fee shown and the energy signed drift
+  // apart and the device contradicts the wallet.
+  it("buffers cost and energy alike", async () => {
+    getTransactionCost.mockResolvedValue({ cost: "3000", energy: 900 });
+
+    const result = await estimateTokenFees(config, CURRENCY_ID, {
+      tokenId: "t-USDT",
+      listOperationsSize: 42,
+    });
+
+    expect(result).toEqual({ cost: BigInt(3600), energy: BigInt(1080) });
+  });
+
+  // There is no constant to substitute: the fee depends on the id's length and
+  // the blob's size.
+  it("rejects instead of fabricating a fallback", async () => {
+    getTransactionCost.mockRejectedValue(new Error("proxy down"));
+
+    await expect(
+      estimateTokenFees(config, CURRENCY_ID, { tokenId: "t-USDT", listOperationsSize: 42 }),
+    ).rejects.toThrow("proxy down");
+  });
+
+  it("never asks the proxy to price an operation it cannot price", async () => {
+    getTransactionCost.mockResolvedValue({ cost: "3000", energy: 900 });
+
+    await estimateTokenFees(config, CURRENCY_ID, { tokenId: "t-USDT", listOperationsSize: 42 });
+
+    const [, , params] = getTransactionCost.mock.calls[0];
+    expect(Object.keys(params.tokenOperationTypeCount)).toEqual(["transfer"]);
+  });
+});

--- a/libs/coin-modules/coin-concordium/src/logic/transaction/estimateFees.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/transaction/estimateFees.ts
@@ -61,10 +61,11 @@ export async function estimateFees(
  * the token id's length and the blob's size, so there is no constant to
  * substitute.
  *
- * The rejection propagates through `prepareTransaction`, which the send flow
- * surfaces and retries with backoff. Catching it to leave the fee unset defeats
- * that retry, and a cleared fee reads as a blocking validation error rather than
- * a pending one — a user who stopped typing during a proxy blip would stay stuck.
+ * The rejection propagates through `prepareTransaction`. The send flow retries
+ * that with backoff, so catching it to leave the fee unset would defeat the
+ * retry, and a cleared fee reads as a blocking validation error rather than a
+ * pending one. `estimateMaxSpendable` is the other caller and has no such retry,
+ * so it catches on its own behalf.
  */
 export async function estimateTokenFees(
   config: ConcordiumCoinConfig,

--- a/libs/coin-modules/coin-concordium/src/logic/transaction/estimateFees.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/transaction/estimateFees.ts
@@ -1,12 +1,30 @@
 import { log } from "@ledgerhq/logs";
 import { memoEncodedSize } from "@ledgerhq/concordium-core";
-import { CONCORDIUM_ENERGY } from "../../constants";
+import { CONCORDIUM_ENERGY, PLT_ENERGY_BUFFER_PERCENT } from "../../constants";
 import { getTransactionCost } from "../../network/proxyClient";
 import type { ConcordiumCoinConfig } from "../../types";
 
 export interface FeeEstimation {
   cost: bigint;
   energy: bigint;
+}
+
+export interface PltFeeParams {
+  /** Priced by its UTF-8 byte length alone, so it must be the on-chain id verbatim. */
+  tokenId: string;
+  /** Byte length of the CBOR operations blob, which must already be encoded. */
+  listOperationsSize: number;
+}
+
+/**
+ * Applies {@link PLT_ENERGY_BUFFER_PERCENT}, rounding up.
+ *
+ * Rounding up rather than truncating keeps a small estimate from losing its
+ * buffer entirely to integer division.
+ */
+export function applyEnergyBuffer(value: bigint): bigint {
+  const scale = BigInt(100);
+  return (value * (scale + PLT_ENERGY_BUFFER_PERCENT) + scale - BigInt(1)) / scale;
 }
 
 export async function estimateFees(
@@ -16,6 +34,7 @@ export async function estimateFees(
 ): Promise<FeeEstimation> {
   try {
     const result = await getTransactionCost(config, currencyId, {
+      type: "simpleTransfer",
       numSignatures: 1,
       ...(memo ? { memoSize: memoEncodedSize(memo) } : {}),
     });
@@ -32,4 +51,36 @@ export async function estimateFees(
       energy: memo ? CONCORDIUM_ENERGY.TRANSFER_WITH_MEMO_MAX : CONCORDIUM_ENERGY.DEFAULT,
     };
   }
+}
+
+/**
+ * Estimates the fee for a PLT transfer, buffered.
+ *
+ * Separate from {@link estimateFees} rather than a branch inside it, because the
+ * CCD path's fixed-energy fallback has no PLT counterpart: the fee depends on
+ * the token id's length and the blob's size, so there is no constant to
+ * substitute.
+ *
+ * The rejection propagates through `prepareTransaction`, which the send flow
+ * surfaces and retries with backoff. Catching it to leave the fee unset defeats
+ * that retry, and a cleared fee reads as a blocking validation error rather than
+ * a pending one — a user who stopped typing during a proxy blip would stay stuck.
+ */
+export async function estimateTokenFees(
+  config: ConcordiumCoinConfig,
+  currencyId: string,
+  { tokenId, listOperationsSize }: PltFeeParams,
+): Promise<FeeEstimation> {
+  const result = await getTransactionCost(config, currencyId, {
+    type: "tokenUpdate",
+    numSignatures: 1,
+    tokenId,
+    listOperationsSize,
+    tokenOperationTypeCount: { transfer: 1 },
+  });
+
+  return {
+    cost: applyEnergyBuffer(BigInt(result.cost)),
+    energy: applyEnergyBuffer(BigInt(result.energy)),
+  };
 }

--- a/libs/coin-modules/coin-concordium/src/logic/transaction/transaction.test.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/transaction/transaction.test.ts
@@ -1,8 +1,6 @@
 import BigNumber from "bignumber.js";
 import { TransactionType } from "@ledgerhq/concordium-core";
-import { CONCORDIUM_ENERGY } from "../../constants";
 import { craftTransaction } from "./craftTransaction";
-import { estimateFees } from "./estimateFees";
 import { combine } from "./combine";
 import { broadcast } from "./broadcast";
 import { createFixtureConfig } from "../../test/fixtures";
@@ -10,10 +8,6 @@ import { createFixtureConfig } from "../../test/fixtures";
 // Mock network calls
 jest.mock("../../network/proxyClient", () => ({
   submitTransfer: jest.fn().mockResolvedValue({ submissionId: "test-submission-id" }),
-  getTransactionCost: jest.fn().mockResolvedValue({
-    cost: "1000000",
-    energy: "501",
-  }),
 }));
 
 const VALID_ADDRESS = "3a9gh23nNY3kH4k3ajaCqAbM8rcbWMor2VhEzQ6qkn2r17UU7w";
@@ -180,71 +174,6 @@ describe("logic/transaction", () => {
       // Expiry should be ~1 hour (3600 seconds) from now
       expect(expiry).toBeGreaterThanOrEqual(beforeTime + 3600);
       expect(expiry).toBeLessThanOrEqual(afterTime + 3600 + 1);
-    });
-  });
-
-  describe("estimateFees", () => {
-    it("should return fee estimation for simple transfer", async () => {
-      const result = await estimateFees(config, "concordium_testnet");
-
-      expect(result).toHaveProperty("cost");
-      expect(result).toHaveProperty("energy");
-      expect(typeof result.cost).toBe("bigint");
-      expect(typeof result.energy).toBe("bigint");
-    });
-
-    it("should use fixed energy for simple transfer without payload", async () => {
-      const result = await estimateFees(config, "concordium_testnet");
-
-      // Simple transfer has fixed energy cost
-      expect(result.energy).toBe(CONCORDIUM_ENERGY.SIMPLE_TRANSFER);
-    });
-
-    it("should calculate energy for transfer with payload", async () => {
-      const result = await estimateFees(config, "concordium_testnet");
-
-      expect(result.energy).toBeGreaterThan(0n);
-    });
-
-    it("should return default values when transaction cost fetch fails", async () => {
-      const { getTransactionCost } = jest.requireMock("../../network/proxyClient");
-      getTransactionCost.mockRejectedValueOnce(new Error("Network error"));
-
-      const result = await estimateFees(config, "concordium_testnet");
-
-      expect(result.cost).toBe(CONCORDIUM_ENERGY.DEFAULT_COST);
-      expect(result.energy).toBe(CONCORDIUM_ENERGY.DEFAULT);
-    });
-
-    it("should return higher default energy for memo transfer when fetch fails", async () => {
-      const { getTransactionCost } = jest.requireMock("../../network/proxyClient");
-      getTransactionCost.mockRejectedValueOnce(new Error("Network error"));
-
-      const result = await estimateFees(config, "concordium_testnet", "some memo");
-
-      expect(result.cost).toBe(CONCORDIUM_ENERGY.DEFAULT_COST);
-      expect(result.energy).toBe(CONCORDIUM_ENERGY.TRANSFER_WITH_MEMO_MAX);
-    });
-
-    it("should call getTransactionCost with correct parameters", async () => {
-      const { getTransactionCost } = jest.requireMock("../../network/proxyClient");
-
-      await estimateFees(config, "concordium_testnet");
-
-      expect(getTransactionCost).toHaveBeenCalledWith(config, "concordium_testnet", {
-        numSignatures: 1,
-      });
-    });
-
-    it("should call getTransactionCost with memoSize when memo provided", async () => {
-      const { getTransactionCost } = jest.requireMock("../../network/proxyClient");
-
-      await estimateFees(config, "concordium_testnet", "test");
-
-      expect(getTransactionCost).toHaveBeenCalledWith(config, "concordium_testnet", {
-        numSignatures: 1,
-        memoSize: 5,
-      });
     });
   });
 

--- a/libs/coin-modules/coin-concordium/src/network/proxyClient.integ.test.ts
+++ b/libs/coin-modules/coin-concordium/src/network/proxyClient.integ.test.ts
@@ -189,7 +189,10 @@ describe("proxyClient", () => {
   describe("getTransactionCost", () => {
     it("should return cost estimation for simple transfer", async () => {
       const numSignatures = 1;
-      const result = await getTransactionCost(config, currencyId, { numSignatures });
+      const result = await getTransactionCost(config, currencyId, {
+        type: "simpleTransfer",
+        numSignatures,
+      });
 
       expect(result).toHaveProperty("cost");
       expect(result).toHaveProperty("energy");
@@ -206,8 +209,12 @@ describe("proxyClient", () => {
       const numSignatures = 1;
       const memoSize = 50;
 
-      const resultWithoutMemo = await getTransactionCost(config, currencyId, { numSignatures });
+      const resultWithoutMemo = await getTransactionCost(config, currencyId, {
+        type: "simpleTransfer",
+        numSignatures,
+      });
       const resultWithMemo = await getTransactionCost(config, currencyId, {
+        type: "simpleTransfer",
         numSignatures,
         memoSize,
       });
@@ -222,10 +229,12 @@ describe("proxyClient", () => {
       const numSignatures = 1;
 
       const resultSmallMemo = await getTransactionCost(config, currencyId, {
+        type: "simpleTransfer",
         numSignatures,
         memoSize: 10,
       });
       const resultLargeMemo = await getTransactionCost(config, currencyId, {
+        type: "simpleTransfer",
         numSignatures,
         memoSize: 100,
       });
@@ -239,26 +248,95 @@ describe("proxyClient", () => {
     it("should return consistent results for same parameters", async () => {
       const numSignatures = 1;
 
-      const result1 = await getTransactionCost(config, currencyId, { numSignatures });
-      const result2 = await getTransactionCost(config, currencyId, { numSignatures });
+      const result1 = await getTransactionCost(config, currencyId, {
+        type: "simpleTransfer",
+        numSignatures,
+      });
+      const result2 = await getTransactionCost(config, currencyId, {
+        type: "simpleTransfer",
+        numSignatures,
+      });
 
       expect(result1.cost).toBe(result2.cost);
       expect(result1.energy).toBe(result2.energy);
+    });
+
+    // These four assert the live contract rather than our encoding of it, since
+    // a silent change to it would surface only as a wrong fee.
+    it("should price a tokenUpdate", async () => {
+      const result = await getTransactionCost(config, currencyId, {
+        type: "tokenUpdate",
+        numSignatures: 1,
+        tokenId: "tUSDT",
+        listOperationsSize: 42,
+        tokenOperationTypeCount: { transfer: 1 },
+      });
+
+      expect(BigInt(result.cost)).toBeGreaterThan(BigInt(0));
+      expect(BigInt(result.energy)).toBeGreaterThan(BigInt(0));
+    });
+
+    it("should charge more for a larger operations blob", async () => {
+      const base = { type: "tokenUpdate" as const, numSignatures: 1, tokenId: "tUSDT" };
+      const count = { transfer: 1 };
+
+      const small = await getTransactionCost(config, currencyId, {
+        ...base,
+        listOperationsSize: 10,
+        tokenOperationTypeCount: count,
+      });
+      const large = await getTransactionCost(config, currencyId, {
+        ...base,
+        listOperationsSize: 200,
+        tokenOperationTypeCount: count,
+      });
+
+      expect(BigInt(large.cost)).toBeGreaterThan(BigInt(small.cost));
+    });
+
+    it("should charge more for a longer token id", async () => {
+      const base = {
+        type: "tokenUpdate" as const,
+        numSignatures: 1,
+        listOperationsSize: 42,
+        tokenOperationTypeCount: { transfer: 1 },
+      };
+
+      const short = await getTransactionCost(config, currencyId, { ...base, tokenId: "a" });
+      const long = await getTransactionCost(config, currencyId, {
+        ...base,
+        tokenId: "a".repeat(64),
+      });
+
+      expect(BigInt(long.cost)).toBeGreaterThan(BigInt(short.cost));
+    });
+
+    it("should reject an operation name it cannot price", async () => {
+      await expect(
+        getTransactionCost(config, currencyId, {
+          type: "tokenUpdate",
+          numSignatures: 1,
+          tokenId: "tUSDT",
+          listOperationsSize: 42,
+          // Not in the proxy's known-cost map, so this is a 400.
+          tokenOperationTypeCount: { transfer: 1, notAnOperation: 1 } as never,
+        }),
+      ).rejects.toThrow();
     });
   });
 
   describe("Network connectivity", () => {
     it("should successfully connect to proxy endpoint", async () => {
       await expect(
-        getTransactionCost(config, currencyId, { numSignatures: 1 }),
+        getTransactionCost(config, currencyId, { type: "simpleTransfer", numSignatures: 1 }),
       ).resolves.toHaveProperty("cost");
     });
 
     it("should handle multiple concurrent requests", async () => {
       const promises = [
-        getTransactionCost(config, currencyId, { numSignatures: 1 }),
-        getTransactionCost(config, currencyId, { numSignatures: 1 }),
-        getTransactionCost(config, currencyId, { numSignatures: 1 }),
+        getTransactionCost(config, currencyId, { type: "simpleTransfer", numSignatures: 1 }),
+        getTransactionCost(config, currencyId, { type: "simpleTransfer", numSignatures: 1 }),
+        getTransactionCost(config, currencyId, { type: "simpleTransfer", numSignatures: 1 }),
       ];
 
       const results = await Promise.all(promises);

--- a/libs/coin-modules/coin-concordium/src/network/proxyClient.test.ts
+++ b/libs/coin-modules/coin-concordium/src/network/proxyClient.test.ts
@@ -362,7 +362,10 @@ describe("proxyClient", () => {
     it("should fetch transaction cost", async () => {
       mockNetwork.mockResolvedValue({ data: { cost: "1000", energy: "500" } });
 
-      const result = await getTransactionCost(config, currencyId, { numSignatures: 1 });
+      const result = await getTransactionCost(config, currencyId, {
+        type: "simpleTransfer",
+        numSignatures: 1,
+      });
 
       expect(result).toEqual({ cost: "1000", energy: "500" });
       expect(mockNetwork).toHaveBeenCalledWith(
@@ -372,6 +375,75 @@ describe("proxyClient", () => {
           params: { type: "simpleTransfer", numSignatures: 1 },
         }),
       );
+    });
+
+    it("omits memoSize when there is no memo", async () => {
+      mockNetwork.mockResolvedValue({ data: { cost: "1000", energy: "500" } });
+
+      await getTransactionCost(config, currencyId, { type: "simpleTransfer", numSignatures: 1 });
+
+      const { params } = mockNetwork.mock.calls[0][0];
+      expect(params).not.toHaveProperty("memoSize");
+    });
+
+    it("passes memoSize through for a memo transfer", async () => {
+      mockNetwork.mockResolvedValue({ data: { cost: "1200", energy: "600" } });
+
+      await getTransactionCost(config, currencyId, {
+        type: "simpleTransfer",
+        numSignatures: 1,
+        memoSize: 12,
+      });
+
+      expect(mockNetwork).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: { type: "simpleTransfer", numSignatures: 1, memoSize: 12 },
+        }),
+      );
+    });
+
+    // The proxy decodes this parameter with `AE.eitherDecode`, so it must arrive
+    // as one JSON document; a bracket or repeated-key form is a parse error.
+    it("serializes tokenOperationTypeCount as JSON", async () => {
+      mockNetwork.mockResolvedValue({ data: { cost: "3000", energy: "900" } });
+
+      const result = await getTransactionCost(config, currencyId, {
+        type: "tokenUpdate",
+        numSignatures: 1,
+        tokenId: "t-USDT",
+        listOperationsSize: 42,
+        tokenOperationTypeCount: { transfer: 1 },
+      });
+
+      expect(result).toEqual({ cost: "3000", energy: "900" });
+      expect(mockNetwork).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "GET",
+          url: "https://ccd-wallet-proxy-testnet.coin.ledger-test.com/v0/transactionCost",
+          params: {
+            type: "tokenUpdate",
+            numSignatures: 1,
+            tokenId: "t-USDT",
+            listOperationsSize: 42,
+            tokenOperationTypeCount: '{"transfer":1}',
+          },
+        }),
+      );
+    });
+
+    it("never sends memoSize on a tokenUpdate", async () => {
+      mockNetwork.mockResolvedValue({ data: { cost: "3000", energy: "900" } });
+
+      await getTransactionCost(config, currencyId, {
+        type: "tokenUpdate",
+        numSignatures: 1,
+        tokenId: "t-USDT",
+        listOperationsSize: 42,
+        tokenOperationTypeCount: { transfer: 1 },
+      });
+
+      const { params } = mockNetwork.mock.calls[0][0];
+      expect(params).not.toHaveProperty("memoSize");
     });
   });
 

--- a/libs/coin-modules/coin-concordium/src/network/proxyClient.ts
+++ b/libs/coin-modules/coin-concordium/src/network/proxyClient.ts
@@ -261,26 +261,46 @@ export async function getTransactions(
 }
 
 /**
+ * Flattens the cost parameters into the query string the proxy parses.
+ *
+ * `tokenOperationTypeCount` is serialized rather than spread: a bracket or
+ * repeated-key encoding is a parse error, not an equivalent form.
+ */
+function toCostQueryParams(params: GetTransactionCostParams): Record<string, string | number> {
+  if (params.type === "tokenUpdate") {
+    return {
+      type: params.type,
+      numSignatures: params.numSignatures,
+      tokenId: params.tokenId,
+      listOperationsSize: params.listOperationsSize,
+      tokenOperationTypeCount: JSON.stringify(params.tokenOperationTypeCount),
+    };
+  }
+
+  return {
+    type: params.type,
+    numSignatures: params.numSignatures,
+    ...(params.memoSize ? { memoSize: params.memoSize } : {}),
+  };
+}
+
+/**
  * Calculate transaction cost
  * GET /v0/transactionCost
  *
- * Always uses "simpleTransfer" type as it's the only supported type for regular transfers.
- * Memo overhead is calculated via the optional memoSize parameter.
+ * The energy returned is a ceiling the caller is expected to buffer, not the
+ * amount the chain will bill.
  */
 export async function getTransactionCost(
   config: ConcordiumCoinConfig,
   currencyId: string,
-  { numSignatures, memoSize }: GetTransactionCostParams,
+  params: GetTransactionCostParams,
 ): Promise<{ cost: string; energy: number }> {
   return withClient(config, currencyId, async client =>
     client.request<{ cost: string; energy: number }>({
       method: "GET",
       url: "/v0/transactionCost",
-      params: {
-        type: "simpleTransfer",
-        numSignatures,
-        ...(memoSize ? { memoSize } : {}),
-      },
+      params: toCostQueryParams(params),
     }),
   );
 }

--- a/libs/coin-modules/coin-concordium/src/test/fixtures.ts
+++ b/libs/coin-modules/coin-concordium/src/test/fixtures.ts
@@ -6,8 +6,14 @@
  *   const account = createFixtureAccount({ balance: new BigNumber(5000) });
  */
 import BigNumber from "bignumber.js";
-import type { Account, Operation } from "@ledgerhq/types-live";
-import type { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
+import type { Account, Operation, TokenAccount } from "@ledgerhq/types-live";
+import { emptyHistoryCache, encodeTokenAccountId } from "@ledgerhq/ledger-wallet-framework/account";
+import {
+  CryptoCurrencyIdSchema,
+  TokenCurrencyIdSchema,
+  type CryptoCurrency,
+  type TokenCurrency,
+} from "@ledgerhq/ledger-wallet-framework/types";
 import type {
   ConcordiumCoinConfig,
   ConcordiumConfig,
@@ -131,4 +137,50 @@ export function createFixtureOperation(overrides?: Partial<Operation>): Operatio
     transactionSequenceNumber: new BigNumber(1),
     ...overrides,
   } as Operation;
+}
+
+/** The launch PLT, `t-USDT`: 6 decimals, the id recorded verbatim as the chain spells it. */
+export const PLT_TOKEN_ID = "t-USDT";
+
+export function createFixtureTokenCurrency(overrides?: Partial<TokenCurrency>): TokenCurrency {
+  return {
+    type: "TokenCurrency",
+    id: TokenCurrencyIdSchema.parse(`concordium_testnet/plt/${PLT_TOKEN_ID.toLowerCase()}`),
+    contractAddress: PLT_TOKEN_ID,
+    parentCurrencyId: CryptoCurrencyIdSchema.parse("concordium_testnet"),
+    tokenType: "plt",
+    name: PLT_TOKEN_ID,
+    ticker: PLT_TOKEN_ID,
+    delisted: false,
+    disableCountervalue: false,
+    units: [{ name: PLT_TOKEN_ID, code: PLT_TOKEN_ID, magnitude: 6 }],
+    ...overrides,
+  };
+}
+
+/**
+ * A PLT sub-account of {@link createFixtureAccount}'s parent.
+ *
+ * The id is composed with `encodeTokenAccountId` rather than written out, so
+ * that `findSubAccountById` resolves it the way the bridge does.
+ */
+export function createFixtureTokenAccount(overrides?: Partial<TokenAccount>): TokenAccount {
+  const token = overrides?.token ?? createFixtureTokenCurrency();
+  const parentId = overrides?.parentId ?? createFixtureAccount().id;
+
+  return {
+    type: "TokenAccount",
+    id: encodeTokenAccountId(parentId, token),
+    parentId,
+    token,
+    balance: new BigNumber(5000000),
+    spendableBalance: new BigNumber(5000000),
+    creationDate: new Date("2024-01-01"),
+    operations: [],
+    operationsCount: 0,
+    pendingOperations: [],
+    balanceHistoryCache: emptyHistoryCache,
+    swapHistory: [],
+    ...overrides,
+  };
 }

--- a/libs/coin-modules/coin-concordium/src/types/network.ts
+++ b/libs/coin-modules/coin-concordium/src/types/network.ts
@@ -129,10 +129,48 @@ export interface TransactionQueryParams {
   blockHeightTo?: number; // inclusive upper bound
 }
 
-export interface GetTransactionCostParams {
-  numSignatures: number;
-  memoSize?: number;
-}
+/**
+ * Token operation names the proxy prices.
+ *
+ * Anything outside this set is a 400 from `computeTokenOperationSpecificCost`,
+ * so the union is what keeps an unpriceable name from being sent at all. The
+ * wallet only ever emits `transfer`; the rest are governance operations it does
+ * not perform, and are listed to match the proxy's own map.
+ */
+export type PltOperationName =
+  | "transfer"
+  | "mint"
+  | "burn"
+  | "addAllowList"
+  | "removeAllowList"
+  | "addDenyList"
+  | "removeDenyList"
+  | "pause"
+  | "unpause";
+
+/**
+ * Parameters for `GET /v0/transactionCost`, discriminated on the transaction
+ * type the proxy prices.
+ *
+ * Every `tokenUpdate` parameter is mandatory and returns its own 400 when
+ * absent.
+ */
+export type GetTransactionCostParams =
+  | {
+      type: "simpleTransfer";
+      numSignatures: number;
+      memoSize?: number;
+    }
+  | {
+      type: "tokenUpdate";
+      numSignatures: number;
+      /** Priced by its UTF-8 byte length alone, not by its value. */
+      tokenId: string;
+      /** Byte length of the CBOR operations blob, which must already be encoded. */
+      listOperationsSize: number;
+      /** Sent as a JSON document in the query string, not as repeated parameters. */
+      tokenOperationTypeCount: Partial<Record<PltOperationName, number>>;
+    };
 
 /**
  * Request payload for submitting a transfer transaction


### PR DESCRIPTION
### 📝 Description

Estimates PLT transfer fees through the wallet-proxy `type=tokenUpdate` cost endpoint. `getTransactionCost` is parameterized on transaction type rather than hardcoding `simpleTransfer`.

- **Order is inverted for PLT.** The CBOR operations blob is encoded before estimating, because `listOperationsSize` is its byte length.
- **A 20% energy buffer** applies to energy and cost alike, and the pair is persisted on the transaction. Signing reads it instead of re-estimating, so the wallet's fee and the device's "Max fees" step cannot disagree.
- **The token comes from `subAccountId`**, which also supplies the CAL unit magnitude for the CBOR exponent and the on-chain id for the proxy.
- **CCD is unchanged**, fixed-energy fallback included. `energy` is dropped whenever the native path re-prices, so a token estimate cannot reach a native transfer.

`estimateTokenFees` rejects rather than falling back: a PLT fee depends on the token id's length and the blob's size, so there is no constant to substitute, and a fabricated figure would be contradicted on the device. The rejection propagates to the send flow, which already surfaces and retries it with backoff.

The api-layer `assertNativeAsset` guard stays. CAL is a bridge-injected hook and no coin module reaches for it below `src/bridge/**`, so the api surface has no sanctioned source for token decimals.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-28335](https://ledgerhq.atlassian.net/browse/LIVE-28335)
- **ADR** (if any): —


[LIVE-28335]: https://ledgerhq.atlassian.net/browse/LIVE-28335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ