### PR TITLE
[LWDM] test(solana): read the rent from the chain, not a pinned figure

### DIFF
--- a/.changeset/solana-rent-from-chain.md
+++ b/.changeset/solana-rent-from-chain.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-solana": patch
+---
+
+Read the rent-exempt minimum from the chain in the Solana integration tests instead of a pinned figure

--- a/libs/coin-modules/coin-solana/src/logic/tests/validateIntent.integ.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/validateIntent.integ.test.ts
@@ -35,10 +35,7 @@ const SENDER = "8DpKDisipx6f76cEmuGvCX9TrA3SjeR76HaTRePxHBDe";
 
 const NETWORK_FEE = 5_000n;
 const MAIN_ACCOUNT_RENT_EXEMPT = 890_880n;
-
-// Exact reproducer from the bug report: native = 0.00293516 SOL, spendable
-// (value - locked) = 0.00204428 SOL = classic 165-byte ATA rent + network fee.
-const BALANCE_AT_BUG_THRESHOLD = 2_044_280n + MAIN_ACCOUNT_RENT_EXEMPT;
+const CLASSIC_ATA_SIZE = 165;
 const SPL_BALANCE = 10_000_000n;
 
 function makeNativeBalance(value: bigint, locked: bigint = MAIN_ACCOUNT_RENT_EXEMPT): Balance {
@@ -76,16 +73,22 @@ describe("validateIntent (integration)", () => {
 
   describe("SPL Token-2022 transfer to recipient without ATA", () => {
     it("packs NotEnoughGas when spendable balance equals classic ATA rent + fee (the regression scenario)", async () => {
+      // Spendable is exactly what a classic 165-byte token account costs, plus the fee -- and a
+      // Token-2022 one costs more. Read from the chain: Solana has lowered the rent-exempt minimum
+      // since this was written, and a pinned figure stops reproducing the case.
+      const classicAtaRent = BigInt(await api.getMinimumBalanceForRentExemption(CLASSIC_ATA_SIZE));
+      const balanceAtBugThreshold = classicAtaRent + NETWORK_FEE + MAIN_ACCOUNT_RENT_EXEMPT;
+
       const result = await validateIntent(
         makeTokenIntent(VIBECODOOR_MINT),
-        [makeNativeBalance(BALANCE_AT_BUG_THRESHOLD), makeTokenBalance(VIBECODOOR_MINT)],
+        [makeNativeBalance(balanceAtBugThreshold), makeTokenBalance(VIBECODOOR_MINT)],
         { value: NETWORK_FEE },
         api,
       );
 
       expect(result.errors.gasPrice).toBeInstanceOf(NotEnoughGas);
       const fees = (result.errors.gasPrice as Error & { fees?: string }).fees;
-      expect(BigInt(fees ?? "0")).toBeGreaterThan(2_044_280n);
+      expect(BigInt(fees ?? "0")).toBeGreaterThan(classicAtaRent + NETWORK_FEE);
     });
 
     it("does not pack NotEnoughGas when spendable balance comfortably covers mint-aware ATA rent + fee", async () => {

--- a/libs/coin-modules/coin-solana/src/prepareTransaction.integ.test.ts
+++ b/libs/coin-modules/coin-solana/src/prepareTransaction.integ.test.ts
@@ -28,8 +28,8 @@ const VIBECODOOR_MINT = "Aj1mSpD4vJDN5r3xptnHsjHQgGWDLge8bRQi2W6pump";
 const SENDER_ADDRESS = "8DpKDisipx6f76cEmuGvCX9TrA3SjeR76HaTRePxHBDe";
 
 const MAIN_ACCOUNT_RENT_EXEMPT = new BigNumber(890_880);
-const SPENDABLE_AT_BUG_THRESHOLD = new BigNumber(2_044_280);
-const BALANCE_AT_BUG_THRESHOLD = SPENDABLE_AT_BUG_THRESHOLD.plus(MAIN_ACCOUNT_RENT_EXEMPT);
+const NETWORK_FEE = new BigNumber(5_000);
+const CLASSIC_ATA_SIZE = 165;
 
 const VIBECODOOR_TOKEN: TokenCurrency = {
   type: "TokenCurrency",
@@ -72,7 +72,7 @@ const senderAtaAddress = PublicKey.findProgramAddressSync(
 
 const subAccountId = encodeAccountIdWithTokenAccountAddress(mainAccountId, senderAtaAddress);
 
-function buildSenderAccount(): SolanaAccount {
+function buildSenderAccount(spendable: BigNumber): SolanaAccount {
   const tokenSub = {
     type: "TokenAccount",
     id: subAccountId,
@@ -108,8 +108,8 @@ function buildSenderAccount(): SolanaAccount {
     creationDate: new Date(),
     lastSyncDate: new Date(0),
     blockHeight: 0,
-    balance: BALANCE_AT_BUG_THRESHOLD,
-    spendableBalance: SPENDABLE_AT_BUG_THRESHOLD,
+    balance: spendable.plus(MAIN_ACCOUNT_RENT_EXEMPT),
+    spendableBalance: spendable,
     operationsCount: 0,
     operations: [],
     pendingOperations: [],
@@ -129,8 +129,13 @@ describe("prepareTransaction packs NotEnoughGas", () => {
 
   const api = getChainAPI({ endpoint: SOLANA_RPC_ENDPOINT });
 
+  // Read from the chain rather than pinned: Solana has lowered the rent-exempt minimum since this
+  // was written, and a pinned figure stops reproducing the case it was meant to.
   it("prepareTransaction packs NotEnoughGas when spendable == classic ATA rent + fee", async () => {
-    const account = buildSenderAccount();
+    const classicAtaRent = new BigNumber(
+      await api.getMinimumBalanceForRentExemption(CLASSIC_ATA_SIZE),
+    );
+    const account = buildSenderAccount(classicAtaRent.plus(NETWORK_FEE));
     const freshRecipient = Keypair.generate().publicKey.toBase58();
 
     const tx: Transaction = {
@@ -149,6 +154,7 @@ describe("prepareTransaction packs NotEnoughGas", () => {
 
     expect(status.errors.gasPrice).toBeInstanceOf(NotEnoughGas);
     const fees = (status.errors.gasPrice as Error & { fees?: string }).fees;
-    expect(parseFloat(fees ?? "0")).toBeGreaterThan(0.001);
+    // Sized from the mint, so above what a classic token account would have cost.
+    expect(parseFloat(fees ?? "0")).toBeGreaterThan(classicAtaRent.toNumber() / 1e9);
   });
 });


### PR DESCRIPTION
### 📝 Description

Two Solana integration tests pinned the rent-exempt minimum for a 165-byte token account. Solana has since lowered it (2 039 280 → 1 855 569 lamports), so the reproducer no longer reproduced anything and both tests were failing on `develop`.

They now read the figure from the chain with `getMinimumBalanceForRentExemption`, and assert against it rather than against a literal.

Verified in both directions: the two tests fail on the current `develop` version (2 of 7) and pass with the change (7 of 7).

Split out of #21231 to keep that PR reviewable. Independent of it.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35692](https://ledgerhq.atlassian.net/browse/LIVE-35692)

[LIVE-35692]: https://ledgerhq.atlassian.net/browse/LIVE-35692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ