### PR TITLE
[LWM] fix(e2e): read the sub-account id instead of rebuilding it

### DIFF
--- a/.changeset/e2e-read-sub-account-id.md
+++ b/.changeset/e2e-read-sub-account-id.md
@@ -1,0 +1,8 @@
+---
+"ledger-live-mobile-e2e-tests": patch
+"live-mobile": patch
+---
+
+Read the sub-account id from the screen in `navigateToSubAccount` instead of rebuilding it. Rebuilding meant hardcoding one of the two id formats in the wild: an account synced before the generic coin framework keeps the format it was stored under, a newer one gets `encodeTokenAccountId`. The helper now opens the sub-account from the flat accounts list and returns the id the app gave it, with an identity assertion that does not depend on the id it just read.
+
+`navigateToTokenInAccount` expands the token list when the "see more" button is present. The list shows three tokens while collapsed, so a fourth one was never on screen to scroll to. Adds a `testID` to that button in `SubAccountsList`.

--- a/apps/ledger-live-mobile/src/screens/Account/SubAccountsList.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/SubAccountsList.tsx
@@ -153,6 +153,7 @@ export default function SubAccountsList({
         type={"shade"}
         outline
         event="accountExpandTokenList"
+        testID="account-expand-token-list"
         Icon={isCollapsed ? DropdownMedium : DropupMedium}
         iconPosition={"right"}
         onPress={() => setIsCollapsed(!isCollapsed)}

--- a/e2e/mobile/page/accounts/account.page.ts
+++ b/e2e/mobile/page/accounts/account.page.ts
@@ -1,3 +1,4 @@
+import invariant from "invariant";
 import { Step } from "jest-allure2-reporter/api";
 import { openDeeplink } from "@e2e/helpers/commonHelpers";
 import { VISIBILITY_PROBE_TIMEOUT } from "@e2e/helpers/elementHelpers";
@@ -36,9 +37,8 @@ export default class AccountPage {
   accountRenameRow = () => getElementById("account-settings-rename-row");
   getSpecificOperation = (operationType: string) =>
     getElementByIdAndText(this.operationRowRegexp, operationType, 0);
-  subAccountId = (account: Account) =>
-    `js:2:${account.currency.id}:${account.parentAccount ? account.parentAccount.address : account.address}:${account.currency.id}Sub+${account.address}`;
   accountGraphId = (accountId: string) => `account-graph-${accountId}`;
+  expandTokenListId = "enabled-account-expand-token-list";
 
   @Step("Wait for account screen and verify account name {{{0}}}")
   async waitAndVerifyAccountName(accountName: string) {
@@ -202,16 +202,49 @@ export default class AccountPage {
   @Step("Navigate to token in account {{{0.accountName}}}")
   async navigateToTokenInAccount(subAccount: Account) {
     const subAccountId = this.baseSubAccountRow + subAccount.currency.ticker;
-    await this.scrollToSubAccount(subAccountId);
+    try {
+      await this.scrollToSubAccount(subAccountId);
+    } catch {
+      await revealForTap(this.expandTokenListId, { container: this.accountScreenScrollView });
+      await tapById(this.expandTokenListId);
+      await this.scrollToSubAccount(subAccountId);
+    }
     await tapById(subAccountId);
   }
 
   @Step("Navigate to sub account {{{0.accountName}}}")
   async navigateToSubAccount(account: AccountType) {
-    const subAccountId = this.subAccountId(account);
+    const { parentAccount } = account;
+    invariant(parentAccount, `${account.accountName} has no parent account`);
+
+    const parentAddress = parentAccount.address;
+    invariant(parentAddress, `${parentAccount.accountName} has no address`);
+
     await this.openViaDeeplink();
-    await this.goToAccountById(subAccountId);
-    await waitForElement(this.accountGraph(subAccountId));
+    await this.goToAccountByName(parentAccount.accountName);
+    await this.navigateToTokenInAccount(account);
+
+    const graphIdRegexp = new RegExp(`^${this.accountGraphId("")}.+\\+.+`);
+    await waitForElementById(graphIdRegexp, undefined, { checkVisibility: false });
+    const graphCount = await countElements(getElementsById(graphIdRegexp));
+    let graphId: string | undefined;
+    for (let index = 0; index < graphCount; index++) {
+      const graph = getElementById(graphIdRegexp, index);
+      try {
+        await detoxExpect(graph).toBeVisible();
+        graphId = (await getIdOfElement(graph)).replace(this.accountGraphId(""), "");
+        break;
+      } catch {
+        continue;
+      }
+    }
+    invariant(graphId, `no visible account graph after opening ${account.accountName}`);
+
+    invariant(
+      graphId.includes(parentAddress),
+      `expected a sub-account of ${parentAccount.accountName}, landed on ${graphId}`,
+    );
+    return graphId;
   }
 
   @Step("Scroll to history and click on last operation {{{0}}}")

--- a/e2e/mobile/specs/subAccount/subAccount.ts
+++ b/e2e/mobile/specs/subAccount/subAccount.ts
@@ -69,8 +69,7 @@ export function runSendSPL(transaction: TransactionType, tmsLinks: string[], tag
       await app.operationDetails.checkOperationInfos(transaction, true, "OUT");
 
       if (!getEnv("DISABLE_TRANSACTION_BROADCAST")) {
-        const subAccountId = app.account.subAccountId(transaction.accountToCredit);
-        await app.account.navigateToSubAccount(transaction.accountToCredit);
+        const subAccountId = await app.account.navigateToSubAccount(transaction.accountToCredit);
         await app.account.expectAccountBalanceVisible(subAccountId);
         await app.account.scrollToHistoryAndClickOnLastOperation(TransactionStatus.RECEIVED);
         await app.operationDetails.checkOperationInfos(transaction, false);


### PR DESCRIPTION
### 📝 Description

`navigateToSubAccount` rebuilt a token sub-account id by hand, which meant hardcoding one of the two formats in the wild: an account synced before the generic coin framework keeps the id it was stored under, a newer one gets `encodeTokenAccountId`.

The helper now reaches the sub-account through its parent and returns the id the app actually gave it, so it no longer depends on either format. `runSendSPL` takes the returned id instead of computing its own.

The now-unused `subAccountId` helper is removed; it had no other caller.

Split out of #21231 to keep that PR reviewable. Independent of it.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35692](https://ledgerhq.atlassian.net/browse/LIVE-35692)

[LIVE-35692]: https://ledgerhq.atlassian.net/browse/LIVE-35692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ