### PR TITLE
fix(generic-coin-framework): carry staking positions, prune sub-accounts

### DIFF
--- a/.changeset/plain-donkeys-marry.md
+++ b/.changeset/plain-donkeys-marry.md
@@ -1,0 +1,13 @@
+---
+"@ledgerhq/live-common": minor
+"@ledgerhq/ledger-wallet-framework": minor
+---
+
+Carry a chain's staking positions through the generic coin framework, and keep sub-accounts
+aligned with what the chain reports:
+
+- an unbonding position with no validator is no longer dropped from the account's list
+- `extractBalances` rebuilds staking positions, so a family validating a staking intent finds them
+- a position reads as withdrawable only when the chain offers a withdraw on it
+- `mergeSubAccounts` keeps only the sub-accounts the chain still reports, instead of letting a pruned one survive with a stale balance
+- a pending operation shows the user's memo only on a plain transfer

--- a/libs/coin-tester-modules/coin-tester-multiversx/src/scenarii/multiversx.ts
+++ b/libs/coin-tester-modules/coin-tester-multiversx/src/scenarii/multiversx.ts
@@ -1,6 +1,5 @@
 import BigNumber from "bignumber.js";
 import { Scenario, ScenarioTransaction } from "@ledgerhq/coin-tester/main";
-import type { BridgeStrategy } from "@ledgerhq/coin-tester/types";
 import type { Account } from "@ledgerhq/types-live";
 import type { TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
@@ -48,10 +47,7 @@ const ESDT_ENABLE_EPOCH = 2;
 // Set during setup (the identifier is only known after issuance), read by getTransactions.
 let scenarioToken: TokenCurrency;
 
-function makeScenarioTransactions(
-  address: string,
-  strategy: BridgeStrategy,
-): MultiversXScenarioTransaction[] {
+function makeScenarioTransactions(address: string): MultiversXScenarioTransaction[] {
   const usdcSubAccountId = encodeTokenAccountId(`js:2:elrond:${address}:`, scenarioToken);
 
   const sendEgld: MultiversXScenarioTransaction = {
@@ -100,14 +96,7 @@ function makeScenarioTransactions(
       // The ESDT transfer produces a new parent operation (fees paid in EGLD).
       expect(currentAccount.operations.length).toBeGreaterThan(previousAccount.operations.length);
       const currentSub = currentAccount.subAccounts?.find(sa => sa.id === usdcSubAccountId);
-      if (strategy === "legacy") {
-        // Legacy sync drops the sub-account once the ESDT balance reaches 0 (node prunes the
-        // storage entry), so spendableBalance is either 0 or the sub-account disappears.
-        if (currentSub) expect(currentSub.spendableBalance).toEqual(new BigNumber(0));
-      }
-      // generic-adapter: mergeSubAccounts (incremental sync) does not zero-out old
-      // sub-accounts absent from newSubAccounts when the node prunes the ESDT entry,
-      // so spendableBalance stays stale. Assert === 0 once mergeSubAccounts is fixed.
+      if (currentSub) expect(currentSub.spendableBalance).toEqual(new BigNumber(0));
     },
   };
 
@@ -194,7 +183,7 @@ export const scenarioMultiversx: Scenario<GenericTransaction, Account> = {
 
     return { account, accountBridge, currencyBridge };
   },
-  getTransactions: (address, strategy) => makeScenarioTransactions(address, strategy),
+  getTransactions: address => makeScenarioTransactions(address),
   beforeAll: account => {
     expect(account.balance.toString()).toEqual(INITIAL_EGLD_FUNDING);
     expect(account.operations.length).toEqual(0);

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/accountBridge.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/accountBridge.ts
@@ -26,8 +26,14 @@ export async function getCoinFrameworkAccountBridge(
   customSigner?: CoinFrameworkSigner,
 ): Promise<AccountBridge<GenericTransaction>> {
   const signer = customSigner ?? (await getSigner(network));
-  const { assignFromAccountRaw, assignToAccountRaw, fromOperationExtraRaw, toOperationExtraRaw } =
-    await getAccountRawAssignHooks(network);
+  const {
+    assignFromAccountRaw,
+    assignToAccountRaw,
+    assignFromTokenAccountRaw,
+    assignToTokenAccountRaw,
+    fromOperationExtraRaw,
+    toOperationExtraRaw,
+  } = await getAccountRawAssignHooks(network);
   return {
     sync: makeSync({ getAccountShape: genericGetAccountShape(network, kind), postSync }),
     receive: makeAccountBridgeReceive(getAddressWrapper(signer.getAddress)),
@@ -41,6 +47,8 @@ export async function getCoinFrameworkAccountBridge(
     signRawOperation: genericSignRawOperation(network, kind)(signer.context),
     assignFromAccountRaw,
     assignToAccountRaw,
+    assignFromTokenAccountRaw,
+    assignToTokenAccountRaw,
     fromOperationExtraRaw,
     toOperationExtraRaw,
     getSerializedAddressParameters, // NOTE: check whether it should be exposed by coin-module's api instead?

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/buildSubAccounts.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/buildSubAccounts.test.ts
@@ -2,7 +2,7 @@ import { TokenCurrency } from "@domain/entity-currency-token";
 import { buildSubAccounts, mergeSubAccounts } from "./buildSubAccounts";
 import { SyncConfig, TokenAccount } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
-import { AssetInfo } from "@ledgerhq/coin-module-framework/api/types";
+import { AssetInfo, Balance } from "@ledgerhq/coin-module-framework/api/types";
 
 describe("buildSubAccounts", () => {
   it("builds sub accounts from asset operations and balances, preserving operations order", async () => {
@@ -259,6 +259,51 @@ describe("buildSubAccounts", () => {
 });
 
 describe("mergeSubAccounts", () => {
+  it("keeps the fields the chain does not report on a sub account it still does", () => {
+    const walletOwned = {
+      pendingOperations: [{ id: "op-pending", hash: "h9" }],
+      swapHistory: [{ operationId: "swap-1" }],
+      balanceHistoryCache: { HOUR: { latestDate: 1, balances: [1] } },
+      creationDate: new Date("2019-04-01"),
+    };
+    const stored = [
+      { id: "accountId+usdt", token: { id: "usdt" }, operations: [], ...walletOwned },
+    ] as unknown as Array<TokenAccount>;
+    const fresh = [
+      {
+        id: "accountId+usdt",
+        token: { id: "usdt" },
+        operations: [],
+        pendingOperations: [],
+        swapHistory: [],
+        balanceHistoryCache: {},
+        creationDate: new Date("2020-01-01"),
+      },
+    ] as unknown as Array<TokenAccount>;
+
+    expect(mergeSubAccounts(stored, fresh)[0]).toMatchObject(walletOwned);
+  });
+
+  it("drops a sub account the chain no longer reports", () => {
+    const stored = [
+      {
+        id: "accountId+ataAddress",
+        token: { id: "usdc" },
+        balance: new BigNumber(10),
+        operations: [],
+      },
+      { id: "accountId+usdt", token: { id: "usdt" }, balance: new BigNumber(5), operations: [] },
+    ] as unknown as Array<TokenAccount>;
+    const fresh = [
+      { id: "accountId+usdt", token: { id: "usdt" }, balance: new BigNumber(7), operations: [] },
+    ] as unknown as Array<TokenAccount>;
+
+    const merged = mergeSubAccounts(stored, fresh);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({ id: "accountId+usdt", balance: new BigNumber(7) });
+  });
+
   it("only keeps new sub accounts", () => {
     const oldSubAccounts = [];
     const newSubAccounts = [
@@ -320,7 +365,7 @@ describe("mergeSubAccounts", () => {
     expect(merged).toEqual(newSubAccounts);
   });
 
-  it("adds new unexisting sub accounts as is", () => {
+  it("keeps only what the chain reports, dropping the stored ones it no longer does", () => {
     const oldSubAccounts = [
       {
         id: "accountId+usdc",
@@ -402,10 +447,10 @@ describe("mergeSubAccounts", () => {
     ] as Array<TokenAccount>;
     const merged = mergeSubAccounts(oldSubAccounts, newSubAccounts);
 
-    expect(merged).toEqual([...oldSubAccounts, ...newSubAccounts]);
+    expect(merged).toEqual(newSubAccounts);
   });
 
-  it("updates existing sub accounts with new data", () => {
+  it("updates the sub account the chain still reports, and drops the one it does not", () => {
     const oldSubAccounts = [
       {
         id: "accountId+usdc",
@@ -488,31 +533,6 @@ describe("mergeSubAccounts", () => {
     const merged = mergeSubAccounts(oldSubAccounts, newSubAccounts);
 
     expect(merged).toEqual([
-      {
-        id: "accountId+usdc",
-        type: "TokenAccount",
-        parentId: "accountId",
-        token: { id: "usdc" },
-        balance: new BigNumber(20),
-        spendableBalance: new BigNumber(15),
-        operations: [
-          {
-            id: "accountId+usdc-tx-hash1-OUT",
-            type: "OUT",
-            senders: ["owner"],
-            recipients: ["other"],
-            date: new Date("2019-04-01"),
-          },
-          {
-            id: "accountId+usdc-tx-hash3-IN",
-            type: "IN",
-            senders: ["other"],
-            recipients: ["owner"],
-            date: new Date("2019-04-02"),
-          },
-        ],
-        operationsCount: 2,
-      },
       {
         id: "accountId+usdt",
         type: "TokenAccount",

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/buildSubAccounts.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/buildSubAccounts.ts
@@ -12,17 +12,18 @@ import { cleanedOperation } from "./utils";
 import { OperationCommon } from "./types";
 
 function buildTokenAccount({
+  id,
   parentAccountId,
   assetBalance,
   token,
   operations,
 }: {
+  id: string;
   parentAccountId: string;
   assetBalance: Balance;
   token: TokenCurrency;
   operations: OperationCommon[];
 }): TokenAccount {
-  const id = encodeTokenAccountId(parentAccountId, token);
   const balance = new BigNumber(assetBalance.value.toString() || "0");
 
   // TODO: recheck this logic
@@ -89,8 +90,9 @@ export async function buildSubAccounts({
   for (const { balance, token } of tokenBalances) {
     // NOTE: for future tokens, will need to check over currencyName/standard(erc20,trc10,trc20, etc)/id
     if (token && !blacklistedTokenIds.includes(token.id)) {
-      tokenAccounts.push(
-        buildTokenAccount({
+      tokenAccounts.push({
+        ...buildTokenAccount({
+          id: encodeTokenAccountId(accountId, token),
           parentAccountId: accountId,
           assetBalance: balance,
           token,
@@ -109,13 +111,14 @@ export async function buildSubAccounts({
             );
           }),
         }),
-      );
+      });
     }
   }
 
   return tokenAccounts;
 }
 
+/** Keeps only what the chain still reports, carrying the stored operations of a token that stays. */
 export function mergeSubAccounts(
   oldSubAccounts: Array<TokenAccount>,
   newSubAccounts: Array<TokenAccount>,
@@ -128,29 +131,19 @@ export function mergeSubAccounts(
     oldSubAccounts.map((account): [string, TokenAccount] => [String(account.token.id), account]),
   );
 
-  const newSubAccountsToAdd: Array<TokenAccount> = [];
-
-  for (const newSubAccount of newSubAccounts) {
+  return newSubAccounts.map(newSubAccount => {
     const existingSubAccount = oldSubAccountsByTokenId[String(newSubAccount.token.id)];
+    if (!existingSubAccount) return newSubAccount;
 
-    if (!existingSubAccount) {
-      // New sub account does not exist yet. Just add it as is.
-      newSubAccountsToAdd.push(newSubAccount);
-      continue;
-    }
-
-    // New sub account is already known, probably outdated
     const operations = mergeOps(existingSubAccount.operations, newSubAccount.operations);
-    oldSubAccountsByTokenId[String(newSubAccount.token.id)] = {
-      ...existingSubAccount,
-      balance: newSubAccount.balance,
-      spendableBalance: newSubAccount.spendableBalance,
+    return {
+      ...newSubAccount,
       operations,
       operationsCount: operations.length,
+      pendingOperations: existingSubAccount.pendingOperations,
+      swapHistory: existingSubAccount.swapHistory,
+      balanceHistoryCache: existingSubAccount.balanceHistoryCache,
+      creationDate: existingSubAccount.creationDate,
     };
-  }
-
-  const updatedOldSubAccounts = Object.values(oldSubAccountsByTokenId);
-
-  return [...updatedOldSubAccounts, ...newSubAccountsToAdd];
+  });
 }

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
@@ -13,7 +13,12 @@ import { getCoinModuleApi } from "./api";
 import { buildContext } from "./api/context";
 import { getBridgeApi } from "./bridge";
 import { getAccountRawAssignHooks } from "./accountRawAssign";
-import { adaptCoreOperationToLiveOperation, cleanedOperation, extractBalance } from "./utils";
+import {
+  adaptCoreOperationToLiveOperation,
+  cleanedOperation,
+  extractBalance,
+  optionalNumeric,
+} from "./utils";
 import { inferSubOperations } from "@ledgerhq/ledger-wallet-framework/serialization";
 import { buildSubAccounts, mergeSubAccounts } from "./buildSubAccounts";
 import { paginateOperations } from "./paginateOperations";
@@ -23,6 +28,7 @@ import type {
   Account,
   AccountReadiness,
   StakingDelegation,
+  StakingPositionDetails,
   StakingResources,
   StakingUnbonding,
   TokenAccount,
@@ -63,17 +69,31 @@ function hasDeactivatingStake(balance: Balance): balance is Balance & {
   stake: Stake;
 } {
   const state = balance.stake?.state;
-  return state === "deactivating" || state === "withdrawable";
-}
-
-function hasStakeDelegate<T extends Balance & { stake: Stake }>(
-  balance: T,
-): balance is T & { stake: Stake & { delegate: string } } {
-  return typeof balance.stake.delegate === "string" && balance.stake.delegate.length > 0;
+  // `inactive` would otherwise fall through both lists and vanish from `stakingResources`.
+  return state === "deactivating" || state === "withdrawable" || state === "inactive";
 }
 
 function delegatedAmountForStakingResources(b: Balance): bigint {
   return b.stake?.amount ?? 0n;
+}
+
+function stakingPositionDetails(stake: Stake): StakingPositionDetails {
+  const details = stake.details ?? {};
+  const activeAmount = optionalNumeric(details.activeAmount);
+  const inactiveAmount = optionalNumeric(details.inactiveAmount);
+  const withdrawableAmount = optionalNumeric(details.withdrawableAmount);
+  const lockedReserve = optionalNumeric(details.lockedReserve);
+
+  // `!== undefined`, not truthiness: a zero amount is meaningful.
+  return {
+    ...(stake.uid ? { positionId: stake.uid } : {}),
+    ...(activeAmount !== undefined ? { activeAmount } : {}),
+    ...(inactiveAmount !== undefined ? { inactiveAmount } : {}),
+    ...(withdrawableAmount !== undefined ? { withdrawableAmount } : {}),
+    ...(lockedReserve !== undefined ? { lockedReserve } : {}),
+    ...(typeof details.canStake === "boolean" ? { canStake: details.canStake } : {}),
+    ...(typeof details.canWithdraw === "boolean" ? { canWithdraw: details.canWithdraw } : {}),
+  };
 }
 
 /**
@@ -522,14 +542,15 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
         0n,
       );
 
-      const delegations: StakingDelegation[] = activeStakes.filter(hasStakeDelegate).map(b => {
+      const delegations: StakingDelegation[] = activeStakes.map(b => {
         const delegated: bigint = delegatedAmountForStakingResources(b);
         const rewarded: bigint = b.stake.amountRewarded ?? 0n;
         const validatorId = b.stake.details?.validatorId;
         const validatorName = b.stake.details?.validatorName;
         const sharesRaw = b.stake.details?.shares;
         return {
-          validatorAddress: b.stake.delegate,
+          ...stakingPositionDetails(b.stake),
+          validatorAddress: b.stake.delegate ?? "",
           amount: new BigNumber(delegated.toString()),
           pendingRewards: new BigNumber(rewarded.toString()),
           status: b.stake.state === "activating" ? "activating" : "bonded",
@@ -538,17 +559,23 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
           ...(typeof sharesRaw === "bigint" ? { shares: new BigNumber(sharesRaw.toString()) } : {}),
         };
       });
-      const unbondings: StakingUnbonding[] = deactivatingStakes.filter(hasStakeDelegate).map(b => {
+      const unbondings: StakingUnbonding[] = deactivatingStakes.map(b => {
         const delegated: bigint = delegatedAmountForStakingResources(b);
         const validatorId = b.stake.details?.validatorId;
         const validatorName = b.stake.details?.validatorName;
         const withdrawId = b.stake.details?.withdrawId;
 
         return {
-          validatorAddress: b.stake.delegate,
+          ...stakingPositionDetails(b.stake),
+          validatorAddress: b.stake.delegate ?? "",
           amount: new BigNumber(delegated.toString()),
           completionDate: b.stake.stateUpdatedAt ?? new Date(),
-          status: b.stake.state === "withdrawable" ? "withdrawable" : "deactivating",
+          // `inactive` also covers an idle stake, so trust `actions` rather than the state.
+          status:
+            b.stake.state === "withdrawable" ||
+            b.stake.actions?.some(action => action === "withdraw")
+              ? "withdrawable"
+              : "deactivating",
           ...(typeof validatorId === "string" ? { validatorId } : {}),
           ...(typeof validatorName === "string" ? { validatorName } : {}),
           ...(typeof withdrawId === "number" ? { withdrawId } : {}),

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/prepareTransaction.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/prepareTransaction.ts
@@ -9,6 +9,7 @@ import {
   getNativeSpendableAfterPending,
   getPendingTokenSpent,
   toGasOptionsFromUnknown,
+  toTransferFeeFromUnknown,
   transactionToIntent,
 } from "./utils";
 import BigNumber from "bignumber.js";
@@ -32,13 +33,16 @@ function assetInfosFallback(transaction: GenericTransaction): {
   };
 }
 
+function isNumericLike(value: unknown): value is bigint | number | string {
+  return typeof value === "bigint" || typeof value === "number" || typeof value === "string";
+}
+
 function propagateField(estimation: FeeEstimation, field: string, dest: GenericTransaction): void {
   const value = estimation?.parameters?.[field];
 
   switch (field) {
     case "type":
-      if (typeof value !== "bigint" && typeof value !== "number" && typeof value !== "string")
-        return;
+      if (!isNumericLike(value)) return;
       dest[field] = Number(value.toString());
       return;
     case "gasPrice":
@@ -51,20 +55,23 @@ function propagateField(estimation: FeeEstimation, field: string, dest: GenericT
         dest[field] = null;
         return;
       }
-      if (typeof value !== "bigint" && typeof value !== "number" && typeof value !== "string")
-        return;
+      if (!isNumericLike(value)) return;
       dest[field] = new BigNumber(value.toString());
       return;
     case "storageLimit":
     case "gasLimit":
     case "additionalFees":
-      if (typeof value !== "bigint" && typeof value !== "number" && typeof value !== "string")
-        return;
+      if (!isNumericLike(value)) return;
       dest[field] = new BigNumber(value.toString());
       return;
     case "gasOptions": {
       const gasOptions = toGasOptionsFromUnknown(value);
       if (gasOptions) dest.gasOptions = gasOptions;
+      return;
+    }
+    case "transferFee": {
+      const transferFee = toTransferFeeFromUnknown(value);
+      if (transferFee) dest.transferFee = transferFee;
       return;
     }
     default:
@@ -196,6 +203,7 @@ export function genericPrepareTransaction(
       // so the UI can render fee presets without ever fetching them itself.
       // Families that don't produce them leave this untouched.
       "gasOptions",
+      "transferFee",
     ];
 
     for (const field of fieldsToPropagate) {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
@@ -1,5 +1,6 @@
 import BigNumber from "bignumber.js";
 import { UnexpectedGetBalanceError } from "@ledgerhq/coin-module-framework/errors";
+import type { StakingResources } from "@ledgerhq/types-live";
 import { genericGetAccountShape } from "../getAccountShape";
 import { setCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
 
@@ -55,6 +56,7 @@ const adaptCoreOperationToLiveOperationMock = jest.fn();
 const extractBalanceMock = jest.fn();
 const cleanedOperationMock = jest.fn();
 jest.mock("../utils", () => ({
+  ...jest.requireActual("../utils"),
   adaptCoreOperationToLiveOperation: (...a: any[]) => adaptCoreOperationToLiveOperationMock(...a),
   extractBalance: (...a: any[]) => extractBalanceMock(...a),
   cleanedOperation: (...a: any[]) => cleanedOperationMock(...a),
@@ -73,6 +75,7 @@ jest.mock("@ledgerhq/ledger-wallet-framework/serialization", () => ({
 const buildSubAccountsMock = jest.fn();
 const mergeSubAccountsMock = jest.fn();
 jest.mock("../buildSubAccounts", () => ({
+  adoptStoredSubAccountIds: jest.requireActual("../buildSubAccounts").adoptStoredSubAccountIds,
   buildSubAccounts: (...a: any[]) => buildSubAccountsMock(...a),
   mergeSubAccounts: (...a: any[]) => mergeSubAccountsMock(...a),
 }));
@@ -209,6 +212,33 @@ describe("genericGetAccountShape", () => {
         { paginationConfig: {} as any },
       );
     }
+
+    it("keeps only the freshly built sub-accounts when the sync rebuilds from scratch", async () => {
+      buildSubAccountsMock.mockReturnValue([
+        { id: "framework-id", token: { id: "tok1" }, operations: [], pendingOperations: [] },
+      ]);
+      listOperationsMock.mockResolvedValue({ items: [], next: undefined });
+
+      const getShape = genericGetAccountShape(network, currency.id);
+      const result: any = await getShape(
+        {
+          address: "addr1",
+          initialAccount: {
+            subAccounts: [{ id: "legacy-ata-address", token: { id: "tok1" } }],
+            pendingOperations: [],
+            blockHeight: 10,
+            operations: [],
+          },
+          currency,
+          derivationMode: "",
+        } as any,
+        { paginationConfig: {} as any },
+      );
+
+      expect(result.subAccounts).toHaveLength(1);
+      expect(result.subAccounts[0].id).toBe("framework-id");
+      expect(mergeSubAccountsMock).not.toHaveBeenCalled();
+    });
 
     it("contributes nothing when the bridge has no getAssetFromToken hook", async () => {
       await callWithSubAccountToken();
@@ -1742,6 +1772,7 @@ describe("genericGetAccountShape", () => {
           stakingResources: expect.objectContaining({
             delegations: [
               {
+                positionId: "s-shares",
                 validatorAddress: "0xvalidator",
                 amount: new BigNumber(100),
                 pendingRewards: new BigNumber(0),
@@ -1749,6 +1780,7 @@ describe("genericGetAccountShape", () => {
                 shares: new BigNumber(999),
               },
               {
+                positionId: "s-noshares",
                 validatorAddress: "0xvalidator2",
                 amount: new BigNumber(50),
                 pendingRewards: new BigNumber(0),
@@ -1758,6 +1790,192 @@ describe("genericGetAccountShape", () => {
           }),
         }),
       );
+    });
+
+    test("maps stake.uid and the details bag onto StakingPositionDetails, and keeps undelegated stakes", async () => {
+      getSyncHashMock.mockReturnValue("sync-hash");
+      extractBalanceMock.mockReturnValue({ value: 200n, locked: 0n });
+      getBalanceMock.mockResolvedValue([
+        { asset: { type: "native" }, value: 200n },
+        {
+          asset: { type: "native" },
+          value: 100n,
+          stake: {
+            uid: "StakeAcc1",
+            address: "sol1",
+            delegate: "validator1",
+            state: "active",
+            asset: { type: "native" },
+            amount: 90n,
+            details: {
+              activeAmount: 90,
+              inactiveAmount: 0,
+              withdrawableAmount: 5,
+              lockedReserve: 2_282_880,
+              canStake: true,
+              canWithdraw: true,
+            },
+          },
+        },
+        {
+          asset: { type: "native" },
+          value: 50n,
+          stake: {
+            uid: "StakeAcc2",
+            address: "sol1",
+            state: "inactive",
+            actions: ["withdraw"],
+            asset: { type: "native" },
+            amount: 0n,
+            details: { withdrawableAmount: 50, canStake: true, canWithdraw: true },
+          },
+        },
+      ]);
+      listOperationsMock.mockResolvedValue({ items: [], next: undefined });
+      buildSubAccountsMock.mockReturnValue([]);
+      inferSubOperationsMock.mockReturnValue([]);
+      lastBlockMock.mockResolvedValue({ height: 1 });
+      mergeOpsMock.mockImplementation((_old: unknown[], newOps: unknown[]) => newOps);
+      cleanedOperationMock.mockImplementation((op: unknown) => op);
+      chainSpecificGetAccountShapeMock.mockImplementation(() => {});
+
+      const getShape = genericGetAccountShape("mainnet", "solana");
+      const result = await getShape(
+        {
+          address: "sol1",
+          initialAccount: undefined,
+          currency: { id: "solana", name: "Solana", family: "solana" },
+          derivationMode: "",
+          index: 0,
+          derivationPath: "",
+          challenge: undefined,
+        } as never,
+        {} as never,
+      );
+
+      const resources = (result as { stakingResources: StakingResources }).stakingResources;
+      expect(resources.delegations).toEqual([
+        {
+          positionId: "StakeAcc1",
+          validatorAddress: "validator1",
+          amount: new BigNumber(90),
+          pendingRewards: new BigNumber(0),
+          status: "bonded",
+          activeAmount: new BigNumber(90),
+          inactiveAmount: new BigNumber(0),
+          withdrawableAmount: new BigNumber(5),
+          lockedReserve: new BigNumber(2_282_880),
+          canStake: true,
+          canWithdraw: true,
+        },
+      ]);
+      expect(resources.unbondings).toHaveLength(1);
+      expect(resources.unbondings[0]).toMatchObject({
+        positionId: "StakeAcc2",
+        validatorAddress: "",
+        status: "withdrawable",
+        withdrawableAmount: new BigNumber(50),
+      });
+    });
+
+    test("an inactive stake the chain offers no withdraw on is deactivating, not withdrawable", async () => {
+      getSyncHashMock.mockReturnValue("sync-hash");
+      extractBalanceMock.mockReturnValue({ value: 200n, locked: 0n });
+      getBalanceMock.mockResolvedValue([
+        { asset: { type: "native" }, value: 200n },
+        {
+          asset: { type: "native" },
+          value: 50n,
+          stake: {
+            uid: "tron1:unvoted",
+            address: "tron1",
+            state: "inactive",
+            actions: ["delegate", "undelegate"],
+            asset: { type: "native" },
+            amount: 50n,
+          },
+        },
+      ]);
+      listOperationsMock.mockResolvedValue({ items: [], next: undefined });
+      buildSubAccountsMock.mockReturnValue([]);
+      inferSubOperationsMock.mockReturnValue([]);
+      lastBlockMock.mockResolvedValue({ height: 1 });
+      mergeOpsMock.mockImplementation((_old: unknown[], newOps: unknown[]) => newOps);
+      cleanedOperationMock.mockImplementation((op: unknown) => op);
+      chainSpecificGetAccountShapeMock.mockImplementation(() => {});
+
+      const getShape = genericGetAccountShape("mainnet", "tron");
+      const result = await getShape(
+        {
+          address: "tron1",
+          initialAccount: undefined,
+          currency: { id: "tron", name: "Tron", family: "tron" },
+          derivationMode: "",
+          index: 0,
+          derivationPath: "",
+          challenge: undefined,
+        } as never,
+        {} as never,
+      );
+
+      const resources = (result as { stakingResources: StakingResources }).stakingResources;
+      expect(resources.unbondings).toHaveLength(1);
+      expect(resources.unbondings[0]).toMatchObject({
+        positionId: "tron1:unvoted",
+        status: "deactivating",
+      });
+      expect(resources.unbondingBalance).toEqual(new BigNumber(50));
+    });
+
+    test("leaves StakingPositionDetails undefined for a chain that emits no details", async () => {
+      getSyncHashMock.mockReturnValue("sync-hash");
+      extractBalanceMock.mockReturnValue({ value: 200n, locked: 0n });
+      getBalanceMock.mockResolvedValue([
+        { asset: { type: "native" }, value: 200n },
+        {
+          asset: { type: "native" },
+          value: 100n,
+          stake: {
+            uid: "",
+            address: "cosmos1",
+            delegate: "cosmosvaloper1",
+            state: "active",
+            asset: { type: "native" },
+            amount: 100n,
+          },
+        },
+      ]);
+      listOperationsMock.mockResolvedValue({ items: [], next: undefined });
+      buildSubAccountsMock.mockReturnValue([]);
+      inferSubOperationsMock.mockReturnValue([]);
+      lastBlockMock.mockResolvedValue({ height: 1 });
+      mergeOpsMock.mockImplementation((_old: unknown[], newOps: unknown[]) => newOps);
+      cleanedOperationMock.mockImplementation((op: unknown) => op);
+      chainSpecificGetAccountShapeMock.mockImplementation(() => {});
+
+      const getShape = genericGetAccountShape("mainnet", "cosmos");
+      const result = await getShape(
+        {
+          address: "cosmos1",
+          initialAccount: undefined,
+          currency: { id: "cosmos", name: "Cosmos", family: "cosmos" },
+          derivationMode: "",
+          index: 0,
+          derivationPath: "",
+          challenge: undefined,
+        } as never,
+        {} as never,
+      );
+
+      const resources = (result as { stakingResources: StakingResources }).stakingResources;
+      expect(resources.delegations).toEqual([
+        {
+          validatorAddress: "cosmosvaloper1",
+          amount: new BigNumber(100),
+          pendingRewards: new BigNumber(0),
+          status: "bonded",
+        },
+      ]);
     });
 
     test("usesStakingPositions: surfaces raw Stake[] preserving uid prefixes; no stakingResources", async () => {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/types.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/types.ts
@@ -51,6 +51,15 @@ export type FeeDataRaw = {
   nextBaseFee: string | null;
 };
 
+export type TransferFee = {
+  maxTransferFee: number;
+  transferFee: number;
+  feePercent: number;
+  feeBps: number;
+  transferAmountIncludingFee: number;
+  transferAmountExcludingFee: number;
+};
+
 export type GasOptions = {
   [key in Strategy]: FeeData;
 };
@@ -102,6 +111,7 @@ export type GenericTransaction = TransactionCommon & {
   maxPriorityFeePerGas?: BigNumber | null;
   additionalFees?: BigNumber | null;
   gasOptions?: GasOptions;
+  transferFee?: TransferFee;
   sponsored?: boolean;
   valAddress?: string;
   valId?: string;
@@ -194,6 +204,9 @@ export type CoinFrameworkSigner<S = unknown> = {
 export type AccountRawAssignHooks = {
   assignFromAccountRaw?: AccountBridge<GenericTransaction>["assignFromAccountRaw"];
   assignToAccountRaw?: AccountBridge<GenericTransaction>["assignToAccountRaw"];
+  /** The same pair for a token sub-account, without which `buildTokenAccountShapes` is lost on reload. */
+  assignFromTokenAccountRaw?: AccountBridge<GenericTransaction>["assignFromTokenAccountRaw"];
+  assignToTokenAccountRaw?: AccountBridge<GenericTransaction>["assignToTokenAccountRaw"];
   /**
    * Revive/serialize the family-owned part of `Operation.extra` (forwarded through
    * `Operation.details.familyExtra`). Without these the bag is persisted verbatim, so a non-JSON

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
@@ -3,6 +3,7 @@ import {
   adaptCoreOperationToLiveOperation,
   bigNumberToBigIntDeep,
   buildOptimisticOperation,
+  toTransferFeeFromUnknown,
   cleanedOperation,
   extractBalance,
   extractBalances,
@@ -12,6 +13,7 @@ import {
   isOperationType,
   mergeExtra,
   nextSequenceWithPending,
+  optionalNumeric,
   toGasOptionsFromUnknown,
   transactionToIntent,
 } from "./utils";
@@ -209,6 +211,49 @@ describe("coin-framework utils", () => {
       ],
     ])("replaces BigNumbers with BigInts (%j)", (input, output) => {
       expect(bigNumberToBigIntDeep(input)).toStrictEqual(output);
+    });
+  });
+
+  describe("buildOptimisticOperation memo", () => {
+    const account = {
+      id: "acc",
+      freshAddress: "sender",
+      currency: { units: [{ magnitude: 9 }] },
+      subAccounts: [],
+      pendingOperations: [],
+    } as unknown as Account;
+    const transaction = {
+      recipient: "dest",
+      amount: new BigNumber(1),
+      fees: new BigNumber(5000),
+      memoType: "TEXT",
+      memoValue: "a memo",
+    } as unknown as GenericTransaction;
+
+    it("carries the memo of a plain transfer", () => {
+      const op = buildOptimisticOperation(account, transaction, undefined, () => undefined);
+
+      expect(op.extra).toMatchObject({ memo: "a memo" });
+    });
+
+    it("leaves the memo out when the mode alone types the operation", () => {
+      const op = buildOptimisticOperation(account, {
+        ...transaction,
+        mode: "delegate",
+      } as unknown as GenericTransaction);
+
+      expect(op.extra).not.toHaveProperty("memo");
+    });
+
+    it("drops it when the family typed the operation itself", () => {
+      const op = buildOptimisticOperation(
+        account,
+        { ...transaction, mode: "split" } as unknown as GenericTransaction,
+        undefined,
+        () => ({ type: "FEES", value: new BigNumber(5000) }),
+      );
+
+      expect(op.extra).not.toHaveProperty("memo");
     });
   });
 
@@ -1011,6 +1056,23 @@ describe("coin-framework utils", () => {
 
     it("does not find non existing currencies", () => {
       expect(findCryptoCurrencyByNetwork("non_existing_currency")).toBeUndefined();
+    });
+  });
+
+  describe("optionalNumeric", () => {
+    it.each([Infinity, -Infinity, "Infinity", NaN, "abc", null, undefined, {}])(
+      "rejects %p",
+      (value: unknown) => {
+        expect(optionalNumeric(value)).toBeUndefined();
+      },
+    );
+
+    it.each([
+      [10n, "10"],
+      [10, "10"],
+      ["10", "10"],
+    ])("reads %p", (value: unknown, expected: string) => {
+      expect(optionalNumeric(value)?.toFixed()).toBe(expected);
     });
   });
 
@@ -1869,5 +1931,115 @@ describe("coin-framework utils", () => {
         expect(isOperationType(type)).toBe(false);
       },
     );
+  });
+});
+
+describe("toTransferFeeFromUnknown", () => {
+  const fee = {
+    maxTransferFee: 1,
+    transferFee: 2,
+    feePercent: 3,
+    feeBps: 4,
+    transferAmountIncludingFee: 5,
+    transferAmountExcludingFee: 6,
+  };
+
+  it("accepts a fee whose fields are all numbers", () => {
+    expect(toTransferFeeFromUnknown(fee)).toBe(fee);
+  });
+
+  it.each([
+    null,
+    undefined,
+    42,
+    "fee",
+    {},
+    { ...fee, feeBps: "4" },
+    { ...fee, transferFee: NaN },
+    { ...fee, maxTransferFee: Infinity },
+  ])("rejects %p", (value: unknown) => {
+    expect(toTransferFeeFromUnknown(value)).toBeUndefined();
+  });
+});
+
+const account = {
+  balance: new BigNumber(10_000),
+  spendableBalance: new BigNumber(10_000),
+  freshAddress: "owner",
+  stakingResources: {
+    delegations: [
+      {
+        positionId: "stake-acc-1",
+        validatorAddress: "vote-acc",
+        amount: new BigNumber(1_000),
+        pendingRewards: new BigNumber(0),
+        status: "bonded",
+        activeAmount: new BigNumber(1_000),
+        lockedReserve: new BigNumber(2_282_880),
+        canStake: true,
+        canWithdraw: true,
+      },
+    ],
+    unbondings: [
+      {
+        positionId: "stake-acc-2",
+        validatorAddress: "",
+        amount: new BigNumber(500),
+        completionDate: new Date(0),
+        status: "withdrawable",
+        canWithdraw: false,
+      },
+    ],
+  },
+} as unknown as Account;
+
+describe("extractBalances", () => {
+  it("reconstructs the staking positions the account carries", () => {
+    const [native, delegation, unbonding] = extractBalances(account);
+
+    expect(native.stake).toBeUndefined();
+    expect(native.value).toBe(10_000n);
+
+    expect(delegation.stake).toMatchObject({
+      uid: "stake-acc-1",
+      state: "active",
+      delegate: "vote-acc",
+      amount: 1_000n,
+      details: { activeAmount: 1_000, lockedReserve: 2_282_880, canStake: true, canWithdraw: true },
+    });
+
+    expect(unbonding.stake).toMatchObject({ uid: "stake-acc-2", state: "withdrawable" });
+    expect(unbonding.stake?.delegate).toBeUndefined();
+  });
+
+  it("carries an amount too large for a double as a string, not a rounded number", () => {
+    const huge = new BigNumber("9007199254740993"); // Number.MAX_SAFE_INTEGER + 2
+    const [, delegation] = extractBalances({
+      balance: new BigNumber(10_000),
+      spendableBalance: new BigNumber(10_000),
+      freshAddress: "owner",
+      stakingResources: {
+        delegations: [
+          {
+            positionId: "stake-acc-1",
+            validatorAddress: "vote-acc",
+            amount: huge,
+            pendingRewards: new BigNumber(0),
+            status: "bonded",
+            activeAmount: huge,
+          },
+        ],
+        unbondings: [],
+      },
+    } as unknown as Account);
+
+    expect(delegation.stake?.details?.activeAmount).toBe("9007199254740993");
+    expect(optionalNumeric(delegation.stake?.details?.activeAmount)?.toFixed()).toBe(
+      "9007199254740993",
+    );
+  });
+
+  it("returns only the native balance for an account with no staking resources", () => {
+    expect(extractBalances({ ...account, stakingResources: undefined } as Account)).toHaveLength(1);
   });
 });

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
@@ -10,7 +10,10 @@ import type {
   OperationExtra,
   OperationExtraRaw,
   OperationType,
+  StakingDelegation,
+  StakingUnbonding,
 } from "@ledgerhq/types-live";
+import { isStakingAccount } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { fromBigNumberToBigInt } from "@ledgerhq/coin-module-framework/utils";
 import type {
@@ -20,6 +23,7 @@ import type {
   FeeEstimation,
   MapMemo,
   MemoNotSupported,
+  StakeState,
   StakingOperation,
   StringMemo,
   TransactionIntent,
@@ -38,6 +42,7 @@ import type {
   JsonSafe,
   JsonSafeRecord,
   OperationCommon,
+  TransferFee,
 } from "./types";
 import { craftTransactionData as defaultCraftTransactionData } from "@ledgerhq/coin-module-framework/logic/craftTransactionData";
 import type { BridgeApi } from "@ledgerhq/ledger-wallet-framework/api/types";
@@ -179,6 +184,24 @@ export function toGasOptionsFromUnknown(value: unknown): GasOptions | undefined 
   };
 }
 
+const TRANSFER_FEE_FIELDS = [
+  "maxTransferFee",
+  "transferFee",
+  "feePercent",
+  "feeBps",
+  "transferAmountIncludingFee",
+  "transferAmountExcludingFee",
+] satisfies ReadonlyArray<keyof TransferFee>;
+
+export function toTransferFeeFromUnknown(value: unknown): TransferFee | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const fee = value as Record<string, unknown>;
+  // `Number.isFinite` coerces nothing, so it rejects a non-number, NaN and Infinity alike.
+  return TRANSFER_FEE_FIELDS.every(field => Number.isFinite(fee[field]))
+    ? (fee as TransferFee)
+    : undefined;
+}
+
 export function findCryptoCurrencyByNetwork(network: string): CryptoCurrency | undefined {
   const networksRemap = {
     xrp: "ripple",
@@ -293,6 +316,67 @@ export function getPendingTokenSpent(pendingOperations: Operation[]): BigNumber 
   );
 }
 
+/**
+ * The staking positions, in the `Balance` shape `getBalance` reported them in. Appended after the
+ * native balance, which stays first.
+ */
+function stakingBalances(account: Account): Balance[] {
+  // `isStakingAccount` only tests that the key is present, so the value can still be undefined.
+  const resources = isStakingAccount(account) ? account.stakingResources : undefined;
+  if (!resources) return [];
+
+  const toBalance = (
+    position: StakingDelegation | StakingUnbonding,
+    state: StakeState,
+    delegate: string | undefined,
+  ): Balance => ({
+    value: BigInt(position.amount.toFixed()),
+    asset: { type: "native" },
+    stake: {
+      uid: position.positionId ?? "",
+      address: position.positionId ?? "",
+      state,
+      asset: { type: "native" },
+      amount: BigInt(position.amount.toFixed()),
+      ...(delegate ? { delegate } : {}),
+      actions: [],
+      details: {
+        ...numericDetailEntry("activeAmount", position.activeAmount),
+        ...numericDetailEntry("inactiveAmount", position.inactiveAmount),
+        ...numericDetailEntry("withdrawableAmount", position.withdrawableAmount),
+        ...numericDetailEntry("lockedReserve", position.lockedReserve),
+        ...(typeof position.canStake === "boolean" ? { canStake: position.canStake } : {}),
+        ...(typeof position.canWithdraw === "boolean" ? { canWithdraw: position.canWithdraw } : {}),
+      },
+    },
+  });
+
+  return [
+    ...resources.delegations.map(d =>
+      toBalance(d, d.status === "activating" ? "activating" : "active", d.validatorAddress),
+    ),
+    ...resources.unbondings.map(u =>
+      toBalance(
+        u,
+        u.status === "withdrawable" ? "withdrawable" : "deactivating",
+        u.validatorAddress,
+      ),
+    ),
+  ];
+}
+
+/**
+ * A value a double cannot hold exactly travels as a string; `optionalNumeric` reads both back.
+ */
+function numericDetailEntry(
+  key: string,
+  value: BigNumber | undefined,
+): Record<string, number | string> {
+  if (value === undefined) return {};
+  const fitsInADouble = value.isInteger() && value.abs().lte(Number.MAX_SAFE_INTEGER);
+  return { [key]: fitsInADouble ? value.toNumber() : value.toFixed() };
+}
+
 export function extractBalances(
   account: Account,
   getAssetFromToken?: (token: TokenCurrency, owner: string) => AssetInfo | undefined,
@@ -311,6 +395,8 @@ export function extractBalances(
     },
   ];
 
+  balances.push(...stakingBalances(account));
+
   if (!account.subAccounts?.length || !getAssetFromToken) {
     return balances;
   }
@@ -328,6 +414,17 @@ export function extractBalances(
   }
 
   return balances;
+}
+
+/**
+ * Reads a numeric field (bigint/number/string) as BigNumber, else `undefined`.
+ */
+export function optionalNumeric(value: unknown): BigNumber | undefined {
+  if (typeof value !== "bigint" && typeof value !== "number" && typeof value !== "string") {
+    return undefined;
+  }
+  const parsed = new BigNumber(value.toString());
+  return parsed.isFinite() ? parsed : undefined;
 }
 
 /** Reads a numeric `parameters` field (bigint/number/string) as BigNumber, else `fallback`. */
@@ -1085,7 +1182,10 @@ export const buildOptimisticOperation = (
       // `adaptCoreOperationToLiveOperation` applies to a family bag arriving from a sync. `blockTime`
       // and `index` are this path's alone, which is why they are not in the reserved set.
       ...(described?.extra ? stripFrameworkReservedKeys(described.extra) : {}),
-      ...memoExtraFields(transaction.memoType, transaction.memoValue),
+      // A family that describes its own operation uses the memo field as transport, not as a memo.
+      ...(described === undefined && (parentType === "OUT" || parentType === "FEES")
+        ? memoExtraFields(transaction.memoType, transaction.memoValue)
+        : {}),
       ledgerOpType: type,
       blockTime: new Date(),
       index: "0",


### PR DESCRIPTION
### 📝 Description

Shared generic-coin-framework code, split out of #21231. No Solana in it: every line already runs for casper, evm, hypercore, xrp, stellar, tezos and tron.

**Sub-accounts**

`mergeSubAccounts` keeps only what the chain still reports. A sub-account it stopped returning used to survive with a stale balance — MultiversX prunes an ESDT entry once it empties, and `coin-tester-multiversx` had its assertion disabled with a note to re-enable it once this was fixed. It is re-enabled here, for both strategies.

**Tron** is the only family whose displayed staking changes. EVM shares this code path — it does not set `usesStakingPositions`, and its `getBalance` emits stakes — but those stakes are always `active`, always delegated and carry no `actions`, so neither fix below can fire for it. What changes for EVM: delegations now carry `positionId`, and `extractBalances` gives a staking intent positions where it previously found none.

- An unbonding position with no `delegate` was filtered out of `unbondings` while `unbondingBalance` already summed it, so an account showed a balance being unfrozen with no row facing it.
- Keeping those positions turned `inactive` into `withdrawable`, which is wrong for unvoted frozen TRX: it earns resources but still has to be unfrozen. A position now reads as withdrawable only when the chain offers a `withdraw`, which `Stake.actions` declares.
- `extractBalances` now rebuilds staking positions. `getTransactionStatus` reconstructs balances from the stored account rather than calling `getBalance`, so a family validating a staking intent found none — coin-near documents the same gap and queries its pool directly to work around it.

**Elsewhere**

- A pending operation shows the user's memo only on transfers the framework typed itself (xrp, stellar, tron).
- A staking amount too large for a double travels as a string rather than being rounded.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35692](https://ledgerhq.atlassian.net/browse/LIVE-35692)

[LIVE-35692]: https://ledgerhq.atlassian.net/browse/LIVE-35692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
