### PR TITLE
test(coin-solana): update expected fees after SMID-0437

### DIFF
--- a/libs/coin-modules/coin-solana/src/logic/tests/validateIntent.integ.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/validateIntent.integ.test.ts
@@ -36,9 +36,18 @@ const SENDER = "8DpKDisipx6f76cEmuGvCX9TrA3SjeR76HaTRePxHBDe";
 const NETWORK_FEE = 5_000n;
 const MAIN_ACCOUNT_RENT_EXEMPT = 890_880n;
 
+// SIMD-0437 progressively reduces ATA rent (293 bytes = 165 data + 128 overhead):
+// Step 0 (pre-SIMD-0437): 6,960 × 293 = 2,039,280
+// Step 1 (Sep 2026):      6,333 × 293 = 1,855,569
+// Step 2 (mid-Sep 2026):  5,080 × 293 = 1,488,440
+// Step 3 (Nov 2026):      2,575 × 293 =   754,475
+// Step 4 (Nov 2026):      1,322 × 293 =   387,346
+// Step 5 (Nov 2026):        696 × 293 =   203,928
+const CLASSIC_ATA_RENT = 1_855_569n; // Step 1 active on mainnet; update to current step when SIMD-0437 advances
+
 // Exact reproducer from the bug report: native = 0.00293516 SOL, spendable
-// (value - locked) = 0.00204428 SOL = classic 165-byte ATA rent + network fee.
-const BALANCE_AT_BUG_THRESHOLD = 2_044_280n + MAIN_ACCOUNT_RENT_EXEMPT;
+// (value - locked) = classic 165-byte ATA rent + network fee.
+const BALANCE_AT_BUG_THRESHOLD = NETWORK_FEE + CLASSIC_ATA_RENT + MAIN_ACCOUNT_RENT_EXEMPT;
 const SPL_BALANCE = 10_000_000n;
 
 function makeNativeBalance(value: bigint, locked: bigint = MAIN_ACCOUNT_RENT_EXEMPT): Balance {
@@ -85,7 +94,7 @@ describe("validateIntent (integration)", () => {
 
       expect(result.errors.gasPrice).toBeInstanceOf(NotEnoughGas);
       const fees = (result.errors.gasPrice as Error & { fees?: string }).fees;
-      expect(BigInt(fees ?? "0")).toBeGreaterThan(2_044_280n);
+      expect(BigInt(fees ?? "0")).toBeGreaterThan(CLASSIC_ATA_RENT + NETWORK_FEE);
     });
 
     it("does not pack NotEnoughGas when spendable balance comfortably covers mint-aware ATA rent + fee", async () => {

--- a/libs/coin-modules/coin-solana/src/prepareTransaction.integ.test.ts
+++ b/libs/coin-modules/coin-solana/src/prepareTransaction.integ.test.ts
@@ -27,8 +27,17 @@ const SOLANA_RPC_ENDPOINT = "https://solana.coin.ledger.com";
 const VIBECODOOR_MINT = "Aj1mSpD4vJDN5r3xptnHsjHQgGWDLge8bRQi2W6pump";
 const SENDER_ADDRESS = "8DpKDisipx6f76cEmuGvCX9TrA3SjeR76HaTRePxHBDe";
 
+// SIMD-0437 progressively reduces ATA rent (293 bytes = 165 data + 128 overhead):
+// Step 0 (pre-SIMD-0437): 6,960 × 293 = 2,039,280
+// Step 1 (Sep 2026):      6,333 × 293 = 1,855,569
+// Step 2 (mid-Sep 2026):  5,080 × 293 = 1,488,440
+// Step 3 (Nov 2026):      2,575 × 293 =   754,475
+// Step 4 (Nov 2026):      1,322 × 293 =   387,346
+// Step 5 (Nov 2026):        696 × 293 =   203,928
+const NETWORK_FEE = 5_000;
+const CLASSIC_ATA_RENT = 1_855_569; // Step 1 active on mainnet; update to current step when SIMD-0437 advances
 const MAIN_ACCOUNT_RENT_EXEMPT = new BigNumber(890_880);
-const SPENDABLE_AT_BUG_THRESHOLD = new BigNumber(2_044_280);
+const SPENDABLE_AT_BUG_THRESHOLD = new BigNumber(NETWORK_FEE + CLASSIC_ATA_RENT);
 const BALANCE_AT_BUG_THRESHOLD = SPENDABLE_AT_BUG_THRESHOLD.plus(MAIN_ACCOUNT_RENT_EXEMPT);
 
 const VIBECODOOR_TOKEN: TokenCurrency = {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Update expected fees after Solana SMID-0437. These values must be re-updated after each steps. See https://solanacompass.com/news/solanas-first-rent-reduction-goes-live-on-testnet-under-simd-0437-targeting-90-cut-in-five-steps.

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
